### PR TITLE
Add random fully when nat

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -983,16 +983,24 @@ log_linux(){
       kubectl exec $pod -n kube-system -- dmesg -T > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
     elif [[ "$sub_component_param" == "iptables-legacy" ]]; then
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-legacy -V > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
-      echo "******************legacy filter ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      echo "******************legacy filter v4 ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-legacy -S >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
-      echo "****************** legacy nat ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      echo "****************** legacy nat v4 ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-legacy -S -t nat >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
+      echo "******************legacy filter v6 ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      kubectl exec $pod -n kube-system -- /usr/sbin/ip6tables-legacy -S >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
+      echo "****************** legacy nat v6 ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      kubectl exec $pod -n kube-system -- /usr/sbin/ip6tables-legacy -S -t nat >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
     elif [[ "$sub_component_param" == "iptables-nft" ]]; then
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-nft -V > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log 2>/dev/null || :
-      echo "*********************nft filter ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      echo "*********************nft filter v4 ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-nft -S >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log 2>/dev/null || :
-      echo "********************* nft nat ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      echo "********************* nft nat v4 ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-nft -S -t nat >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log 2>/dev/null || :
+      echo "*********************nft filter v6 ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      kubectl exec $pod -n kube-system -- /usr/sbin/ip6tables-nft -S >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log 2>/dev/null || :
+      echo "********************* nft nat v6 ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      kubectl exec $pod -n kube-system -- /usr/sbin/ip6tables-nft -S -t nat >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log 2>/dev/null || :
     elif [[ "$sub_component_param" == "route" ]]; then
       kubectl exec $pod -n kube-system -- ip route show > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
       kubectl exec $pod -n kube-system -- ip -6 route show >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -982,12 +982,14 @@ log_linux(){
     if [[ "$sub_component_param" == "dmesg" ]]; then
       kubectl exec $pod -n kube-system -- dmesg -T > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
     elif [[ "$sub_component_param" == "iptables-legacy" ]]; then
-      echo "******************legacy filter ************************" > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      kubectl exec $pod -n kube-system -- /usr/sbin/iptables-legacy -V > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
+      echo "******************legacy filter ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-legacy -S >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
       echo "****************** legacy nat ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-legacy -S -t nat >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log || :
     elif [[ "$sub_component_param" == "iptables-nft" ]]; then
-      echo "*********************nft filter ************************" > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
+      kubectl exec $pod -n kube-system -- /usr/sbin/iptables-nft -V > ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log 2>/dev/null || :
+      echo "*********************nft filter ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-nft -S >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log 2>/dev/null || :
       echo "********************* nft nat ************************" >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log
       kubectl exec $pod -n kube-system -- /usr/sbin/iptables-nft -S -t nat >> ./kubectl-ko-log/$nodeName/$component_param/$sub_component_param.log 2>/dev/null || :

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	k8sexec "k8s.io/utils/exec"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
@@ -60,6 +61,8 @@ type Controller struct {
 	ControllerRuntime
 	localPodName   string
 	localNamespace string
+
+	k8sExec k8sexec.Interface
 }
 
 // NewController init a daemon controller
@@ -98,6 +101,7 @@ func NewController(config *Configuration, podInformerFactory informers.SharedInf
 		nodesSynced: nodeInformer.Informer().HasSynced,
 
 		recorder: recorder,
+		k8sExec:  k8sexec.New(),
 	}
 
 	node, err := config.KubeClient.CoreV1().Nodes().Get(context.Background(), config.NodeName, metav1.GetOptions{})

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -22,6 +22,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	k8siptables "k8s.io/kubernetes/pkg/util/iptables"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -32,6 +33,7 @@ import (
 type ControllerRuntime struct {
 	iptables         map[string]*iptables.IPTables
 	iptablesObsolete map[string]*iptables.IPTables
+	k8sipables       map[string]k8siptables.Interface
 	ipsets           map[string]*ipsets.IPSets
 	gwCounters       map[string]*util.GwIPtableCounters
 }
@@ -75,6 +77,7 @@ func (c *Controller) initRuntime() error {
 	c.iptables = make(map[string]*iptables.IPTables)
 	c.ipsets = make(map[string]*ipsets.IPSets)
 	c.gwCounters = make(map[string]*util.GwIPtableCounters)
+	c.k8sipables = make(map[string]k8siptables.Interface)
 
 	if c.protocol == kubeovnv1.ProtocolIPv4 || c.protocol == kubeovnv1.ProtocolDual {
 		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
@@ -89,6 +92,7 @@ func (c *Controller) initRuntime() error {
 			c.iptablesObsolete[kubeovnv1.ProtocolIPv4] = ipt
 		}
 		c.ipsets[kubeovnv1.ProtocolIPv4] = ipsets.NewIPSets(ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, IPSetPrefix, nil, nil))
+		c.k8sipables[kubeovnv1.ProtocolIPv4] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv4)
 	}
 	if c.protocol == kubeovnv1.ProtocolIPv6 || c.protocol == kubeovnv1.ProtocolDual {
 		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
@@ -103,6 +107,7 @@ func (c *Controller) initRuntime() error {
 			c.iptablesObsolete[kubeovnv1.ProtocolIPv6] = ipt
 		}
 		c.ipsets[kubeovnv1.ProtocolIPv6] = ipsets.NewIPSets(ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, IPSetPrefix, nil, nil))
+		c.k8sipables[kubeovnv1.ProtocolIPv6] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv6)
 	}
 
 	return nil

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -33,7 +33,7 @@ import (
 type ControllerRuntime struct {
 	iptables         map[string]*iptables.IPTables
 	iptablesObsolete map[string]*iptables.IPTables
-	k8sipables       map[string]k8siptables.Interface
+	k8siptables      map[string]k8siptables.Interface
 	ipsets           map[string]*ipsets.IPSets
 	gwCounters       map[string]*util.GwIPtableCounters
 }
@@ -77,7 +77,7 @@ func (c *Controller) initRuntime() error {
 	c.iptables = make(map[string]*iptables.IPTables)
 	c.ipsets = make(map[string]*ipsets.IPSets)
 	c.gwCounters = make(map[string]*util.GwIPtableCounters)
-	c.k8sipables = make(map[string]k8siptables.Interface)
+	c.k8siptables = make(map[string]k8siptables.Interface)
 
 	if c.protocol == kubeovnv1.ProtocolIPv4 || c.protocol == kubeovnv1.ProtocolDual {
 		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
@@ -92,7 +92,7 @@ func (c *Controller) initRuntime() error {
 			c.iptablesObsolete[kubeovnv1.ProtocolIPv4] = ipt
 		}
 		c.ipsets[kubeovnv1.ProtocolIPv4] = ipsets.NewIPSets(ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, IPSetPrefix, nil, nil))
-		c.k8sipables[kubeovnv1.ProtocolIPv4] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv4)
+		c.k8siptables[kubeovnv1.ProtocolIPv4] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv4)
 	}
 	if c.protocol == kubeovnv1.ProtocolIPv6 || c.protocol == kubeovnv1.ProtocolDual {
 		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
@@ -107,7 +107,7 @@ func (c *Controller) initRuntime() error {
 			c.iptablesObsolete[kubeovnv1.ProtocolIPv6] = ipt
 		}
 		c.ipsets[kubeovnv1.ProtocolIPv6] = ipsets.NewIPSets(ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, IPSetPrefix, nil, nil))
-		c.k8sipables[kubeovnv1.ProtocolIPv6] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv6)
+		c.k8siptables[kubeovnv1.ProtocolIPv6] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv6)
 	}
 
 	return nil

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -579,7 +579,7 @@ func (c *Controller) setIptables() error {
 					natPreroutingRules = append(natPreroutingRules, rule)
 					continue
 				case OvnPostrouting:
-					if util.ContainsString(rule.Rule, "MASQUERADE") && c.k8sipables[protocol].HasRandomFully() {
+					if util.ContainsString(rule.Rule, "MASQUERADE") && c.k8siptables[protocol].HasRandomFully() {
 						// https://github.com/kubeovn/kube-ovn/issues/2641
 						// Work around Linux kernel bug that sometimes causes multiple flows to
 						// get mapped to the same IP:PORT and consequently some suffer packet

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -481,7 +481,6 @@ func (c *Controller) setIptables() error {
 		protocols[0] = c.protocol
 	}
 
-	execer := k8sexec.New()
 	var supportRandomFully bool
 
 	for _, protocol := range protocols {
@@ -576,10 +575,10 @@ func (c *Controller) setIptables() error {
 		}
 
 		if protocol == kubeovnv1.ProtocolIPv4 {
-			iptv4 := k8siptables.New(execer, k8siptables.ProtocolIPv4)
+			iptv4 := k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv4)
 			supportRandomFully = iptv4.HasRandomFully()
 		} else {
-			iptv6 := k8siptables.New(execer, k8siptables.ProtocolIPv6)
+			iptv6 := k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv6)
 			supportRandomFully = iptv6.HasRandomFully()
 		}
 
@@ -592,10 +591,10 @@ func (c *Controller) setIptables() error {
 					continue
 				case OvnPostrouting:
 					if util.ContainsString(rule.Rule, "MASQUERADE") && supportRandomFully {
-						//https://github.com/kubeovn/kube-ovn/issues/2641
-						//Work around Linux kernel bug that sometimes causes multiple flows to
-						//get mapped to the same IP:PORT and consequently some suffer packet
-						//drops.
+						// https://github.com/kubeovn/kube-ovn/issues/2641
+						// Work around Linux kernel bug that sometimes causes multiple flows to
+						// get mapped to the same IP:PORT and consequently some suffer packet
+						// drops.
 						rule.Rule = append(rule.Rule, "--random-fully")
 					}
 					natPostroutingRules = append(natPostroutingRules, rule)


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #[2641](https://github.com/kubeovn/kube-ovn/issues/2641)


1. add random fully
2. fix snat rule not delete the last rule, and "i+added" should be replace by "i+added+1"
3. kubectl ko log add ipv6 tables

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 944584e</samp>

Fix gateway iptables bug and improve packet distribution. Use `iptables` package to manage iptables rules in `gateway_linux.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 944584e</samp>

> _To fix a bug in deleting rules_
> _And avoid packet drops by the fools_
> _This pull request adds_
> _The `--random-fully` fads_
> _And uses `iptables` from k8s tools_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 944584e</samp>

*  Import iptables package and declare variables for iptables operations and flag support ([link](https://github.com/kubeovn/kube-ovn/pull/2681/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R22), [link](https://github.com/kubeovn/kube-ovn/pull/2681/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R484-R486))
*  Fix bug in updateIptablesChain function by using correct index to delete obsolete rules ([link](https://github.com/kubeovn/kube-ovn/pull/2681/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L382-R383))
*  Initialize iptables wrapper and check for --random-fully flag support in setIptables function ([link](https://github.com/kubeovn/kube-ovn/pull/2681/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R578-R585))
*  Append --random-fully option to MASQUERADE rules if supported in setIptables function to mitigate kernel bug that causes packet drops ([link](https://github.com/kubeovn/kube-ovn/pull/2681/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R594-R600), [link](https://github.com/kubeovn/kube-ovn/pull/2681/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R484-R486))