### PR TITLE
perf: reduce controller init time

### DIFF
--- a/pkg/controller/election.go
+++ b/pkg/controller/election.go
@@ -56,7 +56,7 @@ func (c *Controller) leaderElection() {
 			klog.Info("waiting for becoming a leader")
 			flag = true
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 }
 

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -3,9 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"strings"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -278,7 +276,6 @@ func (c *Controller) gcLogicalSwitchPort() error {
 	if err := c.markAndCleanLSP(); err != nil {
 		return err
 	}
-	time.Sleep(3 * time.Second)
 	return c.markAndCleanLSP()
 }
 


### PR DESCRIPTION
Controller always sleeps 8 seconds before processing, reducing the sleep time.


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Perf
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
