### PR TITLE
use node ip instead of ovn0 ip when accessing pod/svc from host network

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -43,6 +43,7 @@ type Configuration struct {
 	KubeOvnClient           clientset.Interface
 	NodeName                string
 	ServiceClusterIPRange   string
+	NodeSwitch              string
 	NodeLocalDnsIP          string
 	EncapChecksum           bool
 	EnablePprof             bool
@@ -73,6 +74,7 @@ func ParseFlags() *Configuration {
 		argOvsSocket             = pflag.String("ovs-socket", "", "The socket to local ovs-server")
 		argKubeConfigFile        = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argServiceClusterIPRange = pflag.String("service-cluster-ip-range", "10.96.0.0/12", "The kubernetes service cluster ip range")
+		argNodeSwitch            = pflag.String("node-switch", "join", "The name of node gateway switch which help node to access pod network")
 		argNodeLocalDnsIP        = pflag.String("node-local-dns-ip", "", "If use nodelocaldns the local dns server ip should be set here.")
 		argEncapChecksum         = pflag.Bool("encap-checksum", true, "Enable checksum")
 		argEnablePprof           = pflag.Bool("enable-pprof", false, "Enable pprof")
@@ -125,6 +127,7 @@ func ParseFlags() *Configuration {
 		MacLearningFallback:     *argMacLearningFallback,
 		NodeName:                strings.ToLower(*argNodeName),
 		ServiceClusterIPRange:   *argServiceClusterIPRange,
+		NodeSwitch:              *argNodeSwitch,
 		NodeLocalDnsIP:          *argNodeLocalDnsIP,
 		EncapChecksum:           *argEncapChecksum,
 		NetworkType:             *argsNetworkType,

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -550,7 +550,7 @@ func (c *Controller) setIptables() error {
 			rules[1] = util.IPTableRule{
 				Table: NAT,
 				Chain: OvnPostrouting,
-				Rule:  strings.Fields(fmt.Sprintf(`-m set --match-set %s src -m mark --mark 0x4000/0x4000 -j SNAT --to-source %s`, svcMatchset, nodeIP)),
+				Rule:  strings.Fields(fmt.Sprintf(`-m set --match-set %s src -m set --match-set %s dst -m mark --mark 0x4000/0x4000 -j SNAT --to-source %s`, svcMatchset, matchset, nodeIP)),
 			}
 			iptablesRules = rules
 

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -527,14 +527,14 @@ func (c *Controller) setIptables() error {
 			continue
 		}
 
-		var kubeProxyIpsetProtocol, matchset string
+		var kubeProxyIpsetProtocol, matchset, svcMatchset string
 		var abandonedRules, iptablesRules []util.IPTableRule
 		if protocol == kubeovnv1.ProtocolIPv4 {
 			iptablesRules, abandonedRules = v4Rules, v4AbandonedRules
-			matchset = "ovn40subnets"
+			matchset, svcMatchset = "ovn40subnets", "ovn40services"
 		} else {
 			iptablesRules, abandonedRules = v6Rules, v6AbandonedRules
-			kubeProxyIpsetProtocol, matchset = "6-", "ovn60subnets"
+			kubeProxyIpsetProtocol, matchset, svcMatchset = "6-", "ovn60subnets", "ovn60services"
 		}
 
 		if nodeIP := nodeIPs[protocol]; nodeIP != "" {
@@ -543,6 +543,16 @@ func (c *Controller) setIptables() error {
 				util.IPTableRule{Table: NAT, Chain: Postrouting, Rule: strings.Fields(fmt.Sprintf(`! -s %s -m mark --mark 0x4000/0x4000 -j MASQUERADE`, nodeIP))},
 				util.IPTableRule{Table: NAT, Chain: Postrouting, Rule: strings.Fields(fmt.Sprintf(`! -s %s -m set ! --match-set %s src -m set --match-set %s dst -j MASQUERADE`, nodeIP, matchset, matchset))},
 			)
+
+			rules := make([]util.IPTableRule, len(iptablesRules)+1)
+			copy(rules, iptablesRules[:1])
+			copy(rules[2:], iptablesRules[1:])
+			rules[1] = util.IPTableRule{
+				Table: NAT,
+				Chain: OvnPostrouting,
+				Rule:  strings.Fields(fmt.Sprintf(`-m set --match-set %s src -m mark --mark 0x4000/0x4000 -j SNAT --to-source %s`, svcMatchset, nodeIP)),
+			}
+			iptablesRules = rules
 
 			for _, p := range [...]string{"tcp", "udp"} {
 				ipset := fmt.Sprintf("KUBE-%sNODE-PORT-LOCAL-%s", kubeProxyIpsetProtocol, strings.ToUpper(p))

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -309,7 +309,7 @@ func (c *Controller) createIptablesRule(protocol string, rule util.IPTableRule) 
 
 	s := strings.Join(rule.Rule, " ")
 	if exists {
-		klog.V(3).Infof(`iptables rule "%s" already exists`, s, exists)
+		klog.V(3).Infof(`iptables rule %q already exists`, s)
 		return nil
 	}
 

--- a/test/e2e/kube-ovn/node/node.go
+++ b/test/e2e/kube-ovn/node/node.go
@@ -1,24 +1,56 @@
 package node
 
 import (
+	"fmt"
+	"math/rand"
+	"net"
+	"strconv"
+	"strings"
+
 	clientset "k8s.io/client-go/kubernetes"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 
 	"github.com/onsi/ginkgo/v2"
 
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework/iproute"
 )
 
-var _ = framework.Describe("[group:node]", func() {
+var _ = framework.OrderedDescribe("[group:node]", func() {
 	f := framework.NewDefaultFramework("node")
-	f.SkipNamespaceCreation = true
 
+	var subnet *apiv1.Subnet
 	var cs clientset.Interface
+	var podClient *framework.PodClient
 	var subnetClient *framework.SubnetClient
+	var podName, hostPodName, namespaceName, subnetName, image string
+	var cidr string
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet
+		podClient = f.PodClient()
 		subnetClient = f.SubnetClient()
+		namespaceName = f.Namespace.Name
+		podName = "pod-" + framework.RandomSuffix()
+		hostPodName = "pod-" + framework.RandomSuffix()
+		subnetName = "subnet-" + framework.RandomSuffix()
+		cidr = framework.RandomCIDR(f.ClusterIpFamily)
+
+		if image == "" {
+			image = framework.GetKubeOvnImage(cs)
+		}
+	})
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Deleting pod " + podName)
+		podClient.DeleteSync(podName)
+
+		ginkgo.By("Deleting pod " + hostPodName)
+		podClient.DeleteSync(hostPodName)
+
+		ginkgo.By("Deleting subnet " + subnetName)
+		subnetClient.DeleteSync(subnetName)
 	})
 
 	framework.ConformanceIt("should allocate ip in join subnet to node", func() {
@@ -40,7 +72,63 @@ var _ = framework.Describe("[group:node]", func() {
 			framework.ExpectMAC(node.Annotations[util.MacAddressAnnotation])
 			framework.ExpectHaveKeyWithValue(node.Annotations, util.PortNameAnnotation, "node-"+node.Name)
 
-			// TODO: check IP/route on ovn0
+			podName := "pod-" + framework.RandomSuffix()
+			ginkgo.By("Creating pod " + podName + " with host network")
+			cmd := []string{"sh", "-c", "sleep infinity"}
+			pod := framework.MakePod(namespaceName, podName, nil, nil, image, cmd, nil)
+			pod.Spec.NodeName = node.Name
+			pod.Spec.HostNetwork = true
+			pod = podClient.CreateSync(pod)
+
+			ginkgo.By("Checking ip addresses on ovn0")
+			links, err := iproute.AddressShow("ovn0", func(cmd ...string) ([]byte, []byte, error) {
+				return framework.KubectlExec(pod.Namespace, pod.Name, cmd...)
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectHaveLen(links, 1)
+			framework.Logf(util.GetIpAddrWithMask(node.Annotations[util.IpAddressAnnotation], join.Spec.CIDRBlock))
+			ips := strings.Split(util.GetIpAddrWithMask(node.Annotations[util.IpAddressAnnotation], join.Spec.CIDRBlock), ",")
+			framework.ExpectConsistOf(links[0].NonLinkLocalAddresses(), ips)
+		}
+	})
+
+	framework.ConformanceIt("should access overlay pods using node ip", func() {
+		f.SkipVersionPriorTo(1, 12, "This feature was introduce inn v1.12")
+
+		ginkgo.By("Creating subnet " + subnetName)
+		subnet = framework.MakeSubnet(subnetName, "", cidr, "", nil, nil, nil)
+		subnet = subnetClient.CreateSync(subnet)
+
+		ginkgo.By("Creating pod " + podName)
+		annotations := map[string]string{
+			util.LogicalSwitchAnnotation: subnetName,
+		}
+		port := strconv.Itoa(8000 + rand.Intn(1000))
+		args := []string{"netexec", "--http-port", port}
+		pod := framework.MakePod(namespaceName, podName, nil, annotations, framework.AgnhostImage, nil, args)
+		pod = podClient.CreateSync(pod)
+
+		ginkgo.By("Creating pod " + hostPodName + " with host network")
+		cmd := []string{"sh", "-c", "sleep infinity"}
+		hostPod := framework.MakePod(namespaceName, hostPodName, nil, nil, image, cmd, nil)
+		hostPod.Spec.HostNetwork = true
+		hostPod = podClient.CreateSync(hostPod)
+
+		ginkgo.By("Validating client ip")
+		nodeIPs := make([]string, 0, len(hostPod.Status.PodIPs))
+		for _, podIP := range hostPod.Status.PodIPs {
+			nodeIPs = append(nodeIPs, podIP.IP)
+		}
+		for _, podIP := range pod.Status.PodIPs {
+			ip := podIP.IP
+			protocol := strings.ToLower(util.CheckProtocol(ip))
+			ginkgo.By("Checking connection from " + hostPodName + " to " + podName + " via " + protocol)
+			cmd := fmt.Sprintf("curl -q -s --connect-timeout 5 %s/clientip", net.JoinHostPort(ip, port))
+			ginkgo.By(fmt.Sprintf(`Executing %q in pod %s/%s`, cmd, namespaceName, hostPodName))
+			output := e2epodoutput.RunHostCmdOrDie(namespaceName, hostPodName, cmd)
+			client, _, err := net.SplitHostPort(strings.TrimSpace(output))
+			framework.ExpectNoError(err)
+			framework.ExpectContainElement(nodeIPs, client)
 		}
 	})
 })


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)

Before:
```txt
default via 172.18.0.1 dev eth0
10.16.0.0/16 via 100.64.0.1 dev ovn0
100.64.0.0/16 dev ovn0 proto kernel scope link src 100.64.0.2
172.18.0.0/16 dev eth0 proto kernel scope link src 172.18.0.3
```

After:
```txt
default via 172.18.0.1 dev eth0
10.16.0.0/16 via 100.64.0.1 dev ovn0 src 172.18.0.3
100.64.0.0/16 dev ovn0 proto kernel scope link src 100.64.0.2
172.18.0.0/16 dev eth0 proto kernel scope link src 172.18.0.3
```

This feature for service only supports kube-proxy with IPVS mode.