### PR TITLE
pinger: fix warning logs

### DIFF
--- a/pkg/pinger/util.go
+++ b/pkg/pinger/util.go
@@ -230,7 +230,7 @@ func (e *Exporter) setOvsInterfaceStatisticsMetric(intf *ovsdb.OvsInterface) {
 		case "rx_multicast_packets":
 			interfaceStatRxMulticastPackets.WithLabelValues(e.Client.System.Hostname, intf.Name).Set(float64(value))
 		default:
-			klog.Warningf("unknown statistics %s with value %d on OVS interface %s", key, value, intf.Name)
+			klog.V(3).Infof("unknown statistics %s with value %d on OVS interface %s", key, value, intf.Name)
 		}
 	}
 }


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
W0624 01:56:48.254552    3413 util.go:233] unknown statistics upcall_packets with value 0 on OVS interface aa273774666b_h
W0624 01:56:48.254577    3413 util.go:233] unknown statistics upcall_errors with value 0 on OVS interface aa273774666b_h
W0624 01:56:48.254610    3413 util.go:233] unknown statistics upcall_packets with value 0 on OVS interface br-int
W0624 01:56:48.254618    3413 util.go:233] unknown statistics upcall_errors with value 0 on OVS interface br-int
W0624 01:56:48.254968    3413 util.go:233] unknown statistics upcall_packets with value 103 on OVS interface br-provider
W0624 01:56:48.254986    3413 util.go:233] unknown statistics upcall_errors with value 0 on OVS interface br-provider
W0624 01:56:48.255009    3413 util.go:233] unknown statistics upcall_packets with value 295 on OVS interface eth0
W0624 01:56:48.255026    3413 util.go:233] unknown statistics upcall_errors with value 0 on OVS interface eth0
```
