### PR TITLE
add support of user-defined image name for vpc-dns

### DIFF
--- a/pkg/controller/vpc_dns.go
+++ b/pkg/controller/vpc_dns.go
@@ -40,6 +40,7 @@ var (
 	cmVersion       = ""
 	k8sServiceHost  = ""
 	k8sServicePort  = ""
+	initRouteImage  = ""
 	enableCoredns   = false
 	hostNameservers []string
 )
@@ -459,7 +460,7 @@ func setVpcDnsRoute(dp *v1.Deployment, subnetGw string) {
 	allowPrivilegeEscalation := true
 	dp.Spec.Template.Spec.InitContainers = append(dp.Spec.Template.Spec.InitContainers, corev1.Container{
 		Name:            "init-route",
-		Image:           InitRouteImage,
+		Image:           initRouteImage,
 		Command:         []string{"sh", "-c", routeCmd},
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
@@ -571,8 +572,13 @@ func (c *Controller) resyncVpcDnsConfig() {
 			return
 		}
 	}
-
 	enableCoredns = newEnableCoredns
+
+	if newInitRouteImage, ok := cm.Data["init-route-image"]; ok {
+		initRouteImage = newInitRouteImage
+	} else {
+		initRouteImage = InitRouteImage
+	}
 }
 
 func (c *Controller) getDefaultCoreDnsImage() (string, error) {


### PR DESCRIPTION
- Features

Add support for user-defined image names of vpc-dns to support users specifying the image instead of using the immutable image "kubeovn/vpc-nat-gateway: v1.11.0".