### PR TITLE
feat: Improve subnet and VPC finalizer handling

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -361,7 +361,7 @@ func (c *Controller) syncSubnetFinalizer(cl client.Client) error {
 }
 
 func (c *Controller) handleSubnetFinalizer(subnet *kubeovnv1.Subnet) (*kubeovnv1.Subnet, bool, error) {
-	if subnet.DeletionTimestamp.IsZero() && len(subnet.GetFinalizers()) == 0 {
+	if subnet.DeletionTimestamp.IsZero() && !slices.Contains(subnet.GetFinalizers(), util.KubeOVNControllerFinalizer) {
 		newSubnet := subnet.DeepCopy()
 		controllerutil.AddFinalizer(newSubnet, util.KubeOVNControllerFinalizer)
 		patch, err := util.GenerateMergePatchPayload(subnet, newSubnet)

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -421,6 +421,8 @@ var _ = framework.SerialDescribe("[group:iptables-vpc-nat-gw]", func() {
 		cm.Data["image"] = oldImage
 		_, err = f.ClientSet.CoreV1().ConfigMaps(framework.KubeOvnNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
+		vpcNatGwClient.DeleteSync(vpcNatGwName)
+		subnetClient.DeleteSync(overlaySubnetName + "image")
 	})
 
 	framework.ConformanceIt("iptables eip fip snat dnat", func() {
@@ -545,16 +547,8 @@ var _ = framework.SerialDescribe("[group:iptables-vpc-nat-gw]", func() {
 		vipClient.DeleteSync(dnatVipName)
 		ginkgo.By("Deleting vip " + sharedVipName)
 		vipClient.DeleteSync(sharedVipName)
-
-		ginkgo.By("Deleting custom vpc " + vpcName)
-		vpcClient.DeleteSync(vpcName)
-
-		ginkgo.By("Deleting custom vpc nat gw")
-		vpcNatGwClient.DeleteSync(vpcNatGwName)
-
 		// the only pod for vpc nat gateway
 		vpcNatGwPodName := util.GenNatGwPodName(vpcNatGwName)
-
 		// delete vpc nat gw statefulset remaining ip for eth0 and net1
 		overlaySubnet := subnetClient.Get(overlaySubnetName)
 		macvlanSubnet := subnetClient.Get(networkAttachDefName)
@@ -567,6 +561,12 @@ var _ = framework.SerialDescribe("[group:iptables-vpc-nat-gw]", func() {
 
 		ginkgo.By("Deleting overlay subnet " + overlaySubnetName)
 		subnetClient.DeleteSync(overlaySubnetName)
+
+		ginkgo.By("Deleting custom vpc nat gw")
+		vpcNatGwClient.DeleteSync(vpcNatGwName)
+
+		ginkgo.By("Deleting custom vpc " + vpcName)
+		vpcClient.DeleteSync(vpcName)
 
 		// multiple external network case
 		net2OverlaySubnetV4Cidr := "10.0.1.0/24"
@@ -590,9 +590,6 @@ var _ = framework.SerialDescribe("[group:iptables-vpc-nat-gw]", func() {
 		ginkgo.By("Deleting iptables eip " + net2EipName)
 		iptablesEIPClient.DeleteSync(net2EipName)
 
-		ginkgo.By("Deleting custom vpc " + net2VpcName)
-		vpcClient.DeleteSync(net2VpcName)
-
 		ginkgo.By("Deleting custom vpc nat gw")
 		vpcNatGwClient.DeleteSync(net2VpcNatGwName)
 
@@ -614,6 +611,9 @@ var _ = framework.SerialDescribe("[group:iptables-vpc-nat-gw]", func() {
 
 		ginkgo.By("Deleting overlay subnet " + net2OverlaySubnetName)
 		subnetClient.DeleteSync(net2OverlaySubnetName)
+
+		ginkgo.By("Deleting custom vpc " + net2VpcName)
+		vpcClient.DeleteSync(net2VpcName)
 	})
 })
 
@@ -1318,12 +1318,6 @@ var _ = framework.Describe("[group:qos-policy]", func() {
 			ginkgo.By("Deleting pod " + vpcQosParams.vpc2PodName)
 			podClient.DeleteSync(vpcQosParams.vpc2PodName)
 
-			ginkgo.By("Deleting custom vpc " + vpcQosParams.vpc1Name)
-			vpcClient.DeleteSync(vpcQosParams.vpc1Name)
-
-			ginkgo.By("Deleting custom vpc " + vpcQosParams.vpc2Name)
-			vpcClient.DeleteSync(vpcQosParams.vpc2Name)
-
 			ginkgo.By("Deleting custom vpc nat gw " + vpcQosParams.vpcNat1GwName)
 			vpcNatGwClient.DeleteSync(vpcQosParams.vpcNat1GwName)
 
@@ -1357,6 +1351,12 @@ var _ = framework.Describe("[group:qos-policy]", func() {
 			ipClient.DeleteSync(net1IpName)
 			ginkgo.By("Deleting overlay subnet " + vpcQosParams.vpc2SubnetName)
 			subnetClient.DeleteSync(vpcQosParams.vpc2SubnetName)
+
+			ginkgo.By("Deleting custom vpc " + vpcQosParams.vpc1Name)
+			vpcClient.DeleteSync(vpcQosParams.vpc1Name)
+
+			ginkgo.By("Deleting custom vpc " + vpcQosParams.vpc2Name)
+			vpcClient.DeleteSync(vpcQosParams.vpc2Name)
 		})
 		framework.ConformanceIt("default nic qos", func() {
 			// case 1: set qos policy for natgw

--- a/test/e2e/kube-ovn/pod/vpc_pod_probe.go
+++ b/test/e2e/kube-ovn/pod/vpc_pod_probe.go
@@ -30,7 +30,7 @@ var _ = framework.SerialDescribe("[group:pod]", func() {
 	var eventClient *framework.EventClient
 	var subnetClient *framework.SubnetClient
 	var vpcClient *framework.VpcClient
-	var namespaceName, subnetName, podName, vpcName string
+	var namespaceName, subnetName, podName, vpcName, custVPCSubnetName string
 	var subnet *apiv1.Subnet
 	var cidr string
 
@@ -43,6 +43,7 @@ var _ = framework.SerialDescribe("[group:pod]", func() {
 		subnetName = "subnet-" + framework.RandomSuffix()
 		podName = "pod-" + framework.RandomSuffix()
 		cidr = framework.RandomCIDR(f.ClusterIPFamily)
+		custVPCSubnetName = "subnet-" + framework.RandomSuffix()
 
 		ginkgo.By("Creating subnet " + subnetName)
 		subnet = framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, []string{namespaceName})
@@ -54,6 +55,7 @@ var _ = framework.SerialDescribe("[group:pod]", func() {
 
 		ginkgo.By("Deleting subnet " + subnetName)
 		subnetClient.DeleteSync(subnetName)
+		subnetClient.DeleteSync(custVPCSubnetName)
 
 		ginkgo.By("Deleting VPC " + vpcName)
 		vpcClient.DeleteSync(vpcName)
@@ -77,12 +79,6 @@ var _ = framework.SerialDescribe("[group:pod]", func() {
 		newArgs = append(newArgs, "--enable-tproxy=true")
 		modifyDs.Spec.Template.Spec.Containers[0].Args = newArgs
 		daemonSetClient.PatchSync(modifyDs)
-
-		custVPCSubnetName := "subnet-" + framework.RandomSuffix()
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting subnet " + custVPCSubnetName)
-			subnetClient.DeleteSync(custVPCSubnetName)
-		})
 
 		ginkgo.By("Creating VPC " + vpcName)
 		vpcName = "vpc-" + framework.RandomSuffix()


### PR DESCRIPTION
- Add finalizer to subnet and VPC resources if not present
- Remove VPC finalizer when no subnets exist
- Enhance VPC status management by adding subnets to queue when empty
- Use slices.Contains for more idiomatic finalizer checks

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #5068
