### PR TITLE
fix: clean up garbage lsp

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -146,6 +146,7 @@ func (c *Controller) handleAddNode(key string) error {
 	}
 
 	var v4IP, v6IP, mac string
+
 	portName := util.NodeLspName(key)
 	if node.Annotations[util.AllocatedAnnotation] == "true" && node.Annotations[util.IPAddressAnnotation] != "" && node.Annotations[util.MacAddressAnnotation] != "" {
 		macStr := node.Annotations[util.MacAddressAnnotation]
@@ -160,6 +161,11 @@ func (c *Controller) handleAddNode(key string) error {
 		if err != nil {
 			klog.Errorf("failed to alloc random ip addrs for node %v: %v", node.Name, err)
 			return err
+		}
+
+		// Clean up potentially existing logical switch ports to avoid leftover issues from previous failed configurations
+		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
+			klog.Warningf("failed to delete logical switch port %s: %v", portName, err)
 		}
 	}
 

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -167,9 +167,8 @@ func (c *Controller) handleAddNode(key string) error {
 		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
 			klog.Errorf("failed to delete stale logical switch port %s: %v", portName, err)
 			return err
-		} else {
-			klog.Infof("deleted stale logical switch port %s", portName)
 		}
+		klog.Infof("deleted stale logical switch port %s", portName)
 	}
 
 	ipStr := util.GetStringIP(v4IP, v6IP)

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -165,7 +165,10 @@ func (c *Controller) handleAddNode(key string) error {
 
 		// Clean up potentially existing logical switch ports to avoid leftover issues from previous failed configurations
 		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
-			klog.Warningf("failed to delete logical switch port %s: %v", portName, err)
+			klog.Errorf("failed to delete logical switch port %s: %v", portName, err) // Log as error
+			// Consider adding retry logic here
+		} else {
+			klog.Infof("deleted logical switch port %s", portName)
 		}
 	}
 

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -165,10 +165,10 @@ func (c *Controller) handleAddNode(key string) error {
 
 		// Clean up potentially existing logical switch ports to avoid leftover issues from previous failed configurations
 		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
-			klog.Errorf("failed to delete logical switch port %s: %v", portName, err) // Log as error
-			// Consider adding retry logic here
+			klog.Errorf("failed to delete stale logical switch port %s: %v", portName, err)
+			return err
 		} else {
-			klog.Infof("deleted logical switch port %s", portName)
+			klog.Infof("deleted stale logical switch port %s", portName)
 		}
 	}
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

复现步骤：

17:09:52 第一个kube-ovn-controller 分配node-x.x.x.x 的ip 和 mac
![image](https://github.com/user-attachments/assets/1d59d527-04a0-4bfd-a3a2-51f0d4ffcbdb)


由于环境上和 api-server 的连接出现问题，导致patch失败，所以logical_switch_port 创建完成， 但是annotation并没有配置好
![image](https://github.com/user-attachments/assets/eac4e987-24b3-4cca-a80c-17013abb2f2d)

17:10:14

kube-ovn-controller 发生了选举另外一个kube-ovn-controller上了。

![image](https://github.com/user-attachments/assets/6c6ee567-cec4-4509-a500-f18449566051)

17:10:18 重新分配join 的ip 和 mac
![image](https://github.com/user-attachments/assets/df6249d8-eb7e-4e4e-921d-027d2de7e1b4)


但是由于之前已经创建了lsp ,导致不会再创建，所以lsp仍然是之前的
![image](https://github.com/user-attachments/assets/722e47f4-91e7-4343-8a82-cbd9dfdb51cf)


annoation 反而更新成新分配的mac
![image](https://github.com/user-attachments/assets/490cccec-52d0-4c90-8c9f-549d63d9a696)



