### PR TITLE
fix ovs bridge not deleted cause by port link not found

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -639,11 +639,11 @@ func linkIsAlbBond(link netlink.Link) (bool, error) {
 func removeProviderNic(nicName, brName string) error {
 	nic, err := netlink.LinkByName(nicName)
 	if err != nil {
-		if _, ok := err.(netlink.LinkNotFoundError); !ok {
-			return fmt.Errorf("failed to get nic by name %s: %v", nicName, err)
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
+			klog.Warningf("failed to get nic by name %s: %v", nicName, err)
+			return nil
 		}
-		klog.Warningf("failed to get nic by name %s: %v", nicName, err)
-		return nil
+		return fmt.Errorf("failed to get nic by name %s: %v", nicName, err)
 	}
 	bridge, err := netlink.LinkByName(brName)
 	if err != nil {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -639,7 +639,11 @@ func linkIsAlbBond(link netlink.Link) (bool, error) {
 func removeProviderNic(nicName, brName string) error {
 	nic, err := netlink.LinkByName(nicName)
 	if err != nil {
-		return fmt.Errorf("failed to get nic by name %s: %v", nicName, err)
+		if _, ok := err.(netlink.LinkNotFoundError); !ok {
+			return fmt.Errorf("failed to get nic by name %s: %v", nicName, err)
+		}
+		klog.Warningf("failed to get nic by name %s: %v", nicName, err)
+		return nil
 	}
 	bridge, err := netlink.LinkByName(brName)
 	if err != nil {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:

When handling provider network deletion, if the host nic does not exist, kube-ovn-cni reports an error and the ovs bridge will be never deleted:

```txt
E1126 06:27:15.639671   13460 init.go:172] failed to remove port eth2 from external bridge br-pn-5034: failed to get nic by name eth2: Link not found
E1126 06:27:15.639727   13460 controller.go:220] error syncing 'pn-5034': failed to remove port eth2 from external bridge br-pn-5034: failed to get nic by name eth2: Link not found, requeuing
```

In this kind of scenario, we should ignore the error and finish the bridge deletion.