### PR TITLE
netpol: create node acl before creating acl rules for the first network policy

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -152,7 +152,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 		return err
 	}
 
-	if err = c.checkAndUpdateNodePortGroup(false); err != nil {
+	if err = c.checkAndUpdateNodePortGroup(false, ""); err != nil {
 		klog.Errorf("failed to update node acl: %v", err)
 		return err
 	}
@@ -570,6 +570,11 @@ func (c *Controller) handleDeleteNp(key string) error {
 	c.npKeyMutex.LockKey(key)
 	defer func() { _ = c.npKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle delete network policy %s", key)
+
+	if err = c.checkAndUpdateNodePortGroup(false, ""); err != nil {
+		klog.Errorf("failed to update node acl: %v", err)
+		return err
+	}
 
 	npName := name
 	nameArray := []rune(name)

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -152,6 +152,11 @@ func (c *Controller) handleUpdateNp(key string) error {
 		return err
 	}
 
+	if err = c.checkAndUpdateNodePortGroup(false); err != nil {
+		klog.Errorf("failed to update node acl: %v", err)
+		return err
+	}
+
 	defer func() {
 		if err != nil {
 			c.recorder.Eventf(np, corev1.EventTypeWarning, "CreateACLFailed", err.Error())


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
A node cannot connect pods running on it up to `c.config.NodePgProbeTime` minutes after creating the first network policy:

```shell
root@kube-ovn-control-plane:/kube-ovn# ping -i 0.1 -nq 10.16.0.7
PING 10.16.0.7 (10.16.0.7): 56 data bytes
^C--- 10.16.0.7 ping statistics ---
303 packets transmitted, 39 packets received, 87% packet loss
round-trip min/avg/max/stddev = 0.078/0.180/0.715/0.104 ms
```

```txt
[1690699224.951569] no answer yet for icmp_seq=375
[1690699225.055421] no answer yet for icmp_seq=376
[1690699225.159652] no answer yet for icmp_seq=377
# Sun Jul 30 2023 14:40:25 GMT+0800
[1690699225.160493] 64 bytes from 10.16.0.11: icmp_seq=378 ttl=63 time=0.580 ms
[1690699225.264762] 64 bytes from 10.16.0.11: icmp_seq=379 ttl=63 time=0.796 ms
[1690699225.364181] 64 bytes from 10.16.0.11: icmp_seq=380 ttl=63 time=0.075 ms

Status:               Running
IP:                   10.16.0.11
IPs:
  IP:           10.16.0.11
Containers:
  pinger:
    Container ID:  containerd://c2e252d9a0e6ea4e4769776ea25abfbb1956a20cd667e78550c4427b9b71c355
    State:          Running
      Started:      Sun, 30 Jul 2023 14:39:49 +0800
    Ready:          True
    Restart Count:  0
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 825cd0f</samp>

This pull request fixes a bug in the node acl synchronization with network policies, and optimizes the node acl update logic. It modifies the `checkAndUpdateNodePortGroup` function in `node.go` and the `handleUpdateNp` function in `network_policy.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 825cd0f</samp>

> _We are the guardians of the node_
> _We check and update the node acl_
> _We sync the status with the policy_
> _We fix the bug that could unleash hell_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 825cd0f</samp>

*  Fix node acl update bug when network policy changes ([link](https://github.com/kubeovn/kube-ovn/pull/3093/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46R155-R159), [link](https://github.com/kubeovn/kube-ovn/pull/3093/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L936-R954), [link](https://github.com/kubeovn/kube-ovn/pull/3093/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R1006))
  - Add `updateIfNotExists` argument to `checkAndUpdateNodePortGroup` function in `network_policy.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3093/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46R155-R159), [link](https://github.com/kubeovn/kube-ovn/pull/3093/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L936-R954))
  - Call `checkAndUpdateNodePortGroup` with false argument in `handleUpdateNp` function to update node acl only if it does not exist or does not match network policy status ([link](https://github.com/kubeovn/kube-ovn/pull/3093/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46R155-R159))
  - Add `nodeAclExists` global variable and mutex lock to track and protect node acl status in `node.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3093/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L936-R954))
  - Assign `networkPolicyExists` value to `nodeAclExists` after updating node acl in `checkAndUpdateNodePortGroup` function to synchronize statuses ([link](https://github.com/kubeovn/kube-ovn/pull/3093/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R1006))