### PR TITLE
fix [BUG] subnet创建了多个vip后，如果kube-ovn-controller重启后subnet.status.v4usi…

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -482,7 +482,7 @@ func (c *Controller) InitIPAM() error {
 		if _, _, _, err = c.ipam.GetStaticAddress(vip.Name, portName, vip.Status.V4ip, &vip.Status.Mac, vip.Spec.Subnet, true); err != nil {
 			klog.Errorf("failed to init ipam from vip cr %s: %v", vip.Name, err)
 		}
-		if err := c.initIpamVipIp(vip.Spec.Subnet, vip.Name, vip.Status.V4ip, vip.Status.V6ip); err != nil {
+		if err := c.initIpamVipIP(vip.Spec.Subnet, vip.Name, vip.Status.V4ip, vip.Status.V6ip); err != nil {
 			klog.Errorf("failed to new ipam from vip %s  ip %s: %v", vip.Name, vip.Status.V4ip, err)
 		}
 	}
@@ -538,7 +538,7 @@ func (c *Controller) InitIPAM() error {
 	return nil
 }
 
-func (c *Controller) initIpamVipIp(subnet, vipname, v4ip, v6ip string) error {
+func (c *Controller) initIpamVipIP(subnet, vipname, v4ip, v6ip string) error {
 	klog.Infof("new ipam ip from subnet %s  vip %s  ipv4 %s ipv6 %s", subnet, vipname, v4ip, v6ip)
 	pool, ok := c.ipam.Subnets[subnet]
 	if !ok {


### PR DESCRIPTION
修复subnet创建了多个vip后，如果kube-ovn-controller重启后subnet.status.v4usingIPrange和v4availableIPrange范围错误

# Pull Request

Examples of user facing changes:
kube-ovn-controller初始化时，增加vip所属的subnet的ipam占用

- Features
- Bug fixes
- Docs
- Tests

## Which issue(s) this PR fixes
[BUG] subnet创建了多个vip后，如果kube-ovn-controller重启后subnet.status.v4usingIPrange和v4availableIPrange范围错误

Fixes #(6164)
