### PR TITLE
set ether dst addr for dnat on logical switch

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -32,6 +32,8 @@ RUN cd /usr/src/ && git clone -b v22.03.1 --depth=1 https://github.com/ovn-org/o
     curl -s https://github.com/kubeovn/ovn/commit/d26ae4de0ab070f6b602688ba808c8963f69d5c4.patch | git apply && \
     # change hash type from dp_hash to hash with field src_ip
     curl -s https://github.com/kubeovn/ovn/commit/ab923b252271cbbcccc8091e338ee7efe75e5fcd.patch | git apply && \
+    # set ether dst addr for dnat on logical switch
+    curl -s https://github.com/kubeovn/ovn/commit/94b73d939cd33b0531fa9a3422c999cd83ead087.patch | git apply && \
     sed -i 's/OVN/ovn/g' debian/changelog && \
     rm -rf .git && \
     ./boot.sh && \

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -13,6 +13,7 @@ HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_LB=${ENABLE_LB:-true}
 ENABLE_NP=${ENABLE_NP:-true}
 ENABLE_EIP_SNAT=${ENABLE_EIP_SNAT:-true}
+LS_DNAT_MOD_DL_DST=${LS_DNAT_MOD_DL_DST:-true}
 WITHOUT_KUBE_PROXY=${WITHOUT_KUBE_PROXY:-false}
 ENABLE_EXTERNAL_VPC=${ENABLE_EXTERNAL_VPC:-true}
 CNI_CONFIG_PRIORITY=${CNI_CONFIG_PRIORITY:-01}
@@ -2564,6 +2565,7 @@ spec:
           - --network-type=$NETWORK_TYPE
           - --default-interface-name=$VLAN_INTERFACE_NAME
           - --default-vlan-id=$VLAN_ID
+          - --ls-dnat-mod-dl-dst=$LS_DNAT_MOD_DL_DST
           - --pod-nic-type=$POD_NIC_TYPE
           - --enable-lb=$ENABLE_LB
           - --enable-np=$ENABLE_NP

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -69,6 +69,7 @@ type Configuration struct {
 	DefaultHostInterface string
 	DefaultVlanName      string
 	DefaultVlanID        int
+	LsDnatModDlDst       bool
 
 	EnableLb          bool
 	EnableNP          bool
@@ -123,6 +124,7 @@ func ParseFlags() (*Configuration, error) {
 		argDefaultInterfaceName = pflag.String("default-interface-name", "", "The default host interface name in the vlan/vxlan type")
 		argDefaultVlanName      = pflag.String("default-vlan-name", "ovn-vlan", "The default vlan name")
 		argDefaultVlanID        = pflag.Int("default-vlan-id", 1, "The default vlan id")
+		argLsDnatModDlDst       = pflag.Bool("ls-dnat-mod-dl-dst", true, "Set ethernet destination address for DNAT on logical switch")
 		argPodNicType           = pflag.String("pod-nic-type", "veth-pair", "The default pod network nic implementation type")
 		argEnableLb             = pflag.Bool("enable-lb", true, "Enable load balancer")
 		argEnableNP             = pflag.Bool("enable-np", true, "Enable network policy support")
@@ -182,6 +184,7 @@ func ParseFlags() (*Configuration, error) {
 		PprofPort:                     *argPprofPort,
 		NetworkType:                   *argNetworkType,
 		DefaultVlanID:                 *argDefaultVlanID,
+		LsDnatModDlDst:                *argLsDnatModDlDst,
 		DefaultProviderName:           *argDefaultProviderName,
 		DefaultHostInterface:          *argDefaultInterfaceName,
 		DefaultVlanName:               *argDefaultVlanName,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -481,6 +481,9 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		klog.Fatalf("failed to wait for caches to sync")
 	}
 
+	if err := c.ovnLegacyClient.SetLsDnatModDlDst(c.config.LsDnatModDlDst); err != nil {
+		klog.Fatal(err)
+	}
 	if err := c.ovnLegacyClient.SetUseCtInvMatch(); err != nil {
 		klog.Fatalf("failed to set NB_Global option use_ct_inv_match to false: %v", err)
 	}

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -75,6 +75,13 @@ func (c LegacyClient) SetAzName(azName string) error {
 	return nil
 }
 
+func (c LegacyClient) SetLsDnatModDlDst(enabled bool) error {
+	if _, err := c.ovnNbCommand("set", "NB_Global", ".", fmt.Sprintf("options:ls_dnat_mod_dl_dst=%v", enabled)); err != nil {
+		return fmt.Errorf("failed to set NB_Global option ls_dnat_mod_dl_dst to %v: %v", enabled, err)
+	}
+	return nil
+}
+
 func (c LegacyClient) SetUseCtInvMatch() error {
 	if _, err := c.ovnNbCommand("set", "NB_Global", ".", "options:use_ct_inv_match=false"); err != nil {
 		return fmt.Errorf("failed to set NB_Global option use_ct_inv_match to false: %v", err)


### PR DESCRIPTION
### What type of this PR

- Feature

This patch adds a new OVN NB option `ls_dnat_mod_dl_dst`. If the option is turned on, logical flows are added to the logical switch ingress datapath to translate ethernet destination addresses for DNAT packets.

A new table called `ls_in_after_lb` is added to the logical switch ingress datapath. On default, there is only one logical flow:

```txt
table=14(ls_in_after_lb), priority=0, match=(1), action=(next;)
```

When `ls_dnat_mod_dl_dst` is set to `true`, extra logical flows are added to the table:

```txt
table=14(ls_in_after_lb), priority=100, match=(!ct.dnat), action=(next;)
table=14(ls_in_after_lb), priority=60 , match=(ip4.dst != {10.16.0.0/16}), action=(next;)
table=14(ls_in_after_lb), priority=60 , match=(ip6), action=(next;)
table=14(ls_in_after_lb), priority=50 , match=(ip4.dst == 10.16.0.6), action=(eth.dst = 00:00:00:d0:09:05; next;)
table=14(ls_in_after_lb), priority=50 , match=(ip4.dst == 10.16.0.7), action=(eth.dst = 00:00:00:14:c4:5a; next;)
table=14(ls_in_after_lb), priority=50 , match=(ip4.dst == 10.16.0.8), action=(eth.dst = 00:00:00:d9:e3:a2; next;)
table=14(ls_in_after_lb), priority=50 , match=(ip4.dst == 10.16.0.9), action=(eth.dst = 00:00:00:6b:a2:0e; next;)
table=14(ls_in_after_lb), priority=0  , match=(1), action=(next;)
```

OVN trace result:

```shell
kubectl ko trace kube-system/kube-ovn-pinger-krbkw 10.96.0.10 tcp 9153
+ kubectl exec ovn-central-548f459bcc-jbwlw -n kube-system -c ovn-central -- ovn-trace --ct=new ovn-default 'inport == "kube-ovn-pinger-krbkw.kube-system" && ip.ttl == 64 && eth.src == 00:00:00:14:C4:5A && ip4.src == 10.16.0.7 && eth.dst == 00:00:00:6C:EA:86 && ip4.dst == 10.96.0.10 && tcp.src == 10000 && tcp.dst == 9153'
# tcp,reg14=0x7,vlan_tci=0x0000,dl_src=00:00:00:14:c4:5a,dl_dst=00:00:00:6c:ea:86,nw_src=10.16.0.7,nw_dst=10.96.0.10,nw_tos=0,nw_ecn=0,nw_ttl=64,tp_src=10000,tp_dst=9153,tcp_flags=0

ingress(dp="ovn-default", inport="kube-ovn-pinger-krbkw.kube-system")
---------------------------------------------------------------------
 0. ls_in_port_sec_l2 (northd.c:5511): inport == "kube-ovn-pinger-krbkw.kube-system", priority 50, uuid 8558af07
    next;
 6. ls_in_pre_lb (northd.c:5906): ip4 && ip4.dst == 10.96.0.0/12, priority 100, uuid a82cccb6
    reg0[2] = 1;
    next;
 7. ls_in_pre_stateful (northd.c:5941): reg0[2] == 1 && ip4 && tcp, priority 120, uuid 14b991d5
    reg1 = ip4.dst;
    reg2[0..15] = tcp.dst;
    ct_lb;

ct_lb
-----
 8. ls_in_acl_hint (northd.c:6012): ct.new && !ct.est, priority 7, uuid f816c64a
    reg0[7] = 1;
    reg0[9] = 1;
    next;
 9. ls_in_acl (northd.c:6579): ip && (!ct.est || (ct.est && ct_label.blocked == 1)), priority 1, uuid fd9fa7aa
    reg0[1] = 1;
    next;
12. ls_in_lb (northd.c:6890): ct.new && ip4.dst == 10.96.0.10 && tcp.dst == 9153, priority 120, uuid 65f2dfb2
    reg0[1] = 0;
    reg1 = 10.96.0.10;
    reg2[0..15] = 9153;
    ct_lb(backends=10.16.0.6:9153,10.16.0.8:9153);

ct_lb /* default (use --ct to customize) */
-------------------------------------------
14. ls_in_after_lb (northd.c:6981): ip4.dst == 10.16.0.8, priority 50, uuid 3c8ef3b5
    eth.dst = 00:00:00:d9:e3:a2;
    next;
16. ls_in_pre_hairpin (northd.c:7058): ip && ct.trk, priority 100, uuid 1c521773
    reg0[6] = chk_lb_hairpin();
    reg0[12] = chk_lb_hairpin_reply();
    *** chk_lb_hairpin_reply action not implemented
    next;
25. ls_in_l2_lkup (northd.c:8478): eth.dst == 00:00:00:d9:e3:a2, priority 50, uuid 583fd834
    outport = "coredns-64897985d-x4xpt.kube-system";
    output;

egress(dp="ovn-default", inport="kube-ovn-pinger-krbkw.kube-system", outport="coredns-64897985d-x4xpt.kube-system")
-------------------------------------------------------------------------------------------------------------------
 0. ls_out_pre_lb (northd.c:5916): ip, priority 100, uuid 245f7ca1
    reg0[2] = 1;
    next;
 2. ls_out_pre_stateful (northd.c:5961): reg0[2] == 1, priority 110, uuid 391a0f39
    ct_lb;

ct_lb /* default (use --ct to customize) */
-------------------------------------------
 3. ls_out_acl_hint (northd.c:6065): ct.est && ct_label.blocked == 0, priority 1, uuid f20126d2
    reg0[10] = 1;
    next;
 9. ls_out_port_sec_l2 (northd.c:5608): outport == "coredns-64897985d-x4xpt.kube-system", priority 50, uuid 42d55153
    output;
    /* output to "coredns-64897985d-x4xpt.kube-system", type "" */
```

### Performance Comparison

Unit: Gbits/sec

#### Overlay

| Case | Before | After |
| --- | ---: | ---: |
| Same Node | 15.2 |  14.7 |
| Cross Nodes | 10.6 | 10.4 |

#### Underlay

| Case | Before | After |
| --- | ---: | ---: |
| Same Node | 6.8 | 17.4 |
| Cross Nodes | 5.8 | 10.9 |
