### PR TITLE
fix: only log matched svc with np

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -783,10 +783,10 @@ func (c *Controller) svcMatchNetworkPolicies(svc *corev1.Service) ([]string, err
 		for _, np := range nps {
 			if isPodMatchNetworkPolicy(pod, *podNs, np, np.Namespace) {
 				match = append(match, fmt.Sprintf("%s/%s", np.Namespace, np.Name))
+				klog.V(3).Infof("svc %s/%s match np %s/%s", svc.Namespace, svc.Name, np.Namespace, np.Name)
 			}
 		}
 	}
-	klog.Infof("match svc is %v", match)
 	return match, nil
 }
 


### PR DESCRIPTION
When kube-ovn-controller starts in a cluster with lots of services, the previous empty match log will flood the screen:
```
I0208 00:31:03.804692       1 network_policy.go:789] match svc is []
I0208 00:31:03.804757       1 network_policy.go:789] match svc is []
I0208 00:31:03.804775       1 network_policy.go:789] match svc is []
I0208 00:31:03.804785       1 network_policy.go:789] match svc is []
I0208 00:31:03.804793       1 network_policy.go:789] match svc is []
I0208 00:31:03.804802       1 network_policy.go:789] match svc is []
I0208 00:31:03.804810       1 network_policy.go:789] match svc is []
I0208 00:31:03.804821       1 network_policy.go:789] match svc is []
I0208 00:31:03.804832       1 network_policy.go:789] match svc is []
```

#### What type of this PR
- Bug fixes



