### PR TITLE
fix: panic when node has nil annotations

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -273,6 +273,7 @@ func (c *Controller) handleAddNode(key string) error {
     }]`
 	op := "replace"
 	if len(node.Annotations) == 0 {
+		node.Annotations = map[string]string{}
 		op = "add"
 	}
 


### PR DESCRIPTION
#### What type of this PR
- Bug fixes


```
goroutine 568 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.20.1-rc.1/pkg/util/runtime/runtime.go:55 +0x10c
panic(0x1b5d800, 0x202e040)
	/opt/hostedtoolcache/go/1.15.11/x64/src/runtime/panic.go:969 +0x1b9
github.com/alauda/kube-ovn/pkg/controller.(*Controller).handleAddNode(0xc0000c1200, 0xc001a27860, 0x11, 0xc0005b07c8, 0xc000618120)
	/home/runner/work/kube-ovn/kube-ovn/pkg/controller/node.go:252 +0x825
github.com/alauda/kube-ovn/pkg/controller.(*Controller).processNextAddNodeWorkItem.func1(0xc0000c1200, 0x1abe200, 0xc001db0190, 0x0, 0x0)
	/home/runner/work/kube-ovn/kube-ovn/pkg/controller/node.go:111 +0xe5
github.com/alauda/kube-ovn/pkg/controller.(*Controller).processNextAddNodeWorkItem(0xc0000c1200, 0x203001)
	/home/runner/work/kube-ovn/kube-ovn/pkg/controller/node.go:117 +0x53
github.com/alauda/kube-ovn/pkg/controller.(*Controller).runAddNodeWorker(0xc0000c1200)
	/home/runner/work/kube-ovn/kube-ovn/pkg/controller/node.go:81 +0x2b
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc00051b0e0)
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.20.1-rc.1/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00051b0e0, 0x204ed00, 0xc000f74750, 0x1, 0xc0000b6300)
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.20.1-rc.1/pkg/util/wait/wait.go:156 +0xad
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00051b0e0, 0x3b9aca00, 0x0, 0x1, 0xc0000b6300)
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.20.1-rc.1/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(0xc00051b0e0, 0x3b9aca00, 0xc0000b6300)
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.20.1-rc.1/pkg/util/wait/wait.go:90 +0x4d
created by github.com/alauda/kube-ovn/pkg/controller.(*Controller).startWorkers
	/home/runner/work/kube-ovn/kube-ovn/pkg/controller/controller.go:386 +0x525
```