### PR TITLE
add multicast snoop for release-1.9

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -613,6 +613,8 @@ spec:
                   type: string
                 u2oInterconnection:
                   type: boolean
+                enableMulticastSnoop:
+                  type: boolean
                 u2oInterconnectionIP:
                   type: string
   scope: Cluster

--- a/kubeovn-helm/templates/kube-ovn-crd.yaml
+++ b/kubeovn-helm/templates/kube-ovn-crd.yaml
@@ -436,6 +436,8 @@ spec:
                   type: string
                 u2oInterconnection:
                   type: boolean
+                enableMulticastSnoop:
+                  type: boolean
                 u2oInterconnectionIP:
                   type: string
   scope: Cluster

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -129,6 +129,7 @@ type SubnetSpec struct {
 	DisableInterConnection bool   `json:"disableInterConnection,omitempty"`
 	U2OInterconnection     bool   `json:"u2oInterconnection,omitempty"`
 	U2OInterconnectionIP   string `json:"u2oInterconnectionIP,omitempty"`
+	EnableMulicastSnoop    bool   `json:"enableMulticastSnoop,omitempty"`
 }
 
 // ConditionType encodes information on the condition

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -225,6 +225,8 @@ spec:
                   type: string
                 u2oInterconnection:
                   type: boolean
+                enableMulticastSnoop:
+                  type: boolean
                 u2oInterconnectionIP:
                   type: string
   scope: Cluster


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 950d169</samp>

This pull request adds a new feature to enable multicast snooping on logical switches in kube-ovn. It adds a new field `enableMulticastSnoop` to the `SubnetSpec` schema and struct, and passes it to the ovn client when creating or updating switches. It also updates the helm and yaml templates to expose the new field.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 950d169</samp>

> _We are the masters of the multicast_
> _We control the switches with our code_
> _We unleash the power of the `SubnetSpec`_
> _We enable the snoop with a single node_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 950d169</samp>

*  Add a new field `EnableMulicastSnoop` to the `SubnetSpec` struct and schema to indicate whether to enable multicast snooping on the logical switch ([link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-cf6e828a3b8334b0180f06b380614f951d45a1a12d49efce74818fd68882a868R439-R440), [link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR132), [link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R228-R229))
*  Enqueue the subnet key when the `EnableMulicastSnoop` field changes in the subnet object update event ([link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L97-R98))
*  Pass the `EnableMulicastSnoop` field value to the ovn client methods that create or update the logical switch and set its configuration ([link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L605-R606), [link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L622-R623))
*  Modify the ovn client methods to accept a new parameter `needMulticastSnoop` and use it to set or remove the `other_config:mcast_snoop` and `other_config:mcast_querier` options on the logical switch ([link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L308-R308), [link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373R367-R375), [link](https://github.com/kubeovn/kube-ovn/pull/3192/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L376-R393))