### PR TITLE
fix controller-runtime logger not set

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -873,6 +874,7 @@ func migrateFinalizers(c client.Client, list client.ObjectList, getObjectItem fu
 }
 
 func (c *Controller) syncFinalizers() error {
+	ctrl.SetLogger(klog.NewKlogr())
 	cl, err := client.New(config.GetConfigOrDie(), client.Options{})
 	if err != nil {
 		klog.Errorf("failed to create client: %v", err)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
I0511 06:08:41.446957      29 leaderelection.go:250] attempting to acquire leader lease kube-system/kube-ovn-controller...
I0511 06:09:12.959043      29 leaderelection.go:260] successfully acquired lease kube-system/kube-ovn-controller
I0511 06:09:12.964717      29 client.go:52] connecting to OVN nbdb server tcp:[172.19.0.2]:6641
I0511 06:09:12.972111      29 client.go:52] connecting to OVN sbdb server tcp:[172.19.0.2]:6642
I0511 06:09:12.976959      29 controller.go:503] Starting OVN controller
I0511 06:09:12.977168      29 controller.go:510] Waiting for informer caches to sync
I0511 06:09:13.083673      29 init.go:577] start to sync ips
I0511 06:09:13.085999      29 init.go:590] enqueue update for deleting ip u2o-interconnection.ovn-cluster.subnet-185162152
I0511 06:09:13.086020      29 init.go:590] enqueue update for deleting ip u2o-interconnection.ovn-cluster.subnet-103917740
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 48 [running]:
        >  runtime/debug.Stack()
        >       runtime/debug/stack.go:24 +0x5e
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       sigs.k8s.io/controller-runtime@v0.18.2/pkg/log/log.go:60 +0xcd
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc000203300, {0x5cd9f1ee7d2b, 0x14})
        >       sigs.k8s.io/controller-runtime@v0.18.2/pkg/log/deleg.go:147 +0x3e
        >  github.com/go-logr/logr.Logger.WithName({{0x5cd9f30104e0, 0xc000203300}, 0x0}, {0x5cd9f1ee7d2b?, 0x0?})
        >       github.com/go-logr/logr@v1.4.1/logr.go:345 +0x36
        >  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x0?, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
        >       sigs.k8s.io/controller-runtime@v0.18.2/pkg/client/client.go:129 +0xf1
        >  sigs.k8s.io/controller-runtime/pkg/client.New(0x8?, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
        >       sigs.k8s.io/controller-runtime@v0.18.2/pkg/client/client.go:110 +0x7d
        >  github.com/kubeovn/kube-ovn/pkg/controller.(*Controller).syncFinalizers(0xc0006dad08)
        >       github.com/kubeovn/kube-ovn/pkg/controller/init.go:876 +0x45
        >  github.com/kubeovn/kube-ovn/pkg/controller.(*Controller).Run(0xc0006dad08, {0x5cd9f30084b8, 0xc000596500})
        >       github.com/kubeovn/kube-ovn/pkg/controller/controller.go:772 +0x1a8
        >  github.com/kubeovn/kube-ovn/pkg/controller.Run({0x5cd9f30084b8, 0xc000596500}, 0xc0003a2908)
        >       github.com/kubeovn/kube-ovn/pkg/controller/controller.go:733 +0xb845
        >  github.com/kubeovn/kube-ovn/cmd/controller.CmdMain.func3({0x5cd9f30084b8?, 0xc000596500?})
        >       github.com/kubeovn/kube-ovn/cmd/controller/controller.go:117 +0x25
        >  created by k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run in goroutine 1
        >       k8s.io/client-go@v12.0.0+incompatible/tools/leaderelection/leaderelection.go:213 +0xe6
```
