### PR TITLE
ci: fix multus installation

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1104,16 +1104,12 @@ jobs:
           sudo cp -r /root/.kube/ ~/.kube/
           sudo chown -R $(id -un). ~/.kube/
 
-      - name: Install Multus
-        run: make kind-install-multus
-
-      - name: Install Kube-OVN
+      - name: Install Multus and Kube-OVN
         run: make kind-install-lb-svc
 
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}
         run: make kube-ovn-lb-svc-conformance-e2e
-
 
   kubevirt-e2e:
     name: Kubevirt vm E2E

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -739,11 +739,7 @@ jobs:
           sudo cp -r /root/.kube/ ~/.kube/
           sudo chown -R $(id -un). ~/.kube/
 
-      - name: Install Multus
-        working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
-        run: make kind-install-multus
-
-      - name: Install Kube-OVN
+      - name: Install Multus and Kube-OVN
         working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
         run: |
           version=$(grep -E '^VERSION="v([0-9]+\.){2}[0-9]+"$' dist/images/install.sh | head -n1 | awk -F= '{print $2}' | tr -d '"')

--- a/Makefile
+++ b/Makefile
@@ -617,10 +617,9 @@ kind-install-kubevirt: kind-load-image kind-untaint-control-plane
 .PHONY: kind-install-lb-svc
 kind-install-lb-svc: kind-load-image kind-untaint-control-plane
 	$(call kind_load_image,kube-ovn,$(VPC_NAT_GW_IMG))
+	@$(MAKE) ENABLE_LB_SVC=true CNI_CONFIG_PRIORITY=10 kind-install
+	@$(MAKE) kind-install-multus
 	kubectl apply -f yamls/lb-svc-attachment.yaml
-	sed 's/VERSION=.*/VERSION=$(VERSION)/' dist/images/install.sh | \
-	ENABLE_LB_SVC=true CNI_CONFIG_PRIORITY=10 bash
-	kubectl describe no
 
 .PHONY: kind-install-webhook
 kind-install-webhook: kind-install


### PR DESCRIPTION
Multus now requires a Kubernetes CNI plugin has been installed first. This patch fixes occasional multus installation failure.


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- CI

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb744d8</samp>

This pull request simplifies and improves the GitHub workflows and the Makefile for building and testing Kube-OVN. It also ensures that Multus is installed before applying a load balancer service to a pod network.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cb744d8</samp>

> _`Multus` and `OVN`_
> _moved to `build-x86-image`_
> _workflow streamlined_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb744d8</samp>

*  Simplify the installation of Multus and Kube-OVN in the `build-x86-image.yaml` workflow file by using the `kind-install-lb-svc` target in the Makefile ([link](https://github.com/kubeovn/kube-ovn/pull/2622/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1107-R1107), [link](https://github.com/kubeovn/kube-ovn/pull/2622/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L742-R743))
*  Modify the `kind-install-lb-svc` target in the Makefile to use the `kind-install` target with flags and add the `kind-install-multus` target as a dependency ([link](https://github.com/kubeovn/kube-ovn/pull/2622/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L620-R622))
*  Remove an empty line from the `build-x86-image.yaml` workflow file for formatting ([link](https://github.com/kubeovn/kube-ovn/pull/2622/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1117))