### PR TITLE
add netem qos when create pod

### DIFF
--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -22,11 +22,11 @@ func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, ne
 	return errors.New("DPDK is not supported on Windows")
 }
 
-func (csh cniServerHandler) configureNicWithInternalPort(podName, podNamespace, provider, netns, containerID, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute bool, routes []request.Route, dnsServer, dnsSuffix []string, ingress, egress, priority, DeviceID, nicType string, gwCheckMode int) (string, error) {
-	return ifName, csh.configureNic(podName, podNamespace, provider, netns, containerID, "", ifName, mac, mtu, ip, gateway, isDefaultRoute, routes, dnsServer, dnsSuffix, ingress, egress, priority, DeviceID, nicType, gwCheckMode)
+func (csh cniServerHandler) configureNicWithInternalPort(podName, podNamespace, provider, netns, containerID, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute bool, routes []request.Route, dnsServer, dnsSuffix []string, ingress, egress, priority, DeviceID, nicType, latency, limit, loss string, gwCheckMode int) (string, error) {
+	return ifName, csh.configureNic(podName, podNamespace, provider, netns, containerID, "", ifName, mac, mtu, ip, gateway, isDefaultRoute, routes, dnsServer, dnsSuffix, ingress, egress, priority, DeviceID, nicType, latency, limit, loss, gwCheckMode)
 }
 
-func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute bool, routes []request.Route, dnsServer, dnsSuffix []string, ingress, egress, priority, DeviceID, nicType string, gwCheckMode int) error {
+func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute bool, routes []request.Route, dnsServer, dnsSuffix []string, ingress, egress, priority, DeviceID, nicType, latency, limit, loss string, gwCheckMode int) error {
 	if DeviceID != "" {
 		return errors.New("SR-IOV is not supported on Windows")
 	}

--- a/test/e2e/qos/qos.go
+++ b/test/e2e/qos/qos.go
@@ -34,6 +34,65 @@ var _ = Describe("[Qos]", func() {
 		Fail(err.Error())
 	}
 
+	It("create netem qos", func() {
+		name := f.GetName()
+		autoMount := false
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"e2e":                    "true",
+					"kubernetes.io/hostname": "kube-ovn-control-plane",
+				},
+				Annotations: map[string]string{
+					util.NetemQosLatencyAnnotation: "600",
+					util.NetemQosLimitAnnotation:   "2000",
+					util.NetemQosLossAnnotation:    "10",
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "kube-ovn-control-plane",
+				Containers: []corev1.Container{
+					{
+						Name:            name,
+						Image:           testImage,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+					},
+				},
+				AutomountServiceAccountToken: &autoMount,
+			},
+		}
+
+		By("Create pod")
+		_, err := f.KubeClientSet.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = f.WaitPodReady(name, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Check Qos annotation")
+		pod, err = f.KubeClientSet.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pod.Annotations[util.AllocatedAnnotation]).To(Equal("true"))
+		Expect(pod.Annotations[util.RoutedAnnotation]).To(Equal("true"))
+		Expect(pod.Annotations[util.NetemQosLatencyAnnotation]).To(Equal("600"))
+		Expect(pod.Annotations[util.NetemQosLimitAnnotation]).To(Equal("2000"))
+		Expect(pod.Annotations[util.NetemQosLossAnnotation]).To(Equal("10"))
+
+		By("Check Ovs Qos Para")
+		time.Sleep(3 * time.Second)
+		qos, err := framework.GetPodNetemQosPara(name, namespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(qos.Latency).To(Equal("600000"))
+		Expect(qos.Limit).To(Equal("2000"))
+		Expect(qos.Loss).To(Equal("10"))
+
+		By("Delete pod")
+		err = f.KubeClientSet.CoreV1().Pods(namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("update netem qos", func() {
 		name := f.GetName()
 		autoMount := false


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、add netem qos when create pod with annotation
2、only support pod with veth-pair or internal-port, do not process for dpdk and windows type

#### Which issue(s) this PR fixes:
Fixes #1451 



