### PR TITLE
modify lb-svc dnat port error

### DIFF
--- a/pkg/controller/service_lb.go
+++ b/pkg/controller/service_lb.go
@@ -320,7 +320,7 @@ func (c *Controller) updatePodAttachNets(pod *corev1.Pod, svc *corev1.Service) e
 		}
 
 		var rules []string
-		rules = append(rules, fmt.Sprintf("%s,%d,%s,%s,%d,%s", loadBalancerIP, port.Port, protocol, svc.Spec.ClusterIP, port.TargetPort.IntVal, defaultGateway))
+		rules = append(rules, fmt.Sprintf("%s,%d,%s,%s,%d,%s", loadBalancerIP, port.Port, protocol, svc.Spec.ClusterIP, port.Port, defaultGateway))
 		klog.Infof("add dnat rules for lb svc pod, %v", rules)
 		if err := c.execNatRules(pod, POD_DNAT_ADD, rules); err != nil {
 			klog.Errorf("failed to add dnat for pod, err: %v", err)


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes


### Which issue(s) this PR fixes:
Fixes #2835 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e15922</samp>

Fix DNAT rules for load balancer services in `service_lb.go`. Use service port instead of pod port as destination port.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e15922</samp>

> _Fix DNAT bug_
> _`port` of service, not pod_
> _Winter of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e15922</samp>

* Fix DNAT rules for load balancer service pods to use service port instead of pod port as destination port ([link](https://github.com/kubeovn/kube-ovn/pull/2927/files?diff=unified&w=0#diff-ddee62564b10db25f89355fdeef7a708ee6a588ea55c2d86531c36e19ca70d2eL323-R323))