### PR TITLE
fix: mem leak in ipam

### DIFF
--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -171,6 +171,9 @@ func (subnet *Subnet) pushPodNic(podName, nicName string) {
 
 func (subnet *Subnet) popPodNic(podName, nicName string) {
 	subnet.PodToNicList[podName] = util.RemoveString(subnet.PodToNicList[podName], nicName)
+	if subnet.PodToNicList[podName] == nil {
+		delete(subnet.PodToNicList, podName)
+	}
 }
 
 func (subnet *Subnet) GetRandomAddress(podName, nicName string, mac string, skippedAddrs []string, checkConflict bool) (IP, IP, string, error) {


### PR DESCRIPTION
When all nics are popped from the list the map key still exist which will lead memory leak each time a pod is deleted.


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

#### Which issue(s) this PR fixes:
Fixes #(issue-number)
