### PR TITLE
move dumb-init from base images to kube-ovn image

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -1,6 +1,13 @@
 # syntax = docker/dockerfile:experimental
 FROM kubeovn/kube-ovn-base:v1.10.0
 
+ARG ARCH
+ENV DUMB_INIT_VERSION="1.2.5"
+RUN dump_arch="x86_64"; \
+    if [ "$ARCH" = "arm64" ]; then dump_arch="aarch64"; fi; \
+    curl -sSf -L --retry 5 -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${dump_arch} && \
+    chmod +x /usr/bin/dumb-init
+
 COPY *.sh /kube-ovn/
 COPY kubectl-ko /kube-ovn/kubectl-ko
 COPY 01-kube-ovn.conflist /kube-ovn/01-kube-ovn.conflist
@@ -19,3 +26,5 @@ RUN ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-speaker && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-controller-healthcheck && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-leader-checker
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -75,11 +75,3 @@ RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \
     dpkg -i /packages/openvswitch-*.deb && \
     dpkg -i /packages/python3-openvswitch*.deb &&\
     dpkg -i --ignore-depends=openvswitch-switch,openvswitch-common /packages/ovn-*.deb
-
-ENV DUMB_INIT_VERSION="1.2.5"
-RUN dump_arch="x86_64"; \
-    if [ "$ARCH" = "arm64" ]; then dump_arch="aarch64"; fi; \
-    curl -sSf -L --retry 5 -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${dump_arch} && \
-    chmod +x /usr/bin/dumb-init
-
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
#### What type of this PR

Base image builds fail currently. We need to move dumb-init to make it work.