### PR TITLE
ovs-dpdk supports adding bond for multi-NICs

### DIFF
--- a/dist/images/ovs-dpdk-config
+++ b/dist/images/ovs-dpdk-config
@@ -1,2 +1,4 @@
 ENCAP_IP=192.168.190.2
-DPDK_DEV=0000:00:0b.0
+DPDK_DEV=(0000:00:0b.0 0000:00:0c.0)
+BOND_TYPE=4 # ""=single_port, 0="balance-slb", 1="active-backup", 4="lacp"
+VLAN_TAG=0 # 0=untag

--- a/dist/images/start-ovs-dpdk-v2.sh
+++ b/dist/images/start-ovs-dpdk-v2.sh
@@ -72,8 +72,35 @@ ovs-vsctl --may-exist add-br ${DPDK_TUNNEL_IFACE} \
     -- br-set-external-id ${DPDK_TUNNEL_IFACE} bridge-id ${DPDK_TUNNEL_IFACE} \
     -- set bridge ${DPDK_TUNNEL_IFACE} fail-mode=standalone
 
-ovs-vsctl --timeout 10 add-port ${DPDK_TUNNEL_IFACE} dpdk0 \
-  -- set Interface dpdk0 type=dpdk options:dpdk-devargs=${DPDK_DEV}
+OPTS=""
+IPS=""
+for ((i=0;i< ${#DPDK_DEV[@]};i++));
+do
+   echo ${DPDK_DEV[i]};
+   S=" -- set Interface p$i type=dpdk options:dpdk-devargs=${DPDK_DEV[i]}"
+   OPTS="$OPTS$S"
+   IPS=$IPS" p"$i
+done
+
+case ${BOND_TYPE} in
+  "")
+    ovs-vsctl --timeout 10 add-port ${DPDK_TUNNEL_IFACE} dpdk0 ${OPTS};;
+  "active-backup"|1)
+    ovs-vsctl --timeout 10 add-bond ${DPDK_TUNNEL_IFACE} dpdk0 ${IPS} ${OPTS}
+    ovs-vsctl set port dpdk0 bond_mode=active-backup;;
+  "balance-slb"|0)
+    ovs-vsctl --timeout 10 add-bond ${DPDK_TUNNEL_IFACE} dpdk0 ${IPS} ${OPTS}
+    ovs-vsctl set port dpdk0 bond_mode=balance-slb;;
+  "lacp"|4)
+    ovs-vsctl --timeout 10 add-bond ${DPDK_TUNNEL_IFACE} dpdk0 ${IPS} ${OPTS}
+    ovs-vsctl set port dpdk0 bond_mode=balance-tcp
+    ovs-vsctl set port dpdk0 lacp=active;;
+  *)
+    echo "wrong ovs dpdk bond_type config"
+    exit 1;;
+esac
+
+ovs-vsctl set port ${DPDK_TUNNEL_IFACE} tag=${VLAN_TAG}
 
 ip addr add ${ENCAP_IP} dev ${DPDK_TUNNEL_IFACE}
 fi


### PR DESCRIPTION

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
In the IDC environment, multi-NIC link aggregation is used to achieve high availability，we can get it  through bond
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #1926
