### PR TITLE
fix: port security

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -680,15 +680,15 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 			return err
 		}
 
+		var securityGroups string
 		if portSecurity {
-			securityGroupAnnotation := pod.Annotations[fmt.Sprintf(util.SecurityGroupAnnotationTemplate, podNet.ProviderName)]
-			portName := ovs.PodNameToPortName(name, namespace, podNet.ProviderName)
-			if err = c.reconcilePortSg(portName, securityGroupAnnotation); err != nil {
-				klog.Errorf("reconcilePortSg failed. %v", err)
-				return err
-			}
+			securityGroups = pod.Annotations[fmt.Sprintf(util.SecurityGroupAnnotationTemplate, podNet.ProviderName)]
+			securityGroups = strings.ReplaceAll(securityGroups, " ", "")
 		}
-
+		if err = c.reconcilePortSg(ovs.PodNameToPortName(name, namespace, podNet.ProviderName), securityGroups); err != nil {
+			klog.Errorf("reconcilePortSg failed. %v", err)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -163,12 +163,15 @@ func (c Client) SetPortExternalIds(port, key, value string) error {
 
 func (c Client) SetPortSecurity(portSecurity bool, port, mac, ipStr, vips string) error {
 	var addresses []string
+	ovnCommand := []string{"lsp-set-port-security", port}
 	if portSecurity {
 		addresses = append(addresses, mac)
 		addresses = append(addresses, strings.Split(ipStr, ",")...)
 		addresses = append(addresses, strings.Split(vips, ",")...)
+		ovnCommand = append(ovnCommand, strings.Join(addresses, " "))
 	}
-	if _, err := c.ovnNbCommand("lsp-set-port-security", port, strings.Join(addresses, " ")); err != nil {
+
+	if _, err := c.ovnNbCommand(ovnCommand...); err != nil {
 		klog.Errorf("set port %s security failed: %v", port, err)
 		return err
 	}


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- Bug fixes

1. Correction of lsp-set-port-security command parameters 
2. If port_security is false, the associated security groups should be cleared


