### PR TITLE
ci: fix version comparison

### DIFF
--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -112,7 +112,7 @@ jobs:
           docker manifest create kubeovn/kube-ovn-base:$TAG kubeovn/kube-ovn-base:$TAG-amd64 kubeovn/kube-ovn-base:$TAG-arm64
           docker manifest push kubeovn/kube-ovn-base:$TAG
 
-          if [ "${{ matrix.branch }}" = "master" -o "${{ matrix.branch }}" = "release-1.11" ]; then
+          if [ "${{ matrix.branch }}" = "master" -o "`printf '${{ matrix.branch }}\nrelease-1.11' | sort -Vr | head -n1`" = "${{ matrix.branch }}" ]; then
             docker push kubeovn/kube-ovn-base:$TAG-debug-amd64
             docker push kubeovn/kube-ovn-base:$TAG-debug-arm64
             docker manifest create kubeovn/kube-ovn-base:$TAG-debug kubeovn/kube-ovn-base:$TAG-debug-amd64 kubeovn/kube-ovn-base:$TAG-debug-arm64


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- CI

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54606f8</samp>

Fix the condition for pushing debug images in `.github/workflows/build-kube-ovn-base.yaml` to use version comparison instead of string comparison. This ensures that debug images are pushed for the latest release branch and the master branch.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 54606f8</samp>

> _Debug images_
> _Pushed for latest release branch_
> _Fixing bug in fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54606f8</samp>

*  Modify the condition for pushing debug images to use version comparison instead of string comparison ([link](https://github.com/kubeovn/kube-ovn/pull/3127/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL115-R115))