### PR TITLE
support allow address pairs for SecurityGroup

### DIFF
--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -462,6 +462,9 @@ func (c *Controller) handleUpdateVirtualParents(key string) error {
 			if podNet.Subnet.Name == cachedVip.Spec.Subnet {
 				portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, podNet.Subnet.Spec.Provider)
 				virtualParents = append(virtualParents, portName)
+				key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+				klog.Infof("enqueue update pod security for %s", key)
+				c.updatePodSecurityQueue.Add(key)
 				break
 			}
 		}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5641860</samp>

This pull request enhances the pod controller to support AAPs and port VIPs for pods that share virtual IPs with other pods or services. It also fixes and refines the sync logic for port security and security group rules with OVN. It affects the files `pkg/controller/pod.go` and `pkg/controller/vip.go`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5641860</samp>

> _Oh we are the coders of the OVN_
> _We sync the rules with the database_
> _We add the AAPs for the pods to share_
> _And we heave away on the count of three_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5641860</samp>

*  Add support for AAPs for pods that need to share virtual IPs with other pods or services
  - Enqueue pod for updating port security rules when AAPs annotation changes ([link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L383-R385))
  - Simplify port security reconciliation and update logic by using `getVirtualIPs` function to get virtual IPs from AAPs and port VIP annotations ([link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R647-R648), [link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L717-R721), [link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L983-R988), [link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1139-R1140), [link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1144-R1150), [link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1997-R2037))
  - Enqueue security groups for syncing when pod changes AAPs or port VIPs ([link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1163-R1165))
*  Fix bug that would cause nil pointer dereference if pod does not have AAPs annotation ([link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L983-R988))
*  Enqueue pod for updating port security rules when virtual parent changes in `pkg/controller/vip.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3442/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0R465-R466))
