### PR TITLE
RBAC: fix clusterrole permissions

### DIFF
--- a/charts/templates/ovn-CR.yaml
+++ b/charts/templates/ovn-CR.yaml
@@ -72,7 +72,6 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - ""
       - networking.k8s.io
       - apps
     resources:
@@ -84,16 +83,13 @@ rules:
       - watch
   - apiGroups:
       - ""
-      - apps
     resources:
       - services/status
     verbs:
       - update
   - apiGroups:
       - ""
-      - networking.k8s.io
       - apps
-      - extensions
     resources:
       - services
       - endpoints
@@ -148,8 +144,6 @@ rules:
       - patch
   - apiGroups:
       - ""
-      - networking.k8s.io
-      - apps
     resources:
       - services
       - endpoints
@@ -196,6 +190,13 @@ rules:
       - list
       - patch
       - watch
+  # ovn-external-gw-config
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
   - apiGroups:
       - ""
     resources:
@@ -222,10 +223,10 @@ rules:
       - get
       - list
   - apiGroups:
-      - ""
-      - networking.k8s.io
       - apps
     resources:
       - daemonsets
+    resourceNames:
+      - kube-ovn-pinger
     verbs:
       - get

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2802,8 +2802,6 @@ rules:
       - patch
   - apiGroups:
       - ""
-      - networking.k8s.io
-      - apps
     resources:
       - services
       - endpoints
@@ -2913,7 +2911,6 @@ rules:
       - get
   - apiGroups:
       - ""
-      - networking.k8s.io
       - apps
     resources:
       - networkpolicies
@@ -2924,16 +2921,13 @@ rules:
       - watch
   - apiGroups:
       - ""
-      - apps
     resources:
       - services/status
     verbs:
       - update
   - apiGroups:
       - ""
-      - networking.k8s.io
       - apps
-      - extensions
     resources:
       - services
       - endpoints
@@ -3025,6 +3019,13 @@ rules:
       - list
       - patch
       - watch
+  # ovn-external-gw-config
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
   - apiGroups:
       - ""
     resources:
@@ -3072,11 +3073,11 @@ rules:
       - get
       - list
   - apiGroups:
-      - ""
-      - networking.k8s.io
       - apps
     resources:
       - daemonsets
+    resourceNames:
+      - kube-ovn-pinger
     verbs:
       - get
 ---

--- a/yamls/sa.yaml
+++ b/yamls/sa.yaml
@@ -20,8 +20,6 @@ rules:
       - patch
   - apiGroups:
       - ""
-      - networking.k8s.io
-      - apps
     resources:
       - services
       - endpoints
@@ -128,7 +126,6 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - ""
       - networking.k8s.io
       - apps
     resources:
@@ -140,16 +137,13 @@ rules:
       - watch
   - apiGroups:
       - ""
-      - apps
     resources:
       - services/status
     verbs:
       - update
   - apiGroups:
       - ""
-      - networking.k8s.io
       - apps
-      - extensions
     resources:
       - services
       - endpoints
@@ -239,6 +233,13 @@ rules:
       - list
       - patch
       - watch
+  # ovn-external-gw-config
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
   - apiGroups:
       - ""
     resources:
@@ -284,11 +285,11 @@ rules:
       - get
       - list
   - apiGroups:
-      - ""
-      - networking.k8s.io
       - apps
     resources:
       - daemonsets
+    resourceNames:
+      - kube-ovn-pinger
     verbs:
       - get
 ---


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1454302</samp>

This pull request updates the RBAC definitions for the `ovn-controller` and `ovn-cni` ClusterRoles in `./charts/templates/ovn-CR.yaml` and `./yamls/sa.yaml`. It enhances the security, cleanup, and external gateway features of the ovn-cni and ovn-controller components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1454302</samp>

> _To tidy the RBAC definition_
> _This pull request makes a revision_
> _It changes `ovn-controller` and `ovn-cni`_
> _To read configmaps and daemonsets more finely_
> _And adds a rule for the external gateway vision_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1454302</samp>

*  Remove unnecessary or redundant apiGroups from the ovn-controller and ovn-cni ClusterRoles ([link](https://github.com/kubeovn/kube-ovn/pull/3182/files?diff=unified&w=0#diff-3a12c260f1cdf647b71ad5f0d5caac95cc424e2f31338d15c25c674d49cbf17dL75), [link](https://github.com/kubeovn/kube-ovn/pull/3182/files?diff=unified&w=0#diff-3a12c260f1cdf647b71ad5f0d5caac95cc424e2f31338d15c25c674d49cbf17dL87), [link](https://github.com/kubeovn/kube-ovn/pull/3182/files?diff=unified&w=0#diff-3a12c260f1cdf647b71ad5f0d5caac95cc424e2f31338d15c25c674d49cbf17dL94-R92), [link](https://github.com/kubeovn/kube-ovn/pull/3182/files?diff=unified&w=0#diff-3a12c260f1cdf647b71ad5f0d5caac95cc424e2f31338d15c25c674d49cbf17dL151-L152), [link](https://github.com/kubeovn/kube-ovn/pull/3182/files?diff=unified&w=0#diff-81665da727241a7c7ecbeb9fe089a71e9976f66e3827d18b744206963614f06cL23-L24), [link](https://github.com/kubeovn/kube-ovn/pull/3182/files?diff=unified&w=0#diff-81665da727241a7c7ecbeb9fe089a71e9976f66e3827d18b744206963614f06cL131), [link](https://github.com/kubeovn/kube-ovn/pull/3182/files?diff=unified&w=0#diff-81665da727241a7c7ecbeb9fe089a71e9976f66e3827d18b744206963614f06cL143), [link](https://github.com/kubeovn/kube-ovn/pull/3182/files?diff=unified&w=0#diff-81665da727241a7c7ecbeb9fe089a71e9976f66e3827d18b744206963614f06cL150-R146)). This simplifies the RBAC definitions and avoids potential conflicts or confusion with other apiGroups.