### PR TITLE
ci: run kube-ovn e2e for underlay

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -694,6 +694,9 @@ jobs:
           - ipv4
           - ipv6
           - dual
+        mode:
+          - overlay
+          - underlay
     steps:
       - uses: actions/checkout@v3
 
@@ -761,27 +764,28 @@ jobs:
           sudo chown -R $(id -un). ~/.kube/
 
       - name: Install Kube-OVN
-        run: make kind-install-${{ matrix.ip-family }}
+        run: make kind-install-${{ matrix.mode }}-${{ matrix.ip-family }}
 
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}
         env:
           E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
           E2E_IP_FAMILY: ${{ matrix.ip-family }}
+          E2E_NETWORK_MODE: ${{ matrix.mode }}
         run: make kube-ovn-conformance-e2e
 
       - name: kubectl ko log
         if: failure()
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-conformance-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: kube-ovn-conformance-e2e-${{ matrix.ip-family }}-ko-log
-          path: kube-ovn-conformance-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
+          name: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log
+          path: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Cleanup
         run: sh dist/images/cleanup.sh


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- CI

### Which issue(s) this PR fixes:
Some e2e cases, such as `kubectl ko trace <pod>`, should be run in both overlay and underlay.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 869e2d7</samp>

Add overlay and underlay network mode testing to GitHub Actions workflow. Modify `.github/workflows/build-x86-image.yaml` to use a matrix variable and different commands for each mode.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 869e2d7</samp>

> _`Kube-OVN` modes_
> _test overlay and underlay_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 869e2d7</samp>

* Add a new matrix variable `mode` to test different network modes of Kube-OVN ([link](https://github.com/kubeovn/kube-ovn/pull/2762/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R697-R699))
* Install Kube-OVN with the corresponding `mode` variable in the kind cluster ([link](https://github.com/kubeovn/kube-ovn/pull/2762/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L764-R767))
* Set an environment variable `E2E_NETWORK_MODE` to select the appropriate end-to-end test cases based on the network mode ([link](https://github.com/kubeovn/kube-ovn/pull/2762/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R774))
* Rename the log file and the artifact name and path to include the `mode` variable for the `make kubectl-ko-log` command and the upload-artifact action ([link](https://github.com/kubeovn/kube-ovn/pull/2762/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L777-R781), [link](https://github.com/kubeovn/kube-ovn/pull/2762/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L783-R788))