### PR TITLE
Fix newly created multi-network card pod traffic mirroring

### DIFF
--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -320,7 +320,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 
 		ifaceID := ovs.PodNameToPortName(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider)
-		if err = ovs.ConfigInterfaceMirror(csh.Config.EnableMirror, pod.Annotations[util.MirrorControlAnnotation], ifaceID); err != nil {
+		if err = ovs.ConfigInterfaceMirror(csh.Config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, podRequest.Provider)], ifaceID); err != nil {
 			klog.Errorf("failed mirror to mirror0, %v", err)
 			return
 		}


### PR DESCRIPTION

Fix the failure to enable multi-network card traffic mirroring for newly created pods

When the global traffic mirroring switch is not turned on, creating or restarting a pod with multiple Kube-OVN network cards, only the traffic mirroring of the main network card will take effect, and the traffic mirroring of the second network card will not work.

# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
