### PR TITLE
fix can not clean the last abandoned snat table rule

### DIFF
--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -378,7 +378,7 @@ func (c *Controller) updateIptablesChain(protocol, table, chain, parent string, 
 		added++
 	}
 	for i := len(existingRules) - 1; i >= len(rules)-added; i-- {
-		if err = c.iptables[protocol].Delete(table, chain, strconv.Itoa(i+added)); err != nil {
+		if err = c.iptables[protocol].Delete(table, chain, strconv.Itoa(i+added+1)); err != nil {
 			klog.Errorf(`failed to delete iptables rule %v: %v`, existingRules[i], err)
 			return err
 		}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 162babe</samp>

Fix gateway iptables rule deletion bug in `updateIptablesChain`. This change ensures that the correct iptables rule is removed when updating the gateway chains in `pkg/daemon/gateway_linux.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 162babe</samp>

> _`updateIptablesChain`_
> _Fixes off-by-one bug now_
> _Winter of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 162babe</samp>

* Fix a bug in `updateIptablesChain` that caused the wrong iptables rule to be deleted when updating the gateway iptables chains ([link](https://github.com/kubeovn/kube-ovn/pull/2701/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L381-R381))