### PR TITLE
Release dangle ip associated to deleted pods when address conflict de…

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -448,7 +448,7 @@ func (c *Controller) handleSubnetFinalizer(subnet *kubeovnv1.Subnet) (bool, erro
 	return false, nil
 }
 
-func (c Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, errStr string) {
+func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, errStr string) {
 	if errStr != "" {
 		subnet.Status.SetError(reason, errStr)
 		subnet.Status.NotValidated(reason, errStr)

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -261,3 +261,14 @@ func (ipam *IPAM) GetSubnetV4Mask(subnetName string) (string, error) {
 		return "", ErrNoAvailable
 	}
 }
+
+func (ipam *IPAM) GetPodByIP(ip string, subnetName string) (podList []string) {
+	ipam.mutex.RLock()
+	defer ipam.mutex.RUnlock()
+
+	if subnet, ok := ipam.Subnets[subnetName]; !ok {
+		return
+	} else {
+		return subnet.GetPodByIP(ip)
+	}
+}

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -568,3 +568,20 @@ func (subnet *Subnet) isIPAssignedToPod(ip, podName string) bool {
 	}
 	return false
 }
+
+func (subnet *Subnet) GetPodByIP(ip string) (podList []string) {
+	if pl, ok := subnet.V4IPToPod[IP(ip)]; ok {
+		if strings.TrimSpace(pl) != "" {
+			podList = strings.Split(pl, ",")
+		}
+		return
+	}
+	if pl6, ok := subnet.V6IPToPod[IP(ip)]; ok {
+		if strings.TrimSpace(pl6) != "" {
+			podList = strings.Split(pl6, ",")
+		}
+		return
+	}
+
+	return
+}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes


When ip crd was not deteled properly, address conflicts will occur when another pod acquire the same static ip. This PR release all the ip crd and cache in IPAM when address conflicts detected if the pod associated no longer exists .
