### PR TITLE
release-1.8: do not check static route conflict

### DIFF
--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -680,20 +680,6 @@ func (c Client) AddStaticRoute(policy, cidr, nextHop, router string, routeType s
 		policy = PolicyDstIP
 	}
 
-	var existingRoutes []string
-	if routeType != util.EcmpRouteType {
-		result, err := c.CustomFindEntity("Logical_Router", []string{"static_routes"}, fmt.Sprintf("name=%s", router))
-		if err != nil {
-			return err
-		}
-		if len(result) > 1 {
-			return fmt.Errorf("unexpected error: found %d logical router with name %s", len(result), router)
-		}
-		if len(result) != 0 {
-			existingRoutes = result[0]["static_routes"]
-		}
-	}
-
 	for _, cidrBlock := range strings.Split(cidr, ",") {
 		for _, gw := range strings.Split(nextHop, ",") {
 			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(gw) {
@@ -704,20 +690,6 @@ func (c Client) AddStaticRoute(policy, cidr, nextHop, router string, routeType s
 					return err
 				}
 			} else {
-				if !strings.ContainsRune(cidrBlock, '/') {
-					filter := []string{fmt.Sprintf("policy=%s", policy), fmt.Sprintf(`ip_prefix="%s"`, cidrBlock), fmt.Sprintf(`nexthop!="%s"`, gw)}
-					result, err := c.CustomFindEntity("Logical_Router_Static_Route", []string{"_uuid"}, filter...)
-					if err != nil {
-						return err
-					}
-
-					for _, route := range result {
-						if util.ContainsString(existingRoutes, route["_uuid"][0]) {
-							return fmt.Errorf(`static route "policy=%s ip_prefix=%s" with different nexthop already exists on logical router %s`, policy, cidrBlock, router)
-						}
-					}
-				}
-
 				if _, err := c.ovnNbCommand(MayExist, fmt.Sprintf("%s=%s", Policy, policy), "lr-route-add", router, cidrBlock, gw); err != nil {
 					return err
 				}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:
Fixes #(issue-number)

Duplicate IP addresses will block LSP creation so there is no need to check static route conflict. This patch fixes the following error:

```txt
static route "policy=src-ip ip_prefix=10.3.0.132" with different nexthop already exists on logical router ovn-cluster, requeuing
```