### PR TITLE
[WIP] add dummy interface only when ifName is eth0

### DIFF
--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -178,11 +178,13 @@ func configureContainerNic(nicName, ifName string, ipAddr, gateway string, macAd
 			if err = configureNic(nicName, ipAddr, macAddr, mtu); err != nil {
 				return err
 			}
-			if err = addAdditonalNic(ifName); err != nil {
-				return err
-			}
-			if err = configureAdditonalNic(ifName, ipAddr); err != nil {
-				return err
+			if ifName == "eth0" {
+				if err = addAdditonalNic(ifName); err != nil {
+					return err
+				}
+				if err = configureAdditonalNic(ifName, ipAddr); err != nil {
+					return err
+				}
 			}
 		} else {
 			if err = configureNic(ifName, ipAddr, macAddr, mtu); err != nil {


### PR DESCRIPTION
Fixes #881 

When nic type is `internal-port`, the dummy interface may cause multicast on the OVS interface not working. Since the dummy interface is only needed when ifName is `eth0`, we should create it only when ifName is `eth0`.