### PR TITLE
enqueue endpoint when handling service add event

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -3,7 +3,7 @@ E2E_IP_FAMILY := $(shell echo $${E2E_IP_FAMILY:-ipv4})
 E2E_NETWORK_MODE := $(shell echo $${E2E_NETWORK_MODE:-overlay})
 
 K8S_CONFORMANCE_E2E_FOCUS = "sig-network.*Conformance" "sig-network.*Feature:NoSNAT"
-K8S_CONFORMANCE_E2E_SKIP = "sig-network.*Services.*switch session affinity"
+K8S_CONFORMANCE_E2E_SKIP =
 K8S_NETPOL_E2E_FOCUS = "sig-network.*Feature:NetworkPolicy"
 K8S_NETPOL_E2E_SKIP = "sig-network.*NetworkPolicyLegacy"
 K8S_NETPOL_LEGACY_E2E_FOCUS = "sig-network.*NetworkPolicyLegacy"

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -33,6 +33,7 @@ func (c *Controller) enqueueAddService(obj interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
+	c.updateEndpointQueue.Add(key)
 	svc := obj.(*v1.Service)
 
 	if c.config.EnableNP {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:

Sometimes the endpoint add event comes before the service event. In this scenario, OVN LB cannot be updated since the service is not found.

This patch fixes occasional e2e failure.
