### PR TITLE
Add BGP capabilities to the NAT GW

### DIFF
--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -503,6 +503,15 @@ spec:
                     type: string
                 qosPolicy:
                   type: string
+                bgpSpeaker:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    parameters:
+                      type: array
+                      items:
+                        type: string
                 tolerations:
                   type: array
                   items:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -508,7 +508,23 @@ spec:
                   properties:
                     enabled:
                       type: boolean
-                    parameters:
+                    asn:
+                      type: integer
+                    remoteAsn:
+                      type: integer
+                    neighbors:
+                      type: array
+                      items:
+                        type: string
+                    holdTime:
+                      type: string
+                    routerId:
+                      type: string
+                    password:
+                      type: string
+                    enableGracefulRestart:
+                      type: boolean
+                    extraArgs:
                       type: array
                       items:
                         type: string

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -746,7 +746,23 @@ spec:
                   properties:
                     enabled:
                       type: boolean
-                    parameters:
+                    asn:
+                      type: integer
+                    remoteAsn:
+                      type: integer
+                    neighbors:
+                      type: array
+                      items:
+                        type: string
+                    holdTime:
+                      type: string
+                    routerId:
+                      type: string
+                    password:
+                      type: string
+                    enableGracefulRestart:
+                      type: boolean
+                    extraArgs:
                       type: array
                       items:
                         type: string

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -741,6 +741,15 @@ spec:
                     type: string
                 qosPolicy:
                   type: string
+                bgpSpeaker:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    parameters:
+                      type: array
+                      items:
+                        type: string
                 tolerations:
                   type: array
                   items:

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -524,6 +524,12 @@ type VpcNatSpec struct {
 	Tolerations     []corev1.Toleration `json:"tolerations"`
 	Affinity        corev1.Affinity     `json:"affinity"`
 	QoSPolicy       string              `json:"qosPolicy"`
+	BgpSpeaker      VpcBgpSpeaker       `json:"bgpSpeaker"`
+}
+
+type VpcBgpSpeaker struct {
+	Enabled    bool     `json:"enabled"`
+	Parameters []string `json:"parameters"`
 }
 
 type VpcNatStatus struct {

--- a/pkg/apis/kubeovn/v1/types.go
+++ b/pkg/apis/kubeovn/v1/types.go
@@ -528,8 +528,15 @@ type VpcNatSpec struct {
 }
 
 type VpcBgpSpeaker struct {
-	Enabled    bool     `json:"enabled"`
-	Parameters []string `json:"parameters"`
+	Enabled               bool            `json:"enabled"`
+	ASN                   uint32          `json:"asn"`
+	RemoteASN             uint32          `json:"remoteAsn"`
+	Neighbors             []string        `json:"neighbors"`
+	HoldTime              metav1.Duration `json:"holdTime"`
+	RouterID              string          `json:"routerId"`
+	Password              string          `json:"password"`
+	EnableGracefulRestart bool            `json:"enableGracefulRestart"`
+	ExtraArgs             []string        `json:"extraArgs"`
 }
 
 type VpcNatStatus struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1112,7 +1112,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 	}, time.Second, ctx.Done())
 
 	go wait.Until(func() {
-		c.resyncVpcNatImage()
+		c.resyncVpcNatConfig()
 	}, time.Second, ctx.Done())
 
 	go wait.Until(func() {

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -11,6 +11,7 @@ import (
 var (
 	vpcNatImage             = ""
 	vpcNatGwBgpSpeakerImage = ""
+	vpcNatAPINadName        = ""
 	vpcNatAPINadProvider    = ""
 )
 
@@ -34,6 +35,9 @@ func (c *Controller) resyncVpcNatConfig() {
 	// Image for the BGP sidecar of the gateway (optional)
 	vpcNatGwBgpSpeakerImage = cm.Data["bgpSpeakerImage"]
 
-	// NetworkAttachmentDefinition for the BGP speaker to call the API server
+	// NetworkAttachmentDefinition name for the BGP speaker to call the API server
+	vpcNatAPINadName = cm.Data["apiNadName"]
+
+	// NetworkAttachmentDefinition provider for the BGP speaker to call the API server
 	vpcNatAPINadProvider = cm.Data["apiNadProvider"]
 }

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -29,7 +29,6 @@ func (c *Controller) resyncVpcNatImage() {
 
 	enableBgpSpeaker, exist := cm.Data["enableBgpSpeaker"]
 	if exist && enableBgpSpeaker == "true" {
-		klog.V(5).Infof("experimental BGP speaker enabled")
 		vpcNatEnableBgpSpeaker = true
 	}
 }

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"k8s.io/klog/v2"
 )

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -11,7 +11,7 @@ import (
 var (
 	vpcNatImage             = ""
 	vpcNatGwBgpSpeakerImage = ""
-	vpcNatApiNadProvider    = ""
+	vpcNatAPINadProvider    = ""
 )
 
 func (c *Controller) resyncVpcNatConfig() {
@@ -35,5 +35,5 @@ func (c *Controller) resyncVpcNatConfig() {
 	vpcNatGwBgpSpeakerImage = cm.Data["bgpSpeakerImage"]
 
 	// NetworkAttachmentDefinition for the BGP speaker to call the API server
-	vpcNatApiNadProvider = cm.Data["apiNadProvider"]
+	vpcNatAPINadProvider = cm.Data["apiNadProvider"]
 }

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -9,9 +9,8 @@ import (
 )
 
 var (
-	vpcNatImage              = ""
-	vpcNatGwEnableBgpSpeaker = false
-	vpcNatGwBgpSpeakerImage  = ""
+	vpcNatImage             = ""
+	vpcNatGwBgpSpeakerImage = ""
 )
 
 func (c *Controller) resyncVpcNatImage() {
@@ -30,16 +29,5 @@ func (c *Controller) resyncVpcNatImage() {
 	}
 	vpcNatImage = image
 
-	// Check BGP is enabled on the NAT GW, if yes, verify required parameters are present
-	enableBgpSpeaker, exist := cm.Data["enableBgpSpeaker"]
-	if exist && enableBgpSpeaker == "true" {
-		vpcNatGwEnableBgpSpeaker = true
-
-		vpcNatGwBgpSpeakerImage, exist = cm.Data["bgpSpeakerImage"]
-		if !exist {
-			err = fmt.Errorf("%s should have bgp speaker image field if bgp enabled", util.VpcNatConfig)
-			klog.Error(err)
-			return
-		}
-	}
+	vpcNatGwBgpSpeakerImage = cm.Data["bgpSpeakerImage"]
 }

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -11,9 +11,10 @@ import (
 var (
 	vpcNatImage             = ""
 	vpcNatGwBgpSpeakerImage = ""
+	vpcNatApiNadProvider    = ""
 )
 
-func (c *Controller) resyncVpcNatImage() {
+func (c *Controller) resyncVpcNatConfig() {
 	cm, err := c.configMapsLister.ConfigMaps(c.config.PodNamespace).Get(util.VpcNatConfig)
 	if err != nil {
 		err = fmt.Errorf("failed to get ovn-vpc-nat-config, %w", err)
@@ -21,6 +22,7 @@ func (c *Controller) resyncVpcNatImage() {
 		return
 	}
 
+	// Image we're using to provision the NAT gateways
 	image, exist := cm.Data["image"]
 	if !exist {
 		err = fmt.Errorf("%s should have image field", util.VpcNatConfig)
@@ -29,5 +31,9 @@ func (c *Controller) resyncVpcNatImage() {
 	}
 	vpcNatImage = image
 
+	// Image for the BGP sidecar of the gateway (optional)
 	vpcNatGwBgpSpeakerImage = cm.Data["bgpSpeakerImage"]
+
+	// NetworkAttachmentDefinition for the BGP speaker to call the API server
+	vpcNatApiNadProvider = cm.Data["apiNadProvider"]
 }

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -2,13 +2,14 @@ package controller
 
 import (
 	"fmt"
-
-	"k8s.io/klog/v2"
-
 	"github.com/kubeovn/kube-ovn/pkg/util"
+	"k8s.io/klog/v2"
 )
 
-var vpcNatImage = ""
+var (
+	vpcNatImage            = ""
+	vpcNatEnableBgpSpeaker = false
+)
 
 func (c *Controller) resyncVpcNatImage() {
 	cm, err := c.configMapsLister.ConfigMaps(c.config.PodNamespace).Get(util.VpcNatConfig)
@@ -17,6 +18,7 @@ func (c *Controller) resyncVpcNatImage() {
 		klog.Error(err)
 		return
 	}
+
 	image, exist := cm.Data["image"]
 	if !exist {
 		err = fmt.Errorf("%s should have image field", util.VpcNatConfig)
@@ -24,4 +26,10 @@ func (c *Controller) resyncVpcNatImage() {
 		return
 	}
 	vpcNatImage = image
+
+	enableBgpSpeaker, exist := cm.Data["enableBgpSpeaker"]
+	if exist && enableBgpSpeaker == "true" {
+		klog.V(5).Infof("experimental BGP speaker enabled")
+		vpcNatEnableBgpSpeaker = true
+	}
 }

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	vpcNatImage            = ""
-	vpcNatEnableBgpSpeaker = false
+	vpcNatImage              = ""
+	vpcNatGwEnableBgpSpeaker = false
+	vpcNatGwBgpSpeakerImage  = ""
 )
 
 func (c *Controller) resyncVpcNatImage() {
@@ -27,8 +28,16 @@ func (c *Controller) resyncVpcNatImage() {
 	}
 	vpcNatImage = image
 
+	// Check BGP is enabled on the NAT GW, if yes, verify required parameters are present
 	enableBgpSpeaker, exist := cm.Data["enableBgpSpeaker"]
 	if exist && enableBgpSpeaker == "true" {
-		vpcNatEnableBgpSpeaker = true
+		vpcNatGwEnableBgpSpeaker = true
+
+		vpcNatGwBgpSpeakerImage, exist = cm.Data["bgpSpeakerImage"]
+		if !exist {
+			err = fmt.Errorf("%s should have bgp speaker image field if bgp enabled", util.VpcNatConfig)
+			klog.Error(err)
+			return
+		}
 	}
 }

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -3,8 +3,9 @@ package controller
 import (
 	"fmt"
 
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 var (

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -758,7 +758,7 @@ func setNatGwRoute(annotations map[string]string, subnetGw string) error {
 
 	// Check the API NetworkAttachmentDefinition exists, otherwise we won't be able to attach
 	// the BGP speaker to a network that has access to the K8S apiserver (and won't be able to detect EIPs)
-	if vpcNatApiNadProvider == "" {
+	if vpcNatAPINadProvider == "" {
 		return fmt.Errorf("no NetworkAttachmentDefinition provided to access apiserver, check configmap ovn-vpc-nat-config and field 'apiNadProvider'")
 	}
 
@@ -768,9 +768,9 @@ func setNatGwRoute(annotations map[string]string, subnetGw string) error {
 			buf, err := json.Marshal(routes)
 			if err != nil {
 				return fmt.Errorf("failed to marshal routes %+v: %v", routes, err)
-			} else {
-				annotations[fmt.Sprintf(util.RoutesAnnotationTemplate, vpcNatApiNadProvider)] = string(buf)
 			}
+
+			annotations[fmt.Sprintf(util.RoutesAnnotationTemplate, vpcNatAPINadProvider)] = string(buf)
 			break
 		}
 	}

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -847,6 +847,12 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 								Privileged:               ptr.To(true),
 								AllowPrivilegeEscalation: ptr.To(true),
 							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "GATEWAY_NAME",
+									Value: gw.Name,
+								},
+							},
 						},
 					},
 					NodeSelector: selectors,

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -782,7 +782,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 		util.IPAddressAnnotation:         gw.Spec.LanIP,
 	}
 
-	if vpcNatEnableBgpSpeaker { // Add an interface that can reach the API server
+	if vpcNatGwEnableBgpSpeaker { // Add an interface that can reach the API server
 		defaultSubnet, err := c.subnetsLister.Get(c.config.DefaultLogicalSwitch)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get default subnet %s: %v", c.config.DefaultLogicalSwitch, err)
@@ -905,13 +905,13 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 		},
 	}
 
-	if vpcNatEnableBgpSpeaker {
+	if vpcNatGwEnableBgpSpeaker {
 		containers := sts.Spec.Template.Spec.Containers
 
 		sts.Spec.Template.Spec.ServiceAccountName = "vpc-nat-gw"
 		speakerContainer := corev1.Container{
 			Name:            "vpc-nat-gw-speaker",
-			Image:           "superphenix.net/kubeovn:latest",
+			Image:           vpcNatGwBgpSpeakerImage,
 			Command:         []string{"/kube-ovn/kube-ovn-speaker"},
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Env: []corev1.EnvVar{

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -1,0 +1,155 @@
+package speaker
+
+import (
+	"context"
+	"fmt"
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	bgpapi "github.com/osrg/gobgp/v3/api"
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+	"github.com/vishvananda/netlink"
+	"google.golang.org/protobuf/types/known/anypb"
+	"k8s.io/klog/v2"
+	"net"
+)
+
+// addRoute adds a new route to advertise from our BGP speaker
+func (c *Controller) addRoute(route string) error {
+	// Determine the Address Family Indicator (IPv6/IPv4)
+	routeAfi := bgpapi.Family_AFI_IP
+	if util.CheckProtocol(route) == kubeovnv1.ProtocolIPv6 {
+		routeAfi = bgpapi.Family_AFI_IP6
+	}
+
+	// Get NLRI and attributes to announce all the next hops possible
+	nlri, attrs, err := c.getNlriAndAttrs(route)
+	if err != nil {
+		return fmt.Errorf("failed to get NLRI and attributes: %w", nlri)
+	}
+
+	// Announce every next hop we have
+	for _, attr := range attrs {
+		_, err = c.config.BgpServer.AddPath(context.Background(), &bgpapi.AddPathRequest{
+			Path: &bgpapi.Path{
+				Family: &bgpapi.Family{Afi: routeAfi, Safi: bgpapi.Family_SAFI_UNICAST},
+				Nlri:   nlri,
+				Pattrs: attr,
+			},
+		})
+
+		if err != nil {
+			klog.Errorf("add path failed, %v", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// delRoute removes a route we are currently advertising from our BGP speaker
+func (c *Controller) delRoute(route string) error {
+	// Determine the Address Family Indicator (IPv6/IPv4)
+	routeAfi := bgpapi.Family_AFI_IP
+	if util.CheckProtocol(route) == kubeovnv1.ProtocolIPv6 {
+		routeAfi = bgpapi.Family_AFI_IP6
+	}
+
+	// Get NLRI and attributes to announce all the next hops possible
+	nlri, attrs, err := c.getNlriAndAttrs(route)
+	if err != nil {
+		return fmt.Errorf("failed to get NLRI and attributes: %w", nlri)
+	}
+
+	// Withdraw every next hop we have
+	for _, attr := range attrs {
+		err = c.config.BgpServer.DeletePath(context.Background(), &bgpapi.DeletePathRequest{
+			Path: &bgpapi.Path{
+				Family: &bgpapi.Family{Afi: routeAfi, Safi: bgpapi.Family_SAFI_UNICAST},
+				Nlri:   nlri,
+				Pattrs: attr,
+			},
+		})
+		if err != nil {
+			klog.Errorf("del path failed, %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// getNlriAndAttrs returns the Network Layer Reachability Information (NLRI) and the BGP attributes for a particular route
+func (c *Controller) getNlriAndAttrs(route string) (*anypb.Any, [][]*anypb.Any, error) {
+	// Should this route be advertised to IPv4 or IPv6 peers
+	// GoBGP supports extended-nexthop, we should be able to advertise IPv4 NRLI to IPv6 peer and the opposite to
+	// Is this check really necessary?
+	neighborAddresses := c.config.NeighborAddresses
+	if util.CheckProtocol(route) == kubeovnv1.ProtocolIPv6 {
+		neighborAddresses = c.config.NeighborIPv6Addresses
+	}
+
+	// Get the route we're about to advertise and transform it to an NLRI
+	prefix, prefixLen, err := parseRoute(route)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse route: %w", err)
+	}
+
+	// Marshal the NLRI
+	nlri, err := anypb.New(&bgpapi.IPAddressPrefix{
+		Prefix:    prefix,
+		PrefixLen: prefixLen,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal NLRI: %w", err)
+	}
+
+	// Create attributes for each neighbor to advertise the correct next hop
+	attrs := make([][]*anypb.Any, 0, len(neighborAddresses))
+	for _, addr := range neighborAddresses {
+		a1, _ := anypb.New(&bgpapi.OriginAttribute{
+			Origin: 0,
+		})
+		a2, _ := anypb.New(&bgpapi.NextHopAttribute{
+			NextHop: c.getNextHopAttribute(addr),
+		})
+		attrs = append(attrs, []*anypb.Any{a1, a2})
+	}
+
+	return nlri, attrs, err
+}
+
+// getNextHopAttribute returns the next hop we should advertise for a specific BGP neighbor
+func (c *Controller) getNextHopAttribute(neighborAddress string) string {
+	nextHop := c.config.RouterID // If no route is found, fallback to router ID
+
+	// Retrieve the route we use to speak to this neighbor and consider the source as next hop
+	routes, err := netlink.RouteGet(net.ParseIP(neighborAddress))
+	if err == nil && len(routes) == 1 && routes[0].Src != nil {
+		nextHop = routes[0].Src.String()
+	}
+
+	proto := util.CheckProtocol(nextHop) // Is next hop IPv4 or IPv6
+	nextHopIP := net.ParseIP(nextHop)    // Convert next hop to an IP
+
+	// This takes care of a special case where the speaker might not be running in host mode
+	// If this happens, the nextHopIP will be the IP of a Pod (probably unreachable for the neighbours)
+	// For this case, the configuration allows for manually specifying the IPs to use as next hop (per protocol)
+	nodeIP := c.config.NodeIPs[proto]
+	if nodeIP != nil && nextHopIP != nil && nextHopIP.Equal(c.config.PodIPs[proto]) {
+		nextHop = nodeIP.String()
+	}
+
+	return nextHop
+}
+
+// getNextHopFromPathAttributes returns the next hop from BGP path attributes
+func getNextHopFromPathAttributes(attrs []bgp.PathAttributeInterface) net.IP {
+	for _, attr := range attrs {
+		switch a := attr.(type) {
+		case *bgp.PathAttributeNextHop:
+			return a.Value
+		case *bgp.PathAttributeMpReachNLRI:
+			return a.Nexthop
+		}
+	}
+	return nil
+}

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -112,7 +112,7 @@ func (c *Controller) addRoute(route string) error {
 	// Get NLRI and attributes to announce all the next hops possible
 	nlri, attrs, err := c.getNlriAndAttrs(route)
 	if err != nil {
-		return fmt.Errorf("failed to get NLRI and attributes: %w", nlri)
+		return fmt.Errorf("failed to get NLRI and attributes: %w", err)
 	}
 
 	// Announce every next hop we have
@@ -144,7 +144,7 @@ func (c *Controller) delRoute(route string) error {
 	// Get NLRI and attributes to announce all the next hops possible
 	nlri, attrs, err := c.getNlriAndAttrs(route)
 	if err != nil {
-		return fmt.Errorf("failed to get NLRI and attributes: %w", nlri)
+		return fmt.Errorf("failed to get NLRI and attributes: %w", err)
 	}
 
 	// Withdraw every next hop we have

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	bgpapi "github.com/osrg/gobgp/v3/api"
 	bgpapiutil "github.com/osrg/gobgp/v3/pkg/apiutil"
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
@@ -14,11 +12,12 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/types/known/anypb"
 	"k8s.io/klog/v2"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-var (
-	maskMap = map[string]int{kubeovnv1.ProtocolIPv4: 32, kubeovnv1.ProtocolIPv6: 128}
-)
+var maskMap = map[string]int{kubeovnv1.ProtocolIPv4: 32, kubeovnv1.ProtocolIPv6: 128}
 
 // reconciliateRoutes configures the BGP speaker to announce only the routes we are expected to announce
 // and to withdraw the ones that should not be announced anymore
@@ -125,7 +124,6 @@ func (c *Controller) addRoute(route string) error {
 				Pattrs: attr,
 			},
 		})
-
 		if err != nil {
 			return err
 		}

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -3,6 +3,8 @@ package speaker
 import (
 	"context"
 	"fmt"
+	"net"
+
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	bgpapi "github.com/osrg/gobgp/v3/api"
@@ -12,7 +14,6 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/types/known/anypb"
 	"k8s.io/klog/v2"
-	"net"
 )
 
 var (

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -19,29 +19,29 @@ import (
 
 var maskMap = map[string]int{kubeovnv1.ProtocolIPv4: 32, kubeovnv1.ProtocolIPv6: 128}
 
-// reconciliateRoutes configures the BGP speaker to announce only the routes we are expected to announce
+// reconcileRoutes configures the BGP speaker to announce only the routes we are expected to announce
 // and to withdraw the ones that should not be announced anymore
-func (c *Controller) reconciliateRoutes(expectedPrefixes prefixMap) error {
+func (c *Controller) reconcileRoutes(expectedPrefixes prefixMap) error {
 	if len(c.config.NeighborAddresses) != 0 {
-		err := c.reconciliateIPFamily(kubeovnv1.ProtocolIPv4, expectedPrefixes)
+		err := c.reconcileIPFamily(kubeovnv1.ProtocolIPv4, expectedPrefixes)
 		if err != nil {
-			return fmt.Errorf("failed to reconciliate IPv4 routes: %w", err)
+			return fmt.Errorf("failed to reconcile IPv4 routes: %w", err)
 		}
 	}
 
 	if len(c.config.NeighborIPv6Addresses) != 0 {
-		err := c.reconciliateIPFamily(kubeovnv1.ProtocolIPv6, expectedPrefixes)
+		err := c.reconcileIPFamily(kubeovnv1.ProtocolIPv6, expectedPrefixes)
 		if err != nil {
-			return fmt.Errorf("failed to reconciliate IPv6 routes: %w", err)
+			return fmt.Errorf("failed to reconcile IPv6 routes: %w", err)
 		}
 	}
 
 	return nil
 }
 
-// reconciliateIPFamily announces prefixes we are not currently announcing and withdraws prefixes we should
+// reconcileIPFamily announces prefixes we are not currently announcing and withdraws prefixes we should
 // not be announcing for a given IP family (IPv4/IPv6)
-func (c *Controller) reconciliateIPFamily(ipFamily string, expectedPrefixes prefixMap) error {
+func (c *Controller) reconcileIPFamily(ipFamily string, expectedPrefixes prefixMap) error {
 	// Get the address family associated with the Kube-OVN family
 	afi, err := kubeOvnFamilyToAFI(ipFamily)
 	if err != nil {

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -70,7 +70,7 @@ func (c *Controller) reconciliateIPFamily(ipFamily string, expectedPrefixes pref
 		}
 	}
 
-	// Ask the BGP speaker what routes we're announcing for the IP family selected
+	// Ask the BGP speaker what route we're announcing for the IP family selected
 	if err := c.config.BgpServer.ListPath(context.Background(), listPathRequest, fn); err != nil {
 		return fmt.Errorf("failed to list existing %s routes: %w", ipFamily, err)
 	}

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -55,6 +55,7 @@ type Configuration struct {
 	GracefulRestartTime         time.Duration
 	PassiveMode                 bool
 	EbgpMultihopTTL             uint8
+	EIPAnnouncement             bool
 
 	NodeName       string
 	KubeConfigFile string
@@ -83,8 +84,9 @@ func ParseFlags() (*Configuration, error) {
 		argPprofPort                   = pflag.Uint32("pprof-port", DefaultPprofPort, "The port to get profiling data, default: 10667")
 		argNodeName                    = pflag.String("node-name", os.Getenv(util.HostnameEnv), "Name of the node on which the speaker is running on.")
 		argKubeConfigFile              = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
-		argPassiveMode                 = pflag.BoolP("passivemode", "", false, "Set BGP Speaker to passive model,do not actively initiate connections to peers")
+		argPassiveMode                 = pflag.BoolP("passivemode", "", false, "Set BGP Speaker to passive model, do not actively initiate connections to peers")
 		argEbgpMultihopTTL             = pflag.Uint8("ebgp-multihop", DefaultEbgpMultiHop, "The TTL value of EBGP peer, default: 1")
+		argEIPAnnouncement             = pflag.BoolP("eip-announcement", "", false, "Make the BGP speaker announce EIPs from gateways")
 	)
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -148,6 +150,7 @@ func ParseFlags() (*Configuration, error) {
 		GracefulRestartTime:         *argDefaultGracefulTime,
 		PassiveMode:                 *argPassiveMode,
 		EbgpMultihopTTL:             *argEbgpMultihopTTL,
+		EIPAnnouncement:             *argEIPAnnouncement,
 	}
 
 	if *argNeighborAddress != "" {

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -68,8 +68,8 @@ func ParseFlags() (*Configuration, error) {
 	var (
 		argDefaultGracefulTime         = pflag.Duration("graceful-restart-time", DefaultGracefulRestartTime, "BGP Graceful restart time according to RFC4724 3, maximum 4095s.")
 		argGracefulRestartDeferralTime = pflag.Duration("graceful-restart-deferral-time", DefaultGracefulRestartDeferralTime, "BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h.")
-		argGracefulRestart             = pflag.BoolP("graceful-restart", "", false, "Enables the BGP Graceful Restart  so that routes are preserved on unexpected restarts")
-		argAnnounceClusterIP           = pflag.BoolP("announce-cluster-ip", "", false, "The Cluster IP of the service to  announce to the BGP peers.")
+		argGracefulRestart             = pflag.BoolP("graceful-restart", "", false, "Enables the BGP Graceful Restart so that routes are preserved on unexpected restarts")
+		argAnnounceClusterIP           = pflag.BoolP("announce-cluster-ip", "", false, "The Cluster IP of the service to announce to the BGP peers.")
 		argGrpcHost                    = pflag.String("grpc-host", "127.0.0.1", "The host address for grpc to listen, default: 127.0.0.1")
 		argGrpcPort                    = pflag.Uint32("grpc-port", DefaultBGPGrpcPort, "The port for grpc to listen, default:50051")
 		argClusterAs                   = pflag.Uint32("cluster-as", DefaultBGPClusterAs, "The as number of container network, default 65000")

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -55,7 +55,7 @@ type Configuration struct {
 	GracefulRestartTime         time.Duration
 	PassiveMode                 bool
 	EbgpMultihopTTL             uint8
-	EIPAnnouncement             bool
+	NatGwMode                   bool
 
 	NodeName       string
 	KubeConfigFile string
@@ -86,7 +86,7 @@ func ParseFlags() (*Configuration, error) {
 		argKubeConfigFile              = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
 		argPassiveMode                 = pflag.BoolP("passivemode", "", false, "Set BGP Speaker to passive model, do not actively initiate connections to peers")
 		argEbgpMultihopTTL             = pflag.Uint8("ebgp-multihop", DefaultEbgpMultiHop, "The TTL value of EBGP peer, default: 1")
-		argEIPAnnouncement             = pflag.BoolP("eip-announcement", "", false, "Make the BGP speaker announce EIPs from gateways")
+		argNatGwMode                   = pflag.BoolP("nat-gw-mode", "", false, "Make the BGP speaker announce EIPs from inside a NAT gateway, Pod IP/Service/Subnet announcements will be disabled")
 	)
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -150,7 +150,7 @@ func ParseFlags() (*Configuration, error) {
 		GracefulRestartTime:         *argDefaultGracefulTime,
 		PassiveMode:                 *argPassiveMode,
 		EbgpMultihopTTL:             *argEbgpMultihopTTL,
-		EIPAnnouncement:             *argEIPAnnouncement,
+		NatGwMode:                   *argNatGwMode,
 	}
 
 	if *argNeighborAddress != "" {

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -73,7 +73,7 @@ func ParseFlags() (*Configuration, error) {
 		argAnnounceClusterIP           = pflag.BoolP("announce-cluster-ip", "", false, "The Cluster IP of the service to announce to the BGP peers.")
 		argGrpcHost                    = pflag.String("grpc-host", "127.0.0.1", "The host address for grpc to listen, default: 127.0.0.1")
 		argGrpcPort                    = pflag.Uint32("grpc-port", DefaultBGPGrpcPort, "The port for grpc to listen, default:50051")
-		argClusterAs                   = pflag.Uint32("cluster-as", DefaultBGPClusterAs, "The as number of container network, default 65000")
+		argClusterAs                   = pflag.Uint32("cluster-as", DefaultBGPClusterAs, "The AS number of container network, default 65000")
 		argRouterID                    = pflag.String("router-id", "", "The address for the speaker to use as router id, default the node ip")
 		argNodeIPs                     = pflag.String("node-ips", "", "The comma-separated list of node IP addresses to use instead of the pod IP address for the next hop router IP address.")
 		argNeighborAddress             = pflag.String("neighbor-address", "", "Comma separated IPv4 router addresses the speaker connects to.")

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -1,8 +1,9 @@
 package speaker
 
 import (
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	"time"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -38,6 +38,9 @@ type Controller struct {
 	eipLister kubeovnlister.IptablesEIPLister
 	eipSynced cache.InformerSynced
 
+	natgatewayLister kubeovnlister.VpcNatGatewayLister
+	natgatewaySynced cache.InformerSynced
+
 	informerFactory        kubeinformers.SharedInformerFactory
 	kubeovnInformerFactory kubeovninformer.SharedInformerFactory
 	recorder               record.EventRecorder
@@ -64,18 +67,21 @@ func NewController(config *Configuration) *Controller {
 	subnetInformer := kubeovnInformerFactory.Kubeovn().V1().Subnets()
 	serviceInformer := informerFactory.Core().V1().Services()
 	eipInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesEIPs()
+	natgatewayInformer := kubeovnInformerFactory.Kubeovn().V1().VpcNatGateways()
 
 	controller := &Controller{
 		config: config,
 
-		podsLister:     podInformer.Lister(),
-		podsSynced:     podInformer.Informer().HasSynced,
-		subnetsLister:  subnetInformer.Lister(),
-		subnetSynced:   subnetInformer.Informer().HasSynced,
-		servicesLister: serviceInformer.Lister(),
-		servicesSynced: serviceInformer.Informer().HasSynced,
-		eipLister:      eipInformer.Lister(),
-		eipSynced:      eipInformer.Informer().HasSynced,
+		podsLister:       podInformer.Lister(),
+		podsSynced:       podInformer.Informer().HasSynced,
+		subnetsLister:    subnetInformer.Lister(),
+		subnetSynced:     subnetInformer.Informer().HasSynced,
+		servicesLister:   serviceInformer.Lister(),
+		servicesSynced:   serviceInformer.Informer().HasSynced,
+		eipLister:        eipInformer.Lister(),
+		eipSynced:        eipInformer.Informer().HasSynced,
+		natgatewayLister: natgatewayInformer.Lister(),
+		natgatewaySynced: natgatewayInformer.Informer().HasSynced,
 
 		informerFactory:        informerFactory,
 		kubeovnInformerFactory: kubeovnInformerFactory,

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -102,8 +102,19 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	}
 
 	klog.Info("Started workers")
-	go wait.Until(c.syncSubnetRoutes, 5*time.Second, stopCh)
+	go wait.Until(c.Reconcile, 5*time.Second, stopCh)
 
 	<-stopCh
 	klog.Info("Shutting down workers")
+}
+
+func (c *Controller) Reconcile() {
+	if c.config.EIPAnnouncement {
+		err := c.syncEIPRoutes()
+		if err != nil {
+			klog.Errorf("failed to reconcile EIPs: %s", err.Error())
+		}
+	} else {
+		c.syncSubnetRoutes()
+	}
 }

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -1,6 +1,7 @@
 package speaker
 
 import (
+	"github.com/kubeovn/kube-ovn/pkg/util"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +19,6 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 const controllerAgentName = "ovn-speaker"
@@ -109,7 +109,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 }
 
 func (c *Controller) Reconcile() {
-	if c.config.EIPAnnouncement {
+	if c.config.NatGwMode {
 		err := c.syncEIPRoutes()
 		if err != nil {
 			klog.Errorf("failed to reconcile EIPs: %s", err.Error())

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -3,8 +3,6 @@ package speaker
 import (
 	"time"
 
-	"github.com/kubeovn/kube-ovn/pkg/util"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -20,6 +18,7 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 const controllerAgentName = "ovn-speaker"

--- a/pkg/speaker/eip.go
+++ b/pkg/speaker/eip.go
@@ -1,6 +1,7 @@
 package speaker
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -15,7 +16,7 @@ func (c *Controller) syncEIPRoutes() error {
 	// Retrieve the name of our gateway
 	gatewayName := getGatewayName()
 	if gatewayName == "" {
-		return fmt.Errorf("failed to retrieve the name of the gateway, might not be running in a gateway pod")
+		return errors.New("failed to retrieve the name of the gateway, might not be running in a gateway pod")
 	}
 
 	// Create label requirements to only get EIPs attached to our NAT GW

--- a/pkg/speaker/eip.go
+++ b/pkg/speaker/eip.go
@@ -51,5 +51,5 @@ func (c *Controller) announceEIPs(eips []*v1.IptablesEIP) error {
 		}
 	}
 
-	return c.reconciliateRoutes(expectedPrefixes)
+	return c.reconcileRoutes(expectedPrefixes)
 }

--- a/pkg/speaker/eip.go
+++ b/pkg/speaker/eip.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/klog/v2"
 )
 
 // syncEIPRoutes retrieves all the EIPs attached to our GWs and starts announcing their route
@@ -17,10 +16,8 @@ func (c *Controller) syncEIPRoutes() error {
 		return fmt.Errorf("failed to retrieve the name of the gateway, might not be running in a gateway pod")
 	}
 
-	klog.Infof("gw name is: %s", gatewayName)
-
 	// Create label requirements to only get EIPs attached to our NAT GW
-	requirements, err := labels.NewRequirement(util.VpcNatGatewayLabel, selection.Equals, []string{gatewayName})
+	requirements, err := labels.NewRequirement(util.VpcNatGatewayNameLabel, selection.Equals, []string{gatewayName})
 	if err != nil {
 		return fmt.Errorf("failed to create label selector requirement: %w", err)
 	}
@@ -30,8 +27,6 @@ func (c *Controller) syncEIPRoutes() error {
 	if err != nil {
 		return fmt.Errorf("failed to list EIPs attached to our GW: %w", err)
 	}
-
-	klog.Infof("%v", eips)
 
 	return c.announceEIPs(eips)
 }

--- a/pkg/speaker/eip.go
+++ b/pkg/speaker/eip.go
@@ -2,6 +2,7 @@ package speaker
 
 import (
 	"fmt"
+
 	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/speaker/eip.go
+++ b/pkg/speaker/eip.go
@@ -3,10 +3,11 @@ package speaker
 import (
 	"fmt"
 
-	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+
+	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 // syncEIPRoutes retrieves all the EIPs attached to our GWs and starts announcing their route

--- a/pkg/speaker/natgateway.go
+++ b/pkg/speaker/natgateway.go
@@ -1,0 +1,55 @@
+package speaker
+
+import (
+	"fmt"
+	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+const (
+	HostnameEnvVariable = "HOSTNAME"
+)
+
+// syncEIPRoutes retrieves all the EIPs attached to our GWs and starts announcing their route
+func (c *Controller) syncEIPRoutes() error {
+	// Retrieve the name of our gateway
+	gatewayName := getGatewayName()
+	if gatewayName == "" {
+		return fmt.Errorf("failed to retrieve the name of the gateway, might not be running in a gateway pod")
+	}
+
+	// Create label requirements to only get EIPs attached to our NAT GW
+	requirements, err := labels.NewRequirement(util.VpcNatGatewayLabel, selection.Equals, []string{gatewayName})
+	if err != nil {
+		return fmt.Errorf("failed to create label selector requirement: %w", err)
+	}
+
+	// Filter all EIPs attached to our NAT GW
+	eips, err := c.eipLister.List(labels.NewSelector().Add(*requirements))
+	if err != nil {
+		return fmt.Errorf("failed to list EIPs attached to our GW: %w", err)
+	}
+
+	return c.announceEIPs(eips)
+}
+
+func (c *Controller) announceEIPs(eips []*v1.IptablesEIP) error {
+	expectedPrefixes := make(prefixMap)
+	for _, eip := range eips {
+		if !eip.Status.Ready { // Only announce EIPs marked as "ready"
+			continue
+		}
+
+		if eip.Spec.V4ip != "" { // If we have an IPv4, add it to prefixes we should be announcing
+			addExpectedPrefix(eip.Spec.V4ip, expectedPrefixes)
+		}
+
+		if eip.Spec.V4ip != "" { // If we have an IPv6, add it to prefixes we should be announcing
+			addExpectedPrefix(eip.Spec.V6ip, expectedPrefixes)
+		}
+	}
+
+	return c.reconciliateRoutes(expectedPrefixes)
+}

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -115,7 +115,7 @@ func (c *Controller) syncSubnetRoutes() {
 		}
 	}
 
-	if err := c.reconciliateRoutes(bgpExpected); err != nil {
-		klog.Errorf("failed to reconciliate routes: %s", err.Error())
+	if err := c.reconcileRoutes(bgpExpected); err != nil {
+		klog.Errorf("failed to reconcile routes: %s", err.Error())
 	}
 }

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -4,17 +4,13 @@ package speaker
 import (
 	"context"
 	"fmt"
-	"net"
-	"strconv"
 	"strings"
 
 	bgpapi "github.com/osrg/gobgp/v3/api"
 	bgpapiutil "github.com/osrg/gobgp/v3/pkg/apiutil"
-	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
-	"google.golang.org/protobuf/types/known/anypb"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
@@ -23,31 +19,16 @@ import (
 )
 
 const (
-	// "cluster" is the default policy
+	// announcePolicyCluster makes the Pod IPs/Subnet CIDRs be announced from every speaker, whether there's Pods
+	// that have that specific IP or that are part of the Subnet CIDR on that node. In other words, traffic may enter from
+	// any node hosting a speaker, and then be internally routed in the cluster to the actual Pod. In this configuration
+	// extra hops might be used. This is the default policy to Pods and Subnets.
 	announcePolicyCluster = "cluster"
-	announcePolicyLocal   = "local"
+	// announcePolicyLocal makes the Pod IPs be announced only from speakers on nodes that are actively hosting
+	// them. In other words, traffic will only enter from nodes hosting Pods marked as needing BGP advertisement,
+	// or Pods with an IP belonging to a Subnet marked as needing BGP advertisement. This makes the network path shorter.
+	announcePolicyLocal = "local"
 )
-
-func isPodAlive(p *v1.Pod) bool {
-	if p.Status.Phase == v1.PodSucceeded && p.Spec.RestartPolicy != v1.RestartPolicyAlways {
-		return false
-	}
-
-	if p.Status.Phase == v1.PodFailed && p.Spec.RestartPolicy == v1.RestartPolicyNever {
-		return false
-	}
-
-	if p.Status.Phase == v1.PodFailed && p.Status.Reason == "Evicted" {
-		return false
-	}
-	return true
-}
-
-func isClusterIPService(svc *v1.Service) bool {
-	return svc.Spec.Type == v1.ServiceTypeClusterIP &&
-		svc.Spec.ClusterIP != v1.ClusterIPNone &&
-		len(svc.Spec.ClusterIP) != 0
-}
 
 func (c *Controller) syncSubnetRoutes() {
 	maskMap := map[string]int{kubeovnv1.ProtocolIPv4: 32, kubeovnv1.ProtocolIPv6: 128}
@@ -214,150 +195,4 @@ func (c *Controller) syncSubnetRoutes() {
 			}
 		}
 	}
-}
-
-func routeDiff(expected, exists []string) (toAdd, toDel []string) {
-	expectedMap, existsMap := map[string]bool{}, map[string]bool{}
-	for _, e := range expected {
-		expectedMap[e] = true
-	}
-	for _, e := range exists {
-		existsMap[e] = true
-	}
-
-	for e := range expectedMap {
-		if !existsMap[e] {
-			toAdd = append(toAdd, e)
-		}
-	}
-
-	for e := range existsMap {
-		if !expectedMap[e] {
-			toDel = append(toDel, e)
-		}
-	}
-	return toAdd, toDel
-}
-
-func parseRoute(route string) (string, uint32, error) {
-	var prefixLen uint32 = 32
-	prefix := route
-	if strings.Contains(route, "/") {
-		prefix = strings.Split(route, "/")[0]
-		strLen := strings.Split(route, "/")[1]
-		intLen, err := strconv.Atoi(strLen)
-		if err != nil {
-			return "", 0, err
-		}
-		prefixLen = uint32(intLen)
-	}
-	return prefix, prefixLen, nil
-}
-
-func (c *Controller) addRoute(route string) error {
-	routeAfi := bgpapi.Family_AFI_IP
-	if util.CheckProtocol(route) == kubeovnv1.ProtocolIPv6 {
-		routeAfi = bgpapi.Family_AFI_IP6
-	}
-
-	nlri, attrs, err := c.getNlriAndAttrs(route)
-	if err != nil {
-		return err
-	}
-	for _, attr := range attrs {
-		_, err = c.config.BgpServer.AddPath(context.Background(), &bgpapi.AddPathRequest{
-			Path: &bgpapi.Path{
-				Family: &bgpapi.Family{Afi: routeAfi, Safi: bgpapi.Family_SAFI_UNICAST},
-				Nlri:   nlri,
-				Pattrs: attr,
-			},
-		})
-		if err != nil {
-			klog.Errorf("add path failed, %v", err)
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *Controller) getNlriAndAttrs(route string) (*anypb.Any, [][]*anypb.Any, error) {
-	neighborAddresses := c.config.NeighborAddresses
-	if util.CheckProtocol(route) == kubeovnv1.ProtocolIPv6 {
-		neighborAddresses = c.config.NeighborIPv6Addresses
-	}
-
-	prefix, prefixLen, err := parseRoute(route)
-	if err != nil {
-		return nil, nil, err
-	}
-	nlri, _ := anypb.New(&bgpapi.IPAddressPrefix{
-		Prefix:    prefix,
-		PrefixLen: prefixLen,
-	})
-
-	attrs := make([][]*anypb.Any, 0, len(neighborAddresses))
-	for _, addr := range neighborAddresses {
-		a1, _ := anypb.New(&bgpapi.OriginAttribute{
-			Origin: 0,
-		})
-		a2, _ := anypb.New(&bgpapi.NextHopAttribute{
-			NextHop: c.getNextHopAttribute(addr),
-		})
-		attrs = append(attrs, []*anypb.Any{a1, a2})
-	}
-
-	return nlri, attrs, err
-}
-
-func (c *Controller) delRoute(route string) error {
-	routeAfi := bgpapi.Family_AFI_IP
-	if util.CheckProtocol(route) == kubeovnv1.ProtocolIPv6 {
-		routeAfi = bgpapi.Family_AFI_IP6
-	}
-
-	nlri, attrs, err := c.getNlriAndAttrs(route)
-	if err != nil {
-		return err
-	}
-	for _, attr := range attrs {
-		err = c.config.BgpServer.DeletePath(context.Background(), &bgpapi.DeletePathRequest{
-			Path: &bgpapi.Path{
-				Family: &bgpapi.Family{Afi: routeAfi, Safi: bgpapi.Family_SAFI_UNICAST},
-				Nlri:   nlri,
-				Pattrs: attr,
-			},
-		})
-		if err != nil {
-			klog.Errorf("del path failed, %v", err)
-			return err
-		}
-	}
-	return nil
-}
-
-func getNextHopFromPathAttributes(attrs []bgp.PathAttributeInterface) net.IP {
-	for _, attr := range attrs {
-		switch a := attr.(type) {
-		case *bgp.PathAttributeNextHop:
-			return a.Value
-		case *bgp.PathAttributeMpReachNLRI:
-			return a.Nexthop
-		}
-	}
-	return nil
-}
-
-func (c *Controller) getNextHopAttribute(neighborAddress string) string {
-	nextHop := c.config.RouterID
-	routes, err := netlink.RouteGet(net.ParseIP(neighborAddress))
-	if err == nil && len(routes) == 1 && routes[0].Src != nil {
-		nextHop = routes[0].Src.String()
-	}
-	proto := util.CheckProtocol(nextHop)
-	nextHopIP := net.ParseIP(nextHop)
-	nodeIP := c.config.NodeIPs[proto]
-	if nodeIP != nil && nextHopIP != nil && nextHopIP.Equal(c.config.PodIPs[proto]) {
-		nextHop = nodeIP.String()
-	}
-	return nextHop
 }

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -79,7 +79,7 @@ func parseRoute(route string) (string, uint32, error) {
 	if strings.Contains(route, "/") {
 		prefix = strings.Split(route, "/")[0]
 		strLen := strings.Split(route, "/")[1]
-		intLen, err := strconv.Atoi(strLen)
+		intLen, err := strconv.ParseInt(strLen, 10, 32)
 		if err != nil {
 			return "", 0, err
 		}
@@ -96,11 +96,12 @@ func getGatewayName() string {
 // kubeOvnFamilyToAFI converts an IP family to its associated AFI
 func kubeOvnFamilyToAFI(ipFamily string) (bgpapi.Family_Afi, error) {
 	var family bgpapi.Family_Afi
-	if ipFamily == kubeovnv1.ProtocolIPv6 {
-		family = bgpapi.Family_AFI_IP6
-	} else if ipFamily == kubeovnv1.ProtocolIPv4 {
+	switch ipFamily {
+	case kubeovnv1.ProtocolIPv4:
 		family = bgpapi.Family_AFI_IP
-	} else {
+	case kubeovnv1.ProtocolIPv6:
+		family = bgpapi.Family_AFI_IP6
+	default:
 		return bgpapi.Family_AFI_UNKNOWN, fmt.Errorf("ip family is invalid")
 	}
 

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -11,10 +11,6 @@ import (
 	"strings"
 )
 
-const (
-	GatewayNameEnvVariable = "GATEWAY_NAME"
-)
-
 // prefixMap is a map associating an IP family (IPv4 or IPv6) and an IP
 type prefixMap map[string][]string
 
@@ -94,7 +90,7 @@ func parseRoute(route string) (string, uint32, error) {
 
 // getGatewayName returns the name of the NAT GW hosting this speaker
 func getGatewayName() string {
-	return os.Getenv(GatewayNameEnvVariable)
+	return os.Getenv(util.GatewayNameEnv)
 }
 
 // kubeOvnFamilyToAFI converts an IP family to its associated AFI

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 	"strings"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 	bgpapi "github.com/osrg/gobgp/v3/api"
 	v1 "k8s.io/api/core/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 // prefixMap is a map associating an IP family (IPv4 or IPv6) and an IP
@@ -80,7 +81,7 @@ func parseRoute(route string) (string, uint32, error) {
 	if strings.Contains(route, "/") {
 		prefix = strings.Split(route, "/")[0]
 		strLen := strings.Split(route, "/")[1]
-		intLen, err := strconv.ParseInt(strLen, 10, 32)
+		intLen, err := strconv.ParseUint(strLen, 10, 32)
 		if err != nil {
 			return "", 0, err
 		}

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -1,6 +1,7 @@
 package speaker
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -104,7 +105,7 @@ func kubeOvnFamilyToAFI(ipFamily string) (bgpapi.Family_Afi, error) {
 	case kubeovnv1.ProtocolIPv6:
 		family = bgpapi.Family_AFI_IP6
 	default:
-		return bgpapi.Family_AFI_UNKNOWN, fmt.Errorf("ip family is invalid")
+		return bgpapi.Family_AFI_UNKNOWN, errors.New("ip family is invalid")
 	}
 
 	return family, nil

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -11,6 +11,10 @@ import (
 	"strings"
 )
 
+const (
+	GatewayNameEnvVariable = "GATEWAY_NAME"
+)
+
 // prefixMap is a map associating an IP family (IPv4 or IPv6) and an IP
 type prefixMap map[string][]string
 
@@ -90,17 +94,7 @@ func parseRoute(route string) (string, uint32, error) {
 
 // getGatewayName returns the name of the NAT GW hosting this speaker
 func getGatewayName() string {
-	hostname := os.Getenv(HostnameEnvVariable)
-	hostnameSplit := strings.Split(hostname, "-")
-	splitLength := len(hostnameSplit)
-
-	// The name of the GW is right before the index in the name of the pod
-	// For example: "vpc-nat-gw-gw1-0" is the name of the pod hosting the NAT GW "gw1"
-	if splitLength < 2 {
-		return ""
-	}
-
-	return hostnameSplit[splitLength-2]
+	return os.Getenv(GatewayNameEnvVariable)
 }
 
 // kubeOvnFamilyToAFI converts an IP family to its associated AFI

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -1,10 +1,25 @@
 package speaker
 
 import (
+	"fmt"
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	bgpapi "github.com/osrg/gobgp/v3/api"
 	v1 "k8s.io/api/core/v1"
+	"os"
 	"strconv"
 	"strings"
 )
+
+// prefixMap is a map associating an IP family (IPv4 or IPv6) and an IP
+type prefixMap map[string][]string
+
+// addExpectedPrefix adds a new prefix to the list of expected prefixes we should be announcing
+func addExpectedPrefix(ip string, expectedPrefixes prefixMap) {
+	ipFamily := util.CheckProtocol(ip)
+	prefix := fmt.Sprintf("%s/%d", ip, maskMap[ipFamily])
+	expectedPrefixes[ipFamily] = append(expectedPrefixes[ipFamily], prefix)
+}
 
 // isPodAlive returns whether a Pod is alive or not
 func isPodAlive(p *v1.Pod) bool {
@@ -71,4 +86,33 @@ func parseRoute(route string) (string, uint32, error) {
 		prefixLen = uint32(intLen)
 	}
 	return prefix, prefixLen, nil
+}
+
+// getGatewayName returns the name of the NAT GW hosting this speaker
+func getGatewayName() string {
+	hostname := os.Getenv(HostnameEnvVariable)
+	hostnameSplit := strings.Split(hostname, "-")
+	splitLength := len(hostnameSplit)
+
+	// The name of the GW is right before the index in the name of the pod
+	// For example: "vpc-nat-gw-gw1-0" is the name of the pod hosting the NAT GW "gw1"
+	if splitLength < 2 {
+		return ""
+	}
+
+	return hostnameSplit[splitLength-2]
+}
+
+// kubeOvnFamilyToAFI converts an IP family to its associated AFI
+func kubeOvnFamilyToAFI(ipFamily string) (bgpapi.Family_Afi, error) {
+	var family bgpapi.Family_Afi
+	if ipFamily == kubeovnv1.ProtocolIPv6 {
+		family = bgpapi.Family_AFI_IP6
+	} else if ipFamily == kubeovnv1.ProtocolIPv4 {
+		family = bgpapi.Family_AFI_IP
+	} else {
+		return bgpapi.Family_AFI_UNKNOWN, fmt.Errorf("ip family is invalid")
+	}
+
+	return family, nil
 }

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -2,13 +2,14 @@ package speaker
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	bgpapi "github.com/osrg/gobgp/v3/api"
 	v1 "k8s.io/api/core/v1"
-	"os"
-	"strconv"
-	"strings"
 )
 
 // prefixMap is a map associating an IP family (IPv4 or IPv6) and an IP

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -1,0 +1,74 @@
+package speaker
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"strconv"
+	"strings"
+)
+
+// isPodAlive returns whether a Pod is alive or not
+func isPodAlive(p *v1.Pod) bool {
+	if p.Status.Phase == v1.PodSucceeded && p.Spec.RestartPolicy != v1.RestartPolicyAlways {
+		return false
+	}
+
+	if p.Status.Phase == v1.PodFailed && p.Spec.RestartPolicy == v1.RestartPolicyNever {
+		return false
+	}
+
+	if p.Status.Phase == v1.PodFailed && p.Status.Reason == "Evicted" {
+		return false
+	}
+	return true
+}
+
+// isClusterIPService returns whether a Service is of type ClusterIP or not
+func isClusterIPService(svc *v1.Service) bool {
+	return svc.Spec.Type == v1.ServiceTypeClusterIP &&
+		svc.Spec.ClusterIP != v1.ClusterIPNone &&
+		len(svc.Spec.ClusterIP) != 0
+}
+
+// routeDiff returns the routes that should be added and the routes that should be deleted
+// after receiving the routes we except to advertise versus the route we are advertising
+func routeDiff(expected, exists []string) (toAdd, toDel []string) {
+	expectedMap, existsMap := map[string]bool{}, map[string]bool{}
+	for _, e := range expected {
+		expectedMap[e] = true
+	}
+	for _, e := range exists {
+		existsMap[e] = true
+	}
+
+	for e := range expectedMap {
+		if !existsMap[e] {
+			toAdd = append(toAdd, e)
+		}
+	}
+
+	for e := range existsMap {
+		if !expectedMap[e] {
+			toDel = append(toDel, e)
+		}
+	}
+
+	return toAdd, toDel
+}
+
+// parseRoute returns the prefix and length of the prefix (in bits) by parsing the received route
+// If no prefix is mentioned in the route (e.g 1.1.1.1 instead of 1.1.1.1/32), the prefix length
+// is assumed to be 32 bits
+func parseRoute(route string) (string, uint32, error) {
+	var prefixLen uint32 = 32
+	prefix := route
+	if strings.Contains(route, "/") {
+		prefix = strings.Split(route, "/")[0]
+		strLen := strings.Split(route, "/")[1]
+		intLen, err := strconv.Atoi(strLen)
+		if err != nil {
+			return "", 0, err
+		}
+		prefixLen = uint32(intLen)
+	}
+	return prefix, prefixLen, nil
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -213,7 +213,8 @@ const (
 	InternalType = "internal-port"
 	DpdkType     = "dpdk-port"
 
-	HostnameEnv = "KUBE_NODE_NAME"
+	HostnameEnv    = "KUBE_NODE_NAME"
+	GatewayNameEnv = "GATEWAY_NAME"
 
 	MirrosRetryMaxTimes = 5
 	MirrosRetryInterval = 1


### PR DESCRIPTION
# Pull Request

## What type of this PR

Examples of user facing changes:
- Introduces a flag to the BGP speaker to turn it into a "NAT GW mode", this makes the speaker announce EIPs linked to the GW the speaker is currently in. This disables announcement of Pod IPs/Services/Subnets by the speaker. Note: this mode can only be set inside a NAT GW as the pod will search for a specific new env variable in the GW to determine in which one it is running.
- Introduces a new container to the NAT GW if the experimental BGP option is set in the NAT GW configmap, this container contains a BGP speaker that will announce EIPs added to the GW if they have the correct annotation


## Which issue(s) this PR fixes

Fixes [4217](https://github.com/kubeovn/kube-ovn/issues/4217)

This PR is highly experimental, do not merge in master.


To test:

We need to have a NAD for the interface that the speaker will use to talk to the apiserver.
For that we follow the exact same pattern as for the vpc-dns

Create a NAD with access to kube-ovn default network:
```yaml
apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: ovn-nad
  namespace: default
spec:
  config: '{
      "cniVersion": "0.3.0",
      "type": "kube-ovn",
      "server_socket": "/run/openvswitch/kube-ovn-daemon.sock",
      "provider": "ovn-nad.default.ovn"
    }'
```

Edit the ovn-default subnet to use the NAD as a provider.

Create new permissions for the gateway to poll the apiserver:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    kubernetes.io/bootstrapping: rbac-defaults
  name: system:vpc-nat-gw
rules:
  - apiGroups:
    - ""
    resources:
    - services
    - pods
    verbs:
    - list
    - watch
  - apiGroups:
    - kubeovn.io
    resources:
    - iptables-eips
    - subnets
    - vpc-nat-gateways
    verbs:
    - list
    - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  annotations:
    rbac.authorization.kubernetes.io/autoupdate: "true"
  labels:
    kubernetes.io/bootstrapping: rbac-defaults
  name: vpc-nat-gw
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:vpc-nat-gw
subjects:
- kind: ServiceAccount
  name: vpc-nat-gw
  namespace: kube-system
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: vpc-nat-gw
  namespace: kube-system
```

Launch a NAT GW and mark its EIP with the BGP annotation:
`ovn.kubernetes.io/bgp: "true"`
