### PR TITLE
fix: gateway nodes should not be all deleted in subnet status activat…

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -770,6 +770,7 @@ func (c *Controller) checkGatewayReady() error {
 						pinger.Interval = 1 * time.Second
 
 						success := false
+
 						pinger.OnRecv = func(p *goping.Packet) {
 							success = true
 							pinger.Stop()

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1268,7 +1268,6 @@ func (c *Controller) reconcileOvnRoute(subnet *kubeovnv1.Subnet) error {
 				if newActivateNode == "" {
 					klog.Warningf("all subnet %s gws are not ready", subnet.Name)
 					subnet.Status.ActivateGateway = newActivateNode
-					subnet.Status.NotReady("NoReadyGateway", "")
 					bytes, err := subnet.Status.Bytes()
 					if err != nil {
 						return err


### PR DESCRIPTION
…egateway


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes


#### Which issue(s) this PR fixes:
Fixes #2006 

 e2e is done but activegatewaynode for ecmp must be added.
