### PR TITLE
fix: failed to add eip

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -113,7 +113,7 @@ function add_eip() {
         # gw may lost, even if add_vpc_external_route add route successfully
         exec_cmd "ip route replace default via $gateway dev net1"
         ip route | grep "default via $gateway dev net1"
-        exec_cmd "arping -c 3 -s $eip_without_prefix $gateway"
+        exec_cmd "arping -I net1 -c 3 -D $eip_without_prefix"
     done
 }
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
add eip所使用的arping -s遇到arp回多个包，会造成eip创建失败。




#### Which issue(s) 
在我使用的环境中，出现arp代答（arping 一个包发出会出现2个同样的回包），造成了eip创建失败。

this PR fixes:
使用arping -D 参数代替arping -s

```
[root@hci-dev-mst-1 ~]# arping --help
arping: invalid option -- '-'
Usage: arping [-fqbDUAV] [-c count] [-w timeout] [-I device] [-s source] destination
  -D : duplicate address detection mode
  -s source : source ip address
```

The -D option specifies duplicate address detection mode (DAD). It returns exit status 0, if DAD succeeded i.e. no replies are received.

