### PR TITLE
add kube-ovn-controller nodeAffinity prefer not on ic gateway

### DIFF
--- a/charts/templates/controller-deploy.yaml
+++ b/charts/templates/controller-deploy.yaml
@@ -29,6 +29,15 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: "ovn.kubernetes.io/ic-gw"
+                    operator: NotIn
+                    values:
+                      - "true"
+              weight: 100
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3921,6 +3921,15 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: "ovn.kubernetes.io/ic-gw"
+                operator: NotIn
+                values:
+                - "true"
+            weight: 100
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/yamls/kube-ovn-dual-stack.yaml
+++ b/yamls/kube-ovn-dual-stack.yaml
@@ -29,6 +29,15 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: "ovn.kubernetes.io/ic-gw"
+                    operator: NotIn
+                    values:
+                      - "true"
+              weight: 100
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -29,6 +29,15 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: "ovn.kubernetes.io/ic-gw"
+                    operator: NotIn
+                    values:
+                      - "true"
+              weight: 100
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -29,6 +29,15 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: "ovn.kubernetes.io/ic-gw"
+                    operator: NotIn
+                    values:
+                      - "true"
+              weight: 100
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a09dea1</samp>

Add node affinity rule to controller deployment in various files. This rule prevents the controller pod from running on inter-cluster gateway nodes, which are labeled with `ovn.kubernetes.io/ic-gw`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a09dea1</samp>

> _Controller pod shuns_
> _`ic-gw` nodes in OVN_
> _Autumn leaves falling_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a09dea1</samp>

*  Add node affinity rule to controller deployment to prefer nodes without `ovn.kubernetes.io/ic-gw` label ([link](https://github.com/kubeovn/kube-ovn/pull/3376/files?diff=unified&w=0#diff-ea68dce347b5fa351b4dd8da76b26575f5aeac40e3ce0f5d37e26a603bb6ea51R32-R40), [link](https://github.com/kubeovn/kube-ovn/pull/3376/files?diff=unified&w=0#diff-e859969a88aa85bdf68158e82d71c08bfb052e825a36b0cb099aa1eb9c1247bfR32-R40), [link](https://github.com/kubeovn/kube-ovn/pull/3376/files?diff=unified&w=0#diff-07e8f6419792aca8c81f1e2c432e57504c45c4f0ca43923e0c6d2a6541f34ee3R32-R40), [link](https://github.com/kubeovn/kube-ovn/pull/3376/files?diff=unified&w=0#diff-f8a8d58f0f498b7dcee95dc3e0960b783681402178b44da3d12d999724ba2f35R32-R40))
