### PR TITLE
change inspection logic from manually adding lsp to just readding pod…

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -852,8 +852,7 @@ func getNextHopByTunnelIP(gw []net.IP) string {
 }
 
 func needAllocateSubnets(pod *v1.Pod, nets []*kubeovnNet) []*kubeovnNet {
-	if pod.Status.Phase == v1.PodRunning ||
-		pod.Status.Phase == v1.PodSucceeded ||
+	if pod.Status.Phase == v1.PodSucceeded ||
 		pod.Status.Phase == v1.PodFailed {
 		return nil
 	}


### PR DESCRIPTION
To avoid redundant codes, and to converge the process, the inspection chooses to reinsert lsp-abnormal pod into AddPodQueue to complete pod registration again with existing logical, rather than manually handling the exceptions.

now for a lsp-abnormal pod, first the allocate annotation for the lsp subnet will be removed from annotation, then this pod will be added to AddPodQueue to register lsp.