### PR TITLE
update policy route nexthops para

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2246,7 +2246,7 @@ func (c *Controller) addCommonRoutesForSubnet(subnet *kubeovnv1.Subnet) error {
 			action      = kubeovnv1.PolicyRouteActionAllow
 			externalIDs = map[string]string{"vendor": util.CniTypeName, "subnet": subnet.Name}
 		)
-		klog.Infof("add policy route for router: %s, match %s, action %s, externalID %v", subnet.Spec.Vpc, match, action, externalIDs)
+		klog.Infof("add common policy route for router: %s, match %s, action %s, externalID %v", subnet.Spec.Vpc, match, action, externalIDs)
 		if err := c.addPolicyRouteToVpc(
 			subnet.Spec.Vpc,
 			&kubeovnv1.PolicyRoute{

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -582,7 +582,7 @@ func (c *Controller) addPolicyRouteToVpc(name string, policy *kubeovnv1.PolicyRo
 	)
 
 	if policy.NextHopIP != "" {
-		nextHops = []string{policy.NextHopIP}
+		nextHops = strings.Split(policy.NextHopIP, ",")
 	}
 
 	if err = c.OVNNbClient.AddLogicalRouterPolicy(name, policy.Priority, policy.Match, string(policy.Action), nextHops, externalIDs); err != nil {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

This bug is introduced by PR #3194 

### Which issue(s) this PR fixes:
Fixes #

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e17761</samp>

Refactor policy route logic to support multiple next hops. Update `policy.NextHopIP` field and log message in `subnet.go` and `vpc.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4e17761</samp>

> _`policy.NextHopIP`_
> _now takes many addresses_
> _refactor for spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4e17761</samp>

*  Refactor policy route to support multiple next hops ([link](https://github.com/kubeovn/kube-ovn/pull/3224/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2249-R2249), [link](https://github.com/kubeovn/kube-ovn/pull/3224/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL585-R585))
  - Change the log message in `subnet.go` to indicate the policy route is common ([link](https://github.com/kubeovn/kube-ovn/pull/3224/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2249-R2249))
  - Change the policy.NextHopIP field in `vpc.go` to accept a comma-separated list of IPs ([link](https://github.com/kubeovn/kube-ovn/pull/3224/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL585-R585))