### PR TITLE
feat:  support dpdk interface hotplug for kubevirt

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -47,19 +47,20 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	client := request.NewCniServerClient(netConf.ServerSocket)
 	response, err := client.Add(request.CniRequest{
-		CniType:                   netConf.Type,
-		PodName:                   podName,
-		PodNamespace:              podNamespace,
-		ContainerID:               args.ContainerID,
-		NetNs:                     args.Netns,
-		IfName:                    args.IfName,
-		Provider:                  netConf.Provider,
-		Routes:                    netConf.Routes,
-		DNS:                       netConf.DNS,
-		DeviceID:                  netConf.DeviceID,
-		VfDriver:                  netConf.VfDriver,
-		VhostUserSocketVolumeName: netConf.VhostUserSocketVolumeName,
-		VhostUserSocketName:       netConf.VhostUserSocketName,
+		CniType:                    netConf.Type,
+		PodName:                    podName,
+		PodNamespace:               podNamespace,
+		ContainerID:                args.ContainerID,
+		NetNs:                      args.Netns,
+		IfName:                     args.IfName,
+		Provider:                   netConf.Provider,
+		Routes:                     netConf.Routes,
+		DNS:                        netConf.DNS,
+		DeviceID:                   netConf.DeviceID,
+		VfDriver:                   netConf.VfDriver,
+		VhostUserSocketVolumeName:  netConf.VhostUserSocketVolumeName,
+		VhostUserSocketName:        netConf.VhostUserSocketName,
+		VhostUserSocketConsumption: netConf.VhostUserSocketConsumption,
 	})
 	if err != nil {
 		return types.NewError(types.ErrTryAgainLater, "RPC failed", err.Error())
@@ -151,15 +152,16 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 
 	err = client.Del(request.CniRequest{
-		CniType:                   netConf.Type,
-		PodName:                   podName,
-		PodNamespace:              podNamespace,
-		ContainerID:               args.ContainerID,
-		NetNs:                     args.Netns,
-		IfName:                    args.IfName,
-		Provider:                  netConf.Provider,
-		DeviceID:                  netConf.DeviceID,
-		VhostUserSocketVolumeName: netConf.VhostUserSocketVolumeName,
+		CniType:                    netConf.Type,
+		PodName:                    podName,
+		PodNamespace:               podNamespace,
+		ContainerID:                args.ContainerID,
+		NetNs:                      args.Netns,
+		IfName:                     args.IfName,
+		Provider:                   netConf.Provider,
+		DeviceID:                   netConf.DeviceID,
+		VhostUserSocketVolumeName:  netConf.VhostUserSocketVolumeName,
+		VhostUserSocketConsumption: netConf.VhostUserSocketConsumption,
 	})
 	if err != nil {
 		return types.NewError(types.ErrTryAgainLater, "RPC failed", err.Error())

--- a/cmd/cni/netconf.go
+++ b/cmd/cni/netconf.go
@@ -19,8 +19,9 @@ type netConf struct {
 	DeviceID string `json:"deviceID"`
 	VfDriver string `json:"vf_driver"`
 	// for dpdk
-	VhostUserSocketVolumeName string `json:"vhost_user_socket_volume_name"`
-	VhostUserSocketName       string `json:"vhost_user_socket_name"`
+	VhostUserSocketVolumeName  string `json:"vhost_user_socket_volume_name"`
+	VhostUserSocketName        string `json:"vhost_user_socket_name"`
+	VhostUserSocketConsumption string `json:"vhost_user_socket_consumption"`
 }
 
 func (n *netConf) postLoad() {

--- a/cmd/cni/netconf_windows.go
+++ b/cmd/cni/netconf_windows.go
@@ -16,8 +16,9 @@ type netConf struct {
 	DeviceID string `json:"deviceID"`
 	VfDriver string `json:"vf_driver"`
 	// for dpdk
-	VhostUserSocketVolumeName string `json:"vhost_user_socket_volume_name"`
-	VhostUserSocketName       string `json:"vhost_user_socket_name"`
+	VhostUserSocketVolumeName  string `json:"vhost_user_socket_volume_name"`
+	VhostUserSocketName        string `json:"vhost_user_socket_name"`
+	VhostUserSocketConsumption string `json:"vhost_user_socket_consumption"`
 }
 
 func (n *netConf) postLoad() {

--- a/pkg/daemon/handler_windows.go
+++ b/pkg/daemon/handler_windows.go
@@ -19,12 +19,12 @@ func (csh cniServerHandler) validatePodRequest(req *request.CniRequest) error {
 	return nil
 }
 
-func createShortSharedDir(pod *v1.Pod, volumeName, kubeletDir string) error {
+func createShortSharedDir(pod *v1.Pod, volumeName, socketConsumption, kubeletDir string) error {
 	// nothing to do on Windows
 	return nil
 }
 
-func removeShortSharedDir(pod *v1.Pod, volumeName string) error {
+func removeShortSharedDir(pod *v1.Pod, volumeName, socketConsumption string) error {
 	// nothing to do on Windows
 	return nil
 }

--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, netns, containerID, ifName, mac string, mtu int, ip, gateway, ingress, egress, sharedDir, socketName string) error {
+func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, netns, containerID, ifName, mac string, mtu int, ip, gateway, ingress, egress, sharedDir, socketName, socketConsumption string) error {
 	return errors.New("DPDK is not supported on Windows")
 }
 

--- a/pkg/request/cniserver.go
+++ b/pkg/request/cniserver.go
@@ -34,8 +34,9 @@ type CniRequest struct {
 	DeviceID string `json:"deviceID"`
 	// dpdk
 	// empty dir volume for sharing vhost user unix socket
-	VhostUserSocketVolumeName string `json:"vhost_user_socket_volume_name"`
-	VhostUserSocketName       string `json:"vhost_user_socket_name"`
+	VhostUserSocketVolumeName  string `json:"vhost_user_socket_volume_name"`
+	VhostUserSocketName        string `json:"vhost_user_socket_name"`
+	VhostUserSocketConsumption string `json:"vhost_user_socket_consumption"`
 }
 
 // CniResponse is the cniserver response format

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -282,4 +282,7 @@ const (
 	TProxyPreroutingMask = 0x90004
 
 	HealthCheckNamedVipTemplate = "%s:%s" // ip name, health check vip
+
+	ConsumptionKubevirt       = "kubevirt"
+	VhostUserSocketVolumeName = "vhostuser-sockets"
 )


### PR DESCRIPTION
## What type of this PR

feat:  support dpdk interface hotplug for kubevirt

## Which issue(s) this PR fixes

none

## WHAT

If you want kubevirt support dpdk interface hotplug, nad should define as below:

```yaml
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: ovn-dpdk
  namespace: default
spec:
  config: >-
    {
        "cniVersion": "0.3.0", 
        "type": "kube-ovn", 
        "server_socket": "/run/openvswitch/kube-ovn-daemon.sock", 
        "provider": "xx.xx.ovn",
        "vhost_user_socket_consumption": "kubevirt" # must set
    }
```

## HOW

I will push a pr about kubevirt dpdk feature in recent times.
