### PR TITLE
fix: skip IPAM init for empty IP annotation and handle nil IPRangeList

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -452,9 +452,13 @@ func (c *Controller) InitIPAM() error {
 				portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
 				ip := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)]
 				mac := pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)]
+				if ip == "" {
+					klog.Warningf("pod %s/%s has empty IP annotation for provider %s, skip IPAM init", pod.Namespace, podName, podNet.ProviderName)
+					continue
+				}
 				_, _, _, err := c.ipam.GetStaticAddress(key, portName, ip, &mac, podNet.Subnet.Name, true)
 				if err != nil {
-					klog.Errorf("failed to init pod %s.%s address %s: %v", podName, pod.Namespace, pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)], err)
+					klog.Errorf("failed to init pod %s.%s address %s: %v", podName, pod.Namespace, ip, err)
 				} else {
 					err = c.createOrUpdateIPCR(portName, podName, ip, mac, podNet.Subnet.Name, pod.Namespace, pod.Spec.NodeName, podType)
 					if err != nil {

--- a/pkg/ipam/ip_range_list.go
+++ b/pkg/ipam/ip_range_list.go
@@ -77,6 +77,9 @@ func NewIPRangeListFrom(x ...string) (*IPRangeList, error) {
 }
 
 func (r *IPRangeList) Clone() *IPRangeList {
+	if r == nil {
+		return NewEmptyIPRangeList()
+	}
 	ret := &IPRangeList{make([]*IPRange, r.Len())}
 	for i := range r.ranges {
 		ret.ranges[i] = r.ranges[i].Clone()
@@ -85,10 +88,16 @@ func (r *IPRangeList) Clone() *IPRangeList {
 }
 
 func (r *IPRangeList) Len() int {
+	if r == nil {
+		return 0
+	}
 	return len(r.ranges)
 }
 
 func (r *IPRangeList) Count() internal.BigInt {
+	if r == nil {
+		return internal.BigInt{}
+	}
 	var count internal.BigInt
 	for _, v := range r.ranges {
 		count = count.Add(v.Count())
@@ -97,13 +106,16 @@ func (r *IPRangeList) Count() internal.BigInt {
 }
 
 func (r *IPRangeList) At(i int) *IPRange {
-	if i < len(r.ranges) {
-		return r.ranges[i]
+	if r == nil || i < 0 || i >= len(r.ranges) {
+		return nil
 	}
-	return nil
+	return r.ranges[i]
 }
 
 func (r *IPRangeList) Find(ip IP) (int, bool) {
+	if r == nil {
+		return 0, false
+	}
 	return sort.Find(len(r.ranges), func(i int) int {
 		if r.At(i).Start().GreaterThan(ip) {
 			return -1
@@ -121,6 +133,9 @@ func (r *IPRangeList) Contains(ip IP) bool {
 }
 
 func (r *IPRangeList) Add(ip IP) bool {
+	if r == nil {
+		return false
+	}
 	n, ok := r.Find(ip)
 	if ok {
 		return false
@@ -145,6 +160,9 @@ func (r *IPRangeList) Add(ip IP) bool {
 }
 
 func (r *IPRangeList) Remove(ip IP) bool {
+	if r == nil {
+		return false
+	}
 	n, ok := r.Find(ip)
 	if !ok {
 		return false


### PR DESCRIPTION
- Skip IPAM initialization when pod IP annotation is empty, log warning instead
- Make IPRangeList.Len() nil-safe to prevent panic in GetSubnetIPRangeString
- Add unit test for nil IPRangeList.Separate() behavior

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->


- Bug fixes

两个问题，好像都是空 ip 问题


```bash


E0211 15:34:18.554217       7 init.go:457] failed to init pod vpc-nat-gw-fip-subnet-69897ff101ca5d975cb0fdbb-0.kube-system address : invalid IP address ""
I0211 15:34:18.554251       7 ipam.go:103] allocate v4 10.1.255.254, mac 0e:c3:b7:e6:ad:7f for kube-system/vpc-nat-gw-fip-subnet-69897ff101ca5d975cb0fdbb-0 from subnet subnet-69897ff101ca5d975cb0fdbb


```


```bash

E0211 15:58:51.084850       7 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
	goroutine 1259 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x55fc4ac8c2c8, 0xc000ee5f20}, {0x55fc4a6c3c80, 0x55fc4c8882e0})
		k8s.io/apimachinery@v0.34.3/pkg/util/runtime/runtime.go:132 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x55fc4ac8e188, 0xc00052fc70}, {0x55fc4a6c3c80, 0x55fc4c8882e0}, {0x0, 0x0, 0xc00127b4c0?})
		k8s.io/apimachinery@v0.34.3/pkg/util/runtime/runtime.go:107 +0x116
	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x55fc4ac8e188, 0xc00052fc70}, {0x0, 0x0, 0x0})
		k8s.io/apimachinery@v0.34.3/pkg/util/runtime/runtime.go:78 +0x5a
	panic({0x55fc4a6c3c80?, 0x55fc4c8882e0?})
		runtime/panic.go:783 +0x132
	github.com/kubeovn/kube-ovn/pkg/ipam.(*IPRangeList).Len(...)
		github.com/kubeovn/kube-ovn/pkg/ipam/ip_range_list.go:88
	github.com/kubeovn/kube-ovn/pkg/ipam.(*IPRangeList).Separate(0xc001797d88, 0x0?)
		github.com/kubeovn/kube-ovn/pkg/ipam/ip_range_list.go:215 +0x32
	github.com/kubeovn/kube-ovn/pkg/ipam.(*IPAM).GetSubnetIPRangeString(0xc0008ff8c0, {0xc00087c460, 0x1b}, {0xc000ee4660?, 0x55fc486eada6?, 0xc0009e16c0?})
		github.com/kubeovn/kube-ovn/pkg/ipam/ipam.go:432 +0x1c7
	github.com/kubeovn/kube-ovn/pkg/controller.(*Controller).calcSubnetStatusIP(0xc0000ea008, 0xc001b8f688)
		github.com/kubeovn/kube-ovn/pkg/controller/subnet_status.go:193 +0x347
	github.com/kubeovn/kube-ovn/pkg/controller.(*Controller).handleUpdateSubnetStatus(0xc0000ea008, {0xc001cc1c60, 0x1b})
		github.com/kubeovn/kube-ovn/pkg/controller/subnet_status.go:107 +0x435
	github.com/kubeovn/kube-ovn/pkg/controller.processNextWorkItem[...].func1(0x81fb720eb16c48ee, {0x55fc49623952, 0x17?}, 0x55fc4ac40a30, 0x55fc4ac513a0, {0xc001cc1c60, 0x1b})
		github.com/kubeovn/kube-ovn/pkg/controller/controller.go:1541 +0xb4
	github.com/kubeovn/kube-ovn/pkg/controller.processNextWorkItem[...]({0x55fc49623952, 0x17}, {0x55fc4acaa1a0, 0xc000960ca0}, 0xc001a1b600, 0x55fc4ac40a30)
		github.com/kubeovn/kube-ovn/pkg/controller/controller.go:1547 +0x7c
	github.com/kubeovn/kube-ovn/pkg/controller.(*Controller).startWorkers.runWorker[...].func46()
		github.com/kubeovn/kube-ovn/pkg/controller/controller.go:1577 +0x73
	k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x7ec6e4ccd1dc6bc7?, 0xf9ae47724f0131f4?})
		k8s.io/apimachinery@v0.34.3/pkg/util/wait/backoff.go:233 +0x13
	k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x55fc4ac8e188?, 0xc00052fc70?}, 0x55fc47183e94?)
		k8s.io/apimachinery@v0.34.3/pkg/util/wait/backoff.go:255 +0x51
	k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x55fc4ac8e188, 0xc00052fc70}, 0xc00127bf50, {0x55fc4ac52ce0, 0xc001914120}, 0x1)
		k8s.io/apimachinery@v0.34.3/pkg/util/wait/backoff.go:256 +0xe5
	k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x6b0d0c31d96c925b?, {0x55fc4ac52ce0?, 0xc001914120?}, 0xa1?, 0xc5d0b14418e6a184?)
		k8s.io/apimachinery@v0.34.3/pkg/util/wait/backoff.go:233 +0x46
	k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000ef5580, 0x3b9aca00, 0x0, 0x1, 0xc00052fc70)
		k8s.io/apimachinery@v0.34.3/pkg/util/wait/backoff.go:210 +0x7f
	k8s.io/apimachinery/pkg/util/wait.Until(...)
		k8s.io/apimachinery@v0.34.3/pkg/util/wait/backoff.go:163
	created by github.com/kubeovn/kube-ovn/pkg/controller.(*Controller).startWorkers in goroutine 104
		github.com/kubeovn/kube-ovn/pkg/controller/controller.go:1345 +0x3ae9

```

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
