### PR TITLE
ci/test: bump various versions

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   GO_VERSION: ''
-  GOSEC_VERSION: '2.16.0'
+  GOSEC_VERSION: '2.17.0'
 
 jobs:
   filter:

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -22,8 +22,8 @@ concurrency:
 
 env:
   GO_VERSION: ''
-  GOSEC_VERSION: '2.16.0'
-  HELM_VERSION: v3.12.2
+  GOSEC_VERSION: '2.17.0'
+  HELM_VERSION: v3.12.3
   SUBMARINER_VERSION: '0.14.6'
 
 jobs:

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   GO_VERSION: ''
-  HELM_VERSION: v3.12.2
+  HELM_VERSION: v3.12.3
   SUBMARINER_VERSION: '0.14.6'
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ KUBEVIRT_OPERATOR_YAML = https://github.com/kubevirt/kubevirt/releases/download/
 KUBEVIRT_CR_YAML = https://github.com/kubevirt/kubevirt/releases/download/$(KUBEVIRT_VERSION)/kubevirt-cr.yaml
 KUBEVIRT_TEST_YAML = https://kubevirt.io/labs/manifests/vm.yaml
 
-CILIUM_VERSION = 1.13.4
+CILIUM_VERSION = 1.14.1
 CILIUM_IMAGE_REPO = quay.io/cilium/cilium
 
-CERT_MANAGER_VERSION = v1.12.2
+CERT_MANAGER_VERSION = v1.12.3
 CERT_MANAGER_CONTROLLER = quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_CAINJECTOR = quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_WEBHOOK = quay.io/jetstack/cert-manager-webhook:$(CERT_MANAGER_VERSION)
@@ -59,7 +59,7 @@ DEEPFLOW_CHART_REPO = https://deepflow-ce.oss-cn-beijing.aliyuncs.com/chart/stab
 DEEPFLOW_IMAGE_REPO = registry.cn-beijing.aliyuncs.com/deepflow-ce
 DEEPFLOW_GRAFANA_PORT = 30080
 
-KWOK_VERSION = v0.3.0
+KWOK_VERSION = v0.4.0
 KWOK_IMAGE = registry.k8s.io/kwok/kwok:$(KWOK_VERSION)
 
 VPC_NAT_GW_IMG = $(REGISTRY)/vpc-nat-gateway:$(VERSION)

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -734,6 +734,7 @@ func (c *ovnNbClient) GetAcl(parent, direction, priority, match string, ignoreNo
 		return nil, fmt.Errorf("more than one acl with same 'parent %s direction %s priority %s match %s'", parent, direction, priority, match)
 	}
 
+	// #nosec G602
 	return &aclList[0], nil
 }
 

--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -211,6 +211,7 @@ func (c *ovnNbClient) GetLoadBalancer(lbName string, ignoreNotFound bool) (*ovnn
 		return nil, fmt.Errorf("more than one load balancer with same name %q", lbName)
 	}
 
+	// #nosec G602
 	return &lbList[0], nil
 }
 

--- a/pkg/ovs/ovn-nb-logical_router.go
+++ b/pkg/ovs/ovn-nb-logical_router.go
@@ -109,6 +109,7 @@ func (c *ovnNbClient) GetLogicalRouter(lrName string, ignoreNotFound bool) (*ovn
 		return nil, fmt.Errorf("more than one logical router with same name %q", lrName)
 	}
 
+	// #nosec G602
 	return &lrList[0], nil
 }
 

--- a/pkg/ovs/ovn-nb-logical_switch.go
+++ b/pkg/ovs/ovn-nb-logical_switch.go
@@ -229,6 +229,7 @@ func (c *ovnNbClient) GetLogicalSwitch(lsName string, ignoreNotFound bool) (*ovn
 		return nil, fmt.Errorf("more than one logical switch with same name %q", lsName)
 	}
 
+	// #nosec G602
 	return &lsList[0], nil
 }
 

--- a/pkg/ovs/ovn-sb-chassis.go
+++ b/pkg/ovs/ovn-sb-chassis.go
@@ -121,6 +121,8 @@ func (c *ovnSbClient) GetChassisByHost(nodeName string) (*ovnsb.Chassis, error) 
 		klog.Error(err)
 		return nil, err
 	}
+
+	// #nosec G602
 	return &chassisList[0], nil
 }
 

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -17,7 +17,8 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
 
-var vpcExternalNet = "ovn-vpc-external-network"
+// #nosec G101
+const vpcExternalNet = "ovn-vpc-external-network"
 
 const (
 	IPv4Multicast        = "224.0.0.0/4"


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0318217</samp>

Updated some dependencies and tools versions in the `Makefile` and the GitHub workflow files. Added some comments and constants to suppress gosec warnings and improve code quality in the `pkg/ovs` and `pkg/util` packages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0318217</samp>

> _Sing, O Muse, of the valiant pull request_
> _That updated the tools of the code warriors_
> _Who battle with bugs and vulnerabilities_
> _In the realm of `ovs` and `helm` and `gosec`._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0318217</samp>

*  Update gosec, helm, and cilium versions in workflow files and Makefile ([link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-a3ae20db8d6f829cce559bf09c6fa26bf26822b30ab4994444b49a0b9909470eL26-R26), [link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L25-R26), [link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L14-R14), [link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L40-R43))
*  Add `// #nosec` comments to suppress gosec warnings for using `unsafe` package in `pkg/ovs` files ([link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6R737), [link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-f80a92268723484fa7d5dd097ad7f90925d4efe119bc878098352c751ff5a937R214), [link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-963d5ab25c32b9009a860d464ff78138edef57c9d41f2fc4209510980ec7b51eR112), [link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-6ddbb8fcc94ea100b6c815e02d07765142045d62b2d8023b410ff4613888ab12R232), [link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-8ccc718a81ff28931de9313ea780b7d9fbc9227fa3be982bbc659c0a5add8f5bR124-R125))
*  Add `// #nosec` comment and `const` keyword to `vpcExternalNet` variable in `pkg/util/net.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdL20-R21))
*  Update kwok version in Makefile ([link](https://github.com/kubeovn/kube-ovn/pull/3162/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L62-R62))