### PR TITLE
change the route offset to increase the priority of dst routes

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -38,6 +38,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG SRC_DIR='/usr/src'
 
 ADD patches/4228eab1d722087ba795e310eadc9e25c4513ec1.patch $SRC_DIR
+ADD patches/5e52d4373a819ea739ace68219b771445e2813bd.patch $SRC_DIR
 ADD patches/54056ea65dc28aa1c4c721a2a34d7913f79f8376.patch $SRC_DIR
 ADD patches/6b4dcb311f171d81a5d40ea51a273fc356c123db.patch $SRC_DIR
 ADD patches/f627b7721ec282f2edaf798913b1559b939687f0.patch $SRC_DIR
@@ -98,6 +99,8 @@ RUN cd /usr/src/ && git clone -b branch-24.03 --depth=1 https://github.com/ovn-o
     cd ovn && \
     # change hash type from dp_hash to hash with field src_ip
     git apply $SRC_DIR/e490f5ac0b644101913c2a3db8e03d85e859deff.patch && \
+    # modify route offset 
+    git apply $SRC_DIR/5e52d4373a819ea739ace68219b771445e2813bd.patch && \
     # modify src route priority
     git apply $SRC_DIR/b973ec477b43df1c3ef3cdb69f8646948fcf94ae.patch && \
     # fix reaching resubmit limit in underlay

--- a/dist/images/patches/5e52d4373a819ea739ace68219b771445e2813bd.patch
+++ b/dist/images/patches/5e52d4373a819ea739ace68219b771445e2813bd.patch
@@ -1,0 +1,29 @@
+From 5e52d4373a819ea739ace68219b771445e2813bd Mon Sep 17 00:00:00 2001
+From: Mengxin Liu <liumengxinfly@gmail.com>
+Date: Fri, 10 Oct 2025 08:38:02 +0000
+Subject: [PATCH] change route offset
+
+---
+ northd/northd.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/northd/northd.c b/northd/northd.c
+index 59b3b286a..414d0737c 100644
+--- a/northd/northd.c
++++ b/northd/northd.c
+@@ -289,9 +289,9 @@ static const char *reg_ct_state[] = {
+  * same ip_prefix values:
+  *  -  connected route overrides static one;
+  *  -  static route overrides connected route. */
+-#define ROUTE_PRIO_OFFSET_MULTIPLIER 3
+-#define ROUTE_PRIO_OFFSET_STATIC 1
+-#define ROUTE_PRIO_OFFSET_CONNECTED 2
++#define ROUTE_PRIO_OFFSET_MULTIPLIER 8
++#define ROUTE_PRIO_OFFSET_STATIC 4
++#define ROUTE_PRIO_OFFSET_CONNECTED 6
+ 
+ /* Returns the type of the datapath to which a flow with the given 'stage' may
+  * be added. */
+-- 
+2.34.1
+


### PR DESCRIPTION
# Pull Request

The base route offset in 24.03:
https://github.com/ovn-org/ovn/blob/branch-24.03/northd/northd.c#L293

The base route offset in main:
https://github.com/ovn-org/ovn/blob/main/northd/northd.c#L369

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #5490
