### PR TITLE
fix podcidr route still use join ip as src ip

### DIFF
--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -401,10 +401,9 @@ func routeDiff(nodeNicRoutes, allRoutes []netlink.Route, cidrs, joinCIDR []strin
 		}
 
 		found := false
-		_, cidrNet, _ := net.ParseCIDR(c)
 		for _, ar := range allRoutes {
-			if ar.Dst != nil && ar.Dst.String() == cidrNet.String() {
-				if slices.Contains(joinCIDR, cidrNet.String()) {
+			if ar.Dst != nil && ar.Dst.String() == c {
+				if slices.Contains(joinCIDR, c) {
 					// Only compare Dst for join subnets
 					found = true
 					klog.V(3).Infof("[routeDiff] joinCIDR route already exists in allRoutes: %v", ar)
@@ -421,7 +420,7 @@ func routeDiff(nodeNicRoutes, allRoutes []netlink.Route, cidrs, joinCIDR []strin
 			continue
 		}
 		for _, r := range nodeNicRoutes {
-			if r.Dst == nil || r.Dst.String() != cidrNet.String() {
+			if r.Dst == nil || r.Dst.String() != c {
 				continue
 			}
 			if (src == nil && r.Src == nil) || (src != nil && r.Src != nil && src.Equal(r.Src)) {


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
<img width="850" alt="企业微信截图_17484211222774" src="https://github.com/user-attachments/assets/3d5cda5a-886f-4fc6-8fd7-7761e3a5c5b5" />
when upgrade from lower version to 1.12.29 , the route is not auto replace.

the podcidr route on node should use nodeip as src ip

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
