### PR TITLE
do not install normal ovs-ovn as dpdk is enabled

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3890,9 +3890,8 @@ spec:
             optional: true
             secretName: kube-ovn-tls
 EOF
-fi
-
 kubectl apply -f ovs-ovn-ds.yaml
+fi
 
 if $HYBRID_DPDK; then
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes


### Which issue(s) this PR fixes:
Fixes #2898 

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough