### PR TITLE
update ns annotation when subnet cidr changed

### DIFF
--- a/pkg/controller/namespace.go
+++ b/pkg/controller/namespace.go
@@ -180,7 +180,9 @@ func (c *Controller) handleAddNamespace(key string) error {
 	if namespace.Annotations == nil || len(namespace.Annotations) == 0 {
 		namespace.Annotations = map[string]string{}
 	} else {
-		if namespace.Annotations[util.LogicalSwitchAnnotation] == strings.Join(lss, ",") {
+		if namespace.Annotations[util.LogicalSwitchAnnotation] == strings.Join(lss, ",") &&
+			namespace.Annotations[util.CidrAnnotation] == strings.Join(cidrs, ";") &&
+			namespace.Annotations[util.ExcludeIpsAnnotation] == strings.Join(excludeIps, ";") {
 			return nil
 		}
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -976,7 +976,8 @@ func (c *Controller) reconcileNamespaces(subnet *kubeovnv1.Subnet) error {
 	}
 
 	for _, ns := range namespaces {
-		if ns.Annotations != nil && !util.ContainsString(subnet.Spec.Namespaces, ns.Name) && util.ContainsString(strings.Split(ns.Annotations[util.LogicalSwitchAnnotation], ","), subnet.Name) {
+		// when subnet cidr changed, the ns annotation with the subnet should be updated
+		if ns.Annotations != nil && util.ContainsString(strings.Split(ns.Annotations[util.LogicalSwitchAnnotation], ","), subnet.Name) {
 			c.addNamespaceQueue.Add(ns.Name)
 		}
 	}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Features
- Bug fixes

####
1、when subnet cidr changed, the ns  annotaiton should be updated with subnet


#### Which issue(s) this PR fixes:
Fixes #(issue-number)
