### PR TITLE
base: remove patch for fixing ofpbuf memory leak

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -11,8 +11,6 @@ RUN apt update && apt install -y git curl
 RUN cd /usr/src/ && \
     git clone -b branch-3.1 --depth=1 https://github.com/openvswitch/ovs.git && \
     cd ovs && \
-    # dpif-netlink.: fix ofpbuf memory leak
-    curl -s https://github.com/kubeovn/ovs/commit/142fdf9e324a0598b1377b0fa7776616e88a6684.patch | git apply && \
     # fix memory leak by ofport_usage and trim memory periodically
     curl -s https://github.com/kubeovn/ovs/commit/25d71867370c9a44c66b973556338de7a4d9bad7.patch | git apply && \
     # increase election timer


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Memory leak in dpif_netlink_open() has been [fixed](https://github.com/openvswitch/ovs/commit/c3559dffcb0436a3ab56bee35d4823c349cfbbc6). Remove the patch used for building base images.

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough