### PR TITLE
ci: refactor previous push multi arch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,12 +1,8 @@
-name: Push Multi Arch Image
+name: Publish Release
 on:
-  workflow_run:
-    workflows: ["Build arm64 Image", "Build x86 Image"]
-    branches:
-    - master
-    - release-*
-    types:
-      - completed
+  workflow_dispatch:
+  schedule:
+  - cron: "20 16 * * *"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -14,18 +10,15 @@ concurrency:
 
 jobs:
   build:
-    name: Push multi arch images
+    name: Publish Images
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
 
-      - name: Push
-        if: ${{ github.ref == 'refs/heads/master' || contains(github.ref, 'release') }}
+      - name: Publish
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          COMMIT: ${{ github.sha }}
           DOCKER_CLI_EXPERIMENTAL: enabled
         run: |
           TAG=$(cat VERSION)


### PR DESCRIPTION
Publish based on branch that can be triggerred manually and nightly build master branch to avoid frequent image update.


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- CI
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
