### PR TITLE
fix ovn ic not clean lsp and lrp when az name contains "-"

### DIFF
--- a/pkg/controller/ovn_ic.go
+++ b/pkg/controller/ovn_ic.go
@@ -167,6 +167,7 @@ func (c *Controller) removeInterConnection(azName string) error {
 
 	if azName != "" {
 		if err := c.OVNNbClient.DeleteLogicalSwitchPorts(nil, func(lsp *ovnnb.LogicalSwitchPort) bool {
+			// add the code below because azName may have multi "-"
 			firstIndex := strings.Index(lsp.Name, "-")
 			if firstIndex != -1 {
 				firstPart := lsp.Name[:firstIndex]

--- a/pkg/controller/ovn_ic.go
+++ b/pkg/controller/ovn_ic.go
@@ -186,7 +186,6 @@ func (c *Controller) removeInterConnection(azName string) error {
 				return firstPart == azName && strings.HasPrefix(secondPart, util.InterconnectionSwitch)
 			}
 			return false
-
 		}); err != nil {
 			return err
 		}

--- a/pkg/controller/ovn_ic.go
+++ b/pkg/controller/ovn_ic.go
@@ -167,15 +167,26 @@ func (c *Controller) removeInterConnection(azName string) error {
 
 	if azName != "" {
 		if err := c.OVNNbClient.DeleteLogicalSwitchPorts(nil, func(lsp *ovnnb.LogicalSwitchPort) bool {
-			names := strings.Split(lsp.Name, "-")
-			return len(names) == 2 && names[1] == azName && strings.HasPrefix(names[0], "ts")
+			firstIndex := strings.Index(lsp.Name, "-")
+			if firstIndex != -1 {
+				firstPart := lsp.Name[:firstIndex]
+				secondPart := lsp.Name[firstIndex+1:]
+				return secondPart == azName && strings.HasPrefix(firstPart, util.InterconnectionSwitch)
+			}
+			return false
 		}); err != nil {
 			return err
 		}
 
 		if err := c.OVNNbClient.DeleteLogicalRouterPorts(nil, func(lrp *ovnnb.LogicalRouterPort) bool {
-			names := strings.Split(lrp.Name, "-")
-			return len(names) == 2 && names[0] == azName && strings.HasPrefix(names[1], "ts")
+			lastIndex := strings.LastIndex(lrp.Name, "-")
+			if lastIndex != -1 {
+				firstPart := lrp.Name[:lastIndex]
+				secondPart := lrp.Name[lastIndex+1:]
+				return firstPart == azName && strings.HasPrefix(secondPart, util.InterconnectionSwitch)
+			}
+			return false
+
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
