### PR TITLE
fix: skip unnecessary del port request

### DIFF
--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -401,6 +401,12 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		return
 	}
 
+	if pod.DeletionTimestamp == nil && podRequest.NetNs == "" {
+		klog.Infof("skip del port request: %v", podRequest)
+		resp.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	klog.Infof("del port request: %v", podRequest)
 	if err := csh.validatePodRequest(&podRequest); err != nil {
 		klog.Error(err)

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -401,7 +401,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		return
 	}
 
-	if pod.DeletionTimestamp == nil && podRequest.NetNs == "" {
+	if podRequest.NetNs == "" {
 		klog.Infof("skip del port request: %v", podRequest)
 		resp.WriteHeader(http.StatusNoContent)
 		return


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

skip unnecessary del port request

创建了一个pod，yaml如下，当节点重启后，kubelet会连续删除好几次pause container，都向下执行了，并且当节点重启pod重新创建好后，pod的sleep时间到了，kubelet还会删除pause container，之后向下执行直到报错。

本次修改略过了不必要删除操作。

```
apiVersion: v1
kind: Pod
metadata:
  namespace: ovn-poc
  name: wang
  annotations:
    v1.multus-cni.io/default-network: kube-system/test
    ovn.kubernetes.io/logical_switch: ovn-default
spec:
  nodeName: k8snode1
  containers:
  - name: iperf3
    image: docker.io/library/ubuntu1
    imagePullPolicy: IfNotPresent
    command:
    - sleep
    - "1d"
```

日志如下：
cni报的错误：
一次报错：
del nic failed failed to move container wang/ovn-poc interface eth0 back to host netns: failed to get container namespace for pod ovn-poc/wang5: failed to Statfs "": no such file or directory
第二次报错：
failed to get container interface eth0 for pod ovn-poc/wang5: Link not found
之后报错好几次：pod sleep时间到了，cni报错：
del nic failed failed to move container wang5/ovn-poc interface eth0 back to host netns: failed to get container namespace for pod ovn-poc/wang5: failed to Statfs "": no such file or directory

环境信息：
kubelet --version
Kubernetes v1.24.2

containerd --version
containerd containerd.io 1.6.24 61f9fd88f79f081d64d6fa3bb1a0dc71ec870523

kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.2", GitCommit:"f66044f4361b9f1f96f0053dd46cb7dce5e990a8", GitTreeState:"clean", BuildDate:"2022-06-15T14:20:54Z", GoVersion:"go1.18.3", Compiler:"gc", Platform:"linux/amd64"}

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd83fcc</samp>

Fix a bug that causes port deletion requests to be sent when pod is not using ovn network. Add a condition to `handler.go` to skip port deletion if pod is not being deleted and network namespace is empty.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd83fcc</samp>

> _`pod` not deleted_
> _skip `port` removal request_
> _autumn bug fix done_

## HOW

判断pod的DeletionTimestamp和podRequest.NetNs，当都是空的话，略过之后的执行。

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd83fcc</samp>

*  Add a condition to skip port deletion for pods not using ovn network ([link](https://github.com/kubeovn/kube-ovn/pull/3501/files?diff=unified&w=0#diff-fe92e3665a2b1adaceb337a3b1c930ddf7b127b858e46321bfd4961c4cda8c6fR404-R409))
