### PR TITLE
IPPool: fix missing support for CIDR

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -110,7 +110,7 @@ kube-ovn-conformance-e2e:
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
-	ginkgo $(GINKGO_PARALLEL_OPT) --randomize-all -v \
+	ginkgo $(GINKGO_PARALLEL_OPT) --randomize-all -v --timeout=25m \
 		--focus=CNI:Kube-OVN ./test/e2e/kube-ovn/kube-ovn.test
 
 .PHONY: kube-ovn-ic-conformance-e2e

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -823,6 +823,19 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	}
 
 	c.updateVpcStatusQueue.Add(subnet.Spec.Vpc)
+
+	ippools, err := c.ippoolLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list ippools: %v", err)
+		return err
+	}
+
+	for _, p := range ippools {
+		if p.Spec.Subnet == subnet.Name {
+			c.addOrUpdateIPPoolQueue.Add(p.Name)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/ipam/ip.go
+++ b/pkg/ipam/ip.go
@@ -22,6 +22,12 @@ func NewIP(s string) (IP, error) {
 	return IP(ip), nil
 }
 
+func (a IP) Clone() IP {
+	v := make(IP, len(a))
+	copy(v, a)
+	return v
+}
+
 func (a IP) To4() net.IP {
 	return net.IP(a).To4()
 }
@@ -42,28 +48,23 @@ func (a IP) GreaterThan(b IP) bool {
 	return big.NewInt(0).SetBytes([]byte(a)).Cmp(big.NewInt(0).SetBytes([]byte(b))) > 0
 }
 
-func (a IP) Add(n int64) IP {
-	buff := big.NewInt(0).Add(big.NewInt(0).SetBytes([]byte(a)), big.NewInt(n)).Bytes()
-	if len(buff) < len(a) {
-		tmp := make([]byte, len(a))
+func bytes2IP(buff []byte, length int) IP {
+	if len(buff) < length {
+		tmp := make([]byte, length)
 		copy(tmp[len(tmp)-len(buff):], buff)
 		buff = tmp
-	} else if len(buff) > len(a) {
-		buff = buff[len(buff)-len(a):]
+	} else if len(buff) > length {
+		buff = buff[len(buff)-length:]
 	}
 	return IP(buff)
 }
 
+func (a IP) Add(n int64) IP {
+	return bytes2IP(big.NewInt(0).Add(big.NewInt(0).SetBytes([]byte(a)), big.NewInt(n)).Bytes(), len(a))
+}
+
 func (a IP) Sub(n int64) IP {
-	buff := big.NewInt(0).Sub(big.NewInt(0).SetBytes([]byte(a)), big.NewInt(n)).Bytes()
-	if len(buff) < len(a) {
-		tmp := make([]byte, len(a))
-		copy(tmp[len(tmp)-len(buff):], buff)
-		buff = tmp
-	} else if len(buff) > len(a) {
-		buff = buff[len(buff)-len(a):]
-	}
-	return IP(buff)
+	return bytes2IP(big.NewInt(0).Sub(big.NewInt(0).SetBytes([]byte(a)), big.NewInt(n)).Bytes(), len(a))
 }
 
 func (a IP) String() string {

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -274,7 +274,7 @@ func SplitIpsByProtocol(excludeIps []string) ([]string, []string) {
 	var v4ExcludeIps, v6ExcludeIps []string
 	for _, ex := range excludeIps {
 		ips := strings.Split(ex, "..")
-		if net.ParseIP(ips[0]).To4() != nil {
+		if CheckProtocol(ips[0]) == kubeovnv1.ProtocolIPv4 {
 			v4ExcludeIps = append(v4ExcludeIps, ex)
 		} else {
 			v6ExcludeIps = append(v6ExcludeIps, ex)

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -98,6 +98,16 @@ func ExpectNotContainElement(actual interface{}, extra interface{}, explain ...i
 	gomega.ExpectWithOffset(1, actual).NotTo(gomega.ContainElement(extra), explain...)
 }
 
+// ExpectContainSubstring expects actual contains the passed-in substring.
+func ExpectContainSubstring(actual, substr string, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).To(gomega.ContainSubstring(substr), explain...)
+}
+
+// ExpectNotContainSubstring expects actual does not contain the passed-in substring.
+func ExpectNotContainSubstring(actual, substr string, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).NotTo(gomega.ContainSubstring(substr), explain...)
+}
+
 // ExpectHaveKey expects the actual map has the key in the keyset
 func ExpectHaveKey(actual interface{}, key interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.HaveKey(key), explain...)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -17,6 +17,12 @@ import (
 )
 
 const (
+	IPv4 = "ipv4"
+	IPv6 = "ipv6"
+	Dual = "dual"
+)
+
+const (
 	// poll is how often to Poll resources.
 	poll = 2 * time.Second
 
@@ -103,8 +109,24 @@ func NewFrameworkWithContext(baseName, kubeContext string) *Framework {
 	return f
 }
 
-func (f *Framework) IPv6() bool {
-	return f.ClusterIpFamily == "ipv6"
+func (f *Framework) IsIPv4() bool {
+	return f.ClusterIpFamily == IPv4
+}
+
+func (f *Framework) IsIPv6() bool {
+	return f.ClusterIpFamily == IPv6
+}
+
+func (f *Framework) IsDual() bool {
+	return f.ClusterIpFamily == Dual
+}
+
+func (f *Framework) HasIPv4() bool {
+	return !f.IsIPv6()
+}
+
+func (f *Framework) HasIPv6() bool {
+	return !f.IsIPv4()
 }
 
 // BeforeEach gets a kube-ovn client

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2,16 +2,15 @@ package framework
 
 import (
 	"fmt"
-	"math/big"
 	"math/rand"
 	"net"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/scylladb/go-set/strset"
 
+	"github.com/kubeovn/kube-ovn/pkg/ipam"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -48,11 +47,11 @@ func RandomCIDR(family string) string {
 	}
 
 	switch family {
-	case "ipv4":
+	case IPv4:
 		return fnIPv4()
-	case "ipv6":
+	case IPv6:
 		return fnIPv6()
-	case "dual":
+	case Dual:
 		return fnIPv4() + "," + fnIPv6()
 	default:
 		Failf("invalid ip family: %q", family)
@@ -62,7 +61,11 @@ func RandomCIDR(family string) string {
 
 func sortIPs(ips []string) {
 	sort.Slice(ips, func(i, j int) bool {
-		return util.Ip2BigInt(ips[i]).Cmp(util.Ip2BigInt(ips[j])) < 0
+		x, err := ipam.NewIP(ips[i])
+		ExpectNoError(err)
+		y, err := ipam.NewIP(ips[j])
+		ExpectNoError(err)
+		return x.LessThan(y)
 	})
 }
 
@@ -72,9 +75,11 @@ func RandomExcludeIPs(cidr string, count int) []string {
 		return nil
 	}
 
+	ExpectNotContainSubstring(cidr, ",")
+	ExpectNotContainSubstring(cidr, ";")
+
 	rangeCount := rand.Intn(count + 1)
-	ips := strings.Split(RandomIPPool(cidr, ";", rangeCount*2+count-rangeCount), ";")
-	sortIPs(ips)
+	ips := randomSortedIPs(cidr, rangeCount*2+count-rangeCount, true)
 
 	var idx int
 	rangeLeft := rangeCount
@@ -93,36 +98,38 @@ func RandomExcludeIPs(cidr string, count int) []string {
 	return ret
 }
 
-func RandomIPPool(cidr, sep string, count int) string {
-	fn := func(cidr string) []string {
-		if cidr == "" {
-			return nil
-		}
-
-		firstIP, _ := util.FirstIP(cidr)
-		_, ipnet, _ := net.ParseCIDR(cidr)
-
-		base := util.Ip2BigInt(firstIP)
-		base.Add(base, big.NewInt(1))
-		prefix, size := ipnet.Mask.Size()
-		rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
-		max := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(int64(size-prefix)), nil)
-		max.Sub(max, big.NewInt(3))
-
-		ips := strset.NewWithSize(count)
-		for ips.Size() != count {
-			n := big.NewInt(0).Rand(rnd, max)
-			ips.Add(util.BigInt2Ip(n.Add(n, base)))
-		}
-		return ips.List()
+// ipv4/ipv6 only
+func randomSortedIPs(cidr string, count int, sort bool) []string {
+	if cidr == "" {
+		return nil
 	}
 
+	_, ipNet, err := net.ParseCIDR(cidr)
+	ExpectNoError(err)
+
+	set := strset.NewWithSize(count)
+	r := ipam.NewIPRangeFromCIDR(*ipNet)
+	r = ipam.NewIPRange(r.Start().Add(2), r.End().Sub(1))
+	for set.Size() != count {
+		set.Add(r.Random().String())
+	}
+
+	ips := set.List()
+	if sort {
+		sortIPs(ips)
+	}
+
+	return ips
+}
+
+func RandomIPs(cidr, sep string, count int) string {
 	cidrV4, cidrV6 := util.SplitStringIP(cidr)
-	ipsV4, ipsV6 := fn(cidrV4), fn(cidrV6)
+	ipsV4 := randomSortedIPs(cidrV4, count, false)
+	ipsV6 := randomSortedIPs(cidrV6, count, false)
 
 	dual := make([]string, 0, count)
 	for i := 0; i < count; i++ {
-		var ips []string
+		ips := make([]string, 0, 2)
 		if i < len(ipsV4) {
 			ips = append(ips, ipsV4[i])
 		}
@@ -135,12 +142,96 @@ func RandomIPPool(cidr, sep string, count int) string {
 	return strings.Join(dual, sep)
 }
 
+// ipv4/ipv6 only
+func randomPool(cidr string, count int) []string {
+	if cidr == "" || count == 0 {
+		return nil
+	}
+
+	_, ipNet, err := net.ParseCIDR(cidr)
+	ExpectNoError(err)
+
+	r := ipam.NewIPRangeFromCIDR(*ipNet)
+	r = ipam.NewIPRange(r.Start().Add(2), r.End().Sub(1))
+
+	ones, bits := ipNet.Mask.Size()
+	rl := ipam.NewEmptyIPRangeList()
+	set := strset.NewWithSize(count)
+	for set.Size() != count/4 {
+		prefix := (ones+bits)/2 + rand.Intn((bits-ones)/2+1)
+		_, ipNet, err = net.ParseCIDR(fmt.Sprintf("%s/%d", r.Random(), prefix))
+		ExpectNoError(err)
+
+		v := ipam.NewIPRangeFromCIDR(*ipNet)
+		start, end := v.Start(), v.End()
+		if !r.Contains(start) || !r.Contains(end) || rl.Contains(start) || rl.Contains(end) {
+			continue
+		}
+
+		rl = rl.MergeRange(ipam.NewIPRange(start, end))
+		set.Add(ipNet.String())
+	}
+
+	count -= set.Size()
+	m := count / 3 // <IP1>..<IP2>
+	n := count - m // <IP>
+	ips := make([]ipam.IP, 0, m*2+n)
+	ipSet := strset.NewWithSize(cap(ips))
+	for len(ips) != cap(ips) {
+		ip := r.Random()
+		if rl.Contains(ip) {
+			continue
+		}
+
+		s := ip.String()
+		if ipSet.Has(s) {
+			continue
+		}
+		ips = append(ips, ip)
+		ipSet.Add(s)
+	}
+	sort.Slice(ips, func(i, j int) bool { return ips[i].LessThan(ips[j]) })
+
+	var i, j int
+	k := rand.Intn(len(ips))
+	for i != m || j != n {
+		if i != m {
+			x, y := k%len(ips), (k+1)%len(ips)
+			n1, _ := rl.Find(ips[x])
+			n2, _ := rl.Find(ips[y])
+			if n1 == n2 {
+				set.Add(fmt.Sprintf("%s..%s", ips[x].String(), ips[y].String()))
+				i, k = i+1, k+2
+				continue
+			}
+		}
+
+		if j != n {
+			set.Add(ips[k%len(ips)].String())
+			j, k = j+1, k+1
+		}
+	}
+
+	return set.List()
+}
+
+func RandomIPPool(cidr string, count int) []string {
+	cidrV4, cidrV6 := util.SplitStringIP(cidr)
+	ipsV4, ipsV6 := randomPool(cidrV4, count), randomPool(cidrV6, count)
+	set := strset.NewWithSize(len(cidrV4) + len(cidrV6))
+	set.Add(ipsV4...)
+	set.Add(ipsV6...)
+	return set.List()
+}
+
 func PrevIP(ip string) string {
-	n := util.Ip2BigInt(ip)
-	return util.BigInt2Ip(n.Add(n, big.NewInt(-1)))
+	v, err := ipam.NewIP(ip)
+	ExpectNoError(err)
+	return v.Sub(1).String()
 }
 
 func NextIP(ip string) string {
-	n := util.Ip2BigInt(ip)
-	return util.BigInt2Ip(n.Add(n, big.NewInt(1)))
+	v, err := ipam.NewIP(ip)
+	ExpectNoError(err)
+	return v.Add(1).String()
 }

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -103,12 +103,12 @@ func setupNetworkAttachmentDefinition(
 	for _, config := range dockerExtNetNetwork.IPAM.Config {
 		switch util.CheckProtocol(config.Subnet) {
 		case apiv1.ProtocolIPv4:
-			if f.ClusterIpFamily != "ipv6" {
+			if f.HasIPv4() {
 				cidr = append(cidr, config.Subnet)
 				gateway = append(gateway, config.Gateway)
 			}
 		case apiv1.ProtocolIPv6:
-			if f.ClusterIpFamily != "ipv4" {
+			if f.HasIPv6() {
 				cidr = append(cidr, config.Subnet)
 				gateway = append(gateway, config.Gateway)
 			}
@@ -116,10 +116,10 @@ func setupNetworkAttachmentDefinition(
 	}
 	excludeIPs := make([]string, 0, len(network.Containers)*2)
 	for _, container := range network.Containers {
-		if container.IPv4Address != "" && f.ClusterIpFamily != "ipv6" {
+		if container.IPv4Address != "" && f.HasIPv4() {
 			excludeIPs = append(excludeIPs, strings.Split(container.IPv4Address, "/")[0])
 		}
-		if container.IPv6Address != "" && f.ClusterIpFamily != "ipv4" {
+		if container.IPv6Address != "" && f.HasIPv6() {
 			excludeIPs = append(excludeIPs, strings.Split(container.IPv6Address, "/")[0])
 		}
 	}

--- a/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
+++ b/test/e2e/kube-ovn/kubectl-ko/kubectl-ko.go
@@ -110,7 +110,7 @@ var _ = framework.Describe("[group:kubectl-ko]", func() {
 
 	framework.ConformanceIt(`should support "kubectl ko tcpdump <pod> -c1"`, func() {
 		ping, target := "ping", targetIPv4
-		if f.IPv6() {
+		if f.IsIPv6() {
 			ping, target = "ping6", targetIPv6
 		}
 

--- a/test/e2e/kube-ovn/service/service.go
+++ b/test/e2e/kube-ovn/service/service.go
@@ -121,7 +121,7 @@ var _ = framework.Describe("[group:service]", func() {
 	})
 
 	framework.ConformanceIt("should ovn nb change vip when dual-stack service removes the cluster ip ", func() {
-		if f.ClusterIpFamily != "dual" {
+		if !f.IsDual() {
 			ginkgo.Skip("this case only support dual mode")
 		}
 		f.SkipVersionPriorTo(1, 11, "This case is support in v1.11")

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -363,12 +363,12 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		for _, config := range dockerNetwork.IPAM.Config {
 			switch util.CheckProtocol(config.Subnet) {
 			case apiv1.ProtocolIPv4:
-				if f.ClusterIpFamily != "ipv6" {
+				if f.HasIPv4() {
 					cidr = append(cidr, config.Subnet)
 					gateway = append(gateway, config.Gateway)
 				}
 			case apiv1.ProtocolIPv6:
-				if f.ClusterIpFamily != "ipv4" {
+				if f.HasIPv6() {
 					cidr = append(cidr, config.Subnet)
 					gateway = append(gateway, config.Gateway)
 				}
@@ -376,10 +376,10 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		}
 		excludeIPs := make([]string, 0, len(network.Containers)*2)
 		for _, container := range network.Containers {
-			if container.IPv4Address != "" && f.ClusterIpFamily != "ipv6" {
+			if container.IPv4Address != "" && f.HasIPv4() {
 				excludeIPs = append(excludeIPs, strings.Split(container.IPv4Address, "/")[0])
 			}
-			if container.IPv6Address != "" && f.ClusterIpFamily != "ipv4" {
+			if container.IPv6Address != "" && f.HasIPv6() {
 				excludeIPs = append(excludeIPs, strings.Split(container.IPv6Address, "/")[0])
 			}
 		}
@@ -401,7 +401,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 	})
 
 	framework.ConformanceIt("should be able to detect IPv4 address conflict", func() {
-		if f.ClusterIpFamily != "ipv4" {
+		if !f.IsIPv4() {
 			ginkgo.Skip("Address conflict detection only supports IPv4")
 		}
 		f.SkipVersionPriorTo(1, 9, "Address conflict detection was introduced in v1.9")
@@ -487,12 +487,12 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		for _, config := range dockerNetwork.IPAM.Config {
 			switch util.CheckProtocol(config.Subnet) {
 			case apiv1.ProtocolIPv4:
-				if f.ClusterIpFamily != "ipv6" {
+				if f.HasIPv4() {
 					underlayCidr = append(underlayCidr, config.Subnet)
 					gateway = append(gateway, config.Gateway)
 				}
 			case apiv1.ProtocolIPv6:
-				if f.ClusterIpFamily != "ipv4" {
+				if f.HasIPv6() {
 					underlayCidr = append(underlayCidr, config.Subnet)
 					gateway = append(gateway, config.Gateway)
 				}
@@ -501,10 +501,10 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 
 		excludeIPs := make([]string, 0, len(network.Containers)*2)
 		for _, container := range network.Containers {
-			if container.IPv4Address != "" && f.ClusterIpFamily != "ipv6" {
+			if container.IPv4Address != "" && f.HasIPv4() {
 				excludeIPs = append(excludeIPs, strings.Split(container.IPv4Address, "/")[0])
 			}
-			if container.IPv6Address != "" && f.ClusterIpFamily != "ipv4" {
+			if container.IPv6Address != "" && f.HasIPv6() {
 				excludeIPs = append(excludeIPs, strings.Split(container.IPv6Address, "/")[0])
 			}
 		}

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -333,12 +333,12 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		for _, config := range dockerNetwork.IPAM.Config {
 			switch util.CheckProtocol(config.Subnet) {
 			case apiv1.ProtocolIPv4:
-				if f.ClusterIpFamily != "ipv6" {
+				if f.HasIPv4() {
 					cidr = append(cidr, config.Subnet)
 					gateway = append(gateway, config.Gateway)
 				}
 			case apiv1.ProtocolIPv6:
-				if f.ClusterIpFamily != "ipv4" {
+				if f.HasIPv6() {
 					cidr = append(cidr, config.Subnet)
 					gateway = append(gateway, config.Gateway)
 				}
@@ -346,10 +346,10 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		}
 		excludeIPs := make([]string, 0, len(network.Containers)*2)
 		for _, container := range network.Containers {
-			if container.IPv4Address != "" && f.ClusterIpFamily != "ipv6" {
+			if container.IPv4Address != "" && f.HasIPv4() {
 				excludeIPs = append(excludeIPs, strings.Split(container.IPv4Address, "/")[0])
 			}
-			if container.IPv6Address != "" && f.ClusterIpFamily != "ipv4" {
+			if container.IPv6Address != "" && f.HasIPv6() {
 				excludeIPs = append(excludeIPs, strings.Split(container.IPv6Address, "/")[0])
 			}
 		}

--- a/test/unittest/ipam/ip.go
+++ b/test/unittest/ipam/ip.go
@@ -15,6 +15,10 @@ func uint32ToIPv4(n uint32) string {
 	return fmt.Sprintf("%d.%d.%d.%d", n>>24, n&0xff0000>>16, n&0xff00>>8, n&0xff)
 }
 
+func ipv4ToUint32(ip net.IP) uint32 {
+	return uint32(ip[0])<<24 | uint32(ip[1])<<16 | uint32(ip[2])<<8 | uint32(ip[3])
+}
+
 func uint32ToIPv6(n [4]uint32) string {
 	return fmt.Sprintf(
 		"%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x",


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0558014</samp>

This pull request adds new features and tests for the IPPool and QoS functionalities of the kube-ovn project. It also improves the `ipam` package and the `framework` package with new methods, functions, and imports. It updates some existing method calls and test cases to match the new changes. The affected files are `pkg/internal/big_int.go`, `pkg/ipam/ip_range_list.go`, `pkg/ipam/ip_range.go`, `test/e2e/framework/deployment.go`, `test/e2e/framework/util.go`, `test/e2e/kube-ovn/ipam/ipam.go`, `test/unittest/ipam/ip_range_list.go`, `test/unittest/ipam/ip_range.go`, `pkg/ipam/ip.go`, `test/e2e/framework/ippool.go`, `test/e2e/framework/namespace.go`, `test/e2e/framework/pod.go`, `test/e2e/kube-ovn/qos/qos.go`, and `test/unittest/ipam/ip.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0558014</samp>

> _The `kube-ovn` project is great_
> _It lets users customize their network state_
> _With `IPPool` and `QoS`_
> _And some `ipam` tests_
> _It patches and validates at a fast rate_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0558014</samp>

*  Add and modify methods for the `BigInt` type in the `internal` package to compare with `int64` values and implement the `fmt.Stringer` interface ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-41c53682aa5ac7926179bc4669c896b4c9dc47521db1ca897641f40064e0ef89R20-R23),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-41c53682aa5ac7926179bc4669c896b4c9dc47521db1ca897641f40064e0ef89R36-R39))
*  Add a new function `NewIPRangeFromCIDR` to the `ipam` package to create an `IPRange` value from a CIDR notation ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-1c2f1d8dbe53e5fb98e206fff2652bb8d264a5e137b1254e66edf4a10d393ec4R6),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-1c2f1d8dbe53e5fb98e206fff2652bb8d264a5e137b1254e66edf4a10d393ec4L19-R31))
*  Modify the existing function `NewIPRangeListFrom` in the `ipam` package to support CIDR notation and single IP addresses as inputs ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-de9c95dea5718bdd4ec0189b24b681ecaf21caf346ac1e724b2dc4458f38c172R5),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-de9c95dea5718bdd4ec0189b24b681ecaf21caf346ac1e724b2dc4458f38c172L34-R41),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-de9c95dea5718bdd4ec0189b24b681ecaf21caf346ac1e724b2dc4458f38c172L48-R60))
*  Add a new method `Clone` to the `IP` type in the `ipam` package to create a copy of the `IP` value ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-c7538ef199b0341d14000955343b6a1a87225a354a5a750ffd44af3856f31f22R25-R30))
*  Add new methods `Patch` and `PatchSync` to the `DeploymentClient` type in the `framework` package to patch a deployment object using a merge patch and wait for its rollout status ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR6),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR17-R18),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR25-R26),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR71-R126),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fL88-R149))
*  Add a new method `RolloutStatus` to the `DeploymentClient` type in the `framework` package to wait for a deployment to be rolled out and get the updated deployment object ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR71-R126))
*  Add a new type `IPPoolClient` and its methods to the `framework` package to create, update, delete, and validate `IPPool` objects ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9d73a305002c18762271db0d0893201218b61153401fecb40640adb22e29033bR1-R256))
*  Add a new type `NamespaceClient` and its methods to the `framework` package to create, update, delete, and validate `Namespace` objects ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-6f3289521484b0895205bd2d95e6413af980e90f23b1df17ae3b3780ee22d045R1-R101))
*  Rename the existing method `PatchPod` of the `PodClient` type in the `framework` package to `Patch` to improve the naming consistency of the framework methods ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-5f15fda6193ef82e5636ecbb83e7df08e56285d7c04d7e7360c3461d7b08e065L46-R46))
*  Modify the existing function `RandomIPPool` in the `framework` package to use a set instead of a slice for deduplication and randomization of the IP addresses ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9dcbb8eba12c61d6f3dde188c0b8d8332365139e5062995d322795e02710fb6cR13),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-9dcbb8eba12c61d6f3dde188c0b8d8332365139e5062995d322795e02710fb6cL111-R117))
*  Add a new test case to the `ipam` package in the `test/e2e/kube-ovn/ipam/ipam.go` file to test the IPPool feature of the kube-ovn project ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R5-R6),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R16),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1L22-R31),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1L32-R45),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R65-R67),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1R385-R534))
*  Modify the existing method call in the `qos` package in the `test/e2e/kube-ovn/qos/qos.go` file to use the new name of the `Patch` method of the `PodClient` type ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-d863aabd8d2784f9f3c01d842685af90069bbcc7c037fd43c489a3eb03d72fe2L151-R151))
*  Add a new function `ipv4ToUint32` to the `ipam` package in the `test/unittest/ipam/ip.go` file to convert IPv4 addresses to `uint32` values ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-18b261d1cc318e863aebfb6550d591aa7c1d50aedd50139e29148ac48d5ea6dfR18-R21))
*  Add new test cases to the `ipam` package in the `test/unittest/ipam/ip_range.go` file to test the `NewIPRangeFromCIDR` function with IPv4 and IPv6 addresses ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-422d9214ed62afd697382b89b5060325fe9045c2c22e0c05cde4f080d89a841eR5),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-422d9214ed62afd697382b89b5060325fe9045c2c22e0c05cde4f080d89a841eR58-R78),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-422d9214ed62afd697382b89b5060325fe9045c2c22e0c05cde4f080d89a841eR136-R157))
*  Modify the existing test case in the `ipam` package in the `test/unittest/ipam/ip_range_list.go` file to support the CIDR notation as an input and use the `-` separator for IP ranges ([link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-bdb00d928a87f2a87234c13449419f4efb84da16907dcd9d9502daf0b95d6319R6),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-bdb00d928a87f2a87234c13449419f4efb84da16907dcd9d9502daf0b95d6319L204-R302),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-bdb00d928a87f2a87234c13449419f4efb84da16907dcd9d9502daf0b95d6319L244-R309),[link](https://github.com/kubeovn/kube-ovn/pull/2982/files?diff=unified&w=0#diff-bdb00d928a87f2a87234c13449419f4efb84da16907dcd9d9502daf0b95d6319L250-R315))