### PR TITLE
update policy route when change from ecmp to active-standby

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1102,6 +1102,17 @@ func (c *Controller) reconcileOvnRoute(subnet *kubeovnv1.Subnet) error {
 					node, err := c.nodesLister.Get(subnet.Status.ActivateGateway)
 					if err == nil && nodeReady(node) {
 						klog.Infof("subnet %s uses the old activate gw %s", subnet.Name, node.Name)
+
+						nodeTunlIPAddr, err := getNodeTunlIP(node)
+						if err != nil {
+							klog.Errorf("failed to get gatewayNode tunnel ip for subnet %s", subnet.Name)
+							return err
+						}
+						nextHop := getNextHopByTunnelIP(nodeTunlIPAddr)
+						if err = c.addPolicyRouteForCentralizedSubnet(subnet, subnet.Status.ActivateGateway, nil, strings.Split(nextHop, ",")); err != nil {
+							klog.Errorf("failed to add active-backup policy route for centralized subnet %s: %v", subnet.Name, err)
+							return err
+						}
 						return nil
 					}
 				}
@@ -1597,12 +1608,12 @@ func (c *Controller) addPolicyRouteForCentralizedSubnet(subnet *kubeovnv1.Subnet
 			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(nodeIP) {
 				continue
 			}
-			exist, err := c.checkPolicyRouteExistForNode(nodeName, cidrBlock, nodeIP)
+			consistent, err := c.checkPolicyRouteConsistent(nodeName, cidrBlock, nodeIP)
 			if err != nil {
-				klog.Errorf("check ecmp policy route exist for subnet %v, error %v", subnet.Name, err)
+				klog.Errorf("failed to check policy route for subnet %v, error %v", subnet.Name, err)
 				continue
 			}
-			if exist {
+			if consistent {
 				continue
 			}
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

集中式子网由 ecmp 模式，切换为主备模式，需要删除非activeGateway 网关节点的策略路由 

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb282d6</samp>

This pull request enhances the support for ECMP routing for centralized subnets in `kube-ovn`. It modifies the `checkPolicyRouteExistForNode` function in `node.go` and the routing logic in `subnet.go` to handle different ECMP scenarios.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cb282d6</samp>

> _Sing, O Muse, of the clever coder who devised_
> _A better way to route the packets of the cloud,_
> _With `checkPolicyRouteExistForNode` he revised_
> _The function to support ECMP, of which he was proud._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb282d6</samp>

*  Modify `checkPolicyRouteExistForNode` to return next hops and node name-ip map for ECMP support ([link](https://github.com/kubeovn/kube-ovn/pull/2716/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1089-R1089))
*  Modify `checkPolicyRouteExistForNode` to check policy route existence based on ECMP configuration ([link](https://github.com/kubeovn/kube-ovn/pull/2716/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1095-R1102))
*  Delete `ActivateGateway` field from subnet status when ECMP is enabled in `reconcileOvnRoute` ([link](https://github.com/kubeovn/kube-ovn/pull/2716/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1063-R1078))
*  Add active-backup policy route for centralized subnet when ECMP is disabled in `reconcileOvnRoute` ([link](https://github.com/kubeovn/kube-ovn/pull/2716/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1121-R1131))