### PR TITLE
Ovn ic ecmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,7 @@ kind-install-overlay-ipv4: kind-install
 kind-install-ovn-ic: kind-install
 	$(call kind_load_image,kube-ovn1,$(REGISTRY)/kube-ovn:$(VERSION))
 	kubectl config use-context kind-kube-ovn1
+	$(MAKE) kind-untaint-control-plane
 	sed -e 's/10.16.0/10.18.0/g' \
 		-e 's/10.96.0/10.98.0/g' \
 		-e 's/100.64.0/100.68.0/g' \
@@ -370,8 +371,8 @@ kind-install-ovn-ic: kind-install
 	docker run -d --name ovn-ic-db --network kind $(REGISTRY)/kube-ovn:$(VERSION) bash start-ic-db.sh
 	@set -e; \
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
-	zone=az0 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name=kube-ovn1-worker j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-control-plane;kube-ovn-worker' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn1-control-plane;kube-ovn1-worker' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1

--- a/Makefile
+++ b/Makefile
@@ -371,8 +371,8 @@ kind-install-ovn-ic: kind-install
 	docker run -d --name ovn-ic-db --network kind $(REGISTRY)/kube-ovn:$(VERSION) bash start-ic-db.sh
 	@set -e; \
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
-	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-control-plane;kube-ovn-worker' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn1-control-plane;kube-ovn1-worker' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-control-plane;kube-ovn-worker;kube-ovn-worker2' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn1-control-plane;kube-ovn1-worker;kube-ovn1-worker2' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1

--- a/Makefile
+++ b/Makefile
@@ -371,8 +371,8 @@ kind-install-ovn-ic: kind-install
 	docker run -d --name ovn-ic-db --network kind $(REGISTRY)/kube-ovn:$(VERSION) bash start-ic-db.sh
 	@set -e; \
 	ic_db_host=$$(docker inspect ovn-ic-db -f "{{.NetworkSettings.Networks.kind.IPAddress}}"); \
-	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-control-plane;kube-ovn-worker;kube-ovn-worker2' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
-	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn1-control-plane;kube-ovn1-worker;kube-ovn1-worker2' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
+	zone=az0 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn-worker,kube-ovn-worker2,kube-ovn-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-0.yaml; \
+	zone=az1 ic_db_host=$$ic_db_host gateway_node_name='kube-ovn1-worker,kube-ovn1-worker2,kube-ovn1-control-plane' j2 yamls/ovn-ic.yaml.j2 -o ovn-ic-1.yaml
 	kubectl config use-context kind-kube-ovn
 	kubectl apply -f ovn-ic-0.yaml
 	kubectl config use-context kind-kube-ovn1

--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-TS_NAME=${TS_NAME:-ts}
-TS_CIDR=${TS_CIDR:-169.254.100.0/24}
-
 function quit {
     /usr/share/ovn/scripts/ovn-ctl stop_ic_ovsdb
     exit 0
@@ -19,8 +16,6 @@ trap quit EXIT
 if [[ -z "$NODE_IPS" && -z "$LOCAL_IP" ]]; then
     /usr/share/ovn/scripts/ovn-ctl --db-ic-nb-create-insecure-remote=yes --db-ic-sb-create-insecure-remote=yes start_ic_ovsdb
     /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
-    ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
-    ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
     tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
 else
     if [[ -z "$LEADER_IP" ]]; then
@@ -33,8 +28,6 @@ else
         --ovn-ic-sb-db="$(gen_conn_str 6648)" \
         start_ic_ovsdb
         /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
-        ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
-        ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
         tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
     else
         echo "follower start with local ${LOCAL_IP}, leader ${LEADER_IP} and cluster $(gen_conn_str 6647)"

--- a/pkg/controller/ovn-ic.go
+++ b/pkg/controller/ovn-ic.go
@@ -196,7 +196,7 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 	groups := strings.Split(config["gw-nodes"], ";")
 	for i, group := range groups {
 		gwNodes := strings.Split(group, ",")
-		chassises := make([]string, len(gwNodes)*2)
+		chassises := make([]string, len(gwNodes))
 		for j, gw := range gwNodes {
 			gw = strings.TrimSpace(gw)
 			chassisID, err := c.ovnLegacyClient.GetChassis(gw)
@@ -208,7 +208,6 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 				return fmt.Errorf("no chassisID for gw %s", gw)
 			}
 			chassises[j] = chassisID
-			chassises[j+len(gwNodes)] = chassisID
 
 			cachedNode, err := c.nodesLister.Get(gw)
 			if err != nil {
@@ -259,7 +258,7 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 			return err
 		}
 
-		if err = c.ovnLegacyClient.CreateICLogicalRouterPort(config["az-name"], tsName, util.GenerateMac(), lrpAddr, chassises[i:i+len(gwNodes)]); err != nil {
+		if err = c.ovnLegacyClient.CreateICLogicalRouterPort(config["az-name"], tsName, util.GenerateMac(), lrpAddr, chassises); err != nil {
 			klog.Errorf("failed to create ovn-ic lrp %v", err)
 			return err
 		}

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -126,21 +126,22 @@ func (c LegacyClient) DeleteLogicalRouterPort(port string) error {
 	return nil
 }
 
-func (c LegacyClient) CreateICLogicalRouterPort(az, mac, subnet string, chassises []string) error {
-	lrpName := fmt.Sprintf("%s-ts", az)
+func (c LegacyClient) CreateICLogicalRouterPort(az, ts, mac, subnet string, chassises []string) error {
+	lspName := fmt.Sprintf("%s-%s", ts, az)
+	lrpName := fmt.Sprintf("%s-%s", az, ts)
 	klog.Infof("add vpc lrp %s", lrpName)
 	if _, err := c.ovnNbCommand(MayExist, "lrp-add", c.ClusterRouter, lrpName, mac, subnet); err != nil {
 		return fmt.Errorf("failed to create ovn-ic lrp, %v", err)
 	}
-	if _, err := c.ovnNbCommand(MayExist, "lsp-add", util.InterconnectionSwitch, fmt.Sprintf("ts-%s", az), "--",
-		"lsp-set-addresses", fmt.Sprintf("ts-%s", az), "router", "--",
-		"lsp-set-type", fmt.Sprintf("ts-%s", az), "router", "--",
-		"lsp-set-options", fmt.Sprintf("ts-%s", az), fmt.Sprintf("router-port=%s-ts", az), "--",
-		"set", "logical_switch_port", fmt.Sprintf("ts-%s", az), fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName)); err != nil {
+	if _, err := c.ovnNbCommand(MayExist, "lsp-add", ts, lspName, "--",
+		"lsp-set-addresses", lspName, "router", "--",
+		"lsp-set-type", lspName, "router", "--",
+		"lsp-set-options", lspName, fmt.Sprintf("router-port=%s", lrpName), "--",
+		"set", "logical_switch_port", lspName, fmt.Sprintf("external_ids:vendor=%s", util.CniTypeName)); err != nil {
 		return fmt.Errorf("failed to create ovn-ic lsp, %v", err)
 	}
 	for index, chassis := range chassises {
-		if _, err := c.ovnNbCommand("lrp-set-gateway-chassis", fmt.Sprintf("%s-ts", az), chassis, fmt.Sprintf("%d", 100-index)); err != nil {
+		if _, err := c.ovnNbCommand("lrp-set-gateway-chassis", lrpName, chassis, strconv.Itoa(100-index)); err != nil {
 			return fmt.Errorf("failed to set gateway chassis, %v", err)
 		}
 	}

--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -59,5 +59,8 @@ nodes:
     image: kindest/node:{{ k8s_version }}
     labels:
       kube-ovn/role: master
+  {%- else %}
+  - role: worker
+    image: kindest/node:{{ k8s_version }}
   {%- endif %}
 {%- endif %}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e465701</samp>

This pull request enhances the ovn-ic feature to support multiple availability zones and different Kubernetes versions. It updates the `./Makefile`, the `ovn-ic` controller, the `ovn-nbctl-legacy` command, and the `kind.yaml.j2` template.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e465701</samp>

> _Sing, O Muse, of the mighty deeds of the ovn-ic team_
> _Who, with skill and cunning, forged the interconnection scheme_
> _They changed the logic of the `logical router port` creation_
> _And made it vary by the `transit switch` of each gateway station_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e465701</samp>

*  Modify the logic to create the interconnection between different availability zones using multiple gateway nodes per zone ([link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL205-R266),[link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL321-R343),[link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL464-R495),[link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-a90d8643bea46e8b41ae2967284c3fbc3f11681b2ef2ae06d7406815f0a20373L129-R144))
* Remove the logic to check and create a logical switch port for the transit switch in the ovn-ic controller, since it is no longer needed ([link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL189-L199))
* Modify the logic to generate the ovn-ic yaml files for each availability zone using a comma-separated list of gateway node names for each zone in `Makefile` ([link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L373-R375))
* Add a command to untaint the control plane node in the kind cluster in `Makefile` ([link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R363))
* Remove an unused import of the ovnnb package and add imports of the strset, ovs, and ovnnb packages in the ovn-ic controller ([link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL7),[link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR13),[link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceR20-R21))
* Move the logic to list the logical router policies by external ID before the check for the logical router routes in the ovn-ic controller ([link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL448-R460))
* Remove a redundant error check in the ovn-ic controller ([link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-173d2c52eb78053b84437284c077aba7452636bc799728cc475cc343ea70c2ceL368-L370))
* Add a condition to the kind yaml template to create a worker node with the default image if the k8s_version is not specified in `yamls/kind.yaml.j2` ([link](https://github.com/kubeovn/kube-ovn/pull/3465/files?diff=unified&w=0#diff-f88bb6992159e270ea78e286f19bfd123e4a87bcdb6307eadacc2d06dd6265f4R62-R64))
