### PR TITLE
set ovsdb-server vlog level to avoid warnings caused by ovs-vsctl

### DIFF
--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -72,6 +72,11 @@ else
   ovs-vsctl --no-wait set open_vswitch . other_config:hw-offload=false
 fi
 
+# avoid warnings caused by ovs-vsctl
+ovsdb_server_ctl="/var/run/openvswitch/ovsdb-server.$(cat /var/run/openvswitch/ovsdb-server.pid).ctl"
+ovs-appctl -t "$ovsdb_server_ctl" vlog/set jsonrpc:file:err
+ovs-appctl -t "$ovsdb_server_ctl" vlog/set reconnect:file:err
+
 function exchange_link_names() {
   mappings=($(ovs-vsctl --if-exists get open . external-ids:ovn-bridge-mappings | tr -d '"' | tr ',' ' '))
   bridges=($(ovs-vsctl --no-heading --columns=name find bridge external-ids:vendor=kube-ovn external-ids:exchange-link-name=true))


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:
Fixes #1913 
