### PR TITLE
cni-server: clear iptables mark before doing masquerade

### DIFF
--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -520,7 +520,7 @@ func (c *Controller) setIptables() error {
 			// do not nat node port service traffic with external traffic policy set to local
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m mark --mark 0x80000/0x80000 -m set --match-set ovn40subnets-distributed-gw dst -j RETURN`)},
 			// nat node port service traffic with external traffic policy set to local for subnets with centralized gateway
-			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m mark --mark 0x80000/0x80000 -j` + OvnMasquerade)},
+			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-m mark --mark 0x80000/0x80000 -j ` + OvnMasquerade)},
 			// do not nat reply packets in direct routing
 			{Table: NAT, Chain: OvnPostrouting, Rule: strings.Fields(`-p tcp -m tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -j RETURN`)},
 			// do not nat route traffic


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes bad checksum while accessing pods running on other nodes via service:

```txt
15:17:04.808484 IP (tos 0x0, ttl 64, id 36415, offset 0, flags [DF], proto UDP (17), length 170)
    192.168.129.203.18647 > 192.168.129.205.6081: [bad udp cksum 0x82d8 -> 0xa635!] Geneve, Flags [C], vni 0x3, options [class Open Virtual Networking (OVN) (0x102) type 0x80(C) len 8 data 00010021]
    IP6 (hlim 63, next-header UDP (17) payload length: 72) fd00:100:64::2.41375 > fd00:10:16::24.1053: [udp sum ok] UDP, length 64
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb1b85e</samp>

Add a new iptables chain for node port service traffic with local external policy. Refactor some iptables functions and rules in `gateway_linux.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bb1b85e</samp>

> _To handle node port traffic well_
> _This pull request adds `OvnNodePort` shell_
> _It also refactors rules_
> _And some iptables tools_
> _To make them more readable and swell_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb1b85e</samp>

*  Add a new iptables chain `OvnNodePort` to handle node port service traffic with external traffic policy set to Local ([link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R46), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L515-R539), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R551-R556), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L550-R578), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R589-R594), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L685-R712), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R729-R734), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R769-R772))
*  Extract a new function `createIptablesChain` from `updateIptablesChain` to simplify the logic of ensuring the iptables chain exists ([link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L423-R429))
*  Modify `updateIptablesChain` to use `createIptablesChain` for both the chain and its parent chain, and return early if the chain already exists ([link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L429-R454))
*  Use a short variable declaration for the error variable `err` in `updateIptablesChain` ([link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L443-R462))
*  Replace the iptables rules that nat packets marked by kube-proxy or kube-ovn with rules that return those packets, since they will be SNATed later by kube-proxy ([link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L515-R539), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L550-R578))
*  Add the `--random-fully` option to the MASQUERADE rules if the iptables version supports it, which improves the performance and reduces the risk of port exhaustion ([link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R551-R556), [link](https://github.com/kubeovn/kube-ovn/pull/2919/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R589-R594))