### PR TITLE
ci: support specifying branch

### DIFF
--- a/.github/workflows/build-kube-ovn-base-dpdk.yaml
+++ b/.github/workflows/build-kube-ovn-base-dpdk.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Which branch to build base images"
+        description: "Select branch"
         required: true
         type: choice
         options:

--- a/.github/workflows/build-kube-ovn-base-dpdk.yaml
+++ b/.github/workflows/build-kube-ovn-base-dpdk.yaml
@@ -1,6 +1,15 @@
 name: Build Base DPDK
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Which branch to build base images"
+        required: true
+        type: choice
+        options:
+          - master
+          - release-1.12-cmss
+          - release-1.12
   schedule:
     - cron: "20 19 * * *"
 
@@ -17,16 +26,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        if: github.event.inputs.branch == matrix.branch
         with:
           ref: ${{ matrix.branch }}
+
       - uses: docker/setup-buildx-action@v3
+        if: github.event.inputs.branch == matrix.branch
 
       - name: Build
+        if: github.event.inputs.branch == matrix.branch
         run: |
           make base-amd64-dpdk
           make base-tar-amd64-dpdk
 
       - name: Upload image to artifact
+        if: github.event.inputs.branch == matrix.branch
         uses: actions/upload-artifact@v3
         with:
           name: image-amd64-dpdk-${{ matrix.branch }}
@@ -47,19 +61,23 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        if: github.event.inputs.branch == matrix.branch
         with:
           ref: ${{ matrix.branch }}
 
       - name: Download image
+        if: github.event.inputs.branch == matrix.branch
         uses: actions/download-artifact@v3
         with:
           name: image-amd64-dpdk-${{ matrix.branch }}
 
       - name: Load Image
+        if: github.event.inputs.branch == matrix.branch
         run: |
           docker load --input image-amd64-dpdk.tar
 
       - name: Push
+        if: github.event.inputs.branch == matrix.branch
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -1,6 +1,17 @@
 name: Build Base
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Which branch to build base images"
+        required: true
+        type: choice
+        options:
+          - master
+          - release-1.12-cmss
+          - release-1.12
+          - release-1.11
+          - release-1.9
   schedule:
   - cron: "20 19 * * *"
 
@@ -19,16 +30,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        if: github.event.inputs.branch == matrix.branch
         with:
           ref: ${{ matrix.branch }}
+
       - uses: docker/setup-buildx-action@v3
+        if: github.event.inputs.branch == matrix.branch
 
       - name: Build
+        if: github.event.inputs.branch == matrix.branch
         run: |
           make base-amd64
           make base-tar-amd64
 
       - name: Upload image to artifact
+        if: github.event.inputs.branch == matrix.branch
         uses: actions/upload-artifact@v3
         with:
           name: image-amd64-${{ matrix.branch }}
@@ -49,19 +65,26 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        if: github.event.inputs.branch == matrix.branch
         with:
           ref: ${{ matrix.branch }}
+
       - uses: docker/setup-buildx-action@v3
+        if: github.event.inputs.branch == matrix.branch
+
       - uses: docker/setup-qemu-action@v3
+        if: github.event.inputs.branch == matrix.branch
         with:
           platforms: arm64
 
       - name: Build
+        if: github.event.inputs.branch == matrix.branch
         run: |
           make base-arm64 || make base-arm64
           make base-tar-arm64
 
       - name: Upload image to artifact
+        if: github.event.inputs.branch == matrix.branch
         uses: actions/upload-artifact@v3
         with:
           name: image-arm64-${{ matrix.branch }}
@@ -85,24 +108,30 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        if: github.event.inputs.branch == matrix.branch
         with:
           ref: ${{ matrix.branch }}
+
       - name: Download image
+        if: github.event.inputs.branch == matrix.branch
         uses: actions/download-artifact@v3
         with:
           name: image-amd64-${{ matrix.branch }}
 
       - name: Download image
+        if: github.event.inputs.branch == matrix.branch
         uses: actions/download-artifact@v3
         with:
           name: image-arm64-${{ matrix.branch }}
 
       - name: Load Image
+        if: github.event.inputs.branch == matrix.branch
         run: |
           docker load --input image-amd64.tar
           docker load --input image-arm64.tar
 
       - name: Push
+        if: github.event.inputs.branch == matrix.branch
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Which branch to build base images"
+        description: "Select branch"
         required: true
         type: choice
         options:


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e3d43bc</samp>

This pull request enhances the GitHub workflows for building and pushing base images for kube-ovn. It introduces a user input parameter to select the branch for each workflow, and adds conditional logic to skip steps that are not relevant for the chosen branch. This improves the efficiency and flexibility of the workflows.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e3d43bc</samp>

> _Choose your branch of doom or glory_
> _`build-kube-ovn-base` with DPDK_
> _Skip the steps that waste your story_
> _Push the images to the edge of the dark_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e3d43bc</samp>

*  Add an input parameter to the workflow_dispatch event of the build-kube-ovn-base-dpdk and build-kube-ovn-base workflows to allow the user to select which branch to build the base images for ([link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edR4-R12), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR4-R14))
*  Add conditional expressions to the steps of the build-base-amd64-dpdk, push-base-amd64-dpdk, build-base-amd64, push-base-amd64, build-base-arm64, and push-base-arm64 jobs to only run them if the input branch matches the matrix branch ([link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL20-R37), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edR43), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL50-R69), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL59-R80), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL22-R41), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR47), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL52-R81), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR87), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL88-R116), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR122), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR128), [link](https://github.com/kubeovn/kube-ovn/pull/3444/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR134))
