### PR TITLE
Deleting FIP sets EIP to ready

### DIFF
--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -193,7 +193,7 @@ func (c *Controller) handleResetOvnEip(key string) error {
 		return nil
 	}
 	klog.Infof("handle reset ovn eip %s", cachedEip.Name)
-	if err := c.patchOvnEipStatus(key, true); err != nil {
+	if err := c.patchOvnEipStatus(key, false); err != nil {
 		klog.Errorf("failed to reset nat for eip %s, %v", key, err)
 		return err
 	}
@@ -364,7 +364,7 @@ func (c *Controller) createOrUpdateOvnEipCR(key, subnet, v4ip, v6ip, mac, usageT
 	return nil
 }
 
-func (c *Controller) patchOvnEipStatus(key string, ready bool) error {
+func (c *Controller) patchOvnEipStatus(key string, markEIPAsReady bool) error {
 	cachedOvnEip, err := c.ovnEipsLister.Get(key)
 	if err != nil {
 		klog.Errorf("failed to get cached ovn eip '%s', %v", key, err)
@@ -372,9 +372,11 @@ func (c *Controller) patchOvnEipStatus(key string, ready bool) error {
 	}
 	ovnEip := cachedOvnEip.DeepCopy()
 	changed := false
-	if ovnEip.Status.Ready != ready {
-		ovnEip.Status.Ready = ready
-		changed = true
+	if markEIPAsReady {
+		if !ovnEip.Status.Ready {
+			ovnEip.Status.Ready = true
+			changed = true
+		}
 	}
 	if ovnEip.Status.MacAddress == "" {
 		// not support change ip


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Previously when deleting a FIP, the function `handleResetOvnEip` was called.
- `handleResetOvnEip` called `patchOvnEipStatus` to set the "Ready"
  field to true, regardless of the current EIP.
- This fixes it so when `handleResetOvnEip` is called, the "Ready" is
  field of the EIP is unchanged 

I have rejected a more ambitious fix where all calls of the `handleResetOvnEip` function set the EIP status to not be ready.

## Which issue(s) this PR fixes

Fixes #5114
