### PR TITLE
add log to help find conflict ip owner

### DIFF
--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -149,6 +149,7 @@ func (s *Subnet) GetStaticMac(podName, nicName, mac string, checkConflict bool) 
 	}
 	if checkConflict {
 		if p, ok := s.MacToPod[mac]; ok && p != podName {
+			klog.Errorf("mac %s has been allocated to pod %s", mac, p)
 			return ErrConflict
 		}
 	}
@@ -237,6 +238,7 @@ func (s *Subnet) getV4RandomAddress(ippoolName, podName, nicName string, mac *st
 	}
 	ip := pool.V4Free.Allocate(skipped)
 	if ip == nil {
+		klog.Errorf("no free v4 ip in ip pool %s", ippoolName)
 		return nil, nil, "", ErrConflict
 	}
 
@@ -290,6 +292,7 @@ func (s *Subnet) getV6RandomAddress(ippoolName, podName, nicName string, mac *st
 	}
 	ip := pool.V6Free.Allocate(skipped)
 	if ip == nil {
+		klog.Errorf("no free v6 ip in ip pool %s", ippoolName)
 		return nil, nil, "", ErrConflict
 	}
 


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
add some log about ErrConflict

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30fdc84</samp>

Improve error logging for MAC and IP allocation in `subnet.go`. Add log messages for mismatched MACs and exhausted IP pools.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 30fdc84</samp>

> _When allocating a MAC for a pod_
> _We should log if something is odd_
> _Like a mismatch or no IP_
> _In the pool that we see_
> _So we can debug `subnet.go` with a nod_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30fdc84</samp>

*  Log errors when MAC or IP allocation fails or is inconsistent ([link](https://github.com/kubeovn/kube-ovn/pull/3191/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfR152), [link](https://github.com/kubeovn/kube-ovn/pull/3191/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfR241), [link](https://github.com/kubeovn/kube-ovn/pull/3191/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfR295))