### PR TITLE
fix: add node to pod allow acl

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -501,4 +501,5 @@ func (c *Controller) startWorkers(stopCh <-chan struct{}) {
 
 	go wait.Until(c.resyncSubnetMetrics, 30*time.Second, stopCh)
 	go wait.Until(c.CheckGatewayReady, 5*time.Second, stopCh)
+	go wait.Until(c.resyncNodeACL, 10*time.Second, stopCh)
 }

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -658,3 +658,27 @@ func isNamespaceMatchNetworkPolicy(ns *corev1.Namespace, policy *netv1.NetworkPo
 	}
 	return false
 }
+
+func (c *Controller) resyncNodeACL() {
+	np, _ := c.npsLister.List(labels.Everything())
+	networkPolicyExists := len(np) != 0
+
+	subnets, _ := c.subnetsLister.List(labels.Everything())
+	for _, subnet := range subnets {
+		if subnet.Spec.Provider == util.OvnProvider || subnet.Spec.Provider == "" {
+			if subnet.Name == c.config.NodeSwitch {
+				continue
+			}
+
+			if networkPolicyExists {
+				if err := c.ovnClient.SetNodeSwitchAcl(subnet.Name); err != nil {
+					klog.Errorf("failed to set node acl, %v", err)
+				}
+			} else {
+				if err := c.ovnClient.RemoveNodeSwitchAcl(subnet.Name); err != nil {
+					klog.Errorf("failed to set node acl, %v", err)
+				}
+			}
+		}
+	}
+}

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -231,27 +231,22 @@ func (c *Controller) handleUpdateNp(key string) error {
 					}
 				}
 				klog.Infof("UpdateNp Ingress, allows is %v, excepts is %v", allows, excepts)
-				// should not create address_set if there is no addresses
-				if len(allows) != 0 {
-					if err := c.ovnClient.CreateAddressSet(ingressAllowAsName, np.Namespace, np.Name, "ingress"); err != nil {
-						klog.Errorf("failed to create address_set %s, %v", ingressAllowAsName, err)
-						return err
-					}
-					if err := c.ovnClient.SetAddressesToAddressSet(allows, ingressAllowAsName); err != nil {
-						klog.Errorf("failed to set ingress allow address_set, %v", err)
-						return err
-					}
+				if err := c.ovnClient.CreateAddressSet(ingressAllowAsName, np.Namespace, np.Name, "ingress"); err != nil {
+					klog.Errorf("failed to create address_set %s, %v", ingressAllowAsName, err)
+					return err
+				}
+				if err := c.ovnClient.SetAddressesToAddressSet(allows, ingressAllowAsName); err != nil {
+					klog.Errorf("failed to set ingress allow address_set, %v", err)
+					return err
 				}
 
-				if len(excepts) != 0 {
-					if err := c.ovnClient.CreateAddressSet(ingressExceptAsName, np.Namespace, np.Name, "ingress"); err != nil {
-						klog.Errorf("failed to create address_set %s, %v", ingressExceptAsName, err)
-						return err
-					}
-					if err := c.ovnClient.SetAddressesToAddressSet(excepts, ingressExceptAsName); err != nil {
-						klog.Errorf("failed to set ingress except address_set, %v", err)
-						return err
-					}
+				if err := c.ovnClient.CreateAddressSet(ingressExceptAsName, np.Namespace, np.Name, "ingress"); err != nil {
+					klog.Errorf("failed to create address_set %s, %v", ingressExceptAsName, err)
+					return err
+				}
+				if err := c.ovnClient.SetAddressesToAddressSet(excepts, ingressExceptAsName); err != nil {
+					klog.Errorf("failed to set ingress except address_set, %v", err)
+					return err
 				}
 
 				if len(allows) != 0 || len(excepts) != 0 {
@@ -264,6 +259,15 @@ func (c *Controller) handleUpdateNp(key string) error {
 			if len(np.Spec.Ingress) == 0 {
 				ingressAllowAsName := fmt.Sprintf("%s.%s.all", ingressAllowAsNamePrefix, protocol)
 				ingressExceptAsName := fmt.Sprintf("%s.%s.all", ingressExceptAsNamePrefix, protocol)
+				if err := c.ovnClient.CreateAddressSet(ingressAllowAsName, np.Namespace, np.Name, "ingress"); err != nil {
+					klog.Errorf("failed to create address_set %s, %v", ingressAllowAsName, err)
+					return err
+				}
+
+				if err := c.ovnClient.CreateAddressSet(ingressExceptAsName, np.Namespace, np.Name, "ingress"); err != nil {
+					klog.Errorf("failed to create address_set %s, %v", ingressExceptAsName, err)
+					return err
+				}
 				ingressPorts := []netv1.NetworkPolicyPort{}
 				if err := c.ovnClient.CreateIngressACL(fmt.Sprintf("%s/%s", np.Namespace, np.Name), pgName, ingressAllowAsName, ingressExceptAsName, protocol, ingressPorts); err != nil {
 					klog.Errorf("failed to create ingress acls for np %s, %v", key, err)
@@ -284,6 +288,9 @@ func (c *Controller) handleUpdateNp(key string) error {
 				continue
 			}
 			idxStr := values[len(values)-1]
+			if idxStr == "all" {
+				continue
+			}
 			idx, _ := strconv.Atoi(idxStr)
 			if idx >= len(np.Spec.Ingress) {
 				if err := c.ovnClient.DeleteAddressSet(asName); err != nil {
@@ -340,27 +347,22 @@ func (c *Controller) handleUpdateNp(key string) error {
 					}
 				}
 				klog.Infof("UpdateNp Egress, allows is %v, excepts is %v", allows, excepts)
-				// should not create address_set if there is no addresses
-				if len(allows) != 0 {
-					if err := c.ovnClient.CreateAddressSet(egressAllowAsName, np.Namespace, np.Name, "egress"); err != nil {
-						klog.Errorf("failed to create address_set %s, %v", egressAllowAsName, err)
-						return err
-					}
-					if err = c.ovnClient.SetAddressesToAddressSet(allows, egressAllowAsName); err != nil {
-						klog.Errorf("failed to set egress allow address_set, %v", err)
-						return err
-					}
+				if err := c.ovnClient.CreateAddressSet(egressAllowAsName, np.Namespace, np.Name, "egress"); err != nil {
+					klog.Errorf("failed to create address_set %s, %v", egressAllowAsName, err)
+					return err
+				}
+				if err = c.ovnClient.SetAddressesToAddressSet(allows, egressAllowAsName); err != nil {
+					klog.Errorf("failed to set egress allow address_set, %v", err)
+					return err
 				}
 
-				if len(excepts) != 0 {
-					if err := c.ovnClient.CreateAddressSet(egressExceptAsName, np.Namespace, np.Name, "egress"); err != nil {
-						klog.Errorf("failed to create address_set %s, %v", egressExceptAsName, err)
-						return err
-					}
-					if err = c.ovnClient.SetAddressesToAddressSet(excepts, egressExceptAsName); err != nil {
-						klog.Errorf("failed to set egress except address_set, %v", err)
-						return err
-					}
+				if err := c.ovnClient.CreateAddressSet(egressExceptAsName, np.Namespace, np.Name, "egress"); err != nil {
+					klog.Errorf("failed to create address_set %s, %v", egressExceptAsName, err)
+					return err
+				}
+				if err = c.ovnClient.SetAddressesToAddressSet(excepts, egressExceptAsName); err != nil {
+					klog.Errorf("failed to set egress except address_set, %v", err)
+					return err
 				}
 
 				if len(allows) != 0 || len(excepts) != 0 {
@@ -373,6 +375,15 @@ func (c *Controller) handleUpdateNp(key string) error {
 			if len(np.Spec.Egress) == 0 {
 				egressAllowAsName := fmt.Sprintf("%s.%s.all", egressAllowAsNamePrefix, protocol)
 				egressExceptAsName := fmt.Sprintf("%s.%s.all", egressExceptAsNamePrefix, protocol)
+				if err := c.ovnClient.CreateAddressSet(egressAllowAsName, np.Namespace, np.Name, "egress"); err != nil {
+					klog.Errorf("failed to create address_set %s, %v", egressAllowAsName, err)
+					return err
+				}
+
+				if err := c.ovnClient.CreateAddressSet(egressExceptAsName, np.Namespace, np.Name, "egress"); err != nil {
+					klog.Errorf("failed to create address_set %s, %v", egressExceptAsName, err)
+					return err
+				}
 				egressPorts := []netv1.NetworkPolicyPort{}
 				if err := c.ovnClient.CreateEgressACL(fmt.Sprintf("%s/%s", np.Namespace, np.Name), pgName, egressAllowAsName, egressExceptAsName, protocol, egressPorts); err != nil {
 					klog.Errorf("failed to create egress acls for np %s, %v", key, err)
@@ -393,6 +404,10 @@ func (c *Controller) handleUpdateNp(key string) error {
 				continue
 			}
 			idxStr := values[len(values)-1]
+			if idxStr == "all" {
+				continue
+			}
+
 			idx, _ := strconv.Atoi(idxStr)
 			if idx >= len(np.Spec.Egress) {
 				if err := c.ovnClient.DeleteAddressSet(asName); err != nil {
@@ -676,7 +691,7 @@ func (c *Controller) resyncNodeACL() {
 				}
 			} else {
 				if err := c.ovnClient.RemoveNodeSwitchAcl(subnet.Name); err != nil {
-					klog.Errorf("failed to set node acl, %v", err)
+					klog.Errorf("failed to remove node acl, %v", err)
 				}
 			}
 		}

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -731,6 +731,40 @@ func (c Client) CleanLogicalSwitchAcl(ls string) error {
 	return err
 }
 
+func (c Client) SetNodeSwitchAcl(ls string) error {
+	cidrs := strings.Split(c.NodeSwitchCIDR, ",")
+	for _, cidr := range cidrs {
+		var err error
+		if util.CheckProtocol(cidr) == kubeovnv1.ProtocolIPv4 {
+			_, err = c.ovnNbCommand(MayExist, "acl-add", ls, "to-lport", util.NodeAllowPriority, fmt.Sprintf("ip4.src==%s", c.NodeSwitchCIDR), "allow-related")
+		} else {
+			_, err = c.ovnNbCommand(MayExist, "acl-add", ls, "to-lport", util.NodeAllowPriority, fmt.Sprintf("ip6.src==%s", c.NodeSwitchCIDR), "allow-related")
+		}
+		if err != nil {
+			klog.Errorf("failed to add node switch acl")
+			return err
+		}
+	}
+	return nil
+}
+
+func (c Client) RemoveNodeSwitchAcl(ls string) error {
+	cidrs := strings.Split(c.NodeSwitchCIDR, ",")
+	for _, cidr := range cidrs {
+		var err error
+		if util.CheckProtocol(cidr) == kubeovnv1.ProtocolIPv4 {
+			_, err = c.ovnNbCommand("acl-del", ls, "to-lport", util.NodeAllowPriority, fmt.Sprintf("ip4.src==%s", c.NodeSwitchCIDR))
+		} else {
+			_, err = c.ovnNbCommand("acl-del", ls, "to-lport", util.NodeAllowPriority, fmt.Sprintf("ip6.src==%s", c.NodeSwitchCIDR))
+		}
+		if err != nil {
+			klog.Errorf("failed to delete node switch acl")
+			return err
+		}
+	}
+	return nil
+}
+
 // ResetLogicalSwitchAcl reset acl of a switch
 func (c Client) ResetLogicalSwitchAcl(ls string) error {
 	_, err := c.ovnNbCommand("acl-del", ls)
@@ -744,12 +778,12 @@ func (c Client) SetPrivateLogicalSwitch(ls, protocol, cidr string, allow []strin
 	var dropArgs []string
 	if protocol == kubeovnv1.ProtocolIPv4 {
 		dropArgs = []string{"--", "--log", fmt.Sprintf("--name=%s", ls), fmt.Sprintf("--severity=%s", "warning"), "acl-add", ls, "to-lport", util.DefaultDropPriority, "ip", "drop"}
-		allowArgs = append(allowArgs, "--", "acl-add", ls, "to-lport", util.NodeAllowPriority, fmt.Sprintf("ip4.src==%s", c.NodeSwitchCIDR), "allow-related")
-		allowArgs = append(allowArgs, "--", "acl-add", ls, "to-lport", util.SubnetAllowPriority, fmt.Sprintf(`ip4.src==%s && ip4.dst==%s`, cidr, cidr), "allow-related")
+		allowArgs = append(allowArgs, "--", MayExist, "acl-add", ls, "to-lport", util.NodeAllowPriority, fmt.Sprintf("ip4.src==%s", c.NodeSwitchCIDR), "allow-related")
+		allowArgs = append(allowArgs, "--", MayExist, "acl-add", ls, "to-lport", util.SubnetAllowPriority, fmt.Sprintf(`ip4.src==%s && ip4.dst==%s`, cidr, cidr), "allow-related")
 	} else {
 		dropArgs = []string{"--", "--log", fmt.Sprintf("--name=%s", ls), fmt.Sprintf("--severity=%s", "warning"), "acl-add", ls, "to-lport", util.DefaultDropPriority, "ip", "drop"}
-		allowArgs = append(allowArgs, "--", "acl-add", ls, "to-lport", util.NodeAllowPriority, fmt.Sprintf("ip6.src==%s", c.NodeSwitchCIDR), "allow-related")
-		allowArgs = append(allowArgs, "--", "acl-add", ls, "to-lport", util.SubnetAllowPriority, fmt.Sprintf(`ip6.src==%s && ip6.dst==%s`, cidr, cidr), "allow-related")
+		allowArgs = append(allowArgs, "--", MayExist, "acl-add", ls, "to-lport", util.NodeAllowPriority, fmt.Sprintf("ip6.src==%s", c.NodeSwitchCIDR), "allow-related")
+		allowArgs = append(allowArgs, "--", MayExist, "acl-add", ls, "to-lport", util.SubnetAllowPriority, fmt.Sprintf(`ip6.src==%s && ip6.dst==%s`, cidr, cidr), "allow-related")
 	}
 	ovnArgs := append(delArgs, dropArgs...)
 
@@ -763,7 +797,7 @@ func (c Client) SetPrivateLogicalSwitch(ls, protocol, cidr string, allow []strin
 				match = fmt.Sprintf("(ip6.src==%s && ip6.dst==%s) || (ip6.src==%s && ip6.dst==%s)", strings.TrimSpace(subnet), cidr, cidr, strings.TrimSpace(subnet))
 			}
 
-			allowArgs = append(allowArgs, "--", "acl-add", ls, "to-lport", util.SubnetAllowPriority, match, "allow-related")
+			allowArgs = append(allowArgs, "--", MayExist, "acl-add", ls, "to-lport", util.SubnetAllowPriority, match, "allow-related")
 		}
 	}
 	ovnArgs = append(ovnArgs, allowArgs...)

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -227,7 +227,7 @@ func (c Client) CreateLogicalSwitch(ls, lr, protocol, subnet, gateway string, ex
 			"set", "logical_switch", ls, fmt.Sprintf("other_config:gateway=%s", gateway), "--",
 			"set", "logical_switch", ls, fmt.Sprintf("other_config:exclude_ips=%s", strings.Join(excludeIps, " ")))
 	case kubeovnv1.ProtocolDual:
-		// gateway is not offical column, which is used for private
+		// gateway is not an official column, which is used for private
 		cidrBlocks := strings.Split(subnet, ",")
 		_, err = c.ovnNbCommand(MayExist, "ls-add", ls, "--",
 			"set", "logical_switch", ls, fmt.Sprintf("other_config:subnet=%s", cidrBlocks[0]), "--",


### PR DESCRIPTION
If this acl not exists and networkpolicy is added, probe will failed as is not allowed.
If no networkpolicy exists, this allow acl may increase performance burden. So only add
this acl if any networkpolicy exists

#### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)



