### PR TITLE
Allow same subnet traffic

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1734,6 +1734,8 @@ spec:
                   type: boolean
                 ipv6RAConfigs:
                   type: string
+                allowEWTraffic:
+                  type: boolean
                 acls:
                   type: array
                   items:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2273,6 +2273,8 @@ spec:
                   type: boolean
                 ipv6RAConfigs:
                   type: string
+                allowEWTraffic:
+                  type: boolean
                 acls:
                   type: array
                   items:

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -1521,17 +1521,17 @@ func (mr *MockACLMockRecorder) UpdateIngressACLOps(pgName, asIngressName, asExce
 }
 
 // UpdateLogicalSwitchACL mocks base method.
-func (m *MockACL) UpdateLogicalSwitchACL(lsName string, subnetAcls []v1.ACL) error {
+func (m *MockACL) UpdateLogicalSwitchACL(lsName, cidrBlock string, subnetAcls []v1.ACL, allowEWTraffic bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLogicalSwitchACL", lsName, subnetAcls)
+	ret := m.ctrl.Call(m, "UpdateLogicalSwitchACL", lsName, cidrBlock, subnetAcls, allowEWTraffic)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateLogicalSwitchACL indicates an expected call of UpdateLogicalSwitchACL.
-func (mr *MockACLMockRecorder) UpdateLogicalSwitchACL(lsName, subnetAcls interface{}) *gomock.Call {
+func (mr *MockACLMockRecorder) UpdateLogicalSwitchACL(lsName, cidrBlock, subnetAcls, allowEWTraffic interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLogicalSwitchACL", reflect.TypeOf((*MockACL)(nil).UpdateLogicalSwitchACL), lsName, subnetAcls)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLogicalSwitchACL", reflect.TypeOf((*MockACL)(nil).UpdateLogicalSwitchACL), lsName, cidrBlock, subnetAcls, allowEWTraffic)
 }
 
 // UpdateSgACL mocks base method.
@@ -3953,17 +3953,17 @@ func (mr *MockNbClientMockRecorder) UpdateLogicalRouterPortRA(lrpName, ipv6RACon
 }
 
 // UpdateLogicalSwitchACL mocks base method.
-func (m *MockNbClient) UpdateLogicalSwitchACL(lsName string, subnetAcls []v1.ACL) error {
+func (m *MockNbClient) UpdateLogicalSwitchACL(lsName, cidrBlock string, subnetAcls []v1.ACL, allowEWTraffic bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLogicalSwitchACL", lsName, subnetAcls)
+	ret := m.ctrl.Call(m, "UpdateLogicalSwitchACL", lsName, cidrBlock, subnetAcls, allowEWTraffic)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateLogicalSwitchACL indicates an expected call of UpdateLogicalSwitchACL.
-func (mr *MockNbClientMockRecorder) UpdateLogicalSwitchACL(lsName, subnetAcls interface{}) *gomock.Call {
+func (mr *MockNbClientMockRecorder) UpdateLogicalSwitchACL(lsName, cidrBlock, subnetAcls, allowEWTraffic interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLogicalSwitchACL", reflect.TypeOf((*MockNbClient)(nil).UpdateLogicalSwitchACL), lsName, subnetAcls)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLogicalSwitchACL", reflect.TypeOf((*MockNbClient)(nil).UpdateLogicalSwitchACL), lsName, cidrBlock, subnetAcls, allowEWTraffic)
 }
 
 // UpdateNbGlobal mocks base method.

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -158,7 +158,8 @@ type SubnetSpec struct {
 	EnableIPv6RA  bool   `json:"enableIPv6RA,omitempty"`
 	IPv6RAConfigs string `json:"ipv6RAConfigs,omitempty"`
 
-	Acls []ACL `json:"acls,omitempty"`
+	Acls           []ACL `json:"acls,omitempty"`
+	AllowEWTraffic bool  `json:"allowEWTraffic,omitempty"`
 
 	NatOutgoingPolicyRules []NatOutgoingPolicyRule `json:"natOutgoingPolicyRules,omitempty"`
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -850,7 +850,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", "")
 	}
 
-	if err := c.OVNNbClient.UpdateLogicalSwitchACL(subnet.Name, subnet.Spec.Acls); err != nil {
+	if err := c.OVNNbClient.UpdateLogicalSwitchACL(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Acls, subnet.Spec.AllowEWTraffic); err != nil {
 		c.patchSubnetStatus(subnet, "SetLogicalSwitchAclsFailed", err.Error())
 		return err
 	}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -122,7 +122,7 @@ type ACL interface {
 	CreateSgDenyAllACL(sgName string) error
 	CreateSgBaseACL(sgName, direction string) error
 	UpdateSgACL(sg *kubeovnv1.SecurityGroup, direction string) error
-	UpdateLogicalSwitchACL(lsName string, subnetAcls []kubeovnv1.ACL) error
+	UpdateLogicalSwitchACL(lsName, cidrBlock string, subnetAcls []kubeovnv1.ACL, allowEWTraffic bool) error
 	SetACLLog(pgName, protocol string, logEnable, isIngress bool) error
 	SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR string, allowSubnets []string) error
 	DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string) error

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -417,7 +417,7 @@ func (c *OVNNbClient) UpdateSgACL(sg *kubeovnv1.SecurityGroup, direction string)
 	return nil
 }
 
-func (c *OVNNbClient) UpdateLogicalSwitchACL(lsName string, subnetAcls []kubeovnv1.ACL) error {
+func (c *OVNNbClient) UpdateLogicalSwitchACL(lsName, cidrBlock string, subnetAcls []kubeovnv1.ACL, allowEWTraffic bool) error {
 	if err := c.DeleteAcls(lsName, logicalSwitchKey, "", map[string]string{"subnet": lsName}); err != nil {
 		return fmt.Errorf("delete subnet acls from %s: %v", lsName, err)
 	}
@@ -425,13 +425,38 @@ func (c *OVNNbClient) UpdateLogicalSwitchACL(lsName string, subnetAcls []kubeovn
 	if len(subnetAcls) == 0 {
 		return nil
 	}
-	acls := make([]*ovnnb.ACL, 0, len(subnetAcls))
+	acls := make([]*ovnnb.ACL, 0)
 
 	options := func(acl *ovnnb.ACL) {
 		if acl.ExternalIDs == nil {
 			acl.ExternalIDs = make(map[string]string)
 		}
 		acl.ExternalIDs["subnet"] = lsName
+	}
+
+	if allowEWTraffic {
+		for _, cidr := range strings.Split(cidrBlock, ",") {
+			protocol := util.CheckProtocol(cidr)
+
+			ipSuffix := "ip4"
+			if protocol == kubeovnv1.ProtocolIPv6 {
+				ipSuffix = "ip6"
+			}
+
+			/* same subnet acl */
+			sameSubnetMatch := NewAndACLMatch(
+				NewACLMatch(ipSuffix+".src", "==", cidr, ""),
+				NewACLMatch(ipSuffix+".dst", "==", cidr, ""),
+			)
+
+			sameSubnetACL, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.AllowEWTrafficPriority, sameSubnetMatch.String(), ovnnb.ACLActionAllowRelated, options)
+			if err != nil {
+				klog.Error(err)
+				return fmt.Errorf("new same subnet ingress acl for logical switch %s: %v", lsName, err)
+			}
+
+			acls = append(acls, sameSubnetACL)
+		}
 	}
 
 	/* recreate logical switch acl */

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -655,6 +655,7 @@ func (suite *OvnClientTestSuite) testUpdateLogicalSwitchACL() {
 
 	ovnClient := suite.ovnClient
 	lsName := "test_update_acl_ls"
+	cidrBlock := "192.168.2.0/24,2409:8720:4a00::0/64"
 
 	subnetAcls := []kubeovnv1.ACL{
 		{
@@ -674,11 +675,27 @@ func (suite *OvnClientTestSuite) testUpdateLogicalSwitchACL() {
 	err := ovnClient.CreateBareLogicalSwitch(lsName)
 	require.NoError(t, err)
 
-	err = ovnClient.UpdateLogicalSwitchACL(lsName, subnetAcls)
+	err = ovnClient.UpdateLogicalSwitchACL(lsName, cidrBlock, subnetAcls, true)
 	require.NoError(t, err)
 
 	ls, err := ovnClient.GetLogicalSwitch(lsName, false)
 	require.NoError(t, err)
+
+	for _, cidr := range strings.Split(cidrBlock, ",") {
+		protocol := util.CheckProtocol(cidr)
+
+		match := "ip4.src == 192.168.2.0/24 && ip4.dst == 192.168.2.0/24"
+		if protocol == kubeovnv1.ProtocolIPv6 {
+			match = "ip6.src == 2409:8720:4a00::0/64 && ip6.dst == 2409:8720:4a00::0/64"
+		}
+		acl, err := ovnClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.AllowEWTrafficPriority, match, false)
+		require.NoError(t, err)
+		expect := newACL(lsName, ovnnb.ACLDirectionToLport, util.AllowEWTrafficPriority, match, ovnnb.ACLActionAllowRelated)
+		expect.UUID = acl.UUID
+		expect.ExternalIDs["subnet"] = lsName
+		require.Equal(t, expect, acl)
+		require.Contains(t, ls.ACLs, acl.UUID)
+	}
 
 	for _, subnetACL := range subnetAcls {
 		acl, err := ovnClient.GetACL(lsName, subnetACL.Direction, strconv.Itoa(subnetACL.Priority), subnetACL.Match, false)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -144,6 +144,8 @@ const (
 	EgressAllowPriority = "2001"
 	EgressDefaultDrop   = "2000"
 
+	AllowEWTrafficPriority = "1900"
+
 	SubnetAllowPriority = "1001"
 	DefaultDropPriority = "1000"
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -2045,6 +2045,8 @@ spec:
                   type: boolean
                 ipv6RAConfigs:
                   type: string
+                allowEWTraffic:
+                  type: boolean
                 acls:
                   type: array
                   items:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #3320 
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f920e0</samp>

This pull request adds a new feature to kube-ovn that allows traffic between pods in the same subnet. It modifies the `SubnetSpec` schema and struct, the `UpdateLogicalSwitchACL` method and interface, and the `handleAddOrUpdateSubnet` function. It also adds a new constant and a test case for the feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7f920e0</samp>

> _Sing, O Muse, of the mighty deeds of kube-ovn_
> _The network plugin that spans the clusters of Kubernetes_
> _How they added a new field to the `SubnetSpec` schema_
> _To allow the pods to communicate within the same subnet_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f920e0</samp>

*  Add a new field `AllowSameSubnetTraffic` to the `SubnetSpec` struct and schema to support the same subnet traffic feature in kube-ovn ([link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1737-R1738), [link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aL161-R162))
*  Modify the signature of the `UpdateLogicalSwitchACL` method in the `ACL` and `OVNNbClient` interfaces and structs to accept the subnet CIDR and the same subnet traffic flag as parameters ([link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49L125-R125), [link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L420-R420))
*  Implement the logic to create and append a new ACL for each CIDR that allows traffic between pods in the same subnet in the `UpdateLogicalSwitchACL` method in the `ovn-nb-acl.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L428-R428), [link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6R437-R461))
*  Update the call of the `UpdateLogicalSwitchACL` method in the `handleAddOrUpdateSubnet` function in the `subnet.go` file to pass the subnet CIDR and the same subnet traffic flag as arguments ([link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L853-R853))
*  Define a new constant `AllowSameSubnetPriority` in the `const.go` file to specify the priority of the same subnet ACLs ([link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR147-R148))
*  Update the mock interfaces and recorders in the `interface.go` file to match the real interfaces in the `ovs` package ([link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L1524-R1526), [link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L1532-R1534), [link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L3956-R3958), [link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L3964-R3966))
*  Add a test case for the same subnet traffic feature in the `ovn-nb-acl_test.go` file by passing the subnet CIDR and the same subnet traffic flag to the test method and checking the expected same subnet ACLs ([link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8R658), [link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L677-R678), [link](https://github.com/kubeovn/kube-ovn/pull/3344/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8R684-R699))