### PR TITLE
fix: can not update LSP into another LS

### DIFF
--- a/pkg/ovs/ovn-nb-logical_switch.go
+++ b/pkg/ovs/ovn-nb-logical_switch.go
@@ -299,7 +299,8 @@ func (c *OVNNbClient) LogicalSwitchUpdatePortOp(lsName, lspUUID string, op ovsdb
 		return nil, nil
 	}
 
-	if lsName == "" && op == ovsdb.MutateOperationDelete {
+	if op == ovsdb.MutateOperationDelete {
+		// given ls for deleting lsp is not always real
 		lsList, err := c.ListLogicalSwitch(false, func(ls *ovnnb.LogicalSwitch) bool {
 			return slices.Contains(ls.Ports, lspUUID)
 		})

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -106,10 +106,15 @@ func (c *OVNNbClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName,
 			}
 			return nil
 		}
-		if ops, err = c.LogicalSwitchUpdatePortOp(existingLsp.ExternalIDs[logicalSwitchKey], existingLsp.UUID, ovsdb.MutateOperationDelete); err != nil {
+		// delete lsp from the old logical switch
+		err := fmt.Errorf("logical switch port %s already exists in old logical switch %s, delete it", lspName, existingLsp.ExternalIDs[logicalSwitchKey])
+		klog.Error(err)
+		if err := c.DeleteLogicalSwitchPort(lspName); err != nil {
 			klog.Error(err)
 			return err
 		}
+		// enqueue to re-create lsp in the new logical switch
+		return err
 	}
 
 	createLspOps, err := c.CreateLogicalSwitchPortOp(lsp, lsName)

--- a/pkg/ovs/ovn-nb-logical_switch_port_test.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port_test.go
@@ -223,7 +223,7 @@ func (suite *OvnClientTestSuite) testCreateLogicalSwitchPort() {
 		err = nbClient.CreateLogicalSwitchPort(lsName, lspName, ips, mac, podName, podNamespace, true, sgs, vips, true, dhcpUUIDs, vpcName)
 		require.NoError(t, err)
 		err = nbClient.CreateLogicalSwitchPort(lsName2, lspName, ips, mac, podName, podNamespace, true, sgs, vips, true, dhcpUUIDs, vpcName)
-		require.NoError(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("failed client create logical switch port op error", func(t *testing.T) {


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

update 端口 ip的时候，需要校验下子网和分配 ip 的子网是一致的,。
ovn 在某一个子网更新使用为另一个子网的 ip 是无效的，
这样会导致 ip 对应的 LSP 无法删除，如果一直使用这个 ip ，在无法自动修复，只能手动清理 LSP。
先添加一种逻辑： 当子网不一致时，需要先清理旧的 LSP。


![image](https://github.com/user-attachments/assets/cdf48123-7768-4845-9ee0-76724c98b91a)


![image](https://github.com/user-attachments/assets/bb7e728f-a32c-4c2f-888a-72d5d396cdf9)





<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
