### PR TITLE
ci: fix missing environment variables

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1089,6 +1089,9 @@ jobs:
 
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
+          E2E_IP_FAMILY: ${{ matrix.ip-family }}
         run: make kube-ovn-ic-conformance-e2e
 
       - name: kubectl ko log
@@ -1390,6 +1393,8 @@ jobs:
 
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: make kube-ovn-lb-svc-conformance-e2e
 
   kubevirt-e2e:
@@ -1483,6 +1488,8 @@ jobs:
 
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: make kube-ovn-kubevirt-e2e
 
   webhook-e2e:
@@ -1576,6 +1583,8 @@ jobs:
 
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: make kube-ovn-webhook-e2e
 
       - name: kubectl ko log
@@ -1750,6 +1759,7 @@ jobs:
         working-directory: ${{ env.E2E_DIR }}
         env:
           E2E_CILIUM_CHAINING: "true"
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: make k8s-conformance-e2e
 
       - name: kubectl ko log
@@ -2084,6 +2094,8 @@ jobs:
 
       - name: Run E2E
         working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: make iptables-vpc-nat-gw-conformance-e2e
 
       - name: kubectl ko log
@@ -2189,10 +2201,14 @@ jobs:
 
       - name: Run Vip E2E
         working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: make vip-conformance-e2e
 
       - name: Run Ovn VPC NAT GW E2E
         working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: make ovn-vpc-nat-gw-conformance-e2e
 
   push:


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at df9cfa5</samp>

Add environment variables to GitHub workflow jobs for end-to-end testing. This improves the accuracy and coverage of the tests for different branches, architectures, and IP families.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at df9cfa5</samp>

> _`E2E_BRANCH` set_
> _for each workflow and job_
> _autumn tests align_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at df9cfa5</samp>

*  Add `E2E_BRANCH` and `E2E_IP_FAMILY` environment variables to `Run E2E` step of `Build and Push x86 Image` job to run end-to-end tests for corresponding branch and IP family ([link](https://github.com/kubeovn/kube-ovn/pull/3430/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1092-R1094))
* Add `E2E_BRANCH` environment variable to `Run E2E` step of `Build and Push arm64 Image`, `Build and Push ppc64le Image`, `Build and Push s390x Image`, `Build and Push multi-arch Image`, and `Build and Push multi-arch Image with OVN 20.12.0` jobs to run end-to-end tests for corresponding branch ([link](https://github.com/kubeovn/kube-ovn/pull/3430/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1396-R1397), [link](https://github.com/kubeovn/kube-ovn/pull/3430/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1491-R1492), [link](https://github.com/kubeovn/kube-ovn/pull/3430/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1586-R1587), [link](https://github.com/kubeovn/kube-ovn/pull/3430/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R1762), [link](https://github.com/kubeovn/kube-ovn/pull/3430/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2R2097-R2098))
* Add `E2E_BRANCH` environment variable to `Run Vip E2E` and `Run Ovn VPC NAT GW E2E` steps of `Build and Push multi-arch Image with OVN 20.12.0` job to run end-to-end tests for corresponding branch and features ([link](https://github.com/kubeovn/kube-ovn/pull/3430/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L2192-R2211))
