### PR TITLE
readd assigned ip addresses to ipam when subnet has been changed

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -232,8 +232,18 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 					klog.Errorf("%s address %s not in subnet %s new cidr %s", podName, ip.String(), name, cidrStr)
 					delete(subnet.V4NicToIP, nicName)
 					delete(subnet.V4IPToPod, ip.String())
-					continue
+				} else {
+					// The already assigned addresses should be added in ipam again when subnet cidr changed
+					pool.V4Available.Remove(ip)
+					pool.V4Using.Add(ip)
+					subnet.V4Free.Remove(ip)
+					subnet.V4Available.Remove(ip)
+					subnet.V4Using.Add(ip)
 				}
+			}
+
+			for nicName, ip := range subnet.V4NicToIP {
+				klog.Infof("already assigned ip %s to nic %s in subnet %s", ip.String(), nicName, name)
 			}
 		}
 		if (protocol == kubeovnv1.ProtocolDual || protocol == kubeovnv1.ProtocolIPv6) &&
@@ -275,8 +285,18 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 					klog.Errorf("%s address %s not in subnet %s new cidr %s", podName, ip.String(), name, cidrStr)
 					delete(subnet.V6NicToIP, nicName)
 					delete(subnet.V6IPToPod, ip.String())
-					continue
+				} else {
+					// The already assigned addresses should be added in ipam again when subnet cidr changed
+					pool.V6Available.Remove(ip)
+					pool.V6Using.Add(ip)
+					subnet.V6Free.Remove(ip)
+					subnet.V6Available.Remove(ip)
+					subnet.V6Using.Add(ip)
 				}
+			}
+
+			for nicName, ip := range subnet.V6NicToIP {
+				klog.Infof("already assigned ip %s to nic %s in subnet %s", ip.String(), nicName, name)
 			}
 		}
 

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -130,6 +130,7 @@ func CIDRContainIP(cidrStr, ipStr string) bool {
 			return false
 		}
 
+		found := false
 		for _, ip := range ips {
 			if CheckProtocol(cidr) != CheckProtocol(ip) {
 				continue
@@ -139,9 +140,15 @@ func CIDRContainIP(cidrStr, ipStr string) bool {
 				return false
 			}
 
-			if !cidrNet.Contains(ipAddr) {
-				return false
+			// After ns supports multiple subnets, the ippool static addresses can be allocated in any subnets, such as "ovn.kubernetes.io/ip_pool: 11.16.10.14,12.26.11.21"
+			found = false
+			if cidrNet.Contains(ipAddr) {
+				found = true
+				break
 			}
+		}
+		if !found {
+			return false
 		}
 	}
 	// v4 and v6 address should be both matched for dualstack check

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -1013,10 +1013,12 @@ func Test_CIDRContainIP(t *testing.T) {
 			true,
 		},
 		{
+			// After ns supports multiple subnets, the ippool static addresses can be allocated in any subnets, such as "ovn.kubernetes.io/ip_pool: 11.16.10.14,12.26.11.21"
+			// so if anyone ip is included in cidr, return true
 			"ipv4 family which CIDR does't contain ip",
 			"192.168.230.0/24",
 			"192.168.231.10,192.168.230.11",
-			false,
+			true,
 		},
 		{
 			"ipv6 family",
@@ -1037,10 +1039,12 @@ func Test_CIDRContainIP(t *testing.T) {
 			true,
 		},
 		{
+			// After ns supports multiple subnets, the ippool static addresses can be allocated in any subnets, such as "ovn.kubernetes.io/ip_pool: 11.16.10.14,12.26.11.21"
+			// so if anyone ip is included in cidr, return true
 			"dual which CIDR does't contain ip",
 			"192.168.230.0/24,fc00::0af4:00/112",
 			"fc00::0af4:10,fd00::0af4:11,192.168.230.10,192.168.230.11",
-			false,
+			true,
 		},
 		{
 			"different family",
@@ -1064,6 +1068,7 @@ func Test_CIDRContainIP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("test case %v", tt.desc)
 			got := CIDRContainIP(tt.cidrs, tt.ips)
 			require.Equal(t, got, tt.want)
 		})


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f7466a4</samp>

This pull request enhances the IPAM logic to support subnet CIDR changes and multiple IP pools for both IPv4 and IPv6. It also improves the logging and the `IPInCIDRs` function in `net.go`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f7466a4</samp>

> _The IPAM logic was a mess_
> _It caused conflicts and lots of stress_
> _But with a new `found`_
> _And a loop condition sound_
> _It can handle subnets with finesse_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f7466a4</samp>

*  Handle the case when subnet CIDR changes and some IPs are already assigned to pods ([link](https://github.com/kubeovn/kube-ovn/pull/3448/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L235-R247), [link](https://github.com/kubeovn/kube-ovn/pull/3448/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L278-R300))
*  Modify the logic of checking if an IP is contained in a list of CIDRs ([link](https://github.com/kubeovn/kube-ovn/pull/3448/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdR133), [link](https://github.com/kubeovn/kube-ovn/pull/3448/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdL142-R152))
