### PR TITLE
replace pod name when create ip crd

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -520,8 +520,9 @@ func (c *Controller) handleAddPod(key string) error {
 			return err
 		}
 
-		if err := c.createOrUpdateCrdIPs(pod.Name, ipStr, mac, subnet.Name, pod.Namespace, pod.Spec.NodeName, podNet.ProviderName); err != nil {
-			klog.Errorf("failed to create IP %s.%s: %v", pod.Name, pod.Namespace, err)
+		podName := c.getNameByPod(pod)
+		if err := c.createOrUpdateCrdIPs(podName, ipStr, mac, subnet.Name, pod.Namespace, pod.Spec.NodeName, podNet.ProviderName); err != nil {
+			klog.Errorf("failed to create IP %s.%s: %v", podName, pod.Namespace, err)
 		}
 
 		if podNet.Type != providerTypeIPAM {
@@ -554,7 +555,6 @@ func (c *Controller) handleAddPod(key string) error {
 				}
 			}
 
-			podName := c.getNameByPod(pod)
 			portName := ovs.PodNameToPortName(podName, namespace, podNet.ProviderName)
 			dhcpOptions := &ovs.DHCPOptionsUUIDs{
 				DHCPv4OptionsUUID: subnet.Status.DHCPv4OptionsUUID,


### PR DESCRIPTION
#### What type of this PR
- Bug fixes

####
when `keep-vm-ip` para in kube-ovn-controller is set, the ip name should be consisted of vmname and namespace.


#### Which issue(s) this PR fixes:
Fixes #1413 


