### PR TITLE
kubectl-ko: turn off pipefail for ovn leader check

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -391,7 +391,9 @@ xxctl(){
 
 checkLeader(){
   component="$1"; shift
+  set +o pipefail
   count=$(kubectl get ep ovn-$component -n $KUBE_OVN_NS -o yaml | grep ip | wc -l)
+  set -o pipefail
   if [ $count -eq 0 ]; then
     echo "no ovn-$component exists !!"
     exit 1


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:

If an OVN endpoint contains no IP address, the plugin will exit without any message.
