### PR TITLE
fix: correct V6Eip field assignment in OvnDnatRule status

### DIFF
--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -508,7 +508,7 @@ func (c *Controller) patchOvnDnatStatus(key, vpcName, v4Eip, v6Eip, internalV4Ip
 		changed = true
 	}
 	if v6Eip != "" && dnat.Status.V6Eip != v6Eip {
-		dnat.Status.V4Eip = v6Eip
+		dnat.Status.V6Eip = v6Eip
 		changed = true
 	}
 	if internalV4Ip != "" && dnat.Status.V4Ip != internalV4Ip {


### PR DESCRIPTION
Fix a bug where IPv6 EIP was incorrectly assigned to V4Eip field instead of V6Eip field in patchOvnDnatStatus function. This caused IPv6 DNAT rules to not be properly deleted and status display errors.