### PR TITLE
delete the process of ip crd delete in cni delete request

### DIFF
--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -288,16 +288,5 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		}
 	}
 
-	ipCrName := ovs.PodNameToPortName(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider)
-	err = csh.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipCrName, metav1.DeleteOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		errMsg := fmt.Errorf("del ip crd for %s failed %v", ipCrName, err)
-		klog.Error(errMsg)
-		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
-			klog.Errorf("failed to write response, %v", err)
-		}
-		return
-	}
-
 	resp.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、For pod, IP crd is created when pod is added in cni handleAdd process. And IP crd is deleted when pod is deleted in kube-ovn-controller handleDeletePod process.
2、For node, IP crd is created in kube-ovn-controller handleAddNode process, and deleted in kube-ovn-controller handleDeleteNode process.
3、So delete ip crd in cni handleDel is not necessary. And when a pod is deleted, the cni delete request msg will receive more than once, which cause IP crd to be deleted many times, even after the pod has been restored, so this will cause IP crd lost.
####

#### Which issue(s) this PR fixes:
Fixes #897



