### PR TITLE
fix: continue of deletion for del pod failed when can't found vpc or subnet

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -587,7 +587,9 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 				continue
 			}
 			subnet, err := c.subnetsLister.Get(address.Subnet.Name)
-			if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			} else if err != nil {
 				return err
 			}
 			vpc, err := c.vpcsLister.Get(subnet.Spec.Vpc)

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -591,7 +591,9 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 				return err
 			}
 			vpc, err := c.vpcsLister.Get(subnet.Spec.Vpc)
-			if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			} else if err != nil {
 				return err
 			}
 			if err := c.ovnClient.DeleteStaticRoute(address.Ip, vpc.Status.Router); err != nil {

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alauda/felix/ipsets"
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
+        k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -204,7 +205,9 @@ func (c *Controller) removeEgressConfig(subnet, ip string) error {
 	}
 
 	podSubnet, err := c.subnetsLister.Get(subnet)
-	if err != nil {
+	if k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
 		klog.Errorf("failed to get subnet %s: %+v", subnet, err)
 		return err
 	}

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -13,7 +13,7 @@ import (
 	"github.com/alauda/felix/ipsets"
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
-        k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"


### PR DESCRIPTION
#### What type of this PR
- Bug fixes


fix: continue of deletion for del pod failed when can't found vpc or subnet;

will add webhook later.


#### Which issue(s) this PR fixes:
#1303 
Fixes #(1303)



