### PR TITLE
fix cli ovs-tcpdump can't be used in ovs pod

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /kube-ovn
 RUN rm -f /usr/bin/nc &&\
     rm -f /usr/bin/netcat
 
+RUN apt install -y python3-openvswitch
+
 COPY kube-ovn-cmd /kube-ovn/kube-ovn-cmd
 COPY kube-ovn-webhook /kube-ovn/kube-ovn-webhook
 RUN ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn && \

--- a/dist/images/Dockerfile.dpdk
+++ b/dist/images/Dockerfile.dpdk
@@ -8,6 +8,7 @@ COPY logrotate/* /etc/logrotate.d/
 COPY grace_stop_ovn_controller /usr/share/ovn/scripts/grace_stop_ovn_controller
 
 WORKDIR /kube-ovn
+RUN apt install -y python3-openvswitch
 
 COPY kube-ovn-cmd /kube-ovn/kube-ovn-cmd
 COPY kube-ovn-webhook /kube-ovn/kube-ovn-webhook

--- a/dist/images/Dockerfile.no-avx512
+++ b/dist/images/Dockerfile.no-avx512
@@ -9,6 +9,8 @@ COPY grace_stop_ovn_controller /usr/share/ovn/scripts/grace_stop_ovn_controller
 
 WORKDIR /kube-ovn
 
+RUN apt install -y python3-openvswitch
+
 COPY kube-ovn-cmd /kube-ovn/kube-ovn-cmd
 COPY kube-ovn-webhook /kube-ovn/kube-ovn-webhook
 RUN ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn && \


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #2397
