### PR TITLE
fix: response has no gw when create nic without default route

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -96,11 +96,15 @@ func generateCNIResult(cniResponse *request.CniResponse) current.Result {
 		result.Interfaces = []*current.Interface{&podIface}
 	case kubeovnv1.ProtocolDual:
 		var netMask *net.IPNet
+		var gwStr string
 		for _, cidrBlock := range strings.Split(cniResponse.CIDR, ",") {
 			_, netMask, _ = net.ParseCIDR(cidrBlock)
+			gwStr = ""
 			if util.CheckProtocol(cidrBlock) == kubeovnv1.ProtocolIPv4 {
 				ipStr := strings.Split(cniResponse.IpAddress, ",")[0]
-				gwStr := strings.Split(cniResponse.Gateway, ",")[0]
+				if cniResponse.Gateway != "" {
+					gwStr = strings.Split(cniResponse.Gateway, ",")[0]
+				}
 
 				ip, route := assignV4Address(ipStr, gwStr, netMask)
 				result.IPs = append(result.IPs, ip)
@@ -109,7 +113,9 @@ func generateCNIResult(cniResponse *request.CniResponse) current.Result {
 				}
 			} else if util.CheckProtocol(cidrBlock) == kubeovnv1.ProtocolIPv6 {
 				ipStr := strings.Split(cniResponse.IpAddress, ",")[1]
-				gwStr := strings.Split(cniResponse.Gateway, ",")[1]
+				if cniResponse.Gateway != "" {
+					gwStr = strings.Split(cniResponse.Gateway, ",")[1]
+				}
 
 				ip, route := assignV6Address(ipStr, gwStr, netMask)
 				result.IPs = append(result.IPs, ip)


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- Bug fixes

After issue #1555 , kube-ovn-cni will not response gw when nic without default route;
so we need handle this situation.

#### Which issue(s) this PR fixes:
Fixes #1696 



