### PR TITLE
ci: fix deepflow installation

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -23,8 +23,8 @@ concurrency:
 env:
   GO_VERSION: ''
   GOSEC_VERSION: '2.18.2'
-  HELM_VERSION: v3.13.1
-  SUBMARINER_VERSION: '0.14.7'
+  HELM_VERSION: v3.13.2
+  SUBMARINER_VERSION: '0.16.2'
 
 jobs:
   build-kube-ovn-base:

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -11,8 +11,8 @@ concurrency:
 
 env:
   GO_VERSION: ''
-  HELM_VERSION: v3.13.1
-  SUBMARINER_VERSION: '0.14.7'
+  HELM_VERSION: v3.13.2
+  SUBMARINER_VERSION: '0.16.2'
 
 jobs:
   k8s-conformance-e2e:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MULTUS_VERSION = v4.0.2
 MULTUS_IMAGE = ghcr.io/k8snetworkplumbingwg/multus-cni:$(MULTUS_VERSION)-thick
 MULTUS_YAML = https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/$(MULTUS_VERSION)/deployments/multus-daemonset-thick.yml
 
-KUBEVIRT_VERSION = v1.0.1
+KUBEVIRT_VERSION = v1.1.0
 KUBEVIRT_OPERATOR_IMAGE = quay.io/kubevirt/virt-operator:$(KUBEVIRT_VERSION)
 KUBEVIRT_API_IMAGE = quay.io/kubevirt/virt-api:$(KUBEVIRT_VERSION)
 KUBEVIRT_CONTROLLER_IMAGE = quay.io/kubevirt/virt-controller:$(KUBEVIRT_VERSION)
@@ -37,16 +37,16 @@ KUBEVIRT_OPERATOR_YAML = https://github.com/kubevirt/kubevirt/releases/download/
 KUBEVIRT_CR_YAML = https://github.com/kubevirt/kubevirt/releases/download/$(KUBEVIRT_VERSION)/kubevirt-cr.yaml
 KUBEVIRT_TEST_YAML = https://kubevirt.io/labs/manifests/vm.yaml
 
-CILIUM_VERSION = 1.14.3
+CILIUM_VERSION = 1.14.4
 CILIUM_IMAGE_REPO = quay.io/cilium/cilium
 
-CERT_MANAGER_VERSION = v1.13.1
+CERT_MANAGER_VERSION = v1.13.2
 CERT_MANAGER_CONTROLLER = quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_CAINJECTOR = quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_WEBHOOK = quay.io/jetstack/cert-manager-webhook:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_YAML = https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
 
-SUBMARINER_VERSION = $(shell echo $${SUBMARINER_VERSION:-0.14.7})
+SUBMARINER_VERSION = $(shell echo $${SUBMARINER_VERSION:-0.16.2})
 SUBMARINER_OPERATOR = quay.io/submariner/submariner-operator:$(SUBMARINER_VERSION)
 SUBMARINER_GATEWAY = quay.io/submariner/submariner-gateway:$(SUBMARINER_VERSION)
 SUBMARINER_LIGHTHOUSE_AGENT = quay.io/submariner/lighthouse-agent:$(SUBMARINER_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -842,9 +842,12 @@ kind-install-deepflow: kind-install
 	helm install deepflow -n deepflow deepflow/deepflow \
 		--create-namespace --version $(DEEPFLOW_CHART_VERSION) \
 		--set global.image.repository=$(DEEPFLOW_IMAGE_REPO) \
+		--set global.image.pullPolicy=IfNotPresent \
 		--set grafana.image.repository=$(DEEPFLOW_IMAGE_REPO)/grafana \
-		--set deepflow-agent.sysctlInitContainer.enabled=false \
-		--set 'mysql.storageConfig.persistence.size=5Gi' \
+		--set grafana.image.pullPolicy=IfNotPresent \
+		--set mysql.storageConfig.persistence.size=5Gi \
+		--set mysql.image.pullPolicy=IfNotPresent \
+		--set clickhouse.image.pullPolicy=IfNotPresent \
 		--set-json 'clickhouse.storageConfig.persistence=$(CLICKHOUSE_PERSISTENCE)'
 	kubectl -n deepflow patch svc deepflow-grafana --type=json \
 		-p '[{"op": "replace", "path": "/spec/ports/0/nodePort", "value": $(DEEPFLOW_GRAFANA_PORT)}]'

--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -66,7 +66,7 @@ nodes:
         hostPort: {{ host_port }}
         # optional: set the bind address on the host
         # 0.0.0.0 is the current default
-        listenAddress: "127.0.0.1"
+        listenAddress: "0.0.0.0"
         # optional: set the protocol to one of TCP, UDP, SCTP.
         # TCP is the default
         protocol: TCP


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61d8a9e</samp>

Updated the versions of Helm, Submariner, and other dependencies in the `Makefile` and the GitHub workflows for building and testing kube-ovn. Changed the `listenAddress` option for the node port service in the `kind.yaml.j2` template to enable external access.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61d8a9e</samp>

> _Sing, O Muse, of the valiant deeds of the kube-ovn team,_
> _Who updated their workflows and dependencies with skill and care,_
> _As they sought to improve their image and test their code with Helm and Submariner,_
> _The mighty tools of cloud-native networking, forged by Hephaestus himself._

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61d8a9e</samp>

*  Update Helm, Submariner, KubeVirt, Cilium, and cert-manager versions to use newer features and bug fixes ([link](https://github.com/kubeovn/kube-ovn/pull/3443/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L26-R27), [link](https://github.com/kubeovn/kube-ovn/pull/3443/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41L14-R15), [link](https://github.com/kubeovn/kube-ovn/pull/3443/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L29-R29), [link](https://github.com/kubeovn/kube-ovn/pull/3443/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L40-R43), [link](https://github.com/kubeovn/kube-ovn/pull/3443/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L49-R49))
*  Add `pullPolicy` option to Deepflow Helm chart to avoid unnecessary image pulls ([link](https://github.com/kubeovn/kube-ovn/pull/3443/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L845-R850))
*  Change `listenAddress` option for node port service in `kind.yaml.j2` to allow external access ([link](https://github.com/kubeovn/kube-ovn/pull/3443/files?diff=unified&w=0#diff-f88bb6992159e270ea78e286f19bfd123e4a87bcdb6307eadacc2d06dd6265f4L69-R69))
