### PR TITLE
fix ipv6 service ip not added to ovn lb vips due to pod cache not synced

### DIFF
--- a/pkg/controller/endpoint.go
+++ b/pkg/controller/endpoint.go
@@ -106,7 +106,7 @@ func (c *Controller) handleUpdateEndpoint(key string) error {
 	defer func() { _ = c.epKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle update endpoint %s", key)
 
-	cachedEndpoint, err := c.endpointsLister.Endpoints(namespace).Get(name)
+	ep, err := c.endpointsLister.Endpoints(namespace).Get(name)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -114,7 +114,6 @@ func (c *Controller) handleUpdateEndpoint(key string) error {
 		klog.Error(err)
 		return err
 	}
-	ep := cachedEndpoint.DeepCopy()
 
 	cachedService, err := c.servicesLister.Services(namespace).Get(name)
 	if err != nil {

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -495,12 +495,7 @@ func (c *Controller) gcLoadBalancer() error {
 	)
 
 	for _, svc := range svcs {
-		ips := util.ServiceClusterIPs(*svc)
-		if v, ok := svc.Annotations[util.SwitchLBRuleVipsAnnotation]; ok {
-			ips = strings.Split(v, ",")
-		}
-
-		for _, ip := range ips {
+		for _, ip := range getVipIps(svc) {
 			for _, port := range svc.Spec.Ports {
 				vip := util.JoinHostPort(ip, port.Port)
 				switch port.Protocol {

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -382,11 +382,9 @@ func (c *Controller) handleUpdateService(key string) error {
 				return err
 			}
 
-			if !needUpdateEndpointQueue {
-				if _, ok := lb.Vips[vip]; !ok {
-					klog.Infof("add vip %s to LB %s", vip, lbName)
-					needUpdateEndpointQueue = true
-				}
+			if _, ok := lb.Vips[vip]; !ok {
+				klog.Infof("add vip %s to LB %s", vip, lbName)
+				needUpdateEndpointQueue = true
 			}
 		}
 		for vip := range lb.Vips {


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes occasional e2e test failure `should ovn nb change vip when dual-stack service removes the cluster ip`.
