### PR TITLE
Add support for optional node selector labels for kube-ovn OVS/OVN pods

### DIFF
--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -231,6 +231,9 @@ spec:
         {{- end }}
       nodeSelector:
         kubernetes.io/os: "linux"
+        {{- with .Values.ovsNodesLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: usr-local-sbin
           emptyDir: {}

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -180,6 +180,9 @@ spec:
           {{- end }}
       nodeSelector:
         kubernetes.io/os: "linux"
+        {{- with .Values.ovsNodesLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: usr-local-sbin
           emptyDir: {}

--- a/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
@@ -156,6 +156,9 @@ spec:
             periodSeconds: 10
       nodeSelector:
         kubernetes.io/os: "linux"
+        {{- with .Values.ovsNodesLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: host-run-ovs
           hostPath:

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -47,6 +47,13 @@ masterNodesLabels:
   kube-ovn/role: master
   # node-role.kubernetes.io/control-plane: ""
 
+# -- Additional node selector labels for the OVS/OVN pods.
+# This allows scheduling pods like ovs-ovn, kube-ovn-cni, and kube-ovn-pinger on specific nodes.
+# See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+# @section -- Global parameters
+ovsNodesLabels: {}
+  # kube-ovn/role: ovs
+
 # -- General configuration of the network created by Kube-OVN.
 # @section -- Network parameters of the CNI
 # @default -- "{}"


### PR DESCRIPTION
This change introduces a new Helm value ovsNodesLabels that allows adding custom node selector labels to ovs-ovn pods. For example:
```
 ovsNodesLabels:
  kube-ovn/role: ovs
  ```
This is useful in environments such as OpenStack-Helm, where operators may want to schedule OVS/OVN pods only on specific nodes (e.g., compute nodes) instead of deploying them cluster-wide. When ovsNodesLabels is empty, only the default selector kubernetes.io/os: linux is applied.