### PR TITLE
bgp: support multiple peer addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ broker-info.subm
 broker-info.subm.*
 broker-info-internal.subm
 yamls/clab-bgp.yaml
+yamls/clab-bgp-ha.yaml
 kube-ovn.tar
 vpc-nat-gateway.tar
 image-amd64.tar

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -40,8 +40,8 @@ type Configuration struct {
 	GrpcPort                    uint32
 	ClusterAs                   uint32
 	RouterID                    string
-	NeighborAddress             string
-	NeighborIPv6Address         string
+	NeighborAddresses           []string
+	NeighborIPv6Addresses       []string
 	NeighborAs                  uint32
 	AuthPassword                string
 	HoldTime                    float64
@@ -71,8 +71,8 @@ func ParseFlags() (*Configuration, error) {
 		argGrpcPort                    = pflag.Uint32("grpc-port", DefaultBGPGrpcPort, "The port for grpc to listen, default:50051")
 		argClusterAs                   = pflag.Uint32("cluster-as", DefaultBGPClusterAs, "The as number of container network, default 65000")
 		argRouterID                    = pflag.String("router-id", "", "The address for the speaker to use as router id, default the node ip")
-		argNeighborAddress             = pflag.String("neighbor-address", "", "The router address the speaker connects to.")
-		argNeighborIPv6Address         = pflag.String("neighbor-ipv6-address", "", "The router address the speaker connects to.")
+		argNeighborAddress             = pflag.String("neighbor-address", "", "Comma separated IPv4 router addresses the speaker connects to.")
+		argNeighborIPv6Address         = pflag.String("neighbor-ipv6-address", "", "Comma separated IPv6 router addresses the speaker connects to.")
 		argNeighborAs                  = pflag.Uint32("neighbor-as", DefaultBGPNeighborAs, "The router as number, default 65001")
 		argAuthPassword                = pflag.String("auth-password", "", "bgp peer auth password")
 		argHoldTime                    = pflag.Duration("holdtime", DefaultBGPHoldtime, "ovn-speaker goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3s to 65536s. (default 90s)")
@@ -107,12 +107,6 @@ func ParseFlags() (*Configuration, error) {
 	if *argRouterID != "" && net.ParseIP(*argRouterID) == nil {
 		return nil, fmt.Errorf("invalid router-id format: %s", *argRouterID)
 	}
-	if *argNeighborAddress != "" && net.ParseIP(*argNeighborAddress).To4() == nil {
-		return nil, fmt.Errorf("invalid neighbor-address format: %s", *argNeighborAddress)
-	}
-	if *argNeighborIPv6Address != "" && net.ParseIP(*argNeighborIPv6Address).To16() == nil {
-		return nil, fmt.Errorf("invalid neighbor-ipv6-address format: %s", *argNeighborIPv6Address)
-	}
 	if *argEbgpMultihopTTL < 1 || *argEbgpMultihopTTL > 255 {
 		return nil, errors.New("the bgp MultihopTtl must be in the range 1 to 255")
 	}
@@ -123,8 +117,6 @@ func ParseFlags() (*Configuration, error) {
 		GrpcPort:                    *argGrpcPort,
 		ClusterAs:                   *argClusterAs,
 		RouterID:                    *argRouterID,
-		NeighborAddress:             *argNeighborAddress,
-		NeighborIPv6Address:         *argNeighborIPv6Address,
 		NeighborAs:                  *argNeighborAs,
 		AuthPassword:                *argAuthPassword,
 		HoldTime:                    ht,
@@ -136,6 +128,23 @@ func ParseFlags() (*Configuration, error) {
 		GracefulRestartTime:         *argDefaultGracefulTime,
 		PassiveMode:                 *argPassiveMode,
 		EbgpMultihopTTL:             *argEbgpMultihopTTL,
+	}
+
+	if *argNeighborAddress != "" {
+		config.NeighborAddresses = strings.Split(*argNeighborAddress, ",")
+		for _, addr := range config.NeighborAddresses {
+			if ip := net.ParseIP(addr); ip == nil || ip.To4() == nil {
+				return nil, fmt.Errorf("invalid neighbor-address format: %s", *argNeighborAddress)
+			}
+		}
+	}
+	if *argNeighborIPv6Address != "" {
+		config.NeighborIPv6Addresses = strings.Split(*argNeighborIPv6Address, ",")
+		for _, addr := range config.NeighborIPv6Addresses {
+			if ip := net.ParseIP(addr); ip == nil || ip.To16() == nil {
+				return nil, fmt.Errorf("invalid neighbor-ipv6-address format: %s", *argNeighborIPv6Address)
+			}
+		}
 	}
 
 	if config.RouterID == "" {
@@ -207,7 +216,6 @@ func (config *Configuration) checkGracefulRestartOptions() error {
 
 func (config *Configuration) initBgpServer() error {
 	maxSize := 256 << 20
-	peersMap := make(map[api.Family_Afi]string)
 	var listenPort int32 = -1
 	grpcOpts := []grpc.ServerOption{grpc.MaxRecvMsgSize(maxSize), grpc.MaxSendMsgSize(maxSize)}
 	s := gobgp.NewBgpServer(
@@ -215,11 +223,9 @@ func (config *Configuration) initBgpServer() error {
 		gobgp.GrpcOption(grpcOpts))
 	go s.Serve()
 
-	if config.NeighborAddress != "" {
-		peersMap[api.Family_AFI_IP] = config.NeighborAddress
-	}
-	if config.NeighborIPv6Address != "" {
-		peersMap[api.Family_AFI_IP6] = config.NeighborIPv6Address
+	peersMap := map[api.Family_Afi][]string{
+		api.Family_AFI_IP:  config.NeighborAddresses,
+		api.Family_AFI_IP6: config.NeighborIPv6Addresses,
 	}
 
 	if config.PassiveMode {
@@ -235,56 +241,57 @@ func (config *Configuration) initBgpServer() error {
 	}); err != nil {
 		return err
 	}
-	for ipFamily, address := range peersMap {
-		peer := &api.Peer{
-			Timers: &api.Timers{Config: &api.TimersConfig{HoldTime: uint64(config.HoldTime)}},
-			Conf: &api.PeerConf{
-				NeighborAddress: address,
-				PeerAsn:         config.NeighborAs,
-			},
-			Transport: &api.Transport{
-				PassiveMode: config.PassiveMode,
-			},
-		}
-		if config.EbgpMultihopTTL != DefaultEbgpMultiHop {
-			peer.EbgpMultihop = &api.EbgpMultihop{
-				Enabled:     true,
-				MultihopTtl: uint32(config.EbgpMultihopTTL),
-			}
-		}
-		if config.AuthPassword != "" {
-			peer.Conf.AuthPassword = config.AuthPassword
-		}
-		if config.GracefulRestart {
-
-			if err := config.checkGracefulRestartOptions(); err != nil {
-				return err
-			}
-			peer.GracefulRestart = &api.GracefulRestart{
-				Enabled:         true,
-				RestartTime:     uint32(config.GracefulRestartTime.Seconds()),
-				DeferralTime:    uint32(config.GracefulRestartDeferralTime.Seconds()),
-				LocalRestarting: true,
-			}
-			peer.AfiSafis = []*api.AfiSafi{
-				{
-					Config: &api.AfiSafiConfig{
-						Family:  &api.Family{Afi: ipFamily, Safi: api.Family_SAFI_UNICAST},
-						Enabled: true,
-					},
-					MpGracefulRestart: &api.MpGracefulRestart{
-						Config: &api.MpGracefulRestartConfig{
-							Enabled: true,
-						},
-					},
+	for ipFamily, addresses := range peersMap {
+		for _, addr := range addresses {
+			peer := &api.Peer{
+				Timers: &api.Timers{Config: &api.TimersConfig{HoldTime: uint64(config.HoldTime)}},
+				Conf: &api.PeerConf{
+					NeighborAddress: addr,
+					PeerAsn:         config.NeighborAs,
+				},
+				Transport: &api.Transport{
+					PassiveMode: config.PassiveMode,
 				},
 			}
-		}
+			if config.EbgpMultihopTTL != DefaultEbgpMultiHop {
+				peer.EbgpMultihop = &api.EbgpMultihop{
+					Enabled:     true,
+					MultihopTtl: uint32(config.EbgpMultihopTTL),
+				}
+			}
+			if config.AuthPassword != "" {
+				peer.Conf.AuthPassword = config.AuthPassword
+			}
+			if config.GracefulRestart {
+				if err := config.checkGracefulRestartOptions(); err != nil {
+					return err
+				}
+				peer.GracefulRestart = &api.GracefulRestart{
+					Enabled:         true,
+					RestartTime:     uint32(config.GracefulRestartTime.Seconds()),
+					DeferralTime:    uint32(config.GracefulRestartDeferralTime.Seconds()),
+					LocalRestarting: true,
+				}
+				peer.AfiSafis = []*api.AfiSafi{
+					{
+						Config: &api.AfiSafiConfig{
+							Family:  &api.Family{Afi: ipFamily, Safi: api.Family_SAFI_UNICAST},
+							Enabled: true,
+						},
+						MpGracefulRestart: &api.MpGracefulRestart{
+							Config: &api.MpGracefulRestartConfig{
+								Enabled: true,
+							},
+						},
+					},
+				}
+			}
 
-		if err := s.AddPeer(context.Background(), &api.AddPeerRequest{
-			Peer: peer,
-		}); err != nil {
-			return err
+			if err := s.AddPeer(context.Background(), &api.AddPeerRequest{
+				Peer: peer,
+			}); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/yamls/clab-bgp-ha.yaml.j2
+++ b/yamls/clab-bgp-ha.yaml.j2
@@ -1,0 +1,98 @@
+name: bgp
+topology:
+  kinds:
+    linux:
+      image: kubeovn/kube-ovn:{{ kube_ovn_version }}
+      cmd: bash
+
+  nodes:
+    switch:
+      kind: linux
+      exec:
+      - ip link add br0 type bridge
+      - ip link set net1 master br0
+      - ip link set net2 master br0
+      - ip link set net3 master br0
+      - ip link set net4 master br0
+      - ip link set net5 master br0
+      - ip link set net6 master br0
+      - ip link set net7 master br0
+      - ip link set br0 up
+    router-1:
+      kind: linux
+      image: frrouting/frr:v8.4.1
+      labels:
+        app: frr
+      exec:
+      - ip link delete eth0
+      - ip address add 10.0.1.1/24 dev net1
+      - ip address add 10.0.2.1/24 dev net2
+      - touch /etc/frr/vtysh.conf
+      - sed -i -e 's/bgpd=no/bgpd=yes/g' /etc/frr/daemons
+      - /usr/lib/frr/frrinit.sh start
+      - >-
+         vtysh -c 'conf t'
+         -c 'frr defaults datacenter'
+         -c 'router bgp 65001'
+         -c ' bgp router-id 10.0.1.1'
+         -c ' no bgp ebgp-requires-policy'
+         -c ' neighbor SERVERS peer-group'
+         -c ' neighbor SERVERS remote-as external'
+         -c ' neighbor 10.0.1.101 peer-group SERVERS'
+         -c ' neighbor 10.0.1.102 peer-group SERVERS'
+         -c ' address-family ipv4 unicast'
+         -c '   redistribute connected'
+         -c '  exit-address-family'
+         -c '!'
+    router-2:
+      kind: linux
+      image: frrouting/frr:v8.4.1
+      labels:
+        app: frr
+      exec:
+      - ip link delete eth0
+      - ip address add 10.0.1.2/24 dev net1
+      - ip address add 10.0.2.2/24 dev net2
+      - touch /etc/frr/vtysh.conf
+      - sed -i -e 's/bgpd=no/bgpd=yes/g' /etc/frr/daemons
+      - /usr/lib/frr/frrinit.sh start
+      - >-
+         vtysh -c 'conf t'
+         -c 'frr defaults datacenter'
+         -c 'router bgp 65001'
+         -c ' bgp router-id 10.0.1.2'
+         -c ' no bgp ebgp-requires-policy'
+         -c ' neighbor SERVERS peer-group'
+         -c ' neighbor SERVERS remote-as external'
+         -c ' neighbor 10.0.1.101 peer-group SERVERS'
+         -c ' neighbor 10.0.1.102 peer-group SERVERS'
+         -c ' address-family ipv4 unicast'
+         -c '   redistribute connected'
+         -c '  exit-address-family'
+         -c '!'
+    k8s-master:
+      kind: linux
+      network-mode: container:kube-ovn-control-plane
+      exec:
+      - ip address add 10.0.1.101/24 dev net1
+      - ip route add 10.0.0.0/16 via 10.0.1.1
+    k8s-worker:
+      kind: linux
+      network-mode: container:kube-ovn-worker
+      exec:
+      - ip address add 10.0.1.102/24 dev net1
+      - ip route add 10.0.0.0/16 via 10.0.1.1
+    ext:
+      kind: linux
+      exec:
+      - ip address add 10.0.2.101/24 dev net1
+      - ip route replace default nexthop via 10.0.2.1 weight 1 nexthop via 10.0.2.2 weight 1
+
+  links:
+  - endpoints: ["switch:net1", "router-1:net1"]
+  - endpoints: ["switch:net2", "router-1:net2"]
+  - endpoints: ["switch:net3", "router-2:net1"]
+  - endpoints: ["switch:net4", "router-2:net2"]
+  - endpoints: ["switch:net5", "k8s-master:net1"]
+  - endpoints: ["switch:net6", "k8s-worker:net1"]
+  - endpoints: ["switch:net7", "ext:net1"]


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Features

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c20e681</samp>

This pull request adds new features and tests for the BGP speaker functionality of kube-ovn. It allows the speaker to support multiple BGP neighbors, local subnets, and node name based routes. It also adds new Makefile targets and template files for containerlab and kind to create network topologies for testing the speaker in different scenarios. It modifies the `pkg/speaker/config.go`, `pkg/speaker/subnet.go`, and `yamls/speaker.yaml` files, and adds the `yamls/clab-bgp-ha.yaml.j2` and `yamls/clab-bgp.yaml.j2` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c20e681</samp>

> _We are the speakers of the BGP_
> _We create the topologies of doom_
> _We parse the flags and advertise the routes_
> _We render the templates with Jinja2_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c20e681</samp>

*  Add new targets to the Makefile to create and destroy network topologies with BGP routers using the containerlab tool, and to install and configure the speaker daemonset on the kind cluster ([link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R23-R24), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R406-R431), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R798-R819), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R871-R898), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R942), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R942), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R942), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R942))
* Add new template files `yamls/clab-bgp.yaml.j2` and `yamls/clab-bgp-ha.yaml.j2` for the containerlab tool to render the network topologies with one and two BGP routers respectively ([link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-8bf72b2b0f67789adfc84248a2dc90679b3d89a6d9209205b0588d3fb54c8e46R1-R98), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-685de4eae125744d4922d6278136853fc4497a67259408143b882c4eda8c3055R1-R60))
* Modify the `Configuration` struct and the `ParseFlags` function in `pkg/speaker/config.go` to support multiple BGP neighbors for each IP family, and to get the node name from the command line argument or the environment variable ([link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3R10), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3L42-R44), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3R56), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3L72-R80), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3L107-L112), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3L123-R124), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3R133-R149))
* Modify the `initBgpServer` function in `pkg/speaker/config.go` to create a `Peer` object and call the `AddPeer` method of the BGP server for each address in each IP family ([link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3L206), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3L214-R229), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-542b29142a5f3291a94956f5093d0c45cc98cc91ac7657421bd42bf6ea2149e3L234-R294))
* Modify the `syncSubnetRoutes` function in `pkg/speaker/subnet.go` to handle different values of the `ovn.kubernetes.io/bgp` annotation on the subnets and the pods, and to filter the routes based on the node name of the pod and the speaker ([link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-6a0b10da704c76289c326b1797c4c061f211a3b9a216da5fcab343e48607db44L77-R134))
* Modify the `syncSubnetRoutes` function in `pkg/speaker/subnet.go` to replace the conditions of checking the `NeighborAddress` and `NeighborIPv6Address` fields with the length of the `NeighborAddresses` and `NeighborIPv6Addresses` slices ([link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-6a0b10da704c76289c326b1797c4c061f211a3b9a216da5fcab343e48607db44L113-R153), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-6a0b10da704c76289c326b1797c4c061f211a3b9a216da5fcab343e48607db44L140-R180))
* Modify the `addRoute`, `getNlriAndAttrs`, and `delRoute` functions in `pkg/speaker/subnet.go` to support different path attributes for different neighbors, and to call the `AddPath` and `DeletePath` methods of the BGP server with each slice of path attributes ([link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-6a0b10da704c76289c326b1797c4c061f211a3b9a216da5fcab343e48607db44L219-R277), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-6a0b10da704c76289c326b1797c4c061f211a3b9a216da5fcab343e48607db44L247-R299), [link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-6a0b10da704c76289c326b1797c4c061f211a3b9a216da5fcab343e48607db44L267-R324))
* Add a new environment variable `KUBE_NODE_NAME` to the speaker container in the `yamls/speaker.yaml` file, which passes the node name to the speaker process as the `node-name` flag ([link](https://github.com/kubeovn/kube-ovn/pull/3283/files?diff=unified&w=0#diff-c965abe55af187f2cbe1f47f4767ab31a320325e28a11f1cf779f32cf342c539R41-R44))