### PR TITLE
refactor(daemon): stream OpenFlow entries to ovs-ofctl and skip no-op replace-flows

### DIFF
--- a/pkg/daemon/flow_sync_linux.go
+++ b/pkg/daemon/flow_sync_linux.go
@@ -53,14 +53,17 @@ func (c *Controller) syncFlows() {
 
 		preserved := filterUnmanagedFlows(existing)
 		cachedFlows := flowCacheByBridge[bridgeName]
-		finalFlows := append(preserved, cachedFlows...)
 
-		if err := ovs.ReplaceFlows(bridgeName, finalFlows); err != nil {
-			klog.Errorf("failed to replace flows for bridge %s: %v", bridgeName, err)
+		// Skip replace-flows when there are no cached flows to add and no
+		// managed flows to remove (preserved == existing means nothing was filtered).
+		if len(cachedFlows) == 0 && len(preserved) == len(existing) {
+			klog.V(5).Infof("no managed flows for bridge %s, skipping replace-flows", bridgeName)
 			continue
 		}
-		if len(cachedFlows) == 0 {
-			klog.V(5).Infof("no cached flows for bridge %s", bridgeName)
+
+		finalFlows := append(preserved, cachedFlows...)
+		if err := ovs.ReplaceFlows(bridgeName, finalFlows); err != nil {
+			klog.Errorf("failed to replace flows for bridge %s: %v", bridgeName, err)
 			continue
 		}
 		klog.V(3).Infof("synced %d cached flows on bridge %s", len(cachedFlows), bridgeName)

--- a/pkg/ovs/ovs-ofctl.go
+++ b/pkg/ovs/ovs-ofctl.go
@@ -2,6 +2,7 @@ package ovs
 
 import (
 	"fmt"
+	"io"
 	"os/exec"
 	"slices"
 	"strings"
@@ -11,6 +12,60 @@ import (
 
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+// openFlowStdinReader incrementally renders a flow slice as a newline-delimited
+// stream for ovs-ofctl stdin without constructing one large joined string.
+type openFlowStdinReader struct {
+	flows      []string
+	flowIndex  int
+	flowOffset int
+	needEOL    bool
+}
+
+// Read implements io.Reader over r.flows, producing output equivalent to
+// strings.Join(flows, "\n"), but in small chunks to reduce peak allocations.
+func (r *openFlowStdinReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.flowIndex >= len(r.flows) && !r.needEOL {
+		return 0, io.EOF
+	}
+
+	total := 0
+	for total < len(p) {
+		if r.needEOL {
+			p[total] = '\n'
+			total++
+			r.needEOL = false
+			if total == len(p) {
+				return total, nil
+			}
+			continue
+		}
+
+		if r.flowIndex >= len(r.flows) {
+			break
+		}
+
+		flow := r.flows[r.flowIndex]
+		if r.flowOffset >= len(flow) {
+			r.flowIndex++
+			r.flowOffset = 0
+			r.needEOL = r.flowIndex < len(r.flows)
+			continue
+		}
+
+		copied := copy(p[total:], flow[r.flowOffset:])
+		total += copied
+		r.flowOffset += copied
+	}
+
+	if total == 0 {
+		return 0, io.EOF
+	}
+	return total, nil
+}
 
 func DumpFlows(client *ovs.Client, bridgeName string) ([]string, error) {
 	flows, err := client.OpenFlow.DumpFlows(bridgeName)
@@ -35,11 +90,10 @@ func DumpFlows(client *ovs.Client, bridgeName string) ([]string, error) {
 }
 
 // ReplaceFlows uses ovs-ofctl replace-flows because go-openvswitch does not provide a native API.
+// It streams flows to ovs-ofctl stdin to avoid allocating a large joined string.
 func ReplaceFlows(bridgeName string, flows []string) error {
-	flowData := strings.Join(flows, "\n")
-
 	cmd := exec.Command("ovs-ofctl", "--bundle", "replace-flows", bridgeName, "-")
-	cmd.Stdin = strings.NewReader(flowData)
+	cmd.Stdin = &openFlowStdinReader{flows: flows}
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/ovs/ovs-ofctl_test.go
+++ b/pkg/ovs/ovs-ofctl_test.go
@@ -1,0 +1,159 @@
+package ovs
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenFlowStdinReader(t *testing.T) {
+	tests := []struct {
+		name  string
+		flows []string
+	}{
+		{
+			name:  "empty",
+			flows: nil,
+		},
+		{
+			name:  "single flow",
+			flows: []string{"table=0,priority=100,actions=output:1"},
+		},
+		{
+			name:  "multiple flows",
+			flows: []string{"table=0,priority=100,actions=output:1", "table=0,priority=50,actions=drop"},
+		},
+		{
+			name:  "empty string flow",
+			flows: []string{""},
+		},
+		{
+			name:  "trailing empty flow",
+			flows: []string{"table=0,priority=100,actions=output:1", ""},
+		},
+		{
+			name:  "many flows",
+			flows: makeBenchmarkFlows(100),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := strings.Join(tt.flows, "\n")
+
+			reader := &openFlowStdinReader{flows: tt.flows}
+			got, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, expected, string(got))
+		})
+	}
+}
+
+func TestOpenFlowStdinReaderSmallBuffer(t *testing.T) {
+	flows := []string{"table=0,priority=100,actions=output:1", "table=0,priority=50,actions=drop"}
+	expected := strings.Join(flows, "\n")
+
+	reader := &openFlowStdinReader{flows: flows}
+	var result []byte
+	buf := make([]byte, 3) // deliberately small buffer
+	for {
+		n, err := reader.Read(buf)
+		result = append(result, buf[:n]...)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+	}
+	require.Equal(t, expected, string(result))
+}
+
+func TestOpenFlowStdinReaderZeroLenRead(t *testing.T) {
+	reader := &openFlowStdinReader{flows: []string{"flow1"}}
+	n, err := reader.Read(nil)
+	require.Equal(t, 0, n)
+	require.NoError(t, err)
+}
+
+var benchmarkFlowBytesSink int64
+
+func BenchmarkReplaceFlowsInputRendering(b *testing.B) {
+	benchCases := []struct {
+		name      string
+		flowCount int
+	}{
+		{name: "100_flows", flowCount: 100},
+		{name: "1k_flows", flowCount: 1000},
+		{name: "5k_flows", flowCount: 5000},
+	}
+
+	for _, tc := range benchCases {
+		flows := makeBenchmarkFlows(tc.flowCount)
+		totalBytes := benchmarkFlowsBytes(flows)
+
+		b.Run(tc.name+"/join", func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(totalBytes)
+			for b.Loop() {
+				stdin := strings.NewReader(strings.Join(flows, "\n"))
+				written, err := io.Copy(io.Discard, stdin)
+				if err != nil {
+					b.Fatalf("failed to drain: %v", err)
+				}
+				benchmarkFlowBytesSink = written
+			}
+		})
+
+		b.Run(tc.name+"/stream", func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(totalBytes)
+			for b.Loop() {
+				stdin := &openFlowStdinReader{flows: flows}
+				written, err := io.Copy(io.Discard, stdin)
+				if err != nil {
+					b.Fatalf("failed to drain: %v", err)
+				}
+				benchmarkFlowBytesSink = written
+			}
+		})
+	}
+}
+
+func makeBenchmarkFlows(count int) []string {
+	flows := make([]string, count)
+	const suffix = ",ip,nw_src=10.128.0.0/14,tp_dst=8080,actions=ct(commit),output:2"
+	for i := range flows {
+		flows[i] = "table=0,priority=100,in_port=1,reg0=0x1" + suffix
+	}
+	return flows
+}
+
+func benchmarkFlowsBytes(flows []string) int64 {
+	if len(flows) == 0 {
+		return 0
+	}
+	total := len(flows) - 1 // newline delimiters
+	for _, flow := range flows {
+		total += len(flow)
+	}
+	return int64(total)
+}
+
+func BenchmarkOpenFlowStdinReaderEquivalence(b *testing.B) {
+	flows := makeBenchmarkFlows(1000)
+	expected := []byte(strings.Join(flows, "\n"))
+
+	for b.Loop() {
+		reader := &openFlowStdinReader{flows: flows}
+		got, err := io.ReadAll(reader)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !bytes.Equal(got, expected) {
+			b.Fatal("stream output does not match strings.Join")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Replace `strings.Join` + `strings.NewReader` in `ReplaceFlows` with a streaming `io.Reader` (`openFlowStdinReader`) that writes flow entries directly to ovs-ofctl stdin without allocating a large intermediate string. Reduces per-sync memory allocations from O(total flow bytes) to a constant 48 bytes.
- Skip the `replace-flows` call in `syncFlows` when a bridge has no cached flows **and** no managed flows installed (e.g. br-int), avoiding an unnecessary ovs-ofctl process invocation every 15 seconds.
- Add unit tests and benchmark tests for the streaming reader.

Inspired by upstream [ovn-org/ovn-kubernetes#5981](https://github.com/ovn-org/ovn-kubernetes/pull/5981).

### Benchmark results

| Scale | `strings.Join` | Streaming | Memory saved |
|-------|----------------|-----------|-------------|
| 100 flows | 10,912 B/op, 2 allocs | 48 B/op, 1 alloc | 99.6% |
| 1k flows | 106,528 B/op, 2 allocs | 48 B/op, 1 alloc | 99.95% |
| 5k flows | 524,320 B/op, 2 allocs | 48 B/op, 1 alloc | 99.99% |

## Test plan
- [x] Unit tests pass for `openFlowStdinReader` (empty, single, multiple, small buffer, empty-string edge cases)
- [x] Benchmark tests confirm allocation reduction
- [x] `make lint` passes with 0 issues
- [ ] E2E: verify underlay service flows are correctly synced on provider bridges
- [ ] E2E: verify br-int flows are unaffected (no managed flows, replace-flows skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)