### PR TITLE
fix LB: skip service without cluster IP

### DIFF
--- a/pkg/controller/endpoint.go
+++ b/pkg/controller/endpoint.go
@@ -119,7 +119,7 @@ func (c *Controller) handleUpdateEndpoint(key string) error {
 	if len(clusterIPs) == 0 && svc.Spec.ClusterIP != "" && svc.Spec.ClusterIP != v1.ClusterIPNone {
 		clusterIPs = []string{svc.Spec.ClusterIP}
 	}
-	if len(clusterIPs) == 0 {
+	if len(clusterIPs) == 0 || clusterIPs[0] == v1.ClusterIPNone {
 		return nil
 	}
 


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

If a service has no cluster IP, the `spec.clusterIPs` field is not empty:

```yaml
spec:
  clusterIP: None
  clusterIPs:
  - None
```
