### PR TITLE
fix(netpol): lax dhcp must be after lb for egress

### DIFF
--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -128,6 +128,12 @@ func (c *OVNNbClient) UpdateDefaultBlockExceptionsACLOps(npName, pgName, npNames
 	newACL := func(match string) {
 		options := func(acl *ovnnb.ACL) {
 			setACLName(acl, npName)
+			if direction == ovnnb.ACLDirectionFromLport {
+				if acl.Options == nil {
+					acl.Options = make(map[string]string)
+				}
+				acl.Options["apply-after-lb"] = "true"
+			}
 		}
 
 		acl, err := c.newACLWithoutCheck(pgName, direction, priority, match, ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

DHCP on egress may not work properly due to the rule being applied before the LB. I'm not sure why that is, considering no LB should be at play here. Issue was discused on Slack and might be related to an OVN bug.


