### PR TITLE
fix: validate statefulset pod by name

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -819,7 +819,9 @@ func (c *Controller) handleUpdatePod(key string) error {
 func isStatefulSetPod(pod *v1.Pod) (bool, string) {
 	for _, owner := range pod.OwnerReferences {
 		if owner.Kind == "StatefulSet" && strings.HasPrefix(owner.APIVersion, "apps/") {
-			return true, owner.Name
+			if strings.HasPrefix(pod.Name, owner.Name) {
+				return true, owner.Name
+			}
 		}
 	}
 	return false, ""


### PR DESCRIPTION
Some controller (e.g. vcluster) will add pod owner reference to statefulset, however this pod is not controlled by statefulset controller, we should not treat it as a statefulset pod.

#### What type of this PR
Examples of user facing changes:
- API changes
- Bug fixes
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)



