### PR TITLE
pinger: increase packet send interval

### DIFF
--- a/pkg/pinger/ping.go
+++ b/pkg/pinger/ping.go
@@ -196,7 +196,7 @@ func pingPods(config *Configuration) error {
 					pinger.Timeout = 1 * time.Second
 					pinger.Debug = true
 					pinger.Count = 3
-					pinger.Interval = 1 * time.Millisecond
+					pinger.Interval = 100 * time.Millisecond
 					if err = pinger.Run(); err != nil {
 						klog.Errorf("failed to run pinger for destination %s: %v", podIP, err)
 						pingErr = err
@@ -247,7 +247,7 @@ func pingExternal(config *Configuration) error {
 		pinger.Timeout = 5 * time.Second
 		pinger.Debug = true
 		pinger.Count = 3
-		pinger.Interval = 1 * time.Millisecond
+		pinger.Interval = 100 * time.Millisecond
 		if err = pinger.Run(); err != nil {
 			klog.Errorf("failed to run pinger for destination %s: %v", addr, err)
 			return err


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce3bb43</samp>

Increase ping interval in `ping.go` to reduce network load and improve ping test accuracy. This affects the `pingPods` and `pingExternal` functions that perform connectivity checks for pods and external addresses.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ce3bb43</samp>

> _Sing, O Muse, of the wise and skillful coder_
> _Who changed the `pingInterval` of the network tester_
> _From one swift millisecond to a hundred, slower but surer_
> _Like the cunning Odysseus, who escaped the Cyclops' anger_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce3bb43</samp>

* Increase the ping interval from 1ms to 100ms to avoid network congestion and improve ping test reliability ([link](https://github.com/kubeovn/kube-ovn/pull/3259/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704L199-R199), [link](https://github.com/kubeovn/kube-ovn/pull/3259/files?diff=unified&w=0#diff-ef5e19d2a06e783042497957187c9a7df962e6db67629dfbe8075e6f12c02704L250-R250)) in `ping.go`