### PR TITLE
fix dualStack network checkgw raise panic

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -362,13 +362,11 @@ func waitNetworkReady(nic, ipAddr, gateway string, underlayGateway, verbose bool
 				klog.Infof("MAC addresses of gateway %s is %s", gw, mac.String())
 				klog.Infof("network %s with gateway %s is ready for interface %s after %d checks", ips[i], gw, nic, count)
 			}
-			maxRetry -= count
 		} else {
-			count, err := pingGateway(gw, src, verbose, maxRetry)
+			_, err := pingGateway(gw, src, verbose, maxRetry)
 			if err != nil {
 				return err
 			}
-			maxRetry -= count
 		}
 	}
 	return nil

--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -242,11 +242,10 @@ func waitNetworkReady(nic, ipAddr, gateway string, underlayGateway, verbose bool
 	for i, gw := range strings.Split(gateway, ",") {
 		src := strings.Split(ips[i], "/")[0]
 		if !underlayGateway || util.CheckProtocol(gw) == kubeovnv1.ProtocolIPv6 {
-			count, err := pingGateway(gw, src, verbose, maxRetry)
+			_, err := pingGateway(gw, src, verbose, maxRetry)
 			if err != nil {
 				return err
 			}
-			maxRetry -= count
 		}
 	}
 	return nil


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 946d2b0</samp>

Simplify the `waitNetworkReady` function in `ovs_linux.go` and `ovs_windows.go` by removing redundant code. This improves readability and consistency of the daemon code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 946d2b0</samp>

> _No more retries, no more lies_
> _We purge the code of its decay_
> _We wait for network, we defy_
> _The redundant `maxRetry` we slay_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 946d2b0</samp>

*  Simplify the logic of `waitNetworkReady` function by removing unnecessary decrements of `maxRetry` variable ([link](https://github.com/kubeovn/kube-ovn/pull/3392/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feL365), [link](https://github.com/kubeovn/kube-ovn/pull/3392/files?diff=unified&w=0#diff-9ef24f4ecb94bef2f6117b5b04dd931cc4cec65ab035472384bce083898827feL371), [link](https://github.com/kubeovn/kube-ovn/pull/3392/files?diff=unified&w=0#diff-5fefd55d3cd47d00ef6df5d0afb5f9c6a386812fda3d38d5a40dfa1013854a69L249))
