### PR TITLE
fix(e2e): stabilize ANP domain E2E tests and fix hasDomainNames override bug

### DIFF
--- a/pkg/controller/admin_network_policy.go
+++ b/pkg/controller/admin_network_policy.go
@@ -320,7 +320,7 @@ func (c *Controller) handleAddAnp(key string) (err error) {
 			v6Addrs = append(v6Addrs, v6Addr...)
 
 			// Check if this peer has domain names
-			hasDomainNames = len(anprpeer.DomainNames) > 0
+			hasDomainNames = hasDomainNames || len(anprpeer.DomainNames) > 0
 		}
 		klog.Infof("anp %s, egress rule %s, selected v4 address %v, v6 address %v", anpName, anpr.Name, v4Addrs, v6Addrs)
 


### PR DESCRIPTION
## Summary
- Fix flaky ANP domain E2E test by aligning with already-fixed CNP domain tests: add `waitForDNSResolversCreated()` and increase retry parameters from 20x1s to 30x3s
- Fix `hasDomainNames` override bug in `admin_network_policy.go` where the variable was overwritten instead of accumulated across peers, potentially skipping ACL creation

## Root Cause
The test "should dynamically add and remove domainName deny rules in a single ANP" failed because:
1. The CoreDNS `dnsnameresolver` plugin works **reactively** - it only intercepts DNS queries that actually flow through CoreDNS
2. The test pre-warmed google.com DNS cache (TTL ~300s) before adding the deny rule
3. With only 20x1s retries (~29s window), the DNS cache never expired, so the plugin never intercepted queries and the address set remained empty
4. The deny rule never took effect → test failed after 20 attempts

## Changes
- `test/e2e/anp-domain/e2e_test.go`:
  - Add `waitForDNSResolversCreated()` helper (same pattern as CNP domain tests)
  - Call it in all 5 test cases before testing deny rules
  - Increase default retry from `20 × 1s` to `30 × 3s` (matching CNP tests)
- `pkg/controller/admin_network_policy.go`:
  - Fix `hasDomainNames = len(anprpeer.DomainNames) > 0` → `hasDomainNames = hasDomainNames || len(anprpeer.DomainNames) > 0`

## Test plan
- [ ] ANP domain E2E tests pass consistently (no more flaky failures)
- [ ] Verify hasDomainNames fix with multi-peer egress rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)