### PR TITLE
fix 'request ip return 500 no address allocated' when pod is created by ephemeral VMI

### DIFF
--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -140,6 +140,7 @@ const (
 	HostnameEnv    = "KUBE_NODE_NAME"
 	ChasRetryTime  = 5
 	ChasRetryIntev = 1
+	Vm             = "VirtualMachine"
 	VmInstance     = "VirtualMachineInstance"
 
 	MirrorControlAnnotation = "ovn.kubernetes.io/mirror"


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

1. Fix: pod would not get neither `*/allocated` nor `*/routed` Annotations, when it was created by ephemeral VMI which not managed by a VM
2. Fix: kube-ovn-controller crashed when VM's Template without an Annotations;

#### Which issue(s) this PR fixes:
Fixes #1557



