### PR TITLE
issue#6181 lb的IPPortMappings不为空时，不允许忽略IPPortMapping

### DIFF
--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -149,11 +149,13 @@ func (c *OVNNbClient) LoadBalancerDeleteVip(lbName, vipEndpoint string, ignoreHe
 		lbhc *ovnnb.LoadBalancerHealthCheck
 		err  error
 	)
-
 	lb, lbhc, err = c.GetLoadBalancerHealthCheck(lbName, vipEndpoint, true)
 	if err != nil {
 		klog.Errorf("failed to get lb health check: %v", err)
 		return err
+	}
+	if len(lb.IPPortMappings) != 0 {
+		ignoreHealthCheck = false
 	}
 	if !ignoreHealthCheck && lbhc != nil {
 		klog.Infof("clean health check for lb %s with vip %s", lbName, vipEndpoint)


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
- Bug fixes：修复删除关联多个endpoint的SwitchLBRule后，SwitchLBRule所属的LoadBalancer的IPPortMappings残留vip映射endpoint数据问题



Describe：
LoadBalancerDeleteVip方法，删除vip时，强制校验lb的IPPortMappings，当len(lb.IPPortMappings) != 0 设置ignoreHealthCheck = false，不再忽略健康检查，问题得到修复。


## Which issue(s) this PR fixes

Fixes #6181
