### PR TITLE
ovn: fix corrupted database file on start

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -23,7 +23,9 @@ RUN cd /usr/src/ && \
     # Add jitter parameter patch for netem qos
     curl -s https://github.com/kubeovn/ovs/commit/2eaaf89fbf3ee2172719ed10d045fd79900edc8e.patch | git apply && \
     # fix memory leak in qos
-    curl -s https://github.com/kubeovn/ovs/commit/6a4dd2f4b9311a227cc26fef7c398ae9b241311b.patch | git apply
+    curl -s https://github.com/kubeovn/ovs/commit/6a4dd2f4b9311a227cc26fef7c398ae9b241311b.patch | git apply && \
+    # ovsdb-tool: add command fix-cluster
+    curl -s https://github.com/kubeovn/ovs/commit/f52c239f5ded40b503e4d217f916b46ca413da4c.patch | git apply
 
 RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

```shell
root@kube-ovn-control-plane:~# ovsdb-tool check-cluster ovnnb_db.db
ovsdb-tool: syntax error: ovnnb_db.db: parse error at offset 65335 in header line ""
root@kube-ovn-control-plane:~# stat -c %s ovnnb_db.db
65419
root@kube-ovn-control-plane:~#
root@kube-ovn-control-plane:~# ovsdb-tool fix-cluster ovnnb_db.db
ovsdb-tool: syntax error: ovnnb_db.db: parse error at offset 65335 in header line ""
root@kube-ovn-control-plane:~# stat -c %s ovnnb_db.db
65335
root@kube-ovn-control-plane:~# ovsdb-tool check-cluster ovnnb_db.db
root@kube-ovn-control-plane:~#
```

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough