### PR TITLE
ci: wait for terminating ovs-ovn pod to disappear

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -396,7 +396,7 @@ jobs:
           kubectl -n kube-system rollout status deploy ovn-central
           kubectl -n kube-system rollout status ds ovs-ovn
           while true; do
-            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+            if [ $(kubectl -n kube-system get pod -l app=ovs -o name | wc -l) -eq $(kubectl get node -o name | wc -l) ]; then
               break
             fi
             sleep 1
@@ -542,7 +542,7 @@ jobs:
           kubectl -n kube-system rollout status deploy ovn-central
           kubectl -n kube-system rollout status ds ovs-ovn
           while true; do
-            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+            if [ $(kubectl -n kube-system get pod -l app=ovs -o name | wc -l) -eq $(kubectl get node -o name | wc -l) ]; then
               break
             fi
             sleep 1
@@ -809,7 +809,7 @@ jobs:
           kubectl -n kube-system rollout status deploy ovn-central
           kubectl -n kube-system rollout status ds ovs-ovn
           while true; do
-            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+            if [ $(kubectl -n kube-system get pod -l app=ovs -o name | wc -l) -eq $(kubectl get node -o name | wc -l) ]; then
               break
             fi
             sleep 1
@@ -953,7 +953,7 @@ jobs:
           kubectl -n kube-system rollout status deploy ovn-central
           kubectl -n kube-system rollout status ds ovs-ovn
           while true; do
-            if [ ! -z "$(kubectl -n kube-system get ep ovn-nb -o jsonpath='{.subsets}')" ]; then
+            if [ $(kubectl -n kube-system get pod -l app=ovs -o name | wc -l) -eq $(kubectl get node -o name | wc -l) ]; then
               break
             fi
             sleep 1


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:

```txt
Waiting for daemon set "ovs-ovn" rollout to finish: 1 out of 2 new pods have been updated...
daemon set "ovs-ovn" successfully rolled out
Collecting ovn logging files
Error from server (NotFound): pods "ovs-ovn-pt4ll" not found
Error: Process completed with exit code 1.
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7aa3ab</samp>

Improve the reliability of the build-x86-image workflow by using a better method to wait for ovs-ovn daemonset readiness. Change the pod counting logic in `.github/workflows/build-x86-image.yaml`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b7aa3ab</samp>

> _`ovs-ovn` waits_
> _counting pods, not endpoints_
> _more stable workflow_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b7aa3ab</samp>

*  Modify the condition for waiting for the ovs-ovn daemonset to be ready in four jobs in the workflow ([link](https://github.com/kubeovn/kube-ovn/pull/3160/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L399-R399), [link](https://github.com/kubeovn/kube-ovn/pull/3160/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L545-R545), [link](https://github.com/kubeovn/kube-ovn/pull/3160/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L812-R812), [link](https://github.com/kubeovn/kube-ovn/pull/3160/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L956-R956)). Use the number of ovs pods and nodes instead of the ovn-nb endpoint, which may not be available in some environments.