### PR TITLE
any vpc use any external subnet

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2144,7 +2144,7 @@ spec:
         - jsonPath: .status.subnets
           name: Subnets
           type: string
-        - jsonPath: .status.ExternalSubnets
+        - jsonPath: .status.externalSubnets
           name: ExternalSubnets
           type: string
         - jsonPath: .spec.namespaces
@@ -2167,7 +2167,7 @@ spec:
                   items:
                     type: string
                   type: array
-                ExternalSubnets:
+                externalSubnets:
                   items:
                     type: string
                   type: array
@@ -2289,7 +2289,7 @@ spec:
                   items:
                     type: string
                   type: array
-                ExternalSubnets:
+                externalSubnets:
                   items:
                     type: string
                   type: array

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2135,9 +2135,6 @@ spec:
   group: kubeovn.io
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .status.enableExternal
-          name: EnableExternal
-          type: boolean
         - jsonPath: .status.enableBfd
           name: EnableBfd
           type: boolean
@@ -2147,8 +2144,8 @@ spec:
         - jsonPath: .status.subnets
           name: Subnets
           type: string
-        - jsonPath: .status.extraExternalSubnets
-          name: ExtraExternalSubnets
+        - jsonPath: .status.ExternalSubnets
+          name: ExternalSubnets
           type: string
         - jsonPath: .spec.namespaces
           name: Namespaces
@@ -2164,15 +2161,13 @@ spec:
               properties:
                 defaultSubnet:
                   type: string
-                enableExternal:
-                  type: boolean
                 enableBfd:
                   type: boolean
                 namespaces:
                   items:
                     type: string
                   type: array
-                extraExternalSubnets:
+                ExternalSubnets:
                   items:
                     type: string
                   type: array
@@ -2288,15 +2283,13 @@ spec:
                   type: string
                 standby:
                   type: boolean
-                enableExternal:
-                  type: boolean
                 enableBfd:
                   type: boolean
                 subnets:
                   items:
                     type: string
                   type: array
-                extraExternalSubnets:
+                ExternalSubnets:
                   items:
                     type: string
                   type: array

--- a/pkg/apis/kubeovn/v1/vpc.go
+++ b/pkg/apis/kubeovn/v1/vpc.go
@@ -52,10 +52,12 @@ type VpcSpec struct {
 	VpcPeerings     []*VpcPeering  `json:"vpcPeerings,omitempty"`
 	ExternalSubnets []string       `json:"externalSubnets,omitempty"`
 	// external subnets only using provider network vlan subnet
-	// set the external subnet in the ExternalSubnets means the vpc subnet can access outside via the external network
-	// vpc has no default external subnet, lnly subnet in the ExternalSubnets can be used for external access
-	// use str set to handle ExternalSubnets to avoid duplicate subnet(also webhook)
-	// enable eip snat will set a default external subnet into the ExternalSubnets
+	// choose enable eip snat or ExternalSubnets to use exeternal network
+	// enable eip snat has nothing to do with ExternalSubnets
+	// ExternalSubnets means vpc has no default external subnet
+	// any vpc can use the subnet in ExternalSubnets to access outside
+	// use str set to handle ExternalSubnets to avoid duplicate subnet(also webhook),
+	// diff to sync: add or del lrp for external subnet
 	EnableBfd bool `json:"enableBfd,omitempty"`
 
 	// optional BFD LRP configuration

--- a/pkg/apis/kubeovn/v1/vpc.go
+++ b/pkg/apis/kubeovn/v1/vpc.go
@@ -51,11 +51,6 @@ type VpcSpec struct {
 	PolicyRoutes    []*PolicyRoute `json:"policyRoutes,omitempty"`
 	VpcPeerings     []*VpcPeering  `json:"vpcPeerings,omitempty"`
 	ExternalSubnets []string       `json:"externalSubnets,omitempty"`
-	// external subnets only using provider network vlan subnet
-	// choose enable eip snat or ExternalSubnets to use exeternal network
-	// enable eip snat has nothing to do with ExternalSubnets
-	// ExternalSubnets means vpc has no default external subnet
-	// any vpc can use the subnet in ExternalSubnets to access outside
 	// use str set to handle ExternalSubnets to avoid duplicate subnet(also webhook),
 	// diff to sync: add or del lrp for external subnet
 	EnableBfd bool `json:"enableBfd,omitempty"`
@@ -135,7 +130,7 @@ type VpcStatus struct {
 	SctpSessionLoadBalancer string   `json:"sctpSessionLoadBalancer"`
 	Subnets                 []string `json:"subnets"`
 	VpcPeerings             []string `json:"vpcPeerings"`
-	ExternalSubnets         []string `json:"ExternalSubnets"`
+	ExternalSubnets         []string `json:"externalSubnets"`
 	EnableBfd               bool     `json:"enableBfd"`
 
 	BFDPort BFDPortStatus `json:"bfdPort"`

--- a/pkg/apis/kubeovn/v1/vpc.go
+++ b/pkg/apis/kubeovn/v1/vpc.go
@@ -45,14 +45,18 @@ type Vpc struct {
 }
 
 type VpcSpec struct {
-	DefaultSubnet        string         `json:"defaultSubnet,omitempty"`
-	Namespaces           []string       `json:"namespaces,omitempty"`
-	StaticRoutes         []*StaticRoute `json:"staticRoutes,omitempty"`
-	PolicyRoutes         []*PolicyRoute `json:"policyRoutes,omitempty"`
-	VpcPeerings          []*VpcPeering  `json:"vpcPeerings,omitempty"`
-	EnableExternal       bool           `json:"enableExternal,omitempty"`
-	ExtraExternalSubnets []string       `json:"extraExternalSubnets,omitempty"`
-	EnableBfd            bool           `json:"enableBfd,omitempty"`
+	DefaultSubnet   string         `json:"defaultSubnet,omitempty"`
+	Namespaces      []string       `json:"namespaces,omitempty"`
+	StaticRoutes    []*StaticRoute `json:"staticRoutes,omitempty"`
+	PolicyRoutes    []*PolicyRoute `json:"policyRoutes,omitempty"`
+	VpcPeerings     []*VpcPeering  `json:"vpcPeerings,omitempty"`
+	ExternalSubnets []string       `json:"externalSubnets,omitempty"`
+	// external subnets only using provider network vlan subnet
+	// set the external subnet in the ExternalSubnets means the vpc subnet can access outside via the external network
+	// vpc has no default external subnet, lnly subnet in the ExternalSubnets can be used for external access
+	// use str set to handle ExternalSubnets to avoid duplicate subnet(also webhook)
+	// enable eip snat will set a default external subnet into the ExternalSubnets
+	EnableBfd bool `json:"enableBfd,omitempty"`
 
 	// optional BFD LRP configuration
 	// currently the LRP is used for vpc external gateway only
@@ -129,8 +133,7 @@ type VpcStatus struct {
 	SctpSessionLoadBalancer string   `json:"sctpSessionLoadBalancer"`
 	Subnets                 []string `json:"subnets"`
 	VpcPeerings             []string `json:"vpcPeerings"`
-	EnableExternal          bool     `json:"enableExternal"`
-	ExtraExternalSubnets    []string `json:"extraExternalSubnets"`
+	ExternalSubnets         []string `json:"ExternalSubnets"`
 	EnableBfd               bool     `json:"enableBfd"`
 
 	BFDPort BFDPortStatus `json:"bfdPort"`

--- a/pkg/apis/kubeovn/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeovn/v1/zz_generated.deepcopy.go
@@ -2746,8 +2746,8 @@ func (in *VpcSpec) DeepCopyInto(out *VpcSpec) {
 			}
 		}
 	}
-	if in.ExtraExternalSubnets != nil {
-		in, out := &in.ExtraExternalSubnets, &out.ExtraExternalSubnets
+	if in.ExternalSubnets != nil {
+		in, out := &in.ExternalSubnets, &out.ExternalSubnets
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
@@ -2789,8 +2789,8 @@ func (in *VpcStatus) DeepCopyInto(out *VpcStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.ExtraExternalSubnets != nil {
-		in, out := &in.ExtraExternalSubnets, &out.ExtraExternalSubnets
+	if in.ExternalSubnets != nil {
+		in, out := &in.ExternalSubnets, &out.ExternalSubnets
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -684,7 +684,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		(subnet.Status.U2OInterconnectionIP != "" && subnet.Spec.U2OInterconnection)
 	// 1. overlay subnet, should add lrp, lrp ip is subnet gw
 	// 2. underlay subnet use logical gw, should add lrp, lrp ip is subnet gw
-	randomAllocateGW := !subnet.Spec.LogicalGateway && vpc.Spec.EnableExternal && subnet.Name == c.config.ExternalGatewaySwitch
+	randomAllocateGW := !subnet.Spec.LogicalGateway && vpc.Spec.ExternalSubnets != nil && subnet.Name == c.config.ExternalGatewaySwitch
 	// 3. underlay subnet use physical gw, vpc has eip, lrp managed in vpc process, lrp ip is random allocation, not subnet gw
 
 	gateway := subnet.Spec.Gateway
@@ -1766,7 +1766,7 @@ func (c *Controller) reconcileCustomVpcStaticRoute(subnet *kubeovnv1.Subnet) err
 		return err
 	}
 
-	if vpc.Spec.EnableExternal && vpc.Spec.EnableBfd && subnet.Spec.EnableEcmp {
+	if vpc.Spec.ExternalSubnets != nil && vpc.Spec.EnableBfd && subnet.Spec.EnableEcmp {
 		klog.Infof("add bfd and external static ecmp route for vpc %s, subnet %s", vpc.Name, subnet.Name)
 		// handle vpc static route
 		// use static ecmp route with bfd

--- a/test/e2e/framework/vpc.go
+++ b/test/e2e/framework/vpc.go
@@ -156,7 +156,7 @@ func (c *VpcClient) WaitToDisappear(name string, _, timeout time.Duration) error
 	return nil
 }
 
-func MakeVpc(name, gatewayV4 string, enableExternal, enableBfd bool, namespaces []string) *kubeovnv1.Vpc {
+func MakeVpc(name, gatewayV4 string, enableBfd bool, namespaces, ExternalSubnets []string) *kubeovnv1.Vpc {
 	routes := make([]*kubeovnv1.StaticRoute, 0, 1)
 	if gatewayV4 != "" {
 		routes = append(routes, &kubeovnv1.StaticRoute{
@@ -170,10 +170,10 @@ func MakeVpc(name, gatewayV4 string, enableExternal, enableBfd bool, namespaces 
 			Name: name,
 		},
 		Spec: kubeovnv1.VpcSpec{
-			StaticRoutes:   routes,
-			EnableExternal: enableExternal,
-			EnableBfd:      enableBfd,
-			Namespaces:     namespaces,
+			StaticRoutes:    routes,
+			ExternalSubnets: ExternalSubnets,
+			EnableBfd:       enableBfd,
+			Namespaces:      namespaces,
 		},
 	}
 	return vpc

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -174,7 +174,7 @@ func setupVpcNatGwTestEnvironment(
 	framework.ExpectNoError(err, "failed to get ConfigMap")
 
 	ginkgo.By("Creating custom vpc " + vpcName)
-	vpc := framework.MakeVpc(vpcName, lanIP, false, false, nil)
+	vpc := framework.MakeVpc(vpcName, lanIP, false, nil, nil)
 	_ = vpcClient.CreateSync(vpc)
 
 	ginkgo.By("Creating custom overlay subnet " + overlaySubnetName)

--- a/test/e2e/kube-ovn/pod/vpc_pod_probe.go
+++ b/test/e2e/kube-ovn/pod/vpc_pod_probe.go
@@ -85,7 +85,7 @@ var _ = framework.SerialDescribe("[group:pod]", func() {
 
 		ginkgo.By("Creating VPC " + vpcName)
 		vpcName = "vpc-" + framework.RandomSuffix()
-		customVPC := framework.MakeVpc(vpcName, "", false, false, nil)
+		customVPC := framework.MakeVpc(vpcName, "", false, nil, nil)
 		vpcClient.CreateSync(customVPC)
 
 		ginkgo.By("Creating subnet " + custVPCSubnetName)

--- a/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
+++ b/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
@@ -92,7 +92,7 @@ var _ = framework.Describe("[group:slr]", func() {
 		vip = ""
 		overlaySubnetCidr = framework.RandomCIDR(f.ClusterIPFamily)
 		ginkgo.By("Creating custom vpc")
-		vpc := framework.MakeVpc(vpcName, "", false, false, []string{namespaceName})
+		vpc := framework.MakeVpc(vpcName, "", false, nil, []string{namespaceName})
 		_ = vpcClient.CreateSync(vpc)
 		ginkgo.By("Creating custom overlay subnet")
 		overlaySubnet := framework.MakeSubnet(subnetName, "", overlaySubnetCidr, "", vpcName, "", nil, nil, nil)

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -782,7 +782,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		podClient.DeleteSync(u2oPodNameUnderlay)
 
 		ginkgo.By("Creating VPC " + vpcName)
-		customVPC := framework.MakeVpc(vpcName, "", false, false, []string{namespaceName})
+		customVPC := framework.MakeVpc(vpcName, "", false, nil, []string{namespaceName})
 		vpcClient.CreateSync(customVPC)
 
 		ginkgo.By("Creating subnet " + u2oOverlaySubnetNameCustomVPC)

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -571,9 +571,8 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		ginkgo.By("1. Test custom vpc nats using centralized external gw")
 		noBfdSubnetV4Cidr := "192.168.0.0/24"
 		noBfdSubnetV4Gw := "192.168.0.1"
-		enableExternal := true
 		disableBfd := false
-		noBfdVpc := framework.MakeVpc(noBfdVpcName, "", enableExternal, disableBfd, nil)
+		noBfdVpc := framework.MakeVpc(noBfdVpcName, "", disableBfd, nil, nil)
 		_ = vpcClient.CreateSync(noBfdVpc)
 		ginkgo.By("Creating overlay subnet " + noBfdSubnetName)
 		noBfdSubnet := framework.MakeSubnet(noBfdSubnetName, "", noBfdSubnetV4Cidr, noBfdSubnetV4Gw, noBfdVpcName, util.OvnProvider, nil, nil, nil)
@@ -749,7 +748,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 
 		cachedVpc := vpcClient.Get(noBfdVpcName)
 		noBfdVpc = cachedVpc.DeepCopy()
-		noBfdVpc.Spec.ExtraExternalSubnets = append(noBfdVpc.Spec.ExtraExternalSubnets, underlayExtraSubnetName)
+		noBfdVpc.Spec.ExternalSubnets = append(noBfdVpc.Spec.ExternalSubnets, underlayExtraSubnetName)
 		noBfdVpc.Spec.StaticRoutes = append(noBfdVpc.Spec.StaticRoutes, &kubeovnv1.StaticRoute{
 			Policy:    kubeovnv1.PolicySrc,
 			CIDR:      noBfdExtraSubnetV4Cidr,
@@ -847,7 +846,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		bfdSubnetV4Cidr := "192.168.1.0/24"
 		bfdSubnetV4Gw := "192.168.1.1"
 		enableBfd := true
-		bfdVpc := framework.MakeVpc(bfdVpcName, "", enableExternal, enableBfd, nil)
+		bfdVpc := framework.MakeVpc(bfdVpcName, "", enableBfd, nil, nil)
 		_ = vpcClient.CreateSync(bfdVpc)
 		ginkgo.By("Creating overlay subnet enable ecmp")
 		bfdSubnet := framework.MakeSubnet(bfdSubnetName, "", bfdSubnetV4Cidr, bfdSubnetV4Gw, bfdVpcName, util.OvnProvider, nil, nil, nil)

--- a/test/e2e/vip/e2e_test.go
+++ b/test/e2e/vip/e2e_test.go
@@ -166,7 +166,7 @@ var _ = framework.Describe("[group:vip]", func() {
 		vpcName = "vpc-" + randomSuffix
 		subnetName = "subnet-" + randomSuffix
 		ginkgo.By("Creating vpc " + vpcName)
-		vpc = framework.MakeVpc(vpcName, "", false, false, []string{namespaceName})
+		vpc = framework.MakeVpc(vpcName, "", false, nil, []string{namespaceName})
 		vpc = vpcClient.CreateSync(vpc)
 		ginkgo.By("Creating subnet " + subnetName)
 		subnet = framework.MakeSubnet(subnetName, "", cidr, "", vpcName, "", nil, nil, []string{namespaceName})


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

1. Any VPC can use any `provider-network vlan subnet` via VPC CRD spec externalSubnets (just as vpc nat gw)
2. EnableEipSnat has nothing to do with VPC CRD spec externalSubnets


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->


	// external subnets only contains provider-networks vlan subnet
	// user choose to use either enable-eip-snat or vpc ExternalSubnets to use exeternal network
	// enable eip snat only support default subnet use default external subnet
	// vpc spec externalSubnets means vpc can use any subnet in ExternalSubnets to access outside

## Which issue(s) this PR fixes

Fixes #(issue-number)
