### PR TITLE
support custom vpc dns its deployment replicas

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -39,6 +39,10 @@ spec:
                   type: string
                 subnet:
                   type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 3
             status:
               type: object
               properties:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -264,6 +264,10 @@ spec:
                   type: string
                 subnet:
                   type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 3
             status:
               type: object
               properties:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -853,8 +853,9 @@ type VpcDns struct {
 }
 
 type VpcDNSSpec struct {
-	Vpc    string `json:"vpc"`
-	Subnet string `json:"subnet"`
+	Replicas int32  `json:"replicas"`
+	Vpc      string `json:"vpc"`
+	Subnet   string `json:"subnet"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/vpc_dns.go
+++ b/pkg/controller/vpc_dns.go
@@ -193,12 +193,6 @@ func (c *Controller) handleAddOrUpdateVPCDNS(key string) error {
 		return err
 	}
 
-	if err := c.checkOvnDefaultSpecProvider(); err != nil {
-		err := fmt.Errorf("failed to check %s spec provider, %v", util.DefaultSubnet, err)
-		klog.Error(err)
-		return err
-	}
-
 	if err := c.checkVpcDNSDuplicated(vpcDNS); err != nil {
 		err = fmt.Errorf("failed to deploy %s, %v", vpcDNS.Name, err)
 		klog.Error(err)
@@ -490,20 +484,6 @@ func (c *Controller) checkOvnNad() error {
 	if err != nil {
 		klog.Error(err)
 		return err
-	}
-
-	return nil
-}
-
-func (c *Controller) checkOvnDefaultSpecProvider() error {
-	cachedSubnet, err := c.subnetsLister.Get(util.DefaultSubnet)
-	if err != nil {
-		klog.Error(err)
-		return fmt.Errorf("failed to get default subnet %v", err)
-	}
-
-	if cachedSubnet.Spec.Provider != nadProvider {
-		return fmt.Errorf("the %s provider does not exist", nadProvider)
 	}
 
 	return nil

--- a/pkg/controller/vpc_dns.go
+++ b/pkg/controller/vpc_dns.go
@@ -277,6 +277,10 @@ func (c *Controller) createOrUpdateVpcDNSDep(vpcDNS *kubeovnv1.VpcDns) error {
 		return err
 	}
 
+	if vpcDNS.Spec.Replicas != 0 {
+		newDp.Spec.Replicas = &vpcDNS.Spec.Replicas
+	}
+
 	if needToCreateDp {
 		_, err := c.config.KubeClient.AppsV1().Deployments(c.config.PodNamespace).
 			Create(context.Background(), newDp, metav1.CreateOptions{})

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -39,6 +39,10 @@ spec:
                   type: string
                 subnet:
                   type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 3
             status:
               type: object
               properties:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
- Bug fixes

support run only one vpc-dns pod  in all-in-one env

NAD maps to ovn-default, but the ovn-default's spec provider is no need to change as ovn-nad.default.ovn



### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 344473f</samp>

Add `replicas` field to `VpcDNSSpec` to support VpcDns scaling and high availability. Update CRD schemas, Go types, and controller logic to handle the new field.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 344473f</samp>

> _`VpcDns` can scale_
> _`replicas` field is added_
> _autumn of changes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 344473f</samp>

*  Add support for VpcDns scaling and high availability by introducing a new field `replicas` in the `VpcDNSSpec` schema ([link](https://github.com/kubeovn/kube-ovn/pull/3286/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R42-R45), [link](https://github.com/kubeovn/kube-ovn/pull/3286/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R42-R45))
*  Update the `VpcDNSSpec` type in the Go code to match the CRD schema and add the `json:"replicas"` tag ([link](https://github.com/kubeovn/kube-ovn/pull/3286/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aL856-R858))
*  Modify the `createOrUpdateVpcDNSDep` function in the VpcDns controller to set the `Replicas` field of the `DeploymentSpec` according to the user's specification ([link](https://github.com/kubeovn/kube-ovn/pull/3286/files?diff=unified&w=0#diff-58c0cc00f6a53ef4da72411453c2eac7a8bfdc574600e827bc8837ae93ddb747R280-R283))