### PR TITLE
fix: add ip_reserved label for vip

### DIFF
--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -520,6 +520,11 @@ func (c *Controller) createOrUpdateVipCR(key, ns, subnet, v4ip, v6ip, mac, pV4ip
 			vip.Labels[util.SubnetNameLabel] = subnet
 			needUpdateLabel = true
 		}
+		if _, ok := vip.Labels[util.IPReservedLabel]; !ok {
+			op = "add"
+			vip.Labels[util.IPReservedLabel] = ""
+			needUpdateLabel = true
+		}
 		if needUpdateLabel {
 			patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`
 			raw, _ := json.Marshal(vip.Labels)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

当更新VIP的CR时，若label为空则添加ovn.kubernetes.io/subnet和ovn.kubernetes.io/ip_reserved两个label，但是如果有其它label，则只会更新ovn.kubernetes.io/subnet的label，而不会再添加ovn.kubernetes.io/ip_reserved这个label，导致subnet统计usingIPs未能统计vip的数量。
![image](https://github.com/kubeovn/kube-ovn/assets/52371592/2c0b3b3e-6716-4db7-9c88-0158ab892880)



