### PR TITLE
fix: empty /var/run/netns

### DIFF
--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -38,10 +38,15 @@ fi
 
 function quit {
   set +e
-  for netns in /var/run/netns/*; do
-    nsenter --net=$netns sysctl -w net.ipv4.neigh.eth0.base_reachable_time_ms=180000;
-    nsenter --net=$netns sysctl -w net.ipv4.neigh.eth0.gc_stale_time=180;
-  done
+  if [ -z "$(ls -A /var/run/netns)" ]; then  
+      echo "no ns in /var/run/netns"  
+  else  
+    for netns in /var/run/netns/*; do
+      nsenter --net=$netns sysctl -w net.ipv4.neigh.eth0.base_reachable_time_ms=180000;
+      nsenter --net=$netns sysctl -w net.ipv4.neigh.eth0.gc_stale_time=180;
+    done 
+  fi
+
   # If the arp is in stale or delay status, stop vswitchd will lead prob failed.
   # Wait a while for prob ready.
   # As the timeout has been increased existing entry will not change to stale or delay at the moment
@@ -154,10 +159,14 @@ set -e
 ovs-vsctl --no-wait set open_vswitch . other_config:flow-restore-wait="false"
 
 set +e
-for netns in /var/run/netns/*; do
-  nsenter --net=$netns sysctl -w net.ipv4.neigh.eth0.base_reachable_time_ms=30000;
-  nsenter --net=$netns sysctl -w net.ipv4.neigh.eth0.gc_stale_time=60;
-done
+if [ -z "$(ls -A /var/run/netns)" ]; then  
+    echo "no ns in /var/run/netns"  
+else  
+  for netns in /var/run/netns/*; do
+    nsenter --net=$netns sysctl -w net.ipv4.neigh.eth0.base_reachable_time_ms=30000;
+    nsenter --net=$netns sysctl -w net.ipv4.neigh.eth0.gc_stale_time=60;
+  done
+fi 
 set -e
 
 chmod 600 /etc/openvswitch/*


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->


- Bug fixes

![image](https://github.com/user-attachments/assets/22fc2428-1cb4-4dbd-9d77-053f02ca5040)

 pod failed to start because of empty /var/run/netns



<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
