### PR TITLE
add fip qosPolicy

### DIFF
--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -1689,6 +1689,9 @@ spec:
       - jsonPath: .spec.ipName
         name: IpName
         type: string
+      - jsonPath: .spec.qosPolicy
+        name: qosPolicy
+        type: string
       schema:
         openAPIV3Schema:
           type: object
@@ -1707,6 +1710,8 @@ spec:
                 v6Ip:
                   type: string
                 vpc:
+                  type: string
+                qosPolicy:
                   type: string
                 conditions:
                   type: array
@@ -1741,6 +1746,8 @@ spec:
                 v4Ip:
                   type: string
                 v6Ip:
+                  type: string
+                qosPolicy:
                   type: string
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -2765,6 +2765,72 @@ func (mr *MockNATMockRecorder) UpdateSnat(lrName, externalIP, logicalIP any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSnat", reflect.TypeOf((*MockNAT)(nil).UpdateSnat), lrName, externalIP, logicalIP)
 }
 
+// MockQos is a mock of Qos interface.
+type MockQos struct {
+	ctrl     *gomock.Controller
+	recorder *MockQosMockRecorder
+	isgomock struct{}
+}
+
+// MockQosMockRecorder is the mock recorder for MockQos.
+type MockQosMockRecorder struct {
+	mock *MockQos
+}
+
+// NewMockQos creates a new mock instance.
+func NewMockQos(ctrl *gomock.Controller) *MockQos {
+	mock := &MockQos{ctrl: ctrl}
+	mock.recorder = &MockQosMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockQos) EXPECT() *MockQosMockRecorder {
+	return m.recorder
+}
+
+// AddQos mocks base method.
+func (m *MockQos) AddQos(vpcName, externalSubnetName, v4Eip string, burstMax, rateMax int, direction string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddQos", vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddQos indicates an expected call of AddQos.
+func (mr *MockQosMockRecorder) AddQos(vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddQos", reflect.TypeOf((*MockQos)(nil).AddQos), vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
+}
+
+// DeleteQos mocks base method.
+func (m *MockQos) DeleteQos(vpcName, externalSubnetName, v4Eip, direction string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteQos", vpcName, externalSubnetName, v4Eip, direction)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteQos indicates an expected call of DeleteQos.
+func (mr *MockQosMockRecorder) DeleteQos(vpcName, externalSubnetName, v4Eip, direction any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteQos", reflect.TypeOf((*MockQos)(nil).DeleteQos), vpcName, externalSubnetName, v4Eip, direction)
+}
+
+// UpdateQos mocks base method.
+func (m *MockQos) UpdateQos(vpcName, externalSubnetName, v4Eip string, burstMax, rateMax int, direction string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateQos", vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateQos indicates an expected call of UpdateQos.
+func (mr *MockQosMockRecorder) UpdateQos(vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQos", reflect.TypeOf((*MockQos)(nil).UpdateQos), vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
+}
+
 // MockDHCPOptions is a mock of DHCPOptions interface.
 type MockDHCPOptions struct {
 	ctrl     *gomock.Controller
@@ -2934,6 +3000,20 @@ func (m *MockNbClient) AddNat(lrName, natType, externalIP, logicalIP, logicalMac
 func (mr *MockNbClientMockRecorder) AddNat(lrName, natType, externalIP, logicalIP, logicalMac, port, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNat", reflect.TypeOf((*MockNbClient)(nil).AddNat), lrName, natType, externalIP, logicalIP, logicalMac, port, options)
+}
+
+// AddQos mocks base method.
+func (m *MockNbClient) AddQos(vpcName, externalSubnetName, v4Eip string, burstMax, rateMax int, direction string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddQos", vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddQos indicates an expected call of AddQos.
+func (mr *MockNbClientMockRecorder) AddQos(vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddQos", reflect.TypeOf((*MockNbClient)(nil).AddQos), vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
 }
 
 // AddressSetUpdateAddress mocks base method.
@@ -3832,6 +3912,20 @@ func (m *MockNbClient) DeletePortGroup(pgName ...string) error {
 func (mr *MockNbClientMockRecorder) DeletePortGroup(pgName ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePortGroup", reflect.TypeOf((*MockNbClient)(nil).DeletePortGroup), pgName...)
+}
+
+// DeleteQos mocks base method.
+func (m *MockNbClient) DeleteQos(vpcName, externalSubnetName, v4Eip, direction string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteQos", vpcName, externalSubnetName, v4Eip, direction)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteQos indicates an expected call of DeleteQos.
+func (mr *MockNbClientMockRecorder) DeleteQos(vpcName, externalSubnetName, v4Eip, direction any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteQos", reflect.TypeOf((*MockNbClient)(nil).DeleteQos), vpcName, externalSubnetName, v4Eip, direction)
 }
 
 // DeleteSecurityGroup mocks base method.
@@ -5386,6 +5480,20 @@ func (mr *MockNbClientMockRecorder) UpdateNbGlobal(nbGlobal any, fields ...any) 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{nbGlobal}, fields...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNbGlobal", reflect.TypeOf((*MockNbClient)(nil).UpdateNbGlobal), varargs...)
+}
+
+// UpdateQos mocks base method.
+func (m *MockNbClient) UpdateQos(vpcName, externalSubnetName, v4Eip string, burstMax, rateMax int, direction string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateQos", vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateQos indicates an expected call of UpdateQos.
+func (mr *MockNbClientMockRecorder) UpdateQos(vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQos", reflect.TypeOf((*MockNbClient)(nil).UpdateQos), vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
 }
 
 // UpdateSgACL mocks base method.

--- a/pkg/apis/kubeovn/v1/ovn-fip.go
+++ b/pkg/apis/kubeovn/v1/ovn-fip.go
@@ -28,24 +28,26 @@ type OvnFip struct {
 	Status OvnFipStatus `json:"status"`
 }
 type OvnFipSpec struct {
-	OvnEip string `json:"ovnEip"`
-	IPType string `json:"ipType"` // vip, ip
-	IPName string `json:"ipName"` // vip, ip crd name
-	Vpc    string `json:"vpc"`
-	V4Ip   string `json:"v4Ip"`
-	V6Ip   string `json:"v6Ip"`
-	Type   string `json:"type"` // distributed, centralized
+	OvnEip    string `json:"ovnEip"`
+	IPType    string `json:"ipType"` // vip, ip
+	IPName    string `json:"ipName"` // vip, ip crd name
+	Vpc       string `json:"vpc"`
+	V4Ip      string `json:"v4Ip"`
+	V6Ip      string `json:"v6Ip"`
+	Type      string `json:"type"`                // distributed, centralized
+	QoSPolicy string `json:"qosPolicy,omitempty"` // +optional
 }
 
 type OvnFipStatus struct {
 	// +optional
 	// +patchStrategy=merge
-	Vpc   string `json:"vpc" patchStrategy:"merge"`
-	V4Eip string `json:"v4Eip" patchStrategy:"merge"`
-	V6Eip string `json:"v6Eip" patchStrategy:"merge"`
-	V4Ip  string `json:"v4Ip" patchStrategy:"merge"`
-	V6Ip  string `json:"v6Ip" patchStrategy:"merge"`
-	Ready bool   `json:"ready" patchStrategy:"merge"`
+	Vpc       string `json:"vpc" patchStrategy:"merge"`
+	V4Eip     string `json:"v4Eip" patchStrategy:"merge"`
+	V6Eip     string `json:"v6Eip" patchStrategy:"merge"`
+	V4Ip      string `json:"v4Ip" patchStrategy:"merge"`
+	V6Ip      string `json:"v6Ip" patchStrategy:"merge"`
+	Ready     bool   `json:"ready" patchStrategy:"merge"`
+	QoSPolicy string `json:"qosPolicy" patchStrategy:"merge"` // +optional
 
 	// Conditions represents the latest state of the object
 	// +optional

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -19,6 +19,7 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
+	"net"
 )
 
 func (c *Controller) enqueueAddOvnFip(obj any) {
@@ -51,6 +52,11 @@ func (c *Controller) enqueueUpdateOvnFip(oldObj, newObj any) {
 		c.updateOvnFipQueue.Add(key)
 		return
 	}
+	if oldFip.Spec.QoSPolicy != newFip.Spec.QoSPolicy {
+		klog.Infof("enqueue update qos for fip %s", key)
+		c.updateOvnFipQueue.Add(key)
+		return
+	}
 }
 
 func (c *Controller) enqueueDelOvnFip(obj any) {
@@ -75,6 +81,34 @@ func (c *Controller) isOvnFipDuplicated(fipName, eipV4IP string) error {
 		}
 	}
 	return nil
+}
+
+func (c *Controller) matchSubnetNameWithIP(subnets []*kubeovnv1.Subnet, ip string) (matchSubnet *kubeovnv1.Subnet, err error) {
+	// match subnet name with ip，but not use
+	for _, subnet := range subnets {
+		// cidr := subnet.Spec.CIDRBlock
+		parsedIP := net.ParseIP(ip)
+		klog.Info("parsed ip is ", parsedIP)
+
+		if parsedIP == nil {
+			klog.Errorf("parse ip %s failed", ip)
+			continue
+		}
+
+		_, parsedSubnet, err := net.ParseCIDR(subnet.Spec.CIDRBlock)
+		if err != nil {
+			klog.Errorf("parse subnet %s failed", subnet)
+			continue
+		}
+		//klog.Info("parsed subnet is ", parsedSubnet)
+		if parsedSubnet.Contains(parsedIP) {
+			//klog.Infof("subnet %s matches ip %s", subnet, ip)
+			return subnet, nil
+		}
+
+	}
+	return nil, nil
+
 }
 
 func (c *Controller) handleAddOvnFip(key string) error {
@@ -109,6 +143,9 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		klog.Error(err)
 		return err
 	}
+	var externalSubnetName string
+	externalSubnetName = cachedEip.Spec.ExternalSubnet
+
 	var v4Eip, v6Eip, v4IP, v6IP string
 	v4Eip = cachedEip.Status.V4Ip
 	v6Eip = cachedEip.Status.V6Ip
@@ -118,11 +155,14 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		return err
 	}
 
-	var mac, subnetName, vpcName, ipName string
+	var mac, subnetName, vpcName, ipName, qosPolicy string
 	vpcName = cachedFip.Spec.Vpc
 	v4IP = cachedFip.Spec.V4Ip
 	v6IP = cachedFip.Spec.V6Ip
 	ipName = cachedFip.Spec.IPName
+	qosPolicy = cachedFip.Spec.QoSPolicy
+	klog.Infof("qos policy %s for fip %s", qosPolicy, cachedFip.Name)
+
 	if ipName != "" {
 		if cachedFip.Spec.IPType == util.Vip {
 			internalVip, err := c.virtualIpsLister.Get(ipName)
@@ -217,6 +257,35 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		}
 	}
 
+	// add qos
+	if cachedFip.Spec.QoSPolicy != "" {
+		cachedQosPolicy := &kubeovnv1.QoSPolicy{}
+
+		cachedQosPolicy, err = c.qosPoliciesLister.Get(qosPolicy)
+		if err != nil {
+			klog.Errorf("failed to get qos policy %s, %v", qosPolicy, err)
+			_ = c.patchOvnFipStatus(key, vpcName, v4Eip, v4IP, "", false)
+			return err
+		}
+		klog.Infof("found qos policy %s", cachedQosPolicy)
+
+		for _, rule := range cachedQosPolicy.Spec.BandwidthLimitRules {
+			burstMax, rateMax, direction, err := c.getQosRule(rule)
+			if err != nil {
+				klog.Errorf("failed to get qos rule %s, %v", rule, err)
+				return err
+			}
+			if rateMax > 0 {
+				if err = c.OVNNbClient.AddQos(vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction); err != nil {
+					klog.Errorf("failed to create qos rule, %v", err)
+					_ = c.patchOvnFipStatus(key, vpcName, v4Eip, v4IP, qosPolicy, false)
+					return err
+				}
+			}
+		}
+
+	}
+
 	if err = c.handleAddOvnFipFinalizer(cachedFip); err != nil {
 		klog.Errorf("failed to add finalizer for ovn fip, %v", err)
 		return err
@@ -231,7 +300,7 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		klog.Errorf("failed to update label for fip %s, %v", key, err)
 		return err
 	}
-	if err = c.patchOvnFipStatus(key, vpcName, v4Eip, v4IP, true); err != nil {
+	if err = c.patchOvnFipStatus(key, vpcName, v4Eip, v4IP, qosPolicy, true); err != nil {
 		klog.Errorf("failed to patch status for fip %s, %v", key, err)
 		return err
 	}
@@ -240,6 +309,37 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		return err
 	}
 	return nil
+}
+
+func (c *Controller) getQosRule(rule kubeovnv1.QoSPolicyBandwidthLimitRule) (burstMax int, rateMax int, direction string, err error) {
+	if rule.BurstMax == "" && rule.RateMax == "" {
+		return 0, 0, "", nil
+	}
+	if rule.BurstMax == "" {
+		rule.BurstMax = rule.RateMax
+	}
+	burstMax, err = strconv.Atoi(rule.BurstMax)
+	if err != nil {
+		return 0, 0, "", fmt.Errorf("failed to parse BurstMax '%s': %w", rule.BurstMax, err)
+	}
+	rateMax, err = strconv.Atoi(rule.RateMax)
+	if err != nil {
+		return 0, 0, "", fmt.Errorf("failed to parse RateMax '%s': %w", rule.RateMax, err)
+	}
+
+	if burstMax != 0 {
+		burstMax = burstMax * 1024 // convert to kbps
+	}
+	if rateMax != 0 {
+		rateMax = rateMax * 1024 // convert to kbps
+	}
+	switch rule.Direction {
+	case kubeovnv1.QoSDirectionIngress:
+		direction = "from-lport"
+	case kubeovnv1.QoSDirectionEgress:
+		direction = "to-lport"
+	}
+	return burstMax, rateMax, direction, nil
 }
 
 func (c *Controller) handleUpdateOvnFip(key string) error {
@@ -275,6 +375,9 @@ func (c *Controller) handleUpdateOvnFip(key string) error {
 		klog.Error(err)
 		return err
 	}
+	var externalSubnetName string
+	externalSubnetName = cachedEip.Spec.ExternalSubnet
+
 	var v4Eip, v6Eip, v4IP, v6IP string
 	v4Eip = cachedEip.Status.V4Ip
 	v6Eip = cachedEip.Status.V6Ip
@@ -284,11 +387,12 @@ func (c *Controller) handleUpdateOvnFip(key string) error {
 		return err
 	}
 
-	var subnetName, vpcName, ipName string
+	var subnetName, vpcName, ipName, qosPolicy string
 	vpcName = cachedFip.Spec.Vpc
 	v4IP = cachedFip.Spec.V4Ip
 	v6IP = cachedFip.Spec.V6Ip
 	ipName = cachedFip.Spec.IPName
+	qosPolicy = cachedFip.Spec.QoSPolicy
 	if ipName != "" {
 		if cachedFip.Spec.IPType == util.Vip {
 			internalVip, err := c.virtualIpsLister.Get(ipName)
@@ -329,6 +433,48 @@ func (c *Controller) handleUpdateOvnFip(key string) error {
 		klog.Error(err)
 		return err
 	}
+	if cachedFip.Status.QoSPolicy != cachedFip.Spec.QoSPolicy {
+		if cachedFip.Spec.QoSPolicy == "" {
+			// delete qos rule
+			if err = c.OVNNbClient.DeleteQos(vpcName, externalSubnetName, v4Eip, "from-lport"); err != nil {
+				klog.Errorf("failed to delete qos rule for fip %s, %v", key, err)
+				return err
+			}
+			if err = c.OVNNbClient.DeleteQos(vpcName, externalSubnetName, v4Eip, "to-lport"); err != nil {
+				klog.Errorf("failed to delete qos rule for fip %s, %v", key, err)
+				return err
+			}
+			klog.Infof("deleted qos policy for fip %s", cachedFip.Name)
+			return nil
+		}
+		cachedQosPolicy := &kubeovnv1.QoSPolicy{}
+
+		cachedQosPolicy, err = c.qosPoliciesLister.Get(qosPolicy)
+		if err != nil {
+			klog.Errorf("failed to get qos policy %s, %v", qosPolicy, err)
+			_ = c.patchOvnFipStatus(key, vpcName, v4Eip, v4IP, "", false)
+			return err
+		}
+		klog.Infof("found qos policy %s", cachedQosPolicy)
+
+		for _, rule := range cachedQosPolicy.Spec.BandwidthLimitRules {
+			burstMax, rateMax, direction, err := c.getQosRule(rule)
+			if err != nil {
+				klog.Errorf("failed to get qos rule %s, %v", rule, err)
+				return err
+			}
+			if rateMax > 0 {
+				if err = c.OVNNbClient.UpdateQos(vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction); err != nil {
+					klog.Errorf("failed to create qos rule, %v", err)
+					_ = c.patchOvnFipStatus(key, vpcName, v4Eip, v4IP, qosPolicy, false)
+					return err
+				}
+			}
+		}
+	}
+
+	_ = c.patchOvnFipStatus(key, vpcName, v4Eip, v4IP, qosPolicy, true)
+
 	if vpcName != cachedFip.Status.Vpc {
 		err := fmt.Errorf("not support change vpc for ovn fip %s", cachedEip.Name)
 		klog.Error(err)
@@ -383,10 +529,51 @@ func (c *Controller) handleDelOvnFip(key string) error {
 			return err
 		}
 	}
+	eipName := cachedFip.Spec.OvnEip
+	if eipName == "" {
+		err := errors.New("failed to create fip rule, should set eip")
+		klog.Error(err)
+		return err
+	}
+	cachedEip, err := c.GetOvnEip(eipName)
+	if err != nil {
+		klog.Errorf("failed to get eip, %v", err)
+		return err
+	}
+
+	var v4Eip string
+	v4Eip = cachedEip.Status.V4Ip
+	var externalSubnetName string
+	externalSubnetName = cachedEip.Spec.ExternalSubnet
+	//v6Eip = cachedEip.Status.V6Ip
+
+	var vpcName, qosPolicy string
+	vpcName = cachedFip.Spec.Vpc
+	qosPolicy = cachedFip.Spec.QoSPolicy
+
+	if cachedFip.Spec.QoSPolicy != "" {
+		cachedQosPolicy := &kubeovnv1.QoSPolicy{}
+		cachedQosPolicy, err = c.qosPoliciesLister.Get(qosPolicy)
+		if err != nil {
+			klog.Errorf("failed to get qos policy %s, %v", qosPolicy, err)
+			return err
+		}
+		klog.Infof("found qos policy %s", cachedQosPolicy)
+		for _, rule := range cachedQosPolicy.Spec.BandwidthLimitRules {
+			_, _, direction, err := c.getQosRule(rule)
+			if err = c.OVNNbClient.DeleteQos(vpcName, externalSubnetName, v4Eip, direction); err != nil {
+				klog.Errorf("failed to create qos rule, %v", err)
+				return err
+			}
+		}
+
+	}
+
 	if err = c.handleDelOvnFipFinalizer(cachedFip); err != nil {
 		klog.Errorf("failed to remove finalizer for ovn fip %s, %v", cachedFip.Name, err)
 		return err
 	}
+
 	//  reset eip
 	if cachedFip.Spec.OvnEip != "" {
 		c.resetOvnEipQueue.Add(cachedFip.Spec.OvnEip)
@@ -431,7 +618,7 @@ func (c *Controller) patchOvnFipAnnotations(key, eipName string) error {
 	return nil
 }
 
-func (c *Controller) patchOvnFipStatus(key, vpcName, v4Eip, podIP string, ready bool) error {
+func (c *Controller) patchOvnFipStatus(key, vpcName, v4Eip, podIP string, qosPolicy string, ready bool) error {
 	oriFip, err := c.ovnFipsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -479,6 +666,11 @@ func (c *Controller) patchOvnFipStatus(key, vpcName, v4Eip, podIP string, ready 
 	}
 	if podIP != "" && fip.Status.V4Ip != podIP {
 		fip.Status.V4Ip = podIP
+		changed = true
+	}
+
+	if qosPolicy != "" && fip.Status.QoSPolicy != qosPolicy {
+		fip.Status.QoSPolicy = qosPolicy
 		changed = true
 	}
 	if changed {

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -224,6 +224,12 @@ type NAT interface {
 	ListNats(lrName, natType, logicalIP string, externalIDs map[string]string) ([]*ovnnb.NAT, error)
 }
 
+type Qos interface {
+	AddQos(vpcName string, externalSubnetName string, v4Eip string, burstMax int, rateMax int, direction string) error
+	UpdateQos(vpcName string, externalSubnetName string, v4Eip string, burstMax int, rateMax int, direction string) error
+	DeleteQos(vpcName string, externalSubnetName string, v4Eip string, direction string) error
+}
+
 type DHCPOptions interface {
 	UpdateDHCPOptions(subnet *kubeovnv1.Subnet, mtu int) (*DHCPOptionsUUIDs, error)
 	DeleteDHCPOptions(lsName, protocol string) error
@@ -255,6 +261,7 @@ type NbClient interface {
 	DeleteLogicalGatewaySwitch(lsName, lrName string) error
 	DeleteSecurityGroup(sgName string) error
 	Common
+	Qos
 }
 
 type SbClient interface {

--- a/pkg/ovs/ovn-nb-fip-qos.go
+++ b/pkg/ovs/ovn-nb-fip-qos.go
@@ -1,0 +1,283 @@
+package ovs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"k8s.io/klog/v2"
+	"strings"
+)
+
+func (c *OVNNbClient) AddQos(vpcName string, externalSubnetName string, v4Eip string, burstMax int, rateMax int, direction string) error {
+	qos := c.newQos(vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction, func(qos *ovnnb.QoS) {
+		return
+	})
+
+	fmt.Println(qos)
+	return c.CreateQos(vpcName, externalSubnetName, qos)
+}
+
+func (c *OVNNbClient) newQos(vpcName string, externalSubnetName string, v4Eip string, burstMax int, rateMax int, direction string, options ...func(*ovnnb.QoS)) *ovnnb.QoS {
+	externalPort := fmt.Sprintf("%s-%s", externalSubnetName, vpcName)
+	routerCrPort := fmt.Sprintf("cr-%s-%s", vpcName, externalSubnetName)
+	qos := &ovnnb.QoS{
+		UUID:      ovsclient.NamedUUID(),
+		Action:    map[string]int{},
+		Bandwidth: map[string]int{"rate": rateMax, "burst": burstMax}, //
+		Direction: direction,
+		Priority:  2003,
+		//Match:       "ip4.src == " + v4Eip + " && " + "inport == \"" + externalPort + "\"",
+	}
+	if direction == "from-lport" {
+		qos.Match = fmt.Sprintf("ip4.src == %s && inport == \"%s\" && is_chassis_resident(\"%s\")", v4Eip, externalPort, routerCrPort)
+	}
+	if direction == "to-lport" {
+		qos.Match = fmt.Sprintf("ip4.dst == %s && outport == \"%s\" && is_chassis_resident(\"%s\")", v4Eip, externalPort, routerCrPort)
+	}
+
+	for _, option := range options {
+		option(qos)
+	}
+	return qos
+}
+
+func (c *OVNNbClient) CreateQos(vpcName string, lsName string, QosS ...*ovnnb.QoS) error {
+	externalPort := fmt.Sprintf("%s-%s", lsName, vpcName)
+	models := make([]model.Model, 0, len(QosS))
+	qosUUIDs := make([]string, 0, len(QosS))
+	for _, qos := range QosS {
+		if qos != nil {
+			models = append(models, model.Model(qos))
+			qosUUIDs = append(qosUUIDs, qos.UUID)
+		}
+	}
+
+	createQosSOp, err := c.Create(models...)
+	if err != nil {
+		klog.Error(err)
+		return fmt.Errorf("generate operations for creating QosS: %w", err)
+	}
+
+	qosAddOps, err := c.QoSOp(lsName, qosUUIDs, ovsdb.MutateOperationInsert)
+	if err != nil {
+		klog.Error(err)
+		return fmt.Errorf("generate operations for adding qos to logicalSwitch %s: %w", lsName, err)
+	}
+
+	ops := make([]ovsdb.Operation, 0, len(createQosSOp)+len(qosAddOps))
+	ops = append(ops, createQosSOp...)
+	ops = append(ops, qosAddOps...)
+
+	// klog.Infof("ops: %v", ops)
+
+	if err = c.Transact("qos-add", ops); err != nil {
+		klog.Error(err)
+		return fmt.Errorf("add qos to %s: %w", externalPort, err)
+	}
+
+	return nil
+}
+
+func (c *OVNNbClient) UpdateQos(vpcName string, externalSubnetName string, v4Eip string, burstMax int, rateMax int, direction string) error {
+	klog.Info("update qos for vpc: ", vpcName, "externalSubnetName:", externalSubnetName, "v4Eip: ", v4Eip, " burstMax: ", burstMax, " rateMax: ", rateMax, " direction: ", direction)
+	klog.Infof("before update qos, now delete exists")
+	externalPort := fmt.Sprintf("%s-%s", externalSubnetName, vpcName)
+	routerCrPort := fmt.Sprintf("cr-%s-%s", vpcName, externalSubnetName)
+	err := c.deleteLsQosIfExists(externalSubnetName, externalPort, v4Eip, direction, routerCrPort)
+	if err != nil {
+		klog.Error("delete qos rule faild: ", err)
+		return err
+	}
+
+	err = c.AddQos(vpcName, externalSubnetName, v4Eip, burstMax, rateMax, direction)
+	if err != nil {
+		klog.Error("update qos: add qos rule faild: ", err)
+		return err
+	}
+	return nil
+}
+
+func (c *OVNNbClient) GetQos(vpcName string, externamSubnet string, v4Eip string, direction string) ([]*ovnnb.QoS, error) {
+	// klog.Info("get qos for vpc: ", vpcName, "externalSubnetName:", externamSubnet, "v4Eip: ", v4Eip, " direction: ", direction)
+	lsName := externamSubnet
+	externalPort := fmt.Sprintf("%s-%s", externamSubnet, vpcName)
+	routerCrPort := fmt.Sprintf("cr-%s-%s", vpcName, externamSubnet)
+	qos, err := c.getLogicalSwitchQos(lsName, externalPort, v4Eip, direction, routerCrPort)
+	if err != nil {
+		return nil, err
+	}
+	//fmt.Println(qos)
+	return qos, nil
+}
+
+func (c *OVNNbClient) getLogicalSwitchQos(lsName string, externalPort string, v4Eip string, direction string, routerCrPort string) ([]*ovnnb.QoS, error) {
+
+	fileterFunc := func(qos *ovnnb.QoS) bool {
+		if qos.Direction != direction {
+			return false
+		}
+		if qos.Match != "" {
+			klog.Infof("qos match: %s, externalPort: %s, routerCrPort: %s", qos.Match, externalPort, routerCrPort)
+			// 判断gatewayPort和v4Eip是否在Match字符串中,使用字符串函数来判断
+			if strings.Contains(qos.Match, externalPort) && strings.Contains(qos.Match, v4Eip) {
+				return true
+			}
+			return false
+		}
+		return true
+	}
+	QoSList, err := c.listLogicalSwitchQosByFilter(lsName, fileterFunc)
+	if err != nil {
+		klog.Error(err)
+		return nil, fmt.Errorf("get qos for logicalSwitch %s: %w", lsName, err)
+	}
+	// klog.Info("qos list: ", &QoSList)
+	return QoSList, nil
+}
+
+func (c *OVNNbClient) listLogicalSwitchQosByFilter(lsName string, filter func(qos *ovnnb.QoS) bool) ([]*ovnnb.QoS, error) {
+	ls, err := c.GetLogicalSwitch(lsName, false)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+	// klog.Info("listLogicalSwitchQosByFilter: ", ls.QOSRules)
+	QoSList := make([]*ovnnb.QoS, 0, len(ls.QOSRules))
+	for _, uuid := range ls.QOSRules {
+		qos, err := c.getQosByUUID(uuid)
+		if err != nil {
+			if errors.Is(err, client.ErrNotFound) {
+				continue
+			}
+			klog.Error(err)
+			return nil, err
+		}
+		if filter == nil || filter(qos) {
+			QoSList = append(QoSList, qos)
+		}
+	}
+
+	return QoSList, nil
+}
+
+func (c *OVNNbClient) getQosByUUID(uuid string) (*ovnnb.QoS, error) {
+	//ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	//defer cancel()
+	obj := &ovnnb.QoS{} // Ensure the correct model type is used
+	conditions := []model.Condition{
+		{
+			Field:    &obj.UUID, // Reference a valid field from the QoS model
+			Function: ovsdb.ConditionEqual,
+			Value:    uuid, // Replace `uuid` with the actual value
+		},
+	}
+	var result []*ovnnb.QoS
+	cond := c.ovsDbClient.WhereAll(obj, conditions...)
+	//klog.Infof("cond: %v", &cond)
+	err := cond.List(context.Background(), &result)
+	if err != nil {
+		klog.Error(err)
+	}
+
+	if len(result) > 0 {
+		return result[0], nil
+	}
+	return nil, client.ErrNotFound
+}
+
+func (c *OVNNbClient) deleteQosByUUIDs(lsName string, qosUUIDs []string) error {
+	qosDelOps, err := c.QoSOp(lsName, qosUUIDs, ovsdb.MutateOperationDelete)
+	if err != nil {
+		klog.Error(err)
+		return fmt.Errorf("generate operations for adding qos to logicalSwitch %s: %w", lsName, err)
+	}
+
+	ops := make([]ovsdb.Operation, 0, len(qosDelOps))
+	ops = append(ops, qosDelOps...)
+	if err = c.Transact("qos-del", ops); err != nil {
+		klog.Error(err)
+		return fmt.Errorf("add qos to %s: %w", lsName, err)
+	}
+	return nil
+}
+
+func (c OVNNbClient) deleteLsQosIfExists(lsName string, externalPort string, v4Eip string, direction string, routerCrPort string) error {
+	klog.Info("delete Qos if exists for logicalSwitch: ", lsName, " externalPort: ", externalPort, " v4Eip: ", v4Eip)
+	existQos, err := c.getLogicalSwitchQos(lsName, externalPort, v4Eip, direction, routerCrPort)
+	if err != nil {
+		klog.Errorf("failed to get qos rules for logical switch %s: %v", lsName, err)
+		return err
+	}
+	if len(existQos) > 0 {
+		uuids := []string{}
+		for _, qos := range existQos {
+			uuids = append(uuids, qos.UUID)
+		}
+		err := c.deleteQosByUUIDs(lsName, uuids)
+		if err != nil {
+			klog.Error("delete qos by uuids faild: ", err)
+		}
+	}
+	return nil
+}
+
+func (c *OVNNbClient) DeleteQos(vpcName string, externalSubnetName string, v4Eip string, direction string) error {
+	klog.Info("delete qos for vpc: ", vpcName, "externalSubnetName:", externalSubnetName, "v4Eip: ", v4Eip, " direction: ", direction)
+	externalPort := fmt.Sprintf("%s-%s", externalSubnetName, vpcName)
+	routerCrPort := fmt.Sprintf("cr-%s-%s", vpcName, externalSubnetName)
+	err := c.deleteLsQosIfExists(externalSubnetName, externalPort, v4Eip, direction, routerCrPort)
+	if err != nil {
+		klog.Error("delete qos rule faild: ", err)
+		return err
+	}
+	return nil
+}
+
+// QoSOp create operations about logical switch qos //模仿router_policy写的
+func (c *OVNNbClient) QoSOp(lsName string, qosUUIDs []string, op ovsdb.Mutator) ([]ovsdb.Operation, error) {
+	if len(qosUUIDs) == 0 {
+		return nil, nil
+	}
+	mutation := func(ls *ovnnb.LogicalSwitch) *model.Mutation {
+		mutation := &model.Mutation{
+			Field:   &ls.QOSRules,
+			Value:   qosUUIDs,
+			Mutator: op,
+		}
+
+		return mutation
+	}
+
+	return c.LogicalSwitchQosOp(lsName, mutation)
+}
+
+// LogicalRouterOp create operations about logical router
+func (c *OVNNbClient) LogicalSwitchQosOp(lsName string, mutationsFunc ...func(ls *ovnnb.LogicalSwitch) *model.Mutation) ([]ovsdb.Operation, error) {
+	ls, err := c.GetLogicalSwitch(lsName, false)
+	if err != nil {
+		klog.Error(err)
+		return nil, fmt.Errorf("get logical switch %s: %w", lsName, err)
+	}
+	if len(mutationsFunc) == 0 {
+		return nil, nil
+	}
+	mutations := make([]model.Mutation, 0, len(mutationsFunc))
+	for _, f := range mutationsFunc {
+		mutation := f(ls)
+
+		if mutation != nil {
+			mutations = append(mutations, *mutation)
+		}
+	}
+	ops, err := c.ovsDbClient.Where(ls).Mutate(ls, mutations...)
+	if err != nil {
+		klog.Error(err)
+		return nil, fmt.Errorf("generate operations for mutating logical switch %v: %v", ls, err)
+	}
+	return ops, nil
+}

--- a/pkg/ovs/ovn-nb-fip-qos_test.go
+++ b/pkg/ovs/ovn-nb-fip-qos_test.go
@@ -1,0 +1,123 @@
+package ovs
+
+import (
+	"github.com/stretchr/testify/require"
+	"io"
+	"k8s.io/klog/v2"
+	"testing"
+)
+
+func (suite *OvnClientTestSuite) testFipQos() {
+	t := suite.T()
+	t.Parallel()
+
+	nbClient := suite.ovnNBClient
+	vpcName := "test_vpc"
+	externalSubnet := "test_external_subnet"
+	//subnetName := "test_subnet"
+	v4Eip := "192.168.100.10"
+	klog.SetOutput(io.Discard)
+
+	t.Run("create logical router", func(t *testing.T) {
+		//t.Parallel()
+		err := nbClient.CreateLogicalRouter(vpcName)
+		require.NoError(t, err)
+		lr, err := nbClient.GetLogicalRouter(vpcName, false)
+		require.NoError(t, err)
+		require.NotEmpty(t, lr)
+	})
+
+	t.Run(" create logical switch", func(t *testing.T) {
+		//t.Parallel()
+		err := nbClient.CreateGatewayLogicalSwitch(externalSubnet, vpcName, "ovn", "192.168.100.0/24", "", 10)
+		require.NoError(t, err)
+		_, err = nbClient.GetLogicalSwitch(externalSubnet, false)
+		require.NoError(t, err)
+
+	})
+
+	t.Run("create Qos rule for egress", func(t *testing.T) {
+		//t.Parallel()
+		err := nbClient.AddQos(vpcName, externalSubnet, v4Eip, 1000, 1000, "to-lport")
+		require.NoError(t, err)
+
+		ls, err := nbClient.GetLogicalSwitch(externalSubnet, false)
+		require.NoError(t, err)
+		require.Len(t, ls.QOSRules, 1)
+		//fmt.Println("QoS rules:", ls.QOSRules)
+	})
+
+	t.Run("create Qos rule for ingress ", func(t *testing.T) {
+		//t.Parallel()
+		err := nbClient.AddQos(vpcName, externalSubnet, v4Eip, 1000, 1000, "from-lport")
+		require.NoError(t, err)
+
+		ls, err := nbClient.GetLogicalSwitch(externalSubnet, false)
+		require.NoError(t, err)
+		require.Len(t, ls.QOSRules, 2)
+		//fmt.Println("QoS rules:", ls.QOSRules)
+	})
+
+	t.Run("get QoS rules for logical switch", func(t *testing.T) {
+		qosRules, err := nbClient.GetQos(vpcName, externalSubnet, v4Eip, "from-lport")
+		require.NoError(t, err)
+		require.NotEmpty(t, qosRules, "QoS rules should not be empty")
+		//for _, qos := range qosRules {
+		//	fmt.Println(qos)
+		//}
+	})
+
+	t.Run("update Qos rule for egress", func(t *testing.T) {
+		err := nbClient.UpdateQos(vpcName, externalSubnet, v4Eip, 2000, 2000, "to-lport")
+		require.NoError(t, err)
+		qosRules, err := nbClient.GetQos(vpcName, externalSubnet, v4Eip, "to-lport")
+		require.NoError(t, err)
+		require.Len(t, qosRules, 1)
+		require.Equal(t, 2000, qosRules[0].Bandwidth["rate"], "QoS rate should be updated to 2000")
+	})
+
+	t.Run("update Qos rule for ingress", func(t *testing.T) {
+		err := nbClient.UpdateQos(vpcName, externalSubnet, v4Eip, 2000, 2000, "from-lport")
+		require.NoError(t, err)
+		qosRules, err := nbClient.GetQos(vpcName, externalSubnet, v4Eip, "from-lport")
+		require.NoError(t, err)
+		require.Len(t, qosRules, 1)
+		require.Equal(t, 2000, qosRules[0].Bandwidth["rate"], "QoS rate should be updated to 2000")
+	})
+
+	t.Run("delete Qos rule for egress", func(t *testing.T) {
+		//t.Parallel()
+		err := nbClient.DeleteQos(vpcName, externalSubnet, v4Eip, "to-lport")
+		require.NoError(t, err)
+		qosRules, err := nbClient.GetQos(vpcName, externalSubnet, v4Eip, "to-lport")
+		require.NoError(t, err)
+		require.Empty(t, qosRules, "QoS rules for egress should be deleted")
+	})
+
+	t.Run("delete Qos rule for ingress", func(t *testing.T) {
+		//t.Parallel()
+		err := nbClient.DeleteQos(vpcName, externalSubnet, v4Eip, "from-lport")
+		require.NoError(t, err)
+		qosRules, err := nbClient.GetQos(vpcName, externalSubnet, v4Eip, "from-lport")
+		require.NoError(t, err)
+		require.Empty(t, qosRules, "QoS rules for ingress should be deleted")
+	})
+
+	t.Run("delete logical router", func(t *testing.T) {
+		//t.Parallel()
+		err := nbClient.DeleteLogicalRouter(vpcName)
+		require.NoError(t, err)
+		lr, err := nbClient.GetLogicalRouter(vpcName, false)
+		require.Error(t, err)
+		require.Nil(t, lr, "Logical router should be deleted")
+	})
+
+	t.Run("delete logical switch", func(t *testing.T) {
+		//t.Parallel()
+		err := nbClient.DeleteLogicalSwitch(externalSubnet)
+		require.NoError(t, err)
+		ls, err := nbClient.GetLogicalSwitch(externalSubnet, false)
+		require.Error(t, err)
+		require.Nil(t, ls, "Logical switch should be deleted")
+	})
+}

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -1275,6 +1275,10 @@ func (suite *OvnClientTestSuite) Test_ListQosQueueIDs() {
 	suite.testListQosQueueIDs()
 }
 
+func (suite *OvnClientTestSuite) Test_FipQos() {
+	suite.testFipQos()
+}
+
 func Test_scratch(t *testing.T) {
 	t.SkipNow()
 	endpoint := "tcp:[172.20.149.35]:6641"
@@ -1403,6 +1407,7 @@ func newNbClient(addr string, timeout int) (client.Client, error) {
 		client.WithTable(&ovnnb.NAT{}),
 		client.WithTable(&ovnnb.NBGlobal{}),
 		client.WithTable(&ovnnb.PortGroup{}),
+		client.WithTable(&ovnnb.QoS{}),
 	}
 	if _, err = c.Monitor(context.TODO(), c.NewMonitor(monitorOpts...)); err != nil {
 		klog.Error(err)

--- a/pkg/ovs/ovn.go
+++ b/pkg/ovs/ovn.go
@@ -91,6 +91,7 @@ func NewOvnNbClient(ovnNbAddr string, ovnNbTimeout, ovsDbConTimeout, ovsDbInacti
 		client.WithTable(&ovnnb.NAT{}),
 		client.WithTable(&ovnnb.NBGlobal{}),
 		client.WithTable(&ovnnb.PortGroup{}),
+		client.WithTable(&ovnnb.QoS{}),
 	}
 
 	try := 0


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR ：新功能

## 功能描述： 

本次将自己解决的fip可以添加qosPolicy并应用的功能，请求合并到主分支中。 

该qos中依照openstack 的qos创建规则和逻辑，参考其它nb-*.go文件中的代码，写了一个简单的qos规则添加。

1、复用当前的qosPolicy CR，不再新建新的ovnQosPolicy CR .
2、在创建fip时，可以指定字段qosPolicy，如果指定了qosPolicy，将会在qos表中创建新的qos规则
3、在更新fip时，可以修改qosPolicy为其它规则或空，将会在qos表中match后删除原有规则，然后新建（或删除）规则。
4、如果fip在创建、更新时，如果qosPolicy指定的规则没有被找到，则fip的ready为false，可以通过对比spec.qosPolicy和status.qosPolicy中的规则，来判断是否是因为qosPolicy的错误而导致fip状态失败。

待解决的问题：
1、没有测试用例，还没明白现有代码的测试用例到底是如何运行的。(已经解决，添加了一个简单的测试用例）

与openstack的区别：
1、openstack中qos可以挂载在fip或port上，但根据研究代码，本次代码没有添加挂载port的功能，省去了些许麻烦。
