### PR TITLE
Subnet add mtu config 1.9

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -599,7 +599,7 @@ spec:
                       - 253 # default
                       - 254 # main
                       - 255 # local
-                 mtu:
+                mtu:
                   type: integer
                   minimum: 68
                   maximum: 65535

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -599,6 +599,10 @@ spec:
                       - 253 # default
                       - 254 # main
                       - 255 # local
+                 mtu:
+                  type: integer
+                  minimum: 68
+                  maximum: 65535
                 private:
                   type: boolean
                 vlan:

--- a/kubeovn-helm/templates/kube-ovn-crd.yaml
+++ b/kubeovn-helm/templates/kube-ovn-crd.yaml
@@ -422,6 +422,10 @@ spec:
                       - 253 # default
                       - 254 # main
                       - 255 # local
+                mtu:
+                  type: integer
+                  minimum: 68
+                  maximum: 65535
                 private:
                   type: boolean
                 vlan:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -117,6 +117,7 @@ type SubnetSpec struct {
 	ExternalEgressGateway string `json:"externalEgressGateway,omitempty"`
 	PolicyRoutingPriority uint32 `json:"policyRoutingPriority,omitempty"`
 	PolicyRoutingTableID  uint32 `json:"policyRoutingTableID,omitempty"`
+	Mtu                   uint32 `json:"mtu,omitempty"`
 
 	Private      bool     `json:"private"`
 	AllowSubnets []string `json:"allowSubnets,omitempty"`

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -216,6 +216,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 
 		var mtu int
+
 		if podSubnet.Spec.Mtu > 0 {
 			mtu = int(podSubnet.Spec.Mtu)
 		} else {
@@ -239,31 +240,9 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 						}
 						return
 					}
-					mtuStr := node.Labels[fmt.Sprintf(util.ProviderNetworkMtuTemplate, providerNetwork)]
-					if mtuStr != "" {
-						if mtu, err = strconv.Atoi(mtuStr); err != nil || mtu <= 0 {
-							errMsg := fmt.Errorf("failed to parse provider network MTU %s: %v", mtuStr, err)
-							klog.Error(errMsg)
-							if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
-								klog.Errorf("failed to write response: %v", err)
-							}
-							return
-						}
-						mtuStr := node.Labels[fmt.Sprintf(util.ProviderNetworkMtuTemplate, providerNetwork)]
-						if mtuStr != "" {
-							if mtu, err = strconv.Atoi(mtuStr); err != nil || mtu <= 0 {
-								errMsg := fmt.Errorf("failed to parse provider network MTU %s: %v", mtuStr, err)
-								klog.Error(errMsg)
-								if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
-									klog.Errorf("failed to write response: %v", err)
-								}
-								return
-							}
-						}
-					} else {
-						mtu = csh.Config.MTU
-					}
 				}
+			} else {
+				mtu = csh.Config.MTU
 			}
 		}
 

--- a/yamls/crd.yaml
+++ b/yamls/crd.yaml
@@ -211,6 +211,10 @@ spec:
                       - 253 # default
                       - 254 # main
                       - 255 # local
+                mtu:
+                  type: integer
+                  minimum: 68
+                  maximum: 65535
                 private:
                   type: boolean
                 vlan:


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1ca495</samp>

This pull request adds support for specifying the MTU of pod and provider networks in the CNI plugin. It modifies the `SubnetSpec` and `VlanSpec` schemas in the CRD files and the `types.go` file, and updates the `handleAdd` function in the `handler.go` file to use the MTU from the pod subnet if available.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d1ca495</samp>

> _To customize the MTU_
> _They added a field or two_
> _To `VlanSpec` and `SubnetSpec`_
> _And updated the `handleAdd` func_
> _To make the CNI plugin more true_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1ca495</samp>

*  Add `mtu` field to `VlanSpec` and `SubnetSpec` schemas to allow users to specify the MTU of VLAN and pod networks ([link](https://github.com/kubeovn/kube-ovn/pull/3397/files?diff=unified&w=0#diff-cf6e828a3b8334b0180f06b380614f951d45a1a12d49efce74818fd68882a868R425-R428), [link](https://github.com/kubeovn/kube-ovn/pull/3397/files?diff=unified&w=0#diff-69f75d53361877cc02ab6f413f306486d29287c6400b92b71c4c74f018f3234aR120), [link](https://github.com/kubeovn/kube-ovn/pull/3397/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R214-R217))
*  Modify `handleAdd` function to respect the MTU setting of the pod subnet if provided, and move the original logic for getting the MTU from the provider network or the default config to the else branch ([link](https://github.com/kubeovn/kube-ovn/pull/3397/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL219-R225), [link](https://github.com/kubeovn/kube-ovn/pull/3397/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL239-R267))
*  Update `crd.yaml` and `kube-ovn-crd.yaml` files to reflect the schema changes in `types.go` file ([link](https://github.com/kubeovn/kube-ovn/pull/3397/files?diff=unified&w=0#diff-cf6e828a3b8334b0180f06b380614f951d45a1a12d49efce74818fd68882a868R425-R428), [link](https://github.com/kubeovn/kube-ovn/pull/3397/files?diff=unified&w=0#diff-7b60edb5fc7c18c120f5a0077606604cfb6be9bb55517095bb9380877ef716c5R214-R217))
