### PR TITLE
bump github.com/docker/docker to v24.0.5

### DIFF
--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.20.5'
+  GO_VERSION: ''
 
 jobs:
   build:

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.20.5'
+  GO_VERSION: ''
   GOSEC_VERSION: '2.16.0'
 
 jobs:

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.20.5'
+  GO_VERSION: ''
   GOSEC_VERSION: '2.16.0'
   HELM_VERSION: v3.12.2
   SUBMARINER_VERSION: '0.14.6'

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.20.5'
+  GO_VERSION: ''
   HELM_VERSION: v3.12.2
   SUBMARINER_VERSION: '0.14.6'
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
-	github.com/docker/docker v24.0.4+incompatible
+	github.com/docker/docker v24.0.5+incompatible
 	github.com/emicklei/go-restful/v3 v3.10.2
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-logr/stdr v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m3
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.21+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v24.0.4+incompatible h1:s/LVDftw9hjblvqIeTiGYXBCD95nOEEl7qRsRrIOuQI=
-github.com/docker/docker v24.0.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.5+incompatible h1:WmgcE4fxyI6EEXxBRxsHnZXrO1pQ3smi0k/jho4HLeY=
+github.com/docker/docker v24.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec53394</samp>

This pull request simplifies the Go version management across different GitHub workflows by using a global variable defined in the repository settings. It also updates the `github.com/docker/docker` dependency in the `go.mod` file to fix some security issues and bugs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ec53394</samp>

> _`GO_VERSION` gone_
> _Moved to global variable_
> _Simpler workflows now_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec53394</samp>

*  Remove `GO_VERSION` environment variable from four workflow files and use a global variable instead ([link](https://github.com/kubeovn/kube-ovn/pull/3073/files?diff=unified&w=0#diff-b088395013d567b49eb06813db91882199c2dc2e9f4d8ac9995d7b10f716745aL22-R22), [link](https://github.com/kubeovn/kube-ovn/pull/3073/files?diff=unified&w=0#diff-a3ae20db8d6f829cce559bf09c6fa26bf26822b30ab4994444b49a0b9909470eL25-R25), [link](https://github.com/kubeovn/kube-ovn/pull/3073/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L24-R24), [link](https://github.com/kubeovn/kube-ovn/pull/3073/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L13-R13))
*  Update `github.com/docker/docker` dependency to v24.0.5 in `go.mod` file to fix security issues and bugs ([link](https://github.com/kubeovn/kube-ovn/pull/3073/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L14-R14))