### PR TITLE
fix(helm): rolling upgrade strategy for ovs is wrong

### DIFF
--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -117,7 +117,7 @@ Get IPs of master nodes from values
       {{- end -}}
     {{- end -}}
   {{- else -}}
-    {{- $.Values.ovsOvn.updateStrategy -}}
+    {{- $.Values.ovsOvn.updateStrategy.type -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -20,8 +20,8 @@ spec:
     type: {{ include "kubeovn.ovs-ovn.updateStrategy" . }}
     {{- if eq (include "kubeovn.ovs-ovn.updateStrategy" .) "RollingUpdate" }}
     rollingUpdate:
-      maxSurge: {{ .Values.ovsOvn.strategy.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ .Values.ovsOvn.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.ovsOvn.updateStrategy.maxSurge }}
+      maxUnavailable: {{ .Values.ovsOvn.updateStrategy.maxUnavailable }}
     {{- end }}
   template:
     metadata:


### PR DESCRIPTION
We really need to introduce Helm tests at some point. There's no way the PR that introduced this bug was tested.

The syntax was wrong and any new deployment of the chart instantly lead to errors in the templating of ovs-ovn