### PR TITLE
skip conntrack when access node dns ip

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -50,7 +50,7 @@ RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-o
     # northd: add nb option version_compatibility
     curl -s https://github.com/kubeovn/ovn/commit/06f5a7c684a6030036e2663eecf934b37c3e666e.patch | git apply && \
     # northd: skip conntrack when access node local dns ip
-    curl -s https://github.com/kubeovn/ovn/commit/efac0168b83dcc1944e66d9443d6ae1abf733f03.patch | git apply
+    curl -s https://github.com/kubeovn/ovn/commit/1ea964886da774506962d6bf23f8f894d93a10eb.patch | git apply
 
 RUN apt install -y build-essential fakeroot \
     autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -48,7 +48,9 @@ RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-o
     # lflow: do not send direct traffic between lports to conntrack
     curl -s https://github.com/kubeovn/ovn/commit/54cbe0d1ba2051e640dd3e53498f373362547691.patch | git apply && \
     # northd: add nb option version_compatibility
-    curl -s https://github.com/kubeovn/ovn/commit/06f5a7c684a6030036e2663eecf934b37c3e666e.patch | git apply
+    curl -s https://github.com/kubeovn/ovn/commit/06f5a7c684a6030036e2663eecf934b37c3e666e.patch | git apply && \
+    # northd: skip conntrack when access node local dns ip
+    curl -s https://github.com/kubeovn/ovn/commit/e529c44edcfffe9edd97b2d2e216b0a7228a6a85.patch | git apply
 
 RUN apt install -y build-essential fakeroot \
     autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -50,7 +50,7 @@ RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-o
     # northd: add nb option version_compatibility
     curl -s https://github.com/kubeovn/ovn/commit/06f5a7c684a6030036e2663eecf934b37c3e666e.patch | git apply && \
     # northd: skip conntrack when access node local dns ip
-    curl -s https://github.com/kubeovn/ovn/commit/e529c44edcfffe9edd97b2d2e216b0a7228a6a85.patch | git apply
+    curl -s https://github.com/kubeovn/ovn/commit/0e3916716c7d3bc556c1830cb535f87f19bed6f0.patch | git apply
 
 RUN apt install -y build-essential fakeroot \
     autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -50,7 +50,7 @@ RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-o
     # northd: add nb option version_compatibility
     curl -s https://github.com/kubeovn/ovn/commit/06f5a7c684a6030036e2663eecf934b37c3e666e.patch | git apply && \
     # northd: skip conntrack when access node local dns ip
-    curl -s https://github.com/kubeovn/ovn/commit/1a4306ab08667346b56703a28f3808c5537fdc14.patch | git apply
+    curl -s https://github.com/kubeovn/ovn/commit/efac0168b83dcc1944e66d9443d6ae1abf733f03.patch | git apply
 
 RUN apt install -y build-essential fakeroot \
     autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -50,7 +50,7 @@ RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-o
     # northd: add nb option version_compatibility
     curl -s https://github.com/kubeovn/ovn/commit/06f5a7c684a6030036e2663eecf934b37c3e666e.patch | git apply && \
     # northd: skip conntrack when access node local dns ip
-    curl -s https://github.com/kubeovn/ovn/commit/0e3916716c7d3bc556c1830cb535f87f19bed6f0.patch | git apply
+    curl -s https://github.com/kubeovn/ovn/commit/1a4306ab08667346b56703a28f3808c5537fdc14.patch | git apply
 
 RUN apt install -y build-essential fakeroot \
     autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -102,6 +102,20 @@ func (mr *MockNBGlobalMockRecorder) SetLsCtSkipDstLportIPs(enabled any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLsCtSkipDstLportIPs", reflect.TypeOf((*MockNBGlobal)(nil).SetLsCtSkipDstLportIPs), enabled)
 }
 
+// SetNodeLocalDNSIP mocks base method.
+func (m *MockNBGlobal) SetNodeLocalDNSIP(nodeLocalDNSIP string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetNodeLocalDNSIP", nodeLocalDNSIP)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetNodeLocalDNSIP indicates an expected call of SetNodeLocalDNSIP.
+func (mr *MockNBGlobalMockRecorder) SetNodeLocalDNSIP(nodeLocalDNSIP any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeLocalDNSIP", reflect.TypeOf((*MockNBGlobal)(nil).SetNodeLocalDNSIP), nodeLocalDNSIP)
+}
+
 // SetLsDnatModDlDst mocks base method.
 func (m *MockNBGlobal) SetLsDnatModDlDst(enabled bool) error {
 	m.ctrl.T.Helper()
@@ -4243,6 +4257,20 @@ func (m *MockNbClient) SetLsCtSkipDstLportIPs(enabled bool) error {
 func (mr *MockNbClientMockRecorder) SetLsCtSkipDstLportIPs(enabled any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLsCtSkipDstLportIPs", reflect.TypeOf((*MockNbClient)(nil).SetLsCtSkipDstLportIPs), enabled)
+}
+
+// SetNodeLocalDNSIP mocks base method.
+func (m *MockNbClient) SetNodeLocalDNSIP(nodeLocalDNSIP string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetNodeLocalDNSIP", nodeLocalDNSIP)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetNodeLocalDNSIP indicates an expected call of SetNodeLocalDNSIP.
+func (mr *MockNbClientMockRecorder) SetNodeLocalDNSIP(nodeLocalDNSIP any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeLocalDNSIP", reflect.TypeOf((*MockNbClient)(nil).SetNodeLocalDNSIP), nodeLocalDNSIP)
 }
 
 // SetLsDnatModDlDst mocks base method.

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -292,6 +292,11 @@ func ParseFlags() (*Configuration, error) {
 		return nil, fmt.Errorf("check system cidr failed, %v", err)
 	}
 
+	if err := util.CheckNodeDNSIP(config.NodeLocalDNSIP); err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
 	klog.Infof("config is %+v", config)
 	return config, nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -752,6 +752,10 @@ func (c *Controller) Run(ctx context.Context) {
 		util.LogFatalAndExit(err, "failed to set NB_Global option ls_ct_skip_dst_lport_ips")
 	}
 
+	if err := c.OVNNbClient.SetNodeLocalDNSIP(c.config.NodeLocalDNSIP); err != nil {
+		util.LogFatalAndExit(err, "failed to set NB_Global option node_local_dns_ip")
+	}
+
 	if err := c.InitOVN(); err != nil {
 		util.LogFatalAndExit(err, "failed to initialize ovn resources")
 	}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -18,6 +18,7 @@ type NBGlobal interface {
 	SetICAutoRoute(enable bool, blackList []string) error
 	SetLsDnatModDlDst(enabled bool) error
 	SetLsCtSkipDstLportIPs(enabled bool) error
+	SetNodeLocalDNSIP(nodeLocalDNSIP string) error
 	GetNbGlobal() (*ovnnb.NBGlobal, error)
 }
 

--- a/pkg/ovs/ovn-nb_global.go
+++ b/pkg/ovs/ovn-nb_global.go
@@ -159,5 +159,26 @@ func (c *OVNNbClient) SetLsCtSkipDstLportIPs(enabled bool) error {
 }
 
 func (c *OVNNbClient) SetNodeLocalDNSIP(nodeLocalDNSIP string) error {
-	return c.SetNbGlobalOptions("node_local_dns_ip", nodeLocalDNSIP)
+	if nodeLocalDNSIP != "" {
+		return c.SetNbGlobalOptions("node_local_dns_ip", nodeLocalDNSIP)
+	}
+
+	nbGlobal, err := c.GetNbGlobal()
+	if err != nil {
+		return fmt.Errorf("get nb global: %v", err)
+	}
+
+	options := make(map[string]string, len(nbGlobal.Options))
+	for k, v := range nbGlobal.Options {
+		options[k] = v
+	}
+
+	delete(options, "node_local_dns_ip")
+
+	nbGlobal.Options = options
+	if err := c.UpdateNbGlobal(nbGlobal, &nbGlobal.Options); err != nil {
+		return fmt.Errorf("remove option node_local_dns_ip failed , %v", err)
+	}
+
+	return nil
 }

--- a/pkg/ovs/ovn-nb_global.go
+++ b/pkg/ovs/ovn-nb_global.go
@@ -157,3 +157,7 @@ func (c *OVNNbClient) SetLsDnatModDlDst(enabled bool) error {
 func (c *OVNNbClient) SetLsCtSkipDstLportIPs(enabled bool) error {
 	return c.SetNbGlobalOptions("ls_ct_skip_dst_lport_ips", enabled)
 }
+
+func (c *OVNNbClient) SetNodeLocalDNSIP(nodeLocalDNSIP string) error {
+	return c.SetNbGlobalOptions("node_local_dns_ip", nodeLocalDNSIP)
+}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -525,6 +525,14 @@ func CheckSystemCIDR(cidrs []string) error {
 	return nil
 }
 
+func CheckNodeDNSIP(nodeLocalDNSIP string) error {
+	if nodeLocalDNSIP != "" && IsValidIP(nodeLocalDNSIP) {
+		err := fmt.Errorf("node dns ip %s is not valid ip ", nodeLocalDNSIP)
+		return err
+	}
+	return nil
+}
+
 // GetExternalNetwork returns the external network name
 // if the external network is not specified, return the default external network name
 func GetExternalNetwork(externalNet string) string {

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -526,8 +526,8 @@ func CheckSystemCIDR(cidrs []string) error {
 }
 
 func CheckNodeDNSIP(nodeLocalDNSIP string) error {
-	if nodeLocalDNSIP != "" && IsValidIP(nodeLocalDNSIP) {
-		err := fmt.Errorf("node dns ip %s is not valid ip ", nodeLocalDNSIP)
+	if nodeLocalDNSIP != "" && !IsValidIP(nodeLocalDNSIP) {
+		err := fmt.Errorf("node dns ip %s is not valid ip", nodeLocalDNSIP)
 		return err
 	}
 	return nil


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
如果目标ip 是 localodnsip 169.254.20.10，会走到ct_lb_mark的逻辑中，导致建立conntrack
![image](https://github.com/kubeovn/kube-ovn/assets/47097611/14d22752-781e-4322-a9d0-492621f77808)



Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
