### PR TITLE
mtu merge failed

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -690,7 +690,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	if subnet.Spec.Mtu > 0 {
 		mtu = int(subnet.Spec.Mtu)
 	} else {
-		mtu := util.DefaultMTU
+		mtu = util.DefaultMTU
 		if subnet.Spec.Vlan == "" {
 			switch c.config.NetworkType {
 			case util.NetworkTypeVlan:

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -261,20 +261,9 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 						}
 						return
 					}
-					mtuStr := node.Labels[fmt.Sprintf(util.ProviderNetworkMtuTemplate, providerNetwork)]
-					if mtuStr != "" {
-						if mtu, err = strconv.Atoi(mtuStr); err != nil || mtu <= 0 {
-							errMsg := fmt.Errorf("failed to parse provider network MTU %s: %v", mtuStr, err)
-							klog.Error(errMsg)
-							if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
-								klog.Errorf("failed to write response: %v", err)
-							}
-							return
-						}
-					}
-				} else {
-					mtu = csh.Config.MTU
 				}
+			} else {
+				mtu = csh.Config.MTU
 			}
 		}
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b2eb1a</samp>

This pull request fixes a bug in `subnet.go` that caused incorrect MTU values for subnets, and improves the performance and readability of `handler.go` by simplifying the provider network MTU parsing logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0b2eb1a</samp>

> _Fix `mtu` bug_
> _Simplify parsing logic_
> _Winter code is clean_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b2eb1a</samp>

* Fix a bug where the wrong MTU value was used for subnet creation by using the existing variable instead of declaring a new one ([link](https://github.com/kubeovn/kube-ovn/pull/3417/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L693-R693))
* Simplify the logic for parsing the provider network MTU from the node labels by moving the check outside the loop and only parsing the matched provider network ([link](https://github.com/kubeovn/kube-ovn/pull/3417/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fL264-R266))
