### PR TITLE
fix encap_ip will be lost when we restart the ovs-dpdk node

### DIFF
--- a/dist/images/start-ovs-dpdk-v2.sh
+++ b/dist/images/start-ovs-dpdk-v2.sh
@@ -103,10 +103,11 @@ esac
 
 ovs-vsctl set port ${DPDK_TUNNEL_IFACE} tag=${VLAN_TAG}
 
-ip addr add ${ENCAP_IP} dev ${DPDK_TUNNEL_IFACE}
 fi
 
 ip link set ${DPDK_TUNNEL_IFACE} up
+
+ip addr replace ${ENCAP_IP} dev ${DPDK_TUNNEL_IFACE}
 
 ovs-vsctl --may-exist add-br br-int \
   -- set Bridge br-int datapath_type=netdev \


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #2542
