### PR TITLE
fix: cancel delete staticroute when it's used by NatRule

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -647,6 +647,10 @@ func (c *Controller) gcStaticRoute() error {
 	for _, route := range routes {
 		if route.CIDR != "0.0.0.0/0" && route.CIDR != "::/0" && c.ipam.ContainAddress(route.CIDR) {
 			klog.Infof("gc static route %s %s %s", route.Policy, route.CIDR, route.NextHop)
+			exist, err := c.ovnLegacyClient.NatRuleExists(route.CIDR)
+			if exist || err != nil {
+				continue
+			}
 			if err := c.ovnLegacyClient.DeleteStaticRoute(route.CIDR, c.config.ClusterRouter); err != nil {
 				klog.Errorf("failed to delete stale route %s, %v", route.NextHop, err)
 			}

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1181,6 +1181,18 @@ func (c LegacyClient) DeleteNatRule(logicalIP, router string) error {
 	return err
 }
 
+func (c *LegacyClient) NatRuleExists(logicalIP string) (bool, error) {
+	results, err := c.CustomFindEntity("NAT", []string{"external_ip"}, fmt.Sprintf("logical_ip=%s", logicalIP))
+	if err != nil {
+		klog.Errorf("customFindEntity failed, %v", err)
+		return false, err
+	}
+	if len(results) == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (c LegacyClient) DeleteMatchedStaticRoute(cidr, nexthop, router string) error {
 	if cidr == "" || nexthop == "" {
 		return nil


### PR DESCRIPTION
gc will delete staticroute whice used by natrule.

Signed-off-by: xujunjie-cover <xujunjielxx@163.com>


- [x] Make sure you have followed [Kube-OVN Code Style](../CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes


#### Which issue(s) this PR fixes:
Fixes #1732 
