### PR TITLE
get all chassis once

### DIFF
--- a/pkg/ovs/ovn-sbctl.go
+++ b/pkg/ovs/ovn-sbctl.go
@@ -151,3 +151,23 @@ func (c LegacyClient) GetAllChassis() ([]string, error) {
 	}
 	return result, nil
 }
+
+// GetAllChassisMap return a map of chassis uuid : node name
+func (c LegacyClient) GetAllChassisMap() (map[string]string, error) {
+	output, err := c.ovnSbCommand("--format=csv", "--no-heading", "--data=bare", "--columns=name,hostname", "find", "chassis", fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find node chassis, %v", err)
+	}
+	lines := strings.Split(output, "\n")
+	result := make(map[string]string, len(lines))
+	for _, l := range lines {
+		if len(strings.TrimSpace(l)) == 0 {
+			continue
+		}
+		res := strings.Split(l, ",")
+		if len(res) == 2 {
+			result[res[0]] = res[1]
+		}
+	}
+	return result, nil
+}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

一次性拿到所有 chassis node

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8db356e</samp>

Optimize the sync of node chassis annotations with OVN southbound database. Add a new function to query all chassis nodes by vendor external id in `pkg/ovs/ovn-sbctl.go` and use it in `pkg/controller/init.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8db356e</samp>

> _`syncChassisAnnotation`_
> _Faster with one query_
> _Map of nodes and chassis_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8db356e</samp>

* Optimize the logic of syncing node chassis annotations with OVN southbound database ([link](https://github.com/kubeovn/kube-ovn/pull/3103/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L858-R880), [link](https://github.com/kubeovn/kube-ovn/pull/3103/files?diff=unified&w=0#diff-562d7a17619057b24d0d36932910d6c6cc55cccdad9031107677901c46f17accR154-R173))
  - Add a new function to query all chassis nodes by vendor external id in `ovn-sbctl.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3103/files?diff=unified&w=0#diff-562d7a17619057b24d0d36932910d6c6cc55cccdad9031107677901c46f17accR154-R173))
  - Use the new function to get a map of chassis uuid and node name in `init.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3103/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L858-R880))
  - Iterate over the nodes and check if the chassis name matches the node name in the map ([link](https://github.com/kubeovn/kube-ovn/pull/3103/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L858-R880))
  - Update the node tag in the chassis record if the names do not match ([link](https://github.com/kubeovn/kube-ovn/pull/3103/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L858-R880))
  - Reduce the number of ovn-sbctl calls and improve the performance of the syncChassisAnnotation function ([link](https://github.com/kubeovn/kube-ovn/pull/3103/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L858-R880))