### PR TITLE
fix: kube-ovn-controller cannot be ready when ENABLE_METRICS is false

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -84,9 +84,6 @@ func CmdMain() {
 			}()
 		}
 
-		if !config.EnableMetrics {
-			return
-		}
 		metrics.InitKlogMetrics()
 		metrics.InitClientGoMetrics()
 		addr := util.JoinHostPort(metricsAddr, config.PprofPort)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #4862
