### PR TITLE
ci: fix ovn-vpc-nat-gw e2e failed

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -479,8 +479,15 @@ func checkAndUpdateExcludeIPs(subnet *kubeovnv1.Subnet) bool {
 
 func (c *Controller) handleSubnetFinalizer(subnet *kubeovnv1.Subnet) (bool, error) {
 	if subnet.DeletionTimestamp.IsZero() && !util.ContainsString(subnet.Finalizers, util.ControllerName) {
-		subnet.Finalizers = append(subnet.Finalizers, util.ControllerName)
-		if _, err := c.config.KubeOvnClient.KubeovnV1().Subnets().Update(context.Background(), subnet, metav1.UpdateOptions{}); err != nil {
+		newSubnet := subnet.DeepCopy()
+		newSubnet.Finalizers = append(newSubnet.Finalizers, util.ControllerName)
+		patch, err := util.GenerateMergePatchPayload(subnet, newSubnet)
+		if err != nil {
+			klog.Errorf("failed to generate patch payload for subnet '%s', %v", subnet.Name, err)
+			return false, err
+		}
+		if _, err := c.config.KubeOvnClient.KubeovnV1().Subnets().Patch(context.Background(), subnet.Name,
+			types.MergePatchType, patch, metav1.PatchOptions{}, ""); err != nil {
 			klog.Errorf("failed to add finalizer to subnet %s, %v", subnet.Name, err)
 			return false, err
 		}
@@ -496,8 +503,15 @@ func (c *Controller) handleSubnetFinalizer(subnet *kubeovnv1.Subnet) (bool, erro
 
 	u2oInterconnIP := subnet.Status.U2OInterconnectionIP
 	if !subnet.DeletionTimestamp.IsZero() && (usingIPs == 0 || (usingIPs == 1 && u2oInterconnIP != "")) {
-		subnet.Finalizers = util.RemoveString(subnet.Finalizers, util.ControllerName)
-		if _, err := c.config.KubeOvnClient.KubeovnV1().Subnets().Update(context.Background(), subnet, metav1.UpdateOptions{}); err != nil {
+		newSubnet := subnet.DeepCopy()
+		newSubnet.Finalizers = util.RemoveString(newSubnet.Finalizers, util.ControllerName)
+		patch, err := util.GenerateMergePatchPayload(subnet, newSubnet)
+		if err != nil {
+			klog.Errorf("failed to generate patch payload for subnet '%s', %v", subnet.Name, err)
+			return false, err
+		}
+		if _, err := c.config.KubeOvnClient.KubeovnV1().Subnets().Patch(context.Background(), subnet.Name,
+			types.MergePatchType, patch, metav1.PatchOptions{}, ""); err != nil {
 			klog.Errorf("failed to remove finalizer from subnet %s, %v", subnet.Name, err)
 			return false, err
 		}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

[ovn-vpc-nat-gw e2e failed](https://github.com/kubeovn/kube-ovn/actions/runs/7122458767/job/19394449817?pr=3500)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5d1aafd</samp>

Enhanced the e2e test for ovn-vpc-nat-gw to cover multiple subnets in the underlay network. Updated `test/e2e/ovn-vpc-nat-gw/e2e_test.go` to handle the additional resources.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5d1aafd</samp>

> _`vlan` and `subnet`_
> _added to test underlay_
> _autumn network leaves_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5d1aafd</samp>

* Add a variable `vlanExtraName` to store the name of an extra vlan for testing multiple subnets ([link](https://github.com/kubeovn/kube-ovn/pull/3503/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L84-R84))
* Initialize `vlanExtraName` with a random suffix to avoid name conflicts ([link](https://github.com/kubeovn/kube-ovn/pull/3503/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2R161))
* Create an extra vlan with `vlanExtraName` and `providerExtraNetworkName` ([link](https://github.com/kubeovn/kube-ovn/pull/3503/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2R698-R701))
* Create a subnet for the extra vlan with `underlayExtraSubnetName`, `vlanExtraName`, and the cidr and gateway from `extracidr` and `extragateway` ([link](https://github.com/kubeovn/kube-ovn/pull/3503/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L725-R736))
* Check that the subnet has the expected vlan name and cidr block ([link](https://github.com/kubeovn/kube-ovn/pull/3503/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2L725-R736))
* Delete the extra vlan after the test is done to clean up the resources ([link](https://github.com/kubeovn/kube-ovn/pull/3503/files?diff=unified&w=0#diff-c1831d6aa37f96132386404bff7ef6c738c40bcef66ba7492aca28929d61dca2R473-R474))
