### PR TITLE
fix: create lr-policy-route for serviceCidr and localDNS

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -49,6 +49,7 @@ type Configuration struct {
 	NodeSwitch        string
 	NodeSwitchCIDR    string
 	NodeSwitchGateway string
+	NodeLocalDNS      string
 
 	ServiceClusterIPRange string
 
@@ -112,6 +113,7 @@ func ParseFlags() (*Configuration, error) {
 		argNodeSwitch        = pflag.String("node-switch", "join", "The name of node gateway switch which help node to access pod network")
 		argNodeSwitchCIDR    = pflag.String("node-switch-cidr", "100.64.0.0/16", "The cidr for node switch")
 		argNodeSwitchGateway = pflag.String("node-switch-gateway", "", "The gateway for node switch (default the first ip in node-switch-cidr)")
+		argNodeLocalDNS      = pflag.String("node-localdns", "", "The Ip for node local DNS")
 
 		argServiceClusterIPRange = pflag.String("service-cluster-ip-range", "10.96.0.0/12", "The kubernetes service cluster ip range")
 
@@ -184,6 +186,7 @@ func ParseFlags() (*Configuration, error) {
 		NodeSwitch:                    *argNodeSwitch,
 		NodeSwitchCIDR:                *argNodeSwitchCIDR,
 		NodeSwitchGateway:             *argNodeSwitchGateway,
+		NodeLocalDNS:                  *argNodeLocalDNS,
 		ServiceClusterIPRange:         *argServiceClusterIPRange,
 		ClusterTcpLoadBalancer:        *argClusterTcpLoadBalancer,
 		ClusterUdpLoadBalancer:        *argClusterUdpLoadBalancer,


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes

create lr-policy-route for serviceCidr when disable lb.
we had created port-group for all ports on node. like $node.<node_name>_ip4.
we know all serivce-cidr from controller config.
then when lb disabled, create lr-policy-route:
```
30000 ip4.src == $node.<node_name>_ip4 && ip4.dst == 10.96.0.0/12         reroute                <node-joinipv4>
30000 ip6.src == $node.<node_name>_ip6 && ip6.dst == dd:10:96::/112         reroute             <node-joinipv6>
```

when we create pod, port of pod will be added to port-group(node.<node_name>_ip4 or node.<node_name>_ip6). then will return to node though join subnet.

#### Which issue(s) this PR fixes:
Fixes #1789 
