### PR TITLE
add svc cidr in ovs LB for optimization

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -28,6 +28,13 @@ func (c *Controller) InitOVN() error {
 			klog.Errorf("init load balancer failed: %v", err)
 			return err
 		}
+		v4Svc, _ := util.SplitStringIP(c.config.ServiceClusterIPRange)
+		if v4Svc != "" {
+			if err := c.ovnClient.SetLBCIDR(v4Svc); err != nil {
+				klog.Errorf("init load balancer svc cidr failed: %v", err)
+				return err
+			}
+		}
 	}
 
 	if err := c.initDefaultVlan(); err != nil {

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -1939,3 +1939,10 @@ func (c *Client) AclExists(priority, direction string) (bool, error) {
 	}
 	return true, nil
 }
+
+func (c *Client) SetLBCIDR(svccidr string) error {
+	if _, err := c.ovnNbCommand("set", "NB_Global", ".", fmt.Sprintf("options:svc_ipv4_cidr=%s", svccidr)); err != nil {
+		return fmt.Errorf("failed to set svc cidr for lb, %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
As an automated optimisation patch for #1166 
kubeovn >= 1.9