### PR TITLE
fix bug for issue #5665 : vpc egress gateway error when internal subnet cidr equals to policy cidr

### DIFF
--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -357,15 +357,17 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 	// add routes for the VPC BFD Port so that the egress gateway can establish BFD session(s) with it
 	routes.Add(util.OvnProvider, bfdIPv4, intGatewayIPv4)
 	routes.Add(util.OvnProvider, bfdIPv6, intGatewayIPv6)
+
+	ipv4Cidr, ipv6Cidr := util.SplitStringIP(intSubnet.Spec.CIDRBlock)
 	// add routes for the internal networks
 	for _, dst := range intRouteDstIPv4.UnsortedList() {
-		if intSubnet.Spec.CIDRBlock == dst {
+		if ipv4Cidr == dst {
 			continue
 		}
 		routes.Add(util.OvnProvider, dst, intGatewayIPv4)
 	}
 	for _, dst := range intRouteDstIPv6.UnsortedList() {
-		if intSubnet.Spec.CIDRBlock == dst {
+		if ipv6Cidr == dst {
 			continue
 		}
 		routes.Add(util.OvnProvider, dst, intGatewayIPv6)

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -359,9 +359,15 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 	routes.Add(util.OvnProvider, bfdIPv6, intGatewayIPv6)
 	// add routes for the internal networks
 	for _, dst := range intRouteDstIPv4.UnsortedList() {
+		if intSubnet.Spec.CIDRBlock == dst {
+			continue
+		}
 		routes.Add(util.OvnProvider, dst, intGatewayIPv4)
 	}
 	for _, dst := range intRouteDstIPv6.UnsortedList() {
+		if intSubnet.Spec.CIDRBlock == dst {
+			continue
+		}
 		routes.Add(util.OvnProvider, dst, intGatewayIPv6)
 	}
 	// add default routes to forward traffic to the external network


### PR DESCRIPTION

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes
vpc_egress_gateway.go

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
Before adding annotation for routes, skip when internal subnet CIDR equals to policy CIDR

## Which issue(s) this PR fixes

Fixes #5665
