### PR TITLE
kube-ovn-monitor and kube-ovn-pinger should not export pprof path

### DIFF
--- a/cmd/ovn_monitor/ovn_monitor.go
+++ b/cmd/ovn_monitor/ovn_monitor.go
@@ -31,9 +31,9 @@ func CmdMain() {
 		go exporter.TryClientConnection()
 	}
 	exporter.StartOvnMetrics()
-
+	mux := http.NewServeMux()
 	if config.EnableMetrics {
-		http.Handle(config.MetricsPath, promhttp.Handler())
+		mux.Handle(config.MetricsPath, promhttp.Handler())
 		klog.Infoln("Listening on", config.ListenAddress)
 	}
 
@@ -57,6 +57,7 @@ func CmdMain() {
 	server := &http.Server{
 		Addr:              addr,
 		ReadHeaderTimeout: 3 * time.Second,
+		Handler:           mux,
 	}
 	util.LogFatalAndExit(server.ListenAndServe(), "failed to listen and server on %s", config.ListenAddress)
 }

--- a/cmd/pinger/pinger.go
+++ b/cmd/pinger/pinger.go
@@ -25,7 +25,8 @@ func CmdMain() {
 		util.LogFatalAndExit(err, "failed to parse config")
 	}
 	if config.Mode == "server" && config.EnableMetrics {
-		http.Handle("/metrics", promhttp.Handler())
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
 
 		go func() {
 			// conform to Gosec G114
@@ -33,6 +34,7 @@ func CmdMain() {
 			server := &http.Server{
 				Addr:              fmt.Sprintf("0.0.0.0:%d", config.Port),
 				ReadHeaderTimeout: 3 * time.Second,
+				Handler:           mux,
 			}
 			util.LogFatalAndExit(server.ListenAndServe(), "failed to listen and serve on %s", server.Addr)
 		}()


### PR DESCRIPTION
like /debug/pprof/...

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

kube-ovn-pinger and kube-ovn-monitor should not export /debug/pprof path.

it is default behavior of containerd
![image](https://github.com/kubeovn/kube-ovn/assets/47097611/f7030f8e-a794-4ba6-9e5c-4e119e0399bf)


Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
