### PR TITLE
fix: for existing nic, no need to set the port type to internal

### DIFF
--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -49,29 +49,64 @@ func pingGateway(gw, src string, verbose bool, maxRetry int) (count int, err err
 }
 
 func configureGlobalMirror(portName string, mtu int) error {
-	raw, err := ovs.Exec(ovs.MayExist, "add-port", "br-int", portName, "--",
-		"set", "interface", portName, "type=internal", "--",
-		"clear", "bridge", "br-int", "mirrors", "--",
-		"--id=@mirror0", "get", "port", portName, "--",
-		"--id=@m", "create", "mirror", fmt.Sprintf("name=%s", util.MirrorDefaultName), "select_all=true", "output_port=@mirror0", "--",
-		"add", "bridge", "br-int", "mirrors", "@m")
+	nicExist, err := linkExists(portName)
 	if err != nil {
-		klog.Errorf("failed to configure mirror nic %s %q", portName, raw)
-		return fmt.Errorf(raw)
+		return err
 	}
+
+	if !nicExist {
+		raw, err := ovs.Exec(ovs.MayExist, "add-port", "br-int", portName, "--",
+			"set", "interface", portName, "type=internal", "--",
+			"clear", "bridge", "br-int", "mirrors", "--",
+			"--id=@mirror0", "get", "port", portName, "--",
+			"--id=@m", "create", "mirror", fmt.Sprintf("name=%s", util.MirrorDefaultName), "select_all=true", "output_port=@mirror0", "--",
+			"add", "bridge", "br-int", "mirrors", "@m")
+		if err != nil {
+			klog.Errorf("failed to configure mirror nic %s %q", portName, raw)
+			return fmt.Errorf(raw)
+		}
+	} else {
+		raw, err := ovs.Exec(ovs.MayExist, "add-port", "br-int", portName, "--",
+			"clear", "bridge", "br-int", "mirrors", "--",
+			"--id=@mirror0", "get", "port", portName, "--",
+			"--id=@m", "create", "mirror", fmt.Sprintf("name=%s", util.MirrorDefaultName), "select_all=true", "output_port=@mirror0", "--",
+			"add", "bridge", "br-int", "mirrors", "@m")
+		if err != nil {
+			klog.Errorf("failed to configure mirror nic %s %q", portName, raw)
+			return fmt.Errorf(raw)
+		}
+	}
+
 	return configureMirrorLink(portName, mtu)
 }
 
 func configureEmptyMirror(portName string, mtu int) error {
-	raw, err := ovs.Exec(ovs.MayExist, "add-port", "br-int", portName, "--",
-		"set", "interface", portName, "type=internal", "--",
-		"clear", "bridge", "br-int", "mirrors", "--",
-		"--id=@mirror0", "get", "port", portName, "--",
-		"--id=@m", "create", "mirror", fmt.Sprintf("name=%s", util.MirrorDefaultName), "output_port=@mirror0", "--",
-		"add", "bridge", "br-int", "mirrors", "@m")
+	nicExist, err := linkExists(portName)
 	if err != nil {
-		klog.Errorf("failed to configure mirror nic %s %q", portName, raw)
-		return fmt.Errorf(raw)
+		return err
+	}
+
+	if !nicExist {
+		raw, err := ovs.Exec(ovs.MayExist, "add-port", "br-int", portName, "--",
+			"set", "interface", portName, "type=internal", "--",
+			"clear", "bridge", "br-int", "mirrors", "--",
+			"--id=@mirror0", "get", "port", portName, "--",
+			"--id=@m", "create", "mirror", fmt.Sprintf("name=%s", util.MirrorDefaultName), "output_port=@mirror0", "--",
+			"add", "bridge", "br-int", "mirrors", "@m")
+		if err != nil {
+			klog.Errorf("failed to configure mirror nic %s %q", portName, raw)
+			return fmt.Errorf(raw)
+		}
+	} else {
+		raw, err := ovs.Exec(ovs.MayExist, "add-port", "br-int", portName, "--",
+			"clear", "bridge", "br-int", "mirrors", "--",
+			"--id=@mirror0", "get", "port", portName, "--",
+			"--id=@m", "create", "mirror", fmt.Sprintf("name=%s", util.MirrorDefaultName), "output_port=@mirror0", "--",
+			"add", "bridge", "br-int", "mirrors", "@m")
+		if err != nil {
+			klog.Errorf("failed to configure mirror nic %s %q", portName, raw)
+			return fmt.Errorf(raw)
+		}
 	}
 	return configureMirrorLink(portName, mtu)
 }

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1477,3 +1477,14 @@ func turnOffNicTxChecksum(nicName string) (err error) {
 func getShortSharedDir(uid types.UID, volumeName string) string {
 	return filepath.Join(util.DefaultHostVhostuserBaseDir, string(uid), volumeName)
 }
+
+func linkExists(name string) (bool, error) {
+	_, err := netlink.LinkByName(name)
+	if err == nil {
+		return true, nil
+	} else if _, ok := err.(netlink.LinkNotFoundError); ok {
+		return false, nil
+	} else {
+		return false, err
+	}
+}

--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -339,3 +339,11 @@ func getShortSharedDir(uid types.UID, volumeName string) string {
 	// DPDK is not supported on Windows
 	return ""
 }
+
+func linkExists(name string) (bool, error) {
+	_, err := util.GetNetAdapter(name, true)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #3225 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 52ed53a</samp>

Improve mirror port creation and configuration for OVS bridge. Use netlink package to check mirror interface existence and reduce OVS commands. Affect file `pkg/daemon/ovs.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 52ed53a</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A better way to make the mirror port, and wisely_
> _Used the netlink package, `nl`, to scan the bridge_
> _And spare the OVS commands from needless toil and drudge._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 52ed53a</samp>

*  Import netlink package to check for mirror network interface existence ([link](https://github.com/kubeovn/kube-ovn/pull/3243/files?diff=unified&w=0#diff-067d64bdcf68917f106b1f905d4608e8927a7ea0e9388b9e225c147566ece237R9))
*  Modify `configureGlobalMirror` and `configureEmptyMirror` functions to skip `add-port` command if mirror interface already exists ([link](https://github.com/kubeovn/kube-ovn/pull/3243/files?diff=unified&w=0#diff-067d64bdcf68917f106b1f905d4608e8927a7ea0e9388b9e225c147566ece237L52-R114))