### PR TITLE
fix: ovnic del old AZ after establish the new as name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,8 +236,8 @@ kind-init-ipv4: kind-clean
 	@$(MAKE) kind-create
 
 .PHONY: kind-init-ovn-ic
-kind-init-ovn-ic: kind-clean-ovn-ic kind-init-single
-	@single=true $(MAKE) kind-generate-config
+kind-init-ovn-ic: kind-clean-ovn-ic kind-init-ha
+	@ha=true $(MAKE) kind-generate-config
 	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1)
 
 .PHONY: kind-init-iptables

--- a/pkg/controller/ovn-ic.go
+++ b/pkg/controller/ovn-ic.go
@@ -106,16 +106,17 @@ func (c *Controller) resyncInterConnection() {
 			}
 			c.ovnLegacyClient.OvnICSbAddress = genHostAddress(cm.Data["ic-db-host"], cm.Data["ic-sb-port"])
 
-			if err := c.RemoveOldChassisInSbDB(); err != nil {
-				klog.Errorf("failed to remove remote chassis: %v", err)
-			}
-
 			c.ovnLegacyClient.OvnICNbAddress = genHostAddress(cm.Data["ic-db-host"], cm.Data["ic-nb-port"])
 			klog.Info("start to reestablish ovn-ic")
 			if err := c.establishInterConnection(cm.Data); err != nil {
 				klog.Errorf("failed to reestablish ovn-ic, %v", err)
 				return
 			}
+
+			if err := c.RemoveOldChassisInSbDB(lastIcCm["az-name"]); err != nil {
+				klog.Errorf("failed to remove remote chassis: %v", err)
+			}
+
 			icEnabled = "true"
 			lastIcCm = cm.Data
 			klog.Info("finish reestablishing ovn-ic")
@@ -456,8 +457,8 @@ func (c *Controller) SynRouteToPolicy() {
 	}
 }
 
-func (c *Controller) RemoveOldChassisInSbDB() error {
-	azUUID, err := c.ovnLegacyClient.GetAzUUID(lastIcCm["az-name"])
+func (c *Controller) RemoveOldChassisInSbDB(azName string) error {
+	azUUID, err := c.ovnLegacyClient.GetAzUUID(azName)
 	if err != nil {
 		klog.Errorf("failed to get UUID of AZ %s: %v", lastIcCm["az-name"], err)
 	}

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -194,6 +194,14 @@ var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 		ginkgo.By("Waiting for new az names to be applied")
 		time.Sleep(10 * time.Second)
 
+		pods, err := clientSets[0].CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "app=ovs"})
+		framework.ExpectNoError(err, "failed to get ovs-ovn pods")
+		cmd := "ovn-appctl -t ovn-controller inc-engine/recompute"
+		for _, pod := range pods.Items {
+			execPodOrDie(frameworks[0].KubeContext, "kube-system", pod.Name, cmd)
+		}
+		time.Sleep(2 * time.Second)
+
 		ginkgo.By("Ensuring logical switch ts exists in cluster " + clusters[0])
 		output := execOrDie(frameworks[0].KubeContext, "ko nbctl show ts")
 		for _, az := range azNames {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes


#### Which issue(s) this PR fixes:
Fixes #2205 

The old availability_zone would be deleted before new availability_zone is added into the IC  South DB.
However,  it's possible that IC controller will notice that availability_zone is empty after the deletion of availability_zone, but before addition of the new availability_zone. 
So IC controller will restore availability_zone with the old configuration, and then the new availability_zone will be blocked.

So now deletion for availability_zone will act after the new availability_zone is added.

-------------New problem----
after the change of deletion, the ovn-north could not recognize the next hop of other clusters. 
The central pod need to be reboot...
<img width="955" alt="image" src="https://user-images.githubusercontent.com/10495508/211180702-b372d486-fca2-4b50-84c0-caf772377cae.png">

Now central pod do not need to be reboot. 
But an extra recompute command need to be applied in a CNI pod.
```bash
$ ovn-appctl -t ovn-controller inc-engine/recompute
```
Well this command need to be executed in each CNI pod...