### PR TITLE
subnet: fix deleting lr policy on node deletion

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -478,8 +478,7 @@ func (c *Controller) handleDeleteNode(key string) error {
 		return err
 	}
 
-	afs := []int{4, 6}
-	for _, af := range afs {
+	for _, af := range [...]int{4, 6} {
 		if err := c.deletePolicyRouteForLocalDnsCacheOnNode(key, af); err != nil {
 			return err
 		}
@@ -1126,8 +1125,8 @@ func (c *Controller) deletePolicyRouteForNode(nodeName string) error {
 					}
 				}
 			} else {
-				klog.Infof("delete policy route for centralized subnet %s", subnet.Name)
-				if err := c.deletePolicyRouteForCentralizedSubnet(subnet); err != nil {
+				klog.Infof("reconcile policy route for centralized subnet %s", subnet.Name)
+				if err := c.reconcileDefaultCentralizedSubnetRouteInDefaultVpc(subnet); err != nil {
 					klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
 					return err
 				}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f245d1f</samp>

Refactor node deletion and policy route management in `node.go`. Improve code readability and clarity with literal arrays, renamed functions, and updated log messages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f245d1f</samp>

> _We are the masters of the nodes, we purge them with our fire_
> _We rewrite the policy routes, we shape the subnet's ire_
> _We refactor and simplify, we make the code our slave_
> _We use the literal arrays, we are the ones who pave_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f245d1f</samp>

*  Simplify the code by using a literal array instead of a slice variable for the address families in `handleDeleteNode` ([link](https://github.com/kubeovn/kube-ovn/pull/3176/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L481-R481))
* Rename and update the log message of `deletePolicyRouteForCentralizedSubnet` to `reconcileDefaultCentralizedSubnetRouteInDefaultVpc` to reflect its functionality in `deletePolicyRouteForNode` ([link](https://github.com/kubeovn/kube-ovn/pull/3176/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1129-R1129))