### PR TITLE
fix vpc lb init

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -204,7 +204,7 @@ func (c *Controller) addLoadBalancer(vpc string) (*VpcLoadBalancer, error) {
 	if err := c.initLB(vpcLbConfig.TcpLoadBalancer, string(v1.ProtocolTCP), false); err != nil {
 		return nil, err
 	}
-	if err := c.initLB(vpcLbConfig.TcpSessLoadBalancer, string(v1.ProtocolTCP), false); err != nil {
+	if err := c.initLB(vpcLbConfig.TcpSessLoadBalancer, string(v1.ProtocolTCP), true); err != nil {
 		return nil, err
 	}
 	if err := c.initLB(vpcLbConfig.UdpLoadBalancer, string(v1.ProtocolUDP), false); err != nil {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes
keep the logic the same as ovn-cluster inn init.go

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 175e943</samp>

Enable `keepClientIP` option for TCP load balancers in `vpc.go`. This allows source IP preservation for TCP traffic in kube-ovn.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 175e943</samp>

> _`addLoadBalancer`_
> _Preserves client IP now_
> _Winter snowflakes, unique_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 175e943</samp>

* Enable source IP preservation for TCP load balancers by passing `true` as the third argument to `initLB` in `addLoadBalancer` ([link](https://github.com/kubeovn/kube-ovn/pull/3046/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL207-R207))