### PR TITLE
cni: reduce memory usage

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -56,6 +56,10 @@ jobs:
           - go.sum
           EOF
 
+          sh hack/go-list.sh cmd/cni | while read f; do
+            echo "- $f" | tee -a $filter
+          done
+
           sh hack/go-list.sh cmd/windows | while read f; do
             echo "- $f" | tee -a $filter
           done

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ ARCH = amd64
 .PHONY: build-go
 build-go:
 	go mod tidy
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn -ldflags $(GOLDFLAGS) -v ./cmd/cni
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-cmd -ldflags $(GOLDFLAGS) -v ./cmd
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-webhook -ldflags $(GOLDFLAGS) -v ./cmd/webhook
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(CURDIR)/dist/images/test-server -ldflags $(GOLDFLAGS) -v ./test/server
@@ -81,11 +82,12 @@ build-go:
 .PHONY: build-go-windows
 build-go-windows:
 	go mod tidy
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -buildmode=pie -o $(CURDIR)/dist/windows/kube-ovn.exe -ldflags $(GOLDFLAGS) -v ./cmd/windows/cni
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -buildmode=pie -o $(CURDIR)/dist/windows/kube-ovn.exe -ldflags $(GOLDFLAGS) -v ./cmd/cni
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -buildmode=pie -o $(CURDIR)/dist/windows/kube-ovn-daemon.exe -ldflags $(GOLDFLAGS) -v ./cmd/windows/daemon
 
 .PHONY: build-go-arm
 build-go-arm:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn -ldflags $(GOLDFLAGS) -v ./cmd/cni
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-cmd -ldflags $(GOLDFLAGS) -v ./cmd
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-webhook -ldflags $(GOLDFLAGS) -v ./cmd/webhook
 

--- a/cmd/cmdmain.go
+++ b/cmd/cmdmain.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/kubeovn/kube-ovn/cmd/cni"
 	"github.com/kubeovn/kube-ovn/cmd/controller"
 	"github.com/kubeovn/kube-ovn/cmd/controller_health_check"
 	"github.com/kubeovn/kube-ovn/cmd/daemon"
@@ -16,7 +15,6 @@ import (
 )
 
 const (
-	CmdCNI                   = "kube-ovn"
 	CmdController            = "kube-ovn-controller"
 	CmdDaemon                = "kube-ovn-daemon"
 	CmdMonitor               = "kube-ovn-monitor"
@@ -29,8 +27,6 @@ const (
 func main() {
 	cmd := filepath.Base(os.Args[0])
 	switch cmd {
-	case CmdCNI:
-		cni.CmdMain()
 	case CmdController:
 		controller.CmdMain()
 	case CmdDaemon:

--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -1,4 +1,4 @@
-package cni
+package main
 
 import (
 	"encoding/json"
@@ -18,7 +18,7 @@ import (
 	"github.com/kubeovn/kube-ovn/versions"
 )
 
-func CmdMain() {
+func main() {
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we
 	// must ensure that the goroutine does not jump from OS thread to thread

--- a/cmd/cni/netconf.go
+++ b/cmd/cni/netconf.go
@@ -1,7 +1,7 @@
 //go:build !windows
 // +build !windows
 
-package cni
+package main
 
 import (
 	"github.com/containernetworking/cni/pkg/types"

--- a/cmd/cni/netconf_windows.go
+++ b/cmd/cni/netconf_windows.go
@@ -1,4 +1,4 @@
-package cni
+package main
 
 import (
 	"github.com/containernetworking/plugins/pkg/hns"

--- a/cmd/windows/cni/main_windows.go
+++ b/cmd/windows/cni/main_windows.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/kubeovn/kube-ovn/cmd/cni"
-
-func main() {
-	cni.CmdMain()
-}

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -16,10 +16,10 @@ RUN rm -f /usr/bin/nc &&\
     rm -f /usr/bin/netcat
 RUN deluser sync
 
+COPY kube-ovn /kube-ovn/kube-ovn
 COPY kube-ovn-cmd /kube-ovn/kube-ovn-cmd
 COPY kube-ovn-webhook /kube-ovn/kube-ovn-webhook
-RUN ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn && \
-    ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-controller && \
+RUN ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-controller && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-daemon && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-monitor && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-pinger && \


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Performance

### Which issue(s) this PR fixes:

This patch reduces ~9MB memory usage on each CNI call.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0cae295</samp>

Refactor the `cni` package to be a standalone binary for linux and windows platforms. Add support for building and packaging the kube-ovn CNI plugin for amd64 and arm64 architectures.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0cae295</samp>

> _Oh we're the crew of the `kube-ovn` ship_
> _And we're sailing on the Kubernetes sea_
> _We're refactoring the `cni` package_
> _To make it a standalone binary_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0cae295</samp>

*  Refactor the cni package to be a standalone binary instead of a subcommand of the kube-ovn binary ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-75b8facded9be99f0542693b5a75c6cbb7fc9c103562b8cd05d34c28718e4a91L7), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-75b8facded9be99f0542693b5a75c6cbb7fc9c103562b8cd05d34c28718e4a91L19), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-75b8facded9be99f0542693b5a75c6cbb7fc9c103562b8cd05d34c28718e4a91L32-L33), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-a181d9df098e77ef68d741855af3f27b883f84f5782d1050918489b58efb64fcL1-R1), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-a181d9df098e77ef68d741855af3f27b883f84f5782d1050918489b58efb64fcL21-R21), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-5e77c9354b793af502eeee3d27fc414e33208a04433f5a62e18bac1579bf4043L4-R4), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-9faad26ef5c1366370a26b44207d4cde228c0de3da1445887e6dfcd02c5aaf31L1-R1), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-91004241f29d2ed6a1dec945cea49ab5cf86c538b6720f515aa9149135624d35))
  * Remove the import of the `cni` package and the constant `CmdCNI` from the `cmdmain.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-75b8facded9be99f0542693b5a75c6cbb7fc9c103562b8cd05d34c28718e4a91L7), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-75b8facded9be99f0542693b5a75c6cbb7fc9c103562b8cd05d34c28718e4a91L19))
  * Remove the case for the `CmdCNI` from the switch statement in the main function of the `cmdmain.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-75b8facded9be99f0542693b5a75c6cbb7fc9c103562b8cd05d34c28718e4a91L32-L33))
  * Change the package name of the `cni.go`, `netconf.go`, and `netconf_windows.go` files from `cni` to `main` ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-a181d9df098e77ef68d741855af3f27b883f84f5782d1050918489b58efb64fcL1-R1), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-5e77c9354b793af502eeee3d27fc414e33208a04433f5a62e18bac1579bf4043L4-R4), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-9faad26ef5c1366370a26b44207d4cde228c0de3da1445887e6dfcd02c5aaf31L1-R1))
  * Change the function name of the `cni.go` file from `CmdMain` to `main` ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-a181d9df098e77ef68d741855af3f27b883f84f5782d1050918489b58efb64fcL21-R21))
  * Delete the file `cmd/windows/cni/main_windows.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-91004241f29d2ed6a1dec945cea49ab5cf86c538b6720f515aa9149135624d35))
* Add support for linux amd64 and arm64 platforms for the CNI plugin binary ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R77), [link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L84-R90))
  * Add a new command to the Makefile to build the kube-ovn binary for linux amd64 platform and copy it to the dist/images directory ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R77))
  * Modify the command to build the kube-ovn binary for linux arm64 platform and copy it to the dist/images directory along with the other binaries ([link](https://github.com/kubeovn/kube-ovn/pull/3047/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L84-R90))