### PR TITLE
fix: protect ANP/BNP/CNP priority maps from concurrent access

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -68,12 +69,13 @@ const (
 type Controller struct {
 	config *Configuration
 
-	ipam           *ovnipam.IPAM
-	namedPort      *NamedPort
-	anpPrioNameMap map[int32]string
-	anpNamePrioMap map[string]int32
-	bnpPrioNameMap map[int32]string
-	bnpNamePrioMap map[string]int32
+	ipam             *ovnipam.IPAM
+	namedPort        *NamedPort
+	anpPrioNameMap   map[int32]string
+	anpNamePrioMap   map[string]int32
+	bnpPrioNameMap   map[int32]string
+	bnpNamePrioMap   map[string]int32
+	priorityMapMutex sync.RWMutex
 
 	OVNNbClient ovs.NbClient
 	OVNSbClient ovs.SbClient


### PR DESCRIPTION
## Summary
- Add `sync.RWMutex` (`priorityMapMutex`) to protect `anpPrioNameMap`, `anpNamePrioMap`, `bnpPrioNameMap`, `bnpNamePrioMap` from concurrent read/write across ANP and CNP handler goroutines
- ANP/CNP handlers use different per-key mutexes (`anpKeyMutex` vs `cnpKeyMutex`), which cannot protect shared map access — concurrent map read/write causes `fatal error: concurrent map read and map write`
- Write lock for add/delete handlers, read lock for update handler's validation-only path

Ref: antrea-io/antrea#7717 — same race condition pattern discovered in Antrea

## Test plan
- [x] `make lint` — 0 issues
- [x] `make build-go` — compilation passes
- [x] `go test -race ./pkg/controller/... -run "TestAnp|TestCnp"` — all tests pass with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)