### PR TITLE
add chart version check when upgrade ovs-ovn pod

### DIFF
--- a/dist/images/upgrade-ovs.sh
+++ b/dist/images/upgrade-ovs.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+dsChartVer=`kubectl get ds -n kube-system ovs-ovn -o jsonpath={.metadata.annotations.chart-version}`
 podNames=`kubectl get pod -n kube-system | grep ovs-ovn | awk '{print $1}'`
 for pod in $podNames
 do
+  podChartVer=`kubectl get pod -n kube-system $pod -o jsonpath={.metadata.annotations.chart-version}`
+  if [ $dsChartVer == $podChartVer ]
+  then
+    echo "pod $pod alreay upgraded"
+    continue
+  fi
   echo "upgrade pod $pod"
   kubectl delete pod -n kube-system $pod
 
@@ -18,6 +25,6 @@ do
     readyNum=$(kubectl get daemonset -n kube-system | grep ovs-ovn | awk {'print $4'})
     availableNum=$(kubectl get daemonset -n kube-system | grep ovs-ovn | awk {'print $6'})
     echo "ovs-ovn upgrade, desire $desireNum, current $currentNum, ready $readyNum, available $availableNum"
-    sleep 1
+    sleep 0.5
   done
 done


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Bug fixes

####
1、upgrade ovs-ovn pod one by one when upgrade in acp，the total time is long and reach the limit of sentry，so the post-upgrade job is rebuild. Add check to ignore this situation.

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
