### PR TITLE
fix ips CR not found due to etcd error

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -615,7 +615,9 @@ func (c *Controller) handleAddPod(key string) error {
 		podType := getPodType(pod)
 		podName := c.getNameByPod(pod)
 		if err := c.createOrUpdateCrdIPs(podName, ipStr, mac, subnet.Name, pod.Namespace, pod.Spec.NodeName, podNet.ProviderName, podType, nil); err != nil {
-			klog.Errorf("failed to create IP %s.%s: %v", podName, pod.Namespace, err)
+			err = fmt.Errorf("failed to create ips CR %s.%s: %v", podName, pod.Namespace, err)
+			klog.Error(err)
+			return err
 		}
 
 		if podNet.Type != providerTypeIPAM {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:
If ips CR creation failed, the cni server can not get the CR and reports an error. This results in Pod creation failure:

```txt
  Warning  FailedCreatePodSandBox  4m27s (x268 over 62m)  kubelet            (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "9ca82d1f5769c01278d15bf5a641453a385f3a8ab1202e2dfe389b630e1c4850": plugin type="kube-ovn" failed (add): request ip return 500 failed to get ip crd for 10.3.0.31, ips.kubeovn.io "deploy-78974c7456-zmzs8.cpaas-system" not found
``` 
