### PR TITLE
Lb-svc supports custom VPCs

### DIFF
--- a/pkg/controller/service_lb.go
+++ b/pkg/controller/service_lb.go
@@ -93,6 +93,9 @@ func (c *Controller) genLbSvcDeployment(svc *corev1.Service) (dp *v1.Deployment)
 	if svc.Spec.LoadBalancerIP != "" {
 		podAnnotations[attchIpAnnotation] = svc.Spec.LoadBalancerIP
 	}
+	if v, ok := svc.Annotations[util.LogicalSwitchAnnotation]; ok {
+		podAnnotations[util.LogicalSwitchAnnotation] = v
+	}
 
 	dp = &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
在service中增加注解`ovn.kubernetes.io/logical_switch`，以支持自定义vpc lb-svc的使用
