### PR TITLE
kubectl-ko: fix registry/version

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -577,12 +577,13 @@ getOvnCentralPod(){
       exit 1
     fi
     OVN_SB_POD=$SB_POD
-    VERSION=$(kubectl  -n kube-system get pods -l ovn-sb-leader=true -o yaml | grep  "image: $REGISTRY/kube-ovn:" | head -n 1 | awk -F ':' '{print $3}')
-    if [ -z "$VERSION" ]; then
-          echo "kubeovn version not exists"
+    image=$(kubectl  -n kube-system get pods -l app=kube-ovn-cni -o jsonpath='{.items[0].spec.containers[0].image}')
+    if [ -z "$image" ]; then
+          echo "cannot get kube-ovn image"
           exit 1
     fi
-    KUBE_OVN_VERSION=$VERSION
+    REGISTRY=$(dirname $image)
+    KUBE_OVN_VERSION=$(basename $image | awk -F ':' '{print $2}')
 }
 
 getOvnCentralDbStatus(){


### PR DESCRIPTION
We should get image registry/version from the image being used.


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
