### PR TITLE
when cidr, gw or exclude_ips change , update subnet ipam

### DIFF
--- a/pkg/ipam/ip.go
+++ b/pkg/ipam/ip.go
@@ -51,6 +51,21 @@ func (iprl IPRangeList) Contains(ip IP) bool {
 	return false
 }
 
+func (iprl IPRangeList) Equal(iprl2 IPRangeList) bool {
+	if len(iprl) != len(iprl2) {
+		return false
+	}
+
+	for i, range1 := range iprl {
+		range2 := iprl2[i]
+		if !range1.Start.Equal(range2.Start) || !range1.End.Equal(range2.End) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (iprl IPRangeList) IpRangetoString() string {
 	var ipRangeString []string
 	for _, ipr := range iprl {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2547

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca84aa0</samp>

Optimized subnet controller to reduce IPAM updates. Added a flag to `subnet` key to indicate IP changes and checked it in `pkg/controller/subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ca84aa0</samp>

> _Oh we are the subnet controllers, we work with IPAM_
> _We don't like to waste our time on things that don't matter_
> _So we added a flag to the `subnet key`, to check before we update_
> _And we sing as we heave on the count of three, optimize the subnet state_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca84aa0</samp>

*  Import `strconv` package to enable boolean conversion ([link](https://github.com/kubeovn/kube-ovn/pull/2651/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R9))
*  Modify `enqueueUpdateSubnet` function to append boolean value to subnet key based on CIDR, gateway, or exclude IPs changes ([link](https://github.com/kubeovn/kube-ovn/pull/2651/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R116-R121))
  - Split subnet key into original key and boolean value and parse the latter into `updateIPAM` variable ([link](https://github.com/kubeovn/kube-ovn/pull/2651/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R514-R522))
  - Add condition to check `updateIPAM` before calling IPAM update to skip unnecessary updates ([link](https://github.com/kubeovn/kube-ovn/pull/2651/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L589-R608))