### PR TITLE
fix: set nm not managed only in the case of exchanging the name of nic with br name

### DIFF
--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -40,7 +40,7 @@ func InitOVSBridges() (map[string]string, error) {
 					return nil, fmt.Errorf("failed to check vendor of port %s: %v", port, err)
 				}
 				if ok {
-					if _, err = configProviderNic(port, brName); err != nil {
+					if _, err = configProviderNic(port, brName, false); err != nil {
 						return nil, err
 					}
 					mappings[port] = brName
@@ -125,7 +125,7 @@ func ovsInitProviderNetwork(provider, nic string, exchangeLinkName, macLearningF
 	}
 
 	// add host nic to the external bridge
-	mtu, err := configProviderNic(nic, brName)
+	mtu, err := configProviderNic(nic, brName, exchangeLinkName)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to add nic %s to external bridge %s: %v", nic, brName, err)
 		klog.Error(errMsg)

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -881,7 +881,7 @@ func configureLoNic() error {
 
 // Add host nic to external bridge
 // Mac address, MTU, IP addresses & routes will be copied/transferred to the external bridge
-func configProviderNic(nicName, brName string) (int, error) {
+func configProviderNic(nicName, brName string, exchangeLinkName bool) (int, error) {
 	nic, err := netlink.LinkByName(nicName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get nic by name %s: %v", nicName, err)
@@ -911,10 +911,12 @@ func configProviderNic(nicName, brName string) (int, error) {
 		return 0, fmt.Errorf("failed to get routes on nic %s: %v", nicName, err)
 	}
 
-	// set link unmanaged by NetworkManager
-	if err = nmSetManaged(nicName, false); err != nil {
-		klog.Errorf("failed set device %s unmanaged by NetworkManager: %v", nicName, err)
-		return 0, err
+	if exchangeLinkName {
+		// set link unmanaged by NetworkManager
+		if err = nmSetManaged(nicName, false); err != nil {
+			klog.Errorf("failed set device %s unmanaged by NetworkManager: %v", nicName, err)
+			return 0, err
+		}
 	}
 
 	for _, addr := range addrs {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a43eb85</samp>

This pull request adds a new option to configure the provider network and refactors the `pkg/daemon` package to improve the host nic configuration. It also fixes a potential issue with the host nic and external bridge name exchange.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a43eb85</samp>

> _We're setting sail on the provider network_
> _We need to config the host nic right_
> _We'll pass the `providerNetworkExchange`_
> _And swap the names if we need to, aye!_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a43eb85</samp>

*  Move `configProviderNic` function from `ovs_linux.go` to `init.go` to avoid circular dependency ([link](https://github.com/kubeovn/kube-ovn/pull/2741/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feL884-R884))
* Add `exchangeLinkName` parameter to `configProviderNic` function to control whether to exchange host nic name and external bridge name ([link](https://github.com/kubeovn/kube-ovn/pull/2741/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL43-R43))
* Read `providerNetworkExchange` configuration option from `kube-ovn-config` configmap and pass it to `configProviderNic` function call ([link](https://github.com/kubeovn/kube-ovn/pull/2741/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL128-R128))
* Skip setting host nic unmanaged by NetworkManager if `exchangeLinkName` is false ([link](https://github.com/kubeovn/kube-ovn/pull/2741/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feL914-R919))