### PR TITLE
cni-server: reconcile ovn0 routes periodically

### DIFF
--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -121,66 +121,68 @@ func (c *Controller) initRuntime() error {
 	return nil
 }
 
-func (c *Controller) reconcileRouters(event subnetEvent) error {
+func (c *Controller) reconcileRouters(event *subnetEvent) error {
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets %v", err)
 		return err
 	}
 
-	var ok bool
-	var oldSubnet, newSubnet *kubeovnv1.Subnet
-	if event.old != nil {
-		if oldSubnet, ok = event.old.(*kubeovnv1.Subnet); !ok {
-			klog.Errorf("expected old subnet in subnetEvent but got %#v", event.old)
-			return nil
-		}
-	}
-	if event.new != nil {
-		if newSubnet, ok = event.new.(*kubeovnv1.Subnet); !ok {
-			klog.Errorf("expected new subnet in subnetEvent but got %#v", event.new)
-			return nil
-		}
-	}
-
-	// handle policy routing
-	rulesToAdd, rulesToDel, routesToAdd, routesToDel, err := c.diffPolicyRouting(oldSubnet, newSubnet)
-	if err != nil {
-		klog.Errorf("failed to get policy routing difference: %v", err)
-		return err
-	}
-	// add new routes first
-	for _, r := range routesToAdd {
-		if err = netlink.RouteReplace(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
-			klog.Errorf("failed to replace route for subnet %s: %v", newSubnet.Name, err)
-			return err
-		}
-	}
-	// next, add new rules
-	for _, r := range rulesToAdd {
-		if err = netlink.RuleAdd(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
-			klog.Errorf("failed to add network rule for subnet %s: %v", newSubnet.Name, err)
-			return err
-		}
-	}
-	// then delete old network rules
-	for _, r := range rulesToDel {
-		// loop to delete all matched rules
-		for {
-			if err = netlink.RuleDel(&r); err != nil {
-				if !errors.Is(err, syscall.ENOENT) {
-					klog.Errorf("failed to delete network rule for subnet %s: %v", oldSubnet.Name, err)
-					return err
-				}
-				break
+	if event != nil {
+		var ok bool
+		var oldSubnet, newSubnet *kubeovnv1.Subnet
+		if event.old != nil {
+			if oldSubnet, ok = event.old.(*kubeovnv1.Subnet); !ok {
+				klog.Errorf("expected old subnet in subnetEvent but got %#v", event.old)
+				return nil
 			}
 		}
-	}
-	// last, delete old network routes
-	for _, r := range routesToDel {
-		if err = netlink.RouteDel(&r); err != nil && !errors.Is(err, syscall.ENOENT) {
-			klog.Errorf("failed to delete route for subnet %s: %v", oldSubnet.Name, err)
+		if event.new != nil {
+			if newSubnet, ok = event.new.(*kubeovnv1.Subnet); !ok {
+				klog.Errorf("expected new subnet in subnetEvent but got %#v", event.new)
+				return nil
+			}
+		}
+
+		// handle policy routing
+		rulesToAdd, rulesToDel, routesToAdd, routesToDel, err := c.diffPolicyRouting(oldSubnet, newSubnet)
+		if err != nil {
+			klog.Errorf("failed to get policy routing difference: %v", err)
 			return err
+		}
+		// add new routes first
+		for _, r := range routesToAdd {
+			if err = netlink.RouteReplace(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
+				klog.Errorf("failed to replace route for subnet %s: %v", newSubnet.Name, err)
+				return err
+			}
+		}
+		// next, add new rules
+		for _, r := range rulesToAdd {
+			if err = netlink.RuleAdd(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
+				klog.Errorf("failed to add network rule for subnet %s: %v", newSubnet.Name, err)
+				return err
+			}
+		}
+		// then delete old network rules
+		for _, r := range rulesToDel {
+			// loop to delete all matched rules
+			for {
+				if err = netlink.RuleDel(&r); err != nil {
+					if !errors.Is(err, syscall.ENOENT) {
+						klog.Errorf("failed to delete network rule for subnet %s: %v", oldSubnet.Name, err)
+						return err
+					}
+					break
+				}
+			}
+		}
+		// last, delete old network routes
+		for _, r := range routesToDel {
+			if err = netlink.RouteDel(&r); err != nil && !errors.Is(err, syscall.ENOENT) {
+				klog.Errorf("failed to delete route for subnet %s: %v", oldSubnet.Name, err)
+				return err
+			}
 		}
 	}
 

--- a/pkg/daemon/controller_windows.go
+++ b/pkg/daemon/controller_windows.go
@@ -24,7 +24,7 @@ func (c *Controller) initRuntime() error {
 	return nil
 }
 
-func (c *Controller) reconcileRouters(_ subnetEvent) error {
+func (c *Controller) reconcileRouters(_ *subnetEvent) error {
 	klog.Info("reconcile routes")
 	node, err := c.nodesLister.Get(c.config.NodeName)
 	if err != nil {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
Fixes #2962 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd1fac6</samp>

This pull request refactors some common logic for router reconciliation and enhances the subnet event handling and policy routing management in the daemon controller. It also fixes a nil pointer bug in `controller_linux.go` and removes an unnecessary function call in `controller.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dd1fac6</samp>

> _Sing, O Muse, of the cunning code reviewers_
> _Who scanned the pull request with keen eyes_
> _And praised the skillful mover of `reconcileRouters`_
> _To a common file, where it could better serve the wise._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd1fac6</samp>

*  Move `reconcileRouters` function from `controller_linux.go` to `controller.go` to make it platform-independent and reusable ([link](https://github.com/kubeovn/kube-ovn/pull/2963/files?diff=unified&w=0#diff-2fc809b47dbb2a514497bf5e38d53de7bafc66f8dc976c817d1e5dac9d723c20L124-R124))
*  Add nil check for event parameter in `reconcileRouters` to handle nil event case ([link](https://github.com/kubeovn/kube-ovn/pull/2963/files?diff=unified&w=0#diff-2fc809b47dbb2a514497bf5e38d53de7bafc66f8dc976c817d1e5dac9d723c20L131-R185))
*  Fix bug by passing pointer to `reconcileRouters` instead of value to update original event object ([link](https://github.com/kubeovn/kube-ovn/pull/2963/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L466-R466))
*  Add goroutine to periodically call `reconcileRouters` with nil event to ensure consistency of policy routing rules and routes ([link](https://github.com/kubeovn/kube-ovn/pull/2963/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L614-R621))
*  Remove redundant call to `runGateway` in `loopEncapIpCheck` ([link](https://github.com/kubeovn/kube-ovn/pull/2963/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L614-R621))