### PR TITLE
avoid invalid ovn-nbctl daemon socket path

### DIFF
--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1,6 +1,7 @@
 package ovs
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,8 @@ const (
 	SgAclIngressDirection AclDirection = "to-lport"
 	SgAclEgressDirection  AclDirection = "from-lport"
 )
+
+var nbctlDaemonSocketRegexp = regexp.MustCompile(`^/var/run/ovn/ovn-nbctl\.[0-9]+\.ctl$`)
 
 func (c LegacyClient) ovnNbCommand(cmdArgs ...string) (string, error) {
 	start := time.Now()
@@ -1868,14 +1871,23 @@ func StartOvnNbctlDaemon(ovnNbAddr string) error {
 			"--overwrite-pidfile",
 		}
 	}
-	_ = os.Unsetenv("OVN_NB_DAEMON")
-	output, err = exec.Command("ovn-nbctl", command...).CombinedOutput()
-	if err != nil {
-		klog.Errorf("start ovn-nbctl daemon failed, %q", output)
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("ovn-nbctl", command...)
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err = cmd.Run(); err != nil {
+		klog.Errorf("failed to start ovn-nbctl daemon: %v, %s, %s", err, stdout.String(), stderr.String())
 		return err
 	}
 
-	daemonSocket := strings.TrimSpace(string(output))
+	daemonSocket := strings.TrimSpace(stdout.String())
+	if !nbctlDaemonSocketRegexp.MatchString(daemonSocket) {
+		err = fmt.Errorf("invalid nbctl daemon socket: %q", daemonSocket)
+		klog.Error(err)
+		return err
+	}
+
+	_ = os.Unsetenv("OVN_NB_DAEMON")
 	if err := os.Setenv("OVN_NB_DAEMON", daemonSocket); err != nil {
 		klog.Errorf("failed to set env OVN_NB_DAEMON, %v", err)
 		return err
@@ -1885,14 +1897,12 @@ func StartOvnNbctlDaemon(ovnNbAddr string) error {
 
 // CheckAlive check if kube-ovn-controller can access ovn-nb from nbctl-daemon
 func CheckAlive() error {
-	output, err := exec.Command(
-		"ovn-nbctl",
-		"--timeout=60",
-		"show",
-	).CombinedOutput()
+	var stderr bytes.Buffer
+	cmd := exec.Command("ovn-nbctl", "--timeout=60", "show")
+	cmd.Stderr = &stderr
 
-	if err != nil {
-		klog.Errorf("failed to access ovn-nb from daemon, %q", output)
+	if err := cmd.Run(); err != nil {
+		klog.Errorf("failed to access ovn-nb from daemon: %v, %s", err, stderr.String())
 		return err
 	}
 	return nil


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

In some scenarios, the environment variable OVN_NB_DAEMON contains output of command `ovn-nbctl show`:

```log
E0811 14:09:33.118843 7 ovn-nbctl-legacy.go:1776] failed to access ovn-nb from daemon, "2022-08-11T06:09:33Z|00001|socket_util_unix|WARN|Unix socket name /var/run/ovn/ovn
-nbctl.17.ctl\nswitch ff84faad-84c6-4482-9848-d5418934deda (ovn-default)\n    port devops-api-cfbcdd76b-ndf2b.cpaas-system\n        addresses: [\"00:00:00:61:A5:AD 10.200.0.112
\"]\n    port devops-controller-757f46b86d-dzgbr.cpaas-system\n        addresses: [\"00:00:00:EB:4D:66 10.200.0.46\"]...: could not connect to ovn-nbctl daemon (File name too long); unset OVN_NB_DAEMON to avoid using daemon\n", "exit status 1"
W0811 14:09:33.119636 7 controller.go:73] ovn-nbctl daemon doesn't return, start a new daemon
...
E0811 16:14:24.525177       7 external_vpc.go:19] list lr failed2022-08-11T08:14:24Z|00001|socket_util_unix|WARN|Unix socket name /var/run/ovn/ovn-nbctl.30856.ctl
switch ff84faad-84c6-4482-9848-d5418934deda (ovn-default)
    port icarus-6457b7b867-wltzk.cpaas-system
        addresses: ["00:00:00:C4:CF:12 10.200.0.51"]
    port catalog-operator-7d97f8f9f8-t9zrl.cpaas-system
        addresses: ["00:00:00:68:F9:4A 10.200.0.134"]
    port devops-controller-757f46b86d-dzgbr.cpaas-system
...
    port razor-6f78bbf7dc-m4mq8.cpaas-system
        addresses: ["00:00:00:33:17:91 10.200.0. is longer than maximum 107 bytes
```

This patch adds a path check before setting the environment variable.