### PR TITLE
ipam: fix ippool with single dual-stack address

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -837,7 +837,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-22.04
-    timeout-minutes: 35
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -334,7 +334,7 @@ jobs:
   kube-ovn-conformance-e2e:
     name: Kube-OVN Conformance E2E
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1549,12 +1549,15 @@ func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, st
 			ipPool = strings.Split(ippoolStr, ";")
 		} else {
 			ipPool = strings.Split(ippoolStr, ",")
+			if len(ipPool) == 2 && util.CheckProtocol(ipPool[0]) != util.CheckProtocol(ipPool[1]) {
+				ipPool = []string{ippoolStr}
+			}
 		}
 		for i, ip := range ipPool {
 			ipPool[i] = strings.TrimSpace(ip)
 		}
 
-		if len(ipPool) == 1 && net.ParseIP(ipPool[0]) == nil {
+		if len(ipPool) == 1 && (!strings.ContainsRune(ipPool[0], ',') && net.ParseIP(ipPool[0]) == nil) {
 			var skippedAddrs []string
 			for {
 				portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)

--- a/test/e2e/kube-ovn/ipam/ipam.go
+++ b/test/e2e/kube-ovn/ipam/ipam.go
@@ -252,64 +252,68 @@ var _ = framework.Describe("[group:ipam]", func() {
 			ippoolSep = ","
 		}
 
-		replicas := 3
-		ippool := framework.RandomIPs(cidr, ippoolSep, replicas)
-		labels := map[string]string{"app": stsName}
+		for replicas := 1; replicas <= 3; replicas++ {
+			ippool := framework.RandomIPs(cidr, ippoolSep, replicas)
+			labels := map[string]string{"app": stsName}
 
-		ginkgo.By("Creating statefulset " + stsName + " with ippool " + ippool)
-		sts := framework.MakeStatefulSet(stsName, stsName, int32(replicas), labels, framework.PauseImage)
-		sts.Spec.Template.Annotations = map[string]string{util.IpPoolAnnotation: ippool}
-		sts = stsClient.CreateSync(sts)
+			ginkgo.By("Creating statefulset " + stsName + " with ippool " + ippool)
+			sts := framework.MakeStatefulSet(stsName, stsName, int32(replicas), labels, framework.PauseImage)
+			sts.Spec.Template.Annotations = map[string]string{util.IpPoolAnnotation: ippool}
+			sts = stsClient.CreateSync(sts)
 
-		ginkgo.By("Getting pods for statefulset " + stsName)
-		pods := stsClient.GetPods(sts)
-		framework.ExpectHaveLen(pods.Items, replicas)
+			ginkgo.By("Getting pods for statefulset " + stsName)
+			pods := stsClient.GetPods(sts)
+			framework.ExpectHaveLen(pods.Items, replicas)
 
-		ips := make([]string, 0, replicas)
-		for _, pod := range pods.Items {
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.CidrAnnotation, subnet.Spec.CIDRBlock)
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.GatewayAnnotation, subnet.Spec.Gateway)
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.IpPoolAnnotation, ippool)
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.LogicalSwitchAnnotation, subnet.Name)
-			framework.ExpectMAC(pod.Annotations[util.MacAddressAnnotation])
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+			ips := make([]string, 0, replicas)
+			for _, pod := range pods.Items {
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.CidrAnnotation, subnet.Spec.CIDRBlock)
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.GatewayAnnotation, subnet.Spec.Gateway)
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.IpPoolAnnotation, ippool)
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.LogicalSwitchAnnotation, subnet.Name)
+				framework.ExpectMAC(pod.Annotations[util.MacAddressAnnotation])
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
 
-			podIPs := make([]string, 0, len(pod.Status.PodIPs))
-			for _, podIP := range pod.Status.PodIPs {
-				podIPs = append(podIPs, podIP.IP)
+				podIPs := make([]string, 0, len(pod.Status.PodIPs))
+				for _, podIP := range pod.Status.PodIPs {
+					podIPs = append(podIPs, podIP.IP)
+				}
+				framework.ExpectConsistOf(podIPs, strings.Split(pod.Annotations[util.IpAddressAnnotation], ","))
+				ips = append(ips, pod.Annotations[util.IpAddressAnnotation])
 			}
-			framework.ExpectConsistOf(podIPs, strings.Split(pod.Annotations[util.IpAddressAnnotation], ","))
-			ips = append(ips, pod.Annotations[util.IpAddressAnnotation])
-		}
-		framework.ExpectConsistOf(ips, strings.Split(ippool, ippoolSep))
+			framework.ExpectConsistOf(ips, strings.Split(ippool, ippoolSep))
 
-		ginkgo.By("Deleting pods for statefulset " + stsName)
-		for _, pod := range pods.Items {
-			err := podClient.Delete(pod.Name)
-			framework.ExpectNoError(err, "failed to delete pod "+pod.Name)
-		}
-		stsClient.WaitForRunningAndReady(sts)
-
-		ginkgo.By("Getting pods for statefulset " + stsName)
-		pods = stsClient.GetPods(sts)
-		framework.ExpectHaveLen(pods.Items, replicas)
-
-		for i, pod := range pods.Items {
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.CidrAnnotation, subnet.Spec.CIDRBlock)
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.GatewayAnnotation, subnet.Spec.Gateway)
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.IpPoolAnnotation, ippool)
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.IpAddressAnnotation, ips[i])
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.LogicalSwitchAnnotation, subnet.Name)
-			framework.ExpectMAC(pod.Annotations[util.MacAddressAnnotation])
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-
-			podIPs := make([]string, 0, len(pod.Status.PodIPs))
-			for _, podIP := range pod.Status.PodIPs {
-				podIPs = append(podIPs, podIP.IP)
+			ginkgo.By("Deleting pods for statefulset " + stsName)
+			for _, pod := range pods.Items {
+				err := podClient.Delete(pod.Name)
+				framework.ExpectNoError(err, "failed to delete pod "+pod.Name)
 			}
-			framework.ExpectConsistOf(podIPs, strings.Split(pod.Annotations[util.IpAddressAnnotation], ","))
+			stsClient.WaitForRunningAndReady(sts)
+
+			ginkgo.By("Getting pods for statefulset " + stsName)
+			pods = stsClient.GetPods(sts)
+			framework.ExpectHaveLen(pods.Items, replicas)
+
+			for i, pod := range pods.Items {
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.CidrAnnotation, subnet.Spec.CIDRBlock)
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.GatewayAnnotation, subnet.Spec.Gateway)
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.IpPoolAnnotation, ippool)
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.IpAddressAnnotation, ips[i])
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.LogicalSwitchAnnotation, subnet.Name)
+				framework.ExpectMAC(pod.Annotations[util.MacAddressAnnotation])
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+
+				podIPs := make([]string, 0, len(pod.Status.PodIPs))
+				for _, podIP := range pod.Status.PodIPs {
+					podIPs = append(podIPs, podIP.IP)
+				}
+				framework.ExpectConsistOf(podIPs, strings.Split(pod.Annotations[util.IpAddressAnnotation], ","))
+			}
+
+			ginkgo.By("Deleting statefulset " + stsName)
+			stsClient.DeleteSync(stsName)
 		}
 	})
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #3050 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 345c2bf</samp>

This pull request enhances the `ipPool` annotation feature for pods and statefulsets, and increases the timeout-minutes for some GitHub workflow jobs. It fixes a bug in the pod controller's `acquireAddress` function, adds more test cases for the ipPool annotation in the `test/e2e/kube-ovn/ipam/ipam.go` file, and adjusts the `.github/workflows/build-x86-image.yaml` and `.github/workflows/scheduled-e2e.yaml` files to prevent timeout failures.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 345c2bf</samp>

> _Oh we are the `kube-ovn` crew and we have a job to do_
> _We build and test the image and we push it to the hub_
> _We tweak the timeouts and the tests to make them run just right_
> _And we fix the `ipPool` bug and add a new feature tonight_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 345c2bf</samp>

* Increase the timeout-minutes for the GitHub workflow jobs that build the x86 image and run the conformance tests ([link](https://github.com/kubeovn/kube-ovn/pull/3054/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L840-R840), [link](https://github.com/kubeovn/kube-ovn/pull/3054/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L337-R337))
* Fix a bug that causes pod address allocation to fail when the ipPool annotation has mixed protocols ([link](https://github.com/kubeovn/kube-ovn/pull/3054/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1552-R1554))
* Support the use case where the ipPool annotation specifies a single IP address instead of a range or a list ([link](https://github.com/kubeovn/kube-ovn/pull/3054/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1557-R1560))
* Modify the test case for the ipPool annotation in the `test/e2e/kube-ovn/ipam/ipam.go` file to cover different numbers of replicas and delete the statefulset after each iteration ([link](https://github.com/kubeovn/kube-ovn/pull/3054/files?diff=unified&w=0#diff-77be25df25b4b256f3bdba6c42d5cc3103f8688337df967de0b75429069f56e1L255-R316))