### PR TITLE
fix: go toolchain config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kubeovn/kube-ovn
 
 go 1.22
 
+toolchain go1.22.0
+
 require (
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/Microsoft/hcsshim v0.11.4


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

## Problem

```shell
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
```

**notice:** 

Go toolchain names
The standard Go toolchains are named goV where V is a Go version denoting a beta release, release candidate, or release. For example, go1.21rc1 and go1.21.0 are toolchain names; *go1.21 and go1.22 are not (the initial releases are go1.21.0 and go1.22.0), but go1.20 and go1.19 are.*

Non-standard toolchains use names of the form goV-suffix for any suffix.

Toolchains are compared by comparing the version V embedded in the name (dropping the initial go and discarding off any suffix beginning with -). For example, go1.21.0 and go1.21.0-custom compare equal for ordering purposes.
`

refs: 
- https://go.dev/doc/toolchain

## Solution

1. add toolchain in go.mod
2. replace go version 1.22 -> 1.22.0

refs： 
- https://github.com/golang/go/issues/62278#issuecomment-1693538776

