### PR TITLE
base: set entrypoint to  dumb-init

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -95,6 +95,10 @@ RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /etc/cni/net.d && \
     mkdir -p /opt/cni/bin
 
+ENV DUMB_INIT_VERSION="1.2.5"
+RUN curl -sSf -L --retry 5 -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_$(arch) && \
+    chmod +x /usr/bin/dumb-init
+
 ARG ARCH
 ENV CNI_VERSION=v1.4.1
 RUN curl -sSf -L --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C . ./loopback ./portmap ./macvlan
@@ -126,3 +130,5 @@ RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages \
         rm -rf /var/lib/apt/lists/* && \
         dpkg -i --ignore-depends=openvswitch-switch,openvswitch-common /packages/*.ddeb; \
     fi
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/dist/images/start-cniserver.sh
+++ b/dist/images/start-cniserver.sh
@@ -60,4 +60,4 @@ set_sysctl net.ipv4.neigh.default.gc_thresh3 "$gc_thresh3"
 set_sysctl net.ipv4.ip_no_pmtu_disc "$SYSCTL_IPV4_IP_NO_PMTU_DISC"
 set_sysctl net.netfilter.nf_conntrack_tcp_be_liberal "$SYSCTL_NF_CONNTRACK_TCP_BE_LIBERAL"
 
-./kube-ovn-daemon --ovs-socket=${OVS_SOCK} --bind-socket=${CNI_SOCK} "$@"
+exec ./kube-ovn-daemon --ovs-socket=${OVS_SOCK} --bind-socket=${CNI_SOCK} "$@"

--- a/dist/images/start-controller.sh
+++ b/dist/images/start-controller.sh
@@ -32,6 +32,6 @@ function gen_conn_str {
 nb_addr="$(gen_conn_str 6641)"
 sb_addr="$(gen_conn_str 6642)"
 
-./kube-ovn-controller --ovn-nb-addr="$nb_addr" \
+exec ./kube-ovn-controller --ovn-nb-addr="$nb_addr" \
                            --ovn-sb-addr="$sb_addr" \
                            $@

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -526,4 +526,4 @@ ovs-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/memory-trim-on-compaction o
 ovs-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/memory-trim-on-compaction on
 
 chmod 600 /etc/ovn/*
-/kube-ovn/kube-ovn-leader-checker --probeInterval=${OVN_LEADER_PROBE_INTERVAL} --enableCompact=${ENABLE_COMPACT}
+exec /kube-ovn/kube-ovn-leader-checker --probeInterval=${OVN_LEADER_PROBE_INTERVAL} --enableCompact=${ENABLE_COMPACT}

--- a/dist/images/start-ic-controller.sh
+++ b/dist/images/start-ic-controller.sh
@@ -55,6 +55,6 @@ if [ -z "${OVN_NB_DAEMON}" ]; then
   exit 1
 fi
 
-./kube-ovn-ic-controller  --ovn-nb-addr="$nb_addr" \
+exec ./kube-ovn-ic-controller  --ovn-nb-addr="$nb_addr" \
                            --ovn-sb-addr="$sb_addr" \
                            $@

--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -213,7 +213,7 @@ fi
 
 if [[ $ENABLE_OVN_LEADER_CHECK == "true" ]]; then
     chmod 600 /etc/ovn/*
-    /kube-ovn/kube-ovn-leader-checker --probeInterval=${OVN_LEADER_PROBE_INTERVAL} --isICDBServer=true
+    exec /kube-ovn/kube-ovn-leader-checker --probeInterval=${OVN_LEADER_PROBE_INTERVAL} --isICDBServer=true
 else
     # Compatible with controller deployment methods before kube-ovn 1.11.16
     TS_NAME=${TS_NAME:-ts}
@@ -227,6 +227,6 @@ else
     fi
     ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
     ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
-    tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
+    exec tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
 fi
 

--- a/dist/images/start-ovn-monitor.sh
+++ b/dist/images/start-ovn-monitor.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 ENABLE_SSL=${ENABLE_SSL:-false}
 
-./kube-ovn-monitor $@
+exec ./kube-ovn-monitor $@

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -158,4 +158,4 @@ else
 fi
 
 chmod 600 /etc/openvswitch/*
-tail --follow=name --retry /var/log/ovn/ovn-controller.log
+exec tail --follow=name --retry /var/log/ovn/ovn-controller.log

--- a/dist/images/start-webhook.sh
+++ b/dist/images/start-webhook.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./kube-ovn-webhook
+exec ./kube-ovn-webhook


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

When kube-ovn-conttoller is stopped, the kube-ovn-controller process cannot receive the terminal signal, and the pod keeps in Terminating state until reaching `terminationGracePeriodSeconds` which is 30s by default.

```txt
I0514 02:03:35.241908      29 pod.go:428] take 0 ms to handle sync pod underlay-3836/pod-106582449
I0514 02:03:45.291513      29 endpoint.go:107] update add/update endpoint kube-system/kube-ovn-controller
Log file created at: 2024/05/14 02:04:15
Running on machine: kube-ovn-control-plane
Binary: Built with gc go1.22.3 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I0514 02:04:15.949157      29 config.go:308] no --kubeconfig, use in-cluster kubernetes config
I0514 02:04:15.949652      29 k8s.go:27] succeeded to dial apiserver "10.96.0.1:443"
I0514 02:04:15.951865      29 config.go:366] no --kubeconfig, use in-cluster kubernetes config
I0514 02:04:15.952497      29 config.go:300] config is ...
I0514 02:04:15.967558      29 leaderelection.go:250] attempting to acquire leader lease kube-system/kube-ovn-controller...
I0514 02:04:48.654858      29 leaderelection.go:260] successfully acquired lease kube-system/kube-ovn-controller
```
