### PR TITLE
cni: always enable ipv6

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -50,6 +50,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 		netConf.Provider = util.OvnProvider
 	}
 
+	if err = sysctlEnableIPv6(args.Netns); err != nil {
+		return err
+	}
+
 	client := request.NewCniServerClient(netConf.ServerSocket)
 	response, err := client.Add(request.CniRequest{
 		CniType:                    netConf.Type,

--- a/cmd/cni/sysctl.go
+++ b/cmd/cni/sysctl.go
@@ -1,0 +1,32 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
+)
+
+// For docker version >=17.x the "none" network will disable ipv6 by default.
+// We have to enable ipv6 here to add v6 address and gateway.
+// See https://github.com/containernetworking/cni/issues/531
+func sysctlEnableIPv6(nsPath string) error {
+	return ns.WithNetNSPath(nsPath, func(_ ns.NetNS) error {
+		for _, conf := range [...]string{"all", "default"} {
+			name := fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6", conf)
+			value, err := sysctl.Sysctl(name)
+			if err != nil {
+				return fmt.Errorf("failed to get sysctl variable %s: %w", name, err)
+			}
+			if value != "0" {
+				if _, err = sysctl.Sysctl(name, "0"); err != nil {
+					return fmt.Errorf("failed to set sysctl variable %s to 0: %w", name, err)
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/cmd/cni/sysctl_windows.go
+++ b/cmd/cni/sysctl_windows.go
@@ -1,0 +1,6 @@
+package main
+
+func sysctlEnableIPv6(nsPath string) error {
+	// nothing to do on Windows
+	return nil
+}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes failure in ipv6/dual clusters running in docker.

#4417 
