### PR TITLE
Keep chassis name on node reboot or ovs pod restart

### DIFF
--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -55,7 +55,7 @@ function quit {
 trap quit EXIT
 
 # Start ovsdb
-/usr/share/openvswitch/scripts/ovs-ctl restart --no-ovs-vswitchd --system-id=random
+/usr/share/openvswitch/scripts/ovs-ctl restart --no-ovs-vswitchd --system-id=${KUBE_NODE_NAME}
 # Restrict the number of pthreads ovs-vswitchd creates to reduce the
 # amount of RSS it uses on hosts with many cores
 # https://bugzilla.redhat.com/show_bug.cgi?id=1571379
@@ -72,7 +72,7 @@ else
 fi
 
 # Start vswitchd
-/usr/share/openvswitch/scripts/ovs-ctl restart --no-ovsdb-server --system-id=random
+/usr/share/openvswitch/scripts/ovs-ctl restart --no-ovsdb-server --system-id=${KUBE_NODE_NAME}
 /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
 
 function gen_conn_str {


### PR DESCRIPTION
The sb chassis name comes from system-id.
related #745 
```
ovn-sbctl list chassis  0d2eee9f-3aca-45b1-a252-c502e95746ed

_uuid               : 0d2eee9f-3aca-45b1-a252-c502e95746ed
encaps              : [e5fbf021-6219-46e5-bdac-8987588c02a3]
external_ids        : {datapath-type=netdev, iface-types="bareudp,dpdk,dpdkvhostuser,dpdkvhostuserclient,erspan,geneve,gre,gtpu,internal,ip6erspan,ip6gre,lisp,patch,stt,system,tap,vxlan", is-interconn="false", ovn-bridge-mappings="external:br-tun", ovn-chassis-mac-mappings="", ovn-cms-options="", ovn-monitor-all="false"}
hostname            : bj-wlc-test-net001
name                : bj-wlc-test-net001
nb_cfg              : 7
other_config        : {datapath-type=netdev, iface-types="bareudp,dpdk,dpdkvhostuser,dpdkvhostuserclient,erspan,geneve,gre,gtpu,internal,ip6erspan,ip6gre,lisp,patch,stt,system,tap,vxlan", is-interconn="false", ovn-bridge-mappings="external:br-tun", ovn-chassis-mac-mappings="", ovn-cms-options="", ovn-monitor-all="false"}
transport_zones     : []
vtep_logical_switches: []
```