### PR TITLE
fix: gc should keep lb for dnat after restart kube-ovn-controller

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -457,6 +457,12 @@ func (c *Controller) gcLoadBalancer() error {
 		return err
 	}
 
+	dnats, err := c.ovnDnatRulesLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list dnats, %v", err)
+		return err
+	}
+
 	var (
 		tcpVips         = strset.NewWithSize(len(svcs) * 2)
 		udpVips         = strset.NewWithSize(len(svcs) * 2)
@@ -510,6 +516,10 @@ func (c *Controller) gcLoadBalancer() error {
 		vpcLbs            []string
 		ignoreHealthCheck = true
 	)
+
+	for _, dnat := range dnats {
+		vpcLbs = append(vpcLbs, dnat.Name)
+	}
 
 	removeVip = func(lbName string, svcVips *strset.Set) error {
 		if lbName == "" {


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fix #3418 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 58a7970</samp>

Improve load balancer garbage collection in `ovn` controller. Remove unused dnat rules and load balancers by checking against service and endpoint resources.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 58a7970</samp>

> _Sing, O Muse, of the cunning code that enhanced the garbage collection_
> _Of the load balancers, those mighty workers of the ovn controller_
> _Who distribute the traffic of the network, like Zeus who rules the sky_
> _With his thunderbolts, or Poseidon who stirs the restless sea._

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 58a7970</samp>

*  Add code to list dnat rules and collect load balancer names ([link](https://github.com/kubeovn/kube-ovn/pull/3508/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R460-R465), [link](https://github.com/kubeovn/kube-ovn/pull/3508/files?diff=unified&w=0#diff-efdb6355f2187b31e5e61610c24bf4d446a23d814d51448c170a91ef96ae1e89R520-R523))
