### PR TITLE
fix vpcNatGw status cannot be updated

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -131,19 +131,15 @@ func (c *Controller) handleDelVpcNatGw(key string) error {
 
 func isVpcNatGwChanged(gw *kubeovnv1.VpcNatGateway) bool {
 	if !slices.Equal(gw.Spec.ExternalSubnets, gw.Status.ExternalSubnets) {
-		gw.Status.ExternalSubnets = gw.Spec.ExternalSubnets
 		return true
 	}
 	if !slices.Equal(gw.Spec.Selector, gw.Status.Selector) {
-		gw.Status.Selector = gw.Spec.Selector
 		return true
 	}
 	if !reflect.DeepEqual(gw.Spec.Tolerations, gw.Status.Tolerations) {
-		gw.Status.Tolerations = gw.Spec.Tolerations
 		return true
 	}
 	if !reflect.DeepEqual(gw.Spec.Affinity, gw.Status.Affinity) {
-		gw.Status.Affinity = gw.Spec.Affinity
 		return true
 	}
 	return false


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

isVpcNatGwChanged()中不应该给gw.status赋值，如果这里有了值，那后面在patchNatGwStatus()时就比较不出来gw.spec与gw.status的变化，导致无法进行更新。

