### PR TITLE
add wait for e2e test pod routed annotation

### DIFF
--- a/test/e2e/qos/qos.go
+++ b/test/e2e/qos/qos.go
@@ -76,7 +76,6 @@ var _ = Describe("[Qos]", func() {
 		pod, err = f.KubeClientSet.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pod.Annotations[util.AllocatedAnnotation]).To(Equal("true"))
-		Expect(pod.Annotations[util.RoutedAnnotation]).To(Equal("true"))
 		Expect(pod.Annotations[util.NetemQosLatencyAnnotation]).To(Equal("600"))
 		Expect(pod.Annotations[util.NetemQosLimitAnnotation]).To(Equal("2000"))
 		Expect(pod.Annotations[util.NetemQosLossAnnotation]).To(Equal("10"))
@@ -140,7 +139,6 @@ var _ = Describe("[Qos]", func() {
 		pod, err = f.KubeClientSet.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pod.Annotations[util.AllocatedAnnotation]).To(Equal("true"))
-		Expect(pod.Annotations[util.RoutedAnnotation]).To(Equal("true"))
 		Expect(pod.Annotations[util.NetemQosLatencyAnnotation]).To(Equal("600"))
 		Expect(pod.Annotations[util.NetemQosLimitAnnotation]).To(Equal("2000"))
 		Expect(pod.Annotations[util.NetemQosLossAnnotation]).To(Equal("10"))
@@ -198,7 +196,6 @@ var _ = Describe("[Qos]", func() {
 		pod, err = f.KubeClientSet.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pod.Annotations[util.AllocatedAnnotation]).To(Equal("true"))
-		Expect(pod.Annotations[util.RoutedAnnotation]).To(Equal("true"))
 		Expect(pod.Annotations[util.PriorityAnnotation]).To(Equal("50"))
 		Expect(pod.Annotations[util.IngressRateAnnotation]).To(Equal("300"))
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- enhancement
 1、The e2e passed successfully in my local environment, but failed in github. The routed annotation for pod
 is nil while it should be true.
So add 1s wait for pod to update annotation.

<img width="900" alt="image" src="https://user-images.githubusercontent.com/67130442/205577157-564e1a2f-d047-4c0e-a17f-c150e3c5e4cb.png">


#### Which issue(s) this PR fixes:
Fixes #(issue-number)
