### PR TITLE
[bugfix] Optimize node gc method

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -482,7 +482,10 @@ func (c *Controller) handleDeleteNode(key string) error {
 		klog.Warningf("Node %s is adding, skip the node delete handler, but it may leave some gc resources behind", key)
 		return nil
 	}
+	return c.deleteNode(key)
+}
 
+func (c *Controller) deleteNode(key string) error {
 	portName := util.NodeLspName(key)
 	klog.Infof("delete logical switch port %s", portName)
 	if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->
- Bug fixes
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
1. When the controller is stopped, the node is deleted, and then the controller is restarted, the logical router policy with a priority of 29000 is not properly cleared. 
![image](https://github.com/user-attachments/assets/d051a4f2-fc6b-499b-81c4-df7d448fd01d)
2. Although ovn-controller will skip the error in the picture, it will cause some retries，this causes the ovn-controller to start slowly and the flow table information to be delivered slowly in a large-scale cluster(2000+ node,15w+ pod,100+ subnet).
3. #4194 This PR caused the node deletion logic in the gc node to not be actually executed.
