### PR TITLE
fix clusterrole rules

### DIFF
--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -26,7 +26,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -116,7 +115,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -199,7 +197,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -282,7 +279,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -342,7 +338,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -426,7 +421,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -501,7 +495,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -553,7 +546,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -607,7 +599,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -876,7 +867,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -927,7 +917,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -1015,7 +1004,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ssl:
           - "true"
@@ -1106,8 +1094,11 @@ jobs:
       matrix:
         case:
           - release-1.9 => release-1.11
+          - release-1.9 => release-1.12
           - release-1.9 => master
+          - release-1.11 => release-1.12
           - release-1.11 => master
+          - release-1.12 => master
     steps:
       - uses: actions/checkout@v3
       - uses: azure/setup-helm@v3

--- a/charts/templates/ovn-CR.yaml
+++ b/charts/templates/ovn-CR.yaml
@@ -179,10 +179,15 @@ rules:
       - coordination.k8s.io
     resources:
       - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
     resourceNames:
       - kube-ovn-controller
     verbs:
-      - create
       - delete
       - update
       - patch

--- a/charts/templates/ovn-CR.yaml
+++ b/charts/templates/ovn-CR.yaml
@@ -49,7 +49,46 @@ rules:
       - qos-policies
       - qos-policies/status
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - "kubeovn.io"
+    resources:
+      - vpcs
+      - vpc-nat-gateways
+      - subnets
+      - ips
+      - vips
+      - vlans
+      - provider-networks
+      - iptables-eips
+      - iptables-fip-rules
+      - ovn-eips
+      # VPC DNS
+      - switch-lb-rules
+    verbs:
+      - create
+  - apiGroups:
+      - "kubeovn.io"
+    resources:
+      # sync external VPC
+      - vpcs
+      # gc VPC
+      - vpc-nat-gateways
+      - ips
+      # gc VPC DNS
+      - switch-lb-rules
+      # delete Pod
+      - iptables-eips
+      # delete Pod
+      - iptables-fip-rules
+      # delete VPC or disable VPC external
+      - ovn-eips
+    verbs:
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -59,7 +98,6 @@ rules:
       - nodes
       - configmaps
     verbs:
-      - create
       - get
       - list
       - watch
@@ -72,35 +110,26 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - ""
       - networking.k8s.io
-      - apps
     resources:
       - networkpolicies
-      - daemonsets
     verbs:
       - get
       - list
       - watch
   - apiGroups:
       - ""
-      - apps
     resources:
       - services/status
     verbs:
       - update
   - apiGroups:
       - ""
-      - networking.k8s.io
-      - apps
-      - extensions
     resources:
       - services
       - endpoints
-      - statefulsets
-      - deployments
-      - deployments/scale
     verbs:
+      # switch LB rule needs create/delete/update
       - create
       - delete
       - update
@@ -108,6 +137,36 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - deployments/scale
+    verbs:
+      - update
+      - patch
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      # VPC NAT gateway
+      - statefulsets
+      # LB Service
+      - deployments
+    verbs:
+      - create
+  - apiGroups:
+      - apps
+    resources:
+      # VPC NAT gateway
+      - statefulsets
+      # delete LB Service
+      - deployments
+    verbs:
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -120,8 +179,15 @@ rules:
       - coordination.k8s.io
     resources:
       - leases
+    resourceNames:
+      - kube-ovn-controller
     verbs:
-      - "*"
+      - create
+      - delete
+      - update
+      - patch
+      - get
+      - watch
   - apiGroups:
       - "kubevirt.io"
     resources:
@@ -139,6 +205,7 @@ metadata:
     rbac.authorization.k8s.io/system-only: "true"
   name: system:ovn-ovs
 rules:
+  # ovn-central liveness/readiness probe
   - apiGroups:
       - ""
     resources:
@@ -146,15 +213,15 @@ rules:
     verbs:
       - get
       - patch
+  # ovn-central liveness/readiness probe
   - apiGroups:
       - ""
-      - networking.k8s.io
-      - apps
     resources:
       - services
       - endpoints
     verbs:
       - get
+  # ovs-ovn start-ovs.sh
   - apiGroups:
       - apps
     resources:
@@ -196,6 +263,13 @@ rules:
       - list
       - patch
       - watch
+  # external-gateway-config
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
   - apiGroups:
       - ""
     resources:
@@ -222,10 +296,10 @@ rules:
       - get
       - list
   - apiGroups:
-      - ""
-      - networking.k8s.io
       - apps
     resources:
       - daemonsets
+    resourceNames:
+      - kube-ovn-pinger
     verbs:
       - get

--- a/charts/templates/post-upgrade.yaml
+++ b/charts/templates/post-upgrade.yaml
@@ -1,4 +1,53 @@
 {{ if .Values.restart_ovs }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovs-ovn-upgrade
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/system-only: "true"
+  name: system:ovs-ovn-upgrade
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    resourceNames:
+      - ovs-ovn
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovs-ovn-upgrade
+roleRef:
+  name: system:ovs-ovn-upgrade
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovs-ovn-upgrade
+    namespace: kube-system
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -49,8 +98,8 @@ spec:
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: "linux"
-      serviceAccount: ovn
-      serviceAccountName: ovn
+      serviceAccount: ovs-ovn-upgrade
+      serviceAccountName: ovs-ovn-upgrade
       containers:
         - name: post-upgrade-job
           image: "{{ .Values.global.registry.address}}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}"

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -134,7 +134,7 @@ func CmdMain() {
 }
 
 func checkPermission(config *controller.Configuration) error {
-	resources := []string{"vpcs", "subnets", "ips", "vlans", "vpc-nat-gateways"}
+	resources := []string{"vpcs", "subnets", "ips", "provider-networks", "vlans", "vpc-nat-gateways"}
 	for _, res := range resources {
 		ssar := &v1.SelfSubjectAccessReview{
 			Spec: v1.SelfSubjectAccessReviewSpec{

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3020,10 +3020,15 @@ rules:
       - coordination.k8s.io
     resources:
       - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
     resourceNames:
       - kube-ovn-controller
     verbs:
-      - create
       - delete
       - update
       - patch

--- a/yamls/sa.yaml
+++ b/yamls/sa.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/system-only: "true"
   name: system:ovn-ovs
 rules:
+  # ovn-central liveness/readiness probe
   - apiGroups:
       - ""
     resources:
@@ -18,15 +19,15 @@ rules:
     verbs:
       - get
       - patch
+  # ovn-central liveness/readiness probe
   - apiGroups:
       - ""
-      - networking.k8s.io
-      - apps
     resources:
       - services
       - endpoints
     verbs:
       - get
+  # ovs-ovn start-ovs.sh
   - apiGroups:
       - apps
     resources:
@@ -105,7 +106,46 @@ rules:
       - qos-policies
       - qos-policies/status
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - "kubeovn.io"
+    resources:
+      - vpcs
+      - vpc-nat-gateways
+      - subnets
+      - ips
+      - vips
+      - vlans
+      - provider-networks
+      - iptables-eips
+      - iptables-fip-rules
+      - ovn-eips
+      # VPC DNS
+      - switch-lb-rules
+    verbs:
+      - create
+  - apiGroups:
+      - "kubeovn.io"
+    resources:
+      # sync external VPC
+      - vpcs
+      # gc VPC
+      - vpc-nat-gateways
+      - ips
+      # gc VPC DNS
+      - switch-lb-rules
+      # delete Pod
+      - iptables-eips
+      # delete Pod
+      - iptables-fip-rules
+      # delete VPC or disable VPC external
+      - ovn-eips
+    verbs:
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -115,7 +155,6 @@ rules:
       - nodes
       - configmaps
     verbs:
-      - create
       - get
       - list
       - watch
@@ -128,35 +167,26 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - ""
       - networking.k8s.io
-      - apps
     resources:
       - networkpolicies
-      - daemonsets
     verbs:
       - get
       - list
       - watch
   - apiGroups:
       - ""
-      - apps
     resources:
       - services/status
     verbs:
       - update
   - apiGroups:
       - ""
-      - networking.k8s.io
-      - apps
-      - extensions
     resources:
       - services
       - endpoints
-      - statefulsets
-      - deployments
-      - deployments/scale
     verbs:
+      # switch LB rule needs create/delete/update
       - create
       - delete
       - update
@@ -164,6 +194,36 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - deployments/scale
+    verbs:
+      - update
+      - patch
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      # VPC NAT gateway
+      - statefulsets
+      # LB Service
+      - deployments
+    verbs:
+      - create
+  - apiGroups:
+      - apps
+    resources:
+      # VPC NAT gateway
+      - statefulsets
+      # delete LB Service
+      - deployments
+    verbs:
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -176,8 +236,15 @@ rules:
       - coordination.k8s.io
     resources:
       - leases
+    resourceNames:
+      - kube-ovn-controller
     verbs:
-      - "*"
+      - create
+      - delete
+      - update
+      - patch
+      - get
+      - watch
   - apiGroups:
       - "kubevirt.io"
     resources:
@@ -239,6 +306,13 @@ rules:
       - list
       - patch
       - watch
+  # external-gateway-config
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
   - apiGroups:
       - ""
     resources:
@@ -284,11 +358,11 @@ rules:
       - get
       - list
   - apiGroups:
-      - ""
-      - networking.k8s.io
       - apps
     resources:
       - daemonsets
+    resourceNames:
+      - kube-ovn-pinger
     verbs:
       - get
 ---

--- a/yamls/sa.yaml
+++ b/yamls/sa.yaml
@@ -236,10 +236,15 @@ rules:
       - coordination.k8s.io
     resources:
       - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
     resourceNames:
       - kube-ovn-controller
     verbs:
-      - create
       - delete
       - update
       - patch


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bac653b</samp>

This pull request improves the security, compatibility, and maintainability of the kube-ovn project by updating the cluster roles, service accounts, and workflows for the controller and the upgrade job. It also adds support for the provider-networks feature to the controller.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bac653b</samp>

> _We're sailing on the kube-ovn, the finest network in the sea_
> _We're heaving on the ropes, boys, to grant the permissions we need_
> _We're adding new resources, like `provider-networks` and `ovs-ovn-upgrade`_
> _We're cleaning up the code, boys, and making sure it's up to date_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bac653b</samp>

*  Remove the release-1.10 branch from the scheduled e2e workflow, as it is no longer maintained ([link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L29), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L119), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L202), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L285), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L345), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L429), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L504), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L556), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L610), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L879), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L930), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1018), [link](https://github.com/kubeovn/kube-ovn/pull/3163/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1109-R1101)) in `.github/workflows/scheduled-e2e.yaml`