### PR TITLE
add ovn-ic e2e

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -886,6 +886,56 @@ jobs:
           sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
           sh dist/images/cleanup.sh
 
+  ovnic-e2e:
+    needs: build
+    name: 1-master-ovnic-e2e
+    runs-on: ubuntu-18.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Kind
+        run: |
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+          chmod +x ./kind
+          sudo mv kind /usr/local/bin
+
+      - name: Init Kind
+        run: |
+          pip install j2cli --user
+          pip install "j2cli[yaml]" --user
+          sudo PATH=~/.local/bin:$PATH make kind-init-cluster
+
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: kube-ovn
+
+      - name: Install Kube-OVN
+        run: |
+          docker load --input kube-ovn.tar
+          sudo PATH=~/.local/bin:$PATH make kind-install-cluster
+          sudo PATH=~/.local/bin:$PATH make kind-install-ic
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+        id: go
+
+      - name: Run E2E
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e-ovn-ic
+
+      - name: Cleanup
+        run: |
+          sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
+          sh dist/images/cleanup.sh
+
   push:
     needs:
       - single-e2e
@@ -903,6 +953,7 @@ jobs:
       - no-lb-e2e
       - no-lb-iptables-e2e
       - no-np-e2e
+      - ovnic-e2e
     name: push
     runs-on: ubuntu-18.04
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ image-amd64.tar
 image-arm64.tar
 install-underlay.sh
 test/**/*.test
+install-multi.sh

--- a/test/e2e-ovnic/e2e_suite_test.go
+++ b/test/e2e-ovnic/e2e_suite_test.go
@@ -1,0 +1,96 @@
+package e2e_ovnic_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2eOvnic(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kube-OVN E2E OVN-IC Suite")
+}
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+
+	output, err := exec.Command("kubectl", "config", "use-context", "kind-kube-ovn").CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), string(output))
+	f := framework.NewFramework("init", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")))
+
+	pods, err := f.KubeClientSet.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: "ovn-nb-leader=true"})
+	Expect(err).NotTo(HaveOccurred())
+	if len(pods.Items) != 1 {
+		Fail(fmt.Sprintf("pods %s not right", pods))
+	}
+
+	cmdLS := "ovn-nbctl --format=csv  --data=bare --columns=name --no-heading find logical_switch name=ts"
+	sout, _, err := f.ExecToPodThroughAPI(cmdLS, "ovn-central", pods.Items[0].Name, pods.Items[0].Namespace, nil)
+	if err != nil {
+		Fail(fmt.Sprintf("switch ts does not exist in pod %s for %s", pods.Items[0].Name, err))
+	}
+	if strings.TrimSpace(sout) != "ts" {
+		Fail(fmt.Sprintf("switch ts is not right as %s", sout))
+	}
+
+	checkLSP("ts-az1", pods.Items[0], f)
+	checkLSP("ts-az0", pods.Items[0], f)
+
+	// To avoid the situation that the wrong kube-config context is loaded in framework, and then the test cloud always
+	// pass the test. a replacement kube-client solution is introduced to force the correct context pod-list to be read.
+	// Then if framework read the wrong context, it will get wrong pod which from another cluster.
+	output, err = exec.Command("kubectl", "config", "use-context", "kind-kube-ovn1").CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), string(output))
+	f = framework.NewFramework("init", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")))
+	kubecfg1, err := buildConfigFromFlags("kind-kube-ovn1", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")))
+	Expect(err).NotTo(HaveOccurred())
+	kubeClient1, err := kubernetes.NewForConfig(kubecfg1)
+	Expect(err).NotTo(HaveOccurred())
+
+	pods1, err := kubeClient1.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: "ovn-nb-leader=true"})
+	Expect(err).NotTo(HaveOccurred())
+	if len(pods1.Items) != 1 {
+		Fail(fmt.Sprintf("pods %s length not 1", pods1))
+	}
+
+	sout, _, err = f.ExecToPodThroughAPI(cmdLS, "ovn-central", pods1.Items[0].Name, pods1.Items[0].Namespace, nil)
+	if err != nil {
+		Fail(fmt.Sprintf("switch ts does not exist in pod %s with %s", pods1.Items[0].Name, err))
+	}
+	if strings.TrimSpace(sout) != "ts" {
+		Fail(fmt.Sprintf("switch ts is not right as %s", sout))
+	}
+
+	checkLSP("ts-az1", pods1.Items[0], f)
+	checkLSP("ts-az0", pods1.Items[0], f)
+})
+
+func buildConfigFromFlags(context, kubeconfigPath string) (*rest.Config, error) {
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
+		&clientcmd.ConfigOverrides{
+			CurrentContext: context,
+		}).ClientConfig()
+}
+
+func checkLSP(lspName string, pod v1.Pod, f *framework.Framework) {
+	cmd := fmt.Sprintf("ovn-nbctl --format=csv  --data=bare --columns=name --no-heading find logical_switch_port name=%s", lspName)
+	sout, _, err := f.ExecToPodThroughAPI(cmd, "ovn-central", pod.Name, pod.Namespace, nil)
+	if err != nil {
+		Fail(fmt.Sprintf("switch port %s ts does not exist", lspName))
+	}
+	if strings.TrimSpace(sout) != lspName {
+		Fail(fmt.Sprintf("switch port %s is not right as %s", lspName, sout))
+	}
+}

--- a/yamls/ovn-ic.yaml.j2
+++ b/yamls/ovn-ic.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovn-ic-config
+  namespace: kube-system
+data:
+  enable-ic: "true"
+  az-name: "{{ zone }}"
+  ic-db-host: "{{ host_node_ip }}"
+  ic-nb-port: "6645"
+  ic-sb-port: "6646"
+  gw-nodes: "{{ gateway_node_name }}"
+  auto-route: "true"


### PR DESCRIPTION
Add e2e for ovn-ic as following procedure:
1, add two kind cluster as "kube-ovn" and "kube-ovn1"
2, install kube-OVN on both clusters.
3, install ovn-ic configs and Ic container.
4, check if logical switch "ts" and the corresponding logical switch ports are right on ovn-nb-db.
5, clean enviroment.

Since two clusters in kind ask for more RAM than 1 cluster, it's preferable that the host has 8G RAM. At least in my tests, this is what is needed for stable operation.