### PR TITLE
fix .status.default when initializing the default vpc

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -774,12 +774,12 @@ func (c *Controller) Run(ctx context.Context) {
 		util.LogFatalAndExit(err, "failed to set NB_Global option use_ct_inv_match to false")
 	}
 
-	if err := c.InitDefaultVpc(); err != nil {
-		util.LogFatalAndExit(err, "failed to initialize default vpc")
-	}
-
 	if err := c.InitOVN(); err != nil {
 		util.LogFatalAndExit(err, "failed to initialize ovn resources")
+	}
+
+	if err := c.InitDefaultVpc(); err != nil {
+		util.LogFatalAndExit(err, "failed to initialize default vpc")
 	}
 
 	if err := c.initNodeChassis(); err != nil {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes occasional incorrect field `.status.default` of the default vpc.

kube-ovn-controller updates status of cached vpc objects in function `initLoadBalancer()`. In some scenarios field `.status.default` of the cached object is `false` while it's supposed to be `true`.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 701ad17</samp>

Fix controller crash and improve default VPC initialization. This pull request modifies `controller.go` to handle the default VPC creation and update more robustly and efficiently.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 701ad17</samp>

> _Oh we are the coders of the sea_
> _And we fix the bugs that make us flee_
> _We heave and we ho and we init the VPC_
> _On the count of three, one, two, three!_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 701ad17</samp>

* Remove the redundant initialization of the default VPC in the `Run` function ([link](https://github.com/kubeovn/kube-ovn/pull/3086/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L777-L780))
* Move the initialization of the default VPC to a later point in the `Run` function, after the kube client is initialized ([link](https://github.com/kubeovn/kube-ovn/pull/3086/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R785-R788))