### PR TITLE
refactor: extract pprof and metrics/health server helpers to pkg/metrics

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -46,9 +46,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	if netConf.Provider == "" && netConf.Type == util.CniTypeName && args.IfName == "eth0" {
-		netConf.Provider = util.OvnProvider
-	}
+	applyDefaultProvider(netConf, args)
 
 	if err = sysctlEnableIPv6(args.Netns); err != nil {
 		return err
@@ -137,9 +135,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	if netConf.Provider == "" && netConf.Type == util.CniTypeName && args.IfName == "eth0" {
-		netConf.Provider = util.OvnProvider
-	}
+	applyDefaultProvider(netConf, args)
 
 	err = client.Del(request.CniRequest{
 		CniType:                    netConf.Type,
@@ -157,6 +153,12 @@ func cmdDel(args *skel.CmdArgs) error {
 		return types.NewError(types.ErrTryAgainLater, "RPC failed", err.Error())
 	}
 	return nil
+}
+
+func applyDefaultProvider(netConf *netconf.NetConf, args *skel.CmdArgs) {
+	if netConf.Provider == "" && netConf.Type == util.CniTypeName && args.IfName == "eth0" {
+		netConf.Provider = util.OvnProvider
+	}
 }
 
 func loadNetConf(bytes []byte) (*netconf.NetConf, string, error) {

--- a/cmd/ovn_ic_controller/ovn_ic_controller.go
+++ b/cmd/ovn_ic_controller/ovn_ic_controller.go
@@ -26,11 +26,11 @@ func CmdMain() {
 		util.LogFatalAndExit(err, "failed to parse config")
 	}
 
-	perm, err := strconv.ParseUint(config.LogPerm, 8, 32)
+	logFilePerm, err := strconv.ParseUint(config.LogPerm, 8, 32)
 	if err != nil {
 		util.LogFatalAndExit(err, "failed to parse log-perm")
 	}
-	util.InitLogFilePerm("kube-ovn-ic-controller", os.FileMode(perm))
+	util.InitLogFilePerm("kube-ovn-ic-controller", os.FileMode(logFilePerm))
 
 	stopCh := signals.SetupSignalHandler().Done()
 	ctl := ovn_ic_controller.NewController(config)

--- a/pkg/metrics/servers.go
+++ b/pkg/metrics/servers.go
@@ -1,0 +1,110 @@
+package metrics
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+const (
+	defaultServerIdleTimeout       = 90 * time.Second
+	defaultServerReadHeaderTimeout = 32 * time.Second
+	defaultServerMaxHeaderBytes    = 1 << 20
+)
+
+func NewPprofServer(host string, port int) (*manager.Server, error) {
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP(host), Port: port})
+	if err != nil {
+		return nil, err
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return &manager.Server{
+		Name: "pprof",
+		Server: &http.Server{
+			Handler:           mux,
+			MaxHeaderBytes:    defaultServerMaxHeaderBytes,
+			IdleTimeout:       defaultServerIdleTimeout,
+			ReadHeaderTimeout: defaultServerReadHeaderTimeout,
+		},
+		Listener: listener,
+	}, nil
+}
+
+func NewHealthOnlyServer(addr string, port int) (*manager.Server, error) {
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP(addr), Port: port})
+	if err != nil {
+		return nil, err
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", util.DefaultHealthCheckHandler)
+	mux.HandleFunc("/livez", util.DefaultHealthCheckHandler)
+	mux.HandleFunc("/readyz", util.DefaultHealthCheckHandler)
+	return &manager.Server{
+		Name: "health-check",
+		Server: &http.Server{
+			Handler:           mux,
+			MaxHeaderBytes:    defaultServerMaxHeaderBytes,
+			IdleTimeout:       defaultServerIdleTimeout,
+			ReadHeaderTimeout: defaultServerReadHeaderTimeout,
+		},
+		Listener: listener,
+	}, nil
+}
+
+func StartPprofServerIfNeeded(ctx context.Context, enablePprof, servePprofInMetrics bool, host string, port int) {
+	if !enablePprof || servePprofInMetrics {
+		return
+	}
+	svr, err := NewPprofServer(host, port)
+	if err != nil {
+		util.LogFatalAndExit(err, "failed to run pprof server")
+	}
+	go func() {
+		if err := svr.Start(ctx); err != nil {
+			util.LogFatalAndExit(err, "failed to run pprof server")
+		}
+	}()
+}
+
+func StartMetricsOrHealthServer(ctx context.Context, enableMetrics bool, addrs []string, port int, config *rest.Config, secureServing, withPprof bool, tlsMinVersion, tlsMaxVersion string, tlsCipherSuites []string) {
+	if enableMetrics {
+		InitKlogMetrics()
+		InitClientGoMetrics()
+		for _, addr := range addrs {
+			if port < 0 || port > 65535 {
+				util.LogFatalAndExit(nil, "invalid port number: %d", port)
+				return
+			}
+			listenAddr := util.JoinHostPort(addr, int32(port)) // #nosec G115
+			go func() {
+				if err := Run(ctx, config, listenAddr, secureServing, withPprof, tlsMinVersion, tlsMaxVersion, tlsCipherSuites); err != nil {
+					util.LogFatalAndExit(err, "failed to run metrics server")
+				}
+			}()
+		}
+		return
+	}
+	klog.Info("metrics server is disabled")
+	svr, err := NewHealthOnlyServer(addrs[0], port)
+	if err != nil {
+		util.LogFatalAndExit(err, "failed to run health check server")
+	}
+	go func() {
+		if err := svr.Start(ctx); err != nil {
+			util.LogFatalAndExit(err, "failed to run health check server")
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
Refactoring per REFACTOR.md: extract shared pprof and metrics/health server logic used by controller and daemon.

## Changes
- **pkg/metrics/servers.go**: Add `NewPprofServer`, `NewHealthOnlyServer`, `StartPprofServerIfNeeded`, `StartMetricsOrHealthServer` (calls `InitKlogMetrics` and `InitClientGoMetrics` when metrics enabled).
- **cmd/controller/controller.go**: Use shared helpers; leader election constants; `checkPermission` req/resp naming.
- **cmd/daemon/cniserver.go**: Use shared helpers; keep `daemon.InitMetrics()` before `StartMetricsOrHealthServer`.
- **cmd/cni/cni.go**: Extract `applyDefaultProvider(netConf, args)`.
- **cmd/ovn_ic_controller/ovn_ic_controller.go**: Rename `perm` to `logFilePerm`.
- **cmd/ovn_leader_checker/ovn_leader_checker.go**: Add `defer klog.Flush()` and version logging (aligned with other entrypoints).

Signed-off-by: Mengxin Liu <liumengxinfly@gmail.com>

Made with [Cursor](https://cursor.com)