### PR TITLE
replace StrategicMergePatchType with MergePatchType

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -667,12 +667,13 @@ func (c *Controller) reconcileAllocateSubnets(cachedPod, pod *v1.Pod, needAlloca
 			}
 		}
 	}
-	patch, err := util.GenerateStrategicMergePatchPayload(cachedPod, pod)
+	patch, err := util.GenerateMergePatchPayload(cachedPod, pod)
 	if err != nil {
+		klog.Errorf("failed to generate patch for pod %s/%s: %v", name, namespace, err)
 		return nil, err
 	}
 	patchedPod, err := c.config.KubeClient.CoreV1().Pods(namespace).Patch(context.Background(), name,
-		types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "")
+		types.MergePatchType, patch, metav1.PatchOptions{}, "")
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Sometimes pod is deleted between kube-ovn configure ovn-nb and patch pod.
@@ -807,12 +808,13 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 
 		pod.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, podNet.ProviderName)] = "true"
 	}
-	patch, err := util.GenerateStrategicMergePatchPayload(cachedPod, pod)
+	patch, err := util.GenerateMergePatchPayload(cachedPod, pod)
 	if err != nil {
+		klog.Errorf("failed to generate patch for pod %s/%s: %v", name, namespace, err)
 		return err
 	}
 	if _, err := c.config.KubeClient.CoreV1().Pods(namespace).Patch(context.Background(), name,
-		types.StrategicMergePatchType, patch, metav1.PatchOptions{}, ""); err != nil {
+		types.MergePatchType, patch, metav1.PatchOptions{}, ""); err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Sometimes pod is deleted between kube-ovn configure ovn-nb and patch pod.
 			// Then we need to recycle the resource again.


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes
#2432 
### Which issue(s) this PR fixes:
Fixes #2186 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82ebe2d</samp>

Improve pod annotation update logic in `pod.go` by using merge patch and enhancing error logging.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 82ebe2d</samp>

> _Oh we patch the pods with `merge patch` method_
> _Heave away, me hearties, heave away_
> _We avoid the conflicts and log the errors well_
> _Heave away, me hearties, heave away_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82ebe2d</samp>

* Use merge patch instead of strategic merge patch to update pod annotations in `reconcileAllocateSubnets` and `reconcileRouteSubnets` functions to avoid conflicts with other controllers ([link](https://github.com/kubeovn/kube-ovn/pull/2694/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L670-R676), [link](https://github.com/kubeovn/kube-ovn/pull/2694/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L810-R817))
* Add log message for patch generation error in `reconcileAllocateSubnets` and `reconcileRouteSubnets` functions ([link](https://github.com/kubeovn/kube-ovn/pull/2694/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L670-R676), [link](https://github.com/kubeovn/kube-ovn/pull/2694/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L810-R817))