### PR TITLE
update webhook check

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -479,7 +479,7 @@ func (c *Controller) handleUpdateVpcEip(natGwKey string) error {
 		return err
 	}
 	for _, eip := range eips {
-		if eip.Spec.NatGwDp == natGwKey && eip.Status.Redo != NAT_GW_CREATED_AT && eip.Annotations[util.VpcNatAnnotation] == "" {
+		if eip.Spec.NatGwDp == natGwKey && eip.Status.Redo != NAT_GW_CREATED_AT {
 			klog.V(3).Infof("redo eip %s", eip.Name)
 			if err = c.patchEipStatus(eip.Name, "", NAT_GW_CREATED_AT, "", false); err != nil {
 				klog.Errorf("failed to update eip '%s' to re-apply, %v", eip.Name, err)

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -886,7 +886,8 @@ func (c *Controller) patchEipStatus(key, v4ip, redo, qos string, ready bool) err
 		return err
 	}
 	// nat record all kinds of nat rules using this eip
-	if nat != "" && eip.Status.Nat != nat {
+	klog.V(3).Infof("nat of eip %s is %s", eip.Name, nat)
+	if eip.Status.Nat != nat {
 		eip.Status.Nat = nat
 		changed = true
 	}

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -593,7 +594,7 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 			return err
 		}
 		//  reset eip
-		c.resetIptablesEipQueue.Add(cachedFip.Spec.EIP)
+		c.resetIptablesEipQueue.AddAfter(cachedFip.Spec.EIP, 3*time.Second)
 		return nil
 	}
 	klog.V(3).Infof("handle update fip %s", key)
@@ -761,7 +762,7 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 			return err
 		}
 		//  reset eip
-		c.resetIptablesEipQueue.Add(cachedDnat.Spec.EIP)
+		c.resetIptablesEipQueue.AddAfter(cachedDnat.Spec.EIP, 3*time.Second)
 		return nil
 	}
 	klog.V(3).Infof("handle update dnat %s", key)
@@ -940,7 +941,7 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 			return err
 		}
 		//  reset eip
-		c.resetIptablesEipQueue.Add(cachedSnat.Spec.EIP)
+		c.resetIptablesEipQueue.AddAfter(cachedSnat.Spec.EIP, 3*time.Second)
 		return nil
 	}
 	klog.V(3).Infof("handle update snat %s", key)

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -248,8 +248,11 @@ func ValidateVpc(vpc *kubeovnv1.Vpc) error {
 		}
 
 		if item.Action == kubeovnv1.PolicyRouteActionReroute {
-			if ip := net.ParseIP(item.NextHopIP); ip == nil {
-				return fmt.Errorf("bad next hop ip: %s", item.NextHopIP)
+			// ecmp policy route may reroute to multiple next hop ips
+			for _, ipStr := range strings.Split(item.NextHopIP, ",") {
+				if ip := net.ParseIP(ipStr); ip == nil {
+					return fmt.Errorf("invalid next hop ips: %s", item.NextHopIP)
+				}
 			}
 		}
 	}

--- a/pkg/webhook/subnet.go
+++ b/pkg/webhook/subnet.go
@@ -39,6 +39,15 @@ func (v *ValidatingHook) SubnetCreateHook(ctx context.Context, req admission.Req
 			err := fmt.Errorf("vpc and subnet cannot have the same name")
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
+
+		if o.Spec.Vpc == item.Name && item.Status.Standby && !item.Status.Default {
+			for _, ns := range o.Spec.Namespaces {
+				if !util.ContainsString(item.Spec.Namespaces, ns) {
+					err := fmt.Errorf("namespace '%s' is out of range to custom vpc '%s'", ns, item.Name)
+					return ctrlwebhook.Errored(http.StatusBadRequest, err)
+				}
+			}
+		}
 	}
 
 	return ctrlwebhook.Allowed("by pass")


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Enhancement


### Which issue(s) this PR fixes:
Fixes #2503 #2886 #2887

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff7b1b7</samp>

This pull request enhances the webhook validation for vpc nat gateway rules and ecmp policy routes. It adds context and cache client parameters to webhook functions in `pkg/webhook/vpc_nat_gateway.go`. It allows multiple next hop IPs in `ValidateVpc` function in `pkg/util/validator.go`. It verifies the namespaces and vpc mode in `subnetCreateHook` function in `pkg/webhook/subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ff7b1b7</samp>

> _`ValidateVpc` splits_
> _Next hop IPs for ecmp routes_
> _Autumn of changes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff7b1b7</samp>

*  Add context parameter to cache client calls in vpc nat gateway webhook functions ([link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L177-R177), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L208-R208), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L231-R231), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L262-R262), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L285-R285), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L316-R316))
*  Fetch and validate vpc, qos, and eip objects from cache in vpc nat gateway webhook functions ([link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7R329-R333), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L336-R341), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7R372-R379), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L430-R452), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L476-R503), [link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-54468cdc026f328f4437c0ffd56a4d7bed0f13b32d4e2ed6a3011b1d0c9304d7L489-R521))
*  Support multiple next hop IPs for ecmp policy routes in `ValidateVpc` function in `pkg/util/validator.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-7f0dbc597e1344dab5f2b581992a7ad0423ff2087593902fe39429d0a980782bL251-R255))
*  Check namespace range and vpc mode in subnet creation webhook function in `pkg/webhook/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2878/files?diff=unified&w=0#diff-c72288205ed634db46284a570dff9aba3365e8e6301c48234cd48b3b344ca453R42-R50))