### PR TITLE
local ip bind to service

### DIFF
--- a/cmd/controller_health_check/controller_health_check.go
+++ b/cmd/controller_health_check/controller_health_check.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -23,7 +24,22 @@ func CmdMain() {
 	if err := ovs.CheckAlive(); err != nil {
 		os.Exit(1)
 	}
-	conn, err := net.DialTimeout("tcp", "127.0.0.1:10660", 3*time.Second)
+
+	addr := "127.0.0.1:10660"
+	if os.Getenv("ENABLE_BIND_LOCAL_IP") == "true" {
+		podIpsEnv := os.Getenv("POD_IPS")
+		podIps := strings.Split(podIpsEnv, ",")
+		// when pod in dual mode, golang can't support bind v4 and v6 address in the same time,
+		// so not support bind local ip when in dual mode
+		if len(podIps) == 1 {
+			addr = fmt.Sprintf("%s:10660", podIps[0])
+			if util.CheckProtocol(podIps[0]) == kubeovnv1.ProtocolIPv6 {
+				addr = fmt.Sprintf("[%s]:10660", podIps[0])
+			}
+		}
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
 	if err != nil {
 		util.LogFatalAndExit(err, "failed to probe the socket")
 	}

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/sample-controller/pkg/signals"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	"github.com/kubeovn/kube-ovn/pkg/daemon"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -95,10 +96,23 @@ func CmdMain() {
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
 
+	addr := "0.0.0.0"
+	if os.Getenv("ENABLE_BIND_LOCAL_IP") == "true" {
+		podIpsEnv := os.Getenv("POD_IPS")
+		podIps := strings.Split(podIpsEnv, ",")
+		// when pod in dual mode, golang can't support bind v4 and v6 address in the same time,
+		// so not support bind local ip when in dual mode
+		if len(podIps) == 1 {
+			addr = podIps[0]
+			if util.CheckProtocol(podIps[0]) == kubeovnv1.ProtocolIPv6 {
+				addr = fmt.Sprintf("[%s]", podIps[0])
+			}
+		}
+	}
 	// conform to Gosec G114
 	// https://github.com/securego/gosec#available-rules
 	server := &http.Server{
-		Addr:              fmt.Sprintf("0.0.0.0:%d", config.PprofPort),
+		Addr:              fmt.Sprintf("%s:%d", addr, config.PprofPort),
 		ReadHeaderTimeout: 3 * time.Second,
 		Handler:           mux,
 	}

--- a/cmd/ovn_monitor/ovn_monitor.go
+++ b/cmd/ovn_monitor/ovn_monitor.go
@@ -1,12 +1,16 @@
 package ovn_monitor
 
 import (
+	"fmt"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	ovn "github.com/kubeovn/kube-ovn/pkg/ovnmonitor"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/versions"
@@ -33,8 +37,23 @@ func CmdMain() {
 
 	// conform to Gosec G114
 	// https://github.com/securego/gosec#available-rules
+
+	addr := config.ListenAddress
+	if os.Getenv("ENABLE_BIND_LOCAL_IP") == "true" {
+		podIpsEnv := os.Getenv("POD_IPS")
+		podIps := strings.Split(podIpsEnv, ",")
+		// when pod in dual mode, golang can't support bind v4 and v6 address in the same time,
+		// so not support bind local ip when in dual mode
+		if len(podIps) == 1 {
+			addr = fmt.Sprintf("%s:10661", podIps[0])
+			if util.CheckProtocol(podIps[0]) == kubeovnv1.ProtocolIPv6 {
+				addr = fmt.Sprintf("[%s]:10661", podIps[0])
+			}
+		}
+	}
+
 	server := &http.Server{
-		Addr:              config.ListenAddress,
+		Addr:              addr,
 		ReadHeaderTimeout: 3 * time.Second,
 	}
 	util.LogFatalAndExit(server.ListenAndServe(), "failed to listen and server on %s", config.ListenAddress)

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2023,6 +2023,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 300m
@@ -2517,6 +2521,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 300m
@@ -3016,6 +3024,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
               value: $addresses
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
@@ -3140,6 +3152,10 @@ spec:
             value: $MODULES
           - name: RPMS
             value: $RPMS
+          - name: POD_IPS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIPs
         volumeMounts:
           - name: host-modules
             mountPath: /lib/modules
@@ -3419,6 +3435,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 200m

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -27,6 +27,7 @@ IFACE=${IFACE:-}
 # Specifies the name of the dpdk tunnel iface.
 # Note that the dpdk tunnel iface and tunnel ip cidr should be diffierent with Kubernetes api cidr,otherwise the route will be a problem.
 DPDK_TUNNEL_IFACE=${DPDK_TUNNEL_IFACE:-br-phy}
+ENABLE_BIND_LOCAL_IP=${ENABLE_BIND_LOCAL_IP:-true}
 
 CNI_CONF_DIR="/etc/cni/net.d"
 CNI_BIN_DIR="/opt/cni/bin"
@@ -2028,7 +2029,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "true"
+              value: "$ENABLE_BIND_LOCAL_IP"
           resources:
             requests:
               cpu: 300m
@@ -2528,7 +2529,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "true"
+              value: "$ENABLE_BIND_LOCAL_IP"
           resources:
             requests:
               cpu: 300m
@@ -3033,7 +3034,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "true"
+              value: "$ENABLE_BIND_LOCAL_IP"
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
@@ -3163,7 +3164,7 @@ spec:
               fieldRef:
                 fieldPath: status.podIPs
           - name: ENABLE_BIND_LOCAL_IP
-            value: "true"
+            value: "$ENABLE_BIND_LOCAL_IP"
         volumeMounts:
           - name: host-modules
             mountPath: /lib/modules
@@ -3448,7 +3449,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "true"
+              value: "$ENABLE_BIND_LOCAL_IP"
           resources:
             requests:
               cpu: 200m

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2027,6 +2027,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
               cpu: 300m
@@ -2525,6 +2527,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
               cpu: 300m
@@ -3028,6 +3032,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
@@ -3156,6 +3162,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIPs
+          - name: ENABLE_BIND_LOCAL_IP
+            value: "true"
         volumeMounts:
           - name: host-modules
             mountPath: /lib/modules
@@ -3439,6 +3447,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
               cpu: 200m

--- a/dist/images/ovn-is-leader.sh
+++ b/dist/images/ovn-is-leader.sh
@@ -8,12 +8,24 @@ ovn-ctl status_northd
 ovn-ctl status_ovnnb
 ovn-ctl status_ovnsb
 
+BIND_LOCAL_ADDR=127.0.0.1
+if [[ $ENABLE_BIND_LOCAL_IP == "true" ]]; then
+  POD_IPS_LIST=(${POD_IPS//,/ })
+  if [[ ${#POD_IPS_LIST[@]} == 1 ]]; then
+    if [[ $POD_IP =~ .*:.* ]]; then
+      BIND_LOCAL_ADDR=[${POD_IP}] #ipv6
+    else
+      BIND_LOCAL_ADDR=${POD_IP} #ipv4
+    fi
+  fi
+fi
+
 # For data consistency, only store leader address in endpoint
 # Store ovn-nb leader to svc kube-system/ovn-nb
 if [[ "$ENABLE_SSL" == "false" ]]; then
-  nb_leader=$(ovsdb-client query tcp:127.0.0.1:6641 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Northbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
+  nb_leader=$(ovsdb-client query tcp:$BIND_LOCAL_ADDR:6641 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Northbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
 else
-  nb_leader=$(ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert query ssl:127.0.0.1:6641 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Northbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
+  nb_leader=$(ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert query ssl:$BIND_LOCAL_ADDR:6641 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Northbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
 fi
 
 if [[ $nb_leader =~ "true" ]]
@@ -34,9 +46,9 @@ fi
 
 # Store ovn-sb leader to svc kube-system/ovn-sb
 if [[ "$ENABLE_SSL" == "false" ]]; then
-  sb_leader=$(ovsdb-client query tcp:127.0.0.1:6642 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Southbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
+  sb_leader=$(ovsdb-client query tcp:$BIND_LOCAL_ADDR:6642 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Southbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
 else
-  sb_leader=$(ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert query ssl:127.0.0.1:6642 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Southbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
+  sb_leader=$(ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert query ssl:$BIND_LOCAL_ADDR:6642 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Southbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
 fi
 
 if [[ $sb_leader =~ "true" ]]
@@ -51,9 +63,9 @@ then
     if [ "$northd_leader" == "" ]; then
        # no available northd leader try to release the lock
        if [[ "$ENABLE_SSL" == "false" ]]; then
-         ovsdb-client -v -t 1 steal tcp:127.0.0.1:6642  ovn_northd
+         ovsdb-client -v -t 1 steal tcp:$BIND_LOCAL_ADDR:6642  ovn_northd
        else
-         ovsdb-client -v -t 1 -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert steal ssl:127.0.0.1:6642  ovn_northd
+         ovsdb-client -v -t 1 -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert steal ssl:$BIND_LOCAL_ADDR:6642  ovn_northd
        fi
      fi
    fi

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -25,6 +25,14 @@ DB_NB_PORT=${DB_NB_PORT:-6641}
 DB_SB_ADDR=${DB_SB_ADDR:-::}
 DB_SB_PORT=${DB_SB_PORT:-6642}
 ENABLE_SSL=${ENABLE_SSL:-false}
+ENABLE_BIND_LOCAL_IP=${ENABLE_BIND_LOCAL_IP:-false}
+BIND_LOCAL_ADDR=[::]
+if [[ $ENABLE_BIND_LOCAL_IP == "true" ]]; then
+  POD_IPS_LIST=(${POD_IPS//,/ })
+  if [[ ${#POD_IPS_LIST[@]} == 1 ]]; then
+    BIND_LOCAL_ADDR="[${POD_IP}]"
+  fi
+fi
 
 . /usr/share/openvswitch/scripts/ovs-lib || exit 1
 
@@ -177,8 +185,8 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                 --db-sb-create-insecure-remote=yes \
                 --db-nb-cluster-local-addr="[${POD_IP}]" \
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
-                --db-nb-addr=[::] \
-                --db-sb-addr=[::] \
+                --db-nb-addr=$BIND_LOCAL_ADDR \
+                --db-sb-addr=$BIND_LOCAL_ADDR \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
@@ -222,8 +230,8 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
                 --db-nb-cluster-remote-addr="[${nb_leader_ip}]" \
                 --db-sb-cluster-remote-addr="[${sb_leader_ip}]" \
-                --db-nb-addr=[::] \
-                --db-sb-addr=[::] \
+                --db-nb-addr=$BIND_LOCAL_ADDR \
+                --db-sb-addr=$BIND_LOCAL_ADDR \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
@@ -277,16 +285,16 @@ else
                 --ovn-northd-ssl-ca-cert=/var/run/tls/cacert \
                 --db-nb-cluster-local-addr="[${POD_IP}]" \
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
-                --db-nb-addr=[::] \
-                --db-sb-addr=[::] \
+                --db-nb-addr=$BIND_LOCAL_ADDR \
+                --db-sb-addr=$BIND_LOCAL_ADDR \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
-            ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_NB_PORT}":[::]
+            ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_NB_PORT}":$BIND_LOCAL_ADDR
             ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=180000
             ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set NB_Global . options:use_logical_dp_groups=true
 
-            ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_SB_PORT}":[::]
+            ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_SB_PORT}":$BIND_LOCAL_ADDR
             ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=180000
         else
             # get leader if cluster exists
@@ -328,8 +336,8 @@ else
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
                 --db-nb-cluster-remote-addr="[${nb_leader_ip}]" \
                 --db-sb-cluster-remote-addr="[${sb_leader_ip}]" \
-                --db-nb-addr=[::] \
-                --db-sb-addr=[::] \
+                --db-nb-addr=$BIND_LOCAL_ADDR \
+                --db-sb-addr=$BIND_LOCAL_ADDR \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd

--- a/kubeovn-helm/templates/central-deploy.yaml
+++ b/kubeovn-helm/templates/central-deploy.yaml
@@ -69,6 +69,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
               cpu: 300m

--- a/kubeovn-helm/templates/central-deploy.yaml
+++ b/kubeovn-helm/templates/central-deploy.yaml
@@ -65,6 +65,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 300m

--- a/kubeovn-helm/templates/central-deploy.yaml
+++ b/kubeovn-helm/templates/central-deploy.yaml
@@ -70,7 +70,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "true"
+              value: "{{- .Values.func.ENABLE_BIND_LOCAL_IP }}"
           resources:
             requests:
               cpu: 300m

--- a/kubeovn-helm/templates/controller-deploy.yaml
+++ b/kubeovn-helm/templates/controller-deploy.yaml
@@ -120,7 +120,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "true"
+              value: "{{- .Values.func.ENABLE_BIND_LOCAL_IP }}"
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime

--- a/kubeovn-helm/templates/controller-deploy.yaml
+++ b/kubeovn-helm/templates/controller-deploy.yaml
@@ -115,6 +115,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
               value: "{{ .Values.MASTER_NODES }}"
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime

--- a/kubeovn-helm/templates/controller-deploy.yaml
+++ b/kubeovn-helm/templates/controller-deploy.yaml
@@ -119,6 +119,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime

--- a/kubeovn-helm/templates/monitor-deploy.yaml
+++ b/kubeovn-helm/templates/monitor-deploy.yaml
@@ -53,6 +53,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 200m

--- a/kubeovn-helm/templates/monitor-deploy.yaml
+++ b/kubeovn-helm/templates/monitor-deploy.yaml
@@ -57,6 +57,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
               cpu: 200m

--- a/kubeovn-helm/templates/monitor-deploy.yaml
+++ b/kubeovn-helm/templates/monitor-deploy.yaml
@@ -58,7 +58,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "true"
+              value: "{{- .Values.func.ENABLE_BIND_LOCAL_IP }}"
           resources:
             requests:
               cpu: 200m

--- a/kubeovn-helm/templates/ovncni-ds.yaml
+++ b/kubeovn-helm/templates/ovncni-ds.yaml
@@ -95,7 +95,7 @@ spec:
               fieldRef:
                 fieldPath: status.podIPs
           - name: ENABLE_BIND_LOCAL_IP
-            value: "true"
+            value: "{{- .Values.func.ENABLE_BIND_LOCAL_IP }}"
         volumeMounts:
           - name: host-modules
             mountPath: /lib/modules

--- a/kubeovn-helm/templates/ovncni-ds.yaml
+++ b/kubeovn-helm/templates/ovncni-ds.yaml
@@ -94,6 +94,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIPs
+          - name: ENABLE_BIND_LOCAL_IP
+            value: "true"
         volumeMounts:
           - name: host-modules
             mountPath: /lib/modules

--- a/kubeovn-helm/templates/ovncni-ds.yaml
+++ b/kubeovn-helm/templates/ovncni-ds.yaml
@@ -90,6 +90,10 @@ spec:
             value: "{{- .Values.performance.MODULES }}"
           - name: RPMS
             value: "{{- .Values.performance.RPMS }}"
+          - name: POD_IPS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIPs
         volumeMounts:
           - name: host-modules
             mountPath: /lib/modules

--- a/kubeovn-helm/values.yaml
+++ b/kubeovn-helm/values.yaml
@@ -49,6 +49,7 @@ func:
   LS_DNAT_MOD_DL_DST: true
   CHECK_GATEWAY: true
   LOGICAL_GATEWAY: false
+  ENABLE_BIND_LOCAL_IP: true
 
 ipv4:
   POD_CIDR: "10.16.0.0/16"

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -138,10 +139,18 @@ func checkOvnIsAlive() bool {
 
 func checkNbIsLeader() bool {
 	var command []string
+	listenIp := "127.0.0.1"
+	if os.Getenv("ENABLE_BIND_LOCAL_IP") == "true" {
+		listenIp = os.Getenv("POD_IP")
+		if util.CheckProtocol(listenIp) == kubeovnv1.ProtocolIPv6 {
+			listenIp = fmt.Sprintf("[%s]", os.Getenv("POD_IP"))
+		}
+	}
+
 	if os.Getenv(EnvSSL) == "false" {
 		command = []string{
 			"query",
-			"tcp:127.0.0.1:6641",
+			fmt.Sprintf("tcp:%s:6641", listenIp),
 			`["_Server",{"table":"Database","where":[["name","==","OVN_Northbound"]],"columns":["leader"],"op":"select"}]`,
 		}
 	} else {
@@ -153,7 +162,7 @@ func checkNbIsLeader() bool {
 			"-C",
 			"/var/run/tls/cacert",
 			"query",
-			"ssl:127.0.0.1:6641",
+			fmt.Sprintf("ssl:%s:6641", listenIp),
 			`["_Server",{"table":"Database","where":[["name","==","OVN_Northbound"]],"columns":["leader"],"op":"select"}]`,
 		}
 	}
@@ -176,10 +185,18 @@ func checkNbIsLeader() bool {
 
 func checkSbIsLeader() bool {
 	var command []string
+	listenIp := "127.0.0.1"
+	if os.Getenv("ENABLE_BIND_LOCAL_IP") == "true" {
+		listenIp = os.Getenv("POD_IP")
+		if util.CheckProtocol(listenIp) == kubeovnv1.ProtocolIPv6 {
+			listenIp = fmt.Sprintf("[%s]", os.Getenv("POD_IP"))
+		}
+	}
+
 	if os.Getenv(EnvSSL) == "false" {
 		command = []string{
 			"query",
-			"tcp:127.0.0.1:6642",
+			fmt.Sprintf("tcp:%s:6642", listenIp),
 			`["_Server",{"table":"Database","where":[["name","==","OVN_Southbound"]],"columns":["leader"],"op":"select"}]`,
 		}
 	} else {
@@ -191,7 +208,7 @@ func checkSbIsLeader() bool {
 			"-C",
 			"/var/run/tls/cacert",
 			"query",
-			"ssl:127.0.0.1:6642",
+			fmt.Sprintf("ssl:%s:6642", listenIp),
 			`["_Server",{"table":"Database","where":[["name","==","OVN_Southbound"]],"columns":["leader"],"op":"select"}]`,
 		}
 	}

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -75,6 +75,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
@@ -182,6 +186,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           volumeMounts:
             - name: host-modules
               mountPath: /lib/modules
@@ -422,6 +430,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 200m

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -76,6 +76,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           volumeMounts:
             - mountPath: /var/run/tls
               name: kube-ovn-tls
@@ -171,6 +175,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           volumeMounts:
             - name: host-modules
               mountPath: /lib/modules
@@ -394,6 +402,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 200m

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -75,6 +75,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
@@ -182,6 +186,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           volumeMounts:
             - name: host-modules
               mountPath: /lib/modules
@@ -437,6 +445,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 200m

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -225,6 +225,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 500m

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -244,6 +244,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 500m

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -254,6 +254,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
for security purposes,  local services should bind to local IP but not 0.0.0.0 or ::
- Bug fixes
- Docs
- Tests

when deploying below deployment or ds :kube-ovn-controler/kube-ovn-monitor/kube-ovn-cni/ovn-central

add an env variable
            - name: ENABLE_BIND_LOCAL_IP
              value: "true"

it will work like below
```
root@kube-ovn-worker:/kube-ovn# netstat -tunlp | grep kube-ovn
tcp6       0      0 fc00:f853:ccd:e79:10665 :::*                    LISTEN      1805/./kube-ovn-dae
tcp6       0      0 fc00:f853:ccd:e79:10660 :::*                    LISTEN      1468/./kube-ovn-con
```
this feature will not work when the network is in the dual mode because golang can't support binding v4 and v6 addresses at the same time.

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
in jira ACP-20335
