### PR TITLE
ignore e2e for subnet enableEcmp before v1.12.0

### DIFF
--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -365,6 +365,8 @@ var _ = framework.Describe("[group:subnet]", func() {
 	})
 
 	framework.ConformanceIt("create centralized subnet without enableEcmp", func() {
+		f.SkipVersionPriorTo(1, 12, "Support for enableEcmp in subnet is introduced in v1.12")
+
 		ginkgo.By("Getting nodes")
 		nodes, err := e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Bug fixes


#### Which issue(s) this PR fixes:
Fixes #(issue-number)
