### PR TITLE
fix(e2e): preload pause image into kind cluster to prevent flaky test timeouts

### DIFF
--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -140,6 +140,7 @@ cyclonus-netpol-e2e:
 
 .PHONY: kube-ovn-conformance-e2e
 kube-ovn-conformance-e2e:
+	$(call kind_load_image,kube-ovn,ghcr.io/kubeovn/pause:3.9,1)
 	$(GINKGO_E2E_BUILD) ./test/e2e/kube-ovn
 	E2E_BRANCH=$(E2E_BRANCH) \
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -227,7 +227,7 @@ func (c *DeploymentClient) DeleteSync(name string) {
 }
 
 func (c *DeploymentClient) WaitToComplete(deploy *appsv1.Deployment) error {
-	return testutils.WaitForDeploymentComplete(c.clientSet, deploy, Logf, poll, 2*time.Minute)
+	return testutils.WaitForDeploymentComplete(c.clientSet, deploy, Logf, poll, timeout)
 }
 
 // WaitToDisappear waits the given timeout duration for the specified deployment to disappear.


### PR DESCRIPTION
## Summary
- Preload `ghcr.io/kubeovn/pause:3.9` into the kind cluster before running conformance e2e tests, preventing runtime image pull hangs from ghcr.io
- Unify `WaitToComplete` timeout to use the global `timeout` constant instead of a hardcoded `2*time.Minute`

## Root Cause
The conformance e2e test `should support subnet AvailableIPRange and UsingIPRange is correct when restart deployment` intermittently fails because:
1. The pause image is not preloaded on kind nodes (especially `kube-ovn-control-plane`)
2. When containerd pulls from ghcr.io at runtime with `imagePullPolicy: IfNotPresent`, the pull can hang indefinitely due to containerd concurrent pull lock contention or transient network issues
3. This causes the deployment to stay at 4/5 Ready replicas, timing out `CreateSync`

Evidence from CI run [#22868010234](https://github.com/kubeovn/kube-ovn/actions/runs/22868010234): Pod `plg46` on `kube-ovn-control-plane` node started pulling `ghcr.io/kubeovn/pause:3.9` but never completed, while another pod on the same node pulled the same image in 1.4s. Kube-OVN controller, CNI, and OVN layers all functioned correctly.

## Test plan
- [ ] Verify conformance e2e tests pass consistently (the pause image should now be preloaded on all kind nodes)
- [ ] Confirm no regression in other e2e test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)