### PR TITLE
fix sts/vm lsp in incorrect port groups after rescheduled to another node

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -1666,6 +1666,25 @@ func (mr *MockPortGroupMockRecorder) PortGroupSetPorts(pgName, ports any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortGroupSetPorts", reflect.TypeOf((*MockPortGroup)(nil).PortGroupSetPorts), pgName, ports)
 }
 
+// RemovePortFromPortGroups mocks base method.
+func (m *MockPortGroup) RemovePortFromPortGroups(portName string, portGroupNames ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []any{portName}
+	for _, a := range portGroupNames {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RemovePortFromPortGroups", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemovePortFromPortGroups indicates an expected call of RemovePortFromPortGroups.
+func (mr *MockPortGroupMockRecorder) RemovePortFromPortGroups(portName any, portGroupNames ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{portName}, portGroupNames...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePortFromPortGroups", reflect.TypeOf((*MockPortGroup)(nil).RemovePortFromPortGroups), varargs...)
+}
+
 // MockACL is a mock of ACL interface.
 type MockACL struct {
 	ctrl     *gomock.Controller
@@ -4167,6 +4186,25 @@ func (m *MockNbClient) RemoveLogicalPatchPort(lspName, lrpName string) error {
 func (mr *MockNbClientMockRecorder) RemoveLogicalPatchPort(lspName, lrpName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveLogicalPatchPort", reflect.TypeOf((*MockNbClient)(nil).RemoveLogicalPatchPort), lspName, lrpName)
+}
+
+// RemovePortFromPortGroups mocks base method.
+func (m *MockNbClient) RemovePortFromPortGroups(portName string, portGroupNames ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []any{portName}
+	for _, a := range portGroupNames {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RemovePortFromPortGroups", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemovePortFromPortGroups indicates an expected call of RemovePortFromPortGroups.
+func (mr *MockNbClientMockRecorder) RemovePortFromPortGroups(portName any, portGroupNames ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{portName}, portGroupNames...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePortFromPortGroups", reflect.TypeOf((*MockNbClient)(nil).RemovePortFromPortGroups), varargs...)
 }
 
 // ResetLogicalSwitchPortMigrateOptions mocks base method.

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -788,7 +788,7 @@ func (c *Controller) checkAndUpdateNodePortGroup() error {
 		}
 
 		if err = c.OVNNbClient.PortGroupSetPorts(pgName, nodePorts); err != nil {
-			klog.Errorf("add ports to port group %s: %v", pgName, err)
+			klog.Errorf("failed to set ports of port group %s: %v", pgName, err)
 			return err
 		}
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -687,13 +687,32 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 			return fmt.Errorf("NodeSwitch subnet %s is unavailable for pod", subnet.Name)
 		}
 
+		pgName := getOverlaySubnetsPortGroupName(subnet.Name, pod.Spec.NodeName)
 		portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
+		portGroups, err := c.OVNNbClient.ListPortGroups(map[string]string{"subnet": subnet.Name, "node": "", networkPolicyKey: ""})
+		if err != nil {
+			klog.Errorf("failed to list port groups: %v", err)
+			return err
+		}
+		pgNames := make([]string, 0, len(portGroups))
+		for _, pg := range portGroups {
+			if pg.Name != pgName {
+				pgNames = append(pgNames, pg.Name)
+			}
+		}
+
 		if (!c.config.EnableLb || !(subnet.Spec.EnableLb != nil && *subnet.Spec.EnableLb)) &&
 			subnet.Spec.Vpc == c.config.ClusterRouter &&
 			subnet.Spec.U2OInterconnection &&
 			subnet.Spec.Vlan != "" &&
 			!subnet.Spec.LogicalGateway {
-			pgName := getOverlaySubnetsPortGroupName(subnet.Name, pod.Spec.NodeName)
+			// remove lsp from other port groups
+			// we need to do this because the pod, e.g. a sts/vm, can be rescheduled to another node
+			if err = c.OVNNbClient.RemovePortFromPortGroups(portName, pgNames...); err != nil {
+				klog.Errorf("failed to remove port %s from port groups %v: %v", portName, pgNames, err)
+				return err
+			}
+			// add lsp to the port group
 			if err := c.OVNNbClient.PortGroupAddPorts(pgName, portName); err != nil {
 				klog.Errorf("failed to add port to u2o port group %s: %v", pgName, err)
 				return err
@@ -707,7 +726,6 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 				return err
 			}
 
-			pgName := getOverlaySubnetsPortGroupName(subnet.Name, node.Name)
 			if c.config.EnableEipSnat && (pod.Annotations[util.EipAnnotation] != "" || pod.Annotations[util.SnatAnnotation] != "") {
 				cm, err := c.configMapsLister.ConfigMaps(c.config.ExternalGatewayConfigNS).Get(util.ExternalGatewayConfig)
 				if err != nil {
@@ -762,15 +780,20 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 					}
 
 					var added bool
-
 					for _, nodeAddr := range nodeTunlIPAddr {
 						for _, podAddr := range strings.Split(podIP, ",") {
 							if util.CheckProtocol(nodeAddr.String()) != util.CheckProtocol(podAddr) {
 								continue
 							}
 
+							// remove lsp from other port groups
+							// we need to do this because the pod, e.g. a sts/vm, can be rescheduled to another node
+							if err = c.OVNNbClient.RemovePortFromPortGroups(portName, pgNames...); err != nil {
+								klog.Errorf("failed to remove port %s from port groups %v: %v", portName, pgNames, err)
+								return err
+							}
 							if err := c.OVNNbClient.PortGroupAddPorts(pgName, portName); err != nil {
-								klog.Errorf("add port to port group %s: %v", pgName, err)
+								klog.Errorf("failed to add port %s to port group %s: %v", portName, pgName, err)
 								return err
 							}
 
@@ -970,13 +993,21 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 	if err != nil {
 		klog.Errorf("failed to get kube-ovn nets of pod %s: %v", podKey, err)
 	}
-	if !keepIPCR {
-		ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": podKey})
-		if err != nil {
-			klog.Errorf("failed to list lsps of pod %s: %v", podKey, err)
-			return err
+	ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": podKey})
+	if err != nil {
+		klog.Errorf("failed to list lsps of pod %s: %v", podKey, err)
+		return err
+	}
+	if keepIPCR {
+		// always remove lsp from port groups
+		for _, port := range ports {
+			klog.Infof("remove lsp %s from all port groups", port.Name)
+			if err = c.OVNNbClient.RemovePortFromPortGroups(port.Name); err != nil {
+				klog.Errorf("failed to remove lsp %s from all port groups: %v", port.Name, err)
+				return err
+			}
 		}
-
+	} else {
 		if len(ports) != 0 {
 			addresses := c.ipam.GetPodAddress(podKey)
 			for _, address := range addresses {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1039,13 +1039,9 @@ func (c *Controller) reconcileSubnet(subnet *kubeovnv1.Subnet) error {
 			klog.Errorf("reconcile default vpc ovn route for subnet %s failed: %v", subnet.Name, err)
 			return err
 		}
-	}
-
-	if subnet.Spec.Vpc != c.config.ClusterRouter {
-		if err := c.reconcileCustomVpcStaticRoute(subnet); err != nil {
-			klog.Errorf("reconcile custom vpc ovn route for subnet %s failed: %v", subnet.Name, err)
-			return err
-		}
+	} else if err := c.reconcileCustomVpcStaticRoute(subnet); err != nil {
+		klog.Errorf("reconcile custom vpc ovn route for subnet %s failed: %v", subnet.Name, err)
+		return err
 	}
 
 	if err := c.reconcileVlan(subnet); err != nil {
@@ -1441,6 +1437,12 @@ func (c *Controller) reconcileDistributedSubnetRouteInDefaultVpc(subnet *kubeovn
 		}
 	}
 
+	portGroups, err := c.OVNNbClient.ListPortGroups(map[string]string{"subnet": subnet.Name, "node": "", networkPolicyKey: ""})
+	if err != nil {
+		klog.Errorf("failed to list port groups for subnet %s: %v", subnet.Name, err)
+		return err
+	}
+
 	pods, err := c.podsLister.Pods(metav1.NamespaceAll).List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list pods %v", err)
@@ -1489,6 +1491,18 @@ func (c *Controller) reconcileDistributedSubnetRouteInDefaultVpc(subnet *kubeovn
 			portsToAdd = append(portsToAdd, port)
 		}
 
+		// remove lsp from other port groups
+		// we need to do this because the pod, e.g. a sts/vm, can be rescheduled to another node
+		for _, pg := range portGroups {
+			if pg.Name == pgName {
+				continue
+			}
+			if err = c.OVNNbClient.PortGroupRemovePorts(pg.Name, podPorts...); err != nil {
+				klog.Errorf("remove ports from port group %s: %v", pg.Name, err)
+				return err
+			}
+		}
+		// add ports to the port group
 		if err = c.OVNNbClient.PortGroupAddPorts(pgName, portsToAdd...); err != nil {
 			klog.Errorf("add ports to port group %s: %v", pgName, err)
 			return err
@@ -2464,7 +2478,13 @@ func (c *Controller) createPortGroupForDistributedSubnet(node *v1.Node, subnet *
 	}
 
 	pgName := getOverlaySubnetsPortGroupName(subnet.Name, node.Name)
-	if err := c.OVNNbClient.CreatePortGroup(pgName, map[string]string{networkPolicyKey: subnet.Name + "/" + node.Name}); err != nil {
+	externalIDs := map[string]string{
+		"subnet":         subnet.Name,
+		"node":           node.Name,
+		"vendor":         util.CniTypeName,
+		networkPolicyKey: subnet.Name + "/" + node.Name,
+	}
+	if err := c.OVNNbClient.CreatePortGroup(pgName, externalIDs); err != nil {
 		klog.Errorf("create port group for subnet %s and node %s: %v", subnet.Name, node.Name, err)
 		return err
 	}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -138,6 +138,7 @@ type PortGroup interface {
 	ListPortGroups(externalIDs map[string]string) ([]ovnnb.PortGroup, error)
 	GetPortGroup(pgName string, ignoreNotFound bool) (*ovnnb.PortGroup, error)
 	PortGroupExists(pgName string) (bool, error)
+	RemovePortFromPortGroups(portName string, portGroupNames ...string) error
 }
 
 type ACL interface {

--- a/pkg/ovs/ovn-nb-port_group.go
+++ b/pkg/ovs/ovn-nb-port_group.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
@@ -15,18 +17,25 @@ import (
 )
 
 func (c *OVNNbClient) CreatePortGroup(pgName string, externalIDs map[string]string) error {
-	exist, err := c.PortGroupExists(pgName)
+	pg, err := c.GetPortGroup(pgName, true)
 	if err != nil {
 		klog.Error(err)
 		return err
 	}
 
-	// ignore
-	if exist {
+	if pg != nil {
+		if !maps.Equal(pg.ExternalIDs, externalIDs) {
+			pg.ExternalIDs = maps.Clone(externalIDs)
+			if err = c.UpdatePortGroup(pg, &pg.ExternalIDs); err != nil {
+				err = fmt.Errorf("failed to update port group %s external IDs: %w", pgName, err)
+				klog.Error(err)
+				return err
+			}
+		}
 		return nil
 	}
 
-	pg := &ovnnb.PortGroup{
+	pg = &ovnnb.PortGroup{
 		Name:        pgName,
 		ExternalIDs: externalIDs,
 	}
@@ -213,10 +222,9 @@ func (c *OVNNbClient) ListPortGroups(externalIDs map[string]string) ([]ovnnb.Por
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
 
-	pgs := make([]ovnnb.PortGroup, 0)
-
+	var pgs []ovnnb.PortGroup
 	if err := c.WhereCache(func(pg *ovnnb.PortGroup) bool {
-		if len(pg.ExternalIDs) < len(externalIDs) {
+		if len(externalIDs) != 0 && len(pg.ExternalIDs) < len(externalIDs) {
 			return false
 		}
 
@@ -317,4 +325,53 @@ func (c *OVNNbClient) portGroupOp(pgName string, mutationsFunc ...func(pg *ovnnb
 	}
 
 	return ops, nil
+}
+
+func (c *OVNNbClient) RemovePortFromPortGroups(portName string, portGroupNames ...string) error {
+	lsp, err := c.GetLogicalSwitchPort(portName, true)
+	if err != nil {
+		klog.Error(err)
+		return fmt.Errorf("failed to get logical switch port %s: %w", portName, err)
+	}
+	if lsp == nil {
+		return nil
+	}
+
+	portGroups := make([]ovnnb.PortGroup, 0, len(portGroupNames))
+	if len(portGroupNames) != 0 {
+		for _, pgName := range portGroupNames {
+			pg, err := c.GetPortGroup(pgName, true)
+			if err != nil {
+				klog.Error(err)
+				return fmt.Errorf("failed to get port group %s: %w", pgName, err)
+			}
+			if pg != nil {
+				portGroups = append(portGroups, *pg)
+			}
+		}
+	} else if portGroups, err = c.ListPortGroups(nil); err != nil {
+		klog.Error(err)
+		return fmt.Errorf("failed to list port groups: %w", err)
+	}
+
+	var ops []ovsdb.Operation
+	for _, pg := range portGroups {
+		if !slices.Contains(pg.Ports, lsp.UUID) {
+			continue
+		}
+
+		op, err := c.portGroupUpdatePortOp(pg.Name, []string{lsp.UUID}, ovsdb.MutateOperationDelete)
+		if err != nil {
+			klog.Error(err)
+			return fmt.Errorf("failed to generate operations for removing port %s from port group %s: %w", portName, pg.Name, err)
+		}
+		ops = append(ops, op...)
+	}
+
+	if err = c.Transact("pg-update", ops); err != nil {
+		klog.Error(err)
+		return fmt.Errorf("failed to remove port %s from all port groups: %w", portName, err)
+	}
+
+	return nil
 }

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -643,6 +643,10 @@ func (suite *OvnClientTestSuite) Test_portGroupSetPorts() {
 	suite.testPortGroupSetPorts()
 }
 
+func (suite *OvnClientTestSuite) Test_removePortFromPortGroups() {
+	suite.testRemovePortFromPortGroups()
+}
+
 /* address_set unit test */
 func (suite *OvnClientTestSuite) Test_CreateAddressSet() {
 	suite.testCreateAddressSet()


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
