### PR TITLE
delete cm ovn-ic-config cause crash 1.11

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3677,6 +3677,11 @@ spec:
           image: "$REGISTRY/kube-ovn:$VERSION"
           imagePullPolicy: $IMAGE_PULL_POLICY
           command: ["/kube-ovn/start-ic-controller.sh"]
+          args:
+          - --log_file=/var/log/kube-ovn/kube-ovn-ic-controller.log
+          - --log_file_max_size=0
+          - --logtostderr=false
+          - --alsologtostderr=true
           securityContext:
             capabilities:
               add: ["SYS_NICE"]
@@ -3707,6 +3712,8 @@ spec:
               name: localtime
             - mountPath: /var/run/tls
               name: kube-ovn-tls
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
       nodeSelector:
         kubernetes.io/os: "linux"
         kube-ovn/role: "master"
@@ -3723,6 +3730,9 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true

--- a/kubeovn-helm/templates/ic-controller-deploy.yaml
+++ b/kubeovn-helm/templates/ic-controller-deploy.yaml
@@ -46,6 +46,11 @@ spec:
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/kube-ovn/start-ic-controller.sh"]
+          args:
+          - --log_file=/var/log/kube-ovn/kube-ovn-ic-controller.log
+          - --log_file_max_size=0
+          - --logtostderr=false
+          - --alsologtostderr=true
           securityContext:
             capabilities:
               add: ["SYS_NICE"]
@@ -76,6 +81,8 @@ spec:
               name: localtime
             - mountPath: /var/run/tls
               name: kube-ovn-tls
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
       nodeSelector:
         kubernetes.io/os: "linux"
         kube-ovn/role: "master"
@@ -92,6 +99,9 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        - name: kube-ovn-log
+          hostPath:
+            path: /var/log/kube-ovn
         - name: kube-ovn-tls
           secret:
             optional: true

--- a/pkg/ovn_ic_controller/ovn_ic_controller.go
+++ b/pkg/ovn_ic_controller/ovn_ic_controller.go
@@ -117,19 +117,22 @@ func (c *Controller) resyncInterConnection() {
 			return
 		}
 		klog.Info("start to remove ovn-ic")
-		azName := ""
-		icDBHost := ""
+		var azName, icDBHost, icSBPort, icNBPort string
 		if cm != nil {
 			azName = cm.Data["az-name"]
 			icDBHost = cm.Data["ic-db-host"]
+			icSBPort = cm.Data["ic-sb-port"]
+			icNBPort = cm.Data["ic-nb-port"]
 		} else if lastIcCm != nil {
 			azName = lastIcCm["az-name"]
 			icDBHost = lastIcCm["ic-db-host"]
+			icSBPort = lastIcCm["ic-sb-port"]
+			icNBPort = lastIcCm["ic-nb-port"]
 		}
 
 		if icDBHost != "" {
-			c.ovnLegacyClient.OvnICSbAddress = genHostAddress(icDBHost, cm.Data["ic-sb-port"])
-			c.ovnLegacyClient.OvnICNbAddress = genHostAddress(icDBHost, cm.Data["ic-nb-port"])
+			c.ovnLegacyClient.OvnICSbAddress = genHostAddress(icDBHost, icSBPort)
+			c.ovnLegacyClient.OvnICNbAddress = genHostAddress(icDBHost, icNBPort)
 		}
 
 		c.disableOVNIC(azName)

--- a/pkg/ovn_ic_controller/ovn_ic_controller.go
+++ b/pkg/ovn_ic_controller/ovn_ic_controller.go
@@ -35,19 +35,21 @@ const (
 	icConfigChange
 )
 
-func (c *Controller) disableOVNIC(azName string) {
+func (c *Controller) disableOVNIC(azName string) error {
 	if err := c.removeInterConnection(azName); err != nil {
 		klog.Errorf("failed to remove ovn-ic, %v", err)
-		return
+		return err
 	}
 	if err := c.delLearnedRoute(); err != nil {
 		klog.Errorf("failed to remove learned static routes, %v", err)
-		return
+		return err
 	}
 
 	if err := c.RemoveOldChassisInSbDB(azName); err != nil {
 		klog.Errorf("failed to remove remote chassis: %v", err)
+		return err
 	}
+	return nil
 }
 
 func (c *Controller) setAutoRoute(autoRoute bool) {
@@ -135,7 +137,11 @@ func (c *Controller) resyncInterConnection() {
 			c.ovnLegacyClient.OvnICNbAddress = genHostAddress(icDBHost, icNBPort)
 		}
 
-		c.disableOVNIC(azName)
+		err := c.disableOVNIC(azName)
+		if err != nil {
+			klog.Errorf("Disable az %s OVN IC failed ", azName)
+			return
+		}
 		icEnabled = "false"
 		lastIcCm = nil
 
@@ -172,7 +178,11 @@ func (c *Controller) resyncInterConnection() {
 	case icConfigChange:
 		c.ovnLegacyClient.OvnICSbAddress = genHostAddress(lastIcCm["ic-db-host"], cm.Data["ic-sb-port"])
 		c.ovnLegacyClient.OvnICNbAddress = genHostAddress(lastIcCm["ic-db-host"], cm.Data["ic-nb-port"])
-		c.disableOVNIC(lastIcCm["az-name"])
+		err := c.disableOVNIC(lastIcCm["az-name"])
+		if err != nil {
+			klog.Errorf("Disable az %s OVN IC failed ", lastIcCm["az-name"])
+			return
+		}
 		klog.Info("start to reestablish ovn-ic")
 		if err := c.establishInterConnection(cm.Data); err != nil {
 			klog.Errorf("failed to reestablish ovn-ic, %v", err)


### PR DESCRIPTION
1. fix delete cm ovn-ic-config cause crash
2. add ovn-ic-controller.log to hostpath

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
