### PR TITLE
ci: upgrade deprecated actions

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -23,6 +23,7 @@ env:
   GO_VERSION: '1.19'
   GOSEC_VERSION: '2.13.1'
   KIND_VERSION: v0.15.0
+  HELM_VERSION: v3.10.1
 
 jobs:
   build-kube-ovn:
@@ -1453,6 +1454,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
+      - uses: azure/setup-helm@v3
+        with:
+          version: '${{ env.HELM_VERSION }}'
 
       - name: Install Kind
         run: |
@@ -1464,10 +1468,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: kube-ovn
-
-      - uses: azure/setup-helm@v1
-        with:
-          version: v3.9.0
 
       - name: Load Image
         run: |


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- CI


#### Which issue(s) this PR fixes:
[GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
