### PR TITLE
fix vpc-dns annotations update revision

### DIFF
--- a/pkg/controller/vpc_dns.go
+++ b/pkg/controller/vpc_dns.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"reflect"
 	"strconv"
@@ -221,7 +220,7 @@ func (c *Controller) createOrUpdateVpcDNSDep(vpcDNS *kubeovnv1.VpcDns) error {
 		deploy = nil
 	}
 
-	newDp, err := c.genVpcDNSDeployment(vpcDNS, deploy)
+	newDp, err := c.genVpcDNSDeployment(vpcDNS)
 	if err != nil {
 		klog.Errorf("failed to generate vpc-dns deployment, %v", err)
 		return err
@@ -288,7 +287,7 @@ func (c *Controller) createOrUpdateVpcDNSSlr(vpcDNS *kubeovnv1.VpcDns) error {
 	return nil
 }
 
-func (c *Controller) genVpcDNSDeployment(vpcDNS *kubeovnv1.VpcDns, oldDeploy *v1.Deployment) (*v1.Deployment, error) {
+func (c *Controller) genVpcDNSDeployment(vpcDNS *kubeovnv1.VpcDns) (*v1.Deployment, error) {
 	tmp := template.New("coredns")
 	tmp, err := tmp.Parse(corednsTemplateContent)
 	if err != nil {
@@ -318,10 +317,6 @@ func (c *Controller) genVpcDNSDeployment(vpcDNS *kubeovnv1.VpcDns, oldDeploy *v1
 	}
 
 	dep.Spec.Template.Annotations = make(map[string]string)
-
-	if oldDeploy != nil && len(oldDeploy.Annotations) != 0 {
-		dep.Spec.Template.Annotations = maps.Clone(oldDeploy.Annotations)
-	}
 
 	dep.Labels = map[string]string{
 		util.VpcDNSNameLabel: "true",


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

目前发现，每次kube-ovn-controller重启都会导致vpc-dns的pod自动跟着重启，看代码发现每次都会执行`dep.Spec.Template.Annotations = maps.Clone(oldDeploy.Annotations)`，会将原有deploy的注释赋值给新deploy的template上，感觉这个逻辑不太对。
Deploy里只有一个自动生成的注释是`deployment.kubernetes.io/revision`，现有逻辑会造成模板注释中会存在一个旧版本的revision注释，每次ovn-controller重启时都会调用一次update，但vpc-dns的参数没有任何变化，这时不应该重启pod。但是因为deploy模板中存在`deployment.kubernetes.io/revision`，会导致每次都更新，且版本永远是上一个。
<img width="1085" height="760" alt="xxx" src="https://github.com/user-attachments/assets/fcfdee7a-c013-4150-b41d-c9da8849d806" />


