### PR TITLE
fix golang lint error

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1479,12 +1479,11 @@ func getShortSharedDir(uid types.UID, volumeName string) string {
 }
 
 func linkExists(name string) (bool, error) {
-	_, err := netlink.LinkByName(name)
-	if err == nil {
-		return true, nil
-	} else if _, ok := err.(netlink.LinkNotFoundError); ok {
-		return false, nil
-	} else {
+	if _, err := netlink.LinkByName(name); err != nil {
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
+			return false, nil
+		}
 		return false, err
 	}
+	return true, nil
 }


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

### Which issue(s) this PR fixes:

```txt
Check warning on line 1487 in pkg/daemon/ovs_linux.go

indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14b95a6</samp>

Refactor `linkExists` function in `ovs_linux.go` to simplify link existence check. This change improves the code quality and readability of the file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 14b95a6</samp>

> _`linkExists` changed_
> _Simpler logic, fewer returns_
> _Netlink in winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 14b95a6</samp>

*  Refactor `linkExists` function to simplify logic and reduce return statements ([link](https://github.com/kubeovn/kube-ovn/pull/3323/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feL1482-R1488))