### PR TITLE
Use CA key name when scheduling certificate refresh

### DIFF
--- a/pkg/daemon/ipsec.go
+++ b/pkg/daemon/ipsec.go
@@ -590,7 +590,7 @@ func (c *Controller) SyncIPSecKeys(key string) error {
 		return err
 	}
 
-	c.ipsecQueue.AddAfter("expiry", untilRefresh)
+	c.ipsecQueue.AddAfter(key, untilRefresh)
 
 	return nil
 }


### PR DESCRIPTION
This uses the CA key when scheduling a cert refresh. I'd like to add an e2e test for this but the minimum cert duration is 1h which is a bit long for a test.

Fixes #5575
