### PR TITLE
ci: wait for control-plane nodes before labeling in chart install

### DIFF
--- a/.github/workflows/helm-testing.yaml
+++ b/.github/workflows/helm-testing.yaml
@@ -54,6 +54,7 @@ jobs:
       - name: Run chart-testing (install)
         id: install
         run: |
+          timeout 120 bash -c 'until kubectl get node -l node-role.kubernetes.io/control-plane -o name 2>/dev/null | grep -q .; do echo "Waiting for control-plane nodes to be labeled..."; sleep 2; done'
           kubectl label node --overwrite -l node-role.kubernetes.io/control-plane kube-ovn/role=master
           ct install --target-branch ${{ github.event.repository.default_branch }} --config charts/kube-ovn-v2/ct.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ check-kube-ovn-pod-restarts:
 
 .PHONY: install-chart
 install-chart:
+	@timeout 120 bash -c 'until kubectl get node -l node-role.kubernetes.io/control-plane -o name 2>/dev/null | grep -q .; do echo "Waiting for control-plane nodes to be labeled..."; sleep 2; done'
 	kubectl label node --overwrite -l node-role.kubernetes.io/control-plane kube-ovn/role=master
 	helm install kubeovn ./charts/kube-ovn --wait \
 		--set global.images.kubeovn.tag=$(VERSION) \
@@ -250,6 +251,7 @@ upgrade-chart:
 
 .PHONY: install-chart-v2
 install-chart-v2:
+	@timeout 120 bash -c 'until kubectl get node -l node-role.kubernetes.io/control-plane -o name 2>/dev/null | grep -q .; do echo "Waiting for control-plane nodes to be labeled..."; sleep 2; done'
 	kubectl label node --overwrite -l node-role.kubernetes.io/control-plane kube-ovn/role=master
 	helm install kubeovn ./charts/kube-ovn-v2 --wait \
 		--set global.images.kubeovn.tag=$(VERSION) \


### PR DESCRIPTION
## Summary
- Talos installation tests intermittently fail because `kubectl label node -l node-role.kubernetes.io/control-plane kube-ovn/role=master` silently succeeds (exit 0) when no nodes match the selector, leaving no nodes with `kube-ovn/role=master`
- The subsequent `helm install` then fails at template rendering (`_helpers.tpl`) because `lookup` finds no nodes with that label
- Add a polling loop (up to 120s) before `kubectl label` that waits for at least one node with `node-role.kubernetes.io/control-plane` to appear

## Test plan
- [ ] Verify Talos installation tests (overlay/underlay × ipv4/ipv6/dual) pass consistently
- [ ] Verify helm-testing workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)