### PR TITLE
diff subnet and subnet cross case, use different priority, subnet cro…

### DIFF
--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -721,7 +721,7 @@ func (c *OVNNbClient) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR 
 				),
 			)
 
-			acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.SubnetAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier)
+			acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.SubnetCrossAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier)
 			if err != nil {
 				klog.Error(err)
 				return fmt.Errorf("new allow subnet ingress acl for logical switch %s: %w", lsName, err)

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -1134,7 +1134,7 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchPrivate() {
 					match = fmt.Sprintf("(ip6.src == %s && ip6.dst == %s) || (ip6.src == %s && ip6.dst == %s)", cidr, subnet, subnet, cidr)
 				}
 
-				acl, err = nbClient.GetACL(lsName, direction, util.SubnetAllowPriority, match, false)
+				acl, err = nbClient.GetACL(lsName, direction, util.SubnetCrossAllowPriority, match, false)
 				require.NoError(t, err)
 				require.Contains(t, ls.ACLs, acl.UUID)
 			}
@@ -1203,7 +1203,7 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchPrivate() {
 					match = fmt.Sprintf("(ip6.src == %s && ip6.dst == %s) || (ip6.src == %s && ip6.dst == %s)", cidr, subnet, subnet, cidr)
 				}
 
-				acl, err = nbClient.GetACL(lsName, direction, util.SubnetAllowPriority, match, false)
+				acl, err = nbClient.GetACL(lsName, direction, util.SubnetCrossAllowPriority, match, false)
 				require.NoError(t, err)
 				require.Contains(t, ls.ACLs, acl.UUID)
 			}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -160,8 +160,9 @@ const (
 
 	AllowEWTrafficPriority = "1900"
 
-	SubnetAllowPriority = "1001"
-	DefaultDropPriority = "1000"
+	SubnetCrossAllowPriority = "2004" // Same priority as SecurityGroupAllowPriority to allow subnet allowSubnets to work with security groups
+	SubnetAllowPriority      = "1001" // For same-subnet traffic (basic intra-subnet connectivity)
+	DefaultDropPriority      = "1000"
 
 	GwChassisMaxPriority = 100
 	AnpMaxRules          = 100


### PR DESCRIPTION
…ss case use the same as SG allowSameGroup

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->


- Bug fixes

```bash


acl 优先级 1001 修改之前，用于两种场景，我觉得不太合适，这两种情况是需要区分的， 


一种是非private 模式子网内互通，需要兜底放通，这个逻辑不变

root@xs4772:~# k ko nbctl list acl | grep -C 10 1001
_uuid               : 1a375901-da41-4c27-b59a-e3a1f99f48c6
action              : allow-related
direction           : to-lport
external_ids        : {parent=ovn-vm2}
label               : 0
log                 : false
match               : "ip4.src == 10.197.0.0/16 && ip4.dst == 10.197.0.0/16"
meter               : []
name                : []
options             : {}
priority            : 1001
severity            : []
tier                : 2


一种是子网间，需要更高的优先级放通（需要考虑安全组混用场景），这个逻辑修改

--
_uuid               : f230983d-036b-49b0-bc6c-1c13a27ad1e0
action              : allow-related
direction           : to-lport
external_ids        : {parent=ovn-vm2}
label               : 0
log                 : false
match               : "(ip4.src == 10.197.0.0/16 && ip4.dst == 10.177.0.0/24) || (ip4.src == 10.177.0.0/24 && ip4.dst == 10.197.0.0/16)"
meter               : []
name                : []
options             : {}
priority            : 1001
severity            : []
tier                : 2


这两种情况是需要区分的， 


在 subnet private 场景， 结合子网间场景，用户指定了子网的 spec allowsubnets 肯定是希望它能通，而且客户有可能再使用安全组做逻辑主机组上的放通。

如果客户不希望子网间能通，而是直接删除 spec allowsubnets。

所以保持子网间能通有足够高的优先级是最合适的。

在这个子功能上，至少解决了默认易用性功能混合使用的问题。而且在混用的情况下也并没有破坏安全组的 allowSameGroup 和 subnet allow subnets 本身的基本功能。


```

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)

https://github.com/kubeovn/kube-ovn/issues/6020
