### PR TITLE
fix deleting old sb chassis for a re-added node

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -612,11 +612,8 @@ func (c *Controller) handleUpdateNode(key string) error {
 		return err
 	}
 
-	if node.Annotations[util.ChassisAnnotation] != "" {
-		if err = c.ovnLegacyClient.InitChassisNodeTag(node.Annotations[util.ChassisAnnotation], node.Name); err != nil {
-			klog.Errorf("failed to set chassis nodeTag for node '%s', %v", node.Name, err)
-			return err
-		}
+	if err := c.validateChassis(node); err != nil {
+		return err
 	}
 	if err := c.retryDelDupChassis(util.ChasRetryTime, util.ChasRetryIntev+2, c.checkChassisDupl, node); err != nil {
 		return err

--- a/pkg/ovs/ovn-sbctl.go
+++ b/pkg/ovs/ovn-sbctl.go
@@ -52,19 +52,15 @@ func (c LegacyClient) ovnSbCommand(cmdArgs ...string) (string, error) {
 }
 
 func (c LegacyClient) DeleteChassisByNode(node string) error {
-	output, err := c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("external_ids:node=%s", node))
+	chassis, err := c.GetChassis(node)
 	if err != nil {
 		return fmt.Errorf("failed to get node chassis %s, %v", node, err)
 	}
-	for _, chassis := range strings.Split(output, "\n") {
-		chassis = strings.TrimSpace(chassis)
-		if len(chassis) > 0 {
-			if err := c.DeleteChassisByName(chassis); err != nil {
-				return err
-			}
-		}
+	if chassis == "" {
+		return nil
 	}
-	return nil
+
+	return c.DeleteChassisByName(chassis)
 }
 
 func (c LegacyClient) DeleteChassisByName(chassisName string) error {
@@ -84,12 +80,12 @@ func (c LegacyClient) DeleteChassisByName(chassisName string) error {
 }
 
 func (c LegacyClient) GetChassis(node string) (string, error) {
-	output, err := c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("hostname=%s", node))
+	output, err := c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("external_ids:node=%s", node))
 	if err != nil {
 		return "", fmt.Errorf("failed to find node chassis %s, %v", node, err)
 	}
 	if len(output) == 0 {
-		output, err = c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("external_ids:node=%s", node))
+		output, err = c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("hostname=%s", node))
 		if err != nil {
 			return "", fmt.Errorf("failed to find node chassis %s, %v", node, err)
 		}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:

```txt
I0627 07:27:07.575182       7 node.go:594] handle update node ubuntu-1
W0627 07:27:07.583831       7 ovn-sbctl.go:46] ovn-sbctl command error: ovn-sbctl --timeout=60 --db=tcp:[172.16.70.140]:6642 set chassis c4ef0754-8d6a-433b-ad55-8a15a0ce330c external_ids:vendor=kube-ovn external_ids:node=ubuntu-1 in 8ms
E0627 07:27:07.583882       7 node.go:617] failed to set chassis nodeTag for node 'ubuntu-1', failed to set chassis external_ids, ovn-sbctl: no row "c4ef0754-8d6a-433b-ad55-8a15a0ce330c" in table Chassis
, "exit status 1"
E0627 07:27:07.583926       7 node.go:155] error syncing 'ubuntu-1': failed to set chassis external_ids, ovn-sbctl: no row "c4ef0754-8d6a-433b-ad55-8a15a0ce330c" in table Chassis
, "exit status 1", requeuing
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fbb74c</samp>

Refine chassis management and validation in `ovn-sbctl.go` and `node.go`. This improves the efficiency and reliability of node status updates and network connectivity.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5fbb74c</samp>

> _Sing, O Muse, of the mighty deeds of the ovn-kubernetes team_
> _Who strive to fix the network woes of the nodes and pods supreme_
> _They refactor and refine the code with skill and diligence_
> _To validate and set the chassis nodeTag with elegance_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fbb74c</samp>

*  Refactor the logic of validating and setting the chassis nodeTag for a node into a separate function `validateChassis` ([link](https://github.com/kubeovn/kube-ovn/pull/2989/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L615-R616))
* Simplify the logic of deleting the chassis by node name by calling `GetChassis` and `DeleteChassisByName` functions ([link](https://github.com/kubeovn/kube-ovn/pull/2989/files?diff=unified&w=0#diff-562d7a17619057b24d0d36932910d6c6cc55cccdad9031107677901c46f17accL55-R63))
* Swap the order of the ovn-sb commands in the `GetChassis` function to use the node name as the external_id first, and then the hostname ([link](https://github.com/kubeovn/kube-ovn/pull/2989/files?diff=unified&w=0#diff-562d7a17619057b24d0d36932910d6c6cc55cccdad9031107677901c46f17accL87-R88))