### PR TITLE
Supporting user-defined kubelet directory

### DIFF
--- a/charts/templates/ovncni-ds.yaml
+++ b/charts/templates/ovncni-ds.yaml
@@ -77,6 +77,7 @@ spec:
           - --log_file=/var/log/kube-ovn/kube-ovn-cni.log
           - --log_file_max_size=0
           - --enable-metrics={{- .Values.networking.ENABLE_METRICS }}
+          - --kubelet-dir={{ .Values.kubelet_conf.KUBELET_DIR }}
         securityContext:
           runAsUser: 0
           privileged: true
@@ -108,7 +109,7 @@ spec:
             mountPath: /lib/modules
             readOnly: true
           - name: shared-dir
-            mountPath: /var/lib/kubelet/pods
+            mountPath: {{ .Values.kubelet_conf.KUBELET_DIR }}/pods
           - mountPath: /etc/openvswitch
             name: systemid
             readOnly: true

--- a/charts/templates/ovsovn-ds.yaml
+++ b/charts/templates/ovsovn-ds.yaml
@@ -119,7 +119,7 @@ spec:
             {{- end }}
             {{- if .Values.HYBRID_DPDK }}
             - name: shareddir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ .Values.kubelet_conf.KUBELET_DIR }}/pods
             {{- end }}
           readinessProbe:
             exec:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3919,7 +3919,7 @@ spec:
             - mountPath: /opt/ovs-config
               name: host-config-ovs
             - name: shareddir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: $KUBELET_DIR/pods
             - name: hugepage
               mountPath: /dev/hugepages
             - mountPath: /lib/modules
@@ -4253,6 +4253,7 @@ spec:
           - --alsologtostderr=true
           - --log_file=/var/log/kube-ovn/kube-ovn-cni.log
           - --log_file_max_size=0
+          - --kubelet-dir=$KUBELET_DIR
         securityContext:
           runAsUser: 0
           privileged: true
@@ -4284,7 +4285,7 @@ spec:
             mountPath: /lib/modules
             readOnly: true
           - name: shared-dir
-            mountPath: /var/lib/kubelet/pods
+            mountPath: $KUBELET_DIR/pods
           - mountPath: /etc/openvswitch
             name: systemid
             readOnly: true

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -59,6 +59,7 @@ type Configuration struct {
 	ExternalGatewaySwitch     string // provider network underlay vlan subnet
 	EnableMetrics             bool
 	EnableArpDetectIPConflict bool
+	KubeletDir                string
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -92,6 +93,7 @@ func ParseFlags() *Configuration {
 		argExternalGatewaySwitch     = pflag.String("external-gateway-switch", "external", "The name of the external gateway switch which is a ovs bridge to provide external network, default: external")
 		argEnableMetrics             = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableArpDetectIPConflict = pflag.Bool("enable-arp-detect-ip-conflict", true, "Whether to support arp detect ip conflict in vlan network")
+		argKubeletDir                = pflag.String("kubelet-dir", "/var/lib/kubelet", "Path of the kubelet dir, default: /var/lib/kubelet")
 	)
 
 	// mute info log for ipset lib
@@ -142,6 +144,7 @@ func ParseFlags() *Configuration {
 		ExternalGatewaySwitch:     *argExternalGatewaySwitch,
 		EnableMetrics:             *argEnableMetrics,
 		EnableArpDetectIPConflict: *argEnableArpDetectIPConflict,
+		KubeletDir:                *argKubeletDir,
 	}
 	return config
 }

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -147,7 +147,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			nicType = util.OffloadType
 		} else if podRequest.VhostUserSocketVolumeName != "" {
 			nicType = util.DpdkType
-			if err = createShortSharedDir(pod, podRequest.VhostUserSocketVolumeName); err != nil {
+			if err = createShortSharedDir(pod, podRequest.VhostUserSocketVolumeName, csh.Config.KubeletDir); err != nil {
 				klog.Error(err.Error())
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)

--- a/pkg/daemon/handler_linux.go
+++ b/pkg/daemon/handler_linux.go
@@ -22,7 +22,7 @@ func (csh cniServerHandler) validatePodRequest(req *request.CniRequest) error {
 	return nil
 }
 
-func createShortSharedDir(pod *v1.Pod, volumeName string) (err error) {
+func createShortSharedDir(pod *v1.Pod, volumeName string, kubeletDir string) (err error) {
 	var volume *v1.Volume
 	for index, v := range pod.Spec.Volumes {
 		if v.Name == volumeName {
@@ -36,7 +36,7 @@ func createShortSharedDir(pod *v1.Pod, volumeName string) (err error) {
 	if volume.EmptyDir == nil {
 		return fmt.Errorf("volume %s is not empty dir", volume.Name)
 	}
-	originSharedDir := fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~empty-dir/%s", pod.UID, volumeName)
+	originSharedDir := fmt.Sprintf("%s/pods/%s/volumes/kubernetes.io~empty-dir/%s", kubeletDir, pod.UID, volumeName)
 	newSharedDir := getShortSharedDir(pod.UID, volumeName)
 	// set vhostuser dir 777 for qemu has the permission to create sock
 	mask := syscall.Umask(0)

--- a/pkg/daemon/handler_windows.go
+++ b/pkg/daemon/handler_windows.go
@@ -19,7 +19,7 @@ func (csh cniServerHandler) validatePodRequest(req *request.CniRequest) error {
 	return nil
 }
 
-func createShortSharedDir(pod *v1.Pod, volumeName string) error {
+func createShortSharedDir(pod *v1.Pod, volumeName string, kubeletDir string) error {
 	// nothing to do on Windows
 	return nil
 }


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2047

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5817053</samp>

This pull request adds a new feature to customize the kubelet directory for the ovn-cni daemonset, which is useful for DPDK-based network interfaces. It modifies the `ovncni-ds.yaml` chart template, the `config.go` and `handler.go` files in the `pkg/daemon` package, and the corresponding Linux and Windows handlers. It also adds a new command-line flag `kubelet-dir` for the daemon component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5817053</samp>

> _Sing, O Muse, of the cunning ovn-cni daemonset_
> _That brought to many pods a swift and smooth network_
> _By creating short links for the vhostuser sockets_
> _With `createShortSharedDir`, a skillful function._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5817053</samp>

*  Add a new flag `--kubelet-dir` to the ovn-cni daemonset container, which allows specifying the path of the kubelet directory ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-90880cf33f50d3c72a4349293d1f6abe953633d3edb2dc71c45368462b4ac4e5R80))
*  Replace the hard-coded path `/var/lib/kubelet/pods` with the value of the `kubelet-dir` flag in the ovn-cni daemonset container, which is passed as a Helm value ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-90880cf33f50d3c72a4349293d1f6abe953633d3edb2dc71c45368462b4ac4e5L111-R112))
*  Add a new field `KubeletDir` to the `Configuration` struct in `pkg/daemon/config.go`, which stores the value of the `kubelet-dir` flag ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R62))
*  Parse the `kubelet-dir` flag from the command-line arguments and set the default value to `/var/lib/kubelet` in the `ParseFlags` function in `pkg/daemon/config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R96), [link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R147))
*  Use the `KubeletDir` field of the `Configuration` struct to construct the origin and new shared directories for the vhostuser socket volume in the `createShortSharedDir` function in `pkg/daemon/handler_linux.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-43dd183a81f1129c01a57a334b8303f0c74f7f956930e13db86d15751c8f7f41L25-R26), [link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-43dd183a81f1129c01a57a334b8303f0c74f7f956930e13db86d15751c8f7f41L39-R52))
*  Add loops to check if the origin and new shared directories exist, and wait for up to 20 seconds if not, in the `createShortSharedDir` function in `pkg/daemon/handler_linux.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-43dd183a81f1129c01a57a334b8303f0c74f7f956930e13db86d15751c8f7f41L39-R52), [link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-43dd183a81f1129c01a57a334b8303f0c74f7f956930e13db86d15751c8f7f41R61-R66))
*  Add the `time` package to the imports of the `pkg/daemon/handler_linux.go` file, which is needed for the loops ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-43dd183a81f1129c01a57a334b8303f0c74f7f956930e13db86d15751c8f7f41R10))
*  Add the `KubeletDir` field of the `Configuration` struct to the arguments of the `createShortSharedDir` function in the `handleAdd` function in `pkg/daemon/handler.go`, which is responsible for creating a short symbolic link for the vhostuser socket volume of the pod ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL150-R150))
*  Add the `kubeletDir` parameter to the signature of the `createShortSharedDir` function in `pkg/daemon/handler_windows.go`, which is a dummy function that does nothing on Windows, to keep the function signature consistent with the Linux version ([link](https://github.com/kubeovn/kube-ovn/pull/2893/files?diff=unified&w=0#diff-fdef92069a9f9b9953a33ed595b79a64e3b763812fa0933bb9c38f4f25cd1abbL22-R22))