### PR TITLE
kube-ovn CNI配置文件名字可配置

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -87,7 +87,7 @@ func mvCNIConf(confName string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	cniConfPath := fmt.Sprintf("/etc/cni/net.d/%s", confName)
 	return os.WriteFile(cniConfPath, data, 0444)
 }

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -75,19 +75,21 @@ func CmdMain() {
 	kubeovnInformerFactory.Start(stopCh)
 	go ctl.Run(stopCh)
 	go daemon.RunServer(config, ctl)
-	if err := mvCNIConf(); err != nil {
+	if err := mvCNIConf(config.CniConfName); err != nil {
 		klog.Fatalf("failed to mv cni conf, %v", err)
 	}
 	http.Handle("/metrics", promhttp.Handler())
 	klog.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", config.PprofPort), nil))
 }
 
-func mvCNIConf() error {
+func mvCNIConf(confName string) error {
 	data, err := os.ReadFile("/kube-ovn/01-kube-ovn.conflist")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile("/etc/cni/net.d/01-kube-ovn.conflist", data, 0444)
+	
+	cniConfPath := fmt.Sprintf("/etc/cni/net.d/%s", confName)
+	return os.WriteFile(cniConfPath, data, 0444)
 }
 
 func Retry(attempts int, sleep int, f func(configuration *daemon.Configuration) error, ctrl *daemon.Configuration) (err error) {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -42,6 +42,7 @@ type Configuration struct {
 	EncapChecksum           bool
 	PprofPort               int
 	NetworkType             string
+	CniConfName             string
 	DefaultProviderName     string
 	DefaultInterfaceName    string
 	ExternalGatewayConfigNS string
@@ -64,6 +65,7 @@ func ParseFlags(nicBridgeMappings map[string]string) (*Configuration, error) {
 		argPprofPort             = pflag.Int("pprof-port", 10665, "The port to get profiling data")
 
 		argsNetworkType            = pflag.String("network-type", "geneve", "The ovn network type")
+		argsCniConfName            = pflag.String("cni-conf-name", "01-kube-ovn.conflist", "Specify the name of kube ovn conflist name in dir /etc/cni/net.d/, default: 01-kube-ovn.conflist")
 		argsDefaultProviderName    = pflag.String("default-provider-name", "provider", "The vlan or vxlan type default provider interface name")
 		argsDefaultInterfaceName   = pflag.String("default-interface-name", "", "The default host interface name in the vlan/vxlan type")
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")
@@ -109,6 +111,7 @@ func ParseFlags(nicBridgeMappings map[string]string) (*Configuration, error) {
 		NodeLocalDnsIP:          *argNodeLocalDnsIP,
 		EncapChecksum:           *argEncapChecksum,
 		NetworkType:             *argsNetworkType,
+		CniConfName:             *argsCniConfName,
 		DefaultProviderName:     *argsDefaultProviderName,
 		DefaultInterfaceName:    *argsDefaultInterfaceName,
 		ExternalGatewayConfigNS: *argExternalGatewayConfigNS,


### PR DESCRIPTION
- Bug fixes

Fixes 1314 https://github.com/kubeovn/kube-ovn/issues/1314

验证如下：
edit kube-ovn-cni ds args 加上如下命令
![image](https://user-images.githubusercontent.com/39080750/155255609-04eec8b7-b2e3-40c0-9092-7286224b12e4.png)

查看 /etc/cni/net.d/ 下 kube-ovn cni 文件如下：
![image](https://user-images.githubusercontent.com/39080750/155255680-c0be8559-4b89-43be-9b1e-555a3c862a35.png)



