### PR TITLE
do not add subnet not processed by kube-ovn to vpc

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -689,7 +689,7 @@ func (c *Controller) getVpcSubnets(vpc *kubeovnv1.Vpc) (subnets []string, defaul
 	}
 
 	for _, subnet := range allSubnets {
-		if subnet.Spec.Vpc != vpc.Name || !subnet.DeletionTimestamp.IsZero() {
+		if subnet.Spec.Vpc != vpc.Name || !subnet.DeletionTimestamp.IsZero() || !isOvnSubnet(subnet) {
 			continue
 		}
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Bug fixes

####
1、the external-network subnet for vpc-nat-gw is processed specically. And when add static route for internal subnet in vpc, the static external-networl subnet should be ignored.


#### Which issue(s) this PR fixes:
Fixes #(issue-number)
