### PR TITLE
fix: duplicate gw nodes

### DIFF
--- a/pkg/controller/external_gw.go
+++ b/pkg/controller/external_gw.go
@@ -226,7 +226,12 @@ func (c *Controller) getGatewayChassis(config map[string]string) ([]string, erro
 		nodeNames := strings.Split(config["external-gw-nodes"], ",")
 		for _, name := range nodeNames {
 			name = strings.TrimSpace(name)
-			gwNodes = append(gwNodes, name)
+			if name == "" {
+				continue
+			}
+			if !util.ContainsString(gwNodes, name) {
+				gwNodes = append(gwNodes, name)
+			}
 		}
 	}
 	for _, gw := range gwNodes {

--- a/pkg/ovs/ovn-nb-gateway_chassis.go
+++ b/pkg/ovs/ovn-nb-gateway_chassis.go
@@ -17,11 +17,15 @@ import (
 func (c *OVNNbClient) CreateGatewayChassises(lrpName string, chassises ...string) error {
 	op, err := c.CreateGatewayChassisesOp(lrpName, chassises)
 	if err != nil {
-		return fmt.Errorf("generate operations for creating gateway chassis %v", err)
+		err := fmt.Errorf("generate operations for creating gateway chassis %v", err)
+		klog.Error(err)
+		return err
 	}
 
 	if err = c.Transact("gateway-chassises-add", op); err != nil {
-		return fmt.Errorf("create gateway chassis %v for logical router port %s: %v", chassises, lrpName, err)
+		err := fmt.Errorf("create gateway chassis %v for logical router port %s: %v", chassises, lrpName, err)
+		klog.Error(err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5608907</samp>

This pull request improves the logging and error handling of the `ovs` package and the gateway chassis management logic. It also adds a validation for node names in the `getGatewayChassis` function.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5608907</samp>

> _Sing, O Muse, of the valiant OVN client code_
> _That deftly handles the creation of gateway chassis_
> _And checks for empty and duplicate node names_
> _With `getGatewayChassis`, a function wise and flawless_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5608907</samp>

*  Add logging and error handling for gateway chassis and patch port operations
  - Import klog/v2 package for structured logging ([link](https://github.com/kubeovn/kube-ovn/pull/3500/files?diff=unified&w=0#diff-2cdd0dec2c1ac53cc940998efdf213a7204dd26d6e5e8afd478ae8bcdf630e0eR8))
  - Log errors in CreateGatewayChassises function ([link](https://github.com/kubeovn/kube-ovn/pull/3500/files?diff=unified&w=0#diff-9303d6d8c4b4c52f1cd1cf6a663085b3e9d3515ca917667437e20feaf778e5e7L20-R28))
  - Log and handle errors in CreateLogicalPatchPort function ([link](https://github.com/kubeovn/kube-ovn/pull/3500/files?diff=unified&w=0#diff-2cdd0dec2c1ac53cc940998efdf213a7204dd26d6e5e8afd478ae8bcdf630e0eR53-R54), [link](https://github.com/kubeovn/kube-ovn/pull/3500/files?diff=unified&w=0#diff-2cdd0dec2c1ac53cc940998efdf213a7204dd26d6e5e8afd478ae8bcdf630e0eL59-R79))
  - Prevent errors and inconsistencies in external_gw.go file ([link](https://github.com/kubeovn/kube-ovn/pull/3500/files?diff=unified&w=0#diff-945b73ad15889230d50be6f6fbd9e7352e96338574ce6f8a53b7a32b2e334739L229-R234))
