### PR TITLE
Release 1.9 iptables wrapper

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -15,6 +15,7 @@ COPY logrotate/* /etc/logrotate.d/
 COPY grace_stop_ovn_controller /usr/share/ovn/scripts/grace_stop_ovn_controller
 
 WORKDIR /kube-ovn
+RUN /kube-ovn/iptables-wrapper-installer.sh --no-sanity-check
 
 RUN rm -f /usr/bin/nc &&\
     rm -f /usr/bin/netcat

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -85,9 +85,6 @@ RUN apt update && apt upgrade -y && apt install ca-certificates python3 hostname
         tcpdump ipset curl uuid-runtime openssl inetutils-ping arping ndisc6 \
         logrotate dnsutils net-tools nmap -y --no-install-recommends && \
         rm -rf /var/lib/apt/lists/* && \
-        cd /usr/sbin && \
-        ln -sf /usr/sbin/iptables-legacy iptables && \
-        ln -sf /usr/sbin/ip6tables-legacy ip6tables && \
         rm -rf /etc/localtime
 
 RUN mkdir -p /var/run/openvswitch && \

--- a/dist/images/iptables-wrapper-installer.sh
+++ b/dist/images/iptables-wrapper-installer.sh
@@ -1,0 +1,211 @@
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+# original source:
+# https://github.com/kubernetes-sigs/iptables-wrappers/blob/master/iptables-wrapper-installer.sh
+
+set -eu
+
+# Find iptables binary location
+if [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+    sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+    sbin="/sbin"
+else
+    echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+    exit 1
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -x /usr/sbin/alternatives ]; then
+    # Fedora/SUSE style alternatives
+    altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+    # Debian style alternatives
+    altstyle="debian"
+else
+    # No alternatives system
+    altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+    # Ensure dependencies are installed
+    if ! version=$("${sbin}/iptables-nft" --version 2> /dev/null); then
+        echo "ERROR: iptables-nft is not installed" 1>&2
+        exit 1
+    fi
+    if ! "${sbin}/iptables-legacy" --version > /dev/null 2>&1; then
+        echo "ERROR: iptables-legacy is not installed" 1>&2
+        exit 1
+    fi
+
+    case "${version}" in
+    *v1.8.[0123]\ *)
+        echo "ERROR: iptables 1.8.0 - 1.8.3 have compatibility bugs." 1>&2
+        echo "       Upgrade to 1.8.4 or newer." 1>&2
+        exit 1
+        ;;
+    *)
+        # 1.8.4+ are OK
+        ;;
+    esac
+fi
+
+# Start creating the wrapper...
+rm -f "${sbin}/iptables-wrapper"
+cat > "${sbin}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# In kubernetes 1.17 and later, kubelet will have created at least
+# one chain in the "mangle" table (either "KUBE-IPTABLES-HINT" or
+# "KUBE-KUBELET-CANARY"), so check that first, against
+# iptables-nft, because we can check that more efficiently and
+# it's more common these days.
+nft_kubelet_rules=\$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+if [ "\${nft_kubelet_rules}" -ne 0 ]; then
+    mode=nft
+else
+    # Check for kubernetes 1.17-or-later with iptables-legacy. We
+    # can't pass "-t mangle" to iptables-legacy-save because it would
+    # cause the kernel to create that table if it didn't already
+    # exist, which we don't want. So we have to grab all the rules
+    legacy_kubelet_rules=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+    if [ "\${legacy_kubelet_rules}" -ne 0 ]; then
+        mode=legacy
+    else
+        # With older kubernetes releases there may not be any _specific_
+        # rules we can look for, but we assume that some non-containerized process
+        # (possibly kubelet) will have created _some_ iptables rules.
+        num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+        num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
+    fi
+fi
+
+EOF
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+    fedora)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    debian)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    *)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+    ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >> "${sbin}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${sbin}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+    fedora)
+	alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+	;;
+
+    debian)
+	update-alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	update-alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    *)
+	for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+            rm -f "${sbin}/${cmd}"
+            ln -s "${sbin}/iptables-wrapper" "${sbin}/${cmd}"
+	done
+	;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/dist/images/start-cniserver.sh
+++ b/dist/images/start-cniserver.sh
@@ -38,6 +38,9 @@ while true; do
   sleep 1
 done
 
+# update links to point to the iptables binaries
+iptables -V
+
 # If nftables not exist do not exit
 set +e
 iptables -P FORWARD ACCEPT

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -51,6 +51,9 @@ function quit {
 }
 trap quit EXIT
 
+# update links to point to the iptables binaries
+iptables -V
+
 # Start ovsdb
 /usr/share/openvswitch/scripts/ovs-ctl restart --no-ovs-vswitchd --system-id=random
 # Restrict the number of pthreads ovs-vswitchd creates to reduce the

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
-	github.com/coreos/go-iptables v0.6.0
 	github.com/emicklei/go-restful/v3 v3.9.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/golang/protobuf v1.5.2
 	github.com/greenpau/ovsdb v0.0.0-20181114004433-3582b85e8968
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.1-0.20210510153419-66a699ae3b05
+	github.com/kubeovn/go-iptables v0.0.0-20230322103850-8619a8ab3dca
 	github.com/kubeovn/gonetworkmanager/v2 v2.0.0-20230905082151-e28c4d73a589
 	github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875
 	github.com/neverlee/keymutex v0.0.0-20171121013845-f593aa834bf9

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,6 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
-github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
-github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -693,6 +691,8 @@ github.com/kubeovn/arp v0.0.0-20230101053045-8a0772d9c34c h1:AcOKlV+lInNlGO3o3+1
 github.com/kubeovn/arp v0.0.0-20230101053045-8a0772d9c34c/go.mod h1:Ce8lvkopTGXfPmeb5AY3/umEOmoFVV3HlCPGfGk0+Y0=
 github.com/kubeovn/felix v0.0.0-20220325073257-c8a0f705d139 h1:MaLC8/dohKHU8nkfglfE2oikefB6urJG75yZDOcKTRU=
 github.com/kubeovn/felix v0.0.0-20220325073257-c8a0f705d139/go.mod h1:ulxnUH9cbIOtCH+exhJPeV2mleh+bDv67WKsl/MVU/g=
+github.com/kubeovn/go-iptables v0.0.0-20230322103850-8619a8ab3dca h1:fTMjoho2et9nKVOFrjzVEWVd9XD1zzxOYrlxxZpO0fU=
+github.com/kubeovn/go-iptables v0.0.0-20230322103850-8619a8ab3dca/go.mod h1:jY1XeGzkx8ASNJ+SqQSxTESNXARkjvt+I6IJOTnzIjw=
 github.com/kubeovn/gonetworkmanager/v2 v2.0.0-20230905082151-e28c4d73a589 h1:y9exo1hjCsq7jsGUzt11kxhTiEGrGSQ0ZqibAiZk2PQ=
 github.com/kubeovn/gonetworkmanager/v2 v2.0.0-20230905082151-e28c4d73a589/go.mod h1:49upX+/hUyppWIqu58cumojyIwXdkA8k6reA/mQlKuI=
 github.com/kubeovn/libovsdb v0.0.0-20221125061852-8b910935f8e4 h1:S/R2b2/S7L3l68Y2YwV/0zDGEVDargfRVqYu6989fIw=

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/alauda/felix/ipsets"
+	"github.com/kubeovn/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +31,14 @@ const (
 	LocalPodSet  = "local-pod-ip-nat"
 	OtherNodeSet = "other-node"
 	IPSetPrefix  = "ovn"
+)
+
+const (
+	NAT            = "nat"
+	Prerouting     = "PREROUTING"
+	Postrouting    = "POSTROUTING"
+	OvnPrerouting  = "OVN-PREROUTING"
+	OvnPostrouting = "OVN-POSTROUTING"
 )
 
 type policyRouteMeta struct {
@@ -372,15 +381,6 @@ func (c *Controller) setIptables() error {
 	klog.V(3).Infof("centralized subnets nat ips %v", centralGwNatips)
 
 	var (
-		v4AbandonedRules = []util.IPTableRule{
-			{Table: "nat", Chain: "POSTROUTING", Rule: strings.Fields(`-m mark --mark 0x40000/0x40000 -j MASQUERADE`)},
-			{Table: "mangle", Chain: "PREROUTING", Rule: strings.Fields(`-i ovn0 -m set --match-set ovn40subnets src -m set --match-set ovn40services dst -j MARK --set-xmark 0x40000/0x40000`)},
-		}
-		v6AbandonedRules = []util.IPTableRule{
-			{Table: "nat", Chain: "POSTROUTING", Rule: strings.Fields(`-m mark --mark 0x40000/0x40000 -j MASQUERADE`)},
-			{Table: "mangle", Chain: "PREROUTING", Rule: strings.Fields(`-i ovn0 -m set --match-set ovn60subnets src -m set --match-set ovn60services dst -j MARK --set-xmark 0x40000/0x40000`)},
-		}
-
 		v4Rules = []util.IPTableRule{
 			// nat service traffic
 			{Table: "nat", Chain: "POSTROUTING", Rule: strings.Fields(`-m set --match-set ovn40subnets src -m set --match-set ovn40subnets dst -j MASQUERADE`)},
@@ -435,9 +435,11 @@ func (c *Controller) setIptables() error {
 	}
 
 	for _, protocol := range protocols {
-		if c.iptables[protocol] == nil {
+		ipt := c.iptables[protocol]
+		if ipt == nil {
 			continue
 		}
+
 		// delete unused iptables rule when nat gw with designative ip has been changed in centralized subnet
 		if err = c.deleteUnusedIptablesRule(protocol, "nat", "POSTROUTING", centralGwNatips); err != nil {
 			klog.Errorf("failed to delete iptables rule on node %s, maybe can delete manually, %v", c.config.NodeName, err)
@@ -445,19 +447,19 @@ func (c *Controller) setIptables() error {
 		}
 
 		var matchset string
-		var abandonedRules, iptablesRules []util.IPTableRule
+		var obsoleteRules, iptablesRules []util.IPTableRule
 		if protocol == kubeovnv1.ProtocolIPv4 {
-			iptablesRules, abandonedRules = v4Rules, v4AbandonedRules
+			iptablesRules = v4Rules
 			matchset = "ovn40subnets"
 		} else {
-			iptablesRules, abandonedRules = v6Rules, v6AbandonedRules
+			iptablesRules = v6Rules
 			matchset = "ovn60subnets"
 		}
 
 		if nodeIP := nodeIPs[protocol]; nodeIP != "" {
-			abandonedRules = append(abandonedRules,
-				util.IPTableRule{Table: "nat", Chain: "POSTROUTING", Rule: strings.Fields(fmt.Sprintf(`! -s %s -m set --match-set %s dst -j MASQUERADE`, nodeIP, matchset))},
-			)
+			obsoleteRules = []util.IPTableRule{
+				{Table: "nat", Chain: "POSTROUTING", Rule: strings.Fields(fmt.Sprintf(`! -s %s -m set --match-set %s dst -j MASQUERADE`, nodeIP, matchset))},
+			}
 
 			rules := make([]util.IPTableRule, len(iptablesRules)+2)
 			copy(rules[1:4], iptablesRules[:3])
@@ -465,22 +467,6 @@ func (c *Controller) setIptables() error {
 			rules[4] = util.IPTableRule{Table: "nat", Chain: "POSTROUTING", Rule: strings.Fields(fmt.Sprintf(`! -s %s -m set ! --match-set %s src -m set --match-set %s dst -j MASQUERADE`, nodeIP, matchset, matchset))}
 			copy(rules[5:], iptablesRules[3:])
 			iptablesRules = rules
-		}
-
-		// delete abandoned iptables rules
-		for _, iptRule := range abandonedRules {
-			exists, err := c.iptables[protocol].Exists(iptRule.Table, iptRule.Chain, iptRule.Rule...)
-			if err != nil {
-				klog.Errorf("failed to check existence of iptables rule: %v", err)
-				return err
-			}
-			if exists {
-				klog.Infof("deleting abandoned iptables rule: %s", strings.Join(iptRule.Rule, " "))
-				if err := c.iptables[protocol].Delete(iptRule.Table, iptRule.Chain, iptRule.Rule...); err != nil {
-					klog.Errorf("failed to delete iptables rule %s: %v", strings.Join(iptRule.Rule, " "), err)
-					return err
-				}
-			}
 		}
 
 		// add iptables rule for nat gw with designative ip in centralized subnet
@@ -524,6 +510,91 @@ func (c *Controller) setIptables() error {
 			}
 			klog.V(3).Infof("iptables rules %v, exists %v", strings.Join(iptRule.Rule, " "), exists)
 		}
+
+		if err = c.cleanObsoleteIptablesRules(protocol, obsoleteRules); err != nil {
+			klog.Errorf("failed to clean legacy iptables rules: %v", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteIptablesRule(ipt *iptables.IPTables, rule util.IPTableRule) error {
+	if err := ipt.DeleteIfExists(rule.Table, rule.Chain, rule.Rule...); err != nil {
+		klog.Errorf("failed to delete iptables rule %q: %v", strings.Join(rule.Rule, " "), err)
+		return err
+	}
+	return nil
+}
+
+func clearObsoleteIptablesChain(ipt *iptables.IPTables, table, chain, parent string) error {
+	exists, err := ipt.ChainExists(table, chain)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	rule := fmt.Sprintf(`-m comment --comment "kube-ovn %s rules" -j %s`, strings.ToLower(parent), chain)
+	if err = deleteIptablesRule(ipt, util.IPTableRule{Table: table, Chain: parent, Rule: util.DoubleQuotedFields(rule)}); err != nil {
+		klog.Error(err)
+		return err
+	}
+	if err = ipt.ClearAndDeleteChain(table, chain); err != nil {
+		klog.Errorf("failed to delete iptables chain %q in table %s: %v", chain, table, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) cleanObsoleteIptablesRules(protocol string, rules []util.IPTableRule) error {
+	if c.iptablesObsolete == nil || c.iptablesObsolete[protocol] == nil {
+		return nil
+	}
+
+	v4ObsoleteRules := []util.IPTableRule{
+		{Table: "nat", Chain: "POSTROUTING", Rule: strings.Fields(`-m mark --mark 0x40000/0x40000 -j MASQUERADE`)},
+		{Table: "mangle", Chain: "PREROUTING", Rule: strings.Fields(`-i ovn0 -m set --match-set ovn40subnets src -m set --match-set ovn40services dst -j MARK --set-xmark 0x40000/0x40000`)},
+	}
+	v6ObsoleteRules := []util.IPTableRule{
+		{Table: "nat", Chain: "POSTROUTING", Rule: strings.Fields(`-m mark --mark 0x40000/0x40000 -j MASQUERADE`)},
+		{Table: "mangle", Chain: "PREROUTING", Rule: strings.Fields(`-i ovn0 -m set --match-set ovn60subnets src -m set --match-set ovn60services dst -j MARK --set-xmark 0x40000/0x40000`)},
+	}
+
+	var obsoleteRules []util.IPTableRule
+	if protocol == kubeovnv1.ProtocolIPv4 {
+		obsoleteRules = v4ObsoleteRules
+	} else {
+		obsoleteRules = v6ObsoleteRules
+	}
+
+	ipt := c.iptablesObsolete[protocol]
+	for _, rule := range obsoleteRules {
+		if err := deleteIptablesRule(ipt, rule); err != nil {
+			klog.Error(err)
+			return err
+		}
+	}
+	for _, rule := range rules {
+		if err := deleteIptablesRule(ipt, rule); err != nil {
+			klog.Error(err)
+			return err
+		}
+	}
+
+	if err := clearObsoleteIptablesChain(ipt, NAT, OvnPrerouting, Prerouting); err != nil {
+		return err
+	}
+	if err := clearObsoleteIptablesChain(ipt, NAT, OvnPostrouting, Postrouting); err != nil {
+		return err
+	}
+
+	delete(c.iptablesObsolete, protocol)
+	if len(c.iptablesObsolete) == 0 {
+		c.iptablesObsolete = nil
 	}
 	return nil
 }

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -1,0 +1,24 @@
+package util
+
+import "strings"
+
+func DoubleQuotedFields(s string) []string {
+	var quoted bool
+	var fields []string
+	sb := &strings.Builder{}
+	for _, r := range s {
+		if r == '"' {
+			quoted = !quoted
+		} else if !quoted && r == ' ' {
+			fields = append(fields, sb.String())
+			sb.Reset()
+		} else {
+			sb.WriteRune(r)
+		}
+	}
+	if sb.Len() > 0 {
+		fields = append(fields, sb.String())
+	}
+
+	return fields
+}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a26853</samp>

This pull request updates and refactors the iptables management for the project, using a newer `go-iptables` library and adding support for nft mode. It also adds a new utility function for parsing iptables rules with double-quoted comments.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9a26853</samp>

> _Oh we are the `iptables` crew, we work with rules and chains_
> _We split the strings and parse the fields, we migrate and maintain_
> _Heave away, me hearties, heave away with me_
> _We'll make the gateway node secure, with `go-iptables` library_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a26853</samp>

*  Replace the outdated dependency on `github.com/coreos/go-iptables` with the updated fork `github.com/kubeovn/go-iptables` ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L12),[link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R17),[link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L19-R20),[link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08R14))
*  Add a new field `iptablesObsolete` to the Controller struct, and initialize it with the legacy mode iptables instances if the iptables works in nft mode ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L69-R73),[link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806L124-R163))
*  Add two helper functions to check the iptables mode by evaluating the symbolic links of the iptables commands ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R516-R540))
*  Import the "path/filepath" package to use the `filepath.EvalSymlinks` function ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-faae10a9df4dc5a676f00e677799cb92edfdfb98b7c7267cf90744ee70854806R11))
*  Remove some obsolete iptables rules that are no longer needed for the gateway node, and rename the variable `abandonedRules` to `obsoleteRules` ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L375-L383),[link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L448-R462),[link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L470-L485))
*  Define some constants for the iptables table, chain and comment names, and assign the iptables instance to a local variable `ipt` ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08R36-R43),[link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L438-R442))
*  Add a new function `cleanObsoleteIptablesRules` to delete the obsolete iptables rules in the legacy mode, and clear the obsolete iptables chains ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L527-R625))
*  Add a new function `deleteObsoleteSnatRules` to delete the obsolete SNAT rules for the gateway node, and call it in the `setIptables` function ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L527-R625))
*  Add a new function `DoubleQuotedFields` to split a string into fields by spaces, but preserve the double-quoted parts as a single field, and use it to parse the iptables rules that contain double-quoted comments ([link](https://github.com/kubeovn/kube-ovn/pull/3319/files?diff=unified&w=0#diff-b85cb8dd9eecd095561611310332de19cd87bb74b60f8083131caec5e05d0b0dR1-R24))