### PR TITLE
Temporarily comment out the compile and upload of the centos8 compile…

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -81,11 +81,11 @@ jobs:
           name: centos7-compile
           path: centos7-compile.tar
 
-      - name: Upload centos8-compile image to artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: centos8-compile
-          path: centos8-compile.tar
+#      - name: Upload centos8-compile image to artifact
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: centos8-compile
+#          path: centos8-compile.tar
 
   single-e2e:
     needs: build
@@ -1156,17 +1156,17 @@ jobs:
         with:
           name: centos7-compile
 
-      - name: Download centos8-compile image
-        uses: actions/Download-artifact@v2
-        with:
-          name: centos8-compile
+#      - name: Download centos8-compile image
+#        uses: actions/Download-artifact@v2
+#        with:
+#          name: centos8-compile
 
       - name: Load Image
         run: |
           docker load --input kube-ovn.tar
           docker load --input vpc-nat-gateway.tar
           docker load --input centos7-compile.tar
-          docker load --input centos8-compile.tar
+#          docker load --input centos8-compile.tar
 
       - name: Security Scan
         run: |
@@ -1194,8 +1194,8 @@ jobs:
           docker tag kubeovn/vpc-nat-gateway:$TAG kubeovn/vpc-nat-gateway:$TAG-x86
           docker tag kubeovn/centos7-compile:$TAG kubeovn/centos7-compile-dev:$TAG-x86
           docker tag kubeovn/centos7-compile:$TAG kubeovn/centos7-compile:$TAG-x86
-          docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile-dev:$TAG-x86
-          docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile:$TAG-x86
+#          docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile-dev:$TAG-x86
+#          docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile:$TAG-x86
           docker images
           docker push kubeovn/kube-ovn:$TAG-x86
           docker push kubeovn/kube-ovn-dev:$COMMIT-x86
@@ -1203,5 +1203,5 @@ jobs:
           docker push kubeovn/vpc-nat-gateway-dev:$COMMIT-x86
           docker push kubeovn/centos7-compile:$TAG-x86
           docker push kubeovn/centos7-compile-dev:$TAG-x86
-          docker push kubeovn/centos8-compile:$TAG-x86
-          docker push kubeovn/centos8-compile-dev:$TAG-x86
+#          docker push kubeovn/centos8-compile:$TAG-x86
+#          docker push kubeovn/centos8-compile-dev:$TAG-x86

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ release: lint build-go
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile dist/images/
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG) -o type=docker -f dist/images/vpcnatgateway/Dockerfile dist/images/vpcnatgateway
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/centos7-compile:$(RELEASE_TAG) -o type=docker -f dist/images/compile/centos7/Dockerfile fastpath/
-	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/centos8-compile:$(RELEASE_TAG) -o type=docker -f dist/images/compile/centos8/Dockerfile fastpath/
+#	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/centos8-compile:$(RELEASE_TAG) -o type=docker -f dist/images/compile/centos8/Dockerfile fastpath/
 
 .PHONY: release-arm
 release-arm: build-go-arm
@@ -73,7 +73,7 @@ tar:
 	docker save $(REGISTRY)/kube-ovn:$(RELEASE_TAG) -o kube-ovn.tar
 	docker save $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG) -o vpc-nat-gateway.tar
 	docker save $(REGISTRY)/centos7-compile:$(RELEASE_TAG) -o centos7-compile.tar
-	docker save $(REGISTRY)/centos8-compile:$(RELEASE_TAG) -o centos8-compile.tar
+#	docker save $(REGISTRY)/centos8-compile:$(RELEASE_TAG) -o centos8-compile.tar
 
 .PHONY: base-tar-amd64
 base-tar-amd64:


### PR DESCRIPTION
Centos8 container's repo mirrorlists are deprecated now as described in https://github.com/CentOS/sig-cloud-instance-images/issues/190
Now there is no perfect solution at the moment and the configuration what I can compile on my system does not work in GitHub Actions.
So temporarily I comment out the process of compiling and uploading for centos8. So that our daily building will not be affected.
I'll be back.