### PR TITLE
fix: release VF assigned to the Pod back to the host network namespace

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -146,7 +146,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	if netConf.Type == util.CniTypeName && args.IfName == "eth0" {
+	if netConf.Provider == "" && netConf.Type == util.CniTypeName && args.IfName == "eth0" {
 		netConf.Provider = util.OvnProvider
 	}
 

--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -23,10 +23,10 @@ func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, ne
 }
 
 func (csh cniServerHandler) configureNicWithInternalPort(podName, podNamespace, provider, netns, containerID, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, detectIPConflict bool, routes []request.Route, dnsServer, dnsSuffix []string, ingress, egress, DeviceID, nicType, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP string) (string, error) {
-	return ifName, csh.configureNic(podName, podNamespace, provider, netns, containerID, "", ifName, mac, mtu, ip, gateway, isDefaultRoute, detectIPConflict, routes, dnsServer, dnsSuffix, ingress, egress, DeviceID, nicType, latency, limit, loss, jitter, gwCheckMode, u2oInterconnectionIP)
+	return ifName, csh.configureNic(podName, podNamespace, provider, netns, containerID, "", ifName, mac, mtu, ip, gateway, isDefaultRoute, detectIPConflict, routes, dnsServer, dnsSuffix, ingress, egress, DeviceID, nicType, latency, limit, loss, jitter, gwCheckMode, u2oInterconnectionIP, "")
 }
 
-func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, detectIPConflict bool, routes []request.Route, dnsServer, dnsSuffix []string, ingress, egress, DeviceID, nicType, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP string) error {
+func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, detectIPConflict bool, routes []request.Route, dnsServer, dnsSuffix []string, ingress, egress, DeviceID, nicType, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, _ string) error {
 	if DeviceID != "" {
 		return errors.New("SR-IOV is not supported on Windows")
 	}
@@ -219,7 +219,7 @@ func configureNic(name, ip string, mac net.HardwareAddr, mtu int) error {
 	return nil
 }
 
-func (csh cniServerHandler) deleteNic(podName, podNamespace, containerID, netns, deviceID, ifName, nicType string) error {
+func (csh cniServerHandler) deleteNic(podName, podNamespace, containerID, netns, deviceID, ifName, nicType, _ string) error {
 	epName := hns.ConstructEndpointName(containerID, netns, util.HnsNetwork)[:12]
 	// remove ovs port
 	output, err := ovs.Exec(ovs.IfExists, "--with-iface", "del-port", "br-int", epName)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -76,6 +76,8 @@ const (
 	SecurityGroupAnnotationTemplate = "%s.kubernetes.io/security_groups"
 	LiveMigrationAnnotationTemplate = "%s.kubernetes.io/allow_live_migration"
 	DefaultRouteAnnotationTemplate  = "%s.kubernetes.io/default_route"
+	VfRepresentorNameTemplate       = "%s.kubernetes.io/vf_representor"
+	VfNameTemplate                  = "%s.kubernetes.io/vf"
 
 	ProviderNetworkTemplate           = "%s.kubernetes.io/provider_network"
 	ProviderNetworkErrMessageTemplate = "%s.provider-network.kubernetes.io/err_mesg"


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

fix: release VF assigned to the Pod back to the host network namespace when delete pod

## Which issue(s) this PR fixes

Fixes #3437 

## WHAT
Add a symmetric operation to configure the siriov interface (setupSriovInterface) for the pod: release the sriovs interface

## HOW
1.move VF to the host network namespace
2.renames the VF device from `eth0` to its original name