### PR TITLE
start_ic should run regardless of ts port

### DIFF
--- a/pkg/controller/ovn-ic.go
+++ b/pkg/controller/ovn-ic.go
@@ -110,6 +110,11 @@ func (c *Controller) removeInterConnection(azName string) error {
 }
 
 func (c *Controller) establishInterConnection(config map[string]string) error {
+	if err := c.startOVNIC(config["ic-db-host"], config["ic-nb-port"], config["ic-sb-port"]); err != nil {
+		klog.Errorf("failed to start ovn-ic, %v", err)
+		return err
+	}
+	
 	tsPort := fmt.Sprintf("ts-%s", config["az-name"])
 	exist, err := c.ovnClient.LogicalSwitchPortExists(tsPort)
 	if err != nil {
@@ -119,11 +124,6 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 	if exist {
 		klog.Infof("ts port %s already exists", tsPort)
 		return nil
-	}
-
-	if err := c.startOVNIC(config["ic-db-host"], config["ic-nb-port"], config["ic-sb-port"]); err != nil {
-		klog.Errorf("failed to start ovn-ic, %v", err)
-		return err
 	}
 
 	if err := c.ovnClient.SetAzName(config["az-name"]); err != nil {


### PR DESCRIPTION
If logic swtich ts is created, ovn-ic would not be evoked because of port check.

Now ovn-ic would run first.
Consider that there is no ERROR check for repeatedly evoke ovn-ic, the relevant exceptions need to be noted later.
