### PR TITLE
ci: fix build-base strategy

### DIFF
--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -7,8 +7,9 @@ on:
 jobs:
   build-amd64:
     strategy:
-        matrix:
-          branch: [master, release-1.11, release-1.9]
+      fail-fast: false
+      matrix:
+        branch: [master, release-1.11, release-1.9]
     name: Build AMD64
     runs-on: ubuntu-22.04
     steps:
@@ -30,6 +31,7 @@ jobs:
 
   build-arm64:
     strategy:
+      fail-fast: false
       matrix:
         branch: [master, release-1.11, release-1.9]
     name: Build ARM64
@@ -56,6 +58,7 @@ jobs:
 
   push:
     strategy:
+      fail-fast: false
       matrix:
         branch: [master, release-1.11, release-1.9]
     needs:


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- CI

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d645166</samp>

Fix YAML formatting and enable fail-fast option in `build-kube-ovn-base.yaml` workflow. This enhances the CI process for building the base image of kube-ovn on different platforms.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d645166</samp>

> _To build kube-ovn-base with ease_
> _They fixed the YAML's indenting keys_
> _And added `fail-fast`_
> _To both jobs at last_
> _To test all the branches they please_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d645166</samp>

*  Add `fail-fast` option to `strategy` of `build-amd64` and `build-arm64` jobs in `.github/workflows/build-kube-ovn-base.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2950/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR34), [link](https://github.com/kubeovn/kube-ovn/pull/2950/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR61))
* Fix indentation of `matrix` key in `.github/workflows/build-kube-ovn-base.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2950/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL10-R12))