### PR TITLE
fix: iptables nat gw e2e not clean sts eth0 net1 ip

### DIFF
--- a/test/e2e/framework/ip.go
+++ b/test/e2e/framework/ip.go
@@ -1,0 +1,141 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	v1 "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/typed/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// IpClient is a struct for Ip client.
+type IpClient struct {
+	f *Framework
+	v1.IPInterface
+}
+
+func (f *Framework) IpClient() *IpClient {
+	return &IpClient{
+		f:           f,
+		IPInterface: f.KubeOVNClientSet.KubeovnV1().IPs(),
+	}
+}
+
+func (c *IpClient) Get(name string) *apiv1.IP {
+	Ip, err := c.IPInterface.Get(context.TODO(), name, metav1.GetOptions{})
+	ExpectNoError(err)
+	return Ip.DeepCopy()
+}
+
+// Create creates a new Ip according to the framework specifications
+func (c *IpClient) Create(Ip *apiv1.IP) *apiv1.IP {
+	Ip, err := c.IPInterface.Create(context.TODO(), Ip, metav1.CreateOptions{})
+	ExpectNoError(err, "Error creating Ip")
+	return Ip.DeepCopy()
+}
+
+// CreateSync creates a new IP according to the framework specifications, and waits for it to be ready.
+func (c *IpClient) CreateSync(Ip *apiv1.IP) *apiv1.IP {
+	Ip = c.Create(Ip)
+	ExpectTrue(c.WaitToBeReady(Ip.Name, timeout))
+	// Get the newest IP after it becomes ready
+	return c.Get(Ip.Name).DeepCopy()
+}
+
+// WaitToBeReady returns whether the IP is ready within timeout.
+func (c *IpClient) WaitToBeReady(name string, timeout time.Duration) bool {
+	Logf("Waiting up to %v for IP %s to be ready", timeout, name)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
+		ip := c.Get(name)
+		if ip.Spec.V4IPAddress != "" || ip.Spec.V6IPAddress != "" {
+			Logf("IP %s is ready ", name)
+			return true
+		}
+		Logf("IP %s is not ready ", name)
+	}
+	Logf("IP %s was not ready within %v", name, timeout)
+	return false
+}
+
+// Patch patches the Ip
+func (c *IpClient) Patch(original, modified *apiv1.IP, timeout time.Duration) *apiv1.IP {
+	patch, err := util.GenerateMergePatchPayload(original, modified)
+	ExpectNoError(err)
+
+	var patchedIp *apiv1.IP
+	err = wait.PollImmediate(2*time.Second, timeout, func() (bool, error) {
+		p, err := c.IPInterface.Patch(context.TODO(), original.Name, types.MergePatchType, patch, metav1.PatchOptions{}, "")
+		if err != nil {
+			return handleWaitingAPIError(err, false, "patch Ip %q", original.Name)
+		}
+		patchedIp = p
+		return true, nil
+	})
+	if err == nil {
+		return patchedIp.DeepCopy()
+	}
+
+	if IsTimeout(err) {
+		Failf("timed out while retrying to patch Ip %s", original.Name)
+	}
+	ExpectNoError(maybeTimeoutError(err, "patching Ip %s", original.Name))
+
+	return nil
+}
+
+// Delete deletes a Ip if the Ip exists
+func (c *IpClient) Delete(name string) {
+	err := c.IPInterface.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		Failf("Failed to delete Ip %q: %v", name, err)
+	}
+}
+
+// DeleteSync deletes the IP and waits for the IP to disappear for `timeout`.
+// If the IP doesn't disappear before the timeout, it will fail the test.
+func (c *IpClient) DeleteSync(name string) {
+	c.Delete(name)
+	gomega.Expect(c.WaitToDisappear(name, 2*time.Second, timeout)).To(gomega.Succeed(), "wait for ovn eip %q to disappear", name)
+}
+
+// WaitToDisappear waits the given timeout duration for the specified IP to disappear.
+func (c *IpClient) WaitToDisappear(name string, interval, timeout time.Duration) error {
+	var lastIp *apiv1.IP
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		Logf("Waiting for Ip %s to disappear", name)
+		_, err := c.IPInterface.Get(context.TODO(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			Logf("Ip %s no longer exists", name)
+			return true, nil
+		}
+		return false, nil
+	})
+	if IsTimeout(err) {
+		return TimeoutError(fmt.Sprintf("timed out while waiting for IP %s to disappear", name),
+			lastIp,
+		)
+	}
+	return maybeTimeoutError(err, "waiting for IP %s to disappear", name)
+}
+
+func MakeIp(name, ns, subnet string) *apiv1.IP {
+	// pod ip name should including: pod name and namespace
+	// node ip name: only node name
+	Ip := &apiv1.IP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: apiv1.IPSpec{
+			Namespace: ns,
+			Subnet:    subnet,
+		},
+	}
+	return Ip
+}

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -294,8 +294,8 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		err = cs.CoreV1().ConfigMaps("kube-system").Delete(context.Background(), vpcNatGWConfigMapName, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete ConfigMap")
 
+		// the only pod for vpc nat gateway
 		vpcNatGwPodName := "vpc-nat-gw-" + vpcNatGwName + "-0"
-		// -0 means only one pod name for vpc nat gw
 
 		// delete vpc nat gw statefulset remaining ip for eth0 and net1
 		overlaySubnet = subnetClient.Get(overlaySubnetName)

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/docker"
@@ -31,6 +32,7 @@ import (
 const dockerNetworkName = "kube-ovn-vlan"
 const vpcNatGWConfigMapName = "ovn-vpc-nat-gw-config"
 const networkAttachDefName = "ovn-vpc-external-network"
+const vpcNatGwNs = "kube-system"
 const externalSubnetProvider = "ovn-vpc-external-network.kube-system"
 
 var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
@@ -43,12 +45,13 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 	var vpcClient *framework.VpcClient
 	var vpcNatGwClient *framework.VpcNatGatewayClient
 	var subnetClient *framework.SubnetClient
-	var IptablesEIPClient *framework.IptablesEIPClient
 	var fipVipName, fipEipName, fipName, dnatVipName, dnatEipName, dnatName, snatEipName, snatName string
 	var vipClient *framework.VipClient
-	var IptablesFIPClient *framework.IptablesFIPClient
-	var IptablesSnatRuleClient *framework.IptablesSnatClient
-	var IptablesDnatRuleClient *framework.IptablesDnatClient
+	var ipClient *framework.IpClient
+	var iptablesEIPClient *framework.IptablesEIPClient
+	var iptablesFIPClient *framework.IptablesFIPClient
+	var iptablesSnatRuleClient *framework.IptablesSnatClient
+	var iptablesDnatRuleClient *framework.IptablesDnatClient
 
 	var dockerNetwork *dockertypes.NetworkResource
 	var containerID string
@@ -76,11 +79,12 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		subnetClient = f.SubnetClient()
 		vpcClient = f.VpcClient()
 		vpcNatGwClient = f.VpcNatGatewayClient()
-		IptablesEIPClient = f.IptablesEIPClient()
+		iptablesEIPClient = f.IptablesEIPClient()
 		vipClient = f.VipClient()
-		IptablesFIPClient = f.IptablesFIPClient()
-		IptablesSnatRuleClient = f.IptablesSnatClient()
-		IptablesDnatRuleClient = f.IptablesDnatClient()
+		ipClient = f.IpClient()
+		iptablesFIPClient = f.IptablesFIPClient()
+		iptablesSnatRuleClient = f.IptablesSnatClient()
+		iptablesDnatRuleClient = f.IptablesDnatClient()
 
 		if image == "" {
 			image = framework.GetKubeOvnImage(cs)
@@ -152,14 +156,11 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 			framework.ExpectNoError(err)
 		}
 
-		// todo:// statefulset nat gw pod ip not release automatically
-		// these two subnet will not be deleted successfully
+		ginkgo.By("Deleting overlay subnet " + overlaySubnetName)
+		subnetClient.DeleteSync(overlaySubnetName)
 
-		// ginkgo.By("Deleting subnet " + networkAttachDefName)
-		// subnetClient.DeleteSync(networkAttachDefName)
-
-		// ginkgo.By("Deleting overlay subnet " + overlaySubnetName)
-		// subnetClient.DeleteSync(overlaySubnetName)
+		ginkgo.By("Deleting macvlan underlay subnet " + networkAttachDefName)
+		subnetClient.DeleteSync(networkAttachDefName)
 
 		ginkgo.By("Getting nodes")
 		nodes, err := kind.ListNodes(clusterName, "")
@@ -241,17 +242,17 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		fipVip = vipClient.Get(fipVipName)
 		ginkgo.By("Creating iptables eip for fip")
 		fipEip := framework.MakeIptablesEIP(fipEipName, "", "", "", vpcNatGwName)
-		_ = IptablesEIPClient.CreateSync(fipEip)
+		_ = iptablesEIPClient.CreateSync(fipEip)
 		ginkgo.By("Creating iptables fip")
 		fip := framework.MakeIptablesFIPRule(fipName, fipEipName, fipVip.Status.V4ip)
-		_ = IptablesFIPClient.CreateSync(fip)
+		_ = iptablesFIPClient.CreateSync(fip)
 
 		ginkgo.By("Creating iptables eip for snat")
 		snatEip := framework.MakeIptablesEIP(snatEipName, "", "", "", vpcNatGwName)
-		_ = IptablesEIPClient.CreateSync(snatEip)
+		_ = iptablesEIPClient.CreateSync(snatEip)
 		ginkgo.By("Creating iptables snat")
 		snat := framework.MakeIptablesSnatRule(snatName, snatEipName, overlaySubnetV4Cidr)
-		_ = IptablesSnatRuleClient.CreateSync(snat)
+		_ = iptablesSnatRuleClient.CreateSync(snat)
 
 		ginkgo.By("Creating iptables vip for dnat")
 		dnatVip := framework.MakeVip(dnatVipName, overlaySubnetName, "", "")
@@ -259,24 +260,24 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		dnatVip = vipClient.Get(dnatVipName)
 		ginkgo.By("Creating iptables eip for dnat")
 		dnatEip := framework.MakeIptablesEIP(dnatEipName, "", "", "", vpcNatGwName)
-		_ = IptablesEIPClient.CreateSync(dnatEip)
+		_ = iptablesEIPClient.CreateSync(dnatEip)
 		ginkgo.By("Creating iptables dnat")
 		dnat := framework.MakeIptablesDnatRule(dnatName, dnatEipName, "80", "tcp", dnatVip.Status.V4ip, "8080")
-		_ = IptablesDnatRuleClient.CreateSync(dnat)
+		_ = iptablesDnatRuleClient.CreateSync(dnat)
 
 		ginkgo.By("Deleting iptables fip " + fipName)
-		IptablesFIPClient.DeleteSync(fipName)
+		iptablesFIPClient.DeleteSync(fipName)
 		ginkgo.By("Deleting iptables dnat " + dnatName)
-		IptablesDnatRuleClient.DeleteSync(dnatName)
+		iptablesDnatRuleClient.DeleteSync(dnatName)
 		ginkgo.By("Deleting iptables snat " + snatName)
-		IptablesSnatRuleClient.DeleteSync(snatName)
+		iptablesSnatRuleClient.DeleteSync(snatName)
 
 		ginkgo.By("Deleting iptables eip " + fipEipName)
-		IptablesEIPClient.DeleteSync(fipEipName)
+		iptablesEIPClient.DeleteSync(fipEipName)
 		ginkgo.By("Deleting iptables eip " + dnatEipName)
-		IptablesEIPClient.DeleteSync(dnatEipName)
+		iptablesEIPClient.DeleteSync(dnatEipName)
 		ginkgo.By("Deleting iptables eip " + snatEipName)
-		IptablesEIPClient.DeleteSync(snatEipName)
+		iptablesEIPClient.DeleteSync(snatEipName)
 
 		ginkgo.By("Deleting vip " + fipVipName)
 		vipClient.DeleteSync(fipVipName)
@@ -292,6 +293,19 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		ginkgo.By("Deleting configmap " + vpcNatGWConfigMapName)
 		err = cs.CoreV1().ConfigMaps("kube-system").Delete(context.Background(), vpcNatGWConfigMapName, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete ConfigMap")
+
+		vpcNatGwPodName := "vpc-nat-gw-" + vpcNatGwName + "-0"
+		// -0 means only one pod name for vpc nat gw
+
+		// delete vpc nat gw statefulset remaining ip for eth0 and net1
+		overlaySubnet = subnetClient.Get(overlaySubnetName)
+		macvlanSubnet = subnetClient.Get(networkAttachDefName)
+		eth0IpName := ovs.PodNameToPortName(vpcNatGwPodName, vpcNatGwNs, overlaySubnet.Spec.Provider)
+		net1IpName := ovs.PodNameToPortName(vpcNatGwPodName, vpcNatGwNs, macvlanSubnet.Spec.Provider)
+		ginkgo.By("Deleting vpc nat gw eth0 ip " + eth0IpName)
+		ipClient.DeleteSync(eth0IpName)
+		ginkgo.By("Deleting vpc nat gw net1 ip " + net1IpName)
+		ipClient.DeleteSync(net1IpName)
 
 		err = networkClient.Delete(context.Background(), networkAttachDefName, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "failed to delete")


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Tests

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d784395</samp>

Add a new `framework` package for e2e testing of the IP resource. The package provides a wrapper for the `v1.IPInterface` and some helper methods for manipulating IPs. The change is part of a pull request that adds e2e tests for the IP feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d784395</samp>

> _`framework` package_
> _wraps IP client interface_
> _for e2e testing_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d784395</samp>

*  Add a new package `framework` to provide a wrapper for the IP client interface (F0)