### PR TITLE
bug fix:can not delete pod with sriov vf

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -969,7 +969,7 @@ func setVfMac(deviceID string, vfIndex int, mac string) error {
 		devicePortNameFile := filepath.Join(util.NetSysDir, dev, "phys_port_name")
 		physPortName, err := sriovutilfs.Fs.ReadFile(devicePortNameFile)
 		if err != nil {
-			return err
+			continue
 		}
 
 		if !strings.Contains(strings.TrimSpace(string(physPortName)), "vf") {


### PR DESCRIPTION
Corigine网卡flower模式下，会自动生成PF netdev以及phy port对应的netdev,其中PF netdev是没有phys_port_name属性的。根据两种netdev都能设置该卡VF的MAC地址。因此读取phys_port_name失败后，直接跳过，利用phy port netdev设置VF MAC即可。
