### PR TITLE
modify kube-ovn as multus-cni problem

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -511,6 +511,9 @@ func (c *Controller) initAppendPodExternalIds(pod *v1.Pod) error {
 	}
 
 	for _, podNet := range podNets {
+		if !strings.HasSuffix(podNet.ProviderName, util.OvnProvider) {
+			continue
+		}
 		portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, podNet.ProviderName)
 		externalIds, err := c.ovnClient.OvnGet("logical_switch_port", portName, "external_ids", "")
 		if err != nil {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1125,7 +1125,7 @@ func calcSubnetStatusIP(subnet *kubeovnv1.Subnet, c *Controller) error {
 }
 
 func isOvnSubnet(subnet *kubeovnv1.Subnet) bool {
-	if subnet.Spec.Provider == util.OvnProvider || subnet.Spec.Provider == "" {
+	if subnet.Spec.Provider == util.OvnProvider || subnet.Spec.Provider == "" || strings.HasSuffix(subnet.Spec.Provider, "ovn") {
 		return true
 	}
 	return false


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、when kube-ovn is used as multus-cni, the subnet used for attachment cni should also create logical-switch
2、If  kube-ovn is used as multus-cni, the provider should be cosisted of attachmentName. attachmentNameSpace.ovn, and ended with "ovn"
#### Which issue(s) this PR fixes:
Fixes #(issue-number)



