### PR TITLE
fix: wrong info when update subnet from dual to ipv4 or ipv6.

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1430,9 +1430,13 @@ func calcSubnetStatusIP(subnet *kubeovnv1.Subnet, c *Controller) error {
 	if subnet.Spec.Protocol == kubeovnv1.ProtocolIPv4 {
 		subnet.Status.V4AvailableIPs = availableIPs
 		subnet.Status.V4UsingIPs = usingIPs
+		subnet.Status.V6AvailableIPs = 0
+		subnet.Status.V6UsingIPs = 0
 	} else {
 		subnet.Status.V6AvailableIPs = availableIPs
 		subnet.Status.V6UsingIPs = usingIPs
+		subnet.Status.V4AvailableIPs = 0
+		subnet.Status.V4UsingIPs = 0
 	}
 
 	bytes, err := subnet.Status.Bytes()


### PR DESCRIPTION
when update subnet from dual to ipv4 or ipv6, available and used ip not correct

<img width="840" alt="3506c800b925ac4f6d81109028928f4" src="https://user-images.githubusercontent.com/27765472/180160954-2013afcf-f31a-45c0-af15-2a7721dee23d.png">


#### What type of this PR
Examples of user facing changes:
- Bug fixes



