### PR TITLE
controller: fix DHCP MTU when the default network mode is underlay

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -596,25 +596,24 @@ func (c *Controller) checkSubnetConflict(subnet *kubeovnv1.Subnet) error {
 }
 
 func (c *Controller) updateSubnetDHCPOption(subnet *kubeovnv1.Subnet, needRouter bool) error {
-	var dhcpOptionsUUIDs *ovs.DHCPOptionsUUIDs
-	var err error
-	var mtu int
-	if subnet.Spec.Vlan != "" {
-		mtu = 1500
-	} else {
+	mtu := util.DefaultMTU
+	if subnet.Spec.Vlan == "" {
 		switch c.config.NetworkType {
-		case util.NetworkTypeVxlan:
-			mtu = 1500 - util.VxlanHeaderLength
+		case util.NetworkTypeVlan:
+			// default to geneve
+			fallthrough
 		case util.NetworkTypeGeneve:
-			mtu = 1500 - util.GeneveHeaderLength
+			mtu -= util.GeneveHeaderLength
+		case util.NetworkTypeVxlan:
+			mtu -= util.VxlanHeaderLength
 		case util.NetworkTypeStt:
-			mtu = 1500 - util.SttHeaderLength
+			mtu -= util.SttHeaderLength
 		default:
 			return fmt.Errorf("invalid network type: %s", c.config.NetworkType)
 		}
 	}
 
-	dhcpOptionsUUIDs, err = c.ovnLegacyClient.UpdateDHCPOptions(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.DHCPv4Options, subnet.Spec.DHCPv6Options, subnet.Spec.EnableDHCP, mtu)
+	dhcpOptionsUUIDs, err := c.ovnLegacyClient.UpdateDHCPOptions(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.DHCPv4Options, subnet.Spec.DHCPv6Options, subnet.Spec.EnableDHCP, mtu)
 	if err != nil {
 		klog.Errorf("failed to update dhcp options for switch %s, %v", subnet.Name, err)
 		return err

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -150,6 +150,8 @@ const (
 	SubnetAllowPriority = "1001"
 	DefaultDropPriority = "1000"
 
+	DefaultMTU = 1500
+
 	GeneveHeaderLength = 100
 	VxlanHeaderLength  = 50
 	SttHeaderLength    = 72


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #2930 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6616b9e</samp>

Refactor subnet controller and add default MTU constant. This change simplifies the code for updating DHCP options and ensures a consistent MTU value across the network.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6616b9e</samp>

> _Oh we are the coders of the `util` package_
> _We make the network interfaces run so smooth_
> _We use the `DefaultMTU` constant value_
> _And we refactor the code with every pull_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6616b9e</samp>

*  Refactor `updateSubnetDHCPOption` function to use `DefaultMTU` constant and handle `vlan` network type ([link](https://github.com/kubeovn/kube-ovn/pull/2941/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L599-R610))
*  Add `DefaultMTU` constant to `util` package to store the default network interface MTU value ([link](https://github.com/kubeovn/kube-ovn/pull/2941/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR153-R154))
*  Simplify `dhcpOptionsUUIDs` variable declaration using short syntax in `subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2941/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L617-R616))