### PR TITLE
fix bug for issuse #5597: when slr update, the same vip will be delete too

### DIFF
--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -348,20 +348,19 @@ func (c *Controller) handleUpdateService(svcObject *updateSvcObject) error {
 
 	if needUpdateEndpointQueue {
 		c.addOrUpdateEndpointSliceQueue.Add(key)
-
-		// add the svc key which has the same vip
-		vip, ok := svc.Annotations[util.SwitchLBRuleVipsAnnotation]
-		if ok {
-			allSlrs, err := c.switchLBRuleLister.List(labels.Everything())
-			if err != nil {
-				klog.Error(err)
-				return err
-			}
-			for _, slr := range allSlrs {
-				if slr.Spec.Vip == vip {
-					slrKey := fmt.Sprintf("%s/slr-%s", svc.Namespace, slr.Name)
-					c.addOrUpdateEndpointSliceQueue.Add(slrKey)
-				}
+	}
+	// add the svc key which has the same vip
+	vip, ok := svc.Annotations[util.SwitchLBRuleVipsAnnotation]
+	if ok {
+		allSlrs, err := c.switchLBRuleLister.List(labels.Everything())
+		if err != nil {
+			klog.Error(err)
+			return err
+		}
+		for _, slr := range allSlrs {
+			if slr.Spec.Vip == vip {
+				slrKey := fmt.Sprintf("%s/slr-%s", slr.Spec.Namespace, slr.Name)
+				c.addOrUpdateEndpointSliceQueue.Add(slrKey)
 			}
 		}
 	}


### PR DESCRIPTION
…e too

# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
修复复用VIP的bug，之前的改动逻辑只有新增slr时才会将相同vip的规则过滤并添加到endpointslice更新队列中，这样仍然不够，当slr更新事件发生时，还是会误删VIP规则，现在修改为无论是新增slr还是更新slr，都要过滤所有相同vip的slr，并添加相应的key到endpointslice更新队列中，从而保证最终LB上的VIP规则是准确的
## Which issue(s) this PR fixes

Fixes #5597
