### PR TITLE
ci: build amd64 images without avx512

### DIFF
--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -33,13 +33,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           image: tonistiigi/binfmt:latest
           platforms: arm64
 
       - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Go Build Cache
         uses: actions/cache@v3

--- a/.github/workflows/build-dpdk-image.yaml
+++ b/.github/workflows/build-dpdk-image.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build
         run: |

--- a/.github/workflows/build-kube-ovn-base-dpdk.yaml
+++ b/.github/workflows/build-kube-ovn-base-dpdk.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build
         run: |

--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build
         run: |
@@ -31,13 +31,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
-          image: tonistiigi/binfmt:qemu-v5.2.0
           platforms: arm64
 
       - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build
         run: |
@@ -87,6 +86,9 @@ jobs:
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
           docker images
           docker push kubeovn/kube-ovn-base:$TAG-amd64
+          docker push kubeovn/kube-ovn-base:$TAG-amd64-no-avx512
           docker push kubeovn/kube-ovn-base:$TAG-arm64
           docker manifest create kubeovn/kube-ovn-base:$TAG kubeovn/kube-ovn-base:$TAG-amd64 kubeovn/kube-ovn-base:$TAG-arm64
           docker manifest push kubeovn/kube-ovn-base:$TAG
+          docker manifest create kubeovn/kube-ovn-base:$TAG-no-avx512 kubeovn/kube-ovn-base:$TAG-amd64-no-avx512
+          docker manifest push kubeovn/kube-ovn-base:$TAG-no-avx512

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -31,29 +31,32 @@ jobs:
       - name: Check out OVS
         uses: actions/checkout@v3
         with:
-          repository: openvswitch/ovs
-          ref: master
+          repository: kubeovn/ovs
+          ref: ovn-22.03.1
           path: ovs
 
       - name: Check out OVN
         uses: actions/checkout@v3
         with:
           repository: ovn-org/ovn
-          ref: branch-22.03
+          ref: v22.03.1
           path: ovn
 
       - name: Apply OVS patches
         working-directory: ovs
         run: |
+          # Carefully release NBL in Windows
+          Invoke-WebRequest -Uri "https://github.com/openvswitch/ovs/commit/bb78070fc7ec0d67e80d9d15de482ef830196da3.patch" -OutFile ..\ovs-01.patch
           # fix kernel crash
-          Invoke-WebRequest -Uri "https://github.com/kubeovn/ovs/commit/64383c14a9c25e9e0ca53c6758d9499c60132536.patch" -OutFile ..\ovs-01.patch
+          Invoke-WebRequest -Uri "https://github.com/kubeovn/ovs/commit/64383c14a9c25e9e0ca53c6758d9499c60132536.patch" -OutFile ..\ovs-02.patch
           # support for building in github actions
-          Invoke-WebRequest -Uri "https://github.com/kubeovn/ovs/commit/08a95db2ca506fce4d89fdf4fafab74607b2bb9f.patch" -OutFile ..\ovs-02.patch
+          Invoke-WebRequest -Uri "https://github.com/kubeovn/ovs/commit/08a95db2ca506fce4d89fdf4fafab74607b2bb9f.patch" -OutFile ..\ovs-03.patch
           # listen on tcp 127.0.0.1:6643 by default
-          Invoke-WebRequest -Uri "https://github.com/kubeovn/ovs/commit/680e77a190ae7df3086bc35bb6150238e97f9020.patch" -OutFile ..\ovs-03.patch
+          Invoke-WebRequest -Uri "https://github.com/kubeovn/ovs/commit/680e77a190ae7df3086bc35bb6150238e97f9020.patch" -OutFile ..\ovs-04.patch
           git apply ..\ovs-01.patch
           git apply ..\ovs-02.patch
           git apply ..\ovs-03.patch
+          git apply ..\ovs-04.patch
 
       - name: Apply OVN patches
         working-directory: ovn

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Go Build Cache
         uses: actions/cache@v3
@@ -1285,6 +1285,7 @@ jobs:
           # docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile:$TAG-x86
           docker images
           docker push kubeovn/kube-ovn:$TAG-x86
+          docker push kubeovn/kube-ovn:$TAG-no-avx512
           docker push kubeovn/kube-ovn-dev:$COMMIT-x86
           docker push kubeovn/vpc-nat-gateway:$TAG-x86
           docker push kubeovn/vpc-nat-gateway-dev:$COMMIT-x86

--- a/.github/workflows/push-multiarch-image.yaml
+++ b/.github/workflows/push-multiarch-image.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Push
         if: ${{ github.ref == 'refs/heads/master' || contains(github.ref, 'release') }}

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ build-dpdk:
 .PHONY: base-amd64
 base-amd64:
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/kube-ovn-base:$(RELEASE_TAG)-amd64 -o type=docker -f dist/images/Dockerfile.base dist/images/
+	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 --build-arg NO_AVX512=true -t $(REGISTRY)/kube-ovn-base:$(RELEASE_TAG)-amd64-no-avx512 -o type=docker -f dist/images/Dockerfile.base dist/images/
 
 .PHONY: base-amd64-dpdk
 base-amd64-dpdk:
@@ -67,6 +68,7 @@ base-arm64:
 .PHONY: release
 release: lint build-go
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile dist/images/
+	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG)-no-avx512 -o type=docker -f dist/images/Dockerfile.no-avx512 dist/images/
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG)-dpdk -o type=docker -f dist/images/Dockerfile.dpdk dist/images/
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG) -o type=docker -f dist/images/vpcnatgateway/Dockerfile dist/images/vpcnatgateway
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 -t $(REGISTRY)/centos7-compile:$(RELEASE_TAG) -o type=docker -f dist/images/compile/centos7/Dockerfile fastpath/
@@ -87,14 +89,14 @@ push-release: release
 
 .PHONY: tar
 tar:
-	docker save $(REGISTRY)/kube-ovn:$(RELEASE_TAG) -o kube-ovn.tar
+	docker save $(REGISTRY)/kube-ovn:$(RELEASE_TAG) $(REGISTRY)/kube-ovn:$(RELEASE_TAG)-no-avx512 -o kube-ovn.tar
 	docker save $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG) -o vpc-nat-gateway.tar
 	docker save $(REGISTRY)/centos7-compile:$(RELEASE_TAG) -o centos7-compile.tar
 #	docker save $(REGISTRY)/centos8-compile:$(RELEASE_TAG) -o centos8-compile.tar
 
 .PHONY: base-tar-amd64
 base-tar-amd64:
-	docker save $(REGISTRY)/kube-ovn-base:$(RELEASE_TAG)-amd64 -o image-amd64.tar
+	docker save $(REGISTRY)/kube-ovn-base:$(RELEASE_TAG)-amd64 $(REGISTRY)/kube-ovn-base:$(RELEASE_TAG)-amd64-no-avx512 -o image-amd64.tar
 
 .PHONY: base-tar-amd64-dpdk
 base-tar-amd64-dpdk:

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -2,6 +2,7 @@
 FROM ubuntu:22.04 as ovs-builder
 
 ARG ARCH
+ARG NO_AVX512=false
 ARG DEBIAN_FRONTEND=noninteractive
 ENV SRC_DIR='/usr/src'
 
@@ -11,10 +12,12 @@ RUN apt update && apt install build-essential git libnuma-dev autoconf curl \
     flake8 python3-sphinx graphviz groff wget libjemalloc-dev -y
 
 RUN cd /usr/src/ && \
-    git clone -b branch-2.17 --depth=1 https://github.com/openvswitch/ovs.git && \
+    git clone -b ovn-22.03.1 --depth=1 https://github.com/kubeovn/ovs.git && \
     cd ovs && \
     # increase election timer
     curl -s https://github.com/kubeovn/ovs/commit/22ea22c40b46ee5adeae977ff6cfca81b3ff25d7.patch | git apply && \
+    # compile without avx512
+    if [ "$ARCH" = "amd64" -a "$NO_AVX512" = "true" ]; then curl -s https://github.com/kubeovn/ovs/commit/38c59e078d69b343f56ab0f380fb9f42b94b7c02.patch | git apply; fi && \
     ./boot.sh && \
     rm -rf .git && \
     CONFIGURE_OPTS='LIBS=-ljemalloc' && \
@@ -23,7 +26,7 @@ RUN cd /usr/src/ && \
 
 RUN dpkg -i /usr/src/python3-openvswitch*.deb /usr/src/libopenvswitch*.deb
 
-RUN cd /usr/src/ && git clone -b branch-22.03 --depth=1 https://github.com/ovn-org/ovn.git && \
+RUN cd /usr/src/ && git clone -b v22.03.1 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
     # do not send traffic that not designate to svc to conntrack
     curl -s https://github.com/kubeovn/ovn/commit/d26ae4de0ab070f6b602688ba808c8963f69d5c4.patch | git apply && \
@@ -75,3 +78,11 @@ RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \
     dpkg -i /packages/openvswitch-*.deb && \
     dpkg -i /packages/python3-openvswitch*.deb &&\
     dpkg -i --ignore-depends=openvswitch-switch,openvswitch-common /packages/ovn-*.deb
+
+ENV DUMB_INIT_VERSION="1.2.5"
+RUN dump_arch="x86_64"; \
+    if [ "$ARCH" = "arm64" ]; then dump_arch="aarch64"; fi; \
+    curl -sSf -L --retry 5 -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${dump_arch} && \
+    chmod +x /usr/bin/dumb-init
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/dist/images/Dockerfile.no-avx512
+++ b/dist/images/Dockerfile.no-avx512
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM kubeovn/kube-ovn-base:v1.11.0
+FROM kubeovn/kube-ovn-base:v1.11.0-no-avx512
 
 COPY *.sh /kube-ovn/
 COPY kubectl-ko /kube-ovn/kubectl-ko


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

This patch also:

1. Fixes OVS and OVN versions used in the Dockerfile;
2. Move dumb-init back to the base image.