### PR TITLE
log: show the reason if get gw node failed

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1230,7 +1230,12 @@ func (c *Controller) reconcileGateway(subnet *kubeovnv1.Subnet) error {
 					}
 
 					node, err := c.nodesLister.Get(gw)
-					if err == nil && nodeReady(node) {
+					if err != nil {
+						klog.Errorf("failed to get gw node %s, %v", gw, err)
+						continue
+					}
+
+					if nodeReady(node) {
 						nodeTunlIP := strings.TrimSpace(node.Annotations[util.IpAddressAnnotation])
 						if nodeTunlIP == "" {
 							klog.Errorf("gateway node %v has no ip annotation", node.Name)


### PR DESCRIPTION
If users set a not exist node in subnet gateway_nodes, the log only
show `gateway node is not ready` which is misleading.

#### What type of this PR
Examples of user facing changes:
- Enhancement



