### PR TITLE
feature: forward egress traffic to external gateway

### DIFF
--- a/dist/images/install-pre-1.16.sh
+++ b/dist/images/install-pre-1.16.sh
@@ -232,6 +232,15 @@ spec:
     - name: NAT
       type: boolean
       JSONPath: .spec.natOutgoing
+    - name: ExternalGateway
+      type: string
+      JSONPath: .spec.externalGateway
+    - name: PolicyRoutingPriority
+      type: integer
+      JSONPath: .spec.policyRoutingPriority
+    - name: PolicyRoutingTableID
+      type: integer
+      JSONPath: .spec.policyRoutingTableID
     - name: Default
       type: boolean
       JSONPath: .spec.default
@@ -306,6 +315,22 @@ spec:
               type: string
             natOutgoing:
               type: boolean
+            externalGateway:
+              type: string
+            policyRoutingPriority:
+              type: integer
+              minimum: 1
+              maximum: 32765
+            policyRoutingTableID:
+              type: integer
+              minimum: 1
+              maximum: 2147483647
+              not:
+                enum:
+                  - 252 # compat
+                  - 253 # default
+                  - 254 # main
+                  - 255 # local
             private:
               type: boolean
             vlan:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -414,6 +414,15 @@ spec:
       - name: NAT
         type: boolean
         jsonPath: .spec.natOutgoing
+      - name: ExternalGateway
+        type: string
+        jsonPath: .spec.externalGateway
+      - name: PolicyRoutingPriority
+        type: integer
+        jsonPath: .spec.policyRoutingPriority
+      - name: PolicyRoutingTableID
+        type: integer
+        jsonPath: .spec.policyRoutingTableID
       - name: Default
         type: boolean
         jsonPath: .spec.default
@@ -499,6 +508,22 @@ spec:
                   type: string
                 natOutgoing:
                   type: boolean
+                externalGateway:
+                  type: string
+                policyRoutingPriority:
+                  type: integer
+                  minimum: 1
+                  maximum: 32765
+                policyRoutingTableID:
+                  type: integer
+                  minimum: 1
+                  maximum: 2147483647
+                  not:
+                    enum:
+                      - 252 # compat
+                      - 253 # default
+                      - 254 # main
+                      - 255 # local
                 private:
                   type: boolean
                 vlan:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -88,6 +88,10 @@ type SubnetSpec struct {
 	GatewayNode string `json:"gatewayNode"`
 	NatOutgoing bool   `json:"natOutgoing"`
 
+	ExternalGateway       string `json:"externalGateway,omitempty"`
+	PolicyRoutingPriority uint32 `json:"policyRoutingPriority,omitempty"`
+	PolicyRoutingTableID  uint32 `json:"policyRoutingTableID,omitempty"`
+
 	Private      bool     `json:"private"`
 	AllowSubnets []string `json:"allowSubnets,omitempty"`
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -528,8 +528,20 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	}
 
 	for _, sub := range subnetList {
-		if sub.Spec.Vpc == subnet.Spec.Vpc && sub.Name != subnet.Name && util.CIDRConflict(sub.Spec.CIDRBlock, subnet.Spec.CIDRBlock) {
-			err = fmt.Errorf("subnet %s cidr %s conflict with subnet %s cidr %s", subnet.Name, subnet.Spec.CIDRBlock, sub.Name, sub.Spec.CIDRBlock)
+		if sub.Spec.Vpc != subnet.Spec.Vpc || sub.Name == subnet.Name {
+			continue
+		}
+
+		if util.CIDRConflict(sub.Spec.CIDRBlock, subnet.Spec.CIDRBlock) {
+			err = fmt.Errorf("subnet %s cidr %s is conflict with subnet %s cidr %s", subnet.Name, subnet.Spec.CIDRBlock, sub.Name, sub.Spec.CIDRBlock)
+			klog.Error(err)
+			c.patchSubnetStatus(subnet, "ValidateLogicalSwitchFailed", err.Error())
+			return err
+		}
+
+		if subnet.Spec.ExternalGateway != "" && sub.Spec.ExternalGateway != "" &&
+			subnet.Spec.PolicyRoutingTableID == sub.Spec.PolicyRoutingTableID {
+			err = fmt.Errorf("subnet %s policy routing table ID %d is conflict with subnet %s policy routing table ID %d", subnet.Name, subnet.Spec.PolicyRoutingTableID, sub.Name, sub.Spec.PolicyRoutingTableID)
 			klog.Error(err)
 			c.patchSubnetStatus(subnet, "ValidateLogicalSwitchFailed", err.Error())
 			return err

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -2,37 +2,38 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
+	"reflect"
 	"strings"
+	"syscall"
 	"time"
-
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-
-	"github.com/kubeovn/kube-ovn/pkg/ovs"
 
 	"github.com/alauda/felix/ipsets"
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -115,9 +116,9 @@ func NewController(config *Configuration, podInformerFactory informers.SharedInf
 	}
 
 	subnetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    controller.enqueueSubnet,
+		AddFunc:    controller.enqueueAddSubnet,
 		UpdateFunc: controller.enqueueUpdateSubnet,
-		DeleteFunc: controller.enqueueSubnet,
+		DeleteFunc: controller.enqueueDeleteSubnet,
 	})
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: controller.enqueuePod,
@@ -126,24 +127,20 @@ func NewController(config *Configuration, podInformerFactory informers.SharedInf
 	return controller, nil
 }
 
-func (c *Controller) enqueueSubnet(obj interface{}) {
-	var key string
-	var err error
-	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-	c.subnetQueue.Add(key)
+type subnetEvent struct {
+	old, new interface{}
 }
 
-func (c *Controller) enqueueUpdateSubnet(_, new interface{}) {
-	var key string
-	var err error
-	if key, err = cache.MetaNamespaceKeyFunc(new); err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-	c.subnetQueue.Add(key)
+func (c *Controller) enqueueAddSubnet(obj interface{}) {
+	c.subnetQueue.Add(subnetEvent{new: obj})
+}
+
+func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
+	c.subnetQueue.Add(subnetEvent{old: old, new: new})
+}
+
+func (c *Controller) enqueueDeleteSubnet(obj interface{}) {
+	c.subnetQueue.Add(subnetEvent{old: obj})
 }
 
 func (c *Controller) runSubnetWorker() {
@@ -159,16 +156,15 @@ func (c *Controller) processNextSubnetWorkItem() bool {
 
 	err := func(obj interface{}) error {
 		defer c.subnetQueue.Done(obj)
-		var key string
-		var ok bool
-		if key, ok = obj.(string); !ok {
+		event, ok := obj.(subnetEvent)
+		if !ok {
 			c.subnetQueue.Forget(obj)
-			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("expected subnetEvent in workqueue but got %#v", obj))
 			return nil
 		}
-		if err := c.reconcileRouters(); err != nil {
-			c.subnetQueue.AddRateLimited(key)
-			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		if err := c.reconcileRouters(event); err != nil {
+			c.subnetQueue.AddRateLimited(event)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", event, err.Error())
 		}
 		c.subnetQueue.Forget(obj)
 		return nil
@@ -181,12 +177,69 @@ func (c *Controller) processNextSubnetWorkItem() bool {
 	return true
 }
 
-func (c *Controller) reconcileRouters() error {
+func (c *Controller) reconcileRouters(event subnetEvent) error {
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list namespace %v", err)
 		return err
 	}
+
+	var ok bool
+	var oldSubnet, newSubnet *kubeovnv1.Subnet
+	if event.old != nil {
+		if oldSubnet, ok = event.old.(*kubeovnv1.Subnet); !ok {
+			klog.Errorf("expected old subnet in subnetEvent but got %#v", event.old)
+			return nil
+		}
+	}
+	if event.new != nil {
+		if newSubnet, ok = event.new.(*kubeovnv1.Subnet); !ok {
+			klog.Errorf("expected new subnet in subnetEvent but got %#v", event.new)
+			return nil
+		}
+	}
+
+	// handle policy routing
+	rulesToAdd, rulesToDel, routesToAdd, routesToDel, err := c.diffPolicyRouting(oldSubnet, newSubnet)
+	if err != nil {
+		klog.Errorf("failed to get policy routing difference: %v", err)
+		return err
+	}
+	// add new routes first
+	for _, r := range routesToAdd {
+		if err = netlink.RouteAdd(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
+			klog.Errorf("failed to add route for subnet %s: %v", newSubnet.Name, err)
+			return err
+		}
+	}
+	// next, add new rules
+	for _, r := range rulesToAdd {
+		if err = netlink.RuleAdd(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
+			klog.Errorf("failed to add network rule for subnet %s: %v", newSubnet.Name, err)
+			return err
+		}
+	}
+	// then delete old network rules
+	for _, r := range rulesToDel {
+		// loop to delete all matched rules
+		for {
+			if err = netlink.RuleDel(&r); err != nil {
+				if !errors.Is(err, syscall.ENOENT) {
+					klog.Errorf("failed to delete network rule for subnet %s: %v", oldSubnet.Name, err)
+					return err
+				}
+				break
+			}
+		}
+	}
+	// last, delete old network routes
+	for _, r := range routesToDel {
+		if err = netlink.RouteDel(&r); err != nil && !errors.Is(err, syscall.ENOENT) {
+			klog.Errorf("failed to delete route for subnet %s: %v", oldSubnet.Name, err)
+			return err
+		}
+	}
+
 	cidrs := make([]string, 0, len(subnets)*2)
 	for _, subnet := range subnets {
 		if !subnet.Status.IsReady() || subnet.Spec.UnderlayGateway {
@@ -301,6 +354,146 @@ func routeDiff(existRoutes []netlink.Route, cidrs []string) (toAdd []string, toD
 	return
 }
 
+func getRulesToAdd(oldRules, newRules []netlink.Rule) []netlink.Rule {
+	var toAdd []netlink.Rule
+
+	for _, rule := range newRules {
+		var found bool
+		for _, r := range oldRules {
+			if r.Family == rule.Family && r.Priority == rule.Priority && r.Table == rule.Table && reflect.DeepEqual(r.Src, rule.Src) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toAdd = append(toAdd, rule)
+		}
+	}
+
+	return toAdd
+}
+
+func getRoutesToAdd(oldRoutes, newRoutes []netlink.Route) []netlink.Route {
+	var toAdd []netlink.Route
+
+	for _, route := range newRoutes {
+		var found bool
+		for _, r := range oldRoutes {
+			if r.Equal(route) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toAdd = append(toAdd, route)
+		}
+	}
+
+	return toAdd
+}
+
+func (c *Controller) diffPolicyRouting(oldSubnet, newSubnet *kubeovnv1.Subnet) (rulesToAdd, rulesToDel []netlink.Rule, routesToAdd, routesToDel []netlink.Route, err error) {
+	oldRules, oldRoutes, err := c.getPolicyRouting(oldSubnet)
+	if err != nil {
+		klog.Error(err)
+		return
+	}
+	newRules, newRoutes, err := c.getPolicyRouting(newSubnet)
+	if err != nil {
+		klog.Error(err)
+		return
+	}
+
+	rulesToAdd = getRulesToAdd(oldRules, newRules)
+	rulesToDel = getRulesToAdd(newRules, oldRules)
+	routesToAdd = getRoutesToAdd(oldRoutes, newRoutes)
+	routesToDel = getRoutesToAdd(newRoutes, oldRoutes)
+
+	return
+}
+
+func (c *Controller) getPolicyRouting(subnet *kubeovnv1.Subnet) ([]netlink.Rule, []netlink.Route, error) {
+	if subnet == nil || subnet.Spec.ExternalGateway == "" || subnet.Spec.Vpc != util.DefaultVpc {
+		return nil, nil, nil
+	}
+	if subnet.Spec.GatewayType == kubeovnv1.GWCentralizedType && !util.GatewayContains(subnet.Spec.GatewayNode, c.config.NodeName) {
+		return nil, nil, nil
+	}
+
+	protocols := make([]string, 1, 2)
+	if protocol := util.CheckProtocol(subnet.Spec.ExternalGateway); protocol == kubeovnv1.ProtocolDual {
+		protocols[0] = kubeovnv1.ProtocolIPv4
+		protocols = append(protocols, kubeovnv1.ProtocolIPv6)
+	} else {
+		protocols[0] = protocol
+	}
+
+	cidr := strings.Split(subnet.Spec.CIDRBlock, ",")
+	egw := strings.Split(subnet.Spec.ExternalGateway, ",")
+
+	// rules
+	var rules []netlink.Rule
+	rule := netlink.NewRule()
+	rule.Table = int(subnet.Spec.PolicyRoutingTableID)
+	rule.Priority = int(subnet.Spec.PolicyRoutingPriority)
+	if subnet.Spec.GatewayType == kubeovnv1.GWDistributedType {
+		pods, err := c.podsLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("list pods failed, %+v", err)
+			return nil, nil, err
+		}
+
+		hostname := os.Getenv("KUBE_NODE_NAME")
+		for _, pod := range pods {
+			if pod.Spec.HostNetwork ||
+				pod.Status.PodIP == "" ||
+				pod.Annotations[util.LogicalSwitchAnnotation] != subnet.Name ||
+				pod.Spec.NodeName != hostname {
+				continue
+			}
+
+			for i := range protocols {
+				rule.Family, _ = util.ProtocolToFamily(protocols[i])
+
+				var ip net.IP
+				var maskBits int
+				if len(pod.Status.PodIPs) == 2 && protocols[i] == kubeovnv1.ProtocolIPv6 {
+					ip = net.ParseIP(pod.Status.PodIPs[1].IP)
+					maskBits = 128
+				} else if util.CheckProtocol(pod.Status.PodIP) == protocols[i] {
+					ip = net.ParseIP(pod.Status.PodIP)
+					maskBits = 32
+					if rule.Family == netlink.FAMILY_V6 {
+						maskBits = 128
+					}
+				}
+
+				rule.Src = &net.IPNet{IP: ip, Mask: net.CIDRMask(maskBits, maskBits)}
+				rules = append(rules, *rule)
+			}
+		}
+	} else {
+		for i := range protocols {
+			rule.Family, _ = util.ProtocolToFamily(protocols[i])
+			_, rule.Src, _ = net.ParseCIDR(cidr[i])
+			rules = append(rules, *rule)
+		}
+	}
+
+	// routes
+	var routes []netlink.Route
+	for i := range protocols {
+		family, _ := util.ProtocolToFamily(protocols[i])
+		routes = append(routes, netlink.Route{
+			Protocol: family,
+			Table:    int(subnet.Spec.PolicyRoutingTableID),
+			Gw:       net.ParseIP(egw[i]),
+		})
+	}
+
+	return rules, routes, nil
+}
+
 func (c *Controller) enqueuePod(old, new interface{}) {
 	oldPod := old.(*v1.Pod)
 	newPod := new.(*v1.Pod)
@@ -364,7 +557,7 @@ func (c *Controller) handlePod(key string) error {
 
 	pod, err := c.podsLister.Pods(namespace).Get(name)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -10,8 +10,10 @@ import (
 	"strconv"
 	"strings"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/vishvananda/netlink"
 	"k8s.io/klog"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
 
 // GenerateMac generates mac address.
@@ -156,6 +158,20 @@ func CheckProtocol(address string) string {
 		return kubeovnv1.ProtocolIPv4
 	}
 	return kubeovnv1.ProtocolIPv6
+}
+
+// ProtocolToFamily converts protocol string to netlink family
+func ProtocolToFamily(protocol string) (int, error) {
+	switch protocol {
+	case kubeovnv1.ProtocolDual:
+		return netlink.FAMILY_ALL, nil
+	case kubeovnv1.ProtocolIPv4:
+		return netlink.FAMILY_V4, nil
+	case kubeovnv1.ProtocolIPv6:
+		return netlink.FAMILY_V6, nil
+	default:
+		return -1, fmt.Errorf("invalid protocol: %s", protocol)
+	}
 }
 
 func AddressCount(network *net.IPNet) float64 {

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -86,6 +86,26 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 			return fmt.Errorf("subnet %s cidr %s conflicts with k8s apiserver svc ip %s", subnet.Name, subnet.Spec.CIDRBlock, k8sApiServer)
 		}
 	}
+
+	if egw := subnet.Spec.ExternalGateway; egw != "" {
+		if subnet.Spec.NatOutgoing {
+			return fmt.Errorf("conflict configuration: natOutgoing and externalGateway")
+		}
+		ips := strings.Split(egw, ",")
+		if len(ips) > 2 {
+			return fmt.Errorf("invalid external gateway configuration")
+		}
+		for _, ip := range ips {
+			if net.ParseIP(ip) == nil {
+				return fmt.Errorf("external gateway %s is not a valid address", ip)
+			}
+		}
+		egwProtocol, cidrProtocol := CheckProtocol(egw), CheckProtocol(subnet.Spec.CIDRBlock)
+		if egwProtocol != cidrProtocol && cidrProtocol != kubeovnv1.ProtocolDual {
+			return fmt.Errorf("invalid external gateway configuration")
+		}
+	}
+
 	return nil
 }
 

--- a/yamls/crd-pre-1.16.yaml
+++ b/yamls/crd-pre-1.16.yaml
@@ -93,6 +93,15 @@ spec:
     - name: NAT
       type: boolean
       JSONPath: .spec.natOutgoing
+    - name: ExternalGateway
+      type: string
+      JSONPath: .spec.externalGateway
+    - name: PolicyRoutingPriority
+      type: integer
+      JSONPath: .spec.policyRoutingPriority
+    - name: PolicyRoutingTableID
+      type: integer
+      JSONPath: .spec.policyRoutingTableID
     - name: Default
       type: boolean
       JSONPath: .spec.default
@@ -167,6 +176,22 @@ spec:
               type: string
             natOutgoing:
               type: boolean
+            externalGateway:
+              type: string
+            policyRoutingPriority:
+              type: integer
+              minimum: 1
+              maximum: 32765
+            policyRoutingTableID:
+              type: integer
+              minimum: 1
+              maximum: 2147483647
+              not:
+                enum:
+                  - 252 # compat
+                  - 253 # default
+                  - 254 # main
+                  - 255 # local
             private:
               type: boolean
             vlan:

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -93,6 +93,15 @@ spec:
       - name: NAT
         type: boolean
         jsonPath: .spec.natOutgoing
+      - name: ExternalGateway
+        type: string
+        jsonPath: .spec.externalGateway
+      - name: PolicyRoutingPriority
+        type: integer
+        jsonPath: .spec.policyRoutingPriority
+      - name: PolicyRoutingTableID
+        type: integer
+        jsonPath: .spec.policyRoutingTableID
       - name: Default
         type: boolean
         jsonPath: .spec.default
@@ -168,6 +177,22 @@ spec:
                   type: string
                 natOutgoing:
                   type: boolean
+                externalGateway:
+                  type: string
+                policyRoutingPriority:
+                  type: integer
+                  minimum: 1
+                  maximum: 32765
+                policyRoutingTableID:
+                  type: integer
+                  minimum: 1
+                  maximum: 2147483647
+                  not:
+                    enum:
+                      - 252 # compat
+                      - 253 # default
+                      - 254 # main
+                      - 255 # local
                 private:
                   type: boolean
                 vlan:


### PR DESCRIPTION
Gateway node(s) forwards egress traffic to external gateway based on policy routing. Supports both distributed gateway and centralized gateway modes. New properties are available in subnet spec: externalGateway, policyRoutingPriority & policyRoutingTableID.

Example:

```yaml
apiVersion: kubeovn.io/v1
kind: Subnet
metadata:
  name: subnet1
spec:
  cidrBlock: 192.168.1.0/24
  default: false
  gateway: 192.168.1.1
  gatewayType: centralized
  gatewayNode: kube-ovn-worker
  natOutgoing: false
  private: false
  externalGateway: 172.18.0.1
  policyRoutingPriority: 2000
  policyRoutingTableID: 2000
  namespaces:
    - ns1
```