### PR TITLE
fix ovn nat not clean

### DIFF
--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -38,10 +38,13 @@ func (c *Controller) enqueueUpdateOvnDnatRule(old, new interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-
-	oldDnat := old.(*kubeovnv1.OvnDnatRule)
 	newDnat := new.(*kubeovnv1.OvnDnatRule)
-
+	if !newDnat.DeletionTimestamp.IsZero() {
+		klog.Infof("enqueue del ovn dnat %s", key)
+		c.delOvnDnatRuleQueue.Add(key)
+		return
+	}
+	oldDnat := old.(*kubeovnv1.OvnDnatRule)
 	if oldDnat.Spec.OvnEip != newDnat.Spec.OvnEip {
 		c.resetOvnEipQueue.Add(oldDnat.Spec.OvnEip)
 	}

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -40,9 +40,14 @@ func (c *Controller) enqueueUpdateOvnDnatRule(old, new interface{}) {
 	}
 	newDnat := new.(*kubeovnv1.OvnDnatRule)
 	if !newDnat.DeletionTimestamp.IsZero() {
-		klog.Infof("enqueue del ovn dnat %s", key)
-		c.delOvnDnatRuleQueue.Add(key)
-		return
+		if len(newDnat.Finalizers) == 0 {
+			// avoid delete twice
+			return
+		} else {
+			klog.Infof("enqueue del ovn dnat %s", key)
+			c.delOvnDnatRuleQueue.Add(key)
+			return
+		}
 	}
 	oldDnat := old.(*kubeovnv1.OvnDnatRule)
 	if oldDnat.Spec.OvnEip != newDnat.Spec.OvnEip {

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -49,7 +48,7 @@ func (c *Controller) enqueueUpdateOvnEip(old, new interface{}) {
 			return
 		} else {
 			klog.Infof("enqueue del ovn eip %s", key)
-			c.delOvnEipQueue.Add(newEip)
+			c.delOvnEipQueue.Add(key)
 			return
 		}
 	}
@@ -74,8 +73,7 @@ func (c *Controller) enqueueDelOvnEip(obj interface{}) {
 		return
 	}
 	klog.Infof("enqueue del ovn eip %s", key)
-	eip := obj.(*kubeovnv1.OvnEip)
-	c.delOvnEipQueue.Add(eip)
+	c.delOvnEipQueue.Add(key)
 }
 
 func (c *Controller) runAddOvnEipWorker() {
@@ -189,16 +187,16 @@ func (c *Controller) processNextDeleteOvnEipWorkItem() bool {
 	}
 	err := func(obj interface{}) error {
 		defer c.delOvnEipQueue.Done(obj)
-		var eip *kubeovnv1.OvnEip
+		var key string
 		var ok bool
-		if eip, ok = obj.(*kubeovnv1.OvnEip); !ok {
+		if key, ok = obj.(string); !ok {
 			c.delOvnEipQueue.Forget(obj)
 			utilruntime.HandleError(fmt.Errorf("expected ovn eip in workqueue but got %#v", obj))
 			return nil
 		}
-		if err := c.handleDelOvnEip(eip); err != nil {
-			c.delOvnEipQueue.AddRateLimited(obj)
-			return fmt.Errorf("error syncing '%s': %s, requeuing", eip.Name, err.Error())
+		if err := c.handleDelOvnEip(key); err != nil {
+			c.delOvnEipQueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
 		}
 		c.delOvnEipQueue.Forget(obj)
 		return nil
@@ -285,7 +283,7 @@ func (c *Controller) handleUpdateOvnEip(key string) error {
 		klog.Error(err)
 		return err
 	}
-	klog.V(3).Infof("handle update ovn eip %s", cachedEip.Name)
+	klog.Infof("handle update ovn eip %s", cachedEip.Name)
 	if !cachedEip.DeletionTimestamp.IsZero() {
 		subnetName := cachedEip.Spec.ExternalSubnet
 		if subnetName == "" {
@@ -332,28 +330,30 @@ func (c *Controller) handleResetOvnEip(key string) error {
 	return nil
 }
 
-func (c *Controller) handleDelOvnEip(eip *kubeovnv1.OvnEip) error {
-	klog.V(3).Infof("handle del ovn eip %s", eip.Name)
-	if len(eip.Finalizers) > 1 {
-		err := errors.New("eip is referenced, it cannot be deleted directly")
-		klog.Errorf("failed to delete eip %s, %v", eip.Name, err)
+func (c *Controller) handleDelOvnEip(key string) error {
+	klog.Infof("handle del ovn eip %s", key)
+	eip, err := c.ovnEipsLister.Get(key)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Error(err)
 		return err
 	}
-
-	if err := c.handleDelOvnEipFinalizer(eip, util.OvnEipFinalizer); err != nil {
+	if err = c.handleDelOvnEipFinalizer(eip, util.ControllerName); err != nil {
 		klog.Errorf("failed to handle remove ovn eip finalizer , %v", err)
 		return err
 	}
 
 	if eip.Spec.Type == util.Lsp {
-		if err := c.ovnClient.DeleteLogicalSwitchPort(eip.Name); err != nil {
+		if err = c.ovnClient.DeleteLogicalSwitchPort(eip.Name); err != nil {
 			klog.Errorf("failed to delete lsp %s, %v", eip.Name, err)
 			return err
 		}
 	}
 
 	if eip.Spec.Type == util.Lrp {
-		if err := c.ovnClient.DeleteLogicalRouterPort(eip.Name); err != nil {
+		if err = c.ovnClient.DeleteLogicalRouterPort(eip.Name); err != nil {
 			klog.Errorf("failed to delete lrp %s, %v", eip.Name, err)
 			return err
 		}

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -40,7 +40,6 @@ func (c *Controller) enqueueUpdateOvnEip(old, new interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-	oldEip := old.(*kubeovnv1.OvnEip)
 	newEip := new.(*kubeovnv1.OvnEip)
 	if newEip.DeletionTimestamp != nil {
 		if len(newEip.Finalizers) == 0 {
@@ -52,6 +51,7 @@ func (c *Controller) enqueueUpdateOvnEip(old, new interface{}) {
 			return
 		}
 	}
+	oldEip := old.(*kubeovnv1.OvnEip)
 	if oldEip.Spec.V4Ip != "" && oldEip.Spec.V4Ip != newEip.Spec.V4Ip ||
 		oldEip.Spec.MacAddress != "" && oldEip.Spec.MacAddress != newEip.Spec.MacAddress {
 		klog.Infof("not support change ip or mac for eip %s", key)

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -40,8 +40,13 @@ func (c *Controller) enqueueUpdateOvnFip(old, new interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-	oldFip := old.(*kubeovnv1.OvnFip)
 	newFip := new.(*kubeovnv1.OvnFip)
+	if !newFip.DeletionTimestamp.IsZero() {
+		klog.Infof("enqueue del ovn fip %s", key)
+		c.delOvnFipQueue.Add(key)
+		return
+	}
+	oldFip := old.(*kubeovnv1.OvnFip)
 	if oldFip.Spec.OvnEip != newFip.Spec.OvnEip {
 		// enqueue to reset eip to be clean
 		klog.Infof("enqueue reset old ovn eip %s", oldFip.Spec.OvnEip)

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -42,9 +42,14 @@ func (c *Controller) enqueueUpdateOvnFip(old, new interface{}) {
 	}
 	newFip := new.(*kubeovnv1.OvnFip)
 	if !newFip.DeletionTimestamp.IsZero() {
-		klog.Infof("enqueue del ovn fip %s", key)
-		c.delOvnFipQueue.Add(key)
-		return
+		if len(newFip.Finalizers) == 0 {
+			// avoid delete twice
+			return
+		} else {
+			klog.Infof("enqueue del ovn fip %s", key)
+			c.delOvnFipQueue.Add(key)
+			return
+		}
 	}
 	oldFip := old.(*kubeovnv1.OvnFip)
 	if oldFip.Spec.OvnEip != newFip.Spec.OvnEip {

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -36,8 +36,13 @@ func (c *Controller) enqueueUpdateOvnSnatRule(old, new interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-	oldSnat := old.(*kubeovnv1.OvnSnatRule)
 	newSnat := new.(*kubeovnv1.OvnSnatRule)
+	if !newSnat.DeletionTimestamp.IsZero() {
+		klog.Infof("enqueue del ovn snat %s", key)
+		c.delOvnSnatRuleQueue.Add(key)
+		return
+	}
+	oldSnat := old.(*kubeovnv1.OvnSnatRule)
 	if oldSnat.Spec.OvnEip != newSnat.Spec.OvnEip {
 		// enqueue to reset eip to be clean
 		c.resetOvnEipQueue.Add(oldSnat.Spec.OvnEip)

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -38,9 +38,14 @@ func (c *Controller) enqueueUpdateOvnSnatRule(old, new interface{}) {
 	}
 	newSnat := new.(*kubeovnv1.OvnSnatRule)
 	if !newSnat.DeletionTimestamp.IsZero() {
-		klog.Infof("enqueue del ovn snat %s", key)
-		c.delOvnSnatRuleQueue.Add(key)
-		return
+		if len(newSnat.Finalizers) == 0 {
+			// avoid delete twice
+			return
+		} else {
+			klog.Infof("enqueue del ovn snat %s", key)
+			c.delOvnSnatRuleQueue.Add(key)
+			return
+		}
 	}
 	oldSnat := old.(*kubeovnv1.OvnSnatRule)
 	if oldSnat.Spec.OvnEip != newSnat.Spec.OvnEip {

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -28,7 +28,7 @@ func (c *Controller) enqueueAddVirtualIp(obj interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-	klog.V(3).Infof("enqueue add vip %s", key)
+	klog.Infof("enqueue add vip %s", key)
 	c.addVirtualIpQueue.Add(key)
 }
 
@@ -46,7 +46,7 @@ func (c *Controller) enqueueUpdateVirtualIp(old, new interface{}) {
 		oldVip.Spec.ParentMac != newVip.Spec.ParentMac ||
 		oldVip.Spec.ParentV4ip != newVip.Spec.ParentV4ip ||
 		oldVip.Spec.V4ip != newVip.Spec.V4ip {
-		klog.V(3).Infof("enqueue update vip %s", key)
+		klog.Infof("enqueue update vip %s", key)
 		c.updateVirtualIpQueue.Add(key)
 	}
 }
@@ -58,7 +58,7 @@ func (c *Controller) enqueueDelVirtualIp(obj interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-	klog.V(3).Infof("enqueue del vip %s", key)
+	klog.Infof("enqueue del vip %s", key)
 	vip := obj.(*kubeovnv1.Vip)
 	c.delVirtualIpQueue.Add(vip)
 }

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -298,7 +298,7 @@ func (c *Controller) handleUpdateVirtualIp(key string) error {
 }
 
 func (c *Controller) handleDelVirtualIp(vip *kubeovnv1.Vip) error {
-	klog.Infof("delete vip %s", vip.Name)
+	klog.Infof("handle delete vip %s", vip.Name)
 	// TODO:// clean vip in its parent port aap list
 	if vip.Spec.Type == util.SwitchLBRuleVip {
 		subnet, err := c.subnetsLister.Get(vip.Spec.Subnet)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -20,7 +20,6 @@ const (
 	FipNameAnnotation    = "ovn.kubernetes.io/fip_name"
 	FipEnableAnnotation  = "ovn.kubernetes.io/enable_fip"
 	FipFinalizer         = "ovn.kubernetes.io/fip"
-	OvnEipFinalizer      = "ovn.kubernetes.io/ovn_eip"
 	VipAnnotation        = "ovn.kubernetes.io/vip"
 	ChassisAnnotation    = "ovn.kubernetes.io/chassis"
 

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -307,12 +307,21 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		ovnEipClient.DeleteSync(dnatEipName)
 		ginkgo.By("Deleting ovn eip " + snatEipName)
 		ovnEipClient.DeleteSync(snatEipName)
-		ginkgo.By("Deleting ovn share eip " + sharedEipName)
-		ovnEipClient.DeleteSync(sharedEipName)
 
-		ginkgo.By("Deleting ovn vip " + arpProxyVip1Name)
+		ginkgo.By("Deleting ovn arp proxy vip " + arpProxyVip1Name)
 		vipClient.DeleteSync(arpProxyVip1Name)
-		ginkgo.By("Deleting ovn vip " + arpProxyVip2Name)
+		ginkgo.By("Deleting ovn arp proxy vip " + arpProxyVip2Name)
+
+		// clean up share eip case resource
+		ginkgo.By("Deleting share ovn dnat " + sharedEipDnatName)
+		ovnDnatRuleClient.DeleteSync(sharedEipDnatName)
+		ginkgo.By("Deleting share ovn fip " + sharedEipFipShoudOkName)
+		ovnFipClient.DeleteSync(sharedEipFipShoudOkName)
+		ginkgo.By("Deleting share ovn fip " + sharedEipFipShoudFailName)
+		ovnFipClient.DeleteSync(sharedEipFipShoudFailName)
+		ginkgo.By("Deleting share ovn snat " + sharedEipSnatName)
+		ovnSnatRuleClient.DeleteSync(sharedEipSnatName)
+
 		vipClient.DeleteSync(arpProxyVip2Name)
 		ginkgo.By("Deleting ovn vip " + dnatVipName)
 		vipClient.DeleteSync(dnatVipName)
@@ -323,16 +332,13 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 
 		ginkgo.By("Deleting subnet " + noBfdSubnetName)
 		subnetClient.DeleteSync(noBfdSubnetName)
-
 		ginkgo.By("Deleting subnet " + bfdSubnetName)
 		subnetClient.DeleteSync(bfdSubnetName)
-
 		ginkgo.By("Deleting underlay subnet " + underlaySubnetName)
 		subnetClient.DeleteSync(underlaySubnetName)
 
 		ginkgo.By("Deleting no bfd custom vpc " + noBfdVpcName)
 		vpcClient.DeleteSync(noBfdVpcName)
-
 		ginkgo.By("Deleting bfd custom vpc " + bfdVpcName)
 		vpcClient.DeleteSync(bfdVpcName)
 
@@ -488,16 +494,6 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 			framework.ExpectEqual(route.Policy, kubeovnv1.PolicyDst)
 			framework.ExpectContainSubstring(vlanSubnetGw, route.NextHopIP)
 		}
-
-		// clean up share eip case resource
-		ginkgo.By("Deleting share ovn fip " + sharedEipFipShoudOkName)
-		ovnFipClient.DeleteSync(sharedEipFipShoudOkName)
-		ginkgo.By("Deleting share ovn fip " + sharedEipFipShoudFailName)
-		ovnFipClient.DeleteSync(sharedEipFipShoudFailName)
-		ginkgo.By("Deleting share ovn dnat " + sharedEipDnatName)
-		ovnDnatRuleClient.DeleteSync(sharedEipDnatName)
-		ginkgo.By("Deleting share ovn snat " + sharedEipSnatName)
-		ovnSnatRuleClient.DeleteSync(sharedEipSnatName)
 
 		ginkgo.By("2. Creating custom vpc enable external and bfd")
 		for _, nodeName := range nodeNames {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b5d53e</samp>

This pull request refactors and improves the controller code for handling ovn dnat, fip, and snat events. It removes unnecessary code, reduces logging verbosity, and optimizes performance by avoiding extra lookups. It also makes the logging messages more consistent and visible across the different files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3b5d53e</samp>

> _We're haulin' on the ropes of the `ovn` code_
> _We're makin' it more simple and more fast_
> _We're loggin' and we're handlin' the dnat and the snat_
> _We're workin' as a team to raise the mast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b5d53e</samp>

*  Simplify and refactor the code that handles deletion events for ovn dnat, fip, and snat rules, by passing the object instead of the key and removing unnecessary checks and error handling ([link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L43-L47), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L70-R67), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L157-R162), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L318-R323), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L44-L48), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L69-R66), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L153-R158), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L413-R413), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L435-R421), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eL40-L44), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eL65-R62), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eL152-R157), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eL293-L306), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eL374-R368))
* Change the logging level of several messages from 3 to the default level, to make them more visible and consistent with other similar messages in `ovn_dnat.go`, `ovn_fip.go`, and `ovn_snat.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L29-R29), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L215-R211), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L357-R337), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-7fa512aca42bc3bdafdaed430f6c2000a24cdf0973b09a703a88c7a9b7b054d1L424-R404), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L31-R31), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L205-R201), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L319-R315), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L383-R379), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eL187-R183), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eL281-R277), [link](https://github.com/kubeovn/kube-ovn/pull/3139/files?diff=unified&w=0#diff-fb28e2896fc5096282fe9688d04cca1bbc47ee11feda1d28c0c39874e221139eL347-R329))