### PR TITLE
Fix DISABLE_MODULES_MANAGEMENT

### DIFF
--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -126,7 +126,9 @@ spec:
               - NET_BIND_SERVICE
               - NET_RAW
               - SYS_ADMIN
+              {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
               - SYS_MODULE
+              {{- end }}
               - SYS_NICE
         env:
           - name: ENABLE_SSL

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -81,18 +81,7 @@ spec:
           {{- if .Values.DPDK }}
           command: ["/kube-ovn/start-ovs-dpdk.sh"]
           {{- else }}
-          command:
-          {{- if .Values.DISABLE_MODULES_MANAGEMENT }}
-          - /bin/sh
-          - -ec
-          - |
-              ln -sf /bin/true /usr/sbin/modprobe
-              ln -sf /bin/true /usr/sbin/modinfo
-              ln -sf /bin/true /usr/sbin/rmmod
-              exec /kube-ovn/start-ovs.sh
-          {{- else }}
-          - /kube-ovn/start-ovs.sh
-          {{- end }}
+          command: ["/kube-ovn/start-ovs.sh"]
           {{- end }}
           securityContext:
             runAsUser: 65534
@@ -101,7 +90,9 @@ spec:
               add:
                 - NET_ADMIN
                 - NET_BIND_SERVICE
+                {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
                 - SYS_MODULE
+                {{- end }}
                 - SYS_NICE
                 - SYS_ADMIN
           env:
@@ -133,6 +124,10 @@ spec:
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_OPENFLOW_INTERVAL }}"
+            {{- if .Values.DISABLE_MODULES_MANAGEMENT }}
+            - name: DISABLE_MODULES_MANAGEMENT
+              value: "true"
+            {{- end }}
           volumeMounts:
             - mountPath: /usr/local/sbin
               name: usr-local-sbin

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -15,13 +15,15 @@ OVN_REMOTE_OPENFLOW_INTERVAL=${OVN_REMOTE_OPENFLOW_INTERVAL:-180}
 echo "OVN_REMOTE_PROBE_INTERVAL is set to $OVN_REMOTE_PROBE_INTERVAL"
 echo "OVN_REMOTE_OPENFLOW_INTERVAL is set to $OVN_REMOTE_OPENFLOW_INTERVAL"
 
-# Check required kernel module
-modinfo -m openvswitch
-modinfo -m geneve
-
-# CentOS 8 might not load iptables module by default, which will hurt nat function
-if modinfo -m ip_tables; then
-  modprobe ip_tables
+if [ "${DISABLE_MODULES_MANAGEMENT:-false}" != "true" ]; then
+  # Check required kernel module
+  modinfo -m openvswitch
+  modinfo -m geneve
+  
+  # CentOS 8 might not load iptables module by default, which will hurt nat function
+  if modinfo -m ip_tables; then
+    modprobe ip_tables
+  fi
 fi
 
 # https://bugs.launchpad.net/neutron/+bug/1776778


### PR DESCRIPTION
There is a regression introduced by https://github.com/kubeovn/kube-ovn/pull/4326

Let's move this logic into `start-ovn.sh` script