### PR TITLE
do not snat packets only for subnets with distributed gateway when external traffic policy is set to local

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -432,7 +432,15 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
+            for node in $(sudo kubectl get no -o jsonpath='{.items[*].metadata.name}'); do
+              taint=$(sudo kubectl get no $node -o jsonpath='{.spec.taints[?(@.key=="node-role.kubernetes.io/master")]}')
+              if [ -n "$taint" ]; then
+                sudo kubectl taint node $node node-role.kubernetes.io/master:NoSchedule-
+              fi
+            done
             sudo make kind-install
+            sudo kubectl patch subnet ovn-default --type merge \
+              -p '{"spec":{"gatewayType": "centralized", "gatewayNode": "kube-ovn-control-plane"}}'
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v3

--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -3,7 +3,8 @@
 ovs-dpctl del-dp ovs-system
 
 iptables -t nat -D POSTROUTING -m mark --mark 0x4000/0x4000 -j MASQUERADE
-iptables -t nat -D POSTROUTING -m mark --mark 0x80000/0x80000 -j RETURN
+iptables -t nat -D POSTROUTING -m mark --mark 0x80000/0x80000 -m set --match-set ovn40subnets-distributed-gw dst -j RETURN
+iptables -t nat -D POSTROUTING -m mark --mark 0x80000/0x80000 -j MASQUERADE
 iptables -t nat -D POSTROUTING -p tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -j RETURN
 iptables -t nat -D POSTROUTING -m set ! --match-set ovn40subnets src -m set ! --match-set ovn40other-node src -m set --match-set ovn40subnets-nat dst -j RETURN
 iptables -t nat -D POSTROUTING -m set --match-set ovn40subnets-nat src -m set ! --match-set ovn40subnets dst -j MASQUERADE
@@ -24,12 +25,14 @@ sleep 1
 
 ipset destroy ovn40subnets-nat
 ipset destroy ovn40subnets
+ipset destroy ovn40subnets-distributed-gw
 ipset destroy ovn40local-pod-ip-nat
 ipset destroy ovn40other-node
 ipset destroy ovn40services
 
 ip6tables -t nat -D POSTROUTING -m mark --mark 0x4000/0x4000 -j MASQUERADE
-ip6tables -t nat -D POSTROUTING -m mark --mark 0x80000/0x80000 -j RETURN
+ip6tables -t nat -D POSTROUTING -m mark --mark 0x80000/0x80000 -m set --match-set ovn60subnets-distributed-gw dst -j RETURN
+ip6tables -t nat -D POSTROUTING -m mark --mark 0x80000/0x80000 -j MASQUERADE
 ip6tables -t nat -D POSTROUTING -p tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -j RETURN
 ip6tables -t nat -D POSTROUTING -m set ! --match-set ovn60subnets src -m set ! --match-set ovn60other-node src -m set --match-set ovn60subnets-nat dst -j RETURN
 ip6tables -t nat -D POSTROUTING -m set --match-set ovn60subnets-nat src -m set ! --match-set ovn60subnets dst -j MASQUERADE
@@ -50,6 +53,7 @@ sleep 1
 
 ipset destroy ovn6subnets-nat
 ipset destroy ovn60subnets
+ipset destroy ovn60subnets-distributed-gw
 ipset destroy ovn60local-pod-ip-nat
 ipset destroy ovn60other-node
 ipset destroy ovn60services


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

This patch avoids node port access failure for subnets with a centralized gateway when the external traffic policy is set to Local.