### PR TITLE
increase event burst size

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -249,7 +249,7 @@ type Controller struct {
 func Run(ctx context.Context, config *Configuration) {
 	utilruntime.Must(kubeovnv1.AddToScheme(scheme.Scheme))
 	klog.V(4).Info("Creating event broadcaster")
-	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster := record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{BurstSize: 100})
 	eventBroadcaster.StartLogging(klog.Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: config.KubeFactoryClient.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes event drop by increasing burst size from a default value 25 to 100.

Fixes occasinal e2e failure: https://github.com/kubeovn/kube-ovn/actions/runs/5764556601/job/15628773061

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 52b6a17</samp>

Increase event broadcaster burst size to reduce duplicate events. Modify `eventBroadcaster` creation in `pkg/controller/controller.go` to use a custom `CorrelatorOptions` with a higher `BurstSize` value.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 52b6a17</samp>

> _`eventBroadcaster`_
> _Bursts of a hundred events_
> _Autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 52b6a17</samp>

* Increase the event burst size to 100 to reduce duplicate events ([link](https://github.com/kubeovn/kube-ovn/pull/3115/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L252-R252))