### PR TITLE
Remove termin gracefule timer

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -357,19 +357,35 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 	var delay time.Duration
 	if newPod.Spec.TerminationGracePeriodSeconds != nil {
 		if !newPod.DeletionTimestamp.IsZero() {
-			delay = time.Until(newPod.DeletionTimestamp.Add(time.Duration(*newPod.Spec.TerminationGracePeriodSeconds) * time.Second))
+			delay = time.Until(newPod.DeletionTimestamp.Time)
 		} else {
 			delay = time.Duration(*newPod.Spec.TerminationGracePeriodSeconds) * time.Second
 		}
 	}
 
 	if !newPod.DeletionTimestamp.IsZero() && !isStateful && !isVMPod {
+		// Use short interval check instead of time.AfterFunc for better timing accuracy
+		targetTime := newPod.DeletionTimestamp.Time
+		now := time.Now()
+		expectedExecutionTime := targetTime
+		klog.V(3).Infof("enqueue delete pod %s after %v (current time: %v, expected execution time: %v)", key, targetTime.Sub(now), now, expectedExecutionTime)
+		c.deletingPodObjMap.Store(key, newPod)
+
+		// Use short interval check for better precision
 		go func() {
-			// In case node get lost and pod can not be deleted,
-			// the ip address will not be recycled
-			klog.V(3).Infof("enqueue delete pod %s after %v", key, delay)
-			c.deletingPodObjMap.Store(key, newPod)
-			c.deletePodQueue.AddAfter(key, delay)
+			checkInterval := 1 * time.Second
+			for {
+				now := time.Now()
+				if now.After(targetTime) {
+					klog.V(3).Infof("Adding pod %s to delete queue after short interval check", key)
+					c.deletePodQueue.Add(key)
+					return
+				}
+				sleepStart := time.Now()
+				time.Sleep(checkInterval)
+				actualSleepTime := time.Since(sleepStart)
+				klog.V(4).Infof("Pod %s sleep actual time: %v (expected: %v)", key, actualSleepTime, checkInterval)
+			}
 		}()
 		return
 	}
@@ -380,18 +396,50 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 
 	// do not delete statefulset pod unless ownerReferences is deleted
 	if isStateful && isStatefulSetPodToDel(c.config.KubeClient, newPod, statefulSetName, statefulSetUID) {
+		// Use short interval check instead of time.AfterFunc for better timing accuracy
+		targetTime := newPod.DeletionTimestamp.Time
+		klog.V(3).Infof("enqueue delete pod %s after %v", key, targetTime.Sub(time.Now()))
+		c.deletingPodObjMap.Store(key, newPod)
+
+		// Use short interval check for better precision
 		go func() {
-			klog.V(3).Infof("enqueue delete pod %s after %v", key, delay)
-			c.deletingPodObjMap.Store(key, newPod)
-			c.deletePodQueue.AddAfter(key, delay)
+			checkInterval := 1 * time.Second
+			for {
+				now := time.Now()
+				if now.After(targetTime) {
+					klog.V(3).Infof("Adding statefulset pod %s to delete queue after short interval check", key)
+					c.deletePodQueue.Add(key)
+					return
+				}
+				sleepStart := time.Now()
+				time.Sleep(checkInterval)
+				actualSleepTime := time.Since(sleepStart)
+				klog.V(4).Infof("Statefulset pod %s sleep actual time: %v (expected: %v)", key, actualSleepTime, checkInterval)
+			}
 		}()
 		return
 	}
 	if isVMPod && c.isVMToDel(newPod, vmName) {
+		// Use short interval check instead of time.AfterFunc for better timing accuracy
+		targetTime := time.Now().Add(delay)
+		klog.V(3).Infof("enqueue delete pod %s after %v", key, delay)
+		c.deletingPodObjMap.Store(key, newPod)
+
+		// Use short interval check for better precision
 		go func() {
-			klog.V(3).Infof("enqueue delete pod %s after %v", key, delay)
-			c.deletingPodObjMap.Store(key, newPod)
-			c.deletePodQueue.AddAfter(key, delay)
+			checkInterval := 1 * time.Second
+			for {
+				now := time.Now()
+				if now.After(targetTime) {
+					klog.V(3).Infof("Adding VM pod %s to delete queue after short interval check", key)
+					c.deletePodQueue.Add(key)
+					return
+				}
+				sleepStart := time.Now()
+				time.Sleep(checkInterval)
+				actualSleepTime := time.Since(sleepStart)
+				klog.V(4).Infof("VM pod %s sleep actual time: %v (expected: %v)", key, actualSleepTime, checkInterval)
+			}
 		}()
 		return
 	}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

There is no need to calculate the delay to enqueueDeletePod, because when the terminationGracePeriodSeconds time is reached, there will be an event to enqueueDeletePod.

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
