### PR TITLE
netpol: fix ovn acl action

### DIFF
--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -191,7 +191,7 @@ func (c *ovnClient) CreateNodeAcl(pgName, nodeIpStr, joinIpStr string) error {
 		}
 		pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
 
-		allowIngressAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowStateless)
+		allowIngressAcl, err := c.newAcl(pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllow)
 		if err != nil {
 			return fmt.Errorf("new allow ingress acl for port group %s: %v", pgName, err)
 		}

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -359,10 +359,10 @@ func (suite *OvnClientTestSuite) testCreateNodeAcl() {
 	nodeIp := "192.168.20.3"
 	joinIp := "100.64.0.2,fd00:100:64::2"
 
-	checkAcl := func(pg *ovnnb.PortGroup, direction, priority, match string, options map[string]string) {
+	checkAcl := func(pg *ovnnb.PortGroup, direction, priority, match, action string, options map[string]string) {
 		acl, err := ovnClient.GetAcl(pg.Name, direction, priority, match, false)
 		require.NoError(t, err)
-		expect := newAcl(pg.Name, direction, priority, match, ovnnb.ACLActionAllowStateless)
+		expect := newAcl(pg.Name, direction, priority, match, action)
 		expect.UUID = acl.UUID
 		if len(options) != 0 {
 			expect.Options = options
@@ -382,10 +382,10 @@ func (suite *OvnClientTestSuite) testCreateNodeAcl() {
 			pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
 
 			match := fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, ip, ipSuffix, pgAs)
-			checkAcl(pg, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, match, nil)
+			checkAcl(pg, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, match, ovnnb.ACLActionAllow, nil)
 
 			match = fmt.Sprintf("%s.dst == %s && %s.src == $%s", ipSuffix, ip, ipSuffix, pgAs)
-			checkAcl(pg, ovnnb.ACLDirectionFromLport, util.NodeAllowPriority, match, map[string]string{
+			checkAcl(pg, ovnnb.ACLDirectionFromLport, util.NodeAllowPriority, match, ovnnb.ACLActionAllowStateless, map[string]string{
 				"apply-after-lb": "true",
 			})
 		}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a69ac59</samp>

Fix ICMP packet drops when node IP changes by using stateful ACLs. Change the ACL action from `allow-stateless` to `allow` in `CreateNodeAcl` function in `pkg/ovs/ovn-nb-acl.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a69ac59</samp>

> _`CreateNodeAcl` changed_
> _From `allow-stateless` to `allow`_
> _Fixing ICMP_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a69ac59</samp>

* Change the ACL action from `allow-stateless` to `allow` for ingress traffic from node IP to port group ([link](https://github.com/kubeovn/kube-ovn/pull/3091/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L194-R194)). This fixes a bug that causes ICMP packets to be dropped when the node IP changes due to node reboot or network reconfiguration. The file `ovn-nb-acl.go` contains the function `CreateNodeAcl` that creates the ACL rule.