### PR TITLE
Fixed iptables creation failure due to an excessively long label

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -383,15 +383,13 @@ func (c *Controller) handleUpdateVpcEip(natGwKey string) error {
 		klog.Errorf("failed to init nat gw pod '%s' create at, %v", natGwKey, err)
 		return err
 	}
-	eips, err := c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().List(context.Background(), metav1.ListOptions{
-		LabelSelector: fields.OneTermEqualSelector(util.VpcNatLabel, "").String(),
-	})
+	eips, err := c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		klog.Errorf("failed to get not used eips, %v", err)
+		klog.Errorf("failed to get eip list, %v", err)
 		return err
 	}
 	for _, eip := range eips.Items {
-		if eip.Spec.NatGwDp == natGwKey && eip.Status.Redo != NAT_GW_CREATED_AT {
+		if eip.Spec.NatGwDp == natGwKey && eip.Status.Redo != NAT_GW_CREATED_AT && eip.Annotations[util.VpcNatAnnotation] == "" {
 			klog.V(3).Infof("redo eip %s", eip.Name)
 			if err = c.patchEipStatus(eip.Name, "", NAT_GW_CREATED_AT, "", false); err != nil {
 				klog.Errorf("failed to update eip '%s' to make sure applied, %v", eip.Name, err)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -40,8 +40,10 @@ const (
 	VpcLbAnnotation             = "ovn.kubernetes.io/vpc_lb"
 	VpcExternalLabel            = "ovn.kubernetes.io/vpc_external"
 	VpcEipLabel                 = "ovn.kubernetes.io/vpc_eip"
+	VpcEipAnnotation            = "ovn.kubernetes.io/vpc_eip"
 	VpcDnatEPortLabel           = "ovn.kubernetes.io/vpc_dnat_eport"
 	VpcNatLabel                 = "ovn.kubernetes.io/vpc_nat"
+	VpcNatAnnotation            = "ovn.kubernetes.io/vpc_nat"
 
 	SwitchLBRuleVipsAnnotation = "ovn.kubernetes.io/switch_lb_vip"
 

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -110,9 +110,9 @@ func (v *ValidatingHook) iptablesEIPDeleteHook(ctx context.Context, req admissio
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
-	if eip.Status.Ready && eip.Labels[util.VpcNatLabel] != "" {
+	if eip.Status.Ready && eip.Annotations[util.VpcNatAnnotation] != "" {
 		var err error
-		natName := eip.Labels[util.VpcNatLabel]
+		natName := eip.Annotations[util.VpcNatAnnotation]
 		natType := eip.Status.Nat
 
 		key := types.NamespacedName{Name: natName}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
Fixed iptables creation failure due to an excessively long label
Involved content：eip, fip, snat, dnat

#### Which issue(s) this PR fixes:
Fixes #2348
