### PR TITLE
fix pod access svc ip failed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -300,6 +300,7 @@ replace (
 	k8s.io/cri-api => k8s.io/cri-api v0.28.3
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.28.3
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.28.3
+	k8s.io/endpointslice => k8s.io/endpointslice v0.28.3
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.28.3
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.28.3
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.28.3

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -204,7 +204,7 @@ func (c *OVNNbClient) CreateNodeACL(pgName, nodeIPStr, joinIPStr string) error {
 		}
 		pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
 
-		allowIngressACL, err := c.newACL(pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowStateless)
+		allowIngressACL, err := c.newACL(pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowRelated)
 		if err != nil {
 			klog.Error(err)
 			return fmt.Errorf("new allow ingress acl for port group %s: %v", pgName, err)
@@ -217,7 +217,7 @@ func (c *OVNNbClient) CreateNodeACL(pgName, nodeIPStr, joinIPStr string) error {
 			acl.Options["apply-after-lb"] = "true"
 		}
 
-		allowEgressACL, err := c.newACL(pgName, ovnnb.ACLDirectionFromLport, util.NodeAllowPriority, fmt.Sprintf("%s.dst == %s && %s.src == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowStateless, options)
+		allowEgressACL, err := c.newACL(pgName, ovnnb.ACLDirectionFromLport, util.NodeAllowPriority, fmt.Sprintf("%s.dst == %s && %s.src == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowRelated, options)
 		if err != nil {
 			klog.Error(err)
 			return fmt.Errorf("new allow egress acl for port group %s: %v", pgName, err)

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -361,7 +361,7 @@ func (suite *OvnClientTestSuite) testCreateNodeACL() {
 	checkACL := func(pg *ovnnb.PortGroup, direction, priority, match string, options map[string]string) {
 		acl, err := ovnClient.GetACL(pg.Name, direction, priority, match, false)
 		require.NoError(t, err)
-		expect := newACL(pg.Name, direction, priority, match, ovnnb.ACLActionAllowStateless)
+		expect := newACL(pg.Name, direction, priority, match, ovnnb.ACLActionAllowRelated)
 		expect.UUID = acl.UUID
 		if len(options) != 0 {
 			expect.Options = options


### PR DESCRIPTION
fix pod access svc ip failed


- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #3347

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae9db5c</samp>

This pull request updates the ACL actions to support host network policy and fixes a module dependency issue for Kubernetes 1.22. It modifies the files `pkg/ovs/ovn-nb-acl.go` and `go.mod`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ae9db5c</samp>

> _To fix a k8s issue with slices_
> _We use a replace directive, which suffices_
> _To avoid a breakage_
> _In the API usage_
> _And keep our go.mod free of vices_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae9db5c</samp>

*  Override the k8s.io/endpointslice module version to fix compatibility with Kubernetes 1.22 ([link](https://github.com/kubeovn/kube-ovn/pull/3349/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R303))
*  Change the ACL actions from allow-stateless to allow-related to enable stateful traffic between pods and nodes ([link](https://github.com/kubeovn/kube-ovn/pull/3349/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L207-R207), [link](https://github.com/kubeovn/kube-ovn/pull/3349/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L220-R220))