### PR TITLE
add designative nat ip process for centralized subnet

### DIFF
--- a/docs/subnet.md
+++ b/docs/subnet.md
@@ -59,6 +59,7 @@ For a centralized gateway, outgoing traffic from Pods within the OVN network to 
 - `gatewayNode`: when `gatewayType` is `centralized` used this field to specify which node act as the namespace gateway. This field can be a comma separated string, like `node1,node2`.
 Before kube-ovn v1.6.3, kube-ovn will automatically apply an active-backup failover strategy.
 Since kube-ovn v1.7.0, kube-ovn support ecmp routes, and outgoing traffic can go through multiple gateway specified.
+Since kube-ovn v1.8.0, kube-ovn support using designative egress ip on node, the format of gatewayNode can be like 'kube-ovn-worker:172.18.0.2, kube-ovn-control-plane:172.18.0.3'.
 - `natOutgoing`: `true` or `false`, whether pod ip need to be masqueraded when go through gateway. When `false`, pod ip will be exposed to external network directly, default `false`.
 
 ## Advance Options

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -423,8 +423,13 @@ func CountIpNums(excludeIPs []string) float64 {
 }
 
 func GatewayContains(gatewayNodeStr, gateway string) bool {
+	// the format of gatewayNodeStr can be like 'kube-ovn-worker:172.18.0.2, kube-ovn-control-plane:172.18.0.3', which consists of node name and designative egress ip
 	for _, gw := range strings.Split(gatewayNodeStr, ",") {
-		gw = strings.TrimSpace(gw)
+		if strings.Contains(gw, ":") {
+			gw = strings.TrimSpace(strings.Split(gw, ":")[0])
+		} else {
+			gw = strings.TrimSpace(gw)
+		}
 		if gw == gateway {
 			return true
 		}


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- API changes
####
Support designative ip for centralize subnet gatewayNode，the format can be like 'kube-ovn-worker:172.18.0.2, kube-ovn-control-plane:172.18.0.3' 




