### PR TITLE
ci: free disk space for all x86 jobs

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -33,6 +33,16 @@ jobs:
     outputs:
       build-base: ${{ steps.build.outputs.build-base }}
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
@@ -72,6 +82,16 @@ jobs:
     outputs:
       build-base: ${{ steps.build.outputs.build-dpdk-base }}
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
@@ -200,6 +220,16 @@ jobs:
     name: Build vpc-nat-gateway
     runs-on: ubuntu-22.04
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Build
@@ -217,6 +247,16 @@ jobs:
     name: Build centos-compile
     runs-on: ubuntu-22.04
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
 
@@ -242,6 +282,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -343,6 +393,16 @@ jobs:
           - overlay
           - underlay
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -493,6 +553,16 @@ jobs:
           - ipv6
           - dual
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -638,6 +708,16 @@ jobs:
           - ipv6
           - dual
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -759,6 +839,16 @@ jobs:
           - overlay
           - underlay
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -903,6 +993,16 @@ jobs:
           - dual
     timeout-minutes: 15
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -996,6 +1096,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Install kind
@@ -1032,6 +1142,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Install kind
@@ -1068,6 +1188,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Install kind
@@ -1106,6 +1236,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Install kind
@@ -1147,6 +1287,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -1236,6 +1386,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -1319,6 +1479,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -1413,6 +1583,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Install kind
@@ -1464,6 +1644,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
       - uses: azure/setup-helm@v3
         with:
@@ -1585,6 +1775,16 @@ jobs:
           - ipv6
           - dual
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -1689,6 +1889,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -1771,6 +1981,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -1873,6 +2093,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Create the default branch directory
@@ -1976,6 +2206,16 @@ jobs:
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-22.04
     steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Download kube-ovn image

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1384,7 +1384,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: jlumbroso/free-disk-space@v1.3.1
         with:
@@ -1760,7 +1760,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -2091,7 +2091,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: jlumbroso/free-disk-space@v1.3.1
         with:


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9eb770</samp>

Add disk space cleanup step to docker image workflows. This improves the reliability of the workflows and prevents failures due to low disk space. The change affects the `.github/workflows/build-x86-image.yaml` file and other similar files for different architectures and base images.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e9eb770</samp>

> _`docker` images_
> _need disk space cleanup step_
> _autumn leaves fall_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9eb770</samp>

*  Add a step to free up disk space on the GitHub runner using the jlumbroso/free-disk-space action for all the workflows that build docker images for different architectures and projects ([link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R36-R45), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R85-R94), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R223-R232), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R250-R259), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R285-R294), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R396-R405), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R556-R565), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R711-R720), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R842-R851), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R996-R1005), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1099-R1108), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1145-R1154), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1191-R1200), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1239-R1248), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1290-R1299), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1389-R1398), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1482-R1491), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1586-R1595), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1647-R1656), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1778-R1787), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1892-R1901), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1984-R1993), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R2096-R2105), [link](https://github.com/kubeovn/kube-ovn/pull/3406/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R2209-R2218))
