### PR TITLE
Adding toleartions to pinger daemonSet

### DIFF
--- a/charts/templates/pinger-ds.yaml
+++ b/charts/templates/pinger-ds.yaml
@@ -19,6 +19,13 @@ spec:
         component: network
         type: infra
     spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
       priorityClassName: system-node-critical
       serviceAccountName: kube-ovn-app
       hostPID: true


### PR DESCRIPTION
- [X ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

<!-- 
The `kube-ovn-pinger` is not scheduled on `Not Ready` nodes because it doesn't have tolerations for unready nodes. In this PR, I add the appropriate toleration in `kube-ovn-pinger` in the helm template.  
-->

### Which issue(s) this PR fixes:
Fixes #3171 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bf0063</samp>

Added tolerations to the `pinger` pod daemonset in `charts/templates/pinger-ds.yaml` to make it more resilient to node taints and failures. This improves the network monitoring functionality of the kube-ovn project.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0bf0063</samp>

> _`pinger` pod tolerates_
> _all taints and node failures_
> _critical in winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0bf0063</samp>

*  Add tolerations to pinger daemonset spec ([link](https://github.com/kubeovn/kube-ovn/pull/3172/files?diff=unified&w=0#diff-e86184e0e5f4bdf5ba5efe2812441f1b8fd9760422241814f857126dd389eca2R22-R28)). This allows the pinger pod to run on any node regardless of taints, and to survive node failures or evictions. The tolerations also mark the pinger pod as a critical addon, which gives it priority over other pods. The pinger pod is used to monitor the network connectivity and latency between nodes, and is part of the `kube-ovn` project, which provides an overlay network solution for Kubernetes based on OVS and OVN.