### PR TITLE
fix: egress network policy not work, when no pod hit matchlabel

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -337,15 +337,18 @@ func (c *Controller) handleUpdateNp(key string) error {
 					return err
 				}
 
+				npp := []netv1.NetworkPolicyPort{}
 				if len(allows) != 0 || len(excepts) != 0 {
-					ops, err := c.OVNNbClient.UpdateEgressACLOps(pgName, egressAllowAsName, egressExceptAsName, protocol, aclName, npr.Ports, logEnable, logActions, namedPortMap)
-					if err != nil {
-						klog.Errorf("generate operations that add egress acls to np %s: %v", key, err)
-						return err
-					}
-
-					egressACLOps = append(egressACLOps, ops...)
+					npp = npr.Ports
 				}
+
+				ops, err := c.OVNNbClient.UpdateEgressACLOps(pgName, egressAllowAsName, egressExceptAsName, protocol, aclName, npp, logEnable, logActions, namedPortMap)
+				if err != nil {
+					klog.Errorf("generate operations that add egress acls to np %s: %v", key, err)
+					return err
+				}
+
+				egressACLOps = append(egressACLOps, ops...)
 			}
 			if len(np.Spec.Egress) == 0 {
 				egressAllowAsName := fmt.Sprintf("%s.%s.all", egressAllowAsNamePrefix, protocol)


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes
### repeat step
1. apply network policy like this, and  `service.cpaas.io/name: deployment-qaimages3` does not match any pod.
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: test
  namespace: kube-system
spec:
  egress:
    - to:
        - podSelector:
            matchLabels:
              service.cpaas.io/name: deployment-qaimages3
  podSelector:
    matchLabels:
      app: my-app
  policyTypes:
    - Egress
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-app
  namespace: kube-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app: my-app
  template:
    metadata:
      labels:
        app: my-app
    spec:
      containers:
      - name: my-app-container
        image: nginx:alpine
        ports:
        - containerPort: 80
```

### expect result:
the deploy my-app can't access any pod
### actually result:
the deploy my-app can access any pod

## Which issue(s) this PR fixes

Fixes #(issue-number)
