### PR TITLE
ci: fix scheduled base image build workflow

### DIFF
--- a/.github/workflows/build-kube-ovn-base-dpdk.yaml
+++ b/.github/workflows/build-kube-ovn-base-dpdk.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
       - uses: docker/setup-buildx-action@v3
 
       - name: Build
@@ -27,8 +29,9 @@ jobs:
       - name: Upload image to artifact
         uses: actions/upload-artifact@v3
         with:
-          name: image-amd64-dpdk
+          name: image-amd64-dpdk-${{ matrix.branch }}
           path: image-amd64-dpdk.tar
+          retention-days: 7
 
   push:
     strategy:
@@ -44,11 +47,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Download image
         uses: actions/download-artifact@v3
         with:
-          name: image-amd64-dpdk
+          name: image-amd64-dpdk-${{ matrix.branch }}
 
       - name: Load Image
         run: |

--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           name: image-amd64-${{ matrix.branch }}
           path: image-amd64.tar
+          retention-days: 7
 
   build-arm64:
     strategy:
@@ -65,6 +66,7 @@ jobs:
         with:
           name: image-arm64-${{ matrix.branch }}
           path: image-arm64.tar
+          retention-days: 7
 
   push:
     strategy:
@@ -72,6 +74,7 @@ jobs:
       matrix:
         branch:
         - master
+        - release-1.12-cmss
         - release-1.12
         - release-1.11
         - release-1.9


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9d8107</samp>

Update GitHub workflow to build images from different branches. This enables testing and deploying `kube-ovn` and `kube-ovn-base-dpdk` images for different project versions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c9d8107</samp>

> _Sing, O Muse, of the skillful builders of `kube-ovn`,_
> _Who craft the images of their project with cunning and care._
> _They branch their work like the river Nile, whose many mouths_
> _Feed the fertile land of Egypt with life-giving water._

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9d8107</samp>

* Add ref parameter to checkout actions to specify the branch to checkout for each workflow job ([link](https://github.com/kubeovn/kube-ovn/pull/3415/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL19-R22), [link](https://github.com/kubeovn/kube-ovn/pull/3415/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edR50-R51))
* Update workflow matrix to include different branches of the kube-ovn repository ([link](https://github.com/kubeovn/kube-ovn/pull/3415/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL19-R22))
