### PR TITLE
fix(services): SLRs could not target VM endpoints

### DIFF
--- a/pkg/controller/endpoint_slice_test.go
+++ b/pkg/controller/endpoint_slice_test.go
@@ -109,3 +109,65 @@ func TestEndpointReady(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEndpointTargetLSP(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		namespace string
+		provider  string
+		expected  string
+	}{
+		{
+			name:      "Endpoint empty",
+			target:    "",
+			namespace: "",
+			provider:  "",
+			expected:  "..",
+		},
+		{
+			name:      "Endpoint empty with default provider",
+			target:    "",
+			namespace: "",
+			provider:  "ovn",
+			expected:  ".",
+		},
+		{
+			name:      "Pod target with default provider",
+			target:    "some-pod-1d8fn",
+			namespace: "default",
+			provider:  "ovn",
+			expected:  "some-pod-1d8fn.default",
+		},
+		{
+			name:      "Pod target with custom provider",
+			target:    "some-pod-6xjd8",
+			namespace: "default",
+			provider:  "custom.provider",
+			expected:  "some-pod-6xjd8.default.custom.provider",
+		},
+		{
+			name:      "VM target with default provider",
+			target:    "virt-launcher-some-vm-67jd3",
+			namespace: "default",
+			provider:  "ovn",
+			expected:  "some-vm.default",
+		},
+		{
+			name:      "VM target with custom provider",
+			target:    "virt-launcher-some-vm-67jd3",
+			namespace: "default",
+			provider:  "custom.provider",
+			expected:  "some-vm.default.custom.provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getEndpointTargetLSP(tt.target, tt.namespace, tt.provider)
+			if result != tt.expected {
+				t.Errorf("getEndpointTargetLSP() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -240,8 +240,9 @@ const (
 	ChassisCniDaemonRetryInterval  = 1
 	ChassisControllerRetryInterval = 3
 
-	VM         = "VirtualMachine"
-	VMInstance = "VirtualMachineInstance"
+	VM               = "VirtualMachine"
+	VMInstance       = "VirtualMachineInstance"
+	VMLauncherPrefix = "virt-launcher-"
 
 	StatefulSet = "StatefulSet"
 


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

SLRs/EndpointSlices were flawed when generating the ipPortMapping for LoadBalancers. The mapping is used by healthchecks to verify that each backend IP is responsive by probing the corresponding LSP.

The name of LSPs was computed by the code without the "ovs.PodNameToPortName", but even if it was, it wouldn't have been enough.

When an SLR/Service/bunch of EndpointSlices are targetting "normal" pods, the name of the LSP was correctly generated (podName.namespace). The problem is that this naming scheme was followed for virt-launcher pods, which represent VMs.

But Kube-OVN doesn't use the same naming scheme for "normal" pods and for VMs. So using the podName.namespace template for virt-launchers would generate a faulty LSP name. VMs use a more simple and more stable scheme which is vmName.namespace.

The fix identifies virt-launcher pods and computes the correct LSP name for them, in turn generating the right mapping.

Service monitors should be correctly generated from there.

## Which issue(s) this PR fixes

Fixes https://github.com/kubeovn/kube-ovn/issues/5337
