### PR TITLE
do not delete static routes on controller startup

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -520,9 +520,6 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	if err := c.initSyncCrdVlans(); err != nil {
 		klog.Errorf("failed to sync crd vlans: %v", err)
 	}
-	if err := c.initDeleteOverlayPodsStaticRoutes(); err != nil {
-		klog.Errorf("failed to delete pod's static route in default vpc: %v", err)
-	}
 	// The static route for node gw can be deleted when gc static route, so add it after gc process
 	dstIp := "0.0.0.0/0,::/0"
 	if err := c.ovnLegacyClient.AddStaticRoute("", dstIp, c.config.NodeSwitchGateway, c.config.ClusterRouter, util.NormalRouteType); err != nil {

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -764,35 +764,3 @@ func (c *Controller) initHtbQos() error {
 	}
 	return err
 }
-
-func (c *Controller) initDeleteOverlayPodsStaticRoutes() error {
-	pods, err := c.podsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list pods: %v", err)
-		return err
-	}
-	for _, pod := range pods {
-		if pod.Spec.HostNetwork {
-			continue
-		}
-		podNets, err := c.getPodKubeovnNets(pod)
-		if err != nil {
-			klog.Errorf("failed to get pod kubeovn nets %s.%s address %s: %v", pod.Name, pod.Namespace, pod.Annotations[util.IpAddressAnnotation], err)
-			continue
-		}
-		for _, podNet := range podNets {
-			if !isOvnSubnet(podNet.Subnet) || podNet.Subnet.Spec.Vpc != util.DefaultVpc || podNet.Subnet.Spec.Vlan != "" || podNet.Subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
-				continue
-			}
-			if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] == "true" {
-				for _, podIP := range strings.Split(pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)], ",") {
-					if err := c.ovnLegacyClient.DeleteStaticRoute(podIP, podNet.Subnet.Spec.Vpc); err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
#### What type of this PR

- Performance

In a cluster with a lot of Pods, it takes too long to handle the deletion even if no static routes exist. Obsolete static routes will be deleted in GC, so it's OK to remove the function.
