### PR TITLE
fix: once ovn-encap-csum is set false,it can't be reset to true

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -309,7 +309,11 @@ func (config *Configuration) initNicConfig(nicBridgeMappings map[string]string) 
 	config.MSS = config.MTU - util.TCPIPHeaderLength
 	if !config.EncapChecksum {
 		if err := disableChecksum(); err != nil {
-			klog.Errorf("failed to set checksum offload, %v", err)
+			klog.Errorf("failed to dsiable checksum offload, %v", err)
+		}
+	} else {
+		if err := enableChecksum(); err != nil {
+			klog.Errorf("failed to enable checksum offload, %v", err)
 		}
 	}
 
@@ -419,6 +423,16 @@ func disableChecksum() error {
 		"ovs-vsctl", "set", "open", ".", "external-ids:ovn-encap-csum=false").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to set ovn-encap-csum, %s", string(raw))
+	}
+	return nil
+}
+
+func enableChecksum() error {
+	// #nosec G204
+	raw, err := exec.Command(
+		"ovs-vsctl", "remove", "open", ".", "external-ids", "ovn-encap-csum").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to remove ovn-encap-csum, %s", string(raw))
 	}
 	return nil
 }

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -414,18 +414,9 @@ func setEncapIP(ip string) error {
 
 func setChecksum(encapChecksum bool) error {
 	// #nosec G204
-	if encapChecksum {
-		raw, err := exec.Command(
-			"ovs-vsctl", "remove", "open", ".", "external-ids", "ovn-encap-csum").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("failed to remove ovn-encap-csum, %s", string(raw))
-		}
-	} else {
-		raw, err := exec.Command(
-			"ovs-vsctl", "set", "open", ".", "external-ids:ovn-encap-csum=false").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("failed to set ovn-encap-csum false, %s", string(raw))
-		}
+	raw, err := exec.Command("ovs-vsctl", "set", "open", ".", fmt.Sprintf("external-ids:ovn-encap-csum=%v", encapChecksum)).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to set ovn-encap-csum to %v: %s", encapChecksum, string(raw))
 	}
 	return nil
 }

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -416,6 +416,7 @@ func setChecksum(encapChecksum bool) error {
 	// #nosec G204
 	raw, err := exec.Command("ovs-vsctl", "set", "open", ".", fmt.Sprintf("external-ids:ovn-encap-csum=%v", encapChecksum)).CombinedOutput()
 	if err != nil {
+		klog.Error(err)
 		return fmt.Errorf("failed to set ovn-encap-csum to %v: %s", encapChecksum, string(raw))
 	}
 	return nil


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fix: once ovn-encap-csum is set false,it can't be reset to true