### PR TITLE
fix cleanup order

### DIFF
--- a/dist/images/cleanup.sh
+++ b/dist/images/cleanup.sh
@@ -50,14 +50,6 @@ for oeip in $(kubectl get oeip -o name); do
    kubectl delete --ignore-not-found $oeip
 done
 
-for vlan in $(kubectl get vlan -o name); do
-  kubectl delete --ignore-not-found $vlan
-done
-
-for pn in $(kubectl get provider-network -o name); do
-  kubectl delete --ignore-not-found $pn
-done
-
 for slr in $(kubectl get switch-lb-rule -o name); do
    kubectl delete --ignore-not-found $slr
 done
@@ -71,6 +63,14 @@ set -e
 
 for vpc in $(kubectl get vpc -o name); do
   kubectl delete --ignore-not-found $vpc
+done
+
+for vlan in $(kubectl get vlan -o name); do
+  kubectl delete --ignore-not-found $vlan
+done
+
+for pn in $(kubectl get provider-network -o name); do
+  kubectl delete --ignore-not-found $pn
 done
 
 # Delete Kube-OVN components


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:

```txt
E0511 08:37:22.113563      13 subnet.go:1729] failed to get vlan ovn-vlan: vlan.kubeovn.io "ovn-vlan" not found
E0511 08:37:22.113659      13 subnet.go:925] reconcile vlan for subnet ovn-default failed, vlan.kubeovn.io "ovn-vlan" not found
E0511 08:37:22.113767      13 subnet.go:713] reconcile subnet for ovn-default failed, vlan.kubeovn.io "ovn-vlan" not found
E0511 08:37:22.113872      13 subnet.go:195] error syncing 'ovn-default': vlan.kubeovn.io "ovn-vlan" not found, requeuing
```

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough