### PR TITLE
fix: prevent subnet from getting permanently stuck when VLAN is not ready

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -495,20 +495,20 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 
 	err = c.validateSubnetVlan(subnet)
 	if err != nil {
-		err := fmt.Errorf("failed to validate vlan for subnet %s, %w", key, err)
+		err = fmt.Errorf("failed to validate vlan for subnet %s, %w", key, err)
 		klog.Error(err)
-		if err = c.patchSubnetStatus(subnet, "ValidateSubnetVlanFailed", err.Error()); err != nil {
-			klog.Error(err)
-			return err
+		if patchErr := c.patchSubnetStatus(subnet, "ValidateSubnetVlanFailed", err.Error()); patchErr != nil {
+			klog.Error(patchErr)
+			return patchErr
 		}
 		return err
 	}
 
 	if err = util.ValidateSubnet(*subnet); err != nil {
 		klog.Errorf("failed to validate subnet %s, %v", subnet.Name, err)
-		if err = c.patchSubnetStatus(subnet, "ValidateLogicalSwitchFailed", err.Error()); err != nil {
-			klog.Error(err)
-			return err
+		if patchErr := c.patchSubnetStatus(subnet, "ValidateLogicalSwitchFailed", err.Error()); patchErr != nil {
+			klog.Error(patchErr)
+			return patchErr
 		}
 		return err
 	}

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -275,6 +275,34 @@ func Test_formatSubnet(t *testing.T) {
 	}
 }
 
+func Test_handleAddOrUpdateSubnet_vlanValidationError(t *testing.T) {
+	t.Parallel()
+
+	// Create a subnet that references a non-existent vlan
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-underlay",
+		},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.0.0.0/24",
+			Gateway:   "10.0.0.1",
+			Vlan:      "non-existent-vlan",
+		},
+	}
+
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{subnet},
+	})
+	require.NoError(t, err)
+	ctrl := fakeController.fakeController
+
+	// handleAddOrUpdateSubnet should return an error when the vlan does not exist,
+	// so that the work queue retries the item instead of forgetting it
+	err = ctrl.handleAddOrUpdateSubnet("test-underlay")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to validate vlan")
+}
+
 func Test_isOvnSubnet(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -116,6 +116,14 @@ func (c *Controller) handleAddVlan(key string) error {
 		}
 	}
 
+	// re-enqueue subnets that reference this vlan, so they can proceed
+	// if they were previously blocked by the vlan not being ready
+	for _, subnet := range subnets {
+		if subnet.Spec.Vlan == vlan.Name {
+			c.addOrUpdateSubnetQueue.Add(subnet.Name)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Fix variable shadowing/overwriting in `handleAddOrUpdateSubnet` that caused VLAN and subnet validation errors to be swallowed, preventing work queue retries
- Add subnet re-enqueue logic in `handleAddVlan` so subnets blocked by a missing VLAN get reprocessed once the VLAN is created
- Add unit test to verify `handleAddOrUpdateSubnet` correctly returns errors when VLAN validation fails

## Details

**Bug 1 (subnet.go:496-514)**: When `validateSubnetVlan` or `ValidateSubnet` failed, the error was passed to `patchSubnetStatus`. If the patch succeeded, the original validation error was overwritten with `nil` (due to `err :=` shadowing and `err =` reuse), causing the handler to return `nil`. The work queue then called `Forget(item)` instead of `AddRateLimited(item)`, so the subnet was never retried.

**Bug 2 (vlan.go:53-120)**: `handleAddVlan` updated the VLAN's status with associated subnets but did not re-enqueue those subnets. If a subnet had already been forgotten by the queue due to Bug 1, no event would trigger it to be reprocessed after the VLAN became available.

**Combined effect**: During controller startup in underlay mode, if the subnet was processed before its VLAN was created, the subnet would get permanently stuck, causing `allSubnetReady()` to never return true and the controller to hang at "wait for subnets ready".

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `go test ./pkg/controller/` passes — all existing + new tests pass
- [x] New unit test `Test_handleAddOrUpdateSubnet_vlanValidationError` verifies the error is correctly returned
- [ ] Verify in Talos Installation Test (ipv4, underlay) that the controller no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)