### PR TITLE
bug fix: pinger crashed when change --ds-namespace=other-namespace

### DIFF
--- a/pkg/pinger/config.go
+++ b/pkg/pinger/config.go
@@ -137,9 +137,9 @@ func ParseFlags() (*Configuration, error) {
 
 	podName := os.Getenv("POD_NAME")
 	for i := 0; i < 3; i++ {
-		pod, err := config.KubeClient.CoreV1().Pods("kube-system").Get(context.Background(), podName, metav1.GetOptions{})
+		pod, err := config.KubeClient.CoreV1().Pods(config.DaemonSetNamespace).Get(context.Background(), podName, metav1.GetOptions{})
 		if err != nil {
-			klog.Errorf("failed to get self pod kube-system/%s: %v", podName, err)
+			klog.Errorf("failed to get self pod %s/%s: %v", config.DaemonSetNamespace, podName, err)
 			return nil, err
 		}
 
@@ -152,7 +152,7 @@ func ParseFlags() (*Configuration, error) {
 		}
 
 		if pod.Status.ContainerStatuses[0].Ready {
-			klog.Fatalf("failed to get IPs of Pod kube-system/%s", podName)
+			klog.Fatalf("failed to get IPs of Pod %s/%s", config.DaemonSetNamespace, podName)
 		}
 
 		klog.Infof("cannot get Pod IPs now, waiting Pod to be ready")
@@ -160,7 +160,7 @@ func ParseFlags() (*Configuration, error) {
 	}
 
 	if len(config.PodProtocols) == 0 {
-		klog.Fatalf("failed to get IPs of Pod kube-system/%s after 3 attempts", podName)
+		klog.Fatalf("failed to get IPs of Pod %s/%s after 3 attempts", config.DaemonSetNamespace, podName)
 	}
 
 	klog.Infof("pinger config is %+v", config)


### PR DESCRIPTION
kube-ovn: `latest`
k8s: `1.25.0`

When I set `--ds-namespace=ovn-system` on `kube-ovn-pinger`, the pinger crashed.
```
Controlled By:  DaemonSet/kube-ovn-pinger
Containers:
  pinger:
    Container ID:  containerd://f9b3cea84f3e338852daa04d835ad3aebf83b67cfa7f411759ac61d403b278eb
    Image:         kubeovn/kube-ovn:v1.10.6
    Image ID:      docker.io/kubeovn/kube-ovn@sha256:c3e7e9b09bc049630d850a5bd7afaab559e07a91053187acef191d2a35cecb49
    Port:          <none>
    Host Port:     <none>
    Command:
      /kube-ovn/kube-ovn-pinger
    Args:
      --ds-namespace=ovn-system
      --external-address=114.114.114.114
      --external-dns=alauda.cn
      --logtostderr=false
      --alsologtostderr=true
      --log_file=/var/log/kube-ovn/kube-ovn-pinger.log
      --log_file_max_size=0
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
```
I check the `kube-ovn-pinger.log` file and turns out it is still using `kube-system`:
```
Log file created at: 2022/11/10 16:59:52
Running on machine: kube-ovn-pinger-krjtw
Binary: Built with gc go1.18.5 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
E1110 16:59:52.245959   25442 config.go:142] failed to get self pod kube-system/kube-ovn-pinger-krjtw: pods "kube-ovn-pinger-krjtw" not found
F1110 16:59:52.246154   25442 pinger.go:24] parse config failed pods "kube-ovn-pinger-krjtw" not found
```
So I check the source code `config.go` and find out `kube-system` is hardcoded:
```
podName := os.Getenv("POD_NAME")
	for i := 0; i < 3; i++ {
		pod, err := config.KubeClient.CoreV1().Pods("kube-system").Get(context.Background(), podName, metav1.GetOptions{})
		if err != nil {
			klog.Errorf("failed to get self pod kube-system/%s: %v", podName, err)
			return nil, err
		}
```
Guess it is.