### PR TITLE
fix pg set port fail when lsp is already deleted

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -920,17 +920,23 @@ func (c *Controller) fetchPodsOnNode(nodeName string, pods []*v1.Pod) ([]string,
 	return ports, nil
 }
 
-func (c *Controller) checkPodsChangedOnNode(pgName string, nameIdMap map[string]string, pgPorts, ports []string) (bool, error) {
+func (c *Controller) checkPodsChangedOnNode(pgName string, nameIdMap map[string]string, pgPorts, ports []string) (bool, []string, error) {
+
+	toAddPorts := make([]string, 0)
 	for _, port := range ports {
 		if portId, ok := nameIdMap[port]; ok {
 			if !util.IsStringIn(portId, pgPorts) {
-				klog.Infof("pod on node changed, new added port %v should add to node port group %v", port, pgName)
-				return true, nil
+				toAddPorts = append(toAddPorts, port)
 			}
 		}
 	}
 
-	return false, nil
+	if len(toAddPorts) != 0 {
+		klog.Infof("pod on node changed, new added port %v should add to node port group %v", toAddPorts, pgName)
+		return true, toAddPorts, nil
+	}
+
+	return false, toAddPorts, nil
 }
 
 func (c *Controller) CheckNodePortGroup() {
@@ -974,14 +980,14 @@ func (c *Controller) checkAndUpdateNodePortGroup() error {
 		// The port-group should already created when add node
 		pgName := strings.Replace(node.Annotations[util.PortNameAnnotation], "-", ".", -1)
 		nodeIP := node.Annotations[util.IpAddressAnnotation]
-
+		var toAddPorts []string
 		ports, err := c.fetchPodsOnNode(node.Name, pods)
 		if err != nil {
 			klog.Errorf("failed to fetch pods for node %v, %v", node.Name, err)
 			return err
 		}
 
-		changed, err := c.checkPodsChangedOnNode(pgName, nameIdMap, namePortsMap[pgName], ports)
+		changed, toAddPorts, err := c.checkPodsChangedOnNode(pgName, nameIdMap, namePortsMap[pgName], ports)
 		if err != nil {
 			klog.Errorf("failed to check pod status for node %v, %v", node.Name, err)
 			continue
@@ -998,10 +1004,15 @@ func (c *Controller) checkAndUpdateNodePortGroup() error {
 		}
 		lastNpExists[node.Name] = networkPolicyExists
 
-		err = c.ovnLegacyClient.SetPortsToPortGroup(pgName, ports)
-		if err != nil {
-			klog.Errorf("failed to set port group for node %v, %v", node.Name, err)
-			return err
+		if len(toAddPorts) != 0 {
+			c.ovnPgKeyMutex.Lock(pgName)
+			for _, toAddPort := range toAddPorts {
+				if err = c.ovnClient.PortGroupAddPort(pgName, toAddPort); err != nil {
+					c.ovnPgKeyMutex.Unlock(pgName)
+					return err
+				}
+				c.ovnPgKeyMutex.Unlock(pgName)
+			}
 		}
 
 		if networkPolicyExists {

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -1011,8 +1011,8 @@ func (c *Controller) checkAndUpdateNodePortGroup() error {
 					c.ovnPgKeyMutex.Unlock(pgName)
 					return err
 				}
-				c.ovnPgKeyMutex.Unlock(pgName)
 			}
+			c.ovnPgKeyMutex.Unlock(pgName)
 		}
 
 		if networkPolicyExists {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2441

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4f66b4</samp>

Improved the efficiency of node port group management by checking and adding new ports individually.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f4f66b4</samp>

> _We are the nodes of the port group_
> _We slice the new ports with our skill_
> _We add them one by one to the ovn_
> _We optimize the performance of our will_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4f66b4</samp>

* Optimize the performance of adding ports to the node port group by returning a slice of new ports from `checkPodsChangedOnNode` and using `PortGroupAddPort` to add them ([link](https://github.com/kubeovn/kube-ovn/pull/2658/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L923-R939), [link](https://github.com/kubeovn/kube-ovn/pull/2658/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L977-R983), [link](https://github.com/kubeovn/kube-ovn/pull/2658/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L984-R990), [link](https://github.com/kubeovn/kube-ovn/pull/2658/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1001-R1015)) in `pkg/controller/node.go`