### PR TITLE
Make NAT gateway generation prefix a variable

### DIFF
--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -27,6 +27,8 @@ func (c *Controller) resyncVpcNatConfig() {
 	vpcNatGwNamePrefix := cm.Data["natGwNamePrefix"]
 	if vpcNatGwNamePrefix != "" {
 		util.VpcNatGwNamePrefix = vpcNatGwNamePrefix
+	} else {
+		util.VpcNatGwNamePrefix = util.VpcNatGwNameDefaultPrefix
 	}
 
 	// Image we're using to provision the NAT gateways

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -22,6 +22,13 @@ func (c *Controller) resyncVpcNatConfig() {
 		return
 	}
 
+	// Prefix used to generate the name of the StatefulSet/Pods for a NAT gateway
+	// By default it is equal to the value contained in 'util.VpcNatGwNamePrefix'
+	vpcNatGwNamePrefix := cm.Data["natGwNamePrefix"]
+	if vpcNatGwNamePrefix != "" {
+		util.VpcNatGwNamePrefix = vpcNatGwNamePrefix
+	}
+
 	// Image we're using to provision the NAT gateways
 	image, exist := cm.Data["image"]
 	if !exist {

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -2,10 +2,17 @@ package util
 
 import "fmt"
 
+var (
+	// VpcNatGwNamePrefix is appended to the name of the StatefulSet and Pods for NAT gateways
+	VpcNatGwNamePrefix = "vpc-nat-gw"
+)
+
+// GenNatGwStsName returns the full name of a NAT gateway StatefulSet
 func GenNatGwStsName(name string) string {
-	return fmt.Sprintf("vpc-nat-gw-%s", name)
+	return fmt.Sprintf("%s-%s", VpcNatGwNamePrefix, name)
 }
 
+// GenNatGwPodName returns the full name of the NAT gateway pod within a StatefulSet
 func GenNatGwPodName(name string) string {
-	return fmt.Sprintf("vpc-nat-gw-%s-0", name)
+	return fmt.Sprintf("%s-%s-0", VpcNatGwNamePrefix, name)
 }

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -2,8 +2,11 @@ package util
 
 import "fmt"
 
+// VpcNatGwNameDefaultPrefix is the default prefix appended to the name of the NAT gateways
+const VpcNatGwNameDefaultPrefix = "vpc-nat-gw"
+
 // VpcNatGwNamePrefix is appended to the name of the StatefulSet and Pods for NAT gateways
-var VpcNatGwNamePrefix = "vpc-nat-gw"
+var VpcNatGwNamePrefix = VpcNatGwNameDefaultPrefix
 
 // GenNatGwStsName returns the full name of a NAT gateway StatefulSet
 func GenNatGwStsName(name string) string {

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -2,10 +2,8 @@ package util
 
 import "fmt"
 
-var (
-	// VpcNatGwNamePrefix is appended to the name of the StatefulSet and Pods for NAT gateways
-	VpcNatGwNamePrefix = "vpc-nat-gw"
-)
+// VpcNatGwNamePrefix is appended to the name of the StatefulSet and Pods for NAT gateways
+var VpcNatGwNamePrefix = "vpc-nat-gw"
 
 // GenNatGwStsName returns the full name of a NAT gateway StatefulSet
 func GenNatGwStsName(name string) string {


### PR DESCRIPTION
This makes the prefix in front of Pods/STS generated for NAT gateways a configurable variable from the ConfigMap.