### PR TITLE
fix grep matching device in routes

### DIFF
--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -147,7 +147,7 @@ function wait_flows_pre_check() {
   local devices=""
   local ips=($(echo $OVN_DB_IPS | sed 's/,/ /g'))
   for ip in ${ips[*]}; do
-    devices="$devices $(ip route get $ip | grep -oE 'dev [^\s]+' | awk '{print $2}')"
+    devices="$devices $(ip route get $ip | grep -oE 'dev .+' | awk '{print $2}')"
   done
 
   bridges=($(ovs-vsctl --no-heading --columns=name find bridge external-ids:vendor=kube-ovn))


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:

Fix incorrect grep matching introduced in #1983 :

```shell
[root@k8s ~]# echo '114.114.114.114 via 192.168.152.1 dev enp1s0 src 192.168.155.30 uid 0' | grep -oE 'dev [^\s]+' | awk '{print $2}'
enp1
[root@k8s ~]# echo '114.114.114.114 via 192.168.152.1 dev enp1s0 src 192.168.155.30 uid 0' | grep -oE 'dev .+' | awk '{print $2}'
enp1s0
```
