### PR TITLE
fix: only addOrUpdateSubnetQueue if the GatewayType is distributed instead of if it's not centralized

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -524,7 +524,7 @@ func (c *Controller) handleUpdateNode(key string) error {
 	}
 
 	for _, cachedSubnet := range subnets {
-		if cachedSubnet.Spec.GatewayType != kubeovnv1.GWCentralizedType {
+		if cachedSubnet.Spec.GatewayType == kubeovnv1.GWDistributedType {
 			// we need to reconcile ovn route for subnets with distributed gateway mode,
 			// since the informer node cache may not be synced before the subnet reconcile triggered by node addition
 			c.addOrUpdateSubnetQueue.Add(cachedSubnet.Name)


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

When handleUpdateNode is called, instead of addOrUpdateSubnetQueue for any subnet that's not centralized. Only addOrUpdateSubnetQueue when it's a distributed type. This means that it won't addOrUpdateSubnetQueue for subnets that don't belong to the default VPC which doesn't have a gateway type and causes undesired lag.

## Which issue(s) this PR fixes

This might impact https://github.com/kubeovn/kube-ovn/issues/5312, but it should address https://github.com/kubeovn/kube-ovn/issues/5312#issuecomment-3073975311 where those subnets aren't part of the default VPC and don't have gateway types on the subnet
