### PR TITLE
fix ip statistics in subnet status

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -918,6 +918,9 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 			return err
 		}
 	}
+
+	c.ipam.ReleaseAddressByPod(key)
+
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to get pod nets %v", err)
@@ -935,7 +938,6 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 			}
 		}
 	}
-	c.ipam.ReleaseAddressByPod(key)
 	for _, podNet := range podNets {
 		c.syncVirtualPortsQueue.Add(podNet.Subnet.Name)
 	}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
Fixes incorrect ip statistics in subnet status:

```txt
  v4availableIPrange:      10.16.0.2-10.16.0.3,10.16.0.5,10.16.0.7-10.16.0.16,10.16.0.18-10.16.0.20,10.16.0.23-10.16.255.254
  v4availableIPs:          65529
  v4usingIPrange:          10.16.0.4,10.16.0.6,10.16.0.17,10.16.0.21-10.16.0.22
  v4usingIPs:              4
```

During deleting a pod, kube-ovn-controller deletes the IP CR first and then releases the IP address. There is a chance that subnet status update is triggered by the IP CR deletion before the IP address is released.

This patch fixes the ip statistics by releasing the IP address before deleting the IP CR.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d17481</samp>

This pull request improves the IP address management for pods by avoiding duplicate or stale allocations. It modifies the `pod.go` file to release the pod's IP address only once and before assigning a new one.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6d17481</samp>

> _Oh we are the coders of the `pod.go` file_
> _And we work on the logic of the IP address style_
> _We release the old one before we assign the new_
> _To prevent the conflicts and the leaks that ensue_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d17481</samp>

*  Release the IP address of a pod if it is marked for deletion, before allocating a new one, to avoid IP address conflicts and leaks in `handleAddUpdatePod` ([link](https://github.com/kubeovn/kube-ovn/pull/2769/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R921-R923))
* Remove the redundant call to release the IP address of a pod in `handleDeletePod`, since it is already done in `handleAddUpdatePod` ([link](https://github.com/kubeovn/kube-ovn/pull/2769/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L938))