### PR TITLE
chart: fix ovs-ovn upgrade

### DIFF
--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -26,7 +26,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -116,7 +115,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -199,7 +197,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -282,7 +279,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -342,7 +338,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ip-family:
           - ipv4
@@ -426,7 +421,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -501,7 +495,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -553,7 +546,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -607,7 +599,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -876,7 +867,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -927,7 +917,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
     steps:
       - uses: actions/checkout@v3
@@ -1015,7 +1004,6 @@ jobs:
           - master
           - release-1.12
           - release-1.11
-          - release-1.10
           - release-1.9
         ssl:
           - "true"
@@ -1106,8 +1094,11 @@ jobs:
       matrix:
         case:
           - release-1.9 => release-1.11
+          - release-1.9 => release-1.12
           - release-1.9 => master
+          - release-1.11 => release-1.12
           - release-1.11 => master
+          - release-1.12 => master
     steps:
       - uses: actions/checkout@v3
       - uses: azure/setup-helm@v3
@@ -1169,7 +1160,7 @@ jobs:
         run: |
           sudo pip3 install j2cli
           sudo pip3 install "j2cli[yaml]"
-          sudo PATH=~/.local/bin:$PATH make kind-init
+          sudo PATH=~/.local/bin:$PATH make kind-init-ha
           sudo cp -r /root/.kube/ ~/.kube/
           sudo chown -R $(id -un). ~/.kube/
 
@@ -1185,16 +1176,7 @@ jobs:
         run: |
           version=$(grep -E '^VERSION="v([0-9]+\.){2}[0-9]+"$' dist/images/install.sh | head -n1 | awk -F= '{print $2}' | tr -d '"')
           docker pull kubeovn/kube-ovn:$version
-
-          restart_ovs=false
-          v1=$(printf "$VERSION_FROM\\nrelease-1.11" | sort -Vr | head -n1)
-          v2=$(printf "$VERSION_TO\\nrelease-1.12" | sort -Vr | head -n1)
-          if [ $v1 = "release-1.11" ]; then
-            if [ $VERSION_TO = "master" -o $VERSION_TO = $v2 ]; then
-              restart_ovs=true
-            fi
-          fi
-          CHART_UPGRADE_RESTART_OVS=$restart_ovs VERSION=$version make kind-upgrade-chart
+          VERSION=$version make kind-upgrade-chart
 
       - name: Run E2E
         env:

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,6 @@ endif
 
 CONTROL_PLANE_TAINTS = node-role.kubernetes.io/master node-role.kubernetes.io/control-plane
 
-CHART_UPGRADE_RESTART_OVS=$(shell echo $${CHART_UPGRADE_RESTART_OVS:-false})
-
 MULTUS_VERSION = v4.0.2
 MULTUS_IMAGE = ghcr.io/k8snetworkplumbingwg/multus-cni:$(MULTUS_VERSION)-thick
 MULTUS_YAML = https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/$(MULTUS_VERSION)/deployments/multus-daemonset-thick.yml
@@ -423,30 +421,31 @@ kind-install-chart: kind-load-image kind-untaint-control-plane
 	kubectl label node -lbeta.kubernetes.io/os=linux kubernetes.io/os=linux --overwrite
 	kubectl label node -lnode-role.kubernetes.io/control-plane kube-ovn/role=master --overwrite
 	kubectl label node -lovn.kubernetes.io/ovs_dp_type!=userspace ovn.kubernetes.io/ovs_dp_type=kernel --overwrite
-	ips=$$(kubectl get node -lkube-ovn/role=master --no-headers -o wide | awk '{print $$6}') && \
+	ips=$$(kubectl get node -lkube-ovn/role=master --no-headers -o wide | awk '{print $$6}' | tr '\n' ',' | sed 's/,$$//') && \
 	helm install kubeovn ./charts \
 		--set global.images.kubeovn.tag=$(VERSION) \
-		--set replicaCount=$$(echo $$ips | awk '{print NF}') \
-		--set MASTER_NODES="$$(echo $$ips | tr \\n ',' | sed -e 's/,$$//' -e 's/,/\\,/g')"
-	kubectl rollout status deployment/ovn-central -n kube-system --timeout 300s
-	kubectl rollout status deployment/kube-ovn-controller -n kube-system --timeout 120s
-	kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout 120s
-	kubectl rollout status daemonset/kube-ovn-pinger -n kube-system --timeout 120s
-	kubectl rollout status deployment/coredns -n kube-system --timeout 60s
+		--set replicaCount=$$(echo $$ips | awk -F ',' '{print NF}') \
+		--set MASTER_NODES="$$(echo $$ips | sed 's/,/\\,/g')"
+	sleep 60
+	kubectl -n kube-system rollout status --timeout=1s deployment/ovn-central
+	kubectl -n kube-system rollout status --timeout=1s daemonset/ovs-ovn
+	kubectl -n kube-system rollout status --timeout=1s deployment/kube-ovn-controller
+	kubectl -n kube-system rollout status --timeout=1s daemonset/kube-ovn-cni
+	kubectl -n kube-system rollout status --timeout=1s daemonset/kube-ovn-pinger
 
 .PHONY: kind-upgrade-chart
 kind-upgrade-chart: kind-load-image
-	$(eval OVN_DB_IPS = $(shell kubectl get no -lkube-ovn/role=master --no-headers -o wide | awk '{print $$6}' | tr \\n ',' | sed -e 's/,$$//' -e 's/,/\\,/g'))
+	$(eval OVN_DB_IPS = $(shell kubectl get node -lkube-ovn/role=master --no-headers -o wide | awk '{print $$6}' | tr '\n' ',' | sed -e 's/,$$//' -e 's/,/\\,/g'))
 	helm upgrade kubeovn ./charts \
 		--set global.images.kubeovn.tag=$(VERSION) \
 		--set replicaCount=$$(echo $(OVN_DB_IPS) | awk -F ',' '{print NF}') \
-		--set MASTER_NODES='$(OVN_DB_IPS)' \
-		--set restart_ovs=$(CHART_UPGRADE_RESTART_OVS)
-	kubectl rollout status deployment/ovn-central -n kube-system --timeout 300s
-	kubectl rollout status daemonset/ovs-ovn -n kube-system --timeout 120s
-	kubectl rollout status deployment/kube-ovn-controller -n kube-system --timeout 120s
-	kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout 120s
-	kubectl rollout status daemonset/kube-ovn-pinger -n kube-system --timeout 120s
+		--set MASTER_NODES='$(OVN_DB_IPS)'
+	sleep 90
+	kubectl -n kube-system rollout status --timeout=1s deployment/ovn-central
+	kubectl -n kube-system rollout status --timeout=1s daemonset/ovs-ovn
+	kubectl -n kube-system rollout status --timeout=1s deployment/kube-ovn-controller
+	kubectl -n kube-system rollout status --timeout=1s daemonset/kube-ovn-cni
+	kubectl -n kube-system rollout status --timeout=1s daemonset/kube-ovn-pinger
 
 .PHONY: kind-install
 kind-install: kind-load-image

--- a/charts/README.md
+++ b/charts/README.md
@@ -18,9 +18,3 @@ $ helm install --debug kubeovn ./kubeovn-helm --set MASTER_NODES=${Node0},${Node
 # upgrade to this version
 $ helm upgrade --debug kubeovn ./kubeovn-helm --set MASTER_NODES=${Node0},${Node1},${Node2}, --set replicaCount=3
 ```
-
-If you are upgrading Kube-OVN from versions prior to v1.12, you need to set `restart_ovs` to `true`:
-
-```shell
-$ helm upgrade --debug kubeovn ./kubeovn-helm --set MASTER_NODES=${Node0},${Node1},${Node2}, --set replicaCount=3 --set restart_ovs=true
-```

--- a/charts/templates/upgrade-ovs-ovn.yaml
+++ b/charts/templates/upgrade-ovs-ovn.yaml
@@ -1,4 +1,72 @@
-{{ if .Values.restart_ovs }}
+{{ if (lookup "apps/v1" "DaemonSet" "kube-system" "ovs-ovn") }}
+{{ if eq (lookup "apps/v1" "DaemonSet" "kube-system" "ovs-ovn").spec.updateStrategy.type "OnDelete" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovs-ovn-upgrade
+  namespace: kube-system
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/system-only: "true"
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: system:ovs-ovn-upgrade
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    resourceNames:
+      - ovs-ovn
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovs-ovn-upgrade
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  name: system:ovs-ovn-upgrade
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovs-ovn-upgrade
+    namespace: kube-system
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,7 +81,7 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": post-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-weight": "4"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   completions: 1
@@ -49,8 +117,8 @@ spec:
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: "linux"
-      serviceAccount: ovn
-      serviceAccountName: ovn
+      serviceAccount: ovs-ovn-upgrade
+      serviceAccountName: ovs-ovn-upgrade
       containers:
         - name: post-upgrade-job
           image: "{{ .Values.global.registry.address}}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}"
@@ -70,4 +138,5 @@ spec:
         - name: kube-ovn-log
           hostPath:
             path: /var/log/kube-ovn
+{{ end }}
 {{ end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -115,8 +115,6 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-restart_ovs: false
-
 # hybrid dpdk
 HYBRID_DPDK: false
 HUGEPAGE_SIZE_TYPE: hugepages-2Mi # Default 

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -55,7 +55,14 @@ function quit {
     pid=$(/usr/share/ovn/scripts/ovn-ctl status_controller | awk '{print $NF}')
     if cgroup_match "${pid}" self; then
       /usr/share/ovn/scripts/grace_stop_ovn_controller
-      /usr/share/openvswitch/scripts/ovs-ctl stop
+    fi
+    pid=$(/usr/share/openvswitch/scripts/ovs-ctl status | grep ovsdb-server | awk '{print $NF}')
+    if cgroup_match "${pid}" self; then
+      /usr/share/openvswitch/scripts/ovs-ctl --no-ovs-vswitchd stop
+    fi
+    pid=$(/usr/share/openvswitch/scripts/ovs-ctl status | grep ovs-vswitchd | awk '{print $NF}')
+    if cgroup_match "${pid}" self; then
+      /usr/share/openvswitch/scripts/ovs-ctl --no-ovsdb-server stop
     fi
   fi
 

--- a/dist/images/upgrade-ovs.sh
+++ b/dist/images/upgrade-ovs.sh
@@ -5,9 +5,9 @@ set -e
 POD_NAMESPACE=${POD_NAMESPACE:-kube-system}
 
 dsGenVer=`kubectl -n $POD_NAMESPACE get ds ovs-ovn -o jsonpath={.metadata.generation}`
+kubectl -n $POD_NAMESPACE delete pod -l app=ovs,pod-template-generation!=$dsGenVer
+
 for node in `kubectl get node -o jsonpath='{.items[*].metadata.name}'`; do
-  # delete pod with old version
-  kubectl -n $POD_NAMESPACE delete pod -l app=ovs,pod-template-generation!=$dsGenVer --field-selector spec.nodeName=$node
   # wait the pod with new version to be created and delete it
   while true; do
     pod=`kubectl -n $POD_NAMESPACE get pod -l app=ovs,pod-template-generation=$dsGenVer --field-selector spec.nodeName=$node -o name`

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -214,7 +214,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 100%
+      maxSurge: 1
       maxUnavailable: 0
   template:
     metadata:


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ba2d05</samp>

This pull request updates the scheduled e2e workflows and the ovs-ovn daemonset upgrade process. It removes the outdated `release-1.10` branch from the tests and adds the `release-1.12` branch to the upgrade tests. It also introduces a new post-upgrade hook for the `ovs-ovn` daemonset that uses a dedicated service account.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1ba2d05</samp>

> _No more mercy for the old release_
> _We cut it off from the e2e tests_
> _We unleash the power of the daemonset_
> _With the post-upgrade hook of `ovs-ovn`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1ba2d05</samp>

*  Remove the release-1.10 branch from the scheduled e2e workflow and the e2e upgrade tests for all scenarios ([link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L29), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L119), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L202), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L285), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L345), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L429), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L504), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L556), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L610), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L879), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L930), [link](https://github.com/kubeovn/kube-ovn/pull/3164/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L1018)). This is because the release-1.10 branch is no longer maintained and does not need to run the e2e tests periodically or be tested for upgrade compatibility.