### PR TITLE
fix ovn lb gc

### DIFF
--- a/pkg/controller/endpoint.go
+++ b/pkg/controller/endpoint.go
@@ -115,11 +115,8 @@ func (c *Controller) handleUpdateEndpoint(key string) error {
 	}
 	svc := orisvc.DeepCopy()
 
-	clusterIPs := svc.Spec.ClusterIPs
-	if len(clusterIPs) == 0 && svc.Spec.ClusterIP != "" && svc.Spec.ClusterIP != v1.ClusterIPNone {
-		clusterIPs = []string{svc.Spec.ClusterIP}
-	}
-	if len(clusterIPs) == 0 || clusterIPs[0] == v1.ClusterIPNone {
+	clusterIPs := util.ServiceClusterIPs(*svc)
+	if len(clusterIPs) == 0 {
 		return nil
 	}
 

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -743,10 +743,7 @@ func svcMatchPods(svcs []*corev1.Service, pod *corev1.Pod, protocol string) ([]s
 			return nil, err
 		}
 		if isMatch {
-			clusterIPs := svc.Spec.ClusterIPs
-			if len(clusterIPs) == 0 && svc.Spec.ClusterIP != "" && svc.Spec.ClusterIP != corev1.ClusterIPNone {
-				clusterIPs = []string{svc.Spec.ClusterIP}
-			}
+			clusterIPs := util.ServiceClusterIPs(*svc)
 			protocolClusterIPs := getProtocolSvcIp(clusterIPs, protocol)
 			if len(protocolClusterIPs) != 0 {
 				matchSvcs = append(matchSvcs, protocolClusterIPs...)

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -44,3 +44,11 @@ func GetNodeInternalIP(node v1.Node) (ipv4, ipv6 string) {
 
 	return SplitStringIP(strings.Join(ips, ","))
 }
+
+func ServiceClusterIPs(svc v1.Service) []string {
+	ips := svc.Spec.ClusterIPs
+	if len(ips) == 0 && svc.Spec.ClusterIP != v1.ClusterIPNone && svc.Spec.ClusterIP != "" {
+		ips = []string{svc.Spec.ClusterIP}
+	}
+	return ips
+}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes
- Performance


### Which issue(s) this PR fixes:

1. Fix ovn lb vip gc in dual-stack clusters;
2. Improve ovn lb gc performance.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 37b4454</samp>

This pull request enhances the garbage collection of load balancers and adds support for dual-stack services. It refactors the `gcLoadBalancer` function in `pkg/controller/gc.go` to use more efficient data structures and log more information. It also introduces a new helper function `ServiceClusterIPs` in `pkg/util/k8s.go` to get the cluster IPs of a service.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 37b4454</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever helper function, `ServiceClusterIPs`, to slice_
> _The cluster IPs of services, whether one or two or none,_
> _And handle dual-stack cases, both of IPv4 and IPv6._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 37b4454</samp>

*  Import `time` package and record start time of `gcLoadBalancer` function ([link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R7), [link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R326))
* Refactor logic of collecting VIPs of services for load balancers using maps and sets, and use `ServiceClusterIPs` helper function to handle dual-stack services ([link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L388-R411), [link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-b252a3b0a89aaca5bf1056643f9d4dbead04230b3c96aefbb05020c57ebac26fR47-R54))
* Add log messages and simplify conditions for deleting VIPs from TCP, TCP session, UDP, and UDP session load balancers using `ok` idiom ([link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L433-R439), [link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L454-R461), [link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L476-R484), [link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L498-R507))
* Add log message to indicate elapsed time of `gcLoadBalancer` function ([link](https://github.com/kubeovn/kube-ovn/pull/2728/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R535))