### PR TITLE
perf: only enqueue subnet when necessary

### DIFF
--- a/pkg/controller/vpc_test.go
+++ b/pkg/controller/vpc_test.go
@@ -108,7 +108,7 @@ func Test_handleAddOrUpdateVpc_staticRoutes(t *testing.T) {
 			externalIDs,
 			"10.0.0.1",
 		).Return(nil)
-		mockOvnClient.EXPECT().ClearLogicalRouterPolicy(vpcName).Return(nil)
+		mockOvnClient.EXPECT().ListLogicalRouterPolicies(vpcName, -1, nil, true).Return(nil, nil)
 		mockOvnClient.EXPECT().ListLogicalSwitch(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalSwitch{}, nil).AnyTimes()
 		mockOvnClient.EXPECT().ListLogicalRouter(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalRouter{}, nil).AnyTimes()
 		mockOvnClient.EXPECT().DeleteLogicalRouterPort(fmt.Sprintf("bfd@%s", vpcName)).Return(nil)
@@ -168,7 +168,7 @@ func Test_handleAddOrUpdateVpc_staticRoutes(t *testing.T) {
 			Nat:  []string{},
 		}, nil)
 		mockOvnClient.EXPECT().DeleteLogicalRouterStaticRoute(vpcName, gomock.Any(), gomock.Any(), "10.0.0.0/24", "1.2.3.4").Return(nil)
-		mockOvnClient.EXPECT().ClearLogicalRouterPolicy(vpcName).Return(nil)
+		mockOvnClient.EXPECT().ListLogicalRouterPolicies(vpcName, -1, nil, true).Return(nil, nil)
 		mockOvnClient.EXPECT().ListLogicalSwitch(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalSwitch{}, nil).AnyTimes()
 		mockOvnClient.EXPECT().ListLogicalRouter(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalRouter{}, nil).AnyTimes()
 		mockOvnClient.EXPECT().DeleteLogicalRouterPort(fmt.Sprintf("bfd@%s", vpcName)).Return(nil)
@@ -222,7 +222,7 @@ func Test_handleAddOrUpdateVpc_staticRoutes(t *testing.T) {
 		}, nil)
 		mockOvnClient.EXPECT().DeleteLogicalRouterStaticRoute(vpcName, gomock.Any(), gomock.Any(), "10.0.0.0/24", "1.2.3.4").Return(nil)
 		mockOvnClient.EXPECT().DeleteLogicalRouterStaticRoute(vpcName, gomock.Any(), gomock.Any(), "192.168.0.0/24", "10.0.0.1").Return(nil)
-		mockOvnClient.EXPECT().ClearLogicalRouterPolicy(vpcName).Return(nil)
+		mockOvnClient.EXPECT().ListLogicalRouterPolicies(vpcName, -1, nil, true).Return(nil, nil)
 		mockOvnClient.EXPECT().ListLogicalSwitch(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalSwitch{}, nil).AnyTimes()
 		mockOvnClient.EXPECT().ListLogicalRouter(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalRouter{}, nil).AnyTimes()
 		mockOvnClient.EXPECT().DeleteLogicalRouterPort(fmt.Sprintf("bfd@%s", vpcName)).Return(nil)
@@ -285,7 +285,7 @@ func Test_handleAddOrUpdateVpc_staticRoutes(t *testing.T) {
 			externalIDs,
 			"10.0.0.1",
 		).Return(nil)
-		mockOvnClient.EXPECT().ClearLogicalRouterPolicy(vpcName).Return(nil)
+		mockOvnClient.EXPECT().ListLogicalRouterPolicies(vpcName, -1, nil, true).Return(nil, nil)
 		mockOvnClient.EXPECT().ListLogicalSwitch(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalSwitch{}, nil).AnyTimes()
 		mockOvnClient.EXPECT().ListLogicalRouter(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalRouter{}, nil).AnyTimes()
 		mockOvnClient.EXPECT().DeleteLogicalRouterPort(fmt.Sprintf("bfd@%s", vpcName)).Return(nil)


### PR DESCRIPTION
Only enqueue subnet when necessary to improve performance.

Also fix vpc reconcile static routes and policy may incorrectly delete rules created by u2o and egress-gateway. This can be auto recover before because vpc will enqueue all subnets when updated.

Fix #6235 

Made with [Cursor](https://cursor.com)