### PR TITLE
feat: Make Kube-OVN namespace configurable with default value

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-KUBE_OVN_NS=kube-system
+KUBE_OVN_NS=${KUBE_OVN_NS:-kube-system}
 WITHOUT_KUBE_PROXY=${WITHOUT_KUBE_PROXY:-false}
 OVN_NB_POD=
 OVN_SB_POD=


### PR DESCRIPTION
Allow customization of the Kube-OVN namespace by introducing a default value of 'kube-system' using parameter expansion

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #5024
