### PR TITLE
fix exec cmd in vpc nat gateway

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -8,7 +8,7 @@ function exec_cmd() {
     ret=$?
     if [ $ret -ne 0 ]; then
         echo "failed to exec \"$cmd\""
-        exit $1
+        exit $ret
     fi
 }
 


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

Fix the error `numeric argument required` when arping command failed:

```shell
bash-5.1# bash debug.sh
+ exec_cmd 'arping -c 3 -s 172.18.0.3 172.18.0.254'
+ cmd='arping -c 3 -s 172.18.0.3 172.18.0.254'
+ arping -c 3 -s 172.18.0.3 172.18.0.254
ARPING 172.18.0.254 from 172.18.0.3 eth0
Sent 3 probes (3 broadcast(s))
Received 0 response(s)
+ ret=1
+ '[' 1 -ne 0 ']'
+ echo 'failed to exec "arping -c 3 -s 172.18.0.3 172.18.0.254"'
failed to exec "arping -c 3 -s 172.18.0.3 172.18.0.254"
+ exit arping -c 3 -s 172.18.0.3 172.18.0.254
debug.sh: line 9: exit: arping: numeric argument required
```