### PR TITLE
fix issue 2916

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -734,6 +734,19 @@ func (c *Controller) getVmLsps() []string {
 					vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, provider)
 					vmLsps = append(vmLsps, vmLsp)
 				}
+
+				for _, network := range vm.Spec.Template.Spec.Networks {
+					if network.Multus != nil && network.Multus.NetworkName != "" {
+						items := strings.Split(network.Multus.NetworkName, "/")
+						if len(items) != 2 {
+							continue
+						}
+						provider := fmt.Sprintf("%s.%s.ovn", items[1], items[0])
+						vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, provider)
+						vmLsps = append(vmLsps, vmLsp)
+					}
+				}
+
 			}
 		}
 	}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Bug fixes
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2916 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9467493</samp>

Support Multus CNI for virtual machines by extracting and deleting logical switch ports from OVN database. Modify `pkg/controller/gc.go` to handle networks defined in the virtual machine spec.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9467493</samp>

> _`Multus` networks_
> _loop and extract port names_
> _autumn leaves fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9467493</samp>

*  Add logic to handle Multus CNI networks for virtual machines ([link](https://github.com/kubeovn/kube-ovn/pull/2917/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R737-R749))