### PR TITLE
fix: handle empty IP and CIDR in GetIPAddrWithMask function

### DIFF
--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -334,6 +334,20 @@ func GetStringIP(v4IP, v6IP string) string {
 	return strings.Join(ipList, ",")
 }
 
+// GetIPAddrWithMaskForCNI returns IP address with mask for CNI plugin.
+// When ip is empty, it indicates no-IPAM mode (e.g., NAT gateway macvlan without default EIP).
+// Returns (ipAddr, noIPAM, error) where noIPAM is true when IP allocation is skipped.
+func GetIPAddrWithMaskForCNI(ip, cidr string) (string, bool, error) {
+	if ip == "" {
+		// Network attachment definition using no-IPAM plugin (e.g., NAT gateway net1 macvlan with no default EIP)
+		// IP is not allocated by Kube-OVN, but cidr still comes from subnet configuration
+		klog.V(3).Infof("skipping IP allocation: ip is empty for cidr %s (no-IPAM mode)", cidr)
+		return "", true, nil
+	}
+	ipAddr, err := GetIPAddrWithMask(ip, cidr)
+	return ipAddr, false, err
+}
+
 func GetIPAddrWithMask(ip, cidr string) (string, error) {
 	var ipAddr string
 	ips := strings.Split(ip, ",")

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -937,6 +937,90 @@ func TestGetIPAddrWithMask(t *testing.T) {
 	}
 }
 
+func TestGetIPAddrWithMaskForCNI(t *testing.T) {
+	tests := []struct {
+		name      string
+		ip        string
+		cidr      string
+		wantAddr  string
+		wantNoIP  bool
+		wantError bool
+	}{
+		{
+			name:      "Normal IPv4 address",
+			ip:        "192.168.1.1",
+			cidr:      "192.168.1.0/24",
+			wantAddr:  "192.168.1.1/24",
+			wantNoIP:  false,
+			wantError: false,
+		},
+		{
+			name:      "Normal IPv6 address",
+			ip:        "2001:db8::1",
+			cidr:      "2001:db8::/32",
+			wantAddr:  "2001:db8::1/32",
+			wantNoIP:  false,
+			wantError: false,
+		},
+		{
+			name:      "Dual stack addresses",
+			ip:        "192.168.1.1,2001:db8::1",
+			cidr:      "192.168.1.0/24,2001:db8::/32",
+			wantAddr:  "192.168.1.1/24,2001:db8::1/32",
+			wantNoIP:  false,
+			wantError: false,
+		},
+		{
+			name:      "No-IPAM mode (empty IP with CIDR)",
+			ip:        "",
+			cidr:      "192.168.1.0/24",
+			wantAddr:  "",
+			wantNoIP:  true,
+			wantError: false,
+		},
+		{
+			name:      "No-IPAM mode (empty IP with dual-stack CIDR)",
+			ip:        "",
+			cidr:      "192.168.1.0/24,2001:db8::/32",
+			wantAddr:  "",
+			wantNoIP:  true,
+			wantError: false,
+		},
+		{
+			name:      "Error: invalid dual stack ip format",
+			ip:        "192.168.1.1",
+			cidr:      "192.168.1.0/24,2001:db8::/32",
+			wantAddr:  "",
+			wantNoIP:  false,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAddr, gotNoIP, gotErr := GetIPAddrWithMaskForCNI(tt.ip, tt.cidr)
+
+			if tt.wantError {
+				if gotErr == nil {
+					t.Errorf("GetIPAddrWithMaskForCNI() expected error but got nil")
+				}
+			} else {
+				if gotErr != nil {
+					t.Errorf("GetIPAddrWithMaskForCNI() unexpected error: %v", gotErr)
+				}
+			}
+
+			if gotAddr != tt.wantAddr {
+				t.Errorf("GetIPAddrWithMaskForCNI() gotAddr = %v, want %v", gotAddr, tt.wantAddr)
+			}
+
+			if gotNoIP != tt.wantNoIP {
+				t.Errorf("GetIPAddrWithMaskForCNI() gotNoIP = %v, want %v", gotNoIP, tt.wantNoIP)
+			}
+		})
+	}
+}
+
 func TestGetIPWithoutMask(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
fix: log message for skipping IP allocation in NAT gateway

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes


test yaml


```bash

root@xs4772:~/zbb/vpc-nat# cat 00-nad.yaml
---
apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: ovn-vpc-external-network
  namespace: kube-system
spec:
  config: '{
      "cniVersion": "0.3.1",
      "type": "macvlan",
      "master": "bond0",
      "mode": "bridge",
      "ipam": {
        "type": "kube-ovn",
        "server_socket": "/run/openvswitch/kube-ovn-daemon.sock",
        "provider": "ovn-vpc-external-network.kube-system"
      }
    }'


# cat ovn-vpc-external-network.yml
apiVersion: kubeovn.io/v1
kind: Subnet
metadata:
  name: ovn-vpc-external-network
spec:
  cidrBlock: 10.34.251.0/24
  default: false
  enableLb: false
  excludeIps:
  - 10.34.251.1..10.34.251.100
  - 10.34.251.254
  gateway: 10.34.251.254
  gatewayNode: ""
  natOutgoing: false
  private: false
  protocol: IPv4
  provider: ovn-vpc-external-network.kube-system


root@xs4772:~/zbb/vpc-nat# cat ovn-vm3-subnet.yaml
---
apiVersion: kubeovn.io/v1
kind: Subnet
metadata:
  name: ovn-vm3
spec:
  cidrBlock: 10.196.0.0/16
  default: false
  enableLb: false
  excludeIps:
  - 10.196.0.0..10.196.10.0
  gateway: 10.196.255.254
  gatewayNode: ""
  gatewayType: distributed
  natOutgoing: true
  protocol: IPv4
  provider: ovn-vm3.default.ovn
  vpc: ovn-cluster


root@xs4772:~/zbb/vpc-nat# cat bbgw.yaml
kind: VpcNatGateway
apiVersion: kubeovn.io/v1
metadata:
  name: bb-gw1
spec:
  vpc: ovn-cluster
  subnet: ovn-vm3
  lanIp: 10.196.255.253
  selector:
    - "kubernetes.io/os: linux"
  externalSubnets:
    - ovn-vpc-external-network
  noDefaultEIP: true
root@xs4772:~/zbb/vpc-nat#





```

```bash


root@xs4772:~/zbb/vpc-nat# k describe po -n kube-system          vpc-nat-gw-bb-gw1-0
Name:             vpc-nat-gw-bb-gw1-0
Namespace:        kube-system
Priority:         0
Service Account:  default
Node:             xs4773/10.34.251.22
Start Time:       Sat, 06 Dec 2025 12:00:08 +0800
Labels:           app=vpc-nat-gw-bb-gw1
                  apps.kubernetes.io/pod-index=0
                  controller-revision-hash=vpc-nat-gw-bb-gw1-7fd6bd668b
                  ovn.kubernetes.io/vpc-nat-gw=true
                  statefulset.kubernetes.io/pod-name=vpc-nat-gw-bb-gw1-0
Annotations:      k8s.v1.cni.cncf.io/networks: kube-system/ovn-vpc-external-network
                  ovn-vpc-external-network.kube-system.kubernetes.io/allocated: true
                  ovn.kubernetes.io/allocated: true
                  ovn.kubernetes.io/cidr: 10.196.0.0/16
                  ovn.kubernetes.io/gateway: 10.196.255.254
                  ovn.kubernetes.io/ip_address: 10.196.255.253
                  ovn.kubernetes.io/logical_router: ovn-cluster
                  ovn.kubernetes.io/logical_switch: ovn-vm3
                  ovn.kubernetes.io/mac_address: 02:65:af:9a:13:64
                  ovn.kubernetes.io/pod_nic_type: veth-pair
                  ovn.kubernetes.io/routed: true
                  ovn.kubernetes.io/routes:
                    [{"dst":"10.233.0.0/16","gw":"10.196.255.254"},{"dst":"100.64.0.0/16","gw":"10.196.255.254"},{"dst":"10.222.0.0/16","gw":"10.196.255.254"}...
                  ovn.kubernetes.io/vpc_nat_gw: bb-gw1
Status:           Pending
IP:
IPs:              <none>
Controlled By:    StatefulSet/vpc-nat-gw-bb-gw1
Containers:
  vpc-nat-gw:
    Container ID:
    Image:         docker.io/kubeovn/vpc-nat-gateway:v1.15.0
    Image ID:
    Port:          <none>
    Host Port:     <none>
    Command:
      sleep
      infinity
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Environment:
      GATEWAY_V4:  10.34.251.254
      GATEWAY_V6:
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-98kdh (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   False
  Initialized                 True
  Ready                       False
  ContainersReady             False
  PodScheduled                True
Volumes:
  kube-api-access-98kdh:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              kubernetes.io/os=linux
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason                  Age    From               Message
  ----     ------                  ----   ----               -------
  Normal   Scheduled               2m12s  default-scheduler  Successfully assigned kube-system/vpc-nat-gw-bb-gw1-0 to xs4773
  Normal   AddedInterface          2m5s   multus             Add eth0 [10.196.255.253/16] from kube-ovn
  Warning  FailedCreatePodSandBox  2m4s   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "c6a0a596c0e202a3f356fa22192e94bc151eacef9a7250c25ad3f7aaa947d961": plugin type="multus" name="multus-cni-network" failed (add): [kube-system/vpc-nat-gw-bb-gw1-0/54da6825-33d8-49e7-a358-d1505c1da973:ovn-vpc-external-network]: error adding container to network "ovn-vpc-external-network": RPC failed; Post "http://dummy/api/v1/add": EOF
  Normal   AddedInterface          117s   multus             Add eth0 [10.196.255.253/16] from kube-ovn
  Warning  FailedCreatePodSandBox  117s   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "0ecbd4826b7cb8290b7d8c6044b835cd3ed7579fccfde98faf77b2cfe49e4302": plugin type="multus" name="multus-cni-network" failed (add): [kube-system/vpc-nat-gw-bb-gw1-0/54da6825-33d8-49e7-a358-d1505c1da973:ovn-vpc-external-network]: error adding container to network "ovn-vpc-external-network": RPC failed; Post "http://dummy/api/v1/add": EOF
  Normal   AddedInterface          100s   multus             Add eth0 [10.196.255.253/16] from kube-ovn
  Warning  FailedCreatePodSandBox  100s   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "d8764d7da0e295d350f6700c997b7e0b613f4c550ff19e49d353b863c6753c5d": plugin type="multus" name="multus-cni-network" failed (add): [kube-system/vpc-nat-gw-bb-gw1-0/54da6825-33d8-49e7-a358-d1505c1da973:ovn-vpc-external-network]: error adding container to network "ovn-vpc-external-network": RPC failed; Post "http://dummy/api/v1/add": EOF
  Normal   AddedInterface          80s    multus             Add eth0 [10.196.255.253/16] from kube-ovn
  Warning  FailedCreatePodSandBox  80s    kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "96a6a74d4a22fca57c796f20aa9593063318d948a2c13cda2f21a99eab8e456c": plugin type="multus" name="multus-cni-network" failed (add): [kube-system/vpc-nat-gw-bb-gw1-0/54da6825-33d8-49e7-a358-d1505c1da973:ovn-vpc-external-network]: error adding container to network "ovn-vpc-external-network": RPC failed; Post "http://dummy/api/v1/add": EOF
  Normal   AddedInterface          62s    multus             Add eth0 [10.196.255.253/16] from kube-ovn
  Warning  FailedCreatePodSandBox  61s    kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "8f66c5ac68a03ef2d3e91cbd5dc01e928069407eae9b9d9eec968233c7ed825d": plugin type="multus" name="multus-cni-network" failed (add): [kube-system/vpc-nat-gw-bb-gw1-0/54da6825-33d8-49e7-a358-d1505c1da973:ovn-vpc-external-network]: error adding container to network "ovn-vpc-external-network": RPC failed; Post "http://dummy/api/v1/add": EOF
  Normal   AddedInterface          43s    multus             Add eth0 [10.196.255.253/16] from kube-ovn
  Warning  FailedCreatePodSandBox  43s    kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "fa2de079a51308f1953ba890b19e098711e9c0b1eb2ee8e80c8595e81d1506fd": plugin type="multus" name="multus-cni-network" failed (add): [kube-system/vpc-nat-gw-bb-gw1-0/54da6825-33d8-49e7-a358-d1505c1da973:ovn-vpc-external-network]: error adding container to network "ovn-vpc-external-network": RPC failed; Post "http://dummy/api/v1/add": EOF
  Normal   AddedInterface          22s    multus             Add eth0 [10.196.255.253/16] from kube-ovn
  Warning  FailedCreatePodSandBox  22s    kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "d8f0bdf10b17910c2d088da31fd1d568d407a807ffd2cf5949548af572746c8f": plugin type="multus" name="multus-cni-network" failed (add): [kube-system/vpc-nat-gw-bb-gw1-0/54da6825-33d8-49e7-a358-d1505c1da973:ovn-vpc-external-network]: error adding container to network "ovn-vpc-external-network": RPC failed; Post "http://dummy/api/v1/add": EOF
  Normal   AddedInterface          5s     multus             Add eth0 [10.196.255.253/16] from kube-ovn
  Warning  FailedCreatePodSandBox  4s     kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "7418e6f9c06816bbc8804d9cf5b0ed09e60283f9ef91b5ddf6fb9f4868d43ef8": plugin type="multus" name="multus-cni-network" failed (add): [kube-system/vpc-nat-gw-bb-gw1-0/54da6825-33d8-49e7-a358-d1505c1da973:ovn-vpc-external-network]: error adding container to network "ovn-vpc-external-network": RPC failed; Post "http://dummy/api/v1/add": EOF
root@xs4772:~/zbb/vpc-nat# ll
total 20
drwxr-xr-x  2 root root 4096 Dec  6 11:57 ./
drwxr-xr-x 13 root root 4096 Dec  6 11:04 ../
-rw-r--r--  1 root root  446 Dec  6 11:57 00-nad.yaml
-rw-r--r--  1 root root  253 Dec  6 11:29 bbgw.yaml
-rw-r--r--  1 root root  339 Dec  6 11:20 ovn-vm3-subnet.yaml

```


kube-ovn-cni err log


```bash




I1206 12:30:27.767156 2573453 handler.go:460] del port request: {macvlan vpc-nat-gw-bb-gw1-0 kube-system 1c5bef41be163a2357b38edfe1e1d4679e1e7af21cf41022bbb0fccbc3a29016 /var/run/netns/cni-8b8d9500-7b99-a0d3-d0d7-2cfc75848269 net1 ovn-vpc-external-network.kube-system [] {[]  [] []}     }
I1206 12:30:27.794974 2573453 server.go:74] [2025-12-06T12:30:27+08:00] Outgoing response POST /api/v1/del with 204 status code in 27ms
I1206 12:30:27.831708 2573453 server.go:66] [2025-12-06T12:30:27+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:30:27.831787 2573453 handler.go:460] del port request: {kube-ovn vpc-nat-gw-bb-gw1-0 kube-system 1c5bef41be163a2357b38edfe1e1d4679e1e7af21cf41022bbb0fccbc3a29016 /var/run/netns/cni-8b8d9500-7b99-a0d3-d0d7-2cfc75848269 eth0 ovn [] {[]  [] []}     }
I1206 12:30:27.858881 2573453 server.go:74] [2025-12-06T12:30:27+08:00] Outgoing response POST /api/v1/del with 204 status code in 27ms
I1206 12:30:41.181057 2573453 server.go:66] [2025-12-06T12:30:41+08:00] Incoming HTTP/1.1 POST /api/v1/add request
I1206 12:30:41.181222 2573453 handler.go:82] add port request: {kube-ovn vpc-nat-gw-bb-gw1-0 kube-system 26d34b3880713130ea20b4c7340405bcfc51da197f16a833c3f7705a02b86428 /var/run/netns/cni-1c6ce656-1eed-23f6-d612-225389b01e2c eth0 ovn [] {[]  [] []}     }
I1206 12:30:41.185487 2573453 handler.go:306] create container interface eth0 mac 02:65:af:9a:13:64, ip 10.196.255.253/16, cidr 10.196.0.0/16, gw 10.196.255.254, custom routes [{10.233.0.0/16 10.196.255.254} {100.64.0.0/16 10.196.255.254} {10.222.0.0/16 10.196.255.254} {10.198.0.0/16 10.196.255.254} {10.197.0.0/16 10.196.255.254}]
I1206 12:30:41.269436 2573453 ovs_linux.go:225] ovs interface 26d34b388071_h is ready
I1206 12:30:44.466710 2573453 arp.go:244] announce arp address nic eth0, ip 10.196.255.253, with mac 02:65:af:9a:13:64
I1206 12:30:46.491455 2573453 ovs_linux.go:1279] add ip address 10.196.255.253/16 to eth0
I1206 12:30:46.517501 2573453 ovs_linux.go:619] MAC address of gateway 10.196.255.254 is a6:8a:4b:82:11:94
I1206 12:30:46.517528 2573453 ovs_linux.go:620] network 10.196.255.253/16 with gateway 10.196.255.254 is ready for interface eth0 after 2 checks
I1206 12:30:46.538016 2573453 server.go:74] [2025-12-06T12:30:46+08:00] Outgoing response POST /api/v1/add with 200 status code in 5356ms
I1206 12:30:46.601690 2573453 server.go:66] [2025-12-06T12:30:46+08:00] Incoming HTTP/1.1 POST /api/v1/add request
I1206 12:30:46.601836 2573453 handler.go:82] add port request: {macvlan vpc-nat-gw-bb-gw1-0 kube-system 26d34b3880713130ea20b4c7340405bcfc51da197f16a833c3f7705a02b86428 /var/run/netns/cni-1c6ce656-1eed-23f6-d612-225389b01e2c net1 ovn-vpc-external-network.kube-system [] {[]  [] []}     }
2025/12/06 12:30:46 http: panic serving @: runtime error: index out of range [1] with length 1
goroutine 1147508 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1943 +0xd3
panic({0x5cc3223f58e0?, 0xc001042558?})
	runtime/panic.go:783 +0x132
github.com/kubeovn/kube-ovn/pkg/util.GetIPAddrWithMask({0x0, 0x0}, {0x0, 0x0})
	github.com/kubeovn/kube-ovn/pkg/util/net.go:355 +0x5d4
github.com/kubeovn/kube-ovn/pkg/daemon.cniServerHandler.handleAdd({0xc00056d8c8, {0x5cc322674818, 0xc000552e00}, {0x5cc32260b0b8, 0xc0002a2cb0}, 0xc00057c960}, 0xc001832a00, 0xc0006ac540)
	github.com/kubeovn/kube-ovn/pkg/daemon/handler.go:133 +0x1725
github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0x5cc323f98de0?, 0x0?, 0x0?)
	github.com/emicklei/go-restful/v3@v3.13.0/filter.go:23 +0x53
github.com/kubeovn/kube-ovn/pkg/daemon.requestAndResponseLogger(0xc001832a00, 0xc0006ac540, 0xc000295810)
	github.com/kubeovn/kube-ovn/pkg/daemon/server.go:68 +0xff
github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0xc000b36820?, 0x5cc32262a8d0?, 0xc001034f00?)
	github.com/emicklei/go-restful/v3@v3.13.0/filter.go:21 +0x42
github.com/emicklei/go-restful/v3.(*Container).dispatch(0xc00102a510, {0x5cc32262a8d0, 0xc001034f00}, 0xc000653a40)
	github.com/emicklei/go-restful/v3@v3.13.0/container.go:296 +0x9ac
net/http.HandlerFunc.ServeHTTP(0xc001024000?, {0x5cc32262a8d0?, 0xc001034f00?}, 0x5cc3212111b2?)
	net/http/server.go:2322 +0x29
net/http.(*ServeMux).ServeHTTP(0x5cc32261b450?, {0x5cc32262a8d0, 0xc001034f00}, 0xc000653a40)
	net/http/server.go:2861 +0x1c7
github.com/emicklei/go-restful/v3.(*Container).ServeHTTP(0xc00102a510, {0x5cc32261b450, 0xc0001b3d10}, 0xc000653a40)
	github.com/emicklei/go-restful/v3@v3.13.0/container.go:346 +0xfb
net/http.serverHandler.ServeHTTP({0x5cc322609f38?}, {0x5cc32261b450?, 0xc0001b3d10?}, 0x1?)
	net/http/server.go:3340 +0x8e
net/http.(*conn).serve(0xc0008dba70, {0x5cc322634318, 0xc0010357a0})
	net/http/server.go:2109 +0x665
created by net/http.(*Server).Serve in goroutine 230
	net/http/server.go:3493 +0x485
I1206 12:30:46.632020 2573453 server.go:66] [2025-12-06T12:30:46+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:30:46.632098 2573453 handler.go:460] del port request: {macvlan vpc-nat-gw-bb-gw1-0 kube-system 26d34b3880713130ea20b4c7340405bcfc51da197f16a833c3f7705a02b86428 /var/run/netns/cni-1c6ce656-1eed-23f6-d612-225389b01e2c net1 ovn-vpc-external-network.kube-system [] {[]  [] []}     }
I1206 12:30:46.661588 2573453 server.go:74] [2025-12-06T12:30:46+08:00] Outgoing response POST /api/v1/del with 204 status code in 29ms
I1206 12:30:46.717148 2573453 server.go:66] [2025-12-06T12:30:46+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:30:46.717233 2573453 handler.go:460] del port request: {kube-ovn vpc-nat-gw-bb-gw1-0 kube-system 26d34b3880713130ea20b4c7340405bcfc51da197f16a833c3f7705a02b86428 /var/run/netns/cni-1c6ce656-1eed-23f6-d612-225389b01e2c eth0 ovn [] {[]  [] []}     }
I1206 12:30:46.776625 2573453 server.go:74] [2025-12-06T12:30:46+08:00] Outgoing response POST /api/v1/del with 204 status code in 59ms
I1206 12:30:46.844341 2573453 server.go:66] [2025-12-06T12:30:46+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:30:46.844431 2573453 handler.go:460] del port request: {macvlan vpc-nat-gw-bb-gw1-0 kube-system 26d34b3880713130ea20b4c7340405bcfc51da197f16a833c3f7705a02b86428 /var/run/netns/cni-1c6ce656-1eed-23f6-d612-225389b01e2c net1 ovn-vpc-external-network.kube-system [] {[]  [] []}     }
I1206 12:30:46.870231 2573453 server.go:74] [2025-12-06T12:30:46+08:00] Outgoing response POST /api/v1/del with 204 status code in 25ms
I1206 12:30:46.906655 2573453 server.go:66] [2025-12-06T12:30:46+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:30:46.906727 2573453 handler.go:460] del port request: {kube-ovn vpc-nat-gw-bb-gw1-0 kube-system 26d34b3880713130ea20b4c7340405bcfc51da197f16a833c3f7705a02b86428 /var/run/netns/cni-1c6ce656-1eed-23f6-d612-225389b01e2c eth0 ovn [] {[]  [] []}     }
I1206 12:30:46.932138 2573453 server.go:74] [2025-12-06T12:30:46+08:00] Outgoing response POST /api/v1/del with 204 status code in 25ms
I1206 12:30:58.209049 2573453 server.go:66] [2025-12-06T12:30:58+08:00] Incoming HTTP/1.1 POST /api/v1/add request
I1206 12:30:58.209164 2573453 handler.go:82] add port request: {kube-ovn vpc-nat-gw-bb-gw1-0 kube-system 1fda726280e73cffdf4394187967ae45766f6c3e7feb6d1090186584644a67d7 /var/run/netns/cni-2311a8bb-9208-727f-d243-b8c7e507875c eth0 ovn [] {[]  [] []}     }
I1206 12:30:58.270782 2573453 handler.go:306] create container interface eth0 mac 02:65:af:9a:13:64, ip 10.196.255.253/16, cidr 10.196.0.0/16, gw 10.196.255.254, custom routes [{10.233.0.0/16 10.196.255.254} {100.64.0.0/16 10.196.255.254} {10.222.0.0/16 10.196.255.254} {10.198.0.0/16 10.196.255.254} {10.197.0.0/16 10.196.255.254}]
I1206 12:30:58.355548 2573453 ovs_linux.go:225] ovs interface 1fda726280e7_h is ready
I1206 12:31:00.930470 2573453 arp.go:244] announce arp address nic eth0, ip 10.196.255.253, with mac 02:65:af:9a:13:64
I1206 12:31:02.951533 2573453 ovs_linux.go:1279] add ip address 10.196.255.253/16 to eth0
I1206 12:31:02.965460 2573453 ovs_linux.go:619] MAC address of gateway 10.196.255.254 is a6:8a:4b:82:11:94
I1206 12:31:02.965478 2573453 ovs_linux.go:620] network 10.196.255.253/16 with gateway 10.196.255.254 is ready for interface eth0 after 2 checks
I1206 12:31:02.986602 2573453 server.go:74] [2025-12-06T12:31:02+08:00] Outgoing response POST /api/v1/add with 200 status code in 4777ms
I1206 12:31:03.048871 2573453 server.go:66] [2025-12-06T12:31:03+08:00] Incoming HTTP/1.1 POST /api/v1/add request
I1206 12:31:03.049032 2573453 handler.go:82] add port request: {macvlan vpc-nat-gw-bb-gw1-0 kube-system 1fda726280e73cffdf4394187967ae45766f6c3e7feb6d1090186584644a67d7 /var/run/netns/cni-2311a8bb-9208-727f-d243-b8c7e507875c net1 ovn-vpc-external-network.kube-system [] {[]  [] []}     }
2025/12/06 12:31:03 http: panic serving @: runtime error: index out of range [1] with length 1
goroutine 1147906 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1943 +0xd3
panic({0x5cc3223f58e0?, 0xc001042060?})
	runtime/panic.go:783 +0x132
github.com/kubeovn/kube-ovn/pkg/util.GetIPAddrWithMask({0x0, 0x0}, {0x0, 0x0})
	github.com/kubeovn/kube-ovn/pkg/util/net.go:355 +0x5d4
github.com/kubeovn/kube-ovn/pkg/daemon.cniServerHandler.handleAdd({0xc00056d8c8, {0x5cc322674818, 0xc000552e00}, {0x5cc32260b0b8, 0xc0002a2cb0}, 0xc00057c960}, 0xc000370260, 0xc0003a0d20)
	github.com/kubeovn/kube-ovn/pkg/daemon/handler.go:133 +0x1725
github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0x5cc323f98de0?, 0x0?, 0x0?)
	github.com/emicklei/go-restful/v3@v3.13.0/filter.go:23 +0x53
github.com/kubeovn/kube-ovn/pkg/daemon.requestAndResponseLogger(0xc000370260, 0xc0003a0d20, 0xc000294190)
	github.com/kubeovn/kube-ovn/pkg/daemon/server.go:68 +0xff
github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0xc000b36000?, 0x5cc32262a8d0?, 0xc000d320c0?)
	github.com/emicklei/go-restful/v3@v3.13.0/filter.go:21 +0x42
github.com/emicklei/go-restful/v3.(*Container).dispatch(0xc00102a510, {0x5cc32262a8d0, 0xc000d320c0}, 0xc000652000)
	github.com/emicklei/go-restful/v3@v3.13.0/container.go:296 +0x9ac
net/http.HandlerFunc.ServeHTTP(0xc001024000?, {0x5cc32262a8d0?, 0xc000d320c0?}, 0x5cc3212111b2?)
	net/http/server.go:2322 +0x29
net/http.(*ServeMux).ServeHTTP(0x5cc32261b450?, {0x5cc32262a8d0, 0xc000d320c0}, 0xc000652000)
	net/http/server.go:2861 +0x1c7
github.com/emicklei/go-restful/v3.(*Container).ServeHTTP(0xc00102a510, {0x5cc32261b450, 0xc00125a000}, 0xc000652000)
	github.com/emicklei/go-restful/v3@v3.13.0/container.go:346 +0xfb
net/http.serverHandler.ServeHTTP({0x5cc322609f38?}, {0x5cc32261b450?, 0xc00125a000?}, 0x1?)
	net/http/server.go:3340 +0x8e
net/http.(*conn).serve(0xc00034a1b0, {0x5cc322634318, 0xc0010357a0})
	net/http/server.go:2109 +0x665
created by net/http.(*Server).Serve in goroutine 230
	net/http/server.go:3493 +0x485
I1206 12:31:03.080010 2573453 server.go:66] [2025-12-06T12:31:03+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:31:03.080094 2573453 handler.go:460] del port request: {macvlan vpc-nat-gw-bb-gw1-0 kube-system 1fda726280e73cffdf4394187967ae45766f6c3e7feb6d1090186584644a67d7 /var/run/netns/cni-2311a8bb-9208-727f-d243-b8c7e507875c net1 ovn-vpc-external-network.kube-system [] {[]  [] []}     }
I1206 12:31:03.106701 2573453 server.go:74] [2025-12-06T12:31:03+08:00] Outgoing response POST /api/v1/del with 204 status code in 26ms
I1206 12:31:03.154858 2573453 server.go:66] [2025-12-06T12:31:03+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:31:03.154936 2573453 handler.go:460] del port request: {kube-ovn vpc-nat-gw-bb-gw1-0 kube-system 1fda726280e73cffdf4394187967ae45766f6c3e7feb6d1090186584644a67d7 /var/run/netns/cni-2311a8bb-9208-727f-d243-b8c7e507875c eth0 ovn [] {[]  [] []}     }
I1206 12:31:03.219575 2573453 server.go:74] [2025-12-06T12:31:03+08:00] Outgoing response POST /api/v1/del with 204 status code in 64ms
I1206 12:31:03.293804 2573453 server.go:66] [2025-12-06T12:31:03+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:31:03.293899 2573453 handler.go:460] del port request: {macvlan vpc-nat-gw-bb-gw1-0 kube-system 1fda726280e73cffdf4394187967ae45766f6c3e7feb6d1090186584644a67d7 /var/run/netns/cni-2311a8bb-9208-727f-d243-b8c7e507875c net1 ovn-vpc-external-network.kube-system [] {[]  [] []}     }
I1206 12:31:03.317924 2573453 server.go:74] [2025-12-06T12:31:03+08:00] Outgoing response POST /api/v1/del with 204 status code in 24ms
I1206 12:31:03.352212 2573453 server.go:66] [2025-12-06T12:31:03+08:00] Incoming HTTP/1.1 POST /api/v1/del request
I1206 12:31:03.352296 2573453 handler.go:460] del port request: {kube-ovn vpc-nat-gw-bb-gw1-0 kube-system 1fda726280e73cffdf4394187967ae45766f6c3e7feb6d1090186584644a67d7 /var/run/netns/cni-2311a8bb-9208-727f-d243-b8c7e507875c eth0 ovn [] {[]  [] []}     }
I1206 12:31:03.375729 2573453 server.go:74] [2025-12-06T12:31:03+08:00] Outgoing response POST /api/v1/del with 204 status code in 23ms
I1206 12:31:17.184606 2573453 server.go:66] [2025-12-06T12:31:17+08:00] Incoming HTTP/1.1 POST /api/v1/add request
I1206 12:31:17.184729 2573453 handler.go:82] add port request: {kube-ovn vpc-nat-gw-bb-gw1-0 kube-system 73dee534f1c684cd333b01f63ceabba283fabf2d38bd618f977015214ac776af /var/run/netns/cni-8aa5081e-4406-71df-a0f9-7421f9924abf eth0 ovn [] {[]  [] []}     }
I1206 12:31:17.188791 2573453 handler.go:306] create container interface eth0 mac 02:65:af:9a:13:64, ip 10.196.255.253/16, cidr 10.196.0.0/16, gw 10.196.255.254, custom routes [{10.233.0.0/16 10.196.255.254} {100.64.0.0/16 10.196.255.254} {10.222.0.0/16 10.196.255.254} {10.198.0.0/16 10.196.255.254} {10.197.0.0/16 10.196.255.254}]
I1206 12:31:17.267545 2573453 ovs_linux.go:225] ovs interface 73dee534f1c6_h is ready
I1206 12:31:21.536880 2573453 arp.go:244] announce arp address nic eth0, ip 10.196.255.253, with mac 02:65:af:9a:13:64
^C

```
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
