### PR TITLE
Fix the problem that if available ip is 0 but there is a value in exc…

### DIFF
--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -1389,3 +1389,13 @@ func setVfMac(deviceID string, vfIndex int, mac string) error {
 	}
 	return nil
 }
+
+func linkExists(name string) (bool, error) {
+	if _, err := netlink.LinkByName(name); err != nil {
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
…ludeIPs, the fixed ip is used as the ip in excludeIPs but the error noAddressAvaliable is still reported

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
