### PR TITLE
feat: create the ability to map external Parent Keys

### DIFF
--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -148,6 +148,7 @@ spec:
           - --alsologtostderr=true
           - --gc-interval={{- .Values.performance.gcInterval }}
           - --inspect-interval={{- .Values.performance.inspectInterval }}
+          - --external-acl-parent-keys={{- .Values.performance.externalAclParentKeys }}
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
           - --log_file_max_size=200
           - --enable-lb-svc={{- .Values.features.enableLoadbalancerService }}

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -740,6 +740,12 @@ performance:
   # -- ""
   # @section -- Performance configuration
   ovsVsctlConcurrency: 100
+  # -- Comma-separated list of external_ids key patterns to preserve during GC.
+  # Use this in mixed environments (e.g., OpenStack Neutron) to prevent Kube-OVN
+  # from garbage collecting resources managed by external systems.
+  # Supports glob patterns (e.g., "neutron:*" matches "neutron:security_group_id").
+  # @section -- Performance configuration
+  externalAclParentKeys: ""
 
 # -- Array of extra K8s manifests to deploy.
 # Note: Supports use of custom Helm templates (Go templating)

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -133,6 +133,7 @@ spec:
           - --alsologtostderr=true
           - --gc-interval={{- .Values.performance.GC_INTERVAL }}
           - --inspect-interval={{- .Values.performance.INSPECT_INTERVAL }}
+          - --external-acl-parent-keys={{- .Values.performance.EXTERNAL_ACL_PARENT_KEYS }}
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
           - --log_file_max_size=200
           - --enable-lb-svc={{- .Values.func.ENABLE_LB_SVC }}

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -112,6 +112,11 @@ performance:
   GC_INTERVAL: 360
   INSPECT_INTERVAL: 20
   OVS_VSCTL_CONCURRENCY: 100
+  # Comma-separated list of external_ids key patterns to preserve during GC.
+  # Use this in mixed environments (e.g., OpenStack Neutron) to prevent Kube-OVN
+  # from garbage collecting resources managed by external systems.
+  # Supports glob patterns (e.g., "neutron:*" matches "neutron:security_group_id").
+  EXTERNAL_ACL_PARENT_KEYS: ""
 
 debug:
   ENABLE_MIRROR: false

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -133,6 +133,7 @@ DPDK_MEMORY="2Gi"                       # Default Memory configuration for it --
 # performance
 GC_INTERVAL=360
 INSPECT_INTERVAL=20
+EXTERNAL_ACL_PARENT_KEYS=""  # Comma-separated list of external_ids key patterns to preserve during GC (e.g., "neutron:*")
 
 display_help() {
     echo "Usage: $0 [option...]"
@@ -4803,6 +4804,7 @@ spec:
           - --alsologtostderr=true
           - --gc-interval=$GC_INTERVAL
           - --inspect-interval=$INSPECT_INTERVAL
+          - --external-acl-parent-keys=$EXTERNAL_ACL_PARENT_KEYS
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
           - --log_file_max_size=200
           - --enable-lb-svc=$ENABLE_LB_SVC

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -4283,6 +4283,20 @@ func (mr *MockNbClientMockRecorder) GetPortGroup(pgName, ignoreNotFound any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortGroup", reflect.TypeOf((*MockNbClient)(nil).GetPortGroup), pgName, ignoreNotFound)
 }
 
+// IsKnownParentKey mocks base method.
+func (m *MockNbClient) IsKnownParentKey(externalIDs map[string]string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsKnownParentKey", externalIDs)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsKnownParentKey indicates an expected call of IsKnownParentKey.
+func (mr *MockNbClientMockRecorder) IsKnownParentKey(externalIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsKnownParentKey", reflect.TypeOf((*MockNbClient)(nil).IsKnownParentKey), externalIDs)
+}
+
 // ListAddressSets mocks base method.
 func (m *MockNbClient) ListAddressSets(externalIDs map[string]string) ([]ovnnb.AddressSet, error) {
 	m.ctrl.T.Helper()
@@ -5069,6 +5083,18 @@ func (m *MockNbClient) SetAzName(azName string) error {
 func (mr *MockNbClientMockRecorder) SetAzName(azName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAzName", reflect.TypeOf((*MockNbClient)(nil).SetAzName), azName)
+}
+
+// SetExternalParentKeys mocks base method.
+func (m *MockNbClient) SetExternalParentKeys(keys []string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetExternalParentKeys", keys)
+}
+
+// SetExternalParentKeys indicates an expected call of SetExternalParentKeys.
+func (mr *MockNbClientMockRecorder) SetExternalParentKeys(keys any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExternalParentKeys", reflect.TypeOf((*MockNbClient)(nil).SetExternalParentKeys), keys)
 }
 
 // SetICAutoRoute mocks base method.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -599,6 +599,9 @@ func Run(ctx context.Context, config *Configuration) {
 	); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn nb client")
 	}
+
+	// Set external ACL parent keys for GC exclusion (for mixed environments like OpenStack Neutron)
+	controller.OVNNbClient.SetExternalParentKeys(config.ExternalACLParentKeys)
 	if controller.OVNSbClient, err = ovs.NewOvnSbClient(
 		config.OvnSbAddr,
 		config.OvnTimeout,

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -795,6 +795,13 @@ func (c *Controller) gcSecurityGroup() error {
 		if pg.Name == denyAllPg || pg.Name == defaultPg || pg.ExternalIDs[networkPolicyKey] != "" {
 			continue
 		}
+
+		// Skip port groups that have external parent keys (managed by external systems like OpenStack Neutron)
+		if c.OVNNbClient.IsKnownParentKey(pg.ExternalIDs) && pg.ExternalIDs["sg"] == "" {
+			klog.V(5).Infof("skipping gc for port group %s with external parent key", pg.Name)
+			continue
+		}
+
 		// if port group not exist in security group, delete it
 		if !sgSet.Has(pg.ExternalIDs["sg"]) {
 			klog.Infof("ready to gc port group %s", pg.Name)

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -266,6 +266,8 @@ type NbClient interface {
 	RemoveLogicalPatchPort(lspName, lrpName string) error
 	DeleteLogicalGatewaySwitch(lsName, lrName string) error
 	DeleteSecurityGroup(sgName string) error
+	SetExternalParentKeys(keys []string)
+	IsKnownParentKey(externalIDs map[string]string) bool
 	Common
 }
 

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -1613,8 +1613,8 @@ func (c *OVNNbClient) CleanNoParentKeyAcls() error {
 
 	var aclList []ovnnb.ACL
 	if err := c.ovsDbClient.WhereCache(func(acl *ovnnb.ACL) bool {
-		_, ok := acl.ExternalIDs[aclParentKey]
-		return !ok
+		// Skip ACLs that have a known parent key (either Kube-OVN's "parent" or external system keys)
+		return !c.IsKnownParentKey(acl.ExternalIDs)
 	}).List(ctx, &aclList); err != nil {
 		err = fmt.Errorf("failed to list acls without parent: %w", err)
 		klog.Error(err)

--- a/pkg/ovs/ovn.go
+++ b/pkg/ovs/ovn.go
@@ -30,6 +30,11 @@ type LegacyClient struct {
 
 type OVNNbClient struct {
 	ovsDbClient
+	// ExternalParentKeys holds user-configured external_ids key patterns that should be
+	// preserved during garbage collection. This allows Kube-OVN to coexist with other
+	// systems (like OpenStack Neutron) that manage OVN resources with their own external_ids.
+	// Patterns support glob matching (e.g., "neutron:*" matches "neutron:security_group_id").
+	ExternalParentKeys []string
 }
 
 type OVNSbClient struct {


### PR DESCRIPTION
This feature addresses bug #5995 by creating a system that would allow an operator to extend the known Parent IDs giving kube-ovn better means to co-exist in mixed datacenter operations. The change introduces a new configuration option that takes a comma separated list of strings, with glob capablities. This new option will allow operators to provide a define a list of external IDs which will be respected by Kube-OVNs cleanup system.

Fixes: https://github.com/kubeovn/kube-ovn/issues/5995

# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes

Fixes #5995
