### PR TITLE
choose subnet by pod's annotation in networkpolicy

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -812,11 +812,6 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", "")
 	}
 
-	if err := c.ovnClient.CreateGatewayAcl(subnet.Name, "", subnet.Spec.Gateway); err != nil {
-		klog.Errorf("create gateway acl %s failed, %v", subnet.Name, err)
-		return err
-	}
-
 	if err := c.ovnClient.UpdateLogicalSwitchAcl(subnet.Name, subnet.Spec.Acls); err != nil {
 		c.patchSubnetStatus(subnet, "SetLogicalSwitchAclsFailed", err.Error())
 		return err

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -142,7 +142,7 @@ func (c *ovnClient) CreateGatewayAcl(lsName, pgName, gateway string) error {
 			ipSuffix = "ip6"
 		}
 
-		allowIngressAcl, err := c.newAcl(parentName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, fmt.Sprintf("%s.src == %s", ipSuffix, gw), ovnnb.ACLActionAllowRelated)
+		allowIngressAcl, err := c.newAcl(parentName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, fmt.Sprintf("%s.src == %s", ipSuffix, gw), ovnnb.ACLActionAllowStateless)
 		if err != nil {
 			return fmt.Errorf("new allow ingress acl for %s: %v", parentName, err)
 		}
@@ -154,7 +154,7 @@ func (c *ovnClient) CreateGatewayAcl(lsName, pgName, gateway string) error {
 			acl.Options["apply-after-lb"] = "true"
 		}
 
-		allowEgressAcl, err := c.newAcl(parentName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, fmt.Sprintf("%s.dst == %s", ipSuffix, gw), ovnnb.ACLActionAllowRelated, options)
+		allowEgressAcl, err := c.newAcl(parentName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, fmt.Sprintf("%s.dst == %s", ipSuffix, gw), ovnnb.ACLActionAllowStateless, options)
 		if err != nil {
 			return fmt.Errorf("new allow egress acl for %s: %v", parentName, err)
 		}
@@ -162,7 +162,7 @@ func (c *ovnClient) CreateGatewayAcl(lsName, pgName, gateway string) error {
 		acls = append(acls, allowIngressAcl, allowEgressAcl)
 
 		if ipSuffix == "ip6" {
-			ndAcl, err := c.newAcl(parentName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, "nd || nd_ra || nd_rs", ovnnb.ACLActionAllowRelated, options)
+			ndAcl, err := c.newAcl(parentName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, "nd || nd_ra || nd_rs", ovnnb.ACLActionAllowStateless, options)
 			if err != nil {
 				return fmt.Errorf("new nd acl for %s: %v", parentName, err)
 			}
@@ -179,7 +179,7 @@ func (c *ovnClient) CreateGatewayAcl(lsName, pgName, gateway string) error {
 	return nil
 }
 
-// CreateGatewayACL create allow acl for node join ip
+// CreateNodeAcl create allow acl for node join ip
 func (c *ovnClient) CreateNodeAcl(pgName, nodeIpStr, joinIpStr string) error {
 	acls := make([]*ovnnb.ACL, 0)
 	nodeIPs := strings.Split(nodeIpStr, ",")
@@ -191,7 +191,7 @@ func (c *ovnClient) CreateNodeAcl(pgName, nodeIpStr, joinIpStr string) error {
 		}
 		pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
 
-		allowIngressAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowRelated)
+		allowIngressAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowStateless)
 		if err != nil {
 			return fmt.Errorf("new allow ingress acl for port group %s: %v", pgName, err)
 		}
@@ -203,7 +203,7 @@ func (c *ovnClient) CreateNodeAcl(pgName, nodeIpStr, joinIpStr string) error {
 			acl.Options["apply-after-lb"] = "true"
 		}
 
-		allowEgressAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionFromLport, util.NodeAllowPriority, fmt.Sprintf("%s.dst == %s && %s.src == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowRelated, options)
+		allowEgressAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionFromLport, util.NodeAllowPriority, fmt.Sprintf("%s.dst == %s && %s.src == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowStateless, options)
 		if err != nil {
 			return fmt.Errorf("new allow egress acl for port group %s: %v", pgName, err)
 		}

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -224,7 +224,7 @@ func (suite *OvnClientTestSuite) testCreateGatewayAcl() {
 
 		acl, err := ovnClient.GetAcl(name, direction, priority, match, false)
 		require.NoError(t, err)
-		expect := newAcl(name, direction, priority, match, ovnnb.ACLActionAllowRelated)
+		expect := newAcl(name, direction, priority, match, ovnnb.ACLActionAllowStateless)
 		expect.UUID = acl.UUID
 		if len(options) != 0 {
 			expect.Options = options
@@ -362,7 +362,7 @@ func (suite *OvnClientTestSuite) testCreateNodeAcl() {
 	checkAcl := func(pg *ovnnb.PortGroup, direction, priority, match string, options map[string]string) {
 		acl, err := ovnClient.GetAcl(pg.Name, direction, priority, match, false)
 		require.NoError(t, err)
-		expect := newAcl(pg.Name, direction, priority, match, ovnnb.ACLActionAllowRelated)
+		expect := newAcl(pg.Name, direction, priority, match, ovnnb.ACLActionAllowStateless)
 		expect.UUID = acl.UUID
 		if len(options) != 0 {
 			expect.Options = options


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes


### Which issue(s) this PR fixes:
Fixes #2712

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ace13b1</samp>

This pull request fixes a bug that causes duplicate ACL rules for gateway nodes by removing an unnecessary function call. It also moves a function definition to a more appropriate package to avoid circular dependencies.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ace13b1</samp>

> _`CreateNodeAcl` moved_
> _From `ovs` to `controller`_
> _No more duplicate_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ace13b1</samp>

*  Remove unnecessary call to `CreateGatewayAcl` in `handleAddOrUpdateSubnet` function to fix duplicate ACL rules for gateway nodes ([link](https://github.com/kubeovn/kube-ovn/pull/2987/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L815-L819))
*  Move `CreateNodeAcl` function from `ovs` package to `controller` package to improve code organization and avoid circular dependencies ([link](https://github.com/kubeovn/kube-ovn/pull/2987/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L182-R182))