### PR TITLE
fix bug: logical switch ts not ready

### DIFF
--- a/pkg/controller/ovn-ic.go
+++ b/pkg/controller/ovn-ic.go
@@ -288,7 +288,7 @@ func (c *Controller) stopOVNIC() error {
 func (c *Controller) waitTsReady() error {
 	retry := 6
 	for retry > 0 {
-		exists, err := c.ovnClient.LogicalSwitchExists(util.InterconnectionSwitch, c.config.EnableExternalVpc)
+		exists, err := c.ovnClient.LogicalSwitchExists(util.InterconnectionSwitch, false)
 		if err != nil {
 			klog.Errorf("failed to list logical switch, %v", err)
 			return err


### PR DESCRIPTION
c.config.EnableExternalVpc is set to "true" in default.
So listing logical switch "ts" with the label "vendor=kube-ovn", nothing will return and the checking will always be failed in "ts not ready".
Now for listing logical switch "ts", external label will always be omitted.
#1086 fixed