### PR TITLE
Add the bgp router-id format check

### DIFF
--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -97,6 +98,9 @@ func ParseFlags() (*Configuration, error) {
 	ht := argHoldTime.Seconds()
 	if ht > 65536 || ht < 3 {
 		return nil, errors.New("the bgp holdtime must be in the range 3s to 65536s")
+	}
+	if *argRouterId != "" && net.ParseIP(*argRouterId) == nil {
+		return nil, fmt.Errorf("invalid router-id format: %s", *argRouterId)
 	}
 
 	config := &Configuration{


### PR DESCRIPTION
#### What type of this PR
- Bug fixes

<!-- 
-->
As a key parameter of bgp, router-id needs to be verified.
Currently, this parameter is not properly verified in the gobgp module. 
Validation after parsing configuration parameters reduces unnecessary grpc calls.

