### PR TITLE
fix lsp deletion failure when external-ids:ls is empty

### DIFF
--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -575,12 +575,8 @@ func (c *ovnClient) DeleteLogicalSwitchPortOp(lspName string) ([]ovsdb.Operation
 		return nil, nil
 	}
 
-	lsName, ok := lsp.ExternalIDs[logicalSwitchKey]
-	if !ok {
-		return nil, fmt.Errorf("no %s exist in lsp's external_ids", logicalSwitchKey)
-	}
-
 	// remove logical switch port from logical switch
+	lsName := lsp.ExternalIDs[logicalSwitchKey]
 	lspRemoveOp, err := c.LogicalSwitchUpdatePortOp(lsName, lsp.UUID, ovsdb.MutateOperationDelete)
 	if err != nil {
 		return nil, fmt.Errorf("generate operations for removing port %s from logical switch %s: %v", lspName, lsName, err)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:

During the upgrade, LSP gc for terminated kube-ovn-pinger failed since the external ID is empty and will never be set in kube-ovn-controller initialization.