### PR TITLE
refactor IPAM

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2039,69 +2039,62 @@ func isOvnSubnet(subnet *kubeovnv1.Subnet) bool {
 
 func checkAndFormatsExcludeIps(subnet *kubeovnv1.Subnet) bool {
 	var excludeIps []string
-	mapIps := make(map[string]ipam.IPRange, len(subnet.Spec.ExcludeIps))
-
+	mapIps := make(map[string]*ipam.IPRange, len(subnet.Spec.ExcludeIps))
 	for _, excludeIP := range subnet.Spec.ExcludeIps {
-		ips := strings.Split(excludeIP, "..")
-		if len(ips) == 1 {
-			if _, ok := mapIps[excludeIP]; !ok {
-				ipr := ipam.IPRange{Start: ipam.IP(ips[0]), End: ipam.IP(ips[0])}
-				mapIps[excludeIP] = ipr
-			}
-		} else {
-			if _, ok := mapIps[excludeIP]; !ok {
-				ipr := ipam.IPRange{Start: ipam.IP(ips[0]), End: ipam.IP(ips[1])}
-				mapIps[excludeIP] = ipr
+		if _, ok := mapIps[excludeIP]; !ok {
+			ips := strings.Split(excludeIP, "..")
+			if len(ips) == 1 {
+				mapIps[excludeIP] = ipam.NewIPRange(ipam.NewIP(ips[0]), ipam.NewIP(ips[0]))
+			} else {
+				mapIps[excludeIP] = ipam.NewIPRange(ipam.NewIP(ips[0]), ipam.NewIP(ips[1]))
 			}
 		}
 	}
 	newMap := filterRepeatIPRange(mapIps)
 	for _, v := range newMap {
-		if v.Start == v.End {
-			excludeIps = append(excludeIps, string(v.Start))
+		if v.Start().Equal(v.End()) {
+			excludeIps = append(excludeIps, v.Start().String())
 		} else {
-			excludeIps = append(excludeIps, string(v.Start)+".."+string(v.End))
+			excludeIps = append(excludeIps, v.Start().String()+".."+v.End().String())
 		}
 	}
 	sort.Strings(excludeIps)
-	klog.V(3).Infof("excludeips before format is %v, after format is %v", subnet.Spec.ExcludeIps, excludeIps)
 	if !reflect.DeepEqual(subnet.Spec.ExcludeIps, excludeIps) {
+		klog.V(3).Infof("excludeips before format is %v, after format is %v", subnet.Spec.ExcludeIps, excludeIps)
 		subnet.Spec.ExcludeIps = excludeIps
 		return true
 	}
 	return false
 }
 
-func filterRepeatIPRange(mapIps map[string]ipam.IPRange) map[string]ipam.IPRange {
+func filterRepeatIPRange(mapIps map[string]*ipam.IPRange) map[string]*ipam.IPRange {
 	for ka, a := range mapIps {
 		for kb, b := range mapIps {
 			if ka == kb && a == b {
 				continue
 			}
 
-			if b.End.LessThan(a.Start) || b.Start.GreaterThan(a.End) {
+			if b.End().LessThan(a.Start()) || b.Start().GreaterThan(a.End()) {
 				continue
 			}
 
-			if (a.Start.Equal(b.Start) || a.Start.GreaterThan(b.Start)) &&
-				(a.End.Equal(b.End) || a.End.LessThan(b.End)) {
+			if (a.Start().Equal(b.Start()) || a.Start().GreaterThan(b.Start())) &&
+				(a.End().Equal(b.End()) || a.End().LessThan(b.End())) {
 				delete(mapIps, ka)
 				continue
 			}
 
-			if (a.Start.Equal(b.Start) || a.Start.GreaterThan(b.Start)) &&
-				a.End.GreaterThan(b.End) {
-				ipr := ipam.IPRange{Start: b.Start, End: a.End}
+			if (a.Start().Equal(b.Start()) || a.Start().GreaterThan(b.Start())) &&
+				a.End().GreaterThan(b.End()) {
 				delete(mapIps, ka)
-				mapIps[kb] = ipr
+				mapIps[kb] = ipam.NewIPRange(b.Start(), a.End())
 				continue
 			}
 
-			if (a.End.Equal(b.End) || a.End.LessThan(b.End)) &&
-				a.Start.LessThan(b.Start) {
-				ipr := ipam.IPRange{Start: a.Start, End: b.End}
+			if (a.End().Equal(b.End()) || a.End().LessThan(b.End())) &&
+				a.Start().LessThan(b.Start()) {
 				delete(mapIps, ka)
-				mapIps[kb] = ipr
+				mapIps[kb] = ipam.NewIPRange(a.Start(), b.End())
 				continue
 			}
 

--- a/pkg/ipam/ip.go
+++ b/pkg/ipam/ip.go
@@ -1,201 +1,50 @@
 package ipam
 
 import (
-	"fmt"
 	"math/big"
-	"strings"
-
-	"github.com/kubeovn/kube-ovn/pkg/util"
+	"net"
 )
 
-type IP string
+type IP net.IP
 
-type IPRange struct {
-	Start IP
-	End   IP
+func NewIP(s string) IP {
+	ip := net.ParseIP(s)
+	if ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			ip = ip4
+		}
+	}
+	return IP(ip)
+}
+
+func (a IP) To4() net.IP {
+	return net.IP(a).To4()
+}
+
+func (a IP) To16() net.IP {
+	return net.IP(a).To16()
 }
 
 func (a IP) Equal(b IP) bool {
-	return a == b
+	return net.IP(a).Equal(net.IP(b))
 }
 
 func (a IP) LessThan(b IP) bool {
-	return util.Ip2BigInt(string(a)).Cmp(util.Ip2BigInt(string(b))) == -1
+	return big.NewInt(0).SetBytes([]byte(a)).Cmp(big.NewInt(0).SetBytes([]byte(b))) < 0
 }
 
 func (a IP) GreaterThan(b IP) bool {
-	return util.Ip2BigInt(string(a)).Cmp(util.Ip2BigInt(string(b))) == 1
+	return big.NewInt(0).SetBytes([]byte(a)).Cmp(big.NewInt(0).SetBytes([]byte(b))) > 0
 }
 
-func (a IP) Add(num int64) IP {
-	return IP(util.BigInt2Ip(big.NewInt(0).Add(util.Ip2BigInt(string(a)), big.NewInt(num))))
+func (a IP) Add(n int64) IP {
+	return IP(big.NewInt(0).Add(big.NewInt(0).SetBytes([]byte(a)), big.NewInt(n)).Bytes())
 }
 
-func (a IP) Sub(num int64) IP {
-	return IP(util.BigInt2Ip(big.NewInt(0).Sub(util.Ip2BigInt(string(a)), big.NewInt(num))))
+func (a IP) Sub(n int64) IP {
+	return IP(big.NewInt(0).Sub(big.NewInt(0).SetBytes([]byte(a)), big.NewInt(n)).Bytes())
 }
 
-func (ipr IPRange) IPExist(ip IP) bool {
-	return (ipr.Start.LessThan(ip) || ipr.Start.Equal(ip)) &&
-		(ipr.End.GreaterThan(ip) || ipr.End.Equal(ip))
-}
-
-type IPRangeList []*IPRange
-
-func (iprl IPRangeList) Contains(ip IP) bool {
-	for _, ipr := range iprl {
-		if ipr.IPExist(ip) {
-			return true
-		}
-	}
-	return false
-}
-
-func (iprl IPRangeList) Equal(iprl2 IPRangeList) bool {
-	if len(iprl) != len(iprl2) {
-		return false
-	}
-
-	for i, range1 := range iprl {
-		range2 := iprl2[i]
-		if !range1.Start.Equal(range2.Start) || !range1.End.Equal(range2.End) {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (iprl IPRangeList) IpRangetoString() string {
-	var ipRangeString []string
-	for _, ipr := range iprl {
-		if ipr.Start.Equal(ipr.End) {
-			ipRangeString = append(ipRangeString, string(ipr.Start))
-		} else {
-			ipRangeString = append(ipRangeString, fmt.Sprintf("%s-%s", ipr.Start, ipr.End))
-		}
-	}
-	return strings.Join(ipRangeString, ",")
-}
-
-func splitIPRangeList(iprl IPRangeList, ip IP) (bool, IPRangeList) {
-	newIPRangeList := []*IPRange{}
-	split := false
-	for _, ipr := range iprl {
-		if split {
-			newIPRangeList = append(newIPRangeList, ipr)
-			continue
-		}
-
-		if ipr.Start.Equal(ipr.End) && ipr.Start.Equal(ip) {
-			split = true
-			continue
-		}
-
-		if ipr.Start.Equal(ip) {
-			newIPRangeList = append(newIPRangeList, &IPRange{Start: ip.Add(1), End: ipr.End})
-			split = true
-			continue
-		}
-
-		if ipr.End.Equal(ip) {
-			newIPRangeList = append(newIPRangeList, &IPRange{Start: ipr.Start, End: ip.Add(-1)})
-			split = true
-			continue
-		}
-
-		if ipr.IPExist(ip) {
-			newIpr1 := IPRange{Start: ipr.Start, End: ip.Add(-1)}
-			newIpr2 := IPRange{Start: ip.Add(1), End: ipr.End}
-			newIPRangeList = append(newIPRangeList, &newIpr1, &newIpr2)
-			split = true
-			continue
-		}
-
-		newIPRangeList = append(newIPRangeList, ipr)
-	}
-	return split, newIPRangeList
-}
-
-func mergeIPRangeList(iprl IPRangeList, ip IP) (bool, IPRangeList) {
-	insertIPRangeList := []*IPRange{}
-	inserted := false
-	if iprl.Contains(ip) {
-		return false, nil
-	}
-
-	for _, ipr := range iprl {
-		if inserted || ipr.Start.LessThan(ip) {
-			insertIPRangeList = append(insertIPRangeList, ipr)
-			continue
-		}
-
-		if ipr.Start.GreaterThan(ip) {
-			insertIPRangeList = append(insertIPRangeList, &IPRange{Start: ip, End: ip}, ipr)
-			inserted = true
-			continue
-		}
-	}
-	if !inserted {
-		newIpr := IPRange{Start: ip, End: ip}
-		insertIPRangeList = append(insertIPRangeList, &newIpr)
-	}
-
-	mergedIPRangeList := []*IPRange{}
-	for _, ipr := range insertIPRangeList {
-		if len(mergedIPRangeList) == 0 {
-			mergedIPRangeList = append(mergedIPRangeList, ipr)
-			continue
-		}
-
-		if mergedIPRangeList[len(mergedIPRangeList)-1].End.Add(1).Equal(ipr.Start) {
-			mergedIPRangeList[len(mergedIPRangeList)-1].End = ipr.End
-		} else {
-			mergedIPRangeList = append(mergedIPRangeList, ipr)
-		}
-	}
-
-	return true, mergedIPRangeList
-}
-
-func convertExcludeIps(excludeIps []string) IPRangeList {
-	newIPRangeList := make([]*IPRange, 0, len(excludeIps))
-	for _, ex := range excludeIps {
-		ips := strings.Split(ex, "..")
-		if len(ips) == 1 {
-			ipr := IPRange{Start: IP(ips[0]), End: IP(ips[0])}
-			newIPRangeList = append(newIPRangeList, &ipr)
-		} else {
-			ipr := IPRange{Start: IP(ips[0]), End: IP(ips[1])}
-			newIPRangeList = append(newIPRangeList, &ipr)
-		}
-	}
-	return newIPRangeList
-}
-
-func splitRange(a, b *IPRange) IPRangeList {
-	if b.End.LessThan(a.Start) || b.Start.GreaterThan(a.End) {
-		return IPRangeList{a}
-	}
-
-	if (a.Start.Equal(b.Start) || a.Start.GreaterThan(b.Start)) &&
-		(a.End.Equal(b.End) || a.End.LessThan(b.End)) {
-		return nil
-	}
-
-	if (a.Start.Equal(b.Start) || a.Start.GreaterThan(b.Start)) &&
-		a.End.GreaterThan(b.End) {
-		ipr := IPRange{Start: b.End.Add(1), End: a.End}
-		return IPRangeList{&ipr}
-	}
-
-	if (a.End.Equal(b.End) || a.End.LessThan(b.End)) &&
-		a.Start.LessThan(b.Start) {
-		ipr := IPRange{Start: a.Start, End: b.Start.Add(-1)}
-		return IPRangeList{&ipr}
-	}
-
-	ipr1 := IPRange{Start: a.Start, End: b.Start.Add(-1)}
-	ipr2 := IPRange{Start: b.End.Add(1), End: a.End}
-	return IPRangeList{&ipr1, &ipr2}
+func (a IP) String() string {
+	return net.IP(a).String()
 }

--- a/pkg/ipam/ip_range.go
+++ b/pkg/ipam/ip_range.go
@@ -1,0 +1,76 @@
+package ipam
+
+import (
+	"fmt"
+)
+
+// IPRange represents an IP range of [start, end]
+type IPRange struct {
+	start, end IP
+}
+
+func NewIPRange(start, end IP) *IPRange {
+	return &IPRange{start, end}
+}
+
+func (r *IPRange) Clone() *IPRange {
+	return NewIPRange(r.start, r.end)
+}
+
+func (r *IPRange) Start() IP {
+	return r.start
+}
+
+func (r *IPRange) End() IP {
+	return r.end
+}
+
+func (r *IPRange) SetStart(ip IP) {
+	r.start = ip
+}
+
+func (r *IPRange) SetEnd(ip IP) {
+	r.end = ip
+}
+
+func (r *IPRange) Contains(ip IP) bool {
+	return !r.start.GreaterThan(ip) && !r.end.LessThan(ip)
+}
+
+func (r *IPRange) Add(ip IP) bool {
+	if newStart := r.start.Sub(1); newStart.Equal(ip) {
+		r.start = newStart
+		return true
+	}
+	if newEnd := r.end.Add(1); newEnd.Equal(ip) {
+		r.end = newEnd
+		return true
+	}
+
+	return false
+}
+
+func (r *IPRange) Remove(ip IP) ([]*IPRange, bool) {
+	if !r.Contains(ip) {
+		return nil, false
+	}
+
+	ret := make([]*IPRange, 0, 2)
+	r1 := NewIPRange(r.start, ip.Sub(1))
+	r2 := NewIPRange(ip.Add(1), r.end)
+	if !r1.start.GreaterThan(r1.end) {
+		ret = append(ret, r1)
+	}
+	if !r2.start.GreaterThan(r2.end) {
+		ret = append(ret, r2)
+	}
+
+	return ret, true
+}
+
+func (r *IPRange) String() string {
+	if r.start.Equal(r.end) {
+		return r.start.String()
+	}
+	return fmt.Sprintf("%s-%s", r.start.String(), r.end.String())
+}

--- a/pkg/ipam/ip_range_list.go
+++ b/pkg/ipam/ip_range_list.go
@@ -1,0 +1,251 @@
+package ipam
+
+import (
+	"sort"
+	"strings"
+)
+
+type IPRangeList struct {
+	ranges []*IPRange
+}
+
+func NewIPRangeList() *IPRangeList {
+	return &IPRangeList{}
+}
+
+func NewIPRangeListFrom(x ...string) *IPRangeList {
+	ret := &IPRangeList{make([]*IPRange, 0, len(x))}
+	for _, s := range x {
+		ips := strings.Split(s, "..")
+		if len(ips) == 1 {
+			ret.Add(NewIP(ips[0]))
+		} else {
+			n1, found1 := ret.Find(NewIP(ips[0]))
+			n2, found2 := ret.Find(NewIP(ips[1]))
+			if found1 {
+				if found2 {
+					if n1 != n2 {
+						ret.ranges[n1].SetEnd(ret.ranges[n2].End())
+						ret.ranges = append(ret.ranges[:n1+1], ret.ranges[n2+1:]...)
+					}
+				} else {
+					ret.ranges[n1].SetEnd(NewIP(ips[1]))
+					ret.ranges = append(ret.ranges[:n1+1], ret.ranges[n2:]...)
+				}
+			} else {
+				if found2 {
+					ret.ranges[n2].SetStart(NewIP(ips[0]))
+					ret.ranges = append(ret.ranges[:n1], ret.ranges[n2:]...)
+				} else {
+					if n1 == n2 {
+						tmp := make([]*IPRange, ret.Len()+1)
+						copy(tmp, ret.ranges[:n1])
+						tmp[n1] = NewIPRange(NewIP(ips[0]), NewIP(ips[1]))
+						copy(tmp[n1+1:], ret.ranges[n1:])
+						ret.ranges = tmp
+					} else {
+						ret.ranges[n1] = NewIPRange(NewIP(ips[0]), NewIP(ips[1]))
+						ret.ranges = append(ret.ranges[:n1+1], ret.ranges[n2+1:]...)
+					}
+				}
+			}
+		}
+	}
+	return ret
+}
+
+func (r *IPRangeList) Clone() *IPRangeList {
+	ret := &IPRangeList{make([]*IPRange, r.Len())}
+	copy(ret.ranges, r.ranges)
+	return ret
+}
+
+func (r *IPRangeList) Len() int {
+	return len(r.ranges)
+}
+
+func (r *IPRangeList) At(i int) *IPRange {
+	if i < len(r.ranges) {
+		return r.ranges[i]
+	}
+	return nil
+}
+
+func (r *IPRangeList) Find(ip IP) (int, bool) {
+	return sort.Find(len(r.ranges), func(i int) int {
+		if r.At(i).Start().GreaterThan(ip) {
+			return -1
+		}
+		if r.At(i).End().LessThan(ip) {
+			return 1
+		}
+		return 0
+	})
+}
+
+func (r *IPRangeList) Contains(ip IP) bool {
+	_, found := r.Find(ip)
+	return found
+}
+
+func (r *IPRangeList) Add(ip IP) bool {
+	n, ok := r.Find(ip)
+	if ok {
+		return false
+	}
+
+	if (n-1 >= 0 && r.ranges[n-1].Add(ip)) ||
+		(n < r.Len() && r.ranges[n].Add(ip)) {
+		if n-1 >= 0 && n < r.Len() && r.ranges[n-1].End().Add(1).Equal(r.ranges[n].Start()) {
+			r.ranges[n-1].SetEnd(r.ranges[n].End())
+			r.ranges = append(r.ranges[:n], r.ranges[n+1:]...)
+		}
+		return true
+	}
+
+	tmp := make([]*IPRange, r.Len()+1)
+	copy(tmp, r.ranges[:n])
+	tmp[n] = NewIPRange(ip, ip)
+	copy(tmp[n+1:], r.ranges[n:])
+	r.ranges = tmp
+
+	return true
+}
+
+func (r *IPRangeList) Remove(ip IP) bool {
+	n, ok := r.Find(ip)
+	if !ok {
+		return false
+	}
+
+	v, _ := r.ranges[n].Remove(ip)
+	switch len(v) {
+	case 0:
+		r.ranges = append(r.ranges[:n], r.ranges[n+1:]...)
+	case 1:
+		r.ranges[n] = v[0]
+	case 2:
+		tmp := make([]*IPRange, r.Len()+1)
+		copy(tmp, r.ranges[:n])
+		copy(tmp[n:], v)
+		copy(tmp[n+2:], r.ranges[n+1:])
+		r.ranges = tmp
+	}
+
+	return true
+}
+
+func (r *IPRangeList) Allocate(skipped []IP) IP {
+	if r.Len() == 0 {
+		return nil
+	}
+
+	if len(skipped) == 0 {
+		ret := r.ranges[0].Start()
+		r.Remove(ret)
+		return ret
+	}
+
+	tmp := NewIPRangeList()
+	for _, ip := range skipped {
+		tmp.Add(ip)
+	}
+
+	filtered := r.Difference(tmp)
+	if filtered.Len() == 0 {
+		return nil
+	}
+
+	ret := filtered.ranges[0].Start()
+	r.Remove(ret)
+	return ret
+}
+
+func (r *IPRangeList) Equal(x *IPRangeList) bool {
+	if r.Len() != x.Len() {
+		return false
+	}
+
+	for i := 0; i < r.Len(); i++ {
+		if !r.At(i).Start().Equal(x.At(i).Start()) || !r.At(i).End().Equal(x.At(i).End()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Difference returns a new list which contains items which are in `r` but not in `x`
+func (r *IPRangeList) Difference(x *IPRangeList) *IPRangeList {
+	if r.Len() == 0 {
+		return NewIPRangeList()
+	}
+	if x.Len() == 0 {
+		return r.Clone()
+	}
+
+	var i, j int
+	ret := &IPRangeList{}
+	for ; i < r.Len(); i++ {
+		start, end := r.At(i).Start(), r.At(i).End()
+		for ; j < x.Len(); j++ {
+			if x.At(j).End().LessThan(start) {
+				continue
+			}
+			if x.At(j).Start().GreaterThan(end) {
+				ret.ranges = append(ret.ranges, NewIPRange(start, end))
+				break
+			}
+			if !x.At(j).End().LessThan(end) {
+				if x.At(j).Start().GreaterThan(start) {
+					ret.ranges = append(ret.ranges, NewIPRange(start, x.At(j).Start().Sub(1)))
+				}
+				break
+			}
+			if start.LessThan(x.At(j).Start()) {
+				ret.ranges = append(ret.ranges, NewIPRange(start, x.At(j).Start().Sub(1)))
+			}
+			start = x.At(j).End().Add(1)
+		}
+		if j == x.Len() {
+			ret.ranges = append(ret.ranges, NewIPRange(start, end))
+		}
+	}
+
+	return ret
+}
+
+func (r *IPRangeList) Merge(x *IPRangeList) *IPRangeList {
+	ret := &IPRangeList{make([]*IPRange, 0, r.Len()+x.Len())}
+
+	var i, j int
+	for i != r.Len() || j != x.Len() {
+		if i == r.Len() {
+			ret.ranges = append(ret.ranges, x.ranges[j].Clone())
+			j++
+			continue
+		}
+		if j == x.Len() {
+			ret.ranges = append(ret.ranges, r.ranges[i].Clone())
+			i++
+			continue
+		}
+		if r.ranges[i].Start().LessThan(x.ranges[j].Start()) {
+			ret.ranges = append(ret.ranges, r.ranges[i].Clone())
+			i++
+		} else {
+			ret.ranges = append(ret.ranges, x.ranges[j].Clone())
+			j++
+		}
+	}
+
+	return ret
+}
+
+func (r *IPRangeList) String() string {
+	s := make([]string, 0, r.Len())
+	for i := 0; i < r.Len(); i++ {
+		s = append(s, r.At(i).String())
+	}
+	return strings.Join(s, ",")
+}

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -17,21 +17,21 @@ type Subnet struct {
 	mutex            sync.RWMutex
 	Protocol         string
 	V4CIDR           *net.IPNet
-	V4FreeIPList     IPRangeList
-	V4ReleasedIPList IPRangeList
-	V4ReservedIPList IPRangeList
-	V4AvailIPList    IPRangeList
-	V4UsingIPList    IPRangeList
+	V4FreeIPList     *IPRangeList
+	V4ReleasedIPList *IPRangeList
+	V4ReservedIPList *IPRangeList
+	V4AvailIPList    *IPRangeList
+	V4UsingIPList    *IPRangeList
 	V4NicToIP        map[string]IP
-	V4IPToPod        map[IP]string
+	V4IPToPod        map[string]string
 	V6CIDR           *net.IPNet
-	V6FreeIPList     IPRangeList
-	V6ReleasedIPList IPRangeList
-	V6ReservedIPList IPRangeList
-	V6AvailIPList    IPRangeList
-	V6UsingIPList    IPRangeList
+	V6FreeIPList     *IPRangeList
+	V6ReleasedIPList *IPRangeList
+	V6ReservedIPList *IPRangeList
+	V6AvailIPList    *IPRangeList
+	V6UsingIPList    *IPRangeList
 	V6NicToIP        map[string]IP
-	V6IPToPod        map[IP]string
+	V6IPToPod        map[string]string
 	NicToMac         map[string]string
 	MacToPod         map[string]string
 	PodToNicList     map[string][]string
@@ -40,8 +40,6 @@ type Subnet struct {
 }
 
 func NewSubnet(name, cidrStr string, excludeIps []string) (*Subnet, error) {
-	excludeIps = util.ExpandExcludeIPs(excludeIps, cidrStr)
-
 	var cidrs []*net.IPNet
 	for _, cidrBlock := range strings.Split(cidrStr, ",") {
 		if _, cidr, err := net.ParseCIDR(cidrBlock); err != nil {
@@ -52,90 +50,57 @@ func NewSubnet(name, cidrStr string, excludeIps []string) (*Subnet, error) {
 	}
 
 	// subnet.Spec.ExcludeIps contains both v4 and v6 addresses
+	excludeIps = util.ExpandExcludeIPs(excludeIps, cidrStr)
 	v4ExcludeIps, v6ExcludeIps := util.SplitIpsByProtocol(excludeIps)
 
-	subnet := Subnet{}
 	protocol := util.CheckProtocol(cidrStr)
+	subnet := &Subnet{
+		Name:             name,
+		mutex:            sync.RWMutex{},
+		Protocol:         protocol,
+		V4FreeIPList:     NewIPRangeList(),
+		V6FreeIPList:     NewIPRangeList(),
+		V4ReservedIPList: NewIPRangeListFrom(v4ExcludeIps...),
+		V6ReservedIPList: NewIPRangeListFrom(v6ExcludeIps...),
+		V4ReleasedIPList: NewIPRangeList(),
+		V6ReleasedIPList: NewIPRangeList(),
+		V4UsingIPList:    NewIPRangeList(),
+		V6UsingIPList:    NewIPRangeList(),
+		V4NicToIP:        map[string]IP{},
+		V6NicToIP:        map[string]IP{},
+		V4IPToPod:        map[string]string{},
+		V6IPToPod:        map[string]string{},
+		MacToPod:         map[string]string{},
+		NicToMac:         map[string]string{},
+		PodToNicList:     map[string][]string{},
+	}
 	if protocol == kubeovnv1.ProtocolIPv4 {
 		firstIP, _ := util.FirstIP(cidrStr)
 		lastIP, _ := util.LastIP(cidrStr)
-
-		subnet = Subnet{
-			Name:             name,
-			mutex:            sync.RWMutex{},
-			Protocol:         protocol,
-			V4CIDR:           cidrs[0],
-			V4FreeIPList:     IPRangeList{&IPRange{Start: IP(firstIP), End: IP(lastIP)}},
-			V4ReleasedIPList: IPRangeList{},
-			V4ReservedIPList: convertExcludeIps(v4ExcludeIps),
-			V4AvailIPList:    IPRangeList{&IPRange{Start: IP(firstIP), End: IP(lastIP)}},
-			V4UsingIPList:    IPRangeList{},
-			V4NicToIP:        map[string]IP{},
-			V4IPToPod:        map[IP]string{},
-			V6NicToIP:        map[string]IP{},
-			V6IPToPod:        map[IP]string{},
-			MacToPod:         map[string]string{},
-			NicToMac:         map[string]string{},
-			PodToNicList:     map[string][]string{},
-		}
-		subnet.joinFreeWithReserve()
+		subnet.V4CIDR = cidrs[0]
+		subnet.V4FreeIPList = NewIPRangeListFrom(fmt.Sprintf("%s..%s", firstIP, lastIP))
 	} else if protocol == kubeovnv1.ProtocolIPv6 {
 		firstIP, _ := util.FirstIP(cidrStr)
 		lastIP, _ := util.LastIP(cidrStr)
-
-		subnet = Subnet{
-			Name:             name,
-			mutex:            sync.RWMutex{},
-			Protocol:         protocol,
-			V6CIDR:           cidrs[0],
-			V6FreeIPList:     IPRangeList{&IPRange{Start: IP(firstIP), End: IP(lastIP)}},
-			V6ReleasedIPList: IPRangeList{},
-			V6ReservedIPList: convertExcludeIps(v6ExcludeIps),
-			V6AvailIPList:    IPRangeList{&IPRange{Start: IP(firstIP), End: IP(lastIP)}},
-			V6UsingIPList:    IPRangeList{},
-			V4NicToIP:        map[string]IP{},
-			V4IPToPod:        map[IP]string{},
-			V6NicToIP:        map[string]IP{},
-			V6IPToPod:        map[IP]string{},
-			MacToPod:         map[string]string{},
-			NicToMac:         map[string]string{},
-			PodToNicList:     map[string][]string{},
-		}
-		subnet.joinFreeWithReserve()
+		subnet.V6CIDR = cidrs[0]
+		subnet.V6FreeIPList = NewIPRangeListFrom(fmt.Sprintf("%s..%s", firstIP, lastIP))
 	} else {
+		subnet.V4CIDR = cidrs[0]
+		subnet.V6CIDR = cidrs[1]
 		cidrBlocks := strings.Split(cidrStr, ",")
 		v4FirstIP, _ := util.FirstIP(cidrBlocks[0])
 		v4LastIP, _ := util.LastIP(cidrBlocks[0])
 		v6FirstIP, _ := util.FirstIP(cidrBlocks[1])
 		v6LastIP, _ := util.LastIP(cidrBlocks[1])
-
-		subnet = Subnet{
-			Name:             name,
-			mutex:            sync.RWMutex{},
-			Protocol:         protocol,
-			V4CIDR:           cidrs[0],
-			V4FreeIPList:     IPRangeList{&IPRange{Start: IP(v4FirstIP), End: IP(v4LastIP)}},
-			V4ReleasedIPList: IPRangeList{},
-			V4ReservedIPList: convertExcludeIps(v4ExcludeIps),
-			V4AvailIPList:    IPRangeList{&IPRange{Start: IP(v4FirstIP), End: IP(v4LastIP)}},
-			V4UsingIPList:    IPRangeList{},
-			V4NicToIP:        map[string]IP{},
-			V4IPToPod:        map[IP]string{},
-			V6CIDR:           cidrs[1],
-			V6FreeIPList:     IPRangeList{&IPRange{Start: IP(v6FirstIP), End: IP(v6LastIP)}},
-			V6ReleasedIPList: IPRangeList{},
-			V6ReservedIPList: convertExcludeIps(v6ExcludeIps),
-			V6AvailIPList:    IPRangeList{&IPRange{Start: IP(v6FirstIP), End: IP(v6LastIP)}},
-			V6UsingIPList:    IPRangeList{},
-			V6NicToIP:        map[string]IP{},
-			V6IPToPod:        map[IP]string{},
-			MacToPod:         map[string]string{},
-			NicToMac:         map[string]string{},
-			PodToNicList:     map[string][]string{},
-		}
-		subnet.joinFreeWithReserve()
+		subnet.V4FreeIPList = NewIPRangeListFrom(fmt.Sprintf("%s..%s", v4FirstIP, v4LastIP))
+		subnet.V6FreeIPList = NewIPRangeListFrom(fmt.Sprintf("%s..%s", v6FirstIP, v6LastIP))
 	}
-	return &subnet, nil
+	subnet.V4FreeIPList = subnet.V4FreeIPList.Difference(subnet.V4ReservedIPList)
+	subnet.V6FreeIPList = subnet.V6FreeIPList.Difference(subnet.V6ReservedIPList)
+	subnet.V4AvailIPList = subnet.V4FreeIPList.Clone()
+	subnet.V6AvailIPList = subnet.V6FreeIPList.Clone()
+
+	return subnet, nil
 }
 
 func (subnet *Subnet) GetRandomMac(podName, nicName string) string {
@@ -167,7 +132,7 @@ func (subnet *Subnet) GetStaticMac(podName, nicName, mac string, checkConflict b
 }
 
 func (subnet *Subnet) pushPodNic(podName, nicName string) {
-	if subnet.V4NicToIP[nicName] != "" || subnet.V6NicToIP[nicName] != "" || subnet.NicToMac[nicName] != "" {
+	if subnet.V4NicToIP[nicName] != nil || subnet.V6NicToIP[nicName] != nil || subnet.NicToMac[nicName] != "" {
 		subnet.PodToNicList[podName] = util.UniqString(append(subnet.PodToNicList[podName], nicName))
 	}
 }
@@ -198,15 +163,15 @@ func (subnet *Subnet) GetRandomAddress(podName, nicName string, mac *string, ski
 func (subnet *Subnet) getDualRandomAddress(podName, nicName string, mac *string, skippedAddrs []string, checkConflict bool) (IP, IP, string, error) {
 	v4IP, _, _, err := subnet.getV4RandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	if err != nil {
-		return "", "", "", err
+		return nil, nil, "", err
 	}
 	_, v6IP, macStr, err := subnet.getV6RandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	if err != nil {
-		return "", "", "", err
+		return nil, nil, "", err
 	}
 
 	// allocated IPv4 address may be released in getV6RandomAddress()
-	if subnet.V4NicToIP[nicName] != v4IP {
+	if !subnet.V4NicToIP[nicName].Equal(v4IP) {
 		v4IP, _, _, _ = subnet.getV4RandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)
 	}
 
@@ -217,66 +182,43 @@ func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac *string, s
 	// After 'macAdd' introduced to support only static mac address, pod restart will run into error mac AddressConflict
 	// controller will re-enqueue the new pod then wait for old pod deleted and address released.
 	// here will return only if both ip and mac exist, otherwise only ip without mac returned will trigger CreatePort error.
-	if subnet.V4NicToIP[nicName] != "" && subnet.NicToMac[nicName] != "" {
-		if !util.ContainsString(skippedAddrs, string(subnet.V4NicToIP[nicName])) {
-			return subnet.V4NicToIP[nicName], "", subnet.NicToMac[nicName], nil
+	if subnet.V4NicToIP[nicName] != nil && subnet.NicToMac[nicName] != "" {
+		if !util.ContainsString(skippedAddrs, subnet.V4NicToIP[nicName].String()) {
+			return subnet.V4NicToIP[nicName], nil, subnet.NicToMac[nicName], nil
 		}
 		subnet.releaseAddr(podName, nicName)
 	}
-	if len(subnet.V4FreeIPList) == 0 {
-		if len(subnet.V4ReleasedIPList) == 0 {
-			return "", "", "", ErrNoAvailable
+
+	if subnet.V4FreeIPList.Len() == 0 {
+		if subnet.V4ReleasedIPList.Len() == 0 {
+			return nil, nil, "", ErrNoAvailable
 		}
 		subnet.V4FreeIPList = subnet.V4ReleasedIPList
-		subnet.V4ReleasedIPList = IPRangeList{}
+		subnet.V4ReleasedIPList = NewIPRangeList()
 	}
 
-	var ip IP
-	var idx int
-	for i, ipr := range subnet.V4FreeIPList {
-		for next := ipr.Start; !next.GreaterThan(ipr.End); next = next.Add(1) {
-			if !util.ContainsString(skippedAddrs, string(next)) {
-				ip = next
-				break
-			}
-		}
-		if ip != "" {
-			idx = i
-			break
-		}
+	skipped := make([]IP, 0, len(skippedAddrs))
+	for _, s := range skippedAddrs {
+		skipped = append(skipped, NewIP(s))
 	}
-	if ip == "" {
-		return "", "", "", ErrConflict
+	ip := subnet.V4FreeIPList.Allocate(skipped)
+	if ip == nil {
+		return nil, nil, "", ErrConflict
 	}
 
-	ipr := subnet.V4FreeIPList[idx]
-	part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
-	part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
-	subnet.V4FreeIPList = append(subnet.V4FreeIPList[:idx], subnet.V4FreeIPList[idx+1:]...)
-	if !part1.Start.GreaterThan(part1.End) {
-		subnet.V4FreeIPList = append(subnet.V4FreeIPList, part1)
-	}
-	if !part2.Start.GreaterThan(part2.End) {
-		subnet.V4FreeIPList = append(subnet.V4FreeIPList, part2)
-	}
-	if split, NewV4AvailIPRangeList := splitIPRangeList(subnet.V4AvailIPList, ip); split {
-		subnet.V4AvailIPList = NewV4AvailIPRangeList
-	}
-
-	if merged, NewV4UsingIPRangeList := mergeIPRangeList(subnet.V4UsingIPList, ip); merged {
-		subnet.V4UsingIPList = NewV4UsingIPRangeList
-	}
+	subnet.V4AvailIPList.Remove(ip)
+	subnet.V4UsingIPList.Add(ip)
 
 	subnet.V4NicToIP[nicName] = ip
-	subnet.V4IPToPod[ip] = podName
+	subnet.V4IPToPod[ip.String()] = podName
 	subnet.pushPodNic(podName, nicName)
 	if mac == nil {
-		return ip, "", subnet.GetRandomMac(podName, nicName), nil
+		return ip, nil, subnet.GetRandomMac(podName, nicName), nil
 	} else {
 		if err := subnet.GetStaticMac(podName, nicName, *mac, checkConflict); err != nil {
-			return "", "", "", err
+			return nil, nil, "", err
 		}
-		return ip, "", *mac, nil
+		return ip, nil, *mac, nil
 	}
 }
 
@@ -284,67 +226,43 @@ func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac *string, s
 	// After 'macAdd' introduced to support only static mac address, pod restart will run into error mac AddressConflict
 	// controller will re-enqueue the new pod then wait for old pod deleted and address released.
 	// here will return only if both ip and mac exist, otherwise only ip without mac returned will trigger CreatePort error.
-	if subnet.V6NicToIP[nicName] != "" && subnet.NicToMac[nicName] != "" {
-		if !util.ContainsString(skippedAddrs, string(subnet.V6NicToIP[nicName])) {
-			return "", subnet.V6NicToIP[nicName], subnet.NicToMac[nicName], nil
+	if subnet.V6NicToIP[nicName] != nil && subnet.NicToMac[nicName] != "" {
+		if !util.ContainsString(skippedAddrs, subnet.V6NicToIP[nicName].String()) {
+			return nil, subnet.V6NicToIP[nicName], subnet.NicToMac[nicName], nil
 		}
 		subnet.releaseAddr(podName, nicName)
 	}
 
-	if len(subnet.V6FreeIPList) == 0 {
-		if len(subnet.V6ReleasedIPList) == 0 {
-			return "", "", "", ErrNoAvailable
+	if subnet.V6FreeIPList.Len() == 0 {
+		if subnet.V6ReleasedIPList.Len() == 0 {
+			return nil, nil, "", ErrNoAvailable
 		}
 		subnet.V6FreeIPList = subnet.V6ReleasedIPList
-		subnet.V6ReleasedIPList = IPRangeList{}
+		subnet.V6ReleasedIPList = NewIPRangeList()
 	}
 
-	var ip IP
-	var idx int
-	for i, ipr := range subnet.V6FreeIPList {
-		for next := ipr.Start; !next.GreaterThan(ipr.End); next = next.Add(1) {
-			if !util.ContainsString(skippedAddrs, string(next)) {
-				ip = next
-				break
-			}
-		}
-		if ip != "" {
-			idx = i
-			break
-		}
+	skipped := make([]IP, 0, len(skippedAddrs))
+	for _, s := range skippedAddrs {
+		skipped = append(skipped, NewIP(s))
 	}
-	if ip == "" {
-		return "", "", "", ErrConflict
+	ip := subnet.V6FreeIPList.Allocate(skipped)
+	if ip == nil {
+		return nil, nil, "", ErrConflict
 	}
 
-	ipr := subnet.V6FreeIPList[idx]
-	part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
-	part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
-	subnet.V6FreeIPList = append(subnet.V6FreeIPList[:idx], subnet.V6FreeIPList[idx+1:]...)
-	if !part1.Start.GreaterThan(part1.End) {
-		subnet.V6FreeIPList = append(subnet.V6FreeIPList, part1)
-	}
-	if !part2.Start.GreaterThan(part2.End) {
-		subnet.V6FreeIPList = append(subnet.V6FreeIPList, part2)
-	}
-	if split, NewV6AvailIPRangeList := splitIPRangeList(subnet.V6AvailIPList, ip); split {
-		subnet.V6AvailIPList = NewV6AvailIPRangeList
-	}
-
-	if merged, NewV6UsingIPRangeList := mergeIPRangeList(subnet.V6UsingIPList, ip); merged {
-		subnet.V6UsingIPList = NewV6UsingIPRangeList
-	}
+	subnet.V6AvailIPList.Remove(ip)
+	subnet.V6UsingIPList.Add(ip)
 
 	subnet.V6NicToIP[nicName] = ip
-	subnet.V6IPToPod[ip] = podName
+	subnet.V6IPToPod[ip.String()] = podName
 	subnet.pushPodNic(podName, nicName)
 	if mac == nil {
-		return "", ip, subnet.GetRandomMac(podName, nicName), nil
+		return nil, ip, subnet.GetRandomMac(podName, nicName), nil
 	} else {
 		if err := subnet.GetStaticMac(podName, nicName, *mac, checkConflict); err != nil {
-			return "", "", "", err
+			return nil, nil, "", err
 		}
-		return "", ip, *mac, nil
+		return nil, ip, *mac, nil
 	}
 }
 
@@ -356,42 +274,27 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *stri
 		subnet.pushPodNic(podName, nicName)
 		if isAllocated {
 			if v4 {
-				if split, NewV4AvailIPRangeList := splitIPRangeList(subnet.V4AvailIPList, ip); split {
-					subnet.V4AvailIPList = NewV4AvailIPRangeList
-				}
-
-				if merged, NewV4UsingIPRangeList := mergeIPRangeList(subnet.V4UsingIPList, ip); merged {
-					subnet.V4UsingIPList = NewV4UsingIPRangeList
-				}
+				subnet.V4AvailIPList.Remove(ip)
+				subnet.V4UsingIPList.Add(ip)
 			}
-
 			if v6 {
-				if split, NewV6AvailIPRangeList := splitIPRangeList(subnet.V6AvailIPList, ip); split {
-					subnet.V6AvailIPList = NewV6AvailIPRangeList
-				}
-
-				if merged, NewV6UsingIPRangeList := mergeIPRangeList(subnet.V6UsingIPList, ip); merged {
-					subnet.V6UsingIPList = NewV6UsingIPRangeList
-				}
+				subnet.V6AvailIPList.Remove(ip)
+				subnet.V6UsingIPList.Add(ip)
 			}
 		}
 		subnet.mutex.Unlock()
 	}()
 
-	if net.ParseIP(string(ip)).To4() != nil {
+	if ip.To4() != nil {
 		v4 = subnet.V4CIDR != nil
 	} else {
 		v6 = subnet.V6CIDR != nil
 	}
-	if v4 && !subnet.V4CIDR.Contains(net.ParseIP(string(ip))) {
+	if v4 && !subnet.V4CIDR.Contains(net.IP(ip)) {
 		return ip, "", ErrOutOfRange
 	}
 
-	if v6 {
-		ip = IP(net.ParseIP(string(ip)).String())
-	}
-
-	if v6 && !subnet.V6CIDR.Contains(net.ParseIP(string(ip))) {
+	if v6 && !subnet.V6CIDR.Contains(net.IP(ip)) {
 		return ip, "", ErrOutOfRange
 	}
 
@@ -410,12 +313,12 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *stri
 	}
 
 	if v4 {
-		if existPod, ok := subnet.V4IPToPod[ip]; ok {
+		if existPod, ok := subnet.V4IPToPod[ip.String()]; ok {
 			pods := strings.Split(existPod, ",")
 			if !util.ContainsString(pods, podName) {
 				if !checkConflict {
 					subnet.V4NicToIP[nicName] = ip
-					subnet.V4IPToPod[ip] = fmt.Sprintf("%s,%s", subnet.V4IPToPod[ip], podName)
+					subnet.V4IPToPod[ip.String()] = fmt.Sprintf("%s,%s", subnet.V4IPToPod[ip.String()], podName)
 					return ip, macStr, nil
 				}
 				return ip, macStr, ErrConflict
@@ -427,32 +330,28 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *stri
 
 		if subnet.V4ReservedIPList.Contains(ip) {
 			subnet.V4NicToIP[nicName] = ip
-			subnet.V4IPToPod[ip] = podName
+			subnet.V4IPToPod[ip.String()] = podName
 			return ip, macStr, nil
 		}
 
-		if split, newFreeList := splitIPRangeList(subnet.V4FreeIPList, ip); split {
-			subnet.V4FreeIPList = newFreeList
+		if subnet.V4FreeIPList.Remove(ip) {
 			subnet.V4NicToIP[nicName] = ip
-			subnet.V4IPToPod[ip] = podName
+			subnet.V4IPToPod[ip.String()] = podName
 			isAllocated = true
 			return ip, macStr, nil
-		} else {
-			if split, newReleasedList := splitIPRangeList(subnet.V4ReleasedIPList, ip); split {
-				subnet.V4ReleasedIPList = newReleasedList
-				subnet.V4NicToIP[nicName] = ip
-				subnet.V4IPToPod[ip] = podName
-				isAllocated = true
-				return ip, macStr, nil
-			}
+		} else if subnet.V4ReleasedIPList.Remove(ip) {
+			subnet.V4NicToIP[nicName] = ip
+			subnet.V4IPToPod[ip.String()] = podName
+			isAllocated = true
+			return ip, macStr, nil
 		}
 	} else if v6 {
-		if existPod, ok := subnet.V6IPToPod[ip]; ok {
+		if existPod, ok := subnet.V6IPToPod[ip.String()]; ok {
 			pods := strings.Split(existPod, ",")
 			if !util.ContainsString(pods, podName) {
 				if !checkConflict {
 					subnet.V6NicToIP[nicName] = ip
-					subnet.V6IPToPod[ip] = fmt.Sprintf("%s,%s", subnet.V6IPToPod[ip], podName)
+					subnet.V6IPToPod[ip.String()] = fmt.Sprintf("%s,%s", subnet.V6IPToPod[ip.String()], podName)
 					return ip, macStr, nil
 				}
 				return ip, macStr, ErrConflict
@@ -464,47 +363,44 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *stri
 
 		if subnet.V6ReservedIPList.Contains(ip) {
 			subnet.V6NicToIP[nicName] = ip
-			subnet.V6IPToPod[ip] = podName
+			subnet.V6IPToPod[ip.String()] = podName
 			return ip, macStr, nil
 		}
 
-		if split, newFreeList := splitIPRangeList(subnet.V6FreeIPList, ip); split {
-			subnet.V6FreeIPList = newFreeList
+		if subnet.V6FreeIPList.Remove(ip) {
 			subnet.V6NicToIP[nicName] = ip
-			subnet.V6IPToPod[ip] = podName
+			subnet.V6IPToPod[ip.String()] = podName
 			isAllocated = true
 			return ip, macStr, nil
-		} else {
-			if split, newReleasedList := splitIPRangeList(subnet.V6ReleasedIPList, ip); split {
-				subnet.V6ReleasedIPList = newReleasedList
-				subnet.V6NicToIP[nicName] = ip
-				subnet.V6IPToPod[ip] = podName
-				isAllocated = true
-				return ip, macStr, nil
-			}
+		} else if subnet.V6ReleasedIPList.Remove(ip) {
+			subnet.V6NicToIP[nicName] = ip
+			subnet.V6IPToPod[ip.String()] = podName
+			isAllocated = true
+			return ip, macStr, nil
 		}
 	}
 	return ip, macStr, ErrNoAvailable
 }
 
 func (subnet *Subnet) releaseAddr(podName, nicName string) {
-	ip, mac := IP(""), ""
+	var ip IP
+	var mac string
 	var ok, changed bool
 	if ip, ok = subnet.V4NicToIP[nicName]; ok {
-		oldPods := strings.Split(subnet.V4IPToPod[ip], ",")
+		oldPods := strings.Split(subnet.V4IPToPod[ip.String()], ",")
 		if len(oldPods) > 1 {
 			newPods := util.RemoveString(oldPods, podName)
-			subnet.V4IPToPod[ip] = strings.Join(newPods, ",")
+			subnet.V4IPToPod[ip.String()] = strings.Join(newPods, ",")
 		} else {
 			delete(subnet.V4NicToIP, nicName)
-			delete(subnet.V4IPToPod, ip)
+			delete(subnet.V4IPToPod, ip.String())
 			if mac, ok = subnet.NicToMac[nicName]; ok {
 				delete(subnet.NicToMac, nicName)
 				delete(subnet.MacToPod, mac)
 			}
 
 			// When CIDR changed, do not relocate ip to CIDR list
-			if !subnet.V4CIDR.Contains(net.ParseIP(string(ip))) {
+			if !subnet.V4CIDR.Contains(net.IP(ip)) {
 				// Continue to release IPv6 address
 				klog.Infof("release v4 %s mac %s for %s, ignore ip", ip, mac, podName)
 				changed = true
@@ -515,35 +411,31 @@ func (subnet *Subnet) releaseAddr(podName, nicName string) {
 				changed = true
 			}
 
-			if merged, newReleasedList := mergeIPRangeList(subnet.V4ReleasedIPList, ip); !changed && merged {
-				subnet.V4ReleasedIPList = newReleasedList
-				klog.Infof("release v4 %s mac %s for %s, add ip to released list", ip, mac, podName)
+			if !changed {
+				if subnet.V4ReleasedIPList.Add(ip) {
+					klog.Infof("release v4 %s mac %s for %s, add ip to released list", ip, mac, podName)
+				}
 			}
 
-			if merged, NewV4AvailIPRangeList := mergeIPRangeList(subnet.V4AvailIPList, ip); merged {
-				subnet.V4AvailIPList = NewV4AvailIPRangeList
-			}
-
-			if split, NewV4UsingIPList := splitIPRangeList(subnet.V4UsingIPList, ip); split {
-				subnet.V4UsingIPList = NewV4UsingIPList
-			}
+			subnet.V4AvailIPList.Add(ip)
+			subnet.V4UsingIPList.Remove(ip)
 		}
 	}
 	if ip, ok = subnet.V6NicToIP[nicName]; ok {
-		oldPods := strings.Split(subnet.V6IPToPod[ip], ",")
+		oldPods := strings.Split(subnet.V6IPToPod[ip.String()], ",")
 		if len(oldPods) > 1 {
 			newPods := util.RemoveString(oldPods, podName)
-			subnet.V6IPToPod[ip] = strings.Join(newPods, ",")
+			subnet.V6IPToPod[ip.String()] = strings.Join(newPods, ",")
 		} else {
 			delete(subnet.V6NicToIP, nicName)
-			delete(subnet.V6IPToPod, ip)
+			delete(subnet.V6IPToPod, ip.String())
 			if mac, ok = subnet.NicToMac[nicName]; ok {
 				delete(subnet.NicToMac, nicName)
 				delete(subnet.MacToPod, mac)
 			}
 			changed = false
 			// When CIDR changed, do not relocate ip to CIDR list
-			if !subnet.V6CIDR.Contains(net.ParseIP(string(ip))) {
+			if !subnet.V6CIDR.Contains(net.IP(ip)) {
 				klog.Infof("release v6 %s mac %s for %s, ignore ip", ip, mac, podName)
 				changed = true
 			}
@@ -553,18 +445,14 @@ func (subnet *Subnet) releaseAddr(podName, nicName string) {
 				changed = true
 			}
 
-			if merged, newReleasedList := mergeIPRangeList(subnet.V6ReleasedIPList, ip); !changed && merged {
-				subnet.V6ReleasedIPList = newReleasedList
-				klog.Infof("release v6 %s mac %s for %s, add ip to released list", ip, mac, podName)
+			if !changed {
+				if subnet.V6ReleasedIPList.Add(ip) {
+					klog.Infof("release v6 %s mac %s for %s, add ip to released list", ip, mac, podName)
+				}
 			}
 
-			if merged, NewV6AvailIPRangeList := mergeIPRangeList(subnet.V6AvailIPList, ip); merged {
-				subnet.V6AvailIPList = NewV6AvailIPRangeList
-			}
-
-			if split, NewV6UsingIPList := splitIPRangeList(subnet.V6UsingIPList, ip); split {
-				subnet.V6UsingIPList = NewV6UsingIPList
-			}
+			subnet.V6AvailIPList.Add(ip)
+			subnet.V6UsingIPList.Remove(ip)
 		}
 	}
 }
@@ -590,64 +478,22 @@ func (subnet *Subnet) ContainAddress(address IP) bool {
 	subnet.mutex.RLock()
 	defer subnet.mutex.RUnlock()
 
-	if _, ok := subnet.V4IPToPod[address]; ok {
+	if _, ok := subnet.V4IPToPod[address.String()]; ok {
 		return true
-	} else if _, ok := subnet.V6IPToPod[address]; ok {
+	} else if _, ok := subnet.V6IPToPod[address.String()]; ok {
 		return true
 	}
 	return false
-}
-
-func (subnet *Subnet) joinFreeWithReserve() {
-	protocol := subnet.Protocol
-	if protocol == kubeovnv1.ProtocolDual || protocol == kubeovnv1.ProtocolIPv4 {
-		for _, reserveIpr := range subnet.V4ReservedIPList {
-			newFreeList := IPRangeList{}
-			for _, freeIpr := range subnet.V4FreeIPList {
-				if iprl := splitRange(freeIpr, reserveIpr); iprl != nil {
-					newFreeList = append(newFreeList, iprl...)
-				}
-			}
-			subnet.V4FreeIPList = newFreeList
-
-			newAvailableList := IPRangeList{}
-			for _, availIpr := range subnet.V4AvailIPList {
-				if iprl := splitRange(availIpr, reserveIpr); iprl != nil {
-					newAvailableList = append(newAvailableList, iprl...)
-				}
-			}
-			subnet.V4AvailIPList = newAvailableList
-		}
-	}
-	if protocol == kubeovnv1.ProtocolDual || protocol == kubeovnv1.ProtocolIPv6 {
-		for _, reserveIpr := range subnet.V6ReservedIPList {
-			newFreeList := IPRangeList{}
-			for _, freeIpr := range subnet.V6FreeIPList {
-				if iprl := splitRange(freeIpr, reserveIpr); iprl != nil {
-					newFreeList = append(newFreeList, iprl...)
-				}
-			}
-			subnet.V6FreeIPList = newFreeList
-
-			newAvailableList := IPRangeList{}
-			for _, availIpr := range subnet.V6AvailIPList {
-				if iprl := splitRange(availIpr, reserveIpr); iprl != nil {
-					newAvailableList = append(newAvailableList, iprl...)
-				}
-			}
-			subnet.V6AvailIPList = newAvailableList
-		}
-	}
 }
 
 // This func is only called in ipam.GetPodAddress, move mutex to caller
 func (subnet *Subnet) GetPodAddress(podName, nicName string) (IP, IP, string, string) {
 	if subnet.Protocol == kubeovnv1.ProtocolIPv4 {
 		ip, mac := subnet.V4NicToIP[nicName], subnet.NicToMac[nicName]
-		return ip, "", mac, kubeovnv1.ProtocolIPv4
+		return ip, nil, mac, kubeovnv1.ProtocolIPv4
 	} else if subnet.Protocol == kubeovnv1.ProtocolIPv6 {
 		ip, mac := subnet.V6NicToIP[nicName], subnet.NicToMac[nicName]
-		return "", ip, mac, kubeovnv1.ProtocolIPv6
+		return nil, ip, mac, kubeovnv1.ProtocolIPv6
 	} else {
 		v4IP, v6IP, mac := subnet.V4NicToIP[nicName], subnet.V6NicToIP[nicName], subnet.NicToMac[nicName]
 		return v4IP, v6IP, mac, kubeovnv1.ProtocolDual
@@ -655,14 +501,14 @@ func (subnet *Subnet) GetPodAddress(podName, nicName string) (IP, IP, string, st
 }
 
 func (subnet *Subnet) isIPAssignedToOtherPod(ip, podName string) (string, bool) {
-	if existPod, ok := subnet.V4IPToPod[IP(ip)]; ok {
+	if existPod, ok := subnet.V4IPToPod[ip]; ok {
 		klog.V(4).Infof("v4 check ip assigned, existPod %s, podName %s", existPod, podName)
 		pods := strings.Split(existPod, ",")
 		if !util.ContainsString(pods, podName) {
 			return existPod, true
 		}
 	}
-	if existPod, ok := subnet.V6IPToPod[IP(ip)]; ok {
+	if existPod, ok := subnet.V6IPToPod[ip]; ok {
 		klog.V(4).Infof("v6 check ip assigned, existPod %s, podName %s", existPod, podName)
 		pods := strings.Split(existPod, ",")
 		if !util.ContainsString(pods, podName) {

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -64,7 +64,7 @@ var _ = Describe("[IPAM]", func() {
 
 				pod1 := "pod1.ns"
 				pod1Nic1 := "pod1nic1.ns"
-				freeIp1 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
+				freeIp1 := im.Subnets[subnetName].V4FreeIPList.At(0).Start().String()
 				ip, _, _, err := im.GetStaticAddress(pod1, pod1Nic1, freeIp1, nil, subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp1))
@@ -78,12 +78,12 @@ var _ = Describe("[IPAM]", func() {
 				pod2Nic1 := "pod2Nic1.ns"
 				pod2Nic2 := "pod2Nic2.ns"
 
-				freeIp2 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
+				freeIp2 := im.Subnets[subnetName].V4FreeIPList.At(0).Start().String()
 				ip, _, _, err = im.GetRandomAddress(pod2, pod2Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp2))
 
-				freeIp3 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
+				freeIp3 := im.Subnets[subnetName].V4FreeIPList.At(0).Start().String()
 				ip, _, _, err = im.GetRandomAddress(pod2, pod2Nic2, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp3))
@@ -112,12 +112,12 @@ var _ = Describe("[IPAM]", func() {
 
 				By("release pod with multiple nics")
 				im.ReleaseAddressByPod(pod2)
-				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp2))).Should(BeTrue())
-				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp3))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.NewIP(freeIp2))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.NewIP(freeIp3))).Should(BeTrue())
 
 				By("release pod with single nic")
 				im.ReleaseAddressByPod(pod1)
-				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp1))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.NewIP(freeIp1))).To(BeTrue())
 
 				By("create new pod with released ips")
 				pod4 := "pod4.ns"
@@ -132,7 +132,6 @@ var _ = Describe("[IPAM]", func() {
 
 				_, _, _, err = im.GetRandomAddress(pod5, pod5Nic1, nil, "invalid_subnet", nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
-
 			})
 
 			It("change cidr", func() {
@@ -213,7 +212,7 @@ var _ = Describe("[IPAM]", func() {
 
 				pod1 := "pod1.ns"
 				pod1Nic1 := "pod1nic1.ns"
-				freeIp1 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
+				freeIp1 := im.Subnets[subnetName].V6FreeIPList.At(0).Start().String()
 				_, ip, _, err := im.GetStaticAddress(pod1, pod1Nic1, freeIp1, nil, subnetName, true)
 
 				Expect(err).ShouldNot(HaveOccurred())
@@ -228,12 +227,12 @@ var _ = Describe("[IPAM]", func() {
 				pod2Nic1 := "pod2Nic1.ns"
 				pod2Nic2 := "pod2Nic2.ns"
 
-				freeIp2 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
+				freeIp2 := im.Subnets[subnetName].V6FreeIPList.At(0).Start().String()
 				_, ip, _, err = im.GetRandomAddress(pod2, pod2Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp2))
 
-				freeIp3 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
+				freeIp3 := im.Subnets[subnetName].V6FreeIPList.At(0).Start().String()
 				_, ip, _, err = im.GetRandomAddress(pod2, pod2Nic2, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal(freeIp3))
@@ -262,12 +261,12 @@ var _ = Describe("[IPAM]", func() {
 
 				By("release pod with multiple nics")
 				im.ReleaseAddressByPod(pod2)
-				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp2))).Should(BeTrue())
-				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp3))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.NewIP(freeIp2))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.NewIP(freeIp3))).Should(BeTrue())
 
 				By("release pod with single nic")
 				im.ReleaseAddressByPod(pod1)
-				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp1))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.NewIP(freeIp1))).Should(BeTrue())
 
 				By("create new pod with released ips")
 				pod4 := "pod4.ns"
@@ -362,8 +361,8 @@ var _ = Describe("[IPAM]", func() {
 
 				pod1 := "pod1.ns"
 				pod1Nic1 := "pod1nic1.ns"
-				freeIp41 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
-				freeIp61 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
+				freeIp41 := im.Subnets[subnetName].V4FreeIPList.At(0).Start().String()
+				freeIp61 := im.Subnets[subnetName].V6FreeIPList.At(0).Start().String()
 				dualIp := fmt.Sprintf("%s,%s", freeIp41, freeIp61)
 				ip4, ip6, _, err := im.GetStaticAddress(pod1, pod1Nic1, dualIp, nil, subnetName, true)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -380,15 +379,15 @@ var _ = Describe("[IPAM]", func() {
 				pod2Nic1 := "pod2Nic1.ns"
 				pod2Nic2 := "pod2Nic2.ns"
 
-				freeIp42 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
-				freeIp62 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
+				freeIp42 := im.Subnets[subnetName].V4FreeIPList.At(0).Start().String()
+				freeIp62 := im.Subnets[subnetName].V6FreeIPList.At(0).Start().String()
 				ip4, ip6, _, err = im.GetRandomAddress(pod2, pod2Nic1, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip4).To(Equal(freeIp42))
 				Expect(ip6).To(Equal(freeIp62))
 
-				freeIp43 := string(im.Subnets[subnetName].V4FreeIPList[0].Start)
-				freeIp63 := string(im.Subnets[subnetName].V6FreeIPList[0].Start)
+				freeIp43 := im.Subnets[subnetName].V4FreeIPList.At(0).Start().String()
+				freeIp63 := im.Subnets[subnetName].V6FreeIPList.At(0).Start().String()
 				ip4, ip6, _, err = im.GetRandomAddress(pod2, pod2Nic2, nil, subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip4).To(Equal(freeIp43))
@@ -430,15 +429,15 @@ var _ = Describe("[IPAM]", func() {
 
 				By("release pod with multiple nics")
 				im.ReleaseAddressByPod(pod2)
-				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp42))).Should(BeTrue())
-				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp43))).Should(BeTrue())
-				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp62))).Should(BeTrue())
-				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp63))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.NewIP(freeIp42))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.NewIP(freeIp43))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.NewIP(freeIp62))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.NewIP(freeIp63))).Should(BeTrue())
 
 				By("release pod with single nic")
 				im.ReleaseAddressByPod(pod1)
-				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp41))).Should(BeTrue())
-				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp61))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.NewIP(freeIp41))).Should(BeTrue())
+				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.NewIP(freeIp61))).Should(BeTrue())
 
 				By("create new pod with released ips")
 				pod4 := "pod4.ns"
@@ -517,8 +516,8 @@ var _ = Describe("[IPAM]", func() {
 
 	Describe("[IP]", func() {
 		It("IPv4 operation", func() {
-			ip1 := ipam.IP("10.0.0.16")
-			ip2 := ipam.IP("10.0.0.17")
+			ip1 := ipam.NewIP("10.0.0.16")
+			ip2 := ipam.NewIP("10.0.0.17")
 
 			Expect(ip1.Equal(ip1)).To(BeTrue())
 			Expect(ip1.GreaterThan(ip1)).To(BeFalse())
@@ -533,17 +532,17 @@ var _ = Describe("[IPAM]", func() {
 			Expect(ip1.Sub(-1)).To(Equal(ip2))
 			Expect(ip2.Sub(1)).To(Equal(ip1))
 
-			ipr := ipam.IPRange{Start: "10.0.0.1", End: "10.0.0.254"}
-			Expect(ipr.IPExist(ip1)).To(BeTrue())
-			Expect(ipr.IPExist(ip2)).To(BeTrue())
+			ipr := ipam.NewIPRange(ipam.NewIP("10.0.0.1"), ipam.NewIP("10.0.0.254"))
+			Expect(ipr.Contains(ip1)).To(BeTrue())
+			Expect(ipr.Contains(ip2)).To(BeTrue())
 
-			iprList := ipam.IPRangeList{&ipr}
+			iprList := ipam.NewIPRangeListFrom(fmt.Sprintf("%s..%s", ipr.Start(), ipr.End()))
 			Expect(iprList.Contains(ip1)).To(BeTrue())
 		})
 
 		It("IPv6 operation", func() {
-			ip1 := ipam.IP("fd00::16")
-			ip2 := ipam.IP("fd00::17")
+			ip1 := ipam.NewIP("fd00::16")
+			ip2 := ipam.NewIP("fd00::17")
 
 			Expect(ip1.Equal(ip1)).To(BeTrue())
 			Expect(ip1.GreaterThan(ip1)).To(BeFalse())
@@ -558,11 +557,11 @@ var _ = Describe("[IPAM]", func() {
 			Expect(ip1.Sub(-1)).To(Equal(ip2))
 			Expect(ip2.Sub(1)).To(Equal(ip1))
 
-			ipr := ipam.IPRange{Start: "fd00::01", End: "fd00::ff"}
-			Expect(ipr.IPExist(ip1)).To(BeTrue())
-			Expect(ipr.IPExist(ip2)).To(BeTrue())
+			ipr := ipam.NewIPRange(ipam.NewIP("fd00::01"), ipam.NewIP("fd00::ff"))
+			Expect(ipr.Contains(ip1)).To(BeTrue())
+			Expect(ipr.Contains(ip2)).To(BeTrue())
 
-			iprList := ipam.IPRangeList{&ipr}
+			iprList := ipam.NewIPRangeListFrom(fmt.Sprintf("%s..%s", ipr.Start(), ipr.End()))
 			Expect(iprList.Contains(ip1)).To(BeTrue())
 		})
 	})
@@ -573,14 +572,15 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, ipv4CIDR, ipv4ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.Name).To(Equal(subnetName))
-				Expect(subnet.V4ReservedIPList).To(HaveLen(len(ipv4ExcludeIPs) - 1))
-				Expect(subnet.V4FreeIPList).To(HaveLen(3))
+				Expect(subnet.V4ReservedIPList.Len()).To(Equal(len(ipv4ExcludeIPs) - 2))
+				Expect(subnet.V4FreeIPList.Len()).To(Equal(3))
 				Expect(subnet.V4FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "10.16.0.2", End: "10.16.0.3"},
-						&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
-						&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"10.16.0.2..10.16.0.3",
+						"10.16.0.5..10.16.0.9",
+						"10.16.0.24..10.16.255.254",
+					),
+				))
 			})
 
 			It("static allocation", func() {
@@ -591,46 +591,48 @@ var _ = Describe("[IPAM]", func() {
 				pod1Nic1 := "pod1Nic1.ns"
 				pod1Nic1mac := util.GenerateMac()
 
-				_, _, err = subnet.GetStaticAddress(pod1, pod1Nic1, "10.16.0.2", &pod1Nic1mac, false, true)
+				_, _, err = subnet.GetStaticAddress(pod1, pod1Nic1, ipam.NewIP("10.16.0.2"), &pod1Nic1mac, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod2 := "pod2.ns"
 				pod2Nic1 := "pod2Nic1"
-				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic1, "10.16.0.3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic1, ipam.NewIP("10.16.0.3"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod2Nic2 := "pod2Nic2"
-				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic2, "10.16.0.20", nil, false, true)
+				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic2, ipam.NewIP("10.16.0.20"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.V4FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
-						&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"10.16.0.5..10.16.0.9",
+						"10.16.0.24..10.16.255.254",
+					),
+				))
 
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), pod1))
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.3"), pod2))
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.20"), pod2))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue(pod1Nic1, ipam.IP("10.16.0.2")))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue(pod2Nic1, ipam.IP("10.16.0.3")))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue(pod2Nic2, ipam.IP("10.16.0.20")))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.2", pod1))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.3", pod2))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.20", pod2))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue(pod1Nic1, ipam.NewIP("10.16.0.2")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue(pod2Nic1, ipam.NewIP("10.16.0.3")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue(pod2Nic2, ipam.NewIP("10.16.0.20")))
 				Expect(subnet.NicToMac).To(HaveKeyWithValue(pod1Nic1, pod1Nic1mac))
 				Expect(subnet.MacToPod).To(HaveKeyWithValue(pod1Nic1mac, pod1))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "10.16.0.3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", ipam.NewIP("10.16.0.3"), nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "19.16.0.3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", ipam.NewIP("19.16.0.3"), nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
-				_, _, err = subnet.GetStaticAddress("pod6.ns", "pod5.ns", "10.16.0.121", &pod1Nic1mac, false, true)
+				_, _, err = subnet.GetStaticAddress("pod6.ns", "pod5.ns", ipam.NewIP("10.16.0.121"), &pod1Nic1mac, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				subnet.ReleaseAddress(pod1)
 				subnet.ReleaseAddress(pod2)
 				Expect(subnet.V4FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
-						&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"10.16.0.5..10.16.0.9",
+						"10.16.0.24..10.16.255.254",
+					),
+				))
 
 				Expect(subnet.V4NicToIP).To(BeEmpty())
 				Expect(subnet.V4IPToPod).To(BeEmpty())
@@ -642,28 +644,32 @@ var _ = Describe("[IPAM]", func() {
 
 				ip1, _, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
+				Expect(ip1.String()).To(Equal("10.16.0.1"))
 				ip1, _, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
+				Expect(ip1.String()).To(Equal("10.16.0.1"))
 
 				ip2, _, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ip2).To(Equal(ipam.IP("10.16.0.2")))
+				Expect(ip2.String()).To(Equal("10.16.0.2"))
 
 				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
-				Expect(subnet.V4FreeIPList).To(BeEmpty())
+				Expect(subnet.V4FreeIPList.Len()).To(Equal(0))
 
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.1"), "pod1.ns"))
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod2.ns"))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.1")))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.2")))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.1", "pod1.ns"))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.2", "pod2.ns"))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.NewIP("10.16.0.1")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.NewIP("10.16.0.2")))
 
 				subnet.ReleaseAddress("pod1.ns")
 				subnet.ReleaseAddress("pod2.ns")
-				Expect(subnet.V4FreeIPList).To(Equal(ipam.IPRangeList{}))
-				Expect(subnet.V4ReleasedIPList).To(Equal(ipam.IPRangeList{&ipam.IPRange{Start: "10.16.0.1", End: "10.16.0.2"}}))
+				Expect(subnet.V4FreeIPList.Len()).To(Equal(0))
+				Expect(subnet.V4ReleasedIPList).To(Equal(
+					ipam.NewIPRangeListFrom(
+						"10.16.0.1..10.16.0.2",
+					),
+				))
 				Expect(subnet.V4IPToPod).To(BeEmpty())
 				Expect(subnet.V4NicToIP).To(BeEmpty())
 			})
@@ -674,14 +680,15 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, ipv6CIDR, ipv6ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.Name).To(Equal(subnetName))
-				Expect(subnet.V6ReservedIPList).To(HaveLen(len(ipv6ExcludeIPs) - 1))
-				Expect(subnet.V6FreeIPList).To(HaveLen(3))
+				Expect(subnet.V6ReservedIPList.Len()).To(Equal(len(ipv6ExcludeIPs) - 2))
+				Expect(subnet.V6FreeIPList.Len()).To(Equal(3))
 				Expect(subnet.V6FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "fd00::2", End: "fd00::3"},
-						&ipam.IPRange{Start: "fd00::5", End: "fd00::9"},
-						&ipam.IPRange{Start: "fd00::18", End: "fd00::fffe"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"fd00::2..fd00::3",
+						"fd00::5..fd00::9",
+						"fd00::18..fd00::fffe",
+					),
+				))
 			})
 
 			It("static allocation", func() {
@@ -692,47 +699,49 @@ var _ = Describe("[IPAM]", func() {
 				pod1Nic1 := "pod1Nic1.ns"
 				pod1Nic1mac := util.GenerateMac()
 
-				_, _, err = subnet.GetStaticAddress(pod1, pod1Nic1, "fd00::2", &pod1Nic1mac, false, true)
+				_, _, err = subnet.GetStaticAddress(pod1, pod1Nic1, ipam.NewIP("fd00::2"), &pod1Nic1mac, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod2 := "pod2.ns"
 				pod2Nic1 := "pod2Nic1.ns"
 
-				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic1, "fd00::3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic1, ipam.NewIP("fd00::3"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod2Nic2 := "pod2Nic2.ns"
-				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic2, "fd00::14", nil, false, true)
+				_, _, err = subnet.GetStaticAddress(pod2, pod2Nic2, ipam.NewIP("fd00::14"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.V6FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "fd00::5", End: "fd00::9"},
-						&ipam.IPRange{Start: "fd00::18", End: "fd00::fffe"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"fd00::5..fd00::9",
+						"fd00::18..fd00::fffe",
+					),
+				))
 
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::2"), pod1))
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::3"), pod2))
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::14"), pod2))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue(pod1Nic1, ipam.IP("fd00::2")))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue(pod2Nic1, ipam.IP("fd00::3")))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue(pod2Nic2, ipam.IP("fd00::14")))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::2", pod1))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::3", pod2))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::14", pod2))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue(pod1Nic1, ipam.NewIP("fd00::2")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue(pod2Nic1, ipam.NewIP("fd00::3")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue(pod2Nic2, ipam.NewIP("fd00::14")))
 				Expect(subnet.NicToMac).To(HaveKeyWithValue(pod1Nic1, pod1Nic1mac))
 				Expect(subnet.MacToPod).To(HaveKeyWithValue(pod1Nic1mac, pod1))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "fd00::3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", ipam.NewIP("fd00::3"), nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "fe00::3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", ipam.NewIP("fe00::3"), nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
-				_, _, err = subnet.GetStaticAddress("pod6.ns", "pod5.ns", "fd00::f9", &pod1Nic1mac, false, true)
+				_, _, err = subnet.GetStaticAddress("pod6.ns", "pod5.ns", ipam.NewIP("fd00::f9"), &pod1Nic1mac, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				subnet.ReleaseAddress(pod1)
 				subnet.ReleaseAddress(pod2)
 				Expect(subnet.V6FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "fd00::5", End: "fd00::9"},
-						&ipam.IPRange{Start: "fd00::18", End: "fd00::fffe"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"fd00::5..fd00::9",
+						"fd00::18..fd00::fffe",
+					),
+				))
 
 				Expect(subnet.V6NicToIP).To(BeEmpty())
 				Expect(subnet.V6IPToPod).To(BeEmpty())
@@ -744,28 +753,32 @@ var _ = Describe("[IPAM]", func() {
 
 				_, ip1, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ip1).To(Equal(ipam.IP("fd00::1")))
+				Expect(ip1.String()).To(Equal("fd00::1"))
 				_, ip1, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ip1).To(Equal(ipam.IP("fd00::1")))
+				Expect(ip1.String()).To(Equal("fd00::1"))
 
 				_, ip2, _, err := subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ip2).To(Equal(ipam.IP("fd00::2")))
+				Expect(ip2.String()).To(Equal("fd00::2"))
 
 				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
-				Expect(subnet.V6FreeIPList).To(BeEmpty())
+				Expect(subnet.V6FreeIPList.Len()).To(Equal(0))
 
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::1"), "pod1.ns"))
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::2"), "pod2.ns"))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::1")))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::2")))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::1", "pod1.ns"))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::2", "pod2.ns"))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.NewIP("fd00::1")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.NewIP("fd00::2")))
 
 				subnet.ReleaseAddress("pod1.ns")
 				subnet.ReleaseAddress("pod2.ns")
-				Expect(subnet.V6FreeIPList).To(Equal(ipam.IPRangeList{}))
-				Expect(subnet.V6ReleasedIPList).To(Equal(ipam.IPRangeList{&ipam.IPRange{Start: "fd00::1", End: "fd00::2"}}))
+				Expect(subnet.V6FreeIPList.Len()).To(Equal(0))
+				Expect(subnet.V6ReleasedIPList).To(Equal(
+					ipam.NewIPRangeListFrom(
+						"fd00::1..fd00::2",
+					),
+				))
 				Expect(subnet.V6IPToPod).To(BeEmpty())
 				Expect(subnet.V6NicToIP).To(BeEmpty())
 			})
@@ -776,86 +789,92 @@ var _ = Describe("[IPAM]", func() {
 				subnet, err := ipam.NewSubnet(subnetName, dualCIDR, dualExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(subnet.Name).To(Equal(subnetName))
-				Expect(subnet.V4ReservedIPList).To(HaveLen(len(ipv4ExcludeIPs) - 1))
-				Expect(subnet.V4FreeIPList).To(HaveLen(3))
+				Expect(subnet.V4ReservedIPList.Len()).To(Equal(len(ipv4ExcludeIPs) - 2))
+				Expect(subnet.V4FreeIPList.Len()).To(Equal(3))
 				Expect(subnet.V4FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "10.16.0.2", End: "10.16.0.3"},
-						&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
-						&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
-					}))
-				Expect(subnet.V6ReservedIPList).To(HaveLen(len(ipv6ExcludeIPs) - 1))
-				Expect(subnet.V6FreeIPList).To(HaveLen(3))
+					ipam.NewIPRangeListFrom(
+						"10.16.0.2..10.16.0.3",
+						"10.16.0.5..10.16.0.9",
+						"10.16.0.24..10.16.255.254",
+					),
+				))
+				Expect(subnet.V6ReservedIPList.Len()).To(Equal(len(ipv6ExcludeIPs) - 2))
+				Expect(subnet.V6FreeIPList.Len()).To(Equal(3))
 				Expect(subnet.V6FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "fd00::2", End: "fd00::3"},
-						&ipam.IPRange{Start: "fd00::5", End: "fd00::9"},
-						&ipam.IPRange{Start: "fd00::18", End: "fd00::fffe"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"fd00::2..fd00::3",
+						"fd00::5..fd00::9",
+						"fd00::18..fd00::fffe",
+					),
+				))
 			})
 
 			It("static allocation", func() {
 				subnet, err := ipam.NewSubnet(subnetName, dualCIDR, dualExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "10.16.0.2", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", ipam.NewIP("10.16.0.2"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", "fd00::2", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod1.ns", ipam.NewIP("fd00::2"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "10.16.0.3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", ipam.NewIP("10.16.0.3"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", "fd00::3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod2.ns", "pod2.ns", ipam.NewIP("fd00::3"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "10.16.0.20", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", ipam.NewIP("10.16.0.20"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", "fd00::14", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod3.ns", "pod3.ns", ipam.NewIP("fd00::14"), nil, false, true)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				Expect(subnet.V4FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
-						&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"10.16.0.5..10.16.0.9",
+						"10.16.0.24..10.16.255.254",
+					),
+				))
 				Expect(subnet.V6FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "fd00::5", End: "fd00::9"},
-						&ipam.IPRange{Start: "fd00::18", End: "fd00::fffe"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"fd00::5..fd00::9",
+						"fd00::18..fd00::fffe",
+					),
+				))
 
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod1.ns"))
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.3"), "pod2.ns"))
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.20"), "pod3.ns"))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.2")))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.3")))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("10.16.0.20")))
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::2"), "pod1.ns"))
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::3"), "pod2.ns"))
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::14"), "pod3.ns"))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::2")))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::3")))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("fd00::14")))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.2", "pod1.ns"))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.3", "pod2.ns"))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.20", "pod3.ns"))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.NewIP("10.16.0.2")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.NewIP("10.16.0.3")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.NewIP("10.16.0.20")))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::2", "pod1.ns"))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::3", "pod2.ns"))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::14", "pod3.ns"))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.NewIP("fd00::2")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.NewIP("fd00::3")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod3.ns", ipam.NewIP("fd00::14")))
 
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "10.16.0.3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", ipam.NewIP("10.16.0.3"), nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", "fd00::3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod4.ns", "pod4.ns", ipam.NewIP("fd00::3"), nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrConflict))
-				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", "19.16.0.3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod5.ns", "pod5.ns", ipam.NewIP("19.16.0.3"), nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
-				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod5.ns", "fe00::3", nil, false, true)
+				_, _, err = subnet.GetStaticAddress("pod1.ns", "pod5.ns", ipam.NewIP("fe00::3"), nil, false, true)
 				Expect(err).Should(MatchError(ipam.ErrOutOfRange))
 
 				subnet.ReleaseAddress("pod1.ns")
 				subnet.ReleaseAddress("pod2.ns")
 				subnet.ReleaseAddress("pod3.ns")
 				Expect(subnet.V4FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
-						&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"10.16.0.5..10.16.0.9",
+						"10.16.0.24..10.16.255.254",
+					),
+				))
 				Expect(subnet.V6FreeIPList).To(Equal(
-					ipam.IPRangeList{
-						&ipam.IPRange{Start: "fd00::5", End: "fd00::9"},
-						&ipam.IPRange{Start: "fd00::18", End: "fd00::fffe"},
-					}))
+					ipam.NewIPRangeListFrom(
+						"fd00::5..fd00::9",
+						"fd00::18..fd00::fffe",
+					),
+				))
 
 				Expect(subnet.V4NicToIP).To(BeEmpty())
 				Expect(subnet.V4IPToPod).To(BeEmpty())
@@ -869,38 +888,46 @@ var _ = Describe("[IPAM]", func() {
 
 				ipv4, ipv6, _, err := subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ipv4).To(Equal(ipam.IP("10.16.0.1")))
-				Expect(ipv6).To(Equal(ipam.IP("fd00::1")))
+				Expect(ipv4.String()).To(Equal("10.16.0.1"))
+				Expect(ipv6.String()).To(Equal("fd00::1"))
 				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod1.ns", "pod1.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ipv4).To(Equal(ipam.IP("10.16.0.1")))
-				Expect(ipv6).To(Equal(ipam.IP("fd00::1")))
+				Expect(ipv4.String()).To(Equal("10.16.0.1"))
+				Expect(ipv6.String()).To(Equal("fd00::1"))
 
 				ipv4, ipv6, _, err = subnet.GetRandomAddress("pod2.ns", "pod2.ns", nil, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(ipv4).To(Equal(ipam.IP("10.16.0.2")))
-				Expect(ipv6).To(Equal(ipam.IP("fd00::2")))
+				Expect(ipv4.String()).To(Equal("10.16.0.2"))
+				Expect(ipv6.String()).To(Equal("fd00::2"))
 
 				_, _, _, err = subnet.GetRandomAddress("pod3.ns", "pod3.ns", nil, nil, true)
 				Expect(err).Should(MatchError(ipam.ErrNoAvailable))
-				Expect(subnet.V4FreeIPList).To(BeEmpty())
-				Expect(subnet.V6FreeIPList).To(BeEmpty())
+				Expect(subnet.V4FreeIPList.Len()).To(Equal(0))
+				Expect(subnet.V6FreeIPList.Len()).To(Equal(0))
 
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.1"), "pod1.ns"))
-				Expect(subnet.V4IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod2.ns"))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.1")))
-				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.2")))
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::1"), "pod1.ns"))
-				Expect(subnet.V6IPToPod).To(HaveKeyWithValue(ipam.IP("fd00::2"), "pod2.ns"))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("fd00::1")))
-				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("fd00::2")))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.1", "pod1.ns"))
+				Expect(subnet.V4IPToPod).To(HaveKeyWithValue("10.16.0.2", "pod2.ns"))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.NewIP("10.16.0.1")))
+				Expect(subnet.V4NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.NewIP("10.16.0.2")))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::1", "pod1.ns"))
+				Expect(subnet.V6IPToPod).To(HaveKeyWithValue("fd00::2", "pod2.ns"))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod1.ns", ipam.NewIP("fd00::1")))
+				Expect(subnet.V6NicToIP).To(HaveKeyWithValue("pod2.ns", ipam.NewIP("fd00::2")))
 
 				subnet.ReleaseAddress("pod1.ns")
 				subnet.ReleaseAddress("pod2.ns")
-				Expect(subnet.V4FreeIPList).To(Equal(ipam.IPRangeList{}))
-				Expect(subnet.V4ReleasedIPList).To(Equal(ipam.IPRangeList{&ipam.IPRange{Start: "10.16.0.1", End: "10.16.0.2"}}))
-				Expect(subnet.V6FreeIPList).To(Equal(ipam.IPRangeList{}))
-				Expect(subnet.V6ReleasedIPList).To(Equal(ipam.IPRangeList{&ipam.IPRange{Start: "fd00::1", End: "fd00::2"}}))
+				Expect(subnet.V4FreeIPList.Len()).To(Equal(0))
+				Expect(subnet.V4ReleasedIPList).To(Equal(
+					ipam.NewIPRangeListFrom(
+						"10.16.0.1..10.16.0.2",
+					),
+				))
+				Expect(subnet.V6FreeIPList.Len()).To(Equal(0))
+				Expect(subnet.V6ReleasedIPList).To(Equal(
+					ipam.NewIPRangeListFrom(
+						"fd00::1..fd00::2",
+					),
+				))
 				Expect(subnet.V4IPToPod).To(BeEmpty())
 				Expect(subnet.V4NicToIP).To(BeEmpty())
 				Expect(subnet.V6IPToPod).To(BeEmpty())


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91f76ed</samp>

This pull request refactors the ipam package and its related code in the controller and test packages to use new types and methods for IP ranges and lists. This improves the performance, readability, and consistency of the code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 91f76ed</samp>

> _Sing, O Muse, of the mighty deeds of the ipam package_
> _That refines and restructures the logic of IP ranges_
> _With the help of the net package, the skilled and cunning helper_
> _And the new types and methods, the swift and graceful shapers_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91f76ed</samp>

*  Encapsulate the IPRange logic and operations in a separate file and type `pkg/ipam/ip_range.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-1c2f1d8dbe53e5fb98e206fff2652bb8d264a5e137b1254e66edf4a10d393ec4R1-R76))
*  Encapsulate the IPRangeList logic and operations in a separate file and type `pkg/ipam/ip_range_list.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de9c95dea5718bdd4ec0189b24b681ecaf21caf346ac1e724b2dc4458f38c172R1-R251))
*  Use the net package to parse and format IP addresses in `pkg/ipam/ip.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-c7538ef199b0341d14000955343b6a1a87225a354a5a750ffd44af3856f31f22L4-R36))
*  Use the fmt package to format strings in `pkg/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05R5))
*  Use the new IPRangeList constructor to create IPRangeList objects from slices of strings, and avoid calling the same function twice in `pkg/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L159-R175), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L179-R194))
*  Use the new IPRangeList method to format the IPRangeList as a string, and move the logging statement after the condition check in `pkg/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L280-R285))
*  Replace the use of map[string]ipam.IPRange with map[string]*ipam.IPRange, and use constructors to ensure the validity of the IPRange and IP values in `pkg/controller/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2042-R2063))
*  Replace the use of ipam.IPRange with *ipam.IPRange as the value type of the mapIps and newMap variables, and pass the pointer to the filterRepeatIPRange function in `pkg/controller/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2075-R2070), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2082-R2097))
*  Use methods to access the IPRange fields instead of direct access in `pkg/controller/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2082-R2097))
*  Use the new IPRangeList and IPRange methods instead of direct access and len function in `test/unittest/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L67-R67), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L81-R86), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L216-R215), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L231-R235), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L383-R383), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L390-R390), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L594-R610), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L620-R625), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L630-R635), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L677-R691), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L695-R702), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L701-R719), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L722-R734), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L732-R744), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L758-R767), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L767-R781), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L779-R809), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L800-R839), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L837-R860), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L850-R877), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L886-R906), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L900-R930))
*  Use the new IP constructor to create IP objects, and use the new IP methods to compare IP objects instead of strings in `test/unittest/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L120-R120), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L365-R365), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L536-R539), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L561-R564), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L656-R658), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L665-R672))
*  Use the new IPRange constructor to create IPRange objects, and use the new IPRange method to check if an IP is in an IPRange instead of the IP method in `test/unittest/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L576-R583))
*  Use the consistent assertion style with To instead of ShouldNot in `test/unittest/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L120-R120), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L365-R365), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L656-R658), [link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L665-R672))
*  Remove an empty line in `test/unittest/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2896/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L135))