### PR TITLE
kube-ovn-cni: fix pinger result when timeout is reached

### DIFF
--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -40,6 +40,11 @@ func pingGateway(gw, src string, verbose bool, maxRetry int) (count int, err err
 		return 0, err
 	}
 
+	if pinger.PacketsRecv == 0 {
+		klog.Warningf("%s network not ready after %d ping, gw %s", src, pinger.PacketsSent, gw)
+		return pinger.PacketsSent, fmt.Errorf("no packets received from gateway %s", gw)
+	}
+
 	cniConnectivityResult.WithLabelValues(nodeName).Add(float64(pinger.PacketsSent))
 	if verbose {
 		klog.Infof("%s network ready after %d ping, gw %s", src, pinger.PacketsSent, gw)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
W1124 16:21:39.705812 1626079 ovs.go:34] 10.100.6.9 network not ready after 189 ping to gateway 10.100.6.1
W1124 16:21:42.705081 1626079 ovs.go:34] 10.100.6.9 network not ready after 192 ping to gateway 10.100.6.1
W1124 16:21:45.705465 1626079 ovs.go:34] 10.100.6.9 network not ready after 195 ping to gateway 10.100.6.1
W1124 16:21:48.706072 1626079 ovs.go:34] 10.100.6.9 network not ready after 198 ping to gateway 10.100.6.1
I1124 16:21:50.754492 1626079 ovs.go:45] 10.100.6.9 network ready after 200 ping, gw 10.100.6.1
```

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7aa7fe9</samp>

Improve network readiness check by handling gateway ping failure. Add error return and warning log in `pingGateway` function in `pkg/daemon/ovs.go`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7aa7fe9</samp>

> _`pingGateway` checks_
> _packets from the gateway - none?_
> _logs a warning, fails_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7aa7fe9</samp>

* Add a check for gateway packet loss in `pingGateway` function ([link](https://github.com/kubeovn/kube-ovn/pull/3457/files?diff=unified&w=0#diff-067d64bdcf68917f106b1f905d4608e8927a7ea0e9388b9e225c147566ece237R43-R47)) to improve error handling and logging of network readiness
