### PR TITLE
feat(endpoints): auto-detect provider to adjust ip mapping

### DIFF
--- a/pkg/controller/endpoint_slice_test.go
+++ b/pkg/controller/endpoint_slice_test.go
@@ -1,10 +1,14 @@
 package controller
 
 import (
+	"fmt"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func TestFindServiceKey(t *testing.T) {
@@ -110,63 +114,216 @@ func TestEndpointReady(t *testing.T) {
 	}
 }
 
-func TestGetEndpointTargetLSP(t *testing.T) {
+func TestGetEndpointTargetLSPName(t *testing.T) {
 	tests := []struct {
-		name      string
-		target    string
-		namespace string
-		provider  string
-		expected  string
+		name     string
+		pod      *corev1.Pod
+		provider string
+		expected string
 	}{
 		{
-			name:      "Endpoint empty",
-			target:    "",
-			namespace: "",
-			provider:  "",
-			expected:  "..",
+			name: "No provider, faulty pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "",
+					Namespace: "",
+				},
+			},
+			provider: "",
+			expected: ".",
 		},
 		{
-			name:      "Endpoint empty with default provider",
-			target:    "",
-			namespace: "",
-			provider:  "ovn",
-			expected:  ".",
+			name: "Endpoint empty with default provider and faulty pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "",
+					Namespace: "",
+				},
+			},
+			provider: util.OvnProvider,
+			expected: ".",
 		},
 		{
-			name:      "Pod target with default provider",
-			target:    "some-pod-1d8fn",
-			namespace: "default",
-			provider:  "ovn",
-			expected:  "some-pod-1d8fn.default",
+			name: "Pod target with no provider",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-pod-1d8fn",
+					Namespace: "default",
+				},
+			},
+			provider: "",
+			expected: "some-pod-1d8fn.default",
 		},
 		{
-			name:      "Pod target with custom provider",
-			target:    "some-pod-6xjd8",
-			namespace: "default",
-			provider:  "custom.provider",
-			expected:  "some-pod-6xjd8.default.custom.provider",
+			name: "Pod target with default provider",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-pod-1d8fn",
+					Namespace: "default",
+				},
+			},
+			provider: util.OvnProvider,
+			expected: "some-pod-1d8fn.default",
 		},
 		{
-			name:      "VM target with default provider",
-			target:    "virt-launcher-some-vm-67jd3",
-			namespace: "default",
-			provider:  "ovn",
-			expected:  "some-vm.default",
+			name: "Pod target with custom provider",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-pod-1d8fn",
+					Namespace: "default",
+				},
+			},
+			provider: "custom.provider",
+			expected: "some-pod-1d8fn.default.custom.provider",
 		},
 		{
-			name:      "VM target with custom provider",
-			target:    "virt-launcher-some-vm-67jd3",
-			namespace: "default",
-			provider:  "custom.provider",
-			expected:  "some-vm.default.custom.provider",
+			name: "VM target with no provider",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "virt-launcher-some-vm-67jd3",
+					Namespace: "default",
+					Annotations: map[string]string{
+						fmt.Sprintf(util.VMAnnotationTemplate, util.OvnProvider): "some-vm",
+					},
+				},
+			},
+			provider: "",
+			expected: "some-vm.default",
+		},
+		{
+			name: "VM target with default provider",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "virt-launcher-some-vm-67jd3",
+					Namespace: "default",
+					Annotations: map[string]string{
+						fmt.Sprintf(util.VMAnnotationTemplate, util.OvnProvider): "some-vm",
+					},
+				},
+			},
+			provider: util.OvnProvider,
+			expected: "some-vm.default",
+		},
+		{
+			name: "VM target with custom provider",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "virt-launcher-some-vm-67jd3",
+					Namespace: "default",
+					Annotations: map[string]string{
+						fmt.Sprintf(util.VMAnnotationTemplate, "custom.provider"): "some-vm",
+					},
+				},
+			},
+			provider: "custom.provider",
+			expected: "some-vm.default.custom.provider",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getEndpointTargetLSP(tt.target, tt.namespace, tt.provider)
+			result := getEndpointTargetLSPName(tt.pod, tt.provider)
 			if result != tt.expected {
-				t.Errorf("getEndpointTargetLSP() = %q, want %q", result, tt.expected)
+				t.Errorf("getEndpointTargetLSPName() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetMatchingProviderForAddress(t *testing.T) {
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		providers []string
+		address   string
+		expected  string
+	}{
+		{
+			name: "IP is on default provider and single stack",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "1.1.1.1",
+					},
+				},
+			},
+			providers: []string{util.OvnProvider},
+			address:   "1.1.1.1",
+			expected:  util.OvnProvider,
+		},
+		{
+			name: "IP is on default provider and dual stack",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "1.1.1.1,fd00::a",
+					},
+				},
+			},
+			providers: []string{util.OvnProvider},
+			address:   "fd00::a",
+			expected:  util.OvnProvider,
+		},
+		{
+			name: "IP is on custom provider and dual stack",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fmt.Sprintf(util.IPAddressAnnotationTemplate, "custom.provider"): "1.1.1.1,fd00::a",
+					},
+				},
+			},
+			providers: []string{"custom.provider"},
+			address:   "fd00::a",
+			expected:  "custom.provider",
+		},
+		{
+			name: "IP is on custom provider with multiple other providers present on the pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider):  "10.0.0.1,fd10:0:0::1",
+						fmt.Sprintf(util.IPAddressAnnotationTemplate, "first.provider"):  "1.1.1.1,fd00::a",
+						fmt.Sprintf(util.IPAddressAnnotationTemplate, "second.provider"): "2.2.2.2,fd00::b",
+						fmt.Sprintf(util.IPAddressAnnotationTemplate, "third.provider"):  "3.3.3.3,fd00::c",
+					},
+				},
+			},
+			providers: []string{util.OvnProvider, "first.provider", "second.provider", "third.provider"},
+			address:   "fd00::b",
+			expected:  "second.provider",
+		},
+		{
+			name: "No provider is matching",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "10.0.0.1,fd10:0:0::1",
+					},
+				},
+			},
+			providers: []string{util.OvnProvider},
+			address:   "fd00::b",
+			expected:  "",
+		},
+		{
+			name: "No annotation is present",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			providers: []string{},
+			address:   "fd00::b",
+			expected:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getMatchingProviderForAddress(tt.pod, tt.providers, tt.address)
+			if result != tt.expected {
+				t.Errorf("getMatchingProviderForAddress() = %q, want %q", result, tt.expected)
 			}
 		})
 	}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -240,9 +240,8 @@ const (
 	ChassisCniDaemonRetryInterval  = 1
 	ChassisControllerRetryInterval = 3
 
-	VM               = "VirtualMachine"
-	VMInstance       = "VirtualMachineInstance"
-	VMLauncherPrefix = "virt-launcher-"
+	VM         = "VirtualMachine"
+	VMInstance = "VirtualMachineInstance"
 
 	StatefulSet = "StatefulSet"
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

If a pod/VM uses custom providers (for example, if the VM/Pod is multi-homed with more than one interface), a service will always assume that the IP targeted by the endpointslice is on the default provider ("ovn").

This code introduces an auto-detection mechanism where the IP is matched against every provider available on the pod/VM.
If one provider has the IP, we use it to generate the name of the LSP.

The logic to check which provider has the IP is a bit overkill, as it assumes that anyone of them could have it. In theory, EndpointSlices are managed by a kubernetes controller that assumes only one pair of IP per pod (IPv4/IPv6). It means only the first provider can host the IP targetted by the endpointslice, the others will never appear in the slice.

But this logic can be reused in the future for static endpoints available in SLRs (when not using matchLabels) to generate healthchecks.
