### PR TITLE
[bugfix] When add_eip, send a GARP for eip from net1

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -144,6 +144,7 @@ function add_eip() {
         exec_cmd "ip route replace default via $gateway dev net1"
         ip route | grep "default via $gateway dev net1"
         exec_cmd "arping -I net1 -c 3 -D $eip_without_prefix"
+        exec_cmd "arping -I net1 -c 3 -A $eip_without_prefix "
     done
 }
 


### PR DESCRIPTION
[bugfix] When add_eip, send an ARP packet from net1 to the gateway to announce the EIP to the switch.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

1. Restarting nat-gw will cause external access to EIP traffic to be interrupted and will not be automatically restored.
2. Therefore, when adding add_eip in the nat-gw script, actively send an arp request with src_ip as EIP and sent to the gateway to update the underlying switch arp information.
3. https://github.com/kubeovn/kube-ovn/issues/4690
