### PR TITLE
fix: eip and nat crd can delete even if nat gw pod deleted and ipatab…

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -227,11 +227,7 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) error {
 	c.vpcNatGwKeyMutex.Lock(key)
 	defer c.vpcNatGwKeyMutex.Unlock(key)
 	if vpcNatEnabled != "true" {
-		// wait and check again
-		time.Sleep(10 * time.Second)
-		if vpcNatEnabled != "true" {
-			return fmt.Errorf("failed to addOrUpdateVpcNatGw, vpcNatEnabled='%s'", vpcNatEnabled)
-		}
+		return fmt.Errorf("iptables nat gw not enable")
 	}
 	gw, err := c.vpcNatGatewayLister.Get(key)
 	if err != nil {
@@ -309,10 +305,7 @@ func (c *Controller) syncVpcNatGwRules(key string) error {
 
 func (c *Controller) handleInitVpcNatGw(key string) error {
 	if vpcNatEnabled != "true" {
-		time.Sleep(10 * time.Second)
-		if vpcNatEnabled != "true" {
-			return fmt.Errorf("failed init vpc nat gateway, vpcNatEnabled='%s'", vpcNatEnabled)
-		}
+		return fmt.Errorf("iptables nat gw not enable")
 	}
 	c.vpcNatGwKeyMutex.Lock(key)
 	defer c.vpcNatGwKeyMutex.Unlock(key)
@@ -368,10 +361,7 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 
 func (c *Controller) handleUpdateVpcFloatingIp(natGwKey string) error {
 	if vpcNatEnabled != "true" {
-		time.Sleep(10 * time.Second)
-		if vpcNatEnabled != "true" {
-			return fmt.Errorf("failed to update vpc floatingIp, vpcNatEnabled='%s'", vpcNatEnabled)
-		}
+		return fmt.Errorf("iptables nat gw not enable")
 	}
 	c.vpcNatGwKeyMutex.Lock(natGwKey)
 	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
@@ -403,10 +393,7 @@ func (c *Controller) handleUpdateVpcFloatingIp(natGwKey string) error {
 
 func (c *Controller) handleUpdateVpcEip(natGwKey string) error {
 	if vpcNatEnabled != "true" {
-		time.Sleep(10 * time.Second)
-		if vpcNatEnabled != "true" {
-			return fmt.Errorf("failed to update vpc eip, vpcNatEnabled='%s'", vpcNatEnabled)
-		}
+		return fmt.Errorf("iptables nat gw not enable")
 	}
 	c.vpcNatGwKeyMutex.Lock(natGwKey)
 	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
@@ -435,10 +422,7 @@ func (c *Controller) handleUpdateVpcEip(natGwKey string) error {
 
 func (c *Controller) handleUpdateVpcSnat(natGwKey string) error {
 	if vpcNatEnabled != "true" {
-		time.Sleep(10 * time.Second)
-		if vpcNatEnabled != "true" {
-			return fmt.Errorf("failed to update vpc snat, vpcNatEnabled='%s'", vpcNatEnabled)
-		}
+		return fmt.Errorf("iptables nat gw not enable")
 	}
 	c.vpcNatGwKeyMutex.Lock(natGwKey)
 	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
@@ -467,10 +451,7 @@ func (c *Controller) handleUpdateVpcSnat(natGwKey string) error {
 
 func (c *Controller) handleUpdateVpcDnat(natGwKey string) error {
 	if vpcNatEnabled != "true" {
-		time.Sleep(10 * time.Second)
-		if vpcNatEnabled != "true" {
-			return fmt.Errorf("failed update vpc dnat, vpcNatEnabled='%s'", vpcNatEnabled)
-		}
+		return fmt.Errorf("iptables nat gw not enable")
 	}
 	c.vpcNatGwKeyMutex.Lock(natGwKey)
 	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
@@ -500,10 +481,7 @@ func (c *Controller) handleUpdateVpcDnat(natGwKey string) error {
 
 func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 	if vpcNatEnabled != "true" {
-		time.Sleep(10 * time.Second)
-		if vpcNatEnabled != "true" {
-			return fmt.Errorf("failed to update subnet route, vpcNatEnabled='%s'", vpcNatEnabled)
-		}
+		return fmt.Errorf("iptables nat gw not enable")
 	}
 	c.vpcNatGwKeyMutex.Lock(natGwKey)
 	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
@@ -734,8 +712,7 @@ func (c *Controller) getNatGwPod(name string) (*corev1.Pod, error) {
 	if err != nil {
 		return nil, err
 	} else if len(pods) == 0 {
-		time.Sleep(2 * time.Second)
-		return nil, fmt.Errorf("pod '%s' not exist", name)
+		return nil, k8serrors.NewNotFound(v1.Resource("pod"), name)
 	} else if len(pods) != 1 {
 		time.Sleep(5 * time.Second)
 		return nil, fmt.Errorf("too many pod")

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -285,9 +285,6 @@ func (c *Controller) syncVpcNatGwRules(key string) error {
 	// sync all nat crd
 	pod, err := c.getNatGwPod(key)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 
@@ -325,9 +322,6 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 
 	oriPod, err := c.getNatGwPod(key)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 	pod := oriPod.DeepCopy()
@@ -487,17 +481,11 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
 	gw, err := c.vpcNatGatewayLister.Get(natGwKey)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 
 	oriPod, err := c.getNatGwPod(natGwKey)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 	pod := oriPod.DeepCopy()
@@ -740,9 +728,6 @@ func (c *Controller) initCreateAt(key string) (err error) {
 	}
 	pod, err := c.getNatGwPod(key)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 	NAT_GW_CREATED_AT = pod.CreationTimestamp.Format("2006-01-02T15:04:05")

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -534,9 +534,6 @@ func (c *Controller) GetEip(eipName string) (*kubeovnv1.IptablesEIP, error) {
 func (c *Controller) createEipInPod(dp, gw, v4Cidr string) error {
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 	var addRules []string

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -1502,9 +1502,6 @@ func (c *Controller) redoSnat(key, redo string, eipReady bool) error {
 func (c *Controller) createFipInPod(dp, v4ip, internalIP string) error {
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 	var addRules []string


### PR DESCRIPTION
fix: should delete eip nat successfully after disable nat gw| delete nat gw pod
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Bug fixes

Fixes #1888 