### PR TITLE
static ip in exclude-ips can be allocated normally when subnet's avai…

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1773,6 +1773,7 @@ func (c *Controller) getNameByPod(pod *v1.Pod) string {
 	return pod.Name
 }
 
+// When subnet's v4availableIPs is 0 but still there's available ip in exclude-ips, the static ip in exclude-ips can be allocated normal.
 func (c *Controller) getNsAvailableSubnets(pod *v1.Pod, podNet *kubeovnNet) ([]*kubeovnNet, error) {
 	var result []*kubeovnNet
 	// keep the annotation subnet of the pod in first position
@@ -1796,19 +1797,6 @@ func (c *Controller) getNsAvailableSubnets(pod *v1.Pod, podNet *kubeovnNet) ([]*
 		if err != nil {
 			klog.Errorf("failed to get subnet %v", err)
 			return nil, err
-		}
-
-		switch subnet.Spec.Protocol {
-		case kubeovnv1.ProtocolIPv4:
-			fallthrough
-		case kubeovnv1.ProtocolDual:
-			if subnet.Status.V4AvailableIPs == 0 {
-				continue
-			}
-		case kubeovnv1.ProtocolIPv6:
-			if subnet.Status.V6AvailableIPs == 0 {
-				continue
-			}
 		}
 
 		result = append(result, &kubeovnNet{


### PR DESCRIPTION
…lableIPs is 0


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes


### Which issue(s) this PR fixes:
Fixes #3030 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9de9b2c</samp>

Enable static IP allocation for pods from excluded IPs. Refactor `pod.go` to handle subnets with no free IPs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9de9b2c</samp>

> _Oh we're the coders of the `pod.go` file_
> _And we don't like to waste a single IP_
> _So we'll allocate them from the exclude list_
> _Heave away, me hearties, heave away_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9de9b2c</samp>

*  Enable allocating static IPs from exclude-ips list of a subnet ([link](https://github.com/kubeovn/kube-ovn/pull/3031/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1776), [link](https://github.com/kubeovn/kube-ovn/pull/3031/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1801-L1813))