### PR TITLE
deleting all chassises which are not nodes

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -279,6 +279,10 @@ func (c *Controller) handleAddNode(key string) error {
 		return err
 	}
 
+	if err := c.RemoveRedundantChassis(node); err != nil {
+		return err
+	}
+
 	if err := c.retryDelDupChassis(util.ChasRetryTime, util.ChasRetryIntev+2, c.checkChassisDupl, node); err != nil {
 		return err
 	}
@@ -849,5 +853,40 @@ func (c *Controller) checkAndUpdateNodePortGroup() error {
 		}
 	}
 
+	return nil
+}
+
+func (c *Controller) RemoveRedundantChassis(node *v1.Node) error {
+	chassisAdd, err := c.ovnClient.GetChassis(node.Name)
+	if err != nil {
+		klog.Errorf("failed to get node %s chassisID, %v", node.Name, err)
+		return err
+	}
+	if chassisAdd == "" {
+		chassises, err := c.ovnClient.GetALlChassisHostname()
+		if err != nil {
+			klog.Errorf("failed to get all chassis, %v", err)
+		}
+		nodes, err := c.nodesLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to list nodes, %v", err)
+			return err
+		}
+		for _, chassis := range chassises {
+			matched := true
+			for _, node := range nodes {
+				if chassis == node.Name {
+					matched = false
+				}
+			}
+			if matched {
+				if err := c.ovnClient.DeleteChassis(chassis); err != nil {
+					klog.Errorf("failed to delete chassis for node %s %v", chassis, err)
+					return err
+				}
+			}
+		}
+		return errors.New("chassis reset, reboot ovs-ovn on this node: " + node.Name)
+	}
 	return nil
 }

--- a/pkg/ovs/ovn-sbctl.go
+++ b/pkg/ovs/ovn-sbctl.go
@@ -72,3 +72,19 @@ func (c Client) GetChassis(node string) (string, error) {
 	}
 	return strings.TrimSpace(output), nil
 }
+
+func (c Client) GetALlChassisHostname() ([]string, error) {
+	output, err := c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=hostname", "find", "chassis")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find node chassis, %v", err)
+	}
+	lines := strings.Split(output, "\n")
+	result := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if len(strings.TrimSpace(l)) == 0 {
+			continue
+		}
+		result = append(result, strings.TrimSpace(l))
+	}
+	return result, nil
+}


### PR DESCRIPTION
When a node name is changed, it's possible that the chassis of new-named node could not be added into SBDB.
And the chassis-repair procedure could not repair this scenario because it could not find the chassis based on hostname.

So now if the chassis-repair procedure find a chassis with current hostname could not be found, it will remove all chassises which are not in the hostname lists.