### PR TITLE
add support of user-defined endpoints to SwitchLBRule

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -351,6 +351,10 @@ spec:
                   items:
                     type: string
                   type: array
+                endpoints:
+                  items:
+                    type: string
+                  type: array
             status:
               type: object
               properties:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -966,6 +966,7 @@ type SwitchLBRuleSpec struct {
 	Vip             string    `json:"vip"`
 	Namespace       string    `json:"namespace"`
 	Selector        []string  `json:"selector"`
+	Endpoints       []string  `json:"endpoints"`
 	SessionAffinity string    `json:"sessionAffinity,omitempty"`
 	Ports           []SlrPort `json:"ports"`
 }

--- a/pkg/controller/switch_lb_rule.go
+++ b/pkg/controller/switch_lb_rule.go
@@ -145,7 +145,7 @@ func (c *Controller) handleAddOrUpdateSwitchLBRule(key string) error {
 	}
 
 	svcName = generateSvcName(slr.Name)
-	if oldSvc, err = c.config.KubeClient.CoreV1().Services(slr.Spec.Namespace).Get(context.Background(), svcName, metav1.GetOptions{}); err != nil {
+	if oldSvc, err = c.servicesLister.Services(slr.Spec.Namespace).Get(svcName); err != nil {
 		if k8serrors.IsNotFound(err) {
 			needToCreateSvc = true
 		} else {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features

Add support of user-defined endpoints so that  SwitchLBRule could be used to vms with static ip created by kubevirt.

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36774d0</samp>

This pull request enhances the switch load balancer rule feature by improving the code quality, adding a new field to specify endpoints, and adding a new function to generate endpoints from services. It modifies `pkg/controller/switch_lb_rule.go` and `pkg/apis/kubeovn/v1/types.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 36774d0</samp>

> _`SwitchLBRuleSpec`_
> _Has new field `Endpoints`_
> _Optional, not fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36774d0</samp>

*  Add a new field `Endpoints` to the type `SwitchLBRuleSpec` to allow manual specification of endpoints for switch load balancer rules ([link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR969))
* Rename the function `genSvcName` to `generateSvcName` for consistency and clarity ([link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L28-R28), [link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L189-R217))
* Refactor the function `handleAddOrUpdateSwitchLBRule` to create or update the service and endpoints for the switch load balancer rule based on the `Endpoints` field ([link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L130-R140), [link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L138-R182), [link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L159-R188), [link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L175-R210))
* Refactor the function `generateHeadlessService` to simplify variable declarations and return the service object directly ([link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L217-R256), [link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L233), [link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L242-L243), [link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L252-R285))
* Add a new function `generateEndpoints` to create or update the endpoints object for the switch load balancer rule with the updated addresses and ports ([link](https://github.com/kubeovn/kube-ovn/pull/2777/files?diff=unified&w=0#diff-1bbd8fc68082905bd8c8204a29a746985193081fb932bedaa86f4f25abc2dc02L267-R358))