### PR TITLE
fix ifname start with pod

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -185,6 +185,11 @@ func generateNicName(containerID, ifname string) (string, string) {
 	if ifname == "eth0" {
 		return fmt.Sprintf("%s_h", containerID[0:12]), fmt.Sprintf("%s_c", containerID[0:12])
 	}
+	// The nic name is 14 length and have prefix pod in the Kubevirt v1.0.0
+	if strings.HasPrefix(ifname, "pod") && len(ifname) == 14 {
+		ifname = ifname[3 : len(ifname)-4]
+		return fmt.Sprintf("%s_%s_h", containerID[0:12-len(ifname)], ifname), fmt.Sprintf("%s_%s_c", containerID[0:12-len(ifname)], ifname)
+	}
 	return fmt.Sprintf("%s_%s_h", containerID[0:12-len(ifname)], ifname), fmt.Sprintf("%s_%s_c", containerID[0:12-len(ifname)], ifname)
 }
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:

- Bug fixes


### Which issue(s) this PR fixes:
Fixes #3037 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6cb2437</samp>

Support Kubevirt integration by handling nic names with `pod` prefix in `ovs_linux.go`

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6cb2437</samp>

> _`pod` nic names change_
> _Kubevirt and Kube-OVN_
> _harmonize in spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6cb2437</samp>

*  Add support for Kubevirt v1.0.0 nic names ([link](https://github.com/kubeovn/kube-ovn/pull/3038/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feR188-R192))