### PR TITLE
use different ip crd with provider suffix for pod multus nic

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -334,15 +334,6 @@ func (c *Controller) InitIPAM() error {
 		if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Name, ip.Spec.IPAddress, ip.Spec.MacAddress, ip.Spec.Subnet, false); err != nil {
 			klog.Errorf("failed to init IPAM from IP CR %s: %v", ip.Name, err)
 		}
-		for i := range ip.Spec.AttachSubnets {
-			if i == len(ip.Spec.AttachIPs) || i == len(ip.Spec.AttachMacs) {
-				klog.Errorf("attachment IP/MAC of IP CR %s is invalid", ip.Name)
-				break
-			}
-			if _, _, _, err = c.ipam.GetStaticAddress(ipamKey, ip.Name, ip.Spec.AttachIPs[i], ip.Spec.AttachMacs[i], ip.Spec.AttachSubnets[i], false); err != nil {
-				klog.Errorf("failed to init IPAM from IP CR %s: %v", ip.Name, err)
-			}
-		}
 	}
 
 	nodes, err := c.nodesLister.List(labels.Everything())


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、use different ip crd with provider suffix for pod multus nic
2、ipamKey is repeated in InitIPAM when alloc ip for pod with mutus nic 

#### Which issue(s) this PR fixes:
Fixes #(issue-number)



