### PR TITLE
ovn process skip non-ovn subnet

### DIFF
--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -155,6 +155,11 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 	}
 
 	for _, podNet := range podNets {
+		// Skip non-OVN subnets that don't create OVN logical switch ports
+		if !isOvnSubnet(podNet.Subnet) {
+			continue
+		}
+
 		portName := ovs.PodNameToPortName(vmiMigration.Spec.VMIName, vmiMigration.Namespace, podNet.ProviderName)
 		srcNodeName := vmi.Status.MigrationState.SourceNode
 		targetNodeName := vmi.Status.MigrationState.TargetNode

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1211,6 +1211,11 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 		}
 	}
 	for _, podNet := range podNets {
+		// Skip non-OVN subnets for security group synchronization
+		if !isOvnSubnet(podNet.Subnet) {
+			continue
+		}
+
 		c.syncVirtualPortsQueue.Add(podNet.Subnet.Name)
 		securityGroupAnnotation := pod.Annotations[fmt.Sprintf(util.SecurityGroupAnnotationTemplate, podNet.ProviderName)]
 		if securityGroupAnnotation != "" {
@@ -1262,6 +1267,11 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 
 	// associated with security group
 	for _, podNet := range podNets {
+		// Skip non-OVN subnets (e.g., macvlan) that don't create OVN logical switch ports
+		if !isOvnSubnet(podNet.Subnet) {
+			continue
+		}
+
 		portSecurity := false
 		if pod.Annotations[fmt.Sprintf(util.PortSecurityAnnotationTemplate, podNet.ProviderName)] == "true" {
 			portSecurity = true

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -319,6 +319,11 @@ func (c *Controller) handleUpdateVirtualParents(key string) error {
 			klog.Errorf("failed to get pod nets %v", err)
 		}
 		for _, podNet := range podNets {
+			// Skip non-OVN subnets that don't create OVN logical switch ports
+			if !isOvnSubnet(podNet.Subnet) {
+				continue
+			}
+
 			if podNet.Subnet.Name == cachedVip.Spec.Subnet {
 				portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
 				virtualParents = append(virtualParents, portName)


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->


- Bug fixes


```bash


I1209 11:11:18.953412       7 security_group.go:337] sync lsp for security group ns2
I1209 11:11:18.953608       7 security_group.go:146] handle add/update security group kubeovn_deny_all
I1209 11:11:19.124159       7 security_group.go:146] handle add/update security group kubeovn_deny_all
I1209 12:11:36.739667       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:36.751060       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:36.751209       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:36.756630       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:36.762481       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:36.762593       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:36.773018       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:36.778650       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:36.778758       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:36.799216       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:36.806271       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:36.806426       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:36.847426       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:36.853536       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:36.853627       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:36.934105       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:36.940931       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:36.941028       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:37.101387       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:37.107391       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:37.107755       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:37.428059       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:37.434223       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:37.434364       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:38.075251       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:38.082644       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:38.082803       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:39.363460       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:39.369972       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:39.370114       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:41.931128       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:41.937721       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:41.937832       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:47.058625       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:47.065985       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:47.066088       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:11:57.306687       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:11:57.314518       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:11:57.314633       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:12:17.794903       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:12:17.801796       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:12:17.801907       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:12:58.762001       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:12:58.768721       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:12:58.768846       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:14:20.689608       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:14:20.696563       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:14:20.696735       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:17:04.537586       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:17:04.544852       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:17:04.544968       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:22:32.225873       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:22:32.232679       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:22:32.232790       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:33:27.593800       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:33:27.600813       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:33:27.600970       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 12:50:07.601589       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 12:50:07.609518       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 12:50:07.609638       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 13:06:47.610673       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 13:06:47.617934       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 13:06:47.618054       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 13:07:07.129566       7 security_group.go:337] sync lsp for security group ns1
I1209 13:07:07.134837       7 security_group.go:146] handle add/update security group kubeovn_deny_all
I1209 13:23:27.618887       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 13:23:27.626680       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 13:23:27.626800       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 13:40:07.627624       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 13:40:07.635090       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 13:40:07.635208       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
I1209 13:50:59.438090       7 pod.go:1210] handle add/update pod security group kube-system/vpc-nat-gw-sg-gw-0
E1209 13:50:59.444683       7 pod.go:1255] failed to set security for logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found
E1209 13:50:59.444804       7 controller.go:1443] "Unhandled Error" err="error syncing update pod security \"kube-system/vpc-nat-gw-sg-gw-0\": get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: get logical switch port vpc-nat-gw-sg-gw-0.kube-system.ovn-vpc-external-network.kube-system: object not found, requeuing" logger="UnhandledError"
^C
root@xs4772:~/zbb/sg# k get ip | grep gw
vpc-nat-gw-gw1-0.kube-system                  10.198.255.253          36:db:b9:10:03:4d   xs4772   ovn-vm
vpc-nat-gw-sg-gw-0.kube-system                10.177.0.253            0e:63:cf:45:c4:31   xs4773   ovn-gw1
root@xs4772:~/zbb/sg# k ko nbctl list | grep vpc-nat-gw-sg-gw-0.kube-system\
> ^C
root@xs4772:~/zbb/sg# k ko nbctl list | grep vpc-nat-gw-sg-gw-0.kube-system
ovn-nbctl: 'list' command requires at least 1 arguments
command terminated with exit code 1
root@xs4772:~/zbb/sg# k ko nbctl show | grep vpc-nat-gw-sg-gw-0.kube-system
    port vpc-nat-gw-sg-gw-0.kube-system
root@xs4772:~/zbb/sg# k ko nbctl show | grep -C 3 vpc-nat-gw-sg-gw-0.kube-system
    port ovn-gw1-ovn-cluster
        type: router
        router-port: ovn-cluster-ovn-gw1
    port vpc-nat-gw-sg-gw-0.kube-system
        addresses: ["0e:63:cf:45:c4:31 10.177.0.253"]
switch 7925221d-5140-4fbc-a46a-eb1e79504205 (join)
    port join-ovn-cluster
root@xs4772:~/zbb/sg#


```


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
