### PR TITLE
add metric interface_rx_multicast_packets

### DIFF
--- a/docs/ovn-ovs-monitor.md
+++ b/docs/ovn-ovs-monitor.md
@@ -3,9 +3,9 @@
 This document shows Kube-OVN monitor metrics.
 
 | Type                | Metric                                   | Description                                                                                                                       |
-| ------------------- |------------------------------------------| --------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | OVN_Monitor         |                                          | OVN NB/SB/Northd metrics                                                                                                          |
-| Gauge               | ovn_status                               | OVN Health Status. The values are: (2) for standby or follower, (1) for active or leader, (0) for unhealthy.                                                                        |
+| Gauge               | ovn_status                               | OVN Health Status. The values are: (2) for standby or follower, (1) for active or leader, (0) for unhealthy.                      |
 | Gauge               | ovn_info                                 | This metric provides basic information about OVN. It is always set to 1.                                                          |
 | Gauge               | failed_req_count                         | The number of failed requests to OVN stack.                                                                                       |
 | Gauge               | log_file_size                            | The size of a log file associated with an OVN component.                                                                          |
@@ -35,7 +35,7 @@ This document shows Kube-OVN monitor metrics.
 | Gauge               | cluster_inbound_connections_error_total  | The total number of failed inbound connections to the server.                                                                     |
 | Gauge               | cluster_outbound_connections_error_total | The total number of failed outbound connections from the server.                                                                  |
 | OVS_Monitor         |                                          | ovsdb/vswitchd metrics                                                                                                            |
-| Gauge               | ovs_status                               | OVS Health Status. The values are: health(1), unhealthy(0).                                                                        |
+| Gauge               | ovs_status                               | OVS Health Status. The values are: health(1), unhealthy(0).                                                                       |
 | Gauge               | ovs_info                                 | This metric provides basic information about OVS. It is always set to 1.                                                          |
 | Gauge               | failed_req_count                         | The number of failed requests to OVS stack.                                                                                       |
 | Gauge               | log_file_size                            | The size of a log file associated with an OVS component.                                                                          |
@@ -71,6 +71,7 @@ This document shows Kube-OVN monitor metrics.
 | Gauge               | interface_tx_dropped                     | Represents the number of output packets dropped by OVS interface.                                                                 |
 | Gauge               | interface_tx_errors                      | Represents the total number of transmit errors by OVS interface.                                                                  |
 | Gauge               | interface_collisions                     | Represents the number of collisions on OVS interface.                                                                             |
+| Gauge               | interface_rx_multicast_packets           | Represents the count of multicast packets received by OVS interface.                                                              |
 | Kube-OVN-Pinger     |                                          | Network quality metrics                                                                                                           |
 | Gauge               | pinger_ovs_up                            | If the ovs on the node is up                                                                                                      |
 | Gauge               | pinger_ovs_down                          | If the ovs on the node is down                                                                                                    |

--- a/go.mod
+++ b/go.mod
@@ -259,7 +259,7 @@ require (
 
 replace (
 	github.com/alauda/felix => github.com/kubeovn/felix v0.0.0-20220325073257-c8a0f705d139
-	github.com/greenpau/ovsdb => github.com/alauda/ovsdb v0.0.0-20210113100339-040cf3e76c28
+	github.com/greenpau/ovsdb => github.com/kubeovn/ovsdb v0.0.0-20221213053943-9372db56919f
 	github.com/onsi/ginkgo/v2 => github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20221107163225-3335a34a1d24
 	github.com/ovn-org/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20221208095821-f8830e1998e8

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,6 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/Wifx/gonetworkmanager v0.5.0 h1:P209z0yj705bl5tmyHTlpXPSv3QzjPtIM4X0SyDAqWA=
 github.com/Wifx/gonetworkmanager v0.5.0/go.mod h1:EdhHf2O00IZXfMv9LC6CS6SgTwcMTg/ZSDhGvch0cs8=
-github.com/alauda/ovsdb v0.0.0-20210113100339-040cf3e76c28 h1:FW5M3SAwSGBdtTboeV5sI7kEY6zraApSZQxTUfZ7LQY=
-github.com/alauda/ovsdb v0.0.0-20210113100339-040cf3e76c28/go.mod h1:dXpg+IAC2yp2IZQlEVmnmEc1rqEmSZzgNfu6+ai38J4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -899,6 +897,8 @@ github.com/kubeovn/kubevirt-client-go v0.0.0-20221209084839-9c2ed1f0604d h1:sM7V
 github.com/kubeovn/kubevirt-client-go v0.0.0-20221209084839-9c2ed1f0604d/go.mod h1:FjHUGVwls5NE1q8rsSL0LsRU46p35cwgnwSItkr8oXs=
 github.com/kubeovn/libovsdb v0.0.0-20221208095821-f8830e1998e8 h1:gkYOU8DJQJeDef9hYETOf0D270zVS3xYuytjFLEi0rc=
 github.com/kubeovn/libovsdb v0.0.0-20221208095821-f8830e1998e8/go.mod h1:N20zsElkDpTm57hVDosiZVghprt9Y4Vfqsi1HBXOzr4=
+github.com/kubeovn/ovsdb v0.0.0-20221213053943-9372db56919f h1:nm0ZlQesCje/A5D0LyWfaSUM8/0ro9PVpwd8hVbLBeM=
+github.com/kubeovn/ovsdb v0.0.0-20221213053943-9372db56919f/go.mod h1:LAd0qoeAAm/QyZcpxN2BnpndM2/dhZt+/kokPvcxKcE=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyPlUHk/ofpgvBcNcawJLtf4PYHORLjAA=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=

--- a/pkg/pinger/metrics.go
+++ b/pkg/pinger/metrics.go
@@ -625,6 +625,17 @@ var (
 			"hostname",
 			"interfaceName",
 		})
+
+	interfaceStatRxMulticastPackets = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Name:      "interface_rx_multicast_packets",
+			Help:      "Represents the count of multicast packets received by OVS interface.",
+		},
+		[]string{
+			"hostname",
+			"interfaceName",
+		})
 )
 
 func InitPingerMetrics() {
@@ -694,6 +705,7 @@ func InitPingerMetrics() {
 	prometheus.MustRegister(interfaceStatTxDropped)
 	prometheus.MustRegister(interfaceStatTxErrorsTotal)
 	prometheus.MustRegister(interfaceStatCollisions)
+	prometheus.MustRegister(interfaceStatRxMulticastPackets)
 }
 
 func SetOvsUpMetrics(nodeName string) {

--- a/pkg/pinger/util.go
+++ b/pkg/pinger/util.go
@@ -226,8 +226,10 @@ func (e *Exporter) setOvsInterfaceStatisticsMetric(intf *ovsdb.OvsInterface) {
 			interfaceStatTxErrorsTotal.WithLabelValues(e.Client.System.Hostname, intf.Name).Set(float64(value))
 		case "collisions":
 			interfaceStatCollisions.WithLabelValues(e.Client.System.Hostname, intf.Name).Set(float64(value))
+		case "rx_multicast_packets":
+			interfaceStatRxMulticastPackets.WithLabelValues(e.Client.System.Hostname, intf.Name).Set(float64(value))
 		default:
-			klog.Errorf("OVS interface statistics has unsupported key: %s, value: %d", key, value)
+			klog.Warningf("unknown statistics %s with value %d on OVS interface %s", key, value, intf.Name)
 		}
 	}
 }


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Metrics


#### Which issue(s) this PR fixes:

This patch also:
1. Fix the following error in kube-ovn-pinger:

```txt
E1213 05:16:43.964946  177399 util.go:230] OVS interface statistics has unsupported key: rx_multicast_packets, value: 0
E1213 05:16:43.965016  177399 util.go:230] OVS interface statistics has unsupported key: rx_multicast_packets, value: 0
E1213 05:16:43.965080  177399 util.go:230] OVS interface statistics has unsupported key: rx_multicast_packets, value: 0
E1213 05:16:43.965124  177399 util.go:230] OVS interface statistics has unsupported key: rx_multicast_packets, value: 0
E1213 05:16:43.965156  177399 util.go:230] OVS interface statistics has unsupported key: rx_multicast_packets, value: 0
```

2. Update dependency module `github.com/greenpau/ovsdb`.
