### PR TITLE
use rate limiting queue with delaying for pod deletion events

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -377,10 +377,13 @@ func Run(ctx context.Context, config *Configuration) {
 		providerNetworksLister: providerNetworkInformer.Lister(),
 		providerNetworkSynced:  providerNetworkInformer.Informer().HasSynced,
 
-		podsLister:             podInformer.Lister(),
-		podsSynced:             podInformer.Informer().HasSynced,
-		addOrUpdatePodQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AddOrUpdatePod"),
-		deletePodQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeletePod"),
+		podsLister:          podInformer.Lister(),
+		podsSynced:          podInformer.Informer().HasSynced,
+		addOrUpdatePodQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AddOrUpdatePod"),
+		deletePodQueue: workqueue.NewRateLimitingQueueWithDelayingInterface(
+			workqueue.NewNamedDelayingQueue("DeletePod"),
+			workqueue.DefaultControllerRateLimiter(),
+		),
 		updatePodSecurityQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdatePodSecurity"),
 		podKeyMutex:            keymutex.New(97),
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4becd66</samp>

Changed the pod controller to delay pod deletion events based on the pod's termination grace period or other criteria. This is to prevent network disruption caused by premature IP address deallocation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4becd66</samp>

> _Oh we are the `Controller` crew, we manage the pods and IPs_
> _We don't want to cause a mess, we delay the deletes with ease_
> _Heave away, heave away, heave away on the `deletePodQueue`_
> _We respect the grace and state, we don't delete before it's due_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4becd66</samp>

*  Change the type of `deletePodQueue` field of the `Controller` struct to support delayed enqueuing of pod deletion events ([link](https://github.com/kubeovn/kube-ovn/pull/2774/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L380-R386))
*  Modify the `enqueueUpdatePod` function to calculate a delay based on the pod's termination grace period and deletion timestamp and use it to enqueue the pod deletion event to the `deletePodQueue` with the `AddAfter` method ([link](https://github.com/kubeovn/kube-ovn/pull/2774/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L292-R307))
*  Apply the same delay logic to stateful pods and virtual machine pods in the `enqueueUpdatePod` function by checking the pod's owner references and labels ([link](https://github.com/kubeovn/kube-ovn/pull/2774/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L305-R316), [link](https://github.com/kubeovn/kube-ovn/pull/2774/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L313-R323))