### PR TITLE
add sort for subnet.spec.excludeIps

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -253,7 +254,8 @@ func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 		subnet.Spec.Provider = util.OvnProvider
 		changed = true
 	}
-	if subnet.Spec.Protocol == "" || subnet.Spec.Protocol != util.CheckProtocol(subnet.Spec.CIDRBlock) {
+	newCIDRBlock := subnet.Spec.CIDRBlock
+	if subnet.Spec.Protocol != util.CheckProtocol(newCIDRBlock) {
 		subnet.Spec.Protocol = util.CheckProtocol(subnet.Spec.CIDRBlock)
 		changed = true
 	}
@@ -365,6 +367,7 @@ func checkAndUpdateExcludeIps(subnet *kubeovnv1.Subnet) bool {
 	changed := false
 	var excludeIps []string
 	excludeIps = append(excludeIps, strings.Split(subnet.Spec.Gateway, ",")...)
+	sort.Strings(excludeIps)
 	if len(subnet.Spec.ExcludeIps) == 0 {
 		subnet.Spec.ExcludeIps = excludeIps
 		changed = true
@@ -380,6 +383,7 @@ func checkAndUpdateExcludeIps(subnet *kubeovnv1.Subnet) bool {
 			}
 			if !gwExists {
 				subnet.Spec.ExcludeIps = append(subnet.Spec.ExcludeIps, gw)
+				sort.Strings(subnet.Spec.ExcludeIps)
 				changed = true
 			}
 		}
@@ -1443,6 +1447,7 @@ func checkAndFormatsExcludeIps(subnet *kubeovnv1.Subnet) bool {
 			excludeIps = append(excludeIps, string(v.Start)+".."+string(v.End))
 		}
 	}
+	sort.Strings(excludeIps)
 	klog.V(3).Infof("excludeips before format is %v, after format is %v", subnet.Spec.ExcludeIps, excludeIps)
 	if !reflect.DeepEqual(subnet.Spec.ExcludeIps, excludeIps) {
 		subnet.Spec.ExcludeIps = excludeIps

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -2280,10 +2282,13 @@ func (c LegacyClient) CheckPolicyRouteNexthopConsistent(router, match, nexthop s
 		klog.Errorf("failed to get policy route paras, %v", err)
 		return false, err
 	}
-	for _, next := range nextHops {
-		if next == nexthop {
-			return true, nil
-		}
+	sort.Strings(nextHops)
+
+	inNextHops := strings.Split(nexthop, ",")
+	sort.Strings(inNextHops)
+
+	if reflect.DeepEqual(inNextHops, nextHops) {
+		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
- Bug fixes


fix the compare for subnet.spec.excludeIPs slice，add sort process for slice

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a4c7a0</samp>

Sort and compare exclude IPs and policy route nexthops in `subnet.go` and `ovn-nbctl-legacy.go`. Refactor some code to improve efficiency and readability.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a4c7a0</samp>

> _We sort the IPs of the subnets_
> _To face the doom of redundancy_
> _We use `reflect` and `sort` to compare_
> _The nexthops of our policy_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a4c7a0</samp>

*  Sort the exclude IPs of subnets in alphabetical order to ensure consistency and avoid unnecessary updates ([link](https://github.com/kubeovn/kube-ovn/pull/3436/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R8), [link](https://github.com/kubeovn/kube-ovn/pull/3436/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L256-R258), [link](https://github.com/kubeovn/kube-ovn/pull/3436/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R370), [link](https://github.com/kubeovn/kube-ovn/pull/3436/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R386), [link](https://github.com/kubeovn/kube-ovn/pull/3436/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R1450))
*  Introduce a new variable `newCIDRBlock` to avoid redundant calls to `util.CheckProtocol` in `pkg/controller/subnet.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3436/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L256-R258))
*  Sort and compare the policy route nexthops in alphabetical order to check their consistency in `pkg/ovs/ovn-nbctl-legacy.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3436/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L10-R12), [link](https://github.com/kubeovn/kube-ovn/pull/3436/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L2283-R2291))
