### PR TITLE
fix underlay subnet in custom VPC

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -607,7 +607,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		return err
 	}
 
-	needRouter := (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != util.DefaultVpc
+	needRouter := subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway
 	if !exist {
 		subnet.Status.EnsureStandardConditions()
 		// If multiple namespace use same ls name, only first one will success


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

Do not connect the logical router for underlay subnets in a custom VPC. Users can use the logical gateway feature on need.