### PR TITLE
e2e for allowed address pair

### DIFF
--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -114,3 +114,36 @@ func MakePod(ns, name string, labels, annotations map[string]string, image strin
 
 	return pod
 }
+
+func MakeNetAdminPod(ns, name string, labels, annotations map[string]string, image string, command, args []string) *corev1.Pod {
+	if image == "" {
+		image = PauseImage
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "container",
+					Image:           image,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         command,
+					Args:            args,
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN"}},
+					},
+				},
+			},
+		},
+	}
+	pod.Spec.TerminationGracePeriodSeconds = new(int64)
+	*pod.Spec.TerminationGracePeriodSeconds = 3
+
+	return pod
+}

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -116,34 +116,9 @@ func MakePod(ns, name string, labels, annotations map[string]string, image strin
 }
 
 func MakeNetAdminPod(ns, name string, labels, annotations map[string]string, image string, command, args []string) *corev1.Pod {
-	if image == "" {
-		image = PauseImage
+	pod := MakePod(ns, name, labels, annotations, image, command, args)
+	pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN"}},
 	}
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   ns,
-			Labels:      labels,
-			Annotations: annotations,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:            "container",
-					Image:           image,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         command,
-					Args:            args,
-					SecurityContext: &corev1.SecurityContext{
-						Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN"}},
-					},
-				},
-			},
-		},
-	}
-	pod.Spec.TerminationGracePeriodSeconds = new(int64)
-	*pod.Spec.TerminationGracePeriodSeconds = 3
-
 	return pod
 }

--- a/test/e2e/vip/e2e_test.go
+++ b/test/e2e/vip/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"testing"
 
@@ -137,8 +138,10 @@ var _ = framework.Describe("[group:vip]", func() {
 					options[keyValue[0]] = strings.ReplaceAll(keyValue[1], "\n", "")
 				}
 			}
-			virtualParents := options["virtual-parents"]
-			expectVirtualParents := fmt.Sprintf("%s.%s,%s.%s", aapPodName1, namespaceName, aapPodName2, namespaceName)
+			virtualParents := strings.Split(options["virtual-parents"], ",")
+			sort.Strings(virtualParents)
+			expectVirtualParents := []string{fmt.Sprintf("%s.%s", aapPodName1, namespaceName), fmt.Sprintf("%s.%s", aapPodName2, namespaceName)}
+			sort.Strings(expectVirtualParents)
 			framework.ExpectEqual(expectVirtualParents, virtualParents)
 			// other pods can communicate with the aap pod through vip
 			ginkgo.By("Test pod ping aap address " + vip1.Status.V4ip)

--- a/test/e2e/vip/e2e_test.go
+++ b/test/e2e/vip/e2e_test.go
@@ -134,7 +134,7 @@ var _ = framework.Describe("[group:vip]", func() {
 			for _, pair := range pairs {
 				keyValue := strings.Split(pair, "=")
 				if len(keyValue) == 2 {
-					options[keyValue[0]] = strings.Replace(keyValue[1], "\n", "", -1)
+					options[keyValue[0]] = strings.ReplaceAll(keyValue[1], "\n", "")
 				}
 			}
 			virtualParents := options["virtual-parents"]

--- a/test/e2e/vip/e2e_test.go
+++ b/test/e2e/vip/e2e_test.go
@@ -1,9 +1,14 @@
 package vip
 
 import (
+	"context"
 	"flag"
+	"fmt"
+	"os/exec"
+	"strings"
 	"testing"
 
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e"
 	k8sframework "k8s.io/kubernetes/test/e2e/framework"
@@ -23,24 +28,29 @@ func makeOvnVip(namespaceName, name, subnet, v4ip, v6ip, vipType string) *kubeov
 var _ = framework.Describe("[group:vip]", func() {
 	f := framework.NewDefaultFramework("vip")
 
+	var cs clientset.Interface
+
 	var vpcClient *framework.VpcClient
 	var subnetClient *framework.SubnetClient
 	var vipClient *framework.VipClient
 	var vpc *kubeovnv1.Vpc
 	var subnet *kubeovnv1.Subnet
-	var namespaceName, vpcName, subnetName, cidr string
+	var podClient *framework.PodClient
+	var image, namespaceName, vpcName, subnetName, cidr string
 
 	// test switch lb vip, which ip is in the vpc subnet cidr
 	// switch lb vip use gw mac to trigger lb nat flows
 	var switchLbVip1Name, switchLbVip2Name string
 
 	// test allowed address pair vip
-	var vip1Name, vip2Name string
+	var vip1Name, vip2Name, aapPodName1, aapPodName2 string
 
 	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
 		vpcClient = f.VpcClient()
 		subnetClient = f.SubnetClient()
 		vipClient = f.VipClient()
+		podClient = f.PodClient()
 		namespaceName = f.Namespace.Name
 		cidr = framework.RandomCIDR(f.ClusterIPFamily)
 
@@ -53,6 +63,9 @@ var _ = framework.Describe("[group:vip]", func() {
 		vip1Name = "vip1-" + randomSuffix
 		vip2Name = "vip2-" + randomSuffix
 
+		aapPodName1 = "pod1-" + randomSuffix
+		aapPodName2 = "pod2-" + randomSuffix
+
 		vpcName = "vpc-" + randomSuffix
 		subnetName = "subnet-" + randomSuffix
 		ginkgo.By("Creating vpc " + vpcName)
@@ -61,6 +74,10 @@ var _ = framework.Describe("[group:vip]", func() {
 		ginkgo.By("Creating subnet " + subnetName)
 		subnet = framework.MakeSubnet(subnetName, "", cidr, "", vpcName, "", nil, nil, []string{namespaceName})
 		subnet = subnetClient.CreateSync(subnet)
+
+		if image == "" {
+			image = framework.GetKubeOvnImage(cs)
+		}
 	})
 
 	ginkgo.AfterEach(func() {
@@ -73,6 +90,11 @@ var _ = framework.Describe("[group:vip]", func() {
 		ginkgo.By("Deleting allowed address pair vip " + vip2Name)
 		vipClient.DeleteSync(vip2Name)
 
+		// clean fip pod
+		ginkgo.By("Deleting pod " + aapPodName1)
+		podClient.DeleteSync(aapPodName1)
+		ginkgo.By("Deleting pod " + aapPodName2)
+		podClient.DeleteSync(aapPodName2)
 		ginkgo.By("Deleting subnet " + subnetName)
 		subnetClient.DeleteSync(subnetName)
 		ginkgo.By("Deleting vpc " + vpcName)
@@ -81,6 +103,14 @@ var _ = framework.Describe("[group:vip]", func() {
 
 	framework.ConformanceIt("Test vip", func() {
 		ginkgo.By("1. Test allowed address pair vip")
+		annotations := map[string]string{util.AAPsAnnotation: vip1Name}
+		cmd := []string{"sh", "-c", "sleep infinity"}
+		ginkgo.By("Creating pod1 support allowed address pair using " + vip1Name)
+		aapPod1 := framework.MakeNetAdminPod(namespaceName, aapPodName1, nil, annotations, image, cmd, nil)
+		_ = podClient.CreateSync(aapPod1)
+		ginkgo.By("Creating pod2 support allowed address pair using " + vip1Name)
+		aapPod2 := framework.MakeNetAdminPod(namespaceName, aapPodName2, nil, annotations, image, cmd, nil)
+		_ = podClient.CreateSync(aapPod2)
 		ginkgo.By("Creating allowed address pair vip, should have different ip and mac")
 		ginkgo.By("Creating allowed address pair vip " + vip1Name)
 		vip1 := makeOvnVip(namespaceName, vip1Name, subnetName, "", "", "")
@@ -92,6 +122,47 @@ var _ = framework.Describe("[group:vip]", func() {
 		framework.ExpectNotEqual(vip1.Status.Mac, vip2.Status.Mac)
 		if vip1.Status.V4ip != "" {
 			framework.ExpectNotEqual(vip1.Status.V4ip, vip2.Status.V4ip)
+			// logical switch port with type virtual should be created
+			conditions := fmt.Sprintf("type=virtual name=%s options:virtual-ip=%s ", vip1Name, vip1.Status.V4ip)
+			execCmd := "kubectl ko nbctl --format=list --data=bare --no-heading --columns=options find logical-switch-port " + conditions
+			output, err := exec.Command("bash", "-c", execCmd).CombinedOutput()
+			framework.ExpectNoError(err)
+			framework.ExpectNotEmpty(strings.TrimSpace(string(output)))
+			// virtual parents should be set correctlly
+			pairs := strings.Split(string(output), " ")
+			options := make(map[string]string)
+			for _, pair := range pairs {
+				keyValue := strings.Split(pair, "=")
+				if len(keyValue) == 2 {
+					options[keyValue[0]] = strings.Replace(keyValue[1], "\n", "", -1)
+				}
+			}
+			virtualParents := options["virtual-parents"]
+			expectVirtualParents := fmt.Sprintf("%s.%s,%s.%s", aapPodName1, namespaceName, aapPodName2, namespaceName)
+			framework.ExpectEqual(expectVirtualParents, virtualParents)
+			// other pods can communicate with the aap pod through vip
+			ginkgo.By("Test pod ping aap address " + vip1.Status.V4ip)
+			addIP := fmt.Sprintf("ip addr add %s/24 dev eth0", vip1.Status.V4ip)
+			delIP := fmt.Sprintf("ip addr del %s/24 dev eth0", vip1.Status.V4ip)
+			command := fmt.Sprintf("ping -W 1 -c 1 %s", vip1.Status.V4ip)
+			// check aapPod2 ping aapPod1 through vip
+			stdout, stderr, err := framework.ExecShellInPod(context.Background(), f, namespaceName, aapPodName1, addIP)
+			framework.Logf("exec %s failed err: %v, stderr: %s, stdout: %s", addIP, err, stderr, stdout)
+			stdout, stderr, err = framework.ExecShellInPod(context.Background(), f, namespaceName, aapPodName2, command)
+			framework.Logf("exec %s failed err: %v, stderr: %s, stdout: %s", command, err, stderr, stdout)
+			framework.ExpectNoError(err)
+			// aapPod2 can not ping aapPod1 vip when ip is deleted
+			stdout, stderr, err = framework.ExecShellInPod(context.Background(), f, namespaceName, aapPodName1, delIP)
+			framework.Logf("exec %s failed err: %v, stderr: %s, stdout: %s", delIP, err, stderr, stdout)
+			stdout, stderr, err = framework.ExecShellInPod(context.Background(), f, namespaceName, aapPodName2, command)
+			framework.Logf("exec %s failed err: %v, stderr: %s, stdout: %s", command, err, stderr, stdout)
+			framework.ExpectError(err)
+			// check aapPod1 ping aapPod2 through vip
+			stdout, stderr, err = framework.ExecShellInPod(context.Background(), f, namespaceName, aapPodName2, addIP)
+			framework.Logf("exec %s failed err: %v, stderr: %s, stdout: %s", addIP, err, stderr, stdout)
+			stdout, stderr, err = framework.ExecShellInPod(context.Background(), f, namespaceName, aapPodName1, command)
+			framework.Logf("exec %s failed err: %v, stderr: %s, stdout: %s", command, err, stderr, stdout)
+			framework.ExpectNoError(err)
 		} else {
 			framework.ExpectNotEqual(vip1.Status.V6ip, vip2.Status.V6ip)
 		}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 318f557</samp>

This pull request adds a new e2e test case and a helper function for the allowed address pair feature of `kube-ovn`. The test case verifies that pods can use a virtual IP assigned by an annotation and communicate with each other and the virtual IP. The helper function creates pods with the `NET_ADMIN` capability for manipulating the network interfaces and addresses.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 318f557</samp>

> _We'll make a pod with `NET_ADMIN` and a virtual IP_
> _We'll test the feature of kube-ovn with a simple script_
> _Heave away, me hearties, heave away with care_
> _We're sailing on the network of the Kubernetes fair_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 318f557</samp>

*  Add a new function `MakeNetAdminPod` to create pods with `NET_ADMIN` capability ([link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-5f15fda6193ef82e5636ecbb83e7df08e56285d7c04d7e7360c3461d7b08e065R117-R149))
*  Add new imports, variables and cleanup code to the `vip` package in `test/e2e/vip/e2e_test.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-530049a2db118feb82e846c0fa639e28f8688ac2d50edf27d638aa806fbac73dL4-R11), [link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-530049a2db118feb82e846c0fa639e28f8688ac2d50edf27d638aa806fbac73dR31-R32), [link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-530049a2db118feb82e846c0fa639e28f8688ac2d50edf27d638aa806fbac73dL31-R39), [link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-530049a2db118feb82e846c0fa639e28f8688ac2d50edf27d638aa806fbac73dL38-R53), [link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-530049a2db118feb82e846c0fa639e28f8688ac2d50edf27d638aa806fbac73dR77-R80), [link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-530049a2db118feb82e846c0fa639e28f8688ac2d50edf27d638aa806fbac73dR93-R97))
*  Create two pods with allowed address pair annotation using `MakeNetAdminPod` and `podClient` in `BeforeEach` block ([link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-530049a2db118feb82e846c0fa639e28f8688ac2d50edf27d638aa806fbac73dR106-R113))
*  Test the allowed address pair feature using `exec` and `framework` packages in `It` block ([link](https://github.com/kubeovn/kube-ovn/pull/3394/files?diff=unified&w=0#diff-530049a2db118feb82e846c0fa639e28f8688ac2d50edf27d638aa806fbac73dR125-R153))
