### PR TITLE
fix(ovn): add use-after-free fix for en-sync-sb to null check patch

### DIFF
--- a/dist/images/patches/sbrec-delete-null-check.patch
+++ b/dist/images/patches/sbrec-delete-null-check.patch
@@ -1,3 +1,15 @@
+diff --git a/northd/en-sync-sb.c b/northd/en-sync-sb.c
+index 13266908b..458248f4d 100644
+--- a/northd/en-sync-sb.c
++++ b/northd/en-sync-sb.c
+@@ -957,6 +957,7 @@ sync_changed_lbs(struct sb_lb_table *sb_lbs,
+ 
+             hmap_remove(&sb_lbs->entries, &sb_lb->key_node);
+             free(sb_lb);
++            continue;
+         }
+ 
+         if (!sync_sb_lb_record(sb_lb, sb_lb->sbrec_lb, sb_dpgrp_table, sb_lbs,
 diff --git a/northd/northd.c b/northd/northd.c
 index 74c47972a..6b195d475 100644
 --- a/northd/northd.c


### PR DESCRIPTION
## Summary
- Add missing `continue` in `sync_changed_lbs()` (`northd/en-sync-sb.c`) to prevent use-after-free after `hmap_remove` and `free(sb_lb)`, avoiding subsequent access to the freed entry.
- Existing null pointer checks for `sbrec_port_binding_delete`, `sbrec_bfd_delete`, and `sbrec_encap_delete` are preserved.

## Test plan
- [ ] Verify the patch applies cleanly to the OVN source during image build
- [ ] Run e2e tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)