### PR TITLE
do not calculate subnet.spec.excludeIPs as availableIPs

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -365,8 +365,8 @@ func (c *Controller) InitIPAM() error {
 				if err != nil {
 					klog.Errorf("failed to init pod %s.%s address %s: %v", podName, pod.Namespace, pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)], err)
 				} else {
-					err = c.createOrUpdateCrdIPs(podName, ip, mac, podNet.Subnet.Name, pod.Namespace, pod.Spec.NodeName, podNet.ProviderName, podType)
-					if err != nil {
+					isExcludeIP := isPodIPInSubnetExlcudeIPs(ip, podNet.Subnet)
+					if err = c.createOrUpdateCrdIPs(podName, ip, mac, podNet.Subnet.Name, pod.Namespace, pod.Spec.NodeName, podNet.ProviderName, podType, isExcludeIP); err != nil {
 						klog.Errorf("failed to create/update ips CR %s.%s with ip address %s: %v", podName, pod.Namespace, ip, err)
 					}
 				}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -78,6 +78,7 @@ const (
 	DefaultRouteAnnotationTemplate  = "%s.kubernetes.io/default_route"
 	VfRepresentorNameTemplate       = "%s.kubernetes.io/vf_representor"
 	VfNameTemplate                  = "%s.kubernetes.io/vf"
+	ExcludeIpsTemplate              = "%s.kubernetes.io/exclude_ips"
 
 	ProviderNetworkTemplate           = "%s.kubernetes.io/provider_network"
 	ProviderNetworkErrMessageTemplate = "%s.provider-network.kubernetes.io/err_mesg"


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
- Bug fixes

do not calculate subnet.spec.excludeIPs as availableIPs

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
