### PR TITLE
e2e: do not import pkg/daemon

### DIFF
--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -1360,16 +1360,13 @@ jobs:
           sudo cp -r /root/.kube/ ~/.kube/
           sudo chown -R $(id -un). ~/.kube/
 
-      - name: Install Kube-OVN
+      - name: Install Kube-OVN with VPC NAT gateway enabled
         working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
         run: |
           version=$(grep -E '^VERSION="v([0-9]+\.){2}[0-9]+"$' dist/images/install.sh | head -n1 | awk -F= '{print $2}' | tr -d '"')
           docker pull kubeovn/kube-ovn:$version
           docker pull kubeovn/vpc-nat-gateway:$version
-          VERSION=$version make kind-install
-
-      - name: Install vpc-nat-gw
-        run: make kind-install-vpc-nat-gw
+          VERSION=$version make kind-install-vpc-nat-gw
 
       - name: Run E2E
         run: make iptables-vpc-nat-gw-conformance-e2e

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -39,26 +39,26 @@ const (
 )
 
 const (
-	NAT                        = "nat"
-	MANGLE                     = "mangle"
-	Prerouting                 = "PREROUTING"
-	Postrouting                = "POSTROUTING"
-	Output                     = "OUTPUT"
-	OvnPrerouting              = "OVN-PREROUTING"
-	OvnPostrouting             = "OVN-POSTROUTING"
-	OvnOutput                  = "OVN-OUTPUT"
-	OvnMasquerade              = "OVN-MASQUERADE"
-	OvnNatOutGoingPolicy       = "OVN-NAT-POLICY"
-	OvnNatOutGoingPolicySubnet = "OVN-NAT-PSUBNET-"
+	NAT                        = util.NAT
+	MANGLE                     = util.Mangle
+	Prerouting                 = util.Prerouting
+	Postrouting                = util.Postrouting
+	Output                     = util.Output
+	OvnPrerouting              = util.OvnPrerouting
+	OvnPostrouting             = util.OvnPostrouting
+	OvnOutput                  = util.OvnOutput
+	OvnMasquerade              = util.OvnMasquerade
+	OvnNatOutGoingPolicy       = util.OvnNatOutGoingPolicy
+	OvnNatOutGoingPolicySubnet = util.OvnNatOutGoingPolicySubnet
 )
 
 const (
 	OnOutGoingNatMark     = "0x90001/0x90001"
 	OnOutGoingForwardMark = "0x90002/0x90002"
-	TProxyOutputMark      = 0x90003
-	TProxyOutputMask      = 0x90003
-	TProxyPreroutingMark  = 0x90004
-	TProxyPreroutingMask  = 0x90004
+	TProxyOutputMark      = util.TProxyOutputMark
+	TProxyOutputMask      = util.TProxyOutputMask
+	TProxyPreroutingMark  = util.TProxyPreroutingMark
+	TProxyPreroutingMask  = util.TProxyPreroutingMask
 )
 
 type policyRouteMeta struct {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -255,6 +255,23 @@ const (
 	NatPolicyRuleActionForward = "forward"
 	NatPolicyRuleIDLength      = 12
 
+	NAT                        = "nat"
+	Mangle                     = "mangle"
+	Prerouting                 = "PREROUTING"
+	Postrouting                = "POSTROUTING"
+	Output                     = "OUTPUT"
+	OvnPrerouting              = "OVN-PREROUTING"
+	OvnPostrouting             = "OVN-POSTROUTING"
+	OvnOutput                  = "OVN-OUTPUT"
+	OvnMasquerade              = "OVN-MASQUERADE"
+	OvnNatOutGoingPolicy       = "OVN-NAT-POLICY"
+	OvnNatOutGoingPolicySubnet = "OVN-NAT-PSUBNET-"
+
 	TProxyListenPort = 8102
 	TProxyRouteTable = 10001
+
+	TProxyOutputMark     = 0x90003
+	TProxyOutputMask     = 0x90003
+	TProxyPreroutingMark = 0x90004
+	TProxyPreroutingMask = 0x90004
 )

--- a/test/e2e/framework/image.go
+++ b/test/e2e/framework/image.go
@@ -4,5 +4,4 @@ const (
 	PauseImage   = "kubeovn/pause:3.2"
 	BusyBoxImage = "busybox:stable"
 	AgnhostImage = "kubeovn/agnhost:2.43"
-	NginxImage   = "nginx:latest"
 )

--- a/test/e2e/kube-ovn/ipam/ipam.go
+++ b/test/e2e/kube-ovn/ipam/ipam.go
@@ -253,6 +253,7 @@ var _ = framework.Describe("[group:ipam]", func() {
 		}
 
 		for replicas := 1; replicas <= 3; replicas++ {
+			stsName = "sts-" + framework.RandomSuffix()
 			ippool := framework.RandomIPs(cidr, ippoolSep, replicas)
 			labels := map[string]string{"app": stsName}
 

--- a/test/e2e/kube-ovn/pod/vpc_pod_probe.go
+++ b/test/e2e/kube-ovn/pod/vpc_pod_probe.go
@@ -10,7 +10,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/daemon"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/iptables"
@@ -194,8 +193,8 @@ var _ = framework.SerialDescribe("[group:pod]", func() {
 func checkTProxyRules(f *framework.Framework, pod *corev1.Pod, probePort int, exist bool) {
 
 	nodeName := pod.Spec.NodeName
-	tProxyOutputMarkMask := fmt.Sprintf("%#x/%#x", daemon.TProxyOutputMark, daemon.TProxyOutputMask)
-	tProxyPreRoutingMarkMask := fmt.Sprintf("%#x/%#x", daemon.TProxyPreroutingMark, daemon.TProxyPreroutingMask)
+	tProxyOutputMarkMask := fmt.Sprintf("%#x/%#x", util.TProxyOutputMark, util.TProxyOutputMask)
+	tProxyPreRoutingMarkMask := fmt.Sprintf("%#x/%#x", util.TProxyPreroutingMark, util.TProxyPreroutingMask)
 
 	isZeroIP := false
 	if len(pod.Status.PodIPs) == 2 {
@@ -207,7 +206,7 @@ func checkTProxyRules(f *framework.Framework, pod *corev1.Pod, probePort int, ex
 			expectedRules := []string{
 				fmt.Sprintf(`-A OVN-OUTPUT -d %s/32 -p tcp -m tcp --dport %d -j MARK --set-xmark %s`, podIP.IP, probePort, tProxyOutputMarkMask),
 			}
-			iptables.CheckIptablesRulesOnNode(f, nodeName, daemon.MANGLE, daemon.OvnOutput, apiv1.ProtocolIPv4, expectedRules, exist)
+			iptables.CheckIptablesRulesOnNode(f, nodeName, util.Mangle, util.OvnOutput, apiv1.ProtocolIPv4, expectedRules, exist)
 			hostIP := pod.Status.HostIP
 			if isZeroIP {
 				hostIP = "0.0.0.0"
@@ -215,12 +214,12 @@ func checkTProxyRules(f *framework.Framework, pod *corev1.Pod, probePort int, ex
 			expectedRules = []string{
 				fmt.Sprintf(`-A OVN-PREROUTING -d %s/32 -p tcp -m tcp --dport %d -j TPROXY --on-port %d --on-ip %s --tproxy-mark %s`, podIP.IP, probePort, util.TProxyListenPort, hostIP, tProxyPreRoutingMarkMask),
 			}
-			iptables.CheckIptablesRulesOnNode(f, nodeName, daemon.MANGLE, daemon.OvnPrerouting, apiv1.ProtocolIPv4, expectedRules, exist)
+			iptables.CheckIptablesRulesOnNode(f, nodeName, util.Mangle, util.OvnPrerouting, apiv1.ProtocolIPv4, expectedRules, exist)
 		} else if util.CheckProtocol(podIP.IP) == apiv1.ProtocolIPv6 {
 			expectedRules := []string{
 				fmt.Sprintf(`-A OVN-OUTPUT -d %s/128 -p tcp -m tcp --dport %d -j MARK --set-xmark %s`, podIP.IP, probePort, tProxyOutputMarkMask),
 			}
-			iptables.CheckIptablesRulesOnNode(f, nodeName, daemon.MANGLE, daemon.OvnOutput, apiv1.ProtocolIPv6, expectedRules, exist)
+			iptables.CheckIptablesRulesOnNode(f, nodeName, util.Mangle, util.OvnOutput, apiv1.ProtocolIPv6, expectedRules, exist)
 
 			hostIP := pod.Status.HostIP
 			if isZeroIP {
@@ -229,7 +228,7 @@ func checkTProxyRules(f *framework.Framework, pod *corev1.Pod, probePort int, ex
 			expectedRules = []string{
 				fmt.Sprintf(`-A OVN-PREROUTING -d %s/128 -p tcp -m tcp --dport %d -j TPROXY --on-port %d --on-ip %s --tproxy-mark %s`, podIP.IP, probePort, util.TProxyListenPort, hostIP, tProxyPreRoutingMarkMask),
 			}
-			iptables.CheckIptablesRulesOnNode(f, nodeName, daemon.MANGLE, daemon.OvnPrerouting, apiv1.ProtocolIPv6, expectedRules, exist)
+			iptables.CheckIptablesRulesOnNode(f, nodeName, util.Mangle, util.OvnPrerouting, apiv1.ProtocolIPv6, expectedRules, exist)
 		}
 	}
 }


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Tests


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da445bf</samp>

Refactor iptables constants to `util` package and use them in `daemon` and `pod` packages. This improves code readability, maintainability, and testability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at da445bf</samp>

> _We'll haul away the `daemon` code, me hearties, yo ho!_
> _We'll use the `util` package for the iptables show_
> _We'll make the rules more clear and neat, me hearties, yo ho!_
> _We'll test the tproxy on the pod, and away we go!_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at da445bf</samp>

*  Move iptables constants from `daemon` package to `util` package to avoid duplication and improve readability ([link](https://github.com/kubeovn/kube-ovn/pull/3055/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L42-R52), [link](https://github.com/kubeovn/kube-ovn/pull/3055/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L58-R61), [link](https://github.com/kubeovn/kube-ovn/pull/3055/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cL258-R276))
*  Replace references to `daemon` package with `util` package in `test/e2e/kube-ovn/pod/vpc_pod_probe.go` to use the moved constants ([link](https://github.com/kubeovn/kube-ovn/pull/3055/files?diff=unified&w=0#diff-ad53e5ad19c2740b06dc4d383f31ce191567028bc265b93090d70c3a9a0a6919L13), [link](https://github.com/kubeovn/kube-ovn/pull/3055/files?diff=unified&w=0#diff-ad53e5ad19c2740b06dc4d383f31ce191567028bc265b93090d70c3a9a0a6919L197-R197), [link](https://github.com/kubeovn/kube-ovn/pull/3055/files?diff=unified&w=0#diff-ad53e5ad19c2740b06dc4d383f31ce191567028bc265b93090d70c3a9a0a6919L210-R209), [link](https://github.com/kubeovn/kube-ovn/pull/3055/files?diff=unified&w=0#diff-ad53e5ad19c2740b06dc4d383f31ce191567028bc265b93090d70c3a9a0a6919L218-R222), [link](https://github.com/kubeovn/kube-ovn/pull/3055/files?diff=unified&w=0#diff-ad53e5ad19c2740b06dc4d383f31ce191567028bc265b93090d70c3a9a0a6919L232-R231))