### PR TITLE
do not delete external switch if it is created by provider network vlan subnet

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1040,7 +1040,7 @@ spec:
                         type: string
                       nextHopIP:
                         type: string
-                      ecmp:
+                      ecmpMode:
                         type: string
                       bfdId:
                         type: string

--- a/kubeovn-helm/templates/kube-ovn-crd.yaml
+++ b/kubeovn-helm/templates/kube-ovn-crd.yaml
@@ -822,7 +822,7 @@ spec:
                         type: string
                       nextHopIP:
                         type: string
-                      ecmp:
+                      ecmpMode:
                         type: string
                       bfdId:
                         type: string

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -375,7 +375,7 @@ type StaticRoute struct {
 	Policy    RoutePolicy `json:"policy,omitempty"`
 	CIDR      string      `json:"cidr"`
 	NextHopIP string      `json:"nextHopIP"`
-	ECMP      string      `json:"ecmp"`
+	ECMPMode  string      `json:"ecmpMode"`
 	BfdId     string      `json:"bfdId"`
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -578,50 +578,48 @@ func NewController(config *Configuration) *Controller {
 	}); err != nil {
 		util.LogFatalAndExit(err, "failed to add iptables snat rule event handler")
 	}
-	if config.EnableEipSnat {
-		ovnEipInformer := kubeovnInformerFactory.Kubeovn().V1().OvnEips()
-		controller.ovnEipsLister = ovnEipInformer.Lister()
-		controller.ovnEipSynced = ovnEipInformer.Informer().HasSynced
-		controller.addOvnEipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "addOvnEip")
-		controller.updateOvnEipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "updateOvnEip")
-		controller.resetOvnEipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "resetOvnEip")
-		controller.delOvnEipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "delOvnEip")
+	ovnEipInformer := kubeovnInformerFactory.Kubeovn().V1().OvnEips()
+	controller.ovnEipsLister = ovnEipInformer.Lister()
+	controller.ovnEipSynced = ovnEipInformer.Informer().HasSynced
+	controller.addOvnEipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "addOvnEip")
+	controller.updateOvnEipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "updateOvnEip")
+	controller.resetOvnEipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "resetOvnEip")
+	controller.delOvnEipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "delOvnEip")
 
-		if _, err = ovnEipInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    controller.enqueueAddOvnEip,
-			UpdateFunc: controller.enqueueUpdateOvnEip,
-			DeleteFunc: controller.enqueueDelOvnEip,
-		}); err != nil {
-			util.LogFatalAndExit(err, "failed to add eip event handler")
-		}
+	if _, err = ovnEipInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.enqueueAddOvnEip,
+		UpdateFunc: controller.enqueueUpdateOvnEip,
+		DeleteFunc: controller.enqueueDelOvnEip,
+	}); err != nil {
+		util.LogFatalAndExit(err, "failed to add eip event handler")
+	}
 
-		ovnFipInformer := kubeovnInformerFactory.Kubeovn().V1().OvnFips()
-		controller.ovnFipsLister = ovnFipInformer.Lister()
-		controller.ovnFipSynced = ovnFipInformer.Informer().HasSynced
-		controller.addOvnFipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "addOvnFip")
-		controller.updateOvnFipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "updateOvnFip")
-		controller.delOvnFipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "delOvnFip")
-		if _, err = ovnFipInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    controller.enqueueAddOvnFip,
-			UpdateFunc: controller.enqueueUpdateOvnFip,
-			DeleteFunc: controller.enqueueDelOvnFip,
-		}); err != nil {
-			util.LogFatalAndExit(err, "failed to add ovn fip event handler")
-		}
+	ovnFipInformer := kubeovnInformerFactory.Kubeovn().V1().OvnFips()
+	controller.ovnFipsLister = ovnFipInformer.Lister()
+	controller.ovnFipSynced = ovnFipInformer.Informer().HasSynced
+	controller.addOvnFipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "addOvnFip")
+	controller.updateOvnFipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "updateOvnFip")
+	controller.delOvnFipQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "delOvnFip")
+	if _, err = ovnFipInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.enqueueAddOvnFip,
+		UpdateFunc: controller.enqueueUpdateOvnFip,
+		DeleteFunc: controller.enqueueDelOvnFip,
+	}); err != nil {
+		util.LogFatalAndExit(err, "failed to add ovn fip event handler")
+	}
 
-		ovnSnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().OvnSnatRules()
-		controller.ovnSnatRulesLister = ovnSnatRuleInformer.Lister()
-		controller.ovnSnatRuleSynced = ovnSnatRuleInformer.Informer().HasSynced
-		controller.addOvnSnatRuleQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "addOvnSnatRule")
-		controller.updateOvnSnatRuleQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "updateOvnSnatRule")
-		controller.delOvnSnatRuleQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "delOvnSnatRule")
-		if _, err = ovnSnatRuleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    controller.enqueueAddOvnSnatRule,
-			UpdateFunc: controller.enqueueUpdateOvnSnatRule,
-			DeleteFunc: controller.enqueueDelOvnSnatRule,
-		}); err != nil {
-			util.LogFatalAndExit(err, "failed to add ovn snat rule event handler")
-		}
+	ovnSnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().OvnSnatRules()
+	controller.ovnSnatRulesLister = ovnSnatRuleInformer.Lister()
+	controller.ovnSnatRuleSynced = ovnSnatRuleInformer.Informer().HasSynced
+	controller.addOvnSnatRuleQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "addOvnSnatRule")
+	controller.updateOvnSnatRuleQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "updateOvnSnatRule")
+	controller.delOvnSnatRuleQueue = workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "delOvnSnatRule")
+	if _, err = ovnSnatRuleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.enqueueAddOvnSnatRule,
+		UpdateFunc: controller.enqueueUpdateOvnSnatRule,
+		DeleteFunc: controller.enqueueDelOvnSnatRule,
+	}); err != nil {
+		util.LogFatalAndExit(err, "failed to add ovn snat rule event handler")
 	}
 
 	if _, err = podAnnotatedIptablesEipInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -662,10 +660,7 @@ func (c *Controller) Run(ctx context.Context) {
 		c.podAnnotatedIptablesEipSynced, c.podAnnotatedIptablesFipSynced,
 		c.vlanSynced, c.podsSynced, c.namespacesSynced, c.nodesSynced,
 		c.serviceSynced, c.endpointsSynced, c.configMapsSynced,
-	}
-
-	if c.config.EnableEipSnat {
-		cacheSyncs = append(cacheSyncs, c.ovnEipSynced, c.ovnFipSynced, c.ovnSnatRuleSynced)
+		c.ovnEipSynced, c.ovnFipSynced, c.ovnSnatRuleSynced,
 	}
 
 	if c.config.EnableNP {
@@ -823,20 +818,18 @@ func (c *Controller) shutdown() {
 	c.updateIptablesSnatRuleQueue.ShutDown()
 	c.delIptablesSnatRuleQueue.ShutDown()
 
-	if c.config.EnableEipSnat {
-		c.addOvnEipQueue.ShutDown()
-		c.updateOvnEipQueue.ShutDown()
-		c.resetOvnEipQueue.ShutDown()
-		c.delOvnEipQueue.ShutDown()
+	c.addOvnEipQueue.ShutDown()
+	c.updateOvnEipQueue.ShutDown()
+	c.resetOvnEipQueue.ShutDown()
+	c.delOvnEipQueue.ShutDown()
 
-		c.addOvnFipQueue.ShutDown()
-		c.updateOvnFipQueue.ShutDown()
-		c.delOvnFipQueue.ShutDown()
+	c.addOvnFipQueue.ShutDown()
+	c.updateOvnFipQueue.ShutDown()
+	c.delOvnFipQueue.ShutDown()
 
-		c.addIptablesSnatRuleQueue.ShutDown()
-		c.updateIptablesSnatRuleQueue.ShutDown()
-		c.delIptablesSnatRuleQueue.ShutDown()
-	}
+	c.addOvnSnatRuleQueue.ShutDown()
+	c.updateOvnSnatRuleQueue.ShutDown()
+	c.delOvnSnatRuleQueue.ShutDown()
 
 	if c.config.PodDefaultFipType == util.IptablesFip {
 		c.addPodAnnotatedIptablesEipQueue.ShutDown()
@@ -998,20 +991,18 @@ func (c *Controller) startWorkers(ctx context.Context) {
 	go wait.Until(c.resyncSubnetMetrics, 30*time.Second, ctx.Done())
 	go wait.Until(c.CheckGatewayReady, 5*time.Second, ctx.Done())
 
-	if c.config.EnableEipSnat {
-		go wait.Until(c.runAddOvnEipWorker, time.Second, ctx.Done())
-		go wait.Until(c.runUpdateOvnEipWorker, time.Second, ctx.Done())
-		go wait.Until(c.runResetOvnEipWorker, time.Second, ctx.Done())
-		go wait.Until(c.runDelOvnEipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runAddOvnEipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runUpdateOvnEipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runResetOvnEipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runDelOvnEipWorker, time.Second, ctx.Done())
 
-		go wait.Until(c.runAddOvnFipWorker, time.Second, ctx.Done())
-		go wait.Until(c.runUpdateOvnFipWorker, time.Second, ctx.Done())
-		go wait.Until(c.runDelOvnFipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runAddOvnFipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runUpdateOvnFipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runDelOvnFipWorker, time.Second, ctx.Done())
 
-		go wait.Until(c.runAddOvnSnatRuleWorker, time.Second, ctx.Done())
-		go wait.Until(c.runUpdateOvnSnatRuleWorker, time.Second, ctx.Done())
-		go wait.Until(c.runDelOvnSnatRuleWorker, time.Second, ctx.Done())
-	}
+	go wait.Until(c.runAddOvnSnatRuleWorker, time.Second, ctx.Done())
+	go wait.Until(c.runUpdateOvnSnatRuleWorker, time.Second, ctx.Done())
+	go wait.Until(c.runDelOvnSnatRuleWorker, time.Second, ctx.Done())
 
 	if c.config.EnableNP {
 		go wait.Until(c.CheckNodePortGroup, time.Duration(c.config.NodePgProbeTime)*time.Minute, ctx.Done())

--- a/pkg/controller/external-gw.go
+++ b/pkg/controller/external-gw.go
@@ -273,6 +273,7 @@ func (c *Controller) updateDefaultVpcExternal(enableExternal bool) error {
 	}
 	vpc := cachedVpc.DeepCopy()
 	if vpc.Spec.EnableExternal != enableExternal {
+		vpc.Spec.EnableExternal = enableExternal
 		if _, err := c.config.KubeOvnClient.KubeovnV1().Vpcs().Update(context.Background(), vpc, metav1.UpdateOptions{}); err != nil {
 			errMsg := fmt.Errorf("failed to update vpc enable external %s, %v", vpc.Name, err)
 			klog.Error(errMsg)

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -422,16 +422,14 @@ func (c *Controller) InitIPAM() error {
 			klog.Errorf("failed to init ipam from iptables eip cr %s: %v", eip.Name, err)
 		}
 	}
-	if c.config.EnableEipSnat {
-		oeips, err := c.ovnEipsLister.List(labels.Everything())
-		if err != nil {
-			klog.Errorf("failed to list ovn eips: %v", err)
-			return err
-		}
-		for _, oeip := range oeips {
-			if _, _, _, err = c.ipam.GetStaticAddress(oeip.Name, oeip.Name, oeip.Status.V4Ip, oeip.Status.MacAddress, oeip.Spec.ExternalSubnet, true); err != nil {
-				klog.Errorf("failed to init ipam from ovn eip cr %s: %v", oeip.Name, err)
-			}
+	oeips, err := c.ovnEipsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list ovn eips: %v", err)
+		return err
+	}
+	for _, oeip := range oeips {
+		if _, _, _, err = c.ipam.GetStaticAddress(oeip.Name, oeip.Name, oeip.Status.V4Ip, oeip.Status.MacAddress, oeip.Spec.ExternalSubnet, true); err != nil {
+			klog.Errorf("failed to init ipam from ovn eip cr %s: %v", oeip.Name, err)
 		}
 	}
 	nodes, err := c.nodesLister.List(labels.Everything())

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -341,6 +341,14 @@ func (c *Controller) handleDelOvnEip(key string) error {
 			return err
 		}
 	}
+
+	if cachedEip.Spec.Type == util.LrpUsingEip {
+		if err := c.ovnLegacyClient.DeleteLogicalRouterPort(key); err != nil {
+			klog.Errorf("failed to delete lrp %s, %v", key, err)
+			return err
+		}
+	}
+
 	if err = c.handleDelOvnEipFinalizer(cachedEip); err != nil {
 		klog.Errorf("failed to remove finalizer from ovn eip, %v", err)
 		return err

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1144,7 +1144,7 @@ func (c *Controller) reconcileVpcUseBfdStaticRoute(vpcName, subnetName string) e
 		for _, route := range vpc.Spec.StaticRoutes {
 			if route.Policy == kubeovnv1.PolicySrc &&
 				route.NextHopIP == eip.Status.V4Ip &&
-				route.ECMP == util.StaicRouteBfdEcmp &&
+				route.ECMPMode == util.StaicRouteBfdEcmp &&
 				route.CIDR == subnet.Spec.CIDRBlock {
 				v4Exist = true
 				break
@@ -1156,7 +1156,7 @@ func (c *Controller) reconcileVpcUseBfdStaticRoute(vpcName, subnetName string) e
 				Policy:    kubeovnv1.PolicySrc,
 				CIDR:      subnet.Spec.CIDRBlock,
 				NextHopIP: eip.Status.V4Ip,
-				ECMP:      util.StaicRouteBfdEcmp,
+				ECMPMode:  util.StaicRouteBfdEcmp,
 				BfdId:     bfdId,
 			}
 			klog.V(3).Infof("add ecmp bfd static route %v", route)
@@ -1217,7 +1217,7 @@ func (c *Controller) reconcileVpcAddNormalStaticRoute(vpcName string) error {
 			v6Exist = true
 			continue
 		}
-		if route.ECMP != util.StaicRouteBfdEcmp {
+		if route.ECMPMode != util.StaicRouteBfdEcmp {
 			// filter ecmp bfd route
 			routes = append(routes, route)
 		}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1344,7 +1344,7 @@ func (c *Controller) reconcileOvnDefaultVpcRoute(subnet *kubeovnv1.Subnet) error
 			lrpName := fmt.Sprintf("%s-%s", c.config.ClusterRouter, subnet.Name)
 			klog.Infof("delete logical router port %s", lrpName)
 			if err := c.ovnLegacyClient.DeleteLogicalRouterPort(lrpName); err != nil {
-				klog.Errorf("failed to delete lrp %s-%s, %v", c.config.ClusterRouter, subnet.Name, err)
+				klog.Errorf("failed to delete lrp %s, %v", lrpName, err)
 				return err
 			}
 		}

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -433,7 +433,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 	}
 
 	for _, item := range routeNeedAdd {
-		if item.ECMP == "" {
+		if item.ECMPMode == "" {
 			if err = c.ovnLegacyClient.AddStaticRoute(convertPolicy(item.Policy), item.CIDR, item.NextHopIP,
 				"", "", vpc.Name, util.NormalRouteType); err != nil {
 				klog.Errorf("add normal static route to vpc %s failed, %v", vpc.Name, err)
@@ -441,7 +441,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 			}
 		} else {
 			if err = c.ovnLegacyClient.AddStaticRoute(convertPolicy(item.Policy), item.CIDR, item.NextHopIP,
-				item.ECMP, item.BfdId, vpc.Name, util.EcmpRouteType); err != nil {
+				item.ECMPMode, item.BfdId, vpc.Name, util.EcmpRouteType); err != nil {
 				klog.Errorf("add ecmp static route to vpc %s failed, %v", vpc.Name, err)
 				return err
 			}
@@ -623,7 +623,7 @@ func diffStaticRoute(exist []*ovs.StaticRoute, target []*kubeovnv1.StaticRoute) 
 			Policy:    policy,
 			CIDR:      item.CIDR,
 			NextHopIP: item.NextHop,
-			ECMP:      item.ECMP,
+			ECMPMode:  item.ECMPMode,
 			BfdId:     item.BfdId,
 		})
 	}
@@ -943,7 +943,7 @@ func (c *Controller) handleDeleteVpcStaticRoute(key string) error {
 	needUpdate := false
 	newStaticRoutes := make([]*kubeovnv1.StaticRoute, 0, len(vpc.Spec.StaticRoutes))
 	for _, route := range vpc.Spec.StaticRoutes {
-		if route.ECMP != util.StaicRouteBfdEcmp {
+		if route.ECMPMode != util.StaicRouteBfdEcmp {
 			newStaticRoutes = append(newStaticRoutes, route)
 			needUpdate = true
 		}

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -231,6 +231,7 @@ func (c *Controller) processNextDeleteProviderNetworkWorkItem() bool {
 }
 
 func (c *Controller) handleAddOrUpdateProviderNetwork(key string) error {
+	klog.V(3).Infof("handle update provider network %s", key)
 	node, err := c.nodesLister.Get(c.config.NodeName)
 	if err != nil {
 		return err
@@ -261,6 +262,7 @@ func (c *Controller) initProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v1
 
 	var mtu int
 	var err error
+	klog.V(3).Infof("ovs init provider network %s", pn.Name)
 	if mtu, err = ovsInitProviderNetwork(pn.Name, nic, pn.Spec.ExchangeLinkName, c.config.MacLearningFallback); err != nil {
 		if oldLen := len(node.Labels); oldLen != 0 {
 			delete(node.Labels, fmt.Sprintf(util.ProviderNetworkReadyTemplate, pn.Name))

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -110,6 +110,7 @@ func ovsInitProviderNetwork(provider, nic string, exchangeLinkName, macLearningF
 		}
 	}
 
+	klog.V(3).Infof("configure external bridge %s", brName)
 	if err := configExternalBridge(provider, brName, nic, exchangeLinkName, macLearningFallback); err != nil {
 		errMsg := fmt.Errorf("failed to create and configure external bridge %s: %v", brName, err)
 		klog.Error(errMsg)
@@ -223,6 +224,7 @@ func ovsCleanProviderNetwork(provider string) error {
 	}
 
 	// remove OVS bridge
+	klog.Infof("delete external bridge %s", brName)
 	if output, err = ovs.Exec(ovs.IfExists, "del-br", brName); err != nil {
 		return fmt.Errorf("failed to remove OVS bridge %s, %v: %q", brName, err, output)
 	}

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1164,7 +1164,7 @@ func parseLrRouteListOutput(output string) (routeList []*StaticRoute, err error)
 			switch fields[idx] {
 			case "(learned)":
 				learned = true
-			case "ecmp-symmetric-reply":
+			case util.StaicRouteBfdEcmp:
 				ecmpSymmetricReply = true
 			}
 		}
@@ -1178,7 +1178,7 @@ func parseLrRouteListOutput(output string) (routeList []*StaticRoute, err error)
 			NextHop: fields[1],
 		}
 		if ecmpSymmetricReply {
-			route.ECMPMode = "ecmp-symmetric-reply"
+			route.ECMPMode = util.StaicRouteBfdEcmp
 		}
 
 		routeList = append(routeList, route)

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -902,11 +902,11 @@ func (c LegacyClient) CreatePeerRouterPort(localRouter, remoteRouter, localRoute
 }
 
 type StaticRoute struct {
-	Policy  string
-	CIDR    string
-	NextHop string
-	ECMP    string
-	BfdId   string
+	Policy   string
+	CIDR     string
+	NextHop  string
+	ECMPMode string
+	BfdId    string
 }
 
 // AddStaticRoute add a static route rule in ovn
@@ -1178,7 +1178,7 @@ func parseLrRouteListOutput(output string) (routeList []*StaticRoute, err error)
 			NextHop: fields[1],
 		}
 		if ecmpSymmetricReply {
-			route.ECMP = "ecmp-symmetric-reply"
+			route.ECMPMode = "ecmp-symmetric-reply"
 		}
 
 		routeList = append(routeList, route)

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -822,7 +822,7 @@ spec:
                         type: string
                       nextHopIP:
                         type: string
-                      ecmp:
+                      ecmpMode:
                         type: string
                       bfdId:
                         type: string


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- 避免ovn默认vpc不再使用enalbe-eip-snat时会影响自定义vpc使用该公网功能
- 删除lrp类型的eip时删除lrp，否则可能出现lrp资源层次的ip冲突
- 自定义vpc可单独使用vpc的公网功能，不依赖默认vpc的enable-eip-snat特性


#### Which issue(s) this PR fixes:
Fixes #2446 
