### PR TITLE
fix setting ether dst addr for dnat

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -43,7 +43,7 @@ RUN cd /usr/src/ && git clone -b branch-22.03 --depth=1 https://github.com/ovn-o
     # change hash type from dp_hash to hash with field src_ip
     curl -s https://github.com/kubeovn/ovn/commit/ab923b252271cbbcccc8091e338ee7efe75e5fcd.patch | git apply && \
     # set ether dst addr for dnat on logical switch
-    curl -s https://github.com/kubeovn/ovn/commit/f6217e2c1d9a24eb4595c75727202daf05dadc85.patch | git apply && \
+    curl -s https://github.com/kubeovn/ovn/commit/58a40438926745dfdd498c09ea71e1746b803a42.patch | git apply && \
     sed -i 's/OVN/ovn/g' debian/changelog && \
     rm -rf .git && \
     ./boot.sh && \


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:
Fixes #1880 

Match `!ct.dnat` does not work as expected somehow, so replace it with `reg0[2] == 0`.

Now `tc filter show dev 5baa642db970_h ingress` shows the offloaded flows.