### PR TITLE
reduce ovs-ovn restart downtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,12 @@ kind-reload:
 	kubectl delete pod -n kube-system -l app=kube-ovn-controller
 	kubectl delete pod -n kube-system -l app=kube-ovn-cni
 	kubectl delete pod -n kube-system -l app=kube-ovn-pinger
+	kubectl delete pod -n kube-system -l app=ovs
+
+.PHONY: kind-reload-ovs
+kind-reload-ovs:
+	kind load docker-image --name kube-ovn $(REGISTRY)/kube-ovn:$(RELEASE_TAG)
+	kubectl delete pod -n kube-system -l app=ovs
 
 .PHONY: kind-clean
 kind-clean:


### PR DESCRIPTION
1. start ovsdb  without vswitchd
2. set flow-restore-wait to true to prevent vswitchd flush the flow
3. start ovn-controller and wait ${FLOW_WAIT} seconds to compute init flow
4. set flow-restore-wait to false to indicate vswitchd to process

The network downtime decrease from 2.9 seconds to 0

#### Which issue(s) this PR fixes:
Fixes #1420 



