### PR TITLE
add pod in default vpc to node port-group

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -583,6 +583,10 @@ func (c *Controller) initNodeRoutes() error {
 }
 
 func (c *Controller) initAppendPodExternalIds(pod *v1.Pod) error {
+	if !isPodAlive(pod) {
+		return nil
+	}
+
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to get pod nets %v", err)

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -733,7 +733,7 @@ func (c *Controller) fetchPodsOnNode(nodeName string) ([]string, error) {
 
 	ports := make([]string, 0, len(pods))
 	for _, pod := range pods {
-		if !isPodAlive(pod) || pod.Spec.HostNetwork || pod.Spec.NodeName != nodeName {
+		if !isPodAlive(pod) || pod.Spec.HostNetwork || pod.Spec.NodeName != nodeName || pod.Annotations[util.LogicalRouterAnnotation] != util.DefaultVpc {
 			continue
 		}
 


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、Pod in the custom vpc should not be added to node port-group, (multus-cni pod created by kube-ovn in custom vpc should be considered independently).
2、In the performance test environment , it happens that the pod is deleted when init to append externalids at the time kube-ovn-controller restarts.



