### PR TITLE
fix IPAM for StatefulSet

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -205,9 +205,14 @@ func (c *Controller) markAndCleanLSP() error {
 	}
 	ipNames := make([]string, 0, len(pods)+len(nodes))
 	for _, pod := range pods {
-		if !isPodAlive(pod) {
+		if isStsPod, sts := isStatefulSetPod(pod); isStsPod {
+			if isStatefulSetPodToDel(c.config.KubeClient, pod, sts) {
+				continue
+			}
+		} else if !isPodAlive(pod) {
 			continue
 		}
+
 		for k, v := range pod.Annotations {
 			if !strings.Contains(k, util.AllocatedAnnotationSuffix) || v != "true" {
 				continue

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -308,6 +308,27 @@ func (c *Controller) InitIPAM() error {
 		}
 	}
 
+	ips, err := c.ipsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list IPs: %v", err)
+		return err
+	}
+	for _, ip := range ips {
+		ipamKey := fmt.Sprintf("%s/%s", ip.Spec.Namespace, ip.Spec.PodName)
+		if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Spec.IPAddress, ip.Spec.MacAddress, ip.Spec.Subnet, false); err != nil {
+			klog.Errorf("failed to init IPAM from IP CR %s: %v", ip.Name, err)
+		}
+		for i := range ip.Spec.AttachSubnets {
+			if i == len(ip.Spec.AttachIPs) || i == len(ip.Spec.AttachMacs) {
+				klog.Errorf("attachment IP/MAC of IP CR %s is invalid", ip.Name)
+				break
+			}
+			if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Spec.AttachIPs[i], ip.Spec.AttachMacs[i], ip.Spec.AttachSubnets[i], false); err != nil {
+				klog.Errorf("failed to init IPAM from IP CR %s: %v", ip.Name, err)
+			}
+		}
+	}
+
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list nodes: %v", err)

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -569,6 +569,11 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 		return err
 	}
 
+	var keepIpCR bool
+	if ok, sts := isStatefulSetPod(pod); ok {
+		keepIpCR = !isStatefulSetPodToDel(c.config.KubeClient, pod, sts)
+	}
+
 	// Add additional default ports to compatible with previous versions
 	ports = append(ports, ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider))
 	for _, portName := range ports {
@@ -580,18 +585,22 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 			klog.Errorf("failed to delete lsp %s, %v", portName, err)
 			return err
 		}
-		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), portName, metav1.DeleteOptions{}); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				klog.Errorf("failed to delete ip %s, %v", portName, err)
-				return err
+		if !keepIpCR {
+			if err = c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), portName, metav1.DeleteOptions{}); err != nil {
+				if !k8serrors.IsNotFound(err) {
+					klog.Errorf("failed to delete ip %s, %v", portName, err)
+					return err
+				}
 			}
 		}
 		for _, sg := range sgs {
 			c.syncSgPortsQueue.Add(sg)
 		}
 	}
-	if err := c.deleteAttachmentNetWorkIP(pod); err != nil {
-		klog.Errorf("failed to delete attach ip for pod %v, %v, please delete attach ip manually", pod.Name, err)
+	if !keepIpCR {
+		if err = c.deleteAttachmentNetWorkIP(pod); err != nil {
+			klog.Errorf("failed to delete attach ip for pod %v, %v, please delete attach ip manually", pod.Name, err)
+		}
 	}
 	c.ipam.ReleaseAddressByPod(key)
 	return nil

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -260,7 +260,7 @@ func (csh cniServerHandler) createOrUpdateIPCr(podRequest request.CniRequest, su
 			return errMsg
 		}
 	} else {
-		ipCr.Spec.AttachIPs = append(ipCr.Spec.AttachIPs, strings.Split(ip, ",")...)
+		ipCr.Spec.AttachIPs = append(ipCr.Spec.AttachIPs, ip)
 		ipCr.Labels[subnet] = ""
 		ipCr.Spec.AttachSubnets = append(ipCr.Spec.AttachSubnets, subnet)
 		ipCr.Spec.AttachMacs = append(ipCr.Spec.AttachMacs, macAddr)


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

Consider the following scenario:

1. A StatefulSet Pod with random IP address allocation is deleted and soon kube-ovn-contrller is restarted;
2. kube-ovn-controller initailizes IPAM on startup and no IPAM record for the deleted StatefuleSet Pod is created;
3. A new StatefulSet Pod with the same name is created and kube-ovn-controller assigns a new IP address to it.