### PR TITLE
use existing node switch cidr instead of the configured one

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -153,16 +153,16 @@ func (c *Controller) initDefaultLogicalSwitch() error {
 func (c *Controller) initNodeSwitch() error {
 	subnet, err := c.config.KubeOvnClient.KubeovnV1().Subnets().Get(context.Background(), c.config.NodeSwitch, metav1.GetOptions{})
 	if err == nil {
-		if subnet != nil && util.CheckProtocol(c.config.NodeSwitchCIDR) != util.CheckProtocol(subnet.Spec.CIDRBlock) {
+		if util.CheckProtocol(c.config.NodeSwitchCIDR) == kubeovnv1.ProtocolDual && util.CheckProtocol(subnet.Spec.CIDRBlock) != kubeovnv1.ProtocolDual {
 			// single-stack upgrade to dual-stack
-			if util.CheckProtocol(c.config.NodeSwitchCIDR) == kubeovnv1.ProtocolDual {
-				subnet := subnet.DeepCopy()
-				subnet.Spec.CIDRBlock = c.config.NodeSwitchCIDR
-				if err := formatSubnet(subnet, c); err != nil {
-					klog.Errorf("init format subnet %s failed: %v", c.config.NodeSwitch, err)
-					return err
-				}
+			subnet := subnet.DeepCopy()
+			subnet.Spec.CIDRBlock = c.config.NodeSwitchCIDR
+			if err := formatSubnet(subnet, c); err != nil {
+				klog.Errorf("init format subnet %s failed: %v", c.config.NodeSwitch, err)
+				return err
 			}
+		} else {
+			c.config.NodeSwitchCIDR = subnet.Spec.CIDRBlock
 		}
 		return nil
 	}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #2358 
