### PR TITLE
broadcast free arp when pod setup

### DIFF
--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -536,6 +536,12 @@ func configureNic(link, ip string, macAddr net.HardwareAddr, mtu int, detectIPCo
 				return fmt.Errorf("IP address %s has already been used by host with MAC %s", ip, mac)
 			}
 		}
+		if addr.IP.To4() != nil && !detectIPConflict {
+			// when detectIPConflict is true, free arp is already broadcast in the step of announcement
+			if err := util.AnnounceArpAddress(link, addr.IP.String(), macAddr, 1, 1*time.Second); err != nil {
+				klog.Warningf("failed to broadcast free arp with err %v ", err)
+			}
+		}
 
 		klog.Infof("add ip address %s to %s", ip, link)
 		if err = netlink.AddrAdd(nodeLink, &addr); err != nil {

--- a/pkg/util/arp.go
+++ b/pkg/util/arp.go
@@ -203,17 +203,45 @@ func ArpDetectIPConflict(nic, ip string, mac net.HardwareAddr) (net.HardwareAddr
 	// Announcement is identical to the ARP Probe described above,
 	// except that now the sender and target IP addresses are both
 	// set to the host's newly selected IPv4 address.
-	if pkt, err = arp.NewPacket(arp.OperationRequest, mac, tpa, tha, tpa); err != nil {
+	if err = AnnounceArpAddress(nic, ip, mac, announceNum, announceInterval); err != nil {
 		return nil, err
 	}
 
+	return nil, nil
+}
+
+func AnnounceArpAddress(nic, ip string, mac net.HardwareAddr, announceNum int, announceInterval time.Duration) error {
+	klog.Infof("announce arp address nic %s , ip %s, with mac %v ", nic, ip, mac)
+	netInterface, err := net.InterfaceByName(nic)
+	if err != nil {
+		return err
+	}
+
+	client, err := arp.Dial(netInterface)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	tpa, err := netip.ParseAddr(ip)
+	if err != nil {
+		klog.Errorf("failed to parse IP address %s: %v ", ip, err)
+		return err
+	}
+	tha := net.HardwareAddr{0, 0, 0, 0, 0, 0}
+	pkt, err := arp.NewPacket(arp.OperationRequest, mac, tpa, tha, tpa)
+	if err != nil {
+		return err
+	}
+
+	dstMac := net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	for i := 0; i < announceNum; i++ {
 		c := time.NewTimer(announceInterval)
 		if err = client.SetDeadline(time.Now().Add(announceInterval)); err != nil {
-			return nil, err
+			return err
 		}
 		if err = client.WriteTo(pkt, dstMac); err != nil {
-			return nil, err
+			return err
 		}
 		if i == announceNum-1 {
 			// the last one, no need to wait
@@ -223,5 +251,5 @@ func ArpDetectIPConflict(nic, ip string, mac net.HardwareAddr) (net.HardwareAddr
 		}
 	}
 
-	return nil, nil
+	return nil
 }


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e65ff9</samp>

Refactor and improve IP conflict detection and resolution for NICs using arp packets. Use `util.AnnounceArpAddress` function in `pkg/util/arp.go` and `pkg/daemon/ovs.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4e65ff9</samp>

> _`configureNic` checks_
> _IP version and conflict flag_
> _then sends free arp_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4e65ff9</samp>

*  Add a conditional block to broadcast a free arp packet for the NIC's IP address if it is IPv4 and the detectIPConflict flag is false ([link](https://github.com/kubeovn/kube-ovn/pull/2643/files?diff=unified&w=0#diff-067d64bdcf68917f106b1f905d4608e8927a7ea0e9388b9e225c147566ece237R539-R544)). This avoids IP conflicts when the NIC is moved to a different node or pod. The detectIPConflict flag is set to true when the IP is allocated by the IPAM controller and the ArpDetectIPConflict function is called. The AnnounceArpAddress function is a wrapper for the arp.Announce function from the github.com/mdlayher/arp package that sends an arp packet with the given parameters. The block is added to the configureNic function in `pkg/daemon/ovs.go`.