### PR TITLE
kube-ovn-controller: fix subnet update

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -104,7 +104,7 @@ func (c *Controller) initDefaultLogicalSwitch() error {
 			if util.CheckProtocol(c.config.DefaultCIDR) == kubeovnv1.ProtocolDual {
 				subnet := subnet.DeepCopy()
 				subnet.Spec.CIDRBlock = c.config.DefaultCIDR
-				if err := formatSubnet(subnet, c); err != nil {
+				if _, err = formatSubnet(subnet, c); err != nil {
 					klog.Errorf("init format subnet %s failed: %v", c.config.DefaultLogicalSwitch, err)
 					return err
 				}
@@ -158,7 +158,7 @@ func (c *Controller) initNodeSwitch() error {
 			// single-stack upgrade to dual-stack
 			subnet := subnet.DeepCopy()
 			subnet.Spec.CIDRBlock = c.config.NodeSwitchCIDR
-			if err := formatSubnet(subnet, c); err != nil {
+			if _, err = formatSubnet(subnet, c); err != nil {
 				klog.Errorf("init format subnet %s failed: %v", c.config.NodeSwitch, err)
 				return err
 			}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b68f69</samp>

This pull request improves the `formatSubnet` function and its usage in the subnet controller. It makes the function return the formatted subnet object and the error, and simplifies the code logic in `pkg/controller/subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b68f69</samp>

> _Sing, O Muse, of the skillful coder who reforged_
> _The `formatSubnet` function, a mighty tool of cloud_
> _That shapes the subnet objects, like Hephaestus molds the ore_
> _And gives them back to callers, with error or success._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b68f69</samp>

*  Change the `formatSubnet` function to return the updated subnet object as well as the error, and update the callers to handle the new return type ([link](https://github.com/kubeovn/kube-ovn/pull/2882/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L107-R107), [link](https://github.com/kubeovn/kube-ovn/pull/2882/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L161-R161), [link](https://github.com/kubeovn/kube-ovn/pull/2882/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L261-R261), [link](https://github.com/kubeovn/kube-ovn/pull/2882/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L267-R267), [link](https://github.com/kubeovn/kube-ovn/pull/2882/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L297-R297), [link](https://github.com/kubeovn/kube-ovn/pull/2882/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L314-R320))
*  Return the deep copy of the updated subnet object from `formatSubnet` to avoid mutating the cache ([link](https://github.com/kubeovn/kube-ovn/pull/2882/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L314-R320))
*  Remove the redundant code to get the subnet object from the lister in `syncSubnet`, and move the `handleSubnetFinalizer` function up to use the updated subnet object as the input ([link](https://github.com/kubeovn/kube-ovn/pull/2882/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L489-R492))