### PR TITLE
skip mv if config file already exists

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -202,13 +202,18 @@ func main() {
 }
 
 func mvCNIConf(configDir, configFile, confName string) error {
+	cniConfPath := filepath.Join(configDir, confName)
+	if _, err := os.Stat(cniConfPath); err == nil {
+		klog.Infof("CNI config file %q already exists, skipping copying CNI config file", cniConfPath)
+		return nil
+	}
+
 	data, err := os.ReadFile(configFile) // #nosec G304
 	if err != nil {
 		klog.Errorf("failed to read cni config file %s, %v", configFile, err)
 		return err
 	}
 
-	cniConfPath := filepath.Join(configDir, confName)
 	klog.Infof("Installing cni config file %q to %q", configFile, cniConfPath)
 	return os.WriteFile(cniConfPath, data, 0o644) // #nosec G306
 }


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

Here's the translated text in English:

Users may need to modify the CNI configuration of Kube-OVN, especially in scenarios where Istio performs automatic injection, as it will automatically inject the Istio-CNI configuration. Currently, kube-ovn-cni overwrites the CNI configuration every time it restarts, which may cause the loss of Istio configurations and lead to Istio abnormalities.

## Which issue(s) this PR fixes

Fixes #(issue-number)
