### PR TITLE
delete ecmp route when node is not ready

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -520,6 +520,13 @@ func (c *Controller) checkGatewayReady() error {
 			if util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
 				ipStr := node.Annotations[util.IpAddressAnnotation]
 				for _, ip := range strings.Split(ipStr, ",") {
+					var cidrBlock string
+					for _, cidrBlock = range strings.Split(subnet.Spec.CIDRBlock, ",") {
+						if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) {
+							continue
+						}
+					}
+
 					pinger, err := goping.NewPinger(ip)
 					if err != nil {
 						return fmt.Errorf("failed to init pinger, %v", err)
@@ -538,15 +545,19 @@ func (c *Controller) checkGatewayReady() error {
 					}
 					pinger.Run()
 
-					exist, err := c.checkNodeEcmpRouteExist(ip, subnet.Spec.CIDRBlock)
+					exist, err := c.checkNodeEcmpRouteExist(ip, cidrBlock)
 					if err != nil {
 						klog.Errorf("get ecmp static route for subnet %v, error %v", subnet.Name, err)
 						break
 					}
+					if !nodeReady(node) {
+						success = false
+					}
+
 					if !success {
-						klog.Warningf("failed to ping gw %s", ip)
+						klog.Warningf("failed to ping ovn0 %s or node %v is not ready", ip, node.Name)
 						if exist {
-							if err := c.deleteStaticRoute(ip, c.config.ClusterRouter, subnet); err != nil {
+							if err := c.ovnClient.DeleteMatchedStaticRoute(cidrBlock, ip, c.config.ClusterRouter); err != nil {
 								klog.Errorf("failed to delete static route %s for node %s, %v", ip, node.Name, err)
 								return err
 							}

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -747,6 +747,14 @@ func (c Client) DeleteNatRule(logicalIP, router string) error {
 	return err
 }
 
+func (c Client) DeleteMatchedStaticRoute(cidr, nexthop, router string) error {
+	if cidr == "" || nexthop == "" {
+		return nil
+	}
+	_, err := c.ovnNbCommand(IfExists, "lr-route-del", router, cidr, nexthop)
+	return err
+}
+
 // DeleteStaticRoute delete a static route rule in ovn
 func (c Client) DeleteStaticRoute(cidr, router string) error {
 	if cidr == "" {


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、for centralized subnet, when node is not ready, the ecmp route which nexthop is ovn0 on the node can not be delete correctly.
#### Which issue(s) this PR fixes:
Fixes #916 



