### PR TITLE
cleanup: delete additional ConfigMaps and RoleBindings in cleanup script

### DIFF
--- a/dist/images/cleanup.sh
+++ b/dist/images/cleanup.sh
@@ -86,7 +86,8 @@ done
 
 # Delete Kube-OVN components
 kubectl delete --ignore-not-found -n kube-system deploy kube-ovn-monitor
-kubectl delete --ignore-not-found -n kube-system cm ovn-config ovn-ic-config ovn-external-gw-config
+kubectl delete --ignore-not-found -n kube-system cm ovn-config ovn-ic-config \
+  ovn-external-gw-config ovn-vpc-nat-config ovn-vpc-nat-gw-config
 kubectl delete --ignore-not-found -n kube-system svc kube-ovn-pinger kube-ovn-controller kube-ovn-cni kube-ovn-monitor
 kubectl delete --ignore-not-found -n kube-system deploy kube-ovn-controller
 kubectl delete --ignore-not-found -n kube-system deploy ovn-ic-controller
@@ -194,6 +195,7 @@ done
 kubectl delete --ignore-not-found sa ovn ovn-ovs kube-ovn-cni kube-ovn-app -n kube-system
 kubectl delete --ignore-not-found clusterrole system:ovn system:ovn-ovs system:kube-ovn-cni system:kube-ovn-app
 kubectl delete --ignore-not-found clusterrolebinding ovn ovn ovn-ovs kube-ovn-cni kube-ovn-app
+kubectl delete --ignore-not-found rolebinding -n kube-system ovn kube-ovn-cni kube-ovn-app
 
 kubectl delete --ignore-not-found -n kube-system lease kube-ovn-controller
 kubectl delete --ignore-not-found -n kube-system secret ovn-ipsec-ca


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

使用 cleanup.sh 卸载时，还有残留的资源未被释放。卸载完使用helm 安装时报错

```bash
helm install kube-ovn kubeovn/kube-ovn --wait -n kube-system --version v1.13.12
Error: INSTALLATION FAILED: Unable to continue with install: RoleBinding "ovn" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "kube-ovn"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kube-system"
root@zj:~# kubectl delete rolebinding ovn -n kube-system
rolebinding.rbac.authorization.k8s.io "ovn" deleted
root@zj:~# helm install kube-ovn kubeovn/kube-ovn --wait -n kube-system --version v1.13.12
Error: INSTALLATION FAILED: Unable to continue with install: RoleBinding "kube-ovn-cni" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "kube-ovn"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kube-system"
root@zj:~# kubectl delete rolebinding kube-ovn-cni -n kube-system
rolebinding.rbac.authorization.k8s.io "kube-ovn-cni" deleted
root@zj:~# helm install kube-ovn kubeovn/kube-ovn --wait -n kube-system --version v1.13.12
Error: INSTALLATION FAILED: Unable to continue with install: RoleBinding "kube-ovn-app" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "kube-ovn"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kube-system"
root@zj:~# kubectl delete rolebinding kube-ovn-app -n kube-system
rolebinding.rbac.authorization.k8s.io "kube-ovn-app" deleted

kubectl delete cm -n kube-system ovn-vpc-nat-config ovn-vpc-nat-gw-config


$ helm install kube-ovn kubeovn/kube-ovn --wait -n kube-system --version v1.13.11
NAME: kube-ovn
LAST DEPLOYED: Thu Apr 24 08:30:13 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None```

## Which issue(s) this PR fixes

Fixes #(issue-number)
