### PR TITLE
fix: add empty chassis check in ovn db

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -821,6 +821,10 @@ func (c *Controller) checkChassisDupl(node *v1.Node) error {
 		klog.Errorf("failed to get node %s chassisID, %v", node.Name, err)
 		return err
 	}
+	if chassisAdd == "" {
+		klog.Errorf("chassis of node %s is empty", node.Name)
+		return err
+	}
 	chassisAnn := node.Annotations[util.ChassisAnnotation]
 	if chassisAnn == chassisAdd || chassisAnn == "" {
 		return nil


### PR DESCRIPTION
Now if a node without chassis id could not be added into the cluster.