### PR TITLE
fix

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -255,7 +255,7 @@ jobs:
 
       - name: Install ginkgo
         working-directory: ${{ env.E2E_DIR }}
-        run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+        run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
 
       - name: Download image
         uses: actions/download-artifact@v3

--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -34,7 +34,6 @@ iptables -t filter -D FORWARD -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services dst -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services src -j ACCEPT
 iptables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
-iptables -t mangle -D POSTROUTING -p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP
 
 if [ -n "$nodeIPv4" ]; then
     iptables -t nat -D POSTROUTING ! -s "$nodeIPv4" -m mark --mark 0x4000/0x4000 -j MASQUERADE
@@ -62,7 +61,6 @@ ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
-ip6tables -t mangle -D POSTROUTING -p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP
 
 if [ -n "$nodeIPv6" ]; then
     ip6tables -t nat -D POSTROUTING ! -s "$nodeIPv6" -m mark --mark 0x4000/0x4000 -j MASQUERADE

--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -62,7 +62,7 @@ ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
-ip6tables -t mangle -D POSTROUTING -p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP
+ip6tables -t mangle -D POSTROUTING -p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP
 
 if [ -n "$nodeIPv6" ]; then
     ip6tables -t nat -D POSTROUTING ! -s "$nodeIPv6" -m mark --mark 0x4000/0x4000 -j MASQUERADE

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -428,7 +428,7 @@ func (c *Controller) setIptables() error {
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
 			// Drop invalid rst
-			{Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
+			// {Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 	)
 	protocols := make([]string, 2)

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -403,8 +403,6 @@ func (c *Controller) setIptables() error {
 			{Table: "filter", Chain: "FORWARD", Rule: strings.Fields(`-m set --match-set ovn40services dst -j ACCEPT`)},
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
-			// Drop invalid rst
-			// {Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 		v6Rules = []util.IPTableRule{
 			// nat service traffic
@@ -427,8 +425,6 @@ func (c *Controller) setIptables() error {
 			{Table: "filter", Chain: "FORWARD", Rule: strings.Fields(`-m set --match-set ovn60services dst -j ACCEPT`)},
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
-			// Drop invalid rst
-			// {Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 	)
 	protocols := make([]string, 2)

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -404,7 +404,7 @@ func (c *Controller) setIptables() error {
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
 			// Drop invalid rst
-			{Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
+			// {Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 		v6Rules = []util.IPTableRule{
 			// nat service traffic


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e9b96b5</samp>

Comment out iptables rule that drops invalid TCP RST packets from `ovn60subnets` set in `gateway.go`. This is a workaround for an OVS conntrack bug that affects TCP window scaling.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e9b96b5</samp>

> _`iptables` rule out_
> _TCP RST bug in OVS_
> _Winter workaround_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e9b96b5</samp>

*  Comment out iptables rule that drops invalid TCP RST packets from ovn60subnets set ([link](https://github.com/kubeovn/kube-ovn/pull/3518/files?diff=unified&w=0#diff-cd48154fd02797a7c4ba7b5bc7be248e7b048e4f8621eecf39f28d21530f2d08L431-R431)). This is a temporary workaround for an OVS conntrack bug that causes some TCP connections to be reset by the gateway node. Add comment to explain the reason for the change.
