### PR TITLE
fix: check crds when controller start

### DIFF
--- a/dist/images/install-pre-1.16.sh
+++ b/dist/images/install-pre-1.16.sh
@@ -2207,6 +2207,7 @@ diagnose(){
   kubectl get crd vpc-nat-gateways.kubeovn.io
   kubectl get crd subnets.kubeovn.io
   kubectl get crd ips.kubeovn.io
+  kubectl get crd vlans.kubeovn.io
   kubectl get svc kube-dns -n kube-system
   kubectl get svc kubernetes -n default
   kubectl get sa -n kube-system ovn

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2259,6 +2259,7 @@ diagnose(){
   kubectl get crd vpc-nat-gateways.kubeovn.io
   kubectl get crd subnets.kubeovn.io
   kubectl get crd ips.kubeovn.io
+  kubectl get crd vlans.kubeovn.io
   kubectl get svc kube-dns -n kube-system
   kubectl get svc kubernetes -n default
   kubectl get sa -n kube-system ovn

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -163,6 +163,7 @@ diagnose(){
   kubectl get crd vpc-nat-gateways.kubeovn.io
   kubectl get crd subnets.kubeovn.io
   kubectl get crd ips.kubeovn.io
+  kubectl get crd vlans.kubeovn.io
   kubectl get svc kube-dns -n kube-system
   kubectl get svc kubernetes -n default
   kubectl get sa -n kube-system ovn


### PR DESCRIPTION
Some user upgrade form 1.6 to 1.7 by just changing the image. The crds and rbacs are not updated, however the controller starts successfully and hides the issues. This check will panic kube-ovn-controller if crds are not ready and expose the issues.

#### What type of this PR
Examples of user facing changes:
- Bug fixes



