### PR TITLE
fix memory overflow, add mac_binding related options to router

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -215,6 +215,25 @@ func (mr *MockLogicalRouterMockRecorder) CreateLogicalRouter(lrName any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogicalRouter", reflect.TypeOf((*MockLogicalRouter)(nil).CreateLogicalRouter), lrName)
 }
 
+// UpdateLogicalRouter mocks base method.
+func (m *MockLogicalRouter) UpdateLogicalRouter(lr *ovnnb.LogicalRouter, fields ...interface{}) error {
+	m.ctrl.T.Helper()
+	varargs := []any{lr}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateLogicalRouter", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLogicalRouter indicates an expected call of UpdateLogicalRouter.
+func (mr *MockLogicalRouterMockRecorder) UpdateLogicalRouter(lr *ovnnb.LogicalRouter, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{lr}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLogicalRouter", reflect.TypeOf((*MockLogicalRouter)(nil).UpdateLogicalRouter), varargs...)
+}
+
 // DeleteLogicalRouter mocks base method.
 func (m *MockLogicalRouter) DeleteLogicalRouter(lrName string) error {
 	m.ctrl.T.Helper()
@@ -2754,6 +2773,25 @@ func (m *MockNbClient) CreateLogicalRouter(lrName string) error {
 func (mr *MockNbClientMockRecorder) CreateLogicalRouter(lrName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogicalRouter", reflect.TypeOf((*MockNbClient)(nil).CreateLogicalRouter), lrName)
+}
+
+// UpdateLogicalRouter mocks base method.
+func (m *MockNbClient) UpdateLogicalRouter(lr *ovnnb.LogicalRouter, fields ...interface{}) error {
+	m.ctrl.T.Helper()
+	varargs := []any{lr}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateLogicalRouter", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLogicalRouter indicates an expected call of UpdateLogicalRouter.
+func (mr *MockNbClientMockRecorder) UpdateLogicalRouter(lr *ovnnb.LogicalRouter, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{lr}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLogicalRouter", reflect.TypeOf((*MockLogicalRouter)(nil).UpdateLogicalRouter), varargs...)
 }
 
 // CreateLogicalRouterPort mocks base method.

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -206,7 +206,25 @@ func (c *Controller) initNodeSwitch() error {
 
 // InitClusterRouter init cluster router to connect different logical switches
 func (c *Controller) initClusterRouter() error {
-	return c.OVNNbClient.CreateLogicalRouter(c.config.ClusterRouter)
+	if err := c.OVNNbClient.CreateLogicalRouter(c.config.ClusterRouter); err != nil {
+		klog.Errorf("create logical router %s failed: %v", c.config.ClusterRouter, err)
+		return err
+	}
+
+	lr, err := c.OVNNbClient.GetLogicalRouter(c.config.ClusterRouter, false)
+	if err != nil {
+		klog.Errorf("get logical router %s failed: %v", c.config.ClusterRouter, err)
+		return err
+	}
+
+	lr.Options = map[string]string{"always_learn_from_arp_request": "false", "dynamic_neigh_routers": "true", "mac_binding_age_threshold": "300"}
+	err = c.OVNNbClient.UpdateLogicalRouter(lr)
+	if err != nil {
+		klog.Errorf("update logical router %s failed: %v", c.config.ClusterRouter, err)
+		return err
+	}
+
+	return nil
 }
 
 func (c *Controller) initLB(name, protocol string, sessionAffinity bool) error {

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -218,7 +218,7 @@ func (c *Controller) initClusterRouter() error {
 	}
 
 	lr.Options = map[string]string{"always_learn_from_arp_request": "false", "dynamic_neigh_routers": "true", "mac_binding_age_threshold": "300"}
-	err = c.OVNNbClient.UpdateLogicalRouter(lr)
+	err = c.OVNNbClient.UpdateLogicalRouter(lr, &lr.Options)
 	if err != nil {
 		klog.Errorf("update logical router %s failed: %v", c.config.ClusterRouter, err)
 		return err

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -989,7 +989,7 @@ func (c *Controller) createVpcRouter(lr string) error {
 	}
 
 	vpcRouter.Options = map[string]string{"always_learn_from_arp_request": "false", "dynamic_neigh_routers": "true", "mac_binding_age_threshold": "300"}
-	err = c.OVNNbClient.UpdateLogicalRouter(vpcRouter)
+	err = c.OVNNbClient.UpdateLogicalRouter(vpcRouter, &vpcRouter.Options)
 	if err != nil {
 		klog.Errorf("update logical router %s failed: %v", lr, err)
 		return err

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -977,7 +977,24 @@ func (c *Controller) getVpcSubnets(vpc *kubeovnv1.Vpc) (subnets []string, defaul
 
 // createVpcRouter create router to connect logical switches in vpc
 func (c *Controller) createVpcRouter(lr string) error {
-	return c.OVNNbClient.CreateLogicalRouter(lr)
+	if err := c.OVNNbClient.CreateLogicalRouter(lr); err != nil {
+		klog.Errorf("create logical router %s failed: %v", lr, err)
+		return err
+	}
+
+	vpcRouter, err := c.OVNNbClient.GetLogicalRouter(lr, false)
+	if err != nil {
+		klog.Errorf("get logical router %s failed: %v", lr, err)
+		return err
+	}
+
+	vpcRouter.Options = map[string]string{"always_learn_from_arp_request": "false", "dynamic_neigh_routers": "true", "mac_binding_age_threshold": "300"}
+	err = c.OVNNbClient.UpdateLogicalRouter(vpcRouter)
+	if err != nil {
+		klog.Errorf("update logical router %s failed: %v", lr, err)
+		return err
+	}
+	return nil
 }
 
 // deleteVpcRouter delete router to connect logical switches in vpc

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -27,6 +27,7 @@ type NBGlobal interface {
 
 type LogicalRouter interface {
 	CreateLogicalRouter(lrName string) error
+	UpdateLogicalRouter(lr *ovnnb.LogicalRouter, fields ...interface{}) error
 	DeleteLogicalRouter(lrName string) error
 	LogicalRouterUpdateLoadBalancers(lrName string, op ovsdb.Mutator, lbNames ...string) error
 	GetLogicalRouter(lrName string, ignoreNotFound bool) (*ovnnb.LogicalRouter, error)


### PR DESCRIPTION
always_learn_from_arp_request: false
dynamic_neigh_routers: true
mac_binding_age_threshold: 300

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests
https://github.com/kubeovn/kube-ovn/issues/4604

the fix is refer to  https://bugs.launchpad.net/neutron/+bug/1946318

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #4604
