### PR TITLE
libovsdb: use monitor_cond as the monitor method

### DIFF
--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -717,20 +717,20 @@ func newNbClient(addr string, timeout int) (client.Client, error) {
 	}
 
 	monitorOpts := []client.MonitorOption{
-		client.WithTable(&ovnnb.LogicalRouter{}),
-		client.WithTable(&ovnnb.LogicalRouterPort{}),
-		client.WithTable(&ovnnb.LogicalRouterPolicy{}),
-		client.WithTable(&ovnnb.LogicalRouterStaticRoute{}),
-		client.WithTable(&ovnnb.NAT{}),
-		client.WithTable(&ovnnb.LogicalSwitch{}),
-		client.WithTable(&ovnnb.LogicalSwitchPort{}),
-		client.WithTable(&ovnnb.PortGroup{}),
-		client.WithTable(&ovnnb.NBGlobal{}),
+		client.WithTable(&ovnnb.ACL{}),
+		client.WithTable(&ovnnb.AddressSet{}),
+		client.WithTable(&ovnnb.DHCPOptions{}),
 		client.WithTable(&ovnnb.GatewayChassis{}),
 		client.WithTable(&ovnnb.LoadBalancer{}),
-		client.WithTable(&ovnnb.AddressSet{}),
-		client.WithTable(&ovnnb.ACL{}),
-		client.WithTable(&ovnnb.DHCPOptions{}),
+		client.WithTable(&ovnnb.LogicalRouterPolicy{}),
+		client.WithTable(&ovnnb.LogicalRouterPort{}),
+		client.WithTable(&ovnnb.LogicalRouterStaticRoute{}),
+		client.WithTable(&ovnnb.LogicalRouter{}),
+		client.WithTable(&ovnnb.LogicalSwitchPort{}),
+		client.WithTable(&ovnnb.LogicalSwitch{}),
+		client.WithTable(&ovnnb.NAT{}),
+		client.WithTable(&ovnnb.NBGlobal{}),
+		client.WithTable(&ovnnb.PortGroup{}),
 	}
 	if _, err = c.Monitor(context.TODO(), c.NewMonitor(monitorOpts...)); err != nil {
 		return nil, err

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ovn-org/libovsdb/client"
-
+	"github.com/ovn-org/libovsdb/ovsdb"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -93,23 +93,24 @@ func NewNbClient(addr string) (client.Client, error) {
 		return nil, err
 	}
 
-	monitorOpts := []client.MonitorOption{
-		client.WithTable(&ovnnb.LogicalRouter{}),
-		client.WithTable(&ovnnb.LogicalRouterPort{}),
-		client.WithTable(&ovnnb.LogicalRouterPolicy{}),
-		client.WithTable(&ovnnb.LogicalRouterStaticRoute{}),
-		client.WithTable(&ovnnb.NAT{}),
-		client.WithTable(&ovnnb.LogicalSwitch{}),
-		client.WithTable(&ovnnb.LogicalSwitchPort{}),
-		client.WithTable(&ovnnb.NBGlobal{}),
-		client.WithTable(&ovnnb.PortGroup{}),
+	monitor := c.NewMonitor(
+		client.WithTable(&ovnnb.ACL{}),
+		client.WithTable(&ovnnb.AddressSet{}),
+		client.WithTable(&ovnnb.DHCPOptions{}),
 		client.WithTable(&ovnnb.GatewayChassis{}),
 		client.WithTable(&ovnnb.LoadBalancer{}),
-		client.WithTable(&ovnnb.AddressSet{}),
-		client.WithTable(&ovnnb.ACL{}),
-		client.WithTable(&ovnnb.DHCPOptions{}),
-	}
-	if _, err = c.Monitor(context.TODO(), c.NewMonitor(monitorOpts...)); err != nil {
+		client.WithTable(&ovnnb.LogicalRouterPolicy{}),
+		client.WithTable(&ovnnb.LogicalRouterPort{}),
+		client.WithTable(&ovnnb.LogicalRouterStaticRoute{}),
+		client.WithTable(&ovnnb.LogicalRouter{}),
+		client.WithTable(&ovnnb.LogicalSwitchPort{}),
+		client.WithTable(&ovnnb.LogicalSwitch{}),
+		client.WithTable(&ovnnb.NAT{}),
+		client.WithTable(&ovnnb.NBGlobal{}),
+		client.WithTable(&ovnnb.PortGroup{}),
+	)
+	monitor.Method = ovsdb.ConditionalMonitorRPC
+	if _, err = c.Monitor(context.TODO(), monitor); err != nil {
 		klog.Errorf("failed to monitor database on OVN NB server %s: %v", addr, err)
 		return nil, err
 	}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
By default, libovsdb monitor uses `monitor_cond_since` as the monitor method. If a client is reconnecting a `CondSince` monitor that is the only monitor, it uses its `LastTransactionID`.
This patch is expected to fix #2621 by purging the cache on reconnection.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a5eca6</samp>

This pull request improves the OVN NB client performance and code consistency by using conditional monitoring and sorting monitor options by table name in `pkg/ovsdb/client/client.go` and `pkg/ovs/ovn-nb-suite_test.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a5eca6</samp>

> _To boost the OVN NB client_
> _We use conditional monitor events_
> _We sort by table name_
> _In test and main_
> _And add a missing import statement_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a5eca6</samp>

*  Use conditional monitoring feature of libovsdb client to improve performance and scalability of OVN NB client ([link](https://github.com/kubeovn/kube-ovn/pull/2627/files?diff=unified&w=0#diff-8c46f500ad7d8fe51f1165ee87bbfe97e665d1856bd02101a2b85cc0ea9946adL17-R17), [link](https://github.com/kubeovn/kube-ovn/pull/2627/files?diff=unified&w=0#diff-8c46f500ad7d8fe51f1165ee87bbfe97e665d1856bd02101a2b85cc0ea9946adL96-R113))
  - Add import of `github.com/ovn-org/libovsdb/ovsdb` package in `pkg/ovsdb/client/client.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2627/files?diff=unified&w=0#diff-8c46f500ad7d8fe51f1165ee87bbfe97e665d1856bd02101a2b85cc0ea9946adL17-R17))
  - Modify `NewNbClient` function in `pkg/ovsdb/client/client.go` to use `ovsdb.ConditionalMonitorRPC` constant and sort monitor options alphabetically by table name ([link](https://github.com/kubeovn/kube-ovn/pull/2627/files?diff=unified&w=0#diff-8c46f500ad7d8fe51f1165ee87bbfe97e665d1856bd02101a2b85cc0ea9946adL96-R113))
* Sort monitor options alphabetically by table name in test file `pkg/ovs/ovn-nb-suite_test.go` for consistency and readability ([link](https://github.com/kubeovn/kube-ovn/pull/2627/files?diff=unified&w=0#diff-5d9e40841703fc05abd0bdae3efc305752b84e9c573472da709ed8326a855453L720-R733))
  - Update `newNbClient` function in `pkg/ovs/ovn-nb-suite_test.go` to match the order used in `NewNbClient` function in `pkg/ovsdb/client/client.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2627/files?diff=unified&w=0#diff-5d9e40841703fc05abd0bdae3efc305752b84e9c573472da709ed8326a855453L720-R733))