### PR TITLE
iptables: reject access to invalid service port only for TCP

### DIFF
--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -16,13 +16,13 @@ iptables -t filter -D INPUT -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40services dst -j ACCEPT
 iptables -t filter -D INPUT -m set --match-set ovn40services src -j ACCEPT
-iptables -t filter -D INPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
+iptables -t filter -D INPUT -p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
 iptables -t filter -D FORWARD -m set --match-set ovn40subnets dst -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40subnets src -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services dst -j ACCEPT
 iptables -t filter -D FORWARD -m set --match-set ovn40services src -j ACCEPT
 iptables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
-iptables -t filter -D OUTPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
+iptables -t filter -D OUTPUT -p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
 iptables -t mangle -D PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
 iptables -t mangle -D OUTPUT -m comment --comment "kube-ovn output rules" -j OVN-OUTPUT
 iptables -t mangle -F OVN-PREROUTING
@@ -56,13 +56,13 @@ ip6tables -t filter -D INPUT -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D INPUT -m set --match-set ovn60services src -j ACCEPT
-ip6tables -t filter -D INPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
+ip6tables -t filter -D INPUT -p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60subnets src -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services dst -j ACCEPT
 ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
-ip6tables -t filter -D OUTPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
+ip6tables -t filter -D OUTPUT -p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
 ip6tables -t mangle -D PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
 ip6tables -t mangle -D OUTPUT -m comment --comment "kube-ovn output rules" -j OVN-OUTPUT
 ip6tables -t mangle -F OVN-PREROUTING

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -629,11 +629,22 @@ func (c *Controller) setIptables() error {
 		}
 		if ipsetExists {
 			iptablesRules[0].Rule = strings.Fields(fmt.Sprintf(`-i ovn0 -m set --match-set %s src -m set --match-set %s dst,dst -j MARK --set-xmark 0x4000/0x4000`, matchset, ipset))
-			rejectRule := strings.Fields(fmt.Sprintf(`-m mark ! --mark 0x4000/0x4000 -m set --match-set %s dst -m conntrack --ctstate NEW -j REJECT`, svcMatchset))
+			rejectRule := strings.Fields(fmt.Sprintf(`-p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set %s dst -m conntrack --ctstate NEW -j REJECT`, svcMatchset))
+			obsoleteRejectRule := strings.Fields(fmt.Sprintf(`-m mark ! --mark 0x4000/0x4000 -m set --match-set %s dst -m conntrack --ctstate NEW -j REJECT`, svcMatchset))
 			iptablesRules = append(iptablesRules,
 				util.IPTableRule{Table: "filter", Chain: "INPUT", Rule: rejectRule},
 				util.IPTableRule{Table: "filter", Chain: "OUTPUT", Rule: rejectRule},
 			)
+			obsoleteRejectRules := []util.IPTableRule{
+				{Table: "filter", Chain: "INPUT", Rule: obsoleteRejectRule},
+				{Table: "filter", Chain: "OUTPUT", Rule: obsoleteRejectRule},
+			}
+			for _, rule := range obsoleteRejectRules {
+				if err = deleteIptablesRule(ipt, rule); err != nil {
+					klog.Errorf("failed to delete obsolete iptables rule %v: %v", rule, err)
+					return err
+				}
+			}
 		}
 
 		if nodeIP := nodeIPs[protocol]; nodeIP != "" {


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

When OVN LB is disabled, some application cannot resolve domain names:

```txt
PACKET: 2 144388f2 IN=ovn0 MACSRC=0:0:0:fb:29:2a MACDST=0:0:0:2a:b2:3e MACPROTO=0800 SRC=10.16.0.9 DST=10.96.0.10 LEN=82 TOS=0x0 TTL=63 ID=37904DF SPORT=48914 DPORT=53
 TRACE: 2 144388f2 raw:PREROUTING:rule:0x2:CONTINUE  -4 -t raw -A PREROUTING -p udp -m udp --dport 53 -j TRACE
 TRACE: 2 144388f2 raw:PREROUTING:return:
 TRACE: 2 144388f2 raw:PREROUTING:policy:ACCEPT
PACKET: 2 144388f2 IN=ovn0 MACSRC=0:0:0:fb:29:2a MACDST=0:0:0:2a:b2:3e MACPROTO=0800 SRC=10.16.0.9 DST=10.96.0.10 LEN=82 TOS=0x0 TTL=63 ID=37904DF SPORT=48914 DPORT=53
 TRACE: 2 144388f2 nat:PREROUTING:rule:0x95:JUMP:OVN-PREROUTING  -4 -t nat -A PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
 TRACE: 2 144388f2 nat:OVN-PREROUTING:rule:0x96:CONTINUE  -4 -t nat -A OVN-PREROUTING -i ovn0 -m set --match-set ovn40subnets src -m set --match-set KUBE-CLUSTER-IP dst,dst -j MARK --set-xmark 0x4000/0x4000
 TRACE: 2 144388f2 nat:OVN-PREROUTING:return:
 TRACE: 2 144388f2 nat:PREROUTING:rule:0x15:JUMP:KUBE-SERVICES  -4 -t nat -A PREROUTING -m comment --comment "kubernetes service portals" -j KUBE-SERVICES
 TRACE: 2 144388f2 nat:KUBE-SERVICES:rule:0x394:JUMP:KUBE-NODE-PORT  -4 -t nat -A KUBE-SERVICES -m addrtype --dst-type LOCAL -j KUBE-NODE-PORT
 TRACE: 2 144388f2 nat:KUBE-NODE-PORT:return:
 TRACE: 2 144388f2 nat:KUBE-SERVICES:rule:0x396:ACCEPT  -4 -t nat -A KUBE-SERVICES -m set --match-set KUBE-CLUSTER-IP dst,dst -j ACCEPT
PACKET: 2 144388f2 IN=ovn0 MACSRC=0:0:0:fb:29:2a MACDST=0:0:0:2a:b2:3e MACPROTO=0800 SRC=10.16.0.9 DST=10.96.0.10 LEN=82 TOS=0x0 TTL=63 ID=37904DF SPORT=48914 DPORT=53 MARK=0x4000
 TRACE: 2 144388f2 filter:INPUT:rule:0x9b:ACCEPT  -4 -t filter -A INPUT -m set --match-set ovn40services dst -j ACCEPT
PACKET: 2 144388f2 OUT=ovn0 LL=0x0 0000002affffffb23e000000fffffffb292a0800 SRC=10.16.0.9 DST=10.16.0.6 LEN=82 TOS=0x0 TTL=62 ID=37904DF SPORT=48914 DPORT=53 MARK=0x4000
 TRACE: 2 144388f2 raw:OUTPUT:rule:0x4:CONTINUE  -4 -t raw -A OUTPUT -p udp -m udp --dport 53 -j TRACE
 TRACE: 2 144388f2 raw:OUTPUT:return:
 TRACE: 2 144388f2 raw:OUTPUT:policy:ACCEPT
PACKET: 2 144388f2 OUT=ovn0 LL=0x0 0000002affffffb23e000000fffffffb292a0800 SRC=10.16.0.9 DST=10.16.0.6 LEN=82 TOS=0x0 TTL=62 ID=37904DF SPORT=48914 DPORT=53 MARK=0x4000
 TRACE: 2 144388f2 filter:OUTPUT:rule:0x14:JUMP:KUBE-IPVS-OUT-FILTER  -4 -t filter -A OUTPUT -m comment --comment "kubernetes ipvs access filter" -j KUBE-IPVS-OUT-FILTER
 TRACE: 2 144388f2 filter:KUBE-IPVS-OUT-FILTER:return:
 TRACE: 2 144388f2 filter:OUTPUT:rule:0x3:JUMP:KUBE-FIREWALL  -4 -t filter -A OUTPUT -j KUBE-FIREWALL
 TRACE: 2 144388f2 filter:KUBE-FIREWALL:return:
 TRACE: 2 144388f2 filter:OUTPUT:return:
 TRACE: 2 144388f2 filter:OUTPUT:policy:ACCEPT
PACKET: 2 144388f2 IN=ovn0 OUT=ovn0 MACSRC=0:0:0:fb:29:2a MACDST=0:0:0:2a:b2:3e MACPROTO=0800 SRC=10.16.0.9 DST=10.16.0.6 LEN=82 TOS=0x0 TTL=62 ID=37904DF SPORT=48914 DPORT=53 MARK=0x4000
 TRACE: 2 144388f2 mangle:POSTROUTING:rule:0x7:JUMP:OVN-POSTROUTING  -4 -t mangle -A POSTROUTING -m comment --comment "kube-ovn postrouting rules" -j OVN-POSTROUTING
 TRACE: 2 144388f2 mangle:OVN-POSTROUTING:return:
 TRACE: 2 144388f2 mangle:POSTROUTING:return:
 TRACE: 2 144388f2 mangle:POSTROUTING:policy:ACCEPT
PACKET: 2 144388f2 IN=ovn0 OUT=ovn0 MACSRC=0:0:0:fb:29:2a MACDST=0:0:0:2a:b2:3e MACPROTO=0800 SRC=10.16.0.9 DST=10.16.0.6 LEN=82 TOS=0x0 TTL=62 ID=37904DF SPORT=48914 DPORT=53 MARK=0x4000
 TRACE: 2 144388f2 nat:POSTROUTING:rule:0x9f:JUMP:OVN-POSTROUTING  -4 -t nat -A POSTROUTING -m comment --comment "kube-ovn postrouting rules" -j OVN-POSTROUTING
 TRACE: 2 144388f2 nat:OVN-POSTROUTING:rule:0xa1:JUMP:OVN-MASQUERADE  -4 -t nat -A OVN-POSTROUTING -m mark --mark 0x4000/0x4000 -j OVN-MASQUERADE
 TRACE: 2 144388f2 nat:OVN-MASQUERADE:rule:0x9c:CONTINUE  -4 -t nat -A OVN-MASQUERADE -j MARK --set-xmark 0x0/0xffffffff
 TRACE: 2 144388f2 nat:OVN-MASQUERADE:rule:0x9d:ACCEPT  -4 -t nat -A OVN-MASQUERADE -j MASQUERADE --random-fully
PACKET: 2 e160365d IN=ovn0 MACSRC=0:0:0:fb:29:2a MACDST=0:0:0:2a:b2:3e MACPROTO=0800 SRC=10.16.0.9 DST=10.96.0.10 LEN=82 TOS=0x0 TTL=63 ID=37905DF SPORT=48914 DPORT=53
 TRACE: 2 e160365d raw:PREROUTING:rule:0x2:CONTINUE  -4 -t raw -A PREROUTING -p udp -m udp --dport 53 -j TRACE
 TRACE: 2 e160365d raw:PREROUTING:return:
 TRACE: 2 e160365d raw:PREROUTING:policy:ACCEPT
PACKET: 2 e160365d IN=ovn0 MACSRC=0:0:0:fb:29:2a MACDST=0:0:0:2a:b2:3e MACPROTO=0800 SRC=10.16.0.9 DST=10.96.0.10 LEN=82 TOS=0x0 TTL=63 ID=37905DF SPORT=48914 DPORT=53
 TRACE: 2 e160365d filter:INPUT:rule:0xa1:DROP  -4 -t filter -A INPUT -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT --reject-with icmp-port-unreachable
```
