### PR TITLE
Add neighbor-address format check for kube-ovn-speaker

### DIFF
--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -102,6 +102,9 @@ func ParseFlags() (*Configuration, error) {
 	if *argRouterId != "" && net.ParseIP(*argRouterId) == nil {
 		return nil, fmt.Errorf("invalid router-id format: %s", *argRouterId)
 	}
+	if net.ParseIP(*argNeighborAddress) == nil {
+		return nil, fmt.Errorf("invalid neighbor-address format: %s", *argNeighborAddress)
+	}
 
 	config := &Configuration{
 		AnnounceClusterIP:           *argAnnounceClusterIP,


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- Bug fixes

Similar to pr #2316 
The neighbor-address parameter is not properly verified in the gobgp module.