### PR TITLE
fix(vpcnatgateway): bgp speaker would crash if no ipv4 is available

### DIFF
--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -183,11 +183,11 @@ func ParseFlags() (*Configuration, error) {
 	if config.RouterID == nil {
 		if podIPv4 != "" {
 			config.RouterID = net.ParseIP(podIPv4)
-		} else {
-			config.RouterID = net.ParseIP(podIPv6)
 		}
+
 		if config.RouterID == nil {
-			return nil, errors.New("no router id or POD_IPS")
+			// RouterID must be an IPv4. If no IPv4 exists on the speaker, fallback to 0.0.0.0 to avoid GoBGP crashing.
+			config.RouterID = net.ParseIP("0.0.0.0")
 		}
 	}
 


### PR DESCRIPTION
GoBGP v4 seems to crash when serializing with an invalid RouterID, whereas on older version, it defaulted to 0.0.0.0. There's functionally no problem with multiple peers having the same RouterID when doing eBGP. If using route reflectors, it might be more of a problem. In that case, users can use the --router-id parameter. Note that this case should not occur anyway, the NAT GW doesn't support IPv6 only networks right now as it cannot do NATv6. This is purely a failover to prevent crashes.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
