### PR TITLE
Use cert-manager to issue certificates for IPSec

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -3113,6 +3113,142 @@ jobs:
         if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-e2e.conclusion == 'failure')) }}
         run: make check-kube-ovn-pod-restarts
 
+  kube-ovn-ipsec-cert-mgr-e2e:
+    name: OVN IPSEC E2E CERT MANAGER
+    needs:
+      - build-kube-ovn
+      - build-e2e-binaries
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
+      - uses: actions/checkout@v4
+
+      - name: Create the default branch directory
+        if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
+        run: mkdir -p test/e2e/source
+
+      - name: Check out the default branch
+        if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          path: test/e2e/source
+
+      - name: Export E2E directory
+        run: |
+          if [ '${{ github.base_ref || github.ref_name }}' = '${{ github.event.repository.default_branch }}' ]; then
+            echo "E2E_DIR=." >> "$GITHUB_ENV"
+          else
+            echo "E2E_DIR=test/e2e/source" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/setup-go@v5
+        id: setup-go
+        with:
+          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          check-latest: true
+          cache: false
+
+      - name: Export Go full version
+        run: echo "GO_VERSION=${{ steps.setup-go.outputs.go-version }}" >> "$GITHUB_ENV"
+
+      - name: Go cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-e2e-go-${{ env.GO_VERSION }}-x86-${{ hashFiles(format('{0}/**/go.sum', env.E2E_DIR)) }}
+          restore-keys: ${{ runner.os }}-e2e-go-${{ env.GO_VERSION }}-x86-
+
+      - name: Install kind
+        uses: helm/kind-action@v1.12.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          install_only: true
+
+      - name: Install ginkgo
+        working-directory: ${{ env.E2E_DIR }}
+        run: go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+
+      - name: Download kube-ovn image
+        uses: actions/download-artifact@v4
+        with:
+          name: kube-ovn
+
+      - name: Load images
+        run: docker load -i kube-ovn.tar
+
+      - name: Create kind cluster
+        run: |
+          pipx install jinjanator
+          make kind-init
+
+      - name: Install Kube-OVN
+        id: install
+        run: make kind-install-ovn-ipsec-cert-manager
+
+      - name: Run Ovn IPSEC cert-manager E2E
+        id: kube-ovn-ipsec-cert-mgr-e2e
+        working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
+        run: make kube-ovn-ipsec-cert-mgr-e2e
+
+      - name: Collect k8s events
+        if: failure() && ( steps.ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
+        run: |
+          kubectl get events -A -o yaml > kube-ovn-ipsec-cert-mgr-e2e-events.yaml
+          tar zcf kube-ovn-ipsec-cert-mgr-e2e-events.tar.gz kube-ovn-ipsec-cert-mgr-e2e-events.yaml
+
+      - name: Upload k8s events
+        uses: actions/upload-artifact@v4
+        if: failure() && (steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
+        with:
+          name: kube-ovn-ipsec-cert-mgr-e2e-events
+          path: kube-ovn-ipsec-cert-mgr-e2e-events.tar.gz
+
+      - name: Collect apiserver audit logs
+        if: failure() && (steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
+        run: |
+          docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
+          tar zcf kube-ovn-ipsec-cert-mgr-e2e-audit-log.tar.gz kube-apiserver-audit.log
+
+      - name: Upload apiserver audit logs
+        uses: actions/upload-artifact@v4
+        if: failure() && (steps.kube-ovn-ipse-cert-mgrc-e2e.conclusion == 'failure')
+        with:
+          name: kube-ovn-ipsec-cert-mgr-e2e-audit-log
+          path: kube-ovn-ipsec-cert-mgr-e2e-audit-log.tar.gz
+
+      - name: kubectl ko log
+        if: failure() && (steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
+        run: |
+          make kubectl-ko-log
+          mv kubectl-ko-log.tar.gz kube-ovn-ipsec-cert-mgr-e2e-ko-log.tar.gz
+
+      - name: upload kubectl ko log
+        uses: actions/upload-artifact@v4
+        if: failure() && (steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
+        with:
+          name: kube-ovn-ipsec-cert-mgr-e2e-ko-log
+          path: kube-ovn-ipsec-cert-mgr-e2e-ko-log.tar.gz
+
+      - name: Check kube ovn pod restarts
+        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')) }}
+        run: make check-kube-ovn-pod-restarts
+
   kube-ovn-connectivity-test:
     name: Kube-OVN Connectivity E2E
     needs:
@@ -3379,6 +3515,7 @@ jobs:
       - kube-ovn-conformance-e2e
       - kube-ovn-ic-conformance-e2e
       - kube-ovn-ipsec-e2e
+      - kube-ovn-ipsec-cert-mgr-e2e
       - kube-ovn-underlay-metallb-e2e
       - multus-conformance-e2e
       - vpc-egress-gateway-e2e

--- a/charts/kube-ovn-v2/templates/agent/agent-clusterrole.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-clusterrole.yaml
@@ -83,13 +83,20 @@ rules:
       - "list"
       - "watch"
       - "delete"
-  - apiGroups:
-      - ""
-    resources:
-      - "secrets"
-    resourceNames:
-      - "ovn-ipsec-ca"
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader-ovn-ipsec
+  namespace: {{ .Values.namespace }}
+rules:
+- apiGroups: 
+    - ""
+  resources: 
+    - "secrets"
+  resourceNames: 
+    - "ovn-ipsec-ca"
+  verbs: 
+    - "get"
+    - "list"
+    - "watch"

--- a/charts/kube-ovn-v2/templates/agent/agent-clusterrole.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-clusterrole.yaml
@@ -87,5 +87,9 @@ rules:
       - ""
     resources:
       - "secrets"
+    resourceNames:
+      - "ovn-ipsec-ca"
     verbs:
       - "get"
+      - "list"
+      - "watch"

--- a/charts/kube-ovn-v2/templates/agent/agent-clusterrolebinding.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-clusterrolebinding.yaml
@@ -19,3 +19,17 @@ subjects:
   - kind: ServiceAccount
     name: kube-ovn-cni
     namespace: {{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-ovn-cni-secret-reader
+  namespace: {{ .Values.namespace }}
+subjects:
+- kind: ServiceAccount
+  name: kube-ovn-cni
+  namespace: {{ .Values.namespace }}
+roleRef:
+  kind: Role
+  name: secret-reader-ovn-ipsec
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -273,7 +273,6 @@ rules:
     verbs:
       - get
       - list
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -352,12 +351,23 @@ rules:
       - "list"
       - "watch"
       - "delete"
-  - apiGroups:
-      - ""
-    resources:
-      - "secrets"
-    verbs:
-      - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader-ovn-ipsec
+  namespace: kube-system
+rules:
+- apiGroups: 
+    - ""
+  resources: 
+    - "secrets"
+  resourceNames: 
+    - "ovn-ipsec-ca"
+  verbs: 
+    - "get"
+    - "list"
+    - "watch"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -356,7 +356,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: secret-reader-ovn-ipsec
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 rules:
 - apiGroups: 
     - ""

--- a/charts/kube-ovn/templates/ovn-CRB.yaml
+++ b/charts/kube-ovn/templates/ovn-CRB.yaml
@@ -67,6 +67,20 @@ subjects:
     namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-ovn-cni-secret-reader
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: kube-ovn-cni
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: secret-reader-ovn-ipsec
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kube-ovn-app

--- a/charts/kube-ovn/templates/ovn-CRB.yaml
+++ b/charts/kube-ovn/templates/ovn-CRB.yaml
@@ -70,11 +70,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kube-ovn-cni-secret-reader
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 subjects:
 - kind: ServiceAccount
   name: kube-ovn-cni
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 roleRef:
   kind: Role
   name: secret-reader-ovn-ipsec

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -101,7 +101,7 @@ func main() {
 		kubeinformers.WithTweakListOptions(func(listOption *v1.ListOptions) {
 			listOption.FieldSelector = fmt.Sprintf("metadata.name=%s", util.DefaultOVNIPSecCA)
 		}),
-		kubeinformers.WithNamespace("kube-system"),
+		kubeinformers.WithNamespace(os.Getenv("POD_NAMESPACE")),
 	)
 
 	ctl, err := daemon.NewController(config, stopCh, podInformerFactory, nodeInformerFactory, caSecretInformerFactory, kubeovnInformerFactory)

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -41,6 +41,9 @@ OVS_VSCTL_CONCURRENCY=${OVS_VSCTL_CONCURRENCY:-100}
 ENABLE_COMPACT=${ENABLE_COMPACT:-false}
 SECURE_SERVING=${SECURE_SERVING:-false}
 ENABLE_OVN_IPSEC=${ENABLE_OVN_IPSEC:-false}
+CERT_MANAGER_IPSEC_CERT=${CERT_MANAGER_IPSEC_CERT:-false}
+IPSEC_CERT_DURATION=${IPSEC_CERT_DURATION:-63072000} # 2 years in seconds
+CERT_MANAGER_ISSUER_NAME=${CERT_MANAGER_ISSUER_NAME:-kube-ovn}
 ENABLE_ANP=${ENABLE_ANP:-false}
 SET_VXLAN_TX_OFF=${SET_VXLAN_TX_OFF:-false}
 OVSDB_CON_TIMEOUT=${OVSDB_CON_TIMEOUT:-3}
@@ -3775,12 +3778,32 @@ rules:
       - "list"
       - "watch"
       - "delete"
-  - apiGroups:
-      - ""
-    resources:
-      - "secrets"
-    verbs:
-      - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader-ovn-ipsec
+  namespace: kube-system
+rules:
+- apiGroups: 
+    - ""
+  resources: 
+    - "secrets"
+  resourceNames:
+    - "ovn-ipsec-ca"
+  verbs: 
+    - "get"
+    - "list"
+    - "watch"
+- apiGroups: 
+    - "cert-manager.io"
+  resources: 
+    - "certificaterequests"
+  verbs: 
+    - "get"
+    - "list"
+    - "create"
+    - "delete"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3808,6 +3831,20 @@ subjects:
   - kind: ServiceAccount
     name: kube-ovn-cni
     namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-ovn-cni-secret-reader
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: kube-ovn-cni
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: secret-reader-ovn-ipsec
+  apiGroup: rbac.authorization.k8s.io
 EOF
 
 cat <<EOF > kube-ovn-app-sa.yaml
@@ -4610,6 +4647,7 @@ spec:
           - --enable-metrics=$ENABLE_METRICS
           - --node-local-dns-ip=$NODE_LOCAL_DNS_IP
           - --enable-ovn-ipsec=$ENABLE_OVN_IPSEC
+          - --cert-manager-ipsec-cert=$CERT_MANAGER_IPSEC_CERT
           - --secure-serving=${SECURE_SERVING}
           - --enable-anp=$ENABLE_ANP
           - --ovsdb-con-timeout=$OVSDB_CON_TIMEOUT
@@ -4805,6 +4843,9 @@ spec:
           - --ovs-vsctl-concurrency=$OVS_VSCTL_CONCURRENCY
           - --secure-serving=${SECURE_SERVING}
           - --enable-ovn-ipsec=$ENABLE_OVN_IPSEC
+          - --cert-manager-ipsec-cert=$CERT_MANAGER_IPSEC_CERT
+          - --ovn-ipsec-cert-duration=$IPSEC_CERT_DURATION
+          - --cert-manager-issuer-name=$CERT_MANAGER_ISSUER_NAME
           - --set-vxlan-tx-off=$SET_VXLAN_TX_OFF
         securityContext:
           runAsUser: 0

--- a/e2e.mk
+++ b/e2e.mk
@@ -90,6 +90,7 @@ e2e-build:
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/webhook
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/connectivity
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/metallb
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ipsec-cert-mgr
 
 .PHONY: k8s-conformance-e2e
 k8s-conformance-e2e:

--- a/e2e.mk
+++ b/e2e.mk
@@ -248,8 +248,8 @@ kube-ovn-ipsec-e2e:
 	ginkgo $(GINKGO_OUTPUT_OPT) $(GINKGO_PARALLEL_OPT) --randomize-all -v \
 		--focus=CNI:Kube-OVN ./test/e2e/ipsec/ipsec.test -- $(TEST_BIN_ARGS)
 
-.PHONY: kube-ovn-ipsec-e2e-cert-mgr
-kube-ovn-ipsec-e2e-cert-mgr:
+.PHONY: kube-ovn-ipsec-cert-mgr-e2e
+kube-ovn-ipsec-cert-mgr-e2e:
 	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ipsec-cert-mgr
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \

--- a/e2e.mk
+++ b/e2e.mk
@@ -248,6 +248,15 @@ kube-ovn-ipsec-e2e:
 	ginkgo $(GINKGO_OUTPUT_OPT) $(GINKGO_PARALLEL_OPT) --randomize-all -v \
 		--focus=CNI:Kube-OVN ./test/e2e/ipsec/ipsec.test -- $(TEST_BIN_ARGS)
 
+.PHONY: kube-ovn-ipsec-e2e-cert-mgr
+kube-ovn-ipsec-e2e-cert-mgr:
+	ginkgo build $(E2E_BUILD_FLAGS) ./test/e2e/ipsec-cert-mgr
+	E2E_BRANCH=$(E2E_BRANCH) \
+	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
+	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
+	ginkgo $(GINKGO_OUTPUT_OPT) $(GINKGO_PARALLEL_OPT) --randomize-all -v \
+		--focus=CNI:Kube-OVN ./test/e2e/ipsec-cert-mgr/ipsec-cert-mgr.test -- $(TEST_BIN_ARGS)
+
 .PHONY: kube-ovn-anp-e2e
 kube-ovn-anp-e2e:
 	KUBECONFIG=$(KUBECONFIG) ./test/anp/conformance.sh

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bhendo/go-powershell v0.0.0-20190719160123-219e7fb4e41e
 	github.com/brianvoe/gofakeit/v7 v7.3.0
 	github.com/cenkalti/backoff/v5 v5.0.2
+	github.com/cert-manager/cert-manager v1.17.1
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/containerd/containerd/v2 v2.1.3
 	github.com/containernetworking/cni v1.3.0
@@ -75,8 +76,6 @@ require (
 	sigs.k8s.io/network-policy-api v0.1.5
 )
 
-require sigs.k8s.io/gateway-api v1.1.0 // indirect
-
 require (
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
@@ -95,7 +94,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/hub v1.0.2 // indirect
 	github.com/cenkalti/rpc2 v1.0.4 // indirect
-	github.com/cert-manager/cert-manager v1.17.1
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/container-storage-interface/spec v1.11.0 // indirect
@@ -296,6 +294,7 @@ require (
 	kubevirt.io/containerized-data-importer-api v1.62.0 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.32.1 // indirect
+	sigs.k8s.io/gateway-api v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.19.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,8 @@ require (
 	sigs.k8s.io/network-policy-api v0.1.5
 )
 
+require sigs.k8s.io/gateway-api v1.1.0 // indirect
+
 require (
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
@@ -93,6 +95,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/hub v1.0.2 // indirect
 	github.com/cenkalti/rpc2 v1.0.4 // indirect
+	github.com/cert-manager/cert-manager v1.17.1
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/container-storage-interface/spec v1.11.0 // indirect
@@ -160,7 +163,7 @@ require (
 	github.com/httprunner/funplugin v0.5.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/cenkalti/hub v1.0.2/go.mod h1:8LAFAZcCasb83vfxatMUnZHRoQcffho2ELpHb+k
 github.com/cenkalti/rpc2 v1.0.4 h1:MJWmm7mbt8r/ZkQS+qr/e2KMMrhMLPr/62CYZIHybdI=
 github.com/cenkalti/rpc2 v1.0.4/go.mod h1:2yfU5b86vOr16+iY1jN3MvT6Kxc9Nf8j5iZWwUf7iaw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cert-manager/cert-manager v1.17.1 h1:Aig+lWMoLsmpGd9TOlTvO4t0Ah3D+/vGB37x/f+ZKt0=
+github.com/cert-manager/cert-manager v1.17.1/go.mod h1:zeG4D+AdzqA7hFMNpYCJgcQ2VOfFNBa+Jzm3kAwiDU4=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.3 h1:9liNh8t+u26xl5ddmWLmsOsdNLwkdRTg5AG+JnTiM80=
@@ -336,8 +338,8 @@ github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgf
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
 github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
 github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
+github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
@@ -1225,6 +1227,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.32.1 h1:Cf+ed5N8038zb
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.32.1/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
+sigs.k8s.io/gateway-api v1.1.0 h1:DsLDXCi6jR+Xz8/xd0Z1PYl2Pn0TyaFMOPPZIj4inDM=
+sigs.k8s.io/gateway-api v1.1.0/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=

--- a/kind.mk
+++ b/kind.mk
@@ -657,6 +657,34 @@ kind-install-kwok:
 kind-install-ovn-ipsec:
 	@$(MAKE) ENABLE_OVN_IPSEC=true kind-install
 
+.PHONY: kind-install-cert-manager
+kind-install-cert-manager:
+	$(call kind_load_image,kube-ovn,$(CERT_MANAGER_CONTROLLER),1)
+	kubectl apply -f "$(CERT_MANAGER_YAML)"
+	kubectl rollout status deployment/cert-manager -n cert-manager --timeout 120s
+
+.PHONY: kind-install-ovn-ipsec-cert-manager 
+kind-install-ovn-ipsec-cert-manager:
+	@$(MAKE) ENABLE_OVN_IPSEC=true CERT_MANAGER_IPSEC_CERT=true kind-install
+	@$(MAKE) kind-install-cert-manager
+	
+	kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout 120s
+	
+	$(eval CA_KEY = $(shell mktemp))
+	$(shell openssl genrsa -out $(CA_KEY) 2048)
+	$(eval CA_CERT = $(shell openssl req -x509 -new -nodes \
+		-key "$(CA_KEY)" \
+		-days 3650 \
+		-subj "/C=US/ST=California/L=Palo Alto/O=Open vSwitch/OU=Open vSwitch Certification Authority/CN=OVS CA" | \
+		base64 -w 0 -))
+
+	$(eval CA_KEY64 = $(shell base64 -w 0 "$(CA_KEY)"))
+
+	sed -e 's/KUBE_OVN_CA_KEY/$(CA_KEY64)/g' \
+	    -e 's/KUBE_OVN_CA_CERT/$(CA_CERT)/g' yamls/ipsec-certs.yaml | \
+		kubectl apply -f -
+	rm $(CA_KEY)
+
 .PHONY: kind-install-anp
 kind-install-anp: kind-load-image
 	$(call kind_load_image,kube-ovn,$(ANP_TEST_IMAGE),1)

--- a/kind.mk
+++ b/kind.mk
@@ -660,16 +660,20 @@ kind-install-ovn-ipsec:
 .PHONY: kind-install-cert-manager
 kind-install-cert-manager:
 	$(call kind_load_image,kube-ovn,$(CERT_MANAGER_CONTROLLER),1)
+	$(call kind_load_image,kube-ovn,$(CERT_MANAGER_CAINJECTOR),1)
+	$(call kind_load_image,kube-ovn,$(CERT_MANAGER_WEBHOOK),1)
+
 	kubectl apply -f "$(CERT_MANAGER_YAML)"
+
 	kubectl rollout status deployment/cert-manager -n cert-manager --timeout 120s
+	kubectl rollout status deployment/cert-manager-cainjector -n cert-manager --timeout 120s
+	kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout 120s
 
 .PHONY: kind-install-ovn-ipsec-cert-manager 
 kind-install-ovn-ipsec-cert-manager:
 	@$(MAKE) ENABLE_OVN_IPSEC=true CERT_MANAGER_IPSEC_CERT=true kind-install
 	@$(MAKE) kind-install-cert-manager
-	
-	kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout 120s
-	
+
 	$(eval CA_KEY = $(shell mktemp))
 	$(shell openssl genrsa -out $(CA_KEY) 2048)
 	$(eval CA_CERT = $(shell openssl req -x509 -new -nodes \

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -97,7 +97,7 @@ type Configuration struct {
 	EnableMetrics               bool
 	EnableANP                   bool
 	EnableOVNIPSec              bool
-	CertManagerIPSECCert        bool
+	CertManagerIPSecCert        bool
 	EnableLiveMigrationOptimize bool
 
 	ExternalGatewaySwitch   string
@@ -189,7 +189,7 @@ func ParseFlags() (*Configuration, error) {
 		argEnableMetrics               = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableANP                   = pflag.Bool("enable-anp", false, "Enable support for admin network policy and baseline admin network policy")
 		argEnableOVNIPSec              = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
-		argCertManagerIPSECCert        = pflag.Bool("cert-manager-ipsec-cert", false, "Whether to use cert-manager for signing IPSec certificates")
+		argCertManagerIPSecCert        = pflag.Bool("cert-manager-ipsec-cert", false, "Whether to use cert-manager for signing IPSec certificates")
 		argEnableLiveMigrationOptimize = pflag.Bool("enable-live-migration-optimize", true, "Whether to enable kubevirt live migration optimize")
 
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")
@@ -292,7 +292,7 @@ func ParseFlags() (*Configuration, error) {
 		EnableOVNLBPreferLocal:         *argEnableOVNLBPreferLocal,
 		EnableMetrics:                  *argEnableMetrics,
 		EnableOVNIPSec:                 *argEnableOVNIPSec,
-		CertManagerIPSECCert:           *argCertManagerIPSECCert,
+		CertManagerIPSecCert:           *argCertManagerIPSecCert,
 		EnableLiveMigrationOptimize:    *argEnableLiveMigrationOptimize,
 		BfdMinTx:                       *argBfdMinTx,
 		BfdMinRx:                       *argBfdMinRx,

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -97,6 +97,7 @@ type Configuration struct {
 	EnableMetrics               bool
 	EnableANP                   bool
 	EnableOVNIPSec              bool
+	CertManagerIPSECCert        bool
 	EnableLiveMigrationOptimize bool
 
 	ExternalGatewaySwitch   string
@@ -188,6 +189,7 @@ func ParseFlags() (*Configuration, error) {
 		argEnableMetrics               = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableANP                   = pflag.Bool("enable-anp", false, "Enable support for admin network policy and baseline admin network policy")
 		argEnableOVNIPSec              = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
+		argCertManagerIPSECCert        = pflag.Bool("cert-manager-ipsec-cert", false, "Whether to use cert-manager for signing IPSec certificates")
 		argEnableLiveMigrationOptimize = pflag.Bool("enable-live-migration-optimize", true, "Whether to enable kubevirt live migration optimize")
 
 		argExternalGatewayConfigNS = pflag.String("external-gateway-config-ns", "kube-system", "The namespace of configmap external-gateway-config, default: kube-system")
@@ -290,6 +292,7 @@ func ParseFlags() (*Configuration, error) {
 		EnableOVNLBPreferLocal:         *argEnableOVNLBPreferLocal,
 		EnableMetrics:                  *argEnableMetrics,
 		EnableOVNIPSec:                 *argEnableOVNIPSec,
+		CertManagerIPSECCert:           *argCertManagerIPSECCert,
 		EnableLiveMigrationOptimize:    *argEnableLiveMigrationOptimize,
 		BfdMinTx:                       *argBfdMinTx,
 		BfdMinRx:                       *argBfdMinRx,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -990,7 +990,7 @@ func (c *Controller) Run(ctx context.Context) {
 		util.LogFatalAndExit(err, "failed to sync crd vlans")
 	}
 
-	if c.config.EnableOVNIPSec {
+	if c.config.EnableOVNIPSec && !c.config.CertManagerIPSECCert {
 		if err := c.InitDefaultOVNIPsecCA(); err != nil {
 			util.LogFatalAndExit(err, "failed to init ovn ipsec CA")
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -990,7 +990,7 @@ func (c *Controller) Run(ctx context.Context) {
 		util.LogFatalAndExit(err, "failed to sync crd vlans")
 	}
 
-	if c.config.EnableOVNIPSec && !c.config.CertManagerIPSECCert {
+	if c.config.EnableOVNIPSec && !c.config.CertManagerIPSecCert {
 		if err := c.InitDefaultOVNIPsecCA(); err != nil {
 			util.LogFatalAndExit(err, "failed to init ovn ipsec CA")
 		}

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -69,7 +69,7 @@ type Configuration struct {
 	ExternalGatewaySwitch     string // provider network underlay vlan subnet
 	EnableMetrics             bool
 	EnableOVNIPSec            bool
-	CertManagerIPSECCert      bool
+	CertManagerIPSecCert      bool
 	CertManagerIssuerName     string
 	IPSecCertDuration         int
 	EnableArpDetectIPConflict bool
@@ -130,7 +130,7 @@ func ParseFlags() *Configuration {
 		argEnableTProxy              = pflag.Bool("enable-tproxy", false, "enable tproxy for vpc pod liveness or readiness probe")
 		argOVSVsctlConcurrency       = pflag.Int32("ovs-vsctl-concurrency", 100, "concurrency limit of ovs-vsctl")
 		argEnableOVNIPSec            = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
-		argCertManagerIPSECCert      = pflag.Bool("cert-manager-ipsec-cert", false, "Whether to use cert-manager for signing IPSec certificates")
+		argCertManagerIPSecCert      = pflag.Bool("cert-manager-ipsec-cert", false, "Whether to use cert-manager for signing IPSec certificates")
 		argCertManagerIssuerName     = pflag.String("cert-manager-issuer-name", "kube-ovn", "The cert-manager issuer name to request certificates from")
 		argOVNIPSecCertDuration      = pflag.Int("ovn-ipsec-cert-duration", 2*365*24*60*60, "The duration requested for IPSec certificates (seconds)")
 		argSetVxlanTxOff             = pflag.Bool("set-vxlan-tx-off", false, "Whether to set vxlan_sys_4789 tx off")
@@ -204,7 +204,7 @@ func ParseFlags() *Configuration {
 		TLSMinVersion:             *argTLSMinVersion,
 		TLSMaxVersion:             *argTLSMaxVersion,
 		TLSCipherSuites:           *argTLSCipherSuites,
-		CertManagerIPSECCert:      *argCertManagerIPSECCert,
+		CertManagerIPSecCert:      *argCertManagerIPSecCert,
 		CertManagerIssuerName:     *argCertManagerIssuerName,
 		IPSecCertDuration:         *argOVNIPSecCertDuration,
 	}
@@ -433,7 +433,7 @@ func (config *Configuration) initKubeClient() error {
 	}
 	config.KubeClient = kubeClient
 
-	if config.CertManagerIPSECCert {
+	if config.CertManagerIPSecCert {
 		cfg.ContentType = "application/json"
 		cmClient, err := certmanagerclientset.NewForConfig(cfg)
 		if err != nil {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	certmanagerclientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +50,7 @@ type Configuration struct {
 	KubeConfigFile            string
 	KubeClient                kubernetes.Interface
 	KubeOvnClient             clientset.Interface
+	CertManagerClient         certmanagerclientset.Interface
 	NodeName                  string
 	NodeIPv4                  string
 	NodeIPv6                  string
@@ -67,6 +69,9 @@ type Configuration struct {
 	ExternalGatewaySwitch     string // provider network underlay vlan subnet
 	EnableMetrics             bool
 	EnableOVNIPSec            bool
+	CertManagerIPSECCert      bool
+	CertManagerIssuerName     string
+	IPSecCertDuration         int
 	EnableArpDetectIPConflict bool
 	KubeletDir                string
 	EnableVerboseConnCheck    bool
@@ -125,6 +130,9 @@ func ParseFlags() *Configuration {
 		argEnableTProxy              = pflag.Bool("enable-tproxy", false, "enable tproxy for vpc pod liveness or readiness probe")
 		argOVSVsctlConcurrency       = pflag.Int32("ovs-vsctl-concurrency", 100, "concurrency limit of ovs-vsctl")
 		argEnableOVNIPSec            = pflag.Bool("enable-ovn-ipsec", false, "Whether to enable ovn ipsec")
+		argCertManagerIPSECCert      = pflag.Bool("cert-manager-ipsec-cert", false, "Whether to use cert-manager for signing IPSec certificates")
+		argCertManagerIssuerName     = pflag.String("cert-manager-issuer-name", "kube-ovn", "The cert-manager issuer name to request certificates from")
+		argOVNIPSecCertDuration      = pflag.Int("ovn-ipsec-cert-duration", 2*365*24*60*60, "The duration requested for IPSec certificates (seconds)")
 		argSetVxlanTxOff             = pflag.Bool("set-vxlan-tx-off", false, "Whether to set vxlan_sys_4789 tx off")
 		argLogPerm                   = pflag.String("log-perm", "640", "The permission for the log file")
 
@@ -196,6 +204,9 @@ func ParseFlags() *Configuration {
 		TLSMinVersion:             *argTLSMinVersion,
 		TLSMaxVersion:             *argTLSMaxVersion,
 		TLSCipherSuites:           *argTLSCipherSuites,
+		CertManagerIPSECCert:      *argCertManagerIPSECCert,
+		CertManagerIssuerName:     *argCertManagerIssuerName,
+		IPSecCertDuration:         *argOVNIPSecCertDuration,
 	}
 	return config
 }
@@ -421,6 +432,17 @@ func (config *Configuration) initKubeClient() error {
 		return err
 	}
 	config.KubeClient = kubeClient
+
+	if config.CertManagerIPSECCert {
+		cfg.ContentType = "application/json"
+		cmClient, err := certmanagerclientset.NewForConfig(cfg)
+		if err != nil {
+			klog.Errorf("init certmanager client failed %v", err)
+			return err
+		}
+		config.CertManagerClient = cmClient
+	}
+
 	return nil
 }
 

--- a/pkg/daemon/ipsec.go
+++ b/pkg/daemon/ipsec.go
@@ -660,7 +660,7 @@ func (c *Controller) CreateIPSecKeys(p pkiFiles) error {
 	defer cancel()
 
 	var cert []byte
-	if c.config.CertManagerIPSECCert {
+	if c.config.CertManagerIPSecCert {
 		cert, err = c.getCertManagerSignedCert(ctx, csr64)
 		if err != nil {
 			err := fmt.Errorf("create cr error: %w", err)

--- a/pkg/daemon/ipsec.go
+++ b/pkg/daemon/ipsec.go
@@ -9,9 +9,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	v1 "k8s.io/api/certificates/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,14 +24,19 @@ import (
 )
 
 const (
-	ipsecKeyDir      = "/etc/ovs_ipsec_keys/"
-	ipsecPrivKeyPath = ipsecKeyDir + "ipsec-privkey.pem"
-	ipsecReqPath     = ipsecKeyDir + "ipsec-req.pem"
-	ipsecCACertPath  = ipsecKeyDir + "ipsec-cacert.pem"
-	ipsecCertPath    = ipsecKeyDir + "ipsec-cert.pem"
+	ipsecKeyDir  = "/etc/ovs_ipsec_keys/"
+	ipsecReqPath = ipsecKeyDir + "ipsec-req.pem"
 
-	expireTime = 365 * 24 * time.Hour
+	ipsecPrivKeyPathSpec = ipsecKeyDir + "ipsec-privkey-%d.pem"
+	ipsecCertPathSpec    = ipsecKeyDir + "ipsec-cert-%d.pem"
+	ipsecCACertPathSpec  = ipsecKeyDir + "ipsec-cacert-%s.pem"
 )
+
+type pkiFiles struct {
+	privateKeyPath  string
+	certificatePath string
+	caCertPath      string
+}
 
 func getOVSSystemID() (string, error) {
 	cmd := exec.Command("ovs-vsctl", "--retry", "-t", "60", "get", "Open_vSwitch", ".", "external-ids:system-id")
@@ -47,8 +55,48 @@ func getOVSSystemID() (string, error) {
 	return systemID, nil
 }
 
-func checkCertExpired() (bool, error) {
-	certBytes, err := os.ReadFile(ipsecCertPath)
+func (c *Controller) needNewCA(p pkiFiles) (bool, error) {
+	if p.caCertPath == "" {
+		klog.Infof("ipsec CA cert not configured")
+		return true, nil
+	}
+
+	if _, err := os.Stat(p.caCertPath); os.IsNotExist(err) {
+		klog.Infof("ipsec CA cert %s not present on disk", p.caCertPath)
+		return true, nil
+	}
+
+	caSecret, err := c.caSecretLister.Secrets("kube-system").Get(util.DefaultOVNIPSecCA)
+	if err != nil {
+		klog.Errorf("failed to get secret: %v", err)
+		return false, err
+	}
+
+	caPath := generateCACertFileName(caSecret.ResourceVersion)
+	if p.caCertPath != caPath {
+		klog.Infof("ipsec CA cert changed")
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *Controller) needNewCert(p pkiFiles) (bool, error) {
+	if p.certificatePath == "" || p.privateKeyPath == "" {
+		klog.Infof("ipsec cert and key not configured")
+		return true, nil
+	}
+
+	if _, err := os.Stat(p.certificatePath); os.IsNotExist(err) {
+		klog.Infof("ipsec cert %s not present on disk", p.certificatePath)
+		return true, nil
+	}
+	if _, err := os.Stat(p.privateKeyPath); os.IsNotExist(err) {
+		klog.Infof("ipsec key %s not present on disk", p.privateKeyPath)
+		return true, nil
+	}
+
+	certBytes, err := os.ReadFile(p.certificatePath)
 	if err != nil {
 		return false, fmt.Errorf("failed to read certificate: %w", err)
 	}
@@ -63,14 +111,113 @@ func checkCertExpired() (bool, error) {
 		return false, fmt.Errorf("failed to parse certificate: %w", err)
 	}
 
-	if time.Since(cert.NotBefore) > expireTime {
+	// get a new certificate if we're over half way through this certificates validity
+	now := time.Now()
+	if now.Before(cert.NotBefore) ||
+		time.Since(cert.NotBefore) > (cert.NotAfter.Sub(cert.NotBefore))/2 {
+		klog.Infof("ipsec cert near expiry")
+		return true, nil
+	}
+
+	// now check our certificate is signed by our CA
+	caCertBytes, err := os.ReadFile(p.caCertPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read CA certificate: %w", err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCertBytes) {
+		return false, errors.New("failed to decode CA certificate PEM blocks")
+	}
+
+	chain, err := cert.Verify(
+		x509.VerifyOptions{
+			Roots:     caCertPool,
+			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		})
+	if err != nil {
+		return false, fmt.Errorf("failed to verify cert: %w", err)
+	}
+
+	if len(chain) == 0 {
+		klog.Infof("certificate not signed by trust bundle")
 		return true, nil
 	}
 
 	return false, nil
 }
 
-func generateCSRCode() ([]byte, error) {
+func (c *Controller) untilCertRefresh(certPath string) (time.Duration, error) {
+	certBytes, err := os.ReadFile(certPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read certificate: %w", err)
+	}
+
+	block, _ := pem.Decode(certBytes)
+	if block == nil {
+		return 0, errors.New("failed to decode PEM block containing certificate")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	// get a new certificate if we're over half way through this certificates validity
+	refreshTime := cert.NotBefore.Add((cert.NotAfter.Sub(cert.NotBefore)) / 2)
+	return time.Until(refreshTime), nil
+}
+
+func (c *Controller) getCACert() (string, error) {
+	caSecret, err := c.caSecretLister.Secrets("kube-system").Get(util.DefaultOVNIPSecCA)
+	if err != nil {
+		klog.Errorf("failed to get secret: %v", err)
+		return "", err
+	}
+
+	ca := caSecret.Data["cacert"]
+	caCertPath := generateCACertFileName(caSecret.ResourceVersion)
+
+	if err = os.WriteFile(caCertPath, ca, 0o600); err != nil {
+		klog.Errorf("failed to write file: %v", err)
+		return "", err
+	}
+
+	if err := linkCACertToIPSecDir(ca); err != nil {
+		klog.Errorf("link cacert to ipsec dir error: %v", err)
+		return "", err
+	}
+
+	cmd := exec.Command("ipsec", "rereadcacerts")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Errorf("failed to reload ipsec ca cert: %v, output: %s", err, output)
+		return "", err
+	}
+
+	klog.Infof("ipsec CA Cert file %s written", caCertPath)
+	return caCertPath, nil
+}
+
+func generateNewPrivateKey(path string) error {
+	cmd := exec.Command("openssl", "genrsa", "-out", path, "2048")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Errorf("failed to generate private key: %v, output: %s", err, string(output))
+		return err
+	}
+
+	_, err = os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("privkey file %s not exist", path)
+		}
+		return err
+	}
+	return nil
+}
+
+func generateCSRCode(newPrivKeyPath string) ([]byte, error) {
 	cn, err := getOVSSystemID()
 	if err != nil {
 		klog.Errorf("failed to get ovs system id: %v", err)
@@ -78,28 +225,14 @@ func generateCSRCode() ([]byte, error) {
 	}
 
 	klog.Infof("ovs system id: %s", cn)
-	cmd := exec.Command("openssl", "genrsa", "-out", ipsecPrivKeyPath, "2048")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		klog.Errorf("failed to generate private key: %v, output: %s", err, string(output))
-		return nil, err
-	}
 
-	_, err = os.Stat(ipsecPrivKeyPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("privkey file %s not exist", ipsecPrivKeyPath)
-		}
-		return nil, err
-	}
-
-	cmd = exec.Command("openssl", "req", "-new", "-text",
+	cmd := exec.Command("openssl", "req", "-new", "-text",
 		"-extensions", "v3_req",
 		"-addext", "subjectAltName = DNS:"+cn,
-		"-subj", "/C=CN/O=kubeovn/OU=kind/CN="+cn,
-		"-key", ipsecPrivKeyPath,
+		"-subj", "/C=CN/O=kubeovn/OU=kube-ovn/CN="+cn,
+		"-key", newPrivKeyPath,
 		"-out", ipsecReqPath) // #nosec
-	output, err = cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		klog.Errorf("failed to generate csr: %v, output: %s", err, string(output))
 		return nil, err
@@ -114,7 +247,67 @@ func generateCSRCode() ([]byte, error) {
 	return csrBytes, nil
 }
 
-func (c *Controller) createCSR(csrBytes []byte) error {
+func (c *Controller) getCertManagerSignedCert(ctx context.Context, csrBytes []byte) ([]byte, error) {
+	newCR := &certmanagerv1.CertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ovn-ipsec-" + os.Getenv("HOSTNAME"),
+			Namespace: "kube-system",
+		},
+		Spec: certmanagerv1.CertificateRequestSpec{
+			Request: csrBytes,
+			IssuerRef: cmmeta.ObjectReference{
+				Name:  c.config.CertManagerIssuerName,
+				Kind:  "ClusterIssuer",
+				Group: "cert-manager.io",
+			},
+			Duration: &metav1.Duration{Duration: time.Second * time.Duration(c.config.IPSecCertDuration)},
+			Usages:   []certmanagerv1.KeyUsage{certmanagerv1.UsageIPsecTunnel},
+		},
+	}
+
+	_, err := c.config.CertManagerClient.CertmanagerV1().CertificateRequests("kube-system").Create(ctx, newCR, metav1.CreateOptions{})
+	if err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			klog.Infof("CR %s already exists: %v", newCR.Name, err)
+			err := c.config.CertManagerClient.CertmanagerV1().CertificateRequests("kube-system").Delete(context.Background(), newCR.Name, metav1.DeleteOptions{})
+			if err != nil {
+				klog.Errorf("failed to delete cr: %s; %v", newCR.Name, err)
+			}
+		}
+
+		return nil, fmt.Errorf("creating certificate request; %w", err)
+	}
+
+	defer func() {
+		// clean up the request once it's no longer needed
+		err := c.config.CertManagerClient.CertmanagerV1().CertificateRequests("kube-system").Delete(context.Background(), newCR.Name, metav1.DeleteOptions{})
+		if err != nil {
+			klog.Errorf("failed to delete cr: %s; %v", newCR.Name, err)
+		}
+	}()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("failed to sign certificate request; %w", ctx.Err())
+		case <-ticker.C:
+			cr, err := c.config.CertManagerClient.CertmanagerV1().CertificateRequests("kube-system").Get(ctx, newCR.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("getting certificate request; %w", err)
+			}
+
+			if len(cr.Status.Certificate) == 0 {
+				continue
+			}
+
+			return cr.Status.Certificate, nil
+		}
+	}
+}
+
+func (c *Controller) getSignedCert(ctx context.Context, csrBytes []byte) ([]byte, error) {
 	csr := &v1.CertificateSigningRequest{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "certificates.k8s.io/v1",
@@ -132,44 +325,47 @@ func (c *Controller) createCSR(csrBytes []byte) error {
 		},
 	}
 
-	if _, err := c.config.KubeClient.CertificatesV1().CertificateSigningRequests().Create(context.Background(), csr, metav1.CreateOptions{}); err != nil {
+	if _, err := c.config.KubeClient.CertificatesV1().CertificateSigningRequests().Create(ctx, csr, metav1.CreateOptions{}); err != nil {
 		if k8serrors.IsAlreadyExists(err) {
 			klog.Infof("CSR %s already exists: %v", csr.Name, err)
 		} else {
 			klog.Errorf("failed to create csr: %v", err)
-			return err
+			return nil, err
 		}
 	}
+
+	defer func() {
+		// clean up the request once it's no longer needed
+		if err := c.config.KubeClient.CertificatesV1().CertificateSigningRequests().Delete(context.Background(), csr.Name, metav1.DeleteOptions{}); err != nil {
+			klog.Errorf("failed to delete csr: %v", err)
+		}
+	}()
 
 	// Wait until the certificate signing request has been signed.
-	var certificateStr string
-	counter := 0
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for {
-		csr, err := c.config.KubeClient.CertificatesV1().CertificateSigningRequests().Get(context.Background(), csr.Name, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("failed to get csr: %v", err)
-			return err
-		}
-		if len(csr.Status.Certificate) != 0 {
-			certificateStr = string(csr.Status.Certificate)
-			break
-		}
-		counter++
-		time.Sleep(time.Second)
-		if counter > 300 {
-			klog.Errorf("failed to sign certificate after %d seconds", counter)
-			return fmt.Errorf("unable to sign certificate after %d seconds", counter)
-		}
-	}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("failed to sign certificate request; %w", ctx.Err())
+		case <-ticker.C:
+			csr, err := c.config.KubeClient.CertificatesV1().CertificateSigningRequests().Get(ctx, csr.Name, metav1.GetOptions{})
+			if err != nil {
+				klog.Errorf("failed to get csr: %v", err)
+				return nil, err
+			}
+			if len(csr.Status.Certificate) == 0 {
+				continue
+			}
 
-	klog.V(3).Infof("ipsec get certitfcate\n%s", certificateStr)
-	cmd := exec.Command("openssl", "x509", "-outform", "pem", "-text", "-out", ipsecCertPath)
-	var stdinBuf bytes.Buffer
-	if _, err := stdinBuf.WriteString(certificateStr); err != nil {
-		klog.Error(err)
-		return fmt.Errorf("failed to write certificate: %w", err)
+			return csr.Status.Certificate, nil
+		}
 	}
-	cmd.Stdin = &stdinBuf
+}
+
+func (c *Controller) storeCertificate(cert []byte, certPath string) error {
+	cmd := exec.Command("openssl", "x509", "-outform", "pem", "-text", "-out", certPath)
+	cmd.Stdin = bytes.NewReader(cert)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -177,37 +373,58 @@ func (c *Controller) createCSR(csrBytes []byte) error {
 		return err
 	}
 
-	klog.Infof("ipsec Cert file %s generated", ipsecCertPath)
-	secret, err := c.config.KubeClient.CoreV1().Secrets("kube-system").Get(context.Background(), util.DefaultOVNIPSecCA, metav1.GetOptions{})
-	if err != nil {
-		klog.Errorf("failed to get secret: %v", err)
-		return err
-	}
-
-	output = secret.Data["cacert"]
-	if err = os.WriteFile(ipsecCACertPath, output, 0o600); err != nil {
-		klog.Errorf("failed to write file: %v", err)
-		return err
-	}
-
-	klog.Infof("ipsec CA Cert file %s generated", ipsecCACertPath)
-	// the csr is no longer needed
-	if err := c.config.KubeClient.CertificatesV1().CertificateSigningRequests().Delete(context.Background(), csr.Name, metav1.DeleteOptions{}); err != nil {
-		klog.Errorf("failed to delete csr: %v", err)
-		return err
-	}
-
-	klog.Infof("node %s' ipsec init successfully", os.Getenv("HOSTNAME"))
+	klog.Infof("wrote certificate file: %s", certPath)
 	return nil
 }
 
-func configureOVSWithIPSecKeys() error {
-	cmd := exec.Command("ovs-vsctl", "--retry", "-t", "60", "set", "Open_vSwitch", ".", "other_config:certificate="+ipsecCertPath, "other_config:private_key="+ipsecPrivKeyPath, "other_config:ca_cert="+ipsecCACertPath)
+func configureOVSWithIPSecKeys(p pkiFiles) error {
+	args := []string{
+		"-t", "60", "set", "Open_vSwitch", ".",
+		fmt.Sprintf("other_config:certificate=%s", p.certificatePath),
+		fmt.Sprintf("other_config:private_key=%s", p.privateKeyPath),
+		fmt.Sprintf("other_config:ca_cert=%s", p.caCertPath),
+	}
+	cmd := exec.Command("ovs-vsctl", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to configure OVS with IPSec keys: %q: %w", string(output), err)
 	}
 	return nil
+}
+
+func getOVSIPSecKeys() (pkiFiles, error) {
+	cmd := exec.Command("ovs-vsctl", "--retry", "-t", "60", "get", "Open_vSwitch", ".", "other_config:certificate")
+	certificate, err := cmd.CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(certificate), "no key \"certificate\"") {
+			return pkiFiles{}, nil
+		}
+		return pkiFiles{}, fmt.Errorf("reading OVS certificate config; %w", err)
+	}
+
+	cmd = exec.Command("ovs-vsctl", "--retry", "-t", "60", "get", "Open_vSwitch", ".", "other_config:private_key")
+	privateKey, err := cmd.CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(certificate), "no key \"private_key\"") {
+			return pkiFiles{}, nil
+		}
+		return pkiFiles{}, fmt.Errorf("reading OVS private key config; %w", err)
+	}
+
+	cmd = exec.Command("ovs-vsctl", "--retry", "-t", "60", "get", "Open_vSwitch", ".", "other_config:ca_cert")
+	caCert, err := cmd.CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(certificate), "no key \"ca_cert\"") {
+			return pkiFiles{}, nil
+		}
+		return pkiFiles{}, fmt.Errorf("reading OVS CA certificate config; %w", err)
+	}
+
+	return pkiFiles{
+		certificatePath: strings.Trim(string(certificate), "\n\""),
+		privateKeyPath:  strings.Trim(string(privateKey), "\n\""),
+		caCertPath:      strings.Trim(string(caCert), "\n\""),
+	}, nil
 }
 
 func unconfigureOVSWithIPSecKeys() error {
@@ -228,26 +445,83 @@ func unconfigureOVSWithIPSecKeys() error {
 	return nil
 }
 
-func linkCACertToIPSecDir() error {
-	targetPath := "/etc/ipsec.d/cacerts/ipsec-cacert.pem"
+func linkCACertToIPSecDir(ca []byte) error {
+	// strongswan is unable to read chains or trust bundles and will only read the first certificate in the file. Split out each CA cert into it's own file in the ipsec cacerts directory.
+	// strongswan also does not seem to read the OVS configured CA cert so CAs do need to be written to the directory
 
-	if _, err := os.Stat(targetPath); err == nil {
-		klog.Infof("Target path %s already exists, skipping link operation", targetPath)
-		return nil
-	} else if !os.IsNotExist(err) {
-		klog.Errorf("failed to check if target path exists: %v", err)
-		return err
+	ipsecCADir := "/etc/ipsec.d/cacerts"
+
+	if err := os.RemoveAll(ipsecCADir); err != nil {
+		return fmt.Errorf("clearing ipsec CA directory: %w", err)
 	}
 
-	cmd := exec.Command("ln", "-s", ipsecCACertPath, targetPath)
-	output, err := cmd.CombinedOutput()
+	// Create output directory if it doesn't exist
+	if err := os.MkdirAll(ipsecCADir, 0o755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	// Split and write individual certificates
+	certificates, err := splitPEMCertificates(ca)
 	if err != nil {
-		klog.Errorf("failed to link cacert: %v, output: %s", err, string(output))
-		return err
+		return fmt.Errorf("failed to split certificates: %w", err)
 	}
 
-	klog.V(3).Infof("Successfully linked %s to %s", ipsecCACertPath, targetPath)
+	for i, cert := range certificates {
+		filename := fmt.Sprintf("ca-%03d.pem", i+1)
+		filepath := filepath.Join(ipsecCADir, filename)
+
+		if err := os.WriteFile(filepath, cert, 0o600); err != nil {
+			return fmt.Errorf("failed to write certificate %s: %w", filename, err)
+		}
+
+		klog.Infof("Wrote CA certificate %s", filename)
+	}
+
+	klog.V(3).Infof("Total certificates processed: %d", len(certificates))
 	return nil
+}
+
+func splitPEMCertificates(data []byte) ([][]byte, error) {
+	var certificates [][]byte
+	var currentCert strings.Builder
+
+	// Split by lines and process each PEM block
+	rest := data
+	for {
+		block, remaining := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+
+		// Only process certificate blocks
+		if block.Type != "CERTIFICATE" {
+			rest = remaining
+			continue
+		}
+
+		// Validate that it's actually a certificate
+		_, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			klog.Errorf("Warning: Skipping invalid certificate: %v\n", err)
+			rest = remaining
+			continue
+		}
+
+		// Encode the certificate block back to PEM format
+		currentCert.Reset()
+		if err := pem.Encode(&currentCert, block); err != nil {
+			return nil, fmt.Errorf("failed to encode certificate: %w", err)
+		}
+
+		certificates = append(certificates, []byte(currentCert.String()))
+		rest = remaining
+	}
+
+	if len(certificates) == 0 {
+		return nil, errors.New("no valid certificates found in bundle")
+	}
+
+	return certificates, nil
 }
 
 func clearCACertToIPSecDir() error {
@@ -266,82 +540,145 @@ func initIPSecKeysDir() error {
 	return nil
 }
 
-func clearIPSecKeysDir() error {
-	if err := os.Remove(ipsecPrivKeyPath); err != nil && !os.IsNotExist(err) {
-		klog.Errorf("failed to remove %s: %v", ipsecPrivKeyPath, err)
+func clearIPSecKeysDir(toKeep pkiFiles) error {
+	filesToKeep := map[string]bool{
+		toKeep.caCertPath:      true,
+		toKeep.certificatePath: true,
+		toKeep.privateKeyPath:  true,
+	}
+
+	// Get all files in the directory
+	files, err := os.ReadDir(ipsecKeyDir)
+	if err != nil {
+		klog.Errorf("reading ipsec keys directory: %v\n", err)
 		return err
 	}
-	if err := os.Remove(ipsecReqPath); err != nil && !os.IsNotExist(err) {
-		klog.Errorf("failed to remove %s: %v", ipsecReqPath, err)
-		return err
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue // Skip directories
+		}
+
+		fileName := file.Name()
+		path := filepath.Join(ipsecKeyDir, fileName)
+
+		if !filesToKeep[path] {
+			// Delete the file
+			err := os.Remove(path)
+			if err != nil {
+				klog.Errorf("deleting %s: %v\n", fileName, err)
+			}
+		}
 	}
-	if err := os.Remove(ipsecCACertPath); err != nil && !os.IsNotExist(err) {
-		klog.Errorf("failed to remove %s: %v", ipsecCACertPath, err)
-		return err
-	}
-	if err := os.Remove(ipsecCertPath); err != nil && !os.IsNotExist(err) {
-		klog.Errorf("failed to remove %s: %v", ipsecCertPath, err)
-		return err
-	}
+
 	return nil
 }
 
-func (c *Controller) ManageIPSecKeys() error {
-	if _, err := os.Stat(ipsecCertPath); os.IsNotExist(err) {
-		if err := c.CreateIPSecKeys(); err != nil {
+func (c *Controller) SyncIPSecKeys() error {
+	klog.Info("syncing IPSec keys")
+
+	if err := initIPSecKeysDir(); err != nil {
+		klog.Errorf("init ipsec keys dir: %v", err)
+		return err
+	}
+
+	pkiFiles, err := getOVSIPSecKeys()
+	if err != nil {
+		klog.Errorf("reading OVS ipsec config: %v", err)
+		return err
+	}
+
+	needNewCA, err := c.needNewCA(pkiFiles)
+	if err != nil {
+		klog.Errorf("checking CA valid: %v", err)
+		return err
+	}
+
+	if needNewCA {
+		ca, err := c.getCACert()
+		if err != nil {
+			klog.Errorf("getting new CA cert: %v", err)
+			return err
+		}
+		pkiFiles.caCertPath = ca
+	}
+
+	needNewCert, err := c.needNewCert(pkiFiles)
+	if err != nil {
+		klog.Errorf("checking certificate valid: %v", err)
+		return err
+	}
+
+	if needNewCert {
+		now := time.Now()
+		pkiFiles.privateKeyPath = generatePrivKeyFileName(now)
+		pkiFiles.certificatePath = generateCertFileName(now)
+		if err := c.CreateIPSecKeys(pkiFiles); err != nil {
 			klog.Errorf("create ipsec keys error: %v", err)
 			return err
 		}
-	} else {
-		checkCertExpired, err := checkCertExpired()
+	}
+
+	if needNewCA || needNewCert {
+		err := configureOVSWithIPSecKeys(pkiFiles)
 		if err != nil {
-			klog.Errorf("failed to check ipsec cert expired: %v", err)
+			klog.Errorf("configure ovs with ipsec keys error: %v", err)
 			return err
 		}
-		if !checkCertExpired {
-			klog.V(3).Infof("ipsec cert exist and not expired, skip")
-		} else {
-			if err := c.RemoveIPSecKeys(); err != nil {
-				klog.Errorf("remove ipsec keys error: %v", err)
-			}
 
-			if err := c.CreateIPSecKeys(); err != nil {
-				klog.Errorf("create ipsec keys error: %v", err)
-				return err
-			}
+		if err := clearIPSecKeysDir(pkiFiles); err != nil {
+			// don't return here; we've already programmed the new keys
+			klog.Errorf("cleaning old ipsec files: %v", err)
 		}
 	}
 
-	if err := c.StartIPSecService(); err != nil {
-		klog.Errorf("Start ipsec service error: %v", err)
+	untilRefresh, err := c.untilCertRefresh(pkiFiles.certificatePath)
+	if err != nil {
+		klog.Errorf("calculating cert refresh time: %v", err)
 		return err
 	}
+
+	c.ipsecQueue.AddAfter("expiry", untilRefresh)
 
 	return nil
 }
 
-func (c *Controller) CreateIPSecKeys() error {
-	err := initIPSecKeysDir()
+func (c *Controller) CreateIPSecKeys(p pkiFiles) error {
+	err := generateNewPrivateKey(p.privateKeyPath)
 	if err != nil {
-		klog.Errorf("init ipsec keys dir error: %v", err)
+		klog.Errorf("generate private key error: %v", err)
 		return err
 	}
 
-	csr64, err := generateCSRCode()
+	csr64, err := generateCSRCode(p.privateKeyPath)
 	if err != nil {
 		klog.Errorf("generate csr code error: %v", err)
 		return err
 	}
 
-	err = c.createCSR(csr64)
-	if err != nil {
-		klog.Errorf("create csr error: %v", err)
-		return err
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+
+	var cert []byte
+	if c.config.CertManagerIPSECCert {
+		cert, err = c.getCertManagerSignedCert(ctx, csr64)
+		if err != nil {
+			err := fmt.Errorf("create cr error: %w", err)
+			klog.Error(err)
+			return err
+		}
+	} else {
+		cert, err = c.getSignedCert(ctx, csr64)
+		if err != nil {
+			klog.Errorf("create csr error: %v", err)
+			return err
+		}
 	}
 
-	err = configureOVSWithIPSecKeys()
+	err = c.storeCertificate(cert, p.certificatePath)
 	if err != nil {
-		klog.Errorf("configure ovs with ipsec keys error: %v", err)
+		err := fmt.Errorf("storing certificate; %w", err)
+		klog.Error(err)
 		return err
 	}
 
@@ -349,7 +686,7 @@ func (c *Controller) CreateIPSecKeys() error {
 }
 
 func (c *Controller) RemoveIPSecKeys() error {
-	err := clearIPSecKeysDir()
+	err := clearIPSecKeysDir(pkiFiles{})
 	if err != nil {
 		klog.Errorf("clear ipsec keys dir error: %v", err)
 		return err
@@ -441,11 +778,6 @@ func restartService(serviceName string) error {
 
 func (c *Controller) StartIPSecService() error {
 	// ipsec can't use the specified dir in /etc/ovs_ipsec_keys/ipsec-cacert.pem (perhap strongwan's bug), so link it to the default dir /etc/ipsec.d/cacerts/
-	err := linkCACertToIPSecDir()
-	if err != nil {
-		klog.Errorf("link cacert to ipsec dir error: %v", err)
-		return err
-	}
 
 	if err := restartService("openvswitch-ipsec"); err != nil {
 		return err
@@ -472,4 +804,16 @@ func (c *Controller) StopIPSecService() error {
 	}
 
 	return nil
+}
+
+func generateCACertFileName(resourceVersion string) string {
+	return fmt.Sprintf(ipsecCACertPathSpec, resourceVersion)
+}
+
+func generateCertFileName(startTime time.Time) string {
+	return fmt.Sprintf(ipsecCertPathSpec, startTime.UnixMilli())
+}
+
+func generatePrivKeyFileName(startTime time.Time) string {
+	return fmt.Sprintf(ipsecPrivKeyPathSpec, startTime.UnixMilli())
 }

--- a/test/e2e/ipsec-cert-mgr/e2e_test.go
+++ b/test/e2e/ipsec-cert-mgr/e2e_test.go
@@ -1,0 +1,314 @@
+package ipsec
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e"
+	k8sframework "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/config"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+func init() {
+	klog.SetOutput(ginkgo.GinkgoWriter)
+
+	// Register flags.
+	config.CopyFlags(config.Flags, flag.CommandLine)
+	k8sframework.RegisterCommonFlags(flag.CommandLine)
+	k8sframework.RegisterClusterFlags(flag.CommandLine)
+}
+
+func TestE2E(t *testing.T) {
+	k8sframework.AfterReadingAllFlags(&k8sframework.TestContext)
+	e2e.RunE2ETests(t)
+}
+
+func checkPodXfrmState(pod corev1.Pod, node1IP, node2IP string) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By("Checking ip xfrm state for pod " + pod.Name + " on node " + pod.Spec.NodeName + " from " + node1IP + " to " + node2IP)
+	output, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "ip xfrm state")
+	framework.ExpectNoError(err)
+
+	count := strings.Count(output, fmt.Sprintf("src %s dst %s", node1IP, node2IP))
+
+	framework.ExpectEqual(count, 2)
+}
+
+func checkXfrmState(pods []corev1.Pod, node1IP, node2IP string) {
+	ginkgo.GinkgoHelper()
+
+	for _, pod := range pods {
+		checkPodXfrmState(pod, node1IP, node2IP)
+		checkPodXfrmState(pod, node2IP, node1IP)
+	}
+}
+
+func checkPodCACert(pod corev1.Pod, expectedCACert string) (bool, error) {
+	ginkgo.GinkgoHelper()
+
+	actualCACert, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "cat /etc/ipsec.d/cacerts/*")
+	if err != nil {
+		if strings.Contains(err.Error(), "No such file or directory") {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading CA certs: %w", err)
+	}
+
+	if actualCACert != expectedCACert {
+		return false, nil
+	}
+
+	expectedNumCerts := strings.Count(expectedCACert, "BEGIN CERTIFICATE")
+	output, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "ipsec listcacerts")
+	if err != nil {
+		return false, fmt.Errorf("running ipsec listcacerts: %w", err)
+	}
+	framework.ExpectEqual(expectedNumCerts, strings.Count(output, "subject:"))
+	return true, nil
+}
+
+func getPodCert(pod corev1.Pod) (string, error) {
+	ginkgo.GinkgoHelper()
+
+	return e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "cat /etc/ovs_ipsec_keys/ipsec-cert-*.pem")
+}
+
+func getValueFromSecret(cs clientset.Interface, namespace, secretName, fieldName string) (string, error) {
+	secret, err := cs.CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	val, ok := secret.Data[fieldName]
+	if !ok {
+		return "", fmt.Errorf("%s not found in secret %s", fieldName, secretName)
+	}
+
+	return string(val), nil
+}
+
+// generateSelfSignedCA generates a new self-signed CA certificate
+func generateSelfSignedCA(privateKey *rsa.PrivateKey) (string, error) {
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   "testing-common-name",
+			Organization: []string{"Test CA"},
+			Country:      []string{"US"},
+			Province:     []string{""},
+			Locality:     []string{"Test"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour), // Valid for 1 year
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	// Create the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	// Encode certificate to PEM format
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	return string(certPEM), nil
+}
+
+// Convert RSA private key to PEM string
+func privateKeyToBytes(privateKey *rsa.PrivateKey) ([]byte, error) {
+	// Convert private key to PKCS#1 ASN.1 DER format
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+
+	// Create PEM block
+	privateKeyPEM := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	}
+
+	// Encode to PEM format
+	privateKeyPEMBytes := pem.EncodeToMemory(privateKeyPEM)
+
+	return privateKeyPEMBytes, nil
+}
+
+var _ = framework.SerialDescribe("[group:ipsec-cert-mgr]", func() {
+	f := framework.NewDefaultFramework("ipsec-cert-mgr")
+
+	var podClient *framework.PodClient
+	var podName string
+	var cs clientset.Interface
+
+	ginkgo.BeforeEach(func() {
+		podClient = f.PodClient()
+		cs = f.ClientSet
+		podName = "pod-" + framework.RandomSuffix()
+	})
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Deleting pod " + podName)
+		podClient.DeleteSync(podName)
+	})
+
+	framework.ConformanceIt("Should keep working when rotating CA", func() {
+		ginkgo.By("Getting nodes")
+		nodeList, err := e2enode.GetReadySchedulableNodes(context.Background(), cs)
+		framework.ExpectNoError(err)
+		framework.ExpectNotEmpty(nodeList.Items)
+		framework.ExpectTrue(len(nodeList.Items) >= 2)
+		nodeIPs := make([]string, 0, len(nodeList.Items))
+		for _, node := range nodeList.Items {
+			for _, addr := range node.Status.Addresses {
+				if addr.Type == corev1.NodeInternalIP {
+					nodeIPs = append(nodeIPs, node.Status.Addresses[0].Address)
+					break
+				}
+			}
+		}
+		framework.ExpectHaveLen(nodeIPs, len(nodeList.Items))
+
+		ginkgo.By("Getting current CA")
+		initialOVNCA, err := getValueFromSecret(cs, framework.KubeOvnNamespace, "ovn-ipsec-ca", "cacert")
+		framework.ExpectNoError(err)
+		initialCAKey, err := getValueFromSecret(cs, "cert-manager", "kube-ovn-ca", "tls.key")
+		framework.ExpectNoError(err)
+
+		framework.ExpectNotEmpty(initialCAKey)
+
+		ginkgo.By("Getting kube-ovn-cni pods")
+		daemonSetClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
+		ds := daemonSetClient.Get("kube-ovn-cni")
+		podList, err := daemonSetClient.GetPods(ds)
+		framework.ExpectNoError(err)
+		framework.ExpectHaveLen(podList.Items, len(nodeList.Items))
+
+		ginkgo.By("Getting kube-ovn-cni pod client certificates")
+		initialPodCerts := make(map[string]string)
+		for _, pod := range podList.Items {
+			cert, err := getPodCert(pod)
+			framework.ExpectNoError(err)
+			initialPodCerts[pod.Spec.NodeName] = cert
+		}
+
+		ginkgo.By("Generating secondary CA")
+		secondaryKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		framework.ExpectNoError(err)
+		secondaryCA, err := generateSelfSignedCA(secondaryKey)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Adding secondary CA to secret bundle")
+		ovnIpsecSecret, err := cs.CoreV1().Secrets(framework.KubeOvnNamespace).Get(context.Background(), "ovn-ipsec-ca", metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		ovnIpsecSecret.Data["cacert"] = []byte(initialOVNCA + secondaryCA)
+		_, err = cs.CoreV1().Secrets(framework.KubeOvnNamespace).Update(context.Background(), ovnIpsecSecret, metav1.UpdateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying new trust bundle distributed")
+		for _, pod := range podList.Items {
+			framework.WaitUntil(0, time.Second*30, func(_ context.Context) (bool, error) {
+				return checkPodCACert(pod, initialOVNCA+secondaryCA)
+			}, "Verifying new trust bundle distributed")
+		}
+
+		// changing the CA cert will cause ovs-ipsec-monitor to stroke up new
+		// tunnels and stroke down the old ones so wait for that processing to
+		// complete before checking xfrm state.
+		checkXfrmState(podList.Items, nodeIPs[0], nodeIPs[1])
+
+		ginkgo.By("Verifying client certificates not changed")
+		for _, pod := range podList.Items {
+			cert, err := getPodCert(pod)
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(initialPodCerts[pod.Spec.NodeName], cert)
+		}
+
+		ginkgo.By("Setting new CA on issuer")
+
+		issuerSecret, err := cs.CoreV1().Secrets("cert-manager").Get(context.Background(), "kube-ovn-ca", metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		issuerSecret.Data["tls.crt"] = []byte(secondaryCA)
+		keyBytes, err := privateKeyToBytes(secondaryKey)
+		framework.ExpectNoError(err)
+		issuerSecret.Data["tls.key"] = keyBytes
+		_, err = cs.CoreV1().Secrets("cert-manager").Update(context.Background(), issuerSecret, metav1.UpdateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Triggering client cert reissue on worker")
+		for _, pod := range podList.Items {
+			// clearing the certificate on disk and restarting the pod should
+			// trigger a new certificate request
+			_, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "rm /etc/ovs_ipsec_keys/ipsec-cert-*.pem")
+			framework.ExpectNoError(err)
+		}
+		daemonSetClient.RestartSync(ds)
+
+		podList, err = daemonSetClient.GetPods(ds)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying new client cert issued on kube-ovn-cni pods")
+
+		for _, pod := range podList.Items {
+			framework.WaitUntil(0, time.Second*30, func(_ context.Context) (bool, error) {
+				cert, err := getPodCert(pod)
+				if err != nil {
+					if strings.Contains(err.Error(), "No such file or directory") {
+						return false, nil
+					}
+					framework.ExpectNoError(err)
+				}
+				framework.ExpectNotEqual(initialPodCerts[pod.Spec.NodeName], cert)
+				return true, nil
+			}, "Verifying new trust bundle distributed")
+		}
+
+		ginkgo.By("Verifying IPsec state is functional")
+		checkXfrmState(podList.Items, nodeIPs[0], nodeIPs[1])
+
+		ginkgo.By("Removing initial CA from bundle")
+
+		ovnIpsecSecret, err = cs.CoreV1().Secrets(framework.KubeOvnNamespace).Get(context.Background(), "ovn-ipsec-ca", metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		ovnIpsecSecret.Data["cacert"] = []byte(secondaryCA)
+		_, err = cs.CoreV1().Secrets(framework.KubeOvnNamespace).Update(context.Background(), ovnIpsecSecret, metav1.UpdateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying IPsec CA updated")
+
+		for _, pod := range podList.Items {
+			framework.WaitUntil(0, time.Second*30, func(_ context.Context) (bool, error) {
+				return checkPodCACert(pod, secondaryCA)
+			}, "Verifying new trust bundle distributed")
+		}
+
+		ginkgo.By("Verifying IPsec state is functional")
+
+		checkXfrmState(podList.Items, nodeIPs[0], nodeIPs[1])
+	})
+})

--- a/yamls/ipsec-certs.yaml
+++ b/yamls/ipsec-certs.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: kube-ovn
+spec:
+  ca:
+    secretName: kube-ovn-ca
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-ovn-ca
+  namespace: cert-manager
+type: Opaque
+data:
+  tls.crt: "KUBE_OVN_CA_CERT"
+  tls.key: "KUBE_OVN_CA_KEY"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ovn-ipsec-ca
+  namespace: kube-system
+type: Opaque
+data:
+  cacert: "KUBE_OVN_CA_CERT"


### PR DESCRIPTION
# Pull Request

## What type of this PR

- Features

Add support for issuing IPSec tunnel certificates using cert-manager.

When cert-manager certificates are enabled, the controller no longer generates the IPSec CA cert or private key stored in the `ovn-ipsec-ca` secret. The secret should be populated with the same CA as configured with cert-manager. It still enables IPSec in OVN NB.

When cert-manager certificates are enabled the CNI daemon creates cert-manager CertificateRequest resources instead of CSRs. A cert-manager ClusterIssuer should be configured to approve and sign these CertificateRequests with a matching CA as configured in `ovn-ipsec-ca` secret. The name of the issuer to use is configurable in the CNI.

The CNI daemon now watches the `ovn-ipsec-ca` secret for changes allowing for rollout of a new trust bundle. It verifies the currently configured certificate is signed by the new bundle and if not then triggers a new certificate to be issued. The daemon now splits each certificate in the CA bundle into a separate file as strongswan is unable to parse multiple CAs from a single file.

The CNI daemon now requests a new certificate when the current certificate is at least half way to expiry based on the times in the certificate. When generating a new certificate the daemon also generates a new key just in case the previous one was leaked somehow. The certificate lifetime is also now configurable rather than lasting for a year. The CNI no longer restarts the ipsec or ovs-ipsec-monitor services when the certificate changes and just requests ipsec to reread the CA certs if they change.

To allow for the CNI daemon to keep track of the versions of its key, certificate, and CA cert files it now stores them with locally unique names on disk. Keys and certs are suffixed with the timestamp they were generated. CA files are suffixed with the k8s revision number of the `ovn-ipsec-ca` secret.

The cert manager validation webhook (if used) should be run in the host network to prevent the risk of certificate requests deadlocking in the event of a certificate expiry. The CNI pods and cert manager issuer interact with the API server over the host network to create and approve certificates but the API server calls the webhook of the service network which can be broken in the event of an expired certificate.

A new kind deployment is created using cert-manager issued certificates and a new e2e test is created that uses it. The e2e test runs through rotating the the CA.

## Which issue(s) this PR fixes

Fixes #5073 
