### PR TITLE
support ovn ic ecmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,13 +354,13 @@ kind-init-ovn-ic-ipv4: kind-clean-ovn-ic
 	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1,1)
 
 .PHONY: kind-init-ovn-ic-ipv6
-kind-init-ovn-ic-ipv6: kind-clean-ovn-ic kind-init-ipv6
+kind-init-ovn-ic-ipv6: kind-clean-ovn-ic
 	@ovn_ic=true $(MAKE) kind-init-ipv6
 	@ovn_ic=true ip_family=ipv6 $(MAKE) kind-generate-config
 	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1,1)
 
 .PHONY: kind-init-ovn-ic-dual
-kind-init-ovn-ic-dual: kind-clean-ovn-ic kind-init-dual
+kind-init-ovn-ic-dual: kind-clean-ovn-ic
 	@ovn_ic=true $(MAKE) kind-init-dual
 	@ovn_ic=true ip_family=dual $(MAKE) kind-generate-config
 	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1,1)

--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,7 @@ kind-install-ovn-ic: kind-install-ovn-ic-ipv4
 kind-install-ovn-ic-ipv4: kind-install
 	$(call kind_load_image,kube-ovn1,$(REGISTRY)/kube-ovn:$(VERSION))
 	kubectl config use-context kind-kube-ovn1
+	$(MAKE) kind-untaint-control-plane
 	sed -e 's/10.16.0/10.18.0/g' \
 		-e 's/10.96.0/10.98.0/g' \
 		-e 's/100.64.0/100.68.0/g' \
@@ -521,8 +522,8 @@ kind-install-ovn-ic-ipv4: kind-install
 	docker run -d --name ovn-ic-db --network kind $(REGISTRY)/kube-ovn:$(VERSION) bash start-ic-db.sh
 	@set -e; \
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
-	zone=az0 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn1-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1
@@ -546,8 +547,8 @@ kind-install-ovn-ic-ipv6: kind-install-ipv6
 	docker run -d --name ovn-ic-db --network kind -e PROTOCOL="ipv6" $(REGISTRY)/kube-ovn:$(VERSION) bash start-ic-db.sh
 	@set -e; \
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}"); \
-	zone=az0 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn1-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1
@@ -575,8 +576,8 @@ kind-install-ovn-ic-dual: kind-install-dual
 	@set -e; \
 
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
-	zone=az0 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn1-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1

--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,7 @@ kind-install-ovn-ic-ipv4: kind-install
 	@set -e; \
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
 	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn1-worker,kube-ovn1-worker2;kube-ovn1-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1
@@ -548,7 +548,7 @@ kind-install-ovn-ic-ipv6: kind-install-ipv6
 	@set -e; \
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}"); \
 	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn1-worker,kube-ovn1-worker2;kube-ovn1-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1
@@ -577,7 +577,7 @@ kind-install-ovn-ic-dual: kind-install-dual
 
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
 	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2;kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn1-worker,kube-ovn1-worker2;kube-ovn1-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1

--- a/Makefile
+++ b/Makefile
@@ -348,18 +348,21 @@ kind-init-ipv4: kind-clean
 kind-init-ovn-ic: kind-init-ovn-ic-ipv4
 
 .PHONY: kind-init-ovn-ic-ipv4
-kind-init-ovn-ic-ipv4: kind-clean-ovn-ic kind-init
-	@$(MAKE) kind-generate-config
+kind-init-ovn-ic-ipv4: kind-clean-ovn-ic
+	@ovn_ic=true $(MAKE) kind-init
+	@ovn_ic=true $(MAKE) kind-generate-config
 	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1,1)
 
 .PHONY: kind-init-ovn-ic-ipv6
 kind-init-ovn-ic-ipv6: kind-clean-ovn-ic kind-init-ipv6
-	@ip_family=ipv6 $(MAKE) kind-generate-config
+	@ovn_ic=true $(MAKE) kind-init-ipv6
+	@ovn_ic=true ip_family=ipv6 $(MAKE) kind-generate-config
 	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1,1)
 
 .PHONY: kind-init-ovn-ic-dual
 kind-init-ovn-ic-dual: kind-clean-ovn-ic kind-init-dual
-	@ip_family=dual $(MAKE) kind-generate-config
+	@ovn_ic=true $(MAKE) kind-init-dual
+	@ovn_ic=true ip_family=dual $(MAKE) kind-generate-config
 	$(call kind_create_cluster,yamls/kind.yaml,kube-ovn1,1)
 
 .PHONY: kind-init-ovn-submariner

--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-TS_NAME=${TS_NAME:-ts}
-PROTOCOL=${PROTOCOL:-ipv4}
-if [ "$PROTOCOL" = "ipv4" ]; then
-  TS_CIDR=${TS_CIDR:-169.254.100.0/24}
-elif [ "$PROTOCOL" = "ipv6" ]; then
-  TS_CIDR=${TS_CIDR:-fe80:a9fe:64::/112}
-elif [ "$PROTOCOL" = "dual" ]; then
-  TS_CIDR=${TS_CIDR:-"169.254.100.0/24,fe80:a9fe:64::/112"}
-fi
-
 function quit {
     /usr/share/ovn/scripts/ovn-ctl stop_ic_ovsdb
     exit 0
@@ -26,8 +16,6 @@ trap quit EXIT
 if [[ -z "$NODE_IPS" && -z "$LOCAL_IP" ]]; then
     /usr/share/ovn/scripts/ovn-ctl --db-ic-nb-create-insecure-remote=yes --db-ic-sb-create-insecure-remote=yes --db-ic-nb-addr="[::]" --db-ic-sb-addr="[::]" start_ic_ovsdb
     /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
-    ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
-    ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
     tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
 else
     if [[ -z "$LEADER_IP" ]]; then
@@ -40,8 +28,6 @@ else
         --ovn-ic-sb-db="$(gen_conn_str 6648)" \
         start_ic_ovsdb
         /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
-        ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
-        ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
         tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
     else
         echo "follower start with local ${LOCAL_IP}, leader ${LEADER_IP} and cluster $(gen_conn_str 6647)"

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -704,6 +704,20 @@ func (mr *MockLogicalSwitchPortMockRecorder) DeleteLogicalSwitchPort(lspName int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPort", reflect.TypeOf((*MockLogicalSwitchPort)(nil).DeleteLogicalSwitchPort), lspName)
 }
 
+// DeleteLogicalSwitchPorts mocks base method.
+func (m *MockLogicalSwitchPort) DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(*ovnnb.LogicalSwitchPort) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLogicalSwitchPorts", externalIDs, filter)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLogicalSwitchPorts indicates an expected call of DeleteLogicalSwitchPorts.
+func (mr *MockLogicalSwitchPortMockRecorder) DeleteLogicalSwitchPorts(externalIDs, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPorts", reflect.TypeOf((*MockLogicalSwitchPort)(nil).DeleteLogicalSwitchPorts), externalIDs, filter)
+}
+
 // EnablePortLayer2forward mocks base method.
 func (m *MockLogicalSwitchPort) EnablePortLayer2forward(lspName string) error {
 	m.ctrl.T.Helper()
@@ -1897,6 +1911,21 @@ func (mr *MockLogicalRouterPolicyMockRecorder) DeleteLogicalRouterPolicyByUUID(l
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalRouterPolicyByUUID", reflect.TypeOf((*MockLogicalRouterPolicy)(nil).DeleteLogicalRouterPolicyByUUID), lrName, uuid)
 }
 
+// GetLogicalRouterPoliciesByExtID mocks base method.
+func (m *MockLogicalRouterPolicy) GetLogicalRouterPoliciesByExtID(lrName, key, value string) ([]*ovnnb.LogicalRouterPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogicalRouterPoliciesByExtID", lrName, key, value)
+	ret0, _ := ret[0].([]*ovnnb.LogicalRouterPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLogicalRouterPoliciesByExtID indicates an expected call of GetLogicalRouterPoliciesByExtID.
+func (mr *MockLogicalRouterPolicyMockRecorder) GetLogicalRouterPoliciesByExtID(lrName, key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogicalRouterPoliciesByExtID", reflect.TypeOf((*MockLogicalRouterPolicy)(nil).GetLogicalRouterPoliciesByExtID), lrName, key, value)
+}
+
 // GetLogicalRouterPolicy mocks base method.
 func (m *MockLogicalRouterPolicy) GetLogicalRouterPolicy(lrName string, priority int, match string, ignoreNotFound bool) ([]*ovnnb.LogicalRouterPolicy, error) {
 	m.ctrl.T.Helper()
@@ -1913,18 +1942,18 @@ func (mr *MockLogicalRouterPolicyMockRecorder) GetLogicalRouterPolicy(lrName, pr
 }
 
 // ListLogicalRouterPolicies mocks base method.
-func (m *MockLogicalRouterPolicy) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string) ([]*ovnnb.LogicalRouterPolicy, error) {
+func (m *MockLogicalRouterPolicy) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string, ignoreExtIDEmptyValue bool) ([]*ovnnb.LogicalRouterPolicy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLogicalRouterPolicies", lrName, priority, externalIDs)
+	ret := m.ctrl.Call(m, "ListLogicalRouterPolicies", lrName, priority, externalIDs, ignoreExtIDEmptyValue)
 	ret0, _ := ret[0].([]*ovnnb.LogicalRouterPolicy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListLogicalRouterPolicies indicates an expected call of ListLogicalRouterPolicies.
-func (mr *MockLogicalRouterPolicyMockRecorder) ListLogicalRouterPolicies(lrName, priority, externalIDs interface{}) *gomock.Call {
+func (mr *MockLogicalRouterPolicyMockRecorder) ListLogicalRouterPolicies(lrName, priority, externalIDs, ignoreExtIDEmptyValue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogicalRouterPolicies", reflect.TypeOf((*MockLogicalRouterPolicy)(nil).ListLogicalRouterPolicies), lrName, priority, externalIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogicalRouterPolicies", reflect.TypeOf((*MockLogicalRouterPolicy)(nil).ListLogicalRouterPolicies), lrName, priority, externalIDs, ignoreExtIDEmptyValue)
 }
 
 // MockNAT is a mock of NAT interface.
@@ -2890,6 +2919,20 @@ func (mr *MockNbClientMockRecorder) DeleteLogicalSwitchPort(lspName interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPort", reflect.TypeOf((*MockNbClient)(nil).DeleteLogicalSwitchPort), lspName)
 }
 
+// DeleteLogicalSwitchPorts mocks base method.
+func (m *MockNbClient) DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(*ovnnb.LogicalSwitchPort) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLogicalSwitchPorts", externalIDs, filter)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLogicalSwitchPorts indicates an expected call of DeleteLogicalSwitchPorts.
+func (mr *MockNbClientMockRecorder) DeleteLogicalSwitchPorts(externalIDs, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPorts", reflect.TypeOf((*MockNbClient)(nil).DeleteLogicalSwitchPorts), externalIDs, filter)
+}
+
 // DeleteNat mocks base method.
 func (m *MockNbClient) DeleteNat(lrName, natType, externalIP, logicalIP string) error {
 	m.ctrl.T.Helper()
@@ -3018,6 +3061,21 @@ func (m *MockNbClient) GetLogicalRouter(lrName string, ignoreNotFound bool) (*ov
 func (mr *MockNbClientMockRecorder) GetLogicalRouter(lrName, ignoreNotFound interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogicalRouter", reflect.TypeOf((*MockNbClient)(nil).GetLogicalRouter), lrName, ignoreNotFound)
+}
+
+// GetLogicalRouterPoliciesByExtID mocks base method.
+func (m *MockNbClient) GetLogicalRouterPoliciesByExtID(lrName, key, value string) ([]*ovnnb.LogicalRouterPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogicalRouterPoliciesByExtID", lrName, key, value)
+	ret0, _ := ret[0].([]*ovnnb.LogicalRouterPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLogicalRouterPoliciesByExtID indicates an expected call of GetLogicalRouterPoliciesByExtID.
+func (mr *MockNbClientMockRecorder) GetLogicalRouterPoliciesByExtID(lrName, key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogicalRouterPoliciesByExtID", reflect.TypeOf((*MockNbClient)(nil).GetLogicalRouterPoliciesByExtID), lrName, key, value)
 }
 
 // GetLogicalRouterPolicy mocks base method.
@@ -3201,18 +3259,18 @@ func (mr *MockNbClientMockRecorder) ListLogicalRouter(needVendorFilter, filter i
 }
 
 // ListLogicalRouterPolicies mocks base method.
-func (m *MockNbClient) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string) ([]*ovnnb.LogicalRouterPolicy, error) {
+func (m *MockNbClient) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string, ignoreExtIDEmptyValue bool) ([]*ovnnb.LogicalRouterPolicy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLogicalRouterPolicies", lrName, priority, externalIDs)
+	ret := m.ctrl.Call(m, "ListLogicalRouterPolicies", lrName, priority, externalIDs, ignoreExtIDEmptyValue)
 	ret0, _ := ret[0].([]*ovnnb.LogicalRouterPolicy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListLogicalRouterPolicies indicates an expected call of ListLogicalRouterPolicies.
-func (mr *MockNbClientMockRecorder) ListLogicalRouterPolicies(lrName, priority, externalIDs interface{}) *gomock.Call {
+func (mr *MockNbClientMockRecorder) ListLogicalRouterPolicies(lrName, priority, externalIDs, ignoreExtIDEmptyValue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogicalRouterPolicies", reflect.TypeOf((*MockNbClient)(nil).ListLogicalRouterPolicies), lrName, priority, externalIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogicalRouterPolicies", reflect.TypeOf((*MockNbClient)(nil).ListLogicalRouterPolicies), lrName, priority, externalIDs, ignoreExtIDEmptyValue)
 }
 
 // ListLogicalRouterPorts mocks base method.

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -1239,7 +1239,7 @@ func (c *Controller) deletePolicyRouteForLocalDNSCacheOnNode(nodeName string, af
 		"node":            nodeName,
 		"address-family":  strconv.Itoa(af),
 		"isLocalDnsCache": "true",
-	})
+	}, true)
 	if err != nil {
 		klog.Errorf("failed to list logical router policies: %v", err)
 		return err

--- a/pkg/controller/ovn_ic.go
+++ b/pkg/controller/ovn_ic.go
@@ -577,11 +577,11 @@ func (c *Controller) getTSCidr(index int) (string, error) {
 	var cidr string
 	switch defaultSubnet.Spec.Protocol {
 	case kubeovnv1.ProtocolIPv4:
-		cidr = fmt.Sprintf("169.254.%d.0/24", index)
+		cidr = fmt.Sprintf("169.254.%d.0/24", 100+index)
 	case kubeovnv1.ProtocolIPv6:
-		cidr = fmt.Sprintf("fe80:a9fe:64::%04x0000/112", index)
+		cidr = fmt.Sprintf("fe80:a9fe:%02x::/112", 100+index)
 	case kubeovnv1.ProtocolDual:
-		cidr = fmt.Sprintf("169.254.%d.0/24,fe80:a9fe:64::%04x0000/112", index, index)
+		cidr = fmt.Sprintf("169.254.%d.0/24,fe80:a9fe:%02x::/112", 100+index, 100+index)
 	}
 	return cidr, nil
 }

--- a/pkg/controller/ovn_ic.go
+++ b/pkg/controller/ovn_ic.go
@@ -567,3 +567,21 @@ func (c *Controller) getTSName(index int) string {
 	}
 	return tsName
 }
+
+func (c *Controller) getTSCidr(index int) (string, error) {
+	defaultSubnet, err := c.subnetsLister.Get(c.config.DefaultLogicalSwitch)
+	if err != nil {
+		return "", err
+	}
+
+	var cidr string
+	switch defaultSubnet.Spec.Protocol {
+	case kubeovnv1.ProtocolIPv4:
+		cidr = fmt.Sprintf("169.254.%d.0/24", index)
+	case kubeovnv1.ProtocolIPv6:
+		cidr = fmt.Sprintf("fe80:a9fe:64::%04x0000/112", index)
+	case kubeovnv1.ProtocolDual:
+		cidr = fmt.Sprintf("169.254.%d.0/24,fe80:a9fe:64::%04x0000/112", index, index)
+	}
+	return cidr, nil
+}

--- a/pkg/controller/ovn_ic.go
+++ b/pkg/controller/ovn_ic.go
@@ -559,13 +559,10 @@ func (c *Controller) listRemoteLogicalSwitchPortAddress() (*strset.Set, error) {
 }
 
 func (c *Controller) getTSName(index int) string {
-	var tsName string
 	if index == 0 {
-		tsName = util.InterconnectionSwitch
-	} else {
-		tsName = fmt.Sprintf("%s%d", util.InterconnectionSwitch, index)
+		return util.InterconnectionSwitch
 	}
-	return tsName
+	return fmt.Sprintf("%s%d", util.InterconnectionSwitch, index)
 }
 
 func (c *Controller) getTSCidr(index int) (string, error) {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2669,7 +2669,7 @@ func (c *Controller) deletePolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) 
 		"isU2ORoutePolicy": "true",
 		"vendor":           util.CniTypeName,
 		"subnet":           subnet.Name,
-	})
+	}, true)
 	if err != nil {
 		klog.Errorf("failed to list logical router policies: %v", err)
 		return err

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -464,7 +464,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 				return err
 			}
 		} else {
-			policyRouteLogical, err = c.OVNNbClient.ListLogicalRouterPolicies(vpc.Name, -1, nil)
+			policyRouteLogical, err = c.OVNNbClient.ListLogicalRouterPolicies(vpc.Name, -1, nil, true)
 			if err != nil {
 				klog.Errorf("failed to get vpc %s policy route list, %v", vpc.Name, err)
 				return err

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -74,6 +74,7 @@ type LogicalSwitchPort interface {
 	SetLogicalSwitchPortsSecurityGroup(sgName, op string) error
 	EnablePortLayer2forward(lspName string) error
 	DeleteLogicalSwitchPort(lspName string) error
+	DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(lsp *ovnnb.LogicalSwitchPort) bool) error
 	ListLogicalSwitchPorts(needVendorFilter bool, externalIDs map[string]string, filter func(lsp *ovnnb.LogicalSwitchPort) bool) ([]ovnnb.LogicalSwitchPort, error)
 	ListNormalLogicalSwitchPorts(needVendorFilter bool, externalIDs map[string]string) ([]ovnnb.LogicalSwitchPort, error)
 	ListLogicalSwitchPortsWithLegacyExternalIDs() ([]ovnnb.LogicalSwitchPort, error)
@@ -157,8 +158,9 @@ type LogicalRouterPolicy interface {
 	DeleteLogicalRouterPolicyByUUID(lrName, uuid string) error
 	DeleteLogicalRouterPolicyByNexthop(lrName string, priority int, nexthop string) error
 	ClearLogicalRouterPolicy(lrName string) error
-	ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string) ([]*ovnnb.LogicalRouterPolicy, error)
+	ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string, ignoreExtIDEmptyValue bool) ([]*ovnnb.LogicalRouterPolicy, error)
 	GetLogicalRouterPolicy(lrName string, priority int, match string, ignoreNotFound bool) ([]*ovnnb.LogicalRouterPolicy, error)
+	GetLogicalRouterPoliciesByExtID(lrName, key, value string) ([]*ovnnb.LogicalRouterPolicy, error)
 }
 
 type NAT interface {

--- a/pkg/ovs/ovn-nb-logical_router_policy.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy.go
@@ -228,7 +228,6 @@ func (c *OVNNbClient) GetLogicalRouterPolicyByUUID(uuid string) (*ovnnb.LogicalR
 // GetLogicalRouterPoliciesByExtID get logical router policy route by external ID
 func (c *OVNNbClient) GetLogicalRouterPoliciesByExtID(lrName, key, value string) ([]*ovnnb.LogicalRouterPolicy, error) {
 	fnFilter := func(policy *ovnnb.LogicalRouterPolicy) bool {
-
 		if len(policy.ExternalIDs) != 0 {
 			if _, ok := policy.ExternalIDs[key]; ok {
 				return policy.ExternalIDs[key] == value

--- a/pkg/ovs/ovn-nb-logical_router_policy.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
@@ -29,7 +30,7 @@ func (c *OVNNbClient) AddLogicalRouterPolicy(lrName string, priority int, match,
 	var found bool
 	duplicate := make([]string, 0, len(policyList))
 	for _, policy := range policyList {
-		if found || policy.Action != action || (policy.Action == ovnnb.LogicalRouterPolicyActionReroute && !strset.New(nextHops...).IsEqual(strset.New(policy.Nexthops...))) {
+		if found || policy.Action != action || !reflect.DeepEqual(policy.ExternalIDs, externalIDs) || (policy.Action == ovnnb.LogicalRouterPolicyActionReroute && !strset.New(nextHops...).IsEqual(strset.New(policy.Nexthops...))) {
 			duplicate = append(duplicate, policy.UUID)
 		} else {
 			found = true
@@ -109,7 +110,7 @@ func (c *OVNNbClient) DeleteLogicalRouterPolicy(lrName string, priority int, mat
 // DeleteLogicalRouterPolicy delete some policies from logical router once
 func (c *OVNNbClient) DeleteLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string) error {
 	// remove policies from logical router
-	policies, err := c.ListLogicalRouterPolicies(lrName, priority, externalIDs)
+	policies, err := c.ListLogicalRouterPolicies(lrName, priority, externalIDs, false)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -224,16 +225,23 @@ func (c *OVNNbClient) GetLogicalRouterPolicyByUUID(uuid string) (*ovnnb.LogicalR
 	return policy, nil
 }
 
+// GetLogicalRouterPoliciesByExtID get logical router policy route by external ID
 func (c *OVNNbClient) GetLogicalRouterPoliciesByExtID(lrName, key, value string) ([]*ovnnb.LogicalRouterPolicy, error) {
 	fnFilter := func(policy *ovnnb.LogicalRouterPolicy) bool {
-		return len(policy.ExternalIDs) != 0 && policy.ExternalIDs[key] == value
+
+		if len(policy.ExternalIDs) != 0 {
+			if _, ok := policy.ExternalIDs[key]; ok {
+				return policy.ExternalIDs[key] == value
+			}
+		}
+		return false
 	}
 	return c.listLogicalRouterPoliciesByFilter(lrName, fnFilter)
 }
 
 // ListLogicalRouterPolicies list route policy which match the given externalIDs
-func (c *OVNNbClient) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string) ([]*ovnnb.LogicalRouterPolicy, error) {
-	return c.listLogicalRouterPoliciesByFilter(lrName, policyFilter(priority, externalIDs))
+func (c *OVNNbClient) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string, ignoreExtIDEmptyValue bool) ([]*ovnnb.LogicalRouterPolicy, error) {
+	return c.listLogicalRouterPoliciesByFilter(lrName, policyFilter(priority, externalIDs, ignoreExtIDEmptyValue))
 }
 
 // newLogicalRouterPolicy return logical router policy with basic information
@@ -249,7 +257,7 @@ func (c *OVNNbClient) newLogicalRouterPolicy(priority int, match, action string,
 }
 
 // policyFilter filter policies which match the given externalIDs
-func policyFilter(priority int, externalIDs map[string]string) func(policy *ovnnb.LogicalRouterPolicy) bool {
+func policyFilter(priority int, externalIDs map[string]string, ignoreExtIDEmptyValue bool) func(policy *ovnnb.LogicalRouterPolicy) bool {
 	return func(policy *ovnnb.LogicalRouterPolicy) bool {
 		if len(policy.ExternalIDs) < len(externalIDs) {
 			return false
@@ -257,9 +265,10 @@ func policyFilter(priority int, externalIDs map[string]string) func(policy *ovnn
 
 		if len(policy.ExternalIDs) != 0 {
 			for k, v := range externalIDs {
+				// ignoreExtIDEmptyValue is used to the case below:
 				// if only key exist but not value in externalIDs, we should include this lsp,
 				// it's equal to shell command `ovn-nbctl --columns=xx find logical_router_policy external_ids:key!=\"\"`
-				if len(v) == 0 {
+				if len(v) == 0 && ignoreExtIDEmptyValue {
 					if len(policy.ExternalIDs[k]) == 0 {
 						return false
 					}

--- a/pkg/ovs/ovn-nb-logical_router_policy_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy_test.go
@@ -159,7 +159,7 @@ func (suite *OvnClientTestSuite) testDeleteLogicalRouterPolicies() {
 		require.NoError(t, err)
 		require.Len(t, lr.Policies, 3)
 
-		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs)
+		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs, true)
 		require.NoError(t, err)
 		require.Len(t, policies, 3)
 	}
@@ -174,7 +174,7 @@ func (suite *OvnClientTestSuite) testDeleteLogicalRouterPolicies() {
 		require.NoError(t, err)
 		require.Empty(t, lr.Policies)
 
-		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs)
+		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs, true)
 		require.NoError(t, err)
 		require.Empty(t, policies)
 	})
@@ -190,7 +190,7 @@ func (suite *OvnClientTestSuite) testDeleteLogicalRouterPolicies() {
 		require.Len(t, lr.Policies, 2)
 
 		// no basePriority policy
-		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs)
+		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs, true)
 		require.NoError(t, err)
 		require.Len(t, policies, 2)
 	})
@@ -342,7 +342,7 @@ func (suite *OvnClientTestSuite) testPolicyFilter() {
 	}
 
 	t.Run("include all policies", func(t *testing.T) {
-		filterFunc := policyFilter(-1, nil)
+		filterFunc := policyFilter(-1, nil, true)
 		count := 0
 		for _, policy := range policies {
 			if filterFunc(policy) {
@@ -353,7 +353,7 @@ func (suite *OvnClientTestSuite) testPolicyFilter() {
 	})
 
 	t.Run("include all policies with external ids", func(t *testing.T) {
-		filterFunc := policyFilter(-1, map[string]string{"k1": "v1"})
+		filterFunc := policyFilter(-1, map[string]string{"k1": "v1"}, true)
 		count := 0
 		for _, policy := range policies {
 			if filterFunc(policy) {
@@ -364,7 +364,7 @@ func (suite *OvnClientTestSuite) testPolicyFilter() {
 	})
 
 	t.Run("include all policies with same priority", func(t *testing.T) {
-		filterFunc := policyFilter(10000, map[string]string{"k1": "v1"})
+		filterFunc := policyFilter(10000, map[string]string{"k1": "v1"}, true)
 		count := 0
 		for _, policy := range policies {
 			if filterFunc(policy) {

--- a/pkg/ovs/ovn-nb-logical_router_policy_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy_test.go
@@ -381,7 +381,7 @@ func (suite *OvnClientTestSuite) testPolicyFilter() {
 		filterFunc := policyFilter(-1, map[string]string{
 			"k1":  "v1",
 			"key": "value",
-		})
+		}, true)
 		require.False(t, filterFunc(policy))
 	})
 }

--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -18,7 +18,12 @@ import (
 
 func (c *OVNNbClient) ListLogicalRouterStaticRoutesByOption(lrName, _, key, value string) ([]*ovnnb.LogicalRouterStaticRoute, error) {
 	fnFilter := func(route *ovnnb.LogicalRouterStaticRoute) bool {
-		return len(route.Options) != 0 && route.Options[key] == value
+		if len(route.Options) != 0 {
+			if _, ok := route.Options[key]; ok {
+				return route.Options[key] == value
+			}
+		}
+		return false
 	}
 	return c.listLogicalRouterStaticRoutesByFilter(lrName, fnFilter)
 }

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -564,6 +564,31 @@ func (c *OVNNbClient) DeleteLogicalSwitchPort(lspName string) error {
 	return nil
 }
 
+// DeleteLogicalSwitchPorts delete logical switch port from logical switch
+func (c *OVNNbClient) DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(lrp *ovnnb.LogicalSwitchPort) bool) error {
+	lspList, err := c.ListLogicalSwitchPorts(false, externalIDs, filter)
+	if err != nil {
+		klog.Error(err)
+		return fmt.Errorf("list switch ports: %v", err)
+	}
+
+	ops := make([]ovsdb.Operation, 0, len(lspList))
+	for _, lsp := range lspList {
+		op, err := c.DeleteLogicalSwitchPortOp(lsp.Name)
+		if err != nil {
+			klog.Error(err)
+			return fmt.Errorf("generate operations for deleting logical switch port %s: %v", lsp.Name, err)
+		}
+		ops = append(ops, op...)
+	}
+
+	if err := c.Transact("lsps-del", ops); err != nil {
+		return fmt.Errorf("del logical switch ports: %v", err)
+	}
+
+	return nil
+}
+
 // GetLogicalSwitchPort get logical switch port by name
 func (c *OVNNbClient) GetLogicalSwitchPort(lspName string, ignoreNotFound bool) (*ovnnb.LogicalSwitchPort, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -236,6 +236,7 @@ const (
 	OvnICKey       = "origin"
 	OvnICConnected = "connected"
 	OvnICStatic    = "static"
+	OvnICNone      = ""
 
 	MatchV4Src = "ip4.src"
 	MatchV4Dst = "ip4.dst"

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -230,7 +231,11 @@ var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 		ginkgo.By("Waiting for ecmp gateway to be applied")
 		time.Sleep(15 * time.Second)
 
-		checkECMPCount(3)
+		if frameworks[0].ClusterIPFamily == apiv1.ProtocolDual {
+			checkECMPCount(6)
+		} else {
+			checkECMPCount(3)
+		}
 		fnCheckPodHTTP()
 
 		ginkgo.By("Case 3: Changing the ConfigMap in cluster to half ha and half ecmp")
@@ -238,7 +243,11 @@ var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 		ginkgo.By("Waiting for half gateway to be applied")
 		time.Sleep(15 * time.Second)
 
-		checkECMPCount(2)
+		if frameworks[0].ClusterIPFamily == apiv1.ProtocolDual {
+			checkECMPCount(4)
+		} else {
+			checkECMPCount(2)
+		}
 		fnCheckPodHTTP()
 	})
 })

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
-	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/kind"
@@ -210,6 +209,7 @@ var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 	})
 
 	framework.ConformanceIt("should be able to update gateway to ecmp or HA ", func() {
+		frameworks[0].SkipVersionPriorTo(1, 13, "This feature was introduced in v1.13")
 		gwNodes := make([]string, len(clusters))
 		for i := range clusters {
 			ginkgo.By("fetching the ConfigMap in cluster " + clusters[i])
@@ -242,7 +242,7 @@ var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 		ginkgo.By("Waiting for half gateway to be applied")
 		time.Sleep(15 * time.Second)
 
-		if frameworks[0].ClusterIPFamily == apiv1.ProtocolDual {
+		if frameworks[0].ClusterIPFamily == "dual" {
 			checkECMPCount(4)
 		} else {
 			checkECMPCount(2)

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -237,7 +237,7 @@ var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 		}
 		fnCheckPodHTTP()
 
-		ginkgo.By("Case 3: Changing the ConfigMap in cluster to half ha and half ecmp")
+		ginkgo.By("Case 3: Changing the ConfigMap in cluster to ha + ecmp")
 		changeGatewayType("half", gwNodes, clientSets)
 		ginkgo.By("Waiting for half gateway to be applied")
 		time.Sleep(15 * time.Second)

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -230,8 +230,7 @@ var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 		changeGatewayType("ecmp", gwNodes, clientSets)
 		ginkgo.By("Waiting for ecmp gateway to be applied")
 		time.Sleep(15 * time.Second)
-
-		if frameworks[0].ClusterIPFamily == apiv1.ProtocolDual {
+		if frameworks[0].ClusterIPFamily == "dual" {
 			checkECMPCount(6)
 		} else {
 			checkECMPCount(3)

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -260,7 +260,7 @@ func changeGatewayType(gatewayType string, gwNodes []string, clientSets []client
 		case "ecmp":
 			gatewayStr = strings.ReplaceAll(gwNodes[index], ",", ";")
 		case "half":
-			gatewayStr = strings.Replace(gwNodes[index], ",", ";", 1)
+			gatewayStr = gwNodes[index]
 		}
 		framework.Logf("check gatewayStr %s ", gatewayStr)
 		configMapPatchPayload, err := json.Marshal(corev1.ConfigMap{

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -209,7 +209,6 @@ var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 	})
 
 	framework.ConformanceIt("should be able to update gateway to ecmp or HA ", func() {
-
 		gwNodes := make([]string, len(clusters))
 		for i := range clusters {
 			ginkgo.By("fetching the ConfigMap in cluster " + clusters[i])

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/kind"

--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -10,6 +10,9 @@
 {%- if ha is not defined -%}
   {%- set ha = "false" -%}
 {%- endif -%}
+{%- if ovn_ic is not defined -%}
+  {%- set ovn_ic = "false" -%}
+{%- endif -%}
 {%- if single is not defined -%}
   {%- set single = "false" -%}
 {%- endif -%}
@@ -78,7 +81,7 @@ nodes:
     image: kindest/node:{{ k8s_version }}
     labels:
       kube-ovn/role: master
-  {%- else %}
+  {%- elif ovn_ic is equalto "true" %}
   - role: worker
     image: kindest/node:{{ k8s_version }}
   {%- endif %}

--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -78,5 +78,8 @@ nodes:
     image: kindest/node:{{ k8s_version }}
     labels:
       kube-ovn/role: master
+  {%- else %}
+  - role: worker
+    image: kindest/node:{{ k8s_version }}
   {%- endif %}
 {%- endif %}


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0efe216</samp>

This pull request implements and tests the new design of the interconnection feature for kind clusters, which uses multiple logical switches and ports instead of one shared switch and port. It also fixes a dependency issue with the k8s.io/endpointslice module and adds some comments and external IDs to improve the code readability and reliability. The changes affect the `Makefile`, `mocks/pkg/ovs/interface.go`, `pkg/controller/ovn-ic.go`, `test/e2e/ovn-ic/e2e_test.go`, `go.mod`, `pkg/ovs/interface.go`, `pkg/ovs/ovn-nb-logical_router_policy.go`, and `yamls/kind.yaml.j2` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0efe216</samp>

> _We're the crew of the `ovn-ic`, we sail the k8s sea_
> _We interconnect the clusters with switches and policies_
> _We heave and haul the `LogicalRouterPolicy` on the count of three_
> _We fix the go.mod and the kind.yaml with glee_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0efe216</samp>

*  Add a replace directive to fix a dependency issue with k8s.io/endpointslice ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R304))
*  Modify the Makefile to create two worker nodes and a control plane node for each kind cluster, and to remove the taint from the control plane node ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R514), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L524-R526), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L549-R551), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L578-R580))
  - Modify the `establishInterConnection` function to create one logical switch and one logical patch port for each gateway node, and to simplify the logic ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL185-R194), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL207-R272))
  - Remove the `waitTsReady` function, which is no longer needed ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL300))
  - Replace the `waitTsReady` function with the `createTS` function, which creates a logical switch with the external ID of the subnet ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL342-R361))
  - Modify the `syncOneRouteToPolicy` function to use the `GetLogicalRouterPoliciesByExtID` method, which gets the logical router policies by the external ID of the cluster, and to improve the performance and readability of the code ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR464-R470), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL473-R510))
  - Modify the test cases to check for the existence of the logical switch ts0 and the logical switch ports ts0-az in each cluster ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-9863eb35d8583ef7d80cd732249f5a3c26f07d92915f448b6dcec20c87d87a2eL143-R143), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-9863eb35d8583ef7d80cd732249f5a3c26f07d92915f448b6dcec20c87d87a2eL153-R156), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-9863eb35d8583ef7d80cd732249f5a3c26f07d92915f448b6dcec20c87d87a2eL199-R202))
*  Add the `GetLogicalRouterPoliciesByExtID` method to the `LogicalRouterPolicy` and `NbClient` interfaces, and implement the method in the `ovn-nb-logical_router_policy.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49R143), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R1677-R1691), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R2729-R2743), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8R227))
*  Modify the `removeInterConnection` function to comment out some lines that delete the logical router ports and the logical switches, and to add a TODO comment to use external ID to delete ports ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL168-R181))
*  Rename the `startOvnIC` and `stopOvnIC` functions to `startOVNIC` and `stopOVNIC`, and remove some redundant error logs ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL306-R309), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL326), [link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL332-R337))
*  Modify the `acquireLrpAddress` function to fix some typos in the error messages, and to remove the line that checks the protocol of the logical switch port address ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL275-R284))
*  Add an import statement for the `github.com/kubeovn/kube-ovn/pkg/ovs` package to the `pkg/controller/ovn-ic.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR21))
*  Add some lines to the `yamls/kind.yaml.j2` file to specify that the node is a worker node, and to set the image to the kindest/node with the k8s version variable ([link](https://github.com/kubeovn/kube-ovn/pull/3348/files?diff=unified&w=0#diff-f88bb6992159e270ea78e286f19bfd123e4a87bcdb6307eadacc2d06dd6265f4R81-R83))