### PR TITLE
fix node address set name

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -190,7 +190,7 @@ func (c *Controller) processNextDeleteNodeWorkItem() bool {
 }
 
 func nodeUnderlayAddressSetName(node string, af int) string {
-	return fmt.Sprintf("node_%s_underlay_v%d", node, af)
+	return fmt.Sprintf("node_%s_underlay_v%d", strings.ReplaceAll(node, "-", "_"), af)
 }
 
 func (c *Controller) handleAddNode(key string) error {


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

According to ovn-nb manpage, address set name must match `[a-zA-Z_.][a-zA-Z_.0-9]*`.
