### PR TITLE
replace port_group function call with ovnClient

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -990,7 +990,6 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 	}
 	return nil
 }
-
 func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) error {
 	podName := c.getNameByPod(pod)
 	key := fmt.Sprintf("%s/%s", pod.Namespace, podName)


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
#2453 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74be2f5</samp>

This pull request refactors the port group management logic in various controllers, using the new `ovnClient` instead of the old `ovnLegacyClient` and the `ovn-nbctl` command line tool. This improves the performance, consistency, and simplicity of the network policy and security group operations.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 74be2f5</samp>

> _Sing, O Muse, of the mighty ovnClient, the swift and skillful tool_
> _That replaced the old and cumbersome ovnLegacyClient, the source of many a woe_
> _And how the valiant coders, with wisdom and courage, refactored the port group code_
> _To make it simpler, faster, and more consistent, like the arrows of Apollo_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74be2f5</samp>

*  Replace the ovnLegacyClient with the ovnClient for port group operations, and pass externalIDs to the CreatePortGroup method to store metadata ([link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L581-R607), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L202-R212), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L251-R255), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L394-R398), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L339-R340), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L464-R468), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L986-R967), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1137-R1094), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L993), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L170-R182), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L257-R272), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L381-R400), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L423-R451), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1481-R1495), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2188-R2158), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2352-R2330), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L744-L807), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L1125-L1200), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L1298-L1342), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L1591-L1602))
* Simplify the logic to check and add ports to the port groups, and remove the unused functions to list and map the logical switch ports and port group ports ([link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L948-R934), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L954-R943), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1418-L1423), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2117-L2133))
* Change the way to generate and use the port group names for network policies, using the np.Name field instead of the npName variable ([link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L188-R200), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L542-R548))
* Initialize and populate a map to store the network policy and node port group names in `gc.go`, to avoid duplication and improve lookup efficiency ([link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L549-R551), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L557-R562), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L567-R571))
* Remove an empty line in `node.go` to improve code style ([link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L920-R926))
* Change the way to report the error messages, using a more concise and consistent format ([link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1126-R1082), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1144-R1100), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L185-R192), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2352-R2330), [link](https://github.com/kubeovn/kube-ovn/pull/2608/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2372-R2339))