### PR TITLE
fix: wrong link for iptables

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -45,6 +45,7 @@ RUN apt update && apt upgrade -y && apt install ca-certificates python3 hostname
         tcpdump ipset curl uuid-runtime openssl inetutils-ping arping ndisc6 \
         logrotate -y --no-install-recommends && \
         rm -rf /var/lib/apt/lists/* && \
+        cd /usr/sbin && \
         ln -sf /usr/sbin/iptables-legacy iptables && \
         rm -rf /etc/localtime
 


### PR DESCRIPTION
ubuntu21.04 image will use nftables by default and it cannot work on centos7

#### What type of this PR
Examples of user facing changes:
- Bug fixes


