### PR TITLE
change compact default time from 5s to 15s

### DIFF
--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -31,7 +31,7 @@ const (
 	EnvPodName           = "POD_NAME"
 	EnvPodNameSpace      = "POD_NAMESPACE"
 	OvnNorthdPid         = "/var/run/ovn/ovn-northd.pid"
-	DefaultProbeInterval = 5
+	DefaultProbeInterval = 15
 	OvnNorthdPort        = "6643"
 	MaxFailCount         = 3
 )


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 250cae4</samp>

Increased the probe interval for ovn-northd health checks from 5 to 15 seconds in `pkg/ovn_leader_checker/ovn.go`. This was done to enhance the OVN network stability and performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 250cae4</samp>

> _`ovn-northd` breathes_
> _less health checks in the spring_
> _network more stable_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 250cae4</samp>

* Reduce the health check interval for ovn-northd from 5 to 15 seconds ([link](https://github.com/kubeovn/kube-ovn/pull/3333/files?diff=unified&w=0#diff-a196c025047d1f0ecba3e30efeebb0b7fa9cf82b4df48f5cf452d55a0e5a84abL34-R34)). This improves the stability and performance of the OVN network by avoiding unnecessary restarts of the central controller process.