### PR TITLE
skip ok pod

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -215,7 +215,7 @@ func (c *Controller) enqueueAddPod(obj interface{}) {
 		return
 	}
 
-	exist, err := c.podHasNotRoutedSubnet(p)
+	exist, err := c.podNeedSync(p)
 	if err != nil {
 		klog.Errorf("invalid pod net: %v", err)
 		return
@@ -1217,7 +1217,7 @@ func needAllocateSubnets(pod *v1.Pod, nets []*kubeovnNet) []*kubeovnNet {
 	return result
 }
 
-func (c *Controller) podHasNotRoutedSubnet(pod *v1.Pod) (bool, error) {
+func (c *Controller) podNeedSync(pod *v1.Pod) (bool, error) {
 	// 1. check annotations
 	if pod.Annotations == nil {
 		return true, nil


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
skip ok pod when kube-ovn-controller restart

目前认为在 kube-ovn-controller 重启后，可以选择性的跳过重复 pod handleAddOrUpdate 的逻辑


### Which issue(s) this PR fixes:
![A4F9C8D694D08762B4F6FC300E92B420](https://github.com/kubeovn/kube-ovn/assets/7981158/07cad700-5ffd-4317-a2f5-c2f5ea446b45)


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d61e5b1</samp>

Add support for routing between different subnets without ovn and improve pod logging. Modify `pod.go` to check pod subnet status and enqueue pod events accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d61e5b1</samp>

> _We're sailing on the network of the pods_
> _We're routing 'tween the subnets with no `ovn`_
> _We're logging all the events as they come_
> _We're heaving on the line on the count of three_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d61e5b1</samp>

*  Add support for routing between different subnets without ovn ([link](https://github.com/kubeovn/kube-ovn/pull/3090/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L218-R226), [link](https://github.com/kubeovn/kube-ovn/pull/3090/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1220-R1241))
  - Check if pod has any not routed subnet in `enqueueAddPod` function ([link](https://github.com/kubeovn/kube-ovn/pull/3090/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L218-R226))
  - Add new function `podHasNotRoutedSubnet` to controller package ([link](https://github.com/kubeovn/kube-ovn/pull/3090/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1220-R1241))
* Increase log level for pod deletion events in `enqueueDeletePod` function ([link](https://github.com/kubeovn/kube-ovn/pull/3090/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L242-R249))
* Add log message for pod update events in `enqueueUpdatePod` function ([link](https://github.com/kubeovn/kube-ovn/pull/3090/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L340-R347))