### PR TITLE
feat: add user-defined annotations support for NAT GW Pod

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -605,6 +605,11 @@ spec:
                       nextHopIP:
                         type: string
                         description: Next hop IP address
+                annotations:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: User-defined annotations for the StatefulSet NAT gateway Pod template. Only effective at creation time.
                 tolerations:
                   type: array
                   items:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -605,6 +605,11 @@ spec:
                       nextHopIP:
                         type: string
                         description: Next hop IP address
+                annotations:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: User-defined annotations for the StatefulSet NAT gateway Pod template. Only effective at creation time.
                 tolerations:
                   type: array
                   items:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -855,6 +855,11 @@ spec:
                       nextHopIP:
                         type: string
                         description: Next hop IP address
+                annotations:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: User-defined annotations for the StatefulSet NAT gateway Pod template. Only effective at creation time.
                 tolerations:
                   type: array
                   items:

--- a/pkg/apis/kubeovn/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeovn/v1/zz_generated.deepcopy.go
@@ -2870,6 +2870,13 @@ func (in *VpcNatGatewaySpec) DeepCopyInto(out *VpcNatGatewaySpec) {
 		*out = make([]Route, len(*in))
 		copy(*out, *in)
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -410,7 +410,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := GenNatGwPodAnnotations(&tc.gw, tc.externalNadNamespace, tc.externalNadName, tc.provider, tc.additionalNetworks)
+			result, err := GenNatGwPodAnnotations(nil, &tc.gw, tc.externalNadNamespace, tc.externalNadName, tc.provider, tc.additionalNetworks)
 			if (err != nil) != tc.expectError {
 				t.Errorf("expected error: %v, but got: %v", tc.expectError, err)
 			}

--- a/test/e2e/framework/vpc-nat-gateway.go
+++ b/test/e2e/framework/vpc-nat-gateway.go
@@ -228,3 +228,9 @@ func MakeVpcNatGatewayWithNoDefaultEIP(name, vpc, subnet, lanIP, externalSubnet,
 	vpcNatGw.Spec.NoDefaultEIP = noDefaultEIP
 	return vpcNatGw
 }
+
+func MakeVpcNatGatewayWithAnnotations(name, vpc, subnet, lanIP, externalSubnet, qosPolicyName string, annotations map[string]string) *apiv1.VpcNatGateway {
+	vpcNatGw := MakeVpcNatGateway(name, vpc, subnet, lanIP, externalSubnet, qosPolicyName)
+	vpcNatGw.Spec.Annotations = annotations
+	return vpcNatGw
+}


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

1. User-defined annotations for the StatefulSet NAT gateway Pod template. Only effective at creation time.

If we need hot update, then we should support update pod annotation directly in the future.

I think, should not update nat gw statefulset pod template to trigger pod recreation to update the annotation or something else.



<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
