### PR TITLE
fix kube-ovn-monitor probe

### DIFF
--- a/charts/templates/monitor-deploy.yaml
+++ b/charts/templates/monitor-deploy.yaml
@@ -90,22 +90,22 @@ spec:
               name: kube-ovn-tls
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
-          readinessProbe:
-            exec:
-              command:
-              - cat
-              - /var/run/ovn/ovn-controller.pid
-            periodSeconds: 10
-            timeoutSeconds: 45
           livenessProbe:
-            exec:
-              command:
-              - cat
-              - /var/run/ovn/ovn-controller.pid
+            failureThreshold: 3
             initialDelaySeconds: 30
-            periodSeconds: 10
-            failureThreshold: 5
-            timeoutSeconds: 45
+            periodSeconds: 7
+            successThreshold: 1
+            tcpSocket:
+              port: 10661
+            timeoutSeconds: 3
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 7
+            successThreshold: 1
+            tcpSocket:
+              port: 10661
+            timeoutSeconds: 3
       nodeSelector:
         kubernetes.io/os: "linux"
         kube-ovn/role: "master"

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4463,22 +4463,22 @@ spec:
               name: kube-ovn-tls
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
-          readinessProbe:
-            exec:
-              command:
-              - cat
-              - /var/run/ovn/ovn-controller.pid
-            periodSeconds: 10
-            timeoutSeconds: 45
           livenessProbe:
-            exec:
-              command:
-              - cat
-              - /var/run/ovn/ovn-controller.pid
+            failureThreshold: 3
             initialDelaySeconds: 30
-            periodSeconds: 10
-            failureThreshold: 5
-            timeoutSeconds: 45
+            periodSeconds: 7
+            successThreshold: 1
+            tcpSocket:
+              port: 10661
+            timeoutSeconds: 3
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 7
+            successThreshold: 1
+            tcpSocket:
+              port: 10661
+            timeoutSeconds: 3
       nodeSelector:
         kubernetes.io/os: "linux"
         kube-ovn/role: "master"


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #3330

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02d3b29</samp>

Change the health probes of ovn-controller container to use tcpSocket instead of exec. Improve the probe parameters to handle ovn-controller failures better. Fix issue #1212.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 02d3b29</samp>

> _`tcpSocket` probe_
> _checks ovn-controller port_
> _cutting false alarms_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02d3b29</samp>

*  Change the livenessProbe and readinessProbe of the ovn-controller container to use tcpSocket instead of exec ([link](https://github.com/kubeovn/kube-ovn/pull/3409/files?diff=unified&w=0#diff-aafeafe291807e5f2688246fed7cd4cb6104522cd3e9e6b9cb671249fc5fcb73L93-R108))
