### PR TITLE
update cni plugins to fix CVE-2021-20206

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -63,7 +63,7 @@ RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /opt/cni/bin
 
 ARG ARCH
-ENV CNI_VERSION=v0.8.7
+ENV CNI_VERSION=v1.1.1
 RUN curl -sSf -L --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C . ./loopback ./portmap ./macvlan
 
 RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \

--- a/dist/images/Dockerfile.base-dpdk
+++ b/dist/images/Dockerfile.base-dpdk
@@ -78,7 +78,7 @@ RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /opt/cni/bin
 
 ARG ARCH
-ENV CNI_VERSION=v0.8.7
+ENV CNI_VERSION=v1.1.1
 RUN curl -sSf -L --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C . ./loopback ./portmap ./macvlan
 
 RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \

--- a/dist/images/Dockerfile.rpm
+++ b/dist/images/Dockerfile.rpm
@@ -40,7 +40,7 @@ RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /opt/cni/bin
 
 ARG ARCH
-ENV CNI_VERSION=v0.8.6
+ENV CNI_VERSION=v1.1.1
 RUN curl -sSf -L --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C . ./loopback ./portmap
 
 ENV KUBE_VERSION="v1.13.2"


### PR DESCRIPTION
#### What type of this PR

- Security

Fix CVE-2021-20206 by updating cni plugin binaries to v1.1.1.

```txt
+------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|              LIBRARY               | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| github.com/containernetworking/cni | CVE-2021-20206   | HIGH     | v0.8.0            | v0.8.1        | containernetworking-cni:              |
|                                    |                  |          |                   |               | Arbitrary path injection via          |
|                                    |                  |          |                   |               | type field in CNI configuration       |
|                                    |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-20206 |
+------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
```