### PR TITLE
fix no interface report to multus cni, missing in k8s.v1.cni.cncf.io/network[s]-status

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -206,8 +206,9 @@ func parseValueFromArgs(key, argString string) (string, error) {
 
 func assignV4Address(ipAddress, gateway string, mask *net.IPNet) (*current.IPConfig, *types.Route) {
 	ip := &current.IPConfig{
-		Address: net.IPNet{IP: net.ParseIP(ipAddress).To4(), Mask: mask.Mask},
-		Gateway: net.ParseIP(gateway).To4(),
+		Address:   net.IPNet{IP: net.ParseIP(ipAddress).To4(), Mask: mask.Mask},
+		Gateway:   net.ParseIP(gateway).To4(),
+		Interface: current.Int(0),
 	}
 
 	var route *types.Route
@@ -223,8 +224,9 @@ func assignV4Address(ipAddress, gateway string, mask *net.IPNet) (*current.IPCon
 
 func assignV6Address(ipAddress, gateway string, mask *net.IPNet) (*current.IPConfig, *types.Route) {
 	ip := &current.IPConfig{
-		Address: net.IPNet{IP: net.ParseIP(ipAddress).To16(), Mask: mask.Mask},
-		Gateway: net.ParseIP(gateway).To16(),
+		Address:   net.IPNet{IP: net.ParseIP(ipAddress).To16(), Mask: mask.Mask},
+		Gateway:   net.ParseIP(gateway).To16(),
+		Interface: current.Int(0),
 	}
 
 	var route *types.Route


### PR DESCRIPTION
#### What type of this PR


- Bug fixes
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

#### Which issue(s) this PR fixes:
Fixes current handle interface not report to chaining CNI, eg  multus-cni and openshift [network-metrics-daemon](https://github.com/openshift/network-metrics-daemon/blob/52442b3aea9213ce6055d3cafe5cc058b68b6ee7/pkg/podmetrics/podmetrics.go#L43) 
Before
```
Annotations:          k8s.v1.cni.cncf.io/network-status:
                        [{
                            "name": "kube-ovn",
                            "ips": [
                                "21.100.0.33"
                            ],
                            "mac": "00:00:00:BE:39:E2",
                            "default": true,
                            "dns": {}
                        }]
                      k8s.v1.cni.cncf.io/networks-status:
                        [{
                            "name": "kube-ovn",
                            "ips": [
                                "21.100.0.33"
                            ],
                            "mac": "00:00:00:BE:39:E2",
                            "default": true,
                            "dns": {}
                        }]
```
After
```
Annotations:          k8s.v1.cni.cncf.io/network-status:
                        [{
                            "name": "kube-ovn",
                            "interface": "eth0",
                            "ips": [
                                "21.100.0.33"
                            ],
                            "mac": "00:00:00:BE:39:E2",
                            "default": true,
                            "dns": {}
                        }]
                      k8s.v1.cni.cncf.io/networks-status:
                        [{
                            "name": "kube-ovn",
                            "interface": "eth0",
                            "ips": [
                                "21.100.0.33"
                            ],
                            "mac": "00:00:00:BE:39:E2",
                            "default": true,
                            "dns": {}
                        }]
```



