### PR TITLE
feat(endpoint_slice): refactor and support arbitrary providers

### DIFF
--- a/pkg/controller/endpoint_slice_test.go
+++ b/pkg/controller/endpoint_slice_test.go
@@ -114,7 +114,7 @@ func TestEndpointReady(t *testing.T) {
 	}
 }
 
-func TestGetEndpointTargetLSPName(t *testing.T) {
+func TestGetEndpointTargetLSPNameFromProvider(t *testing.T) {
 	tests := []struct {
 		name     string
 		pod      *corev1.Pod
@@ -222,7 +222,7 @@ func TestGetEndpointTargetLSPName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getEndpointTargetLSPName(tt.pod, tt.provider)
+			result := getEndpointTargetLSPNameFromProvider(tt.pod, tt.provider)
 			if result != tt.expected {
 				t.Errorf("getEndpointTargetLSPName() = %q, want %q", result, tt.expected)
 			}
@@ -324,6 +324,57 @@ func TestGetMatchingProviderForAddress(t *testing.T) {
 			result := getMatchingProviderForAddress(tt.pod, tt.providers, tt.address)
 			if result != tt.expected {
 				t.Errorf("getMatchingProviderForAddress() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestServiceHasSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  *corev1.Service
+		expected bool
+	}{
+		{
+			name: "Service has no selector",
+			service: &corev1.Service{Spec: corev1.ServiceSpec{
+				Selector: nil,
+			}},
+			expected: false,
+		},
+		{
+			name: "Service has empty selectors",
+			service: &corev1.Service{Spec: corev1.ServiceSpec{
+				Selector: map[string]string{},
+			}},
+			expected: false,
+		},
+		{
+			name: "Service has one selector",
+			service: &corev1.Service{Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"a": "b",
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: "Service has multiple selectors",
+			service: &corev1.Service{Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"a": "b",
+					"c": "d",
+				},
+			}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := serviceHasSelector(tt.service)
+			if result != tt.expected {
+				t.Errorf("serviceHasSelector() = %t, want %t", result, tt.expected)
 			}
 		})
 	}

--- a/pkg/controller/switch_lb_rule.go
+++ b/pkg/controller/switch_lb_rule.go
@@ -358,7 +358,30 @@ func generateHeadlessService(slr *kubeovnv1.SwitchLBRule, oldSvc *corev1.Service
 			},
 		}
 	}
+
+	// If the user supplies a VPC/subnet for the SLR, propagate it to the service
+	setUserDefinedNetwork(newSvc, slr)
+
 	return newSvc
+}
+
+// setUserDefinedNetwork propagates user-defined VPC/subnet from the SLR to the Service
+func setUserDefinedNetwork(service *corev1.Service, slr *kubeovnv1.SwitchLBRule) {
+	if service == nil || slr == nil || slr.Annotations == nil {
+		return
+	}
+
+	if service.Annotations == nil {
+		service.Annotations = make(map[string]string)
+	}
+
+	if vpc := slr.Annotations[util.LogicalRouterAnnotation]; vpc != "" {
+		service.Annotations[util.LogicalRouterAnnotation] = vpc
+	}
+
+	if subnet := slr.Annotations[util.LogicalSwitchAnnotation]; subnet != "" {
+		service.Annotations[util.LogicalSwitchAnnotation] = subnet
+	}
 }
 
 func generateEndpoints(slr *kubeovnv1.SwitchLBRule, oldEps *corev1.Endpoints) *corev1.Endpoints {

--- a/pkg/controller/switch_lb_rule_test.go
+++ b/pkg/controller/switch_lb_rule_test.go
@@ -4,6 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -68,6 +73,88 @@ func Test_getIPFamilies(t *testing.T) {
 
 			if policy != tt.expectedFamilyPolicy {
 				t.Errorf("Expected familiyPolicy %s, but got %s", tt.expectedFamilyPolicy, policy)
+			}
+		})
+	}
+}
+
+func Test_setUserDefinedNetwork(t *testing.T) {
+	tests := []struct {
+		name    string
+		service *corev1.Service
+		slr     *kubeovnv1.SwitchLBRule
+		result  *corev1.Service
+	}{
+		{
+			name:    "Propagate VPC",
+			service: &corev1.Service{},
+			slr: &kubeovnv1.SwitchLBRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						util.LogicalRouterAnnotation: "test",
+					},
+				},
+			},
+			result: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						util.LogicalRouterAnnotation: "test",
+					},
+				},
+			},
+		},
+		{
+			name:    "Propagate Subnet",
+			service: &corev1.Service{},
+			slr: &kubeovnv1.SwitchLBRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "test",
+					},
+				},
+			},
+			result: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "test",
+					},
+				},
+			},
+		},
+		{
+			name:    "Propagate VPC/Subnet",
+			service: &corev1.Service{},
+			slr: &kubeovnv1.SwitchLBRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						util.LogicalRouterAnnotation: "test1",
+						util.LogicalSwitchAnnotation: "test2",
+					},
+				},
+			},
+			result: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						util.LogicalRouterAnnotation: "test1",
+						util.LogicalSwitchAnnotation: "test2",
+					},
+				},
+			},
+		},
+		{
+			name:    "Propagate nothing",
+			service: &corev1.Service{},
+			slr:     &kubeovnv1.SwitchLBRule{},
+			result:  &corev1.Service{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setUserDefinedNetwork(tt.service, tt.slr)
+
+			if !reflect.DeepEqual(*tt.service, *tt.result) {
+				t.Errorf("Expected service %v, but got %v", *tt.service, *tt.result)
 			}
 		})
 	}

--- a/pkg/controller/switch_lb_rule_test.go
+++ b/pkg/controller/switch_lb_rule_test.go
@@ -4,12 +4,11 @@ import (
 	"reflect"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_getIPFamilies(t *testing.T) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -9,6 +9,7 @@ import (
 
 	nad "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	"github.com/onsi/ginkgo/v2"
+	extClientSet "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -56,6 +57,7 @@ type Framework struct {
 	KubeVirtClientSet kubecli.KubevirtClient
 	MetallbClientSet  *MetallbClientSet
 	AttachNetClient   nad.Interface
+	ExtClientSet      *extClientSet.Clientset
 	// master/release-1.10/...
 	ClusterVersion string
 	// 999.999 for master
@@ -210,6 +212,17 @@ func (f *Framework) BeforeEach() {
 		config.QPS = f.Options.ClientQPS
 		config.Burst = f.Options.ClientBurst
 		f.KubeVirtClientSet, err = kubecli.GetKubevirtClientFromRESTConfig(config)
+		ExpectNoError(err)
+	}
+
+	if f.ExtClientSet == nil {
+		ginkgo.By("Creating a Kubernetes client")
+		config, err := framework.LoadConfig()
+		ExpectNoError(err)
+
+		config.QPS = f.Options.ClientQPS
+		config.Burst = f.Options.ClientBurst
+		f.ExtClientSet, err = extClientSet.NewForConfig(config)
 		ExpectNoError(err)
 	}
 

--- a/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
+++ b/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
@@ -14,6 +14,7 @@ import (
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/request"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 )
@@ -52,12 +53,14 @@ var _ = framework.Describe("[group:slr]", func() {
 		podClient          *framework.PodClient
 		subnetClient       *framework.SubnetClient
 		vpcClient          *framework.VpcClient
+		nadClient          *framework.NetworkAttachmentDefinitionClient
 
 		namespaceName, suffix                     string
 		vpcName, subnetName, clientPodName, label string
 		stsName, stsSvcName                       string
 		selSlrName, selSvcName                    string
 		epSlrName, epSvcName                      string
+		nadName                                   string
 		overlaySubnetCidr, vip                    string
 		// TODO:// slr support dual-stack
 		frontPort, selSlrFrontPort, epSlrFrontPort, backendPort int32
@@ -71,9 +74,8 @@ var _ = framework.Describe("[group:slr]", func() {
 		podClient = f.PodClient()
 		subnetClient = f.SubnetClient()
 		vpcClient = f.VpcClient()
-
+		nadClient = f.NetworkAttachmentDefinitionClient()
 		suffix = framework.RandomSuffix()
-
 		namespaceName = f.Namespace.Name
 		selSlrName = "sel-" + generateSwitchLBRuleName(suffix)
 		selSvcName = generateServiceName(selSlrName)
@@ -84,6 +86,7 @@ var _ = framework.Describe("[group:slr]", func() {
 		label = "slr"
 		clientPodName = "client-" + suffix
 		subnetName = generateSubnetName(suffix)
+		nadName = subnetName
 		vpcName = generateVpcName(suffix)
 		frontPort = 8090
 		selSlrFrontPort = 8091
@@ -94,15 +97,6 @@ var _ = framework.Describe("[group:slr]", func() {
 		ginkgo.By("Creating custom vpc")
 		vpc := framework.MakeVpc(vpcName, "", false, false, []string{namespaceName})
 		_ = vpcClient.CreateSync(vpc)
-		ginkgo.By("Creating custom overlay subnet")
-		overlaySubnet := framework.MakeSubnet(subnetName, "", overlaySubnetCidr, "", vpcName, "", nil, nil, nil)
-		_ = subnetClient.CreateSync(overlaySubnet)
-		annotations := map[string]string{
-			util.LogicalSwitchAnnotation: subnetName,
-		}
-		ginkgo.By("Creating client pod " + clientPodName)
-		clientPod := framework.MakePod(namespaceName, clientPodName, nil, annotations, framework.AgnhostImage, nil, nil)
-		podClient.CreateSync(clientPod)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -120,10 +114,39 @@ var _ = framework.Describe("[group:slr]", func() {
 		subnetClient.DeleteSync(subnetName)
 		ginkgo.By("Deleting vpc " + vpcName)
 		vpcClient.DeleteSync(vpcName)
+		ginkgo.By("Deleting network attachment definition " + nadName)
+		nadClient.Delete(nadName)
 	})
 
-	framework.ConformanceIt("should access sts and slr svc ok", func() {
+	ginkgo.DescribeTable("Test SLR connectivity", ginkgo.Label("Conformance"), func(customProvider bool) {
 		f.SkipVersionPriorTo(1, 12, "This feature was introduced in v1.12")
+
+		ginkgo.By("Creating custom overlay subnet")
+
+		var provider string
+		annotations := make(map[string]string)
+
+		if customProvider {
+			f.SkipVersionPriorTo(1, 15, "This feature was introduced in v1.15")
+			provider = fmt.Sprintf("%s.%s.%s", subnetName, f.Namespace.Name, util.OvnProvider)
+			annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] = subnetName
+			annotations[util.DefaultNetworkAnnotation] = fmt.Sprintf("%s/%s", f.Namespace.Name, nadName)
+		} else {
+			annotations[util.LogicalSwitchAnnotation] = subnetName
+		}
+
+		overlaySubnet := framework.MakeSubnet(subnetName, "", overlaySubnetCidr, "", vpcName, provider, nil, nil, nil)
+		_ = subnetClient.CreateSync(overlaySubnet)
+
+		if customProvider {
+			nad := framework.MakeOVNNetworkAttachmentDefinition(subnetName, f.Namespace.Namespace, provider, []request.Route{})
+			nadClient.Create(nad)
+		}
+
+		ginkgo.By("Creating client pod " + clientPodName)
+		newClientPod := framework.MakePod(namespaceName, clientPodName, nil, annotations, framework.AgnhostImage, nil, nil)
+		podClient.CreateSync(newClientPod)
+
 		ginkgo.By("1. Creating sts svc with slr")
 		var (
 			clientPod             *corev1.Pod
@@ -136,9 +159,9 @@ var _ = framework.Describe("[group:slr]", func() {
 		ginkgo.By("Creating statefulset " + stsName + " with subnet " + subnetName)
 		sts := framework.MakeStatefulSet(stsName, stsSvcName, int32(replicas), labels, framework.AgnhostImage)
 		ginkgo.By("Creating sts " + stsName)
-		sts.Spec.Template.Annotations = map[string]string{
-			util.LogicalSwitchAnnotation: subnetName,
-		}
+
+		sts.Spec.Template.Annotations = annotations
+
 		portStr := strconv.Itoa(80)
 		webServerCmd := []string{"/agnhost", "netexec", "--http-port", portStr}
 		sts.Spec.Template.Spec.Containers[0].Command = webServerCmd
@@ -151,10 +174,10 @@ var _ = framework.Describe("[group:slr]", func() {
 			TargetPort: intstr.FromInt32(80),
 		}}
 		selector := map[string]string{"app": label}
-		annotations := map[string]string{
+		svcAnnotations := map[string]string{
 			util.LogicalSwitchAnnotation: subnetName,
 		}
-		stsSvc = framework.MakeService(stsSvcName, corev1.ServiceTypeClusterIP, annotations, selector, ports, corev1.ServiceAffinityNone)
+		stsSvc = framework.MakeService(stsSvcName, corev1.ServiceTypeClusterIP, svcAnnotations, selector, ports, corev1.ServiceAffinityNone)
 		stsSvc = serviceClient.CreateSync(stsSvc, func(s *corev1.Service) (bool, error) {
 			return len(s.Spec.ClusterIPs) != 0, nil
 		}, "cluster ips are not empty")
@@ -352,5 +375,8 @@ var _ = framework.Describe("[group:slr]", func() {
 		}
 		ginkgo.By("Checking endpoint switch lb service " + epSvc.Name)
 		curlSvc(f, clientPodName, vip, epSlrFrontPort)
-	})
+	},
+		ginkgo.Entry("SLR with default provider", false),
+		ginkgo.Entry("SLR with custom provider", true),
+	)
 })


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

This PR refactors the way endpoint slices are handled. It makes the logic of detecting the VPC/subnet targetted by a service more straightforward and supports custom providers instead of just the "ovn" one.

Support for specifying "endpoints" instead of selectors is also improved, with custom providers added to them. The refactor will make the implementation of healthchecks for them easier.

Note that this PR doesn't fix the obvious issue where a service targets pods that are in different VPC/subnets. It also only handles the first network of every Pod. For this, we'd need more checks and to use EndpointSlice mirrors.
