### PR TITLE
fix ipam not consistent

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -280,7 +280,12 @@ func (c *Controller) InitIPAM() error {
 		klog.Errorf("failed to list subnet: %v", err)
 		return err
 	}
-	for _, subnet := range subnets {
+	for _, cachedSubnet := range subnets {
+		subnet := cachedSubnet.DeepCopy()
+		if err = formatSubnet(subnet, c); err != nil {
+			klog.Errorf("failed to format subnet %s, %v", subnet.Name, err)
+			return err
+		}
 		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
 			klog.Errorf("failed to init subnet %s: %v", subnet.Name, err)
 		}

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -339,6 +339,13 @@ func (c *Controller) InitIPAM() error {
 			continue
 		}
 
+		// retrigger pod update to clean finalizer to delete pod
+		podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		if pod.DeletionTimestamp != nil && util.ContainsString(pod.Finalizers, util.Finalizer) {
+			klog.Infof("enqueue update for deleting pod %s", podKey)
+			c.updatePodQueue.Add(podKey)
+		}
+
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {
 			klog.Errorf("failed to get pod kubeovn nets %s.%s address %s: %v", pod.Name, pod.Namespace, pod.Annotations[util.IpAddressAnnotation], err)

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -581,6 +581,10 @@ func (c *Controller) initSyncCrdIPs() error {
 
 	for _, ipCr := range ips.Items {
 		ip := ipCr.DeepCopy()
+		if ip.DeletionTimestamp != nil && util.ContainsString(ip.Finalizers, util.ControllerName) {
+			klog.Infof("enqueue update for deleting ip %s", ip.Name)
+			c.updateIPQueue.Add(ip.Name)
+		}
 		changed := false
 		if _, ok := ipMap[ip.Name]; ok && ip.Spec.PodType == "" {
 			ip.Spec.PodType = util.Vm

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -249,8 +249,9 @@ func (c *Controller) handleUpdateIP(key string) error {
 			}
 		}
 		if cleanIPAM {
-			klog.Infof("ip cr %s release ipam from subnet %s", cachedIP.Name, cachedIP.Spec.Subnet)
-			c.ipam.ReleaseAddressByPod(cachedIP.Name, cachedIP.Spec.Subnet)
+			podKey := fmt.Sprintf("%s/%s", cachedIP.Spec.Namespace, cachedIP.Spec.PodName)
+			klog.Infof("ip cr %s release ipam pod key %s from subnet %s", cachedIP.Name, podKey, cachedIP.Spec.Subnet)
+			c.ipam.ReleaseAddressByPod(podKey, cachedIP.Spec.Subnet)
 		}
 		if err = c.handleDelIPFinalizer(cachedIP, util.ControllerName); err != nil {
 			klog.Errorf("failed to handle del ip finalizer %v", err)

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -209,6 +209,7 @@ func (c *Controller) handleUpdateIP(key string) error {
 		return err
 	}
 	if !cachedIP.DeletionTimestamp.IsZero() {
+		klog.Infof("handle deleting ip %s", cachedIP.Name)
 		subnet, err := c.subnetsLister.Get(cachedIP.Spec.Subnet)
 		if err != nil {
 			klog.Errorf("failed to get subnet %s: %v", cachedIP.Spec.Subnet, err)
@@ -262,8 +263,7 @@ func (c *Controller) handleUpdateIP(key string) error {
 }
 
 func (c *Controller) handleDelIP(ip *kubeovnv1.IP) error {
-	klog.V(3).Infof("handle delete ip %s", ip.Name)
-	klog.V(3).Infof("enqueue update status subnet %s", ip.Spec.Subnet)
+	klog.Infof("deleting ip %s enqueue update status subnet %s", ip.Name, ip.Spec.Subnet)
 	c.updateSubnetStatusQueue.Add(ip.Spec.Subnet)
 	for _, as := range ip.Spec.AttachSubnets {
 		klog.V(3).Infof("enqueue update attach status for subnet %s", as)

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -249,7 +249,7 @@ func (c *Controller) handleUpdateIP(key string) error {
 			}
 		}
 		if cleanIPAM {
-			klog.V(3).Infof("release ipam for deleted ip %s from subnet %s", cachedIP.Name, cachedIP.Spec.Subnet)
+			klog.Infof("ip cr %s release ipam from subnet %s", cachedIP.Name, cachedIP.Spec.Subnet)
 			c.ipam.ReleaseAddressByPod(cachedIP.Name, cachedIP.Spec.Subnet)
 		}
 		if err = c.handleDelIPFinalizer(cachedIP, util.ControllerName); err != nil {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -195,14 +195,17 @@ func (c *Controller) enqueueAddPod(obj interface{}) {
 			if isStateful && isStatefulSetPodToDel(c.config.KubeClient, p, statefulSetName) {
 				klog.V(3).Infof("enqueue delete pod %s", key)
 				c.deletePodQueue.Add(obj)
+				return
 			}
 			if isVmPod && c.isVmToDel(p, vmName) {
 				klog.V(3).Infof("enqueue delete pod %s", key)
 				c.deletePodQueue.Add(obj)
+				return
 			}
 		} else {
 			klog.V(3).Infof("enqueue delete pod %s", key)
 			c.deletePodQueue.Add(obj)
+			return
 		}
 		return
 	}
@@ -1542,6 +1545,7 @@ func appendCheckPodToDel(c *Controller, pod *v1.Pod, ownerRefName, ownerRefKind 
 		klog.Errorf("failed to get namespace %s, %v", pod.Namespace, err)
 		return false, err
 	}
+	key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 
 	// check if subnet exist in OwnerReference
 	var ownerRefSubnetExist bool
@@ -1583,7 +1587,7 @@ func appendCheckPodToDel(c *Controller, pod *v1.Pod, ownerRefName, ownerRefKind 
 		nsSubnetNames := podNs.Annotations[util.LogicalSwitchAnnotation]
 		// check if pod use the subnet of its ns
 		if nsSubnetNames != "" && pod.Annotations[util.LogicalSwitchAnnotation] != "" && !util.ContainsString(strings.Split(nsSubnetNames, ","), strings.TrimSpace(pod.Annotations[util.LogicalSwitchAnnotation])) {
-			klog.Infof("ns %s annotation subnet is %s, which is inconstant with subnet for pod %s, delete pod", pod.Namespace, podNs.Annotations[util.LogicalSwitchAnnotation], pod.Name)
+			klog.Infof("ns %s annotation subnet is %s, which is inconstant with subnet for pod %s, delete pod", pod.Namespace, podNs.Annotations[util.LogicalSwitchAnnotation], key)
 			return true, nil
 		}
 	}
@@ -1595,12 +1599,12 @@ func appendCheckPodToDel(c *Controller, pod *v1.Pod, ownerRefName, ownerRefKind 
 		return false, err
 	}
 	if podSubnet != nil && !util.CIDRContainIP(podSubnet.Spec.CIDRBlock, pod.Annotations[util.IpAddressAnnotation]) {
-		klog.Infof("pod's ip %s is not in the range of subnet %s, delete pod", pod.Annotations[util.IpAddressAnnotation], podSubnet.Name)
+		klog.Infof("pod %s ip %s is not in the range of subnet %s, delete pod", key, pod.Annotations[util.IpAddressAnnotation], podSubnet.Name)
 		return true, nil
 	}
 	// subnet of ownerReference(sts/vm) has been changed, it needs to handle delete pod and create port on the new logical switch
 	if podSubnet != nil && ownerRefSubnet != "" && podSubnet.Name != ownerRefSubnet {
-		klog.Infof("Subnet of owner %s has been changed from %s to %s, delete pod %s/%s", ownerRefName, podSubnet.Name, ownerRefSubnet, pod.Namespace, pod.Name)
+		klog.Infof("Subnet of owner %s has been changed from %s to %s, delete pod %s", ownerRefName, podSubnet.Name, ownerRefSubnet, key)
 		return true, nil
 	}
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -843,7 +843,6 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 				klog.Errorf("failed to delete ip for pod %s, %v, please delete manually", pod.Name, err)
 			}
 		}
-		c.ipam.ReleaseAddressByPod(podKey, "")
 		if pod.Annotations[util.VipAnnotation] != "" {
 			if err = c.releaseVip(pod.Annotations[util.VipAnnotation]); err != nil {
 				klog.Errorf("failed to clean label from vip %s, %v", pod.Annotations[util.VipAnnotation], err)
@@ -857,6 +856,10 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 	if err := c.handleDelPodFinalizer(pod); err != nil {
 		klog.Errorf("handle pod finalizer failed %v", err)
 		return err
+	}
+	if !keepIpCR {
+		// subnet ipam lock will block delete pod finalizer
+		c.ipam.ReleaseAddressByPod(podKey, "")
 	}
 	return nil
 }

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -857,10 +857,6 @@ func (c *Controller) handleDeletePod(pod *v1.Pod) error {
 	for _, podNet := range podNets {
 		c.syncVirtualPortsQueue.Add(podNet.Subnet.Name)
 	}
-	if !keepIpCR {
-		// subnet ipam lock will block
-		c.ipam.ReleaseAddressByPod(podKey, "")
-	}
 	return nil
 }
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1648,14 +1648,14 @@ func (c *Controller) checkSubnetStatus(subnetName string, subnetCR *kubeovnv1.Su
 	}
 	if subnetCR.Status.V4AvailableIPs != 0 && len(subnet.V4FreeIPList) == 0 && len(subnet.V4ReleasedIPList) == 0 {
 		err := fmt.Errorf("update ipam subnet %s to make sure v4 available ip", subnet.Name)
-		c.addOrUpdateSubnetQueue.Add(subnetName)
 		klog.Error(err)
+		c.addOrUpdateSubnetQueue.Add(subnetName)
 		return err
 	}
 	if subnetCR.Status.V6AvailableIPs != 0 && len(subnet.V6FreeIPList) == 0 && len(subnet.V6ReleasedIPList) == 0 {
 		err := fmt.Errorf("update ipam subnet %s to make sure v6 available ip", subnet.Name)
-		c.addOrUpdateSubnetQueue.Add(subnetName)
 		klog.Error(err)
+		c.addOrUpdateSubnetQueue.Add(subnetName)
 		return err
 	}
 	return nil

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1646,18 +1646,20 @@ func (c *Controller) checkSubnetStatus(subnetName string, subnetCR *kubeovnv1.Su
 		klog.Error(err)
 		return err
 	}
+
+	// subnetCR.Status update is later than ipam subnet
+	// subnet status available ips should be consistent with ipam subnet ASAP, especially when ipam subnet has no available ips
 	if subnetCR.Status.V4AvailableIPs != 0 && len(subnet.V4FreeIPList) == 0 && len(subnet.V4ReleasedIPList) == 0 {
-		err := fmt.Errorf("update ipam subnet %s to make sure v4 available ip", subnet.Name)
-		klog.Error(err)
+		klog.Warningf("subnet %s v4AvailableIPs %.0f, v4FreeIPList and v4ReleasedIPList has 0 ip", subnet.Name, subnetCR.Status.V4AvailableIPs)
+		// subnet reinitialize, make sure the status is consistent with ipam
 		c.addOrUpdateSubnetQueue.Add(subnetName)
-		return err
 	}
 	if subnetCR.Status.V6AvailableIPs != 0 && len(subnet.V6FreeIPList) == 0 && len(subnet.V6ReleasedIPList) == 0 {
-		err := fmt.Errorf("update ipam subnet %s to make sure v6 available ip", subnet.Name)
-		klog.Error(err)
+		klog.Warningf("subnet %s v6AvailableIPs %.0f, v6FreeIPList and v6ReleasedIPList has 0 ip", subnet.Name, subnetCR.Status.V6AvailableIPs)
+		// subnet reinitialize, make sure the status is consistent with ipam
 		c.addOrUpdateSubnetQueue.Add(subnetName)
-		return err
 	}
+
 	return nil
 }
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -483,7 +483,8 @@ func (c Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, e
 }
 
 func (c *Controller) handleAddOrUpdateSubnet(key string) error {
-	klog.V(3).Infof("handle add or update subnet %s", key)
+	defer klog.Infof("end handle add or update subnet %s", key)
+	klog.Infof("start handle add or update subnet %s", key)
 
 	cachedSubnet, err := c.subnetsLister.Get(key)
 	if err != nil {
@@ -557,13 +558,8 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		return err
 	}
 
-	if subnet.Spec.Protocol == kubeovnv1.ProtocolDual {
-		err = calcDualSubnetStatusIP(subnet, c)
-	} else {
-		err = calcSubnetStatusIP(subnet, c)
-	}
-	if err != nil {
-		klog.Errorf("calculate subnet %s used ip failed, %v", subnet.Name, err)
+	if err := c.handleUpdateSubnetStatus(key); err != nil {
+		klog.Errorf("failed to update subnet %s status, %v", subnet.Name, err)
 		return err
 	}
 
@@ -806,6 +802,8 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 func (c *Controller) handleUpdateSubnetStatus(key string) error {
 	c.subnetStatusKeyMutex.Lock(key)
 	defer c.subnetStatusKeyMutex.Unlock(key)
+	defer klog.Infof("end handle add or update status for subnet %s", key)
+	klog.Infof("start handle add or update status for subnet %s", key)
 
 	cachedSubnet, err := c.subnetsLister.Get(key)
 	subnet := cachedSubnet.DeepCopy()

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -300,7 +300,7 @@ func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 		subnet.Spec.GatewayType = kubeovnv1.GWDistributedType
 		changed = true
 	}
-	if subnet.Spec.Vpc == "" && subnet.Spec.Provider == util.OvnProvider {
+	if subnet.Spec.Vpc == "" && isOvnSubnet(subnet) {
 		changed = true
 		subnet.Spec.Vpc = util.DefaultVpc
 
@@ -323,7 +323,7 @@ func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 
 	klog.Infof("format subnet %v, changed %v", subnet.Name, changed)
 	if changed {
-		subnet, err = c.config.KubeOvnClient.KubeovnV1().Subnets().Update(context.Background(), subnet, metav1.UpdateOptions{})
+		_, err = c.config.KubeOvnClient.KubeovnV1().Subnets().Update(context.Background(), subnet, metav1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("failed to update subnet %s, %v", subnet.Name, err)
 			return err
@@ -531,6 +531,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 			klog.Errorf("failed to get subnet's vpc '%s', %v", subnet.Spec.Vpc, err)
 			return err
 		}
+
 		if !vpc.Status.Standby {
 			err = fmt.Errorf("the vpc '%s' not standby yet", vpc.Name)
 			klog.Error(err)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -483,15 +483,17 @@ func (c Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, e
 }
 
 func (c *Controller) handleAddOrUpdateSubnet(key string) error {
-	var err error
+	klog.V(3).Infof("handle add or update subnet %s", key)
+
 	cachedSubnet, err := c.subnetsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
+			klog.V(3).Infof("subnet %s not found", key)
 			return nil
 		}
+		klog.Errorf("failed to get subnet %s error %v", key, err)
 		return err
 	}
-	klog.V(4).Infof("handle add or update subnet %s", cachedSubnet.Name)
 
 	subnet := cachedSubnet.DeepCopy()
 	if err = formatSubnet(subnet, c); err != nil {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1595,7 +1595,9 @@ func (c *Controller) reconcileVlan(subnet *kubeovnv1.Subnet) error {
 
 func (c *Controller) reconcileU2OInterconnectionIP(subnet *kubeovnv1.Subnet) error {
 	if subnet.Spec.Vpc == "" {
-		return nil
+		err := fmt.Errorf("subnet %s spec should set vpc", subnet.Name)
+		klog.Error(err)
+		return err
 	}
 
 	needCalcIP := false
@@ -2206,9 +2208,6 @@ func (c *Controller) deletePolicyRouteForDistributedSubnet(subnet *kubeovnv1.Sub
 }
 
 func (c *Controller) deletePolicyRouteByGatewayType(subnet *kubeovnv1.Subnet, gatewayType string, isDelete bool) error {
-	if subnet.Spec.Vpc == "" {
-		return nil
-	}
 	if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != util.DefaultVpc {
 		return nil
 	}
@@ -2266,8 +2265,11 @@ func (c *Controller) deletePolicyRouteByGatewayType(subnet *kubeovnv1.Subnet, ga
 
 func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) error {
 	if subnet.Spec.Vpc == "" {
-		return nil
+		err := fmt.Errorf("subnet %s spec should set vpc", subnet.Name)
+		klog.Error(err)
+		return err
 	}
+
 	var v4Gw, v6Gw string
 	for _, gw := range strings.Split(subnet.Spec.Gateway, ",") {
 		switch util.CheckProtocol(gw) {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -810,6 +810,9 @@ func (c *Controller) handleUpdateSubnetStatus(key string) error {
 }
 
 func (c *Controller) handleDeleteRoute(subnet *kubeovnv1.Subnet) error {
+	if subnet.Spec.Vpc == "" {
+		return nil
+	}
 	vpc, err := c.vpcsLister.Get(subnet.Spec.Vpc)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -1565,6 +1568,9 @@ func (c *Controller) reconcileVlan(subnet *kubeovnv1.Subnet) error {
 }
 
 func (c *Controller) reconcileU2OInterconnectionIP(subnet *kubeovnv1.Subnet) error {
+	if subnet.Spec.Vpc == "" {
+		return nil
+	}
 
 	needCalcIP := false
 	klog.Infof("reconcile underlay subnet %s  to overlay interconnection with U2OInterconnection %v U2OInterconnectionIP %s ",
@@ -2174,6 +2180,9 @@ func (c *Controller) deletePolicyRouteForDistributedSubnet(subnet *kubeovnv1.Sub
 }
 
 func (c *Controller) deletePolicyRouteByGatewayType(subnet *kubeovnv1.Subnet, gatewayType string, isDelete bool) error {
+	if subnet.Spec.Vpc == "" {
+		return nil
+	}
 	if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != util.DefaultVpc {
 		return nil
 	}
@@ -2230,7 +2239,9 @@ func (c *Controller) deletePolicyRouteByGatewayType(subnet *kubeovnv1.Subnet, ga
 }
 
 func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) error {
-
+	if subnet.Spec.Vpc == "" {
+		return nil
+	}
 	var v4Gw, v6Gw string
 	for _, gw := range strings.Split(subnet.Spec.Gateway, ",") {
 		switch util.CheckProtocol(gw) {
@@ -2344,7 +2355,9 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 }
 
 func (c *Controller) deletePolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) error {
-
+	if subnet.Spec.Vpc == "" {
+		return nil
+	}
 	results, err := c.ovnLegacyClient.CustomFindEntity("Logical_Router_Policy", []string{"_uuid", "match", "priority"},
 		"external_ids:isU2ORoutePolicy=\"true\"",
 		fmt.Sprintf("external_ids:vendor=\"%s\"", util.CniTypeName),
@@ -2396,7 +2409,9 @@ func (c *Controller) addCustomVPCPolicyRoutesForSubnet(subnet *kubeovnv1.Subnet)
 }
 
 func (c *Controller) deleteCustomVPCPolicyRoutesForSubnet(subnet *kubeovnv1.Subnet) error {
-
+	if subnet.Spec.Vpc == "" {
+		return nil
+	}
 	for _, cidr := range strings.Split(subnet.Spec.CIDRBlock, ",") {
 		af := 4
 		if util.CheckProtocol(cidr) == kubeovnv1.ProtocolIPv6 {
@@ -2413,6 +2428,10 @@ func (c *Controller) deleteCustomVPCPolicyRoutesForSubnet(subnet *kubeovnv1.Subn
 }
 
 func (c *Controller) clearOldU2OResource(subnet *kubeovnv1.Subnet) error {
+	if subnet.Spec.Vpc == "" {
+		return nil
+	}
+
 	if subnet.Status.U2OInterconnectionVPC != "" &&
 		(!subnet.Spec.U2OInterconnection || (subnet.Spec.U2OInterconnection && subnet.Status.U2OInterconnectionVPC != subnet.Spec.Vpc)) {
 		// remove old u2o lsp and lrp first

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1653,11 +1653,13 @@ func (c *Controller) checkSubnetStatus(subnetName string, subnetCR *kubeovnv1.Su
 		klog.Warningf("subnet %s v4AvailableIPs %.0f, v4FreeIPList and v4ReleasedIPList has 0 ip", subnet.Name, subnetCR.Status.V4AvailableIPs)
 		// subnet reinitialize, make sure the status is consistent with ipam
 		c.addOrUpdateSubnetQueue.Add(subnetName)
+		return nil
 	}
 	if subnetCR.Status.V6AvailableIPs != 0 && len(subnet.V6FreeIPList) == 0 && len(subnet.V6ReleasedIPList) == 0 {
 		klog.Warningf("subnet %s v6AvailableIPs %.0f, v6FreeIPList and v6ReleasedIPList has 0 ip", subnet.Name, subnetCR.Status.V6AvailableIPs)
 		// subnet reinitialize, make sure the status is consistent with ipam
 		c.addOrUpdateSubnetQueue.Add(subnetName)
+		return nil
 	}
 
 	return nil

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -484,9 +484,6 @@ func (c Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, e
 
 func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	var err error
-	c.subnetStatusKeyMutex.Lock(key)
-	defer c.subnetStatusKeyMutex.Unlock(key)
-
 	cachedSubnet, err := c.subnetsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -313,7 +313,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		return err
 	}
 	vpc := cachedVpc.DeepCopy()
-	klog.V(3).Infof("handle add or update vpc %s", vpc.Name)
+	klog.Infof("handle add or update vpc %s", vpc.Name)
 
 	if err = formatVpc(vpc, c); err != nil {
 		klog.Errorf("failed to format vpc: %v", err)

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -313,6 +313,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		return err
 	}
 	vpc := cachedVpc.DeepCopy()
+	klog.V(3).Infof("handle add or update vpc %s", vpc.Name)
 
 	if err = formatVpc(vpc, c); err != nil {
 		klog.Errorf("failed to format vpc: %v", err)

--- a/pkg/ipam/ip.go
+++ b/pkg/ipam/ip.go
@@ -95,20 +95,24 @@ func mergeIPRangeList(iprl IPRangeList, ip IP) (bool, IPRangeList) {
 	if iprl.Contains(ip) {
 		return false, nil
 	}
-
+	// keep ip range list sorted
 	for _, ipr := range iprl {
 		if inserted || ipr.Start.LessThan(ip) {
+			// if exist ipr.Start < new ip, just append existing ipr
+			// if new ip inserted, just append existing ipr
 			insertIPRangeList = append(insertIPRangeList, ipr)
 			continue
 		}
 
 		if ipr.Start.GreaterThan(ip) {
+			// if ipr.Start > ip, inserte new ip，and add append existing ipr
 			insertIPRangeList = append(insertIPRangeList, &IPRange{Start: ip, End: ip}, ipr)
 			inserted = true
 			continue
 		}
 	}
 	if !inserted {
+		// add new ip to the end of ip range list
 		newIpr := IPRange{Start: ip, End: ip}
 		insertIPRangeList = append(insertIPRangeList, &newIpr)
 	}
@@ -121,6 +125,7 @@ func mergeIPRangeList(iprl IPRangeList, ip IP) (bool, IPRangeList) {
 		}
 
 		if mergedIPRangeList[len(mergedIPRangeList)-1].End.Add(1).Equal(ipr.Start) {
+			// if the end of the previous ipr equals the start of current ipr, merge
 			mergedIPRangeList[len(mergedIPRangeList)-1].End = ipr.End
 		} else {
 			mergedIPRangeList = append(mergedIPRangeList, ipr)

--- a/pkg/ipam/ip.go
+++ b/pkg/ipam/ip.go
@@ -118,8 +118,8 @@ func mergeIPRangeList(iprl IPRangeList, ip IP) (bool, IPRangeList) {
 	}
 
 	mergedIPRangeList := []*IPRange{}
-	for _, ipr := range insertIPRangeList {
-		if len(mergedIPRangeList) == 0 {
+	for index, ipr := range insertIPRangeList {
+		if index == 0 {
 			mergedIPRangeList = append(mergedIPRangeList, ipr)
 			continue
 		}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -204,9 +204,6 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 
 	// new subnet
 	klog.Infof("adding new subnet %s", name)
-	ipam.mutex.Lock()
-	defer ipam.mutex.Unlock()
-
 	subnet, err := NewSubnet(name, cidrStr, excludeIps)
 	if err != nil {
 		klog.Error(err)
@@ -214,6 +211,9 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 	}
 	subnet.V4Gw = v4Gw
 	subnet.V6Gw = v6Gw
+
+	ipam.mutex.Lock()
+	defer ipam.mutex.Unlock()
 	ipam.Subnets[name] = subnet
 	return nil
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -116,8 +116,6 @@ func checkAndAppendIpsForDual(ips []IP, mac string, podName string, nicName stri
 }
 
 func (ipam *IPAM) ReleaseAddressByPod(podName, subnetName string) {
-	ipam.mutex.RLock()
-	defer ipam.mutex.RUnlock()
 	if subnetName != "" {
 		if subnet, ok := ipam.Subnets[subnetName]; ok {
 			subnet.ReleaseAddress(podName)

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -226,11 +226,8 @@ func (ipam *IPAM) DeleteSubnet(subnetName string) {
 }
 
 func (ipam *IPAM) GetPodAddress(podName string) []*SubnetAddress {
-	ipam.mutex.RLock()
-	defer ipam.mutex.RUnlock()
 	addresses := []*SubnetAddress{}
 	for _, subnet := range ipam.Subnets {
-		subnet.mutex.RLock()
 		for _, nicName := range subnet.PodToNicList[podName] {
 			v4IP, v6IP, mac, protocol := subnet.GetPodAddress(podName, nicName)
 			switch protocol {
@@ -243,7 +240,6 @@ func (ipam *IPAM) GetPodAddress(podName string) []*SubnetAddress {
 				addresses = append(addresses, &SubnetAddress{Subnet: subnet, Ip: string(v6IP), Mac: mac})
 			}
 		}
-		subnet.mutex.RUnlock()
 	}
 	return addresses
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -163,6 +163,7 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 		// update subnet
 		subnet.mutex.Lock()
 		defer subnet.mutex.Unlock()
+
 		subnet.Protocol = protocol
 		if protocol == kubeovnv1.ProtocolDual || protocol == kubeovnv1.ProtocolIPv4 {
 			_, cidr, _ := net.ParseCIDR(v4cidrStr)
@@ -202,16 +203,17 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 	}
 
 	// new subnet
+	klog.Infof("adding new subnet %s", name)
 	ipam.mutex.Lock()
 	defer ipam.mutex.Unlock()
 
 	subnet, err := NewSubnet(name, cidrStr, excludeIps)
 	if err != nil {
+		klog.Error(err)
 		return err
 	}
 	subnet.V4Gw = v4Gw
 	subnet.V6Gw = v6Gw
-	klog.Infof("adding new subnet %s", name)
 	ipam.Subnets[name] = subnet
 	return nil
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -2,6 +2,7 @@ package ipam
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -56,6 +57,8 @@ func (ipam *IPAM) GetStaticAddress(podName, nicName, ip, mac, subnetName string,
 	ipam.mutex.RLock()
 	defer ipam.mutex.RUnlock()
 	if subnet, ok := ipam.Subnets[subnetName]; !ok {
+		err := fmt.Errorf("ipam has no subnet %s", subnetName)
+		klog.Error(err)
 		return "", "", "", ErrNoAvailable
 	} else {
 		var ips []IP
@@ -64,6 +67,7 @@ func (ipam *IPAM) GetStaticAddress(podName, nicName, ip, mac, subnetName string,
 		for _, ipStr := range strings.Split(ip, ",") {
 			ipAddr, mac, err = subnet.GetStaticAddress(podName, nicName, IP(ipStr), mac, false, checkConflict)
 			if err != nil {
+				klog.Errorf("failed to allocate ip %s mac %s for %s", ipStr, mac, podName)
 				return "", "", "", err
 			}
 			ips = append(ips, ipAddr)

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -211,6 +211,7 @@ func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, sk
 	}
 	if len(subnet.V4FreeIPList) == 0 {
 		if len(subnet.V4ReleasedIPList) == 0 {
+			klog.Errorf("no available v4 ip in subnet %s", subnet.Name)
 			return "", "", "", ErrNoAvailable
 		}
 		subnet.V4FreeIPList = subnet.V4ReleasedIPList
@@ -257,6 +258,7 @@ func (subnet *Subnet) getV4RandomAddress(podName, nicName string, mac string, sk
 		return ip, "", subnet.GetRandomMac(podName, nicName), nil
 	} else {
 		if err := subnet.GetStaticMac(podName, nicName, mac, checkConflict); err != nil {
+			klog.Errorf("failed to get static mac %s for pod %s", mac, podName)
 			return "", "", "", err
 		}
 		return ip, "", mac, nil
@@ -276,6 +278,7 @@ func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, sk
 
 	if len(subnet.V6FreeIPList) == 0 {
 		if len(subnet.V6ReleasedIPList) == 0 {
+			klog.Errorf("no available v6 ip in subnet %s", subnet.Name)
 			return "", "", "", ErrNoAvailable
 		}
 		subnet.V6FreeIPList = subnet.V6ReleasedIPList
@@ -322,6 +325,7 @@ func (subnet *Subnet) getV6RandomAddress(podName, nicName string, mac string, sk
 		return "", ip, subnet.GetRandomMac(podName, nicName), nil
 	} else {
 		if err := subnet.GetStaticMac(podName, nicName, mac, checkConflict); err != nil {
+			klog.Errorf("failed to get static mac %s for pod %s", mac, podName)
 			return "", "", "", err
 		}
 		return "", ip, mac, nil
@@ -342,6 +346,7 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac strin
 		v6 = subnet.V6CIDR != nil
 	}
 	if v4 && !subnet.V4CIDR.Contains(net.ParseIP(string(ip))) {
+		klog.Errorf("v4 ip %s is out of range of subnet %s", ip, subnet.Name)
 		return ip, mac, ErrOutOfRange
 	}
 
@@ -350,6 +355,7 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac strin
 	}
 
 	if v6 && !subnet.V6CIDR.Contains(net.ParseIP(string(ip))) {
+		klog.Errorf("v6 ip %s is out of range of subnet %s", ip, subnet.Name)
 		return ip, mac, ErrOutOfRange
 	}
 
@@ -361,6 +367,7 @@ func (subnet *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac strin
 		}
 	} else {
 		if err := subnet.GetStaticMac(podName, nicName, mac, checkConflict); err != nil {
+			klog.Errorf("failed to get static mac %s for pod %s", mac, podName)
 			return ip, mac, err
 		}
 	}

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -166,11 +166,7 @@ func (subnet *Subnet) popPodNic(podName, nicName string) {
 }
 
 func (subnet *Subnet) GetRandomAddress(podName, nicName string, mac string, skippedAddrs []string, checkConflict bool) (IP, IP, string, error) {
-	subnet.mutex.Lock()
-	defer func() {
-		subnet.pushPodNic(podName, nicName)
-		subnet.mutex.Unlock()
-	}()
+	defer subnet.pushPodNic(podName, nicName)
 
 	if subnet.Protocol == kubeovnv1.ProtocolDual {
 		return subnet.getDualRandomAddress(podName, nicName, mac, skippedAddrs, checkConflict)

--- a/pkg/ovs/ovn-nbctl-legacy.go
+++ b/pkg/ovs/ovn-nbctl-legacy.go
@@ -1033,6 +1033,9 @@ func (c LegacyClient) AddStaticRoute(policy, cidr, nextHop, router string, route
 
 // AddPolicyRoute add a policy route rule in ovn
 func (c LegacyClient) AddPolicyRoute(router string, priority int32, match, action, nextHop string, externalIDs map[string]string) error {
+	if router == "" {
+		return nil
+	}
 	consistent, err := c.CheckPolicyRouteNexthopConsistent(router, match, nextHop, priority)
 	if err != nil {
 		return err
@@ -1082,6 +1085,9 @@ func (c LegacyClient) AddPolicyRoute(router string, priority int32, match, actio
 
 // DeletePolicyRoute delete a policy route rule in ovn
 func (c LegacyClient) DeletePolicyRoute(router string, priority int32, match string) error {
+	if router == "" {
+		return nil
+	}
 	exist, err := c.IsPolicyRouteExist(router, priority, match)
 	if err != nil {
 		return err

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -5,6 +5,8 @@ const (
 
 	ControllerName = "kube-ovn-controller"
 
+	Finalizer = "ovn.kubernetes.io/controller"
+
 	AllocatedAnnotation  = "ovn.kubernetes.io/allocated"
 	RoutedAnnotation     = "ovn.kubernetes.io/routed"
 	MacAddressAnnotation = "ovn.kubernetes.io/mac_address"


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
- Bug fixes

当子网计数后对比下 ipam 中的 free list 和 released list，如果明显不一致，则重新触发 subnet create or update 流程，

调小锁作用的业务逻辑范围
子网新建使用 ipam lock
子网分配 ip 使用 subnet lock，但只在ipam的 release 函数，或者分配函数

子网的 status 的更新都迟于 ipam 的更新，所以 status 和 ipam 不一致的时候应该都需要重新计算 status，但目前可分配为 0的情况下触发重新计算，只有这种情况对业务有严重影响。


简化 1.11 ipam 锁应用：
包括减小锁定的业务逻辑范围，
移除 pod key 锁，
subnet ipam 锁仅存于 subnet 粒度的 ipam分配和释放逻辑中,
subnet status 锁仅位于一个函数中，subnet init 锁缩小了业务范围，仅用于 subnet 赋值到 ipam 字典中那一下
ip pool 场景，单独新增一个锁（基于ip pool字符串）

- 修复了散列 ip 地址 release 后无法再分配的问题
- 修复了 ip CR 删除没有清理 ipam 的问题

https://github.com/kubeovn/kube-ovn/issues/3634

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
