### PR TITLE
add static route for active-standby centralized subnet when use old a…

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -669,9 +669,9 @@ func (c *Controller) checkGatewayReady() error {
 						continue
 					}
 
-					exist, err := c.checkNodeEcmpRouteExist(ip, cidrBlock)
+					exist, err := c.checkNodeGwRouteExist(ip, cidrBlock)
 					if err != nil {
-						klog.Errorf("get ecmp static route for subnet %v, error %v", subnet.Name, err)
+						klog.Errorf("failed to get static route for subnet %v, error %v", subnet.Name, err)
 						break
 					}
 
@@ -732,7 +732,7 @@ func (c *Controller) checkGatewayReady() error {
 	return nil
 }
 
-func (c *Controller) checkNodeEcmpRouteExist(nodeIp, cidrBlock string) (bool, error) {
+func (c *Controller) checkNodeGwRouteExist(nodeIp, cidrBlock string) (bool, error) {
 	routes, err := c.ovnClient.GetStaticRouteList(c.config.ClusterRouter)
 	if err != nil {
 		klog.Errorf("failed to list static route %v", err)


### PR DESCRIPTION
…ctive gateway node


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

###
The static route for centralized subnet would be deleted in some case, but we still do not get the certain condition.
The route will not be added if the subnet still use old active gateway after route is deleted.
So add an operation to add back static route when use old active gateway for centralized subnet.

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9901c12</samp>

Add static routes for subnets and improve error handling in `subnet.go`

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9901c12</samp>

> _We'll add some static routes for the subnets_
> _With the `tunnel IP` of the gateway nodes_
> _We'll handle errors and log them as we go_
> _And pull up the sail on the count of three_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9901c12</samp>

*  Add static routes for subnets with source IP policy ([link](https://github.com/kubeovn/kube-ovn/pull/2699/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R950-R959),[link](https://github.com/kubeovn/kube-ovn/pull/2699/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L956))