### PR TITLE
fix nat-gateway arping

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -102,7 +102,7 @@ function add_eip() {
         eip=${rule}
         eip_without_prefix=(${eip//\// })
         exec_cmd "ip addr replace $eip dev net1"
-        exec_cmd "arping -I net1 -c 3 -D $eip_without_prefix"
+        exec_cmd "arping -I net1 -c 3 -U $eip_without_prefix"
     done
 }
 


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

arping -I net1 -c 3 -D这个命令应该只能做冲突检测，当vpc-nat-gw的pod重启后，mac地址变化，交换机上的缓存没有更新，访问eip是有问题的。

改成arping -I net1 -c 3 -C可以强制进行广播更新。
