### PR TITLE
Split ECMP next-hops in custom VPC policy routes

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -563,7 +563,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 	// add new policies
 	for _, item := range policyRouteNeedAdd {
 		klog.Infof("add policy route for router: %s, match %s, action %s, nexthop %s, externalID %v", c.config.ClusterRouter, item.Match, string(item.Action), item.NextHopIP, externalIDs)
-		if err = c.OVNNbClient.AddLogicalRouterPolicy(vpc.Name, item.Priority, item.Match, string(item.Action), []string{item.NextHopIP}, nil, externalIDs); err != nil {
+		if err = c.OVNNbClient.AddLogicalRouterPolicy(vpc.Name, item.Priority, item.Match, string(item.Action), strings.Split(item.NextHopIP, ","), nil, externalIDs); err != nil {
 			klog.Errorf("add policy route to vpc %s failed, %v", vpc.Name, err)
 			return err
 		}

--- a/pkg/controller/vpc_test.go
+++ b/pkg/controller/vpc_test.go
@@ -294,3 +294,74 @@ func Test_handleAddOrUpdateVpc_staticRoutes(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func Test_handleAddOrUpdateVpc_policyRoutes_ecmpNextHops(t *testing.T) {
+	t.Parallel()
+
+	vpcName := "test-vpc-policy"
+
+	t.Run("ECMP next-hops are split correctly for custom VPC policy routes", func(t *testing.T) {
+		fakeController := newFakeController(t)
+		ctrl := fakeController.fakeController
+		fakeinformers := fakeController.fakeInformers
+		mockOvnClient := fakeController.mockOvnClient
+
+		ctrl.vpcKeyMutex = keymutex.NewHashed(500)
+
+		vpc := &kubeovnv1.Vpc{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: vpcName,
+			},
+			Spec: kubeovnv1.VpcSpec{
+				StaticRoutes:   []*kubeovnv1.StaticRoute{},
+				EnableExternal: false,
+				PolicyRoutes: []*kubeovnv1.PolicyRoute{
+					{
+						Priority:  100,
+						Match:     "ip4.dst == 10.1.0.0/16",
+						Action:    kubeovnv1.PolicyRouteActionReroute,
+						NextHopIP: "192.168.1.1,192.168.1.2",
+					},
+				},
+			},
+			Status: kubeovnv1.VpcStatus{
+				Subnets:        []string{},
+				EnableExternal: false,
+			},
+		}
+
+		_, err := ctrl.config.KubeOvnClient.KubeovnV1().Vpcs().Create(context.Background(), vpc, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		err = fakeinformers.vpcInformer.Informer().GetStore().Add(vpc)
+		require.NoError(t, err)
+
+		externalIDs := map[string]string{"vendor": util.CniTypeName}
+
+		mockOvnClient.EXPECT().CreateLogicalRouter(vpcName).Return(nil)
+		mockOvnClient.EXPECT().UpdateLogicalRouter(gomock.Any(), gomock.Any()).Return(nil)
+		mockOvnClient.EXPECT().ListLogicalRouterStaticRoutes(vpcName, nil, nil, "", externalIDs).Return(nil, nil)
+		mockOvnClient.EXPECT().GetLogicalRouter(vpcName, false).Return(&ovnnb.LogicalRouter{
+			Name: vpcName,
+			Nat:  []string{},
+		}, nil)
+		// No existing policies in OVN for this custom VPC
+		mockOvnClient.EXPECT().ListLogicalRouterPolicies(vpcName, -1, nil, true).Return(nil, nil)
+		// The key assertion: next-hops must be split into a slice, not wrapped as one element
+		mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+			vpcName,
+			100,
+			"ip4.dst == 10.1.0.0/16",
+			string(kubeovnv1.PolicyRouteActionReroute),
+			[]string{"192.168.1.1", "192.168.1.2"},
+			([]string)(nil),
+			externalIDs,
+		).Return(nil)
+		mockOvnClient.EXPECT().ListLogicalSwitch(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalSwitch{}, nil).AnyTimes()
+		mockOvnClient.EXPECT().ListLogicalRouter(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalRouter{}, nil).AnyTimes()
+		mockOvnClient.EXPECT().DeleteLogicalRouterPort(fmt.Sprintf("bfd@%s", vpcName)).Return(nil)
+		mockOvnClient.EXPECT().DeleteHAChassisGroup(fmt.Sprintf("bfd@%s", vpcName)).Return(nil)
+		err = ctrl.handleAddOrUpdateVpc(vpcName)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Policy routes with multiple next-hop addresses (ECMP) were getting silently dropped for custom VPCs. The old code was passing the comma-separated NextHopIP as a single string in an array, when it should've been splitting them into individual addresses.

Fixed by using strings.Split to parse the addresses before passing to AddLogicalRouterPolicy. Added a test case to cover this scenario.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CODE_STYLE** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- Fixes #6401