### PR TITLE
ci: fix valgrind result analysis

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -389,18 +389,28 @@ jobs:
           kubectl -n kube-system rollout restart ds ovs-ovn
           kubectl -n kube-system rollout status deploy ovn-central
           kubectl -n kube-system rollout status ds ovs-ovn
+          while true; do
+            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+              break
+            fi
+            sleep 1
+          done
           kubectl ko log ovn
           kubectl ko log ovs
 
-          exit_code=0
-          find kubectl-ko-log -type f -name '*.valgrind.*' | while read f; do
-            if grep -qw 'definitely lost' "$f"; then
-              exit_code=1
-              echo $f; cat "$f";
-            fi;
+          for daemon in ovsdb-nb ovsdb-sb ovn-northd ovn-controller ovsdb-server ovs-vswitchd; do
+            echo "Checking if valgrind log file for $daemon exists..."
+            find kubectl-ko-log -type f -name "$daemon.valgrind.log.[[:digit:]]*" -exec false {} + && exit 1
           done
 
-          exit $exit_code
+          find kubectl-ko-log -type f -name '*.valgrind.log.*' | while read f; do
+            if grep -qw 'definitely lost' "$f"; then
+              echo "Memory leak detected in $(basename $f | awk -F. '{print $1}')."
+              echo $f
+              cat "$f"
+              exit 1
+            fi;
+          done
 
   k8s-netpol-e2e:
     name: Kubernetes Network Policy E2E
@@ -824,18 +834,28 @@ jobs:
           kubectl -n kube-system rollout restart ds ovs-ovn
           kubectl -n kube-system rollout status deploy ovn-central
           kubectl -n kube-system rollout status ds ovs-ovn
+          while true; do
+            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+              break
+            fi
+            sleep 1
+          done
           kubectl ko log ovn
           kubectl ko log ovs
 
-          exit_code=0
-          find kubectl-ko-log -type f -name '*.valgrind.*' | while read f; do
-            if grep -qw 'definitely lost' "$f"; then
-              exit_code=1
-              echo $f; cat "$f";
-            fi;
+          for daemon in ovsdb-nb ovsdb-sb ovn-northd ovn-controller ovsdb-server ovs-vswitchd; do
+            echo "Checking if valgrind log file for $daemon exists..."
+            find kubectl-ko-log -type f -name "$daemon.valgrind.log.[[:digit:]]*" -exec false {} + && exit 1
           done
 
-          exit $exit_code
+          find kubectl-ko-log -type f -name '*.valgrind.log.*' | while read f; do
+            if grep -qw 'definitely lost' "$f"; then
+              echo "Memory leak detected in $(basename $f | awk -F. '{print $1}')."
+              echo $f
+              cat "$f"
+              exit 1
+            fi;
+          done
 
       - name: Cleanup
         run: sh dist/images/cleanup.sh

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -493,6 +493,9 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Export debug image tag
+        run: echo "DEBUG_TAG='$(cat VERSION)-debug'" >> "$GITHUB_ENV"
+
       - name: Create kind cluster
         run: |
           sudo pip3 install j2cli
@@ -502,6 +505,9 @@ jobs:
           sudo chown -R $(id -un). ~/.kube/
 
       - name: Install Kube-OVN
+        env:
+          VERSION: ${{ env.DEBUG_TAG }}
+          DEBUG_WRAPPER: valgrind
         run: make kind-install-${{ matrix.ip-family }}
 
       - name: Run E2E
@@ -520,6 +526,35 @@ jobs:
         with:
           name: k8s-netpol-e2e-${{ matrix.ip-family }}-ko-log
           path: k8s-netpol-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
+
+      - name: Check valgrind result
+        run: |
+          kubectl -n kube-system rollout restart deploy ovn-central
+          kubectl -n kube-system rollout restart ds ovs-ovn
+          kubectl -n kube-system rollout status deploy ovn-central
+          kubectl -n kube-system rollout status ds ovs-ovn
+          while true; do
+            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+              break
+            fi
+            sleep 1
+          done
+          kubectl ko log ovn
+          kubectl ko log ovs
+
+          for daemon in ovsdb-nb ovsdb-sb ovn-northd ovn-controller ovsdb-server ovs-vswitchd; do
+            echo "Checking if valgrind log file for $daemon exists..."
+            find kubectl-ko-log -type f -name "$daemon.valgrind.log.[[:digit:]]*" -exec false {} + && exit 1
+          done
+
+          find kubectl-ko-log -type f -name '*.valgrind.log.*' | while read f; do
+            if grep -qw 'definitely lost' "$f"; then
+              echo "Memory leak detected in $(basename $f | awk -F. '{print $1}')."
+              echo $f
+              cat "$f"
+              exit 1
+            fi;
+          done
 
   k8s-netpol-legacy-e2e:
     name: Kubernetes Network Policy Legacy E2E
@@ -602,6 +637,9 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Export debug image tag
+        run: echo "DEBUG_TAG='$(cat VERSION)-debug'" >> "$GITHUB_ENV"
+
       - name: Create kind cluster
         run: |
           sudo pip3 install j2cli
@@ -611,6 +649,9 @@ jobs:
           sudo chown -R $(id -un). ~/.kube/
 
       - name: Install Kube-OVN
+        env:
+          VERSION: ${{ env.DEBUG_TAG }}
+          DEBUG_WRAPPER: valgrind
         run: make kind-install-${{ matrix.ip-family }}
 
       - name: Run E2E
@@ -629,6 +670,35 @@ jobs:
         with:
           name: k8s-netpol-legacy-e2e-${{ matrix.ip-family }}-ko-log
           path: k8s-netpol-legacy-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
+
+      - name: Check valgrind result
+        run: |
+          kubectl -n kube-system rollout restart deploy ovn-central
+          kubectl -n kube-system rollout restart ds ovs-ovn
+          kubectl -n kube-system rollout status deploy ovn-central
+          kubectl -n kube-system rollout status ds ovs-ovn
+          while true; do
+            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+              break
+            fi
+            sleep 1
+          done
+          kubectl ko log ovn
+          kubectl ko log ovs
+
+          for daemon in ovsdb-nb ovsdb-sb ovn-northd ovn-controller ovsdb-server ovs-vswitchd; do
+            echo "Checking if valgrind log file for $daemon exists..."
+            find kubectl-ko-log -type f -name "$daemon.valgrind.log.[[:digit:]]*" -exec false {} + && exit 1
+          done
+
+          find kubectl-ko-log -type f -name '*.valgrind.log.*' | while read f; do
+            if grep -qw 'definitely lost' "$f"; then
+              echo "Memory leak detected in $(basename $f | awk -F. '{print $1}')."
+              echo $f
+              cat "$f"
+              exit 1
+            fi;
+          done
 
   cyclonus-netpol-e2e:
     name: Cyclonus Network Policy E2E
@@ -687,6 +757,9 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Export debug image tag
+        run: echo "DEBUG_TAG='$(cat VERSION)-debug'" >> "$GITHUB_ENV"
+
       - name: Create kind cluster
         run: |
           sudo pip3 install j2cli
@@ -696,6 +769,9 @@ jobs:
           sudo chown -R $(id -un). ~/.kube/
 
       - name: Install Kube-OVN
+        env:
+          VERSION: ${{ env.DEBUG_TAG }}
+          DEBUG_WRAPPER: valgrind
         run: make kind-install-${{ matrix.ip-family }}
 
       - name: Run E2E
@@ -714,6 +790,35 @@ jobs:
         with:
           name: cyclonus-netpol-e2e-${{ matrix.ip-family }}-ko-log
           path: cyclonus-netpol-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
+
+      - name: Check valgrind result
+        run: |
+          kubectl -n kube-system rollout restart deploy ovn-central
+          kubectl -n kube-system rollout restart ds ovs-ovn
+          kubectl -n kube-system rollout status deploy ovn-central
+          kubectl -n kube-system rollout status ds ovs-ovn
+          while true; do
+            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+              break
+            fi
+            sleep 1
+          done
+          kubectl ko log ovn
+          kubectl ko log ovs
+
+          for daemon in ovsdb-nb ovsdb-sb ovn-northd ovn-controller ovsdb-server ovs-vswitchd; do
+            echo "Checking if valgrind log file for $daemon exists..."
+            find kubectl-ko-log -type f -name "$daemon.valgrind.log.[[:digit:]]*" -exec false {} + && exit 1
+          done
+
+          find kubectl-ko-log -type f -name '*.valgrind.log.*' | while read f; do
+            if grep -qw 'definitely lost' "$f"; then
+              echo "Memory leak detected in $(basename $f | awk -F. '{print $1}')."
+              echo $f
+              cat "$f"
+              exit 1
+            fi;
+          done
 
   kube-ovn-conformance-e2e:
     name: Kube-OVN Conformance E2E

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -271,7 +271,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -21,7 +21,9 @@ RUN cd /usr/src/ && \
     # ovsdb-tool: add optional server id parameter for "join-cluster" command
     curl -s https://github.com/kubeovn/ovs/commit/ebf61515da71fa2e23125a92859fbdb96dcbffe7.patch | git apply && \
     # Add jitter parameter patch for netem qos
-    curl -s https://github.com/kubeovn/ovs/commit/2eaaf89fbf3ee2172719ed10d045fd79900edc8e.patch | git apply
+    curl -s https://github.com/kubeovn/ovs/commit/2eaaf89fbf3ee2172719ed10d045fd79900edc8e.patch | git apply && \
+    # fix memory leak in qos
+    curl -s https://github.com/kubeovn/ovs/commit/6a4dd2f4b9311a227cc26fef7c398ae9b241311b.patch | git apply
 
 RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
@@ -69,14 +71,12 @@ RUN mkdir /packages/ && \
 
 FROM ubuntu:22.04
 
-ARG DEBUG=false
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y && apt install ca-certificates python3 hostname libunwind8 netbase \
         ethtool iproute2 ncat libunbound-dev procps libatomic1 kmod iptables python3-netifaces python3-sortedcontainers \
         tcpdump ipset curl uuid-runtime openssl inetutils-ping arping ndisc6 \
         logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
         libcharon-extauth-plugins libstrongswan-extra-plugins libstrongswan-standard-plugins -y --no-install-recommends && \
-        if [ "${DEBUG}" = "true" ]; then apt install -y --no-install-recommends valgrind; fi && \
         rm -rf /var/lib/apt/lists/* && \
         rm -rf /etc/localtime
 
@@ -94,12 +94,6 @@ ENV KUBE_VERSION="v1.27.2"
 RUN curl -L https://dl.k8s.io/${KUBE_VERSION}/kubernetes-client-linux-${ARCH}.tar.gz | tar -xz -C . && cp ./kubernetes/client/bin/kubectl /usr/bin/kubectl \
  && chmod +x /usr/bin/kubectl && rm -rf ./kubernetes
 
-RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \
-    dpkg -i /packages/openvswitch-*.deb /packages/python3-openvswitch*.deb && \
-    dpkg -i --ignore-depends=openvswitch-switch,openvswitch-common /packages/ovn-*.deb && \
-    if [ "${DEBUG}" = "true" ]; then dpkg -i --ignore-depends=openvswitch-switch,openvswitch-common /packages/*.ddeb; fi && \
-    rm -rf /var/lib/openvswitch/pki/
-
 ENV BFDD_VERSION="v0.5.4"
 RUN curl -sSf -L --retry 3 -o /usr/local/bin/bfdd-control https://github.com/bobz965/bfd-binary-for-kube-ovn-cni/releases/download/${BFDD_VERSION}/bfdd-control && \
     curl -sSf -L --retry 3 -o /usr/local/bin/bfdd-beacon https://github.com/bobz965/bfd-binary-for-kube-ovn-cni/releases/download/${BFDD_VERSION}/bfdd-beacon && \
@@ -110,5 +104,18 @@ RUN dumb_init_arch="x86_64"; \
     if [ "$ARCH" = "arm64" ]; then dumb_init_arch="aarch64"; fi; \
     curl -sSf -L --retry 5 -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${dumb_init_arch} && \
     chmod +x /usr/bin/dumb-init
+
+RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \
+    dpkg -i /packages/openvswitch-*.deb /packages/python3-openvswitch*.deb && \
+    dpkg -i --ignore-depends=openvswitch-switch,openvswitch-common /packages/ovn-*.deb && \
+    rm -rf /var/lib/openvswitch/pki/
+
+ARG DEBUG=false
+RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages \
+    if [ "${DEBUG}" = "true" ]; then \
+        apt update && apt install -y --no-install-recommends valgrind && \
+        rm -rf /var/lib/apt/lists/* && \
+        dpkg -i --ignore-depends=openvswitch-switch,openvswitch-common /packages/*.ddeb; \
+    fi
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- CI

### Which issue(s) this PR fixes:

1. Wait for ovn nb endpoints to be ready since kubectl-ko needs it before collecting logs;
2. Fix the exit code when a memory leak is detected.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1ca827</samp>

Enhance memory leak detection for `ovn` and `ovs` daemons in x86 image testing jobs. Fix some issues with the valgrind log file handling and output.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d1ca827</samp>

> _`ovn-nb` endpoint_
> _waiting for it in a loop_
> _autumn patience grows_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1ca827</samp>

* Add a loop to wait for the ovn-nb endpoint to be ready before logging the ovn pods ([link](https://github.com/kubeovn/kube-ovn/pull/2853/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L392-R414), [link](https://github.com/kubeovn/kube-ovn/pull/2853/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L827-R859))
* Modify the valgrind log file name pattern to match the format used by the ovn and ovs pods ([link](https://github.com/kubeovn/kube-ovn/pull/2853/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L392-R414), [link](https://github.com/kubeovn/kube-ovn/pull/2853/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L827-R859))
* Check for the existence of the valgrind log files for each daemon and exit with an error if any are missing ([link](https://github.com/kubeovn/kube-ovn/pull/2853/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L392-R414), [link](https://github.com/kubeovn/kube-ovn/pull/2853/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L827-R859))
* Print the name of the daemon that has a memory leak, along with the log file name and content ([link](https://github.com/kubeovn/kube-ovn/pull/2853/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L392-R414), [link](https://github.com/kubeovn/kube-ovn/pull/2853/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L827-R859))