### PR TITLE
fix iptables for services with external traffic policy set to Local

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -140,17 +140,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e
 
       - name: Cleanup
         run: |
@@ -263,17 +258,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e-vlan
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e-vlan
 
       - name: Cleanup
         run: |
@@ -465,17 +455,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e
 
       - name: Cleanup
         run: |
@@ -529,17 +514,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e-ipv6
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e-ipv6
 
       - name: Cleanup
         run: |
@@ -593,17 +573,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e-vlan-ipv6
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e-vlan-ipv6
 
       - name: Cleanup
         run: |
@@ -732,17 +707,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e
 
       - name: Cleanup
         run: |
@@ -871,17 +841,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e
 
       - name: Cleanup
         run: |
@@ -953,17 +918,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e
 
       - name: Cleanup
         run: |
@@ -1078,17 +1038,12 @@ jobs:
         id: go
 
       - name: Run E2E
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          shell: bash
-          command: |
-            go install github.com/onsi/ginkgo/ginkgo@latest
-            sudo kubectl cluster-info
-            sudo cp -r /root/.kube/ /home/runner/.kube/
-            sudo chmod -R 777 /home/runner/.kube/
-            make e2e
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@latest
+          sudo kubectl cluster-info
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          make e2e
 
       - name: Cleanup
         run: |

--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -9,8 +9,8 @@ iptables -t nat -D POSTROUTING -m mark --mark 0x80000/0x80000 -j MASQUERADE
 iptables -t nat -D POSTROUTING -p tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -j RETURN
 iptables -t nat -D POSTROUTING -m set ! --match-set ovn40subnets src -m set ! --match-set ovn40other-node src -m set --match-set ovn40subnets-nat dst -j RETURN
 iptables -t nat -D POSTROUTING -m set --match-set ovn40subnets-nat src -m set ! --match-set ovn40subnets dst -j MASQUERADE
-iptables -t nat -D KUBE-NODE-PORT -p tcp -m set --match-set KUBE-NODE-PORT-LOCAL-TCP dst -j MARK --set-xmark 0x80000/0x80000
-iptables -t nat -D KUBE-NODE-PORT -p udp -m set --match-set KUBE-NODE-PORT-LOCAL-UDP dst -j MARK --set-xmark 0x80000/0x80000
+iptables -t nat -D PREROUTING -p tcp -m addrtype --dst-type LOCAL -m set --match-set KUBE-NODE-PORT-LOCAL-TCP dst -j MARK --set-xmark 0x80000/0x80000
+iptables -t nat -D PREROUTING -p udp -m addrtype --dst-type LOCAL -m set --match-set KUBE-NODE-PORT-LOCAL-UDP dst -j MARK --set-xmark 0x80000/0x80000
 iptables -t mangle -D PREROUTING -i ovn0 -m set --match-set ovn40subnets src -m set --match-set ovn40services dst -j MARK --set-xmark 0x4000/0x4000
 iptables -t filter -D INPUT -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40subnets src -j ACCEPT
@@ -38,8 +38,8 @@ ip6tables -t nat -D POSTROUTING -m mark --mark 0x80000/0x80000 -j MASQUERADE
 ip6tables -t nat -D POSTROUTING -p tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -j RETURN
 ip6tables -t nat -D POSTROUTING -m set ! --match-set ovn60subnets src -m set ! --match-set ovn60other-node src -m set --match-set ovn60subnets-nat dst -j RETURN
 ip6tables -t nat -D POSTROUTING -m set --match-set ovn60subnets-nat src -m set ! --match-set ovn60subnets dst -j MASQUERADE
-ip6tables -t nat -D KUBE-NODE-PORT -p tcp -m set --match-set KUBE-6-NODE-PORT-LOCAL-TCP dst -j MARK --set-xmark 0x80000/0x80000
-ip6tables -t nat -D KUBE-NODE-PORT -p udp -m set --match-set KUBE-6-NODE-PORT-LOCAL-UDP dst -j MARK --set-xmark 0x80000/0x80000
+ip6tables -t nat -D PREROUTING -p tcp -m addrtype --dst-type LOCAL -m set --match-set KUBE-6-NODE-PORT-LOCAL-TCP dst -j MARK --set-xmark 0x80000/0x80000
+ip6tables -t nat -D PREROUTING -p udp -m addrtype --dst-type LOCAL -m set --match-set KUBE-6-NODE-PORT-LOCAL-UDP dst -j MARK --set-xmark 0x80000/0x80000
 ip6tables -t mangle -D PREROUTING -i ovn0 -m set --match-set ovn60subnets src -m set --match-set ovn60services dst -j MARK --set-xmark 0x4000/0x4000
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets src -j ACCEPT


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:
Fixes #(issue-number)

Fix recreating iptables rules:

```txt
I0803 09:48:12.420759   14109 gateway_linux.go:492] iptables rules -p udp -m set --match-set KUBE-NODE-PORT-LOCAL-UDP dst -j MARK --set-xmark 0x80000/0x80000 not exist, recreate iptables rules
I0803 09:48:12.435808   14109 gateway_linux.go:492] iptables rules -p tcp -m set --match-set KUBE-NODE-PORT-LOCAL-TCP dst -j MARK --set-xmark 0x80000/0x80000 not exist, recreate iptables rules
I0803 09:48:40.900971   14109 gateway_linux.go:492] iptables rules -p udp -m set --match-set KUBE-NODE-PORT-LOCAL-UDP dst -j MARK --set-xmark 0x80000/0x80000 not exist, recreate iptables rules
I0803 09:48:40.909351   14109 gateway_linux.go:492] iptables rules -p tcp -m set --match-set KUBE-NODE-PORT-LOCAL-TCP dst -j MARK --set-xmark 0x80000/0x80000 not exist, recreate iptables rules
```