### PR TITLE
add node to addNodeQueue if required annotations are missing

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -59,8 +59,13 @@ func (c *Controller) enqueueUpdateNode(oldObj, newObj interface{}) {
 			utilruntime.HandleError(err)
 			return
 		}
-		klog.V(3).Infof("enqueue update node %s", key)
-		c.updateNodeQueue.Add(key)
+		if len(newNode.Annotations) == 0 || newNode.Annotations[util.AllocatedAnnotation] != "true" {
+			klog.V(3).Infof("enqueue add node %s", key)
+			c.addNodeQueue.Add(key)
+		} else {
+			klog.V(3).Infof("enqueue update node %s", key)
+			c.updateNodeQueue.Add(key)
+		}
 	}
 }
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:

In case the annotations assigned to a node by kube-ovn-controller are deleted/replaced by other k8s controllers, we should check node annotations and add the node to the `addNodeQueue` if the annotations are missing.
