### PR TITLE
Resolve SetLoadBalancerAffinityTimeout not being effective

### DIFF
--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -138,6 +138,7 @@ func (c *ovnClient) SetLoadBalancerAffinityTimeout(lbName string, timeout int) e
 		options[k] = v
 	}
 	options["affinity_timeout"] = value
+	lb.Options = options
 	if err := c.UpdateLoadBalancer(lb, &lb.Options); err != nil {
 		return fmt.Errorf("failed to set affinity timeout of lb %s to %d: %v", lbName, timeout, err)
 	}

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -330,6 +330,10 @@ func (suite *OvnClientTestSuite) Test_DeleteLoadBalancerOp() {
 	suite.testDeleteLoadBalancerOp()
 }
 
+func (suite *OvnClientTestSuite) Test_SetLoadBalancerAffinityTimeout() {
+	suite.testSetLoadBalancerAffinityTimeout()
+}
+
 /* port_group unit test */
 func (suite *OvnClientTestSuite) Test_CreatePortGroup() {
 	suite.testCreatePortGroup()


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(2462)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2fd08a6</samp>

Update load balancer options with affinity timeout. This change modifies the `pkg/ovs/ovn-nb-load_balancer.go` file to set and store the affinity timeout option for load balancers in the OVN network backend.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2fd08a6</samp>

> _`options` map set_
> _load balancer updated_
> _autumn leaves fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2fd08a6</samp>

* Set the affinity timeout option for load balancers in the OVN network backend ([link](https://github.com/kubeovn/kube-ovn/pull/2647/files?diff=unified&w=0#diff-f80a92268723484fa7d5dd097ad7f90925d4efe119bc878098352c751ff5a937R141),                             F