### PR TITLE
suport specify u2o from v1.9

### DIFF
--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -616,68 +616,11 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		subnet = subnetClient.Get(subnetName)
 		checkU2OItems(f, subnet, underlayPod, overlayPod, false)
 
-		if f.VersionPriorTo(1, 11) {
+		if f.VersionPriorTo(1, 9) {
 			return
 		}
 
-		ginkgo.By("step7: Change underlay subnet interconnection to overlay subnet in custom vpc")
-
-		ginkgo.By("Deleting underlay pod " + u2oPodNameUnderlay)
-		podClient.DeleteSync(u2oPodNameUnderlay)
-
-		ginkgo.By("Creating VPC " + vpcName)
-		customVPC := framework.MakeVpc(vpcName, "", false, false, []string{namespaceName})
-		vpcClient.CreateSync(customVPC)
-
-		ginkgo.By("Creating subnet " + u2oOverlaySubnetNameCustomVPC)
-		cidr = framework.RandomCIDR(f.ClusterIpFamily)
-		overlaySubnetCustomVpc := framework.MakeSubnet(u2oOverlaySubnetNameCustomVPC, "", cidr, "", vpcName, "", nil, nil, []string{namespaceName})
-		_ = subnetClient.CreateSync(overlaySubnetCustomVpc)
-
-		ginkgo.By("Creating overlay pod " + u2oPodOverlayCustomVPC)
-		args = []string{"netexec", "--http-port", strconv.Itoa(curlListenPort)}
-		u2oPodOverlayCustomVPCAnnotations := map[string]string{
-			util.LogicalSwitchAnnotation: u2oOverlaySubnetNameCustomVPC,
-		}
-		podOverlayCustomVPC := framework.MakePod(namespaceName, u2oPodOverlayCustomVPC, nil, u2oPodOverlayCustomVPCAnnotations, framework.AgnhostImage, nil, args)
-		podOverlayCustomVPC = podClient.CreateSync(podOverlayCustomVPC)
-
-		ginkgo.By("Turning on U2OInterconnection and set VPC to " + vpcName + " for subnet " + subnetName)
-		subnet = subnetClient.Get(subnetName)
-		modifiedSubnet = subnet.DeepCopy()
-		modifiedSubnet.Spec.Vpc = vpcName
-		modifiedSubnet.Spec.U2OInterconnection = true
-		subnetClient.PatchSync(subnet, modifiedSubnet)
-
-		ginkgo.By("Creating underlay pod " + u2oPodNameUnderlay)
-		underlayPod = podClient.CreateSync(originUnderlayPod)
-
-		subnet = subnetClient.Get(subnetName)
-		checkU2OItems(f, subnet, underlayPod, podOverlayCustomVPC, true)
-
-		ginkgo.By("step8: Change underlay subnet interconnection to overlay subnet in default vpc")
-
-		ginkgo.By("Deleting underlay pod " + u2oPodNameUnderlay)
-		podClient.DeleteSync(u2oPodNameUnderlay)
-
-		ginkgo.By("Setting VPC to " + util.DefaultVpc + " for subnet " + subnetName)
-		subnet = subnetClient.Get(subnetName)
-		modifiedSubnet = subnet.DeepCopy()
-		modifiedSubnet.Spec.Vpc = util.DefaultVpc
-		modifiedSubnet.Spec.Namespaces = nil
-		subnetClient.PatchSync(subnet, modifiedSubnet)
-
-		ginkgo.By("Creating underlay pod " + u2oPodNameUnderlay)
-		underlayPod = podClient.CreateSync(originUnderlayPod)
-
-		subnet = subnetClient.Get(subnetName)
-		checkU2OItems(f, subnet, underlayPod, overlayPod, false)
-
-		if f.VersionPriorTo(1, 12) {
-			return
-		}
-
-		ginkgo.By("step9: Specify u2oInterconnectionIP")
+		ginkgo.By("step7: Specify u2oInterconnectionIP")
 
 		// change u2o interconnection ip twice
 		for i := 0; i < 2; i++ {
@@ -713,6 +656,63 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 			checkU2OItems(f, subnet, underlayPod, overlayPod, false)
 		}
 
+		if f.VersionPriorTo(1, 11) {
+			return
+		}
+
+		ginkgo.By("step8: Change underlay subnet interconnection to overlay subnet in custom vpc")
+
+		ginkgo.By("Deleting underlay pod " + u2oPodNameUnderlay)
+		podClient.DeleteSync(u2oPodNameUnderlay)
+
+		ginkgo.By("Creating VPC " + vpcName)
+		customVPC := framework.MakeVpc(vpcName, "", false, false, []string{namespaceName})
+		vpcClient.CreateSync(customVPC)
+
+		ginkgo.By("Creating subnet " + u2oOverlaySubnetNameCustomVPC)
+		cidr = framework.RandomCIDR(f.ClusterIpFamily)
+		overlaySubnetCustomVpc := framework.MakeSubnet(u2oOverlaySubnetNameCustomVPC, "", cidr, "", vpcName, "", nil, nil, []string{namespaceName})
+		_ = subnetClient.CreateSync(overlaySubnetCustomVpc)
+
+		ginkgo.By("Creating overlay pod " + u2oPodOverlayCustomVPC)
+		args = []string{"netexec", "--http-port", strconv.Itoa(curlListenPort)}
+		u2oPodOverlayCustomVPCAnnotations := map[string]string{
+			util.LogicalSwitchAnnotation: u2oOverlaySubnetNameCustomVPC,
+		}
+		podOverlayCustomVPC := framework.MakePod(namespaceName, u2oPodOverlayCustomVPC, nil, u2oPodOverlayCustomVPCAnnotations, framework.AgnhostImage, nil, args)
+		podOverlayCustomVPC = podClient.CreateSync(podOverlayCustomVPC)
+
+		ginkgo.By("Turning on U2OInterconnection and set VPC to " + vpcName + " for subnet " + subnetName)
+		subnet = subnetClient.Get(subnetName)
+		modifiedSubnet = subnet.DeepCopy()
+		modifiedSubnet.Spec.Vpc = vpcName
+		modifiedSubnet.Spec.U2OInterconnection = true
+		subnetClient.PatchSync(subnet, modifiedSubnet)
+
+		ginkgo.By("Creating underlay pod " + u2oPodNameUnderlay)
+		underlayPod = podClient.CreateSync(originUnderlayPod)
+
+		subnet = subnetClient.Get(subnetName)
+		checkU2OItems(f, subnet, underlayPod, podOverlayCustomVPC, true)
+
+		ginkgo.By("step9: Change underlay subnet interconnection to overlay subnet in default vpc")
+
+		ginkgo.By("Deleting underlay pod " + u2oPodNameUnderlay)
+		podClient.DeleteSync(u2oPodNameUnderlay)
+
+		ginkgo.By("Setting VPC to " + util.DefaultVpc + " for subnet " + subnetName)
+		subnet = subnetClient.Get(subnetName)
+		modifiedSubnet = subnet.DeepCopy()
+		modifiedSubnet.Spec.Vpc = util.DefaultVpc
+		modifiedSubnet.Spec.Namespaces = nil
+		subnetClient.PatchSync(subnet, modifiedSubnet)
+
+		ginkgo.By("Creating underlay pod " + u2oPodNameUnderlay)
+		underlayPod = podClient.CreateSync(originUnderlayPod)
+
+		subnet = subnetClient.Get(subnetName)
+		checkU2OItems(f, subnet, underlayPod, overlayPod, false)
+
 		ginkgo.By("step10: Disable u2o")
 
 		ginkgo.By("Deleting underlay pod " + u2oPodNameUnderlay)
@@ -740,7 +740,7 @@ func checkU2OItems(f *framework.Framework, subnet *apiv1.Subnet, underlayPod, ov
 		if !f.VersionPriorTo(1, 11) {
 			framework.ExpectEqual(subnet.Status.U2OInterconnectionVPC, subnet.Spec.Vpc)
 		}
-		if !f.VersionPriorTo(1, 12) {
+		if !f.VersionPriorTo(1, 9) {
 			if subnet.Spec.U2OInterconnectionIP != "" {
 				framework.ExpectEqual(subnet.Spec.U2OInterconnectionIP, subnet.Status.U2OInterconnectionIP)
 			}
@@ -751,7 +751,7 @@ func checkU2OItems(f *framework.Framework, subnet *apiv1.Subnet, underlayPod, ov
 		if !f.VersionPriorTo(1, 11) {
 			framework.ExpectEmpty(subnet.Status.U2OInterconnectionVPC)
 		}
-		if !f.VersionPriorTo(1, 12) {
+		if !f.VersionPriorTo(1, 9) {
 			framework.ExpectEmpty(subnet.Spec.U2OInterconnectionIP)
 		}
 	}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 138524e</samp>

Add and update e2e test for underlay to overlay subnet interconnection. Fix version checks and remove redundant steps in `test/e2e/kube-ovn/underlay/underlay.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 138524e</samp>

> _To test `u2oInterconnectionIP`_
> _We added and updated the script_
> _We fixed some versions_
> _And removed diversions_
> _To make the feature more robust and snappy_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 138524e</samp>

*  Add a new step to test u2oInterconnectionIP feature for underlay subnet interconnection to overlay subnet ([link](https://github.com/kubeovn/kube-ovn/pull/2934/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL604-R635))
* Update step number from 8 to 9, since previous step was added ([link](https://github.com/kubeovn/kube-ovn/pull/2934/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL636-R666))
* Remove redundant step of testing u2oInterconnectionIP feature, since it was already tested in previous step ([link](https://github.com/kubeovn/kube-ovn/pull/2934/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL650-L681))
* Update version check from 1.12 to 1.9, since u2oInterconnectionIP feature was introduced in v1.9 ([link](https://github.com/kubeovn/kube-ovn/pull/2934/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL707-R705), [link](https://github.com/kubeovn/kube-ovn/pull/2934/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL720-R718))