### PR TITLE
add subnetstatus lock for handleAddOrUpdateSubnet

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -433,6 +433,9 @@ func (c Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, e
 
 func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	var err error
+	c.subnetStatusKeyMutex.Lock(key)
+	defer c.subnetStatusKeyMutex.Unlock(key)
+
 	cachedSubnet, err := c.subnetsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e64c97</samp>

Add mutex lock for subnet status updates in `handleAddOrUpdateSubnet`. This prevents race conditions and inconsistent states when multiple workers process the same subnet in `pkg/controller/subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7e64c97</samp>

> _`handleAddOrUpdateSubnet`_
> _Workers share a lock_
> _Autumn leaves fall in order_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e64c97</samp>

*  Add a mutex lock for the subnet key to prevent concurrent updates ([link](https://github.com/kubeovn/kube-ovn/pull/2668/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R436-R438))