### PR TITLE
ignore empty lines when counting lbs

### DIFF
--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -790,7 +790,7 @@ func (c Client) DeleteStaticRouteByNextHop(nextHop string) error {
 func (c Client) FindLoadbalancer(lb string) (string, error) {
 	output, err := c.ovnNbCommand("--data=bare", "--no-heading", "--columns=_uuid",
 		"find", "load_balancer", fmt.Sprintf("name=%s", lb))
-	count := len(strings.Split(output, "\n"))
+	count := len(strings.FieldsFunc(output, func(c rune) bool { return c == '\n' }))
 	if count > 1 {
 		klog.Errorf("%s has %d lb entries", lb, count)
 		return "", fmt.Errorf("%s has %d lb entries", lb, count)


### PR DESCRIPTION
The original code will count empty newlines after the split:

```
()[root@ovn-ovsdb-nb-2 /]# ovn-nbctl --data=bare --no-heading --columns=_uuid find load_balancer name=vpc-neutron-d8ef5ad5-bcb2-44c6-8a67-aca66b5e4644-tcp-sess-load
e7c69a52-7f38-4ea1-bcdb-62f44a5e28c5

88c6298b-c00c-4179-979b-0e3e1dd4baf6
``` 

leads to:

```
E0728 10:40:03.089989       1 ovn-nbctl.go:795] vpc-neutron-d8ef5ad5-bcb2-44c6-8a67-aca66b5e4644-tcp-sess-load has 3 lb entries
```



#### What type of this PR
Examples of user facing changes:
- API changes
- Bug fixes
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)



