### PR TITLE
fix: externalID map should not include external_ids

### DIFF
--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -419,7 +419,7 @@ func (c *Controller) syncSgLogicalPort(key string) error {
 		return err
 	}
 
-	results, err := c.OVNNbClient.ListLogicalSwitchPorts(false, map[string]string{"external_ids:associated_sg_" + key: "true"}, nil)
+	results, err := c.OVNNbClient.ListLogicalSwitchPorts(false, map[string]string{fmt.Sprintf("associated_sg_%s", key): "true"}, nil)
 	if err != nil {
 		klog.Errorf("failed to find logical port, %v", err)
 		return err


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #3377 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f94510b</samp>

Simplify the external_ids key format for logical switch ports associated with security groups in `pkg/controller/security_group.go`. This improves code readability and consistency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f94510b</samp>

> _`ListLogicalSwitchPorts`_
> _Simplifies external_ids_
> _A clear autumn code_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f94510b</samp>

*  Simplify the external_ids key for security group association in logical switch ports ([link](https://github.com/kubeovn/kube-ovn/pull/3385/files?diff=unified&w=0#diff-9c65d5f3e6dd52b4ff12f549e30f4bbc97cc9918c171900794913b40d56ca7e8L422-R422))
