### PR TITLE
Add vendor ID to transit switches

### DIFF
--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -230,8 +230,8 @@ else
     elif [ "$PROTOCOL" = "dual" ]; then
       TS_CIDR=${TS_CIDR:-"169.254.100.0/24,fe80:a9fe:64::/112"}
     fi
-    ovn-ic-nbctl --may-exist ts-add "$TS_NAME"
-    ovn-ic-nbctl set Transit_Switch ts external_ids:subnet="$TS_CIDR"
+    ovn-ic-nbctl \
+        --may-exist ts-add "$TS_NAME" -- \
+        set Transit_Switch "$TS_NAME" external_ids:subnet="$TS_CIDR" external_ids:vendor=kube-ovn
     tail --follow=name --retry /var/log/ovn/ovsdb-server-ic-nb.log
 fi
-

--- a/pkg/ovs/ovn-ic-nbctl.go
+++ b/pkg/ovs/ovn-ic-nbctl.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (c LegacyClient) ovnIcNbCommand(cmdArgs ...string) (string, error) {
@@ -47,7 +49,11 @@ func (c LegacyClient) GetTsSubnet(ts string) (string, error) {
 }
 
 func (c LegacyClient) GetTs() ([]string, error) {
-	cmd := []string{"--format=csv", "--data=bare", "--no-heading", "--columns=name", "list", "Transit_Switch"}
+	cmd := []string{
+		"--format=csv", "--data=bare", "--no-heading", "--columns=name",
+		"find", "Transit_Switch",
+		fmt.Sprintf("external-ids:%s=%s", ExternalIDVendor, util.CniTypeName),
+	}
 	output, err := c.ovnIcNbCommand(cmd...)
 	if err != nil {
 		klog.Errorf("failed to list transit switch: %v", err)


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
To prevent kube-ovn from interfering with resources it is not
responsible for, kube-ovn adds an external ID "vendor" to ovn resources
it creates, and then uses that to filter fetches. The change adding most
of this (#6001) didn't change the Transit Switches managed by
kube-ovn-ic. This change makes sure they also have vendor IDs added and
respected.
