### PR TITLE
optimize ecmp policy route

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -741,7 +741,7 @@ func (c *Controller) checkGatewayReady() error {
 						continue
 					}
 
-					exist, err := c.checkPolicyRouteExistForNode(node.Name, cidrBlock, ip, util.GatewayRouterPolicyPriority)
+					exist, err := c.checkPolicyRouteConsistent(cidrBlock, ip, util.GatewayRouterPolicyPriority)
 					if err != nil {
 						klog.Errorf("check ecmp policy route exist for subnet %v, error %v", subnet.Name, err)
 						break
@@ -1104,20 +1104,7 @@ func (c *Controller) getPolicyRouteParas(cidr string, priority int32) ([]string,
 	return nextHops, nameIpMap, nil
 }
 
-func (c *Controller) checkPolicyRouteExistForNode(nodeName, cidr, nexthop string, priority int32) (bool, error) {
-	nextHops, _, err := c.getPolicyRouteParas(cidr, priority)
-	if err != nil {
-		klog.Errorf("failed to get policy route paras, %v", err)
-		return false, err
-	}
-
-	if util.ContainsString(nextHops, nexthop) {
-		return true, nil
-	}
-	return false, nil
-}
-
-func (c *Controller) checkPolicyRouteConsistent(nodeName, cidr, nexthop string, priority int32) (bool, error) {
+func (c *Controller) checkPolicyRouteConsistent(cidr, nexthop string, priority int32) (bool, error) {
 	nextHops, _, err := c.getPolicyRouteParas(cidr, priority)
 	if err != nil {
 		klog.Errorf("failed to get policy route paras, %v", err)
@@ -1229,7 +1216,7 @@ func (c *Controller) addPolicyRouteForCentralizedSubnetOnNode(nodeName, nodeIP s
 					if util.CheckProtocol(cidrBlock) != util.CheckProtocol(nextHop) {
 						continue
 					}
-					exist, err := c.checkPolicyRouteExistForNode(nodeName, cidrBlock, nextHop, util.GatewayRouterPolicyPriority)
+					exist, err := c.checkPolicyRouteConsistent(cidrBlock, nextHop, util.GatewayRouterPolicyPriority)
 					if err != nil {
 						klog.Errorf("check ecmp policy route exist for subnet %v, error %v", subnet.Name, err)
 						continue

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1974,7 +1974,7 @@ func (c *Controller) updatePolicyRouteForCentralizedSubnet(subnetName, cidr stri
 	for node, ip := range nameIpMap {
 		externalIDs[node] = ip
 	}
-	klog.Infof("add ecmp policy route for router: %s, match %s, action %s, nexthop %s, extrenalID %s", c.config.ClusterRouter, match, "allow", "", externalIDs)
+	klog.Infof("add ecmp policy route for router: %s, match %s, action %s, nexthop %s, extrenalID %s", c.config.ClusterRouter, match, "reroute", nextHopIp, externalIDs)
 	if err := c.ovnLegacyClient.AddPolicyRoute(c.config.ClusterRouter, util.GatewayRouterPolicyPriority, match, "reroute", nextHopIp, externalIDs); err != nil {
 		klog.Errorf("failed to add policy route for centralized subnet %s: %v", subnetName, err)
 		return err
@@ -1989,7 +1989,7 @@ func (c *Controller) addPolicyRouteForCentralizedSubnet(subnet *kubeovnv1.Subnet
 			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(nodeIP) {
 				continue
 			}
-			consistent, err := c.checkPolicyRouteConsistent(nodeName, cidrBlock, nodeIP, util.GatewayRouterPolicyPriority)
+			consistent, err := c.checkPolicyRouteConsistent(cidrBlock, nodeIP, util.GatewayRouterPolicyPriority)
 			if err != nil {
 				klog.Errorf("failed to check policy route for subnet %v, error %v", subnet.Name, err)
 				continue

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -2686,10 +2688,13 @@ func (c LegacyClient) CheckPolicyRouteNexthopConsistent(router, match, nexthop s
 		klog.Errorf("failed to get policy route paras, %v", err)
 		return false, err
 	}
-	for _, next := range nextHops {
-		if next == nexthop {
-			return true, nil
-		}
+	sort.Strings(nextHops)
+
+	inNextHops := strings.Split(nexthop, ",")
+	sort.Strings(inNextHops)
+
+	if reflect.DeepEqual(inNextHops, nextHops) {
+		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76da31c</samp>

This pull request improves the consistency checking of policy routes for nodes and subnets in the OVN controller. It renames and refactors a function in `node.go`, fixes a typo and updates a function call in `subnet.go`, and enhances the logic of `CheckPolicyRouteNexthopConsistent` in `ovn-nbctl-legacy.go`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 76da31c</samp>

> _Sing, O Muse, of the code that was refactored_
> _By the skillful programmer, who sought to enhance_
> _The function `CheckPolicyRouteNexthopConsistent`_
> _And the log message that reports its performance._

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76da31c</samp>

*  Rename and update the logic of `checkPolicyRouteExistForNode` to `checkPolicyRouteConsistent` to compare sorted nexthop slices instead of a single nexthop ([link](https://github.com/kubeovn/kube-ovn/pull/3421/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L744-R744), [link](https://github.com/kubeovn/kube-ovn/pull/3421/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1107-R1107), [link](https://github.com/kubeovn/kube-ovn/pull/3421/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1114-L1126), [link](https://github.com/kubeovn/kube-ovn/pull/3421/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L1232-R1219), [link](https://github.com/kubeovn/kube-ovn/pull/3421/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1992-R1992), [link](https://github.com/kubeovn/kube-ovn/pull/3421/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L2689-R2697))
*  Import `reflect` and `sort` packages in `pkg/ovs/ovn-nbctl-legacy.go` for the new logic of `CheckPolicyRouteNexthopConsistent` ([link](https://github.com/kubeovn/kube-ovn/pull/3421/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L10-R12))
*  Fix a typo in the log message of `syncSubnet` in `pkg/controller/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3421/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1977-R1977))
