### PR TITLE
distinguish nat ip for central subnet with ecmp and active-standby

### DIFF
--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -239,7 +239,11 @@ func (c *Controller) getEgressNatIpByNode(nodeName string) (map[string]string, e
 		for _, cidr := range strings.Split(subnet.Spec.CIDRBlock, ",") {
 			for _, gw := range strings.Split(subnet.Spec.GatewayNode, ",") {
 				if strings.Contains(gw, ":") && util.GatewayContains(gw, nodeName) && util.CheckProtocol(cidr) == util.CheckProtocol(strings.Split(gw, ":")[1]) {
-					subnetsNatIp[cidr] = strings.TrimSpace(strings.Split(gw, ":")[1])
+					if subnet.Spec.EnableEcmp {
+						subnetsNatIp[cidr] = strings.TrimSpace(strings.Split(gw, ":")[1])
+					} else if subnet.Status.ActivateGateway == nodeName {
+						subnetsNatIp[cidr] = strings.TrimSpace(strings.Split(gw, ":")[1])
+					}
 					break
 				}
 			}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 363760e</samp>

Improve gateway node logic for ecmp and active-standby modes. Add checks for `subnet.Spec.GatewayNode` and `subnet.Spec.Ecmp` in `gateway.go` before assigning nat ip.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 363760e</samp>

> _`ecmp` or active_
> _gateway decides `nat ip`_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 363760e</samp>

*  Add a condition to check ecmp or active gateway status before assigning nat ip ([link](https://github.com/kubeovn/kube-ovn/pull/3100/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L242-R246))