### PR TITLE
security: run as unprivileged

### DIFF
--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -47,8 +47,12 @@ spec:
           command: 
           - /kube-ovn/start-db.sh
           securityContext:
+            runAsUser: 0
+            privileged: false
             capabilities:
-              add: ["SYS_NICE"]
+              add:
+                - NET_BIND_SERVICE
+                - SYS_NICE
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -116,6 +116,12 @@ spec:
           - --keep-vm-ip={{- .Values.func.ENABLE_KEEP_VM_IP }}
           - --enable-metrics={{- .Values.networking.ENABLE_METRICS }}
           - --node-local-dns-ip={{- .Values.networking.NODE_LOCAL_DNS_IP }}
+          securityContext:
+            runAsUser: 0
+            privileged: false
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -84,7 +84,13 @@ spec:
           - --ovs-vsctl-concurrency={{ .Values.performance.OVS_VSCTL_CONCURRENCY }}
         securityContext:
           runAsUser: 0
-          privileged: true
+          privileged: false
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_BIND_SERVICE
+              - NET_RAW
+              - SYS_ADMIN
         env:
           - name: ENABLE_SSL
             value: "{{ .Values.networking.ENABLE_SSL }}"
@@ -117,7 +123,7 @@ spec:
             name: cni-conf
           - mountPath: /run/openvswitch
             name: host-run-ovs
-            mountPropagation: Bidirectional
+            mountPropagation: HostToContainer
           - mountPath: /run/ovn
             name: host-run-ovn
           - mountPath: /host/var/run/dbus

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -62,7 +62,13 @@ spec:
           {{- end }}
           securityContext:
             runAsUser: 0
-            privileged: true
+            privileged: false
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_BIND_SERVICE
+                - SYS_MODULE
+                - SYS_NICE
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3341,8 +3341,12 @@ spec:
           command:
           - /kube-ovn/start-db.sh
           securityContext:
+            runAsUser: 0
+            privileged: false
             capabilities:
-              add: ["SYS_NICE"]
+              add:
+                - NET_BIND_SERVICE
+                - SYS_NICE
           env:
             - name: ENABLE_SSL
               value: "$ENABLE_SSL"
@@ -3666,7 +3670,13 @@ spec:
           - /kube-ovn/start-ovs.sh
           securityContext:
             runAsUser: 0
-            privileged: true
+            privileged: false
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_BIND_SERVICE
+                - SYS_MODULE
+                - SYS_NICE
           env:
             - name: ENABLE_SSL
               value: "$ENABLE_SSL"
@@ -4067,6 +4077,12 @@ spec:
           - --enable-lb-svc=$ENABLE_LB_SVC
           - --keep-vm-ip=$ENABLE_KEEP_VM_IP
           - --node-local-dns-ip=$NODE_LOCAL_DNS_IP
+          securityContext:
+            runAsUser: 0
+            privileged: false
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
           env:
             - name: ENABLE_SSL
               value: "$ENABLE_SSL"
@@ -4210,7 +4226,13 @@ spec:
           - --ovs-vsctl-concurrency=$OVS_VSCTL_CONCURRENCY
         securityContext:
           runAsUser: 0
-          privileged: true
+          privileged: false
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_BIND_SERVICE
+              - NET_RAW
+              - SYS_ADMIN
         env:
           - name: ENABLE_SSL
             value: "$ENABLE_SSL"
@@ -4243,7 +4265,7 @@ spec:
             name: cni-conf
           - mountPath: /run/openvswitch
             name: host-run-ovs
-            mountPropagation: Bidirectional
+            mountPropagation: HostToContainer
           - mountPath: /run/ovn
             name: host-run-ovn
           - mountPath: /host/var/run/dbus
@@ -4251,7 +4273,7 @@ spec:
             mountPropagation: HostToContainer
           - mountPath: /var/run/netns
             name: host-ns
-            mountPropagation: Bidirectional
+            mountPropagation: HostToContainer
           - mountPath: /var/log/kube-ovn
             name: kube-ovn-log
           - mountPath: /var/log/openvswitch

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -380,21 +380,6 @@ func (csh cniServerHandler) configureContainerNic(podName, podNamespace, nicName
 			}
 		}
 
-		if util.CheckProtocol(ipAddr) == kubeovnv1.ProtocolDual || util.CheckProtocol(ipAddr) == kubeovnv1.ProtocolIPv6 {
-			// For docker version >=17.x the "none" network will disable ipv6 by default.
-			// We have to enable ipv6 here to add v6 address and gateway.
-			// See https://github.com/containernetworking/cni/issues/531
-			value, err := sysctl.Sysctl("net.ipv6.conf.all.disable_ipv6")
-			if err != nil {
-				return fmt.Errorf("failed to get sysctl net.ipv6.conf.all.disable_ipv6: %v", err)
-			}
-			if value != "0" {
-				if _, err = sysctl.Sysctl("net.ipv6.conf.all.disable_ipv6", "0"); err != nil {
-					return fmt.Errorf("failed to enable ipv6 on all nic: %v", err)
-				}
-			}
-		}
-
 		if nicType == util.InternalType {
 			if err = addAdditionalNic(ifName); err != nil {
 				klog.Error(err)
@@ -785,21 +770,6 @@ func configureNodeGwNic(portName, ip, gw string, macAddr net.HardwareAddr, mtu i
 		klog.V(3).Infof("node external nic %q already in ns %s", util.NodeGwNic, util.NodeGwNsPath)
 	}
 	return ns.WithNetNSPath(gwNS.Path(), func(_ ns.NetNS) error {
-		if util.CheckProtocol(ip) == kubeovnv1.ProtocolDual || util.CheckProtocol(ip) == kubeovnv1.ProtocolIPv6 {
-			// For docker version >=17.x the "none" network will disable ipv6 by default.
-			// We have to enable ipv6 here to add v6 address and gateway.
-			// See https://github.com/containernetworking/cni/issues/531
-			value, err := sysctl.Sysctl("net.ipv6.conf.all.disable_ipv6")
-			if err != nil {
-				return fmt.Errorf("failed to get sysctl net.ipv6.conf.all.disable_ipv6: %v", err)
-			}
-			if value != "0" {
-				if _, err = sysctl.Sysctl("net.ipv6.conf.all.disable_ipv6", "0"); err != nil {
-					return fmt.Errorf("failed to enable ipv6 on all nic: %v", err)
-				}
-			}
-		}
-
 		if err = configureNic(util.NodeGwNic, ip, macAddr, mtu, true); err != nil {
 			klog.Errorf("failed to congigure node gw nic %s, %v", util.NodeGwNic, err)
 			return err

--- a/yamls/speaker.yaml
+++ b/yamls/speaker.yaml
@@ -29,7 +29,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-speaker
-          image: "kubeovn/kube-ovn:v1.13.0"
+          image: "docker.io/kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command:
             - /kube-ovn/kube-ovn-speaker

--- a/yamls/webhook.yaml
+++ b/yamls/webhook.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-webhook
-          image: "kubeovn/kube-ovn:v1.13.0"
+          image: "docker.io/kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command:
             - /kube-ovn/kube-ovn-webhook


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Security

### Which issue(s) this PR fixes:

Run containers as unprivileged.

~kube-ovn-cni still runs as privileged since it writes sysctl variables to enable IPv6 for network links.~