### PR TITLE
webhook: use dedicated port for health probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ KUBEVIRT_TEST_YAML = https://kubevirt.io/labs/manifests/vm.yaml
 CILIUM_VERSION = 1.14.1
 CILIUM_IMAGE_REPO = quay.io/cilium/cilium
 
-CERT_MANAGER_VERSION = v1.12.3
+CERT_MANAGER_VERSION = v1.12.5
 CERT_MANAGER_CONTROLLER = quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_CAINJECTOR = quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_WEBHOOK = quay.io/jetstack/cert-manager-webhook:$(CERT_MANAGER_VERSION)
@@ -769,7 +769,7 @@ kind-install-webhook: kind-install
 	kubectl rollout status deployment/cert-manager-cainjector -n cert-manager --timeout 120s
 	kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout 120s
 
-	kubectl apply -f yamls/webhook.yaml
+	sed 's#image: .*#image: $(REGISTRY)/kube-ovn:$(VERSION)#' yamls/webhook.yaml | kubectl apply -f -
 	kubectl rollout status deployment/kube-ovn-webhook -n kube-system --timeout 120s
 
 .PHONY: kind-install-cilium-chaining

--- a/cmd/webhook/server.go
+++ b/cmd/webhook/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/spf13/pflag"
 	appsv1 "k8s.io/api/apps/v1"
@@ -10,6 +11,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -18,6 +20,8 @@ import (
 	ovnwebhook "github.com/kubeovn/kube-ovn/pkg/webhook"
 	"github.com/kubeovn/kube-ovn/versions"
 )
+
+const healthProbePort = 8080
 
 const hookServerCertDir = "/tmp/k8s-webhook-server/serving-certs"
 
@@ -73,6 +77,7 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
+		HealthProbeBindAddress: util.JoinHostPort(os.Getenv("POD_IP"), healthProbePort),
 	})
 	if err != nil {
 		panic(err)
@@ -88,6 +93,13 @@ func main() {
 	hookServer.Register("/validating", &ctrlwebhook.Admission{Handler: validatingHook})
 
 	if err := mgr.Add(hookServer); err != nil {
+		panic(err)
+	}
+
+	if err = mgr.AddHealthzCheck("liveness probe", healthz.Ping); err != nil {
+		panic(err)
+	}
+	if err = mgr.AddReadyzCheck("readiness probe", healthz.Ping); err != nil {
 		panic(err)
 	}
 

--- a/cmd/webhook/server.go
+++ b/cmd/webhook/server.go
@@ -21,8 +21,6 @@ import (
 	"github.com/kubeovn/kube-ovn/versions"
 )
 
-const healthProbePort = 8080
-
 const hookServerCertDir = "/tmp/k8s-webhook-server/serving-certs"
 
 var scheme = runtime.NewScheme()
@@ -43,6 +41,7 @@ func main() {
 	klog.Infof(versions.String())
 
 	port := pflag.Int("port", 8443, "The port webhook listen on.")
+	healthProbePort := pflag.Int32("health-probe-port", 8080, "The port health probes listen on.")
 
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -77,7 +76,7 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
-		HealthProbeBindAddress: util.JoinHostPort(os.Getenv("POD_IP"), healthProbePort),
+		HealthProbeBindAddress: util.JoinHostPort(os.Getenv("POD_IP"), *healthProbePort),
 	})
 	if err != nil {
 		panic(err)

--- a/yamls/webhook.yaml
+++ b/yamls/webhook.yaml
@@ -39,6 +39,7 @@ spec:
             - /kube-ovn/kube-ovn-webhook
           args:
             - --port=8443
+            - --health-probe-port=8080
             - --v=3
           env:
             - name: POD_IP

--- a/yamls/webhook.yaml
+++ b/yamls/webhook.yaml
@@ -40,6 +40,12 @@ spec:
           args:
             - --port=8443
             - --v=3
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
@@ -48,12 +54,14 @@ spec:
           - containerPort: 8443
             name: https
             protocol: TCP
+          - containerPort: 8080
+            name: health-probe
+            protocol: TCP
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /validating
-              port: 8443
-              scheme: HTTPS
+              path: /healthz
+              port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
@@ -61,9 +69,8 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /validating
-              port: 8443
-              scheme: HTTPS
+              path: /readyz
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
             successThreshold: 1


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:

```txt
E1008 05:38:22.824728       1 http.go:72] admission "msg"="unable to process a request with unknown content type" "error"="contentType=, expected application/json"
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bdc3fe0</samp>

This pull request adds health and readiness probes to the webhook service of kube-ovn using the `healthz` package and environment variables. It also updates the cert-manager dependency and makes the webhook image configurable in the `Makefile`. The `yamls/webhook.yaml` file is modified accordingly to reflect these changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bdc3fe0</samp>

> _Webhook service grows_
> _`healthz` probes and `cert-manager`_
> _Autumn of updates_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bdc3fe0</samp>

*  Add health and readiness probes for the webhook service ([link](https://github.com/kubeovn/kube-ovn/pull/3285/files?diff=unified&w=0#diff-e94cc84ea7a2c61069e225796196c98f4c3d7a5d6bb20a6f20daf6020b409f84R5), [link](https://github.com/kubeovn/kube-ovn/pull/3285/files?diff=unified&w=0#diff-e94cc84ea7a2c61069e225796196c98f4c3d7a5d6bb20a6f20daf6020b409f84R14), [link](https://github.com/kubeovn/kube-ovn/pull/3285/files?diff=unified&w=0#diff-e94cc84ea7a2c61069e225796196c98f4c3d7a5d6bb20a6f20daf6020b409f84R24), [link](https://github.com/kubeovn/kube-ovn/pull/3285/files?diff=unified&w=0#diff-e94cc84ea7a2c61069e225796196c98f4c3d7a5d6bb20a6f20daf6020b409f84R79), [link](https://github.com/kubeovn/kube-ovn/pull/3285/files?diff=unified&w=0#diff-e94cc84ea7a2c61069e225796196c98f4c3d7a5d6bb20a6f20daf6020b409f84R98-R104), [link](https://github.com/kubeovn/kube-ovn/pull/3285/files?diff=unified&w=0#diff-2c10dff1669aa8f867680120ebc5bd2003597b732f651d3942efbe16035401fbR43-R48), [link](https://github.com/kubeovn/kube-ovn/pull/3285/files?diff=unified&w=0#diff-2c10dff1669aa8f867680120ebc5bd2003597b732f651d3942efbe16035401fbL51-R64), [link](https://github.com/kubeovn/kube-ovn/pull/3285/files?diff=unified&w=0#diff-2c10dff1669aa8f867680120ebc5bd2003597b732f651d3942efbe16035401fbL64-R73))