### PR TITLE
optimize kube-ovn-controller logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/kubeovn/gonetworkmanager/v2 v2.0.0-20230327064018-0b27f88874f7
 	github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875
 	github.com/moby/sys/mountinfo v0.6.2
-	github.com/neverlee/keymutex v0.0.0-20171121013845-f593aa834bf9
 	github.com/oilbeater/go-ping v0.0.0-20200413021620-332b7197c5b5
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6

--- a/go.sum
+++ b/go.sum
@@ -1052,8 +1052,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/neverlee/keymutex v0.0.0-20171121013845-f593aa834bf9 h1:UfW5pM66x0MWE72ySrpd2Ymrn+b62kNHirozKkY3ojE=
-github.com/neverlee/keymutex v0.0.0-20171121013845-f593aa834bf9/go.mod h1:3hf2IoUXDKjCg/EuqSLUB5TY8StGS3haWYJiqzP907c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -3,10 +3,10 @@ package controller
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
-	"github.com/neverlee/keymutex"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/keymutex"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
@@ -63,7 +64,7 @@ type Controller struct {
 	addOrUpdatePodQueue    workqueue.RateLimitingInterface
 	deletePodQueue         workqueue.RateLimitingInterface
 	updatePodSecurityQueue workqueue.RateLimitingInterface
-	podKeyMutex            *keymutex.KeyMutex
+	podKeyMutex            keymutex.KeyMutex
 
 	vpcsLister           kubeovnlister.VpcLister
 	vpcSynced            cache.InformerSynced
@@ -81,7 +82,7 @@ type Controller struct {
 	updateVpcDnatQueue            workqueue.RateLimitingInterface
 	updateVpcSnatQueue            workqueue.RateLimitingInterface
 	updateVpcSubnetQueue          workqueue.RateLimitingInterface
-	vpcNatGwKeyMutex              *keymutex.KeyMutex
+	vpcNatGwKeyMutex              keymutex.KeyMutex
 
 	switchLBRuleLister      kubeovnlister.SwitchLBRuleLister
 	switchLBRuleSynced      cache.InformerSynced
@@ -101,7 +102,7 @@ type Controller struct {
 	deleteRouteQueue        workqueue.RateLimitingInterface
 	updateSubnetStatusQueue workqueue.RateLimitingInterface
 	syncVirtualPortsQueue   workqueue.RateLimitingInterface
-	subnetStatusKeyMutex    *keymutex.KeyMutex
+	subnetStatusKeyMutex    keymutex.KeyMutex
 
 	ipsLister kubeovnlister.IPLister
 	ipSynced  cache.InformerSynced
@@ -208,14 +209,14 @@ type Controller struct {
 	npsSynced     cache.InformerSynced
 	updateNpQueue workqueue.RateLimitingInterface
 	deleteNpQueue workqueue.RateLimitingInterface
-	npKeyMutex    *keymutex.KeyMutex
+	npKeyMutex    keymutex.KeyMutex
 
 	sgsLister          kubeovnlister.SecurityGroupLister
 	sgSynced           cache.InformerSynced
 	addOrUpdateSgQueue workqueue.RateLimitingInterface
 	delSgQueue         workqueue.RateLimitingInterface
 	syncSgPortsQueue   workqueue.RateLimitingInterface
-	sgKeyMutex         *keymutex.KeyMutex
+	sgKeyMutex         keymutex.KeyMutex
 
 	qosPoliciesLister    kubeovnlister.QoSPolicyLister
 	qosPolicySynced      cache.InformerSynced
@@ -287,6 +288,10 @@ func Run(ctx context.Context, config *Configuration) {
 	ovnSnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().OvnSnatRules()
 	ovnDnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().OvnDnatRules()
 
+	numKeyLocks := runtime.NumCPU() * 2
+	if numKeyLocks < config.WorkerNum*2 {
+		numKeyLocks = config.WorkerNum * 2
+	}
 	controller := &Controller{
 		config:          config,
 		vpcs:            &sync.Map{},
@@ -311,7 +316,7 @@ func Run(ctx context.Context, config *Configuration) {
 		updateVpcDnatQueue:            workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "UpdateVpcDnat"),
 		updateVpcSnatQueue:            workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "UpdateVpcSnat"),
 		updateVpcSubnetQueue:          workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "UpdateVpcSubnet"),
-		vpcNatGwKeyMutex:              keymutex.New(97),
+		vpcNatGwKeyMutex:              keymutex.NewHashed(numKeyLocks),
 
 		subnetsLister:           subnetInformer.Lister(),
 		subnetSynced:            subnetInformer.Informer().HasSynced,
@@ -320,7 +325,7 @@ func Run(ctx context.Context, config *Configuration) {
 		deleteRouteQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeleteRoute"),
 		updateSubnetStatusQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdateSubnetStatus"),
 		syncVirtualPortsQueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "SyncVirtualPort"),
-		subnetStatusKeyMutex:    keymutex.New(97),
+		subnetStatusKeyMutex:    keymutex.NewHashed(numKeyLocks),
 
 		ipsLister: ipInformer.Lister(),
 		ipSynced:  ipInformer.Informer().HasSynced,
@@ -382,7 +387,7 @@ func Run(ctx context.Context, config *Configuration) {
 		addOrUpdatePodQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AddOrUpdatePod"),
 		deletePodQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeletePod"),
 		updatePodSecurityQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdatePodSecurity"),
-		podKeyMutex:            keymutex.New(97),
+		podKeyMutex:            keymutex.NewHashed(numKeyLocks),
 
 		namespacesLister:  namespaceInformer.Lister(),
 		namespacesSynced:  namespaceInformer.Informer().HasSynced,
@@ -413,7 +418,7 @@ func Run(ctx context.Context, config *Configuration) {
 		configMapsLister: configMapInformer.Lister(),
 		configMapsSynced: configMapInformer.Informer().HasSynced,
 
-		sgKeyMutex:         keymutex.New(97),
+		sgKeyMutex:         keymutex.NewHashed(numKeyLocks),
 		sgsLister:          sgInformer.Lister(),
 		sgSynced:           sgInformer.Informer().HasSynced,
 		addOrUpdateSgQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdateSg"),
@@ -474,7 +479,7 @@ func Run(ctx context.Context, config *Configuration) {
 		controller.npsSynced = npInformer.Informer().HasSynced
 		controller.updateNpQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdateNp")
 		controller.deleteNpQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeleteNp")
-		controller.npKeyMutex = keymutex.New(97)
+		controller.npKeyMutex = keymutex.NewHashed(128)
 	}
 
 	defer controller.shutdown()

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/ovn-org/libovsdb/ovsdb"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,8 +16,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-
-	"github.com/ovn-org/libovsdb/ovsdb"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -141,8 +140,8 @@ func (c *Controller) handleUpdateNp(key string) error {
 		return nil
 	}
 
-	c.npKeyMutex.Lock(key)
-	defer c.npKeyMutex.Unlock(key)
+	c.npKeyMutex.LockKey(key)
+	defer func() { _ = c.npKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle add/update network policy %s", key)
 
 	np, err := c.npsLister.NetworkPolicies(namespace).Get(name)
@@ -564,8 +563,8 @@ func (c *Controller) handleDeleteNp(key string) error {
 		return nil
 	}
 
-	c.npKeyMutex.Lock(key)
-	defer c.npKeyMutex.Unlock(key)
+	c.npKeyMutex.LockKey(key)
+	defer func() { _ = c.npKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle delete network policy %s", key)
 
 	npName := name

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -638,7 +638,7 @@ func (c *Controller) createOrUpdateCrdIPs(podName, ip, mac, subnetName, ns, node
 	if existingCR != nil {
 		ipCr = *existingCR
 	} else {
-		ipCr, err = c.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), ipName, metav1.GetOptions{})
+		ipCr, err = c.ipsLister.Get(ipName)
 		if err != nil {
 			if !k8serrors.IsNotFound(err) {
 				errMsg := fmt.Errorf("failed to get ip CR %s: %v", ipName, err)

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -8,15 +8,17 @@ import (
 	"strconv"
 	"time"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (c *Controller) enqueueAddOvnEip(obj interface{}) {
@@ -711,24 +713,24 @@ func (c *Controller) isOvnEipNotUse(cachedEip *kubeovnv1.OvnEip) (bool, error) {
 	switch cachedEip.Status.Type {
 	case util.DnatUsingEip:
 		// nat change eip not that fast
-		dnats, err := c.config.KubeOvnClient.KubeovnV1().OvnDnatRules().List(context.Background(), metav1.ListOptions{})
+		dnats, err := c.ovnDnatRulesLister.List(labels.Everything())
 		if err != nil {
 			klog.Errorf("failed to get ovn dnat list, %v", err)
 			return false, err
 		}
-		for _, item := range dnats.Items {
+		for _, item := range dnats {
 			if item.Annotations[util.VpcEipAnnotation] == cachedEip.Name {
 				return false, nil
 			}
 		}
 	case util.SnatUsingEip:
 		// nat change eip not that fast
-		snats, err := c.config.KubeOvnClient.KubeovnV1().OvnSnatRules().List(context.Background(), metav1.ListOptions{})
+		snats, err := c.ovnSnatRulesLister.List(labels.Everything())
 		if err != nil {
 			klog.Errorf("failed to get ovn snat, %v", err)
 			return false, err
 		}
-		for _, item := range snats.Items {
+		for _, item := range snats {
 			if item.Annotations[util.VpcEipAnnotation] == cachedEip.Name {
 				return false, nil
 			}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -365,7 +365,6 @@ func (c *Controller) processNextAddOrUpdatePodWorkItem() bool {
 			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
 			return nil
 		}
-		klog.Infof("handle sync pod %s", key)
 		if err := c.handleAddOrUpdatePod(key); err != nil {
 			c.addOrUpdatePodQueue.AddRateLimited(key)
 			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
@@ -400,7 +399,6 @@ func (c *Controller) processNextDeletePodWorkItem() bool {
 			utilruntime.HandleError(fmt.Errorf("expected pod in workqueue but got %#v", obj))
 			return nil
 		}
-		klog.Infof("handle delete pod %s/%s", pod.Namespace, pod.Name)
 		if err := c.handleDeletePod(pod); err != nil {
 			c.deletePodQueue.AddRateLimited(obj)
 			return fmt.Errorf("error syncing '%s': %s, requeuing", pod.Name, err.Error())
@@ -475,7 +473,7 @@ func (c *Controller) getPodKubeovnNets(pod *v1.Pod) ([]*kubeovnNet, error) {
 
 func (c *Controller) changeVMSubnet(vmName, namespace, providerName, subnetName string, pod *v1.Pod) error {
 	ipName := ovs.PodNameToPortName(vmName, namespace, providerName)
-	ipCr, err := c.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), ipName, metav1.GetOptions{})
+	ipCr, err := c.ipsLister.Get(ipName)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			errMsg := fmt.Errorf("failed to get ip CR %s: %v", ipName, err)
@@ -513,8 +511,9 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 		return nil
 	}
 
-	c.podKeyMutex.Lock(key)
-	defer c.podKeyMutex.Unlock(key)
+	c.podKeyMutex.LockKey(key)
+	defer func() { _ = c.podKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle add/update pod %s", key)
 
 	cachedPod, err := c.podsLister.Pods(namespace).Get(name)
 	if err != nil {
@@ -832,13 +831,11 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 }
 
 func (c *Controller) handleDeletePod(pod *v1.Pod) error {
-	var key string
-	var err error
-
 	podName := c.getNameByPod(pod)
-	key = fmt.Sprintf("%s/%s", pod.Namespace, podName)
-	c.podKeyMutex.Lock(key)
-	defer c.podKeyMutex.Unlock(key)
+	key := fmt.Sprintf("%s/%s", pod.Namespace, podName)
+	c.podKeyMutex.LockKey(key)
+	defer func() { _ = c.podKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle delete pod %s", key)
 
 	p, _ := c.podsLister.Pods(pod.Namespace).Get(pod.Name)
 	if p != nil && p.UID != pod.UID {
@@ -951,8 +948,8 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 		return nil
 	}
 
-	c.podKeyMutex.Lock(key)
-	defer c.podKeyMutex.Unlock(key)
+	c.podKeyMutex.LockKey(key)
+	defer func() { _ = c.podKeyMutex.UnlockKey(key) }()
 
 	pod, err := c.podsLister.Pods(namespace).Get(name)
 	if err != nil {

--- a/pkg/controller/qos_policy.go
+++ b/pkg/controller/qos_policy.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -18,6 +16,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (c *Controller) enqueueAddQoSPolicy(obj interface{}) {
@@ -182,9 +183,9 @@ func (c *Controller) processNextDeleteQoSPolicyWorkItem() bool {
 }
 
 func (c *Controller) handleAddQoSPolicy(key string) error {
-
-	c.vpcNatGwKeyMutex.Lock(key)
-	defer c.vpcNatGwKeyMutex.Unlock(key)
+	c.vpcNatGwKeyMutex.LockKey(key)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle add QoS policy %s", key)
 
 	cachedQoS, err := c.qosPoliciesLister.Get(key)
 	if err != nil {
@@ -383,8 +384,9 @@ func (c *Controller) validateQosPolicy(qosPolicy *kubeovnv1.QoSPolicy) error {
 }
 
 func (c *Controller) handleUpdateQoSPolicy(key string) error {
-	c.vpcNatGwKeyMutex.Lock(key)
-	defer c.vpcNatGwKeyMutex.Unlock(key)
+	c.vpcNatGwKeyMutex.LockKey(key)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle update QoS policy %s", key)
 
 	cachedQos, err := c.qosPoliciesLister.Get(key)
 	if err != nil {

--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -227,8 +227,9 @@ func (c *Controller) updateDenyAllSgPorts() error {
 }
 
 func (c *Controller) handleAddOrUpdateSg(key string) error {
-	c.sgKeyMutex.Lock(key)
-	defer c.sgKeyMutex.Unlock(key)
+	c.sgKeyMutex.LockKey(key)
+	defer func() { _ = c.sgKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle add/update security group %s", key)
 
 	// set 'deny all' for port associated with security group
 	if key == util.DenyAllSecurityGroup {
@@ -394,8 +395,9 @@ func (c *Controller) patchSgStatus(sg *kubeovnv1.SecurityGroup) {
 }
 
 func (c *Controller) handleDeleteSg(key string) error {
-	c.sgKeyMutex.Lock(key)
-	defer c.sgKeyMutex.Unlock(key)
+	c.sgKeyMutex.LockKey(key)
+	defer func() { _ = c.sgKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle delete security group %s", key)
 
 	if err := c.ovnClient.DeleteSecurityGroup(key); err != nil {
 		klog.Errorf("delete sg %s: %v", key, err)
@@ -406,8 +408,9 @@ func (c *Controller) handleDeleteSg(key string) error {
 }
 
 func (c *Controller) syncSgLogicalPort(key string) error {
-	c.sgKeyMutex.Lock(key)
-	defer c.sgKeyMutex.Unlock(key)
+	c.sgKeyMutex.LockKey(key)
+	defer func() { _ = c.sgKeyMutex.UnlockKey(key) }()
+	klog.Infof("sync lsp for security group %s", key)
 
 	sg, err := c.sgsLister.Get(key)
 	if err != nil {

--- a/pkg/controller/switch_lb_rule.go
+++ b/pkg/controller/switch_lb_rule.go
@@ -137,7 +137,7 @@ func (c *Controller) handleAddOrUpdateSwitchLBRule(key string) error {
 
 	needToCreate := false
 	name := genSvcName(slr.Name)
-	oldSvc, err := c.config.KubeClient.CoreV1().Services(slr.Spec.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+	oldSvc, err := c.servicesLister.Services(slr.Spec.Namespace).Get(name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			needToCreate = true

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -7,9 +7,6 @@ import (
 	"net"
 	"strings"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/ovs"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,6 +14,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (c *Controller) enqueueAddVirtualIp(obj interface{}) {
@@ -323,7 +324,7 @@ func (c *Controller) subnetCountIp(subnet *kubeovnv1.Subnet) error {
 }
 
 func (c *Controller) createOrUpdateCrdVip(key, ns, subnet, v4ip, v6ip, mac, pV4ip, pV6ip, pmac string) error {
-	vipCr, err := c.config.KubeOvnClient.KubeovnV1().Vips().Get(context.Background(), key, metav1.GetOptions{})
+	vipCr, err := c.virtualIpsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Create(context.Background(), &kubeovnv1.Vip{

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -224,7 +224,7 @@ func (c *Controller) addLoadBalancer(vpc string) (*VpcLoadBalancer, error) {
 
 func (c *Controller) handleAddOrUpdateVpc(key string) error {
 	// get latest vpc info
-	cachedVpc, err := c.config.KubeOvnClient.KubeovnV1().Vpcs().Get(context.Background(), key, metav1.GetOptions{})
+	cachedVpc, err := c.vpcsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -856,7 +856,7 @@ func (c *Controller) handleAddVpcExternal(key string) error {
 }
 
 func (c *Controller) handleDeleteVpcStaticRoute(key string) error {
-	vpc, err := c.config.KubeOvnClient.KubeovnV1().Vpcs().Get(context.Background(), key, metav1.GetOptions{})
+	vpc, err := c.vpcsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil

--- a/pkg/controller/vpc_dns.go
+++ b/pkg/controller/vpc_dns.go
@@ -302,8 +302,7 @@ func (c *Controller) createOrUpdateVpcDnsDep(vpcDns *kubeovnv1.VpcDns) error {
 
 func (c *Controller) createOrUpdateVpcDnsSlr(vpcDns *kubeovnv1.VpcDns) error {
 	needToCreateSlr := false
-	oldSlr, err := c.config.KubeOvnClient.KubeovnV1().SwitchLBRules().Get(context.Background(),
-		genVpcDnsDpName(vpcDns.Name), metav1.GetOptions{})
+	oldSlr, err := c.switchLBRuleLister.Get(genVpcDnsDpName(vpcDns.Name))
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			needToCreateSlr = true

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -207,8 +206,8 @@ func (c *Controller) processNextWorkItem(processName string, queue workqueue.Rat
 }
 
 func (c *Controller) handleDelVpcNatGw(key string) error {
-	c.vpcNatGwKeyMutex.Lock(key)
-	defer c.vpcNatGwKeyMutex.Unlock(key)
+	c.vpcNatGwKeyMutex.LockKey(key)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 	name := genNatGwStsName(key)
 	klog.Infof("delete vpc nat gw %s", name)
 	if err := c.config.KubeClient.AppsV1().StatefulSets(c.config.PodNamespace).Delete(context.Background(),
@@ -244,8 +243,10 @@ func isVpcNatGwChanged(gw *kubeovnv1.VpcNatGateway) bool {
 
 func (c *Controller) handleAddOrUpdateVpcNatGw(key string) error {
 	// create nat gw statefulset
-	c.vpcNatGwKeyMutex.Lock(key)
-	defer c.vpcNatGwKeyMutex.Unlock(key)
+	c.vpcNatGwKeyMutex.LockKey(key)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle add/update vpc nat gateway %s", key)
+
 	if vpcNatEnabled != "true" {
 		return fmt.Errorf("iptables nat gw not enable")
 	}
@@ -344,8 +345,11 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 	if vpcNatEnabled != "true" {
 		return fmt.Errorf("iptables nat gw not enable")
 	}
-	c.vpcNatGwKeyMutex.Lock(key)
-	defer c.vpcNatGwKeyMutex.Unlock(key)
+
+	c.vpcNatGwKeyMutex.LockKey(key)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle init vpc nat gateway %s", key)
+
 	gw, err := c.vpcNatGatewayLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -427,8 +431,11 @@ func (c *Controller) handleUpdateVpcFloatingIp(natGwKey string) error {
 	if vpcNatEnabled != "true" {
 		return fmt.Errorf("iptables nat gw not enable")
 	}
-	c.vpcNatGwKeyMutex.Lock(natGwKey)
-	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
+
+	c.vpcNatGwKeyMutex.LockKey(natGwKey)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
+	klog.Infof("handle update vpc fip %s", natGwKey)
+
 	// refresh exist fips
 	if err := c.initCreateAt(natGwKey); err != nil {
 		err = fmt.Errorf("failed to init nat gw pod '%s' create at, %v", natGwKey, err)
@@ -436,17 +443,14 @@ func (c *Controller) handleUpdateVpcFloatingIp(natGwKey string) error {
 		return err
 	}
 
-	fips, err := c.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().List(context.Background(), metav1.ListOptions{
-		LabelSelector: fields.OneTermEqualSelector(util.VpcNatGatewayNameLabel, natGwKey).String(),
-	})
-
+	fips, err := c.iptablesFipsLister.List(labels.SelectorFromSet(labels.Set{util.VpcNatGatewayNameLabel: natGwKey}))
 	if err != nil {
 		err := fmt.Errorf("failed to get all fips, %v", err)
 		klog.Error(err)
 		return err
 	}
 
-	for _, fip := range fips.Items {
+	for _, fip := range fips {
 		if fip.Status.Redo != NAT_GW_CREATED_AT {
 			klog.V(3).Infof("redo fip %s", fip.Name)
 			if err = c.redoFip(fip.Name, NAT_GW_CREATED_AT, false); err != nil {
@@ -462,8 +466,11 @@ func (c *Controller) handleUpdateVpcEip(natGwKey string) error {
 	if vpcNatEnabled != "true" {
 		return fmt.Errorf("iptables nat gw not enable")
 	}
-	c.vpcNatGwKeyMutex.Lock(natGwKey)
-	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
+
+	c.vpcNatGwKeyMutex.LockKey(natGwKey)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
+	klog.Infof("handle update vpc eip %s", natGwKey)
+
 	// refresh exist fips
 	if err := c.initCreateAt(natGwKey); err != nil {
 		err = fmt.Errorf("failed to init nat gw pod '%s' create at, %v", natGwKey, err)
@@ -492,23 +499,24 @@ func (c *Controller) handleUpdateVpcSnat(natGwKey string) error {
 	if vpcNatEnabled != "true" {
 		return fmt.Errorf("iptables nat gw not enable")
 	}
-	c.vpcNatGwKeyMutex.Lock(natGwKey)
-	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
+
+	c.vpcNatGwKeyMutex.LockKey(natGwKey)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
+	klog.Infof("handle update vpc snat %s", natGwKey)
+
 	// refresh exist snats
 	if err := c.initCreateAt(natGwKey); err != nil {
 		err = fmt.Errorf("failed to init nat gw pod '%s' create at, %v", natGwKey, err)
 		klog.Error(err)
 		return err
 	}
-	snats, err := c.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().List(context.Background(), metav1.ListOptions{
-		LabelSelector: fields.OneTermEqualSelector(util.VpcNatGatewayNameLabel, natGwKey).String(),
-	})
+	snats, err := c.iptablesSnatRulesLister.List(labels.SelectorFromSet(labels.Set{util.VpcNatGatewayNameLabel: natGwKey}))
 	if err != nil {
 		err = fmt.Errorf("failed to get all snats, %v", err)
 		klog.Error(err)
 		return err
 	}
-	for _, snat := range snats.Items {
+	for _, snat := range snats {
 		if snat.Status.Redo != NAT_GW_CREATED_AT {
 			klog.V(3).Infof("redo snat %s", snat.Name)
 			if err = c.redoSnat(snat.Name, NAT_GW_CREATED_AT, false); err != nil {
@@ -525,8 +533,11 @@ func (c *Controller) handleUpdateVpcDnat(natGwKey string) error {
 	if vpcNatEnabled != "true" {
 		return fmt.Errorf("iptables nat gw not enable")
 	}
-	c.vpcNatGwKeyMutex.Lock(natGwKey)
-	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
+
+	c.vpcNatGwKeyMutex.LockKey(natGwKey)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
+	klog.Infof("handle update vpc dnat %s", natGwKey)
+
 	// refresh exist dnats
 	if err := c.initCreateAt(natGwKey); err != nil {
 		err = fmt.Errorf("failed to init nat gw pod '%s' create at, %v", natGwKey, err)
@@ -534,15 +545,13 @@ func (c *Controller) handleUpdateVpcDnat(natGwKey string) error {
 		return err
 	}
 
-	dnats, err := c.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().List(context.Background(), metav1.ListOptions{
-		LabelSelector: fields.OneTermEqualSelector(util.VpcNatGatewayNameLabel, natGwKey).String(),
-	})
+	dnats, err := c.iptablesDnatRulesLister.List(labels.SelectorFromSet(labels.Set{util.VpcNatGatewayNameLabel: natGwKey}))
 	if err != nil {
 		err = fmt.Errorf("failed to get all dnats, %v", err)
 		klog.Error(err)
 		return err
 	}
-	for _, dnat := range dnats.Items {
+	for _, dnat := range dnats {
 		if dnat.Status.Redo != NAT_GW_CREATED_AT {
 			klog.V(3).Infof("redo dnat %s", dnat.Name)
 			if err = c.redoDnat(dnat.Name, NAT_GW_CREATED_AT, false); err != nil {
@@ -592,8 +601,11 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 	if vpcNatEnabled != "true" {
 		return fmt.Errorf("iptables nat gw not enable")
 	}
-	c.vpcNatGwKeyMutex.Lock(natGwKey)
-	defer c.vpcNatGwKeyMutex.Unlock(natGwKey)
+
+	c.vpcNatGwKeyMutex.LockKey(natGwKey)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
+	klog.Infof("handle update subnet route for nat gateway %s", natGwKey)
+
 	gw, err := c.vpcNatGatewayLister.Get(natGwKey)
 	if err != nil {
 		return err
@@ -852,7 +864,7 @@ func (c *Controller) initCreateAt(key string) (err error) {
 }
 
 func (c *Controller) updateCrdNatGwLabels(key string, qos string) error {
-	gw, err := c.config.KubeOvnClient.KubeovnV1().VpcNatGateways().Get(context.Background(), key, metav1.GetOptions{})
+	gw, err := c.vpcNatGatewayLister.Get(key)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to get vpc nat gw '%s', %v", key, err)
 		klog.Error(errMsg)
@@ -998,8 +1010,7 @@ func (c *Controller) patchNatGwStatus(key string) error {
 }
 
 func (c *Controller) execNatGwQoS(gw *kubeovnv1.VpcNatGateway, qos string, operation string) error {
-	var err error
-	qosPolicy, err := c.config.KubeOvnClient.KubeovnV1().QoSPolicies().Get(context.Background(), qos, metav1.GetOptions{})
+	qosPolicy, err := c.qosPoliciesLister.Get(qos)
 	if err != nil {
 		klog.Errorf("get qos policy %s failed: %v", qos, err)
 		return err

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -342,7 +342,7 @@ func (c *Controller) recordProviderNetworkErr(providerNetwork string, errMsg str
 			return
 		}
 	} else {
-		if currentPod, err = c.config.KubeClient.CoreV1().Pods(c.localNamespace).Get(context.Background(), c.localPodName, metav1.GetOptions{}); err != nil {
+		if currentPod, err = c.podsLister.Pods(c.localNamespace).Get(c.localPodName); err != nil {
 			klog.Errorf("failed to get pod %s, %v", c.localPodName, err)
 			return
 		}

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog/v2"
 )
 
@@ -51,4 +53,16 @@ func ServiceClusterIPs(svc v1.Service) []string {
 		ips = []string{svc.Spec.ClusterIP}
 	}
 	return ips
+}
+
+func LabelSelectorNotEquals(key, value string) (labels.Selector, error) {
+	requirement, err := labels.NewRequirement(key, selection.NotEquals, []string{value})
+	if err != nil {
+		return nil, err
+	}
+	return labels.Everything().Add(*requirement), nil
+}
+
+func LabelSelectorNotEmpty(key string) (labels.Selector, error) {
+	return LabelSelectorNotEquals(key, "")
 }


### PR DESCRIPTION
1. get resources using lister interfaces;
2. replace keymutex with the k8s implementation


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cf4547</samp>

This pull request refactors and improves the performance and consistency of the controller and daemon packages by using listers and keymutexes instead of clients and locks, and by updating the usage of the libovsdb and k8s.io/utils packages. It also removes unused imports and dependencies, and adds logging and label selector helpers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8cf4547</samp>

> _Oh we are the lister crew, we query the cache not the API_
> _We use the keymutex too, to lock the keys efficiently_
> _Heave away, heave away, on the count of three_
> _We'll improve the controller code, with performance and consistency_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8cf4547</samp>

*  Replace the custom keymutex.KeyMutex type with the keymutex.KeyMutex type from k8s.io/utils, which has a different method signature for locking and unlocking keys, and add log messages to indicate the start of handling events ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L66-R67),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L84-R85),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L104-R105),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L211-R212),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L218-R219),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L314-R319),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L323-R328),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L385-R390),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L416-R421),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L144-R144),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L567-R567),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L516-R517),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L835-R838),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L954-R952),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L183-R187),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L345-R348),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L230-R232),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L397-R400),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L409-R413),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L515-R516),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L789-R789),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L205-R205),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L221-R223),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L283-R288),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L351-R359),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L386-R394),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L449-R461),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L208-R209),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L343-R342),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL559-R564),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL674-R682),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL739-R747),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL858-R869),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL924-R935))
* Replace the use of the client to get or list resources with the use of the lister, which is more efficient and consistent with other parts of the code ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L684-R686),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L818-R820),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L826-R826),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L100-R100),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L155-R155),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L229-R229),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L235-R235),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L615-R615),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L625-R625),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L672-R672),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L641-R641),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceL714-R721),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceL726-R733),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L478-R477),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L533-R532),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1142-R1141),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1151-R1150),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1230-R1229),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1870-R1869),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1952-R1948),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1961-R1963),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L140-R140),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L326-R327),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL227-R227),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL859-R859),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-58c0cc00f6a53ef4da72411453c2eac7a8bfdc574600e827bc8837ae93ddb747L305-R305),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L416-R427),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L424-R434),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L432-R440),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L458-R469),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L466-R475),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L516-R529),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L776-R788),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L275-R275),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L283-R281),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L292-R290),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L300-R296),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L528-R526),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L566-R564),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL491-R496),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL674-R682),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL739-R747),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL858-R869),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL924-R935),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1730-R1743),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1739-R1750),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L345-R345))
* Add an import for the labels package from k8s.io/apimachinery/pkg, which provides utilities for working with label selectors, and use the helper functions to generate label selectors from a set of key-value pairs or to match non-empty values for a given label key ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceR19-R21),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662R17-R19),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R21-R26),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1888-R1894),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1961-R1963),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aR10))
* Remove unused imports from the controller package in various files ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L6-R9),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L13),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceL11-R13),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L9-L10),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L12-R15),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L16),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L11))
* Remove an unused dependency from the go.mod file ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L26))
* Add a variable to store the number of key locks based on the number of CPUs and workers, and use it to initialize the hash-based key mutexes in `pkg/controller/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R291-R294))
* Use a fixed size of 128 for the hash table of the network policy key mutex, since the network policy keys are not based on pod names ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L477-R482))
* Remove a redundant log message from the function `processNextAddOrUpdatePodWorkItem` in `pkg/controller/pod.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L368))
* Replace the use of fields.OneTermNotEqualSelector with util.LabelSelectorNotEmpty, which is a helper function that generates a label selector that matches any non-empty value for a given label key, in `pkg/controller/gc.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L250-R259))
* Add an import for the ovsdb package from github.com/ovn-org/libovsdb, which provides a client for the OVSDB protocol, in `pkg/controller/network_policy.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46R10))
* Replace the use of the kube client to get a pod with the use of the pods lister, which is a cached and indexed informer, in `pkg/daemon/controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L345-R345))
* Add two functions to the util package to create label selectors that match resources that have a given label key with a value that is not equal to a given value, or that have a given label key with a non-empty value, and add two imports to use the labels and selection packages from the apimachinery library ([link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-b252a3b0a89aaca5bf1056643f9d4dbead04230b3c96aefbb05020c57ebac26fR11-R12),[link](https://github.com/kubeovn/kube-ovn/pull/2771/files?diff=unified&w=0#diff-b252a3b0a89aaca5bf1056643f9d4dbead04230b3c96aefbb05020c57ebac26fR57-R68))