### PR TITLE
delete residual ovs internal ports

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -1036,6 +1036,33 @@ func (c *Controller) loopEncapIpCheck() {
 	}
 }
 
+var lastNoPodOvsPort map[string]bool
+
+func (c *Controller) markAndCleanInternalPort() error {
+	klog.V(4).Infof("start to gc ovs internal ports")
+	residualPorts := ovs.GetResidualInternalPorts()
+	if len(residualPorts) == 0 {
+		return nil
+	}
+
+	noPodOvsPort := map[string]bool{}
+	for _, portName := range residualPorts {
+		if !lastNoPodOvsPort[portName] {
+			noPodOvsPort[portName] = true
+		} else {
+			klog.Infof("gc ovs internal port %s", portName)
+			// Remove ovs port
+			output, err := ovs.Exec(ovs.IfExists, "--with-iface", "del-port", "br-int", portName)
+			if err != nil {
+				return fmt.Errorf("failed to delete ovs port %v, %q", err, output)
+			}
+		}
+	}
+	lastNoPodOvsPort = noPodOvsPort
+
+	return nil
+}
+
 // Run starts controller
 func (c *Controller) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
@@ -1060,6 +1087,11 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	go wait.Until(c.runPodWorker, time.Second, stopCh)
 	go wait.Until(c.runGateway, 3*time.Second, stopCh)
 	go wait.Until(c.loopEncapIpCheck, 3*time.Second, stopCh)
+	go wait.Until(func() {
+		if err := c.markAndCleanInternalPort(); err != nil {
+			klog.Errorf("gc ovs port error: %v", err)
+		}
+	}, 5*time.Minute, stopCh)
 	<-stopCh
 	klog.Info("Shutting down workers")
 }

--- a/pkg/ovs/ovs-vsctl.go
+++ b/pkg/ovs/ovs-vsctl.go
@@ -294,3 +294,26 @@ func ConfigInterfaceMirror(globalMirror bool, open string, iface string) error {
 	}
 	return nil
 }
+
+func GetResidualInternalPorts() []string {
+	residualPorts := make([]string, 0)
+	interfaceList, err := ovsFind("interface", "name,external_ids", "type=internal")
+	if err != nil {
+		klog.Errorf("failed to list ovs internal interface %v", err)
+		return residualPorts
+	}
+
+	for _, intf := range interfaceList {
+		name := strings.Trim(strings.Split(intf, "\n")[0], "\"")
+		if !strings.Contains(name, "_c") {
+			continue
+		}
+
+		// iface-id field does not exist in external_ids for residual internal port
+		externaIds := strings.Split(intf, "\n")[1]
+		if !strings.Contains(externaIds, "iface-id") {
+			residualPorts = append(residualPorts, name)
+		}
+	}
+	return residualPorts
+}


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
When pod is created with internal-port type,  a new ovs internal-port is created for pod after node is restarted and the old ovs internal port will be reserved, add clean operation to clear old reserved ovs internal ports



