### PR TITLE
fix: FIP/DNAT/SNAT spec update cause rule deletion failed

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -289,12 +289,12 @@ function add_eip() {
 function del_eip() {
     # make sure inited
     check_inited
-    for rule in $@
+    for rule in "$@"
     do
         arr=(${rule//,/ })
         eip=${arr[0]}
         eip_without_prefix=(${eip//\// })
-        ipCidr=`ip addr show $EXTERNAL_INTERFACE | grep $eip | awk '{print $2 }'`
+        ipCidr=`ip addr show "$EXTERNAL_INTERFACE" | grep -w "$eip" | awk '{print $2 }'`
         if [ -n "$ipCidr" ]; then
             exec_cmd "ip addr del $ipCidr dev $EXTERNAL_INTERFACE"
         fi
@@ -309,50 +309,94 @@ function del_eip() {
 }
 
 function add_floating_ip() {
+    # Strict validation before adding (FIP is 1:1, identity = EIP):
+    # 1. If EIP rule does not exist -> create DNAT + SNAT rules
+    # 2. If EIP rule exists and internalIp matches -> return success (idempotent)
+    # 3. If EIP rule exists but internalIp mismatches -> return error (reject stale/conflicting data)
+    #
+    # iptables-save output format:
+    #   -A EXCLUSIVE_DNAT -d <eip>/32 -j DNAT --to-destination <internalIp>
+    #   -A EXCLUSIVE_SNAT -s <internalIp>/32 -j SNAT --to-source <eip>
+    # NOTE: Current FIP CRD/controller path sends one rule per invocation.
+    # The for-loop is currently of limited practical value.
+    # TODO: Consider removing the for-loop and avoid cache optimizations driven only by loop batching.
     # make sure inited
     check_inited
-    for rule in $@
+    for rule in "$@"
     do
         arr=(${rule//,/ })
         eip=(${arr[0]//\// })
         internalIp=${arr[1]}
-        # check if already exist
-        $iptables_save_cmd | grep EXCLUSIVE_DNAT | grep -w "\-d $eip/32" | grep destination && exit 0
+        # check if DNAT rule already exists for this eip: match "-d <eip>/32"
+        existingRule=$($iptables_save_cmd | grep EXCLUSIVE_DNAT | grep -w -- "-d $eip/32")
+        if [ -n "$existingRule" ]; then
+            # eip rule exists, check if internalIp matches: match "--to-destination <internalIp>"
+            echo "$existingRule" | grep -w -- "--to-destination $internalIp" > /dev/null 2>&1 && exit 0
+            # eip exists but internalIp mismatch
+            echo "eip $eip already bindTo rule: $existingRule, but expected internalIp $internalIp"
+            exit 1
+        fi
         exec_cmd "$iptables_cmd -t nat -A EXCLUSIVE_DNAT -d $eip -j DNAT --to-destination $internalIp"
         exec_cmd "$iptables_cmd -t nat -A EXCLUSIVE_SNAT -s $internalIp -j SNAT --to-source $eip"
     done
 }
 
 function del_floating_ip() {
+    # Lenient deletion (FIP is 1:1, identity = EIP): match by EIP only.
+    # If the rule exists -> extract the full rule from iptables-save and delete it
+    # If the rule does not exist -> treat as already deleted (no error)
+    #
+    # iptables-save output format:
+    #   -A EXCLUSIVE_DNAT -d <eip>/32 -j DNAT --to-destination <internalIp>
+    #   -A EXCLUSIVE_SNAT -s <internalIp>/32 -j SNAT --to-source <eip>
+    # NOTE: Current FIP CRD/controller path sends one rule per invocation.
+    # The for-loop is currently of limited practical value.
+    # TODO: Consider removing the for-loop and avoid cache optimizations driven only by loop batching.
     # make sure inited
     check_inited
-    for rule in $@
+    for eip in "$@"
     do
-        arr=(${rule//,/ })
-        eip=(${arr[0]//\// })
-        internalIp=${arr[1]}
-        # check if already exist
-        $iptables_save_cmd  | grep EXCLUSIVE_DNAT | grep -w "\-d $eip/32" | grep destination
-        if [ "$?" -eq 0 ];then
-            exec_cmd "$iptables_cmd -t nat -D EXCLUSIVE_DNAT -d $eip -j DNAT --to-destination $internalIp"
-            exec_cmd "$iptables_cmd -t nat -D EXCLUSIVE_SNAT -s $internalIp -j SNAT --to-source $eip"
-            conntrack -D -d $eip 2>/dev/null || true
+        # delete DNAT rule: match "-d <eip>/32" (/32 suffix prevents prefix match)
+        # head -1: FIP is 1:1, at most one rule per EIP; guard against unexpected duplicates
+        dnatRule=$($iptables_save_cmd | grep EXCLUSIVE_DNAT | grep -w -- "-d $eip/32" | head -1)
+        if [ -n "$dnatRule" ]; then
+            dnatRule=$(echo "$dnatRule" | sed 's/^-A //')
+            exec_cmd "$iptables_cmd -t nat -D $dnatRule"
+            conntrack -D -d "$eip" 2>/dev/null || true
+        fi
+        # delete SNAT rule: match "--to-source <eip>" (-w prevents prefix match,
+        # e.g., 10.0.0.1 will not match 10.0.0.10)
+        snatRule=$($iptables_save_cmd | grep EXCLUSIVE_SNAT | grep -w -- "--to-source $eip" | head -1)
+        if [ -n "$snatRule" ]; then
+            snatRule=$(echo "$snatRule" | sed 's/^-A //')
+            exec_cmd "$iptables_cmd -t nat -D $snatRule"
         fi
     done
 }
 
 function add_snat() {
+    # Validation before adding (SNAT identity = (EIP, InternalCIDR), 1:N model):
+    # One EIP can serve multiple CIDRs, and one CIDR can have multiple EIPs
+    # (for port exhaustion mitigation via --random-fully).
+    # 1. If exact (eip, internalCIDR) pair does not exist -> create rule
+    # 2. If exact (eip, internalCIDR) pair already exists -> return success (idempotent)
+    #
+    # iptables-save output format:
+    #   -A SHARED_SNAT -s <internalCIDR> -o <ext_iface> -j SNAT --to-source <eip>
+    # NOTE: Current SNAT CRD/controller path sends one rule per invocation.
+    # The for-loop is currently of limited practical value.
+    # TODO: Consider removing the for-loop and avoid cache optimizations driven only by loop batching.
     # make sure inited
     check_inited
     local all_shared_snat_rules
     all_shared_snat_rules=$($iptables_save_cmd -t nat | grep SHARED_SNAT)
-    for rule in $@
+    for rule in "$@"
     do
         arr=(${rule//,/ })
         eip=(${arr[0]//\// })
         internalCIDR=${arr[1]}
         randomFullyOption=${arr[2]}
-        # check if already exist, skip adding if exists (idempotent)
+        # check if exact (eip, internalCIDR) pair already exists (idempotent)
         ruleMatch=$(echo "$all_shared_snat_rules" | grep -w -- "-s $internalCIDR" | grep -E -- "--to-source $eip(\$| )")
         if [ -z "$ruleMatch" ]; then
             exec_cmd "$iptables_cmd -t nat -A SHARED_SNAT -o $EXTERNAL_INTERFACE -s $internalCIDR -j SNAT --to-source $eip $randomFullyOption"
@@ -360,11 +404,14 @@ function add_snat() {
     done
 }
 function del_snat() {
+    # NOTE: Current SNAT CRD/controller path sends one rule per invocation.
+    # The for-loop is currently of limited practical value.
+    # TODO: Consider removing the for-loop and avoid cache optimizations driven only by loop batching.
     # make sure inited
     check_inited
     local all_shared_snat_rules
     all_shared_snat_rules=$($iptables_save_cmd -t nat | grep SHARED_SNAT)
-    for rule in $@
+    for rule in "$@"
     do
         arr=(${rule//,/ })
         eip=(${arr[0]//\// })
@@ -372,7 +419,7 @@ function del_snat() {
         # check if already exist
         ruleMatch=$(echo "$all_shared_snat_rules" | grep -w -- "-s $internalCIDR" | grep -E -- "--to-source $eip(\$| )" | head -1)
         if [ -n "$ruleMatch" ]; then
-          ruleMatch=$(echo "$ruleMatch" | sed 's/-A //')
+          ruleMatch=$(echo "$ruleMatch" | sed 's/^-A //')
           exec_cmd "$iptables_cmd -t nat -D $ruleMatch"
         fi
     done
@@ -387,9 +434,19 @@ function del_snat() {
 #    bypassing NAT GW. VM A expects reply from EIP, causing connection failure.
 # 5. Hairpin SNAT translates source to EIP, ensuring symmetric return path via NAT GW.
 function add_dnat() {
+    # Strict validation before adding (DNAT identity = (EIP, ExternalPort, Protocol)):
+    # 1. If identity does not exist -> create rule
+    # 2. If identity exists and internalIp:internalPort matches -> return success (idempotent)
+    # 3. If identity exists but internalIp:internalPort mismatches -> return error (reject stale/conflicting data)
+    #
+    # iptables-save output format:
+    #   -A SHARED_DNAT -d <eip>/32 -p <protocol> -m <protocol> --dport <dport> -j DNAT --to-destination <internalIp>:<internalPort>
+    # NOTE: Current DNAT CRD/controller path sends one rule per invocation.
+    # The for-loop is currently of limited practical value.
+    # TODO: Consider removing the for-loop and avoid cache optimizations driven only by loop batching.
     # make sure inited
     check_inited
-    for rule in $@
+    for rule in "$@"
     do
         arr=(${rule//,/ })
         eip=(${arr[0]//\// })
@@ -397,28 +454,42 @@ function add_dnat() {
         protocol=${arr[2]}
         internalIp=${arr[3]}
         internalPort=${arr[4]}
-        # check if already exist
-        $iptables_save_cmd | grep SHARED_DNAT | grep -w "\-d $eip/32" | grep "p $protocol" | grep -w "dport $dport"| grep -w "destination $internalIp:$internalPort" && exit 0
+        # check if identity triplet (eip, dport, protocol) already exists
+        existingRule=$($iptables_save_cmd | grep SHARED_DNAT | grep -w -- "-d $eip/32" | grep -w -- "-p $protocol" | grep -w "dport $dport")
+        if [ -n "$existingRule" ]; then
+            # identity exists, check if internalIp:internalPort matches
+            echo "$existingRule" | grep -w "destination $internalIp:$internalPort" > /dev/null 2>&1 && exit 0
+            # identity exists but internalIp:internalPort mismatch
+            echo "dnat ($eip, $dport, $protocol) already exists: $existingRule, but expected $internalIp:$internalPort"
+            exit 1
+        fi
         exec_cmd "$iptables_cmd -t nat -A SHARED_DNAT -p $protocol -d $eip --dport $dport -j DNAT --to-destination $internalIp:$internalPort"
     done
 }
 
 
 function del_dnat() {
+    # Lenient deletion (DNAT identity = (EIP, ExternalPort, Protocol)):
+    # Match by identity only, ignore internalIp:internalPort.
+    # If the rule exists -> extract the full rule from iptables-save and delete it
+    # If the rule does not exist -> treat as already deleted (no error)
+    # NOTE: Current DNAT CRD/controller path sends one rule per invocation.
+    # The for-loop is currently of limited practical value.
+    # TODO: Consider removing the for-loop and avoid cache optimizations driven only by loop batching.
     # make sure inited
     check_inited
-    for rule in $@
+    for rule in "$@"
     do
         arr=(${rule//,/ })
         eip=(${arr[0]//\// })
         dport=${arr[1]}
         protocol=${arr[2]}
-        internalIp=${arr[3]}
-        internalPort=${arr[4]}
-        # check if already exist
-        $iptables_save_cmd | grep SHARED_DNAT | grep -w "\-d $eip/32" | grep "p $protocol" | grep -w "dport $dport"| grep -w "destination $internalIp:$internalPort"
-        if [ "$?" -eq 0 ];then
-          exec_cmd "$iptables_cmd -t nat -D SHARED_DNAT -p $protocol -d $eip --dport $dport -j DNAT --to-destination $internalIp:$internalPort"
+        # match by identity triplet; head -1 guards against unexpected duplicates
+        existingRule=$($iptables_save_cmd | grep SHARED_DNAT | grep -w -- "-d $eip/32" | grep -w -- "-p $protocol" | grep -w "dport $dport" | head -1)
+        if [ -n "$existingRule" ]; then
+          existingRule=$(echo "$existingRule" | sed 's/^-A //')
+          exec_cmd "$iptables_cmd -t nat -D $existingRule"
+          conntrack -D -d "$eip" -p "$protocol" --dport "$dport" 2>/dev/null || true
         fi
     done
 }

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -36,9 +36,9 @@ func (c *Controller) enqueueUpdateIptablesFip(oldObj, newObj any) {
 		c.updateIptablesFipQueue.Add(key)
 		return
 	}
-	if oldFip.Spec.EIP != newFip.Spec.EIP {
-		// to notify old eip to remove nat label
-		c.resetIptablesEipQueue.Add(oldFip.Spec.EIP)
+	if newFip.Spec.EIP == "" || newFip.Spec.InternalIP == "" {
+		klog.Errorf("skip enqueue fip %s: incomplete spec (eip=%q, internalIP=%q)", key, newFip.Spec.EIP, newFip.Spec.InternalIP)
+		return
 	}
 	if oldFip.Status.V4ip != newFip.Status.V4ip ||
 		oldFip.Spec.EIP != newFip.Spec.EIP ||
@@ -87,19 +87,19 @@ func (c *Controller) enqueueUpdateIptablesDnatRule(oldObj, newObj any) {
 		c.updateIptablesDnatRuleQueue.Add(key)
 		return
 	}
-
-	if oldDnat.Spec.EIP != newDnat.Spec.EIP {
-		// to notify old eip to remove nat table
-		c.resetIptablesEipQueue.Add(oldDnat.Spec.EIP)
+	if newDnat.Spec.EIP == "" || newDnat.Spec.ExternalPort == "" || newDnat.Spec.Protocol == "" ||
+		newDnat.Spec.InternalIP == "" || newDnat.Spec.InternalPort == "" {
+		klog.Errorf("skip enqueue dnat %s: incomplete spec (eip=%q, externalPort=%q, protocol=%q, internalIP=%q, internalPort=%q)",
+			key, newDnat.Spec.EIP, newDnat.Spec.ExternalPort, newDnat.Spec.Protocol, newDnat.Spec.InternalIP, newDnat.Spec.InternalPort)
+		return
 	}
-
 	if oldDnat.Status.V4ip != newDnat.Status.V4ip ||
 		oldDnat.Spec.EIP != newDnat.Spec.EIP ||
 		oldDnat.Status.Redo != newDnat.Status.Redo ||
 		oldDnat.Spec.Protocol != newDnat.Spec.Protocol ||
 		oldDnat.Spec.InternalIP != newDnat.Spec.InternalIP ||
-		oldDnat.Spec.InternalPort != newDnat.Spec.InternalPort ||
-		oldDnat.Spec.ExternalPort != newDnat.Spec.ExternalPort {
+		oldDnat.Spec.ExternalPort != newDnat.Spec.ExternalPort ||
+		oldDnat.Spec.InternalPort != newDnat.Spec.InternalPort {
 		klog.V(3).Infof("enqueue update dnat %s", key)
 		c.updateIptablesDnatRuleQueue.Add(key)
 		return
@@ -143,9 +143,9 @@ func (c *Controller) enqueueUpdateIptablesSnatRule(oldObj, newObj any) {
 		c.updateIptablesSnatRuleQueue.Add(key)
 		return
 	}
-	if oldSnat.Spec.EIP != newSnat.Spec.EIP {
-		// to notify old eip to remove nat label
-		c.resetIptablesEipQueue.Add(oldSnat.Spec.EIP)
+	if newSnat.Spec.EIP == "" || newSnat.Spec.InternalCIDR == "" {
+		klog.Errorf("skip enqueue snat %s: incomplete spec (eip=%q, internalCIDR=%q)", key, newSnat.Spec.EIP, newSnat.Spec.InternalCIDR)
+		return
 	}
 	if oldSnat.Status.V4ip != newSnat.Status.V4ip ||
 		oldSnat.Spec.EIP != newSnat.Spec.EIP ||
@@ -179,6 +179,21 @@ func (c *Controller) enqueueDelIptablesSnatRule(obj any) {
 	c.delIptablesSnatRuleQueue.Add(key)
 }
 
+// handleAddIptablesFip creates a FIP rule from scratch.
+//
+// Responsibility:
+//   - Bring the FIP from an empty Status to a fully consistent state across all 4 dimensions:
+//     1. iptables rule in NAT GW Pod  2. FIP Status  3. FIP Labels  4. EIP Status
+//   - On success, Status MUST be fully populated (V4ip, InternalIP, NatGwDp, Ready=true).
+//     This is the contract that handleUpdateIptablesFip relies on: a complete Status means
+//     the old values are reliable and can be used for spec-change detection and rule deletion.
+//   - On failure at any step, returns error to retry. Partial state (e.g., iptables rule
+//     created but Status not yet patched) may exist; the next retry uses current Spec
+//     and must converge to the desired state.
+//
+// Error state: if this handler never completes (Status.V4ip stays empty), the resource is
+// in an error state. The update handler MUST NOT attempt NAT operations in this state —
+// it lacks reliable old values for safe rule replacement.
 func (c *Controller) handleAddIptablesFip(key string) error {
 	fip, err := c.iptablesFipsLister.Get(key)
 	if err != nil {
@@ -229,7 +244,6 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 		return err
 	}
 
-	// create fip nat
 	if err = c.createFipInPod(eip.Spec.NatGwDp, eip.Status.IP, fip.Spec.InternalIP); err != nil {
 		klog.Errorf("failed to create fip, %v", err)
 		return err
@@ -269,6 +283,48 @@ func (c *Controller) fipTryUseEip(fipName, eipV4IP string) error {
 	return nil
 }
 
+// handleUpdateIptablesFip handles FIP deletion, spec changes, and redo.
+//
+// FIP involves 4 dimensions of data that must be kept consistent:
+//
+//	Dimension        Storage                Description
+//	──────────────── ────────────────────── ──────────────────────────────────────────
+//	1. iptables rule NAT GW Pod             v4ip <-> internalIP DNAT/SNAT pair
+//	2. FIP Status    CR .status             V4ip, InternalIP, NatGwDp, Ready
+//	3. FIP Label     CR .labels/.annotations EipV4IpLabel, VpcNatGatewayNameLabel, VpcEipAnnotation
+//	4. EIP Status    EIP CR .status         Nat field records which NAT rules use this EIP
+//
+// Precondition for spec-change path:
+//   - Status.V4ip != "" (Status is complete, populated by handleAddIptablesFip).
+//     A complete Status means the old values are reliable and reflect what was actually
+//     created in the Pod. This is the ONLY safe basis for deleting old iptables rules.
+//   - If Status.V4ip == "", the resource is in an error state (handleAdd never completed).
+//     The update handler MUST NOT attempt any NAT operations — it has no reliable old
+//     values to delete and creating new rules could leave stale data.
+//     It should log the error and return, leaving recovery to the add handler (or future updates that fix the spec).
+//     IMPORTANT: If a change fails, we must wait for retry until success. Continuing to change spec
+//     on top of a failed state (dirty status) can introduce more zombie rules that are hard to track.
+//
+// Paths:
+//
+//  1. Delete path (DeletionTimestamp set):
+//     Uses Status (with Spec fallback for best-effort cleanup) to locate the old iptables rule.
+//     Removes finalizer, then async-resets EIP to refresh dimension 4.
+//
+//  2. Spec change path (Status.V4ip != "" AND Status differs from Spec+EIP):
+//     Old values come from Status; new values come from Spec + EIP CR.
+//     Steps strictly ordered to maintain all 4 dimensions:
+//     a. finalDeleteFipInPod  (clean dimension 1 with old values from Status)
+//     b. createFipInPod  (create dimension 1 with new values from Spec+EIP)
+//     c. patchFipStatus  (update dimension 2 to match new iptables rule)
+//     d. patchFipLabel   (update dimension 3 to match new EIP)
+//     e. patchEipStatus  (update dimension 4 on new EIP)
+//     f. resetOldEip     (async clean dimension 4 on old EIP, if EIP changed)
+//     If any step fails, returns error to retry. Iptables operations are idempotent.
+//
+//  3. Redo path (gateway pod restarted):
+//     Re-creates the iptables rule using Status.V4ip (the known-good external IP)
+//     plus Spec.InternalIP. Only touches dimension 1; dimensions 2-4 are already correct.
 func (c *Controller) handleUpdateIptablesFip(key string) error {
 	cachedFip, err := c.iptablesFipsLister.Get(key)
 	if err != nil {
@@ -286,9 +342,7 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 	// should delete
 	if !cachedFip.DeletionTimestamp.IsZero() {
 		if vpcNatEnabled == "true" {
-			klog.V(3).Infof("clean fip '%s' in pod", key)
-			if err = c.deleteFipInPod(cachedFip.Status.NatGwDp, cachedFip.Status.V4ip, cachedFip.Status.InternalIP); err != nil {
-				klog.Errorf("failed to delete fip %s, %v", key, err)
+			if err = c.finalDeleteFipInPod(key, cachedFip); err != nil {
 				return err
 			}
 		}
@@ -322,52 +376,106 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 		return err
 	}
 
-	klog.V(3).Infof("fip change ip, old ip '%s', new ip %s", cachedFip.Status.V4ip, eip.Status.IP)
-	if err = c.deleteFipInPod(cachedFip.Status.NatGwDp, cachedFip.Status.V4ip, cachedFip.Status.InternalIP); err != nil {
-		klog.Errorf("failed to delete old fip, %v", err)
-		return err
+	if eip.Spec.NatGwDp == "" {
+		klog.Errorf("fip %s: eip %s has empty NatGwDp, skip binding", key, cachedFip.Spec.EIP)
+		return nil
 	}
-	if err = c.createFipInPod(eip.Spec.NatGwDp, eip.Status.IP, cachedFip.Spec.InternalIP); err != nil {
-		klog.Errorf("failed to create new fip, %v", err)
-		return err
+
+	// Error state: Status incomplete means handleAdd never completed.
+	// Do not attempt NAT operations — no reliable old values for safe rule replacement.
+	// All spec-corresponding Status fields must be populated for the update handler to proceed.
+	if cachedFip.Status.V4ip == "" || cachedFip.Status.NatGwDp == "" || cachedFip.Status.InternalIP == "" {
+		klog.Errorf("fip %s has incomplete status (V4ip=%q, NatGwDp=%q, InternalIP=%q), skipping NAT operations; waiting for add handler to complete",
+			key, cachedFip.Status.V4ip, cachedFip.Status.NatGwDp, cachedFip.Status.InternalIP)
+		return nil
 	}
-	if err = c.patchFipStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
-		klog.Errorf("failed to patch status for fip '%s', %v", key, err)
-		return err
+
+	// spec change: compare Status (old, what's in Pod) vs Spec+EIP (new, desired)
+	oldV4ip := cachedFip.Status.V4ip
+	newV4ip := eip.Status.IP
+	newInternalIP := cachedFip.Spec.InternalIP
+
+	// Warn if we are modifying a resource that might be in a dirty state from a previous failed update.
+	if !cachedFip.Status.Ready {
+		// TODO: consider using a webhook to reject spec changes when the resource is not ready,
+		// to prevent users from modifying the spec when the previous update has not yet been fully reconciled.
+		klog.Warningf("fip %s is being updated while not Ready (previous update likely failed). This may lead to stale iptables rules.", key)
 	}
-	// fip change eip
-	if c.fipChangeEip(cachedFip, eip) {
-		// label too long cause error
+
+	// Verify new parameters are valid before modifying any state.
+	// eip.Status.IP can be empty if EIP itself is in error state.
+	if newV4ip == "" || newInternalIP == "" {
+		klog.Errorf("skipping fip %s update: incomplete new parameters (v4ip=%q, internalIP=%q)", key, newV4ip, newInternalIP)
+		return nil
+	}
+
+	if oldV4ip != newV4ip || cachedFip.Status.InternalIP != newInternalIP {
+		// Mark FIP as not ready before starting the update.
+		// This ensures that if the controller crashes or the update fails midway,
+		// the resource will be left in a non-ready state, indicating a potential inconsistency.
+		if cachedFip.Status.Ready {
+			klog.V(3).Infof("fip %s spec changed, marking as not ready before update", key)
+			if err = c.patchFipStatus(key, oldV4ip, cachedFip.Status.V6ip, cachedFip.Status.NatGwDp, "", false); err != nil {
+				klog.Errorf("failed to mark fip %s as not ready, %v", key, err)
+				return err
+			}
+		}
+		// delete old rule; finalDeleteFipInPod resolves (natGwDp, v4ip) from Status
+		if err = c.finalDeleteFipInPod(key, cachedFip); err != nil {
+			return err
+		}
+		if err = c.createFipInPod(eip.Spec.NatGwDp, newV4ip, newInternalIP); err != nil {
+			klog.Errorf("failed to create fip %s, %v", key, err)
+			return err
+		}
+		if err = c.patchFipStatus(key, newV4ip, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
+			klog.Errorf("failed to patch status for fip %s, %v", key, err)
+			return err
+		}
 		if err = c.patchFipLabel(key, eip); err != nil {
 			klog.Errorf("failed to update label for fip %s, %v", key, err)
 			return err
 		}
 		if err = c.patchEipStatus(cachedFip.Spec.EIP, "", "", "", true); err != nil {
-			// refresh eip nats
 			klog.Errorf("failed to patch fip use eip %s, %v", key, err)
+			return err
+		}
+		// Reset old EIP after all 4 dimensions are updated.
+		// This must NOT be in enqueue — async reset there could race with handler's
+		// patchEipStatus, causing the old EIP's nat label to be cleared before the
+		// new EIP is fully bound, leaving a window where the old EIP appears free.
+		if oldEipName := cachedFip.Annotations[util.VpcEipAnnotation]; oldEipName != "" && oldEipName != cachedFip.Spec.EIP {
+			c.resetIptablesEipQueue.AddAfter(oldEipName, 3*time.Second)
+		}
+		if err = c.handleAddIptablesFipFinalizer(key); err != nil {
+			klog.Errorf("failed to handle add finalizer for fip %s, %v", key, err)
 			return err
 		}
 		return nil
 	}
+
 	// redo
 	if !cachedFip.Status.Ready &&
 		cachedFip.Status.Redo != "" &&
 		cachedFip.Status.V4ip != "" &&
 		cachedFip.DeletionTimestamp.IsZero() {
 		klog.V(3).Infof("reapply fip '%s' in pod", key)
-		gwPod, err := c.getNatGwPod(eip.Spec.NatGwDp)
+		gwPod, err := c.getNatGwPod(cachedFip.Status.NatGwDp)
 		if err != nil {
 			klog.Error(err)
 			return err
 		}
-		// compare gw pod started time with fip redo time. if fip redo time before gw pod started. should redo again
+		// If Pod started before the redo timestamp, it has not restarted since
+		// the redo was marked — iptables rules are still intact, skip re-creation.
 		fipRedo, _ := time.ParseInLocation("2006-01-02T15:04:05", cachedFip.Status.Redo, time.Local)
-		if cachedFip.Status.Ready && cachedFip.Status.V4ip != "" && gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: fipRedo}) {
-			// already ok
-			klog.V(3).Infof("fip %s already ok", key)
+		if len(gwPod.Status.ContainerStatuses) == 0 || gwPod.Status.ContainerStatuses[0].State.Running == nil {
+			return fmt.Errorf("fip %s: gateway pod container not running, will retry redo", key)
+		}
+		if gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: fipRedo}) {
+			klog.V(3).Infof("fip %s: pod started before redo mark, rules intact, skip", key)
 			return nil
 		}
-		if err = c.createFipInPod(eip.Spec.NatGwDp, cachedFip.Status.V4ip, cachedFip.Spec.InternalIP); err != nil {
+		if err = c.createFipInPod(cachedFip.Status.NatGwDp, cachedFip.Status.V4ip, cachedFip.Status.InternalIP); err != nil {
 			klog.Errorf("failed to create fip, %v", err)
 			return err
 		}
@@ -388,6 +496,20 @@ func (c *Controller) handleDelIptablesFip(key string) error {
 	return nil
 }
 
+// handleAddIptablesDnatRule creates a DNAT rule from scratch.
+//
+// Responsibility:
+//   - Bring the DNAT from an empty Status to a fully consistent state across all 4 dimensions:
+//     1. iptables rule in NAT GW Pod  2. DNAT Status  3. DNAT Labels  4. EIP Status
+//   - On success, Status MUST be fully populated (V4ip, Protocol, ExternalPort, InternalIP,
+//     InternalPort, NatGwDp, Ready=true). This is the contract that handleUpdateIptablesDnatRule
+//     relies on: a complete Status provides reliable old values for spec-change detection
+//     and rule deletion.
+//   - On failure at any step, returns error to retry. Partial state may exist; the next
+//     retry uses current Spec and must converge to the desired state.
+//
+// Error state: if this handler never completes (Status.V4ip stays empty), the resource is
+// in an error state. The update handler MUST NOT attempt NAT operations in this state.
 func (c *Controller) handleAddIptablesDnatRule(key string) error {
 	dnat, err := c.iptablesDnatRulesLister.Get(key)
 	if err != nil {
@@ -425,7 +547,13 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		klog.Error(err)
 		return err
 	}
-	// create nat
+	// Add the finalizer **before** creating rules in Pod. If we added it after,
+	// the DNAT could be deleted after createDnatInPod but before the finalizer,
+	// leaving unmanaged iptables rules in the gateway pod.
+	if err = c.handleAddIptablesDnatFinalizer(key); err != nil {
+		klog.Errorf("failed to handle add finalizer for dnat, %v", err)
+		return err
+	}
 	if err = c.createDnatInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol,
 		eip.Status.IP, dnat.Spec.InternalIP,
 		dnat.Spec.ExternalPort, dnat.Spec.InternalPort); err != nil {
@@ -441,10 +569,6 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		klog.Errorf("failed to patch label for dnat %s, %v", key, err)
 		return err
 	}
-	if err = c.handleAddIptablesDnatFinalizer(key); err != nil {
-		klog.Errorf("failed to handle add finalizer for dnat, %v", err)
-		return err
-	}
 	if err = c.patchEipStatus(dnat.Spec.EIP, "", "", "", true); err != nil {
 		// refresh eip nats
 		klog.Errorf("failed to patch dnat use eip %s, %v", key, err)
@@ -453,6 +577,26 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 	return nil
 }
 
+// handleUpdateIptablesDnatRule handles DNAT rule deletion, spec changes, and redo.
+//
+// DNAT involves 4 dimensions of data consistency (see handleUpdateIptablesFip for general pattern):
+//  1. iptables rule  - (protocol, v4ip, externalPort) -> (internalIP, internalPort)
+//  2. DNAT Status    - V4ip, Protocol, InternalIP, ExternalPort, InternalPort, NatGwDp, Ready
+//  3. DNAT Label     - EipV4IpLabel, VpcNatGatewayNameLabel, VpcDnatEPortLabel, VpcEipAnnotation
+//  4. EIP Status     - Nat field
+//
+// Key difference from FIP: DNAT identity = (eip, externalPort, protocol).
+// del_dnat in nat-gateway.sh matches by identity only (lenient deletion),
+// so even if controller passes stale internalIP/internalPort, deletion still works correctly.
+//
+// Precondition for spec-change path:
+//   - Status.V4ip != "" (Status is complete, populated by handleAddIptablesDnatRule).
+//     Status provides reliable old values for detecting what changed and deleting old rules.
+//   - If Status.V4ip == "", the resource is in an error state (handleAdd never completed).
+//     The update handler MUST NOT attempt any NAT operations — it should log the error
+//     and return, leaving recovery to the add handler.
+//     IMPORTANT: If a change fails, we must wait for retry until success. Continuing to change spec
+//     on top of a failed state (dirty status) can introduce more zombie rules that are hard to track.
 func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 	cachedDnat, err := c.iptablesDnatRulesLister.Get(key)
 	if err != nil {
@@ -465,21 +609,17 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 
 	c.vpcNatGwKeyMutex.LockKey(key)
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
-	klog.Infof("handle update iptables fip %s", key)
+	klog.Infof("handle update iptables dnat %s", key)
 
 	// should delete
 	if !cachedDnat.DeletionTimestamp.IsZero() {
-		klog.V(3).Infof("clean dnat '%s' in pod", key)
 		if vpcNatEnabled == "true" {
-			if err = c.deleteDnatInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol,
-				cachedDnat.Status.V4ip, cachedDnat.Status.InternalIP,
-				cachedDnat.Status.ExternalPort, cachedDnat.Status.InternalPort); err != nil {
-				klog.Errorf("failed to delete dnat, %v", err)
+			if err = c.finalDeleteDnatInPod(key, cachedDnat); err != nil {
 				return err
 			}
 		}
 		if err = c.handleDelIptablesDnatFinalizer(key); err != nil {
-			klog.Errorf("failed to handle add finalizer for dnat %s, %v", key, err)
+			klog.Errorf("failed to handle del finalizer for dnat %s, %v", key, err)
 			return err
 		}
 		//  reset eip
@@ -497,7 +637,7 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
 	}
-	if dup, err := c.isDnatDuplicated(cachedDnat.Status.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Name, cachedDnat.Spec.ExternalPort, cachedDnat.Spec.Protocol); dup || err != nil {
+	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Name, cachedDnat.Spec.ExternalPort, cachedDnat.Spec.Protocol); dup || err != nil {
 		klog.Errorf("failed to update dnat, %v", err)
 		return err
 	}
@@ -506,57 +646,119 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		return errors.New("iptables nat gw not enable")
 	}
 
-	if err = c.deleteDnatInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol,
-		cachedDnat.Status.V4ip, cachedDnat.Status.InternalIP,
-		cachedDnat.Status.ExternalPort, cachedDnat.Status.InternalPort); err != nil {
-		klog.Errorf("failed to delete old dnat, %v", err)
-		return err
+	if eip.Spec.NatGwDp == "" {
+		klog.Errorf("dnat %s: eip %s has empty NatGwDp, skip binding", key, cachedDnat.Spec.EIP)
+		return nil
 	}
-	if err = c.createDnatInPod(eip.Spec.NatGwDp, cachedDnat.Spec.Protocol,
-		eip.Status.IP, cachedDnat.Spec.InternalIP,
-		cachedDnat.Spec.ExternalPort, cachedDnat.Spec.InternalPort); err != nil {
-		klog.Errorf("failed to create new dnat %s, %v", key, err)
-		return err
+
+	// Error state: Status incomplete means handleAdd never completed.
+	// Do not attempt NAT operations — no reliable old values for safe rule replacement.
+	// All spec-corresponding Status fields must be populated for the update handler to proceed.
+	if cachedDnat.Status.V4ip == "" || cachedDnat.Status.NatGwDp == "" || cachedDnat.Status.Protocol == "" ||
+		cachedDnat.Status.ExternalPort == "" || cachedDnat.Status.InternalIP == "" || cachedDnat.Status.InternalPort == "" {
+		klog.Errorf("dnat %s has incomplete status (V4ip=%q, NatGwDp=%q, Protocol=%q, ExternalPort=%q, InternalIP=%q, InternalPort=%q), skipping NAT operations; waiting for add handler to complete",
+			key, cachedDnat.Status.V4ip, cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol,
+			cachedDnat.Status.ExternalPort, cachedDnat.Status.InternalIP, cachedDnat.Status.InternalPort)
+		return nil
 	}
-	if err = c.patchDnatStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
-		klog.Errorf("failed to patch status for dnat %s , %v", key, err)
-		return err
+
+	// spec change: compare Status (old, what's in Pod) vs Spec+EIP (new, desired)
+	oldV4ip := cachedDnat.Status.V4ip
+	oldProtocol := cachedDnat.Status.Protocol
+	oldExternalPort := cachedDnat.Status.ExternalPort
+	newV4ip := eip.Status.IP
+	newProtocol := cachedDnat.Spec.Protocol
+	newInternalIP := cachedDnat.Spec.InternalIP
+	newExternalPort := cachedDnat.Spec.ExternalPort
+	newInternalPort := cachedDnat.Spec.InternalPort
+
+	// Warn if we are modifying a resource that might be in a dirty state from a previous failed update.
+	if !cachedDnat.Status.Ready {
+		// TODO: consider using a webhook to reject spec changes when the resource is not ready,
+		// to prevent users from modifying the spec when the previous update has not yet been fully reconciled.
+		klog.Warningf("dnat %s is being updated while not Ready (previous update likely failed). This may lead to stale iptables rules.", key)
 	}
-	// dnat change eip
-	if c.dnatChangeEip(cachedDnat, eip) {
-		klog.V(3).Infof("dnat change ip, old ip '%s', new ip %s", cachedDnat.Status.V4ip, eip.Status.IP)
-		// label too long cause error
+
+	// Verify new parameters are valid before modifying any state.
+	// eip.Status.IP can be empty if EIP itself is in error state.
+	if newV4ip == "" || newInternalIP == "" || newExternalPort == "" || newProtocol == "" || newInternalPort == "" {
+		klog.Errorf("skipping dnat %s update: incomplete new parameters (v4ip=%q, internalIP=%q, externalPort=%q, protocol=%q, internalPort=%q)",
+			key, newV4ip, newInternalIP, newExternalPort, newProtocol, newInternalPort)
+		return nil
+	}
+
+	if oldV4ip != newV4ip || oldProtocol != newProtocol || oldExternalPort != newExternalPort ||
+		cachedDnat.Status.InternalIP != newInternalIP || cachedDnat.Status.InternalPort != newInternalPort {
+		// Mark DNAT as not ready before starting the update.
+		// This ensures that if the controller crashes or the update fails midway,
+		// the resource will be left in a non-ready state, indicating a potential inconsistency.
+		if cachedDnat.Status.Ready {
+			klog.V(3).Infof("dnat %s spec changed, marking as not ready before update", key)
+			if err = c.patchDnatStatus(key, oldV4ip, cachedDnat.Status.V6ip, cachedDnat.Status.NatGwDp, "", false); err != nil {
+				klog.Errorf("failed to mark dnat %s as not ready, %v", key, err)
+				return err
+			}
+		}
+		// delete old rule; finalDeleteDnatInPod resolves identity from Status
+		if err = c.finalDeleteDnatInPod(key, cachedDnat); err != nil {
+			return err
+		}
+		if err = c.createDnatInPod(eip.Spec.NatGwDp, newProtocol,
+			newV4ip, newInternalIP,
+			newExternalPort, newInternalPort); err != nil {
+			klog.Errorf("failed to create dnat %s, %v", key, err)
+			return err
+		}
+		if err = c.patchDnatStatus(key, newV4ip, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
+			klog.Errorf("failed to patch status for dnat %s, %v", key, err)
+			return err
+		}
 		if err = c.patchDnatLabel(key, eip); err != nil {
 			klog.Errorf("failed to patch label for dnat %s, %v", key, err)
 			return err
 		}
 		if err = c.patchEipStatus(cachedDnat.Spec.EIP, "", "", "", true); err != nil {
-			// refresh eip nats
 			klog.Errorf("failed to patch dnat use eip %s, %v", key, err)
 			return err
 		}
+		// Reset old EIP after all 4 dimensions are updated.
+		// This must NOT be in enqueue — async reset there could race with handler's
+		// patchEipStatus, causing the old EIP's nat label to be cleared before the
+		// new EIP is fully bound, leaving a window where the old EIP appears free.
+		if oldEipName := cachedDnat.Annotations[util.VpcEipAnnotation]; oldEipName != "" && oldEipName != cachedDnat.Spec.EIP {
+			c.resetIptablesEipQueue.AddAfter(oldEipName, 3*time.Second)
+		}
+		if err = c.handleAddIptablesDnatFinalizer(key); err != nil {
+			klog.Errorf("failed to handle add finalizer for dnat %s, %v", key, err)
+			return err
+		}
+		return nil
 	}
+
 	// redo
 	if !cachedDnat.Status.Ready &&
 		cachedDnat.Status.Redo != "" &&
 		cachedDnat.Status.V4ip != "" &&
 		cachedDnat.DeletionTimestamp.IsZero() {
 		klog.V(3).Infof("reapply dnat in pod for %s", key)
-		gwPod, err := c.getNatGwPod(eip.Spec.NatGwDp)
+		gwPod, err := c.getNatGwPod(cachedDnat.Status.NatGwDp)
 		if err != nil {
 			klog.Error(err)
 			return err
 		}
-		// compare gw pod started time with dnat redo time. if redo time before gw pod started. redo again
+		// If Pod started before the redo timestamp, it has not restarted since
+		// the redo was marked — iptables rules are still intact, skip re-creation.
 		dnatRedo, _ := time.ParseInLocation("2006-01-02T15:04:05", cachedDnat.Status.Redo, time.Local)
-		if cachedDnat.Status.Ready && cachedDnat.Status.V4ip != "" && gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: dnatRedo}) {
-			// already ok
-			klog.V(3).Infof("dnat %s already ok", key)
+		if len(gwPod.Status.ContainerStatuses) == 0 || gwPod.Status.ContainerStatuses[0].State.Running == nil {
+			return fmt.Errorf("dnat %s: gateway pod container not running, will retry redo", key)
+		}
+		if gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: dnatRedo}) {
+			klog.V(3).Infof("dnat %s: pod started before redo mark, rules intact, skip", key)
 			return nil
 		}
-		if err = c.createDnatInPod(eip.Spec.NatGwDp, cachedDnat.Spec.Protocol,
-			cachedDnat.Status.V4ip, cachedDnat.Spec.InternalIP,
-			cachedDnat.Spec.ExternalPort, cachedDnat.Spec.InternalPort); err != nil {
+		if err = c.createDnatInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol,
+			cachedDnat.Status.V4ip, cachedDnat.Status.InternalIP,
+			cachedDnat.Status.ExternalPort, cachedDnat.Status.InternalPort); err != nil {
 			klog.Errorf("failed to create dnat %s, %v", key, err)
 			return err
 		}
@@ -577,6 +779,19 @@ func (c *Controller) handleDelIptablesDnatRule(key string) error {
 	return nil
 }
 
+// handleAddIptablesSnatRule creates a SNAT rule from scratch.
+//
+// Responsibility:
+//   - Bring the SNAT from an empty Status to a fully consistent state across all 4 dimensions:
+//     1. iptables rule in NAT GW Pod  2. SNAT Status  3. SNAT Labels  4. EIP Status
+//   - On success, Status MUST be fully populated (V4ip, InternalCIDR, NatGwDp, Ready=true).
+//     This is the contract that handleUpdateIptablesSnatRule relies on: a complete Status
+//     provides reliable old values for spec-change detection and rule deletion.
+//   - On failure at any step, returns error to retry. Partial state may exist; the next
+//     retry uses current Spec and must converge to the desired state.
+//
+// Error state: if this handler never completes (Status.V4ip stays empty), the resource is
+// in an error state. The update handler MUST NOT attempt NAT operations in this state.
 func (c *Controller) handleAddIptablesSnatRule(key string) error {
 	snat, err := c.iptablesSnatRulesLister.Get(key)
 	if err != nil {
@@ -617,6 +832,13 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 		err = fmt.Errorf("failed to get snat v4 internal cidr, original cidr is %s", snat.Spec.InternalCIDR)
 		return err
 	}
+	// Add the finalizer **before** creating rules in Pod. If we added it after,
+	// the SNAT could be deleted after createSnatInPod but before the finalizer,
+	// leaving unmanaged iptables rules in the gateway pod.
+	if err = c.handleAddIptablesSnatFinalizer(key); err != nil {
+		klog.Errorf("failed to handle add finalizer for snat, %v", err)
+		return err
+	}
 	if err = c.createSnatInPod(eip.Spec.NatGwDp, eip.Status.IP, v4Cidr); err != nil {
 		klog.Errorf("failed to create snat, %v", err)
 		return err
@@ -629,10 +851,6 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 		klog.Errorf("failed to patch label for snat %s, %v", key, err)
 		return err
 	}
-	if err = c.handleAddIptablesSnatFinalizer(key); err != nil {
-		klog.Errorf("failed to handle add finalizer for snat, %v", err)
-		return err
-	}
 	if err = c.patchEipStatus(snat.Spec.EIP, "", "", "", true); err != nil {
 		// refresh eip nats
 		klog.Errorf("failed to patch snat use eip %s, %v", key, err)
@@ -641,6 +859,27 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 	return nil
 }
 
+// handleUpdateIptablesSnatRule handles SNAT rule deletion, spec changes, and redo.
+//
+// SNAT involves 4 dimensions of data consistency (see handleUpdateIptablesFip for general pattern):
+//  1. iptables rule  - v4ip SNAT for internalCIDR
+//  2. SNAT Status    - V4ip, InternalCIDR, NatGwDp, Ready
+//  3. SNAT Label     - EipV4IpLabel, VpcNatGatewayNameLabel, VpcEipAnnotation
+//  4. EIP Status     - Nat field
+//
+// Key difference from FIP/DNAT: SNAT is a 1:N model. One EIP can serve multiple CIDRs,
+// and one CIDR can have multiple EIPs (for port exhaustion mitigation via --random-fully).
+// SNAT identity = (eip, internalCIDR). del_snat in nat-gateway.sh matches by identity
+// to locate the exact rule.
+//
+// Precondition for spec-change path:
+//   - Status.V4ip != "" (Status is complete, populated by handleAddIptablesSnatRule).
+//     Status provides reliable old values for detecting what changed and deleting old rules.
+//   - If Status.V4ip == "", the resource is in an error state (handleAdd never completed).
+//     The update handler MUST NOT attempt any NAT operations — it should log the error
+//     and return, leaving recovery to the add handler.
+//     IMPORTANT: If a change fails, we must wait for retry until success. Continuing to change spec
+//     on top of a failed state (dirty status) can introduce more zombie rules that are hard to track.
 func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 	cachedSnat, err := c.iptablesSnatRulesLister.Get(key)
 	if err != nil {
@@ -655,13 +894,10 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle update iptables snat rule %s", key)
 
-	v4Cidr, _ := util.SplitStringIP(cachedSnat.Status.InternalCIDR)
 	// should delete
 	if !cachedSnat.DeletionTimestamp.IsZero() {
-		klog.V(3).Infof("clean snat '%s' in pod", key)
-		if vpcNatEnabled == "true" && v4Cidr != "" {
-			if err = c.deleteSnatInPod(cachedSnat.Status.NatGwDp, cachedSnat.Status.V4ip, v4Cidr); err != nil {
-				klog.Errorf("failed to delete snat, %v", err)
+		if vpcNatEnabled == "true" {
+			if err = c.finalDeleteSnatInPod(key, cachedSnat); err != nil {
 				return err
 			}
 		}
@@ -689,50 +925,108 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 		return errors.New("iptables nat gw not enable")
 	}
 
-	klog.V(3).Infof("snat change ip, old ip %s, new ip %s", cachedSnat.Status.V4ip, eip.Status.IP)
-	if err = c.deleteSnatInPod(cachedSnat.Status.NatGwDp, cachedSnat.Status.V4ip, v4Cidr); err != nil {
-		klog.Errorf("failed to delete old snat, %v", err)
-		return err
+	if eip.Spec.NatGwDp == "" {
+		klog.Errorf("snat %s: eip %s has empty NatGwDp, skip binding", key, cachedSnat.Spec.EIP)
+		return nil
 	}
-	v4CidrSpec, _ := util.SplitStringIP(cachedSnat.Spec.InternalCIDR)
-	if err = c.createSnatInPod(eip.Spec.NatGwDp, eip.Status.IP, v4CidrSpec); err != nil {
-		klog.Errorf("failed to create new snat %s, %v", key, err)
-		return err
+
+	// Error state: Status incomplete means handleAdd never completed.
+	// Do not attempt NAT operations — no reliable old values for safe rule replacement.
+	// All spec-corresponding Status fields must be populated for the update handler to proceed.
+	if cachedSnat.Status.V4ip == "" || cachedSnat.Status.NatGwDp == "" || cachedSnat.Status.InternalCIDR == "" {
+		klog.Errorf("snat %s has incomplete status (V4ip=%q, NatGwDp=%q, InternalCIDR=%q), skipping NAT operations; waiting for add handler to complete",
+			key, cachedSnat.Status.V4ip, cachedSnat.Status.NatGwDp, cachedSnat.Status.InternalCIDR)
+		return nil
 	}
-	if err = c.patchSnatStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
-		klog.Errorf("failed to patch status for snat %s , %v", key, err)
-		return err
+
+	// spec change: compare Status (old, what's in Pod) vs Spec+EIP (new, desired)
+	// SNAT identity = (v4ip, internalCIDR), all fields are identity — no non-identity fields.
+	oldV4ip := cachedSnat.Status.V4ip
+	oldV4Cidr, _ := util.SplitStringIP(cachedSnat.Status.InternalCIDR)
+	newV4ip := eip.Status.IP
+	newV4Cidr, _ := util.SplitStringIP(cachedSnat.Spec.InternalCIDR)
+
+	// Warn if we are modifying a resource that might be in a dirty state from a previous failed update.
+	if !cachedSnat.Status.Ready {
+		// TODO: consider using a webhook to reject spec changes when the resource is not ready,
+		// to prevent users from modifying the spec when the previous update has not yet been fully reconciled.
+		klog.Warningf("snat %s is being updated while not Ready (previous update likely failed). This may lead to stale iptables rules.", key)
 	}
-	// snat change eip
-	if c.snatChangeEip(cachedSnat, eip) {
+
+	// Verify new parameters are valid before modifying any state.
+	// eip.Status.IP can be empty if EIP itself is in error state;
+	// SplitStringIP can return empty v4 part for IPv6-only CIDR.
+	if newV4ip == "" || newV4Cidr == "" {
+		klog.Errorf("skipping snat %s update: incomplete new parameters (v4ip=%q, v4Cidr=%q)", key, newV4ip, newV4Cidr)
+		return nil
+	}
+
+	if oldV4ip != newV4ip || oldV4Cidr != newV4Cidr {
+		// Mark SNAT as not ready before starting the update.
+		// This ensures that if the controller crashes or the update fails midway,
+		// the resource will be left in a non-ready state, indicating a potential inconsistency.
+		if cachedSnat.Status.Ready {
+			klog.V(3).Infof("snat %s spec changed, marking as not ready before update", key)
+			if err = c.patchSnatStatus(key, oldV4ip, cachedSnat.Status.V6ip, cachedSnat.Status.NatGwDp, "", false); err != nil {
+				klog.Errorf("failed to mark snat %s as not ready, %v", key, err)
+				return err
+			}
+		}
+		// delete old rule; finalDeleteSnatInPod resolves identity from Status
+		if err = c.finalDeleteSnatInPod(key, cachedSnat); err != nil {
+			return err
+		}
+		if err = c.createSnatInPod(eip.Spec.NatGwDp, newV4ip, newV4Cidr); err != nil {
+			klog.Errorf("failed to create snat %s, %v", key, err)
+			return err
+		}
+		if err = c.patchSnatStatus(key, newV4ip, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
+			klog.Errorf("failed to patch status for snat %s, %v", key, err)
+			return err
+		}
 		if err = c.patchSnatLabel(key, eip); err != nil {
 			klog.Errorf("failed to patch label for snat %s, %v", key, err)
 			return err
 		}
 		if err = c.patchEipStatus(cachedSnat.Spec.EIP, "", "", "", true); err != nil {
-			// refresh eip nats
-			klog.Errorf("failed to patch fip use eip %s, %v", key, err)
+			klog.Errorf("failed to patch snat use eip %s, %v", key, err)
 			return err
 		}
+		// Reset old EIP after all 4 dimensions are updated.
+		// This must NOT be in enqueue — async reset there could race with handler's
+		// patchEipStatus, causing the old EIP's nat label to be cleared before the
+		// new EIP is fully bound, leaving a window where the old EIP appears free.
+		if oldEipName := cachedSnat.Annotations[util.VpcEipAnnotation]; oldEipName != "" && oldEipName != cachedSnat.Spec.EIP {
+			c.resetIptablesEipQueue.AddAfter(oldEipName, 3*time.Second)
+		}
+		if err = c.handleAddIptablesSnatFinalizer(key); err != nil {
+			klog.Errorf("failed to handle add finalizer for snat %s, %v", key, err)
+			return err
+		}
+		return nil
 	}
+
 	// redo
 	if !cachedSnat.Status.Ready &&
 		cachedSnat.Status.Redo != "" &&
 		cachedSnat.Status.V4ip != "" &&
 		cachedSnat.DeletionTimestamp.IsZero() {
-		gwPod, err := c.getNatGwPod(eip.Spec.NatGwDp)
+		gwPod, err := c.getNatGwPod(cachedSnat.Status.NatGwDp)
 		if err != nil {
 			klog.Error(err)
 			return err
 		}
-		// compare gw pod started time with snat redo time. if redo time before gw pod started. redo again
+		// If Pod started before the redo timestamp, it has not restarted since
+		// the redo was marked — iptables rules are still intact, skip re-creation.
 		snatRedo, _ := time.ParseInLocation("2006-01-02T15:04:05", cachedSnat.Status.Redo, time.Local)
-		if cachedSnat.Status.Ready && cachedSnat.Status.V4ip != "" && gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: snatRedo}) {
-			// already ok
-			klog.V(3).Infof("snat %s already ok", key)
+		if len(gwPod.Status.ContainerStatuses) == 0 || gwPod.Status.ContainerStatuses[0].State.Running == nil {
+			return fmt.Errorf("snat %s: gateway pod container not running, will retry redo", key)
+		}
+		if gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: snatRedo}) {
+			klog.V(3).Infof("snat %s: pod started before redo mark, rules intact, skip", key)
 			return nil
 		}
-		if err = c.createSnatInPod(cachedSnat.Status.NatGwDp, cachedSnat.Status.V4ip, v4CidrSpec); err != nil {
+		if err = c.createSnatInPod(cachedSnat.Status.NatGwDp, cachedSnat.Status.V4ip, cachedSnat.Status.InternalCIDR); err != nil {
 			klog.Errorf("failed to create new snat, %v", err)
 			return err
 		}
@@ -1124,7 +1418,8 @@ func (c *Controller) patchDnatLabel(key string, eip *kubeovnv1.IptablesEIP) erro
 			util.EipV4IpLabel:           eip.Spec.V4ip,
 		}
 		needUpdateLabel = true
-	} else if dnat.Labels[util.SubnetNameLabel] != eip.Spec.NatGwDp ||
+	} else if dnat.Labels[util.VpcNatGatewayNameLabel] != eip.Spec.NatGwDp ||
+		dnat.Labels[util.VpcDnatEPortLabel] != dnat.Spec.ExternalPort ||
 		dnat.Labels[util.EipV4IpLabel] != eip.Spec.V4ip {
 		op = "replace"
 		dnat.Labels[util.VpcNatGatewayNameLabel] = eip.Spec.NatGwDp
@@ -1394,7 +1689,221 @@ func (c *Controller) createFipInPod(dp, v4ip, internalIP string) error {
 	return nil
 }
 
-func (c *Controller) deleteFipInPod(dp, v4ip, internalIP string) error {
+// finalDeleteFipInPod resolves (natGwDp, v4ip) from the FIP CR's Status,
+// with best-effort fallback to the EIP resource when Status is incomplete.
+// Then delegates to deleteFipInPod to execute the actual shell deletion.
+//
+// Used by both the delete path (Status may be empty) and the spec-change path
+// (Status guaranteed non-empty by the V4ip guard).
+func (c *Controller) finalDeleteFipInPod(key string, cachedFip *kubeovnv1.IptablesFIPRule) error {
+	klog.V(3).Infof("final delete fip '%s' in pod", key)
+	var firstErr error
+	statusV4ip := cachedFip.Status.V4ip
+	statusNatGwDp := cachedFip.Status.NatGwDp
+	if statusV4ip == "" {
+		klog.Warningf("fip %s has empty Status.V4ip, fallback to eip %s", key, cachedFip.Spec.EIP)
+		eip, err := c.GetEip(cachedFip.Spec.EIP)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.Errorf("fip %s: eip %s not found, skip pod cleanup", key, cachedFip.Spec.EIP)
+				return nil
+			}
+			klog.Errorf("failed to get eip %s for fip %s, %v", cachedFip.Spec.EIP, key, err)
+			return err
+		}
+		statusV4ip = eip.Status.IP
+		if statusNatGwDp == "" {
+			statusNatGwDp = eip.Spec.NatGwDp
+		}
+	}
+	if statusV4ip == "" || statusNatGwDp == "" {
+		klog.Warningf("fip %s: skip status-based cleanup due to incomplete identity (v4ip=%q, natGwDp=%q)", key, statusV4ip, statusNatGwDp)
+	} else if err := c.deleteFipInPod(statusNatGwDp, statusV4ip); err != nil {
+		klog.Errorf("failed to delete fip %s, %v", key, err)
+		firstErr = err
+	}
+
+	// Spec-change crash: Status has old IP (V4ip != "") but Ready=false means a spec
+	// change crashed midway. Pod may have a new-IP rule while Status still points to the old IP.
+	if !cachedFip.Status.Ready && cachedFip.Status.V4ip != "" {
+		eip, err := c.GetEip(cachedFip.Spec.EIP)
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return err
+			}
+			klog.Warningf("fip %s not ready: eip %s not found, skip spec-based cleanup", key, cachedFip.Spec.EIP)
+			return firstErr
+		}
+		specV4ip := eip.Status.IP
+		specNatGwDp := eip.Spec.NatGwDp
+		if specV4ip == "" || specNatGwDp == "" {
+			klog.Warningf("fip %s not ready: skip spec-based cleanup due to incomplete spec identity (v4ip=%q, natGwDp=%q)", key, specV4ip, specNatGwDp)
+			return firstErr
+		}
+		if specV4ip != statusV4ip || specNatGwDp != statusNatGwDp {
+			if err = c.deleteFipInPod(specNatGwDp, specV4ip); err != nil {
+				klog.Errorf("failed spec-based cleanup for fip %s, %v", key, err)
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+	}
+	return firstErr
+}
+
+// finalDeleteDnatInPod resolves (natGwDp, protocol, v4ip, externalPort) from the DNAT CR's
+// Status, with best-effort fallback to EIP/Spec when Status is incomplete.
+// Then delegates to deleteDnatInPod to execute the actual shell deletion.
+func (c *Controller) finalDeleteDnatInPod(key string, cachedDnat *kubeovnv1.IptablesDnatRule) error {
+	klog.V(3).Infof("final delete dnat '%s' in pod", key)
+	var firstErr error
+	statusV4ip := cachedDnat.Status.V4ip
+	statusNatGwDp := cachedDnat.Status.NatGwDp
+	if statusV4ip == "" {
+		klog.Warningf("dnat %s has empty Status.V4ip, fallback to eip %s", key, cachedDnat.Spec.EIP)
+		eip, err := c.GetEip(cachedDnat.Spec.EIP)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.Errorf("dnat %s: eip %s not found, skip pod cleanup", key, cachedDnat.Spec.EIP)
+				return nil
+			}
+			return err
+		}
+		statusV4ip = eip.Status.IP
+		if statusNatGwDp == "" {
+			statusNatGwDp = eip.Spec.NatGwDp
+		}
+	}
+	statusProtocol := cachedDnat.Status.Protocol
+	if statusProtocol == "" {
+		klog.Warningf("dnat %s has empty Status.Protocol, fallback to Spec", key)
+		statusProtocol = cachedDnat.Spec.Protocol
+	}
+	if statusProtocol == "" {
+		klog.Errorf("dnat %s has v4ip %s but protocol is empty in both Status and Spec, skip pod cleanup", key, statusV4ip)
+		return nil
+	}
+	statusExternalPort := cachedDnat.Status.ExternalPort
+	if statusExternalPort == "" {
+		klog.Warningf("dnat %s has empty Status.ExternalPort, fallback to Spec", key)
+		statusExternalPort = cachedDnat.Spec.ExternalPort
+	}
+	if statusExternalPort == "" {
+		klog.Errorf("dnat %s has v4ip %s but externalPort is empty in both Status and Spec, skip pod cleanup", key, statusV4ip)
+		return nil
+	}
+	if statusV4ip == "" || statusNatGwDp == "" {
+		klog.Warningf("dnat %s: skip status-based cleanup due to incomplete identity (v4ip=%q, natGwDp=%q)", key, statusV4ip, statusNatGwDp)
+	} else if err := c.deleteDnatInPod(statusNatGwDp, statusProtocol,
+		statusV4ip, statusExternalPort); err != nil {
+		klog.Errorf("failed to delete dnat %s, %v", key, err)
+		firstErr = err
+	}
+
+	// Spec-change crash: Status has old IP (V4ip != "") but Ready=false means a spec
+	// change crashed midway. Pod may have a new-IP rule while Status still points to the old IP.
+	if !cachedDnat.Status.Ready && cachedDnat.Status.V4ip != "" {
+		eip, err := c.GetEip(cachedDnat.Spec.EIP)
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return err
+			}
+			klog.Warningf("dnat %s not ready: eip %s not found, skip spec-based cleanup", key, cachedDnat.Spec.EIP)
+			return firstErr
+		}
+		specV4ip := eip.Status.IP
+		specNatGwDp := eip.Spec.NatGwDp
+		specProtocol := cachedDnat.Spec.Protocol
+		specExternalPort := cachedDnat.Spec.ExternalPort
+		if specV4ip == "" || specNatGwDp == "" || specProtocol == "" || specExternalPort == "" {
+			klog.Warningf("dnat %s not ready: skip spec-based cleanup due to incomplete spec identity (v4ip=%q, natGwDp=%q, protocol=%q, externalPort=%q)",
+				key, specV4ip, specNatGwDp, specProtocol, specExternalPort)
+			return firstErr
+		}
+		if specV4ip != statusV4ip || specNatGwDp != statusNatGwDp || specProtocol != statusProtocol || specExternalPort != statusExternalPort {
+			if err = c.deleteDnatInPod(specNatGwDp, specProtocol, specV4ip, specExternalPort); err != nil {
+				klog.Errorf("failed spec-based cleanup for dnat %s, %v", key, err)
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+	}
+	return firstErr
+}
+
+// finalDeleteSnatInPod resolves (natGwDp, v4ip, v4Cidr) from the SNAT CR's Status,
+// with best-effort fallback to EIP/Spec when Status is incomplete.
+// Then delegates to deleteSnatInPod to execute the actual shell deletion.
+func (c *Controller) finalDeleteSnatInPod(key string, cachedSnat *kubeovnv1.IptablesSnatRule) error {
+	klog.V(3).Infof("final delete snat '%s' in pod", key)
+	var firstErr error
+	statusV4ip := cachedSnat.Status.V4ip
+	statusNatGwDp := cachedSnat.Status.NatGwDp
+	if statusV4ip == "" {
+		klog.Warningf("snat %s has empty Status.V4ip, fallback to eip %s", key, cachedSnat.Spec.EIP)
+		eip, err := c.GetEip(cachedSnat.Spec.EIP)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.Errorf("snat %s: eip %s not found, skip pod cleanup", key, cachedSnat.Spec.EIP)
+				return nil
+			}
+			return err
+		}
+		statusV4ip = eip.Status.IP
+		if statusNatGwDp == "" {
+			statusNatGwDp = eip.Spec.NatGwDp
+		}
+	}
+	statusV4Cidr, _ := util.SplitStringIP(cachedSnat.Status.InternalCIDR)
+	if statusV4Cidr == "" {
+		klog.Warningf("snat %s has empty Status.InternalCIDR, fallback to Spec", key)
+		statusV4Cidr, _ = util.SplitStringIP(cachedSnat.Spec.InternalCIDR)
+	}
+	if statusV4Cidr == "" {
+		klog.Errorf("snat %s has v4ip %s but v4Cidr is empty in both Status and Spec, skip pod cleanup", key, statusV4ip)
+		return nil
+	}
+	if statusV4ip == "" || statusNatGwDp == "" {
+		klog.Warningf("snat %s: skip status-based cleanup due to incomplete identity (v4ip=%q, natGwDp=%q)", key, statusV4ip, statusNatGwDp)
+	} else if err := c.deleteSnatInPod(statusNatGwDp, statusV4ip, statusV4Cidr); err != nil {
+		klog.Errorf("failed to delete snat %s, %v", key, err)
+		firstErr = err
+	}
+
+	// Spec-change crash: Status has old IP (V4ip != "") but Ready=false means a spec
+	// change crashed midway. Pod may have a new-IP rule while Status still points to the old IP.
+	if !cachedSnat.Status.Ready && cachedSnat.Status.V4ip != "" {
+		eip, err := c.GetEip(cachedSnat.Spec.EIP)
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return err
+			}
+			klog.Warningf("snat %s not ready: eip %s not found, skip spec-based cleanup", key, cachedSnat.Spec.EIP)
+			return firstErr
+		}
+		specV4ip := eip.Status.IP
+		specNatGwDp := eip.Spec.NatGwDp
+		specV4Cidr, _ := util.SplitStringIP(cachedSnat.Spec.InternalCIDR)
+		if specV4ip == "" || specNatGwDp == "" || specV4Cidr == "" {
+			klog.Warningf("snat %s not ready: skip spec-based cleanup due to incomplete spec identity (v4ip=%q, natGwDp=%q, v4Cidr=%q)",
+				key, specV4ip, specNatGwDp, specV4Cidr)
+			return firstErr
+		}
+		if specV4ip != statusV4ip || specNatGwDp != statusNatGwDp || specV4Cidr != statusV4Cidr {
+			if err = c.deleteSnatInPod(specNatGwDp, specV4ip, specV4Cidr); err != nil {
+				klog.Errorf("failed spec-based cleanup for snat %s, %v", key, err)
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+	}
+	return firstErr
+}
+
+func (c *Controller) deleteFipInPod(dp, v4ip string) error {
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -1403,11 +1912,8 @@ func (c *Controller) deleteFipInPod(dp, v4ip, internalIP string) error {
 		klog.Error(err)
 		return err
 	}
-	// del nat
-	var delRules []string
-	rule := fmt.Sprintf("%s,%s", v4ip, internalIP)
-	delRules = append(delRules, rule)
-	if err = c.execNatGwRules(gwPod, natGwSubnetFipDel, delRules); err != nil {
+	// del_floating_ip matches by EIP only (FIP is 1:1, identity = EIP)
+	if err = c.execNatGwRules(gwPod, natGwSubnetFipDel, []string{v4ip}); err != nil {
 		klog.Errorf("failed to delete fip, err: %v", err)
 		return err
 	}
@@ -1431,7 +1937,7 @@ func (c *Controller) createDnatInPod(dp, protocol, v4ip, internalIP, externalPor
 	return nil
 }
 
-func (c *Controller) deleteDnatInPod(dp, protocol, v4ip, internalIP, externalPort, internalPort string) error {
+func (c *Controller) deleteDnatInPod(dp, protocol, v4ip, externalPort string) error {
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -1441,11 +1947,9 @@ func (c *Controller) deleteDnatInPod(dp, protocol, v4ip, internalIP, externalPor
 		return err
 	}
 
-	// del nat
-	var delRules []string
-	rule := fmt.Sprintf("%s,%s,%s,%s,%s", v4ip, externalPort, protocol, internalIP, internalPort)
-	delRules = append(delRules, rule)
-	if err = c.execNatGwRules(gwPod, natGwDnatDel, delRules); err != nil {
+	// del_dnat matches by identity triplet (EIP, ExternalPort, Protocol) only
+	rule := fmt.Sprintf("%s,%s,%s", v4ip, externalPort, protocol)
+	if err = c.execNatGwRules(gwPod, natGwDnatDel, []string{rule}); err != nil {
 		klog.Errorf("failed to delete dnat, err: %v", err)
 		return err
 	}
@@ -1496,39 +2000,6 @@ func (c *Controller) deleteSnatInPod(dp, v4ip, internalCIDR string) error {
 		return err
 	}
 	return nil
-}
-
-func (c *Controller) fipChangeEip(fip *kubeovnv1.IptablesFIPRule, eip *kubeovnv1.IptablesEIP) bool {
-	if fip.Status.V4ip == "" || eip.Status.IP == "" {
-		// eip created but not ready
-		return false
-	}
-	if fip.Status.V4ip != eip.Status.IP {
-		return true
-	}
-	return false
-}
-
-func (c *Controller) dnatChangeEip(dnat *kubeovnv1.IptablesDnatRule, eip *kubeovnv1.IptablesEIP) bool {
-	if dnat.Status.V4ip == "" || eip.Status.IP == "" {
-		// eip created but not ready
-		return false
-	}
-	if dnat.Status.V4ip != eip.Status.IP {
-		return true
-	}
-	return false
-}
-
-func (c *Controller) snatChangeEip(snat *kubeovnv1.IptablesSnatRule, eip *kubeovnv1.IptablesEIP) bool {
-	if snat.Status.V4ip == "" || eip.Status.IP == "" {
-		// eip created but not ready
-		return false
-	}
-	if snat.Status.V4ip != eip.Status.IP {
-		return true
-	}
-	return false
 }
 
 func (c *Controller) isDnatDuplicated(gwName, eipName, dnatName, externalPort, protocol string) (bool, error) {

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -94,6 +94,23 @@ func (v *ValidatingHook) iptablesEIPUpdateHook(ctx context.Context, req admissio
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
+	// IptablesEIP is an internal resource of a NatGwDp. Once created and Ready,
+	// its Spec (including V4ip address) is immutable — the Ready check below blocks
+	// any Spec change. NatGwDp is additionally immutable once set (even before Ready),
+	// because migrating an EIP across gateways is not supported.
+	//
+	// This immutability is a key invariant for NAT rule controllers: they rely on
+	// EIP.Status.IP being stable for the lifetime of the EIP resource.
+
+	// NatGwDp is immutable once set: changing the gateway would require migrating
+	// all associated NAT rules (FIP/DNAT/SNAT) to a different gateway pod,
+	// which is not supported by the update handlers.
+	if eipOld.Spec.NatGwDp != "" && eipNew.Spec.NatGwDp != eipOld.Spec.NatGwDp {
+		err := fmt.Errorf("IptablesEIP %q: NatGwDp is immutable once set (old: %s, new: %s)",
+			eipNew.Name, eipOld.Spec.NatGwDp, eipNew.Spec.NatGwDp)
+		return ctrlwebhook.Errored(http.StatusBadRequest, err)
+	}
+
 	if eipOld.Spec != eipNew.Spec {
 		if eipOld.Status.Ready && eipNew.Status.Redo == eipOld.Status.Redo {
 			err := fmt.Errorf("IptablesEIP \"%s\" is ready, does not support change", eipNew.Name)
@@ -192,19 +209,13 @@ func (v *ValidatingHook) iptablesDnatUpdateHook(ctx context.Context, req admissi
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
-	if dnatOld.Spec != dnatNew.Spec {
-		if dnatOld.Status.Ready && dnatOld.Status.Redo == dnatNew.Status.Redo {
-			err := fmt.Errorf("IptablesDnatRule \"%s\" is ready, does not support change", dnatNew.Name)
-			return ctrlwebhook.Errored(http.StatusBadRequest, err)
-		}
+	if dnatNew.Spec != dnatOld.Spec {
 		if err := v.ValidateVpcNatConfig(ctx); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
-
 		if err := v.ValidateVpcNatGatewayConfig(ctx); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
-
 		if err := v.ValidateIptablesDnat(ctx, &dnatNew); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
@@ -245,19 +256,13 @@ func (v *ValidatingHook) iptablesSnatUpdateHook(ctx context.Context, req admissi
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
-	if snatOld.Spec != snatNew.Spec {
-		if snatOld.Status.Ready && snatOld.Status.Redo == snatNew.Status.Redo {
-			err := fmt.Errorf("IptablesSnatRule \"%s\" is ready, does not support change", snatNew.Name)
-			return ctrlwebhook.Errored(http.StatusBadRequest, err)
-		}
+	if snatNew.Spec != snatOld.Spec {
 		if err := v.ValidateVpcNatConfig(ctx); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
-
 		if err := v.ValidateVpcNatGatewayConfig(ctx); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
-
 		if err := v.ValidateIptablesSnat(ctx, &snatNew); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
@@ -299,22 +304,17 @@ func (v *ValidatingHook) iptablesFipUpdateHook(ctx context.Context, req admissio
 	}
 
 	if fipNew.Spec != fipOld.Spec {
-		if fipOld.Status.Ready && fipNew.Status.Redo == fipOld.Status.Redo {
-			err := fmt.Errorf("IptablesFIPRule \"%s\" is ready, does not support change", fipNew.Name)
-			return ctrlwebhook.Errored(http.StatusBadRequest, err)
-		}
 		if err := v.ValidateVpcNatConfig(ctx); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
-
 		if err := v.ValidateVpcNatGatewayConfig(ctx); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
-
 		if err := v.ValidateIptablesFip(ctx, &fipNew); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
 	}
+
 	return ctrlwebhook.Allowed("bypass")
 }
 
@@ -483,6 +483,18 @@ func (v *ValidatingHook) ValidateIptablesDnat(ctx context.Context, dnat *ovnv1.I
 		return err
 	}
 
+	// Check FIP/DNAT exclusivity: FIP claims all traffic to the EIP (EXCLUSIVE_DNAT),
+	// which shadows any port-specific DNAT rules (SHARED_DNAT) for the same EIP.
+	if eip.Status.IP != "" {
+		fipList := &ovnv1.IptablesFIPRuleList{}
+		if err := v.cache.List(ctx, fipList, cli.MatchingLabels{util.EipV4IpLabel: eip.Status.IP}); err != nil {
+			return fmt.Errorf("failed to list iptables FIP rules: %w", err)
+		}
+		if len(fipList.Items) != 0 {
+			return fmt.Errorf("EIP %q is already used by FIP rule %q; floating IP requires exclusive use of the EIP (FIP matches all traffic, shadowing port-specific DNAT rules)", dnat.Spec.EIP, fipList.Items[0].Name)
+		}
+	}
+
 	return nil
 }
 
@@ -517,6 +529,18 @@ func (v *ValidatingHook) ValidateIptablesFip(ctx context.Context, fip *ovnv1.Ipt
 	if net.ParseIP(fip.Spec.InternalIP) == nil {
 		err := fmt.Errorf("internalIP %s is not a valid", fip.Spec.InternalIP)
 		return err
+	}
+
+	// Check FIP/DNAT exclusivity: FIP claims all traffic to the EIP (EXCLUSIVE_DNAT),
+	// which shadows any port-specific DNAT rules (SHARED_DNAT) for the same EIP.
+	if eip.Status.IP != "" {
+		dnatList := &ovnv1.IptablesDnatRuleList{}
+		if err := v.cache.List(ctx, dnatList, cli.MatchingLabels{util.EipV4IpLabel: eip.Status.IP}); err != nil {
+			return fmt.Errorf("failed to list iptables DNAT rules: %w", err)
+		}
+		if len(dnatList.Items) != 0 {
+			return fmt.Errorf("EIP %q is already used by DNAT rule %q; floating IP requires exclusive use of the EIP (FIP matches all traffic, shadowing port-specific DNAT rules)", fip.Spec.EIP, dnatList.Items[0].Name)
+		}
 	}
 
 	return nil

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -290,6 +290,48 @@ func hairpinSnatRuleExists(natGwPodName, eip string) bool {
 	return re.MatchString(output)
 }
 
+// fipDnatRuleExists checks if the FIP DNAT rule exists in the NAT gateway pod.
+// iptables-save format: -A EXCLUSIVE_DNAT -d <eip>/32 -j DNAT --to-destination <internalIp>
+func fipDnatRuleExists(natGwPodName, eip, internalIP string) bool {
+	output := iptablesSaveNat(natGwPodName)
+	pattern := fmt.Sprintf(`-A EXCLUSIVE_DNAT -d \b%s/32\b .* --to-destination \b%s\b`,
+		regexp.QuoteMeta(eip), regexp.QuoteMeta(internalIP))
+	re := regexp.MustCompile(pattern)
+	return re.MatchString(output)
+}
+
+// fipSnatRuleExists checks if the FIP SNAT rule exists in the NAT gateway pod.
+// iptables-save format: -A EXCLUSIVE_SNAT -s <internalIp>/32 -j SNAT --to-source <eip>
+func fipSnatRuleExists(natGwPodName, eip, internalIP string) bool {
+	output := iptablesSaveNat(natGwPodName)
+	pattern := fmt.Sprintf(`-A EXCLUSIVE_SNAT -s \b%s/32\b .* --to-source \b%s\b`,
+		regexp.QuoteMeta(internalIP), regexp.QuoteMeta(eip))
+	re := regexp.MustCompile(pattern)
+	return re.MatchString(output)
+}
+
+// dnatRuleExists checks if the DNAT rule exists in the NAT gateway pod.
+// iptables-save format: -A SHARED_DNAT -d <eip>/32 -p <protocol> -m <protocol> --dport <externalPort> -j DNAT --to-destination <internalIp>:<internalPort>
+// Note: iptables-save inserts "-m <protocol>" after "-p <protocol>", use .* to absorb it.
+func dnatRuleExists(natGwPodName, eip, externalPort, protocol, internalIP, internalPort string) bool {
+	output := iptablesSaveNat(natGwPodName)
+	pattern := fmt.Sprintf(`-A SHARED_DNAT -d \b%s/32\b -p %s .* --dport %s -j DNAT --to-destination \b%s:%s\b`,
+		regexp.QuoteMeta(eip), regexp.QuoteMeta(protocol),
+		regexp.QuoteMeta(externalPort), regexp.QuoteMeta(internalIP), regexp.QuoteMeta(internalPort))
+	re := regexp.MustCompile(pattern)
+	return re.MatchString(output)
+}
+
+// snatRuleExists checks if the SNAT rule exists in the NAT gateway pod.
+// iptables-save format: -A SHARED_SNAT -s <internalCIDR> ... -j SNAT --to-source <eip>
+func snatRuleExists(natGwPodName, eip, internalCIDR string) bool {
+	output := iptablesSaveNat(natGwPodName)
+	pattern := fmt.Sprintf(`-A SHARED_SNAT\b.*-s %s\b.*--to-source %s\b`,
+		regexp.QuoteMeta(internalCIDR), regexp.QuoteMeta(eip))
+	re := regexp.MustCompile(pattern)
+	return re.MatchString(output)
+}
+
 var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 	f := framework.NewDefaultFramework("iptables-vpc-nat-gw")
 
@@ -590,6 +632,25 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		ginkgo.By("[hairpin SNAT] Verifying hairpin SNAT rule exists after EIP creation")
 		vpcNatGwPodName := util.GenNatGwPodName(vpcNatGwName)
 		snatEip = iptablesEIPClient.Get(snatEipName)
+		fipEip = iptablesEIPClient.Get(fipEipName)
+
+		// Verify FIP iptables rules exist after creation
+		ginkgo.By("Verifying FIP iptables rules exist in NAT gateway pod")
+		gomega.Eventually(func() bool {
+			return fipDnatRuleExists(vpcNatGwPodName, fipEip.Status.IP, fipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"FIP DNAT rule should exist in iptables after FIP creation")
+		gomega.Eventually(func() bool {
+			return fipSnatRuleExists(vpcNatGwPodName, fipEip.Status.IP, fipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"FIP SNAT rule should exist in iptables after FIP creation")
+
+		// Verify SNAT iptables rule exists after creation
+		ginkgo.By("Verifying SNAT iptables rule exists in NAT gateway pod")
+		gomega.Eventually(func() bool {
+			return snatRuleExists(vpcNatGwPodName, snatEip.Status.IP, overlaySubnetV4Cidr)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"SNAT rule should exist in iptables after SNAT creation")
 		if !hairpinSnatChainExists(vpcNatGwPodName) {
 			framework.Logf("HAIRPIN_SNAT chain not found, skipping hairpin EIP verification (feature requires v1.15+)")
 		} else {
@@ -693,6 +754,14 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 			iptablesDnatRuleClient.DeleteSync(dnatName)
 		})
 
+		// Verify DNAT iptables rule exists after creation
+		ginkgo.By("Verifying DNAT iptables rule exists in NAT gateway pod")
+		dnatEip = iptablesEIPClient.Get(dnatEipName)
+		gomega.Eventually(func() bool {
+			return dnatRuleExists(vpcNatGwPodName, dnatEip.Status.IP, "80", "tcp", dnatVip.Status.V4ip, "8080")
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"DNAT rule should exist in iptables after DNAT creation")
+
 		// share eip case
 		ginkgo.By("Creating share vip")
 		shareVip := framework.MakeVip(f.Namespace.Name, sharedVipName, overlaySubnetName, "", "", "")
@@ -780,13 +849,16 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		nats := []string{util.DnatUsingEip, util.FipUsingEip, util.SnatUsingEip}
 		framework.ExpectEqual(shareEip.Status.Nat, strings.Join(nats, ","))
 
+		// Delete SNAT and EIP to verify iptables rule and hairpin cleanup.
+		// Deletion must happen unconditionally; hairpin verification is conditional on chain support.
+		snatEipIP := snatEip.Status.IP
+		ginkgo.By("Deleting SNAT and its EIP to verify rule cleanup")
+		iptablesSnatRuleClient.DeleteSync(snatName)
+		iptablesEIPClient.DeleteSync(snatEipName)
+
 		// Verify hairpin SNAT rule cleanup when EIP is deleted.
 		// Hairpin lifecycle is 1:1 with EIP: created together, deleted together.
 		if hairpinSnatChainExists(vpcNatGwPodName) {
-			snatEipIP := snatEip.Status.IP
-			ginkgo.By("[hairpin SNAT] Deleting EIP and its SNAT to verify hairpin rule cleanup")
-			iptablesSnatRuleClient.DeleteSync(snatName)
-			iptablesEIPClient.DeleteSync(snatEipName)
 			ginkgo.By("[hairpin SNAT] Verifying hairpin rule for the deleted SNAT EIP is removed")
 			gomega.Eventually(func() bool {
 				return hairpinSnatRuleExists(vpcNatGwPodName, snatEipIP)
@@ -796,6 +868,35 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 			gomega.Expect(hairpinSnatRuleExists(vpcNatGwPodName, shareEip.Status.IP)).To(gomega.BeTrue(),
 				"Hairpin SNAT rule for the shared SNAT EIP should NOT be affected by deleting a different SNAT")
 		}
+
+		// Verify SNAT iptables rule is removed after deletion (always, regardless of hairpin support)
+		ginkgo.By("Verifying SNAT iptables rule is removed from NAT gateway pod after deletion")
+		gomega.Eventually(func() bool {
+			return snatRuleExists(vpcNatGwPodName, snatEip.Status.IP, overlaySubnetV4Cidr)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"SNAT rule should be removed from iptables after SNAT deletion")
+
+		// Verify FIP iptables rules are removed after deletion
+		ginkgo.By("Deleting FIP to verify iptables rule cleanup")
+		iptablesFIPClient.DeleteSync(fipName)
+		ginkgo.By("Verifying FIP iptables rules are removed from NAT gateway pod after deletion")
+		gomega.Eventually(func() bool {
+			return fipDnatRuleExists(vpcNatGwPodName, fipEip.Status.IP, fipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"FIP DNAT rule should be removed from iptables after FIP deletion")
+		gomega.Eventually(func() bool {
+			return fipSnatRuleExists(vpcNatGwPodName, fipEip.Status.IP, fipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"FIP SNAT rule should be removed from iptables after FIP deletion")
+
+		// Verify DNAT iptables rule is removed after deletion
+		ginkgo.By("Deleting DNAT to verify iptables rule cleanup")
+		iptablesDnatRuleClient.DeleteSync(dnatName)
+		ginkgo.By("Verifying DNAT iptables rule is removed from NAT gateway pod after deletion")
+		gomega.Eventually(func() bool {
+			return dnatRuleExists(vpcNatGwPodName, dnatEip.Status.IP, "80", "tcp", dnatVip.Status.V4ip, "8080")
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"DNAT rule should be removed from iptables after DNAT deletion")
 
 		// All cleanup is handled by DeferCleanup above, no need for manual cleanup
 	})
@@ -1248,6 +1349,298 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 
 		// All cleanup is handled by DeferCleanup above
 		ginkgo.By("11. Test completed: VPC NAT Gateway with no IPAM NAD and noDefaultEIP works correctly")
+	})
+
+	framework.ConformanceIt("[6] FIP/DNAT/SNAT spec update with iptables rule verification", func() {
+		f.SkipVersionPriorTo(1, 16, "FIP/DNAT/SNAT spec update was introduced in v1.16")
+
+		overlaySubnetV4Cidr := "10.0.6.0/24"
+		overlaySubnetV4Gw := "10.0.6.1"
+		lanIP := "10.0.6.254"
+		setupVpcNatGwTestEnvironment(
+			f, dockerExtNet1Network, attachNetClient,
+			subnetClient, vpcClient, vpcNatGwClient,
+			vpcName, overlaySubnetName, vpcNatGwName, "",
+			overlaySubnetV4Cidr, overlaySubnetV4Gw, lanIP,
+			dockerExtNet1Name, networkAttachDefName, net1NicName,
+			externalSubnetProvider,
+			true, nil,
+		)
+		vpcNatGwPodName := util.GenNatGwPodName(vpcNatGwName)
+
+		// ===================== FIP spec update =====================
+		ginkgo.By("1. Creating two VIPs for FIP (old and new InternalIP)")
+		randomSuffix := framework.RandomSuffix()
+		oldFipVipName := "old-fip-vip-" + randomSuffix
+		newFipVipName := "new-fip-vip-" + randomSuffix
+		oldFipVip := framework.MakeVip(f.Namespace.Name, oldFipVipName, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(oldFipVip)
+		ginkgo.DeferCleanup(func() { vipClient.DeleteSync(oldFipVipName) })
+		oldFipVip = vipClient.Get(oldFipVipName)
+
+		newFipVip := framework.MakeVip(f.Namespace.Name, newFipVipName, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(newFipVip)
+		ginkgo.DeferCleanup(func() { vipClient.DeleteSync(newFipVipName) })
+		newFipVip = vipClient.Get(newFipVipName)
+
+		ginkgo.By("2. Creating two EIPs for FIP (old and new EIP)")
+		oldFipEipName := "old-fip-eip-" + randomSuffix
+		newFipEipName := "new-fip-eip-" + randomSuffix
+		oldFipEip := framework.MakeIptablesEIP(oldFipEipName, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(oldFipEip)
+		ginkgo.DeferCleanup(func() { iptablesEIPClient.DeleteSync(oldFipEipName) })
+		oldFipEip = iptablesEIPClient.Get(oldFipEipName)
+
+		newFipEip := framework.MakeIptablesEIP(newFipEipName, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(newFipEip)
+		ginkgo.DeferCleanup(func() { iptablesEIPClient.DeleteSync(newFipEipName) })
+		newFipEip = iptablesEIPClient.Get(newFipEipName)
+
+		ginkgo.By("3. Creating FIP with old EIP and old InternalIP")
+		fipName := "fip-update-" + randomSuffix
+		fip := framework.MakeIptablesFIPRule(fipName, oldFipEipName, oldFipVip.Status.V4ip)
+		_ = iptablesFIPClient.CreateSync(fip)
+		ginkgo.DeferCleanup(func() { iptablesFIPClient.DeleteSync(fipName) })
+
+		ginkgo.By("4. Verifying old FIP iptables rules exist")
+		gomega.Eventually(func() bool {
+			return fipDnatRuleExists(vpcNatGwPodName, oldFipEip.Status.IP, oldFipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"FIP DNAT rule should exist with old EIP and old InternalIP")
+		gomega.Eventually(func() bool {
+			return fipSnatRuleExists(vpcNatGwPodName, oldFipEip.Status.IP, oldFipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"FIP SNAT rule should exist with old EIP and old InternalIP")
+
+		ginkgo.By("5. Updating FIP: changing both EIP and InternalIP simultaneously")
+		fip = iptablesFIPClient.Get(fipName)
+		modifiedFip := fip.DeepCopy()
+		modifiedFip.Spec.EIP = newFipEipName
+		modifiedFip.Spec.InternalIP = newFipVip.Status.V4ip
+		iptablesFIPClient.PatchSync(fip, modifiedFip, nil, 2*time.Minute)
+
+		ginkgo.By("6. Verifying old FIP iptables rules are removed")
+		gomega.Eventually(func() bool {
+			return fipDnatRuleExists(vpcNatGwPodName, oldFipEip.Status.IP, oldFipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"Old FIP DNAT rule should be removed after spec update")
+		gomega.Eventually(func() bool {
+			return fipSnatRuleExists(vpcNatGwPodName, oldFipEip.Status.IP, oldFipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"Old FIP SNAT rule should be removed after spec update")
+
+		ginkgo.By("7. Verifying new FIP iptables rules exist")
+		gomega.Eventually(func() bool {
+			return fipDnatRuleExists(vpcNatGwPodName, newFipEip.Status.IP, newFipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"New FIP DNAT rule should exist after spec update")
+		gomega.Eventually(func() bool {
+			return fipSnatRuleExists(vpcNatGwPodName, newFipEip.Status.IP, newFipVip.Status.V4ip)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"New FIP SNAT rule should exist after spec update")
+
+		ginkgo.By("8. Verifying FIP Status reflects new values (dimension 2)")
+		fip = iptablesFIPClient.Get(fipName)
+		framework.ExpectEqual(fip.Status.V4ip, newFipEip.Status.IP,
+			"FIP Status.V4ip should match new EIP IP")
+		framework.ExpectEqual(fip.Status.InternalIP, newFipVip.Status.V4ip,
+			"FIP Status.InternalIP should match new InternalIP")
+		framework.ExpectTrue(fip.Status.Ready, "FIP should be ready after update")
+
+		ginkgo.By("9. Verifying FIP Label reflects new EIP (dimension 3)")
+		framework.ExpectHaveKeyWithValue(fip.Labels, util.EipV4IpLabel, newFipEip.Spec.V4ip)
+		framework.ExpectHaveKeyWithValue(fip.Annotations, util.VpcEipAnnotation, newFipEipName)
+
+		// ===================== DNAT spec update =====================
+		ginkgo.By("10. Creating VIPs for DNAT (old and new InternalIP)")
+		oldDnatVipName := "old-dnat-vip-" + randomSuffix
+		newDnatVipName := "new-dnat-vip-" + randomSuffix
+		oldDnatVip := framework.MakeVip(f.Namespace.Name, oldDnatVipName, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(oldDnatVip)
+		ginkgo.DeferCleanup(func() { vipClient.DeleteSync(oldDnatVipName) })
+		oldDnatVip = vipClient.Get(oldDnatVipName)
+
+		newDnatVip := framework.MakeVip(f.Namespace.Name, newDnatVipName, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(newDnatVip)
+		ginkgo.DeferCleanup(func() { vipClient.DeleteSync(newDnatVipName) })
+		newDnatVip = vipClient.Get(newDnatVipName)
+
+		ginkgo.By("11. Creating EIPs for DNAT")
+		dnatEipName := "dnat-eip-" + randomSuffix
+		dnatEip := framework.MakeIptablesEIP(dnatEipName, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(dnatEip)
+		ginkgo.DeferCleanup(func() { iptablesEIPClient.DeleteSync(dnatEipName) })
+		dnatEip = iptablesEIPClient.Get(dnatEipName)
+
+		dnatEip2Name := "dnat-eip2-" + randomSuffix
+		dnatEip2 := framework.MakeIptablesEIP(dnatEip2Name, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(dnatEip2)
+		ginkgo.DeferCleanup(func() { iptablesEIPClient.DeleteSync(dnatEip2Name) })
+		dnatEip2 = iptablesEIPClient.Get(dnatEip2Name)
+
+		ginkgo.By("12. Creating DNAT with old InternalIP and port 80->8080")
+		dnatName := "dnat-update-" + randomSuffix
+		dnat := framework.MakeIptablesDnatRule(dnatName, dnatEipName, "80", "tcp", oldDnatVip.Status.V4ip, "8080")
+		_ = iptablesDnatRuleClient.CreateSync(dnat)
+		ginkgo.DeferCleanup(func() { iptablesDnatRuleClient.DeleteSync(dnatName) })
+
+		ginkgo.By("13. Verifying old DNAT iptables rule exists")
+		gomega.Eventually(func() bool {
+			return dnatRuleExists(vpcNatGwPodName, dnatEip.Status.IP, "80", "tcp", oldDnatVip.Status.V4ip, "8080")
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"DNAT rule should exist with old values")
+
+		ginkgo.By("14. Updating DNAT: changing InternalIP and InternalPort")
+		dnat = iptablesDnatRuleClient.Get(dnatName)
+		modifiedDnat := dnat.DeepCopy()
+		modifiedDnat.Spec.InternalIP = newDnatVip.Status.V4ip
+		modifiedDnat.Spec.InternalPort = "9090"
+		iptablesDnatRuleClient.PatchSync(dnat, modifiedDnat, nil, 2*time.Minute)
+
+		ginkgo.By("15. Verifying old DNAT iptables rule is removed")
+		gomega.Eventually(func() bool {
+			return dnatRuleExists(vpcNatGwPodName, dnatEip.Status.IP, "80", "tcp", oldDnatVip.Status.V4ip, "8080")
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"Old DNAT rule should be removed after spec update")
+
+		ginkgo.By("16. Verifying new DNAT iptables rule exists")
+		gomega.Eventually(func() bool {
+			return dnatRuleExists(vpcNatGwPodName, dnatEip.Status.IP, "80", "tcp", newDnatVip.Status.V4ip, "9090")
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"New DNAT rule should exist after spec update")
+
+		ginkgo.By("17. Verifying DNAT Status reflects new values")
+		dnat = iptablesDnatRuleClient.Get(dnatName)
+		framework.ExpectEqual(dnat.Status.InternalIP, newDnatVip.Status.V4ip,
+			"DNAT Status.InternalIP should match new InternalIP")
+		framework.ExpectEqual(dnat.Status.InternalPort, "9090",
+			"DNAT Status.InternalPort should match new InternalPort")
+		framework.ExpectTrue(dnat.Status.Ready, "DNAT should be ready after update")
+
+		// --- DNAT second update: change EIP + ExternalPort + Protocol (identity side) ---
+		ginkgo.By("17a. Updating DNAT: changing EIP to dnatEip2, ExternalPort, and Protocol (all identity fields)")
+		dnat = iptablesDnatRuleClient.Get(dnatName)
+		modifiedDnat2 := dnat.DeepCopy()
+		modifiedDnat2.Spec.EIP = dnatEip2Name
+		modifiedDnat2.Spec.ExternalPort = "443"
+		modifiedDnat2.Spec.Protocol = "udp"
+		iptablesDnatRuleClient.PatchSync(dnat, modifiedDnat2, nil, 2*time.Minute)
+
+		ginkgo.By("17b. Verifying old DNAT rule (from first update) is removed")
+		gomega.Eventually(func() bool {
+			return dnatRuleExists(vpcNatGwPodName, dnatEip.Status.IP, "80", "tcp", newDnatVip.Status.V4ip, "9090")
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"Previous DNAT rule should be removed after identity change")
+
+		ginkgo.By("17c. Verifying new DNAT rule with updated identity exists")
+		gomega.Eventually(func() bool {
+			return dnatRuleExists(vpcNatGwPodName, dnatEip2.Status.IP, "443", "udp", newDnatVip.Status.V4ip, "9090")
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"New DNAT rule should exist with new EIP, ExternalPort, Protocol")
+
+		ginkgo.By("17d. Verifying DNAT Status reflects all new values")
+		dnat = iptablesDnatRuleClient.Get(dnatName)
+		framework.ExpectEqual(dnat.Status.V4ip, dnatEip2.Status.IP,
+			"DNAT Status.V4ip should match new EIP IP")
+		framework.ExpectEqual(dnat.Status.ExternalPort, "443",
+			"DNAT Status.ExternalPort should match new ExternalPort")
+		framework.ExpectEqual(dnat.Status.Protocol, "udp",
+			"DNAT Status.Protocol should match new Protocol")
+		framework.ExpectTrue(dnat.Status.Ready, "DNAT should be ready after identity change")
+		framework.ExpectHaveKeyWithValue(dnat.Labels, util.EipV4IpLabel, dnatEip2.Spec.V4ip)
+		framework.ExpectHaveKeyWithValue(dnat.Annotations, util.VpcEipAnnotation, dnatEip2Name)
+
+		// ===================== SNAT spec update =====================
+		ginkgo.By("18. Creating EIPs for SNAT (old, new, and third)")
+		oldSnatEipName := "old-snat-eip-" + randomSuffix
+		newSnatEipName := "new-snat-eip-" + randomSuffix
+		snatEip3Name := "snat-eip3-" + randomSuffix
+		oldSnatEip := framework.MakeIptablesEIP(oldSnatEipName, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(oldSnatEip)
+		ginkgo.DeferCleanup(func() { iptablesEIPClient.DeleteSync(oldSnatEipName) })
+		oldSnatEip = iptablesEIPClient.Get(oldSnatEipName)
+
+		newSnatEip := framework.MakeIptablesEIP(newSnatEipName, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(newSnatEip)
+		ginkgo.DeferCleanup(func() { iptablesEIPClient.DeleteSync(newSnatEipName) })
+		newSnatEip = iptablesEIPClient.Get(newSnatEipName)
+
+		snatEip3 := framework.MakeIptablesEIP(snatEip3Name, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(snatEip3)
+		ginkgo.DeferCleanup(func() { iptablesEIPClient.DeleteSync(snatEip3Name) })
+		snatEip3 = iptablesEIPClient.Get(snatEip3Name)
+
+		ginkgo.By("19. Creating SNAT with old EIP and CIDR 10.0.6.0/25")
+		snatName := "snat-update-" + randomSuffix
+		oldSnatCIDR := "10.0.6.0/25"
+		newSnatCIDR := "10.0.6.128/25"
+		snat := framework.MakeIptablesSnatRule(snatName, oldSnatEipName, oldSnatCIDR)
+		_ = iptablesSnatRuleClient.CreateSync(snat)
+		ginkgo.DeferCleanup(func() { iptablesSnatRuleClient.DeleteSync(snatName) })
+
+		ginkgo.By("20. Verifying old SNAT iptables rule exists")
+		gomega.Eventually(func() bool {
+			return snatRuleExists(vpcNatGwPodName, oldSnatEip.Status.IP, oldSnatCIDR)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"SNAT rule should exist with old EIP and old CIDR")
+
+		ginkgo.By("21. Updating SNAT: changing both EIP and InternalCIDR")
+		snat = iptablesSnatRuleClient.Get(snatName)
+		modifiedSnat := snat.DeepCopy()
+		modifiedSnat.Spec.EIP = newSnatEipName
+		modifiedSnat.Spec.InternalCIDR = newSnatCIDR
+		iptablesSnatRuleClient.PatchSync(snat, modifiedSnat, nil, 2*time.Minute)
+
+		ginkgo.By("22. Verifying old SNAT iptables rule is removed")
+		gomega.Eventually(func() bool {
+			return snatRuleExists(vpcNatGwPodName, oldSnatEip.Status.IP, oldSnatCIDR)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"Old SNAT rule should be removed after spec update")
+
+		ginkgo.By("23. Verifying new SNAT iptables rule exists")
+		gomega.Eventually(func() bool {
+			return snatRuleExists(vpcNatGwPodName, newSnatEip.Status.IP, newSnatCIDR)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"New SNAT rule should exist after spec update")
+
+		ginkgo.By("24. Verifying SNAT Status reflects new values")
+		snat = iptablesSnatRuleClient.Get(snatName)
+		framework.ExpectEqual(snat.Status.V4ip, newSnatEip.Status.IP,
+			"SNAT Status.V4ip should match new EIP IP")
+		framework.ExpectEqual(snat.Status.InternalCIDR, newSnatCIDR,
+			"SNAT Status.InternalCIDR should match new InternalCIDR")
+		framework.ExpectTrue(snat.Status.Ready, "SNAT should be ready after update")
+		framework.ExpectHaveKeyWithValue(snat.Labels, util.EipV4IpLabel, newSnatEip.Spec.V4ip)
+		framework.ExpectHaveKeyWithValue(snat.Annotations, util.VpcEipAnnotation, newSnatEipName)
+
+		// --- SNAT second update: change only EIP, keep InternalCIDR unchanged ---
+		ginkgo.By("24a. Updating SNAT: changing only EIP, keeping InternalCIDR=" + newSnatCIDR)
+		snat = iptablesSnatRuleClient.Get(snatName)
+		modifiedSnat2 := snat.DeepCopy()
+		modifiedSnat2.Spec.EIP = snatEip3Name
+		iptablesSnatRuleClient.PatchSync(snat, modifiedSnat2, nil, 2*time.Minute)
+
+		ginkgo.By("24b. Verifying old SNAT rule (newSnatEip + newSnatCIDR) is removed")
+		gomega.Eventually(func() bool {
+			return snatRuleExists(vpcNatGwPodName, newSnatEip.Status.IP, newSnatCIDR)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"Previous SNAT rule should be removed after EIP-only change")
+
+		ginkgo.By("24c. Verifying new SNAT rule with third EIP exists")
+		gomega.Eventually(func() bool {
+			return snatRuleExists(vpcNatGwPodName, snatEip3.Status.IP, newSnatCIDR)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"New SNAT rule should exist with third EIP and same CIDR")
+
+		ginkgo.By("24d. Verifying SNAT Status and labels reflect third EIP")
+		snat = iptablesSnatRuleClient.Get(snatName)
+		framework.ExpectEqual(snat.Status.V4ip, snatEip3.Status.IP,
+			"SNAT Status.V4ip should match third EIP IP")
+		framework.ExpectEqual(snat.Status.InternalCIDR, newSnatCIDR,
+			"SNAT Status.InternalCIDR should remain unchanged after EIP-only change")
+		framework.ExpectTrue(snat.Status.Ready, "SNAT should be ready after EIP-only change")
+		framework.ExpectHaveKeyWithValue(snat.Labels, util.EipV4IpLabel, snatEip3.Spec.V4ip)
+		framework.ExpectHaveKeyWithValue(snat.Annotations, util.VpcEipAnnotation, snatEip3Name)
 	})
 })
 


### PR DESCRIPTION
controller iptables FIP DNAT SNAT 和 webhook 的限制保持一致：
- eip 不允许变更 ip 地址，变更 vpc-nat-gw （pod）：鉴于 kube-ovn 的所有 ip crd 都没有支持直接变更
- iptables FIP DNAT SNAT 可以变更： ip ，端口


外部 ip（+端口）对应到内部 ip （+端口）一对一的 NAT 规则： FIP DNAT
SNAT： 多对多：只能完整基于公网ip+内网 cidr 判断

nat-gateway.sh
- add 的校验应该更严格：防止引入冲突规则
- del 的校验应该可以宽松些，只要公网 ip （+端口+协议）对得上，无论对错，都可以删：防止规则残留

vpc-nat-xx.go
- handleAddX: 确保创建成功，status 完备
- handleUpdateX: 仅在创建成功的基础上，再进行更新
- Del 流程会尝试删除两次： status 和 spec 中的对应规则，防止规则残留

<img width="1648" height="643" alt="企业微信截图_e2957fa5-df4d-4aaf-9fbe-2ae8449b24af" src="https://github.com/user-attachments/assets/1f701e1f-eddd-4dbf-8df4-9669628d0fef" />

  问题根因

  旧代码的 update handler 在 reconcile 时无条件 del+add，且 del 参数直接用 Status 字段。问题出在：

  1. add 部分失败 → Status 未写入（V4ip 为空）→ 下次 reconcile 时 del 用空值调 iptables → 删不掉旧规则
  2. Status 和实际 iptables 规则不一致 → del 用了错误的参数 → 删了个不存在的规则（无效操作），而真正的规则残留




其他问题：
-  FIP eip 本质上无法和 DNAT eip 复用: webhook 拦截

```bash

  确认 iptables 链评估逻辑

  链跳转顺序（L168-170）：
  PREROUTING → -j DNAT_FILTER
    DNAT_FILTER → -j EXCLUSIVE_DNAT   ← FIP 规则在这里
    DNAT_FILTER → -j SHARED_DNAT      ← DNAT 规则在这里

  FIP 规则（L339）：
  -A EXCLUSIVE_DNAT -d $eip -j DNAT --to-destination $internalIp
  无协议/端口过滤 → 匹配所有目的地为 EIP 的流量。-j DNAT 是终结性 target，匹配后不再继续遍历链。

  DNAT 规则（L466）：
  -A SHARED_DNAT -p $protocol -d $eip --dport $dport -j DNAT --to-destination $internalIp:$internalPort

  结论确认： 同一 EIP 上，EXCLUSIVE_DNAT 中的 FIP 规则会先匹配所有流量，SHARED_DNAT 中的 DNAT 规则永远不会被触发。FIP 与 DNAT 共享同一 EIP 是硬性冲突。

```

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
