### PR TITLE
The eip is not cleaned after eip is deleted (#4718)

### DIFF
--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -210,7 +210,13 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 	if !cachedEip.DeletionTimestamp.IsZero() {
 		klog.Infof("clean eip %q in pod", key)
 		if vpcNatEnabled == "true" {
-			if err = c.deleteEipInPod(cachedEip.Spec.NatGwDp, v4Cidr); err != nil {
+			v4ipCidr, err := util.GetIPAddrWithMask(cachedEip.Status.IP, v4Cidr)
+			if err != nil {
+				err = fmt.Errorf("failed to get eip %s with mask by cidr %s: %w", cachedEip.Status.IP, v4Cidr, err)
+				klog.Error(err)
+				return err
+			}
+			if err = c.deleteEipInPod(cachedEip.Spec.NatGwDp, v4ipCidr); err != nil {
 				klog.Errorf("failed to clean eip '%s' in pod, %v", key, err)
 				return err
 			}


### PR DESCRIPTION
The ip address in vpc-nat-gw pod is not cleaned after the eip is deleted. This patch fix this problem.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
