### PR TITLE
Annotation network_type always is geneve

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -502,11 +502,6 @@ func (c *Controller) handleAddPod(key string) error {
 			return err
 		}
 		ipStr := util.GetStringIP(v4IP, v6IP)
-		if subnet.Spec.Vlan != "" {
-			pod.Annotations[fmt.Sprintf(util.NetworkTypeTemplate, podNet.ProviderName)] = util.NetworkTypeVlan
-		} else {
-			pod.Annotations[fmt.Sprintf(util.NetworkTypeTemplate, podNet.ProviderName)] = util.NetworkTypeGeneve
-		}
 		pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)] = ipStr
 		pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)] = mac
 		pod.Annotations[fmt.Sprintf(util.CidrAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.CIDRBlock

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -46,7 +46,6 @@ const (
 	LogicalSwitchAnnotationTemplate = "%s.kubernetes.io/logical_switch"
 	LogicalRouterAnnotationTemplate = "%s.kubernetes.io/logical_router"
 	VlanIdAnnotationTemplate        = "%s.kubernetes.io/vlan_id"
-	NetworkTypeTemplate             = "%s.kubernetes.io/network_type"
 	IngressRateAnnotationTemplate   = "%s.kubernetes.io/ingress_rate"
 	EgressRateAnnotationTemplate    = "%s.kubernetes.io/egress_rate"
 	SecurityGroupAnnotationTemplate = "%s.kubernetes.io/security_groups"


### PR DESCRIPTION
#### What type of this P
annotation network_type is not used in kube-ovn-controller project,So it can be deleted.

#### Which issue(s) this PR fixes:
Fixes #(1452)



