### PR TITLE
Modify the logic for reading the survival of a pod

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -156,7 +156,7 @@ func isPodAlive(p *v1.Pod) bool {
 }
 
 func isPodStatusPhaseAlive(p *v1.Pod) bool {
-	if p.Status.Phase == v1.PodSucceeded && p.Spec.RestartPolicy != v1.RestartPolicyAlways {
+	if p.Status.Phase == v1.PodSucceeded {
 		return false
 	}
 

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -29,7 +29,7 @@ const (
 )
 
 func isPodAlive(p *v1.Pod) bool {
-	if p.Status.Phase == v1.PodSucceeded && p.Spec.RestartPolicy != v1.RestartPolicyAlways {
+	if p.Status.Phase == v1.PodSucceeded {
 		return false
 	}
 


### PR DESCRIPTION
# Pull Request

## What type of this PR

- Bug fixes

If a pod is in the completed state, we can assume that it is no longer alive, and we don't need to determine any other conditions. This prevents some expelled pods from also being in the completed state, resulting in resources not being cleaned up.

## Which issue(s) this PR fixes

Fixes #3810 
