### PR TITLE
fix: wait Pod to be scheduled before assigning addresses to it

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -202,10 +202,13 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 		}
 	}
 
-	// pod assigned an ip
-	if newPod.Annotations[util.AllocatedAnnotation] == "true" &&
-		newPod.Annotations[util.RoutedAnnotation] != "true" &&
-		newPod.Spec.NodeName != "" {
+	if newPod.Annotations == nil || newPod.Annotations[util.AllocatedAnnotation] != "true" {
+		klog.V(3).Infof("enqueue add pod %s", key)
+		c.addPodQueue.Add(key)
+		return
+	}
+	if newPod.Spec.NodeName != "" && newPod.Annotations[util.RoutedAnnotation] != "true" {
+		// pod assigned an ip
 		klog.V(3).Infof("enqueue update pod %s", key)
 		c.updatePodQueue.Add(key)
 	}

--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -296,7 +296,7 @@ func waitNetworkReady(src, gateway string, verbose bool) error {
 		}
 		pinger.SetPrivileged(true)
 		// CNITimeoutSec = 220, cannot exceed
-		count := 200
+		count := 20
 		pinger.Count = count
 		pinger.Timeout = time.Duration(count) * time.Second
 		pinger.Interval = 1 * time.Second
@@ -310,6 +310,7 @@ func waitNetworkReady(src, gateway string, verbose bool) error {
 
 		cniConnectivityResult.WithLabelValues(nodeName).Add(float64(pinger.PacketsSent))
 		if !success {
+			klog.Errorf("%s network not ready after %d ping, gw %v", src, count, gw)
 			return fmt.Errorf("%s network not ready after %d ping %s", src, count, gw)
 		}
 		if verbose {

--- a/test/e2e/ip/static_ip.go
+++ b/test/e2e/ip/static_ip.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -175,14 +176,17 @@ var _ = Describe("[IP Allocation]", func() {
 				},
 			}
 
+			klog.Infof("creating statefulset %s/%s", sts.Namespace, sts.Name)
 			By("Create statefulset")
 			_, err := f.KubeClientSet.AppsV1().StatefulSets(namespace).Create(context.Background(), &sts, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
+			klog.Infof("waiting statefulset %s/%s to be ready", sts.Namespace, sts.Name)
 			err = f.WaitStatefulsetReady(name, namespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			for i := range ips {
+				klog.Infof("getting pod %s/%s", sts.Namespace, fmt.Sprintf("%s-%d", sts.Name, i))
 				pod, err := f.KubeClientSet.CoreV1().Pods(namespace).Get(context.Background(), fmt.Sprintf("%s-%d", name, i), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pod.Status.PodIP).To(Equal(ips[i]))
@@ -219,26 +223,32 @@ var _ = Describe("[IP Allocation]", func() {
 				},
 			}
 
+			klog.Infof("creating statefulset %s/%s", sts.Namespace, sts.Name)
 			By("Create statefulset")
 			_, err := f.KubeClientSet.AppsV1().StatefulSets(namespace).Create(context.Background(), &sts, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
+			klog.Infof("waiting statefulset %s/%s to be ready", sts.Namespace, sts.Name)
 			err = f.WaitStatefulsetReady(name, namespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			ips := make([]string, replicas)
 			for i := range ips {
+				klog.Infof("getting pod %s/%s", sts.Namespace, fmt.Sprintf("%s-%d", sts.Name, i))
 				pod, err := f.KubeClientSet.CoreV1().Pods(namespace).Get(context.Background(), fmt.Sprintf("%s-%d", name, i), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				ips[i] = pod.Status.PodIP
 			}
 
+			klog.Infof("deleting pods of statefulset %s/%s", sts.Namespace, sts.Name)
 			err = f.KubeClientSet.CoreV1().Pods(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(sts.Spec.Template.Labels).String()})
 			Expect(err).NotTo(HaveOccurred())
 
+			klog.Infof("waiting statefulset %s/%s to be ready", sts.Namespace, sts.Name)
 			err = f.WaitStatefulsetReady(name, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			for i := range ips {
+				klog.Infof("getting pod %s/%s", sts.Namespace, fmt.Sprintf("%s-%d", sts.Name, i))
 				pod, err := f.KubeClientSet.CoreV1().Pods(namespace).Get(context.Background(), fmt.Sprintf("%s-%d", name, i), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pod.Status.PodIP).To(Equal(ips[i]))


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

Wait Pod to be scheduled before assigning address(es) to it, so that the annotations written by Kube-OVN controller will not be overwritten by k8s components.

This patch is expected to fix the e2e testing `statefulset with ippool`.
