### PR TITLE
refactor: remove redundant policy route addition in node handling

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -246,10 +246,6 @@ func (c *Controller) handleAddNode(key string) error {
 			klog.Errorf("failed to create port group for node %s and subnet %s: %v", node.Name, subnet.Name, err)
 			return err
 		}
-		if err = c.addPolicyRouteForDistributedSubnet(subnet, node.Name, v4IP, v6IP); err != nil {
-			klog.Errorf("failed to add policy router for node %s and subnet %s: %v", node.Name, subnet.Name, err)
-			return err
-		}
 		// policy route for overlay distributed subnet should be reconciled when node ip changed
 		c.addOrUpdateSubnetQueue.Add(subnet.Name)
 	}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Performance

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Subnet handler will sync route policies, no need to add it here. This can partially solve the issue mentioned in #4822.
