### PR TITLE
Check IPv4 gateway by resolving gateway MAC in underlay subnets

### DIFF
--- a/docs/vlan.md
+++ b/docs/vlan.md
@@ -27,7 +27,7 @@ In the Vlan/Underlay mode, OVS sends origin Pods packets directly to the physica
 1. For K8s running on VMs provided by OpenStack, `PortSecurity` of the network ports MUST be `disabled`;
 2. For K8s running on VMs provided by VMware, the switch security options `MAC Address Changes`, `Forged Transmits` and `Promiscuous Mode Operation` MUST be `allowed`;
 3. The Vlan/Underlay mode can not run on public IaaS providers like AWS/GCE/Alibaba Cloud as their network can not provide the capability to transmit this type packets;
-4. When Kube-OVN creates network it checks the connectivity to the subnet gateway through ICMP, so the gateway MUST respond the ICMP messages;
+4. In versions prior to v1.9.0, Kube-OVN checks the connectivity to the subnet gateway through ICMP, so the gateway MUST respond the ICMP messages if you are using those versions, or you can turn off the check by setting `disableGatewayCheck` to `true` which is introduced in v1.8.0;
 5. For in-cluster service traffic, Pods set the dst mac to gateway mac and then Kube-OVN applies DNAT to transfer the dst ip, the packets will first be sent to the gateway, so the gateway MUST be capable of transmitting the packets back to the subnet.
 
 ## Comparison with Macvlan

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
+	github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc
 	github.com/moul/http2curl v1.0.0 // indirect
 	github.com/neverlee/keymutex v0.0.0-20171121013845-f593aa834bf9
 	github.com/oilbeater/go-ping v0.0.0-20200413021620-332b7197c5b5

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,12 @@ github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vq
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc h1:m7rJJJeXrYCFpsxXYapkDW53wJCDmf9bsIXUg0HoeQY=
+github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc/go.mod h1:eOj1DDj3NAZ6yv+WafaKzY37MFZ58TdfIhQ+8nQbiis=
+github.com/mdlayher/ethernet v0.0.0-20190313224307-5b5fc417d966 h1:O3p5UmisBhl3V6lgs4Vdfg8HpjzbWJPyOfGLdwVJSmI=
+github.com/mdlayher/ethernet v0.0.0-20190313224307-5b5fc417d966/go.mod h1:5s5p/sMJ6sNsFl6uCh85lkFGV8kLuIYJCRJLavVJwvg=
+github.com/mdlayher/raw v0.0.0-20190313224157-43dbcdd7739d h1:rjAS0af7FIYCScTtEU5KjIldC6qVaEScUJhABHC+ccM=
+github.com/mdlayher/raw v0.0.0-20190313224157-43dbcdd7739d/go.mod h1:r1fbeITl2xL/zLbVnNHFyOzQJTgr/3fpf1lJX/cjzR8=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
@@ -637,6 +643,7 @@ golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/pkg/util/arping.go
+++ b/pkg/util/arping.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/mdlayher/arp"
+)
+
+func Arping(nic, srcIP, dstIP string, timeout time.Duration, maxRetry int) (net.HardwareAddr, int, error) {
+	target := net.ParseIP(dstIP)
+	if target == nil {
+		return nil, 0, fmt.Errorf("%s is not a valid IP address", dstIP)
+	}
+
+	var count int
+	var err error
+	var ifi *net.Interface
+	for ; count < maxRetry; count++ {
+		if ifi, err = net.InterfaceByName(nic); err == nil {
+			break
+		}
+		time.Sleep(timeout)
+	}
+	if err != nil {
+		return nil, count, fmt.Errorf("failed to get interface %s: %v", nic, err)
+	}
+
+	var client *arp.Client
+	for ; count < maxRetry; count++ {
+		if client, err = arp.Dial(ifi); err == nil {
+			defer client.Close()
+			break
+		}
+		time.Sleep(timeout)
+	}
+	if err != nil {
+		return nil, count, fmt.Errorf("failed to set up ARP client: %v", err)
+	}
+
+	for ; count < maxRetry; count++ {
+		if err = client.SetDeadline(time.Now().Add(timeout)); err != nil {
+			continue
+		}
+		if mac, err := client.Resolve(target); err == nil {
+			return mac, count + 1, nil
+		}
+	}
+
+	return nil, count, fmt.Errorf("resolve MAC address of %s timeout: %v", dstIP, err)
+}


### PR DESCRIPTION
#### What type of this PR

- Enhancement

By using ARP protocol, we can check IPv4 network connectivity in environments where ICMP are forbidden. Only used in underlay subnets since there are ARP proxy rules in OVS flows.

Similar improvement is not applied to IPv6 checks since:

1. Something wrong happened if the node uses containerd as container runtime;
2. Neighbor Discovery Protocol in IPv6 is implemented with ICMPv6.