### PR TITLE
ci: use concurrency to ensure that only a single workflow using the same concurrency group will run at a time

### DIFF
--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -14,6 +14,10 @@ on:
     - 'docs/**'
     - '**.md'
 
+concurrency: 
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 env:
   GO_VERSION: '1.18'
 

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -15,6 +15,10 @@ on:
     - 'docs/**'
     - '**.md'
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 env:
   GO_VERSION: '1.18'
   GOSEC_VERSION: '2.12.0'

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -15,6 +15,10 @@ on:
     - 'docs/**'
     - '**.md'
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 env:
   GO_VERSION: '1.18'
   GOSEC_VERSION: '2.12.0'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron: '0 17 * * 2'
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
@@ -42,7 +46,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 env:
   GO_VERSION: '1.18'
 

--- a/.github/workflows/push-multiarch-image.yaml
+++ b/.github/workflows/push-multiarch-image.yaml
@@ -8,6 +8,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Push multi arch images


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- CI

https://docs.github.com/en/actions/using-jobs/using-concurrency
