### PR TITLE
fix: cni response missing sandbox field

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -65,19 +65,20 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return types.NewError(types.ErrTryAgainLater, "RPC failed", err.Error())
 	}
 
-	result := generateCNIResult(response)
+	result := generateCNIResult(response, args.Netns)
 	return types.PrintResult(&result, cniVersion)
 }
 
-func generateCNIResult(cniResponse *request.CniResponse) current.Result {
+func generateCNIResult(cniResponse *request.CniResponse, netns string) current.Result {
 	result := current.Result{
 		CNIVersion: current.ImplementedSpecVersion,
 		DNS:        cniResponse.DNS,
 	}
 	_, mask, _ := net.ParseCIDR(cniResponse.CIDR)
 	podIface := current.Interface{
-		Name: cniResponse.PodNicName,
-		Mac:  cniResponse.MacAddress,
+		Name:    cniResponse.PodNicName,
+		Mac:     cniResponse.MacAddress,
+		Sandbox: netns,
 	}
 	switch cniResponse.Protocol {
 	case kubeovnv1.ProtocolIPv4:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes

portmap relies on `ip.interface` and `interface.sandbox` to manipulate iptables rules. Previously we add `ip.interface` but missing `interface.sandbox`.

https://github.com/kubeovn/kube-ovn/pull/1636#issuecomment-1328463488

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
