### PR TITLE
other CNI can be used as the default network

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -42,7 +42,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	if args.IfName == "eth0" {
+	if netConf.Type == util.CniTypeName && args.IfName == "eth0" {
 		netConf.Provider = util.OvnProvider
 	}
 
@@ -126,7 +126,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	if args.IfName == "eth0" {
+	if netConf.Type == util.CniTypeName && args.IfName == "eth0" {
 		netConf.Provider = util.OvnProvider
 	}
 


### PR DESCRIPTION
Examples of user facing changes:
- Optimize

When other CNI network is attached to POD via annotations `v1.multus-cni.io/default-network`, and use kubeovn's IPAM feature, is now allowed.