### PR TITLE
feat: now interface for containerd could be inspected

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2518,6 +2518,8 @@ spec:
               name: localtime
             - mountPath: /var/run/tls
               name: kube-ovn-tls
+            - mountPath: /var/run/containerd
+              name: cruntime
           readinessProbe:
             exec:
               command:
@@ -2578,6 +2580,9 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        - hostPath:
+            path: /var/run/containerd
+          name: cruntime
         - name: kube-ovn-tls
           secret:
             optional: true

--- a/dist/images/ovsdb-inspect.sh
+++ b/dist/images/ovsdb-inspect.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# As a start bash, this is just for the interface recovery of containerd.
+
+function ovs-exec {
+  kubectl -n kube-system exec -i $1 -- $2
+}
+
+# for the crictl inital for containerd in ovs-ovn ds
+function init-ovs-ctr() {
+  for i in $(kubectl -n kube-system get pods -o wide | grep ovs-ovn | awk '{print $1}');
+  do
+    kubectl cp /usr/bin/crictl -n kube-system $i:/usr/bin/
+    ovs-exec $i "crictl config runtime-endpoint unix:///run/containerd/containerd.sock"
+  done
+}
+
+function restore-interface() {
+  POD=$(echo "$1" | awk -F '.' '{print $1}')
+  NS=$(echo "$1" | awk -F '.' '{print $2}')
+  IP=$(kubectl -n $NS get pods $POD -o=jsonpath='{.status.podIP}')
+  CIDWITHC=$(kubectl -n $NS get pods $POD -o=jsonpath={.status.containerStatuses[0].containerID})
+  CID=$(echo "$CIDWITHC" | awk -F '://' '{print $2}')
+  RUNTIME=$(echo "$CIDWITHC" | awk -F '://' '{print $1}')
+  if [[ $RUNTIME == "containerd" ]]; then
+    PID=$(ovs-exec "$2" "crictl inspect  --output go-template --template {{.info.pid}} $CID ")
+    # for convenience, the label here is added as the net ns for the PID
+    # in CNI request of recent version, it should be the cni-XXXX-XXXX, which chould be identified by the ip netns as:
+    # $ ip netns identify PID
+    PIDFILE="proc/$PID/net"
+    SANDBOXID=$(ovs-exec "$2" "crictl inspect  --output go-template --template {{.info.sandboxID}} $CID ")
+    PODIF=${SANDBOXID: 0: 12}"_h"
+  fi
+  # for the docker, the inspect method could be added in HERE as else if
+  echo "restoring ""$POD" "$NS" "$IP" "$PID" "$PODIF"
+  CMD="ovs-vsctl --timeout=30 --may-exist add-port br-int $PODIF -- set interface $PODIF external_ids:iface-id=$1 external_ids:pod_name=$POD external_ids:pod_namespace=$NS external_ids:ip=$IP external_ids:pod_netns=$PIDFILE"
+  ovs-exec $2 "$CMD"
+}
+
+init-ovs-ctr
+
+for i in $(kubectl -n kube-system get pods -o wide | grep ovs-ovn | awk '{print $1}');
+  do
+    NODE=$(ovs-exec $i "printenv KUBE_NODE_NAME")
+    NODEIP=$(ovs-exec $i "printenv OVN_DB_IPS")
+    NSNAME=$(kubectl get pods -o wide -A | grep $NODE | grep -v $NODEIP | awk '{print $2 "." $1}')
+    for j in $NSNAME;
+    do
+      echo $J
+      if [ -z "$(ovs-exec $i "ovs-vsctl --no-heading --column=external_ids find interface external_ids:iface-id=$j")" ]; then
+        restore-interface "$j" "$i"
+      fi
+    done
+  done
+


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features

#### Which issue(s) this PR fixes:
Fixes #1950 

scenario restore:
1. exec cmds in a chosen ovs-ovn pod as following:
   yes | rm /etc/openvswtich/*
   yes | rm /var/run/openvswtich/*
   rm  /etc/openvswitch/*
2. reboot this ovs-ovn pod, and wait till the system is stable.
3. run the bash.
<img width="1728" alt="WeChatWorkScreenshot_10863f27-95c4-41a8-ac9f-f7c3eee1182c" src="https://user-images.githubusercontent.com/10495508/197754788-af17d820-c028-4e5e-bcf8-fb258382e461.png">

Now this shell is just for the contained cause it's not easy to deploy a docker-based environment.