### PR TITLE
add e2e case for netpol

### DIFF
--- a/test/e2e/kube-ovn/network-policy/network-policy.go
+++ b/test/e2e/kube-ovn/network-policy/network-policy.go
@@ -159,9 +159,9 @@ var _ = framework.SerialDescribe("[group:network-policy]", func() {
 					{
 						From: []netv1.NetworkPolicyPeer{
 							{
-								nil,
-								nil,
-								&netv1.IPBlock{CIDR: "0.0.0.0/0", Except: []string{"127.0.0.1/32"}},
+								PodSelector:       nil,
+								NamespaceSelector: nil,
+								IPBlock:           &netv1.IPBlock{CIDR: "0.0.0.0/0", Except: []string{"127.0.0.1/32"}},
 							},
 						},
 					},


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79c2175</samp>

Add a new test case for network policy with host network pods. Use a new variable `defaultServiceClient` to access the default service in the cluster.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 79c2175</samp>

> _Oh we're the network policy crew_
> _And we've got a job to do_
> _We'll add a `defaultServiceClient` on the count of three_
> _And test the ingress with host network pods, yo ho ho and a bottle of tea_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 79c2175</samp>

* Declare and assign a variable to access the default service in the cluster ([link](https://github.com/kubeovn/kube-ovn/pull/3355/files?diff=unified&w=0#diff-868e7ebfcb4861e0393f42b737960b56592067c1747f20c53331653a692bd1c2R33), [link](https://github.com/kubeovn/kube-ovn/pull/3355/files?diff=unified&w=0#diff-868e7ebfcb4861e0393f42b737960b56592067c1747f20c53331653a692bd1c2R43)) in file `test/e2e/kube-ovn/network-policy/network-policy.go`