### PR TITLE
add support of user-defined kubelet directory

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -30,6 +30,8 @@ IFACE=${IFACE:-}
 DPDK_TUNNEL_IFACE=${DPDK_TUNNEL_IFACE:-br-phy}
 ENABLE_BIND_LOCAL_IP=${ENABLE_BIND_LOCAL_IP:-true}
 
+KUBELET_DIR=${KUBELET_DIR:-/var/lib/kubelet}
+
 CNI_CONF_DIR="/etc/cni/net.d"
 CNI_BIN_DIR="/opt/cni/bin"
 
@@ -2889,7 +2891,7 @@ spec:
             type: DirectoryOrCreate
         - name: shareddir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: $KUBELET_DIR/pods
             type: ''
         - name: hugepage
           emptyDir:
@@ -3223,7 +3225,7 @@ spec:
             path: /lib/modules
         - name: shared-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: $KUBELET_DIR/pods
         - name: systemid
           hostPath:
             path: /etc/origin/openvswitch

--- a/kubeovn-helm/templates/ovncni-ds.yaml
+++ b/kubeovn-helm/templates/ovncni-ds.yaml
@@ -154,7 +154,7 @@ spec:
             path: /lib/modules
         - name: shared-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.kubelet_conf.KUBELET_DIR }}/pods
         - name: systemid
           hostPath:
             path: /etc/origin/openvswitch

--- a/kubeovn-helm/values.yaml
+++ b/kubeovn-helm/values.yaml
@@ -89,6 +89,9 @@ cni_conf:
   CNI_CONF_DIR: "/etc/cni/net.d"
   CNI_BIN_DIR: "/opt/cni/bin"
 
+kubelet_conf:
+  KUBELET_DIR: "/var/lib/kubelet"
+  
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
#### What type of this PR
- Features

Add configurations of user-defined kubelet directory to support users specifying the kubelet directory instead of using the default /var/lib/kubelet.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubeovn/kube-ovn/issues/2047