### PR TITLE
Add natoutgoing policy rules

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1593,6 +1593,25 @@ spec:
                   type: string
                 v6availableIPrange:
                   type: string
+                natOutgoingPolicyRules:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      ruleID:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - nat
+                          - forward
+                      match:
+                        type: object
+                        properties:
+                          srcIPs:
+                            type: string
+                          dstIPs:
+                            type: string
                 conditions:
                   type: array
                   items:
@@ -1711,6 +1730,25 @@ spec:
                           - allow
                           - drop
                           - reject
+                natOutgoingPolicyRules:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      ruleID:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - nat
+                          - forward
+                      match:
+                        type: object
+                        properties:
+                          srcIPs:
+                            type: string
+                          dstIPs:
+                            type: string
                 u2oInterconnection:
                   type: boolean
                 enableLb:

--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1735,8 +1735,6 @@ spec:
                   items:
                     type: object
                     properties:
-                      ruleID:
-                        type: string
                       action:
                         type: string
                         enum:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2131,6 +2131,25 @@ spec:
                   type: string
                 v6availableIPrange:
                   type: string
+                natOutgoingPolicyRules:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      ruleID:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - nat
+                          - forward
+                      match:
+                        type: object
+                        properties:
+                          srcIPs:
+                            type: string
+                          dstIPs:
+                            type: string
                 conditions:
                   type: array
                   items:
@@ -2249,6 +2268,23 @@ spec:
                           - allow
                           - drop
                           - reject
+                natOutgoingPolicyRules:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      action:
+                        type: string
+                        enum:
+                          - nat
+                          - forward
+                      match:
+                        type: object
+                        properties:
+                          srcIPs:
+                            type: string
+                          dstIPs:
+                            type: string
                 u2oInterconnection:
                   type: boolean
                 enableLb:

--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -28,6 +28,7 @@ ipset destroy ovn40subnets-distributed-gw
 ipset destroy ovn40local-pod-ip-nat
 ipset destroy ovn40other-node
 ipset destroy ovn40services
+ipset destroy ovn40subnets-nat-policy
 
 ip6tables -t nat -D PREROUTING -j OVN-PREROUTING -m comment --comment "kube-ovn prerouting rules"
 ip6tables -t nat -D POSTROUTING -j OVN-POSTROUTING -m comment --comment "kube-ovn postrouting rules"
@@ -55,6 +56,7 @@ ipset destroy ovn60subnets-distributed-gw
 ipset destroy ovn60local-pod-ip-nat
 ipset destroy ovn60other-node
 ipset destroy ovn60services
+ipset destroy ovn60subnets-nat-policy
 
 rm -rf /var/run/openvswitch/*
 rm -rf /var/run/ovn/*

--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -8,6 +8,8 @@ iptables -t nat -F OVN-PREROUTING
 iptables -t nat -X OVN-PREROUTING
 iptables -t nat -F OVN-POSTROUTING
 iptables -t nat -X OVN-POSTROUTING
+iptables -t nat -F OVN-NAT-POLICY
+iptables -t nat -X OVN-NAT-POLICY
 iptables -t filter -D INPUT -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40services dst -j ACCEPT
@@ -33,6 +35,8 @@ ip6tables -t nat -F OVN-PREROUTING
 ip6tables -t nat -X OVN-PREROUTING
 ip6tables -t nat -F OVN-POSTROUTING
 ip6tables -t nat -X OVN-POSTROUTING
+ip6tables -t nat -F OVN-NAT-POLICY
+ip6tables -t nat -X OVN-NAT-POLICY
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60services dst -j ACCEPT

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -159,6 +159,8 @@ type SubnetSpec struct {
 
 	Acls []Acl `json:"acls,omitempty"`
 
+	NatOutgoingPolicyRules []NatOutgoingPolicyRule `json:"natOutgoingPolicyRules,omitempty"`
+
 	U2OInterconnection bool  `json:"u2oInterconnection,omitempty"`
 	EnableLb           *bool `json:"enableLb,omitempty"`
 	EnableEcmp         bool  `json:"enableEcmp,omitempty"`
@@ -171,6 +173,21 @@ type Acl struct {
 	Priority  int    `json:"priority,omitempty"`
 	Match     string `json:"match,omitempty"`
 	Action    string `json:"action,omitempty"`
+}
+
+type NatOutgoingPolicyRule struct {
+	Match  natOutGoingPolicyMatch `json:"match"`
+	Action string                 `json:"action"`
+}
+
+type NatOutgoingPolicyRuleStatus struct {
+	RuleID string `json:"ruleID"`
+	NatOutgoingPolicyRule
+}
+
+type natOutGoingPolicyMatch struct {
+	SrcIPs string `json:"srcIPs,omitempty"`
+	DstIPs string `json:"dstIPs,omitempty"`
 }
 
 // ConditionType encodes information on the condition
@@ -204,19 +221,20 @@ type SubnetStatus struct {
 	// +patchStrategy=merge
 	Conditions []SubnetCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	V4AvailableIPs        float64 `json:"v4availableIPs"`
-	V4AvailableIPRange    string  `json:"v4availableIPrange"`
-	V4UsingIPs            float64 `json:"v4usingIPs"`
-	V4UsingIPRange        string  `json:"v4usingIPrange"`
-	V6AvailableIPs        float64 `json:"v6availableIPs"`
-	V6AvailableIPRange    string  `json:"v6availableIPrange"`
-	V6UsingIPs            float64 `json:"v6usingIPs"`
-	V6UsingIPRange        string  `json:"v6usingIPrange"`
-	ActivateGateway       string  `json:"activateGateway"`
-	DHCPv4OptionsUUID     string  `json:"dhcpV4OptionsUUID"`
-	DHCPv6OptionsUUID     string  `json:"dhcpV6OptionsUUID"`
-	U2OInterconnectionIP  string  `json:"u2oInterconnectionIP"`
-	U2OInterconnectionVPC string  `json:"u2oInterconnectionVPC"`
+	V4AvailableIPs         float64                       `json:"v4availableIPs"`
+	V4AvailableIPRange     string                        `json:"v4availableIPrange"`
+	V4UsingIPs             float64                       `json:"v4usingIPs"`
+	V4UsingIPRange         string                        `json:"v4usingIPrange"`
+	V6AvailableIPs         float64                       `json:"v6availableIPs"`
+	V6AvailableIPRange     string                        `json:"v6availableIPrange"`
+	V6UsingIPs             float64                       `json:"v6usingIPs"`
+	V6UsingIPRange         string                        `json:"v6usingIPrange"`
+	ActivateGateway        string                        `json:"activateGateway"`
+	DHCPv4OptionsUUID      string                        `json:"dhcpV4OptionsUUID"`
+	DHCPv6OptionsUUID      string                        `json:"dhcpV6OptionsUUID"`
+	U2OInterconnectionIP   string                        `json:"u2oInterconnectionIP"`
+	U2OInterconnectionVPC  string                        `json:"u2oInterconnectionVPC"`
+	NatOutgoingPolicyRules []NatOutgoingPolicyRuleStatus `json:"natOutgoingPolicyRules"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -176,7 +176,7 @@ type Acl struct {
 }
 
 type NatOutgoingPolicyRule struct {
-	Match  natOutGoingPolicyMatch `json:"match"`
+	Match  NatOutGoingPolicyMatch `json:"match"`
 	Action string                 `json:"action"`
 }
 
@@ -185,7 +185,7 @@ type NatOutgoingPolicyRuleStatus struct {
 	NatOutgoingPolicyRule
 }
 
-type natOutGoingPolicyMatch struct {
+type NatOutGoingPolicyMatch struct {
 	SrcIPs string `json:"srcIPs,omitempty"`
 	DstIPs string `json:"dstIPs,omitempty"`
 }

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -663,6 +663,13 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		c.patchSubnetStatus(subnet, "ValidateLogicalSwitchSuccess", "")
 	}
 
+	if subnet.Spec.NatOutgoingPolicyRules != nil {
+		if err := genNatOutgoingPolicyRulesStatus(subnet); err != nil {
+			klog.Error(err)
+			return err
+		}
+	}
+
 	if subnet.Spec.Protocol == kubeovnv1.ProtocolDual {
 		err = calcDualSubnetStatusIP(subnet, c)
 	} else {
@@ -782,13 +789,6 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 
 		c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", "")
-	}
-
-	if subnet.Spec.NatOutgoingPolicyRules != nil {
-		if err := genNatOutgoingPolicyRulesStatus(subnet); err != nil {
-			klog.Error(err)
-			return err
-		}
 	}
 
 	if err := c.ovnClient.CreateGatewayAcl(subnet.Name, "", subnet.Spec.Gateway); err != nil {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -331,7 +331,7 @@ func genNatOutgoingPolicyRulesStatus(subnet *kubeovnv1.Subnet) error {
 			if err != nil {
 				return err
 			}
-			priority := string(index)
+			priority := fmt.Sprintf("%d", index)
 			// hash code generate by subnetName, rule and priority
 			var retBytes []byte
 			retBytes = append(retBytes, []byte(subnet.Name)...)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"reflect"
@@ -101,7 +102,8 @@ func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
 		!reflect.DeepEqual(oldSubnet.Spec.Acls, newSubnet.Spec.Acls) ||
 		oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection ||
 		oldSubnet.Spec.RouteTable != newSubnet.Spec.RouteTable ||
-		oldSubnet.Spec.Vpc != newSubnet.Spec.Vpc {
+		oldSubnet.Spec.Vpc != newSubnet.Spec.Vpc ||
+		!reflect.DeepEqual(oldSubnet.Spec.NatOutgoingPolicyRules, newSubnet.Spec.NatOutgoingPolicyRules) {
 		klog.V(3).Infof("enqueue update subnet %s", key)
 
 		if oldSubnet.Spec.GatewayType != newSubnet.Spec.GatewayType {
@@ -316,6 +318,24 @@ func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 			klog.Errorf("failed to update subnet %s, %v", subnet.Name, err)
 			return err
 		}
+	}
+	return nil
+}
+
+func genNatOutgoingPolicyRulesStatus(subnet *kubeovnv1.Subnet) error {
+	subnet.Status.NatOutgoingPolicyRules = make([]kubeovnv1.NatOutgoingPolicyRuleStatus, len(subnet.Spec.NatOutgoingPolicyRules))
+	for index, rule := range subnet.Spec.NatOutgoingPolicyRules {
+		jsonRule, err := json.Marshal(rule)
+		if err != nil {
+			return err
+		}
+		priority := string(index)
+		retBytes := append(jsonRule, []byte(priority)...)
+		result := util.Sha256ByteToString(retBytes)
+
+		subnet.Status.NatOutgoingPolicyRules[index].RuleID = result[:util.NatPolicyRuleIDLength]
+		subnet.Status.NatOutgoingPolicyRules[index].Match = rule.Match
+		subnet.Status.NatOutgoingPolicyRules[index].Action = rule.Action
 	}
 	return nil
 }
@@ -762,6 +782,13 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 
 		c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", "")
+	}
+
+	if subnet.Spec.NatOutgoingPolicyRules != nil {
+		if err := genNatOutgoingPolicyRulesStatus(subnet); err != nil {
+			klog.Error(err)
+			return err
+		}
 	}
 
 	if err := c.ovnClient.CreateGatewayAcl(subnet.Name, "", subnet.Spec.Gateway); err != nil {

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -22,6 +22,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	k8sipset "k8s.io/kubernetes/pkg/util/ipset"
 	k8siptables "k8s.io/kubernetes/pkg/util/iptables"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -34,6 +35,7 @@ type ControllerRuntime struct {
 	iptables         map[string]*iptables.IPTables
 	iptablesObsolete map[string]*iptables.IPTables
 	k8siptables      map[string]k8siptables.Interface
+	k8sipsets        k8sipset.Interface
 	ipsets           map[string]*ipsets.IPSets
 	gwCounters       map[string]*util.GwIPtableCounters
 }
@@ -78,6 +80,7 @@ func (c *Controller) initRuntime() error {
 	c.ipsets = make(map[string]*ipsets.IPSets)
 	c.gwCounters = make(map[string]*util.GwIPtableCounters)
 	c.k8siptables = make(map[string]k8siptables.Interface)
+	c.k8sipsets = k8sipset.New(c.k8sExec)
 
 	if c.protocol == kubeovnv1.ProtocolIPv4 || c.protocol == kubeovnv1.ProtocolDual {
 		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -119,13 +119,13 @@ func (c *Controller) getSubnetsNatOutGoingPolicy(protocol string) ([]*kubeovnv1.
 		return nil, err
 	}
 
-	var subnetsWithPolicy []*kubeovnv1.Subnet
+	var subnetsWithNatPolicy []*kubeovnv1.Subnet
 	for _, subnet := range subnets {
 		if c.isSubnetNeedNat(subnet, protocol) && len(subnet.Spec.NatOutgoingPolicyRules) != 0 {
-			subnetsWithPolicy = append(subnetsWithPolicy, subnet)
+			subnetsWithNatPolicy = append(subnetsWithNatPolicy, subnet)
 		}
 	}
-	return subnetsWithPolicy, nil
+	return subnetsWithNatPolicy, nil
 }
 
 func (c *Controller) getSubnetsDistributedGateway(protocol string) ([]string, error) {

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -34,7 +34,7 @@ func (c *Controller) runGateway() {
 	if err := c.setExGateway(); err != nil {
 		klog.Errorf("failed to set ex gateway, %v", err)
 	}
-
+	c.gcIPSet()
 	c.appendMssRule()
 }
 
@@ -83,6 +83,18 @@ func (c *Controller) setICGateway() error {
 	return nil
 }
 
+func (c *Controller) isSubnetNeedNat(subnet *kubeovnv1.Subnet, protocol string) bool {
+	if subnet.DeletionTimestamp == nil &&
+		subnet.Spec.NatOutgoing &&
+		(subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) &&
+		subnet.Spec.Vpc == c.config.ClusterRouter &&
+		subnet.Spec.CIDRBlock != "" &&
+		(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) {
+		return true
+	}
+	return false
+}
+
 func (c *Controller) getSubnetsNeedNAT(protocol string) ([]string, error) {
 	var subnetsNeedNat []string
 	subnets, err := c.subnetsLister.List(labels.Everything())
@@ -92,17 +104,28 @@ func (c *Controller) getSubnetsNeedNAT(protocol string) ([]string, error) {
 	}
 
 	for _, subnet := range subnets {
-		if subnet.DeletionTimestamp == nil &&
-			subnet.Spec.NatOutgoing &&
-			(subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) &&
-			subnet.Spec.Vpc == c.config.ClusterRouter &&
-			subnet.Spec.CIDRBlock != "" &&
-			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) {
+		if c.isSubnetNeedNat(subnet, protocol) {
 			cidrBlock := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
 			subnetsNeedNat = append(subnetsNeedNat, cidrBlock)
 		}
 	}
 	return subnetsNeedNat, nil
+}
+
+func (c *Controller) getSubnetsNatOutGoingPolicy(protocol string) ([]*kubeovnv1.Subnet, error) {
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("list subnets failed, %v", err)
+		return nil, err
+	}
+
+	var subnetsWithPolicy []*kubeovnv1.Subnet
+	for _, subnet := range subnets {
+		if c.isSubnetNeedNat(subnet, protocol) && len(subnet.Spec.NatOutgoingPolicyRules) != 0 {
+			subnetsWithPolicy = append(subnetsWithPolicy, subnet)
+		}
+	}
+	return subnetsWithPolicy, nil
 }
 
 func (c *Controller) getSubnetsDistributedGateway(protocol string) ([]string, error) {

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -47,8 +47,8 @@ const (
 )
 
 const (
-	OnOutGoingNatMark     = "0x4001/0x4001"
-	OnOutGoingForwardMark = "0x4002/0x4002"
+	OnOutGoingNatMark     = "0x90001/0x90001"
+	OnOutGoingForwardMark = "0x90002/0x90002"
 )
 
 type policyRouteMeta struct {
@@ -560,7 +560,7 @@ func (c *Controller) setIptables() error {
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m set ! --match-set ovn60subnets src -m set ! --match-set ovn60other-node src -m set --match-set ovn60subnets-nat dst -j RETURN`)},
 			// nat outgoing
 			// nat outgoing policy rules
-			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m set --match-set ovn60subnets-nat-policy src -m set ! --match-set ovn60subnets dst -j MASQUERADE`)},
+			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(fmt.Sprintf(`-m set --match-set ovn60subnets-nat-policy src -m set ! --match-set ovn60subnets dst -j %s`, OvnNatOutGoingPolicy))},
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(fmt.Sprintf(`-m mark --mark %s -j MASQUERADE`, OnOutGoingNatMark))},
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(fmt.Sprintf(`-m mark --mark %s -j RETURN`, OnOutGoingForwardMark))},
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m set --match-set ovn60subnets-nat src -m set ! --match-set ovn60subnets dst -j MASQUERADE`)},
@@ -1464,8 +1464,7 @@ func (c *Controller) ipsetExists(name string) (bool, error) {
 }
 
 func getTruncatedUID(uid string) string {
-	uidLen := len(uid)
-	return uid[uidLen-12:]
+	return uid[len(uid)-12:]
 }
 
 func getNatOutGoingPolicyRuleIPSetName(ruleID, srcOrDst, protocol string, hasPrefix bool) string {

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -18,8 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
-	k8sipset "k8s.io/kubernetes/pkg/util/ipset"
-	k8sexec "k8s.io/utils/exec"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -27,21 +25,30 @@ import (
 )
 
 const (
-	ServiceSet             = "services"
-	SubnetSet              = "subnets"
-	SubnetNatSet           = "subnets-nat"
-	SubnetDistributedGwSet = "subnets-distributed-gw"
-	LocalPodSet            = "local-pod-ip-nat"
-	OtherNodeSet           = "other-node"
-	IPSetPrefix            = "ovn"
+	ServiceSet                 = "services"
+	SubnetSet                  = "subnets"
+	SubnetNatSet               = "subnets-nat"
+	SubnetDistributedGwSet     = "subnets-distributed-gw"
+	LocalPodSet                = "local-pod-ip-nat"
+	OtherNodeSet               = "other-node"
+	IPSetPrefix                = "ovn"
+	NatOutGoingPolicySubnetSet = "subnets-nat-policy"
+	NatOutGoingPolicyRuleSet   = "natpr-"
 )
 
 const (
-	NAT            = "nat"
-	Prerouting     = "PREROUTING"
-	Postrouting    = "POSTROUTING"
-	OvnPrerouting  = "OVN-PREROUTING"
-	OvnPostrouting = "OVN-POSTROUTING"
+	NAT                        = "nat"
+	Prerouting                 = "PREROUTING"
+	Postrouting                = "POSTROUTING"
+	OvnPrerouting              = "OVN-PREROUTING"
+	OvnPostrouting             = "OVN-POSTROUTING"
+	OvnNatOutGoingPolicy       = "OVN-NAT-POLICY"
+	OvnNatOutGoingPolicySubnet = "OVN-NAT-PSUBNET-"
+)
+
+const (
+	OnOutGoingNatMark     = "0x4001/0x4001"
+	OnOutGoingForwardMark = "0x4002/0x4002"
 )
 
 type policyRouteMeta struct {
@@ -116,9 +123,98 @@ func (c *Controller) setIPSet() error {
 			SetID:   OtherNodeSet,
 			Type:    ipsets.IPSetTypeHashNet,
 		}, otherNode)
+		c.reconcileNatOutGoingPolicyIPset(protocol)
 		c.ipsets[protocol].ApplyUpdates()
 	}
 	return nil
+}
+
+func (c *Controller) gcIPSet() {
+	protocols := make([]string, 2)
+	if c.protocol == kubeovnv1.ProtocolDual {
+		protocols[0] = kubeovnv1.ProtocolIPv4
+		protocols[1] = kubeovnv1.ProtocolIPv6
+	} else {
+		protocols[0] = c.protocol
+	}
+
+	for _, protocol := range protocols {
+		if c.ipsets[protocol] == nil {
+			continue
+		}
+		c.ipsets[protocol].ApplyDeletions()
+	}
+}
+
+func (c *Controller) addNatOutGoingPolicyRuleIPset(rule kubeovnv1.NatOutgoingPolicyRuleStatus, subnetName string, protocol string) {
+	if rule.Match.SrcIPs != "" {
+		ipsetName := getNatOutGoingPolicyRuleIPSetName(rule.RuleID, "src", "", false)
+		c.ipsets[protocol].AddOrReplaceIPSet(ipsets.IPSetMetadata{
+			MaxSize: 1048576,
+			SetID:   ipsetName,
+			Type:    ipsets.IPSetTypeHashNet,
+		}, strings.Split(rule.Match.SrcIPs, ","))
+	}
+
+	if rule.Match.DstIPs != "" {
+		ipsetName := getNatOutGoingPolicyRuleIPSetName(rule.RuleID, "dst", "", false)
+		c.ipsets[protocol].AddOrReplaceIPSet(ipsets.IPSetMetadata{
+			MaxSize: 1048576,
+			SetID:   ipsetName,
+			Type:    ipsets.IPSetTypeHashNet,
+		}, strings.Split(rule.Match.DstIPs, ","))
+	}
+}
+
+func (c *Controller) gcNatOutGoingPolicyRuleIPset(protocol string, natPolicyRuleIDs []string) {
+	sets, err := c.k8sipsets.ListSets()
+	if err != nil {
+		klog.Error("failed to list IP sets")
+		return
+	}
+	if len(sets) != 0 {
+		for _, set := range sets {
+			if isNatOutGoingPolicyRuleIPSet(set) {
+				ruleID, _ := getNatOutGoingPolicyRuleIPSetItem(set)
+				if !util.ContainsString(natPolicyRuleIDs, ruleID) {
+					c.ipsets[protocol].RemoveIPSet(formatUnPrefix(set))
+				}
+			}
+		}
+	}
+}
+
+func (c *Controller) reconcileNatOutGoingPolicyIPset(protocol string) {
+	subnets, err := c.getSubnetsNatOutGoingPolicy(protocol)
+	if err != nil {
+		klog.Errorf("failed to get subnets with NAT outgoing policy rule: %v", err)
+		return
+	}
+
+	subnetCidrs := make([]string, 0)
+	natPolicyRuleIDs := make([]string, 0)
+
+	if len(subnets) != 0 {
+		for _, subnet := range subnets {
+			cidrBlock := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
+			subnetCidrs = append(subnetCidrs, cidrBlock)
+			for _, rule := range subnet.Status.NatOutgoingPolicyRules {
+				natPolicyRuleIDs = append(natPolicyRuleIDs, rule.RuleID)
+				if rule.RuleID == "" {
+					continue
+				}
+				c.addNatOutGoingPolicyRuleIPset(rule, subnet.GetName(), protocol)
+			}
+		}
+	}
+
+	c.ipsets[protocol].AddOrReplaceIPSet(ipsets.IPSetMetadata{
+		MaxSize: 1048576,
+		SetID:   NatOutGoingPolicySubnetSet,
+		Type:    ipsets.IPSetTypeHashNet,
+	}, subnetCidrs)
+
+	c.gcNatOutGoingPolicyRuleIPset(protocol, natPolicyRuleIDs)
 }
 
 func (c *Controller) setPolicyRouting() error {
@@ -336,16 +432,17 @@ func (c *Controller) updateIptablesChain(ipt *iptables.IPTables, table, chain, p
 		}
 		klog.Infof("created iptables chain %s in table %s", chain, table)
 	}
-
-	comment := fmt.Sprintf("kube-ovn %s rules", strings.ToLower(parent))
-	rule := util.IPTableRule{
-		Table: table,
-		Chain: parent,
-		Rule:  []string{"-m", "comment", "--comment", comment, "-j", chain},
-	}
-	if err = c.createIptablesRule(ipt, rule); err != nil {
-		klog.Errorf("failed to create iptables rule: %v", err)
-		return err
+	if parent != "" {
+		comment := fmt.Sprintf("kube-ovn %s rules", strings.ToLower(parent))
+		rule := util.IPTableRule{
+			Table: table,
+			Chain: parent,
+			Rule:  []string{"-m", "comment", "--comment", comment, "-j", chain},
+		}
+		if err = c.createIptablesRule(ipt, rule); err != nil {
+			klog.Errorf("failed to create iptables rule: %v", err)
+			return err
+		}
 	}
 
 	// list existing rules
@@ -427,6 +524,11 @@ func (c *Controller) setIptables() error {
 			// do not nat route traffic
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m set ! --match-set ovn40subnets src -m set ! --match-set ovn40other-node src -m set --match-set ovn40subnets-nat dst -j RETURN`)},
 			// nat outgoing
+			// nat outgoing policy rules
+			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(fmt.Sprintf(`-m set --match-set ovn40subnets-nat-policy src -m set ! --match-set ovn40subnets dst -j %s`, OvnNatOutGoingPolicy))},
+			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(fmt.Sprintf(`-m mark --mark %s -j MASQUERADE`, OnOutGoingNatMark))},
+			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(fmt.Sprintf(`-m mark --mark %s -j RETURN`, OnOutGoingForwardMark))},
+			// default nat outgoing rules
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m set --match-set ovn40subnets-nat src -m set ! --match-set ovn40subnets dst -j MASQUERADE`)},
 			// Input Accept
 			{Table: "filter", Chain: "INPUT", Rule: strings.Fields(`-m set --match-set ovn40subnets src -j ACCEPT`)},
@@ -457,6 +559,10 @@ func (c *Controller) setIptables() error {
 			// do not nat route traffic
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m set ! --match-set ovn60subnets src -m set ! --match-set ovn60other-node src -m set --match-set ovn60subnets-nat dst -j RETURN`)},
 			// nat outgoing
+			// nat outgoing policy rules
+			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m set --match-set ovn60subnets-nat-policy src -m set ! --match-set ovn60subnets dst -j MASQUERADE`)},
+			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(fmt.Sprintf(`-m mark --mark %s -j MASQUERADE`, OnOutGoingNatMark))},
+			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(fmt.Sprintf(`-m mark --mark %s -j RETURN`, OnOutGoingForwardMark))},
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m set --match-set ovn60subnets-nat src -m set ! --match-set ovn60subnets dst -j MASQUERADE`)},
 			// Input Accept
 			{Table: "filter", Chain: "INPUT", Rule: strings.Fields(`-m set --match-set ovn60subnets src -j ACCEPT`)},
@@ -515,7 +621,7 @@ func (c *Controller) setIptables() error {
 
 			for _, p := range [...]string{"tcp", "udp"} {
 				ipset := fmt.Sprintf("KUBE-%sNODE-PORT-LOCAL-%s", kubeProxyIpsetProtocol, strings.ToUpper(p))
-				ipsetExists, err := ipsetExists(ipset)
+				ipsetExists, err := c.ipsetExists(ipset)
 				if err != nil {
 					klog.Error("failed to check existence of ipset %s: %v", ipset, err)
 					return err
@@ -618,6 +724,10 @@ func (c *Controller) setIptables() error {
 			natPostroutingRules = append(natPostroutingRules[:n-1], rule, natPostroutingRules[n-1])
 		}
 
+		if err = c.reconcileNatOutgoingPolicyIptablesChain(protocol); err != nil {
+			return err
+		}
+
 		if err = c.updateIptablesChain(ipt, NAT, OvnPrerouting, Prerouting, natPreroutingRules); err != nil {
 			klog.Errorf("failed to update chain %s/%s: %v", NAT, OvnPrerouting)
 			return err
@@ -633,6 +743,105 @@ func (c *Controller) setIptables() error {
 		}
 	}
 	return nil
+}
+
+func (c *Controller) reconcileNatOutgoingPolicyIptablesChain(protocol string) error {
+	ipt := c.iptables[protocol]
+
+	natPolicySubnetIptables, natPolicyRuleIptablesMap, gcNatPolicySubnetChains, err := c.generateNatOutgoingPolicyChainRules(protocol)
+	if err != nil {
+		klog.Errorf(`failed to get nat policy post routing rules with err %v `, err)
+		return err
+	}
+
+	for chainName, natPolicyRuleIptableRules := range natPolicyRuleIptablesMap {
+		if err = c.updateIptablesChain(ipt, NAT, chainName, "", natPolicyRuleIptableRules); err != nil {
+			klog.Errorf("failed to update chain %s with rules %v: %v", chainName, natPolicyRuleIptableRules, err)
+			return err
+		}
+	}
+
+	if err = c.updateIptablesChain(ipt, NAT, OvnNatOutGoingPolicy, "", natPolicySubnetIptables); err != nil {
+		klog.Errorf("failed to update chain %s: %v", OvnNatOutGoingPolicy, err)
+		return err
+	}
+
+	for _, gcNatPolicySubnetChain := range gcNatPolicySubnetChains {
+		if err = ipt.ClearAndDeleteChain("nat", gcNatPolicySubnetChain); err != nil {
+			klog.Errorf("failed to delete iptables chain %q in table nat : %v", gcNatPolicySubnetChain, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) generateNatOutgoingPolicyChainRules(protocol string) ([]util.IPTableRule, map[string][]util.IPTableRule, []string, error) {
+	natPolicySubnetIptables := make([]util.IPTableRule, 0)
+	natPolicyRuleIptablesMap := make(map[string][]util.IPTableRule)
+	natPolicySubnetUIDs := make([]string, 0)
+	gcNatPolicySubnetChains := make([]string, 0)
+
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("list subnets failed, %v", err)
+		return nil, nil, nil, err
+	}
+
+	for _, subnet := range subnets {
+		if c.isSubnetNeedNat(subnet, protocol) && subnet.Status.NatOutgoingPolicyRules != nil {
+			var natPolicyRuleIptables []util.IPTableRule
+			natPolicySubnetUIDs = append(natPolicySubnetUIDs, getTruncatedUID(string(subnet.GetUID())))
+			cidrBlock := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
+
+			OvnNatPolicySubnetChainName := OvnNatOutGoingPolicySubnet + getTruncatedUID(string(subnet.GetUID()))
+			natPolicySubnetIptables = append(natPolicySubnetIptables, util.IPTableRule{Table: NAT, Chain: OvnNatOutGoingPolicy, Rule: strings.Fields(fmt.Sprintf(`-s %s -m comment --comment natPolicySubnet-%s -j %s`, cidrBlock, subnet.Name, OvnNatPolicySubnetChainName))})
+			for _, rule := range subnet.Status.NatOutgoingPolicyRules {
+				var markCode string
+				if rule.Action == util.NatPolicyRuleActionNat {
+					markCode = OnOutGoingNatMark
+				} else if rule.Action == util.NatPolicyRuleActionForward {
+					markCode = OnOutGoingForwardMark
+				}
+
+				if rule.RuleID == "" {
+					continue
+				}
+
+				srcMatch := getNatOutGoingPolicyRuleIPSetName(rule.RuleID, "src", protocol, true)
+				dstMatch := getNatOutGoingPolicyRuleIPSetName(rule.RuleID, "dst", protocol, true)
+
+				var OvnNatoutGoingPolicyRule util.IPTableRule
+				if rule.Match.DstIPs != "" && rule.Match.SrcIPs != "" {
+					OvnNatoutGoingPolicyRule = util.IPTableRule{Table: NAT, Chain: OvnNatPolicySubnetChainName, Rule: strings.Fields(fmt.Sprintf(`-m set --match-set %s src -m set --match-set %s dst -j MARK --set-xmark %s`, srcMatch, dstMatch, markCode))}
+				} else if rule.Match.SrcIPs != "" {
+					OvnNatoutGoingPolicyRule = util.IPTableRule{Table: NAT, Chain: OvnNatPolicySubnetChainName, Rule: strings.Fields(fmt.Sprintf(`-m set --match-set %s src -j MARK --set-xmark %s`, srcMatch, markCode))}
+				} else if rule.Match.DstIPs != "" {
+					OvnNatoutGoingPolicyRule = util.IPTableRule{Table: NAT, Chain: OvnNatPolicySubnetChainName, Rule: strings.Fields(fmt.Sprintf(`-m set --match-set %s dst -j MARK --set-xmark %s`, dstMatch, markCode))}
+				} else {
+					continue
+				}
+				natPolicyRuleIptables = append(natPolicyRuleIptables, OvnNatoutGoingPolicyRule)
+			}
+			natPolicyRuleIptablesMap[OvnNatPolicySubnetChainName] = natPolicyRuleIptables
+		}
+	}
+
+	existNatChains, err := c.iptables[protocol].ListChains("nat")
+	if err != nil {
+		klog.Errorf("list chains in table nat failed")
+		return nil, nil, nil, err
+	}
+
+	if len(existNatChains) != 0 {
+		for _, existNatChain := range existNatChains {
+			if strings.HasPrefix(existNatChain, OvnNatOutGoingPolicySubnet) &&
+				!util.ContainsString(natPolicySubnetUIDs, getNatPolicySubnetChainUID(existNatChain)) {
+				gcNatPolicySubnetChains = append(gcNatPolicySubnetChains, existNatChain)
+			}
+		}
+	}
+
+	return natPolicySubnetIptables, natPolicyRuleIptablesMap, gcNatPolicySubnetChains, nil
 }
 
 func deleteIptablesRule(ipt *iptables.IPTables, rule util.IPTableRule) error {
@@ -1245,11 +1454,49 @@ func (c *Controller) deleteObsoleteSnatRules(ipt *iptables.IPTables, table, chai
 	return nil
 }
 
-func ipsetExists(name string) (bool, error) {
-	sets, err := k8sipset.New(k8sexec.New()).ListSets()
+func (c *Controller) ipsetExists(name string) (bool, error) {
+	sets, err := c.k8sipsets.ListSets()
 	if err != nil {
 		return false, fmt.Errorf("failed to list ipset names: %v", err)
 	}
 
 	return util.ContainsString(sets, name), nil
+}
+
+func getTruncatedUID(uid string) string {
+	uidLen := len(uid)
+	return uid[uidLen-12:]
+}
+
+func getNatOutGoingPolicyRuleIPSetName(ruleID, srcOrDst, protocol string, hasPrefix bool) string {
+	prefix := ""
+
+	if hasPrefix {
+		prefix = "ovn40"
+		if protocol == kubeovnv1.ProtocolIPv6 {
+			prefix = "ovn60"
+		}
+	}
+
+	return prefix + NatOutGoingPolicyRuleSet + fmt.Sprintf("%s-%s", ruleID, srcOrDst)
+}
+
+func isNatOutGoingPolicyRuleIPSet(ipsetName string) bool {
+	return strings.HasPrefix(ipsetName, "ovn40"+NatOutGoingPolicyRuleSet) ||
+		strings.HasPrefix(ipsetName, "ovn60"+NatOutGoingPolicyRuleSet)
+}
+
+func getNatOutGoingPolicyRuleIPSetItem(ipsetName string) (string, string) {
+	items := strings.Split(ipsetName[len("ovn40")+len(NatOutGoingPolicyRuleSet):], "-")
+	ruleID := items[0]
+	srcOrDst := items[1]
+	return ruleID, srcOrDst
+}
+
+func getNatPolicySubnetChainUID(chainName string) string {
+	return chainName[len(OvnNatOutGoingPolicySubnet):]
+}
+
+func formatUnPrefix(ipsetName string) string {
+	return ipsetName[len("ovn40"):]
 }

--- a/pkg/daemon/gateway_windows.go
+++ b/pkg/daemon/gateway_windows.go
@@ -25,6 +25,10 @@ func (c *Controller) setIptables() error {
 	return nil
 }
 
+func (c *Controller) gcIPSet() error {
+	return nil
+}
+
 func (c *Controller) addEgressConfig(subnet *kubeovnv1.Subnet, ip string) error {
 	// nothing to do on Windows
 	return nil

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -246,4 +246,8 @@ const (
 	QoSDirectionEgress  = "egress"
 
 	MainRouteTable = ""
+
+	NatPolicyRuleActionNat     = "nat"
+	NatPolicyRuleActionForward = "forward"
+	NatPolicyRuleIDLength      = 12
 )

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -66,3 +66,7 @@ func LabelSelectorNotEquals(key, value string) (labels.Selector, error) {
 func LabelSelectorNotEmpty(key string) (labels.Selector, error) {
 	return LabelSelectorNotEquals(key, "")
 }
+
+func GetTruncatedUID(uid string) string {
+	return uid[len(uid)-12:]
+}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -1,6 +1,10 @@
 package util
 
-import "strings"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
 
 func DoubleQuotedFields(s string) []string {
 	var quoted bool
@@ -21,4 +25,11 @@ func DoubleQuotedFields(s string) []string {
 	}
 
 	return fields
+}
+
+func Sha256ByteToString(input []byte) string {
+	hasher := sha256.New()
+	hasher.Write(input)
+	hashedBytes := hasher.Sum(nil)
+	return hex.EncodeToString(hashedBytes)
 }

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -111,8 +111,7 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 	}
 
 	if len(subnet.Spec.NatOutgoingPolicyRules) != 0 {
-		err := validateNatOutgoingPolicyRules(subnet)
-		if err != nil {
+		if err := validateNatOutgoingPolicyRules(subnet); err != nil {
 			return err
 		}
 	}
@@ -126,20 +125,17 @@ func validateNatOutgoingPolicyRules(subnet kubeovnv1.Subnet) error {
 
 		if rule.Match.SrcIPs != "" {
 			if srcProtocol, err = validateNatOutGoingPolicyRuleIPs(rule.Match.SrcIPs); err != nil {
-				err := fmt.Errorf("validate nat policy rules src ips %s failed with err %v ", rule.Match.SrcIPs, err)
-				return err
+				return fmt.Errorf("validate nat policy rules src ips %s failed with err %v ", rule.Match.SrcIPs, err)
 			}
 		}
 		if rule.Match.DstIPs != "" {
 			if dstProtocol, err = validateNatOutGoingPolicyRuleIPs(rule.Match.DstIPs); err != nil {
-				err := fmt.Errorf("validate nat policy rules dst ips %s failed with err %v ", rule.Match.DstIPs, err)
-				return err
+				return fmt.Errorf("validate nat policy rules dst ips %s failed with err %v ", rule.Match.DstIPs, err)
 			}
 		}
 
 		if srcProtocol != "" && dstProtocol != "" && srcProtocol != dstProtocol {
-			err := fmt.Errorf("Match.SrcIPS protocol %s not equal to Match.DstIPs protocol %s ", srcProtocol, dstProtocol)
-			return err
+			return fmt.Errorf("Match.SrcIPS protocol %s not equal to Match.DstIPs protocol %s ", srcProtocol, dstProtocol)
 		}
 	}
 	return nil

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -44,9 +44,8 @@ func checkIPSetOnNode(f *framework.Framework, node string, expectetIPsets []stri
 	framework.WaitUntil(2*time.Second, time.Minute, func(_ context.Context) (bool, error) {
 		output := e2epodoutput.RunHostCmdOrDie(ovsPod.Namespace, ovsPod.Name, cmd)
 		exitIPsets := strings.Split(output, "\n")
-		fmt.Printf("exitIPsets is %v ", exitIPsets)
 		for _, r := range expectetIPsets {
-			fmt.Printf("checking ipset %s ", r)
+			framework.Logf("checking ipset %s ", r)
 			ok, err := gomega.ContainElement(gomega.HavePrefix(r)).Match(exitIPsets)
 			if err != nil || ok != shouldExist {
 				return false, err
@@ -76,7 +75,7 @@ func checkIptablesRulesOnNode(f *framework.Framework, node, table, chain, cidr s
 		output := e2epodoutput.RunHostCmdOrDie(ovsPod.Namespace, ovsPod.Name, cmd)
 		rules := strings.Split(output, "\n")
 		for _, r := range expectedRules {
-			fmt.Printf("checking rule %s \n ", r)
+			framework.Logf("checking rule %s \n ", r)
 			ok, err := gomega.ContainElement(gomega.HavePrefix(r)).Match(rules)
 			if err != nil || ok != shouldExist {
 				return false, err

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -75,7 +75,7 @@ func checkIptablesRulesOnNode(f *framework.Framework, node, table, chain, cidr s
 		output := e2epodoutput.RunHostCmdOrDie(ovsPod.Namespace, ovsPod.Name, cmd)
 		rules := strings.Split(output, "\n")
 		for _, r := range expectedRules {
-			framework.Logf("checking rule %s \n ", r)
+			framework.Logf("checking rule %s ", r)
 			ok, err := gomega.ContainElement(gomega.HavePrefix(r)).Match(rules)
 			if err != nil || ok != shouldExist {
 				return false, err
@@ -1165,7 +1165,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 		fakeSubnet.Spec.NatOutgoingPolicyRules = rules
 		fakeSubnet.Spec.NatOutgoing = true
 		_ = subnetClient.CreateSync(fakeSubnet)
-
+		time.Sleep(4 * time.Second) // gateway update every 3 seconds
 		subnet = subnetClient.Get(subnetName)
 		checkNatPolicyRules(f, cs, subnet, cidrV4, cidrV6, true)
 		checkNatPolicyIPsets(f, cs, subnet, cidrV4, cidrV6, true)
@@ -1207,9 +1207,10 @@ var _ = framework.Describe("[group:subnet]", func() {
 		modifiedSubnet.Spec.NatOutgoingPolicyRules = rules
 		subnetClient.PatchSync(subnet, modifiedSubnet)
 
+		time.Sleep(4 * time.Second) // gateway update every 3 seconds
 		subnet = subnetClient.Get(subnetName)
 		checkNatPolicyRules(f, cs, subnet, cidrV4, cidrV6, true)
-		checkNatPolicyIPsets(f, cs, subnet, cidrV4, cidrV4, true)
+		checkNatPolicyIPsets(f, cs, subnet, cidrV4, cidrV6, true)
 
 		fakeSubnet = subnetClient.Get(fakeSubnetName)
 		checkNatPolicyRules(f, cs, fakeSubnet, fakeCidrV4, fakeCidrV6, true)
@@ -1223,9 +1224,10 @@ var _ = framework.Describe("[group:subnet]", func() {
 		modifiedSubnet.Spec.NatOutgoing = false
 		subnetClient.Patch(subnet, modifiedSubnet, 5*time.Second)
 
+		time.Sleep(4 * time.Second) // gateway update every 3 seconds
 		subnet = subnetClient.Get(subnetName)
 		checkNatPolicyRules(f, cs, subnet, cidrV4, cidrV6, false)
-		checkNatPolicyIPsets(f, cs, subnet, cidrV4, cidrV4, false)
+		checkNatPolicyIPsets(f, cs, subnet, cidrV4, cidrV6, false)
 
 		fakeSubnet = subnetClient.Get(fakeSubnetName)
 		checkNatPolicyRules(f, cs, fakeSubnet, fakeCidrV4, fakeCidrV6, true)
@@ -1239,7 +1241,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 		modifiedSubnet.Spec.NatOutgoing = true
 		modifiedSubnet.Spec.NatOutgoingPolicyRules = nil
 		subnetClient.PatchSync(subnet, modifiedSubnet)
-
+		time.Sleep(4 * time.Second) // gateway update every 3 seconds
 		subnet = subnetClient.Get(subnetName)
 		checkNatPolicyRules(f, cs, subnet, cidrV4, cidrV6, false)
 		checkNatPolicyRules(f, cs, subnet, cidrV4, cidrV6, false)

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -51,7 +51,7 @@ func checkIptablesRulesOnNode(f *framework.Framework, node, table, chain, cidr s
 
 	cmd := fmt.Sprintf(`%s -t %s -S `, iptBin, table)
 	if chain != "" {
-		cmd += fmt.Sprintf(`%s`, chain)
+		cmd += chain
 	}
 	framework.WaitUntil(2*time.Second, time.Minute, func(_ context.Context) (bool, error) {
 		output := e2epodoutput.RunHostCmdOrDie(ovsPod.Namespace, ovsPod.Name, cmd)
@@ -989,8 +989,8 @@ var _ = framework.Describe("[group:subnet]", func() {
 		for _, node := range nodes.Items {
 			ginkgo.By("Checking iptables rules on node " + node.Name + " for subnet " + subnetName)
 			expectedRules := []string{
-				fmt.Sprintf(`-A %s -d %s -m comment --comment "%s,%s"`, "FORWARD", cidr, util.OvnSubnetGatewayIptables, subnet),
-				fmt.Sprintf(`-A %s -s %s -m comment --comment "%s,%s"`, "FORWARD", cidr, util.OvnSubnetGatewayIptables, subnet),
+				fmt.Sprintf(`-A %s -d %s -m comment --comment "%s,%s"`, "FORWARD", cidr, util.OvnSubnetGatewayIptables, subnetName),
+				fmt.Sprintf(`-A %s -s %s -m comment --comment "%s,%s"`, "FORWARD", cidr, util.OvnSubnetGatewayIptables, subnetName),
 			}
 
 			checkIptablesRulesOnNode(f, node.Name, "filter", "FORWARD", cidrV4, expectedRules, true)
@@ -1036,8 +1036,8 @@ var _ = framework.Describe("[group:subnet]", func() {
 		for _, node := range nodes.Items {
 			ginkgo.By("Checking iptables rules on node " + node.Name + " for subnet " + subnetName)
 			expectedRules := []string{
-				fmt.Sprintf(`-A %s -d %s -m comment --comment "%s,%s"`, "FORWARD", cidr, util.OvnSubnetGatewayIptables, subnet),
-				fmt.Sprintf(`-A %s -s %s -m comment --comment "%s,%s"`, "FORWARD", cidr, util.OvnSubnetGatewayIptables, subnet),
+				fmt.Sprintf(`-A %s -d %s -m comment --comment "%s,%s"`, "FORWARD", cidr, util.OvnSubnetGatewayIptables, subnetName),
+				fmt.Sprintf(`-A %s -s %s -m comment --comment "%s,%s"`, "FORWARD", cidr, util.OvnSubnetGatewayIptables, subnetName),
 			}
 
 			checkIptablesRulesOnNode(f, node.Name, "filter", "FORWARD", cidrV4, expectedRules, false)
@@ -1127,7 +1127,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 		fakeSubnet := framework.MakeSubnet(fakeSubnetName, "", framework.RandomCIDR(f.ClusterIpFamily), "", "", "", nil, nil, nil)
 		fakeSubnet.Spec.NatOutgoingPolicyRules = rules
 		fakeSubnet.Spec.NatOutgoing = true
-		fakeSubnet = subnetClient.CreateSync(fakeSubnet)
+		_ = subnetClient.CreateSync(fakeSubnet)
 
 		ginkgo.By("Checking nat policy rule existed")
 		subnet = subnetClient.Get(subnetName)
@@ -1209,12 +1209,12 @@ func checkNatPolicyRules(f *framework.Framework, cs clientset.Interface, subnet 
 	for _, node := range nodes.Items {
 		var expectV4Rules, expectV6Rules, staticV4Rules, staticV6Rules []string
 		if cidrV4 != "" {
-			staticV4Rules = append(staticV4Rules, fmt.Sprintf("-A OVN-POSTROUTING -m set --match-set ovn40subnets-nat-policy src -m set ! --match-set ovn40subnets dst -j OVN-NAT-POLICY"))
+			staticV4Rules = append(staticV4Rules, "-A OVN-POSTROUTING -m set --match-set ovn40subnets-nat-policy src -m set ! --match-set ovn40subnets dst -j OVN-NAT-POLICY")
 			expectV4Rules = append(expectV4Rules, fmt.Sprintf("-A OVN-NAT-POLICY -s %s -m comment --comment natPolicySubnet-%s -j OVN-NAT-PSUBNET-%s", cidrV4, subnetName, subnet.UID[len(subnet.UID)-12:]))
 		}
 
 		if cidrV6 != "" {
-			staticV6Rules = append(staticV6Rules, fmt.Sprintf("-A OVN-POSTROUTING -m set --match-set ovn60subnets-nat-policy src -m set ! --match-set ovn60subnets dst -j OVN-NAT-POLICY"))
+			staticV6Rules = append(staticV6Rules, "-A OVN-POSTROUTING -m set --match-set ovn60subnets-nat-policy src -m set ! --match-set ovn60subnets dst -j OVN-NAT-POLICY")
 			expectV6Rules = append(expectV6Rules, fmt.Sprintf("-A OVN-NAT-POLICY -s %s -m comment --comment natPolicySubnet-%s -j OVN-NAT-PSUBNET-%s", cidrV6, subnetName, subnet.UID[len(subnet.UID)-12:]))
 		}
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -2046,8 +2046,6 @@ spec:
                   items:
                     type: object
                     properties:
-                      ruleID:
-                        type: string
                       action:
                         type: string
                         enum:

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -1904,6 +1904,25 @@ spec:
                   type: string
                 v6availableIPrange:
                   type: string
+                natOutgoingPolicyRules:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      ruleID:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - nat
+                          - forward
+                      match:
+                        type: object
+                        properties:
+                          srcIPs:
+                            type: string
+                          dstIPs:
+                            type: string
                 conditions:
                   type: array
                   items:
@@ -2022,6 +2041,25 @@ spec:
                           - allow
                           - drop
                           - reject
+                natOutgoingPolicyRules:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      ruleID:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - nat
+                          - forward
+                      match:
+                        type: object
+                        properties:
+                          srcIPs:
+                            type: string
+                          dstIPs:
+                            type: string
                 u2oInterconnection:
                   type: boolean
                 enableLb:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2809

use method :
kubectl edit subnet net1

```
  natOutgoingPolicyRules:
  - action: forward
    match:
      srcIPs: 10.0.11.0/24
      dstIPs: 10.0.12.0/24
  - action: forward
    match:
      srcIPs: 10.0.11.2
```


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c43320</samp>

This pull request adds a new feature to support NAT outgoing policy rules for subnets. It updates the CRD schema, the API types, the controller logic, the daemon logic, and the e2e tests to implement and validate the feature. It also adds some utility functions and constants to support the feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4c43320</samp>

> _We are the masters of the subnet domain_
> _We set the rules for the NAT outgoing_
> _We use the IP sets and the iptables chains_
> _We hash and encode with the sha256_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4c43320</samp>

*  Add the `natOutgoingPolicyRules` field to the `SubnetSpec` and `SubnetStatus` schemas in the `yamls/crd.yaml` file to support the new feature of NAT outgoing policy for subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1591-R1609), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1728-R1746), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1898-R1916), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R2035-R2053))
*  Add the corresponding Go types for the `natOutgoingPolicyRules` field in the `pkg/apis/kubeovn/v1/types.go` file and align them with the CRD schemas ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR162-R163), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR178-R192), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR236-R237))
*  Add the validation logic for the NAT outgoing policy rules for subnets in the `pkg/util/validator.go` file and call it in the `ValidateSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-7f0dbc597e1344dab5f2b581992a7ad0423ff2087593902fe39429d0a980782bL108-R179))
*  Add the `genNatOutgoingPolicyRulesStatus` function in the `pkg/controller/subnet.go` file to generate the status of the NAT outgoing policy rules for a subnet based on the spec and call it in the `handleAddOrUpdateSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R325-R352), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R569-R573))
*  Add a condition to the `enqueueUpdateSubnet` function in the `pkg/controller/subnet.go` file to trigger the subnet reconciliation when the NAT outgoing policy rules for a subnet are changed ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L104-R106))
*  Add the `encoding/json` package to the import list in the `pkg/controller/subnet.go` file to enable the serialization and deserialization of the NAT outgoing policy rules for subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R5))
*  Add the IP set interface to the `ControllerRuntime` type in the `pkg/daemon/controller_linux.go` file and initialize it in the `initRuntime` function to manipulate IP sets on Linux nodes ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2fc809b47dbb2a514497bf5e38d53de7bafc66f8dc976c817d1e5dac9d723c20R38), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2fc809b47dbb2a514497bf5e38d53de7bafc66f8dc976c817d1e5dac9d723c20R83))
*  Add the `gcIPSet`, `addNatOutGoingPolicyRuleIPset`, `removeNatOutGoingPolicyRuleIPset`, and `reconcileNatOutGoingPolicyIPset` methods to the `Controller` type in the `pkg/daemon/gateway_linux.go` file to implement the IP set logic for the NAT outgoing policy rules for subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R133-R220))
*  Add the `reconcileNatOutgoingPolicyIptablesChain`, `generateNatOutgoingPolicyChainRules`, `getMatchProtocol`, and `formatIPsetUnPrefix` functions to the `pkg/daemon/gateway_linux.go` file to implement the iptables logic for the NAT outgoing policy rules for subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R749-R873))
*  Add the `getNatOutGoingPolicyRuleIPSetName`, `isNatOutGoingPolicyRuleIPSet`, `getNatOutGoingPolicyRuleIPSetItem`, and `getNatPolicySubnetChainUID` functions to the `pkg/daemon/gateway_linux.go` file to provide utility functions for manipulating the IP set names and the iptables chain names for the NAT outgoing policy rules for subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R1492-R1524))
*  Add the `Sha256ByteToString` function to the `pkg/util/strings.go` file to provide a utility function for hashing and encoding data for the NAT outgoing policy rules ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-b85cb8dd9eecd095561611310332de19cd87bb74b60f8083131caec5e05d0b0dR29-R35))
*  Add the `GetTruncatedUID` function to the `pkg/util/k8s.go` file to provide a utility function for getting the truncated UID of a Kubernetes object, such as a subnet ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-b252a3b0a89aaca5bf1056643f9d4dbead04230b3c96aefbb05020c57ebac26fR69-R72))
*  Add the `isSubnetNeedNat` function to the `pkg/daemon/gateway.go` file to encapsulate the logic for determining if a subnet needs NAT outgoing and reuse it in other functions ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08R86-R97))
*  Add the `getSubnetsNatOutGoingPolicy` function to the `pkg/daemon/gateway.go` file to get the subnets that have NAT outgoing policy rules for a given protocol ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08R115-R130))
*  Modify the `setIPSet` function in the `pkg/daemon/gateway_linux.go` file to call the `reconcileNatOutGoingPolicyIPset` method of the controller struct for each protocol when the IP sets are set ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R127))
*  Modify the `setIptables` function in the `pkg/daemon/gateway_linux.go` file to add the iptables rules for the NAT outgoing policy for IPv4 and IPv6 subnets, use the IP set interface of the controller struct instead of the standalone function, and call the `reconcileNatOutgoingPolicyIptablesChain` method of the controller struct for each protocol when the iptables are set ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R528-R532), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R563-R566), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L518-R625), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R728-R731))
*  Modify the `updateIptablesChain` function in the `pkg/daemon/gateway_linux.go` file to check if the parent chain is empty before creating the iptables rule to jump from the parent chain to the chain ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L339-R447))
*  Modify the `getSubnetsNeedNAT` function in the `pkg/daemon/gateway.go` file to simplify the logic for getting the subnets that need NAT outgoing and reuse the `isSubnetNeedNat` function ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L95-R107))
*  Modify the `ipsetExists` function in the `pkg/daemon/gateway_linux.go` file to be a method of the `Controller` type and use the IP set interface instead of the standalone function ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L1248-R1485))
*  Modify the constants in the `pkg/daemon/gateway_linux.go` file to add new constants for the IP set names, the iptables chains, and the iptables marks for the NAT outgoing policy rules and remove the unused `ServiceSet` constant ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L30-R54))
*  Modify the import list in the `pkg/daemon/gateway_linux.go` file to remove the unused `k8s.io/kubernetes/pkg/util/ipset` and `k8s.io/utils/exec` packages and avoid conflicts ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L21-L22))
*  Modify the import list in the `pkg/util/strings.go` file to add the `crypto/sha256` and `encoding/hex` packages to enable the hashing and encoding logic for the NAT outgoing policy rules ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-b85cb8dd9eecd095561611310332de19cd87bb74b60f8083131caec5e05d0b0dL3-R7))
*  Modify the signature of the `checkIptablesRulesOnNode` function in the `test/e2e/kube-ovn/subnet/subnet.go` file to add a new parameter `expectedRules` that represents the expected iptables rules for the subnet on the node and pass it as an argument in the function calls ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L40-R40), [link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L982-R997))
*  Modify the body of the `checkIptablesRulesOnNode` function in the `test/e2e/kube-ovn/subnet/subnet.go` file to use the expected iptables rules passed as an argument instead of hard-coding them in the function and handle the case where the chain parameter is not specified ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L51-R54))
*  Modify the variables in the `test/e2e/kube-ovn/subnet/subnet.go` file to add new variables `podName` and `fakeSubnetName` that represent the name of the pod and another subnet that are created for testing the NAT outgoing policy rules ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L77-R81))
*  Modify the `BeforeEach` block in the `test/e2e/kube-ovn/subnet/subnet.go` file to generate a unique name for the fake subnet for testing the NAT outgoing policy rules ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5R89))
*  Modify the `AfterEach` block in the `test/e2e/kube-ovn/subnet/subnet.go` file to clean up the resources that are created for testing the NAT outgoing policy rules ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5R127-R134))
*  Add a new test case to the `test/e2e/kube-ovn/subnet/subnet.go` file to verify the functionality of the NAT outgoing policy rules for subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1024-R1308))
*  Add the `NatPolicyRuleActionNat`, `NatPolicyRuleActionForward`, and `NatPolicyRuleIDLength` constants to the `pkg/util/const.go` file to define the possible actions and the rule ID length for the NAT outgoing policy rules for subnets ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR249-R252))
*  Add the `k8s.io/kubernetes/pkg/util/ipset` package to the import list in the `pkg/daemon/controller_linux.go` file to enable the creation and deletion of IP sets for the NAT outgoing policy rules ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-2fc809b47dbb2a514497bf5e38d53de7bafc66f8dc976c817d1e5dac9d723c20R25))
*  Add a line to the `setExGateway` function in the `pkg/daemon/gateway.go` file to delete any unused IP sets on the node when the external gateway is set ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L37-R37))
*  Add a line to the `setIptables` function in the `pkg/daemon/gateway_linux.go` file to append an iptables rule to the `rules` slice for the IPv4 protocol ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R528-R532))
*  Add a line to the `setIptables` function in the `pkg/daemon/gateway_linux.go` file to append an iptables rule to the `rules` slice for the IPv6 protocol ([link](https://github.com/kubeovn/kube-ovn/pull/2883/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R563-R566))