### PR TITLE
add cilium e2e

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -936,6 +936,64 @@ jobs:
           sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
           sh dist/images/cleanup.sh
 
+  cilium-e2e:
+    needs: build
+    name: 1-master-cilium-e2e
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Kind
+        run: |
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+          chmod +x ./kind
+          sudo mv kind /usr/local/bin
+
+      - name: Init Kind
+        run: |
+          sudo pip3 install j2cli
+          sudo pip3 install "j2cli[yaml]"
+          sudo PATH=~/.local/bin:$PATH make kind-init-iptables
+
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: kube-ovn
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Install Kube-OVN
+        run: |
+          docker load --input kube-ovn.tar
+          sudo PATH=~/.local/bin:$PATH make kind-install-cilium
+          docker exec kube-ovn-control-plane bash -c "ls -al /etc/cni/net.d/"
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17
+        id: go
+
+      - name: Run E2E
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          docker exec kube-ovn-control-plane bash -c "ls -al /etc/cni/net.d/"
+          kubectl  rollout status -n kube-system ds cilium
+          kubectl get pods -A
+          make e2e-ovn-ebpf
+
+      - name: Cleanup
+        run: |
+          sudo sh dist/images/cleanup.sh
+
   push:
     needs:
       - single-e2e
@@ -954,6 +1012,7 @@ jobs:
       - no-lb-iptables-e2e
       - no-np-e2e
       - ovnic-e2e
+      - cilium-e2e
     name: push
     runs-on: ubuntu-18.04
     steps:

--- a/docs/IntegrateCiliumIntoKubeOVN.md
+++ b/docs/IntegrateCiliumIntoKubeOVN.md
@@ -178,6 +178,12 @@ root@cilium-small-x86-01:~# curl 10.110.121.109:9080
 ```bash
 helm upgrade cilium cilium/cilium --version 1.10.5 \
     --namespace kube-system \
+    --set cni.chainingMode=generic-veth \
+    --set cni.customConf=true \
+    --set cni.configMap=cni-configuration \
+    --set tunnel=disabled \
+    --set enableIPv4Masquerade=false \
+    --set enableIdentityMark=false \
     --set kubeProxyReplacement=strict \
     --set k8sServiceHost=REPLACE_WITH_API_SERVER_IP \
     --set k8sServicePort=REPLACE_WITH_API_SERVER_PORT

--- a/test/e2e-ebpf/e2e_ebpf_suite_test.go
+++ b/test/e2e-ebpf/e2e_ebpf_suite_test.go
@@ -1,0 +1,79 @@
+package e2e_ebpf
+
+import (
+	"context"
+	"fmt"
+	kubeovn "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"testing"
+
+	_ "github.com/kubeovn/kube-ovn/test/e2e-ebpf/service"
+	_ "github.com/kubeovn/kube-ovn/test/e2e/ip"
+	_ "github.com/kubeovn/kube-ovn/test/e2e/subnet"
+)
+
+func TestE2eEbpf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kube-OVN E2E ebpf Suite")
+}
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	f := framework.NewFramework("init", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")))
+	nss, err := f.KubeClientSet.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{LabelSelector: "e2e=true"})
+	if err != nil {
+		Fail(err.Error())
+	}
+	if nss != nil {
+		for _, ns := range nss.Items {
+			err := f.KubeClientSet.CoreV1().Namespaces().Delete(context.Background(), ns.Name, metav1.DeleteOptions{})
+			if err != nil {
+				Fail(err.Error())
+			}
+		}
+	}
+
+	err = f.OvnClientSet.KubeovnV1().Subnets().DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "e2e=true"})
+	if err != nil {
+		Fail(err.Error())
+	}
+})
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	subnetName := "static-ip"
+	namespace := "static-ip"
+	f := framework.NewFramework("init", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")))
+
+	_, err := f.KubeClientSet.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{"e2e": "true"}}}, metav1.CreateOptions{})
+	if err != nil {
+		Fail(err.Error())
+	}
+
+	s := kubeovn.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   subnetName,
+			Labels: map[string]string{"e2e": "true"},
+		},
+		Spec: kubeovn.SubnetSpec{
+			CIDRBlock:  "12.10.0.0/16",
+			Namespaces: []string{namespace},
+		},
+	}
+	_, err = f.OvnClientSet.KubeovnV1().Subnets().Create(context.Background(), &s, metav1.CreateOptions{})
+	if err != nil {
+		Fail(err.Error())
+	}
+	err = f.WaitSubnetReady(subnetName)
+	if err != nil {
+		Fail(err.Error())
+	}
+
+	return nil
+}, func(data []byte) {})

--- a/test/e2e-ebpf/service/service.go
+++ b/test/e2e-ebpf/service/service.go
@@ -1,0 +1,128 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func nodeIPs(node corev1.Node) []string {
+	nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(node)
+	var nodeIPs []string
+	if nodeIPv4 != "" {
+		nodeIPs = append(nodeIPs, nodeIPv4)
+	}
+	if nodeIPv6 != "" {
+		nodeIPs = append(nodeIPs, nodeIPv6)
+	}
+	return nodeIPs
+}
+
+func kubectlArgs(pod, ip string, port int32) string {
+	return fmt.Sprintf("-n kube-system exec %s -- curl %s", pod, curlArgs(ip, port))
+}
+
+func curlArgs(ip string, port int32) string {
+	return fmt.Sprintf("-s -m 3 -o /dev/null -w %%{http_code} %s/metrics", util.JoinHostPort(ip, port))
+}
+
+var _ = Describe("[Service]", func() {
+	f := framework.NewFramework("service", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")))
+
+	hostPods, err := f.KubeClientSet.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: "app=ovs"})
+	Expect(err).NotTo(HaveOccurred())
+	containerPods, err := f.KubeClientSet.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: "app=kube-ovn-pinger"})
+	Expect(err).NotTo(HaveOccurred())
+
+	containerService, err := f.KubeClientSet.CoreV1().Services("kube-system").Get(context.Background(), "kube-ovn-pinger", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	containerService.Spec.Type = corev1.ServiceTypeNodePort
+	containerService, err = f.KubeClientSet.CoreV1().Services("kube-system").Update(context.Background(), containerService, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	Context("service with container network endpoints", func() {
+		It("container to ClusterIP", func() {
+			port := containerService.Spec.Ports[0].Port
+			for _, ip := range containerService.Spec.ClusterIPs {
+				for _, pod := range containerPods.Items {
+					output, err := exec.Command("kubectl", strings.Fields(kubectlArgs(pod.Name, ip, port))...).CombinedOutput()
+					outputStr := string(bytes.TrimSpace(output))
+					Expect(err).NotTo(HaveOccurred(), outputStr)
+					Expect(outputStr).To(Equal("200"))
+				}
+			}
+		})
+
+		It("host to ClusterIP", func() {
+			port := containerService.Spec.Ports[0].Port
+			for _, ip := range containerService.Spec.ClusterIPs {
+				for _, pod := range hostPods.Items {
+					output, err := exec.Command("kubectl", strings.Fields(kubectlArgs(pod.Name, ip, port))...).CombinedOutput()
+					outputStr := string(bytes.TrimSpace(output))
+					Expect(err).NotTo(HaveOccurred(), outputStr)
+					Expect(outputStr).To(Equal("200"))
+				}
+			}
+		})
+
+		It("container to NodePort", func() {
+			port := containerService.Spec.Ports[0].NodePort
+			for _, pod := range containerPods.Items {
+				nodes, err := f.KubeClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes.Items {
+					for _, nodeIP := range nodeIPs(node) {
+						output, err := exec.Command("kubectl", strings.Fields(kubectlArgs(pod.Name, nodeIP, port))...).CombinedOutput()
+						outputStr := string(bytes.TrimSpace(output))
+						Expect(err).NotTo(HaveOccurred(), outputStr)
+						Expect(outputStr).To(Equal("200"))
+					}
+				}
+			}
+		})
+
+		It("host to NodePort", func() {
+			port := containerService.Spec.Ports[0].NodePort
+			for _, pod := range hostPods.Items {
+				nodes, err := f.KubeClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes.Items {
+					for _, nodeIP := range nodeIPs(node) {
+						output, err := exec.Command("kubectl", strings.Fields(kubectlArgs(pod.Name, nodeIP, port))...).CombinedOutput()
+						outputStr := string(bytes.TrimSpace(output))
+						Expect(err).NotTo(HaveOccurred(), outputStr)
+						Expect(outputStr).To(Equal("200"))
+					}
+				}
+			}
+		})
+
+		It("external to NodePort", func() {
+			if runtime.GOOS != "linux" {
+				return
+			}
+
+			port := containerService.Spec.Ports[0].NodePort
+			nodes, err := f.KubeClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for _, node := range nodes.Items {
+				for _, nodeIP := range nodeIPs(node) {
+					output, err := exec.Command("curl", strings.Fields(curlArgs(nodeIP, port))...).CombinedOutput()
+					outputStr := string(bytes.TrimSpace(output))
+					Expect(err).To(HaveOccurred(), outputStr)
+				}
+			}
+		})
+	})
+})

--- a/yamls/chaining.yaml
+++ b/yamls/chaining.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cni-configuration
+  namespace: kube-system
+data:
+  cni-config: |-
+    {
+      "name": "generic-veth",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "kube-ovn",
+          "log_level": "info",
+          "datastore_type": "kubernetes",
+          "mtu": 1400,
+          "server_socket": "/run/openvswitch/kube-ovn-daemon.sock",
+          "ipam": {
+              "type": "kube-ovn",
+              "server_socket": "/run/openvswitch/kube-ovn-daemon.sock"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "cilium-cni"
+        }
+      ]
+    }


### PR DESCRIPTION
As title.
In e2e, kube-proxy is removed and cilium is introduced in but the svc dnat is still available.