### PR TITLE
libovsdb: fix race condition in OVN LB operations

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -51,8 +51,6 @@ RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-o
     curl -s https://github.com/kubeovn/ovn/commit/cd31bebd1c15fb8e50107861a9397e672fcbad27.patch | git apply && \
     # fix reaching resubmit limit in underlay
     curl -s https://github.com/kubeovn/ovn/commit/993147dd6ab2dd4565379315a6d96ab12f4a294d.patch | git apply && \
-    # do not remove LB if vips is empty
-    curl -s https://github.com/kubeovn/ovn/commit/8693053ed3d5ecd5cd70658315d3079f33e9f8e0.patch | git apply && \
     sed -i 's/OVN/ovn/g' debian/changelog && \
     rm -rf .git && \
     ./boot.sh && \

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -866,37 +866,37 @@ func (mr *MockLoadBalancerMockRecorder) ListLoadBalancers(filter interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLoadBalancers", reflect.TypeOf((*MockLoadBalancer)(nil).ListLoadBalancers), filter)
 }
 
-// LoadBalancerAddVips mocks base method.
-func (m *MockLoadBalancer) LoadBalancerAddVips(lbName string, vips map[string]string) error {
+// LoadBalancerAddVip mocks base method.
+func (m *MockLoadBalancer) LoadBalancerAddVip(lbName, vip string, backends ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadBalancerAddVips", lbName, vips)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// LoadBalancerAddVips indicates an expected call of LoadBalancerAddVips.
-func (mr *MockLoadBalancerMockRecorder) LoadBalancerAddVips(lbName, vips interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerAddVips", reflect.TypeOf((*MockLoadBalancer)(nil).LoadBalancerAddVips), lbName, vips)
-}
-
-// LoadBalancerDeleteVips mocks base method.
-func (m *MockLoadBalancer) LoadBalancerDeleteVips(lbName string, vips ...string) error {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{lbName}
-	for _, a := range vips {
+	varargs := []interface{}{lbName, vip}
+	for _, a := range backends {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "LoadBalancerDeleteVips", varargs...)
+	ret := m.ctrl.Call(m, "LoadBalancerAddVip", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// LoadBalancerDeleteVips indicates an expected call of LoadBalancerDeleteVips.
-func (mr *MockLoadBalancerMockRecorder) LoadBalancerDeleteVips(lbName interface{}, vips ...interface{}) *gomock.Call {
+// LoadBalancerAddVip indicates an expected call of LoadBalancerAddVip.
+func (mr *MockLoadBalancerMockRecorder) LoadBalancerAddVip(lbName, vip interface{}, backends ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{lbName}, vips...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerDeleteVips", reflect.TypeOf((*MockLoadBalancer)(nil).LoadBalancerDeleteVips), varargs...)
+	varargs := append([]interface{}{lbName, vip}, backends...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerAddVip", reflect.TypeOf((*MockLoadBalancer)(nil).LoadBalancerAddVip), varargs...)
+}
+
+// LoadBalancerDeleteVip mocks base method.
+func (m *MockLoadBalancer) LoadBalancerDeleteVip(lbName, vip string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadBalancerDeleteVip", lbName, vip)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LoadBalancerDeleteVip indicates an expected call of LoadBalancerDeleteVip.
+func (mr *MockLoadBalancerMockRecorder) LoadBalancerDeleteVip(lbName, vip interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerDeleteVip", reflect.TypeOf((*MockLoadBalancer)(nil).LoadBalancerDeleteVip), lbName, vip)
 }
 
 // LoadBalancerExists mocks base method.
@@ -2757,37 +2757,37 @@ func (mr *MockOvnClientMockRecorder) ListPortGroups(externalIDs interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPortGroups", reflect.TypeOf((*MockOvnClient)(nil).ListPortGroups), externalIDs)
 }
 
-// LoadBalancerAddVips mocks base method.
-func (m *MockOvnClient) LoadBalancerAddVips(lbName string, vips map[string]string) error {
+// LoadBalancerAddVip mocks base method.
+func (m *MockOvnClient) LoadBalancerAddVip(lbName, vip string, backends ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadBalancerAddVips", lbName, vips)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// LoadBalancerAddVips indicates an expected call of LoadBalancerAddVips.
-func (mr *MockOvnClientMockRecorder) LoadBalancerAddVips(lbName, vips interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerAddVips", reflect.TypeOf((*MockOvnClient)(nil).LoadBalancerAddVips), lbName, vips)
-}
-
-// LoadBalancerDeleteVips mocks base method.
-func (m *MockOvnClient) LoadBalancerDeleteVips(lbName string, vips ...string) error {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{lbName}
-	for _, a := range vips {
+	varargs := []interface{}{lbName, vip}
+	for _, a := range backends {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "LoadBalancerDeleteVips", varargs...)
+	ret := m.ctrl.Call(m, "LoadBalancerAddVip", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// LoadBalancerDeleteVips indicates an expected call of LoadBalancerDeleteVips.
-func (mr *MockOvnClientMockRecorder) LoadBalancerDeleteVips(lbName interface{}, vips ...interface{}) *gomock.Call {
+// LoadBalancerAddVip indicates an expected call of LoadBalancerAddVip.
+func (mr *MockOvnClientMockRecorder) LoadBalancerAddVip(lbName, vip interface{}, backends ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{lbName}, vips...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerDeleteVips", reflect.TypeOf((*MockOvnClient)(nil).LoadBalancerDeleteVips), varargs...)
+	varargs := append([]interface{}{lbName, vip}, backends...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerAddVip", reflect.TypeOf((*MockOvnClient)(nil).LoadBalancerAddVip), varargs...)
+}
+
+// LoadBalancerDeleteVip mocks base method.
+func (m *MockOvnClient) LoadBalancerDeleteVip(lbName, vip string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadBalancerDeleteVip", lbName, vip)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LoadBalancerDeleteVip indicates an expected call of LoadBalancerDeleteVip.
+func (mr *MockOvnClientMockRecorder) LoadBalancerDeleteVip(lbName, vip interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerDeleteVip", reflect.TypeOf((*MockOvnClient)(nil).LoadBalancerDeleteVip), lbName, vip)
 }
 
 // LoadBalancerExists mocks base method.

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -504,7 +504,7 @@ func (c *Controller) gcLoadBalancer() error {
 
 			for vip := range lb.Vips {
 				if _, ok := svcVips[vip]; !ok {
-					if err = c.ovnClient.LoadBalancerDeleteVips(lbName, vip); err != nil {
+					if err = c.ovnClient.LoadBalancerDeleteVip(lbName, vip); err != nil {
 						klog.Errorf("failed to delete vip %s from LB %s: %v", vip, lbName, err)
 						return err
 					}

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -594,7 +594,7 @@ func (c *Controller) AddDnatRule(vpcName, dnatName, externalIp, internalIp, exte
 		return err
 	}
 
-	if err := c.ovnClient.LoadBalancerAddVips(dnatName, map[string]string{externalEndpoint: internalEndpoint}); err != nil {
+	if err := c.ovnClient.LoadBalancerAddVip(dnatName, externalEndpoint, internalEndpoint); err != nil {
 		klog.Errorf("add vip %s with backends %s to LB %s: %v", externalEndpoint, internalEndpoint, dnatName, err)
 		return err
 	}
@@ -609,7 +609,7 @@ func (c *Controller) AddDnatRule(vpcName, dnatName, externalIp, internalIp, exte
 func (c *Controller) DelDnatRule(vpcName, dnatName, externalIp, externalPort string) error {
 	externalEndpoint := net.JoinHostPort(externalIp, externalPort)
 
-	if err := c.ovnClient.LoadBalancerDeleteVips(dnatName, externalEndpoint); err != nil {
+	if err := c.ovnClient.LoadBalancerDeleteVip(dnatName, externalEndpoint); err != nil {
 		klog.Errorf("delete loadBalancer vips %s: %v", externalEndpoint, err)
 		return err
 	}

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -266,7 +266,7 @@ func (c *Controller) handleDeleteService(service *vpcService) error {
 		}
 
 		for _, lb := range vpcLB {
-			if err := c.ovnClient.LoadBalancerDeleteVips(lb, vip); err != nil {
+			if err := c.ovnClient.LoadBalancerDeleteVip(lb, vip); err != nil {
 				klog.Errorf("failed to delete vip %s from LB %s: %v", vip, lb, err)
 				return err
 			}
@@ -351,7 +351,7 @@ func (c *Controller) handleUpdateService(key string) error {
 		}
 		klog.V(3).Infof("existing vips of LB %s: %v", lbName, lb.Vips)
 		for _, vip := range svcVips {
-			if err := c.ovnClient.LoadBalancerDeleteVips(oLbName, vip); err != nil {
+			if err := c.ovnClient.LoadBalancerDeleteVip(oLbName, vip); err != nil {
 				klog.Errorf("failed to delete vip %s from LB %s: %v", vip, oLbName, err)
 				return err
 			}
@@ -366,7 +366,7 @@ func (c *Controller) handleUpdateService(key string) error {
 		for vip := range lb.Vips {
 			if ip := parseVipAddr(vip); (util.ContainsString(ips, ip) && !util.IsStringIn(vip, svcVips)) || util.ContainsString(ipsToDel, ip) {
 				klog.Infof("remove stale vip %s from LB %s", vip, lb)
-				if err := c.ovnClient.LoadBalancerDeleteVips(lbName, vip); err != nil {
+				if err := c.ovnClient.LoadBalancerDeleteVip(lbName, vip); err != nil {
 					klog.Errorf("failed to delete vip %s from LB %s: %v", vip, lb, err)
 					return err
 				}
@@ -386,7 +386,7 @@ func (c *Controller) handleUpdateService(key string) error {
 		for vip := range oLb.Vips {
 			if ip := parseVipAddr(vip); util.ContainsString(ips, ip) || util.ContainsString(ipsToDel, ip) {
 				klog.Infof("remove stale vip %s from LB %s", vip, oLbName)
-				if err = c.ovnClient.LoadBalancerDeleteVips(oLbName, vip); err != nil {
+				if err = c.ovnClient.LoadBalancerDeleteVip(oLbName, vip); err != nil {
 					klog.Errorf("failed to delete vip %s from LB %s: %v", vip, oLbName, err)
 					return err
 				}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -70,8 +70,8 @@ type LogicalSwitchPort interface {
 
 type LoadBalancer interface {
 	CreateLoadBalancer(lbName, protocol, selectFields string) error
-	LoadBalancerAddVips(lbName string, vips map[string]string) error
-	LoadBalancerDeleteVips(lbName string, vips ...string) error
+	LoadBalancerAddVip(lbName, vip string, backends ...string) error
+	LoadBalancerDeleteVip(lbName, vip string) error
 	SetLoadBalancerAffinityTimeout(lbName string, timeout int) error
 	DeleteLoadBalancers(filter func(lb *ovnnb.LoadBalancer) bool) error
 	GetLoadBalancer(lbName string, ignoreNotFound bool) (*ovnnb.LoadBalancer, error)

--- a/pkg/ovs/ovn-nb-logical_router.go
+++ b/pkg/ovs/ovn-nb-logical_router.go
@@ -172,7 +172,7 @@ func (c *ovnClient) LogicalRouterUpdateLoadBalancers(lrName string, op ovsdb.Mut
 		return fmt.Errorf("generate operations for logical router %s update lbs %v: %v", lrName, lbNames, err)
 	}
 
-	if err := c.Transact("ls-lb-update", ops); err != nil {
+	if err := c.Transact("lr-lb-update", ops); err != nil {
 		return fmt.Errorf("logical router %s update lbs %v: %v", lrName, lbNames, err)
 
 	}

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -310,8 +310,8 @@ func (suite *OvnClientTestSuite) Test_DeleteLoadBalancer() {
 	suite.testDeleteLoadBalancer()
 }
 
-func (suite *OvnClientTestSuite) Test_LoadBalancerDeleteVips() {
-	suite.testLoadBalancerDeleteVips()
+func (suite *OvnClientTestSuite) Test_LoadBalancerDeleteVip() {
+	suite.testLoadBalancerDeleteVip()
 }
 
 func (suite *OvnClientTestSuite) Test_GetLoadBalancer() {
@@ -322,8 +322,8 @@ func (suite *OvnClientTestSuite) Test_ListLoadBalancers() {
 	suite.testListLoadBalancers()
 }
 
-func (suite *OvnClientTestSuite) Test_LoadBalancerAddVips() {
-	suite.testLoadBalancerAddVips()
+func (suite *OvnClientTestSuite) Test_LoadBalancerAddVip() {
+	suite.testLoadBalancerAddVip()
 }
 
 func (suite *OvnClientTestSuite) Test_DeleteLoadBalancerOp() {
@@ -630,10 +630,12 @@ func Test_scratch(t *testing.T) {
 		"[fd00:10:96::e82f]:8080": "[fc00::af4:f]:8080,[fc00::af4:10]:8080,[fc00::af4:11]:8080",
 	}
 
-	err = ovnClient.LoadBalancerAddVips(lbName, vips)
-	require.NoError(t, err)
+	for vip, backends := range vips {
+		err = ovnClient.LoadBalancerAddVip(lbName, vip, strings.Split(backends, ",")...)
+		require.NoError(t, err)
+	}
 
-	err = ovnClient.LoadBalancerDeleteVips(lbName, "10.96.0.1:443")
+	err = ovnClient.LoadBalancerDeleteVip(lbName, "10.96.0.1:443")
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f8647c8</samp>

This pull request refactors the LoadBalancer interface in the `ovs` package and updates the controller and test packages to use the new methods. The new interface simplifies the arguments and calls for adding and deleting load balancer vips and backends, and avoids unnecessary map operations. It also fixes a typo in the logical router transaction name.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f8647c8</samp>

> _Sing, O Muse, of the mighty refactor of the LoadBalancer interface_
> _That the skilled programmers wrought with their nimble fingers and minds_
> _They simplified the arguments and the calls to the OVN-NB client_
> _And avoided the needless map operations that caused much delay and strife_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f8647c8</samp>

*  Refactor the LoadBalancer interface to use a single vip and a variadic list of backends as parameters instead of a map of vips and backends ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49L73-R74), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L869-R899), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L2760-R2790))
*  Update the endpoint controller to use the new LoadBalancer interface and pass the vip and backends as separate arguments ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-e446ff04750bbbe87ec6cf1387960a29d56757d84784b18f2814a6e0be5fb528L195-R204), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-e446ff04750bbbe87ec6cf1387960a29d56757d84784b18f2814a6e0be5fb528L216-R215), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-e446ff04750bbbe87ec6cf1387960a29d56757d84784b18f2814a6e0be5fb528L264-R263))
*  Update the gc controller to use the new LoadBalancer interface and pass the vip as a single argument ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L507-R507))
*  Update the ovn_dnat controller to use the new LoadBalancer interface and pass the vip and backend as separate arguments ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L597-R597), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L612-R612))
*  Update the service controller to use the new LoadBalancer interface and pass the vip as a single argument ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9L269-R269), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9L354-R354), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9L369-R369), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9L389-R389))
*  Implement the new LoadBalancer interface methods using the OVN-NB client and remove the old LoadBalancer interface methods ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-f80a92268723484fa7d5dd097ad7f90925d4efe119bc878098352c751ff5a937L64-R124), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-f80a92268723484fa7d5dd097ad7f90925d4efe119bc878098352c751ff5a937L227-R235), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-f80a92268723484fa7d5dd097ad7f90925d4efe119bc878098352c751ff5a937L238-R253))
*  Update the test functions to use the new LoadBalancer interface methods and test each vip and backends individually ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-bb86c449c6de575e2b8b9463b68eb394256f27d6c7a037e3758e18b8ddc5e7f9L83-R93), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-bb86c449c6de575e2b8b9463b68eb394256f27d6c7a037e3758e18b8ddc5e7f9L102-R130), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-bb86c449c6de575e2b8b9463b68eb394256f27d6c7a037e3758e18b8ddc5e7f9L171-R188), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-bb86c449c6de575e2b8b9463b68eb394256f27d6c7a037e3758e18b8ddc5e7f9L187-R212), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-5d9e40841703fc05abd0bdae3efc305752b84e9c573472da709ed8326a855453L313-R314), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-5d9e40841703fc05abd0bdae3efc305752b84e9c573472da709ed8326a855453L325-R326), [link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-5d9e40841703fc05abd0bdae3efc305752b84e9c573472da709ed8326a855453L633-R638))
*  Fix a typo in the logical router transaction name ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-963d5ab25c32b9009a860d464ff78138edef57c9d41f2fc4209510980ec7b51eL175-R175))
*  Remove an unused import of "strings" in the endpoint controller ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-e446ff04750bbbe87ec6cf1387960a29d56757d84784b18f2814a6e0be5fb528L6))
*  Add the "sort" and "strings" packages and remove the "reflect" package in the `ovn-nb-load_balancer.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/2625/files?diff=unified&w=0#diff-f80a92268723484fa7d5dd097ad7f90925d4efe119bc878098352c751ff5a937L6-R8))