### PR TITLE
adjust vip prints as ip

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1420,18 +1420,15 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
-      - name: NS
-        type: string
-        jsonPath: .spec.namespace
       - name: V4IP
         type: string
         jsonPath: .status.v4ip
-      - name: Mac
-        type: string
-        jsonPath: .status.mac
       - name: V6IP
         type: string
         jsonPath: .status.v6ip
+      - name: Mac
+        type: string
+        jsonPath: .status.mac
       - name: PMac
         type: string
         jsonPath: .spec.parentMac

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1958,18 +1958,15 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
-      - name: NS
-        type: string
-        jsonPath: .spec.namespace
       - name: V4IP
         type: string
         jsonPath: .status.v4ip
-      - name: Mac
-        type: string
-        jsonPath: .status.mac
       - name: V6IP
         type: string
         jsonPath: .status.v6ip
+      - name: Mac
+        type: string
+        jsonPath: .status.mac
       - name: PMac
         type: string
         jsonPath: .spec.parentMac

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -1731,18 +1731,15 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
-      - name: NS
-        type: string
-        jsonPath: .spec.namespace
       - name: V4IP
         type: string
         jsonPath: .status.v4ip
-      - name: Mac
-        type: string
-        jsonPath: .status.mac
       - name: V6IP
         type: string
         jsonPath: .status.v6ip
+      - name: Mac
+        type: string
+        jsonPath: .status.mac
       - name: PMac
         type: string
         jsonPath: .spec.parentMac


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR


### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea954e3</samp>

Removed `NS` column from `Vlan` CRD in `yamls/crd.yaml` to simplify `kubectl get vlan` output and avoid confusion with `NAMESPACE` column.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea954e3</samp>

> _`NS` column gone_
> _`kubectl get vlan` clear_
> _Autumn leaves confusion_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea954e3</samp>

* Remove the `NS` column from the `Vlan` CRD to simplify the output of `kubectl get vlan` and avoid confusion with the `NAMESPACE` column ([link](https://github.com/kubeovn/kube-ovn/pull/3248/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5L1734-R1742))