### PR TITLE
Do not garbage collect IPs of stopped VMs using non-default multus networks

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -1021,15 +1021,18 @@ func (c *Controller) getVMLsps() []string {
 				vmLsps = append(vmLsps, vmLsp)
 			}
 
-			attachNets, err := nadutils.ParseNetworkAnnotation(vm.Spec.Template.ObjectMeta.Annotations[nadv1.NetworkAttachmentAnnot], vm.Namespace)
-			if err != nil {
-				klog.Errorf("failed to get attachment subnet of vm %s, %v", vm.Name, err)
-				continue
-			}
-			for _, multiNet := range attachNets {
-				provider := fmt.Sprintf("%s.%s.%s", multiNet.Name, multiNet.Namespace, util.OvnProvider)
-				vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, provider)
-				vmLsps = append(vmLsps, vmLsp)
+			nadAnnotation := vm.Spec.Template.ObjectMeta.Annotations[nadv1.NetworkAttachmentAnnot]
+			if nadAnnotation != "" {
+				attachNets, err := nadutils.ParseNetworkAnnotation(nadAnnotation, vm.Namespace)
+				if err != nil {
+					klog.Errorf("failed to get attachment subnet of vm %s, %v", vm.Name, err)
+					continue
+				}
+				for _, multiNet := range attachNets {
+					provider := fmt.Sprintf("%s.%s.%s", multiNet.Name, multiNet.Namespace, util.OvnProvider)
+					vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, provider)
+					vmLsps = append(vmLsps, vmLsp)
+				}
 			}
 
 			for _, network := range vm.Spec.Template.Spec.Networks {


### PR DESCRIPTION
Do not garbage collect IPs of stopped VMs using non-default multus networks

If a kubevirt VM:
- is not using the default multus network
- is stopped
- does not have any annotation under `vm.Spec.Template.ObjectMeta.Annotations[nadv1.NetworkAttachmentAnnot]`

Then GC would delete the IP of this VM.

To fix, we ensure that we find the LSPs of VMs on the spec before it tries (and maybe fails) to get the LSPs defined as annotations

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #5556
