### PR TITLE
ut: fix duplicate LSP name

### DIFF
--- a/pkg/ovs/ovn-nb-logical_switch_port_test.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port_test.go
@@ -681,10 +681,11 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchPortSecurity() {
 	})
 
 	t.Run("set logical switch port arp proxy when external ids is nil", func(t *testing.T) {
-		err = nbClient.CreateBareLogicalSwitchPort(lsName, "test-lsp-nil-external-ids", "unknown", "")
+		name := "test-lsp-set-arp-proxy-when-external-ids-is-nil"
+		err = nbClient.CreateBareLogicalSwitchPort(lsName, name, "unknown", "")
 		require.NoError(t, err)
 
-		lsp, err := nbClient.GetLogicalSwitchPort("test-lsp-nil-external-ids", false)
+		lsp, err := nbClient.GetLogicalSwitchPort(name, false)
 		require.NoError(t, err)
 		require.NotNil(t, lsp)
 
@@ -692,7 +693,7 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchPortSecurity() {
 		err = nbClient.UpdateLogicalSwitchPort(lsp, &lsp.ExternalIDs)
 		require.NoError(t, err)
 
-		err = nbClient.SetLogicalSwitchPortSecurity(true, "test-lsp-nil-external-ids", "00:00:00:AB:B4:65", "10.244.0.37,fc00::af4:25", "10.244.100.10,10.244.100.11")
+		err = nbClient.SetLogicalSwitchPortSecurity(true, name, "00:00:00:AB:B4:65", "10.244.0.37,fc00::af4:25", "10.244.100.10,10.244.100.11")
 		require.NoError(t, err)
 	})
 }
@@ -745,10 +746,11 @@ func (suite *OvnClientTestSuite) testSetSetLogicalSwitchPortExternalIDs() {
 	})
 
 	t.Run("set external ids when external ids is nil", func(t *testing.T) {
-		err = nbClient.CreateBareLogicalSwitchPort(lsName, "test-lsp-nil-external-ids", "unknown", "")
+		name := "test-lsp-set-external-ids-when-nil"
+		err = nbClient.CreateBareLogicalSwitchPort(lsName, name, "unknown", "")
 		require.NoError(t, err)
 
-		lsp, err := nbClient.GetLogicalSwitchPort("test-lsp-nil-external-ids", false)
+		lsp, err := nbClient.GetLogicalSwitchPort(name, false)
 		require.NoError(t, err)
 		require.NotNil(t, lsp)
 
@@ -756,10 +758,10 @@ func (suite *OvnClientTestSuite) testSetSetLogicalSwitchPortExternalIDs() {
 		err = nbClient.UpdateLogicalSwitchPort(lsp, &lsp.ExternalIDs)
 		require.NoError(t, err)
 
-		err = nbClient.SetLogicalSwitchPortExternalIDs("test-lsp-nil-external-ids", map[string]string{"k1": "v1"})
+		err = nbClient.SetLogicalSwitchPortExternalIDs(name, map[string]string{"k1": "v1"})
 		require.NoError(t, err)
 
-		lsp, err = nbClient.GetLogicalSwitchPort("test-lsp-nil-external-ids", false)
+		lsp, err = nbClient.GetLogicalSwitchPort(name, false)
 		require.NoError(t, err)
 		require.NotNil(t, lsp)
 		require.NotNil(t, lsp.ExternalIDs)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
--- FAIL: TestOvnClientTestSuite (4.17s)
    --- FAIL: TestOvnClientTestSuite/Test_SetSetLogicalSwitchPortExternalIds (0.01s)
        --- FAIL: TestOvnClientTestSuite/Test_SetSetLogicalSwitchPortExternalIds/set_external_ids_when_external_ids_is_nil (0.00s)
            ovn-nb-logical_switch_port_test.go:749: 
                	Error Trace:	/home/runner/work/kube-ovn/kube-ovn/pkg/ovs/ovn-nb-logical_switch_port_test.go:749
                	Error:      	Received unexpected error:
                	            	create logical switch port test-lsp-nil-external-ids: constraint violation: operation would cause rows in the "Logical_Switch_Port" table to have identical values (test-lsp-nil-external-ids) for index on column "name". First row, with UUID 98f787b5-5134-4919-bdf7-3029abeea41b, was inserted by this transaction. Second row, with UUID [a440b9f2-0dde-4a67-a52d-75c800aa3174], existed in the database before this operation and was not modified
                	Test:       	TestOvnClientTestSuite/Test_SetSetLogicalSwitchPortExternalIds/set_external_ids_when_external_ids_is_nil
```
