### PR TITLE
kubectl-ko: add support for tracing nodes

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -415,6 +415,7 @@ trace(){
           echo "Error: invalid ARP type $4"
           echo "Usage:"
           echo "  kubectl ko trace {namespace/podname} {target ip address} [target mac address] arp {request|reply}"
+          echo "  kubectl ko trace {node//nodename} {target ip address} [target mac address] arp {request|reply}"
           exit 1
           ;;
       esac
@@ -424,6 +425,8 @@ trace(){
       echo "Usage:"
       echo "  kubectl ko trace {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]"
       echo "  kubectl ko trace {namespace/podname} {target ip address} [target mac address] arp {request|reply}"
+      echo "  kubectl ko trace {node//nodename} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]"
+      echo "  kubectl ko trace {node//nodename} {target ip address} [target mac address] arp {request|reply}"
       exit 1
       ;;
   esac

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -22,6 +22,8 @@ showHelp(){
   echo "  trace ...    trace ovn microflow of specific packet"
   echo "    trace {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]    trace ICMP/TCP/UDP"
   echo "    trace {namespace/podname} {target ip address} [target mac address] arp {request|reply}                     trace ARP request/reply"
+  echo "    trace {node//nodename} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]       trace ICMP/TCP/UDP"
+  echo "    trace {node//nodename} {target ip address} [target mac address] arp {request|reply}                        trace ARP request/reply"
   echo "  diagnose {all|node} [nodename]    diagnose connectivity of all nodes or a specific node"
   echo "  env-check    check the environment configuration"
   echo "  tuning {install-fastpath|local-install-fastpath|remove-fastpath|install-stt|local-install-stt|remove-stt} {centos7|centos8}} [kernel-devel-version]    deploy kernel optimisation components to the system"
@@ -172,47 +174,60 @@ tcpdump(){
 
 trace(){
   set +u
-  namespacedPod="$1"
-  namespace=$(echo "$namespacedPod" | cut -d "/" -f1)
-  podName=$(echo "$namespacedPod" | cut -d "/" -f2)
-  if [ "$podName" = "$namespacedPod" ]; then
-    namespace="default"
+  local lsp= namespace= node= typedName= optNamespace=
+  if [[ "$1" =~ .*//.* ]]; then
+    node=${1##*/}
+    typedName="node/$node"
+    lsp=$(kubectl get $typedName -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/port_name})
+  else
+    namespacedPod="$1"
+    namespace=$(echo "$namespacedPod" | cut -d "/" -f1)
+    podName=$(echo "$namespacedPod" | cut -d "/" -f2)
+    if [ "$podName" = "$namespacedPod" ]; then
+      namespace="default"
+    fi
+    typedName="pod/$podName"
+    optNamespace="-n $namespace"
+    lsp="$podName.$namespace"
+    node=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
   fi
 
-  dst="$2"
+  local dst="$2"
   if [ -z "$dst" ]; then
     echo "Error: missing target IP address"
     exit 1
   fi
 
-  hostNetwork=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.hostNetwork})
-  if [ "$hostNetwork" = "true" ]; then
-    echo "Can not trace host network pod"
-    exit 1
-  fi
-
-  af="4"
-  nw="nw"
-  proto=""
-  if [[ "$dst" =~ .*:.* ]]; then
-    af="6"
-    nw="ipv6"
-    proto="6"
-  fi
-
-  dstMac=""
+  local dstMac=
   if echo "$3" | grep -qE '^([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}$'; then
     dstMac=$3
     shift
   fi
 
-  type="$3"
+  local type="$3"
   if [ -z "$type" ]; then
     echo "Error: missing protocol"
     echo "Usage:"
     echo "  kubectl ko trace {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]"
     echo "  kubectl ko trace {namespace/podname} {target ip address} [target mac address] arp {request|reply}"
+    echo "  kubectl ko trace {node//nodename} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]"
+    echo "  kubectl ko trace {node//nodename} {target ip address} [target mac address] arp {request|reply}"
     exit 1
+  fi
+
+  if [ ! -z $namespace ]; then
+    hostNetwork=$(kubectl get "$typedName" -n "$namespace" -o jsonpath={.spec.hostNetwork})
+    if [ "$hostNetwork" = "true" ]; then
+      echo "Can not trace host network pod"
+      exit 1
+    fi
+  fi
+
+  local af="4" nw="nw" proto=
+  if [[ "$dst" =~ .*:.* ]]; then
+    af="6"
+    nw="ipv6"
+    proto="6"
   fi
 
   if [ "$type" = "arp" ]; then
@@ -222,48 +237,47 @@ trace(){
     fi
   fi
 
-  podIPs=($(kubectl get pod "$podName" -n "$namespace" -o jsonpath="{.status.podIPs[*].ip}"))
-  if [ ${#podIPs[@]} -eq 0 ]; then
-    podIPs=($(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/ip_address} | sed 's/,/ /g'))
-    if [ ${#podIPs[@]} -eq 0 ]; then
-      echo "Error: Pod address not ready"
-      exit 1
-    fi
+  local ips=($(kubectl get "$typedName" $optNamespace -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/ip_address} | sed 's/,/ /g'))
+  if [ ${#ips[@]} -eq 0 ]; then
+    echo "Error: $typedName address not ready"
+    exit 1
+  fi
+  if [ ! -n "$namespace" -a "$type" != "arp" ]; then
+    ips=($(kubectl get $typedName -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}') ${ips[@]})
   fi
 
-  podIP=""
-  for ip in ${podIPs[@]}; do
+  local srcIP=""
+  for ip in ${ips[@]}; do
     if [ "$af" = "4" ]; then
       if [[ ! "$ip" =~ .*:.* ]]; then
-        podIP=$ip
+        srcIP=$ip
         break
       fi
     elif [[ "$ip" =~ .*:.* ]]; then
-      podIP=$ip
+      srcIP=$ip
       break
     fi
   done
 
-  if [ -z "$podIP" ]; then
-    echo "Error: Pod $namespacedPod has no IPv$af address"
+  if [ -z "$srcIP" ]; then
+    echo "Error: $typedName has no IPv$af address"
     exit 1
   fi
 
-  nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
-  ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
+  local ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$node'")].metadata.name}')
   if [ -z "$ovnCni" ]; then
     echo "Error: no kube-ovn-cni Pod running on node $nodeName"
     exit 1
   fi
 
-  ls=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/logical_switch})
+  local ls=$(kubectl get "$typedName" $optNamespace -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/logical_switch})
   if [ -z "$ls" ]; then
-    echo "Error: Pod address not ready"
+    echo "Error: $typedName address not ready"
     exit 1
   fi
 
-  local cidr=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/cidr})
-  mac=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/mac_address})
+  local cidr=$(kubectl get "$typedName" $optNamespace -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/cidr})
+  local mac=$(kubectl get "$typedName" $optNamespace -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/mac_address})
 
   if [ "$type" != "arp" -o "$4" = "reply" ]; then
     # need destination mac
@@ -286,8 +300,8 @@ trace(){
         exit 1
       fi
 
-      vlan=$(kubectl get subnet "$ls" -o jsonpath={.spec.vlan})
-      logicalGateway=$(kubectl get subnet "$ls" -o jsonpath={.spec.logicalGateway})
+      local vlan=$(kubectl get subnet "$ls" -o jsonpath={.spec.vlan})
+      local logicalGateway=$(kubectl get subnet "$ls" -o jsonpath={.spec.logicalGateway})
       if [ ! -z "$vlan" -a "$logicalGateway" != "true" ]; then
         gateway=$(kubectl get subnet "$ls" -o jsonpath={.spec.gateway})
         if [[ "$gateway" =~ .*,.* ]]; then
@@ -298,40 +312,45 @@ trace(){
           fi
         fi
 
-        nicName=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$podName"."$namespace" | tr -d '\r')
+        local nicName=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$lsp" | tr -d '\r')
         if [ -z "$nicName" ]; then
-          echo "Error: failed to find ovs interface for Pod namespacedPod on node $nodeName"
+          echo "Error: failed to find ovs interface for LSP $lsp"
           exit 1
         fi
 
-        podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-        podNetNs=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
+        local podNicType=$(kubectl get "$typedName" $optNamespace -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
+        local podNetNs=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
+        local nicName= nsenterCmd=
+        if [ ! -z $podNetNs ]; then
+          nsenterCmd="nsenter --net='$podNetNs'"
+        fi
         if [ "$podNicType" != "internal-port" ]; then
-          interface=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=name find interface external_id:iface-id="$podName"."$namespace")
-          peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ip link show $interface | grep -oE "^[0-9]+:\\s$interface@if[0-9]+" | awk -F @ '{print $2}')
-          peerIndex=${peer//if/}
-          peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ip link show type veth | grep "^$peerIndex:" | awk -F @ '{print $1}')
+          local interface=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=name find interface external_id:iface-id="$lsp")
+          local peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ip link show $interface | grep -oE "^[0-9]+:\\s$interface@if[0-9]+" | awk -F @ '{print $2}')
+          local peerIndex=${peer//if/}
+          local peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- $nsenterCmd ip link show type veth | grep "^$peerIndex:" | awk -F @ '{print $1}')
           nicName=$(echo $peer | awk '{print $2}')
         fi
 
         set +o pipefail
-        master=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ip link show $nicName | grep -Eo '\smaster\s\w+\s' | awk '{print $2}')
+        local master=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- $nsenterCmd ip link show $nicName | grep -Eo '\smaster\s\w+\s' | awk '{print $2}')
         set -o pipefail
         if [ ! -z "$master" ]; then
           echo "Error: Pod nic $nicName is a slave of $master, please set the destination mac address."
           exit 1
         fi
 
+        local cmd= output=
         if [[ "$gateway" =~ .*:.* ]]; then
           cmd="ndisc6 -q $gateway $nicName"
-          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" ndisc6 -q "$gateway" "$nicName")
+          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- $nsenterCmd ndisc6 -q "$gateway" "$nicName")
         else
           cmd="arping -c3 -C1 -i1 -I $nicName $gateway"
-          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" arping -c3 -C1 -i1 -I "$nicName" "$gateway")
+          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- $nsenterCmd arping -c3 -C1 -i1 -I "$nicName" "$gateway")
         fi
 
         if [ $? -ne 0 ]; then
-          echo "Error: failed to execute '$cmd' in Pod's netns"
+          echo "Error: failed to execute '$cmd' in $typedName"
           exit 1
         fi
 
@@ -341,7 +360,7 @@ trace(){
 
     if [ -z "$dstMac" ]; then
       echo "Using the gateway mac address as destination"
-      lr=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/logical_router})
+      local lr=$(kubectl get "$typedName" $optNamespace -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/logical_router})
       if [ -z "$lr" ]; then
         lr=$(kubectl get subnet "$ls" -o jsonpath={.spec.vpc})
       fi
@@ -359,39 +378,38 @@ trace(){
     dstMac="ff:ff:ff:ff:ff:ff"
   fi
 
-  lsp="$podName.$namespace"
-  lspUUID=$(kubectl exec $OVN_NB_POD -n $KUBE_OVN_NS -c ovn-central -- ovn-nbctl --data=bare --no-heading --columns=_uuid find logical_switch_port name="$lsp")
+  local lspUUID=$(kubectl exec $OVN_NB_POD -n $KUBE_OVN_NS -c ovn-central -- ovn-nbctl --data=bare --no-heading --columns=_uuid find logical_switch_port name="$lsp")
   if [ -z "$lspUUID" ]; then
     echo "Notice: LSP $lsp does not exist"
   fi
-  vmOwner=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[?(@.kind=="VirtualMachineInstance")].name}')
+  local vmOwner=$(kubectl get "$typedName" $optNamespace -o jsonpath='{.metadata.ownerReferences[?(@.kind=="VirtualMachineInstance")].name}')
   if [ ! -z "$vmOwner" ]; then
     lsp="$vmOwner.$namespace"
   fi
 
   if [ -z "$lsp" ]; then
-    echo "Error: failed to get LSP of Pod $namespace/$podName"
+    echo "Error: failed to get LSP of $typedName"
     exit 1
   fi
 
   case $type in
     icmp)
       set -x
-      kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace "$ls" "inport == \"$lsp\" && ip.ttl == 64 && icmp && eth.src == $mac && ip$af.src == $podIP && eth.dst == $dstMac && ip$af.dst == $dst && ct.new"
+      kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace "$ls" "inport == \"$lsp\" && ip.ttl == 64 && icmp && eth.src == $mac && ip$af.src == $srcIP && eth.dst == $dstMac && ip$af.dst == $dst && ct.new"
       ;;
     tcp|udp)
       set -x
-      kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace "$ls" "inport == \"$lsp\" && ip.ttl == 64 && eth.src == $mac && ip$af.src == $podIP && eth.dst == $dstMac && ip$af.dst == $dst && $type.src == 10000 && $type.dst == $4 && ct.new"
+      kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace "$ls" "inport == \"$lsp\" && ip.ttl == 64 && eth.src == $mac && ip$af.src == $srcIP && eth.dst == $dstMac && ip$af.dst == $dst && $type.src == 10000 && $type.dst == $4 && ct.new"
       ;;
     arp)
       case "$4" in
         ""|request)
           set -x
-          kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace "$ls" "inport == \"$lsp\" && eth.src == $mac && eth.dst == $dstMac && arp.op == 1 && arp.sha == $mac && arp.tha == 00:00:00:00:00:00 && arp.spa == $podIP && arp.tpa == $dst"
+          kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace "$ls" "inport == \"$lsp\" && eth.src == $mac && eth.dst == $dstMac && arp.op == 1 && arp.sha == $mac && arp.tha == 00:00:00:00:00:00 && arp.spa == $srcIP && arp.tpa == $dst"
           ;;
         reply)
           set -x
-          kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace "$ls" "inport == \"$lsp\" && eth.src == $mac && eth.dst == $dstMac && arp.op == 2 && arp.sha == $mac && arp.tha == $dstMac && arp.spa == $podIP && arp.tpa == $dst"
+          kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-trace "$ls" "inport == \"$lsp\" && eth.src == $mac && eth.dst == $dstMac && arp.op == 2 && arp.sha == $mac && arp.tha == $dstMac && arp.spa == $srcIP && arp.tpa == $dst"
           ;;
         *)
           echo "Error: invalid ARP type $4"
@@ -416,25 +434,25 @@ trace(){
   echo ""
   echo ""
 
-  inPort=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=ofport find interface external_id:iface-id="$podName"."$namespace")
+  local inPort=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=ofport find interface external_id:iface-id="$lsp")
   case $type in
     icmp)
       set -x
-      kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,icmp$proto,nw_ttl=64,${nw}_src=$podIP,${nw}_dst=$dst,dl_src=$mac,dl_dst=$dstMac"
+      kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,icmp$proto,nw_ttl=64,${nw}_src=$srcIP,${nw}_dst=$dst,dl_src=$mac,dl_dst=$dstMac"
       ;;
     tcp|udp)
       set -x
-      kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,$type$proto,nw_ttl=64,${nw}_src=$podIP,${nw}_dst=$dst,dl_src=$mac,dl_dst=$dstMac,${type}_src=1000,${type}_dst=$4"
+      kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,$type$proto,nw_ttl=64,${nw}_src=$srcIP,${nw}_dst=$dst,dl_src=$mac,dl_dst=$dstMac,${type}_src=1000,${type}_dst=$4"
       ;;
     arp)
       case "$4" in
         ""|request)
           set -x
-          kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,arp,arp_op=1,dl_src=$mac,dl_dst=$dstMac,arp_spa=$podIP,arp_tpa=$dst,arp_sha=$mac,arp_tha=00:00:00:00:00:00"
+          kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,arp,arp_op=1,dl_src=$mac,dl_dst=$dstMac,arp_spa=$srcIP,arp_tpa=$dst,arp_sha=$mac,arp_tha=00:00:00:00:00:00"
           ;;
         reply)
           set -x
-          kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,arp,arp_op=2,dl_src=$mac,dl_dst=$dstMac,arp_spa=$podIP,arp_tpa=$dst,arp_sha=$mac,arp_tha=$dstMac"
+          kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-appctl ofproto/trace br-int "in_port=$inPort,arp,arp_op=2,dl_src=$mac,dl_dst=$dstMac,arp_spa=$srcIP,arp_tpa=$dst,arp_sha=$mac,arp_tha=$dstMac"
           ;;
       esac
       ;;

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -142,9 +142,9 @@ func (f *Framework) VersionPriorTo(major, minor uint) bool {
 	return f.ClusterVersionMajor < major || (f.ClusterVersionMajor == major && f.ClusterVersionMinor < minor)
 }
 
-func (f *Framework) SkipVersionPriorTo(major, minor uint, message string) {
+func (f *Framework) SkipVersionPriorTo(major, minor uint, reason string) {
 	if f.VersionPriorTo(major, minor) {
-		ginkgo.Skip(message)
+		ginkgo.Skip(reason)
 	}
 }
 

--- a/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
+++ b/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
@@ -2,6 +2,7 @@ package kubectl_ko
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 
 	clientset "k8s.io/client-go/kubernetes"
@@ -31,27 +32,31 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 
 	var cs clientset.Interface
 	var podClient *framework.PodClient
-	var namespaceName, kubectlConfig string
+	var namespaceName, podName, kubectlConfig string
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet
 		podClient = f.PodClient()
 		namespaceName = f.Namespace.Name
+		podName = "pod-" + framework.RandomSuffix()
 		kubectlConfig = k8sframework.TestContext.KubeConfig
 		k8sframework.TestContext.KubeConfig = ""
 	})
 	ginkgo.AfterEach(func() {
 		k8sframework.TestContext.KubeConfig = kubectlConfig
+
+		ginkgo.By("Deleting pod " + podName)
+		podClient.DeleteSync(podName)
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko nbctl show"`, func() {
+	framework.ConformanceIt(`should support "kubectl ko nbctl show"`, func() {
 		execOrDie("ko nbctl show")
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko sbctl show"`, func() {
+	framework.ConformanceIt(`should support "kubectl ko sbctl show"`, func() {
 		execOrDie("ko sbctl show")
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko vsctl <node> show"`, func() {
+	framework.ConformanceIt(`should support "kubectl ko vsctl <node> show"`, func() {
 		ginkgo.By("Getting nodes")
 		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)
@@ -61,7 +66,7 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 		}
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko ofctl <node> show br-int"`, func() {
+	framework.ConformanceIt(`should support "kubectl ko ofctl <node> show br-int"`, func() {
 		ginkgo.By("Getting nodes")
 		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)
@@ -71,7 +76,7 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 		}
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko dpctl <node> show"`, func() {
+	framework.ConformanceIt(`should support "kubectl ko dpctl <node> show"`, func() {
 		ginkgo.By("Getting nodes")
 		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)
@@ -81,7 +86,7 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 		}
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko appctl <node> list-commands"`, func() {
+	framework.ConformanceIt(`should support "kubectl ko appctl <node> list-commands"`, func() {
 		ginkgo.By("Getting nodes")
 		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)
@@ -91,7 +96,7 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 		}
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko nb/sb status/backup"`, func() {
+	framework.ConformanceIt(`should support "kubectl ko nb/sb status/backup"`, func() {
 		databases := [...]string{"nb", "sb"}
 		actions := [...]string{"status", "backup"}
 		for _, db := range databases {
@@ -102,48 +107,112 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 		}
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko tcpdump <pod> -c1"`, func() {
-		name := "pod-" + framework.RandomSuffix()
-		ginkgo.By("Creating pod " + name)
+	framework.ConformanceIt(`should support "kubectl ko tcpdump <pod> -c1"`, func() {
 		ping, target := "ping", targetIPv4
 		if f.IPv6() {
 			ping, target = "ping6", targetIPv6
 		}
 
+		ginkgo.By("Creating pod " + podName)
 		cmd := []string{"sh", "-c", fmt.Sprintf(`while true; do %s -c1 -w1 %s; sleep 1; done`, ping, target)}
-		pod := framework.MakePod(namespaceName, name, nil, nil, framework.BusyBoxImage, cmd, nil)
+		pod := framework.MakePod(namespaceName, podName, nil, nil, framework.BusyBoxImage, cmd, nil)
 		pod.Spec.TerminationGracePeriodSeconds = new(int64)
 		pod = podClient.CreateSync(pod)
 
 		execOrDie(fmt.Sprintf("ko tcpdump %s/%s -c1", pod.Namespace, pod.Name))
-
-		ginkgo.By("Deleting pod " + name)
-		podClient.DeleteSync(pod.Name)
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko trace <pod> <args...>"`, func() {
-		name := "pod-" + framework.RandomSuffix()
-		ginkgo.By("Creating pod " + name)
-		pod := framework.MakePod(namespaceName, name, nil, nil, "", nil, nil)
+	framework.ConformanceIt(`should support "kubectl ko trace <pod> <args...>"`, func() {
+		ginkgo.By("Creating pod " + podName)
+		pod := framework.MakePod(namespaceName, podName, nil, nil, "", nil, nil)
 		pod = podClient.CreateSync(pod)
 
-		for _, ip := range pod.Status.PodIPs {
-			target := targetIPv4
-			if util.CheckProtocol(ip.IP) == apiv1.ProtocolIPv6 {
-				target = targetIPv6
-			}
-
-			prefix := fmt.Sprintf("ko trace %s/%s %s", pod.Namespace, pod.Name, target)
-			execOrDie(fmt.Sprintf("%s icmp", prefix))
-			execOrDie(fmt.Sprintf("%s tcp 80", prefix))
-			execOrDie(fmt.Sprintf("%s udp 53", prefix))
+		supportARP := !f.VersionPriorTo(1, 11)
+		supportDstMAC := !f.VersionPriorTo(1, 10)
+		if !supportARP {
+			framework.Logf("Support for ARP was introduce in v1.11")
+		}
+		if !supportDstMAC {
+			framework.Logf("Support for destination MAC was introduce in v1.10")
 		}
 
-		ginkgo.By("Deleting pod " + name)
-		podClient.DeleteSync(pod.Name)
+		for _, ip := range pod.Status.PodIPs {
+			target, testARP := targetIPv4, supportARP
+			if util.CheckProtocol(ip.IP) == apiv1.ProtocolIPv6 {
+				target, testARP = targetIPv6, false
+			}
+
+			targetMAC := util.GenerateMac()
+			prefix := fmt.Sprintf("ko trace %s/%s %s", pod.Namespace, pod.Name, target)
+			if testARP {
+				execOrDie(fmt.Sprintf("%s %s arp reply", prefix, targetMAC))
+			}
+
+			targetMACs := []string{"", targetMAC}
+			for _, mac := range targetMACs {
+				if mac != "" && !supportDstMAC {
+					continue
+				}
+				if testARP {
+					execOrDie(fmt.Sprintf("%s %s arp request", prefix, mac))
+				}
+				execOrDie(fmt.Sprintf("%s %s arp", prefix, mac))
+				execOrDie(fmt.Sprintf("%s %s icmp", prefix, mac))
+				execOrDie(fmt.Sprintf("%s %s tcp 80", prefix, mac))
+				execOrDie(fmt.Sprintf("%s %s udp 53", prefix, mac))
+			}
+		}
 	})
 
-	framework.ConformanceIt(`should succeed to execute "kubectl ko log kube-ovn all"`, func() {
+	framework.ConformanceIt(`should support "kubectl ko trace <node> <args...>"`, func() {
+		f.SkipVersionPriorTo(1, 12, "This feature was introduce in v1.12")
+
+		ginkgo.By("Getting nodes")
+		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
+		framework.ExpectNotNil(nodeList)
+		framework.ExpectNotEmpty(nodeList.Items)
+		node := nodeList.Items[rand.Intn(len(nodeList.Items))]
+
+		supportARP := !f.VersionPriorTo(1, 11)
+		supportDstMAC := !f.VersionPriorTo(1, 10)
+		if !supportARP {
+			framework.Logf("Support for ARP was introduce in v1.11")
+		}
+		if !supportDstMAC {
+			framework.Logf("Support for destination MAC was introduce in v1.10")
+		}
+
+		nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(node)
+		for _, ip := range []string{nodeIPv4, nodeIPv6} {
+			target, testARP := targetIPv4, supportARP
+			if util.CheckProtocol(ip) == apiv1.ProtocolIPv6 {
+				target, testARP = targetIPv6, false
+			}
+
+			targetMAC := util.GenerateMac()
+			prefix := fmt.Sprintf("ko trace node//%s %s", node.Name, target)
+			if testARP {
+				execOrDie(fmt.Sprintf("%s %s arp reply", prefix, targetMAC))
+			}
+
+			targetMACs := []string{"", targetMAC}
+			for _, mac := range targetMACs {
+				if mac != "" && !supportDstMAC {
+					continue
+				}
+				if testARP {
+					execOrDie(fmt.Sprintf("%s %s arp request", prefix, mac))
+				}
+				execOrDie(fmt.Sprintf("%s %s arp", prefix, mac))
+				execOrDie(fmt.Sprintf("%s %s icmp", prefix, mac))
+				execOrDie(fmt.Sprintf("%s %s tcp 80", prefix, mac))
+				execOrDie(fmt.Sprintf("%s %s udp 53", prefix, mac))
+			}
+		}
+	})
+
+	framework.ConformanceIt(`should support "kubectl ko log kube-ovn all"`, func() {
 		f.SkipVersionPriorTo(1, 12, "This feature was introduce in v1.12")
 		components := [...]string{"kube-ovn", "ovn", "ovs", "linux", "all"}
 		for _, component := range components {

--- a/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
+++ b/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
@@ -154,9 +154,9 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 					continue
 				}
 				if testARP {
+					execOrDie(fmt.Sprintf("%s %s arp", prefix, mac))
 					execOrDie(fmt.Sprintf("%s %s arp request", prefix, mac))
 				}
-				execOrDie(fmt.Sprintf("%s %s arp", prefix, mac))
 				execOrDie(fmt.Sprintf("%s %s icmp", prefix, mac))
 				execOrDie(fmt.Sprintf("%s %s tcp 80", prefix, mac))
 				execOrDie(fmt.Sprintf("%s %s udp 53", prefix, mac))
@@ -202,9 +202,9 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 					continue
 				}
 				if testARP {
+					execOrDie(fmt.Sprintf("%s %s arp", prefix, mac))
 					execOrDie(fmt.Sprintf("%s %s arp request", prefix, mac))
 				}
-				execOrDie(fmt.Sprintf("%s %s arp", prefix, mac))
 				execOrDie(fmt.Sprintf("%s %s icmp", prefix, mac))
 				execOrDie(fmt.Sprintf("%s %s tcp 80", prefix, mac))
 				execOrDie(fmt.Sprintf("%s %s udp 53", prefix, mac))

--- a/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
+++ b/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
@@ -185,6 +185,9 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 
 		nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(node)
 		for _, ip := range []string{nodeIPv4, nodeIPv6} {
+			if ip == "" {
+				continue
+			}
 			target, testARP := targetIPv4, supportARP
 			if util.CheckProtocol(ip) == apiv1.ProtocolIPv6 {
 				target, testARP = targetIPv6, false


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Features

### Which issue(s) this PR fixes:
Fixes #2473 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd8f2db</samp>

This pull request enhances the test coverage and readability of the `kubectl_ko` package by adding new test cases, improving existing ones, and renaming some parameters. It also modifies the `test/e2e/framework/framework.go` file to align the parameter name of the `SkipVersionPriorTo` function with the `ginkgo.Skip` function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bd8f2db</samp>

> _Oh we are the `kubectl_ko` crew, and we test our code with ginkgo_
> _We skip the versions that are old, and we give a reason why we do so_
> _Heave away, heave away, heave away on the count of three_
> _We trace the pods with different modes, and we clean them up when we are free_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd8f2db</samp>

*  Rename `message` parameter to `reason` in `SkipVersionPriorTo` function to match `ginkgo.Skip` ([link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-c354587e36151f73f4a4da62c22d612510bee633ada8a52ed16b89c7185f0283L145-R147))
* Import `math/rand` package to `kubectl_ko` package for random node selection ([link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8R5))
* Add `podName` variable to `BeforeEach` block of `kubectl_ko` package to store a random pod name for each test case ([link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L34-R40))
* Delete pod created by each test case using `podName` variable in `AfterEach` block of `kubectl_ko` package ([link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L44-R59))
* Change test descriptions from "should succeed to execute" to "should support" for clarity and consistency in `kubectl_ko` package ([link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L64-R69), [link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L74-R79), [link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L84-R89), [link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L94-R99), [link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L105-R110), [link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L113-R215))
* Simplify test case for `kubectl ko tcpdump` command by reusing `podName` variable ([link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L105-R110))
* Modify test case for `kubectl ko trace` command to support different plugin versions and test different protocols and parameters ([link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L113-R215))
* Add test case for `kubectl ko trace` command with node as the target to test node tracing feature ([link](https://github.com/kubeovn/kube-ovn/pull/2697/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L113-R215))