### PR TITLE
underlay: do not delete patch ports created by ovn-controller

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -963,7 +963,10 @@ jobs:
           done
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: |
+          if [ "${{ matrix.mode }}" != underlay ]; then
+            sh -x dist/images/cleanup.sh
+          fi
 
   kube-ovn-ic-conformance-e2e:
     name: Kube-OVN IC Conformance E2E

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -166,6 +166,13 @@ func ovsCleanProviderNetwork(provider string) error {
 	// remove host nic from the external bridge
 	if output != "" {
 		for _, port := range strings.Split(output, "\n") {
+			// patch port created by ovn-controller has an external ID ovn-localnet-port=localnet.<SUBNET>
+			if output, err = ovs.Exec("--data=bare", "--no-heading", "--columns=_uuid", "find", "port", "name="+port, `external-ids:ovn-localnet-port!=""`); err != nil {
+				return fmt.Errorf("failed to find ovs port %s, %v: %q", port, err, output)
+			}
+			if output != "" {
+				continue
+			}
 			klog.V(3).Infof("removing ovs port %s from bridge %s", port, brName)
 			if err = removeProviderNic(port, brName); err != nil {
 				errMsg := fmt.Errorf("failed to remove port %s from external bridge %s: %v", port, brName, err)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3a01f5</samp>

Fix localnet provider network connectivity issue by skipping deletion of localnet ovs ports in `pkg/daemon/init.go`

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b3a01f5</samp>

> _`localnet` ports_
> _stay on ovs bridge in spring_
> _a bug fix for `#1140`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3a01f5</samp>

*  Skip deleting ovs ports created by ovn-controller for localnet provider networks ([link](https://github.com/kubeovn/kube-ovn/pull/2851/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeR169-R175))