### PR TITLE
support ovn ic ecmp (#3348)

### DIFF
--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-TS_NAME=${TS_NAME:-ts}
-PROTOCOL=${PROTOCOL:-ipv4}
-if [ "$PROTOCOL" = "ipv4" ]; then
-  TS_CIDR=${TS_CIDR:-169.254.100.0/24}
-elif [ "$PROTOCOL" = "ipv6" ]; then
-  TS_CIDR=${TS_CIDR:-fe80:a9fe:64::/112}
-elif [ "$PROTOCOL" = "dual" ]; then
-  TS_CIDR=${TS_CIDR:-"169.254.100.0/24,fe80:a9fe:64::/112"}
-fi
-
 function quit {
     /usr/share/ovn/scripts/ovn-ctl stop_ic_ovsdb
     exit 0
@@ -26,8 +16,6 @@ trap quit EXIT
 if [[ -z "$NODE_IPS" && -z "$LOCAL_IP" ]]; then
     /usr/share/ovn/scripts/ovn-ctl --db-ic-nb-create-insecure-remote=yes --db-ic-sb-create-insecure-remote=yes --db-ic-nb-addr="[::]" --db-ic-sb-addr="[::]" start_ic_ovsdb
     /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
-    ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
-    ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
     tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
 else
     if [[ -z "$LEADER_IP" ]]; then
@@ -40,8 +28,6 @@ else
         --ovn-ic-sb-db="$(gen_conn_str 6648)" \
         start_ic_ovsdb
         /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
-        ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
-        ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
         tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
     else
         echo "follower start with local ${LOCAL_IP}, leader ${LEADER_IP} and cluster $(gen_conn_str 6647)"

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -676,6 +676,20 @@ func (mr *MockLogicalSwitchPortMockRecorder) DeleteLogicalSwitchPort(lspName int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPort", reflect.TypeOf((*MockLogicalSwitchPort)(nil).DeleteLogicalSwitchPort), lspName)
 }
 
+// DeleteLogicalSwitchPorts mocks base method.
+func (m *MockLogicalSwitchPort) DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(*ovnnb.LogicalSwitchPort) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLogicalSwitchPorts", externalIDs, filter)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLogicalSwitchPorts indicates an expected call of DeleteLogicalSwitchPorts.
+func (mr *MockLogicalSwitchPortMockRecorder) DeleteLogicalSwitchPorts(externalIDs, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPorts", reflect.TypeOf((*MockLogicalSwitchPort)(nil).DeleteLogicalSwitchPorts), externalIDs, filter)
+}
+
 // EnablePortLayer2forward mocks base method.
 func (m *MockLogicalSwitchPort) EnablePortLayer2forward(lspName string) error {
 	m.ctrl.T.Helper()
@@ -1855,6 +1869,21 @@ func (mr *MockLogicalRouterPolicyMockRecorder) DeleteLogicalRouterPolicyByUUID(l
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalRouterPolicyByUUID", reflect.TypeOf((*MockLogicalRouterPolicy)(nil).DeleteLogicalRouterPolicyByUUID), lrName, uuid)
 }
 
+// GetLogicalRouterPoliciesByExtID mocks base method.
+func (m *MockLogicalRouterPolicy) GetLogicalRouterPoliciesByExtID(lrName, key, value string) ([]*ovnnb.LogicalRouterPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogicalRouterPoliciesByExtID", lrName, key, value)
+	ret0, _ := ret[0].([]*ovnnb.LogicalRouterPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLogicalRouterPoliciesByExtID indicates an expected call of GetLogicalRouterPoliciesByExtID.
+func (mr *MockLogicalRouterPolicyMockRecorder) GetLogicalRouterPoliciesByExtID(lrName, key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogicalRouterPoliciesByExtID", reflect.TypeOf((*MockLogicalRouterPolicy)(nil).GetLogicalRouterPoliciesByExtID), lrName, key, value)
+}
+
 // GetLogicalRouterPolicy mocks base method.
 func (m *MockLogicalRouterPolicy) GetLogicalRouterPolicy(lrName string, priority int, match string, ignoreNotFound bool) ([]*ovnnb.LogicalRouterPolicy, error) {
 	m.ctrl.T.Helper()
@@ -1871,18 +1900,18 @@ func (mr *MockLogicalRouterPolicyMockRecorder) GetLogicalRouterPolicy(lrName, pr
 }
 
 // ListLogicalRouterPolicies mocks base method.
-func (m *MockLogicalRouterPolicy) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string) ([]*ovnnb.LogicalRouterPolicy, error) {
+func (m *MockLogicalRouterPolicy) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string, ignoreExtIDEmptyValue bool) ([]*ovnnb.LogicalRouterPolicy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLogicalRouterPolicies", lrName, priority, externalIDs)
+	ret := m.ctrl.Call(m, "ListLogicalRouterPolicies", lrName, priority, externalIDs, ignoreExtIDEmptyValue)
 	ret0, _ := ret[0].([]*ovnnb.LogicalRouterPolicy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListLogicalRouterPolicies indicates an expected call of ListLogicalRouterPolicies.
-func (mr *MockLogicalRouterPolicyMockRecorder) ListLogicalRouterPolicies(lrName, priority, externalIDs interface{}) *gomock.Call {
+func (mr *MockLogicalRouterPolicyMockRecorder) ListLogicalRouterPolicies(lrName, priority, externalIDs, ignoreExtIDEmptyValue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogicalRouterPolicies", reflect.TypeOf((*MockLogicalRouterPolicy)(nil).ListLogicalRouterPolicies), lrName, priority, externalIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogicalRouterPolicies", reflect.TypeOf((*MockLogicalRouterPolicy)(nil).ListLogicalRouterPolicies), lrName, priority, externalIDs, ignoreExtIDEmptyValue)
 }
 
 // MockNAT is a mock of NAT interface.
@@ -2834,6 +2863,20 @@ func (mr *MockNbClientMockRecorder) DeleteLogicalSwitchPort(lspName interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPort", reflect.TypeOf((*MockNbClient)(nil).DeleteLogicalSwitchPort), lspName)
 }
 
+// DeleteLogicalSwitchPorts mocks base method.
+func (m *MockNbClient) DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(*ovnnb.LogicalSwitchPort) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLogicalSwitchPorts", externalIDs, filter)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLogicalSwitchPorts indicates an expected call of DeleteLogicalSwitchPorts.
+func (mr *MockNbClientMockRecorder) DeleteLogicalSwitchPorts(externalIDs, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPorts", reflect.TypeOf((*MockNbClient)(nil).DeleteLogicalSwitchPorts), externalIDs, filter)
+}
+
 // DeleteNat mocks base method.
 func (m *MockNbClient) DeleteNat(lrName, natType, externalIP, logicalIP string) error {
 	m.ctrl.T.Helper()
@@ -2962,6 +3005,21 @@ func (m *MockNbClient) GetLogicalRouter(lrName string, ignoreNotFound bool) (*ov
 func (mr *MockNbClientMockRecorder) GetLogicalRouter(lrName, ignoreNotFound interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogicalRouter", reflect.TypeOf((*MockNbClient)(nil).GetLogicalRouter), lrName, ignoreNotFound)
+}
+
+// GetLogicalRouterPoliciesByExtID mocks base method.
+func (m *MockNbClient) GetLogicalRouterPoliciesByExtID(lrName, key, value string) ([]*ovnnb.LogicalRouterPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogicalRouterPoliciesByExtID", lrName, key, value)
+	ret0, _ := ret[0].([]*ovnnb.LogicalRouterPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLogicalRouterPoliciesByExtID indicates an expected call of GetLogicalRouterPoliciesByExtID.
+func (mr *MockNbClientMockRecorder) GetLogicalRouterPoliciesByExtID(lrName, key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogicalRouterPoliciesByExtID", reflect.TypeOf((*MockNbClient)(nil).GetLogicalRouterPoliciesByExtID), lrName, key, value)
 }
 
 // GetLogicalRouterPolicy mocks base method.
@@ -3145,18 +3203,18 @@ func (mr *MockNbClientMockRecorder) ListLogicalRouter(needVendorFilter, filter i
 }
 
 // ListLogicalRouterPolicies mocks base method.
-func (m *MockNbClient) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string) ([]*ovnnb.LogicalRouterPolicy, error) {
+func (m *MockNbClient) ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string, ignoreExtIDEmptyValue bool) ([]*ovnnb.LogicalRouterPolicy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLogicalRouterPolicies", lrName, priority, externalIDs)
+	ret := m.ctrl.Call(m, "ListLogicalRouterPolicies", lrName, priority, externalIDs, ignoreExtIDEmptyValue)
 	ret0, _ := ret[0].([]*ovnnb.LogicalRouterPolicy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListLogicalRouterPolicies indicates an expected call of ListLogicalRouterPolicies.
-func (mr *MockNbClientMockRecorder) ListLogicalRouterPolicies(lrName, priority, externalIDs interface{}) *gomock.Call {
+func (mr *MockNbClientMockRecorder) ListLogicalRouterPolicies(lrName, priority, externalIDs, ignoreExtIDEmptyValue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogicalRouterPolicies", reflect.TypeOf((*MockNbClient)(nil).ListLogicalRouterPolicies), lrName, priority, externalIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogicalRouterPolicies", reflect.TypeOf((*MockNbClient)(nil).ListLogicalRouterPolicies), lrName, priority, externalIDs, ignoreExtIDEmptyValue)
 }
 
 // ListLogicalRouterPorts mocks base method.

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -1239,7 +1239,7 @@ func (c *Controller) deletePolicyRouteForLocalDNSCacheOnNode(nodeName string, af
 		"node":            nodeName,
 		"address-family":  strconv.Itoa(af),
 		"isLocalDnsCache": "true",
-	})
+	}, true)
 	if err != nil {
 		klog.Errorf("failed to list logical router policies: %v", err)
 		return err

--- a/pkg/controller/ovn_ic.go
+++ b/pkg/controller/ovn_ic.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -165,15 +166,22 @@ func (c *Controller) removeInterConnection(azName string) error {
 	}
 
 	if azName != "" {
-		lspName := fmt.Sprintf("ts-%s", azName)
-		lrpName := fmt.Sprintf("%s-ts", azName)
-		if err := c.OVNNbClient.RemoveLogicalPatchPort(lspName, lrpName); err != nil {
-			klog.Errorf("delete ovn-ic logical port %s and %s: %v", lspName, lrpName, err)
+		if err := c.OVNNbClient.DeleteLogicalSwitchPorts(nil, func(lsp *ovnnb.LogicalSwitchPort) bool {
+			names := strings.Split(lsp.Name, "-")
+			return len(names) == 2 && names[1] == azName && strings.HasPrefix(names[0], "ts")
+		}); err != nil {
+			return err
+		}
+
+		if err := c.OVNNbClient.DeleteLogicalRouterPorts(nil, func(lrp *ovnnb.LogicalRouterPort) bool {
+			names := strings.Split(lrp.Name, "-")
+			return len(names) == 2 && names[0] == azName && strings.HasPrefix(names[1], "ts")
+		}); err != nil {
 			return err
 		}
 	}
 
-	if err := c.stopOvnIC(); err != nil {
+	if err := c.stopOVNIC(); err != nil {
 		klog.Errorf("failed to stop ovn-ic, %v", err)
 		return err
 	}
@@ -182,21 +190,9 @@ func (c *Controller) removeInterConnection(azName string) error {
 }
 
 func (c *Controller) establishInterConnection(config map[string]string) error {
-	if err := c.startOvnIC(config["ic-db-host"], config["ic-nb-port"], config["ic-sb-port"]); err != nil {
+	if err := c.startOVNIC(config["ic-db-host"], config["ic-nb-port"], config["ic-sb-port"]); err != nil {
 		klog.Errorf("failed to start ovn-ic, %v", err)
 		return err
-	}
-
-	tsPort := fmt.Sprintf("ts-%s", config["az-name"])
-	exist, err := c.OVNNbClient.LogicalSwitchPortExists(tsPort)
-	if err != nil {
-		klog.Errorf("failed to list logical switch ports, %v", err)
-		return err
-	}
-
-	if exist {
-		klog.Infof("ts port %s already exists", tsPort)
-		return nil
 	}
 
 	if err := c.OVNNbClient.SetAzName(config["az-name"]); err != nil {
@@ -204,66 +200,81 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 		return err
 	}
 
-	chassises := []string{}
-	gwNodes := strings.Split(config["gw-nodes"], ",")
-	for _, gw := range gwNodes {
-		gw = strings.TrimSpace(gw)
-		cachedNode, err := c.nodesLister.Get(gw)
-		if err != nil {
-			klog.Errorf("failed to get gw node %s, %v", gw, err)
-			return err
-		}
-		node := cachedNode.DeepCopy()
-		patchPayloadTemplate := `[{
-        "op": "%s",
-        "path": "/metadata/labels",
-        "value": %s
-    	}]`
-		op := "replace"
-		if len(node.Labels) == 0 {
-			op = "add"
-		}
-		node.Labels[util.ICGatewayLabel] = "true"
-		raw, _ := json.Marshal(node.Labels)
-		patchPayload := fmt.Sprintf(patchPayloadTemplate, op, raw)
-		_, err = c.config.KubeClient.CoreV1().Nodes().Patch(context.Background(), gw, types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}, "")
-		if err != nil {
-			klog.Errorf("patch gw node %s failed %v", gw, err)
-			return err
-		}
-		annoChassisName := node.Annotations[util.ChassisAnnotation]
-		if annoChassisName == "" {
-			err := fmt.Errorf("node %s has no chassis annotation, kube-ovn-cni not ready", gw)
-			klog.Error(err)
-			return err
-		}
-		klog.Infof("gw node %s chassis %s", gw, annoChassisName)
-		chassis, err := c.OVNSbClient.GetChassis(annoChassisName, false)
-		if err != nil {
-			klog.Errorf("failed to get node chassis %s, %v", annoChassisName, err)
-			return err
-		}
-		chassises = append(chassises, chassis.Name)
-	}
-	if len(chassises) == 0 {
-		klog.Error("no available ic gw")
-		return fmt.Errorf("no available ic gw")
-	}
-	if err := c.waitTsReady(); err != nil {
-		klog.Errorf("failed to wait ts ready, %v", err)
-		return err
-	}
+	groups := strings.Split(config["gw-nodes"], ";")
+	for i, group := range groups {
+		gwNodes := strings.Split(group, ",")
+		chassises := make([]string, len(gwNodes))
+		for j, gw := range gwNodes {
+			gw = strings.TrimSpace(gw)
+			chassis, err := c.OVNSbClient.GetChassisByHost(gw)
+			if err != nil {
+				klog.Errorf("failed to get gw %s chassis: %v", gw, err)
+				return err
+			}
+			if chassis.Name == "" {
+				return fmt.Errorf("no chassis for gw %s", gw)
+			}
+			chassises[j] = chassis.Name
 
-	lrpIP, err := c.acquireLrpAddress(util.InterconnectionSwitch)
-	if err != nil {
-		klog.Errorf("failed to acquire lrp address, %v", err)
-		return err
-	}
+			cachedNode, err := c.nodesLister.Get(gw)
+			if err != nil {
+				klog.Errorf("failed to get gw node %s, %v", gw, err)
+				return err
+			}
+			node := cachedNode.DeepCopy()
+			patchPayloadTemplate := `[{
+			"op": "%s",
+			"path": "/metadata/labels",
+			"value": %s
+			}]`
+			op := "replace"
+			if len(node.Labels) == 0 {
+				op = "add"
+			}
+			node.Labels[util.ICGatewayLabel] = "true"
+			raw, _ := json.Marshal(node.Labels)
+			patchPayload := fmt.Sprintf(patchPayloadTemplate, op, raw)
+			_, err = c.config.KubeClient.CoreV1().Nodes().Patch(context.Background(), gw, types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}, "")
+			if err != nil {
+				klog.Errorf("patch gw node %s failed %v", gw, err)
+				return err
+			}
+		}
 
-	lrpName := fmt.Sprintf("%s-ts", config["az-name"])
-	if err := c.OVNNbClient.CreateLogicalPatchPort(util.InterconnectionSwitch, c.config.ClusterRouter, tsPort, lrpName, lrpIP, util.GenerateMac(), chassises...); err != nil {
-		klog.Errorf("failed to create ovn-ic lrp %v", err)
-		return err
+		tsName := c.getTSName(i)
+		cidr, err := c.getTSCidr(i)
+		if err != nil {
+			klog.Errorf("failed to get ts cidr index %d err: %v", i, err)
+			return err
+		}
+
+		if err := c.createTS(genHostAddress(config["ic-db-host"], config["ic-nb-port"]), tsName, cidr); err != nil {
+			klog.Errorf("failed to create ts %q: %v", tsName, err)
+			return err
+		}
+
+		tsPort := fmt.Sprintf("%s-%s", tsName, config["az-name"])
+		exist, err := c.OVNNbClient.LogicalSwitchPortExists(tsPort)
+		if err != nil {
+			klog.Errorf("failed to list logical switch ports, %v", err)
+			return err
+		}
+		if exist {
+			klog.Infof("ts port %s already exists", tsPort)
+			continue
+		}
+
+		lrpAddr, err := c.acquireLrpAddress(tsName)
+		if err != nil {
+			klog.Errorf("failed to acquire lrp address, %v", err)
+			return err
+		}
+
+		lrpName := fmt.Sprintf("%s-%s", config["az-name"], tsName)
+		if err := c.OVNNbClient.CreateLogicalPatchPort(tsName, c.config.ClusterRouter, tsPort, lrpName, lrpAddr, util.GenerateMac(), chassises...); err != nil {
+			klog.Errorf("failed to create ovn-ic lrp %q: %v", lrpName, err)
+			return err
+		}
 	}
 
 	return nil
@@ -272,12 +283,12 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 func (c *Controller) acquireLrpAddress(ts string) (string, error) {
 	cidr, err := c.ovnLegacyClient.GetTsSubnet(ts)
 	if err != nil {
-		klog.Errorf("failed to get ts subnet: %v", err)
+		klog.Errorf("failed to get ts subnet %s: %v", ts, err)
 		return "", err
 	}
 	existAddress, err := c.listRemoteLogicalSwitchPortAddress()
 	if err != nil {
-		klog.Errorf("list remote port address: %v", err)
+		klog.Errorf("failed to list remote port address, %v", err)
 		return "", err
 	}
 
@@ -303,7 +314,7 @@ func (c *Controller) acquireLrpAddress(ts string) (string, error) {
 	}
 }
 
-func (c *Controller) startOvnIC(icHost, icNbPort, icSbPort string) error {
+func (c *Controller) startOVNIC(icHost, icNbPort, icSbPort string) error {
 	cmd := exec.Command("/usr/share/ovn/scripts/ovn-ctl",
 		fmt.Sprintf("--ovn-ic-nb-db=%s", genHostAddress(icHost, icNbPort)),
 		fmt.Sprintf("--ovn-ic-sb-db=%s", genHostAddress(icHost, icSbPort)),
@@ -323,40 +334,39 @@ func (c *Controller) startOvnIC(icHost, icNbPort, icSbPort string) error {
 	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Error(err)
-		return fmt.Errorf("%s", output)
+		return fmt.Errorf("output: %s, err: %v", output, err)
 	}
 	return nil
 }
 
-func (c *Controller) stopOvnIC() error {
+func (c *Controller) stopOVNIC() error {
 	cmd := exec.Command("/usr/share/ovn/scripts/ovn-ctl", "stop_ic")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Error(err)
-		return fmt.Errorf("%s", output)
+		return fmt.Errorf("output: %s, err: %v", output, err)
 	}
 	return nil
 }
 
-func (c *Controller) waitTsReady() error {
-	retry := 6
-	for retry > 0 {
-		ready, err := c.allSubnetReady(util.InterconnectionSwitch)
-		if err != nil {
-			klog.Error(err)
-			return err
-		}
-
-		if ready {
-			return nil
-		}
-
-		klog.Info("wait for logical switch %s ready", util.InterconnectionSwitch)
-		time.Sleep(5 * time.Second)
-		retry--
+func (c *Controller) createTS(icNBAddr, tsName, subnet string) error {
+	cmd := exec.Command("ovn-ic-nbctl",
+		fmt.Sprintf("--db=%s", icNBAddr),
+		ovs.MayExist, "ts-add", tsName,
+		"--", "set", "Transit_Switch", tsName, fmt.Sprintf(`external_ids:subnet="%s"`, subnet))
+	if os.Getenv("ENABLE_SSL") == "true" {
+		cmd = exec.Command("ovn-ic-nbctl",
+			fmt.Sprintf("--db=%s", icNBAddr),
+			"--private-key=/var/run/tls/key",
+			"--certificate=/var/run/tls/cert",
+			"--ca-cert=/var/run/tls/cacert",
+			ovs.MayExist, "ts-add", tsName,
+			"--", "set", "Transit_Switch", tsName, fmt.Sprintf(`external_ids:subnet="%s"`, subnet))
 	}
-	return fmt.Errorf("timeout to wait for logical switch %s ready", util.InterconnectionSwitch)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("output: %s, err: %v", output, err)
+	}
+	return nil
 }
 
 func (c *Controller) delLearnedRoute() error {
@@ -372,12 +382,16 @@ func (c *Controller) delLearnedRoute() error {
 			return err
 		}
 		for _, r := range routeList {
+			var policy ovnnb.LogicalRouterStaticRoutePolicy
+			if r.Policy != nil {
+				policy = *r.Policy
+			}
 			if err = c.deleteStaticRouteFromVpc(
 				lr.Name,
 				r.RouteTable,
 				r.IPPrefix,
 				r.Nexthop,
-				reversePolicy(*r.Policy),
+				reversePolicy(policy),
 			); err != nil {
 				klog.Errorf("failed to delete learned static route %#v on logical router %s: %v", r, lr.Name, err)
 				return err
@@ -409,6 +423,8 @@ func genHostAddress(host, port string) (hostAddress string) {
 func (c *Controller) SynRouteToPolicy() {
 	c.syncOneRouteToPolicy(util.OvnICKey, util.OvnICConnected)
 	c.syncOneRouteToPolicy(util.OvnICKey, util.OvnICStatic)
+	// To support the version before kube-ovn v1.9, in which version the option tag is origin=""
+	c.syncOneRouteToPolicy(util.OvnICKey, util.OvnICNone)
 }
 
 func (c *Controller) RemoveOldChassisInSbDB(azName string) error {
@@ -459,6 +475,13 @@ func (c *Controller) syncOneRouteToPolicy(key, value string) {
 		klog.Errorf("failed to list lr ovn-ic route %v", err)
 		return
 	}
+
+	lrPolicyList, err := c.OVNNbClient.GetLogicalRouterPoliciesByExtID(lr.Name, key, value)
+	if err != nil {
+		klog.Errorf("failed to list ovn-ic lr policy: %v", err)
+		return
+	}
+
 	if len(lrRouteList) == 0 {
 		klog.V(5).Info("lr ovn-ic route does not exist")
 		err := c.OVNNbClient.DeleteLogicalRouterPolicies(lr.Name, util.OvnICPolicyPriority, map[string]string{key: value})
@@ -470,55 +493,36 @@ func (c *Controller) syncOneRouteToPolicy(key, value string) {
 	}
 
 	policyMap := map[string]string{}
-	lrPolicyList, err := c.OVNNbClient.ListLogicalRouterPolicies(lr.Name, util.OvnICPolicyPriority, map[string]string{key: value})
-	if err != nil {
-		klog.Errorf("failed to list ovn-ic lr policy ", err)
-		return
-	}
+
 	for _, lrPolicy := range lrPolicyList {
 		match, err := stripPrefix(lrPolicy.Match)
 		if err != nil {
-			klog.Errorf("policy match abnormal ", err)
+			klog.Errorf("policy match abnormal: %v", err)
 			continue
 		}
 		policyMap[match] = lrPolicy.UUID
 	}
+	networks := strset.NewWithSize(len(lrRouteList))
 	for _, lrRoute := range lrRouteList {
-		if _, ok := policyMap[lrRoute.IPPrefix]; ok {
-			delete(policyMap, lrRoute.IPPrefix)
-		} else {
-			var matchFiled string
-			if util.CheckProtocol(lrRoute.IPPrefix) == kubeovnv1.ProtocolIPv4 {
-				matchFiled = util.MatchV4Dst + " == " + lrRoute.IPPrefix
-				if err := c.addPolicyRouteToVpc(
-					lr.Name,
-					&kubeovnv1.PolicyRoute{
-						Priority: util.OvnICPolicyPriority,
-						Match:    matchFiled,
-						Action:   kubeovnv1.PolicyRouteActionAllow,
-					},
-					map[string]string{key: value, "vendor": util.CniTypeName},
-				); err != nil {
-					klog.Errorf("adding router policy failed %v", err)
-				}
-			}
-
-			if util.CheckProtocol(lrRoute.IPPrefix) == kubeovnv1.ProtocolIPv6 {
-				matchFiled = util.MatchV6Dst + " == " + lrRoute.IPPrefix
-				if err := c.addPolicyRouteToVpc(
-					lr.Name,
-					&kubeovnv1.PolicyRoute{
-						Priority: util.OvnICPolicyPriority,
-						Match:    matchFiled,
-						Action:   kubeovnv1.PolicyRouteActionAllow,
-					},
-					map[string]string{key: value, "vendor": util.CniTypeName},
-				); err != nil {
-					klog.Errorf("adding router policy failed %v", err)
-				}
-			}
-		}
+		networks.Add(lrRoute.IPPrefix)
 	}
+
+	networks.Each(func(prefix string) bool {
+		if _, ok := policyMap[prefix]; ok {
+			delete(policyMap, prefix)
+			return true
+		}
+		match := util.MatchV4Dst + " == " + prefix
+		if util.CheckProtocol(prefix) == kubeovnv1.ProtocolIPv6 {
+			match = util.MatchV6Dst + " == " + prefix
+		}
+
+		if err = c.OVNNbClient.AddLogicalRouterPolicy(lr.Name, util.OvnICPolicyPriority, match, ovnnb.LogicalRouterPolicyActionAllow, nil, map[string]string{key: value, "vendor": util.CniTypeName}); err != nil {
+			klog.Errorf("failed to add router policy: %v", err)
+		}
+
+		return true
+	})
 	for _, uuid := range policyMap {
 		if err := c.OVNNbClient.DeleteLogicalRouterPolicyByUUID(lr.Name, uuid); err != nil {
 			klog.Errorf("deleting router policy failed %v", err)
@@ -552,4 +556,29 @@ func (c *Controller) listRemoteLogicalSwitchPortAddress() (*strset.Set, error) {
 	}
 
 	return existAddress, nil
+}
+
+func (c *Controller) getTSName(index int) string {
+	if index == 0 {
+		return util.InterconnectionSwitch
+	}
+	return fmt.Sprintf("%s%d", util.InterconnectionSwitch, index)
+}
+
+func (c *Controller) getTSCidr(index int) (string, error) {
+	defaultSubnet, err := c.subnetsLister.Get(c.config.DefaultLogicalSwitch)
+	if err != nil {
+		return "", err
+	}
+
+	var cidr string
+	switch defaultSubnet.Spec.Protocol {
+	case kubeovnv1.ProtocolIPv4:
+		cidr = fmt.Sprintf("169.254.%d.0/24", 100+index)
+	case kubeovnv1.ProtocolIPv6:
+		cidr = fmt.Sprintf("fe80:a9fe:%02x::/112", 100+index)
+	case kubeovnv1.ProtocolDual:
+		cidr = fmt.Sprintf("169.254.%d.0/24,fe80:a9fe:%02x::/112", 100+index, 100+index)
+	}
+	return cidr, nil
 }

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2655,7 +2655,7 @@ func (c *Controller) deletePolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) 
 		"isU2ORoutePolicy": "true",
 		"vendor":           util.CniTypeName,
 		"subnet":           subnet.Name,
-	})
+	}, true)
 	if err != nil {
 		klog.Errorf("failed to list logical router policies: %v", err)
 		return err

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -464,7 +464,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 				return err
 			}
 		} else {
-			policyRouteLogical, err = c.OVNNbClient.ListLogicalRouterPolicies(vpc.Name, -1, nil)
+			policyRouteLogical, err = c.OVNNbClient.ListLogicalRouterPolicies(vpc.Name, -1, nil, true)
 			if err != nil {
 				klog.Errorf("failed to get vpc %s policy route list, %v", vpc.Name, err)
 				return err

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -69,6 +69,7 @@ type LogicalSwitchPort interface {
 	SetLogicalSwitchPortsSecurityGroup(sgName, op string) error
 	EnablePortLayer2forward(lspName string) error
 	DeleteLogicalSwitchPort(lspName string) error
+	DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(lsp *ovnnb.LogicalSwitchPort) bool) error
 	ListLogicalSwitchPorts(needVendorFilter bool, externalIDs map[string]string, filter func(lsp *ovnnb.LogicalSwitchPort) bool) ([]ovnnb.LogicalSwitchPort, error)
 	ListNormalLogicalSwitchPorts(needVendorFilter bool, externalIDs map[string]string) ([]ovnnb.LogicalSwitchPort, error)
 	ListLogicalSwitchPortsWithLegacyExternalIDs() ([]ovnnb.LogicalSwitchPort, error)
@@ -152,8 +153,9 @@ type LogicalRouterPolicy interface {
 	DeleteLogicalRouterPolicyByUUID(lrName, uuid string) error
 	DeleteLogicalRouterPolicyByNexthop(lrName string, priority int, nexthop string) error
 	ClearLogicalRouterPolicy(lrName string) error
-	ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string) ([]*ovnnb.LogicalRouterPolicy, error)
+	ListLogicalRouterPolicies(lrName string, priority int, externalIDs map[string]string, ignoreExtIDEmptyValue bool) ([]*ovnnb.LogicalRouterPolicy, error)
 	GetLogicalRouterPolicy(lrName string, priority int, match string, ignoreNotFound bool) ([]*ovnnb.LogicalRouterPolicy, error)
+	GetLogicalRouterPoliciesByExtID(lrName, key, value string) ([]*ovnnb.LogicalRouterPolicy, error)
 }
 
 type NAT interface {

--- a/pkg/ovs/ovn-nb-logical_router_policy_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy_test.go
@@ -159,7 +159,7 @@ func (suite *OvnClientTestSuite) testDeleteLogicalRouterPolicies() {
 		require.NoError(t, err)
 		require.Len(t, lr.Policies, 3)
 
-		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs)
+		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs, true)
 		require.NoError(t, err)
 		require.Len(t, policies, 3)
 	}
@@ -174,7 +174,7 @@ func (suite *OvnClientTestSuite) testDeleteLogicalRouterPolicies() {
 		require.NoError(t, err)
 		require.Empty(t, lr.Policies)
 
-		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs)
+		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs, true)
 		require.NoError(t, err)
 		require.Empty(t, policies)
 	})
@@ -190,7 +190,7 @@ func (suite *OvnClientTestSuite) testDeleteLogicalRouterPolicies() {
 		require.Len(t, lr.Policies, 2)
 
 		// no basePriority policy
-		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs)
+		policies, err := ovnClient.ListLogicalRouterPolicies(lrName, -1, externalIDs, true)
 		require.NoError(t, err)
 		require.Len(t, policies, 2)
 	})
@@ -342,7 +342,7 @@ func (suite *OvnClientTestSuite) testPolicyFilter() {
 	}
 
 	t.Run("include all policies", func(t *testing.T) {
-		filterFunc := policyFilter(-1, nil)
+		filterFunc := policyFilter(-1, nil, true)
 		count := 0
 		for _, policy := range policies {
 			if filterFunc(policy) {
@@ -353,7 +353,7 @@ func (suite *OvnClientTestSuite) testPolicyFilter() {
 	})
 
 	t.Run("include all policies with external ids", func(t *testing.T) {
-		filterFunc := policyFilter(-1, map[string]string{"k1": "v1"})
+		filterFunc := policyFilter(-1, map[string]string{"k1": "v1"}, true)
 		count := 0
 		for _, policy := range policies {
 			if filterFunc(policy) {
@@ -364,7 +364,7 @@ func (suite *OvnClientTestSuite) testPolicyFilter() {
 	})
 
 	t.Run("include all policies with same priority", func(t *testing.T) {
-		filterFunc := policyFilter(10000, map[string]string{"k1": "v1"})
+		filterFunc := policyFilter(10000, map[string]string{"k1": "v1"}, true)
 		count := 0
 		for _, policy := range policies {
 			if filterFunc(policy) {
@@ -381,7 +381,7 @@ func (suite *OvnClientTestSuite) testPolicyFilter() {
 		filterFunc := policyFilter(-1, map[string]string{
 			"k1":  "v1",
 			"key": "value",
-		})
+		}, true)
 		require.False(t, filterFunc(policy))
 	})
 }

--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -18,7 +18,12 @@ import (
 
 func (c *OVNNbClient) ListLogicalRouterStaticRoutesByOption(lrName, _, key, value string) ([]*ovnnb.LogicalRouterStaticRoute, error) {
 	fnFilter := func(route *ovnnb.LogicalRouterStaticRoute) bool {
-		return len(route.Options) != 0 && route.Options[key] == value
+		if len(route.Options) != 0 {
+			if _, ok := route.Options[key]; ok {
+				return route.Options[key] == value
+			}
+		}
+		return false
 	}
 	return c.listLogicalRouterStaticRoutesByFilter(lrName, fnFilter)
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -233,6 +233,7 @@ const (
 	OvnICKey       = "origin"
 	OvnICConnected = "connected"
 	OvnICStatic    = "static"
+	OvnICNone      = ""
 
 	MatchV4Src = "ip4.src"
 	MatchV4Dst = "ip4.dst"

--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -10,6 +10,9 @@
 {%- if ha is not defined -%}
   {%- set ha = "false" -%}
 {%- endif -%}
+{%- if ovn_ic is not defined -%}
+  {%- set ovn_ic = "false" -%}
+{%- endif -%}
 {%- if single is not defined -%}
   {%- set single = "false" -%}
 {%- endif -%}
@@ -78,5 +81,8 @@ nodes:
     image: kindest/node:{{ k8s_version }}
     labels:
       kube-ovn/role: master
+  {%- elif ovn_ic is equalto "true" %}
+  - role: worker
+    image: kindest/node:{{ k8s_version }}
   {%- endif %}
 {%- endif %}


### PR DESCRIPTION
* support ovn ic ecmp

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a093a5a</samp>

This pull request adds and improves features for the ovn interconnection (ovn-ic) between OVN clusters. It updates the `Makefile` and the `kind.yaml.j2` template to enable ovn-ic in the kind environment. It adds new methods and parameters to the `ovs` package for managing logical router policies and logical switch ports based on external IDs. It modifies the `controller` package to use the new methods and parameters and to handle different CIDR formats and route options. It also fixes some format, error, and duplication issues in the code. It adds a new constant `OvnICNone` to the `util` package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a093a5a</samp>

> _`ovs` package grows_
> _adding methods and options_
> _autumn of changes_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a093a5a</samp>

*  Add and modify methods for interacting with the OVN databases ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R679-R692), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R1872-R1886), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L1874-R1905), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L1883-R1914), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R2866-R2879), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R3010-R3024), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L3148-R3208), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L3157-R3217), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49R72), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49L155-R158), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L32-R33), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L112-R113), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L227-R236), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L235-R243), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L252-R259), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L260-R270), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-386553eb41be041eafc944d6270c154cf99b46609ef142b487ce1e2d8dd089d6L21-R26), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-ae7af3149f89df0e91a059141f595e8a25f31da089acc436f931a1ebf3c90305R507-R531))
  * Add `DeleteLogicalSwitchPorts` method to delete logical switch ports by external IDs and filter function ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R679-R692), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49R72), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-ae7af3149f89df0e91a059141f595e8a25f31da089acc436f931a1ebf3c90305R507-R531))
  * Add `GetLogicalRouterPoliciesByExtID` method to get logical router policies by external ID key and value ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R1872-R1886), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-50fe35ba11ad04edb53bfaccef915df3650a81844495ed73d3c158e975c04c49L155-R158), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L227-R236))
  * Modify `ListLogicalRouterPolicies` method to add `ignoreExtIDEmptyValue` parameter and use it to filter policies by external IDs ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L1874-R1905), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L1883-R1914), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L3148-R3208), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71L3157-R3217), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L235-R243), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L252-R259), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L260-R270))
  * Modify `AddLogicalRouterPolicy` method to compare external IDs of existing policies and avoid duplicates ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L32-R33))
  * Modify `DeleteLogicalRouterPolicies` method to add `ignoreExtIDEmptyValue` parameter and pass it to `ListLogicalRouterPolicies` method ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-870a13295328bc3783b052dfa74561e037f27c8b30a4ddfe5d983a8830f268d8L112-R113))
  * Modify `ListLogicalRouterStaticRoutesByOption` method to check option key existence in route options ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-386553eb41be041eafc944d6270c154cf99b46609ef142b487ce1e2d8dd089d6L21-R26))
  * Add and modify tests for the above methods ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R2866-R2879), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2eadf7fb3dd75cdfd04457a9b7e244a2bfb9aa9bb790ff6ed89b86599c0a4c71R3010-R3024), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2618ff1fc82aec4a4ffc11e207b16284441050693e466f1506d2e52dace07ff6L162-R162), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2618ff1fc82aec4a4ffc11e207b16284441050693e466f1506d2e52dace07ff6L177-R177), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2618ff1fc82aec4a4ffc11e207b16284441050693e466f1506d2e52dace07ff6L193-R193), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2618ff1fc82aec4a4ffc11e207b16284441050693e466f1506d2e52dace07ff6L345-R345), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2618ff1fc82aec4a4ffc11e207b16284441050693e466f1506d2e52dace07ff6L356-R356), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2618ff1fc82aec4a4ffc11e207b16284441050693e466f1506d2e52dace07ff6L367-R367), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-2618ff1fc82aec4a4ffc11e207b16284441050693e466f1506d2e52dace07ff6L384-R384))
* Modify methods for establishing and removing the interconnection between OVN clusters ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L168-R184), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L185-R197), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L207-R279), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L275-R291), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L306-R317), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L326-R369), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R385-R388), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L380-R394), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R426-R427), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R478-R484), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L473-R525), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R560-R584))
  * Modify `removeInterConnection` method to delete logical switch ports and logical router ports by external ID and filter function ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L168-R184))
  * Modify `establishInterConnection` method to create multiple transit switches for each group of gateway nodes and use chassis name for logical patch port name ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L185-R197))
  * Modify `establishInterConnection` method to move az name setting logic and remove redundant logical switch port check ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L207-R279))
  * Modify `acquireLrpAddress` method to add transit switch name parameter and more error information ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L275-R291))
  * Modify `startOvnIC` method to rename it to `startOVNIC` and change error handling logic ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L306-R317))
  * Modify `stopOvnIC` method to rename it to `stopOVNIC` and change error handling logic ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L326-R369))
  * Modify `delLearnedRoute` method to handle nil policy and use policy variable instead of pointer ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R385-R388), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L380-R394))
  * Modify `SynRouteToPolicy` method to add a call to `syncOneRouteToPolicy` method with `OvnICNone` tag ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R426-R427))
  * Modify `syncOneRouteToPolicy` method to use `GetLogicalRouterPoliciesByExtID` method and string set for policy routes ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R478-R484), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8L473-R525))
  * Modify `getTSCidr` method to use `subnetsLister` to get default logical switch subnet and protocol ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R560-R584))
  * Add `ovs` package import statement ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-cba763fee4fe58f36170742cfd47077f68084251db8632bcadbcf13fd103d9b8R21))
* Modify methods for deleting policy routes for local DNS cache, underlay to overlay interconnection and VPC ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1242-R1242), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2658-R2658), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL467-R467))
  * Modify `deletePolicyRouteForLocalDNSCacheOnNode` method to add `ignoreExtIDEmptyValue` parameter and pass it to `ListLogicalRouterPolicies` method ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1242-R1242))
  * Modify `deletePolicyRouteForU2OInterconn` method to add `ignoreExtIDEmptyValue` parameter and pass it to `ListLogicalRouterPolicies` method ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L2658-R2658))
  * Modify `handleAddOrUpdateVpc` method to add `ignoreExtIDEmptyValue` parameter and pass it to `ListLogicalRouterPolicies` method ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-ae8a8b5d44d277a4bb96635ee325fe54b48e8bc10b24a79d4bb8e211b57131ecL467-R467))
* Modify Makefile targets for initializing kind clusters with ovn-ic feature ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L349-R363), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R489), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L496-R501), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L521-R526), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L550-R555))
  * Add `ovn_ic` variable to indicate whether ovn-ic feature is enabled and pass it to `kind-init` and `kind-generate-config` targets ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L349-R363))
  * Add command to untaint control plane node for `kind-install-ovn-ic` target ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R489))
  * Modify `gateway_node_name` variable format to use semicolon instead of comma for `kind-install-ovn-ic` target and ovn-ic yaml template file ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L496-R501), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L521-R526), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L550-R555))
* Add `OvnICNone` constant to represent empty ovn-ic tag value ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-23fe1930ce750ec27bfa79a8fb8d076245c64df2b62ea6d6367cdd59260b164cR236))
* Add logic to `kind.yaml.j2` template file to support ovn-ic feature in kind environment ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-f88bb6992159e270ea78e286f19bfd123e4a87bcdb6307eadacc2d06dd6265f4R13-R15), [link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-f88bb6992159e270ea78e286f19bfd123e4a87bcdb6307eadacc2d06dd6265f4R84-R86))
  * Add `ovn_ic` variable and set default value of "false" ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-f88bb6992159e270ea78e286f19bfd123e4a87bcdb6307eadacc2d06dd6265f4R13-R15))
  * Add condition to add worker node if `ovn_ic` is "true" ([link](https://github.com/kubeovn/kube-ovn/pull/3410/files?diff=unified&w=0#diff-f88bb6992159e270ea78e286f19bfd123e4a87bcdb6307eadacc2d06dd6265f4R84-R86))
