### PR TITLE
don't check conflict for migration pod with only static mac

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -272,7 +272,7 @@ func (c *Controller) handleAddNode(key string) error {
 			return err
 		}
 	} else {
-		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, portName, "", c.config.NodeSwitch, nil)
+		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, portName, "", c.config.NodeSwitch, nil, true)
 		if err != nil {
 			klog.Errorf("failed to alloc random ip addrs for node %v: %v", node.Name, err)
 			return err

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1227,7 +1227,7 @@ func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, st
 		for {
 			nicName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
 
-			ipv4, ipv6, mac, err := c.ipam.GetRandomAddress(key, nicName, macStr, podNet.Subnet.Name, skippedAddrs)
+			ipv4, ipv6, mac, err := c.ipam.GetRandomAddress(key, nicName, macStr, podNet.Subnet.Name, skippedAddrs, !podNet.AllowLiveMigration)
 			if err != nil {
 				return "", "", "", err
 			}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -37,7 +37,7 @@ func NewIPAM() *IPAM {
 	}
 }
 
-func (ipam *IPAM) GetRandomAddress(podName, nicName, mac, subnetName string, skippedAddrs []string) (string, string, string, error) {
+func (ipam *IPAM) GetRandomAddress(podName, nicName, mac, subnetName string, skippedAddrs []string, checkConflict bool) (string, string, string, error) {
 	ipam.mutex.RLock()
 	defer ipam.mutex.RUnlock()
 
@@ -46,7 +46,7 @@ func (ipam *IPAM) GetRandomAddress(podName, nicName, mac, subnetName string, ski
 		return "", "", "", ErrNoAvailable
 	}
 
-	v4IP, v6IP, mac, err := subnet.GetRandomAddress(podName, nicName, mac, skippedAddrs)
+	v4IP, v6IP, mac, err := subnet.GetRandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	klog.Infof("allocate v4 %s v6 %s mac %s for %s", v4IP, v6IP, mac, podName)
 	return string(v4IP), string(v6IP), mac, err
 }
@@ -67,7 +67,7 @@ func (ipam *IPAM) GetStaticAddress(podName, nicName, ip, mac, subnetName string,
 			}
 			ips = append(ips, ipAddr)
 		}
-		ips, err = checkAndAppendIpsForDual(ips, mac, podName, nicName, subnet)
+		ips, err = checkAndAppendIpsForDual(ips, mac, podName, nicName, subnet, checkConflict)
 		if err != nil {
 			klog.Errorf("failed to append allocate ip %v mac %s for %s", ips, mac, podName)
 			return "", "", "", err
@@ -88,7 +88,7 @@ func (ipam *IPAM) GetStaticAddress(podName, nicName, ip, mac, subnetName string,
 	return "", "", "", ErrNoAvailable
 }
 
-func checkAndAppendIpsForDual(ips []IP, mac string, podName string, nicName string, subnet *Subnet) ([]IP, error) {
+func checkAndAppendIpsForDual(ips []IP, mac string, podName string, nicName string, subnet *Subnet, checkConflict bool) ([]IP, error) {
 	// IP Address for dual-stack should be format of 'IPv4,IPv6'
 	if subnet.Protocol != kubeovnv1.ProtocolDual || len(ips) == 2 {
 		return ips, nil
@@ -99,10 +99,10 @@ func checkAndAppendIpsForDual(ips []IP, mac string, podName string, nicName stri
 	var err error
 	if util.CheckProtocol(string(ips[0])) == kubeovnv1.ProtocolIPv4 {
 		newIps = ips
-		_, ipAddr, _, err = subnet.getV6RandomAddress(podName, nicName, mac, nil)
+		_, ipAddr, _, err = subnet.getV6RandomAddress(podName, nicName, mac, nil, checkConflict)
 		newIps = append(newIps, ipAddr)
 	} else if util.CheckProtocol(string(ips[0])) == kubeovnv1.ProtocolIPv6 {
-		ipAddr, _, _, err = subnet.getV4RandomAddress(podName, nicName, mac, nil)
+		ipAddr, _, _, err = subnet.getV4RandomAddress(podName, nicName, mac, nil, checkConflict)
 		newIps = append(newIps, ipAddr)
 		newIps = append(newIps, ips...)
 	}

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -159,7 +159,7 @@ func (subnet *Subnet) popPodNic(podName, nicName string) {
 	subnet.PodToNicList[podName] = util.RemoveString(subnet.PodToNicList[podName], nicName)
 }
 
-func (subnet *Subnet) GetRandomAddress(podName, nicName string, mac string, skippedAddrs []string) (IP, IP, string, error) {
+func (subnet *Subnet) GetRandomAddress(podName, nicName string, mac string, skippedAddrs []string, checkConflict bool) (IP, IP, string, error) {
 	subnet.mutex.Lock()
 	defer func() {
 		subnet.pushPodNic(podName, nicName)
@@ -167,33 +167,33 @@ func (subnet *Subnet) GetRandomAddress(podName, nicName string, mac string, skip
 	}()
 
 	if subnet.Protocol == kubeovnv1.ProtocolDual {
-		return subnet.getDualRandomAddress(podName, nicName, mac, skippedAddrs)
+		return subnet.getDualRandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	} else if subnet.Protocol == kubeovnv1.ProtocolIPv4 {
-		return subnet.getV4RandomAddress(podName, nicName, mac, skippedAddrs)
+		return subnet.getV4RandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	} else {
-		return subnet.getV6RandomAddress(podName, nicName, mac, skippedAddrs)
+		return subnet.getV6RandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	}
 }
 
-func (subnet *Subnet) getDualRandomAddress(podName, nicName string, mac string, skippedAddrs []string) (IP, IP, string, error) {
-	v4IP, _, _, err := subnet.getV4RandomAddress(podName, nicName, mac, skippedAddrs)
+func (subnet *Subnet) getDualRandomAddress(podName, nicName string, mac string, skippedAddrs []string, checkConflict bool) (IP, IP, string, error) {
+	v4IP, _, _, err := subnet.getV4RandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	if err != nil {
 		return "", "", "", err
 	}
-	_, v6IP, mac, err := subnet.getV6RandomAddress(podName, nicName, mac, skippedAddrs)
+	_, v6IP, mac, err := subnet.getV6RandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	if err != nil {
 		return "", "", "", err
 	}
 
 	// allocated IPv4 address may be released in getV6RandomAddress()
 	if subnet.V4NicToIP[nicName] != v4IP {
-		v4IP, _, _, _ = subnet.getV4RandomAddress(podName, nicName, mac, skippedAddrs)
+		v4IP, _, _, _ = subnet.getV4RandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	}
 
 	return v4IP, v6IP, mac, nil
 }
 
-func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, skippedAddrs []string) (IP, IP, string, error) {
+func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, skippedAddrs []string, checkConflict bool) (IP, IP, string, error) {
 	// After 'macAdd' introduced to support only static mac address, pod restart will run into error mac AddressConflict
 	// controller will re-enqueue the new pod then wait for old pod deleted and address released.
 	// here will return only if both ip and mac exist, otherwise only ip without mac returned will trigger CreatePort error.
@@ -246,14 +246,14 @@ func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, sk
 	if mac == "" {
 		return ip, "", subnet.GetRandomMac(podName, nicName), nil
 	} else {
-		if err := subnet.GetStaticMac(podName, nicName, mac, true); err != nil {
+		if err := subnet.GetStaticMac(podName, nicName, mac, checkConflict); err != nil {
 			return "", "", "", err
 		}
 		return ip, "", mac, nil
 	}
 }
 
-func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, skippedAddrs []string) (IP, IP, string, error) {
+func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, skippedAddrs []string, checkConflict bool) (IP, IP, string, error) {
 	// After 'macAdd' introduced to support only static mac address, pod restart will run into error mac AddressConflict
 	// controller will re-enqueue the new pod then wait for old pod deleted and address released.
 	// here will return only if both ip and mac exist, otherwise only ip without mac returned will trigger CreatePort error.
@@ -307,7 +307,7 @@ func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, sk
 	if mac == "" {
 		return "", ip, subnet.GetRandomMac(podName, nicName), nil
 	} else {
-		if err := subnet.GetStaticMac(podName, nicName, mac, true); err != nil {
+		if err := subnet.GetStaticMac(podName, nicName, mac, checkConflict); err != nil {
 			return "", "", "", err
 		}
 		return "", ip, mac, nil

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -48,11 +48,11 @@ var _ = Describe("[IPAM]", func() {
 				_, _, _, err = im.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.2"))
 
-				ip, _, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", "", subnetName, nil)
+				ip, _, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.3"))
 
@@ -63,13 +63,13 @@ var _ = Describe("[IPAM]", func() {
 				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "", "invalid_subnet", nil)
+				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "", "invalid_subnet", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 
 				err = im.AddOrUpdateSubnet(subnetName, ipv4CIDR, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil)
+				ip, _, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
@@ -85,7 +85,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "10.17.0.0/16", []string{"10.17.0.1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				ip, _, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil)
+				ip, _, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.17.0.2"))
 			})
@@ -95,17 +95,17 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.0/30", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 			})
@@ -115,7 +115,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.0/30", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
@@ -123,7 +123,7 @@ var _ = Describe("[IPAM]", func() {
 				err = im.AddOrUpdateSubnet(subnetName, "10.16.0.0/30", []string{"10.16.0.1..10.16.0.2"})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 			})
 		})
@@ -145,11 +145,11 @@ var _ = Describe("[IPAM]", func() {
 				_, _, _, err = im.GetStaticAddress("pod1.ns", "pod1.ns", "fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::2"))
 
-				_, ip, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", "", subnetName, nil)
+				_, ip, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::3"))
 
@@ -160,13 +160,13 @@ var _ = Describe("[IPAM]", func() {
 				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "", "invalid_subnet", nil)
+				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "", "invalid_subnet", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 
 				err = im.AddOrUpdateSubnet(subnetName, ipv6CIDR, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil)
+				_, ip, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
@@ -182,7 +182,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "fe00::/112", []string{"fe00::1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				_, ip, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil)
+				_, ip, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fe00::2"))
 			})
@@ -192,17 +192,17 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 			})
@@ -212,7 +212,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
@@ -220,7 +220,7 @@ var _ = Describe("[IPAM]", func() {
 				err = im.AddOrUpdateSubnet(subnetName, "fd00::/126", []string{"fd00::1..fd00::2"})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 			})
 		})
@@ -246,12 +246,12 @@ var _ = Describe("[IPAM]", func() {
 				_, _, _, err = im.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2,fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.2"))
 				Expect(ipv6).To(Equal("fd00::2"))
 
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", "", subnetName, nil)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod2.ns", "pod2.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.3"))
 				Expect(ipv6).To(Equal("fd00::3"))
@@ -263,13 +263,13 @@ var _ = Describe("[IPAM]", func() {
 				_, _, _, err = im.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.2,fd00::2", "", subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "", "invalid_subnet", nil)
+				_, _, _, err = im.GetRandomAddress("pod4.ns", "pod4.ns", "", "invalid_subnet", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 
 				err = im.AddOrUpdateSubnet(subnetName, dualCIDR, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
@@ -287,7 +287,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "10.17.0.2/16,fe00::/112", []string{"10.17.0.1", "fe00::1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.17.0.2"))
 				Expect(ipv6).To(Equal("fe00::2"))
@@ -298,19 +298,19 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.2"))
 				Expect(ipv6).To(Equal("fd00::2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
@@ -321,7 +321,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
@@ -330,7 +330,7 @@ var _ = Describe("[IPAM]", func() {
 				err = im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", []string{"10.16.0.1..10.16.0.2", "fd00::1..fd00::2"})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil)
+				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 			})
 		})
@@ -434,18 +434,18 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "10.16.0.0/30", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip1, _, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil)
+				ip1, _, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
-				ip1, _, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil)
+				ip1, _, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
 
-				ip2, _, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil)
+				ip2, _, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip2).To(Equal(ipam.IP("10.16.0.2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V4FreeIPList).To(BeEmpty())
 
@@ -522,18 +522,18 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip1, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil)
+				_, ip1, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("fd00::1")))
-				_, ip1, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil)
+				_, ip1, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("fd00::1")))
 
-				_, ip2, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil)
+				_, ip2, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip2).To(Equal(ipam.IP("fd00::2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V6FreeIPList).To(BeEmpty())
 
@@ -647,21 +647,21 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "10.16.0.0/30,fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil)
+				ipv4, ipv6, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.1")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::1")))
-				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil)
+				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.1")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::1")))
 
-				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil)
+				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.2")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V4FreeIPList).To(BeEmpty())
 				Expect(subnet.V6FreeIPList).To(BeEmpty())


### PR DESCRIPTION
#### What type of this PR
- Bug fixes

It returned conflict error if kubevirt VM pod with only static mac(no static IP configured) during migration because that mac address is conflicted with the existing pod.

Add parameter to func GetRandomAddress() to skip check conflict for migration pod 

#### Which issue(s) this PR fixes:
relates to #1253 #1001 



