### PR TITLE
CNI: do not return route if nic is not eth0

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -81,13 +81,17 @@ func generateCNIResult(cniResponse *request.CniResponse) current.Result {
 	switch cniResponse.Protocol {
 	case kubeovnv1.ProtocolIPv4:
 		ip, route := assignV4Address(cniResponse.IpAddress, cniResponse.Gateway, mask)
-		result.IPs = []*current.IPConfig{&ip}
-		result.Routes = []*types.Route{&route}
+		result.IPs = []*current.IPConfig{ip}
+		if route != nil {
+			result.Routes = []*types.Route{route}
+		}
 		result.Interfaces = []*current.Interface{&podIface}
 	case kubeovnv1.ProtocolIPv6:
 		ip, route := assignV6Address(cniResponse.IpAddress, cniResponse.Gateway, mask)
-		result.IPs = []*current.IPConfig{&ip}
-		result.Routes = []*types.Route{&route}
+		result.IPs = []*current.IPConfig{ip}
+		if route != nil {
+			result.Routes = []*types.Route{route}
+		}
 		result.Interfaces = []*current.Interface{&podIface}
 	case kubeovnv1.ProtocolDual:
 		var netMask *net.IPNet
@@ -98,15 +102,19 @@ func generateCNIResult(cniResponse *request.CniResponse) current.Result {
 				gwStr := strings.Split(cniResponse.Gateway, ",")[0]
 
 				ip, route := assignV4Address(ipStr, gwStr, netMask)
-				result.IPs = append(result.IPs, &ip)
-				result.Routes = append(result.Routes, &route)
+				result.IPs = append(result.IPs, ip)
+				if route != nil {
+					result.Routes = append(result.Routes, route)
+				}
 			} else if util.CheckProtocol(cidrBlock) == kubeovnv1.ProtocolIPv6 {
 				ipStr := strings.Split(cniResponse.IpAddress, ",")[1]
 				gwStr := strings.Split(cniResponse.Gateway, ",")[1]
 
 				ip, route := assignV6Address(ipStr, gwStr, netMask)
-				result.IPs = append(result.IPs, &ip)
-				result.Routes = append(result.Routes, &route)
+				result.IPs = append(result.IPs, ip)
+				if route != nil {
+					result.Routes = append(result.Routes, route)
+				}
 			}
 		}
 		result.Interfaces = []*current.Interface{&podIface}
@@ -191,29 +199,35 @@ func parseValueFromArgs(key, argString string) (string, error) {
 	return "", fmt.Errorf("%s is required in CNI_ARGS", key)
 }
 
-func assignV4Address(ipAddress, gateway string, mask *net.IPNet) (current.IPConfig, types.Route) {
-	ip := current.IPConfig{
+func assignV4Address(ipAddress, gateway string, mask *net.IPNet) (*current.IPConfig, *types.Route) {
+	ip := &current.IPConfig{
 		Address: net.IPNet{IP: net.ParseIP(ipAddress).To4(), Mask: mask.Mask},
 		Gateway: net.ParseIP(gateway).To4(),
 	}
 
-	route := types.Route{
-		Dst: net.IPNet{IP: net.ParseIP("0.0.0.0").To4(), Mask: net.CIDRMask(0, 32)},
-		GW:  net.ParseIP(gateway).To4(),
+	var route *types.Route
+	if gw := net.ParseIP(gateway); gw != nil {
+		route = &types.Route{
+			Dst: net.IPNet{IP: net.ParseIP("0.0.0.0").To4(), Mask: net.CIDRMask(0, 32)},
+			GW:  net.ParseIP(gateway).To4(),
+		}
 	}
 
 	return ip, route
 }
 
-func assignV6Address(ipAddress, gateway string, mask *net.IPNet) (current.IPConfig, types.Route) {
-	ip := current.IPConfig{
+func assignV6Address(ipAddress, gateway string, mask *net.IPNet) (*current.IPConfig, *types.Route) {
+	ip := &current.IPConfig{
 		Address: net.IPNet{IP: net.ParseIP(ipAddress).To16(), Mask: mask.Mask},
 		Gateway: net.ParseIP(gateway).To16(),
 	}
 
-	route := types.Route{
-		Dst: net.IPNet{IP: net.ParseIP("::").To16(), Mask: net.CIDRMask(0, 128)},
-		GW:  net.ParseIP(gateway).To16(),
+	var route *types.Route
+	if gw := net.ParseIP(gateway); gw != nil {
+		route = &types.Route{
+			Dst: net.IPNet{IP: net.ParseIP("::").To16(), Mask: net.CIDRMask(0, 128)},
+			GW:  net.ParseIP(gateway).To16(),
+		}
 	}
 
 	return ip, route

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -279,7 +279,17 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 	}
 
-	if err := resp.WriteHeaderAndEntity(http.StatusOK, request.CniResponse{Protocol: util.CheckProtocol(cidr), IpAddress: ip, MacAddress: macAddr, CIDR: cidr, Gateway: gw, PodNicName: podNicName}); err != nil {
+	response := &request.CniResponse{
+		Protocol:   util.CheckProtocol(cidr),
+		IpAddress:  ip,
+		MacAddress: macAddr,
+		CIDR:       cidr,
+		PodNicName: podNicName,
+	}
+	if isDefaultRoute {
+		response.Gateway = gw
+	}
+	if err := resp.WriteHeaderAndEntity(http.StatusOK, response); err != nil {
 		klog.Errorf("failed to write response, %v", err)
 	}
 }


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

When the Pod nic is not eth1, the CNI result should not contain the default route.

This patch fixes duplicate default routes in VPC NAT gateway Pods:

```shell
/kube-ovn # ip -c r
default via 192.168.0.1 dev net1
default via 10.0.1.1 dev eth0
```