### PR TITLE
fix: kube-ovn-cni always dump-flows br-provider per period

### DIFF
--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -204,7 +204,7 @@ func (c *Controller) reconcileRouters(event *subnetEvent) error {
 				return err
 			}
 
-			if pn.Status.Ready {
+			if pn.Status.Ready && slices.Contains(pn.Status.ReadyNodes, c.config.NodeName) {
 				bridgeName := util.ExternalBridgeName(pn.Name)
 				underlayNic := pn.Spec.DefaultInterface
 				for _, item := range pn.Spec.CustomInterfaces {


### PR DESCRIPTION
but this node is in pn.Spec.ExcludeNodes, and then it will generate a lot of logs

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

underlay mode , when node is in the provider-network.Spec.ExcludeNodes,  the kube-ovn-cni will generate lots of logs like below

![image](https://github.com/user-attachments/assets/175916f7-e9b4-46e7-b5a9-a63aeb81faa3)

