### PR TITLE
restore ipam by backend configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/osrg/gobgp/v3 v3.17.0
 	github.com/ovn-org/libovsdb v0.0.0-20230207174348-7f620a35d7e8
 	github.com/parnurzeal/gorequest v0.2.16
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus-community/pro-bing v0.3.0
 	github.com/prometheus/client_golang v1.16.0
 	github.com/scylladb/go-set v1.0.2
@@ -186,7 +187,6 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba // indirect
 	github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 // indirect

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -96,6 +96,9 @@ type Configuration struct {
 	GCInterval      int
 	InspectInterval int
 
+	EnableCmRestore  bool
+	SyncIpamInterval int
+
 	BfdMinTx      int
 	BfdMinRx      int
 	BfdDetectMult int
@@ -168,6 +171,9 @@ func ParseFlags() (*Configuration, error) {
 
 		argGCInterval      = pflag.Int("gc-interval", 360, "The interval between GC processes, default 360 seconds")
 		argInspectInterval = pflag.Int("inspect-interval", 20, "The interval between inspect processes, default 20 seconds")
+
+		argEnableCmRestore  = pflag.Bool("enable-cm-restore", false, "restore ipam info from configmap when start kube-ovn-controller, default false")
+		argSyncIpamInterval = pflag.Int("sync-interval", 30, "The interval to sync ipam assigned info to configmap, default 30 seconds")
 
 		argBfdMinTx      = pflag.Int("bfd-min-tx", 100, "This is the minimum interval, in milliseconds, ovn would like to use when transmitting BFD Control packets")
 		argBfdMinRx      = pflag.Int("bfd-min-rx", 100, "This is the minimum interval, in milliseconds, between received BFD Control packets")
@@ -250,6 +256,8 @@ func ParseFlags() (*Configuration, error) {
 		BfdMinRx:                       *argBfdMinRx,
 		BfdDetectMult:                  *argBfdDetectMult,
 		NodeLocalDnsIP:                 *argNodeLocalDnsIP,
+		EnableCmRestore:                *argEnableCmRestore,
+		SyncIpamInterval:               *argSyncIpamInterval,
 	}
 
 	if config.NetworkType == util.NetworkTypeVlan && config.DefaultHostInterface == "" {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1122,6 +1122,11 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		go wait.Until(c.runAddPodAnnotatedIptablesFipWorker, time.Second, ctx.Done())
 		go wait.Until(c.runDelPodAnnotatedIptablesFipWorker, time.Second, ctx.Done())
 	}
+	go wait.Until(func() {
+		if err := c.updateAssignedPodIPAddressRecord(); err != nil {
+			klog.Errorf("update ipam info to configmap error: %v", err)
+		}
+	}, time.Duration(c.config.SyncIpamInterval)*time.Second, ctx.Done())
 }
 
 func (c *Controller) allSubnetReady(subnets ...string) (bool, error) {

--- a/pkg/controller/data_store.go
+++ b/pkg/controller/data_store.go
@@ -1,0 +1,258 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/pkg/errors"
+)
+
+// CheckpointFormatVersion is the version stamp used on stored checkpoints.
+const CheckpointFormatVersion = "kube-ovn-ipam/1"
+
+// CheckpointData is the format of stored checkpoints. Note this is
+// deliberately a "dumb" format since efficiency is less important
+// than version stability here.
+type CheckpointData struct {
+	Version     string            `json:"version"`
+	Allocations []CheckpointEntry `json:"allocations"`
+}
+
+// CheckpointEntry is a "row" in the conceptual IPAM datastore, as stored
+// in checkpoints.
+type CheckpointEntry struct {
+	IPv4            string `json:"ipv4,omitempty"`
+	IPv6            string `json:"ipv6,omitempty"`
+	K8SPodNamespace string `json:"k8sPodNamespace,omitempty"`
+	K8SPodName      string `json:"k8sPodName,omitempty"`
+}
+
+// ReadBackingStore initializes the IP allocation state from the
+// configured backing store. Should be called before using data store.
+func (c *Controller) ReadBackingStore() error {
+	var data CheckpointData
+
+	// Read from checkpoint file
+	klog.Infof("Begin ipam state recovery from backing store")
+
+	cm, err := c.configMapsLister.ConfigMaps(c.config.PodNamespace).Get(util.OvnBackendStoreConfig)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			klog.Infof("Backend store configmap does not exist, will create later")
+			return nil
+		}
+		klog.Errorf("failed to get ovn-backend-store-config, %v", err)
+		return err
+	}
+	if cm.Data == nil {
+		klog.Infof("There's no data record in ovn-backend-store-config, ignore init restore")
+		return nil
+	}
+
+	assignedData := cm.Data[util.OvnAssignedKey]
+	if err := json.Unmarshal([]byte(assignedData), &data); err != nil {
+		klog.Errorf("failed to read configmap data from ovn-backend-store-config, %v", err)
+		return err
+	}
+
+	if data.Version != CheckpointFormatVersion {
+		return errors.Errorf("failed ipam state recovery due to unexpected checkpointVersion: %v/%v", data.Version, CheckpointFormatVersion)
+	}
+	if normalizedData, err := c.normalizeCheckpointDataByPodExistence(data); err != nil {
+		return errors.Wrap(err, "failed normalize checkpoint data with pod check")
+	} else {
+		data = normalizedData
+	}
+
+	for _, allocation := range data.Allocations {
+		cachedPod, err := c.podsLister.Pods(allocation.K8SPodNamespace).Get(allocation.K8SPodName)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			klog.Error(err)
+		}
+		podNets, err := c.getPodKubeovnNets(cachedPod)
+		if err != nil {
+			klog.Errorf("failed to get pod kubeovn nets %s.%s address %s: %v", cachedPod.Name, cachedPod.Namespace, cachedPod.Annotations[util.IpAddressAnnotation], err)
+			continue
+		}
+		podName := c.getNameByPod(cachedPod)
+		key := fmt.Sprintf("%s/%s", cachedPod.Namespace, podName)
+
+		for _, podNet := range podNets {
+			portName := ovs.PodNameToPortName(podName, cachedPod.Namespace, podNet.ProviderName)
+			ip := cachedPod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)]
+			mac := cachedPod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)]
+			_, _, _, err := c.ipam.GetStaticAddress(key, portName, ip, &mac, podNet.Subnet.Name, true)
+			if err != nil {
+				klog.Errorf("failed to init pod %s.%s address %s: %v", podName, cachedPod.Namespace, cachedPod.Annotations[fmt.Sprintf(util.IpAddressAnnotationTemplate, podNet.ProviderName)], err)
+			}
+		}
+	}
+
+	bytes, _ := json.Marshal(data)
+	cm.Data[util.OvnAssignedKey] = string(bytes)
+	if _, err := c.config.KubeClient.CoreV1().ConfigMaps(c.config.PodNamespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("failed to update ovn-backend-store-config configmap, %v", err)
+		return err
+	}
+
+	klog.Infof("Completed ipam state recovery")
+	return nil
+}
+
+func (c *Controller) normalizeCheckpointDataByPodExistence(checkpoint CheckpointData) (CheckpointData, error) {
+	var validatedAllocations []CheckpointEntry
+
+	for _, allocation := range checkpoint.Allocations {
+		if err := c.validateAllocationByPodExistence(allocation); err != nil {
+			klog.Errorf("failed to validate IP allocation for pod(%v): IPv4(%v), IPv6(%v), %v", allocation.K8SPodName, allocation.IPv4, allocation.IPv6, err)
+		} else {
+			validatedAllocations = append(validatedAllocations, allocation)
+		}
+	}
+	checkpoint.Allocations = validatedAllocations
+
+	return checkpoint, nil
+}
+
+func (c *Controller) validateAllocationByPodExistence(allocation CheckpointEntry) error {
+	if allocation.K8SPodNamespace == "" || allocation.K8SPodName == "" {
+		return nil
+	}
+
+	cachedPod, err := c.podsLister.Pods(allocation.K8SPodNamespace).Get(allocation.K8SPodName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Error(err)
+		return err
+	}
+
+	podNets, err := c.getPodKubeovnNets(cachedPod)
+	if err != nil {
+		klog.Errorf("failed to get pod nets %v", err)
+		return err
+	}
+
+	for _, podNet := range podNets {
+		if _, ok := c.ipam.Subnets[podNet.Subnet.Name]; !ok {
+			return fmt.Errorf("can not find subnet for pod %s/%s", allocation.K8SPodNamespace, allocation.K8SPodName)
+		} else {
+			// The ipam is being recreated now, so can not rely on ipam to check, just recover every pod record in cm
+			return nil
+		}
+	}
+
+	return errors.Errorf("ipam record not found for pod %v/%v", allocation.K8SPodNamespace, allocation.K8SPodName)
+}
+
+func (c *Controller) updateAssignedPodIPAddressRecord() error {
+	var allocations []CheckpointEntry
+	var podNs string
+
+	for _, subnet := range c.ipam.Subnets {
+		var allocation CheckpointEntry
+		if subnet.Name == c.config.NodeSwitch {
+			continue
+		}
+
+		switch subnet.Protocol {
+		case kubeovnv1.ProtocolIPv4:
+			for ip, podName := range subnet.V4IPToPod {
+				podInfos := strings.Split(podName, "/")
+				if len(podInfos) > 1 {
+					podNs = podInfos[0]
+					podName = podInfos[1]
+				} else {
+					podName = podInfos[0]
+				}
+
+				allocation.K8SPodName = podName
+				allocation.K8SPodNamespace = podNs
+				allocation.IPv4 = ip
+				allocations = append(allocations, allocation)
+			}
+
+		case kubeovnv1.ProtocolIPv6:
+			for ip, podName := range subnet.V6IPToPod {
+				podInfos := strings.Split(podName, "/")
+				if len(podInfos) > 1 {
+					podNs = podInfos[0]
+					podName = podInfos[1]
+				} else {
+					podName = podInfos[0]
+				}
+
+				allocation.K8SPodName = podName
+				allocation.K8SPodNamespace = podNs
+				allocation.IPv6 = ip
+				allocations = append(allocations, allocation)
+			}
+		case kubeovnv1.ProtocolDual:
+			for ip, podName := range subnet.V4IPToPod {
+				podInfos := strings.Split(podName, "/")
+				if len(podInfos) > 1 {
+					podNs = podInfos[0]
+					podName = podInfos[1]
+				} else {
+					podName = podInfos[0]
+				}
+
+				allocation.K8SPodName = podName
+				allocation.K8SPodNamespace = podNs
+				allocation.IPv4 = ip
+				// it may be error with multus nic
+				nic := subnet.PodToNicList[podName][0]
+				allocation.IPv6 = subnet.V6NicToIP[nic].String()
+				allocations = append(allocations, allocation)
+			}
+		}
+	}
+
+	cm, err := c.configMapsLister.ConfigMaps(c.config.PodNamespace).Get(util.OvnBackendStoreConfig)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			klog.Errorf("failed to get ovn-backend-store-config, should create cm first")
+
+			var newCm corev1.ConfigMap
+			newCm.Name = util.OvnBackendStoreConfig
+			newCm.Namespace = c.config.PodNamespace
+			if cm, err = c.config.KubeClient.CoreV1().ConfigMaps(c.config.PodNamespace).Create(context.Background(), &newCm, metav1.CreateOptions{}); err != nil {
+				klog.Errorf("failed to create ovn-backend-store-config configmap, %v", err)
+				return err
+			}
+		} else {
+			klog.Errorf("failed to get ovn-backend-store-config, %v", err)
+			return err
+		}
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+
+	data := CheckpointData{
+		Version:     CheckpointFormatVersion,
+		Allocations: allocations,
+	}
+	bytes, _ := json.Marshal(data)
+	cm.Data[util.OvnAssignedKey] = string(bytes)
+	if _, err := c.config.KubeClient.CoreV1().ConfigMaps(c.config.PodNamespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("failed to update ovn-backend-store-config configmap, %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -168,6 +168,8 @@ const (
 	VpcNatConfig           = "ovn-vpc-nat-config"
 
 	DefaultSecurityGroupName = "default-securitygroup"
+	OvnBackendStoreConfig    = "ovn-backend-store-config"
+	OvnAssignedKey           = "ovn-assigned"
 
 	DefaultVpc    = "ovn-cluster"
 	DefaultSubnet = "ovn-default"


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Features
- 
### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd570de</samp>

This pull request adds a feature to sync and restore the IPAM state of the controller from a configmap. It introduces a new dependency, two new configuration options, a new goroutine, a new file with the data store logic, and some modifications to the existing IPAM initialization and constants.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dd570de</samp>

> _`SyncIpamInterval` is the countdown to doom_
> _Restoring the state from the `OvnBackendStoreConfig`_
> _No mercy for the pods that don't match the `CheckpointData`_
> _We are the controllers of the IPAM fate_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd570de</samp>

*  Add the feature of restoring and syncing IPAM state from a configmap ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R31), [link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R99-R101), [link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R175-R177), [link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R259-R260), [link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R1125-R1129), [link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-1ee185ed99a5f0b353bd716dbb6205319445ab18799b25d2972d8abb841d9f5fR1-R258), [link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L368-R425), [link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR171-R172))
  * Add two new fields to the `Configuration` type in `pkg/controller/config.go` to control the feature: `EnableCmRestore` and `SyncIpamInterval` ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R99-R101))
  * Add two new command-line flags to the `ParseFlags` function in `pkg/controller/config.go` to set the values of the new fields: `--enable-cm-restore` and `--sync-interval` ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R175-R177))
  * Assign the values of the flags to the fields in the `Configuration` type ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-b47da0cc17fe8ee9178f1d883fbc42f45187f2adbb02d05ca9dd8644079bee75R259-R260))
  * Add a new file `pkg/controller/data_store.go` that contains the logic of reading and writing the IPAM state from and to the configmap ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-1ee185ed99a5f0b353bd716dbb6205319445ab18799b25d2972d8abb841d9f5fR1-R258))
    * Define the `CheckpointData` type, which represents the format of the IPAM state stored in the configmap ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-1ee185ed99a5f0b353bd716dbb6205319445ab18799b25d2972d8abb841d9f5fR1-R258))
    * Define the `ReadBackingStore` function, which is used to restore the IPAM state from the configmap ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-1ee185ed99a5f0b353bd716dbb6205319445ab18799b25d2972d8abb841d9f5fR1-R258))
    * Define the `updateAssignedPodIPAddressRecord` function, which is used to sync the IPAM state to the configmap ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-1ee185ed99a5f0b353bd716dbb6205319445ab18799b25d2972d8abb841d9f5fR1-R258))
    * Define some helper functions to validate and normalize the IPAM state based on the pod existence and subnet information ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-1ee185ed99a5f0b353bd716dbb6205319445ab18799b25d2972d8abb841d9f5fR1-R258))
  * Modify the `InitIPAM` function in `pkg/controller/init.go` to check whether the `EnableCmRestore` field is true, and if so, call the `ReadBackingStore` function instead of iterating over the pods ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L368-R425))
  * Add a new goroutine to the `startWorkers` function in `pkg/controller/controller.go` that periodically calls the `updateAssignedPodIPAddressRecord` function to sync the IPAM state to the configmap ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1R1125-R1129))
  * Add the dependency of `github.com/pkg/errors` v0.9.1 to the `go.mod` file, which is used for error handling in the new code ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R31))
  * Remove the indirect dependency of `github.com/pkg/errors` v0.9.1 from the `go.sum` file, since it is now a direct dependency ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L189))
  * Add two new constants to the `util` package in `pkg/util/const.go` that refer to the name and key of the configmap that stores the IPAM state: `OvnBackendStoreConfig` and `OvnAssignedKey` ([link](https://github.com/kubeovn/kube-ovn/pull/3132/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR171-R172))