### PR TITLE
fix SNAT/PR on Pod startup

### DIFF
--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -180,7 +180,7 @@ func (c *Controller) setPolicyRouting() error {
 }
 
 func (c *Controller) addEgressConfig(subnet *kubeovnv1.Subnet, ip string) error {
-	if subnet.Spec.Vlan != "" ||
+	if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) ||
 		subnet.Spec.GatewayType != kubeovnv1.GWDistributedType ||
 		subnet.Spec.Vpc != util.DefaultVpc {
 		return nil
@@ -212,7 +212,7 @@ func (c *Controller) removeEgressConfig(subnet, ip string) error {
 		return err
 	}
 
-	if podSubnet.Spec.Vlan != "" ||
+	if (podSubnet.Spec.Vlan != "" && !podSubnet.Spec.LogicalGateway) ||
 		podSubnet.Spec.GatewayType != kubeovnv1.GWDistributedType ||
 		podSubnet.Spec.Vpc != util.DefaultVpc {
 		return nil
@@ -674,7 +674,7 @@ func (c *Controller) setExGateway() error {
 
 func (c *Controller) getLocalPodIPsNeedNAT(protocol string) ([]string, error) {
 	var localPodIPs []string
-	hostname := os.Getenv(util.HostnameEnv)
+	nodeName := os.Getenv(util.HostnameEnv)
 	allPods, err := c.podsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("list pods failed, %+v", err)
@@ -683,6 +683,7 @@ func (c *Controller) getLocalPodIPsNeedNAT(protocol string) ([]string, error) {
 	for _, pod := range allPods {
 		if pod.Spec.HostNetwork ||
 			pod.DeletionTimestamp != nil ||
+			pod.Spec.NodeName != nodeName ||
 			pod.Annotations[util.LogicalSwitchAnnotation] == "" ||
 			pod.Annotations[util.IpAddressAnnotation] == "" {
 			continue
@@ -693,36 +694,31 @@ func (c *Controller) getLocalPodIPsNeedNAT(protocol string) ([]string, error) {
 			continue
 		}
 
-		if subnet.Spec.NatOutgoing &&
-			subnet.Spec.Vpc == util.DefaultVpc &&
-			subnet.Spec.GatewayType == kubeovnv1.GWDistributedType &&
-			pod.Spec.NodeName == hostname {
-			if pod.Status.Phase == v1.PodPending {
-				var containerCreating bool
-				for _, s := range pod.Status.ContainerStatuses {
-					if s.State.Waiting != nil && s.State.Waiting.Reason == "ContainerCreating" {
-						containerCreating = true
-						break
-					}
-				}
-				if containerCreating {
-					ipv4, ipv6 := util.SplitStringIP(pod.Annotations[util.IpAddressAnnotation])
-					if ipv4 != "" && protocol == kubeovnv1.ProtocolIPv4 {
-						localPodIPs = append(localPodIPs, ipv4)
-					}
-					if ipv6 != "" && protocol == kubeovnv1.ProtocolIPv6 {
-						localPodIPs = append(localPodIPs, ipv6)
-					}
-				}
-			} else if len(pod.Status.PodIPs) != 0 {
-				if len(pod.Status.PodIPs) == 2 && protocol == kubeovnv1.ProtocolIPv6 {
-					localPodIPs = append(localPodIPs, pod.Status.PodIPs[1].IP)
-				} else if util.CheckProtocol(pod.Status.PodIP) == protocol {
-					localPodIPs = append(localPodIPs, pod.Status.PodIP)
-				}
+		if !subnet.Spec.NatOutgoing ||
+			subnet.Spec.Vpc != util.DefaultVpc ||
+			subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
+			continue
+		}
+		if subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway {
+			continue
+		}
+
+		if len(pod.Status.PodIPs) != 0 {
+			if len(pod.Status.PodIPs) == 2 && protocol == kubeovnv1.ProtocolIPv6 {
+				localPodIPs = append(localPodIPs, pod.Status.PodIPs[1].IP)
+			} else if util.CheckProtocol(pod.Status.PodIP) == protocol {
+				localPodIPs = append(localPodIPs, pod.Status.PodIP)
+			}
+		} else {
+			ipv4, ipv6 := util.SplitStringIP(pod.Annotations[util.IpAddressAnnotation])
+			if ipv4 != "" && protocol == kubeovnv1.ProtocolIPv4 {
+				localPodIPs = append(localPodIPs, ipv4)
+			}
+			if ipv6 != "" && protocol == kubeovnv1.ProtocolIPv6 {
+				localPodIPs = append(localPodIPs, ipv6)
 			}
 		}
-		attachIps, err := c.getAttachmentLocalPodIPsNeedNAT(pod, hostname, protocol)
+		attachIps, err := c.getAttachmentLocalPodIPsNeedNAT(pod, nodeName, protocol)
 		if len(attachIps) != 0 && err == nil {
 			localPodIPs = append(localPodIPs, attachIps...)
 		}
@@ -739,11 +735,12 @@ func (c *Controller) getLocalPodIPsNeedPR(protocol string) (map[policyRouteMeta]
 		return nil, err
 	}
 
-	hostname := os.Getenv(util.HostnameEnv)
+	nodeName := os.Getenv(util.HostnameEnv)
 	localPodIPs := make(map[policyRouteMeta][]string)
 	for _, pod := range allPods {
 		if pod.Spec.HostNetwork ||
 			pod.DeletionTimestamp != nil ||
+			pod.Spec.NodeName != nodeName ||
 			pod.Annotations[util.LogicalSwitchAnnotation] == "" ||
 			pod.Annotations[util.IpAddressAnnotation] == "" {
 			continue
@@ -755,52 +752,49 @@ func (c *Controller) getLocalPodIPsNeedPR(protocol string) (map[policyRouteMeta]
 			continue
 		}
 
-		if subnet.Spec.ExternalEgressGateway != "" &&
-			subnet.Spec.Vpc == util.DefaultVpc &&
-			subnet.Spec.GatewayType == kubeovnv1.GWDistributedType &&
-			pod.Spec.NodeName == hostname {
-			ips := make([]string, 0, 2)
-			if pod.Status.Phase == v1.PodPending {
-				var containerCreating bool
-				for _, s := range pod.Status.ContainerStatuses {
-					if s.State.Waiting != nil && s.State.Waiting.Reason == "ContainerCreating" {
-						containerCreating = true
-						break
-					}
-				}
-				if containerCreating {
-					ipv4, ipv6 := util.SplitStringIP(pod.Annotations[util.IpAddressAnnotation])
-					if ipv4 != "" && protocol == kubeovnv1.ProtocolIPv4 {
-						ips = append(ips, ipv4)
-					}
-					if ipv6 != "" && protocol == kubeovnv1.ProtocolIPv6 {
-						ips = append(ips, ipv6)
-					}
-				}
-			} else if len(pod.Status.PodIPs) != 0 {
-				for _, ip := range pod.Status.PodIPs {
-					ips = append(ips, ip.IP)
-				}
+		if !subnet.Spec.NatOutgoing ||
+			subnet.Spec.Vpc != util.DefaultVpc ||
+			subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
+			continue
+		}
+		if subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway {
+			continue
+		}
+
+		ips := make([]string, 0, 2)
+		if len(pod.Status.PodIPs) != 0 {
+			if len(pod.Status.PodIPs) == 2 && protocol == kubeovnv1.ProtocolIPv6 {
+				ips = append(ips, pod.Status.PodIPs[1].IP)
+			} else if util.CheckProtocol(pod.Status.PodIP) == protocol {
+				ips = append(ips, pod.Status.PodIP)
+			}
+		} else {
+			ipv4, ipv6 := util.SplitStringIP(pod.Annotations[util.IpAddressAnnotation])
+			if ipv4 != "" && protocol == kubeovnv1.ProtocolIPv4 {
+				ips = append(ips, ipv4)
+			}
+			if ipv6 != "" && protocol == kubeovnv1.ProtocolIPv6 {
+				ips = append(ips, ipv6)
+			}
+		}
+
+		if len(ips) != 0 {
+			meta := policyRouteMeta{
+				priority: subnet.Spec.PolicyRoutingPriority,
+				tableID:  subnet.Spec.PolicyRoutingTableID,
 			}
 
-			if len(ips) != 0 {
-				meta := policyRouteMeta{
-					priority: subnet.Spec.PolicyRoutingPriority,
-					tableID:  subnet.Spec.PolicyRoutingTableID,
-				}
-
-				egw := strings.Split(subnet.Spec.ExternalEgressGateway, ",")
-				if util.CheckProtocol(egw[0]) == protocol {
-					meta.gateway = egw[0]
-					if util.CheckProtocol(ips[0]) == protocol {
-						localPodIPs[meta] = append(localPodIPs[meta], ips[0])
-					} else {
-						localPodIPs[meta] = append(localPodIPs[meta], ips[1])
-					}
-				} else if len(egw) == 2 && len(ips) == 2 {
-					meta.gateway = egw[1]
+			egw := strings.Split(subnet.Spec.ExternalEgressGateway, ",")
+			if util.CheckProtocol(egw[0]) == protocol {
+				meta.gateway = egw[0]
+				if util.CheckProtocol(ips[0]) == protocol {
+					localPodIPs[meta] = append(localPodIPs[meta], ips[0])
+				} else {
 					localPodIPs[meta] = append(localPodIPs[meta], ips[1])
 				}
+			} else if len(egw) == 2 && len(ips) == 2 {
+				meta.gateway = egw[1]
+				localPodIPs[meta] = append(localPodIPs[meta], ips[1])
 			}
 		}
 	}
@@ -817,24 +811,13 @@ func (c *Controller) getSubnetsNeedNAT(protocol string) ([]string, error) {
 	}
 
 	for _, subnet := range subnets {
-		if subnet.Spec.Vpc == util.DefaultVpc &&
+		if subnet.DeletionTimestamp == nil &&
+			subnet.Spec.NatOutgoing &&
+			(subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) &&
 			subnet.Spec.GatewayType == kubeovnv1.GWCentralizedType &&
 			util.GatewayContains(subnet.Spec.GatewayNode, c.config.NodeName) &&
-			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) &&
-			subnet.Spec.NatOutgoing &&
-			subnet.Spec.Vlan == "" {
-			// centralized subnet with gatewayNode assigned designative ip processed seperately
-			found := false
-			for _, gw := range strings.Split(subnet.Spec.GatewayNode, ",") {
-				if strings.Contains(gw, ":") && util.GatewayContains(gw, c.config.NodeName) {
-					found = true
-					break
-				}
-			}
-			if found {
-				continue
-			}
-
+			subnet.Spec.Vpc == util.DefaultVpc &&
+			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) {
 			cidrBlock := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
 			subnetsNeedNat = append(subnetsNeedNat, cidrBlock)
 		}
@@ -852,12 +835,12 @@ func (c *Controller) getSubnetsNeedPR(protocol string) (map[policyRouteMeta]stri
 
 	for _, subnet := range subnets {
 		if subnet.DeletionTimestamp == nil &&
-			subnet.Spec.Vpc == util.DefaultVpc &&
+			subnet.Spec.ExternalEgressGateway != "" &&
+			(subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) &&
 			subnet.Spec.GatewayType == kubeovnv1.GWCentralizedType &&
 			util.GatewayContains(subnet.Spec.GatewayNode, c.config.NodeName) &&
-			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) &&
-			subnet.Spec.ExternalEgressGateway != "" &&
-			subnet.Spec.Vlan == "" {
+			subnet.Spec.Vpc == util.DefaultVpc &&
+			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) {
 			meta := policyRouteMeta{
 				priority: subnet.Spec.PolicyRoutingPriority,
 				tableID:  subnet.Spec.PolicyRoutingTableID,
@@ -1002,7 +985,11 @@ func (c *Controller) getEgressNatIpByNode(nodeName string) (map[string]string, e
 	}
 
 	for _, subnet := range subnetList {
-		if subnet.Spec.Vlan != "" || subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType || !subnet.Spec.NatOutgoing || subnet.Spec.GatewayNode == "" || !util.GatewayContains(subnet.Spec.GatewayNode, nodeName) {
+		if !subnet.Spec.NatOutgoing ||
+			(subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) ||
+			subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType ||
+			!util.GatewayContains(subnet.Spec.GatewayNode, nodeName) ||
+			subnet.Spec.Vpc != util.DefaultVpc {
 			continue
 		}
 
@@ -1085,7 +1072,7 @@ func getIptablesRuleNum(table, chain, rule, dstNatIp string) (string, error) {
 	return num, nil
 }
 
-func (c *Controller) getAttachmentLocalPodIPsNeedNAT(pod *v1.Pod, hostname, protocol string) ([]string, error) {
+func (c *Controller) getAttachmentLocalPodIPsNeedNAT(pod *v1.Pod, nodeName, protocol string) ([]string, error) {
 	var attachPodIPs []string
 
 	attachNets, err := util.ParsePodNetworkAnnotation(pod.Annotations[util.AttachmentNetworkAnnotation], pod.Namespace)
@@ -1105,7 +1092,7 @@ func (c *Controller) getAttachmentLocalPodIPsNeedNAT(pod *v1.Pod, hostname, prot
 			if subnet.Spec.NatOutgoing &&
 				subnet.Spec.Vpc == util.DefaultVpc &&
 				subnet.Spec.GatewayType == kubeovnv1.GWDistributedType &&
-				pod.Spec.NodeName == hostname {
+				pod.Spec.NodeName == nodeName {
 				ipv4, ipv6 := util.SplitStringIP(pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, provider)])
 				if ipv4 != "" && protocol == kubeovnv1.ProtocolIPv4 {
 					attachPodIPs = append(attachPodIPs, ipv4)


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

Fixes #732.

How to reproduce the bug:

Generate Job resources using the following shell script:

```sh
#!/bin/bash

for ((i=1;i<=50;i++)); do
cat <<EOF > job-snat-$i.yml
apiVersion: batch/v1
kind: Job
metadata:
  name: job-snat-$i
spec:
  template:
    spec:
      containers:
      - name: nc
        image: kubeovn/kube-ovn:v1.10.0
        command:
        - nc
        - -v
        - -z
        - -w
        - "1"
        - 192.168.128.1
        - "22"
      restartPolicy: Never
  backoffLimit: 0
EOF
done
```

Apply the Job resources. Some Jobs will fail due to connection timeout.

We can also use the following Job template to check whether the `ipset` contains the Pod IP when a Pod starts:

```yml
apiVersion: batch/v1
kind: Job
metadata:
  name: job-snat-1
spec:
  template:
    spec:
      containers:
      - name: ipset
        image: kubeovn/kube-ovn:v1.10.0
        command:
        - bash
        - -xec
        - 'echo $POD_IP; nsenter --net=/proc/1/ns/net ipset -L ovn40local-pod-ip-nat | grep "^$POD_IP$"'
        env:
        - name: POD_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        securityContext:
          runAsUser: 0
          privileged: true
      restartPolicy: Never
      hostPID: true
  backoffLimit: 0
```
