### PR TITLE
trim space the port_binding's output

### DIFF
--- a/pkg/pinger/ovn.go
+++ b/pkg/pinger/ovn.go
@@ -164,5 +164,5 @@ func checkSBBindings(config *Configuration) ([]string, error) {
 		return nil, err
 	}
 
-	return strings.Split(string(output), "\n"), nil
+	return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
 }


### PR DESCRIPTION

I got the `pinger` log as follows, one extra space at the end:

```shell
I0313 06:35:47.025164 1429284 ovn.go:46] port in sb is [node-master1 ]
```



