### PR TITLE
increase initial delay of ovs-ovn liveness probe

### DIFF
--- a/charts/templates/ovsovn-ds.yaml
+++ b/charts/templates/ovsovn-ds.yaml
@@ -93,7 +93,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovs-healthcheck.sh
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1795,7 +1795,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovs-dpdk-healthcheck.sh
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45
@@ -2278,7 +2278,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovs-healthcheck.sh
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45
@@ -2435,7 +2435,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovs-healthcheck.sh
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -414,7 +414,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovs-dpdk-healthcheck.sh
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -432,7 +432,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovs-healthcheck.sh
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -458,7 +458,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovs-healthcheck.sh
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

This patch fixes ovs-ovn crash under high pressure:

```txt
 * ovn-controller is not running
2022-06-21T06:45:50Z|00001|unixctl|WARN|failed to connect to /var/run/openvswitch/ovsdb-server.15683.ctl
ovs-appctl: cannot connect to "/var/run/openvswitch/ovsdb-server.15683.ctl" (No such file or directory)
2022-06-21T06:45:50Z|00001|unixctl|WARN|failed to connect to /var/run/openvswitch/ovsdb-server.15683.ctl
ovs-appctl: cannot connect to "/var/run/openvswitch/ovsdb-server.15683.ctl" (No such file or directory)
 * Exiting ovsdb-server (15683)
 * Killing ovsdb-server (15683)
 * Killing ovsdb-server (15683) with SIGKILL
ovsdb-server: could not initiate process monitoring
 * Starting ovsdb-server
 ```