### PR TITLE
ci: use larger runner for Talos installation test

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -2428,7 +2428,7 @@ jobs:
   talos-installation-test:
     name: Talos Installation Test
     needs: build-kube-ovn
-    runs-on: ubuntu-24.04
+    runs-on: larger-runner
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Switch the Talos Installation Test job runner from `ubuntu-24.04` to `larger-runner` for better performance and stability.

## Test plan
- [ ] Verify the Talos Installation Test job runs successfully on the larger runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)