### PR TITLE
fix getting service backends in dual-stack clusters

### DIFF
--- a/pkg/controller/endpoint.go
+++ b/pkg/controller/endpoint.go
@@ -244,7 +244,9 @@ func getServicePortBackends(endpoints *v1.Endpoints, pods []*v1.Pod, servicePort
 
 		for _, address := range subset.Addresses {
 			if address.TargetRef == nil || address.TargetRef.Kind != "Pod" {
-				backends = append(backends, util.JoinHostPort(address.IP, targetPort))
+				if util.CheckProtocol(address.IP) == protocol {
+					backends = append(backends, util.JoinHostPort(address.IP, targetPort))
+				}
 				continue
 			}
 
@@ -264,7 +266,7 @@ func getServicePortBackends(endpoints *v1.Endpoints, pods []*v1.Pod, servicePort
 					break
 				}
 			}
-			if ip == "" {
+			if ip == "" && util.CheckProtocol(address.IP) == protocol {
 				ip = address.IP
 			}
 			if ip != "" {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)

```txt
### kube-ovn-controller recent log
E0209 13:26:21.658427      12 endpoint.go:192] failed to update vip [fd00:10:96::1f7]:8080 to tcp lb, ovn-nbctl: 10.16.0.5:8080: IP address family is different from VIP [fd00:10:96::1f7]:8080.
E0209 13:26:21.658509      12 endpoint.go:87] error syncing 'kube-system/kube-ovn-pinger': ovn-nbctl: 10.16.0.5:8080: IP address family is different from VIP [fd00:10:96::1f7]:8080.
```