### PR TITLE
fix legacy network policy err

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1153,7 +1153,7 @@ jobs:
       - build-centos-compile
       - k8s-conformance-e2e
       - k8s-netpol-e2e
-      # - k8s-netpol-legacy-e2e
+      - k8s-netpol-legacy-e2e
       - cyclonus-netpol-e2e
       - kube-ovn-conformance-e2e
       - kube-ovn-ic-conformance-e2e

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -520,7 +520,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 		}
 	}
 
-	if err = c.ovnLegacyClient.CreateGatewayACL(pgName, subnet.Spec.Gateway, subnet.Spec.CIDRBlock); err != nil {
+	if err = c.ovnLegacyClient.CreateGatewayACL("", pgName, subnet.Spec.Gateway, subnet.Spec.CIDRBlock); err != nil {
 		klog.Errorf("failed to create gateway acl, %v", err)
 		return err
 	}
@@ -594,7 +594,7 @@ func (c *Controller) fetchSelectedPorts(namespace string, selector *metav1.Label
 
 	ports := make([]string, 0, len(pods))
 	for _, pod := range pods {
-		if !isPodAlive(pod) || pod.Spec.HostNetwork {
+		if pod.Spec.HostNetwork {
 			continue
 		}
 		podName := c.getNameByPod(pod)
@@ -724,19 +724,28 @@ func (c *Controller) fetchPolicySelectedAddresses(namespace, protocol string, np
 		}
 
 		for _, pod := range pods {
-			for _, podIP := range pod.Status.PodIPs {
-				if podIP.IP != "" && util.CheckProtocol(podIP.IP) == protocol {
-					selectedAddresses = append(selectedAddresses, podIP.IP)
-					if len(svcs) == 0 {
-						continue
+			podNets, err := c.getPodKubeovnNets(pod)
+			if err != nil {
+				klog.Errorf("failed to get pod nets %v", err)
+				return nil, nil, err
+			}
+			for _, podNet := range podNets {
+				podIPAnnotation := pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)]
+				podIPs := strings.Split(podIPAnnotation, ",")
+				for _, podIP := range podIPs {
+					if podIP != "" && util.CheckProtocol(podIP) == protocol {
+						selectedAddresses = append(selectedAddresses, podIP)
 					}
-
-					svcIPs, err := svcMatchPods(svcs, pod, protocol)
-					if err != nil {
-						return nil, nil, err
-					}
-					selectedAddresses = append(selectedAddresses, svcIPs...)
 				}
+				if len(svcs) == 0 {
+					continue
+				}
+
+				svcIPs, err := svcMatchPods(svcs, pod, protocol)
+				if err != nil {
+					return nil, nil, err
+				}
+				selectedAddresses = append(selectedAddresses, svcIPs...)
 			}
 		}
 	}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -275,12 +275,6 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 				c.updateNpQueue.Add(np)
 			}
 		}
-
-		if oldPod.Status.PodIP != newPod.Status.PodIP {
-			for _, np := range c.podMatchNetworkPolicies(newPod) {
-				c.updateNpQueue.Add(np)
-			}
-		}
 	}
 
 	if newPod.Spec.HostNetwork {
@@ -344,6 +338,13 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 
 		if newPod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] == "true" && newPod.Spec.NodeName != "" {
 			if newPod.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, podNet.ProviderName)] != "true" {
+				if c.config.EnableNP {
+					for _, np := range c.podMatchNetworkPolicies(newPod) {
+						klog.V(3).Infof("enqueue update pod %s' network policy", key)
+						c.updateNpQueue.Add(np)
+					}
+				}
+
 				klog.V(3).Infof("enqueue update pod %s", key)
 				c.updatePodQueue.Add(key)
 				break

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -753,6 +753,11 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", "")
 	}
 
+	if err := c.ovnLegacyClient.CreateGatewayACL(subnet.Name, "", subnet.Spec.Gateway, subnet.Spec.CIDRBlock); err != nil {
+		klog.Errorf("create gateway acl %s failed, %v", subnet.Name, err)
+		return err
+	}
+
 	if err := c.ovnLegacyClient.UpdateSubnetACL(subnet.Name, subnet.Spec.Acls); err != nil {
 		c.patchSubnetStatus(subnet, "SetLogicalSwitchAclsFailed", err.Error())
 		return err

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1871,10 +1871,6 @@ func (c LegacyClient) CombineEgressACLCmd(pgName, asEgressName, asExceptName, pr
 		ovnArgs = []string{"--", fmt.Sprintf("--id=@%s.drop.%d", id, index), "create", "acl", "action=drop", "direction=from-lport", "log=false", fmt.Sprintf("priority=%s", util.EgressDefaultDrop), fmt.Sprintf("match=\"%s\"", fmt.Sprintf("inport==@%s && ip", pgName)), "options={apply-after-lb=\"true\"}", "--", "add", "port-group", pgName, "acls", fmt.Sprintf("@%s.drop.%d", id, index)}
 	}
 
-	if ipSuffix == "ip6" {
-		ovnArgs = append(ovnArgs, []string{"--", fmt.Sprintf("--id=@%s.ip6nd.%d", id, index), "create", "acl", "action=allow-related", "direction=from-lport", fmt.Sprintf("priority=%s", util.EgressAllowPriority), "match=\"nd || nd_ra || nd_rs\"", "options={apply-after-lb=\"true\"}", "--", "add", "port-group", pgName, "acls", fmt.Sprintf("@%s.ip6nd.%d", id, index)}...)
-	}
-
 	if len(npp) == 0 {
 		allowArgs = []string{"--", fmt.Sprintf("--id=@%s.noport.%d", id, index), "create", "acl", "action=allow-related", "direction=from-lport", fmt.Sprintf("priority=%s", util.EgressAllowPriority), fmt.Sprintf("match=\"%s\"", fmt.Sprintf("%s.dst == $%s && %s.dst != $%s && inport==@%s && ip", ipSuffix, asEgressName, ipSuffix, asExceptName, pgName)), "options={apply-after-lb=\"true\"}", "--", "add", "port-group", pgName, "acls", fmt.Sprintf("@%s.noport.%d", id, index)}
 		ovnArgs = append(ovnArgs, allowArgs...)
@@ -1926,7 +1922,7 @@ func (c LegacyClient) DeleteACL(pgName, direction string) (err error) {
 	return
 }
 
-func (c LegacyClient) CreateGatewayACL(pgName, gateway, cidr string) error {
+func (c LegacyClient) CreateGatewayACL(ls, pgName, gateway, cidr string) error {
 	for _, cidrBlock := range strings.Split(cidr, ",") {
 		for _, gw := range strings.Split(gateway, ",") {
 			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(gw) {
@@ -1937,8 +1933,22 @@ func (c LegacyClient) CreateGatewayACL(pgName, gateway, cidr string) error {
 			if protocol == kubeovnv1.ProtocolIPv6 {
 				ipSuffix = "ip6"
 			}
-			ingressArgs := []string{MayExist, "--type=port-group", "acl-add", pgName, "to-lport", util.IngressAllowPriority, fmt.Sprintf("%s.src == %s", ipSuffix, gw), "allow-related"}
-			egressArgs := []string{"--", MayExist, "--type=port-group", "--apply-after-lb", "acl-add", pgName, "from-lport", util.EgressAllowPriority, fmt.Sprintf("%s.dst == %s", ipSuffix, gw), "allow-related"}
+
+			var ingressArgs, egressArgs []string
+			if pgName != "" {
+				ingressArgs = []string{"--", MayExist, "--type=port-group", "acl-add", pgName, "to-lport", util.IngressAllowPriority, fmt.Sprintf("%s.src == %s", ipSuffix, gw), "allow-related"}
+				egressArgs = []string{"--", MayExist, "--type=port-group", "--apply-after-lb", "acl-add", pgName, "from-lport", util.EgressAllowPriority, fmt.Sprintf("%s.dst == %s", ipSuffix, gw), "allow-related"}
+				if ipSuffix == "ip6" {
+					egressArgs = append(egressArgs, []string{"--", "--type=port-group", MayExist, "--apply-after-lb", "acl-add", pgName, "from-lport", util.EgressAllowPriority, `nd || nd_ra || nd_rs`, "allow-related"}...)
+				}
+			} else if ls != "" {
+				ingressArgs = []string{"--", MayExist, "acl-add", ls, "to-lport", util.IngressAllowPriority, fmt.Sprintf(`%s.src == %s`, ipSuffix, gw), "allow-related"}
+				egressArgs = []string{"--", MayExist, "--apply-after-lb", "acl-add", ls, "from-lport", util.EgressAllowPriority, fmt.Sprintf(`%s.dst == %s`, ipSuffix, gw), "allow-related"}
+				if ipSuffix == "ip6" {
+					egressArgs = append(egressArgs, []string{"--", MayExist, "--apply-after-lb", "acl-add", ls, "from-lport", util.EgressAllowPriority, `nd || nd_ra || nd_rs`, "allow-related"}...)
+				}
+			}
+
 			ovnArgs := append(ingressArgs, egressArgs...)
 			if _, err := c.ovnNbCommand(ovnArgs...); err != nil {
 				return err


### PR DESCRIPTION
```
1. create np's acl rules before the pod completely starts
Because some network legacy cases use startup scripts to verify whether acl is in effect, if acl is configured after the startup 
script, the case will fail

2. fix not allowing gateway packet pass
The subnet does not specify a namespace, the pod and netpol rules (eg: deny all) are in the same namespace, and the pod is 
added to the subnet. According to our current process, the ACL for subnet gateway release is not generated, which will cause
 problems. Unless the ns of the subnet is consistent with the ns of netpol, the acl of the gateway will be generated.

3. udp and sctp can temporarily use the same lb.(but udp and sctp lb can't be used at the same time, there should be new feature to support sctp lb)

I made a modification mainly because there is a group of cases that will test sctp, udp, and tcp in turn. If the service of udp is 
not cleaned up completely, and then run the case of sctp, the vips of sctp will be deleted by the following code

```

![image](https://user-images.githubusercontent.com/47097611/218067672-823a2ff3-cc26-45b4-9b1a-3c6e55d40a11.png)


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #2285
