### PR TITLE
append externalIds for pod and node when upgrade

### DIFF
--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -1685,3 +1685,20 @@ func (c Client) UpdateSgACL(sg *kubeovnv1.SecurityGroup, direction AclDirection)
 	}
 	return nil
 }
+func (c Client) OvnGet(table, record, column, key string) (string, error) {
+	var columnVal string
+	if key == "" {
+		columnVal = column
+	} else {
+		columnVal = column + ":" + key
+	}
+	args := []string{"get", table, record, columnVal}
+	return c.ovnNbCommand(args...)
+}
+
+func (c Client) SetLspExternalIds(cmd []string) error {
+	if _, err := c.ovnNbCommand(cmd...); err != nil {
+		return fmt.Errorf("failed to set lsp externalIds, %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
after v1.7.1, externalIds in lsp is valued by pod name and namespace. When upgrade from 1.6.2 to 1.7.1, externalIds is nil,  which may cause problems



