### PR TITLE
Add network attachment informer to controller

### DIFF
--- a/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
+++ b/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
@@ -84,6 +84,8 @@ rules:
       - network-attachment-definitions
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - ""
       - networking.k8s.io

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -84,6 +84,8 @@ rules:
       - network-attachment-definitions
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - ""
       - networking.k8s.io

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3502,6 +3502,7 @@ rules:
       - network-attachment-definitions
     verbs:
       - get
+      - list
   - apiGroups:
       - ""
       - networking.k8s.io

--- a/pkg/controller/network_attachment.go
+++ b/pkg/controller/network_attachment.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging"
+	multustypes "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func (c *Controller) isNetAttachCRDInstalled() (bool, error) {
+	resources, err := c.config.AttachNetClient.Discovery().ServerResourcesForGroupVersion("k8s.cni.cncf.io/v1")
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting server resources for k8s.cni.cncf.io/v1; %w", err)
+	}
+
+	for _, resource := range resources.APIResources {
+		if resource.Name == "network-attachment-definitions" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// the network-attachment-definition CRD is not required to be installed so
+// periodically check and see if we should start the informer.
+func (c *Controller) StartNetAttachInformerFactory(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				exists, err := c.isNetAttachCRDInstalled()
+				if err != nil {
+					klog.Errorf("checking network attachment CRD exists: %v", err)
+					continue
+				}
+
+				if exists {
+					klog.Info("Start attachment informer")
+
+					c.netAttachInformerFactory.Start(ctx.Done())
+					if !cache.WaitForCacheSync(ctx.Done(), c.netAttachSynced) {
+						util.LogFatalAndExit(nil, "failed to wait for network attachment cache to sync")
+					}
+
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func loadNetConf(bytes []byte) (*multustypes.DelegateNetConf, error) {
+	delegateConf := &multustypes.DelegateNetConf{}
+	if err := json.Unmarshal(bytes, &delegateConf.Conf); err != nil {
+		return nil, logging.Errorf("LoadDelegateNetConf: error unmarshalling delegate config: %v", err)
+	}
+
+	if delegateConf.Conf.Type == "" {
+		if err := multustypes.LoadDelegateNetConfList(bytes, delegateConf); err != nil {
+			return nil, logging.Errorf("LoadDelegateNetConf: failed with: %v", err)
+		}
+	}
+	return delegateConf, nil
+}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -16,8 +16,6 @@ import (
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	"github.com/scylladb/go-set/strset"
-	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging"
-	multustypes "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1655,20 +1653,6 @@ func (c *Controller) getPodDefaultSubnet(pod *v1.Pod) (*kubeovnv1.Subnet, error)
 	return nil, ipam.ErrNoAvailable
 }
 
-func loadNetConf(bytes []byte) (*multustypes.DelegateNetConf, error) {
-	delegateConf := &multustypes.DelegateNetConf{}
-	if err := json.Unmarshal(bytes, &delegateConf.Conf); err != nil {
-		return nil, logging.Errorf("LoadDelegateNetConf: error unmarshalling delegate config: %v", err)
-	}
-
-	if delegateConf.Conf.Type == "" {
-		if err := multustypes.LoadDelegateNetConfList(bytes, delegateConf); err != nil {
-			return nil, logging.Errorf("LoadDelegateNetConf: failed with: %v", err)
-		}
-	}
-	return delegateConf, nil
-}
-
 type providerType int
 
 const (
@@ -1718,8 +1702,7 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 
 	result := make([]*kubeovnNet, 0, len(multusNets))
 	for _, attach := range multusNets {
-		networkClient := c.config.AttachNetClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(attach.Namespace)
-		network, err := networkClient.Get(context.Background(), attach.Name, metav1.GetOptions{})
+		network, err := c.netAttachLister.NetworkAttachmentDefinitions(attach.Namespace).Get(attach.Name)
 		if err != nil {
 			klog.Errorf("failed to get net-attach-def %s, %v", attach.Name, err)
 			return nil, err

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -431,7 +431,7 @@ func (c *Controller) handleAddService(key string) error {
 		return err
 	}
 
-	nad, err := c.getAttachNetwork(svc)
+	nad, err := c.getAttachNetworkForService(svc)
 	if err != nil {
 		c.recorder.Event(svc, v1.EventTypeWarning, "GetNADFailed", err.Error())
 		klog.Errorf("failed to check attachment network of lb svc %s: %v", key, err)

--- a/pkg/controller/service_lb.go
+++ b/pkg/controller/service_lb.go
@@ -57,13 +57,13 @@ func parseAttachNetworkProvider(svc *corev1.Service) (string, string) {
 	return attachmentName, attachmentNs
 }
 
-func (c *Controller) getAttachNetwork(svc *corev1.Service) (*nadv1.NetworkAttachmentDefinition, error) {
+func (c *Controller) getAttachNetworkForService(svc *corev1.Service) (*nadv1.NetworkAttachmentDefinition, error) {
 	attachmentName, attachmentNs := parseAttachNetworkProvider(svc)
 	if attachmentName == "" && attachmentNs == "" {
 		return nil, errors.New("the provider name should be consisted of name and namespace")
 	}
 
-	nad, err := c.config.AttachNetClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(attachmentNs).Get(context.Background(), attachmentName, metav1.GetOptions{})
+	nad, err := c.netAttachLister.NetworkAttachmentDefinitions(attachmentNs).Get(attachmentName)
 	if err != nil {
 		klog.Errorf("failed to get network attachment definition %s in namespace %s, err: %v", attachmentName, attachmentNs, err)
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -3279,8 +3279,7 @@ func (c *Controller) deletePolicyRouteForU2ONoLoadBalancer(subnet *kubeovnv1.Sub
 }
 
 func (c *Controller) findSubnetByNetworkAttachmentDefinition(ns, name string, subnets []*kubeovnv1.Subnet) (*kubeovnv1.Subnet, error) {
-	nadClient := c.config.AttachNetClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(ns)
-	nad, err := nadClient.Get(context.Background(), name, metav1.GetOptions{})
+	nad, err := c.netAttachLister.NetworkAttachmentDefinitions(ns).Get(name)
 	if err != nil {
 		klog.Errorf("failed to get net-attach-def %s/%s: %v", ns, name, err)
 		return nil, err

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -286,8 +286,7 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 	}
 	subStrings := strings.Split(extSubnet.Spec.Provider, ".")
 	nadName, nadNamespace := subStrings[0], subStrings[1]
-	if _, err = c.config.AttachNetClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nadNamespace).
-		Get(context.Background(), nadName, metav1.GetOptions{}); err != nil {
+	if _, err = c.netAttachLister.NetworkAttachmentDefinitions(nadNamespace).Get(nadName); err != nil {
 		klog.Errorf("failed to get net-attach-def %s/%s: %v", nadNamespace, nadName, err)
 		return "", nil, nil, nil, err
 	}


### PR DESCRIPTION

# Pull Request

## What type of this PR

- Bug fixes

This allows caching of network attachment definitions and should improve performance when using multus.

## Which issue(s) this PR fixes

Fixes #5353 
