### PR TITLE
base: fix CVE-2022-3294

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -94,7 +94,7 @@ ARG ARCH
 ENV CNI_VERSION=v1.2.0
 RUN curl -sSf -L --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C . ./loopback ./portmap ./macvlan
 
-ENV KUBE_VERSION="v1.24.2"
+ENV KUBE_VERSION="v1.24.12"
 
 RUN curl -L https://dl.k8s.io/${KUBE_VERSION}/kubernetes-client-linux-${ARCH}.tar.gz | tar -xz -C . && cp ./kubernetes/client/bin/kubectl /usr/bin/kubectl \
  && chmod +x /usr/bin/kubectl && rm -rf ./kubernetes


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

#### What type of this PR

- Security

#### Which issue(s) this PR fixes:
Fixes CVE-2022-3294:

```txt
┌───────────────────┬───────────────┬──────────┬───────────────────┬──────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│      Library      │ Vulnerability │ Severity │ Installed Version │          Fixed Version           │                            Title                             │
├───────────────────┼───────────────┼──────────┼───────────────────┼──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ k8s.io/kubernetes │ CVE-2022-3294 │ HIGH     │ v1.24.2           │ 1.22.16, 1.23.14, 1.24.8, 1.25.4 │ kubernetes: node address isn't always verified when proxying │
│                   │               │          │                   │                                  │ https://avd.aquasec.com/nvd/cve-2022-3294                    │
└───────────────────┴───────────────┴──────────┴───────────────────┴──────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```
