### PR TITLE
informer: wait for cache sync before adding event handlers

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -116,8 +116,7 @@ func CmdMain() {
 		RetryPeriod:   6 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
-				ctl := controller.NewController(config)
-				ctl.Run(ctx)
+				controller.Run(ctx, config)
 			},
 			OnStoppedLeading: func() {
 				select {

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -73,13 +73,10 @@ func CmdMain() {
 		kubeovninformer.WithTweakListOptions(func(listOption *v1.ListOptions) {
 			listOption.AllowWatchBookmarks = true
 		}))
-	ctl, err := daemon.NewController(config, podInformerFactory, nodeInformerFactory, kubeovnInformerFactory)
+	ctl, err := daemon.NewController(config, stopCh, podInformerFactory, nodeInformerFactory, kubeovnInformerFactory)
 	if err != nil {
 		util.LogFatalAndExit(err, "failed to create controller")
 	}
-	podInformerFactory.Start(stopCh)
-	nodeInformerFactory.Start(stopCh)
-	kubeovnInformerFactory.Start(stopCh)
 	klog.Info("start daemon controller")
 	go ctl.Run(stopCh)
 	go daemon.RunServer(config, ctl)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
This patch is expected to fix #2277

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bca7d7</samp>

Refactored the code to create and run controller and daemon instances for the OVN network. Moved the `Run` function from `pkg/controller/controller.go` to `cmd/controller/controller.go` and the logic to wait for informer caches to sync from `Run` to `NewController` in both `pkg/controller/controller.go` and `pkg/daemon/controller.go`. Updated the `CmdMain` functions in `cmd/controller/controller.go` and `cmd/daemon/cniserver.go` to reflect the changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0bca7d7</samp>

> _We are the controllers of the OVN network_
> _We create and run our instances with `Run`_
> _We sync our caches and start our workers_
> _We move our logic to where it belongs_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0bca7d7</samp>

*  Move the `Run` function from `pkg/controller/controller.go` to `cmd/controller/controller.go` and modify it to create and run a new controller instance ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-c49fd9cc751dfc13ff4e4cb0f8d8052514ccbf971a2f3068dced75539f959529L119-R119), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L235-R236), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L680-R719))
* Modify the `NewController` function in `pkg/controller/controller.go` to remove the logic to create and run a new controller instance and move it to the `Run` function in `cmd/controller/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L688-L719))
* Modify the `NewController` function in `pkg/daemon/controller.go` to accept the `stopCh` channel as an argument and use it to wait for the informer caches to sync before starting the workers ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbL76-R76), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L69-R69), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R117-R122), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L593-L596))
* Add the informers and listers for the CRDs of `OvnEip`, `OvnFip`, `OvnSnatRule`, and `OvnDnatRule` to the `Run` function in `cmd/controller/controller.go` and the `NewController` function in `pkg/daemon/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R282-R288), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L416-R448), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L599-L605), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L615-L620), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L629-L634), [link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L643-L648))
* Change the names of the work queues for the CRDs of `VirtualIp`, `IptablesEip`, `IptablesFip`, `IptablesDnatRule`, and `IptablesSnatRule` to use camel case in the `Run` function in `cmd/controller/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L323-R369))
* Add the `sgKeyMutex` field to the controller struct in the `Run` function in `cmd/controller/controller.go` and initialize it with a prime number of buckets ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L402-R416))
* Add the logic to check the `EnableLb` and `EnableNP` flags of the controller configuration and add the informers and listers for the CRDs of `SwitchLBRule`, `VpcDns`, and `NetworkPolicy` if the flags are true in the `Run` function in `cmd/controller/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R459-R508))
* Move the logic to add the event handlers for the CRDs of `SwitchLBRule`, `VpcDns`, and `NetworkPolicy` from the `Run` function in `cmd/controller/controller.go` to the end of the `NewController` function in `pkg/controller/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L483-L512))
* Move the logic to add the event handler for the `NetworkPolicy` CRD from the `Run` function in `cmd/controller/controller.go` to the end of the `NewController` function in `pkg/controller/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2768/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L537-L551))