### PR TITLE
ut:add ut for func DialTCP and DialAPIServer in apk/util/k8s.go

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -336,7 +336,7 @@ func (config *Configuration) initKubeClient() error {
 	}
 
 	// try to connect to apiserver's tcp port
-	if err = util.DialAPIServer(cfg.Host); err != nil {
+	if err = util.DialAPIServer(cfg.Host, 3*time.Second, 10); err != nil {
 		klog.Errorf("failed to dial apiserver: %v", err)
 		return err
 	}

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -373,7 +374,7 @@ func (config *Configuration) initKubeClient() error {
 	}
 
 	// try to connect to apiserver's tcp port
-	if err = util.DialAPIServer(cfg.Host); err != nil {
+	if err = util.DialAPIServer(cfg.Host, 3*time.Second, 10); err != nil {
 		klog.Errorf("failed to dial apiserver: %v", err)
 		return err
 	}

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -48,9 +48,9 @@ func DialTCP(host string, timeout time.Duration, verbose bool) error {
 	return fmt.Errorf("timed out dialing host %q", host)
 }
 
-func DialAPIServer(host string, interval time.Duration, recount int) error {
+func DialAPIServer(host string, interval time.Duration, retry int) error {
 	timer := time.NewTimer(interval)
-	for i := 0; i < recount; i++ {
+	for i := 0; i < retry; i++ {
 		err := DialTCP(host, interval, true)
 		if err == nil {
 			return nil

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -48,10 +48,9 @@ func DialTCP(host string, timeout time.Duration, verbose bool) error {
 	return fmt.Errorf("timed out dialing host %q", host)
 }
 
-func DialAPIServer(host string) error {
-	interval := 3 * time.Second
+func DialAPIServer(host string, interval time.Duration, recount int) error {
 	timer := time.NewTimer(interval)
-	for i := 0; i < 10; i++ {
+	for i := 0; i < recount; i++ {
 		err := DialTCP(host, interval, true)
 		if err == nil {
 			return nil

--- a/pkg/util/k8s_test.go
+++ b/pkg/util/k8s_test.go
@@ -1,11 +1,129 @@
 package util
 
 import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
+
+func TestDialTCP(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		timeout  time.Duration
+		verbose  bool
+		expected error
+	}{
+		{"Valid HTTP Host", "http://localhost:8080", 1 * time.Second, false, nil},
+		{"Valid HTTP Host", "http://localhost:8080", 1 * time.Second, true, nil},
+		{"Valid HTTPS Host", "https://localhost:8443", 1 * time.Second, false, nil},
+		{"Valid TCP Host", "tcp://localhost:8081", 1 * time.Second, false, nil},
+		{"Invalid Host", "https://localhost%:8443", 1 * time.Second, false, fmt.Errorf("failed to parse host")},
+		{"Unsupported Scheme", "ftp://localhost:8080", 1 * time.Second, false, fmt.Errorf("unsupported scheme")},
+		{"Timeout", "http://localhost:8080", 1 * time.Millisecond, false, fmt.Errorf("timed out dialing host")},
+	}
+
+	httpServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	httpServer.StartTLS()
+	defer httpServer.Close()
+
+	tcpListener, err := net.Listen("tcp", "localhost:8081")
+	if err != nil {
+		t.Fatalf("failed to start tcp server: %v", err)
+	}
+	defer tcpListener.Close()
+
+	go func() {
+		for {
+			conn, err := tcpListener.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	for i, tc := range tests {
+		if tc.host == "http://localhost:8080" {
+			tests[i].host = httpServer.URL
+		} else if tc.host == "https://localhost:8443" {
+			tests[i].host = httpServer.URL
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.host == "http://localhost:8080" || tt.host == "https://localhost:8443" {
+				httpServer.Close()
+				defer httpServer.StartTLS()
+			}
+
+			err := DialTCP(tt.host, tt.timeout, tt.verbose)
+			if err != tt.expected && (tt.expected == nil || !strings.Contains(err.Error(), tt.expected.Error())) {
+				t.Errorf("DialTCP(%q) got %v, want %v", tt.host, err, tt.expected)
+			}
+
+			if tt.verbose {
+				klog.Flush()
+			}
+		})
+	}
+}
+
+func TestDialAPIServer(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() (string, func())
+		expected error
+	}{
+		{
+			name: "Successful Dial",
+			setup: func() (string, func()) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+				return server.URL, server.Close
+			},
+			expected: nil,
+		},
+		{
+			name: "Successful TLS Dial",
+			setup: func() (string, func()) {
+				server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+				return server.URL, server.Close
+			},
+			expected: nil,
+		},
+		{
+			name: "Failed Dial",
+			setup: func() (string, func()) {
+				return "http://localhost:12345", func() {}
+			},
+			expected: fmt.Errorf("timed out dialing apiserver"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, cleanup := tt.setup()
+			defer cleanup()
+
+			err := DialAPIServer(host, 1*time.Second, 1)
+
+			if tt.expected == nil && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			} else if tt.expected != nil && (err == nil || !strings.Contains(err.Error(), tt.expected.Error())) {
+				t.Errorf("expected error containing %v, got %v", tt.expected, err)
+			}
+		})
+	}
+}
 
 func TestGetNodeInternalIP(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Tests

<img width="809" alt="image" src="https://github.com/user-attachments/assets/28974330-18d9-4ed5-a592-ccf7fcfec643">
这个函数不方便测试修改了下，将重试间隔和重试次数作为传参，并修改了所有对该函数的引用
<img width="598" alt="image" src="https://github.com/user-attachments/assets/dc511226-a68c-492d-9c96-e3f6760fa374">



<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
