### PR TITLE
fix(helm): add get on crd for ovn-cr

### DIFF
--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -226,6 +226,12 @@ rules:
       - "list"
       - "watch"
       - "get"
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
When deploying v1.14 using the Helm chart, the OVN serviceaccount cannot list CRDs in the cluster, which is now required for the Kubevirt LiveMigration enhancement that was recently pushed in main.

It is ok when installing using the bash script though, so I simply ported the permission in the chart.