### PR TITLE
fix the custom vpc of lb name

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -522,6 +522,7 @@ func (c *Controller) gcLoadBalancer() error {
 			klog.Infof("load balancer %q already deleted", lbName)
 			return nil
 		}
+		klog.Infof("gc: clean LB, removeVip, LB Name:", lbName)
 
 		for vip := range lb.Vips {
 			if !svcVips.Has(vip) {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -1,6 +1,7 @@
 package util
 
 const (
+	None        = ""
 	CniTypeName = "kube-ovn"
 
 	ControllerName = "kube-ovn-controller"


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

Fix when creating ovn-dnat, the lb-name in the ovn-nb show the wrong name(dnat-name).

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

* before fix： 
create the ovn-dnat， the lb-list:
1. odnat
```markdown
# kubectl get odnat
NAME                      VPC    EIP               PROTOCOL   V4EIP       V4IP           INTERNALPORT   EXTERNALPORT   IPNAME                      READY
eip-dnat-111401   vpc1   eip-dnat-111401   tcp        10.5.46.1   10.111.112.2   80             80             eip-dnat-111401-pod2.vpc1   true
```

2.  in the ovn-nb
```markdown
# ovn-nbctl lb-list   
UUID                                    LB                  PROTO      VIP                   IPs
54fdc600-62c3-4bc1-b80d-6bd50c375817    eip-dnat-111401     tcp        10.5.46.1:80          10.111.112.2:80
```

* after fix:
  in the ovn-nb
```markdown
# ovn-nbctl lb-list   
UUID                                                                               LB                  PROTO          VIP                            IPs
8d385c8b-54f3-4928-8687-54811d86db42    vpc-vpc1-tcp-loa           tcp        10.5.46.0:80          10.111.112.2:80
```










