### PR TITLE
fix ifname len exceed 12, for example kubevirt v1.0.0 gen ifname

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -191,6 +191,9 @@ func generateNicName(containerID, ifname string) (string, string) {
 	if ifname == "eth0" {
 		return fmt.Sprintf("%s_h", containerID[0:12]), fmt.Sprintf("%s_c", containerID[0:12])
 	}
+	if (len(ifname) >= 12 ) {
+		return fmt.Sprintf("%s_%s_h", containerID[0:6], ifname[11:len(ifname)]), fmt.Sprintf("%s_%s_c", containerID[0:6], ifname[11:len(ifname)])
+	}
 	return fmt.Sprintf("%s_%s_h", containerID[0:12-len(ifname)], ifname), fmt.Sprintf("%s_%s_c", containerID[0:12-len(ifname)], ifname)
 }
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

- Bug fixes

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bae15e3</samp>

Shorten long interface names in `generateNicName` function to avoid errors. Use container ID and interface suffix to create unique names for OVS ports.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bae15e3</samp>

> _`generateNicName`_
> _Shortens long interface names_
> _Autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bae15e3</samp>

* Shorten interface names that are too long for Linux ([link](https://github.com/kubeovn/kube-ovn/pull/3021/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feR194-R196))