### PR TITLE
add kubectl-ko to docker image

### DIFF
--- a/dist/images/.dockerignore
+++ b/dist/images/.dockerignore
@@ -3,5 +3,4 @@ install.sh
 ovn-ic-db-docker.sh
 generate-ssl-docker.sh
 cleanup.sh
-kubectl-ko
 *.yaml

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -2,6 +2,7 @@
 FROM kubeovn/kube-ovn-base:v1.9.0
 
 COPY *.sh /kube-ovn/
+COPY kubectl-ko /kube-ovn/kubectl-ko
 COPY 01-kube-ovn.conflist /kube-ovn/01-kube-ovn.conflist
 COPY logrotate/* /etc/logrotate.d/
 COPY grace_stop_ovn_controller /usr/share/ovn/scripts/grace_stop_ovn_controller


### PR DESCRIPTION
#### What type of this PR

- Enhencement

Add kubectl-ko to the docker image so that we can get it from kube-ovn containers when we need it.

