### PR TITLE
subnet: do not set .spec.enableLb with value from command line option

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -134,7 +134,6 @@ func (c *Controller) initDefaultLogicalSwitch() error {
 			NatOutgoing:         true,
 			GatewayType:         kubeovnv1.GWDistributedType,
 			Protocol:            util.CheckProtocol(c.config.DefaultCIDR),
-			EnableLb:            &c.config.EnableLb,
 		},
 	}
 	if c.config.NetworkType == util.NetworkTypeVlan {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -317,16 +317,6 @@ func (c *Controller) formatSubnet(subnet *kubeovnv1.Subnet) (*kubeovnv1.Subnet, 
 		}
 	}
 
-	if subnet.Spec.EnableLb == nil && subnet.Name != c.config.NodeSwitch {
-		changed = true
-		subnet.Spec.EnableLb = &c.config.EnableLb
-	}
-	// set join subnet Spec.EnableLb to nil
-	if subnet.Spec.EnableLb != nil && subnet.Name == c.config.NodeSwitch {
-		changed = true
-		subnet.Spec.EnableLb = nil
-	}
-
 	if subnet.Spec.U2OInterconnectionIP != "" && !subnet.Spec.U2OInterconnection {
 		subnet.Spec.U2OInterconnectionIP = ""
 		changed = true
@@ -840,7 +830,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 			vpc.Status.SctpLoadBalancer,
 			vpc.Status.SctpSessionLoadBalancer,
 		}
-		if subnet.Spec.EnableLb != nil && *subnet.Spec.EnableLb {
+		if subnet.Spec.EnableLb == nil || *subnet.Spec.EnableLb {
 			if err := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(subnet.Name, ovsdb.MutateOperationInsert, lbs...); err != nil {
 				c.patchSubnetStatus(subnet, "AddLbToLogicalSwitchFailed", err.Error())
 				klog.Error(err)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

1. Install kube-ovn with `ENABLE_LB=false`;
2. Set kube-ovn-controller command line option `--enable-lb=true`;
3. OVN LB for all existing subnets are still disabled, since the `.spec.enableLb` field has already been set to `false`.
