### PR TITLE
kubectl-ko: fix pod tracing in underlay

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -328,12 +328,12 @@ trace(){
           local interface=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ovs-vsctl --format=csv --data=bare --no-heading --columns=name find interface external_id:iface-id="$lsp")
           local peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- ip link show $interface | grep -oE "^[0-9]+:\\s$interface@if[0-9]+" | awk -F @ '{print $2}')
           local peerIndex=${peer//if/}
-          local peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- $nsenterCmd ip link show type veth | grep "^$peerIndex:" | awk -F @ '{print $1}')
+          local peer=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- sh -c "$nsenterCmd ip link show type veth" | grep "^$peerIndex:" | awk -F @ '{print $1}')
           nicName=$(echo $peer | awk '{print $2}')
         fi
 
         set +o pipefail
-        local master=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- $nsenterCmd ip link show $nicName | grep -Eo '\smaster\s\w+\s' | awk '{print $2}')
+        local master=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- sh -c "$nsenterCmd ip link show $nicName" | grep -Eo '\smaster\s\w+\s' | awk '{print $2}')
         set -o pipefail
         if [ ! -z "$master" ]; then
           echo "Error: Pod nic $nicName is a slave of $master, please set the destination mac address."
@@ -343,10 +343,10 @@ trace(){
         local cmd= output=
         if [[ "$gateway" =~ .*:.* ]]; then
           cmd="ndisc6 -q $gateway $nicName"
-          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- $nsenterCmd ndisc6 -q "$gateway" "$nicName")
+          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- sh -c "$nsenterCmd ndisc6 -q $gateway $nicName")
         else
           cmd="arping -c3 -C1 -i1 -I $nicName $gateway"
-          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- $nsenterCmd arping -c3 -C1 -i1 -I "$nicName" "$gateway")
+          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- sh -c "$nsenterCmd arping -c3 -C1 -i1 -I $nicName $gateway")
         fi
 
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes `kubectl-ko trace <pod>` in underlay networking.

```txt
++ kubectl exec kube-ovn-cni-54d8w -c cni-server -n kube-system -- nsenter '--net='\''/var/run/netns/cni-4267b9fa-d952-f207-e9cf-2c6b6ad99c27'\''' arping -c3 -C1 -i1 -I '' 172.18.0.1
nsenter: cannot open '/var/run/netns/cni-4267b9fa-d952-f207-e9cf-2c6b6ad99c27': No such file or directory
```

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough