### PR TITLE
fix handedeletePod repeat 4 times

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -63,6 +64,7 @@ type Controller struct {
 	podsSynced             cache.InformerSynced
 	addOrUpdatePodQueue    workqueue.RateLimitingInterface
 	deletePodQueue         workqueue.RateLimitingInterface
+	deletingPodObjMap      map[string]*k8sv1.Pod
 	updatePodSecurityQueue workqueue.RateLimitingInterface
 	podKeyMutex            keymutex.KeyMutex
 
@@ -394,6 +396,7 @@ func Run(ctx context.Context, config *Configuration) {
 			workqueue.NewNamedDelayingQueue("DeletePod"),
 			workqueue.DefaultControllerRateLimiter(),
 		),
+		deletingPodObjMap:      make(map[string]*k8sv1.Pod),
 		updatePodSecurityQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdatePodSecurity"),
 		podKeyMutex:            keymutex.NewHashed(numKeyLocks),
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -707,7 +707,7 @@ func (c *Controller) reconcileAllocateSubnets(cachedPod, pod *v1.Pod, needAlloca
 		if k8serrors.IsNotFound(err) {
 			// Sometimes pod is deleted between kube-ovn configure ovn-nb and patch pod.
 			// Then we need to recycle the resource again.
-			key := fmt.Sprintf("%s/%s", namespace, name)
+			key := strings.Join([]string{namespace, name}, "/")
 			c.deletingPodObjMap[key] = pod
 			c.deletePodQueue.AddRateLimited(key)
 			return nil, nil
@@ -853,7 +853,7 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 		if k8serrors.IsNotFound(err) {
 			// Sometimes pod is deleted between kube-ovn configure ovn-nb and patch pod.
 			// Then we need to recycle the resource again.
-			key := fmt.Sprintf("%s/%s", pod.Namespace, podName)
+			key := strings.Join([]string{namespace, name}, "/")
 			c.deletingPodObjMap[key] = pod
 			c.deletePodQueue.AddRateLimited(key)
 			return nil

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -150,6 +150,10 @@ func isPodAlive(p *v1.Pod) bool {
 			return false
 		}
 	}
+	return isPodStatusPhaseAlive(p)
+}
+
+func isPodStatusPhaseAlive(p *v1.Pod) bool {
 	if p.Status.Phase == v1.PodSucceeded && p.Spec.RestartPolicy != v1.RestartPolicyAlways {
 		return false
 	}
@@ -194,15 +198,18 @@ func (c *Controller) enqueueAddPod(obj interface{}) {
 		if isStateful || (isVmPod && c.config.EnableKeepVmIP) {
 			if isStateful && isStatefulSetPodToDel(c.config.KubeClient, p, statefulSetName) {
 				klog.V(3).Infof("enqueue delete pod %s", key)
-				c.deletePodQueue.Add(obj)
+				c.deletingPodObjMap[key] = p
+				c.deletePodQueue.Add(key)
 			}
 			if isVmPod && c.isVmPodToDel(p, vmName) {
 				klog.V(3).Infof("enqueue delete pod %s", key)
-				c.deletePodQueue.Add(obj)
+				c.deletingPodObjMap[key] = p
+				c.deletePodQueue.Add(key)
 			}
 		} else {
 			klog.V(3).Infof("enqueue delete pod %s", key)
-			c.deletePodQueue.Add(obj)
+			c.deletingPodObjMap[key] = p
+			c.deletePodQueue.Add(key)
 		}
 		return
 	}
@@ -232,7 +239,8 @@ func (c *Controller) enqueueDeletePod(obj interface{}) {
 	}
 
 	klog.V(3).Infof("enqueue delete pod %s", key)
-	c.deletePodQueue.Add(obj)
+	c.deletingPodObjMap[key] = p
+	c.deletePodQueue.Add(key)
 }
 
 func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
@@ -283,9 +291,10 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 
 	isStateful, statefulSetName := isStatefulSetPod(newPod)
 	isVmPod, vmName := isVmPod(newPod)
-	if !isPodAlive(newPod) && !isStateful && !isVmPod {
+	if !isPodStatusPhaseAlive(newPod) && !isStateful && !isVmPod {
 		klog.V(3).Infof("enqueue delete pod %s", key)
-		c.deletePodQueue.Add(newObj)
+		c.deletingPodObjMap[key] = newPod
+		c.deletePodQueue.Add(key)
 		return
 	}
 
@@ -304,7 +313,8 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 			// In case node get lost and pod can not be deleted,
 			// the ip address will not be recycled
 			klog.V(3).Infof("enqueue delete pod %s after %v", key, delay)
-			c.deletePodQueue.AddAfter(newObj, delay)
+			c.deletingPodObjMap[key] = newPod
+			c.deletePodQueue.AddAfter(key, delay)
 		}()
 		return
 	}
@@ -313,14 +323,16 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 	if isStateful && isStatefulSetPodToDel(c.config.KubeClient, newPod, statefulSetName) {
 		go func() {
 			klog.V(3).Infof("enqueue delete pod %s after %v", key, delay)
-			c.deletePodQueue.AddAfter(newObj, delay)
+			c.deletingPodObjMap[key] = newPod
+			c.deletePodQueue.AddAfter(key, delay)
 		}()
 		return
 	}
 	if isVmPod && c.isVmPodToDel(newPod, vmName) {
 		go func() {
 			klog.V(3).Infof("enqueue delete pod %s after %v", key, delay)
-			c.deletePodQueue.AddAfter(newObj, delay)
+			c.deletingPodObjMap[key] = newPod
+			c.deletePodQueue.AddAfter(key, delay)
 		}()
 		return
 	}
@@ -400,20 +412,30 @@ func (c *Controller) processNextDeletePodWorkItem() bool {
 	now := time.Now()
 	err := func(obj interface{}) error {
 		defer c.deletePodQueue.Done(obj)
-		var pod *v1.Pod
+		var key string
 		var ok bool
-		if pod, ok = obj.(*v1.Pod); !ok {
+		if key, ok = obj.(string); !ok {
 			c.deletePodQueue.Forget(obj)
-			utilruntime.HandleError(fmt.Errorf("expected pod in workqueue but got %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
 			return nil
 		}
-		if err := c.handleDeletePod(pod); err != nil {
-			c.deletePodQueue.AddRateLimited(obj)
-			return fmt.Errorf("error syncing '%s': %s, requeuing", pod.Name, err.Error())
+		_, exist := c.deletingPodObjMap[key]
+		if !exist {
+			return nil
+		}
+
+		if err := c.handleDeletePod(key); err != nil {
+			c.deletePodQueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
 		}
 		c.deletePodQueue.Forget(obj)
 		last := time.Since(now)
-		klog.Infof("take %d ms to handle delete pod %s/%s", last.Milliseconds(), pod.Namespace, pod.Name)
+		klog.Infof("take %d ms to handle delete pod %s", last.Milliseconds(), key)
+		// gc pod obj in c.deletingPodObjMap
+		go func() {
+			time.Sleep(5 * time.Minute)
+			delete(c.deletingPodObjMap, key)
+		}()
 		return nil
 	}(obj)
 
@@ -685,7 +707,9 @@ func (c *Controller) reconcileAllocateSubnets(cachedPod, pod *v1.Pod, needAlloca
 		if k8serrors.IsNotFound(err) {
 			// Sometimes pod is deleted between kube-ovn configure ovn-nb and patch pod.
 			// Then we need to recycle the resource again.
-			c.deletePodQueue.AddRateLimited(pod)
+			key := fmt.Sprintf("%s/%s", namespace, name)
+			c.deletingPodObjMap[key] = pod
+			c.deletePodQueue.AddRateLimited(key)
 			return nil, nil
 		}
 		klog.Errorf("patch pod %s/%s failed: %v", name, namespace, err)
@@ -829,7 +853,9 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 		if k8serrors.IsNotFound(err) {
 			// Sometimes pod is deleted between kube-ovn configure ovn-nb and patch pod.
 			// Then we need to recycle the resource again.
-			c.deletePodQueue.AddRateLimited(pod)
+			key := fmt.Sprintf("%s/%s", pod.Namespace, podName)
+			c.deletingPodObjMap[key] = pod
+			c.deletePodQueue.AddRateLimited(key)
 			return nil
 		}
 		klog.Errorf("patch pod %s/%s failed %v", name, namespace, err)
@@ -838,9 +864,9 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 	return nil
 }
 
-func (c *Controller) handleDeletePod(pod *v1.Pod) error {
+func (c *Controller) handleDeletePod(key string) error {
+	pod := c.deletingPodObjMap[key]
 	podName := c.getNameByPod(pod)
-	key := fmt.Sprintf("%s/%s", pod.Namespace, podName)
 	c.podKeyMutex.LockKey(key)
 	defer func() { _ = c.podKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle delete pod %s", key)


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2555

做了两个调整：
1. 重新调整进入 deletePodQueue 队列的对象是key,而不是pod指针，能够用到workqueue的去重功能，减少进入handle函数，
维护deletingPodObjMap map来作为删除pod的对象映射。在handleDeletePod 后触发一个5min 协程来释放deletingPodObjMap 对应的pod


但是workqueue的去重功能触发时间非常短，因为进入队列后，一旦deletePodQueue.Get()被调用到, workqueue就会把对象从dirty（表示进入队列还未处理）转到processing，再次进来的对象就算是一样，但workqueue也不会去重。

加了这个改动后，基本上能减少一次handle处理。

2. if !isPodAlive(newPod) && !isStateful && !isVmPod {处  触发enqueue deletePodQueue 和 

下面的 newPod.DeletionTimestamp != nil 触发 enqueue deletePodQueue 感觉逻辑上重叠，应该只需要一次触发就够了。




### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b6387a</samp>

This pull request enhances the pod controller to track and handle pod deletion more reliably. It adds a new feature to the controller to store pod objects that are being deleted in a map and uses the pod status phase to check for deletion. It also updates the pod controller to use the pod objects from the map instead of the cache. It modifies the files `pkg/controller/controller.go` and `pkg/controller/pod.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2b6387a</samp>

> _The pod controller had a new feature_
> _To track pods that were no longer creature_
> _It used `pod status phase`_
> _And a map in a new way_
> _To handle pod deletion more mature_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b6387a</samp>

*  Import the `k8s.io/api/core/v1` package as `k8sv1` to use the `Pod` type ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R12))
* Add a new field `deletingPodObjMap` to the `Controller` type to store the pod objects that are being deleted ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R67))
* Initialize the `deletingPodObjMap` field with an empty map in the `Run` method of the `Controller` ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R394))
* Split the `isPodAlive` function into two functions: `isPodAlive` and `isPodStatusPhaseAlive` to check the pod deletion based on different criteria ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R153-R156))
* Use the `isPodStatusPhaseAlive` function instead of the `isPodAlive` function to check the pod deletion in the `enqueueUpdatePod` function ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L286-R297))
* Store the pod object in the `deletingPodObjMap` and enqueue the pod key instead of the pod object in the `deletePodQueue` in the following functions: `enqueueAddPod` ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L197-R212)), `enqueueDeletePod` ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L235-R243)), `enqueueUpdatePod` ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L307-R317), [link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L316-R327), [link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L323-R335)), `reconcileAllocateSubnets` ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L688-R712)), and `reconcileRouteSubnets` ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L832-R858)) ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L841-R869))
* Get the pod key and the pod object from the `deletingPodObjMap` instead of the `deletePodQueue` in the `processNextDeletePodWorkItem` function ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L403-R438))
* Change the argument of the `handleDeletePod` function from the pod object to the pod key and get the pod object from the `deletingPodObjMap` ([link](https://github.com/kubeovn/kube-ovn/pull/2789/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L841-R869))