### PR TITLE
fix: ovn-fip creation failure due to an excessively long label

### DIFF
--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -39,10 +39,8 @@ const (
 	VpcCIDRsAnnotation          = "ovn.kubernetes.io/vpc_cidrs"
 	VpcLbAnnotation             = "ovn.kubernetes.io/vpc_lb"
 	VpcExternalLabel            = "ovn.kubernetes.io/vpc_external"
-	VpcEipLabel                 = "ovn.kubernetes.io/vpc_eip"
 	VpcEipAnnotation            = "ovn.kubernetes.io/vpc_eip"
 	VpcDnatEPortLabel           = "ovn.kubernetes.io/vpc_dnat_eport"
-	VpcNatLabel                 = "ovn.kubernetes.io/vpc_nat"
 	VpcNatAnnotation            = "ovn.kubernetes.io/vpc_nat"
 
 	OvnEipUsageLabel        = "ovn.kubernetes.io/ovn_eip_usage"


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
```
E0320 16:38:22.376842       7 ovn_fip.go:110] error syncing 'default.cccccccccccccccccccccccccccccccccccccccccccccccccccc-0.shanghai-qa': OvnEip.kubeovn.io "default.cccccccccccccccccccccccccccccccccccccccccccccccccccc-0.shanghai-qa" is invalid: metadata.labels: Invalid value: "default.cccccccccccccccccccccccccccccccccccccccccccccccccccc-0.shanghai-qa": must be no more than 63 characters, requeuin
```

