### PR TITLE
let nat gw only bind one subnet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,40 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `cmd/` entrypoints for CNI plugin, controller, daemon, and helpers; binaries land in `dist/images/` via Make targets.  
-- `pkg/` shared Go libraries; `fastpath/` and `versions/` hold data-plane helpers and release metadata.  
-- `charts/` Helm chart, `yamls/` and top-level `*-sa.yaml` manifest examples; `docs/` product docs.  
-- `hack/` CI/dev scripts; `makefiles/` split build/test logic; `test/` contains `unittest`, `e2e`, `performance`, and fixtures.  
+
+- `cmd/` entrypoints for CNI plugin, controller, daemon, and helpers; binaries land in `dist/images/` via Make targets.
+- `pkg/` shared Go libraries; `fastpath/` and `versions/` hold data-plane helpers and release metadata.
+- `charts/` Helm chart, `yamls/` and top-level `*-sa.yaml` manifest examples; `docs/` product docs.
+- `hack/` CI/dev scripts; `makefiles/` split build/test logic; `test/` contains `unittest`, `e2e`, `performance`, and fixtures.
 
 ## Build, Test, and Development Commands
-- `make build-go` – tidy modules and compile Go binaries for linux/amd64 into `dist/images/`.  
-- `make lint` – run `golangci-lint` plus Go “modernize”; auto-fixes when not in CI.  
-- `make ut` – run unit tests: Ginkgo suites in `test/unittest` and `go test` with coverage for `pkg`.  
+
+- `make build-go` – tidy modules and compile Go binaries for linux/amd64 into `dist/images/`.
+- `make lint` – run `golangci-lint` plus Go “modernize”; auto-fixes when not in CI.
+- `make ut` – run unit tests: Ginkgo suites in `test/unittest` and `go test` with coverage for `pkg`.
 
 ## General Coding Guidlines
+
 - Every time after editing code. MUST run `make lint` to detect and fix potential lint issues.
 - When modifying code, try to clean up any related code logic that is no longer needed.
-- Follow `CODE_STYLE.md`: camelCase identifiers, keep functions short (~100 lines), return/log errors instead of discarding, and prefer `if err := ...; err != nil` patterns. 
+- Follow `CODE_STYLE.md`: camelCase identifiers, keep functions short (~100 lines), return/log errors instead of discarding, and prefer `if err := ...; err != nil` patterns.
 
 ## Adding a New Feature
+
 - Plan first: clarify any uncertainties and confirm the approach before making changes.
 - Add unit tests to cover the new feature.
 - When adding end-to-end (e2e) tests for the new feature, use `f.SkipVersionPriorTo` to ensure they run only on supported branches.
 
+## API Changes (CRD Updates)
+
+When modifying CRD types in `pkg/apis/kubeovn/v1/`, update the following CRD definition files to keep them in sync:
+
+- `dist/images/install.sh` – embedded CRD definitions for install script
+- `kube-ovn-crd.yaml` – standalone CRD manifest in project root
+- `charts/kube-ovn/templates/kube-ovn-crd.yaml` – Helm chart v1 CRD template
+- `charts/kube-ovn-v2/crds/kube-ovn-crd.yaml` – Helm chart v2 CRD definitions
+
 ## Fixing a Bug
+
 - Analyze the issue first and identify the root cause. Confirm the analysis before making edits.
 - Check if the same bug pattern exists elsewhere in the codebase.

--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -500,6 +500,15 @@ spec:
                           type: array
                       type: object
                   type: object
+                routes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                      nextHopIP:
+                        type: string
             spec:
               type: object
               properties:
@@ -1023,13 +1032,13 @@ spec:
                 - externalSubnet
               x-kubernetes-validations:
                 - rule: "!has(self.internalIPs) || size(self.internalIPs) == 0 || size(self.internalIPs) >= self.replicas"
-                  message: 'Size of Internal IPs MUST be equal to or greater than Replicas'
+                  message: "Size of Internal IPs MUST be equal to or greater than Replicas"
                   fieldPath: ".internalIPs"
                 - rule: "!has(self.externalIPs) || size(self.externalIPs) == 0 || size(self.externalIPs) >= self.replicas"
-                  message: 'Size of External IPs MUST be equal to or greater than Replicas'
+                  message: "Size of External IPs MUST be equal to or greater than Replicas"
                   fieldPath: ".externalIPs"
                 - rule: "size(self.policies) != 0 || size(self.selectors) != 0"
-                  message: 'Each VPC Egress Gateway MUST have at least one policy or selector'
+                  message: "Each VPC Egress Gateway MUST have at least one policy or selector"
               properties:
                 replicas:
                   type: integer
@@ -1127,7 +1136,7 @@ spec:
                                 - operator
                         x-kubernetes-validations:
                           - rule: "size(self.matchLabels) != 0 || size(self.matchExpressions) != 0"
-                            message: 'Each namespace selector MUST have at least one matchLabels or matchExpressions'
+                            message: "Each namespace selector MUST have at least one matchLabels or matchExpressions"
                       podSelector:
                         type: object
                         properties:
@@ -1153,7 +1162,7 @@ spec:
                                 - operator
                         x-kubernetes-validations:
                           - rule: "size(self.matchLabels) != 0 || size(self.matchExpressions) != 0"
-                            message: 'Each pod selector MUST have at least one matchLabels or matchExpressions'
+                            message: "Each pod selector MUST have at least one matchLabels or matchExpressions"
                 policies:
                   type: array
                   items:
@@ -1179,7 +1188,7 @@ spec:
                           minLength: 1
                     x-kubernetes-validations:
                       - rule: "size(self.ipBlocks) != 0 || size(self.subnets) != 0"
-                        message: 'Each policy MUST have at least one ipBlock or subnet'
+                        message: "Each policy MUST have at least one ipBlock or subnet"
                 trafficPolicy:
                   type: string
                   enum:
@@ -2188,7 +2197,7 @@ spec:
                   type: object
                   x-kubernetes-validations:
                     - rule: "self.enabled == false || self.ip != ''"
-                      message: 'Port IP must be set when BFD Port is enabled'
+                      message: "Port IP must be set when BFD Port is enabled"
               type: object
             status:
               properties:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -500,6 +500,15 @@ spec:
                           type: array
                       type: object
                   type: object
+                routes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                      nextHopIP:
+                        type: string
             spec:
               type: object
               properties:
@@ -1023,13 +1032,13 @@ spec:
                 - externalSubnet
               x-kubernetes-validations:
                 - rule: "!has(self.internalIPs) || size(self.internalIPs) == 0 || size(self.internalIPs) >= self.replicas"
-                  message: 'Size of Internal IPs MUST be equal to or greater than Replicas'
+                  message: "Size of Internal IPs MUST be equal to or greater than Replicas"
                   fieldPath: ".internalIPs"
                 - rule: "!has(self.externalIPs) || size(self.externalIPs) == 0 || size(self.externalIPs) >= self.replicas"
-                  message: 'Size of External IPs MUST be equal to or greater than Replicas'
+                  message: "Size of External IPs MUST be equal to or greater than Replicas"
                   fieldPath: ".externalIPs"
                 - rule: "size(self.policies) != 0 || size(self.selectors) != 0"
-                  message: 'Each VPC Egress Gateway MUST have at least one policy or selector'
+                  message: "Each VPC Egress Gateway MUST have at least one policy or selector"
               properties:
                 replicas:
                   type: integer
@@ -1127,7 +1136,7 @@ spec:
                                 - operator
                         x-kubernetes-validations:
                           - rule: "size(self.matchLabels) != 0 || size(self.matchExpressions) != 0"
-                            message: 'Each namespace selector MUST have at least one matchLabels or matchExpressions'
+                            message: "Each namespace selector MUST have at least one matchLabels or matchExpressions"
                       podSelector:
                         type: object
                         properties:
@@ -1153,7 +1162,7 @@ spec:
                                 - operator
                         x-kubernetes-validations:
                           - rule: "size(self.matchLabels) != 0 || size(self.matchExpressions) != 0"
-                            message: 'Each pod selector MUST have at least one matchLabels or matchExpressions'
+                            message: "Each pod selector MUST have at least one matchLabels or matchExpressions"
                 policies:
                   type: array
                   items:
@@ -1179,7 +1188,7 @@ spec:
                           minLength: 1
                     x-kubernetes-validations:
                       - rule: "size(self.ipBlocks) != 0 || size(self.subnets) != 0"
-                        message: 'Each policy MUST have at least one ipBlock or subnet'
+                        message: "Each policy MUST have at least one ipBlock or subnet"
                 trafficPolicy:
                   type: string
                   enum:
@@ -1314,21 +1323,21 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - jsonPath: .status.ip
-        name: IP
-        type: string
-      - jsonPath: .spec.macAddress
-        name: Mac
-        type: string
-      - jsonPath: .status.nat
-        name: Nat
-        type: string
-      - jsonPath: .spec.natGwDp
-        name: NatGwDp
-        type: string
-      - jsonPath: .status.ready
-        name: Ready
-        type: boolean
+        - jsonPath: .status.ip
+          name: IP
+          type: string
+        - jsonPath: .spec.macAddress
+          name: Mac
+          type: string
+        - jsonPath: .status.nat
+          name: Nat
+          type: string
+        - jsonPath: .spec.natGwDp
+          name: NatGwDp
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
       schema:
         openAPIV3Schema:
           type: object
@@ -1400,24 +1409,24 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - jsonPath: .spec.eip
-        name: Eip
-        type: string
-      - jsonPath: .status.v4ip
-        name: V4ip
-        type: string
-      - jsonPath: .spec.internalIp
-        name: InternalIp
-        type: string
-      - jsonPath: .status.v6ip
-        name: V6ip
-        type: string
-      - jsonPath: .status.ready
-        name: Ready
-        type: boolean
-      - jsonPath: .status.natGwDp
-        name: NatGwDp
-        type: string
+        - jsonPath: .spec.eip
+          name: Eip
+          type: string
+        - jsonPath: .status.v4ip
+          name: V4ip
+          type: string
+        - jsonPath: .spec.internalIp
+          name: InternalIp
+          type: string
+        - jsonPath: .status.v6ip
+          name: V6ip
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
+        - jsonPath: .status.natGwDp
+          name: NatGwDp
+          type: string
       schema:
         openAPIV3Schema:
           type: object
@@ -1483,33 +1492,33 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - jsonPath: .spec.eip
-        name: Eip
-        type: string
-      - jsonPath: .spec.protocol
-        name: Protocol
-        type: string
-      - jsonPath: .status.v4ip
-        name: V4ip
-        type: string
-      - jsonPath: .status.v6ip
-        name: V6ip
-        type: string
-      - jsonPath: .spec.internalIp
-        name: InternalIp
-        type: string
-      - jsonPath: .spec.externalPort
-        name: ExternalPort
-        type: string
-      - jsonPath: .spec.internalPort
-        name: InternalPort
-        type: string
-      - jsonPath: .status.natGwDp
-        name: NatGwDp
-        type: string
-      - jsonPath: .status.ready
-        name: Ready
-        type: boolean
+        - jsonPath: .spec.eip
+          name: Eip
+          type: string
+        - jsonPath: .spec.protocol
+          name: Protocol
+          type: string
+        - jsonPath: .status.v4ip
+          name: V4ip
+          type: string
+        - jsonPath: .status.v6ip
+          name: V6ip
+          type: string
+        - jsonPath: .spec.internalIp
+          name: InternalIp
+          type: string
+        - jsonPath: .spec.externalPort
+          name: ExternalPort
+          type: string
+        - jsonPath: .spec.internalPort
+          name: InternalPort
+          type: string
+        - jsonPath: .status.natGwDp
+          name: NatGwDp
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
       schema:
         openAPIV3Schema:
           type: object
@@ -1587,24 +1596,24 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - jsonPath: .spec.eip
-        name: EIP
-        type: string
-      - jsonPath: .status.v4ip
-        name: V4ip
-        type: string
-      - jsonPath: .status.v6ip
-        name: V6ip
-        type: string
-      - jsonPath: .spec.internalCIDR
-        name: InternalCIDR
-        type: string
-      - jsonPath: .status.natGwDp
-        name: NatGwDp
-        type: string
-      - jsonPath: .status.ready
-        name: Ready
-        type: boolean
+        - jsonPath: .spec.eip
+          name: EIP
+          type: string
+        - jsonPath: .status.v4ip
+          name: V4ip
+          type: string
+        - jsonPath: .status.v6ip
+          name: V6ip
+          type: string
+        - jsonPath: .spec.internalCIDR
+          name: InternalCIDR
+          type: string
+        - jsonPath: .status.natGwDp
+          name: NatGwDp
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
       schema:
         openAPIV3Schema:
           type: object
@@ -1670,27 +1679,27 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - jsonPath: .status.v4Ip
-        name: V4IP
-        type: string
-      - jsonPath: .status.v6Ip
-        name: V6IP
-        type: string
-      - jsonPath: .status.macAddress
-        name: Mac
-        type: string
-      - jsonPath: .status.type
-        name: Type
-        type: string
-      - jsonPath: .status.nat
-        name: Nat
-        type: string
-      - jsonPath: .status.ready
-        name: Ready
-        type: boolean
-      - jsonPath: .spec.externalSubnet
-        name: ExternalSubnet
-        type: string
+        - jsonPath: .status.v4Ip
+          name: V4IP
+          type: string
+        - jsonPath: .status.v6Ip
+          name: V6IP
+          type: string
+        - jsonPath: .status.macAddress
+          name: Mac
+          type: string
+        - jsonPath: .status.type
+          name: Type
+          type: string
+        - jsonPath: .status.nat
+          name: Nat
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
+        - jsonPath: .spec.externalSubnet
+          name: ExternalSubnet
+          type: string
       schema:
         openAPIV3Schema:
           type: object
@@ -1762,33 +1771,33 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - jsonPath: .status.vpc
-        name: Vpc
-        type: string
-      - jsonPath: .spec.type
-        name: Type
-        type: string
-      - jsonPath: .status.v4Eip
-        name: V4Eip
-        type: string
-      - jsonPath: .status.v6Eip
-        name: V6Eip
-        type: string
-      - jsonPath: .status.v4Ip
-        name: V4Ip
-        type: string
-      - jsonPath: .status.v6Ip
-        name: V6Ip
-        type: string
-      - jsonPath: .status.ready
-        name: Ready
-        type: boolean
-      - jsonPath: .spec.ipType
-        name: IpType
-        type: string
-      - jsonPath: .spec.ipName
-        name: IpName
-        type: string
+        - jsonPath: .status.vpc
+          name: Vpc
+          type: string
+        - jsonPath: .spec.type
+          name: Type
+          type: string
+        - jsonPath: .status.v4Eip
+          name: V4Eip
+          type: string
+        - jsonPath: .status.v6Eip
+          name: V6Eip
+          type: string
+        - jsonPath: .status.v4Ip
+          name: V4Ip
+          type: string
+        - jsonPath: .status.v6Ip
+          name: V6Ip
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
+        - jsonPath: .spec.ipType
+          name: IpType
+          type: string
+        - jsonPath: .spec.ipName
+          name: IpName
+          type: string
       schema:
         openAPIV3Schema:
           type: object
@@ -1864,24 +1873,24 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - jsonPath: .status.vpc
-        name: Vpc
-        type: string
-      - jsonPath: .status.v4Eip
-        name: V4Eip
-        type: string
-      - jsonPath: .status.v6Eip
-        name: V6Eip
-        type: string
-      - jsonPath: .status.v4IpCidr
-        name: V4IpCidr
-        type: string
-      - jsonPath: .status.v6IpCidr
-        name: V6IpCidr
-        type: string
-      - jsonPath: .status.ready
-        name: Ready
-        type: boolean
+        - jsonPath: .status.vpc
+          name: Vpc
+          type: string
+        - jsonPath: .status.v4Eip
+          name: V4Eip
+          type: string
+        - jsonPath: .status.v6Eip
+          name: V6Eip
+          type: string
+        - jsonPath: .status.v4IpCidr
+          name: V4IpCidr
+          type: string
+        - jsonPath: .status.v6IpCidr
+          name: V6IpCidr
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
       schema:
         openAPIV3Schema:
           type: object
@@ -2188,7 +2197,7 @@ spec:
                   type: object
                   x-kubernetes-validations:
                     - rule: "self.enabled == false || self.ip != ''"
-                      message: 'Port IP must be set when BFD Port is enabled'
+                      message: "Port IP must be set when BFD Port is enabled"
               type: object
             status:
               properties:
@@ -2282,21 +2291,21 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
-      - name: V4IP
-        type: string
-        jsonPath: .spec.v4IpAddress
-      - name: V6IP
-        type: string
-        jsonPath: .spec.v6IpAddress
-      - name: Mac
-        type: string
-        jsonPath: .spec.macAddress
-      - name: Node
-        type: string
-        jsonPath: .spec.nodeName
-      - name: Subnet
-        type: string
-        jsonPath: .spec.subnet
+        - name: V4IP
+          type: string
+          jsonPath: .spec.v4IpAddress
+        - name: V6IP
+          type: string
+          jsonPath: .spec.v6IpAddress
+        - name: Mac
+          type: string
+          jsonPath: .spec.macAddress
+        - name: Node
+          type: string
+          jsonPath: .spec.nodeName
+        - name: Subnet
+          type: string
+          jsonPath: .spec.subnet
       schema:
         openAPIV3Schema:
           type: object
@@ -2363,24 +2372,24 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
-      - name: Namespace
-        type: string
-        jsonPath: .spec.namespace
-      - name: V4IP
-        type: string
-        jsonPath: .status.v4ip
-      - name: V6IP
-        type: string
-        jsonPath: .status.v6ip
-      - name: Mac
-        type: string
-        jsonPath: .status.mac
-      - name: Subnet
-        type: string
-        jsonPath: .spec.subnet
-      - name: Type
-        type: string
-        jsonPath: .status.type
+        - name: Namespace
+          type: string
+          jsonPath: .spec.namespace
+        - name: V4IP
+          type: string
+          jsonPath: .status.v4ip
+        - name: V6IP
+          type: string
+          jsonPath: .status.v6ip
+        - name: Mac
+          type: string
+          jsonPath: .status.mac
+        - name: Subnet
+          type: string
+          jsonPath: .spec.subnet
+        - name: Type
+          type: string
+          jsonPath: .status.type
       schema:
         openAPIV3Schema:
           type: object
@@ -2454,51 +2463,51 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - name: Provider
-        type: string
-        jsonPath: .spec.provider
-      - name: Vpc
-        type: string
-        jsonPath: .spec.vpc
-      - name: Vlan
-        type: string
-        jsonPath: .spec.vlan
-      - name: Protocol
-        type: string
-        jsonPath: .spec.protocol
-      - name: CIDR
-        type: string
-        jsonPath: .spec.cidrBlock
-      - name: Private
-        type: boolean
-        jsonPath: .spec.private
-      - name: NAT
-        type: boolean
-        jsonPath: .spec.natOutgoing
-      - name: Default
-        type: boolean
-        jsonPath: .spec.default
-      - name: GatewayType
-        type: string
-        jsonPath: .spec.gatewayType
-      - name: V4Used
-        type: number
-        jsonPath: .status.v4usingIPs
-      - name: V4Available
-        type: number
-        jsonPath: .status.v4availableIPs
-      - name: V6Used
-        type: number
-        jsonPath: .status.v6usingIPs
-      - name: V6Available
-        type: number
-        jsonPath: .status.v6availableIPs
-      - name: ExcludeIPs
-        type: string
-        jsonPath: .spec.excludeIps
-      - name: U2OInterconnectionIP
-        type: string
-        jsonPath: .status.u2oInterconnectionIP
+        - name: Provider
+          type: string
+          jsonPath: .spec.provider
+        - name: Vpc
+          type: string
+          jsonPath: .spec.vpc
+        - name: Vlan
+          type: string
+          jsonPath: .spec.vlan
+        - name: Protocol
+          type: string
+          jsonPath: .spec.protocol
+        - name: CIDR
+          type: string
+          jsonPath: .spec.cidrBlock
+        - name: Private
+          type: boolean
+          jsonPath: .spec.private
+        - name: NAT
+          type: boolean
+          jsonPath: .spec.natOutgoing
+        - name: Default
+          type: boolean
+          jsonPath: .spec.default
+        - name: GatewayType
+          type: string
+          jsonPath: .spec.gatewayType
+        - name: V4Used
+          type: number
+          jsonPath: .status.v4usingIPs
+        - name: V4Available
+          type: number
+          jsonPath: .status.v4availableIPs
+        - name: V6Used
+          type: number
+          jsonPath: .status.v6usingIPs
+        - name: V6Available
+          type: number
+          jsonPath: .status.v6availableIPs
+        - name: ExcludeIPs
+          type: string
+          jsonPath: .spec.excludeIps
+        - name: U2OInterconnectionIP
+          type: string
+          jsonPath: .status.u2oInterconnectionIP
       schema:
         openAPIV3Schema:
           type: object
@@ -2785,27 +2794,27 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - name: Subnet
-        type: string
-        jsonPath: .spec.subnet
-      - name: enableAddressSet
-        type: boolean
-        jsonPath: .spec.enableAddressSet
-      - name: IPs
-        type: string
-        jsonPath: .spec.ips
-      - name: V4Used
-        type: number
-        jsonPath: .status.v4UsingIPs
-      - name: V4Available
-        type: number
-        jsonPath: .status.v4AvailableIPs
-      - name: V6Used
-        type: number
-        jsonPath: .status.v6UsingIPs
-      - name: V6Available
-        type: number
-        jsonPath: .status.v6AvailableIPs
+        - name: Subnet
+          type: string
+          jsonPath: .spec.subnet
+        - name: enableAddressSet
+          type: boolean
+          jsonPath: .spec.enableAddressSet
+        - name: IPs
+          type: string
+          jsonPath: .spec.ips
+        - name: V4Used
+          type: number
+          jsonPath: .status.v4UsingIPs
+        - name: V4Available
+          type: number
+          jsonPath: .status.v4AvailableIPs
+        - name: V6Used
+          type: number
+          jsonPath: .status.v6UsingIPs
+        - name: V6Available
+          type: number
+          jsonPath: .status.v6AvailableIPs
       schema:
         openAPIV3Schema:
           type: object
@@ -2929,15 +2938,15 @@ spec:
                 conflict:
                   type: boolean
       additionalPrinterColumns:
-      - name: ID
-        type: string
-        jsonPath: .spec.id
-      - name: Provider
-        type: string
-        jsonPath: .spec.provider
-      - name: conflict
-        type: boolean
-        jsonPath: .status.conflict
+        - name: ID
+          type: string
+          jsonPath: .spec.id
+        - name: Provider
+          type: string
+          jsonPath: .spec.provider
+        - name: conflict
+          type: boolean
+          jsonPath: .status.conflict
   scope: Cluster
   names:
     plural: vlans
@@ -3073,12 +3082,12 @@ spec:
                       lastTransitionTime:
                         type: string
       additionalPrinterColumns:
-      - name: DefaultInterface
-        type: string
-        jsonPath: .spec.defaultInterface
-      - name: Ready
-        type: boolean
-        jsonPath: .status.ready
+        - name: DefaultInterface
+          type: string
+          jsonPath: .spec.defaultInterface
+        - name: Ready
+          type: boolean
+          jsonPath: .status.ready
   scope: Cluster
   names:
     plural: provider-networks
@@ -3212,12 +3221,12 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-      - jsonPath: .spec.shared
-        name: Shared
-        type: string
-      - jsonPath: .spec.bindingType
-        name: BindingType
-        type: string
+        - jsonPath: .spec.shared
+          name: Shared
+          type: string
+        - jsonPath: .spec.bindingType
+          name: BindingType
+          type: string
       schema:
         openAPIV3Schema:
           type: object

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -750,6 +750,15 @@ spec:
                           type: array
                       type: object
                   type: object
+                routes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                      nextHopIP:
+                        type: string
             spec:
               type: object
               properties:

--- a/pkg/apis/kubeovn/v1/vpc-nat-gateway.go
+++ b/pkg/apis/kubeovn/v1/vpc-nat-gateway.go
@@ -61,6 +61,7 @@ type VpcNatGatewayStatus struct {
 	Selector        []string            `json:"selector" patchStrategy:"merge"`
 	Tolerations     []corev1.Toleration `json:"tolerations" patchStrategy:"merge"`
 	Affinity        corev1.Affinity     `json:"affinity" patchStrategy:"merge"`
+	Routes          []Route             `json:"routes,omitempty" patchStrategy:"merge"`
 }
 
 type Route struct {

--- a/pkg/apis/kubeovn/v1/vpc-nat-gateway.go
+++ b/pkg/apis/kubeovn/v1/vpc-nat-gateway.go
@@ -61,7 +61,7 @@ type VpcNatGatewayStatus struct {
 	Selector        []string            `json:"selector" patchStrategy:"merge"`
 	Tolerations     []corev1.Toleration `json:"tolerations" patchStrategy:"merge"`
 	Affinity        corev1.Affinity     `json:"affinity" patchStrategy:"merge"`
-	Routes          []Route             `json:"routes,omitempty" patchStrategy:"merge"`
+	Routes          []Route             `json:"routes" patchStrategy:"merge"`
 }
 
 type Route struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -107,7 +107,7 @@ type Controller struct {
 	updateVpcFloatingIPQueue      workqueue.TypedRateLimitingInterface[string]
 	updateVpcDnatQueue            workqueue.TypedRateLimitingInterface[string]
 	updateVpcSnatQueue            workqueue.TypedRateLimitingInterface[string]
-	updateVpcSubnetQueue          workqueue.TypedRateLimitingInterface[string]
+	updateNatGwRoutesQueue        workqueue.TypedRateLimitingInterface[string]
 	vpcNatGwKeyMutex              keymutex.KeyMutex
 	vpcNatGwExecKeyMutex          keymutex.KeyMutex
 
@@ -432,7 +432,7 @@ func Run(ctx context.Context, config *Configuration) {
 		updateVpcFloatingIPQueue:         newTypedRateLimitingQueue("UpdateVpcFloatingIp", custCrdRateLimiter),
 		updateVpcDnatQueue:               newTypedRateLimitingQueue("UpdateVpcDnat", custCrdRateLimiter),
 		updateVpcSnatQueue:               newTypedRateLimitingQueue("UpdateVpcSnat", custCrdRateLimiter),
-		updateVpcSubnetQueue:             newTypedRateLimitingQueue("UpdateVpcSubnet", custCrdRateLimiter),
+		updateNatGwRoutesQueue:           newTypedRateLimitingQueue("UpdateNatGwRoutes", custCrdRateLimiter),
 		vpcNatGwKeyMutex:                 keymutex.NewHashed(numKeyLocks),
 		vpcNatGwExecKeyMutex:             keymutex.NewHashed(numKeyLocks),
 		vpcEgressGatewayLister:           vpcEgressGatewayInformer.Lister(),
@@ -1157,7 +1157,7 @@ func (c *Controller) shutdown() {
 	c.updateVpcFloatingIPQueue.ShutDown()
 	c.updateVpcDnatQueue.ShutDown()
 	c.updateVpcSnatQueue.ShutDown()
-	c.updateVpcSubnetQueue.ShutDown()
+	c.updateNatGwRoutesQueue.ShutDown()
 
 	c.addOrUpdateVpcEgressGatewayQueue.ShutDown()
 	c.delVpcEgressGatewayQueue.ShutDown()
@@ -1268,7 +1268,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 	go wait.Until(runWorker("update eip for vpc nat gateway", c.updateVpcEipQueue, c.handleUpdateVpcEip), time.Second, ctx.Done())
 	go wait.Until(runWorker("update dnat for vpc nat gateway", c.updateVpcDnatQueue, c.handleUpdateVpcDnat), time.Second, ctx.Done())
 	go wait.Until(runWorker("update snat for vpc nat gateway", c.updateVpcSnatQueue, c.handleUpdateVpcSnat), time.Second, ctx.Done())
-	go wait.Until(runWorker("update subnet route for vpc nat gateway", c.updateVpcSubnetQueue, c.handleUpdateNatGwSubnetRoute), time.Second, ctx.Done())
+	go wait.Until(runWorker("update routes for vpc nat gateway", c.updateNatGwRoutesQueue, c.handleUpdateNatGwRoutes), time.Second, ctx.Done())
 	go wait.Until(runWorker("add/update csr", c.addOrUpdateCsrQueue, c.handleAddOrUpdateCsr), time.Second, ctx.Done())
 	// add default and join subnet and wait them ready
 	for range c.config.WorkerNum {

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -209,7 +209,7 @@ func (c *Controller) handleUpdateVpcStatus(key string) error {
 	}
 	for _, gw := range natGws {
 		if key == gw.Spec.Vpc {
-			c.updateVpcSubnetQueue.Add(gw.Name)
+			c.updateNatGwRoutesQueue.Add(gw.Name)
 		}
 	}
 	return nil

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -612,10 +612,10 @@ func diffNatGwRoutes(desiredRoutes, currentRoutes map[string]string) (routesToDe
 	routesToAdd = make([]string, 0, len(desiredRoutes))
 	resolvedRoutes = make([]kubeovnv1.Route, 0, len(desiredRoutes))
 
-	// Calculate routes to delete: exist in current but not in desired
-	for cidr, nextHop := range currentRoutes {
-		if _, exists := desiredRoutes[cidr]; !exists {
-			routesToDel = append(routesToDel, fmt.Sprintf("%s,%s", cidr, nextHop))
+	// Calculate routes to delete: routes that no longer exist in desired config or have changed nextHopIP
+	for cidr, currentNextHop := range currentRoutes {
+		if desiredNextHop, exists := desiredRoutes[cidr]; !exists || currentNextHop != desiredNextHop {
+			routesToDel = append(routesToDel, fmt.Sprintf("%s,%s", cidr, currentNextHop))
 		}
 	}
 

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -276,6 +276,11 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) error {
 		}
 	}
 
+	// Always trigger route update check - handleUpdateNatGwRoutes will
+	// calculate the diff between spec.routes and status.routes to determine
+	// if any changes are needed. This handles spec.routes changes.
+	c.updateNatGwRoutesQueue.Add(key)
+
 	return nil
 }
 
@@ -387,7 +392,7 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 	c.updateVpcFloatingIPQueue.Add(key)
 	c.updateVpcDnatQueue.Add(key)
 	c.updateVpcSnatQueue.Add(key)
-	c.updateVpcSubnetQueue.Add(key)
+	c.updateNatGwRoutesQueue.Add(key)
 	c.updateVpcEipQueue.Add(key)
 
 	patch := util.KVPatch{util.VpcNatGatewayInitAnnotation: "true"}
@@ -569,7 +574,63 @@ func (c *Controller) getIptablesVersion(pod *corev1.Pod) (version string, err er
 	return match[1], nil
 }
 
-func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
+// resolveNatGwRoutes resolves the NAT gateway routes by replacing "gateway" nextHopIP with
+// the actual subnet gateway IP based on the CIDR protocol. Returns a map of CIDR -> resolved nextHopIP.
+func (c *Controller) resolveNatGwRoutes(gw *kubeovnv1.VpcNatGateway) (map[string]string, error) {
+	subnet, err := c.subnetsLister.Get(gw.Spec.Subnet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get subnet %s for nat gw %s: %w", gw.Spec.Subnet, gw.Name, err)
+	}
+	v4Gateway, v6Gateway := util.SplitStringIP(subnet.Spec.Gateway)
+
+	resolvedRoutes := make(map[string]string, len(gw.Spec.Routes))
+	for _, route := range gw.Spec.Routes {
+		nextHopIP := route.NextHopIP
+		if nextHopIP == "gateway" {
+			// Resolve "gateway" to the actual subnet gateway IP based on CIDR protocol
+			if util.CheckProtocol(route.CIDR) == kubeovnv1.ProtocolIPv6 {
+				nextHopIP = v6Gateway
+			} else {
+				nextHopIP = v4Gateway
+			}
+		}
+		if nextHopIP == "" {
+			klog.Warningf("skipping route %s with empty nextHopIP for nat gw %s", route.CIDR, gw.Name)
+			continue
+		}
+		resolvedRoutes[route.CIDR] = nextHopIP
+	}
+	return resolvedRoutes, nil
+}
+
+// diffNatGwRoutes calculates routes to add and delete based on desired and current routes.
+// Used for eth0 (VPC internal interface) custom routes defined in spec.routes.
+// Returns routesToDel, routesToAdd as formatted strings "cidr,nextHopIP" for nat-gateway.sh
+// and resolvedRoutes for updating status.
+func diffNatGwRoutes(desiredRoutes, currentRoutes map[string]string) (routesToDel, routesToAdd []string, resolvedRoutes []kubeovnv1.Route) {
+	routesToDel = make([]string, 0, len(currentRoutes))
+	routesToAdd = make([]string, 0, len(desiredRoutes))
+	resolvedRoutes = make([]kubeovnv1.Route, 0, len(desiredRoutes))
+
+	// Calculate routes to delete: exist in current but not in desired
+	for cidr, nextHop := range currentRoutes {
+		if _, exists := desiredRoutes[cidr]; !exists {
+			routesToDel = append(routesToDel, fmt.Sprintf("%s,%s", cidr, nextHop))
+		}
+	}
+
+	// Calculate routes to add: new or changed
+	for cidr, nextHop := range desiredRoutes {
+		if currentNextHop, exists := currentRoutes[cidr]; !exists || currentNextHop != nextHop {
+			routesToAdd = append(routesToAdd, fmt.Sprintf("%s,%s", cidr, nextHop))
+		}
+		resolvedRoutes = append(resolvedRoutes, kubeovnv1.Route{CIDR: cidr, NextHopIP: nextHop})
+	}
+
+	return routesToDel, routesToAdd, resolvedRoutes
+}
+
+func (c *Controller) handleUpdateNatGwRoutes(natGwKey string) error {
 	gw, err := c.vpcNatGatewayLister.Get(natGwKey)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -585,139 +646,69 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 
 	c.vpcNatGwKeyMutex.LockKey(natGwKey)
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
-	klog.Infof("handle update subnet route for nat gateway %s", natGwKey)
 
+	// Get the NAT GW pod
 	pod, err := c.getNatGwPod(natGwKey)
 	if err != nil {
-		err = fmt.Errorf("failed to get nat gw '%s' pod, %w", natGwKey, err)
-		klog.Error(err)
+		if k8serrors.IsNotFound(err) {
+			// Pod not ready yet, routes will be injected via CNI annotation at creation time
+			klog.V(3).Infof("nat gw pod for %s not found, routes will be injected at creation time", natGwKey)
+			return nil
+		}
+		klog.Errorf("failed to get nat gw pod for %s: %v", natGwKey, err)
 		return err
 	}
 
-	v4InternalGw, _, err := c.GetGwBySubnet(gw.Spec.Subnet)
+	// Check if pod is running and initialized
+	if pod.Status.Phase != corev1.PodRunning {
+		klog.V(3).Infof("nat gw pod %s is not running (phase: %s), skipping hot update", pod.Name, pod.Status.Phase)
+		return nil
+	}
+	if _, hasInit := pod.Annotations[util.VpcNatGatewayInitAnnotation]; !hasInit {
+		klog.V(3).Infof("nat gw pod %s not initialized yet, skipping hot update", pod.Name)
+		return nil
+	}
+
+	// Build desired routes map using the shared helper function
+	desiredRoutes, err := c.resolveNatGwRoutes(gw)
 	if err != nil {
-		err = fmt.Errorf("failed to get gw, err: %w", err)
-		klog.Error(err)
-		return err
-	}
-	vpc, err := c.vpcsLister.Get(gw.Spec.Vpc)
-	if err != nil {
-		err = fmt.Errorf("failed to get vpc, err: %w", err)
-		klog.Error(err)
+		klog.Errorf("failed to resolve routes for nat gw %s: %v", natGwKey, err)
 		return err
 	}
 
-	// update route table
-	var newCIDRS, oldCIDRs, toBeDelCIDRs []string
-	// Store the subnet providers to get CIDRs from pod annotations
-	newProviderCIDRMap := make(map[string][]string)
-
-	if len(vpc.Status.Subnets) > 0 {
-		for _, s := range vpc.Status.Subnets {
-			subnet, err := c.subnetsLister.Get(s)
-			if err != nil {
-				err = fmt.Errorf("failed to get subnet, err: %w", err)
-				klog.Error(err)
-				return err
-			}
-			if subnet.Spec.Vlan != "" && !subnet.Spec.U2OInterconnection {
-				continue
-			}
-			if !isOvnSubnet(subnet) || !subnet.Status.IsValidated() {
-				continue
-			}
-			if v4Cidr, _ := util.SplitStringIP(subnet.Spec.CIDRBlock); v4Cidr != "" {
-				newCIDRS = append(newCIDRS, v4Cidr)
-				// Store the provider and CIDR for later use to generate annotations
-				newProviderCIDRMap[subnet.Spec.Provider] = append(newProviderCIDRMap[subnet.Spec.Provider], v4Cidr)
-			}
-		}
-	}
-	// Get all the CIDRs that are already in the annotation using subnet providers
-	for annotation, value := range pod.Annotations {
-		if strings.Contains(annotation, ".kubernetes.io/vpc_cidrs") {
-			var existingCIDR []string
-			if err = json.Unmarshal([]byte(value), &existingCIDR); err != nil {
-				klog.Error(err)
-				return err
-			}
-			oldCIDRs = append(oldCIDRs, existingCIDR...)
-		}
-	}
-	for _, old := range oldCIDRs {
-		if !slices.Contains(newCIDRS, old) {
-			toBeDelCIDRs = append(toBeDelCIDRs, old)
-		}
+	// Build current routes map from status
+	currentRoutes := make(map[string]string)
+	for _, route := range gw.Status.Routes {
+		currentRoutes[route.CIDR] = route.NextHopIP
 	}
 
-	if len(newCIDRS) > 0 {
-		var rules []string
-		for _, cidr := range newCIDRS {
-			if !util.CIDRContainIP(cidr, v4InternalGw) {
-				rules = append(rules, fmt.Sprintf("%s,%s", cidr, v4InternalGw))
-			}
-		}
-		if len(rules) > 0 {
-			if err = c.execNatGwRules(pod, natGwSubnetRouteAdd, rules); err != nil {
-				err = fmt.Errorf("failed to exec nat gateway rule, err: %w", err)
-				klog.Error(err)
-				return err
-			}
-		}
-	}
+	// Calculate routes diff: delete first, then add
+	routesToDel, routesToAdd, resolvedRoutes := diffNatGwRoutes(desiredRoutes, currentRoutes)
 
-	if len(toBeDelCIDRs) > 0 {
-		for _, cidr := range toBeDelCIDRs {
-			if err = c.execNatGwRules(pod, natGwSubnetRouteDel, []string{cidr}); err != nil {
-				err = fmt.Errorf("failed to exec nat gateway rule, err: %w", err)
-				klog.Error(err)
-				return err
-			}
-		}
-	}
-
-	// For each subnet provider, generate vpc cidr annotation
-	patch := util.KVPatch{}
-
-	// Track existing vpc_cidrs annotations to identify stale ones
-	existingProviders := make(map[string]bool)
-	for annotation := range pod.Annotations {
-		if strings.Contains(annotation, ".kubernetes.io/vpc_cidrs") {
-			// Extract provider name from annotation key: <provider>.kubernetes.io/vpc_cidrs
-			parts := strings.Split(annotation, ".kubernetes.io/vpc_cidrs")
-			if len(parts) == 2 && parts[1] == "" {
-				provider := parts[0]
-				existingProviders[provider] = true
-			}
-		}
-	}
-
-	// Add/update annotations for current providers
-	for provider, cidrs := range newProviderCIDRMap {
-		cidrBytes, err := json.Marshal(cidrs)
-		if err != nil {
-			klog.Errorf("marshal eip annotation failed %v", err)
+	// Execute route deletions first
+	if len(routesToDel) > 0 {
+		klog.Infof("deleting routes for vpc nat gw %s: %v", natGwKey, routesToDel)
+		if err := c.execNatGwRules(pod, natGwSubnetRouteDel, routesToDel); err != nil {
+			klog.Errorf("failed to delete routes for nat gw %s: %v", natGwKey, err)
 			return err
 		}
-		patch[fmt.Sprintf(util.VpcCIDRsAnnotationTemplate, provider)] = string(cidrBytes)
-		// Mark this provider as still active
-		delete(existingProviders, provider)
 	}
 
-	// Remove annotations for providers that are no longer associated with the VPC
-	for provider := range existingProviders {
-		patch[fmt.Sprintf(util.VpcCIDRsAnnotationTemplate, provider)] = nil
-		klog.V(3).Infof("Removing stale vpc_cidrs annotation for provider %s from pod %s/%s", provider, pod.Namespace, pod.Name)
-	}
-
-	// Only patch if there are changes to make
-	if len(patch) > 0 {
-		if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(pod.Namespace), pod.Name, patch); err != nil {
-			err = fmt.Errorf("failed to patch pod %s/%s: %w", pod.Namespace, pod.Name, err)
-			klog.Error(err)
+	// Execute route additions
+	if len(routesToAdd) > 0 {
+		klog.Infof("adding routes for vpc nat gw %s: %v", natGwKey, routesToAdd)
+		if err := c.execNatGwRules(pod, natGwSubnetRouteAdd, routesToAdd); err != nil {
+			klog.Errorf("failed to add routes for nat gw %s: %v", natGwKey, err)
 			return err
 		}
-		klog.V(3).Infof("Successfully patched %d vpc_cidrs annotations on pod %s/%s", len(patch), pod.Namespace, pod.Name)
+	}
+
+	// Update status with current routes
+	if len(routesToAdd) > 0 || len(routesToDel) > 0 {
+		if err := c.patchNatGwRoutesStatus(natGwKey, resolvedRoutes); err != nil {
+			klog.Errorf("failed to patch routes status for nat gw %s: %v", natGwKey, err)
+			return err
+		}
 	}
 
 	return nil
@@ -896,71 +887,25 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 
 	maps.Copy(annotations, podAnnotations)
 
-	// Retrieve all subnets in existence
-	subnets, err := c.subnetsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list subnets: %v", err)
-		return nil, err
-	}
-
 	// Configure eth0 (OVN internal network) routes
-	// Retrieve the gateways of the subnet sitting behind the NAT gateway
-	eth0V4Gateway, eth0V6Gateway, err := c.GetGwBySubnet(gw.Spec.Subnet)
-	if err != nil {
-		klog.Errorf("failed to get gateway ips for subnet %s: %v", gw.Spec.Subnet, err)
-		return nil, err
-	}
-
-	// Add routes to join the services (is this still needed?)
-	// It seems like the script inside the NAT GW already does that
-	v4ClusterIPRange, v6ClusterIPRange := util.SplitStringIP(c.config.ServiceClusterIPRange)
-	routes := make([]request.Route, 0, 2)
-	if eth0V4Gateway != "" && v4ClusterIPRange != "" {
-		routes = append(routes, request.Route{Destination: v4ClusterIPRange, Gateway: eth0V4Gateway})
-	}
-	if eth0V6Gateway != "" && v6ClusterIPRange != "" {
-		routes = append(routes, request.Route{Destination: v6ClusterIPRange, Gateway: eth0V6Gateway})
-	}
-
-	// Add gateway to join every subnet in the same VPC? (is this still needed?)
-	// Are we trying to give the NAT gateway access to every subnet in the VPC?
-	// I suspect this is to solve a problem where a static route is inserted to redirect all the traffic
-	// from a VPC into the NAT GW. When that happens, the GW has no return path to the other subnets.
-	for _, subnet := range subnets {
-		if subnet.Spec.Vpc != gw.Spec.Vpc || subnet.Name == gw.Spec.Subnet ||
-			!isOvnSubnet(subnet) || !subnet.Status.IsValidated() ||
-			(subnet.Spec.Vlan != "" && !subnet.Spec.U2OInterconnection) {
-			continue
-		}
-		cidrV4, cidrV6 := util.SplitStringIP(subnet.Spec.CIDRBlock)
-		if cidrV4 != "" && eth0V4Gateway != "" {
-			routes = append(routes, request.Route{Destination: cidrV4, Gateway: eth0V4Gateway})
-		}
-		if cidrV6 != "" && eth0V6Gateway != "" {
-			routes = append(routes, request.Route{Destination: cidrV6, Gateway: eth0V6Gateway})
-		}
-	}
-
-	// Users can specify custom routes to inject in the NAT GW
-	for _, route := range gw.Spec.Routes {
-		nexthop := route.NextHopIP
-
-		// Users can specify "gateway" instead of an actual IP as the next hop, and
-		// we will auto-determine the address of the gateway based on the protocol
-		if nexthop == "gateway" {
-			if util.CheckProtocol(route.CIDR) == kubeovnv1.ProtocolIPv4 {
-				nexthop = eth0V4Gateway
-			} else {
-				nexthop = eth0V6Gateway
-			}
+	// Only user-specified custom routes are injected; no default routes are added.
+	// Users can specify routes via gw.Spec.Routes to customize the NAT gateway routing table.
+	if len(gw.Spec.Routes) > 0 {
+		resolvedRoutes, err := c.resolveNatGwRoutes(gw)
+		if err != nil {
+			klog.Errorf("failed to resolve routes for nat gw %s: %v", gw.Name, err)
+			return nil, err
 		}
 
-		routes = append(routes, request.Route{Destination: route.CIDR, Gateway: nexthop})
-	}
+		routes := make([]request.Route, 0, len(resolvedRoutes))
+		for cidr, nexthop := range resolvedRoutes {
+			routes = append(routes, request.Route{Destination: cidr, Gateway: nexthop})
+		}
 
-	if err = setPodRoutesAnnotation(annotations, eth0SubnetProvider, routes); err != nil {
-		klog.Error(err)
-		return nil, err
+		if err = setPodRoutesAnnotation(annotations, eth0SubnetProvider, routes); err != nil {
+			klog.Error(err)
+			return nil, err
+		}
 	}
 
 	// Set the default routes to the external network
@@ -970,17 +915,17 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 		return nil, err
 	}
 
-	routes = routes[0:0]
+	net1Routes := make([]request.Route, 0, 2)
 	net1V4Gateway, net1V6Gateway := util.SplitStringIP(net1Subnet.Spec.Gateway)
 	if net1V4Gateway != "" {
-		routes = append(routes, request.Route{Destination: "0.0.0.0/0", Gateway: net1V4Gateway})
+		net1Routes = append(net1Routes, request.Route{Destination: "0.0.0.0/0", Gateway: net1V4Gateway})
 	}
 	if net1V6Gateway != "" {
-		routes = append(routes, request.Route{Destination: "::/0", Gateway: net1V6Gateway})
+		net1Routes = append(net1Routes, request.Route{Destination: "::/0", Gateway: net1V6Gateway})
 	}
 	// TODO:// check NAD if has ipam to disable ipam
 	if !gw.Spec.NoDefaultEIP {
-		if err = setPodRoutesAnnotation(annotations, net1Subnet.Spec.Provider, routes); err != nil {
+		if err = setPodRoutesAnnotation(annotations, net1Subnet.Spec.Provider, net1Routes); err != nil {
 			klog.Error(err)
 			return nil, err
 		}
@@ -1178,6 +1123,34 @@ func (c *Controller) updateCrdNatGwLabels(key, qos string) error {
 			klog.Errorf("failed to patch vpc nat gw %s: %v", gw.Name, err)
 			return err
 		}
+	}
+	return nil
+}
+
+func (c *Controller) patchNatGwRoutesStatus(key string, routes []kubeovnv1.Route) error {
+	oriGw, err := c.vpcNatGatewayLister.Get(key)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Errorf("failed to get vpc nat gw %s, %v", key, err)
+		return err
+	}
+	gw := oriGw.DeepCopy()
+	gw.Status.Routes = routes
+
+	bytes, err := gw.Status.Bytes()
+	if err != nil {
+		klog.Errorf("failed to marshal vpc nat gw %s status, %v", gw.Name, err)
+		return err
+	}
+	if _, err = c.config.KubeOvnClient.KubeovnV1().VpcNatGateways().Patch(context.Background(), gw.Name, types.MergePatchType,
+		bytes, metav1.PatchOptions{}, "status"); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Errorf("failed to patch gw %s routes status, %v", gw.Name, err)
+		return err
 	}
 	return nil
 }

--- a/pkg/controller/vpc_nat_gateway_test.go
+++ b/pkg/controller/vpc_nat_gateway_test.go
@@ -316,7 +316,7 @@ func TestDiffNatGwRoutes(t *testing.T) {
 			currentRoutes: map[string]string{
 				"10.0.0.0/8": "192.168.1.1",
 			},
-			wantDelCount:   0, // no delete needed, just update
+			wantDelCount:   1, // delete old route with old nexthop
 			wantAddCount:   1, // add with new nexthop
 			wantRouteCount: 1,
 		},
@@ -409,12 +409,12 @@ func TestDiffNatGwRoutesContent(t *testing.T) {
 			currentRoutes: map[string]string{
 				"10.0.0.0/8": "192.168.1.1",
 			},
-			expectedDel: []string{},
+			expectedDel: []string{"10.0.0.0/8,192.168.1.1"},
 			expectedAdd: []string{"10.0.0.0/8,192.168.1.2"},
 			expectedResolved: []kubeovnv1.Route{
 				{CIDR: "10.0.0.0/8", NextHopIP: "192.168.1.2"},
 			},
-			description: "Changed nexthop should trigger add with new value",
+			description: "Changed nexthop should trigger delete and add",
 		},
 		{
 			name: "mixed operations with content verification",

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -41,8 +41,6 @@ const (
 	VpcFloatingIPMd5Annotation              = "ovn.kubernetes.io/vpc_floating_ips"
 	VpcDnatMd5Annotation                    = "ovn.kubernetes.io/vpc_dnat_md5"
 	VpcSnatMd5Annotation                    = "ovn.kubernetes.io/vpc_snat_md5"
-	VpcCIDRsAnnotation                      = "ovn.kubernetes.io/vpc_cidrs"
-	VpcCIDRsAnnotationTemplate              = "%s.kubernetes.io/vpc_cidrs"
 	VpcLbAnnotation                         = "ovn.kubernetes.io/vpc_lb"
 	VpcExternalLabel                        = "ovn.kubernetes.io/vpc_external"
 	VpcEipAnnotation                        = "ovn.kubernetes.io/vpc_eip"

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -1135,6 +1135,106 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 
 		ginkgo.By("6. Test completed: VPC NAT Gateway custom routes work correctly")
 	})
+
+	framework.ConformanceIt("[7] VPC NAT Gateway dynamic routes update after running", func() {
+		// Test-specific variables
+		randomSuffix := framework.RandomSuffix()
+		vpcName := "vpc-dyn-routes-" + randomSuffix
+		overlaySubnetName := "overlay-subnet-dyn-routes-" + randomSuffix
+		vpcNatGwName := "gw-dyn-routes-" + randomSuffix
+		overlaySubnetV4Cidr := "10.0.7.0/24"
+		overlaySubnetV4Gw := "10.0.7.1"
+		lanIP := "10.0.7.254"
+		natgwQoS := ""
+
+		ginkgo.By("1. Creating VPC")
+		vpc := framework.MakeVpc(vpcName, lanIP, false, false, nil)
+		_ = vpcClient.CreateSync(vpc)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up custom vpc " + vpcName)
+			vpcClient.DeleteSync(vpcName)
+		})
+
+		ginkgo.By("2. Creating overlay subnet")
+		overlaySubnet := framework.MakeSubnet(overlaySubnetName, "", overlaySubnetV4Cidr, overlaySubnetV4Gw, vpcName, "", nil, nil, nil)
+		_ = subnetClient.CreateSync(overlaySubnet)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up custom overlay subnet " + overlaySubnetName)
+			subnetClient.DeleteSync(overlaySubnetName)
+		})
+
+		ginkgo.By("3. Creating VPC NAT Gateway without routes")
+		vpcNatGw := framework.MakeVpcNatGateway(vpcNatGwName, vpcName, overlaySubnetName, lanIP, networkAttachDefName, natgwQoS)
+		_ = vpcNatGwClient.CreateSync(vpcNatGw, f.ClientSet)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up custom vpc nat gw " + vpcNatGwName)
+			vpcNatGwClient.DeleteSync(vpcNatGwName)
+		})
+
+		vpcNatGwPodName := util.GenNatGwPodName(vpcNatGwName)
+
+		ginkgo.By("4. Adding routes to running NAT Gateway")
+		originalGw := vpcNatGwClient.Get(vpcNatGwName)
+		modifiedGw := originalGw.DeepCopy()
+		modifiedGw.Spec.Routes = []apiv1.Route{
+			{CIDR: "192.168.200.0/24", NextHopIP: overlaySubnetV4Gw},
+			{CIDR: "10.100.0.0/16", NextHopIP: "gateway"},
+		}
+		vpcNatGwClient.Patch(originalGw, modifiedGw)
+
+		ginkgo.By("5. Waiting for routes to be applied")
+		time.Sleep(5 * time.Second)
+
+		ginkgo.By("6. Verifying routes are injected into NAT GW pod")
+		stdout, _, err := framework.ExecShellInPod(context.Background(), f, framework.KubeOvnNamespace, vpcNatGwPodName, "ip route show")
+		framework.ExpectNoError(err, "Failed to execute ip route in NAT GW pod")
+		framework.ExpectContainSubstring(stdout, "192.168.200.0/24 via "+overlaySubnetV4Gw, "Added route 192.168.200.0/24 should exist")
+		framework.ExpectContainSubstring(stdout, "10.100.0.0/16 via "+overlaySubnetV4Gw, "Added route 10.100.0.0/16 should exist")
+
+		ginkgo.By("7. Verifying status.routes is updated")
+		updatedGw := vpcNatGwClient.Get(vpcNatGwName)
+		framework.ExpectEqual(len(updatedGw.Status.Routes), 2, "Status should have 2 routes")
+
+		ginkgo.By("8. Modifying routes - change one, keep one")
+		originalGw = vpcNatGwClient.Get(vpcNatGwName)
+		modifiedGw = originalGw.DeepCopy()
+		modifiedGw.Spec.Routes = []apiv1.Route{
+			{CIDR: "192.168.200.0/24", NextHopIP: overlaySubnetV4Gw}, // Keep this route
+			{CIDR: "172.31.0.0/16", NextHopIP: overlaySubnetV4Gw},    // New route, replace 10.100.0.0/16
+		}
+		vpcNatGwClient.Patch(originalGw, modifiedGw)
+
+		ginkgo.By("9. Waiting for route changes to be applied")
+		time.Sleep(5 * time.Second)
+
+		ginkgo.By("10. Verifying route changes in NAT GW pod")
+		stdout, _, err = framework.ExecShellInPod(context.Background(), f, framework.KubeOvnNamespace, vpcNatGwPodName, "ip route show")
+		framework.ExpectNoError(err, "Failed to execute ip route in NAT GW pod")
+		framework.ExpectContainSubstring(stdout, "192.168.200.0/24 via "+overlaySubnetV4Gw, "Kept route 192.168.200.0/24 should still exist")
+		framework.ExpectContainSubstring(stdout, "172.31.0.0/16 via "+overlaySubnetV4Gw, "New route 172.31.0.0/16 should exist")
+		framework.ExpectNotContainSubstring(stdout, "10.100.0.0/16", "Removed route 10.100.0.0/16 should not exist")
+
+		ginkgo.By("11. Removing all routes")
+		originalGw = vpcNatGwClient.Get(vpcNatGwName)
+		modifiedGw = originalGw.DeepCopy()
+		modifiedGw.Spec.Routes = nil
+		vpcNatGwClient.Patch(originalGw, modifiedGw)
+
+		ginkgo.By("12. Waiting for routes to be removed")
+		time.Sleep(5 * time.Second)
+
+		ginkgo.By("13. Verifying all custom routes are removed")
+		stdout, _, err = framework.ExecShellInPod(context.Background(), f, framework.KubeOvnNamespace, vpcNatGwPodName, "ip route show")
+		framework.ExpectNoError(err, "Failed to execute ip route in NAT GW pod")
+		framework.ExpectNotContainSubstring(stdout, "192.168.200.0/24", "Route 192.168.200.0/24 should be removed")
+		framework.ExpectNotContainSubstring(stdout, "172.31.0.0/16", "Route 172.31.0.0/16 should be removed")
+
+		ginkgo.By("14. Verifying status.routes is empty")
+		updatedGw = vpcNatGwClient.Get(vpcNatGwName)
+		framework.ExpectEqual(len(updatedGw.Status.Routes), 0, "Status routes should be empty after removing all routes")
+
+		ginkgo.By("15. Test completed: VPC NAT Gateway dynamic routes update works correctly")
+	})
 })
 
 func init() {


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- 统一使用 gw spec routes 来自定义添加所有网关 pod 对应的路由（统一入口，能够覆盖所有功能）
- 弃用默认的 subnet 扫描添加的逻辑
- 版本升级应该不会导致现有路由发生变化，单需要提前在 spec routes 中明确维护所有需要路由，便于故障后能够恢复。
-  snat fip eip harpin 依赖唯一的 vpc subnet 的直连路由（aws 的 vpc nat gw 也只绑定一个子网）
- 本质上，不推荐，而且也不能使用 vpc-nat-gw 不直接绑定到内部子网的使用方式。因为 reroute 的逻辑限制了只能到本网段


https://github.com/kubeovn/kube-ovn/issues/5572#event-20391376274

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
