### PR TITLE
sync live migration vm port

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -591,4 +591,6 @@ func (c *Controller) startWorkers(stopCh <-chan struct{}) {
 	if c.config.EnableNP {
 		go wait.Until(c.CheckNodePortGroup, 10*time.Second, stopCh)
 	}
+
+	go wait.Until(c.syncVmLiveMigrationPort, 15*time.Second, stopCh)
 }

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -306,7 +306,7 @@ func (c *Controller) handleAddNode(key string) error {
 	}
 
 	ipStr := util.GetStringIP(v4IP, v6IP)
-	if err := c.ovnClient.CreatePort(c.config.NodeSwitch, portName, ipStr, mac, "", "", false, "", ""); err != nil {
+	if err := c.ovnClient.CreatePort(c.config.NodeSwitch, portName, ipStr, mac, "", "", false, "", "", false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- Feature

If vm port with the same IP address already exists, only set 'mac' and flag 'liveMigration'.
Set ip addresses for lsp after live migration success.