### PR TITLE
controller: skip VIP gc if LB not found

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -501,10 +501,14 @@ func (c *Controller) gcLoadBalancer() error {
 				return nil
 			}
 
-			lb, err := c.ovnClient.GetLoadBalancer(lbName, false)
+			lb, err := c.ovnClient.GetLoadBalancer(lbName, true)
 			if err != nil {
 				klog.Errorf("get LB %s: %v", lbName, err)
 				return err
+			}
+			if lb == nil {
+				klog.Infof("load balancer %q not found", lbName)
+				return nil
 			}
 
 			for vip := range lb.Vips {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
In the first run, kube-ovn-controller may exit because the LB does not exist.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d583ea9</samp>

Changed the error handling logic for `GetLoadBalancer` function in `pkg/controller/gc.go` to avoid unnecessary retries and log the missing load balancers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d583ea9</samp>

> _`GetLoadBalancer`_
> _No error if not found now_
> _Autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d583ea9</samp>

* Change the behavior of `GetLoadBalancer` function call to return `nil` instead of error if load balancer is not found ([link](https://github.com/kubeovn/kube-ovn/pull/3048/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L504-R512))