### PR TITLE
ci: fix multus installation

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -2026,10 +2026,7 @@ jobs:
           sudo cp -r /root/.kube/ ~/.kube/
           sudo chown -R $(id -un). ~/.kube/
 
-      - name: Install Kube-OVN
-        run: make kind-install
-
-      - name: Install vpc-nat-gw
+      - name: Install Kube-OVN with VPC NAT gateway enabled
         run: make kind-install-vpc-nat-gw
 
       - name: Run E2E

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/*
 .DS_Store
 dist/images/test-server
+dist/images/kube-ovn
 dist/images/kube-ovn-cmd
 dist/images/kube-ovn-webhook
 dist/windows/kube-ovn.exe


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- CI

### Which issue(s) this PR fixes:

Install the stable version in CI.

https://github.com/k8snetworkplumbingwg/multus-cni/issues/1126

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 81499b3</samp>

This pull request enhances the Makefile, the e2e test file, and the workflow file for the iptables-vpc-nat-gw feature. It makes the code more configurable, readable, and concise, and removes unnecessary steps and dependencies.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 81499b3</samp>

> _We're sailing on the Kubernetes sea_
> _We're simplifying our workflow with `ENABLE_NAT_GW`_
> _We're updating our Makefile and our e2e test_
> _We're heaving on the line, one, two, three, and rest_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 81499b3</samp>

*  Simplify workflow steps by installing Kube-OVN and vpc-nat-gw in one command with `ENABLE_NAT_GW` flag ([link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L2029-R2029))
*  Introduce `MULTUS_VERSION` variable to specify and use consistent version of Multus CNI in workflow and image tag ([link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L25-R27))
*  Remove redundant `kind-untaint-control-plane` dependencies from `kind-install-vpc-nat-gw` and `kind-install-lb-svc` targets in `Makefile` ([link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L693-R698), [link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L726-R727))
*  Add resource names to ginkgo.By messages in `setupVpcNatGwTestEnvironment` function in `test/e2e/iptables-vpc-nat-gw/e2e_test.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L161-R169))
*  Replace hardcoded `.kube-system` suffix with `framework.KubeOvnNamespace` variable in `ovn_eip` package in `test/e2e/iptables-vpc-nat-gw/e2e_test.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L233-R233), [link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L613-R613), [link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L1081-R1081))
*  Add ginkgo.By message to indicate overlay subnet retrieval in `ovn_eip` package in `test/e2e/iptables-vpc-nat-gw/e2e_test.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3062/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L1289-R1292))