### PR TITLE
fix underlay access to node through ovn0

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2064,7 +2064,7 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			prio 31000 match: "ip4.dst == underlay subnet cidr && ip4.dst != node ips"  action: allow
 
 			policy2:
-			prio 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: allow
+			prio 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reoute physical gw
 
 			policy3:
 			prio 29000 match: "ip4.src == underlay subnet cidr"                         action: reroute physical gw
@@ -2079,8 +2079,8 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			return err
 		}
 
-		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match2, "allow")
-		if err := c.ovnLegacyClient.AddPolicyRoute(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match2, "allow", "", externalIDs); err != nil {
+		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s, nexthop %s ", subnet.Spec.Vpc, match2, "reroute", nextHop)
+		if err := c.ovnLegacyClient.AddPolicyRoute(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match2, "reroute", nextHop, externalIDs); err != nil {
 			klog.Errorf("failed to add u2o interconnection policy2 for subnet %s %v", subnet.Name, err)
 			return err
 		}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21e27dc</samp>

Enhance policy route mechanism for underlay to overlay interconnection. Add next hop parameter to `AddPolicyRoute` method in `pkg/controller/subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 21e27dc</samp>

> _We're sailing on the underlay, the overlay is our goal_
> _We need to change the policy route to reach the gateway hole_
> _So heave away and `AddPolicyRoute` with the next hop in your hand_
> _And we'll be on the overlay soon, the finest network in the land_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 21e27dc</samp>

*  Reroute traffic from underlay subnet to physical gateway ([link](https://github.com/kubeovn/kube-ovn/pull/2845/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2067-R2067), [link](https://github.com/kubeovn/kube-ovn/pull/2845/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2082-R2083))