### PR TITLE
check static route conflict

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -574,31 +574,33 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 		return nil
 	}
 
-	addresses := c.ipam.GetPodAddress(key)
-	for _, address := range addresses {
-		if strings.TrimSpace(address.Ip) == "" {
-			continue
-		}
-		subnet, err := c.subnetsLister.Get(address.Subnet.Name)
-		if err != nil {
-			return err
-		}
-		vpc, err := c.vpcsLister.Get(subnet.Spec.Vpc)
-		if err != nil {
-			return err
-		}
-		if err := c.ovnClient.DeleteStaticRoute(address.Ip, vpc.Status.Router); err != nil {
-			return err
-		}
-		if err := c.ovnClient.DeleteNatRule(address.Ip, vpc.Status.Router); err != nil {
-			return err
-		}
-	}
-
 	ports, err := c.ovnClient.ListPodLogicalSwitchPorts(pod.Name, pod.Namespace)
 	if err != nil {
 		klog.Errorf("failed to list lsps of pod '%s', %v", pod.Name, err)
 		return err
+	}
+
+	if len(ports) != 0 {
+		addresses := c.ipam.GetPodAddress(key)
+		for _, address := range addresses {
+			if strings.TrimSpace(address.Ip) == "" {
+				continue
+			}
+			subnet, err := c.subnetsLister.Get(address.Subnet.Name)
+			if err != nil {
+				return err
+			}
+			vpc, err := c.vpcsLister.Get(subnet.Spec.Vpc)
+			if err != nil {
+				return err
+			}
+			if err := c.ovnClient.DeleteStaticRoute(address.Ip, vpc.Status.Router); err != nil {
+				return err
+			}
+			if err := c.ovnClient.DeleteNatRule(address.Ip, vpc.Status.Router); err != nil {
+				return err
+			}
+		}
 	}
 
 	var keepIpCR bool

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -114,7 +114,9 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		priority = pod.Annotations[fmt.Sprintf(util.PriorityAnnotationTemplate, podRequest.Provider)]
 		providerNetwork = pod.Annotations[fmt.Sprintf(util.ProviderNetworkTemplate, podRequest.Provider)]
 		ipAddr = util.GetIpAddrWithMask(ip, cidr)
-		ifName = podRequest.IfName
+		if ifName = podRequest.IfName; ifName == "" {
+			ifName = "eth0"
+		}
 		if podRequest.DeviceID != "" {
 			nicType = util.OffloadType
 		} else {
@@ -127,16 +129,12 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		case "false":
 			isDefaultRoute = false
 		default:
-			if ifName == "" || ifName == "eth0" {
-				isDefaultRoute = true
-			}
+			isDefaultRoute = ifName == "eth0"
 		}
+
 		break
 	}
 
-	if ifName == "" {
-		ifName = "eth0"
-	}
 	if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podRequest.Provider)] != "true" {
 		err := fmt.Errorf("no address allocated to pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
 		klog.Error(err)
@@ -147,6 +145,15 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	}
 
 	if err := csh.createOrUpdateIPCr(podRequest, subnet, ip, macAddr); err != nil {
+		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
+			klog.Errorf("failed to write response, %v", err)
+		}
+		return
+	}
+
+	if isDefaultRoute && pod.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, podRequest.Provider)] != "true" {
+		err := fmt.Errorf("route is not ready for pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
+		klog.Error(err)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

In a specific scenario, a new Pod was assigned with the same IP address as an existing Pod, and the existing static route on the logical router was updated with a different nexthop. This causes access to the external network from the existing Pod to fail.

This patch fixes the issue by:
1. check conflict static routes before adding a new one;
2. check `routed` annotation before handling `ADD` command in CNI;
3. do not delete static routes when the Pod being deleted has no LSP.