### PR TITLE
feat(GC): Add check for GC disabled

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -186,7 +186,7 @@ func ParseFlags() (*Configuration, error) {
 		argExternalGatewayVlanID   = pflag.Int("external-gateway-vlanid", 0, "The vlanId of port ln-ovn-external, default: 0")
 		argNodeLocalDNSIP          = pflag.String("node-local-dns-ip", "", "Comma-separated string of nodelocal DNS ip addresses")
 
-		argGCInterval      = pflag.Int("gc-interval", 360, "The interval between GC processes, default 360 seconds")
+		argGCInterval      = pflag.Int("gc-interval", 360, "The interval between GC processes, default 360 seconds. If set to 0, GC will be disabled")
 		argInspectInterval = pflag.Int("inspect-interval", 20, "The interval between inspect processes, default 20 seconds")
 
 		argBfdMinTx      = pflag.Int("bfd-min-tx", 100, "This is the minimum interval, in milliseconds, ovn would like to use when transmitting BFD Control packets")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1243,11 +1243,13 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		c.resyncVpcNatConfig()
 	}, time.Second, ctx.Done())
 
-	go wait.Until(func() {
-		if err := c.markAndCleanLSP(); err != nil {
-			klog.Errorf("gc lsp error: %v", err)
-		}
-	}, time.Duration(c.config.GCInterval)*time.Second, ctx.Done())
+	if c.config.GCInterval != 0 {
+		go wait.Until(func() {
+			if err := c.markAndCleanLSP(); err != nil {
+				klog.Errorf("gc lsp error: %v", err)
+			}
+		}, time.Duration(c.config.GCInterval)*time.Second, ctx.Done())
+	}
 
 	go wait.Until(func() {
 		if err := c.inspectPod(); err != nil {

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -27,6 +27,10 @@ import (
 var lastNoPodLSP = strset.New()
 
 func (c *Controller) gc() error {
+	if c.config.GCInterval == 0 {
+		klog.Infof("gc is disabled")
+		return nil
+	}
 	gcFunctions := []func() error{
 		c.gcNode,
 		c.gcChassis,


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

No user facing changes, the GCInterval option now respects a zero value.

- Features
- Bug fixes

This change implements a simple check, if the GCInterval is set to the GC methods will not run, even on server start. This change allows an operator to run kube-ovn in mixed environments without worry that garbage collection would inadvertently destroy something it shouldn't.

## Which issue(s) this PR fixes

Fixes https://github.com/kubeovn/kube-ovn/issues/4995
