### PR TITLE
Fix incorrect usage info of 'argExternalGatewayNet'

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -129,7 +129,7 @@ func ParseFlags() (*Configuration, error) {
 		argKeepVmIP             = pflag.Bool("keep-vm-ip", false, "Whether to keep ip for kubevirt pod when pod is rebuild")
 
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")
-		argExternalGatewayNet      = pflag.String("external-gateway-net", "external", "The namespace of configmap external-gateway-config, default: external")
+		argExternalGatewayNet      = pflag.String("external-gateway-net", "external", "The name of the external network which mappings with an ovs bridge, default: external")
 		argExternalGatewayVlanID   = pflag.Int("external-gateway-vlanid", 0, "The vlanId of port ln-ovn-external, default: 0")
 	)
 


### PR DESCRIPTION
introduced in https://github.com/kubeovn/kube-ovn/pull/1247



