### PR TITLE
add iptables drop invalid rst

### DIFF
--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -19,6 +19,8 @@ iptables -t filter -D FORWARD -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services dst -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services src -j ACCEPT
 iptables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
+iptables -t mangle -F OVN-POSTROUTING
+iptables -t mangle -X OVN-POSTROUTING
 
 sleep 1
 
@@ -46,6 +48,8 @@ ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
+ip6tables -t mangle -F OVN-POSTROUTING
+ip6tables -t mangle -X OVN-POSTROUTING
 
 sleep 1
 

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -38,6 +38,7 @@ const (
 
 const (
 	NAT            = "nat"
+	MANGLE         = "mangle"
 	Prerouting     = "PREROUTING"
 	Postrouting    = "POSTROUTING"
 	OvnPrerouting  = "OVN-PREROUTING"
@@ -447,6 +448,8 @@ func (c *Controller) setIptables() error {
 			{Table: "filter", Chain: "FORWARD", Rule: strings.Fields(`-m set --match-set ovn40services dst -j ACCEPT`)},
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
+			// Drop invalid rst
+			{Table: MANGLE, Chain: OvnPostrouting, Rule: strings.Fields(`-p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 		v6Rules = []util.IPTableRule{
 			// mark packets from pod to service
@@ -481,6 +484,8 @@ func (c *Controller) setIptables() error {
 			{Table: "filter", Chain: "FORWARD", Rule: strings.Fields(`-m set --match-set ovn60services dst -j ACCEPT`)},
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
+			// Drop invalid rst
+			{Table: MANGLE, Chain: OvnPostrouting, Rule: strings.Fields(`-p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 	)
 	protocols := make([]string, 2)
@@ -535,7 +540,7 @@ func (c *Controller) setIptables() error {
 			}
 		}
 
-		var natPreroutingRules, natPostroutingRules, ovnMasqueradeRules []util.IPTableRule
+		var natPreroutingRules, natPostroutingRules, ovnMasqueradeRules, manglePostrutingRules []util.IPTableRule
 		for _, rule := range iptablesRules {
 			if rule.Table == NAT {
 				switch rule.Chain {
@@ -547,6 +552,11 @@ func (c *Controller) setIptables() error {
 					continue
 				case OvnMasquerade:
 					ovnMasqueradeRules = append(ovnMasqueradeRules, rule)
+					continue
+				}
+			} else if rule.Table == MANGLE {
+				if rule.Chain == OvnPostrouting {
+					manglePostrutingRules = append(manglePostrutingRules, rule)
 					continue
 				}
 			}
@@ -584,6 +594,11 @@ func (c *Controller) setIptables() error {
 		}
 		if err = c.updateIptablesChain(ipt, NAT, OvnPostrouting, Postrouting, natPostroutingRules); err != nil {
 			klog.Errorf("failed to update chain %s/%s: %v", NAT, OvnPostrouting)
+			return err
+		}
+
+		if err = c.updateIptablesChain(ipt, MANGLE, OvnPostrouting, Postrouting, manglePostrutingRules); err != nil {
+			klog.Errorf("failed to update chain %s/%s: %v", MANGLE, OvnPostrouting, err)
 			return err
 		}
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 88c3b01</samp>

Add iptables rules to drop invalid TCP RST packets from OVN subnets on gateway node. Refactor `setIptables` function in `gateway_linux.go` to handle different tables.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 88c3b01</samp>

> _To the gateway node we must add_
> _Some iptables rules that are rad_
> _They drop TCP RST_
> _From OVN at its best_
> _Using `mangle` and `OvnPostrouting` chain, not bad_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 88c3b01</samp>

*  Define `MANGLE` constant for iptables mangle table ([link](https://github.com/kubeovn/kube-ovn/pull/3491/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R41))
*  Add iptables rules to drop invalid TCP RST packets from ovn40subnets and ovn60subnets sets in `setIptables` function ([link](https://github.com/kubeovn/kube-ovn/pull/3491/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R451-R452), [link](https://github.com/kubeovn/kube-ovn/pull/3491/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R487-R488))
*  Declare `manglePostrutingRules` slice to store iptables rules for mangle table and OvnPostruting chain ([link](https://github.com/kubeovn/kube-ovn/pull/3491/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L538-R543))
*  Append iptables rules for mangle table and OvnPostruting chain to `manglePostrutingRules` slice in for loop ([link](https://github.com/kubeovn/kube-ovn/pull/3491/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R557-R561))
*  Call `updateIptablesChain` function with `manglePostrutingRules` slice to update iptables mangle table and OvnPostruting chain in `pkg/daemon/gateway_linux.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3491/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4R600-R604))
