### PR TITLE
chart: fix kubeVersion to allow for patterns that match sub versions

### DIFF
--- a/charts/kube-ovn/Chart.yaml
+++ b/charts/kube-ovn/Chart.yaml
@@ -23,4 +23,4 @@ version: 1.13.0
 # It is recommended to use it with quotes.
 appVersion: "1.13.0"
 
-kubeVersion: ">= 1.23.0"
+kubeVersion: ">= 1.23.0-0"


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
- Bug fixes

Similar to other charts that don't add the -0 for kubeversion, it then breaks deployments and upgrades for environments like eks where the kube version will look like "v1.25.13-eks-43840fb". This will allow subversion to be accepted durring installs and upgrades for the chart.

