### PR TITLE
vlan subnet vpc is optional

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -156,8 +156,9 @@ func (c *Controller) formatSubnet(subnet *kubeovnv1.Subnet) (*kubeovnv1.Subnet, 
 		changed = true
 	}
 
-	if subnet.Spec.Vpc == "" {
-		if isOvnSubnet(subnet) {
+	if subnet.Spec.Vpc == "" && isOvnSubnet(subnet) {
+		// for better security, if not set, vlan subnet vpc should be empty
+		if subnet.Spec.Vlan == "" {
 			subnet.Spec.Vpc = c.config.ClusterRouter
 			changed = true
 		}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes


在 vlan subnet vpc 场景中，如果没有指定默认 vpc，而代码默认设置为 ovn-cluster，可能会导致一些安全上的问题。比如从 node 或者 默认 vpc 下的pod，可能可以访问 vlan 中的资源，尽管物理网络设计上是隔离的。

而且，如果用户愿意联通，则可以明确指定和哪个 vpc 联通。



<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
