### PR TITLE
some fixes in CI/e2e

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -711,7 +711,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -186,7 +186,7 @@ jobs:
   k8s-netpol-legacy-e2e:
     name: Kubernetes Network Policy Legacy E2E
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -91,6 +91,8 @@ func MakePod(ns, name string, labels, annotations map[string]string, image strin
 			},
 		},
 	}
+	pod.Spec.TerminationGracePeriodSeconds = new(int64)
+	*pod.Spec.TerminationGracePeriodSeconds = 3
 
 	return pod
 }

--- a/test/e2e/framework/service.go
+++ b/test/e2e/framework/service.go
@@ -159,6 +159,8 @@ func MakeService(name string, svcType corev1.ServiceType, annotations, selector 
 			Type:            svcType,
 		},
 	}
+	service.Spec.IPFamilyPolicy = new(corev1.IPFamilyPolicy)
+	*service.Spec.IPFamilyPolicy = corev1.IPFamilyPolicyPreferDualStack
 
 	return service
 }

--- a/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
+++ b/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
@@ -117,7 +117,6 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 		ginkgo.By("Creating pod " + podName)
 		cmd := []string{"sh", "-c", fmt.Sprintf(`while true; do %s -c1 -w1 %s; sleep 1; done`, ping, target)}
 		pod := framework.MakePod(namespaceName, podName, nil, nil, framework.BusyBoxImage, cmd, nil)
-		pod.Spec.TerminationGracePeriodSeconds = new(int64)
 		pod = podClient.CreateSync(pod)
 
 		execOrDie(fmt.Sprintf("ko tcpdump %s/%s -c1", pod.Namespace, pod.Name))

--- a/test/e2e/kube-ovn/node/node.go
+++ b/test/e2e/kube-ovn/node/node.go
@@ -170,8 +170,6 @@ var _ = framework.OrderedDescribe("[group:node]", func() {
 			TargetPort: intstr.FromInt(port),
 		}}
 		service := framework.MakeService(serviceName, "", nil, podLabels, ports, "")
-		service.Spec.IPFamilyPolicy = new(corev1.IPFamilyPolicy)
-		*service.Spec.IPFamilyPolicy = corev1.IPFamilyPolicyPreferDualStack
 		_ = serviceClient.CreateSync(service, func(s *corev1.Service) (bool, error) {
 			return len(s.Spec.ClusterIPs) != 0, nil
 		}, "cluster ips are not empty")

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -837,7 +837,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 		isSuccess := false
 		framework.WaitUntil(2*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
 			subnet = subnetClient.Get(subnetName)
-			framework.Logf("subnet status usingips %d availableIPs %d ", subnet.Status.V4UsingIPs, subnet.Status.V4AvailableIPs)
+			framework.Logf("subnet status usingips %d availableIPs %d", int64(subnet.Status.V4UsingIPs), int64(subnet.Status.V4AvailableIPs))
 			if cidrV4 != "" {
 				isSuccess = checkFunc(subnet.Status.V4UsingIPRange, subnet.Status.V4AvailableIPRange, startIPv4, lastIPv4, replicas, false)
 				if !isSuccess {

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -438,6 +438,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		ginkgo.By("Creating pod " + podName + " with IP address " + ip)
 		annotations := map[string]string{util.IpAddressAnnotation: ip}
 		pod := framework.MakePod(namespaceName, podName, nil, annotations, image, cmd, nil)
+		pod.Spec.TerminationGracePeriodSeconds = nil
 		_ = podClient.Create(pod)
 
 		ginkgo.By("Waiting for pod events")


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- CI/Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82c6a34</samp>

Increase timeout-minutes for some GitHub workflow jobs and improve service and pod specs in e2e tests. Simplify and fix some issues in the service, node, and subnet packages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 82c6a34</samp>

> _`timeout-minutes` grow_
> _avoiding failures in jobs_
> _winter is coming_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82c6a34</samp>

*  Increase the timeout-minutes for two GitHub workflow jobs to avoid failures ([link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L714-R714), [link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L189-R189))
*  Add the TerminationGracePeriodSeconds field to the pod spec in the `test/e2e/framework/pod.go` file to ensure graceful pod termination ([link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-5f15fda6193ef82e5636ecbb83e7df08e56285d7c04d7e7360c3461d7b08e065R94-R95))
*  Add the IPFamilyPolicy field to the service spec in the `test/e2e/framework/service.go` file to prefer dual-stack services ([link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-7d2a92121dec233f7faaaa67d52838470acd9f6675a381b2345c839755d446f2R162-R163))
*  Remove the redundant IPFamilyPolicy field from the service spec in the `test/e2e/kube-ovn/node/node.go` and `test/e2e/kube-ovn/service/service.go` files ([link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-95ebcd8012fc20437f5b35e2cec4091f82204c5a02d3204d81212cdc9b9910a6L173-L174), [link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-90a7c3d6fa34f68f00846179b0157b5698d8d860a9a77dae5ea7ec9e3d5120caL86-L87), [link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-90a7c3d6fa34f68f00846179b0157b5698d8d860a9a77dae5ea7ec9e3d5120caL137-L138))
*  Replace the RunHostCmdOrDie function with the WaitUntil function in the `test/e2e/kube-ovn/service/service.go` file to retry the curl command until success or timeout ([link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-90a7c3d6fa34f68f00846179b0157b5698d8d860a9a77dae5ea7ec9e3d5120caL111-R113))
*  Cast the subnet status fields V4UsingIPs and V4AvailableIPs to int64 in the `test/e2e/kube-ovn/subnet/subnet.go` file to avoid overflow errors ([link](https://github.com/kubeovn/kube-ovn/pull/2856/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L840-R840))