### PR TITLE
fix statefulset Pod deletion

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -270,7 +270,7 @@ jobs:
         run: |
           sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
           sh dist/images/cleanup.sh
-      
+
       - name: Check Node Network
         run: |
           sh -c '
@@ -366,6 +366,24 @@ jobs:
         run: |
           docker load --input kube-ovn.tar
           sudo make kind-install
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17
+        id: go
+
+      - name: Run E2E
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo chmod 666 /home/runner/.kube/config
+          make e2e
+
+      - name: Cleanup
+        run: |
+          sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
+          sh dist/images/cleanup.sh
 
   ipv6-e2e:
     needs: build

--- a/test/e2e/underlay/underlay.go
+++ b/test/e2e/underlay/underlay.go
@@ -250,9 +250,10 @@ var _ = Describe("[Underlay]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("validate OVN logical router port")
-			ovnPods, err := f.KubeClientSet.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: "app=ovn-central"})
+			ovnPods, err := f.KubeClientSet.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: "app=ovn-central,ovn-nb-leader=true"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ovnPods).NotTo(BeNil())
+			Expect(ovnPods.Items).To(HaveLen(1))
 
 			ovnPod := ovnPods.Items[0]
 			lsp := fmt.Sprintf("%s-%s", name, util.DefaultVpc)
@@ -614,7 +615,7 @@ var _ = Describe("[Underlay]", func() {
 
 					By("create pods")
 					name := f.GetName()
-					pods := make([]*corev1.Pod, 2)
+					pods := make([]*corev1.Pod, len(nodes))
 					var autoMount bool
 					for i := range nodes {
 						pods[i] = &corev1.Pod{


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

Fix statefulset Pod deletion introduced in PR #1274 . This patch also adds e2e testing for the 3-master cluster.

As static routes have been totally replaced by logical router policies in the master branch, the target branched is release-1.9.