### PR TITLE
controller: fix vpc update

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -104,7 +104,6 @@ func (c *ovnClient) AddLogicalRouterStaticRoute(lrName, routeTable, policy, ipPr
 		klog.Error(err)
 		return fmt.Errorf("failed to delete static routes from logical router %s: %v", lrName, err)
 	}
-	klog.Infof("logical router %s add static routes: %v", lrName, toAdd)
 	if err = c.CreateLogicalRouterStaticRoutes(lrName, toAdd...); err != nil {
 		return fmt.Errorf("failed to add static routes to logical router %s: %v", lrName, err)
 	}

--- a/pkg/pinger/ovn.go
+++ b/pkg/pinger/ovn.go
@@ -125,7 +125,7 @@ func checkSBBindings(config *Configuration) ([]string, error) {
 	}
 	output, err := exec.Command("ovn-sbctl", command...).CombinedOutput()
 	if err != nil {
-		klog.Errorf("failed to find chassis %v", err)
+		klog.Errorf("failed to find chassis: %v, %s", err, string(output))
 		return nil, err
 	}
 	if len(output) == 0 {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:

1. fixes reference to nil pointer;
2. fixes modification of cached object;
3. remove logging without detailed information.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c16c27</samp>

Refactored some controller code to use deep copies and improve readability. Removed redundant log statements. Added more error details for `ovn-sbctl` command.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1c16c27</samp>

> _Sing, O Muse, of the mighty pull request_
> _That the skilled developer wrought with care_
> _To enhance the code of the `subnet.go` file_
> _And fix the errors that lurked in there._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c16c27</samp>

*  Rename `vpc` to `cachedVpc` and create deep copies of the cached object before updating it in `pkg/controller/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1210-R1210), [link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1230), [link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1351-R1354))
*  Remove unused or redundant variables and log statements in `pkg/controller/subnet.go` and `pkg/controller/vpc.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1269-R1270), [link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1301-R1304), [link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL281), [link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL979-R979))
*  Rename `vpc` to `status` and create a deep copy of the cached object's status before updating it in `pkg/controller/vpc.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL969-R973))
*  Remove redundant log statements in `pkg/ovs/ovn-nb-logical_router_route.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-386553eb41be041eafc944d6270c154cf99b46609ef142b487ce1e2d8dd089d6L107))
*  Add command output to error log in `pkg/pinger/ovn.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3117/files?diff=unified&w=0#diff-dfa20de46cf79d12da22354ba59306dc66c2640596671d92b1f290f2d3470229L128-R128))