### PR TITLE
replace string map with string set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/ovn-org/libovsdb v0.0.0-20230207174348-7f620a35d7e8
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/prometheus/client_golang v1.15.1
+	github.com/scylladb/go-set v0.0.0-20200225121959-cc7b2070d91e
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -491,6 +491,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwC
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
+github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -1258,6 +1260,8 @@ github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHi
 github.com/satori/go.uuid v0.0.0-20160603004225-b111a074d5ef/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/scylladb/go-set v0.0.0-20200225121959-cc7b2070d91e h1:cSF0zPqtdVBEKmdeFW4u68UJemU1V+2aueMZPb4TLDQ=
+github.com/scylladb/go-set v0.0.0-20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
 
 func newLogicalRouterPort(lrName, lrpName, mac string, networks []string) *ovnnb.LogicalRouterPort {
@@ -22,10 +24,10 @@ func newLogicalRouterPort(lrName, lrpName, mac string, networks []string) *ovnnb
 func Test_logicalRouterPortFilter(t *testing.T) {
 	t.Parallel()
 
-	exceptPeerPorts := map[string]struct{}{
-		"except-lrp-0": {},
-		"except-lrp-1": {},
-	}
+	exceptPeerPorts := strset.New(
+		"except-lrp-0",
+		"except-lrp-1",
+	)
 
 	lrpNames := []string{"other-0", "other-1", "other-2", "except-lrp-0", "except-lrp-1"}
 	lrps := make([]*ovnnb.LogicalRouterPort, 0)
@@ -39,7 +41,7 @@ func Test_logicalRouterPortFilter(t *testing.T) {
 	filterFunc := logicalRouterPortFilter(exceptPeerPorts)
 
 	for _, lrp := range lrps {
-		if _, ok := exceptPeerPorts[lrp.Name]; ok {
+		if exceptPeerPorts.Has(lrp.Name) {
 			require.False(t, filterFunc(lrp))
 		} else {
 			require.True(t, filterFunc(lrp))

--- a/pkg/controller/ovn-ic_test.go
+++ b/pkg/controller/ovn-ic_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -35,8 +36,5 @@ func Test_listRemoteLogicalSwitchPortAddress(t *testing.T) {
 
 	addresses, err := ctrl.listRemoteLogicalSwitchPortAddress()
 	require.NoError(t, err)
-	require.Equal(t, map[string]struct{}{
-		"10.244.0.10": {},
-		"10.244.0.18": {},
-	}, addresses)
+	require.True(t, addresses.IsEqual(strset.New("10.244.0.10", "10.244.0.18")))
 }

--- a/pkg/daemon/controller_windows.go
+++ b/pkg/daemon/controller_windows.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/scylladb/go-set/strset"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -123,35 +124,13 @@ func (c *Controller) reconcileRouters(_ subnetEvent) error {
 }
 
 func routeDiff(existingRoutes, v4Cidrs, v6Cidrs []string) (toAddV4, toAddV6, toDel []string) {
-	existing := make(map[string]struct{}, len(existingRoutes))
-	expectedV4 := make(map[string]struct{}, len(v4Cidrs))
-	expectedV6 := make(map[string]struct{}, len(v6Cidrs))
-	for _, r := range existingRoutes {
-		existing[r] = struct{}{}
-	}
+	existing := strset.New(existingRoutes...)
+	expectedV4 := strset.New(v4Cidrs...)
+	expectedV6 := strset.New(v6Cidrs...)
 
-	var ok bool
-	for _, r := range v4Cidrs {
-		expectedV4[r] = struct{}{}
-		if _, ok = existing[r]; !ok {
-			toAddV4 = append(toAddV4, r)
-		}
-	}
-	for _, r := range v6Cidrs {
-		expectedV6[r] = struct{}{}
-		if _, ok = existing[r]; !ok {
-			toAddV6 = append(toAddV6, r)
-		}
-	}
-	for _, r := range existingRoutes {
-		if _, ok = expectedV4[r]; ok {
-			continue
-		}
-		if _, ok = expectedV6[r]; ok {
-			continue
-		}
-		toDel = append(toDel, r)
-	}
+	toAddV4 = strset.Difference(expectedV4, existing).List()
+	toAddV6 = strset.Difference(expectedV6, existing).List()
+	toDel = strset.Difference(existing, expectedV4, expectedV6).List()
 
 	return
 }

--- a/pkg/ovs/ovn-nb-address_set.go
+++ b/pkg/ovs/ovn-nb-address_set.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/ovn-org/libovsdb/client"
+	"github.com/scylladb/go-set/strset"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 // CreateAddressSet create address set with external ids
@@ -68,7 +68,7 @@ func (c *ovnClient) AddressSetUpdateAddress(asName string, addresses ...string) 
 	}
 
 	// update will failed when slice contains duplicate elements
-	addresses = util.UniqString(addresses)
+	addresses = strset.New(addresses...).List()
 
 	// clear addresses when addresses is empty
 	as.Addresses = addresses

--- a/pkg/ovs/ovn-nb-logical_switch_port_test.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
@@ -1500,10 +1501,7 @@ func (suite *OvnClientTestSuite) testgetLogicalSwitchPortSgs() {
 		}
 
 		sgs := getLogicalSwitchPortSgs(lsp)
-		require.Equal(t, map[string]struct{}{
-			"sg1": {},
-			"sg2": {},
-		}, sgs)
+		require.True(t, sgs.IsEqual(strset.New("sg1", "sg2")))
 	})
 
 	t.Run("has no associated security group", func(t *testing.T) {
@@ -1515,7 +1513,7 @@ func (suite *OvnClientTestSuite) testgetLogicalSwitchPortSgs() {
 		}
 
 		sgs := getLogicalSwitchPortSgs(lsp)
-		require.Empty(t, sgs)
+		require.Zero(t, sgs.Size())
 	})
 
 	t.Run("has no external ids", func(t *testing.T) {
@@ -1523,6 +1521,6 @@ func (suite *OvnClientTestSuite) testgetLogicalSwitchPortSgs() {
 		lsp := &ovnnb.LogicalSwitchPort{}
 
 		sgs := getLogicalSwitchPortSgs(lsp)
-		require.Empty(t, sgs)
+		require.Zero(t, sgs.Size())
 	})
 }

--- a/pkg/util/named_port.go
+++ b/pkg/util/named_port.go
@@ -1,6 +1,8 @@
 package util
 
+import "github.com/scylladb/go-set/strset"
+
 type NamedPortInfo struct {
 	PortId int32
-	Pods   map[string]struct{}
+	Pods   *strset.Set
 }


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59ec6f8</samp>

This pull request refactors several files in the `pkg/controller` package to use the `go-set` package for handling sets of strings. This improves the readability, simplicity, and performance of the code that manages the IP address allocation, the interconnection logic, and the pod reconciliation. It also updates the corresponding unit tests and adds the `go-set` dependency to the `go.mod` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 59ec6f8</samp>

> _`go-set` package_
> _simplifies string sets in code_
> _autumn of refactoring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 59ec6f8</samp>

*  Add the go-set package as a dependency to simplify and optimize the code that deals with sets of strings ([link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R34))
  - `pkg/controller/gc.go`: the gc, gcLogicalRouterPort, markAndCleanLSP, gcLoadBalancer, gcPortGroup, and logicalRouterPortFilter functions ([link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R8-R9), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L20-R24), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L57-R61), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L298-R299), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L321-R337), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L347-R353), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L378-R381), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L444-R448), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L462-R475), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L494-R493), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L506-R505), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L550-R549), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L560-R559), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L571-R570), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L586-R585), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L603-R602), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L848-R849))
  - `pkg/controller/init.go`: the InitIPAM and initSyncCrdIPs functions ([link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988R9), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L300-R303), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L313-R315), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L393-R391), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L399-R397), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L472-R475), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L625-R628))
  - `pkg/controller/ovn-ic.go`: the acquireLrpAddress, listRemoteLogicalSwitchPortAddress, and reconcileRouters functions ([link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL13-R13), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR20), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL287-R287), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL508-R508), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL516-R516), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL529-R529))
*  Update the unit tests in `pkg/controller/gc_test.go` and `pkg/controller/ovn-ic_test.go` to use the go-set package and the strset.Set type in the Test_logicalRouterPortFilter and Test_listRemoteLogicalSwitchPortAddress functions ([link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-bf737bb79e41472fe9abf7568b6943edc17b9a462e2cfd59a5b03ec78dd75154L7-R10), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-bf737bb79e41472fe9abf7568b6943edc17b9a462e2cfd59a5b03ec78dd75154L25-R30), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-bf737bb79e41472fe9abf7568b6943edc17b9a462e2cfd59a5b03ec78dd75154L42-R44), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-98bafb4e53b0c777f4c1a71a45ef7362b5bcb20a5600268cc9fa811788c199d6R7), [link](https://github.com/kubeovn/kube-ovn/pull/2765/files?diff=unified&w=0#diff-98bafb4e53b0c777f4c1a71a45ef7362b5bcb20a5600268cc9fa811788c199d6L38-R39))