### PR TITLE
ovs: add fdb update logging

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -22,6 +22,8 @@ RUN cd /usr/src/ && \
     curl -s https://github.com/kubeovn/ovs/commit/918d6dc79634bec760054ee53f7628186315bcfb.patch | git apply && \
     # increase election timer
     curl -s https://github.com/kubeovn/ovs/commit/22ea22c40b46ee5adeae977ff6cfca81b3ff25d7.patch | git apply && \
+    # add fdb update logging
+    curl -s https://github.com/kubeovn/ovs/commit/8c2f28b778129161bbf8f0738fa41d385860d5bc.patch | git apply && \
     # compile without avx512
     if [ "$ARCH" = "amd64" -a "$NO_AVX512" = "true" ]; then curl -s https://github.com/kubeovn/ovs/commit/38c59e078d69b343f56ab0f380fb9f42b94b7c02.patch | git apply; fi && \
     ./boot.sh && \

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -25,7 +25,7 @@ RUN cd /usr/src/ && \
     # add fdb update logging
     curl -s https://github.com/kubeovn/ovs/commit/8c2f28b778129161bbf8f0738fa41d385860d5bc.patch | git apply && \
     # compile without avx512
-    if [ "$ARCH" = "amd64" -a "$NO_AVX512" = "true" ]; then curl -s https://github.com/kubeovn/ovs/commit/38c59e078d69b343f56ab0f380fb9f42b94b7c02.patch | git apply; fi && \
+    if [ "$ARCH" = "amd64" -a "$NO_AVX512" = "true" ]; then curl -s https://github.com/kubeovn/ovs/commit/c257b0794b827cfae9660a9f3238bee8a29e7676.patch | git apply; fi && \
     ./boot.sh && \
     rm -rf .git && \
     CONFIGURE_OPTS='' && \


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Logging


#### Which issue(s) this PR fixes:
Fixes #(issue-number)

With this patch, ovs-vswitchd will log all fdb changes:

```txt
2022-09-29T04:04:29.248Z|00056|bridge|INFO|bridge br-int: added interface 68a94f7125f5_h on port 7
2022-09-29T04:04:29.355Z|00006|ofproto_dpif_xlate(handler1)|DBG|bridge br-net1: learned that 00:00:00:2a:9f:6b is on port patch-localnet.underlay-to-br-int in VLAN 0
2022-09-29T04:04:29.355Z|00007|ofproto_dpif_xlate(handler1)|DBG|bridge br-net1: learned that 00:00:00:2a:9f:6b is on port eth1 in VLAN 0
2022-09-29T04:04:29.357Z|00008|ofproto_dpif_xlate(handler1)|DBG|bridge br-net1: learned that 00:00:00:2a:9f:6b is on port patch-localnet.underlay-to-br-int in VLAN 0
2022-09-29T04:04:29.357Z|00009|ofproto_dpif_xlate(handler1)|DBG|bridge br-net1: learned that 00:00:00:2a:9f:6b is on port eth1 in VLAN 0
2022-09-29T04:04:30.154Z|00007|ofproto_dpif_xlate(handler2)|DBG|bridge br-net1: learned that 00:00:00:2a:9f:6b is on port patch-localnet.underlay-to-br-int in VLAN 0
2022-09-29T04:04:30.156Z|00010|ofproto_dpif_xlate(handler1)|DBG|bridge br-net1: learned that 00:00:00:2a:9f:6b is on port eth1 in VLAN 0
```