### PR TITLE
ovs: fix log file descriptor leak in monitor process

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -18,6 +18,8 @@ RUN cd /usr/src/ && \
     curl -s https://github.com/kubeovn/ovs/commit/24c1b28c416d3a0312c10a9fe9341c04b8b31ce9.patch | git apply && \
     # fix memleak
     curl -s https://github.com/kubeovn/ovs/commit/2dc8e7aa202818952b2fa80b47298604530c9de0.patch | git apply && \
+    # fix log file descriptor leak in monitor process
+    curl -s https://github.com/kubeovn/ovs/commit/918d6dc79634bec760054ee53f7628186315bcfb.patch | git apply && \
     # increase election timer
     curl -s https://github.com/kubeovn/ovs/commit/22ea22c40b46ee5adeae977ff6cfca81b3ff25d7.patch | git apply && \
     # compile without avx512


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:

This patch is part of fixes of #1849.
