### PR TITLE
fix: check ovn0 status

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -73,6 +73,7 @@ RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \
 COPY *.sh /kube-ovn/
 COPY 01-kube-ovn.conflist /kube-ovn/01-kube-ovn.conflist
 COPY logrotate/* /etc/logrotate.d/
+COPY grace_stop_ovn_controller /usr/share/ovn/scripts/grace_stop_ovn_controller
 
 WORKDIR /kube-ovn
 

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -107,7 +107,7 @@ func (c *Controller) setIPSet() error {
 }
 
 func (c *Controller) setIptables() error {
-	klog.Infoln("start to set up iptables")
+	klog.V(3).Infoln("start to set up iptables")
 	node, err := c.nodesLister.Get(c.config.NodeName)
 	if err != nil {
 		klog.Errorf("failed to get node %s, %v", c.config.NodeName, err)


### PR DESCRIPTION
When ovs restart, internal port like ovn0 will go down
and disconnect host and pod network. Check the link status
and ping gw status and restart kube-ovn-cni if the link goes
wrong.