### PR TITLE
fix(kind): set containerd LimitNOFILE to 4096 to avoid valgrind failure

### DIFF
--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -32,6 +32,11 @@ endif
 
 define kind_create_cluster
 	kind create cluster --config $(1) --name $(2)
+	@for node in $$(kind get nodes --name $(2)); do \
+		docker exec $$node sed -i 's/LimitNOFILE=infinity/LimitNOFILE=4096/' /etc/systemd/system/containerd.service; \
+		docker exec $$node systemctl daemon-reload; \
+		docker exec $$node systemctl restart containerd; \
+	done
 	@if [ "x$(3)" = "x1" ]; then \
 		kubectl delete --ignore-not-found sc standard; \
 		kubectl delete --ignore-not-found -n local-path-storage deploy local-path-provisioner; \


### PR DESCRIPTION
## Summary
- Set `LimitNOFILE=4096` for containerd on all Kind nodes after cluster creation
- The default `LimitNOFILE=infinity` causes valgrind to fail with:
  ```
  libcfile Valgrind: FATAL: Private file creation failed.
  The current file descriptor limit is 1073741804.
  If you are running in Docker please consider
  lowering this limit with the shell built-in limit command.
  Exiting now.
  ```

## Test plan
- [x] Run `make kind-init` to create cluster
- [x] Verify `LimitNOFILE=4096` on all nodes: `docker exec <node> grep LimitNOFILE /etc/systemd/system/containerd.service`
- [x] Verify containerd is active: `docker exec <node> systemctl status containerd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)