### PR TITLE
chart: remove subnet finalizers before subnets are deleted

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1080,7 +1080,7 @@ jobs:
           name: kube-ovn-ic-conformance-e2e-ko-log
           path: kube-ovn-ic-conformance-e2e-ko-log.tar.gz
 
-  chart-installation-test:
+  chart-test:
     name: Chart Installation Test
     needs: build-kube-ovn
     runs-on: ubuntu-22.04
@@ -1113,8 +1113,8 @@ jobs:
       - name: Install Kube-OVN
         run: make kind-install-chart
 
-      - name: Cleanup
-        run: sh -x dist/images/cleanup.sh
+      - name: Uninstall Kube-OVN
+        run: make kind-uninstall-chart
 
   underlay-logical-gateway-installation-test:
     name: Underlay Logical Gateway Installation Test

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -2052,7 +2052,7 @@ jobs:
       - webhook-e2e
       - lb-svc-e2e
       - underlay-logical-gateway-installation-test
-      - chart-installation-test
+      - chart-test
       - installation-compatibility-test
       - no-ovn-lb-test
       - no-np-test

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1081,7 +1081,7 @@ jobs:
           path: kube-ovn-ic-conformance-e2e-ko-log.tar.gz
 
   chart-test:
-    name: Chart Installation Test
+    name: Chart Installation/Uninstallation Test
     needs: build-kube-ovn
     runs-on: ubuntu-22.04
     timeout-minutes: 30

--- a/Makefile
+++ b/Makefile
@@ -447,6 +447,10 @@ kind-upgrade-chart: kind-load-image
 	kubectl -n kube-system rollout status --timeout=1s daemonset/kube-ovn-cni
 	kubectl -n kube-system rollout status --timeout=1s daemonset/kube-ovn-pinger
 
+.PHONY: kind-uninstall-chart
+kind-uninstall-chart:
+	helm uninstall kubeovn
+
 .PHONY: kind-install
 kind-install: kind-load-image
 	kubectl config use-context kind-kube-ovn

--- a/charts/templates/pre-delete-hook.yaml
+++ b/charts/templates/pre-delete-hook.yaml
@@ -1,15 +1,12 @@
-{{ if (lookup "apps/v1" "DaemonSet" "kube-system" "ovs-ovn") }}
-{{ if eq (lookup "apps/v1" "DaemonSet" "kube-system" "ovs-ovn").spec.updateStrategy.type "OnDelete" }}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ovs-ovn-upgrade
+  name: kube-ovn-pre-delete-hook
   namespace: kube-system
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-upgrade
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
 ---
@@ -20,57 +17,43 @@ metadata:
     rbac.authorization.k8s.io/system-only: "true"
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-upgrade
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded
-  name: system:ovs-ovn-upgrade
+  name: system:kube-ovn-pre-delete-hook
 rules:
   - apiGroups:
-      - apps
+      - kubeovn.io
     resources:
-      - daemonsets
-    resourceNames:
-      - ovs-ovn
+      - subnets
     verbs:
       - get
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
       - list
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - list
-      - get
-      - delete
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ovs-ovn-upgrade
+  name: kube-ovn-pre-delete-hook
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-upgrade
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
-  name: system:ovs-ovn-upgrade
+  name: system:kube-ovn-pre-delete-hook
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: ovs-ovn-upgrade
+    name: kube-ovn-pre-delete-hook
     namespace: kube-system
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Chart.Name }}-post-upgrade-hook"
+  name: "{{ .Chart.Name }}-pre-delete-hook"
   namespace: kube-system
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
@@ -80,7 +63,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-upgrade
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "4"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
@@ -92,7 +75,7 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        app: post-upgrade
+        app: kube-ovn-pre-delete-hook
         component: job
     spec:
       tolerations:
@@ -108,7 +91,7 @@ spec:
                   - key: app
                     operator: In
                     values:
-                      - post-upgrade
+                      - kube-ovn-pre-delete-hook
                   - key: component
                     operator: In
                     values:
@@ -117,10 +100,10 @@ spec:
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: "linux"
-      serviceAccount: ovs-ovn-upgrade
-      serviceAccountName: ovs-ovn-upgrade
+      serviceAccount: kube-ovn-pre-delete-hook
+      serviceAccountName: kube-ovn-pre-delete-hook
       containers:
-        - name: ovs-ovn-upgrade
+        - name: remove-subnet-finalizer
           image: "{{ .Values.global.registry.address}}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}"
           env:
             - name: POD_NAMESPACE
@@ -130,7 +113,7 @@ spec:
           command:
             - sh
             - -c
-            - /kube-ovn/upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/upgrade-ovs.log
+            - /kube-ovn/remove-subnet-finalizer.sh 2>&1 | tee -a /var/log/kube-ovn/remove-subnet-finalizer.log
           volumeMounts:
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
@@ -138,5 +121,3 @@ spec:
         - name: kube-ovn-log
           hostPath:
             path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
-{{ end }}
-{{ end }}

--- a/dist/images/remove-subnet-finalizer.sh
+++ b/dist/images/remove-subnet-finalizer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+for subnet in $(kubectl get subnet -o name); do
+  kubectl patch "$subnet" --type='json' -p '[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+done


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
#3169 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 712199e</samp>

This pull request improves the GitHub Actions workflow, the OVS and OVN upgrade process, and the Kube-OVN chart uninstallation. It renames some jobs and containers, adds a cleanup step, a pre-delete hook, and a new make target. It affects the files `.github/workflows/build-x86-image.yaml`, `charts/templates/upgrade-ovs-ovn.yaml`, `charts/templates/pre-delete-hook.yaml`, and `Makefile`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 712199e</samp>

> _We unleash the hook of doom_
> _To purge the finalizers from the subnets_
> _We test the chart with helm and make_
> _To ensure the Kube-OVN image is flawless_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 712199e</samp>

* Rename the chart installation test job to `chart-test` for consistency and clarity ([link](https://github.com/kubeovn/kube-ovn/pull/3213/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1083-R1083))
* Add a step to uninstall the Kube-OVN chart after testing it to clean up resources ([link](https://github.com/kubeovn/kube-ovn/pull/3213/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L1116-R1117), [link](https://github.com/kubeovn/kube-ovn/pull/3213/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R450-R453))
* Add a pre-delete hook to the Kube-OVN chart to remove finalizers from subnets before deleting the chart, to avoid subnets being stuck in terminating state ([link](https://github.com/kubeovn/kube-ovn/pull/3213/files?diff=unified&w=0#diff-3660f5e18520e16eed1ed6949abbd6a1271bf72ab044cbc1bc39ef0ea9a41aafR1-R123))
* Rename the post-upgrade job and container to `{{ .Chart.Name }}-post-upgrade-hook` and `ovs-ovn-upgrade` respectively, to be more descriptive and avoid conflicts ([link](https://github.com/kubeovn/kube-ovn/pull/3213/files?diff=unified&w=0#diff-2d71dbf3a35f845caf7551a88cd87cb92364ec452e6c7d2e760b3311d22650d3L73-R73), [link](https://github.com/kubeovn/kube-ovn/pull/3213/files?diff=unified&w=0#diff-2d71dbf3a35f845caf7551a88cd87cb92364ec452e6c7d2e760b3311d22650d3L123-R123))