### PR TITLE
iptables drop invalid rst

### DIFF
--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -29,6 +29,8 @@ iptables -t mangle -F OVN-PREROUTING
 iptables -t mangle -X OVN-PREROUTING
 iptables -t mangle -F OVN-OUTPUT
 iptables -t mangle -X OVN-OUTPUT
+iptables -t mangle -F OVN-POSTROUTING
+iptables -t mangle -X OVN-POSTROUTING
 
 sleep 1
 
@@ -67,6 +69,8 @@ ip6tables -t mangle -F OVN-PREROUTING
 ip6tables -t mangle -X OVN-PREROUTING
 ip6tables -t mangle -F OVN-OUTPUT
 ip6tables -t mangle -X OVN-OUTPUT
+iptables -t mangle -F OVN-POSTROUTING
+iptables -t mangle -X OVN-POSTROUTING
 
 sleep 1
 

--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -69,8 +69,8 @@ ip6tables -t mangle -F OVN-PREROUTING
 ip6tables -t mangle -X OVN-PREROUTING
 ip6tables -t mangle -F OVN-OUTPUT
 ip6tables -t mangle -X OVN-OUTPUT
-iptables -t mangle -F OVN-POSTROUTING
-iptables -t mangle -X OVN-POSTROUTING
+ip6tables -t mangle -F OVN-POSTROUTING
+ip6tables -t mangle -X OVN-POSTROUTING
 
 sleep 1
 

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -551,6 +551,8 @@ func (c *Controller) setIptables() error {
 			{Table: "filter", Chain: "FORWARD", Rule: strings.Fields(`-m set --match-set ovn40services dst -j ACCEPT`)},
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
+			// Drop invalid rst
+			{Table: MANGLE, Chain: OvnPostrouting, Rule: strings.Fields(`-p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 		v6Rules = []util.IPTableRule{
 			// mark packets from pod to service
@@ -588,6 +590,8 @@ func (c *Controller) setIptables() error {
 			{Table: "filter", Chain: "FORWARD", Rule: strings.Fields(`-m set --match-set ovn60services dst -j ACCEPT`)},
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
+			// Drop invalid rst
+			{Table: MANGLE, Chain: OvnPostrouting, Rule: strings.Fields(`-p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 	)
 	protocols := make([]string, 2)
@@ -710,7 +714,7 @@ func (c *Controller) setIptables() error {
 			}
 		}
 
-		var natPreroutingRules, natPostroutingRules, ovnMasqueradeRules []util.IPTableRule
+		var natPreroutingRules, natPostroutingRules, ovnMasqueradeRules, manglePostrutingRules []util.IPTableRule
 		for _, rule := range iptablesRules {
 			if rule.Table == NAT {
 				if c.k8siptables[protocol].HasRandomFully() &&
@@ -727,6 +731,11 @@ func (c *Controller) setIptables() error {
 					continue
 				case OvnMasquerade:
 					ovnMasqueradeRules = append(ovnMasqueradeRules, rule)
+					continue
+				}
+			} else if rule.Table == MANGLE {
+				if rule.Chain == OvnPostrouting {
+					manglePostrutingRules = append(manglePostrutingRules, rule)
 					continue
 				}
 			}
@@ -777,6 +786,11 @@ func (c *Controller) setIptables() error {
 		}
 		if err = c.updateIptablesChain(ipt, NAT, OvnPostrouting, Postrouting, natPostroutingRules); err != nil {
 			klog.Errorf("failed to update chain %s/%s: %v", NAT, OvnPostrouting, err)
+			return err
+		}
+
+		if err = c.updateIptablesChain(ipt, MANGLE, OvnPostrouting, Postrouting, manglePostrutingRules); err != nil {
+			klog.Errorf("failed to update chain %s/%s: %v", MANGLE, OvnPostrouting, err)
 			return err
 		}
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a7b0509</samp>

Add iptables rules to protect pod subnets from TCP RST attacks and refactor gateway code.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a7b0509</samp>

> _To protect pods from TCP RST_
> _This pull request adds to the `MANGLE` chest_
> _Some rules for `OvnPostrouting`_
> _And refactors the routing_
> _To handle different tables with zest_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a7b0509</samp>

*  Add iptables rules to drop TCP RST packets from OVN subnets with invalid state ([link](https://github.com/kubeovn/kube-ovn/pull/3484/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R554-R555), [link](https://github.com/kubeovn/kube-ovn/pull/3484/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R593-R594))
*  Declare a variable to store the iptables rules for the MANGLE table and the OvnPostrouting chain ([link](https://github.com/kubeovn/kube-ovn/pull/3484/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L713-R717))
*  Modify the for loop to append the rules to the variable and skip the rest of the loop ([link](https://github.com/kubeovn/kube-ovn/pull/3484/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R736-R740))
*  Call the updateIptablesChain function to apply the rules to the system and log any error ([link](https://github.com/kubeovn/kube-ovn/pull/3484/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R792-R796))
