### PR TITLE
deepcopy fix steps

### DIFF
--- a/pkg/controller/external-gw.go
+++ b/pkg/controller/external-gw.go
@@ -72,7 +72,8 @@ func (c *Controller) removeExternalGateway() error {
 		klog.Errorf("failed to list nodes, %v", err)
 		return err
 	}
-	for _, no := range nodes {
+	for _, orino := range nodes {
+		no := orino.DeepCopy()
 		patchPayloadTemplate :=
 			`[{
         "op": "%s",
@@ -116,11 +117,12 @@ func (c *Controller) establishExternalGateway(config map[string]string) error {
 	}
 	for _, gw := range gwNodes {
 		gw = strings.TrimSpace(gw)
-		node, err := c.nodesLister.Get(gw)
+		orinode, err := c.nodesLister.Get(gw)
 		if err != nil {
 			klog.Errorf("failed to get gw node %s, %v", gw, err)
 			return err
 		}
+		node := orinode.DeepCopy()
 		patchPayloadTemplate :=
 			`[{
         "op": "%s",

--- a/pkg/controller/external_vpc.go
+++ b/pkg/controller/external_vpc.go
@@ -24,7 +24,7 @@ func (c *Controller) syncExternalVpc() {
 	}
 	vpcMaps := make(map[string]*v1.Vpc)
 	for _, vpc := range vpcs {
-		vpcMaps[vpc.Name] = vpc
+		vpcMaps[vpc.Name] = vpc.DeepCopy()
 	}
 	for vpcName, vpc := range vpcMaps {
 		if _, ok := logicalRouters[vpcName]; ok {

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -279,7 +279,8 @@ func (c *Controller) gcLoadBalancer() error {
 		if err != nil {
 			return err
 		}
-		for _, vpc := range vpcs {
+		for _, orivpc := range vpcs {
+			vpc := orivpc.DeepCopy()
 			for _, subnetName := range vpc.Status.Subnets {
 				_, err := c.subnetsLister.Get(subnetName)
 				if err != nil {

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -54,17 +54,17 @@ func (c *Controller) InitOVN() error {
 }
 
 func (c *Controller) InitDefaultVpc() error {
-	vpc, err := c.vpcsLister.Get(util.DefaultVpc)
+	orivpc, err := c.vpcsLister.Get(util.DefaultVpc)
 	if err != nil {
-		vpc = &kubeovnv1.Vpc{}
-		vpc.Name = util.DefaultVpc
-		vpc, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Create(context.Background(), vpc, metav1.CreateOptions{})
+		orivpc = &kubeovnv1.Vpc{}
+		orivpc.Name = util.DefaultVpc
+		orivpc, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Create(context.Background(), orivpc, metav1.CreateOptions{})
 		if err != nil {
 			klog.Errorf("init default vpc failed: %v", err)
 			return err
 		}
 	}
-
+	vpc := orivpc.DeepCopy()
 	vpc.Status.DefaultLogicalSwitch = c.config.DefaultLogicalSwitch
 	vpc.Status.Router = c.config.ClusterRouter
 	if c.config.EnableLb {
@@ -95,6 +95,7 @@ func (c *Controller) initDefaultLogicalSwitch() error {
 		if subnet != nil && util.CheckProtocol(c.config.DefaultCIDR) != util.CheckProtocol(subnet.Spec.CIDRBlock) {
 			// single-stack upgrade to dual-stack
 			if util.CheckProtocol(c.config.DefaultCIDR) == kubeovnv1.ProtocolDual {
+				subnet := subnet.DeepCopy()
 				subnet.Spec.CIDRBlock = c.config.DefaultCIDR
 				if err := formatSubnet(subnet, c); err != nil {
 					klog.Errorf("init format subnet %s failed: %v", c.config.DefaultLogicalSwitch, err)
@@ -141,6 +142,7 @@ func (c *Controller) initNodeSwitch() error {
 		if subnet != nil && util.CheckProtocol(c.config.NodeSwitchCIDR) != util.CheckProtocol(subnet.Spec.CIDRBlock) {
 			// single-stack upgrade to dual-stack
 			if util.CheckProtocol(c.config.NodeSwitchCIDR) == kubeovnv1.ProtocolDual {
+				subnet := subnet.DeepCopy()
 				subnet.Spec.CIDRBlock = c.config.NodeSwitchCIDR
 				if err := formatSubnet(subnet, c); err != nil {
 					klog.Errorf("init format subnet %s failed: %v", c.config.NodeSwitch, err)
@@ -197,7 +199,8 @@ func (c *Controller) initLoadBalancer() error {
 		return err
 	}
 
-	for _, vpc := range vpcs {
+	for _, orivpc := range vpcs {
+		vpc := orivpc.DeepCopy()
 		vpcLb := c.GenVpcLoadBalancer(vpc.Name)
 
 		tcpLb, err := c.ovnClient.FindLoadbalancer(vpcLb.TcpLoadBalancer)
@@ -438,7 +441,7 @@ func (c *Controller) initSyncCrdIPs() error {
 	}
 
 	for _, ipCr := range ips.Items {
-		ip := ipCr
+		ip := ipCr.DeepCopy()
 		v4IP, v6IP := util.SplitStringIP(ip.Spec.IPAddress)
 		if ip.Spec.V4IPAddress == v4IP && ip.Spec.V6IPAddress == v6IP {
 			continue
@@ -446,7 +449,7 @@ func (c *Controller) initSyncCrdIPs() error {
 		ip.Spec.V4IPAddress = v4IP
 		ip.Spec.V6IPAddress = v6IP
 
-		_, err := c.config.KubeOvnClient.KubeovnV1().IPs().Update(context.Background(), &ip, metav1.UpdateOptions{})
+		_, err := c.config.KubeOvnClient.KubeovnV1().IPs().Update(context.Background(), ip, metav1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("failed to sync crd ip %s: %v", ip.Spec.IPAddress, err)
 			return err
@@ -464,7 +467,8 @@ func (c *Controller) initSyncCrdSubnets() error {
 		}
 		return err
 	}
-	for _, subnet := range subnets {
+	for _, orisubnet := range subnets {
+		subnet := orisubnet.DeepCopy()
 		if util.CheckProtocol(subnet.Spec.CIDRBlock) == kubeovnv1.ProtocolDual {
 			err = calcDualSubnetStatusIP(subnet, c)
 		} else {

--- a/pkg/controller/inspection.go
+++ b/pkg/controller/inspection.go
@@ -24,7 +24,8 @@ func (c *Controller) inspectPod() error {
 		klog.Errorf("failed to list logical switch port, %v", err)
 		return err
 	}
-	for _, pod := range pods {
+	for _, oripod := range pods {
+		pod := oripod.DeepCopy()
 		if pod.Spec.HostNetwork {
 			continue
 		}

--- a/pkg/controller/namespace.go
+++ b/pkg/controller/namespace.go
@@ -111,13 +111,14 @@ func (c *Controller) processNextAddNamespaceWorkItem() bool {
 }
 
 func (c *Controller) handleAddNamespace(key string) error {
-	namespace, err := c.namespacesLister.Get(key)
+	orinamespace, err := c.namespacesLister.Get(key)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	namespace := orinamespace.DeepCopy()
 
 	var ls, cidr string
 	var excludeIps []string

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -194,13 +194,14 @@ func nodeUnderlayAddressSetName(node string, af int) string {
 }
 
 func (c *Controller) handleAddNode(key string) error {
-	node, err := c.nodesLister.Get(key)
+	orinode, err := c.nodesLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	node := orinode.DeepCopy()
 
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
@@ -490,7 +491,8 @@ func (c *Controller) handleUpdateNode(key string) error {
 		return err
 	}
 
-	for _, subnet := range subnets {
+	for _, orisubnet := range subnets {
+		subnet := orisubnet.DeepCopy()
 		if util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
 			if err := c.reconcileGateway(subnet); err != nil {
 				return err

--- a/pkg/controller/ovn-ic.go
+++ b/pkg/controller/ovn-ic.go
@@ -112,7 +112,8 @@ func (c *Controller) removeInterConnection(azName string) error {
 		klog.Errorf("failed to list nodes, %v", err)
 		return err
 	}
-	for _, no := range nodes {
+	for _, orino := range nodes {
+		no := orino.DeepCopy()
 		patchPayloadTemplate :=
 			`[{
         "op": "%s",
@@ -174,11 +175,12 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 	gwNodes := strings.Split(config["gw-nodes"], ",")
 	for _, gw := range gwNodes {
 		gw = strings.TrimSpace(gw)
-		node, err := c.nodesLister.Get(gw)
+		orinode, err := c.nodesLister.Get(gw)
 		if err != nil {
 			klog.Errorf("failed to get gw node %s, %v", gw, err)
 			return err
 		}
+		node := orinode.DeepCopy()
 		patchPayloadTemplate :=
 			`[{
         "op": "%s",

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -413,13 +413,14 @@ func (c *Controller) handleAddPod(key string) error {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
-	pod, err := c.podsLister.Pods(namespace).Get(name)
+	oripod, err := c.podsLister.Pods(namespace).Get(name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	pod := oripod.DeepCopy()
 	if err := util.ValidatePodNetwork(pod.Annotations); err != nil {
 		klog.Errorf("validate pod %s/%s failed: %v", namespace, name, err)
 		c.recorder.Eventf(pod, v1.EventTypeWarning, "ValidatePodNetworkFailed", err.Error())
@@ -668,13 +669,14 @@ func (c *Controller) handleUpdatePod(key string) error {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
-	pod, err := c.podsLister.Pods(namespace).Get(name)
+	oripod, err := c.podsLister.Pods(namespace).Get(name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	pod := oripod.DeepCopy()
 
 	// in case update handler overlap the annotation when cache is not in sync
 	if pod.Annotations[util.AllocatedAnnotation] == "" {

--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -212,13 +212,14 @@ func (c *Controller) handleAddOrUpdateSg(key string) error {
 		}
 	}
 
-	sg, err := c.sgsLister.Get(key)
+	orisg, err := c.sgsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	sg := orisg.DeepCopy()
 
 	if err = c.validateSgRule(sg); err != nil {
 		return err

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -446,13 +446,14 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		return nil
 	}
 
-	subnet, err = c.subnetsLister.Get(key)
+	orisubnet, err := c.subnetsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	subnet = orisubnet.DeepCopy()
 
 	if err := formatSubnet(subnet, c); err != nil {
 		return err
@@ -677,7 +678,8 @@ func (c *Controller) updateNodeAddressSetsForSubnet(subnet *kubeovnv1.Subnet, de
 }
 
 func (c *Controller) handleUpdateSubnetStatus(key string) error {
-	subnet, err := c.subnetsLister.Get(key)
+	orisubnet, err := c.subnetsLister.Get(key)
+	subnet := orisubnet.DeepCopy()
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -851,10 +853,11 @@ func (c *Controller) reconcileNamespaces(subnet *kubeovnv1.Subnet) error {
 		namespaceMap[ns] = true
 	}
 
-	for _, sub := range subnets {
-		if sub.Name == subnet.Name || len(sub.Spec.Namespaces) == 0 {
+	for _, orisub := range subnets {
+		if orisub.Name == subnet.Name || len(orisub.Spec.Namespaces) == 0 {
 			continue
 		}
+		sub := orisub.DeepCopy()
 
 		changed := false
 		reservedNamespaces := []string{}

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -112,13 +112,14 @@ func (c *Controller) handleDelVpc(vpc *kubeovnv1.Vpc) error {
 }
 
 func (c *Controller) handleUpdateVpcStatus(key string) error {
-	vpc, err := c.vpcsLister.Get(key)
+	orivpc, err := c.vpcsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	vpc := orivpc.DeepCopy()
 
 	subnets, defaultSubnet, err := c.getVpcSubnets(vpc)
 	if err != nil {
@@ -251,13 +252,14 @@ func (c *Controller) addLoadBalancer(vpc string) (*VpcLoadBalancer, error) {
 }
 
 func (c *Controller) handleAddOrUpdateVpc(key string) error {
-	vpc, err := c.vpcsLister.Get(key)
+	orivpc, err := c.vpcsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	vpc := orivpc.DeepCopy()
 
 	if err = formatVpc(vpc, c); err != nil {
 		klog.Errorf("failed to format vpc: %v", err)

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -327,13 +327,14 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 		return err
 	}
 
-	pod, err := c.getNatGwPod(key)
+	oripod, err := c.getNatGwPod(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	pod := oripod.DeepCopy()
 
 	if pod.Status.Phase != corev1.PodRunning {
 		time.Sleep(5 * 1000)
@@ -369,13 +370,14 @@ func (c *Controller) handleUpdateVpcEips(natGwKey string) error {
 		return err
 	}
 
-	pod, err := c.getNatGwPod(natGwKey)
+	oripod, err := c.getNatGwPod(natGwKey)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	pod := oripod.DeepCopy()
 
 	var toBeDelEips, oldEips []*kubeovnv1.Eip
 	if eipAnnotation, ok := pod.Annotations[util.VpcEipsAnnotation]; ok {
@@ -446,13 +448,14 @@ func (c *Controller) handleUpdateVpcFloatingIp(natGwKey string) error {
 		return err
 	}
 
-	pod, err := c.getNatGwPod(natGwKey)
+	oripod, err := c.getNatGwPod(natGwKey)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	pod := oripod.DeepCopy()
 
 	// check md5
 	newMd5 := fmt.Sprintf("%x", structhash.Md5(gw.Spec.FloatingIpRules, 1))
@@ -495,13 +498,14 @@ func (c *Controller) handleUpdateVpcSnat(natGwKey string) error {
 		return err
 	}
 
-	pod, err := c.getNatGwPod(natGwKey)
+	oripod, err := c.getNatGwPod(natGwKey)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	pod := oripod.DeepCopy()
 
 	// check md5
 	newMd5 := fmt.Sprintf("%x", structhash.Md5(gw.Spec.SnatRules, 1))
@@ -543,13 +547,14 @@ func (c *Controller) handleUpdateVpcDnat(natGwKey string) error {
 		return err
 	}
 
-	pod, err := c.getNatGwPod(natGwKey)
+	oripod, err := c.getNatGwPod(natGwKey)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	pod := oripod.DeepCopy()
 
 	// check md5
 	newMd5 := fmt.Sprintf("%x", structhash.Md5(gw.Spec.DnatRules, 1))
@@ -591,13 +596,14 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 		return err
 	}
 
-	pod, err := c.getNatGwPod(natGwKey)
+	oripod, err := c.getNatGwPod(natGwKey)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
+	pod := oripod.DeepCopy()
 
 	gwSubnet, err := c.subnetsLister.Get(gw.Spec.Subnet)
 	if err != nil {


### PR DESCRIPTION
To avoid directly modification to client-go data structures in mem, Deep-Copy is required.
As title, try to fix it in steps.