### PR TITLE
fix issue 4803: The two names should have a containment relationship.

### DIFF
--- a/pkg/webhook/static_ip.go
+++ b/pkg/webhook/static_ip.go
@@ -195,7 +195,9 @@ func (v *ValidatingHook) checkIPConflict(ipAddress, annoSubnet, name string, ipL
 				return err
 			}
 			if ipAddr.String() == v4IP || ipAddr.String() == v6IP {
-				if name == ipCR.Spec.PodName {
+				// The IP's spec podName does not equal the Pod name in the request;
+				// The two names have a containment relationship.
+				if strings.Contains(ipCR.Spec.PodName, name) {
 					klog.Infof("get same ip crd for %s", name)
 				} else {
 					err := fmt.Errorf("annotation static-ip %s is conflict with ip crd %s, ip %s", ipAddr.String(), ipCR.Name, ipCR.Spec.IPAddress)


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes


The IP's spec podName does not necessarily equal the Pod name in the request, The two names have a containment relationship.

## Which issue(s) this PR fixes

Fixes #(4803)
