### PR TITLE
northd: remove lookup_arp_ip actions

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -35,7 +35,7 @@ RUN cd /usr/src/ && git clone -b v22.03.1 --depth=1 https://github.com/ovn-org/o
     # change hash type from dp_hash to hash with field src_ip
     curl -s https://github.com/kubeovn/ovn/commit/ab923b252271cbbcccc8091e338ee7efe75e5fcd.patch | git apply && \
     # set ether dst addr for dnat on logical switch
-    curl -s https://github.com/kubeovn/ovn/commit/94b73d939cd33b0531fa9a3422c999cd83ead087.patch | git apply && \
+    curl -s https://github.com/kubeovn/ovn/commit/f6217e2c1d9a24eb4595c75727202daf05dadc85.patch | git apply && \
     sed -i 's/OVN/ovn/g' debian/changelog && \
     rm -rf .git && \
     ./boot.sh && \


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

Fix the following ovn-controller error:

```txt
error parsing actions "lookup_arp_ip("ovn-cluster-join", ip6.dst); next;": Syntax error at 'lookup_arp_ip' expecting action.
```