### PR TITLE
netpol: fix duplicate default drop acl

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -329,7 +329,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 						return err
 					}
 
-					ops, err := c.OVNNbClient.UpdateIngressACLOps(pgName, ingressAllowAsName, ingressExceptAsName, protocol, []netv1.NetworkPolicyPort{}, logEnable, namedPortMap)
+					ops, err := c.OVNNbClient.UpdateIngressACLOps(pgName, ingressAllowAsName, ingressExceptAsName, protocol, nil, logEnable, namedPortMap)
 					if err != nil {
 						klog.Errorf("generate operations that add ingress acls to np %s: %v", key, err)
 						return err
@@ -482,7 +482,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 						return err
 					}
 
-					ops, err := c.OVNNbClient.UpdateEgressACLOps(pgName, egressAllowAsName, egressExceptAsName, protocol, []netv1.NetworkPolicyPort{}, logEnable, namedPortMap)
+					ops, err := c.OVNNbClient.UpdateEgressACLOps(pgName, egressAllowAsName, egressExceptAsName, protocol, nil, logEnable, namedPortMap)
 					if err != nil {
 						klog.Errorf("generate operations that add egress acls to np %s: %v", key, err)
 						return err

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -81,8 +81,8 @@ func (suite *OvnClientTestSuite) testUpdateIngressACLOps() {
 		t.Parallel()
 
 		pgName := "test_create_v4_ingress_acl_pg"
-		asIngressName := "test.default.ingress.allow.ipv4"
-		asExceptName := "test.default.ingress.except.ipv4"
+		asIngressName := "test.default.ingress.allow.ipv4.all"
+		asExceptName := "test.default.ingress.except.ipv4.all"
 		protocol := kubeovnv1.ProtocolIPv4
 
 		err := ovnClient.CreatePortGroup(pgName, nil)
@@ -109,8 +109,8 @@ func (suite *OvnClientTestSuite) testUpdateIngressACLOps() {
 		t.Parallel()
 
 		pgName := "test_create_v6_ingress_acl_pg"
-		asIngressName := "test.default.ingress.allow.ipv6"
-		asExceptName := "test.default.ingress.except.ipv6"
+		asIngressName := "test.default.ingress.allow.ipv6.all"
+		asExceptName := "test.default.ingress.except.ipv6.all"
 		protocol := kubeovnv1.ProtocolIPv6
 
 		err := ovnClient.CreatePortGroup(pgName, nil)
@@ -151,8 +151,8 @@ func (suite *OvnClientTestSuite) testUpdateEgressACLOps() {
 		t.Parallel()
 
 		pgName := "test_create_v4_egress_acl_pg"
-		asEgressName := "test.default.egress.allow.ipv4"
-		asExceptName := "test.default.egress.except.ipv4"
+		asEgressName := "test.default.egress.allow.ipv4.all"
+		asExceptName := "test.default.egress.except.ipv4.all"
 		protocol := kubeovnv1.ProtocolIPv4
 
 		err := ovnClient.CreatePortGroup(pgName, nil)
@@ -179,8 +179,8 @@ func (suite *OvnClientTestSuite) testUpdateEgressACLOps() {
 		t.Parallel()
 
 		pgName := "test_create_v6_egress_acl_pg"
-		asEgressName := "test.default.egress.allow.ipv6"
-		asExceptName := "test.default.egress.except.ipv6"
+		asEgressName := "test.default.egress.allow.ipv6.all"
+		asExceptName := "test.default.egress.except.ipv6.all"
 		protocol := kubeovnv1.ProtocolIPv6
 
 		err := ovnClient.CreatePortGroup(pgName, nil)


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:


```txt
E0911 06:23:53.500514       1 ovn-nb-acl.go:599] more than one acl with same 'parent np.1.kube.system direction from-lport priority 2000 match inport == @np.1.kube.system && ip4'
E0911 06:23:53.500571       1 network_policy.go:500] failed to set egress acl log for np kube-system/np-1, more than one acl with same 'parent np.1.kube.system direction from-lport priority 2000 match inport == @np.1.kube.system && ip4'
```

### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b3a751</samp>

Fix a bug that caused unnecessary default drop rules for network policies with no ports or selectors. Refactor the address set name format and update the unit tests accordingly. Improve the performance and readability of the ACL allow rules functions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8b3a751</samp>

> _There once was a bug in the code_
> _That made default drop rules explode_
> _But with `nil` and a suffix_
> _The logic got fixed_
> _And the network policies flowed_

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b3a751</samp>

*  Avoid creating duplicate default drop rules for port groups when network policy has no pod or namespace selector ([link](https://github.com/kubeovn/kube-ovn/pull/3197/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L25-R51), [link](https://github.com/kubeovn/kube-ovn/pull/3197/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L72-R107))
* Replace empty slice with nil for port argument in `UpdateIngressACLOps` and `UpdateEgressACLOps` functions ([link](https://github.com/kubeovn/kube-ovn/pull/3197/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L332-R332), [link](https://github.com/kubeovn/kube-ovn/pull/3197/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L485-R485))
* Update test cases for `UpdateIngressACLOps` and `UpdateEgressACLOps` functions ([link](https://github.com/kubeovn/kube-ovn/pull/3197/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L84-R85), [link](https://github.com/kubeovn/kube-ovn/pull/3197/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L112-R113), [link](https://github.com/kubeovn/kube-ovn/pull/3197/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L154-R155), [link](https://github.com/kubeovn/kube-ovn/pull/3197/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L182-R183))
