### PR TITLE
Feat: Added non primary cni mode support for Kube-OVN

### DIFF
--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -158,6 +158,7 @@ spec:
           - --enable-live-migration-optimize={{- .Values.features.enableLiveMigrationOptimization }}
           - --enable-ovn-lb-prefer-local={{- .Values.features.ENABLE_OVN_LB_PREFER_LOCAL }}
           - --image={{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
+          - --non-primary-cni-mode={{- .Values.cni.nonPrimaryCNI }}
           securityContext:
             runAsUser: {{ include "kubeovn.runAsUser" . }}
             privileged: false

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -251,6 +251,11 @@ cni:
   # Should be a string representing a double-digit integer.
   # @section -- CNI configuration
   configPriority: "01"
+  # -- Whether to use Kube-OVN as non-primary CNI. When set to true, Kube-OVN will not allocate/handle primary network interfaces.
+  # Interfaces are created using Network Attachment Definitions (NADs)
+  # @section -- CNI configuration
+  nonPrimaryCNI: false
+
 
 # -- Configuration of the validating webhook used to verify custom resources before they are pushed to Kubernetes.
 # Make sure cert-manager is installed for the generation of certificates for the webhook.

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -142,6 +142,7 @@ spec:
           - --enable-live-migration-optimize={{- .Values.func.ENABLE_LIVE_MIGRATION_OPTIMIZE }}
           - --enable-ovn-lb-prefer-local={{- .Values.func.ENABLE_OVN_LB_PREFER_LOCAL }}
           - --image={{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
+          - --non-primary-cni-mode={{- .Values.cni_conf.NON_PRIMARY_CNI }}
           securityContext:
             runAsUser: {{ include "kubeovn.runAsUser" . }}
             privileged: false

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -119,6 +119,7 @@ cni_conf:
   CNI_CONF_FILE: "/kube-ovn/01-kube-ovn.conflist"
   LOCAL_BIN_DIR: "/usr/local/bin"
   MOUNT_LOCAL_BIN_DIR: false
+  NON_PRIMARY_CNI: false
 
 kubelet_conf:
   KUBELET_DIR: "/var/lib/kubelet"

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -124,6 +124,9 @@ type Configuration struct {
 	TLSMinVersion   string
 	TLSMaxVersion   string
 	TLSCipherSuites []string
+
+	// Non Primary CNI flag
+	EnableNonPrimaryCNI bool
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -212,6 +215,8 @@ func ParseFlags() (*Configuration, error) {
 		argTLSMinVersion   = pflag.String("tls-min-version", "", "The minimum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
 		argTLSMaxVersion   = pflag.String("tls-max-version", "", "The maximum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
 		argTLSCipherSuites = pflag.StringSlice("tls-cipher-suites", nil, "Comma-separated list of TLS cipher suite names to use for secure serving (e.g., 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'). Names must match Go's crypto/tls package. See Go documentation for available suites. If not set, defaults are used. Users are responsible for selecting secure cipher suites.")
+
+		argNonPrimaryCNI = pflag.Bool("non-primary-cni-mode", false, "Use Kube-OVN in non primary cni mode. When true, Kube-OVN will only manage the network for network attachment definitions")
 	)
 
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
@@ -303,6 +308,7 @@ func ParseFlags() (*Configuration, error) {
 		TLSMinVersion:                  *argTLSMinVersion,
 		TLSMaxVersion:                  *argTLSMaxVersion,
 		TLSCipherSuites:                *argTLSCipherSuites,
+		EnableNonPrimaryCNI:            *argNonPrimaryCNI,
 	}
 	if config.OvsDbConnectTimeout >= config.OvsDbInactivityTimeout {
 		return nil, errors.New("OVS DB inactivity timeout value should be greater than reconnect timeout value")

--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -134,22 +134,6 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 	// If Kube-OVN is running in secondary CNI mode, the endpoint IPs should be derived from the network attachment definitions
 	// This overwrite can be removed if endpoint construction accounts for network attachment IP address
 	// TODO: Identify how endpoints are constructed, by deafult, endpoints has IP address of eth0 inteface
-	if c.config.EnableSecondaryCNI {
-		var pods []*v1.Pod
-		if pods, err = c.podsLister.Pods(namespace).List(labels.Set(svc.Spec.Selector).AsSelector()); err != nil {
-			klog.Errorf("failed to get pods for service %s in namespace %s: %v", name, namespace, err)
-			return err
-		}
-		err = c.replaceEndpointAddressesWithSecondaryIPs(endpointSlices, pods)
-		if err != nil {
-			klog.Errorf("failed to update endpointSlice: %v", err)
-			return err
-		}
-	}
-
-	// If Kube-OVN is running in secondary CNI mode, the endpoint IPs should be derived from the network attachment definitions
-	// This overwrite can be removed if endpoint construction accounts for network attachment IP address
-	// TODO: Identify how endpoints are constructed, by deafult, endpoints has IP address of eth0 inteface
 	if c.config.EnableNonPrimaryCNI {
 		var pods []*v1.Pod
 		if pods, err = c.podsLister.Pods(namespace).List(labels.Set(svc.Spec.Selector).AsSelector()); err != nil {

--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -276,68 +276,72 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 // Update the endpoint IP address with the secondary IP address of the pod using the network attachment definition annotation
 // This is a temporary fix to allow consumers to use the secondary IP address of the pod
 // TODO: Remove this function and update the endpoint construction to use the secondary IP address of the pod
-func (c *Controller) replaceEndpointAddressesWithSecondaryIPs(endpointSlice []*discoveryv1.EndpointSlice, pods []*v1.Pod) error {
-	// store replaced endpoints in a map
-	replacedEndpoints := make(map[string]bool)
-	// store pod information in a map
+func (c *Controller) replaceEndpointAddressesWithSecondaryIPs(endpointSlices []*discoveryv1.EndpointSlice, pods []*v1.Pod) error {
+	// Track which pods have been processed
+	processedPods := make(map[string]bool)
+	// Store pod information in a map
 	podMap := make(map[string]*v1.Pod, len(pods))
 	for i := range pods {
 		podMap[pods[i].Name] = pods[i]
 	}
-	// iterate over all endpoint slices
-	for i, endpoint := range endpointSlice {
-		// iterate over all endpoints in the slice
+	// Pre-compute secondary IPs for all pods to avoid repeated annotation lookups
+	secondaryIPs := make(map[string]string, len(pods))
+	for _, pod := range pods {
+		providers, err := c.getPodProviders(pod)
+		if err != nil {
+			return err
+		}
+		if len(providers) > 0 {
+			ipAddress := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providers[0])]
+			if ipAddress != "" {
+				secondaryIPs[pod.Name] = ipAddress
+			}
+		}
+	}
+	// Process each endpoint slice
+	for i, endpoint := range endpointSlices {
+		var copiedSlice *discoveryv1.EndpointSlice
+		needsUpdate := false
+		// Check if any endpoints need updating first
 		for j, ep := range endpoint.Endpoints {
 			if ep.TargetRef != nil && ep.TargetRef.Kind == "Pod" {
 				podName := ep.TargetRef.Name
-				if pod, ok := podMap[podName]; ok {
-					// Retrieve all the providers of the pod
-					providers, err := c.getPodProviders(pod)
-					if err != nil {
-						return err
-					}
-					if len(providers) == 0 {
-						// pod has no providers
-						continue
-					}
-					// Get the network attachment definition associated IP address
-					// If multiple providers exist, use the first one.
-					ipAddress := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providers[0])]
-					if ipAddress == "" {
-						klog.Errorf("failed to get pod %s/%s ip address", pod.Namespace, pod.Name)
-						return fmt.Errorf("failed to get pod %s/%s ip address", pod.Namespace, pod.Name)
-					}
-					// Update the matching endpoint with the secondary IP address
-					found := false
-					for k, address := range ep.Addresses {
-						// skip if this specific endpoint has already been replaced
-						if replacedEndpoints[address] {
-							continue
-						}
-						// Endpoints received here are from cache and can be either primary or secondary network IP address
-						// Replace the primary network IP address with the secondary network IP address
-						// Secondary IP address is already seen when the endpoint has been already created/updated
-						if address == pod.Status.PodIP || address == ipAddress {
-							klog.Infof("updating pod %s/%s ip address %s to %s", pod.Namespace, pod.Name, pod.Status.PodIP, ipAddress)
-							// deep copy the EndpointSlice object before modifying
-							copiedEndpointSlice := endpointSlice[i].DeepCopy()
-							// update the endpoint IP address with the secondary IP address
-							copiedEndpointSlice.Endpoints[j].Addresses[k] = ipAddress
-							// mark this specific endpoint position as replaced
-							replacedEndpoints[ipAddress] = true
-							// replace the original slice with the modified copy
-							endpointSlice[i] = copiedEndpointSlice
-							found = true
-							break
+				// Skip if already processed this pod
+				// Include slice index to handle pod in multiple slices
+				podKey := fmt.Sprintf("%s/%d", podName, i)
+				if processedPods[podKey] {
+					continue
+				}
+				if secondaryIP, hasSecondaryIP := secondaryIPs[podName]; hasSecondaryIP {
+					if pod, ok := podMap[podName]; ok {
+						// Check if any address needs replacement
+						for k, address := range ep.Addresses {
+							// Only replace if it's the primary IP
+							if address == pod.Status.PodIP {
+								// Lazy deep copy
+								if !needsUpdate {
+									copiedSlice = endpoint.DeepCopy()
+									needsUpdate = true
+								}
+								klog.Infof("updating pod %s/%s ip address %s to %s",
+									pod.Namespace, pod.Name, pod.Status.PodIP, secondaryIP)
+								copiedSlice.Endpoints[j].Addresses[k] = secondaryIP
+								processedPods[podKey] = true
+								// Only one primary IP per endpoint
+								break
+							} else if address == secondaryIP {
+								// Already has secondary IP, mark as processed
+								processedPods[podKey] = true
+								break
+							}
 						}
 					}
-					// We should always find the pod IP address in the endpoint slice
-					if !found {
-						return fmt.Errorf("failed to find pod %s/%s ip address %s in endpoint slice %s", pod.Namespace, pod.Name, pod.Status.PodIP, endpointSlice[i].Name)
-					}
-					break
 				}
 			}
+		}
+		// Replace the slice if we made changes
+		if needsUpdate {
+			endpointSlices[i] = copiedSlice
 		}
 	}
 

--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -133,7 +133,7 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 
 	// If Kube-OVN is running in secondary CNI mode, the endpoint IPs should be derived from the network attachment definitions
 	// This overwrite can be removed if endpoint construction accounts for network attachment IP address
-	// TODO: Identify how endpoints are constructed, by deafult, endpoints has IP address of eth0 inteface
+	// TODO: Identify how endpoints are constructed, by default, endpoints has IP address of eth0 inteface
 	if c.config.EnableNonPrimaryCNI {
 		var pods []*v1.Pod
 		if pods, err = c.podsLister.Pods(namespace).List(labels.Set(svc.Spec.Selector).AsSelector()); err != nil {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2444,30 +2444,3 @@ func setPodRoutesAnnotation(annotations map[string]string, provider string, rout
 
 	return nil
 }
-
-func (c *Controller) getNadInterfaceFromNetworkStatusAnnotation(networkStatus string, nadName string) (string, error) {
-	var interfaceName string
-	if networkStatus == "" {
-		return "", errors.New("no network status annotation found")
-	}
-
-	var status []map[string]interface{}
-	if err := json.Unmarshal([]byte(networkStatus), &status); err != nil {
-		klog.Errorf("failed to unmarshal network status annotation: %v", err)
-		return interfaceName, err
-	}
-
-	for _, s := range status {
-		if s["name"] == nadName {
-			if iface, ok := s["interface"].(string); ok {
-				interfaceName = iface
-			}
-			break
-		}
-	}
-	if interfaceName == "" {
-		return "", fmt.Errorf("no interface name found for secondary network %s", nadName)
-	}
-
-	return interfaceName, nil
-}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2448,7 +2448,7 @@ func setPodRoutesAnnotation(annotations map[string]string, provider string, rout
 func (c *Controller) getNadInterfaceFromNetworkStatusAnnotation(networkStatus string, nadName string) (string, error) {
 	var interfaceName string
 	if networkStatus == "" {
-		return "", fmt.Errorf("no network status annotation found for pod")
+		return "", errors.New("no network status annotation found")
 	}
 
 	var status []map[string]interface{}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2433,15 +2433,19 @@ func (c *Controller) checkIsPodVpcNatGw(pod *v1.Pod) (bool, string) {
 	}
 	// default provider
 	providerName := util.OvnProvider
-	// get providers
-	providers, err := c.getPodProviders(pod)
-	if err != nil {
-		klog.Errorf("failed to get pod %s/%s providers, %v", pod.Namespace, pod.Name, err)
-		return false, ""
-	}
-	if len(providers) > 0 {
-		// use the first provider
-		providerName = providers[0]
+	// In non-primary CNI mode, we get the providers from the pod annotations
+	// We get the vpc nat gw name using the provider name
+	if c.config.EnableNonPrimaryCNI {
+		// get providers
+		providers, err := c.getPodProviders(pod)
+		if err != nil {
+			klog.Errorf("failed to get pod %s/%s providers, %v", pod.Namespace, pod.Name, err)
+			return false, ""
+		}
+		if len(providers) > 0 {
+			// use the first provider
+			providerName = providers[0]
+		}
 	}
 	vpcGwName, isVpcNatGw := pod.Annotations[fmt.Sprintf(util.VpcNatGatewayAnnotationTemplate, providerName)]
 	if isVpcNatGw {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -533,19 +533,8 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 		}
 	}
 
-	providerName := util.OvnProvider
-	// In non-primary CNI mode, we extract the provider from the pod's annotation.
-	if c.config.EnableNonPrimaryCNI {
-		// get providers
-		providers, err := c.getPodProviders(pod)
-		if err != nil || len(providers) == 0 {
-			klog.Warningf("no pod providers found for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		} else {
-			// use the first provider
-			providerName = providers[0]
-		}
-	}
-	if vpcGwName, isVpcNatGw := pod.Annotations[fmt.Sprintf(util.VpcNatGatewayAnnotationTemplate, providerName)]; isVpcNatGw {
+	isVpcNatGw, vpcGwName := c.checkIsPodVpcNatGw(pod)
+	if isVpcNatGw {
 		if needRestartNatGatewayPod(pod) {
 			klog.Infof("restarting vpc nat gateway %s", vpcGwName)
 			c.addOrUpdateVpcNatGatewayQueue.Add(vpcGwName)
@@ -723,19 +712,8 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	}
 
 	// Check if pod is a vpc nat gateway. Annotation set will have subnet provider name as prefix
-	providerName := util.OvnProvider
-	// In non-primary CNI mode, we extract the provider from the pod's annotation.
-	if c.config.EnableNonPrimaryCNI {
-		// get providers
-		providers, err := c.getPodProviders(pod)
-		if err != nil || len(providers) == 0 {
-			klog.Warningf("no pod providers found for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		} else {
-			// use the first provider
-			providerName = providers[0]
-		}
-	}
-	if vpcGwName, isVpcNatGw := pod.Annotations[fmt.Sprintf(util.VpcNatGatewayAnnotationTemplate, providerName)]; isVpcNatGw {
+	isVpcNatGw, vpcGwName := c.checkIsPodVpcNatGw(pod)
+	if isVpcNatGw {
 		klog.Infof("init vpc nat gateway pod %s/%s with name %s", namespace, name, vpcGwName)
 		c.initVpcNatGatewayQueue.Add(vpcGwName)
 	}
@@ -2443,4 +2421,35 @@ func setPodRoutesAnnotation(annotations map[string]string, provider string, rout
 	annotations[key] = string(buf)
 
 	return nil
+}
+
+// Check if pod is a VPC NAT gateway using pod annotations
+func (c *Controller) checkIsPodVpcNatGw(pod *v1.Pod) (bool, string) {
+	if pod == nil {
+		return false, ""
+	}
+	if pod.Annotations == nil {
+		return false, ""
+	}
+	// default provider
+	providerName := util.OvnProvider
+	// get providers
+	providers, err := c.getPodProviders(pod)
+	if err != nil {
+		klog.Errorf("failed to get pod %s/%s providers, %v", pod.Namespace, pod.Name, err)
+		return false, ""
+	}
+	if len(providers) > 0 {
+		// use the first provider
+		providerName = providers[0]
+	}
+	vpcGwName, isVpcNatGw := pod.Annotations[fmt.Sprintf(util.VpcNatGatewayAnnotationTemplate, providerName)]
+	if isVpcNatGw {
+		if vpcGwName == "" {
+			klog.Errorf("pod %s is vpc nat gateway but name is empty", pod.Name)
+			return false, ""
+		}
+		klog.Infof("pod %s is vpc nat gateway %s", pod.Name, vpcGwName)
+	}
+	return isVpcNatGw, vpcGwName
 }

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -709,9 +709,14 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		return nil, err
 	}
 
-	if vpcGwName, isVpcNatGw := pod.Annotations[util.VpcNatGatewayAnnotation]; isVpcNatGw {
-		c.initVpcNatGatewayQueue.Add(vpcGwName)
+	// Check if pod is a vpc nat gateway. Annotation set will have subnet provider name as prefix
+	for _, podNet := range needAllocatePodNets {
+		if vpcGwName, isVpcNatGw := pod.Annotations[fmt.Sprintf(util.VpcNatGatewayAnnotationTemplate, podNet.ProviderName)]; isVpcNatGw {
+			c.initVpcNatGatewayQueue.Add(vpcGwName)
+			break
+		}
 	}
+
 	return pod, nil
 }
 

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -825,7 +825,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 	}
 
 	subnetProvider := util.OvnProvider
-	if c.config.EnableSecondaryCNI {
+	if c.config.EnableNonPrimaryCNI {
 		// We specify NAD using annotations when Kube-OVN is running as a secondary CNI
 		var attachedNetworks string
 		// Get NetworkAttachmentDefinition if specified by user from pod annotations

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -327,7 +327,7 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 		externalNadNs, externalNadName := c.getExternalSubnetNad(gw)
 		networkStatusAnnotations := pod.Annotations[nadv1.NetworkStatusAnnot]
 		externalNadFullName := fmt.Sprintf("%s/%s", externalNadNs, externalNadName)
-		externalNadIfName, err := c.getNadInterfaceFromNetworkStatusAnnotation(networkStatusAnnotations, externalNadFullName)
+		externalNadIfName, err := util.GetNadInterfaceFromNetworkStatusAnnotation(networkStatusAnnotations, externalNadFullName)
 		if err != nil {
 			klog.Errorf("failed to extract external nad interface name from annotations %v, %v", gw.Annotations, err)
 			return err
@@ -347,7 +347,7 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 		}
 		vpcNadName, vpcNadNamespace := providerParts[0], providerParts[1]
 		vpcNadFullName := fmt.Sprintf("%s/%s", vpcNadNamespace, vpcNadName)
-		vpcNadIfName, err := c.getNadInterfaceFromNetworkStatusAnnotation(networkStatusAnnotations, vpcNadFullName)
+		vpcNadIfName, err := util.GetNadInterfaceFromNetworkStatusAnnotation(networkStatusAnnotations, vpcNadFullName)
 		if err != nil {
 			klog.Errorf("failed to extract internal nad interface name from annotations %v, %v", gw.Annotations, err)
 			return err

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -952,7 +952,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 		routes = append(routes, request.Route{Destination: route.CIDR, Gateway: nexthop})
 	}
 
-	if err = setPodRoutesAnnotation(annotations, util.OvnProvider, routes); err != nil {
+	if err = setPodRoutesAnnotation(annotations, subnetProvider, routes); err != nil {
 		klog.Error(err)
 		return nil, err
 	}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -25,6 +25,7 @@ const (
 	ActivationStrategyAnnotation = "ovn.kubernetes.io/activation_strategy"
 
 	VpcNatGatewayAnnotation                 = "ovn.kubernetes.io/vpc_nat_gw"
+	VpcNatGatewayAnnotationTemplate         = "%s.kubernetes.io/vpc_nat_gw"
 	VpcNatGatewayInitAnnotation             = "ovn.kubernetes.io/vpc_nat_gw_init"
 	VpcNatGatewayContainerRestartAnnotation = "ovn.kubernetes.io/vpc_nat_gw_container_restarted"
 	VpcNatGatewayActivatedAnnotation        = "ovn.kubernetes.io/vpc_nat_gw_activated"
@@ -33,6 +34,7 @@ const (
 	VpcDnatMd5Annotation                    = "ovn.kubernetes.io/vpc_dnat_md5"
 	VpcSnatMd5Annotation                    = "ovn.kubernetes.io/vpc_snat_md5"
 	VpcCIDRsAnnotation                      = "ovn.kubernetes.io/vpc_cidrs"
+	VpcCIDRsAnnotationTemplate              = "%s.kubernetes.io/vpc_cidrs"
 	VpcLbAnnotation                         = "ovn.kubernetes.io/vpc_lb"
 	VpcExternalLabel                        = "ovn.kubernetes.io/vpc_external"
 	VpcEipAnnotation                        = "ovn.kubernetes.io/vpc_eip"

--- a/pkg/util/network_attachment.go
+++ b/pkg/util/network_attachment.go
@@ -35,7 +35,7 @@ func GetNadInterfaceFromNetworkStatusAnnotation(networkStatus string, nadName st
 		return "", errors.New("no network status annotation found")
 	}
 
-	var status []map[string]interface{}
+	var status []map[string]any
 	if err := json.Unmarshal([]byte(networkStatus), &status); err != nil {
 		klog.Errorf("failed to unmarshal network status annotation: %v", err)
 		return interfaceName, err

--- a/pkg/util/network_attachment.go
+++ b/pkg/util/network_attachment.go
@@ -1,10 +1,13 @@
 package util
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
+	"k8s.io/klog/v2"
 )
 
 func IsOvnNetwork(netCfg *types.DelegateNetConf) bool {
@@ -24,4 +27,31 @@ func IsDefaultNet(defaultNetAnnotation string, attach *nadv1.NetworkSelectionEle
 		return true
 	}
 	return false
+}
+
+func GetNadInterfaceFromNetworkStatusAnnotation(networkStatus string, nadName string) (string, error) {
+	var interfaceName string
+	if networkStatus == "" {
+		return "", errors.New("no network status annotation found")
+	}
+
+	var status []map[string]interface{}
+	if err := json.Unmarshal([]byte(networkStatus), &status); err != nil {
+		klog.Errorf("failed to unmarshal network status annotation: %v", err)
+		return interfaceName, err
+	}
+
+	for _, s := range status {
+		if s["name"].(string) == nadName {
+			if iface, ok := s["interface"].(string); ok {
+				interfaceName = iface
+			}
+			break
+		}
+	}
+	if interfaceName == "" {
+		return "", fmt.Errorf("no interface name found for secondary network %s", nadName)
+	}
+
+	return interfaceName, nil
 }

--- a/pkg/util/network_attachment.go
+++ b/pkg/util/network_attachment.go
@@ -42,7 +42,7 @@ func GetNadInterfaceFromNetworkStatusAnnotation(networkStatus string, nadName st
 	}
 
 	for _, s := range status {
-		if s["name"].(string) == nadName {
+		if name, ok := s["name"].(string); ok && name == nadName {
 			if iface, ok := s["interface"].(string); ok {
 				interfaceName = iface
 			}

--- a/pkg/util/network_attachment.go
+++ b/pkg/util/network_attachment.go
@@ -29,7 +29,7 @@ func IsDefaultNet(defaultNetAnnotation string, attach *nadv1.NetworkSelectionEle
 	return false
 }
 
-func GetNadInterfaceFromNetworkStatusAnnotation(networkStatus string, nadName string) (string, error) {
+func GetNadInterfaceFromNetworkStatusAnnotation(networkStatus, nadName string) (string, error) {
 	var interfaceName string
 	if networkStatus == "" {
 		return "", errors.New("no network status annotation found")


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
- Features

The changes enable handling of secondary IP addresses by updating endpoints, NAT gateway configuration, pod network extraction, and associated scripts when non-primary CNI mode is activated.

- endpoint_slice.go: Introduced a function to replace endpoint addresses with pod secondary IPs and added logic in endpoint update handlers to support non-primary CNI mode.
- vpc_nat_gateway.go: Updated NAT gateway initialization and StatefulSet generation to extract network interface names from annotations, configure interfaces for secondary CNI, and added a helper function for retrieving the subnet provider.
- nat-gateway.sh: Revised the NAT gateway script to support custom VPC and external interfaces through validated input and persistent configuration.
- pod.go: Added functionality to extract NAD interface names from network status annotations and adjusted pod network extraction to bypass default networks in non-primary CNI mode.
- config.go and const.go: Added a configuration flag for non-primary CNI mode and updated related annotation templates.

## Which issue(s) this PR fixes
Attempt to support #5360
