### PR TITLE
add mulicast snoop switch

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1760,6 +1760,8 @@ spec:
                   type: boolean
                 enableEcmp:
                   type: boolean
+                enableMulticastSnoop:
+                  type: boolean
                 routeTable:
                   type: string
   scope: Cluster

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2299,6 +2299,8 @@ spec:
                   type: boolean
                 enableEcmp:
                   type: boolean
+                enableMulticastSnoop:
+                  type: boolean
                 routeTable:
                   type: string
   scope: Cluster

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -591,6 +591,20 @@ func (mr *MockLogicalSwitchMockRecorder) LogicalSwitchUpdateLoadBalancers(lsName
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogicalSwitchUpdateLoadBalancers", reflect.TypeOf((*MockLogicalSwitch)(nil).LogicalSwitchUpdateLoadBalancers), varargs...)
 }
 
+// LogicalSwitchUpdateOtherConfig mocks base method.
+func (m *MockLogicalSwitch) LogicalSwitchUpdateOtherConfig(lsName string, op ovsdb.Mutator, otherConfig map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LogicalSwitchUpdateOtherConfig", lsName, op, otherConfig)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LogicalSwitchUpdateOtherConfig indicates an expected call of LogicalSwitchUpdateOtherConfig.
+func (mr *MockLogicalSwitchMockRecorder) LogicalSwitchUpdateOtherConfig(lsName, op, otherConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogicalSwitchUpdateOtherConfig", reflect.TypeOf((*MockLogicalSwitch)(nil).LogicalSwitchUpdateOtherConfig), lsName, op, otherConfig)
+}
+
 // MockLogicalSwitchPort is a mock of LogicalSwitchPort interface.
 type MockLogicalSwitchPort struct {
 	ctrl     *gomock.Controller
@@ -3184,6 +3198,20 @@ func (mr *MockOvnClientMockRecorder) LogicalSwitchUpdateLoadBalancers(lsName, op
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{lsName, op}, lbNames...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogicalSwitchUpdateLoadBalancers", reflect.TypeOf((*MockOvnClient)(nil).LogicalSwitchUpdateLoadBalancers), varargs...)
+}
+
+// LogicalSwitchUpdateOtherConfig mocks base method.
+func (m *MockOvnClient) LogicalSwitchUpdateOtherConfig(lsName string, op ovsdb.Mutator, otherConfig map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LogicalSwitchUpdateOtherConfig", lsName, op, otherConfig)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LogicalSwitchUpdateOtherConfig indicates an expected call of LogicalSwitchUpdateOtherConfig.
+func (mr *MockOvnClientMockRecorder) LogicalSwitchUpdateOtherConfig(lsName, op, otherConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogicalSwitchUpdateOtherConfig", reflect.TypeOf((*MockOvnClient)(nil).LogicalSwitchUpdateOtherConfig), lsName, op, otherConfig)
 }
 
 // NatExists mocks base method.

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -166,6 +166,7 @@ type SubnetSpec struct {
 	U2OInterconnection   bool   `json:"u2oInterconnection,omitempty"`
 	EnableLb             *bool  `json:"enableLb,omitempty"`
 	EnableEcmp           bool   `json:"enableEcmp,omitempty"`
+	EnableMulicastSnoop  bool   `json:"enableMulticastSnoop,omitempty"`
 
 	RouteTable string `json:"routeTable,omitempty"`
 }

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -104,6 +104,7 @@ func (c *Controller) enqueueUpdateSubnet(old, new interface{}) {
 		oldSubnet.Spec.RouteTable != newSubnet.Spec.RouteTable ||
 		oldSubnet.Spec.Vpc != newSubnet.Spec.Vpc ||
 		oldSubnet.Spec.NatOutgoing != newSubnet.Spec.NatOutgoing ||
+		oldSubnet.Spec.EnableMulicastSnoop != newSubnet.Spec.EnableMulicastSnoop ||
 		!reflect.DeepEqual(oldSubnet.Spec.NatOutgoingPolicyRules, newSubnet.Spec.NatOutgoingPolicyRules) ||
 		(newSubnet.Spec.U2OInterconnection && newSubnet.Spec.U2OInterconnectionIP != "" &&
 			oldSubnet.Spec.U2OInterconnectionIP != newSubnet.Spec.U2OInterconnectionIP) {
@@ -756,6 +757,19 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	if err := c.ovnClient.CreateLogicalSwitch(subnet.Name, vpc.Status.Router, subnet.Spec.CIDRBlock, gateway, needRouter, randomAllocateGW); err != nil {
 		klog.Errorf("create logical switch %s: %v", subnet.Name, err)
 		return err
+	}
+
+	multicastSnoopFlag := map[string]string{"mcast_snoop": "true", "mcast_querier": "false"}
+	if subnet.Spec.EnableMulicastSnoop {
+		if err := c.ovnClient.LogicalSwitchUpdateOtherConfig(subnet.Name, ovsdb.MutateOperationInsert, multicastSnoopFlag); err != nil {
+			klog.Errorf("enable logical switch multicast snoop %s: %v", subnet.Name, err)
+			return err
+		}
+	} else {
+		if err := c.ovnClient.LogicalSwitchUpdateOtherConfig(subnet.Name, ovsdb.MutateOperationDelete, multicastSnoopFlag); err != nil {
+			klog.Errorf("disable logical switch multicast snoop  %s: %v", subnet.Name, err)
+			return err
+		}
 	}
 
 	subnet.Status.EnsureStandardConditions()

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -51,6 +51,7 @@ type LogicalSwitch interface {
 	CreateLogicalSwitch(lsName, lrName, cidrBlock, gateway string, needRouter, randomAllocateGW bool) error
 	CreateBareLogicalSwitch(lsName string) error
 	LogicalSwitchUpdateLoadBalancers(lsName string, op ovsdb.Mutator, lbNames ...string) error
+	LogicalSwitchUpdateOtherConfig(lsName string, op ovsdb.Mutator, otherConfig map[string]string) error
 	DeleteLogicalSwitch(lsName string) error
 	ListLogicalSwitch(needVendorFilter bool, filter func(ls *ovnnb.LogicalSwitch) bool) ([]ovnnb.LogicalSwitch, error)
 	LogicalSwitchExists(lsName string) (bool, error)

--- a/pkg/ovs/ovn-nb-logical_switch.go
+++ b/pkg/ovs/ovn-nb-logical_switch.go
@@ -170,6 +170,25 @@ func (c *ovnClient) LogicalSwitchUpdateLoadBalancers(lsName string, op ovsdb.Mut
 	return nil
 }
 
+// LogicalSwitchUpdateOtherConfig add other config to or from logical switch once
+func (c *ovnClient) LogicalSwitchUpdateOtherConfig(lsName string, op ovsdb.Mutator, otherConfig map[string]string) error {
+	if len(otherConfig) == 0 {
+		return nil
+	}
+
+	ops, err := c.LogicalSwitchUpdateOtherConfigOp(lsName, otherConfig, op)
+	if err != nil {
+		klog.Error(err)
+		return fmt.Errorf("generate operations for logical switch %s update other config %v: %v", lsName, otherConfig, err)
+	}
+
+	if err := c.Transact("ls-other-config-update", ops); err != nil {
+		return fmt.Errorf("logical switch %s update other config %v: %v", lsName, otherConfig, err)
+	}
+
+	return nil
+}
+
 // DeleteLogicalSwitch delete logical switch
 func (c *ovnClient) DeleteLogicalSwitch(lsName string) error {
 	op, err := c.DeleteLogicalSwitchOp(lsName)
@@ -277,6 +296,25 @@ func (c *ovnClient) LogicalSwitchUpdatePortOp(lsName string, lspUUID string, op 
 		mutation := &model.Mutation{
 			Field:   &ls.Ports,
 			Value:   []string{lspUUID},
+			Mutator: op,
+		}
+
+		return mutation
+	}
+
+	return c.LogicalSwitchOp(lsName, mutation)
+}
+
+// LogicalSwitchUpdateOtherConfigOp create operations add otherConfig to or delete otherConfig from logical switch
+func (c *ovnClient) LogicalSwitchUpdateOtherConfigOp(lsName string, otherConfig map[string]string, op ovsdb.Mutator) ([]ovsdb.Operation, error) {
+	if len(otherConfig) == 0 {
+		return nil, nil
+	}
+
+	mutation := func(ls *ovnnb.LogicalSwitch) *model.Mutation {
+		mutation := &model.Mutation{
+			Field:   &ls.OtherConfig,
+			Value:   otherConfig,
 			Mutator: op,
 		}
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -2071,6 +2071,8 @@ spec:
                   type: boolean
                 enableEcmp:
                   type: boolean
+                enableMulticastSnoop:
+                  type: boolean
   scope: Cluster
   names:
     plural: subnets


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fef59a</samp>

This pull request adds a new feature to enable or disable multicast snooping on subnets. It updates the `Subnet` CRD schema, the subnet controller, and the OVS package to support this feature. It also modifies the Helm chart template and the YAML file to expose this feature to users.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4fef59a</samp>

> _`Subnet` CRD is the key to our fate_
> _We can snoop on multicast or isolate_
> _With `other_config` we can manipulate_
> _The logical switch that we create_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fef59a</samp>

*  Add a new field `EnableMulicastSnoop` to the `SubnetSpec` type and the `Subnet` CRD schema to allow users to enable or disable multicast snooping on the logical switch associated with the subnet ([link](https://github.com/kubeovn/kube-ovn/pull/3129/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR169), [link](https://github.com/kubeovn/kube-ovn/pull/3129/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1763-R1764), [link](https://github.com/kubeovn/kube-ovn/pull/3129/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R2074-R2075))
*  Update the subnet controller to reconcile the `EnableMulicastSnoop` field with the OVN logical switch `other_config` using the `ovnClient` ([link](https://github.com/kubeovn/kube-ovn/pull/3129/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R107), [link](https://github.com/kubeovn/kube-ovn/pull/3129/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R762-R774))
*  Add a new method `LogicalSwitchUpdateOtherConfig` to the `LogicalSwitch` interface and implement it in the `ovnClient` struct to update the `other_config` of a logical switch with a given mutator and a map of key-value pairs ([link](https://github.com/kubeovn/kube-ovn/pull/3129/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49R54), [link](https://github.com/kubeovn/kube-ovn/pull/3129/files?diff=unified&w=0#diff-6ddbb8fcc94ea100b6c815e02d07765142045d62b2d8023b410ff4613888ab12R173-R191), [link](https://github.com/kubeovn/kube-ovn/pull/3129/files?diff=unified&w=0#diff-6ddbb8fcc94ea100b6c815e02d07765142045d62b2d8023b410ff4613888ab12R308-R326))