### PR TITLE
subnet: fix deleting lr policy on node deletion

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -1199,9 +1199,9 @@ func (c *Controller) deletePolicyRouteForNode(nodeName string) error {
 						}
 					}
 				}
-			} else {
-				klog.Infof("delete policy route for centralized subnet %s", subnet.Name)
-				if err := c.deletePolicyRouteForCentralizedSubnet(subnet); err != nil {
+			} else if subnet.Status.ActivateGateway == nodeName {
+				klog.Infof("reconcile ovn route for centralized subnet %s", subnet.Name)
+				if err := c.reconcileOvnRoute(subnet); err != nil {
 					klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
 					return err
 				}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32069c8</samp>

Fix ovn route update for centralized subnet when activate gateway changes. Modify `deletePolicyRouteForNode` in `node.go` to call `reconcileOvnRoute` instead of deleting policy route.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 32069c8</samp>

> _`deletePolicyRoute`_
> _Fixes ovn route update_
> _A winter bug solved_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32069c8</samp>

* Fix ovn route update for centralized subnet when activate gateway changes ([link](https://github.com/kubeovn/kube-ovn/pull/3178/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1202-R1204))