### PR TITLE
typo

### DIFF
--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -540,7 +540,7 @@ func (c *Controller) setIptables() error {
 			}
 		}
 
-		var natPreroutingRules, natPostroutingRules, ovnMasqueradeRules, manglePostrutingRules []util.IPTableRule
+		var natPreroutingRules, natPostroutingRules, ovnMasqueradeRules, manglePostroutingRules []util.IPTableRule
 		for _, rule := range iptablesRules {
 			if rule.Table == NAT {
 				switch rule.Chain {
@@ -556,7 +556,7 @@ func (c *Controller) setIptables() error {
 				}
 			} else if rule.Table == MANGLE {
 				if rule.Chain == OvnPostrouting {
-					manglePostrutingRules = append(manglePostrutingRules, rule)
+					manglePostroutingRules = append(manglePostroutingRules, rule)
 					continue
 				}
 			}
@@ -597,7 +597,7 @@ func (c *Controller) setIptables() error {
 			return err
 		}
 
-		if err = c.updateIptablesChain(ipt, MANGLE, OvnPostrouting, Postrouting, manglePostrutingRules); err != nil {
+		if err = c.updateIptablesChain(ipt, MANGLE, OvnPostrouting, Postrouting, manglePostroutingRules); err != nil {
 			klog.Errorf("failed to update chain %s/%s: %v", MANGLE, OvnPostrouting, err)
 			return err
 		}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3803d53</samp>

Fix a typo and formatting issues in `gateway_linux.go`. This improves the reliability of the gateway node iptables configuration.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3803d53</samp>

> _A typo was found in the code_
> _That could make the iptables explode_
> _So they fixed `manglePostroutingRules`_
> _And applied some formatting tools_
> _To improve the gateway node's load_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3803d53</samp>

* Fix typo in variable name `manglePostrutingRules` to `manglePostroutingRules` in `gateway_linux.go` ([link](https://github.com/kubeovn/kube-ovn/pull/3495/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L543-R543), [link](https://github.com/kubeovn/kube-ovn/pull/3495/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L559-R559), [link](https://github.com/kubeovn/kube-ovn/pull/3495/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L600-R600))
* Update iptables chain logic to use the correct variable name for the mangle postrouting rules ([link](https://github.com/kubeovn/kube-ovn/pull/3495/files?diff=unified&w=0#diff-88a8204664ceaf4c8e06c023c64d714def45dd2fbde50b994d66fae2f9ea01d4L600-R600))
