### PR TITLE
e2e: fix test container not removed

### DIFF
--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -10,14 +10,15 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 	attachnetclientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
-	"github.com/onsi/ginkgo/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e"
 	k8sframework "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+
+	"github.com/onsi/ginkgo/v2"
 
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -25,8 +26,6 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/docker"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/kind"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const dockerNetworkName = "kube-ovn-vlan"

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	dockertypes "github.com/docker/docker/api/types"
-	"github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+
+	"github.com/onsi/ginkgo/v2"
 
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -392,6 +392,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		cmd := []string{"sh", "-c", "sleep 600"}
 		containerInfo, err := docker.ContainerCreate(containerName, image, dockerNetworkName, cmd)
 		framework.ExpectNoError(err)
+		containerID = containerInfo.ID
 
 		ginkgo.By("Creating vlan " + vlanName)
 		vlan := framework.MakeVlan(vlanName, providerNetworkName, 0)

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	dockertypes "github.com/docker/docker/api/types"
-	"github.com/kubeovn/kube-ovn/pkg/ovs"
-	"github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e"
@@ -21,15 +21,15 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/config"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
+	"github.com/onsi/ginkgo/v2"
+
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/docker"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/iproute"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/kind"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const dockerNetworkName = "kube-ovn-vlan"


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Tests


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77831ac</samp>

This pull request refactors the e2e test packages for `ovn_eip` and `ovn-vpc-nat-gw` features to use the ginkgo testing framework and to follow the k8s.io import conventions. It also improves the code readability and debugging capabilities of the underlay package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 77831ac</samp>

> _`ovn_eip` imports_
> _ginkgo and ovs for tests_
> _autumn code cleanup_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77831ac</samp>

*  Add ginkgo/v2 package to enable ginkgo testing framework in e2e tests for ovn_eip package ([link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7R21-R22), [link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L24-R27))
*  Reorganize imports of k8s.io packages to follow convention of grouping and sorting them alphabetically in ovn_eip and underlay packages ([link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L13-R14), [link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L28-L29), [link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL11-R19))
*  Add corev1 and metav1 packages to enable corev1 and metav1 types in e2e tests for ovn_eip package ([link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L15-R16), [link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L30-L32))
*  Add ovs package to enable ovs utilities in e2e tests for ovn_eip package ([link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L24-R27))
*  Assign containerID variable to store the ID of the container that runs the ping command in `testPodConnectivity` function in `underlay.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2800/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR395))