### PR TITLE
return routes needed del or add

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -597,7 +597,7 @@ func diffStaticRoute(exist []*ovnnb.LogicalRouterStaticRoute, target []*kubeovnv
 	for _, item := range existRouteMap {
 		routeNeedDel = append(routeNeedDel, item)
 	}
-	return
+	return routeNeedDel, routeNeedAdd, nil
 }
 
 func getStaticRouteItemKey(item *kubeovnv1.StaticRoute) (key string) {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)
function ```diffStaticRoute``` did not return the "add or del" routes. 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f98e7ea</samp>

Fixed a bug in `diffStaticRoute` function that caused static route updates to be ignored. Enhanced the static route feature of kube-ovn network plugin.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f98e7ea</samp>

> _`diffStaticRoute`_
> _Returns slices and no error_
> _Fixes bug in fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f98e7ea</samp>

* Fix a bug in `diffStaticRoute` function that caused no routes to be updated ([link](https://github.com/kubeovn/kube-ovn/pull/3110/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL600-R600))