### PR TITLE
Read interface in installation from environment

### DIFF
--- a/dist/images/install-pre-1.16.sh
+++ b/dist/images/install-pre-1.16.sh
@@ -11,7 +11,7 @@ ENABLE_LB=${ENABLE_LB:-true}
 ENABLE_NP=${ENABLE_NP:-true}
 # The nic to support container network can be a nic name or a group of regex
 # separated by comma, if empty will use the nic that the default route use
-IFACE=""
+IFACE=${IFACE:-}
 
 CNI_CONF_DIR="/etc/cni/net.d"
 CNI_BIN_DIR="/opt/cni/bin"

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -12,7 +12,7 @@ ENABLE_LB=${ENABLE_LB:-true}
 ENABLE_NP=${ENABLE_NP:-true}
 # The nic to support container network can be a nic name or a group of regex
 # separated by comma, if empty will use the nic that the default route use
-IFACE=""
+IFACE=${IFACE:-}
 
 CNI_CONF_DIR="/etc/cni/net.d"
 CNI_BIN_DIR="/opt/cni/bin"


### PR DESCRIPTION
#### What type of this PR

- Feature

This PR adds the ability to specify the interface Kube OVN should use for its inter-host network via an environment variable.

/kind feature