### PR TITLE
fix: kube-ovn-cni always dump-flows br-provider per period

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -656,7 +656,7 @@ func (c *Controller) reconcileRouters(event *subnetEvent) error {
 				return err
 			}
 
-			if pn.Status.Ready {
+			if pn.Status.Ready && slices.Contains(pn.Status.ReadyNodes, c.config.NodeName) {
 				bridgeName := util.ExternalBridgeName(pn.Name)
 				underlayNic := pn.Spec.DefaultInterface
 				for _, item := range pn.Spec.CustomInterfaces {


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
