### PR TITLE
add subnet match check when change subnet gatewayType from centralized to distributed

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1262,7 +1262,6 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

1. when change one subnet's gatewayType from distributed to centralized, pods in other subnet are also affected. 

The problem is introduced in commit
https://github.com/kubeovn/kube-ovn/commit/a0e2404c9cc634c6579e8c88ded1a2055953900b

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3ac5d9</samp>

Improve subnet status and gateway type handling in `subnet.go`. Add event recording for errors and update gateway fields and pod annotations when switching from distributed to centralized gateway.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d3ac5d9</samp>

> _Oh we patch the subnets with a yo-ho-ho_
> _And we record the failures as we go_
> _When the gateway type is changed, we reconcile again_
> _And we update the fields and the `podAnnotations`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d3ac5d9</samp>

*  Add event recording for subnet status update failure ([link](https://github.com/kubeovn/kube-ovn/pull/2891/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R415))
*  Handle gateway type change from distributed to centralized in reconcileGateway ([link](https://github.com/kubeovn/kube-ovn/pull/2891/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L829-R842))