### PR TITLE
fix service not working when a node's IPv6 address is before the IPv4 address

### DIFF
--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -303,8 +303,13 @@ func GetIpWithoutMask(ipStr string) string {
 func SplitStringIP(ipStr string) (string, string) {
 	var v4IP, v6IP string
 	if CheckProtocol(ipStr) == kubeovnv1.ProtocolDual {
-		v4IP = strings.Split(ipStr, ",")[0]
-		v6IP = strings.Split(ipStr, ",")[1]
+		for _, ipTmp := range(strings.Split(ipStr, ",")){
+			if CheckProtocol(ipTmp) == kubeovnv1.ProtocolIPv4{
+				v4IP = ipTmp
+			}else{
+				v6IP = ipTmp
+			}
+		}
 	} else if CheckProtocol(ipStr) == kubeovnv1.ProtocolIPv4 {
 		v4IP = ipStr
 	} else if CheckProtocol(ipStr) == kubeovnv1.ProtocolIPv6 {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](../CODE_STYLE.md).

#### What type of this PR
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
fix service not working when a node's IPv6 address is before the IPv4 address
#### Which issue(s) this PR fixes:
Fixes #1716 
