### PR TITLE
netpol: do not create unused address set for services

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/ovn-org/libovsdb/ovsdb"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -130,6 +129,22 @@ func (c *Controller) processNextDeleteNpWorkItem() bool {
 	return true
 }
 
+func (c *Controller) createAsForNetpol(ns, name, direction, asName string, addresses []string) error {
+	if err := c.OVNNbClient.CreateAddressSet(asName, map[string]string{
+		networkPolicyKey: fmt.Sprintf("%s/%s/%s", ns, name, direction),
+	}); err != nil {
+		klog.Errorf("failed to create ovn address set %s for np %s/%s: %v", asName, ns, name, err)
+		return err
+	}
+
+	if err := c.OVNNbClient.AddressSetUpdateAddress(asName, addresses...); err != nil {
+		klog.Errorf("failed to set addresses %q to address set %s: %v", strings.Join(addresses, ","), asName, err)
+		return err
+	}
+
+	return nil
+}
+
 func (c *Controller) handleUpdateNp(key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -158,11 +173,6 @@ func (c *Controller) handleUpdateNp(key string) error {
 	logEnable := false
 	if np.Annotations[util.NetworkPolicyLogAnnotation] == "true" {
 		logEnable = true
-	}
-
-	npName := np.Name
-	if nameArray := []rune(np.Name); !unicode.IsLetter(nameArray[0]) {
-		npName = "np" + np.Name
 	}
 
 	// TODO: ovn acl doesn't support address_set name with '-', now we replace '-' by '.'.
@@ -201,48 +211,11 @@ func (c *Controller) handleUpdateNp(key string) error {
 		return err
 	}
 
-	// set svc address_set
-	svcAsNameIPv4 := strings.ReplaceAll(fmt.Sprintf("%s.%s.service.%s", npName, np.Namespace, kubeovnv1.ProtocolIPv4), "-", ".")
-	svcAsNameIPv6 := strings.ReplaceAll(fmt.Sprintf("%s.%s.service.%s", npName, np.Namespace, kubeovnv1.ProtocolIPv6), "-", ".")
-	svcIpv4s, svcIpv6s, err := c.fetchSelectedSvc(np.Namespace, &np.Spec.PodSelector)
-	if err != nil {
-		klog.Errorf("failed to fetchSelectedSvc svcIPs result  %v", err)
-		return err
-	}
-	for _, subnet := range subnets {
-		for _, cidrBlock := range strings.Split(subnet.Spec.CIDRBlock, ",") {
-			protocol := util.CheckProtocol(cidrBlock)
-			svcAsName := svcAsNameIPv4
-			svcIPs := svcIpv4s
-			if protocol == kubeovnv1.ProtocolIPv6 {
-				svcAsName = svcAsNameIPv6
-				svcIPs = svcIpv6s
-			}
-
-			if err = c.OVNNbClient.CreateAddressSet(svcAsName, map[string]string{
-				networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "service"),
-			}); err != nil {
-				klog.Errorf("create address set %s for np %s: %v", svcAsName, key, err)
-				return err
-			}
-
-			if err = c.OVNNbClient.AddressSetUpdateAddress(svcAsName, svcIPs...); err != nil {
-				klog.Errorf("set service ips to address set %s: %v", svcAsName, err)
-				return err
-			}
-		}
-	}
-
-	var ingressACLOps []ovsdb.Operation
-
-	clearIngressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil)
+	ingressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil)
 	if err != nil {
 		klog.Errorf("generate operations that clear np %s ingress acls: %v", key, err)
 		return err
 	}
-
-	// put clear acl and update acl in a single transaction to imitate update acl
-	ingressACLOps = append(ingressACLOps, clearIngressACLOps...)
 
 	if hasIngressRule(np) {
 		for _, subnet := range subnets {
@@ -274,27 +247,10 @@ func (c *Controller) handleUpdateNp(key string) error {
 					}
 					klog.Infof("UpdateNp Ingress, allows is %v, excepts is %v, log %v", allows, excepts, logEnable)
 
-					if err = c.OVNNbClient.CreateAddressSet(ingressAllowAsName, map[string]string{
-						networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "ingress"),
-					}); err != nil {
-						klog.Errorf("create address set %s for np %s: %v", ingressAllowAsName, key, err)
+					if err = c.createAsForNetpol(np.Namespace, np.Name, "ingress", ingressAllowAsName, allows); err != nil {
 						return err
 					}
-
-					if err = c.OVNNbClient.AddressSetUpdateAddress(ingressAllowAsName, allows...); err != nil {
-						klog.Errorf("set ingress allow ips to address set %s: %v", ingressAllowAsName, err)
-						return err
-					}
-
-					if err = c.OVNNbClient.CreateAddressSet(ingressExceptAsName, map[string]string{
-						networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "ingress"),
-					}); err != nil {
-						klog.Errorf("create address set %s for np %s: %v", ingressExceptAsName, key, err)
-						return err
-					}
-
-					if err = c.OVNNbClient.AddressSetUpdateAddress(ingressExceptAsName, excepts...); err != nil {
-						klog.Errorf("set ingress except ips to address set %s: %v", ingressExceptAsName, err)
+					if err = c.createAsForNetpol(np.Namespace, np.Name, "ingress", ingressExceptAsName, excepts); err != nil {
 						return err
 					}
 
@@ -315,17 +271,10 @@ func (c *Controller) handleUpdateNp(key string) error {
 					ingressAllowAsName := fmt.Sprintf("%s.%s.all", ingressAllowAsNamePrefix, protocol)
 					ingressExceptAsName := fmt.Sprintf("%s.%s.all", ingressExceptAsNamePrefix, protocol)
 
-					if err = c.OVNNbClient.CreateAddressSet(ingressAllowAsName, map[string]string{
-						networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "ingress"),
-					}); err != nil {
-						klog.Errorf("create address set %s for np %s: %v", ingressAllowAsName, key, err)
+					if err = c.createAsForNetpol(np.Namespace, np.Name, "ingress", ingressAllowAsName, nil); err != nil {
 						return err
 					}
-
-					if err = c.OVNNbClient.CreateAddressSet(ingressExceptAsName, map[string]string{
-						networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "ingress"),
-					}); err != nil {
-						klog.Errorf("create address set %s for np %s: %v", ingressExceptAsName, key, err)
+					if err = c.createAsForNetpol(np.Namespace, np.Name, "ingress", ingressExceptAsName, nil); err != nil {
 						return err
 					}
 
@@ -389,16 +338,11 @@ func (c *Controller) handleUpdateNp(key string) error {
 		}
 	}
 
-	var egressACLOps []ovsdb.Operation
-
-	clearEgressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "from-lport", nil)
+	egressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "from-lport", nil)
 	if err != nil {
 		klog.Errorf("generate operations that clear np %s egress acls: %v", key, err)
 		return err
 	}
-
-	// put clear and add acl in a single transaction to imitate acl update
-	egressACLOps = append(egressACLOps, clearEgressACLOps...)
 
 	if hasEgressRule(np) {
 		for _, subnet := range subnets {
@@ -430,27 +374,10 @@ func (c *Controller) handleUpdateNp(key string) error {
 					}
 					klog.Infof("UpdateNp Egress, allows is %v, excepts is %v, log %v", allows, excepts, logEnable)
 
-					if err = c.OVNNbClient.CreateAddressSet(egressAllowAsName, map[string]string{
-						networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "egress"),
-					}); err != nil {
-						klog.Errorf("create address set %s for np %s: %v", egressAllowAsName, key, err)
+					if err = c.createAsForNetpol(np.Namespace, np.Name, "egress", egressAllowAsName, allows); err != nil {
 						return err
 					}
-
-					if err = c.OVNNbClient.AddressSetUpdateAddress(egressAllowAsName, allows...); err != nil {
-						klog.Errorf("set egress allow ips to address set %s: %v", egressAllowAsName, err)
-						return err
-					}
-
-					if err = c.OVNNbClient.CreateAddressSet(egressExceptAsName, map[string]string{
-						networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "egress"),
-					}); err != nil {
-						klog.Errorf("create address set %s for np %s: %v", egressExceptAsName, key, err)
-						return err
-					}
-
-					if err = c.OVNNbClient.AddressSetUpdateAddress(egressExceptAsName, excepts...); err != nil {
-						klog.Errorf("set egress except ips to address set %s: %v", egressExceptAsName, err)
+					if err = c.createAsForNetpol(np.Namespace, np.Name, "egress", egressExceptAsName, excepts); err != nil {
 						return err
 					}
 
@@ -468,17 +395,10 @@ func (c *Controller) handleUpdateNp(key string) error {
 					egressAllowAsName := fmt.Sprintf("%s.%s.all", egressAllowAsNamePrefix, protocol)
 					egressExceptAsName := fmt.Sprintf("%s.%s.all", egressExceptAsNamePrefix, protocol)
 
-					if err = c.OVNNbClient.CreateAddressSet(egressAllowAsName, map[string]string{
-						networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "egress"),
-					}); err != nil {
-						klog.Errorf("create address set %s for np %s: %v", egressAllowAsName, key, err)
+					if err = c.createAsForNetpol(np.Namespace, np.Name, "egress", egressAllowAsName, nil); err != nil {
 						return err
 					}
-
-					if err = c.OVNNbClient.CreateAddressSet(egressExceptAsName, map[string]string{
-						networkPolicyKey: fmt.Sprintf("%s/%s/%s", np.Namespace, np.Name, "egress"),
-					}); err != nil {
-						klog.Errorf("create address set %s for np %s: %v", egressExceptAsName, key, err)
+					if err = c.createAsForNetpol(np.Namespace, np.Name, "egress", egressExceptAsName, nil); err != nil {
 						return err
 					}
 
@@ -634,45 +554,6 @@ func (c *Controller) fetchSelectedPorts(namespace string, selector *metav1.Label
 	}
 	subnets = util.UniqString(subnets)
 	return ports, subnets, nil
-}
-
-func (c *Controller) fetchSelectedSvc(namespace string, selector *metav1.LabelSelector) ([]string, []string, error) {
-	sel, err := metav1.LabelSelectorAsSelector(selector)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating label selector, %v", err)
-	}
-	pods, err := c.podsLister.Pods(namespace).List(sel)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list pods, %v", err)
-	}
-
-	svcIpv4s := make([]string, 0)
-	svcIpv6s := make([]string, 0)
-	svcs, err := c.servicesLister.Services(namespace).List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list svc, %v", err)
-		return nil, nil, err
-	}
-
-	for _, pod := range pods {
-		if !isPodAlive(pod) {
-			continue
-		}
-		if !pod.Spec.HostNetwork && pod.Annotations[util.AllocatedAnnotation] == "true" {
-			svcIpv4, err := svcMatchPods(svcs, pod, kubeovnv1.ProtocolIPv4)
-			if err != nil {
-				return nil, nil, err
-			}
-			svcIpv4s = append(svcIpv4s, svcIpv4...)
-
-			svcIpv6, err := svcMatchPods(svcs, pod, kubeovnv1.ProtocolIPv6)
-			if err != nil {
-				return nil, nil, err
-			}
-			svcIpv6s = append(svcIpv6s, svcIpv6...)
-		}
-	}
-	return svcIpv4s, svcIpv6s, nil
 }
 
 func hasIngressRule(np *netv1.NetworkPolicy) bool {


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49dcb35</samp>

Refactor network policy address set handling in `network_policy.go`. Extract common logic to a new function `createAsForNetpol` and remove unnecessary or redundant code. Improve code consistency and readability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 49dcb35</samp>

> _To handle network policy sets_
> _The code had some issues and debts_
> _So `createAsForNetpol`_
> _Made it simpler and whole_
> _And removed some redundant regrets_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 49dcb35</samp>

*  Simplify the creation and update of address sets for network policies by introducing a new function `createAsForNetpol` in `network_policy.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46R132-R147))
*  Use the new function to replace the direct calls to OVNNbClient methods in the `handleNetworkPolicyCreate` and `handleNetworkPolicyUpdate` functions ([link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L204-R219), [link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L277-R256), [link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L318-R277), [link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L433-R383), [link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L471-R401))
*  Remove the unused import of the ovsdb package from `network_policy.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L10))
*  Remove the unnecessary and inconsistent code that modifies the network policy name if it does not start with a letter ([link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L163-L167))
*  Rename the variable `egressACLOps` to match `ingressACLOps` in `handleNetworkPolicyCreate` ([link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L392-R341))
*  Remove the redundant and inefficient code that appends the clear egress ACL operations to the egress ACL operations slice in `handleNetworkPolicyUpdate` ([link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L400-L402))
*  Remove the unused function `fetchSelectedSvc` from `network_policy.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3208/files?diff=unified&w=0#diff-3441e10e1931fbc479e897af8f790a69fa24fbad89a1308f4f9c8f13ee06de46L639-L677))