### PR TITLE
Update start-ic-db.sh to have gen_conn_addr function defined

### DIFF
--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -57,6 +57,14 @@ function gen_conn_str {
     echo "$x"
 }
 
+function gen_conn_addr {
+    if [[ "$ENABLE_SSL" == "false" ]]; then
+        echo "tcp:[$1]:$2"
+    else
+        echo "ssl:[$1]:$2"
+    fi
+}
+
 function ovn_db_pre_start() {
     local db=""
     local port=""


### PR DESCRIPTION
Else we get log spam of the form:

```
ovn-ic-db-664f8c97bf-qd2gx ovn-ic-db ovsdb-client: failed to connect to "unix:/var/run/openvswitch/db.sock" (No such file or directory)
ovn-ic-db-664f8c97bf-qd2gx ovn-ic-db ./start-ic-db.sh: line 44: gen_conn_addr: command not found
ovn-ic-db-664f8c97bf-qd2gx ovn-ic-db ovsdb-client: failed to connect to "unix:/var/run/openvswitch/db.sock" (No such file or directory)
ovn-ic-db-664f8c97bf-qd2gx ovn-ic-db ./start-ic-db.sh: line 44: gen_conn_addr: command not found
```

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
