### PR TITLE
fix: kubevirt e2e subnet delete timeout and IP CRD label management

### DIFF
--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -48,7 +48,9 @@ func (c *Controller) enqueueUpdateIP(oldObj, newObj any) {
 	newIP := newObj.(*kubeovnv1.IP)
 	// ip can not change these specs below
 	if oldIP.Spec.Subnet != "" && newIP.Spec.Subnet != oldIP.Spec.Subnet {
-		klog.Errorf("ip %s subnet can not change", newIP.Name)
+		klog.Warningf("ip %s subnet changed from %s to %s", newIP.Name, oldIP.Spec.Subnet, newIP.Spec.Subnet)
+		c.updateSubnetStatusQueue.Add(oldIP.Spec.Subnet)
+		c.updateSubnetStatusQueue.Add(newIP.Spec.Subnet)
 		return
 	}
 	if oldIP.Spec.Namespace != "" && newIP.Spec.Namespace != oldIP.Spec.Namespace {
@@ -489,14 +491,20 @@ func (c *Controller) createOrUpdateIPCR(ipCRName, podName, ip, mac, subnetName, 
 	} else {
 		newIPCR := ipCR.DeepCopy()
 		if newIPCR.Labels != nil {
+			// Remove old subnet dynamic label if subnet changed
+			oldSubnet := ipCR.Spec.Subnet
+			if oldSubnet != "" && oldSubnet != subnetName {
+				delete(newIPCR.Labels, oldSubnet)
+			}
 			newIPCR.Labels[util.SubnetNameLabel] = subnetName
 			newIPCR.Labels[util.NodeNameLabel] = nodeName
+			newIPCR.Labels[subnetName] = ""
 		} else {
 			newIPCR.Labels = map[string]string{
 				util.SubnetNameLabel: subnetName,
 				util.NodeNameLabel:   nodeName,
+				subnetName:           "",
 			}
-			// update not touch IP Reserved Label
 		}
 		if owner != nil {
 			// currently we only set owner for node IP, u2o IP and mcast querier ip,

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -66,6 +66,12 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		ginkgo.By("Deleting vm " + vmName)
 		vmClient.DeleteSync(vmName)
 
+		// Wait for the VM's IP CRD to be fully cleaned up before deleting subnet
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+		ginkgo.By("Waiting for IP " + portName + " to be cleaned up")
+		err := ipClient.WaitToDisappear(portName, time.Second, 2*time.Minute)
+		framework.ExpectNoError(err)
+
 		ginkgo.By("Deleting subnet " + subnetName)
 		subnetClient.DeleteSync(subnetName)
 	})


### PR DESCRIPTION
## Summary
- Wait for the VM's IP CRD to be fully cleaned up before deleting subnet in kubevirt e2e `AfterEach`, preventing subnet finalizer removal timeout (seen in CI Run 22626703498, ipv6 underlay job)
- Fix `createOrUpdateIPCR` update path to properly manage dynamic subnet labels (`{subnetName: ""}`), ensuring `calcSubnetStatusIP` counts IPs correctly
- Trigger subnet status recalculation in `enqueueUpdateIP` when IP subnet changes (kubevirt VM restart with subnet change), downgrade log level from Error to Warning since this is a legitimate operation

## Test plan
- [ ] Verify `make lint` passes with 0 issues
- [ ] Verify `make ut` passes
- [ ] Run kubevirt e2e tests multiple times to confirm no subnet delete timeout
- [ ] Verify IP CRD labels are correctly updated when subnet changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)