### PR TITLE
support aap through vip crd using selector

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1490,6 +1490,10 @@ spec:
                   type: string
                 pmac:
                   type: string
+                selector:
+                  type: array
+                  items:
+                    type: string
                 conditions:
                   type: array
                   items:
@@ -1532,6 +1536,10 @@ spec:
                   type: string
                 parentV6ip:
                   type: string
+                selector:
+                  type: array
+                  items:
+                    type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2029,6 +2029,10 @@ spec:
                   type: string
                 pmac:
                   type: string
+                selector:
+                  type: array
+                  items:
+                    type: string
                 conditions:
                   type: array
                   items:
@@ -2071,6 +2075,10 @@ spec:
                   type: string
                 parentV6ip:
                   type: string
+                selector:
+                  type: array
+                  items:
+                    type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -657,6 +657,20 @@ func (mr *MockLogicalSwitchPortMockRecorder) CreateLogicalSwitchPort(lsName, lsp
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogicalSwitchPort", reflect.TypeOf((*MockLogicalSwitchPort)(nil).CreateLogicalSwitchPort), lsName, lspName, ip, mac, podName, namespace, portSecurity, securityGroups, vips, enableDHCP, dhcpOptions, vpc)
 }
 
+// CreateVirtualLogicalSwitchPort mocks base method.
+func (m *MockLogicalSwitchPort) CreateVirtualLogicalSwitchPort(lspName, lsName, ip string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVirtualLogicalSwitchPort", lspName, lsName, ip)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateVirtualLogicalSwitchPort indicates an expected call of CreateVirtualLogicalSwitchPort.
+func (mr *MockLogicalSwitchPortMockRecorder) CreateVirtualLogicalSwitchPort(lspName, lsName, ip interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVirtualLogicalSwitchPort", reflect.TypeOf((*MockLogicalSwitchPort)(nil).CreateVirtualLogicalSwitchPort), lspName, lsName, ip)
+}
+
 // CreateVirtualLogicalSwitchPorts mocks base method.
 func (m *MockLogicalSwitchPort) CreateVirtualLogicalSwitchPorts(lsName string, ips ...string) error {
 	m.ctrl.T.Helper()
@@ -819,6 +833,20 @@ func (m *MockLogicalSwitchPort) SetLogicalSwitchPortSecurity(portSecurity bool, 
 func (mr *MockLogicalSwitchPortMockRecorder) SetLogicalSwitchPortSecurity(portSecurity, lspName, mac, ips, vips interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortSecurity", reflect.TypeOf((*MockLogicalSwitchPort)(nil).SetLogicalSwitchPortSecurity), portSecurity, lspName, mac, ips, vips)
+}
+
+// SetLogicalSwitchPortVirtualParent mocks base method.
+func (m *MockLogicalSwitchPort) SetLogicalSwitchPortVirtualParent(lsName, parents string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLogicalSwitchPortVirtualParent", lsName, parents)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLogicalSwitchPortVirtualParent indicates an expected call of SetLogicalSwitchPortVirtualParent.
+func (mr *MockLogicalSwitchPortMockRecorder) SetLogicalSwitchPortVirtualParent(lsName, parents interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortVirtualParent", reflect.TypeOf((*MockLogicalSwitchPort)(nil).SetLogicalSwitchPortVirtualParent), lsName, parents)
 }
 
 // SetLogicalSwitchPortVirtualParents mocks base method.
@@ -2530,6 +2558,20 @@ func (mr *MockNbClientMockRecorder) CreateSgDenyAllACL(sgName interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSgDenyAllACL", reflect.TypeOf((*MockNbClient)(nil).CreateSgDenyAllACL), sgName)
 }
 
+// CreateVirtualLogicalSwitchPort mocks base method.
+func (m *MockNbClient) CreateVirtualLogicalSwitchPort(lspName, lsName, ip string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVirtualLogicalSwitchPort", lspName, lsName, ip)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateVirtualLogicalSwitchPort indicates an expected call of CreateVirtualLogicalSwitchPort.
+func (mr *MockNbClientMockRecorder) CreateVirtualLogicalSwitchPort(lspName, lsName, ip interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVirtualLogicalSwitchPort", reflect.TypeOf((*MockNbClient)(nil).CreateVirtualLogicalSwitchPort), lspName, lsName, ip)
+}
+
 // CreateVirtualLogicalSwitchPorts mocks base method.
 func (m *MockNbClient) CreateVirtualLogicalSwitchPorts(lsName string, ips ...string) error {
 	m.ctrl.T.Helper()
@@ -3760,6 +3802,20 @@ func (m *MockNbClient) SetLogicalSwitchPortSecurity(portSecurity bool, lspName, 
 func (mr *MockNbClientMockRecorder) SetLogicalSwitchPortSecurity(portSecurity, lspName, mac, ips, vips interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortSecurity", reflect.TypeOf((*MockNbClient)(nil).SetLogicalSwitchPortSecurity), portSecurity, lspName, mac, ips, vips)
+}
+
+// SetLogicalSwitchPortVirtualParent mocks base method.
+func (m *MockNbClient) SetLogicalSwitchPortVirtualParent(lsName, parents string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLogicalSwitchPortVirtualParent", lsName, parents)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLogicalSwitchPortVirtualParent indicates an expected call of SetLogicalSwitchPortVirtualParent.
+func (mr *MockNbClientMockRecorder) SetLogicalSwitchPortVirtualParent(lsName, parents interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortVirtualParent", reflect.TypeOf((*MockNbClient)(nil).SetLogicalSwitchPortVirtualParent), lsName, parents)
 }
 
 // SetLogicalSwitchPortVirtualParents mocks base method.

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -835,20 +835,6 @@ func (mr *MockLogicalSwitchPortMockRecorder) SetLogicalSwitchPortSecurity(portSe
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortSecurity", reflect.TypeOf((*MockLogicalSwitchPort)(nil).SetLogicalSwitchPortSecurity), portSecurity, lspName, mac, ips, vips)
 }
 
-// SetLogicalSwitchPortVirtualParent mocks base method.
-func (m *MockLogicalSwitchPort) SetLogicalSwitchPortVirtualParent(lsName, parents string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetLogicalSwitchPortVirtualParent", lsName, parents)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetLogicalSwitchPortVirtualParent indicates an expected call of SetLogicalSwitchPortVirtualParent.
-func (mr *MockLogicalSwitchPortMockRecorder) SetLogicalSwitchPortVirtualParent(lsName, parents interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortVirtualParent", reflect.TypeOf((*MockLogicalSwitchPort)(nil).SetLogicalSwitchPortVirtualParent), lsName, parents)
-}
-
 // SetLogicalSwitchPortVirtualParents mocks base method.
 func (m *MockLogicalSwitchPort) SetLogicalSwitchPortVirtualParents(lsName, parents string, ips ...string) error {
 	m.ctrl.T.Helper()
@@ -894,6 +880,20 @@ func (m *MockLogicalSwitchPort) SetLogicalSwitchPortsSecurityGroup(sgName, op st
 func (mr *MockLogicalSwitchPortMockRecorder) SetLogicalSwitchPortsSecurityGroup(sgName, op interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortsSecurityGroup", reflect.TypeOf((*MockLogicalSwitchPort)(nil).SetLogicalSwitchPortsSecurityGroup), sgName, op)
+}
+
+// SetVirtualLogicalSwitchPortVirtualParents mocks base method.
+func (m *MockLogicalSwitchPort) SetVirtualLogicalSwitchPortVirtualParents(lsName, parents string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetVirtualLogicalSwitchPortVirtualParents", lsName, parents)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetVirtualLogicalSwitchPortVirtualParents indicates an expected call of SetVirtualLogicalSwitchPortVirtualParents.
+func (mr *MockLogicalSwitchPortMockRecorder) SetVirtualLogicalSwitchPortVirtualParents(lsName, parents interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVirtualLogicalSwitchPortVirtualParents", reflect.TypeOf((*MockLogicalSwitchPort)(nil).SetVirtualLogicalSwitchPortVirtualParents), lsName, parents)
 }
 
 // MockLoadBalancer is a mock of LoadBalancer interface.
@@ -3804,20 +3804,6 @@ func (mr *MockNbClientMockRecorder) SetLogicalSwitchPortSecurity(portSecurity, l
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortSecurity", reflect.TypeOf((*MockNbClient)(nil).SetLogicalSwitchPortSecurity), portSecurity, lspName, mac, ips, vips)
 }
 
-// SetLogicalSwitchPortVirtualParent mocks base method.
-func (m *MockNbClient) SetLogicalSwitchPortVirtualParent(lsName, parents string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetLogicalSwitchPortVirtualParent", lsName, parents)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetLogicalSwitchPortVirtualParent indicates an expected call of SetLogicalSwitchPortVirtualParent.
-func (mr *MockNbClientMockRecorder) SetLogicalSwitchPortVirtualParent(lsName, parents interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPortVirtualParent", reflect.TypeOf((*MockNbClient)(nil).SetLogicalSwitchPortVirtualParent), lsName, parents)
-}
-
 // SetLogicalSwitchPortVirtualParents mocks base method.
 func (m *MockNbClient) SetLogicalSwitchPortVirtualParents(lsName, parents string, ips ...string) error {
 	m.ctrl.T.Helper()
@@ -3905,6 +3891,20 @@ func (m *MockNbClient) SetUseCtInvMatch() error {
 func (mr *MockNbClientMockRecorder) SetUseCtInvMatch() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUseCtInvMatch", reflect.TypeOf((*MockNbClient)(nil).SetUseCtInvMatch))
+}
+
+// SetVirtualLogicalSwitchPortVirtualParents mocks base method.
+func (m *MockNbClient) SetVirtualLogicalSwitchPortVirtualParents(lsName, parents string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetVirtualLogicalSwitchPortVirtualParents", lsName, parents)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetVirtualLogicalSwitchPortVirtualParents indicates an expected call of SetVirtualLogicalSwitchPortVirtualParents.
+func (mr *MockNbClientMockRecorder) SetVirtualLogicalSwitchPortVirtualParents(lsName, parents interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVirtualLogicalSwitchPortVirtualParents", reflect.TypeOf((*MockNbClient)(nil).SetVirtualLogicalSwitchPortVirtualParents), lsName, parents)
 }
 
 // Transact mocks base method.

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -808,6 +808,7 @@ type VipSpec struct {
 	ParentV4ip    string   `json:"parentV4ip"`
 	ParentV6ip    string   `json:"parentV6ip"`
 	ParentMac     string   `json:"parentMac"`
+	Selector      []string `json:"selector"`
 	AttachSubnets []string `json:"attachSubnets"`
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -118,11 +118,12 @@ type Controller struct {
 	ipsLister kubeovnlister.IPLister
 	ipSynced  cache.InformerSynced
 
-	virtualIpsLister     kubeovnlister.VipLister
-	virtualIpsSynced     cache.InformerSynced
-	addVirtualIPQueue    workqueue.RateLimitingInterface
-	updateVirtualIPQueue workqueue.RateLimitingInterface
-	delVirtualIPQueue    workqueue.RateLimitingInterface
+	virtualIpsLister          kubeovnlister.VipLister
+	virtualIpsSynced          cache.InformerSynced
+	addVirtualIPQueue         workqueue.RateLimitingInterface
+	updateVirtualIPQueue      workqueue.RateLimitingInterface
+	updateVirtualParentsQueue workqueue.RateLimitingInterface
+	delVirtualIPQueue         workqueue.RateLimitingInterface
 
 	iptablesEipsLister     kubeovnlister.IptablesEIPLister
 	iptablesEipSynced      cache.InformerSynced
@@ -354,11 +355,12 @@ func Run(ctx context.Context, config *Configuration) {
 		ipsLister: ipInformer.Lister(),
 		ipSynced:  ipInformer.Informer().HasSynced,
 
-		virtualIpsLister:     virtualIPInformer.Lister(),
-		virtualIpsSynced:     virtualIPInformer.Informer().HasSynced,
-		addVirtualIPQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AddVirtualIp"),
-		updateVirtualIPQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdateVirtualIp"),
-		delVirtualIPQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeleteVirtualIp"),
+		virtualIpsLister:          virtualIPInformer.Lister(),
+		virtualIpsSynced:          virtualIPInformer.Informer().HasSynced,
+		addVirtualIPQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AddVirtualIp"),
+		updateVirtualIPQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdateVirtualIp"),
+		updateVirtualParentsQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "UpdateVirtualParents"),
+		delVirtualIPQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DeleteVirtualIp"),
 
 		iptablesEipsLister:     iptablesEipInformer.Lister(),
 		iptablesEipSynced:      iptablesEipInformer.Informer().HasSynced,
@@ -876,6 +878,7 @@ func (c *Controller) shutdown() {
 
 	c.addVirtualIPQueue.ShutDown()
 	c.updateVirtualIPQueue.ShutDown()
+	c.updateVirtualParentsQueue.ShutDown()
 	c.delVirtualIPQueue.ShutDown()
 
 	c.addIptablesEipQueue.ShutDown()
@@ -1097,6 +1100,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 
 	go wait.Until(c.runAddVirtualIPWorker, time.Second, ctx.Done())
 	go wait.Until(c.runUpdateVirtualIPWorker, time.Second, ctx.Done())
+	go wait.Until(c.runUpdateVirtualParentsWorker, time.Second, ctx.Done())
 	go wait.Until(c.runDelVirtualIPWorker, time.Second, ctx.Done())
 
 	go wait.Until(c.runAddIptablesEipWorker, time.Second, ctx.Done())

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -256,14 +256,14 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 	newPod := newObj.(*v1.Pod)
 
 	if !reflect.DeepEqual(oldPod.Labels, newPod.Labels) || !reflect.DeepEqual(oldPod.Annotations, newPod.Annotations) {
-		oldAaps := strings.Split(oldPod.Annotations[util.AAPAnnotation], ",")
-		newAaps := strings.Split(newPod.Annotations[util.AAPAnnotation], ",")
-		if oldAaps != nil || newAaps != nil {
+		oldAAPs := strings.Split(oldPod.Annotations[util.AAPAnnotation], ",")
+		newAAPs := strings.Split(newPod.Annotations[util.AAPAnnotation], ",")
+		if oldAAPs != nil || newAAPs != nil {
 			var vipNames []string
-			vipNames = append(vipNames, oldAaps...)
-			for _, newAap := range newAaps {
-				if !slices.Contains(vipNames, newAap) {
-					vipNames = append(vipNames, newAap)
+			vipNames = append(vipNames, oldAAPs...)
+			for _, newAAP := range newAAPs {
+				if !slices.Contains(vipNames, newAAP) {
+					vipNames = append(vipNames, newAAP)
 				}
 			}
 			for _, vipName := range vipNames {
@@ -271,7 +271,8 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 					if vip.Spec.Namespace != newPod.Namespace {
 						continue
 					}
-					c.updateVirtualIPQueue.Add(vipName)
+					klog.Infof("enqueue update virtual parents for %s", vipName)
+					c.updateVirtualParentsQueue.Add(vipName)
 				}
 			}
 		}
@@ -969,7 +970,8 @@ func (c *Controller) handleDeletePod(key string) error {
 				if vip.Spec.Namespace != pod.Namespace {
 					continue
 				}
-				c.updateVirtualIPQueue.Add(vipName)
+				klog.Infof("enqueue update virtual parents for %s", vipName)
+				c.updateVirtualParentsQueue.Add(vipName)
 			}
 		}
 	}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -255,7 +255,7 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 	oldPod := oldObj.(*v1.Pod)
 	newPod := newObj.(*v1.Pod)
 
-	if !reflect.DeepEqual(oldPod.Labels, newPod.Labels) || !reflect.DeepEqual(oldPod.Annotations, newPod.Annotations) {
+	if oldPod.Annotations[util.AAPAnnotation] != newPod.Annotations[util.AAPAnnotation] {
 		oldAAPs := strings.Split(oldPod.Annotations[util.AAPAnnotation], ",")
 		newAAPs := strings.Split(newPod.Annotations[util.AAPAnnotation], ",")
 		if oldAAPs != nil || newAAPs != nil {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -255,9 +255,9 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 	oldPod := oldObj.(*v1.Pod)
 	newPod := newObj.(*v1.Pod)
 
-	if oldPod.Annotations[util.AAPAnnotation] != newPod.Annotations[util.AAPAnnotation] {
-		oldAAPs := strings.Split(oldPod.Annotations[util.AAPAnnotation], ",")
-		newAAPs := strings.Split(newPod.Annotations[util.AAPAnnotation], ",")
+	if oldPod.Annotations[util.AAPsAnnotation] != newPod.Annotations[util.AAPsAnnotation] {
+		oldAAPs := strings.Split(oldPod.Annotations[util.AAPsAnnotation], ",")
+		newAAPs := strings.Split(newPod.Annotations[util.AAPsAnnotation], ",")
 		if oldAAPs != nil || newAAPs != nil {
 			var vipNames []string
 			vipNames = append(vipNames, oldAAPs...)
@@ -964,7 +964,7 @@ func (c *Controller) handleDeletePod(key string) error {
 		return nil
 	}
 
-	if aaps := strings.Split(pod.Annotations[util.AAPAnnotation], ","); aaps != nil {
+	if aaps := strings.Split(pod.Annotations[util.AAPsAnnotation], ","); aaps != nil {
 		for _, vipName := range aaps {
 			if vip, err := c.virtualIpsLister.Get(vipName); err == nil {
 				if vip.Spec.Namespace != pod.Namespace {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -253,6 +254,42 @@ func (c *Controller) enqueueDeletePod(obj interface{}) {
 func (c *Controller) enqueueUpdatePod(oldObj, newObj interface{}) {
 	oldPod := oldObj.(*v1.Pod)
 	newPod := newObj.(*v1.Pod)
+
+	if !reflect.DeepEqual(oldPod.Labels, newPod.Labels) {
+		vips, err := c.virtualIpsLister.List(labels.SelectorFromSet(labels.Set{
+			util.SubnetNameLabel: newPod.Annotations[util.LogicalSwitchAnnotation],
+		}))
+		if err != nil {
+			klog.Error(err)
+			return
+		}
+		for _, vip := range vips {
+			lspName := fmt.Sprintf("%s-vip-%s", vip.Spec.Subnet, vip.Status.V4ip)
+			lsp, err := c.OVNNbClient.GetLogicalSwitchPort(lspName, true)
+			if err != nil {
+				klog.Error(err)
+				return
+			}
+			if lsp != nil {
+				virtualParents := strings.Split(lsp.Options["virtual-parents"], ",")
+				if slices.Contains(virtualParents, fmt.Sprintf("%s.%s", newPod.Name, newPod.Namespace)) {
+					c.updateVirtualIPQueue.Add(vip.Name)
+					continue
+				}
+				for _, v := range vip.Spec.Selector {
+					parts := strings.Split(strings.TrimSpace(v), ":")
+					if len(parts) != 2 {
+						continue
+					}
+					if newPod.Labels[strings.TrimSpace(parts[0])] == strings.TrimSpace(parts[1]) {
+						c.updateVirtualIPQueue.Add(vip.Name)
+						break
+					}
+				}
+			}
+		}
+	}
+
 	if oldPod.ResourceVersion == newPod.ResourceVersion {
 		return
 	}
@@ -1047,7 +1084,27 @@ func (c *Controller) handleDeletePod(key string) error {
 	}
 	for _, podNet := range podNets {
 		c.syncVirtualPortsQueue.Add(podNet.Subnet.Name)
+		vips, err := c.virtualIpsLister.List(labels.SelectorFromSet(labels.Set{
+			util.SubnetNameLabel: podNet.Subnet.Name,
+		}))
+		if err != nil {
+			klog.Error(err)
+			return err
+		}
+		for _, vip := range vips {
+			lspName := fmt.Sprintf("%s-vip-%s", vip.Spec.Subnet, vip.Status.V4ip)
+			lsp, err := c.OVNNbClient.GetLogicalSwitchPort(lspName, true)
+			if err != nil {
+				klog.Error(err)
+				return err
+			}
+			virtualParents := strings.Split(lsp.Options["virtual-parents"], ",")
+			if slices.Contains(virtualParents, fmt.Sprintf("%s.%s", pod.Name, pod.Namespace)) {
+				c.updateVirtualIPQueue.Add(vip.Name)
+			}
+		}
 	}
+
 	return nil
 }
 

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -425,7 +425,7 @@ func (c *Controller) handleUpdateVirtualParents(key string) error {
 	}
 	// add new virtual port if not exist
 	if err = c.OVNNbClient.CreateVirtualLogicalSwitchPort(cachedVip.Name, cachedVip.Spec.Subnet, cachedVip.Status.V4ip); err != nil {
-		klog.Errorf("create virtual port with vip %s from logical switch %s: %v", cachedVip.Status.V4ip, cachedVip.Spec.Subnet, err)
+		klog.Errorf("create virtual port with vip %s from logical switch %s: %v", cachedVip.Name, cachedVip.Spec.Subnet, err)
 		return err
 	}
 
@@ -462,8 +462,9 @@ func (c *Controller) handleUpdateVirtualParents(key string) error {
 		}
 	}
 
-	if err = c.OVNNbClient.SetLogicalSwitchPortVirtualParent(cachedVip.Name, strings.Join(virtualParents, ",")); err != nil {
-		klog.Errorf("set vip %s virtual parents %s: %v", cachedVip.Name, virtualParents, err)
+	parents := strings.Join(virtualParents, ",")
+	if err = c.OVNNbClient.SetVirtualLogicalSwitchPortVirtualParents(cachedVip.Name, parents); err != nil {
+		klog.Errorf("set vip %s virtual parents %s: %v", cachedVip.Name, parents, err)
 		return err
 	}
 

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -446,6 +446,11 @@ func (c *Controller) handleUpdateVirtualParents(key string) error {
 
 	var virtualParents []string
 	for _, pod := range pods {
+		if pod.Annotations == nil {
+			err = fmt.Errorf("pod annotations have not been initialized")
+			klog.Error(err)
+			return err
+		}
 		if aaps := strings.Split(pod.Annotations[util.AAPsAnnotation], ","); !slices.Contains(aaps, cachedVip.Name) {
 			continue
 		}

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -446,7 +446,7 @@ func (c *Controller) handleUpdateVirtualParents(key string) error {
 
 	var virtualParents []string
 	for _, pod := range pods {
-		if aaps := strings.Split(pod.Annotations[util.AAPAnnotation], ","); !slices.Contains(aaps, cachedVip.Name) {
+		if aaps := strings.Split(pod.Annotations[util.AAPsAnnotation], ","); !slices.Contains(aaps, cachedVip.Name) {
 			continue
 		}
 		podNets, err := c.getPodKubeovnNets(pod)

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -62,8 +62,10 @@ type LogicalSwitchPort interface {
 	CreateBareLogicalSwitchPort(lsName, lspName, ip, mac string) error
 	CreateLocalnetLogicalSwitchPort(lsName, lspName, provider string, vlanID int) error
 	CreateVirtualLogicalSwitchPorts(lsName string, ips ...string) error
+	CreateVirtualLogicalSwitchPort(lspName, lsName, ip string) error
 	SetLogicalSwitchPortSecurity(portSecurity bool, lspName, mac, ips, vips string) error
 	SetLogicalSwitchPortVirtualParents(lsName, parents string, ips ...string) error
+	SetLogicalSwitchPortVirtualParent(lsName, parents string) error
 	SetLogicalSwitchPortArpProxy(lspName string, enableArpProxy bool) error
 	SetLogicalSwitchPortExternalIds(lspName string, externalIds map[string]string) error
 	SetLogicalSwitchPortVlanTag(lspName string, vlanID int) error

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -62,10 +62,12 @@ type LogicalSwitchPort interface {
 	CreateBareLogicalSwitchPort(lsName, lspName, ip, mac string) error
 	CreateLocalnetLogicalSwitchPort(lsName, lspName, provider string, vlanID int) error
 	CreateVirtualLogicalSwitchPorts(lsName string, ips ...string) error
+	// create virtual type logical switch port for allowed-address-pair
 	CreateVirtualLogicalSwitchPort(lspName, lsName, ip string) error
+	// update virtual type logical switch port virtual-parents for allowed-address-pair
+	SetVirtualLogicalSwitchPortVirtualParents(lsName, parents string) error
 	SetLogicalSwitchPortSecurity(portSecurity bool, lspName, mac, ips, vips string) error
 	SetLogicalSwitchPortVirtualParents(lsName, parents string, ips ...string) error
-	SetLogicalSwitchPortVirtualParent(lsName, parents string) error
 	SetLogicalSwitchPortArpProxy(lspName string, enableArpProxy bool) error
 	SetLogicalSwitchPortExternalIds(lspName string, externalIds map[string]string) error
 	SetLogicalSwitchPortVlanTag(lspName string, vlanID int) error

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -185,7 +185,7 @@ func (c *OVNNbClient) CreateVirtualLogicalSwitchPorts(lsName string, ips ...stri
 	return nil
 }
 
-// CreateVirtualLogicalSwitchPort create one virtual type logical switch for aap
+// CreateVirtualLogicalSwitchPort create one virtual type logical switch port for allowed-address-pair
 func (c *OVNNbClient) CreateVirtualLogicalSwitchPort(lspName, lsName, ip string) error {
 	exist, err := c.LogicalSwitchPortExists(lspName)
 	if err != nil {
@@ -214,7 +214,7 @@ func (c *OVNNbClient) CreateVirtualLogicalSwitchPort(lspName, lsName, ip string)
 	}
 
 	if err := c.Transact("lsp-add", op); err != nil {
-		return fmt.Errorf("create virtual logical switch ports for logical switch %s: %v", lsName, err)
+		return fmt.Errorf("create virtual logical switch port %s for logical switch %s: %v", lspName, lsName, err)
 	}
 
 	return nil
@@ -290,8 +290,8 @@ func (c *OVNNbClient) SetLogicalSwitchPortVirtualParents(lsName, parents string,
 	return nil
 }
 
-// CreateVirtualLogicalSwitchPort update one virtual type logical switch port virtual-parents
-func (c *OVNNbClient) SetLogicalSwitchPortVirtualParent(lspName, parents string) error {
+// CreateVirtualLogicalSwitchPort update one virtual type logical switch port virtual-parents for allowed-address-pair
+func (c *OVNNbClient) SetVirtualLogicalSwitchPortVirtualParents(lspName, parents string) error {
 	lsp, err := c.GetLogicalSwitchPort(lspName, true)
 	if err != nil {
 		klog.Error(err)

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -185,6 +185,41 @@ func (c *OVNNbClient) CreateVirtualLogicalSwitchPorts(lsName string, ips ...stri
 	return nil
 }
 
+// CreateVirtualLogicalSwitchPort create one virtual type logical switch for aap
+func (c *OVNNbClient) CreateVirtualLogicalSwitchPort(lspName, lsName, ip string) error {
+	exist, err := c.LogicalSwitchPortExists(lspName)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	// ignore
+	if exist {
+		return nil
+	}
+
+	lsp := &ovnnb.LogicalSwitchPort{
+		UUID: ovsclient.NamedUUID(),
+		Name: lspName,
+		Type: "virtual",
+		Options: map[string]string{
+			"virtual-ip": ip,
+		},
+	}
+
+	op, err := c.CreateLogicalSwitchPortOp(lsp, lsName)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	if err := c.Transact("lsp-add", op); err != nil {
+		return fmt.Errorf("create virtual logical switch ports for logical switch %s: %v", lsName, err)
+	}
+
+	return nil
+}
+
 // CreateBareLogicalSwitchPort create logical switch port with basic configuration
 func (c *OVNNbClient) CreateBareLogicalSwitchPort(lsName, lspName, ip, mac string) error {
 	exist, err := c.LogicalSwitchPortExists(lspName)
@@ -250,6 +285,31 @@ func (c *OVNNbClient) SetLogicalSwitchPortVirtualParents(lsName, parents string,
 	}
 
 	if err := c.Transact("lsp-update", ops); err != nil {
+		return fmt.Errorf("set logical switch port virtual-parents %v", err)
+	}
+	return nil
+}
+
+// CreateVirtualLogicalSwitchPort update one virtual type logical switch port virtual-parents
+func (c *OVNNbClient) SetLogicalSwitchPortVirtualParent(lspName, parents string) error {
+	lsp, err := c.GetLogicalSwitchPort(lspName, true)
+	if err != nil {
+		klog.Error(err)
+		return fmt.Errorf("get logical switch port %s: %v", lspName, err)
+	}
+
+	lsp.Options["virtual-parents"] = parents
+	if len(parents) == 0 {
+		delete(lsp.Options, "virtual-parents")
+	}
+
+	op, err := c.UpdateLogicalSwitchPortOp(lsp, &lsp.Options)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	if err := c.Transact("lsp-update", op); err != nil {
 		return fmt.Errorf("set logical switch port virtual-parents %v", err)
 	}
 	return nil

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -21,6 +21,7 @@ const (
 	FipEnableAnnotation  = "ovn.kubernetes.io/enable_fip"
 	FipFinalizer         = "ovn.kubernetes.io/fip"
 	VipAnnotation        = "ovn.kubernetes.io/vip"
+	AAPAnnotation        = "ovn.kubernetes.io/aaps"
 	ChassisAnnotation    = "ovn.kubernetes.io/chassis"
 
 	ExternalIPAnnotation         = "ovn.kubernetes.io/external_ip"

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -21,7 +21,7 @@ const (
 	FipEnableAnnotation  = "ovn.kubernetes.io/enable_fip"
 	FipFinalizer         = "ovn.kubernetes.io/fip"
 	VipAnnotation        = "ovn.kubernetes.io/vip"
-	AAPAnnotation        = "ovn.kubernetes.io/aaps"
+	AAPsAnnotation       = "ovn.kubernetes.io/aaps"
 	ChassisAnnotation    = "ovn.kubernetes.io/chassis"
 
 	ExternalIPAnnotation         = "ovn.kubernetes.io/external_ip"

--- a/pkg/webhook/vip.go
+++ b/pkg/webhook/vip.go
@@ -47,7 +47,7 @@ func (v *ValidatingHook) VipUpdateHook(ctx context.Context, req admission.Reques
 				return ctrlwebhook.Errored(http.StatusBadRequest, err)
 			}
 		} else {
-			err := fmt.Errorf("vip has been assigned,not support change")
+			err := fmt.Errorf("vip has been assigned, not support change")
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
 	}

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -1801,6 +1801,10 @@ spec:
                   type: string
                 pmac:
                   type: string
+                selector:
+                  type: array
+                  items:
+                    type: string
                 conditions:
                   type: array
                   items:
@@ -1843,6 +1847,10 @@ spec:
                   type: string
                 parentV6ip:
                   type: string
+                selector:
+                  type: array
+                  items:
+                    type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features

1、vip supports both manual allocation and automatic allocation.
2、adding or deleting vips through subnet.spec.vips will update the subnet, configuring aap through vip crd avoids this problem and is easy to manage vips.
3、vip crd supports selector. Users can flexibly configure whether to enable aap through label. The same pod supports multiple aaps.

### Which issue(s) this PR fixes:
Fixes #3318 
Fixes #3187 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0f259f</samp>

This pull request adds a feature to support virtual IP for vlan in kube-ovn. It introduces the `selector` field in the CRD schemas of `Vlan` and `Vip` resources, and updates the controller logic to handle pod label changes and pod deletion events for virtual IP. It also modifies the `VipSpec` struct in `pkg/apis/kubeovn/v1/types.go` to include the `selector` field.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c0f259f</samp>

> _Oh we are the coders of the `kubeovn` crew_
> _And we've got a feature that is shiny and new_
> _We'll add a `selector` field to the `Vip` and `Vlan`_
> _And we'll heave away and haul on the count of three_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0f259f</samp>

*  Add `selector` field to `VlanSpec` and `VipSpec` schemas to specify pod label selectors for vlan and virtual IP ([link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1493-R1496), [link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1539-R1542), [link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1804-R1807), [link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R1850-R1853))
*  Add `Selector` field to `VipSpec` struct in `pkg/apis/kubeovn/v1/types.go` to represent pod label selectors for virtual IP ([link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR811))
*  Add `reflect` and `slices` packages to `pkg/controller/vip.go` and `pkg/controller/pod.go` to provide functions for comparing values and working with slices ([link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R9), [link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0R8-R9))
*  Add `syncVirtualParents` function to `pkg/controller/vip.go` to create and update virtual port and its virtual parents based on virtual IP selector ([link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0R386-R446))
*  Call `syncVirtualParents` function in `handleAddVirtualIP` and `handleUpdateVirtualIP` functions in `pkg/controller/vip.go` if virtual IP has a v4ip assigned ([link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0R251-R255), [link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0R268-R272))
*  Delete virtual port associated with deleted virtual IP from logical switch in `handleDelVirtualIP` function in `pkg/controller/vip.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0R327-R332))
*  Enqueue virtual IP for update if `selector` field has changed in `enqueueUpdateVirtualIP` function in `pkg/controller/vip.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L47-R50))
*  List and enqueue virtual IPs that belong to the same subnet as the updated or deleted pod and match the pod labels or are virtual parents of the virtual port in `handleUpdatePod` and `handleDeletePod` functions in `pkg/controller/pod.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R257-R292), [link](https://github.com/kubeovn/kube-ovn/pull/3359/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1050-R1107))