### PR TITLE
add ovn0 default route

### DIFF
--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -199,8 +199,8 @@ func (c *Controller) reconcileRouters(event *subnetEvent) error {
 	joinCIDR := make([]string, 0, 2)
 	cidrs := make([]string, 0, len(subnets)*2)
 	for _, subnet := range subnets {
-		if !subnet.Status.IsReady() ||
-			subnet.Spec.Vpc != c.config.ClusterRouter ||
+		// The route for overlay subnet cidr via ovn0 should not be deleted even though subnet.Status has changed to not ready
+		if subnet.Spec.Vpc != c.config.ClusterRouter ||
 			(subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway && (!subnet.Spec.U2OInterconnection || (subnet.Spec.EnableLb != nil && *subnet.Spec.EnableLb))) {
 			continue
 		}

--- a/pkg/daemon/controller_windows.go
+++ b/pkg/daemon/controller_windows.go
@@ -53,9 +53,9 @@ func (c *Controller) reconcileRouters(_ *subnetEvent) error {
 	gwIPv4, gwIPv6 := util.SplitStringIP(gateway)
 	v4Cidrs, v6Cidrs := make([]string, 0, len(subnets)), make([]string, 0, len(subnets))
 	for _, subnet := range subnets {
+		// The route for overlay subnet cidr via ovn0 should not be deleted even though subnet.Status has changed to not ready
 		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) ||
-			subnet.Spec.Vpc != c.config.ClusterRouter ||
-			!subnet.Status.IsReady() {
+			subnet.Spec.Vpc != c.config.ClusterRouter {
 			continue
 		}
 

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -87,7 +87,7 @@ func InitNodeGateway(config *Configuration) error {
 		klog.Errorf("failed to get ip %s with mask %s, %v", ip, cidr, err)
 		return err
 	}
-	return configureNodeNic(portName, ipAddr, gw, mac, config.MTU)
+	return configureNodeNic(portName, ipAddr, gw, cidr, mac, config.MTU)
 }
 
 func InitMirror(config *Configuration) error {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -553,7 +555,7 @@ func waitNetworkReady(nic, ipAddr, gateway string, underlayGateway, verbose bool
 	return nil
 }
 
-func configureNodeNic(portName, ip, gw string, macAddr net.HardwareAddr, mtu int) error {
+func configureNodeNic(portName, ip, gw, joinCIDR string, macAddr net.HardwareAddr, mtu int) error {
 	ipStr := util.GetIPWithoutMask(ip)
 	raw, err := ovs.Exec(ovs.MayExist, "add-port", "br-int", util.NodeNic, "--",
 		"set", "interface", util.NodeNic, "type=internal", "--",
@@ -585,6 +587,41 @@ func configureNodeNic(portName, ip, gw string, macAddr net.HardwareAddr, mtu int
 
 	if err = netlink.LinkSetTxQLen(hostLink, 1000); err != nil {
 		return fmt.Errorf("can not set host nic %s qlen: %v", util.NodeNic, err)
+	}
+
+	// check and add default route for ovn0 in case of can not add automatically
+	nodeNicRoutes, err := getNicExistRoutes(hostLink, gw)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	var toAdd []netlink.Route
+	for _, c := range strings.Split(joinCIDR, ",") {
+		found := false
+		for _, r := range nodeNicRoutes {
+			if r.Dst.String() == c {
+				found = true
+				break
+			}
+		}
+		if !found {
+			_, cidr, _ := net.ParseCIDR(c)
+			toAdd = append(toAdd, netlink.Route{
+				Dst:   cidr,
+				Scope: netlink.SCOPE_UNIVERSE,
+			})
+		}
+	}
+	if len(toAdd) > 0 {
+		klog.Infof("route to add for nic %s, %v", util.NodeNic, toAdd)
+	}
+
+	for _, r := range toAdd {
+		r.LinkIndex = hostLink.Attrs().Index
+		if err = netlink.RouteReplace(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
+			klog.Errorf("failed to replace route %v: %v", r, err)
+		}
 	}
 
 	// ping ovn0 gw to activate the flow


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
1、dual-stack cluster
2、IPv6 route for ovn0 on node is deleted in some case, so loopOvn0Check failed and kube-ovn-cni pod crash
3、ovn0 nic has already exist and will not be created again. 
4、The route is added when pod change to Running state and after startWorkers. But before that, the ping check for gateway is failed since IPv6 route on node is deleted and has not been added.
5、So the route for ovn0 should be added before gateway check. 

- Features
- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
