### PR TITLE
fix lr policy recreation after kube-ovn-controller restarts

### DIFF
--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -45,6 +45,7 @@ networking:
   NODE_SUBNET: "join"
   ENABLE_ECMP: false
   ENABLE_METRICS: true
+  # comma-separated string of nodelocal DNS ip addresses
   NODE_LOCAL_DNS_IP: ""
   PROBE_INTERVAL: 180000
   OVN_NORTHD_PROBE_INTERVAL: 5000

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -22,6 +22,7 @@ ENABLE_LB_SVC=${ENABLE_LB_SVC:-false}
 ENABLE_NAT_GW=${ENABLE_NAT_GW:-false}
 ENABLE_KEEP_VM_IP=${ENABLE_KEEP_VM_IP:-true}
 ENABLE_ARP_DETECT_IP_CONFLICT=${ENABLE_ARP_DETECT_IP_CONFLICT:-true}
+# comma-separated string of nodelocal DNS ip addresses
 NODE_LOCAL_DNS_IP=${NODE_LOCAL_DNS_IP:-}
 ENABLE_IC=${ENABLE_IC:-$(kubectl get node --show-labels | grep -qw "ovn.kubernetes.io/ic-gw" && echo true || echo false)}
 # exchange link names of OVS bridge and the provider nic

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -761,7 +762,7 @@ func (c *Controller) Run(ctx context.Context) {
 		util.LogFatalAndExit(err, "failed to set NB_Global option ls_ct_skip_dst_lport_ips")
 	}
 
-	if err := c.OVNNbClient.SetNodeLocalDNSIP(c.config.NodeLocalDNSIP); err != nil {
+	if err := c.OVNNbClient.SetNodeLocalDNSIP(strings.Join(c.config.NodeLocalDNSIPs, ",")); err != nil {
 		util.LogFatalAndExit(err, "failed to set NB_Global option node_local_dns_ip")
 	}
 

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -263,9 +263,10 @@ func (c *Controller) handleAddNode(key string) error {
 			continue
 		}
 
-		nodeIP, protocol, af := nodeIPv4, kubeovnv1.ProtocolIPv4, 4
-		if util.CheckProtocol(ip) == kubeovnv1.ProtocolIPv6 {
-			nodeIP, protocol, af = nodeIPv6, kubeovnv1.ProtocolIPv6, 6
+		nodeIP, af := nodeIPv4, 4
+		protocol := util.CheckProtocol(ip)
+		if protocol == kubeovnv1.ProtocolIPv6 {
+			nodeIP, af = nodeIPv6, 6
 		}
 		if nodeIP != "" {
 			var (

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -535,8 +535,7 @@ func CheckSystemCIDR(cidrs []string) error {
 
 func CheckNodeDNSIP(nodeLocalDNSIP string) error {
 	if nodeLocalDNSIP != "" && !IsValidIP(nodeLocalDNSIP) {
-		err := fmt.Errorf("node dns ip %s is not valid ip", nodeLocalDNSIP)
-		return err
+		return fmt.Errorf("invalid node local dns ip: %q", nodeLocalDNSIP)
 	}
 	return nil
 }

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	"math/big"
 	"net"
 	"reflect"
@@ -558,37 +557,37 @@ func TestIsValidIP(t *testing.T) {
 
 func TestCheckNodeDNSIP(t *testing.T) {
 	tests := []struct {
-		name     string
-		dnsIP    string
-		expected error
+		name    string
+		dnsIP   string
+		wantErr bool
 	}{
 		{
-			name:     "valid IPv4 address",
-			dnsIP:    "192.168.1.1",
-			expected: nil,
+			name:    "valid IPv4 address",
+			dnsIP:   "192.168.1.1",
+			wantErr: false,
 		},
 		{
-			name:     "valid IPv6 address",
-			dnsIP:    "2001:db8::1",
-			expected: nil,
+			name:    "valid IPv6 address",
+			dnsIP:   "2001:db8::1",
+			wantErr: false,
 		},
 		{
-			name:     "invalid IP address",
-			dnsIP:    "invalid",
-			expected: fmt.Errorf("node dns ip invalid is not valid ip"),
+			name:    "invalid IP address",
+			dnsIP:   "invalid",
+			wantErr: true,
 		},
 		{
-			name:     "empty string",
-			dnsIP:    "",
-			expected: nil,
+			name:    "empty string",
+			dnsIP:   "",
+			wantErr: false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := CheckNodeDNSIP(test.dnsIP)
-			if err != nil && test.expected == nil || err == nil && test.expected != nil || (err != nil && test.expected != nil && err.Error() != test.expected.Error()) {
-				t.Errorf("CheckNodeDNSIP(%q) expected error %v, got %v", test.dnsIP, test.expected, err)
+			if test.wantErr != (err != nil) {
+				t.Errorf("CheckNodeDNSIP(%q) expected error = %v, but got error = %v", test.dnsIP, test.wantErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Avoid LR policy recreation which can lead to network break.
