### PR TITLE
fix IP residue after changing subnet of vm in some scenarios

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -521,6 +521,12 @@ func (c *Controller) changeVMSubnet(vmName, namespace, providerName, subnetName 
 	if ipCr != nil {
 		if ipCr.Spec.Subnet != subnetName {
 			key := fmt.Sprintf("%s/%s", pod.Namespace, vmName)
+			if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipName, metav1.DeleteOptions{}); err != nil {
+				if !k8serrors.IsNotFound(err) {
+					klog.Errorf("failed to delete ip %s, %v", ipName, err)
+					return err
+				}
+			}
 			ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": key})
 			if err != nil {
 				klog.Errorf("failed to list lsps of pod '%s', %v", pod.Name, err)
@@ -534,6 +540,7 @@ func (c *Controller) changeVMSubnet(vmName, namespace, providerName, subnetName 
 					return err
 				}
 			}
+			c.ipam.ReleaseAddressByPod(key)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #3369

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c6850c</samp>

Fix pod IP conflicts and leaks on subnet change. Delete and release the pod's IP when its subnet annotation changes in `pod.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3c6850c</samp>

> _Oh, we're the podders of the Kubernetes sea_
> _And we fix the bugs that make the IPs flee_
> _We delete the `IP` and release the `IPAM` cache_
> _On the count of three, heave ho, and watch them dash_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c6850c</samp>

*  Delete and release IP resources for pod when subnet changes ([link](https://github.com/kubeovn/kube-ovn/pull/3370/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R524-R529), [link](https://github.com/kubeovn/kube-ovn/pull/3370/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R543))
