### PR TITLE
fix(e2e): wait for namespace IPPool annotation to prevent flaky IPAM test

### DIFF
--- a/test/e2e/framework/namespace.go
+++ b/test/e2e/framework/namespace.go
@@ -112,6 +112,32 @@ func (c *NamespaceClient) WaitToDisappear(name string, _, timeout time.Duration)
 	return nil
 }
 
+// WaitUntil waits the given timeout duration for the specified condition to be met.
+func (c *NamespaceClient) WaitUntil(name string, cond func(ns *corev1.Namespace) (bool, error), condDesc string, interval, timeout time.Duration) *corev1.Namespace {
+	ginkgo.GinkgoHelper()
+
+	var ns *corev1.Namespace
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(_ context.Context) (bool, error) {
+		Logf("Waiting for namespace %s to meet condition %q", name, condDesc)
+		ns = c.Get(name)
+		met, err := cond(ns)
+		if err != nil {
+			return false, fmt.Errorf("failed to check condition for namespace %s: %w", name, err)
+		}
+		return met, nil
+	})
+	if err == nil {
+		return ns
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		Failf("timed out while waiting for namespace %s to meet condition %q", name, condDesc)
+	}
+	Failf("error occurred while waiting for namespace %s to meet condition %q: %v", name, condDesc, err)
+
+	return nil
+}
+
 func MakeNamespace(name string, labels, annotations map[string]string) *corev1.Namespace {
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/kube-ovn/ipam/ipam.go
+++ b/test/e2e/kube-ovn/ipam/ipam.go
@@ -690,6 +690,11 @@ var _ = framework.Describe("[group:ipam]", func() {
 		ippool := framework.MakeIPPool(ippoolName, subnetName, ips, []string{namespaceName})
 		_ = ippoolClient.CreateSync(ippool)
 
+		ginkgo.By("Waiting for namespace " + namespaceName + " to have IPPool annotation")
+		nsClient.WaitUntil(namespaceName, func(ns *corev1.Namespace) (bool, error) {
+			return strings.Contains(ns.Annotations[util.IPPoolAnnotation], ippoolName), nil
+		}, "IPPool annotation contains "+ippoolName, 2*time.Second, 30*time.Second)
+
 		ginkgo.By("Creating deployment " + deployName + " with replicas equal to the number of IPs in the ippool")
 		labels := map[string]string{"app": deployName}
 		deploy := framework.MakeDeployment(deployName, int32(ipsCount), labels, nil, "pause", framework.PauseImage, "")
@@ -722,6 +727,12 @@ var _ = framework.Describe("[group:ipam]", func() {
 		ips2 := framework.RandomIPPool(cidr2, ipsCount)
 		ippool2 := framework.MakeIPPool(ippoolName2, subnetName2, ips2, []string{namespaceName})
 		_ = ippoolClient.CreateSync(ippool2)
+
+		ginkgo.By("Waiting for namespace " + namespaceName + " to have both IPPool annotations")
+		nsClient.WaitUntil(namespaceName, func(ns *corev1.Namespace) (bool, error) {
+			ann := ns.Annotations[util.IPPoolAnnotation]
+			return strings.Contains(ann, ippoolName) && strings.Contains(ann, ippoolName2), nil
+		}, "IPPool annotation contains both "+ippoolName+" and "+ippoolName2, 2*time.Second, 30*time.Second)
 
 		ginkgo.By("Creating deployment " + deployName + " with replicas equal to the number of IPs in the ippool " + ippoolName)
 		labels := map[string]string{"app": deployName}


### PR DESCRIPTION
## Summary
- Fixed flaky e2e test `should block IP allocation if the ippool bound by namespace annotation has no available IPs` in IPv6 overlay CI
- Root cause: `ippoolClient.CreateSync()` returns when IPPool is Ready, but the namespace `ovn.kubernetes.io/ip_pool` annotation update is **asynchronous**. Pods created before the annotation propagates to the informer cache bypass IPPool constraints and allocate directly from the subnet, so the expected `AcquireAddressFailed` event never fires
- Added `NamespaceClient.WaitUntil()` helper (consistent with existing `IPPoolClient.WaitUntil`, `SubnetClient.WaitUntil` patterns)
- Added explicit waits for namespace IPPool annotation in two affected test cases before creating workloads

## Test plan
- [ ] Verify `Kube-OVN Conformance E2E (ipv6, overlay)` passes consistently
- [ ] Verify `should block IP allocation if the ippool bound by namespace annotation has no available IPs` no longer flakes
- [ ] Verify `should be able to allocate IP from IPPools in different subnets` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)