### PR TITLE
delete String() function

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -235,14 +235,14 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 			for nicName, ip := range subnet.V4NicToIP {
 				if !ips.Contains(ip) {
 					podName := subnet.V4IPToPod[ip.String()]
-					klog.Errorf("%s address %s not in subnet %s new cidr %s", podName, ip.String(), name, cidrStr)
+					klog.Errorf("%s address %s not in subnet %s new cidr %s", podName, ip, name, cidrStr)
 					delete(subnet.V4NicToIP, nicName)
 					delete(subnet.V4IPToPod, ip.String())
 				}
 			}
 
 			for nicName, ip := range subnet.V4NicToIP {
-				klog.Infof("already assigned ip %s to nic %s in subnet %s", ip.String(), nicName, name)
+				klog.Infof("already assigned ip %s to nic %s in subnet %s", ip, nicName, name)
 			}
 		}
 		if (protocol == kubeovnv1.ProtocolDual || protocol == kubeovnv1.ProtocolIPv6) &&
@@ -281,14 +281,14 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 			for nicName, ip := range subnet.V6NicToIP {
 				if !ips.Contains(ip) {
 					podName := subnet.V6IPToPod[ip.String()]
-					klog.Errorf("%s address %s not in subnet %s new cidr %s", podName, ip.String(), name, cidrStr)
+					klog.Errorf("%s address %s not in subnet %s new cidr %s", podName, ip, name, cidrStr)
 					delete(subnet.V6NicToIP, nicName)
 					delete(subnet.V6IPToPod, ip.String())
 				}
 			}
 
 			for nicName, ip := range subnet.V6NicToIP {
-				klog.Infof("already assigned ip %s to nic %s in subnet %s", ip.String(), nicName, name)
+				klog.Infof("already assigned ip %s to nic %s in subnet %s", ip, nicName, name)
 			}
 		}
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features


In the net package,ip has implement the String() function,so we can print it directly with "%s"

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a0dd3a</samp>

Improved logging performance and readability in `ipam.go`. Removed redundant string conversions of IP addresses in log messages.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a0dd3a</samp>

> _`ipam.go` is the master of the net_
> _Allocating and managing every address_
> _No more wasted cycles on `ip.String()`_
> _Only pure and efficient code in the log_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a0dd3a</samp>

* Remove redundant `ip.String()` calls from log messages in `pkg/ipam/ipam.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3488/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L238-R238), [link](https://github.com/kubeovn/kube-ovn/pull/3488/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L245-R245), [link](https://github.com/kubeovn/kube-ovn/pull/3488/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L284-R284), [link](https://github.com/kubeovn/kube-ovn/pull/3488/files?diff=unified&w=0#diff-f6f997198027981d4c52e09a03197d9ba9ebcf4aa58e40b2da03327604850d05L291-R291))
