### PR TITLE
ignore pod not scheduled when reconcile subnet

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1118,6 +1118,10 @@ func (c *Controller) reconcileOvnRoute(subnet *kubeovnv1.Subnet) error {
 				if pod.Annotations[util.NorthGatewayAnnotation] != "" {
 					continue
 				}
+				// Pod will add to port-group when pod get updated
+				if pod.Spec.NodeName == "" {
+					continue
+				}
 
 				pgName := getOverlaySubnetsPortGroupName(subnet.Name, pod.Spec.NodeName)
 				c.ovnPgKeyMutex.Lock(pgName)


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、when reconcile subnet, all pods in this subnet will be checked and add to port-group. Should ignore pod which has not been scheduled to node.
2、 This is caused by https://github.com/kubeovn/kube-ovn/pull/1655

#### Which issue(s) this PR fixes:
Fixes #(issue-number)



