### PR TITLE
fix: ipam clean all pod nic ip address and mac even if just delete a nic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,8 +567,8 @@ lint-windows:
 
 .PHONY: scan
 scan:
-	trivy image --exit-code=1 --ignore-unfixed --security-checks vuln $(REGISTRY)/kube-ovn:$(RELEASE_TAG)
-	trivy image --exit-code=1 --ignore-unfixed --security-checks vuln $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG)
+	trivy image --exit-code=1 --ignore-unfixed --scanners vuln $(REGISTRY)/kube-ovn:$(RELEASE_TAG)
+	trivy image --exit-code=1 --ignore-unfixed --scanners vuln $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG)
 
 .PHONY: ut
 ut:

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -352,20 +352,25 @@ func (c *Controller) markAndCleanLSP() error {
 		}
 		ipCr, err := c.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), lsp.Name, metav1.GetOptions{})
 		if err != nil {
-			if !k8serrors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
+				// ip cr not found, skip lsp gc
 				continue
 			}
 			klog.Errorf("failed to get ip %s, %v", lsp.Name, err)
+			return err
 		}
 		klog.Infof("gc ip %s", ipCr.Name)
 		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipCr.Name, metav1.DeleteOptions{}); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				klog.Errorf("failed to delete ip %s, %v", ipCr.Name, err)
-				return err
+			if k8serrors.IsNotFound(err) {
+				// ip cr not found, skip lsp gc
+				continue
 			}
+			klog.Errorf("failed to delete ip %s, %v", ipCr.Name, err)
+			return err
 		}
 		if ipCr.Spec.Subnet == "" {
 			klog.Errorf("ip %s has no subnet", ipCr.Name)
+			// ip cr no subnet, skip lsp gc
 			continue
 		}
 		if key := lsp.ExternalIDs["pod"]; key != "" {

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -350,15 +350,26 @@ func (c *Controller) markAndCleanLSP() error {
 			klog.Errorf("failed to delete lsp %s, %v", lsp, err)
 			return err
 		}
-		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), lsp.Name, metav1.DeleteOptions{}); err != nil {
+		ipCr, err := c.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), lsp.Name, metav1.GetOptions{})
+		if err != nil {
 			if !k8serrors.IsNotFound(err) {
-				klog.Errorf("failed to delete ip %s, %v", lsp.Name, err)
+				continue
+			}
+			klog.Errorf("failed to get ip %s, %v", lsp.Name, err)
+		}
+		klog.Infof("gc ip %s", ipCr.Name)
+		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipCr.Name, metav1.DeleteOptions{}); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				klog.Errorf("failed to delete ip %s, %v", ipCr.Name, err)
 				return err
 			}
 		}
-
+		if ipCr.Spec.Subnet == "" {
+			klog.Errorf("ip %s has no subnet", ipCr.Name)
+			continue
+		}
 		if key := lsp.ExternalIDs["pod"]; key != "" {
-			c.ipam.ReleaseAddressByPod(key)
+			c.ipam.ReleaseAddressByPod(key, ipCr.Spec.Subnet)
 		}
 	}
 	lastNoPodLSP = noPodLSP

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -490,7 +490,7 @@ func (c *Controller) handleDeleteNode(key string) error {
 		return err
 	}
 
-	c.ipam.ReleaseAddressByPod(portName)
+	c.ipam.ReleaseAddressByPod(portName, c.config.NodeSwitch)
 
 	providerNetworks, err := c.providerNetworksLister.List(labels.Everything())
 	if err != nil && !k8serrors.IsNotFound(err) {

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -299,7 +299,7 @@ func (c *Controller) handleResetOvnEip(key string) error {
 
 func (c *Controller) handleDelOvnEip(key string) error {
 	klog.V(3).Infof("release ovn eip %s", key)
-	c.ipam.ReleaseAddressByPod(key)
+	c.ipam.ReleaseAddressByPod(key, "")
 	return nil
 }
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -830,7 +830,7 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 			c.syncSgPortsQueue.Add(sg)
 		}
 	}
-
+	klog.Infof("release all ip address for deleting pod %s", key)
 	c.ipam.ReleaseAddressByPod(key, "")
 
 	podNets, err := c.getPodKubeovnNets(pod)

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -831,7 +831,7 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 		}
 	}
 
-	c.ipam.ReleaseAddressByPod(key)
+	c.ipam.ReleaseAddressByPod(key, "")
 
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1565,7 +1565,7 @@ func (c *Controller) reconcileU2OInterconnectionIP(subnet *kubeovnv1.Subnet) err
 			}
 		} else if subnet.Spec.U2OInterconnectionIP != "" && subnet.Status.U2OInterconnectionIP != subnet.Spec.U2OInterconnectionIP {
 			if subnet.Status.U2OInterconnectionIP != "" {
-				c.ipam.ReleaseAddressByPod(u2oInterconnName)
+				c.ipam.ReleaseAddressByPod(u2oInterconnName, subnet.Name)
 			}
 
 			v4ip, v6ip, _, err = c.acquireStaticIpAddress(subnet.Name, u2oInterconnName, u2oInterconnLrpName, subnet.Spec.U2OInterconnectionIP)
@@ -1594,7 +1594,7 @@ func (c *Controller) reconcileU2OInterconnectionIP(subnet *kubeovnv1.Subnet) err
 	} else {
 		if subnet.Status.U2OInterconnectionIP != "" {
 			u2oInterconnName := fmt.Sprintf(util.U2OInterconnName, subnet.Spec.Vpc, subnet.Name)
-			c.ipam.ReleaseAddressByPod(u2oInterconnName)
+			c.ipam.ReleaseAddressByPod(u2oInterconnName, subnet.Name)
 			subnet.Status.U2OInterconnectionIP = ""
 
 			if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), u2oInterconnName, metav1.DeleteOptions{}); err != nil {

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -262,7 +262,7 @@ func (c *Controller) handleUpdateVirtualIp(key string) error {
 
 func (c *Controller) handleDelVirtualIp(key string) error {
 	klog.V(3).Infof("release vip %s", key)
-	c.ipam.ReleaseAddressByPod(key)
+	c.ipam.ReleaseAddressByPod(key, "")
 	return nil
 }
 
@@ -468,7 +468,7 @@ func (c *Controller) podReuseVip(key, portName string, isStsPod bool) error {
 		klog.Errorf("failed to patch label for vip '%s', %v", vip.Name, err)
 		return err
 	}
-	c.ipam.ReleaseAddressByPod(key)
+	c.ipam.ReleaseAddressByPod(key, vip.Spec.Subnet)
 	c.updateSubnetStatusQueue.Add(vip.Spec.Subnet)
 	return nil
 }

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -3,6 +3,9 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -10,9 +13,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-	"net"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -393,8 +394,8 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 }
 
 func (c *Controller) handleDelIptablesEip(key string) error {
-	c.ipam.ReleaseAddressByPod(key)
-	klog.V(3).Infof("deleted vpc nat eip %s", key)
+	klog.V(3).Infof("delete vpc nat eip %s", key)
+	c.ipam.ReleaseAddressByPod(key, "")
 	return nil
 }
 

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -111,11 +111,17 @@ func checkAndAppendIpsForDual(ips []IP, mac string, podName string, nicName stri
 	return newIps, err
 }
 
-func (ipam *IPAM) ReleaseAddressByPod(podName string) {
+func (ipam *IPAM) ReleaseAddressByPod(podName, subnetName string) {
 	ipam.mutex.RLock()
 	defer ipam.mutex.RUnlock()
-	for _, subnet := range ipam.Subnets {
-		subnet.ReleaseAddress(podName)
+	if subnetName != "" {
+		if subnet, ok := ipam.Subnets[subnetName]; ok {
+			subnet.ReleaseAddress(podName)
+		}
+	} else {
+		for _, subnet := range ipam.Subnets {
+			subnet.ReleaseAddress(podName)
+		}
 	}
 }
 

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -116,12 +116,12 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				By("release pod with multiple nics")
-				im.ReleaseAddressByPod(pod2)
+				im.ReleaseAddressByPod(pod2, "")
 				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp2))).Should(BeTrue())
 				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp3))).Should(BeTrue())
 
 				By("release pod with single nic")
-				im.ReleaseAddressByPod(pod1)
+				im.ReleaseAddressByPod(pod1, "")
 				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp1))).Should(BeTrue())
 
 				By("create new pod with released ips")
@@ -166,12 +166,12 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.2"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				ip, _, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
@@ -186,7 +186,7 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("10.16.0.1"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				err = im.AddOrUpdateSubnet(subnetName, "10.16.0.0/30", v4Gw, []string{"10.16.0.1..10.16.0.2"})
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -266,12 +266,12 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				By("release pod with multiple nics")
-				im.ReleaseAddressByPod(pod2)
+				im.ReleaseAddressByPod(pod2, "")
 				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp2))).Should(BeTrue())
 				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp3))).Should(BeTrue())
 
 				By("release pod with single nic")
-				im.ReleaseAddressByPod(pod1)
+				im.ReleaseAddressByPod(pod1, "")
 				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp1))).Should(BeTrue())
 
 				By("create new pod with released ips")
@@ -315,12 +315,12 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::2"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				_, ip, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
@@ -335,7 +335,7 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ip).To(Equal("fd00::1"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				err = im.AddOrUpdateSubnet(subnetName, "fd00::/126", v6Gw, []string{"fd00::1..fd00::2"})
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -434,14 +434,14 @@ var _ = Describe("[IPAM]", func() {
 				Expect(err).Should(MatchError(ipam.ErrConflict))
 
 				By("release pod with multiple nics")
-				im.ReleaseAddressByPod(pod2)
+				im.ReleaseAddressByPod(pod2, "")
 				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp42))).Should(BeTrue())
 				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp43))).Should(BeTrue())
 				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp62))).Should(BeTrue())
 				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp63))).Should(BeTrue())
 
 				By("release pod with single nic")
-				im.ReleaseAddressByPod(pod1)
+				im.ReleaseAddressByPod(pod1, "")
 				Expect(im.Subnets[subnetName].V4ReleasedIPList.Contains(ipam.IP(freeIp41))).Should(BeTrue())
 				Expect(im.Subnets[subnetName].V6ReleasedIPList.Contains(ipam.IP(freeIp61))).Should(BeTrue())
 
@@ -487,13 +487,13 @@ var _ = Describe("[IPAM]", func() {
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.2"))
 				Expect(ipv6).To(Equal("fd00::2"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				ipv4, ipv6, _, err = im.GetRandomAddress("pod1.ns", "pod1.ns", "", subnetName, nil, true)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(ipv4).To(Equal("10.16.0.1"))
@@ -510,7 +510,7 @@ var _ = Describe("[IPAM]", func() {
 				Expect(ipv4).To(Equal("10.16.0.1"))
 				Expect(ipv6).To(Equal("fd00::1"))
 
-				im.ReleaseAddressByPod("pod1.ns")
+				im.ReleaseAddressByPod("pod1.ns", "")
 				err = im.AddOrUpdateSubnet(subnetName, "10.16.0.2/30,fd00::/126", dualGw, []string{"10.16.0.1..10.16.0.2", "fd00::1..fd00::2"})
 				Expect(err).ShouldNot(HaveOccurred())
 

--- a/test/unittest/ipam_bench/ipam_test.go
+++ b/test/unittest/ipam_bench/ipam_test.go
@@ -233,7 +233,7 @@ func delPodAddressCapacity(b *testing.B, im *ipam.IPAM, isTimeTrace bool) {
 			fmt.Printf("delete %d to %d pods spent time %ds \n", n+1-step, n, currentTime-startTime)
 			startTime = currentTime
 		}
-		im.ReleaseAddressByPod(podName)
+		im.ReleaseAddressByPod(podName, "")
 	}
 }
 
@@ -331,7 +331,7 @@ func benchmarkAllocFreeAddrParallel(b *testing.B, podNumber int, protocol string
 			}
 			for n := 0; n < podNumber; n++ {
 				podName := fmt.Sprintf("pod%d_%d", key, n)
-				im.ReleaseAddressByPod(podName)
+				im.ReleaseAddressByPod(podName, "")
 			}
 		}
 	})


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes

解决 vm pod 换一张网卡的时候会把所有 ip 释放的问题


- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 362fe2c</samp>

This pull request modifies the `ReleaseAddressByPod` function and its callers to take a subnet name as an argument, and to release the IP address only from the specified subnet if it is not empty, or from all subnets if it is empty. This improves the performance and correctness of the IP address management for various features, such as underlay-to-overlay interconnection, VPC NAT gateway, virtual IPs, and garbage collection. It also updates the unit and benchmark tests to reflect the changes.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 362fe2c</samp>

> _To release IPs from subnets with ease_
> _We modified `ReleaseAddressByPod` please_
> _We added an argument_
> _To specify the segment_
> _And updated the callers and tests with these_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 362fe2c</samp>

*  Modify `ReleaseAddressByPod` function to take a subnet name as an argument and release the IP address only from the specified subnet if it is not empty, or from all subnets if it is empty ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L114-R124))
*  Pass the subnet name from the IP CR to `ReleaseAddressByPod` function in `markAndCleanLSP` function, which garbage collects the logical switch ports and the IP CRs ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89L353-R372))
*  Pass the node switch name to `ReleaseAddressByPod` function in `handleDeleteNode` function, which handles the deletion of a node and its associated resources ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-8a92aa9e5847a415c4c90271fa845087d27a67fd272b8efc2636b06d52cb3619L493-R493))
*  Pass the subnet name from the virtual IP CR to `ReleaseAddressByPod` function in `podReuseVip` function, which reuses a virtual IP for a pod that has the same labels as the previous owner of the virtual IP ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L471-R471))
*  Pass the subnet name to `ReleaseAddressByPod` function in `reconcileU2OInterconnectionIP` function, which reconciles the underlay-to-overlay interconnection IP address for a subnet ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1568-R1568), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205L1597-R1597))
*  Pass an empty string as the subnet name to `ReleaseAddressByPod` function in the following functions, which handle the deletion of various resources that do not belong to any specific subnet: `handleDelOvnEip` ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-28764fafc63230ed4d8301d469d3a770071b3db0759ff3c58121653fcf0334ceL302-R302)), `handleDeletePod` ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L834-R834)), `handleDelVirtualIp` ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-c53f89147c39d7d4c3d3046d288a0cea09719776e947bfb3ef01ea29f75b1fb0L265-R265)), `handleDelIptablesEip` ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L396-R398))
*  Add `net` and `strings` packages as imports to `vpc_nat_gw_eip.go` file, which handles the VPC NAT gateway external IP resources, to resolve the dependency of the modified `ReleaseAddressByPod` function on the imported packages ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92R6-R8))
*  Remove `net` and `strings` packages as imports from `vpc_nat_gw_eip.go` file, which handles the VPC NAT gateway external IP resources, to clean up the unused imports and avoid potential conflicts or errors ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-c2fca6de8b38cf14047d762d1029e969197a5fd0d5172062dce753f1e9613c92L13-R16))
*  Modify the unit tests and the benchmark test for the `ReleaseAddressByPod` function in `ipam_test.go` and `ipam_bench_test.go` files, which test the IPAM module, to pass an empty string as the subnet name to the modified function and test the default behavior of releasing the IP address from all subnets ([link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L119-R124), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L169-R174), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L189-R189), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L269-R274), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L318-R323), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L338-R338), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L437-R437), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L444-R444), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L490-R490), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L496-R496), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-de05eb7a820c593f09e2db0f7913c9184f3ef290cc0d9a9f6f9892a14c278854L513-R513), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-28d0df1939c70d211f3b0a5854793bd66d830c0cdbfca0bccf62453adcdfd690L236-R236), [link](https://github.com/kubeovn/kube-ovn/pull/3451/files?diff=unified&w=0#diff-28d0df1939c70d211f3b0a5854793bd66d830c0cdbfca0bccf62453adcdfd690L334-R334))
