### PR TITLE
sec: conform to Gosec [G114](https://github.com/securego/gosec\#avail…

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -49,7 +49,14 @@ func CmdMain() {
 			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 		}
-		klog.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", config.PprofPort), mux))
+
+		// conform to Gosec G114
+		// https://github.com/securego/gosec#available-rules
+		server := &http.Server{
+			Addr:        fmt.Sprintf("0.0.0.0:%d", config.PprofPort),
+			ReadTimeout: 3 * time.Second,
+		}
+		klog.Fatal(server.ListenAndServe())
 	}()
 
 	ctl := controller.NewController(config)

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -53,8 +53,8 @@ func CmdMain() {
 		// conform to Gosec G114
 		// https://github.com/securego/gosec#available-rules
 		server := &http.Server{
-			Addr:        fmt.Sprintf("0.0.0.0:%d", config.PprofPort),
-			ReadTimeout: 3 * time.Second,
+			Addr:              fmt.Sprintf("0.0.0.0:%d", config.PprofPort),
+			ReadHeaderTimeout: 3 * time.Second,
 		}
 		klog.Fatal(server.ListenAndServe())
 	}()

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -55,6 +55,7 @@ func CmdMain() {
 		server := &http.Server{
 			Addr:              fmt.Sprintf("0.0.0.0:%d", config.PprofPort),
 			ReadHeaderTimeout: 3 * time.Second,
+			Handler:           mux,
 		}
 		klog.Fatal(server.ListenAndServe())
 	}()

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -100,6 +100,7 @@ func CmdMain() {
 	server := &http.Server{
 		Addr:              fmt.Sprintf("0.0.0.0:%d", config.PprofPort),
 		ReadHeaderTimeout: 3 * time.Second,
+		Handler:           mux,
 	}
 	klog.Fatal(server.ListenAndServe())
 }

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -94,7 +94,14 @@ func CmdMain() {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
-	klog.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", config.PprofPort), mux))
+
+	// conform to Gosec G114
+	// https://github.com/securego/gosec#available-rules
+	server := &http.Server{
+		Addr:              fmt.Sprintf("0.0.0.0:%d", config.PprofPort),
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	klog.Fatal(server.ListenAndServe())
 }
 
 func mvCNIConf(configDir, configFile, confName string) error {

--- a/cmd/ovn_monitor/ovn_monitor.go
+++ b/cmd/ovn_monitor/ovn_monitor.go
@@ -2,6 +2,7 @@ package ovn_monitor
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
@@ -28,5 +29,12 @@ func CmdMain() {
 
 	http.Handle(config.MetricsPath, promhttp.Handler())
 	klog.Infoln("Listening on", config.ListenAddress)
-	klog.Fatal(http.ListenAndServe(config.ListenAddress, nil))
+
+	// conform to Gosec G114
+	// https://github.com/securego/gosec#available-rules
+	server := &http.Server{
+		Addr:              config.ListenAddress,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	klog.Fatal(server.ListenAndServe())
 }

--- a/cmd/pinger/pinger.go
+++ b/cmd/pinger/pinger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof" // #nosec
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
@@ -26,7 +27,13 @@ func CmdMain() {
 	if config.Mode == "server" {
 		http.Handle("/metrics", promhttp.Handler())
 		go func() {
-			klog.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", config.Port), nil))
+			// conform to Gosec G114
+			// https://github.com/securego/gosec#available-rules
+			server := &http.Server{
+				Addr:              fmt.Sprintf("0.0.0.0:%d", config.Port),
+				ReadHeaderTimeout: 3 * time.Second,
+			}
+			klog.Fatal(server.ListenAndServe())
 		}()
 	}
 	e := pinger.NewExporter(config)

--- a/cmd/speaker/speaker.go
+++ b/cmd/speaker/speaker.go
@@ -3,6 +3,7 @@ package speaker
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
@@ -26,7 +27,14 @@ func CmdMain() {
 
 	go func() {
 		http.Handle("/metrics", promhttp.Handler())
-		klog.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", config.PprofPort), nil))
+
+		// conform to Gosec G114
+		// https://github.com/securego/gosec#available-rules
+		server := &http.Server{
+			Addr:              fmt.Sprintf("0.0.0.0:%d", config.PprofPort),
+			ReadHeaderTimeout: 3 * time.Second,
+		}
+		klog.Fatal(server.ListenAndServe())
 	}()
 
 	ctl.Run(stopCh)


### PR DESCRIPTION


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- sec: this cli listen http server conform to Gosec ![G114](https://github.com/securego/gosec#available-rules)

#### Which issue(s) this PR fixes:
Fixes (#1859 )
