### PR TITLE
init all not inited vpc nat gw after k8s cluster restarted

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1160,7 +1160,9 @@ func (c *Controller) initResourceOnce() {
 			util.LogFatalAndExit(err, "failed to sync crd vpc nat gateways")
 		}
 	}
-
+	if err := c.initVpcNatGw(); err != nil {
+		util.LogFatalAndExit(err, "failed to initialize vpc nat gateways")
+	}
 	if c.config.EnableLb {
 		if err := c.initVpcDNSConfig(); err != nil {
 			util.LogFatalAndExit(err, "failed to initialize vpc-dns")


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Bug fixes

fix nat gw pod may not inited all its nats after reboot all the whole k8s cluster
 

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ece016a</samp>

This pull request adds support for VPC NAT gateways, a new feature that enables outbound connectivity for multiple VPCs in the same cluster. It modifies `controller.go` to initialize the VPC NAT gateways and adds a new function `c.initVpcNatGw()` in `vpc_nat_gateway.go` to set up the iptables and routes for the gateways.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ece016a</samp>

> _New feature added_
> _`VPC NAT gateways` for_
> _Outbound traffic flow_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ece016a</samp>

* Initialize VPC NAT gateways by adding a new function and calling it before load balancer feature check ([link](https://github.com/kubeovn/kube-ovn/pull/3261/files?diff=unified&w=0#diff-41b4c692987143b2796e2664174ba6858e7c51329d823c612556ef6cd32185c4R1095-R1123), [link](https://github.com/kubeovn/kube-ovn/pull/3261/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L1163-R1165))