### PR TITLE
fix: eip deletion

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -878,6 +878,10 @@ func (c *Controller) handleUpdatePod(key string) error {
 						klog.Errorf("failed to add static route, %v", err)
 						return err
 					}
+				} else {
+					if err := c.ovnLegacyClient.DeleteStaticRoute(podIP, c.config.ClusterRouter); err != nil {
+						return err
+					}
 				}
 			}
 

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1155,8 +1155,8 @@ func parseLrRouteListOutput(output string) (routeList []*StaticRoute, err error)
 
 func (c LegacyClient) UpdateNatRule(policy, logicalIP, externalIP, router, logicalMac, port string) error {
 	// when dual protocol pod has eip or snat, will add nat for all dual addresses.
-	// will failed when logicalIP externalIP is different protocol.
-	if util.CheckProtocol(logicalIP) != util.CheckProtocol(externalIP) {
+	// will fail when logicalIP externalIP is different protocol.
+	if externalIP != "" && util.CheckProtocol(logicalIP) != util.CheckProtocol(externalIP) {
 		return nil
 	}
 


### PR DESCRIPTION
When eip and routed annotation deleted the nat and route rule are not deleted.


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #2105 
