### PR TITLE
ci: fix golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,12 +7,24 @@ on:
       - master
       - main
   pull_request:
+
+env:
+  GO_VERSION: '1.17'
+
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: '${{ env.GO_VERSION }}'
+          check-latest: true
+        id: go
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -23,10 +35,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --timeout 180s --disable ineffassign
+          args: --timeout 180s
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
-
-          # Optional: if set to true then the action will use pre-installed Go
-          # skip-go-installation: true


### PR DESCRIPTION
#### What type of this PR

- CI

```txt
v3.0.0+ requires explicit setup-go installation step prior to using this action: uses: actions/setup-go@v3.
The skip-go-installation option has been removed.
```
