### PR TITLE
fix: add validation for iptables rules to prevent malformed commands …

### DIFF
--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -201,12 +202,12 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 		return nil
 	}
 	klog.V(3).Infof("handle add fip %s", key)
-	// get eip
-	eipName := fip.Spec.EIP
-	if eipName == "" {
-		return errors.New("failed to create fip rule, should set eip")
+
+	if err := c.validateFipRule(fip); err != nil {
+		return err
 	}
-	eip, err := c.GetEip(eipName)
+
+	eip, err := c.GetEip(fip.Spec.EIP)
 	if err != nil {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
@@ -242,7 +243,7 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 		klog.Errorf("failed to update label for fip %s, %v", key, err)
 		return err
 	}
-	if err = c.patchEipStatus(eipName, "", "", "", true); err != nil {
+	if err = c.patchEipStatus(fip.Spec.EIP, "", "", "", true); err != nil {
 		// refresh eip nats
 		klog.Errorf("failed to patch fip use eip %s, %v", key, err)
 		return err
@@ -304,11 +305,12 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 	if vpcNatEnabled != "true" {
 		return errors.New("iptables nat gw not enable")
 	}
-	eipName := cachedFip.Spec.EIP
-	if eipName == "" {
-		return errors.New("failed to update fip rule, should set eip")
+
+	if err := c.validateFipRule(cachedFip); err != nil {
+		return err
 	}
-	eip, err := c.GetEip(eipName)
+
+	eip, err := c.GetEip(cachedFip.Spec.EIP)
 	if err != nil {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
@@ -340,7 +342,7 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 			klog.Errorf("failed to update label for fip %s, %v", key, err)
 			return err
 		}
-		if err = c.patchEipStatus(eipName, "", "", "", true); err != nil {
+		if err = c.patchEipStatus(cachedFip.Spec.EIP, "", "", "", true); err != nil {
 			// refresh eip nats
 			klog.Errorf("failed to patch fip use eip %s, %v", key, err)
 			return err
@@ -409,17 +411,17 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		return nil
 	}
 	klog.V(3).Infof("handle add iptables dnat %s", key)
-	eipName := dnat.Spec.EIP
-	if eipName == "" {
-		return errors.New("failed to create dnat rule, should set eip")
+
+	if err := c.validateDnatRule(dnat); err != nil {
+		return err
 	}
 
-	eip, err := c.GetEip(eipName)
+	eip, err := c.GetEip(dnat.Spec.EIP)
 	if err != nil {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
 	}
-	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, eipName, dnat.Name, dnat.Spec.ExternalPort); dup || err != nil {
+	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, dnat.Spec.EIP, dnat.Name, dnat.Spec.ExternalPort); dup || err != nil {
 		klog.Error(err)
 		return err
 	}
@@ -443,7 +445,7 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		klog.Errorf("failed to handle add finalizer for dnat, %v", err)
 		return err
 	}
-	if err = c.patchEipStatus(eipName, "", "", "", true); err != nil {
+	if err = c.patchEipStatus(dnat.Spec.EIP, "", "", "", true); err != nil {
 		// refresh eip nats
 		klog.Errorf("failed to patch dnat use eip %s, %v", key, err)
 		return err
@@ -485,16 +487,17 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		return nil
 	}
 	klog.V(3).Infof("handle update dnat %s", key)
-	eipName := cachedDnat.Spec.EIP
-	if eipName == "" {
-		return errors.New("failed to update fip rule, should set eip")
+
+	if err := c.validateDnatRule(cachedDnat); err != nil {
+		return err
 	}
-	eip, err := c.GetEip(eipName)
+
+	eip, err := c.GetEip(cachedDnat.Spec.EIP)
 	if err != nil {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
 	}
-	if dup, err := c.isDnatDuplicated(cachedDnat.Status.NatGwDp, eipName, cachedDnat.Name, cachedDnat.Spec.ExternalPort); dup || err != nil {
+	if dup, err := c.isDnatDuplicated(cachedDnat.Status.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Name, cachedDnat.Spec.ExternalPort); dup || err != nil {
 		klog.Errorf("failed to update dnat, %v", err)
 		return err
 	}
@@ -527,7 +530,7 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 			klog.Errorf("failed to patch label for dnat %s, %v", key, err)
 			return err
 		}
-		if err = c.patchEipStatus(eipName, "", "", "", true); err != nil {
+		if err = c.patchEipStatus(cachedDnat.Spec.EIP, "", "", "", true); err != nil {
 			// refresh eip nats
 			klog.Errorf("failed to patch dnat use eip %s, %v", key, err)
 			return err
@@ -597,12 +600,12 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 		return nil
 	}
 	klog.V(3).Infof("handle add iptables snat %s", key)
-	eipName := snat.Spec.EIP
-	if eipName == "" {
-		return errors.New("failed to create snat rule, should set eip")
+
+	if err := c.validateSnatRule(snat); err != nil {
+		return err
 	}
 
-	eip, err := c.GetEip(eipName)
+	eip, err := c.GetEip(snat.Spec.EIP)
 	if err != nil {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
@@ -630,7 +633,7 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 		klog.Errorf("failed to handle add finalizer for snat, %v", err)
 		return err
 	}
-	if err = c.patchEipStatus(eipName, "", "", "", true); err != nil {
+	if err = c.patchEipStatus(snat.Spec.EIP, "", "", "", true); err != nil {
 		// refresh eip nats
 		klog.Errorf("failed to patch snat use eip %s, %v", key, err)
 		return err
@@ -653,19 +656,10 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 	klog.Infof("handle update iptables snat rule %s", key)
 
 	v4Cidr, _ := util.SplitStringIP(cachedSnat.Status.InternalCIDR)
-	if v4Cidr == "" {
-		err = fmt.Errorf("failed to get snat v4 internal cidr, original cidr is %s", cachedSnat.Status.InternalCIDR)
-		return err
-	}
-	v4CidrSpec, _ := util.SplitStringIP(cachedSnat.Spec.InternalCIDR)
-	if v4CidrSpec == "" {
-		err = fmt.Errorf("failed to get snat v4 internal cidr, original cidr is %s", cachedSnat.Spec.InternalCIDR)
-		return err
-	}
 	// should delete
 	if !cachedSnat.DeletionTimestamp.IsZero() {
 		klog.V(3).Infof("clean snat '%s' in pod", key)
-		if vpcNatEnabled == "true" {
+		if vpcNatEnabled == "true" && v4Cidr != "" {
 			if err = c.deleteSnatInPod(cachedSnat.Status.NatGwDp, cachedSnat.Status.V4ip, v4Cidr); err != nil {
 				klog.Errorf("failed to delete snat, %v", err)
 				return err
@@ -675,16 +669,16 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 			klog.Errorf("failed to handle del finalizer for snat %s, %v", key, err)
 			return err
 		}
-		//  reset eip
 		c.resetIptablesEipQueue.AddAfter(cachedSnat.Spec.EIP, 3*time.Second)
 		return nil
 	}
 	klog.V(3).Infof("handle update snat %s", key)
-	eipName := cachedSnat.Spec.EIP
-	if eipName == "" {
-		return errors.New("failed to update fip rule, should set eip")
+
+	if err := c.validateSnatRule(cachedSnat); err != nil {
+		return err
 	}
-	eip, err := c.GetEip(eipName)
+
+	eip, err := c.GetEip(cachedSnat.Spec.EIP)
 	if err != nil {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
@@ -700,12 +694,13 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 		klog.Errorf("failed to delete old snat, %v", err)
 		return err
 	}
-	if err = c.createSnatInPod(cachedSnat.Status.NatGwDp, eip.Status.IP, v4CidrSpec); err != nil {
-		klog.Errorf("failed to create new snat, %v", err)
+	v4CidrSpec, _ := util.SplitStringIP(cachedSnat.Spec.InternalCIDR)
+	if err = c.createSnatInPod(eip.Spec.NatGwDp, eip.Status.IP, v4CidrSpec); err != nil {
+		klog.Errorf("failed to create new snat %s, %v", key, err)
 		return err
 	}
 	if err = c.patchSnatStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
-		klog.Errorf("failed to patch status for snat %s, %v", key, err)
+		klog.Errorf("failed to patch status for snat %s , %v", key, err)
 		return err
 	}
 	// snat change eip
@@ -714,7 +709,7 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 			klog.Errorf("failed to patch label for snat %s, %v", key, err)
 			return err
 		}
-		if err = c.patchEipStatus(eipName, "", "", "", true); err != nil {
+		if err = c.patchEipStatus(cachedSnat.Spec.EIP, "", "", "", true); err != nil {
 			// refresh eip nats
 			klog.Errorf("failed to patch fip use eip %s, %v", key, err)
 			return err
@@ -1608,6 +1603,116 @@ func (c *Controller) patchIptableInfo(name, natType, patchPayload string) error 
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
+		klog.Error(err)
+		return err
+	}
+	return nil
+}
+
+// validateDnatRule validates IptablesDnatRule fields to prevent malformed iptables commands.
+func (c *Controller) validateDnatRule(dnat *kubeovnv1.IptablesDnatRule) error {
+	var err error
+	if dnat.Spec.EIP == "" {
+		err = fmt.Errorf("%s: eip cannot be empty", dnat.Name)
+		klog.Error(err)
+		return err
+	}
+	if err = util.ValidatePort(dnat.Spec.ExternalPort); err != nil {
+		err = fmt.Errorf("%s: invalid externalPort %q: %w", dnat.Name, dnat.Spec.ExternalPort, err)
+		klog.Error(err)
+		return err
+	}
+	if err = util.ValidatePort(dnat.Spec.InternalPort); err != nil {
+		err = fmt.Errorf("%s: invalid internalPort %q: %w", dnat.Name, dnat.Spec.InternalPort, err)
+		klog.Error(err)
+		return err
+	}
+	if dnat.Spec.InternalIP == "" {
+		err = fmt.Errorf("%s: internalIP cannot be empty", dnat.Name)
+		klog.Error(err)
+		return err
+	}
+	if !util.IsValidIP(dnat.Spec.InternalIP) {
+		err = fmt.Errorf("%s: invalid internalIP %q", dnat.Name, dnat.Spec.InternalIP)
+		klog.Error(err)
+		return err
+	}
+	// iptables NAT only supports IPv4
+	if util.CheckProtocol(dnat.Spec.InternalIP) != kubeovnv1.ProtocolIPv4 {
+		err = fmt.Errorf("%s: internalIP %q must be IPv4, IPv6 is not supported", dnat.Name, dnat.Spec.InternalIP)
+		klog.Error(err)
+		return err
+	}
+	if err = util.ValidateProtocol(dnat.Spec.Protocol); err != nil {
+		err = fmt.Errorf("%s: invalid protocol %q: %w", dnat.Name, dnat.Spec.Protocol, err)
+		klog.Error(err)
+		return err
+	}
+	return nil
+}
+
+// validateFipRule validates IptablesFIPRule fields to prevent malformed iptables commands.
+func (c *Controller) validateFipRule(fip *kubeovnv1.IptablesFIPRule) error {
+	var err error
+	if fip.Spec.EIP == "" {
+		err = fmt.Errorf("%s: eip cannot be empty", fip.Name)
+		klog.Error(err)
+		return err
+	}
+	if fip.Spec.InternalIP == "" {
+		err = fmt.Errorf("%s: internalIP cannot be empty", fip.Name)
+		klog.Error(err)
+		return err
+	}
+	if !util.IsValidIP(fip.Spec.InternalIP) {
+		err = fmt.Errorf("%s: invalid internalIP %q", fip.Name, fip.Spec.InternalIP)
+		klog.Error(err)
+		return err
+	}
+	// iptables NAT only supports IPv4
+	if util.CheckProtocol(fip.Spec.InternalIP) != kubeovnv1.ProtocolIPv4 {
+		err = fmt.Errorf("%s: internalIP %q must be IPv4, IPv6 is not supported", fip.Name, fip.Spec.InternalIP)
+		klog.Error(err)
+		return err
+	}
+	return nil
+}
+
+// validateSnatRule validates IptablesSnatRule fields to prevent malformed iptables commands.
+func (c *Controller) validateSnatRule(snat *kubeovnv1.IptablesSnatRule) error {
+	var err error
+	if snat.Spec.EIP == "" {
+		err = fmt.Errorf("%s: eip cannot be empty", snat.Name)
+		klog.Error(err)
+		return err
+	}
+	internalCIDR := snat.Spec.InternalCIDR
+	if internalCIDR == "" {
+		err = fmt.Errorf("%s: internalCIDR cannot be empty", snat.Name)
+		klog.Error(err)
+		return err
+	}
+	// iptables NAT only supports single IPv4 CIDR or IP, ip6tables is not used here
+	if strings.Count(internalCIDR, "/") > 1 {
+		err = fmt.Errorf("%s: internalCIDR %q contains multiple CIDRs, only single CIDR or IP is allowed", snat.Name, internalCIDR)
+		klog.Error(err)
+		return err
+	}
+	if strings.Contains(internalCIDR, "/") {
+		if err = util.CheckCidrs(internalCIDR); err != nil {
+			err = fmt.Errorf("%s: invalid internalCIDR %q: %w", snat.Name, internalCIDR, err)
+			klog.Error(err)
+			return err
+		}
+	} else {
+		if !util.IsValidIP(internalCIDR) {
+			err = fmt.Errorf("%s: invalid internalCIDR %q", snat.Name, internalCIDR)
+			klog.Error(err)
+			return err
+		}
+	}
+	if util.CheckProtocol(internalCIDR) != kubeovnv1.ProtocolIPv4 {
+		err = fmt.Errorf("%s: internalCIDR %q must be IPv4, IPv6 is not supported", snat.Name, internalCIDR)
 		klog.Error(err)
 		return err
 	}

--- a/pkg/controller/vpc_nat_gw_nat_test.go
+++ b/pkg/controller/vpc_nat_gw_nat_test.go
@@ -1,0 +1,483 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+func TestValidateDnat(t *testing.T) {
+	c := &Controller{}
+
+	tests := []struct {
+		name    string
+		dnat    *kubeovnv1.IptablesDnatRule
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid dnat rule",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty eip",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "",
+					ExternalPort: "80",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "eip cannot be empty",
+		},
+		{
+			name: "empty externalPort",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid externalPort",
+		},
+		{
+			name: "invalid externalPort not a number",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "abc",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid externalPort",
+		},
+		{
+			name: "invalid externalPort out of range",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "70000",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "must be between 1 and 65535",
+		},
+		{
+			name: "invalid externalPort zero",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "0",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "must be between 1 and 65535",
+		},
+		{
+			name: "empty internalPort",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid internalPort",
+		},
+		{
+			name: "invalid internalPort not a number",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "xyz",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid internalPort",
+		},
+		{
+			name: "empty internalIP",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "8080",
+					InternalIP:   "",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "internalIP cannot be empty",
+		},
+		{
+			name: "invalid internalIP",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "8080",
+					InternalIP:   "not-an-ip",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid internalIP",
+		},
+		{
+			name: "empty protocol",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid protocol",
+		},
+		{
+			name: "invalid protocol",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "icmp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid protocol",
+		},
+		{
+			name: "uppercase TCP protocol",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "TCP",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "uppercase UDP protocol",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "80",
+					InternalPort: "8080",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "UDP",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid IPv6 internalIP - not supported",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "443",
+					InternalPort: "8443",
+					InternalIP:   "fd00::1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: true,
+			errMsg:  "must be IPv4",
+		},
+		{
+			name: "max valid port",
+			dnat: &kubeovnv1.IptablesDnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+				Spec: kubeovnv1.IptablesDnatRuleSpec{
+					EIP:          "test-eip",
+					ExternalPort: "65535",
+					InternalPort: "65535",
+					InternalIP:   "10.0.0.1",
+					Protocol:     "tcp",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.validateDnatRule(tt.dnat)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateFip(t *testing.T) {
+	c := &Controller{}
+
+	tests := []struct {
+		name    string
+		fip     *kubeovnv1.IptablesFIPRule
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid fip rule",
+			fip: &kubeovnv1.IptablesFIPRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-fip"},
+				Spec: kubeovnv1.IptablesFIPRuleSpec{
+					EIP:        "test-eip",
+					InternalIP: "10.0.0.1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty eip",
+			fip: &kubeovnv1.IptablesFIPRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-fip"},
+				Spec: kubeovnv1.IptablesFIPRuleSpec{
+					EIP:        "",
+					InternalIP: "10.0.0.1",
+				},
+			},
+			wantErr: true,
+			errMsg:  "eip cannot be empty",
+		},
+		{
+			name: "empty internalIP",
+			fip: &kubeovnv1.IptablesFIPRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-fip"},
+				Spec: kubeovnv1.IptablesFIPRuleSpec{
+					EIP:        "test-eip",
+					InternalIP: "",
+				},
+			},
+			wantErr: true,
+			errMsg:  "internalIP cannot be empty",
+		},
+		{
+			name: "invalid internalIP",
+			fip: &kubeovnv1.IptablesFIPRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-fip"},
+				Spec: kubeovnv1.IptablesFIPRuleSpec{
+					EIP:        "test-eip",
+					InternalIP: "invalid-ip",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid internalIP",
+		},
+		{
+			name: "invalid IPv6 internalIP - not supported",
+			fip: &kubeovnv1.IptablesFIPRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-fip"},
+				Spec: kubeovnv1.IptablesFIPRuleSpec{
+					EIP:        "test-eip",
+					InternalIP: "2001:db8::1",
+				},
+			},
+			wantErr: true,
+			errMsg:  "must be IPv4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.validateFipRule(tt.fip)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSnat(t *testing.T) {
+	c := &Controller{}
+
+	tests := []struct {
+		name    string
+		snat    *kubeovnv1.IptablesSnatRule
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid snat rule",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "test-eip",
+					InternalCIDR: "10.0.0.0/24",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty eip",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "",
+					InternalCIDR: "10.0.0.0/24",
+				},
+			},
+			wantErr: true,
+			errMsg:  "eip cannot be empty",
+		},
+		{
+			name: "empty internalCIDR",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "test-eip",
+					InternalCIDR: "",
+				},
+			},
+			wantErr: true,
+			errMsg:  "internalCIDR cannot be empty",
+		},
+		{
+			name: "valid single IP address",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "test-eip",
+					InternalCIDR: "10.0.0.1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid single IPv6 address - not supported",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "test-eip",
+					InternalCIDR: "fd00::1",
+				},
+			},
+			wantErr: true,
+			errMsg:  "must be IPv4",
+		},
+		{
+			name: "invalid internalCIDR - malformed IP",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "test-eip",
+					InternalCIDR: "10.0.0.256",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid internalCIDR",
+		},
+		{
+			name: "invalid internalCIDR - invalid format",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "test-eip",
+					InternalCIDR: "invalid-cidr",
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid internalCIDR",
+		},
+		{
+			name: "invalid IPv6 internalCIDR - not supported",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "test-eip",
+					InternalCIDR: "fd00::/64",
+				},
+			},
+			wantErr: true,
+			errMsg:  "must be IPv4",
+		},
+		{
+			name: "invalid multiple CIDRs - not supported",
+			snat: &kubeovnv1.IptablesSnatRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-snat"},
+				Spec: kubeovnv1.IptablesSnatRuleSpec{
+					EIP:          "test-eip",
+					InternalCIDR: "10.0.0.0/24,192.168.1.0/24",
+				},
+			},
+			wantErr: true,
+			errMsg:  "contains multiple CIDRs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.validateSnatRule(tt.snat)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -791,3 +791,24 @@ func InvalidNetworkMask(network *net.IPNet) error {
 	}
 	return nil
 }
+
+// ValidatePort checks if the port string is a valid port number (1-65535).
+func ValidatePort(port string) error {
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return errors.New("must be a number")
+	}
+	if p < 1 || p > 65535 {
+		return errors.New("must be between 1 and 65535")
+	}
+	return nil
+}
+
+// ValidateProtocol checks if the protocol is valid (tcp or udp).
+func ValidateProtocol(protocol string) error {
+	p := strings.ToLower(protocol)
+	if p != ProtocolTCP && p != ProtocolUDP {
+		return fmt.Errorf("must be %s or %s", ProtocolTCP, ProtocolUDP)
+	}
+	return nil
+}

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -1768,3 +1768,62 @@ func TestCIDRContainsCIDR(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePort(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		port    string
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "valid port 80", port: "80", wantErr: false},
+		{name: "valid port 1", port: "1", wantErr: false},
+		{name: "valid port 65535", port: "65535", wantErr: false},
+		{name: "invalid port 0", port: "0", wantErr: true, errMsg: "must be between 1 and 65535"},
+		{name: "invalid port 65536", port: "65536", wantErr: true, errMsg: "must be between 1 and 65535"},
+		{name: "invalid port negative", port: "-1", wantErr: true, errMsg: "must be between 1 and 65535"},
+		{name: "invalid port not a number", port: "abc", wantErr: true, errMsg: "must be a number"},
+		{name: "invalid port with spaces", port: " 80 ", wantErr: true, errMsg: "must be a number"},
+		{name: "invalid port float", port: "80.5", wantErr: true, errMsg: "must be a number"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePort(tt.port)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateProtocol(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		protocol string
+		wantErr  bool
+	}{
+		{name: "valid tcp lowercase", protocol: "tcp", wantErr: false},
+		{name: "valid udp lowercase", protocol: "udp", wantErr: false},
+		{name: "valid TCP uppercase", protocol: "TCP", wantErr: false},
+		{name: "valid UDP uppercase", protocol: "UDP", wantErr: false},
+		{name: "valid mixed case", protocol: "Tcp", wantErr: false},
+		{name: "invalid protocol icmp", protocol: "icmp", wantErr: true},
+		{name: "invalid protocol sctp", protocol: "sctp", wantErr: true},
+		{name: "empty string", protocol: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProtocol(tt.protocol)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…in nat gateway pod

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes
https://github.com/kubeovn/kube-ovn/issues/6124

问题不是"protocol 缺失"，而是 [externalPort] 缺失导致 bash 数组解析时参数位置整体偏移。

所以这执行 vpc-nat-gw sh 之前应该校验所有必要参数


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
