### PR TITLE
replace util.DefaultVpc with c.config.ClusterRouter

### DIFF
--- a/pkg/controller/endpoint.go
+++ b/pkg/controller/endpoint.go
@@ -147,7 +147,7 @@ func (c *Controller) handleUpdateEndpoint(key string) error {
 
 	if vpcName == "" {
 		if vpcName = svc.Annotations[util.VpcAnnotation]; vpcName == "" {
-			vpcName = util.DefaultVpc
+			vpcName = c.config.ClusterRouter
 		}
 	}
 

--- a/pkg/controller/external-gw.go
+++ b/pkg/controller/external-gw.go
@@ -176,7 +176,7 @@ func (c *Controller) createDefaultVpcLrpEip(config map[string]string) (string, s
 		return "", "", err
 	}
 	needCreateEip := false
-	lrpEipName := fmt.Sprintf("%s-%s", util.DefaultVpc, c.config.ExternalGatewaySwitch)
+	lrpEipName := fmt.Sprintf("%s-%s", c.config.ClusterRouter, c.config.ExternalGatewaySwitch)
 	cachedEip, err := c.ovnEipsLister.Get(lrpEipName)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
@@ -294,7 +294,7 @@ func (c *Controller) updateDefaultVpcExternal(enableExternal bool) error {
 			klog.Errorf("failed to patch vpc %s, %v", c.config.ClusterRouter, err)
 			return err
 		}
-		lrpEipName := fmt.Sprintf("%s-%s", util.DefaultVpc, c.config.ExternalGatewaySwitch)
+		lrpEipName := fmt.Sprintf("%s-%s", c.config.ClusterRouter, c.config.ExternalGatewaySwitch)
 		if err := c.patchLrpOvnEipEnableBfdLabel(lrpEipName, vpc.Spec.EnableBfd); err != nil {
 			klog.Errorf("failed to patch label for lrp %s, %v", lrpEipName, err)
 			return err

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -196,7 +196,7 @@ func (c *Controller) gcCustomLogicalRouter() error {
 	klog.Infof("vpc in kubernetes %v", vpcNames)
 
 	for _, lr := range lrs {
-		if lr.Name == util.DefaultVpc {
+		if lr.Name == c.config.ClusterRouter {
 			continue
 		}
 		if !util.IsStringIn(lr.Name, vpcNames) {
@@ -579,7 +579,7 @@ func (c *Controller) gcPortGroup() error {
 			return err
 		}
 		for _, subnet := range subnets {
-			if subnet.Spec.Vpc != util.DefaultVpc || (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
+			if subnet.Spec.Vpc != c.config.ClusterRouter || (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
 				continue
 			}
 
@@ -615,12 +615,12 @@ func (c *Controller) gcPortGroup() error {
 
 func (c *Controller) gcStaticRoute() error {
 	klog.Infof("start to gc static routes")
-	routes, err := c.ovnLegacyClient.GetStaticRouteList(util.DefaultVpc)
+	routes, err := c.ovnLegacyClient.GetStaticRouteList(c.config.ClusterRouter)
 	if err != nil {
 		klog.Errorf("failed to list static route %v", err)
 		return err
 	}
-	defaultVpc, err := c.vpcsLister.Get(util.DefaultVpc)
+	defaultVpc, err := c.vpcsLister.Get(c.config.ClusterRouter)
 	if err != nil {
 		klog.Errorf("failed to get default vpc, %v", err)
 		return err

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -59,10 +59,10 @@ func (c *Controller) InitOVN() error {
 }
 
 func (c *Controller) InitDefaultVpc() error {
-	cachedVpc, err := c.vpcsLister.Get(util.DefaultVpc)
+	cachedVpc, err := c.vpcsLister.Get(c.config.ClusterRouter)
 	if err != nil {
 		cachedVpc = &kubeovnv1.Vpc{}
-		cachedVpc.Name = util.DefaultVpc
+		cachedVpc.Name = c.config.ClusterRouter
 		cachedVpc, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Create(context.Background(), cachedVpc, metav1.CreateOptions{})
 		if err != nil {
 			klog.Errorf("init default vpc failed: %v", err)
@@ -121,7 +121,7 @@ func (c *Controller) initDefaultLogicalSwitch() error {
 	defaultSubnet := kubeovnv1.Subnet{
 		ObjectMeta: metav1.ObjectMeta{Name: c.config.DefaultLogicalSwitch},
 		Spec: kubeovnv1.SubnetSpec{
-			Vpc:                 util.DefaultVpc,
+			Vpc:                 c.config.ClusterRouter,
 			Default:             true,
 			Provider:            util.OvnProvider,
 			CIDRBlock:           c.config.DefaultCIDR,
@@ -176,7 +176,7 @@ func (c *Controller) initNodeSwitch() error {
 	nodeSubnet := kubeovnv1.Subnet{
 		ObjectMeta: metav1.ObjectMeta{Name: c.config.NodeSwitch},
 		Spec: kubeovnv1.SubnetSpec{
-			Vpc:                    util.DefaultVpc,
+			Vpc:                    c.config.ClusterRouter,
 			Default:                false,
 			Provider:               util.OvnProvider,
 			CIDRBlock:              c.config.NodeSwitchCIDR,

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -210,7 +210,7 @@ func (c *Controller) handleAddNode(key string) error {
 
 	nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(*node)
 	for _, subnet := range subnets {
-		if subnet.Spec.Vpc != util.DefaultVpc {
+		if subnet.Spec.Vpc != c.config.ClusterRouter {
 			continue
 		}
 
@@ -329,7 +329,7 @@ func (c *Controller) handleAddNode(key string) error {
 	}
 
 	for _, subnet := range subnets {
-		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != util.DefaultVpc || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
+		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
 			continue
 		}
 		if err = c.createPortGroupForDistributedSubnet(node, subnet); err != nil {
@@ -914,7 +914,7 @@ func (c *Controller) retryDelDupChassis(attempts int, sleep int, f func(node *v1
 func (c *Controller) fetchPodsOnNode(nodeName string, pods []*v1.Pod) ([]string, error) {
 	ports := make([]string, 0, len(pods))
 	for _, pod := range pods {
-		if !isPodAlive(pod) || pod.Spec.HostNetwork || pod.Spec.NodeName != nodeName || pod.Annotations[util.LogicalRouterAnnotation] != util.DefaultVpc {
+		if !isPodAlive(pod) || pod.Spec.HostNetwork || pod.Spec.NodeName != nodeName || pod.Annotations[util.LogicalRouterAnnotation] != c.config.ClusterRouter {
 			continue
 		}
 		podName := c.getNameByPod(pod)
@@ -1036,7 +1036,7 @@ func (c *Controller) validateChassis(node *v1.Node) error {
 
 func (c *Controller) addNodeGwStaticRoute() error {
 	// If user not manage static route for default vpc, just add route about ovn-default to join
-	if vpc, err := c.vpcsLister.Get(util.DefaultVpc); err != nil || vpc.Spec.StaticRoutes != nil {
+	if vpc, err := c.vpcsLister.Get(c.config.ClusterRouter); err != nil || vpc.Spec.StaticRoutes != nil {
 		existRoute, err := c.ovnLegacyClient.GetStaticRouteList(c.config.ClusterRouter)
 		if err != nil {
 			klog.Errorf("failed to get vpc %s static route list, %v", c.config.ClusterRouter, err)
@@ -1107,7 +1107,7 @@ func (c *Controller) deletePolicyRouteForNode(nodeName string) error {
 	}
 
 	for _, subnet := range subnets {
-		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != util.DefaultVpc || subnet.Name == c.config.NodeSwitch {
+		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || subnet.Name == c.config.NodeSwitch {
 			continue
 		}
 
@@ -1178,7 +1178,7 @@ func (c *Controller) addPolicyRouteForCentralizedSubnetOnNode(nodeName, nodeIP s
 	}
 
 	for _, subnet := range subnets {
-		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != util.DefaultVpc || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType {
+		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType {
 			continue
 		}
 

--- a/pkg/controller/ovn-ic.go
+++ b/pkg/controller/ovn-ic.go
@@ -454,7 +454,7 @@ func stripPrefix(policyMatch string) (string, error) {
 }
 
 func (c *Controller) syncOneRouteToPolicy(key, value string) {
-	lr, err := c.ovnClient.GetLogicalRouter(util.DefaultVpc, false)
+	lr, err := c.ovnClient.GetLogicalRouter(c.config.ClusterRouter, false)
 	if err != nil {
 		klog.Errorf("logical router does not exist %v at %v", err, time.Now())
 		return
@@ -493,7 +493,7 @@ func (c *Controller) syncOneRouteToPolicy(key, value string) {
 			delete(policyMap, lrRoute.IPPrefix)
 		} else {
 			matchFiled := util.MatchV4Dst + " == " + lrRoute.IPPrefix
-			if err := c.ovnClient.AddLogicalRouterPolicy(util.DefaultVpc, util.OvnICPolicyPriority, matchFiled, ovnnb.LogicalRouterPolicyActionAllow, nil, map[string]string{key: value, "vendor": util.CniTypeName}); err != nil {
+			if err := c.ovnClient.AddLogicalRouterPolicy(lr.Name, util.OvnICPolicyPriority, matchFiled, ovnnb.LogicalRouterPolicyActionAllow, nil, map[string]string{key: value, "vendor": util.CniTypeName}); err != nil {
 				klog.Errorf("adding router policy failed %v", err)
 			}
 		}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -722,7 +722,7 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 		podIP = pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)]
 		subnet = podNet.Subnet
 
-		if podIP != "" && (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) && subnet.Spec.Vpc == util.DefaultVpc {
+		if podIP != "" && (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) && subnet.Spec.Vpc == c.config.ClusterRouter {
 			node, err := c.nodesLister.Get(pod.Spec.NodeName)
 			if err != nil {
 				klog.Errorf("failed to get node %s: %v", pod.Spec.NodeName, err)
@@ -876,7 +876,7 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 				return err
 			}
 			// If pod has snat or eip, also need delete staticRoute when delete pod
-			if vpc.Name == util.DefaultVpc {
+			if vpc.Name == c.config.ClusterRouter {
 				if err := c.ovnLegacyClient.DeleteStaticRoute(
 					address.Ip, vpc.Name, subnet.Spec.RouteTable); err != nil {
 					return err
@@ -1352,7 +1352,7 @@ func (c *Controller) validatePodIP(podName, subnetName, ipv4, ipv6 string) (bool
 		return false, false, err
 	}
 
-	if subnet.Spec.Vlan == "" && subnet.Spec.Vpc == util.DefaultVpc {
+	if subnet.Spec.Vlan == "" && subnet.Spec.Vpc == c.config.ClusterRouter {
 		nodes, err := c.nodesLister.List(labels.Everything())
 		if err != nil {
 			klog.Errorf("failed to list nodes: %v", err)

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -310,7 +310,7 @@ func (c *Controller) handleUpdateService(key string) error {
 
 	vpcName := svc.Annotations[util.VpcAnnotation]
 	if vpcName == "" {
-		vpcName = util.DefaultVpc
+		vpcName = c.config.ClusterRouter
 	}
 	vpc, err := c.vpcsLister.Get(vpcName)
 	if err != nil {

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -177,7 +177,7 @@ type VpcLoadBalancer struct {
 }
 
 func (c *Controller) GenVpcLoadBalancer(vpcKey string) *VpcLoadBalancer {
-	if vpcKey == util.DefaultVpc || vpcKey == "" {
+	if vpcKey == c.config.ClusterRouter || vpcKey == "" {
 		return &VpcLoadBalancer{
 			TcpLoadBalancer:      c.config.ClusterTcpLoadBalancer,
 			TcpSessLoadBalancer:  c.config.ClusterTcpSessionLoadBalancer,
@@ -369,7 +369,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		}
 	}
 
-	if vpc.Name != util.DefaultVpc && vpc.Spec.PolicyRoutes == nil {
+	if vpc.Name != c.config.ClusterRouter && vpc.Spec.PolicyRoutes == nil {
 		// do not clean default vpc policy routes
 		if err = c.ovnLegacyClient.CleanPolicyRoute(vpc.Name); err != nil {
 			klog.Errorf("clean all vpc %s policy route failed, %v", vpc.Name, err)

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -43,6 +43,7 @@ type Configuration struct {
 	KubeOvnClient             clientset.Interface
 	NodeName                  string
 	ServiceClusterIPRange     string
+	ClusterRouter             string
 	NodeSwitch                string
 	EncapChecksum             bool
 	EnablePprof               bool
@@ -74,6 +75,7 @@ func ParseFlags() *Configuration {
 		argOvsSocket             = pflag.String("ovs-socket", "", "The socket to local ovs-server")
 		argKubeConfigFile        = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argServiceClusterIPRange = pflag.String("service-cluster-ip-range", "10.96.0.0/12", "The kubernetes service cluster ip range")
+		argClusterRouter         = pflag.String("cluster-router", util.DefaultVpc, "The router name for cluster router")
 		argNodeSwitch            = pflag.String("node-switch", "join", "The name of node gateway switch which help node to access pod network")
 		argEncapChecksum         = pflag.Bool("encap-checksum", true, "Enable checksum")
 		argEnablePprof           = pflag.Bool("enable-pprof", false, "Enable pprof")
@@ -127,6 +129,7 @@ func ParseFlags() *Configuration {
 		MacLearningFallback:       *argMacLearningFallback,
 		NodeName:                  strings.ToLower(*argNodeName),
 		ServiceClusterIPRange:     *argServiceClusterIPRange,
+		ClusterRouter:             *argClusterRouter,
 		NodeSwitch:                *argNodeSwitch,
 		EncapChecksum:             *argEncapChecksum,
 		NetworkType:               *argsNetworkType,

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -186,7 +186,7 @@ func (c *Controller) reconcileRouters(event subnetEvent) error {
 	joinCIDR := make([]string, 0, 2)
 	cidrs := make([]string, 0, len(subnets)*2)
 	for _, subnet := range subnets {
-		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != util.DefaultVpc || !subnet.Status.IsReady() {
+		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || !subnet.Status.IsReady() {
 			continue
 		}
 
@@ -384,7 +384,7 @@ func (c *Controller) diffPolicyRouting(oldSubnet, newSubnet *kubeovnv1.Subnet) (
 }
 
 func (c *Controller) getPolicyRouting(subnet *kubeovnv1.Subnet) ([]netlink.Rule, []netlink.Route, error) {
-	if subnet == nil || subnet.Spec.ExternalEgressGateway == "" || subnet.Spec.Vpc != util.DefaultVpc {
+	if subnet == nil || subnet.Spec.ExternalEgressGateway == "" || subnet.Spec.Vpc != c.config.ClusterRouter {
 		return nil, nil, nil
 	}
 	if subnet.Spec.GatewayType == kubeovnv1.GWCentralizedType && !util.GatewayContains(subnet.Spec.GatewayNode, c.config.NodeName) {

--- a/pkg/daemon/controller_windows.go
+++ b/pkg/daemon/controller_windows.go
@@ -54,7 +54,7 @@ func (c *Controller) reconcileRouters(_ subnetEvent) error {
 	v4Cidrs, v6Cidrs := make([]string, 0, len(subnets)), make([]string, 0, len(subnets))
 	for _, subnet := range subnets {
 		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) ||
-			subnet.Spec.Vpc != util.DefaultVpc ||
+			subnet.Spec.Vpc != c.config.ClusterRouter ||
 			!subnet.Status.IsReady() {
 			continue
 		}

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -95,7 +95,7 @@ func (c *Controller) getSubnetsNeedNAT(protocol string) ([]string, error) {
 		if subnet.DeletionTimestamp == nil &&
 			subnet.Spec.NatOutgoing &&
 			(subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) &&
-			subnet.Spec.Vpc == util.DefaultVpc &&
+			subnet.Spec.Vpc == c.config.ClusterRouter &&
 			subnet.Spec.CIDRBlock != "" &&
 			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) {
 			cidrBlock := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
@@ -116,7 +116,7 @@ func (c *Controller) getSubnetsDistributedGateway(protocol string) ([]string, er
 	for _, subnet := range subnets {
 		if subnet.DeletionTimestamp == nil &&
 			(subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) &&
-			subnet.Spec.Vpc == util.DefaultVpc &&
+			subnet.Spec.Vpc == c.config.ClusterRouter &&
 			subnet.Spec.CIDRBlock != "" &&
 			subnet.Spec.GatewayType == kubeovnv1.GWDistributedType &&
 			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) {
@@ -148,7 +148,7 @@ func (c *Controller) getDefaultVpcSubnetsCIDR(protocol string) ([]string, map[st
 	subnetMap := make(map[string]string, len(subnets)+1)
 
 	for _, subnet := range subnets {
-		if subnet.Spec.Vpc == util.DefaultVpc && (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) && subnet.Spec.CIDRBlock != "" {
+		if subnet.Spec.Vpc == c.config.ClusterRouter && (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) && subnet.Spec.CIDRBlock != "" {
 			cidrBlock := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
 			ret = append(ret, cidrBlock)
 			subnetMap[subnet.Name] = cidrBlock
@@ -207,7 +207,7 @@ func (c *Controller) getEgressNatIpByNode(nodeName string) (map[string]string, e
 			(subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) ||
 			subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType ||
 			!util.GatewayContains(subnet.Spec.GatewayNode, nodeName) ||
-			subnet.Spec.Vpc != util.DefaultVpc {
+			subnet.Spec.Vpc != c.config.ClusterRouter {
 			continue
 		}
 

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -897,7 +897,7 @@ func (c *Controller) setOvnSubnetGatewayMetric() {
 func (c *Controller) addEgressConfig(subnet *kubeovnv1.Subnet, ip string) error {
 	if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) ||
 		subnet.Spec.GatewayType != kubeovnv1.GWDistributedType ||
-		subnet.Spec.Vpc != util.DefaultVpc {
+		subnet.Spec.Vpc != c.config.ClusterRouter {
 		return nil
 	}
 
@@ -925,7 +925,7 @@ func (c *Controller) removeEgressConfig(subnet, ip string) error {
 
 	if (podSubnet.Spec.Vlan != "" && !podSubnet.Spec.LogicalGateway) ||
 		podSubnet.Spec.GatewayType != kubeovnv1.GWDistributedType ||
-		podSubnet.Spec.Vpc != util.DefaultVpc {
+		podSubnet.Spec.Vpc != c.config.ClusterRouter {
 		return nil
 	}
 
@@ -1084,7 +1084,7 @@ func (c *Controller) getLocalPodIPsNeedPR(protocol string) (map[policyRouteMeta]
 		}
 
 		if subnet.Spec.ExternalEgressGateway == "" ||
-			subnet.Spec.Vpc != util.DefaultVpc ||
+			subnet.Spec.Vpc != c.config.ClusterRouter ||
 			subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
 			continue
 		}
@@ -1147,7 +1147,7 @@ func (c *Controller) getSubnetsNeedPR(protocol string) (map[policyRouteMeta]stri
 			(subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) &&
 			subnet.Spec.GatewayType == kubeovnv1.GWCentralizedType &&
 			util.GatewayContains(subnet.Spec.GatewayNode, c.config.NodeName) &&
-			subnet.Spec.Vpc == util.DefaultVpc &&
+			subnet.Spec.Vpc == c.config.ClusterRouter &&
 			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) {
 			meta := policyRouteMeta{
 				priority: subnet.Spec.PolicyRoutingPriority,

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-func (c *ovnClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName, namespace string, portSecurity bool, securityGroups string, vips string, enableDHCP bool, dhcpOptions *DHCPOptionsUUIDs, vpc string) error {
+func (c *ovnClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName, namespace string, portSecurity bool, securityGroups, vips string, enableDHCP bool, dhcpOptions *DHCPOptionsUUIDs, vpc string) error {
 	exist, err := c.LogicalSwitchPortExists(lspName)
 	if err != nil {
 		return err


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bb7e40</samp>

This pull request makes the default VPC name configurable by the user instead of using a fixed constant `util.DefaultVpc`. It changes the references to the default VPC name in various files and functions that deal with logical routers, switches, subnets, pods, services, and endpoints. This allows the user to avoid conflicts with other VPCs and customize the cluster router name.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5bb7e40</samp>

> _Oh, we're the coders of the ovn-nb_
> _And we work on the VPC_
> _We changed the name from `util.DefaultVpc`_
> _To `c.config.ClusterRouter` (hey!)_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5bb7e40</samp>

*  Make the default VPC name configurable by the user instead of using the fixed constant util.DefaultVpc ([link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-e446ff04750bbbe87ec6cf1387960a29d56757d84784b18f2814a6e0be5fb528L150-R150), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-49e9f500bbdd1972f437e33413a4e9761aaa80c62cb2b31fe92b28c8b069333fL179-R179), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-49e9f500bbdd1972f437e33413a4e9761aaa80c62cb2b31fe92b28c8b069333fL297-R297), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L199-R199), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L582-R582), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L618-R623), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L62-R65), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L124-R124), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L179-R179), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L213-R213), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L332-R332), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L917-R917), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1039-R1039), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1110-R1110), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1181-R1181), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL457-R457), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L725-R725), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L879-R879), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1355-R1355), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9L313-R313), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L287-R287), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L622-R622), [link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L853-R853))
* Use the actual logical router name instead of the fixed constant util.DefaultVpc in the AddLogicalRouterPolicy function in the `ovn-ic.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/2782/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL496-R496))