### PR TITLE
ensure address label is correct before deleting it

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -912,8 +912,15 @@ func configProviderNic(nicName, brName string) (int, error) {
 			continue
 		}
 
+		if !strings.HasPrefix(addr.Label, nicName) {
+			if strings.HasPrefix(addr.Label, brName) {
+				addr.Label = nicName + addr.Label[len(brName):]
+			} else {
+				addr.Label = nicName
+			}
+		}
 		if err = netlink.AddrDel(nic, &addr); err != nil {
-			errMsg := fmt.Errorf("failed to delete address %s on nic %s: %v", addr.String(), nicName, err)
+			errMsg := fmt.Errorf("failed to delete address %q on nic %s: %v", addr.String(), nicName, err)
 			if errors.Is(err, syscall.EADDRNOTAVAIL) {
 				// the IP address does not exist now
 				klog.Warning(errMsg)
@@ -923,10 +930,10 @@ func configProviderNic(nicName, brName string) (int, error) {
 		}
 
 		if addr.Label != "" {
-			addr.Label = brName + strings.TrimPrefix(addr.Label, nicName)
+			addr.Label = brName + addr.Label[len(nicName):]
 		}
 		if err = netlink.AddrReplace(bridge, &addr); err != nil {
-			return 0, fmt.Errorf("failed to replace address %s on OVS bridge %s: %v", addr.String(), brName, err)
+			return 0, fmt.Errorf("failed to replace address %q on OVS bridge %s: %v", addr.String(), brName, err)
 		}
 	}
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:

```txt
15 14:51:09.224464    6248 init.go:162] change nic name from eth0 to br-eth0
E0315 14:51:09.416395    6248 init.go:245] failed to add nic br-eth0 to external bridge eth0: failed to delete address 192.168.1.131/24 eth0 on nic br-eth0: label must begin with interface name
```
