### PR TITLE
replace CreatePort function with libovsdb

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -134,7 +134,7 @@ func ParseFlags() (*Configuration, error) {
 		argEnableEipSnat        = pflag.Bool("enable-eip-snat", true, "Enable EIP and SNAT")
 		argEnableExternalVpc    = pflag.Bool("enable-external-vpc", true, "Enable external vpc support")
 		argEnableEcmp           = pflag.Bool("enable-ecmp", false, "Enable ecmp route for centralized subnet")
-		argKeepVmIP             = pflag.Bool("keep-vm-ip", false, "Whether to keep ip for kubevirt pod when pod is rebuild")
+		argKeepVmIP             = pflag.Bool("keep-vm-ip", true, "Whether to keep ip for kubevirt pod when pod is rebuild")
 		argEnableLbSvc          = pflag.Bool("enable-lb-svc", false, "Whether to support loadbalancer service")
 
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -19,6 +19,96 @@ const (
 	logicalSwitchKey = "ls"
 )
 
+func (c OvnClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName, namespace string, portSecurity bool, securityGroups string, vips string, liveMigration bool, enableDHCP bool, dhcpOptions *DHCPOptionsUUIDs, vpc string) error {
+	lsp, err := c.GetLogicalSwitchPort(lspName, true)
+	if err != nil {
+		return err
+	}
+
+	// when kubevirt vm live-migrate, just consider the this case for now(keep-vm-ip=true):
+	// lspName is 'vmName.namespace.providerName' when keep-vm-ip=true, there are two pod with the same lspName,
+	// so to determine vm is in live migration
+	if liveMigration && lsp != nil {
+		lsp.Addresses = []string{mac}
+		lsp.ExternalIDs["liveMigration"] = "1"
+		if err := c.UpdateLogicalSwitchPort(lsp, &lsp.Addresses, &lsp.ExternalIDs); err != nil {
+			return fmt.Errorf("set liveMigration=1 to logical switch port %s: %v", lspName, err)
+		}
+		return nil
+	}
+
+	/* normal lsp creation */
+	lsp = &ovnnb.LogicalSwitchPort{
+		UUID:        ovsclient.UUID(),
+		Name:        lspName,
+		ExternalIDs: make(map[string]string),
+	}
+
+	ipList := strings.Split(ip, ",")
+	vipList := strings.Split(vips, ",")
+	addresses := make([]string, 0, len(ipList)+len(vipList)+1) // +1 is the mac length
+	addresses = append(addresses, mac)
+	addresses = append(addresses, ipList...)
+
+	// addresses is the first element of addresses
+	lsp.Addresses = []string{strings.Join(addresses, " ")}
+
+	if portSecurity {
+		if len(vips) != 0 {
+			addresses = append(addresses, vipList...)
+		}
+		// addresses is the first element of port_security
+		lsp.PortSecurity = []string{strings.Join(addresses, " ")}
+
+		// set sercurity groups
+		if len(securityGroups) != 0 {
+			lsp.ExternalIDs["security_groups"] = strings.ReplaceAll(securityGroups, ",", "/")
+
+			sgList := strings.Split(securityGroups, ",")
+			for _, sg := range sgList {
+				lsp.ExternalIDs["associated_sg_"+sg] = "true"
+			}
+		}
+	}
+
+	// add lsp which does not belong to defualt vpc to default-securitygroup when default-securitygroup configMap exist
+	if vpc != "" && vpc != util.DefaultVpc && !strings.Contains(securityGroups, util.DefaultSecurityGroupName) {
+		lsp.ExternalIDs["associated_sg_"+util.DefaultSecurityGroupName] = "false"
+	}
+
+	// set vips info to external-ids
+	if len(vips) != 0 {
+		lsp.ExternalIDs["vips"] = strings.ReplaceAll(vips, ",", "/")
+		lsp.ExternalIDs["attach-vips"] = "true"
+	}
+
+	// set pod info to external-ids
+	if len(podName) != 0 && len(namespace) != 0 {
+		lsp.ExternalIDs["pod"] = namespace + "/" + podName
+	}
+
+	// set dhcp options
+	if enableDHCP && dhcpOptions != nil {
+		if len(dhcpOptions.DHCPv4OptionsUUID) != 0 {
+			lsp.Dhcpv4Options = &dhcpOptions.DHCPv4OptionsUUID
+		}
+		if len(dhcpOptions.DHCPv6OptionsUUID) != 0 {
+			lsp.Dhcpv6Options = &dhcpOptions.DHCPv6OptionsUUID
+		}
+	}
+
+	ops, err := c.CreateLogicalSwitchPortOp(lsp, lsName)
+	if err != nil {
+		return err
+	}
+
+	if err = c.Transact("lsp-add", ops); err != nil {
+		return fmt.Errorf("create logical switch port %s: %v", lspName, err)
+	}
+
+	return nil
+}
+
 // CreateVirtualLogicalSwitchPorts create some virtual type logical switch port once
 func (c OvnClient) CreateVirtualLogicalSwitchPorts(lsName string, ips ...string) error {
 	ops := make([]ovsdb.Operation, 0, len(ips))

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -85,6 +85,10 @@ func (suite *OvnClientTestSuite) Test_LogicalSwitchOp() {
 }
 
 /* logical_switch_port unit test */
+func (suite *OvnClientTestSuite) Test_CreateLogicalSwitchPort() {
+	suite.testCreateLogicalSwitchPort()
+}
+
 func (suite *OvnClientTestSuite) Test_CreateVirtualLogicalSwitchPorts() {
 	suite.testCreateVirtualLogicalSwitchPorts()
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -135,6 +135,8 @@ const (
 	VpcDnsConfig           = "vpc-dns-config"
 	VpcDnsDepTemplate      = "vpc-dns-dep"
 
+	DefaultSecurityGroupName = "default-securitygroup"
+
 	DefaultVpc    = "ovn-cluster"
 	DefaultSubnet = "ovn-default"
 


### PR DESCRIPTION

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #1675 
1. replace CreatePort function with libovsdb
2. set keep-vm-ip default value to true
