### PR TITLE
fix getting vip with an empty name

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2021,6 +2021,9 @@ func (c *Controller) getVirtualIPs(pod *v1.Pod, podNets []*kubeovnNet) map[strin
 		}
 	}
 	for _, vipName := range vipNamesList {
+		if vipName = strings.TrimSpace(vipName); vipName == "" {
+			continue
+		}
 		vip, err := c.virtualIpsLister.Get(vipName)
 		if err != nil {
 			klog.Errorf("failed to get vip %s, %v", vipName, err)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
### kube-ovn-controller recent log
E0125 15:19:17.507646       1 pod.go:2026] failed to get vip , vip.kubeovn.io "" not found
```

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
