### PR TITLE
fix access svc ip failed, when acl is on

### DIFF
--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -204,7 +204,7 @@ func (c *OVNNbClient) CreateNodeACL(pgName, nodeIPStr, joinIPStr string) error {
 		}
 		pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
 
-		allowIngressACL, err := c.newACL(pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowStateless)
+		allowIngressACL, err := c.newACL(pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, fmt.Sprintf("%s.src == %s && %s.dst == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowRelated)
 		if err != nil {
 			klog.Error(err)
 			return fmt.Errorf("new allow ingress acl for port group %s: %v", pgName, err)
@@ -217,7 +217,7 @@ func (c *OVNNbClient) CreateNodeACL(pgName, nodeIPStr, joinIPStr string) error {
 			acl.Options["apply-after-lb"] = "true"
 		}
 
-		allowEgressACL, err := c.newACL(pgName, ovnnb.ACLDirectionFromLport, util.NodeAllowPriority, fmt.Sprintf("%s.dst == %s && %s.src == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowStateless, options)
+		allowEgressACL, err := c.newACL(pgName, ovnnb.ACLDirectionFromLport, util.NodeAllowPriority, fmt.Sprintf("%s.dst == %s && %s.src == $%s", ipSuffix, nodeIP, ipSuffix, pgAs), ovnnb.ACLActionAllowRelated, options)
 		if err != nil {
 			klog.Error(err)
 			return fmt.Errorf("new allow egress acl for port group %s: %v", pgName, err)

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -361,7 +361,7 @@ func (suite *OvnClientTestSuite) testCreateNodeACL() {
 	checkACL := func(pg *ovnnb.PortGroup, direction, priority, match string, options map[string]string) {
 		acl, err := ovnClient.GetACL(pg.Name, direction, priority, match, false)
 		require.NoError(t, err)
-		expect := newACL(pg.Name, direction, priority, match, ovnnb.ACLActionAllowStateless)
+		expect := newACL(pg.Name, direction, priority, match, ovnnb.ACLActionAllowRelated)
 		expect.UUID = acl.UUID
 		if len(options) != 0 {
 			expect.Options = options


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9a9bac</samp>

This pull request enables connection tracking for node port services by changing the ACL actions in `ovn-nb-acl.go` and updating the corresponding test case in `ovn-nb-acl_test.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e9a9bac</samp>

> _To track connections for node port services_
> _We changed the ACL actions with purpose_
> _We updated the test case_
> _For the `CreateNodeACL` base_
> _To expect the `related` action, not `stateless`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9a9bac</samp>

*  Modify the action of the node port group ACLs to allow related traffic instead of stateless traffic, to support connection tracking for node port services ([link](https://github.com/kubeovn/kube-ovn/pull/3350/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L207-R207), [link](https://github.com/kubeovn/kube-ovn/pull/3350/files?diff=unified&w=0#diff-cebcd3f05c126053ae717f2f1e1fae98b5b1112936636b0d6ee8ba860932b7c6L220-R220))
* Update the test case for the `CreateNodeACL` function in `ovn-nb-acl_test.go` to expect the related action for the node port group ACLs ([link](https://github.com/kubeovn/kube-ovn/pull/3350/files?diff=unified&w=0#diff-5fec517e195bd3aa2f06602f2c19f83df3351068b887f6ffbc5710ff974d96b8L364-R364))