### PR TITLE
skip ping gateway for pods during live migration

### DIFF
--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -176,11 +176,14 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			return
 		}
 
-		if !podSubnet.Spec.DisableGatewayCheck {
-			if podSubnet.Spec.Vlan != "" && !podSubnet.Spec.LogicalGateway {
-				gatewayCheckMode = gatewayCheckModeArping
-			} else {
-				gatewayCheckMode = gatewayCheckModePing
+		//skip ping check gateway for pods during live migration
+		if pod.Annotations[fmt.Sprintf(util.LiveMigrationAnnotationTemplate, podRequest.Provider)] != "true" {
+			if !podSubnet.Spec.DisableGatewayCheck {
+				if podSubnet.Spec.Vlan != "" && !podSubnet.Spec.LogicalGateway {
+					gatewayCheckMode = gatewayCheckModeArping
+				} else {
+					gatewayCheckMode = gatewayCheckModePing
+				}
 			}
 		}
 


### PR DESCRIPTION
#### What type of this PR
support kubevirt VM live migration using subnet with default configuration ```disableGatewayCheck: false``` 

#### Which issue(s) this PR fixes:
relates to #1001 



