### PR TITLE
ovn-nbctl: remove unused functions

### DIFF
--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -6,12 +6,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
-
-	"github.com/ovn-org/libovsdb/model"
-	"github.com/ovn-org/libovsdb/ovsdb"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/require"
-
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/ovs/ovn-nb-address_set_test.go
+++ b/pkg/ovs/ovn-nb-address_set_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
 
 func newAddressSet(name string, externalIDs map[string]string) *ovnnb.AddressSet {

--- a/pkg/ovs/ovn-nb-logical_router_policy_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
-	"github.com/stretchr/testify/require"
 )
 
 func newLogicalRouterPolicy(lrName string, priority int, match, action string, nextHops []string, externalIDs map[string]string) *ovnnb.LogicalRouterPolicy {

--- a/pkg/ovs/ovn-nb-logical_router_port.go
+++ b/pkg/ovs/ovn-nb-logical_router_port.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
-
 	"k8s.io/klog/v2"
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"

--- a/pkg/ovs/ovn-nb-port_group_test.go
+++ b/pkg/ovs/ovn-nb-port_group_test.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 	"testing"
 
-	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
-	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/stretchr/testify/require"
+
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (suite *OvnClientTestSuite) testCreatePortGroup() {

--- a/pkg/ovs/ovn-nbctl-legacy_test.go
+++ b/pkg/ovs/ovn-nbctl-legacy_test.go
@@ -1,10 +1,11 @@
 package ovs
 
 import (
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func Test_parseLrRouteListOutput(t *testing.T) {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a47dd3c</samp>

Removed unused methods from `pkg/ovs/ovn-nbctl-legacy.go` and applied gofmt formatting to several files in `pkg/ovs`. This improves code quality and consistency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a47dd3c</samp>

> _`gofmt` cleans imports_
> _removing blanks and unused_
> _code breathes in spring air_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a47dd3c</samp>

*  Remove unused methods from `pkg/ovs/ovn-nbctl-legacy.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L625-L655), [link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L862-L883), [link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L1141-L1175))
*  Reorder import statements according to the gofmt tool in various files ([link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L9-R14), [link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-d9076cf9f0a3a7d1f6f255e0aa9584dc53c9b3a87724e1335ae433f72f76256eL7-R9), [link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-2618ff1fc82aec4a4ffc11e207b16284441050693e466f1506d2e52dace07ff6L7-R11), [link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-216371c6de59a4543dedd49ca77fe453c38627d431bd572bf262a71da12ce8d9L8-R14), [link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-b874caae9f53d51183c84dcfd89891600d1e298c48947db8dfe4104db72c28abL4-R8))
*  Remove unnecessary blank lines according to the gofmt tool in `pkg/ovs/ovn-nb-acl_test.go` and `pkg/ovs/ovn-nb-logical_router_port.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L11), [link](https://github.com/kubeovn/kube-ovn/pull/2755/files?diff=unified&w=0#diff-e6855e2616a51a054e96fd9081cc8852239a14f67ec293fb75646a3c3e819f06L11))