### PR TITLE
fix ovs-ovn logging

### DIFF
--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -21,7 +21,7 @@ if [[ -z "$NODE_IPS" && -z "$LOCAL_IP" ]]; then
     /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
     ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
     ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
-    tail -f /var/log/ovn/ovsdb-server-ic-nb.log
+    tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
 else
     if [[ -z "$LEADER_IP" ]]; then
         echo "leader start with local ${LOCAL_IP} and cluster $(gen_conn_str 6647)"
@@ -35,7 +35,7 @@ else
         /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
         ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
         ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
-        tail -f /var/log/ovn/ovsdb-server-ic-nb.log
+        tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
     else
         echo "follower start with local ${LOCAL_IP}, leader ${LEADER_IP} and cluster $(gen_conn_str 6647)"
         /usr/share/ovn/scripts/ovn-ctl  --db-ic-nb-create-insecure-remote=yes \
@@ -47,6 +47,6 @@ else
         --ovn-ic-nb-db="$(gen_conn_str 6647)" \
         --ovn-ic-sb-db="$(gen_conn_str 6648)" \
         start_ic_ovsdb
-        tail -f /var/log/ovn/ovsdb-server-ic-nb.log
+        tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
     fi
 fi

--- a/dist/images/start-ovs-dpdk-v2.sh
+++ b/dist/images/start-ovs-dpdk-v2.sh
@@ -103,4 +103,4 @@ ovs-vsctl set open . external-ids:ovn-remote-probe-interval=10000
 ovs-vsctl set open . external-ids:ovn-openflow-probe-interval=180
 ovs-vsctl set open . external-ids:ovn-encap-type=geneve
 
-tail -f /var/log/openvswitch/ovs-vswitchd.log
+tail --follow=name --retry /var/log/openvswitch/ovs-vswitchd.log

--- a/dist/images/start-ovs-dpdk.sh
+++ b/dist/images/start-ovs-dpdk.sh
@@ -49,4 +49,4 @@ ovs-vsctl set open . external-ids:ovn-remote-probe-interval=10000
 ovs-vsctl set open . external-ids:ovn-openflow-probe-interval=180
 ovs-vsctl set open . external-ids:ovn-encap-type=geneve
 
-tail -f /var/log/openvswitch/ovs-vswitchd.log
+tail --follow=name --retry /var/log/openvswitch/ovs-vswitchd.log

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -245,4 +245,4 @@ sleep ${FLOW_WAIT}
 ovs-vsctl --no-wait set open_vswitch . other_config:flow-restore-wait="false"
 
 chmod 600 /etc/openvswitch/*
-tail -f /var/log/ovn/ovn-controller.log
+tail --follow=name --retry /var/log/ovn/ovn-controller.log


### PR DESCRIPTION
tail command should follow file name instead of file descriptor


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:

After the log file has been rotated, tail stops printing the log, and still holds the file descriptor:

```txt
tail  8435  root 3r  REG  253,0  17385  67521247 /var/log/ovn/ovn-controller.log.1 (deleted)
```

This patch is part of fixes for #1849.