### PR TITLE
add special handling for the route policy of the default VPC

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -648,7 +648,13 @@ func (c *Controller) gcStaticRoute() error {
 				continue
 			}
 			klog.Infof("gc static route %s %v %s %s", route.RouteTable, route.Policy, route.IPPrefix, route.Nexthop)
-			if err = c.OVNNbClient.DeleteLogicalRouterStaticRoute(c.config.ClusterRouter, &route.RouteTable, route.Policy, route.IPPrefix, route.Nexthop); err != nil {
+			if err = c.deleteStaticRouteFromVpc(
+				c.config.ClusterRouter,
+				route.RouteTable,
+				route.IPPrefix,
+				route.Nexthop,
+				reversePolicy(*route.Policy),
+			); err != nil {
 				klog.Errorf("failed to delete stale route %s %v %s %s: %v", route.RouteTable, route.Policy, route.IPPrefix, route.Nexthop, err)
 			}
 		}

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -714,21 +714,37 @@ func (c *Controller) initSyncCrdVlans() error {
 }
 
 func (c *Controller) migrateNodeRoute(af int, node, ip, nexthop string) error {
-	match := fmt.Sprintf("ip%d.dst == %s", af, ip)
-	action := ovnnb.LogicalRouterPolicyActionReroute
-	externalIDs := map[string]string{
-		"vendor": util.CniTypeName,
-		"node":   node,
-	}
+	var (
+		match       = fmt.Sprintf("ip%d.dst == %s", af, ip)
+		action      = kubeovnv1.PolicyRouteActionReroute
+		externalIDs = map[string]string{
+			"vendor": util.CniTypeName,
+			"node":   node,
+		}
+	)
 	klog.V(3).Infof("add policy route for router: %s, priority: %d, match %s, action %s, nexthop %s, extrenalID %v",
 		c.config.ClusterRouter, util.NodeRouterPolicyPriority, match, action, nexthop, externalIDs)
-	if err := c.OVNNbClient.AddLogicalRouterPolicy(c.config.ClusterRouter, util.NodeRouterPolicyPriority, match, action, []string{nexthop}, externalIDs); err != nil {
+	if err := c.addPolicyRouteToVpc(
+		c.config.ClusterRouter,
+		&kubeovnv1.PolicyRoute{
+			Priority:  util.NodeRouterPolicyPriority,
+			Match:     match,
+			Action:    action,
+			NextHopIP: nexthop,
+		},
+		externalIDs,
+	); err != nil {
 		klog.Errorf("failed to add logical router policy for node %s: %v", node, err)
 		return err
 	}
 
-	routeTable := util.MainRouteTable
-	if err := c.OVNNbClient.DeleteLogicalRouterStaticRoute(c.config.ClusterRouter, &routeTable, nil, ip, ""); err != nil {
+	if err := c.deleteStaticRouteFromVpc(
+		c.config.ClusterRouter,
+		util.MainRouteTable,
+		ip,
+		"",
+		kubeovnv1.PolicyDst,
+	); err != nil {
 		klog.Errorf("failed to delete obsolete static route for node %s: %v", node, err)
 		return err
 	}
@@ -736,7 +752,7 @@ func (c *Controller) migrateNodeRoute(af int, node, ip, nexthop string) error {
 	asName := nodeUnderlayAddressSetName(node, af)
 	obsoleteMatch := fmt.Sprintf("ip%d.dst == %s && ip%d.src != $%s", af, ip, af, asName)
 	klog.V(3).Infof("delete policy route for router: %s, priority: %d, match %s", c.config.ClusterRouter, util.NodeRouterPolicyPriority, obsoleteMatch)
-	if err := c.OVNNbClient.DeleteLogicalRouterPolicy(c.config.ClusterRouter, util.NodeRouterPolicyPriority, obsoleteMatch); err != nil {
+	if err := c.deletePolicyRouteFromVpc(c.config.ClusterRouter, util.NodeRouterPolicyPriority, obsoleteMatch); err != nil {
 		klog.Errorf("failed to delete obsolete logical router policy for node %s: %v", node, err)
 		return err
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1484,10 +1484,14 @@ func (c *Controller) reconcileDistributedSubnetRouteInDefaultVpc(subnet *kubeovn
 			}
 
 			if pod.Annotations[util.NorthGatewayAnnotation] != "" {
-				nextHop := pod.Annotations[util.NorthGatewayAnnotation]
-				if err := c.OVNNbClient.AddLogicalRouterStaticRoute(
-					c.config.ClusterRouter, util.MainRouteTable, ovnnb.LogicalRouterStaticRoutePolicySrcIP,
-					pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)], nil, nextHop,
+				if err := c.addStaticRouteToVpc(
+					c.config.ClusterRouter,
+					&kubeovnv1.StaticRoute{
+						Policy:     kubeovnv1.PolicySrc,
+						CIDR:       pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)],
+						NextHopIP:  pod.Annotations[util.NorthGatewayAnnotation],
+						RouteTable: util.MainRouteTable,
+					},
 				); err != nil {
 					klog.Errorf("add static route failed, %v", err)
 					return err
@@ -1816,7 +1820,13 @@ func (c *Controller) reconcileCustomVpcStaticRoute(subnet *kubeovnv1.Subnet) err
 
 func (c *Controller) deleteStaticRoute(ip, router, routeTable string) error {
 	for _, ipStr := range strings.Split(ip, ",") {
-		if err := c.OVNNbClient.DeleteLogicalRouterStaticRoute(router, &routeTable, nil, ipStr, ""); err != nil {
+		if err := c.deleteStaticRouteFromVpc(
+			router,
+			routeTable,
+			ipStr,
+			"",
+			kubeovnv1.PolicyDst,
+		); err != nil {
 			klog.Errorf("failed to delete static route %s, %v", ipStr, err)
 			return err
 		}
@@ -2230,11 +2240,22 @@ func (c *Controller) addCommonRoutesForSubnet(subnet *kubeovnv1.Subnet) error {
 		if protocol == kubeovnv1.ProtocolIPv6 {
 			af = 6
 		}
-		match := fmt.Sprintf("ip%d.dst == %s", af, cidr)
-		action := ovnnb.LogicalRouterPolicyActionAllow
-		externalIDs := map[string]string{"vendor": util.CniTypeName, "subnet": subnet.Name}
+
+		var (
+			match       = fmt.Sprintf("ip%d.dst == %s", af, cidr)
+			action      = kubeovnv1.PolicyRouteActionAllow
+			externalIDs = map[string]string{"vendor": util.CniTypeName, "subnet": subnet.Name}
+		)
 		klog.Infof("add policy route for router: %s, match %s, action %s, externalID %v", subnet.Spec.Vpc, match, action, externalIDs)
-		if err := c.OVNNbClient.AddLogicalRouterPolicy(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match, action, nil, externalIDs); err != nil {
+		if err := c.addPolicyRouteToVpc(
+			subnet.Spec.Vpc,
+			&kubeovnv1.PolicyRoute{
+				Priority: util.SubnetRouterPolicyPriority,
+				Match:    match,
+				Action:   action,
+			},
+			externalIDs,
+		); err != nil {
 			klog.Errorf("failed to add logical router policy for CIDR %s of subnet %s: %v", cidr, subnet.Name, err)
 			return err
 		}
@@ -2268,23 +2289,33 @@ func (c *Controller) updatePolicyRouteForCentralizedSubnet(subnetName, cidr stri
 	if util.CheckProtocol(cidr) == kubeovnv1.ProtocolIPv6 {
 		ipSuffix = "ip6"
 	}
-	match := fmt.Sprintf("%s.src == %s", ipSuffix, cidr)
-	action := ovnnb.LogicalRouterPolicyActionReroute
 
-	// there's no way to update policy route when gatewayNode changed for subnet, so delete and readd policy route
-	// The delete operation is processed in AddPolicyRoute if the policy route is inconsistent, so no need delete here
-
-	externalIDs := map[string]string{
-		"vendor": util.CniTypeName,
-		"subnet": subnetName,
-	}
+	var (
+		match  = fmt.Sprintf("%s.src == %s", ipSuffix, cidr)
+		action = kubeovnv1.PolicyRouteActionReroute
+		// there's no way to update policy route when gatewayNode changed for subnet, so delete and readd policy route
+		// The delete operation is processed in AddPolicyRoute if the policy route is inconsistent, so no need delete here
+		externalIDs = map[string]string{
+			"vendor": util.CniTypeName,
+			"subnet": subnetName,
+		}
+	)
 	// It's difficult to delete policy route when delete node,
 	// add map nodeName:nodeIP to external_ids to help process when delete node
 	for node, ip := range nameIPMap {
 		externalIDs[node] = ip
 	}
 	klog.Infof("add policy route for router: %s, match %s, action %s, nexthops %v, extrenalID %s", c.config.ClusterRouter, match, action, nextHops, externalIDs)
-	if err := c.OVNNbClient.AddLogicalRouterPolicy(c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match, action, nextHops, externalIDs); err != nil {
+	if err := c.addPolicyRouteToVpc(
+		c.config.ClusterRouter,
+		&kubeovnv1.PolicyRoute{
+			Priority:  util.GatewayRouterPolicyPriority,
+			Match:     match,
+			Action:    action,
+			NextHopIP: strings.Join(nextHops, ","),
+		},
+		externalIDs,
+	); err != nil {
 		klog.Errorf("failed to add policy route for centralized subnet %s: %v", subnetName, err)
 		return err
 	}
@@ -2324,7 +2355,7 @@ func (c *Controller) deletePolicyRouteForCentralizedSubnet(subnet *kubeovnv1.Sub
 		}
 		match := fmt.Sprintf("%s.src == %s", ipSuffix, cidr)
 		klog.Infof("delete policy route for router: %s, priority: %d, match %s", c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match)
-		if err := c.OVNNbClient.DeleteLogicalRouterPolicy(c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match); err != nil {
+		if err := c.deletePolicyRouteFromVpc(c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match); err != nil {
 			klog.Errorf("failed to delete policy route for centralized subnet %s: %v", subnet.Name, err)
 			return err
 		}
@@ -2350,16 +2381,28 @@ func (c *Controller) addPolicyRouteForDistributedSubnet(subnet *kubeovnv1.Subnet
 			continue
 		}
 
-		pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
-		match := fmt.Sprintf("%s.src == $%s", ipSuffix, pgAs)
-		action := ovnnb.LogicalRouterPolicyActionReroute
-		externalIDs := map[string]string{
-			"vendor": util.CniTypeName,
-			"subnet": subnet.Name,
-			"node":   nodeName,
-		}
+		var (
+			pgAs        = fmt.Sprintf("%s_%s", pgName, ipSuffix)
+			match       = fmt.Sprintf("%s.src == $%s", ipSuffix, pgAs)
+			action      = kubeovnv1.PolicyRouteActionReroute
+			externalIDs = map[string]string{
+				"vendor": util.CniTypeName,
+				"subnet": subnet.Name,
+				"node":   nodeName,
+			}
+		)
+
 		klog.Infof("add policy route for router: %s, match %s, action %s, extrenalID %v", c.config.ClusterRouter, match, action, externalIDs)
-		if err := c.OVNNbClient.AddLogicalRouterPolicy(c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match, action, []string{nodeIP}, externalIDs); err != nil {
+		if err := c.addPolicyRouteToVpc(
+			c.config.ClusterRouter,
+			&kubeovnv1.PolicyRoute{
+				Priority:  util.GatewayRouterPolicyPriority,
+				Match:     match,
+				Action:    action,
+				NextHopIP: nodeIP,
+			},
+			externalIDs,
+		); err != nil {
 			klog.Errorf("failed to add logical router policy for port-group address-set %s: %v", pgAs, err)
 			return err
 		}
@@ -2377,7 +2420,7 @@ func (c *Controller) deletePolicyRouteForDistributedSubnet(subnet *kubeovnv1.Sub
 		pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
 		match := fmt.Sprintf("%s.src == $%s", ipSuffix, pgAs)
 		klog.Infof("delete policy route for router: %s, priority: %d, match %s", c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match)
-		if err := c.OVNNbClient.DeleteLogicalRouterPolicy(c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match); err != nil {
+		if err := c.deletePolicyRouteFromVpc(c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match); err != nil {
 			klog.Errorf("failed to delete policy route for subnet %s: %v", subnet.Name, err)
 			return err
 		}
@@ -2401,7 +2444,7 @@ func (c *Controller) deletePolicyRouteByGatewayType(subnet *kubeovnv1.Subnet, ga
 		}
 		match := fmt.Sprintf("ip%d.dst == %s", af, cidr)
 		klog.Infof("delete policy route for router: %s, priority: %d, match %s", c.config.ClusterRouter, util.SubnetRouterPolicyPriority, match)
-		if err := c.OVNNbClient.DeleteLogicalRouterPolicy(c.config.ClusterRouter, util.SubnetRouterPolicyPriority, match); err != nil {
+		if err := c.deletePolicyRouteFromVpc(c.config.ClusterRouter, util.SubnetRouterPolicyPriority, match); err != nil {
 			klog.Errorf("failed to delete logical router policy for CIDR %s of subnet %s: %v", cidr, subnet.Name, err)
 			return err
 		}
@@ -2531,25 +2574,51 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			policy1 and policy2 allow overlay pod access underlay but when overlay pod access node ip, it should go join subnet,
 			policy3: underlay pod first access u2o interconnection lrp and then reoute to physical gw
 		*/
-		action := ovnnb.LogicalRouterPolicyActionAllow
+		action := kubeovnv1.PolicyRouteActionAllow
 		if subnet.Spec.Vpc == c.config.ClusterRouter {
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match1, action)
-			if err := c.OVNNbClient.AddLogicalRouterPolicy(subnet.Spec.Vpc, util.U2OSubnetPolicyPriority, match1, action, nil, externalIDs); err != nil {
+			if err := c.addPolicyRouteToVpc(
+				subnet.Spec.Vpc,
+				&kubeovnv1.PolicyRoute{
+					Priority: util.U2OSubnetPolicyPriority,
+					Match:    match1,
+					Action:   action,
+				},
+				externalIDs,
+			); err != nil {
 				klog.Errorf("failed to add u2o interconnection policy1 for subnet %s %v", subnet.Name, err)
 				return err
 			}
 
-			action = ovnnb.LogicalRouterPolicyActionReroute
+			action = kubeovnv1.PolicyRouteActionReroute
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match2, action)
-			if err := c.OVNNbClient.AddLogicalRouterPolicy(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match2, action, []string{nextHop}, externalIDs); err != nil {
+			if err := c.addPolicyRouteToVpc(
+				subnet.Spec.Vpc,
+				&kubeovnv1.PolicyRoute{
+					Priority:  util.SubnetRouterPolicyPriority,
+					Match:     match2,
+					Action:    action,
+					NextHopIP: nextHop,
+				},
+				externalIDs,
+			); err != nil {
 				klog.Errorf("failed to add u2o interconnection policy2 for subnet %s %v", subnet.Name, err)
 				return err
 			}
 		}
 
-		action = ovnnb.LogicalRouterPolicyActionReroute
+		action = kubeovnv1.PolicyRouteActionReroute
 		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s, nexthop %s", subnet.Spec.Vpc, match3, action, nextHop)
-		if err := c.OVNNbClient.AddLogicalRouterPolicy(subnet.Spec.Vpc, util.GatewayRouterPolicyPriority, match3, action, []string{nextHop}, externalIDs); err != nil {
+		if err := c.addPolicyRouteToVpc(
+			subnet.Spec.Vpc,
+			&kubeovnv1.PolicyRoute{
+				Priority:  util.GatewayRouterPolicyPriority,
+				Match:     match3,
+				Action:    action,
+				NextHopIP: nextHop,
+			},
+			externalIDs,
+		); err != nil {
 			klog.Errorf("failed to add u2o interconnection policy3 for subnet %s %v", subnet.Name, err)
 			return err
 		}
@@ -2652,7 +2721,7 @@ func (c *Controller) deleteCustomVPCPolicyRoutesForSubnet(subnet *kubeovnv1.Subn
 		}
 		match := fmt.Sprintf("ip%d.dst == %s", af, cidr)
 		klog.Infof("delete policy route for router: %s, priority: %d, match %s", subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match)
-		if err := c.OVNNbClient.DeleteLogicalRouterPolicy(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match); err != nil {
+		if err := c.deletePolicyRouteFromVpc(subnet.Spec.Vpc, util.SubnetRouterPolicyPriority, match); err != nil {
 			klog.Errorf("failed to delete logical router policy for CIDR %s of subnet %s: %v", cidr, subnet.Name, err)
 			return err
 		}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

What type of this PR
Examples of user facing changes:

- Bug fixes

some policies are not maintained by codes in vpc.go and not reflected in the vpc spec.
while updating default vpc, these policies will be accidentally deleted.

system policy and static route synchronize with ovn.
custom policy and static route synchronize with spec.

### Which issue(s) this PR fixes:
Fixes #3102 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21ec276</samp>

Refactor the code to use custom resource definitions (CRDs) to manage static and policy routes in virtual private clouds (VPCs). Update the controller logic and wrapper functions to create, update, and delete the CRD objects along with the OVN API calls. Modify the files `pkg/controller/init.go`, `pkg/controller/node.go`, `pkg/controller/ovn-ic.go`, `pkg/controller/pod.go`, `pkg/controller/subnet.go`, and `pkg/controller/gc.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 21ec276</samp>

> _Sing, O Muse, of the mighty refactor that the coders wrought_
> _To use CRDs for routes in VPCs, a noble task they sought_
> _They wrapped the calls to `ovn-nbctl` and OVN-NB API_
> _With functions that create and delete the CRDs on the fly_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 21ec276</samp>

*  Refactor the code to use CRDs to manage static and policy routes in VPCs by replacing direct calls to OVN-NB API with wrapper functions that also create or delete the corresponding CRD objects ([link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L651-R657), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L717-R747), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-92aa62435bc2b1b2be34f478f650597068bcf35b8d5975d119f91cf78ac54988L739-R755), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L269-R287), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1021-R1040), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1193-R1233), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL375-R381), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL487-R501), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL494-R516), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L801-R808), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L852-R863), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L954-R970), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1487-R1494), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1819-R1829), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2233-R2258), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2271-R2302), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2287-R2318), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2327-R2358), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2353-R2405), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2380-R2423), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2404-R2447), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2534-R2604), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2550-R2621), [link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2655-R2724))
* Remove the unused import of `ovnnb` package in `node.go` as part of the code cleanup ([link](https://github.com/kubeovn/kube-ovn/pull/3194/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L25))