### PR TITLE
auto detect kubevirt install

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -918,9 +918,6 @@ func Run(ctx context.Context, config *Configuration) {
 		}); err != nil {
 			util.LogFatalAndExit(err, "failed to add VMI Migration event handler")
 		}
-	}
-
-	if controller.config.EnableLiveMigrationOptimize {
 		controller.StartMigrationInformerFactory(ctx, kubevirtInformerFactory)
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -272,7 +272,6 @@ type Controller struct {
 	vmiMigrationSynced           cache.InformerSynced
 	addOrUpdateVMIMigrationQueue workqueue.TypedRateLimitingInterface[string]
 	kubevirtInformerFactory      kubevirtController.KubeInformerFactory
-	hasKubevirtVMIMigration      bool
 
 	recorder               record.EventRecorder
 	informerFactory        kubeinformers.SharedInformerFactory
@@ -638,11 +637,6 @@ func Run(ctx context.Context, config *Configuration) {
 	controller.kubeovnInformerFactory.Start(ctx.Done())
 	controller.anpInformerFactory.Start(ctx.Done())
 
-	controller.hasKubevirtVMIMigration = controller.isVMIMigrationCRDInstalled()
-	if controller.config.EnableLiveMigrationOptimize && controller.hasKubevirtVMIMigration {
-		kubevirtInformerFactory.Start(ctx.Done())
-	}
-
 	klog.Info("Waiting for informer caches to sync")
 	cacheSyncs := []cache.InformerSynced{
 		controller.vpcNatGatewaySynced, controller.vpcEgressGatewaySynced,
@@ -662,10 +656,6 @@ func Run(ctx context.Context, config *Configuration) {
 	}
 	if controller.config.EnableANP {
 		cacheSyncs = append(cacheSyncs, controller.anpsSynced, controller.banpsSynced)
-	}
-
-	if controller.config.EnableLiveMigrationOptimize && controller.hasKubevirtVMIMigration {
-		cacheSyncs = append(cacheSyncs, controller.vmiMigrationSynced)
 	}
 
 	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
@@ -921,13 +911,17 @@ func Run(ctx context.Context, config *Configuration) {
 		}
 	}
 
-	if config.EnableLiveMigrationOptimize && controller.hasKubevirtVMIMigration {
+	if config.EnableLiveMigrationOptimize {
 		if _, err = vmiMigrationInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.enqueueAddVMIMigration,
 			UpdateFunc: controller.enqueueUpdateVMIMigration,
 		}); err != nil {
 			util.LogFatalAndExit(err, "failed to add VMI Migration event handler")
 		}
+	}
+
+	if controller.config.EnableLiveMigrationOptimize {
+		controller.StartMigrationInformerFactory(ctx, kubevirtInformerFactory)
 	}
 
 	controller.Run(ctx)
@@ -1335,7 +1329,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		go wait.Until(runWorker("delete base admin network policy", c.deleteBanpQueue, c.handleDeleteBanp), time.Second, ctx.Done())
 	}
 
-	if c.config.EnableLiveMigrationOptimize && c.hasKubevirtVMIMigration {
+	if c.config.EnableLiveMigrationOptimize {
 		go wait.Until(runWorker("add/update vmiMigration ", c.addOrUpdateVMIMigrationQueue, c.handleAddOrUpdateVMIMigration), 50*time.Millisecond, ctx.Done())
 	}
 }

--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -146,20 +146,18 @@ func (c *Controller) isVMIMigrationCRDInstalled() bool {
 }
 
 func (c *Controller) StartMigrationInformerFactory(ctx context.Context, kubevirtInformerFactory kubevirtController.KubeInformerFactory) {
-	isTaskRunning := false
 	ticker := time.NewTicker(10 * time.Second)
 	go func() {
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				if !isTaskRunning && c.isVMIMigrationCRDInstalled() {
+				if c.isVMIMigrationCRDInstalled() {
 					klog.Info("Start VMI migration informer")
 					kubevirtInformerFactory.Start(ctx.Done())
 					if !cache.WaitForCacheSync(ctx.Done(), c.vmiMigrationSynced) {
 						util.LogFatalAndExit(nil, "failed to wait for vmi migration caches to sync")
 					}
-					isTaskRunning = true
 					return
 				}
 			case <-ctx.Done():

--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -161,6 +161,7 @@ func (c *Controller) StartMigrationInformerFactory(ctx context.Context, kubevirt
 						util.LogFatalAndExit(nil, "failed to wait for vmi migration caches to sync")
 					}
 					isTaskRunning = true
+					return
 				}
 			case <-ctx.Done():
 				close(taskStopCh)

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -514,8 +514,6 @@ func (c *Controller) reconcileAllocateSubnets(cachedPod, pod *v1.Pod, needAlloca
 
 	var err error
 	var vmKey string
-	// var isMigrate, migrated, migratedFail bool
-	// var vmKey, srcNodeName, targetNodeName string
 	if isVMPod && c.config.EnableKeepVMIP {
 		vmKey = fmt.Sprintf("%s/%s", namespace, vmName)
 	}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
有可能kubevirt 比 kube-ovn 晚安装，这个迁移优化的功能就没有及时激活，不太好用，所以想加一个监听kubevirt CRD安装，一旦监听到就开启kubevirt相关informer

本来想做成能够在kubevirt 卸载后，kube-ovn自动关闭informerfactory，然后重新安装，再次启动。但
碰到了一些问题，informerFactory start了以后，通过给stopChan 发消息来关闭，执行shutdown。然后再start ，informer似乎就不会再去监听了。

所以这个PR 就暂时没有考虑 kubevirt 卸载的情况。

- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
