### PR TITLE
add flow to map src ip with vlan priority

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -58,6 +58,7 @@ type Configuration struct {
 	ExternalGatewayConfigNS string
 	ExternalGatewaySwitch   string // provider network underlay vlan subnet
 	EnableMetrics           bool
+	EnableAddIPTosFlow      bool
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -90,6 +91,7 @@ func ParseFlags() *Configuration {
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")
 		argExternalGatewaySwitch   = pflag.String("external-gateway-switch", "external", "The name of the external gateway switch which is a ovs bridge to provide external network, default: external")
 		argEnableMetrics           = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
+		argEnableAddIPTosFlow      = pflag.Bool("enable-ip-tos", false, "If enable add ovs flows to map ip tos to vlan priority")
 	)
 
 	// mute info log for ipset lib
@@ -139,6 +141,7 @@ func ParseFlags() *Configuration {
 		ExternalGatewayConfigNS: *argExternalGatewayConfigNS,
 		ExternalGatewaySwitch:   *argExternalGatewaySwitch,
 		EnableMetrics:           *argEnableMetrics,
+		EnableAddIPTosFlow:      *argEnableAddIPTosFlow,
 	}
 	return config
 }

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -53,6 +55,9 @@ type Controller struct {
 	nodesLister listerv1.NodeLister
 	nodesSynced cache.InformerSynced
 
+	configMapsLister listerv1.ConfigMapLister
+	configMapsSynced cache.InformerSynced
+
 	recorder record.EventRecorder
 
 	protocol string
@@ -75,6 +80,8 @@ func NewController(config *Configuration, podInformerFactory informers.SharedInf
 	podInformer := podInformerFactory.Core().V1().Pods()
 	nodeInformer := nodeInformerFactory.Core().V1().Nodes()
 
+	configMapInformer := nodeInformerFactory.Core().V1().ConfigMaps()
+
 	controller := &Controller{
 		config: config,
 
@@ -96,6 +103,9 @@ func NewController(config *Configuration, podInformerFactory informers.SharedInf
 
 		nodesLister: nodeInformer.Lister(),
 		nodesSynced: nodeInformer.Informer().HasSynced,
+
+		configMapsLister: configMapInformer.Lister(),
+		configMapsSynced: configMapInformer.Informer().HasSynced,
 
 		recorder: recorder,
 	}
@@ -573,6 +583,140 @@ func (c *Controller) markAndCleanInternalPort() error {
 	return nil
 }
 
+func (c *Controller) initCniPodNamespace() error {
+	pods, err := c.config.KubeClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=kube-ovn-cni",
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", c.config.NodeName),
+	})
+	if err != nil {
+		klog.Errorf("failed to list pod: %v", err)
+		return err
+	}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == v1.PodRunning {
+			c.localPodName = pod.Name
+			c.localNamespace = pod.Namespace
+			break
+		}
+	}
+	return nil
+}
+
+func (c *Controller) addFlowWithIPTos(cm *v1.ConfigMap) error {
+	pns, err := c.providerNetworksLister.List(labels.Everything())
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Errorf("failed to list provider networks: %v", err)
+		return err
+	}
+	for _, pn := range pns {
+		for tos, priority := range cm.Data {
+			if _, err := strconv.Atoi(tos); err != nil || !strings.HasPrefix(priority, "0x") {
+				continue
+			}
+
+			// ovs-ofctl add-flow br-provider ip,nw_tos=32,actions=mod_vlan_pcp:2,NORMAL
+			if _, err := ovs.OvsExec("add-flow", fmt.Sprintf("br-%s", pn.Name), fmt.Sprintf("ip,nw_tos=%s,actions=mod_vlan_pcp:%s,NORMAL", tos, priority)); err != nil {
+				return fmt.Errorf("failed to add flow with ip_tos %s, %v", tos, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) clearFlowWithIPTos(cm *v1.ConfigMap) error {
+	pns, err := c.providerNetworksLister.List(labels.Everything())
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Errorf("failed to list provider networks: %v", err)
+		return err
+	}
+	for _, pn := range pns {
+		// ovs-ofctl dump-flows br-provider
+		output, err := ovs.OvsExec("dump-flows", fmt.Sprintf("br-%s", pn.Name))
+		if err != nil {
+			return fmt.Errorf("failed to dump flows for provider-networks %s, %v", pn.Name, err)
+		}
+		klog.Infof("output of dump-flows for provider-networks %s is %s", pn.Name, output)
+		if !strings.Contains(output, "nw_tos") && !strings.Contains(output, "mod_vlan_pcp") {
+			continue
+		}
+
+		toss := ovs.ParseDumpFlowsOutput(output)
+		for _, tos := range toss {
+			// delete existed ip_tos flows
+			if _, err := ovs.OvsExec("del-flows", fmt.Sprintf("br-%s", pn.Name), fmt.Sprintf("ip,nw_tos=%s", tos)); err != nil {
+				return fmt.Errorf("failed to delete flow with ip_tos %s, %v", tos, err)
+			}
+		}
+
+		for tos := range cm.Data {
+			if _, err := strconv.Atoi(tos); err != nil {
+				continue
+			}
+
+			// ovs-ofctl del-flows br-provider ip,nw_tos=32
+			if _, err := ovs.OvsExec("del-flows", fmt.Sprintf("br-%s", pn.Name), fmt.Sprintf("ip,nw_tos=%s", tos)); err != nil {
+				return fmt.Errorf("failed to delete flow with ip_tos %s, %v", tos, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+var (
+	ovsFlowVlanPriEnabled   = "unknown"
+	ovsFlowVlanPriCmVersion = ""
+)
+
+func (c *Controller) syncOvsVlanPriConfig() {
+	cm, err := c.configMapsLister.ConfigMaps(c.localNamespace).Get(util.OvsFlowVlanPriConfig)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		klog.Errorf("failed to get ovs-flow-vlan-pri-config, %v", err)
+		return
+	}
+
+	if k8serrors.IsNotFound(err) || cm.Data["enable-tos-vlan-pri"] == "false" {
+		if ovsFlowVlanPriEnabled == "false" {
+			return
+		}
+		klog.Info("start to clean up ovs flows with ip_tos")
+		if err := c.clearFlowWithIPTos(cm); err != nil {
+			klog.Errorf("failed to delete flows with ip_tos, %v", err)
+			return
+		}
+		ovsFlowVlanPriEnabled = "false"
+		ovsFlowVlanPriCmVersion = ""
+		klog.Info("finish cleaning up ovs flows with ip_tos")
+		return
+	} else {
+		if ovsFlowVlanPriEnabled == "true" && ovsFlowVlanPriCmVersion == cm.ResourceVersion {
+			return
+		}
+
+		if err := c.clearFlowWithIPTos(cm); err != nil {
+			klog.Errorf("failed to delete flows with ip_tos, %v", err)
+			return
+		}
+		klog.Info("start to add ovs flows to map ip_tos and vlan priority")
+		if err = c.addFlowWithIPTos(cm); err != nil {
+			klog.Errorf("failed to add flows with ip_tos, %v", err)
+			return
+		}
+
+		ovsFlowVlanPriEnabled = "true"
+		ovsFlowVlanPriCmVersion = cm.ResourceVersion
+		klog.Info("finish adding ovs flows to map ip_tos and vlan priority")
+		return
+	}
+}
+
 // Run starts controller
 func (c *Controller) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
@@ -586,12 +730,15 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	go wait.Until(rotateLog, 1*time.Hour, stopCh)
 	go wait.Until(c.operateMod, 10*time.Second, stopCh)
 
-	if ok := cache.WaitForCacheSync(stopCh, c.providerNetworksSynced, c.subnetsSynced, c.podsSynced, c.nodesSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.providerNetworksSynced, c.subnetsSynced, c.podsSynced, c.nodesSynced, c.configMapsSynced); !ok {
 		util.LogFatalAndExit(nil, "failed to wait for caches to sync")
 	}
 
 	if err := c.setIPSet(); err != nil {
 		util.LogFatalAndExit(err, "failed to set ipsets")
+	}
+	if err := c.initCniPodNamespace(); err != nil {
+		klog.Errorf("failed to init pod namespace %v", err)
 	}
 
 	klog.Info("Started workers")
@@ -609,6 +756,10 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 			klog.Errorf("gc ovs port error: %v", err)
 		}
 	}, 5*time.Minute, stopCh)
+
+	if c.config.EnableAddIPTosFlow {
+		go wait.Until(c.syncOvsVlanPriConfig, 10*time.Second, stopCh)
+	}
 
 	<-stopCh
 	klog.Info("Shutting down workers")

--- a/pkg/ovs/ovn.go
+++ b/pkg/ovs/ovn.go
@@ -52,6 +52,7 @@ const (
 	OVNIcNbCtl  = "ovn-ic-nbctl"
 	OVNIcSbCtl  = "ovn-ic-sbctl"
 	OvsVsCtl    = "ovs-vsctl"
+	OvsOfCtl    = "ovs-ofctl"
 	MayExist    = "--may-exist"
 	IfExists    = "--if-exists"
 	Policy      = "--policy"

--- a/pkg/ovs/ovs-ofctl.go
+++ b/pkg/ovs/ovs-ofctl.go
@@ -1,0 +1,72 @@
+package ovs
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Glory belongs to openvswitch/ovn-kubernetes
+// https://github.com/openvswitch/ovn-kubernetes/blob/master/go-controller/pkg/util/ovs.go
+
+func OvsExec(args ...string) (string, error) {
+	start := time.Now()
+	args = append([]string{"--timeout=30"}, args...)
+	output, err := exec.Command(OvsOfCtl, args...).CombinedOutput()
+	elapsed := float64((time.Since(start)) / time.Millisecond)
+	klog.V(4).Infof("command %s %s in %vms", OvsOfCtl, strings.Join(args, " "), elapsed)
+	method := ""
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "--") {
+			method = arg
+			break
+		}
+	}
+	code := "0"
+	defer func() {
+		ovsClientRequestLatency.WithLabelValues("ovsdb", method, code).Observe(elapsed)
+	}()
+
+	if err != nil {
+		code = "1"
+		klog.Warningf("ovs-ofctl command error: %s %s in %vms", OvsOfCtl, strings.Join(args, " "), elapsed)
+		return "", fmt.Errorf("failed to run '%s %s': %v\n  %q", OvsOfCtl, strings.Join(args, " "), err, output)
+	} else if elapsed > 500 {
+		klog.Warningf("ovs-ofctl command took too long: %s %s in %vms", OvsOfCtl, strings.Join(args, " "), elapsed)
+	}
+	return trimCommandOutput(output), nil
+}
+
+func ParseDumpFlowsOutput(output string) []string {
+	if output == "" {
+		return []string{}
+	}
+
+	lines := strings.Split(output, "\n")
+	toss := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if len(strings.TrimSpace(l)) == 0 {
+			continue
+		}
+
+		if !strings.Contains(l, "nw_tos") && !strings.Contains(l, "mod_vlan_pcp") {
+			continue
+		}
+
+		fields := strings.Fields(l)
+		for _, field := range fields {
+			values := strings.Split(field, "=")
+			if len(values) != 2 {
+				continue
+			}
+
+			if values[0] == "ip,nw_tos" {
+				toss = append(toss, strings.TrimSpace(values[1]))
+			}
+		}
+	}
+	return toss
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -170,6 +170,7 @@ const (
 	VpcNatConfig           = "ovn-vpc-nat-config"
 
 	DefaultSecurityGroupName = "default-securitygroup"
+	OvsFlowVlanPriConfig     = "ovs-flow-vlan-pri-config"
 
 	DefaultVpc    = "ovn-cluster"
 	DefaultSubnet = "ovn-default"

--- a/test/unittest/ofctl/ofctl.go
+++ b/test/unittest/ofctl/ofctl.go
@@ -1,0 +1,31 @@
+package ofctl
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+)
+
+var _ = Describe("[ovs-ofctl]", func() {
+
+	flow_with_tos := "cookie=0x0, duration=33.091s, table=0, n_packets=0, n_bytes=0, ip,nw_tos=32 actions=mod_vlan_pcp:2,NORMAL"
+	flow_without_tos := "cookie=0x0, duration=1857.598s, table=0, n_packets=59697, n_bytes=22576303, priority=0 actions=NORMAL"
+
+	Describe("[dump-flows]", func() {
+		Context("[parse-flows]", func() {
+			It("flow with ip_tos", func() {
+				By("parse flow with ip_tos 32")
+				values := ovs.ParseDumpFlowsOutput(flow_with_tos)
+				Expect(len(values)).To(Equal(1))
+				Expect(values[0]).To(Equal("32"))
+			})
+
+			It("flow without ip_tos", func() {
+				By("parse flow without ip_tos")
+				values := ovs.ParseDumpFlowsOutput(flow_without_tos)
+				Expect(len(values)).To(Equal(0))
+			})
+		})
+	})
+})

--- a/test/unittest/unit_suite_test.go
+++ b/test/unittest/unit_suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	// tests to run
 	_ "github.com/kubeovn/kube-ovn/test/unittest/ipam"
+	_ "github.com/kubeovn/kube-ovn/test/unittest/ofctl"
 	_ "github.com/kubeovn/kube-ovn/test/unittest/util"
 )
 

--- a/yamls/ovs-flow-vlan-pri-config.yaml
+++ b/yamls/ovs-flow-vlan-pri-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovs-flow-vlan-pri-config
+  namespace: kube-system
+data:
+  enable-tos-vlan-pri: "true"
+  "32": "0x1"
+  "64": "0x2"
+  "96": "0x3"
+  "128": "0x4"
+  "160": "0x5"
+  "192": "0x6"
+  "224": "0x7"
+


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Features



### Which issue(s) this PR fixes:
Fixes #2215 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0646e51</samp>

This pull request adds a feature to enable adding ovs flows that map the packet source ip address to the vlan priority based on a config map. It modifies the `daemon`, `ovs`, and `util` packages, adds a new file `pkg/ovs/ovs-ofctl.go` and a new test suite `ofctl`, and provides a sample config map `yamls/ovs-flow-vlan-pri-config.yaml`. The feature can be controlled by a new command-line argument `--enable-src-ip-flow` and a config map field `enable-mark-vlan-pri`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0646e51</samp>

> _We are the masters of the ovs flows_
> _We control the vlan priority with `OvsOfCtl`_
> _We unleash the power of the source ip_
> _We defy the network with `EnableAddSrcIPFlow`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0646e51</samp>

*  Add a new boolean flag `EnableAddSrcIPFlow` to the `Configuration` struct and a new command-line argument `--enable-src-ip-flow` to the `ParseFlags` function in `pkg/daemon/config.go` to control whether to enable adding ovs flows to map packet source ip address to vlan priority ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R61), [link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R94), [link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R144))
* Add a new informer, lister, and synced function for config maps to the `Controller` struct and the `NewController` function in `pkg/daemon/controller.go` to watch for changes in the config maps that store the ovs flow vlan priority configuration ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R59-R61), [link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R83), [link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R107-R109))
* Add a new function `initCniPodNamespace` to the package `daemon` in `pkg/daemon/controller.go` to initialize the local pod name and namespace of the kube-ovn-cni pod running on the same node as the daemon ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R586-R719))
* Add three new functions `addFlowWithPktMark`, `clearFlowWithSrcIP`, and `syncOvsVlanPriConfig` to the package `daemon` in `pkg/daemon/controller.go` to add, delete, and sync the ovs flows that map the packet source ip address to the vlan priority based on the config map data ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L589-R733))
* Add a new call to the `initCniPodNamespace` function and a new conditional block that starts a goroutine to periodically call the `syncOvsVlanPriConfig` function in the `Run` function in `pkg/daemon/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R740-R742), [link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R760-R763))
* Add a new constant `OvsOfCtl` to the package `ovs` in `pkg/ovs/ovn.go` to store the name of the ovs-ofctl command ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-898dd2d56be06b2263eed10e92cf06464d1a951cf50820ac71847a7b3d48cf4dR55))
* Add a new file `pkg/ovs/ovs-ofctl.go` that contains a new package `ovs` with two new functions `OvsExec` and `ParseDumpFlowsOutput` to execute and parse the ovs-ofctl commands and record the latency and error metrics ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-1726d6c2edd94ac4526e0acea69266babcadda65aac6752ca44e9c66f74d0b53R1-R72))
* Add a new constant `OvsFlowVlanPriConfig` to the package `util` in `pkg/util/const.go` to store the name of the config map that stores the ovs flow vlan priority configuration ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR173))
* Add a new file `test/unittest/ofctl/ofctl.go` that contains a new package `ofctl` with a new test suite for the `ovs` package using the ginkgo and gomega frameworks ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-2d125b712a7493583c79a23b9671d7d75dfbf3b14848b40b3424b0e47cc44135R1-R31))
* Add a new import to the package `unittest` in `test/unittest/unit_suite_test.go` to register the `ofctl` test suite to the ginkgo runner ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-0b5e0a307847d408f4e02871a18cb2e707434f75438875022d06ad05568a8cc7R11))
* Add a new file `yamls/ovs-flow-vlan-pri-config.yaml` that contains a sample config map for the ovs flow vlan priority configuration ([link](https://github.com/kubeovn/kube-ovn/pull/2634/files?diff=unified&w=0#diff-539eea21a9fce3b3818984c06389d2f12e9dfd87654a68894d8e7e4ceb002510R1-R15))