### PR TITLE
remove lsp when gw nodes change

### DIFF
--- a/pkg/controller/external_gw.go
+++ b/pkg/controller/external_gw.go
@@ -129,9 +129,10 @@ func (c *Controller) removeExternalGateway() error {
 		// provider network, underlay vlan control the external gateway switch
 		klog.Infof("should keep provider network underlay vlan external gateway switch %s", c.config.ExternalGatewaySwitch)
 		lrpName := fmt.Sprintf("%s-%s", c.config.ClusterRouter, c.config.ExternalGatewaySwitch)
-		klog.Infof("delete logical router port %s", lrpName)
-		if err := c.OVNNbClient.DeleteLogicalRouterPort(lrpName); err != nil {
-			klog.Errorf("failed to delete lrp %s, %v", lrpName, err)
+		lspName := fmt.Sprintf("%s-%s", c.config.ExternalGatewaySwitch, c.config.ClusterRouter)
+		klog.Infof("delete logical patch port lsp %s lrp %s", lspName, lrpName)
+		if err := c.OVNNbClient.RemoveLogicalPatchPort(lspName, lrpName); err != nil {
+			klog.Errorf("failed to remove logical patch port %s/%s, %v", lspName, lrpName, err)
 			return err
 		}
 	}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

The external gateway uses some very old code that contains many poorly considered aspects. For example, configuration errors can cause the entire feature to fail, and it cannot achieve operation idempotency etc. 

Also I think it's not necessary to remove and then recreate ports when gw nodes change.

However, this is just a temporary quick fix to address user feedback problems.

## Which issue(s) this PR fixes

Fixes #5262
