### PR TITLE
Correct vlan e2e testing

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -278,57 +278,6 @@ jobs:
           docker load --input image.tar
           sudo make kind-install-ipv6
 
-  ipv6-vlan-e2e:
-    needs: build
-    name: ipv6-vlan-e2e
-    runs-on: ubuntu-18.04
-    timeout-minutes: 30
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Install Kind
-        env:
-          KIND_VERSION: v0.9.0
-        run: |
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
-
-      - name: Init Kind
-        run: |
-          pip install j2cli --user
-          pip install "j2cli[yaml]" --user
-          sudo PATH=~/.local/bin:$PATH make kind-init-ipv6
-
-      - name: Download image
-        uses: actions/download-artifact@v2
-        with:
-          name: image
-
-      - name: Load Image
-        run: |
-          docker load --input image.tar
-
-      - name: Install Kube-OVN
-        run: |
-          docker load --input image.tar
-          sudo make kind-install-ipv6-vlan
-
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.16
-        id: go
-
-      - name: Run E2E
-        run: |
-          go get -u github.com/onsi/ginkgo/ginkgo
-          go get -u github.com/onsi/gomega/...
-          sudo kubectl cluster-info
-          sudo chmod 666 /home/runner/.kube/config
-          make e2e-vlan
-
   push:
     needs:
       - single-e2e
@@ -336,7 +285,6 @@ jobs:
       - single-node-e2e
       - ha-e2e
       - ipv6-e2e
-      - ipv6-vlan-e2e
     name: push
     runs-on: ubuntu-18.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,18 @@ kind-install:
 
 .PHONY: kind-install-vlan
 kind-install-vlan:
+	$(eval SUBNET = $(shell docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}"))
+	$(eval GATEWAY = $(shell docker network inspect kind -f "{{(index .IPAM.Config 0).Gateway}}"))
+	$(eval EXCLUDE_IPS = $(shell docker network inspect kind -f '{{range .Containers}},{{index (split .IPv4Address "/") 0}}{{end}}' | sed 's/^,//'))
+	sed -e 's@^[[:space:]]*POD_CIDR=.*@POD_CIDR="$(SUBNET)"@' \
+		-e 's@^[[:space:]]*POD_GATEWAY=.*@POD_GATEWAY="$(GATEWAY)"@' \
+		-e 's@^[[:space:]]*EXCLUDE_IPS=.*@EXCLUDE_IPS="$(EXCLUDE_IPS)"@' \
+		-e 's@^VLAN_ID=.*@VLAN_ID="0"@' \
+		dist/images/install.sh > install-vlan.sh
+	chmod +x install-vlan.sh
 	kind load docker-image --name kube-ovn $(REGISTRY)/kube-ovn:$(RELEASE_TAG)
 	kubectl taint node kube-ovn-control-plane node-role.kubernetes.io/master:NoSchedule-
-	ENABLE_SSL=true ENABLE_VLAN=true VLAN_NIC=eth0 dist/images/install.sh
+	ENABLE_SSL=true ENABLE_VLAN=true VLAN_NIC=eth0 ./install-vlan.sh
 	kubectl describe no
 
 .PHONY: kind-install-single
@@ -150,9 +159,23 @@ kind-install-ipv6:
 
 .PHONY: kind-install-ipv6-vlan
 kind-install-ipv6-vlan:
+	docker network inspect bridge
+	docker network inspect kind
+	$(eval SUBNET = $(shell docker network inspect kind -f "{{(index .IPAM.Config 1).Subnet}}"))
+	$(eval GATEWAY = $(shell docker network inspect kind -f "{{(index .IPAM.Config 1).Gateway}}"))
+	$(eval EXCLUDE_IPS = $(shell docker network inspect kind -f '{{range .Containers}},{{index (split .IPv6Address "/") 0}}{{end}}' | sed 's/^,//'))
+ifeq ($(GATEWAY),)
+	$(eval GATEWAY = $(shell docker exec kube-ovn-worker ip -6 route show default | awk '{print $$3}'))
+endif
+	sed -e 's@^[[:space:]]*POD_CIDR=.*@POD_CIDR="$(SUBNET)"@' \
+		-e 's@^[[:space:]]*POD_GATEWAY=.*@POD_GATEWAY="$(GATEWAY)"@' \
+		-e 's@^[[:space:]]*EXCLUDE_IPS=.*@EXCLUDE_IPS="$(EXCLUDE_IPS)"@' \
+		-e 's@^VLAN_ID=.*@VLAN_ID="0"@' \
+		dist/images/install.sh > install-vlan.sh
+	chmod +x install-vlan.sh
 	kind load docker-image --name kube-ovn $(REGISTRY)/kube-ovn:$(RELEASE_TAG)
 	kubectl taint node kube-ovn-control-plane node-role.kubernetes.io/master:NoSchedule-
-	ENABLE_SSL=true IPv6=true ENABLE_VLAN=true VLAN_NIC=eth0 dist/images/install.sh
+	ENABLE_SSL=true IPv6=true ENABLE_VLAN=true VLAN_NIC=eth0 ./install-vlan.sh
 
 .PHONY: kind-install-dual
 kind-install-dual:
@@ -199,7 +222,7 @@ e2e:
 
 .PHONY: e2e-vlan
 e2e-vlan:
-	echo "package node\n\nvar networkJSON = []byte(\`" > test/e2e-vlan/node/network.go
+	printf "package node\n\nvar networkJSON = []byte(\`" > test/e2e-vlan/node/network.go
 	docker inspect -f '{{json .NetworkSettings.Networks.kind}}' kube-ovn-control-plane >> test/e2e-vlan/node/network.go
 	echo "\`)" >> test/e2e-vlan/node/network.go
 	ginkgo -mod=mod -progress -reportPassed --slowSpecThreshold=60 test/e2e-vlan

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -6,6 +6,7 @@ DualStack=${DualStack:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
 ENABLE_VLAN=${ENABLE_VLAN:-false}
 ENABLE_MIRROR=${ENABLE_MIRROR:-false}
+VLAN_NIC=${VLAN_NIC:-}
 HW_OFFLOAD=${HW_OFFLOAD:-false}
 IFACE=""                               # The nic to support container network can be a nic name or a group of regex separated by comma, if empty will use the nic that the default route use
 


### PR DESCRIPTION
#### What type of this PR

Testing

1. Set default vlan id to 0;
2. Set default subnet's CIDR to the docker network's subnet;
3. Set default subnet's gateway to the docker network's gateway;
4. Remove IPv6 Vlan e2e testing in Github workflows.

> Docker network created by `kind` in Github actions has no IPv6 gateway.