### PR TITLE
delete ipam record when gc lsp

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -300,6 +300,8 @@ func (c *Controller) markAndCleanLSP() error {
 			if !lastNoPodLSP[lsp] {
 				noPodLSP[lsp] = true
 			} else {
+				nameNsMap := c.ovnClient.GetLspExternalIds(lsp)
+
 				klog.Infof("gc logical switch port %s", lsp)
 				if err := c.ovnClient.DeleteLogicalSwitchPort(lsp); err != nil {
 					klog.Errorf("failed to delete lsp %s, %v", lsp, err)
@@ -310,6 +312,11 @@ func (c *Controller) markAndCleanLSP() error {
 						klog.Errorf("failed to delete ip %s, %v", lsp, err)
 						return err
 					}
+				}
+
+				for podName, nsName := range nameNsMap {
+					key := fmt.Sprintf("%s/%s", nsName, podName)
+					c.ipam.ReleaseAddressByPod(key)
 				}
 			}
 		}

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -2543,3 +2543,38 @@ func (c Client) UpdateSubnetACL(ls string, acls []kubeovnv1.Acl) error {
 	}
 	return nil
 }
+
+func (c *Client) GetLspExternalIds(lsp string) map[string]string {
+	result, err := c.CustomFindEntity("Logical_Switch_Port", []string{"external_ids"}, fmt.Sprintf("name=%s", lsp))
+	if err != nil {
+		klog.Errorf("customFindEntity failed, %v", err)
+		return nil
+	}
+	if len(result) == 0 {
+		return nil
+	}
+
+	nameNsMap := make(map[string]string, 1)
+	for _, l := range result[0]["external_ids"] {
+		if len(strings.TrimSpace(l)) == 0 {
+			continue
+		}
+		parts := strings.Split(strings.TrimSpace(l), "=")
+		if len(parts) != 2 {
+			continue
+		}
+		if strings.TrimSpace(parts[0]) != "pod" {
+			continue
+		}
+
+		podInfo := strings.Split(strings.TrimSpace(parts[1]), "/")
+		if len(podInfo) != 2 {
+			continue
+		}
+		podNs := podInfo[0]
+		podName := podInfo[1]
+		nameNsMap[podName] = podNs
+	}
+
+	return nameNsMap
+}


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
restart cluster, and restore ipam when kube-ovn-controller initIPAM, but lately gc all lsps. Rebuild all the pod with static ip, will result in ip address conflict.

#### Which issue(s) this PR fixes:
Fixes #(issue-number)



