### PR TITLE
fix goland bug when go mod list 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -320,6 +320,7 @@ replace (
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.2
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.2
 	kubevirt.io/client-go => github.com/kubeovn/kubevirt-client-go v0.0.0-20250902065734-b1fa2304d8ab
+	k8s.io/externaljwt => github.com/kubernetes/externaljwt v0.34.2
 )
 
 tool go.uber.org/mock/mockgen


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

我不明白为什么，当我使用goland进行代码修改时，goland总是会执行"go list -m json all" 行为，并且在shell端执行go mod ，goland也总能监测到并且继续执行这个行为。 然后就会报错"go: k8s.io/externaljwt@v0.0.0: invalid version: unknown revision v0.0.0"

这是个无解的行为，问题导致goland中的依赖被破坏。 经过对ai的拷打，总结出来一个在replace中添加"k8s.io/externaljwt => github.com/kubernetes/externaljwt v0.0.0"，替换到externaljwt v0.0.0


