### PR TITLE
set genev_sys_6081 tx checksum off

### DIFF
--- a/cmd/daemon/init.go
+++ b/cmd/daemon/init.go
@@ -3,7 +3,20 @@
 
 package daemon
 
+import (
+	"fmt"
+	"os/exec"
+
+	"k8s.io/klog/v2"
+)
+
 func initForOS() error {
-	// nothing to do on Linux
+	// disable checksum for genev_sys_6081 as default
+	cmd := exec.Command("sh", "-c", "ethtool -K genev_sys_6081 tx off")
+	if err := cmd.Run(); err != nil {
+		err := fmt.Errorf("failed to set checksum off for genev_sys_6081, %v", err)
+		// should not affect cni pod running if failed, just record err log
+		klog.Error(err)
+	}
 	return nil
 }


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes
<img width="632" alt="企业微信截图_df13dd78-cbd8-4f1c-b0a6-49bbf0a1b4f9" src="https://github.com/kubeovn/kube-ovn/assets/67130442/e0c2ab3f-31ed-4059-995f-1f016936e208">


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7def5cc</samp>

Disable tx checksum for geneve interface on Linux to avoid packet loss. Modify `initForOS` function in `cmd/daemon/init.go` to use `ethtool` command.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7def5cc</samp>

> _`initForOS` changed_
> _checksum off for geneve_
> _buggy in winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7def5cc</samp>

*  Disable tx checksum for geneve interface on Linux ([link](https://github.com/kubeovn/kube-ovn/pull/3045/files?diff=unified&w=0#diff-0fff8b317ba166617018d68a826a11b9f75bdb158222b6bff955c5d3d6377527L6-R21))