### PR TITLE
Modify the pod scheduling of vpcdns

### DIFF
--- a/yamls/coredns-template.yaml
+++ b/yamls/coredns-template.yaml
@@ -27,13 +27,15 @@ spec:
         kubernetes.io/os: linux
       affinity:
          podAntiAffinity:
-           requiredDuringSchedulingIgnoredDuringExecution:
-           - labelSelector:
-               matchExpressions:
-               - key: k8s-app
-                 operator: In
-                 values: ["{{ .DeployName }}"]
-             topologyKey: kubernetes.io/hostname
+           preferredDuringSchedulingIgnoredDuringExecution:
+             - weight: 100
+               podAffinityTerm:
+                 labelSelector:
+                  matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values: ["{{ .DeployName }}"]
+                 topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
         image: {{ .CorednsImage }}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
change the podAntiAffinity from required to preferred.

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
https://github.com/kubeovn/kube-ovn/issues/2412