### PR TITLE
Makefile: run kubectl-ko script when collecting logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/windows/kube-ovn-daemon.exe
 ovnnb_db.*.backup
 ovnsb_db.*.backup
 **/kubectl-ko-log/*
+kubectl-ko-log.tar.gz
 kube-ovn.yaml
 kube-ovn-crd.yaml
 ovn.yaml

--- a/Makefile
+++ b/Makefile
@@ -1011,7 +1011,7 @@ ipam-bench:
 
 .PHONY: kubectl-ko-log
 kubectl-ko-log:
-	kubectl ko log all
+	bash dist/images/kubectl-ko log all
 	tar -zcvf kubectl-ko-log.tar.gz kubectl-ko-log/
 
 .PHONY: clean


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

With this patch, we can collect logs after kube-ovn installation failure occurs in github workflows.
