### PR TITLE
kubectl-ko: support trace for pod with host network

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -180,16 +180,23 @@ trace(){
     typedName="node/$node"
     lsp=$(kubectl get $typedName -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/port_name})
   else
-    namespacedPod="$1"
+    local namespacedPod="$1"
     namespace=$(echo "$namespacedPod" | cut -d "/" -f1)
-    podName=$(echo "$namespacedPod" | cut -d "/" -f2)
+    local podName=$(echo "$namespacedPod" | cut -d "/" -f2)
     if [ "$podName" = "$namespacedPod" ]; then
       namespace="default"
     fi
-    typedName="pod/$podName"
-    optNamespace="-n $namespace"
-    lsp="$podName.$namespace"
     node=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
+    typedName="pod/$podName"
+    local hostNetwork=$(kubectl get "$typedName" -n "$namespace" -o jsonpath={.spec.hostNetwork})
+    if [ "$hostNetwork" = "true" ]; then
+      namespace=""
+      typedName="node/$node"
+      lsp=$(kubectl get $typedName -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/port_name})
+    else
+      optNamespace="-n $namespace"
+      lsp="$podName.$namespace"
+    fi
   fi
 
   local dst="$2"
@@ -213,14 +220,6 @@ trace(){
     echo "  kubectl ko trace {node//nodename} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]"
     echo "  kubectl ko trace {node//nodename} {target ip address} [target mac address] arp {request|reply}"
     exit 1
-  fi
-
-  if [ ! -z $namespace ]; then
-    hostNetwork=$(kubectl get "$typedName" -n "$namespace" -o jsonpath={.spec.hostNetwork})
-    if [ "$hostNetwork" = "true" ]; then
-      echo "Can not trace host network pod"
-      exit 1
-    fi
   fi
 
   local af="4" nw="nw" proto=


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Features

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0d7086</samp>

Improve `kubectl_ko` package by adding a new test case, removing redundant code, and simplifying node tracing logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b0d7086</samp>

> _We're testing `host network pods` with a new case_
> _We're trimming the code and we're setting the pace_
> _We're tracing the nodes with a simpler trace_
> _Heave away, me lads and lasses, heave away!_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b0d7086</samp>

* Add a new conformance test case for `kubectl ko trace` command for pods with host network ([link](https://github.com/kubeovn/kube-ovn/pull/2761/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8R167-R195))
* Remove redundant code for checking Kubernetes version for ARP and destination MAC features ([link](https://github.com/kubeovn/kube-ovn/pull/2761/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L177-L185))
* Simplify logic for testing `kubectl ko trace` command for nodes by removing unnecessary variables and conditions ([link](https://github.com/kubeovn/kube-ovn/pull/2761/files?diff=unified&w=0#diff-ce80b20636ec9810bcd330131c42240209c018f7722c9c1848f04d8b10a861b8L191-R223))