### PR TITLE
IPAM: fix subnet mutex not released when static IP is out of range

### DIFF
--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -314,6 +314,7 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *stri
 	var v4, v6 bool
 	isAllocated := false
 	subnet.mutex.Lock()
+	defer subnet.mutex.Unlock()
 
 	if ip.To4() != nil {
 		v4 = subnet.V4CIDR != nil
@@ -355,7 +356,6 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *stri
 				pool.V6Using.Add(ip)
 			}
 		}
-		subnet.mutex.Unlock()
 	}()
 
 	var macStr string


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8795e83</samp>

Fix concurrency issue in `GetStaticAddress` function. Use defer to unlock mutex and avoid potential deadlocks in `pkg/ipam/subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8795e83</samp>

> _There once was a function called `GetStaticAddress`_
> _That had a concurrency issue to address_
> _It used a mutex lock_
> _But forgot to unlock_
> _So it fixed it with a defer, no less_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8795e83</samp>

*  Add a deferred call to unlock the subnet mutex in `GetStaticAddress` ([link](https://github.com/kubeovn/kube-ovn/pull/2979/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfR317))
*  Remove the redundant explicit call to unlock the subnet mutex in `GetStaticAddress` ([link](https://github.com/kubeovn/kube-ovn/pull/2979/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL358))