### PR TITLE
lrp should use chassis name instead of uuid

### DIFF
--- a/pkg/controller/external-gw.go
+++ b/pkg/controller/external-gw.go
@@ -262,7 +262,7 @@ func (c *Controller) getGatewayChassis(config map[string]string) ([]string, erro
 			klog.Errorf("failed to get node %s chassis: %s, %v", node.Name, annoChassisName, err)
 			return chassises, err
 		}
-		chassises = append(chassises, chassis.UUID)
+		chassises = append(chassises, chassis.Name)
 	}
 	if len(chassises) == 0 {
 		klog.Error("no available external gw")

--- a/pkg/ovs/ovn-sb-chassis.go
+++ b/pkg/ovs/ovn-sb-chassis.go
@@ -38,10 +38,10 @@ func (c *OVNSbClient) DeleteChassis(chassisName string) error {
 	}
 	ops, err := c.ovsDbClient.Where(chassis).Delete()
 	if err != nil {
-		return fmt.Errorf("failed to generate delete operations for chassis %s: %v", chassis.UUID, err)
+		return fmt.Errorf("failed to generate delete chassis operations for node %s: %v", chassis.Hostname, err)
 	}
 	if err = c.Transact("chassis-del", ops); err != nil {
-		return fmt.Errorf("failed to delete chassis with with UUID %s: %v", chassis.UUID, err)
+		return fmt.Errorf("failed to delete chassis for node %s: %v", chassis.Hostname, err)
 	}
 	return nil
 }


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes



### Which issue(s) this PR fixes:
https://github.com/kubeovn/kube-ovn/issues/3253

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6912e37</samp>

Fix gateway router chassis name bug and improve chassis deletion error messages. The changes affect the `pkg/controller/external-gw.go` and `pkg/ovs/ovn-sb-chassis.go` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6912e37</samp>

> _`chassis` name used_
> _better for gateway options_
> _autumn bug fixing_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6912e37</samp>

* Fix gateway router options to use chassis name instead of UUID ([link](https://github.com/kubeovn/kube-ovn/pull/3258/files?diff=unified&w=0#diff-49e9f500bbdd1972f437e33413a4e9761aaa80c62cb2b31fe92b28c8b069333fL265-R265))
* Improve error messages for deleting chassis to use hostname instead of UUID ([link](https://github.com/kubeovn/kube-ovn/pull/3258/files?diff=unified&w=0#diff-8ccc718a81ff28931de9313ea780b7d9fbc9227fa3be982bbc659c0a5add8f5bL41-R44))