### PR TITLE
u2o support specify u2o ip on release-1.11

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1489,6 +1489,8 @@ spec:
                           - reject
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
   scope: Cluster
   names:
     plural: subnets

--- a/kubeovn-helm/templates/kube-ovn-crd.yaml
+++ b/kubeovn-helm/templates/kube-ovn-crd.yaml
@@ -1264,6 +1264,8 @@ spec:
                           - reject
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
   scope: Cluster
   names:
     plural: subnets

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -138,7 +138,8 @@ type SubnetSpec struct {
 
 	Acls []Acl `json:"acls,omitempty"`
 
-	U2OInterconnection bool `json:"u2oInterconnection,omitempty"`
+	U2OInterconnection   bool   `json:"u2oInterconnection,omitempty"`
+	U2OInterconnectionIP string `json:"u2oInterconnectionIP,omitempty"`
 }
 
 type Acl struct {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -94,7 +94,9 @@ func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
 		oldSubnet.Spec.IPv6RAConfigs != newSubnet.Spec.IPv6RAConfigs ||
 		oldSubnet.Spec.Protocol != newSubnet.Spec.Protocol ||
 		!reflect.DeepEqual(oldSubnet.Spec.Acls, newSubnet.Spec.Acls) ||
-		oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection {
+		oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection ||
+		(newSubnet.Spec.U2OInterconnection && newSubnet.Spec.U2OInterconnectionIP != "" &&
+			oldSubnet.Spec.U2OInterconnectionIP != newSubnet.Spec.U2OInterconnectionIP) {
 		klog.V(3).Infof("enqueue update subnet %s", key)
 		c.addOrUpdateSubnetQueue.Add(key)
 	}
@@ -312,6 +314,11 @@ func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 			}
 		}
 	}
+	if subnet.Spec.U2OInterconnectionIP != "" && !subnet.Spec.U2OInterconnection {
+		subnet.Spec.U2OInterconnectionIP = ""
+		changed = true
+	}
+
 	klog.Infof("format subnet %v, changed %v", subnet.Name, changed)
 	if changed {
 		_, err = c.config.KubeOvnClient.KubeovnV1().Subnets().Update(context.Background(), subnet, metav1.UpdateOptions{})
@@ -1488,14 +1495,29 @@ func (c *Controller) reconcileU2OInterconnectionIP(subnet *kubeovnv1.Subnet) err
 	klog.Infof("reconcile underlay subnet %s  to overlay interconnection with U2OInterconnection %v U2OInterconnectionIP %s ",
 		subnet.Name, subnet.Spec.U2OInterconnection, subnet.Status.U2OInterconnectionIP)
 	if subnet.Spec.U2OInterconnection {
-		if subnet.Status.U2OInterconnectionIP == "" {
-			u2oInterconnName := fmt.Sprintf(util.U2OInterconnName, subnet.Spec.Vpc, subnet.Name)
-			u2oInterconnLrpName := fmt.Sprintf("%s-%s", subnet.Spec.Vpc, subnet.Name)
-			v4ip, v6ip, _, err := c.acquireIpAddress(subnet.Name, u2oInterconnName, u2oInterconnLrpName)
+		u2oInterconnName := fmt.Sprintf(util.U2OInterconnName, subnet.Spec.Vpc, subnet.Name)
+		u2oInterconnLrpName := fmt.Sprintf("%s-%s", subnet.Spec.Vpc, subnet.Name)
+		var v4ip, v6ip string
+		var err error
+		if subnet.Spec.U2OInterconnectionIP == "" && subnet.Status.U2OInterconnectionIP == "" {
+			v4ip, v6ip, _, err = c.acquireIpAddress(subnet.Name, u2oInterconnName, u2oInterconnLrpName)
 			if err != nil {
 				klog.Errorf("failed to acquire underlay to overlay interconnection ip address for subnet %s, %v", subnet.Name, err)
 				return err
 			}
+		} else if subnet.Spec.U2OInterconnectionIP != "" && subnet.Status.U2OInterconnectionIP != subnet.Spec.U2OInterconnectionIP {
+			if subnet.Status.U2OInterconnectionIP != "" {
+				c.ipam.ReleaseAddressByPod(u2oInterconnName)
+			}
+
+			v4ip, v6ip, _, err = c.acquireStaticIpAddress(subnet.Name, u2oInterconnName, u2oInterconnLrpName, subnet.Spec.U2OInterconnectionIP)
+			if err != nil {
+				klog.Errorf("failed to acquire static underlay to overlay interconnection ip address for subnet %s, %v", subnet.Name, err)
+				return err
+			}
+		}
+
+		if v4ip != "" || v6ip != "" {
 			switch subnet.Spec.Protocol {
 			case kubeovnv1.ProtocolIPv4:
 				subnet.Status.U2OInterconnectionIP = v4ip

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -105,6 +105,18 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 			}
 		}
 	}
+
+	if subnet.Spec.LogicalGateway && subnet.Spec.U2OInterconnection {
+		return fmt.Errorf("logicalGateway and u2oInterconnection can't be opened at the same time")
+	}
+
+	if subnet.Spec.U2OInterconnectionIP != "" {
+		if !CIDRContainIP(subnet.Spec.CIDRBlock, subnet.Spec.U2OInterconnectionIP) {
+			return fmt.Errorf("u2oInterconnectionIP %s is not in subnet %s cidr %s",
+				subnet.Spec.U2OInterconnectionIP,
+				subnet.Name, subnet.Spec.CIDRBlock)
+		}
+	}
 	return nil
 }
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -1272,6 +1272,8 @@ spec:
                           - reject
                 u2oInterconnection:
                   type: boolean
+                u2oInterconnectionIP:
+                  type: string
   scope: Cluster
   names:
     plural: subnets


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e2de89</samp>

This pull request adds a new feature to allow user-specified or dynamic IP addresses for the underlay to overlay interconnection in subnets. It modifies the `SubnetSpec` and `SubnetStatus` schemas, the subnet controller logic, and the subnet validation function. It also updates the `kube-ovn-crd.yaml` and `crd.yaml` files to reflect the schema changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7e2de89</samp>

> _Oh we are the coders of the kube-ovn_
> _We make the subnets interconnect_
> _We heave and we ho and we validate_
> _The `u2oInterconnectionIP` we set_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e2de89</samp>

*  Add a new field `U2OInterconnectionIP` to the `SubnetSpec` struct to specify a static IP address for the underlay to overlay interconnection ([link](https://github.com/kubeovn/kube-ovn/pull/2937/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aL141-R142))
*  Add a new field `u2oInterconnectionIP` to the `SubnetStatus` schema in the `kube-ovn-crd.yaml` and `crd.yaml` files to store the IP address of the logical router port that connects the overlay subnet to the underlay network ([link](https://github.com/kubeovn/kube-ovn/pull/2937/files?diff=unified&w=0#diff-cf6e828a3b8334b0180f06b380614f951d45a1a12d49efce74818fd68882a868R1267-R1268), [link](https://github.com/kubeovn/kube-ovn/pull/2937/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1275-R1276))
*  Validate the `U2OInterconnectionIP` field in the `ValidateSubnet` function and ensure that it is within the subnet CIDR and not conflicting with the `logicalGateway` field ([link](https://github.com/kubeovn/kube-ovn/pull/2937/files?diff=unified&w=0#diff-7f0dbc597e1344dab5f2b581992a7ad0423ff2087593902fe39429d0a980782bR108-R119))
*  Enqueue the subnet key for processing when the `U2OInterconnectionIP` field changes in the `enqueueUpdateSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2937/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L97-R99))
*  Clear the `U2OInterconnectionIP` field if the `U2OInterconnection` field is false and set the `changed` flag to true in the `formatSubnet` function ([link](https://github.com/kubeovn/kube-ovn/pull/2937/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R317-R321))
*  Allocate or release the IP address for the underlay to overlay interconnection and update the subnet status accordingly in the `reconcileU2OInterconnectionIP` function, handling the cases where the `U2OInterconnectionIP` field is specified or changed by the user ([link](https://github.com/kubeovn/kube-ovn/pull/2937/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1491-R1520))