### PR TITLE
when using vf, set pod_nic_type to sriov

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -151,6 +151,7 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 		oriPod := pod.DeepCopy()
 		pod.Annotations[fmt.Sprintf(util.VfRepresentorNameTemplate, provider)] = hostNicName
 		pod.Annotations[fmt.Sprintf(util.VfNameTemplate, provider)] = containerNicName
+		pod.Annotations[fmt.Sprintf(util.PodNicAnnotationTemplate, provider)] = util.SriovNicType
 		var patch []byte
 		patch, err = util.GenerateMergePatchPayload(oriPod, pod)
 		if err != nil {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -170,6 +170,8 @@ const (
 
 	SRIOVResourceName = "mellanox.com/cx5_sriov_switchdev"
 
+	SriovNicType = "sriov"
+
 	InterconnectionConfig  = "ovn-ic-config"
 	ExternalGatewayConfig  = "ovn-external-gw-config"
 	InterconnectionSwitch  = "ts"


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
当使用veth时，pod_nic_type注解为veth-pair
当使用vf网口时，pod_nic_type注解仍然为veth-pair
![image](https://github.com/user-attachments/assets/49691d58-e46d-4b6c-90ad-1d89f9ac72d2)
