### PR TITLE
reduce image sice by merging webhook binary into kube-ovn-cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ build-go:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-cmd -v ./cmd
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-daemon -v ./cmd/daemon
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-pinger -v ./cmd/pinger
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-webhook -v ./cmd/webhook
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -o $(CURDIR)/dist/images/test-server -v ./test/server
 
 .PHONY: build-go-windows
@@ -118,7 +117,6 @@ build-go-arm:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(GO_BUILD_FLAGS) -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-cmd -v ./cmd
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(GO_BUILD_FLAGS) -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-daemon -v ./cmd/daemon
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(GO_BUILD_FLAGS) -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-pinger -v ./cmd/pinger
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(GO_BUILD_FLAGS) -buildmode=pie -o $(CURDIR)/dist/images/kube-ovn-webhook -v ./cmd/webhook
 
 .PHONY: build-kube-ovn
 build-kube-ovn: build-debug build-go

--- a/cmd/cmdmain.go
+++ b/cmd/cmdmain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubeovn/kube-ovn/cmd/ovn_leader_checker"
 	"github.com/kubeovn/kube-ovn/cmd/ovn_monitor"
 	"github.com/kubeovn/kube-ovn/cmd/speaker"
+	"github.com/kubeovn/kube-ovn/cmd/webhook"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -24,6 +25,7 @@ const (
 	CmdController            = "kube-ovn-controller"
 	CmdMonitor               = "kube-ovn-monitor"
 	CmdSpeaker               = "kube-ovn-speaker"
+	CmdWebhook               = "kube-ovn-webhook"
 	CmdControllerHealthCheck = "kube-ovn-controller-healthcheck"
 	CmdOvnLeaderChecker      = "kube-ovn-leader-checker"
 	CmdOvnICController       = "kube-ovn-ic-controller"
@@ -98,6 +100,8 @@ func main() {
 	case CmdSpeaker:
 		dumpProfile()
 		speaker.CmdMain()
+	case CmdWebhook:
+		webhook.CmdMain()
 	case CmdControllerHealthCheck:
 		controller_health_check.CmdMain()
 	case CmdOvnLeaderChecker:

--- a/cmd/webhook/server.go
+++ b/cmd/webhook/server.go
@@ -1,4 +1,4 @@
-package main
+package webhook
 
 import (
 	"flag"
@@ -36,7 +36,7 @@ func init() {
 	}
 }
 
-func main() {
+func CmdMain() {
 	klog.Infof(versions.String())
 
 	port := pflag.Int("port", 8443, "The port webhook listen on.")

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -21,10 +21,10 @@ COPY kube-ovn /kube-ovn/kube-ovn
 COPY kube-ovn-cmd /kube-ovn/kube-ovn-cmd
 COPY kube-ovn-daemon /kube-ovn/kube-ovn-daemon
 COPY kube-ovn-pinger /kube-ovn/kube-ovn-pinger
-COPY kube-ovn-webhook /kube-ovn/kube-ovn-webhook
 RUN ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-controller && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-monitor && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-speaker && \
+    ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-webhook && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-controller-healthcheck && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-leader-checker && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-ic-controller && \


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Now that we have fixed the metrics problem reported in #1424, we can merge the webhook binary back into `kube-ovn-cmd`.
