### PR TITLE
some fixes in e2e

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -111,12 +111,12 @@ func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
 
 		if oldSubnet.Spec.GatewayType != newSubnet.Spec.GatewayType {
 			c.recorder.Eventf(newSubnet, v1.EventTypeNormal, "SubnetGatewayTypeChanged",
-				"subnet gateway type changes from %s to %s ", oldSubnet.Spec.GatewayType, newSubnet.Spec.GatewayType)
+				"subnet gateway type changes from %q to %q", oldSubnet.Spec.GatewayType, newSubnet.Spec.GatewayType)
 		}
 
 		if oldSubnet.Spec.GatewayNode != newSubnet.Spec.GatewayNode {
 			c.recorder.Eventf(newSubnet, v1.EventTypeNormal, "SubnetGatewayNodeChanged",
-				"gateway node changes from %s to %s ", oldSubnet.Spec.GatewayNode, newSubnet.Spec.GatewayNode)
+				"gateway node changes from %q to %q", oldSubnet.Spec.GatewayNode, newSubnet.Spec.GatewayNode)
 		}
 
 		c.addOrUpdateSubnetQueue.Add(key)

--- a/test/e2e/framework/daemonset.go
+++ b/test/e2e/framework/daemonset.go
@@ -22,6 +22,7 @@ import (
 type DaemonSetClient struct {
 	f *Framework
 	v1apps.DaemonSetInterface
+	namespace string
 }
 
 func (f *Framework) DaemonSetClient() *DaemonSetClient {
@@ -32,6 +33,7 @@ func (f *Framework) DaemonSetClientNS(namespace string) *DaemonSetClient {
 	return &DaemonSetClient{
 		f:                  f,
 		DaemonSetInterface: f.ClientSet.AppsV1().DaemonSets(namespace),
+		namespace:          namespace,
 	}
 }
 

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -29,6 +29,7 @@ import (
 type DeploymentClient struct {
 	f *Framework
 	v1apps.DeploymentInterface
+	namespace string
 }
 
 func (f *Framework) DeploymentClient() *DeploymentClient {
@@ -39,6 +40,7 @@ func (f *Framework) DeploymentClientNS(namespace string) *DeploymentClient {
 	return &DeploymentClient{
 		f:                   f,
 		DeploymentInterface: f.ClientSet.AppsV1().Deployments(namespace),
+		namespace:           namespace,
 	}
 }
 

--- a/test/e2e/framework/endpoints.go
+++ b/test/e2e/framework/endpoints.go
@@ -21,6 +21,7 @@ import (
 type EndpointsClient struct {
 	f *Framework
 	v1core.EndpointsInterface
+	namespace string
 }
 
 func (f *Framework) EndpointClient() *EndpointsClient {
@@ -31,6 +32,7 @@ func (f *Framework) EndpointsClientNS(namespace string) *EndpointsClient {
 	return &EndpointsClient{
 		f:                  f,
 		EndpointsInterface: f.ClientSet.CoreV1().Endpoints(namespace),
+		namespace:          namespace,
 	}
 }
 

--- a/test/e2e/framework/event.go
+++ b/test/e2e/framework/event.go
@@ -13,6 +13,7 @@ import (
 type EventClient struct {
 	f *Framework
 	typedcorev1.EventInterface
+	namespace string
 }
 
 func (f *Framework) EventClient() *EventClient {
@@ -23,6 +24,7 @@ func (f *Framework) EventClientNS(namespace string) *EventClient {
 	return &EventClient{
 		f:              f,
 		EventInterface: f.ClientSet.CoreV1().Events(namespace),
+		namespace:      namespace,
 	}
 }
 
@@ -30,7 +32,7 @@ func (f *Framework) EventClientNS(namespace string) *EventClient {
 func (c *EventClient) WaitToHaveEvent(kind, name, eventType, reason, sourceComponent, sourceHost string) []corev1.Event {
 	var result []corev1.Event
 	err := wait.PollUntilContextTimeout(context.Background(), poll, timeout, false, func(ctx context.Context) (bool, error) {
-		Logf("Waiting for %s %s/%s to have event %s/%s", kind, c.f.Namespace.Name, name, eventType, reason)
+		Logf("Waiting for %s %s/%s to have event %s/%s", kind, c.namespace, name, eventType, reason)
 		selector := fields.Set{
 			"involvedObject.kind": kind,
 			"involvedObject.name": name,

--- a/test/e2e/framework/network-policy.go
+++ b/test/e2e/framework/network-policy.go
@@ -18,6 +18,7 @@ import (
 type NetworkPolicyClient struct {
 	f *Framework
 	v1net.NetworkPolicyInterface
+	namespace string
 }
 
 func (f *Framework) NetworkPolicyClient() *NetworkPolicyClient {
@@ -28,6 +29,7 @@ func (f *Framework) NetworkPolicyClientNS(namespace string) *NetworkPolicyClient
 	return &NetworkPolicyClient{
 		f:                      f,
 		NetworkPolicyInterface: f.ClientSet.NetworkingV1().NetworkPolicies(namespace),
+		namespace:              namespace,
 	}
 }
 

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -17,6 +17,7 @@ import (
 type PodClient struct {
 	f *Framework
 	*e2epod.PodClient
+	namespace string
 }
 
 func (f *Framework) PodClient() *PodClient {
@@ -24,7 +25,7 @@ func (f *Framework) PodClient() *PodClient {
 }
 
 func (f *Framework) PodClientNS(namespace string) *PodClient {
-	return &PodClient{f, e2epod.PodClientNS(f.Framework, namespace)}
+	return &PodClient{f, e2epod.PodClientNS(f.Framework, namespace), namespace}
 }
 
 func (c *PodClient) GetPod(name string) *corev1.Pod {
@@ -75,12 +76,12 @@ func (c *PodClient) Patch(original, modified *corev1.Pod) *corev1.Pod {
 }
 
 func (c *PodClient) WaitForRunning(name string) {
-	err := e2epod.WaitTimeoutForPodRunningInNamespace(context.TODO(), c.f.ClientSet, name, c.f.Namespace.Name, timeout)
+	err := e2epod.WaitTimeoutForPodRunningInNamespace(context.TODO(), c.f.ClientSet, name, c.namespace, timeout)
 	ExpectNoError(err)
 }
 
 func (c *PodClient) WaitForNotFound(name string) {
-	err := e2epod.WaitForPodNotFoundInNamespace(context.TODO(), c.f.ClientSet, name, c.f.Namespace.Name, timeout)
+	err := e2epod.WaitForPodNotFoundInNamespace(context.TODO(), c.f.ClientSet, name, c.namespace, timeout)
 	ExpectNoError(err)
 }
 

--- a/test/e2e/framework/service.go
+++ b/test/e2e/framework/service.go
@@ -23,6 +23,7 @@ import (
 type ServiceClient struct {
 	f *Framework
 	v1core.ServiceInterface
+	namespace string
 }
 
 func (f *Framework) ServiceClient() *ServiceClient {
@@ -33,6 +34,7 @@ func (f *Framework) ServiceClientNS(namespace string) *ServiceClient {
 	return &ServiceClient{
 		f:                f,
 		ServiceInterface: f.ClientSet.CoreV1().Services(namespace),
+		namespace:        namespace,
 	}
 }
 

--- a/test/e2e/framework/statefulset.go
+++ b/test/e2e/framework/statefulset.go
@@ -19,6 +19,7 @@ import (
 type StatefulSetClient struct {
 	f *Framework
 	v1apps.StatefulSetInterface
+	namespace string
 }
 
 func (f *Framework) StatefulSetClient() *StatefulSetClient {
@@ -29,6 +30,7 @@ func (f *Framework) StatefulSetClientNS(namespace string) *StatefulSetClient {
 	return &StatefulSetClient{
 		f:                    f,
 		StatefulSetInterface: f.ClientSet.AppsV1().StatefulSets(namespace),
+		namespace:            namespace,
 	}
 }
 

--- a/test/e2e/framework/switch-lb-rule.go
+++ b/test/e2e/framework/switch-lb-rule.go
@@ -23,6 +23,7 @@ import (
 type SwitchLBRuleClient struct {
 	f *Framework
 	v1.SwitchLBRuleInterface
+	namespace string
 }
 
 func (f *Framework) SwitchLBRuleClient() *SwitchLBRuleClient {
@@ -33,6 +34,7 @@ func (f *Framework) SwitchLBRuleClientNS(namespace string) *SwitchLBRuleClient {
 	return &SwitchLBRuleClient{
 		f:                     f,
 		SwitchLBRuleInterface: f.KubeOVNClientSet.KubeovnV1().SwitchLBRules(),
+		namespace:             namespace,
 	}
 }
 

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -1032,10 +1032,10 @@ var _ = framework.Describe("[group:subnet]", func() {
 		eventClient = f.EventClientNS("default")
 		events := eventClient.WaitToHaveEvent("Subnet", subnetName, "Normal", "SubnetGatewayTypeChanged", "kube-ovn-controller", "")
 
-		message := fmt.Sprintf("subnet gateway type changes from %s to %s ", apiv1.GWDistributedType, apiv1.GWCentralizedType)
+		message := fmt.Sprintf("subnet gateway type changes from %q to %q", apiv1.GWDistributedType, apiv1.GWCentralizedType)
 		found := false
 		for _, event := range events {
-			if strings.Contains(event.Message, message) {
+			if event.Message == message {
 				found = true
 				break
 			}
@@ -1043,9 +1043,9 @@ var _ = framework.Describe("[group:subnet]", func() {
 		framework.ExpectTrue(found, "no SubnetGatewayTypeChanged event")
 		found = false
 		events = eventClient.WaitToHaveEvent("Subnet", subnetName, "Normal", "SubnetGatewayNodeChanged", "kube-ovn-controller", "")
-		message = fmt.Sprintf("gateway node changes from %s to %s ", "", modifiedSubnet.Spec.GatewayNode)
+		message = fmt.Sprintf("gateway node changes from %q to %q", "", modifiedSubnet.Spec.GatewayNode)
 		for _, event := range events {
-			if strings.Contains(event.Message, message) {
+			if event.Message == message {
 				found = true
 				break
 			}
@@ -1073,6 +1073,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 			}
 		}
 	})
+
 	framework.ConformanceIt("should support subnet add nat outgoing policy rules ", func() {
 		f.SkipVersionPriorTo(1, 12, "Support for subnet add nat outgoing policy rules in v1.12")
 


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Tests

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c52f15b</samp>

Add namespace support to various e2e testing framework components and improve event message checks and subnet status updates in the e2e tests and controller.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c52f15b</samp>

> _We're testing the network in different namespaces_
> _We're creating and managing resources with ease_
> _We're quoting the values and checking the events_
> _Heave away, me `code`-ies, heave away_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c52f15b</samp>

*  Extend various resource client types with a `namespace` field to store the namespace of the resources ([link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-7018c9aad5976e478e96ba8314a5bb3eb0e1c40b6d5e16f9ef6d5a407210e30fR25), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR32), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-40999eb74777206d73e8c489195a8d14a06467e99f98baa6a0473b3794c0239cR24), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-d1475c86db30029cabe1778133156eff006d127722e4c46c6a55011cd70da705R16), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-eb39f8377f55ea23cdb47bf251856fcb0352ed1cd1b331843572f0f87a4255ccR21), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-5f15fda6193ef82e5636ecbb83e7df08e56285d7c04d7e7360c3461d7b08e065R20), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-7d2a92121dec233f7faaaa67d52838470acd9f6675a381b2345c839755d446f2R26), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-c6615eea4a784c685d963cfa203fb9f29ba57545ddd8c601762ee86bd75f7b7dR22), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-79772e079f5ad34c71e67fb5e94791f14f6cd466cf3b372b3422f293fe41f288R26))
*  Modify the corresponding constructor functions to assign the `namespace` field with the given namespace parameter ([link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-7018c9aad5976e478e96ba8314a5bb3eb0e1c40b6d5e16f9ef6d5a407210e30fR36), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR43), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-40999eb74777206d73e8c489195a8d14a06467e99f98baa6a0473b3794c0239cR35), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-d1475c86db30029cabe1778133156eff006d127722e4c46c6a55011cd70da705R27), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-eb39f8377f55ea23cdb47bf251856fcb0352ed1cd1b331843572f0f87a4255ccR32), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-5f15fda6193ef82e5636ecbb83e7df08e56285d7c04d7e7360c3461d7b08e065L27-R28), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-7d2a92121dec233f7faaaa67d52838470acd9f6675a381b2345c839755d446f2R37), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-c6615eea4a784c685d963cfa203fb9f29ba57545ddd8c601762ee86bd75f7b7dR33), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-79772e079f5ad34c71e67fb5e94791f14f6cd466cf3b372b3422f293fe41f288R37))
*  Use the `namespace` field instead of the framework namespace to filter or wait for the resources in the `WaitToHaveEvent`, `WaitForRunning`, and `WaitForNotFound` functions ([link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-d1475c86db30029cabe1778133156eff006d127722e4c46c6a55011cd70da705L33-R35), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-5f15fda6193ef82e5636ecbb83e7df08e56285d7c04d7e7360c3461d7b08e065L78-R84))
*  Modify the event messages for subnet gateway type and node changes to use %q instead of %s to quote the values and avoid confusion with spaces or special characters ([link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L114-R119))
*  Modify the tests for subnet gateway type and node changes to use %q instead of %s to match the event message format and use exact equality instead of substring containment to check the event message ([link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1035-R1038), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5L1046-R1048))
*  Add the `waitSubnetStatusUpdate` function to the `underlay` package to wait for the subnet status to reflect the expected number of using IPs in the given namespace ([link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR50-R61))
*  Call the `waitSubnetStatusUpdate` function in various tests for pod IP allocation in the underlay mode to verify that the subnet status is updated correctly after creating or deleting pods in different subnets, nodes, or annotations ([link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR536), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR568), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR586), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR614), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR632), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR674), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR715), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR734), [link](https://github.com/kubeovn/kube-ovn/pull/3116/files?diff=unified&w=0#diff-b9f2f2a533e8aae41e56f957acda5a5cfb7f542d6a2091cf92f2c11faa5a4e5dR752))