### PR TITLE
subnet: update status after deleting IP CR

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1122,7 +1122,8 @@ func (c *Controller) syncKubeOvnNet(cachedPod, pod *v1.Pod, podNets []*kubeovnNe
 
 	for _, portNeedDel := range portsNeedToDel {
 
-		if subnet, ok := c.ipam.Subnets[subnetUsedByPort[portNeedDel]]; ok {
+		subnet, ok := c.ipam.Subnets[subnetUsedByPort[portNeedDel]]
+		if ok {
 			subnet.ReleaseAddressWithNicName(podName, portNeedDel)
 		}
 
@@ -1135,6 +1136,9 @@ func (c *Controller) syncKubeOvnNet(cachedPod, pod *v1.Pod, podNets []*kubeovnNe
 				klog.Errorf("failed to delete ip %s, %v", portNeedDel, err)
 				return nil, err
 			}
+		}
+		if subnet != nil {
+			c.updateSubnetStatusQueue.Add(subnet.Name)
 		}
 	}
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes
- Tests

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9a4ee3</samp>

This pull request enhances the garbage collection and status update of logical switch ports and IP custom resources in the kube-ovn controller. It also adds a new e2e test case to verify the subnet status updates in the underlay network.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f9a4ee3</samp>

> _We're sailing on the kube-ovn net, oh aye, oh aye_
> _We're cleaning up the ports and IPs, oh aye, oh aye_
> _We're using `subnet` as a key, to update the status easily_
> _And we're testing it with IPv6, oh aye, oh aye_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9a4ee3</samp>

*  Add a new variable `subnet` to store the subnet name of the lsp in `markAndCleanLSP` and query the IP CR to get the subnet name ([link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R369-R373), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L734-R738))
*  Enqueue the subnet name to the `updateSubnetStatusQueue` after marking and cleaning the lsp, deleting the IP CR, or releasing the address for the port ([link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R384-R387), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619R746-R748), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1140-R1142))
*  Simplify the code in `syncKubeOvnNet` by assigning the subnet object to a variable ([link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1125-R1126))
*  Add a new function `waitSubnetStatusUpdate` to the `underlay` package to wait for the subnet status fields to match the expected values ([link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR50-R61))
*  Call the `waitSubnetStatusUpdate` function in the `TestUnderlayIPAM` test case to verify the subnet status updates after creating and deleting pods with different subnets and IP versions ([link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR536), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR568), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR586), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR614), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR632), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR674), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR715), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR734), [link](https://github.com/kubeovn/kube-ovn/pull/3113/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR752))