### PR TITLE
charts: add external-gateway-config-ns option for controller

### DIFF
--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -135,6 +135,9 @@ spec:
           - --enable-lb={{- .Values.features.enableLoadbalancer }}
           - --enable-np={{- .Values.features.enableNetworkPolicies }}
           - --enable-eip-snat={{- .Values.networking.enableEipSnat }}
+          {{- if .Values.networking.externalGatewayConfigNs }}
+          - --external-gateway-config-ns={{- .Values.networking.externalGatewayConfigNs }}
+          {{- end }}
           - --enable-external-vpc={{- .Values.features.enableExternalVpcs }}
           - --enable-ecmp={{- .Values.networking.enableEcmp }}
           - --logtostderr=false

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -152,6 +152,10 @@ networking:
   # -- Enable EIP and SNAT.
   # @section -- Network parameters of the CNI
   enableEipSnat: true
+  # -- Namespace where ovn-external-gw-config ConfigMap is located.
+  # Empty means it will use the same namespace as the controller (PodNamespace).
+  # @section -- Network parameters of the CNI
+  externalGatewayConfigNs: ""
   # -- Comma-separated string of NodeLocal DNS IP addresses.
   # @section -- Network parameters of the CNI
   nodeLocalDnsIp: ""

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -127,6 +127,9 @@ spec:
           - --enable-np={{- .Values.func.ENABLE_NP }}
           - --np-enforcement={{- .Values.func.NP_ENFORCEMENT }}
           - --enable-eip-snat={{- .Values.networking.ENABLE_EIP_SNAT }}
+          {{- if .Values.networking.EXTERNAL_GATEWAY_CONFIG_NS }}
+          - --external-gateway-config-ns={{- .Values.networking.EXTERNAL_GATEWAY_CONFIG_NS }}
+          {{- end }}
           - --enable-external-vpc={{- .Values.func.ENABLE_EXTERNAL_VPC }}
           - --enable-ecmp={{- .Values.networking.ENABLE_ECMP }}
           - --logtostderr=false

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -40,6 +40,9 @@ networking:
     VLAN_ID: "100"
   EXCHANGE_LINK_NAME: false
   ENABLE_EIP_SNAT: true
+  # Namespace where ovn-external-gw-config ConfigMap is located.
+  # Default is empty, which means it will use the same namespace as the controller (PodNamespace).
+  EXTERNAL_GATEWAY_CONFIG_NS: ""
   DEFAULT_SUBNET: "ovn-default"
   DEFAULT_VPC: "ovn-cluster"
   NODE_SUBNET: "join"


### PR DESCRIPTION
Add configurable namespace for ovn-external-gw-config ConfigMap.

By default, the controller's ConfigMap informer only watches ConfigMaps in the PodNamespace (where the controller runs). However, the default value for --external-gateway-config-ns is "kube-system", which causes the ConfigMap to never be found if the controller runs in a different namespace (e.g., "kubeovn").

This option allows users to explicitly set the namespace to match where their ovn-external-gw-config ConfigMap is located, or leave it empty to use the controller's namespace (PodNamespace).

Added to both kube-ovn and kube-ovn-v2 charts.
