### PR TITLE
controller: fix lsp not deleted in gc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2
+	github.com/go-logr/zapr v1.3.0
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0
 	github.com/httprunner/httprunner/v5 v5.0.0-20250818135001-47996ed22fb1
@@ -48,6 +49,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
 	go.uber.org/mock v0.6.0
+	go.uber.org/zap v1.27.0
 	go.universe.tf/metallb v0.15.2
 	golang.org/x/mod v0.28.0
 	golang.org/x/net v0.44.0
@@ -325,7 +327,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.21.0 // indirect

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -1080,6 +1080,20 @@ func (mr *MockLogicalSwitchPortMockRecorder) DeleteLogicalSwitchPort(lspName any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPort", reflect.TypeOf((*MockLogicalSwitchPort)(nil).DeleteLogicalSwitchPort), lspName)
 }
 
+// DeleteLogicalSwitchPortByUUID mocks base method.
+func (m *MockLogicalSwitchPort) DeleteLogicalSwitchPortByUUID(lsName, lspUUID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLogicalSwitchPortByUUID", lsName, lspUUID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLogicalSwitchPortByUUID indicates an expected call of DeleteLogicalSwitchPortByUUID.
+func (mr *MockLogicalSwitchPortMockRecorder) DeleteLogicalSwitchPortByUUID(lsName, lspUUID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPortByUUID", reflect.TypeOf((*MockLogicalSwitchPort)(nil).DeleteLogicalSwitchPortByUUID), lsName, lspUUID)
+}
+
 // DeleteLogicalSwitchPorts mocks base method.
 func (m *MockLogicalSwitchPort) DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(*ovnnb.LogicalSwitchPort) bool) error {
 	m.ctrl.T.Helper()
@@ -3772,6 +3786,20 @@ func (m *MockNbClient) DeleteLogicalSwitchPort(lspName string) error {
 func (mr *MockNbClientMockRecorder) DeleteLogicalSwitchPort(lspName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPort", reflect.TypeOf((*MockNbClient)(nil).DeleteLogicalSwitchPort), lspName)
+}
+
+// DeleteLogicalSwitchPortByUUID mocks base method.
+func (m *MockNbClient) DeleteLogicalSwitchPortByUUID(lsName, lspUUID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLogicalSwitchPortByUUID", lsName, lspUUID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLogicalSwitchPortByUUID indicates an expected call of DeleteLogicalSwitchPortByUUID.
+func (mr *MockNbClientMockRecorder) DeleteLogicalSwitchPortByUUID(lsName, lspUUID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogicalSwitchPortByUUID", reflect.TypeOf((*MockNbClient)(nil).DeleteLogicalSwitchPortByUUID), lsName, lspUUID)
 }
 
 // DeleteLogicalSwitchPorts mocks base method.

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -489,8 +489,8 @@ func (c *Controller) markAndCleanLSP() error {
 			continue
 		}
 
-		klog.Infof("gc logical switch port %s", lsp.Name)
-		if err := c.OVNNbClient.DeleteLogicalSwitchPort(lsp.Name); err != nil {
+		klog.Infof("gc logical switch port %s with uuid %s", lsp.Name, lsp.UUID)
+		if err := c.OVNNbClient.DeleteLogicalSwitchPortByUUID(lsp.ExternalIDs[ovs.LogicalSwitchKey], lsp.UUID); err != nil {
 			klog.Errorf("failed to delete lsp %s: %v", lsp.Name, err)
 			return err
 		}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -104,6 +104,7 @@ type LogicalSwitchPort interface {
 	SetLogicalSwitchPortsSecurityGroup(sgName, op string) error
 	EnablePortLayer2forward(lspName string) error
 	DeleteLogicalSwitchPort(lspName string) error
+	DeleteLogicalSwitchPortByUUID(lsName, lspUUID string) error
 	DeleteLogicalSwitchPorts(externalIDs map[string]string, filter func(lsp *ovnnb.LogicalSwitchPort) bool) error
 	ListLogicalSwitchPorts(needVendorFilter bool, externalIDs map[string]string, filter func(lsp *ovnnb.LogicalSwitchPort) bool) ([]ovnnb.LogicalSwitchPort, error)
 	ListNormalLogicalSwitchPorts(needVendorFilter bool, externalIDs map[string]string) ([]ovnnb.LogicalSwitchPort, error)

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -181,7 +181,7 @@ func (c *OVNNbClient) CreateGatewayACL(lsName, pgName, gateway, u2oInterconnecti
 	case len(pgName) != 0:
 		parentName, parentType = pgName, portGroupKey
 	case len(lsName) != 0:
-		parentName, parentType = lsName, logicalSwitchKey
+		parentName, parentType = lsName, LogicalSwitchKey
 	default:
 		return errors.New("one of port group name and logical switch name must be specified")
 	}
@@ -472,7 +472,7 @@ func (c *OVNNbClient) UpdateSgACL(sg *kubeovnv1.SecurityGroup, direction string)
 
 func (c *OVNNbClient) UpdateLogicalSwitchACL(lsName, cidrBlock string, subnetAcls []kubeovnv1.ACL, allowEWTraffic bool) error {
 	if len(subnetAcls) == 0 {
-		if err := c.DeleteAcls(lsName, logicalSwitchKey, "", map[string]string{"subnet": lsName}); err != nil {
+		if err := c.DeleteAcls(lsName, LogicalSwitchKey, "", map[string]string{"subnet": lsName}); err != nil {
 			klog.Error(err)
 			return fmt.Errorf("delete subnet acls from %s: %w", lsName, err)
 		}
@@ -529,13 +529,13 @@ func (c *OVNNbClient) UpdateLogicalSwitchACL(lsName, cidrBlock string, subnetAcl
 		acls = append(acls, acl)
 	}
 
-	delOps, err := c.DeleteAclsOps(lsName, logicalSwitchKey, "", map[string]string{"subnet": lsName})
+	delOps, err := c.DeleteAclsOps(lsName, LogicalSwitchKey, "", map[string]string{"subnet": lsName})
 	if err != nil {
 		klog.Error(err)
 		return err
 	}
 
-	addOps, err := c.CreateAclsOps(lsName, logicalSwitchKey, acls...)
+	addOps, err := c.CreateAclsOps(lsName, LogicalSwitchKey, acls...)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -572,7 +572,7 @@ func (c *OVNNbClient) UpdateACL(acl *ovnnb.ACL, fields ...any) error {
 // SetLogicalSwitchPrivate will drop all ingress traffic except allow subnets, same subnet and node subnet
 func (c *OVNNbClient) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR string, allowSubnets []string) error {
 	// clear acls
-	if err := c.DeleteAcls(lsName, logicalSwitchKey, "", nil); err != nil {
+	if err := c.DeleteAcls(lsName, LogicalSwitchKey, "", nil); err != nil {
 		klog.Error(err)
 		return fmt.Errorf("clear logical switch %s acls: %w", lsName, err)
 	}
@@ -687,7 +687,7 @@ func (c *OVNNbClient) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR 
 		}
 	}
 
-	if err := c.CreateAcls(lsName, logicalSwitchKey, acls...); err != nil {
+	if err := c.CreateAcls(lsName, LogicalSwitchKey, acls...); err != nil {
 		klog.Error(err)
 		return fmt.Errorf("add ingress acls to logical switch %s: %w", lsName, err)
 	}
@@ -1174,8 +1174,8 @@ func aclFilter(direction string, externalIDs map[string]string) func(acl *ovnnb.
 // CreateAcls return operations which create several acl once
 // parentType is 'ls' or 'pg'
 func (c *OVNNbClient) CreateAclsOps(parentName, parentType string, acls ...*ovnnb.ACL) ([]ovsdb.Operation, error) {
-	if parentType != portGroupKey && parentType != logicalSwitchKey {
-		return nil, fmt.Errorf("acl parent type must be '%s' or '%s'", portGroupKey, logicalSwitchKey)
+	if parentType != portGroupKey && parentType != LogicalSwitchKey {
+		return nil, fmt.Errorf("acl parent type must be '%s' or '%s'", portGroupKey, LogicalSwitchKey)
 	}
 
 	if len(acls) == 0 {

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -1360,7 +1360,7 @@ func (suite *OvnClientTestSuite) testCreateAcls() {
 			acls = append(acls, acl)
 		}
 
-		err = nbClient.CreateAcls(lsName, logicalSwitchKey, append(acls, nil)...)
+		err = nbClient.CreateAcls(lsName, LogicalSwitchKey, append(acls, nil)...)
 		require.NoError(t, err)
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
@@ -1503,14 +1503,14 @@ func (suite *OvnClientTestSuite) testDeleteAcls() {
 			acls = append(acls, acl)
 		}
 
-		err = nbClient.CreateAcls(lsName, logicalSwitchKey, acls...)
+		err = nbClient.CreateAcls(lsName, LogicalSwitchKey, acls...)
 		require.NoError(t, err)
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
 		require.NoError(t, err)
 		require.Len(t, ls.ACLs, 5)
 
-		err = nbClient.DeleteAcls(lsName, logicalSwitchKey, "", nil)
+		err = nbClient.DeleteAcls(lsName, LogicalSwitchKey, "", nil)
 		require.NoError(t, err)
 
 		ls, err = nbClient.GetLogicalSwitch(lsName, false)
@@ -1539,7 +1539,7 @@ func (suite *OvnClientTestSuite) testDeleteAcls() {
 			acls = append(acls, acl)
 		}
 
-		err = nbClient.CreateAcls(lsName, logicalSwitchKey, acls...)
+		err = nbClient.CreateAcls(lsName, LogicalSwitchKey, acls...)
 		require.NoError(t, err)
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
@@ -1547,7 +1547,7 @@ func (suite *OvnClientTestSuite) testDeleteAcls() {
 		require.Len(t, ls.ACLs, 5)
 
 		/* delete to-lport direction acl */
-		err = nbClient.DeleteAcls(lsName, logicalSwitchKey, ovnnb.ACLDirectionToLport, nil)
+		err = nbClient.DeleteAcls(lsName, LogicalSwitchKey, ovnnb.ACLDirectionToLport, nil)
 		require.NoError(t, err)
 
 		ls, err = nbClient.GetLogicalSwitch(lsName, false)
@@ -1555,7 +1555,7 @@ func (suite *OvnClientTestSuite) testDeleteAcls() {
 		require.Len(t, ls.ACLs, 3)
 
 		/* delete from-lport direction acl */
-		err = nbClient.DeleteAcls(lsName, logicalSwitchKey, ovnnb.ACLDirectionFromLport, nil)
+		err = nbClient.DeleteAcls(lsName, LogicalSwitchKey, ovnnb.ACLDirectionFromLport, nil)
 		require.NoError(t, err)
 
 		ls, err = nbClient.GetLogicalSwitch(lsName, false)
@@ -1580,7 +1580,7 @@ func (suite *OvnClientTestSuite) testDeleteAcls() {
 		require.NoError(t, err)
 		acls = append(acls, acl)
 
-		err = nbClient.CreateAcls(lsName, logicalSwitchKey, acls...)
+		err = nbClient.CreateAcls(lsName, LogicalSwitchKey, acls...)
 		require.NoError(t, err)
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
@@ -1592,7 +1592,7 @@ func (suite *OvnClientTestSuite) testDeleteAcls() {
 		require.NoError(t, err)
 
 		/* delete to-lport direction acl */
-		err = nbClient.DeleteAcls(lsName, logicalSwitchKey, ovnnb.ACLDirectionToLport, map[string]string{"subnet": lsName})
+		err = nbClient.DeleteAcls(lsName, LogicalSwitchKey, ovnnb.ACLDirectionToLport, map[string]string{"subnet": lsName})
 		require.NoError(t, err)
 
 		ls, err = nbClient.GetLogicalSwitch(lsName, false)
@@ -1601,7 +1601,7 @@ func (suite *OvnClientTestSuite) testDeleteAcls() {
 	})
 
 	t.Run("should no err when acls does not exist", func(t *testing.T) {
-		err = nbClient.DeleteAcls("test-nonexist-ls", logicalSwitchKey, ovnnb.ACLDirectionToLport, map[string]string{"subnet": "test-nonexist-ls"})
+		err = nbClient.DeleteAcls("test-nonexist-ls", LogicalSwitchKey, ovnnb.ACLDirectionToLport, map[string]string{"subnet": "test-nonexist-ls"})
 		require.NoError(t, err)
 	})
 
@@ -1620,10 +1620,10 @@ func (suite *OvnClientTestSuite) testDeleteAcls() {
 		require.NoError(t, err)
 		acls = append(acls, acl)
 
-		err = failedNbClient.CreateAcls(lsName, logicalSwitchKey, acls...)
+		err = failedNbClient.CreateAcls(lsName, LogicalSwitchKey, acls...)
 		require.Error(t, err)
 		// TODO:// should err but not for now
-		err = failedNbClient.DeleteAcls(lsName, logicalSwitchKey, ovnnb.ACLDirectionToLport, map[string]string{"subnet": lsName})
+		err = failedNbClient.DeleteAcls(lsName, LogicalSwitchKey, ovnnb.ACLDirectionToLport, map[string]string{"subnet": lsName})
 		require.NoError(t, err)
 	})
 }
@@ -1674,14 +1674,14 @@ func (suite *OvnClientTestSuite) testDeleteACL() {
 		acl, err := nbClient.newACL(lsName, ovnnb.ACLDirectionToLport, priority, match, ovnnb.ACLActionAllowRelated, util.NetpolACLTier)
 		require.NoError(t, err)
 
-		err = nbClient.CreateAcls(lsName, logicalSwitchKey, acl)
+		err = nbClient.CreateAcls(lsName, LogicalSwitchKey, acl)
 		require.NoError(t, err)
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
 		require.NoError(t, err)
 		require.Len(t, ls.ACLs, 1)
 
-		err = nbClient.DeleteACL(lsName, logicalSwitchKey, ovnnb.ACLDirectionToLport, priority, match)
+		err = nbClient.DeleteACL(lsName, LogicalSwitchKey, ovnnb.ACLDirectionToLport, priority, match)
 		require.NoError(t, err)
 
 		ls, err = nbClient.GetLogicalSwitch(lsName, false)

--- a/pkg/ovs/ovn-nb-dhcp_options.go
+++ b/pkg/ovs/ovn-nb-dhcp_options.go
@@ -224,7 +224,7 @@ func (c *OVNNbClient) DeleteDHCPOptions(lsName, protocol string) error {
 		protocol = ""
 	}
 	externalIDs := map[string]string{
-		logicalSwitchKey: lsName,
+		LogicalSwitchKey: lsName,
 		"protocol":       protocol, // list all protocol dhcp options when protocol is ""
 	}
 
@@ -254,7 +254,7 @@ func (c *OVNNbClient) GetDHCPOptions(lsName, protocol string, ignoreNotFound boo
 	}
 
 	dhcpOptList, err := c.ListDHCPOptions(true, map[string]string{
-		logicalSwitchKey: lsName,
+		LogicalSwitchKey: lsName,
 		"protocol":       protocol,
 	})
 	if err != nil {
@@ -307,7 +307,7 @@ func newDHCPOptions(lsName, cidr, options string) (*ovnnb.DHCPOptions, error) {
 	return &ovnnb.DHCPOptions{
 		Cidr: cidr,
 		ExternalIDs: map[string]string{
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 			"protocol":       protocol,
 			"vendor":         util.CniTypeName,
 		},

--- a/pkg/ovs/ovn-nb-dhcp_options_test.go
+++ b/pkg/ovs/ovn-nb-dhcp_options_test.go
@@ -320,7 +320,7 @@ func (suite *OvnClientTestSuite) testDeleteDHCPOptionsByUUIDs() {
 		require.NoError(t, err)
 	}
 
-	out, err := nbClient.ListDHCPOptions(true, map[string]string{logicalSwitchKey: lsName})
+	out, err := nbClient.ListDHCPOptions(true, map[string]string{LogicalSwitchKey: lsName})
 	require.NoError(t, err)
 	require.Len(t, out, 3)
 	for _, o := range out {
@@ -330,7 +330,7 @@ func (suite *OvnClientTestSuite) testDeleteDHCPOptionsByUUIDs() {
 	err = nbClient.DeleteDHCPOptionsByUUIDs(uuidList...)
 	require.NoError(t, err)
 
-	out, err = nbClient.ListDHCPOptions(true, map[string]string{logicalSwitchKey: lsName})
+	out, err = nbClient.ListDHCPOptions(true, map[string]string{LogicalSwitchKey: lsName})
 	require.NoError(t, err)
 	require.Empty(t, out)
 }
@@ -365,11 +365,11 @@ func (suite *OvnClientTestSuite) testDeleteDHCPOptions() {
 		err := nbClient.DeleteDHCPOptions(lsName, "IPv4")
 		require.NoError(t, err)
 
-		out, err := nbClient.ListDHCPOptions(true, map[string]string{logicalSwitchKey: lsName, "protocol": "IPv4"})
+		out, err := nbClient.ListDHCPOptions(true, map[string]string{LogicalSwitchKey: lsName, "protocol": "IPv4"})
 		require.NoError(t, err)
 		require.Empty(t, out)
 
-		out, err = nbClient.ListDHCPOptions(true, map[string]string{logicalSwitchKey: lsName, "protocol": "IPv6"})
+		out, err = nbClient.ListDHCPOptions(true, map[string]string{LogicalSwitchKey: lsName, "protocol": "IPv6"})
 		require.NoError(t, err)
 		require.Len(t, out, 2)
 
@@ -377,7 +377,7 @@ func (suite *OvnClientTestSuite) testDeleteDHCPOptions() {
 		err = nbClient.DeleteDHCPOptions(lsName, "IPv6")
 		require.NoError(t, err)
 
-		out, err = nbClient.ListDHCPOptions(true, map[string]string{logicalSwitchKey: lsName, "protocol": "IPv6"})
+		out, err = nbClient.ListDHCPOptions(true, map[string]string{LogicalSwitchKey: lsName, "protocol": "IPv6"})
 		require.NoError(t, err)
 		require.Empty(t, out)
 	})
@@ -388,7 +388,7 @@ func (suite *OvnClientTestSuite) testDeleteDHCPOptions() {
 		err := nbClient.DeleteDHCPOptions(lsName, kubeovnv1.ProtocolDual)
 		require.NoError(t, err)
 
-		out, err := nbClient.ListDHCPOptions(true, map[string]string{logicalSwitchKey: lsName, "protocol": "IPv6"})
+		out, err := nbClient.ListDHCPOptions(true, map[string]string{LogicalSwitchKey: lsName, "protocol": "IPv6"})
 		require.NoError(t, err)
 		require.Empty(t, out)
 	})
@@ -483,7 +483,7 @@ func (suite *OvnClientTestSuite) testListDHCPOptions() {
 	}
 
 	/* list all direction acl */
-	out, err := nbClient.ListDHCPOptions(true, map[string]string{logicalSwitchKey: lsName})
+	out, err := nbClient.ListDHCPOptions(true, map[string]string{LogicalSwitchKey: lsName})
 	require.NoError(t, err)
 	require.Len(t, out, 3)
 }
@@ -517,7 +517,7 @@ func (suite *OvnClientTestSuite) testDhcpOptionsFilter() {
 		// create three ipv4 dhcp options with other logical switch name
 		for _, cidr := range v4CidrBlock {
 			dhcpOpt, err := newDHCPOptions(lsName, cidr, "")
-			dhcpOpt.ExternalIDs[logicalSwitchKey] = lsName + "-test"
+			dhcpOpt.ExternalIDs[LogicalSwitchKey] = lsName + "-test"
 			require.NoError(t, err)
 			dhcpOpts = append(dhcpOpts, dhcpOpt)
 		}
@@ -551,7 +551,7 @@ func (suite *OvnClientTestSuite) testDhcpOptionsFilter() {
 		require.Equal(t, count, 8)
 
 		/* include same ls dhcp options */
-		filterFunc = dhcpOptionsFilter(true, map[string]string{logicalSwitchKey: lsName})
+		filterFunc = dhcpOptionsFilter(true, map[string]string{LogicalSwitchKey: lsName})
 		count = 0
 		for _, dhcpOpt := range dhcpOpts {
 			if filterFunc(dhcpOpt) {
@@ -561,7 +561,7 @@ func (suite *OvnClientTestSuite) testDhcpOptionsFilter() {
 		require.Equal(t, count, 5)
 
 		/* include same protocol dhcp options */
-		filterFunc = dhcpOptionsFilter(true, map[string]string{logicalSwitchKey: lsName, "protocol": "IPv4"})
+		filterFunc = dhcpOptionsFilter(true, map[string]string{LogicalSwitchKey: lsName, "protocol": "IPv4"})
 		count = 0
 		for _, dhcpOpt := range dhcpOpts {
 			if filterFunc(dhcpOpt) {
@@ -571,7 +571,7 @@ func (suite *OvnClientTestSuite) testDhcpOptionsFilter() {
 		require.Equal(t, count, 3)
 
 		/* include all protocol dhcp options */
-		filterFunc = dhcpOptionsFilter(true, map[string]string{logicalSwitchKey: lsName, "protocol": ""})
+		filterFunc = dhcpOptionsFilter(true, map[string]string{LogicalSwitchKey: lsName, "protocol": ""})
 		count = 0
 		for _, dhcpOpt := range dhcpOpts {
 			if filterFunc(dhcpOpt) {
@@ -588,7 +588,7 @@ func (suite *OvnClientTestSuite) testDhcpOptionsFilter() {
 		require.NoError(t, err)
 
 		filterFunc := dhcpOptionsFilter(true, map[string]string{
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 			"key":            "value",
 		})
 

--- a/pkg/ovs/ovn-nb-logical_switch_port.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port.go
@@ -73,7 +73,7 @@ func buildLogicalSwitchPort(lspName, lsName, ip, mac, podName, namespace string,
 	}
 
 	// attach necessary info
-	lsp.ExternalIDs[logicalSwitchKey] = lsName
+	lsp.ExternalIDs[LogicalSwitchKey] = lsName
 	lsp.ExternalIDs["vendor"] = util.CniTypeName
 
 	// set dhcp options
@@ -99,14 +99,14 @@ func (c *OVNNbClient) CreateLogicalSwitchPort(lsName, lspName, ip, mac, podName,
 	var ops []ovsdb.Operation
 	lsp := buildLogicalSwitchPort(lspName, lsName, ip, mac, podName, namespace, portSecurity, securityGroups, vips, enableDHCP, dhcpOptions, vpc)
 	if existingLsp != nil {
-		if existingLsp.ExternalIDs[logicalSwitchKey] == lsName {
+		if existingLsp.ExternalIDs[LogicalSwitchKey] == lsName {
 			if err := c.UpdateLogicalSwitchPort(lsp, &lsp.Addresses, &lsp.Dhcpv4Options, &lsp.Dhcpv6Options, &lsp.PortSecurity, &lsp.ExternalIDs); err != nil {
 				klog.Error(err)
 				return fmt.Errorf("failed to update logical switch port %s: %w", lspName, err)
 			}
 			return nil
 		}
-		if ops, err = c.LogicalSwitchUpdatePortOp(existingLsp.ExternalIDs[logicalSwitchKey], existingLsp.UUID, ovsdb.MutateOperationDelete); err != nil {
+		if ops, err = c.LogicalSwitchUpdatePortOp(existingLsp.ExternalIDs[LogicalSwitchKey], existingLsp.UUID, ovsdb.MutateOperationDelete); err != nil {
 			klog.Error(err)
 			return err
 		}
@@ -144,7 +144,7 @@ func (c *OVNNbClient) CreateLocalnetLogicalSwitchPort(lsName, lspName, provider,
 	}
 
 	if lsp != nil {
-		externalIDs[logicalSwitchKey] = lsName
+		externalIDs[LogicalSwitchKey] = lsName
 		externalIDs["vendor"] = util.CniTypeName
 		if !maps.Equal(lsp.ExternalIDs, externalIDs) {
 			lsp.ExternalIDs = externalIDs
@@ -658,7 +658,11 @@ func (c *OVNNbClient) DeleteLogicalSwitchPort(lspName string) error {
 		return nil
 	}
 
-	ops, err := c.DeleteLogicalSwitchPortOp(lspName)
+	return c.DeleteLogicalSwitchPortByUUID(lsp.ExternalIDs[LogicalSwitchKey], lsp.UUID)
+}
+
+func (c *OVNNbClient) DeleteLogicalSwitchPortByUUID(lsName, lspUUID string) error {
+	ops, err := c.DeleteLogicalSwitchPortOp(lsName, lspUUID)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -666,7 +670,7 @@ func (c *OVNNbClient) DeleteLogicalSwitchPort(lspName string) error {
 
 	if err = c.Transact("lsp-del", ops); err != nil {
 		klog.Error(err)
-		return fmt.Errorf("delete logical switch port %s", lspName)
+		return fmt.Errorf("failed to delete logical switch port with UUID %s", lspUUID)
 	}
 
 	return nil
@@ -682,7 +686,7 @@ func (c *OVNNbClient) DeleteLogicalSwitchPorts(externalIDs map[string]string, fi
 
 	ops := make([]ovsdb.Operation, 0, len(lspList))
 	for _, lsp := range lspList {
-		op, err := c.DeleteLogicalSwitchPortOp(lsp.Name)
+		op, err := c.DeleteLogicalSwitchPortOp(lsp.ExternalIDs[LogicalSwitchKey], lsp.UUID)
 		if err != nil {
 			klog.Error(err)
 			return fmt.Errorf("generate operations for deleting logical switch port %s: %w", lsp.Name, err)
@@ -739,7 +743,7 @@ func (c *OVNNbClient) ListLogicalSwitchPortsWithLegacyExternalIDs() ([]ovnnb.Log
 
 	lspList := make([]ovnnb.LogicalSwitchPort, 0)
 	if err := c.WhereCache(func(lsp *ovnnb.LogicalSwitchPort) bool {
-		return len(lsp.ExternalIDs) == 0 || lsp.ExternalIDs[logicalSwitchKey] == "" || lsp.ExternalIDs["vendor"] == ""
+		return len(lsp.ExternalIDs) == 0 || lsp.ExternalIDs[LogicalSwitchKey] == "" || lsp.ExternalIDs["vendor"] == ""
 	}).List(ctx, &lspList); err != nil {
 		klog.Error(err)
 		return nil, fmt.Errorf("failed to list logical switch ports with legacy external-ids: %w", err)
@@ -779,7 +783,7 @@ func (c *OVNNbClient) CreateLogicalSwitchPortOp(lsp *ovnnb.LogicalSwitchPort, ls
 	}
 
 	// attach necessary info
-	lsp.ExternalIDs[logicalSwitchKey] = lsName
+	lsp.ExternalIDs[LogicalSwitchKey] = lsName
 	lsp.ExternalIDs["vendor"] = util.CniTypeName
 
 	/* create logical switch port */
@@ -805,23 +809,7 @@ func (c *OVNNbClient) CreateLogicalSwitchPortOp(lsp *ovnnb.LogicalSwitchPort, ls
 }
 
 // DeleteLogicalSwitchPortOp create operations which delete logical switch port
-func (c *OVNNbClient) DeleteLogicalSwitchPortOp(lspName string) ([]ovsdb.Operation, error) {
-	lsp, err := c.GetLogicalSwitchPort(lspName, true)
-	if err != nil {
-		klog.Error(err)
-		return nil, fmt.Errorf("get logical switch port %s when generate delete operations: %w", lspName, err)
-	}
-
-	// not found, skip
-	if lsp == nil {
-		return nil, nil
-	}
-
-	// remove logical switch port from logical switch
-	lsName, ok := lsp.ExternalIDs[logicalSwitchKey]
-	if !ok {
-		return nil, nil
-	}
+func (c *OVNNbClient) DeleteLogicalSwitchPortOp(lsName, lspUUID string) ([]ovsdb.Operation, error) {
 	exist, err := c.LogicalSwitchExists(lsName)
 	if err != nil {
 		klog.Error(err)
@@ -830,11 +818,11 @@ func (c *OVNNbClient) DeleteLogicalSwitchPortOp(lspName string) ([]ovsdb.Operati
 	if !exist {
 		lsName = ""
 	}
-	klog.Infof("delete logical switch port %s with id %s from logical switch %s", lspName, lsp.UUID, lsName)
-	ops, err := c.LogicalSwitchUpdatePortOp(lsName, lsp.UUID, ovsdb.MutateOperationDelete)
+	klog.Infof("delete logical switch port with UUID %s from logical switch %q", lspUUID, lsName)
+	ops, err := c.LogicalSwitchUpdatePortOp(lsName, lspUUID, ovsdb.MutateOperationDelete)
 	if err != nil {
 		klog.Error(err)
-		return nil, fmt.Errorf("generate operations for removing port %s from logical switch %s: %w", lspName, lsName, err)
+		return nil, fmt.Errorf("generate operations for deleting logical switch port with UUID %s from logical switch %q: %w", lspUUID, lsName, err)
 	}
 	return ops, nil
 }

--- a/pkg/ovs/ovn-nb-logical_switch_port_test.go
+++ b/pkg/ovs/ovn-nb-logical_switch_port_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 	"github.com/stretchr/testify/require"
 
@@ -33,7 +34,7 @@ func (suite *OvnClientTestSuite) testCreateLogicalSwitchPort() {
 	require.NoError(t, err)
 	err = nbClient.CreateDHCPOptions(lsName, "fc00::/64", "")
 	require.NoError(t, err)
-	dhcpOptions, err := nbClient.ListDHCPOptions(true, map[string]string{logicalSwitchKey: lsName})
+	dhcpOptions, err := nbClient.ListDHCPOptions(true, map[string]string{LogicalSwitchKey: lsName})
 	require.NoError(t, err)
 	require.Len(t, dhcpOptions, 2)
 
@@ -639,7 +640,7 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchPortSecurity() {
 		require.ElementsMatch(t, []string{"00:00:00:AB:B4:65 10.244.0.37 fc00::af4:25 10.244.100.10 10.244.100.11"}, lsp.PortSecurity)
 		require.Equal(t, map[string]string{
 			"vendor":         util.CniTypeName,
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 			"vips":           "10.244.100.10,10.244.100.11",
 			"attach-vips":    "true",
 		}, lsp.ExternalIDs)
@@ -655,7 +656,7 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchPortSecurity() {
 		require.Empty(t, lsp.PortSecurity)
 		require.Equal(t, map[string]string{
 			"vendor":         util.CniTypeName,
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 		}, lsp.ExternalIDs)
 	})
 
@@ -674,7 +675,7 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchPortSecurity() {
 		require.ElementsMatch(t, []string{"00:00:00:AB:B4:65 10.244.0.37 fc00::af4:25 10.244.100.10 10.244.100.11"}, lsp.PortSecurity)
 		require.Equal(t, map[string]string{
 			"vendor":         util.CniTypeName,
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 			"vips":           "10.244.100.10,10.244.100.11",
 			"attach-vips":    "true",
 		}, lsp.ExternalIDs)
@@ -1553,13 +1554,13 @@ func (suite *OvnClientTestSuite) testListLogicalSwitchPortsWithLegacyExternalIDs
 	require.NoError(t, err)
 
 	err = nbClient.SetLogicalSwitchPortExternalIDs(lspName1, map[string]string{
-		logicalSwitchKey: "",
+		LogicalSwitchKey: "",
 		"vendor":         "some-vendor",
 	})
 	require.NoError(t, err)
 
 	err = nbClient.SetLogicalSwitchPortExternalIDs(lspName2, map[string]string{
-		logicalSwitchKey: "some-value",
+		LogicalSwitchKey: "some-value",
 		"vendor":         "",
 	})
 	require.NoError(t, err)
@@ -1574,11 +1575,11 @@ func (suite *OvnClientTestSuite) testListLogicalSwitchPortsWithLegacyExternalIDs
 			switch lsp.Name {
 			case lspName1:
 				foundLsp1 = true
-				require.Equal(t, "", lsp.ExternalIDs[logicalSwitchKey])
+				require.Equal(t, "", lsp.ExternalIDs[LogicalSwitchKey])
 				require.Equal(t, "some-vendor", lsp.ExternalIDs["vendor"])
 			case lspName2:
 				foundLsp2 = true
-				require.Equal(t, "some-value", lsp.ExternalIDs[logicalSwitchKey])
+				require.Equal(t, "some-value", lsp.ExternalIDs[LogicalSwitchKey])
 				require.Equal(t, "", lsp.ExternalIDs["vendor"])
 			}
 		}
@@ -1606,7 +1607,7 @@ func (suite *OvnClientTestSuite) testListLogicalSwitchPorts() {
 		err := nbClient.CreateBareLogicalSwitchPort(lsName, lspName, "unknown", "")
 		require.NoError(t, err)
 
-		out, err := nbClient.ListLogicalSwitchPorts(true, map[string]string{logicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
+		out, err := nbClient.ListLogicalSwitchPorts(true, map[string]string{LogicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
 			return lsp.Type == ""
 		})
 		require.NoError(t, err)
@@ -1640,7 +1641,7 @@ func (suite *OvnClientTestSuite) testListLogicalSwitchPorts() {
 		err = nbClient.CreateLogicalPatchPort(lsName, lrName, lspName, lrpName, "10.19.100.1/24", "")
 		require.NoError(t, err)
 
-		out, err := nbClient.ListLogicalSwitchPorts(true, map[string]string{logicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
+		out, err := nbClient.ListLogicalSwitchPorts(true, map[string]string{LogicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
 			return lsp.Type == "router" && len(lsp.Options) != 0 && lsp.Options["router-port"] == lrpName
 		})
 		require.NoError(t, err)
@@ -1656,7 +1657,7 @@ func (suite *OvnClientTestSuite) testListLogicalSwitchPorts() {
 		err := nbClient.CreateVirtualLogicalSwitchPort(lspName, lsName, "unknown")
 		require.NoError(t, err)
 
-		out, err := nbClient.ListLogicalSwitchPorts(true, map[string]string{logicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
+		out, err := nbClient.ListLogicalSwitchPorts(true, map[string]string{LogicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
 			return lsp.Type == "virtual"
 		})
 		require.NoError(t, err)
@@ -1691,7 +1692,7 @@ func (suite *OvnClientTestSuite) testCreateLogicalSwitchPortOp() {
 
 		require.Equal(t, ovsdb.OvsMap{
 			GoMap: map[any]any{
-				logicalSwitchKey: lsName,
+				LogicalSwitchKey: lsName,
 				"pod":            lspName,
 				"vendor":         "kube-ovn",
 			},
@@ -1726,7 +1727,7 @@ func (suite *OvnClientTestSuite) testCreateLogicalSwitchPortOp() {
 
 		require.Equal(t, ovsdb.OvsMap{
 			GoMap: map[any]any{
-				logicalSwitchKey: lsName,
+				LogicalSwitchKey: lsName,
 				"vendor":         "kube-ovn",
 			},
 		}, ops[0].Row["external_ids"])
@@ -1785,7 +1786,7 @@ func (suite *OvnClientTestSuite) testDeleteLogicalSwitchPortOp() {
 	require.NoError(t, err)
 
 	t.Run("normal delete logical switch port", func(t *testing.T) {
-		ops, err := nbClient.DeleteLogicalSwitchPortOp(lspName)
+		ops, err := nbClient.DeleteLogicalSwitchPortOp(lsName, lsp.UUID)
 		require.NoError(t, err)
 		require.Len(t, ops, 1)
 
@@ -1805,27 +1806,24 @@ func (suite *OvnClientTestSuite) testDeleteLogicalSwitchPortOp() {
 	})
 
 	t.Run("delete nonexistent logical switch port", func(t *testing.T) {
-		ops, err := nbClient.DeleteLogicalSwitchPortOp("test-nonexistent-lsp")
-		require.NoError(t, err)
-		require.Nil(t, ops)
+		_, err := nbClient.DeleteLogicalSwitchPortOp("", uuid.NewString())
+		require.Error(t, err)
 	})
 
 	t.Run("failed client delete nonexistent logical switch port", func(t *testing.T) {
-		ops, err := failedNbClient.DeleteLogicalSwitchPortOp("")
+		ops, err := failedNbClient.DeleteLogicalSwitchPortOp("", "")
 		require.Error(t, err)
 		require.Nil(t, ops)
-		ops, err = failedNbClient.DeleteLogicalSwitchPortOp("test-nonexistent-lsp")
-		require.Nil(t, err)
-		require.Nil(t, ops)
+		_, err = failedNbClient.DeleteLogicalSwitchPortOp("", uuid.NewString())
+		require.Error(t, err)
 	})
 
 	t.Run("delete logical switch port with nonexistent logical switch", func(t *testing.T) {
 		err := nbClient.DeleteLogicalSwitch(lsName)
 		require.NoError(t, err)
 
-		ops, err := nbClient.DeleteLogicalSwitchPortOp(lspName)
-		require.NoError(t, err)
-		require.Nil(t, ops)
+		_, err = nbClient.DeleteLogicalSwitchPortOp(lsName, lsp.UUID)
+		require.Error(t, err)
 	})
 }
 
@@ -1879,7 +1877,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 		lsp := &ovnnb.LogicalSwitchPort{
 			Name: lspName,
 			ExternalIDs: map[string]string{
-				logicalSwitchKey: lsName,
+				LogicalSwitchKey: lsName,
 				"vendor":         util.CniTypeName,
 			},
 		}
@@ -1894,7 +1892,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 		lsp := &ovnnb.LogicalSwitchPort{
 			Name: lspName,
 			ExternalIDs: map[string]string{
-				logicalSwitchKey: lsName,
+				LogicalSwitchKey: lsName,
 				"vendor":         util.CniTypeName,
 			},
 			Type: "router",
@@ -1912,7 +1910,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 		lsp := &ovnnb.LogicalSwitchPort{
 			Name: lspName,
 			ExternalIDs: map[string]string{
-				logicalSwitchKey: lsName,
+				LogicalSwitchKey: lsName,
 				"vendor":         util.CniTypeName,
 			},
 			Type: "remote",
@@ -1927,7 +1925,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 		lsp := &ovnnb.LogicalSwitchPort{
 			Name: lspName,
 			ExternalIDs: map[string]string{
-				logicalSwitchKey: lsName,
+				LogicalSwitchKey: lsName,
 				"vendor":         util.CniTypeName,
 			},
 			Type: "virtual",
@@ -1942,7 +1940,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 		lsp := &ovnnb.LogicalSwitchPort{
 			Name: lspName,
 			ExternalIDs: map[string]string{
-				logicalSwitchKey: lsName + "-test",
+				LogicalSwitchKey: lsName + "-test",
 				"vendor":         util.CniTypeName + "-test",
 			},
 		}
@@ -1956,7 +1954,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 		lsp := &ovnnb.LogicalSwitchPort{
 			Name: lspName,
 			ExternalIDs: map[string]string{
-				logicalSwitchKey: lsName + "-test",
+				LogicalSwitchKey: lsName + "-test",
 			},
 		}
 
@@ -1986,7 +1984,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 	})
 
 	t.Run("include all lsp with external ids", func(t *testing.T) {
-		filterFunc := logicalSwitchPortFilter(true, map[string]string{logicalSwitchKey: lsName}, nil)
+		filterFunc := logicalSwitchPortFilter(true, map[string]string{LogicalSwitchKey: lsName}, nil)
 		count := 0
 		for _, lsp := range lsps {
 			if filterFunc(lsp) {
@@ -1997,7 +1995,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 	})
 
 	t.Run("list normal type lsp", func(t *testing.T) {
-		filterFunc := logicalSwitchPortFilter(true, map[string]string{logicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
+		filterFunc := logicalSwitchPortFilter(true, map[string]string{LogicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
 			return lsp.Type == ""
 		})
 		count := 0
@@ -2010,7 +2008,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 	})
 
 	t.Run("list remote type lsp", func(t *testing.T) {
-		filterFunc := logicalSwitchPortFilter(true, map[string]string{logicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
+		filterFunc := logicalSwitchPortFilter(true, map[string]string{LogicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
 			return lsp.Type == "remote"
 		})
 		count := 0
@@ -2023,7 +2021,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 	})
 
 	t.Run("list virtual type lsp", func(t *testing.T) {
-		filterFunc := logicalSwitchPortFilter(true, map[string]string{logicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
+		filterFunc := logicalSwitchPortFilter(true, map[string]string{LogicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
 			return lsp.Type == "virtual"
 		})
 		count := 0
@@ -2036,7 +2034,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 	})
 
 	t.Run("list patch type lsp", func(t *testing.T) {
-		filterFunc := logicalSwitchPortFilter(true, map[string]string{logicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
+		filterFunc := logicalSwitchPortFilter(true, map[string]string{LogicalSwitchKey: lsName}, func(lsp *ovnnb.LogicalSwitchPort) bool {
 			return lsp.Type == "router" && len(lsp.Options) != 0 && lsp.Options["router-port"] == patchPort
 		})
 
@@ -2053,7 +2051,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 		t.Parallel()
 
 		filterFunc := logicalSwitchPortFilter(true, map[string]string{
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 			"key":            "value",
 		}, nil)
 
@@ -2096,7 +2094,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 
 	t.Run("external ids number less than required", func(t *testing.T) {
 		externalIDs := map[string]string{
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 			"vendor":         util.CniTypeName,
 			"extra-key":      "extra-value",
 		}
@@ -2112,7 +2110,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 
 	t.Run("empty value in external ids", func(t *testing.T) {
 		externalIDs := map[string]string{
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 			"vendor":         "",
 		}
 		filterFunc := logicalSwitchPortFilter(false, externalIDs, nil)
@@ -2127,7 +2125,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchPortFilter() {
 
 	t.Run("empty value in external ids and lsp external ids", func(t *testing.T) {
 		externalIDs := map[string]string{
-			logicalSwitchKey: lsName,
+			LogicalSwitchKey: lsName,
 			"vendor":         "",
 		}
 		lsps[0].ExternalIDs["vendor"] = ""

--- a/pkg/ovs/ovn-nb.go
+++ b/pkg/ovs/ovn-nb.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	logicalRouterKey      = "lr"
-	logicalSwitchKey      = "ls"
+	LogicalSwitchKey      = "ls"
 	portGroupKey          = "pg"
 	aclParentKey          = "parent"
 	associatedSgKeyPrefix = "associated_sg_"
@@ -194,10 +194,17 @@ func (c *OVNNbClient) CreateRouterPortOp(lsName, lrName, lspName, lrpName, ip, m
 // RemoveLogicalPatchPort delete logical router port and associated logical switch port which type is router
 func (c *OVNNbClient) RemoveLogicalPatchPort(lspName, lrpName string) error {
 	/* delete logical switch port*/
-	lspDelOp, err := c.DeleteLogicalSwitchPortOp(lspName)
+	lsp, err := c.GetLogicalSwitchPort(lspName, true)
 	if err != nil {
 		klog.Error(err)
-		return err
+		return fmt.Errorf("failed to get logical switch port %s: %w", lspName, err)
+	}
+	var lspDelOp []ovsdb.Operation
+	if lsp != nil {
+		if lspDelOp, err = c.DeleteLogicalSwitchPortOp(lsp.ExternalIDs[LogicalSwitchKey], lsp.UUID); err != nil {
+			klog.Error(err)
+			return err
+		}
 	}
 
 	/* delete logical router port*/

--- a/pkg/ovs/ovn.go
+++ b/pkg/ovs/ovn.go
@@ -65,10 +65,11 @@ func NewOvnNbClient(ovnNbAddr string, ovnNbTimeout, ovsDbConTimeout, ovsDbInacti
 	}
 
 	dbModel.SetIndexes(map[string][]model.ClientIndex{
-		ovnnb.LogicalRouterPolicyTable: {{Columns: []model.ColumnKey{
-			{Column: "match"},
-			{Column: "priority"},
-		}}, {Columns: []model.ColumnKey{{Column: "priority"}}}, {Columns: []model.ColumnKey{{Column: "match"}}}},
+		ovnnb.LogicalRouterPolicyTable: {
+			{Columns: []model.ColumnKey{{Column: "match"}, {Column: "priority"}}},
+			{Columns: []model.ColumnKey{{Column: "priority"}}},
+			{Columns: []model.ColumnKey{{Column: "match"}}},
+		},
 	})
 	klog.Infof("ovn nb table %s client index %#v", ovnnb.LogicalRouterPolicyTable, dbModel.Indexes(ovnnb.LogicalRouterPolicyTable))
 

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -13,9 +13,13 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/model"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/klog/v2"
 )
 
@@ -28,12 +32,22 @@ const (
 
 var namedUUIDCounter uint32
 
+var logger logr.Logger
+
 func init() {
 	buff := make([]byte, 4)
 	if _, err := rand.Reader.Read(buff); err != nil {
 		panic(err)
 	}
 	namedUUIDCounter = binary.LittleEndian.Uint32(buff)
+
+	zc := zap.NewDevelopmentConfig()
+	zc.Level = zap.NewAtomicLevelAt(zapcore.Level(-3))
+	z, err := zc.Build()
+	if err != nil {
+		panic(err)
+	}
+	logger = zapr.NewLogger(z).WithName("libovsdb")
 }
 
 func NamedUUID() string {
@@ -49,7 +63,7 @@ func NewOvsDbClient(
 	ovsDbConTimeout int,
 	ovsDbInactivityTimeout int,
 ) (client.Client, error) {
-	logger := klog.NewKlogr().WithName("libovsdb").WithValues("db", db).V(3)
+	dbLogger := logger.WithValues("db", db)
 	connectTimeout := time.Duration(ovsDbConTimeout) * time.Second
 	inactivityTimeout := time.Duration(ovsDbInactivityTimeout) * time.Second
 	options := []client.Option{
@@ -58,9 +72,8 @@ func NewOvsDbClient(
 		// we don't time out and enter a reconnect loop. In addition it also enables
 		// inactivity check on the ovsdb connection.
 		client.WithInactivityCheck(inactivityTimeout, connectTimeout, &backoff.ZeroBackOff{}),
-
 		client.WithLeaderOnly(true),
-		client.WithLogger(&logger),
+		client.WithLogger(&dbLogger),
 	}
 	klog.Infof("connecting to OVN %s server %s", db, addr)
 	var ssl bool

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -49,7 +49,7 @@ func NewOvsDbClient(
 	ovsDbConTimeout int,
 	ovsDbInactivityTimeout int,
 ) (client.Client, error) {
-	logger := klog.NewKlogr().WithName("libovsdb").WithValues("db", db)
+	logger := klog.NewKlogr().WithName("libovsdb").WithValues("db", db).V(3)
 	connectTimeout := time.Duration(ovsDbConTimeout) * time.Second
 	inactivityTimeout := time.Duration(ovsDbInactivityTimeout) * time.Second
 	options := []client.Option{

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -41,8 +41,14 @@ func init() {
 	}
 	namedUUIDCounter = binary.LittleEndian.Uint32(buff)
 
-	zc := zap.NewDevelopmentConfig()
+	zc := zap.NewProductionConfig()
 	zc.Level = zap.NewAtomicLevelAt(zapcore.Level(-3))
+	zc.EncoderConfig.EncodeLevel = func(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+		if l < zapcore.InfoLevel {
+			l = zapcore.InfoLevel
+		}
+		enc.AppendString(l.String())
+	}
 	z, err := zc.Build()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

After upgrading kube-ovn to v1.14.6, some stale logical switch ports are not deleted in gc:

```log
I0919 15:44:21.952382       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
I0919 15:47:24.083684       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
I0919 15:50:26.197093       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
I0919 15:53:28.168941       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
I0919 15:56:30.300947       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
I0919 15:59:32.394582       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
I0919 16:02:34.638748       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
I0919 16:05:36.632861       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
I0919 16:08:38.697615       7 gc.go:436] gc logical switch port acp-daemonset-m5wc5.e2eproject-acp-0-ns
...
```

It seems the libovsdb's `Get()` method does not return the logical switch port object and the deletion operation is skipped.

Currently I cannot figure not thre reason, so we need to avoid the problem by deleting logical switch ports by UUIDs.