### PR TITLE
skip e2e in release-1.8

### DIFF
--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -520,6 +520,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 	})
 
 	framework.ConformanceIt("should support distributed external egress gateway", func() {
+		f.SkipVersionPriorTo(1, 9, "Do not support before v1.9")
 		ginkgo.By("Getting nodes")
 		nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), cs)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Tests

https://github.com/kubeovn/kube-ovn/actions/runs/5540968475/jobs/10134494711

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at febfa51</samp>

Skip `subnet` test cases on unsupported Kubernetes versions. Use `f.SkipVersionPriorTo` to check the Kubernetes version in `test/e2e/kube-ovn/subnet/subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at febfa51</samp>

> _`kube-ovn` needs new_
> _Kubernetes for `subnet` tests_
> _Skip them in winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at febfa51</samp>

* Skip test cases for unsupported Kubernetes versions ([link](https://github.com/kubeovn/kube-ovn/pull/3039/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5R523))