### PR TITLE
feat: support default service session stickiness timeout

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -3,9 +3,18 @@ E2E_IP_FAMILY := $(shell echo $${E2E_IP_FAMILY:-ipv4})
 E2E_NETWORK_MODE := $(shell echo $${E2E_NETWORK_MODE:-overlay})
 
 K8S_CONFORMANCE_E2E_FOCUS = "sig-network.*Conformance" "sig-network.*Feature:NoSNAT"
-K8S_CONFORMANCE_E2E_SKIP = "sig-network.*Services.*session affinity"
+K8S_CONFORMANCE_E2E_SKIP =
 K8S_NETPOL_E2E_FOCUS = "sig-network.*Feature:NetworkPolicy"
 K8S_NETPOL_E2E_SKIP = "sig-network.*NetworkPolicyLegacy"
+
+ifeq ($(shell echo $(E2E_BRANCH) | grep -o ^release-),release-)
+VERSION_NUM = $(subst release-,,$(E2E_BRANCH))
+VER_MAJOR = $(shell echo $(VERSION_NUM) | cut -f1 -d.)
+VER_MINOR = $(shell echo $(VERSION_NUM) | cut -f2 -d.)
+ifeq ($(shell test $(VER_MAJOR) -lt 1 -o \( $(VER_MAJOR) -eq 1 -a $(VER_MINOR) -lt 12 \) && echo true),true)
+K8S_CONFORMANCE_E2E_SKIP += "sig-network.*Services.*session affinity"
+endif
+endif
 
 ifeq ($(shell test $(E2E_IP_FAMILY) != ipv6 && echo true),true)
 K8S_CONFORMANCE_E2E_FOCUS += \

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -249,6 +249,11 @@ func (c *Controller) initLoadBalancer() error {
 			klog.Infof("tcp session load balancer %s exists", vpcLb.TcpSessLoadBalancer)
 		}
 
+		if err = c.ovnLegacyClient.SetLoadBalancerAffinityTimeout(vpcLb.TcpSessLoadBalancer, util.DefaultServiceSessionStickinessTimeout); err != nil {
+			klog.Errorf("failed to set service session stickiness timeout of cluster tcp session load balancer: %v", err)
+			return err
+		}
+
 		udpLb, err := c.ovnLegacyClient.FindLoadbalancer(vpcLb.UdpLoadBalancer)
 		if err != nil {
 			return fmt.Errorf("failed to find udp lb: %v", err)
@@ -277,6 +282,11 @@ func (c *Controller) initLoadBalancer() error {
 			}
 		} else {
 			klog.Infof("udp session load balancer %s exists", vpcLb.UdpSessLoadBalancer)
+		}
+
+		if err = c.ovnLegacyClient.SetLoadBalancerAffinityTimeout(vpcLb.UdpSessLoadBalancer, util.DefaultServiceSessionStickinessTimeout); err != nil {
+			klog.Errorf("failed to set service session stickiness timeout of cluster udp session load balancer: %v", err)
+			return err
 		}
 
 		vpc.Status.TcpLoadBalancer = vpcLb.TcpLoadBalancer

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -297,6 +297,11 @@ func (c *Controller) addLoadBalancer(vpc string) (*VpcLoadBalancer, error) {
 		klog.Infof("tcp session load balancer %s exists", tcpSessionLb)
 	}
 
+	if err = c.ovnLegacyClient.SetLoadBalancerAffinityTimeout(vpcLbConfig.TcpSessLoadBalancer, util.DefaultServiceSessionStickinessTimeout); err != nil {
+		klog.Errorf("failed to set service session stickiness timeout of cluster tcp session load balancer: %v", err)
+		return nil, err
+	}
+
 	udpLb, err := c.ovnLegacyClient.FindLoadbalancer(vpcLbConfig.UdpLoadBalancer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find udp lb %v", err)
@@ -325,6 +330,11 @@ func (c *Controller) addLoadBalancer(vpc string) (*VpcLoadBalancer, error) {
 		}
 	} else {
 		klog.Infof("udp session load balancer %s exists", udpSessionLb)
+	}
+
+	if err = c.ovnLegacyClient.SetLoadBalancerAffinityTimeout(vpcLbConfig.UdpSessLoadBalancer, util.DefaultServiceSessionStickinessTimeout); err != nil {
+		klog.Errorf("failed to set service session stickiness timeout of cluster udp session load balancer: %v", err)
+		return nil, err
 	}
 
 	return vpcLbConfig, nil

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1479,6 +1479,16 @@ func (c LegacyClient) CreateLoadBalancer(lb, protocol, selectFields string) erro
 	return err
 }
 
+// SetLoadBalancerAffinityTimeout sets the LB's affinity timeout in seconds
+func (c LegacyClient) SetLoadBalancerAffinityTimeout(lb string, timeout int) error {
+	output, err := c.ovnNbCommand("set", "load_balancer", lb, fmt.Sprintf("options:affinity_timeout=%d", timeout))
+	if err != nil {
+		klog.Errorf("failed to set affinity timeout of LB %s to %d, error: %v, output: %s", lb, timeout, err, output)
+		return err
+	}
+	return nil
+}
+
 // CreateLoadBalancerRule create loadbalancer rul in ovn
 func (c LegacyClient) CreateLoadBalancerRule(lb, vip, ips, protocol string) error {
 	_, err := c.ovnNbCommand(MayExist, "lb-add", lb, vip, ips, strings.ToLower(protocol))

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -200,4 +200,6 @@ const (
 
 	U2OInterconnName = "u2o-interconnection.%s.%s"
 	U2OExcludeIPAg   = "%s.u2o_exclude_ip.%s"
+
+	DefaultServiceSessionStickinessTimeout = 10800
 )

--- a/test/e2e/framework/image.go
+++ b/test/e2e/framework/image.go
@@ -3,5 +3,5 @@ package framework
 const (
 	PauseImage   = "kubeovn/pause:3.2"
 	BusyBoxImage = "busybox:stable"
-	AgnhostImage = "kubeovn/agnhost:2.40"
+	AgnhostImage = "kubeovn/agnhost:2.43"
 )


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #2269 

This feature does not include support for custom session stickiness timeout specified by `.spec.sessionAffinityConfig.clientIP.timeoutSeconds`.