### PR TITLE
fix: correct spelling of "deleting" in log messages

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1638,7 +1638,7 @@ func (c *Controller) getPodDefaultSubnet(pod *v1.Pod) (*kubeovnv1.Subnet, error)
 			klog.Errorf("failed to get subnet %s: %v", lsName, err)
 			if k8serrors.IsNotFound(err) {
 				if ignoreSubnetNotExist {
-					klog.Errorf("deletting pod %s/%s default subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, lsName)
+					klog.Errorf("deleting pod %s/%s default subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, lsName)
 					return nil, nil
 				}
 			}
@@ -1670,7 +1670,7 @@ func (c *Controller) getPodDefaultSubnet(pod *v1.Pod) (*kubeovnv1.Subnet, error)
 			klog.Errorf("failed to get subnet %s: %v", subnetName, err)
 			if k8serrors.IsNotFound(err) {
 				if ignoreSubnetNotExist {
-					klog.Errorf("deletting pod %s/%s namespace subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
+					klog.Errorf("deleting pod %s/%s namespace subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
 					// ip name is unique, it is ok if any subnet release it
 					// gc will handle their ip cr, if all subnets are not exist
 					continue
@@ -1862,7 +1862,7 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 					klog.Errorf("failed to pod default subnet, %v", err)
 					if k8serrors.IsNotFound(err) {
 						if ignoreSubnetNotExist {
-							klog.Errorf("deletting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
+							klog.Errorf("deleting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
 							continue
 						}
 					}
@@ -1876,7 +1876,7 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 					klog.Errorf("failed to get subnet %s, %v", subnetName, err)
 					if k8serrors.IsNotFound(err) {
 						if ignoreSubnetNotExist {
-							klog.Errorf("deletting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
+							klog.Errorf("deleting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
 							// just continue to next attach subnet
 							// ip name is unique, so it is ok if the other subnet release it
 							continue


### PR DESCRIPTION
Fix spelling error in pod deletion log messages.
