### PR TITLE
refactor clusterrole for kube-ovn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ vpc-nat-gateway.tar
 image-amd64.tar
 image-arm64.tar
 test/**/*.test
+kube-ovn-app-sa.yaml
+kube-ovn-cni-sa.yaml
+kube-ovn-sa.yaml
+ovn-ovs-sa.yaml
+ovs-ovn-ds.yaml

--- a/charts/templates/central-deploy.yaml
+++ b/charts/templates/central-deploy.yaml
@@ -38,7 +38,7 @@ spec:
                   app: ovn-central
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn
+      serviceAccountName: ovn-ovs
       hostNetwork: true
       containers:
         - name: ovn-central

--- a/charts/templates/monitor-deploy.yaml
+++ b/charts/templates/monitor-deploy.yaml
@@ -36,7 +36,7 @@ spec:
                   app: kube-ovn-monitor
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-app
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor

--- a/charts/templates/ovn-CRB.yaml
+++ b/charts/templates/ovn-CRB.yaml
@@ -11,3 +11,44 @@ subjects:
     name: ovn
     namespace: kube-system
 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovn-ovs
+roleRef:
+  name: system:ovn-ovs
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovn-ovs
+    namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-ovn-cni
+roleRef:
+  name: system:kube-ovn-cni
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kube-ovn-cni
+    namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-ovn-app
+roleRef:
+  name: system:kube-ovn-app
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kube-ovn-app
+    namespace: kube-system

--- a/charts/templates/ovn-sa.yaml
+++ b/charts/templates/ovn-sa.yaml
@@ -11,3 +11,24 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- end }}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn-ovs
+  namespace: kube-system
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ovn-cni
+  namespace: kube-system
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ovn-app
+  namespace: kube-system

--- a/charts/templates/ovncni-ds.yaml
+++ b/charts/templates/ovncni-ds.yaml
@@ -25,7 +25,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-cni
       hostNetwork: true
       hostPID: true
       initContainers:

--- a/charts/templates/ovsovn-ds.yaml
+++ b/charts/templates/ovsovn-ds.yaml
@@ -30,7 +30,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: ovn-ovs
       hostNetwork: true
       hostPID: true
       containers:

--- a/charts/templates/pinger-ds.yaml
+++ b/charts/templates/pinger-ds.yaml
@@ -20,7 +20,7 @@ spec:
         type: infra
     spec:
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-app
       hostPID: true
       containers:
         - name: pinger

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -1,22 +1,3 @@
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: ovn-vpc-nat-config
-  namespace: kube-system
-  annotations:
-    kubernetes.io/description: |
-      kube-ovn vpc-nat common config
-data:
-  image: kubeovn/vpc-nat-gateway:v1.12.0
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: ovn-vpc-nat-gw-config
-  namespace: kube-system
-data:
-  enable-vpc-nat-gw: "false"
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -183,7 +164,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-cni
       hostNetwork: true
       hostPID: true
       initContainers:
@@ -372,7 +353,7 @@ spec:
         type: infra
     spec:
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-app
       hostPID: true
       containers:
         - name: pinger
@@ -503,7 +484,7 @@ spec:
                   app: kube-ovn-monitor
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-app
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -1,22 +1,3 @@
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: ovn-vpc-nat-config
-  namespace: kube-system
-  annotations:
-    kubernetes.io/description: |
-      kube-ovn vpc-nat common config
-data:
-  image: kubeovn/vpc-nat-gateway:v1.12.0
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: ovn-vpc-nat-gw-config
-  namespace: kube-system
-data:
-  enable-vpc-nat-gw: "false"
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -183,7 +164,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-cni
       hostNetwork: true
       hostPID: true
       initContainers:
@@ -372,7 +353,7 @@ spec:
         type: infra
     spec:
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-app
       hostPID: true
       containers:
         - name: pinger
@@ -503,7 +484,7 @@ spec:
                   app: kube-ovn-monitor
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-app
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -1,22 +1,3 @@
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: ovn-vpc-nat-config
-  namespace: kube-system
-  annotations:
-    kubernetes.io/description: |
-      kube-ovn vpc-nat common config
-data:
-  image: kubeovn/vpc-nat-gateway:v1.12.0
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: ovn-vpc-nat-gw-config
-  namespace: kube-system
-data:
-  enable-vpc-nat-gw: "false"
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -185,7 +166,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-cni
       hostNetwork: true
       hostPID: true
       initContainers:
@@ -374,7 +355,7 @@ spec:
         type: infra
     spec:
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-app
       hostPID: true
       containers:
         - name: pinger
@@ -505,7 +486,7 @@ spec:
                   app: kube-ovn-monitor
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn
+      serviceAccountName: kube-ovn-app
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -1,148 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ovn
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    rbac.authorization.k8s.io/system-only: "true"
-  name: system:ovn
-rules:
-  - apiGroups:
-      - "kubeovn.io"
-    resources:
-      - vpcs
-      - vpcs/status
-      - vpc-nat-gateways
-      - vpc-nat-gateways/status
-      - subnets
-      - subnets/status
-      - ips
-      - vips
-      - vips/status
-      - vlans
-      - vlans/status
-      - provider-networks
-      - provider-networks/status
-      - security-groups
-      - security-groups/status
-      - iptables-eips
-      - iptables-fip-rules
-      - iptables-dnat-rules
-      - iptables-snat-rules
-      - iptables-eips/status
-      - iptables-fip-rules/status
-      - iptables-dnat-rules/status
-      - iptables-snat-rules/status
-      - ovn-eips
-      - ovn-fips
-      - ovn-snat-rules
-      - ovn-eips/status
-      - ovn-fips/status
-      - ovn-snat-rules/status
-      - ovn-dnat-rules
-      - ovn-dnat-rules/status
-      - vpc-dnses
-      - vpc-dnses/status
-      - switch-lb-rules
-      - switch-lb-rules/status
-      - qos-policies
-      - qos-policies/status
-    verbs:
-      - "*"
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - pods/exec
-      - namespaces
-      - nodes
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - patch
-      - update
-  - apiGroups:
-      - ""
-      - networking.k8s.io
-      - apps
-      - extensions
-    resources:
-      - networkpolicies
-      - services
-      - services/status
-      - endpoints
-      - statefulsets
-      - daemonsets
-      - deployments
-      - deployments/scale
-    verbs:
-      - create
-      - delete
-      - update
-      - patch
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-      - update
-  - apiGroups:
-      - apps
-    resources:
-      - controllerrevisions
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - "*"
-  - apiGroups:
-      - "k8s.cni.cncf.io"
-    resources:
-      - network-attachment-definitions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - update
-  - apiGroups:
-      - "kubevirt.io"
-    resources:
-      - virtualmachines
-      - virtualmachineinstances
-    verbs:
-      - get
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ovn
-roleRef:
-  name: system:ovn
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: ovn
-    namespace: kube-system
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -234,7 +89,7 @@ spec:
                   app: ovn-central
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn
+      serviceAccountName: ovn-ovs
       hostNetwork: true
       containers:
         - name: ovn-central
@@ -376,7 +231,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: ovn-ovs
       hostNetwork: true
       hostPID: true
       containers:

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -1,147 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ovn
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    rbac.authorization.k8s.io/system-only: "true"
-  name: system:ovn
-rules:
-  - apiGroups:
-      - "kubeovn.io"
-    resources:
-      - vpcs
-      - vpcs/status
-      - vpc-nat-gateways
-      - subnets
-      - subnets/status
-      - ips
-      - vips
-      - vips/status
-      - vlans
-      - vlans/status
-      - provider-networks
-      - provider-networks/status
-      - security-groups
-      - security-groups/status
-      - iptables-eips
-      - iptables-fip-rules
-      - iptables-dnat-rules
-      - iptables-snat-rules
-      - iptables-eips/status
-      - iptables-fip-rules/status
-      - iptables-dnat-rules/status
-      - iptables-snat-rules/status
-      - ovn-eips
-      - ovn-fips
-      - ovn-snat-rules
-      - ovn-eips/status
-      - ovn-fips/status
-      - ovn-snat-rules/status
-      - ovn-dnat-rules
-      - ovn-dnat-rules/status
-      - vpc-dnses
-      - vpc-dnses/status
-      - switch-lb-rules
-      - switch-lb-rules/status
-      - qos-policies
-      - qos-policies/status
-    verbs:
-      - "*"
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - pods/exec
-      - namespaces
-      - nodes
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - patch
-      - update
-  - apiGroups:
-      - ""
-      - networking.k8s.io
-      - apps
-      - extensions
-    resources:
-      - networkpolicies
-      - services
-      - services/status
-      - endpoints
-      - statefulsets
-      - daemonsets
-      - deployments
-      - deployments/scale
-    verbs:
-      - create
-      - delete
-      - update
-      - patch
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-      - update
-  - apiGroups:
-      - apps
-    resources:
-      - controllerrevisions
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - "*"
-  - apiGroups:
-      - "k8s.cni.cncf.io"
-    resources:
-      - network-attachment-definitions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - update
-  - apiGroups:
-      - "kubevirt.io"
-    resources:
-      - virtualmachines
-      - virtualmachineinstances
-    verbs:
-      - get
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ovn
-roleRef:
-  name: system:ovn
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: ovn
-    namespace: kube-system
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -233,7 +89,7 @@ spec:
                   app: ovn-central
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn
+      serviceAccountName: ovn-ovs
       hostNetwork: true
       containers:
         - name: ovn-central
@@ -375,7 +231,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       priorityClassName: system-node-critical
-      serviceAccountName: ovn
+      serviceAccountName: ovn-ovs
       hostNetwork: true
       hostPID: true
       containers:

--- a/yamls/sa.yaml
+++ b/yamls/sa.yaml
@@ -1,3 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn-ovs
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/system-only: "true"
+  name: system:ovn-ovs
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - ""
+      - networking.k8s.io
+      - apps
+    resources:
+      - services
+      - endpoints
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovn-ovs
+roleRef:
+  name: system:ovn-ovs
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovn-ovs
+    namespace: kube-system
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -128,39 +184,26 @@ rules:
     verbs:
       - get
       - list
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: ClusterRoleBinding
 metadata:
-  annotations:
-    rbac.authorization.k8s.io/system-only: "true"
-  name: system:ovn-ovs
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - patch
-  - apiGroups:
-      - ""
-      - networking.k8s.io
-      - apps
-    resources:
-      - services
-      - endpoints
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - controllerrevisions
-    verbs:
-      - get
-      - list
+  name: ovn
+roleRef:
+  name: system:ovn
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovn
+    namespace: kube-system
 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ovn-cni
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -202,7 +245,26 @@ rules:
       - create
       - patch
       - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-ovn-cni
+roleRef:
+  name: system:kube-ovn-cni
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kube-ovn-cni
+    namespace: kube-system
 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ovn-app
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -227,3 +289,16 @@ rules:
       - daemonsets
     verbs:
       - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-ovn-app
+roleRef:
+  name: system:kube-ovn-app
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kube-ovn-app
+    namespace: kube-system

--- a/yamls/vpc-configmap.yaml
+++ b/yamls/vpc-configmap.yaml
@@ -1,0 +1,18 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-vpc-nat-config
+  namespace: kube-system
+  annotations:
+    kubernetes.io/description: |
+      kube-ovn vpc-nat common config
+data:
+  image: kubeovn/vpc-nat-gateway:v1.12.0
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-vpc-nat-gw-config
+  namespace: kube-system
+data:
+  enable-vpc-nat-gw: "false"


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- security

原 sa 拆分为四个，分别为 ovn/ovn-ovs/kube-ovn-cni/kube-ovn-app
其中 ovn，考虑兼容性，为保留的原 sa 的名称，kube-onv-controller 绑定。同时，speaker、webhook 这种可以保证正常启动。
ovn-ovs， 为 ovn-central 和 ovs-ovn pod 启动，绑定的 serviceAccount
kube-ovn-cni，为 kube-ovn-cni 绑定使用
kube-ovn-app，为 kube-ovn-pinger 和 kube-ovn-monitor 绑定使用


### Which issue(s) this PR fixes:
Fixes #2723 
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a546417</samp>

Improved the reliability of the e2e test for ovn-vpc-nat-gw by adding a readiness check for ovn eip objects.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a546417</samp>

> _Create `ovn eip`_
> _Wait for readiness check - poll_
> _Autumn tests are green_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a546417</samp>

* Replace `ovnEipClient.CreateSync` with `ovnEipClient.Create` and a `wait.PollImmediate` block to check the `Ready` status of the ovn eip object after creating it ([link](https://github.com/kubeovn/kube-ovn/pull/2833/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L393-R405))
* Import the `wait` package to use the `wait.PollImmediate` function ([link](https://github.com/kubeovn/kube-ovn/pull/2833/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2R17))