### PR TITLE
feature: support default vpc use nat gw pod as cust vpc

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -66,6 +66,16 @@ func (c *Controller) InitDefaultVpc() error {
 	if err != nil {
 		cachedVpc = &kubeovnv1.Vpc{}
 		cachedVpc.Name = util.DefaultVpc
+		// default vpc created by kube-ovn and support update later
+		if cachedVpc.Spec.StaticRoutes == nil {
+			nodeStaticRoute := kubeovnv1.StaticRoute{
+				Policy:    kubeovnv1.PolicyDst,
+				CIDR:      "0.0.0.0/0,::/0",
+				NextHopIP: c.config.NodeSwitchGateway,
+			}
+			cachedVpc.Spec.StaticRoutes = make([]*kubeovnv1.StaticRoute, 0, 1)
+			cachedVpc.Spec.StaticRoutes = append(cachedVpc.Spec.StaticRoutes, &nodeStaticRoute)
+		}
 		cachedVpc, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Create(context.Background(), cachedVpc, metav1.CreateOptions{})
 		if err != nil {
 			klog.Errorf("init default vpc failed: %v", err)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -734,7 +734,7 @@ func (c *Controller) handleDeleteRoute(subnet *kubeovnv1.Subnet) error {
 		}
 		return err
 	}
-	return c.deleteStaticRoute(subnet.Spec.CIDRBlock, vpc.Status.Router, subnet)
+	return c.deleteStaticRoute(subnet.Spec.CIDRBlock, vpc.Status.Router)
 }
 
 func (c *Controller) handleDeleteLogicalSwitch(key string) (err error) {
@@ -1006,13 +1006,13 @@ func (c *Controller) reconcileOvnRoute(subnet *kubeovnv1.Subnet) error {
 	if subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway {
 		for _, pod := range pods {
 			if pod.Annotations[util.LogicalSwitchAnnotation] == subnet.Name && pod.Annotations[util.IpAddressAnnotation] != "" {
-				if err := c.deleteStaticRoute(pod.Annotations[util.IpAddressAnnotation], c.config.ClusterRouter, subnet); err != nil {
+				if err := c.deleteStaticRoute(pod.Annotations[util.IpAddressAnnotation], c.config.ClusterRouter); err != nil {
 					return err
 				}
 			}
 		}
 
-		if err := c.deleteStaticRoute(subnet.Spec.CIDRBlock, c.config.ClusterRouter, subnet); err != nil {
+		if err := c.deleteStaticRoute(subnet.Spec.CIDRBlock, c.config.ClusterRouter); err != nil {
 			return err
 		}
 
@@ -1284,7 +1284,7 @@ func (c *Controller) reconcileOvnRoute(subnet *kubeovnv1.Subnet) error {
 	return nil
 }
 
-func (c *Controller) deleteStaticRoute(ip, router string, subnet *kubeovnv1.Subnet) error {
+func (c *Controller) deleteStaticRoute(ip, router string) error {
 	for _, ipStr := range strings.Split(ip, ",") {
 		if err := c.ovnLegacyClient.DeleteStaticRoute(ipStr, router); err != nil {
 			klog.Errorf("failed to delete static route %s, %v", ipStr, err)

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -364,56 +364,54 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		}
 	}
 
-	if vpc.Name != util.DefaultVpc {
-		// handle static route
-		existRoute, err := c.ovnLegacyClient.GetStaticRouteList(vpc.Name)
-		if err != nil {
-			klog.Errorf("failed to get vpc %s static route list, %v", vpc.Name, err)
-			return err
-		}
+	// handle static route
+	existRoute, err := c.ovnLegacyClient.GetStaticRouteList(vpc.Name)
+	if err != nil {
+		klog.Errorf("failed to get vpc %s static route list, %v", vpc.Name, err)
+		return err
+	}
 
-		routeNeedDel, routeNeedAdd, err := diffStaticRoute(existRoute, vpc.Spec.StaticRoutes)
-		if err != nil {
-			klog.Errorf("failed to diff vpc %s static route, %v", vpc.Name, err)
+	routeNeedDel, routeNeedAdd, err := diffStaticRoute(existRoute, vpc.Spec.StaticRoutes)
+	if err != nil {
+		klog.Errorf("failed to diff vpc %s static route, %v", vpc.Name, err)
+		return err
+	}
+	for _, item := range routeNeedDel {
+		if err = c.ovnLegacyClient.DeleteStaticRoute(item.CIDR, vpc.Name); err != nil {
+			klog.Errorf("del vpc %s static route failed, %v", vpc.Name, err)
 			return err
 		}
-		for _, item := range routeNeedDel {
-			if err = c.ovnLegacyClient.DeleteStaticRoute(item.CIDR, vpc.Name); err != nil {
-				klog.Errorf("del vpc %s static route failed, %v", vpc.Name, err)
-				return err
-			}
-		}
+	}
 
-		for _, item := range routeNeedAdd {
-			if err = c.ovnLegacyClient.AddStaticRoute(convertPolicy(item.Policy), item.CIDR, item.NextHopIP, vpc.Name, util.NormalRouteType); err != nil {
-				klog.Errorf("add static route to vpc %s failed, %v", vpc.Name, err)
-				return err
-			}
-		}
-		// handle policy route
-		existPolicyRoute, err := c.ovnLegacyClient.GetPolicyRouteList(vpc.Name)
-		if err != nil {
-			klog.Errorf("failed to get vpc %s policy route list, %v", vpc.Name, err)
+	for _, item := range routeNeedAdd {
+		if err = c.ovnLegacyClient.AddStaticRoute(convertPolicy(item.Policy), item.CIDR, item.NextHopIP, vpc.Name, util.NormalRouteType); err != nil {
+			klog.Errorf("add static route to vpc %s failed, %v", vpc.Name, err)
 			return err
 		}
+	}
+	// handle policy route
+	existPolicyRoute, err := c.ovnLegacyClient.GetPolicyRouteList(vpc.Name)
+	if err != nil {
+		klog.Errorf("failed to get vpc %s policy route list, %v", vpc.Name, err)
+		return err
+	}
 
-		policyRouteNeedDel, policyRouteNeedAdd, err := diffPolicyRoute(existPolicyRoute, vpc.Spec.PolicyRoutes)
-		if err != nil {
-			klog.Errorf("failed to diff vpc %s policy route, %v", vpc.Name, err)
+	policyRouteNeedDel, policyRouteNeedAdd, err := diffPolicyRoute(existPolicyRoute, vpc.Spec.PolicyRoutes)
+	if err != nil {
+		klog.Errorf("failed to diff vpc %s policy route, %v", vpc.Name, err)
+		return err
+	}
+	for _, item := range policyRouteNeedDel {
+		if err = c.ovnLegacyClient.DeletePolicyRoute(vpc.Name, item.Priority, item.Match); err != nil {
+			klog.Errorf("del vpc %s policy route failed, %v", vpc.Name, err)
 			return err
 		}
-		for _, item := range policyRouteNeedDel {
-			if err = c.ovnLegacyClient.DeletePolicyRoute(vpc.Name, item.Priority, item.Match); err != nil {
-				klog.Errorf("del vpc %s policy route failed, %v", vpc.Name, err)
-				return err
-			}
-		}
-		for _, item := range policyRouteNeedAdd {
-			externalIDs := map[string]string{"vendor": util.CniTypeName}
-			if err = c.ovnLegacyClient.AddPolicyRoute(vpc.Name, item.Priority, item.Match, string(item.Action), item.NextHopIP, externalIDs); err != nil {
-				klog.Errorf("add policy route to vpc %s failed, %v", vpc.Name, err)
-				return err
-			}
+	}
+	for _, item := range policyRouteNeedAdd {
+		externalIDs := map[string]string{"vendor": util.CniTypeName}
+		if err = c.ovnLegacyClient.AddPolicyRoute(vpc.Name, item.Priority, item.Match, string(item.Action), item.NextHopIP, externalIDs); err != nil {
+			klog.Errorf("add policy route to vpc %s failed, %v", vpc.Name, err)
+			return err
 		}
 	}
 
@@ -538,47 +536,38 @@ func getStaticRouteItemKey(item *kubeovnv1.StaticRoute) (key string) {
 
 func formatVpc(vpc *kubeovnv1.Vpc, c *Controller) error {
 	var changed bool
-
-	// default vpc does not support custom route
-	if vpc.Status.Default {
-		if len(vpc.Spec.StaticRoutes) > 0 {
+	for _, item := range vpc.Spec.StaticRoutes {
+		// check policy
+		if item.Policy == "" {
+			item.Policy = kubeovnv1.PolicyDst
 			changed = true
-			vpc.Spec.StaticRoutes = nil
 		}
-	} else {
-		for _, item := range vpc.Spec.StaticRoutes {
-			// check policy
-			if item.Policy == "" {
-				item.Policy = kubeovnv1.PolicyDst
+		if item.Policy != kubeovnv1.PolicyDst && item.Policy != kubeovnv1.PolicySrc {
+			return fmt.Errorf("unknown policy type: %s", item.Policy)
+		}
+		// check cidr
+		if strings.Contains(item.CIDR, "/") {
+			if _, _, err := net.ParseCIDR(item.CIDR); err != nil {
+				return fmt.Errorf("invalid cidr %s: %w", item.CIDR, err)
+			}
+		} else if ip := net.ParseIP(item.CIDR); ip == nil {
+			return fmt.Errorf("invalid IP %s", item.CIDR)
+		}
+		// check next hop ip
+		if ip := net.ParseIP(item.NextHopIP); ip == nil {
+			return fmt.Errorf("invalid next hop IP %s", item.NextHopIP)
+		}
+	}
+
+	for _, route := range vpc.Spec.PolicyRoutes {
+		if route.Action != kubeovnv1.PolicyRouteActionReroute {
+			if route.NextHopIP != "" {
+				route.NextHopIP = ""
 				changed = true
 			}
-			if item.Policy != kubeovnv1.PolicyDst && item.Policy != kubeovnv1.PolicySrc {
-				return fmt.Errorf("unknown policy type: %s", item.Policy)
-			}
-			// check cidr
-			if strings.Contains(item.CIDR, "/") {
-				if _, _, err := net.ParseCIDR(item.CIDR); err != nil {
-					return fmt.Errorf("invalid cidr %s: %w", item.CIDR, err)
-				}
-			} else if ip := net.ParseIP(item.CIDR); ip == nil {
-				return fmt.Errorf("invalid IP %s", item.CIDR)
-			}
-			// check next hop ip
-			if ip := net.ParseIP(item.NextHopIP); ip == nil {
-				return fmt.Errorf("invalid next hop IP %s", item.NextHopIP)
-			}
-		}
-
-		for _, route := range vpc.Spec.PolicyRoutes {
-			if route.Action != kubeovnv1.PolicyRouteActionReroute {
-				if route.NextHopIP != "" {
-					route.NextHopIP = ""
-					changed = true
-				}
-			} else {
-				if ip := net.ParseIP(route.NextHopIP); ip == nil {
-					return fmt.Errorf("bad next hop ip: %s", route.NextHopIP)
-				}
+		} else {
+			if ip := net.ParseIP(route.NextHopIP); ip == nil {
+				return fmt.Errorf("bad next hop ip: %s", route.NextHopIP)
 			}
 		}
 	}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Features


尝试支持默认vpc和自定义vpc使用同样的nat gw pod功能，该pr支持ovn-cluster可以自定义静态路由。该pr目前只是实现了可支持静态路由，但是即使和自定义vpc那样使用同样的路由，也无法达到和自定义vpc那样同样的从nat gw pod fip dnat访问的效果，该pr 暂不合入，仅用来辅助分析下面遇到的一些问题。

测试中发现 ovn-cluster中的指向到node join网段的静态路由即使去掉了，pod到0.0.0.0的流量依然会在node上直接被“劫持“”走，也就是说join静态路由看起来是没有实际作用的，即使没有该路由，pod到node的流量依然是正常的。 该机制导致即使用了其他静态路由，由于流量被提前劫持走了，也是没有实际作用的