### PR TITLE
fix kubevirt vm e2e

### DIFF
--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -40,7 +40,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 	})
 
 	framework.ConformanceIt("Kubevirt vm pod should keep ip", func() {
-		f.SkipVersionPriorTo(1, 12, "Only test kubevirt vm keep ip in master")
+		f.SkipVersionPriorTo(1, 12, "This feature was introduced in v1.12.")
 
 		ginkgo.By("Get kubevirt vm pod")
 		podList, err := podClient.List(context.TODO(), metav1.ListOptions{
@@ -50,7 +50,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		framework.ExpectHaveLen(podList.Items, 1)
 
 		ginkgo.By("Validating pod annotations")
-		pod := podList.Items[0]
+		pod := &podList.Items[0]
 		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
 		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
 		framework.ExpectHaveKeyWithValue(pod.Annotations, "ovn.kubernetes.io/virtualmachine", "testvm")
@@ -67,8 +67,12 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectHaveLen(podList.Items, 1)
 
+		pod = &podList.Items[0]
+		ginkgo.By("Waiting for pod " + pod.Name + " to be running")
+		podClient.WaitForRunning(pod.Name)
+
 		ginkgo.By("Validating new pod annotations")
-		pod = podList.Items[0]
+		pod = podClient.GetPod(pod.Name)
 		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
 		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
 		framework.ExpectHaveKeyWithValue(pod.Annotations, "ovn.kubernetes.io/virtualmachine", "testvm")


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
STEP: Check kubevirt vm pod after rebuild @ 02/20/24 03:31:07.071
STEP: Validating new pod annotations @ 02/20/24 03:31:07.08
[FAILED] in [It] - /home/runner/work/kube-ovn/kube-ovn/test/e2e/kubevirt/e2e_test.go:72 @ 02/20/24 03:31:07.08
STEP: Destroying namespace "kubevirt-5280" for this suite. @ 02/20/24 03:31:07.081
<< Timeline

[FAILED] Expected
    <map[string]string | len:9>: {
        "kubectl.kubernetes.io/default-container": "compute",
        "kubevirt.io/domain": "testvm",
        "kubevirt.io/migrationTransportUnix": "true",
        "pre.hook.backup.velero.io/container": "compute",
        "kubevirt.io/vm-generation": "2",
        "post.hook.backup.velero.io/command": "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvm\", \"--namespace\", \"default\"]",
        "post.hook.backup.velero.io/container": "compute",
        "pre.hook.backup.velero.io/command": "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvm\", \"--namespace\", \"default\"]",
        "traffic.sidecar.istio.io/kubevirtInterfaces": "k6t-eth0",
    }
to have {key: value}
    <map[interface {}]interface {} | len:1>: {
        <string>"ovn.kubernetes.io/allocated": <string>"true",
    }
In [It] at: /home/runner/work/kube-ovn/kube-ovn/test/e2e/kubevirt/e2e_test.go:72 @ 02/20/24 03:31:07.08
```
