### PR TITLE
controller: fix apiserver connection timeout on startup

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	"kubevirt.io/client-go/kubecli"
 
 	clientset "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned"
 	"github.com/kubeovn/kube-ovn/pkg/util"
-	"kubevirt.io/client-go/kubecli"
 )
 
 // Configuration is the controller conf
@@ -301,6 +301,13 @@ func (config *Configuration) initKubeClient() error {
 		klog.Errorf("failed to build kubeconfig %v", err)
 		return err
 	}
+
+	// try to connect to apiserver's tcp port
+	if err = util.DialApiServer(cfg.Host); err != nil {
+		klog.Errorf("failed to dial apiserver: %v", err)
+		return err
+	}
+
 	cfg.QPS = 1000
 	cfg.Burst = 2000
 	// use cmd arg to modify timeout later

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -325,6 +325,13 @@ func (config *Configuration) initKubeClient() error {
 			return err
 		}
 	}
+
+	// try to connect to apiserver's tcp port
+	if err = util.DialApiServer(cfg.Host); err != nil {
+		klog.Errorf("failed to dial apiserver: %v", err)
+		return err
+	}
+
 	cfg.QPS = 1000
 	cfg.Burst = 2000
 

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -23,7 +23,7 @@ func DialApiServer(host string) error {
 		conn, err := net.DialTimeout("tcp", address, 3*time.Second)
 		if err == nil {
 			klog.Infof("succeeded to connected to apiserver %q", host)
-			conn.Close()
+			_ = conn.Close()
 			return nil
 		}
 		klog.Warningf("failed to dial %s: %v", address, err)

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -1,10 +1,38 @@
 package util
 
 import (
+	"fmt"
+	"net"
+	"net/url"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
+
+func DialApiServer(host string) error {
+	u, err := url.Parse(host)
+	if err != nil {
+		return fmt.Errorf("failed to parse host %q: %v", host, err)
+	}
+
+	address := net.JoinHostPort(u.Hostname(), u.Port())
+	timer := time.NewTimer(3 * time.Second)
+	for i := 0; i < 10; i++ {
+		conn, err := net.DialTimeout("tcp", address, 3*time.Second)
+		if err == nil {
+			klog.Infof("succeeded to connected to apiserver %q", host)
+			conn.Close()
+			return nil
+		}
+		klog.Warningf("failed to dial %s: %v", address, err)
+		<-timer.C
+		timer.Reset(3 * time.Second)
+	}
+
+	return fmt.Errorf("timed out connecting to apiserver %q", host)
+}
 
 func GetNodeInternalIP(node v1.Node) (ipv4, ipv6 string) {
 	var ips []string

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -22,16 +22,16 @@ func DialApiServer(host string) error {
 	for i := 0; i < 10; i++ {
 		conn, err := net.DialTimeout("tcp", address, 3*time.Second)
 		if err == nil {
-			klog.Infof("succeeded to connected to apiserver %q", host)
+			klog.Infof("succeeded to dial apiserver %q", address)
 			_ = conn.Close()
 			return nil
 		}
-		klog.Warningf("failed to dial %s: %v", address, err)
+		klog.Warningf("failed to dial apiserver %q: %v", address, err)
 		<-timer.C
 		timer.Reset(3 * time.Second)
 	}
 
-	return fmt.Errorf("timed out connecting to apiserver %q", host)
+	return fmt.Errorf("timed out dialing apiserver %q", host)
 }
 
 func GetNodeInternalIP(node v1.Node) (ipv4, ipv6 string) {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:

After node reboot, there is a chance that kube-ovn-controller/kube-ovn-cni reports connection timeout and crashes.

This patch makes the controller try to connect the apiserver service's TCP port before creating the k8s client(s).

```txt
I0324 09:55:26.024115       7 config.go:247] no --kubeconfig, use in-cluster kubernetes config
W0324 09:55:26.036828       7 k8s.go:28] failed to dial 10.96.0.1:443: dial tcp 10.96.0.1:443: connect: connection refused
W0324 09:55:32.031709       7 k8s.go:28] failed to dial 10.96.0.1:443: dial tcp 10.96.0.1:443: i/o timeout
I0324 09:55:32.044155       7 config.go:305] no --kubeconfig, use in-cluster kubernetes config
```