### PR TITLE
Fix LoadBalancer in custom VPCs

### DIFF
--- a/dist/images/install-pre-1.16.sh
+++ b/dist/images/install-pre-1.16.sh
@@ -1222,6 +1222,10 @@ rules:
       - daemonsets
       - deployments
     verbs:
+      - create
+      - delete
+      - update
+      - patch
       - get
       - list
       - watch

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1264,6 +1264,10 @@ rules:
       - daemonsets
       - deployments
     verbs:
+      - create
+      - delete
+      - update
+      - patch
       - get
       - list
       - watch

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -416,6 +416,9 @@ func (c *Controller) handleAddPod(key string) error {
 		if pod.Annotations[util.PodNicAnnotation] == "" {
 			pod.Annotations[util.PodNicAnnotation] = c.config.PodNicType
 		}
+		if subnet.Spec.Vlan == "" && subnet.Spec.Vpc != "" {
+			pod.Annotations[fmt.Sprintf(util.LogicalRouterAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.Vpc
+		}
 
 		if err := util.ValidatePodCidr(podNet.Subnet.Spec.CIDRBlock, ipStr); err != nil {
 			klog.Errorf("validate pod %s/%s failed, %v", namespace, name, err)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -40,6 +40,7 @@ const (
 	GatewayAnnotationTemplate       = "%s.kubernetes.io/gateway"
 	IpPoolAnnotationTemplate        = "%s.kubernetes.io/ip_pool"
 	LogicalSwitchAnnotationTemplate = "%s.kubernetes.io/logical_switch"
+	LogicalRouterAnnotationTemplate = "%s.kubernetes.io/logical_router"
 	VlanIdAnnotationTemplate        = "%s.kubernetes.io/vlan_id"
 	NetworkTypeTemplate             = "%s.kubernetes.io/network_type"
 	IngressRateAnnotationTemplate   = "%s.kubernetes.io/ingress_rate"


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

In custom VPCs, services' rules should be added to the corresponding LoadBalancers instead of the ones of default VPC.