### PR TITLE
统一 ovsovn  maxUnavailable

### DIFF
--- a/charts/templates/ovn-dpdk-ds.yaml
+++ b/charts/templates/ovn-dpdk-ds.yaml
@@ -10,9 +10,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: ovs-dpdk
+      app: ovs
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3497,7 +3497,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 100%
+      maxSurge: 1
       maxUnavailable: 0
   template:
     metadata:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3333,7 +3333,10 @@ spec:
     matchLabels:
       app: ovs
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -317,7 +317,10 @@ spec:
     matchLabels:
       app: ovs
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -219,7 +219,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 100%
+      maxSurge: 1
       maxUnavailable: 0
   template:
     metadata:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53c1046</samp>

Modify the `rollingUpdate` strategy parameters for the `ovs-ovn` daemonset in `charts/templates/ovs-ovn-ds.yaml` to enable faster and more robust updates. This improves the performance and reliability of the Open vSwitch and Open Virtual Network components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 53c1046</samp>

> _`ovs-ovn` updates_
> _faster and more robust now_
> _autumn wind of change_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53c1046</samp>

*  Modify the `rollingUpdate` strategy for the `ovs-ovn` daemonset to allow faster and more robust updates ([link](https://github.com/kubeovn/kube-ovn/pull/3148/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L16-R17))