### PR TITLE
fix ovn eip not calculated

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2097,6 +2097,14 @@ func calcSubnetStatusIP(subnet *kubeovnv1.Subnet, c *Controller) error {
 		return err
 	}
 	usingIPs += float64(len(vips))
+	ovnEips, err := c.ovnEipsLister.List(labels.SelectorFromSet(labels.Set{
+		util.SubnetNameLabel: subnet.Name,
+	}))
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	usingIPs += float64(len(ovnEips))
 	if !isOvnSubnet(subnet) {
 		eips, err := c.iptablesEipsLister.List(
 			labels.SelectorFromSet(labels.Set{util.SubnetNameLabel: subnet.Name}))

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -455,15 +455,17 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		subnetClient.DeleteSync(noBfdExtraSubnetName)
 		ginkgo.By("Deleting subnet " + bfdSubnetName)
 		subnetClient.DeleteSync(bfdSubnetName)
-		ginkgo.By("Deleting underlay subnet " + underlaySubnetName)
-		subnetClient.DeleteSync(underlaySubnetName)
-		ginkgo.By("Deleting extra underlay subnet " + underlayExtraSubnetName)
-		subnetClient.DeleteSync(underlayExtraSubnetName)
 
 		ginkgo.By("Deleting no bfd custom vpc " + noBfdVpcName)
 		vpcClient.DeleteSync(noBfdVpcName)
 		ginkgo.By("Deleting bfd custom vpc " + bfdVpcName)
 		vpcClient.DeleteSync(bfdVpcName)
+
+		ginkgo.By("Deleting underlay vlan subnet")
+		ginkgo.By("Deleting underlay subnet " + underlaySubnetName)
+		subnetClient.DeleteSync(underlaySubnetName)
+		ginkgo.By("Deleting extra underlay subnet " + underlayExtraSubnetName)
+		subnetClient.DeleteSync(underlayExtraSubnetName)
 
 		ginkgo.By("Deleting vlan " + vlanName)
 		vlanClient.Delete(vlanName, metav1.DeleteOptions{})


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes
https://github.com/kubeovn/kube-ovn/issues/3474

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac15edd</samp>

Update `calcSubnetStatusIP` function to count OVN EIPs as using IPs. This improves the accuracy of subnet status IP fields for subnets that have OVN EIPs associated with them.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac15edd</samp>

> _`calcSubnetStatusIP`_
> _Adds OVN EIPs to using count_
> _Autumn leaves fall fast_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac15edd</samp>

*  Add logic to count OVN EIPs as using IPs in subnet status ([link](https://github.com/kubeovn/kube-ovn/pull/3477/files?diff=unified&w=0#diff-3742843fd11c637b26eae183fb8a0c4eeff96bbfb18a8db1e0ded0c33733f205R2098-R2105))
