### PR TITLE
Iptables nat support share eip

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -486,7 +486,7 @@ func (c *Controller) handleUpdateVpcEip(natGwKey string) error {
 	for _, eip := range eips {
 		if eip.Spec.NatGwDp == natGwKey && eip.Status.Redo != NAT_GW_CREATED_AT && eip.Annotations[util.VpcNatAnnotation] == "" {
 			klog.V(3).Infof("redo eip %s", eip.Name)
-			if err = c.patchEipStatus(eip.Name, "", NAT_GW_CREATED_AT, "", "", false); err != nil {
+			if err = c.patchEipStatus(eip.Name, "", NAT_GW_CREATED_AT, "", false); err != nil {
 				klog.Errorf("failed to update eip '%s' to re-apply, %v", eip.Name, err)
 				return err
 			}

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -263,74 +263,22 @@ func (c *Controller) handleAddIptablesEip(key string) error {
 	return nil
 }
 
-func (c *Controller) checkEipBindNat(key string, eip *kubeovnv1.IptablesEIP) (bool, string, error) {
-	var notUse bool
-	var natName string
-
-	switch eip.Status.Nat {
-	case util.FipUsingEip:
-		notUse = true
-	case util.DnatUsingEip:
-		// nat change eip not that fast
-		dnats, err := c.iptablesDnatRulesLister.List(labels.SelectorFromSet(labels.Set{util.VpcNatGatewayNameLabel: key}))
-		if err != nil {
-			klog.Errorf("failed to get dnats, %v", err)
-			return notUse, natName, err
-		}
-		notUse = true
-		for _, item := range dnats {
-			if item.Annotations[util.VpcEipAnnotation] == key {
-				notUse = false
-				natName = item.Name
-				break
-			}
-		}
-	case util.SnatUsingEip:
-		// nat change eip not that fast
-		snats, err := c.iptablesSnatRulesLister.List(labels.SelectorFromSet(labels.Set{util.VpcNatGatewayNameLabel: key}))
-		if err != nil {
-			klog.Errorf("failed to get snats, %v", err)
-			return notUse, natName, err
-		}
-		notUse = true
-		for _, item := range snats {
-			if item.Annotations[util.VpcEipAnnotation] == key {
-				notUse = false
-				natName = item.Name
-				break
-			}
-		}
-	default:
-		notUse = true
-	}
-	return notUse, natName, nil
-}
-
 func (c *Controller) handleResetIptablesEip(key string) error {
 	klog.V(3).Infof("handle reset eip %s", key)
-	eip, err := c.iptablesEipsLister.Get(key)
-	if err != nil {
+	if _, err := c.iptablesEipsLister.Get(key); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
 
-	notUse, _, err := c.checkEipBindNat(key, eip)
-	if err != nil {
-		klog.Errorf("failed to check nats bound to eip, %v", err)
+	if err := c.patchEipLabel(key); err != nil {
+		klog.Errorf("failed to patch label for eip %s, %v", key, err)
 		return err
 	}
-
-	if notUse {
-		if err := c.natLabelEip(key, "", eip.Spec.QoSPolicy); err != nil {
-			klog.Errorf("failed to clean label for eip %s, %v", key, err)
-			return err
-		}
-		if err := c.patchResetEipStatusNat(key, ""); err != nil {
-			klog.Errorf("failed to clean status for eip %s, %v", key, err)
-			return err
-		}
+	if err := c.patchEipStatus(key, "", "", "", true); err != nil {
+		klog.Errorf("failed to reset nat for eip %s, %v", key, err)
+		return err
 	}
 	return nil
 }
@@ -403,13 +351,7 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 			}
 		}
 
-		_, natName, err := c.checkEipBindNat(key, cachedEip)
-		if err != nil {
-			klog.Errorf("failed to check nats bound to eip, %v", err)
-			return err
-		}
-
-		if err = c.natLabelEip(key, natName, cachedEip.Spec.QoSPolicy); err != nil {
+		if err = c.patchEipLabel(key); err != nil {
 			klog.Errorf("failed to label qos in eip, %v", err)
 			return err
 		}
@@ -447,7 +389,7 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 			}
 		}
 
-		if err = c.patchEipStatus(key, "", "", "", cachedEip.Spec.QoSPolicy, true); err != nil {
+		if err = c.patchEipStatus(key, "", "", cachedEip.Spec.QoSPolicy, true); err != nil {
 			klog.Errorf("failed to patch status for eip %s, %v", key, err)
 			return err
 		}
@@ -698,6 +640,7 @@ func (c *Controller) createOrUpdateCrdEip(key, v4ip, v6ip, mac, natGwDp, qos, ex
 					Name: key,
 					Labels: map[string]string{
 						util.SubnetNameLabel:        externalNet,
+						util.IptablesEipV4IPLabel:   v4ip,
 						util.VpcNatGatewayNameLabel: natGwDp,
 					},
 				},
@@ -759,6 +702,7 @@ func (c *Controller) createOrUpdateCrdEip(key, v4ip, v6ip, mac, natGwDp, qos, ex
 			eip.Labels = map[string]string{
 				util.SubnetNameLabel:        externalNetwork,
 				util.VpcNatGatewayNameLabel: natGwDp,
+				util.IptablesEipV4IPLabel:   v4ip,
 			}
 			needUpdateLabel = true
 		} else if eip.Labels[util.SubnetNameLabel] != externalNetwork {
@@ -879,7 +823,38 @@ func (c *Controller) patchEipQoSStatus(key, qos string) error {
 	return nil
 }
 
-func (c *Controller) patchEipStatus(key, v4ip, redo, nat, qos string, ready bool) error {
+func (c *Controller) getIptablesEipNat(eipV4IP string) (string, error) {
+	nats := make([]string, 0, 3)
+	selector := labels.SelectorFromSet(labels.Set{util.IptablesEipV4IPLabel: eipV4IP})
+	dnats, err := c.iptablesDnatRulesLister.List(selector)
+	if err != nil {
+		klog.Errorf("failed to get dnats, %v", err)
+		return "", err
+	}
+	if len(dnats) != 0 {
+		nats = append(nats, util.DnatUsingEip)
+	}
+	fips, err := c.iptablesFipsLister.List(selector)
+	if err != nil {
+		klog.Errorf("failed to get dnats, %v", err)
+		return "", err
+	}
+	if len(fips) != 0 {
+		nats = append(nats, util.FipUsingEip)
+	}
+	snats, err := c.iptablesDnatRulesLister.List(selector)
+	if err != nil {
+		klog.Errorf("failed to get snats, %v", err)
+		return "", err
+	}
+	if len(snats) != 0 {
+		nats = append(nats, util.SnatUsingEip)
+	}
+	nat := strings.Join(nats, ",")
+	return nat, nil
+}
+
+func (c *Controller) patchEipStatus(key, v4ip, redo, qos string, ready bool) error {
 	oriEip, err := c.iptablesEipsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -902,6 +877,13 @@ func (c *Controller) patchEipStatus(key, v4ip, redo, nat, qos string, ready bool
 	if ready && v4ip != "" && eip.Status.IP != v4ip {
 		eip.Status.IP = v4ip
 		changed = true
+	}
+
+	nat, err := c.getIptablesEipNat(oriEip.Spec.V4ip)
+	if err != nil {
+		err := fmt.Errorf("failed to get eip nat")
+		klog.Error(err)
+		return err
 	}
 	if ready && nat != "" && eip.Status.Nat != nat {
 		eip.Status.Nat = nat
@@ -930,62 +912,7 @@ func (c *Controller) patchEipStatus(key, v4ip, redo, nat, qos string, ready bool
 	return nil
 }
 
-func (c *Controller) patchEipNat(key, nat string) error {
-	oriEip, err := c.iptablesEipsLister.Get(key)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	if oriEip.Status.Nat == nat {
-		return nil
-	}
-	eip := oriEip.DeepCopy()
-	eip.Status.Nat = nat
-	bytes, err := eip.Status.Bytes()
-	if err != nil {
-		klog.Errorf("failed to marshal eip %s, %v", eip.Name, err)
-		return err
-	}
-	if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Patch(context.Background(), key, types.MergePatchType,
-		bytes, metav1.PatchOptions{}, "status"); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		klog.Errorf("failed to patch eip %s, %v", eip.Name, err)
-		return err
-	}
-	return nil
-}
-
-func (c *Controller) patchResetEipStatusNat(key, nat string) error {
-	oriEip, err := c.iptablesEipsLister.Get(key)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	eip := oriEip.DeepCopy()
-	if eip.Status.Nat != nat {
-		eip.Status.Nat = nat
-		bytes, err := eip.Status.Bytes()
-		if err != nil {
-			return err
-		}
-		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Patch(context.Background(), key, types.MergePatchType,
-			bytes, metav1.PatchOptions{}, "status"); err != nil {
-			if k8serrors.IsNotFound(err) {
-				return nil
-			}
-			klog.Errorf("failed to patch eip '%s' nat type, %v", eip.Name, err)
-			return err
-		}
-	}
-	return nil
-}
-func (c *Controller) natLabelEip(eipName, natName, qosName string) error {
+func (c *Controller) patchEipLabel(eipName string) error {
 	oriEip, err := c.iptablesEipsLister.Get(eipName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -996,7 +923,7 @@ func (c *Controller) natLabelEip(eipName, natName, qosName string) error {
 	externalNetwork := util.GetExternalNetwork(oriEip.Spec.ExternalSubnet)
 
 	eip := oriEip.DeepCopy()
-	var needUpdateLabel, needUpdateAnno bool
+	var needUpdateLabel bool
 	var op string
 	if len(eip.Labels) == 0 {
 		op = "add"
@@ -1004,34 +931,19 @@ func (c *Controller) natLabelEip(eipName, natName, qosName string) error {
 		eip.Labels = map[string]string{
 			util.SubnetNameLabel:        externalNetwork,
 			util.VpcNatGatewayNameLabel: eip.Spec.NatGwDp,
-			util.QoSLabel:               qosName,
+			util.QoSLabel:               eip.Spec.QoSPolicy,
+			util.IptablesEipV4IPLabel:   eip.Spec.V4ip,
 		}
-	} else if eip.Labels[util.VpcNatGatewayNameLabel] != eip.Spec.NatGwDp || eip.Labels[util.QoSLabel] != qosName {
+	} else if eip.Labels[util.VpcNatGatewayNameLabel] != eip.Spec.NatGwDp || eip.Labels[util.QoSLabel] != eip.Spec.QoSPolicy {
 		op = "replace"
 		needUpdateLabel = true
 		eip.Labels[util.SubnetNameLabel] = externalNetwork
 		eip.Labels[util.VpcNatGatewayNameLabel] = eip.Spec.NatGwDp
-		eip.Labels[util.QoSLabel] = qosName
+		eip.Labels[util.QoSLabel] = eip.Spec.QoSPolicy
+		eip.Labels[util.IptablesEipV4IPLabel] = eip.Spec.V4ip
 	}
 	if needUpdateLabel {
 		if err := c.updateIptableLabels(eip.Name, op, "eip", eip.Labels); err != nil {
-			return err
-		}
-	}
-
-	if len(eip.Annotations) == 0 {
-		op = "add"
-		needUpdateAnno = true
-		eip.Annotations = map[string]string{
-			util.VpcNatAnnotation: natName,
-		}
-	} else if eip.Annotations[util.VpcNatAnnotation] != natName {
-		op = "replace"
-		needUpdateAnno = true
-		eip.Annotations[util.VpcNatAnnotation] = natName
-	}
-	if needUpdateAnno {
-		if err := c.updateIptableAnnotations(eip.Name, op, "eip", eip.Annotations); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -836,13 +836,13 @@ func (c *Controller) getIptablesEipNat(eipV4IP string) (string, error) {
 	}
 	fips, err := c.iptablesFipsLister.List(selector)
 	if err != nil {
-		klog.Errorf("failed to get dnats, %v", err)
+		klog.Errorf("failed to get fips, %v", err)
 		return "", err
 	}
 	if len(fips) != 0 {
 		nats = append(nats, util.FipUsingEip)
 	}
-	snats, err := c.iptablesDnatRulesLister.List(selector)
+	snats, err := c.iptablesSnatRulesLister.List(selector)
 	if err != nil {
 		klog.Errorf("failed to get snats, %v", err)
 		return "", err
@@ -885,7 +885,8 @@ func (c *Controller) patchEipStatus(key, v4ip, redo, qos string, ready bool) err
 		klog.Error(err)
 		return err
 	}
-	if ready && nat != "" && eip.Status.Nat != nat {
+	// nat record all kinds of nat rules using this eip
+	if nat != "" && eip.Status.Nat != nat {
 		eip.Status.Nat = nat
 		changed = true
 	}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -47,6 +47,7 @@ const (
 	VpcEipAnnotation            = "ovn.kubernetes.io/vpc_eip"
 	VpcDnatEPortLabel           = "ovn.kubernetes.io/vpc_dnat_eport"
 	VpcNatAnnotation            = "ovn.kubernetes.io/vpc_nat"
+	IptablesEipV4IPLabel        = "ovn.kubernetes.io/iptables_eip_v4_ip"
 
 	OvnEipUsageLabel        = "ovn.kubernetes.io/ovn_eip_usage"
 	OvnLrpEipEnableBfdLabel = "ovn.kubernetes.io/ovn_lrp_eip_enable_bfd"


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes


### Which issue(s) this PR fixes:
Fixes https://github.com/kubeovn/kube-ovn/issues/2729

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f10870</samp>

Refactor and test the shared eip feature for nat gateway. Use labels and status fields instead of annotations and nat fields to handle iptables rules and eip conflicts. Fix some bugs and errors in the eip logic. Add e2e test cases for different nat scenarios.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4f10870</samp>

> _`eip` labels, status_
> _simplify iptables rules_
> _autumn code cleanup_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f10870</samp>

*  Move `checkEipBindNat` and `patchEipStatus` functions from `pkg/controller/vpc_nat_gw_eip.go` to `pkg/controller/vpc_nat_gateway.go` to avoid circular dependency and improve code organization ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L266-R268), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L882-R857))
*  Remove the extra argument in the call to `patchEipStatus` in `handleUpdateVpcEip` and `handleUpdateIptablesEip` functions, which was not needed and caused a compilation error ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L489-R489), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L450-R392))
*  Remove the call to `checkEipBindNat` in `handleResetIptablesEip` and `handleUpdateIptablesEip` functions, which was not needed and caused a logic error. Instead, directly call `patchEipLabel` and `patchEipStatus` to reset or update the eip labels and status ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L319-R281), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L406-R354))
*  Remove the check and assignment of the `eip.Status.Nat` field in `patchEipStatus` function, which was not accurate and caused a logic error. Instead, call `getIptablesEipNat` to get the correct nat status of the eip based on the existing nat rules that use the eip ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L906-R889))
*  Remove the `patchEipNat` function from `pkg/controller/vpc_nat_gw_eip.go` as it was not used and replaced by `patchEipStatus` ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L933-R916))
*  Remove the unused variables `needUpdateAnno` and `op` in `natLabelEip` function, which were not needed and caused a compilation warning ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L999-R927), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L1007-R944))
*  Remove the logic of updating the eip annotations in `natLabelEip` function, which was not needed and caused a logic error. The eip annotations are not used to store the nat information anymore, as they are replaced by the eip labels and status ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L1021-L1037))
*  Add a new label `util.IptablesEipV4IPLabel` to the eip, fip, dnat, and snat objects, which is used to identify them by the eip v4ip in other resources ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92R643), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92R705), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1181-R1153), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1357-R1343), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1484-R1477))
*  Remove the check of the `eip.Status.Nat` field in `handleAddIptablesFip`, `handleUpdateIptablesFip`, `handleAddIptablesDnatRule`, `handleUpdateIptablesDnatRule`, `handleAddIptablesSnatRule`, and `handleUpdateIptablesSnatRule` functions, which was not accurate and caused a logic error. Instead, use a label selector to list the existing fips that use the same eip, and check if there is any conflict ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL519-R532), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL604-R615), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL705-L709), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL785-L789), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL892-L896), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL981-R954))
*  Remove the call to `patchEipNat` and `natLabelEip` in `handleAddIptablesFip`, `handleUpdateIptablesFip`, `handleAddIptablesDnatRule`, `handleUpdateIptablesDnatRule`, `handleAddIptablesSnatRule`, and `handleUpdateIptablesSnatRule` functions, which were not needed and replaced by `patchEipStatus`. Instead, call `patchFipLabel`, `patchDnatLabel`, or `patchSnatLabel` to update the fip, dnat, or snat labels with the eip information, and call `patchEipStatus` to update the eip status with the correct nat information ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL541-R545), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL549-R556), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL632-L635), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL641-R640), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL724-R719), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL732-R730), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL818-L821), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL827-R810), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL912-R890), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL920-R901), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1006-R983))
*  Modify `isDnatDuplicated` function to use the `d.Spec.EIP` field instead of the `d.Annotations[util.VpcEipAnnotation]` field to compare the eip name of the existing dnats, as the annotation field is not used anymore ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1751-R1745))
*  Add error handling and logging for the calls to `iptablesFipsLister.Get`, `iptablesDnatRulesLister.Get`, `iptablesSnatRulesLister.Get`, and `patchEipLabel` in `redoFip`, `redoDnat`, and `redoSnat` functions. Also add the error message to the return value for better debugging ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1326-R1312), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1454-R1448), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1574-R1576))
*  Add a new constant `IptablesEipV4IPLabel` to the `util` package, which is used as a label key for the eip v4ip in other resources ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR50))
*  Add a new constant `sharedEipStatusNat` to the `ovn_eip` package, which is used as an expected value for the eip status nat in the e2e test cases ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7R35))
*  Add new variables for the shared eip test case names in the `ovn_eip` package ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7R48-R49), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7R72-R80))
*  Add the logic of creating and deleting the shared eip and related resources in the e2e test cases. The test cases check the validity and conflict of the shared eip in different nat scenarios ([link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7R278-R333), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7R347-R348), [link](https://github.com/kubeovn/kube-ovn/pull/2805/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7R354-R355))