### PR TITLE
Remove the unnecessary rm command

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -170,8 +170,6 @@ You can use `--default-cidr` flags below to config default Pod CIDR or create a 
     rm -rf /etc/origin/openvswitch/
     rm -rf /etc/origin/ovn/
     # default value
-    rm -rf /etc/cni/net.d/00-kube-ovn.conflist
-    # default value
     rm -rf /etc/cni/net.d/01-kube-ovn.conflist
     rm -rf /var/log/openvswitch
     rm -rf /var/log/ovn


### PR DESCRIPTION
00-kube-ovn.conflist not exists in /etc/cni/net.d, no needed to remove it.