### PR TITLE
clean up legacy iptables rules only when iptables/ip6_tables is loaded

### DIFF
--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -31,6 +31,11 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
+const (
+	kernelModuleIPTables  = "ip_tables"
+	kernelModuleIP6Tables = "ip6_tables"
+)
+
 // ControllerRuntime represents runtime specific controller members
 type ControllerRuntime struct {
 	iptables         map[string]*iptables.IPTables
@@ -93,11 +98,17 @@ func (c *Controller) initRuntime() error {
 		}
 		c.iptables[kubeovnv1.ProtocolIPv4] = ipt
 		if c.iptablesObsolete != nil {
-			if ipt, err = iptables.NewWithProtocolAndMode(iptables.ProtocolIPv4, "legacy"); err != nil {
-				klog.Error(err)
-				return err
+			ok, err := kernelModuleLoaded(kernelModuleIPTables)
+			if err != nil {
+				klog.Errorf("failed to check kernel module %s: %v", kernelModuleIPTables, err)
 			}
-			c.iptablesObsolete[kubeovnv1.ProtocolIPv4] = ipt
+			if ok {
+				if ipt, err = iptables.NewWithProtocolAndMode(iptables.ProtocolIPv4, "legacy"); err != nil {
+					klog.Error(err)
+					return err
+				}
+				c.iptablesObsolete[kubeovnv1.ProtocolIPv4] = ipt
+			}
 		}
 		c.ipsets[kubeovnv1.ProtocolIPv4] = ipsets.NewIPSets(ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, IPSetPrefix, nil, nil))
 		c.k8siptables[kubeovnv1.ProtocolIPv4] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv4)
@@ -110,11 +121,17 @@ func (c *Controller) initRuntime() error {
 		}
 		c.iptables[kubeovnv1.ProtocolIPv6] = ipt
 		if c.iptablesObsolete != nil {
-			if ipt, err = iptables.NewWithProtocolAndMode(iptables.ProtocolIPv6, "legacy"); err != nil {
-				klog.Error(err)
-				return err
+			ok, err := kernelModuleLoaded(kernelModuleIP6Tables)
+			if err != nil {
+				klog.Errorf("failed to check kernel module %s: %v", kernelModuleIP6Tables, err)
 			}
-			c.iptablesObsolete[kubeovnv1.ProtocolIPv6] = ipt
+			if ok {
+				if ipt, err = iptables.NewWithProtocolAndMode(iptables.ProtocolIPv6, "legacy"); err != nil {
+					klog.Error(err)
+					return err
+				}
+				c.iptablesObsolete[kubeovnv1.ProtocolIPv6] = ipt
+			}
 		}
 		c.ipsets[kubeovnv1.ProtocolIPv6] = ipsets.NewIPSets(ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, IPSetPrefix, nil, nil))
 		c.k8siptables[kubeovnv1.ProtocolIPv6] = k8siptables.New(c.k8sExec, k8siptables.ProtocolIPv6)
@@ -695,4 +712,20 @@ func rotateLog() {
 	if err != nil {
 		klog.Errorf("failed to rotate kube-ovn log %q", output)
 	}
+}
+
+func kernelModuleLoaded(module string) (bool, error) {
+	data, err := os.ReadFile("/proc/modules")
+	if err != nil {
+		klog.Errorf("failed to read /proc/modules: %v", err)
+		return false, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if fields := strings.Fields(line); len(fields) != 0 && fields[0] == module {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
