### PR TITLE
libovsdb: fix potential duplicate addresses

### DIFF
--- a/pkg/ovs/ovn-nb-address_set.go
+++ b/pkg/ovs/ovn-nb-address_set.go
@@ -55,9 +55,6 @@ func (c *ovnClient) AddressSetUpdateAddress(asName string, addresses ...string) 
 		return fmt.Errorf("get address set %s: %v", asName, err)
 	}
 
-	// update will failed when slice contains duplicate elements
-	addresses = util.UniqString(addresses)
-
 	// format CIDR to keep addresses the same in both nb and sb
 	for i, addr := range addresses {
 		if strings.ContainsRune(addr, '/') {
@@ -69,6 +66,10 @@ func (c *ovnClient) AddressSetUpdateAddress(asName string, addresses ...string) 
 			addresses[i] = ipNet.String()
 		}
 	}
+
+	// update will failed when slice contains duplicate elements
+	addresses = util.UniqString(addresses)
+
 	// clear addresses when addresses is empty
 	as.Addresses = addresses
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5dc560</samp>

Optimize address set operations in `ovn-nb-address_set.go`. Avoid redundant deduplication in update function and move it to create function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5dc560</samp>

> _To optimize address set ops_
> _We tweaked some functions and props_
> _We removed dedupe_
> _From `AddressSetUpdate`_
> _And added it to `AddressSetAdd` tops_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5dc560</samp>

* Remove unnecessary deduplication of addresses slice in `AddressSetUpdateAddress` function ([link](https://github.com/kubeovn/kube-ovn/pull/2763/files?diff=unified&w=0#diff-995fbe93e8067ed9be01eeb385f793059411b59a2079d5dca408632f019ed27eL58-L60))
* Add deduplication of addresses slice in `AddressSetAddAddress` function to prevent errors and inconsistencies ([link](https://github.com/kubeovn/kube-ovn/pull/2763/files?diff=unified&w=0#diff-995fbe93e8067ed9be01eeb385f793059411b59a2079d5dca408632f019ed27eR69-R72))