### PR TITLE
support helm install  hybrid_dpdk ovs-ovn

### DIFF
--- a/charts/templates/ovn-dpdk-ds.yaml
+++ b/charts/templates/ovn-dpdk-ds.yaml
@@ -1,51 +1,36 @@
+{{- if .Values.HYBRID_DPDK }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: ovs-ovn
-  namespace: {{ .Values.namespace }}
+  name: ovs-ovn-dpdk
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       This daemon set launches the openvswitch daemon.
 spec:
   selector:
     matchLabels:
-      app: ovs
+      app: ovs-dpdk
   updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    type: OnDelete
   template:
     metadata:
       labels:
-        app: ovs
+        app: ovs-dpdk
         component: network
         type: infra
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-        - key: CriticalAddonsOnly
-          operator: Exists
+      - operator: Exists
       priorityClassName: system-node-critical
       serviceAccountName: ovn-ovs
       hostNetwork: true
       hostPID: true
       containers:
         - name: openvswitch
-          {{- if .Values.DPDK }}
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.dpdkRepository }}:{{ .Values.DPDK_VERSION }}-{{ .Values.global.images.kubeovn.tag }}
-          {{- else }}
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          {{- end }}
+          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}-dpdk
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.DPDK }}
-          command: ["/kube-ovn/start-ovs-dpdk.sh"]
-          {{- else }}
-          command: ["/kube-ovn/start-ovs.sh"]
-          {{- end }}
+          command: ["/kube-ovn/start-ovs-dpdk-v2.sh"]
           securityContext:
             runAsUser: 0
             privileged: true
@@ -56,18 +41,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: HW_OFFLOAD
               value: "{{- .Values.func.HW_OFFLOAD }}"
             - name: TUNNEL_TYPE
               value: "{{- .Values.networking.TUNNEL_TYPE }}"
+            - name: DPDK_TUNNEL_IFACE
+              value: "{{- .Values.networking.DPDK_TUNNEL_IFACE }}"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -75,19 +54,22 @@ spec:
             - name: OVN_DB_IPS
               value: "{{ .Values.MASTER_NODES }}"
           volumeMounts:
-            - mountPath: /var/run/netns
-              name: host-ns
-              mountPropagation: HostToContainer
+            - mountPath: /opt/ovs-config
+              name: host-config-ovs
+            - name: shareddir
+              mountPath: {{ .Values.kubelet_conf.KUBELET_DIR }}/pods
+            - name: hugepage
+              mountPath: /dev/hugepages
             - mountPath: /lib/modules
               name: host-modules
               readOnly: true
             - mountPath: /var/run/openvswitch
               name: host-run-ovs
+              mountPropagation: HostToContainer
             - mountPath: /var/run/ovn
               name: host-run-ovn
             - mountPath: /sys
               name: host-sys
-              readOnly: true
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
             - mountPath: /etc/ovn
@@ -101,65 +83,46 @@ spec:
               readOnly: true
             - mountPath: /var/run/tls
               name: kube-ovn-tls
-            - mountPath: /var/run/containerd
-              name: cruntime
-            {{- if .Values.DPDK }}
-            - mountPath: /opt/ovs-config
-              name: host-config-ovs
-            - mountPath: /dev/hugepages
-              name: hugepage
-            {{- end }}
           readinessProbe:
             exec:
-              {{- if .Values.DPDK }}
-              command:
-                - bash
-                - /kube-ovn/ovs-dpdk-healthcheck.sh
-              {{- else }}
               command:
                 - bash
                 - -c
                 - LOG_ROTATE=true /kube-ovn/ovs-healthcheck.sh
-              {{- end }}
-            initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 45
           livenessProbe:
             exec:
-              {{- if .Values.DPDK }}
-              command:
-                - bash
-                - /kube-ovn/ovs-dpdk-healthcheck.sh
-              {{- else }}
               command:
                 - bash
                 - /kube-ovn/ovs-healthcheck.sh
-              {{- end }}
             initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45
           resources:
             requests:
-              {{- if .Values.DPDK }}
-              cpu: {{ .Values.DPDK_CPU }}
-              memory: {{ .Values.DPDK_MEMORY }}
-              {{- else }}
               cpu: {{ index .Values "ovs-ovn" "requests" "cpu" }}
               memory: {{ index .Values "ovs-ovn" "requests" "memory" }}
-              {{- end }}
             limits:
-              {{- if .Values.DPDK }}
-              cpu: {{ .Values.DPDK_CPU }}
-              memory: {{ .Values.DPDK_MEMORY }}
-              hugepages-1Gi: 1Gi
-              {{- else }}
               cpu: {{ index .Values "ovs-ovn" "limits" "cpu" }}
+              {{.Values.HUGEPAGE_SIZE_TYPE}}: {{.Values.HUGEPAGES}}
               memory: {{ index .Values "ovs-ovn" "limits" "memory" }}
-              {{- end }}
       nodeSelector:
         kubernetes.io/os: "linux"
+        ovn.kubernetes.io/ovs_dp_type: "userspace"
       volumes:
+        - name: host-config-ovs
+          hostPath:
+            path: /opt/ovs-config
+            type: DirectoryOrCreate
+        - name: shareddir
+          hostPath:
+            path: {{ .Values.kubelet_conf.KUBELET_DIR }}/pods
+            type: ''
+        - name: hugepage
+          emptyDir:
+            medium: HugePages
         - name: host-modules
           hostPath:
             path: /lib/modules
@@ -191,19 +154,4 @@ spec:
           secret:
             optional: true
             secretName: kube-ovn-tls
-        - name: host-ns
-          hostPath:
-            path: /var/run/netns
-        - hostPath:
-            path: /var/run/containerd
-          name: cruntime
-          readOnly: true
-        {{- if .Values.DPDK }}
-        - name: host-config-ovs
-          hostPath:
-            path: /opt/ovs-config
-            type: DirectoryOrCreate
-        - name: hugepage
-          emptyDir:
-            medium: HugePages
-        {{- end }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -113,6 +113,8 @@ restart_ovs: false
 
 # hybrid dpdk
 HYBRID_DPDK: false
+HUGEPAGE_SIZE_TYPE: hugepages-2Mi # Default 
+HUGEPAGES: 1Gi
 
 # DPDK
 DPDK: false


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
<!-- 
support helm install hybrid dpdk ovs-ovn deamonset 
-->

### Which issue(s) this PR fixes:
Fixes #2898

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a85d57</samp>

This pull request introduces a new hybrid DPDK mode for ovs-ovn, which uses DPDK for userspace networking and OVS for kernel networking. It adds a new daemon set template `ovn-dpdk-ds.yaml` and two new values `hugepagesType` and `hugepageSize` to the `values.yaml` file. It also refactors the existing `ovsovn-ds.yaml` template to remove the hybrid DPDK configuration.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a85d57</samp>

> _`HYBRID_DPDK` mode_
> _New template and values file_
> _Simplify `ovsovn-ds`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a85d57</samp>

*  Add a new daemon set template for ovs-ovn-dpdk in `ovn-dpdk-ds.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-4ff764064ce8dcea779157766f8170f24e26fb03e6886665a42fe7cb4ba5f23fL1-R157))
*  Remove the hybrid DPDK mode logic from `ovsovn-ds.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L40-L41), [link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L48-L49), [link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L81-L84), [link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L114-R106), [link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L120-L123), [link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L159-L162), [link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L172-L175), [link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L221-R201), [link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L230-L235))
*  Add new values for hugepages type and size in `values.yaml` ([link](https://github.com/kubeovn/kube-ovn/pull/2980/files?diff=unified&w=0#diff-2f7bd1822b616f83b06c8d8c356e0fc48c36dde251b8f87ab81d97155ca4cbcbR116-R117))