### PR TITLE
fix: correct the priority of ACL associated with security group

### DIFF
--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -1252,7 +1252,9 @@ func (c *OVNNbClient) sgRuleNoACL(sgName, direction string, rule *kubeovnv1.SgRu
 		)
 	}
 
-	exists, err := c.ACLExists(pgName, direction, strconv.Itoa(rule.Priority), match.String())
+	securityGroupHighestPriority, _ := strconv.Atoi(util.SecurityGroupHighestPriority)
+	priority := securityGroupHighestPriority - rule.Priority
+	exists, err := c.ACLExists(pgName, direction, strconv.Itoa(priority), match.String())
 	if err != nil {
 		err = fmt.Errorf("failed to check acl rule for security group %s: %w", sgName, err)
 		klog.Error(err)

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -1788,3 +1788,82 @@ func (suite *OvnClientTestSuite) testACLFilter() {
 		require.False(t, filterFunc(acl))
 	})
 }
+
+func (suite *OvnClientTestSuite) testSgRuleNoACL() {
+	t := suite.T()
+	t.Parallel()
+
+	ovnClient := suite.ovnClient
+	sgName := "test-sg"
+	pgName := GetSgPortGroupName(sgName)
+
+	err := ovnClient.CreatePortGroup(pgName, nil)
+	require.NoError(t, err)
+
+	t.Run("ipv4 ingress rule", func(t *testing.T) {
+		rule := &kubeovnv1.SgRule{
+			IPVersion:     "ipv4",
+			Protocol:      kubeovnv1.ProtocolTCP,
+			RemoteType:    kubeovnv1.SgRemoteTypeAddress,
+			RemoteAddress: "192.168.1.0/24",
+			PortRangeMin:  80,
+			PortRangeMax:  80,
+			Priority:      200,
+		}
+		noACL, err := ovnClient.sgRuleNoACL(sgName, ovnnb.ACLDirectionToLport, rule)
+		require.NoError(t, err)
+		require.True(t, noACL)
+	})
+
+	t.Run("ipv6 egress rule", func(t *testing.T) {
+		rule := &kubeovnv1.SgRule{
+			IPVersion:           "ipv6",
+			Protocol:            kubeovnv1.ProtocolUDP,
+			RemoteType:          kubeovnv1.SgRemoteTypeSg,
+			RemoteSecurityGroup: "remote-sg",
+			PortRangeMin:        53,
+			PortRangeMax:        53,
+			Priority:            199,
+		}
+		noACL, err := ovnClient.sgRuleNoACL(sgName, ovnnb.ACLDirectionFromLport, rule)
+		require.NoError(t, err)
+		require.True(t, noACL)
+	})
+
+	t.Run("icmp rule", func(t *testing.T) {
+		rule := &kubeovnv1.SgRule{
+			IPVersion:     "ipv4",
+			Protocol:      kubeovnv1.ProtocolICMP,
+			RemoteType:    kubeovnv1.SgRemoteTypeAddress,
+			RemoteAddress: "10.0.0.0/8",
+			Priority:      198,
+		}
+		noACL, err := ovnClient.sgRuleNoACL(sgName, ovnnb.ACLDirectionToLport, rule)
+		require.NoError(t, err)
+		require.True(t, noACL)
+	})
+
+	t.Run("existing ACL", func(t *testing.T) {
+		rule := &kubeovnv1.SgRule{
+			IPVersion:     "ipv4",
+			Protocol:      kubeovnv1.ProtocolTCP,
+			RemoteType:    kubeovnv1.SgRemoteTypeAddress,
+			RemoteAddress: "172.16.0.0/16",
+			PortRangeMin:  443,
+			PortRangeMax:  443,
+			Priority:      197,
+		}
+
+		match := fmt.Sprintf("inport == @%s && ip4 && ip4.dst == 172.16.0.0/16 && 443 <= tcp.dst <= 443", pgName)
+		securityGroupHighestPriority, _ := strconv.Atoi(util.SecurityGroupHighestPriority)
+		priority := securityGroupHighestPriority - rule.Priority
+		acl, err := ovnClient.newACL(pgName, ovnnb.ACLDirectionFromLport, strconv.Itoa(priority), match, ovnnb.ACLActionAllowRelated, util.NetpolACLTier)
+		require.NoError(t, err)
+		err = ovnClient.CreateAcls(pgName, portGroupKey, acl)
+		require.NoError(t, err)
+
+		noACL, err := ovnClient.sgRuleNoACL(sgName, ovnnb.ACLDirectionFromLport, rule)
+		require.NoError(t, err)
+		require.False(t, noACL)
+	})
+}

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -534,6 +534,10 @@ func (suite *OvnClientTestSuite) Test_aclFilter() {
 	suite.testACLFilter()
 }
 
+func (suite *OvnClientTestSuite) Test_sgRuleNoACL() {
+	suite.testSgRuleNoACL()
+}
+
 /* logical_router_policy unit test */
 func (suite *OvnClientTestSuite) Test_AddLogicalRouterPolicy() {
 	suite.testAddLogicalRouterPolicy()


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

当判断安全组对应下发的ACL规则是否已经存在时，判断时使用的优先级应该
是SecurityGroupHighestPriority（2300）- sgRule.Priority，而非直接使用sgRule.Priority去匹配ACL