### PR TITLE
test(e2e): increase VPC egress gateway curl timeout to 2 minutes

### DIFF
--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -456,7 +456,7 @@ func checkEgressAccess(f *framework.Framework, namespaceName, svrPodName, image,
 		cmd := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s/clientip", net.JoinHostPort(svrIP, svrPort))
 		ginkgo.By(fmt.Sprintf(`Executing %q in pod %s/%s`, cmd, pod.Namespace, pod.Name))
 		var clientIP string
-		framework.WaitUntil(time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+		framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
 			output, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, cmd)
 			if err != nil {
 				return false, nil


### PR DESCRIPTION
## Summary
- Increase the curl wait timeout in `checkEgressAccess()` from 30s to 2min to fix flaky VPC Egress Gateway E2E tests in IPv6 environments
- BFD sessions in IPv6 KIND environments may take longer to establish, causing the always-active DROP rule (priority 29090) to catch traffic before the BFD-gated reroute rules (priority 29150/29100) become active

## Test plan
- [ ] VPC Egress Gateway E2E (ipv6) should pass consistently
- [ ] VPC Egress Gateway E2E (ipv4/dual) should not be affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)