### PR TITLE
fix: eip qos

### DIFF
--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -253,7 +253,7 @@ func (c *Controller) handleAddIptablesEip(key string) error {
 	}
 
 	if cachedEip.Spec.QoSPolicy != "" {
-		if err = c.addEipQoS(cachedEip, cachedEip.Status.IP); err != nil {
+		if err = c.addEipQoS(cachedEip, v4ip); err != nil {
 			klog.Errorf("failed to add qos '%s' in pod, %v", key, err)
 			return err
 		}


### PR DESCRIPTION
When an EIP is created, "cachedEip.Status.IP" is empty. This will cause the QoS settings to fail.


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 644b2ca</samp>

Fix a bug in `addEipQoS` function that used the wrong IP address for EIP pods. This change improves the QoS policy for EIP pods in kube-ovn.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 644b2ca</samp>

> _`addEipQoS` fixed_
> _wrong IP caused bad policy_
> _autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 644b2ca</samp>

* Fix a bug where the wrong IP address was passed to the `addEipQoS` function ([link](https://github.com/kubeovn/kube-ovn/pull/2632/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L256-R256)). Use `v4ip`, the IPv4 address of the EIP, instead of `cachedEip.Status.IP`, the IP address of the NAT gateway.