### PR TITLE
fix iptables-rules upgrade compatible 

### DIFF
--- a/dist/images/update/1.10-1.11.2.sh
+++ b/dist/images/update/1.10-1.11.2.sh
@@ -4,31 +4,30 @@ set -eo pipefail
 echo "begin upgrade iptables-dnat-rules"
 all_dnat=$(kubectl get dnat -o name)
 for dnat in $all_dnat;do
-    nat_anno=$(kubectl get $dnat -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_eip")
+    nat_anno=$(kubectl get $dnat -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_eip") || true
     if [ -n "$nat_anno" ];then
         continue
     fi
     eip=$(kubectl get $dnat -o jsonpath='{.spec.eip}')
     kubectl annotate $dnat ovn.kubernetes.io/vpc_eip=$eip
-    eip_anno=$(kubectl get eip $eip -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_nat")
+    eip_anno=$(kubectl get eip $eip -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_nat") || true
     if [ -n "$eip_anno" ];then
         continue
     fi
-    echo "annotate $eip ovn.kubernetes.io/vpc_nat"
     nat_name=$(kubectl get $dnat -o jsonpath='{.metadata.name}')
     kubectl annotate eip $eip ovn.kubernetes.io/vpc_nat=$nat_name
 done
 
-echo "begin annotate iptables-snat-rules.kubeovn.io"
+echo "begin upgrade iptables-snat-rules.kubeovn.io"
 all_snat=$(kubectl get snat -o name)
 for snat in $all_snat;do
-    nat_anno=$(kubectl get $snat -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_eip")
+    nat_anno=$(kubectl get $snat -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_eip") || true
     if [ -n "$nat_anno" ];then
         continue
     fi
     eip=$(kubectl get $snat -o jsonpath='{.spec.eip}')
     kubectl annotate $snat ovn.kubernetes.io/vpc_eip=$eip
-    eip_anno=$(kubectl get eip $eip -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_nat")
+    eip_anno=$(kubectl get eip $eip -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_nat") || true
     if [ -n "$eip_anno" ];then
         continue
     fi
@@ -36,19 +35,21 @@ for snat in $all_snat;do
     kubectl annotate eip $eip ovn.kubernetes.io/vpc_nat=$nat_name
 done
 
-echo "begin annotate iptables-fip-rules.kubeovn.io"
+echo "begin upgrade iptables-fip-rules.kubeovn.io"
 all_fip=$(kubectl get fip -o name)
 for fip in $all_fip;do
-    nat_anno=$(kubectl get $fip -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_eip")
+    nat_anno=$(kubectl get $fip -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_eip") || true
     if [ -n "$nat_anno" ];then
         continue
     fi
     eip=$(kubectl get $fip -o jsonpath='{.spec.eip}')
     kubectl annotate $fip ovn.kubernetes.io/vpc_eip=$eip
-    eip_anno=$(kubectl get eip $eip -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_nat")
+    eip_anno=$(kubectl get eip $eip -o jsonpath='{.metadata.annotations}'|grep "ovn.kubernetes.io/vpc_nat") || true
     if [ -n "$eip_anno" ];then
         continue
     fi
-    nat_name=$(kubectl get $snat -o jsonpath='{.metadata.name}')
+    nat_name=$(kubectl get $fip -o jsonpath='{.metadata.name}')
     kubectl annotate eip $eip ovn.kubernetes.io/vpc_nat=$nat_name
 done
+
+echo "upgrade iptables success!"


### PR DESCRIPTION

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
The `set -e` usage causes `grep` to exit prematurely from the shell script if it does not find a pattern
