### PR TITLE
adapt vpc dns in master

### DIFF
--- a/yamls/embed.go
+++ b/yamls/embed.go
@@ -1,0 +1,8 @@
+package yaml
+
+import (
+	_ "embed"
+)
+
+//go:embed coredns-template.yaml
+var CorednsTemplateContent []byte


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fef1a7</samp>

Fix VPC DNS feature by using dynamic service host and coredns template. This change affects the file `pkg/controller/vpc_dns.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5fef1a7</samp>

> _`KUBERNETES_SERVICE_HOST`_
> _A variable for VPC DNS_
> _Coredns template_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fef1a7</samp>

*  Get the service host from the environment variable KUBERNETES_SERVICE_HOST instead of using a string literal ([link](https://github.com/kubeovn/kube-ovn/pull/2822/files?diff=unified&w=0#diff-58c0cc00f6a53ef4da72411453c2eac7a8bfdc574600e827bc8837ae93ddb747L459-R459)). This allows the user to override the default value of 10.96.0.1 if needed for the VPC DNS feature.