### PR TITLE
add subnet.spec.u2oInterconnectionIP

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1749,6 +1749,8 @@ spec:
                             type: string
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
                 enableLb:
                   type: boolean
                 enableEcmp:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2287,6 +2287,8 @@ spec:
                             type: string
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
                 enableLb:
                   type: boolean
                 enableEcmp:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -161,9 +161,10 @@ type SubnetSpec struct {
 
 	NatOutgoingPolicyRules []NatOutgoingPolicyRule `json:"natOutgoingPolicyRules,omitempty"`
 
-	U2OInterconnection bool  `json:"u2oInterconnection,omitempty"`
-	EnableLb           *bool `json:"enableLb,omitempty"`
-	EnableEcmp         bool  `json:"enableEcmp,omitempty"`
+	U2OInterconnectionIP string `json:"u2oInterconnectionIP,omitempty"`
+	U2OInterconnection   bool   `json:"u2oInterconnection,omitempty"`
+	EnableLb             *bool  `json:"enableLb,omitempty"`
+	EnableEcmp           bool   `json:"enableEcmp,omitempty"`
 
 	RouteTable string `json:"routeTable,omitempty"`
 }

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -118,7 +118,7 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 
 	if subnet.Spec.U2OInterconnectionIP != "" {
 		if !CIDRContainIP(subnet.Spec.CIDRBlock, subnet.Spec.U2OInterconnectionIP) {
-			return fmt.Errorf("u2oInterconnectionIP %s conflicts with subnet %s cidr %s",
+			return fmt.Errorf("u2oInterconnectionIP %s is not in subnet %s cidr %s",
 				subnet.Spec.U2OInterconnectionIP,
 				subnet.Name, subnet.Spec.CIDRBlock)
 		}

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -115,6 +115,15 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 			return err
 		}
 	}
+
+	if subnet.Spec.U2OInterconnectionIP != "" {
+		if !CIDRContainIP(subnet.Spec.CIDRBlock, subnet.Spec.U2OInterconnectionIP) {
+			return fmt.Errorf("u2oInterconnectionIP %s conflicts with subnet %s cidr %s",
+				subnet.Spec.U2OInterconnectionIP,
+				subnet.Name, subnet.Spec.CIDRBlock)
+		}
+	}
+
 	return nil
 }
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -2060,6 +2060,8 @@ spec:
                             type: string
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
                 enableLb:
                   type: boolean
                 enableEcmp:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2888 
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2cf2a80</samp>

This pull request adds a new feature to allow specifying a static IP address for the underlay to overlay interconnection for a subnet. It also updates the validation, reconciliation, and e2e tests for this feature. It modifies the `SubnetSpec` and `SubnetStatus` schemas in the `types.go`, `kube-ovn-crd.yaml`, and `crd.yaml` files to add a new field `U2OInterconnectionIP`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2cf2a80</samp>

> _Sing, O Muse, of the cunning engineers who devised_
> _A way to link the underlay and overlay networks with ease_
> _By adding to the `SubnetSpec` a field of great renown_
> _The `U2OInterconnectionIP`, the glory of the cloud_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2cf2a80</samp>

*  Add a new field `U2OInterconnectionIP` to the `SubnetSpec` struct to specify a static IP address for the underlay to overlay interconnection for a subnet ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aL164-R167))
*  Add a new field `u2oInterconnectionIP` to the `SubnetStatus` schema to store the IP address of the logical router port that connects the underlay and overlay networks for a subnet ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1752-R1753), [link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R2063-R2064))
*  Update the custom resource definition of the subnet with the new field in `crd.yaml` and `kube-ovn-crd.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1752-R1753), [link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R2063-R2064))
*  Validate the `U2OInterconnectionIP` field in the `ValidateSubnet` function and check if it is contained in the subnet CIDR ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-7f0dbc597e1344dab5f2b581992a7ad0423ff2087593902fe39429d0a980782bR118-R126))
*  Enqueue a subnet for reconciliation when the `U2OInterconnectionIP` field has changed in the `enqueueUpdateSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L106-R108))
*  Clear the `U2OInterconnectionIP` field if the `U2OInterconnection` field is false and set the `changed` flag to true in the `formatSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R316-R320))
*  Allocate and release the static or dynamic IP address for the underlay to overlay interconnection for a subnet in the `reconcileU2OInterconnectionIP` function ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1806-R1835))
  *  Avoid unnecessary errors when deleting the pods, subnets, and vpc in the `AfterEach` block ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL282-R304))
  *  Test the `U2OInterconnectionIP` feature by changing the IP address twice and verifying the connectivity in the `It` block ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL638-R680))
  *  Check the version of the kube-ovn controller and verify the `U2OInterconnectionIP` field in the subnet spec and status in the `checkU2OItems` function ([link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR705-R710), [link](https://github.com/kubeovn/kube-ovn/pull/2921/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR717-R720))