### PR TITLE
schedule a part of neccessary e2es for release-1.12-mc

### DIFF
--- a/.github/workflows/build-kube-ovn-base-dpdk.yaml
+++ b/.github/workflows/build-kube-ovn-base-dpdk.yaml
@@ -9,6 +9,7 @@ on:
         options:
           - master
           - release-1.12
+          - release-1.12-mc
   schedule:
     - cron: "20 19 * * *"
 
@@ -20,6 +21,7 @@ jobs:
         branch:
           - master
           - release-1.12
+          - release-1.12-mc
     name: Build AMD64
     runs-on: ubuntu-22.04
     steps:
@@ -52,6 +54,7 @@ jobs:
         branch:
           - master
           - release-1.12
+          - release-1.12-mc
     needs:
       - build-amd64
     name: push

--- a/.github/workflows/build-kube-ovn-base.yaml
+++ b/.github/workflows/build-kube-ovn-base.yaml
@@ -11,6 +11,7 @@ on:
           - release-1.12
           - release-1.11
           - release-1.9
+          - release-1.12-mc
   schedule:
   - cron: "20 19 * * *"
 
@@ -24,6 +25,7 @@ jobs:
         - release-1.12
         - release-1.11
         - release-1.9
+        - release-1.12-mc
     name: Build AMD64
     runs-on: ubuntu-22.04
     steps:
@@ -58,6 +60,7 @@ jobs:
         - release-1.12
         - release-1.11
         - release-1.9
+        - release-1.12-mc
     name: Build ARM64
     runs-on: ubuntu-22.04
     steps:
@@ -97,6 +100,7 @@ jobs:
         - release-1.12
         - release-1.11
         - release-1.9
+        - release-1.12-mc
     needs:
       - build-arm64
       - build-amd64

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -257,6 +257,7 @@ jobs:
           - release-1.12
           - release-1.11
           - release-1.9
+          - release-1.12-mc
         ip-family:
           - ipv4
           - ipv6
@@ -570,6 +571,7 @@ jobs:
           - master
           - release-1.12
           - release-1.11
+          - release-1.12-mc
     steps:
       - uses: actions/checkout@v4
 
@@ -642,6 +644,7 @@ jobs:
         branch:
           - master
           - release-1.12
+          - release-1.12-mc
   
     steps:
       - uses: actions/checkout@v4
@@ -924,6 +927,7 @@ jobs:
           - release-1.12
           - release-1.11
           - release-1.9
+          - release-1.12-mc
         ssl:
           - "true"
           - "false"
@@ -1244,6 +1248,7 @@ jobs:
         branch:
           - master
           - release-1.12
+          - release-1.12-mc
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Tests



<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 304adee</samp>

This pull request adds support for the multi-cluster feature to the workflows for building and testing the `kube-ovn` and `kube-ovn-base` images. It updates the workflows to use the `release-1.12-mc` branch, which contains the feature code for the 1.12 release.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 304adee</samp>

> _Sing, O Muse, of the mighty `kube-ovn`, the network fabric of the cloud_
> _That in the twelfth release of its glorious cycle, a new feature unveiled_
> _The multi-cluster branch, `release-1.12-mc`, that spans the realms of Kubernetes_
> _And builds and tests its images with workflows, swift as the winged Harpies_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 304adee</samp>

*  Add the `release-1.12-mc` branch to the workflows for building and pushing the kube-ovn-base, kube-ovn-base-dpdk, and kube-ovn images with the multi-cluster feature enabled ([link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edR12), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edR24), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-cf12a0f0ac5be6fa3879a24c5a4869ac4c3b4a008898c1f727025530cba611edR57), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR14), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR28), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR63), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-3d53e742565ba26538477979f11f22fbc883066479f4e9fe8d97a0f6a464ab1cR103))
*  Add the `release-1.12-mc` branch to the workflow for running the scheduled end-to-end tests using the images with the multi-cluster feature enabled ([link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R260), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R574), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R647), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R930), [link](https://github.com/kubeovn/kube-ovn/pull/3478/files?diff=unified&w=0#diff-b59f74dfbae2411789393f17d699928b3715b5c071b21b6eddb6a93fe696bf41R1251))
