### PR TITLE
SgPorts should be updated when pod deleted

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1107,6 +1107,17 @@ func (c *Controller) handleDeletePod(key string) error {
 	}
 	for _, podNet := range podNets {
 		c.syncVirtualPortsQueue.Add(podNet.Subnet.Name)
+		if pod.Annotations[fmt.Sprintf(util.PortSecurityAnnotationTemplate, podNet.ProviderName)] == "true" {
+			if securityGroupAnnotation, ok := pod.Annotations[fmt.Sprintf(util.SecurityGroupAnnotationTemplate, podNet.ProviderName)]; ok {
+				sgNames := strings.Split(securityGroupAnnotation, ",")
+				for _, sgName := range sgNames {
+					if sgName == "" {
+						continue
+					}
+					c.syncSgPortsQueue.Add(sgName)
+				}
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #3515 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at af0a342</samp>

Fix security group port synchronization when deleting pods with port security. Add code to `pkg/controller/pod.go` to enqueue security group names for processing when a pod with port security is deleted.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at af0a342</samp>

> _`handleDeletePod`_
> _Syncs security groups now_
> _A bug fix for fall_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at af0a342</samp>

*  Trigger security group port sync when deleting pod with port security ([link](https://github.com/kubeovn/kube-ovn/pull/3516/files?diff=unified&w=0#diff-449e8d1bd46b9c978e208dde912a1d7a76d17ce553067f8d0a67a27f17338d26R1110-R1119))
