### PR TITLE
fix controller exit before process pod update event

### DIFF
--- a/dist/images/vpcnatgateway/Dockerfile
+++ b/dist/images/vpcnatgateway/Dockerfile
@@ -1,9 +1,6 @@
 FROM alpine:3.16
 
 RUN set -ex \
-    && echo "http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
-    && echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && echo "http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
     && apk update \
     && apk upgrade \
     && apk add --no-cache \

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -106,11 +106,10 @@ func (c *Controller) enqueueAddPod(obj interface{}) {
 
 		if p.Annotations != nil &&
 			p.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] == "true" &&
-			p.Status.HostIP != "" && p.Status.PodIP != "" {
-			if p.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, podNet.ProviderName)] != "true" {
-				c.updatePodQueue.Add(key)
-				return
-			}
+			p.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, podNet.ProviderName)] != "true" &&
+			p.Status.HostIP != "" && p.Status.PodIP == "" {
+			c.updatePodQueue.Add(key)
+			return
 		}
 
 		if p.Annotations != nil && p.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] == "true" {


### PR DESCRIPTION
#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:
Fixes handleAdd pod write back allocated annotation and emit a pod update event but controller exit by accident cause update cannot be triggered. 



