### PR TITLE
remove external egress gateway from additionalPrinterColumns

### DIFF
--- a/dist/images/install-pre-1.16.sh
+++ b/dist/images/install-pre-1.16.sh
@@ -411,15 +411,6 @@ spec:
     - name: NAT
       type: boolean
       JSONPath: .spec.natOutgoing
-    - name: ExternalEgressGateway
-      type: string
-      JSONPath: .spec.externalEgressGateway
-    - name: PolicyRoutingPriority
-      type: integer
-      JSONPath: .spec.policyRoutingPriority
-    - name: PolicyRoutingTableID
-      type: integer
-      JSONPath: .spec.policyRoutingTableID
     - name: Default
       type: boolean
       JSONPath: .spec.default

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -427,15 +427,6 @@ spec:
       - name: NAT
         type: boolean
         jsonPath: .spec.natOutgoing
-      - name: ExternalEgressGateway
-        type: string
-        jsonPath: .spec.externalEgressGateway
-      - name: PolicyRoutingPriority
-        type: integer
-        jsonPath: .spec.policyRoutingPriority
-      - name: PolicyRoutingTableID
-        type: integer
-        jsonPath: .spec.policyRoutingTableID
       - name: Default
         type: boolean
         jsonPath: .spec.default

--- a/yamls/crd-pre-1.16.yaml
+++ b/yamls/crd-pre-1.16.yaml
@@ -93,15 +93,6 @@ spec:
     - name: NAT
       type: boolean
       JSONPath: .spec.natOutgoing
-    - name: ExternalEgressGateway
-      type: string
-      JSONPath: .spec.externalEgressGateway
-    - name: PolicyRoutingPriority
-      type: integer
-      JSONPath: .spec.policyRoutingPriority
-    - name: PolicyRoutingTableID
-      type: integer
-      JSONPath: .spec.policyRoutingTableID
     - name: Default
       type: boolean
       JSONPath: .spec.default

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -100,15 +100,6 @@ spec:
       - name: NAT
         type: boolean
         jsonPath: .spec.natOutgoing
-      - name: ExternalEgressGateway
-        type: string
-        jsonPath: .spec.externalEgressGateway
-      - name: PolicyRoutingPriority
-        type: integer
-        jsonPath: .spec.policyRoutingPriority
-      - name: PolicyRoutingTableID
-        type: integer
-        jsonPath: .spec.policyRoutingTableID
       - name: Default
         type: boolean
         jsonPath: .spec.default


### PR DESCRIPTION
Remove external egress gateway and related columns from additionalPrinterColumns to improve readability of simple `get` output.