### PR TITLE
Add Ænix to the Adopters list

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -4,6 +4,7 @@ Share you story about the Kube-OVN journey with the community.
 
 | Type | Name | Website | Use-Case |
 |:-|:-|:-|:-|
+| Vendor | Ænix | https://aenix.io/ | Ænix provides consulting services for cloud providers and uses Kube-OVN as main CNI in free PaaS platform [Cozystack](https://cozystack.io) for running virtual machines and Kubernetes-as-a-Service. |
 | Vendor | Alauda Inc | https://www.alauda.cn/ | Alauda distributes Kube-OVN as part of the [ACP](https://www.alauda.cn/product/acpflag.html) to provide enterprise level cloud native network. |
 | User | China Telecom CTYun | https://www.ctyun.cn/ | CTYun uses Kube-OVN as the cloud native SDN component in [Edge Cloud X](https://www.ctyun.cn/products/ecx). |
 | User | China Yealink | https://www.yealink.com/ | Yealink uses Kube-OVN as the cloud native SDN component in Private Cloud. |


### PR DESCRIPTION
Hi, we use Kube-OVN in our free PaaS platform [Cozystack](https://cozystack.io) as main CNI for running virtual machines and Kubernetes-as-a-Service.

We'd like to share this information :)