### PR TITLE
fix installation script

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1825,7 +1825,7 @@ fi
 
 kubectl apply -f kube-ovn-crd.yaml
 kubectl apply -f ovn.yaml
-kubectl rollout status deployment/ovn-central -n kube-system
+kubectl rollout status deployment/ovn-central -n kube-system --timeout 300s
 echo "-------------------------------"
 echo ""
 
@@ -2413,8 +2413,8 @@ spec:
 EOF
 
 kubectl apply -f kube-ovn.yaml
-kubectl rollout status deployment/kube-ovn-controller -n kube-system
-kubectl rollout status daemonset/kube-ovn-cni -n kube-system
+kubectl rollout status deployment/kube-ovn-controller -n kube-system --timeout 300s
+kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout 300s
 echo "-------------------------------"
 echo ""
 
@@ -2425,8 +2425,9 @@ for ns in $(kubectl get ns --no-headers -o  custom-columns=NAME:.metadata.name);
   done
 done
 
-kubectl rollout status daemonset/kube-ovn-pinger -n kube-system
-kubectl rollout status deployment/coredns -n kube-system
+sleep 5
+kubectl rollout status daemonset/kube-ovn-pinger -n kube-system --timeout 300s
+kubectl rollout status deployment/coredns -n kube-system --timeout 300s
 echo "-------------------------------"
 echo ""
 
@@ -2951,7 +2952,6 @@ fi
 
 echo "[Step 6/6] Run network diagnose"
 kubectl ko diagnose all
-
 
 echo "-------------------------------"
 echo "


### PR DESCRIPTION
1. add timeout for `kubectl rollout status`;
2. sleep 5 seconds after deleting Pods.

#### What type of this PR

- Bug fixes

This patch fixes the following failure in e2e testing:

```txt
### start to diagnose node kube-ovn-control-plane
#### ovn-controller log:
error: unable to upgrade connection: container not found ("pinger")
```
