### PR TITLE
fix: multus macvlan ipvlan use kube-ovn ipam，but  ip not inited in init-ipam

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -367,17 +367,6 @@ func (c *Controller) InitIPAM() error {
 		for _, podNet := range podNets {
 			if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] == "true" {
 				portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
-				if !isAlive && isStsPod {
-					if ipCR := ipsMap[portName]; ipCR != nil && ipCR.Spec.PodType == "" {
-						if _, _, _, err = c.ipam.GetStaticAddress(key, ipCR.Name, ipCR.Spec.IPAddress, ipCR.Spec.MacAddress, ipCR.Spec.Subnet, true); err != nil {
-							klog.Errorf("failed to init IPAM from IP CR %s: %v", ipCR.Name, err)
-						}
-						if err = c.createOrUpdateCrdIPs(podName, ipCR.Spec.IPAddress, ipCR.Spec.MacAddress, ipCR.Spec.Subnet, pod.Namespace, pod.Spec.NodeName, podNet.ProviderName, podType, &ipCR); err != nil {
-							klog.Errorf("failed to create/update ips CR %s.%s with ip address %s: %v", podName, pod.Namespace, ipCR.Spec.IPAddress, err)
-						}
-						continue
-					}
-				}
 				ip := pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)]
 				mac := pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)]
 				subnet := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podNet.ProviderName)]


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

fix: multus macvlan ipvlan use kube-ovn ipam，but  ip not inited in init-ipam
1. fix: ip-list-recovery-ipam skips all non StatefulSet ip and pod-list-recovery-ipam skips non-ovn subnet, which cause nat-gw-pod (other cni using kube-ovn ipam, such as macvlan,ipvlan) lost ipam after kube-ovn-controller crashed



经沟通，大多数ip ipam恢复的数据源以pod为准，ip list 只处理sts ip（包含join ip和业务sts pod ip）

#### Which issue(s) this PR fixes:
Fixes #1840 
