### PR TITLE
U2o support custom vpc

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1580,6 +1580,8 @@ spec:
                   type: string
                 u2oInterconnectionIP:
                   type: string
+                u2oInterconnectionVPC:
+                  type: string
                 v4usingIPrange:
                   type: string
                 v4availableIPrange:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2115,6 +2115,8 @@ spec:
                   type: string
                 u2oInterconnectionIP:
                   type: string
+                u2oInterconnectionVPC:
+                  type: string
                 v4usingIPrange:
                   type: string
                 v4availableIPrange:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -204,18 +204,19 @@ type SubnetStatus struct {
 	// +patchStrategy=merge
 	Conditions []SubnetCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	V4AvailableIPs       float64 `json:"v4availableIPs"`
-	V4AvailableIPRange   string  `json:"v4availableIPrange"`
-	V4UsingIPs           float64 `json:"v4usingIPs"`
-	V4UsingIPRange       string  `json:"v4usingIPrange"`
-	V6AvailableIPs       float64 `json:"v6availableIPs"`
-	V6AvailableIPRange   string  `json:"v6availableIPrange"`
-	V6UsingIPs           float64 `json:"v6usingIPs"`
-	V6UsingIPRange       string  `json:"v6usingIPrange"`
-	ActivateGateway      string  `json:"activateGateway"`
-	DHCPv4OptionsUUID    string  `json:"dhcpV4OptionsUUID"`
-	DHCPv6OptionsUUID    string  `json:"dhcpV6OptionsUUID"`
-	U2OInterconnectionIP string  `json:"u2oInterconnectionIP"`
+	V4AvailableIPs        float64 `json:"v4availableIPs"`
+	V4AvailableIPRange    string  `json:"v4availableIPrange"`
+	V4UsingIPs            float64 `json:"v4usingIPs"`
+	V4UsingIPRange        string  `json:"v4usingIPrange"`
+	V6AvailableIPs        float64 `json:"v6availableIPs"`
+	V6AvailableIPRange    string  `json:"v6availableIPrange"`
+	V6UsingIPs            float64 `json:"v6usingIPs"`
+	V6UsingIPRange        string  `json:"v6usingIPrange"`
+	ActivateGateway       string  `json:"activateGateway"`
+	DHCPv4OptionsUUID     string  `json:"dhcpV4OptionsUUID"`
+	DHCPv6OptionsUUID     string  `json:"dhcpV6OptionsUUID"`
+	U2OInterconnectionIP  string  `json:"u2oInterconnectionIP"`
+	U2OInterconnectionVPC string  `json:"u2oInterconnectionVPC"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/test/e2e/framework/vpc.go
+++ b/test/e2e/framework/vpc.go
@@ -145,7 +145,7 @@ func (c *VpcClient) WaitToDisappear(name string, interval, timeout time.Duration
 	return nil
 }
 
-func MakeVpc(name, gatewayV4 string, enableExternal, enableBfd bool) *kubeovnv1.Vpc {
+func MakeVpc(name, gatewayV4 string, enableExternal, enableBfd bool, namespaces []string) *kubeovnv1.Vpc {
 	routes := make([]*kubeovnv1.StaticRoute, 0, 1)
 	if gatewayV4 != "" {
 		routes = append(routes, &kubeovnv1.StaticRoute{
@@ -162,6 +162,7 @@ func MakeVpc(name, gatewayV4 string, enableExternal, enableBfd bool) *kubeovnv1.
 			StaticRoutes:   routes,
 			EnableExternal: enableExternal,
 			EnableBfd:      enableBfd,
+			Namespaces:     namespaces,
 		},
 	}
 	return vpc

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -233,7 +233,7 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		overlaySubnetV4Cidr := "192.168.0.0/24"
 		overlaySubnetV4Gw := "192.168.0.1"
 		lanIp := "192.168.0.254"
-		vpc := framework.MakeVpc(vpcName, lanIp, false, false)
+		vpc := framework.MakeVpc(vpcName, lanIp, false, false, nil)
 		_ = vpcClient.CreateSync(vpc)
 
 		ginkgo.By("Creating custom overlay subnet")

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -599,7 +599,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		u2oOverlaySubnetNameCustomVPC = "subnet-" + framework.RandomSuffix()
 		cidr = framework.RandomCIDR(f.ClusterIpFamily)
 		overlaySubnetCustomVpc := framework.MakeSubnet(u2oOverlaySubnetNameCustomVPC, "", cidr, "", vpcName, "", nil, nil, []string{namespaceName})
-		overlaySubnetCustomVpc = subnetClient.CreateSync(overlaySubnetCustomVpc)
+		_ = subnetClient.CreateSync(overlaySubnetCustomVpc)
 
 		args = []string{"netexec", "--http-port", strconv.Itoa(curlListenPort)}
 		u2oPodOverlayCustomVPCAnnotations := map[string]string{

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -588,7 +588,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		subnet = subnetClient.Get(subnetName)
 		checkU2OItems(true, subnet, underlayPod, overlayPod, false)
 
-		f.SkipVersionPriorTo(1, 12, "This feature was introduce in v1.12 ")
+		f.SkipVersionPriorTo(1, 11, "This feature was introduce in v1.11 ")
 		ginkgo.By("step7: Change underlay subnet interconnection to overlay subnet in custom vpc")
 		podClient.DeleteSync(u2oPodNameUnderlay)
 

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -697,7 +697,7 @@ func checkU2OItems(isEnableU2O bool, subnet *apiv1.Subnet, underlayPod, overlayP
 		}
 
 		ginkgo.By(fmt.Sprintf("checking underlay subnet's policy3 route %s", protocolStr))
-		hitPolicyStr = fmt.Sprintf("%d %s.src == %s reroute %s", util.GatewayRouterPolicyPriority, protocolStr, cidr, gw)
+		hitPolicyStr := fmt.Sprintf("%d %s.src == %s reroute %s", util.GatewayRouterPolicyPriority, protocolStr, cidr, gw)
 		checkPolicy(hitPolicyStr, isEnableU2O, subnet.Spec.Vpc)
 	}
 

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -380,7 +380,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		overlaySubnetV4Gw := "192.168.0.1"
 		enableExternal := true
 		enableBfd := true
-		vpc := framework.MakeVpc(vpcName, overlaySubnetV4Gw, enableExternal, enableBfd)
+		vpc := framework.MakeVpc(vpcName, overlaySubnetV4Gw, enableExternal, enableBfd, nil)
 		_ = vpcClient.CreateSync(vpc)
 
 		ginkgo.By("Creating overlay subnet enable ecmp")

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -1887,6 +1887,8 @@ spec:
                   type: string
                 u2oInterconnectionIP:
                   type: string
+                u2oInterconnectionVPC:
+                  type: string
                 v4usingIPrange:
                   type: string
                 v4availableIPrange:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #[2795](https://github.com/kubeovn/kube-ovn/issues/2795)

use method:
1. subnet.spec.vpc= {custom vpc}
2. subnet.spec.u2oInterconnection = true 


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca9aa07</samp>

This pull request adds support for underlay to overlay interconnection for custom VPCs in the kube-ovn project. It introduces a new field `u2oInterconnectionVPC` in the `SubnetSpec` and `SubnetStatus` schemas to store the VPC name for each subnet. It also modifies the `MakeVpc` function and the `subnet.go`, `underlay.go`, and `e2e_test.go` files to handle the policy routes and resource management for different VPCs and subnets. It adds tests for the new feature in the `underlay.go` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ca9aa07</samp>

> _Sing, O Muse, of the mighty deeds of the `kube-ovn` team,_
> _Who forged new paths for custom VPCs to interconnect,_
> _And added new fields to the `SubnetSpec` and `SubnetStatus` schemas,_
> _To store the names of the VPCs that the subnets joined._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca9aa07</samp>

*  Add a new field `u2oInterconnectionVPC` to the `SubnetSpec` and `SubnetStatus` schemas to store the name of the VPC that the subnet is connected to for underlay to overlay interconnection ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1582-R1583), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aL207-R219), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1889-R1890))
*  Add a condition to only reconcile the underlay to overlay interconnection IP for subnets that have a VLAN and no logical gateway ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L590-R594))
*  Add a call to clear the old underlay to overlay resources for a subnet if the subnet's VPC or interconnection status has changed ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R654-R658))
*  Add a logic to set the `U2OInterconnectionVPC` field in the `SubnetStatus` to update the VPC name for the subnet's underlay to overlay interconnection ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R724-R728))
*  Add a call to delete the custom VPC policy routes for a subnet when the subnet is deleted ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R849-R855))
*  Modify the `addCommonRoutesForSubnet` function call to pass a new parameter `isDefaultVPC` to indicate whether the subnet belongs to the default VPC or not ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1302-R1321), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1354-R1373))
*  Add a logic to call the `addPolicyRouteForU2OInterconn` function to add the policy route for underlay to overlay interconnection for subnets that have a VLAN, no logical gateway, and enable interconnection ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1720-R1732))
*  Modify the signature of the `addCommonRoutesForSubnet` function to add a new parameter `isDefaultVPC` and use it to determine the logical router name for adding the policy route ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2082-R2114), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2110-R2151))
*  Modify the logic of the `addPolicyRouteForU2OInterconn` and `deletePolicyRouteForU2OInterconn` functions to only add or delete the policy route for underlay to overlay interconnection for subnets that belong to the default VPC or use the `U2OInterconnectionVPC` field to determine the logical router name ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2420-R2470), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2456-R2507))
*  Add three new functions `addCustomVPCPolicyRoutesForSubnet`, `deleteCustomVPCPolicyRoutesForSubnet`, and `clearOldU2OResource` to add or delete the custom VPC policy routes for a subnet, and to clear the old underlay to overlay resources for a subnet ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2557-R2602))
*  Modify the signature of the `MakeVpc` function to add a new parameter `namespaces` to indicate the namespaces that belong to the VPC and use it to set the `Namespaces` field in the `VpcSpec` ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-d0b44aca95ce8e8d2c8a9051991cb3207a364feeb01a58a74812b05848e5f8aeL166-R166), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-d0b44aca95ce8e8d2c8a9051991cb3207a364feeb01a58a74812b05848e5f8aeR183))
*  Modify the `MakeVpc` function call in the test files to pass a new parameter `nil` to indicate that the VPC does not have any namespaces ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L227-R227), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L376-R376))
*  Add new variables for the custom VPC name, the overlay subnet name in the custom VPC, and the overlay pod name in the custom VPC and a variable declaration for the `vpcClient` in the test framework ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL56-R58), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR64))
*  Add a logic to initialize the `vpcClient` and reset the new variables for the custom VPC name, the overlay subnet name in the custom VPC, and the overlay pod name in the custom VPC in the `BeforeEach` block in the test file ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR76), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR91-R93))
*  Add a logic to delete the custom VPC, the overlay subnet in the custom VPC, and the overlay pod in the custom VPC in the `AfterEach` block in the test file ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL276-R296))
*  Modify the `checkU2OItems` function call in the test file to pass a new parameter `isU2OCustomVpc` to indicate whether the overlay subnet belongs to a custom VPC or not ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL520-R536), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL533-R551), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL545-R565), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL561-R579))
*  Add a logic to create a custom VPC, an overlay subnet in the custom VPC, and an overlay pod in the custom VPC, and to change the underlay subnet's interconnection to the overlay subnet in the custom VPC in the test file ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL573-R651))
*  Modify the signature of the `checkU2OItems` function to add a new parameter `isU2OCustomVpc` and use it to determine whether to check the policy routes for underlay to overlay interconnection for subnets that belong to the default VPC ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL583-R661), [link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL611-R701))
*  Modify the signature of the `checkPolicy` function to add a new parameter `vpcName` to indicate the name of the VPC that the policy route belongs to ([link](https://github.com/kubeovn/kube-ovn/pull/2831/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL716-R798))