### PR TITLE
fix vpc already delete while delete policy route

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2532,6 +2532,11 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 }
 
 func (c *Controller) deletePolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) error {
+	logicalRouter, err := c.ovnClient.GetLogicalRouter(subnet.Spec.Vpc, true)
+	if err == nil && logicalRouter == nil {
+		klog.Infof("logical router %s already deleted", subnet.Spec.Vpc)
+		return nil
+	}
 	policies, err := c.ovnClient.ListLogicalRouterPolicies(subnet.Spec.Vpc, -1, map[string]string{
 		"isU2ORoutePolicy": "true",
 		"vendor":           util.CniTypeName,
@@ -2608,7 +2613,11 @@ func (c *Controller) addCustomVPCPolicyRoutesForSubnet(subnet *kubeovnv1.Subnet)
 }
 
 func (c *Controller) deleteCustomVPCPolicyRoutesForSubnet(subnet *kubeovnv1.Subnet) error {
-
+	logicalRouter, err := c.ovnClient.GetLogicalRouter(subnet.Spec.Vpc, true)
+	if err == nil && logicalRouter == nil {
+		klog.Infof("logical router %s already deleted", subnet.Spec.Vpc)
+		return nil
+	}
 	for _, cidr := range strings.Split(subnet.Spec.CIDRBlock, ",") {
 		af := 4
 		if util.CheckProtocol(cidr) == kubeovnv1.ProtocolIPv6 {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes


### Which issue(s) this PR fixes:
Fixes #2877 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a7e127</samp>

Improve policy route handling for custom VPC subnets. Prevent errors and unnecessary operations in `subnet.go` when deleting VPCs or subnets.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a7e127</samp>

> _Oh we are the coders of the `policy routes`_
> _We work with the `VPCs` and the `subnets` too_
> _We check for the errors and the deletions_
> _And we pull and we push and we merge on the count of three_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a7e127</samp>

*  Add a check for logical router existence before adding or deleting policy routes for U2O interconnection ([link](https://github.com/kubeovn/kube-ovn/pull/3005/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2535-R2539), [link](https://github.com/kubeovn/kube-ovn/pull/3005/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2611-R2620)) in `pkg/controller/subnet.go`