### PR TITLE
fix: prevent GC from deleting KubeVirt VM interfaces

### DIFF
--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -112,6 +112,7 @@ const (
 	VpcDNSNameLabel                    = "ovn.kubernetes.io/vpc-dns"
 	QoSLabel                           = "ovn.kubernetes.io/qos"
 	NodeNameLabel                      = "ovn.kubernetes.io/node-name"
+	KubeVirtVMNameLabel                = "vm.kubevirt.io/name"
 	NetworkPolicyLogAnnotation         = "ovn.kubernetes.io/enable_log"
 	NetworkPolicyEnforcementAnnotation = "ovn.kubernetes.io/network_policy_enforcement"
 	ACLActionsLogAnnotation            = "ovn.kubernetes.io/log_acl_actions"


### PR DESCRIPTION
The garbage collector introduced in PR #5789 incorrectly identifies KubeVirt VM interfaces as 'lost' and deletes them, breaking network connectivity for VMs within ~60 seconds of creation.

Root cause: For KubeVirt VMs, the pod_name in OVS external_ids is set to the VM name (e.g., 'ubuntu-vm-br'), not the launcher pod name (e.g., 'virt-launcher-ubuntu-vm-br-xyz'). When gcInterfaces() tries to look up the pod by the VM name, it fails and incorrectly deletes the interface.

Solution: When a pod is not found by direct lookup, check if it might be a KubeVirt VM by searching for launcher pods with the label 'vm.kubevirt.io/name' matching the pod_name from OVS. If a matching launcher pod exists, keep the interface instead of deleting it.

This fix maintains backward compatibility with non-KubeVirt pods while preventing false-positive deletions for KubeVirt VMs.

# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR



- Bug fixes



## Which issue(s) this PR fixes 

Fixes #5811
