### PR TITLE
fix(slr): deleting old entries from ipmapping to avoid clogging loadbalancer

### DIFF
--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -531,25 +531,40 @@ func (c *OVNNbClient) LoadBalancerDeleteIPPortMapping(lbName, vipEndpoint string
 
 // LoadBalancerUpdateIPPortMapping update load balancer ip port mapping
 func (c *OVNNbClient) LoadBalancerUpdateIPPortMapping(lbName, vipEndpoint string, ipPortMappings map[string]string) error {
-	if len(ipPortMappings) != 0 {
-		ops, err := c.LoadBalancerOp(
-			lbName,
-			func(lb *ovnnb.LoadBalancer) []model.Mutation {
-				return []model.Mutation{
-					{
-						Field:   &lb.IPPortMappings,
-						Value:   ipPortMappings,
-						Mutator: ovsdb.MutateOperationInsert,
-					},
+	ops, err := c.LoadBalancerOp(
+		lbName,
+		func(lb *ovnnb.LoadBalancer) []model.Mutation {
+			// Delete from the IPPortMappings any outdated mapping
+			mappingToDelete := make(map[string]string)
+			for portIP, portMapVip := range lb.IPPortMappings {
+				if _, ok := ipPortMappings[portIP]; !ok {
+					mappingToDelete[portIP] = portMapVip
 				}
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("failed to generate operations when adding ip port mapping with vip %v to load balancers %s: %w", vipEndpoint, lbName, err)
-		}
-		if err = c.Transact("lb-add", ops); err != nil {
-			return fmt.Errorf("failed to add ip port mapping with vip %v to load balancers %s: %w", vipEndpoint, lbName, err)
-		}
+			}
+
+			if len(mappingToDelete) > 0 {
+				klog.Infof("deleting outdated entry from ipportmapping %v", mappingToDelete)
+			}
+
+			return []model.Mutation{
+				{
+					Field:   &lb.IPPortMappings,
+					Value:   mappingToDelete,
+					Mutator: ovsdb.MutateOperationDelete,
+				},
+				{
+					Field:   &lb.IPPortMappings,
+					Value:   ipPortMappings,
+					Mutator: ovsdb.MutateOperationInsert,
+				},
+			}
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to generate operations when adding ip port mapping with vip %v to load balancers %s: %w", vipEndpoint, lbName, err)
+	}
+	if err = c.Transact("lb-add", ops); err != nil {
+		return fmt.Errorf("failed to add ip port mapping with vip %v to load balancers %s: %w", vipEndpoint, lbName, err)
 	}
 	return nil
 }


### PR DESCRIPTION

SLRs create Load_Balancer entries on the NorthBound table of OVN.

These LBs have an "ip_port_mapping" field to map backend IPs to a LSP. This is used to determine which LSP is up and which backend is up.

The mapping is refreshed each time a new pod pops up in the endpoint slice, but it isn't updated when a pod is deleted.

This fix introduces a way for IPMapping to be updated correctly by removing any "old" mapping that shouldn't be present anymore