### PR TITLE
fix LSP existence check

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1478,7 +1478,7 @@ func (c *Controller) reconcileOvnDefaultVpcRoute(subnet *kubeovnv1.Subnet) error
 						return err
 					}
 
-					if exist {
+					if !exist {
 						klog.Errorf("lsp does not exist for pod %v, please delete the pod and retry", port)
 						continue
 					}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1a3ce1</samp>

Fix a logic error in `reconcileOvnDefaultVpcRoute` that caused missing default routes for some pods. This bug fix resolves issue #1140.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b1a3ce1</samp>

> _`reconcileOvn`_
> _Fixes logic error - kya!_
> _Pods can surf now_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b1a3ce1</samp>

* Fix logic error in `reconcileOvnDefaultVpcRoute` function to skip pods without lsp instead of with lsp ([link](https://github.com/kubeovn/kube-ovn/pull/2657/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1481-R1481))