### PR TITLE
 fix underlay access to node through ovn0 when u2o enable

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2364,7 +2364,7 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			prio 31000 match: "ip4.dst == underlay subnet cidr && ip4.dst != node ips"  action: allow
 
 			policy2:
-			prio 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: allow
+			prio 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reoute physical gw
 
 			policy3:
 			prio 29000 match: "ip4.src == underlay subnet cidr"                         action: reroute physical gw
@@ -2380,8 +2380,9 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			return err
 		}
 
+		action = ovnnb.LogicalRouterPolicyActionReroute
 		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match2, action)
-		if err := c.ovnClient.AddLogicalRouterPolicy(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match2, action, nil, externalIDs); err != nil {
+		if err := c.ovnClient.AddLogicalRouterPolicy(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match2, action, []string{nextHop}, externalIDs); err != nil {
 			klog.Errorf("failed to add u2o interconnection policy2 for subnet %s %v", subnet.Name, err)
 			return err
 		}

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -610,11 +610,11 @@ func checkU2OItems(isEnableU2O bool, subnet *apiv1.Subnet, underlayPod, overlayP
 		}
 		asName := strings.Replace(fmt.Sprintf("%s.u2o_exclude_ip.%s", subnet.Name, protocolStr), "-", ".", -1)
 		ginkgo.By(fmt.Sprintf("checking underlay subnet's policy1 route %s", protocolStr))
-		hitPolicyStr := fmt.Sprintf("%d %s.dst == $%s && %s.src == %s allow", util.SubnetRouterPolicyPriority, protocolStr, asName, protocolStr, cidr)
+		hitPolicyStr := fmt.Sprintf("%d %s.dst == %s && %s.dst != $%s allow", util.SubnetRouterPolicyPriority, protocolStr, cidr, protocolStr, asName)
 		checkPolicy(hitPolicyStr, isEnableU2O)
 
 		ginkgo.By(fmt.Sprintf("checking underlay subnet's policy2 route %s", protocolStr))
-		hitPolicyStr = fmt.Sprintf("%d %s.dst == %s && %s.dst != $%s allow", util.SubnetRouterPolicyPriority, protocolStr, cidr, protocolStr, asName)
+		hitPolicyStr = fmt.Sprintf("%d %s.dst == $%s && %s.src == %s reroute %s", util.SubnetRouterPolicyPriority, protocolStr, asName, protocolStr, cidr, gw)
 		checkPolicy(hitPolicyStr, isEnableU2O)
 
 		ginkgo.By(fmt.Sprintf("checking underlay subnet's policy3 route %s", protocolStr))


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #[2807](https://github.com/kubeovn/kube-ovn/issues/2807)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7869a3d</samp>

Enhance the underlay to overlay interconnection feature by rerouting the traffic from the underlay subnet to the gateway node. Update the test function to check the new logical router policies.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7869a3d</samp>

> _Oh we are the OVN crew and we work on the kube_
> _We add and check policies for the underlay and overlay_
> _Heave away, heave away, on the count of three_
> _We reroute the traffic to the gateway IP_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7869a3d</samp>

*  Reroute traffic from underlay subnet to gateway node for interconnection ([link](https://github.com/kubeovn/kube-ovn/pull/2842/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2367-R2367), [link](https://github.com/kubeovn/kube-ovn/pull/2842/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2383-R2385))
* Update test function to check the updated policy2 ([link](https://github.com/kubeovn/kube-ovn/pull/2842/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL614-R618))