### PR TITLE
fix: do not recreate port for terminating pods

### DIFF
--- a/pkg/controller/inspection.go
+++ b/pkg/controller/inspection.go
@@ -31,6 +31,11 @@ func (c *Controller) inspectPod() error {
 		if pod.Spec.HostNetwork {
 			continue
 		}
+
+		if !isPodAlive(pod) {
+			continue
+		}
+
 		podName := c.getNameByPod(pod)
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {


### PR DESCRIPTION
When node is not ready lots of pods may stay in `Terminating` status. The inspection previously will always put the pods into addQueue which will waste lots of cpu.

#### What type of this PR
- Bug fixes



