### PR TITLE
fix some typos.

### DIFF
--- a/pkg/controller/qos_policy.go
+++ b/pkg/controller/qos_policy.go
@@ -32,7 +32,7 @@ func (c *Controller) enqueueAddQoSPolicy(obj interface{}) {
 	c.addQoSPolicyQueue.Add(key)
 }
 
-func compareQoSPolicyBandwithLimitRules(old, new kubeovnv1.QoSPolicyBandwidthLimitRules) bool {
+func compareQoSPolicyBandwidthLimitRules(old, new kubeovnv1.QoSPolicyBandwidthLimitRules) bool {
 	if len(old) != len(new) {
 		return false
 	}
@@ -59,7 +59,7 @@ func (c *Controller) enqueueUpdateQoSPolicy(old, new interface{}) {
 	}
 	if oldQos.Status.Shared != newQos.Spec.Shared ||
 		oldQos.Status.BindingType != newQos.Spec.BindingType ||
-		!compareQoSPolicyBandwithLimitRules(oldQos.Status.BandwidthLimitRules,
+		!compareQoSPolicyBandwidthLimitRules(oldQos.Status.BandwidthLimitRules,
 			newQos.Spec.BandwidthLimitRules) {
 		klog.V(3).Infof("enqueue update qos %s", key)
 		c.updateQoSPolicyQueue.Add(key)
@@ -223,7 +223,7 @@ func (c *Controller) handleAddQoSPolicy(key string) error {
 }
 
 func (c *Controller) patchQoSStatus(
-	key string, shared bool, qosType kubeovnv1.QoSPolicyBindingType, bandwithRules kubeovnv1.QoSPolicyBandwidthLimitRules) error {
+	key string, shared bool, qosType kubeovnv1.QoSPolicyBindingType, bandwidthRules kubeovnv1.QoSPolicyBandwidthLimitRules) error {
 	oriQoS, err := c.qosPoliciesLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -234,7 +234,7 @@ func (c *Controller) patchQoSStatus(
 	qos := oriQoS.DeepCopy()
 	qos.Status.Shared = shared
 	qos.Status.BindingType = qosType
-	qos.Status.BandwidthLimitRules = bandwithRules
+	qos.Status.BandwidthLimitRules = bandwidthRules
 	bytes, err := qos.Status.Bytes()
 	if err != nil {
 		return err
@@ -279,7 +279,7 @@ func (c *Controller) handleDelQoSPoliciesFinalizer(key string) error {
 	return nil
 }
 
-func diffQoSPolicyBandwithLimitRules(oldList, newList kubeovnv1.QoSPolicyBandwidthLimitRules) (added, deleted, updated kubeovnv1.QoSPolicyBandwidthLimitRules) {
+func diffQoSPolicyBandwidthLimitRules(oldList, newList kubeovnv1.QoSPolicyBandwidthLimitRules) (added, deleted, updated kubeovnv1.QoSPolicyBandwidthLimitRules) {
 	added = kubeovnv1.QoSPolicyBandwidthLimitRules{}
 	deleted = kubeovnv1.QoSPolicyBandwidthLimitRules{}
 	updated = kubeovnv1.QoSPolicyBandwidthLimitRules{}
@@ -448,10 +448,10 @@ func (c *Controller) handleUpdateQoSPolicy(key string) error {
 		return err
 	}
 
-	added, deleted, updated := diffQoSPolicyBandwithLimitRules(cachedQos.Status.BandwidthLimitRules, cachedQos.Spec.BandwidthLimitRules)
-	bandwithRulesChanged := len(added) > 0 || len(deleted) > 0 || len(updated) > 0
+	added, deleted, updated := diffQoSPolicyBandwidthLimitRules(cachedQos.Status.BandwidthLimitRules, cachedQos.Spec.BandwidthLimitRules)
+	bandwidthRulesChanged := len(added) > 0 || len(deleted) > 0 || len(updated) > 0
 
-	if bandwithRulesChanged {
+	if bandwidthRulesChanged {
 		klog.V(3).Infof(
 			"bandwidth limit rules is changed for qos %s, added: %s, deleted: %s, updated: %s",
 			key, added.Strings(), deleted.Strings(), updated.Strings())


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes
fix some typos.


### Which issue(s) this PR fixes:
fix typos

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a9dd8d</samp>

Fix typos in QoSPolicyBandwidthLimitRules function and parameter names. Improve readability and consistency of `bandwidth` spelling in `./pkg/controller/qos_policy.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a9dd8d</samp>

> _Sing, O Muse, of the skillful coder who corrected_
> _The errors in the names of structs and functions_
> _That govern the limits of bandwidth, the precious resource_
> _That flows like the river of Ocean around the earth._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a9dd8d</samp>

*  Fix typos in function and parameter names related to QoSPolicyBandwidthLimitRules ([link](https://github.com/kubeovn/kube-ovn/pull/2814/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L35-R35), [link](https://github.com/kubeovn/kube-ovn/pull/2814/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L62-R62), [link](https://github.com/kubeovn/kube-ovn/pull/2814/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L226-R226), [link](https://github.com/kubeovn/kube-ovn/pull/2814/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L237-R237), [link](https://github.com/kubeovn/kube-ovn/pull/2814/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L282-R282), [link](https://github.com/kubeovn/kube-ovn/pull/2814/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662L451-R454))