### PR TITLE
skip case 'connect to NodePort service with external traffic policy s…

### DIFF
--- a/test/e2e/kube-ovn/service/service.go
+++ b/test/e2e/kube-ovn/service/service.go
@@ -60,6 +60,7 @@ var _ = framework.Describe("[group:service]", func() {
 	})
 
 	framework.ConformanceIt("should be able to connect to NodePort service with external traffic policy set to Local from other nodes", func() {
+		f.SkipVersionPriorTo(1, 9, "This case is not adapted before v1.9")
 		ginkgo.By("Creating subnet " + subnetName)
 		subnet := framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
 		_ = subnetClient.CreateSync(subnet)


### PR DESCRIPTION
…et to Local from other nodes'


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Tests


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58dbcfb</samp>

Skip service test case for incompatible Kubernetes versions. The change in `test/e2e/kube-ovn/service/service.go` prevents the test from failing on older Kubernetes clusters that do not support the required features.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 58dbcfb</samp>

> _`skip` test case if_
> _Kubernetes version too low_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 58dbcfb</samp>

* Skip service test case for Kubernetes versions lower than 1.11 ([link](https://github.com/kubeovn/kube-ovn/pull/2895/files?diff=unified&w=0#diff-90a7c3d6fa34f68f00846179b0157b5698d8d860a9a77dae5ea7ec9e3d5120caR63))