### PR TITLE
do not exit if chassis is not found

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -856,8 +856,10 @@ func (c *Controller) initNodeChassis() error {
 	}
 	for _, node := range nodes {
 		if err := c.UpdateChassisTag(node); err != nil {
-			klog.Error(err)
-			return err
+			if _, ok := err.(*ErrChassisNotFound); !ok {
+				klog.Error(err)
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
I0701 15:24:37.427598      13 node.go:899] chassis not registered for node kube-ovn-control-plane, do chassis gc once
I0701 15:24:37.427716      13 gc.go:738] start to gc chassis
E0701 15:24:37.428693      13 init.go:859] chassis not registered for node kube-ovn-control-plane, will try again later
E0701 15:24:37.428893      13 klog.go:10] "failed to initialize node chassis" err="chassis not registered for node kube-ovn-control-plane, will try again later"
```
