### PR TITLE
feat: suport vm live migration

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -292,7 +292,7 @@ func (c *Controller) InitIPAM() error {
 				fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
 				pod.Annotations[util.IpAddressAnnotation],
 				pod.Annotations[util.MacAddressAnnotation],
-				pod.Annotations[util.LogicalSwitchAnnotation])
+				pod.Annotations[util.LogicalSwitchAnnotation], false)
 			if err != nil {
 				klog.Errorf("failed to init pod %s.%s address %s: %v", pod.Name, pod.Namespace, pod.Annotations[util.IpAddressAnnotation], err)
 			}
@@ -309,7 +309,7 @@ func (c *Controller) InitIPAM() error {
 			portName := fmt.Sprintf("node-%s", node.Name)
 			v4IP, v6IP, _, err := c.ipam.GetStaticAddress(portName, node.Annotations[util.IpAddressAnnotation],
 				node.Annotations[util.MacAddressAnnotation],
-				node.Annotations[util.LogicalSwitchAnnotation])
+				node.Annotations[util.LogicalSwitchAnnotation], true)
 			if err != nil {
 				klog.Errorf("failed to init node %s.%s address %s: %v", node.Name, node.Namespace, node.Annotations[util.IpAddressAnnotation], err)
 			}

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -251,7 +251,7 @@ func (c *Controller) handleAddNode(key string) error {
 	if node.Annotations[util.AllocatedAnnotation] == "true" && node.Annotations[util.IpAddressAnnotation] != "" && node.Annotations[util.MacAddressAnnotation] != "" {
 		v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(portName, node.Annotations[util.IpAddressAnnotation],
 			node.Annotations[util.MacAddressAnnotation],
-			node.Annotations[util.LogicalSwitchAnnotation])
+			node.Annotations[util.LogicalSwitchAnnotation], true)
 		if err != nil {
 			klog.Errorf("failed to alloc static ip addrs for node %v: %v", node.Name, err)
 			return err

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -139,9 +139,9 @@ func (c Client) SetPortExternalIds(port, key, value string) error {
 func (c Client) CreatePort(ls, port, ip, cidr, mac, pod, namespace string, portSecurity bool, securityGroups string) error {
 	var ovnCommand []string
 	if util.CheckProtocol(cidr) == kubeovnv1.ProtocolDual {
-		ips := strings.Split(ip, ",")
+		//ips := strings.Split(ip, ",")
 		ovnCommand = []string{MayExist, "lsp-add", ls, port, "--",
-			"lsp-set-addresses", port, fmt.Sprintf("%s %s %s", mac, ips[0], ips[1])}
+			"lsp-set-addresses", port, mac}
 
 		ipAddr := util.GetIpAddrWithMask(ip, cidr)
 		ipAddrs := strings.Split(ipAddr, ",")
@@ -151,7 +151,7 @@ func (c Client) CreatePort(ls, port, ip, cidr, mac, pod, namespace string, portS
 		}
 	} else {
 		ovnCommand = []string{MayExist, "lsp-add", ls, port, "--",
-			"lsp-set-addresses", port, fmt.Sprintf("%s %s", mac, ip)}
+			"lsp-set-addresses", port, mac}
 
 		if portSecurity {
 			ovnCommand = append(ovnCommand,

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -47,6 +47,8 @@ const (
 	IngressRateAnnotationTemplate   = "%s.kubernetes.io/ingress_rate"
 	EgressRateAnnotationTemplate    = "%s.kubernetes.io/egress_rate"
 	SecurityGroupAnnotationTemplate = "%s.kubernetes.io/security_groups"
+	LiveMigrationAnnotationTemplate = "%s.kubernetes.io/allow_live_migration"
+	DefaultRouteAnnotationTemplate  = "%s.kubernetes.io/default_route"
 
 	ProviderNetworkTemplate          = "%s.kubernetes.io/provider_network"
 	ProviderNetworkReadyTemplate     = "%s.provider-network.kubernetes.io/ready"

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -45,7 +45,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, ipv4CIDR, ipv4ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetStaticAddress("pod1.ns", "10.16.0.2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod1.ns", "10.16.0.2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				ip, _, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
@@ -56,11 +56,11 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.3"))
 
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2", "", subnetName, true)
 				Expect(err).Should(MatchError(ipam.ConflictError))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				_, _, _, err = im.GetRandomAddress("pod4.ns", "invalid_subnet", nil)
@@ -125,7 +125,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, ipv6CIDR, ipv6ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetStaticAddress("pod1.ns", "fd00::2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod1.ns", "fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				_, ip, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
@@ -136,11 +136,11 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::3"))
 
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "fd00::2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "fd00::2", "", subnetName, true)
 				Expect(err).Should(MatchError(ipam.ConflictError))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "fd00::2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				_, _, _, err = im.GetRandomAddress("pod4.ns", "invalid_subnet", nil)
@@ -209,7 +209,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, dualCIDR, dualExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetStaticAddress("pod1.ns", "10.16.0.2,fd00::2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod1.ns", "10.16.0.2,fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
@@ -222,11 +222,11 @@ var _ = Describe("[IPAM]", func() {
 				Expect(ipv4).To(Equal("10.16.0.3"))
 				Expect(ipv6).To(Equal("fd00::3"))
 
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2,fd00::2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2,fd00::2", "", subnetName, true)
 				Expect(err).Should(MatchError(ipam.ConflictError))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2,fd00::2", "", subnetName)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2,fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				_, _, _, err = im.GetRandomAddress("pod4.ns", "invalid_subnet", nil)
@@ -341,11 +341,11 @@ var _ = Describe("[IPAM]", func() {
 			It("static allocation", func() {
 				subnet, err := ipam.NewSubnet(subnetName, ipv4CIDR, ipv4ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "10.16.0.2", "", false)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "10.16.0.2", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "10.16.0.3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "10.16.0.3", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "10.16.0.20", "", false)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "10.16.0.20", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.V4FreeIPList).To(Equal(
 					ipam.IPRangeList{
@@ -360,9 +360,9 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.3")))
 				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("10.16.0.20")))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "10.16.0.3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "10.16.0.3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ConflictError))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "19.16.0.3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "19.16.0.3", "", false, true)
 				Expect(err).Should(MatchError(ipam.OutOfRangeError))
 
 				subnet.ReleaseAddress("pod1.ns")
@@ -429,11 +429,11 @@ var _ = Describe("[IPAM]", func() {
 			It("static allocation", func() {
 				subnet, err := ipam.NewSubnet(subnetName, ipv6CIDR, ipv6ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "fd00::2", "", false)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "fd00::2", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "fd00::3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "fd00::3", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "fd00::14", "", false)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "fd00::14", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.V6FreeIPList).To(Equal(
 					ipam.IPRangeList{
@@ -448,9 +448,9 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::3")))
 				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("fd00::14")))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "fd00::3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "fd00::3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ConflictError))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "fe00::3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "fe00::3", "", false, true)
 				Expect(err).Should(MatchError(ipam.OutOfRangeError))
 
 				subnet.ReleaseAddress("pod1.ns")
@@ -525,17 +525,17 @@ var _ = Describe("[IPAM]", func() {
 			It("static allocation", func() {
 				subnet, err := ipam.NewSubnet(subnetName, dualCIDR, dualExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "10.16.0.2", "", false)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "10.16.0.2", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "fd00::2", "", false)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "fd00::2", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "10.16.0.3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "10.16.0.3", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "fd00::3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "fd00::3", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "10.16.0.20", "", false)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "10.16.0.20", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "fd00::14", "", false)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "fd00::14", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				Expect(subnet.V4FreeIPList).To(Equal(
@@ -562,13 +562,13 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::3")))
 				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("fd00::14")))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "10.16.0.3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "10.16.0.3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ConflictError))
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "fd00::3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "fd00::3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ConflictError))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "19.16.0.3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "19.16.0.3", "", false, true)
 				Expect(err).Should(MatchError(ipam.OutOfRangeError))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "fe00::3", "", false)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "fe00::3", "", false, true)
 				Expect(err).Should(MatchError(ipam.OutOfRangeError))
 
 				subnet.ReleaseAddress("pod1.ns")


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- API changes

# How does kubevirt VM live migrate via kube-ovn
1. The default NIC is only used for live migration, and the VM NIC is attached through Multus-cni.
2. If you need to assign fixed IP addresses to VM, use `<attach>.<ns>.ovn.kubernetes.io/allow_live_migration: 'true'` annotation to avoid IP conflict errors.
3. If you use kubevirt DHCP configuration vm network, need to solve the problem of the default route, we can use `<attach >.<ns>ovn.kubernetes.io/default_route: 'true'` annotation to select the default routing NIC.