### PR TITLE
fix: remove rollout check

### DIFF
--- a/dist/images/start-cniserver.sh
+++ b/dist/images/start-cniserver.sh
@@ -31,8 +31,4 @@ done
 iptables -P FORWARD ACCEPT
 iptables-nft -P FORWARD ACCEPT
 
-# wait kube-ovn-controller ready
-kubectl rollout status deployment/kube-ovn-controller -n "$(cat /run/secrets/kubernetes.io/serviceaccount/namespace)"
-sleep 1
-
 ./kube-ovn-daemon --ovs-socket=${OVS_SOCK} --bind-socket=${CNI_SOCK} "$@"


### PR DESCRIPTION
For incident, part of kube-ovn-controller instances may down,
but it should not prevent kube-ovn-cni starts.

#### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->




