### PR TITLE
ovn nb and sb can't bind lan ip in ssl

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2024,12 +2024,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: POD_IPS
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIPs
-            - name: ENABLE_BIND_LOCAL_IP
-              value: "$ENABLE_BIND_LOCAL_IP"
           resources:
             requests:
               cpu: 300m
@@ -2524,12 +2518,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: POD_IPS
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIPs
-            - name: ENABLE_BIND_LOCAL_IP
-              value: "$ENABLE_BIND_LOCAL_IP"
           resources:
             requests:
               cpu: 300m

--- a/dist/images/ovn-is-leader.sh
+++ b/dist/images/ovn-is-leader.sh
@@ -8,24 +8,12 @@ ovn-ctl status_northd
 ovn-ctl status_ovnnb
 ovn-ctl status_ovnsb
 
-BIND_LOCAL_ADDR=127.0.0.1
-if [[ $ENABLE_BIND_LOCAL_IP == "true" ]]; then
-  POD_IPS_LIST=(${POD_IPS//,/ })
-  if [[ ${#POD_IPS_LIST[@]} == 1 ]]; then
-    if [[ $POD_IP =~ .*:.* ]]; then
-      BIND_LOCAL_ADDR=[${POD_IP}] #ipv6
-    else
-      BIND_LOCAL_ADDR=${POD_IP} #ipv4
-    fi
-  fi
-fi
-
 # For data consistency, only store leader address in endpoint
 # Store ovn-nb leader to svc kube-system/ovn-nb
 if [[ "$ENABLE_SSL" == "false" ]]; then
-  nb_leader=$(ovsdb-client query tcp:$BIND_LOCAL_ADDR:6641 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Northbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
+  nb_leader=$(ovsdb-client query tcp:127.0.0.1:6641 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Northbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
 else
-  nb_leader=$(ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert query ssl:$BIND_LOCAL_ADDR:6641 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Northbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
+  nb_leader=$(ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert query ssl:127.0.0.1:6641 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Northbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
 fi
 
 if [[ $nb_leader =~ "true" ]]
@@ -46,9 +34,9 @@ fi
 
 # Store ovn-sb leader to svc kube-system/ovn-sb
 if [[ "$ENABLE_SSL" == "false" ]]; then
-  sb_leader=$(ovsdb-client query tcp:$BIND_LOCAL_ADDR:6642 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Southbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
+  sb_leader=$(ovsdb-client query tcp:127.0.0.1:6642 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Southbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
 else
-  sb_leader=$(ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert query ssl:$BIND_LOCAL_ADDR:6642 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Southbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
+  sb_leader=$(ovsdb-client -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert query ssl:127.0.0.1:6642 "[\"_Server\",{\"table\":\"Database\",\"where\":[[\"name\",\"==\", \"OVN_Southbound\"]],\"columns\": [\"leader\"],\"op\":\"select\"}]")
 fi
 
 if [[ $sb_leader =~ "true" ]]
@@ -63,9 +51,9 @@ then
     if [ "$northd_leader" == "" ]; then
        # no available northd leader try to release the lock
        if [[ "$ENABLE_SSL" == "false" ]]; then
-         ovsdb-client -v -t 1 steal tcp:$BIND_LOCAL_ADDR:6642  ovn_northd
+         ovsdb-client -v -t 1 steal tcp:127.0.0.1:6642  ovn_northd
        else
-         ovsdb-client -v -t 1 -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert steal ssl:$BIND_LOCAL_ADDR:6642  ovn_northd
+         ovsdb-client -v -t 1 -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert steal ssl:127.0.0.1:6642  ovn_northd
        fi
      fi
    fi

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -25,14 +25,6 @@ DB_NB_PORT=${DB_NB_PORT:-6641}
 DB_SB_ADDR=${DB_SB_ADDR:-::}
 DB_SB_PORT=${DB_SB_PORT:-6642}
 ENABLE_SSL=${ENABLE_SSL:-false}
-ENABLE_BIND_LOCAL_IP=${ENABLE_BIND_LOCAL_IP:-false}
-BIND_LOCAL_ADDR=[::]
-if [[ $ENABLE_BIND_LOCAL_IP == "true" ]]; then
-  POD_IPS_LIST=(${POD_IPS//,/ })
-  if [[ ${#POD_IPS_LIST[@]} == 1 ]]; then
-    BIND_LOCAL_ADDR="[${POD_IP}]"
-  fi
-fi
 
 . /usr/share/openvswitch/scripts/ovs-lib || exit 1
 
@@ -185,8 +177,8 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                 --db-sb-create-insecure-remote=yes \
                 --db-nb-cluster-local-addr="[${POD_IP}]" \
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
-                --db-nb-addr=$BIND_LOCAL_ADDR \
-                --db-sb-addr=$BIND_LOCAL_ADDR \
+                --db-nb-addr=[::] \
+                --db-sb-addr=[::] \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
@@ -230,8 +222,8 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
                 --db-nb-cluster-remote-addr="[${nb_leader_ip}]" \
                 --db-sb-cluster-remote-addr="[${sb_leader_ip}]" \
-                --db-nb-addr=$BIND_LOCAL_ADDR \
-                --db-sb-addr=$BIND_LOCAL_ADDR \
+                --db-nb-addr=[::] \
+                --db-sb-addr=[::] \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
@@ -285,16 +277,16 @@ else
                 --ovn-northd-ssl-ca-cert=/var/run/tls/cacert \
                 --db-nb-cluster-local-addr="[${POD_IP}]" \
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
-                --db-nb-addr=$BIND_LOCAL_ADDR \
-                --db-sb-addr=$BIND_LOCAL_ADDR \
+                --db-nb-addr=[::] \
+                --db-sb-addr=[::] \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
-            ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_NB_PORT}":$BIND_LOCAL_ADDR
+            ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_NB_PORT}":[::]
             ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=180000
             ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set NB_Global . options:use_logical_dp_groups=true
 
-            ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_SB_PORT}":$BIND_LOCAL_ADDR
+            ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_SB_PORT}":[::]
             ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=180000
         else
             # get leader if cluster exists
@@ -336,8 +328,8 @@ else
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
                 --db-nb-cluster-remote-addr="[${nb_leader_ip}]" \
                 --db-sb-cluster-remote-addr="[${sb_leader_ip}]" \
-                --db-nb-addr=$BIND_LOCAL_ADDR \
-                --db-sb-addr=$BIND_LOCAL_ADDR \
+                --db-nb-addr=[::] \
+                --db-sb-addr=[::] \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd

--- a/kubeovn-helm/templates/central-deploy.yaml
+++ b/kubeovn-helm/templates/central-deploy.yaml
@@ -65,12 +65,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: POD_IPS
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIPs
-            - name: ENABLE_BIND_LOCAL_IP
-              value: "{{- .Values.func.ENABLE_BIND_LOCAL_IP }}"
           resources:
             requests:
               cpu: 300m

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -139,18 +138,10 @@ func checkOvnIsAlive() bool {
 
 func checkNbIsLeader() bool {
 	var command []string
-	listenIp := "127.0.0.1"
-	if os.Getenv("ENABLE_BIND_LOCAL_IP") == "true" {
-		listenIp = os.Getenv("POD_IP")
-		if util.CheckProtocol(listenIp) == kubeovnv1.ProtocolIPv6 {
-			listenIp = fmt.Sprintf("[%s]", os.Getenv("POD_IP"))
-		}
-	}
-
 	if os.Getenv(EnvSSL) == "false" {
 		command = []string{
 			"query",
-			fmt.Sprintf("tcp:%s:6641", listenIp),
+			"tcp:127.0.0.1:6641",
 			`["_Server",{"table":"Database","where":[["name","==","OVN_Northbound"]],"columns":["leader"],"op":"select"}]`,
 		}
 	} else {
@@ -162,7 +153,7 @@ func checkNbIsLeader() bool {
 			"-C",
 			"/var/run/tls/cacert",
 			"query",
-			fmt.Sprintf("ssl:%s:6641", listenIp),
+			"ssl:127.0.0.1:6641",
 			`["_Server",{"table":"Database","where":[["name","==","OVN_Northbound"]],"columns":["leader"],"op":"select"}]`,
 		}
 	}
@@ -185,18 +176,10 @@ func checkNbIsLeader() bool {
 
 func checkSbIsLeader() bool {
 	var command []string
-	listenIp := "127.0.0.1"
-	if os.Getenv("ENABLE_BIND_LOCAL_IP") == "true" {
-		listenIp = os.Getenv("POD_IP")
-		if util.CheckProtocol(listenIp) == kubeovnv1.ProtocolIPv6 {
-			listenIp = fmt.Sprintf("[%s]", os.Getenv("POD_IP"))
-		}
-	}
-
 	if os.Getenv(EnvSSL) == "false" {
 		command = []string{
 			"query",
-			fmt.Sprintf("tcp:%s:6642", listenIp),
+			"tcp:127.0.0.1:6642",
 			`["_Server",{"table":"Database","where":[["name","==","OVN_Southbound"]],"columns":["leader"],"op":"select"}]`,
 		}
 	} else {
@@ -208,7 +191,7 @@ func checkSbIsLeader() bool {
 			"-C",
 			"/var/run/tls/cacert",
 			"query",
-			fmt.Sprintf("ssl:%s:6642", listenIp),
+			"ssl:127.0.0.1:6642",
 			`["_Server",{"table":"Database","where":[["name","==","OVN_Southbound"]],"columns":["leader"],"op":"select"}]`,
 		}
 	}

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -225,10 +225,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: POD_IPS
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 500m

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -244,10 +244,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: POD_IPS
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 500m

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -254,10 +254,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: POD_IPS
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIPs
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
该pr  不让ovn-central的ovsdb-server进行绑localip的操作。改回绑定[::]

原因是因为在ovncentral多master节点情况下且连接db方式为ssl会出问题：
具体如下：
1. master节点会去配置db connections字段，这个字段会被配置为master节点的localhost ip
2. 非master节点也是会监听这个connections字段，但本地又没有master节点的localhost ip所以报错了。以前因为是监听[::]，本地节点存在[::]，所以不存在该问题。

这个我看了配置貌似没有比较好的解决方法，
1. ovn貌似没提供单独的配置去配置ssl的监听端口（ptcp有），所以必须得通过配置db connections字段来达成。
2. connections这个字段是全局唯一的。只能配一个或者一组ip下去。我试过修改connections字段包含所有节点的localhostip，看ovn的行为是不是只要能监听到其中一个节点的localhostip:6641就认为正常了，但试了不是这样。他会认为connections下所有ip:port都能监听到才算正常。

=================================

 

另外多master节点且连接db方式为ptcp的情况下，绑定localhost ip是可以配置的：

https://satishdotpatel.github.io/openstack-ansible-ovn-clustering/

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
