### PR TITLE
add sync map to fix cocurrent write

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -63,7 +63,7 @@ type Controller struct {
 	podsSynced             cache.InformerSynced
 	addOrUpdatePodQueue    workqueue.RateLimitingInterface
 	deletePodQueue         workqueue.RateLimitingInterface
-	deletingPodObjMap      sync.Map
+	deletingPodObjMap      *sync.Map
 	updatePodSecurityQueue workqueue.RateLimitingInterface
 	podKeyMutex            keymutex.KeyMutex
 
@@ -298,12 +298,13 @@ func Run(ctx context.Context, config *Configuration) {
 		numKeyLocks = config.WorkerNum * 2
 	}
 	controller := &Controller{
-		config:          config,
-		vpcs:            &sync.Map{},
-		podSubnetMap:    &sync.Map{},
-		ovnLegacyClient: ovs.NewLegacyClient(config.OvnNbAddr, config.OvnTimeout, config.OvnSbAddr, config.ClusterRouter, config.ClusterTcpLoadBalancer, config.ClusterUdpLoadBalancer, config.ClusterTcpSessionLoadBalancer, config.ClusterUdpSessionLoadBalancer, config.NodeSwitch, config.NodeSwitchCIDR),
-		ipam:            ovnipam.NewIPAM(),
-		namedPort:       NewNamedPort(),
+		config:            config,
+		vpcs:              &sync.Map{},
+		podSubnetMap:      &sync.Map{},
+		deletingPodObjMap: &sync.Map{},
+		ovnLegacyClient:   ovs.NewLegacyClient(config.OvnNbAddr, config.OvnTimeout, config.OvnSbAddr, config.ClusterRouter, config.ClusterTcpLoadBalancer, config.ClusterUdpLoadBalancer, config.ClusterTcpSessionLoadBalancer, config.ClusterUdpSessionLoadBalancer, config.NodeSwitch, config.NodeSwitchCIDR),
+		ipam:              ovnipam.NewIPAM(),
+		namedPort:         NewNamedPort(),
 
 		vpcsLister:           vpcInformer.Lister(),
 		vpcSynced:            vpcInformer.Informer().HasSynced,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -63,7 +63,7 @@ type Controller struct {
 	podsSynced             cache.InformerSynced
 	addOrUpdatePodQueue    workqueue.RateLimitingInterface
 	deletePodQueue         workqueue.RateLimitingInterface
-	deletingPodObjMap      map[string]*corev1.Pod
+	deletingPodObjMap      sync.Map
 	updatePodSecurityQueue workqueue.RateLimitingInterface
 	podKeyMutex            keymutex.KeyMutex
 
@@ -395,7 +395,6 @@ func Run(ctx context.Context, config *Configuration) {
 			workqueue.NewNamedDelayingQueue("DeletePod"),
 			workqueue.DefaultControllerRateLimiter(),
 		),
-		deletingPodObjMap:      make(map[string]*corev1.Pod),
 		updatePodSecurityQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdatePodSecurity"),
 		podKeyMutex:            keymutex.NewHashed(numKeyLocks),
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2907

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67e9f20</samp>

This pull request enhances the pod deletion logic in the `Controller` type by using a `sync.Map` for the `deletingPodObjMap` field. This improves the thread-safety and performance of the controller when handling pod deletion events. The pull request modifies `pkg/controller/controller.go` and `pkg/controller/pod.go` to use the `sync.Map` type.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 67e9f20</samp>

> _There once was a type called `Controller`_
> _That managed the pods of a cluster_
> _To delete them with care_
> _It used a `sync.Map` there_
> _And thus made its performance much bolder_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67e9f20</samp>

*  Replace regular map with `sync.Map` for `deletingPodObjMap` field of `Controller` type to improve thread-safety and avoid concurrent map access errors ([link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L66-R66), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L398))
* Use `Store` method of `sync.Map` to atomically set the value for a key in `deletingPodObjMap` in various functions that enqueue pod events ([link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L202-R212), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L243-R243), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L297-R297), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L317-R317), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L327-R327), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L335-R335), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L721-R720), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L868-R867))
* Use `Load` method of `sync.Map` to atomically get the value for a key in `deletingPodObjMap` in functions that process pod deletion events ([link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L423-R423), [link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L879-R882))
* Use `Delete` method of `sync.Map` to atomically remove the value for a key in `deletingPodObjMap` in `processNextDeletePodWorkItem` function ([link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L438-R437))
* Check the second return value of `Load` method to handle the case where the key is not found in `deletingPodObjMap` in `handleDeletePod` function ([link](https://github.com/kubeovn/kube-ovn/pull/2918/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L879-R882))