### PR TITLE
fix static route recreation after kube-ovn-controller restarts

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -341,10 +341,6 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		}
 	}
 
-	if vpc.Name == c.config.ClusterRouter && vpc.Spec.EnableExternal {
-		// custom vpc enable external, just like default vpc with enable eip and snat above
-		targetRoutes = vpc.Spec.StaticRoutes
-	}
 	routeNeedDel, routeNeedAdd, err := diffStaticRoute(existRoute, targetRoutes)
 	if err != nil {
 		klog.Errorf("failed to diff vpc %s static route, %v", vpc.Name, err)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
After kube-ovn-controller restarts, the following static routes will be deleted and recreated:

```txt
IPv4 Routes
Route Table <main>:
                0.0.0.0/0                100.64.0.1 dst-ip

IPv6 Routes
Route Table <main>:
                     ::/0            fd00:100:64::1 dst-ip
```

During the recreation, communication across subnets will be blocked.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36c8352</samp>

Remove redundant code for custom vpc in `pkg/controller/vpc.go`. Simplify the logic for setting target routes for vpcs with external access.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 36c8352</samp>

> _`vpc` logic cleansed_
> _Redundant code removed now_
> _Simpler and error-free_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36c8352</samp>

*  Simplify the logic for custom vpc with enable external by removing redundant code ([link](https://github.com/kubeovn/kube-ovn/pull/2778/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL344-L347))