### PR TITLE
kubectl-ko: replace endpoint with endpointslice

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -518,7 +518,7 @@ xxctl(){
 checkLeader(){
   component="$1"; shift
   set +o pipefail
-  count=$(kubectl get ep ovn-$component -n $KUBE_OVN_NS -o yaml | grep "ip:" | wc -l)
+  count=$(kubectl get endpointslice -l kubernetes.io/service-name=ovn-$component -n $KUBE_OVN_NS -o jsonpath='{.items[*].endpoints[*].addresses[0]}' | sort | uniq | wc -l)
   set -o pipefail
   if [ $count -eq 0 ]; then
     echo "no ovn-$component exists !!"


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```txt
Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
ovn-nb leader check ok
Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
ovn-sb leader check ok
Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
ovn-northd leader check ok
```
