### PR TITLE
fix br-external not init because of  no permission after ovn-nat-gw configmap created

### DIFF
--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -231,6 +231,15 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - ""
+      - networking.k8s.io
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -233,7 +233,6 @@ rules:
       - update
   - apiGroups:
       - ""
-      - networking.k8s.io
     resources:
       - configmaps
     verbs:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3101,6 +3101,15 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - ""
+      - networking.k8s.io
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3103,7 +3103,6 @@ rules:
       - update
   - apiGroups:
       - ""
-      - networking.k8s.io
     resources:
       - configmaps
     verbs:

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -1383,11 +1383,12 @@ func (c *Controller) setExGateway() error {
 			klog.Errorf("failed to get ovn-external-gw-config, %v", err)
 			return err
 		}
-		// enable external-gw-config without 'external-gw-nic' configured
-		// to reuse existing physical network from arg 'external-gateway-net'
+
 		linkName, exist := cm.Data["external-gw-nic"]
 		if !exist || len(linkName) == 0 {
-			return nil
+			err = fmt.Errorf("external-gw-nic not configured in ovn-external-gw-config")
+			klog.Error(err)
+			return err
 		}
 		link, err := netlink.LinkByName(linkName)
 		if err != nil {
@@ -1414,6 +1415,7 @@ func (c *Controller) setExGateway() error {
 		}
 
 		if !externalBrReady {
+			klog.Infof("create external bridge %s and add nic %s", externalBridge, linkName)
 			if _, err := ovs.Exec(
 				ovs.MayExist, "add-br", externalBridge, "--",
 				ovs.MayExist, "add-port", externalBridge, linkName,

--- a/pkg/daemon/gateway_windows.go
+++ b/pkg/daemon/gateway_windows.go
@@ -54,12 +54,14 @@ func (c *Controller) setExGateway() error {
 			klog.Errorf("failed to get ovn-external-gw-config, %v", err)
 			return err
 		}
-		// enable external-gw-config without 'external-gw-nic' configured
-		// to reuse existing physical network from arg 'external-gateway-net'
+
 		linkName, exist := cm.Data["external-gw-nic"]
 		if !exist || len(linkName) == 0 {
-			return nil
+			err = fmt.Errorf("external-gw-nic not configured in ovn-external-gw-config")
+			klog.Error(err)
+			return err
 		}
+
 		externalBrReady := false
 		// if external nic already attached into another bridge
 		if existBr, err := ovs.Exec("port-to-br", linkName); err == nil {

--- a/pkg/ovs/ovn-nb-bfd.go
+++ b/pkg/ovs/ovn-nb-bfd.go
@@ -23,7 +23,7 @@ func (c *OVNNbClient) ListBFDs(lrpName, dstIP string) ([]ovnnb.BFD, error) {
 		if bfd.LogicalPort != lrpName {
 			return false
 		}
-		return bfd.DstIP == dstIP
+		return dstIP == "" || bfd.DstIP == dstIP
 	}).List(ctx, &bfdList); err != nil {
 		err := fmt.Errorf("failed to list BFD with logical_port=%s and dst_ip=%s: %v", lrpName, dstIP, err)
 		klog.Error(err)
@@ -140,12 +140,12 @@ func (c *OVNNbClient) DeleteBFD(lrpName, dstIP string) error {
 			klog.Error(err)
 			return err
 		}
+		klog.Infof("delete lrp %s BFD dst ip %s", lrpName, bfd.DstIP)
 		if err = c.Transact("bfd-del", ops); err != nil {
 			err := fmt.Errorf("failed to delete BFD with with UUID %s: %v", bfd.UUID, err)
 			klog.Error(err)
 			return err
 		}
-		klog.Infof("deleted lrp %s BFD dst ip %s", lrpName, bfd.DstIP)
 	}
 	return nil
 }

--- a/pkg/ovs/ovn-nb-bfd.go
+++ b/pkg/ovs/ovn-nb-bfd.go
@@ -23,7 +23,7 @@ func (c *OVNNbClient) ListBFDs(lrpName, dstIP string) ([]ovnnb.BFD, error) {
 		if bfd.LogicalPort != lrpName {
 			return false
 		}
-		return dstIP == "" || bfd.DstIP == dstIP
+		return bfd.DstIP == dstIP
 	}).List(ctx, &bfdList); err != nil {
 		err := fmt.Errorf("failed to list BFD with logical_port=%s and dst_ip=%s: %v", lrpName, dstIP, err)
 		klog.Error(err)
@@ -133,7 +133,6 @@ func (c *OVNNbClient) DeleteBFD(lrpName, dstIP string) error {
 	if len(bfdList) == 0 {
 		return nil
 	}
-
 	for _, bfd := range bfdList {
 		ops, err := c.Where(&bfd).Delete()
 		if err != nil {
@@ -146,8 +145,8 @@ func (c *OVNNbClient) DeleteBFD(lrpName, dstIP string) error {
 			klog.Error(err)
 			return err
 		}
+		klog.Infof("deleted lrp %s BFD dst ip %s", lrpName, bfd.DstIP)
 	}
-
 	return nil
 }
 

--- a/yamls/sa.yaml
+++ b/yamls/sa.yaml
@@ -276,7 +276,6 @@ rules:
       - update
   - apiGroups:
       - ""
-      - networking.k8s.io
     resources:
       - configmaps
     verbs:

--- a/yamls/sa.yaml
+++ b/yamls/sa.yaml
@@ -274,6 +274,15 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - ""
+      - networking.k8s.io
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

https://github.com/kubeovn/kube-ovn/issues/3798#issuecomment-2044337716

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
