### PR TITLE
check ovn0 mac should be set expected

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -669,6 +669,15 @@ func configureNodeNic(cs kubernetes.Interface, nodeName, portName, ip, gw, joinC
 		return fmt.Errorf("can not find nic %s: %w", util.NodeNic, err)
 	}
 
+	actualMac := hostLink.Attrs().HardwareAddr
+	if actualMac.String() != macAddr.String() {
+		macAddr = actualMac
+		err := fmt.Errorf("MAC address mismatch on %s: expected %s, actual %s", util.NodeNic, macAddr.String(), actualMac.String())
+		klog.Error(err)
+		return err
+	}
+	klog.Infof("MAC address %s successfully set on %s", macAddr.String(), util.NodeNic)
+
 	if err = netlink.LinkSetTxQLen(hostLink, 1000); err != nil {
 		return fmt.Errorf("can not set host nic %s qlen: %w", util.NodeNic, err)
 	}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
There's a chance that the MAC address of the ovn0 network interface card (NIC) may differ from the MAC address assigned to it by kube-ovn-controller. To check if the MAC address is incorrect, restart kube-ovn-cni.
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
