### PR TITLE
fix: chassis id is empty but cannt identify

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -837,7 +837,7 @@ func (c *Controller) checkChassisDupl(node *v1.Node) error {
 		klog.Errorf("failed to get node %s chassisID, %v", node.Name, err)
 		return err
 	}
-	if chassisAdd == "" {
+	if len(chassisAdd) < util.ChassisIDLength {
 		klog.Errorf("chassis of node %s is empty", node.Name)
 		return err
 	}
@@ -1015,8 +1015,9 @@ func (c *Controller) validateChassis(node *v1.Node) error {
 		}
 		return nil
 	}
-	if chassisAdd == "" {
-		// If no chassisID for this node is obtained, we need to perform GC in order for the chassis to be re-registered
+	if len(chassisAdd) < util.ChassisIDLength {
+		// If no chassisID for this node is obtained, we need to perform GC for the chassis' being re-registered
+		klog.Errorf("chassis empty in node %s", node.Name)
 		if err = c.gcChassis(); err != nil {
 			return fmt.Errorf("failed to gc chassis, %v", err)
 		}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -187,4 +187,6 @@ const (
 
 	MatchV4Src = "ip4.src"
 	MatchV4Dst = "ip4.dst"
+
+	ChassisIDLength = 5
 )


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes

A bug shows that the empty sure can not identify the scenario where chassis id is missed in ovn sbdb.
Now judgement is based on the length of chassis id.

#### Which issue(s) this PR fixes:

