### PR TITLE
fix: add condition for triggering the deletion of redundant chassises in sbdb

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -1013,7 +1013,8 @@ func (c *Controller) RemoveRedundantChassis(node *v1.Node) error {
 		klog.Errorf("failed to get node %s chassisID, %v", node.Name, err)
 		return err
 	}
-	if chassisAdd == "" {
+
+	if chassisAdd == "" && node.Annotations[util.ChassisAnnotation] != "" {
 		chassises, err := c.ovnClient.GetAllChassisHostname()
 		if err != nil {
 			klog.Errorf("failed to get all chassis, %v", err)


### PR DESCRIPTION
For some scenarios, Kubeovn is not actually deployed on some node.
But this "remove redundant chasisses" function may always be called.
So more condition is added to fix this problem.

