### PR TITLE
fix network policy issues

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -1,3 +1,5 @@
+E2E_BUILD_FLAGS = -ldflags "-w -s"
+
 KUBECONFIG = $(shell echo $${KUBECONFIG:-$(HOME)/.kube/config})
 
 E2E_BRANCH := $(shell echo $${E2E_BRANCH:-master})
@@ -55,18 +57,18 @@ e2e: kube-ovn-conformance-e2e
 
 .PHONY: e2e-build
 e2e-build:
-	ginkgo build -ldflags "-w -s" ./test/e2e/k8s-network
-	ginkgo build -ldflags "-w -s" ./test/e2e/kube-ovn
-	ginkgo build -ldflags "-w -s" ./test/e2e/ovn-ic
-	ginkgo build -ldflags "-w -s" ./test/e2e/lb-svc
-	ginkgo build -ldflags "-w -s" ./test/e2e/ovn-eip
-	ginkgo build -ldflags "-w -s" ./test/e2e/security
-	ginkgo build -ldflags "-w -s" ./test/e2e/kubevirt
-	ginkgo build -ldflags "-w -s" ./test/e2e/webhook
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/k8s-network
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/kube-ovn
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ovn-ic
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/lb-svc
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ovn-eip
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/security
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/kubevirt
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/webhook
 
 .PHONY: k8s-conformance-e2e
 k8s-conformance-e2e:
-	ginkgo build ./test/e2e/k8s-network
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/k8s-network
 	ginkgo $(GINKGO_PARALLEL_OPT) --randomize-all --always-emit-ginkgo-writer --timeout=1h \
 		$(call ginkgo_option,focus,$(K8S_CONFORMANCE_E2E_FOCUS)) \
 		$(call ginkgo_option,skip,$(K8S_CONFORMANCE_E2E_SKIP)) \
@@ -74,14 +76,14 @@ k8s-conformance-e2e:
 
 .PHONY: k8s-netpol-legacy-e2e
 k8s-netpol-legacy-e2e:
-	ginkgo build ./test/e2e/k8s-network
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/k8s-network
 	ginkgo -p --randomize-all --always-emit-ginkgo-writer --timeout=2h \
 		$(call ginkgo_option,focus,$(K8S_NETPOL_LEGACY_E2E_FOCUS)) \
 		./test/e2e/k8s-network/k8s-network.test
 
 .PHONY: k8s-netpol-e2e
 k8s-netpol-e2e:
-	ginkgo build ./test/e2e/k8s-network
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/k8s-network
 	ginkgo -p --randomize-all --always-emit-ginkgo-writer --timeout=2h \
 		$(call ginkgo_option,focus,$(K8S_NETPOL_E2E_FOCUS)) \
 		$(call ginkgo_option,skip,$(K8S_NETPOL_E2E_SKIP)) \
@@ -103,7 +105,7 @@ cyclonus-netpol-e2e:
 
 .PHONY: kube-ovn-conformance-e2e
 kube-ovn-conformance-e2e:
-	ginkgo build ./test/e2e/kube-ovn
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/kube-ovn
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
@@ -112,7 +114,7 @@ kube-ovn-conformance-e2e:
 
 .PHONY: kube-ovn-ic-conformance-e2e
 kube-ovn-ic-conformance-e2e:
-	ginkgo build ./test/e2e/ovn-ic
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ovn-ic
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
@@ -127,7 +129,7 @@ kube-ovn-submariner-conformance-e2e:
 
 .PHONY: kube-ovn-lb-svc-conformance-e2e
 kube-ovn-lb-svc-conformance-e2e:
-	ginkgo build ./test/e2e/lb-svc
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/lb-svc
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
@@ -136,7 +138,7 @@ kube-ovn-lb-svc-conformance-e2e:
 
 .PHONY: kube-ovn-eip-conformance-e2e
 kube-ovn-eip-conformance-e2e:
-	ginkgo build ./test/e2e/ovn-eip
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ovn-eip
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
@@ -145,7 +147,7 @@ kube-ovn-eip-conformance-e2e:
 
 .PHONY: kube-ovn-security-e2e
 kube-ovn-security-e2e:
-	ginkgo build ./test/e2e/security
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/security
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
@@ -154,7 +156,7 @@ kube-ovn-security-e2e:
 
 .PHONY: kube-ovn-kubevirt-e2e
 kube-ovn-kubevirt-e2e:
-	ginkgo build ./test/e2e/kubevirt
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/kubevirt
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
@@ -163,7 +165,7 @@ kube-ovn-kubevirt-e2e:
 
 .PHONY: kube-ovn-webhook-e2e
 kube-ovn-webhook-e2e:
-	ginkgo build ./test/e2e/webhook
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/webhook
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -1062,18 +1062,18 @@ func (mr *MockPortGroupMockRecorder) PortGroupRemovePorts(pgName interface{}, ls
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortGroupRemovePorts", reflect.TypeOf((*MockPortGroup)(nil).PortGroupRemovePorts), varargs...)
 }
 
-// PortGroupResetPorts mocks base method.
-func (m *MockPortGroup) PortGroupResetPorts(pgName string) error {
+// PortGroupSetPorts mocks base method.
+func (m *MockPortGroup) PortGroupSetPorts(pgName string, ports []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PortGroupResetPorts", pgName)
+	ret := m.ctrl.Call(m, "PortGroupSetPorts", pgName, ports)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// PortGroupResetPorts indicates an expected call of PortGroupResetPorts.
-func (mr *MockPortGroupMockRecorder) PortGroupResetPorts(pgName interface{}) *gomock.Call {
+// PortGroupSetPorts indicates an expected call of PortGroupSetPorts.
+func (mr *MockPortGroupMockRecorder) PortGroupSetPorts(pgName, ports interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortGroupResetPorts", reflect.TypeOf((*MockPortGroup)(nil).PortGroupResetPorts), pgName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortGroupSetPorts", reflect.TypeOf((*MockPortGroup)(nil).PortGroupSetPorts), pgName, ports)
 }
 
 // MockACL is a mock of ACL interface.
@@ -2986,18 +2986,18 @@ func (mr *MockOvnClientMockRecorder) PortGroupRemovePorts(pgName interface{}, ls
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortGroupRemovePorts", reflect.TypeOf((*MockOvnClient)(nil).PortGroupRemovePorts), varargs...)
 }
 
-// PortGroupResetPorts mocks base method.
-func (m *MockOvnClient) PortGroupResetPorts(pgName string) error {
+// PortGroupSetPorts mocks base method.
+func (m *MockOvnClient) PortGroupSetPorts(pgName string, ports []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PortGroupResetPorts", pgName)
+	ret := m.ctrl.Call(m, "PortGroupSetPorts", pgName, ports)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// PortGroupResetPorts indicates an expected call of PortGroupResetPorts.
-func (mr *MockOvnClientMockRecorder) PortGroupResetPorts(pgName interface{}) *gomock.Call {
+// PortGroupSetPorts indicates an expected call of PortGroupSetPorts.
+func (mr *MockOvnClientMockRecorder) PortGroupSetPorts(pgName, ports interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortGroupResetPorts", reflect.TypeOf((*MockOvnClient)(nil).PortGroupResetPorts), pgName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortGroupSetPorts", reflect.TypeOf((*MockOvnClient)(nil).PortGroupSetPorts), pgName, ports)
 }
 
 // RemoveLogicalPatchPort mocks base method.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -209,6 +209,7 @@ type Controller struct {
 	npsSynced     cache.InformerSynced
 	updateNpQueue workqueue.RateLimitingInterface
 	deleteNpQueue workqueue.RateLimitingInterface
+	npKeyMutex    *keymutex.KeyMutex
 
 	sgsLister          kubeovnlister.SecurityGroupLister
 	sgSynced           cache.InformerSynced
@@ -541,6 +542,7 @@ func NewController(config *Configuration) *Controller {
 		controller.npsSynced = npInformer.Informer().HasSynced
 		controller.updateNpQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdateNp")
 		controller.deleteNpQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeleteNp")
+		controller.npKeyMutex = keymutex.New(97)
 		if _, err = npInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.enqueueAddNp,
 			UpdateFunc: controller.enqueueUpdateNp,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -54,7 +54,6 @@ type Controller struct {
 
 	ovnLegacyClient *ovs.LegacyClient
 	ovnClient       ovs.OvnClient
-	ovnPgKeyMutex   *keymutex.KeyMutex
 
 	// ExternalGatewayType define external gateway type, centralized
 	ExternalGatewayType string
@@ -286,7 +285,6 @@ func NewController(config *Configuration) *Controller {
 		vpcs:            &sync.Map{},
 		podSubnetMap:    &sync.Map{},
 		ovnLegacyClient: ovs.NewLegacyClient(config.OvnNbAddr, config.OvnTimeout, config.OvnSbAddr, config.ClusterRouter, config.ClusterTcpLoadBalancer, config.ClusterUdpLoadBalancer, config.ClusterTcpSessionLoadBalancer, config.ClusterUdpSessionLoadBalancer, config.NodeSwitch, config.NodeSwitchCIDR),
-		ovnPgKeyMutex:   keymutex.New(97),
 		ipam:            ovnipam.NewIPAM(),
 		namedPort:       NewNamedPort(),
 

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -963,7 +963,7 @@ func (c *Controller) checkAndUpdateNodePortGroup() error {
 			return err
 		}
 
-		if err := c.ovnClient.PortGroupAddPorts(pgName, nodePorts...); err != nil {
+		if err = c.ovnClient.PortGroupSetPorts(pgName, nodePorts); err != nil {
 			klog.Errorf("add ports to port group %s: %v", pgName, err)
 			return err
 		}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -552,7 +552,7 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	if len(needRoutePodNets) > 0 {
 		if c.config.EnableNP {
 			for _, np := range c.podMatchNetworkPolicies(pod) {
-				klog.V(3).Infof("enqueue update pod %s' network policy", key)
+				klog.V(3).Infof("enqueue update network policy %s for pod %s", np, key)
 				c.updateNpQueue.Add(np)
 			}
 		}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -742,12 +742,9 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 
 				// remove lsp from port group to make EIP/SNAT work
 				portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
-				c.ovnPgKeyMutex.Lock(pgName)
 				if err = c.ovnClient.PortGroupRemovePorts(pgName, portName); err != nil {
-					c.ovnPgKeyMutex.Unlock(pgName)
 					return err
 				}
-				c.ovnPgKeyMutex.Unlock(pgName)
 
 			} else {
 				if subnet.Spec.GatewayType == kubeovnv1.GWDistributedType && pod.Annotations[util.NorthGatewayAnnotation] == "" {
@@ -764,15 +761,10 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 							}
 
 							portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
-							c.ovnPgKeyMutex.Lock(pgName)
-
 							if err := c.ovnClient.PortGroupAddPorts(pgName, portName); err != nil {
-								c.ovnPgKeyMutex.Unlock(pgName)
 								klog.Errorf("add port to port group %s: %v", pgName, err)
 								return err
 							}
-
-							c.ovnPgKeyMutex.Unlock(pgName)
 
 							added = true
 							break

--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -216,20 +216,9 @@ func (c *Controller) updateDenyAllSgPorts() error {
 	}
 	pgName := ovs.GetSgPortGroupName(util.DenyAllSecurityGroup)
 
-	// reset pg ports
-	if err := c.ovnClient.PortGroupResetPorts(pgName); err != nil {
+	klog.V(6).Infof("setting ports of port group %s to %v", pgName, addPorts)
+	if err = c.ovnClient.PortGroupSetPorts(pgName, addPorts); err != nil {
 		klog.Error(err)
-		return err
-	}
-
-	// add port
-	if len(addPorts) == 0 {
-		return nil
-	}
-
-	klog.V(6).Infof("add ports %v to port group %s", addPorts, pgName)
-	if err := c.ovnClient.PortGroupAddPorts(pgName, addPorts...); err != nil {
-		klog.Errorf("add ports to port group %s: %v", pgName, err)
 		return err
 	}
 

--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -428,7 +428,7 @@ func (c *Controller) syncSgLogicalPort(key string) error {
 		}
 	}
 
-	if err := c.ovnClient.PortGroupAddPorts(sg.Status.PortGroup, ports...); err != nil {
+	if err = c.ovnClient.PortGroupSetPorts(sg.Status.PortGroup, ports); err != nil {
 		klog.Errorf("add ports to port group %s: %v", sg.Status.PortGroup, err)
 		return err
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1471,8 +1471,6 @@ func (c *Controller) reconcileOvnDefaultVpcRoute(subnet *kubeovnv1.Subnet) error
 				}
 
 				pgName := getOverlaySubnetsPortGroupName(subnet.Name, pod.Spec.NodeName)
-				c.ovnPgKeyMutex.Lock(pgName)
-
 				portsToAdd := make([]string, 0, len(podPorts))
 				for _, port := range podPorts {
 					exist, err := c.ovnClient.LogicalSwitchPortExists(port)
@@ -1488,12 +1486,10 @@ func (c *Controller) reconcileOvnDefaultVpcRoute(subnet *kubeovnv1.Subnet) error
 					portsToAdd = append(portsToAdd, port)
 				}
 
-				if err := c.ovnClient.PortGroupAddPorts(pgName, portsToAdd...); err != nil {
+				if err = c.ovnClient.PortGroupAddPorts(pgName, portsToAdd...); err != nil {
 					klog.Errorf("add ports to port group %s: %v", pgName, err)
 					return err
 				}
-
-				c.ovnPgKeyMutex.Unlock(pgName)
 			}
 			return nil
 		} else {

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -83,7 +83,7 @@ type PortGroup interface {
 	CreatePortGroup(pgName string, externalIDs map[string]string) error
 	PortGroupAddPorts(pgName string, lspNames ...string) error
 	PortGroupRemovePorts(pgName string, lspNames ...string) error
-	PortGroupResetPorts(pgName string) error
+	PortGroupSetPorts(pgName string, ports []string) error
 	DeletePortGroup(pgName string) error
 	ListPortGroups(externalIDs map[string]string) ([]ovnnb.PortGroup, error)
 	GetPortGroup(pgName string, ignoreNotFound bool) (*ovnnb.PortGroup, error)

--- a/pkg/ovs/ovn-nb-port_group_test.go
+++ b/pkg/ovs/ovn-nb-port_group_test.go
@@ -74,7 +74,7 @@ func (suite *OvnClientTestSuite) testPortGroupResetPorts() {
 	require.NoError(t, err)
 	require.NotEmpty(t, pg.Ports)
 
-	err = ovnClient.PortGroupResetPorts(pgName)
+	err = ovnClient.PortGroupSetPorts(pgName, nil)
 	require.NoError(t, err)
 
 	pg, err = ovnClient.GetPortGroup(pgName, false)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes network policy e2e failure.
https://github.com/kubeovn/kube-ovn/actions/runs/4691717677/jobs/8316548978

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48d55fe</samp>

This pull request enhances the network policy and security group controller and the ovnClient by adding a new method to set ports of a port group in one transaction, and using it to optimize the performance and reduce the network traffic. It also updates the interface, implementation, and test cases of the `PortGroup` type in the `pkg/ovs` package, and improves the log messages and error handling in the controller.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 48d55fe</samp>

> _`ovnClient` sets ports_
> _Network policies improved_
> _Winter of bugs ends_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 48d55fe</samp>

*  Add a variable `E2E_BUILD_FLAGS` to simplify and unify the build flags for the end-to-end tests in the `Makefile.e2e` file ([link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aR1-R2), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL58-R71), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL77-R79), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL84-R86), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL106-R108), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL115-R117), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL130-R132), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL139-R141), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL148-R150), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL157-R159), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aL166-R168))
*  Add a new method `PortGroupSetPorts` to the `PortGroup` and `OvnClient` interfaces and implementations in the `pkg/ovs` package, to set the ports of a port group in one transaction ([link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L1065-R1076), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L2989-R3000), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49L86-R86), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-8bb8ed3335ff6e3862262476592e96a15ccf7c18c7448eed83c5b45ea80543c1L53-R96), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-8bb8ed3335ff6e3862262476592e96a15ccf7c18c7448eed83c5b45ea80543c1L224-R249), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-216371c6de59a4543dedd49ca77fe453c38627d431bd572bf262a71da12ce8d9L77-R77))
*  Add a new field `npKeyMutex` to the `Controller` type in the `pkg/controller` package, to synchronize the access to network policies by different workers ([link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R212), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R545))
*  Use the `npKeyMutex` to lock and unlock the network policy key before updating or deleting the network policy in the `handleUpdateNp` and `handleDeleteNp` functions in the `pkg/controller/network_policy.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46R141-R145), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46R538-R542))
*  Replace the calls to `PortGroupAddPorts` and `PortGroupResetPorts` with the call to `PortGroupSetPorts` in the `handleUpdateNp` and `updateDenyAllSgPorts` functions in the `pkg/controller/network_policy.go` and `pkg/controller/security_group.go` files, to optimize the performance and reduce the network traffic ([link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L194-L198), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L211-R211), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L219-R224))
*  Simplify the code and improve the readability and performance by moving or avoiding unnecessary variable declarations and assignments in the `handleUpdateNp` function in the `pkg/controller/network_policy.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L180-R185), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L398-R397))
*  Improve the readability and debuggability of the error and log messages by adding the network policy name to the messages in the `processNextUpdateNpWorkItem` and `handleAddOrUpdatePod` functions in the `pkg/controller/network_policy.go` and `pkg/controller/pod.go` files ([link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L91-R91), [link](https://github.com/kubeovn/kube-ovn/pull/2652/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L555-R555))