### PR TITLE
subnet support config mtu

### DIFF
--- a/charts/templates/kube-ovn-crd.yaml
+++ b/charts/templates/kube-ovn-crd.yaml
@@ -1714,6 +1714,10 @@ spec:
                       - 253 # default
                       - 254 # main
                       - 255 # local
+                mtu:
+                  type: integer
+                  minimum: 68
+                  maximum: 65535
                 private:
                   type: boolean
                 vlan:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2254,6 +2254,10 @@ spec:
                       - 253 # default
                       - 254 # main
                       - 255 # local
+                mtu:
+                  type: integer
+                  minimum: 68
+                  maximum: 65535
                 private:
                   type: boolean
                 vlan:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -140,6 +140,7 @@ type SubnetSpec struct {
 	ExternalEgressGateway string `json:"externalEgressGateway,omitempty"`
 	PolicyRoutingPriority uint32 `json:"policyRoutingPriority,omitempty"`
 	PolicyRoutingTableID  uint32 `json:"policyRoutingTableID,omitempty"`
+	Mtu                   uint32 `json:"mtu,omitempty"`
 
 	Private      bool     `json:"private"`
 	AllowSubnets []string `json:"allowSubnets,omitempty"`

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -625,7 +625,7 @@ func (c *Controller) updateSubnetDHCPOption(subnet *kubeovnv1.Subnet, needRouter
 	if subnet.Spec.Mtu > 0 {
 		mtu = int(subnet.Spec.Mtu)
 	} else {
-		mtu := util.DefaultMTU
+		mtu = util.DefaultMTU
 		if subnet.Spec.Vlan == "" {
 			switch c.config.NetworkType {
 			case util.NetworkTypeVlan:

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -621,20 +621,25 @@ func (c *Controller) checkSubnetConflict(subnet *kubeovnv1.Subnet) error {
 }
 
 func (c *Controller) updateSubnetDHCPOption(subnet *kubeovnv1.Subnet, needRouter bool) error {
-	mtu := util.DefaultMTU
-	if subnet.Spec.Vlan == "" {
-		switch c.config.NetworkType {
-		case util.NetworkTypeVlan:
-			// default to geneve
-			fallthrough
-		case util.NetworkTypeGeneve:
-			mtu -= util.GeneveHeaderLength
-		case util.NetworkTypeVxlan:
-			mtu -= util.VxlanHeaderLength
-		case util.NetworkTypeStt:
-			mtu -= util.SttHeaderLength
-		default:
-			return fmt.Errorf("invalid network type: %s", c.config.NetworkType)
+	var mtu int
+	if subnet.Spec.Mtu > 0 {
+		mtu = int(subnet.Spec.Mtu)
+	} else {
+		mtu := util.DefaultMTU
+		if subnet.Spec.Vlan == "" {
+			switch c.config.NetworkType {
+			case util.NetworkTypeVlan:
+				// default to geneve
+				fallthrough
+			case util.NetworkTypeGeneve:
+				mtu -= util.GeneveHeaderLength
+			case util.NetworkTypeVxlan:
+				mtu -= util.VxlanHeaderLength
+			case util.NetworkTypeStt:
+				mtu -= util.SttHeaderLength
+			default:
+				return fmt.Errorf("invalid network type: %s", c.config.NetworkType)
+			}
 		}
 	}
 

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -255,29 +255,33 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 
 		var mtu int
-		if providerNetwork != "" && !podSubnet.Spec.LogicalGateway && !podSubnet.Spec.U2OInterconnection {
-			node, err := csh.Controller.nodesLister.Get(csh.Config.NodeName)
-			if err != nil {
-				errMsg := fmt.Errorf("failed to get node %s: %v", csh.Config.NodeName, err)
-				klog.Error(errMsg)
-				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
-					klog.Errorf("failed to write response: %v", err)
-				}
-				return
-			}
-			mtuStr := node.Labels[fmt.Sprintf(util.ProviderNetworkMtuTemplate, providerNetwork)]
-			if mtuStr != "" {
-				if mtu, err = strconv.Atoi(mtuStr); err != nil || mtu <= 0 {
-					errMsg := fmt.Errorf("failed to parse provider network MTU %s: %v", mtuStr, err)
+		if podSubnet.Spec.Mtu > 0 {
+			mtu = int(podSubnet.Spec.Mtu)
+		} else {
+			if providerNetwork != "" && !podSubnet.Spec.LogicalGateway && !podSubnet.Spec.U2OInterconnection {
+				node, err := csh.Controller.nodesLister.Get(csh.Config.NodeName)
+				if err != nil {
+					errMsg := fmt.Errorf("failed to get node %s: %v", csh.Config.NodeName, err)
 					klog.Error(errMsg)
 					if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 						klog.Errorf("failed to write response: %v", err)
 					}
 					return
 				}
+				mtuStr := node.Labels[fmt.Sprintf(util.ProviderNetworkMtuTemplate, providerNetwork)]
+				if mtuStr != "" {
+					if mtu, err = strconv.Atoi(mtuStr); err != nil || mtu <= 0 {
+						errMsg := fmt.Errorf("failed to parse provider network MTU %s: %v", mtuStr, err)
+						klog.Error(errMsg)
+						if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
+							klog.Errorf("failed to write response: %v", err)
+						}
+						return
+					}
+				}
+			} else {
+				mtu = csh.Config.MTU
 			}
-		} else {
-			mtu = csh.Config.MTU
 		}
 
 		routes = append(podRequest.Routes, routes...)

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -1249,7 +1249,7 @@ var _ = framework.Describe("[group:subnet]", func() {
 	framework.ConformanceIt("should support customize mtu of all pods in subnet", func() {
 		ginkgo.By("Creating subnet " + subnetName)
 		subnet = framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
-		subnet.Spec.Mtu = 1100
+		subnet.Spec.Mtu = 1600
 		subnet = subnetClient.CreateSync(subnet)
 
 		ginkgo.By("Creating pod " + podName)

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -1245,6 +1245,31 @@ var _ = framework.Describe("[group:subnet]", func() {
 		checkNatPolicyRules(f, cs, fakeSubnet, fakeCidrV4, fakeCidrV6, false)
 		checkNatPolicyIPsets(f, cs, fakeSubnet, fakeCidrV4, fakeCidrV6, false)
 	})
+
+	framework.ConformanceIt("should support customize mtu of all pods in subnet", func() {
+
+		ginkgo.By("Creating subnet " + subnetName)
+		subnet = framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
+		subnet.Spec.Mtu = 1100
+		subnet = subnetClient.CreateSync(subnet)
+
+		ginkgo.By("Creating pod " + podName)
+		annotations := map[string]string{
+			util.LogicalSwitchAnnotation: subnetName,
+		}
+
+		pod := framework.MakePod(namespaceName, podName, nil, annotations, framework.AgnhostImage, nil, nil)
+		_ = podClient.CreateSync(pod)
+
+		ginkgo.By("Validating pod MTU")
+		links, err := iproute.AddressShow("eth0", func(cmd ...string) ([]byte, []byte, error) {
+			return framework.KubectlExec(namespaceName, podName, cmd...)
+		})
+		framework.ExpectNoError(err)
+		framework.ExpectHaveLen(links, 1, "should get eth0 information")
+		framework.ExpectEqual(links[0].Mtu, int(subnet.Spec.Mtu))
+
+	})
 })
 
 func checkNatPolicyIPsets(f *framework.Framework, cs clientset.Interface, subnet *apiv1.Subnet, cidrV4, cidrV6 string, shouldExist bool) {

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -1247,7 +1247,6 @@ var _ = framework.Describe("[group:subnet]", func() {
 	})
 
 	framework.ConformanceIt("should support customize mtu of all pods in subnet", func() {
-
 		ginkgo.By("Creating subnet " + subnetName)
 		subnet = framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
 		subnet.Spec.Mtu = 1100
@@ -1268,7 +1267,6 @@ var _ = framework.Describe("[group:subnet]", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectHaveLen(links, 1, "should get eth0 information")
 		framework.ExpectEqual(links[0].Mtu, int(subnet.Spec.Mtu))
-
 	})
 })
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -2025,6 +2025,10 @@ spec:
                       - 253 # default
                       - 254 # main
                       - 255 # local
+                mtu:
+                  type: integer
+                  minimum: 68
+                  maximum: 65535
                 private:
                   type: boolean
                 vlan:


### PR DESCRIPTION
- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR
Examples of user facing changes:
- Features
- Bug fixes
- Docs
- Tests
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4190923</samp>

Add support for customizing the MTU of subnets and pods in kube-ovn. This feature allows users to specify the `Mtu` field in the `SubnetSpec` schema, which is reflected in the `SubnetStatus` schema and the pod network interface. The feature is implemented in `handler.go`, `types.go`, `kube-ovn-crd.yaml`, and `crd.yaml`, and tested in `subnet.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4190923</samp>

> _To customize the MTU_
> _Of subnets and pods in kube-ovn_
> _We added a field to the schema_
> _And updated the types and the testa_
> _And handled the value in `handleAdd` too_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4190923</samp>

*  Add `mtu` field to `SubnetSpec` and `SubnetStatus` schemas to support customizing the MTU of subnets and pods ([link](https://github.com/kubeovn/kube-ovn/pull/3367/files?diff=unified&w=0#diff-d671263a0aa28dac78faa045e43d18cde05bf81846c6d1bf1db009cddda883f2R1717-R1720), [link](https://github.com/kubeovn/kube-ovn/pull/3367/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR143), [link](https://github.com/kubeovn/kube-ovn/pull/3367/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R2028-R2031))
*  Use the `mtu` field of the subnet as the MTU of the pod's network interface if specified, otherwise fall back to the original logic of checking the node's label for the provider network MTU ([link](https://github.com/kubeovn/kube-ovn/pull/3367/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL258-R264), [link](https://github.com/kubeovn/kube-ovn/pull/3367/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL278-R284))
*  Add a new end-to-end test case to verify that the `mtu` field works as expected and the pod's network interface has the same MTU as the subnet ([link](https://github.com/kubeovn/kube-ovn/pull/3367/files?diff=unified&w=0#diff-2a0a0a9bdcac251e79fa5828804f065f18960ef5659b60372a3bf633a45969d5R1248-R1272))