### PR TITLE
chore(vpc-nat-gw): refactor before adding HA gw

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -102,7 +102,7 @@ func (c *Controller) gcVpcNatGateway() error {
 				return err
 			}
 		}
-		gwStsNames = append(gwStsNames, util.GenNatGwStsName(gw.Name))
+		gwStsNames = append(gwStsNames, util.GenNatGwName(gw.Name))
 	}
 
 	sel, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{util.VpcNatGatewayLabel: "true"}})

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -577,13 +577,6 @@ func GetExternalNetwork(externalNet string) string {
 	return externalNet
 }
 
-func GetNatGwExternalNetwork(externalNets []string) string {
-	if len(externalNets) == 0 {
-		return vpcExternalNet
-	}
-	return externalNets[0]
-}
-
 func TCPConnectivityCheck(endpoint string) error {
 	conn, err := net.DialTimeout("tcp", endpoint, 3*time.Second)
 	if err != nil {

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -819,39 +819,6 @@ func TestAppendGwByCidr(t *testing.T) {
 	}
 }
 
-func TestGetNatGwExternalNetwork(t *testing.T) {
-	tests := []struct {
-		name         string
-		externalNets []string
-		expected     string
-	}{
-		{
-			name:         "External network specified",
-			externalNets: []string{"custom-external-network"},
-			expected:     "custom-external-network",
-		},
-		{
-			name:         "External network not specified",
-			externalNets: []string{},
-			expected:     "ovn-vpc-external-network",
-		},
-		{
-			name:         "Multiple external networks specified",
-			externalNets: []string{"custom-external-network1", "custom-external-network2"},
-			expected:     "custom-external-network1",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := GetNatGwExternalNetwork(tt.externalNets)
-			if result != tt.expected {
-				t.Errorf("got %v, but want %v", result, tt.expected)
-			}
-		})
-	}
-}
-
 func TestSplitIpsByProtocol(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -3,11 +3,13 @@ package util
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
 
 // VpcNatGwNameDefaultPrefix is the default prefix appended to the name of the NAT gateways
@@ -16,8 +18,8 @@ const VpcNatGwNameDefaultPrefix = "vpc-nat-gw"
 // VpcNatGwNamePrefix is appended to the name of the StatefulSet and Pods for NAT gateways
 var VpcNatGwNamePrefix = VpcNatGwNameDefaultPrefix
 
-// GenNatGwStsName returns the full name of a NAT gateway StatefulSet
-func GenNatGwStsName(name string) string {
+// GenNatGwName returns the full name of a NAT gateway StatefulSet/Deployment
+func GenNatGwName(name string) string {
 	return fmt.Sprintf("%s-%s", VpcNatGwNamePrefix, name)
 }
 
@@ -37,7 +39,7 @@ func GetNatGwExternalNetwork(externalNets []string) string {
 // GenNatGwLabels returns the labels to set on a NAT gateway
 func GenNatGwLabels(gwName string) map[string]string {
 	return map[string]string{
-		"app":              gwName,
+		"app":              GenNatGwName(gwName),
 		VpcNatGatewayLabel: "true",
 	}
 }

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -1,6 +1,14 @@
 package util
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
 
 // VpcNatGwNameDefaultPrefix is the default prefix appended to the name of the NAT gateways
 const VpcNatGwNameDefaultPrefix = "vpc-nat-gw"
@@ -16,4 +24,140 @@ func GenNatGwStsName(name string) string {
 // GenNatGwPodName returns the full name of the NAT gateway pod within a StatefulSet
 func GenNatGwPodName(name string) string {
 	return fmt.Sprintf("%s-%s-0", VpcNatGwNamePrefix, name)
+}
+
+// GetNatGwExternalNetwork returns the external network attached to a NAT gateway
+func GetNatGwExternalNetwork(externalNets []string) string {
+	if len(externalNets) == 0 {
+		return vpcExternalNet
+	}
+	return externalNets[0]
+}
+
+// GenNatGwLabels returns the labels to set on a NAT gateway
+func GenNatGwLabels(gwName string) map[string]string {
+	return map[string]string{
+		"app":              gwName,
+		VpcNatGatewayLabel: "true",
+	}
+}
+
+// GenNatGwSelectors returns the selectors of a NAT gateway
+func GenNatGwSelectors(selectors []string) map[string]string {
+	s := make(map[string]string, len(selectors))
+	for _, v := range selectors {
+		parts := strings.Split(strings.TrimSpace(v), ":")
+		if len(parts) != 2 {
+			continue
+		}
+		s[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+
+	return s
+}
+
+// GenNatGwPodAnnotations returns the Pod annotations for a NAT gateway
+func GenNatGwPodAnnotations(gw *kubeovnv1.VpcNatGateway, externalNadNamespace, externalNadName string) map[string]string {
+	return map[string]string{
+		VpcNatGatewayAnnotation:      gw.Name,
+		nadv1.NetworkAttachmentAnnot: fmt.Sprintf("%s/%s", externalNadNamespace, externalNadName),
+		LogicalSwitchAnnotation:      gw.Spec.Subnet,
+		IPAddressAnnotation:          gw.Spec.LanIP,
+	}
+}
+
+// GenNatGwBgpSpeakerContainer crafts a BGP speaker container for a VPC gateway
+func GenNatGwBgpSpeakerContainer(speakerParams kubeovnv1.VpcBgpSpeaker, speakerImage, gatewayName string) (*corev1.Container, error) {
+	// We need a speaker image configured in the NAT GW ConfigMap
+	if speakerImage == "" {
+		return nil, fmt.Errorf("%s should have bgp speaker image field if bgp enabled", VpcNatConfig)
+	}
+
+	args := []string{
+		"--nat-gw-mode", // Force speaker to run in  NAT GW mode, we're not announcing Pod IPs or Services, only EIPs
+	}
+
+	if speakerParams.RouterID != "" { // Override default auto-selected RouterID
+		args = append(args, "--router-id="+speakerParams.RouterID)
+	}
+
+	if speakerParams.Password != "" { // Password for TCP MD5 BGP
+		args = append(args, "--auth-password="+speakerParams.Password)
+	}
+
+	if speakerParams.EnableGracefulRestart { // Enable graceful restart
+		args = append(args, "--graceful-restart")
+	}
+
+	if speakerParams.HoldTime != (metav1.Duration{}) { // Hold time
+		args = append(args, "--holdtime="+speakerParams.HoldTime.Duration.String())
+	}
+
+	if speakerParams.ASN == 0 { // The ASN we use to speak
+		return nil, errors.New("ASN not set, but must be non-zero value")
+	}
+
+	if speakerParams.RemoteASN == 0 { // The ASN we speak to
+		return nil, errors.New("remote ASN not set, but must be non-zero value")
+	}
+
+	args = append(args, fmt.Sprintf("--cluster-as=%d", speakerParams.ASN))
+	args = append(args, fmt.Sprintf("--neighbor-as=%d", speakerParams.RemoteASN))
+
+	if len(speakerParams.Neighbors) == 0 {
+		return nil, errors.New("no BGP neighbors specified")
+	}
+
+	var neighIPv4 []string
+	var neighIPv6 []string
+	for _, neighbor := range speakerParams.Neighbors {
+		switch CheckProtocol(neighbor) {
+		case kubeovnv1.ProtocolIPv4:
+			neighIPv4 = append(neighIPv4, neighbor)
+		case kubeovnv1.ProtocolIPv6:
+			neighIPv6 = append(neighIPv6, neighbor)
+		default:
+			return nil, fmt.Errorf("unsupported protocol for peer %s", neighbor)
+		}
+	}
+
+	argNeighIPv4 := strings.Join(neighIPv4, ",")
+	argNeighIPv6 := strings.Join(neighIPv6, ",")
+	argNeighIPv4 = "--neighbor-address=" + argNeighIPv4
+	argNeighIPv6 = "--neighbor-ipv6-address=" + argNeighIPv6
+
+	if len(neighIPv4) > 0 {
+		args = append(args, argNeighIPv4)
+	}
+
+	if len(neighIPv6) > 0 {
+		args = append(args, argNeighIPv6)
+	}
+
+	// Extra args to start the speaker with, for example, logging levels...
+	args = append(args, speakerParams.ExtraArgs...)
+
+	bgpSpeakerContainer := &corev1.Container{
+		Name:            "vpc-nat-gw-speaker",
+		Image:           speakerImage,
+		Command:         []string{"/kube-ovn/kube-ovn-speaker"},
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Env: []corev1.EnvVar{
+			{
+				Name:  GatewayNameEnv,
+				Value: gatewayName,
+			},
+			{
+				Name: "POD_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "status.podIP",
+					},
+				},
+			},
+		},
+		Args: args,
+	}
+
+	return bgpSpeakerContainer, nil
 }

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -1,6 +1,10 @@
 package util
 
 import (
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
 	"testing"
 )
 
@@ -26,6 +30,45 @@ func TestGenNatGwStsName(t *testing.T) {
 			expected: "vpc-nat-gw-",
 		},
 	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GenNatGwStsName(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGenNatGwStsNameWithCustomPrefix(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Test case 1",
+			input:    "test-nat-gw",
+			expected: "custom-prefix-test-nat-gw",
+		},
+		{
+			name:     "Test case 2",
+			input:    "my-nat-gateway",
+			expected: "custom-prefix-my-nat-gateway",
+		},
+		{
+			name:     "Test case 3",
+			input:    "",
+			expected: "custom-prefix-",
+		},
+	}
+
+	// It is possible to override the default prefix appended to NAT GW statefulsets
+	VpcNatGwNamePrefix = "custom-prefix"
+	t.Cleanup(func() {
+		VpcNatGwNamePrefix = VpcNatGwNameDefaultPrefix
+	})
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -65,6 +108,291 @@ func TestGenNatGwPodName(t *testing.T) {
 			result := GenNatGwPodName(tc.input)
 			if result != tc.expected {
 				t.Errorf("Expected %s, but got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGenNatGwPodNameWithCustomPrefix(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Test case 1",
+			input:    "test-nat-gw",
+			expected: "another-prefix-test-nat-gw-0",
+		},
+		{
+			name:     "Test case 2",
+			input:    "my-nat-gateway",
+			expected: "another-prefix-my-nat-gateway-0",
+		},
+		{
+			name:     "Test case 3",
+			input:    "",
+			expected: "another-prefix--0",
+		},
+	}
+
+	// It is possible to override the default prefix appended to NAT GW pods
+	VpcNatGwNamePrefix = "another-prefix"
+	t.Cleanup(func() {
+		VpcNatGwNamePrefix = VpcNatGwNameDefaultPrefix
+	})
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GenNatGwPodName(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetNatGwExternalNetwork(t *testing.T) {
+	tests := []struct {
+		name         string
+		externalNets []string
+		expected     string
+	}{
+		{
+			name:         "External network specified",
+			externalNets: []string{"custom-external-network"},
+			expected:     "custom-external-network",
+		},
+		{
+			name:         "External network not specified",
+			externalNets: []string{},
+			expected:     vpcExternalNet,
+		},
+		{
+			name:         "Multiple external networks specified",
+			externalNets: []string{"custom-external-network1", "custom-external-network2"},
+			expected:     "custom-external-network1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetNatGwExternalNetwork(tc.externalNets)
+			if result != tc.expected {
+				t.Errorf("got %v, but want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGenNatGwLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		gwName   string
+		expected map[string]string
+	}{
+		{
+			name:   "Gateway name filled",
+			gwName: "test-gateway",
+			expected: map[string]string{
+				"app":              "test-gateway",
+				VpcNatGatewayLabel: "true",
+			},
+		},
+		{
+			name:   "Gateway label empty",
+			gwName: "",
+			expected: map[string]string{
+				"app":              "",
+				VpcNatGatewayLabel: "true",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GenNatGwLabels(tc.gwName)
+			if !reflect.DeepEqual(tc.expected, result) {
+				t.Errorf("got %v, but want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGenNatGwSelectors(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors []string
+		expected  map[string]string
+	}{
+		{
+			name:      "One selector",
+			selectors: []string{"kubernetes.io/hostname: kube-ovn-worker"},
+			expected: map[string]string{
+				"kubernetes.io/hostname": "kube-ovn-worker",
+			},
+		},
+		{
+			name:      "Empty selector",
+			selectors: []string{},
+			expected:  map[string]string{},
+		},
+		{
+			name:      "Multiple selectors",
+			selectors: []string{"kubernetes.io/hostname: kube-ovn-worker", "kubernetes.io/os: linux"},
+			expected: map[string]string{
+				"kubernetes.io/hostname": "kube-ovn-worker",
+				"kubernetes.io/os":       "linux",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GenNatGwSelectors(tc.selectors)
+			if !reflect.DeepEqual(tc.expected, result) {
+				t.Errorf("got %v, but want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGenNatGwPodAnnotations(t *testing.T) {
+	tests := []struct {
+		name                 string
+		gw                   v1.VpcNatGateway
+		externalNadNamespace string
+		externalNadName      string
+		expected             map[string]string
+	}{
+		{
+			name: "All fields provided",
+			gw: v1.VpcNatGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway",
+				},
+				Spec: v1.VpcNatGatewaySpec{
+					Subnet: "internal-subnet",
+					LanIP:  "10.20.30.40",
+				},
+			},
+			externalNadName:      "external-subnet",
+			externalNadNamespace: "kube-system",
+			expected: map[string]string{
+				VpcNatGatewayAnnotation:      "test-gateway",
+				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
+				LogicalSwitchAnnotation:      "internal-subnet",
+				IPAddressAnnotation:          "10.20.30.40",
+			},
+		},
+		{
+			name: "No static LAN IP",
+			gw: v1.VpcNatGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway",
+				},
+				Spec: v1.VpcNatGatewaySpec{
+					Subnet: "internal-subnet",
+					LanIP:  "",
+				},
+			},
+			externalNadName:      "external-subnet",
+			externalNadNamespace: "kube-system",
+			expected: map[string]string{
+				VpcNatGatewayAnnotation:      "test-gateway",
+				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
+				LogicalSwitchAnnotation:      "internal-subnet",
+				IPAddressAnnotation:          "",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GenNatGwPodAnnotations(&tc.gw, tc.externalNadNamespace, tc.externalNadName)
+			if !reflect.DeepEqual(tc.expected, result) {
+				t.Errorf("got %v, but want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGenNatGwBgpSpeakerContainer(t *testing.T) {
+	tests := []struct {
+		name          string
+		speakerImage  string
+		gatewayName   string
+		speakerParams v1.VpcBgpSpeaker
+		mustError     bool
+	}{
+		{
+			name:          "Speaker with missing params",
+			speakerImage:  "kubeovn.io/fake/image:latest",
+			gatewayName:   "test-gateway",
+			speakerParams: v1.VpcBgpSpeaker{},
+			mustError:     true,
+		},
+		{
+			name:         "Speaker dualstack neighbors",
+			speakerImage: "kubeovn.io/fake/image:latest",
+			gatewayName:  "working-fw",
+			speakerParams: v1.VpcBgpSpeaker{
+				ASN:       123456,
+				RemoteASN: 213219,
+				Neighbors: []string{"10.10.10.10", "fd00::a", "1.2.3.4", "fd00:c00f:ee::"},
+			},
+			mustError: false,
+		},
+		{
+			name:         "Only v6 neighbors",
+			speakerImage: "kubeovn.io/fake/image:latest",
+			gatewayName:  "working-fw",
+			speakerParams: v1.VpcBgpSpeaker{
+				ASN:       123456,
+				RemoteASN: 213219,
+				Neighbors: []string{"fd00::a", "fd00:c00f:ee::"},
+			},
+			mustError: false,
+		},
+		{
+			name:         "Only v4 neighbors",
+			speakerImage: "kubeovn.io/fake/image:latest",
+			gatewayName:  "working-fw",
+			speakerParams: v1.VpcBgpSpeaker{
+				ASN:       123456,
+				RemoteASN: 213219,
+				Neighbors: []string{"10.10.10.10", "1.2.3.4"},
+			},
+			mustError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := GenNatGwBgpSpeakerContainer(tc.speakerParams, tc.speakerImage, tc.gatewayName)
+			if !tc.mustError && err != nil {
+				t.Errorf("generation returned error: %s", err.Error())
+			} else if tc.mustError && err != nil {
+				return
+			}
+
+			if result.Name != "vpc-nat-gw-speaker" {
+				t.Errorf("speaker container doesn't have the right name, expected vpc-nat-gw-speaker, got %s", result.Name)
+			}
+
+			if result.Image != tc.speakerImage {
+				t.Errorf("speaker container has wrong image, expected %s, got %s", tc.speakerImage, result.Image)
+			}
+
+			// Speaker MUST be in NAT GW mode
+			if result.Args[0] != "--nat-gw-mode" {
+				t.Errorf("speaker not running in NAT gateway mode")
+			}
+
+			// Check we inject the gateway name correctly, used by the speaker to retrieve EIPs by ownership
+			firstEnv := result.Env[0]
+			if firstEnv.Name != GatewayNameEnv || firstEnv.Value != tc.gatewayName {
+				t.Errorf("gateway name env injection is faulty, got %v", firstEnv)
 			}
 		})
 	}

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -1,14 +1,16 @@
 package util
 
 import (
-	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
+
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
 
-func TestGenNatGwStsName(t *testing.T) {
+func TestGenNatGwName(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    string
@@ -33,7 +35,7 @@ func TestGenNatGwStsName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := GenNatGwStsName(tc.input)
+			result := GenNatGwName(tc.input)
 			if result != tc.expected {
 				t.Errorf("Expected %s, but got %s", tc.expected, result)
 			}
@@ -41,7 +43,7 @@ func TestGenNatGwStsName(t *testing.T) {
 	}
 }
 
-func TestGenNatGwStsNameWithCustomPrefix(t *testing.T) {
+func TestGenNatGwNameWithCustomPrefix(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    string
@@ -72,7 +74,7 @@ func TestGenNatGwStsNameWithCustomPrefix(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := GenNatGwStsName(tc.input)
+			result := GenNatGwName(tc.input)
 			if result != tc.expected {
 				t.Errorf("Expected %s, but got %s", tc.expected, result)
 			}
@@ -195,7 +197,7 @@ func TestGenNatGwLabels(t *testing.T) {
 			name:   "Gateway name filled",
 			gwName: "test-gateway",
 			expected: map[string]string{
-				"app":              "test-gateway",
+				"app":              "vpc-nat-gw-test-gateway",
 				VpcNatGatewayLabel: "true",
 			},
 		},
@@ -203,7 +205,7 @@ func TestGenNatGwLabels(t *testing.T) {
 			name:   "Gateway label empty",
 			gwName: "",
 			expected: map[string]string{
-				"app":              "",
+				"app":              "vpc-nat-gw-",
 				VpcNatGatewayLabel: "true",
 			},
 		},


### PR DESCRIPTION
This issue refactors the VPC NAT gateway before I start implementing the HA from https://github.com/kubeovn/kube-ovn/issues/4415

There's gonna be a lot of duplicate code between the stateful GW (that need to stay for backward compatibility) and the HA ones. I don't want that so I'm doing some refactoring.

Some code is under-documented and I cannot really make sense of it. I put comments with "(is this still needed"
)" in it.

If @zhangzujian can help me understand what it does and if it can be moved, I'd be glad.

I don't get a few things:
- https://github.com/kubeovn/kube-ovn/blob/41cd031667768fe773a2cd980fc4adda4b592280/pkg/controller/vpc_nat_gateway.go#L752

Was added a month back by https://github.com/kubeovn/kube-ovn/commit/b1c5f2565206d6b974f41020919d4884657d6868 and @kldancer 

I don't get what this annotation is supposed to do, is this to retrigger a sync of the statefulset? I wonder if this is gonna be useful in the deployment too.

- https://github.com/kubeovn/kube-ovn/blame/41cd031667768fe773a2cd980fc4adda4b592280/pkg/controller/vpc_nat_gateway.go#L786

This was added a year back and as I put in my comments, I'm not sure what it is trying to solve
> 	// Add gateway to join every subnet in the same VPC? (is this still needed?)
	// Are we trying to give the NAT gateway access to every subnet in the VPC?
	// I suspect this is to solve a problem where a static route is inserted to redirect all the traffic
	// from a VPC into the NAT GW. When that happens, the GW has no return path to the other subnets.


As goes for this

```go
// Add routes to join the services (is this still needed?)
	v4ClusterIPRange, v6ClusterIPRange := util.SplitStringIP(c.config.ServiceClusterIPRange)
	routes := make([]request.Route, 0, 2)
	if v4Gateway != "" && v4ClusterIPRange != "" {
		routes = append(routes, request.Route{Destination: v4ClusterIPRange, Gateway: v4Gateway})
	}
	if v6Gateway != "" && v6ClusterIPRange != "" {
		routes = append(routes, request.Route{Destination: v6ClusterIPRange, Gateway: v6Gateway})
	}
```

Why do we need services to be added to the gateway? Can it even reach it?

Leaving this as draft until I understand what's needed and what's not to finalize refactoring and adjust the generation of multi-replica deployments in the HA deployment