### PR TITLE
ci: disable valgrind for metallb e2e and increase speaker rollout timeout

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -4025,14 +4025,6 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
-      - name: Set environment variables
-        run: |
-          if [ $(($RANDOM%2)) -ne 0 ]; then
-            # run as root and use valgrind to debug memory leak
-            echo "VERSION=$(cat VERSION)-debug" >> "$GITHUB_ENV"
-            echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
-          fi
-
       - name: Create kind cluster
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -515,7 +515,8 @@ kind-install-metallb:
 		--create-namespace \
 		--set speaker.frr.image.tag=$(FRR_VERSION)
 	$(call kubectl_wait_exist_and_ready,metallb-system,deployment,metallb-controller)
-	$(call kubectl_wait_exist_and_ready,metallb-system,daemonset,metallb-speaker)
+	$(call kubectl_wait_exist,metallb-system,daemonset,metallb-speaker)
+	kubectl -n metallb-system rollout status --timeout=120s daemonset metallb-speaker
 
 .PHONY: kind-configure-metallb
 kind-configure-metallb:


### PR DESCRIPTION
## Summary
- Remove the random valgrind debug wrapper selection from the metallb e2e job, as MetalLB is not a Kube-OVN component and wrapping OVN/OVS with valgrind provides no benefit for metallb tests
- Increase the metallb-speaker daemonset rollout timeout from 60s to 120s to accommodate FRR container's slow startup and the metallb-memberlist secret race condition

## Root Cause Analysis
The metallb e2e installation failure ([run #22609762649](https://github.com/kubeovn/kube-ovn/actions/runs/22609762649)) was caused by:
1. **memberlist secret race** (~15s): metallb-controller hadn't created `metallb-memberlist` secret yet when speaker pods started, causing `FailedMount`
2. **FRR slow startup** (~54s): FRR container's health probe endpoint returns HTTP 404 during initialization, especially slow under valgrind
3. **Liveness probe restart**: worker node's FRR container was killed and restarted due to liveness failure, adding another startup cycle
4. **60s timeout too tight**: total recovery time exceeded the hardcoded 60s rollout timeout

## Test plan
- [ ] Verify metallb e2e tests pass across all IP families (ipv4, ipv6, dual)
- [ ] Confirm metallb-speaker pods start within the new 120s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)