### PR TITLE
fix repeate set chassis

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -782,6 +782,10 @@ func (c *Controller) Run(ctx context.Context) {
 		util.LogFatalAndExit(err, "failed to initialize ovn resources")
 	}
 
+	if err := c.initNodeChassis(); err != nil {
+		util.LogFatalAndExit(err, "failed to initialize node chassis")
+	}
+
 	// sync ip crd before initIPAM since ip crd will be used to restore vm and statefulset pod in initIPAM
 	if err := c.initSyncCrdIPs(); err != nil {
 		util.LogFatalAndExit(err, "failed to sync crd ips")
@@ -789,10 +793,6 @@ func (c *Controller) Run(ctx context.Context) {
 
 	if err := c.InitIPAM(); err != nil {
 		util.LogFatalAndExit(err, "failed to initialize ipam")
-	}
-
-	if err := c.initNodeChassis(); err != nil {
-		util.LogFatalAndExit(err, "failed to initialize node chassis")
 	}
 
 	if err := c.initNodeRoutes(); err != nil {

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -853,6 +853,14 @@ func (c *Controller) initNodeChassis() error {
 	for _, node := range nodes {
 		chassisName := node.Annotations[util.ChassisAnnotation]
 		if chassisName != "" {
+			existChasisId, err := c.ovnLegacyClient.GetChassis(node.Name)
+			if err != nil {
+				klog.Errorf("failed to get chassis id: %v", err)
+				return err
+			}
+			if existChasisId == chassisName {
+				continue
+			}
 			exist, err := c.ovnLegacyClient.ChassisExist(chassisName)
 			if err != nil {
 				klog.Errorf("failed to check chassis exist: %v", err)

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -96,8 +96,7 @@ func (c *Controller) syncSubnetRoutes() {
 		}
 	}
 
-
-	klog.V(5).Infof("expected announce ipv4 routes %v\n,ipv6 route %v", bgpExpected[kubeovnv1.ProtocolIPv4], bgpExpected[kubeovnv1.ProtocolIPv6])
+	klog.V(5).Infof("expected announce ipv4 routes: %v, ipv6 routes: %v", bgpExpected[kubeovnv1.ProtocolIPv4], bgpExpected[kubeovnv1.ProtocolIPv6])
 
 	fn := func(d *bgpapi.Destination) {
 		for _, path := range d.Paths {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes

### Which issue(s) this PR fixes:
Fixes #3084 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bad86a3</samp>

Improve OVN controller performance by skipping chassis updates for nodes with matching ids. Add a chassis id check in `pkg/controller/init.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bad86a3</samp>

> _`chassis id` check_
> _skips nodes with matching names_
> _snowflakes in OVN_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bad86a3</samp>

*  Add a check to skip nodes with matching chassis id and name ([link](https://github.com/kubeovn/kube-ovn/pull/3083/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988R856-R863)) to avoid unnecessary updates to the OVN database