### PR TITLE
fix update fip rules not effect correctly

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -552,6 +552,8 @@ spec:
                   type: string
                 redo:
                   type: string
+                internalIp:
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -582,11 +582,12 @@ type IptablesFIPRuleCondition struct {
 type IptablesFIPRuleStatus struct {
 	// +optional
 	// +patchStrategy=merge
-	Ready   bool   `json:"ready" patchStrategy:"merge"`
-	V4ip    string `json:"v4ip" patchStrategy:"merge"`
-	V6ip    string `json:"v6ip" patchStrategy:"merge"`
-	NatGwDp string `json:"natGwDp" patchStrategy:"merge"`
-	Redo    string `json:"redo" patchStrategy:"merge"`
+	Ready      bool   `json:"ready" patchStrategy:"merge"`
+	V4ip       string `json:"v4ip" patchStrategy:"merge"`
+	V6ip       string `json:"v6ip" patchStrategy:"merge"`
+	NatGwDp    string `json:"natGwDp" patchStrategy:"merge"`
+	Redo       string `json:"redo" patchStrategy:"merge"`
+	InternalIp string `json:"internalIp"  patchStrategy:"merge"`
 
 	// Conditions represents the latest state of the object
 	// +optional
@@ -711,12 +712,11 @@ type IptablesDnatRuleCondition struct {
 type IptablesDnatRuleStatus struct {
 	// +optional
 	// +patchStrategy=merge
-	Ready   bool   `json:"ready" patchStrategy:"merge"`
-	V4ip    string `json:"v4ip" patchStrategy:"merge"`
-	V6ip    string `json:"v6ip" patchStrategy:"merge"`
-	NatGwDp string `json:"natGwDp" patchStrategy:"merge"`
-	Redo    string `json:"redo" patchStrategy:"merge"`
-
+	Ready        bool   `json:"ready" patchStrategy:"merge"`
+	V4ip         string `json:"v4ip" patchStrategy:"merge"`
+	V6ip         string `json:"v6ip" patchStrategy:"merge"`
+	NatGwDp      string `json:"natGwDp" patchStrategy:"merge"`
+	Redo         string `json:"redo" patchStrategy:"merge"`
 	Protocol     string `json:"protocol"  patchStrategy:"merge"`
 	InternalIp   string `json:"internalIp"  patchStrategy:"merge"`
 	InternalPort string `json:"internalPort"  patchStrategy:"merge"`

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -334,6 +334,8 @@ spec:
                   type: string
                 redo:
                   type: string
+                internalIp:
+                  type: string
                 conditions:
                   type: array
                   items:


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
- Bug fixes

While update the internal ip of the fip rule, it will not really take effect in the vpc nat gateway pod, the rule k8s shows does not match the actual rule in gateway pod.

