### PR TITLE
add e2e for new ippool feature

### DIFF
--- a/pkg/internal/big_int.go
+++ b/pkg/internal/big_int.go
@@ -17,6 +17,10 @@ func (b BigInt) Equal(n BigInt) bool {
 	return b.Cmp(n) == 0
 }
 
+func (b BigInt) EqualInt64(n int64) bool {
+	return b.Int.Cmp(big.NewInt(n)) == 0
+}
+
 func (b BigInt) Cmp(n BigInt) int {
 	return b.Int.Cmp(&n.Int)
 }
@@ -27,6 +31,10 @@ func (b BigInt) Add(n BigInt) BigInt {
 
 func (b BigInt) Sub(n BigInt) BigInt {
 	return BigInt{*big.NewInt(0).Sub(&b.Int, &n.Int)}
+}
+
+func (b BigInt) String() string {
+	return b.Int.String()
 }
 
 func (b BigInt) MarshalJSON() ([]byte, error) {

--- a/test/e2e/framework/ippool.go
+++ b/test/e2e/framework/ippool.go
@@ -1,0 +1,256 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/onsi/gomega"
+
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	v1 "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/typed/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+// IPPoolClient is a struct for ippool client.
+type IPPoolClient struct {
+	f *Framework
+	v1.IPPoolInterface
+}
+
+func (f *Framework) IPPoolClient() *IPPoolClient {
+	return &IPPoolClient{
+		f:               f,
+		IPPoolInterface: f.KubeOVNClientSet.KubeovnV1().IPPools(),
+	}
+}
+
+func (s *IPPoolClient) Get(name string) *apiv1.IPPool {
+	ippool, err := s.IPPoolInterface.Get(context.TODO(), name, metav1.GetOptions{})
+	ExpectNoError(err)
+	return ippool
+}
+
+// Create creates a new ippool according to the framework specifications
+func (c *IPPoolClient) Create(ippool *apiv1.IPPool) *apiv1.IPPool {
+	s, err := c.IPPoolInterface.Create(context.TODO(), ippool, metav1.CreateOptions{})
+	ExpectNoError(err, "Error creating ippool")
+	return s.DeepCopy()
+}
+
+// CreateSync creates a new ippool according to the framework specifications, and waits for it to be ready.
+func (c *IPPoolClient) CreateSync(ippool *apiv1.IPPool) *apiv1.IPPool {
+	s := c.Create(ippool)
+	ExpectTrue(c.WaitToBeReady(s.Name, timeout))
+	// Get the newest ippool after it becomes ready
+	return c.Get(s.Name).DeepCopy()
+}
+
+// Update updates the ippool
+func (c *IPPoolClient) Update(ippool *apiv1.IPPool, options metav1.UpdateOptions, timeout time.Duration) *apiv1.IPPool {
+	var updatedIPPool *apiv1.IPPool
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		s, err := c.IPPoolInterface.Update(ctx, ippool, options)
+		if err != nil {
+			return handleWaitingAPIError(err, false, "update ippool %q", ippool.Name)
+		}
+		updatedIPPool = s
+		return true, nil
+	})
+	if err == nil {
+		return updatedIPPool.DeepCopy()
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while retrying to update ippool %s", ippool.Name)
+	}
+	Failf("error occurred while retrying to update ippool %s: %v", ippool.Name, err)
+
+	return nil
+}
+
+// UpdateSync updates the ippool and waits for the ippool to be ready for `timeout`.
+// If the ippool doesn't become ready before the timeout, it will fail the test.
+func (c *IPPoolClient) UpdateSync(ippool *apiv1.IPPool, options metav1.UpdateOptions, timeout time.Duration) *apiv1.IPPool {
+	s := c.Update(ippool, options, timeout)
+	ExpectTrue(c.WaitToBeUpdated(s, timeout))
+	ExpectTrue(c.WaitToBeReady(s.Name, timeout))
+	// Get the newest ippool after it becomes ready
+	return c.Get(s.Name).DeepCopy()
+}
+
+// Patch patches the ippool
+func (c *IPPoolClient) Patch(original, modified *apiv1.IPPool, timeout time.Duration) *apiv1.IPPool {
+	patch, err := util.GenerateMergePatchPayload(original, modified)
+	ExpectNoError(err)
+
+	var patchedIPPool *apiv1.IPPool
+	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		s, err := c.IPPoolInterface.Patch(ctx, original.Name, types.MergePatchType, patch, metav1.PatchOptions{}, "")
+		if err != nil {
+			return handleWaitingAPIError(err, false, "patch ippool %q", original.Name)
+		}
+		patchedIPPool = s
+		return true, nil
+	})
+	if err == nil {
+		return patchedIPPool.DeepCopy()
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while retrying to patch ippool %s", original.Name)
+	}
+	Failf("error occurred while retrying to patch ippool %s: %v", original.Name, err)
+
+	return nil
+}
+
+// PatchSync patches the ippool and waits for the ippool to be ready for `timeout`.
+// If the ippool doesn't become ready before the timeout, it will fail the test.
+func (c *IPPoolClient) PatchSync(original, modified *apiv1.IPPool) *apiv1.IPPool {
+	s := c.Patch(original, modified, timeout)
+	ExpectTrue(c.WaitToBeUpdated(s, timeout))
+	ExpectTrue(c.WaitToBeReady(s.Name, timeout))
+	// Get the newest ippool after it becomes ready
+	return c.Get(s.Name).DeepCopy()
+}
+
+// Delete deletes a ippool if the ippool exists
+func (c *IPPoolClient) Delete(name string) {
+	err := c.IPPoolInterface.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		Failf("Failed to delete ippool %q: %v", name, err)
+	}
+}
+
+// DeleteSync deletes the ippool and waits for the ippool to disappear for `timeout`.
+// If the ippool doesn't disappear before the timeout, it will fail the test.
+func (c *IPPoolClient) DeleteSync(name string) {
+	c.Delete(name)
+	gomega.Expect(c.WaitToDisappear(name, 2*time.Second, timeout)).To(gomega.Succeed(), "wait for ippool %q to disappear", name)
+}
+
+func isIPPoolConditionSetAsExpected(ippool *apiv1.IPPool, conditionType apiv1.ConditionType, wantTrue, silent bool) bool {
+	for _, cond := range ippool.Status.Conditions {
+		if cond.Type == conditionType {
+			if (wantTrue && (cond.Status == corev1.ConditionTrue)) || (!wantTrue && (cond.Status != corev1.ConditionTrue)) {
+				return true
+			}
+			if !silent {
+				Logf("Condition %s of ippool %s is %v instead of %t. Reason: %v, message: %v",
+					conditionType, ippool.Name, cond.Status == corev1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
+			}
+			return false
+		}
+	}
+	if !silent {
+		Logf("Couldn't find condition %v on ippool %v", conditionType, ippool.Name)
+	}
+	return false
+}
+
+// IsIPPoolConditionSetAsExpected returns a wantTrue value if the ippool has a match to the conditionType,
+// otherwise returns an opposite value of the wantTrue with detailed logging.
+func IsIPPoolConditionSetAsExpected(ippool *apiv1.IPPool, conditionType apiv1.ConditionType, wantTrue bool) bool {
+	return isIPPoolConditionSetAsExpected(ippool, conditionType, wantTrue, false)
+}
+
+// WaitConditionToBe returns whether ippool "name's" condition state matches wantTrue
+// within timeout. If wantTrue is true, it will ensure the ippool condition status is
+// ConditionTrue; if it's false, it ensures the ippool condition is in any state other
+// than ConditionTrue (e.g. not true or unknown).
+func (c *IPPoolClient) WaitConditionToBe(name string, conditionType apiv1.ConditionType, wantTrue bool, timeout time.Duration) bool {
+	Logf("Waiting up to %v for ippool %s condition %s to be %t", timeout, name, conditionType, wantTrue)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
+		ippool := c.Get(name)
+		if IsIPPoolConditionSetAsExpected(ippool, conditionType, wantTrue) {
+			Logf("IPPool %s reach desired %t condition status", name, wantTrue)
+			return true
+		}
+		Logf("IPPool %s still not reach desired %t condition status", name, wantTrue)
+	}
+	Logf("IPPool %s didn't reach desired %s condition status (%t) within %v", name, conditionType, wantTrue, timeout)
+	return false
+}
+
+// WaitToBeReady returns whether the ippool is ready within timeout.
+func (c *IPPoolClient) WaitToBeReady(name string, timeout time.Duration) bool {
+	return c.WaitConditionToBe(name, apiv1.Ready, true, timeout)
+}
+
+// WaitToBeUpdated returns whether the ippool is updated within timeout.
+func (c *IPPoolClient) WaitToBeUpdated(ippool *apiv1.IPPool, timeout time.Duration) bool {
+	Logf("Waiting up to %v for ippool %s to be updated", timeout, ippool.Name)
+	rv, _ := big.NewInt(0).SetString(ippool.ResourceVersion, 10)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
+		s := c.Get(ippool.Name)
+		if current, _ := big.NewInt(0).SetString(s.ResourceVersion, 10); current.Cmp(rv) > 0 {
+			Logf("IPPool %s updated", ippool.Name)
+			return true
+		}
+		Logf("IPPool %s still not updated", ippool.Name)
+	}
+	Logf("IPPool %s was not updated within %v", ippool.Name, timeout)
+	return false
+}
+
+// WaitUntil waits the given timeout duration for the specified condition to be met.
+func (c *IPPoolClient) WaitUntil(name string, cond func(s *apiv1.IPPool) (bool, error), condDesc string, interval, timeout time.Duration) *apiv1.IPPool {
+	var ippool *apiv1.IPPool
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(_ context.Context) (bool, error) {
+		Logf("Waiting for ippool %s to meet condition %q", name, condDesc)
+		ippool = c.Get(name).DeepCopy()
+		met, err := cond(ippool)
+		if err != nil {
+			return false, fmt.Errorf("failed to check condition for ippool %s: %v", name, err)
+		}
+		return met, nil
+	})
+	if err == nil {
+		return ippool
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while waiting for ippool %s to meet condition %q", name, condDesc)
+	}
+	Failf("error occurred while waiting for ippool %s to meet condition %q: %v", name, condDesc, err)
+
+	return nil
+}
+
+// WaitToDisappear waits the given timeout duration for the specified ippool to disappear.
+func (c *IPPoolClient) WaitToDisappear(name string, interval, timeout time.Duration) error {
+	err := framework.Gomega().Eventually(context.Background(), framework.HandleRetry(func(ctx context.Context) (*apiv1.IPPool, error) {
+		ippool, err := c.IPPoolInterface.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return ippool, err
+	})).WithTimeout(timeout).Should(gomega.BeNil())
+	if err != nil {
+		return fmt.Errorf("expected ippool %s to not be found: %w", name, err)
+	}
+	return nil
+}
+
+func MakeIPPool(name, subnet string, ips, namespaces []string) *apiv1.IPPool {
+	return &apiv1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: apiv1.IPPoolSpec{
+			Subnet:     subnet,
+			IPs:        ips,
+			Namespaces: namespaces,
+		},
+	}
+}

--- a/test/e2e/framework/namespace.go
+++ b/test/e2e/framework/namespace.go
@@ -1,0 +1,101 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/onsi/gomega"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+// NamespaceClient is a struct for namespace  client.
+type NamespaceClient struct {
+	f *Framework
+	v1core.NamespaceInterface
+}
+
+func (f *Framework) NamespaceClient() *NamespaceClient {
+	return &NamespaceClient{
+		f:                  f,
+		NamespaceInterface: f.ClientSet.CoreV1().Namespaces(),
+	}
+}
+
+func (s *NamespaceClient) Get(name string) *corev1.Namespace {
+	np, err := s.NamespaceInterface.Get(context.TODO(), name, metav1.GetOptions{})
+	ExpectNoError(err)
+	return np
+}
+
+// Create creates a new namespace according to the framework specifications
+func (c *NamespaceClient) Create(ns *corev1.Namespace) *corev1.Namespace {
+	np, err := c.NamespaceInterface.Create(context.TODO(), ns, metav1.CreateOptions{})
+	ExpectNoError(err, "Error creating namespace")
+	return np.DeepCopy()
+}
+
+func (c *NamespaceClient) Patch(original, modified *corev1.Namespace) *corev1.Namespace {
+	patch, err := util.GenerateMergePatchPayload(original, modified)
+	ExpectNoError(err)
+
+	var patchedNS *corev1.Namespace
+	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		ns, err := c.NamespaceInterface.Patch(ctx, original.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "")
+		if err != nil {
+			return handleWaitingAPIError(err, false, "patch namespace %s", original.Name)
+		}
+		patchedNS = ns
+		return true, nil
+	})
+	if err == nil {
+		return patchedNS.DeepCopy()
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while retrying to patch namespace %s", original.Name)
+	}
+	Failf("error occurred while retrying to patch namespace %s: %v", original.Name, err)
+
+	return nil
+}
+
+// Delete deletes a namespace if the namespace exists
+func (c *NamespaceClient) Delete(name string) {
+	err := c.NamespaceInterface.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		Failf("Failed to delete namespace %q: %v", name, err)
+	}
+}
+
+// DeleteSync deletes the namespace and waits for the namespace to disappear for `timeout`.
+// If the namespace doesn't disappear before the timeout, it will fail the test.
+func (c *NamespaceClient) DeleteSync(name string) {
+	c.Delete(name)
+	gomega.Expect(c.WaitToDisappear(name, 2*time.Second, timeout)).To(gomega.Succeed(), "wait for namespace %q to disappear", name)
+}
+
+// WaitToDisappear waits the given timeout duration for the specified namespace to disappear.
+func (c *NamespaceClient) WaitToDisappear(name string, interval, timeout time.Duration) error {
+	err := framework.Gomega().Eventually(context.Background(), framework.HandleRetry(func(ctx context.Context) (*corev1.Namespace, error) {
+		policy, err := c.NamespaceInterface.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return policy, err
+	})).WithTimeout(timeout).Should(gomega.BeNil())
+	if err != nil {
+		return fmt.Errorf("expected namespace %s to not be found: %w", name, err)
+	}
+	return nil
+}

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -43,7 +43,7 @@ func (c *PodClient) DeleteSync(name string) {
 	c.PodClient.DeleteSync(context.Background(), name, metav1.DeleteOptions{}, timeout)
 }
 
-func (c *PodClient) PatchPod(original, modified *corev1.Pod) *corev1.Pod {
+func (c *PodClient) Patch(original, modified *corev1.Pod) *corev1.Pod {
 	patch, err := util.GenerateMergePatchPayload(original, modified)
 	ExpectNoError(err)
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/scylladb/go-set/strset"
 
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -108,14 +109,12 @@ func RandomIPPool(cidr, sep string, count int) string {
 		max := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(int64(size-prefix)), nil)
 		max.Sub(max, big.NewInt(3))
 
-		ips := make([]string, 0, count)
-		for len(ips) != count {
+		ips := strset.NewWithSize(count)
+		for ips.Size() != count {
 			n := big.NewInt(0).Rand(rnd, max)
-			if ip := util.BigInt2Ip(n.Add(n, base)); !util.ContainsString(ips, ip) {
-				ips = append(ips, ip)
-			}
+			ips.Add(util.BigInt2Ip(n.Add(n, base)))
 		}
-		return ips
+		return ips.List()
 	}
 
 	cidrV4, cidrV6 := util.SplitStringIP(cidr)

--- a/test/e2e/kube-ovn/qos/qos.go
+++ b/test/e2e/kube-ovn/qos/qos.go
@@ -148,7 +148,7 @@ var _ = framework.Describe("[group:qos]", func() {
 		}
 		modifiedPod.Annotations[util.NetemQosLimitAnnotation] = strconv.Itoa(limit)
 		modifiedPod.Annotations[util.NetemQosLossAnnotation] = strconv.Itoa(loss)
-		pod = podClient.PatchPod(pod, modifiedPod)
+		pod = podClient.Patch(pod, modifiedPod)
 
 		ginkgo.By("Validating pod annotations")
 		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Tests


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc7d4ed</samp>

This pull request adds and updates the test packages and methods for the IPPool and namespace annotation features in the kube-ovn project. It also enhances the framework package with new packages, methods, and error handling. Additionally, it renames some PatchPod methods to Patch for consistency. The affected files are `test/e2e/framework/deployment.go`, `test/e2e/framework/util.go`, `test/e2e/kube-ovn/ipam/ipam.go`, `pkg/internal/big_int.go`, `test/e2e/framework/ippool.go`, `test/e2e/framework/namespace.go`, `test/e2e/framework/pod.go`, and `test/e2e/kube-ovn/qos/qos.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fc7d4ed</samp>

> _The pull request has many changes_
> _To test the `IPPool` and its ranges_
> _It adds new methods and files_
> _To the `framework` and its styles_
> _And patches the pods with some patches_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc7d4ed</samp>

*  Add methods to create, update, patch, delete, and validate IPPools in the framework package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-9d73a305002c18762271db0d0893201218b61153401fecb40640adb22e29033bR1-R256))
*  Add methods to get, create, patch, and delete namespaces in the framework package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-6f3289521484b0895205bd2d95e6413af980e90f23b1df17ae3b3780ee22d045R1-R101))
*  Add methods to patch and wait for deployment rollout in the framework package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR71-R126), [link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fL88-R149))
*  Add method to check if BigInt is equal to int64 in the internal package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-41c53682aa5ac7926179bc4669c896b4c9dc47521db1ca897641f40064e0ef89R20-R23))
*  Rename PatchPod method to Patch in the framework and qos packages ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-5f15fda6193ef82e5636ecbb83e7df08e56285d7c04d7e7360c3461d7b08e065L46-R46), [link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-d863aabd8d2784f9f3c01d842685af90069bbcc7c037fd43c489a3eb03d72fe2L151-R151))
*  Use strset package to generate and manipulate random IPs in the framework package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-9dcbb8eba12c61d6f3dde188c0b8d8332365139e5062995d322795e02710fb6cR13), [link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-9dcbb8eba12c61d6f3dde188c0b8d8332365139e5062995d322795e02710fb6cL111-R117))
*  Use ipam package to define and manipulate IP and IPRange objects in the ipam package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R16))
*  Add test case to verify IPPool feature in the ipam package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R385-R570))
*  Add and modify imports and variables in the framework, ipam, and qos packages ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR6), [link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR17-R18), [link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR25-R26), [link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R5-R6), [link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1L22-R31), [link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1L32-R45))
*  Add step to delete ippool in the ipam package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R65-R67))
*  Use sort package to sort IPs by numerical order in the ipam package ([link](https://github.com/kubeovn/kube-ovn/pull/2981/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R5-R6))