### PR TITLE
add policy route when use old active gateway node for centralized subnet

### DIFF
--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -443,11 +443,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 		subnet = subnetClient.PatchSync(subnet, modifiedSubnet)
 
 		ginkgo.By("Validating active gateway")
-		subnet = subnetClient.WaitUntil(subnetName, func(s *apiv1.Subnet) (bool, error) {
-			return gomega.BeEmpty().Match(s.Status.ActivateGateway)
-		}, "field .status.activateGateway is empty",
-			2*time.Second, time.Minute,
-		)
+		time.Sleep(1 * time.Minute)
 
 		execCmd := "kubectl ko nbctl --format=csv --data=bare --no-heading --columns=nexthops find logical-router-policy " + fmt.Sprintf("external_ids:subnet=%s", subnetName)
 		output, err := exec.Command("bash", "-c", execCmd).CombinedOutput()


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 905d29b</samp>

Improve policy route handling for centralized subnets with ecmp. Remove `activateGateway` field from subnet status and use node's `tunnelIP` as next hop.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 905d29b</samp>

> _We're sailing on the network sea, with policy routes to guide us_
> _We don't need `activateGateway`, we've got `tunnelIP` beside us_
> _So haul away the subnet status, and make the ecmp steady_
> _We'll reach the centralized subnets, with our code review ready_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 905d29b</samp>

* Remove the update of subnet status with activate gateway field for ecmp subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2722/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1537-L1553))
* Use tunnel IP as next hop for policy route for centralized subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2722/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1626-R1636))