### PR TITLE
fix parsing resolv.conf when systemd-resolved is running on the host

### DIFF
--- a/pkg/daemon/exporter_metric.go
+++ b/pkg/daemon/exporter_metric.go
@@ -58,7 +58,7 @@ func (c *Controller) setCheckSumErrMetric() {
 }
 
 func (c *Controller) setDNSSearchMetric() {
-	file, err := resolvconf.Get()
+	file, err := resolvconf.GetSpecific("/etc/resolv.conf")
 	if err != nil {
 		klog.Errorf("failed to get /etc/resolv.conf content: %v", err)
 		return
@@ -67,7 +67,8 @@ func (c *Controller) setDNSSearchMetric() {
 
 	found := false
 	for _, domain := range domains {
-		if strings.Contains(domain, "local") {
+		if domain == "." {
+			// Ignore the root domain
 			continue
 		}
 


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
E0703 06:36:54.585261   12600 exporter_metric.go:63] failed to get /etc/resolv.conf content: open /run/systemd/resolve/resolv.conf: no such file or directory
```

> When /etc/resolv.conf contains 127.0.0.53 as the only nameserver, then it is assumed systemd-resolved manages DNS. Because inside the container 127.0.0.53 is not a valid DNS server, Path() returns /run/systemd/resolve/resolv.conf which is the resolv.conf that systemd-resolved generates and manages.
