### PR TITLE
add process for pod attachment nic with subnet in default vpc

### DIFF
--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -37,6 +37,7 @@ const (
 
 	AllocatedAnnotationSuffix       = ".kubernetes.io/allocated"
 	AllocatedAnnotationTemplate     = "%s.kubernetes.io/allocated"
+	RoutedAnnotationTemplate        = "%s.kubernetes.io/routed"
 	MacAddressAnnotationTemplate    = "%s.kubernetes.io/mac_address"
 	IpAddressAnnotationTemplate     = "%s.kubernetes.io/ip_address"
 	CidrAnnotationTemplate          = "%s.kubernetes.io/cidr"


### PR DESCRIPTION
#### What type of this PR
enhencement
####
when kube-ovn is used as attachment cni for pod, and with subnet in default vpc, the attchment nic should be processed normal

#### Which issue(s) this PR fixes:
Fixes #1121



