### PR TITLE
Deep copy informer objects before mutation

### DIFF
--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -555,6 +555,10 @@ func diffSvcPorts(oldPorts, newPorts []v1.ServicePort) (toDel []v1.ServicePort) 
 }
 
 func (c *Controller) checkServiceLBIPBelongToSubnet(svc *v1.Service) error {
+	svc = svc.DeepCopy()
+	if svc.Annotations == nil {
+		svc.Annotations = map[string]string{}
+	}
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets: %v", err)

--- a/pkg/controller/switch_lb_rule.go
+++ b/pkg/controller/switch_lb_rule.go
@@ -330,6 +330,9 @@ func generateHeadlessService(slr *kubeovnv1.SwitchLBRule, oldSvc *corev1.Service
 
 	if oldSvc != nil {
 		newSvc = oldSvc.DeepCopy()
+		if newSvc.Annotations == nil {
+			newSvc.Annotations = map[string]string{}
+		}
 		newSvc.Name = name
 		newSvc.Namespace = slr.Spec.Namespace
 		newSvc.Annotations[util.SwitchLBRuleVipsAnnotation] = slr.Spec.Vip

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -417,6 +417,9 @@ func (c *Controller) podReuseVip(vipName, portName string, keepVIP bool) error {
 		return err
 	}
 	vip := oriVip.DeepCopy()
+	if vip.Labels == nil {
+		vip.Labels = map[string]string{}
+	}
 	var op string
 
 	if vip.Labels[util.IPReservedLabel] != "" {

--- a/pkg/controller/vpc_dns.go
+++ b/pkg/controller/vpc_dns.go
@@ -402,6 +402,9 @@ func setVpcDNSRoute(dp *v1.Deployment, subnetGw string) {
 			if err != nil {
 				klog.Errorf("failed to marshal routes %+v: %v", routes, err)
 			} else {
+				if dp.Spec.Template.Annotations == nil {
+					dp.Spec.Template.Annotations = map[string]string{}
+				}
 				dp.Spec.Template.Annotations[fmt.Sprintf(util.RoutesAnnotationTemplate, nadProvider)] = string(buf)
 			}
 			break

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -390,6 +390,9 @@ func (csh cniServerHandler) UpdateIPCR(podRequest request.CniRequest, subnet, ip
 			klog.Error(err)
 		} else if ipCR.Spec.NodeName != csh.Config.NodeName {
 			ipCR := ipCR.DeepCopy()
+			if ipCR.Labels == nil {
+				ipCR.Labels = map[string]string{}
+			}
 			ipCR.Spec.NodeName = csh.Config.NodeName
 			ipCR.Spec.AttachIPs = []string{}
 			ipCR.Labels[subnet] = ""


### PR DESCRIPTION
## Summary
- deep copy IP object in handleAddReservedIP before modifying labels
- deep copy Service in checkServiceLBIPBelongToSubnet and initialize annotations
- guard annotation/label maps in SwitchLBRule, VIP reuse, VPC DNS route setup, and IPCR updates

## Testing
- `go test ./pkg/controller/... ./pkg/daemon/...` *(hang, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ac168a4170832ca53e5c2c01266c0a

fix #5641