### PR TITLE
add ssl vpn gw 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ SUBMARINER_ROUTE_AGENT = quay.io/submariner/submariner-route-agent:$(SUBMARINER_
 SUBMARINER_NETTEST = quay.io/submariner/nettest:$(SUBMARINER_VERSION)
 
 VPC_NAT_GW_IMG = $(REGISTRY)/vpc-nat-gateway:$(VERSION)
+SSL_VPN_IMG = "registry.cn-hangzhou.aliyuncs.com/bobz/openvpn:0.0.1"
 
 E2E_NETWORK = bridge
 ifneq ($(VLAN_ID),)
@@ -594,6 +595,7 @@ kind-install-multus:
 .PHONY: kind-install-vpc-nat-gw
 kind-install-vpc-nat-gw: kind-load-image kind-untaint-control-plane
 	$(call kind_load_image,kube-ovn,$(VPC_NAT_GW_IMG))
+	$(call kind_load_image,kube-ovn,$(SSL_VPN_IMG))
 	@$(MAKE) ENABLE_NAT_GW=true CNI_CONFIG_PRIORITY=10 kind-install
 	@$(MAKE) kind-install-multus
 	kubectl apply -f yamls/vpc-nat-gw-attachment.yaml

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3514,6 +3514,7 @@ metadata:
       kube-ovn vpc-nat common config
 data:
   image: $REGISTRY/$VPC_NAT_IMAGE:$VERSION
+  ssl-vpn-image: "registry.cn-hangzhou.aliyuncs.com/bobz/openvpn:0.0.1"
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	vpcNatImage = ""
+	sslVpnImage = ""
 )
 
 func (c *Controller) resyncVpcNatConfig() {
@@ -26,4 +27,9 @@ func (c *Controller) resyncVpcNatConfig() {
 		return
 	}
 	vpcNatImage = image
+	sslVpnImage, exist = cm.Data["ssl-vpn-image"]
+	if exist {
+		klog.Infof("enable ssl vpn")
+		return
+	}
 }


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d0cc60</samp>

This pull request adds a new SSL VPN gateway feature for VPC NAT in kube-ovn. It updates the `Makefile` to support testing the feature with kind, and refactors the pod creation logic in `vpc_nat_gateway.go` and `vpc_nat.go` to use multiple containers and read the image name from a configmap.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2d0cc60</samp>

> _To make kube-ovn more secure_
> _A new SSL VPN feature_
> _Was added with care_
> _To the vpc nat `podSpec`_
> _And the image name came from the `configmap` store_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d0cc60</samp>

* Enable SSL VPN feature for vpc nat gateway by adding a new image variable and a conditional container ([link](https://github.com/kubeovn/kube-ovn/pull/2864/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R56), [link](https://github.com/kubeovn/kube-ovn/pull/2864/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L690-R717), [link](https://github.com/kubeovn/kube-ovn/pull/2864/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L707-R734))
* Load SSL VPN image into kind cluster for testing and development ([link](https://github.com/kubeovn/kube-ovn/pull/2864/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R598))
* Read SSL VPN image from configmap and assign it to a global variable in `controller` package ([link](https://github.com/kubeovn/kube-ovn/pull/2864/files?diff=unified&w=0#diff-12c6edf8de05c599fc0d7e5ea49d25ef2b24fbdcc801efa72dc2e21840d09b61R12), [link](https://github.com/kubeovn/kube-ovn/pull/2864/files?diff=unified&w=0#diff-12c6edf8de05c599fc0d7e5ea49d25ef2b24fbdcc801efa72dc2e21840d09b61R30-R34))
* Remove redundant assignment of vpc nat image from configmap in `vpc_nat_gateway.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2864/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L95))