### PR TITLE
ovn client: fix sb chassis existence check

### DIFF
--- a/pkg/ovs/ovn-sbctl.go
+++ b/pkg/ovs/ovn-sbctl.go
@@ -113,7 +113,7 @@ func (c LegacyClient) ChassisExist(chassisName string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to find node chassis %s, %v", chassisName, err)
 	}
-	if len(strings.Split(output, "\n")) == 0 {
+	if len(output) == 0 {
 		return false, nil
 	}
 	return true, nil


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
Fixes #3049 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49d6461</samp>

Simplify the logic of checking node chassis existence in `ChassisExist` function. Use string length instead of splitting output by newline characters.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 49d6461</samp>

> _`ChassisExist` checks_
> _Output of `ovn-sbctl`_
> _Empty or not? - cold_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 49d6461</samp>

*  Simplify logic to check if node chassis exists in OVN southbound database ([link](https://github.com/kubeovn/kube-ovn/pull/3072/files?diff=unified&w=0#diff-562d7a17619057b24d0d36932910d6c6cc55cccdad9031107677901c46f17accL116-R116))