### PR TITLE
fix arping error log

### DIFF
--- a/pkg/util/arping.go
+++ b/pkg/util/arping.go
@@ -42,11 +42,12 @@ func Arping(nic, srcIP, dstIP string, timeout time.Duration, maxRetry int) (net.
 		return nil, count, fmt.Errorf("failed to set up ARP client: %v", err)
 	}
 
+	var mac net.HardwareAddr
 	for ; count < maxRetry; count++ {
 		if err = client.SetDeadline(time.Now().Add(timeout)); err != nil {
 			continue
 		}
-		if mac, err := client.Resolve(target); err == nil {
+		if mac, err = client.Resolve(target); err == nil {
 			return mac, count + 1, nil
 		}
 	}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:

Fix the missing error in the arping error log:

```txt
gateway 10.252.0.1 is not ready for interface eth0 after 200 checks: resolve MAC address of 10.252.0.1 timeout: <nil>
```

