### PR TITLE
fix ovs fdb for the local bridge port

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -541,11 +541,6 @@ func configProviderNic(nicName, brName string) (int, error) {
 		return 0, fmt.Errorf("failed to get routes on nic %s: %v", nicName, err)
 	}
 
-	if _, err = ovs.Exec(ovs.MayExist, "add-port", brName, nicName,
-		"--", "set", "port", nicName, "external_ids:vendor="+util.CniTypeName); err != nil {
-		return 0, fmt.Errorf("failed to add %s to OVS bridge %s: %v", nicName, brName, err)
-	}
-
 	for _, addr := range addrs {
 		if addr.IP.IsLinkLocalUnicast() {
 			// skip 169.254.0.0/16 and fe80::/10
@@ -602,6 +597,11 @@ func configProviderNic(nicName, brName string) (int, error) {
 				}
 			}
 		}
+	}
+
+	if _, err = ovs.Exec(ovs.MayExist, "add-port", brName, nicName,
+		"--", "set", "port", nicName, "external_ids:vendor="+util.CniTypeName); err != nil {
+		return 0, fmt.Errorf("failed to add %s to OVS bridge %s: %v", nicName, brName, err)
 	}
 
 	if err = netlink.LinkSetUp(nic); err != nil {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:
Fixes incorrect mac learning on OVS bridge initialization when hairpin is enabled.

The issue occurs when the node nic contains unicast IPv6 addresses. Delay the port addition, so that ovs-vswitchd can handle IPv6 multicast packets sent back by the switch/bridge:

```shell
root@k8s:/kube-ovn# tcpdump -i eth0 -nnvve ip6
tcpdump: listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
05:04:54.956995 02:42:ac:14:00:02 > 33:33:00:00:00:16, ethertype IPv6 (0x86dd), length 110: (hlim 1, next-header Options (0) payload length: 56) :: > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 2 group record(s) [gaddr ff02::1:ff00:2 to_in { }] [gaddr ff02::1:ff00:0 to_in { }]
05:04:54.957046 02:42:ac:14:00:02 > 33:33:00:00:00:16, ethertype IPv6 (0x86dd), length 110: (hlim 1, next-header Options (0) payload length: 56) :: > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 2 group record(s) [gaddr ff02::1:ff00:2 to_in { }] [gaddr ff02::1:ff00:0 to_in { }]
05:04:54.969435 02:42:ac:14:00:02 > 33:33:00:00:00:16, ethertype IPv6 (0x86dd), length 130: (hlim 1, next-header Options (0) payload length: 76) :: > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 3 group record(s) [gaddr ff02::1:ff14:2 to_ex { }] [gaddr ff02::1:ff00:2 to_ex { }] [gaddr ff02::2 to_ex { }]
05:04:54.969490 02:42:ac:14:00:02 > 33:33:00:00:00:16, ethertype IPv6 (0x86dd), length 130: (hlim 1, next-header Options (0) payload length: 76) :: > ff02::16: HBH (rtalert: 0x0000) (padn) [icmp6 sum ok] ICMP6, multicast listener report v2, 3 group record(s) [gaddr ff02::1:ff14:2 to_ex { }] [gaddr ff02::1:ff00:2 to_ex { }] [gaddr ff02::2 to_ex { }]
```
