### PR TITLE
keep vm vip when enableKeepVmIP is true

### DIFF
--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -439,7 +439,7 @@ func (c *Controller) patchVipStatus(key, v4ip string, ready bool) error {
 	return nil
 }
 
-func (c *Controller) podReuseVip(key, portName string, isStsPod bool) error {
+func (c *Controller) podReuseVip(key, portName string, keepVIP bool) error {
 	// when pod use static vip, label vip reserved for pod
 	oriVip, err := c.virtualIpsLister.Get(key)
 	if err != nil {
@@ -453,7 +453,7 @@ func (c *Controller) podReuseVip(key, portName string, isStsPod bool) error {
 	var op string
 
 	if vip.Labels[util.IpReservedLabel] != "" {
-		if isStsPod && vip.Labels[util.IpReservedLabel] == portName {
+		if keepVIP && vip.Labels[util.IpReservedLabel] == portName {
 			return nil
 		} else {
 			return fmt.Errorf("vip '%s' is in use by pod %s", vip.Name, vip.Labels[util.IpReservedLabel])


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #2954

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 94621b0</samp>

This pull request adds a feature to reuse IP addresses for virtual machine pods and refactors the `podReuseVip` function. It changes the logic and location of the function in `pkg/controller/vip.go` and updates the function call in `pkg/controller/pod.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 94621b0</samp>

> _Sing, O Muse, of the cunning code that changed the fate of pods_
> _That dwell in virtual machines and share the same abodes_
> _How they learned to keep their IP, the precious `podReuseVip`_
> _That moved from `pod.go` to another file with skill and zip_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 94621b0</samp>

*  Add support for keeping the same IP address for virtual machine pods when they are recreated ([link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1370), [link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1380-R1384), [link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L442-R442), [link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L456-R456))
  * Introduce a new variable `isVMPod` in `acquireAddress` in `pkg/controller/pod.go` to indicate whether the pod is a virtual machine pod or not ([link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1370))
  * Check the `c.config.EnableKeepVmIP` flag and set the `isVMPod` variable accordingly in `acquireAddress` in `pkg/controller/pod.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1380-R1384))
  * Pass the `isVMPod` variable as an argument to the `podReuseVip` function, which is moved from `pkg/controller/vip.go` to `pkg/controller/pod.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1380-R1384), [link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L442-R442))
  * Rename the parameter `isStsPod` to `keepVIP` in the `podReuseVip` function to reflect the more general purpose of reusing the VIP for pods that need to keep the same IP address ([link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L442-R442))
  * Replace the `isStsPod` variable with the `keepVIP` variable in the condition of the `podReuseVip` function ([link](https://github.com/kubeovn/kube-ovn/pull/3053/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L456-R456))