### PR TITLE
跟踪日志发现在eip绑定qos以及修改qos的过程中，有v4ip为空的情况也会执行nat网关的tc规则，v4ip为空规则解析错误，排除该场景。

### DIFF
--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -462,7 +462,7 @@ func (c *Controller) addEipQoSInPod(
 	burst string,
 ) error {
 	if v4ip == "" {
-		klog.Info("v4ip is nil")
+		klog.Infof("v4ip is empty for nat gateway %s, skipping QoS rule addition", dp)
 		return nil
 	}
 	var operation string


### PR DESCRIPTION
Signed-off-by: mengyu <595983420@qq.com>

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
