### PR TITLE
refactor logical router policy routes

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -599,22 +599,10 @@ func (c *Controller) gcStaticRoute() error {
 		return err
 	}
 	for _, route := range routes {
-		if route.Policy == ovs.PolicyDstIP || route.Policy == "" {
-			if !c.ipam.ContainAddress(route.NextHop) {
-				klog.Infof("gc static route %s %s %s", route.Policy, route.CIDR, route.NextHop)
-				if err := c.ovnClient.DeleteStaticRouteByNextHop(route.NextHop); err != nil {
-					klog.Errorf("failed to delete stale nexthop route %s, %v", route.NextHop, err)
-				}
-			}
-		} else {
-			if strings.Contains(route.CIDR, "/") {
-				continue
-			}
-			if !c.ipam.ContainAddress(route.CIDR) {
-				klog.Infof("gc static route %s %s %s", route.Policy, route.CIDR, route.NextHop)
-				if err := c.ovnClient.DeleteStaticRoute(route.CIDR, c.config.ClusterRouter); err != nil {
-					klog.Errorf("failed to delete stale route %s, %v", route.NextHop, err)
-				}
+		if route.CIDR != "0.0.0.0/0" && route.CIDR != "::/0" && c.ipam.ContainAddress(route.CIDR) {
+			klog.Infof("gc static route %s %s %s", route.Policy, route.CIDR, route.NextHop)
+			if err := c.ovnClient.DeleteStaticRoute(route.CIDR, c.config.ClusterRouter); err != nil {
+				klog.Errorf("failed to delete stale route %s, %v", route.NextHop, err)
 			}
 		}
 	}

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -58,11 +58,6 @@ func (c *Controller) InitOVN() error {
 		return err
 	}
 
-	if err := c.createOverlaySubnetsAddressSet(); err != nil {
-		klog.Errorf("failed to create overlay subnets address-set, %v", err)
-		return err
-	}
-
 	return nil
 }
 
@@ -656,20 +651,30 @@ func (c *Controller) initSyncCrdVlans() error {
 	return nil
 }
 
-func (c *Controller) migrateNodeRoute(af int, node, ip, nexthop string, cidrs []string) error {
+func (c *Controller) migrateNodeRoute(af int, node, ip, nexthop string) error {
 	if err := c.ovnClient.DeleteStaticRoute(ip, c.config.ClusterRouter); err != nil {
 		klog.Errorf("failed to delete obsolete static route for node %s: %v", node, err)
 		return err
 	}
 
 	asName := nodeUnderlayAddressSetName(node, af)
-	if err := c.ovnClient.CreateAddressSetWithAddresses(asName, cidrs...); err != nil {
-		klog.Errorf("failed to create address set %s for node %s: %v", asName, node, err)
+	obsoleteMatch := fmt.Sprintf("ip%d.dst == %s && ip%d.src != $%s", af, ip, af, asName)
+	if err := c.ovnClient.DeletePolicyRoute(c.config.ClusterRouter, util.NodeRouterPolicyPriority, obsoleteMatch); err != nil {
+		klog.Errorf("failed to delete obsolete logical router policy for node %s: %v", node, err)
 		return err
 	}
 
-	match := fmt.Sprintf("ip%d.dst == %s && ip%d.src != $%s", af, ip, af, asName)
-	if err := c.ovnClient.AddPolicyRoute(c.config.ClusterRouter, util.NodeRouterPolicyPriority, match, "reroute", nexthop); err != nil {
+	if err := c.ovnClient.DeleteAddressSet(asName); err != nil {
+		klog.Errorf("failed to delete obsolete address set %s for node %s: %v", asName, node, err)
+		return err
+	}
+
+	match := fmt.Sprintf("ip%d.dst == %s", af, ip)
+	externalIDs := map[string]string{
+		"vendor": util.CniTypeName,
+		"node":   node,
+	}
+	if err := c.ovnClient.AddPolicyRoute(c.config.ClusterRouter, util.NodeRouterPolicyPriority, match, "reroute", nexthop, externalIDs); err != nil {
 		klog.Errorf("failed to add logical router policy for node %s: %v", node, err)
 		return err
 	}
@@ -678,11 +683,6 @@ func (c *Controller) migrateNodeRoute(af int, node, ip, nexthop string, cidrs []
 }
 
 func (c *Controller) initNodeRoutes() error {
-	subnets, err := c.subnetsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list subnets: %v", err)
-		return err
-	}
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list nodes: %v", err)
@@ -690,30 +690,14 @@ func (c *Controller) initNodeRoutes() error {
 	}
 	for _, node := range nodes {
 		nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(*node)
-
-		var v4CIDRs, v6CIDRs []string
-		for _, subnet := range subnets {
-			if subnet.Spec.Vlan == "" || !subnet.Spec.LogicalGateway || subnet.Spec.Vpc != util.DefaultVpc {
-				continue
-			}
-
-			v4, v6 := util.SplitStringIP(subnet.Spec.CIDRBlock)
-			if util.CIDRContainIP(v4, nodeIPv4) {
-				v4CIDRs = append(v4CIDRs, v4)
-			}
-			if util.CIDRContainIP(v6, nodeIPv6) {
-				v6CIDRs = append(v6CIDRs, v6)
-			}
-		}
-
 		joinAddrV4, joinAddrV6 := util.SplitStringIP(node.Annotations[util.IpAddressAnnotation])
 		if nodeIPv4 != "" && joinAddrV4 != "" {
-			if err = c.migrateNodeRoute(4, node.Name, nodeIPv4, joinAddrV4, v4CIDRs); err != nil {
+			if err = c.migrateNodeRoute(4, node.Name, nodeIPv4, joinAddrV4); err != nil {
 				klog.Errorf("failed to migrate IPv4 route for node %s: %v", node.Name, err)
 			}
 		}
 		if nodeIPv6 != "" && joinAddrV6 != "" {
-			if err = c.migrateNodeRoute(6, node.Name, nodeIPv6, joinAddrV6, v6CIDRs); err != nil {
+			if err = c.migrateNodeRoute(6, node.Name, nodeIPv6, joinAddrV6); err != nil {
 				klog.Errorf("failed to migrate IPv6 route for node %s: %v", node.Name, err)
 			}
 		}

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -337,7 +337,8 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 			}
 		}
 		for _, item := range policyRouteNeedAdd {
-			if err = c.ovnClient.AddPolicyRoute(vpc.Name, item.Priority, item.Match, string(item.Action), item.NextHopIP); err != nil {
+			externalIDs := map[string]string{"vendor": util.CniTypeName}
+			if err = c.ovnClient.AddPolicyRoute(vpc.Name, item.Priority, item.Match, string(item.Action), item.NextHopIP, externalIDs); err != nil {
 				klog.Errorf("add policy route to vpc %s failed, %v", vpc.Name, err)
 				return err
 			}

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -912,23 +912,36 @@ func (c Client) AddStaticRoute(policy, cidr, nextHop, router string, routeType s
 }
 
 // AddPolicyRoute add a policy route rule in ovn
-func (c Client) AddPolicyRoute(router string, priority int32, match string, action string, nextHop string) error {
-	exist, err := c.IsPolicyRouteExist(router, priority, match)
-	if err != nil {
-		return err
-	}
-	if exist {
-		return nil
-	}
-
+func (c Client) AddPolicyRoute(router string, priority int32, match, action, nextHop string, externalIDs map[string]string) error {
 	// lr-policy-add ROUTER PRIORITY MATCH ACTION [NEXTHOP]
-	args := []string{"lr-policy-add", router, strconv.Itoa(int(priority)), match, action}
+	args := []string{MayExist, "lr-policy-add", router, strconv.Itoa(int(priority)), match, action}
 	if nextHop != "" {
 		args = append(args, nextHop)
 	}
 	if _, err := c.ovnNbCommand(args...); err != nil {
 		return err
 	}
+
+	if len(externalIDs) == 0 {
+		return nil
+	}
+
+	result, err := c.CustomFindEntity("logical_router_policy", []string{"_uuid"}, fmt.Sprintf("priority=%d", priority), fmt.Sprintf(`match="%s"`, match))
+	if err != nil {
+		klog.Errorf("failed to get logical router policy UUID: %v", err)
+		return err
+	}
+	for _, policy := range result {
+		args := make([]string, 0, len(externalIDs)+3)
+		args = append(args, "set", "logical_router_policy", policy["_uuid"][0])
+		for k, v := range externalIDs {
+			args = append(args, fmt.Sprintf("external-ids:%s=%v", k, v))
+		}
+		if _, err = c.ovnNbCommand(args...); err != nil {
+			return fmt.Errorf("failed to set external ids of logical router policy %s: %v", policy["_uuid"][0], err)
+		}
+	}
+
 	return nil
 }
 
@@ -2178,16 +2191,14 @@ func (c *Client) PolicyRouteExists(priority int32, match string) (bool, error) {
 }
 
 func (c *Client) GetPolicyRouteParas(priority int32, match string) ([]string, map[string]string, error) {
-	var nexthops []string
-	result, err := c.CustomFindEntity("Logical_Router_Policy", []string{"nexthops", "external_ids"}, fmt.Sprintf("priority=%d", priority), fmt.Sprintf("match=\"%s\"", match))
+	result, err := c.CustomFindEntity("Logical_Router_Policy", []string{"nexthops", "external_ids"}, fmt.Sprintf("priority=%d", priority), fmt.Sprintf(`match="%s"`, match))
 	if err != nil {
 		klog.Errorf("customFindEntity failed, %v", err)
-		return nexthops, nil, err
+		return nil, nil, err
 	}
 	if len(result) == 0 {
-		return nexthops, nil, nil
+		return nil, nil, nil
 	}
-	nexthops = append(nexthops, result[0]["nexthops"]...)
 
 	nameIpMap := make(map[string]string, len(result[0]["external_ids"]))
 	for _, l := range result[0]["external_ids"] {
@@ -2203,7 +2214,7 @@ func (c *Client) GetPolicyRouteParas(priority int32, match string) ([]string, ma
 		nameIpMap[name] = ip
 	}
 
-	return nexthops, nameIpMap, nil
+	return result[0]["nexthops"], nameIpMap, nil
 }
 
 func (c Client) SetPolicyRouteExternalIds(priority int32, match string, nameIpMaps map[string]string) error {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -129,9 +129,9 @@ const (
 	EcmpRouteType   = "ecmp"
 	NormalRouteType = "normal"
 
-	PodRouterPolicyPriority  = 20000
-	CentralSubnetPriority    = 25000
-	NodeRouterPolicyPriority = 30000
+	GatewayRouterPolicyPriority = 29000
+	NodeRouterPolicyPriority    = 30000
+	SubnetRouterPolicyPriority  = 31000
 
 	OffloadType  = "offload-port"
 	InternalType = "internal-port"

--- a/test/e2e/qos/qos.go
+++ b/test/e2e/qos/qos.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -215,7 +216,11 @@ var _ = Describe("[Qos]", func() {
 
 	It("update htb qos", func() {
 		name := f.GetName()
+		isIPv6 := strings.EqualFold(os.Getenv("IPV6"), "true")
 		cidr := "20.6.0.0/16"
+		if isIPv6 {
+			cidr = "fc00:20:6::/112"
+		}
 
 		By("create subnet with htbqos")
 		s := kubeovn.Subnet{

--- a/test/e2e/subnet/normal.go
+++ b/test/e2e/subnet/normal.go
@@ -56,7 +56,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			af, cidr, protocol := 4, "11.10.0.0/16", kubeovn.ProtocolIPv4
 			if isIPv6 {
-				af, cidr, protocol = 6, "fc10::/16", kubeovn.ProtocolIPv6
+				af, cidr, protocol = 6, "fc00:11:10::/112", kubeovn.ProtocolIPv6
 			}
 			gateway, _ := util.FirstIP(cidr)
 
@@ -95,7 +95,7 @@ var _ = Describe("[Subnet]", func() {
 			By("validate status")
 			Expect(subnet.Status.ActivateGateway).To(BeEmpty())
 			if isIPv6 {
-				Expect(subnet.Status.V6AvailableIPs).To(Equal(math.Exp2(128-16) - 3))
+				Expect(subnet.Status.V6AvailableIPs).To(Equal(math.Exp2(128-112) - 3))
 			} else {
 				Expect(subnet.Status.V4AvailableIPs).To(Equal(math.Exp2(32-16) - 3))
 			}
@@ -115,7 +115,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			cidr := "11.11.0.0/16"
 			if isIPv6 {
-				cidr = "fc11::/16"
+				cidr = "fc00:11:11::/112"
 			}
 
 			By("create subnet")
@@ -150,7 +150,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			cidr := "11.12.0.0/16"
 			if isIPv6 {
-				cidr = "fc12::/16"
+				cidr = "fc00:11:12::/112"
 			}
 
 			By("create subnet")
@@ -195,7 +195,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			cidr := "11.13.0.0/16"
 			if isIPv6 {
-				cidr = "fc13::/16"
+				cidr = "fc00:11:13::/112"
 			}
 			By("create subnet")
 			s := kubeovn.Subnet{
@@ -231,7 +231,7 @@ var _ = Describe("[Subnet]", func() {
 			name := f.GetName()
 			cidr := "11.14.0.10/16"
 			if isIPv6 {
-				cidr = "fc14::/16"
+				cidr = "fc00:11:14::/112"
 			}
 			By("create subnet")
 			s := &kubeovn.Subnet{
@@ -256,7 +256,7 @@ var _ = Describe("[Subnet]", func() {
 			if !isIPv6 {
 				Expect(s.Spec.CIDRBlock).To(Equal("11.14.0.0/16"))
 			} else {
-				Expect(s.Spec.CIDRBlock).To(Equal("fc14::/16"))
+				Expect(s.Spec.CIDRBlock).To(Equal("fc00:11:14::/112"))
 			}
 
 		})
@@ -352,7 +352,7 @@ var _ = Describe("[Subnet]", func() {
 
 			af, cidr := 4, "11.15.0.0/16"
 			if isIPv6 {
-				af, cidr = 6, "fc15::/16"
+				af, cidr = 6, "fc00:11:15::/112"
 			}
 
 			var egw string
@@ -491,7 +491,7 @@ var _ = Describe("[Subnet]", func() {
 
 			af, cidr := 4, "11.16.0.0/16"
 			if isIPv6 {
-				af, cidr = 6, "fc16::/16"
+				af, cidr = 6, "fc00:11:16::/112"
 			}
 
 			var selectedNode *corev1.Node


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

This patch fixes #1467.

New OVN routes:

```shell
Routing Policies
     # pod/node to overlay subnets
     31000                            ip4.dst == 10.16.0.0/16    allow
     31000                           ip4.dst == 100.64.0.0/16    allow
     # pod to node
     30000                              ip4.dst == 172.18.0.2  reroute  100.64.0.2
     30000                              ip4.dst == 172.18.0.3  reroute  100.64.0.3
     # distributed gateway
     29000 ip4.src == $ovn.default.kube.ovn.control.plane_ip4  reroute  100.64.0.2
     29000        ip4.src == $ovn.default.kube.ovn.worker_ip4  reroute  100.64.0.3
     # centralized gateway
     29000                            ip4.src == 10.17.0.0/16  reroute  100.64.0.2
IPv4 Routes
Route Table <main>:
                0.0.0.0/0                100.64.0.1 dst-ip
```