### PR TITLE
Do not add MSS rule in iptables

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -28,7 +28,6 @@ import (
 type Configuration struct {
 	Iface                 string
 	MTU                   int
-	MSS                   int
 	EnableMirror          bool
 	MirrorNic             string
 	BindSocket            string
@@ -172,7 +171,6 @@ func (config *Configuration) initNicConfig() error {
 		config.MTU = iface.MTU - util.GeneveHeaderLength
 	}
 
-	config.MSS = config.MTU - util.TcpIpHeaderLength
 	if !config.EncapChecksum {
 		if err := disableChecksum(); err != nil {
 			klog.Errorf("failed to set checksum offload, %v", err)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -99,7 +99,6 @@ const (
 	DefaultDropPriority = "1000"
 
 	GeneveHeaderLength = 100
-	TcpIpHeaderLength  = 40
 
 	OvnProvider                 = "ovn"
 	AttachmentNetworkAnnotation = "k8s.v1.cni.cncf.io/networks"


### PR DESCRIPTION
The iptables rule for setting TCP MSS is useless, we should remove it.