### PR TITLE
feat(chart): make daemonset update strategy configurable in values.yaml

### DIFF
--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -117,7 +117,7 @@ Get IPs of master nodes from values
       {{- end -}}
     {{- end -}}
   {{- else -}}
-    RollingUpdate
+    {{- $.Values.ovsOvn.updateStrategy -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -18,9 +18,11 @@ spec:
       app.kubernetes.io/part-of: kube-ovn
   updateStrategy:
     type: {{ include "kubeovn.ovs-ovn.updateStrategy" . }}
+    {{- if eq (include "kubeovn.ovs-ovn.updateStrategy" .) "RollingUpdate" }}
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.ovsOvn.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.ovsOvn.strategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   template:
     metadata:
       {{- with .Values.ovsOvn.podAnnotations }}

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
@@ -18,10 +18,12 @@ spec:
       app.kubernetes.io/name: kube-ovn-ovs-dpdk
       app.kubernetes.io/part-of: kube-ovn
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.ovsOvn.updateStrategy.type }}
+    {{- if eq .Values.ovsOvn.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.ovsOvn.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.ovsOvn.strategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   template:
     metadata:
       {{- with .Values.ovsOvn.podAnnotations }}

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -398,6 +398,14 @@ ovsOvn:
       cpu: "2"
       memory: "1000Mi"
 
+  # -- ovs-ovn DaemonSet update strategy.
+  # ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy
+  # @section -- OVS/OVN daemons configuration
+  updateStrategy:
+    type: "RollingUpdate"
+    maxSurge: 1
+    maxUnavailable: 0
+
   # -- Disable auto-loading of kernel modules by OVS.
   # If this is disabled, you will have to enable the Open vSwitch kernel module yourself.
   # @section -- OVS/OVN daemons configuration


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
make ovsOvn daemonset update strategy configurable in values.yaml. 

The chart sets it to onDelete if the DaemonSet exists on a cluster, but this Helm functionality is not working within ArgoCD, see: https://github.com/argoproj/argo-cd/issues/5202. Therefore, we would like to have it configurable to manually override the value later, also to onDelete. To not break the existing logic, I suggest keeping the default value of the new variable "RollingUpdate"

## Which issue(s) this PR fixes

Fixes #(issue-number)
