### PR TITLE
add policy route for distributed subnet in default vpc

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -405,6 +405,14 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	if err := c.initSyncCrdVlans(); err != nil {
 		klog.Errorf("failed to sync crd vlans: %v", err)
 	}
+	if err := c.initDeleteOverlayPodsStaticRoutes(); err != nil {
+		klog.Errorf("failed to delete pod's static route in default vpc: %v", err)
+	}
+	// The static route for node gw can be deleted when gc static route, so add it after gc process
+	dstIp := "0.0.0.0/0,::/0"
+	if err := c.ovnClient.AddStaticRoute("", dstIp, c.config.NodeSwitchGateway, c.config.ClusterRouter, util.NormalRouteType); err != nil {
+		klog.Errorf("failed to add static route for node gw: %v", err)
+	}
 
 	// start workers to do all the network operations
 	c.startWorkers(stopCh)

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -495,6 +496,21 @@ func (c *Controller) gcPortGroup() error {
 		}
 		for _, node := range nodes {
 			npNames = append(npNames, fmt.Sprintf("%s/%s", "node", node.Name))
+		}
+
+		// append overlay subnets port group to npNames to avoid gc distributed subnets port group
+		subnets, err := c.subnetsLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to list subnets %v", err)
+			return err
+		}
+		for _, subnet := range subnets {
+			if subnet.Spec.Vpc != util.DefaultVpc || subnet.Spec.Vlan != "" || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
+				continue
+			}
+			for _, node := range nodes {
+				npNames = append(npNames, fmt.Sprintf("%s/%s", subnet.Name, node.Name))
+			}
 		}
 	}
 

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -57,6 +57,11 @@ func (c *Controller) InitOVN() error {
 		return err
 	}
 
+	if err := c.createOverlaySubnetsAddressSet(); err != nil {
+		klog.Errorf("failed to create overlay subnets address-set, %v", err)
+		return err
+	}
+
 	return nil
 }
 
@@ -681,4 +686,36 @@ func (c *Controller) initHtbQos() error {
 		}
 	}
 	return err
+}
+
+func (c *Controller) initDeleteOverlayPodsStaticRoutes() error {
+	pods, err := c.podsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list pods: %v", err)
+		return err
+	}
+	for _, pod := range pods {
+		if pod.Spec.HostNetwork {
+			continue
+		}
+		podNets, err := c.getPodKubeovnNets(pod)
+		if err != nil {
+			klog.Errorf("failed to get pod kubeovn nets %s.%s address %s: %v", pod.Name, pod.Namespace, pod.Annotations[util.IpAddressAnnotation], err)
+			continue
+		}
+		for _, podNet := range podNets {
+			if !isOvnSubnet(podNet.Subnet) || podNet.Subnet.Spec.Vpc != util.DefaultVpc || podNet.Subnet.Spec.Vlan != "" || podNet.Subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
+				continue
+			}
+			if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] == "true" {
+				for _, podIP := range strings.Split(pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)], ",") {
+					if err := c.ovnClient.DeleteStaticRoute(podIP, podNet.Subnet.Spec.Vpc); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -320,6 +320,11 @@ func (c *Controller) handleAddNode(key string) error {
 		}
 	}
 
+	if err := c.addNodeGwStaticRoute(); err != nil {
+		klog.Errorf("failed to add static route for node gw: %v", err)
+		return err
+	}
+
 	patchPayloadTemplate :=
 		`[{
         "op": "%s",
@@ -609,7 +614,7 @@ func (c *Controller) checkGatewayReady() error {
 						continue
 					}
 
-					exist, err := c.checkNodeEcmpRouteExist(ip, cidrBlock)
+					exist, err := c.checkRouteExist(ip, cidrBlock, ovs.PolicySrcIP)
 					if err != nil {
 						klog.Errorf("get ecmp static route for subnet %v, error %v", subnet.Name, err)
 						break
@@ -671,7 +676,7 @@ func (c *Controller) checkGatewayReady() error {
 	return nil
 }
 
-func (c *Controller) checkNodeEcmpRouteExist(nodeIp, cidrBlock string) (bool, error) {
+func (c *Controller) checkRouteExist(nextHop, cidrBlock, routePolicy string) (bool, error) {
 	routes, err := c.ovnClient.GetStaticRouteList(c.config.ClusterRouter)
 	if err != nil {
 		klog.Errorf("failed to list static route %v", err)
@@ -679,11 +684,12 @@ func (c *Controller) checkNodeEcmpRouteExist(nodeIp, cidrBlock string) (bool, er
 	}
 
 	for _, route := range routes {
-		if route.Policy != ovs.PolicySrcIP {
+		if route.Policy != routePolicy {
 			continue
 		}
-		if route.CIDR == cidrBlock && route.NextHop == nodeIp {
-			klog.V(3).Infof("src-ip static route exist for cidr %s, nexthop %v", cidrBlock, nodeIp)
+
+		if route.CIDR == cidrBlock && route.NextHop == nextHop {
+			klog.V(3).Infof("static route exists for cidr %s, nexthop %v", cidrBlock, nextHop)
 			return true, nil
 		}
 	}
@@ -902,6 +908,31 @@ func (c *Controller) RemoveRedundantChassis(node *v1.Node) error {
 			}
 		}
 		return errors.New("chassis reset, reboot ovs-ovn on this node: " + node.Name)
+	}
+	return nil
+}
+
+func (c *Controller) addNodeGwStaticRoute() error {
+	dstCidr := "0.0.0.0/0,::/0"
+	for _, cidrBlock := range strings.Split(dstCidr, ",") {
+		for _, nextHop := range strings.Split(c.config.NodeSwitchGateway, ",") {
+			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(nextHop) {
+				continue
+			}
+
+			exist, err := c.checkRouteExist(nextHop, cidrBlock, ovs.PolicyDstIP)
+			if err != nil {
+				klog.Errorf("get static route for node gw error %v", err)
+				return err
+			}
+
+			if !exist {
+				if err := c.ovnClient.AddStaticRoute("", cidrBlock, nextHop, c.config.ClusterRouter, util.NormalRouteType); err != nil {
+					klog.Errorf("failed to add static route for node gw: %v", err)
+					return err
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -616,6 +616,7 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 		if err != nil {
 			klog.Warningf("filed to get port '%s' sg, %v", portName, err)
 		}
+		// when lsp is deleted, the port of pod is deleted from any port-group automatically.
 		if err := c.ovnClient.DeleteLogicalSwitchPort(portName); err != nil {
 			klog.Errorf("failed to delete lsp %s, %v", portName, err)
 			return err
@@ -720,6 +721,12 @@ func (c *Controller) handleUpdatePod(key string) error {
 		return err
 	}
 
+	_, idNameMap, err := c.ovnClient.ListLspForNodePortgroup()
+	if err != nil {
+		klog.Errorf("failed to list lsp info, %v", err)
+		return err
+	}
+
 	for _, podNet := range podNets {
 		if !isOvnSubnet(podNet.Subnet) {
 			continue
@@ -764,6 +771,19 @@ func (c *Controller) handleUpdatePod(key string) error {
 						klog.Errorf("get node %s failed %v", pod.Spec.NodeName, err)
 						return err
 					}
+
+					pgName := getOverlaySubnetsPortGroupName(subnet.Name, node.Name)
+					exist, err := c.ovnClient.PortGroupExists(pgName)
+					if err != nil {
+						return err
+					}
+					if !exist {
+						if err = c.ovnClient.CreateNpPortGroup(pgName, subnet.Name, node.Name); err != nil {
+							klog.Errorf("failed to create port group for subnet %s and node %s, %v", subnet.Name, node.Name, err)
+							return err
+						}
+					}
+
 					nodeTunlIPAddr, err := getNodeTunlIP(node)
 					if err != nil {
 						return err
@@ -774,9 +794,41 @@ func (c *Controller) handleUpdatePod(key string) error {
 							if util.CheckProtocol(nodeAddr.String()) != util.CheckProtocol(podAddr) {
 								continue
 							}
-							if err := c.ovnClient.AddStaticRoute(ovs.PolicySrcIP, podAddr, nodeAddr.String(), c.config.ClusterRouter, util.NormalRouteType); err != nil {
-								klog.Errorf("failed to add static route, %v", err)
+
+							pgPorts, err := c.getPgPorts(idNameMap, pgName)
+							if err != nil {
+								klog.Errorf("failed to fetch ports for pg %v, %v", pgName, err)
 								return err
+							}
+
+							portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, podNet.ProviderName)
+							if !util.IsStringIn(portName, pgPorts) {
+								pgPorts = append(pgPorts, portName)
+
+								if err = c.ovnClient.SetPortsToPortGroup(pgName, pgPorts); err != nil {
+									klog.Errorf("failed to set ports to port group %v, %v", pgName, err)
+									return err
+								}
+							}
+
+							ipSuffix := "ip4"
+							subnetAsName := getOverlaySubnetsAddressSetName(c.config.ClusterRouter, kubeovnv1.ProtocolIPv4)
+							if util.CheckProtocol(nodeAddr.String()) == kubeovnv1.ProtocolIPv6 {
+								ipSuffix = "ip6"
+								subnetAsName = getOverlaySubnetsAddressSetName(c.config.ClusterRouter, kubeovnv1.ProtocolIPv6)
+							}
+							pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
+							match := fmt.Sprintf("%s.src == $%s && %s.dst != $%s", ipSuffix, pgAs, ipSuffix, subnetAsName)
+
+							exist, err := c.ovnClient.PolicyRouteExists(util.PodRouterPolicyPriority, match)
+							if err != nil {
+								return err
+							}
+							if !exist {
+								if err = c.ovnClient.AddPolicyRoute(c.config.ClusterRouter, util.PodRouterPolicyPriority, match, "reroute", nodeAddr.String()); err != nil {
+									klog.Errorf("failed to add logical router policy for port-group address-set %s: %v", pgAs, err)
+									return err
+								}
 							}
 						}
 					}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -605,6 +605,11 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 	}
 
+	if err := c.updateOverlaySubnetAddressSet(subnet, true); err != nil {
+		klog.Errorf("failed to update overlay subnets address-set, %v", err)
+		return err
+	}
+
 	if err := c.reconcileSubnet(subnet); err != nil {
 		klog.Errorf("reconcile subnet for %s failed, %v", subnet.Name, err)
 		return err
@@ -752,6 +757,11 @@ func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) error {
 		return err
 	}
 
+	if err := c.updateOverlaySubnetAddressSet(subnet, false); err != nil {
+		klog.Errorf("failed to update overlay subnets address-set, %v", err)
+		return err
+	}
+
 	err := c.handleDeleteLogicalSwitch(subnet.Name)
 	if err != nil {
 		klog.Errorf("failed to delete logical switch %s %v", subnet.Name, err)
@@ -826,7 +836,7 @@ func (c *Controller) reconcileSubnet(subnet *kubeovnv1.Subnet) error {
 
 	if subnet.Name != c.config.NodeSwitch {
 		if err := c.reconcileGateway(subnet); err != nil {
-			klog.Errorf("reconcile centralized gateway for subnet %s failed, %v", subnet.Name, err)
+			klog.Errorf("reconcile gateway for subnet %s failed, %v", subnet.Name, err)
 			return err
 		}
 	}
@@ -895,10 +905,11 @@ func (c *Controller) reconcileGateway(subnet *kubeovnv1.Subnet) error {
 	} else {
 		// if gw is distributed remove activateGateway field
 		if subnet.Spec.GatewayType == kubeovnv1.GWDistributedType {
-			if subnet.Spec.GatewayNode == "" {
+			if subnet.Spec.GatewayNode == "" && subnet.Status.ActivateGateway == "" {
 				return nil
 			}
 			subnet.Spec.GatewayNode = ""
+			subnet.Status.ActivateGateway = ""
 			bytes, err := subnet.Status.Bytes()
 			if err != nil {
 				return err
@@ -908,8 +919,27 @@ func (c *Controller) reconcileGateway(subnet *kubeovnv1.Subnet) error {
 				return err
 			}
 
+			nodes, err := c.nodesLister.List(labels.Everything())
+			if err != nil {
+				klog.Errorf("failed to list nodes: %v", err)
+				return err
+			}
+			for _, node := range nodes {
+				pgName := getOverlaySubnetsPortGroupName(subnet.Name, node.Name)
+				if err = c.ovnClient.CreateNpPortGroup(pgName, subnet.Name, node.Name); err != nil {
+					klog.Errorf("failed to create port group for subnet %s and node %s, %v", subnet.Name, node.Name, err)
+					return err
+				}
+			}
+
+			_, idNameMap, err := c.ovnClient.ListLspForNodePortgroup()
+			if err != nil {
+				klog.Errorf("failed to list lsp info, %v", err)
+				return err
+			}
+
 			for _, pod := range pods {
-				if !isPodAlive(pod) || pod.Annotations[util.IpAddressAnnotation] == "" || pod.Annotations[util.LogicalSwitchAnnotation] != subnet.Name {
+				if !isPodAlive(pod) {
 					continue
 				}
 
@@ -927,15 +957,82 @@ func (c *Controller) reconcileGateway(subnet *kubeovnv1.Subnet) error {
 					klog.Errorf("failed to get node %s tunnel ip, %v", node.Name, err)
 					return err
 				}
-
 				nextHop := getNextHopByTunnelIP(nodeIP)
-				if pod.Annotations[util.NorthGatewayAnnotation] != "" {
-					nextHop = pod.Annotations[util.NorthGatewayAnnotation]
+
+				pgName := getOverlaySubnetsPortGroupName(subnet.Name, node.Name)
+				pgPorts, err := c.getPgPorts(idNameMap, pgName)
+				if err != nil {
+					klog.Errorf("failed to fetch ports for pg %v, %v", pgName, err)
+					return err
 				}
 
-				if err := c.ovnClient.AddStaticRoute(ovs.PolicySrcIP, pod.Annotations[util.IpAddressAnnotation], nextHop, c.config.ClusterRouter, util.NormalRouteType); err != nil {
-					klog.Errorf("add static route failed, %v", err)
+				changed := false
+				podNets, err := c.getPodKubeovnNets(pod)
+				if err != nil {
+					klog.Errorf("failed to get pod nets %v", err)
 					return err
+				}
+				for _, podNet := range podNets {
+					if !isOvnSubnet(podNet.Subnet) {
+						continue
+					}
+
+					if pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)] == "" || pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podNet.ProviderName)] != subnet.Name {
+						continue
+					}
+
+					if pod.Annotations[util.NorthGatewayAnnotation] != "" {
+						nextHop = pod.Annotations[util.NorthGatewayAnnotation]
+						exist, err := c.checkRouteExist(nextHop, pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)], ovs.PolicySrcIP)
+						if err != nil {
+							klog.Errorf("failed to get static route for subnet %v, error %v", subnet.Name, err)
+							return err
+						}
+						if exist {
+							continue
+						}
+
+						if err := c.ovnClient.AddStaticRoute(ovs.PolicySrcIP, pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)], nextHop, c.config.ClusterRouter, util.NormalRouteType); err != nil {
+							klog.Errorf("add static route failed, %v", err)
+							return err
+						}
+					} else {
+						portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, podNet.ProviderName)
+						if !util.IsStringIn(portName, pgPorts) {
+							klog.Infof("new port %v should add to port group %v", portName, pgName)
+							pgPorts = append(pgPorts, portName)
+							changed = true
+
+							if err = c.ovnClient.SetPortsToPortGroup(pgName, pgPorts); err != nil {
+								klog.Errorf("failed to set ports to port group %v, %v", pgName, err)
+								return err
+							}
+						}
+					}
+				}
+
+				if pod.Annotations[util.NorthGatewayAnnotation] != "" {
+					continue
+				}
+				if changed {
+					for _, nextHopIp := range strings.Split(nextHop, ",") {
+						if nextHopIp == "" {
+							continue
+						}
+
+						ipSuffix := "ip4"
+						subnetAsName := getOverlaySubnetsAddressSetName(c.config.ClusterRouter, kubeovnv1.ProtocolIPv4)
+						if util.CheckProtocol(nextHopIp) == kubeovnv1.ProtocolIPv6 {
+							ipSuffix = "ip6"
+							subnetAsName = getOverlaySubnetsAddressSetName(c.config.ClusterRouter, kubeovnv1.ProtocolIPv6)
+						}
+						pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
+						match := fmt.Sprintf("%s.src == $%s && %s.dst != $%s", ipSuffix, pgAs, ipSuffix, subnetAsName)
+						if err = c.ovnClient.AddPolicyRoute(c.config.ClusterRouter, util.PodRouterPolicyPriority, match, "reroute", nextHopIp); err != nil {
+							klog.Errorf("failed to add logical router policy for port-group address-set %s: %v", pgAs, err)
+							return err
+						}
+					}
 				}
 			}
 			return c.deleteStaticRoute(subnet.Spec.CIDRBlock, c.config.ClusterRouter, subnet)
@@ -1378,7 +1475,7 @@ func (c *Controller) deleteEcmpRouteForNode(subnet *kubeovnv1.Subnet) error {
 					continue
 				}
 
-				exist, err := c.checkNodeEcmpRouteExist(ip, cidrBlock)
+				exist, err := c.checkRouteExist(ip, cidrBlock, ovs.PolicySrcIP)
 				if err != nil {
 					klog.Errorf("get ecmp static route for subnet %v, error %v", subnet.Name, err)
 					break
@@ -1394,5 +1491,137 @@ func (c *Controller) deleteEcmpRouteForNode(subnet *kubeovnv1.Subnet) error {
 			}
 		}
 	}
+	return nil
+}
+
+func (c *Controller) getPgPorts(idNameMap map[string]string, pgName string) ([]string, error) {
+	var portNames []string
+	pgPorts, err := c.ovnClient.ListPgPorts(pgName)
+	if err != nil {
+		klog.Errorf("failed to fetch ports for pg %v, %v", pgName, err)
+		return portNames, err
+	}
+
+	for _, portId := range pgPorts {
+		if portName, ok := idNameMap[portId]; ok {
+			portNames = append(portNames, portName)
+		}
+	}
+
+	return portNames, nil
+}
+
+func getOverlaySubnetsPortGroupName(subnetName, nodeName string) string {
+	return strings.Replace(fmt.Sprintf("%s.%s", subnetName, nodeName), "-", ".", -1)
+}
+
+func getOverlaySubnetsAddressSetName(router, protocol string) string {
+	return strings.Replace(fmt.Sprintf("%s.overlay.subnets.%s", router, protocol), "-", ".", -1)
+}
+
+func (c *Controller) createOverlaySubnetsAddressSet() error {
+	var v4CIDRs, v6CIDRs []string
+	subnetList, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets %v", err)
+		return err
+	}
+
+	for _, subnet := range subnetList {
+		if subnet.Spec.Vlan != "" || subnet.Spec.Vpc != util.DefaultVpc || subnet.Name == c.config.NodeSwitch {
+			continue
+		}
+
+		for _, cidrBlock := range strings.Split(subnet.Spec.CIDRBlock, ",") {
+			protocol := util.CheckProtocol(cidrBlock)
+
+			switch protocol {
+			case kubeovnv1.ProtocolIPv4:
+				v4CIDRs = append(v4CIDRs, cidrBlock)
+			case kubeovnv1.ProtocolIPv6:
+				v6CIDRs = append(v6CIDRs, cidrBlock)
+			}
+		}
+	}
+
+	subnetAsIPv4 := getOverlaySubnetsAddressSetName(c.config.ClusterRouter, kubeovnv1.ProtocolIPv4)
+	subnetAsIPv6 := getOverlaySubnetsAddressSetName(c.config.ClusterRouter, kubeovnv1.ProtocolIPv6)
+	if err = c.ovnClient.CreateAddressSet(subnetAsIPv4); err != nil {
+		klog.Errorf("failed to create address set for IPv4 overlay subnets: %v", err)
+		return err
+	}
+	if err = c.ovnClient.CreateAddressSet(subnetAsIPv6); err != nil {
+		klog.Errorf("failed to create address set for IPv6 overlay subnets: %v", err)
+		return err
+	}
+
+	if err = c.ovnClient.SetAddressesToAddressSet(v4CIDRs, subnetAsIPv4); err != nil {
+		klog.Errorf("failed to set IPv4 overlay address_set, %v", err)
+		return err
+	}
+	if err = c.ovnClient.SetAddressesToAddressSet(v6CIDRs, subnetAsIPv6); err != nil {
+		klog.Errorf("failed to set IPv6 overlay address_set, %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) updateOverlaySubnetAddressSet(subnet *kubeovnv1.Subnet, isAdd bool) error {
+	var err error
+	if subnet.Spec.Vlan != "" || subnet.Spec.Vpc != util.DefaultVpc || subnet.Name == c.config.NodeSwitch {
+		return nil
+	}
+
+	subnetAsIPv4 := getOverlaySubnetsAddressSetName(c.config.ClusterRouter, kubeovnv1.ProtocolIPv4)
+	subnetAsIPv6 := getOverlaySubnetsAddressSetName(c.config.ClusterRouter, kubeovnv1.ProtocolIPv6)
+	for _, cidrBlock := range strings.Split(subnet.Spec.CIDRBlock, ",") {
+		protocol := util.CheckProtocol(cidrBlock)
+
+		switch protocol {
+		case kubeovnv1.ProtocolIPv4:
+			err = c.updateAddressSet(subnetAsIPv4, cidrBlock, isAdd)
+		case kubeovnv1.ProtocolIPv6:
+			err = c.updateAddressSet(subnetAsIPv6, cidrBlock, isAdd)
+		}
+		if err != nil {
+			klog.Errorf("failed to update address_set for subnet %v, %v", subnet.Name, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) updateAddressSet(addressSetName, cidr string, isAdd bool) error {
+	var err error
+	var addresses []string
+
+	if addresses, err = c.ovnClient.ListAddressesByName(addressSetName); err != nil {
+		klog.Errorf("failed to get addresses for addressSet %v: %v", addressSetName, err)
+		return err
+	}
+	exist := util.ContainsString(addresses, cidr)
+
+	if isAdd {
+		if exist {
+			return nil
+		}
+		addresses = append(addresses, cidr)
+		if err = c.ovnClient.SetAddressesToAddressSet(addresses, addressSetName); err != nil {
+			klog.Errorf("failed to set address %v to address_set %v, %v", cidr, addressSetName, err)
+			return err
+		}
+	} else {
+		if !exist {
+			return nil
+		}
+
+		if err = c.ovnClient.RemoveAddressSetAddresses(addressSetName, cidr); err != nil {
+			klog.Errorf("failed to delete address %v from address_set %v, %v", cidr, addressSetName, err)
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -122,6 +122,7 @@ const (
 	EcmpRouteType   = "ecmp"
 	NormalRouteType = "normal"
 
+	PodRouterPolicyPriority  = 20000
 	NodeRouterPolicyPriority = 30000
 
 	OffloadType  = "offload-port"


### PR DESCRIPTION
#### What type of this PR
- API changes
####
1. Add policy-route for distributed subnet in default vpc
2. Add port-group based on combination of subnet and node, add pod's ports to port-group on pod's node
3. Add overlay subnet address-set to avoid pod traffic when pod visit pod of overlay subnet

#### Which issue(s) this PR fixes:
Fixes #1256



