### PR TITLE
Add Layer 2 forwarding for subnet ports again

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -702,6 +702,14 @@ func (c *Controller) reconcileAllocateSubnets(cachedPod, pod *v1.Pod, needAlloca
 				return nil, err
 			}
 
+			if pod.Annotations[fmt.Sprintf(util.Layer2ForwardAnnotationTemplate, podNet.ProviderName)] == "true" {
+				if err := c.OVNNbClient.EnablePortLayer2forward(portName); err != nil {
+					c.recorder.Eventf(pod, v1.EventTypeWarning, "SetOVNPortL2ForwardFailed", err.Error())
+					klog.Errorf("%v", err)
+					return nil, err
+				}
+			}
+
 			if portSecurity {
 				sgNames := strings.Split(securityGroupAnnotation, ",")
 				for _, sgName := range sgNames {


### PR DESCRIPTION
This feature has been added in #1487 and then again in #2067, but fallen victim to a refactoring in 
#2477 that removed it. We now add it back again.

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

Feature/Bug Fix.

### Which issue(s) this PR fixes:
Fixes #2043

### WHAT

Adds the ability to configure a subnet port with addresses `unknown` in OVN, such that the port gets all layer 2 packets. See #2043 
