### PR TITLE
fix: add kube-ovn-cni prob timeout

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2046,6 +2046,7 @@ spec:
               - 127.0.0.1
               - "10665"
           periodSeconds: 3
+          timeoutSeconds: 5
         livenessProbe:
           exec:
             command:
@@ -2057,6 +2058,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 7
           failureThreshold: 5
+          timeoutSeconds: 5
         resources:
           requests:
             cpu: 100m

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -199,6 +199,7 @@ spec:
                 - 127.0.0.1
                 - "10665"
             periodSeconds: 3
+            timeoutSeconds: 5
           livenessProbe:
             exec:
               command:
@@ -209,6 +210,7 @@ spec:
                 - "10665"
             initialDelaySeconds: 30
             periodSeconds: 7
+            timeoutSeconds: 5
             failureThreshold: 5
           resources:
             requests:


### PR DESCRIPTION
When node load is high, the nc probe may take more than the default 1 second and lead prob failed.

#### What type of this PR
Examples of user facing changes:
- Bug fixes


