### PR TITLE
fix(helm): allow explicit override of ovs-ovn DaemonSet update strategy

### DIFF
--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -36,28 +36,42 @@ Number of master nodes
   {{- len (split "," (.Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .))) }}
 {{- end -}}
 
+{{/*
+Determine the updateStrategy type for the ovs-ovn DaemonSet.
+If ovs-ovn.updateStrategy.type is set, use it directly.
+Otherwise, auto-detect based on the currently deployed DaemonSet.
+*/}}
 {{- define "kubeovn.ovs-ovn.updateStrategy" -}}
-  {{- $ds := lookup "apps/v1" "DaemonSet" $.Values.namespace "ovs-ovn" -}}
-  {{- if $ds -}}
-    {{- if eq $ds.spec.updateStrategy.type "RollingUpdate" -}}
-      RollingUpdate
-    {{- else -}}
-      {{- $chartVersion := index $ds.metadata.annotations "chart-version" }}
-      {{- $newChartVersion := printf "%s-%s" .Chart.Name .Chart.Version }}
-      {{- $imageVersion := (index $ds.spec.template.spec.containers 0).image | splitList ":" | last | trimPrefix "v" -}}
-      {{- $versionRegex := `^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)` -}}
-      {{- if and (ne $newChartVersion $chartVersion) (regexMatch $versionRegex $imageVersion) -}}
-        {{- if regexFind $versionRegex $imageVersion | semverCompare ">= 1.12.0" -}}
-          RollingUpdate
+  {{- $updateStrategy := index $.Values "ovs-ovn" "updateStrategy" -}}
+  {{- $desiredStrategy := "" -}}
+  {{- if $updateStrategy -}}
+    {{- $desiredStrategy = index $updateStrategy "type" -}}
+  {{- end -}}
+  {{- if $desiredStrategy -}}
+    {{- $desiredStrategy -}}
+  {{- else -}}
+    {{- $ds := lookup "apps/v1" "DaemonSet" $.Values.namespace "ovs-ovn" -}}
+    {{- if $ds -}}
+      {{- if eq $ds.spec.updateStrategy.type "RollingUpdate" -}}
+        RollingUpdate
+      {{- else -}}
+        {{- $chartVersion := index $ds.metadata.annotations "chart-version" }}
+        {{- $newChartVersion := printf "%s-%s" .Chart.Name .Chart.Version }}
+        {{- $imageVersion := (index $ds.spec.template.spec.containers 0).image | splitList ":" | last | trimPrefix "v" -}}
+        {{- $versionRegex := `^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)` -}}
+        {{- if and (ne $newChartVersion $chartVersion) (regexMatch $versionRegex $imageVersion) -}}
+          {{- if regexFind $versionRegex $imageVersion | semverCompare ">= 1.12.0" -}}
+            RollingUpdate
+          {{- else -}}
+            OnDelete
+          {{- end -}}
         {{- else -}}
           OnDelete
         {{- end -}}
-      {{- else -}}
-        OnDelete
       {{- end -}}
+    {{- else -}}
+      RollingUpdate
     {{- end -}}
-  {{- else -}}
-    RollingUpdate
   {{- end -}}
 {{- end -}}
 

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -11,11 +11,14 @@ spec:
   selector:
     matchLabels:
       app: ovs
+  {{- $updateStrategyType := include "kubeovn.ovs-ovn.updateStrategy" . | trim }}
   updateStrategy:
-    type: {{ include "kubeovn.ovs-ovn.updateStrategy" . }}
+    type: {{ $updateStrategyType }}
+    {{- if eq $updateStrategyType "RollingUpdate" }}
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+    {{- end }}
   template:
     metadata:
       labels:

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -161,6 +161,8 @@ ovn-central:
     memory: "4Gi"
     ephemeral-storage: 1Gi
 ovs-ovn:
+  updateStrategy:
+    type: ""  # Override the DaemonSet update strategy. Leave empty to auto-detect based on the deployed version.
   requests:
     cpu: "200m"
     memory: "200Mi"


### PR DESCRIPTION
  - [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).                                                                                 
                                                                                                                                                                                                          
## What type of this PR                                                                                                                                                                                 
                                                                                                                                                                                                          
- Bug fixes                                                                                                                                                                                             
                                                                                                                                                                                                          
## Description                                                                                                                                                                                          

Add `ovs-ovn.updateStrategy.type` to `values.yaml` so users can explicitly
set the update strategy instead of relying solely on auto-detection.

When the value is set, it takes precedence over the auto-detect logic.
Also fix `ovsovn-ds.yaml` to only render `rollingUpdate` config when the
strategy type is `RollingUpdate`, preventing invalid config for `OnDelete`.

## Which issue(s) this PR fixes
N/A