### PR TITLE
fix vpcnatgw image is not synced

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1026,9 +1026,13 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		// maintain l3 ha about the vpc external lrp binding to the gw chassis
 		c.OVNNbClient.MonitorBFD()
 	}
-
+	// TODO: we should merge these two vpc nat config into one config and resync them together
 	go wait.Until(func() {
 		c.resyncVpcNatGwConfig()
+	}, time.Second, ctx.Done())
+
+	go wait.Until(func() {
+		c.resyncVpcNatImage()
 	}, time.Second, ctx.Done())
 
 	go wait.Until(func() {

--- a/pkg/controller/service_lb.go
+++ b/pkg/controller/service_lb.go
@@ -69,10 +69,6 @@ func (c *Controller) checkAttachNetwork(svc *corev1.Service) error {
 }
 
 func (c *Controller) genLbSvcDeployment(svc *corev1.Service) (dp *v1.Deployment) {
-	if err := c.resyncVpcNatImage(); err != nil {
-		klog.Errorf("failed to resync vpc nat config, err: %v", err)
-		return nil
-	}
 	name := genLbSvcDpName(svc.Name)
 	labels := map[string]string{
 		"app":       name,

--- a/pkg/controller/vpc_lb.go
+++ b/pkg/controller/vpc_lb.go
@@ -66,10 +66,6 @@ func (c *Controller) deleteVpcLb(vpc *kubeovnv1.Vpc) error {
 }
 
 func (c *Controller) genVpcLbDeployment(vpc *kubeovnv1.Vpc) (*v1.Deployment, error) {
-	if err := c.resyncVpcNatImage(); err != nil {
-		klog.Errorf("failed to resync vpc nat config, err: %v", err)
-		return nil, err
-	}
 	if len(vpc.Status.Subnets) == 0 {
 		return nil, nil
 	}

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -10,19 +10,22 @@ import (
 
 var vpcNatImage = ""
 
-func (c *Controller) resyncVpcNatImage() error {
+func (c *Controller) resyncVpcNatImage() {
+	if vpcNatEnabled != "true" {
+		return
+	}
+
 	cm, err := c.configMapsLister.ConfigMaps(c.config.PodNamespace).Get(util.VpcNatConfig)
 	if err != nil {
 		err = fmt.Errorf("failed to get ovn-vpc-nat-config, %v", err)
 		klog.Error(err)
-		return err
+		return
 	}
 	image, exist := cm.Data["image"]
 	if !exist {
 		err = fmt.Errorf("%s should have image field", util.VpcNatConfig)
 		klog.Error(err)
-		return err
+		return
 	}
 	vpcNatImage = image
-	return nil
 }

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -87,10 +87,6 @@ func (c *Controller) resyncVpcNatGwConfig() {
 		klog.Errorf("failed to get vpc nat gateway, %v", err)
 		return
 	}
-	if err = c.resyncVpcNatImage(); err != nil {
-		klog.Errorf("failed to resync vpc nat config, err: %v", err)
-		return
-	}
 	vpcNatEnabled = "true"
 	VpcNatCmVersion = cm.ResourceVersion
 	for _, gw := range gws {


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

The vpc-nat-gw image will only be updated when both the `ovn-vpc-nat-gw-config` and `ovn-vpc-nat-config` are changed. This PR split the logical, now changing the vpc-nat-gw image only need to change the `ovn-vpc-nat-config`.

I have write an e2e about this and it passed. However, when running together with other cases I meet other issues when quickly adding and deleting vpc and subnet with same name. I will fix them later and add the e2e together in another PR.

<!-- 
Select one or more options that fit this PR.
-->
- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
