### PR TITLE
u2o support custom vpc release 1.11

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1367,6 +1367,8 @@ spec:
                   type: string
                 u2oInterconnectionIP:
                   type: string
+                u2oInterconnectionVPC:
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/kubeovn-helm/templates/kube-ovn-crd.yaml
+++ b/kubeovn-helm/templates/kube-ovn-crd.yaml
@@ -1142,6 +1142,8 @@ spec:
                   type: string
                 u2oInterconnectionIP:
                   type: string
+                u2oInterconnectionVPC:
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -179,14 +179,15 @@ type SubnetStatus struct {
 	// +patchStrategy=merge
 	Conditions []SubnetCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	V4AvailableIPs       float64 `json:"v4availableIPs"`
-	V4UsingIPs           float64 `json:"v4usingIPs"`
-	V6AvailableIPs       float64 `json:"v6availableIPs"`
-	V6UsingIPs           float64 `json:"v6usingIPs"`
-	ActivateGateway      string  `json:"activateGateway"`
-	DHCPv4OptionsUUID    string  `json:"dhcpV4OptionsUUID"`
-	DHCPv6OptionsUUID    string  `json:"dhcpV6OptionsUUID"`
-	U2OInterconnectionIP string  `json:"u2oInterconnectionIP"`
+	V4AvailableIPs        float64 `json:"v4availableIPs"`
+	V4UsingIPs            float64 `json:"v4usingIPs"`
+	V6AvailableIPs        float64 `json:"v6availableIPs"`
+	V6UsingIPs            float64 `json:"v6usingIPs"`
+	ActivateGateway       string  `json:"activateGateway"`
+	DHCPv4OptionsUUID     string  `json:"dhcpV4OptionsUUID"`
+	DHCPv6OptionsUUID     string  `json:"dhcpV6OptionsUUID"`
+	U2OInterconnectionIP  string  `json:"u2oInterconnectionIP"`
+	U2OInterconnectionVPC string  `json:"u2oInterconnectionVPC"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -1150,6 +1150,8 @@ spec:
                   type: string
                 u2oInterconnectionIP:
                   type: string
+                u2oInterconnectionVPC:
+                  type: string
                 conditions:
                   type: array
                   items:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 539f7d9</samp>

This pull request adds support for custom VPCs for subnets and improves the handling of underlay subnet to overlay interconnection. It introduces a new field `u2oInterconnectionVPC` in the `SubnetSpec` schema and the `SubnetStatus` type to store and sync the name of the logical router that connects the underlay subnet to the overlay network. It also updates the `pkg/controller/subnet.go` file to manage the policy routes and logical ports for the subnets in the custom VPC logical router and the cluster router. It modifies the `kubeovn-helm/templates/kube-ovn-crd.yaml` and the `yamls/crd.yaml` files to reflect the new field in the CRD definition.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 539f7d9</samp>

> _We're the crew of the kube-ovn ship, we sail the cloud so free_
> _We make the subnets interconnect with custom VPCs_
> _We add the field `u2oInterconnectionVPC` to the CRD_
> _And then we heave and ho and sync the status with the `SubnetStatus` type_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 539f7d9</samp>

*  Add a new field `u2oInterconnectionVPC` to the `SubnetSpec` and `SubnetStatus` types to store the name of the logical router that connects the underlay subnet to the overlay network ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-cf6e828a3b8334b0180f06b380614f951d45a1a12d49efce74818fd68882a868R1145-R1146), [link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aL182-R190), [link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1153-R1154))
*  Check if the subnet is a VLAN subnet and does not have a logical gateway before allocating and assigning an IP address for the underlay subnet to overlay interconnection logical router port in the `handleAddOrUpdateSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L565-R569))
*  Delete the old logical switch port and logical router port for the underlay subnet to overlay interconnection if the subnet configuration has changed in the `handleAddOrUpdateSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R662-R667), [link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2271-R2316))
*  Set the `U2OInterconnectionVPC` field in the subnet status to the name of the logical router that connects the underlay subnet to the overlay network in the `handleAddOrUpdateSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R731-R735))
*  Delete the policy routes for the subnet in the custom VPC logical router in the `handleDeleteSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R858-R864), [link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2271-R2316))
*  Add the policy routes for the subnet in the custom VPC logical router and the underlay subnet to overlay interconnection in the `reconcileSubnet` and `reconcileOvnCustomVpcRoute` functions ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R938-R944), [link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1464-R1478), [link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2271-R2316))
*  Use the subnet's VPC name instead of the cluster router name when adding the policy routes for the subnet in the logical router in the `addCommonRoutesForSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1843-R1885))
*  Fix a typo in the comment of the `addPolicyRouteForU2OInterconn` function ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2149-R2191))
*  Avoid adding redundant policy routes for the cluster router when adding the policy routes for the underlay subnet to overlay interconnection in the `addPolicyRouteForU2OInterconn` function ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2158-R2212))
*  Use the subnet's status field `U2OInterconnectionVPC` instead of the spec field `Vpc` when deleting the policy routes for the underlay subnet to overlay interconnection in the `deletePolicyRouteForU2OInterconn` function ([link](https://github.com/kubeovn/kube-ovn/pull/2849/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2194-R2251))