### PR TITLE
kube-ovn-controller: fix memory growth caused by unused workqueue

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -131,11 +131,10 @@ type Controller struct {
 	resetIptablesEipQueue  workqueue.RateLimitingInterface
 	delIptablesEipQueue    workqueue.RateLimitingInterface
 
-	podAnnotatedIptablesEipLister      v1.PodLister
-	podAnnotatedIptablesEipSynced      cache.InformerSynced
-	addPodAnnotatedIptablesEipQueue    workqueue.RateLimitingInterface
-	updatePodAnnotatedIptablesEipQueue workqueue.RateLimitingInterface
-	delPodAnnotatedIptablesEipQueue    workqueue.RateLimitingInterface
+	podAnnotatedIptablesEipLister   v1.PodLister
+	podAnnotatedIptablesEipSynced   cache.InformerSynced
+	addPodAnnotatedIptablesEipQueue workqueue.RateLimitingInterface
+	delPodAnnotatedIptablesEipQueue workqueue.RateLimitingInterface
 
 	iptablesFipsLister     kubeovnlister.IptablesFIPRuleLister
 	iptablesFipSynced      cache.InformerSynced
@@ -143,11 +142,10 @@ type Controller struct {
 	updateIptablesFipQueue workqueue.RateLimitingInterface
 	delIptablesFipQueue    workqueue.RateLimitingInterface
 
-	podAnnotatedIptablesFipLister      v1.PodLister
-	podAnnotatedIptablesFipSynced      cache.InformerSynced
-	addPodAnnotatedIptablesFipQueue    workqueue.RateLimitingInterface
-	updatePodAnnotatedIptablesFipQueue workqueue.RateLimitingInterface
-	delPodAnnotatedIptablesFipQueue    workqueue.RateLimitingInterface
+	podAnnotatedIptablesFipLister   v1.PodLister
+	podAnnotatedIptablesFipSynced   cache.InformerSynced
+	addPodAnnotatedIptablesFipQueue workqueue.RateLimitingInterface
+	delPodAnnotatedIptablesFipQueue workqueue.RateLimitingInterface
 
 	iptablesDnatRulesLister     kubeovnlister.IptablesDnatRuleLister
 	iptablesDnatRuleSynced      cache.InformerSynced
@@ -367,11 +365,10 @@ func Run(ctx context.Context, config *Configuration) {
 		resetIptablesEipQueue:  workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "ResetIptablesEip"),
 		delIptablesEipQueue:    workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "DeleteIptablesEip"),
 
-		podAnnotatedIptablesEipLister:      podAnnotatedIptablesEipInformer.Lister(),
-		podAnnotatedIptablesEipSynced:      podAnnotatedIptablesEipInformer.Informer().HasSynced,
-		addPodAnnotatedIptablesEipQueue:    workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "AddPodAnnotatedIptablesEip"),
-		updatePodAnnotatedIptablesEipQueue: workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "UpdatePodAnnotatedIptablesEip"),
-		delPodAnnotatedIptablesEipQueue:    workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "DeletePodAnnotatedIptablesEip"),
+		podAnnotatedIptablesEipLister:   podAnnotatedIptablesEipInformer.Lister(),
+		podAnnotatedIptablesEipSynced:   podAnnotatedIptablesEipInformer.Informer().HasSynced,
+		addPodAnnotatedIptablesEipQueue: workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "AddPodAnnotatedIptablesEip"),
+		delPodAnnotatedIptablesEipQueue: workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "DeletePodAnnotatedIptablesEip"),
 
 		iptablesFipsLister:     iptablesFipInformer.Lister(),
 		iptablesFipSynced:      iptablesFipInformer.Informer().HasSynced,
@@ -379,11 +376,10 @@ func Run(ctx context.Context, config *Configuration) {
 		updateIptablesFipQueue: workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "UpdateIptablesFip"),
 		delIptablesFipQueue:    workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "DeleteIptablesFip"),
 
-		podAnnotatedIptablesFipLister:      podAnnotatedIptablesFipInformer.Lister(),
-		podAnnotatedIptablesFipSynced:      podAnnotatedIptablesFipInformer.Informer().HasSynced,
-		addPodAnnotatedIptablesFipQueue:    workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "AddPodAnnotatedIptablesFip"),
-		updatePodAnnotatedIptablesFipQueue: workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "UpdatePodAnnotatedIptablesFip"),
-		delPodAnnotatedIptablesFipQueue:    workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "DeletePodAnnotatedIptablesFip"),
+		podAnnotatedIptablesFipLister:   podAnnotatedIptablesFipInformer.Lister(),
+		podAnnotatedIptablesFipSynced:   podAnnotatedIptablesFipInformer.Informer().HasSynced,
+		addPodAnnotatedIptablesFipQueue: workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "AddPodAnnotatedIptablesFip"),
+		delPodAnnotatedIptablesFipQueue: workqueue.NewNamedRateLimitingQueue(custCrdRateLimiter, "DeletePodAnnotatedIptablesFip"),
 
 		iptablesDnatRulesLister:     iptablesDnatRuleInformer.Lister(),
 		iptablesDnatRuleSynced:      iptablesDnatRuleInformer.Informer().HasSynced,
@@ -916,15 +912,12 @@ func (c *Controller) shutdown() {
 	c.updateOvnDnatRuleQueue.ShutDown()
 	c.delOvnDnatRuleQueue.ShutDown()
 
-	if c.config.PodDefaultFipType == util.IptablesFip {
-		c.addPodAnnotatedIptablesEipQueue.ShutDown()
-		c.updatePodAnnotatedIptablesEipQueue.ShutDown()
-		c.delPodAnnotatedIptablesEipQueue.ShutDown()
+	c.addPodAnnotatedIptablesEipQueue.ShutDown()
+	c.delPodAnnotatedIptablesEipQueue.ShutDown()
 
-		c.addPodAnnotatedIptablesFipQueue.ShutDown()
-		c.updatePodAnnotatedIptablesFipQueue.ShutDown()
-		c.delPodAnnotatedIptablesFipQueue.ShutDown()
-	}
+	c.addPodAnnotatedIptablesFipQueue.ShutDown()
+	c.delPodAnnotatedIptablesFipQueue.ShutDown()
+
 	if c.config.EnableNP {
 		c.updateNpQueue.ShutDown()
 		c.deleteNpQueue.ShutDown()
@@ -1120,13 +1113,11 @@ func (c *Controller) startWorkers(ctx context.Context) {
 	go wait.Until(c.runUpdateQoSPolicyWorker, time.Second, ctx.Done())
 	go wait.Until(c.runDelQoSPolicyWorker, time.Second, ctx.Done())
 
-	if c.config.PodDefaultFipType == util.IptablesFip {
-		go wait.Until(c.runAddPodAnnotatedIptablesEipWorker, time.Second, ctx.Done())
-		go wait.Until(c.runDelPodAnnotatedIptablesEipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runAddPodAnnotatedIptablesEipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runDelPodAnnotatedIptablesEipWorker, time.Second, ctx.Done())
 
-		go wait.Until(c.runAddPodAnnotatedIptablesFipWorker, time.Second, ctx.Done())
-		go wait.Until(c.runDelPodAnnotatedIptablesFipWorker, time.Second, ctx.Done())
-	}
+	go wait.Until(c.runAddPodAnnotatedIptablesFipWorker, time.Second, ctx.Done())
+	go wait.Until(c.runDelPodAnnotatedIptablesFipWorker, time.Second, ctx.Done())
 }
 
 func (c *Controller) allSubnetReady(subnets ...string) (bool, error) {

--- a/pkg/controller/pod_iptables_eip.go
+++ b/pkg/controller/pod_iptables_eip.go
@@ -167,6 +167,13 @@ func (c *Controller) processNextAddPodAnnotatedIptablesEipWorkItem() bool {
 	if shutdown {
 		return false
 	}
+
+	if c.config.PodDefaultFipType != util.IptablesFip {
+		c.addPodAnnotatedIptablesEipQueue.Forget(obj)
+		c.addPodAnnotatedIptablesEipQueue.Done(obj)
+		return true
+	}
+
 	err := func(obj interface{}) error {
 		defer c.addPodAnnotatedIptablesEipQueue.Done(obj)
 		var key string
@@ -195,6 +202,13 @@ func (c *Controller) processNextDeletePodAnnotatedIptablesEipWorkItem() bool {
 	if shutdown {
 		return false
 	}
+
+	if c.config.PodDefaultFipType != util.IptablesFip {
+		c.delPodAnnotatedIptablesEipQueue.Forget(obj)
+		c.delPodAnnotatedIptablesEipQueue.Done(obj)
+		return true
+	}
+
 	err := func(obj interface{}) error {
 		defer c.delPodAnnotatedIptablesEipQueue.Done(obj)
 		var pod *v1.Pod

--- a/pkg/controller/pod_iptables_fip.go
+++ b/pkg/controller/pod_iptables_fip.go
@@ -155,6 +155,13 @@ func (c *Controller) processNextAddPodAnnotatedIptablesFipWorkItem() bool {
 	if shutdown {
 		return false
 	}
+
+	if c.config.PodDefaultFipType != util.IptablesFip {
+		c.addPodAnnotatedIptablesFipQueue.Forget(obj)
+		c.addPodAnnotatedIptablesFipQueue.Done(obj)
+		return true
+	}
+
 	err := func(obj interface{}) error {
 		defer c.addPodAnnotatedIptablesFipQueue.Done(obj)
 		var key string
@@ -183,6 +190,13 @@ func (c *Controller) processNextDeletePodAnnotatedIptablesFipWorkItem() bool {
 	if shutdown {
 		return false
 	}
+
+	if c.config.PodDefaultFipType != util.IptablesFip {
+		c.delPodAnnotatedIptablesFipQueue.Forget(obj)
+		c.delPodAnnotatedIptablesFipQueue.Done(obj)
+		return true
+	}
+
 	err := func(obj interface{}) error {
 		defer c.delPodAnnotatedIptablesFipQueue.Done(obj)
 		var pod *v1.Pod


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes


### Which issue(s) this PR fixes:
Fixes #3365

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68e9f5f</samp>

This pull request simplifies the pod update work queues and adds configuration checks for iptables eip and fip rules. It removes the unused `updatePodAnnotatedIptablesEipQueue` and `updatePodAnnotatedIptablesFipQueue` fields and workers from the `Controller` struct and file `pkg/controller/controller.go`. It also adds conditions to check the `PodDefaultFipType` configuration in the `pkg/controller/pod_iptables_eip.go` and `pkg/controller/pod_iptables_fip.go` files, which handle the iptables eip and fip rules for pods.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 68e9f5f</samp>

> _To handle pod updates with ease_
> _We removed some redundant work queues_
> _We also added checks_
> _For `PodDefaultFipType`_
> _To skip iptables rules we don't need_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68e9f5f</samp>

*  Remove redundant work queues for pod updates that affect iptables eip and fip rules ([link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L134-R137), [link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L146-R148), [link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L370-R371), [link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L382-R382), [link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L919-R920), [link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1L1123-R1120))
*  Add conditions to check `PodDefaultFipType` configuration before creating or deleting iptables eip and fip rules for pods ([link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-2d73329e26ec408ad10253e5352451fb5d5db2bac81ebb1ead0e546e8df7e061R170-R176), [link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-2d73329e26ec408ad10253e5352451fb5d5db2bac81ebb1ead0e546e8df7e061R205-R211), [link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-2960c0e4e70cbdd9f919fdbb4ededdc0afc2afc91ae80ef40dacad94560d285bR158-R164), [link](https://github.com/kubeovn/kube-ovn/pull/3366/files?diff=unified&w=0#diff-2960c0e4e70cbdd9f919fdbb4ededdc0afc2afc91ae80ef40dacad94560d285bR193-R199))