### PR TITLE
fix: skip NetworkUnavailable condition in non-primary CNI mode

### DIFF
--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -143,6 +143,7 @@ spec:
           - --ovs-vsctl-concurrency={{ .Values.performance.ovsVsctlConcurrency }}
           - --secure-serving={{- .Values.features.enableSecureServing }}
           - --enable-ovn-ipsec={{- .Values.features.enableOvnIpsec }}
+          - --non-primary-cni-mode={{- .Values.cni.nonPrimaryCNI }}
         securityContext:
           runAsGroup: 0
           runAsUser: 0

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -125,6 +125,7 @@ spec:
           - --secure-serving={{- .Values.func.SECURE_SERVING }}
           - --enable-ovn-ipsec={{- .Values.func.ENABLE_OVN_IPSEC }}
           - --set-vxlan-tx-off={{- .Values.func.SET_VXLAN_TX_OFF }}
+          - --non-primary-cni-mode={{- .Values.cni_conf.NON_PRIMARY_CNI }}
         securityContext:
           runAsUser: 0
           privileged: false

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -83,6 +83,7 @@ type Configuration struct {
 	OVSVsctlConcurrency       int32
 	SetVxlanTxOff             bool
 	LogPerm                   string
+	EnableNonPrimaryCNI       bool
 
 	// TLS configuration for secure serving
 	TLSMinVersion   string
@@ -145,6 +146,7 @@ func ParseFlags() *Configuration {
 		argTLSMinVersion   = pflag.String("tls-min-version", "", "The minimum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
 		argTLSMaxVersion   = pflag.String("tls-max-version", "", "The maximum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
 		argTLSCipherSuites = pflag.StringSlice("tls-cipher-suites", nil, "Comma-separated list of TLS cipher suite names to use for secure serving (e.g., 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'). Names must match Go's crypto/tls package. See Go documentation for available suites. If not set, defaults are used. Users are responsible for selecting secure cipher suites.")
+		argNonPrimaryCNI   = pflag.Bool("non-primary-cni-mode", false, "Use Kube-OVN in non primary cni mode. When true, skip setting NetworkUnavailable node condition")
 	)
 
 	// mute info log for ipset lib
@@ -215,6 +217,7 @@ func ParseFlags() *Configuration {
 		CertManagerIPSecCert:      *argCertManagerIPSecCert,
 		CertManagerIssuerName:     *argCertManagerIssuerName,
 		IPSecCertDuration:         *argOVNIPSecCertDuration,
+		EnableNonPrimaryCNI:       *argNonPrimaryCNI,
 	}
 
 	return config

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -87,7 +87,7 @@ func InitNodeGateway(config *Configuration) error {
 		klog.Errorf("failed to get ip %s with mask %s, %v", ip, joinCIDR, err)
 		return err
 	}
-	return configureNodeNic(config.KubeClient, config.NodeName, portName, ipAddr, gw, joinCIDR, mac, config.MTU)
+	return configureNodeNic(config.KubeClient, config.NodeName, portName, ipAddr, gw, joinCIDR, mac, config.MTU, config.EnableNonPrimaryCNI)
 }
 
 func InitMirror(config *Configuration) error {


### PR DESCRIPTION
## Summary

When kube-ovn is configured as a non-primary CNI (e.g., with Cilium as primary), the daemon incorrectly sets the `NetworkUnavailable` node condition. This PR fixes the issue by:

- Adding `--non-primary-cni-mode` flag to daemon configuration
- Skipping `NetworkUnavailable` condition update in `configureNodeNic()` when in non-primary mode
- Skipping `loopOvn0Check()` entirely in non-primary mode (ovn0 health isn't critical for node networking in this mode)
- Updating Helm charts (v1 and v2) to pass the flag to the daemon

The gateway ping is still performed to activate OVN flows - only the condition update is skipped.

Fixes: #6194

