### PR TITLE
set networkpolicy log default to false

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -54,7 +54,8 @@ func (c *Controller) enqueueUpdateNp(old, new interface{}) {
 	}
 	oldNp := old.(*netv1.NetworkPolicy)
 	newNp := new.(*netv1.NetworkPolicy)
-	if !reflect.DeepEqual(oldNp.Spec, newNp.Spec) {
+	if !reflect.DeepEqual(oldNp.Spec, newNp.Spec) ||
+		!reflect.DeepEqual(oldNp.Annotations, newNp.Annotations) {
 		var key string
 		var err error
 		if key, err = cache.MetaNamespaceKeyFunc(new); err != nil {
@@ -177,6 +178,11 @@ func (c *Controller) handleUpdateNp(key string) error {
 		}
 	}()
 
+	logEnable := false
+	if np.Annotations[util.NetworkPolicyLogAnnotation] == "true" {
+		logEnable = true
+	}
+
 	// TODO: ovn acl doesn't support address_set name with '-', now we replace '-' by '.'.
 	// This may cause conflict if two np with name test-np and test.np. Maybe hash is a better solution,
 	// but we do not want to lost the readability now.
@@ -283,7 +289,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 						excepts = append(excepts, except...)
 					}
 				}
-				klog.Infof("UpdateNp Ingress, allows is %v, excepts is %v", allows, excepts)
+				klog.Infof("UpdateNp Ingress, allows is %v, excepts is %v, log %v", allows, excepts, logEnable)
 				if err = c.ovnLegacyClient.CreateNpAddressSet(ingressAllowAsName, np.Namespace, np.Name, "ingress"); err != nil {
 					klog.Errorf("failed to create address_set %s, %v", ingressAllowAsName, err)
 					return err
@@ -303,7 +309,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 				}
 
 				if len(allows) != 0 || len(excepts) != 0 {
-					if err = c.ovnLegacyClient.CreateIngressACL(pgName, ingressAllowAsName, ingressExceptAsName, svcAsName, protocol, npr.Ports); err != nil {
+					if err = c.ovnLegacyClient.CreateIngressACL(pgName, ingressAllowAsName, ingressExceptAsName, svcAsName, protocol, npr.Ports, logEnable); err != nil {
 						klog.Errorf("failed to create ingress acls for np %s, %v", key, err)
 						return err
 					}
@@ -322,10 +328,15 @@ func (c *Controller) handleUpdateNp(key string) error {
 					return err
 				}
 				ingressPorts := []netv1.NetworkPolicyPort{}
-				if err = c.ovnLegacyClient.CreateIngressACL(pgName, ingressAllowAsName, ingressExceptAsName, svcAsName, protocol, ingressPorts); err != nil {
+				if err = c.ovnLegacyClient.CreateIngressACL(pgName, ingressAllowAsName, ingressExceptAsName, svcAsName, protocol, ingressPorts, logEnable); err != nil {
 					klog.Errorf("failed to create ingress acls for np %s, %v", key, err)
 					return err
 				}
+			}
+
+			if err = c.ovnLegacyClient.SetAclLog(pgName, logEnable, true); err != nil {
+				// just log and do not return err here
+				klog.Errorf("failed to set ingress acl log for np %s, %v", key, err)
 			}
 		}
 
@@ -419,7 +430,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 						excepts = append(excepts, except...)
 					}
 				}
-				klog.Infof("UpdateNp Egress, allows is %v, excepts is %v", allows, excepts)
+				klog.Infof("UpdateNp Egress, allows is %v, excepts is %v, log %v", allows, excepts, logEnable)
 				if err = c.ovnLegacyClient.CreateNpAddressSet(egressAllowAsName, np.Namespace, np.Name, "egress"); err != nil {
 					klog.Errorf("failed to create address_set %s, %v", egressAllowAsName, err)
 					return err
@@ -439,7 +450,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 				}
 
 				if len(allows) != 0 || len(excepts) != 0 {
-					if err = c.ovnLegacyClient.CreateEgressACL(pgName, egressAllowAsName, egressExceptAsName, protocol, npr.Ports, svcAsName); err != nil {
+					if err = c.ovnLegacyClient.CreateEgressACL(pgName, egressAllowAsName, egressExceptAsName, protocol, npr.Ports, svcAsName, logEnable); err != nil {
 						klog.Errorf("failed to create egress acls for np %s, %v", key, err)
 						return err
 					}
@@ -458,10 +469,14 @@ func (c *Controller) handleUpdateNp(key string) error {
 					return err
 				}
 				egressPorts := []netv1.NetworkPolicyPort{}
-				if err = c.ovnLegacyClient.CreateEgressACL(pgName, egressAllowAsName, egressExceptAsName, protocol, egressPorts, svcAsName); err != nil {
+				if err = c.ovnLegacyClient.CreateEgressACL(pgName, egressAllowAsName, egressExceptAsName, protocol, egressPorts, svcAsName, logEnable); err != nil {
 					klog.Errorf("failed to create egress acls for np %s, %v", key, err)
 					return err
 				}
+			}
+			if err = c.ovnLegacyClient.SetAclLog(pgName, logEnable, false); err != nil {
+				// just log and do not return err here
+				klog.Errorf("failed to set egress acl log for np %s, %v", key, err)
 			}
 		}
 

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1586,14 +1586,19 @@ func (c LegacyClient) CreateNpAddressSet(asName, npNamespace, npName, direction 
 	return err
 }
 
-func (c LegacyClient) CreateIngressACL(pgName, asIngressName, asExceptName, svcAsName, protocol string, npp []netv1.NetworkPolicyPort) error {
-	var allowArgs []string
+func (c LegacyClient) CreateIngressACL(pgName, asIngressName, asExceptName, svcAsName, protocol string, npp []netv1.NetworkPolicyPort, logEnable bool) error {
+	var allowArgs, ovnArgs []string
 
 	ipSuffix := "ip4"
 	if protocol == kubeovnv1.ProtocolIPv6 {
 		ipSuffix = "ip6"
 	}
-	ovnArgs := []string{MayExist, "--type=port-group", "--log", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "to-lport", util.IngressDefaultDrop, fmt.Sprintf("outport==@%s && ip", pgName), "drop"}
+
+	if logEnable {
+		ovnArgs = []string{MayExist, "--type=port-group", "--log", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "to-lport", util.IngressDefaultDrop, fmt.Sprintf("outport==@%s && ip", pgName), "drop"}
+	} else {
+		ovnArgs = []string{MayExist, "--type=port-group", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "to-lport", util.IngressDefaultDrop, fmt.Sprintf("outport==@%s && ip", pgName), "drop"}
+	}
 
 	if len(npp) == 0 {
 		allowArgs = []string{"--", MayExist, "--type=port-group", "acl-add", pgName, "to-lport", util.IngressAllowPriority, fmt.Sprintf("%s.src == $%s && %s.src != $%s && outport==@%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, pgName), "allow-related"}
@@ -1616,15 +1621,18 @@ func (c LegacyClient) CreateIngressACL(pgName, asIngressName, asExceptName, svcA
 	return err
 }
 
-func (c LegacyClient) CreateEgressACL(pgName, asEgressName, asExceptName, protocol string, npp []netv1.NetworkPolicyPort, portSvcName string) error {
-	var allowArgs []string
+func (c LegacyClient) CreateEgressACL(pgName, asEgressName, asExceptName, protocol string, npp []netv1.NetworkPolicyPort, portSvcName string, logEnable bool) error {
+	var allowArgs, ovnArgs []string
 
 	ipSuffix := "ip4"
 	if protocol == kubeovnv1.ProtocolIPv6 {
 		ipSuffix = "ip6"
 	}
-	ovnArgs := []string{"--", MayExist, "--type=port-group", "--log", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "from-lport", util.EgressDefaultDrop, fmt.Sprintf("inport==@%s && ip", pgName), "drop"}
-
+	if logEnable {
+		ovnArgs = []string{"--", MayExist, "--type=port-group", "--log", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "from-lport", util.EgressDefaultDrop, fmt.Sprintf("inport==@%s && ip", pgName), "drop"}
+	} else {
+		ovnArgs = []string{"--", MayExist, "--type=port-group", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "from-lport", util.EgressDefaultDrop, fmt.Sprintf("inport==@%s && ip", pgName), "drop"}
+	}
 	if len(npp) == 0 {
 		allowArgs = []string{"--", MayExist, "--type=port-group", "acl-add", pgName, "from-lport", util.EgressAllowPriority, fmt.Sprintf("%s.dst == $%s && %s.dst != $%s && inport==@%s && ip", ipSuffix, asEgressName, ipSuffix, asExceptName, pgName), "allow-related"}
 		ovnArgs = append(ovnArgs, allowArgs...)
@@ -2653,4 +2661,35 @@ func (c *LegacyClient) GetLspExternalIds(lsp string) map[string]string {
 	}
 
 	return nameNsMap
+}
+
+func (c LegacyClient) SetAclLog(pgName string, logEnable, isIngress bool) error {
+	var direction, match string
+	if isIngress {
+		direction = "to-lport"
+		match = fmt.Sprintf("outport==@%s && ip", pgName)
+	} else {
+		direction = "from-lport"
+		match = fmt.Sprintf("inport==@%s && ip", pgName)
+	}
+
+	priority, _ := strconv.Atoi(util.IngressDefaultDrop)
+	result, err := c.CustomFindEntity("acl", []string{"_uuid"}, fmt.Sprintf("priority=%d", priority), fmt.Sprintf(`match="%s"`, match), fmt.Sprintf("direction=%s", direction), "action=drop")
+	if err != nil {
+		klog.Errorf("failed to get acl UUID: %v", err)
+		return err
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	uuid := result[0]["_uuid"][0]
+	ovnCmd := []string{"set", "acl", uuid, fmt.Sprintf("log=%v", logEnable)}
+
+	if _, err := c.ovnNbCommand(ovnCmd...); err != nil {
+		return fmt.Errorf("failed to set acl log, %v", err)
+	}
+
+	return nil
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -84,6 +84,8 @@ const (
 	VpcNatGatewayNameLabel = "ovn.kubernetes.io/vpc-nat-gw-name"
 	VpcLbLabel             = "ovn.kubernetes.io/vpc_lb"
 
+	NetworkPolicyLogAnnotation = "ovn.kubernetes.io/enable_log"
+
 	ProtocolTCP = "tcp"
 	ProtocolUDP = "udp"
 


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、set networkpolicy log default to false
2、add annotation "ovn.kubernetes.io/enable_log=true" to networkpolicy can enable ovn-controller log for acl rules

#### Which issue(s) this PR fixes:
Fixes #1603



