### PR TITLE
enqueue subnets after vpc update

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -447,6 +447,17 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		return err
 	}
 
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	for _, subnet := range subnets {
+		if subnet.Spec.Vpc == key {
+			c.addOrUpdateSubnetQueue.Add(subnet.Name)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](../CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:
Fixes #1697 

Avoid long time waiting for subnets to be ready after the VPC has already been updated.