### PR TITLE
fix external_ids:pod_netns

### DIFF
--- a/dist/images/install-pre-1.16.sh
+++ b/dist/images/install-pre-1.16.sh
@@ -2216,12 +2216,12 @@ tcpdump(){
       exit 1
     fi
     podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r')
+    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
     set -x
     if [ "$podNicType" = "internal-port" ]; then
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ip netns exec "$podNetNs" tcpdump -nn -i "$nicName" "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
     else
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ip netns exec "$podNetNs" tcpdump -nn -i eth0 "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i eth0 "$@"
     fi
   fi
 }
@@ -2268,14 +2268,14 @@ trace(){
     fi
 
     gateway=$(kubectl get subnet "$ls" -o jsonpath={.spec.gateway})
-    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r')
+    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
 
     podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
     if [ "$podNicType" != "internal-port" ]; then
       nicName="eth0"
     fi
 
-    output=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="/var/run/netns/$podNetNs" arping -c1 -i "$nicName" "$gateway")
+    output=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" arping -c1 -i "$nicName" "$gateway")
     if [ $? -ne 0 ]; then
       echo "failed to run 'arping -c1 -i $nicName $gateway' in Pod netns"
       exit 1

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2258,12 +2258,12 @@ tcpdump(){
       exit 1
     fi
     podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r')
+    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
     set -x
     if [ "$podNicType" = "internal-port" ]; then
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ip netns exec "$podNetNs" tcpdump -nn -i "$nicName" "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
     else
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ip netns exec "$podNetNs" tcpdump -nn -i eth0 "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i eth0 "$@"
     fi
   fi
 }
@@ -2310,14 +2310,14 @@ trace(){
     fi
 
     gateway=$(kubectl get subnet "$ls" -o jsonpath={.spec.gateway})
-    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r')
+    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
 
     podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
     if [ "$podNicType" != "internal-port" ]; then
       nicName="eth0"
     fi
 
-    output=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="/var/run/netns/$podNetNs" arping -c1 -i "$nicName" "$gateway")
+    output=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" arping -c1 -i "$nicName" "$gateway")
     if [ $? -ne 0 ]; then
       echo "failed to run 'arping -c1 -i $nicName $gateway' in Pod netns"
       exit 1

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -52,12 +52,12 @@ tcpdump(){
       exit 1
     fi
     podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r')
+        podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
     set -x
     if [ "$podNicType" = "internal-port" ]; then
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ip netns exec "$podNetNs" tcpdump -nn -i "$nicName" "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
     else
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ip netns exec "$podNetNs" tcpdump -nn -i eth0 "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i eth0 "$@"
     fi
   fi
 }
@@ -104,14 +104,14 @@ trace(){
     fi
 
     gateway=$(kubectl get subnet "$ls" -o jsonpath={.spec.gateway})
-    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r')
+    podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
 
     podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
     if [ "$podNicType" != "internal-port" ]; then
       nicName="eth0"
     fi
 
-    output=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="/var/run/netns/$podNetNs" arping -c1 -i "$nicName" "$gateway")
+    output=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" arping -c1 -i "$nicName" "$gateway")
     if [ $? -ne 0 ]; then
       echo "failed to run 'arping -c1 -i $nicName $gateway' in Pod netns"
       exit 1

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -174,13 +174,11 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 
 		klog.Infof("create container interface %s mac %s, ip %s, cidr %s, gw %s", ifName, macAddr, ipAddr, cidr, gw)
-		nsArray := strings.Split(netns, "/")
-		podNetns := nsArray[len(nsArray)-1]
 		if nicType == util.InternalType {
-			podNicName, err = csh.configureNicWithInternalPort(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, vlanID, podRequest.DeviceID, nicType, podNetns, !podSubnet.Spec.DisableGatewayCheck)
+			podNicName, err = csh.configureNicWithInternalPort(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, vlanID, podRequest.DeviceID, nicType, netns, !podSubnet.Spec.DisableGatewayCheck)
 		} else {
 			podNicName = ifName
-			err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, vlanID, podRequest.DeviceID, nicType, podNetns, !podSubnet.Spec.DisableGatewayCheck)
+			err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, vlanID, podRequest.DeviceID, nicType, netns, !podSubnet.Spec.DisableGatewayCheck)
 		}
 		if err != nil {
 			errMsg := fmt.Errorf("configure nic failed %v", err)

--- a/test/e2e/underlay/underlay.go
+++ b/test/e2e/underlay/underlay.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -258,14 +257,14 @@ var _ = Describe("[Underlay]", func() {
 				for _, field := range strings.Fields(stdout) {
 					if strings.HasPrefix(field, "pod_netns=") {
 						netns = strings.TrimPrefix(field, "pod_netns=")
-						netns = netns[:len(netns)-1]
+						netns = strings.Trim(netns[:len(netns)-1], `"`)
 						break
 					}
 				}
 				Expect(netns).NotTo(BeEmpty())
 
 				By("validate pod's MTU")
-				cmd = fmt.Sprintf("nsenter --net=%s ip link show eth0", filepath.Join("/var/run/netns", netns))
+				cmd = fmt.Sprintf("nsenter --net=%s ip link show eth0", netns)
 				stdout, _, err = f.ExecToPodThroughAPI(cmd, "cni-server", cniPod.Name, cniPod.Namespace, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(stdout).To(ContainSubstring(" mtu %d ", nodeMTU[pod.Spec.NodeName]))
@@ -322,7 +321,7 @@ var _ = Describe("[Underlay]", func() {
 					for _, field := range strings.Fields(stdout) {
 						if strings.HasPrefix(field, "pod_netns=") {
 							netns = strings.TrimPrefix(field, "pod_netns=")
-							netns = netns[:len(netns)-1]
+							netns = strings.Trim(netns[:len(netns)-1], `"`)
 							break
 						}
 					}
@@ -339,7 +338,7 @@ var _ = Describe("[Underlay]", func() {
 					Expect(hostIP).ToNot(BeEmpty())
 
 					By("ping host")
-					cmd = fmt.Sprintf("nsenter --net=%s ping -c1 -W1 %s", filepath.Join("/var/run/netns", netns), hostIP)
+					cmd = fmt.Sprintf("nsenter --net=%s ping -c1 -W1 %s", netns, hostIP)
 					stdout, _, err = f.ExecToPodThroughAPI(cmd, "cni-server", cniPod.Name, cniPod.Namespace, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(stdout).To(ContainSubstring(" 0% packet loss"))
@@ -410,7 +409,7 @@ var _ = Describe("[Underlay]", func() {
 					for _, field := range strings.Fields(stdout) {
 						if strings.HasPrefix(field, "pod_netns=") {
 							netns = strings.TrimPrefix(field, "pod_netns=")
-							netns = netns[:len(netns)-1]
+							netns = strings.Trim(netns[:len(netns)-1], `"`)
 							break
 						}
 					}
@@ -427,7 +426,7 @@ var _ = Describe("[Underlay]", func() {
 					Expect(hostIP).ToNot(BeEmpty())
 
 					By("ping host")
-					cmd = fmt.Sprintf("nsenter --net=%s ping -c1 -W1 %s", filepath.Join("/var/run/netns", netns), hostIP)
+					cmd = fmt.Sprintf("nsenter --net=%s ping -c1 -W1 %s", netns, hostIP)
 					stdout, _, err = f.ExecToPodThroughAPI(cmd, "cni-server", cniPod.Name, cniPod.Namespace, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(stdout).To(ContainSubstring(" 0% packet loss"))
@@ -503,14 +502,14 @@ var _ = Describe("[Underlay]", func() {
 						for _, field := range strings.Fields(stdout) {
 							if strings.HasPrefix(field, "pod_netns=") {
 								netns = strings.TrimPrefix(field, "pod_netns=")
-								netns = netns[:len(netns)-1]
+								netns = strings.Trim(netns[:len(netns)-1], `"`)
 								break
 							}
 						}
 						Expect(netns).NotTo(BeEmpty())
 
 						By("ping another pod")
-						cmd = fmt.Sprintf("nsenter --net=%s ping -c1 -W1 %s", filepath.Join("/var/run/netns", netns), pods[(i+len(pods)+1)%len(pods)].Status.PodIP)
+						cmd = fmt.Sprintf("nsenter --net=%s ping -c1 -W1 %s", netns, pods[(i+len(pods)+1)%len(pods)].Status.PodIP)
 						stdout, _, err = f.ExecToPodThroughAPI(cmd, "cni-server", cniPods[nodes[i]].Name, cniPods[nodes[i]].Namespace, nil)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(stdout).To(ContainSubstring(" 0% packet loss"))
@@ -600,14 +599,14 @@ var _ = Describe("[Underlay]", func() {
 					for _, field := range strings.Fields(stdout) {
 						if strings.HasPrefix(field, "pod_netns=") {
 							netns = strings.TrimPrefix(field, "pod_netns=")
-							netns = netns[:len(netns)-1]
+							netns = strings.Trim(netns[:len(netns)-1], `"`)
 							break
 						}
 					}
 					Expect(netns).NotTo(BeEmpty())
 
 					By("ping overlay pod")
-					cmd = fmt.Sprintf("nsenter --net=%s ping -c1 -W1 %s", filepath.Join("/var/run/netns", netns), opod.Status.PodIP)
+					cmd = fmt.Sprintf("nsenter --net=%s ping -c1 -W1 %s", netns, opod.Status.PodIP)
 					stdout, _, err = f.ExecToPodThroughAPI(cmd, "cni-server", cniPod.Name, cniPod.Namespace, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(stdout).To(ContainSubstring(" 0% packet loss"))


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

`netns` passed by CNI is a file path in a form of `/var/run/netns/cni-<UUID>` in clusters created by `kind`, but in more generic scenarios the path is `/proc/<PID>/ns/net`.