### PR TITLE
ci: do not compile fastpath kernel module for centos

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -260,40 +260,6 @@ jobs:
           name: vpc-nat-gateway
           path: vpc-nat-gateway.tar
 
-  build-centos-compile:
-    name: Build centos-compile
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          android: true
-          dotnet: true
-          haskell: true
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-          swap-storage: false
-
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Build
-        run: |
-          make image-centos-compile
-          make tar-centos-compile
-
-      - name: Upload centos7-compile image to artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: centos7-compile
-          path: centos7-compile.tar
-
-      # - name: Upload centos8-compile image to artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: centos8-compile
-      #     path: centos8-compile.tar
-
   build-e2e-binaries:
     name: Build E2E Binaries
     runs-on: ubuntu-22.04
@@ -2531,7 +2497,6 @@ jobs:
   push:
     name: Push Images
     needs:
-      - build-centos-compile
       - k8s-conformance-e2e
       - k8s-netpol-e2e
       - k8s-netpol-legacy-e2e
@@ -2582,22 +2547,10 @@ jobs:
         with:
           name: vpc-nat-gateway
 
-      - name: Download centos7-compile image
-        uses: actions/download-artifact@v4
-        with:
-          name: centos7-compile
-
-      # - name: Download centos8-compile image
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: centos8-compile
-
       - name: Load image
         run: |
           docker load --input kube-ovn.tar
           docker load --input vpc-nat-gateway.tar
-          docker load --input centos7-compile.tar
-          # docker load --input centos8-compile.tar
           if [ '${{ github.event_name }}' != 'pull_request' ]; then
             docker load --input kube-ovn-dpdk.tar
           fi
@@ -2627,10 +2580,6 @@ jobs:
           docker tag kubeovn/kube-ovn:$TAG-dpdk kubeovn/kube-ovn:$TAG-dpdk-x86
           docker tag kubeovn/vpc-nat-gateway:$TAG kubeovn/vpc-nat-gateway-dev:$COMMIT-x86
           docker tag kubeovn/vpc-nat-gateway:$TAG kubeovn/vpc-nat-gateway:$TAG-x86
-          docker tag kubeovn/centos7-compile:$TAG kubeovn/centos7-compile-dev:$TAG-x86
-          docker tag kubeovn/centos7-compile:$TAG kubeovn/centos7-compile:$TAG-x86
-          # docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile-dev:$TAG-x86
-          # docker tag kubeovn/centos8-compile:$TAG kubeovn/centos8-compile:$TAG-x86
           docker images
           docker push kubeovn/kube-ovn:$TAG-x86
           docker push kubeovn/kube-ovn-dev:$COMMIT-x86
@@ -2638,7 +2587,3 @@ jobs:
           docker push kubeovn/kube-ovn:$TAG-dpdk-x86
           docker push kubeovn/vpc-nat-gateway:$TAG-x86
           docker push kubeovn/vpc-nat-gateway-dev:$COMMIT-x86
-          docker push kubeovn/centos7-compile:$TAG-x86
-          docker push kubeovn/centos7-compile-dev:$TAG-x86
-          # docker push kubeovn/centos8-compile:$TAG-x86
-          # docker push kubeovn/centos8-compile-dev:$TAG-x86


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

CentOS Linux 7 reached end of life (EOL) on June 30, 2024, and the workflow job always fails:

```txt
#7 [2/4] RUN yum install -y gcc elfutils-libelf-devel make perl python3 autoconf automake libtool rpm-build openssl-devel git     && git clone -b branch-2.16 --depth=1 https://github.com/openvswitch/ovs.git /ovs/     && yum erase -y git && yum clean all
#7 0.224 Loaded plugins: fastestmirror, ovl
#7 0.330 Determining fastest mirrors
#7 0.359 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
#7 0.359 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
#7 0.361 
#7 0.361 
#7 0.361  One of the configured repositories failed (Unknown),
#7 0.361  and yum doesn't have enough cached data to continue. At this point the only
#7 0.361  safe thing yum can do is fail. There are a few ways to work "fix" this:
#7 0.361 
#7 0.361      1. Contact the upstream for the repository and get them to fix the problem.
#7 0.361 
#7 0.361      2. Reconfigure the baseurl/etc. for the repository, to point to a working
#7 0.361         upstream. This is most often useful if you are using a newer
#7 0.361         distribution release than is supported by the repository (and the
#7 0.361         packages for the previous distribution release still work).
#7 0.3[61](https://github.com/zhangzujian/kube-ovn/actions/runs/9754157622/job/26920745295#step:5:62) 
#7 0.361      3. Run the command with the repository temporarily disabled
#7 0.361             yum --disablerepo=<repoid> ...
#7 0.361 
#7 0.361      4. Disable the repository permanently, so yum won't use it by default. Yum
#7 0.361         will then just ignore the repository until you permanently enable it
#7 0.361         again or use --enablerepo for temporary usage:
#7 0.361 
#7 0.361             yum-config-manager --disable <repoid>
#7 0.361         or
#7 0.361             subscription-manager repos --disable=<repoid>
#7 0.361 
#7 0.361      5. Configure the failing repository to be skipped, if it is unavailable.
#7 0.361         Note that yum will try to contact the repo. when it runs most commands,
#7 0.361         so will have to try and fail each time (and thus. yum will be be much
#7 0.361         slower). If it is a very temporary problem though, this is often a nice
#7 0.361         compromise:
#7 0.361 
#7 0.361             yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
#7 0.361 
#7 0.361 Cannot find a valid baseurl for repo: base/7/x86_[64](https://github.com/zhangzujian/kube-ovn/actions/runs/9754157622/job/26920745295#step:5:65)
```
