### PR TITLE
bug: add support to ignore Calico pods during migrating from calico

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -188,6 +188,11 @@ func (c *Controller) enqueueAddPod(obj any) {
 		return
 	}
 
+	if util.IgnoreCalicoPod(p) {
+		klog.Infof("ignore add calico pod %s/%s", p.Namespace, p.Name)
+		return
+	}
+
 	// Pod might be targeted by manual endpoints and we need to recompute its port mappings
 	c.enqueueStaticEndpointUpdateInNamespace(p.Namespace)
 
@@ -261,6 +266,11 @@ func (c *Controller) enqueueDeletePod(obj any) {
 		return
 	}
 
+	if util.IgnoreCalicoPod(p) {
+		klog.Infof("ignore del calico pod %s/%s", p.Namespace, p.Name)
+		return
+	}
+
 	// Pod might be targeted by manual endpoints and we need to recompute its port mappings
 	c.enqueueStaticEndpointUpdateInNamespace(p.Namespace)
 
@@ -285,6 +295,11 @@ func (c *Controller) enqueueDeletePod(obj any) {
 func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 	oldPod := oldObj.(*v1.Pod)
 	newPod := newObj.(*v1.Pod)
+
+	if util.IgnoreCalicoPod(newPod) {
+		klog.Infof("ignore update calico pod %s/%s", newPod.Namespace, newPod.Name)
+		return
+	}
 
 	// Pod might be targeted by manual endpoints and we need to recompute its port mappings
 	c.enqueueStaticEndpointUpdateInNamespace(oldPod.Namespace)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -341,6 +341,9 @@ const (
 
 	MasqueradeExternalLBAccessMac = "00:00:00:01:00:01"
 	MasqueradeCheckIP             = "0.0.0.0"
+
+	// Ignore Calico pods
+	CalicoPodIPAnnotation = "cni.projectcalico.org/podIP"
 )
 
 var KubeVirtCRD = []string{"virtualmachineinstancemigrations.kubevirt.io", "virtualmachines.kubevirt.io"}

--- a/pkg/util/pod_filter.go
+++ b/pkg/util/pod_filter.go
@@ -1,0 +1,12 @@
+package util
+
+import v1 "k8s.io/api/core/v1"
+
+// IgnoreCalicoPod returns true when the given annotations map contains the Calico pod IP key.
+func IgnoreCalicoPod(pod *v1.Pod) bool {
+	if pod.Annotations == nil {
+		return false
+	}
+	_, ok := pod.Annotations[CalicoPodIPAnnotation]
+	return ok
+}


### PR DESCRIPTION
…o kubeovn, to avoid ip allocate to a running pod

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->


- Bug fixes


bug: add support to ignore Calico pods during migrating from calico to kubeovn, to avoid ip allocate to a running pod

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
