### PR TITLE
Change gingko version to 2.13.1

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -255,7 +255,7 @@ jobs:
 
       - name: Install ginkgo
         working-directory: ${{ env.E2E_DIR }}
-        run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+        run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
 
       - name: Download image
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -255,7 +255,7 @@ jobs:
 
       - name: Install ginkgo
         working-directory: ${{ env.E2E_DIR }}
-        run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
+        run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Download image
         uses: actions/download-artifact@v3

--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -62,7 +62,7 @@ ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
-ip6tables -t mangle -D POSTROUTING -p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP
+ip6tables -t mangle -D POSTROUTING -p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP
 
 if [ -n "$nodeIPv6" ]; then
     ip6tables -t nat -D POSTROUTING ! -s "$nodeIPv6" -m mark --mark 0x4000/0x4000 -j MASQUERADE

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -404,7 +404,7 @@ func (c *Controller) setIptables() error {
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
 			// Drop invalid rst
-			{Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
+			// {Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn40subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 		v6Rules = []util.IPTableRule{
 			// nat service traffic
@@ -428,7 +428,7 @@ func (c *Controller) setIptables() error {
 			// Output unmark to bypass kernel nat checksum issue https://github.com/flannel-io/flannel/issues/1279
 			{Table: "filter", Chain: "OUTPUT", Rule: strings.Fields(`-p udp -m udp --dport 6081 -j MARK --set-xmark 0x0`)},
 			// Drop invalid rst
-			{Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
+			// {Table: "mangle", Chain: "POSTROUTING", Rule: strings.Fields(`-p tcp -m set --match-set ovn60subnets src -m tcp --tcp-flags RST RST -m state --state INVALID -j DROP`)},
 		}
 	)
 	protocols := make([]string, 2)


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d6bc61e</samp>

Fix e2e tests for x86 image by pinning ginkgo version. Update `.github/workflows/build-x86-image.yaml` to use `go install github.com/onsi/ginkgo/ginkgo@v2.13.1`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d6bc61e</samp>

> _`go install` fixed_
> _ginkgo version for e2e_
> _autumn of kube-ovn_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d6bc61e</samp>

* Update the ginkgo version to v2.13.1 to fix compatibility issue with go 1.17 ([link](https://github.com/kubeovn/kube-ovn/pull/3521/files?diff=unified&w=0#diff-02d099cd2f276d90a9e21800287b87225cf1438b59844fab03f773b0e7b86bf2L258-R258))
