### PR TITLE
fix: use the same cni dir as the mount

### DIFF
--- a/charts/kube-ovn-v2/README.md
+++ b/charts/kube-ovn-v2/README.md
@@ -650,6 +650,15 @@ false
 			<td>Location of the CNI configuration inside the agent's pod.</td>
 		</tr>
 		<tr>
+			<td>cni.mountConfigDirectory</td>
+			<td>string</td>
+			<td><pre lang="json">
+"/etc/cni/net.d"
+</pre>
+</td>
+			<td>Location of the CNI configuration to be mounted inside the pod.</td>
+		</tr>
+		<tr>
 			<td>cni.mountToolingDirectory</td>
 			<td>bool</td>
 			<td><pre lang="json">

--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -77,7 +77,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - /kube-ovn/install-cni.sh
-          - --cni-conf-dir=/etc/cni/net.d
+          - --cni-conf-dir={{ .Values.cni.mountConfigDirectory }}
           - --cni-conf-file={{ .Values.cni.localConfigFile }}
           - --cni-conf-name={{- .Values.cni.configPriority -}}-kube-ovn.conflist
         securityContext:
@@ -86,7 +86,7 @@ spec:
         volumeMounts:
           - mountPath: /opt/cni/bin
             name: cni-bin
-          - mountPath: /etc/cni/net.d
+          - mountPath: {{ .Values.cni.mountConfigDirectory }}
             name: cni-conf
           {{- if .Values.cni.mountToolingDirectory }}
           - mountPath: /usr/local/bin

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -240,6 +240,9 @@ cni:
   # -- Location of the CNI configuration on the node.
   # @section -- CNI configuration
   configDirectory: "/etc/cni/net.d"
+  # -- Location of the CNI configuration to be mounted inside the pod.
+  # @section -- CNI configuration
+  mountConfigDirectory: "/etc/cni/net.d"
   # -- Location on the node where the agent will inject the Kube-OVN binary.
   # @section -- CNI configuration
   binaryDirectory: "/opt/cni/bin"

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -61,7 +61,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - /kube-ovn/install-cni.sh
-          - --cni-conf-dir=/etc/cni/net.d
+          - --cni-conf-dir={{ .Values.cni_conf.MOUNT_CNI_CONF_DIR }}
           - --cni-conf-file={{ .Values.cni_conf.CNI_CONF_FILE }}
           - --cni-conf-name={{- .Values.cni_conf.CNI_CONFIG_PRIORITY -}}-kube-ovn.conflist
         securityContext:
@@ -70,7 +70,7 @@ spec:
         volumeMounts:
           - mountPath: /opt/cni/bin
             name: cni-bin
-          - mountPath: /etc/cni/net.d
+          - mountPath: {{ .Values.cni_conf.MOUNT_CNI_CONF_DIR }}
             name: cni-conf
           {{- if .Values.cni_conf.MOUNT_LOCAL_BIN_DIR }}
           - mountPath: /usr/local/bin

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -120,6 +120,7 @@ debug:
 cni_conf:
   CNI_CONFIG_PRIORITY: "01"
   CNI_CONF_DIR: "/etc/cni/net.d"
+  MOUNT_CNI_CONF_DIR: "/etc/cni/net.d"
   CNI_BIN_DIR: "/opt/cni/bin"
   CNI_CONF_FILE: "/kube-ovn/01-kube-ovn.conflist"
   LOCAL_BIN_DIR: "/usr/local/bin"


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Bug fixes

Sets the cni-conf-dir to `/etc/cni/net.d`, because that's the path mounted to the installer pod. configDirectory is already used properly in the mount's creation.