### PR TITLE
adapt dualstack for vpc-nat-gw

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -345,12 +345,17 @@ func (ipam *IPAM) IsIPAssignedToOtherPod(ip, subnetName, podName string) (string
 	}
 }
 
-func (ipam *IPAM) GetSubnetV4Mask(subnetName string) (string, error) {
+func (ipam *IPAM) GetSubnetMask(subnetName string) (string, string, error) {
 	if subnet, ok := ipam.Subnets[subnetName]; ok {
-		mask, _ := subnet.V4CIDR.Mask.Size()
-		return strconv.Itoa(mask), nil
+		v4Mask, _ := subnet.V4CIDR.Mask.Size()
+		if subnet.V6CIDR != nil {
+			v6Mask, _ := subnet.V6CIDR.Mask.Size()
+			return strconv.Itoa(v4Mask), strconv.Itoa(v6Mask), nil
+		} else {
+			return strconv.Itoa(v4Mask), "", nil
+		}
 	} else {
-		return "", ErrNoAvailable
+		return "", "", ErrNoAvailable
 	}
 }
 

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -58,7 +58,7 @@ var _ = Describe("[IPAM]", func() {
 				im := ipam.NewIPAM()
 				err := im.AddOrUpdateSubnet(subnetName, ipv4CIDR, v4Gw, ipv4ExcludeIPs)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(im.GetSubnetV4Mask(subnetName)).To(Equal(strings.Split(ipv4CIDR, "/")[1]))
+				Expect(im.GetSubnetMask(subnetName)).To(Equal(strings.Split(ipv4CIDR, "/")[1]))
 				Expect(im.Subnets[subnetName].V4Gw).To(Equal(v4Gw))
 
 				pod1 := "pod1.ns"


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Features


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 626fb16</samp>

This pull request adds IPv6 support and fixes some bugs for the VPC NAT gateway feature. It modifies several files in `pkg/controller` and `pkg/ipam` to handle dual-stack EIP and internal IPs and CIDRs, subnet masks, and data sources. It also updates the unit test in `test/unittest/ipam/ipam.go` to reflect the changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 626fb16</samp>

> _`VPC NAT gateway`_
> _Dual-stack subnets and EIPs_
> _Autumn of changes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 626fb16</samp>

*  Modify the `handleInitVpcNatGw` function to support multiple service cluster IP ranges and gateway IPs for IPv4 and IPv6 ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L379-R390))
*  Modify the `handleUpdateNatGwSubnetRoute` function to use the `subnetsLister` instead of the `ipam` to get the subnet information, and to support IPv6 external and internal subnets and dual-stack subnets ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4R618-R620), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L619-R648), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L634-R655), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L650-R677), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L673-R706), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L688-R725))
*  Modify the `handleAddIptablesEip`, `handleUpdateIptablesEip`, `createEipInPod`, and `deleteEipInPod` functions to support IPv6 EIP for the VPC NAT gateway feature ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L225-R237), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L242-R257), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L303-R311), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L310-R317), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L372-R389), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L425-R432), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L432-R444), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L440-R451), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L450-R464), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L623-R644))
*  Modify the `handleAddIptablesFip`, `handleUpdateIptablesFip`, `createFipInPod`, and `deleteFipInPod` functions to support IPv6 EIP and dual-stack internal IPs for the VPC NAT gateway feature ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL529-R529), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL624-R628), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1608-R1588), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1615-R1607), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1624-R1615), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1635-R1638))
*  Modify the `handleAddIptablesDnatRule`, `handleUpdateIptablesDnatRule`, `createDnatInPod`, and `deleteDnatInPod` functions to support IPv6 EIP and dual-stack internal IPs for the VPC NAT gateway feature ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL714-R714), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL792-R792), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1644-R1646), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1651-R1664), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1661-R1673), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1673-R1697))
*  Modify the `handleAddIptablesSnatRule`, `handleUpdateIptablesSnatRule`, `createSnatInPod`, and `deleteSnatInPod` functions to support IPv6 EIP and dual-stack internal CIDRs for the VPC NAT gateway feature ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL883-R883), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL926-R925), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL970-R959), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL999-R984), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1682-R1705), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1688-L1690), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1696-R1738), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1708-R1746), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1719-R1769))
*  Modify the `patchFipLabel`, `patchDnatLabel`, and `patchSnatLabel` functions to use the correct label key and value for the FIP, DNAT, and SNAT objects, and to avoid conflicts with other DNAT rules that use the same EIP ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1163-R1148), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1357-R1343), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1495-R1481))
*  Modify the `patchSnatStatus` function to support dual-stack internal CIDRs for the VPC NAT gateway feature ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL1553-R1541))
*  Modify the `GetSubnetV4Mask` function to rename it to `GetSubnetMask` and return both the IPv4 and IPv6 masks of the subnet ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L348-R358))
*  Modify the unit test for the `AddOrUpdateSubnet` function to use the `GetSubnetMask` function instead of the `GetSubnetV4Mask` function to get the subnet mask ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L61-R61))
*  Modify the log messages in the `handleUpdateVpcFloatingIp`, `handleUpdateVpcEip`, `handleUpdateVpcSnat`, `handleUpdateVpcDnat`, `handleUpdateIptablesEip`, `handleUpdateIptablesFip`, and `handleUpdateIptablesDnatRule` functions to use consistent and clear terms ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L432-R443), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L467-R478), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L500-R511), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L534-R545), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L327-R334), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL588-R589), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL743-R743), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL755-R758))
*  Add the `strings` package to the imports of the `pkg/controller/vpc_nat_gw_nat.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aR7))
*  Remove some empty lines in the `pkg/controller/vpc_nat_gw_nat.go` file to improve the code formatting and readability ([link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL35), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL602-R602), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL656-R656), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL698-R698), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL772-R772), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL798-R798), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL828-R828), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL871-R871), [link](https://github.com/kubeovn/kube-ovn/pull/3161/files?diff=unified&w=0#diff-9730fd87f1276f8f297415b3bbf5407de631488b88c318d7fd500b0b6a5a9c4aL953-R938))