### PR TITLE
fix: Do not Recreate Logical_Router_Port when Vpc recreated

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router.go
+++ b/pkg/ovs/ovn-nb-logical_router.go
@@ -26,6 +26,6 @@ func (c OvnClient) GetLogicalRouter(name string, ignoreNotFound bool) (*ovnnb.Lo
 }
 
 func (c OvnClient) LogicalRouterExists(name string) (bool, error) {
-	lsp, err := c.GetLogicalRouter(name, true)
-	return lsp != nil, err
+	lr, err := c.GetLogicalRouter(name, true)
+	return lr != nil, err
 }

--- a/pkg/ovs/ovn-nb-logical_router.go
+++ b/pkg/ovs/ovn-nb-logical_router.go
@@ -1,0 +1,31 @@
+package ovs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ovn-org/libovsdb/client"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+)
+
+func (c OvnClient) GetLogicalRouter(name string, ignoreNotFound bool) (*ovnnb.LogicalRouter, error) {
+	predicate := func(model *ovnnb.LogicalRouter) bool {
+		return model.Name == name
+	}
+	// Logical_Router has no indexes defined in the schema
+	var result []*ovnnb.LogicalRouter
+	if err := c.ovnNbClient.WhereCache(predicate).List(context.TODO(), &result); err != nil || len(result) == 0 {
+		if ignoreNotFound && (err == client.ErrNotFound || len(result) == 0) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get logical router %s: %v", name, err)
+	}
+
+	return result[0], nil
+}
+
+func (c OvnClient) LogicalRouterExists(name string) (bool, error) {
+	lsp, err := c.GetLogicalRouter(name, true)
+	return lsp != nil, err
+}

--- a/pkg/ovs/ovn-nb-logical_router_port.go
+++ b/pkg/ovs/ovn-nb-logical_router_port.go
@@ -77,6 +77,6 @@ func (c OvnClient) AddLogicalRouterPort(lr, name, mac, networks string) error {
 }
 
 func (c OvnClient) LogicalRouterPortExists(name string) (bool, error) {
-	lsp, err := c.GetLogicalRouterPort(name, true)
-	return lsp != nil, err
+	lrp, err := c.GetLogicalRouterPort(name, true)
+	return lrp != nil, err
 }

--- a/pkg/ovs/ovn-nb-logical_router_port.go
+++ b/pkg/ovs/ovn-nb-logical_router_port.go
@@ -1,0 +1,82 @@
+package ovs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
+
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func (c OvnClient) GetLogicalRouterPort(name string, ignoreNotFound bool) (*ovnnb.LogicalRouterPort, error) {
+	lrp := &ovnnb.LogicalRouterPort{Name: name}
+	if err := c.ovnNbClient.Get(context.TODO(), lrp); err != nil {
+		if ignoreNotFound && err == client.ErrNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get logical router port %s: %v", name, err)
+	}
+
+	return lrp, nil
+}
+
+func (c OvnClient) AddLogicalRouterPort(lr, name, mac, networks string) error {
+	router, err := c.GetLogicalRouter(lr, false)
+	if err != nil {
+		return err
+	}
+
+	if mac == "" {
+		mac = util.GenerateMac()
+	}
+
+	var ops []ovsdb.Operation
+
+	lrp := &ovnnb.LogicalRouterPort{
+		UUID:        ovsclient.NamedUUID(),
+		Name:        name,
+		MAC:         mac,
+		Networks:    strings.Split(networks, ","),
+		ExternalIDs: map[string]string{"vendor": util.CniTypeName},
+	}
+
+	// ensure there is no port in the same name, before we create it in the transaction
+	waitOp := ConstructWaitForNameNotExistsOperation(name, "Logical_Router_Port")
+	ops = append(ops, waitOp)
+
+	createOps, err := c.ovnNbClient.Create(lrp)
+	if err != nil {
+		return err
+	}
+	ops = append(ops, createOps...)
+
+	mutationOps, err := c.ovnNbClient.
+		Where(router).
+		Mutate(router,
+			model.Mutation{
+				Field:   &router.Ports,
+				Mutator: ovsdb.MutateOperationInsert,
+				Value:   []string{lrp.UUID},
+			},
+		)
+	if err != nil {
+		return err
+	}
+	ops = append(ops, mutationOps...)
+
+	if err := Transact(c.ovnNbClient, "lrp-add", ops, c.ovnNbClient.Timeout); err != nil {
+		return fmt.Errorf("failed to create logical router port %s: %v", name, err)
+	}
+	return nil
+}
+
+func (c OvnClient) LogicalRouterPortExists(name string) (bool, error) {
+	lsp, err := c.GetLogicalRouterPort(name, true)
+	return lsp != nil, err
+}

--- a/pkg/ovs/ovn.go
+++ b/pkg/ovs/ovn.go
@@ -52,6 +52,8 @@ const (
 	Policy      = "--policy"
 	PolicyDstIP = "dst-ip"
 	PolicySrcIP = "src-ip"
+
+	OVSDBWaitTimeout = 0
 )
 
 // NewLegacyClient init a legacy ovn client
@@ -117,4 +119,21 @@ func Transact(c client.Client, method string, operations []ovsdb.Operation, time
 	}
 
 	return nil
+}
+
+func ConstructWaitForNameNotExistsOperation(name string, table string) ovsdb.Operation {
+	return ConstructWaitForUniqueOperation(table, "name", name)
+}
+
+func ConstructWaitForUniqueOperation(table string, column string, value interface{}) ovsdb.Operation {
+	timeout := OVSDBWaitTimeout
+	return ovsdb.Operation{
+		Op:      ovsdb.OperationWait,
+		Table:   table,
+		Timeout: &timeout,
+		Where:   []ovsdb.Condition{{Column: column, Function: ovsdb.ConditionEqual, Value: value}},
+		Columns: []string{column},
+		Until:   "!=",
+		Rows:    []ovsdb.Row{{column: value}},
+	}
 }

--- a/pkg/ovs/util.go
+++ b/pkg/ovs/util.go
@@ -23,3 +23,11 @@ func trimCommandOutput(raw []byte) string {
 	output := strings.TrimSpace(string(raw))
 	return strings.Trim(output, "\"")
 }
+
+func LogicalRouterPortName(lr, ls string) string {
+	return fmt.Sprintf("%s-%s", lr, ls)
+}
+
+func LogicalSwitchPortName(lr, ls string) string {
+	return fmt.Sprintf("%s-%s", ls, lr)
+}

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -84,6 +84,7 @@ func NewNbClient(addr string, timeout int) (client.Client, error) {
 
 	monitorOpts := []client.MonitorOption{
 		client.WithTable(&ovnnb.LogicalRouter{}),
+		client.WithTable(&ovnnb.LogicalRouterPort{}),
 		client.WithTable(&ovnnb.LogicalRouterPolicy{}),
 		client.WithTable(&ovnnb.LogicalSwitchPort{}),
 		client.WithTable(&ovnnb.PortGroup{}),


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:

- Bug fixes

1. Recreate Logical_Router_Port when Vpc recreated
2. New method to check if Logical_Router, Logical_Router_Port exists
3. New method to Create Logical_Router_Port by libovsdb

#### Which issue(s) this PR fixes:
Fixes #1569 



