### PR TITLE
fix migrate down time

### DIFF
--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -95,8 +95,7 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 		return err
 	}
 
-	needAllocatePodNets := needAllocateSubnets(sourcePod, podNets)
-	for _, podNet := range needAllocatePodNets {
+	for _, podNet := range podNets {
 		portName := ovs.PodNameToPortName(vmiMigration.Spec.VMIName, vmiMigration.Namespace, podNet.ProviderName)
 		srcNodeName := vmi.Status.MigrationState.SourceNode
 		targetNodeName := vmi.Status.MigrationState.TargetNode


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR




Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
<img width="1280" alt="企业微信截图_17507360081435" src="https://github.com/user-attachments/assets/a6d75ab4-aac4-41c2-a491-d5fe17cb106a" />
<img width="805" alt="企业微信截图_17507337221346" src="https://github.com/user-attachments/assets/3086c52e-24fd-44e8-909f-0b988a3c3499" />

During hot migration, there is a possibility that the target pod's annotation kubevirt.io/migrationJobName is not updated in time, resulting in the failure of the lsp option to be successfully delivered.

This annotation is not considered at present, and the migration status is based on the status of the vmiMigration cr.

- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #5343
