### PR TITLE
netpol: fix enqueueing network policy after LSP creation

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -242,25 +242,42 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 		return
 	}
 
+	key, err := cache.MetaNamespaceKeyFunc(newObj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	podNets, err := c.getPodKubeovnNets(newPod)
+	if err != nil {
+		klog.Errorf("failed to get newPod nets %v", err)
+		return
+	}
+
 	if c.config.EnableNP {
 		c.namedPort.AddNamedPortByPod(newPod)
+		newNp := c.podMatchNetworkPolicies(newPod)
 		if !reflect.DeepEqual(oldPod.Labels, newPod.Labels) {
 			oldNp := c.podMatchNetworkPolicies(oldPod)
-			newNp := c.podMatchNetworkPolicies(newPod)
 			for _, np := range util.DiffStringSlice(oldNp, newNp) {
 				c.updateNpQueue.Add(np)
+			}
+		}
+
+		for _, podNet := range podNets {
+			oldAllocated := oldPod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)]
+			newAllocated := newPod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)]
+			if oldAllocated != newAllocated {
+				for _, np := range newNp {
+					klog.V(3).Infof("enqueue update network policy %s for pod %s", np, key)
+					c.updateNpQueue.Add(np)
+				}
+				break
 			}
 		}
 	}
 
 	if newPod.Spec.HostNetwork {
-		return
-	}
-
-	var key string
-	var err error
-	if key, err = cache.MetaNamespaceKeyFunc(newObj); err != nil {
-		utilruntime.HandleError(err)
 		return
 	}
 
@@ -301,12 +318,6 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 	}
 
 	c.addOrUpdatePodQueue.Add(key)
-
-	podNets, err := c.getPodKubeovnNets(newPod)
-	if err != nil {
-		klog.Errorf("failed to get newPod nets %v", err)
-		return
-	}
 
 	// security policy changed
 	for _, podNet := range podNets {
@@ -548,17 +559,7 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 
 	// check if route subnet is need.
 	pod = cachedPod.DeepCopy()
-	needRoutePodNets := needRouteSubnets(pod, podNets)
-	if len(needRoutePodNets) > 0 {
-		if c.config.EnableNP {
-			for _, np := range c.podMatchNetworkPolicies(pod) {
-				klog.V(3).Infof("enqueue update network policy %s for pod %s", np, key)
-				c.updateNpQueue.Add(np)
-			}
-		}
-		return c.reconcileRouteSubnets(cachedPod, pod, needRoutePodNets)
-	}
-	return nil
+	return c.reconcileRouteSubnets(cachedPod, pod, needRouteSubnets(pod, podNets))
 }
 
 // do the same thing as add pod
@@ -691,6 +692,10 @@ func (c *Controller) reconcileAllocateSubnets(cachedPod, pod *v1.Pod, needAlloca
 
 // do the same thing as update pod
 func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodNets []*kubeovnNet) error {
+	if len(needRoutePodNets) == 0 {
+		return nil
+	}
+
 	namespace := pod.Namespace
 	name := pod.Name
 	podName := c.getNameByPod(pod)
@@ -701,9 +706,6 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 	var subnet *kubeovnv1.Subnet
 
 	for _, podNet := range needRoutePodNets {
-		if !isOvnSubnet(podNet.Subnet) {
-			continue
-		}
 		// in case update handler overlap the annotation when cache is not in sync
 		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] == "" {
 			return fmt.Errorf("no address has been allocated to %s/%s", namespace, name)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
When handling network policy for a new Pod, there is a chance that the Pod in the `List()` result does not have `allocated` annotation.

This patch fixes the following e2e failure:

```txt
Summarizing 1 Failure:
  [FAIL] [CNI:Kube-OVN] [group:network-policy] [It] should be able to access pods from node after creating a network policy with empty ingress rules [Conformance]
  /home/runner/work/kube-ovn/kube-ovn/test/e2e/kube-ovn/network-policy/network-policy.go:135
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 92654f2</samp>

Improve pod controller efficiency and readability. Refactor `pkg/controller/pod.go` to streamline host network, ovn network, network policy, and route subnet handling.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 92654f2</samp>

> _We're the pod controllers, we work with skill and speed_
> _We tidy up our logic and we prune what we don't need_
> _We heave away on `hostNetwork` and `ovnNetwork` too_
> _And when we're done we'll have a route for every subnet through_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 92654f2</samp>

*  Skip pod update event for host network pods ([link](https://github.com/kubeovn/kube-ovn/pull/2687/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R244-R246), [link](https://github.com/kubeovn/kube-ovn/pull/2687/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L256-L259))
*  Enqueue network policies for update when pod allocated annotation changes ([link](https://github.com/kubeovn/kube-ovn/pull/2687/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R312-R322))
*  Simplify reconcileRouteSubnets function by removing redundant checks and conditional blocks ([link](https://github.com/kubeovn/kube-ovn/pull/2687/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L551-R561), [link](https://github.com/kubeovn/kube-ovn/pull/2687/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R694-R697), [link](https://github.com/kubeovn/kube-ovn/pull/2687/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L704-L706))