### PR TITLE
Don't enqueue VPC update when DeletionTimestamp is zero

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -44,7 +44,7 @@ func (c *Controller) enqueueUpdateVpc(oldObj, newObj interface{}) {
 	oldVpc := oldObj.(*kubeovnv1.Vpc)
 	newVpc := newObj.(*kubeovnv1.Vpc)
 
-	if newVpc.DeletionTimestamp.IsZero() ||
+	if !newVpc.DeletionTimestamp.IsZero() ||
 		!reflect.DeepEqual(oldVpc.Spec.Namespaces, newVpc.Spec.Namespaces) ||
 		!reflect.DeepEqual(oldVpc.Spec.StaticRoutes, newVpc.Spec.StaticRoutes) ||
 		!reflect.DeepEqual(oldVpc.Spec.PolicyRoutes, newVpc.Spec.PolicyRoutes) ||


### PR DESCRIPTION
We change the check to not enqueue a VPC update when the DeletionTimestamp is zero. Previously, the VPC update would basically always be enqueued, as the DeletionTimestamp would be zero until it was scheduled for deletion. This lead to a huge amount of enqueued VPC updates and therefore a lot of Kubernetes API requests and load on the API.

The logical not was removed in #3107 which therefore introduced this bug.

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

Bug Fix

### Which issue(s) this PR fixes:

Fixes #3301 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01fc78b</samp>

Fix Vpc deletion bug by enqueuing update events when Vpc has deletion timestamp. Modify `pkg/controller/vpc.go` to implement this logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 01fc78b</samp>

> _`Vpc` deletion_
> _Enqueue update event now_
> _Fixes autumn bug_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 01fc78b</samp>

* Fix issue #1144 by enqueuing Vpc update events when the Vpc has a deletion timestamp ([link](https://github.com/kubeovn/kube-ovn/pull/3302/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL47-R47))