### PR TITLE
kube-ovn-controller: fix ovn ic log directory not mounted to hostpath

### DIFF
--- a/charts/templates/controller-deploy.yaml
+++ b/charts/templates/controller-deploy.yaml
@@ -136,6 +136,9 @@ spec:
               readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
+            # ovn-ic log directory
+            - mountPath: /var/log/ovn
+              name: ovn-log
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -168,6 +171,9 @@ spec:
         - name: kube-ovn-log
           hostPath:
             path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+        - name: ovn-log
+          hostPath:
+            path: {{ .Values.log_conf.LOG_DIR }}/ovn
         - name: kube-ovn-tls
           secret:
             optional: true

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3977,6 +3977,9 @@ spec:
               readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
+            # ovn-ic log directory
+            - mountPath: /var/log/ovn
+              name: ovn-log
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -4009,6 +4012,9 @@ spec:
         - name: kube-ovn-log
           hostPath:
             path: $LOG_DIR/kube-ovn
+        - name: ovn-log
+          hostPath:
+            path: $LOG_DIR/ovn
         - name: kube-ovn-tls
           secret:
             optional: true

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -99,6 +99,9 @@ spec:
               readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
+            # ovn-ic log directory
+            - mountPath: /var/log/ovn
+              name: ovn-log
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -130,7 +133,10 @@ spec:
             path: /etc/localtime
         - name: kube-ovn-log
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+            path: /var/log/kube-ovn
+        - name: ovn-log
+          hostPath:
+            path: /var/log/ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -315,13 +321,13 @@ spec:
             path: /var/run/dbus
         - name: host-log-ovs
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
+            path: /var/log/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+            path: /var/log/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -433,13 +439,13 @@ spec:
             path: /etc/origin/openvswitch
         - name: host-log-ovs
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
+            path: /var/log/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+            path: /var/log/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -574,7 +580,7 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -584,7 +590,7 @@ spec:
             secretName: kube-ovn-tls
         - name: kube-ovn-log
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+            path: /var/log/kube-ovn
 ---
 kind: Service
 apiVersion: v1

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -99,6 +99,9 @@ spec:
               readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
+            # ovn-ic log directory
+            - mountPath: /var/log/ovn
+              name: ovn-log
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -130,7 +133,10 @@ spec:
             path: /etc/localtime
         - name: kube-ovn-log
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+            path: /var/log/kube-ovn
+        - name: ovn-log
+          hostPath:
+            path: /var/log/ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -315,13 +321,13 @@ spec:
             path: /var/run/dbus
         - name: host-log-ovs
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
+            path: /var/log/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+            path: /var/log/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -433,13 +439,13 @@ spec:
             path: /etc/origin/openvswitch
         - name: host-log-ovs
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
+            path: /var/log/openvswitch
         - name: kube-ovn-log
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+            path: /var/log/kube-ovn
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -574,7 +580,7 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -584,7 +590,7 @@ spec:
             secretName: kube-ovn-tls
         - name: kube-ovn-log
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+            path: /var/log/kube-ovn
 ---
 kind: Service
 apiVersion: v1

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -101,6 +101,9 @@ spec:
               readOnly: true
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
+            # ovn-ic log directory
+            - mountPath: /var/log/ovn
+              name: ovn-log
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -133,6 +136,9 @@ spec:
         - name: kube-ovn-log
           hostPath:
             path: /var/log/kube-ovn
+        - name: ovn-log
+          hostPath:
+            path: /var/log/ovn
         - name: kube-ovn-tls
           secret:
             optional: true

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -297,10 +297,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
+            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: kube-ovn-tls
           secret:
             optional: true
@@ -438,10 +438,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
+            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: host-config-ovs
           hostPath:
             path: /opt/ovs-config

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -194,10 +194,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
+            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime
@@ -358,10 +358,10 @@ spec:
             path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/openvswitch
+            path: /var/log/openvswitch
         - name: host-log-ovn
           hostPath:
-            path: {{ .Values.log_conf.LOG_DIR }}/ovn
+            path: /var/log/ovn
         - name: localtime
           hostPath:
             path: /etc/localtime


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 73e651e</samp>

This pull request standardizes and hard-codes the log directory paths for various kube-ovn deployment modes and components. This improves the logging, compatibility, and reliability of the kube-ovn system. It also adds support for ovn-ic logs in the `kube-ovn-controller` deployment.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 73e651e</samp>

> _Sing, O Muse, of the valiant deeds of the kube-ovn heroes,_
> _Who tamed the wild network with their skillful `yaml` files,_
> _And mounted many a log directory on their swift `kube-ovn-controller`,_
> _To trace the paths of `ovn-ic` and `ovn-central` across the cloud._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 73e651e</samp>

*  Add volume mount and definition for ovn-ic log directory to kube-ovn-controller container and deployment in various yaml files ([link](https://github.com/kubeovn/kube-ovn/pull/3322/files?diff=unified&w=0#diff-ea68dce347b5fa351b4dd8da76b26575f5aeac40e3ce0f5d37e26a603bb6ea51R139-R141), [link](https://github.com/kubeovn/kube-ovn/pull/3322/files?diff=unified&w=0#diff-ea68dce347b5fa351b4dd8da76b26575f5aeac40e3ce0f5d37e26a603bb6ea51R174-R176), [link](https://github.com/kubeovn/kube-ovn/pull/3322/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR102-R104), [link](https://github.com/kubeovn/kube-ovn/pull/3322/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfL133-R139), [link](https://github.com/kubeovn/kube-ovn/pull/3322/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R102-R104), [link](https://github.com/kubeovn/kube-ovn/pull/3322/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3L133-R139), [link](https://github.com/kubeovn/kube-ovn/pull/3322/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R104-R106), [link](https://github.com/kubeovn/kube-ovn/pull/3322/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R139-R141)). This supports the interconnection feature between different ovn clusters.