### PR TITLE
e2e: add curl parameters

### DIFF
--- a/test/e2e/kube-ovn/network-policy/network-policy.go
+++ b/test/e2e/kube-ovn/network-policy/network-policy.go
@@ -102,7 +102,7 @@ var _ = framework.SerialDescribe("[group:network-policy]", func() {
 		for _, podIP := range pod.Status.PodIPs {
 			ip := podIP.IP
 			protocol := strings.ToLower(util.CheckProtocol(ip))
-			cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 %s", net.JoinHostPort(ip, port))
+			cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s", net.JoinHostPort(ip, port))
 
 			var podSameNode *corev1.Pod
 			for _, hostPod := range pods {

--- a/test/e2e/kube-ovn/node/node.go
+++ b/test/e2e/kube-ovn/node/node.go
@@ -131,7 +131,7 @@ var _ = framework.OrderedDescribe("[group:node]", func() {
 			ip := podIP.IP
 			protocol := strings.ToLower(util.CheckProtocol(ip))
 			ginkgo.By("Checking connection from " + hostPodName + " to " + podName + " via " + protocol)
-			cmd := fmt.Sprintf("curl -q -s --connect-timeout 5 %s/clientip", net.JoinHostPort(ip, port))
+			cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s/clientip", net.JoinHostPort(ip, port))
 			ginkgo.By(fmt.Sprintf(`Executing %q in pod %s/%s`, cmd, namespaceName, hostPodName))
 			output := e2epodoutput.RunHostCmdOrDie(namespaceName, hostPodName, cmd)
 			client, _, err := net.SplitHostPort(strings.TrimSpace(output))
@@ -182,7 +182,7 @@ var _ = framework.OrderedDescribe("[group:node]", func() {
 		for _, ip := range util.ServiceClusterIPs(*service) {
 			protocol := strings.ToLower(util.CheckProtocol(ip))
 			ginkgo.By("Checking connection from " + hostPodName + " to " + serviceName + " via " + protocol)
-			cmd := fmt.Sprintf("curl -q -s --connect-timeout 5 %s/clientip", net.JoinHostPort(ip, portStr))
+			cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s/clientip", net.JoinHostPort(ip, portStr))
 			ginkgo.By(fmt.Sprintf(`Executing %q in pod %s/%s`, cmd, namespaceName, hostPodName))
 			output := e2epodoutput.RunHostCmdOrDie(namespaceName, hostPodName, cmd)
 			client, _, err := net.SplitHostPort(strings.TrimSpace(output))

--- a/test/e2e/kube-ovn/service/service.go
+++ b/test/e2e/kube-ovn/service/service.go
@@ -106,7 +106,7 @@ var _ = framework.Describe("[group:service]", func() {
 			}
 			protocol := strings.ToLower(util.CheckProtocol(nodeIP))
 			ginkgo.By("Checking " + protocol + " connection via node " + nodeName)
-			cmd := fmt.Sprintf("curl -q -s --connect-timeout 5 %s/clientip", util.JoinHostPort(nodeIP, nodePort))
+			cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s/clientip", util.JoinHostPort(nodeIP, nodePort))
 			framework.WaitUntil(2*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
 				ginkgo.By(fmt.Sprintf(`Executing %q in pod %s/%s`, cmd, namespaceName, hostPodName))
 				_, err := e2epodoutput.RunHostCmd(namespaceName, hostPodName, cmd)

--- a/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
+++ b/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
@@ -36,7 +36,7 @@ func generateSubnetName(name string) string {
 
 func curlSvc(f *framework.Framework, clientPodName, vip string, port int32) {
 	ginkgo.GinkgoHelper()
-	cmd := fmt.Sprintf("curl -q -s --connect-timeout 5 %s", util.JoinHostPort(vip, port))
+	cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s", util.JoinHostPort(vip, port))
 	ginkgo.By(fmt.Sprintf(`Executing %q in pod %s/%s`, cmd, f.Namespace.Name, clientPodName))
 	e2epodoutput.RunHostCmdOrDie(f.Namespace.Name, clientPodName, cmd)
 }

--- a/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
+++ b/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
@@ -36,7 +36,7 @@ func generateSubnetName(name string) string {
 
 func curlSvc(f *framework.Framework, clientPodName, vip string, port int32) {
 	ginkgo.GinkgoHelper()
-	cmd := fmt.Sprintf("curl %s", util.JoinHostPort(vip, port))
+	cmd := fmt.Sprintf("curl -q -s --connect-timeout 5 %s", util.JoinHostPort(vip, port))
 	ginkgo.By(fmt.Sprintf(`Executing %q in pod %s/%s`, cmd, f.Namespace.Name, clientPodName))
 	e2epodoutput.RunHostCmdOrDie(f.Namespace.Name, clientPodName, cmd)
 }

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -1051,7 +1051,7 @@ func checkReachable(podName, podNamespace, sourceIP, targetIP, targetPort string
 	ginkgo.GinkgoHelper()
 
 	ginkgo.By("checking curl reachable")
-	cmd := fmt.Sprintf("curl -q -s --connect-timeout 5 %s/clientip", net.JoinHostPort(targetIP, targetPort))
+	cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s/clientip", net.JoinHostPort(targetIP, targetPort))
 	output, err := e2epodoutput.RunHostCmd(podNamespace, podName, cmd)
 	if expectReachable {
 		framework.ExpectNoError(err)

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -133,7 +133,7 @@ var _ = framework.SerialDescribe("[group:ovn-ic]", func() {
 					ip := podIP.IP
 					protocol := strings.ToLower(util.CheckProtocol(ip))
 					ginkgo.By("Checking connection from cluster " + clusters[i] + " to cluster " + clusters[j] + " via " + protocol)
-					cmd := fmt.Sprintf("curl -q -s --connect-timeout 5 %s/clientip", net.JoinHostPort(ip, ports[j]))
+					cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s/clientip", net.JoinHostPort(ip, ports[j]))
 					output := execPodOrDie(frameworks[i].KubeContext, pods[i].Namespace, pods[i].Name, cmd)
 					client, _, err := net.SplitHostPort(strings.TrimSpace(output))
 					framework.ExpectNoError(err)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
  [FAILED] error running /opt/hostedtoolcache/kind/v0.22.0/amd64/kubectl/bin/kubectl --kubeconfig=/home/runner/.kube/config --namespace=slr-8636 exec client-436803287 -- /bin/sh -x -c curl [fd00:10:96::670f]:8090:
  Command stdout:

  stderr:
  + curl '[fd00:10:96::670f]:8090'
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
  ...
  0     0    0     0    0     0      0      0 --:--:--  0:02:10 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:02:11 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:02:12 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:02:13 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:02:14 --:--:--     0
  curl: (28) Failed to connect to fd00:10:96::670f port 8090 after 134102 ms: Operation timed out
  command terminated with exit code 28
```
