### PR TITLE
delete log severity for drop acl when update networkpolicy

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/pprof" // #nosec
+	"os"
 	"strings"
 	"time"
 
@@ -92,11 +92,11 @@ func CmdMain() {
 }
 
 func mvCNIConf() error {
-	data, err := ioutil.ReadFile("/kube-ovn/01-kube-ovn.conflist")
+	data, err := os.ReadFile("/kube-ovn/01-kube-ovn.conflist")
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile("/etc/cni/net.d/01-kube-ovn.conflist", data, 0444)
+	return os.WriteFile("/etc/cni/net.d/01-kube-ovn.conflist", data, 0444)
 }
 
 func Retry(attempts int, sleep int, f func(configuration *daemon.Configuration) error, ctrl *daemon.Configuration) (err error) {
@@ -114,7 +114,7 @@ func Retry(attempts int, sleep int, f func(configuration *daemon.Configuration) 
 }
 
 func initChassisAnno(cfg *daemon.Configuration) error {
-	chassisID, err := ioutil.ReadFile(util.ChassisLoc)
+	chassisID, err := os.ReadFile(util.ChassisLoc)
 	if err != nil {
 		klog.Errorf("read chassis file failed, %v", err)
 		return err

--- a/pkg/ovnmonitor/util.go
+++ b/pkg/ovnmonitor/util.go
@@ -2,7 +2,7 @@ package ovnmonitor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -42,7 +42,7 @@ func (e *Exporter) getOvnStatus() map[string]int {
 	result["ovsdb-server-southbound"] = parseDbStatus(string(output))
 
 	// get ovn-northd status
-	pid, err := ioutil.ReadFile("/var/run/ovn/ovn-northd.pid")
+	pid, err := os.ReadFile("/var/run/ovn/ovn-northd.pid")
 	if err != nil {
 		klog.Errorf("read ovn-northd pid failed, err %v", err)
 		result["ovn-northd"] = 0

--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -1161,7 +1161,7 @@ func (c Client) CreateIngressACL(pgName, asIngressName, asExceptName, svcAsName,
 	if logEnable {
 		ovnArgs = []string{MayExist, "--type=port-group", "--log", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "to-lport", util.IngressDefaultDrop, fmt.Sprintf("%s.dst == $%s", ipSuffix, pgAs), "drop"}
 	} else {
-		ovnArgs = []string{MayExist, "--type=port-group", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "to-lport", util.IngressDefaultDrop, fmt.Sprintf("%s.dst == $%s", ipSuffix, pgAs), "drop"}
+		ovnArgs = []string{MayExist, "--type=port-group", "acl-add", pgName, "to-lport", util.IngressDefaultDrop, fmt.Sprintf("%s.dst == $%s", ipSuffix, pgAs), "drop"}
 	}
 
 	if len(npp) == 0 {
@@ -1192,7 +1192,7 @@ func (c Client) CreateEgressACL(pgName, asEgressName, asExceptName, protocol str
 	if logEnable {
 		ovnArgs = []string{"--", MayExist, "--type=port-group", "--log", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "from-lport", util.EgressDefaultDrop, fmt.Sprintf("%s.src == $%s", ipSuffix, pgAs), "drop"}
 	} else {
-		ovnArgs = []string{"--", MayExist, "--type=port-group", fmt.Sprintf("--severity=%s", "warning"), "acl-add", pgName, "from-lport", util.EgressDefaultDrop, fmt.Sprintf("%s.src == $%s", ipSuffix, pgAs), "drop"}
+		ovnArgs = []string{"--", MayExist, "--type=port-group", "acl-add", pgName, "from-lport", util.EgressDefaultDrop, fmt.Sprintf("%s.src == $%s", ipSuffix, pgAs), "drop"}
 	}
 	if len(npp) == 0 {
 		allowArgs = []string{"--", MayExist, "--type=port-group", "acl-add", pgName, "from-lport", util.EgressAllowPriority, fmt.Sprintf("%s.dst == $%s && %s.dst != $%s && %s.src == $%s", ipSuffix, asEgressName, ipSuffix, asExceptName, ipSuffix, pgAs), "allow-related"}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Bug fixes

####
1、It does not work when just delete --log parameter to ignore acl log.  The affected version is ovn 20.03 and kube-ovn v1.8
2、The  --log work in kube-ovn v1.9 and later where ovn is 20.06.

#### Which issue(s) this PR fixes:
Fixes #1603 
