### PR TITLE
some fixes in vlan initialization

### DIFF
--- a/test/e2e-vlan/node/node.go
+++ b/test/e2e-vlan/node/node.go
@@ -146,23 +146,13 @@ var _ = Describe("[Vlan Node]", func() {
 		stdout, _, err = f.ExecToPodThroughAPI("ip addr show "+vlanNic, "openvswitch", ovsPod.Name, ovsPod.Namespace, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		var newMac, hasAddr bool
-		for i, s := range strings.Split(stdout, "\n") {
-			if i == 1 {
-				s = strings.TrimSpace(s)
-				newMac = strings.HasPrefix(s, "link/ether 00:00:00:")
-				if newMac && network != nil && network.MacAddress != "" {
-					newMac = !strings.HasPrefix(s, fmt.Sprintf("link/ether %s ", network.MacAddress))
-				}
-				continue
-			}
-
+		var hasAddr bool
+		for _, s := range strings.Split(stdout, "\n") {
 			if s = strings.TrimSpace(s); strings.HasPrefix(s, "inet ") || strings.HasPrefix(s, "inet6 ") {
 				hasAddr = true
 				break
 			}
 		}
-		Expect(newMac).To(BeTrue())
 		Expect(hasAddr).To(BeFalse())
 
 		stdout, _, err = f.ExecToPodThroughAPI("ip route show dev "+vlanBr, "openvswitch", ovsPod.Name, ovsPod.Namespace, nil)


### PR DESCRIPTION
1. do not change MAC address of provider interface;
2. add routes to OVS bridge in order by scope;
3. simplify error checks.

#### What type of this PR

- Bug fixes
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

> If the host is a VM in VMWare ESXi, mac change of the provider interface will result in network failure.