### PR TITLE
skip handleDeleteNode, when new  same name node  is adding

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -67,6 +67,7 @@ type Controller struct {
 	addOrUpdatePodQueue    workqueue.RateLimitingInterface
 	deletePodQueue         workqueue.RateLimitingInterface
 	deletingPodObjMap      *sync.Map
+	deletingNodeObjMap     *sync.Map
 	updatePodSecurityQueue workqueue.RateLimitingInterface
 	podKeyMutex            keymutex.KeyMutex
 
@@ -298,13 +299,14 @@ func Run(ctx context.Context, config *Configuration) {
 		numKeyLocks = config.WorkerNum * 2
 	}
 	controller := &Controller{
-		config:            config,
-		vpcs:              &sync.Map{},
-		podSubnetMap:      &sync.Map{},
-		deletingPodObjMap: &sync.Map{},
-		ovnLegacyClient:   ovs.NewLegacyClient(config.OvnTimeout),
-		ipam:              ovnipam.NewIPAM(),
-		namedPort:         NewNamedPort(),
+		config:             config,
+		vpcs:               &sync.Map{},
+		podSubnetMap:       &sync.Map{},
+		deletingPodObjMap:  &sync.Map{},
+		deletingNodeObjMap: &sync.Map{},
+		ovnLegacyClient:    ovs.NewLegacyClient(config.OvnTimeout),
+		ipam:               ovnipam.NewIPAM(),
+		namedPort:          NewNamedPort(),
 
 		vpcsLister:           vpcInformer.Lister(),
 		vpcSynced:            vpcInformer.Informer().HasSynced,


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

## 问题现象：

集中式网关当只有唯一一个节点的时候，将这个节点从集群中删除，然后再加回来时，偶发kube-ovn-cni 起不来

## 问题原因：

是由于handleDeleteNode 一直没有删除成功，导致报错
```
 failed to delete policy route for centralized subnet ovn-default, subnet ovn-default gws are not ready
```
失败后会event 一直放进deleteNodeQueue。

但是当下一次同名节点成功加入后，由于删除的事件还在deleteNodeQueue 中，仍然会走到 handleDeleteNode 所以导致了某些节点相关的db 比如lsp，portgroup被清理了。

## 问题解决办法：

目前没想到比较好的方法，
方法1：
如果从deleteNodeQueue 中强制清理掉删除的event，handleDeleteNode 就没完全成功，导致某些规则没有清理的话，会不会导致下一次添加节点出问题。

我这边说的不一定是这个集中式网关的例子，handleDeleteNode return err的地方也不少，如果要强制从队列清理掉删除event的话，那估计得检查，在handleDeleteNode任意一个点如果return err会不会导致下一次node 加入失败。
![企业微信截图_17188503333392](https://github.com/kubeovn/kube-ovn/assets/47097611/be98e572-8b04-4321-81ff-d1a31a061d9a)


方法2：
该pr 使用的，如果addNode的时候 发现有删除event在队列中，那就报警，让用户自己评估。


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)