### PR TITLE
fix:  The gc delete multus ip cr and lsp setting when enable keep vm ip

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -771,7 +771,7 @@ func (c *Controller) getVMLsps() []string {
 				if network.Multus != nil && network.Multus.NetworkName != "" {
 					items := strings.Split(network.Multus.NetworkName, "/")
 					if len(items) != 2 {
-						continue
+						items = []string{vm.GetNamespace(), items[0]}
 					}
 					provider := fmt.Sprintf("%s.%s.ovn", items[1], items[0])
 					vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, provider)


### PR DESCRIPTION
## What type of this PR

The vm multus ip cr and lsp setting will be deleted by gc logic when vm define multus networkName as below:
```yaml
spec:
  template:
    spec:
      networks:
      - multus:
          networkName: <nad-name> # not <nad-namespace>/<nad-name>
        name: <nic-name>
```


## Which issue(s) this PR fixes

The vm ip and mac somethime change when enable keep VM IP. 

## WHAT

I have remove not need logic in the pr.

## HOW

Keep vm ip and mac not change is very important, because it can cause the vm nic not get ip when mac address change.
