### PR TITLE
ci: update trivy options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,8 +396,8 @@ lint-windows:
 
 .PHONY: scan
 scan:
-	trivy image --light --exit-code=1 --severity=HIGH --ignore-unfixed $(REGISTRY)/kube-ovn:$(RELEASE_TAG)
-	trivy image --light --exit-code=1 --severity=HIGH --ignore-unfixed $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG)
+	trivy image --exit-code=1 --severity=HIGH --ignore-unfixed --security-checks vuln $(REGISTRY)/kube-ovn:$(RELEASE_TAG)
+	trivy image --exit-code=1 --severity=HIGH --ignore-unfixed --security-checks vuln $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG)
 
 .PHONY: ut
 ut:


### PR DESCRIPTION
Remove deprecated flag and do not scan secret as ovs has embed private key for ssl.

#### What type of this PR
Examples of user facing changes:
- CI