### PR TITLE
Add passivemode for kube-ovn-speaker

### DIFF
--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/osrg/gobgp/pkg/packet/bgp"
 	"os"
 	"time"
 
@@ -44,6 +45,7 @@ type Configuration struct {
 	GracefulRestart             bool
 	GracefulRestartDeferralTime time.Duration
 	GracefulRestartTime         time.Duration
+	PassiveMode                 bool
 
 	KubeConfigFile string
 	KubeClient     kubernetes.Interface
@@ -68,6 +70,7 @@ func ParseFlags() (*Configuration, error) {
 		argHoldTime                    = pflag.Duration("holdtime", DefaultBGPHoldtime, "ovn-speaker goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3s to 65536s. (default 90s)")
 		argPprofPort                   = pflag.Uint32("pprof-port", DefaultPprofPort, "The port to get profiling data, default: 10667")
 		argKubeConfigFile              = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
+		argPassiveMode                 = pflag.BoolP("passivemode", "", false, "Set BGP Speaker to passive model,do not actively initiate connections to peers ")
 	)
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -107,6 +110,7 @@ func ParseFlags() (*Configuration, error) {
 		GracefulRestart:             *argGracefulRestart,
 		GracefulRestartDeferralTime: *argGracefulRestartDeferralTime,
 		GracefulRestartTime:         *argDefaultGracefulTime,
+		PassiveMode:                 *argPassiveMode,
 	}
 
 	if config.RouterId == "" {
@@ -178,17 +182,21 @@ func (config *Configuration) checkGracefulRestartOptions() error {
 
 func (config *Configuration) initBgpServer() error {
 	maxSize := 256 << 20
+	var listenPort int32 = -1
 	grpcOpts := []grpc.ServerOption{grpc.MaxRecvMsgSize(maxSize), grpc.MaxSendMsgSize(maxSize)}
 	s := gobgp.NewBgpServer(
 		gobgp.GrpcListenAddress(fmt.Sprintf("%s:%d", config.GrpcHost, config.GrpcPort)),
 		gobgp.GrpcOption(grpcOpts))
 	go s.Serve()
 
+	if config.PassiveMode {
+		listenPort = bgp.BGP_PORT
+	}
 	if err := s.StartBgp(context.Background(), &api.StartBgpRequest{
 		Global: &api.Global{
 			As:               config.ClusterAs,
 			RouterId:         config.RouterId,
-			ListenPort:       -1,
+			ListenPort:       listenPort,
 			UseMultiplePaths: true,
 		},
 	}); err != nil {
@@ -200,6 +208,9 @@ func (config *Configuration) initBgpServer() error {
 		Conf: &api.PeerConf{
 			NeighborAddress: config.NeighborAddress,
 			PeerAs:          config.NeighborAs,
+		},
+		Transport: &api.Transport{
+			PassiveMode: config.PassiveMode,
 		},
 	}
 	if config.AuthPassword != "" {


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- 
- Feature

Add the --passivemode option to the startup parameters of kube-ovn-speaker, the default is false.
if you want to enable the passivemode, only set --passivemode=true, then the kube-ovn-spekaer will listen 179 port,you can You can view it with the netstat -nlp .


/kind  feature


#### Which issue(s) this PR fixes:
Fixes #1594



