### PR TITLE
bfd: fix bfdd-control setting mintx/minrx

### DIFF
--- a/dist/images/bfdd-prestart.sh
+++ b/dist/images/bfdd-prestart.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-bfdd-control session new set mintx "${BFD_MIN_TX:-1000}"
-bfdd-control session new set minrx "${BFD_MIN_RX:-1000}"
+bfdd-control session new set mintx "${BFD_MIN_TX:-1000}" ms
+bfdd-control session new set minrx "${BFD_MIN_RX:-1000}" ms
 bfdd-control session new set multi "${BFD_MULTI:-3}"
 
 PEER_IPS=($(echo "${BFD_PEER_IPS:-::}" | tr ',' ' '))


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```shell
$ bfdd-control session new set mintx 1000
Must supply a unit after the value 1000: 's', 'ms' or 'us'
$ bfdd-control session new set mintx 1000 ms
Attempting to set mintx to 1,000,000 us.
```
