### PR TITLE
fix: avoid OVN northd "No path for static route" warning on startup

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -904,10 +904,6 @@ func (c *Controller) syncNodeRoutes() error {
 		return err
 	}
 
-	if err := c.addNodeGatewayStaticRoute(); err != nil {
-		klog.Errorf("failed to add static route for node gateway")
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Remove `addNodeGatewayStaticRoute()` from `syncNodeRoutes()` (init phase) and `handleAddNode()` where it ran before the join subnet's OVN Logical Router Port existed, causing OVN northd to warn: `No path for static route 0.0.0.0/0 on router ovn-cluster; next hop 100.64.0.1`
- Add `LogicalSwitchExists` check in `handleAddOrUpdateVpc()` to requeue the default VPC if the join subnet's logical switch is not yet ready, preventing the race between VPC worker and Subnet worker
- Remove the now-unused `addNodeGatewayStaticRoute()` function since `handleAddOrUpdateVpc()` already manages default route reconciliation via VPC route diffing

## Root Cause

During controller startup, there were three places adding default gateway routes:

| Location | Function | Timing | Safe? |
|----------|----------|--------|-------|
| Init phase | `syncNodeRoutes()` → `addNodeGatewayStaticRoute()` | Before workers start | ❌ join LRP does not exist |
| VPC Worker | `handleAddOrUpdateVpc()` | Concurrent with Subnet Worker | ⚠️ race condition |
| Node Worker | `handleAddNode()` → `addNodeGatewayStaticRoute()` | After subnet ready | ✅ but redundant |

The init phase call always triggered the warning. The VPC worker call could race with the Subnet worker.

## Fix

- **Init phase**: Remove the route addition entirely — let the VPC worker handle it
- **VPC worker**: Check that the join logical switch exists before adding routes; requeue if not ready
- **Node worker**: Remove redundant call since VPC worker already reconciles all routes

On controller restart, the informer's initial list triggers `enqueueAddVpc` for the default VPC, and since OVN NB data is persistent, the join logical switch already exists — routes are added immediately without warnings.

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make ut` passes (all packages ok)
- [ ] Verify no `No path for static route` warning in OVN northd logs after controller restart
- [ ] Verify default routes (`0.0.0.0/0`, `::/0`) are present after fresh install and controller restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)