### PR TITLE
fix: wrong usage about DeepEqual

### DIFF
--- a/pkg/controller/external_gw.go
+++ b/pkg/controller/external_gw.go
@@ -78,7 +78,7 @@ func (c *Controller) removeExternalGateway() error {
 	sel, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{util.ExGatewayLabel: "true"}})
 	nodes, err := c.nodesLister.List(sel)
 	if err != nil {
-		klog.Errorf("failed to list nodes, %v", err)
+		klog.Errorf("failed to list external gw nodes, %v", err)
 		return err
 	}
 	for _, cachedNode := range nodes {
@@ -223,10 +223,13 @@ func (c *Controller) getGatewayChassis(config map[string]string) ([]string, erro
 		gwNodes = append(gwNodes, node.Name)
 	}
 	if config["type"] != "distributed" {
-		gwNodes = strings.Split(config["external-gw-nodes"], ",")
+		nodeNames := strings.Split(config["external-gw-nodes"], ",")
+		for _, name := range nodeNames {
+			name = strings.TrimSpace(name)
+			gwNodes = append(gwNodes, name)
+		}
 	}
 	for _, gw := range gwNodes {
-		gw = strings.TrimSpace(gw)
 		cachedNode, err := c.nodesLister.Get(gw)
 		if err != nil {
 			klog.Errorf("failed to get gw node %s, %v", gw, err)

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -56,8 +55,8 @@ func (c *Controller) enqueueUpdateOvnEip(oldObj, newObj interface{}) {
 		c.resetOvnEipQueue.Add(key)
 		return
 	}
-	if !reflect.DeepEqual(oldEip.Spec.V4Ip, newEip.Spec.V4Ip) ||
-		!reflect.DeepEqual(oldEip.Spec.V6Ip, newEip.Spec.V6Ip) {
+	if oldEip.Spec.V4Ip != newEip.Spec.V4Ip ||
+		oldEip.Spec.V6Ip != newEip.Spec.V6Ip {
 		klog.Infof("enqueue update ovn eip %s", key)
 		c.updateOvnEipQueue.Add(key)
 	}

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,8 +54,8 @@ func (c *Controller) enqueueUpdateOvnFip(oldObj, newObj interface{}) {
 		klog.Infof("enqueue reset old ovn eip %s", oldFip.Spec.OvnEip)
 		c.resetOvnEipQueue.Add(oldFip.Spec.OvnEip)
 	}
-	if !reflect.DeepEqual(oldFip.Spec.IPName, newFip.Spec.IPName) ||
-		!reflect.DeepEqual(oldFip.Spec.IPType, newFip.Spec.IPType) {
+	if oldFip.Spec.IPName != newFip.Spec.IPName ||
+		oldFip.Spec.IPType != newFip.Spec.IPType {
 		klog.Infof("enqueue update fip %s", key)
 		c.updateOvnFipQueue.Add(key)
 		return

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -51,10 +51,10 @@ func (c *Controller) enqueueUpdateVpc(oldObj, newObj interface{}) {
 		!reflect.DeepEqual(oldVpc.Spec.StaticRoutes, newVpc.Spec.StaticRoutes) ||
 		!reflect.DeepEqual(oldVpc.Spec.PolicyRoutes, newVpc.Spec.PolicyRoutes) ||
 		!reflect.DeepEqual(oldVpc.Spec.VpcPeerings, newVpc.Spec.VpcPeerings) ||
-		!reflect.DeepEqual(oldVpc.Spec.EnableExternal, newVpc.Spec.EnableExternal) ||
-		!reflect.DeepEqual(oldVpc.Spec.EnableBfd, newVpc.Spec.EnableBfd) ||
 		!reflect.DeepEqual(oldVpc.Annotations, newVpc.Annotations) ||
 		!reflect.DeepEqual(oldVpc.Spec.ExtraExternalSubnets, newVpc.Spec.ExtraExternalSubnets) ||
+		oldVpc.Spec.EnableExternal != newVpc.Spec.EnableExternal ||
+		oldVpc.Spec.EnableBfd != newVpc.Spec.EnableBfd ||
 		oldVpc.Labels[util.VpcExternalLabel] != newVpc.Labels[util.VpcExternalLabel] {
 		// TODO:// label VpcExternalLabel replace with spec enable external
 		var (


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c187db</samp>

This pull request improves the performance and readability of the code that handles external gateway nodes, `OvnEip`, `OvnFip`, and `Vpc` resources in the `pkg/controller` package. It removes unnecessary dependencies on the `reflect` package and simplifies object comparison logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8c187db</samp>

> _This pull request has some changes_
> _To improve how the code manages_
> _`Vpc`, `OvnEip`, and `OvnFip`_
> _And external gateway nodes that slip_
> _By using less `reflect` and more ranges_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c187db</samp>

*  Simplify the comparison of old and new objects in the `enqueueUpdateOvnEip`, `enqueueUpdateOvnFip`, and `enqueueUpdateVpc` functions by using direct equality checks instead of `reflect.DeepEqual` calls for simple string and boolean fields. This improves the performance and readability of the code. ([link](https://github.com/kubeovn/kube-ovn/pull/3396/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceL59-R59), [link](https://github.com/kubeovn/kube-ovn/pull/3396/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L58-R58), [link](https://github.com/kubeovn/kube-ovn/pull/3396/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL54-R57))
* Remove the unused `reflect` package import from the `ovn_eip.go` and `ovn_fip.go` files, following the best practice of removing unnecessary dependencies. ([link](https://github.com/kubeovn/kube-ovn/pull/3396/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceL7), [link](https://github.com/kubeovn/kube-ovn/pull/3396/files?diff=unified&w=0#diff-c1d005a7fb842ce7ae53c4bd4780cf0703a409b350f4f41d482b36158af0f459L7))
* Refactor the logic in the `getGatewayChassis` function in `external_gw.go` to use a loop to trim and append the node names from the `external-gw-nodes` config, instead of using a single `strings.Split` call. This avoids potential issues with empty or extra spaces in the node names, and makes the code more consistent with other similar functions. ([link](https://github.com/kubeovn/kube-ovn/pull/3396/files?diff=unified&w=0#diff-945b73ad15889230d50be6f6fbd9e7352e96338574ce6f8a53b7a32b2e334739L226-R232))
