### PR TITLE
mount modules  for auto load ip6tables moudles

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2718,6 +2718,9 @@ spec:
           - name: RPMS
             value: $RPMS
         volumeMounts:
+          - name: host-modules
+            mountPath: /lib/modules
+            readOnly: true
           - name: shared-dir
             mountPath: /var/lib/kubelet/pods
           - mountPath: /etc/openvswitch
@@ -2768,6 +2771,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
         - name: shared-dir
           hostPath:
             path: /var/lib/kubelet/pods

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -183,6 +183,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
+            - name: host-modules
+              mountPath: /lib/modules
+              readOnly: true
             - mountPath: /etc/openvswitch
               name: systemid
             - mountPath: /etc/cni/net.d
@@ -222,6 +225,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
         - name: systemid
           hostPath:
             path: /etc/origin/openvswitch

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -172,6 +172,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
+            - name: host-modules
+              mountPath: /lib/modules
+              readOnly: true
             - mountPath: /etc/openvswitch
               name: systemid
             - mountPath: /etc/cni/net.d
@@ -202,6 +205,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
         - name: systemid
           hostPath:
             path: /etc/origin/openvswitch

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -183,6 +183,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
+            - name: host-modules
+              mountPath: /lib/modules
+              readOnly: true
             - mountPath: /etc/openvswitch
               name: systemid
             - mountPath: /etc/cni/net.d
@@ -228,6 +231,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
         - name: systemid
           hostPath:
             path: /etc/origin/openvswitch


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- bugs
- I have encountered a situation where the ipv6 kernel could not be loaded. We solved the problem by mounting moudles to CNI 





