### PR TITLE
add permision for test-server.sh

### DIFF
--- a/dist/images/Dockerfile.test
+++ b/dist/images/Dockerfile.test
@@ -11,4 +11,5 @@ RUN set -ex \
 WORKDIR /kube-ovn
 COPY test-server /kube-ovn/test-server
 COPY test-server.sh /kube-ovn/test-server.sh
+RUN chmod +x /kube-ovn/test-server.sh
 CMD bash test-server.sh

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -1260,6 +1260,35 @@ spec:
     - name: $podName
       image: $imageID
       imagePullPolicy: IfNotPresent
+      command: ["sh", "-c", "sleep infinity"]
+  nodeSelector:
+    kubernetes.io/hostname: $nodeID
+EOF
+  kubectl apply -f $tmpFileName
+  rm $tmpFileName
+}
+
+applyTestHostClient() {
+  tmpFileName="test-host-client.yaml"
+  local podName="test-host-client"
+  local nodeID=$1
+  local imageID=$2
+  touch $tmpFileName
+  cat <<EOF > $tmpFileName
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $podName
+  namespace: $KUBE_OVN_NS
+  labels:
+    app: $PERF_LABEL
+spec:
+  hostNetwork: true
+  containers:
+    - name: $podName
+      image: $imageID
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c", "sleep infinity"]
   nodeSelector:
     kubernetes.io/hostname: $nodeID
 EOF
@@ -1273,19 +1302,21 @@ perf(){
   nodes=($(kubectl get node --no-headers -o custom-columns=NAME:.metadata.name))
   if [[ ${#nodes} -eq 1 ]]; then
     applyTestClient ${nodes[0]} $imageID
-    applyTestHostServer ${nodes[0]} $imageID
+    applyTestHostClient ${nodes[0]} $imageID
     applyTestServer ${nodes[0]} $imageID
+    applyTestHostServer ${nodes[0]} $imageID
   elif [[ ${#nodes} -le 0 ]]; then
     echo "can't find node in the cluster"
     return
   elif [[ ${#nodes} -ge 2 ]]; then
     applyTestClient ${nodes[1]} $imageID
-    applyTestHostServer ${nodes[0]} $imageID
+    applyTestHostClient ${nodes[1]} $imageID
     applyTestServer ${nodes[0]} $imageID
+    applyTestHostServer ${nodes[0]} $imageID
   fi
 
   isfailed=true
-  for i in {0..59}
+  for i in {0..300}
   do
     if kubectl wait pod --for=condition=Ready -l app=$PERF_LABEL -n kube-system ; then
       isfailed=false
@@ -1303,10 +1334,10 @@ perf(){
   local hostserverIP=$(kubectl get pod test-host-server -n $KUBE_OVN_NS -o jsonpath={.status.podIP})
 
   echo "Start doing pod network performance"
-  unicastPerfTest $serverIP
+  unicastPerfTest test-client $serverIP
 
   echo "Start doing host network performance"
-  unicastPerfTest $hostserverIP
+  unicastPerfTest test-host-client $hostserverIP
 
   echo "Start doing pod multicast network performance"
   multicastPerfTest
@@ -1318,19 +1349,20 @@ perf(){
 }
 
 unicastPerfTest() {
-  serverIP=$1
+  clientPodName=$1
+  serverIP=$2
   echo "=================================== unicast perfromance test ============================================================="
   printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "Size" "TCP Latency" "TCP Bandwidth" "UDP Latency" "UDP Lost Rate" "UDP Bandwidth"
   for size in "64" "128" "512" "1k" "4k"
   do
-    output=$(kubectl exec test-client -n $KUBE_OVN_NS -- qperf -t $PERF_TIMES $serverIP -ub -oo msg_size:$size -vu tcp_lat udp_lat 2>&1)
-    tcpLat="$(echo $output | grep -oP 'tcp_lat: latency = \K[\d.]+ us')"
-    udpLat="$(echo $output | grep -oP 'udp_lat: latency = \K[\d.]+ us')"
-    kubectl exec test-client -n $KUBE_OVN_NS -- iperf3 -c $serverIP -u -t $PERF_TIMES -i 1 -P 10 -b 1000G -l $size > temp_perf_result.log 2> /dev/null
+    output=$(kubectl exec $clientPodName -n $KUBE_OVN_NS -- qperf -t $PERF_TIMES $serverIP -ub -oo msg_size:$size -vu tcp_lat udp_lat 2>&1)
+    tcpLat="$(echo $output | grep -oP 'tcp_lat: latency = \K[\d.]+ (us|ms|sec)')"
+    udpLat="$(echo $output | grep -oP 'udp_lat: latency = \K[\d.]+ (us|ms|sec)')"
+    kubectl exec $clientPodName -n $KUBE_OVN_NS -- iperf3 -c $serverIP -u -t $PERF_TIMES -i 1 -P 10 -b 1000G -l $size > temp_perf_result.log 2> /dev/null
     udpBw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
     udpLostRate=$(cat temp_perf_result.log | grep -oP '\(\d+(\.\d+)?%\)' | tail -n 1)
 
-    kubectl exec test-client -n $KUBE_OVN_NS -- iperf3 -c $serverIP -t $PERF_TIMES -i 1 -P 10 -l $size > temp_perf_result.log 2> /dev/null
+    kubectl exec $clientPodName -n $KUBE_OVN_NS -- iperf3 -c $serverIP -t $PERF_TIMES -i 1 -P 10 -l $size > temp_perf_result.log 2> /dev/null
     tcpBw=$(cat temp_perf_result.log | grep -oP '\d+\.?\d* [KMG]bits/sec' | tail -n 1)
     printf "%-15s %-15s %-15s %-15s %-15s %-15s\n" "$size" "$tcpLat" "$tcpBw" "$udpLat" "$udpLostRate" "$udpBw"
   done


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 217fc5c</samp>

This pull request adds TCP and UDP connectivity checks to the `kube-ovn` project. It introduces configuration options and utility functions for the `daemon` and `pinger` components to enable network diagnostics and troubleshooting. It also modifies the `CNIServer` and `pinger` commands to start TCP and UDP listeners if the feature is enabled.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 217fc5c</samp>

> _`kube-ovn` pings pods_
> _TCP and UDP checks_
> _Autumn network woes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 217fc5c</samp>

*  Add TCP and UDP connectivity checks between nodes and pods in the cluster using the `pinger` component ([link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR112-R128), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-cc7c97c269c4de582c3c4aaaa10bf1dfc8507245babb89bb7cbc2877f6f61a33R39-R54), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704R95-R109), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704R166-R181), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR529-R612))
*  Add configuration options for the TCP and UDP connectivity checks in the `daemon` and `pinger` components ([link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R63-R65), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R100-R102), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R154-R156), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-56f139df697aad97197df93aedd368692be48a0ef3d6a4399b7f17fea0c6c8fcL53-R65), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-56f139df697aad97197df93aedd368692be48a0ef3d6a4399b7f17fea0c6c8fcR130-R133))
*  Add TCP and UDP listeners in the `daemon` and `pinger` components if the `EnableVerboseConnCheck` flag is set to true ([link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR112-R128), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-cc7c97c269c4de582c3c4aaaa10bf1dfc8507245babb89bb7cbc2877f6f61a33R39-R54), [link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR529-R612))
*  Add the `time` package to the `util` package for setting timeouts and deadlines for the TCP and UDP connectivity checks ([link](https://github.com/kubeovn/kube-ovn/pull/2942/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR12))