### PR TITLE
fix(ci): redesign log upload steps in build-x86-image workflow

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -592,43 +592,31 @@ jobs:
         run: make k8s-conformance-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-events.yaml
           tar zcf k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-events.tar.gz k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-events
           path: k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-audit-log
           path: k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log
-          path: k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -636,17 +624,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz k8s-conformance-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: k8s-conformance-e2e-restarts-ko-log
-          path: k8s-conformance-e2e-ko-log.tar.gz
+          name: k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log
+          path: k8s-conformance-e2e-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log.tar.gz
 
       - name: Check valgrind result
         run: |
@@ -803,43 +791,31 @@ jobs:
         run: make k8s-netpol-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > k8s-netpol-e2e-${{ matrix.ip-family }}-events.yaml
           tar zcf k8s-netpol-e2e-${{ matrix.ip-family }}-events.tar.gz k8s-netpol-e2e-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: k8s-netpol-e2e-${{ matrix.ip-family }}-events
           path: k8s-netpol-e2e-${{ matrix.ip-family }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf k8s-netpol-e2e-${{ matrix.ip-family }}-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: k8s-netpol-e2e-${{ matrix.ip-family }}-audit-log
           path: k8s-netpol-e2e-${{ matrix.ip-family }}-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz k8s-netpol-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: k8s-netpol-e2e-${{ matrix.ip-family }}-ko-log
-          path: k8s-netpol-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -847,17 +823,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz k8s-netpol-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz k8s-netpol-e2e-${{ matrix.ip-family }}-${{ matrix.np-enforcement }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: k8s-netpol-e2e-restarts-ko-log
-          path: k8s-netpol-e2e-ko-log.tar.gz
+          name: k8s-netpol-e2e-${{ matrix.ip-family }}-${{ matrix.np-enforcement }}-ko-log
+          path: k8s-netpol-e2e-${{ matrix.ip-family }}-${{ matrix.np-enforcement }}-ko-log.tar.gz
 
       - name: Check valgrind result
         run: |
@@ -987,43 +963,31 @@ jobs:
         run: make cyclonus-netpol-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > cyclonus-netpol-e2e-${{ matrix.ip-family }}-events.yaml
           tar zcf cyclonus-netpol-e2e-${{ matrix.ip-family }}-events.tar.gz cyclonus-netpol-e2e-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: cyclonus-netpol-e2e-${{ matrix.ip-family }}-events
           path: cyclonus-netpol-e2e-${{ matrix.ip-family }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf cyclonus-netpol-e2e-${{ matrix.ip-family }}-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: cyclonus-netpol-e2e-${{ matrix.ip-family }}-audit-log
           path: cyclonus-netpol-e2e-${{ matrix.ip-family }}-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz cyclonus-netpol-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: cyclonus-netpol-e2e-${{ matrix.ip-family }}-ko-log
-          path: cyclonus-netpol-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -1031,17 +995,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz cyclonus-netpol-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz cyclonus-netpol-e2e-${{ matrix.ip-family }}-${{ matrix.np-enforcement }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: cyclonus-netpol-e2e-restarts-ko-log
-          path: cyclonus-netpol-e2e-ko-log.tar.gz
+          name: cyclonus-netpol-e2e-${{ matrix.ip-family }}-${{ matrix.np-enforcement }}-ko-log
+          path: cyclonus-netpol-e2e-${{ matrix.ip-family }}-${{ matrix.np-enforcement }}-ko-log.tar.gz
 
       - name: Check valgrind result
         run: |
@@ -1194,43 +1158,31 @@ jobs:
           make kube-ovn-kubevirt-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
           tar zcf kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events
           path: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-audit-log
           path: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log
-          path: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -1238,17 +1190,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-conformance-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: kube-ovn-conformance-e2e-restarts-ko-log
-          path: kube-ovn-conformance-e2e-ko-log.tar.gz
+          name: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log
+          path: kube-ovn-conformance-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check valgrind result
         run: |
@@ -1389,7 +1341,7 @@ jobs:
         run: make kube-ovn-ic-conformance-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           for cluster in `kind get clusters`; do
             kubectl config use-context kind-$cluster
@@ -1400,13 +1352,13 @@ jobs:
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: kube-ovn-ic-conformance-e2e-${{ matrix.ip-family }}-events
           path: kube-ovn-ic-conformance-e2e-${{ matrix.ip-family }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           for cluster in `kind get clusters`; do
             docker cp $cluster-control-plane:/var/log/kubernetes/kube-apiserver-audit.log \
@@ -1417,13 +1369,19 @@ jobs:
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: kube-ovn-ic-conformance-e2e-${{ matrix.ip-family }}-audit-log
           path: kube-ovn-ic-conformance-e2e-${{ matrix.ip-family }}-audit-log.tar.gz
 
+
+      - name: Check kube ovn pod restarts
+        id: check-restarts
+        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')) }}
+        run: make check-kube-ovn-pod-restarts
+
       - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           for cluster in `kind get clusters`; do
             kubectl config use-context kind-$cluster
@@ -1435,28 +1393,10 @@ jobs:
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
           name: kube-ovn-ic-conformance-e2e-${{ matrix.ip-family }}-ko-log
           path: kube-ovn-ic-conformance-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: Check kube ovn pod restarts
-        id: check-restarts
-        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')) }}
-        run: make check-kube-ovn-pod-restarts
-
-      - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-ic-conformance-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
-        with:
-          name: kube-ovn-ic-conformance-e2e-restarts-ko-log
-          path: kube-ovn-ic-conformance-e2e-ko-log.tar.gz
 
   multus-conformance-e2e:
     name: Multus Conformance E2E
@@ -1563,43 +1503,31 @@ jobs:
         run: make kube-ovn-multus-conformance-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > multus-conformance-e2e-${{ matrix.ip-family }}-events.yaml
           tar zcf multus-conformance-e2e-${{ matrix.ip-family }}-events.tar.gz multus-conformance-e2e-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: multus-conformance-e2e-${{ matrix.ip-family }}-events
           path: multus-conformance-e2e-${{ matrix.ip-family }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf multus-conformance-e2e-${{ matrix.ip-family }}-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: multus-conformance-e2e-${{ matrix.ip-family }}-audit-log
           path: multus-conformance-e2e-${{ matrix.ip-family }}-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz multus-conformance-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: multus-conformance-e2e-${{ matrix.ip-family }}-ko-log
-          path: multus-conformance-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -1607,17 +1535,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz multus-conformance-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz multus-conformance-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: multus-conformance-e2e-restarts-ko-log
-          path: multus-conformance-e2e-ko-log.tar.gz
+          name: multus-conformance-e2e-${{ matrix.ip-family }}-ko-log
+          path: multus-conformance-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
   non-primary-cni-e2e:
     name: Non-Primary CNI E2E
@@ -1734,44 +1662,31 @@ jobs:
         run: make kube-ovn-non-primary-cni-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > non-primary-cni-e2e-${{ matrix.ip-family }}-events.yaml
           tar zcf non-primary-cni-e2e-${{ matrix.ip-family }}-events.tar.gz non-primary-cni-e2e-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: non-primary-cni-e2e-${{ matrix.ip-family }}-events
           path: non-primary-cni-e2e-${{ matrix.ip-family }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf non-primary-cni-e2e-${{ matrix.ip-family }}-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: non-primary-cni-e2e-${{ matrix.ip-family }}-audit-log
           path: non-primary-cni-e2e-${{ matrix.ip-family }}-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        working-directory: ${{ env.E2E_DIR }}
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log
-          path: non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -1779,17 +1694,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz non-primary-cni-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: non-primary-cni-e2e-restarts-ko-log
-          path: non-primary-cni-e2e-ko-log.tar.gz
+          name: non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log
+          path: non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
   chart-test:
     name: Chart Installation/Uninstallation Test
@@ -1848,17 +1763,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz chart-test-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz chart-test-${{ matrix.ssl }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: chart-test-restarts-ko-log
-          path: chart-test-ko-log.tar.gz
+          name: chart-test-${{ matrix.ssl }}-ko-log
+          path: chart-test-${{ matrix.ssl }}-ko-log.tar.gz
 
       - name: Uninstall Kube-OVN
         run: make uninstall-chart
@@ -1912,16 +1827,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz underlay-logical-gateway-installation-test-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: underlay-logical-gateway-installation-test-restarts-ko-log
+          name: underlay-logical-gateway-installation-test-ko-log
           path: underlay-logical-gateway-installation-test-ko-log.tar.gz
 
       - name: Cleanup
@@ -1978,16 +1893,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz no-ovn-lb-test-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: no-ovn-lb-test-restarts-ko-log
+          name: no-ovn-lb-test-ko-log
           path: no-ovn-lb-test-ko-log.tar.gz
 
       - name: Cleanup
@@ -2044,16 +1959,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz no-np-test-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: no-np-test-restarts-ko-log
+          name: no-np-test-ko-log
           path: no-np-test-ko-log.tar.gz
 
       - name: Cleanup
@@ -2161,43 +2076,31 @@ jobs:
         run: make kube-ovn-lb-svc-conformance-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > lb-svc-e2e-events.yaml
           tar zcf lb-svc-e2e-events.tar.gz lb-svc-e2e-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: lb-svc-e2e-events
           path: lb-svc-e2e-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf lb-svc-e2e-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: lb-svc-e2e-audit-log
           path: lb-svc-e2e-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz lb-svc-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: lb-svc-e2e-ko-log
-          path: lb-svc-e2e-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -2205,16 +2108,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz lb-svc-e2e-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: lb-svc-e2e-restarts-ko-log
+          name: lb-svc-e2e-ko-log
           path: lb-svc-e2e-ko-log.tar.gz
 
   webhook-e2e:
@@ -2311,18 +2214,6 @@ jobs:
           E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: make kube-ovn-webhook-e2e
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz webhook-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: webhook-e2e-ko-log
-          path: webhook-e2e-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -2330,16 +2221,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz webhook-e2e-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: webhook-e2e-restarts-ko-log
+          name: webhook-e2e-ko-log
           path: webhook-e2e-ko-log.tar.gz
 
   installation-compatibility-test:
@@ -2397,30 +2288,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz installation-compatibility-test-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz installation-compatibility-test-${{ matrix.k8s-version }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: installation-compatibility-test-restarts-ko-log
-          path: installation-compatibility-test-ko-log.tar.gz
-
-      - name: kubectl ko log
-        if: failure() && steps.install.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz installation-compatibility-test-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.install.conclusion == 'failure'
-        with:
-          name: installation-compatibility-test-ko-log
-          path: installation-compatibility-test-ko-log.tar.gz
+          name: installation-compatibility-test-${{ matrix.k8s-version }}-ko-log
+          path: installation-compatibility-test-${{ matrix.k8s-version }}-ko-log.tar.gz
 
       - name: Cleanup
         run: timeout -k 10 180 sh -x dist/images/cleanup.sh
@@ -2499,17 +2377,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts || make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz talos-installation-test-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz talos-installation-test-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: talos-installation-test-restarts-ko-log
-          path: talos-installation-test-ko-log.tar.gz
+          name: talos-installation-test-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log
+          path: talos-installation-test-${{ matrix.ip-family }}-${{ matrix.mode }}-ko-log.tar.gz
 
   kube-ovn-cnp-domain-e2e:
     name: Kube-OVN CNP Domain E2E
@@ -2629,14 +2507,14 @@ jobs:
         run: make kube-ovn-cnp-domain-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
           tar zcf kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: kube-ovn-cnp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events
           path: kube-ovn-cnp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz
@@ -2647,17 +2525,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-cnp-domain-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz kube-ovn-cnp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: kube-ovn-cnp-domain-e2e-restarts-ko-log
-          path: kube-ovn-cnp-domain-e2e-ko-log.tar.gz
+          name: kube-ovn-cnp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log
+          path: kube-ovn-cnp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
   kube-ovn-anp-domain-e2e:
     name: Kube-OVN ANP Domain E2E
@@ -2777,14 +2655,14 @@ jobs:
         run: make kube-ovn-anp-domain-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
           tar zcf kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events
           path: kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz
@@ -2795,17 +2673,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-anp-domain-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: kube-ovn-anp-domain-e2e-restarts-ko-log
-          path: kube-ovn-anp-domain-e2e-ko-log.tar.gz
+          name: kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log
+          path: kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
   cilium-chaining-e2e:
     name: Cilium Chaining E2E
@@ -2926,43 +2804,31 @@ jobs:
         run: make k8s-conformance-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
           tar zcf cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events
           path: cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-audit-log
           path: cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: cilium-chaining-e2e-ko-log
-          path: cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -2970,17 +2836,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz cilium-chaining-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: cilium-chaining-e2e-restarts-ko-log
-          path: cilium-chaining-e2e-ko-log.tar.gz
+          name: cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log
+          path: cilium-chaining-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Cleanup
         run: timeout -k 10 180 sh -x dist/images/cleanup.sh
@@ -3098,18 +2964,6 @@ jobs:
           make kube-ovn-security-e2e
           make kube-ovn-ha-e2e
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log
-          path: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -3117,17 +2971,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-ha-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: kube-ovn-ha-e2e-restarts-ko-log
-          path: kube-ovn-ha-e2e-ko-log.tar.gz
+          name: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log
+          path: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Cleanup
         run: timeout -k 10 180 sh -x dist/images/cleanup.sh
@@ -3207,18 +3061,6 @@ jobs:
         working-directory: ${{ env.E2E_DIR }}
         run: make kube-ovn-submariner-conformance-e2e
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-submariner-conformance-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: kube-ovn-submariner-conformance-e2e-ko-log
-          path: kube-ovn-submariner-conformance-e2e-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -3226,16 +3068,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz kube-ovn-submariner-conformance-e2e-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: kube-ovn-submariner-conformance-e2e-restarts-ko-log
+          name: kube-ovn-submariner-conformance-e2e-ko-log
           path: kube-ovn-submariner-conformance-e2e-ko-log.tar.gz
 
       - name: Cleanup
@@ -3348,43 +3190,31 @@ jobs:
         run: make vpc-egress-gateway-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > vpc-egress-gateway-e2e-${{ matrix.ip-family }}-events.yaml
           tar zcf vpc-egress-gateway-e2e-${{ matrix.ip-family }}-events.tar.gz vpc-egress-gateway-e2e-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: vpc-egress-gateway-e2e-${{ matrix.ip-family }}-events
           path: vpc-egress-gateway-e2e-${{ matrix.ip-family }}-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf vpc-egress-gateway-e2e-${{ matrix.ip-family }}-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: vpc-egress-gateway-e2e-${{ matrix.ip-family }}-audit-log
           path: vpc-egress-gateway-e2e-${{ matrix.ip-family }}-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz vpc-egress-gateway-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: vpc-egress-gateway-e2e-${{ matrix.ip-family }}-ko-log
-          path: vpc-egress-gateway-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -3392,17 +3222,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz vpc-egress-gateway-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz vpc-egress-gateway-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: vpc-egress-gateway-e2e-restarts-ko-log
-          path: vpc-egress-gateway-e2e-ko-log.tar.gz
+          name: vpc-egress-gateway-e2e-${{ matrix.ip-family }}-ko-log
+          path: vpc-egress-gateway-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Check valgrind result
         run: |
@@ -3539,43 +3369,31 @@ jobs:
         run: make iptables-vpc-nat-gw-conformance-e2e
 
       - name: Collect k8s events
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > iptables-vpc-nat-gw-conformance-e2e-events.yaml
           tar zcf iptables-vpc-nat-gw-conformance-e2e-events.tar.gz iptables-vpc-nat-gw-conformance-e2e-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: iptables-vpc-nat-gw-conformance-e2e-events
           path: iptables-vpc-nat-gw-conformance-e2e-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf iptables-vpc-nat-gw-conformance-e2e-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: iptables-vpc-nat-gw-conformance-e2e-audit-log
           path: iptables-vpc-nat-gw-conformance-e2e-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && steps.e2e.conclusion == 'failure'
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz iptables-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && steps.e2e.conclusion == 'failure'
-        with:
-          name: iptables-vpc-nat-gw-conformance-e2e-ko-log
-          path: iptables-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -3583,16 +3401,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz iptables-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: iptables-vpc-nat-gw-conformance-e2e-restarts-ko-log
+          name: iptables-vpc-nat-gw-conformance-e2e-ko-log
           path: iptables-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
 
   ovn-vpc-nat-gw-conformance-e2e:
@@ -3696,43 +3514,31 @@ jobs:
         run: make ovn-vpc-nat-gw-conformance-e2e
 
       - name: Collect k8s events
-        if: failure() && (steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > ovn-vpc-nat-gw-conformance-e2e-events.yaml
           tar zcf ovn-vpc-nat-gw-conformance-e2e-events.tar.gz ovn-vpc-nat-gw-conformance-e2e-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
         with:
           name: ovn-vpc-nat-gw-conformance-e2e-events
           path: ovn-vpc-nat-gw-conformance-e2e-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && (steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf ovn-vpc-nat-gw-conformance-e2e-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
         with:
           name: ovn-vpc-nat-gw-conformance-e2e-audit-log
           path: ovn-vpc-nat-gw-conformance-e2e-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && (steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz ovn-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && (steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure')
-        with:
-          name: ovn-vpc-nat-gw-conformance-e2e-ko-log
-          path: ovn-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -3740,16 +3546,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz ovn-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.vip-e2e.conclusion == 'failure' || steps.vpc-e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: ovn-vpc-nat-gw-conformance-e2e-restarts-ko-log
+          name: ovn-vpc-nat-gw-conformance-e2e-ko-log
           path: ovn-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
 
   kube-ovn-ipsec-e2e:
@@ -3846,43 +3652,31 @@ jobs:
         run: make kube-ovn-ipsec-e2e
 
       - name: Collect k8s events
-        if: failure() && ( steps.ovn-ipsec-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > kube-ovn-ipsec-e2e-events.yaml
           tar zcf kube-ovn-ipsec-e2e-events.tar.gz kube-ovn-ipsec-e2e-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
         with:
           name: kube-ovn-ipsec-e2e-events
           path: kube-ovn-ipsec-e2e-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && (steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf kube-ovn-ipsec-e2e-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
         with:
           name: kube-ovn-ipsec-e2e-audit-log
           path: kube-ovn-ipsec-e2e-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && (steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-ipsec-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-ipsec-e2e.conclusion == 'failure')
-        with:
-          name: kube-ovn-ipsec-e2e-ko-log
-          path: kube-ovn-ipsec-e2e-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -3892,16 +3686,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz kube-ovn-ipsec-e2e-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: kube-ovn-ipsec-e2e-restarts-ko-log
+          name: kube-ovn-ipsec-e2e-ko-log
           path: kube-ovn-ipsec-e2e-ko-log.tar.gz
 
   kube-ovn-ipsec-cert-mgr-e2e:
@@ -3998,43 +3792,31 @@ jobs:
         run: make kube-ovn-ipsec-cert-mgr-e2e
 
       - name: Collect k8s events
-        if: failure() && ( steps.ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > kube-ovn-ipsec-cert-mgr-e2e-events.yaml
           tar zcf kube-ovn-ipsec-cert-mgr-e2e-events.tar.gz kube-ovn-ipsec-cert-mgr-e2e-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
         with:
           name: kube-ovn-ipsec-cert-mgr-e2e-events
           path: kube-ovn-ipsec-cert-mgr-e2e-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && (steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf kube-ovn-ipsec-cert-mgr-e2e-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-ipse-cert-mgrc-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
         with:
           name: kube-ovn-ipsec-cert-mgr-e2e-audit-log
           path: kube-ovn-ipsec-cert-mgr-e2e-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && (steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-ipsec-cert-mgr-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure')
-        with:
-          name: kube-ovn-ipsec-cert-mgr-e2e-ko-log
-          path: kube-ovn-ipsec-cert-mgr-e2e-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -4042,16 +3824,16 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz kube-ovn-ipsec-cert-mgr-e2e-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-ipsec-cert-mgr-e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: kube-ovn-ipsec-cert-mgr-e2e-restarts-ko-log
+          name: kube-ovn-ipsec-cert-mgr-e2e-ko-log
           path: kube-ovn-ipsec-cert-mgr-e2e-ko-log.tar.gz
 
   kube-ovn-connectivity-test:
@@ -4154,14 +3936,14 @@ jobs:
         run: make kube-ovn-connectivity-e2e
 
       - name: kubectl ko log
-        if: failure() && (steps.e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz kube-ovn-connectivity-e2e-${{ matrix.mode }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-connectivity-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         with:
           name: kube-ovn-connectivity-e2e-${{ matrix.mode }}-ko-log
           path: kube-ovn-connectivity-e2e-${{ matrix.mode }}-ko-log.tar.gz
@@ -4277,43 +4059,31 @@ jobs:
         run: make kube-ovn-underlay-metallb-e2e
 
       - name: Collect k8s events
-        if: failure() && (steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
         run: |
           kubectl get events -A -o yaml > kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-events.yaml
           tar zcf kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-events.tar.gz kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
         with:
           name: kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-events
           path: kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-events.tar.gz
 
       - name: Collect apiserver audit logs
-        if: failure() && (steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
         run: |
           docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
           tar zcf kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-audit-log.tar.gz kube-apiserver-audit.log
 
       - name: Upload apiserver audit logs
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
         with:
           name: kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-audit-log
           path: kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-audit-log.tar.gz
 
-      - name: kubectl ko log
-        if: failure() && (steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && (steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure')
-        with:
-          name: kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-ko-log
-          path: kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-ko-log.tar.gz
 
       - name: Check kube ovn pod restarts
         id: check-restarts
@@ -4321,17 +4091,17 @@ jobs:
         run: make check-kube-ovn-pod-restarts
 
       - name: kubectl ko log
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz kube-ovn-underlay-metallb-e2e-ko-log.tar.gz
+          mv kubectl-ko-log.tar.gz kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && steps.check-restarts.conclusion == 'failure'
+        if: failure() && (steps.install.conclusion == 'failure' || steps.kube-ovn-underlay-metallb-e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: kube-ovn-underlay-metallb-e2e-restarts-ko-log
-          path: kube-ovn-underlay-metallb-e2e-ko-log.tar.gz
+          name: kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-ko-log
+          path: kube-ovn-underlay-metallb-${{ matrix.ip-family }}-e2e-ko-log.tar.gz
 
   push:
     name: Push Images


### PR DESCRIPTION
## Summary

- Merge duplicate ko-log upload steps (e2e-failure + restarts-failure) into one unified pair per job, eliminating 230 lines of duplication
- Fix artifact name conflicts: all ko-log artifacts now include full matrix variables to prevent collisions across matrix combinations
- Expand events/audit-log/ko-log collection conditions to also trigger on install step failures
- Fix 5 existing bugs: wrong step IDs in ipsec/ipsec-cert-mgr/connectivity jobs and missing matrix vars in cilium-chaining artifact name

## Test plan

- [ ] Verify all E2E jobs still collect logs correctly on failure
- [ ] Confirm no artifact name collisions across matrix combinations
- [ ] Check that install failures now trigger log collection
- [ ] Validate YAML syntax is correct (verified locally with `yaml.safe_load`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)