### PR TITLE
fix: skip unallocated pods during IPAM initialization

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -437,6 +437,10 @@ func (c *Controller) InitIPAM() error {
 			continue
 		}
 
+		if !hasAllocatedAnnotation(pod) {
+			continue
+		}
+
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {
 			klog.Errorf("failed to get pod kubeovn nets %s.%s address %s: %v", pod.Name, pod.Namespace, pod.Annotations[util.IPAddressAnnotation], err)
@@ -1033,4 +1037,13 @@ func (c *Controller) syncFinalizers() error {
 	}
 	klog.Info("sync finalizers done")
 	return nil
+}
+
+func hasAllocatedAnnotation(pod *v1.Pod) bool {
+	for key, value := range pod.Annotations {
+		if value == "true" && strings.HasSuffix(key, util.AllocatedAnnotationSuffix) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controller/init_test.go
+++ b/pkg/controller/init_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHasAllocatedAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			name: "default provider allocated",
+			annotations: map[string]string{
+				"ovn.kubernetes.io/allocated": "true",
+			},
+			expected: true,
+		},
+		{
+			name: "custom provider allocated",
+			annotations: map[string]string{
+				"my-provider.kubernetes.io/allocated": "true",
+			},
+			expected: true,
+		},
+		{
+			name: "allocated is false",
+			annotations: map[string]string{
+				"ovn.kubernetes.io/allocated": "false",
+			},
+			expected: false,
+		},
+		{
+			name: "unrelated annotations only",
+			annotations: map[string]string{
+				"app":                          "test",
+				"ovn.kubernetes.io/ip_address": "10.0.0.1",
+			},
+			expected: false,
+		},
+		{
+			name: "multiple providers with one allocated",
+			annotations: map[string]string{
+				"ovn.kubernetes.io/allocated":         "false",
+				"my-provider.kubernetes.io/allocated": "true",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			require.Equal(t, tt.expected, hasAllocatedAnnotation(pod))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- During controller first startup, `InitIPAM()` iterates all pods and calls `getPodKubeovnNets()`, which checks namespace network annotations. However, namespace annotations are not yet set at this point because the namespace worker starts **after** `InitIPAM()`. This causes spurious error logs for pods not yet managed by kube-ovn (e.g., coredns on first startup):
  ```
  E0223 02:05:17.580428  pod.go:1673] namespace kube-system network annotations is empty
  E0223 02:05:17.580621  init.go:442] failed to get pod kubeovn nets coredns-xxx.kube-system address : namespace kube-system network annotations is empty
  ```
- Skip pods without any `*.kubernetes.io/allocated=true` annotation before calling `getPodKubeovnNets()`, since they have no IP to restore into IPAM anyway. The inner loop at `init.go:450` already checks `allocated == "true"` per provider, so these pods would be no-ops even if they passed.

## Test plan
- [x] Unit tests for `hasAllocatedAnnotation()` covering nil/empty annotations, default/custom providers, false values, and multi-provider scenarios
- [x] `make lint` passes with 0 issues
- [x] `go test ./pkg/controller/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)