### PR TITLE
do not gc vm pod lsp when vm still exists

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -236,6 +236,10 @@ func (c *Controller) markAndCleanLSP() error {
 		}
 	}
 
+	// The lsp for vm pod should not be deleted if vm still exists
+	vmLsps := c.getVmLsps()
+	ipNames = append(ipNames, vmLsps...)
+
 	lsps, err := c.ovnClient.ListLogicalSwitchPort(c.config.EnableExternalVpc)
 	if err != nil {
 		klog.Errorf("failed to list logical switch port, %v", err)
@@ -571,4 +575,35 @@ func (c *Controller) isOVNProvided(providerName string, pod *corev1.Pod) (bool, 
 		return false, nil
 	}
 	return true, nil
+}
+
+func (c *Controller) getVmLsps() []string {
+	var vmLsps []string
+
+	if !c.config.EnableKeepVmIP {
+		return vmLsps
+	}
+
+	nss, err := c.namespacesLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list namespaces, %v", err)
+		return vmLsps
+	}
+
+	for _, ns := range nss {
+		vms, err := c.config.KubevirtClient.VirtualMachine(ns.Name).List(&metav1.ListOptions{})
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				klog.Errorf("failed to list vm in namespace %s, %v", ns, err)
+			}
+			continue
+		} else {
+			for _, vm := range vms.Items {
+				vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, util.OvnProvider)
+				vmLsps = append(vmLsps, vmLsp)
+			}
+		}
+	}
+
+	return vmLsps
 }


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、do not gc vm pod lsp when vm still exists (keep-vm-ip flag is set in kube-ovn-controller)
2、The same problem exists for sts when sts pods do not use ip_pool to assign static ips

#### Which issue(s) this PR fixes:
Fixes #1502



