### PR TITLE
add sg acl check when init

### DIFF
--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -1734,13 +1734,25 @@ func (c Client) createSgRuleACL(sgName string, direction AclDirection, rule *kub
 
 func (c Client) CreateSgDenyAllACL() error {
 	portGroupName := GetSgPortGroupName(util.DenyAllSecurityGroup)
-	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclIngressDirection), util.SecurityGroupDropPriority,
-		fmt.Sprintf("outport==@%s && ip", portGroupName), "drop"); err != nil {
+	exist, err := c.AclExists(util.SecurityGroupDropPriority, string(SgAclIngressDirection))
+	if err != nil {
 		return err
 	}
-	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclEgressDirection), util.SecurityGroupDropPriority,
-		fmt.Sprintf("inport==@%s && ip", portGroupName), "drop"); err != nil {
+	if !exist {
+		if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclIngressDirection), util.SecurityGroupDropPriority,
+			fmt.Sprintf("outport==@%s && ip", portGroupName), "drop"); err != nil {
+			return err
+		}
+	}
+	exist, err = c.AclExists(util.SecurityGroupDropPriority, string(SgAclEgressDirection))
+	if err != nil {
 		return err
+	}
+	if !exist {
+		if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclEgressDirection), util.SecurityGroupDropPriority,
+			fmt.Sprintf("inport==@%s && ip", portGroupName), "drop"); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1818,4 +1830,17 @@ func (c Client) SetLspExternalIds(cmd []string) error {
 		return fmt.Errorf("failed to set lsp externalIds, %v", err)
 	}
 	return nil
+}
+
+func (c *Client) AclExists(priority, direction string) (bool, error) {
+	priorityVal, _ := strconv.Atoi(priority)
+	results, err := c.CustomFindEntity("acl", []string{"match"}, fmt.Sprintf("priority=%d", priorityVal), fmt.Sprintf("direction=%s", direction))
+	if err != nil {
+		klog.Errorf("customFindEntity failed, %v", err)
+		return false, err
+	}
+	if len(results) == 0 {
+		return false, nil
+	}
+	return true, nil
 }


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
In the test environment, kube-ovn-controller pod always crashes because add-acl failed. So add check for acl existing, create it if the acl does not exist. 

`
W1129 16:22:00.476317       1 ovn-nbctl.go:48] ovn-nbctl command error: ovn-nbctl --timeout=60 --wait=sb --may-exist --type=port-group acl-add ovn.sg.kubeovn_deny_all to-lport 2003 outport==@ovn.sg.kubeovn_deny_all && ip drop in 60003ms
F1129 16:22:00.476392       1 controller.go:381] failed to init 'deny_all' security group: 2021-11-29T08:22:00Z|00001|fatal_signal|WARN|terminating with signal 14 (signal 14)
, "signal: alarm clock"
[root@bogon ~]#
`

#### Which issue(s) this PR fixes:
Fixes #(issue-number)



