### PR TITLE
feat: add pod_name and pod_namespace labels to interface metrics

### DIFF
--- a/pkg/pinger/metrics.go
+++ b/pkg/pinger/metrics.go
@@ -493,6 +493,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatTxBytes = prometheus.NewGaugeVec(
@@ -504,6 +506,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatRxPackets = prometheus.NewGaugeVec(
@@ -515,6 +519,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatRxBytes = prometheus.NewGaugeVec(
@@ -526,6 +532,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	// OVS Interface Statistics: Receive errors
@@ -538,6 +546,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatRxDropped = prometheus.NewGaugeVec(
@@ -549,6 +559,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatRxErrorsTotal = prometheus.NewGaugeVec(
@@ -560,6 +572,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatRxFrameError = prometheus.NewGaugeVec(
@@ -571,6 +585,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatRxMissedError = prometheus.NewGaugeVec(
@@ -582,6 +598,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatRxOverrunError = prometheus.NewGaugeVec(
@@ -593,6 +611,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	// OVS Interface Statistics: Transmit errors
@@ -605,6 +625,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatTxErrorsTotal = prometheus.NewGaugeVec(
@@ -616,6 +638,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatCollisions = prometheus.NewGaugeVec(
@@ -627,6 +651,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 
 	interfaceStatRxMulticastPackets = prometheus.NewGaugeVec(
@@ -638,6 +664,8 @@ var (
 		[]string{
 			"hostname",
 			"interfaceName",
+			"pod_name",
+			"pod_namespace",
 		})
 )
 


### PR DESCRIPTION
Add pod_name and pod_namespace labels to all OVS interface statistics metrics to enable Pod-level network monitoring and troubleshooting.

Changes:
- Add pod_name and pod_namespace labels to interface statistics metrics definitions
- Extract Pod information from interface external_ids in setOvsInterfaceStatisticsMetric
- Support empty labels for interfaces without Pod information (system interfaces)

Affected metrics:
- kube_ovn_interface_tx_packets, kube_ovn_interface_tx_bytes
- kube_ovn_interface_rx_packets, kube_ovn_interface_rx_bytes
- kube_ovn_interface_rx_crc_err, kube_ovn_interface_rx_dropped
- kube_ovn_interface_rx_errors, kube_ovn_interface_rx_frame_err
- kube_ovn_interface_rx_missed_err, kube_ovn_interface_rx_over_err
- kube_ovn_interface_tx_dropped, kube_ovn_interface_tx_errors
- kube_ovn_interface_collisions, kube_ovn_interface_rx_multicast_packets

This enables users to:
- Monitor network performance by Pod
- Create Pod-based network alerts
- Troubleshoot network issues for specific applications
- Analyze application-level network behavior

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Metrics

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #5443
