### PR TITLE
make compatible with simplicified enable-eip-snat-cm

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -771,8 +771,16 @@ func (c *Controller) reconcileRouteSubnets(cachedPod, pod *v1.Pod, needRoutePodN
 				}
 				nextHop := cm.Data["external-gw-addr"]
 				if nextHop == "" {
-					klog.Errorf("no available gateway nic address")
-					return fmt.Errorf("no available gateway nic address")
+					externalSubnet, err := c.subnetsLister.Get(c.config.ExternalGatewaySwitch)
+					if err != nil {
+						klog.Errorf("failed to get subnet %s, %v", c.config.ExternalGatewaySwitch, err)
+						return err
+					}
+					nextHop = externalSubnet.Spec.Gateway
+					if nextHop == "" {
+						klog.Errorf("no available gateway address")
+						return fmt.Errorf("no available gateway address")
+					}
 				}
 				if strings.Contains(nextHop, "/") {
 					nextHop = strings.Split(nextHop, "/")[0]

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -323,8 +323,16 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 			if err == nil {
 				nextHop := cm.Data["external-gw-addr"]
 				if nextHop == "" {
-					klog.Errorf("no available gateway nic address")
-					return fmt.Errorf("no available gateway nic address")
+					externalSubnet, err := c.subnetsLister.Get(c.config.ExternalGatewaySwitch)
+					if err != nil {
+						klog.Errorf("failed to get subnet %s, %v", c.config.ExternalGatewaySwitch, err)
+						return err
+					}
+					nextHop = externalSubnet.Spec.Gateway
+					if nextHop == "" {
+						klog.Errorf("no available gateway address")
+						return fmt.Errorf("no available gateway address")
+					}
 				}
 				if strings.Contains(nextHop, "/") {
 					nextHop = strings.Split(nextHop, "/")[0]


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes

if ovn-default reuse enable eip snat fip, some parameter may not need to specify.


### Which issue(s) this PR fixes:
Fixes #3008 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 472f773</samp>

This pull request adds fallback logic to get the external gateway address from the external subnet in the pod and vpc controllers. This is to support the scenario where the external gateway switch is a logical switch in `ovn`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 472f773</samp>

> _`reconcileRouteSubnets`_
> _Adds fallback logic for ovn_
> _Winter of config_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 472f773</samp>

*  Add fallback logic to get next hop gateway address from external subnet ([link](https://github.com/kubeovn/kube-ovn/pull/3009/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L774-R779), [link](https://github.com/kubeovn/kube-ovn/pull/3009/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL326-R331))