### PR TITLE
For eip created without spec.V4ip this field is always empty

### DIFF
--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -413,7 +413,7 @@ func (c *Controller) GetEip(eipName string) (*kubeovnv1.IptablesEIP, error) {
 		klog.Errorf("failed to get eip %s, %v", eipName, err)
 		return nil, err
 	}
-	if cachedEip.Status.IP == "" || cachedEip.Spec.V4ip == "" {
+	if cachedEip.Status.IP == "" {
 		return nil, fmt.Errorf("eip '%s' is not ready, has no v4ip", eipName)
 	}
 	eip := cachedEip.DeepCopy()
@@ -601,7 +601,7 @@ func (c *Controller) acquireEip(name, namespace, nicName, externalSubnet string)
 }
 
 func (c *Controller) eipChangeIP(eip *kubeovnv1.IptablesEIP) bool {
-	if eip.Status.IP == "" || eip.Spec.V4ip == "" {
+	if eip.Status.IP == "" {
 		// eip created but not ready
 		return false
 	}


### PR DESCRIPTION

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36d8a30</samp>

Refactor EIP-related functions in `vpc_nat_gw_eip.go` to remove redundant checks and simplify logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 36d8a30</samp>

> _No more redundant checks for `eip.Spec.V4ip`_
> _Simplify the logic, avoid the abyss_
> _EIP spec and status must align_
> _Or face the wrath of the divine_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36d8a30</samp>

*  Simplify the logic of getting and updating EIPs by removing redundant checks for `eip.Spec.V4ip` ([link](https://github.com/kubeovn/kube-ovn/pull/2912/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L416-R416), [link](https://github.com/kubeovn/kube-ovn/pull/2912/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L604-R604))