### PR TITLE
list ls with label to avoid listing ts failure

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -563,7 +563,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 	}
 
-	exist, err := c.ovnClient.LogicalSwitchExists(subnet.Name)
+	exist, err := c.ovnClient.LogicalSwitchExists(subnet.Name, fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName))
 	if err != nil {
 		klog.Errorf("failed to list logical switch, %v", err)
 		c.patchSubnetStatus(subnet, "ListLogicalSwitchFailed", err.Error())
@@ -653,7 +653,7 @@ func (c *Controller) handleDeleteRoute(subnet *kubeovnv1.Subnet) error {
 func (c *Controller) handleDeleteLogicalSwitch(key string) error {
 	c.ipam.DeleteSubnet(key)
 
-	exist, err := c.ovnClient.LogicalSwitchExists(key)
+	exist, err := c.ovnClient.LogicalSwitchExists(key, fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName))
 	if err != nil {
 		klog.Errorf("failed to list logical switch, %v", err)
 		return err

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -468,8 +468,8 @@ func (c Client) GetEntityInfo(entity string, index string, attris []string) (res
 	return result, nil
 }
 
-func (c Client) LogicalSwitchExists(logicalSwitch string) (bool, error) {
-	lss, err := c.ListLogicalSwitch(fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName))
+func (c Client) LogicalSwitchExists(logicalSwitch string, args ...string) (bool, error) {
+	lss, err := c.ListLogicalSwitch(args...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
ts, the logical_switch which is created in start-ic-db.sh, could not pass its "external_id" to Kube-ovn NBDB. 
This problem leads to "ls ts not ready" problem when creating connection between ts and default router.
So I raised the search criteria level to avoid this problem.