### PR TITLE
fix update snat rules not effect correctly

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -739,6 +739,8 @@ spec:
                   type: string
                 redo:
                   type: string
+               internalCIDR:
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -646,11 +646,12 @@ type IptablesSnatRuleCondition struct {
 type IptablesSnatRuleStatus struct {
 	// +optional
 	// +patchStrategy=merge
-	Ready   bool   `json:"ready" patchStrategy:"merge"`
-	V4ip    string `json:"v4ip" patchStrategy:"merge"`
-	V6ip    string `json:"v6ip" patchStrategy:"merge"`
-	NatGwDp string `json:"natGwDp" patchStrategy:"merge"`
-	Redo    string `json:"redo" patchStrategy:"merge"`
+	Ready        bool   `json:"ready" patchStrategy:"merge"`
+	V4ip         string `json:"v4ip" patchStrategy:"merge"`
+	V6ip         string `json:"v6ip" patchStrategy:"merge"`
+	NatGwDp      string `json:"natGwDp" patchStrategy:"merge"`
+	Redo         string `json:"redo" patchStrategy:"merge"`
+	InternalCIDR string `json:"internalCIDR" patchStrategy:"merge"`
 
 	// Conditions represents the latest state of the object
 	// +optional

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -521,6 +521,8 @@ spec:
                   type: string
                 redo:
                   type: string
+                internalCIDR:
+                  type: string
                 conditions:
                   type: array
                   items:


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes

While update the internal CIDR of the snat rule, it will not really take effect in the vpc nat gateway pod, the rule k8s shows does not match the actual rule in gateway pod.
