### PR TITLE
feat: add interface field to VPC NAT Gateway routes for specifying ne…

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -606,7 +606,13 @@ spec:
                         description: Destination CIDR for the route
                       nextHopIP:
                         type: string
-                        description: Next hop IP address
+                        description: "Next hop IP or gateway. Empty: use default gateway; 0.0.0.0/:: : on-link route; valid IP: use as gateway"
+                      interface:
+                        type: string
+                        description: Interface to apply the route (eth0 or net1). Defaults to eth0.
+                        enum:
+                          - eth0
+                          - net1
                 tolerations:
                   type: array
                   items:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -606,7 +606,13 @@ spec:
                         description: Destination CIDR for the route
                       nextHopIP:
                         type: string
-                        description: Next hop IP address
+                        description: "Next hop IP or gateway. Empty: use default gateway; 0.0.0.0/:: : on-link route; valid IP: use as gateway"
+                      interface:
+                        type: string
+                        description: Interface to apply the route (eth0 or net1). Defaults to eth0.
+                        enum:
+                          - eth0
+                          - net1
                 tolerations:
                   type: array
                   items:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -856,7 +856,13 @@ spec:
                         description: Destination CIDR for the route
                       nextHopIP:
                         type: string
-                        description: Next hop IP address
+                        description: "Next hop IP or gateway. Empty: use default gateway; 0.0.0.0/:: : on-link route; valid IP: use as gateway"
+                      interface:
+                        type: string
+                        description: Interface to apply the route (eth0 or net1). Defaults to eth0.
+                        enum:
+                          - eth0
+                          - net1
                 tolerations:
                   type: array
                   items:

--- a/pkg/apis/kubeovn/v1/vpc-nat-gateway.go
+++ b/pkg/apis/kubeovn/v1/vpc-nat-gateway.go
@@ -63,9 +63,24 @@ type VpcNatGatewayStatus struct {
 	Affinity        corev1.Affinity     `json:"affinity" patchStrategy:"merge"`
 }
 
+// Route interface constants for VPC NAT Gateway
+const (
+	// Net1InGW represents the external network interface in NAT Gateway
+	Net1InGW = "net1"
+)
+
 type Route struct {
-	CIDR      string `json:"cidr"`
-	NextHopIP string `json:"nextHopIP"`
+	CIDR string `json:"cidr"`
+	// NextHopIP specifies the next hop IP address or gateway for the route.
+	// Supported values:
+	//   - Empty ("")     : use the interface's default gateway
+	//   - "0.0.0.0"/"::" : on-link route (direct route without gateway)
+	//   - Valid IP       : use the specified IP as gateway
+	NextHopIP string `json:"nextHopIP,omitempty"`
+	// Interface specifies which interface to apply the route.
+	// Valid values are "eth0" (internal OVN network) and "net1" (external network).
+	// If not specified, defaults to "eth0" for backward compatibility.
+	Interface string `json:"interface,omitempty"`
 }
 
 func (s *VpcNatGatewayStatus) Bytes() ([]byte, error) {


### PR DESCRIPTION
…twork interface

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

allow to set route on any nic inside vpc-nat-gw with  vpc-nat-gw spec routes 


我理解这个需求比较通用：

- node 访问 eip 的时候可能使用 node 上的任何 ip， 所以需要设置一个回程路由



<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
