### PR TITLE
fix: add back the leader check

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1153,7 +1153,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovn-is-leader.sh
-            periodSeconds: 3
+            periodSeconds: 15
             timeoutSeconds: 45
           livenessProbe:
             exec:
@@ -1161,7 +1161,7 @@ spec:
                 - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
-            periodSeconds: 7
+            periodSeconds: 15
             failureThreshold: 5
             timeoutSeconds: 45
       nodeSelector:
@@ -1636,7 +1636,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovn-is-leader.sh
-            periodSeconds: 3
+            periodSeconds: 15
             timeoutSeconds: 45
           livenessProbe:
             exec:
@@ -1644,7 +1644,7 @@ spec:
                 - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
-            periodSeconds: 7
+            periodSeconds: 15
             failureThreshold: 5
             timeoutSeconds: 45
       nodeSelector:

--- a/dist/images/ovn-is-leader.sh
+++ b/dist/images/ovn-is-leader.sh
@@ -42,6 +42,22 @@ fi
 if [[ $sb_leader =~ "true" ]]
 then
    kubectl label --overwrite pod "$POD_NAME" -n "$POD_NAMESPACE" ovn-sb-leader=true
+   set +e
+   northd_svc=$(kubectl get svc -n kube-system | grep ovn-northd)
+   if [ -z "$northd_svc" ]; then
+    echo "ovn-northd svc not exist"
+   else
+    northd_leader=$(kubectl get ep -n kube-system ovn-northd -o jsonpath={.subsets\[0\].addresses\[0\].ip})
+    if [ "$northd_leader" == "" ]; then
+       # no available northd leader try to release the lock
+       if [[ "$ENABLE_SSL" == "false" ]]; then
+         ovsdb-client -v -t 1 steal tcp:127.0.0.1:6642  ovn_northd
+       else
+         ovsdb-client -v -t 1 -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert steal ssl:127.0.0.1:6642  ovn_northd
+       fi
+     fi
+   fi
+   set -e
 else
   kubectl label pod "$POD_NAME" -n "$POD_NAMESPACE" ovn-sb-leader-
 fi

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -284,7 +284,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovn-is-leader.sh
-            periodSeconds: 3
+            periodSeconds: 15
             timeoutSeconds: 45
           livenessProbe:
             exec:
@@ -292,7 +292,7 @@ spec:
                 - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
-            periodSeconds: 7
+            periodSeconds: 15
             failureThreshold: 5
             timeoutSeconds: 45
       nodeSelector:


### PR DESCRIPTION
Previous patch doesn't change the readiness prob interval which may leader two probs run in the same period and always steal the lock from ovn-northd. Increase the interval and add back the leader check.

#### What type of this PR
Examples of user facing changes:
- API changes
- Bug fixes


