### PR TITLE
fix u2o policy route allocate too many openflows cause oom

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2515,13 +2515,13 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			U2OexcludeIPAs = u2oExcludeIp6Ag
 		}
 
-		match1 := fmt.Sprintf("%s.dst == %s && %s.dst != $%s", ipSuffix, cidrBlock, ipSuffix, U2OexcludeIPAs)
+		match1 := fmt.Sprintf("%s.dst == %s", ipSuffix, cidrBlock)
 		match2 := fmt.Sprintf("%s.dst == $%s && %s.src == %s", ipSuffix, U2OexcludeIPAs, ipSuffix, cidrBlock)
 		match3 := fmt.Sprintf("%s.src == %s", ipSuffix, cidrBlock)
 
 		/*
 			policy1:
-			prio 31000 match: "ip4.dst == underlay subnet cidr && ip4.dst != node ips"  action: allow
+			prio 29400 match: "ip4.dst == underlay subnet cidr"                         action: allow
 
 			policy2:
 			prio 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reroute physical gw
@@ -2536,7 +2536,7 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 		action := ovnnb.LogicalRouterPolicyActionAllow
 		if subnet.Spec.Vpc == c.config.ClusterRouter {
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match1, action)
-			if err := c.ovnClient.AddLogicalRouterPolicy(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match1, action, nil, externalIDs); err != nil {
+			if err := c.ovnClient.AddLogicalRouterPolicy(subnet.Spec.Vpc, util.U2OSubnetPolicyPriority, match1, action, nil, externalIDs); err != nil {
 				klog.Errorf("failed to add u2o interconnection policy1 for subnet %s %v", subnet.Name, err)
 				return err
 			}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -187,6 +187,7 @@ const (
 	OvnFip      = "ovn"
 	IptablesFip = "iptables"
 
+	U2OSubnetPolicyPriority     = 29400
 	GatewayRouterPolicyPriority = 29000
 	OvnICPolicyPriority         = 29500
 	NodeRouterPolicyPriority    = 30000

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -785,7 +785,7 @@ func checkU2OItems(f *framework.Framework, subnet *apiv1.Subnet, underlayPod, ov
 		asName := strings.Replace(fmt.Sprintf("%s.u2o_exclude_ip.%s", subnet.Name, protocolStr), "-", ".", -1)
 		if !isU2OCustomVpc {
 			ginkgo.By(fmt.Sprintf("checking underlay subnet's policy1 route %s", protocolStr))
-			hitPolicyStr := fmt.Sprintf("%d %s.dst == %s && %s.dst != $%s allow", util.SubnetRouterPolicyPriority, protocolStr, cidr, protocolStr, asName)
+			hitPolicyStr := fmt.Sprintf("%d %s.dst == %s allow", util.U2OSubnetPolicyPriority, protocolStr, cidr)
 			checkPolicy(hitPolicyStr, subnet.Spec.U2OInterconnection, subnet.Spec.Vpc)
 
 			ginkgo.By(fmt.Sprintf("checking underlay subnet's policy2 route %s", protocolStr))


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes 

when turn on the u2o switch, the policy route below will cause oom, when addresses in the address set are more than 8 , or  the underlay subnet's mask length is big,  it will cause the ovs to generate many OpenFlow tables.


![image](https://github.com/kubeovn/kube-ovn/assets/47097611/efde013f-3735-4b96-a92b-25dde6c6735a)

The reason is that when ovn generates the flow table, it divides dst 192.168.0.0/16 into addresses to generate the openflow flow table. And it seems that the same address may form various rules with different masks.



### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough