### PR TITLE
add e2e test for ovn db recover

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1654,8 +1654,8 @@ jobs:
       - name: Cleanup
         run: sh -x dist/images/cleanup.sh
 
-  kube-ovn-security-e2e:
-    name: Kube-OVN Security E2E
+  kube-ovn-ha-e2e:
+    name: Kube-OVN HA E2E
     needs:
       - build-kube-ovn
       - build-e2e-binaries
@@ -1752,116 +1752,25 @@ jobs:
         env:
           E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
           E2E_IP_FAMILY: ${{ matrix.ip-family }}
-        run: make kube-ovn-security-e2e
+        run: |
+          make kube-ovn-security-e2e
+          make kube-ovn-ha-e2e
 
       - name: kubectl ko log
         if: failure()
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-security-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: kube-ovn-security-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log
-          path: kube-ovn-security-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
+          name: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log
+          path: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Cleanup
         run: sh -x dist/images/cleanup.sh
-
-  push:
-    name: Push Images
-    needs:
-      - build-centos-compile
-      - k8s-conformance-e2e
-      - k8s-netpol-e2e
-      - k8s-netpol-legacy-e2e
-      - cyclonus-netpol-e2e
-      - kube-ovn-conformance-e2e
-      - kube-ovn-ic-conformance-e2e
-      - ovn-vpc-nat-gw-conformance-e2e
-      - iptables-vpc-nat-gw-conformance-e2e
-      - webhook-e2e
-      - lb-svc-e2e
-      - underlay-logical-gateway-installation-test
-      - chart-installation-test
-      - installation-compatibility-test
-      - no-ovn-lb-test
-      - no-np-test
-      - cilium-chaining-e2e
-      - kube-ovn-security-e2e
-      - kubevirt-e2e
-    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download kube-ovn image
-        uses: actions/download-artifact@v3
-        with:
-          name: kube-ovn
-
-      - name: Download vpc-nat-gateway image
-        uses: actions/download-artifact@v3
-        with:
-          name: vpc-nat-gateway
-
-      - name: Download centos7-compile image
-        uses: actions/download-artifact@v3
-        with:
-          name: centos7-compile
-
-      # - name: Download centos8-compile image
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: centos8-compile
-
-      - name: Load image
-        run: |
-          docker load --input kube-ovn.tar
-          docker load --input vpc-nat-gateway.tar
-          docker load --input centos7-compile.tar
-          # docker load --input centos8-compile.tar
-
-      - name: Security Scan
-        run: |
-          sudo apt-get install wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-          echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install trivy
-          make scan
-
-      - name: Push
-        if: github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'release-')
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          COMMIT: ${{ github.sha }}
-        run: |
-          cat VERSION
-          TAG=$(cat VERSION)
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          docker tag kubeovn/kube-ovn:$TAG kubeovn/kube-ovn-dev:$COMMIT-x86
-          docker tag kubeovn/kube-ovn:$TAG kubeovn/kube-ovn:$TAG-x86
-          docker tag kubeovn/kube-ovn:$TAG-debug kubeovn/kube-ovn:$TAG-debug-x86
-          docker tag kubeovn/vpc-nat-gateway:$TAG kubeovn/vpc-nat-gateway-dev:$COMMIT-x86
-          docker tag kubeovn/vpc-nat-gateway:$TAG kubeovn/vpc-nat-gateway:$TAG-x86
-          docker tag kubeovn/centos7-compile:$TAG kubeovn/centos7-compile-dev:$TAG-x86
-          docker tag kubeovn/centos7-compile:$TAG kubeovn/centos7-compile:$TAG-x86
-          # docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile-dev:$TAG-x86
-          # docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile:$TAG-x86
-          docker images
-          docker push kubeovn/kube-ovn:$TAG-x86
-          docker push kubeovn/kube-ovn-dev:$COMMIT-x86
-          docker push kubeovn/kube-ovn:$TAG-debug-x86
-          docker push kubeovn/vpc-nat-gateway:$TAG-x86
-          docker push kubeovn/vpc-nat-gateway-dev:$COMMIT-x86
-          docker push kubeovn/centos7-compile:$TAG-x86
-          docker push kubeovn/centos7-compile-dev:$TAG-x86
-          # docker push kubeovn/centos8-compile:$TAG-x86
-          # docker push kubeovn/centos8-compile-dev:$TAG-x86
 
   kube-ovn-submariner-conformance-e2e:
     name: Kube-OVN Submariner Conformance E2E
@@ -2114,3 +2023,97 @@ jobs:
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}
         run: make ovn-vpc-nat-gw-conformance-e2e
+
+  push:
+    name: Push Images
+    needs:
+      - build-centos-compile
+      - k8s-conformance-e2e
+      - k8s-netpol-e2e
+      - k8s-netpol-legacy-e2e
+      - cyclonus-netpol-e2e
+      - kube-ovn-conformance-e2e
+      - kube-ovn-ic-conformance-e2e
+      - ovn-vpc-nat-gw-conformance-e2e
+      - iptables-vpc-nat-gw-conformance-e2e
+      - webhook-e2e
+      - lb-svc-e2e
+      - underlay-logical-gateway-installation-test
+      - chart-installation-test
+      - installation-compatibility-test
+      - no-ovn-lb-test
+      - no-np-test
+      - cilium-chaining-e2e
+      - kube-ovn-ha-e2e
+      - kubevirt-e2e
+      - kube-ovn-submariner-conformance-e2e
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download kube-ovn image
+        uses: actions/download-artifact@v3
+        with:
+          name: kube-ovn
+
+      - name: Download vpc-nat-gateway image
+        uses: actions/download-artifact@v3
+        with:
+          name: vpc-nat-gateway
+
+      - name: Download centos7-compile image
+        uses: actions/download-artifact@v3
+        with:
+          name: centos7-compile
+
+      # - name: Download centos8-compile image
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: centos8-compile
+
+      - name: Load image
+        run: |
+          docker load --input kube-ovn.tar
+          docker load --input vpc-nat-gateway.tar
+          docker load --input centos7-compile.tar
+          # docker load --input centos8-compile.tar
+
+      - name: Security Scan
+        run: |
+          sudo apt-get install wget apt-transport-https gnupg lsb-release
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
+          echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install trivy
+          make scan
+
+      - name: Push
+        if: github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'release-')
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          COMMIT: ${{ github.sha }}
+        run: |
+          cat VERSION
+          TAG=$(cat VERSION)
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker tag kubeovn/kube-ovn:$TAG kubeovn/kube-ovn-dev:$COMMIT-x86
+          docker tag kubeovn/kube-ovn:$TAG kubeovn/kube-ovn:$TAG-x86
+          docker tag kubeovn/kube-ovn:$TAG-debug kubeovn/kube-ovn:$TAG-debug-x86
+          docker tag kubeovn/vpc-nat-gateway:$TAG kubeovn/vpc-nat-gateway-dev:$COMMIT-x86
+          docker tag kubeovn/vpc-nat-gateway:$TAG kubeovn/vpc-nat-gateway:$TAG-x86
+          docker tag kubeovn/centos7-compile:$TAG kubeovn/centos7-compile-dev:$TAG-x86
+          docker tag kubeovn/centos7-compile:$TAG kubeovn/centos7-compile:$TAG-x86
+          # docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile-dev:$TAG-x86
+          # docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile:$TAG-x86
+          docker images
+          docker push kubeovn/kube-ovn:$TAG-x86
+          docker push kubeovn/kube-ovn-dev:$COMMIT-x86
+          docker push kubeovn/kube-ovn:$TAG-debug-x86
+          docker push kubeovn/vpc-nat-gateway:$TAG-x86
+          docker push kubeovn/vpc-nat-gateway-dev:$COMMIT-x86
+          docker push kubeovn/centos7-compile:$TAG-x86
+          docker push kubeovn/centos7-compile-dev:$TAG-x86
+          # docker push kubeovn/centos8-compile:$TAG-x86
+          # docker push kubeovn/centos8-compile-dev:$TAG-x86

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -1047,8 +1047,8 @@ jobs:
         working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
         run: sh dist/images/cleanup.sh
 
-  kube-ovn-security-e2e:
-    name: Kube-OVN Security E2E
+  kube-ovn-ha-e2e:
+    name: Kube-OVN HA E2E
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -1132,7 +1132,9 @@ jobs:
         env:
           E2E_BRANCH: ${{ matrix.branch }}
           E2E_IP_FAMILY: ${{ matrix.ip-family }}
-        run: make kube-ovn-security-e2e
+        run: |
+          make kube-ovn-security-e2e
+          make kube-ovn-ha-e2e
 
       - name: Cleanup
         run: sh dist/images/cleanup.sh

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -63,6 +63,7 @@ e2e-build:
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/lb-svc
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/iptables-vpc-nat-gw
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ovn-vpc-nat-gw
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ha
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/security
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/kubevirt
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/webhook
@@ -154,6 +155,15 @@ ovn-vpc-nat-gw-conformance-e2e:
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
 	ginkgo $(GINKGO_PARALLEL_OPT) --randomize-all -v \
 		--focus=CNI:Kube-OVN ./test/e2e/ovn-vpc-nat-gw/ovn-vpc-nat-gw.test
+
+.PHONY: kube-ovn-ha-e2e
+kube-ovn-ha-e2e:
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ha
+	E2E_BRANCH=$(E2E_BRANCH) \
+	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
+	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
+	ginkgo $(GINKGO_PARALLEL_OPT) --randomize-all -v \
+		--focus=CNI:Kube-OVN ./test/e2e/ha/ha.test
 
 .PHONY: kube-ovn-security-e2e
 kube-ovn-security-e2e:

--- a/test/e2e/framework/exec_utils.go
+++ b/test/e2e/framework/exec_utils.go
@@ -12,23 +12,23 @@ import (
 )
 
 // ExecCommandInContainer executes a command in the specified container.
-func ExecCommandInContainer(f *Framework, podName, containerName string, cmd ...string) (string, string, error) {
-	return util.ExecuteCommandInContainer(f.ClientSet, f.ClientConfig(), f.Namespace.Name, podName, containerName, cmd...)
+func ExecCommandInContainer(f *Framework, namespace, pod, container string, cmd ...string) (string, string, error) {
+	return util.ExecuteCommandInContainer(f.ClientSet, f.ClientConfig(), namespace, pod, container, cmd...)
 }
 
 // ExecShellInContainer executes the specified command on the pod's container.
-func ExecShellInContainer(f *Framework, podName, containerName string, cmd string) (string, string, error) {
-	return ExecCommandInContainer(f, podName, containerName, "/bin/sh", "-c", cmd)
+func ExecShellInContainer(f *Framework, namespace, pod, container, cmd string) (string, string, error) {
+	return ExecCommandInContainer(f, namespace, pod, container, "/bin/sh", "-c", cmd)
 }
 
-func execCommandInPod(ctx context.Context, f *Framework, podName string, cmd ...string) (string, string, error) {
-	pod, err := f.PodClient().Get(ctx, podName, metav1.GetOptions{})
-	framework.ExpectNoError(err, "failed to get pod %v", podName)
-	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
-	return ExecCommandInContainer(f, podName, pod.Spec.Containers[0].Name, cmd...)
+func execCommandInPod(ctx context.Context, f *Framework, namespace, pod string, cmd ...string) (string, string, error) {
+	p, err := f.PodClientNS(namespace).Get(ctx, pod, metav1.GetOptions{})
+	framework.ExpectNoError(err, "failed to get pod %s/%s", namespace, pod)
+	gomega.Expect(p.Spec.Containers).NotTo(gomega.BeEmpty())
+	return ExecCommandInContainer(f, namespace, pod, p.Spec.Containers[0].Name, cmd...)
 }
 
 // ExecShellInPod executes the specified command on the pod.
-func ExecShellInPod(ctx context.Context, f *Framework, podName string, cmd string) (string, string, error) {
-	return execCommandInPod(ctx, f, podName, "/bin/sh", "-c", cmd)
+func ExecShellInPod(ctx context.Context, f *Framework, namespace, pod, cmd string) (string, string, error) {
+	return execCommandInPod(ctx, f, namespace, pod, "/bin/sh", "-c", cmd)
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -186,3 +186,7 @@ func OrderedDescribe(text string, body func()) bool {
 func ConformanceIt(text string, body interface{}) bool {
 	return ginkgo.It(text+" [Conformance]", ginkgo.Offset(1), body)
 }
+
+func CorruptiveIt(text string, body interface{}) bool {
+	return ginkgo.It(text+" [Corruptive]", ginkgo.Offset(1), body)
+}

--- a/test/e2e/ha/ha_test.go
+++ b/test/e2e/ha/ha_test.go
@@ -1,0 +1,109 @@
+package ha
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e"
+	k8sframework "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/config"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+func init() {
+	klog.SetOutput(ginkgo.GinkgoWriter)
+
+	// Register flags.
+	config.CopyFlags(config.Flags, flag.CommandLine)
+	k8sframework.RegisterCommonFlags(flag.CommandLine)
+	k8sframework.RegisterClusterFlags(flag.CommandLine)
+}
+
+func TestE2E(t *testing.T) {
+	if k8sframework.TestContext.KubeConfig == "" {
+		k8sframework.TestContext.KubeConfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	}
+	k8sframework.AfterReadingAllFlags(&k8sframework.TestContext)
+
+	e2e.RunE2ETests(t)
+}
+
+var _ = framework.Describe("[group:ha]", func() {
+	f := framework.NewDefaultFramework("ha")
+	f.SkipNamespaceCreation = true
+
+	framework.CorruptiveIt("ovn db should recover automatically from db file corruption", func() {
+		f.SkipVersionPriorTo(1, 11, "This feature was introduced in v1.11")
+
+		ginkgo.By("Getting daemonset ovs-ovn")
+		dsClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
+		ds := dsClient.Get("ovs-ovn")
+
+		ginkgo.By("Getting deployment ovn-central")
+		deployClient := f.DeploymentClientNS(framework.KubeOvnNamespace)
+		deploy := deployClient.Get("ovn-central")
+		replicas := *deploy.Spec.Replicas
+		framework.ExpectNotZero(replicas)
+
+		ginkgo.By("Ensuring deployment ovn-central is ready")
+		deployClient.RolloutStatus(deploy.Name)
+
+		ginkgo.By("Getting nodes running deployment ovn-central")
+		deployClient.RolloutStatus(deploy.Name)
+		pods, err := deployClient.GetPods(deploy)
+		framework.ExpectNoError(err)
+		framework.ExpectHaveLen(pods.Items, int(replicas))
+		nodes := make([]string, 0, int(replicas))
+		for _, pod := range pods.Items {
+			nodes = append(nodes, pod.Spec.NodeName)
+		}
+
+		ginkgo.By("Setting size of deployment ovn-central to 0")
+		deployClient.SetScale(deploy.Name, 0)
+
+		ginkgo.By("Waiting for ovn-central pods to disappear")
+		framework.WaitUntil(2*time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
+			pods, err := deployClient.GetAllPods(deploy)
+			if err != nil {
+				return false, err
+			}
+			return len(pods.Items) == 0, nil
+		}, "")
+
+		db := "/etc/ovn/ovnnb_db.db"
+		checkCmd := fmt.Sprintf("ovsdb-tool check-cluster " + db)
+		corruptCmd := fmt.Sprintf(`bash -c 'dd if=/dev/zero of="%s" bs=1 count=$((10+$RANDOM%%10)) seek=$(stat -c %%s "%s")'`, db, db)
+		for _, node := range nodes {
+			ginkgo.By("Getting ovs-ovn pod running on node " + node)
+			pod, err := dsClient.GetPodOnNode(ds, node)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Ensuring db file " + db + " on node " + node + " is ok")
+			stdout, stderr, err := framework.ExecShellInPod(context.Background(), f, pod.Namespace, pod.Name, checkCmd)
+			framework.ExpectNoError(err, fmt.Sprintf("failed to check db file %q: stdout = %q, stderr = %q", db, stdout, stderr))
+			ginkgo.By("Corrupting db file " + db + " on node " + node)
+			stdout, stderr, err = framework.ExecShellInPod(context.Background(), f, pod.Namespace, pod.Name, corruptCmd)
+			framework.ExpectNoError(err, fmt.Sprintf("failed to corrupt db file %q: stdout = %q, stderr = %q", db, stdout, stderr))
+			ginkgo.By("Ensuring db file " + db + " on node " + node + " is corrupted")
+			stdout, stderr, err = framework.ExecShellInPod(context.Background(), f, pod.Namespace, pod.Name, checkCmd)
+			framework.ExpectError(err)
+			framework.Logf("command output: stdout = %q, stderr = %q", stdout, stderr)
+		}
+
+		ginkgo.By("Setting size of deployment ovn-central to " + strconv.Itoa(int(replicas)))
+		deployClient.SetScale(deploy.Name, replicas)
+
+		ginkgo.By("Waiting for deployment ovn-central to be ready")
+		deployClient.RolloutStatus(deploy.Name)
+	})
+})

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -563,7 +563,7 @@ var _ = framework.Describe("[group:iptables-vpc-nat-gw]", func() {
 func iperf(f *framework.Framework, iperfClientPod *corev1.Pod, iperfServerEIP *apiv1.IptablesEIP) string {
 	for i := 0; i < 20; i++ {
 		command := fmt.Sprintf("iperf -e -p %s --reportstyle C -i 1 -c %s -t 10", iperf2Port, iperfServerEIP.Status.IP)
-		stdOutput, errOutput, err := framework.ExecShellInPod(context.Background(), f, iperfClientPod.Name, command)
+		stdOutput, errOutput, err := framework.ExecShellInPod(context.Background(), f, iperfClientPod.Namespace, iperfClientPod.Name, command)
 		framework.Logf("output from exec on client pod %s (eip %s)\n", iperfClientPod.Name, iperfServerEIP.Name)
 		if stdOutput != "" && err == nil {
 			framework.Logf("output:\n%s", stdOutput)

--- a/test/e2e/security/e2e_test.go
+++ b/test/e2e/security/e2e_test.go
@@ -146,7 +146,6 @@ var _ = framework.Describe("[group:security]", func() {
 		ginkgo.By("Getting daemonset kube-ovn-cni")
 		daemonSetClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
 		ds := daemonSetClient.Get("kube-ovn-cni")
-		framework.ExpectNoError(err, "failed to to get daemonset kube-ovn-cni")
 
 		ginkgo.By("Getting kube-ovn-cni pods")
 		pods := make([]corev1.Pod, 0, len(nodeList.Items))


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- CI/Tests


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8061253</samp>

This pull request adds a new e2e test case for high availability of ovn db, and updates the GitHub Actions workflows and the `framework` package to support it. It also renames and modifies some existing e2e test cases and make targets for clarity and consistency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8061253</samp>

> _`kube-ovn` tests grow_
> _Corrupt, scale, and fail nodes_
> _Winter is coming_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8061253</samp>

*  Rename and modify the e2e test job for ovn db high availability ([link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1657-R1658), [link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1755-R1757), [link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1761-R1763), [link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1767-R1774), [link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1050-R1051), [link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1135-R1137))
*  Add a new make target `kube-ovn-ha-e2e` to build and run the high availability test case ([link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aR66), [link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-c6c608a44221cc490b39781deca27f76d95887d10f75895d2a302a9cbc8a0f6aR159-R167))
*  Add a new test file `test/e2e/ha/ha_test.go` to implement the high availability test case, using the `framework` package ([link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-ef9805f164fe5a183ce58192f5cd8154e48af8c6ab32320a1c34441e0160d2f4R1-R114))
*  Add a new function `CorruptiveIt` to the `framework` package, to mark a test case as corruptive and skip or isolate it accordingly ([link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-c354587e36151f73f4a4da62c22d612510bee633ada8a52ed16b89c7185f0283R189-R192))
*  Add new functions `GetAllPods` and `SetScale` to the `DeploymentClient` struct in the `framework` package, to get and update the scale of a deployment ([link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR57-R65), [link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-9070f9dc0f0509c18c444ce4ed7090c92e229144af431eb7ad2c18cf23a9e59fR163-R175))
*  Modify the functions `ExecCommandInContainer`, `ExecShellInContainer`, `execCommandInPod`, and `ExecShellInPod` in the `framework` package, to take an additional parameter `namespace` for the pod where the command is executed ([link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-d7ae451418eef174f23bcfe45fbd9006de4069b5fb24324e27b9e100324c1c27L15-R33))
*  Modify the function call `framework.ExecShellInPod` in the `iptables-vpc-nat-gw` test case, to pass the namespace of the pod as an additional parameter ([link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L566-R566))
*  Move the `push` job to the end of the `.github/workflows/build-x86-image.yaml` file, and update its dependency to include the new test cases ([link](https://github.com/kubeovn/kube-ovn/pull/3118/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R2026-R2119))