### PR TITLE
replace klog.Fatalf with klog.ErrorS and klog.FlushAndExit

### DIFF
--- a/cmd/cmdmain.go
+++ b/cmd/cmdmain.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/klog/v2"
-
 	"github.com/kubeovn/kube-ovn/cmd/cni"
 	"github.com/kubeovn/kube-ovn/cmd/controller"
 	"github.com/kubeovn/kube-ovn/cmd/controller_health_check"
@@ -14,6 +12,7 @@ import (
 	"github.com/kubeovn/kube-ovn/cmd/ovn_monitor"
 	"github.com/kubeovn/kube-ovn/cmd/pinger"
 	"github.com/kubeovn/kube-ovn/cmd/speaker"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 const (
@@ -47,6 +46,6 @@ func main() {
 	case CmdOvnLeaderChecker:
 		ovn_leader_checker.CmdMain()
 	default:
-		klog.Fatalf("%s is an unknown command", cmd)
+		util.LogFatalAndExit(nil, "%s is an unknown command", cmd)
 	}
 }

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -31,11 +31,11 @@ func CmdMain() {
 	util.InitKlogMetrics()
 	config, err := controller.ParseFlags()
 	if err != nil {
-		klog.Fatalf("parse config failed %v", err)
+		util.LogFatalAndExit(err, "failed to parse config")
 	}
 
 	if err := checkPermission(config); err != nil {
-		klog.Fatalf("failed to check permission %v", err)
+		util.LogFatalAndExit(err, "failed to check permission")
 	}
 
 	go loopOvnNbctlDaemon(config)

--- a/cmd/controller_health_check/controller_health_check.go
+++ b/cmd/controller_health_check/controller_health_check.go
@@ -7,29 +7,28 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func CmdMain() {
 	content, err := os.ReadFile("/var/run/ovn/ovn-nbctl.pid")
 	if err != nil {
-		klog.Fatalf("failed to get ovn-nbctl daemon pid, %s", err)
+		util.LogFatalAndExit(err, "failed to get ovn-nbctl daemon pid")
 	}
 	daemonPid := strings.TrimSuffix(string(content), "\n")
 	if err := os.Setenv("OVN_NB_DAEMON", fmt.Sprintf("/var/run/ovn/ovn-nbctl.%s.ctl", daemonPid)); err != nil {
-		klog.Fatalf("failed to set env OVN_NB_DAEMON, %v", err)
+		util.LogFatalAndExit(err, "failed to set env OVN_NB_DAEMON")
 	}
 	if err := ovs.CheckAlive(); err != nil {
 		os.Exit(1)
 	}
 	conn, err := net.DialTimeout("tcp", "127.0.0.1:10660", 3*time.Second)
 	if err != nil {
-		klog.Fatalf("failed to probe the socket, %s", err)
+		util.LogFatalAndExit(err, "failed to probe the socket")
 	}
 	err = conn.Close()
 	if err != nil {
-		klog.Fatalf("Unexpected error closing TCP probe socket: %v (%#v)", err, err)
+		util.LogFatalAndExit(err, "failed to close connection")
 	}
 }

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -39,23 +39,23 @@ func CmdMain() {
 
 	nicBridgeMappings, err := daemon.InitOVSBridges()
 	if err != nil {
-		klog.Fatalf("failed to initialize OVS bridges: %v", err)
+		util.LogFatalAndExit(err, "failed to initialize OVS bridges")
 	}
 
 	if err = config.Init(nicBridgeMappings); err != nil {
-		klog.Fatalf("failed to initialize config: %v", err)
+		util.LogFatalAndExit(err, "failed to initialize config")
 	}
 
 	if err := Retry(util.ChasRetryTime, util.ChasRetryIntev, initChassisAnno, config); err != nil {
-		klog.Fatalf("failed to annotate chassis id, %v", err)
+		util.LogFatalAndExit(err, "failed to initialize ovn chassis annotation")
 	}
 
 	if err = daemon.InitMirror(config); err != nil {
-		klog.Fatalf("failed to init mirror nic, %v", err)
+		util.LogFatalAndExit(err, "failed to initialize ovs mirror")
 	}
 
 	if err = daemon.InitNodeGateway(config); err != nil {
-		klog.Fatalf("init node gateway failed %v", err)
+		util.LogFatalAndExit(err, "failed to initialize node gateway")
 	}
 
 	stopCh := signals.SetupSignalHandler()
@@ -74,7 +74,7 @@ func CmdMain() {
 		}))
 	ctl, err := daemon.NewController(config, podInformerFactory, nodeInformerFactory, kubeovnInformerFactory)
 	if err != nil {
-		klog.Fatalf("create controller failed %v", err)
+		util.LogFatalAndExit(err, "failed to create controller")
 	}
 	podInformerFactory.Start(stopCh)
 	nodeInformerFactory.Start(stopCh)
@@ -82,7 +82,7 @@ func CmdMain() {
 	go ctl.Run(stopCh)
 	go daemon.RunServer(config, ctl)
 	if err := mvCNIConf(config.CniConfDir, config.CniConfFile, config.CniConfName); err != nil {
-		klog.Fatalf("failed to mv cni conf, %v", err)
+		util.LogFatalAndExit(err, "failed to mv cni config file")
 	}
 
 	mux := http.NewServeMux()

--- a/cmd/ovn_leader_checker/ovn_leader_checker.go
+++ b/cmd/ovn_leader_checker/ovn_leader_checker.go
@@ -1,18 +1,17 @@
 package ovn_leader_checker
 
 import (
-	"k8s.io/klog/v2"
-
 	"github.com/kubeovn/kube-ovn/pkg/ovn_leader_checker"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func CmdMain() {
 	cfg, err := ovn_leader_checker.ParseFlags()
 	if err != nil {
-		klog.Fatalf("ovn_leader_checker parseFlags error %v", err)
+		util.LogFatalAndExit(err, "failed to parse flags")
 	}
 	if err = ovn_leader_checker.KubeClientInit(cfg); err != nil {
-		klog.Fatalf("KubeClientInit err %v", err)
+		util.LogFatalAndExit(err, "failed to initialize kube client")
 	}
 	ovn_leader_checker.StartOvnLeaderCheck(cfg)
 }

--- a/cmd/ovn_monitor/ovn_monitor.go
+++ b/cmd/ovn_monitor/ovn_monitor.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/klog/v2"
 
 	ovn "github.com/kubeovn/kube-ovn/pkg/ovnmonitor"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/versions"
 )
 
@@ -17,7 +18,7 @@ func CmdMain() {
 	klog.Infof(versions.String())
 	config, err := ovn.ParseFlags()
 	if err != nil {
-		klog.Fatalf("parse config failed %v", err)
+		util.LogFatalAndExit(err, "failed to parse config")
 	}
 
 	exporter := ovn.NewExporter(config)

--- a/cmd/pinger/pinger.go
+++ b/cmd/pinger/pinger.go
@@ -22,7 +22,7 @@ func CmdMain() {
 	util.InitKlogMetrics()
 	config, err := pinger.ParseFlags()
 	if err != nil {
-		klog.Fatalf("parse config failed %v", err)
+		util.LogFatalAndExit(err, "failed to parse config")
 	}
 	if config.Mode == "server" {
 		http.Handle("/metrics", promhttp.Handler())

--- a/cmd/speaker/speaker.go
+++ b/cmd/speaker/speaker.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/sample-controller/pkg/signals"
 
 	"github.com/kubeovn/kube-ovn/pkg/speaker"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/versions"
 )
 
@@ -19,7 +20,7 @@ func CmdMain() {
 	klog.Infof(versions.String())
 	config, err := speaker.ParseFlags()
 	if err != nil {
-		klog.Fatalf("failed to parse config %v", err)
+		util.LogFatalAndExit(err, "failed to parse config")
 	}
 
 	stopCh := signals.SetupSignalHandler()

--- a/cmd/webhook/server.go
+++ b/cmd/webhook/server.go
@@ -12,6 +12,7 @@ import (
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	ovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 	ovnwebhook "github.com/kubeovn/kube-ovn/pkg/webhook"
 	"github.com/kubeovn/kube-ovn/versions"
 	"github.com/spf13/pflag"
@@ -27,13 +28,13 @@ var (
 
 func init() {
 	if err := corev1.AddToScheme(scheme); err != nil {
-		klog.Fatalf("failed to add scheme, %v", err)
+		util.LogFatalAndExit(err, "failed to add core v1 scheme")
 	}
 	if err := appsv1.AddToScheme(scheme); err != nil {
-		klog.Fatalf("failed to add scheme, %v", err)
+		util.LogFatalAndExit(err, "failed to add apps v1 scheme")
 	}
 	if err := ovnv1.AddToScheme(scheme); err != nil {
-		klog.Fatalf("failed to add scheme, %v", err)
+		util.LogFatalAndExit(err, "failed to add ovn v1 scheme")
 	}
 }
 
@@ -52,7 +53,7 @@ func main() {
 		if f2 != nil {
 			value := f1.Value.String()
 			if err := f2.Value.Set(value); err != nil {
-				klog.Fatalf("failed to set flag, %v", err)
+				util.LogFatalAndExit(err, "failed to set flag")
 			}
 		}
 	})

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -163,7 +163,7 @@ func ParseFlags() (*Configuration, error) {
 		if f2 != nil {
 			value := f1.Value.String()
 			if err := f2.Value.Set(value); err != nil {
-				klog.Fatalf("failed to set pflag, %v", err)
+				util.LogFatalAndExit(err, "failed to set pflag")
 			}
 		}
 	})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -624,72 +624,72 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	}
 
 	if ok := cache.WaitForCacheSync(stopCh, cacheSyncs...); !ok {
-		klog.Fatalf("failed to wait for caches to sync")
+		util.LogFatalAndExit(nil, "failed to wait for caches to sync")
 	}
 
 	if err := c.ovnLegacyClient.SetLsDnatModDlDst(c.config.LsDnatModDlDst); err != nil {
-		klog.Fatal(err)
+		util.LogFatalAndExit(err, "failed to set NB_Global option ls_dnat_mod_dl_dst")
 	}
 	if err := c.ovnLegacyClient.SetUseCtInvMatch(); err != nil {
-		klog.Fatalf("failed to set NB_Global option use_ct_inv_match to false: %v", err)
+		util.LogFatalAndExit(err, "failed to set NB_Global option use_ct_inv_match")
 	}
 
 	if err := c.InitDefaultVpc(); err != nil {
-		klog.Fatalf("failed to init default vpc: %v", err)
+		util.LogFatalAndExit(err, "failed to initialize default vpc")
 	}
 
 	if err := c.InitOVN(); err != nil {
-		klog.Fatalf("failed to init ovn resource: %v", err)
+		util.LogFatalAndExit(err, "failed to initialize ovn resources")
 	}
 
 	// sync ip crd before initIPAM since ip crd will be used to restore vm and statefulset pod in initIPAM
 	if err := c.initSyncCrdIPs(); err != nil {
-		klog.Errorf("failed to sync crd ips: %v", err)
+		util.LogFatalAndExit(err, "failed to sync crd ips")
 	}
 
 	if err := c.InitIPAM(); err != nil {
-		klog.Fatalf("failed to init ipam: %v", err)
+		util.LogFatalAndExit(err, "failed to initialize ipam")
 	}
 
 	if err := c.initNodeChassis(); err != nil {
-		klog.Errorf("failed to init node chassis: %v", err)
+		util.LogFatalAndExit(err, "failed to initialize node chassis")
 	}
 
 	if err := c.initNodeRoutes(); err != nil {
-		klog.Fatalf("failed to initialize node routes: %v", err)
+		util.LogFatalAndExit(err, "failed to initialize node routes")
 	}
 
 	if err := c.initDenyAllSecurityGroup(); err != nil {
-		klog.Fatalf("failed to init 'deny_all' security group: %v", err)
+		util.LogFatalAndExit(err, "failed to initialize 'deny_all' security group")
 	}
 
 	// remove resources in ovndb that not exist any more in kubernetes resources
 	if err := c.gc(); err != nil {
-		klog.Fatalf("gc failed: %v", err)
+		util.LogFatalAndExit(err, "failed to run gc")
 	}
 
 	c.registerSubnetMetrics()
 	if err := c.initSyncCrdSubnets(); err != nil {
-		klog.Errorf("failed to sync crd subnets: %v", err)
+		util.LogFatalAndExit(err, "failed to sync crd subnets")
 	}
 	if err := c.initSyncCrdVlans(); err != nil {
-		klog.Errorf("failed to sync crd vlans: %v", err)
+		util.LogFatalAndExit(err, "failed to sync crd vlans")
 	}
 
 	if c.config.PodDefaultFipType == util.IptablesFip {
 		if err := c.initSyncCrdVpcNatGw(); err != nil {
-			klog.Errorf("failed to sync crd vpc nat gws: %v", err)
+			util.LogFatalAndExit(err, "failed to sync crd vpc nat gateways")
 		}
 	}
 
 	if c.config.EnableLb {
 		if err := c.initVpcDnsConfig(); err != nil {
-			klog.Errorf("failed to init vpc-dns: %v", err)
+			util.LogFatalAndExit(err, "failed to initialize vpc-dns")
 		}
 	}
 
 	if err := c.addNodeGwStaticRoute(); err != nil {
-		klog.Errorf("failed to add static route for node gw: %v", err)
+		util.LogFatalAndExit(err, "failed to add static route for node gateway")
 	}
 
 	// start workers to do all the network operations
@@ -828,7 +828,7 @@ func (c *Controller) startWorkers(stopCh <-chan struct{}) {
 		time.Sleep(3 * time.Second)
 		lss, err := c.ovnLegacyClient.ListLogicalSwitch(c.config.EnableExternalVpc)
 		if err != nil {
-			klog.Fatalf("failed to list logical switch: %v", err)
+			util.LogFatalAndExit(err, "failed to list logical switch")
 		}
 
 		if util.IsStringIn(c.config.DefaultLogicalSwitch, lss) && util.IsStringIn(c.config.NodeSwitch, lss) && c.addNamespaceQueue.Len() == 0 {
@@ -851,7 +851,7 @@ func (c *Controller) startWorkers(stopCh <-chan struct{}) {
 		time.Sleep(3 * time.Second)
 		nodes, err := c.nodesLister.List(labels.Everything())
 		if err != nil {
-			klog.Fatalf("failed to list nodes: %v", err)
+			util.LogFatalAndExit(err, "failed to list nodes")
 		}
 		for _, node := range nodes {
 			if node.Annotations[util.AllocatedAnnotation] != "true" {

--- a/pkg/controller/election.go
+++ b/pkg/controller/election.go
@@ -79,7 +79,7 @@ func setupLeaderElection(config *leaderElectionConfig) *leaderelection.LeaderEle
 			if config.OnStoppedLeading != nil {
 				config.OnStoppedLeading()
 			}
-			klog.Fatalf("leaderelection lost")
+			util.LogFatalAndExit(nil, "leaderelection lost")
 		},
 		OnNewLeader: func(identity string) {
 			klog.Infof("new leader elected: %v", identity)
@@ -114,7 +114,7 @@ func setupLeaderElection(config *leaderElectionConfig) *leaderelection.LeaderEle
 		Callbacks:     callbacks,
 	})
 	if err != nil {
-		klog.Fatalf("unexpected error starting leader election: %v", err)
+		util.LogFatalAndExit(err, "failed to create leader elector")
 	}
 
 	go elector.Run(context.Background())

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -100,7 +100,7 @@ func ParseFlags() *Configuration {
 		if f2 != nil {
 			value := f1.Value.String()
 			if err := f2.Value.Set(value); err != nil {
-				klog.Fatalf("failed to set flag, %v", err)
+				util.LogFatalAndExit(err, "failed to set flag")
 			}
 		}
 	})

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -101,8 +101,7 @@ func NewController(config *Configuration, podInformerFactory informers.SharedInf
 
 	node, err := config.KubeClient.CoreV1().Nodes().Get(context.Background(), config.NodeName, metav1.GetOptions{})
 	if err != nil {
-		klog.Fatalf("failed to get node %s info %v", config.NodeName, err)
-		return nil, err
+		util.LogFatalAndExit(err, "failed to get node %s info", config.NodeName)
 	}
 	controller.protocol = util.CheckProtocol(node.Annotations[util.IpAddressAnnotation])
 
@@ -659,13 +658,11 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	go wait.Until(c.operateMod, 10*time.Second, stopCh)
 
 	if ok := cache.WaitForCacheSync(stopCh, c.providerNetworksSynced, c.subnetsSynced, c.podsSynced, c.nodesSynced, c.htbQosSynced); !ok {
-		klog.Fatalf("failed to wait for caches to sync")
-		return
+		util.LogFatalAndExit(nil, "failed to wait for caches to sync")
 	}
 
 	if err := c.setIPSet(); err != nil {
-		klog.Errorf("failed to set ipsets: %v", err)
-		return
+		util.LogFatalAndExit(err, "failed to set ipsets")
 	}
 
 	klog.Info("Started workers")

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -408,11 +408,11 @@ func configureNodeNic(portName, ip, gw string, macAddr net.HardwareAddr, mtu int
 func (c *Controller) loopOvn0Check() {
 	link, err := netlink.LinkByName(util.NodeNic)
 	if err != nil {
-		klog.Fatalf("failed to get ovn0 nic: %v", err)
+		util.LogFatalAndExit(err, "failed to get ovn0 nic")
 	}
 
 	if link.Attrs().OperState == netlink.OperDown {
-		klog.Fatalf("ovn0 nic is down")
+		util.LogFatalAndExit(err, "ovn0 nic is down")
 	}
 
 	node, err := c.nodesLister.Get(c.config.NodeName)
@@ -423,7 +423,7 @@ func (c *Controller) loopOvn0Check() {
 	ip := node.Annotations[util.IpAddressAnnotation]
 	gw := node.Annotations[util.GatewayAnnotation]
 	if err := waitNetworkReady(util.NodeNic, ip, gw, false, false); err != nil {
-		klog.Fatalf("failed to ping ovn0 gw: %s, %v", gw, err)
+		util.LogFatalAndExit(err, "failed to ping ovn0 gateway %s", gw)
 	}
 }
 

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -361,10 +361,10 @@ func compactOvnDatabase(db string) {
 
 func doOvnLeaderCheck(cfg *Configuration, podName string, podNamespace string) {
 	if podName == "" || podNamespace == "" {
-		klog.Fatalf("env variables POD_NAME and POD_NAMESPACE must be set")
+		util.LogFatalAndExit(nil, "env variables POD_NAME and POD_NAMESPACE must be set")
 	}
 	if cfg == nil || cfg.KubeClient == nil {
-		klog.Fatalf("preValidChkCfg: invalid cfg")
+		util.LogFatalAndExit(nil, "preValidChkCfg: invalid cfg")
 	}
 
 	if !checkOvnIsAlive() {

--- a/pkg/ovnmonitor/exporter.go
+++ b/pkg/ovnmonitor/exporter.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/greenpau/ovsdb"
 	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 const metricNamespace = "kube_ovn"
@@ -112,8 +114,7 @@ func (e *Exporter) StartConnection() error {
 func (e *Exporter) TryClientConnection() {
 	for {
 		if tryConnectCnt > 5 {
-			klog.Fatalf("%s: ovn-monitor failed to reconnect db socket finally", e.Client.System.Hostname)
-			break
+			util.LogFatalAndExit(nil, "%s: ovn-monitor failed to reconnect db socket finally", e.Client.System.Hostname)
 		}
 
 		if err := e.StartConnection(); err != nil {

--- a/pkg/pinger/config.go
+++ b/pkg/pinger/config.go
@@ -89,7 +89,7 @@ func ParseFlags() (*Configuration, error) {
 		if f2 != nil {
 			value := f1.Value.String()
 			if err := f2.Value.Set(value); err != nil {
-				klog.Fatalf("failed to set flag %v", err)
+				util.LogFatalAndExit(err, "failed to set flag")
 			}
 		}
 	})
@@ -152,7 +152,7 @@ func ParseFlags() (*Configuration, error) {
 		}
 
 		if pod.Status.ContainerStatuses[0].Ready {
-			klog.Fatalf("failed to get IPs of Pod %s/%s", config.DaemonSetNamespace, podName)
+			util.LogFatalAndExit(nil, "failed to get IPs of Pod %s/%s", config.DaemonSetNamespace, podName)
 		}
 
 		klog.Infof("cannot get Pod IPs now, waiting Pod to be ready")
@@ -160,7 +160,7 @@ func ParseFlags() (*Configuration, error) {
 	}
 
 	if len(config.PodProtocols) == 0 {
-		klog.Fatalf("failed to get IPs of Pod %s/%s after 3 attempts", config.DaemonSetNamespace, podName)
+		util.LogFatalAndExit(nil, "failed to get IPs of Pod %s/%s after 3 attempts", config.DaemonSetNamespace, podName)
 	}
 
 	klog.Infof("pinger config is %+v", config)

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/klog/v2"
 
 	clientset "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 const (
@@ -84,7 +85,7 @@ func ParseFlags() (*Configuration, error) {
 		if f2 != nil {
 			value := f1.Value.String()
 			if err := f2.Value.Set(value); err != nil {
-				klog.Fatalf("failed to set flag, %v", err)
+				util.LogFatalAndExit(err, "failed to set flag")
 			}
 		}
 	})

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -18,6 +18,7 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 const controllerAgentName = "ovn-speaker"
@@ -82,7 +83,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	c.kubeovnInformerFactory.Start(stopCh)
 
 	if !cache.WaitForCacheSync(stopCh, c.podsSynced, c.subnetSynced, c.servicesSynced) {
-		klog.Fatalf("failed to wait for caches to sync")
+		util.LogFatalAndExit(nil, "failed to wait for caches to sync")
 		return
 	}
 

--- a/pkg/util/klog.go
+++ b/pkg/util/klog.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+)
+
+func LogFatalAndExit(err error, format string, a ...interface{}) {
+	klog.ErrorS(err, fmt.Sprintf(format, a...))
+	klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -178,7 +178,7 @@ func GenerateRandomV4IP(cidr string) string {
 	hostNum := 32 - netMask
 	add, err := rand.Int(rand.Reader, big.NewInt(1<<(uint(hostNum)-1)))
 	if err != nil {
-		klog.Fatalf("failed to generate random ip, %v", err)
+		LogFatalAndExit(err, "failed to generate random ip")
 	}
 	t := big.NewInt(0).Add(Ip2BigInt(ip), add)
 	return fmt.Sprintf("%s/%d", BigInt2Ip(t), netMask)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

#### Which issue(s) this PR fixes:

`klog.Fatalf` may be stuck or take too long. Replace it with `klog.ErrorS` and `klog.FlushAndExit` to exit the process as expected.