### PR TITLE
when router is deleted return success for static route deletion

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -136,10 +136,15 @@ func (c *OVNNbClient) UpdateLogicalRouterStaticRoute(route *ovnnb.LogicalRouterS
 	return nil
 }
 
-// DeleteLogicalRouterStaticRoute add a logical router static route
+// DeleteLogicalRouterStaticRoute delete a logical router static route
 func (c *OVNNbClient) DeleteLogicalRouterStaticRoute(lrName string, routeTable, policy *string, ipPrefix, nexthop string) error {
 	if policy == nil || len(*policy) == 0 {
 		policy = ptr.To(ovnnb.LogicalRouterStaticRoutePolicyDstIP)
+	}
+
+	lr, err := c.GetLogicalRouter(lrName, true)
+	if lr == nil && err == nil {
+		return nil
 	}
 
 	routes, err := c.ListLogicalRouterStaticRoutes(lrName, routeTable, policy, ipPrefix, nil)


### PR DESCRIPTION
Signed-off-by: oilbeater <liumengxinfly@gmail.com># Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

When in E2E vpc may be deleted before related subnet. Then subnet cannot delete the static route as the router is already not exist.

<!-- 
Select one or more options that fit this PR.
-->
- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
