### PR TITLE
kubectl-ko: fix trace for KubeVirt VM

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -19,7 +19,7 @@ showHelp(){
   echo "  dpctl {nodeName} [ovs-dpctl options ...]   invoke ovs-dpctl on the specified node"
   echo "  appctl {nodeName} [ovs-appctl options ...]   invoke ovs-appctl on the specified node"
   echo "  tcpdump {namespace/podname} [tcpdump options ...]     capture pod traffic"
-  echo "  trace {namespace/podname} {target ip address} {icmp|tcp|udp} [target tcp or udp port]    trace ovn microflow of specific packet"
+  echo "  trace {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp or udp port]    trace ovn microflow of specific packet"
   echo "  diagnose {all|node} [nodename]    diagnose connectivity of all nodes or a specific node"
   echo "  env-check check the environment configuration"
   echo "  tuning {install-fastpath|local-install-fastpath|remove-fastpath|install-stt|local-install-stt|remove-stt} {centos7|centos8}} [kernel-devel-version]  deploy  kernel optimisation components to the system"
@@ -141,7 +141,7 @@ tcpdump(){
     exit 1
   fi
 
-  ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -o wide| grep kube-ovn-cni| grep " $nodeName " | awk '{print $1}')
+  ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
   if [ -z "$ovnCni" ]; then
     echo "kube-ovn-cni not exist on node $nodeName"
     exit 1
@@ -223,6 +223,13 @@ trace(){
     exit 1
   fi
 
+  nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
+  ovsPod=$(kubectl get pod -n $KUBE_OVN_NS -l app=ovs -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
+  if [ -z "$ovsPod" ]; then
+    echo "ovs pod doesn't exist on node $nodeName"
+    exit 1
+  fi
+
   ls=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/logical_switch})
   if [ -z "$ls" ]; then
     echo "pod address not ready"
@@ -231,10 +238,12 @@ trace(){
 
   local cidr=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/cidr})
   mac=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/mac_address})
-  nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
 
   dstMac=""
-  if ipIsInCidr $dst $cidr; then
+  if echo "$3" | grep -oE '^([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}$'; then
+    dstMac=$3
+    shift
+  elif ipIsInCidr $dst $cidr; then
     set +o pipefail
     if [ $af -eq 4 ]; then
       dstMac=$(kubectl exec $OVN_NB_POD -n $KUBE_OVN_NS -c ovn-central -- ovn-nbctl --data=bare --no-heading --columns=addresses list logical_switch_port | grep -w "$(echo $dst | tr . '\.')" | awk '{print $1}')
@@ -243,6 +252,7 @@ trace(){
     fi
     set -o pipefail
   fi
+
   if [ -z "$dstMac" ]; then
     vlan=$(kubectl get subnet "$ls" -o jsonpath={.spec.vlan})
     logicalGateway=$(kubectl get subnet "$ls" -o jsonpath={.spec.logicalGateway})
@@ -256,7 +266,7 @@ trace(){
         fi
       fi
 
-      ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -o wide | grep -w kube-ovn-cni | grep " $nodeName " | awk '{print $1}')
+      ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
       if [ -z "$ovnCni" ]; then
         echo "No kube-ovn-cni Pod running on node $nodeName"
         exit 1
@@ -271,7 +281,11 @@ trace(){
       podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
       podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
       if [ "$podNicType" != "internal-port" ]; then
-        nicName="eth0"
+        interface=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=name find interface external_id:iface-id="$podName"."$namespace")
+        peer=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ip link show $interface | grep -oE "^[0-9]+:\\s$interface@if[0-9]+" | awk -F @ '{print $2}')
+        peerIndex=${peer//if/}
+        peer=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ip link show type veth | grep "^$peerIndex:" | awk -F @ '{print $1}')
+        nicName=$(echo $peer | awk '{print $2}')
       fi
 
       if [[ "$gateway" =~ .*:.* ]]; then
@@ -286,7 +300,7 @@ trace(){
         echo "failed to run '$cmd' in Pod's netns"
         exit 1
       fi
-      dstMac=$(echo "$output" | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}')
+      dstMac=$(echo "$output" | grep -oE '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}')
     else
       lr=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/logical_router})
       if [ -z "$lr" ]; then
@@ -301,15 +315,30 @@ trace(){
     exit 1
   fi
 
+  lsp="$podName.$namespace"
+  lspUUID=$(kubectl exec $OVN_NB_POD -n $KUBE_OVN_NS -c ovn-central -- ovn-nbctl --data=bare --no-heading --columns=_uuid find logical_switch_port name="$lsp")
+  if [ -z "$lspUUID" ]; then
+    echo "Notice: LSP $lsp does not exist"
+  fi
+  vmOwner=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[?(@.kind=="VirtualMachineInstance")].name}')
+  if [ ! -z "$vmOwner" ]; then
+    lsp="$vmOwner.$namespace"
+  fi
+
+  if [ -z "$lsp" ]; then
+    echo "failed to get LSP of Pod $namespace/$podName"
+    exit 1
+  fi
+
   type="$3"
   case $type in
     icmp)
       set -x
-      kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace --ct=new "$ls" "inport == \"$podName.$namespace\" && ip.ttl == 64 && icmp && eth.src == $mac && ip$af.src == $podIP && eth.dst == $dstMac && ip$af.dst == $dst"
+      kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace --ct=new "$ls" "inport == \"$lsp\" && ip.ttl == 64 && icmp && eth.src == $mac && ip$af.src == $podIP && eth.dst == $dstMac && ip$af.dst == $dst"
       ;;
     tcp|udp)
       set -x
-      kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace --ct=new "$ls" "inport == \"$podName.$namespace\" && ip.ttl == 64 && eth.src == $mac && ip$af.src == $podIP && eth.dst == $dstMac && ip$af.dst == $dst && $type.src == 10000 && $type.dst == $4"
+      kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace --ct=new "$ls" "inport == \"$lsp\" && ip.ttl == 64 && eth.src == $mac && ip$af.src == $podIP && eth.dst == $dstMac && ip$af.dst == $dst && $type.src == 10000 && $type.dst == $4"
       ;;
     *)
       echo "type $type not supported"
@@ -323,12 +352,6 @@ trace(){
   echo "Start OVS Tracing"
   echo ""
   echo ""
-
-  ovsPod=$(kubectl get pod -n $KUBE_OVN_NS -o wide | grep " $nodeName " | grep ovs-ovn | awk '{print $1}')
-  if [ -z "$ovsPod" ]; then
-    echo "ovs pod doesn't exist on node $nodeName"
-    exit 1
-  fi
 
   inPort=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=ofport find interface external_id:iface-id="$podName"."$namespace")
   case $type in
@@ -352,7 +375,7 @@ xxctl(){
   subcommand="$1"; shift
   nodeName="$1"; shift
   kubectl get no "$nodeName" > /dev/null
-  ovsPod=$(kubectl get pod -n $KUBE_OVN_NS -o wide | grep " $nodeName " | grep ovs-ovn | awk '{print $1}')
+  ovsPod=$(kubectl get pod -n $KUBE_OVN_NS -l app=ovs -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
   if [ -z "$ovsPod" ]; then
     echo "ovs pod  doesn't exist on node $nodeName"
     exit 1
@@ -887,5 +910,6 @@ case $subcommand in
     ;;
   *)
     showHelp
+    exit 1
     ;;
 esac

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -224,9 +224,9 @@ trace(){
   fi
 
   nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
-  ovsPod=$(kubectl get pod -n $KUBE_OVN_NS -l app=ovs -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
-  if [ -z "$ovsPod" ]; then
-    echo "ovs pod doesn't exist on node $nodeName"
+  ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
+  if [ -z "$ovnCni" ]; then
+    echo "No kube-ovn-cni Pod running on node $nodeName"
     exit 1
   fi
 
@@ -266,48 +266,52 @@ trace(){
         fi
       fi
 
-      ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
-      if [ -z "$ovnCni" ]; then
-        echo "No kube-ovn-cni Pod running on node $nodeName"
-        exit 1
-      fi
-
-      nicName=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$podName"."$namespace" | tr -d '\r')
+      nicName=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$podName"."$namespace" | tr -d '\r')
       if [ -z "$nicName" ]; then
-        echo "nic doesn't exist on node $nodeName"
+        echo "failed to find ovs interface for Pod namespacedPod on node $nodeName"
         exit 1
       fi
 
       podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-      podNetNs=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
+      podNetNs=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
       if [ "$podNicType" != "internal-port" ]; then
-        interface=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=name find interface external_id:iface-id="$podName"."$namespace")
-        peer=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ip link show $interface | grep -oE "^[0-9]+:\\s$interface@if[0-9]+" | awk -F @ '{print $2}')
+        interface=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=name find interface external_id:iface-id="$podName"."$namespace")
+        peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ip link show $interface | grep -oE "^[0-9]+:\\s$interface@if[0-9]+" | awk -F @ '{print $2}')
         peerIndex=${peer//if/}
-        peer=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ip link show type veth | grep "^$peerIndex:" | awk -F @ '{print $1}')
+        peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ip link show type veth | grep "^$peerIndex:" | awk -F @ '{print $1}')
         nicName=$(echo $peer | awk '{print $2}')
+      fi
+
+      master=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ip link show $nicName | grep -Eo '\smaster\s\w+\s' | awk '{print $2}')
+      if [ ! -z "$master" ]; then
+        echo "Error: Pod nic $nicName is a slave of $master, please set the destination mac address."
+        exit 1
       fi
 
       if [[ "$gateway" =~ .*:.* ]]; then
         cmd="ndisc6 -q $gateway $nicName"
-        output=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ndisc6 -q "$gateway" "$nicName")
+        output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ndisc6 -q "$gateway" "$nicName")
       else
         cmd="arping -c3 -C1 -i1 -I $nicName $gateway"
-        output=$(kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" arping -c3 -C1 -i1 -I "$nicName" "$gateway")
+        output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" arping -c3 -C1 -i1 -I "$nicName" "$gateway")
       fi
 
       if [ $? -ne 0 ]; then
-        echo "failed to run '$cmd' in Pod's netns"
+        echo "Error: failed to execute '$cmd' in Pod's netns"
         exit 1
       fi
+
       dstMac=$(echo "$output" | grep -oE '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}')
-    else
-      lr=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/logical_router})
-      if [ -z "$lr" ]; then
-        lr=$(kubectl get subnet "$ls" -o jsonpath={.spec.vpc})
-      fi
-      dstMac=$(kubectl exec $OVN_NB_POD -n $KUBE_OVN_NS -c ovn-central -- ovn-nbctl --data=bare --no-heading --columns=mac find logical_router_port name="$lr"-"$ls" | tr -d '\r')
     fi
+  fi
+
+  if [ -z "$dstMac" ]; then
+    echo "Using the gateway mac address as destination"
+    lr=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/logical_router})
+    if [ -z "$lr" ]; then
+      lr=$(kubectl get subnet "$ls" -o jsonpath={.spec.vpc})
+    fi
+    dstMac=$(kubectl exec $OVN_NB_POD -n $KUBE_OVN_NS -c ovn-central -- ovn-nbctl --data=bare --no-heading --columns=mac find logical_router_port name="$lr"-"$ls" | tr -d '\r')
   fi
 
   if [ -z "$dstMac" ]; then
@@ -342,7 +346,7 @@ trace(){
       ;;
     *)
       echo "type $type not supported"
-      echo "kubectl ko trace {namespace/podname} {target ip address} {icmp|tcp|udp} [target tcp or udp port]"
+      echo "kubectl ko trace {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp or udp port]"
       exit 1
       ;;
   esac
@@ -353,19 +357,19 @@ trace(){
   echo ""
   echo ""
 
-  inPort=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=ofport find interface external_id:iface-id="$podName"."$namespace")
+  inPort=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=ofport find interface external_id:iface-id="$podName"."$namespace")
   case $type in
     icmp)
       set -x
-      kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,icmp$proto,nw_ttl=64,${nw}_src=$podIP,${nw}_dst=$dst,dl_src=$mac,dl_dst=$dstMac"
+      kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,icmp$proto,nw_ttl=64,${nw}_src=$podIP,${nw}_dst=$dst,dl_src=$mac,dl_dst=$dstMac"
       ;;
     tcp|udp)
       set -x
-      kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,$type$proto,nw_ttl=64,${nw}_src=$podIP,${nw}_dst=$dst,dl_src=$mac,dl_dst=$dstMac,${type}_src=1000,${type}_dst=$4"
+      kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,$type$proto,nw_ttl=64,${nw}_src=$podIP,${nw}_dst=$dst,dl_src=$mac,dl_dst=$dstMac,${type}_src=1000,${type}_dst=$4"
       ;;
     *)
       echo "type $type not supported"
-      echo "kubectl ko trace {namespace/podname} {target ip address} {icmp|tcp|udp} [target tcp or udp port]"
+      echo "kubectl ko trace {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp or udp port]"
       exit 1
       ;;
   esac

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -116,7 +116,7 @@ ipIsInCidr(){
   local ip_dec=$((0x$ip_hex))
   local network_hex=$(ipv4_to_hex $network)
   local network_dec=$((0x$network_hex))
-  local broadcast_dec=$(($network_dec + 2**$prefix - 1))
+  local broadcast_dec=$(($network_dec + 2**(32-$prefix) - 1))
   # TODO: check whether the IP is network/broadcast address
   if [ $ip_dec -gt $network_dec -a $ip_dec -lt $broadcast_dec ]; then
     return 0

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -240,7 +240,7 @@ trace(){
   mac=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/mac_address})
 
   dstMac=""
-  if echo "$3" | grep -oE '^([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}$'; then
+  if echo "$3" | grep -qE '^([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}$'; then
     dstMac=$3
     shift
   elif ipIsInCidr $dst $cidr; then

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -282,7 +282,9 @@ trace(){
         nicName=$(echo $peer | awk '{print $2}')
       fi
 
+      set +o pipefail
       master=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ip link show $nicName | grep -Eo '\smaster\s\w+\s' | awk '{print $2}')
+      set -o pipefail
       if [ ! -z "$master" ]; then
         echo "Error: Pod nic $nicName is a slave of $master, please set the destination mac address."
         exit 1

--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -137,10 +137,10 @@ ct_next(ct_state=new|trk)
 ....Skip More....
 ```
 
-If the pod is a virtual machine running in underlay network, you may need to set the destination mac address:
+If the pod is a virtual machine running in underlay network, you may need to add another parameter to specify the destination mac address:
 
-```sh
-kubectl ko trace default/ds1-l6n7p 8.8.8.8 82:7c:9f:83:8c:01 icmp
+```bash
+kubectl ko trace default/virt-handler-7lvml 8.8.8.8 82:7c:9f:83:8c:01 icmp
 ```
 
 4. Diagnose network connectivity

--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -9,7 +9,7 @@ To enable kubectl plugin, kubectl version of 1.12 or later is recommended. You c
 1. Get the `kubectl-ko` file
 
 ```bash
-wget https://raw.githubusercontent.com/alauda/kube-ovn/release-1.8/dist/images/kubectl-ko
+wget https://raw.githubusercontent.com/kubeovn/kube-ovn/release-1.10/dist/images/kubectl-ko
 ```
 
 2. Move the file to one of $PATH directories
@@ -38,7 +38,7 @@ The following compatible plugins are available:
 ```text
 kubectl ko {subcommand} [option...]
 Available Subcommands:
-  [nb|sb] [status|kick|backup]     ovn-db operations show cluster status, kick stale server or backup database
+  [nb|sb] [status|kick|backup|dbstatus|restore]     ovn-db operations show cluster status, kick stale server, backup database, get db consistency status or restore ovn nb db when met 'inconsistent data' error
   nbctl [ovn-nbctl options ...]    invoke ovn-nbctl
   sbctl [ovn-sbctl options ...]    invoke ovn-sbctl
   vsctl {nodeName} [ovs-vsctl options ...]   invoke ovs-vsctl on the specified node
@@ -46,8 +46,10 @@ Available Subcommands:
   dpctl {nodeName} [ovs-dpctl options ...]   invoke ovs-dpctl on the specified node
   appctl {nodeName} [ovs-appctl options ...]   invoke ovs-appctl on the specified node
   tcpdump {namespace/podname} [tcpdump options ...]     capture pod traffic
-  trace {namespace/podname} {target ip address} {icmp|tcp|udp} [target tcp or udp port]    trace ovn microflow of specific packet
+  trace {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp or udp port]    trace ovn microflow of specific packet
   diagnose {all|node} [nodename]    diagnose connectivity of all nodes or a specific node
+  env-check check the environment configuration
+  tuning {install-fastpath|local-install-fastpath|remove-fastpath|install-stt|local-install-stt|remove-stt} {centos7|centos8}} [kernel-devel-version]  deploy  kernel optimisation components to the system
   reload restart all kube-ovn components
 ```
 
@@ -133,6 +135,12 @@ ct_next(ct_state=new|trk)
     output;
 
 ....Skip More....
+```
+
+If the pod is a virtual machine running in underlay network, you may need to set the destination mac address:
+
+```sh
+kubectl ko trace default/ds1-l6n7p 8.8.8.8 82:7c:9f:83:8c:01 icmp
 ```
 
 4. Diagnose network connectivity


### PR DESCRIPTION
1. Get veth peer by link index;
2. Fix LSP name when keep-vm-ip is enabled.


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:
Fixes #1778
