### PR TITLE
u2o specify u2o ip on release-1.10

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1094,6 +1094,8 @@ spec:
                           - reject
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
   scope: Cluster
   names:
     plural: subnets

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -139,7 +139,8 @@ type SubnetSpec struct {
 
 	Acls []Acl `json:"acls,omitempty"`
 
-	U2OInterconnection bool `json:"u2oInterconnection,omitempty"`
+	U2OInterconnection   bool   `json:"u2oInterconnection,omitempty"`
+	U2OInterconnectionIP string `json:"u2oInterconnectionIP,omitempty"`
 }
 
 type Acl struct {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -100,7 +100,9 @@ func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
 		oldSubnet.Spec.IPv6RAConfigs != newSubnet.Spec.IPv6RAConfigs ||
 		oldSubnet.Spec.Protocol != newSubnet.Spec.Protocol ||
 		!reflect.DeepEqual(oldSubnet.Spec.Acls, newSubnet.Spec.Acls) ||
-		oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection {
+		oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection ||
+		(newSubnet.Spec.U2OInterconnection && newSubnet.Spec.U2OInterconnectionIP != "" &&
+			oldSubnet.Spec.U2OInterconnectionIP != newSubnet.Spec.U2OInterconnectionIP) {
 		klog.V(3).Infof("enqueue update subnet %s", key)
 		c.addOrUpdateSubnetQueue.Add(key)
 	}
@@ -318,6 +320,11 @@ func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 			}
 		}
 	}
+	if subnet.Spec.U2OInterconnectionIP != "" && !subnet.Spec.U2OInterconnection {
+		subnet.Spec.U2OInterconnectionIP = ""
+		changed = true
+	}
+
 	klog.Infof("format subnet %v, changed %v", subnet.Name, changed)
 	if changed {
 		_, err = c.config.KubeOvnClient.KubeovnV1().Subnets().Update(context.Background(), subnet, metav1.UpdateOptions{})
@@ -1387,14 +1394,29 @@ func (c *Controller) reconcileU2OInterconnectionIP(subnet *kubeovnv1.Subnet) err
 	klog.Infof("reconcile underlay subnet %s  to overlay interconnection with U2OInterconnection %v U2OInterconnectionIP %s ",
 		subnet.Name, subnet.Spec.U2OInterconnection, subnet.Status.U2OInterconnectionIP)
 	if subnet.Spec.U2OInterconnection {
-		if subnet.Status.U2OInterconnectionIP == "" {
-			u2oInterconnName := fmt.Sprintf(util.U2OInterconnName, subnet.Spec.Vpc, subnet.Name)
-			u2oInterconnLrpName := fmt.Sprintf("%s-%s", subnet.Spec.Vpc, subnet.Name)
-			v4ip, v6ip, _, err := c.acquireIpAddress(subnet.Name, u2oInterconnName, u2oInterconnLrpName)
+		u2oInterconnName := fmt.Sprintf(util.U2OInterconnName, subnet.Spec.Vpc, subnet.Name)
+		u2oInterconnLrpName := fmt.Sprintf("%s-%s", subnet.Spec.Vpc, subnet.Name)
+		var v4ip, v6ip string
+		var err error
+		if subnet.Spec.U2OInterconnectionIP == "" && subnet.Status.U2OInterconnectionIP == "" {
+			v4ip, v6ip, _, err = c.acquireIpAddress(subnet.Name, u2oInterconnName, u2oInterconnLrpName)
 			if err != nil {
 				klog.Errorf("failed to acquire underlay to overlay interconnection ip address for subnet %s, %v", subnet.Name, err)
 				return err
 			}
+		} else if subnet.Spec.U2OInterconnectionIP != "" && subnet.Status.U2OInterconnectionIP != subnet.Spec.U2OInterconnectionIP {
+			if subnet.Status.U2OInterconnectionIP != "" {
+				c.ipam.ReleaseAddressByPod(u2oInterconnName)
+			}
+
+			v4ip, v6ip, _, err = c.acquireStaticIpAddress(subnet.Name, u2oInterconnName, u2oInterconnLrpName, subnet.Spec.U2OInterconnectionIP)
+			if err != nil {
+				klog.Errorf("failed to acquire static underlay to overlay interconnection ip address for subnet %s, %v", subnet.Name, err)
+				return err
+			}
+		}
+
+		if v4ip != "" || v6ip != "" {
 			switch subnet.Spec.Protocol {
 			case kubeovnv1.ProtocolIPv4:
 				subnet.Status.U2OInterconnectionIP = v4ip

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2186,3 +2186,20 @@ func (c *Controller) acquireIpAddress(subnetName, name, nicName string) (string,
 		}
 	}
 }
+
+func (c *Controller) acquireStaticIpAddress(subnetName, name, nicName, ip string) (string, string, string, error) {
+	checkConflict := true
+	var v4ip, v6ip, mac string
+	var err error
+	for _, ipStr := range strings.Split(ip, ",") {
+		if net.ParseIP(ipStr) == nil {
+			return "", "", "", fmt.Errorf("failed to parse vip ip %s", ipStr)
+		}
+	}
+
+	if v4ip, v6ip, mac, err = c.ipam.GetStaticAddress(name, nicName, ip, "", subnetName, checkConflict); err != nil {
+		klog.Errorf("failed to get static virtual ip '%s', mac '%s', subnet '%s', %v", ip, mac, subnetName, err)
+		return "", "", "", err
+	}
+	return v4ip, v6ip, mac, nil
+}

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -92,6 +92,18 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 			}
 		}
 	}
+
+	if subnet.Spec.LogicalGateway && subnet.Spec.U2OInterconnection {
+		return fmt.Errorf("logicalGateway and u2oInterconnection can't be opened at the same time")
+	}
+
+	if subnet.Spec.U2OInterconnectionIP != "" {
+		if !CIDRContainIP(subnet.Spec.CIDRBlock, subnet.Spec.U2OInterconnectionIP) {
+			return fmt.Errorf("u2oInterconnectionIP %s is not in subnet %s cidr %s",
+				subnet.Spec.U2OInterconnectionIP,
+				subnet.Name, subnet.Spec.CIDRBlock)
+		}
+	}
 	return nil
 }
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -714,6 +714,8 @@ spec:
                           - reject
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
   scope: Cluster
   names:
     plural: subnets


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acc2670</samp>

This pull request adds a new feature to support user-defined and dynamic IP addresses for the underlay to overlay (U2O) interconnection in `kube-ovn`. It modifies the `Subnet` custom resource and the subnet controller to enable this feature, and adds validation rules to ensure the IP address consistency and correctness.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at acc2670</samp>

> _Oh we are the subnet sailors, and we work on the overlay_
> _We need a static IP address for the `U2OInterconnection`_
> _So haul away the `SubnetSpec`, and validate it well, me hearties_
> _And set the `u2oInterconnectionIP` on the count of three_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at acc2670</samp>

*  Add a new field `u2oInterconnectionIP` to the `SubnetSpec` type to allow users to specify a static IP address for the underlay to overlay interconnection logical router port ([link](https://github.com/kubeovn/kube-ovn/pull/2936/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aL142-R143))
*  Validate the `u2oInterconnectionIP` field in the `ValidateSubnet` function to ensure it is a valid IP address within the subnet's CIDR block and does not conflict with the `logicalGateway` field ([link](https://github.com/kubeovn/kube-ovn/pull/2936/files?diff=unified&w=0#diff-7f0dbc597e1344dab5f2b581992a7ad0423ff2087593902fe39429d0a980782bR95-R106))
*  Update the `Subnet` custom resource definition to include the new field `u2oInterconnectionIP` in the `spec` section ([link](https://github.com/kubeovn/kube-ovn/pull/2936/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R717-R718))
*  Trigger a subnet update when the `u2oInterconnectionIP` field changes in the `enqueueUpdateSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2936/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L103-R105))
*  Clear the `u2oInterconnectionIP` field if the `u2oInterconnection` field is false in the `formatSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2936/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R323-R327))
*  Refactor the `reconcileU2OInterconnectionIP` function to handle dynamic and static IP address allocation and configuration for the underlay to overlay interconnection logical router port ([link](https://github.com/kubeovn/kube-ovn/pull/2936/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1390-R1419))