### PR TITLE
add log near err

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -127,6 +127,7 @@ func mvCNIConf(configDir, configFile, confName string) error {
 	// #nosec
 	data, err := os.ReadFile(configFile)
 	if err != nil {
+		klog.Errorf("failed to read cni config file %s, %v", configFile, err)
 		return err
 	}
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -259,6 +259,7 @@ func ParseFlags() (*Configuration, error) {
 	if config.DefaultGateway == "" {
 		gw, err := util.GetGwByCidr(config.DefaultCIDR)
 		if err != nil {
+			klog.Error(err)
 			return nil, err
 		}
 		config.DefaultGateway = gw
@@ -271,6 +272,7 @@ func ParseFlags() (*Configuration, error) {
 	if config.NodeSwitchGateway == "" {
 		gw, err := util.GetGwByCidr(config.NodeSwitchCIDR)
 		if err != nil {
+			klog.Error(err)
 			return nil, err
 		}
 		config.NodeSwitchGateway = gw

--- a/pkg/controller/endpoint.go
+++ b/pkg/controller/endpoint.go
@@ -100,6 +100,7 @@ func (c *Controller) handleUpdateEndpoint(key string) error {
 		if errors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -108,6 +109,7 @@ func (c *Controller) handleUpdateEndpoint(key string) error {
 		if errors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	svc := cachedService.DeepCopy()

--- a/pkg/controller/external_vpc.go
+++ b/pkg/controller/external_vpc.go
@@ -36,7 +36,7 @@ func (c *Controller) syncExternalVpc() {
 			}
 			_, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().UpdateStatus(context.Background(), vpc, metav1.UpdateOptions{})
 			if err != nil {
-				klog.V(4).Infof("update vpc %s status failed", vpcName)
+				klog.Errorf("update vpc %s status failed: %v", vpcName, err)
 				continue
 			}
 			delete(logicalRouters, vpcName)
@@ -44,10 +44,10 @@ func (c *Controller) syncExternalVpc() {
 		} else {
 			err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Delete(context.Background(), vpcName, metav1.DeleteOptions{})
 			if err != nil {
-				klog.V(4).Infof("delete vpc %s failed", vpcName)
+				klog.Error("delete vpc %s failed: %v", vpcName, err)
 				continue
 			}
-			klog.V(4).Infof("delete vpc %s ", vpcName)
+			klog.Infof("deleted vpc %s ", vpcName)
 		}
 	}
 	if len(logicalRouters) != 0 {

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -395,6 +395,7 @@ func (c *Controller) gcLoadBalancer() error {
 		// remove lb from logical switch
 		vpcs, err := c.vpcsLister.List(labels.Everything())
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		for _, cachedVpc := range vpcs {
@@ -405,6 +406,7 @@ func (c *Controller) gcLoadBalancer() error {
 					if k8serrors.IsNotFound(err) {
 						continue
 					}
+					klog.Error(err)
 					return err
 				}
 				if !isOvnSubnet(subnet) {
@@ -425,10 +427,12 @@ func (c *Controller) gcLoadBalancer() error {
 			vpc.Status.SctpSessionLoadBalancer = ""
 			bytes, err := vpc.Status.Bytes()
 			if err != nil {
+				klog.Error(err)
 				return err
 			}
 			_, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), vpc.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
 			if err != nil {
+				klog.Error(err)
 				return err
 			}
 		}

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -86,6 +86,7 @@ func (c *Controller) InitDefaultVpc() error {
 
 	bytes, err := vpc.Status.Bytes()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	_, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), vpc.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
@@ -263,10 +264,12 @@ func (c *Controller) initLoadBalancer() error {
 		vpc.Status.SctpSessionLoadBalancer = vpcLb.SctpSessLoadBalancer
 		bytes, err := vpc.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		_, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), vpc.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 	}
@@ -588,6 +591,7 @@ func (c *Controller) initDefaultVlan() error {
 	}
 
 	if err := c.initDefaultProviderNetwork(); err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -664,6 +668,7 @@ func (c *Controller) initSyncCrdSubnets() error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	for _, orisubnet := range subnets {
@@ -745,6 +750,7 @@ func (c *Controller) initSyncCrdVlans() error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 

--- a/pkg/controller/inspection.go
+++ b/pkg/controller/inspection.go
@@ -43,6 +43,7 @@ func (c *Controller) inspectPod() error {
 				portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
 				exists, err := c.ovnClient.LogicalSwitchPortExists(portName)
 				if err != nil {
+					klog.Errorf("failed to check port %s exists, %v", portName, err)
 					return err
 				}
 
@@ -51,6 +52,7 @@ func (c *Controller) inspectPod() error {
 					delete(pod.Annotations, fmt.Sprintf(util.RoutedAnnotationTemplate, podNet.ProviderName))
 					patch, err := util.GenerateStrategicMergePatchPayload(oriPod, pod)
 					if err != nil {
+						klog.Errorf("failed to generate patch payload, %v", err)
 						return err
 					}
 					if _, err := c.config.KubeClient.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name,

--- a/pkg/controller/ovn-ic.go
+++ b/pkg/controller/ovn-ic.go
@@ -323,6 +323,7 @@ func (c *Controller) startOvnIC(icHost, icNbPort, icSbPort string) error {
 	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("%s", output)
 	}
 	return nil
@@ -332,6 +333,7 @@ func (c *Controller) stopOvnIC() error {
 	cmd := exec.Command("/usr/share/ovn/scripts/ovn-ctl", "stop_ic")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("%s", output)
 	}
 	return nil
@@ -342,6 +344,7 @@ func (c *Controller) waitTsReady() error {
 	for retry > 0 {
 		ready, err := c.allSubnetReady(util.InterconnectionSwitch)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 
@@ -406,16 +409,19 @@ func (c *Controller) RemoveOldChassisInSbDB(azName string) error {
 	azUUID, err := c.ovnLegacyClient.GetAzUUID(azName)
 	if err != nil {
 		klog.Errorf("failed to get UUID of AZ %s: %v", lastIcCm["az-name"], err)
+		return err
 	}
 
 	gateways, err := c.ovnLegacyClient.GetGatewayUUIDsInOneAZ(azUUID)
 	if err != nil {
 		klog.Errorf("failed to get gateway UUIDs in AZ %s: %v", azUUID, err)
+		return err
 	}
 
 	routes, err := c.ovnLegacyClient.GetRouteUUIDsInOneAZ(azUUID)
 	if err != nil {
 		klog.Errorf("failed to get route UUIDs in AZ %s: %v", azUUID, err)
+		return err
 	}
 
 	c.ovnLegacyClient.DestroyGateways(gateways)
@@ -504,6 +510,7 @@ func (c *Controller) listRemoteLogicalSwitchPortAddress() (*strset.Set, error) {
 		return lsp.Type == "remote"
 	})
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("list remote logical switch ports: %v", err)
 	}
 

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -183,6 +183,7 @@ func (c *Controller) isOvnDnatDuplicated(eipName, dnatName, externalPort string)
 	}))
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
+			klog.Error(err)
 			return false, err
 		}
 	}
@@ -203,6 +204,7 @@ func (c *Controller) handleAddOvnDnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -318,6 +320,7 @@ func (c *Controller) handleDelOvnDnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -345,6 +348,7 @@ func (c *Controller) handleUpdateOvnDnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -458,6 +462,7 @@ func (c *Controller) patchOvnDnatAnnotations(key, eipName string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -495,6 +500,7 @@ func (c *Controller) patchOvnDnatStatus(key, vpcName, v4Eip, podIp, podMac strin
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	dnat := oriDnat.DeepCopy()
@@ -562,6 +568,7 @@ func (c *Controller) patchOvnDnatStatus(key, vpcName, v4Eip, podIp, podMac strin
 	if changed {
 		bytes, err := dnat.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err = c.config.KubeOvnClient.KubeovnV1().OvnDnatRules().Patch(context.Background(), dnat.Name,

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -217,6 +217,7 @@ func (c *Controller) handleAddOvnEip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedEip.Status.MacAddress != "" {
@@ -281,6 +282,7 @@ func (c *Controller) handleUpdateOvnEip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	klog.V(3).Infof("handle update ovn eip %s", cachedEip.Name)
@@ -316,6 +318,7 @@ func (c *Controller) handleResetOvnEip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if !cachedEip.DeletionTimestamp.IsZero() {
@@ -384,6 +387,7 @@ func (c *Controller) createOrUpdateCrdOvnEip(key, subnet, v4ip, v6ip, mac, usage
 			}, metav1.CreateOptions{})
 			if err != nil {
 				err := fmt.Errorf("failed to create crd ovn eip '%s', %v", key, err)
+				klog.Error(err)
 				return err
 			}
 			// wait local cache ready
@@ -513,6 +517,7 @@ func (c *Controller) natLabelAndAnnoOvnEip(eipName, natName, vpcName string) err
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	eip := cachedEip.DeepCopy()

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -195,6 +195,7 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedFip.Status.Ready && cachedFip.Status.V4Ip != "" {
@@ -406,6 +407,7 @@ func (c *Controller) handleDelOvnFip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	eipName := cachedFip.Spec.OvnEip
@@ -430,6 +432,7 @@ func (c *Controller) patchOvnFipAnnotations(key, eipName string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	fip := oriFip.DeepCopy()
@@ -466,6 +469,7 @@ func (c *Controller) patchOvnFipStatus(key, vpcName, v4Eip, podIp, podMac string
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	fip := oriFip.DeepCopy()
@@ -510,6 +514,7 @@ func (c *Controller) patchOvnFipStatus(key, vpcName, v4Eip, podIp, podMac string
 	if changed {
 		bytes, err := fip.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err = c.config.KubeOvnClient.KubeovnV1().OvnFips().Patch(context.Background(), fip.Name,

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -177,6 +177,7 @@ func (c *Controller) handleAddOvnSnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedSnat.Status.Ready && cachedSnat.Status.V4IpCidr != "" {
@@ -272,6 +273,7 @@ func (c *Controller) handleUpdateOvnSnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	klog.V(3).Infof("handle update ovn snat %s", key)
@@ -376,6 +378,7 @@ func (c *Controller) patchOvnSnatStatus(key, vpc, v4Eip, v4IpCidr string, ready 
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	snat := oriSnat.DeepCopy()
@@ -436,6 +439,7 @@ func (c *Controller) patchOvnSnatAnnotation(key, eipName string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	snat := oriFip.DeepCopy()

--- a/pkg/controller/pod_iptables_eip.go
+++ b/pkg/controller/pod_iptables_eip.go
@@ -222,7 +222,7 @@ func (c *Controller) processNextDeletePodAnnotatedIptablesEipWorkItem() bool {
 func (c *Controller) handleAddPodAnnotatedIptablesEip(key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		klog.Error(err)
 		return nil
 	}
 	cachedPod, err := c.podsLister.Pods(namespace).Get(name)
@@ -230,6 +230,7 @@ func (c *Controller) handleAddPodAnnotatedIptablesEip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedPod.Annotations[util.FipEnableAnnotation] != "true" {
@@ -250,6 +251,7 @@ func (c *Controller) handleAddPodAnnotatedIptablesEip(key string) error {
 	newPod := cachedPod.DeepCopy()
 	if newPod.Annotations[util.AllocatedAnnotation] != "true" {
 		err = fmt.Errorf("pod network not allocated, failed to create iptables eip %s", eipName)
+		klog.Error(err)
 		return err
 	}
 	if eip, err := c.iptablesEipsLister.Get(eipName); err != nil {
@@ -280,6 +282,7 @@ func (c *Controller) handleAddPodAnnotatedIptablesEip(key string) error {
 		newPod.Annotations[util.EipAnnotation] = eip.Status.IP
 		patch, err := util.GenerateStrategicMergePatchPayload(cachedPod, newPod)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err := c.config.KubeClient.CoreV1().Pods(namespace).Patch(context.Background(), name,

--- a/pkg/controller/pod_iptables_fip.go
+++ b/pkg/controller/pod_iptables_fip.go
@@ -217,6 +217,7 @@ func (c *Controller) handleAddPodAnnotatedIptablesFip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedPod.Annotations[util.FipEnableAnnotation] != "true" {
@@ -255,6 +256,7 @@ func (c *Controller) handleAddPodAnnotatedIptablesFip(key string) error {
 	newPod.Annotations[util.FipNameAnnotation] = fipName
 	patch, err := util.GenerateStrategicMergePatchPayload(cachedPod, newPod)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	if _, err := c.config.KubeClient.CoreV1().Pods(namespace).Patch(context.Background(), name,

--- a/pkg/controller/qos_policy.go
+++ b/pkg/controller/qos_policy.go
@@ -192,6 +192,7 @@ func (c *Controller) handleAddQoSPolicy(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -229,6 +230,7 @@ func (c *Controller) patchQoSStatus(
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	qos := oriQoS.DeepCopy()
@@ -237,6 +239,7 @@ func (c *Controller) patchQoSStatus(
 	qos.Status.BandwidthLimitRules = bandwidthRules
 	bytes, err := qos.Status.Bytes()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	if _, err = c.config.KubeOvnClient.KubeovnV1().QoSPolicies().Patch(context.Background(), qos.Name,
@@ -256,6 +259,7 @@ func (c *Controller) handleDelQoSPoliciesFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if len(cachedQoSPolicies.Finalizers) == 0 {
@@ -393,6 +397,7 @@ func (c *Controller) handleUpdateQoSPolicy(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	// should delete
@@ -511,6 +516,7 @@ func (c *Controller) handleAddQoSPolicyFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedQoSPolicy.DeletionTimestamp.IsZero() {

--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -206,6 +206,7 @@ func (c *Controller) updateDenyAllSgPorts() error {
 		sgs := strings.Split(lsp.ExternalIDs[sgsKey], "/")
 		allNotExist, err := c.securityGroupAllNotExist(sgs)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 
@@ -244,6 +245,7 @@ func (c *Controller) handleAddOrUpdateSg(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	sg := cachedSg.DeepCopy()
@@ -531,6 +533,7 @@ func (c *Controller) securityGroupAllNotExist(sgs []string) (bool, error) {
 	for _, sg := range sgs {
 		ok, err := c.ovnClient.PortGroupExists(ovs.GetSgPortGroupName(sg))
 		if err != nil {
+			klog.Error(err)
 			return true, err
 		}
 

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -236,6 +236,7 @@ func (c *Controller) processNextUpdateServiceWorkItem() bool {
 func (c *Controller) handleDeleteService(service *vpcService) error {
 	key, err := cache.MetaNamespaceKeyFunc(service.Svc)
 	if err != nil {
+		klog.Error(err)
 		utilruntime.HandleError(fmt.Errorf("failed to get meta namespace key of %#v: %v", service.Svc, err))
 		return nil
 	}
@@ -303,6 +304,7 @@ func (c *Controller) handleUpdateService(key string) error {
 
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
+		klog.Error(err)
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
@@ -316,6 +318,7 @@ func (c *Controller) handleUpdateService(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -437,6 +440,7 @@ func parseVipAddr(vip string) string {
 func (c *Controller) handleAddService(key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
+		klog.Error(err)
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
@@ -450,6 +454,7 @@ func (c *Controller) handleAddService(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if svc.Spec.Type != v1.ServiceTypeLoadBalancer || !c.config.EnableLbSvc {
@@ -489,6 +494,7 @@ func (c *Controller) handleAddService(key string) error {
 			if k8serrors.IsNotFound(err) {
 				return nil
 			}
+			klog.Error(err)
 			return err
 		}
 	}
@@ -504,6 +510,7 @@ func (c *Controller) handleAddService(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	var ingress v1.LoadBalancerIngress

--- a/pkg/controller/service_lb.go
+++ b/pkg/controller/service_lb.go
@@ -187,6 +187,7 @@ func (c *Controller) getLbSvcPod(svcName, svcNamespace string) (*corev1.Pod, err
 
 	pods, err := c.podsLister.Pods(svcNamespace).List(sel)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	} else if len(pods) == 0 {
 		time.Sleep(2 * time.Second)
@@ -267,6 +268,7 @@ func (c *Controller) execNatRules(pod *corev1.Pod, operation string, rules []str
 		if len(stdOutput) > 0 {
 			klog.V(3).Infof("failed to ExecuteCommandInContainer, stdOutput: %v", stdOutput)
 		}
+		klog.Error(err)
 		return err
 	}
 

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -199,6 +199,7 @@ func (c *Controller) handleAddVirtualIp(key string) error {
 		v4ip, v6ip, mac, err = c.acquireIpAddress(subnet.Name, vip.Name, portName)
 	}
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	var parentV4ip, parentV6ip, parentMac string
@@ -256,6 +257,7 @@ func (c *Controller) handleUpdateVirtualIp(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	vip := cachedVip.DeepCopy()
@@ -342,11 +344,13 @@ func (c *Controller) acquireIpAddress(subnetName, name, nicName string) (string,
 	for {
 		v4ip, v6ip, mac, err = c.ipam.GetRandomAddress(name, nicName, nil, subnetName, "", skippedAddrs, checkConflict)
 		if err != nil {
+			klog.Error(err)
 			return "", "", "", err
 		}
 
 		ipv4OK, ipv6OK, err := c.validatePodIP(name, subnetName, v4ip, v6ip)
 		if err != nil {
+			klog.Error(err)
 			return "", "", "", err
 		}
 
@@ -465,9 +469,9 @@ func (c *Controller) patchVipStatus(key, v4ip string, ready bool) error {
 	oriVip, err := c.virtualIpsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			klog.Errorf("failed to get cached vip '%s', %v", key, err)
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	vip := oriVip.DeepCopy()
@@ -496,9 +500,9 @@ func (c *Controller) podReuseVip(key, portName string, keepVIP bool) error {
 	oriVip, err := c.virtualIpsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			klog.Errorf("failed to get cached vip '%s', %v", key, err)
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	vip := oriVip.DeepCopy()
@@ -530,9 +534,9 @@ func (c *Controller) releaseVip(key string) error {
 	oriVip, err := c.virtualIpsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			klog.Errorf("failed to get cached vip '%s', %v", key, err)
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	vip := oriVip.DeepCopy()
@@ -573,6 +577,7 @@ func (c *Controller) handleAddVipFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedVip.DeletionTimestamp.IsZero() {
@@ -604,6 +609,7 @@ func (c *Controller) handleDelVipFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if len(cachedVip.Finalizers) == 0 {

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -110,6 +110,7 @@ func (c *Controller) handleDelVpc(vpc *kubeovnv1.Vpc) error {
 
 	err := c.deleteVpcRouter(vpc.Status.Router)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	return nil
@@ -125,12 +126,14 @@ func (c *Controller) handleUpdateVpcStatus(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	vpc := cachedVpc.DeepCopy()
 
 	subnets, defaultSubnet, err := c.getVpcSubnets(vpc)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -143,11 +146,13 @@ func (c *Controller) handleUpdateVpcStatus(key string) error {
 	vpc.Status.Subnets = subnets
 	bytes, err := vpc.Status.Bytes()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
 	vpc, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), vpc.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	if change {
@@ -158,6 +163,7 @@ func (c *Controller) handleUpdateVpcStatus(key string) error {
 
 	natGws, err := c.vpcNatGatewayLister.List(labels.Everything())
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	for _, gw := range natGws {
@@ -234,6 +240,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	vpc := cachedVpc.DeepCopy()
@@ -434,6 +441,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 	if c.config.EnableLb {
 		vpcLb, err := c.addLoadBalancer(key)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		vpc.Status.TcpLoadBalancer = vpcLb.TcpLoadBalancer
@@ -445,10 +453,12 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 	}
 	bytes, err := vpc.Status.Bytes()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	vpc, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), vpc.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status")
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -462,6 +472,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -752,6 +763,7 @@ func (c *Controller) getVpcSubnets(vpc *kubeovnv1.Vpc) (subnets []string, defaul
 	subnets = []string{}
 	allSubnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
+		klog.Error(err)
 		return nil, "", err
 	}
 
@@ -781,6 +793,7 @@ func (c *Controller) deleteVpcRouter(lr string) error {
 func (c *Controller) handleAddVpcExternal(key string) error {
 	cachedSubnet, err := c.subnetsLister.Get(c.config.ExternalGatewaySwitch)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	lrpEipName := fmt.Sprintf("%s-%s", key, c.config.ExternalGatewaySwitch)

--- a/pkg/controller/vpc_dns.go
+++ b/pkg/controller/vpc_dns.go
@@ -306,6 +306,7 @@ func (c *Controller) createOrUpdateVpcDnsSlr(vpcDns *kubeovnv1.VpcDns) error {
 		if k8serrors.IsNotFound(err) {
 			needToCreateSlr = true
 		} else {
+			klog.Error(err)
 			return err
 		}
 	}
@@ -487,6 +488,7 @@ func (c *Controller) checkOvnNad() error {
 	_, err := c.config.AttachNetClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(corev1.NamespaceDefault).
 		Get(context.Background(), nadName, metav1.GetOptions{})
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -496,6 +498,7 @@ func (c *Controller) checkOvnNad() error {
 func (c *Controller) checkOvnDefaultSpecProvider() error {
 	cachedSubnet, err := c.subnetsLister.Get(util.DefaultSubnet)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("failed to get default subnet %v", err)
 	}
 
@@ -589,6 +592,7 @@ func (c *Controller) getDefaultCoreDnsImage() (string, error) {
 	dp, err := c.config.KubeClient.AppsV1().Deployments("kube-system").
 		Get(context.Background(), "coredns", metav1.GetOptions{})
 	if err != nil {
+		klog.Error(err)
 		return "", err
 	}
 

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -251,6 +251,7 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if _, err := c.vpcsLister.Get(gw.Spec.Vpc); err != nil {
@@ -274,6 +275,7 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) error {
 		if k8serrors.IsNotFound(err) {
 			needToCreate = true
 		} else {
+			klog.Error(err)
 			return err
 		}
 	}
@@ -351,6 +353,7 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	// subnet for vpc-nat-gw has been checked when create vpc-nat-gw
@@ -407,6 +410,7 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 	pod.Annotations[util.VpcNatGatewayInitAnnotation] = "true"
 	patch, err := util.GenerateStrategicMergePatchPayload(oriPod, pod)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	if _, err := c.config.KubeClient.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name,
@@ -568,6 +572,7 @@ func (c *Controller) getIptablesVersion(pod *corev1.Pod) (version string, err er
 		if len(stdOutput) > 0 {
 			klog.V(3).Infof("failed to ExecuteCommandInContainer, stdOutput: %v", stdOutput)
 		}
+		klog.Error(err)
 		return "", err
 	}
 
@@ -599,6 +604,7 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 
 	gw, err := c.vpcNatGatewayLister.Get(natGwKey)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -695,6 +701,7 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 	pod.Annotations[util.VpcCIDRsAnnotation] = string(cidrBytes)
 	patch, err := util.GenerateStrategicMergePatchPayload(oriPod, pod)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	if _, err := c.config.KubeClient.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name,
@@ -719,6 +726,7 @@ func (c *Controller) execNatGwRules(pod *corev1.Pod, operation string, rules []s
 		if len(stdOutput) > 0 {
 			klog.V(3).Infof("failed to ExecuteCommandInContainer, stdOutput: %v", stdOutput)
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -828,6 +836,7 @@ func (c *Controller) getNatGwPod(name string) (*corev1.Pod, error) {
 
 	pods, err := c.podsLister.Pods(c.config.PodNamespace).List(sel)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	} else if len(pods) == 0 {
 		return nil, k8serrors.NewNotFound(v1.Resource("pod"), name)
@@ -848,6 +857,7 @@ func (c *Controller) initCreateAt(key string) (err error) {
 	}
 	pod, err := c.getNatGwPod(key)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	NAT_GW_CREATED_AT = pod.CreationTimestamp.Format("2006-01-02T15:04:05")
@@ -906,6 +916,7 @@ func (c *Controller) getNatGw(router, subnet string) (string, error) {
 	selectors := labels.Set{util.VpcNameLabel: router, util.SubnetNameLabel: subnet}.AsSelector()
 	gws, err := c.vpcNatGatewayLister.List(selectors)
 	if err != nil {
+		klog.Error(err)
 		return "", err
 	}
 	if len(gws) == 1 {
@@ -986,6 +997,7 @@ func (c *Controller) patchNatGwStatus(key string) error {
 	if changed {
 		bytes, err := gw.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err = c.config.KubeOvnClient.KubeovnV1().VpcNatGateways().Patch(context.Background(), gw.Name, types.MergePatchType,

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -215,6 +215,7 @@ func (c *Controller) handleAddIptablesEip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedEip.Status.Ready && cachedEip.Status.IP != "" {
@@ -293,6 +294,7 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	externalNetwork := util.GetExternalNetwork(cachedEip.Spec.ExternalSubnet)
@@ -423,6 +425,7 @@ func (c *Controller) GetEip(eipName string) (*kubeovnv1.IptablesEIP, error) {
 func (c *Controller) createEipInPod(dp, gw, v4Cidr string) error {
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	var addRules []string
@@ -440,12 +443,14 @@ func (c *Controller) deleteEipInPod(dp, v4Cidr string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	var delRules []string
 	rule := v4Cidr
 	delRules = append(delRules, rule)
 	if err = c.execNatGwRules(gwPod, natGwEipDel, delRules); err != nil {
+		klog.Error(err)
 		return err
 	}
 	return nil
@@ -518,6 +523,7 @@ func (c *Controller) addEipQoSInPod(
 	var operation string
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	var addRules []string
@@ -541,6 +547,7 @@ func (c *Controller) delEipQoSInPod(dp string, v4ip string, direction kubeovnv1.
 	var operation string
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	var delRules []string
@@ -581,11 +588,13 @@ func (c *Controller) acquireEip(name, namespace, nicName, externalSubnet string)
 	for {
 		ipv4, ipv6, mac, err := c.ipam.GetRandomAddress(name, nicName, nil, externalSubnet, "", skippedAddrs, true)
 		if err != nil {
+			klog.Error(err)
 			return "", "", "", err
 		}
 
 		ipv4OK, ipv6OK, err := c.validatePodIP(name, externalSubnet, ipv4, ipv6)
 		if err != nil {
+			klog.Error(err)
 			return "", "", "", err
 		}
 		if ipv4OK && ipv6OK {
@@ -684,6 +693,7 @@ func (c *Controller) createOrUpdateCrdEip(key, v4ip, v6ip, mac, natGwDp, qos, ex
 			eip.Status.QoSPolicy = qos
 			bytes, err := eip.Status.Bytes()
 			if err != nil {
+				klog.Error(err)
 				return err
 			}
 			if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Patch(context.Background(), key, types.MergePatchType,
@@ -735,6 +745,7 @@ func (c *Controller) handleAddIptablesEipFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedIptablesEip.DeletionTimestamp.IsZero() {
@@ -766,6 +777,7 @@ func (c *Controller) handleDelIptablesEipFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if len(cachedIptablesEip.Finalizers) == 0 {
@@ -796,6 +808,7 @@ func (c *Controller) patchEipQoSStatus(key, qos string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	eip := oriEip.DeepCopy()
@@ -809,6 +822,7 @@ func (c *Controller) patchEipQoSStatus(key, qos string) error {
 	if changed {
 		bytes, err := eip.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Patch(context.Background(), key, types.MergePatchType,
@@ -860,6 +874,7 @@ func (c *Controller) patchEipStatus(key, v4ip, redo, qos string, ready bool) err
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	eip := oriEip.DeepCopy()
@@ -900,6 +915,7 @@ func (c *Controller) patchEipStatus(key, v4ip, redo, qos string, ready bool) err
 	if changed {
 		bytes, err := eip.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Patch(context.Background(), key, types.MergePatchType,
@@ -920,6 +936,7 @@ func (c *Controller) patchEipLabel(eipName string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	externalNetwork := util.GetExternalNetwork(oriEip.Spec.ExternalSubnet)

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -500,6 +500,7 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if fip.Status.Ready && fip.Status.V4ip != "" {
@@ -578,6 +579,7 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	// should delete
@@ -686,6 +688,7 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if dnat.Status.Ready && dnat.Status.V4ip != "" {
@@ -744,6 +747,7 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	// should delete
@@ -857,6 +861,7 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if snat.Status.Ready && snat.Status.V4ip != "" {
@@ -915,6 +920,7 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	v4Cidr, _ := util.SplitStringIP(cachedSnat.Status.InternalCIDR)
@@ -1017,6 +1023,7 @@ func (c *Controller) handleAddIptablesFipFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedIptablesFip.DeletionTimestamp.IsZero() {
@@ -1048,6 +1055,7 @@ func (c *Controller) handleDelIptablesFipFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if len(cachedIptablesFip.Finalizers) == 0 {
@@ -1077,6 +1085,7 @@ func (c *Controller) handleAddIptablesDnatFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedIptablesDnat.DeletionTimestamp.IsZero() {
@@ -1108,6 +1117,7 @@ func (c *Controller) handleDelIptablesDnatFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if len(cachedIptablesDnat.Finalizers) == 0 {
@@ -1137,6 +1147,7 @@ func (c *Controller) patchFipLabel(key string, eip *kubeovnv1.IptablesEIP) error
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	fip := oriFip.DeepCopy()
@@ -1187,6 +1198,7 @@ func (c *Controller) handleAddIptablesSnatFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if cachedIptablesSnat.DeletionTimestamp.IsZero() {
@@ -1218,6 +1230,7 @@ func (c *Controller) handleDelIptablesSnatFinalizer(key string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	if len(cachedIptablesSnat.Finalizers) == 0 {
@@ -1247,6 +1260,7 @@ func (c *Controller) patchFipStatus(key, v4ip, v6ip, natGwDp, redo string, ready
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	fip := oriFip.DeepCopy()
@@ -1274,6 +1288,7 @@ func (c *Controller) patchFipStatus(key, v4ip, v6ip, natGwDp, redo string, ready
 	if changed {
 		bytes, err := fip.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Patch(context.Background(), fip.Name,
@@ -1325,6 +1340,7 @@ func (c *Controller) patchDnatLabel(key string, eip *kubeovnv1.IptablesEIP) erro
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	dnat := oriDnat.DeepCopy()
@@ -1377,6 +1393,7 @@ func (c *Controller) patchDnatStatus(key, v4ip, v6ip, natGwDp, redo string, read
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	var changed bool
@@ -1415,6 +1432,7 @@ func (c *Controller) patchDnatStatus(key, v4ip, v6ip, natGwDp, redo string, read
 	if changed {
 		bytes, err := dnat.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().Patch(context.Background(), dnat.Name,
@@ -1461,6 +1479,7 @@ func (c *Controller) patchSnatLabel(key string, eip *kubeovnv1.IptablesEIP) erro
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	snat := oriSnat.DeepCopy()
@@ -1482,6 +1501,7 @@ func (c *Controller) patchSnatLabel(key string, eip *kubeovnv1.IptablesEIP) erro
 	}
 	if needUpdateLabel {
 		if err := c.updateIptableLabels(snat.Name, op, util.SnatUsingEip, snat.Labels); err != nil {
+			klog.Error(err)
 			return err
 		}
 	}
@@ -1511,6 +1531,7 @@ func (c *Controller) patchSnatStatus(key, v4ip, v6ip, natGwDp, redo string, read
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	snat := oriSnat.DeepCopy()
@@ -1543,6 +1564,7 @@ func (c *Controller) patchSnatStatus(key, v4ip, v6ip, natGwDp, redo string, read
 	if changed {
 		bytes, err := snat.Status.Bytes()
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().Patch(context.Background(), snat.Name,
@@ -1586,6 +1608,7 @@ func (c *Controller) redoSnat(key, redo string, eipReady bool) error {
 func (c *Controller) createFipInPod(dp, v4ip, internalIP string) error {
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	var addRules []string
@@ -1604,6 +1627,7 @@ func (c *Controller) deleteFipInPod(dp, v4ip, internalIP string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	// del nat
@@ -1640,6 +1664,7 @@ func (c *Controller) deleteDnatInPod(dp, protocol, v4ip, internalIp, externalPor
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 
@@ -1686,6 +1711,7 @@ func (c *Controller) deleteSnatInPod(dp, v4ip, internalCIDR string) error {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	// del nat
@@ -1843,6 +1869,7 @@ func (c *Controller) patchIptableInfo(name, natType, patchPayload string) error 
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
 		return err
 	}
 	return nil

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -72,10 +72,12 @@ func (ipam *IPAM) GetStaticAddress(podName, nicName, ip string, mac *string, sub
 		for _, ipStr := range strings.Split(ip, ",") {
 			ip, err := NewIP(ipStr)
 			if err != nil {
+				klog.Errorf("failed to parse ip %s", ipStr)
 				return "", "", "", err
 			}
 			ipAddr, macStr, err = subnet.GetStaticAddress(podName, nicName, ip, mac, false, checkConflict)
 			if err != nil {
+				klog.Errorf("failed to allocate static ip %s for %s", ipStr, podName)
 				return "", "", "", err
 			}
 			ips = append(ips, ipAddr)
@@ -169,10 +171,12 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 		subnet.Protocol = protocol
 		v4Reserved, err := NewIPRangeListFrom(v4ExcludeIps...)
 		if err != nil {
+			klog.Errorf("failed to parse v4 exclude ips %v", v4ExcludeIps)
 			return err
 		}
 		v6Reserved, err := NewIPRangeListFrom(v6ExcludeIps...)
 		if err != nil {
+			klog.Errorf("failed to parse v6 exclude ips %v", v6ExcludeIps)
 			return err
 		}
 		if (protocol == kubeovnv1.ProtocolDual || protocol == kubeovnv1.ProtocolIPv4) &&
@@ -273,6 +277,7 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 
 	subnet, err := NewSubnet(name, cidrStr, excludeIps)
 	if err != nil {
+		klog.Errorf("failed to create subnet %s, %v", name, err)
 		return err
 	}
 	subnet.V4Gw = v4Gw

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -258,6 +258,7 @@ func patchPodLabels(cfg *Configuration, cachedPod *corev1.Pod, labels map[string
 	pod.Labels = labels
 	patch, err := util.GenerateStrategicMergePatchPayload(cachedPod, pod)
 	if err != nil {
+		klog.Errorf("failed to generate patch payload, %v", err)
 		return err
 	}
 	_, err = cfg.KubeClient.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name,

--- a/pkg/ovnmonitor/util.go
+++ b/pkg/ovnmonitor/util.go
@@ -76,6 +76,7 @@ func getClusterEnableState(dbName string) (bool, error) {
 	cmd := exec.Command("sh", "-c", cmdstr)
 	_, err := cmd.CombinedOutput()
 	if err != nil {
+		klog.Error(err)
 		return false, err
 	}
 	return true, nil

--- a/pkg/ovs/ovn-ic-nbctl.go
+++ b/pkg/ovs/ovn-ic-nbctl.go
@@ -40,6 +40,7 @@ func (c LegacyClient) ovnIcNbCommand(cmdArgs ...string) (string, error) {
 func (c LegacyClient) GetTsSubnet(ts string) (string, error) {
 	subnet, err := c.ovnIcNbCommand("get", "Transit_Switch", ts, "external_ids:subnet")
 	if err != nil {
+		klog.Error(err)
 		return "", fmt.Errorf("failed to get ts subnet, %v", err)
 	}
 	return subnet, nil

--- a/pkg/ovs/ovn-ic-sbctl.go
+++ b/pkg/ovs/ovn-ic-sbctl.go
@@ -41,7 +41,9 @@ func (c LegacyClient) FindUUIDWithAttrInTable(attribute, value, table string) ([
 	key := attribute + "=" + value
 	output, err := c.ovnIcSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=_uuid", "find", table, key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find ovn-ic-sb db, %v", err)
+		err := fmt.Errorf("failed to find ovn-ic-sb db, %v", err)
+		klog.Error(err)
+		return nil, err
 	}
 	lines := strings.Split(output, "\n")
 	result := make([]string, 0, len(lines))
@@ -57,6 +59,7 @@ func (c LegacyClient) FindUUIDWithAttrInTable(attribute, value, table string) ([
 func (c LegacyClient) DestroyTableWithUUID(uuid, table string) error {
 	_, err := c.ovnIcSbCommand("destroy", table, uuid)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("failed to destroy record %s in table %s: %v", uuid, table, err)
 	}
 	return nil
@@ -65,6 +68,7 @@ func (c LegacyClient) DestroyTableWithUUID(uuid, table string) error {
 func (c LegacyClient) GetAzUUID(az string) (string, error) {
 	uuids, err := c.FindUUIDWithAttrInTable("name", az, "availability_zone")
 	if err != nil {
+		klog.Error(err)
 		return "", fmt.Errorf("failed to get ovn-ic-sb availability_zone uuid: %v", err)
 	}
 	if len(uuids) == 1 {
@@ -78,6 +82,7 @@ func (c LegacyClient) GetAzUUID(az string) (string, error) {
 func (c LegacyClient) GetGatewayUUIDsInOneAZ(uuid string) ([]string, error) {
 	gateways, err := c.FindUUIDWithAttrInTable("availability_zone", uuid, "gateway")
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("failed to get ovn-ic-sb gateways with uuid %v: %v", uuid, err)
 	}
 	return gateways, nil
@@ -86,6 +91,7 @@ func (c LegacyClient) GetGatewayUUIDsInOneAZ(uuid string) ([]string, error) {
 func (c LegacyClient) GetRouteUUIDsInOneAZ(uuid string) ([]string, error) {
 	routes, err := c.FindUUIDWithAttrInTable("availability_zone", uuid, "route")
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("failed to get ovn-ic-sb routes with uuid %v: %v", uuid, err)
 	}
 	return routes, nil
@@ -111,6 +117,7 @@ func (c LegacyClient) DestroyRoutes(uuids []string) {
 
 func (c LegacyClient) DestroyChassis(uuid string) error {
 	if err := c.DestroyTableWithUUID(uuid, "availability_zone"); err != nil {
+		klog.Error(err)
 		return fmt.Errorf("failed to delete chassis %v: %v", uuid, err)
 	}
 	return nil

--- a/pkg/ovs/ovn-nb-address_set.go
+++ b/pkg/ovs/ovn-nb-address_set.go
@@ -22,6 +22,7 @@ func (c *ovnClient) CreateAddressSet(asName string, externalIDs map[string]strin
 
 	exists, err := c.AddressSetExists(asName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -37,6 +38,7 @@ func (c *ovnClient) CreateAddressSet(asName string, externalIDs map[string]strin
 
 	ops, err := c.ovnNbClient.Create(as)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for creating address set %s: %v", asName, err)
 	}
 
@@ -52,6 +54,7 @@ func (c *ovnClient) CreateAddressSet(asName string, externalIDs map[string]strin
 func (c *ovnClient) AddressSetUpdateAddress(asName string, addresses ...string) error {
 	as, err := c.GetAddressSet(asName, false)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get address set %s: %v", asName, err)
 	}
 
@@ -88,10 +91,12 @@ func (c *ovnClient) UpdateAddressSet(as *ovnnb.AddressSet, fields ...interface{}
 
 	op, err := c.Where(as).Update(as, fields...)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for updating address set %s: %v", as.Name, err)
 	}
 
 	if err = c.Transact("as-update", op); err != nil {
+		klog.Error(err)
 		return fmt.Errorf("update address set %s: %v", as.Name, err)
 	}
 
@@ -101,6 +106,7 @@ func (c *ovnClient) UpdateAddressSet(as *ovnnb.AddressSet, fields ...interface{}
 func (c *ovnClient) DeleteAddressSet(asName string) error {
 	as, err := c.GetAddressSet(asName, true)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get address set %s: %v", asName, err)
 	}
 
@@ -111,6 +117,7 @@ func (c *ovnClient) DeleteAddressSet(asName string) error {
 
 	op, err := c.Where(as).Delete()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -130,6 +137,7 @@ func (c *ovnClient) DeleteAddressSets(externalIDs map[string]string) error {
 
 	op, err := c.WhereCache(addressSetFilter(externalIDs)).Delete()
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operation for deleting address sets with external IDs %v: %v", externalIDs, err)
 	}
 
@@ -150,6 +158,7 @@ func (c *ovnClient) GetAddressSet(asName string, ignoreNotFound bool) (*ovnnb.Ad
 		if ignoreNotFound && err == client.ErrNotFound {
 			return nil, nil
 		}
+		klog.Error(err)
 		return nil, fmt.Errorf("get address set %s: %v", asName, err)
 	}
 

--- a/pkg/ovs/ovn-nb-bfd.go
+++ b/pkg/ovs/ovn-nb-bfd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"k8s.io/klog/v2"
 )
 
 func (c *ovnClient) ListBFD(lrpName, dstIP string) ([]ovnnb.BFD, error) {
@@ -27,6 +28,7 @@ func (c *ovnClient) ListBFD(lrpName, dstIP string) ([]ovnnb.BFD, error) {
 func (c *ovnClient) CreateBFD(lrpName, dstIP string, minRx, minTx, detectMult int) (*ovnnb.BFD, error) {
 	bfdList, err := c.ListBFD(lrpName, dstIP)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 	if len(bfdList) != 0 {
@@ -60,6 +62,7 @@ func (c *ovnClient) CreateBFD(lrpName, dstIP string, minRx, minTx, detectMult in
 func (c *ovnClient) DeleteBFD(lrpName, dstIP string) error {
 	bfdList, err := c.ListBFD(lrpName, dstIP)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	if len(bfdList) == 0 {

--- a/pkg/ovs/ovn-nb-gateway_chassis.go
+++ b/pkg/ovs/ovn-nb-gateway_chassis.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
+	"k8s.io/klog/v2"
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -38,6 +39,7 @@ func (c *ovnClient) DeleteGatewayChassises(lrpName string, chassises []string) e
 		gwChassisName := lrpName + "-" + chassisName
 		op, err := c.DeleteGatewayChassisOp(gwChassisName)
 		if err != nil {
+			klog.Error(err)
 			return nil
 		}
 
@@ -82,6 +84,7 @@ func (c *ovnClient) GatewayChassisExist(name string) (bool, error) {
 func (c *ovnClient) newGatewayChassis(gwChassisName, chassisName string, priority int) (*ovnnb.GatewayChassis, error) {
 	exists, err := c.GatewayChassisExist(gwChassisName)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -113,6 +116,7 @@ func (c *ovnClient) CreateGatewayChassisesOp(lrpName string, chassises []string)
 		gwChassisName := lrpName + "-" + chassisName
 		gwChassis, err := c.newGatewayChassis(gwChassisName, chassisName, 100-i)
 		if err != nil {
+			klog.Error(err)
 			return nil, err
 		}
 
@@ -125,12 +129,14 @@ func (c *ovnClient) CreateGatewayChassisesOp(lrpName string, chassises []string)
 
 	gwChassisCreateop, err := c.Create(models...)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for creating gateway chassis %v", err)
 	}
 
 	/* add gateway chassis to logical router port */
 	gwChassisAddOp, err := c.LogicalRouterPortUpdateGatewayChassisOp(lrpName, uuids, ovsdb.MutateOperationInsert)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -146,6 +152,7 @@ func (c *ovnClient) DeleteGatewayChassisOp(chassisName string) ([]ovsdb.Operatio
 	gwChassis, err := c.GetGatewayChassis(chassisName, true)
 
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -156,6 +163,7 @@ func (c *ovnClient) DeleteGatewayChassisOp(chassisName string) ([]ovsdb.Operatio
 
 	op, err := c.Where(gwChassis).Delete()
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 

--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
+	"k8s.io/klog/v2"
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -18,6 +19,7 @@ import (
 func (c *ovnClient) CreateLoadBalancer(lbName, protocol, selectFields string) error {
 	exist, err := c.LoadBalancerExists(lbName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -126,6 +128,7 @@ func (c *ovnClient) LoadBalancerDeleteVip(lbName string, vip string) error {
 func (c *ovnClient) SetLoadBalancerAffinityTimeout(lbName string, timeout int) error {
 	lb, err := c.GetLoadBalancer(lbName, false)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	value := strconv.Itoa(timeout)
@@ -171,10 +174,12 @@ func (c *ovnClient) DeleteLoadBalancers(filter func(lb *ovnnb.LoadBalancer) bool
 func (c *ovnClient) DeleteLoadBalancer(lbName string) error {
 	op, err := c.DeleteLoadBalancerOp(lbName)
 	if err != nil {
-		return nil
+		klog.Error(err)
+		return err
 	}
 
 	if err := c.Transact("lb-del", op); err != nil {
+		klog.Error(err)
 		return fmt.Errorf("delete load balancer %s: %v", lbName, err)
 	}
 
@@ -236,6 +241,7 @@ func (c *ovnClient) ListLoadBalancers(filter func(lb *ovnnb.LoadBalancer) bool) 
 func (c *ovnClient) LoadBalancerOp(lbName string, mutationsFunc ...func(lb *ovnnb.LoadBalancer) []model.Mutation) ([]ovsdb.Operation, error) {
 	lb, err := c.GetLoadBalancer(lbName, false)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -255,6 +261,7 @@ func (c *ovnClient) LoadBalancerOp(lbName string, mutationsFunc ...func(lb *ovnn
 
 	ops, err := c.ovnNbClient.Where(lb).Mutate(lb, mutations...)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for mutating load balancer %s: %v", lb.Name, err)
 	}
 
@@ -266,6 +273,7 @@ func (c *ovnClient) DeleteLoadBalancerOp(lbName string) ([]ovsdb.Operation, erro
 	lb, err := c.GetLoadBalancer(lbName, true)
 
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -276,6 +284,7 @@ func (c *ovnClient) DeleteLoadBalancerOp(lbName string) ([]ovsdb.Operation, erro
 
 	op, err := c.Where(lb).Delete()
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 

--- a/pkg/ovs/ovn-nb-logical_router.go
+++ b/pkg/ovs/ovn-nb-logical_router.go
@@ -32,6 +32,7 @@ func (c *ovnClient) CreateLogicalRouter(lrName string) error {
 
 	op, err := c.ovnNbClient.Create(lr)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for creating logical router %s: %v", lrName, err)
 	}
 
@@ -46,6 +47,7 @@ func (c *ovnClient) CreateLogicalRouter(lrName string) error {
 func (c *ovnClient) UpdateLogicalRouter(lr *ovnnb.LogicalRouter, fields ...interface{}) error {
 	op, err := c.UpdateLogicalRouterOp(lr, fields...)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -60,6 +62,7 @@ func (c *ovnClient) UpdateLogicalRouter(lr *ovnnb.LogicalRouter, fields ...inter
 func (c *ovnClient) DeleteLogicalRouter(lrName string) error {
 	lr, err := c.GetLogicalRouter(lrName, true)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get logical router %s when delete: %v", lrName, err)
 	}
 
@@ -70,6 +73,7 @@ func (c *ovnClient) DeleteLogicalRouter(lrName string) error {
 
 	op, err := c.Where(lr).Delete()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -148,6 +152,7 @@ func (c *ovnClient) LogicalRouterUpdateLoadBalancers(lrName string, op ovsdb.Mut
 	for _, lbName := range lbNames {
 		lb, err := c.GetLoadBalancer(lbName, true)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 
@@ -169,6 +174,7 @@ func (c *ovnClient) LogicalRouterUpdateLoadBalancers(lrName string, op ovsdb.Mut
 
 	ops, err := c.LogicalRouterOp(lrName, mutation)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for logical router %s update lbs %v: %v", lrName, lbNames, err)
 	}
 
@@ -188,6 +194,7 @@ func (c *ovnClient) UpdateLogicalRouterOp(lr *ovnnb.LogicalRouter, fields ...int
 
 	op, err := c.ovnNbClient.Where(lr).Update(lr, fields...)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for updating logical router %s: %v", lr.Name, err)
 	}
 
@@ -299,6 +306,7 @@ func (c *ovnClient) LogicalRouterUpdateStaticRouteOp(lrName string, routeUUIDs [
 func (c *ovnClient) LogicalRouterOp(lrName string, mutationsFunc ...func(lr *ovnnb.LogicalRouter) *model.Mutation) ([]ovsdb.Operation, error) {
 	lr, err := c.GetLogicalRouter(lrName, false)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("get logical router %s: %v", lrName, err)
 	}
 
@@ -318,6 +326,7 @@ func (c *ovnClient) LogicalRouterOp(lrName string, mutationsFunc ...func(lr *ovn
 
 	ops, err := c.ovnNbClient.Where(lr).Mutate(lr, mutations...)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for mutating logical router %s: %v", lrName, err)
 	}
 

--- a/pkg/ovs/ovn-nb-logical_router_policy.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/scylladb/go-set/strset"
+	"k8s.io/klog/v2"
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -66,11 +67,13 @@ func (c *ovnClient) CreateLogicalRouterPolicies(lrName string, policies ...*ovnn
 
 	createPoliciesOp, err := c.ovnNbClient.Create(models...)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for creating policies: %v", err)
 	}
 
 	policyAddOp, err := c.LogicalRouterUpdatePolicyOp(lrName, policyUUIDs, ovsdb.MutateOperationInsert)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for adding policies to logical router %s: %v", lrName, err)
 	}
 
@@ -89,11 +92,13 @@ func (c *ovnClient) CreateLogicalRouterPolicies(lrName string, policies ...*ovnn
 func (c *ovnClient) DeleteLogicalRouterPolicy(lrName string, priority int, match string) error {
 	policyList, err := c.GetLogicalRouterPolicy(lrName, priority, match, true)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
 	for _, p := range policyList {
 		if err := c.DeleteLogicalRouterPolicyByUUID(lrName, p.UUID); err != nil {
+			klog.Error(err)
 			return err
 		}
 	}
@@ -106,6 +111,7 @@ func (c *ovnClient) DeleteLogicalRouterPolicies(lrName string, priority int, ext
 	// remove policies from logical router
 	policies, err := c.ListLogicalRouterPolicies(lrName, priority, externalIDs)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	if len(policies) == 0 {
@@ -147,6 +153,7 @@ func (c *ovnClient) DeleteLogicalRouterPolicyByNexthop(lrName string, priority i
 		return (route.Nexthop != nil && *route.Nexthop == nexthop) || util.ContainsString(route.Nexthops, nexthop)
 	})
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	for _, policy := range policyList {
@@ -290,6 +297,7 @@ func (c *ovnClient) DeleteRouterPolicy(lr *ovnnb.LogicalRouter, uuid string) err
 func (c *ovnClient) listLogicalRouterPoliciesByFilter(lrName string, filter func(route *ovnnb.LogicalRouterPolicy) bool) ([]*ovnnb.LogicalRouterPolicy, error) {
 	lr, err := c.GetLogicalRouter(lrName, false)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 

--- a/pkg/ovs/ovn-nb-logical_router_port.go
+++ b/pkg/ovs/ovn-nb-logical_router_port.go
@@ -21,6 +21,7 @@ func (c *ovnClient) CreatePeerRouterPort(localRouter, remoteRouter, localRouterP
 
 	exist, err := c.LogicalRouterPortExists(localRouterPort)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -44,6 +45,7 @@ func (c *ovnClient) CreatePeerRouterPort(localRouter, remoteRouter, localRouterP
 
 	ops, err := c.CreateLogicalRouterPortOp(lrp, localRouter)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -57,6 +59,7 @@ func (c *ovnClient) CreatePeerRouterPort(localRouter, remoteRouter, localRouterP
 func (c *ovnClient) UpdateLogicalRouterPortRA(lrpName, ipv6RAConfigsStr string, enableIPv6RA bool) error {
 	lrp, err := c.GetLogicalRouterPort(lrpName, false)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -84,6 +87,7 @@ func (c *ovnClient) UpdateLogicalRouterPortOptions(lrpName string, options map[s
 
 	lrp, err := c.GetLogicalRouterPort(lrpName, false)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -109,6 +113,7 @@ func (c *ovnClient) UpdateLogicalRouterPort(lrp *ovnnb.LogicalRouterPort, fields
 
 	op, err := c.Where(lrp).Update(lrp, fields...)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for updating logical router port %s: %v", lrp.Name, err)
 	}
 
@@ -123,6 +128,7 @@ func (c *ovnClient) UpdateLogicalRouterPort(lrp *ovnnb.LogicalRouterPort, fields
 func (c *ovnClient) CreateLogicalRouterPort(lrName string, lrpName, mac string, networks []string) error {
 	exists, err := c.LogicalRouterPortExists(lrpName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -144,6 +150,7 @@ func (c *ovnClient) CreateLogicalRouterPort(lrName string, lrpName, mac string, 
 
 	op, err := c.CreateLogicalRouterPortOp(lrp, lrName)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for creating logical router port %s: %v", lrp.Name, err)
 	}
 
@@ -158,6 +165,7 @@ func (c *ovnClient) CreateLogicalRouterPort(lrName string, lrpName, mac string, 
 func (c *ovnClient) DeleteLogicalRouterPorts(externalIDs map[string]string, filter func(lrp *ovnnb.LogicalRouterPort) bool) error {
 	lrpList, err := c.ListLogicalRouterPorts(externalIDs, filter)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("list logical router ports: %v", err)
 	}
 
@@ -165,6 +173,7 @@ func (c *ovnClient) DeleteLogicalRouterPorts(externalIDs map[string]string, filt
 	for _, lrp := range lrpList {
 		op, err := c.DeleteLogicalRouterPortOp(lrp.Name)
 		if err != nil {
+			klog.Error(err)
 			return fmt.Errorf("generate operations for deleting logical router port %s: %v", lrp.Name, err)
 		}
 		ops = append(ops, op...)
@@ -181,6 +190,7 @@ func (c *ovnClient) DeleteLogicalRouterPorts(externalIDs map[string]string, filt
 func (c *ovnClient) DeleteLogicalRouterPort(lrpName string) error {
 	ops, err := c.DeleteLogicalRouterPortOp(lrpName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -276,12 +286,14 @@ func (c *ovnClient) CreateLogicalRouterPortOp(lrp *ovnnb.LogicalRouterPort, lrNa
 	/* create logical router port */
 	lrpCreateOp, err := c.Create(lrp)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for creating logical router port %s: %v", lrp.Name, err)
 	}
 
 	/* add logical router port to logical router*/
 	lrpAddOp, err := c.LogicalRouterUpdatePortOp(lrName, lrp.UUID, ovsdb.MutateOperationInsert)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -296,6 +308,7 @@ func (c *ovnClient) CreateLogicalRouterPortOp(lrp *ovnnb.LogicalRouterPort, lrNa
 func (c *ovnClient) DeleteLogicalRouterPortOp(lrpName string) ([]ovsdb.Operation, error) {
 	lrp, err := c.GetLogicalRouterPort(lrpName, true)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("get logical router port %s when generate delete operations: %v", lrpName, err)
 	}
 
@@ -313,6 +326,7 @@ func (c *ovnClient) DeleteLogicalRouterPortOp(lrpName string) ([]ovsdb.Operation
 func (c *ovnClient) LogicalRouterPortOp(lrpName string, mutationsFunc ...func(lrp *ovnnb.LogicalRouterPort) *model.Mutation) ([]ovsdb.Operation, error) {
 	lrp, err := c.GetLogicalRouterPort(lrpName, false)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -332,6 +346,7 @@ func (c *ovnClient) LogicalRouterPortOp(lrpName string, mutationsFunc ...func(lr
 
 	ops, err := c.ovnNbClient.Where(lrp).Mutate(lrp, mutations...)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for mutating logical router port %s: %v", lrpName, err)
 	}
 
@@ -373,6 +388,7 @@ func logicalRouterPortFilter(externalIDs map[string]string, filter func(lrp *ovn
 func (c *ovnClient) AddLogicalRouterPort(lr, name, mac, networks string) error {
 	router, err := c.GetLogicalRouter(lr, false)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -394,6 +410,7 @@ func (c *ovnClient) AddLogicalRouterPort(lr, name, mac, networks string) error {
 
 	createOps, err := c.ovnNbClient.Create(lrp)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	ops = append(ops, createOps...)
@@ -408,6 +425,7 @@ func (c *ovnClient) AddLogicalRouterPort(lr, name, mac, networks string) error {
 			},
 		)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	ops = append(ops, mutationOps...)

--- a/pkg/ovs/ovn-nb-logical_switch.go
+++ b/pkg/ovs/ovn-nb-logical_switch.go
@@ -65,6 +65,7 @@ func (c *ovnClient) CreateLogicalSwitch(lsName, lrName, cidrBlock, gateway strin
 func (c *ovnClient) CreateBareLogicalSwitch(lsName string) error {
 	exist, err := c.LogicalSwitchExists(lsName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -80,6 +81,7 @@ func (c *ovnClient) CreateBareLogicalSwitch(lsName string) error {
 
 	op, err := c.ovnNbClient.Create(ls)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for creating logical switch %s: %v", lsName, err)
 	}
 
@@ -94,15 +96,18 @@ func (c *ovnClient) CreateBareLogicalSwitch(lsName string) error {
 func (c *ovnClient) LogicalSwitchAddPort(lsName, lspName string) error {
 	lsp, err := c.GetLogicalSwitchPort(lspName, false)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get logical switch port %s when logical switch add port: %v", lspName, err)
 	}
 
 	ops, err := c.LogicalSwitchUpdatePortOp(lsName, lsp.UUID, ovsdb.MutateOperationInsert)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for logical switch %s add port %s: %v", lsName, lspName, err)
 	}
 
 	if err := c.Transact("lsp-add", ops); err != nil {
+		klog.Error(err)
 		return fmt.Errorf("add port %s to logical switch %s: %v", lspName, lsName, err)
 	}
 
@@ -113,11 +118,13 @@ func (c *ovnClient) LogicalSwitchAddPort(lsName, lspName string) error {
 func (c *ovnClient) LogicalSwitchDelPort(lsName, lspName string) error {
 	lsp, err := c.GetLogicalSwitchPort(lspName, false)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get logical switch port %s when logical switch del port: %v", lspName, err)
 	}
 
 	ops, err := c.LogicalSwitchUpdatePortOp(lsName, lsp.UUID, ovsdb.MutateOperationDelete)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for logical switch %s del port %s: %v", lsName, lspName, err)
 	}
 
@@ -139,6 +146,7 @@ func (c *ovnClient) LogicalSwitchUpdateLoadBalancers(lsName string, op ovsdb.Mut
 	for _, lbName := range lbNames {
 		lb, err := c.GetLoadBalancer(lbName, true)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 
@@ -150,6 +158,7 @@ func (c *ovnClient) LogicalSwitchUpdateLoadBalancers(lsName string, op ovsdb.Mut
 
 	ops, err := c.LogicalSwitchUpdateLoadBalancerOp(lsName, lbUUIDs, op)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for logical switch %s update lbs %v: %v", lsName, lbNames, err)
 	}
 
@@ -165,6 +174,7 @@ func (c *ovnClient) LogicalSwitchUpdateLoadBalancers(lsName string, op ovsdb.Mut
 func (c *ovnClient) DeleteLogicalSwitch(lsName string) error {
 	op, err := c.DeleteLogicalSwitchOp(lsName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -318,6 +328,7 @@ func (c *ovnClient) logicalSwitchUpdateAclOp(lsName string, aclUUIDs []string, o
 func (c *ovnClient) LogicalSwitchOp(lsName string, mutationsFunc ...func(ls *ovnnb.LogicalSwitch) *model.Mutation) ([]ovsdb.Operation, error) {
 	ls, err := c.GetLogicalSwitch(lsName, false)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("get logical switch %s when generate mutate operations: %v", lsName, err)
 	}
 
@@ -337,6 +348,7 @@ func (c *ovnClient) LogicalSwitchOp(lsName string, mutationsFunc ...func(ls *ovn
 
 	ops, err := c.ovnNbClient.Where(ls).Mutate(ls, mutations...)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for mutating logical switch %s: %v", lsName, err)
 	}
 
@@ -347,6 +359,7 @@ func (c *ovnClient) LogicalSwitchOp(lsName string, mutationsFunc ...func(ls *ovn
 func (c *ovnClient) DeleteLogicalSwitchOp(lsName string) ([]ovsdb.Operation, error) {
 	ls, err := c.GetLogicalSwitch(lsName, true)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("get logical switch %s: %v", lsName, err)
 	}
 
@@ -357,6 +370,7 @@ func (c *ovnClient) DeleteLogicalSwitchOp(lsName string) ([]ovsdb.Operation, err
 
 	op, err := c.Where(ls).Delete()
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for deleting logical switch %s: %v", lsName, err)
 	}
 

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/scylladb/go-set/strset"
+	"k8s.io/klog/v2"
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -18,6 +19,7 @@ import (
 func (c *ovnClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName, namespace string, portSecurity bool, securityGroups, vips string, enableDHCP bool, dhcpOptions *DHCPOptionsUUIDs, vpc string) error {
 	exist, err := c.LogicalSwitchPortExists(lspName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -88,6 +90,7 @@ func (c *ovnClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName, n
 
 	ops, err := c.CreateLogicalSwitchPortOp(lsp, lsName)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for creating logical switch port %s: %v", lspName, err)
 	}
 
@@ -102,6 +105,7 @@ func (c *ovnClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName, n
 func (c *ovnClient) CreateLocalnetLogicalSwitchPort(lsName, lspName, provider string, vlanID int) error {
 	exist, err := c.LogicalSwitchPortExists(lspName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -127,6 +131,7 @@ func (c *ovnClient) CreateLocalnetLogicalSwitchPort(lsName, lspName, provider st
 
 	ops, err := c.CreateLogicalSwitchPortOp(lsp, lsName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -146,6 +151,7 @@ func (c *ovnClient) CreateVirtualLogicalSwitchPorts(lsName string, ips ...string
 
 		exist, err := c.LogicalSwitchPortExists(lspName)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 
@@ -165,6 +171,7 @@ func (c *ovnClient) CreateVirtualLogicalSwitchPorts(lsName string, ips ...string
 
 		op, err := c.CreateLogicalSwitchPortOp(lsp, lsName)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 
@@ -182,6 +189,7 @@ func (c *ovnClient) CreateVirtualLogicalSwitchPorts(lsName string, ips ...string
 func (c *ovnClient) CreateBareLogicalSwitchPort(lsName, lspName, ip, mac string) error {
 	exist, err := c.LogicalSwitchPortExists(lspName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -204,6 +212,7 @@ func (c *ovnClient) CreateBareLogicalSwitchPort(lsName, lspName, ip, mac string)
 
 	ops, err := c.CreateLogicalSwitchPortOp(lsp, lsName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -222,6 +231,7 @@ func (c *ovnClient) SetLogicalSwitchPortVirtualParents(lsName, parents string, i
 
 		lsp, err := c.GetLogicalSwitchPort(lspName, true)
 		if err != nil {
+			klog.Error(err)
 			return fmt.Errorf("get logical switch port %s: %v", lspName, err)
 		}
 
@@ -232,6 +242,7 @@ func (c *ovnClient) SetLogicalSwitchPortVirtualParents(lsName, parents string, i
 
 		op, err := c.UpdateLogicalSwitchPortOp(lsp, &lsp.Options)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 
@@ -259,6 +270,7 @@ func (c *ovnClient) SetLogicalSwitchPortArpProxy(lspName string, enableArpProxy 
 
 	op, err := c.UpdateLogicalSwitchPortOp(lsp, &lsp.Options)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	if err := c.Transact("lsp-update", op); err != nil {
@@ -271,6 +283,7 @@ func (c *ovnClient) SetLogicalSwitchPortArpProxy(lspName string, enableArpProxy 
 func (c *ovnClient) SetLogicalSwitchPortSecurity(portSecurity bool, lspName, mac, ips, vips string) error {
 	lsp, err := c.GetLogicalSwitchPort(lspName, false)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get logical switch port %s: %v", lspName, err)
 	}
 
@@ -315,6 +328,7 @@ func (c *ovnClient) SetLogicalSwitchPortSecurity(portSecurity bool, lspName, mac
 func (c *ovnClient) SetLogicalSwitchPortExternalIds(lspName string, externalIds map[string]string) error {
 	lsp, err := c.GetLogicalSwitchPort(lspName, false)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get logical switch port %s: %v", lspName, err)
 	}
 
@@ -396,6 +410,7 @@ func (c *ovnClient) SetLogicalSwitchPortsSecurityGroup(sgName string, op string)
 	externalIds := map[string]string{associatedSgKey: associated}
 	lsps, err := c.ListNormalLogicalSwitchPorts(true, externalIds)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("list logical switch ports with external_ids %v: %v", externalIds, err)
 	}
 
@@ -413,6 +428,7 @@ func (c *ovnClient) SetLogicalSwitchPortsSecurityGroup(sgName string, op string)
 func (c *ovnClient) EnablePortLayer2forward(lspName string) error {
 	lsp, err := c.GetLogicalSwitchPort(lspName, false)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get logical switch port %s: %v", lspName, err)
 	}
 
@@ -433,6 +449,7 @@ func (c *ovnClient) SetLogicalSwitchPortVlanTag(lspName string, vlanID int) erro
 
 	lsp, err := c.GetLogicalSwitchPort(lspName, false)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("get logical switch port %s: %v", lspName, err)
 	}
 
@@ -461,6 +478,7 @@ func (c *ovnClient) UpdateLogicalSwitchPort(lsp *ovnnb.LogicalSwitchPort, fields
 
 	op, err := c.Where(lsp).Update(lsp, fields...)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("generate operations for updating logical switch port %s: %v", lsp.Name, err)
 	}
 
@@ -475,6 +493,7 @@ func (c *ovnClient) UpdateLogicalSwitchPort(lsp *ovnnb.LogicalSwitchPort, fields
 func (c *ovnClient) DeleteLogicalSwitchPort(lspName string) error {
 	ops, err := c.DeleteLogicalSwitchPortOp(lspName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -506,6 +525,7 @@ func (c *ovnClient) ListNormalLogicalSwitchPorts(needVendorFilter bool, external
 		return lsp.Type == ""
 	})
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("list logical switch ports: %v", err)
 	}
 
@@ -563,12 +583,14 @@ func (c *ovnClient) CreateLogicalSwitchPortOp(lsp *ovnnb.LogicalSwitchPort, lsNa
 	/* create logical switch port */
 	lspCreateOp, err := c.Create(lsp)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("generate operations for creating logical switch port %s: %v", lsp.Name, err)
 	}
 
 	/* add logical switch port to logical switch*/
 	lspAddOp, err := c.LogicalSwitchUpdatePortOp(lsName, lsp.UUID, ovsdb.MutateOperationInsert)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -583,6 +605,7 @@ func (c *ovnClient) CreateLogicalSwitchPortOp(lsp *ovnnb.LogicalSwitchPort, lsNa
 func (c *ovnClient) DeleteLogicalSwitchPortOp(lspName string) ([]ovsdb.Operation, error) {
 	lsp, err := c.GetLogicalSwitchPort(lspName, true)
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("get logical switch port %s when generate delete operations: %v", lspName, err)
 	}
 

--- a/pkg/ovs/ovn-nb-port_group.go
+++ b/pkg/ovs/ovn-nb-port_group.go
@@ -16,6 +16,7 @@ import (
 func (c *ovnClient) CreatePortGroup(pgName string, externalIDs map[string]string) error {
 	exist, err := c.PortGroupExists(pgName)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -61,6 +62,7 @@ func (c *ovnClient) PortGroupSetPorts(pgName string, ports []string) error {
 	for _, port := range ports {
 		lsp, err := c.GetLogicalSwitchPort(port, true)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 		if lsp != nil {
@@ -113,6 +115,7 @@ func (c *ovnClient) PortGroupUpdatePorts(pgName string, op ovsdb.Mutator, lspNam
 	for _, lspName := range lspNames {
 		lsp, err := c.GetLogicalSwitchPort(lspName, true)
 		if err != nil {
+			klog.Error(err)
 			return err
 		}
 
@@ -147,6 +150,7 @@ func (c *ovnClient) DeletePortGroup(pgName string) error {
 
 	op, err := c.Where(pg).Delete()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 

--- a/pkg/ovs/ovn-nb_global.go
+++ b/pkg/ovs/ovn-nb_global.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"k8s.io/klog/v2"
 )
 
 func (c *ovnClient) CreateNbGlobal(nbGlobal *ovnnb.NBGlobal) error {
@@ -21,11 +22,13 @@ func (c *ovnClient) CreateNbGlobal(nbGlobal *ovnnb.NBGlobal) error {
 func (c *ovnClient) DeleteNbGlobal() error {
 	nbGlobal, err := c.GetNbGlobal()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
 	op, err := c.Where(nbGlobal).Delete()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
@@ -44,6 +47,7 @@ func (c *ovnClient) GetNbGlobal() (*ovnnb.NBGlobal, error) {
 	}).List(ctx, &nbGlobalList)
 
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("list nbGlobal: %v", err)
 	}
 

--- a/pkg/ovs/ovn-sbctl.go
+++ b/pkg/ovs/ovn-sbctl.go
@@ -57,6 +57,7 @@ func (c LegacyClient) GetVersion() (string, error) {
 	}
 	output, err := c.ovnSbCommand("--version")
 	if err != nil {
+		klog.Error(err)
 		return "", fmt.Errorf("failed to get version,%v", err)
 	}
 	lines := strings.Split(output, "\n")
@@ -69,6 +70,7 @@ func (c LegacyClient) GetVersion() (string, error) {
 func (c LegacyClient) DeleteChassisByNode(node string) error {
 	chassis, err := c.GetChassis(node)
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("failed to get node chassis %s, %v", node, err)
 	}
 	if chassis == "" {
@@ -81,6 +83,7 @@ func (c LegacyClient) DeleteChassisByNode(node string) error {
 func (c LegacyClient) DeleteChassisByName(chassisName string) error {
 	ovnVersion, err := c.GetVersion()
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("failed to get ovn version, %v", err)
 	}
 
@@ -97,11 +100,13 @@ func (c LegacyClient) DeleteChassisByName(chassisName string) error {
 func (c LegacyClient) GetChassis(node string) (string, error) {
 	output, err := c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("external_ids:node=%s", node))
 	if err != nil {
+		klog.Error(err)
 		return "", fmt.Errorf("failed to find node chassis %s, %v", node, err)
 	}
 	if len(output) == 0 {
 		output, err = c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("hostname=%s", node))
 		if err != nil {
+			klog.Error(err)
 			return "", fmt.Errorf("failed to find node chassis %s, %v", node, err)
 		}
 	}
@@ -111,6 +116,7 @@ func (c LegacyClient) GetChassis(node string) (string, error) {
 func (c LegacyClient) ChassisExist(chassisName string) (bool, error) {
 	output, err := c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("name=%s", chassisName))
 	if err != nil {
+		klog.Error(err)
 		return false, fmt.Errorf("failed to find node chassis %s, %v", chassisName, err)
 	}
 	if len(output) == 0 {
@@ -122,6 +128,7 @@ func (c LegacyClient) ChassisExist(chassisName string) (bool, error) {
 func (c LegacyClient) InitChassisNodeTag(chassisName string, nodeName string) error {
 	_, err := c.ovnSbCommand("set", "chassis", chassisName, fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName), fmt.Sprintf("external_ids:node=%s", nodeName))
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("failed to set chassis external_ids, %v", err)
 	}
 	return nil
@@ -131,6 +138,7 @@ func (c LegacyClient) InitChassisNodeTag(chassisName string, nodeName string) er
 func (c LegacyClient) GetAllChassis() ([]string, error) {
 	output, err := c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name", "find", "chassis", fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName))
 	if err != nil {
+		klog.Error(err)
 		return nil, fmt.Errorf("failed to find node chassis, %v", err)
 	}
 	lines := strings.Split(output, "\n")

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -40,6 +40,7 @@ func NamedUUID() string {
 func NewNbClient(addr string) (client.Client, error) {
 	dbModel, err := ovnnb.FullDatabaseModel()
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -62,10 +63,12 @@ func NewNbClient(addr string) (client.Client, error) {
 	if ssl {
 		cert, err := tls.LoadX509KeyPair("/var/run/tls/cert", "/var/run/tls/key")
 		if err != nil {
+			klog.Error(err)
 			return nil, fmt.Errorf("failed to load x509 cert key pair: %v", err)
 		}
 		caCert, err := os.ReadFile("/var/run/tls/cacert")
 		if err != nil {
+			klog.Error(err)
 			return nil, fmt.Errorf("failed to read ca cert: %v", err)
 		}
 
@@ -83,6 +86,7 @@ func NewNbClient(addr string) (client.Client, error) {
 
 	c, err := client.NewOVSDBClient(dbModel, options...)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 

--- a/pkg/pinger/ovn.go
+++ b/pkg/pinger/ovn.go
@@ -39,11 +39,13 @@ func checkPortBindings(config *Configuration) error {
 	klog.Infof("start to check port binding")
 	ovsBindings, err := checkOvsBindings()
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
 	sbBindings, err := checkSBBindings(config)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	klog.Infof("port in sb is %v", sbBindings)

--- a/pkg/tproxy/tproxy_tcp_linux.go
+++ b/pkg/tproxy/tproxy_tcp_linux.go
@@ -34,6 +34,7 @@ func (listener *Listener) Accept() (net.Conn, error) {
 func (listener *Listener) AcceptTProxy() (*Conn, error) {
 	tcpConn, err := listener.base.(*net.TCPListener).AcceptTCP()
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -64,6 +65,7 @@ func ListenTCP(network string, laddr *net.TCPAddr) (net.Listener, error) {
 func listenTCP(device, network string, laddr *net.TCPAddr) (net.Listener, error) {
 	listener, err := net.ListenTCP(network, laddr)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
@@ -153,21 +155,25 @@ func dialTCP(device string, laddr, raddr *net.TCPAddr, dontAssumeRemote bool, is
 
 	remoteSocketAddress, err := tcpAddrToSocketAddr(raddr)
 	if err != nil {
+		klog.Error(err)
 		return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("build destination socket address: %s", err)}
 	}
 
 	localSocketAddress, err := tcpAddrToSocketAddr(laddr)
 	if err != nil {
+		klog.Error(err)
 		return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("build local socket address: %s", err)}
 	}
 
 	fileDescriptor, err := syscall.Socket(tcpAddrFamily("tcp", raddr, laddr), syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
 	if err != nil {
+		klog.Error(err)
 		return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("socket open: %s", err)}
 	}
 
 	if device != "" {
 		if err = syscall.BindToDevice(int(fileDescriptor), device); err != nil {
+			klog.Error(err)
 			return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("set socket option: SO_BINDTODEVICE(%s): %s", device, err)}
 		}
 	}
@@ -176,6 +182,7 @@ func dialTCP(device string, laddr, raddr *net.TCPAddr, dontAssumeRemote bool, is
 		if err := syscall.Close(fileDescriptor); err != nil {
 			klog.Errorf("fileDescriptor %v Close err: %v ", fileDescriptor, err)
 		}
+		klog.Error(err)
 		return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("set socket option: SO_REUSEADDR: %s", err)}
 	}
 
@@ -183,6 +190,7 @@ func dialTCP(device string, laddr, raddr *net.TCPAddr, dontAssumeRemote bool, is
 		if err := syscall.Close(fileDescriptor); err != nil {
 			klog.Errorf("fileDescriptor %v Close err: %v ", fileDescriptor, err)
 		}
+		klog.Error(err)
 		return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("set socket option: IP_TRANSPARENT: %s", err)}
 	}
 
@@ -190,6 +198,7 @@ func dialTCP(device string, laddr, raddr *net.TCPAddr, dontAssumeRemote bool, is
 		if err := syscall.Close(fileDescriptor); err != nil {
 			klog.Errorf("fileDescriptor %v Close err: %v ", fileDescriptor, err)
 		}
+		klog.Error(err)
 		return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("set socket option: SO_NONBLOCK: %s", err)}
 	}
 
@@ -198,6 +207,7 @@ func dialTCP(device string, laddr, raddr *net.TCPAddr, dontAssumeRemote bool, is
 			if err := syscall.Close(fileDescriptor); err != nil {
 				klog.Errorf("fileDescriptor %v Close err: %v ", fileDescriptor, err)
 			}
+			klog.Error(err)
 			return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("socket bind: %s", err)}
 		}
 	}
@@ -206,6 +216,7 @@ func dialTCP(device string, laddr, raddr *net.TCPAddr, dontAssumeRemote bool, is
 		if err := syscall.Close(fileDescriptor); err != nil {
 			klog.Errorf("fileDescriptor %v Close err: %v ", fileDescriptor, err)
 		}
+		klog.Error(err)
 		return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("socket connect: %s", err)}
 	}
 
@@ -221,7 +232,7 @@ func dialTCP(device string, laddr, raddr *net.TCPAddr, dontAssumeRemote bool, is
 		if err := syscall.Close(fileDescriptor); err != nil {
 			klog.Errorf("fileDescriptor %v Close err: %v ", fileDescriptor, err)
 		}
-
+		klog.Error(err)
 		return nil, &net.OpError{Op: "dial", Err: fmt.Errorf("convert file descriptor to connection: %s", err)}
 	}
 

--- a/pkg/util/arp.go
+++ b/pkg/util/arp.go
@@ -93,16 +93,19 @@ func ArpDetectIPConflict(nic, ip string, mac net.HardwareAddr) (net.HardwareAddr
 	tha := net.HardwareAddr{0, 0, 0, 0, 0, 0}
 	pkt, err := arp.NewPacket(arp.OperationRequest, mac, spa, tha, tpa)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
 	ifi, err := net.InterfaceByName(nic)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 
 	client, err := arp.Dial(ifi)
 	if err != nil {
+		klog.Error(err)
 		return nil, err
 	}
 	defer client.Close()
@@ -210,11 +213,13 @@ func AnnounceArpAddress(nic, ip string, mac net.HardwareAddr, announceNum int, a
 	klog.Infof("announce arp address nic %s , ip %s, with mac %v ", nic, ip, mac)
 	netInterface, err := net.InterfaceByName(nic)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 
 	client, err := arp.Dial(netInterface)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	defer client.Close()
@@ -227,6 +232,7 @@ func AnnounceArpAddress(nic, ip string, mac net.HardwareAddr, announceNum int, a
 	tha := net.HardwareAddr{0, 0, 0, 0, 0, 0}
 	pkt, err := arp.NewPacket(arp.OperationRequest, mac, tpa, tha, tpa)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -574,6 +574,7 @@ func UDPConnectivityCheck(address string) error {
 
 	conn, err := net.DialUDP("udp", nil, udpAddr)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
add log


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6005137</samp>

This pull request improves the error handling and logging of various functions in the kube-ovn controller and daemon components. It adds log messages to report errors that occur when interacting with the informer cache, the ovn network, or the network resources. It also adds or modifies return statements to propagate errors to the callers. The purpose of these changes is to enhance the debugging and monitoring capabilities of the kube-ovn system. The affected files are `pkg/controller/*.go` and `cmd/daemon/cniserver.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6005137</samp>

> _`Log the errors`, `report the failures`_
> _Don't let the network fall into the dark_
> _`Handle the events`, `patch the resources`_
> _Fight for the ovn and the kubeovn spark_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6005137</samp>

*  Add log messages to report errors in various functions related to handling pod, service, subnet, and other resources ([link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR130), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R262), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R275), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-e446ff04750bbbe87ec6cf1387960a29d56757d84784b18f2814a6e0be5fb528R103), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-e446ff04750bbbe87ec6cf1387960a29d56757d84784b18f2814a6e0be5fb528R112), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-10f6d73ec07300b657a0bc498905b8cf89fb4ef5fe4945b169f345489d8c024aL39-R39), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-10f6d73ec07300b657a0bc498905b8cf89fb4ef5fe4945b169f345489d8c024aL47-R50), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R398), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R409), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L428-R435), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988R89), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L266-R272), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988R594), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988R671), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988R753), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-1ce54ed91b0303d71ec6de68e93ced446ee7b2ba23b8d0cfd282c7f7a075c072R46), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-1ce54ed91b0303d71ec6de68e93ced446ee7b2ba23b8d0cfd282c7f7a075c072R55), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1R186), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1R207), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1R323), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1R351), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1R465), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1R503), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1R571), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceR220), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceR285), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceR321), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceR390), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceR520), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459R198), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459R410), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459R435), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459R472), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459R517), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eR180), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eR276), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eR381), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eR442), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R490), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R496), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R562), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R618), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R670), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R818), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R942), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R949), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1040), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1241), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1539-R1554), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-2d73329e26ec408ad10253e5352451fb5d5db2bac81ebb1ead0e546e8df7e061L225-R225), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-2d73329e26ec408ad10253e5352451fb5d5db2bac81ebb1ead0e546e8df7e061R233), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-2d73329e26ec408ad10253e5352451fb5d5db2bac81ebb1ead0e546e8df7e061R254), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-2d73329e26ec408ad10253e5352451fb5d5db2bac81ebb1ead0e546e8df7e061R285), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-2960c0e4e70cbdd9f919fdbb4ededdc0afc2afc91ae80ef40dacad94560d285bR220), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-2960c0e4e70cbdd9f919fdbb4ededdc0afc2afc91ae80ef40dacad94560d285bR259), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662R195), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662R233), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662R242), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662R262), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662R400), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-8aa74956ce96fc812f32fcad39869a83b2fe26b5cf48958c78e41c29a56ca662R519), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8R209), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8R248), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R239), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R307), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R321), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R443), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R457), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R497), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R513), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-ddee62564b10db25f89355fdeef7a708ee6a588ea55c2d86531c36e19ca70d2eR190), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-ddee62564b10db25f89355fdeef7a708ee6a588ea55c2d86531c36e19ca70d2eR271), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R272), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R340), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R370), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R378), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R397), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R668), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R675), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R854), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1509), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1566), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1945), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1967), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1976), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2014), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2010-R2029), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2041), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2049), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2105), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2619))
* Modify error handling in `handleAddPodAnnotatedIptablesEip` function in `pkg/controller/pod_iptables_eip.go` to use log message instead of `utilruntime.HandleError` function ([link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-2d73329e26ec408ad10253e5352451fb5d5db2bac81ebb1ead0e546e8df7e061L225-R225))
* Add return statements to `RemoveOldChassisInSbDB` function in `pkg/controller/ovn-ic.go` to propagate errors when getting or deleting chassis records from ovn southbound database ([link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR412), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR418), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR424))
* Modify log messages in `syncExternalVpc` function in `pkg/controller/external_vpc.go` to use error level and include error message when updating or deleting vpc fails ([link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-10f6d73ec07300b657a0bc498905b8cf89fb4ef5fe4945b169f345489d8c024aL39-R39), [link](https://github.com/kubeovn/kube-ovn/pull/3098/files?diff=unified&w=0#diff-10f6d73ec07300b657a0bc498905b8cf89fb4ef5fe4945b169f345489d8c024aL47-R50))