### PR TITLE
build arm image test

### DIFF
--- a/.github/workflows/build-kube-ovn-test.yaml
+++ b/.github/workflows/build-kube-ovn-test.yaml
@@ -13,6 +13,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
           cache: false
+          platforms: arm64
 
       - name: Build
         run: make image-test
@@ -24,4 +25,4 @@ jobs:
           COMMIT: ${{ github.sha }}
         run: |
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          docker push kubeovn/test:$(cat VERSION)
+          docker push kubeovn/test:$(cat VERSION)-arm

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ image-centos-compile:
 
 .PHOONY: image-test
 image-test: build-go
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/test:$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile.test dist/images/
+	docker buildx build --platform linux/arm64 -t $(REGISTRY)/test:$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile.test dist/images/
 
 .PHONY: release
 release: lint image-kube-ovn image-vpc-nat-gateway image-centos-compile


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 635bb56</samp>

This pull request adds support for building and pushing Docker images for ARM64 architecture, using `docker buildx` and a separate image tag. This enables running `kube-ovn` on ARM64-based clusters.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 635bb56</samp>

> _Oh we are the Docker builders, we work with Buildx tool_
> _We build for ARM64 platform, we make kube-ovn cool_
> _Heave away, me hearties, heave away with me_
> _On the count of three we push the image tag_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 635bb56</samp>

*  Enable multi-platform image building for ARM64 architecture ([link](https://github.com/kubeovn/kube-ovn/pull/2991/files?diff=unified&w=0#diff-da151d51e031bfd9050eba160fd73ee8a78d22a43a210fdd3a0d2b0c1ffb7bc6R16), [link](https://github.com/kubeovn/kube-ovn/pull/2991/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L133-R133))
* Append `-arm` to image tag for ARM64 images ([link](https://github.com/kubeovn/kube-ovn/pull/2991/files?diff=unified&w=0#diff-da151d51e031bfd9050eba160fd73ee8a78d22a43a210fdd3a0d2b0c1ffb7bc6L27-R28))