### PR TITLE
ovs: increase cpu amd memory limit

### DIFF
--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -156,8 +156,8 @@ ovs-ovn:
     cpu: "200m"
     memory: "200Mi"
   limits:
-    cpu: "2"
-    memory: "1000Mi"
+    cpu: "4"
+    memory: "2000Mi"
 kube-ovn-controller:
   requests:
     cpu: "200m"

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4370,8 +4370,8 @@ spec:
               cpu: 200m
               memory: 200Mi
             limits:
-              cpu: "2"
-              memory: 1000Mi
+              cpu: "4"
+              memory: 2000Mi
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

在大规模集群场景下（40个节点），ovs-ovn的ds出现了内存使用超过1G的情况（实际占用1.2G），导致ovs的pod out of memery。 
