### PR TITLE
ci: fix go cache key

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -325,7 +325,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-${{ hashFiles(format('{0}/**/go.sum', env.E2E_DIR)) }}
+          key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-${{ hashFiles(format('{0}/**/go.sum', env.E2E_DIR)) }}
           restore-keys: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-
 
       - name: Install kind

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -703,16 +703,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Create branch directory
-        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
-
-      - name: Check out branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.branch }}
-          fetch-depth: 1
-          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
-
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -730,6 +720,16 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-
+
+      - name: Create branch directory
+        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
+
+      - name: Check out branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 1
+          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
 
       - name: Install kind
         uses: helm/kind-action@v1.7.0
@@ -773,16 +773,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Create branch directory
-        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
-
-      - name: Check out branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.branch }}
-          fetch-depth: 1
-          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
-
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -800,6 +790,16 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-
+
+      - name: Create branch directory
+        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
+
+      - name: Check out branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 1
+          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
 
       - name: Install kind
         uses: helm/kind-action@v1.7.0
@@ -842,16 +842,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Create branch directory
-        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
-
-      - name: Check out branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.branch }}
-          fetch-depth: 1
-          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
-
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -869,6 +859,16 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-e2e-${{ env.GO_FULL_VER }}-x86-
+
+      - name: Create branch directory
+        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
+
+      - name: Check out branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 1
+          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
 
       - name: Install kind
         uses: helm/kind-action@v1.7.0


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- CI

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2746c04</samp>

This change improves the scheduled e2e workflow by fixing the branch handling logic. It simplifies the workflow for the default branches and adds the necessary steps for the non-default branches in `.github/workflows/scheduled-e2e.yaml`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2746c04</samp>

> _Oh we are the e2e testers, we run the tests on `kube-ovn`_
> _We check out different branches, to see what's going on_
> _We don't need the default ones, we've got them in our sights_
> _But we need the non-default ones, to fix them up all right_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2746c04</samp>

* Fix the branch checkout steps for the scheduled e2e workflow ([link](https://github.com/kubeovn/kube-ovn/pull/3015/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L706-L715), [link](https://github.com/kubeovn/kube-ovn/pull/3015/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R724-R733), [link](https://github.com/kubeovn/kube-ovn/pull/3015/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L776-L785), [link](https://github.com/kubeovn/kube-ovn/pull/3015/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R794-R803), [link](https://github.com/kubeovn/kube-ovn/pull/3015/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L845-L854), [link](https://github.com/kubeovn/kube-ovn/pull/3015/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R863-R872))