### PR TITLE
Kubectl ko diagnose perf

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -109,6 +109,21 @@ func CmdMain() {
 			}
 		}
 	}
+
+	go func() {
+		connListenaddr := fmt.Sprintf("%s:%d", addr, config.TCPConnCheckPort)
+		if err := util.TCPConnectivityListen(connListenaddr); err != nil {
+			util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
+		}
+	}()
+
+	go func() {
+		connListenaddr := fmt.Sprintf("%s:%d", addr, config.UDPConnCheckPort)
+		if err := util.UDPConnectivityListen(connListenaddr); err != nil {
+			util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
+		}
+	}()
+
 	// conform to Gosec G114
 	// https://github.com/securego/gosec#available-rules
 	server := &http.Server{

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -110,19 +110,21 @@ func CmdMain() {
 		}
 	}
 
-	go func() {
-		connListenaddr := fmt.Sprintf("%s:%d", addr, config.TCPConnCheckPort)
-		if err := util.TCPConnectivityListen(connListenaddr); err != nil {
-			util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
-		}
-	}()
+	if config.EnableVerboseConnCheck {
+		go func() {
+			connListenaddr := fmt.Sprintf("%s:%d", addr, config.TCPConnCheckPort)
+			if err := util.TCPConnectivityListen(connListenaddr); err != nil {
+				util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
+			}
+		}()
 
-	go func() {
-		connListenaddr := fmt.Sprintf("%s:%d", addr, config.UDPConnCheckPort)
-		if err := util.UDPConnectivityListen(connListenaddr); err != nil {
-			util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
-		}
-	}()
+		go func() {
+			connListenaddr := fmt.Sprintf("%s:%d", addr, config.UDPConnCheckPort)
+			if err := util.UDPConnectivityListen(connListenaddr); err != nil {
+				util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
+			}
+		}()
+	}
 
 	// conform to Gosec G114
 	// https://github.com/securego/gosec#available-rules

--- a/cmd/pinger/pinger.go
+++ b/cmd/pinger/pinger.go
@@ -36,21 +36,23 @@ func CmdMain() {
 			}
 			util.LogFatalAndExit(server.ListenAndServe(), "failed to listen and serve on %s", server.Addr)
 		}()
+
+		if config.EnableVerboseConnCheck {
+			go func() {
+				addr := fmt.Sprintf("0.0.0.0:%d", config.TCPConnCheckPort)
+				if err := util.TCPConnectivityListen(addr); err != nil {
+					util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
+				}
+			}()
+
+			go func() {
+				addr := fmt.Sprintf("0.0.0.0:%d", config.UDPConnCheckPort)
+				if err := util.UDPConnectivityListen(addr); err != nil {
+					util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
+				}
+			}()
+		}
 	}
-	go func() {
-		addr := fmt.Sprintf("0.0.0.0:%d", config.TCPConnCheckPort)
-		if err := util.TCPConnectivityListen(addr); err != nil {
-			util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
-		}
-	}()
-
-	go func() {
-		addr := fmt.Sprintf("0.0.0.0:%d", config.UDPConnCheckPort)
-		if err := util.UDPConnectivityListen(addr); err != nil {
-			util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
-		}
-	}()
-
 	e := pinger.NewExporter(config)
 	pinger.StartPinger(config, e)
 }

--- a/cmd/pinger/pinger.go
+++ b/cmd/pinger/pinger.go
@@ -37,6 +37,20 @@ func CmdMain() {
 			util.LogFatalAndExit(server.ListenAndServe(), "failed to listen and serve on %s", server.Addr)
 		}()
 	}
+	go func() {
+		addr := fmt.Sprintf("0.0.0.0:%d", config.TCPConnCheckPort)
+		if err := util.TCPConnectivityListen(addr); err != nil {
+			util.LogFatalAndExit(err, "failed to start TCP listen on addr %s ", addr)
+		}
+	}()
+
+	go func() {
+		addr := fmt.Sprintf("0.0.0.0:%d", config.UDPConnCheckPort)
+		if err := util.UDPConnectivityListen(addr); err != nil {
+			util.LogFatalAndExit(err, "failed to start UDP listen on addr %s ", addr)
+		}
+	}()
+
 	e := pinger.NewExporter(config)
 	pinger.StartPinger(config, e)
 }

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -5,6 +5,7 @@ KUBE_OVN_NS=kube-system
 WITHOUT_KUBE_PROXY=${WITHOUT_KUBE_PROXY:-false}
 OVN_NB_POD=
 OVN_SB_POD=
+OVN_NORTHD_POD=
 KUBE_OVN_VERSION=
 REGISTRY="kubeovn"
 
@@ -599,6 +600,12 @@ getOvnCentralPod(){
       exit 1
     fi
     OVN_SB_POD=$SB_POD
+    NORTHD_POD=$(kubectl get pod -n kube-system -l ovn-northd-leader=true | grep ovn-central | head -n 1 | awk '{print $1}')
+    if [ -z "$NORTHD_POD" ]; then
+      echo "ovn northd not exists"
+      exit 1
+    fi
+    OVN_NORTHD_POD=$NORTHD_POD
     image=$(kubectl  -n kube-system get pods -l app=kube-ovn-cni -o jsonpath='{.items[0].spec.containers[0].image}')
     if [ -z "$image" ]; then
           echo "cannot get kube-ovn image"
@@ -1082,6 +1089,171 @@ log(){
   echo "Collected files have been saved in the directory $PWD/kubectl-ko-log "
 }
 
+perfTimes=5
+
+perf(){
+  curl -O https://raw.githubusercontent.com/kubeovn/kube-ovn/master/test/server/test-server.yaml
+
+  nodes=($(kubectl get node --no-headers -o custom-columns=NAME:.metadata.name))
+  if [[ ${#nodes} = 1 ]]; then
+    sed -i "s/kube-ovn-control-plane/${nodes[0]}/g" test-server.yaml
+    sed -i "s/kube-ovn-worker/${nodes[0]}/g" test-server.yaml
+  elif [[ ${#nodes} -le 0 ]]; then
+    echo "can't find node in the cluster"
+    return
+  elif [[ ${#nodes} -ge 2 ]]; then
+    sed -i "s/kube-ovn-control-plane/${nodes[0]}/g" test-server.yaml
+    sed -i "s/kube-ovn-worker/${nodes[1]}/g" test-server.yaml
+  fi
+
+  kubectl apply -f test-server.yaml
+
+  isfailed=true
+  for i in {0..59}
+  do
+    clientPod=$(kubectl get pod test-client | awk '{if($2=="1/1" && $3=="Running") print $1}')
+    serverPod=$(kubectl get pod test-server | awk '{if($2=="1/1" && $3=="Running") print $1}')
+    hostServerPod=$(kubectl get pod test-host-server | awk '{if($2=="1/1" && $3=="Running") print $1}')
+
+    if [[ $clientPod = "test-client" ]] && [[ $serverPod = "test-server" ]] && [[ $hostServerPod = "test-host-server" ]] ; then
+      echo "test pods all ready"
+      isfailed=false
+      break
+    fi
+    sleep 1
+  done
+  if $isfailed; then
+    echo "Error test pod not ready"
+    return
+  fi
+
+  local serverIP=$(kubectl get pod test-server -o jsonpath={.status.podIP})
+  local hostserverIP=$(kubectl get pod test-host-server -o jsonpath={.status.podIP})
+
+  echo "Start doing pod network performance"
+  unicast_perf_test $serverIP
+
+  echo "Start doing host network performance"
+  unicast_perf_test $hostserverIP
+
+  echo "Start doing pod multicast network performance"
+  multicast_perf_test
+
+  echo "Start doing leader recover time test"
+  check_leader_recover
+
+  rm test-server.yaml
+
+}
+
+unicast_perf_test() {
+
+  serverIP=$1
+  echo "=================================== unicast perfromance test ============================================================="
+  printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "Size" "TCP Latency" "TCP Bandwidth" "UDP Latency" "UDP Lost Rate" "UDP Bandwidth"
+  for size in "64" "1k" "4k"
+  do
+    output=$(kubectl exec test-client -- qperf -t $perfTimes $serverIP -ub -oo msg_size:$size -vu tcp_lat udp_lat 2>&1)
+
+    tcp_lat="$(echo $output | grep -oP 'tcp_lat: latency = \K[\d.]+ us')"
+    udp_lat="$(echo $output | grep -oP 'udp_lat: latency = \K[\d.]+ us')"
+
+    kubectl exec test-client -- iperf3 -c $serverIP -u -t $perfTimes -i 1 -P 10 -b 1000G -l $size > temp_perf_result.log 2> /dev/null
+    udp_bw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+    udp_lost_rate=$(cat temp_perf_result.log | grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
+
+    kubectl exec test-client -- iperf3 -c $serverIP -t $perfTimes -i 1 -P 10 -l $size > temp_perf_result.log 2> /dev/null
+    tcp_bw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+
+    printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "$size" "$tcp_lat" "$tcp_bw" "$udp_lat" "$udp_lost_rate" "$udp_bw"
+  done
+  echo "========================================================================================================================="
+  rm temp_perf_result.log
+}
+
+multicast_perf_test() {
+  clientNode=$(kubectl get pod test-client -o jsonpath={.spec.nodeName})
+  serverNode=$(kubectl get pod test-server -o jsonpath={.spec.nodeName})
+
+  clientNs=$(kubectl ko vsctl $clientNode --column=external_ids find interface external_ids:iface-id=test-client.default | awk -F 'pod_netns=' '{print $2}' | grep -o 'cni-[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')
+  serverNs=$(kubectl ko vsctl $serverNode --column=external_ids find interface external_ids:iface-id=test-server.default | awk -F 'pod_netns=' '{print $2}' | grep -o 'cni-[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')
+
+  clientovsPod=$(kubectl get pod -owide -A |grep ovs-ovn | grep $clientNode | awk '{print $2}')
+  kubectl exec $clientovsPod -n kube-system -- ip netns exec $clientNs ip maddr add 01:00:5e:00:00:64 dev eth0
+
+  serverovsPod=$(kubectl get pod -owide -A |grep ovs-ovn | grep $serverNode | awk '{print $2}')
+  kubectl exec $serverovsPod -n kube-system -- ip netns exec $serverNs ip maddr add 01:00:5e:00:00:64 dev eth0
+
+  gen_multicast_perf_result test-server
+
+  kubectl exec $clientovsPod -n kube-system -- ip netns exec $clientNs ip maddr del 01:00:5e:00:00:64 dev eth0
+  kubectl exec $serverovsPod -n kube-system -- ip netns exec $serverNs ip maddr del 01:00:5e:00:00:64 dev eth0
+}
+
+gen_multicast_perf_result() {
+  serverName=$1
+
+  start_server_cmd="iperf -s -B 224.0.0.100 -i 1 -u"
+  kubectl exec $serverName -- $start_server_cmd > $serverName.log &
+
+  echo "=================================== multicast perfromance test ========================================================="
+  printf "%-15s %-15s %-15s %-15s\n" "Size" "UDP Latency" "UDP Lost Rate" "UDP Bandwidth"
+  for size in "64" "1k" "4k"
+  do
+    kubectl exec test-client -- iperf -c 224.0.0.100 -u -T 32 -t $perfTimes -i 1 -b 1000G -l $size > /dev/null
+    udp_bw=$(cat $serverName.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+    udp_lost_rate=$(cat $serverName.log |grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
+    kubectl exec test-client -- iperf -c 224.0.0.100 -u -T 32 -t $perfTimes -i 1 -l $size > /dev/null
+    udp_lat=$(cat  $serverName.log | grep -oP '\d+\.?\d* ms' | tail -n 1)
+    printf "%-15s %-15s %-15s %-15s\n" "$size" "$udp_lat" "$udp_lost_rate" "$udp_bw"
+  done
+
+  echo "========================================================================================================================="
+
+  pids=($(ps -ef | grep "$start_server_cmd" | grep -v grep | awk '{print $2}'))
+  kill ${pids[1]}
+
+  rm $serverName.log
+}
+
+check_leader_recover() {
+  getOvnCentralPod
+  getPodRecoverTime "nb"
+  sleep 5
+  getOvnCentralPod
+  getPodRecoverTime "sb"
+  sleep 5
+  getOvnCentralPod
+  getPodRecoverTime "northd"
+
+}
+
+getPodRecoverTime(){
+  component_name=$1
+  start_time=$(date +%s.%N)
+  echo "Delete ovn central $component_name pod"
+  if [[ $component_name == "nb" ]]; then
+    kubectl delete pod $OVN_NB_POD -n kube-system
+  elif [[ $component_name == "sb" ]]; then
+    kubectl delete pod $OVN_SB_POD -n kube-system
+  elif [[ $component_name == "northd" ]]; then
+    kubectl delete pod $OVN_NORTHD_POD -n kube-system
+  fi
+  echo "Waiting for ovn central $component_name pod running"
+  replicas=$(kubectl get deployment -n kube-system ovn-central -o jsonpath={.spec.replicas})
+  availableNum=$(kubectl get deployment -n kube-system | grep ovn-central | awk {'print $4'})
+  while [ $availableNum != $replicas ]
+  do
+    availableNum=$(kubectl get deployment -n kube-system | grep ovn-central | awk {'print $4'})
+    usleep 0.001
+  done
+
+  end_time=$(date +%s.%N)
+  elapsed_time=$(echo "$end_time - $start_time" | bc)
+  echo "================================  OVN $component_name recover takes $elapsed_time s =================================="
+}
+
+
 if [ $# -lt 1 ]; then
   showHelp
   exit 0
@@ -1124,6 +1296,9 @@ case $subcommand in
     ;;
   log)
     log "$@"
+    ;;
+  perf)
+    perf
     ;;
   *)
     showHelp

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -8,6 +8,10 @@ OVN_SB_POD=
 OVN_NORTHD_POD=
 KUBE_OVN_VERSION=
 REGISTRY="kubeovn"
+PERF_TIMES=5
+PERF_LABEL="PerfTest"
+CONN_CHECK_LABEL="conn-check"
+CONN_CHECK_SERVER="conn-check-server"
 
 showHelp(){
   echo "kubectl ko {subcommand} [option...]"
@@ -25,11 +29,12 @@ showHelp(){
   echo "    trace {namespace/podname} {target ip address} [target mac address] arp {request|reply}                     trace ARP request/reply"
   echo "    trace {node//nodename} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]       trace ICMP/TCP/UDP"
   echo "    trace {node//nodename} {target ip address} [target mac address] arp {request|reply}                        trace ARP request/reply"
-  echo "  diagnose {all|node} [nodename]    diagnose connectivity of all nodes or a specific node"
+  echo "  diagnose {all|node|subnet} [nodename|subnetName]    diagnose connectivity of all nodes or a specific node or specify subnet's ds pod"
   echo "  env-check    check the environment configuration"
   echo "  tuning {install-fastpath|local-install-fastpath|remove-fastpath|install-stt|local-install-stt|remove-stt} {centos7|centos8}} [kernel-devel-version]    deploy kernel optimisation components to the system"
   echo "  reload    restart all kube-ovn components"
   echo "  log {kube-ovn|ovn|ovs|linux|all}    save log to ./kubectl-ko-log/"
+  echo "  perf [image] performance test default image is kubeovn/test:v1.12.0"
 }
 
 # usage: ipv4_to_hex 192.168.0.1
@@ -493,6 +498,67 @@ checkLeader(){
   echo "ovn-$component leader check ok"
 }
 
+applyConnServerDaemonset(){
+  subnetName=$1
+
+  if [ $(kubectl get subnet $subnetName | wc -l) -eq 0 ]; then
+    echo "no subnet $subnetName exists !!"
+    exit 1
+  fi
+
+  imageID=$(kubectl get ds -n $KUBE_OVN_NS kube-ovn-pinger -o jsonpath={.spec.template.spec.containers[0].image})
+  tmpFileName="conn-server.yaml"
+  cat <<EOF > $tmpFileName
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: $subnetName-$CONN_CHECK_SERVER
+  namespace: $KUBE_OVN_NS
+spec:
+  selector:
+    matchLabels:
+      app: $CONN_CHECK_LABEL
+  template:
+    metadata:
+      annotations:
+        ovn.kubernetes.io/logical_switch: $subnetName
+      labels:
+        app: $CONN_CHECK_LABEL
+    spec:
+      serviceAccountName: kube-ovn-app
+      containers:
+        - name: $subnetName-$CONN_CHECK_SERVER
+          imagePullPolicy: IfNotPresent
+          image: $imageID
+          command:
+            - /kube-ovn/kube-ovn-pinger
+          args:
+            - --enable-verbose-conn-check=true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+EOF
+  kubectl apply -f $tmpFileName
+  rm $tmpFileName
+
+  isfailed=true
+  for i in {0..59}
+  do
+    if kubectl wait pod --for=condition=Ready -l app=$CONN_CHECK_LABEL -n $KUBE_OVN_NS ; then
+      isfailed=false
+      break
+    fi
+    sleep 1; \
+  done
+
+  if $isfailed; then
+    echo "Error ds $subnetName-$CONN_CHECK_SERVER pod not ready"
+    return
+  fi
+}
+
 diagnose(){
   kubectl get crd vpcs.kubeovn.io
   kubectl get crd vpc-nat-gateways.kubeovn.io
@@ -580,9 +646,27 @@ diagnose(){
       echo "### finish diagnose node $nodeName"
       echo ""
       ;;
+    subnet)
+      subnetName="$2"
+      applyConnServerDaemonset $subnetName
+
+      if [ $(kubectl get ds kube-ovn-cni -n $KUBE_OVN_NS -oyaml | grep enable-verbose-conn-check | wc -l) -eq 0 ]; then
+        echo "Warning: kube-ovn-cni not have args enable-verbose-conn-check, it will fail when check node tcp/udp connectivity"
+      fi
+
+      pingers=$(kubectl -n $KUBE_OVN_NS get po --no-headers -o custom-columns=NAME:.metadata.name -l app=kube-ovn-pinger)
+      for pinger in $pingers
+      do
+        echo "#### pinger diagnose results:"
+        kubectl exec -n $KUBE_OVN_NS "$pinger" -- /kube-ovn/kube-ovn-pinger --mode=job --ds-name=$subnetName-$CONN_CHECK_SERVER --ds-namespace=$KUBE_OVN_NS --enable-verbose-conn-check=true
+        echo ""
+      done
+
+      kubectl delete ds $subnetName-$CONN_CHECK_SERVER -n $KUBE_OVN_NS
+      ;;
     *)
       echo "type $type not supported"
-      echo "kubectl ko diagnose {all|node} [nodename]"
+      echo "kubectl ko diagnose {all|node|subnet} [nodename|subnetName]"
       ;;
     esac
 }
@@ -1089,123 +1173,199 @@ log(){
   echo "Collected files have been saved in the directory $PWD/kubectl-ko-log "
 }
 
-perfTimes=5
+
+
+applyTestServer() {
+  tmpFileName="test-server.yaml"
+  podName="test-server"
+  nodeID=$1
+  imageID=$2
+
+  cat <<EOF > $tmpFileName
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $podName
+  namespace: $KUBE_OVN_NS
+  labels:
+    app: $PERF_LABEL
+spec:
+  containers:
+    - name: $podName
+      image: $imageID
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          qperf &
+          ./test-server.sh
+  nodeSelector:
+    kubernetes.io/hostname: $nodeID
+EOF
+
+  kubectl apply -f $tmpFileName
+  rm $tmpFileName
+}
+
+applyTestHostServer() {
+  tmpFileName="test-host-server.yaml"
+  podName="test-host-server"
+  nodeID=$1
+  imageID=$2
+
+  cat <<EOF > $tmpFileName
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $podName
+  namespace: $KUBE_OVN_NS
+  labels:
+    app: $PERF_LABEL
+spec:
+  hostNetwork: true
+  containers:
+    - name: $podName
+      image: $imageID
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          qperf &
+          ./test-server.sh
+  nodeSelector:
+    kubernetes.io/hostname: $nodeID
+EOF
+
+  kubectl apply -f $tmpFileName
+  rm $tmpFileName
+}
+
+
+applyTestClient() {
+  tmpFileName="test-client.yaml"
+  local podName="test-client"
+  local nodeID=$1
+  local imageID=$2
+  touch $tmpFileName
+  cat <<EOF > $tmpFileName
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $podName
+  namespace: $KUBE_OVN_NS
+  labels:
+    app: $PERF_LABEL
+spec:
+  containers:
+    - name: $podName
+      image: $imageID
+      imagePullPolicy: IfNotPresent
+  nodeSelector:
+    kubernetes.io/hostname: $nodeID
+EOF
+  kubectl apply -f $tmpFileName
+  rm $tmpFileName
+}
 
 perf(){
-  curl -O https://raw.githubusercontent.com/kubeovn/kube-ovn/master/test/server/test-server.yaml
+  imageID=${1:-"kubeovn/test:v1.12.0"}
 
   nodes=($(kubectl get node --no-headers -o custom-columns=NAME:.metadata.name))
-  if [[ ${#nodes} = 1 ]]; then
-    sed -i "s/kube-ovn-control-plane/${nodes[0]}/g" test-server.yaml
-    sed -i "s/kube-ovn-worker/${nodes[0]}/g" test-server.yaml
+  if [[ ${#nodes} -eq 1 ]]; then
+    applyTestClient ${nodes[0]} $imageID
+    applyTestHostServer ${nodes[0]} $imageID
+    applyTestServer ${nodes[0]} $imageID
   elif [[ ${#nodes} -le 0 ]]; then
     echo "can't find node in the cluster"
     return
   elif [[ ${#nodes} -ge 2 ]]; then
-    sed -i "s/kube-ovn-control-plane/${nodes[0]}/g" test-server.yaml
-    sed -i "s/kube-ovn-worker/${nodes[1]}/g" test-server.yaml
+    applyTestClient ${nodes[1]} $imageID
+    applyTestHostServer ${nodes[0]} $imageID
+    applyTestServer ${nodes[0]} $imageID
   fi
-
-  kubectl apply -f test-server.yaml
 
   isfailed=true
   for i in {0..59}
   do
-    clientPod=$(kubectl get pod test-client | awk '{if($2=="1/1" && $3=="Running") print $1}')
-    serverPod=$(kubectl get pod test-server | awk '{if($2=="1/1" && $3=="Running") print $1}')
-    hostServerPod=$(kubectl get pod test-host-server | awk '{if($2=="1/1" && $3=="Running") print $1}')
-
-    if [[ $clientPod = "test-client" ]] && [[ $serverPod = "test-server" ]] && [[ $hostServerPod = "test-host-server" ]] ; then
-      echo "test pods all ready"
+    if kubectl wait pod --for=condition=Ready -l app=$PERF_LABEL -n kube-system ; then
       isfailed=false
       break
     fi
-    sleep 1
-  done
+		sleep 1; \
+	done
+
   if $isfailed; then
     echo "Error test pod not ready"
     return
   fi
 
-  local serverIP=$(kubectl get pod test-server -o jsonpath={.status.podIP})
-  local hostserverIP=$(kubectl get pod test-host-server -o jsonpath={.status.podIP})
+  local serverIP=$(kubectl get pod test-server -n $KUBE_OVN_NS -o jsonpath={.status.podIP})
+  local hostserverIP=$(kubectl get pod test-host-server -n $KUBE_OVN_NS -o jsonpath={.status.podIP})
 
   echo "Start doing pod network performance"
-  unicast_perf_test $serverIP
+  unicastPerfTest $serverIP
 
   echo "Start doing host network performance"
-  unicast_perf_test $hostserverIP
+  unicastPerfTest $hostserverIP
 
   echo "Start doing pod multicast network performance"
-  multicast_perf_test
+  multicastPerfTest
 
   echo "Start doing leader recover time test"
-  check_leader_recover
-
-  rm test-server.yaml
-
+  checkLeaderRecover
 }
 
-unicast_perf_test() {
-
+unicastPerfTest() {
   serverIP=$1
   echo "=================================== unicast perfromance test ============================================================="
   printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "Size" "TCP Latency" "TCP Bandwidth" "UDP Latency" "UDP Lost Rate" "UDP Bandwidth"
-  for size in "64" "1k" "4k"
+  for size in "64" "128" "512" "1k" "4k"
   do
-    output=$(kubectl exec test-client -- qperf -t $perfTimes $serverIP -ub -oo msg_size:$size -vu tcp_lat udp_lat 2>&1)
+    output=$(kubectl exec test-client -n $KUBE_OVN_NS -- qperf -t $PERF_TIMES $serverIP -ub -oo msg_size:$size -vu tcp_lat udp_lat 2>&1)
+    tcpLat="$(echo $output | grep -oP 'tcp_lat: latency = \K[\d.]+ us')"
+    udpLat="$(echo $output | grep -oP 'udp_lat: latency = \K[\d.]+ us')"
+    kubectl exec test-client -n $KUBE_OVN_NS -- iperf3 -c $serverIP -u -t $PERF_TIMES -i 1 -P 10 -b 1000G -l $size > temp_perf_result.log 2> /dev/null
+    udpBw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+    udpLostRate=$(cat temp_perf_result.log | grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
 
-    tcp_lat="$(echo $output | grep -oP 'tcp_lat: latency = \K[\d.]+ us')"
-    udp_lat="$(echo $output | grep -oP 'udp_lat: latency = \K[\d.]+ us')"
-
-    kubectl exec test-client -- iperf3 -c $serverIP -u -t $perfTimes -i 1 -P 10 -b 1000G -l $size > temp_perf_result.log 2> /dev/null
-    udp_bw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
-    udp_lost_rate=$(cat temp_perf_result.log | grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
-
-    kubectl exec test-client -- iperf3 -c $serverIP -t $perfTimes -i 1 -P 10 -l $size > temp_perf_result.log 2> /dev/null
-    tcp_bw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
-
-    printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "$size" "$tcp_lat" "$tcp_bw" "$udp_lat" "$udp_lost_rate" "$udp_bw"
+    kubectl exec test-client -n $KUBE_OVN_NS -- iperf3 -c $serverIP -t $PERF_TIMES -i 1 -P 10 -l $size > temp_perf_result.log 2> /dev/null
+    tcpBw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+    printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "$size" "$tcpLat" "$tcpBw" "$udpLat" "$udpLostRate" "$udpBw"
   done
   echo "========================================================================================================================="
   rm temp_perf_result.log
 }
 
-multicast_perf_test() {
-  clientNode=$(kubectl get pod test-client -o jsonpath={.spec.nodeName})
-  serverNode=$(kubectl get pod test-server -o jsonpath={.spec.nodeName})
-
-  clientNs=$(kubectl ko vsctl $clientNode --column=external_ids find interface external_ids:iface-id=test-client.default | awk -F 'pod_netns=' '{print $2}' | grep -o 'cni-[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')
-  serverNs=$(kubectl ko vsctl $serverNode --column=external_ids find interface external_ids:iface-id=test-server.default | awk -F 'pod_netns=' '{print $2}' | grep -o 'cni-[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')
-
+multicastPerfTest() {
+  clientNode=$(kubectl get pod test-client -n $KUBE_OVN_NS -o jsonpath={.spec.nodeName})
+  serverNode=$(kubectl get pod test-server -n $KUBE_OVN_NS -o jsonpath={.spec.nodeName})
+  clientNs=$(kubectl ko vsctl $clientNode --column=external_ids find interface external_ids:iface-id=test-client.$KUBE_OVN_NS | awk -F 'pod_netns=' '{print $2}' | grep -o 'cni-[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')
+  serverNs=$(kubectl ko vsctl $serverNode --column=external_ids find interface external_ids:iface-id=test-server.$KUBE_OVN_NS | awk -F 'pod_netns=' '{print $2}' | grep -o 'cni-[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')
   clientovsPod=$(kubectl get pod -owide -A |grep ovs-ovn | grep $clientNode | awk '{print $2}')
   kubectl exec $clientovsPod -n kube-system -- ip netns exec $clientNs ip maddr add 01:00:5e:00:00:64 dev eth0
-
   serverovsPod=$(kubectl get pod -owide -A |grep ovs-ovn | grep $serverNode | awk '{print $2}')
   kubectl exec $serverovsPod -n kube-system -- ip netns exec $serverNs ip maddr add 01:00:5e:00:00:64 dev eth0
-
-  gen_multicast_perf_result test-server
-
+  genMulticastPerfResult test-server
   kubectl exec $clientovsPod -n kube-system -- ip netns exec $clientNs ip maddr del 01:00:5e:00:00:64 dev eth0
   kubectl exec $serverovsPod -n kube-system -- ip netns exec $serverNs ip maddr del 01:00:5e:00:00:64 dev eth0
 }
 
-gen_multicast_perf_result() {
+genMulticastPerfResult() {
   serverName=$1
 
   start_server_cmd="iperf -s -B 224.0.0.100 -i 1 -u"
-  kubectl exec $serverName -- $start_server_cmd > $serverName.log &
+  kubectl exec $serverName -n $KUBE_OVN_NS -- $start_server_cmd > $serverName.log &
 
   echo "=================================== multicast perfromance test ========================================================="
   printf "%-15s %-15s %-15s %-15s\n" "Size" "UDP Latency" "UDP Lost Rate" "UDP Bandwidth"
-  for size in "64" "1k" "4k"
+  for size in "64" "128" "512" "1k" "4k"
   do
-    kubectl exec test-client -- iperf -c 224.0.0.100 -u -T 32 -t $perfTimes -i 1 -b 1000G -l $size > /dev/null
-    udp_bw=$(cat $serverName.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
-    udp_lost_rate=$(cat $serverName.log |grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
-    kubectl exec test-client -- iperf -c 224.0.0.100 -u -T 32 -t $perfTimes -i 1 -l $size > /dev/null
-    udp_lat=$(cat  $serverName.log | grep -oP '\d+\.?\d* ms' | tail -n 1)
-    printf "%-15s %-15s %-15s %-15s\n" "$size" "$udp_lat" "$udp_lost_rate" "$udp_bw"
+    kubectl exec test-client -n $KUBE_OVN_NS -- iperf -c 224.0.0.100 -u -T 32 -t $PERF_TIMES -i 1 -b 1000G -l $size > /dev/null
+    udpBw=$(cat $serverName.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
+    udpLostRate=$(cat $serverName.log |grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
+    kubectl exec test-client -n $KUBE_OVN_NS -- iperf -c 224.0.0.100 -u -T 32 -t $PERF_TIMES -i 1 -l $size > /dev/null
+    udpLat=$(cat  $serverName.log | grep -oP '\d+\.?\d* ms' | tail -n 1)
+    printf "%-15s %-15s %-15s %-15s\n" "$size" "$udpLat" "$udpLostRate" "$udpBw"
   done
 
   echo "========================================================================================================================="
@@ -1216,7 +1376,7 @@ gen_multicast_perf_result() {
   rm $serverName.log
 }
 
-check_leader_recover() {
+checkLeaderRecover() {
   getOvnCentralPod
   getPodRecoverTime "nb"
   sleep 5
@@ -1298,7 +1458,7 @@ case $subcommand in
     log "$@"
     ;;
   perf)
-    perf
+    perf "$@"
     ;;
   *)
     showHelp

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -1313,6 +1313,8 @@ perf(){
 
   echo "Start doing leader recover time test"
   checkLeaderRecover
+
+  kubectl delete pods -l app=$PERF_LABEL -n $KUBE_OVN_NS
 }
 
 unicastPerfTest() {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -60,6 +60,7 @@ type Configuration struct {
 	EnableMetrics             bool
 	EnableArpDetectIPConflict bool
 	KubeletDir                string
+	EnableVerboseConnCheck    bool
 	TCPConnCheckPort          int
 	UDPConnCheckPort          int
 }
@@ -96,6 +97,7 @@ func ParseFlags() *Configuration {
 		argEnableMetrics             = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableArpDetectIPConflict = pflag.Bool("enable-arp-detect-ip-conflict", true, "Whether to support arp detect ip conflict in vlan network")
 		argKubeletDir                = pflag.String("kubelet-dir", "/var/lib/kubelet", "Path of the kubelet dir, default: /var/lib/kubelet")
+		argEnableVerboseConnCheck    = pflag.Bool("enable-verbose-conn-check", false, "enable TCP/UDP connectivity check listen port")
 		argTCPConnectivityCheckPort  = pflag.Int("tcp-conn-check-port", 8100, "TCP connectivity Check Port")
 		argUDPConnectivityCheckPort  = pflag.Int("udp-conn-check-port", 8101, "UDP connectivity Check Port")
 	)
@@ -149,6 +151,7 @@ func ParseFlags() *Configuration {
 		EnableMetrics:             *argEnableMetrics,
 		EnableArpDetectIPConflict: *argEnableArpDetectIPConflict,
 		KubeletDir:                *argKubeletDir,
+		EnableVerboseConnCheck:    *argEnableVerboseConnCheck,
 		TCPConnCheckPort:          *argTCPConnectivityCheckPort,
 		UDPConnCheckPort:          *argUDPConnectivityCheckPort,
 	}

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -60,6 +60,8 @@ type Configuration struct {
 	EnableMetrics             bool
 	EnableArpDetectIPConflict bool
 	KubeletDir                string
+	TCPConnCheckPort          int
+	UDPConnCheckPort          int
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -94,6 +96,8 @@ func ParseFlags() *Configuration {
 		argEnableMetrics             = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableArpDetectIPConflict = pflag.Bool("enable-arp-detect-ip-conflict", true, "Whether to support arp detect ip conflict in vlan network")
 		argKubeletDir                = pflag.String("kubelet-dir", "/var/lib/kubelet", "Path of the kubelet dir, default: /var/lib/kubelet")
+		argTCPConnectivityCheckPort  = pflag.Int("tcp-conn-check-port", 8100, "TCP connectivity Check Port")
+		argUDPConnectivityCheckPort  = pflag.Int("udp-conn-check-port", 8101, "UDP connectivity Check Port")
 	)
 
 	// mute info log for ipset lib
@@ -145,6 +149,8 @@ func ParseFlags() *Configuration {
 		EnableMetrics:             *argEnableMetrics,
 		EnableArpDetectIPConflict: *argEnableArpDetectIPConflict,
 		KubeletDir:                *argKubeletDir,
+		TCPConnCheckPort:          *argTCPConnectivityCheckPort,
+		UDPConnCheckPort:          *argUDPConnectivityCheckPort,
 	}
 	return config
 }

--- a/pkg/pinger/config.go
+++ b/pkg/pinger/config.go
@@ -50,11 +50,17 @@ type Configuration struct {
 	ServiceVswitchdFilePidPath      string
 	ServiceOvnControllerFileLogPath string
 	ServiceOvnControllerFilePidPath string
+	TCPConnCheckPort                int
+	UDPConnCheckPort                int
 }
 
 func ParseFlags() (*Configuration, error) {
 	var (
-		argPort               = pflag.Int("port", 8080, "metrics port")
+		argPort = pflag.Int("port", 8080, "metrics port")
+
+		argTCPConnectivityCheckPort = pflag.Int("tcp-conn-check-port", 8100, "TCP connectivity Check Port")
+		argUDPConnectivityCheckPort = pflag.Int("udp-conn-check-port", 8101, "UDP connectivity Check Port")
+
 		argKubeConfigFile     = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argDaemonSetNameSpace = pflag.String("ds-namespace", "kube-system", "kube-ovn-pinger daemonset namespace")
 		argDaemonSetName      = pflag.String("ds-name", "kube-ovn-pinger", "kube-ovn-pinger daemonset name")
@@ -118,6 +124,8 @@ func ParseFlags() (*Configuration, error) {
 		ExternalAddress:    *argExternalAddress,
 		NetworkMode:        *argNetworkMode,
 		EnableMetrics:      *argEnableMetrics,
+		TCPConnCheckPort:   *argTCPConnectivityCheckPort,
+		UDPConnCheckPort:   *argUDPConnectivityCheckPort,
 
 		// OVS Monitor
 		PollTimeout:                     *argPollTimeout,

--- a/pkg/pinger/config.go
+++ b/pkg/pinger/config.go
@@ -50,6 +50,7 @@ type Configuration struct {
 	ServiceVswitchdFilePidPath      string
 	ServiceOvnControllerFileLogPath string
 	ServiceOvnControllerFilePidPath string
+	EnableVerboseConnCheck          bool
 	TCPConnCheckPort                int
 	UDPConnCheckPort                int
 }
@@ -58,6 +59,7 @@ func ParseFlags() (*Configuration, error) {
 	var (
 		argPort = pflag.Int("port", 8080, "metrics port")
 
+		argEnableVerboseConnCheck   = pflag.Bool("enable-verbose-conn-check", false, "enable TCP/UDP connectivity check")
 		argTCPConnectivityCheckPort = pflag.Int("tcp-conn-check-port", 8100, "TCP connectivity Check Port")
 		argUDPConnectivityCheckPort = pflag.Int("udp-conn-check-port", 8101, "UDP connectivity Check Port")
 
@@ -124,8 +126,10 @@ func ParseFlags() (*Configuration, error) {
 		ExternalAddress:    *argExternalAddress,
 		NetworkMode:        *argNetworkMode,
 		EnableMetrics:      *argEnableMetrics,
-		TCPConnCheckPort:   *argTCPConnectivityCheckPort,
-		UDPConnCheckPort:   *argUDPConnectivityCheckPort,
+
+		EnableVerboseConnCheck: *argEnableVerboseConnCheck,
+		TCPConnCheckPort:       *argTCPConnectivityCheckPort,
+		UDPConnCheckPort:       *argUDPConnectivityCheckPort,
 
 		// OVS Monitor
 		PollTimeout:                     *argPollTimeout,

--- a/pkg/pinger/ping.go
+++ b/pkg/pinger/ping.go
@@ -92,18 +92,19 @@ func pingNodes(config *Configuration) error {
 		for _, addr := range no.Status.Addresses {
 			if addr.Type == v1.NodeInternalIP && util.ContainsString(config.PodProtocols, util.CheckProtocol(addr.Address)) {
 				func(nodeIP, nodeName string) {
-					if err := util.TCPConnectivityCheck(fmt.Sprintf("%s:%d", nodeIP, config.TCPConnCheckPort)); err != nil {
-						klog.Infof("TCP connnectivity to node %s %s failed", nodeName, nodeIP)
-						pingErr = err
-					} else {
-						klog.Infof("TCP connnectivity to node %s %s success", nodeName, nodeIP)
-					}
-
-					if err := util.UDPConnectivityCheck(fmt.Sprintf("%s:%d", nodeIP, config.UDPConnCheckPort)); err != nil {
-						klog.Infof("UDP connnectivity to node %s %s failed", nodeName, nodeIP)
-						pingErr = err
-					} else {
-						klog.Infof("UDP connnectivity to node %s %s success", nodeName, nodeIP)
+					if config.EnableVerboseConnCheck {
+						if err := util.TCPConnectivityCheck(fmt.Sprintf("%s:%d", nodeIP, config.TCPConnCheckPort)); err != nil {
+							klog.Infof("TCP connnectivity to node %s %s failed", nodeName, nodeIP)
+							pingErr = err
+						} else {
+							klog.Infof("TCP connnectivity to node %s %s success", nodeName, nodeIP)
+						}
+						if err := util.UDPConnectivityCheck(fmt.Sprintf("%s:%d", nodeIP, config.UDPConnCheckPort)); err != nil {
+							klog.Infof("UDP connnectivity to node %s %s failed", nodeName, nodeIP)
+							pingErr = err
+						} else {
+							klog.Infof("UDP connnectivity to node %s %s success", nodeName, nodeIP)
+						}
 					}
 
 					pinger, err := goping.NewPinger(nodeIP)
@@ -162,18 +163,20 @@ func pingPods(config *Configuration) error {
 		for _, podIP := range pod.Status.PodIPs {
 			if util.ContainsString(config.PodProtocols, util.CheckProtocol(podIP.IP)) {
 				func(podIp, podName, nodeIP, nodeName string) {
-					if err := util.TCPConnectivityCheck(fmt.Sprintf("%s:%d", podIp, config.TCPConnCheckPort)); err != nil {
-						klog.Infof("TCP connnectivity to pod %s %s failed", podName, podIp)
-						pingErr = err
-					} else {
-						klog.Infof("TCP connnectivity to pod %s %s success", podName, podIp)
-					}
+					if config.EnableVerboseConnCheck {
+						if err := util.TCPConnectivityCheck(fmt.Sprintf("%s:%d", podIp, config.TCPConnCheckPort)); err != nil {
+							klog.Infof("TCP connnectivity to pod %s %s failed", podName, podIp)
+							pingErr = err
+						} else {
+							klog.Infof("TCP connnectivity to pod %s %s success", podName, podIp)
+						}
 
-					if err := util.UDPConnectivityCheck(fmt.Sprintf("%s:%d", podIp, config.UDPConnCheckPort)); err != nil {
-						klog.Infof("UDP connnectivity to pod %s %s failed", podName, podIp)
-						pingErr = err
-					} else {
-						klog.Infof("UDP connnectivity to pod %s %s success", podName, podIp)
+						if err := util.UDPConnectivityCheck(fmt.Sprintf("%s:%d", podIp, config.UDPConnCheckPort)); err != nil {
+							klog.Infof("UDP connnectivity to pod %s %s failed", podName, podIp)
+							pingErr = err
+						} else {
+							klog.Infof("UDP connnectivity to pod %s %s success", podName, podIp)
+						}
 					}
 
 					pinger, err := goping.NewPinger(podIp)

--- a/pkg/pinger/ping.go
+++ b/pkg/pinger/ping.go
@@ -92,6 +92,20 @@ func pingNodes(config *Configuration) error {
 		for _, addr := range no.Status.Addresses {
 			if addr.Type == v1.NodeInternalIP && util.ContainsString(config.PodProtocols, util.CheckProtocol(addr.Address)) {
 				func(nodeIP, nodeName string) {
+					if err := util.TCPConnectivityCheck(fmt.Sprintf("%s:%d", nodeIP, config.TCPConnCheckPort)); err != nil {
+						klog.Infof("TCP connnectivity to node %s %s failed", nodeName, nodeIP)
+						pingErr = err
+					} else {
+						klog.Infof("TCP connnectivity to node %s %s success", nodeName, nodeIP)
+					}
+
+					if err := util.UDPConnectivityCheck(fmt.Sprintf("%s:%d", nodeIP, config.UDPConnCheckPort)); err != nil {
+						klog.Infof("UDP connnectivity to node %s %s failed", nodeName, nodeIP)
+						pingErr = err
+					} else {
+						klog.Infof("UDP connnectivity to node %s %s success", nodeName, nodeIP)
+					}
+
 					pinger, err := goping.NewPinger(nodeIP)
 					if err != nil {
 						klog.Errorf("failed to init pinger, %v", err)
@@ -148,6 +162,20 @@ func pingPods(config *Configuration) error {
 		for _, podIP := range pod.Status.PodIPs {
 			if util.ContainsString(config.PodProtocols, util.CheckProtocol(podIP.IP)) {
 				func(podIp, podName, nodeIP, nodeName string) {
+					if err := util.TCPConnectivityCheck(fmt.Sprintf("%s:%d", podIp, config.TCPConnCheckPort)); err != nil {
+						klog.Infof("TCP connnectivity to pod %s %s failed", podName, podIp)
+						pingErr = err
+					} else {
+						klog.Infof("TCP connnectivity to pod %s %s success", podName, podIp)
+					}
+
+					if err := util.UDPConnectivityCheck(fmt.Sprintf("%s:%d", podIp, config.UDPConnCheckPort)); err != nil {
+						klog.Infof("UDP connnectivity to pod %s %s failed", podName, podIp)
+						pingErr = err
+					} else {
+						klog.Infof("UDP connnectivity to pod %s %s success", podName, podIp)
+					}
+
 					pinger, err := goping.NewPinger(podIp)
 					if err != nil {
 						klog.Errorf("failed to init pinger, %v", err)

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -544,8 +544,6 @@ func TCPConnectivityListen(address string) error {
 		return fmt.Errorf("listen failed with err %v", err)
 	}
 
-	defer listener.Close()
-
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -597,8 +595,6 @@ func UDPConnectivityListen(address string) error {
 	if err != nil {
 		return fmt.Errorf("listen udp address failed with %v", err)
 	}
-
-	defer conn.Close()
 
 	buffer := make([]byte, 1024)
 

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -524,4 +525,92 @@ func GetNatGwExternalNetwork(externalNets []string) string {
 		return vpcExternalNet
 	}
 	return externalNets[0]
+}
+
+func TCPConnectivityCheck(address string) error {
+	conn, err := net.DialTimeout("tcp", address, 3*time.Second)
+	if err != nil {
+		return err
+	}
+
+	_ = conn.Close()
+
+	return nil
+}
+
+func TCPConnectivityListen(address string) error {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return fmt.Errorf("listen failed with err %v", err)
+	}
+
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			continue
+		}
+		_ = conn.Close()
+	}
+}
+
+func UDPConnectivityCheck(address string) error {
+
+	udpAddr, err := net.ResolveUDPAddr("udp", address)
+	if err != nil {
+		return fmt.Errorf("resolve udp addr failed with err %v", err)
+	}
+
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	if err != nil {
+		return err
+	}
+
+	defer conn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		return err
+	}
+
+	_, err = conn.Write([]byte("health check"))
+	if err != nil {
+		return fmt.Errorf("send udp packet failed with err %v", err)
+	}
+
+	buffer := make([]byte, 1024)
+	_, err = conn.Read(buffer)
+	if err != nil {
+		return fmt.Errorf("read udp packet from remote failed %v", err)
+	}
+
+	return nil
+}
+
+func UDPConnectivityListen(address string) error {
+	listenAddr, err := net.ResolveUDPAddr("udp", address)
+	if err != nil {
+		return fmt.Errorf("resolve udp addr failed with err %v", err)
+	}
+
+	conn, err := net.ListenUDP("udp", listenAddr)
+	if err != nil {
+		return fmt.Errorf("listen udp address failed with %v", err)
+	}
+
+	defer conn.Close()
+
+	buffer := make([]byte, 1024)
+
+	for {
+		_, clientAddr, err := conn.ReadFromUDP(buffer)
+		if err != nil {
+			continue
+		}
+
+		_, err = conn.WriteToUDP([]byte("health check"), clientAddr)
+		if err != nil {
+			continue
+		}
+	}
 }

--- a/test/server/test-server.yaml
+++ b/test/server/test-server.yaml
@@ -9,6 +9,33 @@ spec:
     - name: test-server
       image: kubeovn/test:v1.12.0
       imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          qperf &
+          ./test-server.sh
+  nodeSelector:
+    kubernetes.io/hostname: kube-ovn-control-plane
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-host-server
+  labels:
+    env: test-host-server
+spec:
+  hostNetwork: true
+  containers:
+    - name: test-host-server
+      image: kubeovn/test:v1.12.0
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          qperf &
+          ./test-server.sh
   nodeSelector:
     kubernetes.io/hostname: kube-ovn-control-plane
 

--- a/test/server/test-server.yaml
+++ b/test/server/test-server.yaml
@@ -9,33 +9,6 @@ spec:
     - name: test-server
       image: kubeovn/test:v1.12.0
       imagePullPolicy: IfNotPresent
-      command: ["sh", "-c"]
-      args:
-        - |
-          qperf &
-          ./test-server.sh
-  nodeSelector:
-    kubernetes.io/hostname: kube-ovn-control-plane
-
----
-
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-host-server
-  labels:
-    env: test-host-server
-spec:
-  hostNetwork: true
-  containers:
-    - name: test-host-server
-      image: kubeovn/test:v1.12.0
-      imagePullPolicy: IfNotPresent
-      command: ["sh", "-c"]
-      args:
-        - |
-          qperf &
-          ./test-server.sh
   nodeSelector:
     kubernetes.io/hostname: kube-ovn-control-plane
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
1. kubectl ko add perf
2. add TCP/UDP connectivity check
3.  add kubectl ko diagnose subnet


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a05e06f</samp>

This pull request adds TCP and UDP connectivity checks to the kube-ovn network. It modifies the `daemon`, `pinger`, and `util` packages to implement and configure the checks, and updates the `test-server.yaml` file to support `qperf` testing. It also adds TCP and UDP listeners to the `cniserver.go` and `pinger.go` files to enable the checks between nodes and pods.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a05e06f</samp>

> _Oh we are the `kube-ovn` crew and we work on the net_
> _We listen for TCP and UDP on the ports that we set_
> _We use the `util` package and the `config` flags_
> _And we heave away, me hearties, heave away on the lags_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a05e06f</samp>

*  Add TCP and UDP connectivity checks between nodes and pods in the kube-ovn network ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR112-R126), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-cc7c97c269c4de582c3c4aaaa10bf1dfc8507245babb89bb7cbc2877f6f61a33R39-R52), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704R95-R108), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704R160-R173), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR529-R612))
  * Add two fields to store the port numbers for the TCP and UDP checks in the `Configuration` type in `config.go` files of the `daemon` and `pinger` packages ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R63-R64), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-56f139df697aad97197df93aedd368692be48a0ef3d6a4399b7f17fea0c6c8fcL53-R63))
  * Add two command-line flags to set the port numbers for the TCP and UDP checks in the `ParseFlags` functions in `config.go` files of the `daemon` and `pinger` packages ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R99-R100), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R152-R153), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-56f139df697aad97197df93aedd368692be48a0ef3d6a4399b7f17fea0c6c8fcR127-R128))
  * Add two goroutines to start TCP and UDP listeners on the specified address and port in the `main` functions of the `cniserver.go` and `pinger.go` files of the `daemon` and `pinger` packages, using the `TCPConnectivityListen` and `UDPConnectivityListen` functions from the `util` package ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR112-R126), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-cc7c97c269c4de582c3c4aaaa10bf1dfc8507245babb89bb7cbc2877f6f61a33R39-R52))
  * Add two calls to check the TCP and UDP connectivity to the node and pod IP address and port in the `pingNodes` and `pingPods` functions of the `ping.go` file of the `pinger` package, using the `TCPConnectivityCheck` and `UDPConnectivityCheck` functions from the `util` package, and log the results ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704R95-R108), [link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704R160-R173))
  * Add four functions to implement the logic for checking and listening for TCP and UDP connectivity, using the `net` package, in the `net.go` file of the `util` package ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR529-R612))
  * Add the `time` package to the import list in the `net.go` file of the `util` package, to use it for setting timeouts and deadlines for the TCP and UDP checks ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR12))
* Add a test server pod on the control plane node, which can be used for testing the TCP and UDP connectivity checks from other nodes and pods, in the `test-server.yaml` file in the `test` folder ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-aaa53b027bdb6b3327d2a742e325d6ab2ce9590b2363be945280c1667b22e99bR25-R46))
  * Modify the `command` and `args` fields of the `test-server` container to run `qperf` in the background, before running the `test-server.sh` script, to enable `qperf` testing for the TCP and UDP checks ([link](https://github.com/kubeovn/kube-ovn/pull/2915/files?diff=unified&w=0#diff-aaa53b027bdb6b3327d2a742e325d6ab2ce9590b2363be945280c1667b22e99bR12-R16))