### PR TITLE
fix: add  default deny acl

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -394,6 +394,13 @@ jobs:
           sudo chmod -R 777 /home/runner/.kube/
           make e2e-underlay-single-nic
 
+      - name: Run networkpolicy E2E
+        working-directory: test/networkpolicy-cyclonus/
+        run: |
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          bash ./start-test.sh
+
       - name: Cleanup
         run: |
           sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
@@ -556,6 +563,13 @@ jobs:
           sudo chmod -R 777 /home/runner/.kube/
           make e2e
 
+      - name: Run networkpolicy E2E
+        working-directory: test/networkpolicy-cyclonus/
+        run: |
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          bash ./start-test.sh
+
       - name: Cleanup
         run: |
           sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
@@ -565,7 +579,7 @@ jobs:
     needs: build-kube-ovn
     name: ipv6-e2e
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
 
@@ -626,6 +640,13 @@ jobs:
           sudo cp -r /root/.kube/ /home/runner/.kube/
           sudo chmod -R 777 /home/runner/.kube/
           make e2e-ipv6
+
+      - name: Run networkpolicy E2E
+        working-directory: test/networkpolicy-cyclonus/
+        run: |
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          bash ./start-test.sh
 
       - name: Cleanup
         run: |
@@ -769,6 +790,13 @@ jobs:
           sudo chmod -R 777 /home/runner/.kube/
           make e2e-underlay-single-nic
 
+      - name: Run networkpolicy E2E
+        working-directory: test/networkpolicy-cyclonus/
+        run: |
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          bash ./start-test.sh
+
       - name: Cleanup
         run: |
           sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
@@ -856,6 +884,13 @@ jobs:
           sudo chmod -R 777 /home/runner/.kube/
           make e2e
 
+      - name: Run networkpolicy E2E
+        working-directory: test/networkpolicy-cyclonus/
+        run: |
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          bash ./start-test.sh
+
       - name: Cleanup
         run: |
           sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
@@ -865,7 +900,7 @@ jobs:
     needs: build-kube-ovn
     name: dual-stack-underlay-e2e-single-nic
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
 
@@ -927,6 +962,13 @@ jobs:
           sudo chmod -R 777 /home/runner/.kube/
           make e2e-underlay-single-nic
 
+      - name: Run networkpolicy E2E
+        working-directory: test/networkpolicy-cyclonus/
+        run: |
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          bash ./start-test.sh
+
       - name: Cleanup
         run: |
           sh -c 'while :; do if [ $(kubectl get --no-headers subnet | wc -l) -eq 2 ]; then break; fi; sleep 5; done'
@@ -952,7 +994,7 @@ jobs:
     needs: build-kube-ovn
     name: dual-stack-underlay-logical-gateway-e2e
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
 
@@ -1013,6 +1055,13 @@ jobs:
           sudo cp -r /root/.kube/ /home/runner/.kube/
           sudo chmod -R 777 /home/runner/.kube/
           make e2e
+
+      - name: Run networkpolicy E2E
+        working-directory: test/networkpolicy-cyclonus/
+        run: |
+          sudo cp -r /root/.kube/ /home/runner/.kube/
+          sudo chmod -R 777 /home/runner/.kube/
+          bash ./start-test.sh
 
       - name: Cleanup
         run: |

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -313,6 +313,11 @@ func (c *Controller) handleUpdateNp(key string) error {
 						klog.Errorf("failed to create ingress acls for np %s, %v", key, err)
 						return err
 					}
+				} else {
+					if err = c.ovnLegacyClient.CreateIngressACL(pgName, ingressAllowAsName, ingressExceptAsName, svcAsName, protocol, []netv1.NetworkPolicyPort{}, logEnable); err != nil {
+						klog.Errorf("failed to create default deny all ingress acls for np %s, %v", key, err)
+						return err
+					}
 				}
 			}
 			if len(np.Spec.Ingress) == 0 {

--- a/test/networkpolicy-cyclonus/cyclonus.yaml
+++ b/test/networkpolicy-cyclonus/cyclonus.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cyclonus
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - command:
+            - ./cyclonus
+            - generate
+            - --exclude=
+            - --include=upstream-e2e
+            - --retries=3
+            - --noisy=true
+            - --ignore-loopback=true
+            - --cleanup-namespaces=true
+            - --server-port=80
+            - --server-protocol=tcp
+          name: cyclonus
+          imagePullPolicy: IfNotPresent
+          image: mfenwick100/cyclonus:v0.5.0
+      serviceAccount: cyclonus

--- a/test/networkpolicy-cyclonus/start-test.sh
+++ b/test/networkpolicy-cyclonus/start-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -xv
+
+# set up cyclonus
+kubectl create clusterrolebinding cyclonus --clusterrole=cluster-admin --serviceaccount=kube-system:cyclonus
+kubectl create sa cyclonus -n kube-system
+kubectl create -f ./cyclonus.yaml
+
+# don't fail on errors, so we can dump the logs.
+set +e
+
+time kubectl wait --for=condition=complete --timeout=60m -n kube-system job.batch/cyclonus
+rc=$?
+
+# grab the job logs
+LOG_FILE=$(mktemp)
+kubectl logs -n kube-system job.batch/cyclonus > "$LOG_FILE"
+cat "$LOG_FILE"
+
+# if 'failure' is in the logs, fail; otherwise succeed
+cat "$LOG_FILE" | grep "failure" > /dev/null 2>&1 && rc=1
+exit $rc


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes

When the LabelSelector in ingress of NetworkPolicy could not match any pods, then all the data streams should be blocked.
But due to the `allow` and `except` is 0 then a default deny all ACL is not created.
Now the bug is fixed.
Besides, a networkpolicy e2e based on cyclonus is also added in tests.

#### Which issue(s) this PR fixes:
Fixes #1920  #1877 