### PR TITLE
feat: pod can use multiple nic with the same subnet

### DIFF
--- a/docs/multi-nic.md
+++ b/docs/multi-nic.md
@@ -236,8 +236,6 @@ spec:
     image: alpine
 ```
 
-Note that the pod cannot be assigned the same subnet, the above example assumes that kube-ovn is not the default network.
-
 ### Create pod with specified subnet
 
 For allocation from the specified subnet:
@@ -275,4 +273,42 @@ spec:
   - name: static-ip
     command: ["/bin/ash", "-c", "trap : TERM INT; sleep infinity & wait"]
     image: alpine
+```
+
+### Create pod with multiple interface and alloc the same subnet
+For allocation from the same subnet to multiple interface:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spec-subnet
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/networks: default/attachnet
+    attachnet.default.ovn.kubernetes.io/logical_switch: my-subnet  # <name>.<namespace>.ovn.kubernetes.io/logical_switch
+    ovn.kubernetes.io/logical_switch: my-subnet
+spec:
+  containers:
+  - name: spec-subnet
+    command: ["/bin/ash", "-c", "trap : TERM INT; sleep infinity & wait"]
+    image: alpine
+```
+
+The same subnet will be alloc to multiple interface:
+
+```shell
+/ # ip a
+995: eth0@if996: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc noqueue state UP group default 
+    link/ether 00:00:00:ea:74:5f brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 10.16.0.14/16 brd 10.16.255.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::200:ff:feea:745f/64 scope link 
+       valid_lft forever preferred_lft forever
+997: net1@if998: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc noqueue state UP group default 
+    link/ether 00:00:00:d1:d4:1b brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 10.16.0.10/16 brd 10.16.255.255 scope global net1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::200:ff:fed1:d41b/64 scope link 
+       valid_lft forever preferred_lft forever
 ```

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -301,6 +301,7 @@ func (c *Controller) InitIPAM() error {
 			for _, podNet := range podNets {
 				_, _, _, err := c.ipam.GetStaticAddress(
 					fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+					ovs.PodNameToPortName(pod.Name, pod.Namespace, podNet.ProviderName),
 					pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)],
 					pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)],
 					pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podNet.ProviderName)], false)
@@ -326,7 +327,7 @@ func (c *Controller) InitIPAM() error {
 		} else {
 			ipamKey = fmt.Sprintf("node-%s", ip.Spec.PodName)
 		}
-		if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Spec.IPAddress, ip.Spec.MacAddress, ip.Spec.Subnet, false); err != nil {
+		if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Name, ip.Spec.IPAddress, ip.Spec.MacAddress, ip.Spec.Subnet, false); err != nil {
 			klog.Errorf("failed to init IPAM from IP CR %s: %v", ip.Name, err)
 		}
 		for i := range ip.Spec.AttachSubnets {
@@ -334,7 +335,7 @@ func (c *Controller) InitIPAM() error {
 				klog.Errorf("attachment IP/MAC of IP CR %s is invalid", ip.Name)
 				break
 			}
-			if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Spec.AttachIPs[i], ip.Spec.AttachMacs[i], ip.Spec.AttachSubnets[i], false); err != nil {
+			if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Name, ip.Spec.AttachIPs[i], ip.Spec.AttachMacs[i], ip.Spec.AttachSubnets[i], false); err != nil {
 				klog.Errorf("failed to init IPAM from IP CR %s: %v", ip.Name, err)
 			}
 		}
@@ -348,7 +349,7 @@ func (c *Controller) InitIPAM() error {
 	for _, node := range nodes {
 		if node.Annotations[util.AllocatedAnnotation] == "true" {
 			portName := fmt.Sprintf("node-%s", node.Name)
-			v4IP, v6IP, _, err := c.ipam.GetStaticAddress(portName, node.Annotations[util.IpAddressAnnotation],
+			v4IP, v6IP, _, err := c.ipam.GetStaticAddress(portName, portName, node.Annotations[util.IpAddressAnnotation],
 				node.Annotations[util.MacAddressAnnotation],
 				node.Annotations[util.LogicalSwitchAnnotation], true)
 			if err != nil {

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -250,7 +250,7 @@ func (c *Controller) handleAddNode(key string) error {
 	var v4IP, v6IP, mac string
 	portName := fmt.Sprintf("node-%s", key)
 	if node.Annotations[util.AllocatedAnnotation] == "true" && node.Annotations[util.IpAddressAnnotation] != "" && node.Annotations[util.MacAddressAnnotation] != "" {
-		v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(portName, node.Annotations[util.IpAddressAnnotation],
+		v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(portName, portName, node.Annotations[util.IpAddressAnnotation],
 			node.Annotations[util.MacAddressAnnotation],
 			node.Annotations[util.LogicalSwitchAnnotation], true)
 		if err != nil {
@@ -258,7 +258,7 @@ func (c *Controller) handleAddNode(key string) error {
 			return err
 		}
 	} else {
-		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, c.config.NodeSwitch, nil)
+		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, portName, c.config.NodeSwitch, nil)
 		if err != nil {
 			klog.Errorf("failed to alloc random ip addrs for node %v: %v", node.Name, err)
 			return err

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -402,16 +402,6 @@ func (c *Controller) getPodKubeovnNets(pod *v1.Pod) ([]*kubeovnNet, error) {
 		})
 	}
 
-	for i, net1 := range podNets {
-		if i >= len(podNets)-1 {
-			break
-		}
-		for _, net2 := range podNets[i+1:] {
-			if net1.Subnet.Name == net2.Subnet.Name {
-				return nil, fmt.Errorf("subnet conflict, the same subnet should not be attached repeatedly")
-			}
-		}
-	}
 	return podNets, nil
 }
 
@@ -1073,7 +1063,8 @@ func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, st
 		pod.Annotations[fmt.Sprintf(util.IpPoolAnnotationTemplate, podNet.ProviderName)] == "" {
 		var skippedAddrs []string
 		for {
-			ipv4, ipv6, mac, err := c.ipam.GetRandomAddress(key, podNet.Subnet.Name, skippedAddrs)
+			nicName := ovs.PodNameToPortName(pod.Name, pod.Namespace, podNet.ProviderName)
+			ipv4, ipv6, mac, err := c.ipam.GetRandomAddress(key, nicName, podNet.Subnet.Name, skippedAddrs)
 			if err != nil {
 				return "", "", "", err
 			}
@@ -1095,10 +1086,11 @@ func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, st
 		}
 	}
 
+	nicName := ovs.PodNameToPortName(pod.Name, pod.Namespace, podNet.ProviderName)
 	// Static allocate
 	if pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)] != "" {
 		ipStr := pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)]
-		return c.acquireStaticAddress(key, ipStr, macStr, podNet.Subnet.Name, podNet.AllowLiveMigration)
+		return c.acquireStaticAddress(key, nicName, ipStr, macStr, podNet.Subnet.Name, podNet.AllowLiveMigration)
 	}
 
 	// IPPool allocate
@@ -1113,7 +1105,7 @@ func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, st
 				klog.Errorf("static address %s for %s has been assigned", staticIP, key)
 				continue
 			}
-			if v4IP, v6IP, mac, err := c.acquireStaticAddress(key, staticIP, macStr, podNet.Subnet.Name, podNet.AllowLiveMigration); err == nil {
+			if v4IP, v6IP, mac, err := c.acquireStaticAddress(key, nicName, staticIP, macStr, podNet.Subnet.Name, podNet.AllowLiveMigration); err == nil {
 				return v4IP, v6IP, mac, nil
 			} else {
 				klog.Errorf("acquire address %s for %s failed, %v", staticIP, key, err)
@@ -1124,7 +1116,7 @@ func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, st
 		numStr := strings.Split(pod.Name, "-")[numIndex]
 		index, _ := strconv.Atoi(numStr)
 		if index < len(ipPool) {
-			return c.acquireStaticAddress(key, ipPool[index], macStr, podNet.Subnet.Name, podNet.AllowLiveMigration)
+			return c.acquireStaticAddress(key, nicName, ipPool[index], macStr, podNet.Subnet.Name, podNet.AllowLiveMigration)
 		}
 	}
 	klog.Errorf("alloc address for %s failed, return NoAvailableAddress", key)
@@ -1143,7 +1135,7 @@ func generatePatchPayload(annotations map[string]string, op string) []byte {
 	return []byte(fmt.Sprintf(patchPayloadTemplate, op, raw))
 }
 
-func (c *Controller) acquireStaticAddress(key, ip, mac, subnet string, liveMigration bool) (string, string, string, error) {
+func (c *Controller) acquireStaticAddress(key, nicName, ip, mac, subnet string, liveMigration bool) (string, string, string, error) {
 	var v4IP, v6IP string
 	var err error
 	for _, ipStr := range strings.Split(ip, ",") {
@@ -1152,7 +1144,7 @@ func (c *Controller) acquireStaticAddress(key, ip, mac, subnet string, liveMigra
 		}
 	}
 
-	if v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(key, ip, mac, subnet, !liveMigration); err != nil {
+	if v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(key, nicName, ip, mac, subnet, !liveMigration); err != nil {
 		klog.Errorf("failed to get static ip %v, mac %v, subnet %v, err %v", ip, mac, subnet, err)
 		return "", "", "", err
 	}

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -45,31 +45,31 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, ipv4CIDR, ipv4ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetStaticAddress("pod1.ns", "10.16.0.2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
+				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.2"))
 
-				ip, _, _, err = im.GetRandomAddress("pod2.ns", subnetName, nil)
+				ip, _, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.3"))
 
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.2", "", subnetName, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod4.ns", "invalid_subnet", nil)
+				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "invalid_subnet", nil)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 
 				err = im.AddOrUpdateSubnet(subnetName, ipv4CIDR, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err = im.GetRandomAddress("pod5.ns", subnetName, nil)
+				ip, _, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
@@ -85,7 +85,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "10.17.0.0/16", []string{"10.17.0.1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				ip, _, _, err := im.GetRandomAddress("pod5.ns", subnetName, nil)
+				ip, _, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.17.0.2"))
 			})
@@ -95,17 +95,17 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.0/30", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
+				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ip, _, _, err = im.GetRandomAddress("pod1.ns", subnetName, nil)
+				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ip, _, _, err = im.GetRandomAddress("pod1.ns", subnetName, nil)
+				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 			})
@@ -125,31 +125,31 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, ipv6CIDR, ipv6ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetStaticAddress("pod1.ns", "fd00::2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod1.ns", "pod1.ns", "fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
+				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::2"))
 
-				_, ip, _, err = im.GetRandomAddress("pod2.ns", subnetName, nil)
+				_, ip, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::3"))
 
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "fd00::2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "fd00::2", "", subnetName, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "fd00::2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod4.ns", "invalid_subnet", nil)
+				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "invalid_subnet", nil)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 
 				err = im.AddOrUpdateSubnet(subnetName, ipv6CIDR, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err = im.GetRandomAddress("pod5.ns", subnetName, nil)
+				_, ip, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
@@ -165,7 +165,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "fe00::/112", []string{"fe00::1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				_, ip, _, err := im.GetRandomAddress("pod5.ns", subnetName, nil)
+				_, ip, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fe00::2"))
 			})
@@ -175,17 +175,17 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
+				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, ip, _, err = im.GetRandomAddress("pod1.ns", subnetName, nil)
+				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, ip, _, err = im.GetRandomAddress("pod1.ns", subnetName, nil)
+				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 			})
@@ -209,33 +209,33 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, dualCIDR, dualExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetStaticAddress("pod1.ns", "10.16.0.2,fd00::2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2,fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.2"))
 				Expect(ipv6).To(Equal("fd00::2"))
 
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod2.ns", subnetName, nil)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.3"))
 				Expect(ipv6).To(Equal("fd00::3"))
 
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2,fd00::2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.2,fd00::2", "", subnetName, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, _, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2,fd00::2", "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.2,fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod4.ns", "invalid_subnet", nil)
+				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "invalid_subnet", nil)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 
 				err = im.AddOrUpdateSubnet(subnetName, dualCIDR, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod5.ns", subnetName, nil)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
@@ -253,7 +253,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "10.17.0.2/16,fe00::/112", []string{"10.17.0.1", "fe00::1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod5.ns", subnetName, nil)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.17.0.2"))
 				Expect(ipv6).To(Equal("fe00::2"))
@@ -264,19 +264,19 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", subnetName, nil)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", subnetName, nil)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.2"))
 				Expect(ipv6).To(Equal("fd00::2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", subnetName, nil)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", subnetName, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
@@ -341,11 +341,11 @@ var _ = Describe("[IPAM]", func() {
 			It("static allocation", func() {
 				subnet, err := ipam.NewSubnet(subnetName, ipv4CIDR, ipv4ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "10.16.0.2", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "10.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "10.16.0.3", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "10.16.0.20", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.20", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.V4FreeIPList).To(Equal(
 					ipam.IPRangeList{
@@ -356,13 +356,13 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod1.ns"))
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.3"), "pod2.ns"))
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.20"), "pod3.ns"))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.2")))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.3")))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("10.16.0.20")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.2")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.3")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("10.16.0.20")))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "10.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "10.16.0.3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "19.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "19.16.0.3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
 
 				subnet.ReleaseAddress("pod1.ns")
@@ -374,7 +374,7 @@ var _ = Describe("[IPAM]", func() {
 						&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
 					}))
 
-				Expect(subnet.V4PodToIP).To(BeEmpty())
+				Expect(subnet.V4NicToIP).To(BeEmpty())
 				Expect(subnet.V4IPToPod).To(BeEmpty())
 			})
 
@@ -382,32 +382,32 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "10.16.0.0/30", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip1, _, _, err := subnet.GetRandomAddress("pod1.ns", nil)
+				ip1, _, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
-				ip1, _, _, err = subnet.GetRandomAddress("pod1.ns", nil)
+				ip1, _, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
 
-				ip2, _, _, err := subnet.GetRandomAddress("pod2.ns", nil)
+				ip2, _, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip2).To(Equal(ipam.IP("10.16.0.2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", nil)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V4FreeIPList).To(BeEmpty())
 
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.1"), "pod1.ns"))
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod2.ns"))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.1")))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.2")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.1")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.2")))
 
 				subnet.ReleaseAddress("pod1.ns")
 				subnet.ReleaseAddress("pod2.ns")
 				Expect(subnet.V4FreeIPList).To(Equal(ipam.IPRangeList{}))
 				Expect(subnet.V4ReleasedIPList).To(Equal(ipam.IPRangeList{&ipam.IPRange{Start: "10.16.0.1", End: "10.16.0.2"}}))
 				Expect(subnet.V4IPToPod).To(BeEmpty())
-				Expect(subnet.V4PodToIP).To(BeEmpty())
+				Expect(subnet.V4NicToIP).To(BeEmpty())
 			})
 		})
 
@@ -429,11 +429,11 @@ var _ = Describe("[IPAM]", func() {
 			It("static allocation", func() {
 				subnet, err := ipam.NewSubnet(subnetName, ipv6CIDR, ipv6ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "fd00::2", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "fd00::2", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "fd00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "fd00::3", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "fd00::14", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "fd00::14", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.V6FreeIPList).To(Equal(
 					ipam.IPRangeList{
@@ -444,13 +444,13 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::2"), "pod1.ns"))
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::3"), "pod2.ns"))
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::14"), "pod3.ns"))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::2")))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::3")))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("fd00::14")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::2")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::3")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("fd00::14")))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "fd00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "fd00::3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "fe00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "fe00::3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
 
 				subnet.ReleaseAddress("pod1.ns")
@@ -462,7 +462,7 @@ var _ = Describe("[IPAM]", func() {
 						&ipam.IPRange{Start: "fd00::18", End: "fd00::fffe"},
 					}))
 
-				Expect(subnet.V6PodToIP).To(BeEmpty())
+				Expect(subnet.V6NicToIP).To(BeEmpty())
 				Expect(subnet.V6IPToPod).To(BeEmpty())
 			})
 
@@ -470,32 +470,32 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip1, _, err := subnet.GetRandomAddress("pod1.ns", nil)
+				_, ip1, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("fd00::1")))
-				_, ip1, _, err = subnet.GetRandomAddress("pod1.ns", nil)
+				_, ip1, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("fd00::1")))
 
-				_, ip2, _, err := subnet.GetRandomAddress("pod2.ns", nil)
+				_, ip2, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip2).To(Equal(ipam.IP("fd00::2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", nil)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V6FreeIPList).To(BeEmpty())
 
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::1"), "pod1.ns"))
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::2"), "pod2.ns"))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::1")))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::2")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::1")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::2")))
 
 				subnet.ReleaseAddress("pod1.ns")
 				subnet.ReleaseAddress("pod2.ns")
 				Expect(subnet.V6FreeIPList).To(Equal(ipam.IPRangeList{}))
 				Expect(subnet.V6ReleasedIPList).To(Equal(ipam.IPRangeList{&ipam.IPRange{Start: "fd00::1", End: "fd00::2"}}))
 				Expect(subnet.V6IPToPod).To(BeEmpty())
-				Expect(subnet.V6PodToIP).To(BeEmpty())
+				Expect(subnet.V6NicToIP).To(BeEmpty())
 			})
 		})
 
@@ -525,17 +525,17 @@ var _ = Describe("[IPAM]", func() {
 			It("static allocation", func() {
 				subnet, err := ipam.NewSubnet(subnetName, dualCIDR, dualExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "10.16.0.2", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "fd00::2", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "fd00::2", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "10.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "10.16.0.3", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "fd00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "fd00::3", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "10.16.0.20", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.20", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "fd00::14", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "fd00::14", "", false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				Expect(subnet.V4FreeIPList).To(Equal(
@@ -552,23 +552,23 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod1.ns"))
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.3"), "pod2.ns"))
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.20"), "pod3.ns"))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.2")))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.3")))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("10.16.0.20")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.2")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.3")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("10.16.0.20")))
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::2"), "pod1.ns"))
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::3"), "pod2.ns"))
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::14"), "pod3.ns"))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::2")))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::3")))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("fd00::14")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::2")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::3")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("fd00::14")))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "10.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "10.16.0.3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "fd00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "fd00::3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "19.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "19.16.0.3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "fe00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod5.ns", "fe00::3", "", false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
 
 				subnet.ReleaseAddress("pod1.ns")
@@ -585,9 +585,9 @@ var _ = Describe("[IPAM]", func() {
 						&ipam.IPRange{Start: "fd00::18", End: "fd00::fffe"},
 					}))
 
-				Expect(subnet.V4PodToIP).To(BeEmpty())
+				Expect(subnet.V4NicToIP).To(BeEmpty())
 				Expect(subnet.V4IPToPod).To(BeEmpty())
-				Expect(subnet.V6PodToIP).To(BeEmpty())
+				Expect(subnet.V6NicToIP).To(BeEmpty())
 				Expect(subnet.V6IPToPod).To(BeEmpty())
 			})
 
@@ -595,33 +595,33 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "10.16.0.0/30,fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := subnet.GetRandomAddress("pod1.ns", nil)
+				ipv4, ipv6, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.1")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::1")))
-				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod1.ns", nil)
+				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.1")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::1")))
 
-				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod2.ns", nil)
+				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.2")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", nil)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V4FreeIPList).To(BeEmpty())
 				Expect(subnet.V6FreeIPList).To(BeEmpty())
 
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.1"), "pod1.ns"))
 				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod2.ns"))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.1")))
-				Expect(subnet.V4PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.2")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.1")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.2")))
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::1"), "pod1.ns"))
 				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::2"), "pod2.ns"))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::1")))
-				Expect(subnet.V6PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::2")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::1")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::2")))
 
 				subnet.ReleaseAddress("pod1.ns")
 				subnet.ReleaseAddress("pod2.ns")
@@ -630,9 +630,9 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.V6FreeIPList).To(Equal(ipam.IPRangeList{}))
 				Expect(subnet.V6ReleasedIPList).To(Equal(ipam.IPRangeList{&ipam.IPRange{Start: "fd00::1", End: "fd00::2"}}))
 				Expect(subnet.V4IPToPod).To(BeEmpty())
-				Expect(subnet.V4PodToIP).To(BeEmpty())
+				Expect(subnet.V4NicToIP).To(BeEmpty())
 				Expect(subnet.V6IPToPod).To(BeEmpty())
-				Expect(subnet.V6PodToIP).To(BeEmpty())
+				Expect(subnet.V6NicToIP).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
Examples of user facing changes:
- API changes
 
Pod can be assigned multiple nics of the same subnet, for example:
```
...
annotations
  ovn.kubernetes.io/logical_switch: ovn-default
  attachnet.default.ovn.kubernetes.io/logical_switch: ovn-default
...
```