### PR TITLE
ci: fix scheduled vpc nat gateway e2e

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   GOSEC_VERSION: '2.15.0'
-  HELM_VERSION: v3.11.1
+  HELM_VERSION: v3.11.3
   SUBMARINER_VERSION: '0.14.3'
 
 jobs:
@@ -1311,7 +1311,7 @@ jobs:
         run: |
           sudo pip3 install j2cli
           sudo pip3 install "j2cli[yaml]"
-          sudo PATH=~/.local/bin:$PATH k8s_version=v1.23.13 make kind-init
+          sudo PATH=~/.local/bin:$PATH k8s_version=v1.23.17 make kind-init
           sudo cp -r /root/.kube/ ~/.kube/
           sudo chown -R $(id -un). ~/.kube/
 

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1112,7 +1112,7 @@ jobs:
         run: make kube-ovn-lb-svc-conformance-e2e
 
   kubevirt-e2e:
-    name: Kubevirt vm E2E
+    name: Kubevirt VM E2E
     needs:
       - build-kube-ovn
       - build-e2e-binaries
@@ -1564,6 +1564,9 @@ jobs:
       - cyclonus-netpol-e2e
       - kube-ovn-conformance-e2e
       - kube-ovn-ic-conformance-e2e
+      - ovn-vpc-nat-gw-conformance-e2e
+      - iptables-vpc-nat-gw-conformance-e2e
+      - webhook-e2e
       - lb-svc-e2e
       - underlay-logical-gateway-installation-test
       - chart-installation-test
@@ -1723,7 +1726,7 @@ jobs:
         run: sh dist/images/cleanup.sh
 
   iptables-vpc-nat-gw-conformance-e2e:
-    name: Iptables vpc nat gw E2E
+    name: Iptables VPC NAT Gateway E2E
     needs:
       - build-kube-ovn
       - build-vpc-nat-gateway
@@ -1814,7 +1817,7 @@ jobs:
         run: make iptables-vpc-nat-gw-conformance-e2e
 
   ovn-vpc-nat-gw-conformance-e2e:
-    name: Ovn vpc nat gw E2E
+    name: OVN VPC NAT Gateway E2E
     needs:
       - build-kube-ovn
       - build-e2e-binaries
@@ -1876,8 +1879,7 @@ jobs:
           name: kube-ovn
 
       - name: Load images
-        run: |
-          docker load -i kube-ovn.tar
+        run: docker load -i kube-ovn.tar
 
       - name: Create kind cluster
         run: |

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -751,7 +751,7 @@ jobs:
         run: make kube-ovn-lb-svc-conformance-e2e
 
   kubevirt-e2e:
-    name: Kubevirt vm E2E
+    name: Kubevirt VM E2E
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -1273,39 +1273,19 @@ jobs:
         run: sh dist/images/cleanup.sh
 
   iptables-vpc-nat-gw-conformance-e2e:
-    name: Iptables vpc nat gw E2E
-    needs:
-      - build-kube-ovn
-      - build-vpc-nat-gateway
-      - build-e2e-binaries
+    name: Iptables VPC NAT Gateway E2E
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - master
     steps:
       - uses: actions/checkout@v3
-
-      - name: Create the default branch directory
-        if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
-        run: mkdir -p test/e2e/source
-
-      - name: Check out the default branch
-        if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 1
-          path: test/e2e/source
-
-      - name: Export E2E directory
-        run: |
-          if [ '${{ github.base_ref || github.ref_name }}' = '${{ github.event.repository.default_branch }}' ]; then
-            echo "E2E_DIR=." >> "$GITHUB_ENV"
-          else
-            echo "E2E_DIR=test/e2e/source" >> "$GITHUB_ENV"
-          fi
-
       - uses: actions/setup-go@v4
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -1313,13 +1293,23 @@ jobs:
         run: echo "GO_FULL_VER=$(go version | awk '{print $3}')" >> "$GITHUB_ENV"
 
       - name: Go cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-${{ hashFiles(format('{0}/**/go.sum', env.E2E_DIR)) }}
+          key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-
+
+      - name: Create branch directory
+        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
+
+      - name: Check out branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 1
+          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
 
       - name: Install kind
         uses: helm/kind-action@v1
@@ -1327,25 +1317,10 @@ jobs:
           install_only: true
 
       - name: Install ginkgo
-        working-directory: ${{ env.E2E_DIR }}
         run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
-      - name: Download kube-ovn image
-        uses: actions/download-artifact@v3
-        with:
-          name: kube-ovn
-
-      - name: Download vpc-nat-gateway image
-        uses: actions/download-artifact@v3
-        with:
-          name: vpc-nat-gateway
-
-      - name: Load images
-        run: |
-          docker load -i kube-ovn.tar
-          docker load -i vpc-nat-gateway.tar
-
       - name: Create kind cluster
+        working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
         run: |
           sudo pip3 install j2cli
           sudo pip3 install "j2cli[yaml]"
@@ -1354,48 +1329,33 @@ jobs:
           sudo chown -R $(id -un). ~/.kube/
 
       - name: Install Kube-OVN
-        run: make kind-install
+        working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
+        run: |
+          version=$(grep -E '^VERSION="v([0-9]+\.){2}[0-9]+"$' dist/images/install.sh | head -n1 | awk -F= '{print $2}' | tr -d '"')
+          docker pull kubeovn/kube-ovn:$version
+          docker pull kubeovn/vpc-nat-gateway:$version
+          VERSION=$version make kind-install
 
       - name: Install vpc-nat-gw
         run: make kind-install-vpc-nat-gw
 
       - name: Run E2E
-        working-directory: ${{ env.E2E_DIR }}
         run: make iptables-vpc-nat-gw-conformance-e2e
 
   ovn-vpc-nat-gw-conformance-e2e:
-    name: Ovn vpc nat gw E2E
-    needs:
-      - build-kube-ovn
-      - build-e2e-binaries
+    name: OVN VPC NAT Gateway E2E
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - master
     steps:
       - uses: actions/checkout@v3
-
-      - name: Create the default branch directory
-        if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
-        run: mkdir -p test/e2e/source
-
-      - name: Check out the default branch
-        if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 1
-          path: test/e2e/source
-
-      - name: Export E2E directory
-        run: |
-          if [ '${{ github.base_ref || github.ref_name }}' = '${{ github.event.repository.default_branch }}' ]; then
-            echo "E2E_DIR=." >> "$GITHUB_ENV"
-          else
-            echo "E2E_DIR=test/e2e/source" >> "$GITHUB_ENV"
-          fi
-
       - uses: actions/setup-go@v4
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -1403,13 +1363,23 @@ jobs:
         run: echo "GO_FULL_VER=$(go version | awk '{print $3}')" >> "$GITHUB_ENV"
 
       - name: Go cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-${{ hashFiles(format('{0}/**/go.sum', env.E2E_DIR)) }}
+          key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-
+
+      - name: Create branch directory
+        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
+
+      - name: Check out branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 1
+          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
 
       - name: Install kind
         uses: helm/kind-action@v1
@@ -1417,19 +1387,10 @@ jobs:
           install_only: true
 
       - name: Install ginkgo
-        working-directory: ${{ env.E2E_DIR }}
         run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
-      - name: Download kube-ovn image
-        uses: actions/download-artifact@v3
-        with:
-          name: kube-ovn
-
-      - name: Load images
-        run: |
-          docker load -i kube-ovn.tar
-
       - name: Create kind cluster
+        working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
         run: |
           sudo pip3 install j2cli
           sudo pip3 install "j2cli[yaml]"
@@ -1438,8 +1399,11 @@ jobs:
           sudo chown -R $(id -un). ~/.kube/
 
       - name: Install Kube-OVN
-        run: make kind-install
+        working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
+        run: |
+          version=$(grep -E '^VERSION="v([0-9]+\.){2}[0-9]+"$' dist/images/install.sh | head -n1 | awk -F= '{print $2}' | tr -d '"')
+          docker pull kubeovn/kube-ovn:$version
+          VERSION=$version make kind-install
 
       - name: Run E2E
-        working-directory: ${{ env.E2E_DIR }}
         run: make ovn-vpc-nat-gw-conformance-e2e

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  HELM_VERSION: v3.11.1
+  HELM_VERSION: v3.11.3
   SUBMARINER_VERSION: '0.14.3'
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CHART_UPGRADE_RESTART_OVS=$(shell echo $${CHART_UPGRADE_RESTART_OVS:-false})
 MULTUS_IMAGE = ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
 MULTUS_YAML = https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset-thick.yml
 
-KUBEVIRT_VERSION = v0.58.0
+KUBEVIRT_VERSION = v0.58.1
 KUBEVIRT_OPERATOR_IMAGE = quay.io/kubevirt/virt-operator:$(KUBEVIRT_VERSION)
 KUBEVIRT_API_IMAGE = quay.io/kubevirt/virt-api:$(KUBEVIRT_VERSION)
 KUBEVIRT_CONTROLLER_IMAGE = quay.io/kubevirt/virt-controller:$(KUBEVIRT_VERSION)
@@ -35,10 +35,10 @@ KUBEVIRT_OPERATOR_YAML = https://github.com/kubevirt/kubevirt/releases/download/
 KUBEVIRT_CR_YAML = https://github.com/kubevirt/kubevirt/releases/download/$(KUBEVIRT_VERSION)/kubevirt-cr.yaml
 KUBEVIRT_TEST_YAML = https://kubevirt.io/labs/manifests/vm.yaml
 
-CILIUM_VERSION = 1.12.7
+CILIUM_VERSION = 1.12.9
 CILIUM_IMAGE_REPO = quay.io/cilium/cilium
 
-CERT_MANAGER_VERSION = v1.11.0
+CERT_MANAGER_VERSION = v1.11.1
 CERT_MANAGER_CONTROLLER = quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_CAINJECTOR = quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_WEBHOOK = quay.io/jetstack/cert-manager-webhook:$(CERT_MANAGER_VERSION)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- CI

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 92cd4ba</samp>

This pull request updates some workflow files, the `Makefile`, and the `kind.yaml.j2` template file to use the latest versions of some dependencies and tools, and to improve the testing and deployment of the Kube-OVN network plugin.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 92cd4ba</samp>

> _To test and deploy Kube-OVN_
> _We updated `kind.yaml.j2`_
> _And some workflow files_
> _With matrix and Helm styles_
> _And patched some deps like KubeVirt and Cilium_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 92cd4ba</samp>

*  Update Helm version to v3.11.3 in GitHub workflows ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L25-R25), [link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L13-R13))
*  Update Kubernetes version to v1.23.17 in GitHub workflows and kind cluster template ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1314-R1314), [link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-f88bb6992159e270ea78e286f19bfd123e4a87bcdb6307eadacc2d06dd6265f4L2-R2))
*  Update KubeVirt version to v0.58.1 in `Makefile` ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L27-R27))
*  Update Cilium and cert-manager versions to 1.12.9 and v1.11.1, respectively, in `Makefile` ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L38-R41))
*  Capitalize acronyms in job names for consistency and readability ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1115-R1115), [link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1726-R1729), [link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1817-R1820))
*  Add new jobs to run end-to-end tests for different features of Kube-OVN in `build-x86-image.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1567-R1569))
*  Simplify `Load images` step in `ovn-vpc-nat-gw-conformance-e2e` job ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1879-R1882))
*  Use matrix strategy to run tests for different branches in `iptables-vpc-nat-gw-conformance-e2e` and `ovn-vpc-nat-gw-conformance-e2e` jobs in `scheduled-e2e.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1276-R1296), [link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1363-R1345))
*  Remove unnecessary steps and dependencies in `iptables-vpc-nat-gw-conformance-e2e` and `ovn-vpc-nat-gw-conformance-e2e` jobs in `scheduled-e2e.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1329-R1316), [link](https://github.com/kubeovn/kube-ovn/pull/2692/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1419-R1367))