### PR TITLE
fix subnet finalizer

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -471,7 +471,7 @@ func (c *Controller) handleSubnetFinalizer(subnet *kubeovnv1.Subnet) (bool, erro
 	}
 
 	u2oInterconnIP := subnet.Status.U2OInterconnectionIP
-	if !subnet.DeletionTimestamp.IsZero() && usingIps == 0 || (usingIps == 1 && u2oInterconnIP != "") {
+	if !subnet.DeletionTimestamp.IsZero() && (usingIps == 0 || (usingIps == 1 && u2oInterconnIP != "")) {
 		subnet.Finalizers = util.RemoveString(subnet.Finalizers, util.ControllerName)
 		if _, err := c.config.KubeOvnClient.KubeovnV1().Subnets().Update(context.Background(), subnet, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("failed to remove finalizer from subnet %s, %v", subnet.Name, err)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d885619</samp>

Fix a logical bug in `subnet.go` that could cause a premature removal of the subnet finalizer. This change ensures the proper cleanup of subnet resources.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d885619</samp>

> _Subnet finalizer_
> _Fixed with parentheses `and`_
> _No more autumn leaks_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d885619</samp>

* Fix the logical condition for removing the finalizer from the subnet object ([link](https://github.com/kubeovn/kube-ovn/pull/3004/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L474-R474))