### PR TITLE
Fix DISABLE_MODULES_MANAGEMENT

### DIFF
--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -39,7 +39,9 @@ spec:
             chown -R nobody: /var/log/kube-ovn
             chmod g+r /run/xtables.lock
             chmod g+w /var/run/netns
+            {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
             iptables -V
+            {{- end }}
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:
@@ -126,7 +128,9 @@ spec:
               - NET_BIND_SERVICE
               - NET_RAW
               - SYS_ADMIN
+              {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
               - SYS_MODULE
+              {{- end }}
               - SYS_NICE
         env:
           - name: ENABLE_SSL

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -49,7 +49,13 @@ spec:
             - -xec
             - |
               chown -R nobody: /var/run/ovn /var/log/ovn /etc/openvswitch /var/run/openvswitch /var/log/openvswitch
+              {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
               iptables -V
+              {{- else }}
+              ln -sf /bin/true /usr/local/sbin/modprobe
+              ln -sf /bin/true /usr/local/sbin/modinfo
+              ln -sf /bin/true /usr/local/sbin/rmmod
+              {{- end }}
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:
@@ -81,18 +87,7 @@ spec:
           {{- if .Values.DPDK }}
           command: ["/kube-ovn/start-ovs-dpdk.sh"]
           {{- else }}
-          command:
-          {{- if .Values.DISABLE_MODULES_MANAGEMENT }}
-          - /bin/sh
-          - -ec
-          - |
-              ln -sf /bin/true /usr/sbin/modprobe
-              ln -sf /bin/true /usr/sbin/modinfo
-              ln -sf /bin/true /usr/sbin/rmmod
-              exec /kube-ovn/start-ovs.sh
-          {{- else }}
-          - /kube-ovn/start-ovs.sh
-          {{- end }}
+          command: ["/kube-ovn/start-ovs.sh"]
           {{- end }}
           securityContext:
             runAsUser: 65534
@@ -101,7 +96,9 @@ spec:
               add:
                 - NET_ADMIN
                 - NET_BIND_SERVICE
+                {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
                 - SYS_MODULE
+                {{- end }}
                 - SYS_NICE
                 - SYS_ADMIN
           env:


### PR DESCRIPTION
Same as https://github.com/kubeovn/kube-ovn/pull/4363
It's more correct way for fixing DISABLE_MODULES_MANAGEMENT

However on Talos Linux it is still broken, as OVN itself now requires `SYS_MODULE` which is restricted in Talos Linux:
https://www.talos.dev/v1.7/learn-more/process-capabilities/

```
/usr/share/openvswitch/scripts/ovs-ctl: 1: ovs-vswitchd: Operation not permitted
```

details: https://github.com/kubeovn/kube-ovn/pull/4363#discussion_r1703649895
