### PR TITLE
replace some of port_group table with libovsdb

### DIFF
--- a/pkg/ovs/ovn-nb-gateway_chassis.go
+++ b/pkg/ovs/ovn-nb-gateway_chassis.go
@@ -111,6 +111,7 @@ func (c OvnClient) DeleteGatewayChassisOp(chassisName string) ([]ovsdb.Operation
 	return op, nil
 }
 
+// GetGatewayChassis get gateway chassis by name
 func (c OvnClient) GetGatewayChassis(name string, ignoreNotFound bool) (*ovnnb.GatewayChassis, error) {
 	gwChassis := &ovnnb.GatewayChassis{Name: name}
 	if err := c.Get(context.TODO(), gwChassis); err != nil {

--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -75,7 +75,8 @@ func (c OvnClient) DeleteLoadBalancers(lbs ...string) error {
 	return nil
 }
 
-// GetLoadBalancer get load balancer by name
+// GetLoadBalancer get load balancer by name,
+// it is because of lack name index that does't use ovnNbClient.Get
 func (c OvnClient) GetLoadBalancer(lbName string, ignoreNotFound bool) (*ovnnb.LoadBalancer, error) {
 	lbList := make([]ovnnb.LoadBalancer, 0)
 	if err := c.ovnNbClient.WhereCache(func(lb *ovnnb.LoadBalancer) bool {

--- a/pkg/ovs/ovn-nb-logical_router.go
+++ b/pkg/ovs/ovn-nb-logical_router.go
@@ -64,6 +64,8 @@ func (c OvnClient) DeleteLogicalRouter(lrName string) error {
 	return nil
 }
 
+// GetLogicalRouter get load balancer by name,
+// it is because of lack name index that does't use ovnNbClient.Get
 func (c OvnClient) GetLogicalRouter(lrName string, ignoreNotFound bool) (*ovnnb.LogicalRouter, error) {
 	lrList := make([]ovnnb.LogicalRouter, 0)
 	if err := c.ovnNbClient.WhereCache(func(lr *ovnnb.LogicalRouter) bool {

--- a/pkg/ovs/ovn-nb-logical_router_port.go
+++ b/pkg/ovs/ovn-nb-logical_router_port.go
@@ -128,6 +128,7 @@ func (c OvnClient) DeleteLogicalRouterPort(lrpName string) error {
 	return nil
 }
 
+// GetLogicalRouterPort get logical router port by name,
 func (c OvnClient) GetLogicalRouterPort(lrpName string, ignoreNotFound bool) (*ovnnb.LogicalRouterPort, error) {
 	lrp := &ovnnb.LogicalRouterPort{Name: lrpName}
 	if err := c.Get(context.TODO(), lrp); err != nil {

--- a/pkg/ovs/ovn-nb-logical_switch.go
+++ b/pkg/ovs/ovn-nb-logical_switch.go
@@ -156,7 +156,8 @@ func (c OvnClient) DeleteLogicalSwitch(lsName string) error {
 	return nil
 }
 
-// GetLogicalSwitch get logical switch by name
+// GetLogicalSwitch get logical switch by name,
+// it is because of lack name index that does't use ovnNbClient.Get
 func (c OvnClient) GetLogicalSwitch(name string, ignoreNotFound bool) (*ovnnb.LogicalSwitch, error) {
 	lsList := make([]ovnnb.LogicalSwitch, 0)
 	if err := c.ovnNbClient.WhereCache(func(ls *ovnnb.LogicalSwitch) bool {
@@ -204,7 +205,7 @@ func (c OvnClient) ListLogicalSwitch(needVendorFilter bool) ([]ovnnb.LogicalSwit
 // LogicalSwitchUpdatePortOp create operations add port to or delete port from logical switch
 func (c OvnClient) LogicalSwitchUpdatePortOp(lsName string, lspUUID string, op ovsdb.Mutator) ([]ovsdb.Operation, error) {
 	if len(lspUUID) == 0 {
-		return nil, fmt.Errorf("uuid %s add or del to logical switch %s cannot be empty", lspUUID, lsName)
+		return nil, nil
 	}
 
 	mutation := func(ls *ovnnb.LogicalSwitch) *model.Mutation {
@@ -262,7 +263,7 @@ func (c OvnClient) LogicalSwitchOp(lsName string, mutationsFunc ...func(ls *ovnn
 
 	ops, err := c.ovnNbClient.Where(ls).Mutate(ls, mutations...)
 	if err != nil {
-		return nil, fmt.Errorf("generate operations for mutating logical switch %s: %v", ls.Name, err)
+		return nil, fmt.Errorf("generate operations for mutating logical switch %s: %v", lsName, err)
 	}
 
 	return ops, nil

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -356,6 +356,7 @@ func (c OvnClient) DeleteLogicalSwitchPort(lspName string) error {
 	return nil
 }
 
+// GetLogicalSwitchPort get logical switch port by name
 func (c OvnClient) GetLogicalSwitchPort(name string, ignoreNotFound bool) (*ovnnb.LogicalSwitchPort, error) {
 	lsp := &ovnnb.LogicalSwitchPort{Name: name}
 	if err := c.Get(context.TODO(), lsp); err != nil {
@@ -411,7 +412,6 @@ func (c OvnClient) ListLogicalSwitchPorts(needVendorFilter bool, externalIDs map
 						return false
 					}
 				}
-
 			}
 		}
 

--- a/pkg/ovs/ovn-nb-port_group.go
+++ b/pkg/ovs/ovn-nb-port_group.go
@@ -3,48 +3,228 @@ package ovs
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"k8s.io/klog/v2"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
 
+func (c OvnClient) CreatePortGroup(pgName string, externalIDs map[string]string) error {
+	pg, err := c.GetPortGroup(pgName, true)
+	if err != nil {
+		return err
+	}
+
+	// found, ingore
+	if pg != nil {
+		return nil
+	}
+
+	pg = &ovnnb.PortGroup{
+		Name:        pgName,
+		ExternalIDs: externalIDs,
+	}
+
+	ops, err := c.ovnNbClient.Create(pg)
+	if err != nil {
+		return fmt.Errorf("generate operations for creating port group %s: %v", pgName, err)
+	}
+
+	if err = c.Transact("pg-add", ops); err != nil {
+		return fmt.Errorf("create port group %s: %v", pgName, err)
+	}
+
+	return nil
+}
+
+// PortGroupUpdatePorts add several ports to or from port group once
+func (c OvnClient) PortGroupUpdatePorts(pgName string, op ovsdb.Mutator, lspNames ...string) error {
+	if len(lspNames) == 0 {
+		return nil
+	}
+
+	lspUUIDs := make([]string, 0, len(lspNames))
+
+	for _, lspName := range lspNames {
+		lsp, err := c.GetLogicalSwitchPort(lspName, true)
+		if err != nil {
+			return err
+		}
+
+		// ingnore non-existent object
+		if lsp != nil {
+			lspUUIDs = append(lspUUIDs, lsp.UUID)
+		}
+	}
+
+	ops, err := c.portGroupUpdatePortOp(pgName, lspUUIDs, op)
+	if err != nil {
+		return fmt.Errorf("generate operations for port group %s update ports %s: %v", pgName, strings.Join(lspNames, " "), err)
+	}
+
+	if err := c.Transact("pg-ports-update", ops); err != nil {
+		return fmt.Errorf("port group %s update ports %s: %v", pgName, strings.Join(lspNames, " "), err)
+	}
+
+	return nil
+}
+
+func (c OvnClient) DeletePortGroup(pgName string) error {
+	pg, err := c.GetPortGroup(pgName, true)
+	if err != nil {
+		return fmt.Errorf("get port group %s when delete: %v", pgName, err)
+	}
+
+	// not found, skip
+	if pg == nil {
+		return nil
+	}
+
+	op, err := c.Where(pg).Delete()
+	if err != nil {
+		return err
+	}
+
+	if err := c.Transact("pg-del", op); err != nil {
+		return fmt.Errorf("delete port group %s: %v", pgName, err)
+	}
+
+	return nil
+}
+
+// GetPortGroup get port group by name
 func (c OvnClient) GetPortGroup(name string, ignoreNotFound bool) (*ovnnb.PortGroup, error) {
 	pg := &ovnnb.PortGroup{Name: name}
 	if err := c.ovnNbClient.Get(context.TODO(), pg); err != nil {
 		if ignoreNotFound && err == client.ErrNotFound {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to get port group %s: %v", name, err)
+		return nil, fmt.Errorf("get port group %s: %v", name, err)
 	}
 
 	return pg, nil
 }
 
-func (c OvnClient) CreatePortGroup(name string, externalIDs map[string]string) error {
-	pg, err := c.GetPortGroup(name, true)
-	if err != nil {
-		return err
-	}
-	if pg != nil {
-		return nil
+// ListPortGroups list port groups which match the given externalIDs,
+// result should include all port groups when externalIDs is empty,
+// result should include all port groups which externalIDs[key] is not empty when externalIDs[key] is ""
+func (c OvnClient) ListPortGroups(externalIDs map[string]string) ([]ovnnb.PortGroup, error) {
+	pgs := make([]ovnnb.PortGroup, 0)
+
+	if err := c.WhereCache(func(pg *ovnnb.PortGroup) bool {
+		if len(pg.ExternalIDs) < len(externalIDs) {
+			return false
+		}
+
+		if len(pg.ExternalIDs) != 0 {
+			for k, v := range externalIDs {
+				// if only key exist but not value in externalIDs, we should include this pg,
+				// it's equal to shell command `ovn-nbctl --columns=xx find port_group external_ids:key!=\"\"`
+				if len(v) == 0 {
+					if len(pg.ExternalIDs[k]) == 0 {
+						return false
+					}
+				} else {
+					if pg.ExternalIDs[k] != v {
+						return false
+					}
+				}
+
+			}
+		}
+
+		return true
+	}).List(context.TODO(), &pgs); err != nil {
+		klog.Errorf("list logical switch ports: %v", err)
+		return nil, err
 	}
 
-	pg = &ovnnb.PortGroup{
-		Name:        name,
-		ExternalIDs: externalIDs,
-	}
-	ops, err := c.ovnNbClient.Create(pg)
-	if err != nil {
-		return fmt.Errorf("failed to generate create operations for port group %s: %v", name, err)
-	}
-	if err = Transact(c.ovnNbClient, "pg-add", ops, c.ovnNbClient.Timeout); err != nil {
-		return fmt.Errorf("failed to create port group %s: %v", name, err)
-	}
-
-	return nil
+	return pgs, nil
 }
 
+func (c OvnClient) PortGroupExists(name string) (bool, error) {
+	lsp, err := c.GetPortGroup(name, true)
+	return lsp != nil, err
+}
+
+// PortGroupALLNotExist return true if all port group does not exist
+func (c OvnClient) PortGroupALLNotExist(sgs []string) (bool, error) {
+	if len(sgs) == 0 {
+		return true, nil
+	}
+
+	notExistsCount := 0
+	// sgs format: sg1/sg2/sg3
+	for _, sg := range sgs {
+		ok, err := c.PortGroupExists(GetSgPortGroupName(sg))
+		if err != nil {
+			return true, err
+		}
+
+		if !ok {
+			notExistsCount++
+		}
+	}
+
+	return notExistsCount == len(sgs), nil
+}
+
+// portGroupUpdatePortOp create operations add port to or delete port from port group
+func (c OvnClient) portGroupUpdatePortOp(pgName string, lspUUIDs []string, op ovsdb.Mutator) ([]ovsdb.Operation, error) {
+	if len(lspUUIDs) == 0 {
+		return nil, nil
+	}
+
+	mutation := func(pg *ovnnb.PortGroup) *model.Mutation {
+		mutation := &model.Mutation{
+			Field:   &pg.Ports,
+			Value:   lspUUIDs,
+			Mutator: op,
+		}
+
+		return mutation
+	}
+
+	return c.portGroupOp(pgName, mutation)
+}
+
+// portGroupOp create operations about port group
+func (c OvnClient) portGroupOp(pgName string, mutationsFunc ...func(pg *ovnnb.PortGroup) *model.Mutation) ([]ovsdb.Operation, error) {
+	pg, err := c.GetPortGroup(pgName, false)
+	if err != nil {
+		return nil, fmt.Errorf("get port group %s when generate mutate operations: %v", pgName, err)
+	}
+
+	if len(mutationsFunc) == 0 {
+		return nil, nil
+	}
+
+	mutations := make([]model.Mutation, 0, len(mutationsFunc))
+
+	for _, f := range mutationsFunc {
+		mutation := f(pg)
+
+		if mutation != nil {
+			mutations = append(mutations, *mutation)
+		}
+	}
+
+	ops, err := c.ovnNbClient.Where(pg).Mutate(pg, mutations...)
+	if err != nil {
+		return nil, fmt.Errorf("generate operations for mutating port group %s: %v", pgName, err)
+	}
+
+	return ops, nil
+}
+
+/*
+----------------------------------------------------------------------------------------------
+TODO: wait to be deleted
+*/
 func (c OvnClient) portGroupPortOp(pgName, portName string, opIsAdd bool) error {
 	pg, err := c.GetPortGroup(pgName, false)
 	if err != nil {
@@ -78,7 +258,7 @@ func (c OvnClient) portGroupPortOp(pgName, portName string, opIsAdd bool) error 
 	if err != nil {
 		return fmt.Errorf("failed to generate update operations for port group %s: %v", pgName, err)
 	}
-	if err = Transact(c.ovnNbClient.Client, "update", ops, c.ovnNbClient.Timeout); err != nil {
+	if err = c.Transact("update", ops); err != nil {
 		return fmt.Errorf("failed to update ports of port group %s: %v", pgName, err)
 	}
 

--- a/pkg/ovs/ovn-nb-port_group_test.go
+++ b/pkg/ovs/ovn-nb-port_group_test.go
@@ -1,0 +1,416 @@
+package ovs
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *OvnClientTestSuite) testCreatePortGroup() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test-create-pg"
+
+	err := ovnClient.CreatePortGroup(pgName, map[string]string{
+		"type": "security_group",
+		"sg":   "test-sg",
+	})
+	require.NoError(t, err)
+
+	pg, err := ovnClient.GetPortGroup(pgName, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, pg.UUID)
+	require.Equal(t, pgName, pg.Name)
+	require.Equal(t, map[string]string{
+		"type": "security_group",
+		"sg":   "test-sg",
+	}, pg.ExternalIDs)
+}
+
+func (suite *OvnClientTestSuite) testPortGroupUpdatePorts() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test-add-ports-to-pg"
+	lsName := "test-add-ports-to-ls"
+	prefix := "test-add-lsp"
+	lspNames := make([]string, 0, 3)
+
+	err := ovnClient.CreateBareLogicalSwitch(lsName)
+	require.NoError(t, err)
+
+	err = ovnClient.CreatePortGroup(pgName, map[string]string{
+		"type": "security_group",
+		"sg":   "test-sg",
+	})
+	require.NoError(t, err)
+
+	for i := 1; i <= 3; i++ {
+		lspName := fmt.Sprintf("%s-%d", prefix, i)
+		lspNames = append(lspNames, lspName)
+		err := ovnClient.CreateBareLogicalSwitchPort(lsName, lspName)
+		require.NoError(t, err)
+	}
+
+	t.Run("add ports to port group", func(t *testing.T) {
+		err = ovnClient.PortGroupUpdatePorts(pgName, ovsdb.MutateOperationInsert, lspNames...)
+		require.NoError(t, err)
+
+		pg, err := ovnClient.GetPortGroup(pgName, false)
+		require.NoError(t, err)
+
+		for _, lspName := range lspNames {
+			lsp, err := ovnClient.GetLogicalSwitchPort(lspName, false)
+			require.NoError(t, err)
+			require.Contains(t, pg.Ports, lsp.UUID)
+		}
+	})
+
+	t.Run("should no err when add non-existent ports to port group", func(t *testing.T) {
+		// add a non-existent ports
+		err = ovnClient.PortGroupUpdatePorts(pgName, ovsdb.MutateOperationInsert, "test-add-lsp-non-existent")
+		require.NoError(t, err)
+	})
+
+	t.Run("del lbs from logical switch", func(t *testing.T) {
+		// delete the first two lbs from logical switch
+		err = ovnClient.PortGroupUpdatePorts(pgName, ovsdb.MutateOperationDelete, lspNames[0:2]...)
+		require.NoError(t, err)
+
+		pg, err := ovnClient.GetPortGroup(pgName, false)
+		require.NoError(t, err)
+
+		for i, lspName := range lspNames {
+			lsp, err := ovnClient.GetLogicalSwitchPort(lspName, false)
+			require.NoError(t, err)
+
+			// port group contains the last ports
+			if i == 2 {
+				require.Contains(t, pg.Ports, lsp.UUID)
+				continue
+			}
+			require.NotContains(t, pg.Ports, lsp.UUID)
+		}
+	})
+
+	t.Run("del non-existent ports from port group", func(t *testing.T) {
+		// del a non-existent ports
+		err = ovnClient.PortGroupUpdatePorts(pgName, ovsdb.MutateOperationDelete, "test-del-lsp-non-existent")
+		require.NoError(t, err)
+	})
+}
+
+func (suite *OvnClientTestSuite) testDeletePortGroup() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test-delete-pg"
+
+	t.Run("no err when delete existent port group", func(t *testing.T) {
+		t.Parallel()
+		err := ovnClient.CreatePortGroup(pgName, nil)
+		require.NoError(t, err)
+
+		err = ovnClient.DeletePortGroup(pgName)
+		require.NoError(t, err)
+
+		_, err = ovnClient.GetPortGroup(pgName, false)
+		require.ErrorContains(t, err, "object not found")
+	})
+
+	t.Run("no err when delete non-existent logical router", func(t *testing.T) {
+		t.Parallel()
+		err := ovnClient.DeletePortGroup("test-delete-pg-non-existent")
+		require.NoError(t, err)
+	})
+}
+
+func (suite *OvnClientTestSuite) testGetGetPortGroup() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test-get-pg"
+
+	err := ovnClient.CreatePortGroup(pgName, map[string]string{
+		"type": "security_group",
+		"sg":   "test-sg",
+	})
+	require.NoError(t, err)
+
+	t.Run("should return no err when found port group", func(t *testing.T) {
+		t.Parallel()
+		pg, err := ovnClient.GetPortGroup(pgName, false)
+		require.NoError(t, err)
+		require.Equal(t, pgName, pg.Name)
+		require.NotEmpty(t, pg.UUID)
+	})
+
+	t.Run("should return err when not found port group", func(t *testing.T) {
+		t.Parallel()
+		_, err := ovnClient.GetPortGroup("test-get-pg-non-existent", false)
+		require.ErrorContains(t, err, "object not found")
+	})
+
+	t.Run("no err when not found port group and ignoreNotFound is true", func(t *testing.T) {
+		t.Parallel()
+		_, err := ovnClient.GetPortGroup("test-get-pg-non-existent", true)
+		require.NoError(t, err)
+	})
+}
+
+func (suite *OvnClientTestSuite) testListPortGroups() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+
+	t.Run("result should exclude pg when externalIDs's length is not equal", func(t *testing.T) {
+		pgName := "test-list-pg-mismatch-length"
+
+		err := ovnClient.CreatePortGroup(pgName, map[string]string{"key": "value"})
+		require.NoError(t, err)
+
+		pgs, err := ovnClient.ListPortGroups(map[string]string{"sg": "sg", "type": "security_group", "key": "value"})
+		require.NoError(t, err)
+		require.Empty(t, pgs)
+	})
+
+	t.Run("result should include lsp when key exists in pg column: external_ids", func(t *testing.T) {
+		pgName := "test-list-pg-exist-key"
+
+		err := ovnClient.CreatePortGroup(pgName, map[string]string{"sg": "sg", "type": "security_group", "key": "value"})
+		require.NoError(t, err)
+
+		pgs, err := ovnClient.ListPortGroups(map[string]string{"type": "security_group", "key": "value"})
+		require.NoError(t, err)
+		require.Len(t, pgs, 1)
+		require.Equal(t, pgName, pgs[0].Name)
+	})
+
+	t.Run("result should include all pg when externalIDs is empty", func(t *testing.T) {
+		prefix := "test-list-pg-all"
+
+		for i := 0; i < 4; i++ {
+			pgName := fmt.Sprintf("%s-%d", prefix, i)
+
+			err := ovnClient.CreatePortGroup(pgName, map[string]string{"sg": "sg", "type": "security_group", "key": "value"})
+			require.NoError(t, err)
+		}
+
+		out, err := ovnClient.ListPortGroups(nil)
+		require.NoError(t, err)
+		count := 0
+		for _, v := range out {
+			if strings.Contains(v.Name, prefix) {
+				count++
+			}
+		}
+		require.Equal(t, count, 4)
+
+		out, err = ovnClient.ListPortGroups(map[string]string{})
+		require.NoError(t, err)
+		count = 0
+		for _, v := range out {
+			if strings.Contains(v.Name, prefix) {
+				count++
+			}
+		}
+		require.Equal(t, count, 4)
+	})
+
+	t.Run("result should include pg which externalIDs[key] is ''", func(t *testing.T) {
+		pgName := "test-list-pg-no-val"
+
+		err := ovnClient.CreatePortGroup(pgName, map[string]string{"sg_test": "sg", "type": "security_group", "key": "value"})
+		require.NoError(t, err)
+
+		pgs, err := ovnClient.ListPortGroups(map[string]string{"sg_test": "", "key": ""})
+		require.NoError(t, err)
+		require.Len(t, pgs, 1)
+		require.Equal(t, pgName, pgs[0].Name)
+
+		pgs, err = ovnClient.ListPortGroups(map[string]string{"sg_test": ""})
+		require.NoError(t, err)
+		require.Len(t, pgs, 1)
+		require.Equal(t, pgName, pgs[0].Name)
+
+		pgs, err = ovnClient.ListPortGroups(map[string]string{"sg_test": "", "key": "", "key1": ""})
+		require.NoError(t, err)
+		require.Empty(t, pgs)
+	})
+}
+
+func (suite *OvnClientTestSuite) testPortGroupALLNotExist() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	sgName := "sg"
+	pgName := GetSgPortGroupName(sgName)
+
+	err := ovnClient.CreatePortGroup(pgName, map[string]string{
+		"type": "security_group",
+		"sg":   "test-sg",
+	})
+	require.NoError(t, err)
+
+	t.Run("should return false when some port group exist", func(t *testing.T) {
+		exist, err := ovnClient.PortGroupALLNotExist([]string{sgName, "sg1", "sg2", "sg3"})
+		require.NoError(t, err)
+		require.False(t, exist)
+	})
+
+	t.Run("should return true when all port group does't exist", func(t *testing.T) {
+		exist, err := ovnClient.PortGroupALLNotExist([]string{"sg1", "sg2", "sg3"})
+		require.NoError(t, err)
+		require.True(t, exist)
+	})
+
+	t.Run("should return true when sgs is empty", func(t *testing.T) {
+		exist, err := ovnClient.PortGroupALLNotExist([]string{})
+		require.NoError(t, err)
+		require.True(t, exist)
+	})
+}
+
+func (suite *OvnClientTestSuite) testportGroupUpdatePortOp() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test-update-port-op-pg"
+	lspUUIDs := []string{ovsclient.UUID(), ovsclient.UUID()}
+
+	err := ovnClient.CreatePortGroup(pgName, map[string]string{
+		"type": "security_group",
+		"sg":   "test-sg",
+	})
+	require.NoError(t, err)
+
+	t.Run("add new port to port group", func(t *testing.T) {
+		t.Parallel()
+		ops, err := ovnClient.portGroupUpdatePortOp(pgName, lspUUIDs, ovsdb.MutateOperationInsert)
+		require.NoError(t, err)
+		require.Equal(t, []ovsdb.Mutation{
+			{
+				Column:  "ports",
+				Mutator: ovsdb.MutateOperationInsert,
+				Value: ovsdb.OvsSet{
+					GoSet: []interface{}{
+						ovsdb.UUID{
+							GoUUID: lspUUIDs[0],
+						},
+						ovsdb.UUID{
+							GoUUID: lspUUIDs[1],
+						},
+					},
+				},
+			},
+		}, ops[0].Mutations)
+	})
+
+	t.Run("del port from port group", func(t *testing.T) {
+		t.Parallel()
+		ops, err := ovnClient.portGroupUpdatePortOp(pgName, lspUUIDs, ovsdb.MutateOperationDelete)
+		require.NoError(t, err)
+		require.Equal(t, []ovsdb.Mutation{
+			{
+				Column:  "ports",
+				Mutator: ovsdb.MutateOperationDelete,
+				Value: ovsdb.OvsSet{
+					GoSet: []interface{}{
+						ovsdb.UUID{
+							GoUUID: lspUUIDs[0],
+						},
+						ovsdb.UUID{
+							GoUUID: lspUUIDs[1],
+						},
+					},
+				},
+			},
+		}, ops[0].Mutations)
+	})
+
+	t.Run("should return err when port group does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ovnClient.portGroupUpdatePortOp("test-port-op-pg-non-existent", lspUUIDs, ovsdb.MutateOperationInsert)
+		require.ErrorContains(t, err, "object not found")
+	})
+}
+
+func (suite *OvnClientTestSuite) testportGroupOp() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test-port-op-pg"
+
+	err := ovnClient.CreatePortGroup(pgName, map[string]string{
+		"type": "security_group",
+		"sg":   "test-sg",
+	})
+	require.NoError(t, err)
+
+	lspUUID := ovsclient.UUID()
+	lspMutation := func(pg *ovnnb.PortGroup) *model.Mutation {
+		mutation := &model.Mutation{
+			Field:   &pg.Ports,
+			Value:   []string{lspUUID},
+			Mutator: ovsdb.MutateOperationInsert,
+		}
+
+		return mutation
+	}
+
+	aclUUID := ovsclient.UUID()
+	aclMutation := func(pg *ovnnb.PortGroup) *model.Mutation {
+		mutation := &model.Mutation{
+			Field:   &pg.ACLs,
+			Value:   []string{aclUUID},
+			Mutator: ovsdb.MutateOperationInsert,
+		}
+
+		return mutation
+	}
+
+	ops, err := ovnClient.portGroupOp(pgName, lspMutation, aclMutation)
+	require.NoError(t, err)
+
+	require.Len(t, ops[0].Mutations, 2)
+	require.Equal(t, []ovsdb.Mutation{
+		{
+			Column:  "ports",
+			Mutator: ovsdb.MutateOperationInsert,
+			Value: ovsdb.OvsSet{
+				GoSet: []interface{}{
+					ovsdb.UUID{
+						GoUUID: lspUUID,
+					},
+				},
+			},
+		},
+		{
+			Column:  "acls",
+			Mutator: ovsdb.MutateOperationInsert,
+			Value: ovsdb.OvsSet{
+				GoSet: []interface{}{
+					ovsdb.UUID{
+						GoUUID: aclUUID,
+					},
+				},
+			},
+		},
+	}, ops[0].Mutations)
+}

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -249,6 +249,39 @@ func (suite *OvnClientTestSuite) Test_DeleteLoadBalancerOp() {
 	suite.testDeleteLoadBalancerOp()
 }
 
+/* port_group unit test */
+func (suite *OvnClientTestSuite) Test_CreatePortGroup() {
+	suite.testCreatePortGroup()
+}
+
+func (suite *OvnClientTestSuite) Test_PortGroupUpdatePorts() {
+	suite.testPortGroupUpdatePorts()
+}
+
+func (suite *OvnClientTestSuite) Test_DeletePortGroup() {
+	suite.testDeletePortGroup()
+}
+
+func (suite *OvnClientTestSuite) Test_GetGetPortGroup() {
+	suite.testGetGetPortGroup()
+}
+
+func (suite *OvnClientTestSuite) Test_ListPortGroups() {
+	suite.testListPortGroups()
+}
+
+func (suite *OvnClientTestSuite) Test_PortGroupALLNotExist() {
+	suite.testPortGroupALLNotExist()
+}
+
+func (suite *OvnClientTestSuite) Test_portGroupUpdatePortOp() {
+	suite.testportGroupUpdatePortOp()
+}
+
+func (suite *OvnClientTestSuite) Test_portGroupOp() {
+	suite.testportGroupOp()
+}
+
 /* mixed operations unit test */
 func (suite *OvnClientTestSuite) Test_CreateGatewayLogicalSwitch() {
 	suite.testCreateGatewayLogicalSwitch()


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #1675 

replace some of port_group table with libovsdb
