### PR TITLE
fix: gateway route should stay still when node is pingable

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -688,15 +688,12 @@ func (c *Controller) checkGatewayReady() error {
 						pinger.Interval = 1 * time.Second
 
 						success := false
+
 						pinger.OnRecv = func(p *goping.Packet) {
 							success = true
 							pinger.Stop()
 						}
 						pinger.Run()
-
-						if !nodeReady(node) {
-							success = false
-						}
 
 						if !success {
 							klog.Warningf("failed to ping ovn0 %s or node %v is not ready", ip, node.Name)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -974,7 +974,6 @@ func (c *Controller) reconcileGateway(subnet *kubeovnv1.Subnet) error {
 				if newActivateNode == "" {
 					klog.Warningf("all subnet %s gws are not ready", subnet.Name)
 					subnet.Status.ActivateGateway = newActivateNode
-					subnet.Status.NotReady("NoReadyGateway", "")
 					bytes, err := subnet.Status.Bytes()
 					if err != nil {
 						return err


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes


#### Which issue(s) this PR fixes:
Fixes #2011 

Considering that the existence of gateway should not stop the subnet function. e.g., subnet in a cluster should also work well even if the only gateway is down.
So now subnet will stay ready when the gateway nodes are all not ready.