### PR TITLE
Using full repo name to avoid short-name error in podman

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 global:
   registry:
-    address: kubeovn
+    address: docker.io/kubeovn
     imagePullSecrets: []
   images:
     kubeovn:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -36,7 +36,7 @@ KUBELET_DIR=${KUBELET_DIR:-/var/lib/kubelet}
 CNI_CONF_DIR="/etc/cni/net.d"
 CNI_BIN_DIR="/opt/cni/bin"
 
-REGISTRY="kubeovn"
+REGISTRY="docker.io/kubeovn"
 VPC_NAT_IMAGE="vpc-nat-gateway"
 VERSION="v1.12.0"
 IMAGE_PULL_POLICY="IfNotPresent"


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2730

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98b5bec</samp>

Use official docker hub registry for kube-ovn images. Update `charts/values.yaml` to reflect the new registry address.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 98b5bec</samp>

> _`kubeovn` address_
> _changed to `docker.io`_
> _pull images with ease_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 98b5bec</samp>

* Change the global registry address to use the official docker hub repository ([link](https://github.com/kubeovn/kube-ovn/pull/2746/files?diff=unified&w=0#diff-2f7bd1822b616f83b06c8d8c356e0fc48c36dde251b8f87ab81d97155ca4cbcbL6-R6)). This allows users to pull the images without having to configure a local registry or mirror, and resolves issue #1012.