### PR TITLE
e2e: fix docker network with random suffix not deleted

### DIFF
--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 const (
+	dockerExtNetName       = "kube-ovn-ext"
 	dockerExtNet1Name      = "kube-ovn-ext-net1"
 	dockerExtNet2Name      = "kube-ovn-ext-net2"
 	vpcNatGWConfigMapName  = "ovn-vpc-nat-gw-config"
@@ -1038,7 +1039,6 @@ var _ = framework.Describe("[group:qos-policy]", func() {
 	var containerID string
 	var image string
 	var net1NicName string
-	var dockerExtNetName string
 
 	// docker network
 	var dockerExtNetNetwork *dockertypes.NetworkResource
@@ -1061,8 +1061,6 @@ var _ = framework.Describe("[group:qos-policy]", func() {
 
 	ginkgo.BeforeEach(func() {
 		vpcQosParams = newVPCQoSParamsInit()
-
-		dockerExtNetName = "kube-ovn-qos-" + framework.RandomSuffix()
 
 		vpcQosParams.vpc1SubnetName = "qos-vpc1-subnet-" + framework.RandomSuffix()
 		vpcQosParams.vpc2SubnetName = "qos-vpc2-subnet-" + framework.RandomSuffix()


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 991e5f1</samp>

Refactor e2e tests to use a constant external network name. This improves test reliability and cleanup.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 991e5f1</samp>

> _Sing, O Muse, of the valiant code review_
> _That sought to improve the e2e tests_
> _And make them run with fewer errors due_
> _To network conflicts or leaks that vexed._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 991e5f1</samp>

*  Define a constant `dockerExtNetName` with the value `"kube-ovn-ext"` in the package `ovn_eip` to create a docker network for external access in the e2e tests ([link](https://github.com/kubeovn/kube-ovn/pull/3280/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7R34))
* Remove the declaration and assignment of the variable `dockerExtNetName` in the `BeforeEach` block of the `Describe` block for the e2e tests, since the constant `dockerExtNetName` is used instead ([link](https://github.com/kubeovn/kube-ovn/pull/3280/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L1041), [link](https://github.com/kubeovn/kube-ovn/pull/3280/files?diff=unified&w=0#diff-0416268fd62f92e39257f4ad706c4b179fad611280054689adc5b3800ed14ed7L1065-L1066))