### PR TITLE
log: rotate all logs in kube-ovn-cni and add compress

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1906,6 +1906,7 @@ spec:
           - --logtostderr=false
           - --alsologtostderr=true
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
+          - --log_file_max_size=0
           env:
             - name: ENABLE_SSL
               value: "$ENABLE_SSL"
@@ -2024,6 +2025,7 @@ spec:
           - --logtostderr=false
           - --alsologtostderr=true
           - --log_file=/var/log/kube-ovn/kube-ovn-cni.log
+          - --log_file_max_size=0
         securityContext:
           runAsUser: 0
           privileged: true
@@ -2056,6 +2058,10 @@ spec:
             mountPropagation: HostToContainer
           - mountPath: /var/log/kube-ovn
             name: kube-ovn-log
+          - mountPath: /var/log/openvswitch
+            name: host-log-ovs
+          - mountPath: /var/log/ovn
+            name: host-log-ovn
           - mountPath: /etc/localtime
             name: localtime
           - mountPath: /tmp
@@ -2104,9 +2110,15 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
+        - name: host-log-ovs
+          hostPath:
+            path: /var/log/openvswitch
         - name: kube-ovn-log
           hostPath:
             path: /var/log/kube-ovn
+        - name: host-log-ovn
+          hostPath:
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -2149,6 +2161,7 @@ spec:
           - --logtostderr=false
           - --alsologtostderr=true
           - --log_file=/var/log/kube-ovn/kube-ovn-pinger.log
+          - --log_file_max_size=0
           imagePullPolicy: $IMAGE_PULL_POLICY
           securityContext:
             runAsUser: 0

--- a/dist/images/logrotate/kubeovn
+++ b/dist/images/logrotate/kubeovn
@@ -5,18 +5,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without warranty of any kind.
 
-/var/log/openvswitch/*.log {
+/var/log/kube-ovn/*.log {
     daily
+    copytruncate
     rotate 7
     compress
     sharedscripts
     missingok
     postrotate
-        # Tell Open vSwitch daemons to reopen their log files
-        if [ -d /var/run/openvswitch ]; then
-            for ctl in /var/run/openvswitch/*.ctl; do
-                ovs-appctl -t "$ctl" vlog/reopen 2>/dev/null || :
-            done
-        fi
     endscript
 }

--- a/dist/images/logrotate/ovn
+++ b/dist/images/logrotate/ovn
@@ -7,6 +7,7 @@
 
 /var/log/ovn/*.log {
     daily
+    rotate 7
     compress
     sharedscripts
     missingok

--- a/dist/images/ovs-healthcheck.sh
+++ b/dist/images/ovs-healthcheck.sh
@@ -4,12 +4,6 @@ shopt -s expand_aliases
 
 OVN_DB_IPS=${OVN_DB_IPS:-}
 ENABLE_SSL=${ENABLE_SSL:-false}
-LOG_ROTATE=${LOG_ROTATE:-false}
-
-if [[ "$LOG_ROTATE" == "true" ]]; then
-  logrotate /etc/logrotate.d/openvswitch
-  logrotate /etc/logrotate.d/ovn
-fi
 
 function gen_conn_str {
   if [[ -z "${OVN_DB_IPS}" ]]; then

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -194,6 +194,12 @@ spec:
             - mountPath: /var/run/netns
               name: host-ns
               mountPropagation: HostToContainer
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
+            - mountPath: /var/log/openvswitch
+              name: host-log-ovs
+            - mountPath: /var/log/ovn
+              name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
           livenessProbe:
@@ -240,6 +246,15 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
+        - name: host-log-ovs
+          hostPath:
+            path: /var/log/openvswitch
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
+        - name: host-log-ovn
+          hostPath:
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime


### PR DESCRIPTION
Previous logrotate config will discard all old ovs/ovn logs when rotating. Now reserve last 7 days logs and also rotate kube-ovn-controller/kube-ovn-cni/kube-ovn-pinger logs in the same way


