### PR TITLE
fix setting mtu for ovs internal port

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -450,10 +450,6 @@ func configureMirrorLink(portName string, mtu int) error {
 		return fmt.Errorf("can not find mirror nic %s: %v", portName, err)
 	}
 
-	if err = netlink.LinkSetMTU(mirrorLink, mtu); err != nil {
-		return fmt.Errorf("can not set mirror nic mtu: %v", err)
-	}
-
 	if mirrorLink.Attrs().OperState != netlink.OperUp {
 		if err = netlink.LinkSetUp(mirrorLink); err != nil {
 			return fmt.Errorf("can not set mirror nic %s up: %v", portName, err)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Changing MTU of ovs internal port with iproute2/netlink may not work, we should set interface mtu_request instead.

For OVS bridges, the MTU will be automatically adjusted, so there is no need to set MTU manually.