### PR TITLE
We've seen instances of a VPC being left with a now-deleted subnet on its status field.

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -492,6 +492,14 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		}
 	}
 
+	vpcSubnets, defaultSubnet, err := c.getVpcSubnets(vpc)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	vpc.Status.Subnets = vpcSubnets
+	vpc.Status.DefaultLogicalSwitch = defaultSubnet
 	vpc.Status.Router = key
 	vpc.Status.Standby = true
 	vpc.Status.VpcPeerings = newPeers


### PR DESCRIPTION
# Pull Request

- [ X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

We believe this is due to a race condition where we patch a VPC without taking care of ResourceVersion. For now, every time we run `handleAddOrUpdateVpc` we ensure the vpc.Status.Subnets field is correct.


## Which issue(s) this PR fixes

Fixes: #5220
