### PR TITLE
feat(controller): skip appending VM LSPs if default Multus network is…

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -968,8 +968,17 @@ func (c *Controller) getVMLsps() []string {
 			continue
 		}
 		for _, vm := range vms.Items {
-			vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, util.OvnProvider)
-			vmLsps = append(vmLsps, vmLsp)
+			defaultMultus := false
+			for _, network := range vm.Spec.Template.Spec.Networks {
+				if network.Multus != nil && network.Multus.Default {
+					defaultMultus = true
+					break
+				}
+			}
+			if !defaultMultus {
+				vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, util.OvnProvider)
+				vmLsps = append(vmLsps, vmLsp)
+			}
 
 			attachNets, err := nadutils.ParseNetworkAnnotation(vm.Spec.Template.ObjectMeta.Annotations[nadv1.NetworkAttachmentAnnot], vm.Namespace)
 			if err != nil {


### PR DESCRIPTION
… present

Updated the logic in getVMLsps to check for a default Multus network in VM specifications. If a default Multus network is found, the corresponding VM LSP will not be appended to the list. This change ensures that only VMs without a default Multus network are processed for LSP creation.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #5087 
