### PR TITLE
fix: loadbalancerservice value

### DIFF
--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -146,7 +146,7 @@ spec:
           - --inspect-interval={{- .Values.performance.inspectInterval }}
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
           - --log_file_max_size=200
-          - --enable-lb-svc={{- .Values.features.enableLoadbalancer }}
+          - --enable-lb-svc={{- .Values.features.enableLoadbalancerService }}
           - --keep-vm-ip={{- .Values.features.enableKeepVmIps }}
           - --enable-metrics={{- .Values.networking.enableMetrics }}
           - --node-local-dns-ip={{- .Values.networking.nodeLocalDnsIp }}


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Fixes the enable-lb-svc argument for the kube-ovn-v2 chart, as it was pointing to the setting for enable-lb instead.