### PR TITLE
fix: lr-route using nic-ip for nexthop, and not external gateway addr.

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -572,6 +572,9 @@ func (c *Controller) handleUpdatePod(key string) error {
 				return fmt.Errorf("no available gateway nic address")
 			}
 			nextHop = strings.Split(nextHop, "/")[0]
+			if addr := cm.Data["external-gw-addr"]; addr != "" {
+				nextHop = addr
+			}
 
 			if err := c.ovnClient.AddStaticRoute(ovs.PolicySrcIP, podIP, nextHop, c.config.ClusterRouter, util.NormalRouteType); err != nil {
 				klog.Errorf("failed to add static route, %v", err)


### PR DESCRIPTION
```
[root@node-20 ingress]# kubectl -n kube-system get cm ovn-external-gw-config  -o yaml 
apiVersion: v1
data:
  enable-external-gw: "true"
  external-gw-addr: 192.168.8.24
  external-gw-nic: eth1
  external-gw-nodes: 192.168.7.222
  nic-ip: 192.168.8.1/24
  nic-mac: "0:0:0:1:2:3"
  type: centralized
kind: ConfigMap
...
[root@node-20 ingress]# ovn-nbctl show ovn-cluster
router 4c4e4b81-3b6f-4fbe-9dc6-992b4d44b647 (ovn-cluster)
    port ovn-cluster-ovn-external
        mac: "0:0:0:1:2:3"
        networks: ["192.168.8.1/24"]
        gateway chassis: [54a9dd4b-0eb4-46a7-bfe0-202798c9acb0]
    port ovn-cluster-join
        mac: "00:00:00:73:8B:CB"
        networks: ["100.64.0.1/16"]
    port ovn-cluster-ovn-default
        mac: "00:00:00:8B:15:78"
        networks: ["172.20.0.1/16"]
    nat 4762fed3-c8c8-4efa-8e47-0ebb6868ca6c
        external ip: "192.168.8.220"
        logical ip: "172.20.0.81"
        type: "dnat_and_snat"
    nat 5edad9a3-0a3a-4025-8ee2-d3a017935a89
        external ip: "192.168.8.221"
        logical ip: "172.20.0.82"
        type: "dnat_and_snat"
    nat 7358edd3-fd0b-4310-be88-cdfa5c64afd3
        external ip: "192.168.8.222"
        logical ip: "172.20.0.83"
        type: "snat"
    nat a6579baa-5fc1-4d51-8cbb-5c578b07083c
        external ip: "192.168.8.223"
        logical ip: "172.20.0.84"
        type: "dnat_and_snat"
[root@node-20 ingress]# ovn-nbctl lr-route-list ovn-cluster | grep 192.168.8.24
              172.20.0.81              192.168.8.24 src-ip
              172.20.0.82              192.168.8.24 src-ip
              172.20.0.83              192.168.8.24 src-ip
              172.20.0.84              192.168.8.24 src-ip
[root@node-20 ingress]# 
