### PR TITLE
add concurrency limiter to ovs-vsctl

### DIFF
--- a/charts/templates/ovncni-ds.yaml
+++ b/charts/templates/ovncni-ds.yaml
@@ -79,6 +79,7 @@ spec:
           - --enable-metrics={{- .Values.networking.ENABLE_METRICS }}
           - --kubelet-dir={{ .Values.kubelet_conf.KUBELET_DIR }}
           - --enable-tproxy={{ .Values.func.ENABLE_TPROXY }}
+          - --ovs-vsctl-concurrency={{ .Values.performance.OVS_VSCTL_CONCURRENCY }}
         securityContext:
           runAsUser: 0
           privileged: true

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -97,6 +97,7 @@ performance:
   RPMS: "openvswitch-kmod"
   GC_INTERVAL: 360
   INSPECT_INTERVAL: 20
+  OVS_VSCTL_CONCURRENCY: 100
 
 debug:
   ENABLE_MIRROR: false

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -20,6 +20,7 @@ import (
 
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	"github.com/kubeovn/kube-ovn/pkg/daemon"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/versions"
 )
@@ -36,6 +37,8 @@ func CmdMain() {
 	if err := initForOS(); err != nil {
 		util.LogFatalAndExit(err, "failed to do the OS initialization")
 	}
+
+	ovs.UpdateOVSVsctlLimiter(config.OVSVsctlConcurrency)
 
 	nicBridgeMappings, err := daemon.InitOVSBridges()
 	if err != nil {

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -33,6 +33,7 @@ IFACE=${IFACE:-}
 DPDK_TUNNEL_IFACE=${DPDK_TUNNEL_IFACE:-br-phy}
 ENABLE_BIND_LOCAL_IP=${ENABLE_BIND_LOCAL_IP:-true}
 ENABLE_TPROXY=${ENABLE_TPROXY:-false}
+OVS_VSCTL_CONCURRENCY=${OVS_VSCTL_CONCURRENCY:-100}
 
 # debug
 DEBUG_WRAPPER=${DEBUG_WRAPPER:-}
@@ -4065,6 +4066,7 @@ spec:
           - --log_file_max_size=0
           - --kubelet-dir=$KUBELET_DIR
           - --enable-tproxy=$ENABLE_TPROXY
+          - --ovs-vsctl-concurrency=$OVS_VSCTL_CONCURRENCY
         securityContext:
           runAsUser: 0
           privileged: true

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -64,6 +64,7 @@ type Configuration struct {
 	TCPConnCheckPort          int
 	UDPConnCheckPort          int
 	EnableTProxy              bool
+	OVSVsctlConcurrency       int32
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -102,6 +103,7 @@ func ParseFlags() *Configuration {
 		argTCPConnectivityCheckPort  = pflag.Int("tcp-conn-check-port", 8100, "TCP connectivity Check Port")
 		argUDPConnectivityCheckPort  = pflag.Int("udp-conn-check-port", 8101, "UDP connectivity Check Port")
 		argEnableTProxy              = pflag.Bool("enable-tproxy", false, "enable tproxy for vpc pod liveness or readiness probe")
+		argOVSVsctlConcurrency       = pflag.Int32("ovs-vsctl-concurrency", 100, "concurrency limit of ovs-vsctl")
 	)
 
 	// mute info log for ipset lib
@@ -157,6 +159,7 @@ func ParseFlags() *Configuration {
 		TCPConnCheckPort:          *argTCPConnectivityCheckPort,
 		UDPConnCheckPort:          *argUDPConnectivityCheckPort,
 		EnableTProxy:              *argEnableTProxy,
+		OVSVsctlConcurrency:       *argOVSVsctlConcurrency,
 	}
 	return config
 }

--- a/pkg/ovs/ovs-vsctl.go
+++ b/pkg/ovs/ovs-vsctl.go
@@ -1,6 +1,7 @@
 package ovs
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -13,25 +14,57 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
+var limiter *Limiter
+
+func init() {
+	limiter = new(Limiter)
+}
+
+func UpdateOVSVsctlLimiter(c int32) {
+	if c > 0 {
+		limiter.Update(c)
+		klog.V(4).Infof("update ovs-vsctl concurrency limit to %d", limiter.Limit())
+	}
+}
+
 // Glory belongs to openvswitch/ovn-kubernetes
 // https://github.com/openvswitch/ovn-kubernetes/blob/master/go-controller/pkg/util/ovs.go
 
 var podNetNsRegexp = regexp.MustCompile(`pod_netns="([^"]+)"`)
 
 func Exec(args ...string) (string, error) {
-	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var (
+		start        time.Time
+		elapsed      float64
+		output       []byte
+		method, code string
+		err          error
+	)
+
+	if err = limiter.Wait(ctx); err != nil {
+		klog.V(4).Infof("command %s %s waiting for execution timeout by concurrency limit of %d", OvsVsCtl, strings.Join(args, " "), limiter.Limit())
+		return "", err
+	}
+	defer limiter.Done()
+	klog.V(4).Infof("command %s %s waiting for execution concurrency %d/%d", OvsVsCtl, strings.Join(args, " "), limiter.Current(), limiter.Limit())
+
+	start = time.Now()
 	args = append([]string{"--timeout=30"}, args...)
-	output, err := exec.Command(OvsVsCtl, args...).CombinedOutput()
-	elapsed := float64((time.Since(start)) / time.Millisecond)
+	output, err = exec.Command(OvsVsCtl, args...).CombinedOutput()
+	elapsed = float64((time.Since(start)) / time.Millisecond)
 	klog.V(4).Infof("command %s %s in %vms", OvsVsCtl, strings.Join(args, " "), elapsed)
-	method := ""
+
 	for _, arg := range args {
 		if !strings.HasPrefix(arg, "--") {
 			method = arg
 			break
 		}
 	}
-	code := "0"
+
+	code = "0"
 	defer func() {
 		ovsClientRequestLatency.WithLabelValues("ovsdb", method, code).Observe(elapsed)
 	}()

--- a/pkg/ovs/ovs-vsctl.go
+++ b/pkg/ovs/ovs-vsctl.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func UpdateOVSVsctlLimiter(c int32) {
-	if c > 0 {
+	if c >= 0 {
 		limiter.Update(c)
 		klog.V(4).Infof("update ovs-vsctl concurrency limit to %d", limiter.Limit())
 	}

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -201,6 +201,7 @@ spec:
             - --log_file=/var/log/kube-ovn/kube-ovn-cni.log
             - --log_file_max_size=0
             - --enable-tproxy=false
+            - --ovs-vsctl-concurrency=100
           securityContext:
             runAsUser: 0
             privileged: true

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -201,6 +201,7 @@ spec:
             - --log_file=/var/log/kube-ovn/kube-ovn-cni.log
             - --log_file_max_size=0
             - --enable-tproxy=false
+            - --ovs-vsctl-concurrency=100
           securityContext:
             runAsUser: 0
             privileged: true


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features

Features
add rate limiter to limit the number of concurrent executions of the ovs-vsctl command

Which issue(s) this PR fixes:
Fixes #3210

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a35e40</samp>

This pull request adds a new feature to limit the concurrency of `ovs-vsctl` commands, which are used by the kube-ovn daemon to configure Open vSwitch on each node. It also fixes a bug in the `ovsClientRequestLatency` metric and adds tests for the new feature. The feature can be configured through a command-line argument, a helm value, or a yaml file, depending on the deployment mode. The default concurrency limit is 100.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5a35e40</samp>

> _`ovs-vsctl` calls_
> _Limited by concurrency_
> _Winter of OVS_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a35e40</samp>

*  Add concurrency limit logic for ovs-vsctl commands ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-90880cf33f50d3c72a4349293d1f6abe953633d3edb2dc71c45368462b4ac4e5R82), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-2f7bd1822b616f83b06c8d8c356e0fc48c36dde251b8f87ab81d97155ca4cbcbR100), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR23), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR41-R42), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R67), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R106), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R162), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-cc01ae9ad85a57ec159e703231d5028ea72aec39c7abf3953aadc6a63a5ad0b9R4), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-cc01ae9ad85a57ec159e703231d5028ea72aec39c7abf3953aadc6a63a5ad0b9R17-R29), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-cc01ae9ad85a57ec159e703231d5028ea72aec39c7abf3953aadc6a63a5ad0b9L22-R59), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-cc01ae9ad85a57ec159e703231d5028ea72aec39c7abf3953aadc6a63a5ad0b9L34-R67), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-8161e77fe331f5dd6eb9ecd97d22bc4bd88d5c967bdf8b0fa28478353434dfc3L4-R9), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-8161e77fe331f5dd6eb9ecd97d22bc4bd88d5c967bdf8b0fa28478353434dfc3R241-R281), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR204), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R204))
  * Define and initialize a global Limiter variable in the `ovs-vsctl.go` file to control the number of concurrent ovs-vsctl commands ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-cc01ae9ad85a57ec159e703231d5028ea72aec39c7abf3953aadc6a63a5ad0b9R17-R29))
  * Add a new argument named `ovs-vsctl-concurrency` to the ovn-cni container in the `ovncni-ds.yaml`, `kube-ovn-dual-stack.yaml`, and `kube-ovn-ipv6.yaml` files to specify the concurrency limit ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-90880cf33f50d3c72a4349293d1f6abe953633d3edb2dc71c45368462b4ac4e5R82), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR204), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R204))
  * Add a new value named `ovsVsctlConcurrency` to the helm chart values file to define the default concurrency limit of 100 ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-2f7bd1822b616f83b06c8d8c356e0fc48c36dde251b8f87ab81d97155ca4cbcbR100))
  * Add a new field named `OVSVsctlConcurrency` to the Configuration type in the `config.go` file to store the concurrency limit value ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R67))
  * Parse the `ovs-vsctl-concurrency` argument from the command-line and assign it to the `OVSVsctlConcurrency` field of the config object in the `config.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R106), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-fde9321dc0cca23d5eacc02fbb93b4c7979afdb901f7bd0ce31af16fe5ba1073R162))
  * Import the ovs package in the `cniserver.go` file and call the `UpdateOVSVsctlLimiter` function with the `OVSVsctlConcurrency` value from the config object to update the limit field of the Limiter variable ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR23), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-2eecf9a49ec68a8fcdcaa8a202d707c2a72418faf0dbb84edf615440c234adbbR41-R42))
  * Modify the `Exec` function in the `ovs-vsctl.go` file to use the Limiter variable and the context package to wait until the limiter allows the execution of the ovs-vsctl command or the context is canceled by timeout, and to increment and decrement the current field of the Limiter variable ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-cc01ae9ad85a57ec159e703231d5028ea72aec39c7abf3953aadc6a63a5ad0b9L22-R59), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-cc01ae9ad85a57ec159e703231d5028ea72aec39c7abf3953aadc6a63a5ad0b9L34-R67))
  * Fix a bug that causes the code variable to always be "0" in the defer statement of the `Exec` function by assigning it before the defer statement ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-cc01ae9ad85a57ec159e703231d5028ea72aec39c7abf3953aadc6a63a5ad0b9L34-R67))
  * Import the context, sync/atomic, and time packages in the `util.go` file to use the context type, atomic operations, and timeouts in the Limiter type and its methods ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-8161e77fe331f5dd6eb9ecd97d22bc4bd88d5c967bdf8b0fa28478353434dfc3L4-R9))
  * Define the Limiter type and its methods in the `util.go` file to implement the concurrency limit logic ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-8161e77fe331f5dd6eb9ecd97d22bc4bd88d5c967bdf8b0fa28478353434dfc3R241-R281))
* Add test cases for the Limiter type and its methods in the `util_test.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-7517a56aa734bd26cf4e7d8841925eda0f09b370b17ede5902084e2a2a89333bL4-R6), [link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-7517a56aa734bd26cf4e7d8841925eda0f09b370b17ede5902084e2a2a89333bR234-R322))
  * Import the context and time packages in the `util_test.go` file to create contexts with timeouts and timers for testing the Limiter type and its methods ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-7517a56aa734bd26cf4e7d8841925eda0f09b370b17ede5902084e2a2a89333bL4-R6))
  * Add the `Test_Limiter` test case and its subtests to test the Limiter type and its methods with different scenarios, such as without limit, with limit, and with timeout ([link](https://github.com/kubeovn/kube-ovn/pull/3288/files?diff=unified&w=0#diff-7517a56aa734bd26cf4e7d8841925eda0f09b370b17ede5902084e2a2a89333bR234-R322))