### PR TITLE
fix(cni): prevent stale ADD from clearing active iface-id on sandbox churn

### DIFF
--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
+	"github.com/neverlee/keymutex"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,11 +39,30 @@ type cniServerHandler struct {
 	KubeClient    kubernetes.Interface
 	KubeOvnClient clientset.Interface
 	Controller    *Controller
+	podReqKeyMux  *keymutex.KeyMutex
 }
 
 func createCniServerHandler(config *Configuration, controller *Controller) *cniServerHandler {
-	csh := &cniServerHandler{KubeClient: config.KubeClient, KubeOvnClient: config.KubeOvnClient, Config: config, Controller: controller}
+	csh := &cniServerHandler{
+		KubeClient:    config.KubeClient,
+		KubeOvnClient: config.KubeOvnClient,
+		Config:        config,
+		Controller:    controller,
+		podReqKeyMux:  keymutex.New(97),
+	}
 	return csh
+}
+
+func cniRequestLockKey(podRequest request.CniRequest) string {
+	provider := podRequest.Provider
+	if provider == "" {
+		provider = util.OvnProvider
+	}
+	ifName := podRequest.IfName
+	if ifName == "" {
+		ifName = "eth0"
+	}
+	return fmt.Sprintf("%s/%s/%s/%s", podRequest.PodNamespace, podRequest.PodName, provider, ifName)
 }
 
 func (csh cniServerHandler) providerExists(provider string) (*kubeovnv1.Subnet, bool) {
@@ -68,6 +88,9 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 		return
 	}
+	lockKey := cniRequestLockKey(podRequest)
+	csh.podReqKeyMux.Lock(lockKey)
+	defer csh.podReqKeyMux.Unlock(lockKey)
 	klog.V(5).Infof("request body is %v", podRequest)
 	podSubnet, exist := csh.providerExists(podRequest.Provider)
 	if !exist {
@@ -427,6 +450,9 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		}
 		return
 	}
+	lockKey := cniRequestLockKey(podRequest)
+	csh.podReqKeyMux.Lock(lockKey)
+	defer csh.podReqKeyMux.Unlock(lockKey)
 
 	// Try to get the Pod, but if it fails due to not being found, log a warning and continue.
 	pod, err := csh.Controller.podsLister.Pods(podRequest.PodNamespace).Get(podRequest.PodName)

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -6,18 +6,19 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/neverlee/keymutex"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/keymutex"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	clientset "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned"
@@ -39,16 +40,17 @@ type cniServerHandler struct {
 	KubeClient    kubernetes.Interface
 	KubeOvnClient clientset.Interface
 	Controller    *Controller
-	podReqKeyMux  *keymutex.KeyMutex
+	podReqKeyMux  keymutex.KeyMutex
 }
 
 func createCniServerHandler(config *Configuration, controller *Controller) *cniServerHandler {
+	numKeyLocks := runtime.NumCPU() * 2
 	csh := &cniServerHandler{
 		KubeClient:    config.KubeClient,
 		KubeOvnClient: config.KubeOvnClient,
 		Config:        config,
 		Controller:    controller,
-		podReqKeyMux:  keymutex.New(97),
+		podReqKeyMux:  keymutex.NewHashed(numKeyLocks),
 	}
 	return csh
 }
@@ -89,8 +91,8 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		return
 	}
 	lockKey := cniRequestLockKey(podRequest)
-	csh.podReqKeyMux.Lock(lockKey)
-	defer csh.podReqKeyMux.Unlock(lockKey)
+	csh.podReqKeyMux.LockKey(lockKey)
+	defer func() { _ = csh.podReqKeyMux.UnlockKey(lockKey) }()
 	klog.V(5).Infof("request body is %v", podRequest)
 	podSubnet, exist := csh.providerExists(podRequest.Provider)
 	if !exist {
@@ -451,8 +453,8 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		return
 	}
 	lockKey := cniRequestLockKey(podRequest)
-	csh.podReqKeyMux.Lock(lockKey)
-	defer csh.podReqKeyMux.Unlock(lockKey)
+	csh.podReqKeyMux.LockKey(lockKey)
+	defer func() { _ = csh.podReqKeyMux.UnlockKey(lockKey) }()
 
 	// Try to get the Pod, but if it fails due to not being found, log a warning and continue.
 	pod, err := csh.Controller.podsLister.Pods(podRequest.PodNamespace).Get(podRequest.PodName)

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -48,7 +48,7 @@ func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, ne
 
 	ipStr := util.GetIPWithoutMask(ip)
 	ifaceID := ovs.PodNameToPortName(podName, podNamespace, provider)
-	ovs.CleanDuplicatePort(ifaceID, hostNicName)
+	ovs.CleanDuplicatePortByNetns(ifaceID, hostNicName, netns)
 
 	vhostServerPath := path.Join(sharedDir, socketName)
 	if socketConsumption == util.ConsumptionKubevirt {
@@ -99,7 +99,7 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 
 	ipStr := util.GetIPWithoutMask(ip)
 	ifaceID := ovs.PodNameToPortName(podName, podNamespace, provider)
-	ovs.CleanDuplicatePort(ifaceID, hostNicName)
+	ovs.CleanDuplicatePortByNetns(ifaceID, hostNicName, netns)
 	if yusur.IsYusurSmartNic(deviceID) {
 		klog.Infof("add Yusur smartnic vfr %s to ovs", hostNicName)
 		// Add yusur ovs port
@@ -1800,7 +1800,7 @@ func (csh cniServerHandler) configureNicWithInternalPort(podName, podNamespace, 
 	_, containerNicName := generateNicName(containerID, ifName)
 	ipStr := util.GetIPWithoutMask(ip)
 	ifaceID := ovs.PodNameToPortName(podName, podNamespace, provider)
-	ovs.CleanDuplicatePort(ifaceID, containerNicName)
+	ovs.CleanDuplicatePortByNetns(ifaceID, containerNicName, netns)
 
 	// Add container iface to ovs port as internal port
 	output, err := ovs.Exec(ovs.MayExist, "add-port", "br-int", containerNicName, "--",

--- a/pkg/ovs/ovs-vsctl.go
+++ b/pkg/ovs/ovs-vsctl.go
@@ -3,6 +3,7 @@ package ovs
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"slices"
@@ -304,12 +305,36 @@ func CleanLostInterface() {
 // but only the latest one should have the iface-id set.
 // See: https://github.com/ovn-org/ovn-kubernetes/pull/869
 func CleanDuplicatePort(ifaceID, portName string) {
+	CleanDuplicatePortByNetns(ifaceID, portName, "")
+}
+
+func CleanDuplicatePortByNetns(ifaceID, portName, podNetns string) {
 	uuids, _ := ovsFind("Interface", "_uuid", "external-ids:iface-id="+ifaceID, "name!="+portName)
 	for _, uuid := range uuids {
+		if podNetns != "" {
+			existingNetns, err := ovsGet("Interface", uuid, "external_ids", "pod_netns")
+			if err != nil {
+				klog.Errorf("failed to get pod_netns for OVS interface %q: %v", uuid, err)
+				continue
+			}
+			existingNetns = strings.Trim(existingNetns, "\"")
+			if existingNetns != "" && existingNetns != podNetns && netnsPathExists(existingNetns) {
+				klog.Infof("skip cleaning active OVS interface %q for iface-id %q: pod_netns %q does not match current %q", uuid, ifaceID, existingNetns, podNetns)
+				continue
+			}
+		}
 		if out, err := Exec("remove", "Interface", uuid, "external-ids", "iface-id"); err != nil {
 			klog.Errorf("failed to clear stale OVS port %q iface-id %q: %v\n  %q", uuid, ifaceID, err, out)
 		}
 	}
+}
+
+func netnsPathExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 // ValidatePortVendor returns true if the port's external_ids:vendor=kube-ovn


### PR DESCRIPTION
## Background
On nodes with rapid sandbox churn (ADD/DEL/ADD) and kube-ovn-cni restarts, an older delayed ADD can clear iface-id of the newer active interface. This causes ovn-controller to release lport and flip it to down.

Observed symptoms:
- OVN binding toggles: `Claiming -> up -> Releasing -> down` in a short window
- CNI logs show stale netns errors after a newer ADD already succeeded
- pinger pod may fail startup with transient API connectivity errors due to datapath instability

## Root Cause
`CleanDuplicatePort(ifaceID, portName)` removed iface-id from any duplicate interface except current port name, without checking whether that duplicate belongs to another still-active sandbox netns.

When old requests arrive late (or after cni restart), cleanup can touch the active interface of the new sandbox.

## What changed
1. Add netns-aware duplicate cleanup in OVS helper:
   - New `CleanDuplicatePortByNetns(ifaceID, portName, podNetns)`
   - If duplicate interface belongs to a different and existing `pod_netns`, skip cleanup

2. Use netns-aware cleanup on Linux NIC creation paths:
   - normal veth/sriov path
   - internal port path
   - dpdk path

3. Serialize CNI add/del requests per pod/provider/ifname in daemon handler:
   - Add key mutex in cniServerHandler
   - Lock in both handleAdd and handleDel

## Reproduction (before fix)
1. On one node, repeatedly trigger pod sandbox churn for same pod identity (or quickly restart a daemonset pod).
2. During churn, restart kube-ovn-cni on that node.
3. Observe interleaving logs:
   - old ADD (container A)
   - DEL (container A)
   - new ADD (container B) success
   - old ADD continues and fails open old netns
4. Check ovn-controller log for the same lport:
   - up then immediate down (release)

## Verification
- Re-run churn + cni restart scenario above
- Ensure active sandbox interface keeps iface-id
- Ensure ovn-controller no longer releases the active lport due to stale cleanup
- Ensure no new regressions in add/del handling paths

## Notes
This change is intentionally minimal and keeps existing behavior for normal stale cleanup while preventing cross-sandbox destructive cleanup in race windows.