### PR TITLE
chart: Autodiscover master nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,11 +462,8 @@ kind-install-chart: kind-load-image kind-untaint-control-plane
 	kubectl label node -lbeta.kubernetes.io/os=linux kubernetes.io/os=linux --overwrite
 	kubectl label node -lnode-role.kubernetes.io/control-plane kube-ovn/role=master --overwrite
 	kubectl label node -lovn.kubernetes.io/ovs_dp_type!=userspace ovn.kubernetes.io/ovs_dp_type=kernel --overwrite
-	ips=$$(kubectl get node -lkube-ovn/role=master --no-headers -o wide | awk '{print $$6}' | tr '\n' ',' | sed 's/,$$//') && \
 	helm install kubeovn ./charts \
-		--set global.images.kubeovn.tag=$(VERSION) \
-		--set replicaCount=$$(echo $$ips | awk -F ',' '{print NF}') \
-		--set MASTER_NODES="$$(echo $$ips | sed 's/,/\\,/g')"
+		--set global.images.kubeovn.tag=$(VERSION)
 	sleep 60
 	kubectl -n kube-system rollout status --timeout=1s deployment/ovn-central
 	kubectl -n kube-system rollout status --timeout=1s daemonset/ovs-ovn
@@ -476,11 +473,8 @@ kind-install-chart: kind-load-image kind-untaint-control-plane
 
 .PHONY: kind-upgrade-chart
 kind-upgrade-chart: kind-load-image
-	$(eval OVN_DB_IPS = $(shell kubectl get node -lkube-ovn/role=master --no-headers -o wide | awk '{print $$6}' | tr '\n' ',' | sed -e 's/,$$//' -e 's/,/\\,/g'))
 	helm upgrade kubeovn ./charts \
-		--set global.images.kubeovn.tag=$(VERSION) \
-		--set replicaCount=$$(echo $(OVN_DB_IPS) | awk -F ',' '{print NF}') \
-		--set MASTER_NODES='$(OVN_DB_IPS)'
+		--set global.images.kubeovn.tag=$(VERSION)
 	sleep 90
 	kubectl -n kube-system rollout status --timeout=1s deployment/ovn-central
 	kubectl -n kube-system rollout status --timeout=1s daemonset/ovs-ovn

--- a/charts/README.md
+++ b/charts/README.md
@@ -10,11 +10,13 @@ $ kubectl label node -lnode-role.kubernetes.io/control-plane  kube-ovn/role=mast
 $ kubectl label node -lovn.kubernetes.io/ovs_dp_type!=userspace ovn.kubernetes.io/ovs_dp_type=kernel  --overwrite
 
 # standard install 
-$ helm install --debug kubeovn ./charts --set MASTER_NODES=${Node0},
+$ helm install --debug kubeovn ./charts --set MASTER_NODES=${Node0}
 
 # high availability install
-$ helm install --debug kubeovn ./charts --set MASTER_NODES=${Node0},${Node1},${Node2}, --set replicaCount=3
+$ helm install --debug kubeovn ./charts --set MASTER_NODES=${Node0},${Node1},${Node2}
 
 # upgrade to this version
-$ helm upgrade --debug kubeovn ./charts --set MASTER_NODES=${Node0},${Node1},${Node2}, --set replicaCount=3
+$ helm upgrade --debug kubeovn ./charts --set MASTER_NODES=${Node0},${Node1},${Node2}
 ```
+
+If `MASTER_NODES` unspecified Helm will take internal IPs of nodes with `kube-ovn/role=master` label

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{/*
+Get IP-addresses of master nodes
+*/}}
+{{- define "kubeovn.nodeIPs" -}}
+{{- $nodes := lookup "v1" "Node" "" "" -}}
+{{- $ips := list -}}
+{{- range $node := $nodes.items -}}
+  {{- if eq (index $node.metadata.labels "kube-ovn/role") "master" -}}
+    {{- range $address := $node.status.addresses -}}
+      {{- if eq $address.type "InternalIP" -}}
+        {{- $ips = append $ips $address.address -}}
+        {{- break -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{ join "," $ips }}
+{{- end -}}
+
+{{/*
+Number of master nodes
+*/}}
+{{- define "kubeovn.nodeCount" -}}
+  {{- len (split "," (.Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .))) }}
+{{- end -}}

--- a/charts/templates/central-deploy.yaml
+++ b/charts/templates/central-deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/description: |
       OVN components: northd, nb and sb.
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ include "kubeovn.nodeCount" . }}
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -53,7 +53,7 @@ spec:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"
             - name: NODE_IPS
-              value: "{{ .Values.MASTER_NODES }}"
+              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/templates/controller-deploy.yaml
+++ b/charts/templates/controller-deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/description: |
       kube-ovn controller
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ include "kubeovn.nodeCount" . }}
   selector:
     matchLabels:
       app: kube-ovn-controller
@@ -132,7 +132,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ .Values.MASTER_NODES }}"
+              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
             - name: POD_IPS
               valueFrom:
                 fieldRef:

--- a/charts/templates/ovn-dpdk-ds.yaml
+++ b/charts/templates/ovn-dpdk-ds.yaml
@@ -55,7 +55,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ .Values.MASTER_NODES }}"
+              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/templates/ovsovn-ds.yaml
+++ b/charts/templates/ovsovn-ds.yaml
@@ -74,7 +74,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ .Values.MASTER_NODES }}"
+              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -18,7 +18,6 @@ image:
   pullPolicy: IfNotPresent
 
 namespace: kube-system
-replicaCount: 1
 MASTER_NODES: ""
 
 networking:


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).
- 

## What type of this PR

Examples of user facing changes:

- Features

This PR introduces automatic discovery for `MASTER_NODE` nodes and calculates their correct number.
Thus if `MASTER_NODES` unspecified Helm will take internal IPs of nodes with `kube-ovn/role=master` label.

Specifying `replicaCount` parameter will make no effect since now

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
