### PR TITLE
fix: subnet status usingIp not consistent with availableIPRange and usingIPRange

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2106,13 +2106,6 @@ func (c *Controller) calcDualSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv
 	}
 
 	v4UsingIPStr, v6UsingIPStr, v4AvailableIPStr, v6AvailableIPStr := c.ipam.GetSubnetIPRangeString(subnet.Name, subnet.Spec.ExcludeIps)
-	if v4UsingIPStr == "" || v6UsingIPStr == "" {
-		if usingIPs != 0 {
-			err := fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
-			klog.Error(err)
-			return nil, err
-		}
-	}
 
 	if subnet.Status.V4AvailableIPs == v4availableIPs &&
 		subnet.Status.V6AvailableIPs == v6availableIPs &&
@@ -2123,6 +2116,11 @@ func (c *Controller) calcDualSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv
 		subnet.Status.V4AvailableIPRange == v4AvailableIPStr &&
 		subnet.Status.V6AvailableIPRange == v6AvailableIPStr {
 		return subnet, nil
+	}
+
+	if v4UsingIPStr == "" && v6UsingIPStr == "" && usingIPs != 0 {
+		err = fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
+		klog.Warning(err)
 	}
 
 	subnet.Status.V4AvailableIPs = v4availableIPs
@@ -2209,13 +2207,6 @@ func (c *Controller) calcSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv1.Su
 	}
 
 	v4UsingIPStr, v6UsingIPStr, v4AvailableIPStr, v6AvailableIPStr := c.ipam.GetSubnetIPRangeString(subnet.Name, subnet.Spec.ExcludeIps)
-	if v4UsingIPStr == "" || v6UsingIPStr == "" {
-		if usingIPs != 0 {
-			err := fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
-			klog.Error(err)
-			return nil, err
-		}
-	}
 	cachedFloatFields := [4]float64{
 		subnet.Status.V4AvailableIPs,
 		subnet.Status.V4UsingIPs,
@@ -2256,6 +2247,11 @@ func (c *Controller) calcSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv1.Su
 		subnet.Status.V6AvailableIPRange,
 	} {
 		return subnet, nil
+	}
+
+	if v4UsingIPStr == "" && v6UsingIPStr == "" && usingIPs != 0 {
+		err = fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
+		klog.Warning(err)
 	}
 
 	bytes, err := subnet.Status.Bytes()

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2119,6 +2119,7 @@ func (c *Controller) calcDualSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv
 	}
 
 	if v4UsingIPStr == "" && v6UsingIPStr == "" && usingIPs != 0 {
+		// in case of subnet deletion, v4 v6 using ip should be 0
 		err = fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
 		klog.Warning(err)
 	}
@@ -2250,6 +2251,7 @@ func (c *Controller) calcSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv1.Su
 	}
 
 	if v4UsingIPStr == "" && v6UsingIPStr == "" && usingIPs != 0 {
+		// in case of subnet deletion, v4 v6 using ip should be 0
 		err = fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
 		klog.Warning(err)
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2121,7 +2121,8 @@ func (c *Controller) calcDualSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv
 	if v4UsingIPStr == "" && v6UsingIPStr == "" && usingIPs != 0 {
 		// in case of subnet deletion, v4 v6 using ip should be 0
 		err = fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
-		klog.Warning(err)
+		klog.Error(err)
+		return nil, err
 	}
 
 	subnet.Status.V4AvailableIPs = v4availableIPs
@@ -2253,7 +2254,8 @@ func (c *Controller) calcSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv1.Su
 	if v4UsingIPStr == "" && v6UsingIPStr == "" && usingIPs != 0 {
 		// in case of subnet deletion, v4 v6 using ip should be 0
 		err = fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
-		klog.Warning(err)
+		klog.Error(err)
+		return nil, err
 	}
 
 	bytes, err := subnet.Status.Bytes()

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2108,8 +2108,9 @@ func (c *Controller) calcDualSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv
 	v4UsingIPStr, v6UsingIPStr, v4AvailableIPStr, v6AvailableIPStr := c.ipam.GetSubnetIPRangeString(subnet.Name, subnet.Spec.ExcludeIps)
 	if v4UsingIPStr == "" || v6UsingIPStr == "" {
 		if usingIPs != 0 {
-			klog.Warningf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
-			usingIPs = 0
+			err := fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
+			klog.Error(err)
+			return nil, err
 		}
 	}
 
@@ -2210,8 +2211,9 @@ func (c *Controller) calcSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv1.Su
 	v4UsingIPStr, v6UsingIPStr, v4AvailableIPStr, v6AvailableIPStr := c.ipam.GetSubnetIPRangeString(subnet.Name, subnet.Spec.ExcludeIps)
 	if v4UsingIPStr == "" || v6UsingIPStr == "" {
 		if usingIPs != 0 {
-			klog.Warningf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
-			usingIPs = 0
+			err := fmt.Errorf("ipam subnet %s has no ip in using, but some ip cr left: ip %d, vip %d, iptable eip %d, ovn eip %d", subnet.Name, lenIP, lenVip, lenIptablesEip, lenOvnEip)
+			klog.Error(err)
+			return nil, err
 		}
 	}
 	cachedFloatFields := [4]float64{

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2040,8 +2040,8 @@ func (c *Controller) calcDualSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv
 	var lenIP, lenVip, lenIptablesEip, lenOvnEip int
 	lenIP = len(podUsedIPs)
 	usingIPNums := lenIP
-	for _, podUsedIP := range podUsedIPs {
-		for _, excludeIP := range subnet.Spec.ExcludeIps {
+	for _, excludeIP := range subnet.Spec.ExcludeIps {
+		for _, podUsedIP := range podUsedIPs {
 			if util.ContainsIPs(excludeIP, podUsedIP.Spec.V4IPAddress) || util.ContainsIPs(excludeIP, podUsedIP.Spec.V6IPAddress) {
 				// This ip cr is allocated from subnet.spec.excludeIPs, do not count it as usingIPNums
 				usingIPNums--
@@ -2157,8 +2157,8 @@ func (c *Controller) calcSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv1.Su
 	}
 	lenIP = len(podUsedIPs)
 	usingIPNums := lenIP
-	for _, podUsedIP := range podUsedIPs {
-		for _, excludeIP := range subnet.Spec.ExcludeIps {
+	for _, excludeIP := range subnet.Spec.ExcludeIps {
+		for _, podUsedIP := range podUsedIPs {
 			if util.ContainsIPs(excludeIP, podUsedIP.Spec.V4IPAddress) || util.ContainsIPs(excludeIP, podUsedIP.Spec.V6IPAddress) {
 				// This ip cr is allocated from subnet.spec.excludeIPs, do not count it as usingIPNums
 				usingIPNums--


### PR DESCRIPTION
fix: subnet status usingIp not consistent with availableIPRange and usingIPRange

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes
![image](https://github.com/kubeovn/kube-ovn/assets/7981158/b299ec77-1ae4-416e-847d-9e3e3436070c)


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->


crd 的 delete 事件也触发了 update 事件，可能导致 eip 被计数。实际上只在 add 中计数是 ok 的。
如果子网计数中出现了，图示中的bug情况，目前认为可以重试一次计数。



## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
