### PR TITLE
fix: add retry logic to SLR e2e connectivity test to fix flaky failure

### DIFF
--- a/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
+++ b/test/e2e/kube-ovn/switch_lb_rule/switch_lb_rule.go
@@ -37,9 +37,12 @@ func generateSubnetName(name string) string {
 
 func curlSvc(f *framework.Framework, clientPodName, vip string, port int32) {
 	ginkgo.GinkgoHelper()
-	cmd := "curl -q -s --connect-timeout 2 --max-time 2 " + util.JoinHostPort(vip, port)
+	cmd := "curl -q -s --connect-timeout 5 --max-time 5 " + util.JoinHostPort(vip, port)
 	ginkgo.By(fmt.Sprintf(`Executing %q in pod %s/%s`, cmd, f.Namespace.Name, clientPodName))
-	e2epodoutput.RunHostCmdOrDie(f.Namespace.Name, clientPodName, cmd)
+	framework.WaitUntil(2*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+		_, err := e2epodoutput.RunHostCmd(f.Namespace.Name, clientPodName, cmd)
+		return err == nil, nil
+	}, fmt.Sprintf("%s:%d is reachable", vip, port))
 }
 
 func isMultusInstalled(f *framework.Framework) bool {


### PR DESCRIPTION
## Summary
- Fix intermittent "SLR with default provider" e2e test failure (IPv6 curl timeout, exit code 28)
- Replace single-shot `RunHostCmdOrDie` with `WaitUntil` retry loop (2s interval, 30s timeout) in `curlSvc()`
- Increase curl timeout from 2s to 5s to accommodate IPv6 and cross-node latency

## Root Cause
The test checks connectivity immediately after Kubernetes Endpoints are created, but OVN LB rules need additional time to propagate through the data plane (NB → SB → ovn-controller → OVS datapath). The third test phase (Endpoint SLR, port 8092) is most affected due to higher rule complexity and accumulated system load from previous phases. IPv6 exacerbates the issue due to NDP and longer rule processing times.

## Test plan
- [ ] Verify the SLR e2e test passes consistently in CI (both IPv4 and IPv6)
- [ ] Confirm the retry pattern aligns with other network connectivity tests (network-policy, service, lb-svc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)