### PR TITLE
Add missing metadata directive in VpcNatGateway example

### DIFF
--- a/docs/vpc.md
+++ b/docs/vpc.md
@@ -127,6 +127,7 @@ Controller will check this configmap and create network attachment definition.
 ```yaml
 kind: VpcNatGateway
 apiVersion: kubeovn.io/v1
+metadata:
   name: ngw
 spec:
   vpc: test-vpc-1                  # Specifies which VPC the gateway belongs to


### PR DESCRIPTION
#### What type of this PR
- Documentation fixes

Add missing metadata directive in VpcNatGateway example of `docs/vpc.md`

/kind documentation