### PR TITLE
fix: double quoting causing nxdomain

### DIFF
--- a/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
@@ -81,13 +81,12 @@ spec:
           {{- else if eq .Values.networking.stack "IPv6" -}}
           {{ .Values.pinger.targets.externalAddresses.v6 }}
           {{- end }}
-          - --external-dns=
           {{- if eq .Values.networking.stack "Dual" -}}
-          "{{ .Values.pinger.targets.externalDomain.v6 }}"
+          - --external-dns={{ .Values.pinger.targets.externalDomain.v6 }}
           {{- else if eq .Values.networking.stack "IPv4" -}}
-          "{{ .Values.pinger.targets.externalDomain.v4 }}"
+          - --external-dns={{ .Values.pinger.targets.externalDomain.v4 }}
           {{- else if eq .Values.networking.stack "IPv6" -}}
-          "{{ .Values.pinger.targets.externalDomain.v6 }}"
+          - --external-dns={{ .Values.pinger.targets.externalDomain.v6 }}
           {{- end }}
           - --ds-namespace={{ .Values.namespace }}
           - --logtostderr=false


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

Pinger is unable to resolve the address because the quotations aren't parsed properly.