### PR TITLE
base: remove ovn patch for skipping ct

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -428,7 +428,7 @@ jobs:
       - build-e2e-binaries
       - netpol-path-filter
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -108,7 +108,7 @@ jobs:
   k8s-netpol-e2e:
     name: Kubernetes Network Policy E2E
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -86,7 +86,7 @@ k8s-netpol-legacy-e2e:
 .PHONY: k8s-netpol-e2e
 k8s-netpol-e2e:
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/k8s-network
-	ginkgo -p --randomize-all -v --timeout=2h \
+	ginkgo --randomize-all -v --timeout=2h \
 		$(call ginkgo_option,focus,$(K8S_NETPOL_E2E_FOCUS)) \
 		$(call ginkgo_option,skip,$(K8S_NETPOL_E2E_SKIP)) \
 		./test/e2e/k8s-network/k8s-network.test

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -29,8 +29,6 @@ RUN cd /usr/src/ && \
 
 RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
-    # do not send direct traffic between lports to conntrack
-    curl -s https://github.com/kubeovn/ovn/commit/4124fb623183541b80a577846ce145c7faf8eb5d.patch | git apply && \
     # change hash type from dp_hash to hash with field src_ip
     curl -s https://github.com/kubeovn/ovn/commit/daa09e380eec61620d4ee317e3265c44366d1147.patch | git apply && \
     # set ether dst addr for dnat on logical switch

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -109,7 +109,7 @@ RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \
 ARG DEBUG=false
 RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages \
     if [ "${DEBUG}" = "true" ]; then \
-        apt update && apt install -y --no-install-recommends valgrind && \
+        apt update && apt install -y --no-install-recommends gdb valgrind && \
         rm -rf /var/lib/apt/lists/* && \
         dpkg -i --ignore-depends=openvswitch-switch,openvswitch-common /packages/*.ddeb; \
     fi


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
In redhat/rocky 8.6, pods cannot coommunicate with each other via pod ips:

```txt
tcp      6 117 SYN_SENT src=10.16.0.6 dst=10.16.0.4 sport=37890 dport=9153 [UNREPLIED] src=10.16.0.4 dst=10.16.0.6 sport=9153 dport=37890 mark=0 zone=9 use=1
tcp      6 298 ESTABLISHED src=10.16.0.4 dst=10.16.0.6 sport=9153 dport=37890 [UNREPLIED] src=10.16.0.6 dst=10.16.0.4 sport=37890 dport=51655 mark=0 zone=8 use=1
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 621b685</samp>

Increased the timeout-minutes for two GitHub workflow jobs that run network policy tests. This is to prevent the jobs from failing due to timeout errors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 621b685</samp>

> _`timeout-minutes` grows_
> _netpol tests are slow and flaky_
> _autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 621b685</samp>

*  Increase the timeout-minutes for two jobs that run time-consuming and flaky tests ([link](https://github.com/kubeovn/kube-ovn/pull/3141/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L431-R431), [link](https://github.com/kubeovn/kube-ovn/pull/3141/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L111-R111))