### PR TITLE
Fix relevant annotations are not deleted in hotnoplug nic process

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1120,7 +1120,7 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) error {
 
 	for _, providerName := range annotationsNeedToDel {
 		for annotationKey := range pod.Annotations {
-			if strings.HasPrefix(key, providerName) {
+			if strings.HasPrefix(annotationKey, providerName) {
 				delete(pod.Annotations, annotationKey)
 			}
 		}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
Fix relevant annotations are not deleted in hotnoplug nic process
We can't hotplug a nic after performing hotplug and hotunplug operations on it once. This is because the annotations generate in first hotplug process are not be deleted in hotunplug process.
We find a little mistake in current code.

### HOW
Fix the mistake so we can delete relevant annotations in hotnoplug nic process.