### PR TITLE
add base rules for allowing vrrp packets

### DIFF
--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -473,7 +473,7 @@ func (suite *OvnClientTestSuite) testCreateSgBaseACL() {
 
 		pg, err := ovnClient.GetPortGroup(pgName, false)
 		require.NoError(t, err)
-		require.Len(t, pg.ACLs, 4)
+		require.Len(t, pg.ACLs, 5)
 
 		// arp
 		match := fmt.Sprintf("%s == @%s && arp", portDirection, pgName)
@@ -489,6 +489,10 @@ func (suite *OvnClientTestSuite) testCreateSgBaseACL() {
 
 		// dhcpv6
 		match = fmt.Sprintf("%s == @%s && udp.src == 547 && udp.dst == 546 && ip6", portDirection, pgName)
+		expect(pg, match)
+
+		// vrrp
+		match = fmt.Sprintf("%s == @%s && ip.proto == 112", portDirection, pgName)
 		expect(pg, match)
 	})
 
@@ -508,14 +512,14 @@ func (suite *OvnClientTestSuite) testCreateSgBaseACL() {
 
 		pg, err := ovnClient.GetPortGroup(pgName, false)
 		require.NoError(t, err)
-		require.Len(t, pg.ACLs, 4)
+		require.Len(t, pg.ACLs, 5)
 
 		// arp
 		match := fmt.Sprintf("%s == @%s && arp", portDirection, pgName)
 		expect(pg, match)
 
 		// icmpv6
-		match = fmt.Sprintf("%s == @%s && icmp6.type == {130, 134, 135, 136} && icmp6.code == 0 && ip.ttl == 255", portDirection, pgName)
+		match = fmt.Sprintf("%s == @%s && icmp6.type == {130, 133, 135, 136} && icmp6.code == 0 && ip.ttl == 255", portDirection, pgName)
 		expect(pg, match)
 
 		// dhcpv4
@@ -524,6 +528,10 @@ func (suite *OvnClientTestSuite) testCreateSgBaseACL() {
 
 		// dhcpv6
 		match = fmt.Sprintf("%s == @%s && udp.src == 546 && udp.dst == 547 && ip6", portDirection, pgName)
+		expect(pg, match)
+
+		// vrrp
+		match = fmt.Sprintf("%s == @%s && ip.proto == 112", portDirection, pgName)
 		expect(pg, match)
 	})
 }


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #3292

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59ecef0</samp>

Enhance security group rules for IPv6 and VRRP packets in `ovn-nb-acl.go`. Add variables and match conditions to allow ICMPv6 and VRRP traffic within port groups.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 59ecef0</samp>

> _To enhance the security group rules_
> _For IPv6 and VRRP packets, cool_
> _We use `icmpv6Type`_
> _And `vrrpMatch` to hype_
> _The ingress and egress of our pools_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 59ecef0</samp>

*  Add a variable `icmpv6Type` to store the allowed ICMPv6 types for ingress and egress rules ([link](https://github.com/kubeovn/kube-ovn/pull/3293/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L289-R294))
*  Use the variable `icmpv6Type` in the `icmpv6Match` condition instead of hard-coded values ([link](https://github.com/kubeovn/kube-ovn/pull/3293/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L317-R319))
*  Add a new match condition `vrrpMatch` for VRRP packets in the same security group ([link](https://github.com/kubeovn/kube-ovn/pull/3293/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L339-R349))