### PR TITLE
perf: reduce metrics labels

### DIFF
--- a/pkg/controller/client_go_adapter.go
+++ b/pkg/controller/client_go_adapter.go
@@ -21,6 +21,7 @@ package controller
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -154,7 +155,12 @@ type latencyAdapter struct {
 }
 
 func (l *latencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
-	l.metric.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
+	url := u.String()
+	last := strings.LastIndex(url, "/")
+	if last != -1 {
+		url = url[:last]
+	}
+	l.metric.WithLabelValues(verb, url).Observe(latency.Seconds())
 }
 
 type resultAdapter struct {

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -170,7 +171,12 @@ type latencyAdapter struct {
 }
 
 func (l *latencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
-	l.metric.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
+	url := u.String()
+	last := strings.LastIndex(url, "/")
+	if last != -1 {
+		url = url[:last]
+	}
+	l.metric.WithLabelValues(verb, url).Observe(latency.Seconds())
 }
 
 type resultAdapter struct {


### PR DESCRIPTION
Previously every new url will create a metrics entry with url as label. It will keep increasing as pod/ip creating and will not be released which will exhaust the memory. Aggregate the metrics by url prefix.


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
