### PR TITLE
ovs: fix dpif-netlink ofpbuf memory leak

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -14,6 +14,8 @@ RUN apt update && apt install -y build-essential fakeroot git curl \
 RUN cd /usr/src/ && \
     git clone -b branch-3.1 --depth=1 https://github.com/openvswitch/ovs.git && \
     cd ovs && \
+    # dpif-netlink.: fix ofpbuf memory leak
+    curl -s https://github.com/kubeovn/ovs/commit/142fdf9e324a0598b1377b0fa7776616e88a6684.patch | git apply && \
     # fix memory leak by ofport_usage and trim memory periodically
     curl -s https://github.com/kubeovn/ovs/commit/25d71867370c9a44c66b973556338de7a4d9bad7.patch | git apply && \
     # increase election timer


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes memory leak in ovs-vswitchd:

```txt
==00:00:01:02.010 55300== 1,088 (64 direct, 1,024 indirect) bytes in 1 blocks are definitely lost in loss record 371 of 394
==00:00:01:02.010 55300==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==00:00:01:02.010 55300==    by 0x30B286: xmalloc__ (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x30B368: xmalloc (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x2B722F: ofpbuf_new (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x345FD2: nl_sock_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x346E78: nl_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x327472: dpif_netlink_dp_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x31CE09: dpif_netlink_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x1F2894: do_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x1F2A67: dpif_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x1F2AF4: dpif_create_and_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x1624A4: open_dpif_backer (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==
==00:00:01:02.010 55300== 2,176 (128 direct, 2,048 indirect) bytes in 2 blocks are definitely lost in loss record 386 of 394
==00:00:01:02.010 55300==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==00:00:01:02.010 55300==    by 0x30B286: xmalloc__ (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x30B368: xmalloc (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x2B722F: ofpbuf_new (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x345FD2: nl_sock_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x346E78: nl_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x327472: dpif_netlink_dp_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x31CE09: dpif_netlink_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x1F2894: do_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x1F2A67: dpif_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x39E14E: dps_for_each (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x39E410: dpctl_dump_dps (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==
==00:00:01:02.010 55300== 2,176 (128 direct, 2,048 indirect) bytes in 2 blocks are definitely lost in loss record 387 of 394
==00:00:01:02.010 55300==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==00:00:01:02.010 55300==    by 0x30B286: xmalloc__ (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x30B368: xmalloc (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x2B722F: ofpbuf_new (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x345FD2: nl_sock_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x346E78: nl_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x327472: dpif_netlink_dp_transact (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x31CE09: dpif_netlink_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x1F2894: do_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x1F2A67: dpif_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x39C495: parsed_dpif_open (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==    by 0x39E30C: dpctl_show (in /usr/sbin/ovs-vswitchd)
==00:00:01:02.010 55300==
```

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough