### PR TITLE
bug_fix: if only one port bind to the sg, then unbind the port to the sg, it will not enforce in port_group

### DIFF
--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -427,9 +427,6 @@ func (c *Controller) syncSgLogicalPort(key string) error {
 		klog.Errorf("failed to find logical port, %v", err)
 		return err
 	}
-	if len(results) == 0 {
-		return nil
-	}
 
 	var ports, v4s, v6s []string
 	for _, lsp := range results {


### PR DESCRIPTION
…sg ,it will not enforce in port_group


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:

- Bug fixes
- Docs

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56417d4</samp>

Refactor security group controller logic and remove unnecessary check in `syncSgLogicalPort` function. This change simplifies the code and avoids potential confusion or errors in `pkg/controller/security_group.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 56417d4</samp>

> _`syncSgLogicalPort`_
> _No need to check for nothing_
> _Simpler code in fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 56417d4</samp>

*  Simplify and refactor the security group controller logic ([link](https://github.com/kubeovn/kube-ovn/pull/3092/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L430-L432),                             