### PR TITLE
e2e: fix switch lb rule test

### DIFF
--- a/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
+++ b/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
@@ -133,11 +133,9 @@ var _ = framework.Describe("[group:slr]", func() {
 		labels := map[string]string{"app": label}
 		ginkgo.By("Creating statefulset " + stsName + " with subnet " + subnetName)
 		sts := framework.MakeStatefulSet(stsName, stsSvcName, int32(replicas), labels, framework.AgnhostImage)
-		pool := framework.RandomIPs(overlaySubnetCidr, ";", replicas)
-		ginkgo.By("Creating sts " + stsName + " with ip pool " + pool)
+		ginkgo.By("Creating sts " + stsName)
 		sts.Spec.Template.Annotations = map[string]string{
 			util.LogicalSwitchAnnotation: subnetName,
-			util.IpPoolAnnotation:        pool,
 		}
 		portStr := strconv.Itoa(80)
 		webServerCmd := []string{"/agnhost", "netexec", "--http-port", portStr}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Tests


### Which issue(s) this PR fixes:
Fixes occasional address conflict in switch lb rule e2e test.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5a21ad</samp>

Remove pool annotation from statefulset test case. Use kube-ovn IPAM feature instead.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d5a21ad</samp>

> _No more pool annotation_
> _Statefulset pods use IPAM_
> _Simpler and better_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d5a21ad</samp>

* Remove the pool annotation and the code that assigns random IPs to the statefulset pods ([link](https://github.com/kubeovn/kube-ovn/pull/3071/files?diff=unified&w=0#diff-0bc2dad9f41dd1a8d981f6e3b93597cb758775caa3758897ca73f7d2363e7f13L136-R138)). This simplifies the test case and aligns with the best practices of using kube-ovn IPAM feature to allocate IPs from the subnet. The file `switch_lb_rule.go` contains the test case for verifying the switch load balancing rule functionality.