### PR TITLE
delete monitor noexecute toleration

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2538,8 +2538,6 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
-        - effect: NoExecute
-          operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -389,8 +389,6 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
-        - effect: NoExecute
-          operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -361,8 +361,6 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
-        - effect: NoExecute
-          operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -404,8 +404,6 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
-        - effect: NoExecute
-          operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
The kube-ovn-monitor replicas is set to 1，so the pod can be scheduled between master nodes

#### Which issue(s) this PR fixes:
Fixes #(issue-number)



