### PR TITLE
controller: avoid concurrent map access in service update

### DIFF
--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"reflect"
 	"slices"
@@ -281,19 +282,22 @@ func (c *Controller) handleUpdateService(svcObject *updateSvcObject) error {
 			klog.Errorf("failed to get LB %s: %v", lbName, err)
 			return err
 		}
-		klog.V(3).Infof("existing vips of LB %s: %v", lbName, lb.Vips)
+
+		lbVips := maps.Clone(lb.Vips)
+		klog.V(3).Infof("existing vips of LB %s: %v", lbName, lbVips)
 		for _, vip := range svcVips {
 			if err := c.OVNNbClient.LoadBalancerDeleteVip(oLbName, vip, ignoreHealthCheck); err != nil {
 				klog.Errorf("failed to delete vip %s from LB %s: %v", vip, oLbName, err)
 				return err
 			}
 
-			if _, ok := lb.Vips[vip]; !ok {
+			if _, ok := lbVips[vip]; !ok {
 				klog.Infof("add vip %s to LB %s", vip, lbName)
 				needUpdateEndpointQueue = true
 			}
 		}
-		for vip := range lb.Vips {
+
+		for vip := range lbVips {
 			if ip := parseVipAddr(vip); (slices.Contains(ips, ip) && !slices.Contains(svcVips, vip)) || slices.Contains(ipsToDel, ip) {
 				klog.Infof("remove stale vip %s from LB %s", vip, lbName)
 				if err := c.OVNNbClient.LoadBalancerDeleteVip(lbName, vip, ignoreHealthCheck); err != nil {
@@ -312,8 +316,10 @@ func (c *Controller) handleUpdateService(svcObject *updateSvcObject) error {
 			klog.Errorf("failed to get LB %s: %v", oLbName, err)
 			return err
 		}
-		klog.V(3).Infof("existing vips of LB %s: %v", oLbName, lb.Vips)
-		for vip := range oLb.Vips {
+
+		oLbVips := maps.Clone(oLb.Vips)
+		klog.V(3).Infof("existing vips of LB %s: %v", oLbName, oLbVips)
+		for vip := range oLbVips {
 			if ip := parseVipAddr(vip); slices.Contains(ips, ip) || slices.Contains(ipsToDel, ip) {
 				klog.Infof("remove stale vip %s from LB %s", vip, oLbName)
 				if err = c.OVNNbClient.LoadBalancerDeleteVip(oLbName, vip, ignoreHealthCheck); err != nil {


### PR DESCRIPTION
## Summary
- clone load balancer VIP maps before iterating to prevent concurrent access panics

## Testing
- `go test ./pkg/controller -run TestDummy -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6898b0b2e250832cad515a0f52953538