### PR TITLE
livenessprobe fail if ovn nb/ovn sb not running

### DIFF
--- a/dist/images/ovn-healthcheck.sh
+++ b/dist/images/ovn-healthcheck.sh
@@ -5,5 +5,5 @@ shopt -s expand_aliases
 alias ovn-ctl='/usr/share/ovn/scripts/ovn-ctl'
 
 ovn-ctl status_northd
-ovn-ctl status_ovnnb
-ovn-ctl status_ovnsb
+ovn-ctl status_ovnnb | grep -q '^running'
+ovn-ctl status_ovnsb | grep -q '^running'


### PR DESCRIPTION
ovn-ctl status_ovnnb
not running