### PR TITLE
feat: support vip

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -266,7 +266,7 @@ func (c *Controller) handleAddNode(key string) error {
 	}
 
 	ipStr := util.GetStringIP(v4IP, v6IP)
-	if err := c.ovnClient.CreatePort(c.config.NodeSwitch, portName, ipStr, subnet.Spec.CIDRBlock, mac, "", "", false, ""); err != nil {
+	if err := c.ovnClient.CreatePort(c.config.NodeSwitch, portName, ipStr, mac, "", "", false, "", ""); err != nil {
 		return err
 	}
 

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -30,6 +30,7 @@ const (
 	VpcAnnotation           = "ovn.kubernetes.io/vpc"
 
 	PortSecurityAnnotationTemplate = "%s.kubernetes.io/port_security"
+	PortVipAnnotationTemplate      = "%s.kubernetes.io/port_vips"
 	PortSecurityAnnotation         = "ovn.kubernetes.io/port_security"
 	NorthGatewayAnnotation         = "ovn.kubernetes.io/north_gateway"
 


### PR DESCRIPTION
#### What type of this PR
- API changes

With this feature, we can assign High Availability VIP for VM now.

#### Usage
- Update `excludeIps` of subnet to reserve VIPs.
- Enable port_security with annotations `ovn.kubernetes.io/port_security`.
- Specify allowed VIPs with annotations `ovn.kubernetes.io/port_vips`, such as `10.18.0.100,10.18.0.101`.