### PR TITLE
add switch for compact

### DIFF
--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -23,6 +23,8 @@ cat /proc/cmdline"
     exit 1
 fi
 
+PRBOE_INTERVAL=${PRBOE_INTERVAL:-5}
+ENABLE_COMPACT=${ENABLE_COMPACT:-false}
 DB_NB_ADDR=${DB_NB_ADDR:-::}
 DB_NB_PORT=${DB_NB_PORT:-6641}
 DB_SB_ADDR=${DB_SB_ADDR:-::}
@@ -366,5 +368,5 @@ ovs-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/memory-trim-on-compaction o
 ovs-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/memory-trim-on-compaction on
 
 chmod 600 /etc/ovn/*
-/kube-ovn/kube-ovn-leader-checker
+/kube-ovn/kube-ovn-leader-checker --probeInterval=$PRBOE_INTERVAL --enableCompact=$ENABLE_COMPACT
 

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -52,7 +52,7 @@ func ParseFlags() (*Configuration, error) {
 	var (
 		argKubeConfigFile = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argProbeInterval  = pflag.Int("probeInterval", DefaultProbeInterval, "interval of probing leader in seconds")
-		argEnableCompact  = pflag.Bool("enableCompact", true, "interval of probing leader in seconds")
+		argEnableCompact  = pflag.Bool("enableCompact", true, "is enable compact")
 	)
 
 	klogFlags := flag.NewFlagSet("klog", flag.ContinueOnError)

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -43,6 +43,7 @@ type Configuration struct {
 	KubeConfigFile string
 	KubeClient     kubernetes.Interface
 	ProbeInterval  int
+	EnableCompact  bool
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -51,6 +52,7 @@ func ParseFlags() (*Configuration, error) {
 	var (
 		argKubeConfigFile = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argProbeInterval  = pflag.Int("probeInterval", DefaultProbeInterval, "interval of probing leader in seconds")
+		argEnableCompact  = pflag.Bool("enableCompact", true, "interval of probing leader in seconds")
 	)
 
 	klogFlags := flag.NewFlagSet("klog", flag.ContinueOnError)
@@ -80,6 +82,7 @@ func ParseFlags() (*Configuration, error) {
 	config := &Configuration{
 		KubeConfigFile: *argKubeConfigFile,
 		ProbeInterval:  *argProbeInterval,
+		EnableCompact:  *argEnableCompact,
 	}
 	return config, nil
 }
@@ -379,8 +382,11 @@ func doOvnLeaderCheck(cfg *Configuration, podName string, podNamespace string) {
 			stealLock()
 		}
 	}
-	compactOvnDatabase("nb")
-	compactOvnDatabase("sb")
+
+	if cfg.EnableCompact {
+		compactOvnDatabase("nb")
+		compactOvnDatabase("sb")
+	}
 }
 
 func StartOvnLeaderCheck(cfg *Configuration) {


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21af1f3</samp>

Added a feature to control OVN database compaction from the ovn-leader-checker component. The feature can be configured by a command-line flag or a config file field.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 21af1f3</samp>

> _We're sailing on the OVN, a mighty network tool_
> _We need to keep our databases clean and running smooth_
> _So when the captain gives the order, we know what to do_
> _We set the `--enableCompact` flag and compact them on cue_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 21af1f3</samp>

*  Add a new field `EnableCompact` to the `Configuration` type to control whether to compact the OVN databases or not ([link](https://github.com/kubeovn/kube-ovn/pull/3336/files?diff=unified&w=0#diff-a196c025047d1f0ecba3e30efeebb0b7fa9cf82b4df48f5cf452d55a0e5a84abR46))
*  Add a new command-line argument `--enableCompact` to the `ParseFlags` function to set the value of the `EnableCompact` field ([link](https://github.com/kubeovn/kube-ovn/pull/3336/files?diff=unified&w=0#diff-a196c025047d1f0ecba3e30efeebb0b7fa9cf82b4df48f5cf452d55a0e5a84abR55), [link](https://github.com/kubeovn/kube-ovn/pull/3336/files?diff=unified&w=0#diff-a196c025047d1f0ecba3e30efeebb0b7fa9cf82b4df48f5cf452d55a0e5a84abR85))
*  Add a conditional statement to the `doOvnLeaderCheck` function to call the `compactOvnDatabase` function only if the `EnableCompact` field is true ([link](https://github.com/kubeovn/kube-ovn/pull/3336/files?diff=unified&w=0#diff-a196c025047d1f0ecba3e30efeebb0b7fa9cf82b4df48f5cf452d55a0e5a84abL382-R389))