### PR TITLE
add map ip tos to vlan priority

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -50,6 +50,7 @@ type Configuration struct {
 	DefaultInterfaceName    string
 	ExternalGatewayConfigNS string
 	EnableMetrics           bool
+	EnableAddIPTosFlow      bool
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -75,6 +76,7 @@ func ParseFlags(nicBridgeMappings map[string]string) (*Configuration, error) {
 		argsDefaultInterfaceName   = pflag.String("default-interface-name", "", "The default host interface name in the vlan/vxlan type")
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")
 		argEnableMetrics           = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
+		argEnableAddIPTosFlow      = pflag.Bool("enable-ip-tos", false, "If enable add ovs flows to map ip tos to vlan priority")
 	)
 
 	// mute info log for ipset lib
@@ -123,6 +125,7 @@ func ParseFlags(nicBridgeMappings map[string]string) (*Configuration, error) {
 		DefaultInterfaceName:    *argsDefaultInterfaceName,
 		ExternalGatewayConfigNS: *argExternalGatewayConfigNS,
 		EnableMetrics:           *argEnableMetrics,
+		EnableAddIPTosFlow:      *argEnableAddIPTosFlow,
 	}
 
 	if err := config.initKubeClient(); err != nil {

--- a/pkg/ovs/ovn.go
+++ b/pkg/ovs/ovn.go
@@ -47,6 +47,7 @@ const (
 	OvnSbCtl    = "ovn-sbctl"
 	OVNIcNbCtl  = "ovn-ic-nbctl"
 	OvsVsCtl    = "ovs-vsctl"
+	OvsOfCtl    = "ovs-ofctl"
 	MayExist    = "--may-exist"
 	IfExists    = "--if-exists"
 	Policy      = "--policy"

--- a/pkg/ovs/ovs-ofctl.go
+++ b/pkg/ovs/ovs-ofctl.go
@@ -1,0 +1,72 @@
+package ovs
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Glory belongs to openvswitch/ovn-kubernetes
+// https://github.com/openvswitch/ovn-kubernetes/blob/master/go-controller/pkg/util/ovs.go
+
+func OvsExec(args ...string) (string, error) {
+	start := time.Now()
+	args = append([]string{"--timeout=30"}, args...)
+	output, err := exec.Command(OvsOfCtl, args...).CombinedOutput()
+	elapsed := float64((time.Since(start)) / time.Millisecond)
+	klog.V(4).Infof("command %s %s in %vms", OvsOfCtl, strings.Join(args, " "), elapsed)
+	method := ""
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "--") {
+			method = arg
+			break
+		}
+	}
+	code := "0"
+	defer func() {
+		ovsClientRequestLatency.WithLabelValues("ovsdb", method, code).Observe(elapsed)
+	}()
+
+	if err != nil {
+		code = "1"
+		klog.Warningf("ovs-ofctl command error: %s %s in %vms", OvsOfCtl, strings.Join(args, " "), elapsed)
+		return "", fmt.Errorf("failed to run '%s %s': %v\n  %q", OvsOfCtl, strings.Join(args, " "), err, output)
+	} else if elapsed > 500 {
+		klog.Warningf("ovs-ofctl command took too long: %s %s in %vms", OvsOfCtl, strings.Join(args, " "), elapsed)
+	}
+	return trimCommandOutput(output), nil
+}
+
+func ParseDumpFlowsOutput(output string) []string {
+	if output == "" {
+		return []string{}
+	}
+
+	lines := strings.Split(output, "\n")
+	toss := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if len(strings.TrimSpace(l)) == 0 {
+			continue
+		}
+
+		if !strings.Contains(l, "nw_tos") && !strings.Contains(l, "mod_vlan_pcp") {
+			continue
+		}
+
+		fields := strings.Fields(l)
+		for _, field := range fields {
+			values := strings.Split(field, "=")
+			if len(values) != 2 {
+				continue
+			}
+
+			if values[0] == "ip,nw_tos" {
+				toss = append(toss, strings.TrimSpace(values[1]))
+			}
+		}
+	}
+	return toss
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -121,6 +121,8 @@ const (
 	VpcExternalNet         = "ovn-vpc-external-network"
 	VpcLbNetworkAttachment = "ovn-vpc-lb"
 
+	OvsFlowVlanPriConfig = "ovs-flow-vlan-pri-config"
+
 	DefaultVpc    = "ovn-cluster"
 	DefaultSubnet = "ovn-default"
 

--- a/test/unittest/ofctl/ofctl.go
+++ b/test/unittest/ofctl/ofctl.go
@@ -1,0 +1,31 @@
+package ofctl
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+)
+
+var _ = Describe("[ovs-ofctl]", func() {
+
+	flow_with_tos := "cookie=0x0, duration=33.091s, table=0, n_packets=0, n_bytes=0, ip,nw_tos=32 actions=mod_vlan_pcp:2,NORMAL"
+	flow_without_tos := "cookie=0x0, duration=1857.598s, table=0, n_packets=59697, n_bytes=22576303, priority=0 actions=NORMAL"
+
+	Describe("[dump-flows]", func() {
+		Context("[parse-flows]", func() {
+			It("flow with ip_tos", func() {
+				By("parse flow with ip_tos 32")
+				values := ovs.ParseDumpFlowsOutput(flow_with_tos)
+				Expect(len(values)).To(Equal(1))
+				Expect(values[0]).To(Equal("32"))
+			})
+
+			It("flow without ip_tos", func() {
+				By("parse flow without ip_tos")
+				values := ovs.ParseDumpFlowsOutput(flow_without_tos)
+				Expect(len(values)).To(Equal(0))
+			})
+		})
+	})
+})

--- a/test/unittest/unit_suite_test.go
+++ b/test/unittest/unit_suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	// tests to run
 	_ "github.com/kubeovn/kube-ovn/test/unittest/ipam"
+	_ "github.com/kubeovn/kube-ovn/test/unittest/ofctl"
 	_ "github.com/kubeovn/kube-ovn/test/unittest/util"
 )
 

--- a/yamls/ovs-flow-vlan-pri-config.yaml
+++ b/yamls/ovs-flow-vlan-pri-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovs-flow-vlan-pri-config
+  namespace: kube-system
+data:
+  enable-tos-vlan-pri: "true"
+  "32": "0x1"
+  "64": "0x2"
+  "96": "0x3"
+  "128": "0x4"
+  "160": "0x5"
+  "192": "0x6"
+  "224": "0x7"


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Features


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7632034</samp>

This pull request adds a new feature to enable adding OVS flows for IP TOS to VLAN priority mapping on provider network bridges. It introduces a new flag `--enable-ip-tos` to the kube-ovn daemon, a new ConfigMap resource `ovs-flow-vlan-pri-config` to store the mapping rules and the flag value, and new functions to the `ovs` and `daemon` packages to manipulate the OVS flows. It also adds a new unit test suite for the `ovs-ofctl` related functions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7632034</samp>

> _`Ovs-ofctl` commands the flows of the bridge_
> _Mapping IP TOS to VLAN with a ConfigMap switch_
> _Unleash the power of the provider network_
> _With the `--enable-ip-tos` flag we rock_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7632034</samp>

*  Add a new feature to enable adding OVS flows to map IP TOS to VLAN priority ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R53), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R79), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R128), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R67-R69), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R94-R95), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R118-R120), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R1245-R1376), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L1249-R1389), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-898dd2d56be06b2263eed10e92cf06464d1a951cf50820ac71847a7b3d48cf4dR50), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-1726d6c2edd94ac4526e0acea69266babcadda65aac6752ca44e9c66f74d0b53R1-R72), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR124-R125), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-539eea21a9fce3b3818984c06389d2f12e9dfd87654a68894d8e7e4ceb002510R1-R14))
  * Add a new field `EnableAddIPTosFlow` to the `Configuration` struct and a new command-line argument `--enable-ip-tos` to the `ParseFlags` function in `pkg/daemon/config.go` to allow the user to set the flag when starting the kube-ovn daemon ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R53), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R79), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R128))
  * Add two new fields `configMapsLister` and `configMapsSynced` to the `Controller` struct and create a ConfigMap informer in the `NewController` function in `pkg/daemon/controller.go` to access and sync the ConfigMap resources from the Kubernetes API server ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R67-R69), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R94-R95), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R118-R120))
  * Add three new functions `initCniPodNamespace`, `addFlowWithIPTos`, and `clearFlowWithIPTos` to the `Controller` struct in `pkg/daemon/controller.go` to find the namespace and name of the kube-ovn-cni pod, add OVS flows to the provider network bridges, and delete the existing OVS flows with IP TOS and VLAN priority actions ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R1245-R1376))
  * Modify the `Run` function of the `Controller` struct in `pkg/daemon/controller.go` to add the `configMapsSynced` function to the list of cache sync functions and to start a goroutine that periodically calls the `syncOvsVlanPriConfig` function to check the ConfigMap resource and decide whether to add or delete the OVS flows ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L1249-R1389))
  * Add a new constant `OvsOfCtl` to the `ovs` package in `pkg/ovs/ovn.go` to store the name of the `ovs-ofctl` command ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-898dd2d56be06b2263eed10e92cf06464d1a951cf50820ac71847a7b3d48cf4dR50))
  * Add a new file `ovs-ofctl.go` to the `ovs` package in `pkg/ovs/ovs-ofctl.go` to define a new function `OvsExec` that wraps the `ovs-ofctl` command execution and a new function `ParseDumpFlowsOutput` that parses the output of the `ovs-ofctl dump-flows` command and extracts the IP TOS values from the flows ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-1726d6c2edd94ac4526e0acea69266babcadda65aac6752ca44e9c66f74d0b53R1-R72))
  * Add a new constant `OvsFlowVlanPriConfig` to the `util` package in `pkg/util/const.go` to store the name of the ConfigMap resource that contains the IP TOS to VLAN priority mapping rules and the enablement flag ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR124-R125))
  * Add a new file `ovs-flow-vlan-pri-config.yaml` to the `yamls` directory in `yamls/ovs-flow-vlan-pri-config.yaml` to define a ConfigMap resource that can be used to create the ConfigMap resource in the Kubernetes cluster and enable the feature ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-539eea21a9fce3b3818984c06389d2f12e9dfd87654a68894d8e7e4ceb002510R1-R14))
* Add a new unit test suite for the `ovs-ofctl` related functions in the `ovs` package ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-2d125b712a7493583c79a23b9671d7d75dfbf3b14848b40b3424b0e47cc44135R1-R31), [link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-0b5e0a307847d408f4e02871a18cb2e707434f75438875022d06ad05568a8cc7R11))
  * Add a new file `ofctl.go` to the `ofctl` package in `test/unittest/ofctl/ofctl.go` to define a new unit test suite that uses the Ginkgo and Gomega frameworks to describe and verify the behavior of the `ParseDumpFlowsOutput` function ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-2d125b712a7493583c79a23b9671d7d75dfbf3b14848b40b3424b0e47cc44135R1-R31))
  * Add a new import line to the `unit_suite_test.go` file in `test/unittest/unit_suite_test.go` to import the `ofctl` package and run the test suite as part of the unittest package ([link](https://github.com/kubeovn/kube-ovn/pull/2640/files?diff=unified&w=0#diff-0b5e0a307847d408f4e02871a18cb2e707434f75438875022d06ad05568a8cc7R11))