### PR TITLE
clean up code about static routes

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -98,7 +98,6 @@ type Controller struct {
 	subnetSynced            cache.InformerSynced
 	addOrUpdateSubnetQueue  workqueue.RateLimitingInterface
 	deleteSubnetQueue       workqueue.RateLimitingInterface
-	deleteRouteQueue        workqueue.RateLimitingInterface
 	updateSubnetStatusQueue workqueue.RateLimitingInterface
 	syncVirtualPortsQueue   workqueue.RateLimitingInterface
 	subnetStatusKeyMutex    *keymutex.KeyMutex
@@ -317,7 +316,6 @@ func Run(ctx context.Context, config *Configuration) {
 		subnetSynced:            subnetInformer.Informer().HasSynced,
 		addOrUpdateSubnetQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AddSubnet"),
 		deleteSubnetQueue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeleteSubnet"),
-		deleteRouteQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeleteRoute"),
 		updateSubnetStatusQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdateSubnetStatus"),
 		syncVirtualPortsQueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "SyncVirtualPort"),
 		subnetStatusKeyMutex:    keymutex.New(97),
@@ -807,7 +805,6 @@ func (c *Controller) shutdown() {
 
 	c.addOrUpdateSubnetQueue.ShutDown()
 	c.deleteSubnetQueue.ShutDown()
-	c.deleteRouteQueue.ShutDown()
 	c.updateSubnetStatusQueue.ShutDown()
 	c.syncVirtualPortsQueue.ShutDown()
 
@@ -988,7 +985,6 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		go wait.Until(c.runUpdatePodSecurityWorker, time.Second, ctx.Done())
 
 		go wait.Until(c.runDeleteSubnetWorker, time.Second, ctx.Done())
-		go wait.Until(c.runDeleteRouteWorker, time.Second, ctx.Done())
 		go wait.Until(c.runUpdateSubnetStatusWorker, time.Second, ctx.Done())
 		go wait.Until(c.runSyncVirtualPortsWorker, time.Second, ctx.Done())
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 534bb67</samp>

This pull request refactors the `Controller` struct to remove the static routing logic for subnets with centralized gateways. This reduces the complexity and potential errors of the routing management in `pkg/controller/controller.go` and `pkg/controller/subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 534bb67</samp>

> _`Controller` cleans up_
> _No more static routes for subnets_
> _Autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 534bb67</samp>

*  Remove `deleteRouteQueue` field from `Controller` struct and its initialization and shutdown in `Run` and `shutdown` methods ([link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L101), [link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L320), [link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L810))
* Remove invocation of `runDeleteRouteWorker` method in `startWorkers` method of `Controller` struct ([link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L991))
* Remove conditional logic that adds a subnet to `deleteRouteQueue` in `enqueueDeleteSubnet` method of `Controller` struct ([link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L50-R50))
* Remove definition of `runDeleteRouteWorker` method and its helper methods `processNextDeleteRoutePodWorkItem` and `handleDeleteRoute` from `subnet.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L135-L139), [link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L210-L239), [link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L807-L817))
* Remove invocation of `deleteStaticRoute` method in `reconcileOvnDefaultVpcRoute` method of `Controller` struct ([link](https://github.com/kubeovn/kube-ovn/pull/2779/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1375-L1379))