### PR TITLE
add key lock for more resources

### DIFF
--- a/pkg/controller/endpoint.go
+++ b/pkg/controller/endpoint.go
@@ -90,7 +90,10 @@ func (c *Controller) handleUpdateEndpoint(key string) error {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
-	klog.Infof("update endpoint %s/%s", namespace, name)
+
+	c.epKeyMutex.LockKey(key)
+	defer func() { _ = c.epKeyMutex.UnlockKey(key) }()
+	klog.Infof("update add/update endpoint %s/%s", namespace, name)
 
 	ep, err := c.endpointsLister.Endpoints(namespace).Get(name)
 	if err != nil {

--- a/pkg/controller/namespace.go
+++ b/pkg/controller/namespace.go
@@ -107,6 +107,10 @@ func (c *Controller) processNextAddNamespaceWorkItem() bool {
 }
 
 func (c *Controller) handleAddNamespace(key string) error {
+	c.nsKeyMutex.LockKey(key)
+	defer func() { _ = c.nsKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle add/update namespace %s", key)
+
 	cachedNs, err := c.namespacesLister.Get(key)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -192,6 +192,9 @@ func nodeUnderlayAddressSetName(node string, af int) string {
 }
 
 func (c *Controller) handleAddNode(key string) error {
+	c.nodeKeyMutex.LockKey(key)
+	defer func() { _ = c.nodeKeyMutex.UnlockKey(key) }()
+
 	cachedNode, err := c.nodesLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -454,6 +457,10 @@ func (c *Controller) handleNodeAnnotationsForProviderNetworks(node *v1.Node) err
 }
 
 func (c *Controller) handleDeleteNode(key string) error {
+	c.nodeKeyMutex.LockKey(key)
+	defer func() { _ = c.nodeKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle delete node %s", key)
+
 	portName := fmt.Sprintf("node-%s", key)
 	klog.Infof("delete logical switch port %s", portName)
 	if err := c.ovnClient.DeleteLogicalSwitchPort(portName); err != nil {
@@ -579,6 +586,10 @@ func (c *Controller) updateProviderNetworkForNodeDeletion(pn *kubeovnv1.Provider
 }
 
 func (c *Controller) handleUpdateNode(key string) error {
+	c.nodeKeyMutex.LockKey(key)
+	defer func() { _ = c.nodeKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle update node %s", key)
+
 	node, err := c.nodesLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -473,8 +473,8 @@ func (c Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, e
 }
 
 func (c *Controller) handleAddOrUpdateSubnet(key string) error {
-	c.subnetStatusKeyMutex.LockKey(key)
-	defer func() { _ = c.subnetStatusKeyMutex.UnlockKey(key) }()
+	c.subnetKeyMutex.LockKey(key)
+	defer func() { _ = c.subnetKeyMutex.UnlockKey(key) }()
 
 	cachedSubnet, err := c.subnetsLister.Get(key)
 	if err != nil {
@@ -746,8 +746,8 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 }
 
 func (c *Controller) handleUpdateSubnetStatus(key string) error {
-	c.subnetStatusKeyMutex.LockKey(key)
-	defer func() { _ = c.subnetStatusKeyMutex.UnlockKey(key) }()
+	c.subnetKeyMutex.LockKey(key)
+	defer func() { _ = c.subnetKeyMutex.UnlockKey(key) }()
 
 	cachedSubnet, err := c.subnetsLister.Get(key)
 	subnet := cachedSubnet.DeepCopy()
@@ -816,6 +816,9 @@ func (c *Controller) handleDeleteLogicalSwitch(key string) (err error) {
 }
 
 func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) error {
+	c.subnetKeyMutex.LockKey(subnet.Name)
+	defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
+
 	c.updateVpcStatusQueue.Add(subnet.Spec.Vpc)
 	klog.Infof("delete u2o interconnection policy route for subnet %s", subnet.Name)
 	if err := c.deletePolicyRouteForU2OInterconn(subnet); err != nil {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -168,12 +168,15 @@ func (c *Controller) processNextDelVlanWorkItem() bool {
 }
 
 func (c *Controller) handleAddVlan(key string) error {
+	c.vlanKeyMutex.LockKey(key)
+	defer func() { _ = c.vlanKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle add vlan %s", key)
+
 	cachedVlan, err := c.vlansLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
-
 		return err
 	}
 
@@ -229,6 +232,10 @@ func (c *Controller) handleAddVlan(key string) error {
 }
 
 func (c *Controller) handleUpdateVlan(key string) error {
+	c.vlanKeyMutex.LockKey(key)
+	defer func() { _ = c.vlanKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle update vlan %s", key)
+
 	vlan, err := c.vlansLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -263,6 +270,10 @@ func (c *Controller) handleUpdateVlan(key string) error {
 }
 
 func (c *Controller) handleDelVlan(key string) error {
+	c.vlanKeyMutex.LockKey(key)
+	defer func() { _ = c.vlanKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle delete vlan %s", key)
+
 	subnet, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets: %v", err)

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -95,6 +95,10 @@ func (c *Controller) runDelVpcWorker() {
 }
 
 func (c *Controller) handleDelVpc(vpc *kubeovnv1.Vpc) error {
+	c.vpcKeyMutex.LockKey(vpc.Name)
+	defer func() { _ = c.vpcKeyMutex.UnlockKey(vpc.Name) }()
+	klog.Infof("handle delete vpc %s", vpc.Name)
+
 	if err := c.deleteVpcLb(vpc); err != nil {
 		return err
 	}
@@ -119,6 +123,10 @@ func (c *Controller) handleDelVpc(vpc *kubeovnv1.Vpc) error {
 }
 
 func (c *Controller) handleUpdateVpcStatus(key string) error {
+	c.vpcKeyMutex.LockKey(key)
+	defer func() { _ = c.vpcKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle status update for vpc %s", key)
+
 	cachedVpc, err := c.vpcsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -223,6 +231,10 @@ func (c *Controller) addLoadBalancer(vpc string) (*VpcLoadBalancer, error) {
 }
 
 func (c *Controller) handleAddOrUpdateVpc(key string) error {
+	c.vpcKeyMutex.LockKey(key)
+	defer func() { _ = c.vpcKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle add/update vpc %s", key)
+
 	// get latest vpc info
 	cachedVpc, err := c.vpcsLister.Get(key)
 	if err != nil {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #2704 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5dd48e7</samp>

This pull request adds and improves concurrency control and data integrity for various controller functions in `kube-ovn` by using mutex locking and unlocking by resource keys. This prevents concurrent updates to the same resources by different workers or threads, and enhances the performance and reliability of the controller logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5dd48e7</samp>

> _To handle events in the cloud_
> _We need to avoid a resource crowd_
> _So we lock by the key_
> _With a `KeyMutex` spree_
> _And make our controller code proud_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5dd48e7</samp>

*  Add and initialize new fields for `vpcKeyMutex`, `nsKeyMutex`, and `svcKeyMutex` to the `Controller` struct and the `Run` function in `pkg/controller/controller.go` to synchronize access to VPC, namespace, and service resources by their names ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R74), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R198), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L202-R210), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R312), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R403), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L408-R422))
* Rename the field `subnetStatusKeyMutex` to `subnetKeyMutex` in the `Controller` struct and the `Run` function in `pkg/controller/controller.go` to reflect its usage for both subnet status updates and subnet logical switch operations ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L104-R105), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L326-R332))
* Reorder the fields of the `Controller` struct in `pkg/controller/controller.go` to group them by their related resources ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L177-R191))
* Lock and unlock the `epKeyMutex` by the endpoint key in the `handleUpdateEndpoint` function in `pkg/controller/endpoint.go` to prevent concurrent updates to the same endpoint resource ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-e446ff04750bbbe87ec6cf1387960a29d56757d84784b18f2814a6e0be5fb528L93-R97))
* Lock and unlock the `nsKeyMutex` by the namespace key in the `processNextAddNamespaceWorkItem` function in `pkg/controller/namespace.go` to prevent concurrent updates to the same namespace resource ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-6c3f4bf55669b7ff4d91e4b0e6501b0ab597c9a615ada984fb9c8451ef75f6bfR110-R113))
* Lock and unlock the `nodeKeyMutex` by the node key in the `nodeUnderlayAddressSetName`, `handleNodeAnnotationsForProviderNetworks`, and `updateProviderNetworkForNodeDeletion` functions in `pkg/controller/node.go` to prevent concurrent updates to the same node resource ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R195-R197), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R460-R463), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R589-R592))
* Lock and unlock the `svcKeyMutex` by the service key in the `processNextUpdateServiceWorkItem`, `handleUpdateService`, and `handleAddService` functions in `pkg/controller/service.go` to prevent concurrent updates to the same service resource ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R238-R247), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9L300-R314), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R445-R448))
* Lock and unlock the `subnetKeyMutex` by the subnet name in the `handleAddOrUpdateSubnet`, `handleUpdateSubnetStatus`, and `handleDeleteLogicalSwitch` functions in `pkg/controller/subnet.go` to prevent concurrent updates to the same subnet resource ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L476-R477), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L749-R750), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R819-R821))
* Lock and unlock the `vlanKeyMutex` by the VLAN key in the `processNextDelVlanWorkItem`, `handleAddVlan`, and `handleUpdateVlan` functions in `pkg/controller/vlan.go` to prevent concurrent updates to the same VLAN resource ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-7405fc764106a56c3d8c53ca59401ba6b0c285e3a136518b6be936880cbcd8d0R171-R174), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-7405fc764106a56c3d8c53ca59401ba6b0c285e3a136518b6be936880cbcd8d0R235-R238), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-7405fc764106a56c3d8c53ca59401ba6b0c285e3a136518b6be936880cbcd8d0R273-R276))
* Lock and unlock the `vpcKeyMutex` by the VPC name or key in the `runDelVpcWorker`, `handleDelVpc`, and `addLoadBalancer` functions in `pkg/controller/vpc.go` to prevent concurrent updates to the same VPC resource ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecR98-R101), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecR126-R129), [link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecR234-R237))
* Remove an empty line from the `pkg/controller/vlan.go` file for minor formatting improvement ([link](https://github.com/kubeovn/kube-ovn/pull/2781/files?diff=unified&w=0#diff-7405fc764106a56c3d8c53ca59401ba6b0c285e3a136518b6be936880cbcd8d0L176))