### PR TITLE
Fix:hybrid-dpdk with vxlan tunnel mode，The OVS node does not create a VXLAN tunnel to the OVS-DPDK node

### DIFF
--- a/dist/images/start-ovs-dpdk-v2.sh
+++ b/dist/images/start-ovs-dpdk-v2.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 DPDK_TUNNEL_IFACE=${DPDK_TUNNEL_IFACE:-br-phy}
+TUNNEL_TYPE=${TUNNEL_TYPE:-geneve}
 
 OVS_DPDK_CONFIG_FILE=/opt/ovs-config/ovs-dpdk-config
 if ! test -f "$OVS_DPDK_CONFIG_FILE"; then
@@ -94,6 +95,6 @@ ovn-ctl restart_controller
 ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
 ovs-vsctl set open . external-ids:ovn-remote-probe-interval=10000
 ovs-vsctl set open . external-ids:ovn-openflow-probe-interval=180
-ovs-vsctl set open . external-ids:ovn-encap-type=geneve
+ovs-vsctl set open . external-ids:ovn-encap-type="${TUNNEL_TYPE}"
 
 tail --follow=name --retry /var/log/openvswitch/ovs-vswitchd.log


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
Hybrid-dpdk with vxlan tunnel mode，The OVS node does not create a VXLAN tunnel to the OVS-DPDK node
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
In the ovs node, ovs-vsctl show the tunnel to the ovs-dpdk node，ovs does not have the tunnel port to the ovs-dpdk node
#### Which issue(s) this PR fixes:
Fixes #2037
