### PR TITLE
delete legacy acls when upgrading to v1.13.x (#4742)

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -1871,32 +1871,32 @@ func (mr *MockACLMockRecorder) CreateSgDenyAllACL(sgName any) *gomock.Call {
 }
 
 // DeleteAcls mocks base method.
-func (m *MockACL) DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string) error {
+func (m *MockACL) DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string, tier int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAcls", parentName, parentType, direction, externalIDs)
+	ret := m.ctrl.Call(m, "DeleteAcls", parentName, parentType, direction, externalIDs, tier)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAcls indicates an expected call of DeleteAcls.
-func (mr *MockACLMockRecorder) DeleteAcls(parentName, parentType, direction, externalIDs any) *gomock.Call {
+func (mr *MockACLMockRecorder) DeleteAcls(parentName, parentType, direction, externalIDs, tier any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAcls", reflect.TypeOf((*MockACL)(nil).DeleteAcls), parentName, parentType, direction, externalIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAcls", reflect.TypeOf((*MockACL)(nil).DeleteAcls), parentName, parentType, direction, externalIDs, tier)
 }
 
 // DeleteAclsOps mocks base method.
-func (m *MockACL) DeleteAclsOps(parentName, parentType, direction string, externalIDs map[string]string) ([]ovsdb.Operation, error) {
+func (m *MockACL) DeleteAclsOps(parentName, parentType, direction string, externalIDs map[string]string, tier int) ([]ovsdb.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAclsOps", parentName, parentType, direction, externalIDs)
+	ret := m.ctrl.Call(m, "DeleteAclsOps", parentName, parentType, direction, externalIDs, tier)
 	ret0, _ := ret[0].([]ovsdb.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeleteAclsOps indicates an expected call of DeleteAclsOps.
-func (mr *MockACLMockRecorder) DeleteAclsOps(parentName, parentType, direction, externalIDs any) *gomock.Call {
+func (mr *MockACLMockRecorder) DeleteAclsOps(parentName, parentType, direction, externalIDs, tier any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAclsOps", reflect.TypeOf((*MockACL)(nil).DeleteAclsOps), parentName, parentType, direction, externalIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAclsOps", reflect.TypeOf((*MockACL)(nil).DeleteAclsOps), parentName, parentType, direction, externalIDs, tier)
 }
 
 // SGLostACL mocks base method.
@@ -3150,32 +3150,32 @@ func (mr *MockNbClientMockRecorder) CreateVirtualLogicalSwitchPorts(lsName any, 
 }
 
 // DeleteAcls mocks base method.
-func (m *MockNbClient) DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string) error {
+func (m *MockNbClient) DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string, tier int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAcls", parentName, parentType, direction, externalIDs)
+	ret := m.ctrl.Call(m, "DeleteAcls", parentName, parentType, direction, externalIDs, tier)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAcls indicates an expected call of DeleteAcls.
-func (mr *MockNbClientMockRecorder) DeleteAcls(parentName, parentType, direction, externalIDs any) *gomock.Call {
+func (mr *MockNbClientMockRecorder) DeleteAcls(parentName, parentType, direction, externalIDs, tier any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAcls", reflect.TypeOf((*MockNbClient)(nil).DeleteAcls), parentName, parentType, direction, externalIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAcls", reflect.TypeOf((*MockNbClient)(nil).DeleteAcls), parentName, parentType, direction, externalIDs, tier)
 }
 
 // DeleteAclsOps mocks base method.
-func (m *MockNbClient) DeleteAclsOps(parentName, parentType, direction string, externalIDs map[string]string) ([]ovsdb.Operation, error) {
+func (m *MockNbClient) DeleteAclsOps(parentName, parentType, direction string, externalIDs map[string]string, tier int) ([]ovsdb.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAclsOps", parentName, parentType, direction, externalIDs)
+	ret := m.ctrl.Call(m, "DeleteAclsOps", parentName, parentType, direction, externalIDs, tier)
 	ret0, _ := ret[0].([]ovsdb.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeleteAclsOps indicates an expected call of DeleteAclsOps.
-func (mr *MockNbClientMockRecorder) DeleteAclsOps(parentName, parentType, direction, externalIDs any) *gomock.Call {
+func (mr *MockNbClientMockRecorder) DeleteAclsOps(parentName, parentType, direction, externalIDs, tier any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAclsOps", reflect.TypeOf((*MockNbClient)(nil).DeleteAclsOps), parentName, parentType, direction, externalIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAclsOps", reflect.TypeOf((*MockNbClient)(nil).DeleteAclsOps), parentName, parentType, direction, externalIDs, tier)
 }
 
 // DeleteAddressSet mocks base method.

--- a/pkg/controller/admin_network_policy.go
+++ b/pkg/controller/admin_network_policy.go
@@ -190,7 +190,7 @@ func (c *Controller) handleAddAnp(key string) (err error) {
 		return err
 	}
 
-	ingressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil)
+	ingressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil, util.NilACLTier)
 	if err != nil {
 		klog.Errorf("failed to generate clear operations for anp %s ingress acls: %v", key, err)
 		return err
@@ -266,7 +266,7 @@ func (c *Controller) handleAddAnp(key string) (err error) {
 		return fmt.Errorf("failed to delete unused ingress address set for anp %s: %w", key, err)
 	}
 
-	egressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "from-lport", nil)
+	egressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "from-lport", nil, util.NilACLTier)
 	if err != nil {
 		klog.Errorf("failed to generate clear operations for anp %s egress acls: %v", key, err)
 		return err

--- a/pkg/controller/baseline_admin_network_policy.go
+++ b/pkg/controller/baseline_admin_network_policy.go
@@ -148,7 +148,7 @@ func (c *Controller) handleAddBanp(key string) (err error) {
 		return err
 	}
 
-	ingressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil)
+	ingressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil, util.NilACLTier)
 	if err != nil {
 		klog.Errorf("failed to generate clear operations for banp %s ingress acls: %v", key, err)
 		return err
@@ -225,7 +225,7 @@ func (c *Controller) handleAddBanp(key string) (err error) {
 		return fmt.Errorf("failed to delete unused ingress address set for banp %s: %w", key, err)
 	}
 
-	egressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "from-lport", nil)
+	egressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "from-lport", nil, util.NilACLTier)
 	if err != nil {
 		klog.Errorf("failed to generate clear operations for banp %s egress acls: %v", key, err)
 		return err

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -995,6 +995,8 @@ func (c *Controller) Run(ctx context.Context) {
 		}
 	}
 
+	c.handleUpgrading()
+
 	// start workers to do all the network operations
 	c.startWorkers(ctx)
 
@@ -1128,6 +1130,25 @@ func (c *Controller) shutdown() {
 
 	if c.config.EnableLiveMigrationOptimize {
 		c.addOrUpdateVMIMigrationQueue.ShutDown()
+	}
+}
+
+func (c *Controller) handleUpgrading() {
+	klog.Info("Start upgrading")
+
+	if err := c.upgradeSecurityGroups(); err != nil {
+		util.LogFatalAndExit(err, "failed to upgrade security groups")
+	}
+	if err := c.upgradeSubnets(); err != nil {
+		util.LogFatalAndExit(err, "failed to upgrade subnets")
+	}
+	if c.config.EnableNP {
+		if err := c.upgradeNetworkPolicies(); err != nil {
+			util.LogFatalAndExit(err, "failed to upgrade network policies")
+		}
+	}
+	if err := c.upgradeNodes(); err != nil {
+		util.LogFatalAndExit(err, "failed to upgrade nodes")
 	}
 }
 

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -1,0 +1,36 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func Test_upgradeNetworkPolicies(t *testing.T) {
+	t.Parallel()
+
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	fakeinformers := fakeController.fakeInformers
+	mockOvnClient := fakeController.mockOvnClient
+
+	np := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "np1",
+			Namespace: "default",
+		},
+	}
+
+	err := fakeinformers.npInformer.Informer().GetStore().Add(np)
+	require.NoError(t, err)
+
+	mockOvnClient.EXPECT().DeleteAcls(gomock.Any(), portGroupKey, "", nil, util.DefaultACLTier).Return(nil)
+
+	err = ctrl.upgradeNetworkPolicies()
+	require.NoError(t, err)
+}

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func Test_upgradeNodes(t *testing.T) {
+	t.Parallel()
+
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	fakeinformers := fakeController.fakeInformers
+	mockOvnClient := fakeController.mockOvnClient
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+			Annotations: map[string]string{
+				util.PortNameAnnotation: "node-1",
+			},
+		},
+	}
+
+	err := fakeinformers.nodeInformer.Informer().GetStore().Add(node)
+	require.NoError(t, err)
+
+	mockOvnClient.EXPECT().DeleteAcls(gomock.Any(), portGroupKey, "", nil, util.DefaultACLTier).Return(nil).Times(1)
+
+	err = ctrl.upgradeNodes()
+	require.NoError(t, err)
+}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -162,8 +162,8 @@ type ACL interface {
 	SetACLLog(pgName string, logEnable, isIngress bool) error
 	SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR string, allowSubnets []string) error
 	SGLostACL(sg *kubeovnv1.SecurityGroup) (bool, error)
-	DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string) error
-	DeleteAclsOps(parentName, parentType, direction string, externalIDs map[string]string) ([]ovsdb.Operation, error)
+	DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string, tier int) error
+	DeleteAclsOps(parentName, parentType, direction string, externalIDs map[string]string, tier int) ([]ovsdb.Operation, error)
 	UpdateAnpRuleACLOps(pgName, asName, protocol, aclName string, priority int, aclAction ovnnb.ACLAction, logACLActions []ovnnb.ACLAction, rulePorts []v1alpha1.AdminNetworkPolicyPort, isIngress, isBanp bool) ([]ovsdb.Operation, error)
 }
 

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnsb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 type OvnClientTestSuite struct {
@@ -1248,7 +1249,7 @@ func Test_scratch(t *testing.T) {
 	ovnClient, err := newOvnNbClient(t, endpoint, 10)
 	require.NoError(t, err)
 
-	err = ovnClient.DeleteAcls("test_pg", portGroupKey, ovnnb.ACLDirectionToLport, nil)
+	err = ovnClient.DeleteAcls("test_pg", portGroupKey, ovnnb.ACLDirectionToLport, nil, util.NilACLTier)
 	require.NoError(t, err)
 }
 

--- a/pkg/ovs/ovn-nb.go
+++ b/pkg/ovs/ovn-nb.go
@@ -118,7 +118,7 @@ func (c *OVNNbClient) DeleteSecurityGroup(sgName string) error {
 	pgName := GetSgPortGroupName(sgName)
 
 	// clear acl
-	if err := c.DeleteAcls(pgName, portGroupKey, "", nil); err != nil {
+	if err := c.DeleteAcls(pgName, portGroupKey, "", nil, util.NilACLTier); err != nil {
 		klog.Error(err)
 		return fmt.Errorf("delete acls from port group %s: %w", pgName, err)
 	}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -160,6 +160,8 @@ const (
 	AnpMaxPriority       = 99
 	AnpACLMaxPriority    = 30000
 	BanpACLMaxPriority   = 1800
+	NilACLTier           = -1
+	DefaultACLTier       = 0
 	AnpACLTier           = 1
 	NetpolACLTier        = 2
 	BanpACLTier          = 3


### PR DESCRIPTION
the acls in v1.13.x are in tier 2 rather than tier 0 in v1.12.x, the legacy acls
may cause some unexpected behaviors because acls in tier 0 have the higest priority.
we should delete legacy acls and recreate them when upgrading to v1.13.x.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
