### PR TITLE
fix libovsdb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/osrg/gobgp v0.0.0-20190401195721-805d02fdfbc5
-	github.com/ovn-org/libovsdb v0.0.0-20220517011431-3f40c8abb6ff
+	github.com/ovn-org/libovsdb v0.0.0-20220603173653-bbc32842d174
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1081,8 +1081,8 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
 github.com/osrg/gobgp v0.0.0-20190401195721-805d02fdfbc5 h1:ZFqHsIsRU5o6JY4HrCrkBYOEEHe3QqF1XR7f0FwAJn4=
 github.com/osrg/gobgp v0.0.0-20190401195721-805d02fdfbc5/go.mod h1:CM+XMF5H4FfrlOm3OCFsOXJkVmWB7sx1AfoS+EKA47g=
-github.com/ovn-org/libovsdb v0.0.0-20220517011431-3f40c8abb6ff h1:ycq/55SQBESNSVvix3uN5Se6wgbbvVIrm1h4Rs0jN20=
-github.com/ovn-org/libovsdb v0.0.0-20220517011431-3f40c8abb6ff/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
+github.com/ovn-org/libovsdb v0.0.0-20220603173653-bbc32842d174 h1:vn8YwJUXw0+E/JZu+ktRB8mMw9C14BXOOwksxg2KtUs=
+github.com/ovn-org/libovsdb v0.0.0-20220603173653-bbc32842d174/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/parnurzeal/gorequest v0.2.16 h1:T/5x+/4BT+nj+3eSknXmCTnEVGSzFzPGdpqmUVVZXHQ=
 github.com/parnurzeal/gorequest v0.2.16/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -34,11 +34,11 @@ func NewNbClient(addr string, timeout int) (client.Client, error) {
 	}
 
 	logger := stdr.NewWithOptions(log.New(os.Stderr, "", log.LstdFlags), stdr.Options{LogCaller: stdr.All}).
-		WithName("libovsdb").
-		WithValues("database", dbModel.Name())
+		WithName("libovsdb")
+	stdr.SetVerbosity(3)
 	options := []client.Option{
 		client.WithReconnect(time.Duration(timeout)*time.Second, &backoff.ZeroBackOff{}),
-		client.WithLeaderOnly(false),
+		client.WithLeaderOnly(true),
 		client.WithLogger(&logger),
 	}
 


### PR DESCRIPTION
#### What type of this PR

- Bug fixes

1. Create a client with the option leader-only enabled;
2. Set libovsdb logging verbosity to print error messages;
3. Remove duplicate logger values since libovsdb will set it.