### PR TITLE
e2e: fix ip conflict

### DIFF
--- a/test/e2e/kube-ovn/ipam/ipam.go
+++ b/test/e2e/kube-ovn/ipam/ipam.go
@@ -3,6 +3,7 @@ package ipam
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -607,8 +608,16 @@ var _ = framework.Describe("[group:ipam]", func() {
 		ipsCount := 1
 
 		ginkgo.By("Creating IPPool resources ")
-		ipsRange1 := framework.RandomIPPool(cidr, ipsCount)
-		ipsRange2 := framework.RandomIPPool(cidr, ipsCount)
+		ipsRange := framework.RandomIPPool(cidr, ipsCount*2)
+		ipv4Range, ipv6Range := util.SplitIpsByProtocol(ipsRange)
+		var ipsRange1, ipsRange2 []string
+		if f.HasIPv4() {
+			ipsRange1, ipsRange2 = slices.Clone(ipv4Range[:ipsCount]), slices.Clone(ipv4Range[ipsCount:])
+		}
+		if f.HasIPv6() {
+			ipsRange1 = append(ipsRange1, ipv6Range[:ipsCount]...)
+			ipsRange2 = append(ipsRange2, ipv6Range[ipsCount:]...)
+		}
 		ippool1 := framework.MakeIPPool(ippoolName, subnetName, ipsRange1, []string{namespaceName})
 		ippool2 := framework.MakeIPPool(ippoolName2, subnetName, ipsRange2, []string{namespaceName})
 		ippoolClient.CreateSync(ippool1)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes occasional e2e test failure:

```txt
INFO: Condition Ready of ippool ippool2-686267735 is false instead of true. Reason: UpdateIPAMFailed, message: ippool ippool2-686267735 has conflict IPs with ippool ippool-621146943: 10.246.192.197
```
