### PR TITLE
ci: remove 3-master e2e

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -202,21 +202,6 @@ jobs:
           docker load --input image.tar
           sudo make kind-install
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.15
-        id: go
-
-      - name: Run E2E
-        run: |
-          go get -u github.com/onsi/ginkgo/ginkgo
-          go get -u github.com/onsi/gomega/...
-          sudo kubectl cluster-info
-          sudo chmod 666 /home/runner/.kube/config
-          make e2e
-
-
   ipv6-e2e:
     needs: build
     name: ipv6-e2e


### PR DESCRIPTION
As the resource provided by github action is limited and 3-master-e2e
uses lots memory and cpu which might lead to k8s crush. Skip this e2e
to accelerate ci process.



