### PR TITLE
OvnEip using default external subnet when externalSubnet not set

### DIFF
--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -222,9 +222,8 @@ func (c *Controller) handleAddOvnEip(key string) error {
 	var v4ip, v6ip, mac, subnetName string
 	subnetName = cachedEip.Spec.ExternalSubnet
 	if subnetName == "" {
-		err := fmt.Errorf("failed to create ovn eip '%s', subnet should be set", key)
-		klog.Error(err)
-		return err
+		klog.Infof("subnet has not been set for eip %q, using default external subnet %q", key, c.config.ExternalGatewaySwitch)
+		subnetName = c.config.ExternalGatewaySwitch
 	}
 	subnet, err := c.subnetsLister.Get(subnetName)
 	if err != nil {


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features

In most cases, users will only use the default external network, so there is no need to explicitly specify externalSubnet when creating ovneip.
When the external Subnet field is empty, it will be set as the default external subnet. When you need to use an additional external network, you need to set it explicitly.

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 72785c6</samp>

Enhance ovn eip controller to use default external subnet and log it. Fix error handling for missing subnet in `ovn_eip.go`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 72785c6</samp>

> _`ovn eip` controller_
> _uses default subnet if none_
> _autumn leaves no trace_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 72785c6</samp>

*  Add default external subnet for ovn eip controller ([link](https://github.com/kubeovn/kube-ovn/pull/3445/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceL225-R226))
