### PR TITLE
fix(bgpspeaker): nat gateway with embedded bgp speaker would crash

### DIFF
--- a/cmd/speaker/speaker.go
+++ b/cmd/speaker/speaker.go
@@ -27,11 +27,14 @@ func CmdMain() {
 		util.LogFatalAndExit(err, "failed to parse config")
 	}
 
-	perm, err := strconv.ParseUint(config.LogPerm, 8, 32)
-	if err != nil {
-		util.LogFatalAndExit(err, "failed to parse log-perm")
+	// Do not try to redirect the logs on the node if we're running in a NAT gateway
+	if !config.NatGwMode {
+		perm, err := strconv.ParseUint(config.LogPerm, 8, 32)
+		if err != nil {
+			util.LogFatalAndExit(err, "failed to parse log-perm")
+		}
+		util.InitLogFilePerm("kube-ovn-speaker", os.FileMode(perm))
 	}
-	util.InitLogFilePerm("kube-ovn-speaker", os.FileMode(perm))
 
 	ctrl.SetLogger(klog.NewKlogr())
 	ctx := signals.SetupSignalHandler()


### PR DESCRIPTION
# Pull Request

- [ x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Fix a bug where the BGP speaker will not start within a NAT gateway due to a log directory not existing

## Which issue(s) this PR fixes

Fixes #5284
