### PR TITLE
fix: arp check should ignore broadcast arp pkt

### DIFF
--- a/pkg/util/arp.go
+++ b/pkg/util/arp.go
@@ -148,7 +148,8 @@ func ArpDetectIPConflict(nic, ip string, mac net.HardwareAddr) (net.HardwareAddr
 				return
 			}
 
-			if pkt.SenderIP.String() == ip {
+			if pkt.SenderIP.String() == ip && !macEqual(pkt.SenderHardwareAddr, mac) {
+				klog.Infof("received IPv4 address probe for %s from remote host %s, current host %s", ip, pkt.SenderHardwareAddr.String(), mac.String())
 				ch <- pkt.SenderHardwareAddr
 				return
 			}
@@ -161,7 +162,7 @@ func ArpDetectIPConflict(nic, ip string, mac net.HardwareAddr) (net.HardwareAddr
 				!macEqual(pkt.SenderHardwareAddr, mac) {
 				// received probe from another host
 				// treat this as an address conflict
-				klog.Infof("received IPv4 address probe for %s from host %s", ip, pkt.SenderHardwareAddr.String())
+				klog.Infof("received IPv4 address probe for %s from remote host %s, current host %s", ip, pkt.SenderHardwareAddr.String(), mac.String())
 				ch <- pkt.SenderHardwareAddr
 				return
 			}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes
#2659 

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6926930</samp>

Enhance ARP conflict detection and logging in `arp.go`. Log both IP and MAC address conflicts and show the local MAC address for debugging.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6926930</samp>

> _`ARP` probes reveal_
> _IP and MAC conflicts now_
> _Logging in autumn_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6926930</samp>

*  Add condition and log message for MAC address conflicts detected by ARP probes ([link](https://github.com/kubeovn/kube-ovn/pull/2688/files?diff=unified&w=0#diff-1fde66a27588df521a2a0fec2cfc0d6b59944eaab04e1e3fc31237c5e14fd246L151-R152), [link](https://github.com/kubeovn/kube-ovn/pull/2688/files?diff=unified&w=0#diff-1fde66a27588df521a2a0fec2cfc0d6b59944eaab04e1e3fc31237c5e14fd246L164-R165))