### PR TITLE
refactor: Improving query performance of iptablesEips using caching

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1870,13 +1870,12 @@ func calcDualSubnetStatusIP(subnet *kubeovnv1.Subnet, c *Controller) error {
 	usingIPs += float64(len(vips.Items))
 
 	if subnet.Name == util.VpcExternalNet {
-		eips, err := c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().List(context.Background(), metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector(util.SubnetNameLabel, subnet.Name).String(),
-		})
+		eips, err := c.iptablesEipsLister.List(
+			labels.SelectorFromSet(labels.Set{util.SubnetNameLabel: subnet.Name}))
 		if err != nil {
 			return err
 		}
-		usingIPs += float64(len(eips.Items))
+		usingIPs += float64(len(eips))
 	}
 	v4availableIPs = v4availableIPs - usingIPs
 	if v4availableIPs < 0 {
@@ -1942,13 +1941,12 @@ func calcSubnetStatusIP(subnet *kubeovnv1.Subnet, c *Controller) error {
 	}
 	usingIPs += float64(len(vips.Items))
 	if subnet.Name == util.VpcExternalNet {
-		eips, err := c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().List(context.Background(), metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector(util.SubnetNameLabel, subnet.Name).String(),
-		})
+		eips, err := c.iptablesEipsLister.List(
+			labels.SelectorFromSet(labels.Set{util.SubnetNameLabel: subnet.Name}))
 		if err != nil {
 			return err
 		}
-		usingIPs += float64(len(eips.Items))
+		usingIPs += float64(len(eips))
 	}
 
 	availableIPs = availableIPs - usingIPs

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -395,13 +395,13 @@ func (c *Controller) handleUpdateVpcEip(natGwKey string) error {
 		klog.Error(err)
 		return err
 	}
-	eips, err := c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().List(context.Background(), metav1.ListOptions{})
+	eips, err := c.iptablesEipsLister.List(labels.Everything())
 	if err != nil {
 		err = fmt.Errorf("failed to get eip list, %v", err)
 		klog.Error(err)
 		return err
 	}
-	for _, eip := range eips.Items {
+	for _, eip := range eips {
 		if eip.Spec.NatGwDp == natGwKey && eip.Status.Redo != NAT_GW_CREATED_AT && eip.Annotations[util.VpcNatAnnotation] == "" {
 			klog.V(3).Infof("redo eip %s", eip.Name)
 			if err = c.patchEipStatus(eip.Name, "", NAT_GW_CREATED_AT, "", "", false); err != nil {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e4a6ba</samp>

Refactor controller package to improve performance, readability, and consistency. Use iptables eips lister and label selectors for QoS policy management. Simplify and fix iptables rule generation for vpc eip updates.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5e4a6ba</samp>

> _Sing, O Muse, of the mighty refactorings_
> _That the skilled coders wrought on the controller_
> _To enhance its performance and its beauty_
> _With iptables and label selectors._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e4a6ba</samp>

*  Replace the `fields` package with the `labels` package and use the iptables eips lister instead of the kubeovn client for better performance and consistency in the controller package ([link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L13-R13), [link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92R12))
*  Update the `handleUpdateQoSPolicy` function in `qos_policy.go` to use the iptables eips lister with label selectors and assign the `eip` variable directly from the `eips` slice ([link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L357-R363), [link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L405-R414))
*  Update the `calcDualSubnetStatusIP` and `calcSubnetStatusIP` functions in `subnet.go` to use the iptables eips lister with label selectors ([link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1873-R1878), [link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1945-R1949))
*  Update the `handleUpdateVpcEip` function in `vpc_nat_gateway.go` to use the iptables eips lister with label selectors and assign the `eip` variable directly from the `eips` slice ([link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L398-R398), [link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L404-R404))
*  Update the `addEipQoS` and `deleteEipQoS` functions in `vpc_nat_gw_eip.go` to use the iptables eips lister with label selectors and check the QoS policy sharing status ([link](https://github.com/kubeovn/kube-ovn/pull/2713/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L507-R515))