### PR TITLE
feat(vpcnatgw): send gratuitous arp for nexthops at natgw initialization

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -47,6 +47,10 @@ function init() {
     $iptables_cmd -t nat -A POSTROUTING -j SNAT_FILTER
     $iptables_cmd -t nat -A SNAT_FILTER -j EXCLUSIVE_SNAT
     $iptables_cmd -t nat -A SNAT_FILTER -j SHARED_SNAT
+
+    # Send gratuitous ARP for all the IPs on the external network interface at initialization
+    # This is especially useful to update the MAC of the nexthop we announce to the BGP speaker 
+    ip -4 addr show dev net1 | awk '/inet /{print $2}' | cut -d/ -f1 | xargs -n1 arping -I net1 -c 3 -U
 }
 
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

This PR adds a one-liner to the script launched at the initialization of a VPC NAT gateway. The one-liner picks up every IPv4 on the external interface (the one that connects to the physical network) and sends gratuitous ARP for each of the interface.

When the NAT gateway is in pure ARP mode (which is the default mode), it doesn't serve any specific purpose.

But when the NAT gateway is in BGP mode, the external BGP router will see a nexthop address mounted on this interface (whereas in ARP mode, the nexthop is the EIP directly, which already has a gratuitous ARP feature).

The BGP router will forward traffic to this nexthop by resolving the MAC address through ARP and will cache it. If the NAT gateway restarts and is scheduled on another node, the MAC address changes, but no announcement of that change is propagated to the BGP router.

The BGP router will keep forwarding traffic to the wrong node until its cache expire. In the meantime, all the traffic is blackholed.

This fix will ensure the cache for the nexthop is updated on any neighbour of the NAT gateway when it boots up.

## Which issue(s) this PR fixes

Fixes #(issue-number)
