### PR TITLE
subnet: fix nat outgoing policy rule

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -830,7 +830,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -110,7 +110,7 @@ kube-ovn-conformance-e2e:
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
-	ginkgo $(GINKGO_PARALLEL_OPT) --randomize-all -v --timeout=25m \
+	ginkgo $(GINKGO_PARALLEL_OPT) --randomize-all -v --timeout=30m \
 		--focus=CNI:Kube-OVN ./test/e2e/kube-ovn/kube-ovn.test
 
 .PHONY: kube-ovn-ic-conformance-e2e

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -121,7 +121,7 @@ func (c *Controller) getSubnetsNatOutGoingPolicy(protocol string) ([]*kubeovnv1.
 
 	var subnetsWithNatPolicy []*kubeovnv1.Subnet
 	for _, subnet := range subnets {
-		if c.isSubnetNeedNat(subnet, protocol) && len(subnet.Spec.NatOutgoingPolicyRules) != 0 {
+		if c.isSubnetNeedNat(subnet, protocol) && len(subnet.Status.NatOutgoingPolicyRules) != 0 {
 			subnetsWithNatPolicy = append(subnetsWithNatPolicy, subnet)
 		}
 	}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -27,7 +27,7 @@ func DoubleQuotedFields(s string) []string {
 	return fields
 }
 
-func Sha256ByteToString(input []byte) string {
+func Sha256Hash(input []byte) string {
 	hasher := sha256.New()
 	hasher.Write(input)
 	hashedBytes := hasher.Sum(nil)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes
- Tests


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a36e85c</samp>

This pull request enhances the NAT outgoing policy feature for subnets in kube-ovn. It improves the subnet controller logic, the gateway daemon implementation, and the e2e test case for the feature. It also refactors some code and fixes some bugs related to the feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a36e85c</samp>

> _We are the masters of the gateway_
> _We filter the subnets with `natOutgoingPolicy`_
> _We hash and slice with `Sha256Hash` and `strset.Set`_
> _We rule the iptables with fire and fury_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a36e85c</samp>

*  Add and update functions to reconcile NAT outgoing policy rules on subnets and gateways ([link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R106), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L332-R335), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L347-R347), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L354-R354), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L689-L693), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R793-R797), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L124-R124), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R17), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L171-R182), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L197-R206), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L485-R482), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L783-R783), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L793-R798), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L819-R860), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L873-R872))
* Rename the `Sha256ByteToString` function to `Sha256Hash` in `pkg/util/strings.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-b85cb8dd9eecd095561611310332de19cd87bb74b60f8083131caec5e05d0b0dL30-R30))
* Modify and add test cases for NAT outgoing policy rules in `test/e2e/kube-ovn/subnet/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L38-R66), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L68-R95), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1093-R1112), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1137-R1156), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1160-R1197), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1185-R1203), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1208-R1236), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1226-R1251), [link](https://github.com/kubeovn/kube-ovn/pull/3003/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1243-R1275))