### PR TITLE
Only GC LRPs that have the "vendor"="kube-ovn" external ID.

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -75,7 +75,9 @@ func (c *Controller) gcLogicalRouterPort() error {
 		}
 	}
 
-	if err = c.OVNNbClient.DeleteLogicalRouterPorts(nil, logicalRouterPortFilter(exceptPeerPorts)); err != nil {
+	if err = c.OVNNbClient.DeleteLogicalRouterPorts(
+		map[string]string{"vendor": util.CniTypeName},
+		logicalRouterPortFilter(exceptPeerPorts)); err != nil {
 		klog.Errorf("delete non-existent peer logical router port: %v", err)
 		return err
 	}


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Bug Fix - In environments where there are LRPs from other vendors, do not delete them. 

## Which issue(s) this PR fixes

Fixes #(issue-number)
