### PR TITLE
add e2e test for slr

### DIFF
--- a/test/e2e/framework/endpoints.go
+++ b/test/e2e/framework/endpoints.go
@@ -1,0 +1,155 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// EndpointsClient is a struct for endpoint client.
+type EndpointsClient struct {
+	f *Framework
+	v1core.EndpointsInterface
+}
+
+func (f *Framework) EndpointClient() *EndpointsClient {
+	return f.EndpointsClientNS(f.Namespace.Name)
+}
+
+func (f *Framework) EndpointsClientNS(namespace string) *EndpointsClient {
+	return &EndpointsClient{
+		f:                  f,
+		EndpointsInterface: f.ClientSet.CoreV1().Endpoints(namespace),
+	}
+}
+
+func (c *EndpointsClient) Get(name string) *corev1.Endpoints {
+	endpoints, err := c.EndpointsInterface.Get(context.TODO(), name, metav1.GetOptions{})
+	ExpectNoError(err)
+	return endpoints
+}
+
+// Create creates a new endpoints according to the framework specifications
+func (c *EndpointsClient) Create(endpoints *corev1.Endpoints) *corev1.Endpoints {
+	e, err := c.EndpointsInterface.Create(context.TODO(), endpoints, metav1.CreateOptions{})
+	ExpectNoError(err, "Error creating endpoints")
+	return e.DeepCopy()
+}
+
+// CreateSync creates a new endpoints according to the framework specifications, and waits for it to be updated.
+func (c *EndpointsClient) CreateSync(endpoints *corev1.Endpoints, cond func(s *corev1.Endpoints) (bool, error), condDesc string) *corev1.Endpoints {
+	_ = c.Create(endpoints)
+	return c.WaitUntil(endpoints.Name, cond, condDesc, 2*time.Second, timeout)
+}
+
+// Patch patches the endpoints
+func (c *EndpointsClient) Patch(original, modified *corev1.Endpoints) *corev1.Endpoints {
+	patch, err := util.GenerateMergePatchPayload(original, modified)
+	ExpectNoError(err)
+
+	var patchedEndpoints *corev1.Endpoints
+	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		s, err := c.EndpointsInterface.Patch(context.TODO(), original.Name, types.MergePatchType, patch, metav1.PatchOptions{}, "")
+		if err != nil {
+			return handleWaitingAPIError(err, false, "patch endpoints %q", original.Name)
+		}
+		patchedEndpoints = s
+		return true, nil
+	})
+	if err == nil {
+		return patchedEndpoints.DeepCopy()
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while retrying to patch endpoints %s", original.Name)
+	}
+	Failf("error occurred while retrying to patch endpoints %s: %v", original.Name, err)
+
+	return nil
+}
+
+// PatchSync patches the endpoints and waits the endpoints to meet the condition
+func (c *EndpointsClient) PatchSync(original, modified *corev1.Endpoints, cond func(s *corev1.Endpoints) (bool, error), condDesc string) *corev1.Endpoints {
+	_ = c.Patch(original, modified)
+	return c.WaitUntil(original.Name, cond, condDesc, 2*time.Second, timeout)
+}
+
+// Delete deletes a endpoints if the endpoints exists
+func (c *EndpointsClient) Delete(name string) {
+	err := c.EndpointsInterface.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		Failf("Failed to delete endpoints %q: %v", name, err)
+	}
+}
+
+// DeleteSync deletes the endpoints and waits for the endpoints to disappear for `timeout`.
+// If the endpoints doesn't disappear before the timeout, it will fail the test.
+func (c *EndpointsClient) DeleteSync(name string) {
+	c.Delete(name)
+	gomega.Expect(c.WaitToDisappear(name, 2*time.Second, timeout)).To(gomega.Succeed(), "wait for endpoints %q to disappear", name)
+}
+
+// WaitUntil waits the given timeout duration for the specified condition to be met.
+func (c *EndpointsClient) WaitUntil(name string, cond func(s *corev1.Endpoints) (bool, error), condDesc string, interval, timeout time.Duration) *corev1.Endpoints {
+	var endpoints *corev1.Endpoints
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		Logf("Waiting for endpoints %s to meet condition %q", name, condDesc)
+		endpoints = c.Get(name).DeepCopy()
+		met, err := cond(endpoints)
+		if err != nil {
+			return false, fmt.Errorf("failed to check condition for endpoints %s: %v", name, err)
+		}
+		if met {
+			Logf("endpoints %s met condition %q", name, condDesc)
+		} else {
+			Logf("endpoints %s not met condition %q", name, condDesc)
+		}
+		return met, nil
+	})
+	if err == nil {
+		return endpoints
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while retrying to patch endpoints %s", name)
+	}
+	Failf("error occurred while retrying to patch endpoints %s: %v", name, err)
+
+	return nil
+}
+
+// WaitToDisappear waits the given timeout duration for the specified endpoints to disappear.
+func (c *EndpointsClient) WaitToDisappear(name string, interval, timeout time.Duration) error {
+	err := framework.Gomega().Eventually(context.Background(), framework.HandleRetry(func(ctx context.Context) (*corev1.Endpoints, error) {
+		svc, err := c.EndpointsInterface.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return svc, err
+	})).WithTimeout(timeout).Should(gomega.BeNil())
+	if err != nil {
+		return fmt.Errorf("expected endpoints %s to not be found: %w", name, err)
+	}
+	return nil
+}
+
+func MakeEndpoints(name string, annotations map[string]string, subset []corev1.EndpointSubset) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+		Subsets: subset,
+	}
+}

--- a/test/e2e/framework/switch-lb-rule.go
+++ b/test/e2e/framework/switch-lb-rule.go
@@ -1,0 +1,165 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	v1 "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/typed/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/onsi/gomega"
+)
+
+// SwitchLBRuleClient is a struct for switch-lb-rule client.
+type SwitchLBRuleClient struct {
+	f *Framework
+	v1.SwitchLBRuleInterface
+}
+
+func (f *Framework) SwitchLBRuleClient() *SwitchLBRuleClient {
+	return f.SwitchLBRuleClientNS(f.Namespace.Name)
+}
+
+func (f *Framework) SwitchLBRuleClientNS(namespace string) *SwitchLBRuleClient {
+	return &SwitchLBRuleClient{
+		f:                     f,
+		SwitchLBRuleInterface: f.KubeOVNClientSet.KubeovnV1().SwitchLBRules(),
+	}
+}
+
+func (c *SwitchLBRuleClient) Get(name string) *apiv1.SwitchLBRule {
+	rules, err := c.SwitchLBRuleInterface.Get(context.TODO(), name, metav1.GetOptions{})
+	ExpectNoError(err)
+	return rules
+}
+
+// Create creates a new switch-lb-rule according to the framework specifications
+func (c *SwitchLBRuleClient) Create(rule *apiv1.SwitchLBRule) *apiv1.SwitchLBRule {
+	e, err := c.SwitchLBRuleInterface.Create(context.TODO(), rule, metav1.CreateOptions{})
+	ExpectNoError(err, "error creating switch-lb-rule")
+	return e.DeepCopy()
+}
+
+// CreateSync creates a new switch-lb-rule according to the framework specifications, and waits for it to be updated.
+func (c *SwitchLBRuleClient) CreateSync(rule *apiv1.SwitchLBRule, cond func(s *apiv1.SwitchLBRule) (bool, error), condDesc string) *apiv1.SwitchLBRule {
+	_ = c.Create(rule)
+	return c.WaitUntil(rule.Name, cond, condDesc, 2*time.Second, timeout)
+}
+
+// Patch patches the switch-lb-rule
+func (c *SwitchLBRuleClient) Patch(original, modified *apiv1.SwitchLBRule) *apiv1.SwitchLBRule {
+	patch, err := util.GenerateMergePatchPayload(original, modified)
+	ExpectNoError(err)
+
+	var patchedService *apiv1.SwitchLBRule
+	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		s, err := c.SwitchLBRuleInterface.Patch(context.TODO(), original.Name, types.MergePatchType, patch, metav1.PatchOptions{}, "")
+		if err != nil {
+			return handleWaitingAPIError(err, false, "patch switch-lb-rule %q", original.Name)
+		}
+		patchedService = s
+		return true, nil
+	})
+	if err == nil {
+		return patchedService.DeepCopy()
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while retrying to patch switch-lb-rule %s", original.Name)
+	}
+	Failf("error occurred while retrying to patch switch-lb-rule %s: %v", original.Name, err)
+
+	return nil
+}
+
+// PatchSync patches the switch-lb-rule and waits the switch-lb-rule to meet the condition
+func (c *SwitchLBRuleClient) PatchSync(original, modified *apiv1.SwitchLBRule, cond func(s *apiv1.SwitchLBRule) (bool, error), condDesc string) *apiv1.SwitchLBRule {
+	_ = c.Patch(original, modified)
+	return c.WaitUntil(original.Name, cond, condDesc, 2*time.Second, timeout)
+}
+
+// Delete deletes a switch-lb-rule if the switch-lb-rule exists
+func (c *SwitchLBRuleClient) Delete(name string) {
+	err := c.SwitchLBRuleInterface.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		Failf("Failed to delete switch-lb-rule %q: %v", name, err)
+	}
+}
+
+// DeleteSync deletes the switch-lb-rule and waits for the switch-lb-rule to disappear for `timeout`.
+// If the switch-lb-rule doesn't disappear before the timeout, it will fail the test.
+func (c *SwitchLBRuleClient) DeleteSync(name string) {
+	c.Delete(name)
+	gomega.Expect(c.WaitToDisappear(name, 2*time.Second, timeout)).To(gomega.Succeed(), "wait for switch-lb-rule %q to disappear", name)
+}
+
+// WaitUntil waits the given timeout duration for the specified condition to be met.
+func (c *SwitchLBRuleClient) WaitUntil(name string, cond func(s *apiv1.SwitchLBRule) (bool, error), condDesc string, interval, timeout time.Duration) *apiv1.SwitchLBRule {
+	var rules *apiv1.SwitchLBRule
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		Logf("Waiting for switch-lb-rule %s to meet condition %q", name, condDesc)
+		rules = c.Get(name).DeepCopy()
+		met, err := cond(rules)
+		if err != nil {
+			return false, fmt.Errorf("failed to check condition for switch-lb-rule %s: %v", name, err)
+		}
+		if met {
+			Logf("switch-lb-rule %s met condition %q", name, condDesc)
+		} else {
+			Logf("switch-lb-rule %s not met condition %q", name, condDesc)
+		}
+		return met, nil
+	})
+	if err == nil {
+		return rules
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while retrying to patch switch-lb-rule %s", name)
+	}
+	Failf("error occurred while retrying to patch switch-lb-rule %s: %v", name, err)
+
+	return nil
+}
+
+// WaitToDisappear waits the given timeout duration for the specified switch-lb-rule to disappear.
+func (c *SwitchLBRuleClient) WaitToDisappear(name string, interval, timeout time.Duration) error {
+	err := framework.Gomega().Eventually(context.Background(), framework.HandleRetry(func(ctx context.Context) (*apiv1.SwitchLBRule, error) {
+		svc, err := c.SwitchLBRuleInterface.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return svc, err
+	})).WithTimeout(timeout).Should(gomega.BeNil())
+	if err != nil {
+		return fmt.Errorf("expected endpoints %s to not be found: %w", name, err)
+	}
+	return nil
+}
+
+func MakeSwitchLBRule(name, namespace, vip string, sessionAffinity corev1.ServiceAffinity, annotations map[string]string, slector, endpoints []string, ports []apiv1.SlrPort) *apiv1.SwitchLBRule {
+	return &apiv1.SwitchLBRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: apiv1.SwitchLBRuleSpec{
+			Vip:             vip,
+			Namespace:       namespace,
+			Selector:        slector,
+			Endpoints:       endpoints,
+			SessionAffinity: string(sessionAffinity),
+			Ports:           ports,
+		},
+	}
+}

--- a/test/e2e/kube-ovn/e2e_test.go
+++ b/test/e2e/kube-ovn/e2e_test.go
@@ -22,8 +22,8 @@ import (
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/qos"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/service"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/subnet"
+	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/switch_lb_rule"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/underlay"
-	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/vpc-internal-lb"
 )
 
 func init() {

--- a/test/e2e/kube-ovn/e2e_test.go
+++ b/test/e2e/kube-ovn/e2e_test.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/service"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/subnet"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/underlay"
+	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/vpc-internal-lb"
 )
 
 func init() {

--- a/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
+++ b/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
@@ -1,19 +1,14 @@
-package vpc_internal_lb
+package switch_lb_rule
 
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/test/e2e"
-	k8sframework "k8s.io/kubernetes/test/e2e/framework"
 
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
@@ -30,15 +25,6 @@ func generateServiceName(slrName string) string {
 
 func generatePodName(name string) string {
 	return "pod-" + name
-}
-
-func TestE2E(t *testing.T) {
-	if k8sframework.TestContext.KubeConfig == "" {
-		k8sframework.TestContext.KubeConfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	}
-	k8sframework.AfterReadingAllFlags(&k8sframework.TestContext)
-
-	e2e.RunE2ETests(t)
 }
 
 var _ = framework.Describe("[group:vpc-internal-lb]", func() {
@@ -93,13 +79,15 @@ var _ = framework.Describe("[group:vpc-internal-lb]", func() {
 	})
 
 	framework.ConformanceIt("should create switch-lb-rule with selector for vpc-internal-lb", func() {
+		f.SkipVersionPriorTo(1, 12, "This feature was introduce in v1.12")
+
 		var (
 			pod *corev1.Pod
 			err error
 		)
 
 		ginkgo.By("Get pod " + podName)
-		pod, err = podClient.PodInterface.Get(context.TODO(), podName, metav1.GetOptions{})
+		pod, err = podClient.Get(context.TODO(), podName, metav1.GetOptions{})
 		framework.ExpectNil(err)
 		framework.ExpectNotNil(pod)
 
@@ -198,6 +186,8 @@ var _ = framework.Describe("[group:vpc-internal-lb]", func() {
 	})
 
 	framework.ConformanceIt("should create switch-lb-rule with endpoints for vpc-internal-lb", func() {
+		f.SkipVersionPriorTo(1, 12, "This feature was introduce in v1.12")
+
 		var (
 			pod *corev1.Pod
 			err error

--- a/test/e2e/kube-ovn/vpc-internal-lb/vpc-internal-lb.go
+++ b/test/e2e/kube-ovn/vpc-internal-lb/vpc-internal-lb.go
@@ -1,0 +1,305 @@
+package vpc_internal_lb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e"
+	k8sframework "k8s.io/kubernetes/test/e2e/framework"
+
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+	"github.com/onsi/ginkgo/v2"
+)
+
+func generateSwitchLBRuleName(ruleName string) string {
+	return "lb-" + ruleName
+}
+
+func generateServiceName(slrName string) string {
+	return "slr-" + slrName
+}
+
+func generatePodName(name string) string {
+	return "pod-" + name
+}
+
+func TestE2E(t *testing.T) {
+	if k8sframework.TestContext.KubeConfig == "" {
+		k8sframework.TestContext.KubeConfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	}
+	k8sframework.AfterReadingAllFlags(&k8sframework.TestContext)
+
+	e2e.RunE2ETests(t)
+}
+
+var _ = framework.Describe("[group:vpc-internal-lb]", func() {
+	f := framework.NewDefaultFramework("vpc-internal-lb")
+
+	var (
+		slrName, svcName, podName, namespaceName, image, suffix string
+		switchLBRuleClient                                      *framework.SwitchLBRuleClient
+		endpointsClient                                         *framework.EndpointsClient
+		serviceClient                                           *framework.ServiceClient
+		podClient                                               *framework.PodClient
+		clientset                                               clientset.Interface
+	)
+
+	ginkgo.BeforeEach(func() {
+		switchLBRuleClient = f.SwitchLBRuleClient()
+		endpointsClient = f.EndpointClient()
+		serviceClient = f.ServiceClient()
+		podClient = f.PodClient()
+		clientset = f.ClientSet
+
+		if image == "" {
+			image = framework.GetKubeOvnImage(clientset)
+		}
+		suffix = framework.RandomSuffix()
+
+		namespaceName = f.Namespace.Name
+		slrName = generateSwitchLBRuleName(suffix)
+		svcName = generateServiceName(slrName)
+		podName = generatePodName(suffix)
+
+		var (
+			pod     *corev1.Pod
+			command []string
+			labels  map[string]string
+		)
+		labels = map[string]string{"app": "test"}
+
+		ginkgo.By("Creating pod " + podName)
+		command = []string{"sh", "-c", "sleep infinity"}
+
+		pod = framework.MakePod(namespaceName, podName, labels, nil, image, command, nil)
+		podClient.CreateSync(pod)
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Deleting pod " + podName)
+		podClient.DeleteSync(podName)
+
+		ginkgo.By("Deleting switch-lb-rule " + slrName)
+		switchLBRuleClient.DeleteSync(slrName)
+	})
+
+	framework.ConformanceIt("should create switch-lb-rule with selector for vpc-internal-lb", func() {
+		var (
+			pod *corev1.Pod
+			err error
+		)
+
+		ginkgo.By("Get pod " + podName)
+		pod, err = podClient.PodInterface.Get(context.TODO(), podName, metav1.GetOptions{})
+		framework.ExpectNil(err)
+		framework.ExpectNotNil(pod)
+
+		ginkgo.By("Creating SwitchLBRule " + slrName)
+		var (
+			rule                *apiv1.SwitchLBRule
+			selector, endpoints []string
+			ports               []apiv1.SlrPort
+			sessionAffinity     corev1.ServiceAffinity
+			vip                 string
+		)
+
+		vip = "1.1.1.1"
+		sessionAffinity = corev1.ServiceAffinityClientIP
+		ports = []apiv1.SlrPort{
+			{
+				Name:       "dns",
+				Port:       8888,
+				TargetPort: 80,
+				Protocol:   "TCP",
+			},
+		}
+		selector = []string{
+			"app:test",
+		}
+
+		rule = framework.MakeSwitchLBRule(slrName, namespaceName, vip, sessionAffinity, nil, selector, endpoints, ports)
+		_ = switchLBRuleClient.Create(rule)
+
+		ginkgo.By("Waiting for switch-lb-rule " + slrName + " to be ready")
+		framework.WaitUntil(2*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+			_, err = switchLBRuleClient.SwitchLBRuleInterface.Get(context.TODO(), slrName, metav1.GetOptions{})
+			if err == nil {
+				return true, nil
+			}
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}, fmt.Sprintf("switch-lb-rule %s is created", slrName))
+
+		var (
+			svc *corev1.Service
+			eps *corev1.Endpoints
+		)
+
+		ginkgo.By("Waiting for headless service " + svcName + " to be ready")
+		framework.WaitUntil(2*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+			svc, err = serviceClient.ServiceInterface.Get(context.TODO(), svcName, metav1.GetOptions{})
+			if err == nil {
+				return true, nil
+			}
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}, fmt.Sprintf("service %s is created", svcName))
+		framework.ExpectNotNil(svc)
+
+		ginkgo.By("Waiting for endpoints " + svcName + " to be ready")
+		framework.WaitUntil(2*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+			eps, err = endpointsClient.EndpointsInterface.Get(context.TODO(), svcName, metav1.GetOptions{})
+			if err == nil {
+				return true, nil
+			}
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}, fmt.Sprintf("endpoints %s is created", svcName))
+		framework.ExpectNotNil(eps)
+
+		for _, subset := range eps.Subsets {
+			var (
+				ips       []string
+				tps       []int32
+				protocols = make(map[int32]string)
+			)
+
+			ginkgo.By("Checking endpoint address")
+			for _, address := range subset.Addresses {
+				ips = append(ips, address.IP)
+			}
+			framework.ExpectContainElement(ips, pod.Status.PodIP)
+
+			ginkgo.By("Checking endpoint ports")
+			for _, port := range subset.Ports {
+				tps = append(tps, port.Port)
+				protocols[port.Port] = string(port.Protocol)
+			}
+			for _, port := range ports {
+				framework.ExpectContainElement(tps, port.TargetPort)
+				framework.ExpectEqual(protocols[port.TargetPort], port.Protocol)
+			}
+		}
+	})
+
+	framework.ConformanceIt("should create switch-lb-rule with endpoints for vpc-internal-lb", func() {
+		var (
+			pod *corev1.Pod
+			err error
+		)
+
+		ginkgo.By("Get pod " + podName)
+		pod, err = podClient.PodInterface.Get(context.TODO(), podName, metav1.GetOptions{})
+		framework.ExpectNil(err)
+		framework.ExpectNotNil(pod)
+
+		ginkgo.By("Creating SwitchLBRule " + slrName)
+		var (
+			rule                *apiv1.SwitchLBRule
+			annotations         map[string]string
+			selector, endpoints []string
+			ports               []apiv1.SlrPort
+			sessionAffinity     corev1.ServiceAffinity
+			vip                 string
+		)
+
+		vip = "1.1.1.1"
+		sessionAffinity = corev1.ServiceAffinityClientIP
+		ports = []apiv1.SlrPort{
+			{
+				Name:       "dns",
+				Port:       8888,
+				TargetPort: 80,
+				Protocol:   "TCP",
+			},
+		}
+		endpoints = []string{
+			pod.Status.PodIP,
+		}
+
+		rule = framework.MakeSwitchLBRule(slrName, namespaceName, vip, sessionAffinity, annotations, selector, endpoints, ports)
+		_ = switchLBRuleClient.Create(rule)
+
+		ginkgo.By("Waiting for switch-lb-rule " + slrName + " to be ready")
+		framework.WaitUntil(2*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+			_, err := switchLBRuleClient.SwitchLBRuleInterface.Get(context.TODO(), slrName, metav1.GetOptions{})
+			if err == nil {
+				return true, nil
+			}
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}, fmt.Sprintf("switch-lb-rule %s is created", slrName))
+
+		var (
+			svc *corev1.Service
+			eps *corev1.Endpoints
+		)
+
+		ginkgo.By("Waiting for headless service " + svcName + " to be ready")
+		framework.WaitUntil(2*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+			svc, err = serviceClient.ServiceInterface.Get(context.TODO(), svcName, metav1.GetOptions{})
+			if err == nil {
+				return true, nil
+			}
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}, fmt.Sprintf("service %s is created", svcName))
+		framework.ExpectNotNil(svc)
+
+		ginkgo.By("Waiting for endpoints " + svcName + " to be ready")
+		framework.WaitUntil(2*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+			eps, err = endpointsClient.EndpointsInterface.Get(context.TODO(), svcName, metav1.GetOptions{})
+			if err == nil {
+				return true, nil
+			}
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}, fmt.Sprintf("endpoints %s is created", svcName))
+		framework.ExpectNotNil(eps)
+
+		for _, subset := range eps.Subsets {
+			var (
+				ips       []string
+				tps       []int32
+				protocols = make(map[int32]string)
+			)
+
+			ginkgo.By("Checking endpoint address")
+			for _, address := range subset.Addresses {
+				ips = append(ips, address.IP)
+			}
+			framework.ExpectContainElement(ips, pod.Status.PodIP)
+
+			ginkgo.By("Checking endpoint ports")
+			for _, port := range subset.Ports {
+				tps = append(tps, port.Port)
+				protocols[port.Port] = string(port.Protocol)
+			}
+			for _, port := range ports {
+				framework.ExpectContainElement(tps, port.TargetPort)
+				framework.ExpectEqual(protocols[port.TargetPort], port.Protocol)
+			}
+		}
+	})
+})

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -129,6 +129,10 @@ spec:
                   items:
                     type: string
                   type: array
+                endpoints:
+                  items:
+                    type: string
+                  type: array
             status:
               type: object
               properties:


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Tests

add e2e test for slr

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 902a67b</samp>

This pull request adds new files and test cases to the e2e test framework and the kube-ovn package, to support and test the VPC internal load balancer feature. It introduces `endpoints.go` and `switch-lb-rule.go` to provide reusable interfaces for manipulating endpoints and switch-lb-rule resources, and `vpc-internal-lb.go` to define and register two test cases for verifying the load balancing functionality. It also updates `e2e_test.go` to import the new test package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 902a67b</samp>

> _`SwitchLBRuleClient`_
> _Tests VPC internal load balancer_
> _`EndpointsClient` too_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 902a67b</samp>

*  Add new files `endpoints.go` and `switch-lb-rule.go` to provide reusable and consistent interfaces for manipulating endpoints and switch-lb-rule resources in the e2e test framework ([link](https://github.com/kubeovn/kube-ovn/pull/2841/files?diff=unified&w=0#diff-40999eb74777206d73e8c489195a8d14a06467e99f98baa6a0473b3794c0239cR1-R155), [link](https://github.com/kubeovn/kube-ovn/pull/2841/files?diff=unified&w=0#diff-79772e079f5ad34c71e67fb5e94791f14f6cd466cf3b372b3422f293fe41f288R1-R165))
*  Add new file `vpc-internal-lb.go` to define and register two test cases for testing the VPC internal load balancer feature using the `SwitchLBRuleClient` and the `EndpointsClient` ([link](https://github.com/kubeovn/kube-ovn/pull/2841/files?diff=unified&w=0#diff-f3cbc8484148b04fd51676e3679390ad5b269c4772ffb58dbabcabe2524b17ecR1-R305), [link](https://github.com/kubeovn/kube-ovn/pull/2841/files?diff=unified&w=0#diff-1c091530afa65bef1cfae13cb619c6fc3e5bd32eb270a99a18bef1142de580a6R26))