### PR TITLE
underlay: set trunks of host nic port

### DIFF
--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -197,6 +197,7 @@ rules:
       - "kubeovn.io"
     resources:
       - subnets
+      - vlans
       - provider-networks
     verbs:
       - get

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3118,6 +3118,7 @@ rules:
       - "kubeovn.io"
     resources:
       - subnets
+      - vlans
       - provider-networks
     verbs:
       - get

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -97,7 +97,7 @@ func InitMirror(config *Configuration) error {
 	return configureEmptyMirror(config.MirrorNic, config.MTU)
 }
 
-func (c *Controller) ovsInitProviderNetwork(provider, nic string, exchangeLinkName, macLearningFallback bool) (int, error) {
+func (c *Controller) ovsInitProviderNetwork(provider, nic string, trunks []string, exchangeLinkName, macLearningFallback bool) (int, error) {
 	// create and configure external bridge
 	brName := util.ExternalBridgeName(provider)
 	if exchangeLinkName {
@@ -127,7 +127,7 @@ func (c *Controller) ovsInitProviderNetwork(provider, nic string, exchangeLinkNa
 
 	// add host nic to the external bridge
 	klog.Infof("config provider nic %s on bridge %s", nic, brName)
-	mtu, err := c.configProviderNic(nic, brName)
+	mtu, err := c.configProviderNic(nic, brName, trunks)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to add nic %s to external bridge %s: %v", nic, brName, err)
 		klog.Error(errMsg)

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1327,7 +1327,7 @@ func (c *Controller) transferAddrsAndRoutes(nicName, brName string, delNonExiste
 
 // Add host nic to external bridge
 // Mac address, MTU, IP addresses & routes will be copied/transferred to the external bridge
-func (c *Controller) configProviderNic(nicName, brName string) (int, error) {
+func (c *Controller) configProviderNic(nicName, brName string, trunks []string) (int, error) {
 	sysctlDisableIPv6 := fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6", brName)
 	disableIPv6, err := sysctl.Sysctl(sysctlDisableIPv6)
 	if err != nil {
@@ -1345,7 +1345,7 @@ func (c *Controller) configProviderNic(nicName, brName string) (int, error) {
 	}
 
 	if _, err = ovs.Exec(ovs.MayExist, "add-port", brName, nicName,
-		"--", "set", "port", nicName, "external_ids:vendor="+util.CniTypeName); err != nil {
+		"--", "set", "port", nicName, "trunks="+strings.Join(trunks, ","), "external_ids:vendor="+util.CniTypeName); err != nil {
 		return 0, fmt.Errorf("failed to add %s to OVS bridge %s: %v", nicName, brName, err)
 	}
 	klog.V(3).Infof("ovs port %s has been added to bridge %s", nicName, brName)

--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -377,7 +377,7 @@ func configureMirrorLink(portName string, mtu int) error {
 	return nil
 }
 
-func (c *Controller) configProviderNic(nicName, brName string) (int, error) {
+func (c *Controller) configProviderNic(nicName, brName string, trunks []string) (int, error) {
 	// nothing to do on Windows
 	return 0, nil
 }


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Set port trunks to filter out traffic from unused VLAN networks.

Fix ovs-vswitchd high cpu usage when too many broadcast packets received through the host nic.
