### PR TITLE
enable check vlan conflict

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2994,6 +2994,8 @@ spec:
                   type: array
                   items:
                     type: string
+                conflict:
+                  type: bool
       additionalPrinterColumns:
       - name: ID
         type: string
@@ -3001,6 +3003,9 @@ spec:
       - name: Provider
         type: string
         jsonPath: .spec.provider
+      - name: conflict
+        type: bool
+        jsonPath: .status.conflict
   scope: Cluster
   names:
     plural: vlans

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -32,6 +32,7 @@ EXCHANGE_LINK_NAME=${EXCHANGE_LINK_NAME:-false}
 # The nic to support container network can be a nic name or a group of regex
 # separated by comma, if empty will use the nic that the default route use
 IFACE=${IFACE:-}
+IFACE=${IFACE:-bond0.123}
 # Specifies the name of the dpdk tunnel iface.
 # Note that the dpdk tunnel iface and tunnel ip cidr should be diffierent with Kubernetes api cidr, otherwise the route will be a problem.
 DPDK_TUNNEL_IFACE=${DPDK_TUNNEL_IFACE:-br-phy}

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4908,7 +4908,6 @@ spec:
         args:
           - --enable-mirror=$ENABLE_MIRROR
           - --enable-arp-detect-ip-conflict=$ENABLE_ARP_DETECT_IP_CONFLICT
-          - --enable-check-vlan-conflict=true
           - --encap-checksum=true
           - --service-cluster-ip-range=$SVC_CIDR
           - --iface=${IFACE}

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4924,6 +4924,7 @@ spec:
           - --secure-serving=${SECURE_SERVING}
           - --enable-ovn-ipsec=$ENABLE_OVN_IPSEC
           - --set-vxlan-tx-off=$SET_VXLAN_TX_OFF
+          - --enable-check-vlan-conflicts=true
         securityContext:
           runAsUser: 0
           privileged: false

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2995,7 +2995,7 @@ spec:
                   items:
                     type: string
                 conflict:
-                  type: bool
+                  type: boolean
       additionalPrinterColumns:
       - name: ID
         type: string
@@ -3004,7 +3004,7 @@ spec:
         type: string
         jsonPath: .spec.provider
       - name: conflict
-        type: bool
+        type: boolean
         jsonPath: .status.conflict
   scope: Cluster
   names:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4907,6 +4907,7 @@ spec:
         args:
           - --enable-mirror=$ENABLE_MIRROR
           - --enable-arp-detect-ip-conflict=$ENABLE_ARP_DETECT_IP_CONFLICT
+          - --enable-check-vlan-conflict=true
           - --encap-checksum=true
           - --service-cluster-ip-range=$SVC_CIDR
           - --iface=${IFACE}
@@ -4924,7 +4925,6 @@ spec:
           - --secure-serving=${SECURE_SERVING}
           - --enable-ovn-ipsec=$ENABLE_OVN_IPSEC
           - --set-vxlan-tx-off=$SET_VXLAN_TX_OFF
-          - --enable-check-vlan-conflicts=true
         securityContext:
           runAsUser: 0
           privileged: false

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -32,7 +32,6 @@ EXCHANGE_LINK_NAME=${EXCHANGE_LINK_NAME:-false}
 # The nic to support container network can be a nic name or a group of regex
 # separated by comma, if empty will use the nic that the default route use
 IFACE=${IFACE:-}
-IFACE=${IFACE:-bond0.123}
 # Specifies the name of the dpdk tunnel iface.
 # Note that the dpdk tunnel iface and tunnel ip cidr should be diffierent with Kubernetes api cidr, otherwise the route will be a problem.
 DPDK_TUNNEL_IFACE=${DPDK_TUNNEL_IFACE:-br-phy}

--- a/pkg/apis/kubeovn/v1/vlan.go
+++ b/pkg/apis/kubeovn/v1/vlan.go
@@ -38,7 +38,7 @@ type VlanStatus struct {
 	// +patchStrategy=merge
 	Subnets []string `json:"subnets,omitempty"`
 
-	Conflict bool `json:"conflicts,omitempty"`
+	Conflict bool `json:"conflict,omitempty"`
 
 	// Conditions represents the latest state of the object
 	// +optional

--- a/pkg/apis/kubeovn/v1/vlan.go
+++ b/pkg/apis/kubeovn/v1/vlan.go
@@ -38,6 +38,8 @@ type VlanStatus struct {
 	// +patchStrategy=merge
 	Subnets []string `json:"subnets,omitempty"`
 
+	Conflict bool `json:"conflicts,omitempty"`
+
 	// Conditions represents the latest state of the object
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -179,7 +179,7 @@ func ParseFlags() (*Configuration, error) {
 		argEnableMetrics               = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableANP                   = pflag.Bool("enable-anp", false, "Enable support for admin network policy and baseline admin network policy")
 		argEnableOVNIPSec              = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
-		argEnableCheckVlanConflict     = pflag.Bool("enable-check-vlan-conflict", true, "Whether to enable check vlan conflict")
+		argEnableCheckVlanConflict     = pflag.Bool("enable-check-vlan-conflict", false, "Whether to enable check vlan conflict")
 		argEnableLiveMigrationOptimize = pflag.Bool("enable-live-migration-optimize", true, "Whether to enable kubevirt live migration optimize")
 
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -96,6 +96,7 @@ type Configuration struct {
 	EnableMetrics               bool
 	EnableANP                   bool
 	EnableOVNIPSec              bool
+	EnableCheckVlanConflict     bool
 	EnableLiveMigrationOptimize bool
 
 	ExternalGatewaySwitch   string
@@ -178,6 +179,7 @@ func ParseFlags() (*Configuration, error) {
 		argEnableMetrics               = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableANP                   = pflag.Bool("enable-anp", false, "Enable support for admin network policy and baseline admin network policy")
 		argEnableOVNIPSec              = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
+		argEnableCheckVlanConflict     = pflag.Bool("enable-check-vlan-conflict", true, "Whether to enable check vlan conflict")
 		argEnableLiveMigrationOptimize = pflag.Bool("enable-live-migration-optimize", true, "Whether to enable kubevirt live migration optimize")
 
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")
@@ -273,6 +275,7 @@ func ParseFlags() (*Configuration, error) {
 		EnableLbSvc:                    *argEnableLbSvc,
 		EnableMetrics:                  *argEnableMetrics,
 		EnableOVNIPSec:                 *argEnableOVNIPSec,
+		EnableCheckVlanConflict:        *argEnableCheckVlanConflict,
 		EnableLiveMigrationOptimize:    *argEnableLiveMigrationOptimize,
 		BfdMinTx:                       *argBfdMinTx,
 		BfdMinRx:                       *argBfdMinRx,

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -621,14 +621,14 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	subnet := cachedSubnet.DeepCopy()
 	subnet, err = c.formatSubnet(subnet)
 	if err != nil {
-		err := fmt.Errorf("failed to format subnet %s, %v", key, err)
+		err := fmt.Errorf("failed to format subnet %s, %w", key, err)
 		klog.Error(err)
 		return err
 	}
 
 	err = c.validateSubnetVlan(subnet)
 	if err != nil {
-		err := fmt.Errorf("failed to format subnet %s, %v", key, err)
+		err := fmt.Errorf("failed to format subnet %s, %w", key, err)
 		klog.Error(err)
 		if err = c.patchSubnetStatus(subnet, "ValidateSubnetVlanFailed", err.Error()); err != nil {
 			klog.Error(err)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -179,12 +179,10 @@ func (c *Controller) formatSubnet(subnet *kubeovnv1.Subnet) (*kubeovnv1.Subnet, 
 			klog.Error(err)
 			return nil, err
 		}
-		if c.config.EnableCheckVlanConflict {
-			if vlan.Status.Conflict {
-				err = fmt.Errorf("subnet %s vlan %s is conflict in cluster", subnet.Name, vlan.Name)
-				klog.Error(err)
-				return nil, err
-			}
+		if c.config.EnableCheckVlanConflict && vlan.Status.Conflict {
+			err = fmt.Errorf("subnet %s vlan %s is conflict, please see vlan provider network for more details", subnet.Name, vlan.Name)
+			klog.Error(err)
+			return nil, err
 		}
 	}
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -180,7 +180,7 @@ func (c *Controller) formatSubnet(subnet *kubeovnv1.Subnet) (*kubeovnv1.Subnet, 
 			return nil, err
 		}
 		if c.config.EnableCheckVlanConflict && vlan.Status.Conflict {
-			err = fmt.Errorf("subnet %s has conflict vlan %s, please see its vlan provider network for more details", subnet.Name, vlan.Name)
+			err = fmt.Errorf("subnet %s has conflict vlan %s, please see kube-ovn-cni pod for more details", subnet.Name, vlan.Name)
 			klog.Error(err)
 			return nil, err
 		}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -179,10 +179,12 @@ func (c *Controller) formatSubnet(subnet *kubeovnv1.Subnet) (*kubeovnv1.Subnet, 
 			klog.Error(err)
 			return nil, err
 		}
-		if vlan.Status.Conflict {
-			err = fmt.Errorf("subnet %s vlan %s is conflict in cluster", subnet.Name, vlan.Name)
-			klog.Error(err)
-			return nil, err
+		if c.config.EnableCheckVlanConflict {
+			if vlan.Status.Conflict {
+				err = fmt.Errorf("subnet %s vlan %s is conflict in cluster", subnet.Name, vlan.Name)
+				klog.Error(err)
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -173,8 +173,14 @@ func (c *Controller) formatSubnet(subnet *kubeovnv1.Subnet) (*kubeovnv1.Subnet, 
 	}
 
 	if subnet.Spec.Vlan != "" {
-		if _, err := c.vlansLister.Get(subnet.Spec.Vlan); err != nil {
+		vlan, err := c.vlansLister.Get(subnet.Spec.Vlan)
+		if err != nil {
 			err = fmt.Errorf("failed to get vlan %s: %w", subnet.Spec.Vlan, err)
+			klog.Error(err)
+			return nil, err
+		}
+		if vlan.Status.Conflict {
+			err = fmt.Errorf("subnet %s vlan %s is conflict in cluster", subnet.Name, vlan.Name)
 			klog.Error(err)
 			return nil, err
 		}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -617,6 +617,10 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	if err != nil {
 		err := fmt.Errorf("failed to format subnet %s, %v", key, err)
 		klog.Error(err)
+		if err = c.patchSubnetStatus(subnet, "FormatSubnetFailed", err.Error()); err != nil {
+			klog.Error(err)
+			return err
+		}
 		return err
 	}
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -628,7 +628,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 
 	err = c.validateSubnetVlan(subnet)
 	if err != nil {
-		err := fmt.Errorf("failed to format subnet %s, %w", key, err)
+		err := fmt.Errorf("failed to validate vlan for subnet %s, %w", key, err)
 		klog.Error(err)
 		if err = c.patchSubnetStatus(subnet, "ValidateSubnetVlanFailed", err.Error()); err != nil {
 			klog.Error(err)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -180,7 +180,7 @@ func (c *Controller) formatSubnet(subnet *kubeovnv1.Subnet) (*kubeovnv1.Subnet, 
 			return nil, err
 		}
 		if c.config.EnableCheckVlanConflict && vlan.Status.Conflict {
-			err = fmt.Errorf("subnet %s vlan %s is conflict, please see vlan provider network for more details", subnet.Name, vlan.Name)
+			err = fmt.Errorf("subnet %s has conflict vlan %s, please see its vlan provider network for more details", subnet.Name, vlan.Name)
 			klog.Error(err)
 			return nil, err
 		}

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -59,50 +59,52 @@ func (c *Controller) handleAddVlan(key string) error {
 		}
 	}
 
-	// todo: check if vlan conflict in webhook
-	conflict := false
-	// check if vlan conflict with node tunnel vlan
-	nodes, err := c.nodesLister.List(labels.SelectorFromSet(labels.Set{util.TunnelUseVlanLabel: "true"}))
-	if err != nil {
-		klog.Errorf("failed to list nodes: %v", err)
-		return err
-	}
-	nodeTunVlanIDs := strset.New()
-	for _, node := range nodes {
-		id := node.Labels[util.TunnelVlanIDLabel]
-		nodeTunVlanIDs.Add(id)
-		if id == strconv.Itoa(vlan.Spec.ID) {
-			conflict = true
-			err = fmt.Errorf("vlan %s id %s conflict with node %s tunnel nic vlan", vlan.Name, id, node.Name)
-			klog.Error(err)
-		}
-	}
-
-	if nodeTunVlanIDs.Size() > 1 {
-		klog.Warningf("cluster nodes tunnel nic span multi vlan ids: %v", nodeTunVlanIDs.List())
-	}
-	// check if new vlan conflict with other vlans
-	vlans, err := c.vlansLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list vlans: %v", err)
-		return err
-	}
-	for _, vlan := range vlans {
-		if vlan.Spec.ID == cachedVlan.Spec.ID && vlan.Name != cachedVlan.Name {
-			conflict = true
-			err = fmt.Errorf("new vlan %s conflict with vlan %s", cachedVlan.Name, vlan.Name)
-			klog.Error(err)
-			continue
-		}
-	}
-	if conflict {
-		vlan.Status.Conflict = true
-		vlan, err = c.config.KubeOvnClient.KubeovnV1().Vlans().UpdateStatus(context.Background(), vlan, metav1.UpdateOptions{})
+	if c.config.EnableCheckVlanConflict {
+		// todo: check if vlan conflict in webhook
+		conflict := false
+		// check if vlan conflict with node tunnel vlan
+		nodes, err := c.nodesLister.List(labels.SelectorFromSet(labels.Set{util.TunnelUseVlanLabel: "true"}))
 		if err != nil {
-			klog.Errorf("failed to update conflict status of vlan %s: %v", vlan.Name, err)
+			klog.Errorf("failed to list nodes: %v", err)
 			return err
 		}
-		return err
+		nodeTunVlanIDs := strset.New()
+		for _, node := range nodes {
+			id := node.Labels[util.TunnelVlanIDLabel]
+			nodeTunVlanIDs.Add(id)
+			if id == strconv.Itoa(vlan.Spec.ID) {
+				conflict = true
+				err = fmt.Errorf("vlan %s id %s conflict with node %s tunnel nic vlan", vlan.Name, id, node.Name)
+				klog.Error(err)
+			}
+		}
+
+		if nodeTunVlanIDs.Size() > 1 {
+			klog.Warningf("cluster nodes tunnel nic span multi vlan ids: %v", nodeTunVlanIDs.List())
+		}
+		// check if new vlan conflict with other vlans
+		vlans, err := c.vlansLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to list vlans: %v", err)
+			return err
+		}
+		for _, vlan := range vlans {
+			if vlan.Spec.ID == cachedVlan.Spec.ID && vlan.Name != cachedVlan.Name {
+				conflict = true
+				err = fmt.Errorf("new vlan %s conflict with vlan %s", cachedVlan.Name, vlan.Name)
+				klog.Error(err)
+				continue
+			}
+		}
+		if conflict {
+			vlan.Status.Conflict = true
+			vlan, err = c.config.KubeOvnClient.KubeovnV1().Vlans().UpdateStatus(context.Background(), vlan, metav1.UpdateOptions{})
+			if err != nil {
+				klog.Errorf("failed to update conflict status of vlan %s: %v", vlan.Name, err)
+				return err
+			}
+			return err
+		}
 	}
 
 	subnets, err := c.subnetsLister.List(labels.Everything())

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -6,15 +6,17 @@ import (
 	"slices"
 	"strconv"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/scylladb/go-set/strset"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (c *Controller) enqueueAddVlan(obj interface{}) {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -6,15 +6,16 @@ import (
 	"slices"
 	"strconv"
 
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/ovs"
-	"github.com/kubeovn/kube-ovn/pkg/util"
-	"github.com/scylladb/go-set/strset"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/scylladb/go-set/strset"
 )
 
 func (c *Controller) enqueueAddVlan(obj interface{}) {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/scylladb/go-set/strset"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -15,7 +16,6 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
-	"github.com/scylladb/go-set/strset"
 )
 
 func (c *Controller) enqueueAddVlan(obj interface{}) {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -60,14 +60,6 @@ func (c *Controller) handleAddVlan(key string) error {
 		}
 	}
 
-	if c.config.EnableCheckVlanConflict {
-		err := c.checkVlanConflict(vlan, vlan.Spec.ProviderInterfaceName)
-		if err != nil {
-			klog.Errorf("failed to check vlan %s: %v", vlan.Name, err)
-			return err
-		}
-	}
-
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets: %v", err)
@@ -94,6 +86,14 @@ func (c *Controller) handleAddVlan(key string) error {
 	if err != nil {
 		klog.Errorf("failed to get provider network %s: %v", vlan.Spec.Provider, err)
 		return err
+	}
+
+	if c.config.EnableCheckVlanConflict {
+		err := c.checkVlanConflict(vlan, pn.Spec.DefaultInterface)
+		if err != nil {
+			klog.Errorf("failed to check vlan %s: %v", vlan.Name, err)
+			return err
+		}
 	}
 
 	if !slices.Contains(pn.Status.Vlans, vlan.Name) {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -117,11 +117,12 @@ func (c *Controller) checkVlanConflict(vlan *kubeovnv1.Vlan) error {
 	}
 	nodeTunVlanIDs := strset.New()
 	conflict := false
+	myVlanID := strconv.Itoa(vlan.Spec.ID)
 	for _, node := range nodes {
 		id := node.Labels[util.TunnelVlanIDLabel]
 		if id != "" {
 			nodeTunVlanIDs.Add(id)
-			if id == strconv.Itoa(vlan.Spec.ID) {
+			if id == myVlanID {
 				conflict = true
 				klog.Errorf("vlan %s id %s conflict with node %s tunnel nic vlan", vlan.Name, id, node.Name)
 			}
@@ -140,7 +141,7 @@ func (c *Controller) checkVlanConflict(vlan *kubeovnv1.Vlan) error {
 	for _, v := range vlans {
 		if v.Spec.ID == v.Spec.ID && v.Name != v.Name {
 			conflict = true
-			klog.Error("new vlan %s conflict with exist vlan %s", v.Name, v.Name)
+			klog.Errorf("new vlan %s conflict with exist vlan %s", v.Name, v.Name)
 		}
 	}
 	if conflict {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -6,16 +6,15 @@ import (
 	"slices"
 	"strconv"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/scylladb/go-set/strset"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	"github.com/kubeovn/kube-ovn/pkg/ovs"
-	"github.com/kubeovn/kube-ovn/pkg/util"
-	"github.com/scylladb/go-set/strset"
 )
 
 func (c *Controller) enqueueAddVlan(obj interface{}) {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -6,17 +6,15 @@ import (
 	"slices"
 	"strconv"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/scylladb/go-set/strset"
-
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (c *Controller) enqueueAddVlan(obj interface{}) {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -124,7 +124,7 @@ func (c *Controller) checkVlanConflict(vlan *kubeovnv1.Vlan) error {
 			nodeTunVlanIDs.Add(id)
 			if id == myVlanID {
 				conflict = true
-				klog.Errorf("vlan %s id %s conflict with node %s tunnel nic vlan", vlan.Name, id, node.Name)
+				klog.Errorf("vlan %s id %s conflict with tunnel nic vlan on node %s", vlan.Name, id, node.Name)
 			}
 		}
 	}

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -134,7 +134,7 @@ func (c *Controller) checkVlanConflict(vlan *kubeovnv1.Vlan, vlanInterface strin
 			continue
 		}
 		nodeTunnVlanIDs.Add(id)
-		// confilct with tunnel interface: same if master nic and same vlan id
+		// conflict with tunnel interface: same if master nic and same vlan id
 		if tunnelIFMaster != vlanInterface {
 			continue
 		}

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -142,7 +142,7 @@ func (c *Controller) checkVlanConflict(vlan *kubeovnv1.Vlan) error {
 		return err
 	}
 	for _, v := range vlans {
-		if v.Spec.ID == v.Spec.ID && v.Name != v.Name {
+		if v.Spec.ID == vlan.Spec.ID && v.Name != vlan.Name {
 			conflict = true
 			conflictErr := fmt.Errorf("new vlan %s conflict with exist vlan %s", v.Name, v.Name)
 			klog.Error(conflictErr)

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -444,16 +444,13 @@ func setChecksum(encapChecksum bool) error {
 
 func (config *Configuration) getVLAN(iface string) (int, error) {
 	// -1 means no vlan id
-	tunnelVlanID := -1
-	// get iface vlan id
 	link, err := netlink.LinkByName(iface)
 	if err != nil || link == nil {
-		return -1, fmt.Errorf("failed to get iface %s: %v", iface, err)
+		return -1, fmt.Errorf("failed to get iface %s: %w", iface, err)
 	}
 	if vlan, ok := link.(*netlink.Vlan); ok {
-		tunnelVlanID = vlan.VlanId
-		klog.Infof("iface %s vlan id is: %d", iface, tunnelVlanID)
-		return tunnelVlanID, nil
+		klog.Infof("iface %s vlan id is: %d", iface, vlan.VlanId)
+		return vlan.VlanId, nil
 	}
 	klog.Infof("iface %s not use vlan", iface)
 	return -1, nil

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -122,8 +122,8 @@ func ParseFlags() *Configuration {
 		argOVSVsctlConcurrency       = pflag.Int32("ovs-vsctl-concurrency", 100, "concurrency limit of ovs-vsctl")
 		argEnableOVNIPSec            = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
 		argSetVxlanTxOff             = pflag.Bool("set-vxlan-tx-off", false, "Whether to set vxlan_sys_4789 tx off")
-		argEnableCheckVlanConflict   = pflag.Bool("enable-check-vlan-conflict", true, "Whether to enable check vlan conflict")
-		argEnableDelConflictVlanIF   = pflag.Bool("enable-del-conflict-vlan-interface", true, "Whether to enable delete vlan conflict interface")
+		argEnableCheckVlanConflict   = pflag.Bool("enable-check-vlan-conflict", false, "Whether to enable check vlan conflict")
+		argEnableDelConflictVlanIF   = pflag.Bool("enable-del-conflict-vlan-interface", false, "Whether to enable delete vlan conflict interface")
 	)
 
 	// mute info log for ipset lib

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -455,6 +455,6 @@ func (config *Configuration) getVLAN(iface string) (int, error) {
 		klog.Infof("iface %s vlan id is: %d", iface, vlan.VlanId)
 		return vlan.VlanId, nil
 	}
-	klog.Infof("iface %s not use vlan", iface)
+	klog.V(3).Infof("iface %s not use vlan", iface)
 	return -1, nil
 }

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -77,6 +77,7 @@ type Configuration struct {
 	OVSVsctlConcurrency       int32
 	SetVxlanTxOff             bool
 	EnableCheckVlanConflict   bool
+	EnableDelConflictVlanIF   bool
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -122,6 +123,7 @@ func ParseFlags() *Configuration {
 		argEnableOVNIPSec            = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
 		argSetVxlanTxOff             = pflag.Bool("set-vxlan-tx-off", false, "Whether to set vxlan_sys_4789 tx off")
 		argEnableCheckVlanConflict   = pflag.Bool("enable-check-vlan-conflict", true, "Whether to enable check vlan conflict")
+		argEnableDelConflictVlanIF   = pflag.Bool("enable-del-conflict-vlan-interface", true, "Whether to enable delete vlan conflict interface")
 	)
 
 	// mute info log for ipset lib
@@ -183,6 +185,7 @@ func ParseFlags() *Configuration {
 		OVSVsctlConcurrency:       *argOVSVsctlConcurrency,
 		SetVxlanTxOff:             *argSetVxlanTxOff,
 		EnableCheckVlanConflict:   *argEnableCheckVlanConflict,
+		EnableDelConflictVlanIF:   *argEnableDelConflictVlanIF,
 	}
 	return config
 }

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -287,14 +288,6 @@ func (config *Configuration) initNicConfig(nicBridgeMappings map[string]string) 
 		klog.Infof("tunnel nic %s use %s as tunnel address", iface.Name, encapIP)
 		mtu = iface.MTU
 		config.tunnelIface = iface.Name
-
-		if config.EnableCheckVlanConflict {
-			config.IfaceVlanID, err = config.getVLAN(iface.Name)
-			if err != nil {
-				klog.Errorf("failed to get vlan id for tunel iface %s: %v", iface.Name, err)
-				return err
-			}
-		}
 	}
 
 	encapIsIPv6 := util.CheckProtocol(encapIP) == kubeovnv1.ProtocolIPv6
@@ -333,7 +326,29 @@ func (config *Configuration) initNicConfig(nicBridgeMappings map[string]string) 
 		return err
 	}
 
-	return setEncapIP(encapIP)
+	if err := setEncapIP(encapIP); err != nil {
+		klog.Errorf("failed to set encap ip %s: %v", encapIP, err)
+		return err
+	}
+	if config.EnableCheckVlanConflict {
+		config.IfaceVlanID, err = config.getVLAN(config.tunnelIface)
+		if err != nil {
+			klog.Errorf("failed to get vlan id for tunel iface %s: %v", config.tunnelIface, err)
+			return err
+		}
+		if config.IfaceVlanID != -1 && node.Labels[util.TunnelVlanIDLabel] != strconv.Itoa(config.IfaceVlanID) {
+			// kube-ovn-controller make sure vlan not conflict with tun
+			if node.Labels == nil {
+				node.Labels = make(map[string]string)
+			}
+			node.Labels[util.TunnelVlanIDLabel] = strconv.Itoa(config.IfaceVlanID)
+			if _, err := config.KubeClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{}); err != nil {
+				klog.Errorf("failed to update tunnel vlan id lable for node %s: %v", config.NodeName, err)
+				return nil
+			}
+		}
+	}
+	return nil
 }
 
 func (config *Configuration) getEncapIP(node *corev1.Node) string {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -74,7 +74,7 @@ type Configuration struct {
 	EnableTProxy              bool
 	OVSVsctlConcurrency       int32
 	SetVxlanTxOff             bool
-	EnableCheckVlanConflicts  bool
+	EnableCheckVlanConflict   bool
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -119,7 +119,7 @@ func ParseFlags() *Configuration {
 		argOVSVsctlConcurrency       = pflag.Int32("ovs-vsctl-concurrency", 100, "concurrency limit of ovs-vsctl")
 		argEnableOVNIPSec            = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
 		argSetVxlanTxOff             = pflag.Bool("set-vxlan-tx-off", false, "Whether to set vxlan_sys_4789 tx off")
-		argEnableCheckVlanConflicts  = pflag.Bool("enable-check-vlan-conflicts", false, "Whether to enable check vlan conflicts")
+		argEnableCheckVlanConflict   = pflag.Bool("enable-check-vlan-conflict", true, "Whether to enable check vlan conflict")
 	)
 
 	// mute info log for ipset lib
@@ -180,7 +180,7 @@ func ParseFlags() *Configuration {
 		EnableTProxy:              *argEnableTProxy,
 		OVSVsctlConcurrency:       *argOVSVsctlConcurrency,
 		SetVxlanTxOff:             *argSetVxlanTxOff,
-		EnableCheckVlanConflicts:  *argEnableCheckVlanConflicts,
+		EnableCheckVlanConflict:   *argEnableCheckVlanConflict,
 	}
 	return config
 }

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -74,6 +74,7 @@ type Configuration struct {
 	EnableTProxy              bool
 	OVSVsctlConcurrency       int32
 	SetVxlanTxOff             bool
+	EnableCheckVlanConflicts  bool
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -118,6 +119,7 @@ func ParseFlags() *Configuration {
 		argOVSVsctlConcurrency       = pflag.Int32("ovs-vsctl-concurrency", 100, "concurrency limit of ovs-vsctl")
 		argEnableOVNIPSec            = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
 		argSetVxlanTxOff             = pflag.Bool("set-vxlan-tx-off", false, "Whether to set vxlan_sys_4789 tx off")
+		argEnableCheckVlanConflicts  = pflag.Bool("enable-check-vlan-conflicts", false, "Whether to enable check vlan conflicts")
 	)
 
 	// mute info log for ipset lib
@@ -178,6 +180,7 @@ func ParseFlags() *Configuration {
 		EnableTProxy:              *argEnableTProxy,
 		OVSVsctlConcurrency:       *argOVSVsctlConcurrency,
 		SetVxlanTxOff:             *argSetVxlanTxOff,
+		EnableCheckVlanConflicts:  *argEnableCheckVlanConflicts,
 	}
 	return config
 }

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -291,8 +291,8 @@ func (config *Configuration) initNicConfig(nicBridgeMappings map[string]string) 
 		mtu = iface.MTU
 		config.tunnelIface = iface.Name
 		if config.EnableCheckVlanConflict {
-			// cache the tunnel nic vlan id
 			config.IfaceVlanID, err = config.getVLAN(config.tunnelIface)
+			klog.Infof("tunnel nic %s use vlan id %d", config.tunnelIface, config.IfaceVlanID)
 			if err != nil {
 				klog.Errorf("failed to get vlan id for tunnel iface %s: %v", config.tunnelIface, err)
 				return err
@@ -452,7 +452,7 @@ func (config *Configuration) getVLAN(iface string) (int, error) {
 		return -1, fmt.Errorf("failed to get iface %s: %w", iface, err)
 	}
 	if vlan, ok := link.(*netlink.Vlan); ok {
-		klog.Infof("iface %s vlan id is: %d", iface, vlan.VlanId)
+		klog.V(3).Infof("iface %s vlan id is: %d", iface, vlan.VlanId)
 		return vlan.VlanId, nil
 	}
 	klog.V(3).Infof("iface %s not use vlan", iface)

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -455,6 +455,6 @@ func (config *Configuration) getVLAN(iface string) (int, error) {
 		klog.Infof("iface %s vlan id is: %d", iface, tunnelVlanID)
 		return tunnelVlanID, nil
 	}
-	klog.Infof("iface %s has no vlan", iface)
+	klog.Infof("iface %s not use vlan", iface)
 	return -1, nil
 }

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -569,6 +569,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	go wait.Until(c.loopOvn0Check, 5*time.Second, stopCh)
 	go wait.Until(c.loopOvnExt0Check, 5*time.Second, stopCh)
 	go wait.Until(c.loopTunnelCheck, 5*time.Second, stopCh)
+	go wait.Until(c.loopCheckVlan, 60*time.Second, stopCh)
 	go wait.Until(c.runAddOrUpdateProviderNetworkWorker, time.Second, stopCh)
 	go wait.Until(c.runDeleteProviderNetworkWorker, time.Second, stopCh)
 	go wait.Until(c.runSubnetWorker, time.Second, stopCh)

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -295,7 +295,7 @@ func (c *Controller) initProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v1
 			klog.Error(err)
 			c.recordProviderNetworkErr(pn.Name, err.Error())
 			// tunnel interface using, so ovs can not use this vlan
-			continue
+			return err
 		}
 		vlans.Add(strconv.Itoa(vlan.Spec.ID))
 	}

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -290,11 +290,11 @@ func (c *Controller) initProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v1
 			klog.Errorf("failed to get vlan %q: %v", vlanName, err)
 			return err
 		}
-		if c.config.IfaceVlanID > 0 && vlan.Spec.ID == c.config.IfaceVlanID {
-			err = fmt.Errorf("vlan %d is already used by tunnel interface", vlan.Spec.ID)
+		if c.config.EnableCheckVlanConflict && c.config.IfaceVlanID > 0 && vlan.Spec.ID == c.config.IfaceVlanID {
+			err = fmt.Errorf("vlan %d is already used by tunnel interface on node %s", vlan.Spec.ID, node.Name)
 			klog.Error(err)
 			c.recordProviderNetworkErr(pn.Name, err.Error())
-			// tunnel interface using, so can not use this vlan
+			// tunnel interface using, so ovs can not use this vlan
 			continue
 		}
 		vlans.Add(strconv.Itoa(vlan.Spec.ID))

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -310,6 +310,9 @@ func (c *Controller) initProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v1
 	patch[fmt.Sprintf(util.ProviderNetworkReadyTemplate, pn.Name)] = "true"
 	patch[fmt.Sprintf(util.ProviderNetworkInterfaceTemplate, pn.Name)] = nic
 	patch[fmt.Sprintf(util.ProviderNetworkMtuTemplate, pn.Name)] = strconv.Itoa(mtu)
+	if c.config.IfaceVlanID > 0 {
+		patch[util.TunnelVlanIDLabel] = strconv.Itoa(c.config.IfaceVlanID)
+	}
 	if err = util.PatchLabels(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
 		klog.Errorf("failed to patch labels of node %s: %v", node.Name, err)
 		return err

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1214,31 +1214,27 @@ func (c *Controller) patchNodeTunnelVlanLabel() error {
 	}
 	var patch util.KVPatch
 	var needUpdate bool
-	if c.config.IfaceVlanID > 0 {
-		id := strconv.Itoa(c.config.IfaceVlanID)
-		if node.Labels[util.TunnelVlanIDLabel] != "true" || node.Labels[util.TunnelVlanIDLabel] != id {
-			klog.Infof("patching tunnel vlan id %d to node %s", c.config.IfaceVlanID, node.Name)
-			patch = util.KVPatch{
-				util.TunnelUseVlanLabel: "true",
-				util.TunnelVlanIDLabel:  id,
-			}
-			needUpdate = true
+	id := strconv.Itoa(c.config.IfaceVlanID)
+	if c.config.IfaceVlanID > 0 && node.Labels[util.TunnelVlanIDLabel] != id {
+		klog.Infof("patching tunnel vlan id %d to node %s", c.config.IfaceVlanID, node.Name)
+		patch = util.KVPatch{
+			util.TunnelUseVlanLabel: "true",
+			util.TunnelVlanIDLabel:  id,
 		}
-	} else {
-		if node.Labels[util.TunnelVlanIDLabel] != "" {
-			klog.Infof("removing tunnel vlan id from node %s", node.Name)
-			patch = util.KVPatch{
-				util.TunnelUseVlanLabel: nil,
-				util.TunnelVlanIDLabel:  nil,
-			}
-			needUpdate = true
+		needUpdate = true
+	} else if c.config.IfaceVlanID <= 0 && node.Labels[util.TunnelVlanIDLabel] != "" {
+		klog.Infof("removing tunnel vlan id from node %s", node.Name)
+		patch = util.KVPatch{
+			util.TunnelUseVlanLabel: nil,
+			util.TunnelVlanIDLabel:  nil,
 		}
+		needUpdate = true
 	}
 	if !needUpdate {
 		return nil
 	}
 	if err = util.PatchLabels(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
-		klog.Errorf("failed to update tunnel vlan id lable for node %s: %v", node.Name, err)
+		klog.Errorf("failed to update tunnel vlan id for node %s: %v", node.Name, err)
 		return err
 	}
 	return nil

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -789,7 +789,6 @@ func (c *Controller) loopTunnelCheck() {
 // This method checks the tunnel and ovs vlan id, and record it in the node label
 // kube-ovn-controller will check if vlan crd is conflict with all node existing vlan
 func (c *Controller) loopCheckVlanConflict() {
-	tunnelVlanID := c.config.IfaceVlanID
 	pns, err := c.providerNetworksLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list provider network: %v", err)
@@ -821,6 +820,7 @@ func (c *Controller) loopCheckVlanConflict() {
 		}
 	}
 	if ovsLocalVlans.Size() > 0 {
+		tunnelVlanID := c.config.IfaceVlanID
 		klog.Infof("check if local ovs vlans %v conflict with tunnel vlan %d", ovsLocalVlans, tunnelVlanID)
 		if ovsLocalVlans.Has(strconv.Itoa(tunnelVlanID)) {
 			// tunnel interface using, so ovs can not use this vlan
@@ -872,8 +872,8 @@ func (c *Controller) loopCheckVlanConflict() {
 			}
 			// make sure not delete tunnel nic
 			if nicName == c.config.tunnelIface {
-				klog.Infof("avoid delete tunnel vlan interface %s", nicName)
 				klog.Errorf("admin should delete invalid vlan crd which vlan id is %s", vlanID)
+				klog.Infof("skip auto delete tunnel vlan interface %s", nicName)
 				continue
 			}
 			// auto del os conflict vlan iface
@@ -882,7 +882,7 @@ func (c *Controller) loopCheckVlanConflict() {
 				klog.Errorf("failed to get link by name %s", nicName)
 				continue
 			}
-			klog.Infof("delete os local vlan interface %s", nicName)
+			klog.Infof("auto delete os local vlan interface %s", nicName)
 			if err := netlink.LinkDel(link); err != nil {
 				klog.Errorf("failed to delete os local vlan interface %s: %v", nicName, err)
 			}

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -798,8 +798,10 @@ func (c *Controller) loopCheckVlan() {
 	}
 	klog.Info("start to check vlan conflicts")
 	tunnelVlanID, err := c.getTunnelVLAN()
-	if err != nil || tunnelVlanID == -1 {
-		klog.Errorf("failed to get tunnel vlan id: %v", err)
+	if tunnelVlanID == -1 {
+		if err != nil {
+			klog.Errorf("failed to get tunnel vlan id: %v", err)
+		}
 		return
 	}
 	pns, err := c.providerNetworksLister.List(labels.Everything())
@@ -868,6 +870,7 @@ func (c *Controller) getTunnelVLAN() (int, error) {
 		klog.Infof("tunnel nic %s vlan id: %d", c.config.Iface, tunnelVlanID)
 		return tunnelVlanID, nil
 	}
+	klog.Infof("tunnel nic %s is not vlan nic", c.config.Iface)
 	return -1, nil
 }
 

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -797,11 +797,10 @@ func (c *Controller) loopCheckVlan() {
 		return
 	}
 	klog.Info("start to check vlan conflicts")
-	tunnelVlanID, err := c.getTunnelVLAN()
+	tunnelVlanID := c.config.IfaceVlanID
+	klog.Infof("tunnel nic %s vlan id: %d", c.config.Iface, tunnelVlanID)
 	if tunnelVlanID == -1 {
-		if err != nil {
-			klog.Errorf("failed to get tunnel vlan id: %v", err)
-		}
+		klog.Infof("tunnel nic %s not use vlan", c.config.Iface)
 		return
 	}
 	pns, err := c.providerNetworksLister.List(labels.Everything())
@@ -855,23 +854,6 @@ func (c *Controller) loopCheckVlan() {
 	// 	return
 	// }
 
-}
-
-func (c *Controller) getTunnelVLAN() (int, error) {
-	// -1 means no vlan id
-	tunnelVlanID := -1
-	// get tunnel vlan id
-	link, err := netlink.LinkByName(c.config.Iface)
-	if err != nil || link == nil {
-		return -1, fmt.Errorf("failed to get tunnel nic %s: %v", c.config.Iface, err)
-	}
-	if vlan, ok := link.(*netlink.Vlan); ok {
-		tunnelVlanID = vlan.VlanId
-		klog.Infof("tunnel nic %s vlan id: %d", c.config.Iface, tunnelVlanID)
-		return tunnelVlanID, nil
-	}
-	klog.Infof("tunnel nic %s is not vlan nic", c.config.Iface)
-	return -1, nil
 }
 
 func (c *Controller) checkNodeGwNicInNs(nodeExtIP, ip, gw string, gwNS ns.NetNS) error {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -793,7 +793,7 @@ func (c *Controller) loopCheckVlan() {
 	// so we need to check if these two vlan set is conflict
 	// 先实现，再把一部分逻辑分拆到 init provider，以及 init tunnel
 	// patch tunnel vlan id to node label
-	if !c.config.EnableCheckVlanConflicts {
+	if !c.config.EnableCheckVlanConflict {
 		return
 	}
 	klog.Info("start to check vlan conflicts")

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -825,7 +825,7 @@ func (c *Controller) loopCheckVlanConflict() {
 	klog.Infof("get ovs local vlan ids: %v", ovsLocalVlans)
 	if tunnelVlanID > 0 && ovsLocalVlans.Has(strconv.Itoa(tunnelVlanID)) {
 		// tunnel interface using, so ovs can not use this vlan
-		err := fmt.Errorf("vlan %s conflict with tunnel vlan id", tunnelVlanID)
+		err := fmt.Errorf("vlan %d conflict with tunnel vlan id", tunnelVlanID)
 		klog.Error(err)
 	}
 	// check if ovs local vlan conflict with os local vlan

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -791,14 +791,13 @@ func (c *Controller) loopCheckVlan() {
 	// ovs use vlans = provider network vlan + 1 tunnel vlan
 	// node use vlan = provider network port bond nic vlan + tunnel bond nic vlan
 	// so we need to check if these two vlan set is conflict
-	// 先实现，再把一部分逻辑分拆到 init provider，以及 init tunnel
-	// patch tunnel vlan id to node label
+	// 先实现，再把一部分逻辑分拆到 init provider
+	// todo:// get other vlan id from tunnel nic and provider network nic
 	if !c.config.EnableCheckVlanConflict {
 		return
 	}
 	klog.Info("start to check vlan conflicts")
 	tunnelVlanID := c.config.IfaceVlanID
-	klog.Infof("tunnel nic %s vlan id: %d", c.config.Iface, tunnelVlanID)
 	if tunnelVlanID == -1 {
 		klog.Infof("tunnel nic %s not use vlan", c.config.Iface)
 		return
@@ -835,25 +834,6 @@ func (c *Controller) loopCheckVlan() {
 		klog.Error(err)
 		return
 	}
-
-	// todo:// get other vlan id from tunnel nic and provider network nic
-
-	// todo:// patch node tunnel id to tell kube-ovn-controller check vlan conflict
-	// do this in init node tunnel nic for once
-	// node, err := c.nodesLister.Get(c.config.NodeName)
-	// if err != nil {
-	// 	klog.Errorf("failed to get node %s: %v", c.config.NodeName, err)
-	// 	return
-	// }
-	// if node.Labels == nil {
-	// 	node.Labels = make(map[string]string)
-	// }
-	// node.Labels[util.TunnelVlanIDLabel] = strconv.Itoa(tunnelVlanID)
-	// if _, err := c.config.KubeClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{}); err != nil {
-	// 	klog.Errorf("failed to update node %s: %v", c.config.NodeName, err)
-	// 	return
-	// }
-
 }
 
 func (c *Controller) checkNodeGwNicInNs(nodeExtIP, ip, gw string, gwNS ns.NetNS) error {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -821,10 +821,10 @@ func (c *Controller) loopCheckVlanConflict() {
 		}
 	}
 	if ovsLocalVlans.Size() > 0 {
-		klog.Infof("check if local ovs vlans %v conflict with tunnel vlan %d", tunnelVlanID, ovsLocalVlans)
+		klog.Infof("check if local ovs vlans %v conflict with tunnel vlan %d", ovsLocalVlans, tunnelVlanID)
 		if ovsLocalVlans.Has(strconv.Itoa(tunnelVlanID)) {
 			// tunnel interface using, so ovs can not use this vlan
-			err := fmt.Errorf("tunnel vlan %d conflict with local ovs vlans %v", tunnelVlanID, ovsLocalVlans)
+			err := fmt.Errorf("local ovs vlans %v conflict with tunnel vlan %d", ovsLocalVlans, tunnelVlanID)
 			klog.Error(err)
 		}
 	}
@@ -865,7 +865,7 @@ func (c *Controller) loopCheckVlanConflict() {
 	for vlanID, nicName := range osLocalVlans {
 		if ovsLocalVlans.Has(vlanID) {
 			pnName := ovsVlanPNs[vlanID]
-			err := fmt.Errorf("vlan %s conflict with os vlan on node %s in provider network %s", vlanID, c.config.NodeName, pnName)
+			err := fmt.Errorf("os local vlan %s conflict with ovs vlan in provider network %s", vlanID, pnName)
 			c.recordProviderNetworkErr(pnName, err.Error())
 			if !c.config.EnableDelConflictVlanIF {
 				continue

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -856,17 +856,16 @@ func (c *Controller) loopCheckVlan() {
 }
 
 func (c *Controller) getTunnelVLAN() (int, error) {
-	// -1 means no vlan
+	// -1 means no vlan id
 	tunnelVlanID := -1
-	tunnelNic := c.config.tunnelIface
 	// get tunnel vlan id
-	link, err := netlink.LinkByName(tunnelNic)
+	link, err := netlink.LinkByName(c.config.Iface)
 	if err != nil || link == nil {
-		return -1, fmt.Errorf("failed to get tunnel nic %s: %v", tunnelNic, err)
+		return -1, fmt.Errorf("failed to get tunnel nic %s: %v", c.config.Iface, err)
 	}
 	if vlan, ok := link.(*netlink.Vlan); ok {
 		tunnelVlanID = vlan.VlanId
-		klog.Infof("tunnel nic %s vlan id: %d", tunnelNic, tunnelVlanID)
+		klog.Infof("tunnel nic %s vlan id: %d", c.config.Iface, tunnelVlanID)
 		return tunnelVlanID, nil
 	}
 	return -1, nil

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -870,15 +870,21 @@ func (c *Controller) loopCheckVlanConflict() {
 			if !c.config.EnableDelConflictVlanIF {
 				continue
 			}
+			// make sure not delete tunnel nic
+			if nicName == c.config.tunnelIface {
+				klog.Infof("avoid delete tunnel vlan interface %s", nicName)
+				klog.Errorf("admin should delete invalid vlan crd which vlan id is %s", vlanID)
+				continue
+			}
 			// auto del os conflict vlan iface
 			link, err := netlink.LinkByName(nicName)
 			if err != nil {
 				klog.Errorf("failed to get link by name %s", nicName)
 				continue
 			}
-			klog.Infof("delete os local vlan %s interface %s", vlanID, nicName)
+			klog.Infof("delete os local vlan interface %s", nicName)
 			if err := netlink.LinkDel(link); err != nil {
-				klog.Errorf("failed to delete os local vlan %s interface %s: %v", vlanID, nicName, err)
+				klog.Errorf("failed to delete os local vlan interface %s: %v", nicName, err)
 			}
 		}
 	}

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1188,7 +1188,7 @@ func (c *Controller) patchNodeTunnelVlanLabel() error {
 		klog.Errorf("failed to get node %s: %v", c.config.NodeName, err)
 		return err
 	}
-	patch := util.KVPatch{}
+	var patch util.KVPatch
 	if c.config.IfaceVlanID > 0 {
 		klog.Infof("patching tunnel vlan id %d to node %s", c.config.IfaceVlanID, node.Name)
 		patch = util.KVPatch{

--- a/pkg/daemon/ovs_windows.go
+++ b/pkg/daemon/ovs_windows.go
@@ -418,3 +418,12 @@ func linkExists(name string) (bool, error) {
 	}
 	return true, nil
 }
+
+func (c *Controller) patchNodeTunnelVlanLabel() error {
+	// nothing to do on Windows
+	return nil
+}
+
+func (c *Controller) loopCheckVlanConflict() {
+	// nothing to do on Windows
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -95,6 +95,8 @@ const (
 
 	TunnelInterfaceAnnotation = "ovn.kubernetes.io/tunnel_interface"
 
+	TunnelVlanIDLabel = "ovn.kubernetes.io/tunnel_vlan"
+
 	OvsDpTypeLabel = "ovn.kubernetes.io/ovs_dp_type"
 
 	VpcNameLabel               = "ovn.kubernetes.io/vpc"

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -95,7 +95,7 @@ const (
 
 	TunnelInterfaceAnnotation = "ovn.kubernetes.io/tunnel_interface"
 
-	TunnelVlanIDLabel  = "ovn.kubernetes.io/tunnel_interface_vlan"
+	TunnelIFLabel      = "ovn.kubernetes.io/tunnel_interface"
 	TunnelUseVlanLabel = "ovn.kubernetes.io/tunnel_use_vlan"
 
 	OvsDpTypeLabel = "ovn.kubernetes.io/ovs_dp_type"

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -95,7 +95,7 @@ const (
 
 	TunnelInterfaceAnnotation = "ovn.kubernetes.io/tunnel_interface"
 
-	TunnelVlanIDLabel = "ovn.kubernetes.io/tunnel_vlan"
+	TunnelVlanIDLabel = "ovn.kubernetes.io/tunnel_interface_vlan"
 
 	OvsDpTypeLabel = "ovn.kubernetes.io/ovs_dp_type"
 

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -95,7 +95,8 @@ const (
 
 	TunnelInterfaceAnnotation = "ovn.kubernetes.io/tunnel_interface"
 
-	TunnelVlanIDLabel = "ovn.kubernetes.io/tunnel_interface_vlan"
+	TunnelVlanIDLabel  = "ovn.kubernetes.io/tunnel_interface_vlan"
+	TunnelUseVlanLabel = "ovn.kubernetes.io/tunnel_use_vlan"
 
 	OvsDpTypeLabel = "ovn.kubernetes.io/ovs_dp_type"
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

1. kube-ovn-controller 保证新创建 vlan crd 不和集群内的 tunnel nic vlan 以及已存在的 vlan 冲突（vlan crd 生效前处理，vlan status conflict 为 true，子网 not ready）
2. kube-ovn-cni 保证新创建 vlan crd 不和集群内的 tunnel vlan，以及 node 上已有的 vlan 子接口冲突 （记录 ProviderNetwork condition err，not ready）
3. kube-ovn-cni 周期性检查：vlan 已创建，如果发现有其他provider network 同网卡的子接口 vlan 冲突，则（记录 ProviderNetwork condition err，not ready）


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
