### PR TITLE
update the volumeMounts premission

### DIFF
--- a/charts/templates/central-deploy.yaml
+++ b/charts/templates/central-deploy.yaml
@@ -96,6 +96,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:

--- a/charts/templates/controller-deploy.yaml
+++ b/charts/templates/controller-deploy.yaml
@@ -133,6 +133,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /var/run/tls

--- a/charts/templates/monitor-deploy.yaml
+++ b/charts/templates/monitor-deploy.yaml
@@ -80,12 +80,12 @@ spec:
               name: host-config-openvswitch
             - mountPath: /etc/ovn
               name: host-config-ovn
-            - mountPath: /var/log/openvswitch
-              name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/log/kube-ovn
@@ -122,9 +122,6 @@ spec:
         - name: host-config-ovn
           hostPath:
             path: /etc/origin/ovn
-        - name: host-log-ovs
-          hostPath:
-            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn

--- a/charts/templates/ovncni-ds.yaml
+++ b/charts/templates/ovncni-ds.yaml
@@ -111,6 +111,7 @@ spec:
             mountPath: /var/lib/kubelet/pods
           - mountPath: /etc/openvswitch
             name: systemid
+            readOnly: true
           - mountPath: /etc/cni/net.d
             name: cni-conf
           - mountPath: /run/openvswitch
@@ -132,6 +133,7 @@ spec:
             name: host-log-ovn
           - mountPath: /etc/localtime
             name: localtime
+            readOnly: true
           - mountPath: /tmp
             name: tmp
         readinessProbe:

--- a/charts/templates/ovsovn-ds.yaml
+++ b/charts/templates/ovsovn-ds.yaml
@@ -96,8 +96,6 @@ spec:
             - mountPath: /sys
               name: host-sys
               readOnly: true
-            - mountPath: /etc/cni/net.d
-              name: cni-conf
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /etc/ovn
@@ -108,6 +106,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/run/containerd
@@ -193,9 +192,6 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
-        - name: cni-conf
-          hostPath:
-            path: /etc/cni/net.d
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
@@ -221,6 +217,7 @@ spec:
         - hostPath:
             path: /var/run/containerd
           name: cruntime
+          readOnly: true
         {{- if or .Values.DPDK .Values.HYBRID_DPDK }}
         - name: host-config-ovs
           hostPath:

--- a/charts/templates/pinger-ds.yaml
+++ b/charts/templates/pinger-ds.yaml
@@ -73,28 +73,23 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - mountPath: /lib/modules
-              name: host-modules
-              readOnly: true
-            - mountPath: /run/openvswitch
-              name: host-run-ovs
             - mountPath: /var/run/openvswitch
               name: host-run-ovs
             - mountPath: /var/run/ovn
               name: host-run-ovn
-            - mountPath: /sys
-              name: host-sys
-              readOnly: true
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /var/log/openvswitch
               name: host-log-ovs
+              readOnly: true
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           resources:
@@ -107,18 +102,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
-        - name: host-modules
-          hostPath:
-            path: /lib/modules
         - name: host-run-ovs
           hostPath:
             path: /run/openvswitch
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
-        - name: host-sys
-          hostPath:
-            path: /sys
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2930,6 +2930,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -3049,8 +3050,6 @@ spec:
             - mountPath: /sys
               name: host-sys
               readOnly: true
-            - mountPath: /etc/cni/net.d
-              name: cni-conf
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /etc/ovn
@@ -3065,6 +3064,7 @@ spec:
               name: hugepage
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -3110,9 +3110,6 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
-        - name: cni-conf
-          hostPath:
-            path: /etc/cni/net.d
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
@@ -3443,6 +3440,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -3578,8 +3576,6 @@ spec:
             - mountPath: /sys
               name: host-sys
               readOnly: true
-            - mountPath: /etc/cni/net.d
-              name: cni-conf
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /etc/ovn
@@ -3590,10 +3586,12 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/run/containerd
               name: cruntime
+              readOnly: true
           readinessProbe:
             exec:
               command:
@@ -3637,9 +3635,6 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
-        - name: cni-conf
-          hostPath:
-            path: /etc/cni/net.d
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
@@ -3742,8 +3737,6 @@ spec:
               name: host-run-ovn
             - mountPath: /sys
               name: host-sys
-            - mountPath: /etc/cni/net.d
-              name: cni-conf
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /etc/ovn
@@ -3754,6 +3747,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -3809,9 +3803,6 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
-        - name: cni-conf
-          hostPath:
-            path: /etc/cni/net.d
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
@@ -3962,6 +3953,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /var/run/tls
@@ -4100,6 +4092,7 @@ spec:
             mountPath: /var/lib/kubelet/pods
           - mountPath: /etc/openvswitch
             name: systemid
+            readOnly: true
           - mountPath: /etc/cni/net.d
             name: cni-conf
           - mountPath: /run/openvswitch
@@ -4121,6 +4114,7 @@ spec:
             name: host-log-ovn
           - mountPath: /etc/localtime
             name: localtime
+            readOnly: true
           - mountPath: /tmp
             name: tmp
         livenessProbe:
@@ -4255,28 +4249,23 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - mountPath: /lib/modules
-              name: host-modules
-              readOnly: true
-            - mountPath: /run/openvswitch
-              name: host-run-ovs
             - mountPath: /var/run/openvswitch
               name: host-run-ovs
             - mountPath: /var/run/ovn
               name: host-run-ovn
-            - mountPath: /sys
-              name: host-sys
-              readOnly: true
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /var/log/openvswitch
               name: host-log-ovs
+              readOnly: true
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           resources:
@@ -4289,18 +4278,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
-        - name: host-modules
-          hostPath:
-            path: /lib/modules
         - name: host-run-ovs
           hostPath:
             path: /run/openvswitch
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
-        - name: host-sys
-          hostPath:
-            path: /sys
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
@@ -4403,12 +4386,12 @@ spec:
               name: host-config-openvswitch
             - mountPath: /etc/ovn
               name: host-config-ovn
-            - mountPath: /var/log/openvswitch
-              name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/log/kube-ovn
@@ -4445,9 +4428,6 @@ spec:
         - name: host-config-ovn
           hostPath:
             path: /etc/origin/ovn
-        - name: host-log-ovs
-          hostPath:
-            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -115,6 +115,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /var/run/tls
@@ -252,6 +253,7 @@ spec:
               mountPath: /var/lib/kubelet/pods
             - mountPath: /etc/openvswitch
               name: systemid
+              readOnly: true
             - mountPath: /etc/cni/net.d
               name: cni-conf
             - mountPath: /run/openvswitch
@@ -273,6 +275,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /tmp
               name: tmp
           livenessProbe:
@@ -407,28 +410,23 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - mountPath: /lib/modules
-              name: host-modules
-              readOnly: true
-            - mountPath: /run/openvswitch
-              name: host-run-ovs
             - mountPath: /var/run/openvswitch
               name: host-run-ovs
             - mountPath: /var/run/ovn
               name: host-run-ovn
-            - mountPath: /sys
-              name: host-sys
-              readOnly: true
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /var/log/openvswitch
               name: host-log-ovs
+              readOnly: true
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           resources:
@@ -441,18 +439,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
-        - name: host-modules
-          hostPath:
-            path: /lib/modules
         - name: host-run-ovs
           hostPath:
             path: /run/openvswitch
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
-        - name: host-sys
-          hostPath:
-            path: /sys
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
@@ -555,12 +547,12 @@ spec:
               name: host-config-openvswitch
             - mountPath: /etc/ovn
               name: host-config-ovn
-            - mountPath: /var/log/openvswitch
-              name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/log/kube-ovn
@@ -597,9 +589,6 @@ spec:
         - name: host-config-ovn
           hostPath:
             path: /etc/origin/ovn
-        - name: host-log-ovs
-          hostPath:
-            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -115,6 +115,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /var/run/tls
@@ -252,6 +253,7 @@ spec:
               mountPath: /var/lib/kubelet/pods
             - mountPath: /etc/openvswitch
               name: systemid
+              readOnly: true
             - mountPath: /etc/cni/net.d
               name: cni-conf
             - mountPath: /run/openvswitch
@@ -273,6 +275,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /tmp
               name: tmp
           livenessProbe:
@@ -407,28 +410,23 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - mountPath: /lib/modules
-              name: host-modules
-              readOnly: true
-            - mountPath: /run/openvswitch
-              name: host-run-ovs
             - mountPath: /var/run/openvswitch
               name: host-run-ovs
             - mountPath: /var/run/ovn
               name: host-run-ovn
-            - mountPath: /sys
-              name: host-sys
-              readOnly: true
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /var/log/openvswitch
               name: host-log-ovs
+              readOnly: true
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           resources:
@@ -441,18 +439,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
-        - name: host-modules
-          hostPath:
-            path: /lib/modules
         - name: host-run-ovs
           hostPath:
             path: /run/openvswitch
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
-        - name: host-sys
-          hostPath:
-            path: /sys
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
@@ -555,12 +547,12 @@ spec:
               name: host-config-openvswitch
             - mountPath: /etc/ovn
               name: host-config-ovn
-            - mountPath: /var/log/openvswitch
-              name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/log/kube-ovn
@@ -597,9 +589,6 @@ spec:
         - name: host-config-ovn
           hostPath:
             path: /etc/origin/ovn
-        - name: host-log-ovs
-          hostPath:
-            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -117,6 +117,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /var/run/tls
@@ -254,6 +255,7 @@ spec:
               mountPath: /var/lib/kubelet/pods
             - mountPath: /etc/openvswitch
               name: systemid
+              readOnly: true
             - mountPath: /etc/cni/net.d
               name: cni-conf
             - mountPath: /run/openvswitch
@@ -275,6 +277,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /tmp
               name: tmp
           livenessProbe:
@@ -409,28 +412,23 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - mountPath: /lib/modules
-              name: host-modules
-              readOnly: true
-            - mountPath: /run/openvswitch
-              name: host-run-ovs
             - mountPath: /var/run/openvswitch
               name: host-run-ovs
             - mountPath: /var/run/ovn
               name: host-run-ovn
-            - mountPath: /sys
-              name: host-sys
-              readOnly: true
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /var/log/openvswitch
               name: host-log-ovs
+              readOnly: true
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           resources:
@@ -443,18 +441,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
-        - name: host-modules
-          hostPath:
-            path: /lib/modules
         - name: host-run-ovs
           hostPath:
             path: /run/openvswitch
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
-        - name: host-sys
-          hostPath:
-            path: /sys
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
@@ -557,12 +549,12 @@ spec:
               name: host-config-openvswitch
             - mountPath: /etc/ovn
               name: host-config-ovn
-            - mountPath: /var/log/openvswitch
-              name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+              readOnly: true
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/log/kube-ovn
@@ -599,9 +591,6 @@ spec:
         - name: host-config-ovn
           hostPath:
             path: /etc/origin/ovn
-        - name: host-log-ovs
-          hostPath:
-            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -365,8 +365,6 @@ spec:
             - mountPath: /sys
               name: host-sys
               readOnly: true
-            - mountPath: /etc/cni/net.d
-              name: cni-conf
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /etc/ovn
@@ -418,9 +416,6 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
-        - name: cni-conf
-          hostPath:
-            path: /etc/cni/net.d
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -292,6 +292,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -423,8 +424,6 @@ spec:
             - mountPath: /sys
               name: host-sys
               readOnly: true
-            - mountPath: /etc/cni/net.d
-              name: cni-conf
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /etc/ovn
@@ -435,10 +434,12 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/run/containerd
               name: cruntime
+              readOnly: true
           readinessProbe:
             exec:
               command:
@@ -482,9 +483,6 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
-        - name: cni-conf
-          hostPath:
-            path: /etc/cni/net.d
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -291,6 +291,7 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -428,8 +429,6 @@ spec:
             - mountPath: /sys
               name: host-sys
               readOnly: true
-            - mountPath: /etc/cni/net.d
-              name: cni-conf
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /etc/ovn
@@ -440,10 +439,12 @@ spec:
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
+              readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
             - mountPath: /var/run/containerd
               name: cruntime
+              readOnly: true
           readinessProbe:
             exec:
               command:
@@ -487,9 +488,6 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
-        - name: cni-conf
-          hostPath:
-            path: /etc/cni/net.d
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- security

### Which issue(s) this PR fixes:
Fixes #2724 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8eb030</samp>

This pull request enhances the security and stability of the pods in the kube-ovn project by adding `readOnly` options to the volume mounts that only need read access to the host paths. It also removes some unused or unnecessary volume mounts and definitions from the templates and yaml files. These changes simplify and secure the pod configurations and avoid potential issues with the host paths.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b8eb030</samp>

> _No more writing to the host path_
> _`readOnly` is the way of wrath_
> _Secure and stable are the pods_
> _We are the masters of the `ovn` gods_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b8eb030</samp>

*  Add `readOnly: true` option to `host-log-ovn` volume mount in all pods that use it to prevent writing to host path `/var/log/ovn` ([link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-a5c7ec4d325cefcc89bab9608d877fd9489239e8859881bb070ec43f23fa2051R99), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-ea68dce347b5fa351b4dd8da76b26575f5aeac40e3ce0f5d37e26a603bb6ea51R136), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-aafeafe291807e5f2688246fed7cd4cb6104522cd3e9e6b9cb671249fc5fcb73L83-R88), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-90880cf33f50d3c72a4349293d1f6abe953633d3edb2dc71c45368462b4ac4e5R114), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131R109), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e86184e0e5f4bdf5ba5efe2812441f1b8fd9760422241814f857126dd389eca2L76-R92), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR118), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R118), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R120), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e8ff83be2329052ff8d94933b1ee843421bd0ebce8f505a4f27fba7f887b90b0L368-L369), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadR295), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9R294))
*  Add `readOnly: true` option to `localtime` volume mount in all pods that use it to prevent writing to host path `/etc/localtime` ([link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-aafeafe291807e5f2688246fed7cd4cb6104522cd3e9e6b9cb671249fc5fcb73L83-R88), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-90880cf33f50d3c72a4349293d1f6abe953633d3edb2dc71c45368462b4ac4e5R136), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e86184e0e5f4bdf5ba5efe2812441f1b8fd9760422241814f857126dd389eca2L76-R92), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR256), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R256), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R258), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL438-R442), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L443-R447))
*  Add `readOnly: true` option to `cruntime` volume mount in all pods that use it to prevent writing to host path `/var/run/containerd` ([link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131R220), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR278), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R278), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R280), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL438-R442), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L443-R447))
*  Remove `host-log-ovs` volume mount and definition from `monitor-deploy.yaml`, `kube-ovn-dual-stack.yaml`, `kube-ovn-ipv6.yaml`, and `kube-ovn.yaml` as it is not used by the monitor pod ([link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-aafeafe291807e5f2688246fed7cd4cb6104522cd3e9e6b9cb671249fc5fcb73L83-R88), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-aafeafe291807e5f2688246fed7cd4cb6104522cd3e9e6b9cb671249fc5fcb73L125-L127), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL558-R555), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL600-L602), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L558-R555), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L600-L602), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L560-R557), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L602-L604))
*  Remove `cni-conf` volume mount and definition from `ovsovn-ds.yaml`, `ovn-dpdk.yaml`, `ovn-ha.yaml`, and `ovn.yaml` as it is not used by the ovn-ovs pod ([link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L99-L100), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L196-L198), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e8ff83be2329052ff8d94933b1ee843421bd0ebce8f505a4f27fba7f887b90b0L368-L369), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e8ff83be2329052ff8d94933b1ee843421bd0ebce8f505a4f27fba7f887b90b0L421-L423), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL426-L427), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL485-L487), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L431-L432), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-a73e3ad03224ed2e051bc38dfc9b1ab92308690f9a223a4fa4d5456ada9d75a9L490-L492))
*  Remove `host-modules`, `host-run-ovs`, and `host-sys` volume mounts and definitions from `pinger-ds.yaml`, `kube-ovn-dual-stack.yaml`, `kube-ovn-ipv6.yaml`, and `kube-ovn.yaml` as they are not used by the pinger or ovn-ovs pods ([link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e86184e0e5f4bdf5ba5efe2812441f1b8fd9760422241814f857126dd389eca2L76-R92), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e86184e0e5f4bdf5ba5efe2812441f1b8fd9760422241814f857126dd389eca2L110-L112), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e86184e0e5f4bdf5ba5efe2812441f1b8fd9760422241814f857126dd389eca2L119-L121), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL410-R429), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL444-L446), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL453-L455), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L410-R429), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L444-L446), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L453-L455), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L412-R431), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L446-L448), [link](https://github.com/kubeovn/kube-ovn/pull/2852/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35L455-L457))