### PR TITLE
optimize iptables eip nat

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -100,7 +100,7 @@ func ParseFlags() (*Configuration, error) {
 		argOvnNbAddr            = pflag.String("ovn-nb-addr", "", "ovn-nb address")
 		argOvnSbAddr            = pflag.String("ovn-sb-addr", "", "ovn-sb address")
 		argOvnTimeout           = pflag.Int("ovn-timeout", 60, "")
-		argCustCrdRetryMinDelay = pflag.Int("cust-crd-retry-min-delay", 2, "The min delay seconds between custom crd two retries")
+		argCustCrdRetryMinDelay = pflag.Int("cust-crd-retry-min-delay", 1, "The min delay seconds between custom crd two retries")
 		argCustCrdRetryMaxDelay = pflag.Int("cust-crd-retry-max-delay", 20, "The max delay seconds between custom crd two retries")
 		argKubeConfigFile       = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -415,7 +415,7 @@ func (c *Controller) InitIPAM() error {
 		return err
 	}
 	for _, eip := range eips {
-		if _, _, _, err = c.ipam.GetStaticAddress(eip.Name, eip.Name, eip.Spec.V4ip, eip.Spec.MacAddress, util.VpcExternalNet, false); err != nil {
+		if _, _, _, err = c.ipam.GetStaticAddress(eip.Name, eip.Name, eip.Status.IP, eip.Spec.MacAddress, util.VpcExternalNet, true); err != nil {
 			klog.Errorf("failed to init ipam from iptables eip cr %s: %v", eip.Name, err)
 		}
 	}

--- a/pkg/controller/pod_iptables_eip.go
+++ b/pkg/controller/pod_iptables_eip.go
@@ -283,8 +283,8 @@ func (c *Controller) handleAddPodAnnotatedIptablesEip(key string) error {
 		return err
 	}
 	// update pod eip annotation
-	if eip.Spec.V4ip != "" {
-		newPod.Annotations[util.EipAnnotation] = eip.Spec.V4ip
+	if eip.Status.IP != "" {
+		newPod.Annotations[util.EipAnnotation] = eip.Status.IP
 		patch, err := util.GenerateStrategicMergePatchPayload(cachedPod, newPod)
 		if err != nil {
 			return err

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -48,7 +48,7 @@ func (ipam *IPAM) GetRandomAddress(podName, nicName, mac, subnetName string, ski
 	}
 
 	v4IP, v6IP, mac, err := subnet.GetRandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
-	klog.Infof("allocate v4 %s v6 %s mac %s for %s", v4IP, v6IP, mac, podName)
+	klog.Infof("allocate v4 %s v6 %s mac %s for %s from subnet %s", v4IP, v6IP, mac, podName, subnetName)
 	return string(v4IP), string(v6IP), mac, err
 }
 

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -151,6 +151,7 @@ const (
 	LrpUsingEip  = "lrp"
 	FipUsingEip  = "fip"
 	SnatUsingEip = "snat"
+	DnatUsingEip = "dnat"
 
 	OvnFip      = "ovn"
 	IptablesFip = "iptables"


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Bug fixes

eip as a ip holder not support change ip
nat only use eip status ip, not use spec ip
faster: create 50 eip and fips in 3 minutes
nat and eip use label to refer to each other, but label represent soft relation, if label too long should not stop eip and nat to be ready



#### Which issue(s) this PR fixes:
Fixes #(issue-number)
