### PR TITLE
fix(e2e): prevent OVS datapath race condition in underlay tests

### DIFF
--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -222,6 +222,19 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 			linkMap[node.Name()] = linkMap[node.ID]
 			routeMap[node.Name()] = routeMap[node.ID]
 			nodeNames = append(nodeNames, node.Name())
+
+			// Clean up any stale OVS datapath port entries for this NIC.
+			// Previous provider network tests may leave stale port references in the
+			// ovs-system datapath when bridge cleanup races with NIC state changes.
+			// This prevents "could not open network device (File exists)" errors when
+			// the next test creates a bridge with exchangeLinkName=true.
+			nicName := linkMap[node.ID].IfName
+			if stdout, _, err := node.Exec("ovs-dpctl", "show"); err == nil {
+				if strings.Contains(string(stdout), nicName) {
+					framework.Logf("Cleaning up stale OVS datapath port %s on node %s", nicName, node.Name())
+					_, _, _ = node.Exec("ovs-dpctl", "del-if", "ovs-system", nicName)
+				}
+			}
 		}
 
 		itFn = func(exchangeLinkName bool) {
@@ -373,7 +386,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		framework.ExpectNoError(err, "getting nodes in cluster")
 
 		ginkgo.By("Waiting for ovs bridge to disappear")
-		deadline := time.Now().Add(time.Minute)
+		deadline := time.Now().Add(2 * time.Minute)
 		for _, node := range nodes {
 			err = node.WaitLinkToDisappear(util.ExternalBridgeName(providerNetworkName), time.Second, deadline)
 			framework.ExpectNoError(err, "timed out waiting for ovs bridge to disappear in node %s", node.Name())


### PR DESCRIPTION
## Summary
- Clean up stale OVS datapath port entries in BeforeEach to prevent `could not open network device (File exists)` errors when creating bridges with `exchangeLinkName=true`
- Increase AfterEach bridge disappearance timeout from 1 to 2 minutes

## Root Cause

When an underlay provider network test cleans up its OVS bridge (e.g., `br-tpn-*`), OVS may attempt to re-add the physical NIC (e.g., `eth1`) to the `ovs-system` datapath during bridge reconciliation. If the NIC is in a transient state, the add fails with `No such device` but leaves a stale port entry in the datapath.

When the next test creates a provider network with `exchangeLinkName=true`:
1. The NIC is renamed (e.g., `eth1` → `br-pn-*`)
2. An OVS bridge is created with the original NIC name (`eth1`)
3. OVS tries to create the bridge's kernel interface but the kernel's openvswitch module finds the stale datapath port entry and returns `EEXIST`
4. This error persists indefinitely — the daemon's retry loop (delete bridge + recreate every 5s) cannot resolve it
5. The test times out after 180 seconds, and all subsequent underlay tests cascade-fail

## Fix

**BeforeEach**: After connecting nodes to the docker network and discovering NIC names, check each node's OVS datapath (`ovs-dpctl show`) for stale port entries matching the NIC name. If found, remove them with `ovs-dpctl del-if ovs-system <nic>`. This is idempotent and safe — a fresh NIC from docker network connection should never be in the OVS datapath.

**AfterEach**: Increase bridge disappearance timeout from 1 to 2 minutes to match the `DeleteSync` timeout, preventing premature test failure when daemon cleanup is slow.

## Test plan
- [ ] Run underlay e2e tests multiple times to verify no `File exists` flaky failures
- [ ] Verify the `should exchange link names` test passes consistently
- [ ] Verify no regression in other underlay tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)