### PR TITLE
fix manifest yamls

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -526,6 +526,8 @@ spec:
                   type: string
                 redo:
                   type: string
+                qosPolicy:
+                  type: string
                 conditions:
                   type: array
                   items:
@@ -553,6 +555,8 @@ spec:
                 macAddress:
                   type: string
                 natGwDp:
+                  type: string
+                qosPolicy:
                   type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -1113,62 +1117,62 @@ spec:
           name: Ready
           type: boolean
       schema:
-          openAPIV3Schema:
-            type: object
-            properties:
-              status:
-                type: object
-                properties:
-                  ready:
-                    type: boolean
-                  v4Eip:
-                    type: string
-                  v4Ip:
-                    type: string
-                  macAddress:
-                    type: string
-                  vpc:
-                    type: string
-                  externalPort:
-                    type: string
-                  internalPort:
-                    type: string
-                  protocol:
-                    type: string
-                  ipName:
-                    type: string
-                  conditions:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        type:
-                          type: string
-                        status:
-                          type: string
-                        reason:
-                          type: string
-                        message:
-                          type: string
-                        lastUpdateTime:
-                          type: string
-                        lastTransitionTime:
-                          type: string
-              spec:
-                type: object
-                properties:
-                  ovnEip:
-                    type: string
-                  ipType:
-                    type: string
-                  ipName:
-                    type: string
-                  externalPort:
-                    type: string
-                  internalPort:
-                    type: string
-                  protocol:
-                    type: string
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                ready:
+                  type: boolean
+                v4Eip:
+                  type: string
+                v4Ip:
+                  type: string
+                macAddress:
+                  type: string
+                vpc:
+                  type: string
+                externalPort:
+                  type: string
+                internalPort:
+                  type: string
+                protocol:
+                  type: string
+                ipName:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastUpdateTime:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+            spec:
+              type: object
+              properties:
+                ovnEip:
+                  type: string
+                ipType:
+                  type: string
+                ipName:
+                  type: string
+                externalPort:
+                  type: string
+                internalPort:
+                  type: string
+                protocol:
+                  type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1787,7 +1791,6 @@ spec:
                   not:
                     enum:
                       - int
-                      - external
             spec:
               type: object
               properties:
@@ -1958,3 +1961,72 @@ spec:
         status: {}
   conversion:
     strategy: None
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: qos-policies.kubeovn.io
+spec:
+  group: kubeovn.io
+  names:
+    plural: qos-policies
+    singular: qos-policy
+    shortNames:
+      - qos
+    kind: QoSPolicy
+    listKind: QoSPolicyList
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - jsonPath: .spec.bandwidthLimitRule.ingressMax
+        name: IngressMax
+        type: string
+      - jsonPath: .spec.bandwidthLimitRule.egressMax
+        name: EgressMax
+        type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                bandwidthLimitRule:
+                  type: object
+                  properties:
+                    ingressMax:
+                      type: string
+                    egressMax:
+                      type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastUpdateTime:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+            spec:
+              type: object
+              properties:
+                bandwidthLimitRule:
+                  type: object
+                  properties:
+                    ingressMax:
+                      type: string
+                    egressMax:
+                      type: string

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3820,7 +3820,7 @@ metadata:
   namespace: kube-system
   annotations:
     kubernetes.io/description: |
-      This daemon set launches the openvswitch daemon.
+      This daemon set launches the pinger daemon.
 spec:
   selector:
     matchLabels:

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -1092,8 +1092,11 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - jsonPath: .status.vpc
-          name: Vpc
+        - jsonPath: .spec.ovnEip
+          name: Eip
+          type: string
+        - jsonPath: .status.protocol
+          name: Protocol
           type: string
         - jsonPath: .status.v4Eip
           name: V4Eip
@@ -1101,15 +1104,18 @@ spec:
         - jsonPath: .status.v4Ip
           name: V4Ip
           type: string
-        - jsonPath: .status.ready
-          name: Ready
-          type: boolean
-        - jsonPath: .spec.ipType
-          name: IpType
+        - jsonPath: .status.internalPort
+          name: InternalPort
+          type: string
+        - jsonPath: .status.externalPort
+          name: ExternalPort
           type: string
         - jsonPath: .spec.ipName
           name: IpName
           type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
       schema:
         openAPIV3Schema:
           type: object
@@ -1126,6 +1132,14 @@ spec:
                 macAddress:
                   type: string
                 vpc:
+                  type: string
+                externalPort:
+                  type: string
+                internalPort:
+                  type: string
+                protocol:
+                  type: string
+                ipName:
                   type: string
                 conditions:
                   type: array
@@ -1152,6 +1166,12 @@ spec:
                 ipType:
                   type: string
                 ipName:
+                  type: string
+                externalPort:
+                  type: string
+                internalPort:
+                  type: string
+                protocol:
                   type: string
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -1,3 +1,21 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-vpc-nat-config
+  namespace: kube-system
+  annotations:
+    kubernetes.io/description: |
+      kube-ovn vpc-nat common config
+data:
+  image: kubeovn/vpc-nat-gateway:v1.12.0
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-vpc-nat-gw-config
+  namespace: kube-system
+data:
+  enable-vpc-nat-gw: "false"
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -41,7 +59,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-controller
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           args:
             - /kube-ovn/start-controller.sh
@@ -49,17 +67,29 @@ spec:
             - --default-gateway=10.16.0.1,fd00:10:16::1
             - --default-gateway-check=true
             - --default-logical-gateway=false
+            - --default-u2o-interconnection=false
             - --default-exclude-ips=
             - --node-switch-cidr=100.64.0.0/16,fd00:100:64::/64
             - --service-cluster-ip-range=10.96.0.0/12,fd00:10:96::/112
             - --network-type=geneve
             - --default-interface-name=
+            - --default-exchange-link-name=false
             - --default-vlan-id=100
+            - --ls-dnat-mod-dl-dst=true
             - --pod-nic-type=veth-pair
             - --enable-lb=true
             - --enable-np=true
             - --enable-eip-snat=true
             - --enable-external-vpc=true
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --gc-interval=360
+            - --inspect-interval=20
+            - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
+            - --log_file_max_size=0
+            - --enable-lb-svc=false
+            - --keep-vm-ip=true
+            - --pod-default-fip-type=
           env:
             - name: ENABLE_SSL
               value: "false"
@@ -79,9 +109,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -111,6 +145,9 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -149,7 +186,7 @@ spec:
       hostPID: true
       initContainers:
         - name: install-cni
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/install-cni.sh"]
           securityContext:
@@ -158,9 +195,11 @@ spec:
           volumeMounts:
             - mountPath: /opt/cni/bin
               name: cni-bin
+            - mountPath: /usr/local/bin
+              name: local-bin
       containers:
         - name: cni-server
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -170,8 +209,14 @@ spec:
             - --encap-checksum=true
             - --service-cluster-ip-range=10.96.0.0/12,fd00:10:96::/112
             - --iface=
+            - --dpdk-tunnel-iface=br-phy
             - --network-type=geneve
             - --default-interface-name=
+            - --cni-conf-name=01-kube-ovn.conflist
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --log_file=/var/log/kube-ovn/kube-ovn-cni.log
+            - --log_file_max_size=0
           securityContext:
             runAsUser: 0
             privileged: true
@@ -186,27 +231,49 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: MODULES
+              value: kube_ovn_fastpath.ko
+            - name: RPMS
+              value: openvswitch-kmod
             - name: POD_IPS
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
+            - name: DBUS_SYSTEM_BUS_ADDRESS
+              value: "unix:path=/host/var/run/dbus/system_bus_socket"
           volumeMounts:
             - name: host-modules
               mountPath: /lib/modules
               readOnly: true
+            - name: shared-dir
+              mountPath: /var/lib/kubelet/pods
             - mountPath: /etc/openvswitch
               name: systemid
             - mountPath: /etc/cni/net.d
               name: cni-conf
             - mountPath: /run/openvswitch
               name: host-run-ovs
+              mountPropagation: HostToContainer
             - mountPath: /run/ovn
               name: host-run-ovn
+            - mountPath: /host/var/run/dbus
+              name: host-dbus
+              mountPropagation: HostToContainer
             - mountPath: /var/run/netns
               name: host-ns
               mountPropagation: HostToContainer
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
+            - mountPath: /var/log/openvswitch
+              name: host-log-ovs
+            - mountPath: /var/log/ovn
+              name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+            - mountPath: /tmp
+              name: tmp
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 30
@@ -217,7 +284,6 @@ spec:
             timeoutSeconds: 3
           readinessProbe:
             failureThreshold: 3
-            initialDelaySeconds: 30
             periodSeconds: 7
             successThreshold: 1
             tcpSocket:
@@ -225,8 +291,8 @@ spec:
             timeoutSeconds: 3
           resources:
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 100m
+              memory: 100Mi
             limits:
               cpu: 1000m
               memory: 1Gi
@@ -236,6 +302,9 @@ spec:
         - name: host-modules
           hostPath:
             path: /lib/modules
+        - name: shared-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
         - name: systemid
           hostPath:
             path: /etc/origin/openvswitch
@@ -254,9 +323,27 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
+        - name: host-dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: host-log-ovs
+          hostPath:
+            path: /var/log/openvswitch
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
+        - name: host-log-ovn
+          hostPath:
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
+        - name: tmp
+          hostPath:
+            path: /tmp
+        - name: local-bin
+          hostPath:
+            path: /usr/local/bin
 
 ---
 kind: DaemonSet
@@ -285,11 +372,16 @@ spec:
       hostPID: true
       containers:
         - name: pinger
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           command:
             - /kube-ovn/kube-ovn-pinger
+          args:
             - --external-address=114.114.114.114,2400:3200::1
             - --external-dns=alauda.cn
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --log_file=/var/log/kube-ovn/kube-ovn-pinger.log
+            - --log_file_max_size=0
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0
@@ -332,6 +424,8 @@ spec:
               name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
             - mountPath: /etc/localtime
               name: localtime
             - mountPath: /var/run/tls
@@ -339,7 +433,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 100Mi
             limits:
               cpu: 200m
               memory: 400Mi
@@ -364,6 +458,9 @@ spec:
         - name: host-log-ovs
           hostPath:
             path: /var/log/openvswitch
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn
@@ -412,12 +509,12 @@ spec:
                 matchLabels:
                   app: kube-ovn-monitor
               topologyKey: kubernetes.io/hostname
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: ovn
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:
@@ -439,6 +536,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
               cpu: 200m
@@ -522,12 +621,14 @@ metadata:
   labels:
     app: kube-ovn-monitor
 spec:
-  ipFamilyPolicy: PreferDualStack
-  selector:
-    app: kube-ovn-monitor
   ports:
     - name: metrics
       port: 10661
+  type: ClusterIP
+  ipFamilyPolicy: PreferDualStack
+  selector:
+    app: kube-ovn-monitor
+  sessionAffinity: None
 ---
 kind: Service
 apiVersion: v1

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -1,3 +1,21 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-vpc-nat-config
+  namespace: kube-system
+  annotations:
+    kubernetes.io/description: |
+      kube-ovn vpc-nat common config
+data:
+  image: kubeovn/vpc-nat-gateway:v1.12.0
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-vpc-nat-gw-config
+  namespace: kube-system
+data:
+  enable-vpc-nat-gw: "false"
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -41,7 +59,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-controller
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           args:
             - /kube-ovn/start-controller.sh
@@ -49,18 +67,29 @@ spec:
             - --default-gateway=2001:db8:0000:0000::1
             - --default-gateway-check=true
             - --default-logical-gateway=false
+            - --default-u2o-interconnection=false
             - --default-exclude-ips=
             - --node-switch-cidr=2001:db8:0000:0001::/64
-            - --node-switch-gateway=2001:db8:0000:0001::1
             - --service-cluster-ip-range=fd00:10:96::/112
             - --network-type=geneve
             - --default-interface-name=
+            - --default-exchange-link-name=false
             - --default-vlan-id=100
+            - --ls-dnat-mod-dl-dst=true
             - --pod-nic-type=veth-pair
             - --enable-lb=true
             - --enable-np=true
             - --enable-eip-snat=true
             - --enable-external-vpc=true
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --gc-interval=360
+            - --inspect-interval=20
+            - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
+            - --log_file_max_size=0
+            - --enable-lb-svc=false
+            - --keep-vm-ip=true
+            - --pod-default-fip-type=
           env:
             - name: ENABLE_SSL
               value: "false"
@@ -80,7 +109,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           volumeMounts:
+            - mountPath: /etc/localtime
+              name: localtime
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -97,9 +132,22 @@ spec:
             periodSeconds: 7
             failureThreshold: 5
             timeoutSeconds: 45
+          resources:
+            requests:
+              cpu: 200m
+              memory: 200Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -138,7 +186,7 @@ spec:
       hostPID: true
       initContainers:
         - name: install-cni
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/install-cni.sh"]
           securityContext:
@@ -147,9 +195,11 @@ spec:
           volumeMounts:
             - mountPath: /opt/cni/bin
               name: cni-bin
+            - mountPath: /usr/local/bin
+              name: local-bin
       containers:
         - name: cni-server
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -159,8 +209,14 @@ spec:
             - --encap-checksum=true
             - --service-cluster-ip-range=fd00:10:96::/112
             - --iface=
+            - --dpdk-tunnel-iface=br-phy
             - --network-type=geneve
             - --default-interface-name=
+            - --cni-conf-name=01-kube-ovn.conflist
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --log_file=/var/log/kube-ovn/kube-ovn-cni.log
+            - --log_file_max_size=0
           securityContext:
             runAsUser: 0
             privileged: true
@@ -175,25 +231,49 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: MODULES
+              value: kube_ovn_fastpath.ko
+            - name: RPMS
+              value: openvswitch-kmod
             - name: POD_IPS
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
+            - name: DBUS_SYSTEM_BUS_ADDRESS
+              value: "unix:path=/host/var/run/dbus/system_bus_socket"
           volumeMounts:
             - name: host-modules
               mountPath: /lib/modules
               readOnly: true
+            - name: shared-dir
+              mountPath: /var/lib/kubelet/pods
             - mountPath: /etc/openvswitch
               name: systemid
             - mountPath: /etc/cni/net.d
               name: cni-conf
             - mountPath: /run/openvswitch
               name: host-run-ovs
+              mountPropagation: HostToContainer
             - mountPath: /run/ovn
               name: host-run-ovn
+            - mountPath: /host/var/run/dbus
+              name: host-dbus
+              mountPropagation: HostToContainer
             - mountPath: /var/run/netns
               name: host-ns
               mountPropagation: HostToContainer
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
+            - mountPath: /var/log/openvswitch
+              name: host-log-ovs
+            - mountPath: /var/log/ovn
+              name: host-log-ovn
+            - mountPath: /etc/localtime
+              name: localtime
+            - mountPath: /tmp
+              name: tmp
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 30
@@ -204,18 +284,27 @@ spec:
             timeoutSeconds: 3
           readinessProbe:
             failureThreshold: 3
-            initialDelaySeconds: 30
             periodSeconds: 7
             successThreshold: 1
             tcpSocket:
               port: 10665
             timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
         - name: host-modules
           hostPath:
             path: /lib/modules
+        - name: shared-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
         - name: systemid
           hostPath:
             path: /etc/origin/openvswitch
@@ -234,6 +323,27 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
+        - name: host-dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: host-log-ovs
+          hostPath:
+            path: /var/log/openvswitch
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
+        - name: host-log-ovn
+          hostPath:
+            path: /var/log/ovn
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - name: tmp
+          hostPath:
+            path: /tmp
+        - name: local-bin
+          hostPath:
+            path: /usr/local/bin
 
 ---
 kind: DaemonSet
@@ -262,11 +372,16 @@ spec:
       hostPID: true
       containers:
         - name: pinger
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           command:
             - /kube-ovn/kube-ovn-pinger
+          args:
             - --external-address=2400:3200::1
             - --external-dns=alauda.cn
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --log_file=/var/log/kube-ovn/kube-ovn-pinger.log
+            - --log_file_max_size=0
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0
@@ -309,12 +424,16 @@ spec:
               name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
+            - mountPath: /etc/localtime
+              name: localtime
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           resources:
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 100Mi
             limits:
               cpu: 200m
               memory: 400Mi
@@ -339,9 +458,15 @@ spec:
         - name: host-log-ovs
           hostPath:
             path: /var/log/openvswitch
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -389,7 +514,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:
@@ -411,6 +536,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
               cpu: 200m

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -1,3 +1,21 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-vpc-nat-config
+  namespace: kube-system
+  annotations:
+    kubernetes.io/description: |
+      kube-ovn vpc-nat common config
+data:
+  image: kubeovn/vpc-nat-gateway:v1.12.0
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-vpc-nat-gw-config
+  namespace: kube-system
+data:
+  enable-vpc-nat-gw: "false"
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -36,12 +54,12 @@ spec:
                 matchLabels:
                   app: kube-ovn-controller
               topologyKey: kubernetes.io/hostname
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: ovn
       hostNetwork: true
       containers:
         - name: kube-ovn-controller
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           args:
             - /kube-ovn/start-controller.sh
@@ -49,17 +67,29 @@ spec:
             - --default-gateway=10.16.0.1
             - --default-gateway-check=true
             - --default-logical-gateway=false
+            - --default-u2o-interconnection=false
             - --default-exclude-ips=
             - --node-switch-cidr=100.64.0.0/16
             - --service-cluster-ip-range=10.96.0.0/12
             - --network-type=geneve
             - --default-interface-name=
+            - --default-exchange-link-name=false
             - --default-vlan-id=100
+            - --ls-dnat-mod-dl-dst=true
             - --pod-nic-type=veth-pair
             - --enable-lb=true
             - --enable-np=true
             - --enable-eip-snat=true
             - --enable-external-vpc=true
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --gc-interval=360
+            - --inspect-interval=20
+            - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
+            - --log_file_max_size=0
+            - --enable-lb-svc=false
+            - --keep-vm-ip=true
+            - --pod-default-fip-type=
           env:
             - name: ENABLE_SSL
               value: "false"
@@ -75,13 +105,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: OVN_DB_IPS
+              value: 172.17.0.2
             - name: POD_IPS
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -111,6 +147,9 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -149,7 +188,7 @@ spec:
       hostPID: true
       initContainers:
         - name: install-cni
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/install-cni.sh"]
           securityContext:
@@ -158,9 +197,11 @@ spec:
           volumeMounts:
             - mountPath: /opt/cni/bin
               name: cni-bin
+            - mountPath: /usr/local/bin
+              name: local-bin
       containers:
         - name: cni-server
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -170,8 +211,14 @@ spec:
             - --encap-checksum=true
             - --service-cluster-ip-range=10.96.0.0/12
             - --iface=
+            - --dpdk-tunnel-iface=br-phy
             - --network-type=geneve
             - --default-interface-name=
+            - --cni-conf-name=01-kube-ovn.conflist
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --log_file=/var/log/kube-ovn/kube-ovn-cni.log
+            - --log_file_max_size=0
           securityContext:
             runAsUser: 0
             privileged: true
@@ -186,22 +233,31 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: MODULES
+              value: kube_ovn_fastpath.ko
+            - name: RPMS
+              value: openvswitch-kmod
             - name: POD_IPS
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
             - name: DBUS_SYSTEM_BUS_ADDRESS
               value: "unix:path=/host/var/run/dbus/system_bus_socket"
           volumeMounts:
             - name: host-modules
               mountPath: /lib/modules
               readOnly: true
+            - name: shared-dir
+              mountPath: /var/lib/kubelet/pods
             - mountPath: /etc/openvswitch
               name: systemid
             - mountPath: /etc/cni/net.d
               name: cni-conf
             - mountPath: /run/openvswitch
               name: host-run-ovs
+              mountPropagation: HostToContainer
             - mountPath: /run/ovn
               name: host-run-ovn
             - mountPath: /host/var/run/dbus
@@ -218,6 +274,8 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+            - mountPath: /tmp
+              name: tmp
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 30
@@ -235,8 +293,8 @@ spec:
             timeoutSeconds: 3
           resources:
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 100m
+              memory: 100Mi
             limits:
               cpu: 1000m
               memory: 1Gi
@@ -246,6 +304,9 @@ spec:
         - name: host-modules
           hostPath:
             path: /lib/modules
+        - name: shared-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
         - name: systemid
           hostPath:
             path: /etc/origin/openvswitch
@@ -279,6 +340,12 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        - name: tmp
+          hostPath:
+            path: /tmp
+        - name: local-bin
+          hostPath:
+            path: /usr/local/bin
 
 ---
 kind: DaemonSet
@@ -307,11 +374,16 @@ spec:
       hostPID: true
       containers:
         - name: pinger
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           command:
             - /kube-ovn/kube-ovn-pinger
+          args:
             - --external-address=114.114.114.114
             - --external-dns=alauda.cn
+            - --logtostderr=false
+            - --alsologtostderr=true
+            - --log_file=/var/log/kube-ovn/kube-ovn-pinger.log
+            - --log_file_max_size=0
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0
@@ -354,6 +426,8 @@ spec:
               name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
             - mountPath: /etc/localtime
               name: localtime
             - mountPath: /var/run/tls
@@ -361,7 +435,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 100Mi
             limits:
               cpu: 200m
               memory: 400Mi
@@ -386,6 +460,9 @@ spec:
         - name: host-log-ovs
           hostPath:
             path: /var/log/openvswitch
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn
@@ -439,7 +516,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:
@@ -461,6 +538,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
               cpu: 200m

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -36,10 +36,18 @@ rules:
       - iptables-fip-rules/status
       - iptables-dnat-rules/status
       - iptables-snat-rules/status
-      - switch-lb-rules
-      - switch-lb-rules/status
+      - ovn-eips
+      - ovn-fips
+      - ovn-snat-rules
+      - ovn-eips/status
+      - ovn-fips/status
+      - ovn-snat-rules/status
+      - ovn-dnat-rules
+      - ovn-dnat-rules/status
       - vpc-dnses
       - vpc-dnses/status
+      - switch-lb-rules
+      - switch-lb-rules/status
       - qos-policies
       - qos-policies/status
     verbs:
@@ -74,13 +82,13 @@ rules:
       - deployments
       - deployments/scale
     verbs:
+      - create
+      - delete
+      - update
+      - patch
       - get
       - list
       - watch
-      - update
-      - create
-      - delete
-      - patch
   - apiGroups:
       - ""
     resources:
@@ -132,13 +140,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ovn
-    namespace:  kube-system
+    namespace: kube-system
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
-  namespace:  kube-system
+  namespace: kube-system
 spec:
   ports:
     - name: ovn-nb
@@ -155,7 +163,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ovn-sb
-  namespace:  kube-system
+  namespace: kube-system
 spec:
   ports:
     - name: ovn-sb
@@ -189,7 +197,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: ovn-central
-  namespace:  kube-system
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       OVN components: northd, nb and sb.
@@ -229,7 +237,7 @@ spec:
       hostNetwork: true
       containers:
         - name: ovn-central
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-db.sh"]
           securityContext:
@@ -256,9 +264,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 200Mi
             limits:
               cpu: 3
@@ -279,6 +289,8 @@ spec:
               name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+            - mountPath: /etc/localtime
+              name: localtime
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -286,7 +298,7 @@ spec:
               command:
                 - bash
                 - /kube-ovn/ovn-healthcheck.sh
-            periodSeconds: 3
+            periodSeconds: 15
             timeoutSeconds: 45
           livenessProbe:
             exec:
@@ -294,7 +306,7 @@ spec:
                 - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
-            periodSeconds: 7
+            periodSeconds: 15
             failureThreshold: 5
             timeoutSeconds: 45
       nodeSelector:
@@ -322,6 +334,9 @@ spec:
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -331,7 +346,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: ovs-ovn
-  namespace:  kube-system
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       This daemon set launches the openvswitch daemon.
@@ -358,13 +373,13 @@ spec:
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       serviceAccountName: ovn
       hostNetwork: true
       hostPID: true
       containers:
         - name: openvswitch
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovs.sh"]
           securityContext:
@@ -387,11 +402,16 @@ spec:
                   fieldPath: metadata.namespace
             - name: HW_OFFLOAD
               value: "false"
+            - name: TUNNEL_TYPE
+              value: "geneve"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
+            - mountPath: /var/run/netns
+              name: host-ns
+              mountPropagation: HostToContainer
             - mountPath: /lib/modules
               name: host-modules
               readOnly: true
@@ -412,8 +432,12 @@ spec:
               name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+            - mountPath: /etc/localtime
+              name: localtime
             - mountPath: /var/run/tls
               name: kube-ovn-tls
+            - mountPath: /var/run/containerd
+              name: cruntime
           readinessProbe:
             exec:
               command:
@@ -438,7 +462,7 @@ spec:
               memory: 200Mi
             limits:
               cpu: 1000m
-              memory: 800Mi
+              memory: 1000Mi
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
@@ -454,6 +478,9 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+        - name: host-ns
+          hostPath:
+            path: /var/run/netns
         - name: cni-conf
           hostPath:
             path: /etc/cni/net.d
@@ -469,6 +496,12 @@ spec:
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - hostPath:
+            path: /var/run/containerd
+          name: cruntime
         - name: kube-ovn-tls
           secret:
             optional: true

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ovn
-  namespace:  kube-system
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -28,7 +28,6 @@ rules:
       - provider-networks/status
       - security-groups
       - security-groups/status
-      - htbqoses
       - iptables-eips
       - iptables-fip-rules
       - iptables-dnat-rules
@@ -37,10 +36,20 @@ rules:
       - iptables-fip-rules/status
       - iptables-dnat-rules/status
       - iptables-snat-rules/status
-      - switch-lb-rules
-      - switch-lb-rules/status
+      - ovn-eips
+      - ovn-fips
+      - ovn-snat-rules
+      - ovn-eips/status
+      - ovn-fips/status
+      - ovn-snat-rules/status
+      - ovn-dnat-rules
+      - ovn-dnat-rules/status
       - vpc-dnses
       - vpc-dnses/status
+      - switch-lb-rules
+      - switch-lb-rules/status
+      - qos-policies
+      - qos-policies/status
     verbs:
       - "*"
   - apiGroups:
@@ -57,16 +66,6 @@ rules:
       - list
       - watch
       - patch
-      - update
-  - apiGroups:
-      - "k8s.cni.cncf.io"
-    resources:
-      - network-attachment-definitions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
       - update
   - apiGroups:
       - ""
@@ -141,13 +140,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ovn
-    namespace:  kube-system
+    namespace: kube-system
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
-  namespace:  kube-system
+  namespace: kube-system
 spec:
   ports:
     - name: ovn-nb
@@ -164,7 +163,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ovn-sb
-  namespace:  kube-system
+  namespace: kube-system
 spec:
   ports:
     - name: ovn-sb
@@ -198,7 +197,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: ovn-central
-  namespace:  kube-system
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       OVN components: northd, nb and sb.
@@ -238,7 +237,7 @@ spec:
       hostNetwork: true
       containers:
         - name: ovn-central
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-db.sh"]
           securityContext:
@@ -248,7 +247,7 @@ spec:
             - name: ENABLE_SSL
               value: "false"
             - name: NODE_IPS
-              value: $addresses
+              value: 172.17.0.2
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -265,9 +264,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "true"
           resources:
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 200Mi
             limits:
               cpu: 3
@@ -378,12 +379,18 @@ spec:
       hostPID: true
       containers:
         - name: openvswitch
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.12.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovs.sh"]
           securityContext:
             runAsUser: 0
-            privileged: true
+            privileged: false
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_BIND_SERVICE
+                - SYS_MODULE
+                - SYS_NICE
           env:
             - name: ENABLE_SSL
               value: "false"
@@ -401,11 +408,16 @@ spec:
                   fieldPath: metadata.namespace
             - name: HW_OFFLOAD
               value: "false"
+            - name: TUNNEL_TYPE
+              value: "geneve"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
+            - mountPath: /var/run/netns
+              name: host-ns
+              mountPropagation: HostToContainer
             - mountPath: /lib/modules
               name: host-modules
               readOnly: true
@@ -430,6 +442,8 @@ spec:
               name: localtime
             - mountPath: /var/run/tls
               name: kube-ovn-tls
+            - mountPath: /var/run/containerd
+              name: cruntime
           readinessProbe:
             exec:
               command:
@@ -454,7 +468,7 @@ spec:
               memory: 200Mi
             limits:
               cpu: 1000m
-              memory: 800Mi
+              memory: 1000Mi
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
@@ -470,6 +484,9 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+        - name: host-ns
+          hostPath:
+            path: /var/run/netns
         - name: cni-conf
           hostPath:
             path: /etc/cni/net.d
@@ -488,6 +505,9 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        - hostPath:
+            path: /var/run/containerd
+          name: cruntime
         - name: kube-ovn-tls
           secret:
             optional: true


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b844f5</samp>

This pull request updates the kube-ovn deployment files and CRDs to support the latest release version and new features for QoS, EIP, FIP, and NAT. It also improves the logging, resource management, security, and performance of the kube-ovn and ovn components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7b844f5</samp>

> _Sing, O Muse, of the mighty deeds of kube-ovn_
> _The cloud-native network fabric of `Subnet` and `VpcNatGateway`_
> _How they updated their CRDs with skill and wisdom_
> _To support QoS policies and port mapping for the gateway_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b844f5</samp>

*  Add new CRDs and RBAC resources for `QoSPolicy`, `EIP`, `FIP`, and `NAT` features ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R529-R530),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R559-R560),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1964-R2032),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5L1095-R1100),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5L1104-R1118),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1136-R1143),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1170-R1175),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL228-R295),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R292-R298),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL39-R50),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L40-R52))
*  Update image tags of `kube-ovn-controller`, `install-cni`, `cni-server`, `pinger`, `kube-ovn-monitor`, `ovn-central`, and `openvswitch` containers to `v1.12.0` ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL44-R62),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL152-R189),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL161-R202),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL288-R384),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL415-R517),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L44-R62),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L141-R189),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L150-R202),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L265-R384),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L392-R517),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L39-R62),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L152-R191),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L161-R204),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L310-R386),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L442-R519),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL232-R240),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL367-R382),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L241-R240),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L381-R393))
*  Add new arguments and environment variables for `kube-ovn-controller` container to enable and configure new features and logging parameters ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR70),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL57-R78),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR84-R92),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL82-R118),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L52-R78),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R84-R92),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L83-R118),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R70),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L57-R78),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R84-R92),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L78-R120))
*  Add new arguments and environment variables for `cni-server` container to enable and configure new features and logging parameters ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL173-R219),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL189-R251),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L162-R219),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L178-R251),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L173-R221),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L189-R245))
*  Add new arguments and environment variables for `pinger` and `kube-ovn-monitor` containers to enable and configure logging parameters ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL288-R384),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR539-R540),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L265-R384),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R539-R540),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L310-R386),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R541-R542))
*  Add new arguments and environment variables for `ovn-central` and `openvswitch` containers to enable and configure new features ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadR405-R406),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L251-R250),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L268-R271),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9R411-R412))
*  Add new volume mounts and volumes for various containers and pods to access host paths, sockets, logs, TLS certificates, and network namespaces ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL82-R118),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR148-R150),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL161-R202),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL189-R251),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL203-R276),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL220),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR305-R307),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL257-R346),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR461-R463),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L83-R118),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L150-R202),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L178-R251),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L192-R276),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L207),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R305-R307),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R326-R346),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R427-R430),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L342-R469),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L78-R120),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R150-R152),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L161-R204),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L189-R245),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R252-R253),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R260),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R277-R278),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R307-R309),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R343-R348),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R429-R430),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R463-R465),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL259-R271),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadR292-R293),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadR337-R339),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadR412-R414),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL415-R440),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadR481-R483),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadR499-R504),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9R418-R420),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9R445-R446),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9R487-R489),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9R508-R510))
*  Remove unused or unsupported fields and values from CRD specs ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2L1116-R1175),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2L1790))
*  Update `jsonPath` and add `Protocol` column for `VpcNatGateway` CRD ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5L1095-R1100),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5L1104-R1118))
*  Update `priorityClassName` of `kube-ovn-controller`, `kube-ovn-monitor`, and `ovs-ovn` pods ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR84-R92),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL415-R517),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L392-R517),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L39-R62),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L442-R519),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL361-R376))
*  Update resource requests and limits of `kube-ovn-controller`, `cni-server`, and `pinger` containers ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L100-R150),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L317-R436),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L238-R297),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L364-R438))
*  Remove `ipFamilyPolicy` parameter from `kube-ovn-monitor` service spec for single-stack clusters ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL525-R631))
*  Replace `kube-ovn-dual-stack.yaml`, `kube-ovn-ipv6.yaml`, and `kube-ovn.yaml` files with `kube-ovn-crd.yaml` file ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL1-R19),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L1-R19),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L1-R19))
*  Fix formatting issues in various files ([link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2L1116-R1175),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL135-R143),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL141-R149),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL158-R166),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL334-R349),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L5-R5),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L144-R143),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L150-R149),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L167-R166),[link](https://github.com/kubeovn/kube-ovn/pull/2689/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L201-R200))