### PR TITLE
feat(natgw): give pod_ips to bgp speaker to prioritize IPv4 over IPv6

### DIFF
--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -157,6 +157,14 @@ func GenNatGwBgpSpeakerContainer(speakerParams kubeovnv1.VpcBgpSpeaker, speakerI
 					},
 				},
 			},
+			{
+				Name: "POD_IPS",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "status.podIPs",
+					},
+				},
+			},
 		},
 		Args: args,
 	}


### PR DESCRIPTION
When running DualStack with IPv6 before IPv4 in the podCIDR, the podIP env variable will contain an IPv6, which is not a valid router ID. This causes GoBGP to crash, failing to properly serialize its own routerID inthe BGPOpen message. The NAT GW already has code to infer the routerID from the podIPs, and will prioritize IPv4s. We just didn't pass it through the correct env variable when the speaker is in a NAT gateway

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
