### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -9,7 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, release-1.11, release-1.9]
+        branch:
+        - master
+        - release-1.12
+        - release-1.11
+        - release-1.9
     name: Build AMD64
     runs-on: ubuntu-22.04
     steps:
@@ -33,7 +37,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, release-1.11, release-1.9]
+        branch:
+        - master
+        - release-1.12
+        - release-1.11
+        - release-1.9
     name: Build ARM64
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -60,7 +60,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, release-1.11, release-1.9]
+        branch:
+        - master
+        - release-1.12
+        - release-1.11
+        - release-1.9
     needs:
       - build-arm64
       - build-amd64
@@ -100,7 +104,7 @@ jobs:
           docker manifest create kubeovn/kube-ovn-base:$TAG kubeovn/kube-ovn-base:$TAG-amd64 kubeovn/kube-ovn-base:$TAG-arm64
           docker manifest push kubeovn/kube-ovn-base:$TAG
 
-          if [ "${{ matrix.branch }}" == "master" || "${{ matrix.branch }}" == "release-1.11" ]; then
+          if [ "${{ matrix.branch }}" = "master" -o "${{ matrix.branch }}" = "release-1.11" ]; then
             docker push kubeovn/kube-ovn-base:$TAG-debug-amd64
             docker push kubeovn/kube-ovn-base:$TAG-debug-arm64
             docker manifest create kubeovn/kube-ovn-base:$TAG-debug kubeovn/kube-ovn-base:$TAG-debug-amd64 kubeovn/kube-ovn-base:$TAG-debug-arm64

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -24,10 +24,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
         ip-family:
           - ipv4
           - ipv6
@@ -114,10 +114,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
         ip-family:
           - ipv4
           - ipv6
@@ -197,10 +197,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
         ip-family:
           - ipv4
           - ipv6
@@ -280,10 +280,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
         ip-family:
           - ipv4
           - ipv6
@@ -340,10 +340,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
         ip-family:
           - ipv4
           - ipv6
@@ -424,6 +424,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
@@ -489,54 +490,6 @@ jobs:
           E2E_BRANCH: ${{ matrix.branch }}
         run: make kube-ovn-ic-conformance-e2e
 
-  ha-installation-test:
-    name: HA Installation Test
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        branch:
-          - release-1.8
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Create branch directory
-        run: mkdir -p test/e2e/kube-ovn/branches/${{ matrix.branch }}
-
-      - name: Check out branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.branch }}
-          fetch-depth: 1
-          path: test/e2e/kube-ovn/branches/${{ matrix.branch }}
-
-      - name: Install kind
-        uses: helm/kind-action@v1.8.0
-        with:
-          version: v0.20.0
-          install_only: true
-
-      - name: Create kind cluster
-        working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
-        run: |
-          sudo pip3 install j2cli
-          sudo pip3 install "j2cli[yaml]"
-          sudo PATH=~/.local/bin:$PATH make kind-init-ha
-          sudo cp -r /root/.kube/ ~/.kube/
-          sudo chown -R $(id -un). ~/.kube/
-
-      - name: Install Kube-OVN
-        working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
-        run: |
-          version=$(grep -E '^VERSION="v([0-9]+\.){2}[0-9]+"$' dist/images/install.sh | head -n1 | awk -F= '{print $2}' | tr -d '"')
-          docker pull kubeovn/kube-ovn:$version
-          sudo ENABLE_SSL=true VERSION=$version make kind-install
-
-      - name: Cleanup
-        working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
-        run: sh dist/images/cleanup.sh
-
   underlay-logical-gateway-installation-test:
     name: Underlay Logical Gateway Installation Test
     runs-on: ubuntu-22.04
@@ -546,6 +499,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
@@ -597,10 +551,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
     steps:
       - uses: actions/checkout@v3
 
@@ -651,10 +605,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
     steps:
       - uses: actions/checkout@v3
 
@@ -705,6 +659,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
     steps:
       - uses: actions/checkout@v3
@@ -777,6 +732,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
     steps:
       - uses: actions/checkout@v3
 
@@ -847,6 +803,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
     steps:
       - uses: actions/checkout@v3
 
@@ -917,10 +874,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
     steps:
       - uses: actions/checkout@v3
 
@@ -968,10 +925,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
-          - release-1.8
     steps:
       - uses: actions/checkout@v3
       - uses: azure/setup-helm@v3
@@ -1056,6 +1013,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
           - release-1.11
           - release-1.10
           - release-1.9
@@ -1254,6 +1212,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
     steps:
       - uses: actions/checkout@v3
 
@@ -1311,6 +1270,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -1380,6 +1340,7 @@ jobs:
       matrix:
         branch:
           - master
+          - release-1.12
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- CI


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c7728d</samp>

This pull request updates the GitHub workflows for building and testing Kube-OVN to support the new `release-1.12` branch. It fixes a debug image push bug in the `build-kube-ovn-base.yaml` file and adds more installation and end-to-end test cases in the `scheduled-e2e.yaml` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c7728d</samp>

> _Oh we're the crew of the Kube-OVN_
> _And we work on the code all day_
> _We test the branch of release-1.12_
> _With IPv4, 6, and dual-stack, hey!_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c7728d</samp>

*  Add release-1.12 branch to the matrix of branches for various jobs in the scheduled-e2e workflow ([link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L27-R30), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L117-R120), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L200-R203), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L283-R286), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L343-R346), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R427), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R502), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L600-R557), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L654-R611), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R662), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R735), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R806), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L920-R880), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L971-R931), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R1016), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R1215), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R1273), [link](https://github.com/kubeovn/kube-ovn/pull/3125/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R1343)). This enables testing the latest version of Kube-OVN on different kind cluster configurations, such as IPv4, IPv6, dual-stack, SSL, and IPvlan.