### PR TITLE
fix e2e testing on macOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f // indirect
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
 	google.golang.org/grpc v1.27.1
 	k8s.io/api v0.20.4
 	k8s.io/apimachinery v0.20.4

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	"k8s.io/klog"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -164,11 +164,11 @@ func CheckProtocol(address string) string {
 func ProtocolToFamily(protocol string) (int, error) {
 	switch protocol {
 	case kubeovnv1.ProtocolDual:
-		return netlink.FAMILY_ALL, nil
+		return unix.AF_UNSPEC, nil
 	case kubeovnv1.ProtocolIPv4:
-		return netlink.FAMILY_V4, nil
+		return unix.AF_INET, nil
 	case kubeovnv1.ProtocolIPv6:
-		return netlink.FAMILY_V6, nil
+		return unix.AF_INET6, nil
 	default:
 		return -1, fmt.Errorf("invalid protocol: %s", protocol)
 	}


### PR DESCRIPTION
#### What type of this PR
Bug fixes

Use unix.AF_XXX instead of netlink.FAMILY_XXX to avoid e2e testing failure on macOS.



