### PR TITLE
fix typo

### DIFF
--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -714,7 +714,7 @@ func (c *Controller) setIptables() error {
 			}
 		}
 
-		var natPreroutingRules, natPostroutingRules, ovnMasqueradeRules, manglePostrutingRules []util.IPTableRule
+		var natPreroutingRules, natPostroutingRules, ovnMasqueradeRules, manglePostroutingRules []util.IPTableRule
 		for _, rule := range iptablesRules {
 			if rule.Table == NAT {
 				if c.k8siptables[protocol].HasRandomFully() &&
@@ -735,7 +735,7 @@ func (c *Controller) setIptables() error {
 				}
 			} else if rule.Table == MANGLE {
 				if rule.Chain == OvnPostrouting {
-					manglePostrutingRules = append(manglePostrutingRules, rule)
+					manglePostroutingRules = append(manglePostroutingRules, rule)
 					continue
 				}
 			}
@@ -789,7 +789,7 @@ func (c *Controller) setIptables() error {
 			return err
 		}
 
-		if err = c.updateIptablesChain(ipt, MANGLE, OvnPostrouting, Postrouting, manglePostrutingRules); err != nil {
+		if err = c.updateIptablesChain(ipt, MANGLE, OvnPostrouting, Postrouting, manglePostroutingRules); err != nil {
 			klog.Errorf("failed to update chain %s/%s: %v", MANGLE, OvnPostrouting, err)
 			return err
 		}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c61e70b</samp>

Fix a typo and formatting in `gateway_linux.go`. This improves the readability and correctness of the gateway daemon code.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c61e70b</samp>

> _A typo was found in a name_
> _That messed up the iptables game_
> _The gateway daemon_
> _Was not behaving_
> _So this pull request fixed the same_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c61e70b</samp>

* Fix a typo in the variable name `manglePostrutingRules` to `manglePostroutingRules` in `gateway_linux.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3494/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L738-R738), [link](https://github.com/kubeovn/kube-ovn/pull/3494/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L792-R792))
* Remove a no-op change in `gateway_linux.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3494/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L717-R717))
