### PR TITLE
fix MTU when subnet is using logical gateway

### DIFF
--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -253,7 +253,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 
 		var mtu int
-		if providerNetwork != "" {
+		if providerNetwork != "" && !podSubnet.Spec.LogicalGateway && !podSubnet.Spec.U2OInterconnection {
 			node, err := csh.Controller.nodesLister.Get(csh.Config.NodeName)
 			if err != nil {
 				errMsg := fmt.Errorf("failed to get node %s: %v", csh.Config.NodeName, err)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ccb0800</samp>

Improve pod subnet handling for multiple provider networks. Avoid node queries when pod subnet does not use logical gateway in `pkg/daemon/handler.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ccb0800</samp>

> _`pod subnet` checks_
> _if `logical gateway` is needed_
> _node queries reduced_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ccb0800</samp>

*  Add a condition to check pod subnet gateway type ([link](https://github.com/kubeovn/kube-ovn/pull/2834/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL256-R256))
*  Skip getting node object if pod subnet does not use logical gateway ([link](https://github.com/kubeovn/kube-ovn/pull/2834/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL256-R256))