### PR TITLE
fix: make vpc nat gw e2e could rerun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -607,7 +607,6 @@ kind-install-vpc-nat-gw: kind-load-image kind-untaint-control-plane
 	$(call kind_load_image,kube-ovn,$(VPC_NAT_GW_IMG))
 	@$(MAKE) ENABLE_NAT_GW=true CNI_CONFIG_PRIORITY=10 kind-install
 	@$(MAKE) kind-install-multus
-	kubectl apply -f yamls/vpc-nat-gw-attachment.yaml
 
 .PHONY: kind-install-kubevirt
 kind-install-kubevirt: kind-load-image kind-untaint-control-plane

--- a/test/e2e/framework/network-attachment-definition.go
+++ b/test/e2e/framework/network-attachment-definition.go
@@ -1,0 +1,55 @@
+package framework
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+)
+
+// NetworkAttachmentDefinitionClient is a struct for nad client.
+type NetworkAttachmentDefinitionClient struct {
+	f *Framework
+	v1.NetworkAttachmentDefinitionInterface
+}
+
+func (f *Framework) NetworkAttachmentDefinitionClient(namespace string) *NetworkAttachmentDefinitionClient {
+	return &NetworkAttachmentDefinitionClient{
+		f:                                    f,
+		NetworkAttachmentDefinitionInterface: f.AttachNetClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace),
+	}
+}
+
+func (s *NetworkAttachmentDefinitionClient) Get(name string) *apiv1.NetworkAttachmentDefinition {
+	nad, err := s.NetworkAttachmentDefinitionInterface.Get(context.TODO(), name, metav1.GetOptions{})
+	ExpectNoError(err)
+	return nad
+}
+
+// Create creates a new nad according to the framework specifications
+func (c *NetworkAttachmentDefinitionClient) Create(nad *apiv1.NetworkAttachmentDefinition) *apiv1.NetworkAttachmentDefinition {
+	nad, err := c.NetworkAttachmentDefinitionInterface.Create(context.TODO(), nad, metav1.CreateOptions{})
+	ExpectNoError(err, "Error creating nad")
+	return nad.DeepCopy()
+}
+
+// Delete deletes a nad if the nad exists
+func (c *NetworkAttachmentDefinitionClient) Delete(name string) {
+	err := c.NetworkAttachmentDefinitionInterface.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	ExpectNoError(err, "Error deleting nad")
+}
+
+func MakeNetworkAttachmentDefinition(name, namespace, conf string) *apiv1.NetworkAttachmentDefinition {
+	nad := &apiv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: apiv1.NetworkAttachmentDefinitionSpec{
+			Config: conf,
+		},
+	}
+	return nad
+}

--- a/yamls/vpc-nat-gw-attachment.yaml
+++ b/yamls/vpc-nat-gw-attachment.yaml
@@ -1,7 +1,0 @@
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
-metadata:
-  name: ovn-vpc-external-network
-  namespace: kube-system
-spec:
-  config: '{"cniVersion": "0.3.0","type": "macvlan","master": "eth1","mode": "bridge"}'


### PR DESCRIPTION
Support repeating the execution of e2e


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- E2E
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2876

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a8f80b</samp>

Simplify and fix the iptables-vpc-nat-gw test. Remove redundant cleanup code and correct a ginkgo message in `test/e2e/iptables-vpc-nat-gw/e2e_test.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a8f80b</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who simplified the test of iptables-vpc-nat-gw_
> _And removed the needless code that cluttered the script_
> _Like the Augean stables that Heracles cleansed._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a8f80b</samp>

* Remove unnecessary code that disconnects nodes from docker network ([link](https://github.com/kubeovn/kube-ovn/pull/2866/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L174-R176))
* Fix typo in ginkgo message ([link](https://github.com/kubeovn/kube-ovn/pull/2866/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L193-R189))
* Remove redundant code that deletes configmap and network attachment definition for vpc nat gateway ([link](https://github.com/kubeovn/kube-ovn/pull/2866/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L361-L363), [link](https://github.com/kubeovn/kube-ovn/pull/2866/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L378-L379))