### PR TITLE
done for logical_switch_port replacment with libovsdb

### DIFF
--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -89,6 +89,10 @@ func (suite *OvnClientTestSuite) Test_CreateLogicalSwitchPort() {
 	suite.testCreateLogicalSwitchPort()
 }
 
+func (suite *OvnClientTestSuite) Test_CreateLocalnetLogicalSwitchPort() {
+	suite.testCreateLocalnetLogicalSwitchPort()
+}
+
 func (suite *OvnClientTestSuite) Test_CreateVirtualLogicalSwitchPorts() {
 	suite.testCreateVirtualLogicalSwitchPorts()
 }
@@ -103,6 +107,10 @@ func (suite *OvnClientTestSuite) Test_SetLogicalSwitchPortSecurity() {
 
 func (suite *OvnClientTestSuite) Test_EnablePortLayer2forward() {
 	suite.testEnablePortLayer2forward()
+}
+
+func (suite *OvnClientTestSuite) Test_SetLogicalSwitchPortVlanTag() {
+	suite.testSetLogicalSwitchPortVlanTag()
 }
 
 func (suite *OvnClientTestSuite) Test_UpdateLogicalSwitchPort() {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #1675 
