### PR TITLE
if startOVNIC firstly, and setazName secondly, the ovn-ic-db may sync…

### DIFF
--- a/pkg/ovn_ic_controller/ovn_ic_controller.go
+++ b/pkg/ovn_ic_controller/ovn_ic_controller.go
@@ -281,13 +281,13 @@ func (c *Controller) removeInterConnection(azName string) error {
 }
 
 func (c *Controller) establishInterConnection(config map[string]string) error {
-	if err := c.startOVNIC(config["ic-db-host"], config["ic-nb-port"], config["ic-sb-port"]); err != nil {
-		klog.Errorf("failed to start ovn-ic, %v", err)
+	if err := c.OVNNbClient.SetAzName(config["az-name"]); err != nil {
+		klog.Errorf("failed to set az name. %v", err)
 		return err
 	}
 
-	if err := c.OVNNbClient.SetAzName(config["az-name"]); err != nil {
-		klog.Errorf("failed to set az name. %v", err)
+	if err := c.startOVNIC(config["ic-db-host"], config["ic-nb-port"], config["ic-sb-port"]); err != nil {
+		klog.Errorf("failed to start ovn-ic, %v", err)
 		return err
 	}
 


### PR DESCRIPTION
… the old azname (#3759)

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
