### PR TITLE
cleanup.sh: wait for provier-networks to be deleted before deleting kube-ovn-cni

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -968,10 +968,7 @@ jobs:
           done
 
       - name: Cleanup
-        run: |
-          if [ "${{ matrix.mode }}" != underlay ]; then
-            sh -x dist/images/cleanup.sh
-          fi
+        run: sh -x dist/images/cleanup.sh
 
   kube-ovn-ic-conformance-e2e:
     name: Kube-OVN IC Conformance E2E
@@ -1108,7 +1105,7 @@ jobs:
         run: make kind-install-chart
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: sh -x dist/images/cleanup.sh
 
   underlay-logical-gateway-installation-test:
     name: Underlay Logical Gateway Installation Test
@@ -1144,7 +1141,7 @@ jobs:
         run: make kind-install-underlay-logical-gateway-dual
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: sh -x dist/images/cleanup.sh
 
   no-ovn-lb-test:
     name: Disable OVN LB Test
@@ -1182,7 +1179,7 @@ jobs:
         run: make kind-install
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: sh -x dist/images/cleanup.sh
 
   no-np-test:
     name: Disable Network Policy Test
@@ -1220,7 +1217,7 @@ jobs:
         run: make kind-install
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: sh -x dist/images/cleanup.sh
 
   lb-svc-e2e:
     name: LB Service E2E
@@ -1535,7 +1532,7 @@ jobs:
           path: installation-compatibility-test-ko-log.tar.gz
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: sh -x dist/images/cleanup.sh
 
   cilium-chaining-e2e:
     name: Cilium Chaining E2E
@@ -1642,7 +1639,7 @@ jobs:
           path: cilium-chaining-e2e-ko-log.tar.gz
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: sh -x dist/images/cleanup.sh
 
   kube-ovn-security-e2e:
     name: Kube-OVN Security E2E
@@ -1757,7 +1754,7 @@ jobs:
           path: kube-ovn-security-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: sh -x dist/images/cleanup.sh
 
   push:
     name: Push Images
@@ -1930,7 +1927,7 @@ jobs:
           path: kube-ovn-submariner-conformance-e2e-ko-log.tar.gz
 
       - name: Cleanup
-        run: sh dist/images/cleanup.sh
+        run: sh -x dist/images/cleanup.sh
 
   iptables-vpc-nat-gw-conformance-e2e:
     name: Iptables VPC NAT Gateway E2E

--- a/dist/images/cleanup.sh
+++ b/dist/images/cleanup.sh
@@ -81,8 +81,11 @@ done
 kubectl delete --ignore-not-found deploy kube-ovn-monitor -n kube-system
 kubectl delete --ignore-not-found cm ovn-config ovn-ic-config ovn-external-gw-config -n kube-system
 kubectl delete --ignore-not-found svc kube-ovn-pinger kube-ovn-controller kube-ovn-cni kube-ovn-monitor -n kube-system
-kubectl delete --ignore-not-found ds kube-ovn-cni -n kube-system
 kubectl delete --ignore-not-found deploy kube-ovn-controller -n kube-system
+
+# wait for provier-networks to be deleted before deleting kube-ovn-cni
+sleep 5
+kubectl delete --ignore-not-found ds kube-ovn-cni -n kube-system
 
 # ensure kube-ovn-cni has been deleted
 while :; do


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec2f4b7</samp>

Simplify and debug the cleanup steps of some jobs in the `build-x86-image.yaml` workflow. Remove the mode check and add the `-x` flag to the shell commands.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ec2f4b7</samp>

> _`-x` flag added_
> _simplify and debug code_
> _autumn leaves cleanup_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec2f4b7</samp>

*  Enable shell debugging mode for cleanup steps in various jobs by adding the -x flag to the sh command ([link](https://github.com/kubeovn/kube-ovn/pull/3006/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1111-R1108), [link](https://github.com/kubeovn/kube-ovn/pull/3006/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1147-R1144), [link](https://github.com/kubeovn/kube-ovn/pull/3006/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1185-R1182), [link](https://github.com/kubeovn/kube-ovn/pull/3006/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1223-R1220), [link](https://github.com/kubeovn/kube-ovn/pull/3006/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1538-R1535), [link](https://github.com/kubeovn/kube-ovn/pull/3006/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1645-R1642), [link](https://github.com/kubeovn/kube-ovn/pull/3006/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1760-R1757), [link](https://github.com/kubeovn/kube-ovn/pull/3006/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1933-R1930)) in `.github/workflows/build-x86-image.yaml`