### PR TITLE
keep subnet's vlan empty if not specified

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -260,10 +260,6 @@ func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 		if subnet.Spec.Default && subnet.Name != c.config.DefaultLogicalSwitch {
 			subnet.Spec.Default = false
 		}
-		if c.config.NetworkType == util.NetworkTypeVlan && subnet.Spec.Vlan == "" {
-			subnet.Spec.Vlan = c.config.DefaultVlanName
-			subnet.Spec.UnderlayGateway = true
-		}
 		if subnet.Spec.Vlan != "" {
 			if _, err := c.vlansLister.Get(subnet.Spec.Vlan); err != nil {
 				klog.Warningf("subnet %s reference a none exist vlan %s", subnet.Name, subnet.Spec.Vlan)


### PR DESCRIPTION
#### What type of this PR

Bug fixes

Keep subnet's vlan empty if not specified. The default network type should take effect only on the default subnet.