### PR TITLE
fix nat gw qos not update

### DIFF
--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -447,7 +447,7 @@ func (c *Controller) addEipQoS(eip *kubeovnv1.IptablesEIP, v4ip string) error {
 	return c.addOrUpdateEIPBandwidthLimitRules(eip, v4ip, qosPolicy.Status.BandwidthLimitRules)
 }
 
-func (c *Controller) delEIPBandtithLimitRules(eip *kubeovnv1.IptablesEIP, v4ip string, rules kubeovnv1.QoSPolicyBandwidthLimitRules) error {
+func (c *Controller) delEIPBandwidthLimitRules(eip *kubeovnv1.IptablesEIP, v4ip string, rules kubeovnv1.QoSPolicyBandwidthLimitRules) error {
 	var err error
 	for _, rule := range rules {
 		// del qos
@@ -471,7 +471,7 @@ func (c *Controller) delEipQoS(eip *kubeovnv1.IptablesEIP, v4ip string) error {
 		return err
 	}
 
-	return c.delEIPBandtithLimitRules(eip, v4ip, qosPolicy.Status.BandwidthLimitRules)
+	return c.delEIPBandwidthLimitRules(eip, v4ip, qosPolicy.Status.BandwidthLimitRules)
 }
 
 func (c *Controller) addEipQoSInPod(


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

1. **移除全局的 Shared 限制**：将"共享 QoS 不支持更新"的限制从全局改为只针对 `QoSBindingTypeEIP` 类型
2. **增加 NatGw 类型的规则更新处理**：新增对 `QoSBindingTypeNatGw` 类型的规则更新逻辑
3. **实现 reconcileNatGwBandwidthLimitRules 函数**：协调 VPC NAT Gateway 的带宽限制规则更新


** handleUpdateQoSPolicy 改动内容**：
- 将原来对"共享 QoS 不支持更新"的全局限制改为只针对 `QoSBindingTypeEIP`
- 新增 `case kubeovnv1.QoSBindingTypeNatGw` 分支处理 NatGw 类型的规则更新

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
