### PR TITLE
skip nad without config

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1708,6 +1708,10 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			return nil, err
 		}
 
+		if network.Spec.Config == "" {
+			continue
+		}
+
 		netCfg, err := loadNetConf([]byte(network.Spec.Config))
 		if err != nil {
 			klog.Errorf("failed to load config of net-attach-def %s, %v", attach.Name, err)


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

Multus NAD without config is valid https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#networkattachmentdefinition-with-cni-config-file. the following load error will prevent pod creation.

## Which issue(s) this PR fixes

Fixes #(issue-number)
