### PR TITLE
replace some of acl table with libovsdb

### DIFF
--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -4,24 +4,94 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
+
+	netv1 "k8s.io/api/networking/v1"
 
 	"github.com/ovn-org/libovsdb/ovsdb"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 const (
-	portGroupKey = "pg"
+	aclParentKey = "acl-parent"
 )
 
-// GetAcl get acl by name
-// aclName's format is: pgName.direction.priority
-func (c OvnClient) GetAcl(aclName string, ignoreNotFound bool) (*ovnnb.ACL, error) {
+// CreateIngressACL creates an ingress ACL
+func (c OvnClient) CreateIngressACL(pgName, asIngressName, asExceptName, protocol string, npp []netv1.NetworkPolicyPort) error {
+	aclUUIDs := make([]string, 0)
+
+	/* default drop acl */
+	match := fmt.Sprintf("outport==@%s && ip", pgName)
+	options := func(acl *ovnnb.ACL) {
+		acl.Name = &pgName
+		acl.Log = true
+		acl.Severity = &ovnnb.ACLSeverityWarning
+	}
+
+	defaultDropAclOp, uuid, err := c.CreateAclOp(pgName, ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, match, ovnnb.ACLActionAllowRelated, options)
+	if err != nil {
+		return fmt.Errorf("generate operations for creating acl: %v", err)
+	}
+
+	aclUUIDs = append(aclUUIDs, uuid)
+
+	/* allow acl */
+	matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+
+	allowAclOps := make([]ovsdb.Operation, 0, len(matches))
+	for _, m := range matches {
+		allowAclOp, uuid, err := c.CreateAclOp(pgName, ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, m, ovnnb.ACLActionAllowRelated)
+		if err != nil {
+			return fmt.Errorf("generate operations for creating acl: %v", err)
+		}
+		aclUUIDs = append(aclUUIDs, uuid)
+		allowAclOps = append(allowAclOps, allowAclOp...)
+	}
+
+	// acl attach to port group
+	aclAddOp, err := c.portGroupUpdateAclOp(pgName, aclUUIDs, ovsdb.MutateOperationInsert)
+	if err != nil {
+		return fmt.Errorf("generate operations for port group %s adding acl %v: %v", pgName, aclUUIDs, err)
+	}
+
+	ops := make([]ovsdb.Operation, 0, len(defaultDropAclOp)+len(allowAclOps)+len(aclAddOp))
+	ops = append(ops, defaultDropAclOp...)
+	ops = append(ops, allowAclOps...)
+	ops = append(ops, aclAddOp...)
+
+	if err = c.Transact("acl-add", ops); err != nil {
+		return fmt.Errorf("add acls to port group %s: %v", pgName, err)
+	}
+	return nil
+}
+
+func (c OvnClient) CreateBareACL(direction, priority, match, action string) error {
+	op, _, err := c.CreateAclOp("", direction, priority, match, action)
+	if err != nil {
+		return fmt.Errorf("generate operations for create acl: %v", err)
+	}
+
+	if err = c.Transact("acl-create", op); err != nil {
+		return fmt.Errorf("add acl direction %s priority %s match %s action %s: %v", direction, priority, match, action, err)
+	}
+
+	return nil
+}
+
+// GetAcl get acl by direction, priority and match,
+// be consistent with ovn-nbctl which direction, priority and match determine one acl rule
+func (c OvnClient) GetAcl(direction, priority, match string, ignoreNotFound bool) (*ovnnb.ACL, error) {
+	intPriority, _ := strconv.Atoi(priority)
+
 	aclList := make([]ovnnb.ACL, 0)
 	if err := c.ovnNbClient.WhereCache(func(acl *ovnnb.ACL) bool {
-		return acl.Name != nil && *acl.Name == aclName
+		return acl.Direction == direction && acl.Priority == intPriority && acl.Match == match
 	}).List(context.TODO(), &aclList); err != nil {
-		return nil, fmt.Errorf("get acl %s: %v", aclName, err)
+		return nil, fmt.Errorf("get acl direction %s priority %s match %s: %v", direction, priority, match, err)
 	}
 
 	// not found
@@ -29,68 +99,59 @@ func (c OvnClient) GetAcl(aclName string, ignoreNotFound bool) (*ovnnb.ACL, erro
 		if ignoreNotFound {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("not found acl %s", aclName)
+		return nil, fmt.Errorf("not found acl direction %s priority %s match %s", direction, priority, match)
 	}
 
 	if len(aclList) > 1 {
-		return nil, fmt.Errorf("more than one acl with same name %s", aclName)
+		return nil, fmt.Errorf("more than one acl with same direction %s priority %s match %s", direction, priority, match)
 	}
 
 	return &aclList[0], nil
 }
 
-func (c OvnClient) AclExists(aclName string) (bool, error) {
-	acl, err := c.GetAcl(aclName, true)
+func (c OvnClient) AclExists(direction, priority, match string) (bool, error) {
+	acl, err := c.GetAcl(direction, priority, match, true)
 	return acl != nil, err
 }
 
-// CreateAclOp generate operation which create an ACL,
-func (c OvnClient) CreateAclOp(acl *ovnnb.ACL) ([]ovsdb.Operation, error) {
-	if acl.Name == nil {
-		return nil, fmt.Errorf("acl name is empty")
+// CreateAclOp generate operation which create an ACL
+func (c OvnClient) CreateAclOp(parentName, direction, priority, match, action string, options ...func(acl *ovnnb.ACL)) ([]ovsdb.Operation, string, error) {
+	if len(direction) == 0 || len(priority) == 0 || len(match) == 0 || len(action) == 0 {
+		return nil, "", fmt.Errorf("acl direction or priority or match or action is empty")
 	}
 
-	aclName := *acl.Name
-
-	// aclName's format is: pgName.direction.priority
-	// the acl maximum allowed length is 63
-	if len(aclName) > 63 {
-		return nil, fmt.Errorf("acl %s length %d is greater than maximum allowed length 63", aclName, len(aclName))
-	}
-
-	exists, err := c.AclExists(aclName)
+	exists, err := c.AclExists(direction, priority, match)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// found, ingore
 	if exists {
-		return nil, nil
+		return nil, "", nil
 	}
+
+	acl := newAcl(parentName, direction, priority, match, action, options...)
 
 	op, err := c.ovnNbClient.Create(acl)
 	if err != nil {
-		return nil, fmt.Errorf("generate operations for creating acl %s: %v", aclName, err)
+		return nil, "", fmt.Errorf("generate operations for creating acl direction %s priority %d match %s action %s: %v", acl.Direction, acl.Priority, acl.Match, acl.Action, err)
 	}
 
-	return op, nil
+	return op, acl.UUID, nil
 }
 
 // newAcl return acl with basic information
-func (c OvnClient) newAcl(pgName, match, direction, action, priority string, options ...func(acl *ovnnb.ACL)) *ovnnb.ACL {
-	// aclName's format is: pgName.direction.priority
-	aclName := fmt.Sprintf("%s.%s.%s", pgName, direction, priority)
-
+func newAcl(parentName, direction, priority, match, action string, options ...func(acl *ovnnb.ACL)) *ovnnb.ACL {
 	intPriority, _ := strconv.Atoi(priority)
 
 	acl := &ovnnb.ACL{
-		Name:      &aclName,
+		UUID:      ovsclient.UUID(),
 		Action:    action,
 		Direction: direction,
 		Match:     match,
 		Priority:  intPriority,
 		ExternalIDs: map[string]string{
-			portGroupKey: pgName,
+			aclParentKey: parentName,
 		},
 	}
 
@@ -99,4 +160,40 @@ func (c OvnClient) newAcl(pgName, match, direction, action, priority string, opt
 	}
 
 	return acl
+}
+
+func newIngressAllowACLMatch(pgName, asIngressName, asExceptName, protocol string, npp []netv1.NetworkPolicyPort) []string {
+	/* allow acl */
+	ipSuffix := "ip4"
+	if protocol == kubeovnv1.ProtocolIPv6 {
+		ipSuffix = "ip6"
+	}
+
+	matches := make([]string, 0)
+
+	if len(npp) == 0 {
+		match := fmt.Sprintf("%s.src == $%s && %s.src != $%s && outport == @%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, pgName)
+		matches = append(matches, match)
+		return matches
+	}
+
+	for _, port := range npp {
+		protocol := strings.ToLower(string(*port.Protocol))
+		if port.Port == nil {
+			match := fmt.Sprintf("%s.src == $%s && %s.src != $%s && %s && outport == @%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, protocol, pgName)
+			matches = append(matches, match)
+			continue
+		}
+
+		if port.EndPort == nil {
+			match := fmt.Sprintf("%s.src == $%s && %s.src != $%s && %s.dst == %d && outport == @%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, protocol, port.Port.IntVal, pgName)
+			matches = append(matches, match)
+			continue
+		}
+
+		match := fmt.Sprintf("%s.src == $%s && %s.src != $%s && %d <= %s.dst <= %d && outport == @%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, port.Port.IntVal, protocol, *port.EndPort, pgName)
+		matches = append(matches, match)
+	}
+
+	return matches
 }

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -8,6 +8,7 @@ import (
 
 	netv1 "k8s.io/api/networking/v1"
 
+	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -21,62 +22,131 @@ const (
 )
 
 // CreateIngressACL creates an ingress ACL
-func (c OvnClient) CreateIngressACL(pgName, asIngressName, asExceptName, protocol string, npp []netv1.NetworkPolicyPort) error {
-	aclUUIDs := make([]string, 0)
+func (c OvnClient) CreateIngressAcl(pgName, asIngressName, asExceptName, protocol string, npp []netv1.NetworkPolicyPort) error {
+	acls := make([]*ovnnb.ACL, 0)
 
 	/* default drop acl */
-	match := fmt.Sprintf("outport==@%s && ip", pgName)
+	AllIpMatch := NewAndAclMatchRule(
+		NewAclRuleKv("outport", "==", "@"+pgName, ""),
+		NewAclRuleKv("ip", "", "", ""),
+	)
 	options := func(acl *ovnnb.ACL) {
 		acl.Name = &pgName
 		acl.Log = true
 		acl.Severity = &ovnnb.ACLSeverityWarning
 	}
 
-	defaultDropAclOp, uuid, err := c.CreateAclOp(pgName, ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, match, ovnnb.ACLActionAllowRelated, options)
+	defaultDropAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, AllIpMatch.String(), ovnnb.ACLActionDrop, options)
 	if err != nil {
-		return fmt.Errorf("generate operations for creating acl: %v", err)
+		return fmt.Errorf("new ingress default drop acl direction %s priority %s match %s action %s: %v", ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, AllIpMatch, ovnnb.ACLActionDrop, err)
 	}
 
-	aclUUIDs = append(aclUUIDs, uuid)
+	acls = append(acls, defaultDropAcl)
 
 	/* allow acl */
-	matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
-
-	allowAclOps := make([]ovsdb.Operation, 0, len(matches))
+	matches := newAllowAclMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp)
 	for _, m := range matches {
-		allowAclOp, uuid, err := c.CreateAclOp(pgName, ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, m, ovnnb.ACLActionAllowRelated)
+		allowAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, m, ovnnb.ACLActionAllowRelated)
 		if err != nil {
-			return fmt.Errorf("generate operations for creating acl: %v", err)
+			return fmt.Errorf("new ingress allow acl direction %s priority %s match %s action %s: %v", ovnnb.ACLDirectionToLport, util.IngressAllowPriority, m, ovnnb.ACLActionAllowRelated, err)
 		}
-		aclUUIDs = append(aclUUIDs, uuid)
-		allowAclOps = append(allowAclOps, allowAclOp...)
+
+		acls = append(acls, allowAcl)
 	}
 
-	// acl attach to port group
-	aclAddOp, err := c.portGroupUpdateAclOp(pgName, aclUUIDs, ovsdb.MutateOperationInsert)
-	if err != nil {
-		return fmt.Errorf("generate operations for port group %s adding acl %v: %v", pgName, aclUUIDs, err)
+	if err := c.CreateAcls(pgName, acls...); err != nil {
+		return fmt.Errorf("add ingress acls to port group %s: %v", pgName, err)
 	}
 
-	ops := make([]ovsdb.Operation, 0, len(defaultDropAclOp)+len(allowAclOps)+len(aclAddOp))
-	ops = append(ops, defaultDropAclOp...)
-	ops = append(ops, allowAclOps...)
-	ops = append(ops, aclAddOp...)
-
-	if err = c.Transact("acl-add", ops); err != nil {
-		return fmt.Errorf("add acls to port group %s: %v", pgName, err)
-	}
 	return nil
 }
 
-func (c OvnClient) CreateBareACL(direction, priority, match, action string) error {
-	op, _, err := c.CreateAclOp("", direction, priority, match, action)
+// CreateIngressACL creates an egress ACL
+func (c OvnClient) CreateEgressAcl(pgName, asEgressName, asExceptName, protocol string, npp []netv1.NetworkPolicyPort) error {
+	acls := make([]*ovnnb.ACL, 0)
+
+	/* default drop acl */
+	AllIpMatch := NewAndAclMatchRule(
+		NewAclRuleKv("inport", "==", "@"+pgName, ""),
+		NewAclRuleKv("ip", "", "", ""),
+	)
+	options := func(acl *ovnnb.ACL) {
+		acl.Name = &pgName
+		acl.Log = true
+		acl.Severity = &ovnnb.ACLSeverityWarning
+	}
+
+	defaultDropAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionFromLport, util.EgressDefaultDrop, AllIpMatch.String(), ovnnb.ACLActionDrop, options)
 	if err != nil {
-		return fmt.Errorf("generate operations for create acl: %v", err)
+		return fmt.Errorf("new egress default drop acl direction %s priority %s match %s action %s: %v", ovnnb.ACLDirectionFromLport, util.EgressDefaultDrop, AllIpMatch, ovnnb.ACLActionDrop, err)
+	}
+
+	acls = append(acls, defaultDropAcl)
+
+	/* allow acl */
+	matches := newAllowAclMatch(pgName, asEgressName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionFromLport, npp)
+	for _, m := range matches {
+		allowAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, ovnnb.ACLActionAllowRelated)
+		if err != nil {
+			return fmt.Errorf("new egress allow acl direction %s priority %s match %s action %s: %v", ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, ovnnb.ACLActionAllowRelated, err)
+		}
+
+		acls = append(acls, allowAcl)
+	}
+
+	if err := c.CreateAcls(pgName, acls...); err != nil {
+		return fmt.Errorf("add egress acls to port group %s: %v", pgName, err)
+	}
+
+	return nil
+}
+
+// CreateAcls generate operation which create several acl once
+func (c OvnClient) CreateAcls(parentName string, acls ...*ovnnb.ACL) error {
+	models := make([]model.Model, 0, len(acls))
+	aclUUIDs := make([]string, 0, len(acls))
+	for _, acl := range acls {
+		if acl != nil {
+			models = append(models, model.Model(acl))
+			aclUUIDs = append(aclUUIDs, acl.UUID)
+		}
+	}
+
+	createAclsOp, err := c.ovnNbClient.Create(models...)
+	if err != nil {
+		return fmt.Errorf("generate operations for creating acls: %v", err)
+	}
+
+	// acl attach to port group
+	aclAddOp, err := c.portGroupUpdateAclOp(parentName, aclUUIDs, ovsdb.MutateOperationInsert)
+	if err != nil {
+		return fmt.Errorf("generate operations for adding acls to %s: %v", parentName, err)
+	}
+
+	ops := make([]ovsdb.Operation, 0, len(createAclsOp)+len(aclAddOp))
+	ops = append(ops, createAclsOp...)
+	ops = append(ops, aclAddOp...)
+
+	if err = c.Transact("acls-add", ops); err != nil {
+		return fmt.Errorf("add acls to %s: %v", parentName, err)
+	}
+
+	return nil
+}
+
+func (c OvnClient) CreateBareAcl(parentName, direction, priority, match, action string) error {
+	acl, err := c.newAcl(parentName, direction, priority, match, action)
+	if err != nil {
+		return fmt.Errorf("new acl direction %s priority %s match %s action %s: %v", direction, priority, match, action, err)
+	}
+
+	op, err := c.ovnNbClient.Create(acl)
+	if err != nil {
+		return fmt.Errorf("generate operations for creating acl direction %s priority %s match %s action %s: %v", direction, priority, match, action, err)
 	}
 
 	if err = c.Transact("acl-create", op); err != nil {
-		return fmt.Errorf("add acl direction %s priority %s match %s action %s: %v", direction, priority, match, action, err)
+		return fmt.Errorf("create acl direction %s priority %s match %s action %s: %v", direction, priority, match, action, err)
 	}
 
 	return nil
@@ -109,39 +179,68 @@ func (c OvnClient) GetAcl(direction, priority, match string, ignoreNotFound bool
 	return &aclList[0], nil
 }
 
+// ListAcls list acks which match the given externalIDs,
+// result should include all to-lport and from-lport acls when direction is empty,
+// result should include all acls when externalIDs is empty,
+// result should include all acls which externalIDs[key] is not empty when externalIDs[key] is ""
+// TODO: maybe add other filter conditions(priority or match)
+func (c OvnClient) ListAcls(direction string, externalIDs map[string]string) ([]ovnnb.ACL, error) {
+	aclList := make([]ovnnb.ACL, 0)
+
+	if err := c.WhereCache(func(acl *ovnnb.ACL) bool {
+		if len(acl.ExternalIDs) < len(externalIDs) {
+			return false
+		}
+
+		if len(acl.ExternalIDs) != 0 {
+			for k, v := range externalIDs {
+				// if only key exist but not value in externalIDs, we should include this lsp,
+				// it's equal to shell command `ovn-nbctl --columns=xx find acl external_ids:key!=\"\"`
+				if len(v) == 0 {
+					if len(acl.ExternalIDs[k]) == 0 {
+						return false
+					}
+				} else {
+					if acl.ExternalIDs[k] != v {
+						return false
+					}
+				}
+			}
+		}
+
+		if len(direction) != 0 && acl.Direction != direction {
+			return false
+		}
+
+		return true
+	}).List(context.TODO(), &aclList); err != nil {
+		return nil, fmt.Errorf("list acls: %v", err)
+	}
+
+	return aclList, nil
+}
+
 func (c OvnClient) AclExists(direction, priority, match string) (bool, error) {
 	acl, err := c.GetAcl(direction, priority, match, true)
 	return acl != nil, err
 }
 
-// CreateAclOp generate operation which create an ACL
-func (c OvnClient) CreateAclOp(parentName, direction, priority, match, action string, options ...func(acl *ovnnb.ACL)) ([]ovsdb.Operation, string, error) {
+// newAcl return acl with basic information
+func (c OvnClient) newAcl(parentName, direction, priority, match, action string, options ...func(acl *ovnnb.ACL)) (*ovnnb.ACL, error) {
 	if len(direction) == 0 || len(priority) == 0 || len(match) == 0 || len(action) == 0 {
-		return nil, "", fmt.Errorf("acl direction or priority or match or action is empty")
+		return nil, fmt.Errorf("acl 'direction %s' or 'priority %s' or 'match %s' or 'action %s' is empty", direction, priority, match, action)
 	}
 
 	exists, err := c.AclExists(direction, priority, match)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	// found, ingore
 	if exists {
-		return nil, "", nil
+		return nil, nil
 	}
 
-	acl := newAcl(parentName, direction, priority, match, action, options...)
-
-	op, err := c.ovnNbClient.Create(acl)
-	if err != nil {
-		return nil, "", fmt.Errorf("generate operations for creating acl direction %s priority %d match %s action %s: %v", acl.Direction, acl.Priority, acl.Match, acl.Action, err)
-	}
-
-	return op, acl.UUID, nil
-}
-
-// newAcl return acl with basic information
-func newAcl(parentName, direction, priority, match, action string, options ...func(acl *ovnnb.ACL)) *ovnnb.ACL {
 	intPriority, _ := strconv.Atoi(priority)
 
 	acl := &ovnnb.ACL{
@@ -159,40 +258,76 @@ func newAcl(parentName, direction, priority, match, action string, options ...fu
 		option(acl)
 	}
 
-	return acl
+	return acl, nil
 }
 
-func newIngressAllowACLMatch(pgName, asIngressName, asExceptName, protocol string, npp []netv1.NetworkPolicyPort) []string {
-	/* allow acl */
+func newAllowAclMatch(pgName, asAllowName, asExceptName, protocol, direction string, npp []netv1.NetworkPolicyPort) []string {
 	ipSuffix := "ip4"
 	if protocol == kubeovnv1.ProtocolIPv6 {
 		ipSuffix = "ip6"
 	}
 
+	// ingress rule
+	srcOrDst, portDriection := "src", "outport"
+	if direction == ovnnb.ACLDirectionFromLport { // egress rule
+		srcOrDst = "dst"
+		portDriection = "inport"
+	}
+
+	ipKey := ipSuffix + "." + srcOrDst
+
+	// match all traffic to or from pgName
+	AllIpMatch := NewAndAclMatchRule(
+		NewAclRuleKv(portDriection, "==", "@"+pgName, ""),
+		NewAclRuleKv("ip", "", "", ""),
+	)
+
+	allowedIpMatch := NewAndAclMatchRule(
+		AllIpMatch,
+		NewAclRuleKv(ipKey, "==", "$"+asAllowName, ""),
+		NewAclRuleKv(ipKey, "!=", "$"+asExceptName, ""),
+	)
+
 	matches := make([]string, 0)
 
+	// allow allowed ip traffic but except
 	if len(npp) == 0 {
-		match := fmt.Sprintf("%s.src == $%s && %s.src != $%s && outport == @%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, pgName)
-		matches = append(matches, match)
-		return matches
+		return []string{allowedIpMatch.String()}
 	}
 
 	for _, port := range npp {
 		protocol := strings.ToLower(string(*port.Protocol))
+
+		// allow all tcp or udp traffic
 		if port.Port == nil {
-			match := fmt.Sprintf("%s.src == $%s && %s.src != $%s && %s && outport == @%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, protocol, pgName)
-			matches = append(matches, match)
+			allLayer4Match := NewAndAclMatchRule(
+				allowedIpMatch,
+				NewAclRuleKv(protocol, "", "", ""),
+			)
+
+			matches = append(matches, allLayer4Match.String())
 			continue
 		}
 
+		// allow one tcp or udp port traffic
 		if port.EndPort == nil {
-			match := fmt.Sprintf("%s.src == $%s && %s.src != $%s && %s.dst == %d && outport == @%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, protocol, port.Port.IntVal, pgName)
-			matches = append(matches, match)
+			tcpKey := protocol + ".dst"
+			oneTcpMatch := NewAndAclMatchRule(
+				allowedIpMatch,
+				NewAclRuleKv(tcpKey, "==", fmt.Sprintf("%d", port.Port.IntVal), ""),
+			)
+
+			matches = append(matches, oneTcpMatch.String())
 			continue
 		}
 
-		match := fmt.Sprintf("%s.src == $%s && %s.src != $%s && %d <= %s.dst <= %d && outport == @%s && ip", ipSuffix, asIngressName, ipSuffix, asExceptName, port.Port.IntVal, protocol, *port.EndPort, pgName)
-		matches = append(matches, match)
+		// allow several tcp or udp port traffic
+		tcpKey := protocol + ".dst"
+		severalTcpMatch := NewAndAclMatchRule(
+			allowedIpMatch,
+			NewAclRuleKv(tcpKey, "<=", fmt.Sprintf("%d", port.Port.IntVal), fmt.Sprintf("%d", *port.EndPort)),
+		)
+		matches = append(matches, severalTcpMatch.String())
 	}
 
 	return matches

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -2,9 +2,10 @@ package ovs
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
-	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -38,7 +40,28 @@ func mockNetworkPolicyPort() []netv1.NetworkPolicyPort {
 	}
 }
 
-func (suite *OvnClientTestSuite) testCreateIngressACL() {
+func newAcl(parentName, direction, priority, match, action string, options ...func(acl *ovnnb.ACL)) *ovnnb.ACL {
+	intPriority, _ := strconv.Atoi(priority)
+
+	acl := &ovnnb.ACL{
+		UUID:      ovsclient.UUID(),
+		Action:    action,
+		Direction: direction,
+		Match:     match,
+		Priority:  intPriority,
+		ExternalIDs: map[string]string{
+			aclParentKey: parentName,
+		},
+	}
+
+	for _, option := range options {
+		option(acl)
+	}
+
+	return acl
+}
+
+func (suite *OvnClientTestSuite) testCreateIngressAcl() {
 	t := suite.T()
 	t.Parallel()
 
@@ -52,23 +75,84 @@ func (suite *OvnClientTestSuite) testCreateIngressACL() {
 
 	npp := mockNetworkPolicyPort()
 
-	err = ovnClient.CreateIngressACL(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+	err = ovnClient.CreateIngressAcl(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
 	require.NoError(t, err)
 
 	pg, err := ovnClient.GetPortGroup(pgName, false)
 	require.NoError(t, err)
 	require.Len(t, pg.ACLs, 3)
 
-	match := fmt.Sprintf("outport==@%s && ip", pgName)
+	match := fmt.Sprintf("outport == @%s && ip", pgName)
 	defaultDropAcl, err := ovnClient.GetAcl(ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, match, false)
 	require.NoError(t, err)
-	require.Equal(t, pgName, *defaultDropAcl.Name)
+
+	expect := newAcl(pgName, ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, match, ovnnb.ACLActionDrop, func(acl *ovnnb.ACL) {
+		acl.Name = &pgName
+		acl.Log = true
+		acl.Severity = &ovnnb.ACLSeverityWarning
+		acl.UUID = defaultDropAcl.UUID
+	})
+
+	require.Equal(t, expect, defaultDropAcl)
 	require.Contains(t, pg.ACLs, defaultDropAcl.UUID)
 
-	matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+	matches := newAllowAclMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp)
 	for _, m := range matches {
-		allowAcl, err := ovnClient.GetAcl(ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, m, false)
+		allowAcl, err := ovnClient.GetAcl(ovnnb.ACLDirectionToLport, util.IngressAllowPriority, m, false)
 		require.NoError(t, err)
+
+		expect := newAcl(pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, m, ovnnb.ACLActionAllowRelated)
+		expect.UUID = allowAcl.UUID
+		require.Equal(t, expect, allowAcl)
+
+		require.Contains(t, pg.ACLs, allowAcl.UUID)
+	}
+}
+
+func (suite *OvnClientTestSuite) testCreateEgressAcl() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test_create_egress_acl_pg"
+	asEgressName := "test.default.egress.allow.ipv4"
+	asExceptName := "test.default.egress.except.ipv4"
+
+	err := ovnClient.CreatePortGroup(pgName, nil)
+	require.NoError(t, err)
+
+	npp := mockNetworkPolicyPort()
+
+	err = ovnClient.CreateEgressAcl(pgName, asEgressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+	require.NoError(t, err)
+
+	pg, err := ovnClient.GetPortGroup(pgName, false)
+	require.NoError(t, err)
+	require.Len(t, pg.ACLs, 3)
+
+	match := fmt.Sprintf("inport == @%s && ip", pgName)
+	defaultDropAcl, err := ovnClient.GetAcl(ovnnb.ACLDirectionFromLport, util.EgressDefaultDrop, match, false)
+	require.NoError(t, err)
+
+	expect := newAcl(pgName, ovnnb.ACLDirectionFromLport, util.EgressDefaultDrop, match, ovnnb.ACLActionDrop, func(acl *ovnnb.ACL) {
+		acl.Name = &pgName
+		acl.Log = true
+		acl.Severity = &ovnnb.ACLSeverityWarning
+		acl.UUID = defaultDropAcl.UUID
+	})
+
+	require.Equal(t, expect, defaultDropAcl)
+	require.Contains(t, pg.ACLs, defaultDropAcl.UUID)
+
+	matches := newAllowAclMatch(pgName, asEgressName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionFromLport, npp)
+	for _, m := range matches {
+		allowAcl, err := ovnClient.GetAcl(ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, false)
+		require.NoError(t, err)
+
+		expect := newAcl(pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, ovnnb.ACLActionAllowRelated)
+		expect.UUID = allowAcl.UUID
+		require.Equal(t, expect, allowAcl)
+
 		require.Contains(t, pg.ACLs, allowAcl.UUID)
 	}
 }
@@ -78,10 +162,11 @@ func (suite *OvnClientTestSuite) testGetAcl() {
 	t.Parallel()
 
 	ovnClient := suite.ovnClient
-	priority := "1001"
+	pgName := "test_get_acl_pg"
+	priority := "2000"
 	match := "outport==@ovn.sg.test_create_acl_pg && ip"
 
-	err := ovnClient.CreateBareACL(ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated)
+	err := ovnClient.CreateBareAcl(pgName, ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated)
 	require.NoError(t, err)
 
 	t.Run("direction, priority and match are same", func(t *testing.T) {
@@ -89,7 +174,7 @@ func (suite *OvnClientTestSuite) testGetAcl() {
 		acl, err := ovnClient.GetAcl(ovnnb.ACLDirectionToLport, priority, match, false)
 		require.NoError(t, err)
 		require.Equal(t, ovnnb.ACLDirectionToLport, acl.Direction)
-		require.Equal(t, 1001, acl.Priority)
+		require.Equal(t, 2000, acl.Priority)
 		require.Equal(t, match, acl.Match)
 		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
 	})
@@ -115,44 +200,184 @@ func (suite *OvnClientTestSuite) testGetAcl() {
 	})
 }
 
-func (suite *OvnClientTestSuite) testCreateAclOp() {
+func (suite *OvnClientTestSuite) testListAcls() {
 	t := suite.T()
 	t.Parallel()
 
 	ovnClient := suite.ovnClient
-	pgName := "test-create-acl-op-pg"
-	priority := "1001"
-	match := "outport==@ovn.sg.test_create_acl_pg && ip"
+	pgName := "test-list-acl-pg"
+	basePort := 50000
 
-	op, aclUUID, err := ovnClient.CreateAclOp(pgName, ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated)
+	t.Run("list acl by direction", func(t *testing.T) {
+		matchPrefix := "outport == @ovn.sg.test_list_acl_pg && ip"
+		// create two to-lport acl
+		for i := 0; i < 2; i++ {
+			match := fmt.Sprintf("%s && tcp.dst == %d", matchPrefix, basePort+i)
+			err := ovnClient.CreateBareAcl(pgName, ovnnb.ACLDirectionToLport, "9999", match, ovnnb.ACLActionAllowRelated)
+			require.NoError(t, err)
+		}
+
+		// create two from-lport acl
+		for i := 0; i < 3; i++ {
+			match := fmt.Sprintf("%s && tcp.dst == %d", matchPrefix, basePort+i)
+			err := ovnClient.CreateBareAcl(pgName, ovnnb.ACLDirectionFromLport, "9999", match, ovnnb.ACLActionAllowRelated)
+			require.NoError(t, err)
+		}
+
+		/* list all direction acl */
+		out, err := ovnClient.ListAcls("", nil)
+		require.NoError(t, err)
+		count := 0
+		for _, v := range out {
+			if strings.Contains(v.Match, matchPrefix) {
+				count++
+			}
+		}
+		require.Equal(t, count, 5)
+
+		/* list to-lport acl */
+		out, err = ovnClient.ListAcls(ovnnb.ACLDirectionToLport, nil)
+		require.NoError(t, err)
+		count = 0
+		for _, v := range out {
+			if strings.Contains(v.Match, matchPrefix) && v.Direction == ovnnb.ACLDirectionToLport {
+				count++
+			}
+		}
+		require.Equal(t, count, 2)
+
+		/* list from-lport acl */
+		out, err = ovnClient.ListAcls(ovnnb.ACLDirectionFromLport, nil)
+		require.NoError(t, err)
+		count = 0
+		for _, v := range out {
+			if strings.Contains(v.Match, matchPrefix) && v.Direction == ovnnb.ACLDirectionFromLport {
+				count++
+			}
+		}
+		require.Equal(t, count, 3)
+	})
+
+	t.Run("result should exclude acl when externalIDs's length is not equal", func(t *testing.T) {
+		match := "outport == @ovn.sg.test_list_acl_pg && ip"
+		err := ovnClient.CreateBareAcl(pgName, ovnnb.ACLDirectionToLport, "9999", match, ovnnb.ACLActionAllowRelated)
+		require.NoError(t, err)
+
+		out, err := ovnClient.ListAcls("", map[string]string{
+			aclParentKey: pgName,
+			"key":        "value",
+		})
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+
+	t.Run("result should include acl when key exists in acl column: external_ids", func(t *testing.T) {
+		matchPrefix := "outport == @ovn.sg.test_list_acl_pg && ip"
+		pgName := "test-list-acl-with-kv-pg"
+		// create two to-lport acl
+		for i := 0; i < 3; i++ {
+			match := fmt.Sprintf("%s && udp.dst == %d", matchPrefix, basePort+i)
+			err := ovnClient.CreateBareAcl(pgName, ovnnb.ACLDirectionToLport, "9999", match, ovnnb.ACLActionAllowRelated)
+			require.NoError(t, err)
+		}
+
+		// create two from-lport acl
+		for i := 0; i < 2; i++ {
+			match := fmt.Sprintf("%s && udp.dst == %d", matchPrefix, basePort+i)
+			err := ovnClient.CreateBareAcl(pgName, ovnnb.ACLDirectionFromLport, "9999", match, ovnnb.ACLActionAllowRelated)
+			require.NoError(t, err)
+		}
+
+		out, err := ovnClient.ListAcls("", map[string]string{aclParentKey: pgName})
+		require.NoError(t, err)
+		require.Len(t, out, 5)
+
+		/* list to-lport acl */
+		out, err = ovnClient.ListAcls(ovnnb.ACLDirectionToLport, map[string]string{aclParentKey: pgName})
+		require.NoError(t, err)
+		count := 0
+		for _, v := range out {
+			if strings.Contains(v.Match, matchPrefix) && v.Direction == ovnnb.ACLDirectionToLport {
+				count++
+			}
+		}
+		require.Equal(t, count, 3)
+	})
+
+	t.Run("result should include acl which externalIDs[key] is ''", func(t *testing.T) {
+		matchPrefix := "outport == @ovn.sg.test_list_acl_pg && ip"
+		pgName := "test-list-acl-with-key-pg"
+		// create two to-lport acl
+		for i := 0; i < 3; i++ {
+			match := fmt.Sprintf("%s && udp.dst == %d", matchPrefix, basePort+i)
+			err := ovnClient.CreateBareAcl(pgName, ovnnb.ACLDirectionToLport, "1897", match, ovnnb.ACLActionAllowRelated)
+			require.NoError(t, err)
+		}
+
+		// create two from-lport acl
+		for i := 0; i < 2; i++ {
+			match := fmt.Sprintf("%s && udp.dst == %d", matchPrefix, basePort+i)
+			err := ovnClient.CreateBareAcl(pgName, ovnnb.ACLDirectionFromLport, "1897", match, ovnnb.ACLActionAllowRelated)
+			require.NoError(t, err)
+		}
+
+		out, err := ovnClient.ListAcls("", map[string]string{aclParentKey: ""})
+		require.NoError(t, err)
+
+		count := 0
+		for _, v := range out {
+			if strings.Contains(v.ExternalIDs[aclParentKey], pgName) {
+				count++
+			}
+		}
+		require.Equal(t, count, 5)
+	})
+}
+
+func (suite *OvnClientTestSuite) testCreateAcls() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test-create-acls-pg"
+	priority := "5000"
+	basePort := 12300
+	matchPrefix := "outport == @ovn.sg.test_create_acl_pg && ip"
+	acls := make([]*ovnnb.ACL, 0, 3)
+
+	err := ovnClient.CreatePortGroup(pgName, nil)
 	require.NoError(t, err)
-	require.Len(t, op, 1)
 
-	require.Equal(t,
-		ovsdb.Operation{
-			Op:    "insert",
-			Table: "ACL",
-			Row: ovsdb.Row{
-				"_uuid":     ovsdb.UUID{GoUUID: aclUUID},
-				"direction": ovnnb.ACLDirectionToLport,
-				"priority":  1001,
-				"match":     match,
-				"action":    ovnnb.ACLActionAllowRelated,
-				"external_ids": ovsdb.OvsMap{GoMap: map[interface{}]interface{}{
-					aclParentKey: pgName,
-				}},
-				"log": false,
-			},
-			UUIDName: aclUUID,
-		}, op[0])
+	for i := 0; i < 3; i++ {
+		match := fmt.Sprintf("%s && tcp.dst == %d", matchPrefix, basePort+i)
+		acl, err := ovnClient.newAcl(pgName, ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated)
+		require.NoError(t, err)
+		acls = append(acls, acl)
+	}
+
+	err = ovnClient.CreateAcls(pgName, acls...)
+	require.NoError(t, err)
+
+	pg, err := ovnClient.GetPortGroup(pgName, false)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		match := fmt.Sprintf("%s && tcp.dst == %d", matchPrefix, basePort+i)
+		acl, err := ovnClient.GetAcl(ovnnb.ACLDirectionToLport, priority, match, false)
+		require.NoError(t, err)
+		require.Equal(t, match, acl.Match)
+
+		require.Contains(t, pg.ACLs, acl.UUID)
+	}
 }
 
 func (suite *OvnClientTestSuite) testnewAcl() {
 	t := suite.T()
 	t.Parallel()
 
+	ovnClient := suite.ovnClient
 	pgName := "test-new-acl-pg"
-	priority := "1001"
+	priority := "1000"
 	match := "outport==@ovn.sg.test_create_acl_pg && ip"
 	options := func(acl *ovnnb.ACL) {
 		acl.Log = true
@@ -165,7 +390,7 @@ func (suite *OvnClientTestSuite) testnewAcl() {
 		Action:    ovnnb.ACLActionAllowRelated,
 		Direction: ovnnb.ACLDirectionToLport,
 		Match:     match,
-		Priority:  1001,
+		Priority:  1000,
 		ExternalIDs: map[string]string{
 			aclParentKey: pgName,
 		},
@@ -173,27 +398,50 @@ func (suite *OvnClientTestSuite) testnewAcl() {
 		Severity: &ovnnb.ACLSeverityWarning,
 	}
 
-	acl := newAcl(pgName, ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated, options)
+	acl, err := ovnClient.newAcl(pgName, ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated, options)
+	require.NoError(t, err)
 	expect.UUID = acl.UUID
 	require.Equal(t, expect, acl)
 }
 
-func (suite *OvnClientTestSuite) testnewIngressAllowACL() {
+func (suite *OvnClientTestSuite) testnewAllowAclMatch() {
 	t := suite.T()
 	t.Parallel()
 
-	pgName := "test-new-allow-acl-pg"
-	asIngressName := "test.default.ingress.allow.ipv4"
-	asExceptName := "test.default.ingress.except.ipv4"
+	pgName := "test-new-acl-m-pg"
+	asAllowName := "test.default.xx.allow.ipv4"
+	asExceptName := "test.default.xx.except.ipv4"
 
-	t.Run("has network policy port", func(t *testing.T) {
+	t.Run("has ingress network policy port", func(t *testing.T) {
 		t.Parallel()
 
 		npp := mockNetworkPolicyPort()
-		matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+		// matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+		matches := newAllowAclMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp)
 		require.Equal(t, []string{
-			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp.dst == 12345 && outport == @test-new-allow-acl-pg && ip",
-			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && 12346 <= tcp.dst <= 20000 && outport == @test-new-allow-acl-pg && ip",
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[0].Port.IntVal),
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && %d <= tcp.dst <= %d", pgName, asAllowName, asExceptName, npp[1].Port.IntVal, *npp[1].EndPort),
+		}, matches)
+	})
+
+	t.Run("has egress network policy port", func(t *testing.T) {
+		t.Parallel()
+
+		npp := mockNetworkPolicyPort()
+
+		matches := newAllowAclMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionFromLport, npp)
+		require.Equal(t, []string{
+			fmt.Sprintf("inport == @%s && ip && ip4.dst == $%s && ip4.dst != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[0].Port.IntVal),
+			fmt.Sprintf("inport == @%s && ip && ip4.dst == $%s && ip4.dst != $%s && %d <= tcp.dst <= %d", pgName, asAllowName, asExceptName, npp[1].Port.IntVal, *npp[1].EndPort),
+		}, matches)
+	})
+
+	t.Run("network policy port is nil", func(t *testing.T) {
+		t.Parallel()
+
+		matches := newAllowAclMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, nil)
+		require.Equal(t, []string{
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s", pgName, asAllowName, asExceptName),
 		}, matches)
 	})
 
@@ -202,10 +450,11 @@ func (suite *OvnClientTestSuite) testnewIngressAllowACL() {
 
 		npp := mockNetworkPolicyPort()
 		npp[1].Port = nil
-		matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+
+		matches := newAllowAclMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp)
 		require.Equal(t, []string{
-			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp.dst == 12345 && outport == @test-new-allow-acl-pg && ip",
-			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp && outport == @test-new-allow-acl-pg && ip",
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[0].Port.IntVal),
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp", pgName, asAllowName, asExceptName),
 		}, matches)
 	})
 
@@ -214,19 +463,11 @@ func (suite *OvnClientTestSuite) testnewIngressAllowACL() {
 
 		npp := mockNetworkPolicyPort()
 		npp[1].EndPort = nil
-		matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
-		require.Equal(t, []string{
-			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp.dst == 12345 && outport == @test-new-allow-acl-pg && ip",
-			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp.dst == 12346 && outport == @test-new-allow-acl-pg && ip",
-		}, matches)
-	})
 
-	t.Run("has network policy port is nil", func(t *testing.T) {
-		t.Parallel()
-
-		matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, nil)
+		matches := newAllowAclMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp)
 		require.Equal(t, []string{
-			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && outport == @test-new-allow-acl-pg && ip",
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[0].Port.IntVal),
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[1].Port.IntVal),
 		}, matches)
 	})
 }

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -2,12 +2,118 @@ package ovs
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/require"
 
+	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func mockNetworkPolicyPort() []netv1.NetworkPolicyPort {
+	protocolTcp := v1.ProtocolTCP
+	var endPort int32 = 20000
+	return []netv1.NetworkPolicyPort{
+		{
+			Port: &intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: 12345,
+			},
+			Protocol: &protocolTcp,
+		},
+		{
+			Port: &intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: 12346,
+			},
+			EndPort:  &endPort,
+			Protocol: &protocolTcp,
+		},
+	}
+}
+
+func (suite *OvnClientTestSuite) testCreateIngressACL() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	pgName := "test_create_ingress_acl_pg"
+	asIngressName := "test.default.ingress.allow.ipv4"
+	asExceptName := "test.default.ingress.except.ipv4"
+
+	err := ovnClient.CreatePortGroup(pgName, nil)
+	require.NoError(t, err)
+
+	npp := mockNetworkPolicyPort()
+
+	err = ovnClient.CreateIngressACL(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+	require.NoError(t, err)
+
+	pg, err := ovnClient.GetPortGroup(pgName, false)
+	require.NoError(t, err)
+	require.Len(t, pg.ACLs, 3)
+
+	match := fmt.Sprintf("outport==@%s && ip", pgName)
+	defaultDropAcl, err := ovnClient.GetAcl(ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, match, false)
+	require.NoError(t, err)
+	require.Equal(t, pgName, *defaultDropAcl.Name)
+	require.Contains(t, pg.ACLs, defaultDropAcl.UUID)
+
+	matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+	for _, m := range matches {
+		allowAcl, err := ovnClient.GetAcl(ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, m, false)
+		require.NoError(t, err)
+		require.Contains(t, pg.ACLs, allowAcl.UUID)
+	}
+}
+
+func (suite *OvnClientTestSuite) testGetAcl() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	priority := "1001"
+	match := "outport==@ovn.sg.test_create_acl_pg && ip"
+
+	err := ovnClient.CreateBareACL(ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated)
+	require.NoError(t, err)
+
+	t.Run("direction, priority and match are same", func(t *testing.T) {
+		t.Parallel()
+		acl, err := ovnClient.GetAcl(ovnnb.ACLDirectionToLport, priority, match, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLDirectionToLport, acl.Direction)
+		require.Equal(t, 1001, acl.Priority)
+		require.Equal(t, match, acl.Match)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+	})
+
+	t.Run("direction, priority and match are not all same", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ovnClient.GetAcl(ovnnb.ACLDirectionFromLport, priority, match, false)
+		require.ErrorContains(t, err, "not found acl")
+
+		_, err = ovnClient.GetAcl(ovnnb.ACLDirectionToLport, "1010", match, false)
+		require.ErrorContains(t, err, "not found acl")
+
+		_, err = ovnClient.GetAcl(ovnnb.ACLDirectionToLport, priority, match+" && tcp", false)
+		require.ErrorContains(t, err, "not found acl")
+	})
+
+	t.Run("should no err when direction, priority and match are not all same but ignoreNotFound=true", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ovnClient.GetAcl(ovnnb.ACLDirectionFromLport, priority, match, true)
+		require.NoError(t, err)
+	})
+}
 
 func (suite *OvnClientTestSuite) testCreateAclOp() {
 	t := suite.T()
@@ -17,11 +123,8 @@ func (suite *OvnClientTestSuite) testCreateAclOp() {
 	pgName := "test-create-acl-op-pg"
 	priority := "1001"
 	match := "outport==@ovn.sg.test_create_acl_pg && ip"
-	aclName := fmt.Sprintf("%s.%s.%s", pgName, ovnnb.ACLDirectionToLport, priority)
 
-	acl := ovnClient.newAcl(pgName, match, ovnnb.ACLDirectionToLport, ovnnb.ACLActionAllowRelated, priority)
-
-	op, err := ovnClient.CreateAclOp(acl)
+	op, aclUUID, err := ovnClient.CreateAclOp(pgName, ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated)
 	require.NoError(t, err)
 	require.Len(t, op, 1)
 
@@ -30,49 +133,100 @@ func (suite *OvnClientTestSuite) testCreateAclOp() {
 			Op:    "insert",
 			Table: "ACL",
 			Row: ovsdb.Row{
-				"action":    ovnnb.ACLActionAllowRelated,
+				"_uuid":     ovsdb.UUID{GoUUID: aclUUID},
 				"direction": ovnnb.ACLDirectionToLport,
+				"priority":  1001,
+				"match":     match,
+				"action":    ovnnb.ACLActionAllowRelated,
 				"external_ids": ovsdb.OvsMap{GoMap: map[interface{}]interface{}{
-					portGroupKey: pgName,
+					aclParentKey: pgName,
 				}},
-				"match": match,
-				"log":   false,
-				"name": ovsdb.OvsSet{
-					GoSet: []interface{}{
-						aclName,
-					}},
-				"priority": 1001,
-			}}, op[0])
+				"log": false,
+			},
+			UUIDName: aclUUID,
+		}, op[0])
 }
 
 func (suite *OvnClientTestSuite) testnewAcl() {
 	t := suite.T()
 	t.Parallel()
 
-	ovnClient := suite.ovnClient
 	pgName := "test-new-acl-pg"
 	priority := "1001"
 	match := "outport==@ovn.sg.test_create_acl_pg && ip"
-	aclName := fmt.Sprintf("%s.%s.%s", pgName, ovnnb.ACLDirectionToLport, priority)
-
 	options := func(acl *ovnnb.ACL) {
 		acl.Log = true
 		acl.Severity = &ovnnb.ACLSeverityWarning
+		acl.Name = &pgName
 	}
 
 	expect := &ovnnb.ACL{
-		Name:      &aclName,
+		Name:      &pgName,
 		Action:    ovnnb.ACLActionAllowRelated,
 		Direction: ovnnb.ACLDirectionToLport,
 		Match:     match,
 		Priority:  1001,
 		ExternalIDs: map[string]string{
-			portGroupKey: pgName,
+			aclParentKey: pgName,
 		},
 		Log:      true,
 		Severity: &ovnnb.ACLSeverityWarning,
 	}
 
-	acl := ovnClient.newAcl(pgName, match, ovnnb.ACLDirectionToLport, ovnnb.ACLActionAllowRelated, priority, options)
+	acl := newAcl(pgName, ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated, options)
+	expect.UUID = acl.UUID
 	require.Equal(t, expect, acl)
+}
+
+func (suite *OvnClientTestSuite) testnewIngressAllowACL() {
+	t := suite.T()
+	t.Parallel()
+
+	pgName := "test-new-allow-acl-pg"
+	asIngressName := "test.default.ingress.allow.ipv4"
+	asExceptName := "test.default.ingress.except.ipv4"
+
+	t.Run("has network policy port", func(t *testing.T) {
+		t.Parallel()
+
+		npp := mockNetworkPolicyPort()
+		matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+		require.Equal(t, []string{
+			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp.dst == 12345 && outport == @test-new-allow-acl-pg && ip",
+			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && 12346 <= tcp.dst <= 20000 && outport == @test-new-allow-acl-pg && ip",
+		}, matches)
+	})
+
+	t.Run("has network policy port but port is not set", func(t *testing.T) {
+		t.Parallel()
+
+		npp := mockNetworkPolicyPort()
+		npp[1].Port = nil
+		matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+		require.Equal(t, []string{
+			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp.dst == 12345 && outport == @test-new-allow-acl-pg && ip",
+			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp && outport == @test-new-allow-acl-pg && ip",
+		}, matches)
+	})
+
+	t.Run("has network policy port but endPort is not set", func(t *testing.T) {
+		t.Parallel()
+
+		npp := mockNetworkPolicyPort()
+		npp[1].EndPort = nil
+		matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, npp)
+		require.Equal(t, []string{
+			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp.dst == 12345 && outport == @test-new-allow-acl-pg && ip",
+			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && tcp.dst == 12346 && outport == @test-new-allow-acl-pg && ip",
+		}, matches)
+	})
+
+	t.Run("has network policy port is nil", func(t *testing.T) {
+		t.Parallel()
+
+		matches := newIngressAllowACLMatch(pgName, asIngressName, asExceptName, kubeovnv1.ProtocolIPv4, nil)
+		require.Equal(t, []string{
+			"ip4.src == $test.default.ingress.allow.ipv4 && ip4.src != $test.default.ingress.except.ipv4 && outport == @test-new-allow-acl-pg && ip",
+		}, matches)
+	})
 }

--- a/pkg/ovs/ovn-nb-gateway_chassis_test.go
+++ b/pkg/ovs/ovn-nb-gateway_chassis_test.go
@@ -3,33 +3,7 @@ package ovs
 import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/require"
-
-	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
-
-func (suite *OvnClientTestSuite) testCreateGatewayChassis() {
-	t := suite.T()
-	t.Parallel()
-
-	ovnClient := suite.ovnClient
-	chassis := "c7efec70-9519-4b03-8b67-057f2a95e5c7"
-	name := "test-create-gateway-chassis" + "-" + chassis
-
-	gwChassis := &ovnnb.GatewayChassis{
-		Name:        name,
-		ChassisName: chassis,
-		Priority:    50,
-	}
-	err := ovnClient.CreateGatewayChassis(gwChassis)
-	require.NoError(t, err)
-
-	gwChassis, err = ovnClient.GetGatewayChassis(name, false)
-	require.NoError(t, err)
-	require.NotEmpty(t, gwChassis.UUID)
-	require.Equal(t, name, gwChassis.Name)
-	require.Equal(t, chassis, gwChassis.ChassisName)
-	require.Equal(t, 50, gwChassis.Priority)
-}
 
 func (suite *OvnClientTestSuite) testCreateGatewayChassises() {
 	t := suite.T()
@@ -51,6 +25,10 @@ func (suite *OvnClientTestSuite) testCreateGatewayChassises() {
 		require.Equal(t, chassisName, gwChassis.ChassisName)
 		require.Equal(t, 100-i, gwChassis.Priority)
 	}
+
+	err = ovnClient.CreateGatewayChassises(lrpName, []string{"c7efec70-9519-4b03-8b67-057f2a95e5c7"})
+	require.NoError(t, err)
+
 }
 
 func (suite *OvnClientTestSuite) testDeleteGatewayChassises() {

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -212,10 +212,6 @@ func (suite *OvnClientTestSuite) Test_DeleteLogicalRouterPortOp() {
 }
 
 /* gateway_chassis unit test */
-func (suite *OvnClientTestSuite) Test_CreateGatewayChassis() {
-	suite.testCreateGatewayChassis()
-}
-
 func (suite *OvnClientTestSuite) Test_CreateGatewayChassises() {
 	suite.testCreateGatewayChassises()
 }
@@ -308,24 +304,32 @@ func (suite *OvnClientTestSuite) Test_ListAddressSets() {
 }
 
 /* acl unit test */
-func (suite *OvnClientTestSuite) Test_CreateIngressACL() {
-	suite.testCreateIngressACL()
+func (suite *OvnClientTestSuite) Test_CreateIngressAcl() {
+	suite.testCreateIngressAcl()
+}
+
+func (suite *OvnClientTestSuite) Test_CreateEgressAcl() {
+	suite.testCreateEgressAcl()
 }
 
 func (suite *OvnClientTestSuite) Test_GetAcl() {
 	suite.testGetAcl()
 }
 
-func (suite *OvnClientTestSuite) Test_CreateAclOp() {
-	suite.testCreateAclOp()
+func (suite *OvnClientTestSuite) Test_ListAcls() {
+	suite.testListAcls()
+}
+
+func (suite *OvnClientTestSuite) Test_CreateAcls() {
+	suite.testCreateAcls()
 }
 
 func (suite *OvnClientTestSuite) Test_newAcl() {
 	suite.testnewAcl()
 }
 
-func (suite *OvnClientTestSuite) Test_newIngressAllowACL() {
-	suite.testnewIngressAllowACL()
+func (suite *OvnClientTestSuite) Test_newAllowAclMatch() {
+	suite.testnewAllowAclMatch()
 }
 
 /* mixed operations unit test */

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -308,12 +308,24 @@ func (suite *OvnClientTestSuite) Test_ListAddressSets() {
 }
 
 /* acl unit test */
+func (suite *OvnClientTestSuite) Test_CreateIngressACL() {
+	suite.testCreateIngressACL()
+}
+
+func (suite *OvnClientTestSuite) Test_GetAcl() {
+	suite.testGetAcl()
+}
+
 func (suite *OvnClientTestSuite) Test_CreateAclOp() {
 	suite.testCreateAclOp()
 }
 
 func (suite *OvnClientTestSuite) Test_newAcl() {
 	suite.testnewAcl()
+}
+
+func (suite *OvnClientTestSuite) Test_newIngressAllowACL() {
+	suite.testnewIngressAllowACL()
 }
 
 /* mixed operations unit test */


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #1675 

1. replace some of acl table with libovsdb
2. it does't work using `pgname.direction.priority` to determinate one acl, because more than one acl has the same `priority` when NetworkPolicyPort has serveral Port, be consistent with ovn-nbctl which `direction`, `priority` and `match` determine one acl.
