### PR TITLE
underlay: get address/route before setting nm managed to no

### DIFF
--- a/pkg/daemon/init_linux.go
+++ b/pkg/daemon/init_linux.go
@@ -105,13 +105,6 @@ func changeProvideNicName(current, target string) (bool, error) {
 		return true, nil
 	}
 
-	// set link unmanaged by NetworkManager
-	if err = nmSetManaged(current, false); err != nil {
-		klog.Errorf("failed set device %s unmanaged by NetworkManager: %v", current, err)
-		return false, err
-	}
-
-	klog.Infof("renaming link %s as %s", current, target)
 	addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
 	if err != nil {
 		klog.Errorf("failed to list addresses of link %s: %v", current, err)
@@ -123,6 +116,13 @@ func changeProvideNicName(current, target string) (bool, error) {
 		return false, err
 	}
 
+	// set link unmanaged by NetworkManager
+	if err = nmSetManaged(current, false); err != nil {
+		klog.Errorf("failed set device %s unmanaged by NetworkManager: %v", current, err)
+		return false, err
+	}
+
+	klog.Infof("renaming link %s as %s", current, target)
 	if err = netlink.LinkSetDown(link); err != nil {
 		klog.Errorf("failed to set link %s down: %v", current, err)
 		return false, err


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Bug fixes


#### Which issue(s) this PR fixes:
In some scenarios, NetworkManager flushes the address/route after a device is set unmanaged. We should get the address/route before setting a device unmanaged by NetworkManager.
