### PR TITLE
fix e2e install failed

### DIFF
--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -130,7 +130,6 @@ func CIDRContainIP(cidrStr, ipStr string) bool {
 			return false
 		}
 
-		found := false
 		for _, ip := range ips {
 			if CheckProtocol(cidr) != CheckProtocol(ip) {
 				continue
@@ -140,15 +139,9 @@ func CIDRContainIP(cidrStr, ipStr string) bool {
 				return false
 			}
 
-			// After ns supports multiple subnets, the ippool static addresses can be allocated in any subnets, such as "ovn.kubernetes.io/ip_pool: 11.16.10.14,12.26.11.21"
-			found = false
-			if cidrNet.Contains(ipAddr) {
-				found = true
-				break
+			if !cidrNet.Contains(ipAddr) {
+				return false
 			}
-		}
-		if !found {
-			return false
 		}
 	}
 	// v4 and v6 address should be both matched for dualstack check

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -1013,12 +1013,10 @@ func Test_CIDRContainIP(t *testing.T) {
 			true,
 		},
 		{
-			// After ns supports multiple subnets, the ippool static addresses can be allocated in any subnets, such as "ovn.kubernetes.io/ip_pool: 11.16.10.14,12.26.11.21"
-			// so if anyone ip is included in cidr, return true
 			"ipv4 family which CIDR does't contain ip",
 			"192.168.230.0/24",
 			"192.168.231.10,192.168.230.11",
-			true,
+			false,
 		},
 		{
 			"ipv6 family",
@@ -1039,12 +1037,10 @@ func Test_CIDRContainIP(t *testing.T) {
 			true,
 		},
 		{
-			// After ns supports multiple subnets, the ippool static addresses can be allocated in any subnets, such as "ovn.kubernetes.io/ip_pool: 11.16.10.14,12.26.11.21"
-			// so if anyone ip is included in cidr, return true
 			"dual which CIDR does't contain ip",
 			"192.168.230.0/24,fc00::0af4:00/112",
 			"fc00::0af4:10,fd00::0af4:11,192.168.230.10,192.168.230.11",
-			true,
+			false,
 		},
 		{
 			"different family",
@@ -1068,7 +1064,6 @@ func Test_CIDRContainIP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Logf("test case %v", tt.desc)
 			got := CIDRContainIP(tt.cidrs, tt.ips)
 			require.Equal(t, got, tt.want)
 		})

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -584,7 +584,7 @@ func TestValidatePodNetwork(t *testing.T) {
 				"ovn.kubernetes.io/egress_rate":  "1",
 				"ovn.kubernetes.io/cidr":         "10.16.0.0/16",
 			},
-			err: "10.16.1111.15,10.16.0.16,10.16.0.17 not in cidr 10.16.0.0/16",
+			err: "10.16.1111.15 in ovn.kubernetes.io/ip_pool is not a valid address",
 		},
 		{
 			name: "ingRaErr",
@@ -613,6 +613,7 @@ func TestValidatePodNetwork(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("test case %v", tt.name)
 			ret := ValidatePodNetwork(tt.annotations)
 			if !ErrorContains(ret, tt.err) {
 				t.Errorf("got %v, want a error %v", ret, tt.err)


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e091dd</samp>

This pull request improves the functionality and performance of the `CIDRContainIP` function and its test cases, and enhances the `ValidatePodNetwork` function to handle multiple subnets in the IP pool annotation. These changes are relevant for the kube-ovn project, which provides an overlay network solution for Kubernetes.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e091dd</samp>

> _Oh we are the coders of the pod network_
> _We validate the CIDR and the IP pool_
> _We simplify and optimize the `CIDRContainIP`_
> _And we pull the code with a hearty yo-ho-ho_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e091dd</samp>

*  Simplify and fix the logic of the `CIDRContainIP` function, which checks if a given IP or IP pool is contained in a CIDR ([link](https://github.com/kubeovn/kube-ovn/pull/3450/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdL133), [link](https://github.com/kubeovn/kube-ovn/pull/3450/files?diff=unified&w=0#diff-a1ffb52e88506b4737c752182fb157473a2575e8e7bb356ed709d2316141a3cdL143-R145))
*  Update and remove the test cases and log statements in the `Test_CIDRContainIP` function, which tests the `CIDRContainIP` function with different inputs ([link](https://github.com/kubeovn/kube-ovn/pull/3450/files?diff=unified&w=0#diff-9ee3e314cf37b71e944f320cc6ab7c6c03ce914f2e2cd03444863d4cc6ba8080L1016-R1019), [link](https://github.com/kubeovn/kube-ovn/pull/3450/files?diff=unified&w=0#diff-9ee3e314cf37b71e944f320cc6ab7c6c03ce914f2e2cd03444863d4cc6ba8080L1042-R1043), [link](https://github.com/kubeovn/kube-ovn/pull/3450/files?diff=unified&w=0#diff-9ee3e314cf37b71e944f320cc6ab7c6c03ce914f2e2cd03444863d4cc6ba8080L1071))
*  Modify the logic of the `ValidatePodNetwork` function, which validates the pod network annotations and returns any errors, to support the use case of multiple subnets in the IP pool and handle the situation when the CIDR annotation may be empty ([link](https://github.com/kubeovn/kube-ovn/pull/3450/files?diff=unified&w=0#diff-7f0dbc597e1344dab5f2b581992a7ad0423ff2087593902fe39429d0a980782bL232-R255))
