### PR TITLE
fix: pod mistaken ls label

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1094,7 +1094,7 @@ func (c *Controller) reconcileOvnRoute(subnet *kubeovnv1.Subnet) error {
 				podNets, err := c.getPodKubeovnNets(pod)
 				if err != nil {
 					klog.Errorf("failed to get pod nets %v", err)
-					return err
+					continue
 				}
 
 				podPorts := make([]string, 0, 1)


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes

In very rare cases, subnets may be deleted forcibly(e.g., manually remove finalizer).
Then a running pod labeled with deleted subnet will block the creation of a new subnet.
This pr fix this problem.

#### Which issue(s) this PR fixes:
Fixes #1911 
