### PR TITLE
fix golang lint in 1.11

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -690,7 +690,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	if subnet.Spec.Mtu > 0 {
 		mtu = int(subnet.Spec.Mtu)
 	} else {
-		mtu := util.DefaultMTU
+		mtu = util.DefaultMTU
 		if subnet.Spec.Vlan == "" {
 			switch c.config.NetworkType {
 			case util.NetworkTypeVlan:


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a3ff09</samp>

Fix a variable shadowing bug in `subnet.go` that caused incorrect MTU values for subnets. This resolves issue #1019.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a3ff09</samp>

> _`mtu` was shadowed_
> _bug caused by redeclaring_
> _fixed with assignment_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a3ff09</samp>

* Fix a bug that caused mtu to be shadowed by a new declaration in the same scope ([link](https://github.com/kubeovn/kube-ovn/pull/3416/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L693-R693))
