### PR TITLE
fix: add del bash for redundant ips

### DIFF
--- a/dist/images/del-redundant-ips.sh
+++ b/dist/images/del-redundant-ips.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# This is a script for deleting redundant crd IPS
+# This script will exit with code 1 if check failed
+# This script is recommended for regular check, i.e., crontab, in a temporary processing
+
+set -euo pipefail
+
+delIPSWithIP(){
+  IPS=()
+  IPNAME=$(kubectl get ips -o=jsonpath='{range .items[*]}{.spec.ipAddress}{","}{.metadata.name}{"\n"}{end}')
+  for ipname in $IPNAME
+  do
+    ARRIN=(${ipname//,/ })
+    if [ ${ARRIN[0]} == $1 ]; then
+      echo "delete ips " ${ARRIN[1]}
+      kubectl delete ips ${ARRIN[1]}
+    fi
+  done
+}
+
+IPS=()
+IPSUBNET=$(kubectl get ips -o=jsonpath='{range .items[*]}{.spec.ipAddress}{","}{.spec.subnet}{"\n"}{end}')
+for ipsubnet in $IPSUBNET
+do
+  ARRIN=(${ipsubnet//,/ })
+  if [ ${ARRIN[1]} != "join" ]; then
+    IPS+=(${ARRIN[0]})
+  fi
+done
+
+PODS=()
+PODIPNODEIP=$(kubectl get pods -A  -o=jsonpath='{range .items[*]}{.status.podIP}{","}{.status.hostIP}{"\n"}{end}')
+for podnode in $PODIPNODEIP
+do
+  ARRIN=(${podnode//,/ })
+  if [ ${ARRIN[0]} != ${ARRIN[1]} ]; then
+    PODS+=(${ARRIN[0]})
+  fi
+done
+
+for ip in "${IPS[@]}"
+do
+  IN=true
+  for pod in "${PODS[@]}"
+  do
+    if [ "$ip" == "$pod" ]; then
+      IN=false
+      continue
+    fi
+  done
+  if $IN; then
+    delIPSWithIP "$ip"
+  fi
+done


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes

#### Which issue(s) this PR fixes:
Fixes #

This script automatically deletes redundant CRD IPS.
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/10495508/203072575-22d291fd-85e8-467c-8e35-b2e00f54409e.png">


<img width="478" alt="image" src="https://user-images.githubusercontent.com/10495508/203072512-d16832a2-6911-44cd-af3b-6affce6fd13d.png">

Script will get all IPS, and check if the IP in IPS is used in all Pods.
if not, then the corresponding IPS with this specific IP will be deleted.