### PR TITLE
OVN-Interconnect: Only set-up LRP/LSP between the transit switches and default router if we want to.

### DIFF
--- a/yamls/ovn-ic-config.yaml.j2
+++ b/yamls/ovn-ic-config.yaml.j2
@@ -11,3 +11,4 @@ data:
   ic-sb-port: "6646"
   gw-nodes: "{{ gateway_nodes }}"
   auto-route: "true"
+  interconnect-default-router: "true"


### PR DESCRIPTION
OVN-Interconnect: Only set-up LRP/LSP between the transit switches and default router if we want to.

This allows people to create transit switches and only have non-default routers connected to them

# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
