### PR TITLE
fix ovn nb load balancer health check unittest

### DIFF
--- a/pkg/ovs/ovn-nb-load_balancer_health_check_test.go
+++ b/pkg/ovs/ovn-nb-load_balancer_health_check_test.go
@@ -165,7 +165,6 @@ func (suite *OvnClientTestSuite) testGetLoadBalancerHealthCheck() {
 		lbName         = "test-get-lb-hc"
 		vip            = "1.1.1.22:80"
 		vipNonExistent = "1.1.1.33:80"
-		lbhc           *ovnnb.LoadBalancerHealthCheck
 		err            error
 	)
 
@@ -178,7 +177,7 @@ func (suite *OvnClientTestSuite) testGetLoadBalancerHealthCheck() {
 	t.Run("should return no err when found load balancer health check",
 		func(t *testing.T) {
 			t.Parallel()
-			_, lbhc, err = ovnClient.GetLoadBalancerHealthCheck(lbName, vip, false)
+			_, lbhc, err := ovnClient.GetLoadBalancerHealthCheck(lbName, vip, false)
 			require.NoError(t, err)
 			require.Equal(t, vip, lbhc.Vip)
 			require.NotEmpty(t, lbhc.UUID)
@@ -188,7 +187,7 @@ func (suite *OvnClientTestSuite) testGetLoadBalancerHealthCheck() {
 	t.Run("should return err when not found load balancer health check",
 		func(t *testing.T) {
 			t.Parallel()
-			_, _, err = ovnClient.GetLoadBalancerHealthCheck(lbName, vipNonExistent, false)
+			_, _, err := ovnClient.GetLoadBalancerHealthCheck(lbName, vipNonExistent, false)
 			require.Error(t, err)
 		},
 	)
@@ -196,7 +195,7 @@ func (suite *OvnClientTestSuite) testGetLoadBalancerHealthCheck() {
 	t.Run("no err when not found load balancer health check and ignoreNotFound is true",
 		func(t *testing.T) {
 			t.Parallel()
-			_, _, err = ovnClient.GetLoadBalancerHealthCheck(lbName, vipNonExistent, true)
+			_, _, err := ovnClient.GetLoadBalancerHealthCheck(lbName, vipNonExistent, true)
 			require.NoError(t, err)
 		},
 	)
@@ -207,13 +206,12 @@ func (suite *OvnClientTestSuite) testListLoadBalancerHealthChecks() {
 	t.Parallel()
 
 	var (
-		ovnClient     = suite.ovnClient
-		lbNamePrefix  = "test-list-lb-hcs"
-		vipFormat     = "1.1.1.%d:80"
-		vips, newVips []string
-		lbhcs         []ovnnb.LoadBalancerHealthCheck
-		lbName, vip   string
-		err           error
+		ovnClient    = suite.ovnClient
+		lbNamePrefix = "test-list-lb-hcs"
+		vipFormat    = "1.1.1.%d:80"
+		vips         []string
+		lbName, vip  string
+		err          error
 	)
 
 	vips = make([]string, 0, 5)
@@ -234,11 +232,11 @@ func (suite *OvnClientTestSuite) testListLoadBalancerHealthChecks() {
 		func(t *testing.T) {
 			t.Parallel()
 
-			lbhcs, err = ovnClient.ListLoadBalancerHealthChecks(nil)
+			lbhcs, err := ovnClient.ListLoadBalancerHealthChecks(nil)
 			require.NoError(t, err)
 			require.NotEmpty(t, lbhcs)
 
-			newVips = make([]string, 0, 5)
+			newVips := make([]string, 0, 5)
 			for _, lbhc := range lbhcs {
 				newVips = append(newVips, lbhc.Vip)
 			}
@@ -255,7 +253,7 @@ func (suite *OvnClientTestSuite) testListLoadBalancerHealthChecks() {
 				func(t *testing.T) {
 					t.Parallel()
 
-					lbhcs, err = ovnClient.ListLoadBalancerHealthChecks(
+					lbhcs, err := ovnClient.ListLoadBalancerHealthChecks(
 						func(lbhc *ovnnb.LoadBalancerHealthCheck) bool {
 							return strings.Contains(lbhc.Vip, "1.1.1")
 						},
@@ -263,7 +261,7 @@ func (suite *OvnClientTestSuite) testListLoadBalancerHealthChecks() {
 					require.NoError(t, err)
 					require.NotEmpty(t, lbhcs)
 
-					newVips = make([]string, 0, 5)
+					newVips := make([]string, 0, 5)
 					for _, lbhc := range lbhcs {
 						if !strings.Contains(lbhc.Vip, "1.1.1.10") {
 							continue
@@ -287,14 +285,13 @@ func (suite *OvnClientTestSuite) testDeleteLoadBalancerHealthCheckOp() {
 		vip            = "1.1.1.44:80"
 		vipNonExistent = "1.1.1.55:80"
 		lbhc           *ovnnb.LoadBalancerHealthCheck
-		ops            []ovsdb.Operation
 		err            error
 	)
 
 	err = ovnClient.CreateLoadBalancer(lbName, "tcp", "ip_dst")
 	require.NoError(t, err)
 
-	err = ovnClient.AddLoadBalancerHealthCheck(lbName, vip, map[string]string{})
+	err = ovnClient.AddLoadBalancerHealthCheck(lbName, vip, nil)
 	require.NoError(t, err)
 
 	_, lbhc, err = ovnClient.GetLoadBalancerHealthCheck(lbName, vip, false)
@@ -304,7 +301,7 @@ func (suite *OvnClientTestSuite) testDeleteLoadBalancerHealthCheckOp() {
 		func(t *testing.T) {
 			t.Parallel()
 
-			ops, err = ovnClient.DeleteLoadBalancerHealthCheckOp(lbName, vip)
+			ops, err := ovnClient.DeleteLoadBalancerHealthCheckOp(lbName, vip)
 			require.NoError(t, err)
 			require.Len(t, ops, 1)
 
@@ -329,7 +326,7 @@ func (suite *OvnClientTestSuite) testDeleteLoadBalancerHealthCheckOp() {
 		func(t *testing.T) {
 			t.Parallel()
 
-			ops, err = ovnClient.DeleteLoadBalancerHealthCheckOp(lbName, vipNonExistent)
+			ops, err := ovnClient.DeleteLoadBalancerHealthCheckOp(lbName, vipNonExistent)
 			require.NoError(t, err)
 			require.Len(t, ops, 0)
 		},


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 821 [running]:
testing.tRunner.func1.2({0x1691840, 0xc00038f548})
        /home/linuxbrew/.linuxbrew/Cellar/go/1.22.0/libexec/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /home/linuxbrew/.linuxbrew/Cellar/go/1.22.0/libexec/src/testing/testing.go:1634 +0x377
panic({0x1691840?, 0xc00038f548?})
        /home/linuxbrew/.linuxbrew/Cellar/go/1.22.0/libexec/src/runtime/panic.go:770 +0x132
github.com/kubeovn/kube-ovn/pkg/ovs.(*OvnClientTestSuite).testDeleteLoadBalancerHealthCheckOp.func1(0xc000938680)
        /home/zhang/kube-ovn/pkg/ovs/ovn-nb-load_balancer_health_check_test.go:324 +0x2da
testing.tRunner(0xc000938680, 0xc0003c6820)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.22.0/libexec/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 90
        /home/linuxbrew/.linuxbrew/Cellar/go/1.22.0/libexec/src/testing/testing.go:1742 +0x390
FAIL    github.com/kubeovn/kube-ovn/pkg/ovs     0.364s
?       github.com/kubeovn/kube-ovn/pkg/webhook [no test files]
ok      github.com/kubeovn/kube-ovn/pkg/util    (cached)
FAIL
make: *** [Makefile:961: ut] Error 1
```


## WHAT

copilot:summary

copilot:poem

## HOW

copilot:walkthrough
