### PR TITLE
ovn northd: fix connection inactivity probe

### DIFF
--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -194,11 +194,8 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
-            ovn-nbctl --no-leader-only set-connection ptcp:"${DB_NB_PORT}":[::]
             ovn-nbctl --no-leader-only set NB_Global . options:northd_probe_interval=180000
             ovn-nbctl --no-leader-only set NB_Global . options:use_logical_dp_groups=true
-
-            ovn-sbctl --no-leader-only set-connection ptcp:"${DB_SB_PORT}":[::]
         else
             # known leader always first
             set +eo pipefail
@@ -301,11 +298,8 @@ else
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
-            ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_NB_PORT}":["${DB_NB_ADDR}"]
             ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set NB_Global . options:northd_probe_interval=180000
             ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set NB_Global . options:use_logical_dp_groups=true
-
-            ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_SB_PORT}":["${DB_SB_ADDR}"]
         else
             # get leader if cluster exists
             set +eo pipefail

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -187,6 +187,8 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
                 --db-nb-addr=$BIND_LOCAL_ADDR \
                 --db-sb-addr=$BIND_LOCAL_ADDR \
+                --db-nb-port=$DB_NB_PORT \
+                --db-sb-port=$DB_SB_PORT \
                 --db-nb-use-remote-in-db=no \
                 --db-sb-use-remote-in-db=no \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
@@ -233,6 +235,8 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                 --db-sb-cluster-remote-addr="[${sb_leader_ip}]" \
                 --db-nb-addr=$BIND_LOCAL_ADDR \
                 --db-sb-addr=$BIND_LOCAL_ADDR \
+                --db-nb-port=$DB_NB_PORT \
+                --db-sb-port=$DB_SB_PORT \
                 --db-nb-use-remote-in-db=no \
                 --db-sb-use-remote-in-db=no \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
@@ -290,6 +294,8 @@ else
                 --db-sb-cluster-local-addr="[${POD_IP}]" \
                 --db-nb-addr=$BIND_LOCAL_ADDR \
                 --db-sb-addr=$BIND_LOCAL_ADDR \
+                --db-nb-port=$DB_NB_PORT \
+                --db-sb-port=$DB_SB_PORT \
                 --db-nb-use-remote-in-db=no \
                 --db-sb-use-remote-in-db=no \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \
@@ -342,6 +348,8 @@ else
                 --db-sb-cluster-remote-addr="[${sb_leader_ip}]" \
                 --db-nb-addr=$BIND_LOCAL_ADDR \
                 --db-sb-addr=$BIND_LOCAL_ADDR \
+                --db-nb-port=$DB_NB_PORT \
+                --db-sb-port=$DB_SB_PORT \
                 --db-nb-use-remote-in-db=no \
                 --db-sb-use-remote-in-db=no \
                 --ovn-northd-nb-db="$(gen_conn_str 6641)" \

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -193,11 +193,10 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
             ovn-nbctl --no-leader-only set-connection ptcp:"${DB_NB_PORT}":[::]
-            ovn-nbctl --no-leader-only set Connection . inactivity_probe=180000
+            ovn-nbctl --no-leader-only set NB_Global . options:northd_probe_interval=180000
             ovn-nbctl --no-leader-only set NB_Global . options:use_logical_dp_groups=true
 
             ovn-sbctl --no-leader-only set-connection ptcp:"${DB_SB_PORT}":[::]
-            ovn-sbctl --no-leader-only set Connection . inactivity_probe=180000
         else
             # known leader always first
             set +eo pipefail
@@ -297,11 +296,10 @@ else
                 --ovn-northd-sb-db="$(gen_conn_str 6642)" \
                 start_northd
             ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_NB_PORT}":["${DB_NB_ADDR}"]
-            ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=180000
+            ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set NB_Global . options:northd_probe_interval=180000
             ovn-nbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set NB_Global . options:use_logical_dp_groups=true
 
             ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_SB_PORT}":["${DB_SB_ADDR}"]
-            ovn-sbctl --no-leader-only -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=180000
         else
             # get leader if cluster exists
             set +eo pipefail


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:

OVN DB does not use connection configurations in nb/sb db. Set the northd inactivity probe in NB_Global.

```txt
options : northd_probe_interval: optional string

    The inactivity probe interval of the connection to the OVN Northbound and
    Southbound databases from ovn-northd, in milliseconds. If the value is zero, it
    disables the connection keepalive feature.

    If the value is nonzero, then it will be forced to a value of at least 1000 ms.
```