### PR TITLE
fix vip str format

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1415,6 +1415,9 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
+      - name: NS
+        type: string
+        jsonPath: .spec.namespace
       - name: V4IP
         type: string
         jsonPath: .status.v4ip

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1953,6 +1953,9 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
+      - name: NS
+        type: string
+        jsonPath: .spec.namespace
       - name: V4IP
         type: string
         jsonPath: .status.v4ip

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -1726,6 +1726,9 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
+      - name: NS
+        type: string
+        jsonPath: .spec.namespace
       - name: V4IP
         type: string
         jsonPath: .status.v4ip


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5b3bcd</samp>

This pull request improves the vip controller, the daemon handler, and the vip crd. It fixes some bugs and inconsistencies in the vip controller, enhances the security and privacy of the pod data in the daemon handler, and adds a new column to the vip crd for better visibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f5b3bcd</samp>

> _This pull request is about vips_
> _And how to avoid some bad slips_
> _It fixes the `handleAdd`_
> _And adds a new column `NS`_
> _And cleans up the logical switch ports_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5b3bcd</samp>

*  Use namespace from vip spec instead of vip object metadata for consistency and correctness ([link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L193-R193), [link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L243-R242), [link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L296-R281))
*  Use utility function `util.GetStringIP` to join v4ip and v6ip strings with a comma, avoiding extra comma when one of the IPs is empty ([link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L220-R221))
*  Move code that deletes logical switch port for vip of type `SwitchLBRuleVip` from `handleUpdateVirtualIp` to `handleDelVirtualIp`, as it should only be executed when vip is deleted ([link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L265-L278), [link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L314-R314))
*  Add more logging messages to indicate deletion of vip and vip arp proxy lsp in `handleDelVirtualIp` ([link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L314-R314))
*  Remove podRequest argument from logging message in `handleAdd` function in `pkg/daemon/handler.go`, as it may contain sensitive information such as pod annotations ([link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL81-R81))
*  Add new column `NS` to vip crd in `yamls/crd.yaml`, which displays namespace from vip spec, improving visibility and usability of vip crd ([link](https://github.com/kubeovn/kube-ovn/pull/2879/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1729-R1731))