### PR TITLE
Fix: IPv6 Link-Local Address Used as Source IP During Pod Initialization

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -510,6 +510,14 @@ func (csh cniServerHandler) configureContainerNic(podName, podNamespace, nicName
 				interfaceName = ifName
 			}
 
+			// Check if IPv6 is being used
+			if util.CheckProtocol(ipAddr) == kubeovnv1.ProtocolIPv6 || util.CheckProtocol(ipAddr) == kubeovnv1.ProtocolDual {
+				// Wait for IPv6 address to be in preferred state
+				if err := waitIPv6AddressPreferred(interfaceName, 10, 500*time.Millisecond); err != nil {
+					klog.Warningf("Some IPv6 addresses might not be in preferred state: %v", err)
+				}
+			}
+
 			if u2oInterconnectionIP != "" {
 				if err := csh.checkGatewayReady(podName, podNamespace, gwCheckMode, interfaceName, ipAddr, u2oInterconnectionIP, false, true); err != nil {
 					klog.Error(err)
@@ -1974,4 +1982,64 @@ func rollBackVethPair(nicName string) error {
 	}
 	klog.Infof("rollback veth success %s", nicName)
 	return nil
+}
+
+func waitIPv6AddressPreferred(interfaceName string, maxRetry int, retryInterval time.Duration) error {
+	var retry int
+	for retry < maxRetry {
+		link, err := netlink.LinkByName(interfaceName)
+		if err != nil {
+			klog.Errorf("failed to get link %s: %v", interfaceName, err)
+			return err
+		}
+
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+		if err != nil {
+			klog.Errorf("failed to get IPv6 addresses on interface %s: %v", interfaceName, err)
+			return err
+		}
+
+		var globalIPv6Found bool
+		var badStateIPv6Found bool
+
+		for _, addr := range addrs {
+			// Skip link-local addresses
+			if addr.IP.IsLinkLocalUnicast() {
+				continue
+			}
+
+			globalIPv6Found = true
+			// Check if the address is in a bad state
+			if (addr.Flags & unix.IFA_F_DEPRECATED) != 0 {
+				badStateIPv6Found = true
+				klog.Warningf("IPv6 address %s on interface %s is deprecated", addr.IP.String(), interfaceName)
+			} else if (addr.Flags & unix.IFA_F_DADFAILED) != 0 {
+				badStateIPv6Found = true
+				klog.Warningf("IPv6 address %s on interface %s has failed duplicate address detection (DAD)", addr.IP.String(), interfaceName)
+			} else if (addr.Flags & unix.IFA_F_TENTATIVE) != 0 {
+				badStateIPv6Found = true
+				klog.Warningf("IPv6 address %s on interface %s is in tentative state (DAD in progress)", addr.IP.String(), interfaceName)
+			} else {
+				klog.Infof("IPv6 address %s on interface %s is in preferred state", addr.IP.String(), interfaceName)
+			}
+		}
+
+		if globalIPv6Found && !badStateIPv6Found {
+			klog.Infof("All non-link-local IPv6 addresses on interface %s are in preferred state", interfaceName)
+			return nil
+		}
+
+		if !globalIPv6Found {
+			klog.Warningf("No non-link-local IPv6 addresses found on interface %s, retry %d/%d", interfaceName, retry+1, maxRetry)
+		} else {
+			klog.Warningf("Some IPv6 addresses on interface %s are in bad state (deprecated, tentative, or DAD failed), retry %d/%d", interfaceName, retry+1, maxRetry)
+		}
+
+		retry++
+		if retry < maxRetry {
+			time.Sleep(retryInterval)
+		}
+	}
+
+	return fmt.Errorf("failed to find non-link-local IPv6 addresses in preferred state on interface %s after %d retries", interfaceName, maxRetry)
 }

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -2010,16 +2010,17 @@ func waitIPv6AddressPreferred(interfaceName string, maxRetry int, retryInterval 
 
 			globalIPv6Found = true
 			// Check if the address is in a bad state
-			if (addr.Flags & unix.IFA_F_DEPRECATED) != 0 {
+			switch {
+			case (addr.Flags & unix.IFA_F_DEPRECATED) != 0:
 				badStateIPv6Found = true
 				klog.Warningf("IPv6 address %s on interface %s is deprecated", addr.IP.String(), interfaceName)
-			} else if (addr.Flags & unix.IFA_F_DADFAILED) != 0 {
+			case (addr.Flags & unix.IFA_F_DADFAILED) != 0:
 				badStateIPv6Found = true
 				klog.Warningf("IPv6 address %s on interface %s has failed duplicate address detection (DAD)", addr.IP.String(), interfaceName)
-			} else if (addr.Flags & unix.IFA_F_TENTATIVE) != 0 {
+			case (addr.Flags & unix.IFA_F_TENTATIVE) != 0:
 				badStateIPv6Found = true
 				klog.Warningf("IPv6 address %s on interface %s is in tentative state (DAD in progress)", addr.IP.String(), interfaceName)
-			} else {
+			default:
 				klog.Infof("IPv6 address %s on interface %s is in preferred state", addr.IP.String(), interfaceName)
 			}
 		}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

## Fix: IPv6 Link-Local Address Used as Source IP During Pod Initialization
This change addresses an issue where pods sometimes use their IPv6 link-local address as the source IP for outbound connections during initialization, rather than using the global IPv6 address assigned by Kube-OVN.


## Root Cause
When a pod is first created, its assigned IPv6 address may be in a tentative state (during Duplicate Address Detection) or other non-preferred states. During this period, if the pod attempts to establish network connections, the Linux kernel will select the link-local address as the source IP since the global address is not yet ready for use.
## Fix Implementation
Added a new function waitIPv6AddressPreferred that:
Checks the status of IPv6 addresses on the pod's network interface
Verifies if non-link-local global IPv6 addresses exist
Confirms these addresses are in a preferred state (not deprecated, tentative, or DAD-failed)
Retries with backoff if addresses are not yet in the preferred state
This check is performed after configuring the network interface but before the pod initiates any network traffic, ensuring that all global IPv6 addresses are ready for use before proceeding.

##  The solution now properly handles:
DEPRECATED addresses (valid but should not be used for new connections)
TENTATIVE addresses (DAD in progress)
DADFAILED addresses (detected as duplicate on the network)
By ensuring pods wait for proper IPv6 address states, this fix prevents the intermittent use of link-local addresses for outbound connections, improving network reliability in IPv6 environments.




Fixes #(issue-number)

<img width="1264" alt="企业微信截图_17439378153162" src="https://github.com/user-attachments/assets/db5e07fb-e76f-430d-8c8f-694af90d9af2" />

