### PR TITLE
ci: wait for metallb-memberlist secret before speaker rollout

### DIFF
--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -515,6 +515,7 @@ kind-install-metallb:
 		--create-namespace \
 		--set speaker.frr.image.tag=$(FRR_VERSION)
 	$(call kubectl_wait_exist_and_ready,metallb-system,deployment,metallb-controller)
+	$(call kubectl_wait_exist,metallb-system,secret,metallb-memberlist)
 	$(call kubectl_wait_exist,metallb-system,daemonset,metallb-speaker)
 	kubectl -n metallb-system rollout status --timeout=120s daemonset metallb-speaker
 


### PR DESCRIPTION
## Summary
- Wait for `metallb-memberlist` secret to exist before starting speaker daemonset rollout
- The secret is created asynchronously by metallb-controller; if speaker pods schedule before it exists, they hit FailedMount errors and FRR startup probe failures can exhaust the rollout timeout
- Uses the existing `kubectl_wait_exist` macro, inserted between controller ready check and speaker rollout

## Test plan
- [ ] Verify MetalLB E2E tests (IPv4/IPv6/dual) pass without speaker rollout timeout
- [ ] Confirm `kubectl_wait_exist` correctly polls for the secret resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)