### PR TITLE
fix: clean up gateway chassis list for external gw

### DIFF
--- a/pkg/controller/external-gw.go
+++ b/pkg/controller/external-gw.go
@@ -45,6 +45,14 @@ func (c *Controller) resyncExternalGateway() {
 		if exGwEnabled == "true" && lastExGwCM != nil && reflect.DeepEqual(cm.Data, lastExGwCM) {
 			return
 		}
+		if (lastExGwCM["type"] == "distributed" && cm.Data["type"] == "centralized") ||
+			!reflect.DeepEqual(lastExGwCM["external-gw-nodes"], cm.Data["external-gw-nodes"]) {
+			klog.Info("external gw nodes list changed, start to remove ovn external gw")
+			if err := c.removeExternalGateway(); err != nil {
+				klog.Errorf("failed to remove old ovn external gw, %v", err)
+				return
+			}
+		}
 		klog.Info("start to establish ovn external gw")
 		if err := c.establishExternalGateway(cm.Data); err != nil {
 			klog.Errorf("failed to establish ovn-external-gw, %v", err)


### PR DESCRIPTION
- Bug fixes

When the external gateway's type is changed from 'distributed' to 'centralized' or external-gw-nodes list changes, it needs to clean up the existing chassis gateways. And also when gw nodes list changes, it should clean the gw chassis too.

Considering the exGw configuration does not change frequently, the entire gw chassis are cleaned here, to avoid code complexity.


#### Which issue(s) this PR fixes:
Fixes #887



