### PR TITLE
<fix> update qos ingress_policing_burst

### DIFF
--- a/pkg/ovs/ovs-vsctl.go
+++ b/pkg/ovs/ovs-vsctl.go
@@ -119,7 +119,7 @@ func SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress string)
 
 	for _, ifName := range interfaceList {
 		// ingress_policing_rate is in Kbps
-		err := ovsSet("interface", ifName, fmt.Sprintf("ingress_policing_rate=%d", ingressKPS), fmt.Sprintf("ingress_policing_burst=%d", ingressKPS*10/8))
+		err := ovsSet("interface", ifName, fmt.Sprintf("ingress_policing_rate=%d", ingressKPS), fmt.Sprintf("ingress_policing_burst=%d", ingressKPS*8/10))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Ovs document suggest set ingress_policing_burst  at least as large as 80% of  ingress_policing_rate, this helps TCP come closer to achieving the full rate.






