### PR TITLE
e2e: multiple external network

### DIFF
--- a/test/e2e/framework/iptables-eip.go
+++ b/test/e2e/framework/iptables-eip.go
@@ -147,7 +147,7 @@ func (c *IptablesEIPClient) WaitToDisappear(name string, interval, timeout time.
 	return nil
 }
 
-func MakeIptablesEIP(name, v4ip, v6ip, mac, natGwDp string) *apiv1.IptablesEIP {
+func MakeIptablesEIP(name, v4ip, v6ip, mac, natGwDp, externalSubnet string) *apiv1.IptablesEIP {
 	eip := &apiv1.IptablesEIP{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -158,6 +158,9 @@ func MakeIptablesEIP(name, v4ip, v6ip, mac, natGwDp string) *apiv1.IptablesEIP {
 			MacAddress: mac,
 			NatGwDp:    natGwDp,
 		},
+	}
+	if externalSubnet != "" {
+		eip.Spec.ExternalSubnet = externalSubnet
 	}
 	return eip
 }

--- a/test/e2e/framework/vpc-nat-gw.go
+++ b/test/e2e/framework/vpc-nat-gw.go
@@ -144,7 +144,7 @@ func (c *VpcNatGatewayClient) WaitToDisappear(name string, interval, timeout tim
 	return nil
 }
 
-func MakeVpcNatGateway(name, vpc, subnet, lanIp string) *apiv1.VpcNatGateway {
+func MakeVpcNatGateway(name, vpc, subnet, lanIp, externalSubnet string) *apiv1.VpcNatGateway {
 	vpcNatGw := &apiv1.VpcNatGateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -154,6 +154,9 @@ func MakeVpcNatGateway(name, vpc, subnet, lanIp string) *apiv1.VpcNatGateway {
 			Subnet: subnet,
 			LanIp:  lanIp,
 		},
+	}
+	if externalSubnet != "" {
+		vpcNatGw.Spec.ExternalSubnets = []string{externalSubnet}
 	}
 	return vpcNatGw
 }

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -29,9 +29,91 @@ import (
 )
 
 const dockerExtNet1Name = "kube-ovn-ext-net1"
+const dockerExtNet2Name = "kube-ovn-ext-net2"
 const vpcNatGWConfigMapName = "ovn-vpc-nat-gw-config"
 const networkAttachDefName = "ovn-vpc-external-network"
 const externalSubnetProvider = "ovn-vpc-external-network.kube-system"
+
+func setupVpcNatGwTestEnvironment(
+	f *framework.Framework,
+	dockerExtNetNetwork *dockertypes.NetworkResource,
+	attachNetClient *framework.NetworkAttachmentDefinitionClient,
+	subnetClient *framework.SubnetClient,
+	vpcClient *framework.VpcClient,
+	vpcNatGwClient *framework.VpcNatGatewayClient,
+	vpcName string,
+	overlaySubnetName string,
+	vpcNatGwName string,
+	overlaySubnetV4Cidr string,
+	overlaySubnetV4Gw string,
+	lanIp string,
+	dockerExtNetName string,
+	externalNetworkName string,
+	nicName string,
+	provider string,
+) {
+	ginkgo.By("Getting docker network " + dockerExtNetName)
+	network, err := docker.NetworkInspect(dockerExtNetName)
+	framework.ExpectNoError(err, "getting docker network "+dockerExtNetName)
+
+	ginkgo.By("Getting k8s nodes")
+	_, err = e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+	framework.ExpectNoError(err)
+
+	ginkgo.By("Getting network attachment definition " + externalNetworkName)
+	attachConf := fmt.Sprintf(`{"cniVersion": "0.3.0","type": "macvlan","master": "%s","mode": "bridge"}`, nicName)
+	attachNet := framework.MakeNetworkAttachmentDefinition(externalNetworkName, framework.KubeOvnNamespace, attachConf)
+	attachNetClient.Create(attachNet)
+
+	nad := attachNetClient.Get(externalNetworkName)
+	framework.ExpectNoError(err, "failed to get")
+	ginkgo.By("Got network attachment definition " + nad.Name)
+
+	ginkgo.By("Creating underlay macvlan subnet " + externalNetworkName)
+	cidr := make([]string, 0, 2)
+	gateway := make([]string, 0, 2)
+	for _, config := range dockerExtNetNetwork.IPAM.Config {
+		switch util.CheckProtocol(config.Subnet) {
+		case apiv1.ProtocolIPv4:
+			if f.ClusterIpFamily != "ipv6" {
+				cidr = append(cidr, config.Subnet)
+				gateway = append(gateway, config.Gateway)
+			}
+		case apiv1.ProtocolIPv6:
+			if f.ClusterIpFamily != "ipv4" {
+				cidr = append(cidr, config.Subnet)
+				gateway = append(gateway, config.Gateway)
+			}
+		}
+	}
+	excludeIPs := make([]string, 0, len(network.Containers)*2)
+	for _, container := range network.Containers {
+		if container.IPv4Address != "" && f.ClusterIpFamily != "ipv6" {
+			excludeIPs = append(excludeIPs, strings.Split(container.IPv4Address, "/")[0])
+		}
+		if container.IPv6Address != "" && f.ClusterIpFamily != "ipv4" {
+			excludeIPs = append(excludeIPs, strings.Split(container.IPv6Address, "/")[0])
+		}
+	}
+	macvlanSubnet := framework.MakeSubnet(externalNetworkName, "", strings.Join(cidr, ","), strings.Join(gateway, ","), "", provider, excludeIPs, nil, nil)
+	_ = subnetClient.CreateSync(macvlanSubnet)
+
+	ginkgo.By("Getting config map " + vpcNatGWConfigMapName)
+	_, err = f.ClientSet.CoreV1().ConfigMaps(framework.KubeOvnNamespace).Get(context.Background(), vpcNatGWConfigMapName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "failed to get ConfigMap")
+
+	ginkgo.By("Creating custom vpc")
+	vpc := framework.MakeVpc(vpcName, lanIp, false, false, nil)
+	_ = vpcClient.CreateSync(vpc)
+
+	ginkgo.By("Creating custom overlay subnet")
+	overlaySubnet := framework.MakeSubnet(overlaySubnetName, "", overlaySubnetV4Cidr, overlaySubnetV4Gw, vpcName, "", nil, nil, nil)
+	_ = subnetClient.CreateSync(overlaySubnet)
+
+	ginkgo.By("Creating custom vpc nat gw")
+	vpcNatGw := framework.MakeVpcNatGateway(vpcNatGwName, vpcName, overlaySubnetName, lanIp, externalNetworkName)
+	_ = vpcNatGwClient.CreateSync(vpcNatGw)
+}
 
 var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 	f := framework.NewDefaultFramework("iptables-vpc-nat-gw")
@@ -58,6 +140,16 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 	var image string
 	var net1NicName string
 
+	// multiple external network case
+	var dockerExtNet2Network *dockertypes.NetworkResource
+	var net2NicName string
+	var net2AttachDefName string
+	var net2SubnetProvider string
+	var net2OverlaySubnetName string
+	var net2VpcNatGwName string
+	var net2VpcName string
+	var net2EipName string
+
 	vpcName = "vpc-" + framework.RandomSuffix()
 	vpcNatGwName = "gw-" + framework.RandomSuffix()
 
@@ -80,6 +172,13 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 	snatEipName = "snat-eip-" + framework.RandomSuffix()
 	snatName = "snat-" + framework.RandomSuffix()
 	overlaySubnetName = "overlay-subnet-" + framework.RandomSuffix()
+
+	net2AttachDefName = "net2-ovn-vpc-external-network-" + framework.RandomSuffix()
+	net2SubnetProvider = net2AttachDefName + ".kube-system"
+	net2OverlaySubnetName = "net2-overlay-subnet-" + framework.RandomSuffix()
+	net2VpcNatGwName = "net2-gw-" + framework.RandomSuffix()
+	net2VpcName = "net2-vpc-" + framework.RandomSuffix()
+	net2EipName = "net2-eip-" + framework.RandomSuffix()
 
 	ginkgo.BeforeEach(func() {
 		containerID = ""
@@ -118,9 +217,16 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 
 		if dockerExtNet1Network == nil {
 			ginkgo.By("Ensuring docker network " + dockerExtNet1Name + " exists")
-			network, err := docker.NetworkCreate(dockerExtNet1Name, true, true)
+			network1, err := docker.NetworkCreate(dockerExtNet1Name, true, true)
 			framework.ExpectNoError(err, "creating docker network "+dockerExtNet1Name)
-			dockerExtNet1Network = network
+			dockerExtNet1Network = network1
+		}
+
+		if dockerExtNet2Network == nil {
+			ginkgo.By("Ensuring docker network " + dockerExtNet2Name + " exists")
+			network2, err := docker.NetworkCreate(dockerExtNet2Name, true, true)
+			framework.ExpectNoError(err, "creating docker network "+dockerExtNet2Name)
+			dockerExtNet2Network = network2
 		}
 
 		ginkgo.By("Getting kind nodes")
@@ -132,30 +238,42 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		err = kind.NetworkConnect(dockerExtNet1Network.ID, nodes)
 		framework.ExpectNoError(err, "connecting nodes to network "+dockerExtNet1Name)
 
+		ginkgo.By("Connecting nodes to the docker network")
+		err = kind.NetworkConnect(dockerExtNet2Network.ID, nodes)
+		framework.ExpectNoError(err, "connecting nodes to network "+dockerExtNet2Name)
+
 		ginkgo.By("Getting node links that belong to the docker network")
 		nodes, err = kind.ListNodes(clusterName, "")
 		framework.ExpectNoError(err, "getting nodes in kind cluster")
 
 		ginkgo.By("Validating node links")
-		network, err := docker.NetworkInspect(dockerExtNet1Name)
+		network1, err := docker.NetworkInspect(dockerExtNet1Name)
 		framework.ExpectNoError(err)
-		var eth0Exist, net1Exist bool
+		network2, err := docker.NetworkInspect(dockerExtNet2Name)
+		framework.ExpectNoError(err)
+		var eth0Exist, net1Exist, net2Exist bool
 		for _, node := range nodes {
 			links, err := node.ListLinks()
 			framework.ExpectNoError(err, "failed to list links on node %s: %v", node.Name(), err)
-			nicMac := network.Containers[node.ID].MacAddress
+			net1Mac := network1.Containers[node.ID].MacAddress
+			net2Mac := network2.Containers[node.ID].MacAddress
 			for _, link := range links {
 				ginkgo.By("exist node nic " + link.IfName)
 				if link.IfName == "eth0" {
 					eth0Exist = true
 				}
-				if link.Address == nicMac {
+				if link.Address == net1Mac {
 					net1NicName = link.IfName
 					net1Exist = true
+				}
+				if link.Address == net2Mac {
+					net2NicName = link.IfName
+					net2Exist = true
 				}
 			}
 			framework.ExpectTrue(eth0Exist)
 			framework.ExpectTrue(net1Exist)
+			framework.ExpectTrue(net2Exist)
 		}
 	})
 
@@ -166,11 +284,15 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 			framework.ExpectNoError(err)
 		}
 
-		ginkgo.By("Deleting overlay subnet " + overlaySubnetName)
-		subnetClient.DeleteSync(overlaySubnetName)
-
 		ginkgo.By("Deleting macvlan underlay subnet " + networkAttachDefName)
 		subnetClient.DeleteSync(networkAttachDefName)
+
+		// delete net1 attachment definition
+		ginkgo.By("Deleting nad " + networkAttachDefName)
+		attachNetClient.Delete(networkAttachDefName)
+		// delete net2 attachment definition
+		ginkgo.By("Deleting nad " + net2AttachDefName)
+		attachNetClient.Delete(net2AttachDefName)
 
 		ginkgo.By("Getting nodes")
 		nodes, err := kind.ListNodes(clusterName, "")
@@ -181,87 +303,39 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 			err = kind.NetworkDisconnect(dockerExtNet1Network.ID, nodes)
 			framework.ExpectNoError(err, "disconnecting nodes from network "+dockerExtNet1Name)
 		}
+		if dockerExtNet2Network != nil {
+			ginkgo.By("Disconnecting nodes from the docker network")
+			err = kind.NetworkDisconnect(dockerExtNet2Network.ID, nodes)
+			framework.ExpectNoError(err, "disconnecting nodes from network "+dockerExtNet2Name)
+		}
 	})
 
 	framework.ConformanceIt("iptables eip fip snat dnat", func() {
-		ginkgo.By("Getting docker network " + dockerExtNet1Name)
-		network, err := docker.NetworkInspect(dockerExtNet1Name)
-		framework.ExpectNoError(err, "getting docker network "+dockerExtNet1Name)
-
-		ginkgo.By("Getting k8s nodes")
-		_, err = e2enode.GetReadySchedulableNodes(context.Background(), cs)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Getting network attachment definition " + networkAttachDefName)
-		attachConf := fmt.Sprintf(`{"cniVersion": "0.3.0","type": "macvlan","master": "%s","mode": "bridge"}`, net1NicName)
-		attachNet := framework.MakeNetworkAttachmentDefinition(networkAttachDefName, framework.KubeOvnNamespace, attachConf)
-		attachNetClient.Create(attachNet)
-
-		nad := attachNetClient.Get(networkAttachDefName)
-		framework.ExpectNoError(err, "failed to get")
-		ginkgo.By("Got network attachment definition " + nad.Name)
-
-		ginkgo.By("Creating underlay macvlan subnet " + networkAttachDefName)
-		cidr := make([]string, 0, 2)
-		gateway := make([]string, 0, 2)
-		for _, config := range dockerExtNet1Network.IPAM.Config {
-			switch util.CheckProtocol(config.Subnet) {
-			case apiv1.ProtocolIPv4:
-				if f.ClusterIpFamily != "ipv6" {
-					cidr = append(cidr, config.Subnet)
-					gateway = append(gateway, config.Gateway)
-				}
-			case apiv1.ProtocolIPv6:
-				if f.ClusterIpFamily != "ipv4" {
-					cidr = append(cidr, config.Subnet)
-					gateway = append(gateway, config.Gateway)
-				}
-			}
-		}
-		excludeIPs := make([]string, 0, len(network.Containers)*2)
-		for _, container := range network.Containers {
-			if container.IPv4Address != "" && f.ClusterIpFamily != "ipv6" {
-				excludeIPs = append(excludeIPs, strings.Split(container.IPv4Address, "/")[0])
-			}
-			if container.IPv6Address != "" && f.ClusterIpFamily != "ipv4" {
-				excludeIPs = append(excludeIPs, strings.Split(container.IPv6Address, "/")[0])
-			}
-		}
-		macvlanSubnet := framework.MakeSubnet(networkAttachDefName, "", strings.Join(cidr, ","), strings.Join(gateway, ","), "", externalSubnetProvider, excludeIPs, nil, nil)
-		_ = subnetClient.CreateSync(macvlanSubnet)
-
-		ginkgo.By("Getting config map " + vpcNatGWConfigMapName)
-		_, err = cs.CoreV1().ConfigMaps(framework.KubeOvnNamespace).Get(context.Background(), vpcNatGWConfigMapName, metav1.GetOptions{})
-		framework.ExpectNoError(err, "failed to get ConfigMap")
-
-		ginkgo.By("Creating custom vpc")
 		overlaySubnetV4Cidr := "192.168.0.0/24"
 		overlaySubnetV4Gw := "192.168.0.1"
 		lanIp := "192.168.0.254"
-		vpc := framework.MakeVpc(vpcName, lanIp, false, false, nil)
-		_ = vpcClient.CreateSync(vpc)
-
-		ginkgo.By("Creating custom overlay subnet")
-		overlaySubnet := framework.MakeSubnet(overlaySubnetName, "", overlaySubnetV4Cidr, overlaySubnetV4Gw, vpcName, "", nil, nil, nil)
-		_ = subnetClient.CreateSync(overlaySubnet)
-
-		ginkgo.By("Creating custom vpc nat gw")
-		vpcNatGw := framework.MakeVpcNatGateway(vpcNatGwName, vpcName, overlaySubnetName, lanIp)
-		_ = vpcNatGwClient.CreateSync(vpcNatGw)
+		setupVpcNatGwTestEnvironment(
+			f, dockerExtNet1Network, attachNetClient,
+			subnetClient, vpcClient, vpcNatGwClient,
+			vpcName, overlaySubnetName, vpcNatGwName,
+			overlaySubnetV4Cidr, overlaySubnetV4Gw, lanIp,
+			dockerExtNet1Name, networkAttachDefName, net1NicName,
+			externalSubnetProvider,
+		)
 
 		ginkgo.By("Creating iptables vip for fip")
 		fipVip := framework.MakeVip(fipVipName, overlaySubnetName, "", "", "")
 		_ = vipClient.CreateSync(fipVip)
 		fipVip = vipClient.Get(fipVipName)
 		ginkgo.By("Creating iptables eip for fip")
-		fipEip := framework.MakeIptablesEIP(fipEipName, "", "", "", vpcNatGwName)
+		fipEip := framework.MakeIptablesEIP(fipEipName, "", "", "", vpcNatGwName, "")
 		_ = iptablesEIPClient.CreateSync(fipEip)
 		ginkgo.By("Creating iptables fip")
 		fip := framework.MakeIptablesFIPRule(fipName, fipEipName, fipVip.Status.V4ip)
 		_ = iptablesFIPClient.CreateSync(fip)
 
 		ginkgo.By("Creating iptables eip for snat")
-		snatEip := framework.MakeIptablesEIP(snatEipName, "", "", "", vpcNatGwName)
+		snatEip := framework.MakeIptablesEIP(snatEipName, "", "", "", vpcNatGwName, "")
 		_ = iptablesEIPClient.CreateSync(snatEip)
 		ginkgo.By("Creating iptables snat")
 		snat := framework.MakeIptablesSnatRule(snatName, snatEipName, overlaySubnetV4Cidr)
@@ -272,7 +346,7 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		_ = vipClient.CreateSync(dnatVip)
 		dnatVip = vipClient.Get(dnatVipName)
 		ginkgo.By("Creating iptables eip for dnat")
-		dnatEip := framework.MakeIptablesEIP(dnatEipName, "", "", "", vpcNatGwName)
+		dnatEip := framework.MakeIptablesEIP(dnatEipName, "", "", "", vpcNatGwName, "")
 		_ = iptablesEIPClient.CreateSync(dnatEip)
 		ginkgo.By("Creating iptables dnat")
 		dnat := framework.MakeIptablesDnatRule(dnatName, dnatEipName, "80", "tcp", dnatVip.Status.V4ip, "8080")
@@ -284,7 +358,7 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		_ = vipClient.CreateSync(shareVip)
 		fipVip = vipClient.Get(fipVipName)
 		ginkgo.By("Creating share iptables eip")
-		shareEip := framework.MakeIptablesEIP(sharedEipName, "", "", "", vpcNatGwName)
+		shareEip := framework.MakeIptablesEIP(sharedEipName, "", "", "", vpcNatGwName, "")
 		_ = iptablesEIPClient.CreateSync(shareEip)
 		ginkgo.By("Creating the first iptables fip with share eip vip should be ok")
 		shareFipShouldOk := framework.MakeIptablesFIPRule(sharedEipFipShoudOkName, sharedEipName, fipVip.Status.V4ip)
@@ -367,16 +441,61 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 		vpcNatGwPodName := "vpc-nat-gw-" + vpcNatGwName + "-0"
 
 		// delete vpc nat gw statefulset remaining ip for eth0 and net1
-		overlaySubnet = subnetClient.Get(overlaySubnetName)
-		macvlanSubnet = subnetClient.Get(networkAttachDefName)
+		overlaySubnet := subnetClient.Get(overlaySubnetName)
+		macvlanSubnet := subnetClient.Get(networkAttachDefName)
 		eth0IpName := ovs.PodNameToPortName(vpcNatGwPodName, framework.KubeOvnNamespace, overlaySubnet.Spec.Provider)
 		net1IpName := ovs.PodNameToPortName(vpcNatGwPodName, framework.KubeOvnNamespace, macvlanSubnet.Spec.Provider)
 		ginkgo.By("Deleting vpc nat gw eth0 ip " + eth0IpName)
 		ipClient.DeleteSync(eth0IpName)
 		ginkgo.By("Deleting vpc nat gw net1 ip " + net1IpName)
 		ipClient.DeleteSync(net1IpName)
-		ginkgo.By("Deleting nad " + networkAttachDefName)
-		attachNetClient.Delete(networkAttachDefName)
+
+		ginkgo.By("Deleting overlay subnet " + overlaySubnetName)
+		subnetClient.DeleteSync(overlaySubnetName)
+
+		// multiple external network case
+		net2OverlaySubnetV4Cidr := "192.168.1.0/24"
+		net2OoverlaySubnetV4Gw := "192.168.1.1"
+		net2LanIp := "192.168.1.254"
+		setupVpcNatGwTestEnvironment(
+			f, dockerExtNet2Network, attachNetClient,
+			subnetClient, vpcClient, vpcNatGwClient,
+			net2VpcName, net2OverlaySubnetName, net2VpcNatGwName,
+			net2OverlaySubnetV4Cidr, net2OoverlaySubnetV4Gw, net2LanIp,
+			dockerExtNet2Name, net2AttachDefName, net2NicName,
+			net2SubnetProvider)
+
+		ginkgo.By("Creating iptables eip of net2")
+		net2Eip := framework.MakeIptablesEIP(net2EipName, "", "", "", net2VpcNatGwName, net2AttachDefName)
+		_ = iptablesEIPClient.CreateSync(net2Eip)
+
+		ginkgo.By("Deleting iptables eip " + net2EipName)
+		iptablesEIPClient.DeleteSync(net2EipName)
+
+		ginkgo.By("Deleting custom vpc " + net2VpcName)
+		vpcClient.DeleteSync(net2VpcName)
+
+		ginkgo.By("Deleting custom vpc nat gw")
+		vpcNatGwClient.DeleteSync(net2VpcNatGwName)
+
+		// the only pod for vpc nat gateway
+		vpcNatGwPodName = "vpc-nat-gw-" + net2VpcNatGwName + "-0"
+
+		// delete vpc nat gw statefulset remaining ip for eth0 and net2
+		overlaySubnet = subnetClient.Get(net2OverlaySubnetName)
+		macvlanSubnet = subnetClient.Get(net2AttachDefName)
+		eth0IpName = ovs.PodNameToPortName(vpcNatGwPodName, framework.KubeOvnNamespace, overlaySubnet.Spec.Provider)
+		net2IpName := ovs.PodNameToPortName(vpcNatGwPodName, framework.KubeOvnNamespace, macvlanSubnet.Spec.Provider)
+		ginkgo.By("Deleting vpc nat gw eth0 ip " + eth0IpName)
+		ipClient.DeleteSync(eth0IpName)
+		ginkgo.By("Deleting vpc nat gw net2 ip " + net2IpName)
+		ipClient.DeleteSync(net2IpName)
+
+		ginkgo.By("Deleting macvlan underlay subnet " + net2AttachDefName)
+		subnetClient.DeleteSync(net2AttachDefName)
+
+		ginkgo.By("Deleting overlay subnet " + net2OverlaySubnetName)
+		subnetClient.DeleteSync(net2OverlaySubnetName)
 	})
 })
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2679

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91c8e94</samp>

This pull request enhances the e2e test framework and the iptables eip test to support multiple external subnets for iptables eip and vpc nat gateway. It adds a new parameter `externalSubnet` to the `MakeIptablesEIP` and `MakeVpcNatGateway` functions and updates the `test/e2e/iptables-vpc-nat-gw/e2e_test.go` file to use it.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 91c8e94</samp>

> _`iptables eip` now_
> _can use external subnet_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91c8e94</samp>

*  Add a new parameter `externalSubnet` to the `MakeIptablesEIP` and `MakeVpcNatGateway` functions to allow specifying the external subnet for the iptables eip and the vpc nat gateway ([link](https://github.com/kubeovn/kube-ovn/pull/2884/files?diff=unified&w=0#diff-a93889515fa94ec885fca2cbe615fd2e2f23913893ad72208ad9b02b7d8a552bL150-R150), [link](https://github.com/kubeovn/kube-ovn/pull/2884/files?diff=unified&w=0#diff-4dd4a4506f011ab3499f43da15637ad1e0f21c88a4d6eb0f2a03a455dc3b2a20L147-R147)).