### PR TITLE
do not use exec for start scripts using `trap quit EXIT`

### DIFF
--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -44,7 +44,7 @@ spec:
         - name: ovn-central
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: 
+          command: 
           - /kube-ovn/start-db.sh
           securityContext:
             capabilities:

--- a/charts/kube-ovn/templates/ic-controller-deploy.yaml
+++ b/charts/kube-ovn/templates/ic-controller-deploy.yaml
@@ -45,8 +45,8 @@ spec:
         - name: ovn-ic-controller
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/kube-ovn/start-ic-controller.sh"]
           args:
-          - /kube-ovn/start-ic-controller.sh
           - --log_file=/var/log/kube-ovn/kube-ovn-ic-controller.log
           - --log_file_max_size=0
           - --logtostderr=false

--- a/charts/kube-ovn/templates/monitor-deploy.yaml
+++ b/charts/kube-ovn/templates/monitor-deploy.yaml
@@ -42,8 +42,8 @@ spec:
         - name: kube-ovn-monitor
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:
-          - /kube-ovn/start-ovn-monitor.sh
           - --log_file=/var/log/kube-ovn/kube-ovn-monitor.log
           - --logtostderr=false
           - --alsologtostderr=true

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -47,8 +47,10 @@ spec:
       - name: cni-server
         image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args:
+        command:
+          - bash
           - /kube-ovn/start-cniserver.sh
+        args:
           - --enable-mirror={{- .Values.debug.ENABLE_MIRROR }}
           - --mirror-iface={{- .Values.debug.MIRROR_IFACE }}
           - --node-switch={{ .Values.networking.NODE_SUBNET }}

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -47,7 +47,7 @@ spec:
           {{- if .Values.DPDK }}
           command: ["/kube-ovn/start-ovs-dpdk.sh"]
           {{- else }}
-          args: 
+          command: 
           {{- if .Values.DISABLE_MODULES_MANAGEMENT }}
           - /bin/sh
           - -ec

--- a/charts/kube-ovn/templates/pinger-ds.yaml
+++ b/charts/kube-ovn/templates/pinger-ds.yaml
@@ -32,8 +32,9 @@ spec:
       containers:
         - name: pinger
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          args:
+          command:
           - /kube-ovn/kube-ovn-pinger
+          args:
           - --external-address=
           {{- if eq .Values.networking.NET_STACK "dual_stack" -}}
           {{ .Values.dual_stack.PINGER_EXTERNAL_ADDRESS }} 

--- a/dist/images/install-ic-server.sh
+++ b/dist/images/install-ic-server.sh
@@ -57,7 +57,7 @@ spec:
         - name: ovn-ic-server
           image: "$REGISTRY/kube-ovn:$VERSION"
           imagePullPolicy: $IMAGE_PULL_POLICY
-          args: ["/kube-ovn/start-ic-db.sh"]
+          command: ["/kube-ovn/start-ic-db.sh"]
           securityContext:
             capabilities:
               add: ["SYS_NICE"]

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3308,7 +3308,7 @@ spec:
         - name: ovn-central
           image: "$REGISTRY/kube-ovn:$VERSION"
           imagePullPolicy: $IMAGE_PULL_POLICY
-          args:
+          command:
           - /kube-ovn/start-db.sh
           securityContext:
             capabilities:
@@ -3632,7 +3632,7 @@ spec:
         - name: openvswitch
           image: "$REGISTRY/kube-ovn:$VERSION"
           imagePullPolicy: $IMAGE_PULL_POLICY
-          args:
+          command:
           - /kube-ovn/start-ovs.sh
           securityContext:
             runAsUser: 0
@@ -4160,8 +4160,10 @@ spec:
       - name: cni-server
         image: "$REGISTRY/kube-ovn:$VERSION"
         imagePullPolicy: $IMAGE_PULL_POLICY
-        args:
+        command:
+          - bash
           - /kube-ovn/start-cniserver.sh
+        args:
           - --enable-mirror=$ENABLE_MIRROR
           - --enable-arp-detect-ip-conflict=$ENABLE_ARP_DETECT_IP_CONFLICT
           - --encap-checksum=true
@@ -4459,8 +4461,8 @@ spec:
         - name: kube-ovn-monitor
           image: "$REGISTRY/kube-ovn:$VERSION"
           imagePullPolicy: $IMAGE_PULL_POLICY
+          command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:
-          - /kube-ovn/start-ovn-monitor.sh
           - --log_file=/var/log/kube-ovn/kube-ovn-monitor.log
           - --logtostderr=false
           - --alsologtostderr=true
@@ -4669,8 +4671,8 @@ spec:
         - name: ovn-ic-controller
           image: "$REGISTRY/kube-ovn:$VERSION"
           imagePullPolicy: $IMAGE_PULL_POLICY
+          command: ["/kube-ovn/start-ic-controller.sh"]
           args:
-          - /kube-ovn/start-ic-controller.sh
           - --log_file=/var/log/kube-ovn/kube-ovn-ic-controller.log
           - --log_file_max_size=0
           - --logtostderr=false

--- a/dist/images/start-cniserver.sh
+++ b/dist/images/start-cniserver.sh
@@ -60,4 +60,4 @@ set_sysctl net.ipv4.neigh.default.gc_thresh3 "$gc_thresh3"
 set_sysctl net.ipv4.ip_no_pmtu_disc "$SYSCTL_IPV4_IP_NO_PMTU_DISC"
 set_sysctl net.netfilter.nf_conntrack_tcp_be_liberal "$SYSCTL_NF_CONNTRACK_TCP_BE_LIBERAL"
 
-exec ./kube-ovn-daemon --ovs-socket=${OVS_SOCK} --bind-socket=${CNI_SOCK} "$@"
+./kube-ovn-daemon --ovs-socket=${OVS_SOCK} --bind-socket=${CNI_SOCK} "$@"

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -526,4 +526,4 @@ ovs-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/memory-trim-on-compaction o
 ovs-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/memory-trim-on-compaction on
 
 chmod 600 /etc/ovn/*
-exec /kube-ovn/kube-ovn-leader-checker --probeInterval=${OVN_LEADER_PROBE_INTERVAL} --enableCompact=${ENABLE_COMPACT}
+/kube-ovn/kube-ovn-leader-checker --probeInterval=${OVN_LEADER_PROBE_INTERVAL} --enableCompact=${ENABLE_COMPACT}

--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -213,7 +213,7 @@ fi
 
 if [[ $ENABLE_OVN_LEADER_CHECK == "true" ]]; then
     chmod 600 /etc/ovn/*
-    exec /kube-ovn/kube-ovn-leader-checker --probeInterval=${OVN_LEADER_PROBE_INTERVAL} --isICDBServer=true
+    /kube-ovn/kube-ovn-leader-checker --probeInterval=${OVN_LEADER_PROBE_INTERVAL} --isICDBServer=true
 else
     # Compatible with controller deployment methods before kube-ovn 1.11.16
     TS_NAME=${TS_NAME:-ts}
@@ -227,6 +227,6 @@ else
     fi
     ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
     ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
-    exec tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
+    tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
 fi
 

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -158,4 +158,4 @@ else
 fi
 
 chmod 600 /etc/openvswitch/*
-exec tail --follow=name --retry /var/log/ovn/ovn-controller.log
+tail --follow=name --retry /var/log/ovn/ovn-controller.log


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

`exec` replaces the current program in the current process, without forking a new process:

```txt
containerd-shim(731886)─┬─dumb-init(731983)───tail(732051)
                        ├─monitor(732200)───ovsdb-server(732201)
                        ├─monitor(732337)───ovs-vswitchd(732338)─┬─{ovs-vswitchd}(732521)
                        │                                        ├─{ovs-vswitchd}(732522)
                        │                                        ├─{ovs-vswitchd}(732523)
                        │                                        ├─{ovs-vswitchd}(732524)
                        │                                        ├─{ovs-vswitchd}(732525)
                        │                                        ├─{ovs-vswitchd}(732526)
                        │                                        ├─{ovs-vswitchd}(732527)
                        │                                        ├─{ovs-vswitchd}(732528)
                        │                                        ├─{ovs-vswitchd}(732529)
                        │                                        ├─{ovs-vswitchd}(732530)
                        │                                        ├─{ovs-vswitchd}(732531)
                        │                                        └─{ovs-vswitchd}(732532)
                        ├─monitor(732513)───ovn-controller(732514)─┬─{ovn-controller}(732515)
                        │                                          ├─{ovn-controller}(732516)
                        │                                          └─{ovn-controller}(732518)
                        ├─pause(731921)
```

Expected:

```txt
containerd-shim(940513)─┬─monitor(940761)───ovsdb-server(940763)
                        ├─monitor(940937)───ovs-vswitchd(940938)─┬─{ovs-vswitchd}(941152)
                        │                                        ├─{ovs-vswitchd}(941153)
                        │                                        ├─{ovs-vswitchd}(941155)
                        │                                        ├─{ovs-vswitchd}(941157)
                        │                                        ├─{ovs-vswitchd}(941158)
                        │                                        ├─{ovs-vswitchd}(941159)
                        │                                        ├─{ovs-vswitchd}(941160)
                        │                                        ├─{ovs-vswitchd}(941161)
                        │                                        ├─{ovs-vswitchd}(941162)
                        │                                        ├─{ovs-vswitchd}(941163)
                        │                                        ├─{ovs-vswitchd}(941164)
                        │                                        └─{ovs-vswitchd}(941165)
                        ├─monitor(941134)───ovn-controller(941136)─┬─{ovn-controller}(941137)
                        │                                          ├─{ovn-controller}(941138)
                        │                                          └─{ovn-controller}(941142)
                        ├─pause(940557)
                        ├─start-ovs.sh(940629)───tail(941143)
```
