### PR TITLE
attach node name label in ip cr

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -640,6 +640,7 @@ func (c *Controller) createOrUpdateCrdIPs(podName, ip, mac, subnetName, ns, node
 				Name: ipName,
 				Labels: map[string]string{
 					util.SubnetNameLabel: subnetName,
+					util.NodeNameLabel:   nodeName,
 					subnetName:           "",
 				},
 			},
@@ -667,9 +668,11 @@ func (c *Controller) createOrUpdateCrdIPs(podName, ip, mac, subnetName, ns, node
 		newIpCr := ipCr.DeepCopy()
 		if newIpCr.Labels != nil {
 			newIpCr.Labels[util.SubnetNameLabel] = subnetName
+			newIpCr.Labels[util.NodeNameLabel] = nodeName
 		} else {
 			newIpCr.Labels = map[string]string{
 				util.SubnetNameLabel: subnetName,
+				util.NodeNameLabel:   nodeName,
 			}
 		}
 		newIpCr.Spec.PodName = key

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -113,6 +113,7 @@ const (
 	VpcLbLabel                 = "ovn.kubernetes.io/vpc_lb"
 	VpcDnsNameLabel            = "ovn.kubernetes.io/vpc-dns"
 	QoSLabel                   = "ovn.kubernetes.io/qos"
+	NodeNameLabel              = "ovn.kubernetes.io/node-name"
 	NetworkPolicyLogAnnotation = "ovn.kubernetes.io/enable_log"
 
 	ProtocolTCP  = "tcp"


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2317 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3075070</samp>

This pull request adds node name label support to IP CRD objects for node IPAM feature. It also refactors the subnet name label logic to use a constant from the util package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3075070</samp>

> _`Node name label` is the key to the gate_
> _Unleash the power of the IP CRD fate_
> _Subnet name logic is not enough_
> _We need to label all the nodes and stuff_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3075070</samp>

*  Add and set a new label for node name to IP CRD objects ([link](https://github.com/kubeovn/kube-ovn/pull/2680/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R643), [link](https://github.com/kubeovn/kube-ovn/pull/2680/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L670-R675), [link](https://github.com/kubeovn/kube-ovn/pull/2680/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR116))
  - Define a constant for the label key in `pkg/util/const.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2680/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR116))
  - Use the constant to add the label with the node name as the value in `pkg/controller/node.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2680/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R643))
  - Update the existing logic of setting the subnet name label to also set the node name label in the same function in `pkg/controller/node.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2680/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L670-R675))