### PR TITLE
add base sg rules for ports

### DIFF
--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -254,6 +254,9 @@ func (c *Controller) handleAddOrUpdateSg(key string) error {
 			c.patchSgStatus(sg)
 			return err
 		}
+		if err := c.ovnLegacyClient.CreateSgBaseIngressACL(sg.Name); err != nil {
+			return err
+		}
 		sg.Status.IngressMd5 = newIngressMd5
 		sg.Status.IngressLastSyncSuccess = true
 		c.patchSgStatus(sg)
@@ -262,6 +265,9 @@ func (c *Controller) handleAddOrUpdateSg(key string) error {
 		if err = c.ovnLegacyClient.UpdateSgACL(sg, ovs.SgAclEgressDirection); err != nil {
 			sg.Status.EgressLastSyncSuccess = false
 			c.patchSgStatus(sg)
+			return err
+		}
+		if err := c.ovnLegacyClient.CreateSgBaseEgressACL(sg.Name); err != nil {
 			return err
 		}
 		sg.Status.EgressMd5 = newEgressMd5

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -2405,6 +2405,65 @@ func (c LegacyClient) CreateSgDenyAllACL() error {
 	return nil
 }
 
+func (c LegacyClient) CreateSgBaseEgressACL(sgName string) error {
+	portGroupName := GetSgPortGroupName(sgName)
+	klog.Infof("add base egress acl, sg: %s", portGroupName)
+	// allow arp
+	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclEgressDirection), util.SecurityGroupBasePriority,
+		fmt.Sprintf("outport==@%s && arp", portGroupName), "allow-related"); err != nil {
+		return err
+	}
+
+	// icmpv6
+	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclEgressDirection), util.SecurityGroupBasePriority,
+		fmt.Sprintf("outport==@%s && icmp6.type=={130, 133, 135, 136} && icmp6.code == 0 && ip.ttl == 255", portGroupName), "allow-related"); err != nil {
+		return err
+	}
+
+	// dhcpv4 res
+	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclEgressDirection), util.SecurityGroupBasePriority,
+		fmt.Sprintf("outport==@%s && udp.src==68 && udp.dst==67 && ip4", portGroupName), "allow-related"); err != nil {
+		return err
+	}
+
+	// dhcpv6 res
+	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclEgressDirection), util.SecurityGroupBasePriority,
+		fmt.Sprintf("outport==@%s && udp.src==546 && udp.dst==547 && ip6", portGroupName), "allow-related"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c LegacyClient) CreateSgBaseIngressACL(sgName string) error {
+	portGroupName := GetSgPortGroupName(sgName)
+	klog.Infof("add base ingress acl, sg: %s", portGroupName)
+	// allow arp
+	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclIngressDirection), util.SecurityGroupBasePriority,
+		fmt.Sprintf("inport==@%s && arp", portGroupName), "allow-related"); err != nil {
+		return err
+	}
+
+	// icmpv6
+	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclIngressDirection), util.SecurityGroupBasePriority,
+		fmt.Sprintf("inport==@%s && icmp6.type=={130, 134, 135, 136} && icmp6.code == 0 && ip.ttl == 255", portGroupName), "allow-related"); err != nil {
+		return err
+	}
+
+	// dhcpv4 offer
+	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclIngressDirection), util.SecurityGroupBasePriority,
+		fmt.Sprintf("inport==@%s && udp.src==67 && udp.dst==68 && ip4", portGroupName), "allow-related"); err != nil {
+		return err
+	}
+
+	// dhcpv6 offer
+	if _, err := c.ovnNbCommand(MayExist, "--type=port-group", "acl-add", portGroupName, string(SgAclIngressDirection), util.SecurityGroupBasePriority,
+		fmt.Sprintf("inport==@%s && udp.src==547 && udp.dst==546 && ip6", portGroupName), "allow-related"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c LegacyClient) UpdateSgACL(sg *kubeovnv1.SecurityGroup, direction AclDirection) error {
 	sgPortGroupName := GetSgPortGroupName(sg.Name)
 	// clear acl

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -125,6 +125,7 @@ const (
 	NodeAllowPriority = "3000"
 
 	SecurityGroupHighestPriority = "2300"
+	SecurityGroupBasePriority    = "2005"
 	SecurityGroupAllowPriority   = "2004"
 	SecurityGroupDropPriority    = "2003"
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes

**add base sg rules** 
```
BaseEgressSecurityGroup
放通icmpv6相关流出报文  
outport==@pg1 && nd
outport==@pg1 && icmp6.tpye=={130, 133} && icmp6.code == 0 && ip.ttl == 255
放通dhcp相关流出报文
outport==@pg1 && udp.src==68 && udp.dst==67 && ip4
outport==@pg1 && udp.src==546 && udp.dst==547 && ip6
流出的ARP流量
outport==@pg1 && arp
BaseIngressSecurityGroup
流入的ARP流量
inport==@pg1 && arp 
ipv6的部分icmp流量
inport==@pg1 && icmp6.type=={130, 134, 135, 136} && icmp6.code == 0 && ip.ttl == 255
dhcp offer的流量
inport==@pg1 && udp.src==67 && udp.dst==68 && ip4
outport==@pg1 && udp.src==547 && udp.dst==546 && ip6
```


#### Which issue(s) this PR fixes:
Fixes #2342
