### PR TITLE
fix missing main route table for the default vpc

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -273,6 +273,10 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 	rtbs := c.getRouteTablesByVpc(vpc)
 	targetRoutes := vpc.Spec.StaticRoutes
 	if vpc.Name == c.config.ClusterRouter {
+		if _, ok := rtbs[util.MainRouteTable]; !ok {
+			rtbs[util.MainRouteTable] = nil
+		}
+
 		joinSubnet, err := c.subnetsLister.Get(c.config.NodeSwitch)
 		if err != nil {
 			if !k8serrors.IsNotFound(err) {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1959a1e</samp>

Fix route table sync for VPCs with implicit main route table. Include the main route table of the VPC in the `rtbs` map in `pkg/controller/vpc.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1959a1e</samp>

> _`rtbs` map expands_
> _to include main route table_
> _cutting sync errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1959a1e</samp>

*  Ensure main route table is always in rtbs map ([link](https://github.com/kubeovn/kube-ovn/pull/2785/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecR276-R279))