### PR TITLE
support disable arp check ip conflict in vlan provider network

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -20,6 +20,7 @@ CNI_CONFIG_PRIORITY=${CNI_CONFIG_PRIORITY:-01}
 ENABLE_LB_SVC=${ENABLE_LB_SVC:-false}
 ENABLE_NAT_GW=${ENABLE_NAT_GW:-false}
 ENABLE_KEEP_VM_IP=${ENABLE_KEEP_VM_IP:-true}
+ENABLE_ARP_DETECT_IP_CONFLICT=${ENABLE_ARP_DETECT_IP_CONFLICT:-true}
 NODE_LOCAL_DNS_IP=${NODE_LOCAL_DNS_IP:-}
 # exchange link names of OVS bridge and the provider nic
 # in the default provider-network
@@ -3726,6 +3727,7 @@ spec:
           - /kube-ovn/start-cniserver.sh
         args:
           - --enable-mirror=$ENABLE_MIRROR
+          - --enable-arp-detect-ip-conflict=$ENABLE_ARP_DETECT_IP_CONFLICT
           - --encap-checksum=true
           - --service-cluster-ip-range=$SVC_CIDR
           - --iface=${IFACE}

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -226,10 +226,11 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			u2oInterconnectionIP = podSubnet.Status.U2OInterconnectionIP
 		}
 
-		detectIPConflict := podSubnet.Spec.Vlan != ""
+		subnetHasVlan := podSubnet.Spec.Vlan != ""
+		detectIPConflict := csh.Config.EnableArpDetectIPConflict && subnetHasVlan
 		// skip ping check gateway for pods during live migration
 		if pod.Annotations[fmt.Sprintf(util.LiveMigrationAnnotationTemplate, podRequest.Provider)] != "true" {
-			if podSubnet.Spec.Vlan != "" && !podSubnet.Spec.LogicalGateway {
+			if subnetHasVlan && !podSubnet.Spec.LogicalGateway {
 				if podSubnet.Spec.DisableGatewayCheck {
 					gatewayCheckMode = gatewayCheckModeArpingNotConcerned
 				} else {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e56c78a</samp>

Added a feature to enable ARP detection for IP conflicts in VLAN networks. This feature can be configured by a new flag in the daemon config file. The daemon handler logic was updated to respect the flag value when adding a pod.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e56c78a</samp>

> _To avoid IP conflicts in VLANs_
> _We added a feature for our fans_
> _With `--enable-arp-detect-ip-conflict`_
> _You can set `detectIPConflict` to true or false_
> _And use ARP detection as you plan_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e56c78a</samp>

*  Add a configuration option to enable or disable ARP detection for IP conflicts in VLAN networks ([link](https://github.com/kubeovn/kube-ovn/pull/2760/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073L32-R60), [link](https://github.com/kubeovn/kube-ovn/pull/2760/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073L82-R92), [link](https://github.com/kubeovn/kube-ovn/pull/2760/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073L115-R141), [link](https://github.com/kubeovn/kube-ovn/pull/2760/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL229-R229))
  - Define a new field `EnableArpDetectIPConflict` in the `Configuration` struct in `config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2760/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073L32-R60))
  - Add a new command-line flag `--enable-arp-detect-ip-conflict` to the `ParseFlags` function in `config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2760/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073L82-R92))
  - Assign the value of the flag to the field in the `ParseFlags` function in `config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2760/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073L115-R141))
  - Use the field value to determine whether to perform ARP detection in the `handleAdd` function in `handler.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2760/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL229-R229))