### PR TITLE
perf: use link alias to filter packet

### DIFF
--- a/fastpath/kube_ovn_fastpath.c
+++ b/fastpath/kube_ovn_fastpath.c
@@ -22,8 +22,8 @@ unsigned int hook_func(unsigned int hooknum,
     struct udphdr *udp_header = NULL;
 
     // For container network traffic, DO NOT traverse netfilter
-    if (NULL != in &&  in->name[13] == 'c' ) { return NF_STOP; }
-    if (NULL != out && out->name[13] == 'c' ) { return NF_STOP; }
+    if (NULL != in && NULL != in->ifalias && in->ifalias[13] == 'c' ) { return NF_STOP; }
+    if (NULL != out && NULL != out->ifalias && out->ifalias[13] == 'c' ) { return NF_STOP; }
 
     if (!skb){
         return NF_ACCEPT;

--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -158,6 +158,12 @@ func configureContainerNic(nicName, ifName string, ipAddr, gateway string, route
 		return fmt.Errorf("can not find container nic %s: %v", nicName, err)
 	}
 
+	// Set link alias to its origin link name for fastpath to recognize and bypass netfilter
+	if err := netlink.LinkSetAlias(containerLink, nicName); err != nil {
+		klog.Errorf("failed to set link alias for container nic %s: %v", nicName, err)
+		return err
+	}
+
 	if err = netlink.LinkSetNsFd(containerLink, int(netns.Fd())); err != nil {
 		return fmt.Errorf("failed to link netns: %v", err)
 	}


### PR DESCRIPTION
Veth will be renamed to `eth0` in container, use alias to store the origin name for filter

#### What type of this PR
Examples of user facing changes:
- Perf


