### PR TITLE
add kube-ovn-controller switch for EIP and SNAT

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -12,6 +12,7 @@ VLAN_NIC=${VLAN_NIC:-}
 HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_LB=${ENABLE_LB:-true}
 ENABLE_NP=${ENABLE_NP:-true}
+ENABLE_EIP_SNAT=${ENABLE_EIP_SNAT:-true}
 WITHOUT_KUBE_PROXY=${WITHOUT_KUBE_PROXY:-false}
 ENABLE_EXTERNAL_VPC=${ENABLE_EXTERNAL_VPC:-true}
 CNI_CONFIG_PRIORITY=${CNI_CONFIG_PRIORITY:-01}
@@ -159,6 +160,7 @@ echo "Default Subnet CIDR:  $POD_CIDR"
 echo "Join Subnet CIDR:     $JOIN_CIDR"
 echo "Enable SVC LB:        $ENABLE_LB"
 echo "Enable Networkpolicy: $ENABLE_NP"
+echo "Enable EIP and SNAT:  $ENABLE_EIP_SNAT"
 echo "Enable Mirror:        $ENABLE_MIRROR"
 echo "-------------------------------"
 
@@ -2149,6 +2151,7 @@ spec:
           - --pod-nic-type=$POD_NIC_TYPE
           - --enable-lb=$ENABLE_LB
           - --enable-np=$ENABLE_NP
+          - --enable-eip-snat=$ENABLE_EIP_SNAT
           - --enable-external-vpc=$ENABLE_EXTERNAL_VPC
           - --logtostderr=false
           - --alsologtostderr=true

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -70,6 +70,7 @@ type Configuration struct {
 
 	EnableLb          bool
 	EnableNP          bool
+	EnableEipSnat     bool
 	EnableExternalVpc bool
 	EnableEcmp        bool
 	EnableKeepVmIP    bool
@@ -118,6 +119,7 @@ func ParseFlags() (*Configuration, error) {
 		argPodNicType           = pflag.String("pod-nic-type", "veth-pair", "The default pod network nic implementation type")
 		argEnableLb             = pflag.Bool("enable-lb", true, "Enable load balancer")
 		argEnableNP             = pflag.Bool("enable-np", true, "Enable network policy support")
+		argEnableEipSnat        = pflag.Bool("enable-eip-snat", true, "Enable EIP and SNAT")
 		argEnableExternalVpc    = pflag.Bool("enable-external-vpc", true, "Enable external vpc support")
 		argEnableEcmp           = pflag.Bool("enable-ecmp", false, "Enable ecmp route for centralized subnet")
 		argKeepVmIP             = pflag.Bool("keep-vm-ip", false, "Whether to keep ip for kubevirt pod when pod is rebuild")
@@ -177,6 +179,7 @@ func ParseFlags() (*Configuration, error) {
 		PodNicType:                    *argPodNicType,
 		EnableLb:                      *argEnableLb,
 		EnableNP:                      *argEnableNP,
+		EnableEipSnat:                 *argEnableEipSnat,
 		EnableExternalVpc:             *argEnableExternalVpc,
 		ExternalGatewayConfigNS:       *argExternalGatewayConfigNS,
 		ExternalGatewayNet:            *argExternalGatewayNet,

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -347,14 +347,14 @@ func (c *Controller) processNextDeletePodWorkItem() bool {
 			utilruntime.HandleError(fmt.Errorf("expected pod in workqueue but got %#v", obj))
 			return nil
 		}
-		klog.Infof("handle delete pod %s", pod.Name)
+		klog.Infof("handle delete pod %s/%s", pod.Namespace, pod.Name)
 		if err := c.handleDeletePod(pod); err != nil {
 			c.deletePodQueue.AddRateLimited(obj)
 			return fmt.Errorf("error syncing '%s': %s, requeuing", pod.Name, err.Error())
 		}
 		c.deletePodQueue.Forget(obj)
 		last := time.Since(now)
-		klog.Infof("take %d ms to handle delete pod %s", last.Milliseconds(), pod.Name)
+		klog.Infof("take %d ms to handle delete pod %s/%s", last.Milliseconds(), pod.Namespace, pod.Name)
 		return nil
 	}(obj)
 
@@ -372,6 +372,7 @@ func (c *Controller) processNextUpdatePodWorkItem() bool {
 		return false
 	}
 
+	now := time.Now()
 	err := func(obj interface{}) error {
 		defer c.updatePodQueue.Done(obj)
 		var key string
@@ -381,11 +382,14 @@ func (c *Controller) processNextUpdatePodWorkItem() bool {
 			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
 			return nil
 		}
+		klog.Infof("handle update pod %s", key)
 		if err := c.handleUpdatePod(key); err != nil {
 			c.updatePodQueue.AddRateLimited(key)
 			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
 		}
 		c.updatePodQueue.Forget(obj)
+		last := time.Since(now)
+		klog.Infof("take %d ms to handle update pod %s", last.Milliseconds(), key)
 		return nil
 	}(obj)
 
@@ -453,13 +457,15 @@ func (c *Controller) getPodKubeovnNets(pod *v1.Pod) ([]*kubeovnNet, error) {
 }
 
 func (c *Controller) handleAddPod(key string) error {
-	c.podKeyMutex.Lock(key)
-	defer c.podKeyMutex.Unlock(key)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
+
+	c.podKeyMutex.Lock(key)
+	defer c.podKeyMutex.Unlock(key)
+
 	oripod, err := c.podsLister.Pods(namespace).Get(name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -481,7 +487,7 @@ func (c *Controller) handleAddPod(key string) error {
 	}
 
 	op := "replace"
-	if pod.Annotations == nil || len(pod.Annotations) == 0 {
+	if len(pod.Annotations) == 0 {
 		op = "add"
 		pod.Annotations = map[string]string{}
 	}
@@ -746,13 +752,15 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 }
 
 func (c *Controller) handleUpdatePod(key string) error {
-	c.podKeyMutex.Lock(key)
-	defer c.podKeyMutex.Unlock(key)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
+
+	c.podKeyMutex.Lock(key)
+	defer c.podKeyMutex.Unlock(key)
+
 	oripod, err := c.podsLister.Pods(namespace).Get(name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -792,7 +800,7 @@ func (c *Controller) handleUpdatePod(key string) error {
 		subnet = podNet.Subnet
 
 		if podIP != "" && subnet.Spec.Vlan == "" && subnet.Spec.Vpc == util.DefaultVpc {
-			if pod.Annotations[util.EipAnnotation] != "" || pod.Annotations[util.SnatAnnotation] != "" {
+			if c.config.EnableEipSnat && (pod.Annotations[util.EipAnnotation] != "" || pod.Annotations[util.SnatAnnotation] != "") {
 				cm, err := c.configMapsLister.ConfigMaps(c.config.ExternalGatewayConfigNS).Get(util.ExternalGatewayConfig)
 				if err != nil {
 					klog.Errorf("failed to get ex-gateway config, %v", err)
@@ -889,15 +897,17 @@ func (c *Controller) handleUpdatePod(key string) error {
 				}
 			}
 
-			for _, ipStr := range strings.Split(podIP, ",") {
-				if err := c.ovnClient.UpdateNatRule("dnat_and_snat", ipStr, pod.Annotations[util.EipAnnotation], c.config.ClusterRouter, pod.Annotations[util.MacAddressAnnotation], fmt.Sprintf("%s.%s", podName, pod.Namespace)); err != nil {
-					klog.Errorf("failed to add nat rules, %v", err)
-					return err
-				}
+			if c.config.EnableEipSnat {
+				for _, ipStr := range strings.Split(podIP, ",") {
+					if err := c.ovnClient.UpdateNatRule("dnat_and_snat", ipStr, pod.Annotations[util.EipAnnotation], c.config.ClusterRouter, pod.Annotations[util.MacAddressAnnotation], fmt.Sprintf("%s.%s", podName, pod.Namespace)); err != nil {
+						klog.Errorf("failed to add nat rules, %v", err)
+						return err
+					}
 
-				if err := c.ovnClient.UpdateNatRule("snat", ipStr, pod.Annotations[util.SnatAnnotation], c.config.ClusterRouter, "", ""); err != nil {
-					klog.Errorf("failed to add nat rules, %v", err)
-					return err
+					if err := c.ovnClient.UpdateNatRule("snat", ipStr, pod.Annotations[util.SnatAnnotation], c.config.ClusterRouter, "", ""); err != nil {
+						klog.Errorf("failed to add nat rules, %v", err)
+						return err
+					}
 				}
 			}
 		}

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -59,6 +59,7 @@ spec:
             - --pod-nic-type=veth-pair
             - --enable-lb=true
             - --enable-np=true
+            - --enable-eip-snat=true
             - --enable-external-vpc=true
           env:
             - name: ENABLE_SSL

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -60,6 +60,8 @@ spec:
             - --pod-nic-type=veth-pair
             - --enable-lb=true
             - --enable-np=true
+            - --enable-eip-snat=true
+            - --enable-external-vpc=true
           env:
             - name: ENABLE_SSL
               value: "false"

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -59,6 +59,7 @@ spec:
             - --pod-nic-type=veth-pair
             - --enable-lb=true
             - --enable-np=true
+            - --enable-eip-snat=true
             - --enable-external-vpc=true
           env:
             - name: ENABLE_SSL


### PR DESCRIPTION
#### What type of this PR

- Performance

Add a switch for EIP and SNAT in kube-ovn-controller. When it's off, the performance of Pod update event handing can be improved.