### PR TITLE
fix: disable checksum validation

### DIFF
--- a/dist/images/install-pre-1.16.sh
+++ b/dist/images/install-pre-1.16.sh
@@ -1678,7 +1678,7 @@ spec:
           - /kube-ovn/start-cniserver.sh
         args:
           - --enable-mirror=$ENABLE_MIRROR
-          - --encap-checksum=true
+          - --encap-checksum=false
           - --service-cluster-ip-range=$SVC_CIDR
           - --iface=${IFACE}
           - --network-type=$NETWORK_TYPE

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1718,7 +1718,7 @@ spec:
           - /kube-ovn/start-cniserver.sh
         args:
           - --enable-mirror=$ENABLE_MIRROR
-          - --encap-checksum=true
+          - --encap-checksum=false
           - --service-cluster-ip-range=$SVC_CIDR
           - --iface=${IFACE}
           - --network-type=$NETWORK_TYPE


### PR DESCRIPTION
For some unknown reason, kernel will report "UDP bad checksum" and drop packet, disable validation to bypass this issue