### PR TITLE
iptables: reject access to invalid service port when kube-proxy works in IPVS mode

### DIFF
--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -16,11 +16,13 @@ iptables -t filter -D INPUT -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40services dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40services src -j ACCEPT
+iptables -t filter -D INPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
 iptables -t filter -D FORWARD -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services dst -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services src -j ACCEPT
 iptables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
+iptables -t filter -D OUTPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
 iptables -t mangle -D PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
 iptables -t mangle -D OUTPUT -m comment --comment "kube-ovn output rules" -j OVN-OUTPUT
 iptables -t mangle -F OVN-PREROUTING
@@ -52,11 +54,13 @@ ip6tables -t filter -D INPUT -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60services src -j ACCEPT
+ip6tables -t filter -D INPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
+ip6tables -t filter -D OUTPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
 ip6tables -t mangle -D PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
 ip6tables -t mangle -D OUTPUT -m comment --comment "kube-ovn output rules" -j OVN-OUTPUT
 ip6tables -t mangle -F OVN-PREROUTING


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Reject access to invalid service port, such as `10.96.0.1:22`, when kube-proxy works in IPVS mode.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0496c7</samp>

Improve service proxy support in kube-ovn. Add iptables rules to handle different service modes and policies in `gateway_linux.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d0496c7</samp>

> _To support services with proxy modes_
> _And traffic policies for different loads_
> _We add some rules to `iptables`_
> _To reject some packets with labels_
> _That match `ovn40services` or `ovn60services` nodes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d0496c7</samp>

*  Add iptables rules to support services with different proxy modes and traffic policies ([link](https://github.com/kubeovn/kube-ovn/pull/3059/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R522-R524), [link](https://github.com/kubeovn/kube-ovn/pull/3059/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R563-R564))