### PR TITLE
add workflows for release chart

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,0 +1,35 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+permissions: {}
+jobs:
+  release:
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: charts
+          config: cr.yaml
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,1 @@
+sign: false


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Features
#2642 

### Which issue(s) this PR fixes:
Fixes #2354 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9710ad9</samp>

This pull request adds a GitHub workflow to automatically release Helm charts for the `kube-ovn` project. It also disables the chart signing feature in the `cr.yaml` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9710ad9</samp>

> _`chart-releaser-action`_
> _Publishes Helm charts to site_
> _No signing in spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9710ad9</samp>

*  Add a GitHub workflow to release Helm charts ([link](https://github.com/kubeovn/kube-ovn/pull/2672/files?diff=unified&w=0#diff-dddbf01192c102f70ca20e758a8e49e9e4abc415ba9721c1b1809c85e6a4985bR1-R35))
*  Disable chart signing for chart-releaser-action ([link](https://github.com/kubeovn/kube-ovn/pull/2672/files?diff=unified&w=0#diff-18e43e5a0cfd243050fd65da26541401a366ffc76e9c99538ca0796ae316cc11R1))