### PR TITLE
Add genev_sys_6081 to cilium devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -877,7 +877,7 @@ kind-install-cilium-chaining-%:
 		--set ipv4.enabled=$(shell if echo $* | grep -q ipv6; then echo false; else echo true; fi) \
 		--set ipv6.enabled=$(shell if echo $* | grep -q ipv4; then echo false; else echo true; fi) \
 		--set routingMode=native \
-		--set devices="eth+ ovn0 genev_sys_6081" \
+		--set devices="eth+ ovn0 genev_sys_6081 vxlan_sys_4789" \
 		--set forceDeviceDetection=true \
 		--set ipam.mode=cluster-pool \
 		--set-json ipam.operator.clusterPoolIPv4PodCIDRList='["100.65.0.0/16"]' \

--- a/Makefile
+++ b/Makefile
@@ -877,7 +877,7 @@ kind-install-cilium-chaining-%:
 		--set ipv4.enabled=$(shell if echo $* | grep -q ipv6; then echo false; else echo true; fi) \
 		--set ipv6.enabled=$(shell if echo $* | grep -q ipv4; then echo false; else echo true; fi) \
 		--set routingMode=native \
-		--set devices="eth+ ovn0" \
+		--set devices="eth+ ovn0 genev_sys_6081" \
 		--set forceDeviceDetection=true \
 		--set ipam.mode=cluster-pool \
 		--set-json ipam.operator.clusterPoolIPv4PodCIDRList='["100.65.0.0/16"]' \


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

I use kube-ovn with cilium, metallb and kubevirt.
I run ubuntu vm and expose 22 port with loadbalancer service
I can not access vm via externalIP assigned by metallb (externalTrafficPolicy: local)

## Which issue(s) this PR fixes

It seems cilium is not correctly handled response packets recieved on `genev_sys_6081` interface:

```
/ # tcpdump -nn -i any port 22
tcpdump: data link type LINUX_SLL2
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on any, link-type LINUX_SLL2 (Linux cooked v2), snapshot length 262144 bytes
10:41:10.865457 eno5  In  IP 172.16.2.173.52314 > 10.2.0.242.22: Flags [S], seq 720481636, win 65535, options [mss 1410,nop,wscale 6,nop,nop,TS val 135386350 ecr 0,sackOK,eol], length 0
10:41:10.865465 bond0 In  IP 172.16.2.173.52314 > 10.2.0.242.22: Flags [S], seq 720481636, win 65535, options [mss 1410,nop,wscale 6,nop,nop,TS val 135386350 ecr 0,sackOK,eol], length 0
10:41:10.865537 ovn0  Out IP 172.16.2.173.52314 > 10.244.2.5.22: Flags [S], seq 720481636, win 65535, options [mss 1410,nop,wscale 6,nop,nop,TS val 135386350 ecr 0,sackOK,eol], length 0
10:41:10.865867 a33c4744248c_h Out IP 172.16.2.173.52314 > 10.244.2.5.22: Flags [S], seq 720481636, win 65535, options [mss 1410,nop,wscale 6,nop,nop,TS val 135386350 ecr 0,sackOK,eol], length 0
10:41:10.866210 a33c4744248c_h P   IP 10.244.2.5.22 > 172.16.2.173.52314: Flags [S.], seq 3405953119, ack 720481637, win 64704, options [mss 1360,sackOK,TS val 1687566854 ecr 135386350,nop,wscale 7], length 0
10:41:10.866270 genev_sys_6081 Out IP 10.244.2.5.22 > 172.16.2.173.52314: Flags [S.], seq 3405953119, ack 720481637, win 64704, options [mss 1360,sackOK,TS val 1687566854 ecr 135386350,nop,wscale 7], length 0
```

So I specidied it explicitly in cilium configuration, now packets are going fine