### PR TITLE
any vpc can use any external subnet

### DIFF
--- a/pkg/apis/kubeovn/v1/vpc.go
+++ b/pkg/apis/kubeovn/v1/vpc.go
@@ -45,14 +45,19 @@ type Vpc struct {
 }
 
 type VpcSpec struct {
-	DefaultSubnet        string         `json:"defaultSubnet,omitempty"`
-	Namespaces           []string       `json:"namespaces,omitempty"`
-	StaticRoutes         []*StaticRoute `json:"staticRoutes,omitempty"`
-	PolicyRoutes         []*PolicyRoute `json:"policyRoutes,omitempty"`
-	VpcPeerings          []*VpcPeering  `json:"vpcPeerings,omitempty"`
-	EnableExternal       bool           `json:"enableExternal,omitempty"`
-	ExtraExternalSubnets []string       `json:"extraExternalSubnets,omitempty"`
-	EnableBfd            bool           `json:"enableBfd,omitempty"`
+	DefaultSubnet string         `json:"defaultSubnet,omitempty"`
+	Namespaces    []string       `json:"namespaces,omitempty"`
+	StaticRoutes  []*StaticRoute `json:"staticRoutes,omitempty"`
+	PolicyRoutes  []*PolicyRoute `json:"policyRoutes,omitempty"`
+	VpcPeerings   []*VpcPeering  `json:"vpcPeerings,omitempty"`
+
+	EnableExternal bool `json:"enableExternal,omitempty"`
+	// EnableExternal only handle default external subnet
+
+	ExtraExternalSubnets []string `json:"extraExternalSubnets,omitempty"`
+	// ExtraExternalSubnets only handle provider-network vlan subnet
+
+	EnableBfd bool `json:"enableBfd,omitempty"`
 
 	// optional BFD LRP configuration
 	// currently the LRP is used for vpc external gateway only

--- a/pkg/controller/external_gw.go
+++ b/pkg/controller/external_gw.go
@@ -30,6 +30,18 @@ func (c *Controller) resyncExternalGateway() {
 		return
 	}
 
+	// check if default vpc only use extra external subnet
+	defaultVPC, err := c.vpcsLister.Get(c.config.ClusterRouter)
+	if err != nil {
+		klog.Errorf("failed to get vpc %s, %v", c.config.ClusterRouter, err)
+		return
+	}
+	if defaultVPC.Spec.ExtraExternalSubnets != nil || defaultVPC.Status.ExtraExternalSubnets != nil {
+		// vpc controller will handle
+		klog.Infof("default vpc only use extra external subnets: %v", defaultVPC.Spec.ExtraExternalSubnets)
+		return
+	}
+
 	if k8serrors.IsNotFound(err) || cm.Data["enable-external-gw"] == "false" {
 		if exGwEnabled == "false" {
 			return

--- a/pkg/controller/external_gw.go
+++ b/pkg/controller/external_gw.go
@@ -24,12 +24,6 @@ var (
 )
 
 func (c *Controller) resyncExternalGateway() {
-	cm, err := c.configMapsLister.ConfigMaps(c.config.ExternalGatewayConfigNS).Get(util.ExternalGatewayConfig)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		klog.Errorf("failed to get ovn-external-gw-config, %v", err)
-		return
-	}
-
 	// check if default vpc only use extra external subnet
 	defaultVPC, err := c.vpcsLister.Get(c.config.ClusterRouter)
 	if err != nil {
@@ -42,6 +36,11 @@ func (c *Controller) resyncExternalGateway() {
 		return
 	}
 
+	cm, err := c.configMapsLister.ConfigMaps(c.config.ExternalGatewayConfigNS).Get(util.ExternalGatewayConfig)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		klog.Errorf("failed to get ovn-external-gw-config, %v", err)
+		return
+	}
 	if k8serrors.IsNotFound(err) || cm.Data["enable-external-gw"] == "false" {
 		if exGwEnabled == "false" {
 			return

--- a/pkg/controller/external_gw.go
+++ b/pkg/controller/external_gw.go
@@ -30,6 +30,7 @@ func (c *Controller) resyncExternalGateway() {
 		klog.Errorf("failed to get vpc %s, %v", c.config.ClusterRouter, err)
 		return
 	}
+
 	if defaultVPC.Spec.ExtraExternalSubnets != nil || defaultVPC.Status.ExtraExternalSubnets != nil {
 		// vpc controller will handle
 		klog.Infof("default vpc only use extra external subnets: %v", defaultVPC.Spec.ExtraExternalSubnets)
@@ -41,6 +42,7 @@ func (c *Controller) resyncExternalGateway() {
 		klog.Errorf("failed to get ovn-external-gw-config, %v", err)
 		return
 	}
+
 	if k8serrors.IsNotFound(err) || cm.Data["enable-external-gw"] == "false" {
 		if exGwEnabled == "false" {
 			return

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -381,7 +381,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 					}
 					nextHop = externalSubnet.Spec.Gateway
 					if nextHop == "" {
-						err := errors.New("no available gateway address")
+						err := fmt.Errorf("subnet %s has no gateway configuration", externalSubnet.Name)
 						klog.Error(err)
 						return err
 					}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

any vpc can use any external subnet

For ovn-cluster to use the default `external` subnet:
1. Use enable-eip-snat
2. Use VPC spec enableExternal

For a custom VPC to use the default `external` subnet:
1. Use VPC spec enableExternal


For any VPC to use any provider-network vlan (external) subnet
1. Set the external subnet in the Vpc spec ExtraExternalSubnets
2. Set the enableExternal to true at the same time


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
