### PR TITLE
Fix the problem that if available ip is 0 but there is a value in exc…

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1469,18 +1469,18 @@ func (c *Controller) getPodDefaultSubnet(pod *v1.Pod) (*kubeovnv1.Subnet, error)
 
 		switch subnet.Spec.Protocol {
 		case kubeovnv1.ProtocolDual:
-			if subnet.Status.V6AvailableIPs == 0 {
+			if subnet.Status.V6AvailableIPs == 0 && !c.podCanUseExcludeIPs(pod, subnet) {
 				klog.Infof("there's no available ipv6 address in subnet %s, try next one", subnet.Name)
 				continue
 			}
 			fallthrough
 		case kubeovnv1.ProtocolIPv4:
-			if subnet.Status.V4AvailableIPs == 0 {
+			if subnet.Status.V4AvailableIPs == 0 && !c.podCanUseExcludeIPs(pod, subnet) {
 				klog.Infof("there's no available ipv4 address in subnet %s, try next one", subnet.Name)
 				continue
 			}
 		case kubeovnv1.ProtocolIPv6:
-			if subnet.Status.V6AvailableIPs == 0 {
+			if subnet.Status.V6AvailableIPs == 0 && !c.podCanUseExcludeIPs(pod, subnet) {
 				klog.Infof("there's no available ipv6 address in subnet %s, try next one", subnet.Name)
 				continue
 			}
@@ -1502,6 +1502,36 @@ func loadNetConf(bytes []byte) (*multustypes.DelegateNetConf, error) {
 		}
 	}
 	return delegateConf, nil
+}
+
+func (c *Controller) podCanUseExcludeIPs(pod *v1.Pod, subnet *kubeovnv1.Subnet) bool {
+	if ipAddr := pod.Annotations[util.IPAddressAnnotation]; ipAddr != "" {
+		return c.checkIPsInExcludeList(ipAddr, subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock)
+	}
+	if ipPool := pod.Annotations[util.IPPoolAnnotation]; ipPool != "" {
+		return c.checkIPsInExcludeList(ipPool, subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock)
+	}
+
+	return false
+}
+
+func (c *Controller) checkIPsInExcludeList(ips string, excludeIPs []string, cidr string) bool {
+	expandedExcludeIPs := util.ExpandExcludeIPs(excludeIPs, cidr)
+
+	for _, ipAddr := range strings.Split(strings.TrimSpace(ips), ",") {
+		ipAddr = strings.TrimSpace(ipAddr)
+		if ipAddr == "" {
+			continue
+		}
+
+		for _, excludeIP := range expandedExcludeIPs {
+			if util.ContainsIPs(excludeIP, ipAddr) {
+				klog.V(3).Infof("IP %s is found in exclude IP %s, allowing allocation", ipAddr, excludeIP)
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type providerType int


### PR DESCRIPTION
…ludeIPs, the fixed ip is used as the ip in excludeIPs but the error noAddressAvaliable is still reported

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
