### PR TITLE
vpc egress gateway: add traffic policy

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -1116,6 +1116,12 @@ spec:
                     x-kubernetes-validations:
                       - rule: "size(self.ipBlocks) != 0 || size(self.subnets) != 0"
                         message: 'Each policy MUST have at least one ipBlock or subnet'
+                trafficPolicy:
+                  type: string
+                  enum:
+                    - Local
+                    - Cluster
+                  default: Cluster
                 nodeSelector:
                   type: array
                   items:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -1132,6 +1132,12 @@ spec:
                     x-kubernetes-validations:
                       - rule: "size(self.ipBlocks) != 0 || size(self.subnets) != 0"
                         message: 'Each policy MUST have at least one ipBlock or subnet'
+                trafficPolicy:
+                  type: string
+                  enum:
+                    - Local
+                    - Cluster
+                  default: Cluster
                 nodeSelector:
                   type: array
                   items:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1370,6 +1370,12 @@ spec:
                     x-kubernetes-validations:
                       - rule: "size(self.ipBlocks) != 0 || size(self.subnets) != 0"
                         message: 'Each policy MUST have at least one ipBlock or subnet'
+                trafficPolicy:
+                  type: string
+                  enum:
+                    - Local
+                    - Cluster
+                  default: Cluster
                 nodeSelector:
                   type: array
                   items:

--- a/pkg/apis/kubeovn/v1/vpc-egress-gateway.go
+++ b/pkg/apis/kubeovn/v1/vpc-egress-gateway.go
@@ -5,6 +5,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	TrafficPolicyLocal   = "Local"
+	TrafficPolicyCluster = "Cluster"
+)
+
 // Phase represents resource phase
 type Phase string
 
@@ -68,6 +73,11 @@ type VpcEgressGatewaySpec struct {
 	ExternalIPs []string `json:"externalIPs,omitempty"`
 	// namespace/pod selectors
 	Selectors []VpcEgressGatewaySelector `json:"selectors,omitempty"`
+	// optional traffic policy used to control the traffic routing
+	// if not specified, the default traffic policy "Cluster" will be used
+	// if set to "Local", traffic will be routed to the gateway pod/instance on the same node when available
+	// currently it works only for the default vpc
+	TrafficPolicy string `json:"trafficPolicy,omitempty"`
 
 	// BFD configuration
 	BFD VpcEgressGatewayBFDConfig `json:"bfd"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1283,9 +1283,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 	go wait.Until(runWorker("update ovn dnat", c.updateOvnDnatRuleQueue, c.handleUpdateOvnDnatRule), time.Second, ctx.Done())
 	go wait.Until(runWorker("delete ovn dnat", c.delOvnDnatRuleQueue, c.handleDelOvnDnatRule), time.Second, ctx.Done())
 
-	if c.config.EnableNP {
-		go wait.Until(c.CheckNodePortGroup, time.Duration(c.config.NodePgProbeTime)*time.Minute, ctx.Done())
-	}
+	go wait.Until(c.CheckNodePortGroup, time.Duration(c.config.NodePgProbeTime)*time.Minute, ctx.Done())
 
 	go wait.Until(runWorker("add ip", c.addIPQueue, c.handleAddReservedIP), time.Second, ctx.Done())
 	go wait.Until(runWorker("update ip", c.updateIPQueue, c.handleUpdateIP), time.Second, ctx.Done())

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -754,8 +754,11 @@ func (c *Controller) CheckNodePortGroup() {
 
 func (c *Controller) checkAndUpdateNodePortGroup() error {
 	klog.V(3).Infoln("start to check node port-group status")
-	np, _ := c.npsLister.List(labels.Everything())
-	networkPolicyExists := len(np) != 0
+	var networkPolicyExists bool
+	if c.config.EnableNP {
+		np, _ := c.npsLister.List(labels.Everything())
+		networkPolicyExists = len(np) != 0
+	}
 
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -735,6 +735,12 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 				return err
 			}
 
+			nodePortGroup := strings.ReplaceAll(node.Annotations[util.PortNameAnnotation], "-", ".")
+			if err = c.OVNNbClient.PortGroupAddPorts(nodePortGroup, portName); err != nil {
+				klog.Errorf("failed to add port %s to port group %s: %v", portName, nodePortGroup, err)
+				return err
+			}
+
 			pgName := getOverlaySubnetsPortGroupName(subnet.Name, node.Name)
 			if c.config.EnableEipSnat && (pod.Annotations[util.EipAnnotation] != "" || pod.Annotations[util.SnatAnnotation] != "") {
 				cm, err := c.configMapsLister.ConfigMaps(c.config.ExternalGatewayConfigNS).Get(util.ExternalGatewayConfig)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -214,14 +214,15 @@ const (
 	OvnFip      = "ovn"
 	IptablesFip = "iptables"
 
-	U2OSubnetPolicyPriority         = 29400
-	GatewayRouterPolicyPriority     = 29000
-	EgressGatewayPolicyPriority     = 29100
-	NorthGatewayRoutePolicyPriority = 29250
-	OvnICPolicyPriority             = 29500
-	NodeRouterPolicyPriority        = 30000
-	NodeLocalDNSPolicyPriority      = 30100
-	SubnetRouterPolicyPriority      = 31000
+	U2OSubnetPolicyPriority          = 29400
+	GatewayRouterPolicyPriority      = 29000
+	EgressGatewayPolicyPriority      = 29100
+	EgressGatewayLocalPolicyPriority = 29150
+	NorthGatewayRoutePolicyPriority  = 29250
+	OvnICPolicyPriority              = 29500
+	NodeRouterPolicyPriority         = 30000
+	NodeLocalDNSPolicyPriority       = 30100
+	SubnetRouterPolicyPriority       = 31000
 
 	OffloadType  = "offload-port"
 	InternalType = "internal-port"


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

New feature: traffic policy. Works only for the default VPC for now.
If set to *Local*, egress traffic will be routed to the gateway instance on the same node when available.
