### PR TITLE
fix(slr): switchlbrule doesn't support multi-homed/ipv6-first pods

### DIFF
--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -256,12 +256,14 @@ func (c *Controller) getVpcSubnetName(pods []*v1.Pod, endpointSlices []*discover
 		for _, endpointSlice := range endpointSlices {
 			for _, endpoint := range endpointSlice.Endpoints {
 				for _, addr := range endpoint.Addresses {
-					if addr == pod.Status.PodIP {
-						if vpcName == "" {
-							vpcName = pod.Annotations[util.LogicalRouterAnnotation]
-						}
-						if vpcName != "" {
-							break LOOP
+					for _, podIP := range pod.Status.PodIPs {
+						if addr == podIP.IP {
+							if vpcName == "" {
+								vpcName = pod.Annotations[util.LogicalRouterAnnotation]
+							}
+							if vpcName != "" {
+								break LOOP
+							}
 						}
 					}
 				}


### PR DESCRIPTION
SwitchLBRules won't work correctly in some cases.

The EndpointSlice code uses the podIP field and not the podIPs (emphasis on the plural), which means that cheks to detect the VPC of an SLR (based on the VPC of the pods it's targeting) is flawed.

If there's multiple IPs, not in the right order (depending on how the PodIP CIDR was given, and in what order), the check can fail because it cannot find a matching IP.

This fix goes through every possible pod IP instead of just the "main IP"