### PR TITLE
Revert "nm not managed only in the change provide nic name case (#2754)"

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -914,6 +914,12 @@ func configProviderNic(nicName, brName string) (int, error) {
 		return 0, fmt.Errorf("failed to get routes on nic %s: %v", nicName, err)
 	}
 
+	// set link unmanaged by NetworkManager
+	if err = nmSetManaged(nicName, false); err != nil {
+		klog.Errorf("failed set device %s unmanaged by NetworkManager: %v", nicName, err)
+		return 0, err
+	}
+
 	for _, addr := range addrs {
 		if addr.IP.IsLinkLocalUnicast() {
 			// skip 169.254.0.0/16 and fe80::/10


### PR DESCRIPTION
This reverts commit c77f368187b5be35fe27a97ef60a09375e8ca226.

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:

Revert #2754

We still need to set underlay links unmanaged by NetworkManager since in some scenarios, some routes on the underlay link cannot be cleaned if the link is managed by NetworkManager.

Now it's safe to set the link unmanaged by NetworkManager, because:

1. After the node reboots, start-ovs.sh removes all OVS bridges used in underlay networking;
2. kube-ovn-cni waits ovs-vswitchd to be running before it starts.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e16f8d2</samp>

This pull request improves logging and network stability for the OVS daemon. It removes redundant log messages in `init.go` and prevents NetworkManager from managing the provider nic in `ovs_linux.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e16f8d2</samp>

> _Sing, O Muse, of the mighty pull request_
> _That the skilled coder sent to his peers_
> _To improve the network of the pods sublime_
> _With OVS and the provider nic._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e16f8d2</samp>

* Remove redundant log messages that print the same information as the previous line ([link](https://github.com/kubeovn/kube-ovn/pull/2944/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL43), [link](https://github.com/kubeovn/kube-ovn/pull/2944/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL129)) in `init.go`