### PR TITLE
do not set subnet's vlan empty on error

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -320,8 +320,9 @@ func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 		}
 		if subnet.Spec.Vlan != "" {
 			if _, err := c.vlansLister.Get(subnet.Spec.Vlan); err != nil {
-				klog.Warningf("subnet %s reference a none exist vlan %s", subnet.Name, subnet.Spec.Vlan)
-				subnet.Spec.Vlan = ""
+				err = fmt.Errorf("failed to get vlan %s: %s", subnet.Spec.Vlan, err)
+				klog.Error(err)
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
