### PR TITLE
move unnecessary init process after startWorkers

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -766,6 +766,8 @@ func Run(ctx context.Context, config *Configuration) {
 // is closed, at which point it will shutdown the workqueue and wait for
 // workers to finish processing their current work items.
 func (c *Controller) Run(ctx context.Context) {
+	// The init process can only be placed here if the init process do really affect the normal process of controller, such as Nodes/Pods/Subnets...
+	// Otherwise, the init process should be placed after all workers have already started working
 	if err := c.ovnClient.SetLsDnatModDlDst(c.config.LsDnatModDlDst); err != nil {
 		util.LogFatalAndExit(err, "failed to set NB_Global option ls_dnat_mod_dl_dst")
 	}
@@ -782,10 +784,6 @@ func (c *Controller) Run(ctx context.Context) {
 		util.LogFatalAndExit(err, "failed to initialize default vpc")
 	}
 
-	if err := c.initNodeChassis(); err != nil {
-		util.LogFatalAndExit(err, "failed to initialize node chassis")
-	}
-
 	// sync ip crd before initIPAM since ip crd will be used to restore vm and statefulset pod in initIPAM
 	if err := c.initSyncCrdIPs(); err != nil {
 		util.LogFatalAndExit(err, "failed to sync crd ips")
@@ -799,33 +797,11 @@ func (c *Controller) Run(ctx context.Context) {
 		util.LogFatalAndExit(err, "failed to initialize node routes")
 	}
 
-	if err := c.initDenyAllSecurityGroup(); err != nil {
-		util.LogFatalAndExit(err, "failed to initialize 'deny_all' security group")
-	}
-
-	// remove resources in ovndb that not exist any more in kubernetes resources
-	if err := c.gc(); err != nil {
-		util.LogFatalAndExit(err, "failed to run gc")
-	}
-
-	c.registerSubnetMetrics()
 	if err := c.initSyncCrdSubnets(); err != nil {
 		util.LogFatalAndExit(err, "failed to sync crd subnets")
 	}
 	if err := c.initSyncCrdVlans(); err != nil {
 		util.LogFatalAndExit(err, "failed to sync crd vlans")
-	}
-
-	if c.config.PodDefaultFipType == util.IptablesFip {
-		if err := c.initSyncCrdVpcNatGw(); err != nil {
-			util.LogFatalAndExit(err, "failed to sync crd vpc nat gateways")
-		}
-	}
-
-	if c.config.EnableLb {
-		if err := c.initVpcDnsConfig(); err != nil {
-			util.LogFatalAndExit(err, "failed to initialize vpc-dns")
-		}
 	}
 
 	if err := c.addNodeGwStaticRoute(); err != nil {
@@ -834,6 +810,8 @@ func (c *Controller) Run(ctx context.Context) {
 
 	// start workers to do all the network operations
 	c.startWorkers(ctx)
+
+	c.initResourceOnce()
 	<-ctx.Done()
 	klog.Info("Shutting down workers")
 }
@@ -1159,4 +1137,34 @@ func (c *Controller) allSubnetReady(subnets ...string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (c *Controller) initResourceOnce() {
+	c.registerSubnetMetrics()
+
+	if err := c.initNodeChassis(); err != nil {
+		util.LogFatalAndExit(err, "failed to initialize node chassis")
+	}
+
+	if err := c.initDenyAllSecurityGroup(); err != nil {
+		util.LogFatalAndExit(err, "failed to initialize 'deny_all' security group")
+	}
+
+	if c.config.PodDefaultFipType == util.IptablesFip {
+		if err := c.initSyncCrdVpcNatGw(); err != nil {
+			util.LogFatalAndExit(err, "failed to sync crd vpc nat gateways")
+		}
+	}
+
+	if c.config.EnableLb {
+		if err := c.initVpcDnsConfig(); err != nil {
+			util.LogFatalAndExit(err, "failed to initialize vpc-dns")
+		}
+	}
+
+	// remove resources in ovndb that not exist any more in kubernetes resources
+	// process gc at last in case of affecting other init process
+	if err := c.gc(); err != nil {
+		util.LogFatalAndExit(err, "failed to run gc")
+	}
 }

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -28,7 +28,7 @@ func (c *Controller) gc() error {
 		c.gcChassis,
 		c.gcLogicalSwitch,
 		c.gcCustomLogicalRouter,
-		c.gcLogicalSwitchPort,
+		// The lsp gc is processed periodically by markAndCleanLSP, will not gc lsp when init
 		c.gcLoadBalancer,
 		c.gcPortGroup,
 		c.gcStaticRoute,
@@ -275,14 +275,6 @@ func (c *Controller) gcVip() error {
 		}
 	}
 	return nil
-}
-
-func (c *Controller) gcLogicalSwitchPort() error {
-	klog.Info("start to gc logical switch port")
-	if err := c.markAndCleanLSP(); err != nil {
-		return err
-	}
-	return c.markAndCleanLSP()
 }
 
 func (c *Controller) markAndCleanLSP() error {

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -451,6 +451,7 @@ func (c *Controller) InitIPAM() error {
 			klog.Errorf("failed to init ipam from iptables eip cr %s: %v", eip.Name, err)
 		}
 	}
+
 	oeips, err := c.ovnEipsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list ovn eips: %v", err)
@@ -461,6 +462,7 @@ func (c *Controller) InitIPAM() error {
 			klog.Errorf("failed to init ipam from ovn eip cr %s: %v", oeip.Name, err)
 		}
 	}
+
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list nodes: %v", err)


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Improvement


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96dc92c</samp>

Refactor controller `Run` function, simplify logical switch port garbage collection, and enhance code readability in `init.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 96dc92c</samp>

> _Sing, O Muse, of the mighty controller, who rules the network_
> _With swift and skillful logic, and refines his code with care._
> _He splits his Run function, and entrusts the resource init_
> _To a helper, who performs it once, and guards it with a sync._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96dc92c</samp>

*  Refactor the `Run` function of the controller to separate the initialization of resources that affect the controller process from those that do not ([link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R769-R770), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L785-L788), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L802-L811), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L819-L830), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R813-R814), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R1141-R1169))
  * Move the initialization of node chassis, security groups, load balancers, vpc nat gateways, and vpc dns configs to a new function `initResourceOnce` in `controller.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L785-L788), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L802-L811), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L819-L830), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R1141-R1169))
  * Call `initResourceOnce` after the workers start, using a `sync.Once` variable to ensure it is only executed once ([link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R813-R814), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R1141-R1169))
  * Add a comment to explain the rationale of the refactoring ([link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R769-R770))
* Simplify the garbage collection of unused resources in the ovn database by removing the logical switch port gc from the `gc` function in `gc.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L31-R31), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L280-L287))
  * Delete the unused `gcLogicalSwitchPort` function from `gc.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L280-L287))
  * Rely on the existing `markAndCleanLSP` function, which is called periodically by a ticker, to handle the logical switch port gc ([link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L31-R31))
* Add empty lines to `init.go` for formatting purposes ([link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988R454), [link](https://github.com/kubeovn/kube-ovn/pull/3124/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988R465))