### PR TITLE
netpol: fix egress rules when service cluster ips are included in ipBlock

### DIFF
--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -108,7 +108,20 @@ func (c *OVNNbClient) UpdateEgressACLOps(pgName, asEgressName, asExceptName, pro
 	/* allow acl */
 	matches := newNetworkPolicyACLMatch(pgName, asEgressName, asExceptName, protocol, ovnnb.ACLDirectionFromLport, npp, namedPortMap)
 	for _, m := range matches {
-		allowACL, err := c.newACLWithoutCheck(pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, ovnnb.ACLActionAllowRelated, func(acl *ovnnb.ACL) {
+		allowACL, err := c.newACLWithoutCheck(pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, ovnnb.ACLActionAllowStateless)
+		if err != nil {
+			klog.Error(err)
+			return nil, fmt.Errorf("new allow egress acl for port group %s: %v", pgName, err)
+		}
+		if err != nil {
+			klog.Error(err)
+			return nil, fmt.Errorf("new allow egress acl for port group %s: %v", pgName, err)
+		}
+
+		acls = append(acls, allowACL)
+
+		// allow after LB
+		allowACL, err = c.newACLWithoutCheck(pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, ovnnb.ACLActionAllowRelated, func(acl *ovnnb.ACL) {
 			if acl.Options == nil {
 				acl.Options = make(map[string]string)
 			}


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #3193 

### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3847358</samp>

Refactor ACL unit tests and support stateless egress traffic. The pull request updates the `pkg/ovs/ovn-nb-acl.go` and `pkg/ovs/ovn-nb-acl_test.go` files to create two ACLs for each egress match, one with the `allow-stateless` action and one with the `allow-related` and `apply-after-lb` options. It also replaces string literals with constants in the unit tests and adds error handling.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3847358</samp>

> _To support stateless egress flow_
> _We create two ACLs for each row_
> _One with `allow-stateless`_
> _One with `allow-related`_
> _And the `apply-after-lb` option to show_

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3847358</samp>

* Create two ACLs for each egress match to support stateless and related traffic ([link](https://github.com/kubeovn/kube-ovn/pull/3198/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L111-R124), [link](https://github.com/kubeovn/kube-ovn/pull/3198/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L165-R167), [link](https://github.com/kubeovn/kube-ovn/pull/3198/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L173-R177), [link](https://github.com/kubeovn/kube-ovn/pull/3198/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L191-R197), [link](https://github.com/kubeovn/kube-ovn/pull/3198/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L199-R207))
* Replace string literals with constants for ACL actions and security group rule fields ([link](https://github.com/kubeovn/kube-ovn/pull/3198/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L97-R97), [link](https://github.com/kubeovn/kube-ovn/pull/3198/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L123-R123), [link](https://github.com/kubeovn/kube-ovn/pull/3198/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L997-R1007))
