### PR TITLE
Fix max unavailable

### DIFF
--- a/charts/templates/ovn-dpdk-ds.yaml
+++ b/charts/templates/ovn-dpdk-ds.yaml
@@ -12,7 +12,10 @@ spec:
     matchLabels:
       app: ovs-dpdk
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3331,13 +3331,16 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: ovs
+      app: ovs-dpdk
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
-        app: ovs
+        app: ovs-dpdk
         component: network
         type: infra
     spec:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3497,7 +3497,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 100%
+      maxSurge: 1
       maxUnavailable: 0
   template:
     metadata:

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -315,13 +315,16 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: ovs
+      app: ovs-dpdk
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
-        app: ovs
+        app: ovs-dpdk
         component: network
         type: infra
     spec:

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -219,7 +219,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 100%
+      maxSurge: 1
       maxUnavailable: 0
   template:
     metadata:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
ovs-ovn 更新机制以及dpdk label 调为一致

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b29e74c</samp>

This pull request updates the update strategy of the `ovs-dpdk` daemonset to use rolling update with minimal disruption. It also renames the app label of the daemonset and adjusts the maxSurge parameter of the `ovn-ha` deployment.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b29e74c</samp>

> _`ovs-dpdk` pods_
> _rolling update strategy_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b29e74c</samp>

*  Change the update strategy of the ovs-dpdk daemonset to use rolling update with maxSurge and maxUnavailable set to 1 ([link](https://github.com/kubeovn/kube-ovn/pull/3149/files?diff=unified&w=0#diff-4ff764064ce8dcea779157766f8170f24e26fb03e6886665a42fe7cb4ba5f23fL15-R18), [link](https://github.com/kubeovn/kube-ovn/pull/3149/files?diff=unified&w=0#diff-e8ff83be2329052ff8d94933b1ee843421bd0ebce8f505a4f27fba7f887b90b0L318-R327))
*  Rename the app label of the ovs-dpdk daemonset from ovs to ovs-dpdk for clarity ([link](https://github.com/kubeovn/kube-ovn/pull/3149/files?diff=unified&w=0#diff-e8ff83be2329052ff8d94933b1ee843421bd0ebce8f505a4f27fba7f887b90b0L318-R327))
*  Reduce the maxSurge parameter of the rolling update strategy of the ovn-central deployment from 100% to 1 to avoid resource exhaustion ([link](https://github.com/kubeovn/kube-ovn/pull/3149/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL222-R222))