### PR TITLE
add init container in vpc-nat-gateway statefulset for init

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -802,7 +802,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 							Name:            "vpc-nat-gw-init",
 							Image:           vpcNatImage,
 							Command:         []string{"bash"},
-							Args:            []string{"-c", fmt.Sprintf("/kube-ovn/nat-gateway.sh init %s,%s", c.config.ServiceClusterIPRange, v4SubnetGw)},
+							Args:            []string{"-c", fmt.Sprintf("bash /kube-ovn/nat-gateway.sh init %s,%s", c.config.ServiceClusterIPRange, v4SubnetGw)},
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
 								Privileged:               &privileged,

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -767,7 +767,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 		selectors[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
 	}
 	klog.V(3).Infof("prepare for vpc nat gateway pod, node selector: %v", selectors)
-
+	v4SubnetGw, _, _ := c.GetGwBySubnet(gw.Spec.Subnet)
 	newSts = &v1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
@@ -790,6 +790,19 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 							Image:           vpcNatImage,
 							Command:         []string{"bash"},
 							Args:            []string{"-c", "while true; do sleep 10000; done"},
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							SecurityContext: &corev1.SecurityContext{
+								Privileged:               &privileged,
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:            "vpc-nat-gw-init",
+							Image:           vpcNatImage,
+							Command:         []string{"bash"},
+							Args:            []string{"-c", fmt.Sprintf("/kube-ovn/nat-gateway.sh init %s,%s", c.config.ServiceClusterIPRange, v4SubnetGw)},
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
 								Privileged:               &privileged,


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
Bug fixes
### Which issue(s) this PR fixes:
Fixes #(https://github.com/kubeovn/kube-ovn/issues/3241)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 523e033</samp>

Add an init container to `vpc_nat_gateway.go` to set up NAT network settings and subnet gateway IP.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 523e033</samp>

> _Sing, O Muse, of the cunning pull request_
> _That added an init container to the `vpc nat gateway` pod_
> _And taught it how to shape the network flows_
> _Like Proteus, the old man of the sea, who changes his form at will._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 523e033</samp>

*  Add an init container to the vpc nat gateway pod to set up iptables and routes ([link](https://github.com/kubeovn/kube-ovn/pull/3254/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4R800-R812))
*  Get the subnet gateway IP for the vpc nat gateway ([link](https://github.com/kubeovn/kube-ovn/pull/3254/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4L770-R770))