### PR TITLE
keep eip as ip, no ipv6

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1751,9 +1751,6 @@ spec:
       - jsonPath: .status.v4Ip
         name: V4IP
         type: string
-      - jsonPath: .status.v6Ip
-        name: V6IP
-        type: string
       - jsonPath: .status.macAddress
         name: Mac
         type: string
@@ -1778,8 +1775,6 @@ spec:
                 nat:
                   type: string
                 v4Ip:
-                  type: string
-                v6Ip:
                   type: string
                 macAddress:
                   type: string

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1763,9 +1763,6 @@ spec:
       - jsonPath: .status.nat
         name: Nat
         type: string
-      - jsonPath: .status.ready
-        name: Ready
-        type: boolean
       - jsonPath: .spec.externalSubnet
         name: ExternalSubnet
         type: string
@@ -1780,8 +1777,6 @@ spec:
                   type: string
                 nat:
                   type: string
-                ready:
-                  type: boolean
                 v4Ip:
                   type: string
                 v6Ip:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1836,14 +1836,8 @@ spec:
       - jsonPath: .status.v4Eip
         name: V4Eip
         type: string
-      - jsonPath: .status.v6Eip
-        name: V6Eip
-        type: string
       - jsonPath: .status.v4Ip
         name: V4Ip
-        type: string
-      - jsonPath: .status.v6Ip
-        name: V6Ip
         type: string
       - jsonPath: .status.ready
         name: Ready
@@ -1865,11 +1859,7 @@ spec:
                   type: boolean
                 v4Eip:
                   type: string
-                v6Eip:
-                  type: string
                 v4Ip:
-                  type: string
-                v6Ip:
                   type: string
                 vpc:
                   type: string
@@ -1903,8 +1893,6 @@ spec:
                   type: string
                 v4Ip:
                   type: string
-                v6Ip:
-                  type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1933,14 +1921,8 @@ spec:
       - jsonPath: .status.v4Eip
         name: V4Eip
         type: string
-      - jsonPath: .status.v6Eip
-        name: V6Eip
-        type: string
       - jsonPath: .status.v4IpCidr
         name: V4IpCidr
-        type: string
-      - jsonPath: .status.v6IpCidr
-        name: V6IpCidr
         type: string
       - jsonPath: .status.ready
         name: Ready
@@ -1956,11 +1938,7 @@ spec:
                   type: boolean
                 v4Eip:
                   type: string
-                v6Eip:
-                  type: string
                 v4IpCidr:
-                  type: string
-                v6IpCidr:
                   type: string
                 vpc:
                   type: string
@@ -1993,8 +1971,6 @@ spec:
                 vpc:
                   type: string
                 v4IpCidr:
-                  type: string
-                v6IpCidr:
                   type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2030,14 +2006,8 @@ spec:
         - jsonPath: .status.v4Eip
           name: V4Eip
           type: string
-        - jsonPath: .status.v6Eip
-          name: V6Eip
-          type: string
         - jsonPath: .status.v4Ip
           name: V4Ip
-          type: string
-        - jsonPath: .status.v6Ip
-          name: V6Ip
           type: string
         - jsonPath: .status.internalPort
           name: InternalPort

--- a/pkg/apis/kubeovn/v1/ovn-dnat-rule.go
+++ b/pkg/apis/kubeovn/v1/ovn-dnat-rule.go
@@ -37,7 +37,6 @@ type OvnDnatRuleSpec struct {
 	Protocol     string `json:"protocol,omitempty"`
 	Vpc          string `json:"vpc"`
 	V4Ip         string `json:"v4Ip"`
-	V6Ip         string `json:"v6Ip"`
 }
 
 type OvnDnatRuleStatus struct {
@@ -45,10 +44,8 @@ type OvnDnatRuleStatus struct {
 	// +patchStrategy=merge
 	Vpc          string `json:"vpc" patchStrategy:"merge"`
 	V4Eip        string `json:"v4Eip" patchStrategy:"merge"`
-	V6Eip        string `json:"v6Eip" patchStrategy:"merge"`
 	ExternalPort string `json:"externalPort"`
 	V4Ip         string `json:"v4Ip" patchStrategy:"merge"`
-	V6Ip         string `json:"v6Ip" patchStrategy:"merge"`
 	InternalPort string `json:"internalPort"`
 	Protocol     string `json:"protocol,omitempty"`
 	IPName       string `json:"ipName"`

--- a/pkg/apis/kubeovn/v1/ovn-eip.go
+++ b/pkg/apis/kubeovn/v1/ovn-eip.go
@@ -48,7 +48,6 @@ type OvnEipStatus struct {
 
 	Type       string `json:"type" patchStrategy:"merge"`
 	Nat        string `json:"nat" patchStrategy:"merge"`
-	Ready      bool   `json:"ready" patchStrategy:"merge"`
 	V4Ip       string `json:"v4Ip" patchStrategy:"merge"`
 	V6Ip       string `json:"v6Ip" patchStrategy:"merge"`
 	MacAddress string `json:"macAddress" patchStrategy:"merge"`

--- a/pkg/apis/kubeovn/v1/ovn-eip.go
+++ b/pkg/apis/kubeovn/v1/ovn-eip.go
@@ -30,7 +30,6 @@ type OvnEip struct {
 type OvnEipSpec struct {
 	ExternalSubnet string `json:"externalSubnet"`
 	V4Ip           string `json:"v4Ip"`
-	V6Ip           string `json:"v6Ip"`
 	MacAddress     string `json:"macAddress"`
 	Type           string `json:"type"`
 	// usage type: lrp, lsp, nat
@@ -49,7 +48,6 @@ type OvnEipStatus struct {
 	Type       string `json:"type" patchStrategy:"merge"`
 	Nat        string `json:"nat" patchStrategy:"merge"`
 	V4Ip       string `json:"v4Ip" patchStrategy:"merge"`
-	V6Ip       string `json:"v6Ip" patchStrategy:"merge"`
 	MacAddress string `json:"macAddress" patchStrategy:"merge"`
 }
 

--- a/pkg/apis/kubeovn/v1/ovn-fip.go
+++ b/pkg/apis/kubeovn/v1/ovn-fip.go
@@ -33,7 +33,6 @@ type OvnFipSpec struct {
 	IPName string `json:"ipName"` // vip, ip crd name
 	Vpc    string `json:"vpc"`
 	V4Ip   string `json:"v4Ip"`
-	V6Ip   string `json:"v6Ip"`
 }
 
 type OvnFipStatus struct {
@@ -41,9 +40,7 @@ type OvnFipStatus struct {
 	// +patchStrategy=merge
 	Vpc   string `json:"vpc" patchStrategy:"merge"`
 	V4Eip string `json:"v4Eip" patchStrategy:"merge"`
-	V6Eip string `json:"v6Eip" patchStrategy:"merge"`
 	V4Ip  string `json:"v4Ip" patchStrategy:"merge"`
-	V6Ip  string `json:"v6Ip" patchStrategy:"merge"`
 	Ready bool   `json:"ready" patchStrategy:"merge"`
 
 	// Conditions represents the latest state of the object

--- a/pkg/apis/kubeovn/v1/ovn-snat-rule.go
+++ b/pkg/apis/kubeovn/v1/ovn-snat-rule.go
@@ -34,7 +34,6 @@ type OvnSnatRuleSpec struct {
 	IPName    string `json:"ipName"`
 	Vpc       string `json:"vpc"`
 	V4IpCidr  string `json:"v4IpCidr"` // subnet cidr or pod ip address
-	V6IpCidr  string `json:"v6IpCidr"` // subnet cidr or pod ip address
 }
 
 type OvnSnatRuleStatus struct {
@@ -42,9 +41,7 @@ type OvnSnatRuleStatus struct {
 	// +patchStrategy=merge
 	Vpc      string `json:"vpc" patchStrategy:"merge"`
 	V4Eip    string `json:"v4Eip" patchStrategy:"merge"`
-	V6Eip    string `json:"v6Eip" patchStrategy:"merge"`
 	V4IpCidr string `json:"v4IpCidr" patchStrategy:"merge"`
-	V6IpCidr string `json:"v6IpCidr" patchStrategy:"merge"`
 	Ready    bool   `json:"ready" patchStrategy:"merge"`
 
 	// Conditions represents the latest state of the object

--- a/pkg/controller/external_gw.go
+++ b/pkg/controller/external_gw.go
@@ -186,13 +186,12 @@ func (c *Controller) createDefaultVpcLrpEip() (string, string, error) {
 			return "", "", err
 		}
 	} else {
-		var v6ip string
-		v4ip, v6ip, mac, err = c.acquireIPAddress(c.config.ExternalGatewaySwitch, lrpEipName, lrpEipName)
+		v4ip, _, mac, err = c.acquireIPAddress(c.config.ExternalGatewaySwitch, lrpEipName, lrpEipName)
 		if err != nil {
 			klog.Errorf("failed to acquire ip address for default vpc lrp %s, %v", lrpEipName, err)
 			return "", "", err
 		}
-		if err := c.createOrUpdateOvnEipCR(lrpEipName, c.config.ExternalGatewaySwitch, v4ip, v6ip, mac, util.OvnEipTypeLRP); err != nil {
+		if err := c.createOrUpdateOvnEipCR(lrpEipName, c.config.ExternalGatewaySwitch, v4ip, mac, util.OvnEipTypeLRP); err != nil {
 			klog.Errorf("failed to create ovn lrp eip %s, %v", lrpEipName, err)
 			return "", "", err
 		}

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -459,7 +459,6 @@ func (c *Controller) patchOvnDnatStatus(key, vpcName, v4Eip, v6Eip, internalV4Ip
 		needUpdateLabel = true
 		dnat.Labels = map[string]string{
 			util.EipV4IpLabel: v4Eip,
-			util.EipV6IpLabel: v6Eip,
 		}
 	} else if dnat.Labels[util.EipV4IpLabel] != v4Eip {
 		op = "replace"

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -118,8 +118,7 @@ func (c *Controller) handleAddOvnDnatRule(key string) error {
 
 	var v4Eip, v6Eip, internalV4Ip, internalV6Ip, subnetName, vpcName, ipName string
 	v4Eip = cachedEip.Status.V4Ip
-	v6Eip = cachedEip.Status.V6Ip
-	if v4Eip == "" && v6Eip == "" {
+	if v4Eip == "" {
 		err := fmt.Errorf("failed to dnat %s, eip %s has no ip", cachedDnat.Name, eipName)
 		klog.Error(err)
 		return err
@@ -224,7 +223,7 @@ func (c *Controller) handleAddOvnDnatRule(key string) error {
 		klog.Errorf("failed to patch status for dnat %s, %v", key, err)
 		return err
 	}
-	if err = c.patchOvnEipStatus(eipName, true); err != nil {
+	if err = c.patchOvnEipStatus(eipName); err != nil {
 		klog.Errorf("failed to patch status for eip %s, %v", key, err)
 		return err
 	}
@@ -307,7 +306,6 @@ func (c *Controller) handleUpdateOvnDnatRule(key string) error {
 	}
 	var v4Eip, v6Eip, internalV4Ip, internalV6Ip, subnetName, vpcName, ipName string
 	v4Eip = cachedEip.Status.V4Ip
-	v6Eip = cachedEip.Status.V6Ip
 	if v4Eip == "" && v6Eip == "" {
 		err := fmt.Errorf("failed to update dnat %s, eip %s has no ip", cachedDnat.Name, eipName)
 		klog.Error(err)

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -144,8 +144,8 @@ func (c *Controller) handleUpdateOvnEip(key string) error {
 		klog.Error(err)
 		return err
 	}
-	if !cachedEip.Status.Ready {
-		// create eip only in add process, just check to error out here
+	if cachedEip.Status.V4Ip == "" {
+		// allocate ip only in add process, just check to error out here
 		klog.Infof("wait ovn eip %s to be ready only in the handle add process", cachedEip.Name)
 		return nil
 	}
@@ -372,10 +372,6 @@ func (c *Controller) patchOvnEipStatus(key string, ready bool) error {
 	}
 	ovnEip := cachedOvnEip.DeepCopy()
 	changed := false
-	if ovnEip.Status.Ready != ready {
-		ovnEip.Status.Ready = ready
-		changed = true
-	}
 	if ovnEip.Status.MacAddress == "" {
 		// not support change ip
 		ovnEip.Status.V4Ip = cachedOvnEip.Spec.V4Ip

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -111,7 +111,6 @@ func (c *Controller) handleAddOvnFip(key string) error {
 	}
 	var v4Eip, v6Eip, v4IP, v6IP string
 	v4Eip = cachedEip.Status.V4Ip
-	v6Eip = cachedEip.Status.V6Ip
 	if err = c.isOvnFipDuplicated(key, cachedEip.Spec.V4Ip); err != nil {
 		err = fmt.Errorf("failed to add fip %s, %w", key, err)
 		klog.Error(err)
@@ -209,7 +208,7 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		klog.Errorf("failed to patch status for fip %s, %v", key, err)
 		return err
 	}
-	if err = c.patchOvnEipStatus(eipName, true); err != nil {
+	if err = c.patchOvnEipStatus(eipName); err != nil {
 		klog.Errorf("failed to patch status for eip %s, %v", key, err)
 		return err
 	}
@@ -251,7 +250,6 @@ func (c *Controller) handleUpdateOvnFip(key string) error {
 	}
 	var v4Eip, v6Eip, v4IP, v6IP string
 	v4Eip = cachedEip.Status.V4Ip
-	v6Eip = cachedEip.Status.V6Ip
 	if err = c.isOvnFipDuplicated(key, cachedEip.Spec.V4Ip); err != nil {
 		err = fmt.Errorf("failed to add fip %s, %w", key, err)
 		klog.Error(err)
@@ -476,7 +474,7 @@ func (c *Controller) GetOvnEip(eipName string) (*kubeovnv1.OvnEip, error) {
 		klog.Errorf("failed to get eip %s, %v", eipName, err)
 		return nil, err
 	}
-	if cachedEip.Status.V4Ip == "" && cachedEip.Status.V6Ip == "" {
+	if cachedEip.Status.V4Ip == "" {
 		err := fmt.Errorf("eip '%s' is not ready, has no ip", eipName)
 		klog.Error(err)
 		return nil, err

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -91,7 +91,6 @@ func (c *Controller) handleAddOvnSnatRule(key string) error {
 	}
 	var v4Eip, v6Eip, v4IpCidr, v6IpCidr, vpcName, subnetName, ipName string
 	v4Eip = cachedEip.Status.V4Ip
-	v6Eip = cachedEip.Status.V6Ip
 	v4IpCidr = cachedSnat.Spec.V4IpCidr
 	v6IpCidr = cachedSnat.Spec.V6IpCidr
 	vpcName = cachedSnat.Spec.Vpc
@@ -165,7 +164,7 @@ func (c *Controller) handleAddOvnSnatRule(key string) error {
 		klog.Errorf("failed to update status for snat %s, %v", key, err)
 		return err
 	}
-	if err = c.patchOvnEipStatus(eipName, true); err != nil {
+	if err = c.patchOvnEipStatus(eipName); err != nil {
 		klog.Errorf("failed to patch status for eip %s, %v", key, err)
 		return err
 	}
@@ -206,7 +205,6 @@ func (c *Controller) handleUpdateOvnSnatRule(key string) error {
 	}
 	var v4Eip, v6Eip, v4IpCidr, v6IpCidr, vpcName, subnetName, ipName string
 	v4Eip = cachedEip.Status.V4Ip
-	v6Eip = cachedEip.Status.V6Ip
 	v4IpCidr = cachedSnat.Spec.V4IpCidr
 	v6IpCidr = cachedSnat.Spec.V6IpCidr
 	vpcName = cachedSnat.Spec.Vpc

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -329,13 +329,11 @@ func (c *Controller) patchOvnSnatStatus(key, vpc, v4Eip, v6Eip, v4IpCidr, v6IpCi
 		needUpdateLabel = true
 		snat.Labels = map[string]string{
 			util.EipV4IpLabel: v4Eip,
-			util.EipV6IpLabel: v6Eip,
 		}
 	} else if snat.Labels[util.EipV4IpLabel] != v4Eip {
 		op = "replace"
 		needUpdateLabel = true
 		snat.Labels[util.EipV4IpLabel] = v4Eip
-		snat.Labels[util.EipV6IpLabel] = v4Eip
 	}
 	if needUpdateLabel {
 		patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1273,7 +1273,7 @@ func (c *Controller) reconcileCustomVpcBfdStaticRoute(vpcName, subnetName string
 		klog.Error(err)
 		return err
 	}
-	if !lrpEip.Status.Ready || lrpEip.Status.V4Ip == "" {
+	if lrpEip.Status.V4Ip == "" {
 		err := fmt.Errorf("lrp eip %q not ready", lrpEipName)
 		klog.Error(err)
 		return err
@@ -1281,7 +1281,7 @@ func (c *Controller) reconcileCustomVpcBfdStaticRoute(vpcName, subnetName string
 	vpc := cachedVpc.DeepCopy()
 
 	for _, eip := range ovnEips {
-		if !eip.Status.Ready || eip.Status.V4Ip == "" {
+		if eip.Status.V4Ip == "" {
 			err := fmt.Errorf("ovn eip %q not ready", eip.Name)
 			klog.Error(err)
 			return err

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -1238,14 +1238,14 @@ func (c *Controller) handleAddVpcExternalSubnet(key, subnet string) error {
 		}
 		needCreateEip = true
 	}
-	var v4ip, v6ip, mac string
+	var v4ip, mac string
 	klog.V(3).Infof("create vpc lrp eip %s", lrpEipName)
 	if needCreateEip {
-		if v4ip, v6ip, mac, err = c.acquireIPAddress(subnet, lrpEipName, lrpEipName); err != nil {
+		if v4ip, _, mac, err = c.acquireIPAddress(subnet, lrpEipName, lrpEipName); err != nil {
 			klog.Errorf("failed to acquire ip address for lrp eip %s, %v", lrpEipName, err)
 			return err
 		}
-		if err := c.createOrUpdateOvnEipCR(lrpEipName, subnet, v4ip, v6ip, mac, util.OvnEipTypeLRP); err != nil {
+		if err := c.createOrUpdateOvnEipCR(lrpEipName, subnet, v4ip, mac, util.OvnEipTypeLRP); err != nil {
 			klog.Errorf("failed to create ovn eip for lrp %s: %v", lrpEipName, err)
 			return err
 		}

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -801,7 +801,7 @@ func (c *Controller) checkNodeGwNicInNs(nodeExtIP, ip, gw string, gwNS ns.NetNS)
 					return err
 				}
 				for _, eip := range ovnEips {
-					if eip.Status.Ready {
+					if eip.Status.V4Ip != "" {
 						// #nosec G204
 						cmd := exec.Command("bfdd-control", "status", "remote", eip.Spec.V4Ip, "local", nodeExtIP)
 						var outb bytes.Buffer
@@ -1055,10 +1055,6 @@ func (c *Controller) patchOvnEipStatus(key string, ready bool) error {
 	}
 	ovnEip := cachedOvnEip.DeepCopy()
 	changed := false
-	if ovnEip.Status.Ready != ready {
-		ovnEip.Status.Ready = ready
-		changed = true
-	}
 	if changed {
 		bytes, err := ovnEip.Status.Bytes()
 		if err != nil {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -995,7 +995,7 @@ func (c *Controller) loopOvnExt0Check() {
 		klog.Errorf("ecmp gateway ovn eip still has no ip")
 		return
 	}
-	ips := util.GetStringIP(cachedEip.Status.V4Ip, cachedEip.Status.V6Ip)
+	ips := cachedEip.Status.V4Ip
 	cachedSubnet, err := c.subnetsLister.Get(cachedEip.Spec.ExternalSubnet)
 	if err != nil {
 		klog.Errorf("failed to get external subnet %s, %v", cachedEip.Spec.ExternalSubnet, err)
@@ -1041,33 +1041,6 @@ func (c *Controller) loopOvnExt0Check() {
 		klog.Errorf("failed to patch labels of node %s: %v", node.Name, err)
 		return
 	}
-	if err = c.patchOvnEipStatus(portName, true); err != nil {
-		klog.Errorf("failed to patch status for eip %s, %v", portName, err)
-		return
-	}
-}
-
-func (c *Controller) patchOvnEipStatus(key string, ready bool) error {
-	cachedOvnEip, err := c.ovnEipsLister.Get(key)
-	if err != nil {
-		klog.Errorf("failed to get cached ovn eip '%s', %v", key, err)
-		return err
-	}
-	ovnEip := cachedOvnEip.DeepCopy()
-	changed := false
-	if changed {
-		bytes, err := ovnEip.Status.Bytes()
-		if err != nil {
-			klog.Errorf("failed to marshal ovn eip status '%s', %v", key, err)
-			return err
-		}
-		if _, err = c.config.KubeOvnClient.KubeovnV1().OvnEips().Patch(context.Background(), ovnEip.Name,
-			types.MergePatchType, bytes, metav1.PatchOptions{}, "status"); err != nil {
-			klog.Errorf("failed to patch status for ovn eip '%s', %v", key, err)
-			return err
-		}
-	}
-	return nil
 }
 
 func (c *Controller) patchNodeExternalGwLabel(enabled bool) error {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -40,7 +40,6 @@ const (
 	VpcNatAnnotation                        = "ovn.kubernetes.io/vpc_nat"
 	OvnEipTypeLabel                         = "ovn.kubernetes.io/ovn_eip_type"
 	EipV4IpLabel                            = "ovn.kubernetes.io/eip_v4_ip"
-	EipV6IpLabel                            = "ovn.kubernetes.io/eip_v6_ip"
 
 	SwitchLBRuleVipsAnnotation = "ovn.kubernetes.io/switch_lb_vip"
 	SwitchLBRuleVip            = "switch_lb_vip"

--- a/pkg/webhook/ovn_nat_gateway.go
+++ b/pkg/webhook/ovn_nat_gateway.go
@@ -52,7 +52,7 @@ func (v *ValidatingHook) ovnEipUpdateHook(ctx context.Context, req admission.Req
 	}
 
 	if eipOld.Spec != eipNew.Spec {
-		if eipOld.Status.Ready {
+		if eipOld.Status.V4Ip != "" {
 			err := errors.New("OvnEip not support change")
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
@@ -102,7 +102,7 @@ func (v *ValidatingHook) ovnEipDeleteHook(ctx context.Context, req admission.Req
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
-	if eip.Status.Ready {
+	if eip.Status.V4Ip != "" {
 		var err error
 		nat, err := v.isOvnEipInUse(ctx, eip.Spec.V4Ip, eip.Spec.V6Ip)
 		if nat != "" {

--- a/pkg/webhook/ovn_nat_gateway.go
+++ b/pkg/webhook/ovn_nat_gateway.go
@@ -256,7 +256,7 @@ func (v *ValidatingHook) ValidateOvnDnat(ctx context.Context, dnat *ovnv1.OvnDna
 		err := errors.New("should set spec ovnEip")
 		return err
 	}
-	if dnat.Spec.IPName == "" && dnat.Spec.V4Ip == "" && dnat.Spec.V6Ip == "" {
+	if dnat.Spec.IPName == "" && dnat.Spec.V4Ip == "" {
 		err := errors.New("should set spec ipName or v4 or v6 Ip")
 		return err
 	}
@@ -310,16 +310,16 @@ func (v *ValidatingHook) ValidateOvnSnat(ctx context.Context, snat *ovnv1.OvnSna
 		return errors.New("should not set spec vpcSubnet and ipName at the same time")
 	}
 
-	if snat.Spec.Vpc != "" && snat.Spec.V4IpCidr == "" && snat.Spec.V6IpCidr == "" {
-		return errors.New("should set spec v4 or v6 IpCidr (subnet cidr or ip address) when spec vpc is set")
+	if snat.Spec.Vpc != "" && snat.Spec.V4IpCidr == "" {
+		return errors.New("should set spec v4 IpCidr (subnet cidr or ip address) when spec vpc is set")
 	}
 
-	if snat.Spec.Vpc == "" && snat.Spec.V4IpCidr != "" && snat.Spec.V6IpCidr != "" {
-		return errors.New("should set spec vpc while spec v4 or v6 IpCidr is not set")
+	if snat.Spec.Vpc == "" && snat.Spec.V4IpCidr != "" {
+		return errors.New("should set spec vpc while spec v4 IpCidr is not set")
 	}
 
-	if snat.Spec.VpcSubnet == "" && snat.Spec.IPName == "" && snat.Spec.Vpc == "" && snat.Spec.V4IpCidr == "" && snat.Spec.V6IpCidr == "" {
-		return errors.New("should set spec vpcSubnet or ipName or vpc and v4 and v6 IpCidr at least")
+	if snat.Spec.VpcSubnet == "" && snat.Spec.IPName == "" && snat.Spec.Vpc == "" && snat.Spec.V4IpCidr == "" {
+		return errors.New("should set spec vpcSubnet or ipName or vpc and v4 IpCidr at least")
 	}
 
 	eip := &ovnv1.OvnEip{}
@@ -332,7 +332,7 @@ func (v *ValidatingHook) ValidateOvnFip(ctx context.Context, fip *ovnv1.OvnFip) 
 		err := errors.New("should set spec ovnEip")
 		return err
 	}
-	if fip.Spec.IPName == "" && fip.Spec.V4Ip == "" && fip.Spec.V6Ip == "" {
+	if fip.Spec.IPName == "" && fip.Spec.V4Ip == "" {
 		err := errors.New("should set spec ipName or ip")
 		return err
 	}

--- a/test/e2e/framework/ovn-eip.go
+++ b/test/e2e/framework/ovn-eip.go
@@ -158,7 +158,7 @@ func (c *OvnEipClient) WaitToDisappear(name string, _, timeout time.Duration) er
 	return nil
 }
 
-func MakeOvnEip(name, subnet, v4ip, v6ip, mac, usage string) *apiv1.OvnEip {
+func MakeOvnEip(name, subnet, v4ip, mac, usage string) *apiv1.OvnEip {
 	eip := &apiv1.OvnEip{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,

--- a/test/e2e/framework/ovn-eip.go
+++ b/test/e2e/framework/ovn-eip.go
@@ -7,14 +7,13 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
-
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	v1 "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/typed/kubeovn/v1"
@@ -120,7 +119,7 @@ func (c *OvnEipClient) DeleteSync(name string) {
 func (c *OvnEipClient) WaitToBeReady(name string, timeout time.Duration) bool {
 	Logf("Waiting up to %v for ovn eip %s to be ready", timeout, name)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
-		if c.Get(name).Status.Ready {
+		if c.Get(name).Status.V4Ip != "" {
 			Logf("ovn eip %s is ready", name)
 			return true
 		}

--- a/test/e2e/framework/ovn-eip.go
+++ b/test/e2e/framework/ovn-eip.go
@@ -166,7 +166,6 @@ func MakeOvnEip(name, subnet, v4ip, v6ip, mac, usage string) *apiv1.OvnEip {
 		Spec: apiv1.OvnEipSpec{
 			ExternalSubnet: subnet,
 			V4Ip:           v4ip,
-			V6Ip:           v6ip,
 			MacAddress:     mac,
 			Type:           usage,
 		},

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	dockernetwork "github.com/docker/docker/api/types/network"
+	"github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -18,8 +19,6 @@ import (
 	k8sframework "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
-
-	"github.com/onsi/ginkgo/v2"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -52,8 +51,8 @@ func makeProviderNetwork(providerNetworkName string, exchangeLinkName bool, link
 	return framework.MakeProviderNetwork(providerNetworkName, exchangeLinkName, defaultInterface, customInterfaces, nil)
 }
 
-func makeOvnEip(name, subnet, v4ip, v6ip, mac, usage string) *kubeovnv1.OvnEip {
-	return framework.MakeOvnEip(name, subnet, v4ip, v6ip, mac, usage)
+func makeOvnEip(name, subnet, v4ip, mac, usage string) *kubeovnv1.OvnEip {
+	return framework.MakeOvnEip(name, subnet, v4ip, mac, usage)
 }
 
 func makeOvnVip(namespaceName, name, subnet, v4ip, v6ip, vipType string) *kubeovnv1.Vip {
@@ -513,7 +512,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		vlanSubnetGw := strings.Join(gateway, ",")
 		underlaySubnet := framework.MakeSubnet(underlaySubnetName, vlanName, vlanSubnetCidr, vlanSubnetGw, "", "", excludeIPs, nil, nil)
 		oldUnderlayExternalSubnet := subnetClient.CreateSync(underlaySubnet)
-		countingEip := makeOvnEip(countingEipName, underlaySubnetName, "", "", "", "")
+		countingEip := makeOvnEip(countingEipName, underlaySubnetName, "", "", "")
 		_ = ovnEipClient.CreateSync(countingEip)
 		ginkgo.By("Checking underlay vlan " + oldUnderlayExternalSubnet.Name)
 		framework.ExpectEqual(oldUnderlayExternalSubnet.Spec.Vlan, vlanName)
@@ -595,7 +594,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		cmd := []string{"sleep", "infinity"}
 		fipPod := framework.MakePod(namespaceName, fipPodName, nil, annotations, f.KubeOVNImage, cmd, nil)
 		fipPod = podClient.CreateSync(fipPod)
-		podEip := framework.MakeOvnEip(podEipName, underlaySubnetName, "", "", "", "")
+		podEip := framework.MakeOvnEip(podEipName, underlaySubnetName, "", "", "")
 		_ = ovnEipClient.CreateSync(podEip)
 		fipPodIP := ovs.PodNameToPortName(fipPod.Name, fipPod.Namespace, noBfdSubnet.Spec.Provider)
 		podFip := framework.MakeOvnFip(podFipName, podEipName, "", fipPodIP, "", "")
@@ -778,7 +777,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		annotations = map[string]string{util.LogicalSwitchAnnotation: noBfdExtraSubnetName}
 		fipPod = framework.MakePod(namespaceName, fipExtraPodName, nil, annotations, f.KubeOVNImage, cmd, nil)
 		fipPod = podClient.CreateSync(fipPod)
-		podEip = framework.MakeOvnEip(podExtraEipName, underlayExtraSubnetName, "", "", "", "")
+		podEip = framework.MakeOvnEip(podExtraEipName, underlayExtraSubnetName, "", "", "")
 		_ = ovnEipClient.CreateSync(podEip)
 		fipPodIP = ovs.PodNameToPortName(fipPod.Name, fipPod.Namespace, noBfdExtraSubnet.Spec.Provider)
 		podFip = framework.MakeOvnFip(podExtraFipName, podExtraEipName, "", fipPodIP, "", "")
@@ -839,7 +838,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 			// in this case, each node has one ecmp bfd ovs lsp nic
 			eipName := nodeName
 			ginkgo.By("Creating ovn node-ext-gw type eip " + nodeName)
-			eip := makeOvnEip(eipName, underlaySubnetName, "", "", "", util.OvnEipTypeLSP)
+			eip := makeOvnEip(eipName, underlaySubnetName, "", "", util.OvnEipTypeLSP)
 			_ = ovnEipClient.CreateSync(eip)
 		}
 
@@ -862,7 +861,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		ipFipVip = vipClient.CreateSync(ipFipVip)
 		framework.ExpectNotEmpty(ipFipVip.Status.V4ip)
 		ginkgo.By("Creating ovn eip " + ipFipEipName)
-		ipFipEip := makeOvnEip(ipFipEipName, underlaySubnetName, "", "", "", util.OvnEipTypeNAT)
+		ipFipEip := makeOvnEip(ipFipEipName, underlaySubnetName, "", "", util.OvnEipTypeNAT)
 		ipFipEip = ovnEipClient.CreateSync(ipFipEip)
 		framework.ExpectNotEmpty(ipFipEip.Status.V4Ip)
 		ginkgo.By("Creating ovn fip " + ipFipName)
@@ -877,7 +876,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		ipDnatVip = vipClient.CreateSync(ipDnatVip)
 		framework.ExpectNotEmpty(ipDnatVip.Status.V4ip)
 		ginkgo.By("Creating ovn eip " + ipDnatEipName)
-		ipDnatEip := makeOvnEip(ipDnatEipName, underlaySubnetName, "", "", "", util.OvnEipTypeNAT)
+		ipDnatEip := makeOvnEip(ipDnatEipName, underlaySubnetName, "", "", util.OvnEipTypeNAT)
 		ipDnatEip = ovnEipClient.CreateSync(ipDnatEip)
 		framework.ExpectNotEmpty(ipDnatEip.Status.V4Ip)
 		ginkgo.By("Creating ovn dnat " + ipDnatName)
@@ -889,7 +888,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 
 		ginkgo.By("Test ovn snat with eip name and ip cidr")
 		ginkgo.By("Creating ovn eip " + cidrSnatEipName)
-		cidrSnatEip := makeOvnEip(cidrSnatEipName, underlaySubnetName, "", "", "", "")
+		cidrSnatEip := makeOvnEip(cidrSnatEipName, underlaySubnetName, "", "", "")
 		cidrSnatEip = ovnEipClient.CreateSync(cidrSnatEip)
 		framework.ExpectNotEmpty(cidrSnatEip.Status.V4Ip)
 		ginkgo.By("Creating ovn snat mapping with subnet cidr" + bfdSubnetV4Cidr)
@@ -905,7 +904,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		ipSnatVip = vipClient.CreateSync(ipSnatVip)
 		framework.ExpectNotEmpty(ipSnatVip.Status.V4ip)
 		ginkgo.By("Creating ovn eip " + ipSnatEipName)
-		ipSnatEip := makeOvnEip(ipSnatEipName, underlaySubnetName, "", "", "", "")
+		ipSnatEip := makeOvnEip(ipSnatEipName, underlaySubnetName, "", "", "")
 		ipSnatEip = ovnEipClient.CreateSync(ipSnatEip)
 		framework.ExpectNotEmpty(ipSnatEip.Status.V4Ip)
 		ginkgo.By("Creating ovn snat " + ipSnatName)
@@ -970,7 +969,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 			ginkgo.By("Get pod ip" + ipName)
 			ip := ipClient.Get(ipName)
 			ginkgo.By("Creating ovn eip " + eipOnNodeName)
-			eipOnNode := makeOvnEip(eipOnNodeName, underlaySubnetName, "", "", "", "")
+			eipOnNode := makeOvnEip(eipOnNodeName, underlaySubnetName, "", "", "")
 			_ = ovnEipClient.CreateSync(eipOnNode)
 			ginkgo.By("Creating ovn fip " + fipOnNodeName)
 			fip := makeOvnFip(fipOnNodeName, eipOnNodeName, "", ip.Name, "", "")


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

keep eip as ip, no ready status is more simple

ovn eip 用于 nat 场景，仅支持 ipv4。

ipv6 不需要使用 nat ，使用公网地址是更好的选择

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
