### PR TITLE
feat: allow vpc-nat-gw image use Ubuntu 24.04

### DIFF
--- a/dist/images/vpcnatgateway/Dockerfile.ubuntu
+++ b/dist/images/vpcnatgateway/Dockerfile.ubuntu
@@ -1,0 +1,70 @@
+# syntax = docker/dockerfile:experimental
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DUMB_INIT_VERSION="1.2.5"
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /usr/lib/apt/methods/mirror && \
+    apt update && apt upgrade -y && \
+    apt install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    conntrack \
+    curl \
+    iperf3 \
+    iproute2 \
+    iptables \
+    iputils-arping \
+    iputils-ping \
+    jq \
+    kmod \
+    mtr \
+    net-tools \
+    netcat-openbsd \
+    nftables \
+    tcpdump \
+    telnet \
+    traceroute \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu 24.04 iptables package ships iptables-legacy alongside nft backend.
+# Remove iptables-legacy so nat-gateway.sh always uses the nft-based iptables.
+RUN rm -f /usr/sbin/iptables-legacy /usr/sbin/iptables-legacy-save
+
+ARG NETTRACE_SHA256_AMD64="dfd9231000015223f2a2cb1da4cc35c597bb879f5be686942c81e055650b50ed"
+ARG NETTRACE_SHA256_ARM64="b16ac63c9216174bba8a23970a49240f15474e152d9aee07a37a70f2ce66da43"
+ARG DUMB_INIT_SHA256_AMD64="e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df"
+ARG DUMB_INIT_SHA256_ARM64="b7d648f97154a99c539b63c55979cd29f005f88430fb383007fe3458340b795e"
+RUN case ${TARGETARCH} in \
+    "amd64") \
+    NETTRACE_SHA256=${NETTRACE_SHA256_AMD64}; \
+    ARCH="x86_64"; \
+    DUMB_INIT_SHA256=${DUMB_INIT_SHA256_AMD64}; \
+    ;; \
+    "arm64") \
+    NETTRACE_SHA256=${NETTRACE_SHA256_ARM64}; \
+    ARCH="aarch64"; \
+    DUMB_INIT_SHA256=${DUMB_INIT_SHA256_ARM64}; \
+    ;; \
+    *) echo "unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -sSf -L --retry 5 -o /tmp/nettrace.deb \
+    https://github.com/OpenCloudOS/nettrace/releases/download/v1.2.11/nettrace-1.2.11-2.${TARGETARCH}.deb && \
+    echo "${NETTRACE_SHA256}  /tmp/nettrace.deb" | sha256sum -c - && \
+    dpkg -i /tmp/nettrace.deb && \
+    rm -f /tmp/nettrace.deb && \
+    curl -sSf -L --retry 5 -o /usr/bin/dumb-init \
+    https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} && \
+    echo "${DUMB_INIT_SHA256}  /usr/bin/dumb-init" | sha256sum -c - && \
+    chmod +x /usr/bin/dumb-init
+
+WORKDIR /kube-ovn
+COPY nat-gateway.sh /kube-ovn/
+COPY lb-svc.sh /kube-ovn/
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["sleep", "infinity"]

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -101,6 +101,14 @@ image-kube-ovn-dpdk: gen-crd build-go
 image-vpc-nat-gateway:
 	docker buildx build --platform linux/amd64 -t $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG) -o type=docker -f dist/images/vpcnatgateway/Dockerfile dist/images/vpcnatgateway
 
+.PHONY: image-vpc-nat-gateway-ubuntu
+image-vpc-nat-gateway-ubuntu:
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/vpc-nat-gateway-ubuntu:$(RELEASE_TAG) -o type=docker -f dist/images/vpcnatgateway/Dockerfile.ubuntu dist/images/vpcnatgateway
+
+.PHONY: image-vpc-nat-gateway-ubuntu-arm64
+image-vpc-nat-gateway-ubuntu-arm64:
+	docker buildx build --platform linux/arm64 -t $(REGISTRY)/vpc-nat-gateway-ubuntu:$(RELEASE_TAG) -o type=docker -f dist/images/vpcnatgateway/Dockerfile.ubuntu dist/images/vpcnatgateway
+
 .PHONY: image-test
 image-test: build-go
 	docker buildx build --platform linux/amd64 -t $(REGISTRY)/test:$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile.test dist/images/

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -113,6 +113,14 @@ image-kube-ovn-dpdk: gen-crd build-go
 image-vpc-nat-gateway:
 	docker buildx build $(IMAGE_LABELS) --platform linux/amd64 -t $(REGISTRY)/vpc-nat-gateway:$(RELEASE_TAG) -o type=docker -f dist/images/vpcnatgateway/Dockerfile dist/images/vpcnatgateway
 
+.PHONY: image-vpc-nat-gateway-ubuntu
+image-vpc-nat-gateway-ubuntu:
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/vpc-nat-gateway-ubuntu:$(RELEASE_TAG) -o type=docker -f dist/images/vpcnatgateway/Dockerfile.ubuntu dist/images/vpcnatgateway
+
+.PHONY: image-vpc-nat-gateway-ubuntu-arm64
+image-vpc-nat-gateway-ubuntu-arm64:
+	docker buildx build --platform linux/arm64 -t $(REGISTRY)/vpc-nat-gateway-ubuntu:$(RELEASE_TAG) -o type=docker -f dist/images/vpcnatgateway/Dockerfile.ubuntu dist/images/vpcnatgateway
+
 .PHONY: image-test
 image-test: build-go
 	docker buildx build $(IMAGE_LABELS) --platform linux/amd64 -t $(REGISTRY)/test:$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile.test dist/images/

--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -96,6 +96,7 @@ e2e-build:
 	$(GINKGO_E2E_BUILD) ./test/e2e/vip
 	$(GINKGO_E2E_BUILD) ./test/e2e/vpc-egress-gateway
 	$(GINKGO_E2E_BUILD) ./test/e2e/iptables-vpc-nat-gw
+	$(GINKGO_E2E_BUILD) ./test/e2e/iptables-eip-qos
 	$(GINKGO_E2E_BUILD) ./test/e2e/ovn-vpc-nat-gw
 	$(GINKGO_E2E_BUILD) ./test/e2e/ha
 	$(GINKGO_E2E_BUILD) ./test/e2e/security

--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -97,6 +97,7 @@ e2e-build:
 	$(GINKGO_E2E_BUILD) ./test/e2e/vip
 	$(GINKGO_E2E_BUILD) ./test/e2e/vpc-egress-gateway
 	$(GINKGO_E2E_BUILD) ./test/e2e/iptables-vpc-nat-gw
+	$(GINKGO_E2E_BUILD) ./test/e2e/iptables-eip-qos
 	$(GINKGO_E2E_BUILD) ./test/e2e/ovn-vpc-nat-gw
 	$(GINKGO_E2E_BUILD) ./test/e2e/ha
 	$(GINKGO_E2E_BUILD) ./test/e2e/security

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -3,6 +3,7 @@
 UNTAINT_CONTROL_PLANE ?= true
 
 VPC_NAT_GW_IMG = $(REGISTRY)/vpc-nat-gateway:$(VERSION)
+VPC_NAT_GW_UBUNTU_IMG = $(REGISTRY)/vpc-nat-gateway-ubuntu:$(VERSION)
 
 # Cilium configuration variables (fallback if not defined in main Makefile)
 CILIUM_VERSION ?= v1.18.5
@@ -245,6 +246,10 @@ kind-load-image:
 .PHONY: kind-load-image-vpc-nat-gateway
 kind-load-image-vpc-nat-gateway:
 	$(call kind_load_image,kube-ovn,$(VPC_NAT_GW_IMG))
+
+.PHONY: kind-load-image-vpc-nat-gateway-ubuntu
+kind-load-image-vpc-nat-gateway-ubuntu:
+	$(call kind_load_image,kube-ovn,$(VPC_NAT_GW_UBUNTU_IMG))
 
 .PHONY: kind-install-chart
 kind-install-chart: kind-load-image untaint-control-plane install-chart
@@ -567,6 +572,12 @@ kind-install-metallb-pool-from-underlay: kind-install-metallb-pool-from-underlay
 .PHONY: kind-install-vpc-nat-gw
 kind-install-vpc-nat-gw:
 	@$(MAKE) kind-load-image-vpc-nat-gateway
+	@$(MAKE) ENABLE_NAT_GW=true CNI_CONFIG_PRIORITY=10 kind-install
+	@$(MAKE) kind-install-multus
+
+.PHONY: kind-install-vpc-nat-gw-ubuntu
+kind-install-vpc-nat-gw-ubuntu:
+	@$(MAKE) kind-load-image-vpc-nat-gateway-ubuntu
 	@$(MAKE) ENABLE_NAT_GW=true CNI_CONFIG_PRIORITY=10 kind-install
 	@$(MAKE) kind-install-multus
 

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -4,6 +4,7 @@ UNTAINT_CONTROL_PLANE ?= true
 TENANT_CONTROL_PLANE_REPLICAS ?= 1
 
 VPC_NAT_GW_IMG = $(REGISTRY)/vpc-nat-gateway:$(VERSION)
+VPC_NAT_GW_UBUNTU_IMG = $(REGISTRY)/vpc-nat-gateway-ubuntu:$(VERSION)
 
 # Cilium configuration variables (fallback if not defined in main Makefile)
 CILIUM_VERSION ?= v1.18.5
@@ -250,6 +251,10 @@ kind-load-image:
 .PHONY: kind-load-image-vpc-nat-gateway
 kind-load-image-vpc-nat-gateway:
 	$(call kind_load_image,kube-ovn,$(VPC_NAT_GW_IMG))
+
+.PHONY: kind-load-image-vpc-nat-gateway-ubuntu
+kind-load-image-vpc-nat-gateway-ubuntu:
+	$(call kind_load_image,kube-ovn,$(VPC_NAT_GW_UBUNTU_IMG))
 
 .PHONY: kind-install-chart
 kind-install-chart: kind-load-image untaint-control-plane install-chart
@@ -573,6 +578,12 @@ kind-install-metallb-pool-from-underlay: kind-install-metallb-pool-from-underlay
 .PHONY: kind-install-vpc-nat-gw
 kind-install-vpc-nat-gw:
 	@$(MAKE) kind-load-image-vpc-nat-gateway
+	@$(MAKE) ENABLE_NAT_GW=true CNI_CONFIG_PRIORITY=10 kind-install
+	@$(MAKE) kind-install-multus
+
+.PHONY: kind-install-vpc-nat-gw-ubuntu
+kind-install-vpc-nat-gw-ubuntu:
+	@$(MAKE) kind-load-image-vpc-nat-gateway-ubuntu
 	@$(MAKE) ENABLE_NAT_GW=true CNI_CONFIG_PRIORITY=10 kind-install
 	@$(MAKE) kind-install-multus
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Tests

Some users may want to use ubuntu22.04 （just the same as kubeovn base image）


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
