### PR TITLE
support natgw net1 use private net and eip net to save real eip

### DIFF
--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -142,9 +142,10 @@ func (c *Controller) handleAddIptablesEip(key string) error {
 		return err
 	}
 
-	// Get the external subnet gateway to pass to nat-gateway.sh
-	externalGateway := subnet.Spec.Gateway
-	if err = c.createEipInPod(cachedEip.Spec.NatGwDp, addrV4, externalGateway); err != nil {
+	// Get the external subnet gateway matching the EIP IP version
+	// For IPv4 EIP, use IPv4 gateway; for IPv6 EIP, use IPv6 gateway
+	gwV4, _ := util.SplitStringIP(subnet.Spec.Gateway)
+	if err = c.createEipInPod(cachedEip.Spec.NatGwDp, addrV4, gwV4); err != nil {
 		klog.Errorf("failed to create eip '%s' in pod, %v", key, err)
 		return err
 	}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

 工作流程：

  1. 用户创建 IptablesEIP
     ↓
  2. Controller 从 ExternalSubnet 获取网关（10.34.251.254）
     ↓
  3. 调用 nat-gateway.sh: eip-add 10.34.251.100/24,10.34.251.254
     ↓
  4. nat-gateway.sh:
     - 添加 EIP: ip addr add 10.34.251.100/24 dev net1
     - 替换路由: ip route replace default via 10.34.251.254 dev net1
     ↓
  5. ✅ EIP 能访问公网


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
