### PR TITLE
fix: const extGw may expired, after subnet updated, so use ipam subne…

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -299,7 +299,7 @@ func (c *Controller) InitIPAM() error {
 		return err
 	}
 	for _, subnet := range subnets {
-		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.ExcludeIps); err != nil {
+		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
 			klog.Errorf("failed to init subnet %s: %v", subnet.Name, err)
 		}
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -549,7 +549,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		return err
 	}
 
-	if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.ExcludeIps); err != nil {
+	if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
 		return err
 	}
 

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -214,15 +214,13 @@ func (c *Controller) handleAddVirtualIp(key string) error {
 		klog.Errorf("failed to create or update vip '%s', %v", vip.Name, err)
 		return err
 	}
-	_, err = c.handleVipFinalizer(vip)
-	if err != nil {
+	if _, err = c.handleVipFinalizer(vip); err != nil {
 		klog.Errorf("failed to handle vip finalizer, %v", err)
 		return err
 	}
 	if err = c.subnetCountVip(subnet); err != nil {
 		klog.Errorf("failed to count vip '%s' in subnet, %v", vip.Name, err)
 		return err
-
 	}
 	return nil
 }
@@ -246,8 +244,7 @@ func (c *Controller) handleUpdateVirtualIp(key string) error {
 			return err
 		}
 		vip.Status.Ready = false
-		_, err = c.handleVipFinalizer(vip)
-		if err != nil {
+		if _, err = c.handleVipFinalizer(vip); err != nil {
 			klog.Errorf("failed to handle vip finalizer %v", err)
 			return err
 		}
@@ -270,8 +267,7 @@ func (c *Controller) handleUpdateVirtualIp(key string) error {
 		}
 	}
 	vip.Status.Ready = true
-	_, err = c.handleVipFinalizer(vip)
-	if err != nil {
+	if _, err = c.handleVipFinalizer(vip); err != nil {
 		klog.Errorf("failed to handle vip finalizer %v", err)
 		return err
 	}
@@ -406,8 +402,7 @@ func (c *Controller) createOrUpdateCrdVip(key, ns, subnet, v4ip, v6ip, mac, pV4i
 			vip.Status.Pv6ip = pV6ip
 			vip.Status.Pmac = pmac
 
-			_, err := c.config.KubeOvnClient.KubeovnV1().Vips().Update(context.Background(), vip, metav1.UpdateOptions{})
-			if err != nil {
+			if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Update(context.Background(), vip, metav1.UpdateOptions{}); err != nil {
 				errMsg := fmt.Errorf("failed to update vip '%s', %v", key, err)
 				klog.Error(errMsg)
 				return errMsg
@@ -432,8 +427,8 @@ func (c *Controller) createOrUpdateCrdVip(key, ns, subnet, v4ip, v6ip, mac, pV4i
 			patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`
 			raw, _ := json.Marshal(vip.Labels)
 			patchPayload := fmt.Sprintf(patchPayloadTemplate, op, raw)
-			_, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(context.Background(), vip.Name, types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{})
-			if err != nil {
+			if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(context.Background(), vip.Name, types.JSONPatchType,
+				[]byte(patchPayload), metav1.PatchOptions{}); err != nil {
 				klog.Errorf("failed to patch label for vip '%s', %v", vip.Name, err)
 				return err
 			}
@@ -572,8 +567,8 @@ func (c *Controller) releaseVip(key string) error {
 		patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`
 		raw, _ := json.Marshal(vip.Labels)
 		patchPayload := fmt.Sprintf(patchPayloadTemplate, op, raw)
-		_, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(context.Background(), vip.Name, types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{})
-		if err != nil {
+		if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(context.Background(), vip.Name,
+			types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}); err != nil {
 			klog.Errorf("failed to patch label for vip '%s', %v", vip.Name, err)
 			return err
 		}

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -759,8 +759,7 @@ func (c *Controller) getNatGwPod(name string) (*corev1.Pod, error) {
 
 func (c *Controller) checkVpcExternalNet() (err error) {
 	networkClient := c.config.AttachNetClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(c.config.PodNamespace)
-	_, err = networkClient.Get(context.Background(), util.VpcExternalNet, metav1.GetOptions{})
-	if err != nil {
+	if _, err = networkClient.Get(context.Background(), util.VpcExternalNet, metav1.GetOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			klog.Errorf("vpc external multus net '%s' should be exist already before ovn-vpc-nat-gw-config applied", util.VpcExternalNet)
 		}

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -212,8 +212,8 @@ func (c *Controller) handleDelVpcNatGw(key string) error {
 	defer c.vpcNatGwKeyMutex.Unlock(key)
 	name := genNatGwStsName(key)
 	klog.Infof("delete vpc nat gw %s", name)
-	err := c.config.KubeClient.AppsV1().StatefulSets(c.config.PodNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
-	if err != nil {
+	if err := c.config.KubeClient.AppsV1().StatefulSets(c.config.PodNamespace).Delete(context.Background(),
+		name, metav1.DeleteOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
@@ -549,6 +549,7 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 	}
 
 	if v4InternalGw, _, err = c.GetGwbySubnet(gw.Spec.Subnet); err != nil {
+		klog.Errorf("failed to get gw, err: %v", err)
 		return err
 	}
 	vpc, err := c.vpcsLister.Get(gw.Spec.Vpc)

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -497,8 +497,7 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 			klog.Errorf("failed to get gw, %v", err)
 			return err
 		}
-		err = c.createEipInPod(eip.Spec.NatGwDp, v4Gw, eipV4Cidr)
-		if err != nil {
+		if err = c.createEipInPod(eip.Spec.NatGwDp, v4Gw, eipV4Cidr); err != nil {
 			klog.Errorf("failed to create eip, %v", err)
 			return err
 		}

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -546,8 +546,7 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 	}
 
 	// create fip nat
-	err = c.createFipInPod(eip.Spec.NatGwDp, eip.Spec.V4ip, fip.Spec.InternalIp)
-	if err != nil {
+	if err = c.createFipInPod(eip.Spec.NatGwDp, eip.Spec.V4ip, fip.Spec.InternalIp); err != nil {
 		klog.Errorf("failed to create fip, %v", err)
 		return err
 	}
@@ -720,11 +719,9 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		return err
 	}
 	// create nat
-	err = c.createDnatInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol,
+	if err = c.createDnatInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol,
 		eip.Spec.V4ip, dnat.Spec.InternalIp,
-		dnat.Spec.ExternalPort, dnat.Spec.InternalPort,
-	)
-	if err != nil {
+		dnat.Spec.ExternalPort, dnat.Spec.InternalPort); err != nil {
 		// not retry too often
 		klog.Errorf("failed to create dnat, %v", err)
 		return err
@@ -900,8 +897,7 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 		return err
 	}
 	// create snat
-	err = c.createSnatInPod(eip.Spec.NatGwDp, eip.Spec.V4ip, snat.Spec.InternalCIDR)
-	if err != nil {
+	if err = c.createSnatInPod(eip.Spec.NatGwDp, eip.Spec.V4ip, snat.Spec.InternalCIDR); err != nil {
 		klog.Errorf("failed to create snat, %v", err)
 		return err
 	}
@@ -1248,8 +1244,11 @@ func (c *Controller) patchFipStatus(key, v4ip, v6ip, natGwDp, redo string, ready
 		return err
 	}
 	if changed {
-		_, err = c.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Patch(context.Background(), fip.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
-		return err
+		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Patch(context.Background(), fip.Name,
+			types.MergePatchType, bytes, metav1.PatchOptions{}, "status"); err != nil {
+			klog.Errorf("failed to patch fip %s, %v", fip.Name, err)
+			return err
+		}
 	}
 	return nil
 }
@@ -1313,8 +1312,8 @@ func (c *Controller) patchDnatLabel(key string, eip *kubeovnv1.IptablesEIP) erro
 		patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`
 		raw, _ := json.Marshal(dnat.Labels)
 		patchPayload := fmt.Sprintf(patchPayloadTemplate, op, raw)
-		_, err := c.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().Patch(context.Background(), dnat.Name, types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{})
-		if err != nil {
+		if _, err := c.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().Patch(context.Background(), dnat.Name,
+			types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}); err != nil {
 			klog.Errorf("failed to patch label for dnat %s, %v", dnat.Name, err)
 			return err
 		}
@@ -1352,8 +1351,11 @@ func (c *Controller) patchDnatStatus(key, v4ip, v6ip, natGwDp, redo string, read
 		return err
 	}
 	if changed {
-		_, err = c.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().Patch(context.Background(), dnat.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
-		return err
+		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().Patch(context.Background(), dnat.Name,
+			types.MergePatchType, bytes, metav1.PatchOptions{}, "status"); err != nil {
+			klog.Errorf("failed to patch dnat %s, %v", dnat.Name, err)
+			return err
+		}
 	}
 	return nil
 }
@@ -1415,8 +1417,8 @@ func (c *Controller) patchSnatLabel(key string, eip *kubeovnv1.IptablesEIP) erro
 		patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`
 		raw, _ := json.Marshal(snat.Labels)
 		patchPayload := fmt.Sprintf(patchPayloadTemplate, op, raw)
-		_, err := c.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().Patch(context.Background(), snat.Name, types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{})
-		if err != nil {
+		if _, err := c.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().Patch(context.Background(), snat.Name,
+			types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}); err != nil {
 			klog.Errorf("failed to patch label for snat %s, %v", snat.Name, err)
 			return err
 		}
@@ -1454,8 +1456,11 @@ func (c *Controller) patchSnatStatus(key, v4ip, v6ip, natGwDp, redo string, read
 		return err
 	}
 	if changed {
-		_, err = c.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().Patch(context.Background(), snat.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
-		return err
+		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().Patch(context.Background(), snat.Name,
+			types.MergePatchType, bytes, metav1.PatchOptions{}, "status"); err != nil {
+			klog.Errorf("failed to patch snat %s, %v", snat.Name, err)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -1494,6 +1494,7 @@ func (c *Controller) createFipInPod(dp, v4ip, internalIP string) error {
 	rule := fmt.Sprintf("%s,%s", v4ip, internalIP)
 	addRules = append(addRules, rule)
 	if err = c.execNatGwRules(gwPod, natGwSubnetFipAdd, addRules); err != nil {
+		klog.Errorf("failed to create fip, err: %v", err)
 		return err
 	}
 	return nil
@@ -1512,6 +1513,7 @@ func (c *Controller) deleteFipInPod(dp, v4ip, internalIP string) error {
 	rule := fmt.Sprintf("%s,%s", v4ip, internalIP)
 	delRules = append(delRules, rule)
 	if err = c.execNatGwRules(gwPod, natGwSubnetFipDel, delRules); err != nil {
+		klog.Errorf("failed to delete fip, err: %v", err)
 		return err
 	}
 	return nil
@@ -1528,6 +1530,7 @@ func (c *Controller) createDnatInPod(dp, protocol, v4ip, internalIp, externalPor
 	addRules = append(addRules, rule)
 
 	if err = c.execNatGwRules(gwPod, natGwDnatAdd, addRules); err != nil {
+		klog.Errorf("failed to create dnat, err: %v", err)
 		return err
 	}
 	return nil
@@ -1544,6 +1547,7 @@ func (c *Controller) deleteDnatInPod(dp, protocol, v4ip, internalIp, externalPor
 	rule := fmt.Sprintf("%s,%s,%s,%s,%s", v4ip, externalPort, protocol, internalIp, internalPort)
 	delRules = append(delRules, rule)
 	if err = c.execNatGwRules(gwPod, natGwDnatDel, delRules); err != nil {
+		klog.Errorf("failed to delete dnat, err: %v", err)
 		return err
 	}
 	return nil
@@ -1576,6 +1580,7 @@ func (c *Controller) deleteSnatInPod(dp, v4ip, internalCIDR string) error {
 	rule := fmt.Sprintf("%s,%s", v4ip, internalCIDR)
 	delRules = append(delRules, rule)
 	if err = c.execNatGwRules(gwPod, natGwSnatDel, delRules); err != nil {
+		klog.Errorf("failed to delete snat, err: %v", err)
 		return err
 	}
 	return nil

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -31,6 +31,8 @@ type Subnet struct {
 	NicToMac         map[string]string
 	MacToPod         map[string]string
 	PodToNicList     map[string][]string
+	V4Gw             string
+	V6Gw             string
 }
 
 func NewSubnet(name, cidrStr string, excludeIps []string) (*Subnet, error) {

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -210,7 +210,7 @@ var _ = Describe("[IPAM]", func() {
 				Expect(ip).To(Equal("fd00::1"))
 			})
 
-			It("donot reuse released address after update subnet's excludedIps", func() {
+			It("do not reuse released address after update subnet's excludedIps", func() {
 				im := ipam.NewIPAM()
 				err := im.AddOrUpdateSubnet(subnetName, "fd00::/126", v6Gw, nil)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -319,7 +319,7 @@ var _ = Describe("[IPAM]", func() {
 				Expect(ipv6).To(Equal("fd00::1"))
 			})
 
-			It("donot reuse released address after update subnet's excludedIps", func() {
+			It("do not reuse released address after update subnet's excludedIps", func() {
 				im := ipam.NewIPAM()
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", dualGw, nil)
 				Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
fix:  After external subnet updated, const extGw may expired, so use ipam subnet to cache ipv4|v6 gw。

also,  later ipv6(dualstack) eip and route in nat-gateway.sh  need another set of ipv6 route,eip add function, ipam subnet cache gw would be more convenient

- [x] Make sure you have followed [Kube-OVN Code Style](../CODE_STYLE.md).

#### What type of this PR
- Bug fixes

