### PR TITLE
add 'virtual' port for vip

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -540,6 +540,10 @@ spec:
                   type: array
                   items:
                     type: string
+                vips:
+                  type: array
+                  items:
+                    type: string
                 gatewayType:
                   type: string
                 allowSubnets:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -121,6 +121,8 @@ type SubnetSpec struct {
 	Vlan   string `json:"vlan,omitempty"`
 	HtbQos string `json:"htbqos,omitempty"`
 
+	Vips []string `json:"vips,omitempty"`
+
 	LogicalGateway         bool `json:"logicalGateway"`
 	DisableGatewayCheck    bool `json:"disableGatewayCheck"`
 	DisableInterConnection bool `json:"disableInterConnection"`

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -90,6 +90,7 @@ func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
 		oldSubnet.Spec.LogicalGateway != newSubnet.Spec.LogicalGateway ||
 		oldSubnet.Spec.Gateway != newSubnet.Spec.Gateway ||
 		!reflect.DeepEqual(oldSubnet.Spec.ExcludeIps, newSubnet.Spec.ExcludeIps) ||
+		!reflect.DeepEqual(oldSubnet.Spec.Vips, newSubnet.Spec.Vips) ||
 		oldSubnet.Spec.Vlan != newSubnet.Spec.Vlan {
 		klog.V(3).Infof("enqueue update subnet %s", key)
 		c.addOrUpdateSubnetQueue.Add(key)
@@ -114,6 +115,41 @@ func (c *Controller) runDeleteRouteWorker() {
 func (c *Controller) runDeleteSubnetWorker() {
 	for c.processNextDeleteSubnetWorkItem() {
 	}
+}
+
+func (c *Controller) runSyncVirtualPortsWorker() {
+	for c.processNextSyncVirtualPortsWorkItem() {
+	}
+}
+
+func (c *Controller) processNextSyncVirtualPortsWorkItem() bool {
+	obj, shutdown := c.syncVirtualPortsQueue.Get()
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer c.syncVirtualPortsQueue.Done(obj)
+		var key string
+		var ok bool
+		if key, ok = obj.(string); !ok {
+			c.syncVirtualPortsQueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		if err := c.syncVirtualPort(key); err != nil {
+			c.syncVirtualPortsQueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		}
+		c.syncVirtualPortsQueue.Forget(obj)
+		return nil
+	}(obj)
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+	return true
 }
 
 func (c *Controller) processNextAddSubnetWorkItem() bool {
@@ -833,6 +869,89 @@ func (c *Controller) reconcileSubnet(subnet *kubeovnv1.Subnet) error {
 	if err := c.reconcileVlan(subnet); err != nil {
 		klog.Errorf("reconcile vlan for subnet %s failed, %v", subnet.Name, err)
 		return err
+	}
+
+	if err := c.reconcileVips(subnet); err != nil {
+		klog.Errorf("reconcile vips for subnet %s failed, %v", subnet.Name, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) reconcileVips(subnet *kubeovnv1.Subnet) error {
+	// 1. get all vip port
+	results, err := c.ovnClient.CustomFindEntity("logical_switch_port", []string{"name", "options"}, "type=virtual", fmt.Sprintf("external_ids:ls=%s", subnet.Name))
+	if err != nil {
+		klog.Errorf("failed to find virtual port, %v", err)
+		return err
+	}
+
+	// 2. remove no need port
+	var existVips []string
+	for _, ret := range results {
+		options := ret["options"]
+		for _, value := range options {
+			if !strings.HasPrefix(value, "virtual-ip=") {
+				continue
+			}
+			vip := strings.TrimPrefix(value, "virtual-ip=")
+			if vip == "" || net.ParseIP(vip) == nil {
+				continue
+			}
+			if !util.ContainsString(subnet.Spec.Vips, vip) {
+				if err = c.ovnClient.DeleteLogicalSwitchPort(ret["name"][0]); err != nil {
+					klog.Errorf("failed to delete virtual port, %v", err)
+					return err
+				}
+			} else {
+				existVips = append(existVips, vip)
+			}
+		}
+	}
+
+	// 3. create new port
+	newVips := util.DiffStringSlice(existVips, subnet.Spec.Vips)
+	for _, vip := range newVips {
+		if err = c.ovnClient.CreateVirtualPort(subnet.Name, vip); err != nil {
+			klog.Errorf("failed to create virtual port, %v", err)
+			return err
+		}
+	}
+	c.syncVirtualPortsQueue.Add(subnet.Name)
+	return nil
+}
+
+func (c *Controller) syncVirtualPort(key string) error {
+	subnet, err := c.subnetsLister.Get(key)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		} else {
+			klog.Errorf("failed to get subnet %s, %v", key, err)
+			return err
+		}
+	}
+	results, err := c.ovnClient.CustomFindEntity("logical_switch_port", []string{"name", "port_security"},
+		fmt.Sprintf("external_ids:ls=%s", subnet.Name), "external_ids:attach-vips=true")
+	if err != nil {
+		klog.Errorf("failed to list logical_switch_port, %v", err)
+		return err
+	}
+	for _, vip := range subnet.Spec.Vips {
+		if !util.CIDRContainIP(subnet.Spec.CIDRBlock, vip) {
+			klog.Errorf("vip %s is out of range to subnet %s", vip, subnet.Name)
+			continue
+		}
+		var virtualParents []string
+		for _, ret := range results {
+			if util.ContainsString(ret["port_security"], vip) {
+				virtualParents = append(virtualParents, ret["name"][0])
+			}
+		}
+		if err = c.ovnClient.SetVirtualParents(subnet.Name, vip, strings.Join(virtualParents, ",")); err != nil {
+			klog.Errorf("failed to set vip %s virtual parents, %v", vip, err)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -108,6 +108,13 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		}
 	}
 
+	if len(subnet.Spec.Vips) != 0 {
+		for _, vip := range subnet.Spec.Vips {
+			if !CIDRContainIP(subnet.Spec.CIDRBlock, vip) {
+				return fmt.Errorf("vip %s conflicts with subnet %s cidr %s", vip, subnet.Name, subnet.Spec.CIDRBlock)
+			}
+		}
+	}
 	return nil
 }
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -178,6 +178,10 @@ spec:
                   type: array
                   items:
                     type: string
+                vips:
+                  type: array
+                  items:
+                    type: string
                 gatewayType:
                   type: string
                 allowSubnets:


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- API changes

之前的 vip 功能是不完整的，这个 pr 目的是对此进行修正，解决 vip 没有 arp 流表的问题，参考 ovn 的 patch
https://patchwork.ozlabs.org/project/openvswitch/patch/20190706062258.5597-1-nusiddiq@redhat.com/

kube-ovn 修改逻辑:
1. subnet spec 增加 vips array
2. subnet controller 根据 vips array 创建对应的 'virtual' port
3. pod 变更时，根据 vip annotation 同步 subnet 内 'virtual' port 的绑定关系

实现逻辑参考以下命令行示例：
```
ovn-nbctl ls-add sw0

ovn-nbctl lsp-add sw0 sw0-vir
ovn-nbctl lsp-set-addresses sw0-vir "50:54:00:00:00:10 10.0.0.10"
ovn-nbctl lsp-set-port-security sw0-vir "50:54:00:00:00:10 10.0.0.10"
ovn-nbctl lsp-set-type sw0-vir virtual
ovn-nbctl set logical_switch_port sw0-vir options:virtual-ip=10.0.0.10
ovn-nbctl set logical_switch_port sw0-vir options:virtual-parents=sw0-p1,sw0-p2

ovn-nbctl lsp-add sw0 sw0-p1
ovn-nbctl lsp-set-addresses sw0-p1 "50:54:00:00:00:03 10.0.0.3"
ovn-nbctl lsp-set-port-security sw0-p1 "50:54:00:00:00:03 10.0.0.3 10.0.0.10"

ovn-nbctl lsp-add sw0 sw0-p2
ovn-nbctl lsp-set-addresses sw0-p2 "50:54:00:00:00:04 10.0.0.4"
ovn-nbctl lsp-set-port-security sw0-p2 "50:54:00:00:00:04 10.0.0.4 10.0.0.10"

```
