### PR TITLE
ci: deploy multus in thick-plugin mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ CONTROL_PLANE_TAINTS = node-role.kubernetes.io/master node-role.kubernetes.io/co
 
 CHART_UPGRADE_RESTART_OVS=$(shell echo $${CHART_UPGRADE_RESTART_OVS:-false})
 
-MULTUS_IMAGE = ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot
-MULTUS_YAML = https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset.yml
+MULTUS_IMAGE = ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
+MULTUS_YAML = https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset-thick.yml
 
 KUBEVIRT_VERSION = v0.58.0
 KUBEVIRT_OPERATOR_IMAGE = quay.io/kubevirt/virt-operator:$(KUBEVIRT_VERSION)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- CI


### Which issue(s) this PR fixes:

> With the multus 4.0 release, we introduce a new client/server-style plugin deployment. This new deployment is called ['thick plugin'](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/thick-plugin.md), in contrast to deployments in previous versions, which is now called a 'thin plugin'. The new thick plugin consists of two binaries, multus-daemon and multus-shim CNI plugin. The 'multus-daemon' will be deployed to all nodes as a local agent and supports additional features, such as metrics, which were not available with the 'thin plugin' deployment before. Due to these additional features, the 'thick plugin' comes with the trade-off of consuming more resources than the 'thin plugin'.

By deploying multus-cni in thick-plugin mode, we can collect arguments passed to and results returned from CNI plugins for debugging purposes.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7880d60</samp>

Update `Makefile` and Helm chart to support Multus CNI thick plugin mode. This mode bundles multiple CNI binaries into the Multus binary, simplifying the network attachment for pods.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7880d60</samp>

> _`Multus` supports thick_
> _Bundling all CNI plugins_
> _Simpler for spring pods_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7880d60</samp>

* Update the Multus image and YAML file to use the thick plugin mode ([link](https://github.com/kubeovn/kube-ovn/pull/2628/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L24-R25))