### PR TITLE
Remove negative matching for ipblock except rules.

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -2094,33 +2094,33 @@ func (mr *MockACLMockRecorder) UpdateDefaultBlockExceptionsACLOps(npName, pgName
 }
 
 // UpdateEgressACLOps mocks base method.
-func (m *MockACL) UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName string, npp []v10.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error) {
+func (m *MockACL) UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName string, npp []v10.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateEgressACLOps", pgName, asEgressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
+	ret := m.ctrl.Call(m, "UpdateEgressACLOps", pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
 	ret0, _ := ret[0].([]ovsdb.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateEgressACLOps indicates an expected call of UpdateEgressACLOps.
-func (mr *MockACLMockRecorder) UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap any) *gomock.Call {
+func (mr *MockACLMockRecorder) UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEgressACLOps", reflect.TypeOf((*MockACL)(nil).UpdateEgressACLOps), pgName, asEgressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEgressACLOps", reflect.TypeOf((*MockACL)(nil).UpdateEgressACLOps), pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
 }
 
 // UpdateIngressACLOps mocks base method.
-func (m *MockACL) UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName string, npp []v10.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error) {
+func (m *MockACL) UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName string, npp []v10.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateIngressACLOps", pgName, asIngressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
+	ret := m.ctrl.Call(m, "UpdateIngressACLOps", pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
 	ret0, _ := ret[0].([]ovsdb.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateIngressACLOps indicates an expected call of UpdateIngressACLOps.
-func (mr *MockACLMockRecorder) UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap any) *gomock.Call {
+func (mr *MockACLMockRecorder) UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIngressACLOps", reflect.TypeOf((*MockACL)(nil).UpdateIngressACLOps), pgName, asIngressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIngressACLOps", reflect.TypeOf((*MockACL)(nil).UpdateIngressACLOps), pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
 }
 
 // UpdateLogicalSwitchACL mocks base method.
@@ -5296,18 +5296,18 @@ func (mr *MockNbClientMockRecorder) UpdateDnatAndSnat(lrName, externalIP, logica
 }
 
 // UpdateEgressACLOps mocks base method.
-func (m *MockNbClient) UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName string, npp []v10.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error) {
+func (m *MockNbClient) UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName string, npp []v10.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateEgressACLOps", pgName, asEgressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
+	ret := m.ctrl.Call(m, "UpdateEgressACLOps", pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
 	ret0, _ := ret[0].([]ovsdb.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateEgressACLOps indicates an expected call of UpdateEgressACLOps.
-func (mr *MockNbClientMockRecorder) UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap any) *gomock.Call {
+func (mr *MockNbClientMockRecorder) UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEgressACLOps", reflect.TypeOf((*MockNbClient)(nil).UpdateEgressACLOps), pgName, asEgressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEgressACLOps", reflect.TypeOf((*MockNbClient)(nil).UpdateEgressACLOps), pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
 }
 
 // UpdateGatewayChassis mocks base method.
@@ -5330,18 +5330,18 @@ func (mr *MockNbClientMockRecorder) UpdateGatewayChassis(gwChassis any, fields .
 }
 
 // UpdateIngressACLOps mocks base method.
-func (m *MockNbClient) UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName string, npp []v10.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error) {
+func (m *MockNbClient) UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName string, npp []v10.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateIngressACLOps", pgName, asIngressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
+	ret := m.ctrl.Call(m, "UpdateIngressACLOps", pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
 	ret0, _ := ret[0].([]ovsdb.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateIngressACLOps indicates an expected call of UpdateIngressACLOps.
-func (mr *MockNbClientMockRecorder) UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap any) *gomock.Call {
+func (mr *MockNbClientMockRecorder) UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIngressACLOps", reflect.TypeOf((*MockNbClient)(nil).UpdateIngressACLOps), pgName, asIngressName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIngressACLOps", reflect.TypeOf((*MockNbClient)(nil).UpdateIngressACLOps), pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, logEnable, logACLActions, namedPortMap)
 }
 
 // UpdateLogicalRouter mocks base method.

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -160,8 +160,8 @@ type PortGroup interface {
 type ACL interface {
 	UpdateDefaultBlockACLOps(npName, pgName, direction string, loggingEnabled, lax bool) ([]ovsdb.Operation, error)
 	UpdateDefaultBlockExceptionsACLOps(npName, pgName, npNamespace, direction string) ([]ovsdb.Operation, error)
-	UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName string, npp []netv1.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error)
-	UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName string, npp []netv1.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error)
+	UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName string, npp []netv1.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error)
+	UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName string, npp []netv1.NetworkPolicyPort, logEnable bool, logACLActions []ovnnb.ACLAction, namedPortMap map[string]*util.NamedPortInfo) ([]ovsdb.Operation, error)
 	CreateGatewayACL(lsName, pgName, gateway, u2oInterconnectionIP string) error
 	CreateNodeACL(pgName, nodeIPStr, joinIPStr string) error
 	CreateSgDenyAllACL(sgName string) error

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -214,7 +214,8 @@ func (suite *OvnClientTestSuite) testUpdateIngressACLOps() {
 		t.Parallel()
 
 		pgName := "test_create_v4_ingress_acl_pg"
-		asIngressName := "test.default.ingress.allow.ipv4.all"
+		asSelectorName := "test.default.ingress.selector.ipv4.all"
+		asIPBlockName := "test.default.ingress.ipblock.ipv4.all"
 		asExceptName := "test.default.ingress.except.ipv4.all"
 		protocol := kubeovnv1.ProtocolIPv4
 		aclName := "test_create_v4_ingress_acl_pg"
@@ -222,13 +223,18 @@ func (suite *OvnClientTestSuite) testUpdateIngressACLOps() {
 		err := nbClient.CreatePortGroup(pgName, nil)
 		require.NoError(t, err)
 
+		err = nbClient.CreateAddressSet(asIPBlockName, nil)
+		require.NoError(t, err)
+		err = nbClient.AddressSetUpdateAddress(asIPBlockName, "10.244.0.0/16")
+		require.NoError(t, err)
+
 		npp := mockNetworkPolicyPort()
 
-		ops, err := nbClient.UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName, npp, true, nil, nil)
+		ops, err := nbClient.UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, true, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, ops, 3)
 
-		matches := newNetworkPolicyACLMatch(pgName, asIngressName, asExceptName, protocol, ovnnb.ACLDirectionToLport, npp, nil)
+		matches := newNetworkPolicyACLMatch(pgName, asIPBlockName, protocol, ovnnb.ACLDirectionToLport, npp, nil)
 		i := 0
 		for _, m := range matches {
 			require.Equal(t, m, ops[i].Row["match"])
@@ -241,7 +247,8 @@ func (suite *OvnClientTestSuite) testUpdateIngressACLOps() {
 		t.Parallel()
 
 		pgName := "test_create_v6_ingress_acl_pg"
-		asIngressName := "test.default.ingress.allow.ipv6.all"
+		asSelectorName := "test.default.ingress.selector.ipv6.all"
+		asIPBlockName := "test.default.ingress.ipblock.ipv6.all"
 		asExceptName := "test.default.ingress.except.ipv6.all"
 		protocol := kubeovnv1.ProtocolIPv6
 		aclName := "test_create_v6_ingress_acl_pg"
@@ -249,11 +256,16 @@ func (suite *OvnClientTestSuite) testUpdateIngressACLOps() {
 		err := nbClient.CreatePortGroup(pgName, nil)
 		require.NoError(t, err)
 
-		ops, err := nbClient.UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName, nil, true, nil, nil)
+		err = nbClient.CreateAddressSet(asIPBlockName, nil)
+		require.NoError(t, err)
+		err = nbClient.AddressSetUpdateAddress(asIPBlockName, "fd00::/64")
+		require.NoError(t, err)
+
+		ops, err := nbClient.UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, nil, true, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, ops, 2)
 
-		matches := newNetworkPolicyACLMatch(pgName, asIngressName, asExceptName, protocol, ovnnb.ACLDirectionToLport, nil, nil)
+		matches := newNetworkPolicyACLMatch(pgName, asIPBlockName, protocol, ovnnb.ACLDirectionToLport, nil, nil)
 		i := 0
 		for _, m := range matches {
 			require.Equal(t, m, ops[i].Row["match"])
@@ -266,12 +278,13 @@ func (suite *OvnClientTestSuite) testUpdateIngressACLOps() {
 		t.Parallel()
 
 		pgName := ""
-		asIngressName := "test.default.ingress.allow.ipv4.all"
+		asSelectorName := "test.default.ingress.selector.ipv4.all"
+		asIPBlockName := "test.default.ingress.ipblock.ipv4.all"
 		asExceptName := "test.default.ingress.except.ipv4.all"
 		protocol := kubeovnv1.ProtocolIPv4
 		aclName := "test_create_v4_ingress_acl_pg"
 
-		_, err := nbClient.UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName, nil, true, nil, nil)
+		_, err := nbClient.UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, nil, true, nil, nil)
 		require.ErrorContains(t, err, "the port group name or logical switch name is required")
 	})
 
@@ -279,12 +292,13 @@ func (suite *OvnClientTestSuite) testUpdateIngressACLOps() {
 		t.Parallel()
 
 		pgName := ""
-		asIngressName := "test.default.ingress.allow.ipv4"
+		asSelectorName := "test.default.ingress.selector.ipv4"
+		asIPBlockName := "test.default.ingress.ipblock.ipv4"
 		asExceptName := "test.default.ingress.except.ipv4"
 		protocol := kubeovnv1.ProtocolIPv4
 		aclName := "test_create_v4_ingress_acl_pg"
 
-		_, err := nbClient.UpdateIngressACLOps(pgName, asIngressName, asExceptName, protocol, aclName, nil, true, nil, nil)
+		_, err := nbClient.UpdateIngressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, nil, true, nil, nil)
 		require.ErrorContains(t, err, "the port group name or logical switch name is required")
 	})
 }
@@ -308,7 +322,8 @@ func (suite *OvnClientTestSuite) testUpdateEgressACLOps() {
 		t.Parallel()
 
 		pgName := "test_create_v4_egress_acl_pg"
-		asEgressName := "test.default.egress.allow.ipv4.all"
+		asSelectorName := "test.default.egress.selector.ipv4.all"
+		asIPBlockName := "test.default.egress.ipblock.ipv4.all"
 		asExceptName := "test.default.egress.except.ipv4.all"
 		protocol := kubeovnv1.ProtocolIPv4
 		aclName := "test_create_v4_egress_acl_pg"
@@ -316,13 +331,18 @@ func (suite *OvnClientTestSuite) testUpdateEgressACLOps() {
 		err := nbClient.CreatePortGroup(pgName, nil)
 		require.NoError(t, err)
 
+		err = nbClient.CreateAddressSet(asIPBlockName, nil)
+		require.NoError(t, err)
+		err = nbClient.AddressSetUpdateAddress(asIPBlockName, "10.244.0.0/16")
+		require.NoError(t, err)
+
 		npp := mockNetworkPolicyPort()
 
-		ops, err := nbClient.UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName, npp, true, nil, nil)
+		ops, err := nbClient.UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, npp, true, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, ops, 3)
 
-		matches := newNetworkPolicyACLMatch(pgName, asEgressName, asExceptName, protocol, ovnnb.ACLDirectionFromLport, npp, nil)
+		matches := newNetworkPolicyACLMatch(pgName, asIPBlockName, protocol, ovnnb.ACLDirectionFromLport, npp, nil)
 		i := 0
 		for _, m := range matches {
 			require.Equal(t, m, ops[i].Row["match"])
@@ -335,7 +355,8 @@ func (suite *OvnClientTestSuite) testUpdateEgressACLOps() {
 		t.Parallel()
 
 		pgName := "test_create_v6_egress_acl_pg"
-		asEgressName := "test.default.egress.allow.ipv6.all"
+		asSelectorName := "test.default.egress.selector.ipv6.all"
+		asIPBlockName := "test.default.egress.ipblock.ipv6.all"
 		asExceptName := "test.default.egress.except.ipv6.all"
 		protocol := kubeovnv1.ProtocolIPv6
 		aclName := "test_create_v6_egress_acl_pg"
@@ -343,11 +364,16 @@ func (suite *OvnClientTestSuite) testUpdateEgressACLOps() {
 		err := nbClient.CreatePortGroup(pgName, nil)
 		require.NoError(t, err)
 
-		ops, err := nbClient.UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName, nil, true, nil, nil)
+		err = nbClient.CreateAddressSet(asIPBlockName, nil)
+		require.NoError(t, err)
+		err = nbClient.AddressSetUpdateAddress(asIPBlockName, "fd00::/64")
+		require.NoError(t, err)
+
+		ops, err := nbClient.UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, nil, true, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, ops, 2)
 
-		matches := newNetworkPolicyACLMatch(pgName, asEgressName, asExceptName, protocol, ovnnb.ACLDirectionFromLport, nil, nil)
+		matches := newNetworkPolicyACLMatch(pgName, asIPBlockName, protocol, ovnnb.ACLDirectionFromLport, nil, nil)
 		i := 0
 		for _, m := range matches {
 			require.Equal(t, m, ops[i].Row["match"])
@@ -360,12 +386,13 @@ func (suite *OvnClientTestSuite) testUpdateEgressACLOps() {
 		t.Parallel()
 
 		pgName := ""
-		asEgressName := "test.default.egress.allow.ipv4.all"
+		asSelectorName := "test.default.egress.selector.ipv4.all"
+		asIPBlockName := "test.default.egress.ipblock.ipv4.all"
 		asExceptName := "test.default.egress.except.ipv4.all"
 		protocol := kubeovnv1.ProtocolIPv4
 		aclName := "test_create_v4_egress_acl_pg"
 
-		_, err := nbClient.UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName, nil, true, nil, nil)
+		_, err := nbClient.UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, nil, true, nil, nil)
 		require.ErrorContains(t, err, "the port group name or logical switch name is required")
 	})
 
@@ -373,12 +400,13 @@ func (suite *OvnClientTestSuite) testUpdateEgressACLOps() {
 		t.Parallel()
 
 		pgName := ""
-		asEgressName := "test.default.egress.allow.ipv4"
+		asSelectorName := "test.default.egress.selector.ipv4"
+		asIPBlockName := "test.default.egress.ipblock.ipv4"
 		asExceptName := "test.default.egress.except.ipv4"
 		protocol := kubeovnv1.ProtocolIPv4
 		aclName := "test_create_v4_egress_acl_pg"
 
-		_, err := nbClient.UpdateEgressACLOps(pgName, asEgressName, asExceptName, protocol, aclName, nil, true, nil, nil)
+		_, err := nbClient.UpdateEgressACLOps(pgName, asSelectorName, asIPBlockName, asExceptName, protocol, aclName, nil, true, nil, nil)
 		require.ErrorContains(t, err, "the port group name or logical switch name is required")
 	})
 }
@@ -1996,16 +2024,15 @@ func (suite *OvnClientTestSuite) testnewNetworkPolicyACLMatch() {
 
 	pgName := "test-new-acl-m-pg"
 	asAllowName := "test.default.xx.allow.ipv4"
-	asExceptName := "test.default.xx.except.ipv4"
 
 	t.Run("has ingress network policy port", func(t *testing.T) {
 		t.Parallel()
 
 		npp := mockNetworkPolicyPort()
-		matches := newNetworkPolicyACLMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, nil)
+		matches := newNetworkPolicyACLMatch(pgName, asAllowName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, nil)
 		require.ElementsMatch(t, []string{
-			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[0].Port.IntVal),
-			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && %d <= tcp.dst <= %d", pgName, asAllowName, asExceptName, npp[1].Port.IntVal, *npp[1].EndPort),
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && tcp.dst == %d", pgName, asAllowName, npp[0].Port.IntVal),
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && %d <= tcp.dst <= %d", pgName, asAllowName, npp[1].Port.IntVal, *npp[1].EndPort),
 		}, matches)
 	})
 
@@ -2014,19 +2041,19 @@ func (suite *OvnClientTestSuite) testnewNetworkPolicyACLMatch() {
 
 		npp := mockNetworkPolicyPort()
 
-		matches := newNetworkPolicyACLMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionFromLport, npp, nil)
+		matches := newNetworkPolicyACLMatch(pgName, asAllowName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionFromLport, npp, nil)
 		require.ElementsMatch(t, []string{
-			fmt.Sprintf("inport == @%s && ip && ip4.dst == $%s && ip4.dst != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[0].Port.IntVal),
-			fmt.Sprintf("inport == @%s && ip && ip4.dst == $%s && ip4.dst != $%s && %d <= tcp.dst <= %d", pgName, asAllowName, asExceptName, npp[1].Port.IntVal, *npp[1].EndPort),
+			fmt.Sprintf("inport == @%s && ip && ip4.dst == $%s && tcp.dst == %d", pgName, asAllowName, npp[0].Port.IntVal),
+			fmt.Sprintf("inport == @%s && ip && ip4.dst == $%s && %d <= tcp.dst <= %d", pgName, asAllowName, npp[1].Port.IntVal, *npp[1].EndPort),
 		}, matches)
 	})
 
 	t.Run("network policy port is nil", func(t *testing.T) {
 		t.Parallel()
 
-		matches := newNetworkPolicyACLMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, nil, nil)
+		matches := newNetworkPolicyACLMatch(pgName, asAllowName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, nil, nil)
 		require.ElementsMatch(t, []string{
-			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s", pgName, asAllowName, asExceptName),
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s", pgName, asAllowName),
 		}, matches)
 	})
 
@@ -2036,10 +2063,10 @@ func (suite *OvnClientTestSuite) testnewNetworkPolicyACLMatch() {
 		npp := mockNetworkPolicyPort()
 		npp[1].Port = nil
 
-		matches := newNetworkPolicyACLMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, nil)
+		matches := newNetworkPolicyACLMatch(pgName, asAllowName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, nil)
 		require.ElementsMatch(t, []string{
-			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[0].Port.IntVal),
-			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp", pgName, asAllowName, asExceptName),
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && tcp.dst == %d", pgName, asAllowName, npp[0].Port.IntVal),
+			fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && tcp", pgName, asAllowName),
 		}, matches)
 	})
 
@@ -2051,10 +2078,10 @@ func (suite *OvnClientTestSuite) testnewNetworkPolicyACLMatch() {
 			npp := mockNetworkPolicyPort()
 			npp[1].EndPort = nil
 
-			matches := newNetworkPolicyACLMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, nil)
+			matches := newNetworkPolicyACLMatch(pgName, asAllowName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, nil)
 			require.ElementsMatch(t, []string{
-				fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[0].Port.IntVal),
-				fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, npp[1].Port.IntVal),
+				fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && tcp.dst == %d", pgName, asAllowName, npp[0].Port.IntVal),
+				fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && tcp.dst == %d", pgName, asAllowName, npp[1].Port.IntVal),
 			}, matches)
 		})
 
@@ -2076,9 +2103,9 @@ func (suite *OvnClientTestSuite) testnewNetworkPolicyACLMatch() {
 					PortID: 13455,
 				},
 			}
-			matches := newNetworkPolicyACLMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, namedPortMap)
+			matches := newNetworkPolicyACLMatch(pgName, asAllowName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, namedPortMap)
 			require.ElementsMatch(t, []string{
-				fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, 13455),
+				fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && tcp.dst == %d", pgName, asAllowName, 13455),
 			}, matches)
 		})
 
@@ -2100,9 +2127,9 @@ func (suite *OvnClientTestSuite) testnewNetworkPolicyACLMatch() {
 					PortID: 13455,
 				},
 			}
-			matches := newNetworkPolicyACLMatch(pgName, asAllowName, asExceptName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, namedPortMap)
+			matches := newNetworkPolicyACLMatch(pgName, asAllowName, kubeovnv1.ProtocolIPv4, ovnnb.ACLDirectionToLport, npp, namedPortMap)
 			require.ElementsMatch(t, []string{
-				fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && ip4.src != $%s && tcp.dst == %d", pgName, asAllowName, asExceptName, 0),
+				fmt.Sprintf("outport == @%s && ip && ip4.src == $%s && tcp.dst == %d", pgName, asAllowName, 0),
 			}, matches)
 		})
 	})

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -152,11 +152,15 @@ const (
 	SecurityGroupAllowPriority   = "2004"
 	SecurityGroupDropPriority    = "2003"
 
-	IngressAllowPriority = "2001"
-	IngressDefaultDrop   = "2000"
+	IngressSelectorAllowPriority = "2003"
+	IngressExceptDropPriority    = "2002"
+	IngressAllowPriority         = "2001"
+	IngressDefaultDrop           = "2000"
 
-	EgressAllowPriority = "2001"
-	EgressDefaultDrop   = "2000"
+	EgressSelectorAllowPriority = "2003"
+	EgressExceptDropPriority    = "2002"
+	EgressAllowPriority         = "2001"
+	EgressDefaultDrop           = "2000"
 
 	AllowEWTrafficPriority = "1900"
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Performance

## Refactor NetworkPolicy IPBlock handling to fix rule priority issues

### Problem

**Issue 1**: The original implementation used a single ACL rule to match both IPBlock CIDR and except ranges with `!= $except`, which caused OVS flow table bloat.

**Issue 2**: When a Pod IP matched by PodSelector also fell within an IPBlock except range, it would be incorrectly dropped, violating the NetworkPolicy "OR" semantics where any matching rule should allow traffic.

### Solution

Separate NetworkPolicy rules by type with different ACL priorities:

- **Priority 2003**: PodSelector/NamespaceSelector IPs → allow-related
- **Priority 2002**: IPBlock except IPs → drop  
- **Priority 2001**: IPBlock CIDR → allow-related

### Changes

1. Split `fetchPolicySelectedAddresses` to return three separate lists: `selectorIPs`, `blockCIDRs`, and `exceptCIDRs`
2. Create three address sets per rule: selector, ipblock, and except
3. Generate ACLs with proper priorities ensuring selector-matched IPs are always allowed
4. Add new priority constants: `IngressSelectorAllowPriority` and `EgressSelectorAllowPriority`

### Benefits

- ✅ Eliminates `!=` operator usage, reducing OVS flow table size
- ✅ Ensures correct NetworkPolicy semantics (OR relationship between rules)
- ✅ PodSelector-matched IPs always allowed regardless of IPBlock except ranges

---
