### PR TITLE
fix: scripts

### DIFF
--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -45,6 +45,7 @@ spec:
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: 
+          - bash
           - /kube-ovn/start-db.sh
           securityContext:
             runAsUser: 0

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -40,6 +40,9 @@ OVS_VSCTL_CONCURRENCY=${OVS_VSCTL_CONCURRENCY:-100}
 ENABLE_COMPACT=${ENABLE_COMPACT:-false}
 SECURE_SERVING=${SECURE_SERVING:-false}
 
+# ovn version
+versionCompatibility=24.03
+
 # debug
 DEBUG_WRAPPER=${DEBUG_WRAPPER:-}
 
@@ -3462,6 +3465,8 @@ spec:
               value: "1"
             - name: ENABLE_COMPACT
               value: "$ENABLE_COMPACT"
+            - name: OVN_VERSION_COMPATIBILITY
+              value: "$versionCompatibility"
           resources:
             requests:
               cpu: 300m

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4933,8 +4933,8 @@ if ! sh -c "echo \":$PATH:\" | grep -q \":/usr/local/bin:\""; then
 fi
 
 echo "[Step 6/6] Run network diagnose"
-kubectl cp kube-system/"$(kubectl -n kube-system get pods -o wide | grep cni | awk '{print $1}' | awk 'NR==1{print}')":/kube-ovn/kubectl-ko /usr/local/bin/kubectl-ko
-chmod +x /usr/local/bin/kubectl-ko
+sudo kubectl cp kube-system/"$(kubectl -n kube-system get pods -o wide | grep cni | awk '{print $1}' | awk 'NR==1{print}')":/kube-ovn/kubectl-ko /usr/local/bin/kubectl-ko
+sudo chmod +x /usr/local/bin/kubectl-ko
 # show pod status in kube-system namespace before diagnose
 kubectl get pod -n kube-system -o wide
 kubectl ko diagnose all

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3418,6 +3418,7 @@ spec:
           image: "$REGISTRY/kube-ovn:$VERSION"
           imagePullPolicy: $IMAGE_PULL_POLICY
           command:
+          - bash
           - /kube-ovn/start-db.sh
           securityContext:
             runAsUser: 0

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -40,9 +40,6 @@ OVS_VSCTL_CONCURRENCY=${OVS_VSCTL_CONCURRENCY:-100}
 ENABLE_COMPACT=${ENABLE_COMPACT:-false}
 SECURE_SERVING=${SECURE_SERVING:-false}
 
-# ovn version
-versionCompatibility=24.03
-
 # debug
 DEBUG_WRAPPER=${DEBUG_WRAPPER:-}
 
@@ -3465,8 +3462,6 @@ spec:
               value: "1"
             - name: ENABLE_COMPACT
               value: "$ENABLE_COMPACT"
-            - name: OVN_VERSION_COMPATIBILITY
-              value: "$versionCompatibility"
           resources:
             requests:
               cpu: 300m

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4933,8 +4933,8 @@ if ! sh -c "echo \":$PATH:\" | grep -q \":/usr/local/bin:\""; then
 fi
 
 echo "[Step 6/6] Run network diagnose"
-sudo kubectl cp kube-system/"$(kubectl -n kube-system get pods -o wide | grep cni | awk '{print $1}' | awk 'NR==1{print}')":/kube-ovn/kubectl-ko /usr/local/bin/kubectl-ko
-sudo chmod +x /usr/local/bin/kubectl-ko
+kubectl cp kube-system/"$(kubectl -n kube-system get pods -o wide | grep cni | awk '{print $1}' | awk 'NR==1{print}')":/kube-ovn/kubectl-ko /usr/local/bin/kubectl-ko
+chmod +x /usr/local/bin/kubectl-ko
 # show pod status in kube-system namespace before diagnose
 kubectl get pod -n kube-system -o wide
 kubectl ko diagnose all

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -140,7 +140,7 @@ function is_clustered {
 function set_nb_version_compatibility() {
     if [ -n "$OVN_VERSION_COMPATIBILITY" ]; then
         if ! ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS get NB_Global . options | grep -q version_compatibility=; then
-            echo "ovn nb global option version_compatibility is set to ${OVN_VERSION_COMPATIBILITY}"
+            echo "setting ovn NB_Global option version_compatibility to ${OVN_VERSION_COMPATIBILITY}"
             ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS set NB_Global . options:version_compatibility=${OVN_VERSION_COMPATIBILITY}
             return
         fi
@@ -150,8 +150,8 @@ function set_nb_version_compatibility() {
             ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS set NB_Global . options:version_compatibility=${OVN_VERSION_COMPATIBILITY}
         fi
     else
-        echo "ovn nb global option version_compatibility is set to _$OVN_VERSION_COMPATIBILITY"
-        ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS set NB_Global . options:version_compatibility=_${OVN_VERSION_COMPATIBILITY}
+        echo "OVN_VERSION_COMPATIBILITY is not set"
+        return 1
     fi
 }
 

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -139,6 +139,7 @@ function is_clustered {
 function set_nb_version_compatibility() {
     if [ -n "$OVN_VERSION_COMPATIBILITY" ]; then
         if ! ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS get NB_Global . options | grep -q version_compatibility=; then
+            echo "ovn nb global option version_compatibility is set to ${OVN_VERSION_COMPATIBILITY}"
             ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS set NB_Global . options:version_compatibility=${OVN_VERSION_COMPATIBILITY}
             return
         fi
@@ -147,6 +148,9 @@ function set_nb_version_compatibility() {
         if [ "$value" != "_$OVN_VERSION_COMPATIBILITY" ]; then
             ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS set NB_Global . options:version_compatibility=${OVN_VERSION_COMPATIBILITY}
         fi
+    else
+        echo "ovn nb global option version_compatibility is set to _$OVN_VERSION_COMPATIBILITY"
+        ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS set NB_Global . options:version_compatibility=_${OVN_VERSION_COMPATIBILITY}
     fi
 }
 

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -149,9 +149,6 @@ function set_nb_version_compatibility() {
         if [ "$value" != "_$OVN_VERSION_COMPATIBILITY" ]; then
             ovn-nbctl --db=$(gen_conn_str 6641) $SSL_OPTIONS set NB_Global . options:version_compatibility=${OVN_VERSION_COMPATIBILITY}
         fi
-    else
-        echo "OVN_VERSION_COMPATIBILITY is not set"
-        return 1
     fi
 }
 

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -41,6 +41,9 @@ SB_CLUSTER_PORT=${SB_CLUSTER_PORT:-6644}
 ENABLE_SSL=${ENABLE_SSL:-false}
 ENABLE_BIND_LOCAL_IP=${ENABLE_BIND_LOCAL_IP:-false}
 
+echo "ENABLE_SSL is set to $ENABLE_SSL"
+echo "ENABLE_BIND_LOCAL_IP is set to $ENABLE_BIND_LOCAL_IP"
+
 DB_ADDR=::
 DB_ADDRESSES=::
 if [[ $ENABLE_BIND_LOCAL_IP == "true" ]]; then
@@ -49,11 +52,9 @@ if [[ $ENABLE_BIND_LOCAL_IP == "true" ]]; then
 fi
 
 SSL_OPTIONS=
-function ssl_options() {
-    if "$ENABLE_SSL" != "false" ]; then
-        SSL_OPTIONS="-p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert"
-    fi
-}
+if [ "$ENABLE_SSL" != "false" ]; then
+    SSL_OPTIONS="-p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert"
+fi
 
 . /usr/share/openvswitch/scripts/ovs-lib || exit 1
 

--- a/dist/images/upgrade-ovs.sh
+++ b/dist/images/upgrade-ovs.sh
@@ -10,7 +10,7 @@ OVN_VERSION_COMPATIBILITY=${OVN_VERSION_COMPATIBILITY:-}
 UPDATE_STRATEGY=`kubectl -n kube-system get ds ovs-ovn -o jsonpath='{.spec.updateStrategy.type}'`
 
 SSL_OPTIONS=
-if "$ENABLE_SSL" != "false" ]; then
+if [ "$ENABLE_SSL" != "false" ]; then
     SSL_OPTIONS="-p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert"
 fi
 

--- a/dist/images/upgrade-ovs.sh
+++ b/dist/images/upgrade-ovs.sh
@@ -38,7 +38,7 @@ nb_addr="$(gen_conn_str 6641)"
 while true; do
   if [ x`ovn-nbctl --db=$nb_addr $SSL_OPTIONS get NB_Global . options | grep -o 'version_compatibility='` != "x" ]; then
     value=`ovn-nbctl --db=$nb_addr $SSL_OPTIONS get NB_Global . options:version_compatibility | sed -e 's/^"//' -e 's/"$//'`
-    echo "ovn NB_Global option version_compatibility is set to $value"
+    echo "ovn NB_Global option version_compatibility is already set to $value"
     if [ "$value" = "$OVN_VERSION_COMPATIBILITY" -o "$value" = "_$OVN_VERSION_COMPATIBILITY" ]; then
       break
     fi

--- a/dist/images/upgrade-ovs.sh
+++ b/dist/images/upgrade-ovs.sh
@@ -10,11 +10,9 @@ OVN_VERSION_COMPATIBILITY=${OVN_VERSION_COMPATIBILITY:-}
 UPDATE_STRATEGY=`kubectl -n kube-system get ds ovs-ovn -o jsonpath='{.spec.updateStrategy.type}'`
 
 SSL_OPTIONS=
-function ssl_options() {
-    if "$ENABLE_SSL" != "false" ]; then
-        SSL_OPTIONS="-p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert"
-    fi
-}
+if "$ENABLE_SSL" != "false" ]; then
+    SSL_OPTIONS="-p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert"
+fi
 
 function gen_conn_str {
   if [[ -z "${OVN_DB_IPS}" ]]; then

--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -41,16 +41,18 @@ apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   kubeProxyMode: {{ kube_proxy_mode }}
   disableDefaultCNI: true
-  ipFamily: {{ ip_family }}
   apiServerAddress: {{ api_server_address }}
   apiServerPort: {{ api_server_port }}
-{%- if ip_family is equalto "ipv4" %}
+{%- if "ipv4" in ip_family  %}
+  ipFamily: ipv4
   podSubnet: {{ pod_cidr_v4 }}
   serviceSubnet: {{ svc_cidr_v4 }}
-{%- elif ip_family is equalto "ipv6" %}
+{%- elif "ipv6" in ip_family %}
+  ipFamily: ipv6
   podSubnet: "fd00:10:16::/112"
   serviceSubnet: "fd00:10:96::/108"
 {%- else %}
+  ipFamily: dual
   podSubnet: "10.16.0.0/16,fd00:10:16::/112"
   serviceSubnet: "10.96.0.0/12,fd00:10:96::/108"
 {%- endif %}

--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -41,18 +41,16 @@ apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   kubeProxyMode: {{ kube_proxy_mode }}
   disableDefaultCNI: true
+  ipFamily: {{ ip_family }}
   apiServerAddress: {{ api_server_address }}
   apiServerPort: {{ api_server_port }}
-{%- if "ipv4" in ip_family  %}
-  ipFamily: ipv4
+{%- if ip_family is equalto "ipv4" %}
   podSubnet: {{ pod_cidr_v4 }}
   serviceSubnet: {{ svc_cidr_v4 }}
-{%- elif "ipv6" in ip_family %}
-  ipFamily: ipv6
+{%- elif ip_family is equalto "ipv6" %}
   podSubnet: "fd00:10:16::/112"
   serviceSubnet: "fd00:10:96::/108"
 {%- else %}
-  ipFamily: dual
   podSubnet: "10.16.0.0/16,fd00:10:16::/112"
   serviceSubnet: "10.96.0.0/12,fd00:10:96::/108"
 {%- endif %}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->


- Bug fixes

release 1.12-mc

In the helm upgrade process, if  user not set OVN_VERSION_COMPATIBILITY, will be blocked in this `while true`.

so if user not set OVN_VERSION_COMPATIBILITY, should set it to none.

```

sudo kubectl exec  -it -n kube-system    kubeovn-dzwl2 -- bash

++ grep -o version_compatibility=
++ ovn-nbctl '--db=tcp:[10.233.60.33]:6641' get nb . options
+ '[' x '!=' x ']'
+ echo 'waiting for ovn nb global option version_compatibility to be set...'
waiting for ovn nb global option version_compatibility to be set...
+ sleep 3
+ true
++ grep -o version_compatibility=
++ ovn-nbctl '--db=tcp:[10.233.60.33]:6641' get nb . options
+ '[' x '!=' x ']'
+ echo 'waiting for ovn nb global option version_compatibility to be set...'
waiting for ovn nb global option version_compatibility to be set...
+ sleep 3
+ true


```

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
