### PR TITLE
update alpine to fix CVE-2022-1271

### DIFF
--- a/dist/images/vpcnatgateway/Dockerfile
+++ b/dist/images/vpcnatgateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.15
 
 RUN set -ex \
     && echo "http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \


### PR DESCRIPTION
#### What type of this PR

- Security

```txt
+---------+------------------+----------+-------------------+---------------+--------------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                TITLE                 |
+---------+------------------+----------+-------------------+---------------+--------------------------------------+
| xz-libs | CVE-2022-1271    | HIGH     | 5.2.5-r0          | 5.2.5-r1      | gzip: arbitrary-file-write           |
|         |                  |          |                   |               | vulnerability                        |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-1271 |
+---------+------------------+----------+-------------------+---------------+--------------------------------------+
```