### PR TITLE
fix(ovn): add null check before sbrec delete calls

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -65,6 +65,7 @@ ADD patches/e7d3ba53cdcbc524bb29c54ddb07b83cc4258ed7.patch $SRC_DIR
 ADD patches/9286e1fd578fdb8f565a0f4aa9066b538295e1ac.patch $SRC_DIR
 ADD patches/737d9f932edada5a91f315b5f382daada8dee952.patch $SRC_DIR
 ADD patches/52b727b3315463668669ff423ce8bfa129861162.patch $SRC_DIR
+ADD patches/sbrec-delete-null-check.patch $SRC_DIR
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -131,7 +132,9 @@ RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-o
     # add skip conntrack ipcidrs support
     git apply $SRC_DIR/737d9f932edada5a91f315b5f382daada8dee952.patch && \
     # set dl_src for packets redirected by router port
-    git apply $SRC_DIR/52b727b3315463668669ff423ce8bfa129861162.patch
+    git apply $SRC_DIR/52b727b3315463668669ff423ce8bfa129861162.patch && \
+    # add null check before sbrec delete calls
+    git apply $SRC_DIR/sbrec-delete-null-check.patch
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/dist/images/patches/sbrec-delete-null-check.patch
+++ b/dist/images/patches/sbrec-delete-null-check.patch
@@ -1,0 +1,39 @@
+diff --git a/northd/northd.c b/northd/northd.c
+index 74c47972a..6b195d475 100644
+--- a/northd/northd.c
++++ b/northd/northd.c
+@@ -4950,7 +4950,9 @@ ls_handle_lsp_changes(struct ovsdb_idl_txn *ovnsb_idl_txn,
+             add_op_to_northd_tracked_ports(&trk_lsps->deleted, op);
+             hmap_remove(&nd->ls_ports, &op->key_node);
+             hmap_remove(&od->ports, &op->dp_node);
+-            sbrec_port_binding_delete(op->sb);
++            if (op->sb) {
++                sbrec_port_binding_delete(op->sb);
++            }
+             delete_fdb_entries(ni->sbrec_fdb_by_dp_and_port, od->tunnel_key,
+                                 op->tunnel_key);
+         }
+@@ -10702,7 +10704,7 @@ bfd_table_sync(struct ovsdb_idl_txn *ovnsb_txn,
+     }
+ 
+     HMAP_FOR_EACH_POP (bfd_e, hmap_node, &sync_bfd_connections) {
+-        if (bfd_e->stale) {
++        if (bfd_e->stale && bfd_e->sb_bt) {
+             sbrec_bfd_delete(bfd_e->sb_bt);
+         }
+         bfd_erase_entry(bfd_e);
+diff --git a/utilities/ovn-sbctl.c b/utilities/ovn-sbctl.c
+index b00b8cd04..2b126d52f 100644
+--- a/utilities/ovn-sbctl.c
++++ b/utilities/ovn-sbctl.c
+@@ -494,7 +494,9 @@ cmd_chassis_del(struct ctl_context *ctx)
+             size_t i;
+ 
+             for (i = 0; i < sbctl_ch->ch_cfg->n_encaps; i++) {
+-                sbrec_encap_delete(sbctl_ch->ch_cfg->encaps[i]);
++                if (sbctl_ch->ch_cfg->encaps[i]) {
++                    sbrec_encap_delete(sbctl_ch->ch_cfg->encaps[i]);
++                }
+             }
+ 
+             struct sbctl_chassis_private *sbctl_ch_priv;


### PR DESCRIPTION
## Summary
- Add a patch for OVN (branch-25.03) that adds null pointer checks before calling `sbrec_port_binding_delete`, `sbrec_bfd_delete`, and `sbrec_encap_delete`
- Prevents potential null pointer dereference crashes in `northd` and `ovn-sbctl`
- Applies the patch during the OVN build in `Dockerfile.base`

## Changes
- `dist/images/patches/sbrec-delete-null-check.patch`: New patch file with null checks in three locations:
  - `northd/northd.c`: Check `op->sb` before `sbrec_port_binding_delete`
  - `northd/northd.c`: Check `bfd_e->sb_bt` before `sbrec_bfd_delete`
  - `utilities/ovn-sbctl.c`: Check `sbctl_ch->ch_cfg->encaps[i]` before `sbrec_encap_delete`
- `dist/images/Dockerfile.base`: Add and apply the new patch

## Test plan
- [x] Verify the OVN base image builds successfully with the new patch applied
- [x] Confirm no null pointer crashes in northd when deleting port bindings
- [x] Confirm no null pointer crashes in northd BFD table sync
- [x] Confirm no null pointer crashes in ovn-sbctl chassis deletion

Fix #6053

🤖 Generated with [Claude Code](https://claude.com/claude-code)