### PR TITLE
fix(helm): template and podaffinity

### DIFF
--- a/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
-        {{- include "kube-ovn.affinities.nodeAffinity" (dict "userPreferred" .Values.monitor.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.monitor.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) -}}
+        {{- include "kube-ovn.affinities.nodeAffinity" (dict "userPreferred" .Values.monitor.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.monitor.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) | nindent 8 -}}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
@@ -81,13 +81,16 @@ spec:
           {{- else if eq .Values.networking.stack "IPv6" -}}
           {{ .Values.pinger.targets.externalAddresses.v6 }}
           {{- end }}
+          
+          - --external-dns=
           {{- if eq .Values.networking.stack "Dual" -}}
-          - --external-dns={{ .Values.pinger.targets.externalDomain.v6 }}
+          {{ .Values.pinger.targets.externalDomain.v6 }}
           {{- else if eq .Values.networking.stack "IPv4" -}}
-          - --external-dns={{ .Values.pinger.targets.externalDomain.v4 }}
+          {{ .Values.pinger.targets.externalDomain.v4 }}
           {{- else if eq .Values.networking.stack "IPv6" -}}
-          - --external-dns={{ .Values.pinger.targets.externalDomain.v6 }}
+          {{ .Values.pinger.targets.externalDomain.v6 }}
           {{- end }}
+          
           - --ds-namespace={{ .Values.namespace }}
           - --logtostderr=false
           - --alsologtostderr=true


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

PR https://github.com/kubeovn/kube-ovn/commit/5262026646c460436c76bfc2c17c22ad4e9d6c95 and https://github.com/kubeovn/kube-ovn/commit/a6fcfbcf56bc6b9f7b3fb1c0728b016065523b8b have introduced bugs that break templating.

PodAffinity has a faulty indentation and the address in the pinger is suffixed with a dash that breaks the resolution.

