### PR TITLE
Improve multicast performace

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -24,6 +24,7 @@ RUN dpkg -i /usr/src/python3-openvswitch*.deb /usr/src/libopenvswitch*.deb
 RUN cd /usr/src/ && git clone -b branch-21.06 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
     curl -s https://github.com/kubeovn/ovn/commit/e24734913d25c0bffdf1cfd79e14ef43d01e1019.patch | git apply && \
+    curl -s https://github.com/kubeovn/ovn/commit/8f4e4868377afb5e980856755b9f6394f8b649e2.patch | git apply && \
     sed -i 's/OVN/ovn/g' debian/changelog && \
     rm -rf .git && \
     ./boot.sh && \

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -24,7 +24,6 @@ RUN dpkg -i /usr/src/python3-openvswitch*.deb /usr/src/libopenvswitch*.deb
 RUN cd /usr/src/ && git clone -b branch-21.06 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
     curl -s https://github.com/kubeovn/ovn/commit/e24734913d25c0bffdf1cfd79e14ef43d01e1019.patch | git apply && \
-    curl -s https://github.com/kubeovn/ovn/commit/eee4ace8a3dd00f0a067fed0f0cabee46a29aa54.patch | git apply && \
     sed -i 's/OVN/ovn/g' debian/changelog && \
     rm -rf .git && \
     ./boot.sh && \

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -13,7 +13,6 @@ HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_LB=${ENABLE_LB:-true}
 ENABLE_NP=${ENABLE_NP:-true}
 ENABLE_EXTERNAL_VPC=${ENABLE_EXTERNAL_VPC:-true}
-MULTICAST_PRIVILEGED=${MULTICAST_PRIVILEGED:-false}
 # The nic to support container network can be a nic name or a group of regex
 # separated by comma, if empty will use the nic that the default route use
 IFACE=${IFACE:-}
@@ -1886,7 +1885,6 @@ spec:
           - --enable-lb=$ENABLE_LB
           - --enable-np=$ENABLE_NP
           - --enable-external-vpc=$ENABLE_EXTERNAL_VPC
-          - --multicast-privileged=$MULTICAST_PRIVILEGED
           - --logtostderr=false
           - --alsologtostderr=true
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -69,8 +69,6 @@ type Configuration struct {
 	EnableLb          bool
 	EnableNP          bool
 	EnableExternalVpc bool
-
-	MulticastPrivileged bool
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -113,8 +111,6 @@ func ParseFlags() (*Configuration, error) {
 		argEnableLb             = pflag.Bool("enable-lb", true, "Enable load balancer")
 		argEnableNP             = pflag.Bool("enable-np", true, "Enable network policy support")
 		argEnableExternalVpc    = pflag.Bool("enable-external-vpc", true, "Enable external vpc support")
-
-		argMulticastPrivileged = pflag.Bool("multicast-privileged", false, "Move broadcast/multicast flows to table ls_in_pre_lb in logical switches' ingress pipeline to improve broadcast/multicast performace (default false)")
 	)
 
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
@@ -168,7 +164,6 @@ func ParseFlags() (*Configuration, error) {
 		EnableLb:                      *argEnableLb,
 		EnableNP:                      *argEnableNP,
 		EnableExternalVpc:             *argEnableExternalVpc,
-		MulticastPrivileged:           *argMulticastPrivileged,
 	}
 
 	if config.NetworkType == util.NetworkTypeVlan && config.DefaultHostInterface == "" {

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -18,10 +18,6 @@ import (
 )
 
 func (c *Controller) InitOVN() error {
-	if err := c.ovnClient.SetMulticastPrivileged(c.config.MulticastPrivileged); err != nil {
-		return err
-	}
-
 	if err := c.initClusterRouter(); err != nil {
 		klog.Errorf("init cluster router failed: %v", err)
 		return err

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -67,13 +67,6 @@ func (c Client) SetUseCtInvMatch() error {
 	return nil
 }
 
-func (c Client) SetMulticastPrivileged(enabled bool) error {
-	if _, err := c.ovnNbCommand("set", "NB_Global", ".", fmt.Sprintf("options:mcast_privileged=%v", enabled)); err != nil {
-		return fmt.Errorf("failed to set NB_Global option mcast_privileged to %v: %v", enabled, err)
-	}
-	return nil
-}
-
 func (c Client) SetICAutoRoute(enable bool, blackList []string) error {
 	if enable {
 		if _, err := c.ovnNbCommand("set", "NB_Global", ".", "options:ic-route-adv=true", "options:ic-route-learn=true", fmt.Sprintf("options:ic-route-blacklist=%s", strings.Join(blackList, ","))); err != nil {

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -57,8 +57,6 @@ spec:
             - --pod-nic-type=veth-pair
             - --enable-lb=true
             - --enable-np=true
-            - --enable-external-vpc=true
-            - --multicast-privileged=false
           env:
             - name: ENABLE_SSL
               value: "false"

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -49,7 +49,6 @@ spec:
             - --default-logical-gateway=false
             - --default-exclude-ips=
             - --node-switch-cidr=100.64.0.0/16
-            - --node-switch-gateway=100.64.0.1
             - --service-cluster-ip-range=10.96.0.0/12
             - --network-type=geneve
             - --default-interface-name=
@@ -58,7 +57,6 @@ spec:
             - --enable-lb=true
             - --enable-np=true
             - --enable-external-vpc=true
-            - --multicast-privileged=false
           env:
             - name: ENABLE_SSL
               value: "false"


### PR DESCRIPTION
#### What type of this PR

- Performance

This patch reverts PR #1127 .

Improve multicast performace by not sending multicast packets to conntrack. Rule `match=(eth.mcast), action=(next;)` is added to table `ls_in_pre_lb` and `ls_out_pre_lb` in logical flows:

```txt
Datapath: "multicast" (0369bfac-b6fa-4371-8879-49d65217d81f)  Pipeline: ingress
  table=6 (ls_in_pre_lb       ), priority=110  , match=(eth.dst == $svc_monitor_mac), action=(next;)
  table=6 (ls_in_pre_lb       ), priority=110  , match=(eth.mcast), action=(next;)
  table=6 (ls_in_pre_lb       ), priority=110  , match=(ip && inport == "multicast-ovn-cluster"), action=(next;)
  table=6 (ls_in_pre_lb       ), priority=110  , match=(nd || nd_rs || nd_ra || mldv1 || mldv2), action=(next;)
  table=6 (ls_in_pre_lb       ), priority=100  , match=(ip), action=(reg0[2] = 1; next;)
  table=6 (ls_in_pre_lb       ), priority=0    , match=(1), action=(next;)
Datapath: "multicast" (0369bfac-b6fa-4371-8879-49d65217d81f)  Pipeline: egress
  table=0 (ls_out_pre_lb      ), priority=110  , match=(eth.mcast), action=(next;)
  table=0 (ls_out_pre_lb      ), priority=110  , match=(eth.src == $svc_monitor_mac), action=(next;)
  table=0 (ls_out_pre_lb      ), priority=110  , match=(ip && outport == "multicast-ovn-cluster"), action=(next;)
  table=0 (ls_out_pre_lb      ), priority=110  , match=(nd || nd_rs || nd_ra || mldv1 || mldv2), action=(next;)
  table=0 (ls_out_pre_lb      ), priority=100  , match=(ip), action=(reg0[2] = 1; next;)
  table=0 (ls_out_pre_lb      ), priority=0    , match=(1), action=(next;)
```

#### Performance Testing

Create a subnet and two iperf2 Pods:

```txt
switch 65a35e00-b046-414b-b22b-00d96e22916d (multicast)
switch f2956855-7e2f-4773-b05d-4bebc405e803 (multicast)
    port iperf-s.multicast
        addresses: ["00:00:00:B5:02:9A 172.17.0.2"]
    port iperf-c.multicast
        addresses: ["00:00:00:CF:72:92 172.17.0.3"]
    port multicast-ovn-cluster
        type: router
        router-port: ovn-cluster-multicast
```

OVN trace result after applying the patch:

```shell
root@master:/kube-ovn# ovn-trace --ct=new multicast "inport == \"iperf-c.multicast\" && eth.src == 00:00:00:CF:72:92 && ip4.src == 172.17.0.3 && eth.dst == 01:00:5E:00:01:01 && ip4.dst == 224.0.1.1"
# ip,reg14=0x3,vlan_tci=0x0000,dl_src=00:00:00:5e:88:37,dl_dst=01:00:5e:00:01:01,nw_src=172.17.0.3,nw_dst=224.0.1.1,nw_proto=0,nw_tos=0,nw_ecn=0,nw_ttl=0

ingress(dp="multicast", inport="iperf-c.multicast")
---------------------------------------------------
 0. ls_in_port_sec_l2 (ovn-northd.c:4837): inport == "iperf-c.multicast", priority 50, uuid e87f53ae
    next;
 6. ls_in_pre_lb (ovn-northd.c:5176): eth.mcast, priority 110, uuid d09ec031
    next;
 8. ls_in_acl_hint (ovn-northd.c:5379): !ct.trk, priority 5, uuid 2cd06df8
    reg0[8] = 1;
    reg0[9] = 1;
    next;
22. ls_in_l2_lkup (ovn-northd.c:7371): eth.mcast, priority 70, uuid d9fc74ec
    outport = "_MC_flood";
    output;

multicast(dp="multicast", mcgroup="_MC_flood")
----------------------------------------------

    egress(dp="multicast", inport="iperf-c.multicast", outport="iperf-c.multicast")
    -------------------------------------------------------------------------------
            /* omitting output because inport == outport && !flags.loopback */

    egress(dp="multicast", inport="iperf-c.multicast", outport="iperf-s.multicast")
    -------------------------------------------------------------------------------
         0. ls_out_pre_lb (ovn-northd.c:5178): eth.mcast, priority 110, uuid df3be655
            next;
         3. ls_out_acl_hint (ovn-northd.c:5379): !ct.trk, priority 5, uuid 71746e17
            reg0[8] = 1;
            reg0[9] = 1;
            next;
         9. ls_out_port_sec_l2 (ovn-northd.c:4950): eth.mcast, priority 100, uuid 7493f47e
            output;
            /* output to "iperf-s.multicast", type "" */

    egress(dp="multicast", inport="iperf-c.multicast", outport="multicast-ovn-cluster")
    -----------------------------------------------------------------------------------
         0. ls_out_pre_lb (ovn-northd.c:5178): eth.mcast, priority 110, uuid df3be655
            next;
         3. ls_out_acl_hint (ovn-northd.c:5379): !ct.trk, priority 5, uuid 71746e17
            reg0[8] = 1;
            reg0[9] = 1;
            next;
         9. ls_out_port_sec_l2 (ovn-northd.c:4950): eth.mcast, priority 100, uuid 7493f47e
            output;
            /* output to "multicast-ovn-cluster", type "patch" */

        ingress(dp="ovn-cluster", inport="ovn-cluster-multicast")
        ---------------------------------------------------------
         0. lr_in_admission (ovn-northd.c:9564): eth.mcast && inport == "ovn-cluster-multicast", priority 50, uuid c113673c
            xreg0[0..47] = 00:00:00:49:12:56;
            next;
         1. lr_in_lookup_neighbor (ovn-northd.c:9646): 1, priority 0, uuid 4c9d6761
            reg9[2] = 1;
            next;
         2. lr_in_learn_neighbor (ovn-northd.c:9655): reg9[2] == 1, priority 100, uuid f095be55
            next;
         3. lr_in_ip_input (ovn-northd.c:10753): ip4.mcast || ip6.mcast, priority 82, uuid 4ac8e946
            drop;
```

Performance comparison when two Pods are on the same node:

```shell
/ $ iperf -c 226.94.1.1 -u -T 32 -t 10 -i 1 -b 10G
------------------------------------------------------------
Client connecting to 226.94.1.1, UDP port 5001
Sending 1470 byte datagrams, IPG target: 1.10 us (kalman adjust)
UDP buffer size:  256 KByte (default)
------------------------------------------------------------
[  1] local 172.17.0.13 port 42302 connected with 226.94.1.1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-1.00 sec  46.2 MBytes   388 Mbits/sec
[  1] 1.00-2.00 sec  47.1 MBytes   395 Mbits/sec
[  1] 2.00-3.00 sec  46.8 MBytes   392 Mbits/sec
[  1] 3.00-4.00 sec  44.5 MBytes   373 Mbits/sec
[  1] 4.00-5.00 sec  47.4 MBytes   398 Mbits/sec
[  1] 5.00-6.00 sec  45.2 MBytes   379 Mbits/sec
[  1] 6.00-7.00 sec  45.8 MBytes   384 Mbits/sec
[  1] 7.00-8.00 sec  45.1 MBytes   378 Mbits/sec
[  1] 8.00-9.00 sec  41.1 MBytes   345 Mbits/sec
[  1] 9.00-10.00 sec  48.1 MBytes   403 Mbits/sec
[  1] 0.00-10.00 sec   457 MBytes   384 Mbits/sec
[  1] Sent 326171 datagrams
```

```shell
/ $ iperf -c 226.94.1.1 -u -T 32 -t 10 -i 1 -b 10G
------------------------------------------------------------
Client connecting to 226.94.1.1, UDP port 5001
Sending 1470 byte datagrams, IPG target: 1.10 us (kalman adjust)
UDP buffer size:  256 KByte (default)
------------------------------------------------------------
[  1] local 172.17.0.3 port 49802 connected with 226.94.1.1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-1.00 sec   205 MBytes  1.72 Gbits/sec
[  1] 1.00-2.00 sec   229 MBytes  1.92 Gbits/sec
[  1] 2.00-3.00 sec   226 MBytes  1.89 Gbits/sec
[  1] 3.00-4.00 sec   210 MBytes  1.76 Gbits/sec
[  1] 4.00-5.00 sec   219 MBytes  1.84 Gbits/sec
[  1] 5.00-6.00 sec   224 MBytes  1.88 Gbits/sec
[  1] 6.00-7.00 sec   212 MBytes  1.78 Gbits/sec
[  1] 7.00-8.00 sec   214 MBytes  1.80 Gbits/sec
[  1] 8.00-9.00 sec   214 MBytes  1.79 Gbits/sec
[  1] 9.00-10.00 sec   193 MBytes  1.62 Gbits/sec
[  1] 0.00-10.00 sec  2.10 GBytes  1.80 Gbits/sec
[  1] Sent 1530462 datagrams
```

| Case | Bandwidth |
| :---: | :---: |
| Before |  384 Mbits/sec |
| After | 1.80 Gbits/sec |

Performance comparison when two Pods are on different nodes:

```shell
/ $ iperf -c 226.94.1.1 -u -T 32 -t 10 -i 1 -b 10G
------------------------------------------------------------
Client connecting to 226.94.1.1, UDP port 5001
Sending 1470 byte datagrams, IPG target: 1.10 us (kalman adjust)
UDP buffer size:  256 KByte (default)
------------------------------------------------------------
[  1] local 172.17.0.11 port 44717 connected with 226.94.1.1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-1.00 sec  50.2 MBytes   421 Mbits/sec
[  1] 1.00-2.00 sec  54.9 MBytes   461 Mbits/sec
[  1] 2.00-3.00 sec  53.4 MBytes   448 Mbits/sec
[  1] 3.00-4.00 sec  48.3 MBytes   405 Mbits/sec
[  1] 4.00-5.00 sec  46.1 MBytes   387 Mbits/sec
[  1] 5.00-6.00 sec  49.5 MBytes   415 Mbits/sec
[  1] 6.00-7.00 sec  51.4 MBytes   431 Mbits/sec
[  1] 7.00-8.00 sec  52.8 MBytes   443 Mbits/sec
[  1] 8.00-9.00 sec  49.9 MBytes   419 Mbits/sec
[  1] 9.00-10.00 sec  58.4 MBytes   490 Mbits/sec
[  1] 0.00-10.00 sec   515 MBytes   432 Mbits/sec
[  1] Sent 367358 datagrams
```

```shell
/ $ iperf -c 226.94.1.1 -u -T 32 -t 10 -i 1 -b 10G
------------------------------------------------------------
Client connecting to 226.94.1.1, UDP port 5001
Sending 1470 byte datagrams, IPG target: 1.10 us (kalman adjust)
UDP buffer size:  256 KByte (default)
------------------------------------------------------------
[  1] local 172.17.0.9 port 36975 connected with 226.94.1.1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-1.00 sec   103 MBytes   865 Mbits/sec
[  1] 1.00-2.00 sec   100 MBytes   839 Mbits/sec
[  1] 2.00-3.00 sec   111 MBytes   930 Mbits/sec
[  1] 3.00-4.00 sec   104 MBytes   875 Mbits/sec
[  1] 4.00-5.00 sec   109 MBytes   916 Mbits/sec
[  1] 5.00-6.00 sec   100 MBytes   839 Mbits/sec
[  1] 6.00-7.00 sec  94.8 MBytes   795 Mbits/sec
[  1] 7.00-8.00 sec   103 MBytes   862 Mbits/sec
[  1] 8.00-9.00 sec   104 MBytes   875 Mbits/sec
[  1] 9.00-10.00 sec   119 MBytes  1.00 Gbits/sec
[  1] 0.00-10.00 sec  1.02 GBytes   880 Mbits/sec
[  1] Sent 748058 datagrams
```

| Case | Bandwidth |
| :---: | :---: |
| Before |  432 Mbits/sec |
| After | 880 Gbits/sec |
