### PR TITLE
Optimise the redundancy code

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 	_ "net/http/pprof" // #nosec
-	"os"
 	"strings"
 	"time"
 
@@ -106,18 +105,13 @@ func Retry(attempts int, sleep int, f func(configuration *daemon.Configuration) 
 }
 
 func initChassisAnno(cfg *daemon.Configuration) error {
-
 	chassisID, err := ioutil.ReadFile(util.ChassisLoc)
 	if err != nil {
 		klog.Errorf("read chassis file failed, %v", err)
 		return err
 	}
 
-	hostname := os.Getenv(util.HostnameEnv)
-	if hostname == "" {
-		klog.Errorf("env %s does not exist", util.HostnameEnv)
-		return err
-	}
+	hostname := cfg.NodeName
 	node, err := cfg.KubeClient.CoreV1().Nodes().Get(context.Background(), hostname, v1.GetOptions{})
 	if err != nil {
 		klog.Errorf("failed to get node %s %v", hostname, err)

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -85,7 +85,7 @@ func ParseFlags() (*Configuration, error) {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	nodeName := os.Getenv("KUBE_NODE_NAME")
+	nodeName := os.Getenv(util.HostnameEnv)
 	if nodeName == "" {
 		klog.Errorf("env KUBE_NODE_NAME not exists")
 		return nil, fmt.Errorf("env KUBE_NODE_NAME not exists")


### PR DESCRIPTION
The nodeName env is hanlder in daemon config[1], and initChassisAnno
should use it directly, rather than get it again. this PS to optimise

[1]: https://github.com/kubeovn/kube-ovn/blob/c6da7eaa903889f6cb37523ab2d5ff1ef2a2875e/pkg/daemon/config.go#L88