### PR TITLE
support node local dns cache

### DIFF
--- a/charts/templates/controller-deploy.yaml
+++ b/charts/templates/controller-deploy.yaml
@@ -106,7 +106,7 @@ spec:
           - --keep-vm-ip={{- .Values.func.ENABLE_KEEP_VM_IP }}
           - --pod-default-fip-type={{- .Values.networking.POD_DEFAULT_FIP_TYPE }}
           - --enable-metrics={{- .Values.networking.ENABLE_METRICS }}
-          - --node-local-dns-cache-ip={{- .Values.networking.NODE_LOCAL_DNS_CACHE_IP }}
+          - --node-local-dns-ip={{- .Values.networking.NODE_LOCAL_DNS_IP }}
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"

--- a/charts/templates/controller-deploy.yaml
+++ b/charts/templates/controller-deploy.yaml
@@ -106,6 +106,7 @@ spec:
           - --keep-vm-ip={{- .Values.func.ENABLE_KEEP_VM_IP }}
           - --pod-default-fip-type={{- .Values.networking.POD_DEFAULT_FIP_TYPE }}
           - --enable-metrics={{- .Values.networking.ENABLE_METRICS }}
+          - --node-local-dns-cache-ip={{- .Values.networking.NODE_LOCAL_DNS_CACHE_IP }}
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"

--- a/charts/templates/ovncni-ds.yaml
+++ b/charts/templates/ovncni-ds.yaml
@@ -52,7 +52,6 @@ spec:
           - --enable-mirror={{- .Values.debug.ENABLE_MIRROR }}
           - --mirror-iface={{- .Values.debug.MIRROR_IFACE }}
           - --node-switch={{ .Values.networking.NODE_SUBNET }}
-          - --node-local-dns-ip={{ .Values.networking.NODE_LOCAL_DNS_IP }}
           - --encap-checksum=true
           - --service-cluster-ip-range=
           {{- if eq .Values.networking.NET_STACK "dual_stack" -}}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -46,7 +46,13 @@ networking:
   NODE_SUBNET: "join"
   ENABLE_ECMP: false
   ENABLE_METRICS: true
+  # NODE_LOCAL_DNS_IP:
+  # this local dns server is customer self-definition,
+  # kube-ovn just put this ip in ipset ovn40subnet or ovn60subnet
   NODE_LOCAL_DNS_IP: ""
+  # NODE_LOCAL_DNS_CACHE_IP:
+  # this feature is to support nodelocaldnscache which is k8s official component
+  NODE_LOCAL_DNS_CACHE_IP: ""
 
 func:
   ENABLE_LB: true

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -46,13 +46,7 @@ networking:
   NODE_SUBNET: "join"
   ENABLE_ECMP: false
   ENABLE_METRICS: true
-  # NODE_LOCAL_DNS_IP:
-  # this local dns server is customer self-definition,
-  # kube-ovn just put this ip in ipset ovn40subnet or ovn60subnet
   NODE_LOCAL_DNS_IP: ""
-  # NODE_LOCAL_DNS_CACHE_IP:
-  # this feature is to support nodelocaldnscache which is k8s official component
-  NODE_LOCAL_DNS_CACHE_IP: ""
 
 func:
   ENABLE_LB: true

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -20,6 +20,7 @@ CNI_CONFIG_PRIORITY=${CNI_CONFIG_PRIORITY:-01}
 ENABLE_LB_SVC=${ENABLE_LB_SVC:-false}
 ENABLE_NAT_GW=${ENABLE_NAT_GW:-false}
 ENABLE_KEEP_VM_IP=${ENABLE_KEEP_VM_IP:-true}
+NODE_LOCAL_DNS_CACHE_IP=${NODE_LOCAL_DNS_CACHE_IP:-}
 # exchange link names of OVS bridge and the provider nic
 # in the default provider-network
 EXCHANGE_LINK_NAME=${EXCHANGE_LINK_NAME:-false}
@@ -3596,6 +3597,7 @@ spec:
           - --enable-lb-svc=$ENABLE_LB_SVC
           - --keep-vm-ip=$ENABLE_KEEP_VM_IP
           - --pod-default-fip-type=$POD_DEFAULT_FIP_TYPE
+          - --node-local-dns-cache-ip=$NODE_LOCAL_DNS_CACHE_IP
           env:
             - name: ENABLE_SSL
               value: "$ENABLE_SSL"

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -20,7 +20,7 @@ CNI_CONFIG_PRIORITY=${CNI_CONFIG_PRIORITY:-01}
 ENABLE_LB_SVC=${ENABLE_LB_SVC:-false}
 ENABLE_NAT_GW=${ENABLE_NAT_GW:-false}
 ENABLE_KEEP_VM_IP=${ENABLE_KEEP_VM_IP:-true}
-NODE_LOCAL_DNS_CACHE_IP=${NODE_LOCAL_DNS_CACHE_IP:-}
+NODE_LOCAL_DNS_IP=${NODE_LOCAL_DNS_IP:-}
 # exchange link names of OVS bridge and the provider nic
 # in the default provider-network
 EXCHANGE_LINK_NAME=${EXCHANGE_LINK_NAME:-false}
@@ -3597,7 +3597,7 @@ spec:
           - --enable-lb-svc=$ENABLE_LB_SVC
           - --keep-vm-ip=$ENABLE_KEEP_VM_IP
           - --pod-default-fip-type=$POD_DEFAULT_FIP_TYPE
-          - --node-local-dns-cache-ip=$NODE_LOCAL_DNS_CACHE_IP
+          - --node-local-dns-ip=$NODE_LOCAL_DNS_IP
           env:
             - name: ENABLE_SSL
               value: "$ENABLE_SSL"

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -99,6 +99,8 @@ type Configuration struct {
 	BfdMinTx      int
 	BfdMinRx      int
 	BfdDetectMult int
+
+	NodeLocalDnsCacheIP string
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -162,6 +164,7 @@ func ParseFlags() (*Configuration, error) {
 		argExternalGatewaySwitch   = pflag.String("external-gateway-switch", "external", "The name of the external gateway switch which is a ovs bridge to provide external network, default: external")
 		argExternalGatewayNet      = pflag.String("external-gateway-net", "external", "The name of the external network which mappings with an ovs bridge, default: external")
 		argExternalGatewayVlanID   = pflag.Int("external-gateway-vlanid", 0, "The vlanId of port ln-ovn-external, default: 0")
+		argNodeLocalDnsCacheIP     = pflag.String("node-local-dns-cache-ip", "", "The node local dns cache ip , this feature is using the local dns cache in k8s")
 
 		argGCInterval      = pflag.Int("gc-interval", 360, "The interval between GC processes, default 360 seconds")
 		argInspectInterval = pflag.Int("inspect-interval", 20, "The interval between inspect processes, default 20 seconds")
@@ -246,6 +249,7 @@ func ParseFlags() (*Configuration, error) {
 		BfdMinTx:                       *argBfdMinTx,
 		BfdMinRx:                       *argBfdMinRx,
 		BfdDetectMult:                  *argBfdDetectMult,
+		NodeLocalDnsCacheIP:            *argNodeLocalDnsCacheIP,
 	}
 
 	if config.NetworkType == util.NetworkTypeVlan && config.DefaultHostInterface == "" {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -100,7 +100,7 @@ type Configuration struct {
 	BfdMinRx      int
 	BfdDetectMult int
 
-	NodeLocalDnsCacheIP string
+	NodeLocalDnsIP string
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -164,7 +164,7 @@ func ParseFlags() (*Configuration, error) {
 		argExternalGatewaySwitch   = pflag.String("external-gateway-switch", "external", "The name of the external gateway switch which is a ovs bridge to provide external network, default: external")
 		argExternalGatewayNet      = pflag.String("external-gateway-net", "external", "The name of the external network which mappings with an ovs bridge, default: external")
 		argExternalGatewayVlanID   = pflag.Int("external-gateway-vlanid", 0, "The vlanId of port ln-ovn-external, default: 0")
-		argNodeLocalDnsCacheIP     = pflag.String("node-local-dns-cache-ip", "", "The node local dns cache ip , this feature is using the local dns cache in k8s")
+		argNodeLocalDnsIP          = pflag.String("node-local-dns-ip", "", "The node local dns ip , this feature is using the local dns cache in k8s")
 
 		argGCInterval      = pflag.Int("gc-interval", 360, "The interval between GC processes, default 360 seconds")
 		argInspectInterval = pflag.Int("inspect-interval", 20, "The interval between inspect processes, default 20 seconds")
@@ -249,7 +249,7 @@ func ParseFlags() (*Configuration, error) {
 		BfdMinTx:                       *argBfdMinTx,
 		BfdMinRx:                       *argBfdMinRx,
 		BfdDetectMult:                  *argBfdDetectMult,
-		NodeLocalDnsCacheIP:            *argNodeLocalDnsCacheIP,
+		NodeLocalDnsIP:                 *argNodeLocalDnsIP,
 	}
 
 	if config.NetworkType == util.NetworkTypeVlan && config.DefaultHostInterface == "" {

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -280,11 +280,11 @@ func (c *Controller) handleAddNode(key string) error {
 			}
 
 			if c.config.NodeLocalDnsIP != "" {
-				pgAs := strings.Replace(fmt.Sprintf("%s_ip%d", portName, af), "-", ".", -1)
-				match := fmt.Sprintf("ip%d.src == $%s && ip%d.dst == %s", af, pgAs, af, c.config.NodeLocalDnsIP)
-				klog.Infof("add node local dns cache policy route for router: %s, match %s, action %s, nexthop %s, externalID %v", c.config.ClusterRouter, match, "reroute", ip, externalIDs)
-				if err = c.ovnLegacyClient.AddPolicyRoute(c.config.ClusterRouter, util.NodeLocalDnsPolicyPriority, match, "reroute", ip, externalIDs); err != nil {
-					klog.Errorf("failed to add logical router policy for node %s: %v", node.Name, err)
+				if err = c.addPolicyRouteForLocalDnsCacheOnNode(portName, ip, node.Name, af); err != nil {
+					return err
+				}
+			} else {
+				if err = c.deletePolicyRouteForLocalDnsCacheOnNode(portName, node.Name, af); err != nil {
 					return err
 				}
 			}
@@ -469,18 +469,15 @@ func (c *Controller) handleDeleteNode(key string) error {
 		return err
 	}
 
-	// ovn acl doesn't support address_set name with '-', so replace '-' by '.'
-	pgName := strings.Replace(portName, "-", ".", -1)
 	afs := []int{4, 6}
 	for _, af := range afs {
-		pgAs := strings.Replace(fmt.Sprintf("%s_ip%d", pgName, af), "-", ".", -1)
-		match := fmt.Sprintf("ip%d.src == $%s && ip%d.dst == %s", af, pgAs, af, c.config.NodeLocalDnsIP)
-		if err := c.ovnLegacyClient.DeletePolicyRoute(c.config.ClusterRouter, util.NodeLocalDnsPolicyPriority, match); err != nil {
-			klog.Errorf("failed to delete policy route for node local dns in router %s with match %s : %v", c.config.ClusterRouter, match, err)
+		if err := c.deletePolicyRouteForLocalDnsCacheOnNode(portName, key, af); err != nil {
 			return err
 		}
 	}
 
+	// ovn acl doesn't support address_set name with '-', so replace '-' by '.'
+	pgName := strings.Replace(portName, "-", ".", -1)
 	if err := c.ovnClient.DeletePortGroup(pgName); err != nil {
 		klog.Errorf("delete port group %s for node: %v", portName, err)
 		return err
@@ -1227,6 +1224,53 @@ func (c *Controller) addPolicyRouteForCentralizedSubnetOnNode(nodeName, nodeIP s
 				klog.Errorf("failed to add active-backup policy route for centralized subnet %s: %v", subnet.Name, err)
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func (c *Controller) addPolicyRouteForLocalDnsCacheOnNode(nodePortName, nodeIP, nodeName string, af int) error {
+	externalIDs := map[string]string{
+		"vendor":          util.CniTypeName,
+		"node":            nodeName,
+		"address-family":  strconv.Itoa(af),
+		"isLocalDnsCache": "true",
+	}
+
+	pgAs := strings.Replace(fmt.Sprintf("%s_ip%d", nodePortName, af), "-", ".", -1)
+	match := fmt.Sprintf("ip%d.src == $%s && ip%d.dst == %s", af, pgAs, af, c.config.NodeLocalDnsIP)
+	klog.Infof("add node local dns cache policy route for router: %s, match %s, action %s, nexthop %s, externalID %v", c.config.ClusterRouter, match, "reroute", nodeIP, externalIDs)
+	if err := c.ovnLegacyClient.AddPolicyRoute(c.config.ClusterRouter, util.NodeLocalDnsPolicyPriority, match, "reroute", nodeIP, externalIDs); err != nil {
+		klog.Errorf("failed to add logical router policy for node %s: %v", nodeName, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) deletePolicyRouteForLocalDnsCacheOnNode(nodePortName, nodeName string, af int) error {
+	results, err := c.ovnLegacyClient.CustomFindEntity("Logical_Router_Policy", []string{"_uuid", "match", "priority"},
+		fmt.Sprintf("external_ids:vendor=\"%s\"", util.CniTypeName),
+		fmt.Sprintf("external_ids:node=\"%s\"", nodeName),
+		fmt.Sprintf("external_ids:address-family=\"%s\"", strconv.Itoa(af)),
+		"external_ids:isLocalDnsCache=\"true\"",
+	)
+	if err != nil {
+		klog.Errorf("customFindEntity failed, %v", err)
+		return err
+	}
+
+	if len(results) == 0 {
+		return nil
+	}
+
+	var uuids []string
+	for _, result := range results {
+		uuids = append(uuids, result["_uuid"][0])
+		klog.Infof("delete node local dns cache policy route for router %s with match %s ", c.config.ClusterRouter, result["match"])
+
+		if err := c.ovnLegacyClient.DeletePolicyRouteByUUID(c.config.ClusterRouter, uuids); err != nil {
+			klog.Errorf("failed to delete policy route for node local dns in router %s with match %s : %v", c.config.ClusterRouter, result["match"], err)
+			return err
 		}
 	}
 	return nil

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -279,12 +279,12 @@ func (c *Controller) handleAddNode(key string) error {
 				return err
 			}
 
+			if err = c.deletePolicyRouteForLocalDnsCacheOnNode(portName, node.Name, af); err != nil {
+				return err
+			}
+
 			if c.config.NodeLocalDnsIP != "" {
 				if err = c.addPolicyRouteForLocalDnsCacheOnNode(portName, ip, node.Name, af); err != nil {
-					return err
-				}
-			} else {
-				if err = c.deletePolicyRouteForLocalDnsCacheOnNode(portName, node.Name, af); err != nil {
 					return err
 				}
 			}

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -279,9 +279,9 @@ func (c *Controller) handleAddNode(key string) error {
 				return err
 			}
 
-			if c.config.NodeLocalDnsCacheIP != "" {
+			if c.config.NodeLocalDnsIP != "" {
 				pgAs := strings.Replace(fmt.Sprintf("%s_ip%d", portName, af), "-", ".", -1)
-				match := fmt.Sprintf("ip%d.src == $%s && ip%d.dst == %s", af, pgAs, af, c.config.NodeLocalDnsCacheIP)
+				match := fmt.Sprintf("ip%d.src == $%s && ip%d.dst == %s", af, pgAs, af, c.config.NodeLocalDnsIP)
 				klog.Infof("add node local dns cache policy route for router: %s, match %s, action %s, nexthop %s, externalID %v", c.config.ClusterRouter, match, "reroute", ip, externalIDs)
 				if err = c.ovnLegacyClient.AddPolicyRoute(c.config.ClusterRouter, util.NodeLocalDnsPolicyPriority, match, "reroute", ip, externalIDs); err != nil {
 					klog.Errorf("failed to add logical router policy for node %s: %v", node.Name, err)
@@ -474,7 +474,7 @@ func (c *Controller) handleDeleteNode(key string) error {
 	afs := []int{4, 6}
 	for _, af := range afs {
 		pgAs := strings.Replace(fmt.Sprintf("%s_ip%d", pgName, af), "-", ".", -1)
-		match := fmt.Sprintf("ip%d.src == $%s && ip%d.dst == %s", af, pgAs, af, c.config.NodeLocalDnsCacheIP)
+		match := fmt.Sprintf("ip%d.src == $%s && ip%d.dst == %s", af, pgAs, af, c.config.NodeLocalDnsIP)
 		if err := c.ovnLegacyClient.DeletePolicyRoute(c.config.ClusterRouter, util.NodeLocalDnsPolicyPriority, match); err != nil {
 			klog.Errorf("failed to delete policy route for node local dns in router %s with match %s : %v", c.config.ClusterRouter, match, err)
 			return err

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -611,7 +611,7 @@ func (c *Controller) reconcileAllocateSubnets(cachedPod, pod *v1.Pod, needAlloca
 		}
 
 		if podNet.Type != providerTypeIPAM {
-			if (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) && subnet.Spec.Vpc != "" {
+			if (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway || subnet.Spec.U2OInterconnection) && subnet.Spec.Vpc != "" {
 				pod.Annotations[fmt.Sprintf(util.LogicalRouterAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.Vpc
 			}
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1205,7 +1205,7 @@ func (c *Controller) reconcileVpcAddNormalStaticRoute(vpcName string) error {
 
 	defualtExternalSubnet, err := c.subnetsLister.Get(c.config.ExternalGatewaySwitch)
 	if err != nil {
-		klog.Error("failed to get default external switch subnet %s: %v", c.config.ExternalGatewaySwitch)
+		klog.Error("failed to get default external switch subnet %s: %v", c.config.ExternalGatewaySwitch, err)
 		return err
 	}
 	gatewayV4, gatewayV6 := util.SplitStringIP(defualtExternalSubnet.Spec.Gateway)

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -44,7 +44,6 @@ type Configuration struct {
 	NodeName                string
 	ServiceClusterIPRange   string
 	NodeSwitch              string
-	NodeLocalDnsIP          string
 	EncapChecksum           bool
 	EnablePprof             bool
 	MacLearningFallback     bool
@@ -75,7 +74,6 @@ func ParseFlags() *Configuration {
 		argKubeConfigFile        = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argServiceClusterIPRange = pflag.String("service-cluster-ip-range", "10.96.0.0/12", "The kubernetes service cluster ip range")
 		argNodeSwitch            = pflag.String("node-switch", "join", "The name of node gateway switch which help node to access pod network")
-		argNodeLocalDnsIP        = pflag.String("node-local-dns-ip", "", "If use nodelocaldns the local dns server ip should be set here.")
 		argEncapChecksum         = pflag.Bool("encap-checksum", true, "Enable checksum")
 		argEnablePprof           = pflag.Bool("enable-pprof", false, "Enable pprof")
 		argPprofPort             = pflag.Int("pprof-port", 10665, "The port to get profiling data")
@@ -128,7 +126,6 @@ func ParseFlags() *Configuration {
 		NodeName:                strings.ToLower(*argNodeName),
 		ServiceClusterIPRange:   *argServiceClusterIPRange,
 		NodeSwitch:              *argNodeSwitch,
-		NodeLocalDnsIP:          *argNodeLocalDnsIP,
 		EncapChecksum:           *argEncapChecksum,
 		NetworkType:             *argsNetworkType,
 		CniConfDir:              *argCniConfDir,

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"net"
 	"os/exec"
 	"strings"
 

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -147,9 +147,7 @@ func (c *Controller) getDefaultVpcSubnetsCIDR(protocol string) ([]string, map[st
 
 	ret := make([]string, 0, len(subnets)+1)
 	subnetMap := make(map[string]string, len(subnets)+1)
-	if c.config.NodeLocalDnsIP != "" && net.ParseIP(c.config.NodeLocalDnsIP) != nil && util.CheckProtocol(c.config.NodeLocalDnsIP) == protocol {
-		ret = append(ret, c.config.NodeLocalDnsIP)
-	}
+
 	for _, subnet := range subnets {
 		if subnet.Spec.Vpc == util.DefaultVpc && (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) && subnet.Spec.CIDRBlock != "" {
 			cidrBlock := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -984,10 +984,10 @@ func (c LegacyClient) CreateGatewayACL(ls, pgName, gateway, cidr string) error {
 					egressArgs = append(egressArgs, []string{"--", "--type=port-group", MayExist, "--apply-after-lb", "acl-add", pgName, "from-lport", util.EgressAllowPriority, `nd || nd_ra || nd_rs`, "allow-related"}...)
 				}
 			} else if ls != "" {
-				ingressArgs = []string{"--", MayExist, "acl-add", ls, "to-lport", util.IngressAllowPriority, fmt.Sprintf(`%s.src == %s`, ipSuffix, gw), "allow-related"}
-				egressArgs = []string{"--", MayExist, "--apply-after-lb", "acl-add", ls, "from-lport", util.EgressAllowPriority, fmt.Sprintf(`%s.dst == %s`, ipSuffix, gw), "allow-related"}
+				ingressArgs = []string{"--", MayExist, "acl-add", ls, "to-lport", util.IngressAllowPriority, fmt.Sprintf(`%s.src == %s`, ipSuffix, gw), "allow-stateless"}
+				egressArgs = []string{"--", MayExist, "--apply-after-lb", "acl-add", ls, "from-lport", util.EgressAllowPriority, fmt.Sprintf(`%s.dst == %s`, ipSuffix, gw), "allow-stateless"}
 				if ipSuffix == "ip6" {
-					egressArgs = append(egressArgs, []string{"--", MayExist, "--apply-after-lb", "acl-add", ls, "from-lport", util.EgressAllowPriority, `nd || nd_ra || nd_rs`, "allow-related"}...)
+					egressArgs = append(egressArgs, []string{"--", MayExist, "--apply-after-lb", "acl-add", ls, "from-lport", util.EgressAllowPriority, `nd || nd_ra || nd_rs`, "allow-stateless"}...)
 				}
 			}
 

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -190,9 +190,10 @@ const (
 	IptablesFip = "iptables"
 
 	GatewayRouterPolicyPriority = 29000
-	NodeRouterPolicyPriority    = 30000
-	SubnetRouterPolicyPriority  = 31000
 	OvnICPolicyPriority         = 29500
+	NodeRouterPolicyPriority    = 30000
+	NodeLocalDnsPolicyPriority  = 30100
+	SubnetRouterPolicyPriority  = 31000
 
 	OffloadType  = "offload-port"
 	InternalType = "internal-port"

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -90,6 +90,7 @@ spec:
             - --enable-lb-svc=false
             - --keep-vm-ip=true
             - --pod-default-fip-type=
+            - --node-local-dns-cache-ip=
           env:
             - name: ENABLE_SSL
               value: "false"

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -90,7 +90,7 @@ spec:
             - --enable-lb-svc=false
             - --keep-vm-ip=true
             - --pod-default-fip-type=
-            - --node-local-dns-cache-ip=
+            - --node-local-dns-ip=
           env:
             - name: ENABLE_SSL
               value: "false"

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -90,6 +90,7 @@ spec:
             - --enable-lb-svc=false
             - --keep-vm-ip=true
             - --pod-default-fip-type=
+            - --node-local-dns-cache-ip=
           env:
             - name: ENABLE_SSL
               value: "false"

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -90,7 +90,7 @@ spec:
             - --enable-lb-svc=false
             - --keep-vm-ip=true
             - --pod-default-fip-type=
-            - --node-local-dns-cache-ip=
+            - --node-local-dns-ip=
           env:
             - name: ENABLE_SSL
               value: "false"

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -90,6 +90,7 @@ spec:
             - --enable-lb-svc=false
             - --keep-vm-ip=true
             - --pod-default-fip-type=
+            - --node-local-dns-cache-ip=
           env:
             - name: ENABLE_SSL
               value: "false"

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -90,7 +90,7 @@ spec:
             - --enable-lb-svc=false
             - --keep-vm-ip=true
             - --pod-default-fip-type=
-            - --node-local-dns-cache-ip=
+            - --node-local-dns-ip=
           env:
             - name: ENABLE_SSL
               value: "false"


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #[2661](https://github.com/kubeovn/kube-ovn/issues/2661)

使用方法： 

1. 按照kube-proxy ipvs的模式安装好localdnscache
2. 修改kube-ovn-controller 在-- -node-local-dns-cache-ip=169.254.20.10
3. 如果是underlay subnet开启u2o，如果是overlay不需要
4. 重建现有pod


流量走向：
overlay，分布式和集中网关都是走本地ovn0到达节点。
underlay 打开u2o后，走join子网，到达本地ovn0到达节点

功能一些不足：
一旦创建了networkpolicy也就是allowed-related的 acl，仍有可能触发conntrack冲突

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17b3e62</samp>

This pull request adds a new feature to support node local dns cache for the pods on the ovn network. It introduces a new flag `--node-local-dns-cache-ip` to the controller binary and the deployment templates, and adds or modifies the relevant logic in the controller and the ovn-nbctl-legacy packages. It also adds a new constant `NodeLocalDnsPolicyPriority` to the util package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 17b3e62</samp>

> _Oh we are the ovn controllers, we sail the kubernetes sea_
> _We set the `--node-local-dns-cache-ip` flag to make the pods happy_
> _We add and delete the router policies, we sync them with the cache_
> _And when we're done we sing this song and hope we don't get bashed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 17b3e62</samp>

*  Add a new flag `--node-local-dns-cache-ip` to the controller container to configure the node local dns cache ip for the controller ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-ea68dce347b5fa351b4dd8da76b26575f5aeac40e3ce0f5d37e26a603bb6ea51R109), [link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR93), [link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R93), [link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R93))
*  Add a new value `NODE_LOCAL_DNS_CACHE_IP` to the `values.yaml` file to set the node local dns cache ip for the controller in the helm chart ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-2f7bd1822b616f83b06c8d8c356e0fc48c36dde251b8f87ab81d97155ca4cbcbL49-R55))
*  Add a new field `NodeLocalDnsCacheIP` to the `Configuration` struct in `config.go` to store the node local dns cache ip from the flag or environment variable ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R102-R103))
*  Add a new variable `argNodeLocalDnsCacheIP` to the `ParseFlags` function in `config.go` to bind the flag `--node-local-dns-cache-ip` to a string pointer ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R167))
*  Assign the value of `argNodeLocalDnsCacheIP` to the `NodeLocalDnsCacheIP` field of the `Configuration` struct in the `ParseFlags` function in `config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R252))
*  Add a new block of code to the `handleAddNode` function in `node.go` to add a logical router policy for the node local dns cache ip in the cluster router ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L276-R290))
*  Add a new block of code to the `handleDeleteNode` function in `node.go` to delete the logical router policy for the node local dns cache ip in the cluster router ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R474-R483))
*  Add a new constant `NodeLocalDnsPolicyPriority` to the `const.go` file to define the priority of the logical router policy for the node local dns cache ip ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cL193-R196))
*  Modify the action of the gateway ACLs from `allow-related` to `allow-stateless` in the `CreateGatewayACL` function in `ovn-nbctl-legacy.go` to improve the performance and compatibility of the gateway ACLs ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L987-R990))
*  Add a new condition `subnet.Spec.U2OInterconnection` to the `if` statement in the `reconcileAllocateSubnets` function in `pod.go` to check if the subnet is an underlay to overlay interconnection subnet and add the pod annotation for the logical router accordingly ([link](https://github.com/kubeovn/kube-ovn/pull/2733/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L614-R614))