### PR TITLE
match outgoing interface when perform snat

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -190,7 +190,7 @@ function add_snat() {
         randomFullyOption=${arr[2]}
         # check if already exist
         iptables-save  | grep "SHARED_SNAT" | grep "\-s $internalCIDR" | grep "source $eip" && exit 0
-        exec_cmd "iptables -t nat -A SHARED_SNAT -s $internalCIDR -j SNAT --to-source $eip $randomFullyOption"
+        exec_cmd "iptables -t nat -A SHARED_SNAT -o net1 -s $internalCIDR -j SNAT --to-source $eip $randomFullyOption"
     done
 }
 function del_snat() {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

vpc-nat-gateway can't visit the pod in the vpc when an snat rule match the cidr of the subnet.

Let's the subnet is 100.17.0.0/24 and an snat rule match internal cidr 100.17.0.0/24. It will create a iptables rule 
`-A SHARED_SNAT -s 100.17.0.0/24 -j SNAT --to-source 172.18.0.11 --random-fully`

However the IP of vpc-nat-gateway eth0 also in the range of 100.17.0.0/24, so when visit the vpc it also will be snat to an external address and failed to visit.

This PR add `-o net1` to match only the traffic outgoing to net1 to fix this issue.

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough