### PR TITLE
fix: add ipv6_src to LB selection_fields for IPv6 session affinity

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -1520,17 +1520,22 @@ func (m *MockLoadBalancer) EXPECT() *MockLoadBalancerMockRecorder {
 }
 
 // CreateLoadBalancer mocks base method.
-func (m *MockLoadBalancer) CreateLoadBalancer(lbName, protocol, selectFields string) error {
+func (m *MockLoadBalancer) CreateLoadBalancer(lbName, protocol string, selectFields ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateLoadBalancer", lbName, protocol, selectFields)
+	varargs := []any{lbName, protocol}
+	for _, a := range selectFields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateLoadBalancer", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateLoadBalancer indicates an expected call of CreateLoadBalancer.
-func (mr *MockLoadBalancerMockRecorder) CreateLoadBalancer(lbName, protocol, selectFields any) *gomock.Call {
+func (mr *MockLoadBalancerMockRecorder) CreateLoadBalancer(lbName, protocol any, selectFields ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockLoadBalancer)(nil).CreateLoadBalancer), lbName, protocol, selectFields)
+	varargs := append([]any{lbName, protocol}, selectFields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockLoadBalancer)(nil).CreateLoadBalancer), varargs...)
 }
 
 // DeleteLoadBalancers mocks base method.
@@ -3502,17 +3507,22 @@ func (mr *MockNbClientMockRecorder) CreateHAChassisGroup(name, chassises, extern
 }
 
 // CreateLoadBalancer mocks base method.
-func (m *MockNbClient) CreateLoadBalancer(lbName, protocol, selectFields string) error {
+func (m *MockNbClient) CreateLoadBalancer(lbName, protocol string, selectFields ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateLoadBalancer", lbName, protocol, selectFields)
+	varargs := []any{lbName, protocol}
+	for _, a := range selectFields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateLoadBalancer", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateLoadBalancer indicates an expected call of CreateLoadBalancer.
-func (mr *MockNbClientMockRecorder) CreateLoadBalancer(lbName, protocol, selectFields any) *gomock.Call {
+func (mr *MockNbClientMockRecorder) CreateLoadBalancer(lbName, protocol any, selectFields ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockNbClient)(nil).CreateLoadBalancer), lbName, protocol, selectFields)
+	varargs := append([]any{lbName, protocol}, selectFields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockNbClient)(nil).CreateLoadBalancer), varargs...)
 }
 
 // CreateLoadBalancerHealthCheck mocks base method.

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -257,15 +257,18 @@ func (c *Controller) initLB(name, protocol string, sessionAffinity bool) error {
 	protocol = strings.ToLower(protocol)
 
 	var (
-		selectFields string
+		selectFields []string
 		err          error
 	)
 
 	if sessionAffinity {
-		selectFields = ovnnb.LoadBalancerSelectionFieldsIPSrc
+		selectFields = []string{
+			ovnnb.LoadBalancerSelectionFieldsIPSrc,
+			ovnnb.LoadBalancerSelectionFieldsIpv6Src,
+		}
 	}
 
-	if err = c.OVNNbClient.CreateLoadBalancer(name, protocol, selectFields); err != nil {
+	if err = c.OVNNbClient.CreateLoadBalancer(name, protocol, selectFields...); err != nil {
 		klog.Errorf("create load balancer %s: %v", name, err)
 		return err
 	}

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -601,7 +601,7 @@ func (c *Controller) AddDnatRule(vpcName, dnatName, externalIP, internalIP, exte
 		err              error
 	)
 
-	if err = c.OVNNbClient.CreateLoadBalancer(dnatName, protocol, ""); err != nil {
+	if err = c.OVNNbClient.CreateLoadBalancer(dnatName, protocol); err != nil {
 		klog.Errorf("create loadBalancer %s: %v", dnatName, err)
 		return err
 	}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -128,7 +128,7 @@ type LogicalSwitchPort interface {
 }
 
 type LoadBalancer interface {
-	CreateLoadBalancer(lbName, protocol, selectFields string) error
+	CreateLoadBalancer(lbName, protocol string, selectFields ...string) error
 	LoadBalancerAddVip(lbName, vip string, backends ...string) error
 	LoadBalancerDeleteVip(lbName, vip string, ignoreHealthCheck bool) error
 	LoadBalancerAddIPPortMapping(lbName, vip string, ipPortMappings map[string]string) error

--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -20,7 +20,7 @@ import (
 )
 
 // CreateLoadBalancer create loadbalancer
-func (c *OVNNbClient) CreateLoadBalancer(lbName, protocol, selectFields string) error {
+func (c *OVNNbClient) CreateLoadBalancer(lbName, protocol string, selectFields ...string) error {
 	var (
 		exist bool
 		err   error
@@ -50,7 +50,7 @@ func (c *OVNNbClient) CreateLoadBalancer(lbName, protocol, selectFields string) 
 	}
 
 	if len(selectFields) != 0 {
-		lb.SelectionFields = []string{selectFields}
+		lb.SelectionFields = selectFields
 	}
 
 	if ops, err = c.Create(lb); err != nil {

--- a/pkg/ovs/ovn-nb-load_balancer_health_check_test.go
+++ b/pkg/ovs/ovn-nb-load_balancer_health_check_test.go
@@ -219,7 +219,7 @@ func (suite *OvnClientTestSuite) testGetLoadBalancerHealthCheck() {
 	t.Run("should return err when health checks have the same vipEndpoint",
 		func(t *testing.T) {
 			t.Parallel()
-			err = nbClient.CreateLoadBalancer(lbName+"1", "tcp", "")
+			err = nbClient.CreateLoadBalancer(lbName+"1", "tcp")
 			require.NoError(t, err)
 			lbhc1 := &ovnnb.LoadBalancerHealthCheck{
 				UUID:        ovsclient.NamedUUID(),
@@ -435,7 +435,7 @@ func (suite *OvnClientTestSuite) testNewLoadBalancerHealthCheck() {
 		require.ErrorContains(t, err, "not found load balancer")
 		require.Nil(t, lbhc)
 
-		err = nbClient.CreateLoadBalancer(lbName, "tcp", "")
+		err = nbClient.CreateLoadBalancer(lbName, "tcp")
 		require.NoError(t, err)
 
 		lbhc, err = nbClient.newLoadBalancerHealthCheck(lbName, vip, externals)

--- a/pkg/ovs/ovn-nb-load_balancer_test.go
+++ b/pkg/ovs/ovn-nb-load_balancer_test.go
@@ -95,7 +95,7 @@ func (suite *OvnClientTestSuite) testDeleteLoadBalancers() {
 
 	for i := range 5 {
 		lbName := fmt.Sprintf("%s-%d", lbNamePrefix, i)
-		err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+		err := nbClient.CreateLoadBalancer(lbName, "tcp")
 		require.NoError(t, err)
 
 		lbNames = append(lbNames, lbName)
@@ -119,7 +119,7 @@ func (suite *OvnClientTestSuite) testDeleteLoadBalancer() {
 	nbClient := suite.ovnNBClient
 	lbName := "test-del-lb"
 
-	err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err := nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	err = nbClient.DeleteLoadBalancer(lbName)
@@ -136,7 +136,7 @@ func (suite *OvnClientTestSuite) testGetLoadBalancer() {
 	nbClient := suite.ovnNBClient
 	lbName := "test-get-lb"
 
-	err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err := nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	t.Run("should return no err when found load balancer", func(t *testing.T) {
@@ -172,7 +172,7 @@ func (suite *OvnClientTestSuite) testListLoadBalancers() {
 	for i := range 3 {
 		for _, p := range protocol {
 			lbName := fmt.Sprintf("%s-%s-%d", lbNamePrefix, p, i)
-			err := nbClient.CreateLoadBalancer(lbName, p, "")
+			err := nbClient.CreateLoadBalancer(lbName, p)
 			require.NoError(t, err)
 
 			lbNames = append(lbNames, lbName)
@@ -250,7 +250,7 @@ func (suite *OvnClientTestSuite) testDeleteLoadBalancerOp() {
 	nbClient := suite.ovnNBClient
 	lbName := "test-del-lb-op"
 
-	err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err := nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	lb, err := nbClient.GetLoadBalancer(lbName, false)
@@ -327,7 +327,7 @@ func (suite *OvnClientTestSuite) testSetLoadBalancerAffinityTimeout() {
 	nbClient := suite.ovnNBClient
 	lbName := "test-set-lb-affinity-timeout"
 
-	err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err := nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	lb, err := nbClient.GetLoadBalancer(lbName, false)
@@ -404,7 +404,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerAddVip() {
 		err                error
 	)
 
-	err = nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err = nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	_, err = nbClient.GetLoadBalancer(lbName, false)
@@ -477,7 +477,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerAddHealthCheck() {
 				"[fd00:10:96::e86f]:8080": "[fc00::af4:a]:8080,[fc00::af4:b]:8080,[fc00::af4:c]:8080",
 			}
 			// create load balancer
-			err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+			err := nbClient.CreateLoadBalancer(lbName, "tcp")
 			require.NoError(t, err)
 			for vip, backends := range vips {
 				backends := strings.Split(backends, ",")
@@ -528,7 +528,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerAddHealthCheck() {
 			err = nbClient.Transact("lb-add", ops)
 			require.NoError(t, err)
 
-			err = nbClient.CreateLoadBalancer(lbName, "tcp", "")
+			err = nbClient.CreateLoadBalancer(lbName, "tcp")
 			require.ErrorContains(t, err, "more than one load balancer with same name")
 		},
 	)
@@ -547,7 +547,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerDeleteVip() {
 		err         error
 	)
 
-	err = nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err = nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	_, err = nbClient.GetLoadBalancer(lbName, false)
@@ -630,7 +630,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerAddIPPortMapping() {
 		err            error
 	)
 
-	err = nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err = nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	_, err = nbClient.GetLoadBalancer(lbName, false)
@@ -735,7 +735,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerDeleteIPPortMapping() {
 		err            error
 	)
 
-	err = nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err = nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	_, err = nbClient.GetLoadBalancer(lbName, false)
@@ -904,7 +904,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerWithHealthCheck() {
 		err            error
 	)
 
-	err = nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err = nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	_, err = nbClient.GetLoadBalancer(lbName, false)
@@ -1050,7 +1050,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerOp() {
 	nbClient := suite.ovnNBClient
 	lbName := "test-lb-op"
 
-	err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err := nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	t.Run("no mutations", func(t *testing.T) {
@@ -1137,7 +1137,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerUpdateHealthCheckOp() {
 	nbClient := suite.ovnNBClient
 	lbName := "test-lb-update-hc-op"
 
-	err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+	err := nbClient.CreateLoadBalancer(lbName, "tcp")
 	require.NoError(t, err)
 
 	t.Run("empty lbhcUUIDs", func(t *testing.T) {

--- a/pkg/ovs/ovn-nb-logical_router_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_test.go
@@ -300,7 +300,7 @@ func (suite *OvnClientTestSuite) testLogicalRouterUpdateLoadBalancers() {
 	for i := 1; i <= 3; i++ {
 		lbName := fmt.Sprintf("%s-%d", prefix, i)
 		lbNames = append(lbNames, lbName)
-		err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+		err := nbClient.CreateLoadBalancer(lbName, "tcp")
 		require.NoError(t, err)
 	}
 

--- a/pkg/ovs/ovn-nb-logical_switch_test.go
+++ b/pkg/ovs/ovn-nb-logical_switch_test.go
@@ -246,7 +246,7 @@ func (suite *OvnClientTestSuite) testLogicalSwitchUpdateLoadBalancers() {
 	for i := 1; i <= 3; i++ {
 		lbName := fmt.Sprintf("%s-%d", prefix, i)
 		lbNames = append(lbNames, lbName)
-		err := nbClient.CreateLoadBalancer(lbName, "tcp", "")
+		err := nbClient.CreateLoadBalancer(lbName, "tcp")
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
## Summary
- OVN LB `selection_fields` only included `ip_src`, which per `ovs-fields(7)` is an IPv4-only field (prerequisite `eth_type=0x0800`). For IPv6 packets, `ip_src` has no value, so all IPv6 packets hash identically — session affinity cannot distinguish different IPv6 clients.
- Add `ipv6_src` alongside `ip_src` so both IPv4 and IPv6 session affinity work correctly.
- Change `CreateLoadBalancer` signature from `selectFields string` to `selectFields ...string` to support multiple selection fields cleanly.

## Test plan
- [ ] Existing unit tests pass (signature change is backward-compatible via variadic args)
- [ ] E2E: `should function for client IP based session affinity: udp [LinuxOnly]` in dual-stack overlay should no longer fail due to IPv6 affinity not working
- [ ] Verify OVN LB `selection_fields` contains both `ip_src` and `ipv6_src` for session affinity LBs

🤖 Generated with [Claude Code](https://claude.com/claude-code)