### PR TITLE
do not allocate MAC address when kube-ovn is called as an IPAM plugin

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -242,15 +242,15 @@ func (c *Controller) handleAddNode(key string) error {
 	var v4IP, v6IP, mac string
 	portName := fmt.Sprintf("node-%s", key)
 	if node.Annotations[util.AllocatedAnnotation] == "true" && node.Annotations[util.IpAddressAnnotation] != "" && node.Annotations[util.MacAddressAnnotation] != "" {
+		macStr := node.Annotations[util.MacAddressAnnotation]
 		v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(portName, portName, node.Annotations[util.IpAddressAnnotation],
-			node.Annotations[util.MacAddressAnnotation],
-			node.Annotations[util.LogicalSwitchAnnotation], true)
+			&macStr, node.Annotations[util.LogicalSwitchAnnotation], true)
 		if err != nil {
 			klog.Errorf("failed to alloc static ip addrs for node %v: %v", node.Name, err)
 			return err
 		}
 	} else {
-		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, portName, "", c.config.NodeSwitch, nil, true)
+		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, portName, nil, c.config.NodeSwitch, nil, true)
 		if err != nil {
 			klog.Errorf("failed to alloc random ip addrs for node %v: %v", node.Name, err)
 			return err

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -627,7 +627,7 @@ func (c *Controller) acquireStaticEip(name, namespace, nicName, ip, externalSubn
 		}
 	}
 
-	if v4ip, v6ip, mac, err = c.ipam.GetStaticAddress(name, nicName, ip, mac, externalSubnet, checkConflict); err != nil {
+	if v4ip, v6ip, mac, err = c.ipam.GetStaticAddress(name, nicName, ip, nil, externalSubnet, checkConflict); err != nil {
 		klog.Errorf("failed to get static ip %v, mac %v, subnet %v, err %v", ip, mac, externalSubnet, err)
 		return "", "", "", err
 	}
@@ -637,7 +637,7 @@ func (c *Controller) acquireStaticEip(name, namespace, nicName, ip, externalSubn
 func (c *Controller) acquireEip(name, namespace, nicName, externalSubnet string) (string, string, string, error) {
 	var skippedAddrs []string
 	for {
-		ipv4, ipv6, mac, err := c.ipam.GetRandomAddress(name, nicName, "", externalSubnet, skippedAddrs, true)
+		ipv4, ipv6, mac, err := c.ipam.GetRandomAddress(name, nicName, nil, externalSubnet, skippedAddrs, true)
 		if err != nil {
 			return "", "", "", err
 		}

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	clientset "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/request"
@@ -43,17 +44,17 @@ func createCniServerHandler(config *Configuration, controller *Controller) *cniS
 	return csh
 }
 
-func (csh cniServerHandler) providerExists(provider string) bool {
+func (csh cniServerHandler) providerExists(provider string) (*kubeovnv1.Subnet, bool) {
 	if provider == "" || strings.HasSuffix(provider, util.OvnProvider) {
-		return true
+		return nil, true
 	}
 	subnets, _ := csh.Controller.subnetsLister.List(labels.Everything())
 	for _, subnet := range subnets {
 		if subnet.Spec.Provider == provider {
-			return true
+			return subnet.DeepCopy(), true
 		}
 	}
-	return false
+	return nil, false
 }
 
 func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Response) {
@@ -67,7 +68,8 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		return
 	}
 	klog.V(5).Infof("request body is %v", podRequest)
-	if exist := csh.providerExists(podRequest.Provider); !exist {
+	podSubnet, exist := csh.providerExists(podRequest.Provider)
+	if !exist {
 		errMsg := fmt.Errorf("provider %s not bind to any subnet", podRequest.Provider)
 		klog.Error(errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
@@ -115,7 +117,6 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			time.Sleep(1 * time.Second)
 			continue
 		}
-		macAddr = pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podRequest.Provider)]
 		ip = pod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podRequest.Provider)]
 		cidr = pod.Annotations[fmt.Sprintf(util.CidrAnnotationTemplate, podRequest.Provider)]
 		gw = pod.Annotations[fmt.Sprintf(util.GatewayAnnotationTemplate, podRequest.Provider)]
@@ -189,7 +190,10 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		return
 	}
 
-	if err := csh.UpdateIPCr(podRequest, subnet, ip, macAddr); err != nil {
+	if subnet == "" && podSubnet != nil {
+		subnet = podSubnet.Name
+	}
+	if err := csh.UpdateIPCr(podRequest, subnet, ip); err != nil {
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -275,6 +279,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 
 		routes = append(podRequest.Routes, routes...)
+		macAddr = pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podRequest.Provider)]
 		klog.Infof("create container interface %s mac %s, ip %s, cidr %s, gw %s, custom routes %v", ifName, macAddr, ipAddr, cidr, gw, routes)
 		if nicType == util.InternalType {
 			podNicName, err = csh.configureNicWithInternalPort(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, detectIPConflict, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, podRequest.DeviceID, nicType, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP)
@@ -324,7 +329,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	}
 }
 
-func (csh cniServerHandler) UpdateIPCr(podRequest request.CniRequest, subnet, ip, macAddr string) error {
+func (csh cniServerHandler) UpdateIPCr(podRequest request.CniRequest, subnet, ip string) error {
 	ipCrName := ovs.PodNameToPortName(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider)
 	oriIpCr, err := csh.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), ipCrName, metav1.GetOptions{})
 	if err != nil {

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -65,11 +65,11 @@ var _ = Describe("[IPAM]", func() {
 				pod1 := "pod1.ns"
 				pod1Nic1 := "pod1nic1.ns"
 				freeIp1 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
-				ip, _, _, err := im.GetStaticAddress(pod1, pod1Nic1, freeIp1, "", subnetName, true)
+				ip, _, _, err := im.GetStaticAddress(pod1, pod1Nic1, freeIp1, nil, subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp1))
 
-				ip, _, _, err = im.GetRandomAddress(pod1, pod1Nic1, "", subnetName, nil, true)
+				ip, _, _, err = im.GetRandomAddress(pod1, pod1Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp1))
 
@@ -79,12 +79,12 @@ var _ = Describe("[IPAM]", func() {
 				pod2Nic2 := "pod2Nic2.ns"
 
 				freeIp2 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
-				ip, _, _, err = im.GetRandomAddress(pod2, pod2Nic1, "", subnetName, nil, true)
+				ip, _, _, err = im.GetRandomAddress(pod2, pod2Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp2))
 
 				freeIp3 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
-				ip, _, _, err = im.GetRandomAddress(pod2, pod2Nic2, "", subnetName, nil, true)
+				ip, _, _, err = im.GetRandomAddress(pod2, pod2Nic2, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp3))
 
@@ -107,7 +107,7 @@ var _ = Describe("[IPAM]", func() {
 				By("get static ip conflict with ip in use ")
 				pod3 := "pod3.ns"
 				pod3Nic1 := "pod3Nic1.ns"
-				_, _, _, err = im.GetStaticAddress(pod3, pod3Nic1, freeIp3, "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress(pod3, pod3Nic1, freeIp3, nil, subnetName, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				By("release pod with multiple nics")
@@ -123,14 +123,14 @@ var _ = Describe("[IPAM]", func() {
 				pod4 := "pod4.ns"
 				pod4Nic1 := "pod4Nic1.ns"
 
-				_, _, _, err = im.GetStaticAddress(pod4, pod4Nic1, freeIp1, "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress(pod4, pod4Nic1, freeIp1, nil, subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				By("create pod with no initialized subnet")
 				pod5 := "pod5.ns"
 				pod5Nic1 := "pod5Nic1.ns"
 
-				_, _, _, err = im.GetRandomAddress(pod5, pod5Nic1, "", "invalid_subnet", nil, true)
+				_, _, _, err = im.GetRandomAddress(pod5, pod5Nic1, nil, "invalid_subnet", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 
 			})
@@ -142,7 +142,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "10.17.0.0/16", v4Gw, []string{"10.17.0.1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				ip, _, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
+				ip, _, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.17.0.2"))
 
@@ -157,17 +157,17 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.0/30", v4Gw, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 			})
@@ -177,7 +177,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.0/30", v4Gw, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				ip, _, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
@@ -185,7 +185,7 @@ var _ = Describe("[IPAM]", func() {
 				err = im.AddOrUpdateSubnet(subnetName, "10.16.0.0/30", v4Gw, []string{"10.16.0.1..10.16.0.2"})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 			})
 		})
@@ -214,12 +214,12 @@ var _ = Describe("[IPAM]", func() {
 				pod1 := "pod1.ns"
 				pod1Nic1 := "pod1nic1.ns"
 				freeIp1 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
-				_, ip, _, err := im.GetStaticAddress(pod1, pod1Nic1, freeIp1, "", subnetName, true)
+				_, ip, _, err := im.GetStaticAddress(pod1, pod1Nic1, freeIp1, nil, subnetName, true)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp1))
 
-				_, ip, _, err = im.GetRandomAddress(pod1, pod1Nic1, "", subnetName, nil, true)
+				_, ip, _, err = im.GetRandomAddress(pod1, pod1Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp1))
 
@@ -229,12 +229,12 @@ var _ = Describe("[IPAM]", func() {
 				pod2Nic2 := "pod2Nic2.ns"
 
 				freeIp2 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
-				_, ip, _, err = im.GetRandomAddress(pod2, pod2Nic1, "", subnetName, nil, true)
+				_, ip, _, err = im.GetRandomAddress(pod2, pod2Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp2))
 
 				freeIp3 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
-				_, ip, _, err = im.GetRandomAddress(pod2, pod2Nic2, "", subnetName, nil, true)
+				_, ip, _, err = im.GetRandomAddress(pod2, pod2Nic2, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp3))
 
@@ -257,7 +257,7 @@ var _ = Describe("[IPAM]", func() {
 				By("get static ip conflict with ip in use ")
 				pod3 := "pod3.ns"
 				pod3Nic1 := "pod3Nic1.ns"
-				_, _, _, err = im.GetStaticAddress(pod3, pod3Nic1, freeIp3, "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress(pod3, pod3Nic1, freeIp3, nil, subnetName, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				By("release pod with multiple nics")
@@ -273,14 +273,14 @@ var _ = Describe("[IPAM]", func() {
 				pod4 := "pod4.ns"
 				pod4Nic1 := "pod4Nic1.ns"
 
-				_, _, _, err = im.GetStaticAddress(pod4, pod4Nic1, freeIp1, "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress(pod4, pod4Nic1, freeIp1, nil, subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				By("create pod with no initialized subnet")
 				pod5 := "pod5.ns"
 				pod5Nic1 := "pod5Nic1.ns"
 
-				_, _, _, err = im.GetRandomAddress(pod5, pod5Nic1, "", "invalid_subnet", nil, true)
+				_, _, _, err = im.GetRandomAddress(pod5, pod5Nic1, nil, "invalid_subnet", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 			})
 
@@ -291,7 +291,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "fe00::/112", v6Gw, []string{"fe00::1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				_, ip, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
+				_, ip, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fe00::2"))
 
@@ -306,17 +306,17 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "fd00::/126", v6Gw, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 			})
@@ -326,7 +326,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "fd00::/126", v6Gw, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				_, ip, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
@@ -334,7 +334,7 @@ var _ = Describe("[IPAM]", func() {
 				err = im.AddOrUpdateSubnet(subnetName, "fd00::/126", v6Gw, []string{"fd00::1..fd00::2"})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 			})
 		})
@@ -365,12 +365,12 @@ var _ = Describe("[IPAM]", func() {
 				freeIp41 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
 				freeIp61 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
 				dualIp := fmt.Sprintf("%s,%s", freeIp41, freeIp61)
-				ip4, ip6, _, err := im.GetStaticAddress(pod1, pod1Nic1, dualIp, "", subnetName, true)
+				ip4, ip6, _, err := im.GetStaticAddress(pod1, pod1Nic1, dualIp, nil, subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip4).To(Equal(freeIp41))
 				Expect(ip6).To(Equal(freeIp61))
 
-				ip4, ip6, _, err = im.GetRandomAddress(pod1, pod1Nic1, "", subnetName, nil, true)
+				ip4, ip6, _, err = im.GetRandomAddress(pod1, pod1Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip4).To(Equal(freeIp41))
 				Expect(ip6).To(Equal(freeIp61))
@@ -382,14 +382,14 @@ var _ = Describe("[IPAM]", func() {
 
 				freeIp42 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
 				freeIp62 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
-				ip4, ip6, _, err = im.GetRandomAddress(pod2, pod2Nic1, "", subnetName, nil, true)
+				ip4, ip6, _, err = im.GetRandomAddress(pod2, pod2Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip4).To(Equal(freeIp42))
 				Expect(ip6).To(Equal(freeIp62))
 
 				freeIp43 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
 				freeIp63 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
-				ip4, ip6, _, err = im.GetRandomAddress(pod2, pod2Nic2, "", subnetName, nil, true)
+				ip4, ip6, _, err = im.GetRandomAddress(pod2, pod2Nic2, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip4).To(Equal(freeIp43))
 				Expect(ip6).To(Equal(freeIp63))
@@ -422,10 +422,10 @@ var _ = Describe("[IPAM]", func() {
 				By("get static ip conflict with ip in use ")
 				pod3 := "pod3.ns"
 				pod3Nic1 := "pod3Nic1.ns"
-				_, _, _, err = im.GetStaticAddress(pod3, pod3Nic1, freeIp43, "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress(pod3, pod3Nic1, freeIp43, nil, subnetName, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
-				_, _, _, err = im.GetStaticAddress(pod3, pod3Nic1, freeIp63, "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress(pod3, pod3Nic1, freeIp63, nil, subnetName, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				By("release pod with multiple nics")
@@ -444,17 +444,17 @@ var _ = Describe("[IPAM]", func() {
 				pod4 := "pod4.ns"
 				pod4Nic1 := "pod4Nic1.ns"
 
-				_, _, _, err = im.GetStaticAddress(pod4, pod4Nic1, freeIp41, "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress(pod4, pod4Nic1, freeIp41, nil, subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetStaticAddress(pod4, pod4Nic1, freeIp61, "", subnetName, true)
+				_, _, _, err = im.GetStaticAddress(pod4, pod4Nic1, freeIp61, nil, subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				By("create pod with no initialized subnet")
 				pod5 := "pod5.ns"
 				pod5Nic1 := "pod5Nic1.ns"
 
-				_, _, _, err = im.GetRandomAddress(pod5, pod5Nic1, "", "invalid_subnet", nil, true)
+				_, _, _, err = im.GetRandomAddress(pod5, pod5Nic1, nil, "invalid_subnet", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 
 			})
@@ -466,7 +466,7 @@ var _ = Describe("[IPAM]", func() {
 
 				err = im.AddOrUpdateSubnet(subnetName, "10.17.0.2/16,fe00::/112", dualGw, []string{"10.17.0.1", "fe00::1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", "", subnetName, nil, true)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod5.ns", "pod5.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.17.0.2"))
 				Expect(ipv6).To(Equal("fe00::2"))
@@ -477,19 +477,19 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", dualGw, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.2"))
 				Expect(ipv6).To(Equal("fd00::2"))
 
 				im.ReleaseAddressByPod("pod1.ns")
-				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
@@ -500,7 +500,7 @@ var _ = Describe("[IPAM]", func() {
 				err := im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", dualGw, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				ipv4, ipv6, _, err := im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
@@ -509,7 +509,7 @@ var _ = Describe("[IPAM]", func() {
 				err = im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", dualGw, []string{"10.16.0.1..10.16.0.2", "fd00::1..fd00::2"})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
+				_, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", nil, subnetName, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 			})
 		})
@@ -591,16 +591,16 @@ var _ = Describe("[IPAM]", func() {
 				pod1Nic1 := "pod1Nic1.ns"
 				pod1Nic1mac := util.GenerateMac()
 
-				_, _, err = subnet.GetStaticAddress(pod1, pod1Nic1, "10.16.0.2", pod1Nic1mac, false, true)
+				_, _, err = subnet.GetStaticAddress(pod1, pod1Nic1, "10.16.0.2", &pod1Nic1mac, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod2 := "pod2.ns"
 				pod2Nic1 := "pod2Nic1"
-				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic1, "10.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic1, "10.16.0.3", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod2Nic2 := "pod2Nic2"
-				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic2, "10.16.0.20", "", false, true)
+				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic2, "10.16.0.20", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.V4FreeIPList).To(Equal(
 					ipam.IPRangeList{
@@ -617,11 +617,11 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.NicToMac).To(HaveKeyWithValue(pod1Nic1, pod1Nic1mac))
 				Expect(subnet.MacToPod).To(HaveKeyWithValue(pod1Nic1mac, pod1))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "10.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "10.16.0.3", nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "19.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "19.16.0.3", nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
-				_, _, err = subnet.GetStaticAddress("pod6.ns", "pod5.ns", "10.16.0.121", pod1Nic1mac, false, true)
+				_, _, err = subnet.GetStaticAddress("pod6.ns", "pod5.ns", "10.16.0.121", &pod1Nic1mac, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				subnet.ReleaseAddress(pod1)
@@ -640,18 +640,18 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "10.16.0.0/30", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ip1, _, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
+				ip1, _, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
-				ip1, _, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
+				ip1, _, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
 
-				ip2, _, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil, true)
+				ip2, _, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip2).To(Equal(ipam.IP("10.16.0.2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil, true)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V4FreeIPList).To(BeEmpty())
 
@@ -692,17 +692,17 @@ var _ = Describe("[IPAM]", func() {
 				pod1Nic1 := "pod1Nic1.ns"
 				pod1Nic1mac := util.GenerateMac()
 
-				_, _, err = subnet.GetStaticAddress(pod1, pod1Nic1, "fd00::2", pod1Nic1mac, false, true)
+				_, _, err = subnet.GetStaticAddress(pod1, pod1Nic1, "fd00::2", &pod1Nic1mac, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod2 := "pod2.ns"
 				pod2Nic1 := "pod2Nic1.ns"
 
-				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic1, "fd00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic1, "fd00::3", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod2Nic2 := "pod2Nic2.ns"
-				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic2, "fd00::14", "", false, true)
+				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic2, "fd00::14", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.V6FreeIPList).To(Equal(
 					ipam.IPRangeList{
@@ -719,11 +719,11 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.NicToMac).To(HaveKeyWithValue(pod1Nic1, pod1Nic1mac))
 				Expect(subnet.MacToPod).To(HaveKeyWithValue(pod1Nic1mac, pod1))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "fd00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "fd00::3", nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "fe00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "fe00::3", nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
-				_, _, err = subnet.GetStaticAddress("pod6.ns", "pod5.ns", "fd00::f9", pod1Nic1mac, false, true)
+				_, _, err = subnet.GetStaticAddress("pod6.ns", "pod5.ns", "fd00::f9", &pod1Nic1mac, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				subnet.ReleaseAddress(pod1)
@@ -742,18 +742,18 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, ip1, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
+				_, ip1, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("fd00::1")))
-				_, ip1, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
+				_, ip1, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip1).To(Equal(ipam.IP("fd00::1")))
 
-				_, ip2, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil, true)
+				_, ip2, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip2).To(Equal(ipam.IP("fd00::2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil, true)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V6FreeIPList).To(BeEmpty())
 
@@ -797,17 +797,17 @@ var _ = Describe("[IPAM]", func() {
 			It("static allocation", func() {
 				subnet, err := ipam.NewSubnet(subnetName, dualCIDR, dualExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "fd00::2", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "fd00::2", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "10.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "10.16.0.3", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "fd00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "fd00::3", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.20", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.20", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "fd00::14", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "fd00::14", nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				Expect(subnet.V4FreeIPList).To(Equal(
@@ -834,13 +834,13 @@ var _ = Describe("[IPAM]", func() {
 				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::3")))
 				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("fd00::14")))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "10.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "10.16.0.3", nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "fd00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "fd00::3", nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "19.16.0.3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "19.16.0.3", nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod5.ns", "fe00::3", "", false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod5.ns", "fe00::3", nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
 
 				subnet.ReleaseAddress("pod1.ns")
@@ -867,21 +867,21 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, "10.16.0.0/30,fd00::/126", nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ipv4, ipv6, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
+				ipv4, ipv6, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.1")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::1")))
-				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", "", nil, true)
+				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.1")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::1")))
 
-				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod2.ns", "pod2.ns", "", nil, true)
+				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal(ipam.IP("10.16.0.2")))
 				Expect(ipv6).To(Equal(ipam.IP("fd00::2")))
 
-				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", "", nil, true)
+				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
 				Expect(subnet.V4FreeIPList).To(BeEmpty())
 				Expect(subnet.V6FreeIPList).To(BeEmpty())

--- a/test/unittest/ipam_bench/ipam_test.go
+++ b/test/unittest/ipam_bench/ipam_test.go
@@ -186,7 +186,7 @@ func addSerailAddrCapacity(b *testing.B, im *ipam.IPAM, protocol string) {
 	for n := 0; n < b.N; n++ {
 		podName := fmt.Sprintf("pod%d", n)
 		nicName := fmt.Sprintf("nic%d", n)
-		if _, _, _, err := im.GetRandomAddress(podName, nicName, "", subnetName, nil, true); err != nil {
+		if _, _, _, err := im.GetRandomAddress(podName, nicName, nil, subnetName, nil, true); err != nil {
 			b.Errorf("ERROR: allocate %s address failed with index %d with err %v ", protocol, n, err)
 			return
 		}
@@ -217,7 +217,7 @@ func addRandomAddrCapacity(b *testing.B, im *ipam.IPAM, protocol string, isTimeT
 			startTime = currentTime
 		}
 
-		if _, _, _, err := im.GetStaticAddress(podName, nicName, ip, "", subnetName, true); err != nil {
+		if _, _, _, err := im.GetStaticAddress(podName, nicName, ip, nil, subnetName, true); err != nil {
 			b.Errorf("ERROR: allocate %s address failed with index %d with err %v ", protocol, n, err)
 			return
 		}
@@ -313,7 +313,7 @@ func benchmarkAllocFreeAddrParallel(b *testing.B, podNumber int, protocol string
 				podName := fmt.Sprintf("pod%d_%d", key, n)
 				nicName := fmt.Sprintf("nic%d_%d", key, n)
 				if key%2 == 1 {
-					if _, _, _, err := im.GetRandomAddress(podName, nicName, "", subnetName, nil, true); err != nil {
+					if _, _, _, err := im.GetRandomAddress(podName, nicName, nil, subnetName, nil, true); err != nil {
 						b.Errorf("ERROR: allocate %s address failed with index %d err %v ", protocol, n, err)
 						return
 					}
@@ -324,7 +324,7 @@ func benchmarkAllocFreeAddrParallel(b *testing.B, podNumber int, protocol string
 						return
 					}
 
-					if _, _, _, err := im.GetStaticAddress(podName, nicName, ip, "", subnetName, false); err != nil {
+					if _, _, _, err := im.GetStaticAddress(podName, nicName, ip, nil, subnetName, false); err != nil {
 						b.Errorf("ERROR: allocate %s address failed with index %d with err %v ", protocol, n, err)
 						return
 					}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2503313</samp>

This pull request changes the type and handling of the mac address parameter in various functions and methods related to IP and MAC allocation, to use pointers to strings instead of strings. This allows for nil values to represent unassigned or unused mac addresses, and simplifies the logic and code readability. The pull request also refactors some code to handle different pod network providers more gracefully, and updates the test and benchmark code to match the new function signatures and arguments. The affected files are `pkg/controller/init.go`, `pkg/controller/node.go`, `pkg/controller/pod.go`, `pkg/controller/vip.go`, `pkg/controller/vpc_nat_gw_eip.go`, `pkg/daemon/handler.go`, `pkg/ipam/ipam.go`, `pkg/ipam/subnet.go`, `test/unittest/ipam_bench/ipam_test.go`, and `test/unittest/ipam/ipam.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2503313</samp>

> _No more empty strings, no more placeholders_
> _We use pointers to strings for our MAC addresses_
> _We refactor the code, we simplify the logic_
> _We handle different providers with grace and magic_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2503313</samp>

*  Change the mac address parameter of the `GetStaticAddress` and `GetRandomAddress` methods in the `Subnet` struct from a string to a pointer to a string, to indicate whether a mac address was given or not, and handle the case where the pod network provider does not use mac addresses ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L290-R290),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L348-R348),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L379-R379),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L424-R424),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L436-R436),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L446-R446),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L458-R460),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L245-R247),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L253-R253),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L283-R283),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L296-R296),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L510-R514),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L630-R630),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L640-R640),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L41-R41),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L50-R55),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L64-R66),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L71-R72),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L79-R87),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L172-R173),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L192-R193),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL179-R182),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL195-R203),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL210-R216),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL270-R283),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL338-R351),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL392-R409),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL414-R424),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL426-R431),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL434-R439),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL441-R446),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL451-R461),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL463-R468),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL471-R476),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL478-R487),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L68-R72),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L82-R87),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L110-R110),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L126-R126),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L133-R133),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L145-R145),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L160-R170),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L180-R180),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L188-R188),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L217-R222),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L232-R237),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L260-R260),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L276-R276),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L283-R283),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L294-R294),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L309-R319),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L329-R329),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L337-R337),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L368-R373),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L385-R385),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L392-R392),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L425-R428),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L447-R450),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L457-R457),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L469-R469),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L480-R480),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L486-R486),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L492-R492),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L503-R503),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L512-R512),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L594-R603),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L620-R624),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-28d0df1939c70d211f3b0a5854793bd66d830c0cdbfca0bccf62453adcdfd690L189-R189),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-28d0df1939c70d211f3b0a5854793bd66d830c0cdbfca0bccf62453adcdfd690L220-R220),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-28d0df1939c70d211f3b0a5854793bd66d830c0cdbfca0bccf62453adcdfd690L316-R316),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-28d0df1939c70d211f3b0a5854793bd66d830c0cdbfca0bccf62453adcdfd690L327-R327))
* Remove the mac address parameter from the `UpdateIPCr` function in the `handler` and `ipam` packages, as it was no longer needed to update the IP CRD object ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L613-R629),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL118),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL192-R196),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL327-R332),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L92-R93),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L103-R107))
* Add a condition to check if the mac address annotation was empty in the `pod.go` and `handler.go` files, and set the pointer to nil if so, to handle the case where the pod network provider does not use mac addresses, such as the calico provider ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1425-R1445),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fR282))
* Conditionally add or delete the mac address, logical switch and pod nic annotations in the `pod.go` file, based on whether the pod network provider uses mac addresses or is ovn or not, to avoid unnecessary annotations for different providers ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1535-R1552))
* Change the `providerExists` function in the `handler.go` file to return a pointer to a Subnet object along with a boolean value, instead of just a boolean value, to avoid querying the subnet lister again in the `handleAdd` function, and to pass the subnet object to the `UpdateIPCr` function ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fR20),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL46-R57),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL70-R72))
* Add a subnet name variable assignment in the `handleAdd` function in the `handler.go` file, to check if the subnet name was empty and use the pod subnet name instead, to handle the case where the pod network provider is not ovn and does not have a logical switch annotation ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL192-R196))
* Move the mac address variable assignment to the end of the `handleAdd` function in the `handler.go` file, as it was only needed to pass to the `ovs.Exec` function ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fR282))
* Add a condition to check if the mac address was empty in the `GetStaticMac` method in the `Subnet` struct in the `ipam` package, and return nil if so, to avoid generating a random mac address for providers that do not use mac addresses ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfR156-R158))
* Change the mac address parameter of the `GetStaticMac` method in the `Subnet` struct from a string to a pointer to a string, to match the change in the `GetStaticAddress` function signature ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L92-R93),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L103-R107),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL392-R409),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL414-R424))
* Change the IP address parameter of the `GetRandomAddress` and `GetStaticAddress` methods in the `Subnet` struct from a string to a pointer to an `IP` struct, to unify the IP allocation logic for both IPv4 and IPv6 addresses, and to avoid parsing strings to IPs repeatedly ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L643-R654),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L695-R695),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L701-R705),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L722-R726),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L745-R756),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L800-R810),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L837-R843),[link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L870-R884))
* Assign the mac address annotation to a variable instead of directly passing it to the function in the `pod.go` file, to make the code more consistent and readable ([link](https://github.com/kubeovn/kube-ovn/pull/2816/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1544-R1564))