### PR TITLE
logrotate: set file size limit to 100M

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -6,7 +6,7 @@ FROM kubeovn/kube-ovn-base:$BASE_TAG
 COPY *.sh /kube-ovn/
 COPY kubectl-ko /kube-ovn/kubectl-ko
 COPY 01-kube-ovn.conflist /kube-ovn/01-kube-ovn.conflist
-COPY logrotate/* /etc/logrotate.d/
+COPY --chmod=0644 logrotate/* /etc/logrotate.d/
 COPY grace_stop_ovn_controller /usr/share/ovn/scripts/grace_stop_ovn_controller
 
 WORKDIR /kube-ovn

--- a/dist/images/logrotate/kubeovn
+++ b/dist/images/logrotate/kubeovn
@@ -9,6 +9,7 @@
     daily
     copytruncate
     rotate 7
+    size 100M
     compress
     sharedscripts
     missingok

--- a/dist/images/logrotate/openvswitch
+++ b/dist/images/logrotate/openvswitch
@@ -8,6 +8,7 @@
 /var/log/openvswitch/*.log {
     daily
     rotate 7
+    size 100M
     compress
     sharedscripts
     missingok

--- a/dist/images/logrotate/ovn
+++ b/dist/images/logrotate/ovn
@@ -8,6 +8,7 @@
 /var/log/ovn/*.log {
     daily
     rotate 7
+    size 100M
     compress
     sharedscripts
     missingok


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

1. Limit log file size to 100M;
2. Ensure logrotate config file permission is correct.

```txt
Potentially dangerous mode on /etc/logrotate.d/ovn: 0664
error: Ignoring /etc/logrotate.d/ovn because it is writable by group or others.
```
