### PR TITLE
bugfix kube-ovn image tag from v.1.14.0 to v1.15.0, add default labels

### DIFF
--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -493,7 +493,8 @@ pinger:
   annotations: {}
   # -- Labels to be added to all top-level kube-ovn-pinger objects (resources under templates/pinger)
   # @section -- Ping daemon configuration
-  labels: {}
+  labels:
+    app: kube-ovn-pinger
   # -- Annotations to be added to kube-ovn-pinger pods.
   # @section -- Ping daemon configuration
   podAnnotations: {}
@@ -555,7 +556,8 @@ monitor:
   annotations: {}
   # -- Labels to be added to all top-level kube-ovn-monitor objects (resources under templates/monitor)
   # @section -- OVN monitoring daemon configuration
-  labels: {}
+  labels:
+    app: kube-ovn-monitor
   # -- Annotations to be added to kube-ovn-monitor pods.
   # @section -- OVN monitoring daemon configuration
   podAnnotations: {}
@@ -614,7 +616,8 @@ controller:
   annotations: {}
   # -- Labels to be added to all top-level kube-ovn-controller objects (resources under templates/controller)
   # @section -- Kube-OVN controller configuration
-  labels: {}
+  labels:
+    app: kube-ovn-controller
   # -- Annotations to be added to kube-ovn-controller pods.
   # @section -- Kube-OVN controller configuration
   podAnnotations: {}
@@ -673,7 +676,8 @@ central:
   annotations: {}
   # -- Labels to be added to all top-level ovn-central objects (resources under templates/central)
   # @section -- OVN-central daemon configuration
-  labels: {}
+  labels:
+    app: kube-ovn-central
   # -- Annotations to be added to ovn-central pods.
   # @section -- OVN-central daemon configuration
   podAnnotations: {}
@@ -762,7 +766,8 @@ agent:
   annotations: {}
   # -- Labels to be added to all top-level agent objects (resources under templates/agent)
   # @section -- CNI agent configuration
-  labels: {}
+  labels:
+    app: kube-ovn-cni
   # -- Annotations to be added to the agent pods (kube-ovn-cni)
   # @section -- CNI agent configuration
   podAnnotations: {}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

<!-- 
fixing the version number in the values.yaml to grab the v.1.15.0 image
add default labels for pinger, controller, monitor and agent to be aligned with the documentation https://kubeovn.github.io/docs/stable/en/guide/prometheus-grafana/ 
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
