### PR TITLE
update ovs health check, delete connection to ovn sb db

### DIFF
--- a/charts/templates/monitor-deploy.yaml
+++ b/charts/templates/monitor-deploy.yaml
@@ -81,14 +81,14 @@ spec:
             exec:
               command:
               - cat
-              - /var/run/ovn/ovnnb_db.pid
+              - /var/run/ovn/ovn-controller.pid
             periodSeconds: 10
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
               - cat
-              - /var/run/ovn/ovnnb_db.pid
+              - /var/run/ovn/ovn-controller.pid
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 5

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3016,14 +3016,14 @@ spec:
             exec:
               command:
               - cat
-              - /var/run/ovn/ovnnb_db.pid
+              - /var/run/ovn/ovn-controller.pid
             periodSeconds: 10
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
               - cat
-              - /var/run/ovn/ovnnb_db.pid
+              - /var/run/ovn/ovn-controller.pid
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 5

--- a/dist/images/ovs-healthcheck.sh
+++ b/dist/images/ovs-healthcheck.sh
@@ -23,11 +23,11 @@ function gen_conn_str {
   echo "$x"
 }
 
-echo Connecting OVN SB "$(gen_conn_str 6642)"
+# echo Connecting OVN SB "$(gen_conn_str 6642)"
 if [[ "$ENABLE_SSL" == "false" ]]; then
-  ovsdb-client list-dbs "$(gen_conn_str 6642)"
+  ovsdb-client list-dbs
 else
-  ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert list-dbs "$(gen_conn_str 6642)"
+  ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert list-dbs
 fi
 alias ovs-ctl='/usr/share/openvswitch/scripts/ovs-ctl'
 alias ovn-ctl='/usr/share/ovn/scripts/ovn-ctl'

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -443,14 +443,14 @@ spec:
             exec:
               command:
                 - cat
-                - /var/run/ovn/ovnnb_db.pid
+                - /var/run/ovn/ovn-controller.pid
             periodSeconds: 10
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
                 - cat
-                - /var/run/ovn/ovnnb_db.pid
+                - /var/run/ovn/ovn-controller.pid
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 5

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -415,14 +415,14 @@ spec:
             exec:
               command:
                 - cat
-                - /var/run/ovn/ovnnb_db.pid
+                - /var/run/ovn/ovn-controller.pid
             periodSeconds: 10
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
                 - cat
-                - /var/run/ovn/ovnnb_db.pid
+                - /var/run/ovn/ovn-controller.pid
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 5

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -458,14 +458,14 @@ spec:
             exec:
               command:
                 - cat
-                - /var/run/ovn/ovnnb_db.pid
+                - /var/run/ovn/ovn-controller.pid
             periodSeconds: 10
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
                 - cat
-                - /var/run/ovn/ovnnb_db.pid
+                - /var/run/ovn/ovn-controller.pid
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 5


### PR DESCRIPTION
#### What type of this PR
- Bug fixes

####
1、update ovs health check, delete connection to ovn sb db
2、It's better for kube-ovn-monitor to keep running without ovn-central pod

#### Which issue(s) this PR fixes:
Fixes #1575 



