### PR TITLE
ovn ic support dual

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -979,6 +979,13 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ip-family:
+          - ipv4
+          - ipv6
+          - dual
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
@@ -1043,12 +1050,12 @@ jobs:
         run: |
           sudo pip3 install j2cli
           sudo pip3 install "j2cli[yaml]"
-          sudo PATH=~/.local/bin:$PATH make kind-init-ovn-ic
+          sudo PATH=~/.local/bin:$PATH make kind-init-ovn-ic-${{ matrix.ip-family }}
           sudo cp -r /root/.kube/ ~/.kube/
           sudo chown -R $(id -un). ~/.kube/
 
       - name: Install Kube-OVN
-        run: make kind-install-ovn-ic
+        run: make kind-install-ovn-ic-${{ matrix.ip-family }}
 
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}

--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,10 @@ kind-install-ipv4: kind-install-overlay-ipv4
 kind-install-overlay-ipv4: kind-install
 
 .PHONY: kind-install-ovn-ic
-kind-install-ovn-ic: kind-install
+kind-install-ovn-ic: kind-install-ovn-ic-ipv4
+
+.PHONY: kind-install-ovn-ic-ipv4
+kind-install-ovn-ic-ipv4: kind-install
 	$(call kind_load_image,kube-ovn1,$(REGISTRY)/kube-ovn:$(VERSION))
 	kubectl config use-context kind-kube-ovn1
 	sed -e 's/10.16.0/10.18.0/g' \

--- a/Makefile
+++ b/Makefile
@@ -328,8 +328,21 @@ kind-init-ipv4: kind-clean
 	@$(MAKE) kind-create
 
 .PHONY: kind-init-ovn-ic
-kind-init-ovn-ic: kind-clean-ovn-ic kind-init
+kind-init-ovn-ic: kind-init-ovn-ic-ipv4
+
+.PHONY: kind-init-ovn-ic-ipv4
+kind-init-ovn-ic-ipv4: kind-clean-ovn-ic kind-init
 	@$(MAKE) kind-generate-config
+	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1)
+
+.PHONY: kind-init-ovn-ic-ipv6
+kind-init-ovn-ic-ipv6: kind-clean-ovn-ic kind-init-ipv6
+	@ip_family=ipv6 $(MAKE) kind-generate-config
+	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1)
+
+.PHONY: kind-init-ovn-ic-dual
+kind-init-ovn-ic-dual: kind-clean-ovn-ic kind-init-dual
+	@ip_family=dual $(MAKE) kind-generate-config
 	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1)
 
 .PHONY: kind-init-ovn-submariner
@@ -451,6 +464,60 @@ kind-install-ovn-ic: kind-install
 
 	docker run -d --name ovn-ic-db --network kind $(REGISTRY)/kube-ovn:$(VERSION) bash start-ic-db.sh
 	@set -e; \
+	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
+	zone=az0 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn1-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	kubectl config use-context kind-kube-ovn
+	kubectl apply -f ovn-ic-0.yaml
+	kubectl config use-context kind-kube-ovn1
+	kubectl apply -f ovn-ic-1.yaml
+	sleep 6
+	docker exec ovn-ic-db ovn-ic-sbctl show
+
+.PHONY: kind-install-ovn-ic-ipv6
+kind-install-ovn-ic-ipv6: kind-install-ipv6
+	$(call kind_load_image,kube-ovn1,$(REGISTRY)/kube-ovn:$(VERSION))
+	kubectl config use-context kind-kube-ovn1
+	@$(MAKE) kind-untaint-control-plane
+	sed -e 's/fd00:10:16:/fd00:10:18:/g' \
+		-e 's/fd00:10:96:/fd00:10:98:/g' \
+		-e 's/fd00:100:64:/fd00:100:68:/g' \
+		-e 's/VERSION=.*/VERSION=$(VERSION)/' \
+		dist/images/install.sh | \
+		IPV6=true bash
+	kubectl describe no
+
+	docker run -d --name ovn-ic-db --network kind -e PROTOCOL="ipv6" $(REGISTRY)/kube-ovn:$(VERSION) bash start-ic-db.sh
+	@set -e; \
+	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}"); \
+	zone=az0 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn1-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	kubectl config use-context kind-kube-ovn
+	kubectl apply -f ovn-ic-0.yaml
+	kubectl config use-context kind-kube-ovn1
+	kubectl apply -f ovn-ic-1.yaml
+	sleep 6
+	docker exec ovn-ic-db ovn-ic-sbctl show
+
+.PHONY: kind-install-ovn-ic-dual
+kind-install-ovn-ic-dual: kind-install-dual
+	$(call kind_load_image,kube-ovn1,$(REGISTRY)/kube-ovn:$(VERSION))
+	kubectl config use-context kind-kube-ovn1
+	@$(MAKE) kind-untaint-control-plane
+	sed -e 's/10.16.0/10.18.0/g' \
+		-e 's/10.96.0/10.98.0/g' \
+		-e 's/100.64.0/100.68.0/g' \
+	    -e 's/fd00:10:16:/fd00:10:18:/g' \
+		-e 's/fd00:10:96:/fd00:10:98:/g' \
+		-e 's/fd00:100:64:/fd00:100:68:/g' \
+		-e 's/VERSION=.*/VERSION=$(VERSION)/' \
+		dist/images/install.sh | \
+		DUAL_STACK=true bash
+	kubectl describe no
+
+	docker run -d --name ovn-ic-db --network kind -e PROTOCOL="dual" $(REGISTRY)/kube-ovn:$(VERSION) bash start-ic-db.sh
+	@set -e; \
+
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
 	zone=az0 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
 	zone=az1 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn1-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -38,7 +38,9 @@ RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-o
     # fix reaching resubmit limit in underlay
     curl -s https://github.com/kubeovn/ovn/commit/6934f1a1eb5986a904eefb560c0d6d57811453d9.patch | git apply && \
     # ovn-controller: do not send GARP on localnet for Kube-OVN ports
-    curl -s https://github.com/kubeovn/ovn/commit/8af8751cdb55f582c675db921f2526b06fd3d8c0.patch | git apply
+    curl -s https://github.com/kubeovn/ovn/commit/8af8751cdb55f582c675db921f2526b06fd3d8c0.patch | git apply && \
+    # ovn-ic blacklist function not work on ipv6
+    curl -s https://github.com/kubeovn/ovn/commit/78ab91005854532e7eb5c4fe6b2923ce292e3681.patch | git apply
 
 RUN apt install -y build-essential fakeroot \
     autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -236,6 +236,8 @@ const (
 
 	MatchV4Src = "ip4.src"
 	MatchV4Dst = "ip4.dst"
+	MatchV6Src = "ip6.src"
+	MatchV6Dst = "ip6.dst"
 
 	U2OInterconnName = "u2o-interconnection.%s.%s"
 	U2OExcludeIPAg   = "%s.u2o_exclude_ip.%s"

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -181,13 +181,24 @@ func AddressCount(network *net.IPNet) float64 {
 }
 
 func GenerateRandomV4IP(cidr string) string {
+	return genRandomIP(cidr, false)
+}
+
+func GenerateRandomV6IP(cidr string) string {
+	return genRandomIP(cidr, true)
+}
+
+func genRandomIP(cidr string, isIPv6 bool) string {
 	if len(strings.Split(cidr, "/")) != 2 {
 		return ""
 	}
 	ip := strings.Split(cidr, "/")[0]
 	netMask, _ := strconv.Atoi(strings.Split(cidr, "/")[1])
-	hostNum := 32 - netMask
-	add, err := rand.Int(rand.Reader, big.NewInt(1<<(uint(hostNum)-1)))
+	hostBits := 32 - netMask
+	if isIPv6 {
+		hostBits = 128 - netMask
+	}
+	add, err := rand.Int(rand.Reader, big.NewInt(1<<(uint(hostBits)-1)))
 	if err != nil {
 		LogFatalAndExit(err, "failed to generate random ip")
 	}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2873

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89abc34</samp>

This pull request adds support for dual stack and IPv6 interconnection in `kube-ovn`. It updates the GitHub workflow, the Makefile, and the ovn-ic controller to handle different IP protocols. It also adds and modifies some util functions and constants for IP address generation and logical router policy matching.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 89abc34</samp>

> _We're sailing on the `kube-ovn` ship, with `ovn-ic` on board_
> _We're matching IPv6 fields, with constants from the `util` hoard_
> _Heave away, me hearties, heave away with all your might_
> _We're testing dual stack features, with GitHub workflows in sight_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89abc34</samp>

*  Add strategy section to GitHub workflow file to run job with different IP protocols ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R982-R988))
*  Modify commands to initialize and install kube-ovn with interconnection feature on kind clusters with different IP protocols ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1046-R1058))
*  Define new targets in `Makefile` for creating and installing kind clusters with different IP protocols ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L331-R347), [link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R477-R530))
*  Import kubeovn v1 API package in `ovn-ic.go` to use constants and types for IP protocols ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR20))
*  Rename variable `subnet` to `lrpIP` in `establishInterConnection` function to reflect actual value ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL256-R257), [link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL263-R264))
*  Modify `acquireLrpAddress` function to support generating random IP addresses for IPv4, IPv6, or dual stack ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL284-R295))
*  Query interconnection switch subnet from ovnLegacyClient and assign it to `cidr` variable in `stripPrefix` function ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR439-R444))
*  Modify `syncOneRouteToPolicy` function to support adding logical router policies for IPv4, IPv6, or dual stack ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL467-R496))
*  Add constants for IPv6 match fields in `const.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR239-R240))
*  Add function to generate random IPv6 addresses in `net.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR184-R191))
*  Modify function to generate random IP addresses for IPv4 or IPv6 in `net.go` ([link](https://github.com/kubeovn/kube-ovn/pull/2970/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdL189-R201))