### PR TITLE
fix iptables rules

### DIFF
--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -16,11 +16,13 @@ iptables -t filter -D INPUT -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40services dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40services src -j ACCEPT
+iptables -t filter -D INPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
 iptables -t filter -D FORWARD -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services dst -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services src -j ACCEPT
 iptables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
+iptables -t filter -D OUTPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
 iptables -t mangle -D PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
 iptables -t mangle -D OUTPUT -m comment --comment "kube-ovn output rules" -j OVN-OUTPUT
 iptables -t mangle -F OVN-PREROUTING
@@ -52,11 +54,13 @@ ip6tables -t filter -D INPUT -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60services src -j ACCEPT
+ip6tables -t filter -D INPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
+ip6tables -t filter -D OUTPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
 ip6tables -t mangle -D PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
 ip6tables -t mangle -D OUTPUT -m comment --comment "kube-ovn output rules" -j OVN-OUTPUT
 ip6tables -t mangle -F OVN-PREROUTING


### PR DESCRIPTION
1. add --random-fully to SNAT rules;
2. do not specify src ip for access to service ip;
3. reject access to invalid service port when kube-proxy works in IPVS mode.


- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Now that we have added src ip in routes for overlay pods in #2243, there is no need to specify src ip for access to service ips.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f30e5e3</samp>

Enhance gateway support for dual-stack services and improve SNAT rules. Refactor and simplify iptables and ipset code in `gateway_linux.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f30e5e3</samp>

> _To enhance the gateway's features_
> _We support cluster IP creatures_
> _And apply `--random-fully`_
> _To SNAT rules more duly_
> _And refactor some iptables leechers_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f30e5e3</samp>

*  Add and modify iptables rules to support cluster IP services in dual-stack mode ([link](https://github.com/kubeovn/kube-ovn/pull/3067/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R619-R633), [link](https://github.com/kubeovn/kube-ovn/pull/3067/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L626-L635))
* Refactor the code to add the `--random-fully` option to the MASQUERADE and SNAT rules in the `nat` table ([link](https://github.com/kubeovn/kube-ovn/pull/3067/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L698-R713), [link](https://github.com/kubeovn/kube-ovn/pull/3067/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L730-R741))