### PR TITLE
fix ipam random get

### DIFF
--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -239,11 +239,15 @@ func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, sk
 		return "", "", "", ErrConflict
 	}
 
-	if subnet.V4FreeIPList[idx].End.Equal(ip) {
-		// the item of ip range is all allocated, remove it
-		subnet.V4FreeIPList = append(subnet.V4FreeIPList[:idx], subnet.V4FreeIPList[idx+1:]...)
-	} else {
-		subnet.V4FreeIPList[idx].Start = ip.Add(1)
+	ipr := subnet.V4FreeIPList[idx]
+	part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
+	part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
+	subnet.V4FreeIPList = append(subnet.V4FreeIPList[:idx], subnet.V4FreeIPList[idx+1:]...)
+	if !part1.Start.GreaterThan(part1.End) {
+		subnet.V4FreeIPList = append(subnet.V4FreeIPList, part1)
+	}
+	if !part2.Start.GreaterThan(part2.End) {
+		subnet.V4FreeIPList = append(subnet.V4FreeIPList, part2)
 	}
 
 	subnet.V4NicToIP[nicName] = ip
@@ -300,11 +304,15 @@ func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, sk
 		return "", "", "", ErrConflict
 	}
 
-	if subnet.V6FreeIPList[idx].End.Equal(ip) {
-		// the item of ip range is all allocated, remove it
-		subnet.V6FreeIPList = append(subnet.V6FreeIPList[:idx], subnet.V6FreeIPList[idx+1:]...)
-	} else {
-		subnet.V6FreeIPList[idx].Start = ip.Add(1)
+	ipr := subnet.V6FreeIPList[idx]
+	part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
+	part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
+	subnet.V6FreeIPList = append(subnet.V6FreeIPList[:idx], subnet.V6FreeIPList[idx+1:]...)
+	if !part1.Start.GreaterThan(part1.End) {
+		subnet.V6FreeIPList = append(subnet.V6FreeIPList, part1)
+	}
+	if !part2.Start.GreaterThan(part2.End) {
+		subnet.V6FreeIPList = append(subnet.V6FreeIPList, part2)
 	}
 
 	subnet.V6NicToIP[nicName] = ip

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -220,10 +220,13 @@ func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, sk
 	var ip IP
 	var idx int
 	for i, ipr := range subnet.V4FreeIPList {
+		klog.Infof("allocate pod %s v4 ip in the range of start: %s, end: %s", podName, ipr.Start, ipr.End)
 		for next := ipr.Start; !next.GreaterThan(ipr.End); next = next.Add(1) {
 			if !util.ContainsString(skippedAddrs, string(next)) {
 				ip = next
 				break
+			} else {
+				klog.Infof("v4 ip %s is in skipped addrs %+v", skippedAddrs)
 			}
 		}
 		if ip != "" {
@@ -235,16 +238,19 @@ func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, sk
 		klog.Errorf("no available ip in subnet %s, v4 free ip list %v", subnet.Name, subnet.V4FreeIPList)
 		return "", "", "", ErrConflict
 	}
-
-	ipr := subnet.V4FreeIPList[idx]
-	part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
-	part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
-	subnet.V4FreeIPList = append(subnet.V4FreeIPList[:idx], subnet.V4FreeIPList[idx+1:]...)
-	if !part1.Start.GreaterThan(part1.End) {
-		subnet.V4FreeIPList = append(subnet.V4FreeIPList, part1)
-	}
-	if !part2.Start.GreaterThan(part2.End) {
-		subnet.V4FreeIPList = append(subnet.V4FreeIPList, part2)
+	if subnet.V4FreeIPList[idx].Start.Equal(ip) {
+		subnet.V4FreeIPList[idx].Start = ip.Add(1)
+	} else {
+		ipr := subnet.V4FreeIPList[idx]
+		part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
+		part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
+		subnet.V4FreeIPList = append(subnet.V4FreeIPList[:idx], subnet.V4FreeIPList[idx+1:]...)
+		if !part1.Start.GreaterThan(part1.End) {
+			subnet.V4FreeIPList = append(subnet.V4FreeIPList, part1)
+		}
+		if !part2.Start.GreaterThan(part2.End) {
+			subnet.V4FreeIPList = append(subnet.V4FreeIPList, part2)
+		}
 	}
 
 	subnet.V4NicToIP[nicName] = ip
@@ -282,10 +288,13 @@ func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, sk
 	var ip IP
 	var idx int
 	for i, ipr := range subnet.V6FreeIPList {
+		klog.Infof("allocate pod %s v6 ip in the range of start: %s, end: %s", podName, ipr.Start, ipr.End)
 		for next := ipr.Start; !next.GreaterThan(ipr.End); next = next.Add(1) {
 			if !util.ContainsString(skippedAddrs, string(next)) {
 				ip = next
 				break
+			} else {
+				klog.Infof("v6 ip %s is in skipped addrs %+v", skippedAddrs)
 			}
 		}
 		if ip != "" {
@@ -297,16 +306,19 @@ func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, sk
 		klog.Errorf("no available ip in subnet %s, v6 free ip list %v", subnet.Name, subnet.V6FreeIPList)
 		return "", "", "", ErrConflict
 	}
-
-	ipr := subnet.V6FreeIPList[idx]
-	part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
-	part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
-	subnet.V6FreeIPList = append(subnet.V6FreeIPList[:idx], subnet.V6FreeIPList[idx+1:]...)
-	if !part1.Start.GreaterThan(part1.End) {
-		subnet.V6FreeIPList = append(subnet.V6FreeIPList, part1)
-	}
-	if !part2.Start.GreaterThan(part2.End) {
-		subnet.V6FreeIPList = append(subnet.V6FreeIPList, part2)
+	if subnet.V6FreeIPList[idx].Start.Equal(ip) {
+		subnet.V6FreeIPList[idx].Start = ip.Add(1)
+	} else {
+		ipr := subnet.V6FreeIPList[idx]
+		part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
+		part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
+		subnet.V6FreeIPList = append(subnet.V6FreeIPList[:idx], subnet.V6FreeIPList[idx+1:]...)
+		if !part1.Start.GreaterThan(part1.End) {
+			subnet.V6FreeIPList = append(subnet.V6FreeIPList, part1)
+		}
+		if !part2.Start.GreaterThan(part2.End) {
+			subnet.V6FreeIPList = append(subnet.V6FreeIPList, part2)
+		}
 	}
 
 	subnet.V6NicToIP[nicName] = ip

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -238,19 +238,12 @@ func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, sk
 		klog.Errorf("no available ip in subnet %s, v4 free ip list %v", subnet.Name, subnet.V4FreeIPList)
 		return "", "", "", ErrConflict
 	}
-	if subnet.V4FreeIPList[idx].Start.Equal(ip) {
-		subnet.V4FreeIPList[idx].Start = ip.Add(1)
-	} else {
-		ipr := subnet.V4FreeIPList[idx]
-		part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
-		part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
+
+	if subnet.V4FreeIPList[idx].End.Equal(ip) {
+		// the item of ip range is all allocated, remove it
 		subnet.V4FreeIPList = append(subnet.V4FreeIPList[:idx], subnet.V4FreeIPList[idx+1:]...)
-		if !part1.Start.GreaterThan(part1.End) {
-			subnet.V4FreeIPList = append(subnet.V4FreeIPList, part1)
-		}
-		if !part2.Start.GreaterThan(part2.End) {
-			subnet.V4FreeIPList = append(subnet.V4FreeIPList, part2)
-		}
+	} else {
+		subnet.V4FreeIPList[idx].Start = ip.Add(1)
 	}
 
 	subnet.V4NicToIP[nicName] = ip
@@ -306,19 +299,12 @@ func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, sk
 		klog.Errorf("no available ip in subnet %s, v6 free ip list %v", subnet.Name, subnet.V6FreeIPList)
 		return "", "", "", ErrConflict
 	}
-	if subnet.V6FreeIPList[idx].Start.Equal(ip) {
-		subnet.V6FreeIPList[idx].Start = ip.Add(1)
-	} else {
-		ipr := subnet.V6FreeIPList[idx]
-		part1 := &IPRange{Start: ipr.Start, End: ip.Sub(1)}
-		part2 := &IPRange{Start: ip.Add(1), End: ipr.End}
+
+	if subnet.V6FreeIPList[idx].End.Equal(ip) {
+		// the item of ip range is all allocated, remove it
 		subnet.V6FreeIPList = append(subnet.V6FreeIPList[:idx], subnet.V6FreeIPList[idx+1:]...)
-		if !part1.Start.GreaterThan(part1.End) {
-			subnet.V6FreeIPList = append(subnet.V6FreeIPList, part1)
-		}
-		if !part2.Start.GreaterThan(part2.End) {
-			subnet.V6FreeIPList = append(subnet.V6FreeIPList, part2)
-		}
+	} else {
+		subnet.V6FreeIPList[idx].Start = ip.Add(1)
 	}
 
 	subnet.V6NicToIP[nicName] = ip


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:

- Bug fixes
https://github.com/kubeovn/kube-ovn/issues/3190

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b78654a</samp>

Improve IP allocation performance and debuggability for pods. Add logging of pod name and IP range in `subnet.go`. Simplify free IP list update logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b78654a</samp>

> _The pods need some IPs to run_
> _But the allocation was not fun_
> _So `subnet.go` got a tweak_
> _With logging and logic more sleek_
> _Now the performance is second to none_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b78654a</samp>

*  Add logging statements to the functions that allocate random IP addresses for pods from subnets, for debugging purposes ([link](https://github.com/kubeovn/kube-ovn/pull/3200/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL223-R229), [link](https://github.com/kubeovn/kube-ovn/pull/3200/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL285-R297))
*  Optimize the logic of updating the free IP list after allocating an IP address for a pod, by avoiding unnecessary splitting and appending of the IP range ([link](https://github.com/kubeovn/kube-ovn/pull/3200/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL238-R254), [link](https://github.com/kubeovn/kube-ovn/pull/3200/files?diff=unified&w=0#diff-4fc061eef222d8c0b8154fd54f4d00c56f2442eaa20ae37f34bb67078075afbfL300-R322))