### PR TITLE
u2o support specify u2o ip on release-1.9

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -613,6 +613,8 @@ spec:
                   type: string
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
   scope: Cluster
   names:
     plural: subnets

--- a/kubeovn-helm/templates/kube-ovn-crd.yaml
+++ b/kubeovn-helm/templates/kube-ovn-crd.yaml
@@ -436,6 +436,8 @@ spec:
                   type: string
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
   scope: Cluster
   names:
     plural: subnets

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -124,11 +124,12 @@ type SubnetSpec struct {
 	Vlan   string `json:"vlan,omitempty"`
 	HtbQos string `json:"htbqos,omitempty"`
 
-	LogicalGateway         bool `json:"logicalGateway,omitempty"`
-	DisableGatewayCheck    bool `json:"disableGatewayCheck,omitempty"`
-	DisableInterConnection bool `json:"disableInterConnection,omitempty"`
-	U2OInterconnection     bool `json:"u2oInterconnection,omitempty"`
+	LogicalGateway         bool   `json:"logicalGateway,omitempty"`
+	DisableGatewayCheck    bool   `json:"disableGatewayCheck,omitempty"`
+	DisableInterConnection bool   `json:"disableInterConnection,omitempty"`
+	U2OInterconnection     bool   `json:"u2oInterconnection,omitempty"`
 	U2OInterconnectionIP   string `json:"u2oInterconnectionIP,omitempty"`
+}
 
 // ConditionType encodes information on the condition
 type ConditionType string

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -128,7 +128,7 @@ type SubnetSpec struct {
 	DisableGatewayCheck    bool `json:"disableGatewayCheck,omitempty"`
 	DisableInterConnection bool `json:"disableInterConnection,omitempty"`
 	U2OInterconnection     bool `json:"u2oInterconnection,omitempty"`
-}
+	U2OInterconnectionIP   string `json:"u2oInterconnectionIP,omitempty"`
 
 // ConditionType encodes information on the condition
 type ConditionType string

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1965,3 +1965,20 @@ func (c *Controller) acquireIpAddress(subnetName, name, nicName string) (string,
 		}
 	}
 }
+
+func (c *Controller) acquireStaticIpAddress(subnetName, name, nicName, ip string) (string, string, string, error) {
+	checkConflict := true
+	var v4ip, v6ip, mac string
+	var err error
+	for _, ipStr := range strings.Split(ip, ",") {
+		if net.ParseIP(ipStr) == nil {
+			return "", "", "", fmt.Errorf("failed to parse vip ip %s", ipStr)
+		}
+	}
+
+	if v4ip, v6ip, mac, err = c.ipam.GetStaticAddress(name, nicName, ip, "", subnetName, checkConflict); err != nil {
+		klog.Errorf("failed to get static virtual ip '%s', mac '%s', subnet '%s', %v", ip, mac, subnetName, err)
+		return "", "", "", err
+	}
+	return v4ip, v6ip, mac, nil
+}

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -111,6 +111,18 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		}
 	}
 
+	if subnet.Spec.LogicalGateway && subnet.Spec.U2OInterconnection {
+		return fmt.Errorf("logicalGateway and u2oInterconnection can't be opened at the same time")
+	}
+
+	if subnet.Spec.U2OInterconnectionIP != "" {
+		if !CIDRContainIP(subnet.Spec.CIDRBlock, subnet.Spec.U2OInterconnectionIP) {
+			return fmt.Errorf("u2oInterconnectionIP %s is not in subnet %s cidr %s",
+				subnet.Spec.U2OInterconnectionIP,
+				subnet.Name, subnet.Spec.CIDRBlock)
+		}
+	}
+
 	return nil
 }
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -225,6 +225,8 @@ spec:
                   type: string
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
   scope: Cluster
   names:
     plural: subnets


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed91ab1</samp>

This pull request adds a new feature to allow users to specify a static IP address for the underlay to overlay interconnection in each subnet. It modifies the `SubnetSpec` schema and struct, the `subnet.go` and `validator.go` files, and the `kube-ovn-crd.yaml` and `crd.yaml` files to support the new `u2oInterconnectionIP` field and its validation and reconciliation logic. It also adds a check to prevent users from enabling both the logical gateway and the underlay to overlay interconnection features at the same time.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ed91ab1</samp>

> _Oh we are the coders of the kube-ovn_
> _We make the subnets interconnect_
> _We heave and we ho and we add a new field_
> _`u2oInterconnectionIP` we set_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed91ab1</samp>

*  Add `u2oInterconnectionIP` field to `SubnetSpec` schema and struct to allow users to configure the underlay to overlay interconnection IP address for each subnet ([link](https://github.com/kubeovn/kube-ovn/pull/2935/files?diff=unified&w=0#diff-cf6e828a3b8334b0180f06b380614f951d45a1a12d49efce74818fd68882a868R439-R440), [link](https://github.com/kubeovn/kube-ovn/pull/2935/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aL131-R131), [link](https://github.com/kubeovn/kube-ovn/pull/2935/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R228-R229))
*  Enqueue subnet key for processing when `u2oInterconnectionIP` field changes in `enqueueUpdateSubnet` function in `subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2935/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L95-R97))
*  Clear `u2oInterconnectionIP` field and set `changed` flag if `u2oInterconnection` field is not set in `formatSubnet` function in `subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2935/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R279-R283))
*  Acquire or release static IP address for underlay to overlay interconnection logical router port based on `u2oInterconnectionIP` field in `reconcileU2OInterconnectionIP` function in `subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2935/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1222-R1251))
*  Validate that `logicalGateway` and `u2oInterconnection` fields are not both set to true, and that `u2oInterconnectionIP` field is within subnet CIDR range in `ValidateSubnet` function in `validator.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2935/files?diff=unified&w=0#diff-7f0dbc597e1344dab5f2b581992a7ad0423ff2087593902fe39429d0a980782bR114-R125))