### PR TITLE
replace some of logical_switch_port table with libovsdb

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router.go
+++ b/pkg/ovs/ovn-nb-logical_router.go
@@ -23,7 +23,11 @@ func (c OvnClient) CreateLogicalRouter(name string) error {
 		return fmt.Errorf("generate create operations for logical router %s: %v", name, err)
 	}
 
-	return c.Transact("lr-add", op)
+	if err := c.Transact("lr-add", op); err != nil {
+		return fmt.Errorf("create logical router %s: %v", name, err)
+	}
+
+	return nil
 }
 
 // DeleteLogicalRouter delete logical router in ovn
@@ -43,7 +47,11 @@ func (c OvnClient) DeleteLogicalRouter(name string) error {
 		return err
 	}
 
-	return c.Transact("lr-del", op)
+	if err := c.Transact("lr-del", op); err != nil {
+		return fmt.Errorf("delete logical router %s: %v", name, err)
+	}
+
+	return nil
 }
 
 func (c OvnClient) GetLogicalRouter(name string, ignoreNotFound bool) (*ovnnb.LogicalRouter, error) {

--- a/pkg/ovs/ovn-nb-logical_router_port.go
+++ b/pkg/ovs/ovn-nb-logical_router_port.go
@@ -81,7 +81,7 @@ func (c *OvnClient) UpdateRouterPortIPv6RA(lrpName, ipv6RAConfigsStr string, ena
 	return c.UpdateLogicalRouterPort(lrp, &lrp.Ipv6Prefix, &lrp.Ipv6RaConfigs)
 }
 
-// CreateVpcExGwLogicalRouterPort create logical router port for vpc external gateway
+// UpdateLogicalRouterPort update logical router port
 func (c OvnClient) UpdateLogicalRouterPort(lrp *ovnnb.LogicalRouterPort, fields ...interface{}) error {
 	if lrp == nil {
 		return fmt.Errorf("logical_router_port is nil")
@@ -92,7 +92,7 @@ func (c OvnClient) UpdateLogicalRouterPort(lrp *ovnnb.LogicalRouterPort, fields 
 		return fmt.Errorf("generate update operations for logical router port %s: %v", lrp.Name, err)
 	}
 
-	if err = c.Transact("lrp-set", op); err != nil {
+	if err = c.Transact("lrp-update", op); err != nil {
 		return fmt.Errorf("update logical router port %s: %v", lrp.Name, err)
 	}
 

--- a/pkg/ovs/ovn-nb-logical_router_port_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_port_test.go
@@ -247,7 +247,7 @@ func (suite *OvnClientTestSuite) testUpdateLogicalRouterPort() {
 	require.NoError(t, err)
 
 	t.Run("normal update", func(t *testing.T) {
-		lrp = &ovnnb.LogicalRouterPort{
+		lrp := &ovnnb.LogicalRouterPort{
 			Name:     lrpName,
 			Networks: []string{"192.168.123.1/24", "192.168.125.1/24"},
 		}
@@ -260,7 +260,7 @@ func (suite *OvnClientTestSuite) testUpdateLogicalRouterPort() {
 	})
 
 	t.Run("clear networks", func(t *testing.T) {
-		lrp = &ovnnb.LogicalRouterPort{
+		lrp := &ovnnb.LogicalRouterPort{
 			Name:     lrpName,
 			Networks: nil,
 		}

--- a/pkg/ovs/ovn-nb-logical_router_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_test.go
@@ -21,10 +21,6 @@ func (suite *OvnClientTestSuite) testGetLogicalRouter() {
 
 	err := ovnClient.CreateLogicalRouter(name)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		err = ovnClient.DeleteLogicalRouter(name)
-		require.NoError(t, err)
-	})
 
 	t.Run("should return no err when found logical router", func(t *testing.T) {
 		lr, err := ovnClient.GetLogicalRouter(name, false)
@@ -50,11 +46,6 @@ func (suite *OvnClientTestSuite) testCreateLogicalRouter() {
 
 	ovnClient := suite.ovnClient
 	name := "test-create-lr"
-
-	t.Cleanup(func() {
-		err := ovnClient.DeleteLogicalRouter(name)
-		require.NoError(t, err)
-	})
 
 	err := ovnClient.CreateLogicalRouter(name)
 	require.NoError(t, err)

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -85,6 +85,14 @@ func (suite *OvnClientTestSuite) Test_LogicalSwitchOp() {
 }
 
 /* logical_switch_port unit test */
+func (suite *OvnClientTestSuite) Test_SetLogicalSwitchPortSecurity() {
+	suite.testSetLogicalSwitchPortSecurity()
+}
+
+func (suite *OvnClientTestSuite) Test_UpdateLogicalSwitchPort() {
+	suite.testUpdateLogicalSwitchPort()
+}
+
 func (suite *OvnClientTestSuite) Test_DeleteLogicalSwitchPort() {
 	suite.testDeleteLogicalSwitchPort()
 }

--- a/pkg/ovs/ovn-nb.go
+++ b/pkg/ovs/ovn-nb.go
@@ -20,8 +20,7 @@ func (c OvnClient) CreateRouterPort(lsName, lrName, ip string, chassises ...stri
 
 	// create gateway chassis
 	lrpName := fmt.Sprintf("%s-%s", lrName, lsName)
-	err := c.CreateGatewayChassises(lrpName, chassises)
-	if err != nil {
+	if err := c.CreateGatewayChassises(lrpName, chassises); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](../CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #1675 

replace some of logical_switch_port table with libovsdb
