### PR TITLE
fix: ovs gc just for pod if

### DIFF
--- a/pkg/ovs/ovs-vsctl.go
+++ b/pkg/ovs/ovs-vsctl.go
@@ -188,7 +188,7 @@ func ClearPodBandwidth(podName, podNamespace, ifaceID string) error {
 // When reboot node, the ovs internal interface will be deleted.
 func CleanLostInterface() {
 	// when interface error ofport will be -1
-	interfaceList, err := ovsFind("interface", "name,error", "ofport=-1")
+	interfaceList, err := ovsFind("interface", "name,error", "ofport=-1", "external_ids:pod_netns!=[]")
 	if err != nil {
 		klog.Errorf("failed to list failed interface %v", err)
 		return
@@ -206,7 +206,7 @@ func CleanLostInterface() {
 				return
 			}
 			klog.Infof("delete lost port %s", name)
-			output, err := Exec("--if-exists", "--with-iface", "del-port", "br-int", name)
+			output, err := Exec("--if-exists", "--with-iface", "del-port", name)
 			if err != nil {
 				klog.Errorf("failed to delete ovs port %v, %s", err, output)
 				return


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes


#### Which issue(s) this PR fixes:
Fixes #2085 

1. Now only interfaces of pods(with external netns) will be listed as error ones.
2. bridge name of interface now is identified by interface=>ports=>bridges, but but always br-int.  

delete eth1 and nothing happens:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/10495508/209497498-745d0106-5d6f-49e5-afc9-2ec86e9202c4.png">


delete pod interface and gc:
<img width="775" alt="image" src="https://user-images.githubusercontent.com/10495508/209497447-8c29c463-3c24-458c-8654-34392f2ea25d.png">

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/10495508/209497436-51ac7f77-8ad0-456c-a714-d5a8a0191539.png">
