### PR TITLE
fix routes for packets from Pods to other nodes

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1599,7 +1599,7 @@ func (c *Controller) createOverlaySubnetsAddressSet() error {
 	}
 
 	for _, subnet := range subnetList {
-		if subnet.Spec.Vlan != "" || subnet.Spec.Vpc != util.DefaultVpc || subnet.Name == c.config.NodeSwitch {
+		if subnet.Spec.Vlan != "" || subnet.Spec.Vpc != util.DefaultVpc {
 			continue
 		}
 

--- a/test/e2e/subnet/normal.go
+++ b/test/e2e/subnet/normal.go
@@ -3,6 +3,7 @@ package subnet
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -55,7 +56,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			af, cidr, protocol := 4, "11.10.0.0/16", kubeovn.ProtocolIPv4
 			if isIPv6 {
-				af, cidr, protocol = 6, "fd00:11:10::/112", kubeovn.ProtocolIPv6
+				af, cidr, protocol = 6, "fc10::/16", kubeovn.ProtocolIPv6
 			}
 			gateway, _ := util.FirstIP(cidr)
 
@@ -94,9 +95,9 @@ var _ = Describe("[Subnet]", func() {
 			By("validate status")
 			Expect(subnet.Status.ActivateGateway).To(BeEmpty())
 			if isIPv6 {
-				Expect(subnet.Status.V6AvailableIPs).To(Equal(float64(65533)))
+				Expect(subnet.Status.V6AvailableIPs).To(Equal(math.Exp2(128-16) - 3))
 			} else {
-				Expect(subnet.Status.V4AvailableIPs).To(Equal(float64(65533)))
+				Expect(subnet.Status.V4AvailableIPs).To(Equal(math.Exp2(32-16) - 3))
 			}
 			Expect(subnet.Status.V4UsingIPs).To(BeZero())
 			Expect(subnet.Status.V6UsingIPs).To(BeZero())
@@ -114,7 +115,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			cidr := "11.11.0.0/16"
 			if isIPv6 {
-				cidr = "fd00:11:11::/112"
+				cidr = "fc11::/16"
 			}
 
 			By("create subnet")
@@ -149,7 +150,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			cidr := "11.12.0.0/16"
 			if isIPv6 {
-				cidr = "fd00:11:12::/112"
+				cidr = "fc12::/16"
 			}
 
 			By("create subnet")
@@ -189,7 +190,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			cidr := "11.13.0.0/16"
 			if isIPv6 {
-				cidr = "fd00:11:13::/112"
+				cidr = "fc13::/16"
 			}
 			By("create subnet")
 			s := kubeovn.Subnet{
@@ -225,7 +226,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			cidr := "11.14.0.10/16"
 			if isIPv6 {
-				cidr = "fd00:11:14::10/112"
+				cidr = "fc14::/16"
 			}
 			By("create subnet")
 			s := &kubeovn.Subnet{
@@ -250,7 +251,7 @@ var _ = Describe("[Subnet]", func() {
 			if !isIPv6 {
 				Expect(s.Spec.CIDRBlock).To(Equal("11.14.0.0/16"))
 			} else {
-				Expect(s.Spec.CIDRBlock).To(Equal("fd00:11:14::/112"))
+				Expect(s.Spec.CIDRBlock).To(Equal("fc14::/16"))
 			}
 
 		})
@@ -346,7 +347,7 @@ var _ = Describe("[Subnet]", func() {
 
 			af, cidr := 4, "11.15.0.0/16"
 			if isIPv6 {
-				af, cidr = 6, "fd00:11:15::/112"
+				af, cidr = 6, "fc15::/16"
 			}
 
 			var egw string
@@ -485,7 +486,7 @@ var _ = Describe("[Subnet]", func() {
 
 			af, cidr := 4, "11.16.0.0/16"
 			if isIPv6 {
-				af, cidr = 6, "fd00:11:16::/112"
+				af, cidr = 6, "fc16::/16"
 			}
 
 			var selectedNode *corev1.Node


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

`join` subnet should also be treated as overlay subnets in logical router route policies.

This patch also changes the IPv6 CIDRs used in e2e testing to avoid issue #1467.