### PR TITLE
fix: sometimes allocate IPv6 address failed but there is available IP in V6FreeIPList

### DIFF
--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -332,6 +332,11 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac strin
 	if v4 && !subnet.V4CIDR.Contains(net.ParseIP(string(ip))) {
 		return ip, mac, ErrOutOfRange
 	}
+
+	if v6 {
+		ip = IP(net.ParseIP(string(ip)).String())
+	}
+
 	if v6 && !subnet.V6CIDR.Contains(net.ParseIP(string(ip))) {
 		return ip, mac, ErrOutOfRange
 	}


### PR DESCRIPTION
sometimes ipam.GetStaticAddress return NoAvailableAddress but there is available IP in V6FreeIPList

when use ipam.GetStaticAddress with param ipv6 address without clean Zero such as "fd00::00e9:0ed1", and exactly subnet.V6FreeIPList has a range with start fd00::e9:ed1 and end with any v6 address, or start with an any v6 address and end with fd00::e9:ed1, it will cause ipr.Start.Equal(ip) or ipr.End.Equal(ip) failed, Because equal only check the string match .


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
