### PR TITLE
fix underlay e2e testing

### DIFF
--- a/pkg/daemon/init_linux.go
+++ b/pkg/daemon/init_linux.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"syscall"
+
 	"k8s.io/klog/v2"
 
 	"github.com/Wifx/gonetworkmanager"
@@ -105,7 +107,7 @@ func changeProvideNicName(current, target string) (bool, error) {
 				continue
 			}
 			if route.Scope == scope {
-				if err = netlink.RouteReplace(&route); err != nil {
+				if err = netlink.RouteReplace(&route); err != nil && err != syscall.EEXIST {
 					klog.Errorf("failed to replace route %s: %v", route.String(), err)
 					return false, err
 				}

--- a/test/e2e/underlay/underlay.go
+++ b/test/e2e/underlay/underlay.go
@@ -197,7 +197,10 @@ var _ = Describe("[Underlay]", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
+			By("wait provider network to be ready")
 			time.Sleep(3 * time.Second)
+			err = f.WaitProviderNetworkReady(ProviderNetwork)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("validate provider network")
 			pn, err := f.OvnClientSet.KubeovnV1().ProviderNetworks().Get(context.Background(), ProviderNetwork, metav1.GetOptions{})
@@ -221,6 +224,11 @@ var _ = Describe("[Underlay]", func() {
 			newPn := pn.DeepCopy()
 			newPn.Spec.ExcludeNodes = nil
 			_, err = f.OvnClientSet.KubeovnV1().ProviderNetworks().Update(context.Background(), newPn, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("wait provider network to be ready")
+			time.Sleep(3 * time.Second)
+			err = f.WaitProviderNetworkReady(ProviderNetwork)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes/Tests


#### Which issue(s) this PR fixes:
Fixes #(issue-number)

Sometimes `netlink.RouteReplace()` returns error causing the underlay testing failure:

```txt
init_linux.go:67] change nic name from br-net1 to eth1
init_linux.go:109] failed to replace route {Ifindex: 15 Dst: 172.17.0.0/16 Src: 172.17.0.3 Gw: <nil> Flags: [] Table: 254 Realm: 0}: file exists
init.go:233] failed to change provider nic name from br-net1 to eth1: file exists
controller.go:190] error syncing 'net1': file exists, requeuing
```

We should ignore the returned `syscall.EEXIST` error.