### PR TITLE
update qos process

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -916,7 +916,7 @@ func (c *Controller) handlePod(key string) error {
 		provider := fmt.Sprintf("%s.%s.ovn", multiNet.Name, multiNet.Namespace)
 		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] == "true" {
 			ifaceID = ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
-			err = ovs.SetInterfaceBandwidth(pod.Name, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)])
+			err = ovs.SetInterfaceBandwidth(pod.Name, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)])
 			if err != nil {
 				return err
 			}

--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -63,7 +63,7 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 	if err = configureHostNic(hostNicName, vlanID); err != nil {
 		return err
 	}
-	if err = ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, ingress, egress); err != nil {
+	if err = ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress); err != nil {
 		return err
 	}
 
@@ -888,7 +888,7 @@ func (csh cniServerHandler) configureNicWithInternalPort(podName, podNamespace, 
 		return containerNicName, fmt.Errorf("failed to parse mac %s %v", macAddr, err)
 	}
 
-	if err = ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, ingress, egress); err != nil {
+	if err = ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress); err != nil {
 		return containerNicName, err
 	}
 

--- a/pkg/ovs/ovs-vsctl.go
+++ b/pkg/ovs/ovs-vsctl.go
@@ -114,7 +114,7 @@ func ClearPodBandwidth(podName, podNamespace string) error {
 	return nil
 }
 
-// SetInterfaceBandwidth set ingress/egress qos for given pod
+// SetInterfaceBandwidth set ingress/egress qos for given pod, from the point of pod's view
 func SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress string) error {
 	ingressMPS, _ := strconv.Atoi(ingress)
 	ingressKPS := ingressMPS * 1000


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- Bug fixes
####
1、When pod's ingress and egress rate annotation is changed, the handlePod process in daemon pod will process qos correct
2、When pod is added with qos annotation directly, the qos is add in handleAdd process. The parameter is reversed in this situation and results in the error in issue 795  

#### Which issue(s) this PR fixes:
Fixes #795 



