### PR TITLE
fix initialization check of vpc nat gateway configuration

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -709,12 +709,17 @@ func (c *Controller) initSyncCrdVpcNatGw() error {
 	}
 	// get vpc nat gateway image
 	cm, err = c.configMapsLister.ConfigMaps(c.config.PodNamespace).Get(util.VpcNatConfig)
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			klog.Errorf("configMap of %s not set, %v", util.VpcNatConfig, err)
+			return err
+		}
 		klog.Errorf("failed to get %s, %v", util.VpcNatConfig, err)
 		return err
 	}
-	if k8serrors.IsNotFound(err) || cm.Data["image"] == "" {
-		err = errors.New("image of vpc-nat-gw not set")
+
+	if cm.Data["image"] == "" {
+		err = errors.New("image of vpc-nat-gateway not set")
 		klog.Error(err)
 		return err
 	}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

fix initialization check of vpc nat gateway configuration caused by splition of configuration of vpc-nat-config and vpc-nat-gw-config

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2e2eec</samp>

Refactor the code in `pkg/controller/init.go` to separate the logic of checking the vpc nat and vpc nat gateway configmaps. This improves the code readability and robustness, and matches the documentation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c2e2eec</samp>

> _Split configmap logic_
> _`ovn-vpc-nat` and `gw`_
> _Clearer code in spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2e2eec</samp>

*  Split the logic of checking the ovn-vpc-nat-config and the ovn-vpc-nat-gw-config configmaps in the initVpcNatGateway function ([link](https://github.com/kubeovn/kube-ovn/pull/2978/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L700-R715))