### PR TITLE
perf: only tregger update when related annotations changed

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"maps"
 	"reflect"
 	"slices"
 	"strconv"
@@ -63,7 +62,7 @@ func (c *Controller) enqueueUpdateNp(oldObj, newObj any) {
 	oldNp := oldObj.(*netv1.NetworkPolicy)
 	newNp := newObj.(*netv1.NetworkPolicy)
 	if !reflect.DeepEqual(oldNp.Spec, newNp.Spec) ||
-		!maps.Equal(oldNp.Annotations, newNp.Annotations) {
+		kubeOvnAnnotationsChanged(oldNp.Annotations, newNp.Annotations) {
 		key := cache.MetaObjectToName(newNp).String()
 		klog.V(3).Infof("enqueue update np %s", key)
 		c.updateNpQueue.Add(key)

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -1,0 +1,177 @@
+package controller
+
+import (
+	"testing"
+)
+
+func TestKubeOvnAnnotationsChanged(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldAnnotations map[string]string
+		newAnnotations map[string]string
+		expected       bool
+	}{
+		{
+			name:           "no annotations",
+			oldAnnotations: map[string]string{},
+			newAnnotations: map[string]string{},
+			expected:       false,
+		},
+		{
+			name:           "kube-ovn annotation added",
+			oldAnnotations: map[string]string{},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/allocated": "true",
+			},
+			expected: true,
+		},
+		{
+			name: "kube-ovn annotation removed",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/allocated": "true",
+			},
+			newAnnotations: map[string]string{},
+			expected:       true,
+		},
+		{
+			name: "kube-ovn annotation value changed",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+			},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.2",
+			},
+			expected: true,
+		},
+		{
+			name: "kube-ovn annotation unchanged",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+			},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+			},
+			expected: false,
+		},
+		{
+			name: "non-kube-ovn annotation changed",
+			oldAnnotations: map[string]string{
+				"other.io/annotation": "value1",
+			},
+			newAnnotations: map[string]string{
+				"other.io/annotation": "value2",
+			},
+			expected: false,
+		},
+		{
+			name: "mixed annotations, only non-kube-ovn changed",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+				"other.io/annotation":          "value1",
+			},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+				"other.io/annotation":          "value2",
+			},
+			expected: false,
+		},
+		{
+			name: "mixed annotations, kube-ovn changed",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+				"other.io/annotation":          "value1",
+			},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.2",
+				"other.io/annotation":          "value2",
+			},
+			expected: true,
+		},
+		{
+			name: "multiple kube-ovn annotations unchanged",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address":  "10.0.0.1",
+				"ovn.kubernetes.io/mac_address": "00:11:22:33:44:55",
+				"ovn.kubernetes.io/allocated":   "true",
+			},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address":  "10.0.0.1",
+				"ovn.kubernetes.io/mac_address": "00:11:22:33:44:55",
+				"ovn.kubernetes.io/allocated":   "true",
+			},
+			expected: false,
+		},
+		{
+			name: "multiple kube-ovn annotations, one changed",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address":  "10.0.0.1",
+				"ovn.kubernetes.io/mac_address": "00:11:22:33:44:55",
+			},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address":  "10.0.0.1",
+				"ovn.kubernetes.io/mac_address": "00:11:22:33:44:56",
+			},
+			expected: true,
+		},
+		{
+			name: "provider network annotation changed",
+			oldAnnotations: map[string]string{
+				"net1.kubernetes.io/provider_network": "provider1",
+			},
+			newAnnotations: map[string]string{
+				"net1.kubernetes.io/provider_network": "provider2",
+			},
+			expected: true,
+		},
+		{
+			name: "annotation with kubernetes.io in value not key",
+			oldAnnotations: map[string]string{
+				"some.annotation": "value.kubernetes.io",
+			},
+			newAnnotations: map[string]string{
+				"some.annotation": "changed.kubernetes.io",
+			},
+			expected: false,
+		},
+		{
+			name:           "empty to kube-ovn annotations",
+			oldAnnotations: map[string]string{},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address":  "10.0.0.1",
+				"ovn.kubernetes.io/mac_address": "00:11:22:33:44:55",
+				"ovn.kubernetes.io/chassis":     "node1",
+			},
+			expected: true,
+		},
+		{
+			name: "kube-ovn annotations to empty",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address":  "10.0.0.1",
+				"ovn.kubernetes.io/mac_address": "00:11:22:33:44:55",
+			},
+			newAnnotations: map[string]string{},
+			expected:       true,
+		},
+		{
+			name: "non-kube-ovn added and removed",
+			oldAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+				"old.annotation":               "value",
+			},
+			newAnnotations: map[string]string{
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+				"new.annotation":               "value",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := kubeOvnAnnotationsChanged(tt.oldAnnotations, tt.newAnnotations)
+			if result != tt.expected {
+				t.Errorf("kubeOvnAnnotationsChanged() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -60,7 +60,7 @@ func (c *Controller) enqueueUpdateVpc(oldObj, newObj any) {
 		!reflect.DeepEqual(oldVpc.Spec.StaticRoutes, newVpc.Spec.StaticRoutes) ||
 		!reflect.DeepEqual(oldVpc.Spec.PolicyRoutes, newVpc.Spec.PolicyRoutes) ||
 		!reflect.DeepEqual(oldVpc.Spec.VpcPeerings, newVpc.Spec.VpcPeerings) ||
-		!maps.Equal(oldVpc.Annotations, newVpc.Annotations) ||
+		kubeOvnAnnotationsChanged(oldVpc.Annotations, newVpc.Annotations) ||
 		!slices.Equal(oldVpc.Spec.ExtraExternalSubnets, newVpc.Spec.ExtraExternalSubnets) ||
 		oldVpc.Spec.EnableExternal != newVpc.Spec.EnableExternal ||
 		oldVpc.Spec.EnableBfd != newVpc.Spec.EnableBfd ||


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Performance

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

Previously, any change to a node's annotation would trigger nodeUpdate and subnetUpdate events. However, KubeVirt continuously updates a heartbeat annotation on nodes, causing unnecessary updates for Kube-OVN. This PR further filters the annotations to only those we need to handle.

## Which issue(s) this PR fixes

Fixes #(issue-number)
