### PR TITLE
update centralize subnet gatewayNode until gw is ready

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1259,8 +1259,10 @@ func (c *Controller) reconcileOvnRoute(subnet *kubeovnv1.Subnet) error {
 					if err != nil {
 						return err
 					}
-					_, err = c.config.KubeOvnClient.KubeovnV1().Subnets().Patch(context.Background(), subnet.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
-					return err
+					if _, err = c.config.KubeOvnClient.KubeovnV1().Subnets().Patch(context.Background(), subnet.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status"); err != nil {
+						klog.Errorf("failed to patch subnet %s NoReadyGateway status: %v", subnet.Name, err)
+					}
+					return fmt.Errorf("all subnet %s gws are not ready", subnet.Name)
 				}
 
 				nextHop := getNextHopByTunnelIP(nodeTunlIPAddr)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Bug fixes

####
1、 GatewayNode is nil for centralized subnet and patch subnet status as not ready succeed,  which will lead no update for subnet. 
Wait gatewayNode ready for centralized subnet.
2、If subnet is not ready，the route from subnet cidr to ovn0 would not be added in cni.

#### Which issue(s) this PR fixes:
Fixes #1803 
