### PR TITLE
feat: lsp forwarding external Layer-2 packets

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -565,6 +565,13 @@ func (c *Controller) handleAddPod(key string) error {
 				return err
 			}
 
+			if pod.Annotations[fmt.Sprintf(util.Layer2ForwardAnnotationTemplate, podNet.ProviderName)] == "true" {
+				if err := c.ovnClient.EnablePortLayer2forward(subnet.Name, portName); err != nil {
+					c.recorder.Eventf(pod, v1.EventTypeWarning, "EnablePortLayer2forwardFailed", err.Error())
+					return err
+				}
+			}
+
 			if portSecurity {
 				sgNames := strings.Split(securityGroupAnnotation, ",")
 				for _, sgName := range sgNames {

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -237,6 +237,15 @@ func (c Client) ListVirtualPort(ls string) ([]string, error) {
 	return result, nil
 }
 
+// EnablePortLayer2forward set logical switch port addresses as 'unknown'
+func (c Client) EnablePortLayer2forward(ls, port string) error {
+	if _, err := c.ovnNbCommand("lsp-set-addresses", port, "unknown"); err != nil {
+		klog.Errorf("enable port %s layer2 forward failed: %v", port, err)
+		return err
+	}
+	return nil
+}
+
 // CreatePort create logical switch port in ovn
 func (c Client) CreatePort(ls, port, ip, mac, pod, namespace string, portSecurity bool, securityGroups string, vips string, liveMigration bool, enableDHCP bool, dhcpOptions *DHCPOptionsUUIDs) error {
 	var ovnCommand []string

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -30,10 +30,11 @@ const (
 	LogicalRouterAnnotation = "ovn.kubernetes.io/logical_router"
 	VpcAnnotation           = "ovn.kubernetes.io/vpc"
 
-	PortSecurityAnnotationTemplate = "%s.kubernetes.io/port_security"
-	PortVipAnnotationTemplate      = "%s.kubernetes.io/port_vips"
-	PortSecurityAnnotation         = "ovn.kubernetes.io/port_security"
-	NorthGatewayAnnotation         = "ovn.kubernetes.io/north_gateway"
+	Layer2ForwardAnnotationTemplate = "%s.kubernetes.io/layer2_forward"
+	PortSecurityAnnotationTemplate  = "%s.kubernetes.io/port_security"
+	PortVipAnnotationTemplate       = "%s.kubernetes.io/port_vips"
+	PortSecurityAnnotation          = "ovn.kubernetes.io/port_security"
+	NorthGatewayAnnotation          = "ovn.kubernetes.io/north_gateway"
 
 	AllocatedAnnotationSuffix       = ".kubernetes.io/allocated"
 	AllocatedAnnotationTemplate     = "%s.kubernetes.io/allocated"


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- API changes

This feature is designed to support layer 2 communication between internal subnets and external subnets.
OVN delivers unicast Ethernet packets whose destination MAC address is not in any logical port’s addresses column to ports with address unknown.