### PR TITLE
delete lsp and ipam with ip

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -377,6 +377,14 @@ func (c *Controller) markAndCleanLSP() error {
 			klog.Errorf("failed to delete ip %s, %v", ipCr.Name, err)
 			return err
 		}
+		if ipCr.Spec.Subnet == "" {
+			klog.Errorf("ip %s has no subnet", ipCr.Name)
+			// ip cr no subnet, skip lsp gc
+			continue
+		}
+		if key := lsp.ExternalIDs["pod"]; key != "" {
+			c.ipam.ReleaseAddressByPod(key, ipCr.Spec.Subnet)
+		}
 	}
 	lastNoPodLSP = noPodLSP
 

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -377,14 +377,6 @@ func (c *Controller) markAndCleanLSP() error {
 			klog.Errorf("failed to delete ip %s, %v", ipCr.Name, err)
 			return err
 		}
-		if ipCr.Spec.Subnet == "" {
-			klog.Errorf("ip %s has no subnet", ipCr.Name)
-			// ip cr no subnet, skip lsp gc
-			continue
-		}
-		if key := lsp.ExternalIDs["pod"]; key != "" {
-			c.ipam.ReleaseAddressByPod(key, ipCr.Spec.Subnet)
-		}
 	}
 	lastNoPodLSP = noPodLSP
 

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -211,6 +211,7 @@ func (c *Controller) handleUpdateIP(key string) error {
 			klog.Errorf("failed to get subnet %s: %v", cachedIP.Spec.Subnet, err)
 			return err
 		}
+		cleanIPAM := true
 		if isOvnSubnet(subnet) {
 			portName := cachedIP.Name
 			port, err := c.OVNNbClient.GetLogicalSwitchPort(portName, true)
@@ -219,31 +220,34 @@ func (c *Controller) handleUpdateIP(key string) error {
 				return err
 			}
 			if port != nil {
-				if !(slices.Contains(port.Addresses, cachedIP.Spec.V4IPAddress) || slices.Contains(port.Addresses, cachedIP.Spec.V6IPAddress)) {
-					// port ip address changed, only delete ip cr, do not delete lsp
-					klog.Infof("port %s changed, only delete old ip cr %s", portName, key)
-					return nil
-				}
-				klog.Infof("delete ip cr lsp %s from switch %s", portName, subnet.Name)
-				if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
-					klog.Errorf("delete ip cr lsp %s from switch %s: %v", portName, subnet.Name, err)
-					return err
-				}
-				klog.V(3).Infof("sync sg for deleted port %s", portName)
-				sgList, err := c.getPortSg(port)
-				if err != nil {
-					klog.Errorf("get port sg failed, %v", err)
-					return err
-				}
-				for _, sgName := range sgList {
-					if sgName != "" {
-						c.syncSgPortsQueue.Add(sgName)
+				if slices.Contains(port.Addresses, cachedIP.Spec.V4IPAddress) || slices.Contains(port.Addresses, cachedIP.Spec.V6IPAddress) {
+					klog.Infof("delete ip cr lsp %s from switch %s", portName, subnet.Name)
+					if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
+						klog.Errorf("delete ip cr lsp %s from switch %s: %v", portName, subnet.Name, err)
+						return err
 					}
+					klog.V(3).Infof("sync sg for deleted port %s", portName)
+					sgList, err := c.getPortSg(port)
+					if err != nil {
+						klog.Errorf("get port sg failed, %v", err)
+						return err
+					}
+					for _, sgName := range sgList {
+						if sgName != "" {
+							c.syncSgPortsQueue.Add(sgName)
+						}
+					}
+				} else {
+					// ip subnet changed in pod handle add or update pod process
+					klog.Infof("lsp %s ip changed, only delete old ip cr %s", portName, key)
+					cleanIPAM = false
 				}
 			}
 		}
-		klog.V(3).Infof("release ipam for deleted ip %s from subnet %s", cachedIP.Name, cachedIP.Spec.Subnet)
-		c.ipam.ReleaseAddressByPod(cachedIP.Name, cachedIP.Spec.Subnet)
+		if cleanIPAM {
+			klog.V(3).Infof("release ipam for deleted ip %s from subnet %s", cachedIP.Name, cachedIP.Spec.Subnet)
+			c.ipam.ReleaseAddressByPod(cachedIP.Name, cachedIP.Spec.Subnet)
+		}
 		if err = c.handleDelIPFinalizer(cachedIP, util.ControllerName); err != nil {
 			klog.Errorf("failed to handle del ip finalizer %v", err)
 			return err

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -1,47 +1,234 @@
 package controller
 
 import (
+	"context"
+	"fmt"
+	"reflect"
 	"strings"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-func (c *Controller) enqueueAddOrDelIP(obj interface{}) {
+func (c *Controller) enqueueAddIP(obj interface{}) {
 	ipObj := obj.(*kubeovnv1.IP)
-	klog.V(3).Infof("enqueue update status subnet %s", ipObj.Spec.Subnet)
 	if strings.HasPrefix(ipObj.Name, util.U2OInterconnName[0:19]) {
 		return
 	}
-	if !ipObj.DeletionTimestamp.IsZero() {
-		klog.V(3).Infof("delete ip %s", ipObj.Name)
-		subnet, err := c.subnetsLister.Get(ipObj.Spec.Subnet)
-		if err != nil {
-			klog.Errorf("failed to get subnet %s: %v", ipObj.Spec.Subnet, err)
-			return
+	klog.V(3).Infof("enqueue update status subnet %s", ipObj.Spec.Subnet)
+	c.updateSubnetStatusQueue.Add(ipObj.Spec.Subnet)
+	for _, as := range ipObj.Spec.AttachSubnets {
+		klog.V(3).Infof("enqueue update attach status for subnet %s", as)
+		c.updateSubnetStatusQueue.Add(as)
+	}
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	klog.V(3).Infof("enqueue add ip %s", key)
+	c.addIPQueue.Add(key)
+}
+
+func (c *Controller) enqueueUpdateIP(oldObj, newObj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(newObj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	oldIP := oldObj.(*kubeovnv1.IP)
+	newIP := newObj.(*kubeovnv1.IP)
+	if !newIP.DeletionTimestamp.IsZero() {
+		klog.V(3).Infof("enqueue update ip %s", key)
+		c.updateIPQueue.Add(key)
+		return
+	}
+	if !reflect.DeepEqual(oldIP.Spec.AttachSubnets, newIP.Spec.AttachSubnets) {
+		klog.V(3).Infof("enqueue update status subnet %s", newIP.Spec.Subnet)
+		for _, as := range newIP.Spec.AttachSubnets {
+			klog.V(3).Infof("enqueue update status for attach subnet %s", as)
+			c.updateSubnetStatusQueue.Add(as)
 		}
-		portName := ovs.PodNameToPortName(ipObj.Name, ipObj.Spec.Namespace, subnet.Spec.Provider)
+	}
+}
+
+func (c *Controller) enqueueDelIP(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	ipObj := obj.(*kubeovnv1.IP)
+	if strings.HasPrefix(ipObj.Name, util.U2OInterconnName[0:19]) {
+		return
+	}
+	klog.V(3).Infof("enqueue del ip %s", key)
+	c.delIPQueue.Add(ipObj)
+}
+
+func (c *Controller) runAddIPWorker() {
+	for c.processNextAddIPWorkItem() {
+	}
+}
+
+func (c *Controller) runUpdateIPWorker() {
+	for c.processNextUpdateIPWorkItem() {
+	}
+}
+
+func (c *Controller) runDelIPWorker() {
+	for c.processNextDeleteIPWorkItem() {
+	}
+}
+
+func (c *Controller) processNextAddIPWorkItem() bool {
+	obj, shutdown := c.addIPQueue.Get()
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer c.addIPQueue.Done(obj)
+		var key string
+		var ok bool
+		if key, ok = obj.(string); !ok {
+			c.addIPQueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		if err := c.handleAddIP(key); err != nil {
+			c.addIPQueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		}
+		c.addIPQueue.Forget(obj)
+		return nil
+	}(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+	return true
+}
+
+func (c *Controller) processNextUpdateIPWorkItem() bool {
+	obj, shutdown := c.updateIPQueue.Get()
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer c.updateIPQueue.Done(obj)
+		var key string
+		var ok bool
+		if key, ok = obj.(string); !ok {
+			c.updateIPQueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		if err := c.handleUpdateIP(key); err != nil {
+			c.updateIPQueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		}
+		c.updateIPQueue.Forget(obj)
+		return nil
+	}(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+	return true
+}
+
+func (c *Controller) processNextDeleteIPWorkItem() bool {
+	obj, shutdown := c.delIPQueue.Get()
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer c.delIPQueue.Done(obj)
+		var ip *kubeovnv1.IP
+		var ok bool
+		if ip, ok = obj.(*kubeovnv1.IP); !ok {
+			c.delIPQueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected ip in workqueue but got %#v", obj))
+			return nil
+		}
+		if err := c.handleDelIP(ip); err != nil {
+			c.delIPQueue.AddRateLimited(obj)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", ip.Name, err.Error())
+		}
+		c.delIPQueue.Forget(obj)
+		return nil
+	}(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+	return true
+}
+
+func (c *Controller) handleAddIP(key string) error {
+	cachedIP, err := c.ipsLister.Get(key)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	klog.V(3).Infof("handle add ip %s", cachedIP.Name)
+	if err := c.handleAddIPFinalizer(cachedIP, util.ControllerName); err != nil {
+		klog.Errorf("failed to handle add ip finalizer %v", err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) handleUpdateIP(key string) error {
+	cachedIP, err := c.ipsLister.Get(key)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Error(err)
+		return err
+	}
+	if !cachedIP.DeletionTimestamp.IsZero() {
+		subnet, err := c.subnetsLister.Get(cachedIP.Spec.Subnet)
+		if err != nil {
+			klog.Errorf("failed to get subnet %s: %v", cachedIP.Spec.Subnet, err)
+			return err
+		}
 		if isOvnSubnet(subnet) {
+			portName := cachedIP.Name
 			port, err := c.OVNNbClient.GetLogicalSwitchPort(portName, true)
 			if err != nil {
 				klog.Errorf("failed to get logical switch port %s: %v", portName, err)
-				return
+				return err
 			}
 			if port != nil {
 				sgList, err := c.getPortSg(port)
 				if err != nil {
 					klog.Errorf("get port sg failed, %v", err)
-					return
+					return err
 				}
-				klog.V(3).Infof("delete ip logical switch port %s from logical switch %s", portName, subnet.Name)
+				klog.Infof("delete ip cr lsp %s from switch %s", portName, subnet.Name)
 				if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
-					klog.Errorf("delete ip logical switch port %s from logical switch %s: %v", portName, subnet.Name, err)
-					return
+					klog.Errorf("delete ip cr lsp %s from switch %s: %v", portName, subnet.Name, err)
+					return err
 				}
-				// refresh sg after delete port
+				klog.V(3).Infof("sync sg for deleted port %s", portName)
 				for _, sgName := range sgList {
 					if sgName != "" {
 						c.syncSgPortsQueue.Add(sgName)
@@ -49,21 +236,69 @@ func (c *Controller) enqueueAddOrDelIP(obj interface{}) {
 				}
 			}
 		}
-		klog.V(3).Infof("release ipam for ip %s from subnet %s", ipObj.Name, ipObj.Spec.Subnet)
-		c.ipam.ReleaseAddressByPod(ipObj.Name, ipObj.Spec.Subnet)
+		klog.V(3).Infof("release ipam for deleted ip %s from subnet %s", cachedIP.Name, cachedIP.Spec.Subnet)
+		c.ipam.ReleaseAddressByPod(cachedIP.Name, cachedIP.Spec.Subnet)
+		if err = c.handleDelIPFinalizer(cachedIP, util.ControllerName); err != nil {
+			klog.Errorf("failed to handle del ip finalizer %v", err)
+			return err
+		}
 	}
-	c.updateSubnetStatusQueue.Add(ipObj.Spec.Subnet)
-	for _, as := range ipObj.Spec.AttachSubnets {
+	return nil
+}
+
+func (c *Controller) handleDelIP(ip *kubeovnv1.IP) error {
+	klog.V(3).Infof("handle delete ip %s", ip.Name)
+	klog.V(3).Infof("enqueue update status subnet %s", ip.Spec.Subnet)
+	c.updateSubnetStatusQueue.Add(ip.Spec.Subnet)
+	for _, as := range ip.Spec.AttachSubnets {
 		klog.V(3).Infof("enqueue update attach status for subnet %s", as)
 		c.updateSubnetStatusQueue.Add(as)
 	}
+	return nil
 }
 
-func (c *Controller) enqueueUpdateIP(_, newObj interface{}) {
-	ipObj := newObj.(*kubeovnv1.IP)
-	klog.V(3).Infof("enqueue update status subnet %s", ipObj.Spec.Subnet)
-	for _, as := range ipObj.Spec.AttachSubnets {
-		klog.V(3).Infof("enqueue update status for attach subnet %s", as)
-		c.updateSubnetStatusQueue.Add(as)
+func (c *Controller) handleAddIPFinalizer(cachedIP *kubeovnv1.IP, finalizer string) error {
+	if cachedIP.DeletionTimestamp.IsZero() {
+		if util.ContainsString(cachedIP.Finalizers, finalizer) {
+			return nil
+		}
 	}
+	newIP := cachedIP.DeepCopy()
+	controllerutil.AddFinalizer(newIP, finalizer)
+	patch, err := util.GenerateMergePatchPayload(cachedIP, newIP)
+	if err != nil {
+		klog.Errorf("failed to generate patch payload for ip %s, %v", cachedIP.Name, err)
+		return err
+	}
+	if _, err := c.config.KubeOvnClient.KubeovnV1().IPs().Patch(context.Background(), cachedIP.Name,
+		types.MergePatchType, patch, metav1.PatchOptions{}, ""); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Errorf("failed to add finalizer for ip %s, %v", cachedIP.Name, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) handleDelIPFinalizer(cachedIP *kubeovnv1.IP, finalizer string) error {
+	if len(cachedIP.Finalizers) == 0 {
+		return nil
+	}
+	newIP := cachedIP.DeepCopy()
+	controllerutil.RemoveFinalizer(newIP, finalizer)
+	patch, err := util.GenerateMergePatchPayload(cachedIP, newIP)
+	if err != nil {
+		klog.Errorf("failed to generate patch payload for ip %s, %v", cachedIP.Name, err)
+		return err
+	}
+	if _, err := c.config.KubeOvnClient.KubeovnV1().IPs().Patch(context.Background(), cachedIP.Name,
+		types.MergePatchType, patch, metav1.PatchOptions{}, ""); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Errorf("failed to remove finalizer from ip %s, %v", cachedIP.Name, err)
+		return err
+	}
+	return nil
 }

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"slices"
 	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -219,8 +218,9 @@ func (c *Controller) handleUpdateIP(key string) error {
 				klog.Errorf("failed to get logical switch port %s: %v", portName, err)
 				return err
 			}
-			if port != nil {
-				if slices.Contains(port.Addresses, cachedIP.Spec.V4IPAddress) || slices.Contains(port.Addresses, cachedIP.Spec.V6IPAddress) {
+			if port != nil && len(port.Addresses) > 0 {
+				address := port.Addresses[0]
+				if strings.Contains(address, cachedIP.Spec.MacAddress) {
 					klog.Infof("delete ip cr lsp %s from switch %s", portName, subnet.Name)
 					if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
 						klog.Errorf("delete ip cr lsp %s from switch %s: %v", portName, subnet.Name, err)

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -218,10 +219,10 @@ func (c *Controller) handleUpdateIP(key string) error {
 				return err
 			}
 			if port != nil {
-				sgList, err := c.getPortSg(port)
-				if err != nil {
-					klog.Errorf("get port sg failed, %v", err)
-					return err
+				if !(slices.Contains(port.Addresses, cachedIP.Spec.V4IPAddress) || slices.Contains(port.Addresses, cachedIP.Spec.V6IPAddress)) {
+					// port ip address changed, only delete ip cr, do not delete lsp
+					klog.Infof("port %s changed, only delete old ip cr %s", portName, key)
+					return nil
 				}
 				klog.Infof("delete ip cr lsp %s from switch %s", portName, subnet.Name)
 				if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
@@ -229,6 +230,11 @@ func (c *Controller) handleUpdateIP(key string) error {
 					return err
 				}
 				klog.V(3).Infof("sync sg for deleted port %s", portName)
+				sgList, err := c.getPortSg(port)
+				if err != nil {
+					klog.Errorf("get port sg failed, %v", err)
+					return err
+				}
 				for _, sgName := range sgList {
 					if sgName != "" {
 						c.syncSgPortsQueue.Add(sgName)

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -14,6 +15,24 @@ func (c *Controller) enqueueAddOrDelIP(obj interface{}) {
 	klog.V(3).Infof("enqueue update status subnet %s", ipObj.Spec.Subnet)
 	if strings.HasPrefix(ipObj.Name, util.U2OInterconnName[0:19]) {
 		return
+	}
+	if !ipObj.DeletionTimestamp.IsZero() {
+		klog.V(3).Infof("delete ip %s", ipObj.Name)
+		subnet, err := c.subnetsLister.Get(ipObj.Spec.Subnet)
+		if err != nil {
+			klog.Errorf("failed to get subnet %s: %v", ipObj.Spec.Subnet, err)
+			return
+		}
+		portName := ovs.PodNameToPortName(ipObj.Name, ipObj.Spec.Namespace, subnet.Spec.Provider)
+		if isOvnSubnet(subnet) {
+			klog.V(3).Infof("delete ip logical switch port %s from logical switch %s", portName, subnet.Name)
+			if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
+				klog.Errorf("delete ip logical switch port %s from logical switch %s: %v", portName, subnet.Name, err)
+				return
+			}
+		}
+		klog.V(3).Infof("release ipam for ip %s from subnet %s", ipObj.Name, ipObj.Spec.Subnet)
+		c.ipam.ReleaseAddressByPod(ipObj.Name, ipObj.Spec.Subnet)
 	}
 	c.updateSubnetStatusQueue.Add(ipObj.Spec.Subnet)
 	for _, as := range ipObj.Spec.AttachSubnets {

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -223,7 +223,7 @@ func (c *Controller) handleUpdateIP(key string) error {
 				if strings.Contains(address, cachedIP.Spec.MacAddress) {
 					klog.Infof("delete ip cr lsp %s from switch %s", portName, subnet.Name)
 					if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
-						klog.Errorf("delete ip cr lsp %s from switch %s: %v", portName, subnet.Name, err)
+						klog.Errorf("failed to delete ip cr lsp %s from switch %s: %v", portName, subnet.Name, err)
 						return err
 					}
 					klog.V(3).Infof("sync sg for deleted port %s", portName)

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -728,18 +728,6 @@ func (c *Controller) createOrUpdateCrdIPs(podName, ip, mac, subnetName, ns, node
 	return nil
 }
 
-func (c *Controller) deleteCrdIPs(podName, ns, providerName string) error {
-	portName := ovs.PodNameToPortName(podName, ns, providerName)
-	klog.Infof("delete cr ip '%s' for pod %s/%s", portName, ns, podName)
-	if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), portName, metav1.DeleteOptions{}); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			klog.Errorf("failed to delete ip %s, %v", portName, err)
-			return err
-		}
-	}
-	return nil
-}
-
 func (c *Controller) CheckGatewayReady() {
 	if err := c.checkGatewayReady(); err != nil {
 		klog.Errorf("failed to check gateway ready %v", err)

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -547,14 +547,20 @@ func (c *Controller) changeVMSubnet(vmName, namespace, providerName, subnetName 
 		ipCr = nil
 	}
 	if ipCr != nil && ipCr.Spec.Subnet != subnetName {
+		key := fmt.Sprintf("%s/%s", namespace, vmName)
+		klog.Infof("gc logical switch port %s", key)
+		if err := c.OVNNbClient.DeleteLogicalSwitchPort(key); err != nil {
+			klog.Errorf("failed to delete lsp %s, %v", key, err)
+			return err
+		}
+		// old lsp has been deleted, delete old ip cr
 		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipName, metav1.DeleteOptions{}); err != nil {
 			if !k8serrors.IsNotFound(err) {
 				klog.Errorf("failed to delete ip %s, %v", ipName, err)
 				return err
 			}
 		}
-		// wait for old ip CR deleted
-		time.Sleep(1 * time.Second)
+		// handleAddOrUpdatePod will create new lsp and new ip cr
 	}
 	return nil
 }

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -553,6 +553,8 @@ func (c *Controller) changeVMSubnet(vmName, namespace, providerName, subnetName 
 				return err
 			}
 		}
+		// wait for old ip CR deleted
+		time.Sleep(1 * time.Second)
 	}
 	return nil
 }
@@ -1099,6 +1101,18 @@ func (c *Controller) handleDeletePod(key string) error {
 					c.syncSgPortsQueue.Add(sgName)
 				}
 			}
+		}
+	}
+	return nil
+}
+
+func (c *Controller) deleteCrdIPs(podName, ns, providerName string) error {
+	portName := ovs.PodNameToPortName(podName, ns, providerName)
+	klog.Infof("delete cr ip '%s' for pod %s/%s", portName, ns, podName)
+	if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), portName, metav1.DeleteOptions{}); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			klog.Errorf("failed to delete ip %s, %v", portName, err)
+			return err
 		}
 	}
 	return nil

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -534,7 +534,7 @@ func (c *Controller) getPodKubeovnNets(pod *v1.Pod) ([]*kubeovnNet, error) {
 	return podNets, nil
 }
 
-func (c *Controller) changeVMSubnet(vmName, namespace, providerName, subnetName string, pod *v1.Pod) error {
+func (c *Controller) changeVMSubnet(vmName, namespace, providerName, subnetName string) error {
 	ipName := ovs.PodNameToPortName(vmName, namespace, providerName)
 	ipCr, err := c.ipsLister.Get(ipName)
 	if err != nil {
@@ -546,30 +546,12 @@ func (c *Controller) changeVMSubnet(vmName, namespace, providerName, subnetName 
 		// the returned pointer is not nil if the CR does not exist
 		ipCr = nil
 	}
-	if ipCr != nil {
-		if ipCr.Spec.Subnet != subnetName {
-			key := fmt.Sprintf("%s/%s", pod.Namespace, vmName)
-			if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipName, metav1.DeleteOptions{}); err != nil {
-				if !k8serrors.IsNotFound(err) {
-					klog.Errorf("failed to delete ip %s, %v", ipName, err)
-					return err
-				}
-			}
-			ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": key})
-			if err != nil {
-				klog.Errorf("failed to list lsps of pod '%s', %v", pod.Name, err)
+	if ipCr != nil && ipCr.Spec.Subnet != subnetName {
+		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipName, metav1.DeleteOptions{}); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				klog.Errorf("failed to delete ip %s, %v", ipName, err)
 				return err
 			}
-			for _, port := range ports {
-				// when lsp is deleted, the port of pod is deleted from any port-group automatically.
-				klog.Infof("gc logical switch port %s", port.Name)
-				if err := c.OVNNbClient.DeleteLogicalSwitchPort(port.Name); err != nil {
-					klog.Errorf("failed to delete lsp %s, %v", port.Name, err)
-					return err
-				}
-			}
-			klog.Infof("after changing subnet, release ip %s", ipName)
-			c.ipam.ReleaseAddressByPod(key, ipCr.Spec.Subnet)
 		}
 	}
 	return nil
@@ -677,7 +659,7 @@ func (c *Controller) reconcileAllocateSubnets(cachedPod, pod *v1.Pod, needAlloca
 		pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] = "true"
 		if isVMPod && c.config.EnableKeepVMIP {
 			pod.Annotations[fmt.Sprintf(util.VMTemplate, podNet.ProviderName)] = vmName
-			if err := c.changeVMSubnet(vmName, namespace, podNet.ProviderName, subnet.Name, pod); err != nil {
+			if err := c.changeVMSubnet(vmName, namespace, podNet.ProviderName, subnet.Name); err != nil {
 				klog.Errorf("change subnet of pod %s/%s to %s failed: %v", namespace, name, subnet.Name, err)
 				return nil, err
 			}

--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -419,14 +419,14 @@ func (c *Controller) syncSgLogicalPort(key string) error {
 		return err
 	}
 
-	results, err := c.OVNNbClient.ListLogicalSwitchPorts(false, map[string]string{fmt.Sprintf("associated_sg_%s", key): "true"}, nil)
+	sgPorts, err := c.OVNNbClient.ListLogicalSwitchPorts(false, map[string]string{fmt.Sprintf("associated_sg_%s", key): "true"}, nil)
 	if err != nil {
 		klog.Errorf("failed to find logical port, %v", err)
 		return err
 	}
 
 	var ports, v4s, v6s []string
-	for _, lsp := range results {
+	for _, lsp := range sgPorts {
 		if len(lsp.PortSecurity) == 0 {
 			continue
 		}

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -666,6 +666,7 @@ func (c *OVNNbClient) CreateLogicalSwitchPortOp(lsp *ovnnb.LogicalSwitchPort, ls
 	lsp.ExternalIDs["vendor"] = util.CniTypeName
 
 	/* create logical switch port */
+	klog.V(3).Infof("create logical switch port %s in logical switch %s", lsp.Name, lsName)
 	lspCreateOp, err := c.Create(lsp)
 	if err != nil {
 		klog.Error(err)
@@ -701,6 +702,7 @@ func (c *OVNNbClient) DeleteLogicalSwitchPortOp(lspName string) ([]ovsdb.Operati
 
 	// remove logical switch port from logical switch
 	lsName := lsp.ExternalIDs[logicalSwitchKey]
+	klog.Infof("delete logical switch port %s with id %s from logical switch %s", lspName, lsp.UUID, lsName)
 	ops, err := c.LogicalSwitchUpdatePortOp(lsName, lsp.UUID, ovsdb.MutateOperationDelete)
 	if err != nil {
 		return nil, fmt.Errorf("generate operations for removing port %s from logical switch %s: %v", lspName, lsName, err)


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features： 在清理 IP 的过程中， lsp 和 ipam 直接随 ip 删除而释放。

1. 用户确定不再使用当前的子网，
1.1 基于 multus 多网卡 NAD 维护，用户换了一个子网，由于 multus network-attachment-definition 的设计在使用多网卡时十分灵活。如果 IP 删除而 lsp 保留则会导致无法新建同名的 lsp。这种 ip 会直接走 changeVMSubnet 逻辑直接删除重建。
1.2 基于 multus 多网卡 NAD 维护，用户移除了一个子网，这种 ip 要在pod annos变更之后， 手动删除该 IP


用户关机 --> 删除 ipcr --> 开机： 这个场景会创建新的 IP


2. 将部署 pod 关联的 sg 以及 ipam 的资源清理移到 IP 的 清理逻辑中，应该可以加快 pod 资源的释放。

参考：
在 openstack neutron 的设计中：
neutron 设计了一个 port 的数据库表，用于直接维护 ip 以及 安全组，地址对 ip 等信息。
目前 kube-ovn 的 IP 的业务逻辑十分简单。 可以考虑将一些 IP 相关的资源的逻辑 IP中去。


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
