### PR TITLE
add kubectl ko perf test

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -109,6 +109,21 @@ func CmdMain() {
 			}
 		}
 	}
+
+	go func() {
+		connListenaddr := fmt.Sprintf("%s:%d", addr, config.TCPConnCheckPort)
+		if err := util.TCPConnectivityListen(connListenaddr); err != nil {
+			util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
+		}
+	}()
+
+	go func() {
+		connListenaddr := fmt.Sprintf("%s:%d", addr, config.UDPConnCheckPort)
+		if err := util.UDPConnectivityListen(connListenaddr); err != nil {
+			util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
+		}
+	}()
+
 	// conform to Gosec G114
 	// https://github.com/securego/gosec#available-rules
 	server := &http.Server{

--- a/cmd/pinger/pinger.go
+++ b/cmd/pinger/pinger.go
@@ -37,6 +37,20 @@ func CmdMain() {
 			util.LogFatalAndExit(server.ListenAndServe(), "failed to listen and serve on %s", server.Addr)
 		}()
 	}
+	go func() {
+		addr := fmt.Sprintf("0.0.0.0:%d", config.TCPConnCheckPort)
+		if err := util.TCPConnectivityListen(addr); err != nil {
+			util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
+		}
+	}()
+
+	go func() {
+		addr := fmt.Sprintf("0.0.0.0:%d", config.UDPConnCheckPort)
+		if err := util.UDPConnectivityListen(addr); err != nil {
+			util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
+		}
+	}()
+
 	e := pinger.NewExporter(config)
 	pinger.StartPinger(config, e)
 }

--- a/cmd/pinger/pinger.go
+++ b/cmd/pinger/pinger.go
@@ -36,21 +36,21 @@ func CmdMain() {
 			}
 			util.LogFatalAndExit(server.ListenAndServe(), "failed to listen and serve on %s", server.Addr)
 		}()
+
+		go func() {
+			addr := fmt.Sprintf("0.0.0.0:%d", config.TCPConnCheckPort)
+			if err := util.TCPConnectivityListen(addr); err != nil {
+				util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
+			}
+		}()
+
+		go func() {
+			addr := fmt.Sprintf("0.0.0.0:%d", config.UDPConnCheckPort)
+			if err := util.UDPConnectivityListen(addr); err != nil {
+				util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
+			}
+		}()
 	}
-	go func() {
-		addr := fmt.Sprintf("0.0.0.0:%d", config.TCPConnCheckPort)
-		if err := util.TCPConnectivityListen(addr); err != nil {
-			util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
-		}
-	}()
-
-	go func() {
-		addr := fmt.Sprintf("0.0.0.0:%d", config.UDPConnCheckPort)
-		if err := util.UDPConnectivityListen(addr); err != nil {
-			util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
-		}
-	}()
-
 	e := pinger.NewExporter(config)
 	pinger.StartPinger(config, e)
 }

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -5,6 +5,7 @@ KUBE_OVN_NS=kube-system
 WITHOUT_KUBE_PROXY=${WITHOUT_KUBE_PROXY:-false}
 OVN_NB_POD=
 OVN_SB_POD=
+OVN_NORTHD_POD=
 KUBE_OVN_VERSION=
 REGISTRY="kubeovn"
 
@@ -599,6 +600,12 @@ getOvnCentralPod(){
       exit 1
     fi
     OVN_SB_POD=$SB_POD
+    NORTHD_POD=$(kubectl get pod -n kube-system -l ovn-northd-leader=true | grep ovn-central | head -n 1 | awk '{print $1}')
+    if [ -z "$NORTHD_POD" ]; then
+      echo "ovn northd not exists"
+      exit 1
+    fi
+    OVN_NORTHD_POD=$NORTHD_POD
     image=$(kubectl  -n kube-system get pods -l app=kube-ovn-cni -o jsonpath='{.items[0].spec.containers[0].image}')
     if [ -z "$image" ]; then
           echo "cannot get kube-ovn image"
@@ -1082,6 +1089,171 @@ log(){
   echo "Collected files have been saved in the directory $PWD/kubectl-ko-log "
 }
 
+perfTimes=5
+
+perf(){
+  curl -O https://raw.githubusercontent.com/kubeovn/kube-ovn/master/test/server/test-server.yaml
+
+  nodes=($(kubectl get node --no-headers -o custom-columns=NAME:.metadata.name))
+  if [[ ${#nodes} = 1 ]]; then
+    sed -i "s/kube-ovn-control-plane/${nodes[0]}/g" test-server.yaml
+    sed -i "s/kube-ovn-worker/${nodes[0]}/g" test-server.yaml
+  elif [[ ${#nodes} -le 0 ]]; then
+    echo "can't find node in the cluster"
+    return
+  elif [[ ${#nodes} -ge 2 ]]; then
+    sed -i "s/kube-ovn-control-plane/${nodes[0]}/g" test-server.yaml
+    sed -i "s/kube-ovn-worker/${nodes[1]}/g" test-server.yaml
+  fi
+
+  kubectl apply -f test-server.yaml
+
+  isfailed=true
+  for i in {0..59}
+  do
+    clientPod=$(kubectl get pod test-client | awk '{if($2=="1/1" && $3=="Running") print $1}')
+    serverPod=$(kubectl get pod test-server | awk '{if($2=="1/1" && $3=="Running") print $1}')
+    hostServerPod=$(kubectl get pod test-host-server | awk '{if($2=="1/1" && $3=="Running") print $1}')
+
+    if [[ $clientPod = "test-client" ]] && [[ $serverPod = "test-server" ]] && [[ $hostServerPod = "test-host-server" ]] ; then
+      echo "test pods all ready"
+      isfailed=false
+      break
+    fi
+    sleep 1
+  done
+  if $isfailed; then
+    echo "Error test pod not ready"
+    return
+  fi
+
+  local serverIP=$(kubectl get pod test-server -o jsonpath={.status.podIP})
+  local hostserverIP=$(kubectl get pod test-host-server -o jsonpath={.status.podIP})
+
+  echo "Start doing pod network performance"
+  unicast_perf_test $serverIP
+
+  echo "Start doing host network performance"
+  unicast_perf_test $hostserverIP
+
+  echo "Start doing pod multicast network performance"
+  multicast_perf_test
+
+  echo "Start doing leader recover time test"
+  check_leader_recover
+
+  rm test-server.yaml
+
+}
+
+unicast_perf_test() {
+
+  serverIP=$1
+  echo "=================================== unicast perfromance test ============================================================="
+  printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "Size" "TCP Latency" "TCP Bandwidth" "UDP Latency" "UDP Lost Rate" "UDP Bandwidth"
+  for size in "64" "1k" "4k"
+  do
+    output=$(kubectl exec test-client -- qperf -t $perfTimes $serverIP -ub -oo msg_size:$size -vu tcp_lat udp_lat 2>&1)
+
+    tcp_lat="$(echo $output | grep -oP 'tcp_lat: latency = \K[\d.]+ us')"
+    udp_lat="$(echo $output | grep -oP 'udp_lat: latency = \K[\d.]+ us')"
+
+    kubectl exec test-client -- iperf3 -c $serverIP -u -t $perfTimes -i 1 -P 10 -b 1000G -l $size > temp_perf_result.log 2> /dev/null
+    udp_bw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+    udp_lost_rate=$(cat temp_perf_result.log | grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
+
+    kubectl exec test-client -- iperf3 -c $serverIP -t $perfTimes -i 1 -P 10 -l $size > temp_perf_result.log 2> /dev/null
+    tcp_bw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+
+    printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "$size" "$tcp_lat" "$tcp_bw" "$udp_lat" "$udp_lost_rate" "$udp_bw"
+  done
+  echo "========================================================================================================================="
+  rm temp_perf_result.log
+}
+
+multicast_perf_test() {
+  clientNode=$(kubectl get pod test-client -o jsonpath={.spec.nodeName})
+  serverNode=$(kubectl get pod test-server -o jsonpath={.spec.nodeName})
+
+  clientNs=$(kubectl ko vsctl $clientNode --column=external_ids find interface external_ids:iface-id=test-client.default | awk -F 'pod_netns=' '{print $2}' | grep -o 'cni-[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')
+  serverNs=$(kubectl ko vsctl $serverNode --column=external_ids find interface external_ids:iface-id=test-server.default | awk -F 'pod_netns=' '{print $2}' | grep -o 'cni-[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')
+
+  clientovsPod=$(kubectl get pod -owide -A |grep ovs-ovn | grep $clientNode | awk '{print $2}')
+  kubectl exec $clientovsPod -n kube-system -- ip netns exec $clientNs ip maddr add 01:00:5e:00:00:64 dev eth0
+
+  serverovsPod=$(kubectl get pod -owide -A |grep ovs-ovn | grep $serverNode | awk '{print $2}')
+  kubectl exec $serverovsPod -n kube-system -- ip netns exec $serverNs ip maddr add 01:00:5e:00:00:64 dev eth0
+
+  gen_multicast_perf_result test-server
+
+  kubectl exec $clientovsPod -n kube-system -- ip netns exec $clientNs ip maddr del 01:00:5e:00:00:64 dev eth0
+  kubectl exec $serverovsPod -n kube-system -- ip netns exec $serverNs ip maddr del 01:00:5e:00:00:64 dev eth0
+}
+
+gen_multicast_perf_result() {
+  serverName=$1
+
+  start_server_cmd="iperf -s -B 224.0.0.100 -i 1 -u"
+  kubectl exec $serverName -- $start_server_cmd > $serverName.log &
+
+  echo "=================================== multicast perfromance test ========================================================="
+  printf "%-15s %-15s %-15s %-15s\n" "Size" "UDP Latency" "UDP Lost Rate" "UDP Bandwidth"
+  for size in "64" "1k" "4k"
+  do
+    kubectl exec test-client -- iperf -c 224.0.0.100 -u -T 32 -t $perfTimes -i 1 -b 1000G -l $size > /dev/null
+    udp_bw=$(cat $serverName.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+    udp_lost_rate=$(cat $serverName.log |grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
+    kubectl exec test-client -- iperf -c 224.0.0.100 -u -T 32 -t $perfTimes -i 1 -l $size > /dev/null
+    udp_lat=$(cat  $serverName.log | grep -oP '\d+\.?\d* ms' | tail -n 1)
+    printf "%-15s %-15s %-15s %-15s\n" "$size" "$udp_lat" "$udp_lost_rate" "$udp_bw"
+  done
+
+  echo "========================================================================================================================="
+
+  pids=($(ps -ef | grep "$start_server_cmd" | grep -v grep | awk '{print $2}'))
+  kill ${pids[1]}
+
+  rm $serverName.log
+}
+
+check_leader_recover() {
+  getOvnCentralPod
+  getPodRecoverTime "nb"
+  sleep 5
+  getOvnCentralPod
+  getPodRecoverTime "sb"
+  sleep 5
+  getOvnCentralPod
+  getPodRecoverTime "northd"
+
+}
+
+getPodRecoverTime(){
+  component_name=$1
+  start_time=$(date +%s.%N)
+  echo "Delete ovn central $component_name pod"
+  if [[ $component_name == "nb" ]]; then
+    kubectl delete pod $OVN_NB_POD -n kube-system
+  elif [[ $component_name == "sb" ]]; then
+    kubectl delete pod $OVN_SB_POD -n kube-system
+  elif [[ $component_name == "northd" ]]; then
+    kubectl delete pod $OVN_NORTHD_POD -n kube-system
+  fi
+  echo "Waiting for ovn central $component_name pod running"
+  replicas=$(kubectl get deployment -n kube-system ovn-central -o jsonpath={.spec.replicas})
+  availableNum=$(kubectl get deployment -n kube-system | grep ovn-central | awk {'print $4'})
+  while [ $availableNum != $replicas ]
+  do
+    availableNum=$(kubectl get deployment -n kube-system | grep ovn-central | awk {'print $4'})
+    usleep 0.001
+  done
+
+  end_time=$(date +%s.%N)
+  elapsed_time=$(echo "$end_time - $start_time" | bc)
+  echo "================================  OVN $component_name recover takes $elapsed_time s =================================="
+}
+
+
 if [ $# -lt 1 ]; then
   showHelp
   exit 0
@@ -1124,6 +1296,9 @@ case $subcommand in
     ;;
   log)
     log "$@"
+    ;;
+  perf)
+    perf
     ;;
   *)
     showHelp

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -60,6 +60,8 @@ type Configuration struct {
 	EnableMetrics             bool
 	EnableArpDetectIPConflict bool
 	KubeletDir                string
+	TCPConnCheckPort          int
+	UDPConnCheckPort          int
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -94,6 +96,8 @@ func ParseFlags() *Configuration {
 		argEnableMetrics             = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableArpDetectIPConflict = pflag.Bool("enable-arp-detect-ip-conflict", true, "Whether to support arp detect ip conflict in vlan network")
 		argKubeletDir                = pflag.String("kubelet-dir", "/var/lib/kubelet", "Path of the kubelet dir, default: /var/lib/kubelet")
+		argTCPConnectivityCheckPort  = pflag.Int("tcp-conn-check-port", 8100, "TCP connectivity Check Port")
+		argUDPConnectivityCheckPort  = pflag.Int("udp-conn-check-port", 8101, "UDP connectivity Check Port")
 	)
 
 	// mute info log for ipset lib
@@ -145,6 +149,8 @@ func ParseFlags() *Configuration {
 		EnableMetrics:             *argEnableMetrics,
 		EnableArpDetectIPConflict: *argEnableArpDetectIPConflict,
 		KubeletDir:                *argKubeletDir,
+		TCPConnCheckPort:          *argTCPConnectivityCheckPort,
+		UDPConnCheckPort:          *argUDPConnectivityCheckPort,
 	}
 	return config
 }

--- a/pkg/pinger/config.go
+++ b/pkg/pinger/config.go
@@ -50,11 +50,17 @@ type Configuration struct {
 	ServiceVswitchdFilePidPath      string
 	ServiceOvnControllerFileLogPath string
 	ServiceOvnControllerFilePidPath string
+	TCPConnCheckPort                int
+	UDPConnCheckPort                int
 }
 
 func ParseFlags() (*Configuration, error) {
 	var (
-		argPort               = pflag.Int("port", 8080, "metrics port")
+		argPort = pflag.Int("port", 8080, "metrics port")
+
+		argTCPConnectivityCheckPort = pflag.Int("tcp-conn-check-port", 8100, "TCP connectivity Check Port")
+		argUDPConnectivityCheckPort = pflag.Int("udp-conn-check-port", 8101, "UDP connectivity Check Port")
+
 		argKubeConfigFile     = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argDaemonSetNameSpace = pflag.String("ds-namespace", "kube-system", "kube-ovn-pinger daemonset namespace")
 		argDaemonSetName      = pflag.String("ds-name", "kube-ovn-pinger", "kube-ovn-pinger daemonset name")
@@ -118,6 +124,8 @@ func ParseFlags() (*Configuration, error) {
 		ExternalAddress:    *argExternalAddress,
 		NetworkMode:        *argNetworkMode,
 		EnableMetrics:      *argEnableMetrics,
+		TCPConnCheckPort:   *argTCPConnectivityCheckPort,
+		UDPConnCheckPort:   *argUDPConnectivityCheckPort,
 
 		// OVS Monitor
 		PollTimeout:                     *argPollTimeout,

--- a/pkg/pinger/ping.go
+++ b/pkg/pinger/ping.go
@@ -92,6 +92,20 @@ func pingNodes(config *Configuration) error {
 		for _, addr := range no.Status.Addresses {
 			if addr.Type == v1.NodeInternalIP && util.ContainsString(config.PodProtocols, util.CheckProtocol(addr.Address)) {
 				func(nodeIP, nodeName string) {
+					if err := util.TCPConnectivityCheck(fmt.Sprintf("%s:%d", nodeIP, config.TCPConnCheckPort)); err != nil {
+						klog.Infof("TCP connnectivity to node %s %s failed", nodeName, nodeIP)
+						pingErr = err
+					} else {
+						klog.Infof("TCP connnectivity to node %s %s success", nodeName, nodeIP)
+					}
+
+					if err := util.UDPConnectivityCheck(fmt.Sprintf("%s:%d", nodeIP, config.UDPConnCheckPort)); err != nil {
+						klog.Infof("UDP connnectivity to node %s %s failed", nodeName, nodeIP)
+						pingErr = err
+					} else {
+						klog.Infof("UDP connnectivity to node %s %s success", nodeName, nodeIP)
+					}
+
 					pinger, err := goping.NewPinger(nodeIP)
 					if err != nil {
 						klog.Errorf("failed to init pinger, %v", err)
@@ -143,6 +157,20 @@ func pingPods(config *Configuration) error {
 		for _, podIP := range pod.Status.PodIPs {
 			if util.ContainsString(config.PodProtocols, util.CheckProtocol(podIP.IP)) {
 				func(podIp, podName, nodeIP, nodeName string) {
+					if err := util.TCPConnectivityCheck(fmt.Sprintf("%s:%d", podIp, config.TCPConnCheckPort)); err != nil {
+						klog.Infof("TCP connnectivity to pod %s %s failed", podName, podIp)
+						pingErr = err
+					} else {
+						klog.Infof("TCP connnectivity to pod %s %s success", podName, podIp)
+					}
+
+					if err := util.UDPConnectivityCheck(fmt.Sprintf("%s:%d", podIp, config.UDPConnCheckPort)); err != nil {
+						klog.Infof("UDP connnectivity to pod %s %s failed", podName, podIp)
+						pingErr = err
+					} else {
+						klog.Infof("UDP connnectivity to pod %s %s success", podName, podIp)
+					}
+
 					pinger, err := goping.NewPinger(podIp)
 					if err != nil {
 						klog.Errorf("failed to init pinger, %v", err)

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -544,8 +544,6 @@ func TCPConnectivityListen(address string) error {
 		return fmt.Errorf("listen failed with err %v", err)
 	}
 
-	defer listener.Close()
-
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -597,8 +595,6 @@ func UDPConnectivityListen(address string) error {
 	if err != nil {
 		return fmt.Errorf("listen udp address failed with %v", err)
 	}
-
-	defer conn.Close()
 
 	buffer := make([]byte, 1024)
 

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -524,4 +525,92 @@ func GetNatGwExternalNetwork(externalNets []string) string {
 		return vpcExternalNet
 	}
 	return externalNets[0]
+}
+
+func TCPConnectivityCheck(address string) error {
+	conn, err := net.DialTimeout("tcp", address, 3*time.Second)
+	if err != nil {
+		return err
+	}
+
+	_ = conn.Close()
+
+	return nil
+}
+
+func TCPConnectivityListen(address string) error {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return fmt.Errorf("listen failed with err %v", err)
+	}
+
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			continue
+		}
+		_ = conn.Close()
+	}
+}
+
+func UDPConnectivityCheck(address string) error {
+
+	udpAddr, err := net.ResolveUDPAddr("udp", address)
+	if err != nil {
+		return fmt.Errorf("resolve udp addr failed with err %v", err)
+	}
+
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	if err != nil {
+		return err
+	}
+
+	defer conn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		return err
+	}
+
+	_, err = conn.Write([]byte("health check"))
+	if err != nil {
+		return fmt.Errorf("send udp packet failed with err %v", err)
+	}
+
+	buffer := make([]byte, 1024)
+	_, err = conn.Read(buffer)
+	if err != nil {
+		return fmt.Errorf("read udp packet from remote failed %v", err)
+	}
+
+	return nil
+}
+
+func UDPConnectivityListen(address string) error {
+	listenAddr, err := net.ResolveUDPAddr("udp", address)
+	if err != nil {
+		return fmt.Errorf("resolve udp addr failed with err %v", err)
+	}
+
+	conn, err := net.ListenUDP("udp", listenAddr)
+	if err != nil {
+		return fmt.Errorf("listen udp address failed with %v", err)
+	}
+
+	defer conn.Close()
+
+	buffer := make([]byte, 1024)
+
+	for {
+		_, clientAddr, err := conn.ReadFromUDP(buffer)
+		if err != nil {
+			continue
+		}
+
+		_, err = conn.WriteToUDP([]byte("health check"), clientAddr)
+		if err != nil {
+			continue
+		}
+	}
 }

--- a/test/server/test-server.yaml
+++ b/test/server/test-server.yaml
@@ -9,6 +9,33 @@ spec:
     - name: test-server
       image: kubeovn/test:v1.12.0
       imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          qperf &
+          ./test-server.sh
+  nodeSelector:
+    kubernetes.io/hostname: kube-ovn-control-plane
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-host-server
+  labels:
+    env: test-host-server
+spec:
+  hostNetwork: true
+  containers:
+    - name: test-host-server
+      image: kubeovn/test:v1.12.0
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          qperf &
+          ./test-server.sh
   nodeSelector:
     kubernetes.io/hostname: kube-ovn-control-plane
 


### PR DESCRIPTION
2. kube-ovn-pinger add tcp/udp test


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

1. add kubectl ko perf test
2. add kube-ovn-pinger tcp/udp test

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 729de78</samp>

This pull request adds TCP and UDP connectivity checks to the `daemon` and `pinger` packages, and updates the `util` package to support them. It also modifies the `test-server` container and adds a new `test-host-server` pod to test the network performance and connectivity of the cluster from both the pod network and the host network.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 729de78</samp>

> _Oh we are the `pinger` crew, we check the network for you_
> _We ping and probe with TCP and UDP too_
> _So haul away the `daemon` line, and set the port numbers fine_
> _And sing along with us, the `pinger` shanty tune_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 729de78</samp>

*  Add TCP and UDP connectivity checks between nodes and pods in the cluster using the `pinger` package ([link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-cc7c97c269c4de582c3c4aaaa10bf1dfc8507245babb89bb7cbc2877f6f61a33R40-R53), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704R95-R108), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704R160-R173), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR12), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR529-R616))
*  Start TCP and UDP listeners on the specified address and port in the `daemon` package to handle connectivity requests from the `pinger` package ([link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR112-R126), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R63-R64), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R99-R100), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R152-R153))
*  Add command-line flags and configuration options for the TCP and UDP connectivity check port numbers in the `pinger` and `daemon` packages ([link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R63-R64), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R99-R100), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R152-R153), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-56f139df697aad97197df93aedd368692be48a0ef3d6a4399b7f17fea0c6c8fcL53-R63), [link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-56f139df697aad97197df93aedd368692be48a0ef3d6a4399b7f17fea0c6c8fcR127-R128))
*  Add a new pod definition to the `test/server/test-server.yaml` file that uses the host network and runs the `test-host-server` container for testing the network performance and connectivity of the cluster from the host network ([link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-aaa53b027bdb6b3327d2a742e325d6ab2ce9590b2363be945280c1667b22e99bR25-R46))
*  Add a command and an argument to the `test-server` container in the `test/server/test-server.yaml` file to start the `qperf` tool and the `test-server.sh` script in the background for testing the network performance and connectivity of the cluster ([link](https://github.com/kubeovn/kube-ovn/pull/2906/files?diff=unified&w=0#diff-aaa53b027bdb6b3327d2a742e325d6ab2ce9590b2363be945280c1667b22e99bR12-R16))