### PR TITLE
fix: no need to set address for ls to lr port

### DIFF
--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -641,7 +641,6 @@ func (c Client) createRouterPort(ls, lr, ip, mac string) error {
 	_, err := c.ovnNbCommand(MayExist, "lsp-add", ls, lsTolr, "--",
 		"set", "logical_switch_port", lsTolr, "type=router", "--",
 		"lsp-set-addresses", lsTolr, "router", "--",
-		"set", "logical_switch_port", lsTolr, fmt.Sprintf("addresses=\"%s\"", mac), "--",
 		"set", "logical_switch_port", lsTolr, fmt.Sprintf("options:router-port=%s", lrTols), "--",
 		"set", "logical_switch_port", lsTolr, fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName))
 	if err != nil {


### PR DESCRIPTION
The address type has already be set to router, set mac address will bring back performance penalty

#### What type of this PR
- Bug fixes


