### PR TITLE
delete pinger check for protocols

### DIFF
--- a/pkg/pinger/config.go
+++ b/pkg/pinger/config.go
@@ -1,19 +1,15 @@
 package pinger
 
 import (
-	"context"
 	"flag"
 	"os"
 	"time"
 
 	"github.com/spf13/pflag"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
-
-	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 type Configuration struct {
@@ -134,18 +130,6 @@ func ParseFlags() (*Configuration, error) {
 	}
 	if err := config.initKubeClient(); err != nil {
 		return nil, err
-	}
-
-	name := os.Getenv("POD_NAME")
-	pod, err := config.KubeClient.CoreV1().Pods("kube-system").Get(context.Background(), name, metav1.GetOptions{})
-	if err != nil {
-		klog.Errorf("failed to get self pod kube-system/%s: %v", name, err)
-		return nil, err
-	}
-
-	config.PodProtocols = make([]string, len(pod.Status.PodIPs))
-	for i, podIP := range pod.Status.PodIPs {
-		config.PodProtocols[i] = util.CheckProtocol(podIP.IP)
 	}
 
 	klog.Infof("pinger config is %+v", config)

--- a/pkg/pinger/ping.go
+++ b/pkg/pinger/ping.go
@@ -14,8 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
-
-	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func StartPinger(config *Configuration, e *Exporter) {
@@ -90,7 +88,7 @@ func pingNodes(config *Configuration) error {
 	var pingErr error
 	for _, no := range nodes.Items {
 		for _, addr := range no.Status.Addresses {
-			if addr.Type == v1.NodeInternalIP && util.ContainsString(config.PodProtocols, util.CheckProtocol(addr.Address)) {
+			if addr.Type == v1.NodeInternalIP {
 				func(nodeIP, nodeName string) {
 					pinger, err := goping.NewPinger(nodeIP)
 					if err != nil {
@@ -141,38 +139,36 @@ func pingPods(config *Configuration) error {
 	var pingErr error
 	for _, pod := range pods.Items {
 		for _, podIP := range pod.Status.PodIPs {
-			if util.ContainsString(config.PodProtocols, util.CheckProtocol(podIP.IP)) {
-				func(podIp, podName, nodeIP, nodeName string) {
-					pinger, err := goping.NewPinger(podIp)
-					if err != nil {
-						klog.Errorf("failed to init pinger, %v", err)
-						pingErr = err
-						return
-					}
-					pinger.SetPrivileged(true)
-					pinger.Timeout = 1 * time.Second
-					pinger.Debug = true
-					pinger.Count = 3
-					pinger.Interval = 1 * time.Millisecond
-					pinger.Run()
-					stats := pinger.Statistics()
-					klog.Infof("ping pod: %s %s, count: %d, loss count %d, average rtt %.2fms",
-						podName, podIp, pinger.Count, int(math.Abs(float64(stats.PacketsSent-stats.PacketsRecv))), float64(stats.AvgRtt)/float64(time.Millisecond))
-					if int(math.Abs(float64(stats.PacketsSent-stats.PacketsRecv))) != 0 {
-						pingErr = fmt.Errorf("ping failed")
-					}
-					SetPodPingMetrics(
-						config.NodeName,
-						config.HostIP,
-						config.PodName,
-						nodeName,
-						nodeIP,
-						podIp,
-						float64(stats.AvgRtt)/float64(time.Millisecond),
-						int(math.Abs(float64(stats.PacketsSent-stats.PacketsRecv))),
-						int(float64(stats.PacketsSent)))
-				}(podIP.IP, pod.Name, pod.Status.HostIP, pod.Spec.NodeName)
-			}
+			func(podIp, podName, nodeIP, nodeName string) {
+				pinger, err := goping.NewPinger(podIp)
+				if err != nil {
+					klog.Errorf("failed to init pinger, %v", err)
+					pingErr = err
+					return
+				}
+				pinger.SetPrivileged(true)
+				pinger.Timeout = 1 * time.Second
+				pinger.Debug = true
+				pinger.Count = 3
+				pinger.Interval = 1 * time.Millisecond
+				pinger.Run()
+				stats := pinger.Statistics()
+				klog.Infof("ping pod: %s %s, count: %d, loss count %d, average rtt %.2fms",
+					podName, podIp, pinger.Count, int(math.Abs(float64(stats.PacketsSent-stats.PacketsRecv))), float64(stats.AvgRtt)/float64(time.Millisecond))
+				if int(math.Abs(float64(stats.PacketsSent-stats.PacketsRecv))) != 0 {
+					pingErr = fmt.Errorf("ping failed")
+				}
+				SetPodPingMetrics(
+					config.NodeName,
+					config.HostIP,
+					config.PodName,
+					nodeName,
+					nodeIP,
+					podIp,
+					float64(stats.AvgRtt)/float64(time.Millisecond),
+					int(math.Abs(float64(stats.PacketsSent-stats.PacketsRecv))),
+					int(float64(stats.PacketsSent)))
+			}(podIP.IP, pod.Name, pod.Status.HostIP, pod.Spec.NodeName)
 		}
 	}
 	return pingErr
@@ -185,10 +181,6 @@ func pingExternal(config *Configuration) error {
 
 	addresses := strings.Split(config.ExternalAddress, ",")
 	for _, addr := range addresses {
-		if !util.ContainsString(config.PodProtocols, util.CheckProtocol(addr)) {
-			continue
-		}
-
 		klog.Infof("start to check ping external to %s", addr)
 		pinger, err := goping.NewPinger(addr)
 		if err != nil {


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
In some cases, the pod.Status.IPs is null for pinger pod. The logs is as follows
```
I1224 10:05:05.831165    3466 config.go:147] len(pod.Status.PodIPs) 0, pod.Status.PodIPs []
I1224 10:05:05.831491    3466 config.go:152] config.PodProtocols []
I1224 10:05:05.831527    3466 config.go:154] pinger config is &{KubeConfigFile: KubeClient:0xc000758000 Port:8080 DaemonSetNamespace:kube-system DaemonSetName:kube-ovn-pinger Interval:5 Mode:server ExitCode:0 InternalDNS:kubernetes.default ExternalDNS:alauda.cn NodeName:kube-ovn-worker HostIP:172.18.0.2 PodName:kube-ovn-pinger-dcjvz PodIP:10.16.0.8 PodProtocols:[] ExternalAddress:114.114.114.114 NetworkMode:kube-ovn PollTimeout:2 PollInterval:15 SystemRunDir:/var/run/openvswitch DatabaseVswitchName:Open_vSwitch DatabaseVswitchSocketRemote:unix:/var/run/openvswitch/db.sock DatabaseVswitchFileDataPath:/etc/openvswitch/conf.db DatabaseVswitchFileLogPath:/var/log/openvswitch/ovsdb-server.log DatabaseVswitchFilePidPath:/var/run/openvswitch/ovsdb-server.pid DatabaseVswitchFileSystemIDPath:/etc/openvswitch/system-id.conf ServiceVswitchdFileLogPath:/var/log/openvswitch/ovs-vswitchd.log ServiceVswitchdFilePidPath:/var/run/openvswitch/ovs-vswitchd.pid ServiceOvnControllerFileLogPath:/var/log/ovn/ovn-controller.log ServiceOvnControllerFilePidPath:/var/run/ovn/ovn-controller.pid}
I1224 10:05:05.836147    3466 exporter.go:75] kube-ovn-worker: exporter connect successfully
```

#### Which issue(s) this PR fixes:
Fixes #1140 



