### PR TITLE
fix underlay access to node through ovn0

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2146,7 +2146,7 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			prio 31000 match: "ip4.dst == underlay subnet cidr && ip4.dst != node ips"  action: allow
 
 			policy2:
-			prio 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: allow
+			prio 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reoute physical gw
 
 			policy3:
 			prio 29000 match: "ip4.src == underlay subnet cidr"                         action: reroute physical gw
@@ -2161,8 +2161,8 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			return err
 		}
 
-		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match2, "allow")
-		if err := c.ovnLegacyClient.AddPolicyRoute(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match2, "allow", "", externalIDs); err != nil {
+		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s, nexthop %s", subnet.Spec.Vpc, match2, "reroute", nextHop)
+		if err := c.ovnLegacyClient.AddPolicyRoute(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match2, "reroute", nextHop, externalIDs); err != nil {
 			klog.Errorf("failed to add u2o interconnection policy2 for subnet %s %v", subnet.Name, err)
 			return err
 		}

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -608,11 +608,13 @@ func checkU2OItems(isEnableU2O bool, subnet *apiv1.Subnet, underlayPod, overlayP
 		}
 		agName := strings.Replace(fmt.Sprintf("%s.u2o_exclude_ip.%s", subnet.Name, protocolStr), "-", ".", -1)
 		ginkgo.By(fmt.Sprintf("checking underlay subnet's policy1 route %s", protocolStr))
-		hitPolicyStr := fmt.Sprintf("%d %s.dst == $%s && %s.src == %s allow", util.SubnetRouterPolicyPriority, protocolStr, agName, protocolStr, cidr)
+
+		hitPolicyStr := fmt.Sprintf("%d %s.dst == %s && %s.dst != $%s allow", util.SubnetRouterPolicyPriority, protocolStr, cidr, protocolStr, agName)
 		checkPolicy(hitPolicyStr, isEnableU2O)
 
 		ginkgo.By(fmt.Sprintf("checking underlay subnet's policy2 route %s", protocolStr))
-		hitPolicyStr = fmt.Sprintf("%d %s.dst == %s && %s.dst != $%s allow", util.SubnetRouterPolicyPriority, protocolStr, cidr, protocolStr, agName)
+		hitPolicyStr = fmt.Sprintf("%d %s.dst == $%s && %s.src == %s reroute %s", util.SubnetRouterPolicyPriority, protocolStr, agName, protocolStr, cidr, gw)
+
 		checkPolicy(hitPolicyStr, isEnableU2O)
 
 		ginkgo.By(fmt.Sprintf("checking underlay subnet's policy3 route %s", protocolStr))


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4453e3e</samp>

This pull request implements a new feature of interconnecting underlay and overlay networks with a physical gateway. It changes the policy routes in `subnet.go` and updates the corresponding test cases in `underlay.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4453e3e</samp>

> _Oh we are the coders of the `kube-ovn` crew_
> _And we work on the features that are shiny and new_
> _We change the policy routes for the underlay_
> _And we reroute the packets to the gateway, hey!_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4453e3e</samp>

*  Modify the policy routes for underlay to overlay interconnection with physical gateway in `pkg/controller/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2846/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2149-R2149), [link](https://github.com/kubeovn/kube-ovn/pull/2846/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2164-R2165))
* Update the test cases for the policy routes in `test/e2e/kube-ovn/underlay/underlay.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2846/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL611-R617))