### PR TITLE
underlay: sync NetworkManager IP config to OVS bridge

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -277,7 +277,7 @@ func (c *Controller) initProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v1
 	var mtu int
 	var err error
 	klog.V(3).Infof("ovs init provider network %s", pn.Name)
-	if mtu, err = ovsInitProviderNetwork(pn.Name, nic, pn.Spec.ExchangeLinkName, c.config.MacLearningFallback); err != nil {
+	if mtu, err = c.ovsInitProviderNetwork(pn.Name, nic, pn.Spec.ExchangeLinkName, c.config.MacLearningFallback); err != nil {
 		if oldLen := len(node.Labels); oldLen != 0 {
 			delete(node.Labels, fmt.Sprintf(util.ProviderNetworkReadyTemplate, pn.Name))
 			delete(node.Labels, fmt.Sprintf(util.ProviderNetworkInterfaceTemplate, pn.Name))
@@ -391,7 +391,7 @@ func (c *Controller) cleanProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v
 		return err
 	}
 
-	if err = ovsCleanProviderNetwork(pn.Name); err != nil {
+	if err = c.ovsCleanProviderNetwork(pn.Name); err != nil {
 		return err
 	}
 
@@ -399,7 +399,7 @@ func (c *Controller) cleanProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v
 }
 
 func (c *Controller) handleDeleteProviderNetwork(pn *kubeovnv1.ProviderNetwork) error {
-	if err := ovsCleanProviderNetwork(pn.Name); err != nil {
+	if err := c.ovsCleanProviderNetwork(pn.Name); err != nil {
 		return err
 	}
 

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -38,6 +38,8 @@ type ControllerRuntime struct {
 	k8sipsets        k8sipset.Interface
 	ipsets           map[string]*ipsets.IPSets
 	gwCounters       map[string]*util.GwIPtableCounters
+
+	nmSyncer *networkManagerSyncer
 }
 
 func evalCommandSymlinks(cmd string) (string, error) {
@@ -112,6 +114,9 @@ func (c *Controller) initRuntime() error {
 		c.ipsets[kubeovnv1.ProtocolIPv6] = ipsets.NewIPSets(ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, IPSetPrefix, nil, nil))
 		c.k8siptables[kubeovnv1.ProtocolIPv6] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv6)
 	}
+
+	c.nmSyncer = newNetworkManagerSyncer()
+	c.nmSyncer.Run(c.transferAddrsAndRoutes)
 
 	return nil
 }

--- a/pkg/daemon/init_windows.go
+++ b/pkg/daemon/init_windows.go
@@ -1,6 +1,6 @@
 package daemon
 
-func changeProvideNicName(nic, br string) (bool, error) {
+func (c *Controller) changeProvideNicName(nic, br string) (bool, error) {
 	// not supported on windows
 	return false, nil
 }

--- a/pkg/daemon/nm_linux.go
+++ b/pkg/daemon/nm_linux.go
@@ -1,0 +1,186 @@
+package daemon
+
+import (
+	"sync"
+
+	"github.com/kubeovn/gonetworkmanager/v2"
+	"github.com/scylladb/go-set/strset"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type networkManagerSyncer struct {
+	manager     gonetworkmanager.NetworkManager
+	workqueue   workqueue.Interface
+	devicePaths *strset.Set
+	pathMap     map[string]string
+	bridgeMap   map[string]string
+	lock        sync.Mutex
+}
+
+func newNetworkManagerSyncer() *networkManagerSyncer {
+	syncer := &networkManagerSyncer{}
+
+	manager, err := gonetworkmanager.NewNetworkManager()
+	if err != nil {
+		klog.V(3).Infof("failed to connect to NetworkManager: %v", err)
+		return syncer
+	}
+
+	running, err := manager.Running()
+	if err != nil {
+		klog.V(3).Infof("failed to check NetworkManager running state: %v", err)
+		return syncer
+	}
+	if !running {
+		klog.V(3).Info("NetworkManager is not running, ignore")
+		return syncer
+	}
+
+	syncer.manager = manager
+	syncer.workqueue = workqueue.NewNamed("NetworkManagerSyncer")
+	syncer.devicePaths = strset.New()
+	syncer.pathMap = make(map[string]string)
+	syncer.bridgeMap = make(map[string]string)
+	return syncer
+}
+
+func (n *networkManagerSyncer) Run(handler func(nic, bridge string, delNonExistent bool) (int, error)) {
+	if n.manager == nil {
+		return
+	}
+
+	go func() {
+		for n.ProcessNextItem(handler) {
+		}
+	}()
+
+	go func() {
+		ch := n.manager.Subscribe()
+		defer n.manager.Unsubscribe()
+
+		stateChange := gonetworkmanager.DeviceInterface + "." + gonetworkmanager.ActiveConnectionSignalStateChanged
+		for {
+			event := <-ch
+
+			n.lock.Lock()
+			if len(event.Body) == 0 || event.Name != stateChange || !n.devicePaths.Has(string(event.Path)) {
+				n.lock.Unlock()
+				continue
+			}
+			n.lock.Unlock()
+
+			state, ok := event.Body[0].(uint32)
+			if !ok {
+				klog.Warningf("failed to convert %#v to uint32", event.Body[0])
+				continue
+			}
+			if gonetworkmanager.NmDeviceState(state) != gonetworkmanager.NmDeviceStateActivated {
+				continue
+			}
+
+			klog.Infof("adding dbus object path %s to workqueue", event.Path)
+			n.workqueue.Add(string(event.Path))
+		}
+	}()
+}
+
+func (n *networkManagerSyncer) ProcessNextItem(handler func(nic, bridge string, delNonExistent bool) (int, error)) bool {
+	item, shutdown := n.workqueue.Get()
+	if shutdown {
+		return false
+	}
+	defer n.workqueue.Done(item)
+
+	klog.Infof("process dbus object path %v", item)
+	path := item.(string)
+	n.lock.Lock()
+	if !n.devicePaths.Has(path) {
+		n.lock.Unlock()
+		return true
+	}
+	var nic string
+	for k, v := range n.pathMap {
+		if v == path {
+			nic = k
+			break
+		}
+	}
+	n.lock.Unlock()
+
+	bridge := n.bridgeMap[nic]
+	if _, err := handler(nic, bridge, true); err != nil {
+		klog.Errorf("failed to handle NetworkManager event for device %s with bridge %s: %v", nic, bridge, err)
+	}
+
+	return true
+}
+
+func (n *networkManagerSyncer) AddDevice(nicName, bridge string) error {
+	if n.manager == nil {
+		return nil
+	}
+
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	if _, ok := n.pathMap[nicName]; ok {
+		return nil
+	}
+
+	device, err := n.manager.GetDeviceByIpIface(nicName)
+	if err != nil {
+		klog.Errorf("failed to get device by IP iface %q: %v", nicName, err)
+		return err
+	}
+
+	path := string(device.GetPath())
+	klog.V(3).Infof("adding device %s with dbus object path %s and bridge %s", nicName, path, bridge)
+	n.devicePaths.Add(path)
+	n.pathMap[nicName] = path
+	n.bridgeMap[nicName] = bridge
+
+	return nil
+}
+
+func (n *networkManagerSyncer) RemoveDevice(nicName string) error {
+	if n.manager == nil {
+		return nil
+	}
+
+	n.lock.Lock()
+	n.devicePaths.Remove(n.pathMap[nicName])
+	delete(n.pathMap, nicName)
+	delete(n.bridgeMap, nicName)
+	n.lock.Unlock()
+
+	return nil
+}
+
+func (n *networkManagerSyncer) SetManaged(name string, managed bool) error {
+	if n.manager == nil {
+		return nil
+	}
+
+	device, err := n.manager.GetDeviceByIpIface(name)
+	if err != nil {
+		klog.Errorf("failed to get device by IP iface %q: %v", name, err)
+		return err
+	}
+	current, err := device.GetPropertyManaged()
+	if err != nil {
+		klog.Errorf("failed to get device property managed: %v", err)
+		return err
+	}
+	if current == managed {
+		return nil
+	}
+
+	klog.Infof(`setting device %s NetworkManager property "managed" to %v`, name, managed)
+	if err = device.SetPropertyManaged(managed); err != nil {
+		klog.Errorf("failed to set device property managed to %v: %v", managed, err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -903,7 +903,7 @@ func (c *Controller) transferAddrsAndRoutes(nicName, brName string, delNonExiste
 
 	brAddrs, err := netlink.AddrList(bridge, netlink.FAMILY_ALL)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get addresses on OVS brdige %s: %v", brName, err)
+		return 0, fmt.Errorf("failed to get addresses on OVS bridge %s: %v", brName, err)
 	}
 
 	var delAddrs []netlink.Addr
@@ -999,7 +999,7 @@ func (c *Controller) transferAddrsAndRoutes(nicName, brName string, delNonExiste
 
 	brRoutes, err := netlink.RouteList(bridge, netlink.FAMILY_ALL)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get routes on OVS brdige %s: %v", brName, err)
+		return 0, fmt.Errorf("failed to get routes on OVS bridge %s: %v", brName, err)
 	}
 
 	var delRoutes []netlink.Route

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1028,7 +1028,6 @@ func (c *Controller) transferAddrsAndRoutes(nicName, brName string, delNonExiste
 	for i := len(routeScopeOrders) - 1; i >= 0; i-- {
 		for _, route := range delRoutes {
 			if route.Scope == routeScopeOrders[i] {
-				route.LinkIndex = bridge.Attrs().Index
 				if err = netlink.RouteDel(&route); err != nil {
 					return 0, fmt.Errorf("failed to delete route %s from OVS bridge %s: %v", route.String(), brName, err)
 				}

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -882,9 +882,7 @@ func configureLoNic() error {
 	return nil
 }
 
-// Add host nic to external bridge
-// Mac address, MTU, IP addresses & routes will be copied/transferred to the external bridge
-func configProviderNic(nicName, brName string) (int, error) {
+func (c *Controller) transferAddrsAndRoutes(nicName, brName string, delNonExistent bool) (int, error) {
 	nic, err := netlink.LinkByName(nicName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get nic by name %s: %v", nicName, err)
@@ -892,17 +890,6 @@ func configProviderNic(nicName, brName string) (int, error) {
 	bridge, err := netlink.LinkByName(brName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get bridge by name %s: %v", brName, err)
-	}
-
-	sysctlDisableIPv6 := fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6", brName)
-	disableIPv6, err := sysctl.Sysctl(sysctlDisableIPv6)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get sysctl %s: %v", sysctlDisableIPv6, err)
-	}
-	if disableIPv6 != "0" {
-		if _, err = sysctl.Sysctl(sysctlDisableIPv6, "0"); err != nil {
-			return 0, fmt.Errorf("failed to enable ipv6 on OVS bridge %s: %v", brName, err)
-		}
 	}
 
 	addrs, err := netlink.AddrList(nic, netlink.FAMILY_ALL)
@@ -914,9 +901,39 @@ func configProviderNic(nicName, brName string) (int, error) {
 		return 0, fmt.Errorf("failed to get routes on nic %s: %v", nicName, err)
 	}
 
+	brAddrs, err := netlink.AddrList(bridge, netlink.FAMILY_ALL)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get addresses on OVS brdige %s: %v", brName, err)
+	}
+
+	var delAddrs []netlink.Addr
+	if delNonExistent {
+		for _, addr := range brAddrs {
+			if addr.IP.IsLinkLocalUnicast() {
+				// skip 169.254.0.0/16 and fe80::/10
+				continue
+			}
+
+			var found bool
+			for _, v := range addrs {
+				if v.Equal(addr) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				delAddrs = append(delAddrs, addr)
+			}
+		}
+	}
+
 	// set link unmanaged by NetworkManager
-	if err = nmSetManaged(nicName, false); err != nil {
-		klog.Errorf("failed set device %s unmanaged by NetworkManager: %v", nicName, err)
+	if err = c.nmSyncer.SetManaged(nicName, false); err != nil {
+		klog.Errorf("failed to set device %s unmanaged by NetworkManager: %v", nicName, err)
+		return 0, err
+	}
+	if err = c.nmSyncer.AddDevice(nicName, brName); err != nil {
+		klog.Errorf("failed to monitor NetworkManager event for device %s: %v", nicName, err)
 		return 0, err
 	}
 
@@ -938,6 +955,14 @@ func configProviderNic(nicName, brName string) (int, error) {
 			return 0, fmt.Errorf("failed to replace address %q on OVS bridge %s: %v", addr.String(), brName, err)
 		}
 		klog.Infof("address %q has been added/replaced to link %s", addr.String(), brName)
+	}
+	for _, addr := range delAddrs {
+		if err = netlink.AddrDel(bridge, &addr); err != nil {
+			errMsg := fmt.Errorf("failed to delete address %q on OVS bridge %s: %v", addr.String(), brName, err)
+			klog.Error(errMsg)
+			return 0, errMsg
+		}
+		klog.Infof("address %q has been removed from OVS bridge %s", addr.String(), brName)
 	}
 
 	// keep mac address the same with the provider nic,
@@ -965,11 +990,77 @@ func configProviderNic(nicName, brName string) (int, error) {
 			if route.Scope == scope {
 				route.LinkIndex = bridge.Attrs().Index
 				if err = netlink.RouteReplace(&route); err != nil {
-					return 0, fmt.Errorf("failed to add/replace route %s: %v", route.String(), err)
+					return 0, fmt.Errorf("failed to add/replace route %s to OVS bridge %s: %v", route.String(), brName, err)
 				}
-				klog.Infof("route %q has been added/replaced to link %s", route.String(), brName)
+				klog.Infof("route %q has been added/replaced to OVS bridge %s", route.String(), brName)
 			}
 		}
+	}
+
+	brRoutes, err := netlink.RouteList(bridge, netlink.FAMILY_ALL)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get routes on OVS brdige %s: %v", brName, err)
+	}
+
+	var delRoutes []netlink.Route
+	if delNonExistent {
+		for _, route := range brRoutes {
+			if route.Gw == nil && route.Dst != nil && route.Dst.IP.IsLinkLocalUnicast() {
+				// skip 169.254.0.0/16 and fe80::/10
+				continue
+			}
+
+			var found bool
+			for _, v := range routes {
+				v.LinkIndex = route.LinkIndex
+				v.ILinkIndex = route.ILinkIndex
+				if v.Equal(route) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				delRoutes = append(delRoutes, route)
+			}
+		}
+	}
+
+	for i := len(routeScopeOrders) - 1; i >= 0; i-- {
+		for _, route := range delRoutes {
+			if route.Scope == routeScopeOrders[i] {
+				route.LinkIndex = bridge.Attrs().Index
+				if err = netlink.RouteDel(&route); err != nil {
+					return 0, fmt.Errorf("failed to delete route %s from OVS bridge %s: %v", route.String(), brName, err)
+				}
+				klog.Infof("route %q has been deleted from OVS bridge %s", route.String(), brName)
+			}
+		}
+	}
+
+	if err = netlink.LinkSetUp(nic); err != nil {
+		return 0, fmt.Errorf("failed to set link %s up: %v", nicName, err)
+	}
+
+	return nic.Attrs().MTU, nil
+}
+
+// Add host nic to external bridge
+// Mac address, MTU, IP addresses & routes will be copied/transferred to the external bridge
+func (c *Controller) configProviderNic(nicName, brName string) (int, error) {
+	sysctlDisableIPv6 := fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6", brName)
+	disableIPv6, err := sysctl.Sysctl(sysctlDisableIPv6)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get sysctl %s: %v", sysctlDisableIPv6, err)
+	}
+	if disableIPv6 != "0" {
+		if _, err = sysctl.Sysctl(sysctlDisableIPv6, "0"); err != nil {
+			return 0, fmt.Errorf("failed to enable ipv6 on OVS bridge %s: %v", brName, err)
+		}
+	}
+
+	mtu, err := c.transferAddrsAndRoutes(nicName, brName, false)
+	if err != nil {
+		return 0, fmt.Errorf("failed to transfer addresess and routes from %s to %s: %v", nicName, brName, err)
 	}
 
 	if _, err = ovs.Exec(ovs.MayExist, "add-port", brName, nicName,
@@ -978,11 +1069,7 @@ func configProviderNic(nicName, brName string) (int, error) {
 	}
 	klog.V(3).Infof("ovs port %s has been added to bridge %s", nicName, brName)
 
-	if err = netlink.LinkSetUp(nic); err != nil {
-		return 0, fmt.Errorf("failed to set link %s up: %v", nicName, err)
-	}
-
-	return nic.Attrs().MTU, nil
+	return mtu, nil
 }
 
 func linkIsAlbBond(link netlink.Link) (bool, error) {

--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -320,7 +320,7 @@ func configureMirrorLink(portName string, mtu int) error {
 	return nil
 }
 
-func configProviderNic(nicName, brName string) (int, error) {
+func (c *Controller) configProviderNic(nicName, brName string) (int, error) {
 	// nothing to do on Windows
 	return 0, nil
 }


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Features

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4aa324c</samp>

This pull request adds a new feature to support NetworkManager on Linux nodes by creating a `networkManagerSyncer` type that syncs network configuration between NetworkManager and OVS bridges. It also refactors the controller code to use receiver methods instead of global functions for provider network initialization and cleanup, improving modularity and testability. The changes affect the files `pkg/daemon/controller_linux.go`, `pkg/daemon/controller.go`, `pkg/daemon/init_linux.go`, `pkg/daemon/init.go`, `pkg/daemon/ovs_linux.go`, `pkg/daemon/init_windows.go`, and `pkg/daemon/nm_linux.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4aa324c</samp>

> _To sync OVS bridges and NetworkManager_
> _We added a new type and a syncer_
> _We also refactored_
> _The controller methods_
> _And used receivers instead of global handler_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4aa324c</samp>

*  Add a new type `networkManagerSyncer` and its methods to handle the synchronization of network configuration between NetworkManager and OVS bridges on Linux nodes ([link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-5b6401607166ee0f22c716831b54ac541660e8e73ef3f0245a83d4f732dffbe3R1-R380))
*  Add a field `nmSyncer *networkManagerSyncer` to the `Controller` struct to store a reference to the network manager syncer instance ([link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-2fc809b47dbb2a514497bf5e38d53de7bafc66f8dc976c817d1e5dac9d723c20R41-R42))
*  Initialize and run the network manager syncer in the `initRuntime` function of the controller ([link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-2fc809b47dbb2a514497bf5e38d53de7bafc66f8dc976c817d1e5dac9d723c20R118-R120))
*  Refactor the functions `ovsInitProviderNetwork`, `ovsCleanProviderNetwork`, `configProviderNic`, and `changeProvideNicName` to use the receiver `c *Controller` instead of global functions, making the code more modular and testable ([link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L280-R280), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L394-R394), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L402-R402), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL100-R100), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL130-R126), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL140-R136), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL194-R190), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-5011c3763408899ae41df12f37ce50078b2bfaa8027b9c4f455c6015a647eb11L93-R52), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-cdb22a4a3074aca17fee37c3e45d50d29c45a9018fae2de602e59af54290765dL3-R3), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feL887-R887))
*  Remove the unused import statement and function `nmSetManaged` from the file `pkg/daemon/init_linux.go` as they are no longer needed ([link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-5011c3763408899ae41df12f37ce50078b2bfaa8027b9c4f455c6015a647eb11L6), [link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-5011c3763408899ae41df12f37ce50078b2bfaa8027b9c4f455c6015a647eb11L20-L59))
*  Remove the redundant code to configure the provider NIC in the `InitOVSBridges` function as it is now handled by the network manager syncer ([link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-1319d6b2b4c1ca7d881ce69ae20eed6d7a7c64352096f340a2a0e63c4adcd0aeL43-L46))
*  Set the provider NIC unmanaged by NetworkManager and add it to the network manager syncer in the `configProviderNic` function ([link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feR917-R923))
*  Use the network manager syncer instance to set the provider NIC managed or unmanaged by NetworkManager in the `changeProvideNicName` function ([link](https://github.com/kubeovn/kube-ovn/pull/2949/files?diff=unified&w=0#diff-5011c3763408899ae41df12f37ce50078b2bfaa8027b9c4f455c6015a647eb11L120-R79))