### PR TITLE
When Subnet spec.vpc is updated, the status in VPC should also be updated

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -77,6 +77,10 @@ func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
 		return
 	}
 
+	if oldSubnet.Spec.Vpc != newSubnet.Spec.Vpc {
+		c.updateVpcStatusQueue.Add(oldSubnet.Spec.Vpc)
+	}
+
 	if oldSubnet.Spec.Private != newSubnet.Spec.Private ||
 		oldSubnet.Spec.CIDRBlock != newSubnet.Spec.CIDRBlock ||
 		!reflect.DeepEqual(oldSubnet.Spec.AllowSubnets, newSubnet.Spec.AllowSubnets) ||
@@ -100,7 +104,8 @@ func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
 		oldSubnet.Spec.EnableEcmp != newSubnet.Spec.EnableEcmp ||
 		!reflect.DeepEqual(oldSubnet.Spec.Acls, newSubnet.Spec.Acls) ||
 		oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection ||
-		oldSubnet.Spec.RouteTable != newSubnet.Spec.RouteTable {
+		oldSubnet.Spec.RouteTable != newSubnet.Spec.RouteTable ||
+		oldSubnet.Spec.Vpc != newSubnet.Spec.Vpc {
 		klog.V(3).Infof("enqueue update subnet %s", key)
 
 		if oldSubnet.Spec.GatewayType != newSubnet.Spec.GatewayType {

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -321,16 +321,16 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 				}
 
 				for _, nat := range lr.Nat {
-					logical_ip, err := c.ovnLegacyClient.GetNatIPInfo(nat)
+					logicalIP, err := c.ovnLegacyClient.GetNatIPInfo(nat)
 					if err != nil {
 						klog.Errorf("failed to get nat ip info for vpc %s, %v", vpc.Name, err)
 						return err
 					}
-					if logical_ip != "" {
+					if logicalIP != "" {
 						for rtb := range rtbs {
 							targetRoutes = append(targetRoutes, &kubeovnv1.StaticRoute{
 								Policy:     kubeovnv1.PolicySrc,
-								CIDR:       logical_ip,
+								CIDR:       logicalIP,
 								NextHopIP:  nextHop,
 								RouteTable: rtb,
 							})
@@ -402,7 +402,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		}
 		for _, item := range policyRouteNeedAdd {
 			externalIDs := map[string]string{"vendor": util.CniTypeName}
-			klog.Infof("add policy route for router: %s, match %s, action %s, nexthop %s, extrenalID %v", c.config.ClusterRouter, item.Match, string(item.Action), item.NextHopIP, externalIDs)
+			klog.Infof("add policy route for router: %s, match %s, action %s, nexthop %s, externalID %v", c.config.ClusterRouter, item.Match, string(item.Action), item.NextHopIP, externalIDs)
 			if err = c.ovnLegacyClient.AddPolicyRoute(vpc.Name, item.Priority, item.Match, string(item.Action), item.NextHopIP, externalIDs); err != nil {
 				klog.Errorf("add policy route to vpc %s failed, %v", vpc.Name, err)
 				return err
@@ -455,7 +455,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 
 	if cachedVpc.Spec.EnableExternal {
 		if !cachedVpc.Status.EnableExternal {
-			// connecte vpc to external
+			// connect vpc to external
 			klog.V(3).Infof("connect external network with vpc %s", vpc.Name)
 			if err := c.handleAddVpcExternal(key); err != nil {
 				klog.Errorf("failed to add external connection for vpc %s, error %v", key, err)
@@ -464,7 +464,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		}
 		if vpc.Spec.EnableBfd {
 			klog.V(3).Infof("remove normal static ecmp route for vpc %s", vpc.Name)
-			// auto remove normal type static route, if use ecmp based bfd
+			// auto remove normal type static route, if using ecmp based bfd
 			if err := c.reconcileVpcDelNormalStaticRoute(vpc.Name); err != nil {
 				klog.Errorf("failed to reconcile del vpc %q normal static route", vpc.Name)
 				return err


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes

There is still issues when change the vpc field, related lrp will not be deleted.

### Which issue(s) this PR fixes:
Fixes #1190

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0426884</samp>

This pull request enhances the VPC and subnet controller logic and fixes some minor issues in the code and comments of `vpc.go`. It improves the handling of subnet VPC changes and the ecmp based bfd feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0426884</samp>

> _Sing, O Muse, of the skillful code review_
> _That fixed the errors and improved the features_
> _Of the subnet controller, the wise and true_
> _Guardian of the VPC, the cloud's great teacher._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0426884</samp>

*  Add logic to handle subnet VPC changes ([link](https://github.com/kubeovn/kube-ovn/pull/2756/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R80-R83), [link](https://github.com/kubeovn/kube-ovn/pull/2756/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L103-R108))
* Fix typos and improve naming in `pkg/controller/vpc.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2756/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL324-R333), [link](https://github.com/kubeovn/kube-ovn/pull/2756/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL405-R405), [link](https://github.com/kubeovn/kube-ovn/pull/2756/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL458-R458), [link](https://github.com/kubeovn/kube-ovn/pull/2756/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL467-R467))