### PR TITLE
some fixes in e2e

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -21,7 +21,7 @@ const (
 
 // RandomSuffix provides a random sequence to append to resources.
 func RandomSuffix() string {
-	return fmt.Sprintf("%d%04d", ginkgo.GinkgoParallelProcess(), rand.Intn(10000))
+	return fmt.Sprintf("%d%04d%04d", ginkgo.GinkgoParallelProcess(), rand.Intn(10000), rand.Intn(10000))
 }
 
 func RandomCIDR(family string) string {

--- a/test/e2e/kube-ovn/network-policy/network-policy.go
+++ b/test/e2e/kube-ovn/network-policy/network-policy.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 )
 
-var _ = framework.Describe("[group:network-policy]", func() {
+var _ = framework.SerialDescribe("[group:network-policy]", func() {
 	f := framework.NewDefaultFramework("network-policy")
 
 	var subnet *apiv1.Subnet

--- a/test/e2e/kube-ovn/service/service.go
+++ b/test/e2e/kube-ovn/service/service.go
@@ -126,11 +126,12 @@ var _ = framework.Describe("[group:service]", func() {
 		}
 		f.SkipVersionPriorTo(1, 11, "This case is support in v1.11")
 		ginkgo.By("Creating service " + serviceName)
+		port := 8000 + rand.Int31n(1000)
 		ports := []corev1.ServicePort{{
 			Name:       "tcp",
 			Protocol:   corev1.ProtocolTCP,
-			Port:       80,
-			TargetPort: intstr.FromInt(80),
+			Port:       port,
+			TargetPort: intstr.FromInt(int(port)),
 		}}
 
 		selector := map[string]string{"app": "svc-dual"}
@@ -142,6 +143,7 @@ var _ = framework.Describe("[group:service]", func() {
 		v6ClusterIp := service.Spec.ClusterIPs[1]
 		originService := service.DeepCopy()
 
+		ginkgo.By("Creating pod " + podName)
 		podBackend := framework.MakePod(namespaceName, podName, selector, nil, framework.PauseImage, nil, nil)
 		_ = podClient.CreateSync(podBackend)
 
@@ -149,11 +151,19 @@ var _ = framework.Describe("[group:service]", func() {
 			execCmd := "kubectl ko nbctl --format=csv --data=bare --no-heading --columns=vips find Load_Balancer name=cluster-tcp-loadbalancer"
 			framework.WaitUntil(2*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
 				output, err := exec.Command("bash", "-c", execCmd).CombinedOutput()
-				framework.Logf("output is %s ", output)
-				framework.Logf("v6ClusterIp is %s ", v6ClusterIp)
 				framework.ExpectNoError(err)
-				if (isContain && strings.Contains(string(output), v6ClusterIp)) ||
-					(!isContain && !strings.Contains(string(output), v6ClusterIp)) {
+				framework.Logf("output is %q", output)
+				framework.Logf("v6ClusterIp is %q", v6ClusterIp)
+				vips := strings.Fields(string(output))
+				prefix := util.JoinHostPort(v6ClusterIp, port) + ":"
+				var found bool
+				for _, vip := range vips {
+					if strings.HasPrefix(vip, prefix) {
+						found = true
+						break
+					}
+				}
+				if found == isContain {
 					return true, nil
 				}
 				return false, nil

--- a/test/e2e/kube-ovn/service/service.go
+++ b/test/e2e/kube-ovn/service/service.go
@@ -155,7 +155,7 @@ var _ = framework.Describe("[group:service]", func() {
 				framework.Logf("output is %q", output)
 				framework.Logf("v6ClusterIp is %q", v6ClusterIp)
 				vips := strings.Fields(string(output))
-				prefix := util.JoinHostPort(v6ClusterIp, port) + ":"
+				prefix := util.JoinHostPort(v6ClusterIp, port) + "="
 				var found bool
 				for _, vip := range vips {
 					if strings.HasPrefix(vip, prefix) {

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -1085,7 +1085,6 @@ var _ = framework.Describe("[group:subnet]", func() {
 			util.LogicalSwitchAnnotation: subnetName,
 		}
 
-		podName = "pod-" + framework.RandomSuffix()
 		pod := framework.MakePod(namespaceName, podName, nil, annotations, framework.AgnhostImage, nil, nil)
 		_ = podClient.CreateSync(pod)
 
@@ -1099,7 +1098,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 			{
 				Match: apiv1.NatOutGoingPolicyMatch{
 					SrcIPs: "1.1.1.1",
-					DstIPs: "169.254.0.0/16",
+					DstIPs: "199.255.0.0/16",
 				},
 				Action: util.NatPolicyRuleActionNat,
 			},

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -167,7 +167,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		}
 
 		itFn = func(exchangeLinkName bool) {
-			ginkgo.By("Creating provider network")
+			ginkgo.By("Creating provider network " + providerNetworkName)
 			pn := makeProviderNetwork(providerNetworkName, exchangeLinkName, linkMap)
 			pn = providerNetworkClient.CreateSync(pn)
 
@@ -313,7 +313,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		ginkgo.By("Deleting vlan " + vlanName)
 		vlanClient.Delete(vlanName, metav1.DeleteOptions{})
 
-		ginkgo.By("Deleting provider network")
+		ginkgo.By("Deleting provider network " + providerNetworkName)
 		providerNetworkClient.DeleteSync(providerNetworkName)
 
 		ginkgo.By("Getting nodes")
@@ -345,7 +345,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 	})
 
 	framework.ConformanceIt("should keep pod mtu the same with node interface", func() {
-		ginkgo.By("Creating provider network")
+		ginkgo.By("Creating provider network " + providerNetworkName)
 		pn := makeProviderNetwork(providerNetworkName, false, linkMap)
 		_ = providerNetworkClient.CreateSync(pn)
 
@@ -406,7 +406,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		}
 		f.SkipVersionPriorTo(1, 9, "Address conflict detection was introduced in v1.9")
 
-		ginkgo.By("Creating provider network")
+		ginkgo.By("Creating provider network " + providerNetworkName)
 		pn := makeProviderNetwork(providerNetworkName, false, linkMap)
 		_ = providerNetworkClient.CreateSync(pn)
 
@@ -469,7 +469,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 	framework.ConformanceIt("should support underlay to overlay subnet interconnection", func() {
 		f.SkipVersionPriorTo(1, 9, "This feature was introduced in v1.9")
 
-		ginkgo.By("Creating provider network")
+		ginkgo.By("Creating provider network " + providerNetworkName)
 		pn := makeProviderNetwork(providerNetworkName, false, linkMap)
 		_ = providerNetworkClient.CreateSync(pn)
 

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -200,7 +200,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		}
 
 		itFn = func(exchangeLinkName bool) {
-			ginkgo.By("Creating provider network")
+			ginkgo.By("Creating provider network " + providerNetworkName)
 			pn := makeProviderNetwork(providerNetworkName, exchangeLinkName, linkMap)
 			pn = providerNetworkClient.CreateSync(pn)
 
@@ -293,7 +293,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		ginkgo.By("Deleting vlan " + vlanName)
 		vlanClient.Delete(vlanName, metav1.DeleteOptions{})
 
-		ginkgo.By("Deleting provider network")
+		ginkgo.By("Deleting provider network " + providerNetworkName)
 		providerNetworkClient.DeleteSync(providerNetworkName)
 
 		ginkgo.By("Getting nodes")


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Tests


### Which issue(s) this PR fixes:
1. reduce possiblilty of the same name suffix;
2. fix e2e logging.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cc27de</samp>

The pull request improves the reliability, readability, and quality of the e2e test cases for `kube-ovn` by using random ports and names, enhancing log messages, and fixing minor bugs and code smells in the test packages. The changes affect the files `service.go`, `subnet.go`, `underlay.go`, `e2e_test.go`, and `util.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8cc27de</samp>

> _Sing, O Muse, of the valiant pull request_
> _That enhanced the test code of the framework_
> _With random suffixes and ports, and log messages_
> _That shone like the bright stars in the night sky._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8cc27de</samp>

*  Increase the length of the random suffix for resource names to avoid conflicts ([link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-9dcbb8eba12c61d6f3dde188c0b8d8332365139e5062995d322795e02710fb6cL24-R24))
*  Use a random port between 8000 and 8999 for service tests to avoid port conflicts ([link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-90a7c3d6fa34f68f00846179b0157b5698d8d860a9a77dae5ea7ec9e3d5120caL129-R134))
*  Improve the log messages for creating and deleting provider networks in various packages ([link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-90a7c3d6fa34f68f00846179b0157b5698d8d860a9a77dae5ea7ec9e3d5120caR146), [link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL170-R170), [link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL316-R316), [link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL348-R348), [link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL409-R409), [link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL472-R472), [link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L203-R203), [link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L296-R296))
*  Fix the bug of checking the IPv6 cluster IP in the `ipvsadm` output by using field-based matching instead of string contains ([link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-90a7c3d6fa34f68f00846179b0157b5698d8d860a9a77dae5ea7ec9e3d5120caL152-R166))
*  Remove the redundant and unused assignment of the `podName` variable in the `subnet` package ([link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1088))
*  Change the `DstIPs` field in the `NatOutGoingPolicyMatch` struct to use a non-reserved IP range ([link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1102-R1101))
*  Simplify and clarify the code for generating the `asName` variable in the `underlay` package by using `strings.ReplaceAll` and a constant format string ([link](https://github.com/kubeovn/kube-ovn/pull/3094/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dL785-R785))