### PR TITLE
cni-server: wait ovs-vswitchd to be running

### DIFF
--- a/dist/images/start-cniserver.sh
+++ b/dist/images/start-cniserver.sh
@@ -30,15 +30,12 @@ then
   rm ${CNI_SOCK}
 fi
 
-while true
-do
-  sleep 1
-  if [[ -e "$OVS_SOCK" ]]
-  then
-    break
-  else
-    echo "waiting for ovs ready"
+while true; do
+  if [[ -e "$OVS_SOCK" ]]; then
+    /usr/share/openvswitch/scripts/ovs-ctl status && break
   fi
+  echo "waiting for ovs ready"
+  sleep 1
 done
 
 # update links to point to the iptables binaries


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
In #2516 we removed the IP/route transfer logic in `start-ovs.sh` and all underlay bridges will be deleted after the node reboot before ovs-vswitchd starts up. However, there is a chance that kube-ovn-cni starts before the bridge deletion completes, and uses a non-existent ovs bridge as the tunnel interface.

This patch fixes the bug by making kube-ovn-cni wait for ovs-vswitchd to run.

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough