### PR TITLE
fix lsp not updating addresses

### DIFF
--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -98,7 +98,7 @@ func (c *OVNNbClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName,
 	// update if exists
 	if exist {
 		lsp := buildLogicalSwitchPort(lspName, lsName, ip, mac, podName, namespace, portSecurity, securityGroups, vips, enableDHCP, dhcpOptions, vpc)
-		if err := c.UpdateLogicalSwitchPort(lsp, &lsp.PortSecurity, &lsp.ExternalIDs); err != nil {
+		if err := c.UpdateLogicalSwitchPort(lsp, &lsp.Addresses, &lsp.Dhcpv4Options, &lsp.Dhcpv6Options, &lsp.PortSecurity, &lsp.ExternalIDs); err != nil {
 			klog.Error(err)
 			return fmt.Errorf("failed to update logical switch port %s: %v", lspName, err)
 		}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

## Which issue(s) this PR fixes

1. Stop kube-ovn-controller by setting its replicas to 0;
2. Delete a running pod;
3. Recreate the pod;
4. Start kube-ovn-controller by setting its replicas to non-zero;
5. Waiting for the pod to be running.

In step 5, the recreated pod will never be running, because the LSP's addresses field is not updated.

This patch is a simple fix. Maybe we should record pod uid in the LSP's external-ids.
