### PR TITLE
fix: add static route to wrong table of ovn

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -309,10 +309,11 @@ func (c *OVNNbClient) newLogicalRouterStaticRoute(lrName, routeTable, policy, ip
 	}
 
 	route := &ovnnb.LogicalRouterStaticRoute{
-		UUID:     ovsclient.NamedUUID(),
-		Policy:   &policy,
-		IPPrefix: ipPrefix,
-		Nexthop:  nexthop,
+		UUID:       ovsclient.NamedUUID(),
+		Policy:     &policy,
+		IPPrefix:   ipPrefix,
+		Nexthop:    nexthop,
+		RouteTable: routeTable,
 	}
 	for _, option := range options {
 		option(route)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

fix the bug of name of table is not set while adding policy  route to ovn

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d62840</samp>

Add `routeTable` parameter to `LogicalRouterStaticRoute` struct and function. This enables multiple route tables for OVN logical routers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5d62840</samp>

> _`routeTable` added_
> _to support multiple routes_
> _in OVN schema_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5d62840</samp>

*  Add `routeTable` parameter to `LogicalRouterStaticRoute` struct and `newLogicalRouterStaticRoute` function ([link](https://github.com/kubeovn/kube-ovn/pull/3195/files?diff=unified&w=0#diff-386553eb41be041eafc944d6270c154cf99b46609ef142b487ce1e2d8dd089d6L312-R316),                           