### PR TITLE
fix installation scripts

### DIFF
--- a/dist/images/install-pre-1.16.sh
+++ b/dist/images/install-pre-1.16.sh
@@ -2754,8 +2754,7 @@ chmod +x /usr/local/bin/kubectl-ko
 echo "-------------------------------"
 echo ""
 
-echo ":$PATH:" | grep -q ":/usr/local/bin:"
-if [  $? != 0  ]; then
+if ! sh -c "echo \":$PATH:\" | grep -q \":/usr/local/bin:\""; then
   echo "Tips:Please join the /usr/local/bin to your PATH. Temporarily, we do it for this execution."
   export PATH=/usr/local/bin:$PATH
   echo "-------------------------------"

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2827,8 +2827,7 @@ chmod +x /usr/local/bin/kubectl-ko
 echo "-------------------------------"
 echo ""
 
-echo ":$PATH:" | grep -q ":/usr/local/bin:"
-if [  $? != 0  ]; then
+if ! sh -c "echo \":$PATH:\" | grep -q \":/usr/local/bin:\""; then
   echo "Tips:Please join the /usr/local/bin to your PATH. Temporarily, we do it for this execution."
   export PATH=/usr/local/bin:$PATH
   echo "-------------------------------"


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

The installation scripts will exit with non-zero exit code if `/usr/local/bin` is not included in environment variable `PATH`.
