### PR TITLE
ipam: return error for invalid ip range

### DIFF
--- a/pkg/ipam/ip_range_list.go
+++ b/pkg/ipam/ip_range_list.go
@@ -43,6 +43,9 @@ func NewIPRangeListFrom(x ...string) (*IPRangeList, error) {
 			if err != nil {
 				return nil, err
 			}
+			if start.GreaterThan(end) {
+				return nil, fmt.Errorf("invalid ip range %q: %s is greater than %s", s, start, end)
+			}
 			r = NewIPRange(start, end)
 		} else if strings.ContainsRune(s, '/') {
 			_, cidr, err := net.ParseCIDR(s)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -199,7 +199,7 @@ func randomPool(cidr string, count int) []string {
 			x, y := k%len(ips), (k+1)%len(ips)
 			n1, _ := rl.Find(ips[x])
 			n2, _ := rl.Find(ips[y])
-			if n1 == n2 {
+			if n1 == n2 && ips[x].LessThan(ips[y]) {
 				set.Add(fmt.Sprintf("%s..%s", ips[x].String(), ips[y].String()))
 				i, k = i+1, k+2
 				continue


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7acc52e</samp>

This pull request adds a validation check for creating IP range lists and improves the random IP range generation function. These changes enhance the robustness and reliability of the IPAM module and the e2e testing framework.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7acc52e</samp>

> _`NewIPRangeListFrom`_
> _Validates start and end IPs_
> _Error in winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7acc52e</samp>

* Add validation check to prevent creating invalid IP ranges ([link](https://github.com/kubeovn/kube-ovn/pull/3088/files?diff=unified&w=0#diff-de9c95dea5718bdd4ec0189b24b681ecaf21caf346ac1e724b2dc4458f38c172R46-R48))
* Modify random IP range generation to ensure ascending and non-overlapping ranges ([link](https://github.com/kubeovn/kube-ovn/pull/3088/files?diff=unified&w=0#diff-9dcbb8eba12c61d6f3dde188c0b8d8332365139e5062995d322795e02710fb6cL202-R202))