### PR TITLE
feat: add vendor information to objects

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -64,6 +64,20 @@ func (mr *MockNBGlobalMockRecorder) GetNbGlobal() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNbGlobal", reflect.TypeOf((*MockNBGlobal)(nil).GetNbGlobal))
 }
 
+// MigrateVendorExternalIDs mocks base method.
+func (m *MockNBGlobal) MigrateVendorExternalIDs() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MigrateVendorExternalIDs")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MigrateVendorExternalIDs indicates an expected call of MigrateVendorExternalIDs.
+func (mr *MockNBGlobalMockRecorder) MigrateVendorExternalIDs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateVendorExternalIDs", reflect.TypeOf((*MockNBGlobal)(nil).MigrateVendorExternalIDs))
+}
+
 // SetAzName mocks base method.
 func (m *MockNBGlobal) SetAzName(azName string) error {
 	m.ctrl.T.Helper()
@@ -4901,6 +4915,20 @@ func (m *MockNbClient) MigrateACLTier() error {
 func (mr *MockNbClientMockRecorder) MigrateACLTier() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateACLTier", reflect.TypeOf((*MockNbClient)(nil).MigrateACLTier))
+}
+
+// MigrateVendorExternalIDs mocks base method.
+func (m *MockNbClient) MigrateVendorExternalIDs() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MigrateVendorExternalIDs")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MigrateVendorExternalIDs indicates an expected call of MigrateVendorExternalIDs.
+func (mr *MockNbClientMockRecorder) MigrateVendorExternalIDs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateVendorExternalIDs", reflect.TypeOf((*MockNbClient)(nil).MigrateVendorExternalIDs))
 }
 
 // MonitorBFD mocks base method.

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func newLogicalRouterPort(lrName, lrpName, mac string, networks []string) *ovnnb.LogicalRouterPort {
@@ -15,7 +16,8 @@ func newLogicalRouterPort(lrName, lrpName, mac string, networks []string) *ovnnb
 		MAC:      mac,
 		Networks: networks,
 		ExternalIDs: map[string]string{
-			"lr": lrName,
+			"lr":     lrName,
+			"vendor": util.CniTypeName,
 		},
 	}
 }

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -30,8 +30,24 @@ import (
 func (c *Controller) InitOVN() error {
 	var err error
 
-	if err = c.migrateACLForVersionCompat(); err != nil {
-		klog.Errorf("failed to sync the older acl : %v", err)
+	// migrate vendor externalIDs to kube-ovn resources created in versions prior to v1.15.0
+	// this must run before ACL cleanup to ensure existing resources are properly tagged
+	if err = c.OVNNbClient.MigrateVendorExternalIDs(); err != nil {
+		klog.Errorf("failed to migrate vendor externalIDs: %v", err)
+		return err
+	}
+
+	// migrate tier field of ACL rules created in versions prior to v1.13.0
+	// after upgrading, the tier field has a default value of zero, which is not the value used in versions >= v1.13.0
+	// we need to migrate the tier field to the correct value
+	if err = c.OVNNbClient.MigrateACLTier(); err != nil {
+		klog.Errorf("failed to migrate ACL tier: %v", err)
+		return err
+	}
+
+	// clean all no parent key acls
+	if err = c.OVNNbClient.CleanNoParentKeyAcls(); err != nil {
+		klog.Errorf("failed to clean all no parent key acls: %v", err)
 		return err
 	}
 
@@ -67,22 +83,6 @@ func (c *Controller) InitOVN() error {
 		return err
 	}
 
-	return nil
-}
-
-func (c *Controller) migrateACLForVersionCompat() error {
-	// migrate tier field of ACL rules created in versions prior to v1.13.0
-	// after upgrading, the tier field has a default value of zero, which is not the value used in versions >= v1.13.0
-	// we need to migrate the tier field to the correct value
-	if err := c.OVNNbClient.MigrateACLTier(); err != nil {
-		klog.Errorf("failed to migrate ACL tier: %v", err)
-		return err
-	}
-	// clean all no parent key acls
-	if err := c.OVNNbClient.CleanNoParentKeyAcls(); err != nil {
-		klog.Errorf("failed to clean all no parent key acls: %v", err)
-		return err
-	}
 	return nil
 }
 

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -27,6 +27,7 @@ type NBGlobal interface {
 	SetNodeLocalDNSIP(nodeLocalDNSIP string) error
 	SetSkipConntrackCidrs(skipConntrackCidrs string) error
 	GetNbGlobal() (*ovnnb.NBGlobal, error)
+	MigrateVendorExternalIDs() error
 }
 
 type LogicalRouter interface {

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -70,6 +70,7 @@ func newACL(parentName, direction, priority, match, action string, tier int, opt
 		Priority:  intPriority,
 		ExternalIDs: map[string]string{
 			aclParentKey: parentName,
+			"vendor":     util.CniTypeName,
 		},
 		Tier: tier,
 	}
@@ -1910,6 +1911,7 @@ func (suite *OvnClientTestSuite) testNewACL() {
 		Priority:  1000,
 		ExternalIDs: map[string]string{
 			aclParentKey: pgName,
+			"vendor":     util.CniTypeName,
 		},
 		Log:      true,
 		Severity: ptr.To(ovnnb.ACLSeverityWarning),

--- a/pkg/ovs/ovn-nb-address_set_test.go
+++ b/pkg/ovs/ovn-nb-address_set_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func newAddressSet(name string, externalIDs map[string]string) *ovnnb.AddressSet {
@@ -33,8 +34,10 @@ func (suite *OvnClientTestSuite) testCreateAddressSet() {
 		require.NoError(t, err)
 		require.NotEmpty(t, as.UUID)
 		require.Equal(t, asName, as.Name)
+		// vendor is automatically added by CreateAddressSet
 		require.Equal(t, map[string]string{
-			sgKey: "test-sg",
+			sgKey:    "test-sg",
+			"vendor": util.CniTypeName,
 		}, as.ExternalIDs)
 	})
 

--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -16,6 +16,7 @@ import (
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 // CreateLoadBalancer create loadbalancer
@@ -43,6 +44,9 @@ func (c *OVNNbClient) CreateLoadBalancer(lbName, protocol, selectFields string) 
 		UUID:     ovsclient.NamedUUID(),
 		Name:     lbName,
 		Protocol: &protocol,
+		ExternalIDs: map[string]string{
+			"vendor": util.CniTypeName,
+		},
 	}
 
 	if len(selectFields) != 0 {

--- a/pkg/ovs/ovn-nb-logical_router_port.go
+++ b/pkg/ovs/ovn-nb-logical_router_port.go
@@ -189,6 +189,9 @@ func (c *OVNNbClient) CreateLogicalRouterPort(lrName, lrpName, mac string, netwo
 		Name:     lrpName,
 		MAC:      mac,
 		Networks: networks,
+		ExternalIDs: map[string]string{
+			"vendor": util.CniTypeName,
+		},
 	}
 
 	op, err := c.CreateLogicalRouterPortOp(lrp, lrName)

--- a/pkg/ovs/ovn-nb-migration.go
+++ b/pkg/ovs/ovn-nb-migration.go
@@ -1,0 +1,595 @@
+package ovs
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/versions"
+)
+
+const (
+	// kubeOvnVersionKey is the key used to store kube-ovn version in NBGlobal ExternalIDs
+	kubeOvnVersionKey = "kube-ovn-version"
+)
+
+// Naming patterns used by kube-ovn resources
+var (
+	// Security group port group pattern: ovn.sg.{name} (with dashes replaced by dots)
+	// Requires at least one character after "ovn.sg."
+	sgPortGroupPattern = regexp.MustCompile(`^ovn\.sg\..+`)
+
+	// Security group address set patterns: ovn.sg.{name}.associated.v4/v6
+	sgAddressSetPattern = regexp.MustCompile(`^ovn\.sg\..+\.associated\.v[46]$`)
+
+	// Network policy address set patterns: {name}.{namespace}.{ingress|egress}.{allow|except}.{ip4|ip6|all}.{index}
+	npAddressSetPattern = regexp.MustCompile(`\.(ingress|egress)\.(allow|except)\.(ip[46]|all)(\.\d+)?$`)
+
+	// kube-ovn load balancer patterns
+	clusterLBPattern = regexp.MustCompile(`^cluster-(tcp|udp|sctp)(-session)?-loadbalancer$`)
+	vpcLBPattern     = regexp.MustCompile(`^vpc-.+-(tcp|udp|sctp)-(load|sess-load)$`)
+)
+
+// GetKubeOvnVersion retrieves the stored kube-ovn version from NBGlobal ExternalIDs
+func (c *OVNNbClient) GetKubeOvnVersion() (string, error) {
+	nbGlobal, err := c.GetNbGlobal()
+	if err != nil {
+		return "", fmt.Errorf("failed to get NBGlobal: %w", err)
+	}
+
+	if nbGlobal.ExternalIDs == nil {
+		return "", nil
+	}
+
+	return nbGlobal.ExternalIDs[kubeOvnVersionKey], nil
+}
+
+// SetKubeOvnVersion stores the kube-ovn version in NBGlobal ExternalIDs
+func (c *OVNNbClient) SetKubeOvnVersion(version string) error {
+	nbGlobal, err := c.GetNbGlobal()
+	if err != nil {
+		return fmt.Errorf("failed to get NBGlobal: %w", err)
+	}
+
+	if nbGlobal.ExternalIDs == nil {
+		nbGlobal.ExternalIDs = make(map[string]string)
+	}
+
+	if nbGlobal.ExternalIDs[kubeOvnVersionKey] == version {
+		return nil // already set to current version
+	}
+
+	nbGlobal.ExternalIDs[kubeOvnVersionKey] = version
+	if err := c.UpdateNbGlobal(nbGlobal, &nbGlobal.ExternalIDs); err != nil {
+		return fmt.Errorf("failed to update NBGlobal with kube-ovn version: %w", err)
+	}
+
+	klog.Infof("updated kube-ovn version in NBGlobal to %s", version)
+	return nil
+}
+
+// needsVendorMigration checks if vendor migration is needed based on version comparison.
+// Migration is needed if:
+// 1. No version is stored (fresh install or upgrade from very old version)
+// 2. Stored version is older than the version that introduced vendor tagging (v1.15.0)
+func (c *OVNNbClient) needsVendorMigration() (bool, error) {
+	storedVersion, err := c.GetKubeOvnVersion()
+	if err != nil {
+		return false, err
+	}
+
+	// No version stored - this is either a fresh install or an upgrade from an old version
+	// In either case, we should run migration (it's idempotent and will skip if nothing to do)
+	if storedVersion == "" {
+		klog.Info("no kube-ovn version found in NBGlobal, migration may be needed")
+		return true, nil
+	}
+
+	// If stored version matches current version, no migration needed
+	// This handles the case where version is "unknown" during tests
+	if storedVersion == versions.VERSION {
+		klog.Infof("stored version %s matches current version, skipping vendor migration", storedVersion)
+		return false, nil
+	}
+
+	// Strip 'v' prefix if present for comparison
+	stored := strings.TrimPrefix(storedVersion, "v")
+	vendorTagVersion := "1.15.0" // version that introduced vendor tagging
+
+	// If stored version is older than v1.15.0, we need to migrate
+	if util.CompareVersion(stored, vendorTagVersion) < 0 {
+		klog.Infof("stored version %s is older than %s, vendor migration needed", storedVersion, vendorTagVersion)
+		return true, nil
+	}
+
+	klog.Infof("stored version %s is >= %s, skipping vendor migration", storedVersion, vendorTagVersion)
+	return false, nil
+}
+
+// MigrateVendorExternalIDs adds vendor=kube-ovn externalID to existing kube-ovn OVN resources
+// that don't already have it. This is called during controller initialization to handle
+// upgrades from versions prior to vendor tagging (v1.15.0).
+//
+// The migration only runs when:
+// 1. No version is stored in NBGlobal (fresh install or very old upgrade)
+// 2. Stored version is older than v1.15.0 (when vendor tagging was introduced)
+//
+// The migration uses several strategies to identify kube-ovn resources:
+// 1. Resources with existing kube-ovn-specific externalIDs (lr, ls, parent, sg, etc.)
+// 2. Resources with kube-ovn naming patterns
+// 3. Resources associated with known kube-ovn logical routers/switches
+//
+// Resources that cannot be positively identified as kube-ovn resources are left untouched
+// to avoid interfering with external systems like OpenStack Neutron.
+//
+// After successful migration, the current version is stored in NBGlobal to prevent
+// re-running on subsequent restarts.
+func (c *OVNNbClient) MigrateVendorExternalIDs() error {
+	// Check if migration is needed based on version
+	needsMigration, err := c.needsVendorMigration()
+	if err != nil {
+		klog.Errorf("failed to check if vendor migration is needed: %v", err)
+		return err
+	}
+
+	if !needsMigration {
+		// Still update version to current if it changed (e.g., patch upgrade within same major)
+		return c.SetKubeOvnVersion(versions.VERSION)
+	}
+
+	klog.Info("starting migration of vendor externalIDs to kube-ovn resources")
+
+	// Get all kube-ovn logical routers (they already have vendor tag from CreateLogicalRouter)
+	kubeOvnRouters, err := c.getKubeOvnRouterNames()
+	if err != nil {
+		klog.Errorf("failed to get kube-ovn router names: %v", err)
+		return err
+	}
+	klog.Infof("found %d kube-ovn logical routers", len(kubeOvnRouters))
+
+	// Get all kube-ovn logical switches (they already have vendor tag)
+	kubeOvnSwitches, err := c.getKubeOvnSwitchNames()
+	if err != nil {
+		klog.Errorf("failed to get kube-ovn switch names: %v", err)
+		return err
+	}
+	klog.Infof("found %d kube-ovn logical switches", len(kubeOvnSwitches))
+
+	// Migrate resources in order of dependencies
+	if err := c.migrateLogicalRouterPorts(kubeOvnRouters); err != nil {
+		return err
+	}
+
+	if err := c.migratePortGroups(); err != nil {
+		return err
+	}
+
+	if err := c.migrateAddressSets(); err != nil {
+		return err
+	}
+
+	if err := c.migrateLoadBalancers(); err != nil {
+		return err
+	}
+
+	if err := c.migrateACLs(kubeOvnSwitches); err != nil {
+		return err
+	}
+
+	klog.Info("completed migration of vendor externalIDs")
+
+	// Store the current version to prevent re-running migration on next startup
+	if err := c.SetKubeOvnVersion(versions.VERSION); err != nil {
+		klog.Errorf("failed to store kube-ovn version after migration: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// getKubeOvnRouterNames returns names of logical routers that belong to kube-ovn
+func (c *OVNNbClient) getKubeOvnRouterNames() (map[string]bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	var lrList []ovnnb.LogicalRouter
+	if err := c.ovsDbClient.WhereCache(func(lr *ovnnb.LogicalRouter) bool {
+		// Include routers that already have vendor=kube-ovn
+		if len(lr.ExternalIDs) > 0 && lr.ExternalIDs["vendor"] == util.CniTypeName {
+			return true
+		}
+		return false
+	}).List(ctx, &lrList); err != nil {
+		return nil, fmt.Errorf("failed to list logical routers: %w", err)
+	}
+
+	names := make(map[string]bool, len(lrList))
+	for _, lr := range lrList {
+		names[lr.Name] = true
+	}
+	return names, nil
+}
+
+// getKubeOvnSwitchNames returns names of logical switches that belong to kube-ovn
+func (c *OVNNbClient) getKubeOvnSwitchNames() (map[string]bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	var lsList []ovnnb.LogicalSwitch
+	if err := c.ovsDbClient.WhereCache(func(ls *ovnnb.LogicalSwitch) bool {
+		// Include switches that already have vendor=kube-ovn
+		if len(ls.ExternalIDs) > 0 && ls.ExternalIDs["vendor"] == util.CniTypeName {
+			return true
+		}
+		return false
+	}).List(ctx, &lsList); err != nil {
+		return nil, fmt.Errorf("failed to list logical switches: %w", err)
+	}
+
+	names := make(map[string]bool, len(lsList))
+	for _, ls := range lsList {
+		names[ls.Name] = true
+	}
+	return names, nil
+}
+
+// migrateLogicalRouterPorts adds vendor tag to LRPs that belong to kube-ovn routers
+func (c *OVNNbClient) migrateLogicalRouterPorts(kubeOvnRouters map[string]bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	var lrpList []ovnnb.LogicalRouterPort
+	if err := c.ovsDbClient.WhereCache(func(lrp *ovnnb.LogicalRouterPort) bool {
+		// Skip if already has vendor tag
+		if len(lrp.ExternalIDs) > 0 && lrp.ExternalIDs["vendor"] == util.CniTypeName {
+			return false
+		}
+		// Include if it has 'lr' externalID pointing to a kube-ovn router
+		if len(lrp.ExternalIDs) > 0 {
+			if lrName, ok := lrp.ExternalIDs[logicalRouterKey]; ok && kubeOvnRouters[lrName] {
+				return true
+			}
+		}
+		return false
+	}).List(ctx, &lrpList); err != nil {
+		return fmt.Errorf("failed to list logical router ports for migration: %w", err)
+	}
+
+	if len(lrpList) == 0 {
+		klog.Info("no logical router ports need vendor migration")
+		return nil
+	}
+
+	klog.Infof("migrating %d logical router ports to add vendor tag", len(lrpList))
+
+	ops := make([]ovsdb.Operation, 0, len(lrpList))
+	for i := range lrpList {
+		lrp := &lrpList[i]
+		if lrp.ExternalIDs == nil {
+			lrp.ExternalIDs = make(map[string]string)
+		}
+		lrp.ExternalIDs["vendor"] = util.CniTypeName
+
+		op, err := c.Where(lrp).Update(lrp, &lrp.ExternalIDs)
+		if err != nil {
+			klog.Errorf("failed to generate update operation for LRP %s: %v", lrp.Name, err)
+			continue
+		}
+		ops = append(ops, op...)
+	}
+
+	if len(ops) == 0 {
+		return nil
+	}
+
+	if err := c.Transact("lrp-vendor-migrate", ops); err != nil {
+		return fmt.Errorf("failed to migrate logical router port vendor tags: %w", err)
+	}
+
+	klog.Infof("successfully migrated %d logical router ports", len(lrpList))
+	return nil
+}
+
+// migratePortGroups adds vendor tag to port groups that match kube-ovn patterns
+func (c *OVNNbClient) migratePortGroups() error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	var pgList []ovnnb.PortGroup
+	if err := c.ovsDbClient.WhereCache(func(pg *ovnnb.PortGroup) bool {
+		// Skip if already has vendor tag
+		if len(pg.ExternalIDs) > 0 && pg.ExternalIDs["vendor"] == util.CniTypeName {
+			return false
+		}
+
+		// Security group port groups: ovn.sg.{name}
+		if sgPortGroupPattern.MatchString(pg.Name) {
+			return true
+		}
+
+		// Port groups with 'sg' or 'type' externalID (kube-ovn specific)
+		if len(pg.ExternalIDs) > 0 {
+			if _, hasSg := pg.ExternalIDs[sgKey]; hasSg {
+				return true
+			}
+			if _, hasType := pg.ExternalIDs["type"]; hasType {
+				return true
+			}
+		}
+
+		// Network policy port groups have kube-ovn specific externalIDs
+		// Don't use name patterns alone as they're too broad and risk mis-tagging
+		// resources from other systems
+
+		return false
+	}).List(ctx, &pgList); err != nil {
+		return fmt.Errorf("failed to list port groups for migration: %w", err)
+	}
+
+	if len(pgList) == 0 {
+		klog.Info("no port groups need vendor migration")
+		return nil
+	}
+
+	klog.Infof("migrating %d port groups to add vendor tag", len(pgList))
+
+	ops := make([]ovsdb.Operation, 0, len(pgList))
+	for i := range pgList {
+		pg := &pgList[i]
+		if pg.ExternalIDs == nil {
+			pg.ExternalIDs = make(map[string]string)
+		}
+		pg.ExternalIDs["vendor"] = util.CniTypeName
+
+		op, err := c.Where(pg).Update(pg, &pg.ExternalIDs)
+		if err != nil {
+			klog.Errorf("failed to generate update operation for PortGroup %s: %v", pg.Name, err)
+			continue
+		}
+		ops = append(ops, op...)
+	}
+
+	if len(ops) == 0 {
+		return nil
+	}
+
+	if err := c.Transact("pg-vendor-migrate", ops); err != nil {
+		return fmt.Errorf("failed to migrate port group vendor tags: %w", err)
+	}
+
+	klog.Infof("successfully migrated %d port groups", len(pgList))
+	return nil
+}
+
+// migrateAddressSets adds vendor tag to address sets that match kube-ovn patterns
+func (c *OVNNbClient) migrateAddressSets() error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	var asList []ovnnb.AddressSet
+	if err := c.ovsDbClient.WhereCache(func(as *ovnnb.AddressSet) bool {
+		// Skip if already has vendor tag
+		if len(as.ExternalIDs) > 0 && as.ExternalIDs["vendor"] == util.CniTypeName {
+			return false
+		}
+
+		// Security group address sets: ovn.sg.{name}.associated.v4/v6
+		if sgAddressSetPattern.MatchString(as.Name) {
+			return true
+		}
+
+		// Network policy address sets: {name}.{namespace}.{direction}.{type}.{protocol}
+		if npAddressSetPattern.MatchString(as.Name) {
+			return true
+		}
+
+		// Address sets with 'sg' externalID (kube-ovn specific)
+		if len(as.ExternalIDs) > 0 {
+			if _, hasSg := as.ExternalIDs[sgKey]; hasSg {
+				return true
+			}
+		}
+
+		return false
+	}).List(ctx, &asList); err != nil {
+		return fmt.Errorf("failed to list address sets for migration: %w", err)
+	}
+
+	if len(asList) == 0 {
+		klog.Info("no address sets need vendor migration")
+		return nil
+	}
+
+	klog.Infof("migrating %d address sets to add vendor tag", len(asList))
+
+	ops := make([]ovsdb.Operation, 0, len(asList))
+	for i := range asList {
+		as := &asList[i]
+		if as.ExternalIDs == nil {
+			as.ExternalIDs = make(map[string]string)
+		}
+		as.ExternalIDs["vendor"] = util.CniTypeName
+
+		op, err := c.Where(as).Update(as, &as.ExternalIDs)
+		if err != nil {
+			klog.Errorf("failed to generate update operation for AddressSet %s: %v", as.Name, err)
+			continue
+		}
+		ops = append(ops, op...)
+	}
+
+	if len(ops) == 0 {
+		return nil
+	}
+
+	if err := c.Transact("as-vendor-migrate", ops); err != nil {
+		return fmt.Errorf("failed to migrate address set vendor tags: %w", err)
+	}
+
+	klog.Infof("successfully migrated %d address sets", len(asList))
+	return nil
+}
+
+// migrateLoadBalancers adds vendor tag to load balancers that match kube-ovn patterns
+func (c *OVNNbClient) migrateLoadBalancers() error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	var lbList []ovnnb.LoadBalancer
+	if err := c.ovsDbClient.WhereCache(func(lb *ovnnb.LoadBalancer) bool {
+		// Skip if already has vendor tag
+		if len(lb.ExternalIDs) > 0 && lb.ExternalIDs["vendor"] == util.CniTypeName {
+			return false
+		}
+
+		// Cluster load balancers: cluster-{protocol}-loadbalancer or cluster-{protocol}-session-loadbalancer
+		if clusterLBPattern.MatchString(lb.Name) {
+			return true
+		}
+
+		// VPC load balancers: vpc-{name}-{protocol}-load or vpc-{name}-{protocol}-sess-load
+		if vpcLBPattern.MatchString(lb.Name) {
+			return true
+		}
+
+		return false
+	}).List(ctx, &lbList); err != nil {
+		return fmt.Errorf("failed to list load balancers for migration: %w", err)
+	}
+
+	if len(lbList) == 0 {
+		klog.Info("no load balancers need vendor migration")
+		return nil
+	}
+
+	klog.Infof("migrating %d load balancers to add vendor tag", len(lbList))
+
+	ops := make([]ovsdb.Operation, 0, len(lbList))
+	for i := range lbList {
+		lb := &lbList[i]
+		if lb.ExternalIDs == nil {
+			lb.ExternalIDs = make(map[string]string)
+		}
+		lb.ExternalIDs["vendor"] = util.CniTypeName
+
+		op, err := c.Where(lb).Update(lb, &lb.ExternalIDs)
+		if err != nil {
+			klog.Errorf("failed to generate update operation for LoadBalancer %s: %v", lb.Name, err)
+			continue
+		}
+		ops = append(ops, op...)
+	}
+
+	if len(ops) == 0 {
+		return nil
+	}
+
+	if err := c.Transact("lb-vendor-migrate", ops); err != nil {
+		return fmt.Errorf("failed to migrate load balancer vendor tags: %w", err)
+	}
+
+	klog.Infof("successfully migrated %d load balancers", len(lbList))
+	return nil
+}
+
+// migrateACLs adds vendor tag to ACLs that belong to kube-ovn
+func (c *OVNNbClient) migrateACLs(kubeOvnSwitches map[string]bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	// First, get all port groups that belong to kube-ovn (either already tagged or matching patterns)
+	kubeOvnPortGroups := make(map[string]bool)
+	var pgList []ovnnb.PortGroup
+	if err := c.ovsDbClient.WhereCache(func(pg *ovnnb.PortGroup) bool {
+		// Include port groups with vendor tag
+		if len(pg.ExternalIDs) > 0 && pg.ExternalIDs["vendor"] == util.CniTypeName {
+			return true
+		}
+		// Include port groups matching kube-ovn patterns
+		if sgPortGroupPattern.MatchString(pg.Name) {
+			return true
+		}
+		if len(pg.ExternalIDs) > 0 {
+			if _, hasSg := pg.ExternalIDs[sgKey]; hasSg {
+				return true
+			}
+			if _, hasType := pg.ExternalIDs["type"]; hasType {
+				return true
+			}
+		}
+		// Network policy port groups have kube-ovn specific externalIDs
+		// Don't use name patterns alone as they're too broad
+		return false
+	}).List(ctx, &pgList); err != nil {
+		return fmt.Errorf("failed to list port groups: %w", err)
+	}
+
+	for _, pg := range pgList {
+		kubeOvnPortGroups[pg.Name] = true
+	}
+
+	var aclList []ovnnb.ACL
+	if err := c.ovsDbClient.WhereCache(func(acl *ovnnb.ACL) bool {
+		// Skip if already has vendor tag
+		if len(acl.ExternalIDs) > 0 && acl.ExternalIDs["vendor"] == util.CniTypeName {
+			return false
+		}
+
+		// ACLs with 'parent' externalID pointing to kube-ovn port group or switch
+		if len(acl.ExternalIDs) > 0 {
+			if parent, ok := acl.ExternalIDs[aclParentKey]; ok {
+				if kubeOvnPortGroups[parent] || kubeOvnSwitches[parent] {
+					return true
+				}
+			}
+			// ACLs with 'subnet' externalID pointing to kube-ovn switch
+			if subnet, ok := acl.ExternalIDs["subnet"]; ok && kubeOvnSwitches[subnet] {
+				return true
+			}
+		}
+
+		return false
+	}).List(ctx, &aclList); err != nil {
+		return fmt.Errorf("failed to list ACLs for migration: %w", err)
+	}
+
+	if len(aclList) == 0 {
+		klog.Info("no ACLs need vendor migration")
+		return nil
+	}
+
+	klog.Infof("migrating %d ACLs to add vendor tag", len(aclList))
+
+	ops := make([]ovsdb.Operation, 0, len(aclList))
+	for i := range aclList {
+		acl := &aclList[i]
+		if acl.ExternalIDs == nil {
+			acl.ExternalIDs = make(map[string]string)
+		}
+		acl.ExternalIDs["vendor"] = util.CniTypeName
+
+		op, err := c.Where(acl).Update(acl, &acl.ExternalIDs)
+		if err != nil {
+			klog.Errorf("failed to generate update operation for ACL %s: %v", acl.UUID, err)
+			continue
+		}
+		ops = append(ops, op...)
+	}
+
+	if len(ops) == 0 {
+		return nil
+	}
+
+	if err := c.Transact("acl-vendor-migrate", ops); err != nil {
+		return fmt.Errorf("failed to migrate ACL vendor tags: %w", err)
+	}
+
+	klog.Infof("successfully migrated %d ACLs", len(aclList))
+	return nil
+}

--- a/pkg/ovs/ovn-nb-migration_test.go
+++ b/pkg/ovs/ovn-nb-migration_test.go
@@ -1,0 +1,360 @@
+package ovs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/versions"
+)
+
+// ensureNbGlobalExists creates NBGlobal if it doesn't exist (needed for migration tests)
+func ensureNbGlobalExists(t *testing.T, nbClient *OVNNbClient) {
+	_, err := nbClient.GetNbGlobal()
+	if err != nil {
+		// NBGlobal doesn't exist, create it
+		nbGlobal := &ovnnb.NBGlobal{
+			Options: map[string]string{},
+		}
+		err = nbClient.CreateNbGlobal(nbGlobal)
+		require.NoError(t, err)
+	}
+}
+
+func (suite *OvnClientTestSuite) testMigrateVendorExternalIDs() {
+	t := suite.T()
+	// Note: Cannot run in parallel as these tests modify shared NBGlobal state
+
+	nbClient := suite.ovnNBClient
+	lrName := "test-migrate-lr"
+	lsName := "test-migrate-ls"
+
+	// Clean up NBGlobal after test to avoid affecting other tests
+	t.Cleanup(func() {
+		_ = nbClient.DeleteNbGlobal()
+	})
+
+	// Ensure NBGlobal exists for test
+	ensureNbGlobalExists(t, nbClient)
+
+	// Clear any existing version to simulate upgrade from old version
+	nbGlobal, err := nbClient.GetNbGlobal()
+	require.NoError(t, err)
+	if nbGlobal.ExternalIDs != nil {
+		delete(nbGlobal.ExternalIDs, kubeOvnVersionKey)
+		err = nbClient.UpdateNbGlobal(nbGlobal, &nbGlobal.ExternalIDs)
+		require.NoError(t, err)
+	}
+
+	// Create a logical router with vendor tag (this simulates existing kube-ovn router)
+	err = nbClient.CreateLogicalRouter(lrName)
+	require.NoError(t, err)
+
+	// Create a logical switch with vendor tag
+	err = nbClient.CreateBareLogicalSwitch(lsName)
+	require.NoError(t, err)
+
+	// Create test resources without vendor tags to simulate pre-v1.15.0 resources
+
+	// 1. Create LRP without vendor tag but with 'lr' externalID
+	lrpName := lrName + "-" + lsName
+	lrp := &ovnnb.LogicalRouterPort{
+		UUID:     ovsclient.NamedUUID(),
+		Name:     lrpName,
+		MAC:      util.GenerateMac(),
+		Networks: []string{"10.0.0.1/24"},
+		ExternalIDs: map[string]string{
+			logicalRouterKey: lrName, // This identifies it as kube-ovn resource
+			// vendor tag intentionally missing
+		},
+	}
+	ops, err := nbClient.CreateLogicalRouterPortOp(lrp, lrName)
+	require.NoError(t, err)
+	err = nbClient.Transact("test-lrp-add", ops)
+	require.NoError(t, err)
+
+	// 2. Create port group without vendor tag using low-level OVSDB operation
+	// to simulate pre-v1.15.0 resources (high-level CreatePortGroup auto-adds vendor tag)
+	sgPgName := "ovn.sg.test.security.group"
+	pg := &ovnnb.PortGroup{
+		UUID: ovsclient.NamedUUID(),
+		Name: sgPgName,
+		ExternalIDs: map[string]string{
+			sgKey: "test-sg",
+			// vendor tag intentionally missing
+		},
+	}
+	ops, err = nbClient.Create(pg)
+	require.NoError(t, err)
+	err = nbClient.Transact("test-pg-add", ops)
+	require.NoError(t, err)
+
+	// 3. Create address set without vendor tag using low-level OVSDB operation
+	asName := "ovn.sg.test.sg.associated.v4"
+	as := &ovnnb.AddressSet{
+		UUID: ovsclient.NamedUUID(),
+		Name: asName,
+		ExternalIDs: map[string]string{
+			sgKey: "test-sg",
+			// vendor tag intentionally missing
+		},
+	}
+	ops, err = nbClient.Create(as)
+	require.NoError(t, err)
+	err = nbClient.Transact("test-as-add", ops)
+	require.NoError(t, err)
+
+	// 4. Create load balancer without vendor tag using low-level OVSDB operation
+	lbName := "cluster-tcp-loadbalancer"
+	lb := &ovnnb.LoadBalancer{
+		UUID:     ovsclient.NamedUUID(),
+		Name:     lbName,
+		Protocol: &[]string{"tcp"}[0],
+		// vendor tag intentionally missing (ExternalIDs is nil)
+	}
+	ops, err = nbClient.Create(lb)
+	require.NoError(t, err)
+	err = nbClient.Transact("test-lb-add", ops)
+	require.NoError(t, err)
+
+	// Run migration (should run because no version is stored)
+	err = nbClient.MigrateVendorExternalIDs()
+	require.NoError(t, err)
+
+	// Verify LRP has vendor tag
+	migratedLrp, err := nbClient.GetLogicalRouterPort(lrpName, false)
+	require.NoError(t, err)
+	require.Equal(t, util.CniTypeName, migratedLrp.ExternalIDs["vendor"])
+
+	// Verify port group has vendor tag
+	migratedPg, err := nbClient.GetPortGroup(sgPgName, false)
+	require.NoError(t, err)
+	require.Equal(t, util.CniTypeName, migratedPg.ExternalIDs["vendor"])
+
+	// Verify load balancer has vendor tag
+	migratedLb, err := nbClient.GetLoadBalancer(lbName, false)
+	require.NoError(t, err)
+	require.Equal(t, util.CniTypeName, migratedLb.ExternalIDs["vendor"])
+
+	// Verify version was stored
+	storedVersion, err := nbClient.GetKubeOvnVersion()
+	require.NoError(t, err)
+	require.Equal(t, versions.VERSION, storedVersion)
+}
+
+func (suite *OvnClientTestSuite) testMigrateVendorExternalIDsIdempotent() {
+	t := suite.T()
+	// Note: Cannot run in parallel as these tests modify shared NBGlobal state
+
+	nbClient := suite.ovnNBClient
+	lrName := "test-migrate-idempotent-lr"
+
+	// Clean up NBGlobal after test to avoid affecting other tests
+	t.Cleanup(func() {
+		_ = nbClient.DeleteNbGlobal()
+	})
+
+	// Ensure NBGlobal exists for test
+	ensureNbGlobalExists(t, nbClient)
+
+	// Create a logical router with vendor tag
+	err := nbClient.CreateLogicalRouter(lrName)
+	require.NoError(t, err)
+
+	// Clear version to trigger first migration
+	nbGlobal, err := nbClient.GetNbGlobal()
+	require.NoError(t, err)
+	if nbGlobal.ExternalIDs != nil {
+		delete(nbGlobal.ExternalIDs, kubeOvnVersionKey)
+		err = nbClient.UpdateNbGlobal(nbGlobal, &nbGlobal.ExternalIDs)
+		require.NoError(t, err)
+	}
+
+	// First migration should run
+	err = nbClient.MigrateVendorExternalIDs()
+	require.NoError(t, err)
+
+	// Verify version was stored
+	storedVersion, err := nbClient.GetKubeOvnVersion()
+	require.NoError(t, err)
+	require.Equal(t, versions.VERSION, storedVersion)
+
+	// Subsequent calls should skip migration but not fail
+	for range 3 {
+		err = nbClient.MigrateVendorExternalIDs()
+		require.NoError(t, err)
+	}
+
+	// Version should still be set
+	storedVersion, err = nbClient.GetKubeOvnVersion()
+	require.NoError(t, err)
+	require.Equal(t, versions.VERSION, storedVersion)
+}
+
+func (suite *OvnClientTestSuite) testMigrateSkipsWhenVersionSet() {
+	t := suite.T()
+	// Note: Cannot run in parallel as these tests modify shared NBGlobal state
+
+	nbClient := suite.ovnNBClient
+
+	// Clean up NBGlobal after test to avoid affecting other tests
+	t.Cleanup(func() {
+		_ = nbClient.DeleteNbGlobal()
+	})
+
+	// Ensure NBGlobal exists for test
+	ensureNbGlobalExists(t, nbClient)
+
+	// Set version to current (simulating already-migrated system)
+	err := nbClient.SetKubeOvnVersion(versions.VERSION)
+	require.NoError(t, err)
+
+	// Check that migration is not needed
+	needsMigration, err := nbClient.needsVendorMigration()
+	require.NoError(t, err)
+	require.False(t, needsMigration, "migration should not be needed when current version is set")
+}
+
+func (suite *OvnClientTestSuite) testMigrateRunsWhenOldVersion() {
+	t := suite.T()
+	// Note: Cannot run in parallel as these tests modify shared NBGlobal state
+
+	nbClient := suite.ovnNBClient
+
+	// Clean up NBGlobal after test to avoid affecting other tests
+	t.Cleanup(func() {
+		_ = nbClient.DeleteNbGlobal()
+	})
+
+	// Ensure NBGlobal exists for test
+	ensureNbGlobalExists(t, nbClient)
+
+	// Set version to old version (before vendor tagging was introduced)
+	err := nbClient.SetKubeOvnVersion("v1.14.0")
+	require.NoError(t, err)
+
+	// Check that migration IS needed
+	needsMigration, err := nbClient.needsVendorMigration()
+	require.NoError(t, err)
+	require.True(t, needsMigration, "migration should be needed when old version is stored")
+}
+
+func (suite *OvnClientTestSuite) testMigrateVendorExternalIDsSkipsNonKubeOvn() {
+	t := suite.T()
+	// Note: Cannot run in parallel as these tests modify shared NBGlobal state
+
+	nbClient := suite.ovnNBClient
+
+	// Clean up NBGlobal after test to avoid affecting other tests
+	t.Cleanup(func() {
+		_ = nbClient.DeleteNbGlobal()
+	})
+
+	// Ensure NBGlobal exists for test
+	ensureNbGlobalExists(t, nbClient)
+
+	// Create resources that should NOT be tagged (simulating external resources)
+
+	// 1. Port group with neutron-like naming (should be skipped)
+	neutronPgName := "neutron.security.group.123"
+	pg := &ovnnb.PortGroup{
+		UUID: ovsclient.NamedUUID(),
+		Name: neutronPgName,
+		ExternalIDs: map[string]string{
+			"neutron:security_group_id": "123",
+		},
+	}
+	ops, err := nbClient.Create(pg)
+	require.NoError(t, err)
+	err = nbClient.Transact("test-neutron-pg", ops)
+	require.NoError(t, err)
+
+	// Run migration
+	err = nbClient.MigrateVendorExternalIDs()
+	require.NoError(t, err)
+
+	// Verify neutron resource was NOT tagged
+	migratedPg, err := nbClient.GetPortGroup(neutronPgName, false)
+	require.NoError(t, err)
+	// Should not have vendor tag
+	require.NotEqual(t, util.CniTypeName, migratedPg.ExternalIDs["vendor"])
+}
+
+func TestSecurityGroupPatterns(t *testing.T) {
+	t.Parallel()
+
+	// Test security group port group pattern
+	testCases := []struct {
+		name     string
+		expected bool
+	}{
+		{"ovn.sg.default", true},
+		{"ovn.sg.my.security.group", true},
+		{"ovn.sg.test.with.many.dots", true},
+		{"ovn.sg.", false}, // empty sg name
+		{"ovn.other.thing", false},
+		{"neutron.sg.something", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := sgPortGroupPattern.MatchString(tc.name)
+			if result != tc.expected {
+				t.Errorf("sgPortGroupPattern.MatchString(%q) = %v, want %v", tc.name, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestLoadBalancerPatterns(t *testing.T) {
+	t.Parallel()
+
+	clusterCases := []struct {
+		name     string
+		expected bool
+	}{
+		{"cluster-tcp-loadbalancer", true},
+		{"cluster-udp-loadbalancer", true},
+		{"cluster-sctp-loadbalancer", true},
+		{"cluster-tcp-session-loadbalancer", true},
+		{"cluster-udp-session-loadbalancer", true},
+		{"cluster-sctp-session-loadbalancer", true},
+		{"other-tcp-loadbalancer", false},
+		{"cluster-http-loadbalancer", false},
+	}
+
+	for _, tc := range clusterCases {
+		t.Run("cluster/"+tc.name, func(t *testing.T) {
+			result := clusterLBPattern.MatchString(tc.name)
+			if result != tc.expected {
+				t.Errorf("clusterLBPattern.MatchString(%q) = %v, want %v", tc.name, result, tc.expected)
+			}
+		})
+	}
+
+	vpcCases := []struct {
+		name     string
+		expected bool
+	}{
+		{"vpc-default-tcp-load", true},
+		{"vpc-default-udp-load", true},
+		{"vpc-default-sctp-load", true},
+		{"vpc-default-tcp-sess-load", true},
+		{"vpc-my-custom-vpc-udp-sess-load", true},
+		{"vpc-custom-sctp-load", true},
+		{"vpc-default-http-load", false},
+		{"cluster-tcp-loadbalancer", false},
+	}
+
+	for _, tc := range vpcCases {
+		t.Run("vpc/"+tc.name, func(t *testing.T) {
+			result := vpcLBPattern.MatchString(tc.name)
+			if result != tc.expected {
+				t.Errorf("vpcLBPattern.MatchString(%q) = %v, want %v", tc.name, result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/ovs/ovn-nb-port_group_test.go
+++ b/pkg/ovs/ovn-nb-port_group_test.go
@@ -11,6 +11,7 @@ import (
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (suite *OvnClientTestSuite) testCreatePortGroup() {
@@ -32,7 +33,13 @@ func (suite *OvnClientTestSuite) testCreatePortGroup() {
 		pg, err := nbClient.GetPortGroup(pgName, false)
 		require.NoError(t, err)
 		require.Equal(t, pgName, pg.Name)
-		require.Equal(t, externalIDs, pg.ExternalIDs)
+		// vendor is automatically added by CreatePortGroup
+		expectedExternalIDs := map[string]string{
+			"type":   "test",
+			"key":    "value",
+			"vendor": util.CniTypeName,
+		}
+		require.Equal(t, expectedExternalIDs, pg.ExternalIDs)
 	})
 
 	t.Run("create existing port group", func(t *testing.T) {
@@ -52,7 +59,12 @@ func (suite *OvnClientTestSuite) testCreatePortGroup() {
 		pg, err := nbClient.GetPortGroup(pgName, false)
 		require.NoError(t, err)
 		require.Equal(t, pgName, pg.Name)
-		require.Equal(t, updatedExternalIDs, pg.ExternalIDs)
+		// vendor is automatically added by CreatePortGroup
+		expectedExternalIDs := map[string]string{
+			"new":    "data",
+			"vendor": util.CniTypeName,
+		}
+		require.Equal(t, expectedExternalIDs, pg.ExternalIDs)
 	})
 
 	t.Run("create port group with nil externalIDs", func(t *testing.T) {
@@ -63,7 +75,8 @@ func (suite *OvnClientTestSuite) testCreatePortGroup() {
 		pg, err := nbClient.GetPortGroup(pgName, false)
 		require.NoError(t, err)
 		require.Equal(t, pgName, pg.Name)
-		require.Empty(t, pg.ExternalIDs)
+		// vendor is automatically added by CreatePortGroup even with nil input
+		require.Equal(t, map[string]string{"vendor": util.CniTypeName}, pg.ExternalIDs)
 	})
 
 	t.Run("create port group with empty externalIDs", func(t *testing.T) {
@@ -74,7 +87,8 @@ func (suite *OvnClientTestSuite) testCreatePortGroup() {
 		pg, err := nbClient.GetPortGroup(pgName, false)
 		require.NoError(t, err)
 		require.Equal(t, pgName, pg.Name)
-		require.Empty(t, pg.ExternalIDs)
+		// vendor is automatically added by CreatePortGroup even with empty input
+		require.Equal(t, map[string]string{"vendor": util.CniTypeName}, pg.ExternalIDs)
 	})
 }
 

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -1056,6 +1056,27 @@ func (suite *OvnClientTestSuite) Test_NewOvnSbClient() {
 	suite.testNewOvnSbClient()
 }
 
+/* migration unit test */
+func (suite *OvnClientTestSuite) Test_MigrateVendorExternalIDs() {
+	suite.testMigrateVendorExternalIDs()
+}
+
+func (suite *OvnClientTestSuite) Test_MigrateVendorExternalIDsIdempotent() {
+	suite.testMigrateVendorExternalIDsIdempotent()
+}
+
+func (suite *OvnClientTestSuite) Test_MigrateSkipsWhenVersionSet() {
+	suite.testMigrateSkipsWhenVersionSet()
+}
+
+func (suite *OvnClientTestSuite) Test_MigrateRunsWhenOldVersion() {
+	suite.testMigrateRunsWhenOldVersion()
+}
+
+func (suite *OvnClientTestSuite) Test_MigrateVendorExternalIDsSkipsNonKubeOvn() {
+	suite.testMigrateVendorExternalIDsSkipsNonKubeOvn()
+}
+
 /* sb chassis unit test */
 func (suite *OvnClientTestSuite) Test_GetChassis() {
 	suite.testGetChassis()

--- a/pkg/ovs/ovn-nb.go
+++ b/pkg/ovs/ovn-nb.go
@@ -176,6 +176,9 @@ func (c *OVNNbClient) CreateRouterPortOp(lsName, lrName, lspName, lrpName, ip, m
 		Name:     lrpName,
 		Networks: strings.Split(ip, ","),
 		MAC:      mac,
+		ExternalIDs: map[string]string{
+			"vendor": util.CniTypeName,
+		},
 	}
 
 	lrpCreateOp, err := c.CreateLogicalRouterPortOp(lrp, lrName)


### PR DESCRIPTION
This change will implement a vendor name on ACL objects which will allow the garbage collection system to key off the vendor name before attempting to cleanup and remove database entries.

In the course of this investigation, I've also discovered other resources that are not using the kube-ovn vendor object, so I've taken steps to add it where appropriate.

Closes-Bug: https://github.com/kubeovn/kube-ovn/issues/5995
Related: https://github.com/rackerlabs/genestack/issues/1342
