### PR TITLE
fix dialing https server

### DIFF
--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -169,12 +169,14 @@ spec:
             exec:
               command:
                 - /kube-ovn/kube-ovn-controller-healthcheck
+                - --tls={{- .Values.func.SECURE_SERVING }}
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
                 - /kube-ovn/kube-ovn-controller-healthcheck
+                - --tls={{- .Values.func.SECURE_SERVING }}
             initialDelaySeconds: 300
             periodSeconds: 7
             failureThreshold: 5

--- a/cmd/controller_health_check/controller_health_check.go
+++ b/cmd/controller_health_check/controller_health_check.go
@@ -1,25 +1,49 @@
 package controller_health_check
 
 import (
-	"net"
+	"flag"
 	"os"
 	"time"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
 
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func CmdMain() {
+	tls := pflag.Bool("tls", false, "Whether kube-ovn-controller uses TLS")
+
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+
+	// sync the glog and klog flags.
+	pflag.CommandLine.VisitAll(func(f1 *pflag.Flag) {
+		f2 := klogFlags.Lookup(f1.Name)
+		if f2 != nil {
+			value := f1.Value.String()
+			if err := f2.Value.Set(value); err != nil {
+				util.LogFatalAndExit(err, "failed to set pflag")
+			}
+		}
+	})
+
+	pflag.CommandLine.AddGoFlagSet(klogFlags)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
 	addr := "127.0.0.1:10660"
 	if os.Getenv("ENABLE_BIND_LOCAL_IP") == "true" {
 		addr = util.JoinHostPort(os.Getenv("POD_IP"), 10660)
 	}
 
-	conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
-	if err != nil {
-		util.LogFatalAndExit(err, "failed to probe the socket")
+	if *tls {
+		addr = "tls://" + addr
+	} else {
+		addr = "tcp://" + addr
 	}
-	err = conn.Close()
-	if err != nil {
-		util.LogFatalAndExit(err, "failed to close connection")
+
+	if err := util.DialTCP(addr, time.Second, false); err != nil {
+		util.LogFatalAndExit(err, "failed to probe the socket")
 	}
 }

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4209,12 +4209,14 @@ spec:
             exec:
               command:
                 - /kube-ovn/kube-ovn-controller-healthcheck
+                - --tls=${SECURE_SERVING}
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
                 - /kube-ovn/kube-ovn-controller-healthcheck
+                - --tls=${SECURE_SERVING}
             initialDelaySeconds: 300
             periodSeconds: 7
             failureThreshold: 5


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Use `tls.Dial` to dial tls/https server. Fixes the following error when secure serving is enabled:

```txt
2024/07/19 13:10:53 http: TLS handshake error from 172.19.0.2:37244: EOF
```
