### PR TITLE
delete vm's lsp and release ipam.ip

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -996,14 +996,15 @@ func (c *Controller) handleDeletePod(key string) error {
 		}
 	}
 
-	ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": key})
+	podKey := fmt.Sprintf("%s/%s", pod.Namespace, podName)
+	ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": podKey})
 	if err != nil {
 		klog.Errorf("failed to list lsps of pod '%s', %v", pod.Name, err)
 		return err
 	}
 
 	if len(ports) != 0 {
-		addresses := c.ipam.GetPodAddress(key)
+		addresses := c.ipam.GetPodAddress(podKey)
 		for _, address := range addresses {
 			if strings.TrimSpace(address.IP) == "" {
 				continue
@@ -1083,7 +1084,7 @@ func (c *Controller) handleDeletePod(key string) error {
 		}
 	}
 
-	c.ipam.ReleaseAddressByPod(key)
+	c.ipam.ReleaseAddressByPod(podKey)
 
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: yuanliu@cmss.chinamobile.com <yuanliu@cmss.chinamobile.com>

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

delete vm's lsp and release ipam.ip

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85716e6</samp>

Improved pod controller logic by using `podKey` for switch ports and IPAM. This avoids potential conflicts or errors with pod names or namespaces.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85716e6</samp>

> _Oh, we are the pod controllers, and we work on the code_
> _We refactor and we test it, and we make it run in mode_
> _We use the `podKey` now, to identify the ports_
> _And IPAM operations, are consistent of course_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85716e6</samp>

*  Introduce `podKey` variable to use pod namespace and name as key for pod-related operations ([link](https://github.com/kubeovn/kube-ovn/pull/3476/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L999-R1000), [link](https://github.com/kubeovn/kube-ovn/pull/3476/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1006-R1007), [link](https://github.com/kubeovn/kube-ovn/pull/3476/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1086-R1087))
  * Use `podKey` to list logical switch ports associated with pod in `pkg/controller/pod.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3476/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L999-R1000))
  * Use `podKey` to get and release pod address from IPAM module in `pkg/controller/pod.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3476/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1006-R1007), [link](https://github.com/kubeovn/kube-ovn/pull/3476/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26L1086-R1087))
