### PR TITLE
fix StatefulSet down scale

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -826,11 +826,7 @@ func isStatefulSetPodToDel(c kubernetes.Interface, pod *v1.Pod, statefulSetName 
 		return false
 	}
 
-	if index >= int64(*ss.Spec.Replicas) {
-		return true
-	}
-
-	return false
+	return index >= int64(*ss.Spec.Replicas) && index >= int64(ss.Status.Replicas)
 }
 
 func getNodeTunlIP(node *v1.Node) ([]net.IP, error) {


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

Before a scaling operation is applied to a Pod, all of its predecessors must be Running and Ready.

Deletion of LSP may cause liveness/readiness probe failure.