### PR TITLE
fix: init node with wrong ipamkey and lead conflict

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -314,7 +314,12 @@ func (c *Controller) InitIPAM() error {
 		return err
 	}
 	for _, ip := range ips {
-		ipamKey := fmt.Sprintf("%s/%s", ip.Spec.Namespace, ip.Spec.PodName)
+		var ipamKey string
+		if ip.Spec.Namespace != "" {
+			ipamKey = fmt.Sprintf("%s/%s", ip.Spec.Namespace, ip.Spec.PodName)
+		} else {
+			ipamKey = fmt.Sprintf("node-%s", ip.Spec.PodName)
+		}
 		if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Spec.IPAddress, ip.Spec.MacAddress, ip.Spec.Subnet, false); err != nil {
 			klog.Errorf("failed to init IPAM from IP CR %s: %v", ip.Name, err)
 		}


### PR DESCRIPTION
```
E0926 09:50:20.371312       1 init.go:347] failed to init node kube-ovn-worker. address 100.64.0.3: AddressConflict
E0926 09:50:20.377591       1 init.go:347] failed to init node kube-ovn-control-plane. address 100.64.0.2: AddressConflict

```

#### What type of this PR
- Bug fixes

