### PR TITLE
fix nat rule

### DIFF
--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -25,8 +25,6 @@ iptables -t nat -D POSTROUTING -m set ! --match-set ovn40subnets src -m set ! --
 iptables -t nat -D POSTROUTING -m set ! --match-set ovn40subnets src -m set ! --match-set ovn40other-node src -m set --match-set ovn40subnets-nat dst -j RETURN
 iptables -t nat -D POSTROUTING -m set --match-set ovn40subnets-nat src -m set ! --match-set ovn40subnets dst -j MASQUERADE
 iptables -t nat -D POSTROUTING -m set --match-set ovn40local-pod-ip-nat src -m set ! --match-set ovn40subnets dst -j MASQUERADE
-iptables -t nat -D POSTROUTING -m mark --mark 0x40000/0x40000 -j MASQUERADE
-iptables -t mangle -D PREROUTING -i ovn0 -m set --match-set ovn40subnets src -m set --match-set ovn40services dst -j MARK --set-xmark 0x40000/0x40000
 iptables -t filter -D INPUT -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40services dst -j ACCEPT
@@ -38,7 +36,7 @@ iptables -t filter -D FORWARD -m set --match-set ovn40services src -j ACCEPT
 iptables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
 
 if [ -n "$nodeIPv4" ]; then
-    iptables -t nat -D POSTROUTING ! -s "$nodeIPv4" -m set --match-set ovn40subnets dst -j MASQUERADE
+    iptables -t nat -D POSTROUTING ! -s "$nodeIPv4" -m set ! --match-set ovn40subnets src -m set --match-set ovn40subnets dst -j MASQUERADE
 fi
 
 sleep 1
@@ -53,8 +51,6 @@ ip6tables -t nat -D POSTROUTING -m set ! --match-set ovn60subnets src -m set ! -
 ip6tables -t nat -D POSTROUTING -m set ! --match-set ovn60subnets src -m set ! --match-set ovn60other-node src -m set --match-set ovn60subnets-nat dst -j RETURN
 ip6tables -t nat -D POSTROUTING -m set --match-set ovn60subnets-nat src -m set ! --match-set ovn60subnets dst -j MASQUERADE
 ip6tables -t nat -D POSTROUTING -m set --match-set ovn60local-pod-ip-nat src -m set ! --match-set ovn60subnets dst -j MASQUERADE
-ip6tables -t nat -D POSTROUTING -m mark --mark 0x40000/0x40000 -j MASQUERADE
-ip6tables -t mangle -D PREROUTING -i ovn0 -m set --match-set ovn60subnets src -m set --match-set ovn60services dst -j MARK --set-xmark 0x40000/0x40000
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60services dst -j ACCEPT
@@ -66,7 +62,7 @@ ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
 
 if [ -n "$nodeIPv6" ]; then
-    ip6tables -t nat -D POSTROUTING ! -s "$nodeIPv6" -m set --match-set ovn60subnets dst -j MASQUERADE
+    ip6tables -t nat -D POSTROUTING ! -s "$nodeIPv6" -m set ! --match-set ovn60subnets src -m set --match-set ovn60subnets dst -j MASQUERADE
 fi
 
 sleep 1


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- Bug fixes

1. kube-proxy 已为 cluster ip 包设置 mark 和 MASQUERADE 规则，不需要在cni中再次配置；
2. 对于通过 ovn0 网卡的流量，增加对源 ip 的判断， 内部流量只需路由、不需要 MASQUERADE。
