### PR TITLE
Makefile: fix clab bgp cleanup

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -23,7 +23,7 @@ concurrency:
 env:
   GO_VERSION: ''
   GOSEC_VERSION: '2.18.2'
-  HELM_VERSION: v3.13.2
+  HELM_VERSION: v3.13.3
   SUBMARINER_VERSION: '0.16.2'
 
 jobs:

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   GO_VERSION: ''
-  HELM_VERSION: v3.13.2
+  HELM_VERSION: v3.13.3
   SUBMARINER_VERSION: '0.16.2'
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ KUBEVIRT_OPERATOR_YAML = https://github.com/kubevirt/kubevirt/releases/download/
 KUBEVIRT_CR_YAML = https://github.com/kubevirt/kubevirt/releases/download/$(KUBEVIRT_VERSION)/kubevirt-cr.yaml
 KUBEVIRT_TEST_YAML = https://kubevirt.io/labs/manifests/vm.yaml
 
-CILIUM_VERSION = 1.14.4
+CILIUM_VERSION = 1.14.5
 CILIUM_IMAGE_REPO = quay.io/cilium/cilium
 
-CERT_MANAGER_VERSION = v1.13.2
+CERT_MANAGER_VERSION = v1.13.3
 CERT_MANAGER_CONTROLLER = quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_CAINJECTOR = quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
 CERT_MANAGER_WEBHOOK = quay.io/jetstack/cert-manager-webhook:$(CERT_MANAGER_VERSION)
@@ -422,12 +422,12 @@ kind-init-bgp: kind-clean-bgp kind-init
 	docker run --rm --privileged \
 		--name kube-ovn-bgp \
 		--network host \
+		--pid host \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /var/run/netns:/var/run/netns \
 		-v /var/lib/docker/containers:/var/lib/docker/containers \
-		--pid=host \
-		-v $(CURDIR)/yamls/clab-bgp.yaml:/clab.yaml \
-		$(CLAB_IMAGE) clab deploy -t /clab.yaml
+		-v $(CURDIR)/yamls/clab-bgp.yaml:/clab-bgp/clab.yaml \
+		$(CLAB_IMAGE) clab deploy -t /clab-bgp/clab.yaml
 
 .PHONY: kind-init-bgp-ha
 kind-init-bgp-ha: kind-clean-bgp kind-init
@@ -435,12 +435,12 @@ kind-init-bgp-ha: kind-clean-bgp kind-init
 	docker run --rm --privileged \
 		--name kube-ovn-bgp \
 		--network host \
+		--pid host \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /var/run/netns:/var/run/netns \
 		-v /var/lib/docker/containers:/var/lib/docker/containers \
-		--pid=host \
-		-v $(CURDIR)/yamls/clab-bgp-ha.yaml:/clab.yaml \
-		$(CLAB_IMAGE) clab deploy -t /clab.yaml
+		-v $(CURDIR)/yamls/clab-bgp-ha.yaml:/clab-bgp/clab.yaml \
+		$(CLAB_IMAGE) clab deploy -t /clab-bgp/clab.yaml
 
 .PHONY: kind-load-image
 kind-load-image:
@@ -894,12 +894,12 @@ kind-clean-bgp: kind-clean-bgp-ha
 	docker run --rm --privileged \
 		--name kube-ovn-bgp \
 		--network host \
+		--pid host \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /var/run/netns:/var/run/netns \
 		-v /var/lib/docker/containers:/var/lib/docker/containers \
-		--pid=host \
-		-v $(CURDIR)/yamls/clab-bgp.yaml:/clab.yaml \
-		$(CLAB_IMAGE) clab destroy -t /clab.yaml
+		-v $(CURDIR)/yamls/clab-bgp.yaml:/clab-bgp/clab.yaml \
+		$(CLAB_IMAGE) clab destroy -t /clab-bgp/clab.yaml
 	@$(MAKE) kind-clean
 
 .PHONY: kind-clean-bgp-ha
@@ -908,12 +908,12 @@ kind-clean-bgp-ha:
 	docker run --rm --privileged \
 		--name kube-ovn-bgp \
 		--network host \
+		--pid host \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /var/run/netns:/var/run/netns \
 		-v /var/lib/docker/containers:/var/lib/docker/containers \
-		--pid=host \
-		-v $(CURDIR)/yamls/clab-bgp-ha.yaml:/clab.yaml \
-		$(CLAB_IMAGE) clab destroy -t /clab.yaml
+		-v $(CURDIR)/yamls/clab-bgp-ha.yaml:/clab-bgp/clab.yaml \
+		$(CLAB_IMAGE) clab destroy -t /clab-bgp/clab.yaml
 	@$(MAKE) kind-clean
 
 .PHONY: uninstall


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce35fa3</samp>

Improved the Makefile to support BGP testing with container lab. Fixed volume mount paths and added make targets for clab-bgp and clab-bgp-ha scenarios.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce35fa3</samp>

> _Sing, O Muse, of the skillful coder who changed the paths_
> _Of the volume mounts for `clab-bgp` and `clab-bgp-ha`, files of power_
> _To avoid the strife of conflicts and match the commands of clab_
> _The tool of many wonders, that creates and destroys container labs_

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce35fa3</samp>

*  Change volume mount paths and commands for clab-bgp.yaml and clab-bgp-ha.yaml files to avoid conflicts with other clab files ([link](https://github.com/kubeovn/kube-ovn/pull/3524/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L425-R430), [link](https://github.com/kubeovn/kube-ovn/pull/3524/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L438-R443), [link](https://github.com/kubeovn/kube-ovn/pull/3524/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L897-R902), [link](https://github.com/kubeovn/kube-ovn/pull/3524/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L911-R916))
* Add support for BGP peering with external routers in a container lab environment using `clab-bgp.yaml` and `clab-bgp-ha.yaml` files ([link](https://github.com/kubeovn/kube-ovn/pull/3524/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L425-R430), [link](https://github.com/kubeovn/kube-ovn/pull/3524/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L438-R443))
* Add a make target to clean up the container lab environment for BGP peering with external routers using `clab destroy` command ([link](https://github.com/kubeovn/kube-ovn/pull/3524/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L897-R902), [link](https://github.com/kubeovn/kube-ovn/pull/3524/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L911-R916))
