### PR TITLE
ci: fix scheduled workflow runs of building base images

### DIFF
--- a/.github/workflows/build-kube-ovn-base-dpdk.yaml
+++ b/.github/workflows/build-kube-ovn-base-dpdk.yaml
@@ -26,21 +26,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         with:
           ref: ${{ matrix.branch }}
 
       - uses: docker/setup-buildx-action@v3
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
 
       - name: Build
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         run: |
           make base-amd64-dpdk
           make base-tar-amd64-dpdk
 
       - name: Upload image to artifact
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         uses: actions/upload-artifact@v3
         with:
           name: image-amd64-dpdk-${{ matrix.branch }}
@@ -61,23 +61,23 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         with:
           ref: ${{ matrix.branch }}
 
       - name: Download image
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         uses: actions/download-artifact@v3
         with:
           name: image-amd64-dpdk-${{ matrix.branch }}
 
       - name: Load Image
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         run: |
           docker load --input image-amd64-dpdk.tar
 
       - name: Push
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -30,21 +30,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        if: github.event.inputs.branch == matrix.branch
+        if: (github.event.inputs.branch || matrix.branch) == matrix.branch
         with:
           ref: ${{ matrix.branch }}
 
       - uses: docker/setup-buildx-action@v3
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
 
       - name: Build
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         run: |
           make base-amd64
           make base-tar-amd64
 
       - name: Upload image to artifact
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         uses: actions/upload-artifact@v3
         with:
           name: image-amd64-${{ matrix.branch }}
@@ -65,26 +65,26 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         with:
           ref: ${{ matrix.branch }}
 
       - uses: docker/setup-buildx-action@v3
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
 
       - uses: docker/setup-qemu-action@v3
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         with:
           platforms: arm64
 
       - name: Build
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         run: |
           make base-arm64 || make base-arm64
           make base-tar-arm64
 
       - name: Upload image to artifact
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         uses: actions/upload-artifact@v3
         with:
           name: image-arm64-${{ matrix.branch }}
@@ -108,30 +108,30 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         with:
           ref: ${{ matrix.branch }}
 
       - name: Download image
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         uses: actions/download-artifact@v3
         with:
           name: image-amd64-${{ matrix.branch }}
 
       - name: Download image
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         uses: actions/download-artifact@v3
         with:
           name: image-arm64-${{ matrix.branch }}
 
       - name: Load Image
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         run: |
           docker load --input image-amd64.tar
           docker load --input image-arm64.tar
 
       - name: Push
-        if: github.event.inputs.branch == matrix.branch
+        if:  (github.event.inputs.branch || matrix.branch) == matrix.branch
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 30919a1</samp>

This pull request improves the GitHub workflows for building and pushing the base images for `kube-ovn`. It adds branch-aware logic to avoid redundant or conflicting steps when the workflows run on the input branch or the default branch. It also updates the workflow for the `kube-ovn-base-dpdk` image to run on both branches.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 30919a1</samp>

> _`Branch` of fate, `workflow` of doom_
> _We build and push the images of power_
> _Conditional logic, our shield and sword_
> _We defy the conflicts that devour_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 30919a1</samp>

*  Modify the condition for the first three steps of the `build-base-amd64-dpdk` job to run on both the specified branch and the default branch ([link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL29-R37))
*  Modify the condition for the step that uploads the image to the artifact for the `build-base-amd64-dpdk` job to run on both the specified branch and the default branch ([link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL43-R43))
*  Modify the condition for the first two steps of the `push-base-amd64-dpdk` job to run on both the specified branch and the default branch ([link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL64-R69))
*  Modify the condition for the last two steps of the `push-base-amd64-dpdk` job to run on both the specified branch and the default branch ([link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edL75-R80))
*  Copy the same logic to the `build-base-amd64` job, which builds the base image for amd64 without dpdk ([link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL33-R41), [link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL47-R47))
*  Copy the same logic to the `build-base-arm64` job, which builds the base image for arm64 ([link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL68-R81), [link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL87-R87))
*  Copy the same logic to the `push-base-amd64` job, which downloads and pushes the base image for amd64 without dpdk ([link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL111-R116), [link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL128-R128))
*  Copy the same logic to the `push-base-arm64` job, which downloads and pushes the base image for arm64 ([link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL122-R122), [link](https://github.com/kubeovn/kube-ovn/pull/3449/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cL134-R134))
