### PR TITLE
support user custom log location

### DIFF
--- a/charts/templates/central-deploy.yaml
+++ b/charts/templates/central-deploy.yaml
@@ -143,10 +143,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime

--- a/charts/templates/controller-deploy.yaml
+++ b/charts/templates/controller-deploy.yaml
@@ -167,7 +167,7 @@ spec:
             path: /etc/localtime
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true

--- a/charts/templates/monitor-deploy.yaml
+++ b/charts/templates/monitor-deploy.yaml
@@ -124,7 +124,7 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -134,4 +134,4 @@ spec:
             secretName: kube-ovn-tls
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn

--- a/charts/templates/ovn-dpdk-ds.yaml
+++ b/charts/templates/ovn-dpdk-ds.yaml
@@ -146,10 +146,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime

--- a/charts/templates/ovncni-ds.yaml
+++ b/charts/templates/ovncni-ds.yaml
@@ -192,16 +192,16 @@ spec:
             path: /var/run/dbus
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: tmp
           hostPath:
             path: /tmp

--- a/charts/templates/ovsovn-ds.yaml
+++ b/charts/templates/ovsovn-ds.yaml
@@ -186,10 +186,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime

--- a/charts/templates/pinger-ds.yaml
+++ b/charts/templates/pinger-ds.yaml
@@ -120,13 +120,13 @@ spec:
             path: /etc/origin/openvswitch
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime

--- a/charts/templates/upgrade-ovs-ovn.yaml
+++ b/charts/templates/upgrade-ovs-ovn.yaml
@@ -137,6 +137,6 @@ spec:
       volumes:
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
 {{ end }}
 {{ end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -110,6 +110,9 @@ cni_conf:
 
 kubelet_conf:
   KUBELET_DIR: "/var/lib/kubelet"
+
+log_conf:
+  LOG_DIR: "/var/log"
   
 imagePullSecrets: []
 nameOverride: ""

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -38,6 +38,7 @@ ENABLE_TPROXY=${ENABLE_TPROXY:-false}
 DEBUG_WRAPPER=${DEBUG_WRAPPER:-}
 
 KUBELET_DIR=${KUBELET_DIR:-/var/lib/kubelet}
+LOG_DIR=${LOG_DIR:-/var/log}
 
 CNI_CONF_DIR="/etc/cni/net.d"
 CNI_BIN_DIR="/opt/cni/bin"
@@ -3305,10 +3306,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: $LOG_DIR/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: $LOG_DIR/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -3464,10 +3465,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: $LOG_DIR/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: $LOG_DIR/ovn
         - name: host-config-ovs
           hostPath:
             path: /opt/ovs-config
@@ -3643,10 +3644,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: $LOG_DIR/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: $LOG_DIR/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -3740,9 +3741,9 @@ spec:
               name: host-config-openvswitch
             - mountPath: /etc/ovn
               name: host-config-ovn
-            - mountPath: /var/log/openvswitch
+            - mountPath: $LOG_DIR/openvswitch
               name: host-log-ovs
-            - mountPath: /var/log/ovn
+            - mountPath: $LOG_DIR/ovn
               name: host-log-ovn
             - mountPath: /etc/localtime
               name: localtime
@@ -3810,10 +3811,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: $LOG_DIR/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: $LOG_DIR/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -3986,7 +3987,7 @@ spec:
             path: /etc/localtime
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: $LOG_DIR/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -4172,13 +4173,13 @@ spec:
             path: /var/run/dbus
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: $LOG_DIR/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: $LOG_DIR/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: $LOG_DIR/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -4290,13 +4291,13 @@ spec:
             path: /etc/origin/openvswitch
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: $LOG_DIR/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: $LOG_DIR/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: $LOG_DIR/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -4431,7 +4432,7 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: $LOG_DIR/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -4441,7 +4442,7 @@ spec:
             secretName: kube-ovn-tls
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: $LOG_DIR/kube-ovn
 ---
 kind: Service
 apiVersion: v1

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -130,7 +130,7 @@ spec:
             path: /etc/localtime
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -314,13 +314,13 @@ spec:
             path: /var/run/dbus
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -432,13 +432,13 @@ spec:
             path: /etc/origin/openvswitch
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -573,7 +573,7 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -583,7 +583,7 @@ spec:
             secretName: kube-ovn-tls
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
 ---
 kind: Service
 apiVersion: v1

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -130,7 +130,7 @@ spec:
             path: /etc/localtime
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -314,13 +314,13 @@ spec:
             path: /var/run/dbus
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -432,13 +432,13 @@ spec:
             path: /etc/origin/openvswitch
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -573,7 +573,7 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -583,7 +583,7 @@ spec:
             secretName: kube-ovn-tls
         - name: kube-ovn-log
           hostPath:
-            path: /var/log/kube-ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
 ---
 kind: Service
 apiVersion: v1

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -297,10 +297,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -434,10 +434,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: host-config-ovs
           hostPath:
             path: /opt/ovs-config

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -194,10 +194,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -358,10 +358,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: /var/log/openvswitch
+            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: /var/log/ovn
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
support user custom log location


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d88acc</samp>

This pull request adds a new feature to customize the log directory for all the kube-ovn components, either as a helm chart parameter or as an environment variable. It updates the helm chart templates, the yaml files, and the values.yaml file to support this feature. It also enables some flags and settings for the egress IP and IPv6-only features.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2d88acc</samp>

> _Sing, O Muse, of the mighty deeds of the `kube-ovn` team,_
> _Who, with skill and wisdom, forged a helm chart for their scheme,_
> _And gave the users power to set the log directory,_
> _For each container and volume, with a simple variable key._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d88acc</samp>

*  Add a new variable `log_conf.LOG_DIR` to configure the log directory for all the containers and volumes that use it ([link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-2f7bd1822b616f83b06c8d8c356e0fc48c36dde251b8f87ab81d97155ca4cbcbR113-R115))
*  Replace the hard-coded paths for the `host-log-ovs` and `host-log-ovn` volumes with the `log_conf.LOG_DIR` variable in the `central-deploy`, `controller-deploy`, `monitor-deploy`, `ovn-dpdk-ds`, and `ovncni-ds` templates ([link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-a5c7ec4d325cefcc89bab9608d877fd9489239e8859881bb070ec43f23fa2051L146-R149), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-ea68dce347b5fa351b4dd8da76b26575f5aeac40e3ce0f5d37e26a603bb6ea51L170-R170), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-aafeafe291807e5f2688246fed7cd4cb6104522cd3e9e6b9cb671249fc5fcb73L127-R127), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-4ff764064ce8dcea779157766f8170f24e26fb03e6886665a42fe7cb4ba5f23fL149-R152), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-90880cf33f50d3c72a4349293d1f6abe953633d3edb2dc71c45368462b4ac4e5L201-R204))
*  Replace the hard-coded paths for the `kube-ovn-log` volume with the `log_conf.LOG_DIR` variable in the `monitor-deploy` template ([link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-aafeafe291807e5f2688246fed7cd4cb6104522cd3e9e6b9cb671249fc5fcb73L137-L136))
*  Replace the hard-coded paths for the `ovn-controller` and `ovs-vswitchd` containers with the `log_conf.LOG_DIR` variable in the `ovsovn-ds` template ([link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-b2359252dbe0d2c107f7acd6bcadad19a27f3b529c84ea6136a995c8c2644131L189-R192))
*  Replace the hard-coded paths for the `kube-ovn-pinger` container with the `log_conf.LOG_DIR` variable in the `pinger-ds` template ([link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-e86184e0e5f4bdf5ba5efe2812441f1b8fd9760422241814f857126dd389eca2L123-R129))
*  Replace the hard-coded paths for the `kube-ovn-upgrade-ovs-ovn` container with the `log_conf.LOG_DIR` variable in the `upgrade-ovs-ovn` template ([link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-2d71dbf3a35f845caf7551a88cd87cb92364ec452e6c7d2e760b3311d22650d3L140-R140))
*  Apply the same changes to the `kube-ovn-dual-stack.yaml`, `kube-ovn-ipv6.yaml`, `ovn-dpdk.yaml`, and `ovn-ha.yaml` files, which are alternative ways of deploying kube-ovn without using the helm chart ([link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL133-R133), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL317-R323), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL435-R441), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL576-R576), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL586-R586), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L133-R133), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L317-R323), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L435-R441), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L576-R576), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L586-R586), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-e8ff83be2329052ff8d94933b1ee843421bd0ebce8f505a4f27fba7f887b90b0L300-R303), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-e8ff83be2329052ff8d94933b1ee843421bd0ebce8f505a4f27fba7f887b90b0L437-R440), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL197-R200), [link](https://github.com/kubeovn/kube-ovn/pull/3186/files?diff=unified&w=0#diff-758698341a22066119ba6e800153bd169d69b0b2017bbf932d5f7cbefac4afadL361-R364))