### PR TITLE
fix: correct error log message in getDBStatus function

### DIFF
--- a/pkg/ovnmonitor/util.go
+++ b/pkg/ovnmonitor/util.go
@@ -323,7 +323,7 @@ func getDBStatus(dbName string) (bool, error) {
 	cmd := exec.Command("sh", "-c", cmdstr) // #nosec G204
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Errorf("get ovn-northbound status failed, err %v", err)
+		klog.Errorf("get %s status failed, err %v", dbName, err)
 		return false, err
 	}
 	lines := strings.SplitSeq(string(output), "\n")


### PR DESCRIPTION
The error message in getDBStatus() was hardcoded to display 'ovn-northbound' regardless of which database actually failed. This could be misleading when OVN_Southbound database fails.