### PR TITLE
feat: add support to ignore Calico pods during migrating from calico

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -431,6 +431,11 @@ func (c *Controller) InitIPAM() error {
 			continue
 		}
 
+		if util.IgnoreCalicoPod(pod.Annotations) {
+			klog.V(3).Infof("ignore calico pod %s/%s during init", pod.Namespace, pod.Name)
+			continue
+		}
+
 		isAlive := isPodAlive(pod)
 		isStsPod, _, _ := isStatefulSetPod(pod)
 		if !isAlive && !isStsPod {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -188,6 +188,11 @@ func (c *Controller) enqueueAddPod(obj any) {
 		return
 	}
 
+	if util.IgnoreCalicoPod(p.Annotations) {
+		klog.V(3).Infof("ignore calico pod %s/%s", p.Namespace, p.Name)
+		return
+	}
+
 	// Pod might be targeted by manual endpoints and we need to recompute its port mappings
 	c.enqueueStaticEndpointUpdateInNamespace(p.Namespace)
 
@@ -261,6 +266,11 @@ func (c *Controller) enqueueDeletePod(obj any) {
 		return
 	}
 
+	if util.IgnoreCalicoPod(p.Annotations) {
+		klog.V(5).Infof("ignore calico pod %s/%s", p.Namespace, p.Name)
+		return
+	}
+
 	// Pod might be targeted by manual endpoints and we need to recompute its port mappings
 	c.enqueueStaticEndpointUpdateInNamespace(p.Namespace)
 
@@ -288,6 +298,11 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 
 	// Pod might be targeted by manual endpoints and we need to recompute its port mappings
 	c.enqueueStaticEndpointUpdateInNamespace(oldPod.Namespace)
+
+	if util.IgnoreCalicoPod(newPod.Annotations) {
+		klog.V(3).Infof("ignore calico pod %s/%s", newPod.Namespace, newPod.Name)
+		return
+	}
 
 	if oldPod.Annotations[util.AAPsAnnotation] != "" || newPod.Annotations[util.AAPsAnnotation] != "" {
 		oldAAPs := strings.Split(oldPod.Annotations[util.AAPsAnnotation], ",")

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -341,6 +341,9 @@ const (
 
 	MasqueradeExternalLBAccessMac = "00:00:00:01:00:01"
 	MasqueradeCheckIP             = "0.0.0.0"
+
+	// Ignore Calico pods
+	CalicoPodIPAnnotation = "cni.projectcalico.org/podIP"
 )
 
 var KubeVirtCRD = []string{"virtualmachineinstancemigrations.kubevirt.io", "virtualmachines.kubevirt.io"}

--- a/pkg/util/pod_filter.go
+++ b/pkg/util/pod_filter.go
@@ -1,0 +1,10 @@
+package util
+
+// IgnoreCalicoPod returns true when the given annotations map contains the Calico pod IP key.
+func IgnoreCalicoPod(annotations map[string]string) bool {
+	if len(annotations) == 0 {
+		return false
+	}
+	_, ok := annotations[CalicoPodIPAnnotation]
+	return ok
+}


### PR DESCRIPTION
…to kubeovn + cilum

# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

while migrating from calico to kubeovn, the calico pod should be keep running

and kube-ovn should ignore it, 

just let user to decide when to reboot the pod

```bash

cili-control | CHANGED | rc=0 >>
I1111 12:10:50.462592       6 pod.go:233] enqueue add pod default/calico-python-no-check1-daemon-84h9j
I1111 12:10:50.462608       6 pod.go:233] enqueue add pod default/calico-python-no-check2-daemon-54kq7
I1111 12:10:50.462611       6 pod.go:233] enqueue add pod default/calico-python-no-check1-daemon-frhsp
I1111 12:10:50.462616       6 pod.go:233] enqueue add pod default/calico-python-no-check4-daemon-7cfpd
I1111 12:10:50.462632       6 pod.go:233] enqueue add pod default/calico-python2-daemon-zlv4l
I1111 12:10:50.462642       6 pod.go:233] enqueue add pod default/calico-python-no-check-daemon-pglrs
I1111 12:10:50.462658       6 pod.go:233] enqueue add pod default/calico-python-no-check5-daemon-glj7m
I1111 12:10:50.462662       6 pod.go:233] enqueue add pod default/calico-python-no-check-daemon-mhlkw
I1111 12:10:50.462667       6 pod.go:233] enqueue add pod default/calico-python4-daemon-v57pb
I1111 12:10:50.462671       6 pod.go:233] enqueue add pod default/calico-python-no-check2-daemon-wtb2w
I1111 12:10:50.462685       6 pod.go:233] enqueue add pod default/calico-python2-daemon-8pz6m
I1111 12:10:50.462699       6 pod.go:233] enqueue add pod default/calico-python5-daemon-9nklc
I1111 12:10:50.462702       6 pod.go:233] enqueue add pod default/calico-python-no-check4-daemon-mpcfh
I1111 12:10:50.462714       6 pod.go:233] enqueue add pod default/calico-python-no-check-daemon-lwb7v
I1111 12:10:50.462718       6 pod.go:233] enqueue add pod default/calico-python-daemon-67wjn
I1111 12:10:50.462722       6 pod.go:233] enqueue add pod default/calico-python-no-check3-daemon-k8hxs
I1111 12:10:50.462725       6 pod.go:233] enqueue add pod default/calico-python3-daemon-lxqng
I1111 12:10:50.462727       6 pod.go:233] enqueue add pod default/calico-python-daemon-fl2l4
I1111 12:10:50.462735       6 pod.go:233] enqueue add pod default/calico-python-no-check5-daemon-r9vz7
I1111 12:10:50.462737       6 pod.go:233] enqueue add pod default/calico-python1-daemon-rsmjk
I1111 12:10:50.462739       6 pod.go:233] enqueue add pod default/calico-python4-daemon-cjqvq
I1111 12:10:50.462749       6 pod.go:233] enqueue add pod default/calico-python-no-check3-daemon-s52j2
I1111 12:10:50.462752       6 pod.go:233] enqueue add pod default/calico-python3-daemon-6g5dz
I1111 12:10:50.462764       6 pod.go:233] enqueue add pod default/calico-python3-daemon-4t4xv
I1111 12:10:50.462768       6 pod.go:233] enqueue add pod default/calico-python-no-check5-daemon-kd9wg
I1111 12:10:50.462771       6 pod.go:233] enqueue add pod default/calico-python5-daemon-jq8tp
I1111 12:10:50.462780       6 pod.go:233] enqueue add pod default/calico-python-daemon-vpxh6
I1111 12:10:50.462784       6 pod.go:233] enqueue add pod default/calico-python-no-check3-daemon-kqhzj
I1111 12:10:50.462786       6 pod.go:233] enqueue add pod default/calico-python1-daemon-nwmxm
I1111 12:10:50.462790       6 pod.go:233] enqueue add pod default/calico-python4-daemon-zqs4k
I1111 12:10:50.462796       6 pod.go:233] enqueue add pod default/calico-python2-daemon-cm6xg
I1111 12:10:50.462798       6 pod.go:233] enqueue add pod default/calico-python5-daemon-ghd47
I1111 12:10:50.462803       6 pod.go:233] enqueue add pod default/calico-python-no-check1-daemon-lsqxs
I1111 12:10:50.462805       6 pod.go:233] enqueue add pod default/calico-python-no-check4-daemon-p6tj7
I1111 12:10:50.462809       6 pod.go:233] enqueue add pod default/calico-python1-daemon-n546h
I1111 12:10:50.462811       6 pod.go:233] enqueue add pod default/calico-python-no-check2-daemon-w6skf
E1111 12:10:50.634826       6 init.go:442] failed to get pod kubeovn nets calico-python2-daemon-cm6xg.default address : namespace default network annotations is empty
E1111 12:10:50.634843       6 init.go:442] failed to get pod kubeovn nets calico-python5-daemon-ghd47.default address : namespace default network annotations is empty
E1111 12:10:50.634915       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check1-daemon-lsqxs.default address : namespace default network annotations is empty
E1111 12:10:50.634922       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check4-daemon-p6tj7.default address : namespace default network annotations is empty
E1111 12:10:50.634928       6 init.go:442] failed to get pod kubeovn nets calico-python1-daemon-n546h.default address : namespace default network annotations is empty
E1111 12:10:50.634935       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check2-daemon-w6skf.default address : namespace default network annotations is empty
E1111 12:10:50.635021       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check1-daemon-84h9j.default address : namespace default network annotations is empty
E1111 12:10:50.635028       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check2-daemon-54kq7.default address : namespace default network annotations is empty
E1111 12:10:50.635067       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check1-daemon-frhsp.default address : namespace default network annotations is empty
E1111 12:10:50.635073       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check4-daemon-7cfpd.default address : namespace default network annotations is empty
E1111 12:10:50.635185       6 init.go:442] failed to get pod kubeovn nets calico-python2-daemon-zlv4l.default address : namespace default network annotations is empty
E1111 12:10:50.635421       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check-daemon-pglrs.default address : namespace default network annotations is empty
E1111 12:10:50.635478       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check5-daemon-glj7m.default address : namespace default network annotations is empty
E1111 12:10:50.635489       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check-daemon-mhlkw.default address : namespace default network annotations is empty
E1111 12:10:50.635495       6 init.go:442] failed to get pod kubeovn nets calico-python4-daemon-v57pb.default address : namespace default network annotations is empty
E1111 12:10:50.635507       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check2-daemon-wtb2w.default address : namespace default network annotations is empty
E1111 12:10:50.635616       6 init.go:442] failed to get pod kubeovn nets calico-python2-daemon-8pz6m.default address : namespace default network annotations is empty
E1111 12:10:50.635642       6 init.go:442] failed to get pod kubeovn nets calico-python5-daemon-9nklc.default address : namespace default network annotations is empty
E1111 12:10:50.635647       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check4-daemon-mpcfh.default address : namespace default network annotations is empty
E1111 12:10:50.635718       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check-daemon-lwb7v.default address : namespace default network annotations is empty
E1111 12:10:50.635757       6 init.go:442] failed to get pod kubeovn nets calico-python-daemon-67wjn.default address : namespace default network annotations is empty
E1111 12:10:50.635762       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check3-daemon-k8hxs.default address : namespace default network annotations is empty
E1111 12:10:50.635768       6 init.go:442] failed to get pod kubeovn nets calico-python3-daemon-lxqng.default address : namespace default network annotations is empty
E1111 12:10:50.635808       6 init.go:442] failed to get pod kubeovn nets calico-python-daemon-fl2l4.default address : namespace default network annotations is empty
E1111 12:10:50.635860       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check5-daemon-r9vz7.default address : namespace default network annotations is empty
E1111 12:10:50.635865       6 init.go:442] failed to get pod kubeovn nets calico-python1-daemon-rsmjk.default address : namespace default network annotations is empty
E1111 12:10:50.635872       6 init.go:442] failed to get pod kubeovn nets calico-python4-daemon-cjqvq.default address : namespace default network annotations is empty
E1111 12:10:50.635926       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check3-daemon-s52j2.default address : namespace default network annotations is empty
E1111 12:10:50.635932       6 init.go:442] failed to get pod kubeovn nets calico-python3-daemon-6g5dz.default address : namespace default network annotations is empty
E1111 12:10:50.636002       6 init.go:442] failed to get pod kubeovn nets calico-python3-daemon-4t4xv.default address : namespace default network annotations is empty
E1111 12:10:50.636008       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check5-daemon-kd9wg.default address : namespace default network annotations is empty
E1111 12:10:50.636014       6 init.go:442] failed to get pod kubeovn nets calico-python5-daemon-jq8tp.default address : namespace default network annotations is empty
E1111 12:10:50.636070       6 init.go:442] failed to get pod kubeovn nets calico-python-daemon-vpxh6.default address : namespace default network annotations is empty
E1111 12:10:50.636083       6 init.go:442] failed to get pod kubeovn nets calico-python-no-check3-daemon-kqhzj.default address : namespace default network annotations is empty
E1111 12:10:50.636089       6 init.go:442] failed to get pod kubeovn nets calico-python1-daemon-nwmxm.default address : namespace default network annotations is empty
E1111 12:10:50.636137       6 init.go:442] failed to get pod kubeovn nets calico-python4-daemon-zqs4k.default address : namespace default network annotations is empty

```

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
