### PR TITLE
refactor: profiling, Retry, assignAddress, runIfLinkExists

### DIFF
--- a/cmd/cmdmain.go
+++ b/cmd/cmdmain.go
@@ -1,15 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"runtime/pprof"
-	"syscall"
-	"time"
-
-	"k8s.io/klog/v2"
 
 	"github.com/kubeovn/kube-ovn/cmd/ovn_ic_controller"
 	"github.com/kubeovn/kube-ovn/cmd/ovn_leader_checker"
@@ -17,6 +10,7 @@ import (
 	"github.com/kubeovn/kube-ovn/cmd/speaker"
 	"github.com/kubeovn/kube-ovn/cmd/webhook"
 	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/pkg/util/profiling"
 )
 
 const (
@@ -27,71 +21,14 @@ const (
 	CmdOvnICController  = "kube-ovn-ic-controller"
 )
 
-const timeFormat = "2006-01-02_15:04:05"
-
-func dumpProfile() {
-	ch1 := make(chan os.Signal, 1)
-	ch2 := make(chan os.Signal, 1)
-	signal.Notify(ch1, syscall.SIGUSR1)
-	signal.Notify(ch2, syscall.SIGUSR2)
-	go func() {
-		for {
-			<-ch1
-			name := fmt.Sprintf("cpu-profile-%s.pprof", time.Now().Format(timeFormat))
-			path := filepath.Join(os.TempDir(), name)
-			f, err := os.Create(path) // #nosec G303,G304
-			if err != nil {
-				klog.Errorf("failed to create cpu profile file: %v", err)
-				return
-			}
-			if err = pprof.StartCPUProfile(f); err != nil {
-				klog.Errorf("failed to start cpu profile: %v", err)
-				if err = f.Close(); err != nil {
-					klog.Errorf("failed to close file %q: %v", path, err)
-				}
-				return
-			}
-			time.Sleep(30 * time.Second)
-			pprof.StopCPUProfile()
-			if err = f.Close(); err != nil {
-				klog.Errorf("failed to close file %q: %v", path, err)
-				return
-			}
-		}
-	}()
-	go func() {
-		for {
-			<-ch2
-			name := fmt.Sprintf("mem-profile-%s.pprof", time.Now().Format(timeFormat))
-			path := filepath.Join(os.TempDir(), name)
-			f, err := os.Create(path) // #nosec G303,G304
-			if err != nil {
-				klog.Errorf("failed to create memory profile file: %v", err)
-				return
-			}
-			if err = pprof.WriteHeapProfile(f); err != nil {
-				klog.Errorf("failed to write memory profile file: %v", err)
-				if err = f.Close(); err != nil {
-					klog.Errorf("failed to close file %q: %v", path, err)
-				}
-				return
-			}
-			if err = f.Close(); err != nil {
-				klog.Errorf("failed to close file %q: %v", path, err)
-				return
-			}
-		}
-	}()
-}
-
 func main() {
 	cmd := filepath.Base(os.Args[0])
 	switch cmd {
 	case CmdMonitor:
-		dumpProfile()
+		profiling.DumpProfile()
 		ovn_monitor.CmdMain()
 	case CmdSpeaker:
-		dumpProfile()
+		profiling.DumpProfile()
 		speaker.CmdMain()
 	case CmdWebhook:
 		webhook.CmdMain()

--- a/cmd/controller/cmdmain.go
+++ b/cmd/controller/cmdmain.go
@@ -1,18 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"runtime/pprof"
-	"syscall"
-	"time"
-
-	"k8s.io/klog/v2"
 
 	"github.com/kubeovn/kube-ovn/cmd/pinger"
 	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/pkg/util/profiling"
 )
 
 const (
@@ -20,71 +14,14 @@ const (
 	CmdPinger     = "kube-ovn-pinger"
 )
 
-const timeFormat = "2006-01-02_15:04:05"
-
-func dumpProfile() {
-	ch1 := make(chan os.Signal, 1)
-	ch2 := make(chan os.Signal, 1)
-	signal.Notify(ch1, syscall.SIGUSR1)
-	signal.Notify(ch2, syscall.SIGUSR2)
-	go func() {
-		for {
-			<-ch1
-			name := fmt.Sprintf("cpu-profile-%s.pprof", time.Now().Format(timeFormat))
-			path := filepath.Join(os.TempDir(), name)
-			f, err := os.Create(path) // #nosec G303,G304
-			if err != nil {
-				klog.Errorf("failed to create cpu profile file: %v", err)
-				return
-			}
-			if err = pprof.StartCPUProfile(f); err != nil {
-				klog.Errorf("failed to start cpu profile: %v", err)
-				if err = f.Close(); err != nil {
-					klog.Errorf("failed to close file %q: %v", path, err)
-				}
-				return
-			}
-			time.Sleep(30 * time.Second)
-			pprof.StopCPUProfile()
-			if err = f.Close(); err != nil {
-				klog.Errorf("failed to close file %q: %v", path, err)
-				return
-			}
-		}
-	}()
-	go func() {
-		for {
-			<-ch2
-			name := fmt.Sprintf("mem-profile-%s.pprof", time.Now().Format(timeFormat))
-			path := filepath.Join(os.TempDir(), name)
-			f, err := os.Create(path) // #nosec G303,G304
-			if err != nil {
-				klog.Errorf("failed to create memory profile file: %v", err)
-				return
-			}
-			if err = pprof.WriteHeapProfile(f); err != nil {
-				klog.Errorf("failed to write memory profile file: %v", err)
-				if err = f.Close(); err != nil {
-					klog.Errorf("failed to close file %q: %v", path, err)
-				}
-				return
-			}
-			if err = f.Close(); err != nil {
-				klog.Errorf("failed to close file %q: %v", path, err)
-				return
-			}
-		}
-	}()
-}
-
 func main() {
 	cmd := filepath.Base(os.Args[0])
 	switch cmd {
 	case CmdController:
-		dumpProfile()
+		profiling.DumpProfile()
 		CmdMain()
 	case CmdPinger:
-		dumpProfile()
+		profiling.DumpProfile()
 		pinger.CmdMain()
 	default:
 		util.LogFatalAndExit(nil, "%s is an unknown command", cmd)

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -223,11 +223,11 @@ func mvCNIConf(configDir, configFile, confName string) error {
 	return os.WriteFile(cniConfPath, data, 0o600) // #nosec G306
 }
 
-func Retry(attempts, sleep int, f func(configuration *daemon.Configuration) error, ctrl *daemon.Configuration) (err error) {
+func Retry(attempts, sleep int, f func(configuration *daemon.Configuration) error, cfg *daemon.Configuration) (err error) {
 	for i := 0; ; i++ {
-		err = f(ctrl)
+		err = f(cfg)
 		if err == nil {
-			return err
+			return nil
 		}
 		if i >= (attempts - 1) {
 			break

--- a/pkg/request/cniserver.go
+++ b/pkg/request/cniserver.go
@@ -19,6 +19,14 @@ type Route struct {
 	Gateway     string `json:"gw,omitempty"`
 }
 
+// IPConfig represents a single IP configuration (one per protocol)
+type IPConfig struct {
+	Protocol string `json:"protocol"`
+	IP       string `json:"ip"`
+	CIDR     string `json:"cidr"`
+	Gateway  string `json:"gateway,omitempty"`
+}
+
 // CniRequest is the cniserver request format
 type CniRequest struct {
 	CniType      string    `json:"cni_type"`
@@ -42,16 +50,13 @@ type CniRequest struct {
 
 // CniResponse is the cniserver response format
 type CniResponse struct {
-	Protocol   string    `json:"protocol"`
-	IPAddress  string    `json:"address"`
-	MacAddress string    `json:"mac_address"`
-	CIDR       string    `json:"cidr"`
-	Gateway    string    `json:"gateway"`
-	Routes     []Route   `json:"routes"`
-	Mtu        int       `json:"mtu"`
-	PodNicName string    `json:"nicname"`
-	DNS        types.DNS `json:"dns"`
-	Err        string    `json:"error"`
+	IPs        []IPConfig `json:"ips"`
+	MacAddress string     `json:"mac_address"`
+	Routes     []Route    `json:"routes"`
+	Mtu        int        `json:"mtu"`
+	PodNicName string     `json:"nicname"`
+	DNS        types.DNS  `json:"dns"`
+	Err        string     `json:"error"`
 }
 
 // Add pod request

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -1,0 +1,60 @@
+package profiling
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime/pprof"
+	"syscall"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	timeFormat         = "2006-01-02_15:04:05"
+	CPUProfileDuration = 30 * time.Second
+)
+
+func writeProfileToTemp(pattern string, writeFn func(*os.File) error) {
+	path := filepath.Join(os.TempDir(), fmt.Sprintf(pattern, time.Now().Format(timeFormat)))
+	f, err := os.Create(path) // #nosec G303,G304
+	if err != nil {
+		klog.Errorf("failed to create profile file: %v", err)
+		return
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			klog.Errorf("failed to close file %q: %v", path, err)
+		}
+	}()
+	if err := writeFn(f); err != nil {
+		klog.Errorf("failed to write profile: %v", err)
+	}
+}
+
+// DumpProfile starts a goroutine that handles SIGUSR1 (CPU profile) and SIGUSR2 (heap profile).
+func DumpProfile() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGUSR1, syscall.SIGUSR2)
+	go func() {
+		for sig := range ch {
+			switch sig {
+			case syscall.SIGUSR1:
+				writeProfileToTemp("cpu-profile-%s.pprof", func(f *os.File) error {
+					if err := pprof.StartCPUProfile(f); err != nil {
+						return err
+					}
+					time.Sleep(CPUProfileDuration)
+					pprof.StopCPUProfile()
+					return nil
+				})
+			case syscall.SIGUSR2:
+				writeProfileToTemp("mem-profile-%s.pprof", func(f *os.File) error {
+					return pprof.WriteHeapProfile(f)
+				})
+			}
+		}
+	}()
+}


### PR DESCRIPTION
- Add pkg/util/profiling with DumpProfile(); use from cmd/cmdmain.go and cmd/controller/cmdmain.go
- cmd/cmdmain.go: remove local dumpProfile, use profiling.DumpProfile()
- cmd/controller/cmdmain.go: remove duplicated dumpProfile, use profiling.DumpProfile()
- cmd/daemon/cniserver.go: Retry param ctrl->cfg, return nil on success
- cmd/cni/cni.go: assignAddress(ipAddress, gateway, protocol, mask), merge IPv4/IPv6 case in generateCNIResult

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- refactor

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
