### PR TITLE
kube-ovn-dpdk building need its dpdk base img

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
         if: steps.check.outputs.buildx == 1
 
-      - name: Build
+      - name: Build kube-ovn-base image
         id: build
         if: steps.check.outputs.buildx == 1
         run: |
@@ -58,9 +58,6 @@ jobs:
             make base-tar-amd64
             echo build-base=1 >> "$GITHUB_OUTPUT"
           fi
-          if git diff --name-only HEAD^ HEAD | grep -q ^dist/images/Dockerfile.base-dpdk$; then
-            make base-amd64-dpdk
-          fi
 
       - name: Upload base images to artifact
         if: steps.build.outputs.build-base == 1
@@ -68,6 +65,23 @@ jobs:
         with:
           name: kube-ovn-base
           path: image-amd64.tar
+
+      - name: Build kube-ovn-base-dpdk image
+        id: build
+        if: steps.check.outputs.buildx == 1
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep -q ^dist/images/Dockerfile.base-dpdk$; then
+            make base-amd64-dpdk
+            echo build-base-dpdk=1 >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload base-dpdk images to artifact
+        if: steps.build.outputs.build-base-dpdk == 1
+        uses: actions/upload-artifact@v3
+        with:
+          name: kube-ovn-base-dpdk
+          path: image-amd64-dpdk.tar
+
 
   build-kube-ovn:
     name: Build kube-ovn


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d905240</samp>

Refactor workflow for building `kube-ovn-base` image and its `dpdk` variant. Use artifacts and conditional step to optimize image sharing and build time.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d905240</samp>

> _`kube-ovn-base` splits_
> _dpdk build is conditional_
> _snowflakes in artifacts_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d905240</samp>

*  Rename build step to `Build kube-ovn-base image` for clarity and consistency ([link](https://github.com/kubeovn/kube-ovn/pull/3371/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L52-R52))
*  Move code for building `base-amd64-dpdk` image to a separate step ([link](https://github.com/kubeovn/kube-ovn/pull/3371/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L61-L63), [link](https://github.com/kubeovn/kube-ovn/pull/3371/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R69-R85))
