### PR TITLE
bgp: support announce policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ kwok-node.yaml
 broker-info.subm
 broker-info.subm.*
 broker-info-internal.subm
+yamls/clab-bgp.yaml
 kube-ovn.tar
 vpc-nat-gateway.tar
 image-amd64.tar

--- a/Makefile
+++ b/Makefile
@@ -847,7 +847,7 @@ kind-clean-ovn-submariner: kind-clean
 .PHONY: kind-clean-bgp
 kind-clean-bgp:
 	$(call docker_rm_container,kube-ovn-bgp)
-	kube_ovn_version=$(RELEASE_TAG) j2 yamls/clab-bgp.yaml.j2 -o yamls/clab-bgp.yaml
+	kube_ovn_version=$(VERSION) j2 yamls/clab-bgp.yaml.j2 -o yamls/clab-bgp.yaml
 	docker run --rm --privileged \
 		--name kube-ovn-bgp \
 		--network host \

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ endif
 
 CONTROL_PLANE_TAINTS = node-role.kubernetes.io/master node-role.kubernetes.io/control-plane
 
+CLAB_IMAGE = ghcr.io/srl-labs/clab:latest
+
 MULTUS_VERSION = v4.0.2
 MULTUS_IMAGE = ghcr.io/k8snetworkplumbingwg/multus-cni:$(MULTUS_VERSION)-thick
 MULTUS_YAML = https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/$(MULTUS_VERSION)/deployments/multus-daemonset-thick.yml
@@ -401,6 +403,19 @@ kind-init-ipv6:
 kind-init-dual:
 	@ip_family=dual $(MAKE) kind-init
 
+.PHONY: kind-init-bgp
+kind-init-bgp: kind-clean-bgp kind-init
+	kube_ovn_version=$(VERSION) j2 yamls/clab-bgp.yaml.j2 -o yamls/clab-bgp.yaml
+	docker run --rm --privileged \
+		--name kube-ovn-bgp \
+		--network host \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /var/run/netns:/var/run/netns \
+		-v /var/lib/docker/containers:/var/lib/docker/containers \
+		--pid=host \
+		-v $(CURDIR)/yamls/clab-bgp.yaml:/clab.yaml \
+		$(CLAB_IMAGE) clab deploy -t /clab.yaml
+
 .PHONY: kind-load-image
 kind-load-image:
 	$(call kind_load_image,kube-ovn,$(REGISTRY)/kube-ovn:$(VERSION))
@@ -767,6 +782,17 @@ kind-install-cilium-chaining: kind-load-image kind-untaint-control-plane
 		ENABLE_LB=false ENABLE_NP=false CNI_CONFIG_PRIORITY=10 bash
 	kubectl describe no
 
+.PHONY: kind-install-bgp
+kind-install-bgp: kind-install
+	kubectl label node --all ovn.kubernetes.io/bgp=true
+	kubectl annotate subnet ovn-default ovn.kubernetes.io/bgp=local
+	sed -e 's#image: .*#image: $(REGISTRY)/kube-ovn:$(VERSION)#' \
+		-e 's/--neighbor-address=.*/--neighbor-address=10.0.1.1/' \
+		-e 's/--neighbor-as=.*/--neighbor-as=65001/' \
+		-e 's/--cluster-as=.*/--cluster-as=65002/' yamls/speaker.yaml | \
+		kubectl apply -f -
+	kubectl -n kube-system rollout status ds kube-ovn-speaker --timeout 60s
+
 .PHONY: kind-install-deepflow
 kind-install-deepflow: kind-install
 	helm repo add deepflow $(DEEPFLOW_CHART_REPO)
@@ -818,6 +844,21 @@ kind-clean-ovn-ic: kind-clean
 kind-clean-ovn-submariner: kind-clean
 	kind delete cluster --name=kube-ovn1
 
+.PHONY: kind-clean-bgp
+kind-clean-bgp:
+	$(call docker_rm_container,kube-ovn-bgp)
+	kube_ovn_version=$(RELEASE_TAG) j2 yamls/clab-bgp.yaml.j2 -o yamls/clab-bgp.yaml
+	docker run --rm --privileged \
+		--name kube-ovn-bgp \
+		--network host \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /var/run/netns:/var/run/netns \
+		-v /var/lib/docker/containers:/var/lib/docker/containers \
+		--pid=host \
+		-v $(CURDIR)/yamls/clab-bgp.yaml:/clab.yaml \
+		$(CLAB_IMAGE) clab destroy -t /clab.yaml
+	@$(MAKE) kind-clean
+
 .PHONY: uninstall
 uninstall:
 	bash dist/images/cleanup.sh
@@ -860,7 +901,7 @@ ipam-bench:
 .PHONY: clean
 clean:
 	$(RM) dist/images/kube-ovn dist/images/kube-ovn-cmd
-	$(RM) yamls/kind.yaml
+	$(RM) yamls/kind.yaml yamls/clab-bgp.yaml
 	$(RM) ovn.yaml kube-ovn.yaml kube-ovn-crd.yaml
 	$(RM) ovn-ic-0.yaml ovn-ic-1.yaml
 	$(RM) kustomization.yaml kwok.yaml kwok-node.yaml

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	api "github.com/osrg/gobgp/v3/api"
@@ -52,6 +53,7 @@ type Configuration struct {
 	PassiveMode                 bool
 	EbgpMultihopTTL             uint8
 
+	NodeName       string
 	KubeConfigFile string
 	KubeClient     kubernetes.Interface
 	KubeOvnClient  clientset.Interface
@@ -75,6 +77,7 @@ func ParseFlags() (*Configuration, error) {
 		argAuthPassword                = pflag.String("auth-password", "", "bgp peer auth password")
 		argHoldTime                    = pflag.Duration("holdtime", DefaultBGPHoldtime, "ovn-speaker goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3s to 65536s. (default 90s)")
 		argPprofPort                   = pflag.Uint32("pprof-port", DefaultPprofPort, "The port to get profiling data, default: 10667")
+		argNodeName                    = pflag.String("node-name", os.Getenv(util.HostnameEnv), "Name of the node on which the speaker is running on.")
 		argKubeConfigFile              = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argPassiveMode                 = pflag.BoolP("passivemode", "", false, "Set BGP Speaker to passive model,do not actively initiate connections to peers ")
 		argEbgpMultihopTTL             = pflag.Uint8("ebgp-multihop", DefaultEbgpMultiHop, "The TTL value of EBGP peer, default: 1")
@@ -126,6 +129,7 @@ func ParseFlags() (*Configuration, error) {
 		AuthPassword:                *argAuthPassword,
 		HoldTime:                    ht,
 		PprofPort:                   *argPprofPort,
+		NodeName:                    strings.ToLower(*argNodeName),
 		KubeConfigFile:              *argKubeConfigFile,
 		GracefulRestart:             *argGracefulRestart,
 		GracefulRestartDeferralTime: *argGracefulRestartDeferralTime,

--- a/yamls/clab-bgp.yaml.j2
+++ b/yamls/clab-bgp.yaml.j2
@@ -1,0 +1,60 @@
+name: bgp
+topology:
+  kinds:
+    linux:
+      image: kubeovn/kube-ovn:{{ kube_ovn_version }}
+      cmd: bash
+
+  nodes:
+    router:
+      kind: linux
+      image: frrouting/frr:v8.4.1
+      labels:
+        app: frr
+      exec:
+      - ip link delete eth0
+      - ip link add br0 type bridge
+      - ip link set net1 master br0
+      - ip link set net2 master br0
+      - ip link set br0 up
+      - ip address add 10.0.1.1/24 dev br0
+      - ip address add 10.0.2.1/24 dev net3
+      - touch /etc/frr/vtysh.conf
+      - sed -i -e 's/bgpd=no/bgpd=yes/g' /etc/frr/daemons
+      - /usr/lib/frr/frrinit.sh start
+      - >-
+         vtysh -c 'conf t'
+         -c 'frr defaults datacenter'
+         -c 'router bgp 65001'
+         -c ' bgp router-id 10.0.1.1'
+         -c ' no bgp ebgp-requires-policy'
+         -c ' neighbor SERVERS peer-group'
+         -c ' neighbor SERVERS remote-as external'
+         -c ' neighbor 10.0.1.2 peer-group SERVERS'
+         -c ' neighbor 10.0.1.3 peer-group SERVERS'
+         -c ' address-family ipv4 unicast'
+         -c '   redistribute connected'
+         -c '  exit-address-family'
+         -c '!'
+    k8s-master:
+      kind: linux
+      network-mode: container:kube-ovn-control-plane
+      exec:
+      - ip address add 10.0.1.2/24 dev net1
+      - ip route add 10.0.0.0/16 via 10.0.1.1
+    k8s-worker:
+      kind: linux
+      network-mode: container:kube-ovn-worker
+      exec:
+      - ip address add 10.0.1.3/24 dev net1
+      - ip route add 10.0.0.0/16 via 10.0.1.1
+    ext:
+      kind: linux
+      exec:
+      - ip address add 10.0.2.2/24 dev net1
+      - ip route replace default via 10.0.2.1
+
+  links:
+  - endpoints: ["router:net1", "k8s-master:net1"]
+  - endpoints: ["router:net2", "k8s-worker:net1"]
+  - endpoints: ["router:net3", "ext:net1"]

--- a/yamls/speaker.yaml
+++ b/yamls/speaker.yaml
@@ -38,6 +38,10 @@ spec:
             - --neighbor-as=65030
             - --cluster-as=65000
           env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: POD_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Features

### Which issue(s) this PR fixes:

Add a new BGP announce policy `local`.

To use this policy, annotate subnet/pod with `ovn.kubernetes.io/bgp=local`.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0286577</samp>

This pull request adds BGP integration testing and configuration for kube-ovn. It introduces new Makefile targets and a network topology template for creating a BGP lab with containerlab. It also adds a node name flag and a BGP policy annotation for the speaker component, which announces node subnet routes to the network. It modifies the `yamls/speaker.yaml` file to pass the node name to the speaker container.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0286577</samp>

> _This pull request is quite a feat_
> _It adds BGP policies to `syncSubnetRoutes`_
> _It uses containerlab to test the integration_
> _And sets the `KUBE_NODE_NAME` for the speaker configuration_
> _It also adds a flag and a field for the node name to complete_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0286577</samp>

*  Define a variable `CLAB_IMAGE` to store the containerlab image name ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R23-R24))
*  Add a new target `kind-init-bgp` to create a network topology with a BGP router and two Kubernetes nodes using containerlab ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R406-R418))
*  Add a new target `kind-install-bgp` to enable BGP peering and route advertisement on the nodes ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R785-R795))
*  Add a new target `kind-clean-bgp` to destroy the network topology and delete the kind cluster and the kube-ovn images ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R847-R861))
*  Modify the `clean` target to also remove the `yamls/clab-bgp.yaml` file ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L863-R904))
*  Add the `strings` package to the import list in `pkg/speaker/config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3R10))
*  Add a new field `NodeName` to the `Configuration` struct in `pkg/speaker/config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3R56))
*  Add a new flag `--node-name` to the `ParseFlags` function in `pkg/speaker/config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3R80))
*  Assign the value of the `--node-name` flag to the `NodeName` field and convert it to lower case in the `ParseFlags` function in `pkg/speaker/config.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3R132))
*  Modify the `syncSubnetRoutes` function in `pkg/speaker/subnet.go` to support different BGP policies specified by the `ovn.kubernetes.io/bgp` annotation on the subnets and pods ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-6a0b10da704c76289c326b1797c4c061f211a3b9a216da5fcab343e48607db44L77-R134))
*  Add a new file `yamls/clab-bgp.yaml.j2`, which is a Jinja2 template for defining the network topology for the BGP test scenario using containerlab ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-685de4eae125744d4922d6278136853fc4497a67259408143b882c4eda8c3055R1-R61))
*  Add a new environment variable `KUBE_NODE_NAME` to the `kube-ovn-speaker` container in the `yamls/speaker.yaml` file ([link](https://github.com/kubeovn/kube-ovn/pull/3282/files?diff=unified&w=0#diff-c965abe55af187f2cbe1f47f4767ab31a320325e28a11f1cf779f32cf342c539R41-R44))