### PR TITLE
uninstall.sh: delete OVN-POSTROUTING rule in mangle table

### DIFF
--- a/dist/images/uninstall.sh
+++ b/dist/images/uninstall.sh
@@ -24,6 +24,7 @@ iptables -t filter -D FORWARD -m set --match-set ovn40services src -j ACCEPT
 iptables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
 iptables -t filter -D OUTPUT -p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn40services dst -m conntrack --ctstate NEW -j REJECT
 iptables -t mangle -D PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
+iptables -t mangle -D POSTROUTING -m comment --comment "kube-ovn postrouting rules" -j OVN-POSTROUTING
 iptables -t mangle -D OUTPUT -m comment --comment "kube-ovn output rules" -j OVN-OUTPUT
 iptables -t mangle -F OVN-PREROUTING
 iptables -t mangle -X OVN-PREROUTING
@@ -64,6 +65,7 @@ ip6tables -t filter -D FORWARD -m set --match-set ovn60services src -j ACCEPT
 ip6tables -t filter -D OUTPUT -p udp -m udp --dport 6081 -j MARK --set-xmark 0x0
 ip6tables -t filter -D OUTPUT -p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set ovn60services dst -m conntrack --ctstate NEW -j REJECT
 ip6tables -t mangle -D PREROUTING -m comment --comment "kube-ovn prerouting rules" -j OVN-PREROUTING
+ip6tables -t mangle -D POSTROUTING -m comment --comment "kube-ovn postrouting rules" -j OVN-POSTROUTING
 ip6tables -t mangle -D OUTPUT -m comment --comment "kube-ovn output rules" -j OVN-OUTPUT
 ip6tables -t mangle -F OVN-PREROUTING
 ip6tables -t mangle -X OVN-PREROUTING


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
+ iptables -t mangle -X OVN-POSTROUTING
iptables v1.8.7 (nf_tables):  CHAIN_USER_DEL failed (Device or resource busy): chain OVN-POSTROUTING
```
