### PR TITLE
add route for service ip range when init vpc-nat-gw

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -33,6 +33,15 @@ function init() {
     iptables -t nat -A POSTROUTING -j SNAT_FILTER
     iptables -t nat -A SNAT_FILTER -j EXCLUSIVE_SNAT
     iptables -t nat -A SNAT_FILTER -j SHARED_SNAT
+
+    for rule in $@
+    do
+        arr=(${rule//,/ })
+        cidr=${arr[0]}
+        nextHop=${arr[1]}
+
+        exec_cmd "ip route replace $cidr via $nextHop dev eth0"
+    done
 }
 
 

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -357,12 +357,7 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 		}
 		return err
 	}
-	var v4Cidr string
-	if subnet, ok := c.ipam.Subnets[gw.Spec.Subnet]; ok {
-		v4Cidr = subnet.V4CIDR.String()
-	} else {
-		return fmt.Errorf("failed to get subnet %s", gw.Spec.Subnet)
-	}
+	// subnet for vpc-nat-gw has been checked when create vpc-nat-gw
 
 	oriPod, err := c.getNatGwPod(key)
 	if err != nil {
@@ -382,7 +377,7 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 	}
 	NAT_GW_CREATED_AT = pod.CreationTimestamp.Format("2006-01-02T15:04:05")
 	klog.V(3).Infof("nat gw pod '%s' inited at %s", key, NAT_GW_CREATED_AT)
-	if err = c.execNatGwRules(pod, natGwInit, []string{v4Cidr}); err != nil {
+	if err = c.execNatGwRules(pod, natGwInit, []string{fmt.Sprintf("%s,%s", c.config.ServiceClusterIPRange, pod.Annotations[util.GatewayAnnotation])}); err != nil {
 		err = fmt.Errorf("failed to init vpc nat gateway, %v", err)
 		klog.Error(err)
 		return err


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Features

### Which issue(s) this PR fixes:
Fixes #2808 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11706c1</samp>

Fixed a bug and improved code quality in `vpc_nat_gateway.go`. The bug affected the masquerading rules for vpc-nat-gw traffic, and the code improvement removed redundant logic for getting subnet v4Cidr.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 11706c1</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `subnet v4Cidr` logic and the bug he fixed_
> _In the `vpc-nat-gw` rules, that cunning device_
> _To mask the traffic sources from the prying eyes._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 11706c1</samp>

* Fix a bug that caused some traffic to be dropped by the vpc-nat-gw by passing the service cluster IP range and the gateway annotation to the execNatGwRules function ([link](https://github.com/kubeovn/kube-ovn/pull/2821/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L385-R380))
* Simplify the code logic by removing the unnecessary error handling for getting the v4Cidr from the subnet, which has been checked when the vpc-nat-gw was created ([link](https://github.com/kubeovn/kube-ovn/pull/2821/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L360-R360))