### PR TITLE
fix race condition in gateway check logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,12 +23,12 @@ require (
 	github.com/kubeovn/gonetworkmanager/v2 v2.0.0-20230327064018-0b27f88874f7
 	github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875
 	github.com/moby/sys/mountinfo v0.6.2
-	github.com/oilbeater/go-ping v0.0.0-20200413021620-332b7197c5b5
 	github.com/onsi/ginkgo/v2 v2.10.0
 	github.com/onsi/gomega v1.27.8
 	github.com/osrg/gobgp/v3 v3.15.0
 	github.com/ovn-org/libovsdb v0.0.0-20230207174348-7f620a35d7e8
 	github.com/parnurzeal/gorequest v0.2.16
+	github.com/prometheus-community/pro-bing v0.2.0
 	github.com/prometheus/client_golang v1.15.1
 	github.com/scylladb/go-set v1.0.2
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -1061,8 +1061,6 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/oilbeater/go-ping v0.0.0-20200413021620-332b7197c5b5 h1:r2QP8IbxbQJeRsxlNEMjS48F5LajUp/g/LDlLhEtxQ0=
-github.com/oilbeater/go-ping v0.0.0-20200413021620-332b7197c5b5/go.mod h1:ZeD7oOS+O/ywjMQWgHqo1tUGfNzB6mNAmv/MYAWxmWg=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v0.0.0-20170117200651-66bb6560562f/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -1195,6 +1193,8 @@ github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 h1:J
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54/go.mod h1:UgC0aTQ2KMDxlX3lU/stndk7DMUBJqzN40yFiILHgxc=
 github.com/projectcalico/libcalico-go v0.0.0-20190305235709-3d935c3b8b86 h1:YOg439Y4IiIFQrwaY3D6l/eB8fsXTBMtCE7TKCogROI=
 github.com/projectcalico/libcalico-go v0.0.0-20190305235709-3d935c3b8b86/go.mod h1:0b/n/rPzNXjhn4ywFcEJuQdA/5olt9UxFIATz57xkbc=
+github.com/prometheus-community/pro-bing v0.2.0 h1:hyK7yPFndU3LCDwEQJwPQUCjNkp1DGP/VxyzrWfXZUU=
+github.com/prometheus-community/pro-bing v0.2.0/go.mod h1:20arNb2S8rNG3EtmjHyZZU92cfbhQx7oCHZ9sulAV+I=
 github.com/prometheus/alertmanager v0.18.0/go.mod h1:WcxHBl40VSPuOaqWae6l6HpnEOVRIycEJ7i9iYkadEE=
 github.com/prometheus/alertmanager v0.20.0/go.mod h1:9g2i48FAyZW6BtbsnvHtMHQXl2aVtrORKwKVCQ+nbrg=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	goping "github.com/oilbeater/go-ping"
+	goping "github.com/prometheus-community/pro-bing"
 	"github.com/scylladb/go-set/strset"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -809,7 +809,10 @@ func (c *Controller) checkGatewayReady() error {
 							success = true
 							pinger.Stop()
 						}
-						pinger.Run()
+						if err = pinger.Run(); err != nil {
+							klog.Errorf("failed to run pinger for destination %s: %v", ip, err)
+							return err
+						}
 
 						if !nodeReady(node) {
 							success = false

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -412,7 +412,7 @@ func (c *Controller) createIptablesRule(ipt *iptables.IPTables, rule util.IPTabl
 		return nil
 	}
 
-	klog.Infof(`creating iptables rules: "%s"`, s)
+	klog.Infof("creating iptables rule in table %s chain %s at position %d: %q", rule.Table, rule.Chain, 1, s)
 	if err = ipt.Insert(rule.Table, rule.Chain, 1, rule.Rule...); err != nil {
 		klog.Errorf(`failed to insert iptables rule "%s": %v`, s, err)
 		return err
@@ -470,11 +470,11 @@ func (c *Controller) updateIptablesChain(ipt *iptables.IPTables, table, chain, p
 			klog.V(5).Infof("iptables rule %v already exists", rule.Rule)
 			continue
 		}
+		klog.Infof("creating iptables rule in table %s chain %s at position %d: %q", table, chain, i+1, strings.Join(rule.Rule, " "))
 		if err = ipt.Insert(table, chain, i+1, rule.Rule...); err != nil {
 			klog.Errorf(`failed to insert iptables rule %v: %v`, rule.Rule, err)
 			return err
 		}
-		klog.Infof(`created iptables rule %v`, rule.Rule)
 		added++
 	}
 	for i := len(existingRules) - 1; i >= len(rules)-added; i-- {

--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	goping "github.com/oilbeater/go-ping"
+	goping "github.com/prometheus-community/pro-bing"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -14,10 +14,10 @@ import (
 
 const gatewayCheckMaxRetry = 200
 
-func pingGateway(gw, src string, verbose bool, maxRetry int) error {
+func pingGateway(gw, src string, verbose bool, maxRetry int) (count int, err error) {
 	pinger, err := goping.NewPinger(gw)
 	if err != nil {
-		return fmt.Errorf("failed to init pinger: %v", err)
+		return 0, fmt.Errorf("failed to init pinger: %v", err)
 	}
 	pinger.SetPrivileged(true)
 	// CNITimeoutSec = 220, cannot exceed
@@ -29,30 +29,23 @@ func pingGateway(gw, src string, verbose bool, maxRetry int) error {
 		pinger.Stop()
 	}
 
-	// long time keep ping may result in readiness probe failed when start
-	// show ping fails when gw not work
-	go func() {
-		for {
-			time.Sleep(3 * time.Second)
-			stats := pinger.Statistics()
-			if stats.PacketsSent >= pinger.Count {
-				break
-			}
-			if stats.PacketsRecv == 0 {
-				klog.Errorf("%s network not ready after %d ping %s, %v%% packet loss", src, stats.PacketsSent, gw, stats.PacketLoss)
-			} else {
-				break
-			}
+	pinger.OnSend = func(p *goping.Packet) {
+		if pinger.PacketsRecv == 0 && pinger.PacketsSent != 0 && pinger.PacketsSent%3 == 0 {
+			klog.Warningf("%s network not ready after %d ping to gateway %s", src, pinger.PacketsSent, gw)
 		}
-	}()
+	}
 
-	pinger.Run()
+	if err = pinger.Run(); err != nil {
+		klog.Errorf("failed to run pinger for destination %s: %v", gw, err)
+		return 0, err
+	}
+
 	cniConnectivityResult.WithLabelValues(nodeName).Add(float64(pinger.PacketsSent))
 	if verbose {
 		klog.Infof("%s network ready after %d ping, gw %s", src, pinger.PacketsSent, gw)
 	}
 
-	return nil
+	return pinger.PacketsSent, nil
 }
 
 func configureGlobalMirror(portName string, mtu int) error {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -363,10 +363,13 @@ func waitNetworkReady(nic, ipAddr, gateway string, underlayGateway, verbose bool
 				klog.Infof("MAC addresses of gateway %s is %s", gw, mac.String())
 				klog.Infof("network %s with gateway %s is ready for interface %s after %d checks", ips[i], gw, nic, count)
 			}
+			maxRetry -= count
 		} else {
-			if err := pingGateway(gw, src, verbose, maxRetry); err != nil {
+			count, err := pingGateway(gw, src, verbose, maxRetry)
+			if err != nil {
 				return err
 			}
+			maxRetry -= count
 		}
 	}
 	return nil

--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -242,9 +242,11 @@ func waitNetworkReady(nic, ipAddr, gateway string, underlayGateway, verbose bool
 	for i, gw := range strings.Split(gateway, ",") {
 		src := strings.Split(ips[i], "/")[0]
 		if !underlayGateway || util.CheckProtocol(gw) == kubeovnv1.ProtocolIPv6 {
-			if err := pingGateway(gw, src, verbose, maxRetry); err != nil {
+			count, err := pingGateway(gw, src, verbose, maxRetry)
+			if err != nil {
 				return err
 			}
+			maxRetry -= count
 		}
 	}
 	return nil


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #2850 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2203a6</samp>

Replaced the ping library `github.com/oilbeater/go-ping` with `github.com/prometheus-community/pro-bing` for better ping functionality and logging. Updated the import statements and the pingGateway function in the daemon, controller, and pinger packages. Improved the logging of iptables rule creation in `gateway_linux.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f2203a6</samp>

> _Sing, O Muse, of the valiant code review_
> _That changed the import of the `goping` tool_
> _And made the network pings more swift and true_
> _With `pro-bing`, the library of the cool._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2203a6</samp>

*  Replace `github.com/oilbeater/go-ping` with `github.com/prometheus-community/pro-bing` for sending ICMP ping packets and collecting statistics ([link](https://github.com/kubeovn/kube-ovn/pull/2928/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L26), [link](https://github.com/kubeovn/kube-ovn/pull/2928/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R31), [link](https://github.com/kubeovn/kube-ovn/pull/2928/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L13-R13), [link](https://github.com/kubeovn/kube-ovn/pull/2928/files?diff=unified&w=0#diff-067d64bdcf68917f106b1f905d4608e8927a7ea0e9388b9e225c147566ece237L8-R8), [link](https://github.com/kubeovn/kube-ovn/pull/2928/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704L12-R12))
*  Use `OnSend` callback of `pinger` to log warnings every three packets sent if no response from gateway, instead of using a separate goroutine to check ping statistics and log errors ([link](https://github.com/kubeovn/kube-ovn/pull/2928/files?diff=unified&w=0#diff-067d64bdcf68917f106b1f905d4608e8927a7ea0e9388b9e225c147566ece237L32-R36))
*  Improve log messages for creating iptables rules in `gateway_linux.go` to include more information about the table, chain and position of the rule, and to use a consistent format for quoting the rule string ([link](https://github.com/kubeovn/kube-ovn/pull/2928/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L415-R415), [link](https://github.com/kubeovn/kube-ovn/pull/2928/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L473-R477))