### PR TITLE
kube-ovn-controller: fix workqueue metrics

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -13,12 +13,12 @@ import (
 	v1 "k8s.io/api/authorization/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/controller"
@@ -35,7 +35,7 @@ func CmdMain() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		stopCh := server.SetupSignalHandler()
+		stopCh := signals.SetupSignalHandler().Done()
 		<-stopCh
 		cancel()
 	}()

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	gopkg.in/k8snetworkplumbingwg/multus-cni.v4 v4.0.2
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
-	k8s.io/apiserver v0.27.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/kubectl v0.27.3
@@ -248,6 +247,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.27.3 // indirect
+	k8s.io/apiserver v0.27.3 // indirect
 	k8s.io/cli-runtime v0.27.3 // indirect
 	k8s.io/cloud-provider v0.27.3 // indirect
 	k8s.io/cluster-bootstrap v0.27.3 // indirect

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +14,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (c *Controller) enqueueAddOvnDnatRule(obj interface{}) {

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,6 +12,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (c *Controller) enqueueAddOvnFip(obj interface{}) {

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,6 +12,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (c *Controller) enqueueAddOvnSnatRule(obj interface{}) {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:

Do not import `k8s.io/component-base/metrics` since it sets the default workqueue metrics provider.

```shell
$ go mod why k8s.io/component-base/metrics                                                                            ✔  02:33:49 PM 
# k8s.io/component-base/metrics
github.com/kubeovn/kube-ovn/cmd/controller
k8s.io/apiserver/pkg/server
k8s.io/apiserver/pkg/audit
k8s.io/component-base/metrics
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a09280e</samp>

Refactor workqueue creation in the controller. Extract common logic to a new function `newNamedRateLimitingQueue` in `pkg/controller/controller.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a09280e</samp>

> _Oh, we're the brave controllers of the Kubernetes fleet_
> _We manage all the workqueues with our code so neat_
> _We've refactored and improved the `newNamedRateLimitingQueue`_
> _So pull the line and sing along, we'll make it run like new_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a09280e</samp>

*  Add a new function `newNamedRateLimitingQueue` to create workqueues with custom names, rate limiters, and metrics providers ([link](https://github.com/kubeovn/kube-ovn/pull/3011/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R47-R57))
* Refactor the `Run` function to use `newNamedRateLimitingQueue` instead of `workqueue.NewNamedRateLimitingQueue` for creating the `podQueue`, `subnetQueue`, `ipQueue`, `vpcQueue`, `serviceQueue`, and `endpointQueue` workqueues ([link](https://github.com/kubeovn/kube-ovn/pull/3011/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L319-R359))