### PR TITLE
optimize lrp create for subnet in vpc

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -487,15 +487,15 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		return err
 	}
 
-	cachedSubnet, err = c.subnetsLister.Get(key)
+	subnet, err = c.config.KubeOvnClient.KubeovnV1().Subnets().Get(context.Background(), key, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Errorf("failed to get subnet %s error %v", key, err)
 		return err
 	}
 
-	subnet = cachedSubnet.DeepCopy()
 	deleted, err := c.handleSubnetFinalizer(subnet)
 	if err != nil {
 		klog.Errorf("handle subnet finalizer failed %v", err)
@@ -624,6 +624,13 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		if err := c.ovnLegacyClient.CreateLogicalSwitch(subnet.Name, vpc.Status.Router, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, needRouter); err != nil {
 			c.patchSubnetStatus(subnet, "CreateLogicalSwitchFailed", err.Error())
 			return err
+		}
+
+		if needRouter {
+			if err := c.reconcileRouterPortBySubnet(vpc, subnet); err != nil {
+				klog.Errorf("failed to connect switch %s to router %s, %v", subnet.Name, vpc.Name, err)
+				return err
+			}
 		}
 	} else {
 		// logical switch exists, only update other_config

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -199,6 +199,35 @@ func (c *Controller) reconcileRouterPorts(vpc *kubeovnv1.Vpc) error {
 	return nil
 }
 
+func (c *Controller) reconcileRouterPortBySubnet(vpc *kubeovnv1.Vpc, subnet *kubeovnv1.Subnet) error {
+	router := vpc.Name
+	routerPortName := ovs.LogicalRouterPortName(router, subnet.Name)
+	exists, err := c.ovnClient.LogicalRouterPortExists(routerPortName)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		subnet, err := c.subnetsLister.Get(subnet.Name)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			klog.Errorf("failed to get subnet %s, err %v", subnet.Name, err)
+			return err
+		}
+
+		networks := util.GetIpAddrWithMask(subnet.Spec.Gateway, subnet.Spec.CIDRBlock)
+		klog.Infof("router port does not exist, trying to create %s with ip %s", routerPortName, networks)
+
+		if err := c.ovnClient.AddLogicalRouterPort(router, routerPortName, "", networks); err != nil {
+			klog.Errorf("failed to create router port %s, err %v", routerPortName, err)
+			return err
+		}
+	}
+	return nil
+}
+
 type VpcLoadBalancer struct {
 	TcpLoadBalancer     string
 	TcpSessLoadBalancer string
@@ -660,17 +689,13 @@ func (c *Controller) getVpcSubnets(vpc *kubeovnv1.Vpc) (subnets []string, defaul
 	}
 
 	for _, subnet := range allSubnets {
-		deleted, err := c.handleSubnetFinalizer(subnet)
-		if err != nil {
-			klog.Errorf("handle subnet finalizer failed %v", err)
-			return nil, "", err
+		if subnet.Spec.Vpc != vpc.Name || !subnet.DeletionTimestamp.IsZero() {
+			continue
 		}
 
-		if !deleted && subnet.Spec.Vpc == vpc.Name {
-			subnets = append(subnets, subnet.Name)
-			if subnet.Spec.Default {
-				defaultSubnet = subnet.Name
-			}
+		subnets = append(subnets, subnet.Name)
+		if subnet.Spec.Default {
+			defaultSubnet = subnet.Name
 		}
 	}
 	return

--- a/pkg/ovs/ovn-nb-logical_switch.go
+++ b/pkg/ovs/ovn-nb-logical_switch.go
@@ -1,0 +1,27 @@
+package ovs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ovn-org/libovsdb/client"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+)
+
+func (c OvnClient) GetLogicalSwitch(name string, ignoreNotFound bool) (*ovnnb.LogicalSwitch, error) {
+	ls := &ovnnb.LogicalSwitch{Name: name}
+	if err := c.ovnNbClient.Get(context.TODO(), ls); err != nil {
+		if ignoreNotFound && err == client.ErrNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get logical switch %s: %v", name, err)
+	}
+
+	return ls, nil
+}
+
+func (c OvnClient) LogicalSwitchExists(name string) (bool, error) {
+	ls, err := c.GetLogicalSwitch(name, true)
+	return ls != nil, err
+}

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -456,9 +456,7 @@ func (c LegacyClient) CreateLogicalSwitch(ls, lr, subnet, gateway string, needRo
 	}
 
 	if needRouter {
-		ip := util.GetIpAddrWithMask(gateway, subnet)
-		mac := util.GenerateMac()
-		if err := c.createRouterPort(ls, lr, ip, mac); err != nil {
+		if err := c.createRouterPort(ls, lr); err != nil {
 			klog.Errorf("failed to connect switch %s to router, %v", ls, err)
 			return err
 		}
@@ -791,8 +789,8 @@ func (c LegacyClient) RemoveRouterPort(ls, lr string) error {
 	return nil
 }
 
-func (c LegacyClient) createRouterPort(ls, lr, ip, mac string) error {
-	klog.Infof("add %s to %s with ip=%s, mac=%s", ls, lr, ip, mac)
+func (c LegacyClient) createRouterPort(ls, lr string) error {
+	klog.Infof("add %s to %s", ls, lr)
 	lsTolr := fmt.Sprintf("%s-%s", ls, lr)
 	lrTols := fmt.Sprintf("%s-%s", lr, ls)
 	_, err := c.ovnNbCommand(MayExist, "lsp-add", ls, lsTolr, "--",
@@ -802,20 +800,6 @@ func (c LegacyClient) createRouterPort(ls, lr, ip, mac string) error {
 		"set", "logical_switch_port", lsTolr, fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName))
 	if err != nil {
 		klog.Errorf("failed to create switch router port %s: %v", lsTolr, err)
-		return err
-	}
-	if len(ip) == 0 {
-		klog.Errorf("failed to create switch router port: ip is empty")
-		return err
-	}
-	ipStr := strings.Split(ip, ",")
-	if len(ipStr) == 2 {
-		_, err = c.ovnNbCommand(MayExist, "lrp-add", lr, lrTols, mac, ipStr[0], ipStr[1])
-	} else {
-		_, err = c.ovnNbCommand(MayExist, "lrp-add", lr, lrTols, mac, ipStr[0])
-	}
-	if err != nil {
-		klog.Errorf("failed to create router port %s: %v", lrTols, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
#### What type of this PR
- Bug fixes
####
1、create lrp operation was added in https://github.com/kubeovn/kube-ovn/pull/1570， which is used when vpc is recreated
2、the operation is confict with subnet creation. When a subnet is created, the lr-ls lrp is added too.

#### Which issue(s) this PR fixes:
Fixes #1695 
