### PR TITLE
feat: add args for gc/inspect interval

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -85,6 +85,8 @@ DPDK_MEMORY="2Gi"                       # Default Memory configuration for it --
 # performance
 MODULES="kube_ovn_fastpath.ko"
 RPMS="openvswitch-kmod"
+GC_INTERVAL=360
+INSPECT_INTERVAL=20
 
 display_help() {
     echo "Usage: $0 [option...]"
@@ -2569,6 +2571,8 @@ spec:
           - --enable-external-vpc=$ENABLE_EXTERNAL_VPC
           - --logtostderr=false
           - --alsologtostderr=true
+          - --gc-interval=$GC_INTERVAL
+          - --inspect-interval=$INSPECT_INTERVAL
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
           - --log_file_max_size=0
           env:

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -80,6 +80,9 @@ type Configuration struct {
 	ExternalGatewayConfigNS string
 	ExternalGatewayNet      string
 	ExternalGatewayVlanID   int
+
+	GCInterval      int
+	InspectInterval int
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -131,6 +134,9 @@ func ParseFlags() (*Configuration, error) {
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")
 		argExternalGatewayNet      = pflag.String("external-gateway-net", "external", "The name of the external network which mappings with an ovs bridge, default: external")
 		argExternalGatewayVlanID   = pflag.Int("external-gateway-vlanid", 0, "The vlanId of port ln-ovn-external, default: 0")
+
+		argGCInterval      = pflag.Int("gc-interval", 360, "The interval between GC processes, default 360 seconds")
+		argInspectInterval = pflag.Int("inspect-interval", 20, "The interval between inspect processes, default 20 seconds")
 	)
 
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
@@ -192,6 +198,8 @@ func ParseFlags() (*Configuration, error) {
 		EnableEcmp:                    *argEnableEcmp,
 		EnableKeepVmIP:                *argKeepVmIP,
 		NodePgProbeTime:               *argNodePgProbeTime,
+		GCInterval:                    *argGCInterval,
+		InspectInterval:               *argInspectInterval,
 	}
 
 	if config.NetworkType == util.NetworkTypeVlan && config.DefaultHostInterface == "" {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -715,13 +715,13 @@ func (c *Controller) startWorkers(stopCh <-chan struct{}) {
 		if err := c.markAndCleanLSP(); err != nil {
 			klog.Errorf("gc lsp error: %v", err)
 		}
-	}, 6*time.Minute, stopCh)
+	}, time.Duration(c.config.GCInterval)*time.Second, stopCh)
 
 	go wait.Until(func() {
 		if err := c.inspectPod(); err != nil {
 			klog.Errorf("inspection error: %v", err)
 		}
-	}, 20*time.Second, stopCh)
+	}, time.Duration(c.config.InspectInterval)*time.Second, stopCh)
 
 	if c.config.EnableExternalVpc {
 		go wait.Until(func() {


### PR DESCRIPTION

Examples of user facing changes:
- Bug fixes

/kind feature

Add interval configuration for GC and Inspect processes.
Now user could define intervals in install.sh when installation Kube-OVN

#### Which issue(s) this PR fixes:
Fixes #1419 



