### PR TITLE
fix policy routes not be deleted while the field of policyRoutes set to empty

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -401,13 +401,14 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		}
 	}
 
-	if vpc.Spec.PolicyRoutes != nil {
-		// diff update vpc policy route
+	// update vpc policy route
+	{
 		policyList, err := c.ovnNbClient.ListLogicalRouterPolicies(vpc.Name, -1, nil)
 		if err != nil {
 			klog.Errorf("failed to get vpc %s policy route list, %v", vpc.Name, err)
 			return err
 		}
+		// diff vpc policy route
 		policyRouteNeedDel, policyRouteNeedAdd, err := diffPolicyRoute(policyList, vpc.Spec.PolicyRoutes)
 		if err != nil {
 			klog.Errorf("failed to diff vpc %s policy route, %v", vpc.Name, err)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes

delete policy routes while the field of policyRoutes is set to empty

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68f2292</samp>

Refactor and document policy route reconciliation in `vpc.go`. Improve code readability and maintainability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 68f2292</samp>

> _`vpc.go` is the path to hell_
> _We must simplify and document well_
> _No more redundant checks of policy routes_
> _Or we'll face the wrath of the code review notes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68f2292</samp>

*  Simplify the logic for updating VPC policy routes by removing an unnecessary condition check ([link](https://github.com/kubeovn/kube-ovn/pull/3174/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL404-R405))
*  Add a comment to explain the purpose of the code block that compares and applies the policy route changes ([link](https://github.com/kubeovn/kube-ovn/pull/3174/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecR411))