### PR TITLE
kubectl-ko: get ovn db leaders only on necessary

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -509,8 +509,7 @@ applyConnServerDaemonset(){
   fi
 
   imageID=$(kubectl get ds -n $KUBE_OVN_NS kube-ovn-pinger -o jsonpath={.spec.template.spec.containers[0].image})
-  tmpFileName="conn-server.yaml"
-  cat <<EOF > $tmpFileName
+  cat <<EOF | kubectl apply -f -
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -544,8 +543,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
 EOF
-  kubectl apply -f $tmpFileName
-  rm $tmpFileName
 
   isfailed=true
   for i in {0..59}
@@ -565,9 +562,7 @@ EOF
 
 applyTestNodePortService() {
   local svcName="test-node-port"
-  tmpFileName="$svcName.yaml"
-
-  cat <<EOF > $tmpFileName
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Service
 metadata:
@@ -585,12 +580,9 @@ spec:
   selector:
     app: kube-ovn-pinger
 EOF
-  kubectl apply -f $tmpFileName
-  rm $tmpFileName
 }
 
 getTestNodePortServiceIPPorts() {
-
   targetIPPorts=""
   nodeIPs=($(kubectl get node -o wide | grep -v "INTERNAL-IP" | awk '{print $6}'))
   nodePort=$(kubectl get svc test-node-port -n $KUBE_OVN_NS -o 'jsonpath={.spec.ports[0].nodePort}')
@@ -1253,9 +1245,7 @@ applyTestServer() {
   podName="test-server"
   nodeID=$1
   imageID=$2
-  tmpFileName="$podName.yaml"
-
-  cat <<EOF > $tmpFileName
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -1277,18 +1267,13 @@ spec:
   nodeSelector:
     kubernetes.io/hostname: $nodeID
 EOF
-
-  kubectl apply -f $tmpFileName
-  rm $tmpFileName
 }
 
 applyTestHostServer() {
   podName="test-host-server"
   nodeID=$1
   imageID=$2
-  tmpFileName="$podName.yaml"
-
-  cat <<EOF > $tmpFileName
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -1310,19 +1295,13 @@ spec:
   nodeSelector:
     kubernetes.io/hostname: $nodeID
 EOF
-
-  kubectl apply -f $tmpFileName
-  rm $tmpFileName
 }
-
 
 applyTestClient() {
   local podName="test-client"
   local nodeID=$1
   local imageID=$2
-  tmpFileName="$podName.yaml"
-
-  cat <<EOF > $tmpFileName
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -1339,17 +1318,13 @@ spec:
   nodeSelector:
     kubernetes.io/hostname: $nodeID
 EOF
-  kubectl apply -f $tmpFileName
-  rm $tmpFileName
 }
 
 applyTestHostClient() {
   local podName="test-host-client"
   local nodeID=$1
   local imageID=$2
-  tmpFileName="$podName.yaml"
-
-  cat <<EOF > $tmpFileName
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -1367,15 +1342,11 @@ spec:
   nodeSelector:
     kubernetes.io/hostname: $nodeID
 EOF
-  kubectl apply -f $tmpFileName
-  rm $tmpFileName
 }
 
 applyTestServerService() {
   local svcName="test-server"
-  tmpFileName="$svcName.yaml"
-
-  cat <<EOF > $tmpFileName
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Service
 metadata:
@@ -1404,8 +1375,6 @@ spec:
   selector:
     env: server
 EOF
-  kubectl apply -f $tmpFileName
-  rm $tmpFileName
 }
 
 addHeaderDecoration() {

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -7,7 +7,7 @@ OVN_NB_POD=
 OVN_SB_POD=
 OVN_NORTHD_POD=
 KUBE_OVN_VERSION=
-REGISTRY="kubeovn"
+REGISTRY="docker.io/kubeovn"
 PERF_TIMES=5
 PERF_LABEL="PerfTest"
 CONN_CHECK_LABEL="conn-check"
@@ -36,7 +36,7 @@ showHelp(){
   echo "  tuning {install-fastpath|local-install-fastpath|remove-fastpath|install-stt|local-install-stt|remove-stt} {centos7|centos8}} [kernel-devel-version]    deploy kernel optimisation components to the system"
   echo "  reload    restart all kube-ovn components"
   echo "  log {kube-ovn|ovn|ovs|linux|all}    save log to ./kubectl-ko-log/"
-  echo "  perf [image] performance test default image is kubeovn/test:v1.12.0"
+  echo "  perf [image] performance test default image is docker.io/kubeovn/test:v1.13.0"
 }
 
 # usage: ipv4_to_hex 192.168.0.1
@@ -1456,7 +1456,7 @@ quitPerfTest() {
 
 perf(){
   addHeaderDecoration "Prepareing Performance Test Resources"
-  imageID=${1:-"kubeovn/test:v1.12.0"}
+  imageID=${1:-"docker.io/kubeovn/test:v1.13.0"}
 
   nodes=($(kubectl get node --no-headers -o custom-columns=NAME:.metadata.name))
   if [[ ${#nodes} -eq 1 ]]; then
@@ -1601,7 +1601,7 @@ genMulticastPerfResult() {
   tmpFileName="multicast-$serverName.log"
   PERF_GC_COMMAND+=("rm -f $tmpFileName")
   LAST_PERF_FAILED_LOG=$tmpFileName
-  
+
   start_server_cmd="iperf -s -B 224.0.0.100 -i 1 -u"
   kubectl exec $serverName -n $KUBE_OVN_NS -- $start_server_cmd > $tmpFileName &
   sleep 1
@@ -1627,7 +1627,6 @@ checkLeaderRecover() {
   sleep 5
   getOvnCentralPod
   getPodRecoverTime "northd"
-
 }
 
 getPodRecoverTime(){
@@ -1663,25 +1662,27 @@ fi
 
 subcommand="$1"; shift
 
-getOvnCentralPod
-
 case $subcommand in
   nbctl)
+    getOvnCentralPod
     kubectl exec "$OVN_NB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-nbctl "$@"
     ;;
   sbctl)
+    getOvnCentralPod
     kubectl exec "$OVN_SB_POD" -n $KUBE_OVN_NS -c ovn-central -- ovn-sbctl "$@"
     ;;
   vsctl|ofctl|dpctl|appctl)
     xxctl "$subcommand" "$@"
     ;;
   nb|sb)
+    getOvnCentralPod
     dbtool "$subcommand" "$@"
     ;;
   tcpdump)
     tcpdump "$@"
     ;;
   trace)
+    getOvnCentralPod
     trace "$@"
     ;;
   diagnose)
@@ -1700,6 +1701,7 @@ case $subcommand in
     log "$@"
     ;;
   perf)
+    getOvnCentralPod
     perf "$@"
     ;;
   *)

--- a/test/server/README.md
+++ b/test/server/README.md
@@ -4,7 +4,7 @@ This server mainly focuses on test network break effect during kube-ovn upgrade 
 
 ## How test server test network break
 
-The test-server will use ping, iperf3 and curl to visit a specified address during upgrade or reload. Then it automatically collect metrics from 
+The test-server will use ping, iperf3 and curl to visit a specified address during upgrade or reload. Then it automatically collect metrics from
 `/proc/net/snmp` and return code to calculate ICMP lost, TCP retransmit packets and TCP connection failure.
 
 ```bash
@@ -13,15 +13,15 @@ make kind-init kind-install
 
 # Build and deploy test-server
 make image-test
-kind load docker-image --name kube-ovn kubeovn/test:v1.12.0
+kind load docker-image --name kube-ovn kubeovn/test:v1.13.0
 kubectl apply -f test/server/test-server.yaml
-docker run --name kube-ovn-test -d --net=kind kubeovn/test:v1.12.0
+docker run --name kube-ovn-test -d --net=kind kubeovn/test:v1.13.0
 docker inspect kube-ovn-test -f '{{.NetworkSettings.Networks.kind.IPAddress}}'
 
 # Run test-server analysis tool in one terminal and reload kube-ovn in another terminal
 # terminal 1 (replace 172.18.0.5/80 with the address/port you want to test)
 kubectl exec -it test-client -- ./test-server --remote-address=172.18.0.5 --remote-port=80 --output=json --duration-seconds=60
- 
+
 # terminal 2
 kubectl ko reload
 

--- a/test/server/test-server.yaml
+++ b/test/server/test-server.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: test-server
-      image: kubeovn/test:v1.12.0
+      image: kubeovn/test:v1.13.0
       imagePullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/hostname: kube-ovn-control-plane
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: test-client
-      image: kubeovn/test:v1.12.0
+      image: kubeovn/test:v1.13.0
       imagePullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/hostname: kube-ovn-worker

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-controller
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           args:
             - /kube-ovn/start-controller.sh
@@ -169,7 +169,7 @@ spec:
       hostPID: true
       initContainers:
         - name: install-cni
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/install-cni.sh"]
           securityContext:
@@ -182,7 +182,7 @@ spec:
               name: local-bin
       containers:
         - name: cni-server
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -358,7 +358,7 @@ spec:
       hostPID: true
       containers:
         - name: pinger
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           command:
             - /kube-ovn/kube-ovn-pinger
           args:
@@ -489,7 +489,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-controller
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           args:
             - /kube-ovn/start-controller.sh
@@ -169,7 +169,7 @@ spec:
       hostPID: true
       initContainers:
         - name: install-cni
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/install-cni.sh"]
           securityContext:
@@ -182,7 +182,7 @@ spec:
               name: local-bin
       containers:
         - name: cni-server
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -358,7 +358,7 @@ spec:
       hostPID: true
       containers:
         - name: pinger
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           command:
             - /kube-ovn/kube-ovn-pinger
           args:
@@ -489,7 +489,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-monitor
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -93,7 +93,7 @@ spec:
       hostNetwork: true
       containers:
         - name: ovn-central
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command: 
           - /kube-ovn/start-db.sh
@@ -243,7 +243,7 @@ spec:
       hostPID: true
       containers:
         - name: openvswitch
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command: 
           - /kube-ovn/start-ovs.sh

--- a/yamls/speaker.yaml
+++ b/yamls/speaker.yaml
@@ -29,7 +29,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-speaker
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command:
             - /kube-ovn/kube-ovn-speaker

--- a/yamls/vpc-configmap.yaml
+++ b/yamls/vpc-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/description: |
       kube-ovn vpc-nat common config
 data:
-  image: kubeovn/vpc-nat-gateway:v1.12.0
+  image: kubeovn/vpc-nat-gateway:v1.13.0
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/yamls/webhook.yaml
+++ b/yamls/webhook.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
         - name: kube-ovn-webhook
-          image: "kubeovn/kube-ovn:v1.12.0"
+          image: "kubeovn/kube-ovn:v1.13.0"
           imagePullPolicy: IfNotPresent
           command:
             - /kube-ovn/kube-ovn-webhook


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22fda0b</samp>

This pull request updates the image tags of various containers in the `./yamls` directory to use the latest kube-ovn version, v1.13.0. This version provides dual-stack, IPv6, BGP, VPC NAT gateway, egress IP, and webhook features for the kube-ovn project, which enables OVN-based networking for Kubernetes clusters.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 22fda0b</samp>

> _We're upgrading to the latest release_
> _`kube-ovn` v1.13.0 is the beast_
> _BGP, NAT, webhooks and dual-stack_
> _We're ready to unleash the network attack_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22fda0b</samp>

*  Bump the image tag of various kube-ovn components from v1.12.0 to v1.13.0 to support new features and bug fixes in the latest release ([link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfL16-R18), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-aaa53b027bdb6b3327d2a742e325d6ab2ce9590b2363be945280c1667b22e99bL10-R10), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-aaa53b027bdb6b3327d2a742e325d6ab2ce9590b2363be945280c1667b22e99bL26-R26), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL43-R43), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL172-R172), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL185-R185), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL361-R361), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL492-R492), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L43-R43), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L172-R172), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L185-R185), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L361-R361), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L492-R492), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL96-R96), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL246-R246), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-c965abe55af187f2cbe1f47f4767ab31a320325e28a11f1cf779f32cf342c539L32-R32), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-205cf3f7574bf5a1200c254d9c7d6b1cd39762ff00734aa71e23e1096a5dfd3eL10-R10), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-2c10dff1669aa8f867680120ebc5bd2003597b732f651d3942efbe16035401fbL36-R36))
*  Remove trailing whitespaces in the `test/server/README.md` file for better formatting ([link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfL7-R7), [link](https://github.com/kubeovn/kube-ovn/pull/3158/files?diff=unified&w=0#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfL24-R24))