### PR TITLE
fix bug #5686: update node exgateway label to true when it is readyNode for providernetwork.status

### DIFF
--- a/pkg/controller/provider_network.go
+++ b/pkg/controller/provider_network.go
@@ -62,6 +62,14 @@ func (c *Controller) resyncProviderNetworkStatus() {
 					conditionsUpdated = true
 				}
 				readyNodes = append(readyNodes, node.Name)
+				// set node label ovn.kubernetes.io/external-gw=true for readyNode
+				if node.Labels[util.ExGatewayLabel] != "true" {
+					patch := util.KVPatch{util.ExGatewayLabel: "true"}
+					if err = util.PatchLabels(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
+						klog.Errorf("failed to patch external gw node %s: %v", node.Name, err)
+					}
+					klog.Infof("finish patch node %s label: ovn.kubernetes.io/external-gw=true", node.Name)
+				}
 			} else {
 				var errMsg string
 				if pod := podMap[node.Name]; pod == nil {


### PR DESCRIPTION
update node exgateway label to true when it is readyNode for providernetwork.status

# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
当node在provider-network资源中是ready状态，则讲节点label: ovn.kubernetes.io/external-gw 改为true
通过这个方式修复默认vpc不启用外部网络时，网关节点label: ovn.kubernetes.io/external-gw 改为false的问题。
## Which issue(s) this PR fixes

Fixes #5686
