### PR TITLE
do not set bridge-nf-call-iptables

### DIFF
--- a/dist/images/install-cni.sh
+++ b/dist/images/install-cni.sh
@@ -2,10 +2,6 @@
 
 set -u -e
 
-if [[ -f "/proc/sys/net/bridge/bridge-nf-call-iptables" ]];
-    then echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables;
-fi
-
 if [[ -f "/proc/sys/net/ipv4/ip_forward" ]];
     then echo 1 > /proc/sys/net/ipv4/ip_forward;
 fi


### PR DESCRIPTION
Examples of user facing changes:
- optimize

kubeovn does not use linux bridge, there is no need for this configuration