### PR TITLE
fix: check and load ip_tables module

### DIFF
--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -9,6 +9,10 @@ TUNNEL_TYPE=${TUNNEL_TYPE:-geneve}
 # Check required kernel module
 modinfo openvswitch
 modinfo geneve
+modinfo ip_tables
+
+# CentOS 8 might not load iptables module by default, which will hurt nat function
+modprobe ip_tables
 
 # https://bugs.launchpad.net/neutron/+bug/1776778
 if grep -q "3.10.0-862" /proc/version

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ Kube-OVN includes two parts:
 - Kubernetes >= 1.11, version 1.16 and later is recommended
 - Docker >= 1.12.6
 - OS: CentOS 7/8, Ubuntu 16.04/18.04 
-- Other Linux distributions with geneve and openvswitch module installed. You can use commands  `modinfo geneve` and `modinfo openvswitch` to verify
+- Other Linux distributions with geneve, openvswitch and ip_tables module installed. You can use commands  `modinfo geneve`, `modinfo openvswitch` and `modinfo ip_tables` to verify
 - Kernel boot with `ipv6.disable=0`
 - Kube-proxy *MUST* be ready so that Kube-OVN can connect to apiserver
 


### PR DESCRIPTION
Distributed/Centralized gateway and vpc-nat-gateway rely on iptables. CentOS8 might not load ip_tables module by default



