### PR TITLE
server: add hostname and pod IPs into TLS certificate SAN

### DIFF
--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -49,7 +49,7 @@ define kind_load_image
 	@if [ "x$(3)" = "x1" ]; then \
 		$(call docker_ensure_image_exists,$(2)); \
 	fi
-	if kind load docker-image --name $(1) $(2) 2>/dev/null; then \
+	@if kind load docker-image --name $(1) $(2) 2>/dev/null; then \
 		echo "Successfully loaded $(2) using docker-image method"; \
 	else \
 		echo "docker-image method failed, trying image-archive method..."; \


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

```shell
$ echo | openssl s_client -showcerts -connect 172.18.0.2:10665 -servername 172.18.0.2 | openssl x509 -noout -subject -ext subjectAltName
Connecting to 172.18.0.2
depth=0 CN=localhost
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 CN=localhost
verify error:num=21:unable to verify the first certificate
verify return:1
depth=0 CN=localhost
verify return:1
DONE
subject=CN=localhost
X509v3 Subject Alternative Name:
    DNS:localhost, DNS:kube-ovn-control-plane, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1, IP Address:172.18.0.2
```
