### PR TITLE
fix: delete static route should consider dualstack

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -879,7 +879,7 @@ func (c *Controller) handleUpdatePod(key string) error {
 						klog.Errorf("failed to add static route, %v", err)
 						return err
 					}
-				} else {
+				} else if c.config.EnableEipSnat {
 					if err := c.ovnLegacyClient.DeleteStaticRoute(podIP, c.config.ClusterRouter); err != nil {
 						return err
 					}

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1385,8 +1385,14 @@ func (c LegacyClient) DeleteStaticRoute(cidr, router string) error {
 	if cidr == "" {
 		return nil
 	}
-	_, err := c.ovnNbCommand(IfExists, "lr-route-del", router, cidr)
-	return err
+	for _, cidrBlock := range strings.Split(cidr, ",") {
+		if _, err := c.ovnNbCommand(IfExists, "lr-route-del", router, cidrBlock); err != nil {
+			klog.Errorf("fail to delete static route %s from %s, %v", cidrBlock, router, err)
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (c LegacyClient) DeleteStaticRouteByNextHop(nextHop string) error {


### PR DESCRIPTION
Fix bug found in qos e2e failure
```bash
I1206 04:12:59.519482      13 pod.go:787] update pod kube-system/coredns-6d4b75cb6d-2f4hg
W1206 04:12:59.525818      13 ovn-nbctl-legacy.go:52] ovn-nbctl command error: ovn-nbctl --timeout=60 --no-wait --if-exists lr-route-del ovn-cluster 10.16.0.6,fd00:10:16::6 in 10ms
E1206 04:12:59.526008      13 pod.go:401] error syncing 'kube-system/coredns-6d4b75cb6d-5r6b8': ovn-nbctl: bad prefix argument: 10.16.0.6,fd00:10:16::6
, "exit status 1", requeuing
W1206 04:12:59.530624      13 ovn-nbctl-legacy.go:52] ovn-nbctl command error: ovn-nbctl --timeout=60 --no-wait --if-exists lr-route-del ovn-cluster 10.16.0.11,fd00:10:16::b in 8ms
E1206 04:12:59.530757      13 pod.go:401] error syncing 'qos/update-netem-qos': ovn-nbctl: bad prefix argument: 10.16.0.11,fd00:10:16::b
, "exit status 1", requeuing
W1206 04:12:59.533704      13 ovn-nbctl-legacy.go:52] ovn-nbctl command error: ovn-nbctl --timeout=60 --no-wait --if-exists lr-route-del ovn-cluster 10.16.0.7,fd00:10:16::7 in 9ms
E1206 04:12:59.533842      13 pod.go:401] error syncing 'kube-system/coredns-6d4b75cb6d-2f4hg': ovn-nbctl: bad prefix argument: 10.16.0.7,fd00:10:16::7

```

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
