### PR TITLE
libovsdb: simplify operations for columns with a strong ref type

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router_port.go
+++ b/pkg/ovs/ovn-nb-logical_router_port.go
@@ -269,22 +269,7 @@ func (c *ovnClient) DeleteLogicalRouterPortOp(lrpName string) ([]ovsdb.Operation
 
 	// remove logical router port from logical router
 	lrName := lrp.ExternalIDs[logicalRouterKey]
-	lrpRemoveOp, err := c.LogicalRouterUpdatePortOp(lrName, lrp.UUID, ovsdb.MutateOperationDelete)
-	if err != nil {
-		return nil, err
-	}
-
-	// delete logical router port
-	lrpDelOp, err := c.Where(lrp).Delete()
-	if err != nil {
-		return nil, err
-	}
-
-	ops := make([]ovsdb.Operation, 0, len(lrpRemoveOp)+len(lrpDelOp))
-	ops = append(ops, lrpRemoveOp...)
-	ops = append(ops, lrpDelOp...)
-
-	return ops, nil
+	return c.LogicalRouterUpdatePortOp(lrName, lrp.UUID, ovsdb.MutateOperationDelete)
 }
 
 // LogicalRouterPortOp create operations about logical router port

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -570,21 +570,10 @@ func (c *ovnClient) DeleteLogicalSwitchPortOp(lspName string) ([]ovsdb.Operation
 
 	// remove logical switch port from logical switch
 	lsName := lsp.ExternalIDs[logicalSwitchKey]
-	lspRemoveOp, err := c.LogicalSwitchUpdatePortOp(lsName, lsp.UUID, ovsdb.MutateOperationDelete)
+	ops, err := c.LogicalSwitchUpdatePortOp(lsName, lsp.UUID, ovsdb.MutateOperationDelete)
 	if err != nil {
 		return nil, fmt.Errorf("generate operations for removing port %s from logical switch %s: %v", lspName, lsName, err)
 	}
-
-	// delete logical switch port
-	lspDelOp, err := c.Where(lsp).Delete()
-	if err != nil {
-		return nil, fmt.Errorf("generate operations for deleting logical switch port %s: %v", lspName, err)
-	}
-
-	ops := make([]ovsdb.Operation, 0, len(lspRemoveOp)+len(lspDelOp))
-	ops = append(ops, lspRemoveOp...)
-	ops = append(ops, lspDelOp...)
-
 	return ops, nil
 }
 

--- a/pkg/ovs/ovn-nb-nat.go
+++ b/pkg/ovs/ovn-nb-nat.go
@@ -171,21 +171,10 @@ func (c *ovnClient) DeleteNats(lrName, natType, logicalIP string) error {
 		natsUUIDs = append(natsUUIDs, nat.UUID)
 	}
 
-	removeNatOp, err := c.LogicalRouterUpdateNatOp(lrName, natsUUIDs, ovsdb.MutateOperationDelete)
+	ops, err := c.LogicalRouterUpdateNatOp(lrName, natsUUIDs, ovsdb.MutateOperationDelete)
 	if err != nil {
 		return fmt.Errorf("generate operations for deleting nats from logical router %s: %v", lrName, err)
 	}
-
-	// delete nats
-	delNatsOp, err := c.WhereCache(natFilter(natType, logicalIP, externalIDs)).Delete()
-	if err != nil {
-		return fmt.Errorf("generate operation for deleting nats: %v", err)
-	}
-
-	ops := make([]ovsdb.Operation, 0, len(removeNatOp)+len(delNatsOp))
-	ops = append(ops, removeNatOp...)
-	ops = append(ops, delNatsOp...)
-
 	if err = c.Transact("nats-del", ops); err != nil {
 		return fmt.Errorf("del nats from logical router %s: %v", lrName, err)
 	}
@@ -201,21 +190,10 @@ func (c *ovnClient) DeleteNat(lrName, natType, externalIP, logicalIP string) err
 	}
 
 	// remove nat from logical router
-	removeNatOp, err := c.LogicalRouterUpdateNatOp(lrName, []string{nat.UUID}, ovsdb.MutateOperationDelete)
+	ops, err := c.LogicalRouterUpdateNatOp(lrName, []string{nat.UUID}, ovsdb.MutateOperationDelete)
 	if err != nil {
 		return fmt.Errorf("generate operations for deleting nat from logical router %s: %v", lrName, err)
 	}
-
-	// delete nat
-	delNatsOp, err := c.Where(nat).Delete()
-	if err != nil {
-		return fmt.Errorf("generate operation for deleting nat: %v", err)
-	}
-
-	ops := make([]ovsdb.Operation, 0, len(removeNatOp)+len(delNatsOp))
-	ops = append(ops, removeNatOp...)
-	ops = append(ops, delNatsOp...)
-
 	if err = c.Transact("lr-nat-del", ops); err != nil {
 		return fmt.Errorf("del nat from logical router %s: %v", lrName, err)
 	}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 703fd48</samp>

This pull request refactors and simplifies the code for deleting various OVN-NB objects, such as logical router policies, static routes, nats, and ports. It introduces common functions that generate the necessary operations for deleting the objects from both the logical topology and the database, reducing code duplication and improving readability. The affected files are `ovn-nb-logical_router_policy.go`, `ovn-nb-logical_router_route.go`, `ovn-nb-nat.go`, `ovn-nb-logical_router_port.go`, and `ovn-nb-logical_switch_port.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 703fd48</samp>

> _We are the masters of the logical domain_
> _We slash the code with our razor-sharp brains_
> _We simplify and refactor, we generate the ops_
> _We delete the redundant, we are the logical gods_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 703fd48</samp>

*  Simplify the code for deleting logical router policies by using a single function `LogicalRouterUpdatePolicyOp` ([link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L132-R135), [link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L156-R147), [link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L189-R166))
*  Simplify the code for deleting logical router ports by using a single function `LogicalRouterUpdatePortOp` ([link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-e6855e2616a51a054e96fd9081cc8852239a14f67ec293fb75646a3c3e819f06L272-R272))
*  Simplify the code for deleting logical router static routes by using a single function `LogicalRouterUpdateStaticRouteOp` ([link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-386553eb41be041eafc944d6270c154cf99b46609ef142b487ce1e2d8dd089d6L195-R198), [link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-386553eb41be041eafc944d6270c154cf99b46609ef142b487ce1e2d8dd089d6L226-R218))
*  Simplify the code for deleting logical switch ports by using a single function `LogicalSwitchUpdatePortOp` ([link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-ae7af3149f89df0e91a059141f595e8a25f31da089acc436f931a1ebf3c90305L573-R576))
*  Simplify the code for deleting nats by using a single function `LogicalRouterUpdateNatOp` ([link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-1a843dfb6cc5e7791427ee159e4f1243b5fa6db07b5fefdbafaed21ebfe6692bL174-R177), [link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-1a843dfb6cc5e7791427ee159e4f1243b5fa6db07b5fefdbafaed21ebfe6692bL204-R196))
*  Remove some redundant code for deleting logical router policy by UUID in `pkg/ovs/ovn-nb-logical_router_policy.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2775/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L343-L352))