### PR TITLE
ci: free disk space

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -109,6 +109,16 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build-kube-ovn-base
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
docker save kubeovn/kube-ovn:v1.13.0 kubeovn/kube-ovn:v1.13.0-debug kubeovn/kube-ovn:v1.13.0-dpdk -o kube-ovn.tar
write ./.docker_temp_1935084608: no space left on device
make: *** [Makefile:165: tar-kube-ovn] Error 1
```

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a2e50e</samp>

Add a step to free disk space in `build-x86-image` workflow. This fixes the disk space issue that causes the workflow to fail.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a2e50e</samp>

> _`build-x86-image`_
> _needs more disk space to run_
> _delete unused files_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a2e50e</samp>

* Add a step to free up disk space on the GitHub runner before building the image ([link](https://github.com/kubeovn/kube-ovn/pull/3404/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R112-R121))
