### PR TITLE
broadcast free arp when pod is setup

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -843,6 +843,12 @@ func configureNic(link, ip string, macAddr net.HardwareAddr, mtu int, detectIPCo
 				return fmt.Errorf("IP address %s has already been used by host with MAC %s", ip, mac)
 			}
 		}
+		if addr.IP.To4() != nil && !detectIPConflict {
+			// when detectIPConflict is true, free arp is already broadcast in the step of announcement
+			if err := util.BroadcastFreeArp(link, addr.IP.String(), macAddr); err != nil {
+				klog.Warningf("failed to broadcast free arp with err %v ", err)
+			}
+		}
 
 		klog.Infof("add ip address %s to %s", ip, link)
 		if err = netlink.AddrAdd(nodeLink, &addr); err != nil {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -845,7 +845,7 @@ func configureNic(link, ip string, macAddr net.HardwareAddr, mtu int, detectIPCo
 		}
 		if addr.IP.To4() != nil && !detectIPConflict {
 			// when detectIPConflict is true, free arp is already broadcast in the step of announcement
-			if err := util.BroadcastFreeArp(link, addr.IP.String(), macAddr); err != nil {
+			if err := util.BroadcastFreeArp(link, addr.IP.String(), macAddr, 1, 1*time.Second); err != nil {
 				klog.Warningf("failed to broadcast free arp with err %v ", err)
 			}
 		}

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -845,7 +845,7 @@ func configureNic(link, ip string, macAddr net.HardwareAddr, mtu int, detectIPCo
 		}
 		if addr.IP.To4() != nil && !detectIPConflict {
 			// when detectIPConflict is true, free arp is already broadcast in the step of announcement
-			if err := util.BroadcastFreeArp(link, addr.IP.String(), macAddr, 1, 1*time.Second); err != nil {
+			if err := util.AnnounceArpAddress(link, addr.IP.String(), macAddr, 1, 1*time.Second); err != nil {
 				klog.Warningf("failed to broadcast free arp with err %v ", err)
 			}
 		}

--- a/pkg/util/arp.go
+++ b/pkg/util/arp.go
@@ -208,12 +208,12 @@ func ArpDetectIPConflict(nic, ip string, mac net.HardwareAddr) (net.HardwareAddr
 
 func AnnounceArpAddress(nic, ip string, mac net.HardwareAddr, announceNum int, announceInterval time.Duration) error {
 	klog.Infof("announce arp address nic %s , ip %s, with mac %v ", nic, ip, mac)
-	ifi, err := net.InterfaceByName(nic)
+	netInterface, err := net.InterfaceByName(nic)
 	if err != nil {
 		return err
 	}
 
-	client, err := arp.Dial(ifi)
+	client, err := arp.Dial(netInterface)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/arp.go
+++ b/pkg/util/arp.go
@@ -199,16 +199,15 @@ func ArpDetectIPConflict(nic, ip string, mac net.HardwareAddr) (net.HardwareAddr
 	// Announcement is identical to the ARP Probe described above,
 	// except that now the sender and target IP addresses are both
 	// set to the host's newly selected IPv4 address.
-	err = BroadcastFreeArp(nic, ip, mac, announceNum, announceInterval)
-	if err != nil {
+	if err = AnnounceArpAddress(nic, ip, mac, announceNum, announceInterval); err != nil {
 		return nil, err
 	}
 
 	return nil, nil
 }
 
-func BroadcastFreeArp(nic, ip string, mac net.HardwareAddr, announceNum int, announceInterval time.Duration) error {
-	klog.Infof("broadcast free arp with nic %s , ip %s, with mac %v ", nic, ip, mac)
+func AnnounceArpAddress(nic, ip string, mac net.HardwareAddr, announceNum int, announceInterval time.Duration) error {
+	klog.Infof("announce arp address nic %s , ip %s, with mac %v ", nic, ip, mac)
 	ifi, err := net.InterfaceByName(nic)
 	if err != nil {
 		return err
@@ -218,6 +217,7 @@ func BroadcastFreeArp(nic, ip string, mac net.HardwareAddr, announceNum int, ann
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	tpa, err := netip.ParseAddr(ip)
 	if err != nil {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e8d30a</samp>

This pull request adds a new feature to enable or disable IP conflict detection in the kube-ovn controller, and improves the ARP handling for pod IP addresses. It introduces a new flag `detectIPConflict` and a new utility function `BroadcastFreeArp` in the `util` package, and modifies the `configureNic` and `announce` functions in the `ovs_linux.go` and `ipam.go` files respectively.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4e8d30a</samp>

> _`BroadcastFreeArp`_
> _A new function for pods_
> _To avoid conflict_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4e8d30a</samp>

*  Add a new utility function to broadcast free ARP requests ([link](https://github.com/kubeovn/kube-ovn/pull/2638/files?diff=unified&w=0#diff-1fde66a27588df521a2a0fec2cfc0d6b59944eaab04e1e3fc31237c5e14fd246R224-R264))
* Use the new utility function to announce pod IP and MAC address after configuring the network interface ([link](https://github.com/kubeovn/kube-ovn/pull/2638/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feR846-R851))