### PR TITLE
Add VM migration e2e tests and fix ip crd bug

### DIFF
--- a/charts/kube-ovn-v2/ct.yaml
+++ b/charts/kube-ovn-v2/ct.yaml
@@ -1,3 +1,5 @@
+chart-dirs:
+  - charts/kube-ovn-v2
 validate-maintainers: false
 check-version-increment: false
 namespace: kube-system

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1682,7 +1682,7 @@ func needAllocateSubnets(pod *v1.Pod, nets []*kubeovnNet) []*kubeovnNet {
 	}
 
 	migrate := false
-	if job, ok := pod.Annotations[kubevirtv1.MigrationJobNameAnnotation]; ok {
+	if job, ok := pod.Annotations[kubevirtv1.MigrationJobNameAnnotation]; ok && pod.DeletionTimestamp.IsZero() {
 		klog.Infof("pod %s/%s is in the migration job %s", pod.Namespace, pod.Name, job)
 		migrate = true
 	}

--- a/test/e2e/framework/virtual-machine-instance-migration.go
+++ b/test/e2e/framework/virtual-machine-instance-migration.go
@@ -96,14 +96,14 @@ func (c *VMIMigrationClient) WaitForPhase(name string, phase v1.VirtualMachineIn
 }
 
 // WaitToDisappear waits for the migration to be fully deleted.
-func (c *VMIMigrationClient) WaitToDisappear(name string, _, timeout time.Duration) error {
+func (c *VMIMigrationClient) WaitToDisappear(name string, poll, timeout time.Duration) error {
 	err := k8sframework.Gomega().Eventually(context.Background(), k8sframework.HandleRetry(func(ctx context.Context) (*v1.VirtualMachineInstanceMigration, error) {
 		m, err := c.VirtualMachineInstanceMigrationInterface.Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return m, err
-	})).WithTimeout(timeout).Should(gomega.BeNil())
+	})).WithPolling(poll).WithTimeout(timeout).Should(gomega.BeNil())
 	if err != nil {
 		return fmt.Errorf("expected migration %s to not be found: %w", name, err)
 	}

--- a/test/e2e/framework/virtual-machine-instance-migration.go
+++ b/test/e2e/framework/virtual-machine-instance-migration.go
@@ -1,0 +1,123 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sframework "k8s.io/kubernetes/test/e2e/framework"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+)
+
+// VMIMigrationClient represents a KubeVirt VirtualMachineInstanceMigration client
+type VMIMigrationClient struct {
+	f *Framework
+	kubecli.VirtualMachineInstanceMigrationInterface
+}
+
+func (f *Framework) VMIMigrationClient() *VMIMigrationClient {
+	return f.VMIMigrationClientNS(f.Namespace.Name)
+}
+
+func (f *Framework) VMIMigrationClientNS(namespace string) *VMIMigrationClient {
+	return &VMIMigrationClient{
+		f:                                        f,
+		VirtualMachineInstanceMigrationInterface: f.KubeVirtClientSet.VirtualMachineInstanceMigration(namespace),
+	}
+}
+
+func (c *VMIMigrationClient) Get(name string) *v1.VirtualMachineInstanceMigration {
+	ginkgo.GinkgoHelper()
+	m, err := c.VirtualMachineInstanceMigrationInterface.Get(context.TODO(), name, metav1.GetOptions{})
+	ExpectNoError(err)
+	return m
+}
+
+// Create creates a new VirtualMachineInstanceMigration.
+func (c *VMIMigrationClient) Create(migration *v1.VirtualMachineInstanceMigration) *v1.VirtualMachineInstanceMigration {
+	ginkgo.GinkgoHelper()
+	m, err := c.VirtualMachineInstanceMigrationInterface.Create(context.TODO(), migration, metav1.CreateOptions{})
+	ExpectNoError(err, "failed to create migration %s", migration.Name)
+	return c.Get(m.Name)
+}
+
+// Delete deletes a VirtualMachineInstanceMigration if it exists.
+func (c *VMIMigrationClient) Delete(name string) {
+	ginkgo.GinkgoHelper()
+	err := c.VirtualMachineInstanceMigrationInterface.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		Logf("migration %s not found, skip deleting", name)
+		return
+	}
+	ExpectNoError(err, "failed to delete migration %s", name)
+}
+
+// DeleteSync deletes the migration and waits for it to disappear.
+func (c *VMIMigrationClient) DeleteSync(name string) {
+	ginkgo.GinkgoHelper()
+	c.Delete(name)
+	gomega.Expect(c.WaitToDisappear(name, poll, timeout)).To(gomega.Succeed(), "wait for migration %q to disappear", name)
+}
+
+// Abort cancels a running migration by patching spec.cancel = true.
+func (c *VMIMigrationClient) Abort(name string) {
+	ginkgo.GinkgoHelper()
+	patch := []byte(`{"spec":{"cancel":true}}`)
+	_, err := c.Patch(context.TODO(), name, types.MergePatchType, patch, metav1.PatchOptions{})
+	ExpectNoError(err, "failed to abort migration %s", name)
+}
+
+// WaitForPhase waits until the migration reaches the specified phase.
+func (c *VMIMigrationClient) WaitForPhase(name string, phase v1.VirtualMachineInstanceMigrationPhase, timeout time.Duration) error {
+	err := k8sframework.Gomega().Eventually(context.TODO(), k8sframework.RetryNotFound(func(ctx context.Context) (*v1.VirtualMachineInstanceMigration, error) {
+		return c.VirtualMachineInstanceMigrationInterface.Get(ctx, name, metav1.GetOptions{})
+	})).WithTimeout(timeout).Should(
+		k8sframework.MakeMatcher(func(m *v1.VirtualMachineInstanceMigration) (func() string, error) {
+			if m.Status.Phase == phase {
+				return nil, nil
+			}
+			return func() string {
+				return fmt.Sprintf("expected migration phase %s, got %s instead:\n%s",
+					phase, m.Status.Phase, format.Object(m.Status, 1))
+			}, nil
+		}))
+	if err != nil {
+		return fmt.Errorf("expected migration %s to reach phase %s: %w", name, phase, err)
+	}
+	return nil
+}
+
+// WaitToDisappear waits for the migration to be fully deleted.
+func (c *VMIMigrationClient) WaitToDisappear(name string, _, timeout time.Duration) error {
+	err := k8sframework.Gomega().Eventually(context.Background(), k8sframework.HandleRetry(func(ctx context.Context) (*v1.VirtualMachineInstanceMigration, error) {
+		m, err := c.VirtualMachineInstanceMigrationInterface.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return m, err
+	})).WithTimeout(timeout).Should(gomega.BeNil())
+	if err != nil {
+		return fmt.Errorf("expected migration %s to not be found: %w", name, err)
+	}
+	return nil
+}
+
+// MakeVMIMigration returns a VirtualMachineInstanceMigration object targeting the given VMI.
+func MakeVMIMigration(name, vmiName string) *v1.VirtualMachineInstanceMigration {
+	return &v1.VirtualMachineInstanceMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.VirtualMachineInstanceMigrationSpec{
+			VMIName: vmiName,
+		},
+	}
+}

--- a/test/e2e/framework/virtual-machine-instance-migration.go
+++ b/test/e2e/framework/virtual-machine-instance-migration.go
@@ -7,7 +7,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	k8sframework "k8s.io/kubernetes/test/e2e/framework"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -65,14 +64,6 @@ func (c *VMIMigrationClient) DeleteSync(name string) {
 	ginkgo.GinkgoHelper()
 	c.Delete(name)
 	gomega.Expect(c.WaitToDisappear(name, poll, timeout)).To(gomega.Succeed(), "wait for migration %q to disappear", name)
-}
-
-// Abort cancels a running migration by patching spec.cancel = true.
-func (c *VMIMigrationClient) Abort(name string) {
-	ginkgo.GinkgoHelper()
-	patch := []byte(`{"spec":{"cancel":true}}`)
-	_, err := c.Patch(context.TODO(), name, types.MergePatchType, patch, metav1.PatchOptions{})
-	ExpectNoError(err, "failed to abort migration %s", name)
 }
 
 // WaitForPhase waits until the migration reaches the specified phase.

--- a/test/e2e/framework/virtual-machine.go
+++ b/test/e2e/framework/virtual-machine.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8sframework "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -296,5 +297,61 @@ func MakeVM(name, image, size string, runStrategy *v1.VirtualMachineRunStrategy)
 			},
 		},
 	}
+	return vm
+}
+
+// MakeVMLiveMigratable creates a VM that supports live migration.
+// It sets EvictionStrategy to LiveMigrate and RunStrategy to Always.
+func MakeVMLiveMigratable(name, image, size string) *v1.VirtualMachine {
+	vm := MakeVM(name, image, size, ptr.To(v1.RunStrategyAlways))
+	vm.Spec.Template.Spec.EvictionStrategy = ptr.To(v1.EvictionStrategyLiveMigrate)
+	return vm
+}
+
+// MakeVMLiveMigratableBridge creates a VM that supports live migration using
+// a bridge interface instead of masquerade. Bridge mode requires the
+// AllowPodBridgeNetworkLiveMigrationAnnotation annotation on the VMI template.
+func MakeVMLiveMigratableBridge(name, image, size string) *v1.VirtualMachine {
+	vm := MakeVMLiveMigratable(name, image, size)
+	vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{
+		{
+			Name:                   "default",
+			InterfaceBindingMethod: v1.DefaultBridgeNetworkInterface().InterfaceBindingMethod,
+		},
+	}
+	if vm.Spec.Template.ObjectMeta.Annotations == nil {
+		vm.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	vm.Spec.Template.ObjectMeta.Annotations[v1.AllowPodBridgeNetworkLiveMigrationAnnotation] = "true"
+	return vm
+}
+
+// MakeVMLiveMigratableMultiNIC creates a VM that supports live migration with
+// both the default pod network (masquerade) and an additional OVN NIC via Multus.
+// nadName should be in the form "namespace/name".
+func MakeVMLiveMigratableMultiNIC(name, image, size, nadName string) *v1.VirtualMachine {
+	vm := MakeVMLiveMigratable(name, image, size)
+	vm.Spec.Template.Spec.Domain.Devices.Interfaces = append(
+		vm.Spec.Template.Spec.Domain.Devices.Interfaces,
+		v1.Interface{
+			Name:                   "secondary",
+			InterfaceBindingMethod: v1.DefaultBridgeNetworkInterface().InterfaceBindingMethod,
+		},
+	)
+	vm.Spec.Template.Spec.Networks = append(
+		vm.Spec.Template.Spec.Networks,
+		v1.Network{
+			Name: "secondary",
+			NetworkSource: v1.NetworkSource{
+				Multus: &v1.MultusNetwork{
+					NetworkName: nadName,
+				},
+			},
+		},
+	)
+	if vm.Spec.Template.ObjectMeta.Annotations == nil {
+		vm.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	vm.Spec.Template.ObjectMeta.Annotations[v1.AllowPodBridgeNetworkLiveMigrationAnnotation] = "true"
 	return vm
 }

--- a/test/e2e/framework/virtual-machine.go
+++ b/test/e2e/framework/virtual-machine.go
@@ -219,8 +219,11 @@ func MakeVMWithMultusNetwork(name, image, size string, runStrategy *v1.VirtualMa
 	return vm
 }
 
-func MakeVM(name, image, size string, runStrategy *v1.VirtualMachineRunStrategy) *v1.VirtualMachine {
-	vm := &v1.VirtualMachine{
+// makeBaseVM creates the common VM skeleton with a container disk, default pod
+// network, and no interface binding or cloud-init. Callers add the appropriate
+// interface mode (masquerade/bridge) and any extra disks/volumes.
+func makeBaseVM(name, image, size string, runStrategy *v1.VirtualMachineRunStrategy) *v1.VirtualMachine {
+	return &v1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -244,20 +247,6 @@ func MakeVM(name, image, size string, runStrategy *v1.VirtualMachineRunStrategy)
 											Bus: v1.DiskBusVirtio,
 										},
 									},
-								},
-								{
-									Name: "cloudinitdisk",
-									DiskDevice: v1.DiskDevice{
-										Disk: &v1.DiskTarget{
-											Bus: v1.DiskBusVirtio,
-										},
-									},
-								},
-							},
-							Interfaces: []v1.Interface{
-								{
-									Name:                   "default",
-									InterfaceBindingMethod: v1.DefaultMasqueradeNetworkInterface().InterfaceBindingMethod,
 								},
 							},
 						},
@@ -283,28 +272,64 @@ func MakeVM(name, image, size string, runStrategy *v1.VirtualMachineRunStrategy)
 								},
 							},
 						},
-						{
-							Name: "cloudinitdisk",
-							VolumeSource: v1.VolumeSource{
-								CloudInitNoCloud: &v1.CloudInitNoCloudSource{
-									UserDataBase64: "SGkuXG4=",
-								},
-							},
-						},
 					},
 					TerminationGracePeriodSeconds: new(int64(0)),
 				},
 			},
 		},
 	}
+}
+
+// MakeVM creates a VM with masquerade networking and a cloud-init disk.
+func MakeVM(name, image, size string, runStrategy *v1.VirtualMachineRunStrategy) *v1.VirtualMachine {
+	vm := makeBaseVM(name, image, size, runStrategy)
+	vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{
+		{
+			Name:                   "default",
+			InterfaceBindingMethod: v1.DefaultMasqueradeNetworkInterface().InterfaceBindingMethod,
+		},
+	}
+	vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
+		Name: "cloudinitdisk",
+		DiskDevice: v1.DiskDevice{
+			Disk: &v1.DiskTarget{
+				Bus: v1.DiskBusVirtio,
+			},
+		},
+	})
+	vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+		Name: "cloudinitdisk",
+		VolumeSource: v1.VolumeSource{
+			CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+				UserDataBase64: "SGkuXG4=",
+			},
+		},
+	})
+	return vm
+}
+
+// MakeVMBridge creates a VM with bridge networking and no cloud-init disk.
+// Cloud-init is excluded because it interferes with DHCP-based network
+// configuration in bridge mode.
+func MakeVMBridge(name, image, size string, runStrategy *v1.VirtualMachineRunStrategy) *v1.VirtualMachine {
+	vm := makeBaseVM(name, image, size, runStrategy)
+	vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{
+		{
+			Name:                   "default",
+			InterfaceBindingMethod: v1.DefaultBridgeNetworkInterface().InterfaceBindingMethod,
+		},
+	}
 	return vm
 }
 
 // MakeVMLiveMigratable creates a VM that supports live migration.
-// It sets EvictionStrategy to LiveMigrate and RunStrategy to Always.
+// It sets EvictionStrategy to LiveMigrate, RunStrategy to Always, and
+// increases memory to 128Mi to ensure the guest OS can fully boot and
+// configure networking.
 func MakeVMLiveMigratable(name, image, size string) *v1.VirtualMachine {
 	vm := MakeVM(name, image, size, ptr.To(v1.RunStrategyAlways))
 	vm.Spec.Template.Spec.EvictionStrategy = ptr.To(v1.EvictionStrategyLiveMigrate)
+	vm.Spec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory] = resource.MustParse("128Mi")
 	return vm
 }
 
@@ -312,13 +337,9 @@ func MakeVMLiveMigratable(name, image, size string) *v1.VirtualMachine {
 // a bridge interface instead of masquerade. Bridge mode requires the
 // AllowPodBridgeNetworkLiveMigrationAnnotation annotation on the VMI template.
 func MakeVMLiveMigratableBridge(name, image, size string) *v1.VirtualMachine {
-	vm := MakeVMLiveMigratable(name, image, size)
-	vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{
-		{
-			Name:                   "default",
-			InterfaceBindingMethod: v1.DefaultBridgeNetworkInterface().InterfaceBindingMethod,
-		},
-	}
+	vm := MakeVMBridge(name, image, size, ptr.To(v1.RunStrategyAlways))
+	vm.Spec.Template.Spec.EvictionStrategy = ptr.To(v1.EvictionStrategyLiveMigrate)
+	vm.Spec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory] = resource.MustParse("128Mi")
 	if vm.Spec.Template.ObjectMeta.Annotations == nil {
 		vm.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -327,10 +348,11 @@ func MakeVMLiveMigratableBridge(name, image, size string) *v1.VirtualMachine {
 }
 
 // MakeVMLiveMigratableMultiNIC creates a VM that supports live migration with
-// both the default pod network (masquerade) and an additional OVN NIC via Multus.
+// both the default pod network (bridge) and an additional OVN NIC via Multus.
 // nadName should be in the form "namespace/name".
+// Cloud-init is excluded because the bridge interfaces rely on DHCP.
 func MakeVMLiveMigratableMultiNIC(name, image, size, nadName string) *v1.VirtualMachine {
-	vm := MakeVMLiveMigratable(name, image, size)
+	vm := MakeVMLiveMigratableBridge(name, image, size)
 	vm.Spec.Template.Spec.Domain.Devices.Interfaces = append(
 		vm.Spec.Template.Spec.Domain.Devices.Interfaces,
 		v1.Interface{
@@ -349,9 +371,5 @@ func MakeVMLiveMigratableMultiNIC(name, image, size, nadName string) *v1.Virtual
 			},
 		},
 	)
-	if vm.Spec.Template.ObjectMeta.Annotations == nil {
-		vm.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-	}
-	vm.Spec.Template.ObjectMeta.Annotations[v1.AllowPodBridgeNetworkLiveMigrationAnnotation] = "true"
 	return vm
 }

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -51,6 +51,48 @@ func getVMPod(podClient *framework.PodClient, vmName string) *corev1.Pod {
 	return result
 }
 
+func expectVMAnnotations(pod *corev1.Pod, vmName string) {
+	ginkgo.GinkgoHelper()
+	framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+	framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+	framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+}
+
+func expectLSPMigrationCleanup(portName string) {
+	ginkgo.GinkgoHelper()
+	cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
+	output, _, err := framework.NBExec(cmd)
+	framework.ExpectNoError(err)
+	outputStr := string(output)
+	framework.ExpectNotContainSubstring(outputStr, "activation-strategy")
+	if strings.Contains(outputStr, "requested-chassis") {
+		scanner := bufio.NewScanner(strings.NewReader(outputStr))
+		scanner.Split(bufio.ScanWords)
+		for scanner.Scan() {
+			if chassisValue, ok := strings.CutPrefix(scanner.Text(), "requested-chassis="); ok {
+				framework.ExpectNotContainSubstring(chassisValue, ",")
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			framework.ExpectNoError(err)
+		}
+	}
+}
+
+func parsePingStats(stdout string) (transmitted, received, lost int) {
+	ginkgo.GinkgoHelper()
+	re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
+	matches := re.FindStringSubmatch(stdout)
+	framework.ExpectNotEmpty(matches, "failed to parse ping statistics from output")
+	var err error
+	transmitted, err = strconv.Atoi(matches[1])
+	framework.ExpectNoError(err)
+	received, err = strconv.Atoi(matches[2])
+	framework.ExpectNoError(err)
+	lost = transmitted - received
+	return
+}
+
 func init() {
 	if env := os.Getenv("KUBEVIRT_CONTAINERDISK_IMAGE"); env != "" {
 		image = env
@@ -78,7 +120,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 	var vmClient *framework.VMClient
 	var ipClient *framework.IPClient
 	ginkgo.BeforeEach(func() {
-		f.SkipVersionPriorTo(1, 12, "This feature was introduced in v1.12.")
+		f.SkipVersionPriorTo(1, 14, "This feature was introduced in v1.14.")
 
 		namespaceName = f.Namespace.Name
 		vmName = "vm-" + framework.RandomSuffix()
@@ -108,39 +150,24 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 	framework.ConformanceIt("should be able to keep pod ips after vm pod is deleted", func() {
 		ginkgo.By("Getting pod of vm " + vmName)
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		podList, err := podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod := getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating pod annotations")
-		pod := &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 		ips := pod.Status.PodIPs
 
 		ginkgo.By("Deleting pod " + pod.Name)
 		podClient.DeleteSync(pod.Name)
 
 		ginkgo.By("Waiting for vm " + vmName + " to be ready")
-		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+		err := vmClient.WaitToBeReady(vmName, 2*time.Minute)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		podList, err = podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod = getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating new pod annotations")
-		pod = &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 
 		ginkgo.By("Checking whether pod ips are changed")
 		framework.ExpectEqual(ips, pod.Status.PodIPs)
@@ -148,18 +175,10 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 	framework.ConformanceIt("should be able to keep pod ips after the vm is restarted", func() {
 		ginkgo.By("Getting pod of vm " + vmName)
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		podList, err := podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod := getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating pod annotations")
-		pod := &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 		ips := pod.Status.PodIPs
 
 		ginkgo.By("Stopping vm " + vmName)
@@ -179,17 +198,10 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		framework.ExpectEqual(oldVMIP.Spec, newVMIP.Spec)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		podList, err = podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod = getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating new pod annotations")
-		pod = &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 
 		ginkgo.By("Checking whether pod ips are changed")
 		framework.ExpectEqual(ips, pod.Status.PodIPs)
@@ -206,18 +218,10 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		_ = subnetClient.CreateSync(subnet)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		podList, err := podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod := getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating pod annotations")
-		pod := &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 		ips := pod.Status.PodIPs
 
 		ginkgo.By("Stopping vm " + vmName)
@@ -225,24 +229,17 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 		// the ip is deleted
 		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
-		err = ipClient.WaitToDisappear(portName, time.Second, 2*time.Minute)
+		err := ipClient.WaitToDisappear(portName, time.Second, 2*time.Minute)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Starting vm " + vmName)
 		vmClient.StartSync(vmName)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		podList, err = podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod = getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating new pod annotations")
-		pod = &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 
 		ginkgo.By("Checking whether pod ips are changed")
 		framework.ExpectNotEqual(ips, pod.Status.PodIPs)
@@ -256,19 +253,10 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 	framework.ConformanceIt("should be able to handle vm restart when subnet changes after the vm is stopped", func() {
 		ginkgo.By("Getting pod of vm " + vmName)
-
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		podList, err := podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod := getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating pod annotations")
-		pod := &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 		ips := pod.Status.PodIPs
 
 		ginkgo.By("Stopping vm " + vmName)
@@ -283,17 +271,10 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		vmClient.StartSync(vmName)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		podList, err = podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod = getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating new pod annotations")
-		pod = &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 
 		ginkgo.By("Checking whether pod ips are changed")
 		framework.ExpectNotEqual(ips, pod.Status.PodIPs)
@@ -312,18 +293,10 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		// create new subnet in the namespace.
 		// make sure ip changed after vm started
 		ginkgo.By("Getting pod of vm " + vmName)
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		podList, err := podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod := getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating pod annotations")
-		pod := &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 		ginkgo.By("Stopping vm " + vmName)
 		vmClient.StopSync(vmName)
 
@@ -348,17 +321,10 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		framework.ExpectNotEmpty(newVMIP.Spec.IPAddress)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		podList, err = podClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod = getVMPod(podClient, vmName)
 
 		ginkgo.By("Validating new pod annotations")
-		pod = &podList.Items[0]
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		expectVMAnnotations(pod, vmName)
 		framework.ExpectHaveKeyWithValue(pod.Annotations, util.LogicalSwitchAnnotation, subnetName)
 
 		ginkgo.By("Checking whether pod ips are changed")
@@ -430,12 +396,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		_ = vmClient.CreateSync(vm)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		podList, err := podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
-
-		pod := &podList.Items[0]
+		pod := getVMPod(podClient, vmName)
 		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
 
 		ginkgo.By("Checking attachment IP exists")
@@ -448,7 +409,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		podClient.DeleteSync(pod.Name)
 
 		ginkgo.By("Waiting for vm " + vmName + " to be ready")
-		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+		err := vmClient.WaitToBeReady(vmName, 2*time.Minute)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Checking attachment IP is preserved")
@@ -486,13 +447,9 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		_ = vmClient.CreateSync(vm)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		podList, err := podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
+		pod := getVMPod(podClient, vmName)
 
 		ginkgo.By("Recording IPs")
-		pod := &podList.Items[0]
 		primaryIPs := pod.Status.PodIPs
 
 		attachPortNameA := ovs.PodNameToPortName(vmName, namespaceName, providerA)
@@ -525,11 +482,9 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		framework.ExpectTrue(ipClient.WaitToBeReady(attachPortNameB, 2*time.Minute))
 
 		ginkgo.By("Verifying primary network IP is preserved")
-		podList, err = podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
-		framework.ExpectNoError(err)
-		framework.ExpectHaveLen(podList.Items, 1)
-		framework.ExpectNotEmpty(podList.Items[0].Status.PodIPs)
-		framework.ExpectEqual(primaryIPs, podList.Items[0].Status.PodIPs)
+		pod = getVMPod(podClient, vmName)
+		framework.ExpectNotEmpty(pod.Status.PodIPs)
+		framework.ExpectEqual(primaryIPs, pod.Status.PodIPs)
 	})
 })
 
@@ -543,7 +498,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 	var migrationClient *framework.VMIMigrationClient
 
 	ginkgo.BeforeEach(func() {
-		f.SkipVersionPriorTo(1, 13, "Live migration e2e tests require v1.13 or later.")
+		f.SkipVersionPriorTo(1, 14, "Live migration e2e tests require v1.14 or later.")
 
 		nodes, err := e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
 		framework.ExpectNoError(err)
@@ -582,9 +537,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			origNode := pod.Spec.NodeName
 
 			ginkgo.By("Validating pod annotations")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+			expectVMAnnotations(pod, vmName)
 			origIPs := pod.Status.PodIPs
 			origMAC := pod.Annotations[util.MacAddressAnnotation]
 			framework.ExpectMAC(origMAC)
@@ -609,9 +562,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			framework.ExpectNotEqual(pod.Spec.NodeName, origNode)
 
 			ginkgo.By("Validating pod annotations after migration")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+			expectVMAnnotations(pod, vmName)
 
 			ginkgo.By("Checking that IP and MAC are unchanged")
 			framework.ExpectEqual(pod.Status.PodIPs, origIPs)
@@ -635,29 +586,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Checking OVN LSP options for " + portName)
-			cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
-			output, _, err := framework.NBExec(cmd)
-			framework.ExpectNoError(err)
-			outputStr := string(output)
-
-			ginkgo.By("Verifying activation-strategy is removed")
-			framework.ExpectNotContainSubstring(outputStr, "activation-strategy")
-
-			ginkgo.By("Verifying requested-chassis does not contain a comma (dual-node binding)")
-			if strings.Contains(outputStr, "requested-chassis") {
-				// requested-chassis should be a single node, not "src,target"
-				scanner := bufio.NewScanner(strings.NewReader(outputStr))
-				scanner.Split(bufio.ScanWords)
-				for scanner.Scan() {
-					field := scanner.Text()
-					if chassisValue, ok := strings.CutPrefix(field, "requested-chassis="); ok {
-						framework.ExpectNotContainSubstring(chassisValue, ",")
-					}
-				}
-				if err := scanner.Err(); err != nil {
-					framework.ExpectNoError(err)
-				}
-			}
+			expectLSPMigrationCleanup(portName)
 		})
 
 		framework.ConformanceIt("should preserve IP CRD resource through live migration", func() {
@@ -728,12 +657,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 			portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
 			ginkgo.By("Checking OVN LSP options for " + portName)
-			cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
-			output, _, err := framework.NBExec(cmd)
-			framework.ExpectNoError(err)
-
-			ginkgo.By("Verifying activation-strategy is removed after migration completes")
-			framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+			expectLSPMigrationCleanup(portName)
 		})
 
 		framework.ConformanceIt("should maintain network connectivity through multiple sequential migrations", func() {
@@ -758,12 +682,15 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 				podClient.DeleteSync(proberName)
 			})
 
+			var stdout string
+			var err error
 			ginkgo.By("Verifying initial connectivity from prober to VM")
-			stdout, _, err := framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
-			framework.ExpectNoError(err, "initial connectivity check failed")
+			gomega.Eventually(func() error {
+				stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+				return err
+			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(gomega.Succeed(), "initial connectivity check failed")
 			framework.Logf("Initial ping output:\n%s", stdout)
 
-			re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
 			maxAcceptableLoss := 5
 
 			const migrationCount = 3
@@ -779,13 +706,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 				stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, pingCmd)
 				framework.ExpectNoError(err)
 
-				matches := re.FindStringSubmatch(stdout)
-				framework.ExpectNotEmpty(matches, "failed to parse ping statistics from output")
-				transmitted, err := strconv.Atoi(matches[1])
-				framework.ExpectNoError(err)
-				received, err := strconv.Atoi(matches[2])
-				framework.ExpectNoError(err)
-				lost := transmitted - received
+				transmitted, received, lost := parsePingStats(stdout)
 				framework.Logf("[migration %d/%d] Ping: %d transmitted, %d received, %d lost", i, migrationCount, transmitted, received, lost)
 
 				ginkgo.By(fmt.Sprintf("[migration %d/%d] Verifying migration succeeded", i, migrationCount))
@@ -809,9 +730,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 				framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
 
 				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking annotations", i, migrationCount))
-				framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-				framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-				framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+				expectVMAnnotations(pod, vmName)
 
 				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking IP CRD preserved", i, migrationCount))
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -824,10 +743,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 				}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
 
 				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking OVN LSP cleanup", i, migrationCount))
-				cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
-				output, _, err := framework.NBExec(cmd)
-				framework.ExpectNoError(err)
-				framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+				expectLSPMigrationCleanup(portName)
 
 				framework.Logf("[migration %d/%d] PASSED — node: %s, IP: %v, MAC: %s, lost packets: %d", i, migrationCount, pod.Spec.NodeName, pod.Status.PodIPs, origMAC, lost)
 			}
@@ -867,7 +783,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			gomega.Eventually(func() error {
 				stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
 				return err
-			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(gomega.Succeed(), "initial connectivity check failed")
+			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(gomega.Succeed(), "initial connectivity check failed")
 			framework.Logf("Initial ping output:\n%s", stdout)
 
 			migrationName := "mig-" + framework.RandomSuffix()
@@ -882,15 +798,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			framework.Logf("Continuous ping output:\n%s", stdout)
 
 			ginkgo.By("Parsing ping statistics for packet loss")
-			re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
-			matches := re.FindStringSubmatch(stdout)
-			framework.ExpectNotEmpty(matches, "failed to parse ping statistics from output")
-
-			transmitted, err := strconv.Atoi(matches[1])
-			framework.ExpectNoError(err)
-			received, err := strconv.Atoi(matches[2])
-			framework.ExpectNoError(err)
-			lost := transmitted - received
+			transmitted, received, lost := parsePingStats(stdout)
 			framework.Logf("Ping results: %d transmitted, %d received, %d lost", transmitted, received, lost)
 
 			ginkgo.By("Verifying migration succeeded")
@@ -922,7 +830,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 	var migrationClient *framework.VMIMigrationClient
 
 	ginkgo.BeforeEach(func() {
-		f.SkipVersionPriorTo(1, 13, "Multus live migration e2e tests require v1.14 or later.")
+		f.SkipVersionPriorTo(1, 14, "Multus live migration e2e tests require v1.14 or later.")
 
 		nodes, err := e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
 		framework.ExpectNoError(err)
@@ -1029,17 +937,11 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 		ginkgo.By("Checking default NIC OVN LSP cleanup")
 		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
-		cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
-		output, _, err := framework.NBExec(cmd)
-		framework.ExpectNoError(err)
-		framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+		expectLSPMigrationCleanup(portName)
 
 		ginkgo.By("Checking secondary NIC OVN LSP cleanup")
 		secondaryPortName := ovs.PodNameToPortName(vmName, namespaceName, provider)
-		cmd = "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + secondaryPortName
-		output, _, err = framework.NBExec(cmd)
-		framework.ExpectNoError(err)
-		framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+		expectLSPMigrationCleanup(secondaryPortName)
 
 		framework.Logf("After migration — default IP: %v, MAC: %s, secondary IP: %s, MAC: %s",
 			pod.Status.PodIPs, pod.Annotations[util.MacAddressAnnotation],

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -515,7 +515,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 })
 
 var _ = framework.Describe("[group:kubevirt]", func() {
-	f := framework.NewDefaultFramework("kubevirt")
+	f := framework.NewDefaultFramework("kubevirt-migrations")
 
 	var vmName, namespaceName string
 	var podClient *framework.PodClient
@@ -894,7 +894,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 })
 
 var _ = framework.Describe("[group:kubevirt]", func() {
-	f := framework.NewDefaultFramework("kubevirt")
+	f := framework.NewDefaultFramework("kubevirt-multus-migrations")
 
 	var vmName, namespaceName, subnetName, nadName string
 	var podClient *framework.PodClient
@@ -926,7 +926,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			}
 		}
 		if !nadFound {
-			ginkgo.Skip("Multus CRD (NetworkAttachmentDefinition) not installed, skipping multi-NIC test")
+			ginkgo.Fail("Multus CRD (NetworkAttachmentDefinition) not installed, skipping multi-NIC test")
 		}
 
 		vmName = "vm-" + framework.RandomSuffix()

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -33,6 +33,23 @@ import (
 
 var image = "quay.io/kubevirt/cirros-container-disk-demo:v1.7.2"
 
+func getVMPod(podClient *framework.PodClient, vmName string) *corev1.Pod {
+	ginkgo.GinkgoHelper()
+	labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
+	var result *corev1.Pod
+	gomega.Eventually(func(g gomega.Gomega) {
+		podList, err := podClient.List(context.TODO(), metav1.ListOptions{
+			LabelSelector: labelSelector,
+			FieldSelector: "status.phase=Running",
+		})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(podList.Items).To(gomega.HaveLen(1),
+			"expected exactly 1 running pod for vm %s, got %d", vmName, len(podList.Items))
+		result = &podList.Items[0]
+	}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
+	return result
+}
+
 func init() {
 	if env := os.Getenv("KUBEVIRT_CONTAINERDISK_IMAGE"); env != "" {
 		image = env
@@ -545,23 +562,6 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		framework.ExpectNoError(err)
 	})
 
-	getVMPod := func() *corev1.Pod {
-		ginkgo.GinkgoHelper()
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		var result *corev1.Pod
-		gomega.Eventually(func(g gomega.Gomega) {
-			podList, err := podClient.List(context.TODO(), metav1.ListOptions{
-				LabelSelector: labelSelector,
-				FieldSelector: "status.phase=Running",
-			})
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			g.Expect(podList.Items).To(gomega.HaveLen(1),
-				"expected exactly 1 running pod for vm %s, got %d", vmName, len(podList.Items))
-			result = &podList.Items[0]
-		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
-		return result
-	}
-
 	ginkgo.Context("with bridge interface", func() {
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("Creating live-migratable bridge vm " + vmName)
@@ -571,7 +571,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 		framework.ConformanceIt("should keep pod ip and mac unchanged after live migration", func() {
 			ginkgo.By("Getting pod of vm " + vmName)
-			pod := getVMPod()
+			pod := getVMPod(podClient, vmName)
 			origNode := pod.Spec.NodeName
 
 			ginkgo.By("Validating pod annotations")
@@ -596,7 +596,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Getting pod of vm " + vmName + " after migration")
-			pod = getVMPod()
+			pod = getVMPod(podClient, vmName)
 
 			ginkgo.By("Checking that the vm moved to a different node")
 			framework.ExpectNotEqual(pod.Spec.NodeName, origNode)
@@ -657,7 +657,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
 
 			ginkgo.By("Getting pod of vm " + vmName)
-			pod := getVMPod()
+			pod := getVMPod(podClient, vmName)
 			origNode := pod.Spec.NodeName
 
 			ginkgo.By("Getting IP CRD " + portName + " before migration")
@@ -680,7 +680,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Getting pod of vm " + vmName + " after migration")
-			pod = getVMPod()
+			pod = getVMPod(podClient, vmName)
 			newNode := pod.Spec.NodeName
 			framework.ExpectNotEqual(newNode, origNode)
 
@@ -699,7 +699,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 		framework.ConformanceIt("should preserve network identity when migration is aborted", func() {
 			ginkgo.By("Getting pod of vm " + vmName)
-			pod := getVMPod()
+			pod := getVMPod(podClient, vmName)
 			origIPs := pod.Status.PodIPs
 			origMAC := pod.Annotations[util.MacAddressAnnotation]
 			framework.ExpectMAC(origMAC)
@@ -713,7 +713,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			migrationClient.Delete(migration.Name)
 
 			ginkgo.By("Getting pod of vm " + vmName + " after canceled migration")
-			pod = getVMPod()
+			pod = getVMPod(podClient, vmName)
 
 			ginkgo.By("Checking that IP and MAC are unchanged regardless of migration outcome")
 			framework.ExpectEqual(pod.Status.PodIPs, origIPs)
@@ -731,7 +731,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 		framework.ConformanceIt("should maintain network connectivity through multiple sequential migrations", func() {
 			ginkgo.By("Getting pod of vm " + vmName)
-			pod := getVMPod()
+			pod := getVMPod(podClient, vmName)
 			vmIP := pod.Status.PodIPs[0].IP
 			origIPs := pod.Status.PodIPs
 			origMAC := pod.Annotations[util.MacAddressAnnotation]
@@ -761,7 +761,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 			const migrationCount = 3
 			for i := 1; i <= migrationCount; i++ {
-				prevNode := getVMPod().Spec.NodeName
+				prevNode := getVMPod(podClient, vmName).Spec.NodeName
 				migrationName := fmt.Sprintf("mig-%d-%s", i, framework.RandomSuffix())
 				ginkgo.By(fmt.Sprintf("[migration %d/%d] Creating migration %s (non-blocking)", i, migrationCount, migrationName))
 				migration := framework.MakeVMIMigration(migrationName, vmName)
@@ -793,7 +793,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 				err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
 				framework.ExpectNoError(err)
 
-				pod = getVMPod()
+				pod = getVMPod(podClient, vmName)
 				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking node changed from %s to %s", i, migrationCount, prevNode, pod.Spec.NodeName))
 				framework.ExpectNotEqual(pod.Spec.NodeName, prevNode)
 
@@ -841,7 +841,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 		framework.ConformanceIt("should maintain network connectivity during live migration with masquerade interface", func() {
 			ginkgo.By("Getting pod of vm " + vmName)
-			pod := getVMPod()
+			pod := getVMPod(podClient, vmName)
 			vmIP := pod.Status.PodIPs[0].IP
 			framework.Logf("VM pod IP: %s, node: %s", vmIP, pod.Spec.NodeName)
 
@@ -966,23 +966,6 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		subnetClient.DeleteSync(subnetName)
 	})
 
-	getVMPod := func() *corev1.Pod {
-		ginkgo.GinkgoHelper()
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		var result *corev1.Pod
-		gomega.Eventually(func(g gomega.Gomega) {
-			podList, err := podClient.List(context.TODO(), metav1.ListOptions{
-				LabelSelector: labelSelector,
-				FieldSelector: "status.phase=Running",
-			})
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			g.Expect(podList.Items).To(gomega.HaveLen(1),
-				"expected exactly 1 running pod for vm %s, got %d", vmName, len(podList.Items))
-			result = &podList.Items[0]
-		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
-		return result
-	}
-
 	framework.ConformanceIt("should preserve all NICs through live migration of a multi-NIC vm", func() {
 		provider := fmt.Sprintf("%s.%s.%s", nadName, namespaceName, util.OvnProvider)
 
@@ -1001,7 +984,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		_ = vmClient.CreateSync(vm)
 
 		ginkgo.By("Getting pod of vm " + vmName)
-		pod := getVMPod()
+		pod := getVMPod(podClient, vmName)
 		origNode := pod.Spec.NodeName
 
 		ginkgo.By("Checking default NIC annotations")
@@ -1033,7 +1016,7 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Getting pod of vm " + vmName + " after migration")
-		pod = getVMPod()
+		pod = getVMPod(podClient, vmName)
 		framework.Logf("After migration — node: %s", pod.Spec.NodeName)
 
 		ginkgo.By("Checking that the vm moved to a different node")

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -6,10 +6,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -20,6 +23,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -507,5 +511,606 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		framework.ExpectHaveLen(podList.Items, 1)
 		framework.ExpectNotEmpty(podList.Items[0].Status.PodIPs)
 		framework.ExpectEqual(primaryIPs, podList.Items[0].Status.PodIPs)
+	})
+})
+
+var _ = framework.Describe("[group:kubevirt]", func() {
+	f := framework.NewDefaultFramework("kubevirt")
+
+	var vmName, namespaceName string
+	var podClient *framework.PodClient
+	var vmClient *framework.VMClient
+	var ipClient *framework.IPClient
+	var migrationClient *framework.VMIMigrationClient
+
+	ginkgo.BeforeEach(func() {
+		f.SkipVersionPriorTo(1, 13, "Live migration e2e tests require v1.13 or later.")
+
+		namespaceName = f.Namespace.Name
+		vmName = "vm-" + framework.RandomSuffix()
+		podClient = f.PodClientNS(namespaceName)
+		vmClient = f.VMClientNS(namespaceName)
+		ipClient = f.IPClient()
+		migrationClient = f.VMIMigrationClientNS(namespaceName)
+
+		ginkgo.By("Creating live-migratable bridge vm " + vmName)
+		vm := framework.MakeVMLiveMigratableBridge(vmName, image, "small")
+		_ = vmClient.CreateSync(vm)
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Deleting vm " + vmName)
+		vmClient.DeleteSync(vmName)
+
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+		ginkgo.By("Waiting for IP " + portName + " to be cleaned up")
+		err := ipClient.WaitToDisappear(portName, time.Second, 2*time.Minute)
+		framework.ExpectNoError(err)
+	})
+
+	getVMPod := func() *corev1.Pod {
+		ginkgo.GinkgoHelper()
+		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
+		var result *corev1.Pod
+		gomega.Eventually(func(g gomega.Gomega) {
+			podList, err := podClient.List(context.TODO(), metav1.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: "status.phase=Running",
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(podList.Items).To(gomega.HaveLen(1),
+				"expected exactly 1 running pod for vm %s, got %d", vmName, len(podList.Items))
+			result = &podList.Items[0]
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
+		return result
+	}
+
+	framework.ConformanceIt("should keep pod ip and mac unchanged after live migration", func() {
+		ginkgo.By("Getting pod of vm " + vmName)
+		pod := getVMPod()
+		origNode := pod.Spec.NodeName
+
+		ginkgo.By("Validating pod annotations")
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+		origIPs := pod.Status.PodIPs
+		origMAC := pod.Annotations[util.MacAddressAnnotation]
+		framework.ExpectMAC(origMAC)
+
+		migrationName := "mig-" + framework.RandomSuffix()
+		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+		migration := framework.MakeVMIMigration(migrationName, vmName)
+		migration = migrationClient.Create(migration)
+
+		ginkgo.By("Waiting for migration to succeed")
+		err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for vm " + vmName + " to be ready")
+		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Getting pod of vm " + vmName + " after migration")
+		pod = getVMPod()
+
+		ginkgo.By("Checking that the vm moved to a different node")
+		framework.ExpectNotEqual(pod.Spec.NodeName, origNode)
+
+		ginkgo.By("Validating pod annotations after migration")
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+
+		ginkgo.By("Checking that IP and MAC are unchanged")
+		framework.ExpectEqual(pod.Status.PodIPs, origIPs)
+		framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
+	})
+
+	framework.ConformanceIt("should clean up OVN LSP migrate options after successful migration", func() {
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+
+		migrationName := "mig-" + framework.RandomSuffix()
+		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+		migration := framework.MakeVMIMigration(migrationName, vmName)
+		migration = migrationClient.Create(migration)
+
+		ginkgo.By("Waiting for migration to succeed")
+		err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for vm " + vmName + " to be ready")
+		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Checking OVN LSP options for " + portName)
+		cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
+		output, _, err := framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+		outputStr := string(output)
+
+		ginkgo.By("Verifying activation-strategy is removed")
+		framework.ExpectNotContainSubstring(outputStr, "activation-strategy")
+
+		ginkgo.By("Verifying requested-chassis does not contain a comma (dual-node binding)")
+		if strings.Contains(outputStr, "requested-chassis") {
+			// requested-chassis should be a single node, not "src,target"
+			for _, field := range strings.Fields(outputStr) {
+				if strings.HasPrefix(field, "requested-chassis=") {
+					chassisValue := strings.TrimPrefix(field, "requested-chassis=")
+					framework.ExpectNotContainSubstring(chassisValue, ",")
+				}
+			}
+		}
+	})
+
+	framework.ConformanceIt("should preserve IP CRD resource through live migration", func() {
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+
+		ginkgo.By("Getting pod of vm " + vmName)
+		pod := getVMPod()
+		origNode := pod.Spec.NodeName
+
+		ginkgo.By("Getting IP CRD " + portName + " before migration")
+		origIP := ipClient.Get(portName)
+		framework.ExpectNotEmpty(origIP.Spec.IPAddress)
+		origUID := origIP.UID
+		framework.ExpectEqual(origIP.Spec.NodeName, origNode)
+
+		migrationName := "mig-" + framework.RandomSuffix()
+		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+		migration := framework.MakeVMIMigration(migrationName, vmName)
+		migration = migrationClient.Create(migration)
+
+		ginkgo.By("Waiting for migration to succeed")
+		err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for vm " + vmName + " to be ready")
+		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Getting pod of vm " + vmName + " after migration")
+		pod = getVMPod()
+		newNode := pod.Spec.NodeName
+		framework.ExpectNotEqual(newNode, origNode)
+
+		ginkgo.By("Getting IP CRD " + portName + " after migration")
+		gomega.Eventually(func(g gomega.Gomega) {
+			newIP := ipClient.Get(portName)
+			g.Expect(string(newIP.UID)).To(gomega.Equal(string(origUID)), "IP CRD should not be recreated")
+			g.Expect(newIP.Spec.IPAddress).To(gomega.Equal(origIP.Spec.IPAddress))
+			g.Expect(newIP.Spec.MacAddress).To(gomega.Equal(origIP.Spec.MacAddress))
+			g.Expect(newIP.Spec.Subnet).To(gomega.Equal(origIP.Spec.Subnet))
+			g.Expect(newIP.Spec.PodName).To(gomega.Equal(origIP.Spec.PodName))
+			g.Expect(newIP.Spec.NodeName).To(gomega.Equal(newNode),
+				"IP CRD NodeName should be updated to %s", newNode)
+		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+	})
+
+	framework.ConformanceIt("should preserve network identity when migration is aborted", func() {
+		ginkgo.By("Getting pod of vm " + vmName)
+		pod := getVMPod()
+		origIPs := pod.Status.PodIPs
+		origMAC := pod.Annotations[util.MacAddressAnnotation]
+		framework.ExpectMAC(origMAC)
+
+		migrationName := "mig-" + framework.RandomSuffix()
+		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+		migration := framework.MakeVMIMigration(migrationName, vmName)
+		migration = migrationClient.Create(migration)
+
+		ginkgo.By("Aborting migration " + migrationName)
+		migrationClient.Abort(migration.Name)
+
+		ginkgo.By("Waiting for migration to reach a terminal phase (Succeeded or Failed)")
+		var finalPhase v1.VirtualMachineInstanceMigrationPhase
+		gomega.Eventually(func(g gomega.Gomega) {
+			m := migrationClient.Get(migration.Name)
+			g.Expect(m.Status.Phase == v1.MigrationSucceeded || m.Status.Phase == v1.MigrationFailed).To(gomega.BeTrue(),
+				"expected terminal phase, got %s", m.Status.Phase)
+			finalPhase = m.Status.Phase
+		}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
+		framework.Logf("Migration %s finished with phase: %s", migrationName, finalPhase)
+
+		ginkgo.By("Waiting for vm " + vmName + " to be ready")
+		err := vmClient.WaitToBeReady(vmName, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Getting pod of vm " + vmName + " after migration")
+		pod = getVMPod()
+
+		ginkgo.By("Checking that IP and MAC are unchanged regardless of migration outcome")
+		framework.ExpectEqual(pod.Status.PodIPs, origIPs)
+		framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
+
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+		ginkgo.By("Checking OVN LSP options for " + portName)
+		cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
+		output, _, err := framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying activation-strategy is removed after migration completes")
+		framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+	})
+
+	framework.ConformanceIt("should maintain network connectivity through multiple sequential migrations", func() {
+		ginkgo.By("Getting pod of vm " + vmName)
+		pod := getVMPod()
+		vmIP := pod.Status.PodIPs[0].IP
+		origIPs := pod.Status.PodIPs
+		origMAC := pod.Annotations[util.MacAddressAnnotation]
+		framework.ExpectMAC(origMAC)
+		framework.Logf("VM pod IP: %s, node: %s", vmIP, pod.Spec.NodeName)
+
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+		origIP := ipClient.Get(portName)
+		origUID := origIP.UID
+
+		proberName := "prober-" + framework.RandomSuffix()
+		ginkgo.By("Creating prober pod " + proberName)
+		proberPod := framework.MakePod(namespaceName, proberName, nil, nil, framework.AgnhostImage, nil, []string{"pause"})
+		_ = podClient.CreateSync(proberPod)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting prober pod " + proberName)
+			podClient.DeleteSync(proberName)
+		})
+
+		ginkgo.By("Verifying initial connectivity from prober to VM")
+		stdout, _, err := framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+		framework.ExpectNoError(err, "initial connectivity check failed")
+		framework.Logf("Initial ping output:\n%s", stdout)
+
+		re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
+		maxAcceptableLoss := 5
+
+		const migrationCount = 3
+		for i := 1; i <= migrationCount; i++ {
+			prevNode := getVMPod().Spec.NodeName
+			migrationName := fmt.Sprintf("mig-%d-%s", i, framework.RandomSuffix())
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Creating migration %s (non-blocking)", i, migrationCount, migrationName))
+			migration := framework.MakeVMIMigration(migrationName, vmName)
+			_ = migrationClient.Create(migration)
+
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Running continuous ping during migration", i, migrationCount))
+			pingCmd := fmt.Sprintf("ping -c 400 -i 0.1 -w 60 %s 2>&1 || true", vmIP)
+			stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, pingCmd)
+			framework.ExpectNoError(err)
+
+			matches := re.FindStringSubmatch(stdout)
+			framework.ExpectNotEmpty(matches, "failed to parse ping statistics from output")
+			transmitted, err := strconv.Atoi(matches[1])
+			framework.ExpectNoError(err)
+			received, err := strconv.Atoi(matches[2])
+			framework.ExpectNoError(err)
+			lost := transmitted - received
+			framework.Logf("[migration %d/%d] Ping: %d transmitted, %d received, %d lost", i, migrationCount, transmitted, received, lost)
+
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Verifying migration succeeded", i, migrationCount))
+			err = migrationClient.WaitForPhase(migrationName, v1.MigrationSucceeded, 5*time.Minute)
+			framework.ExpectNoError(err)
+
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Asserting packet loss (%d) within threshold (%d)", i, migrationCount, lost, maxAcceptableLoss))
+			gomega.Expect(lost).To(gomega.BeNumerically("<=", maxAcceptableLoss),
+				"migration %d/%d: expected at most %d lost packets, but lost %d out of %d", i, migrationCount, maxAcceptableLoss, lost, transmitted)
+
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Waiting for vm to be ready", i, migrationCount))
+			err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+			framework.ExpectNoError(err)
+
+			pod = getVMPod()
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking node changed from %s to %s", i, migrationCount, prevNode, pod.Spec.NodeName))
+			framework.ExpectNotEqual(pod.Spec.NodeName, prevNode)
+
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking IP and MAC unchanged", i, migrationCount))
+			framework.ExpectEqual(pod.Status.PodIPs, origIPs)
+			framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
+
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking annotations", i, migrationCount))
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking IP CRD preserved", i, migrationCount))
+			gomega.Eventually(func(g gomega.Gomega) {
+				currentIP := ipClient.Get(portName)
+				g.Expect(string(currentIP.UID)).To(gomega.Equal(string(origUID)))
+				g.Expect(currentIP.Spec.IPAddress).To(gomega.Equal(origIP.Spec.IPAddress))
+				g.Expect(currentIP.Spec.MacAddress).To(gomega.Equal(origIP.Spec.MacAddress))
+				g.Expect(currentIP.Spec.NodeName).To(gomega.Equal(pod.Spec.NodeName),
+					"IP CRD NodeName should be updated to %s", pod.Spec.NodeName)
+			}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking OVN LSP cleanup", i, migrationCount))
+			cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
+			output, _, err := framework.NBExec(cmd)
+			framework.ExpectNoError(err)
+			framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+
+			framework.Logf("[migration %d/%d] PASSED — node: %s, IP: %v, MAC: %s, lost packets: %d", i, migrationCount, pod.Spec.NodeName, pod.Status.PodIPs, origMAC, lost)
+		}
+
+		ginkgo.By("Verifying post-migration connectivity")
+		stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+		framework.ExpectNoError(err, "post-migration connectivity check failed")
+		framework.Logf("Post-migration ping output:\n%s", stdout)
+	})
+})
+
+var _ = framework.Describe("[group:kubevirt]", func() {
+	f := framework.NewDefaultFramework("kubevirt")
+
+	var vmName, namespaceName string
+	var podClient *framework.PodClient
+	var vmClient *framework.VMClient
+	var ipClient *framework.IPClient
+	var migrationClient *framework.VMIMigrationClient
+
+	ginkgo.BeforeEach(func() {
+		f.SkipVersionPriorTo(1, 13, "Live migration e2e tests require v1.13 or later.")
+
+		namespaceName = f.Namespace.Name
+		vmName = "vm-" + framework.RandomSuffix()
+		podClient = f.PodClientNS(namespaceName)
+		vmClient = f.VMClientNS(namespaceName)
+		ipClient = f.IPClient()
+		migrationClient = f.VMIMigrationClientNS(namespaceName)
+
+		ginkgo.By("Creating live-migratable masquerade vm " + vmName)
+		vm := framework.MakeVMLiveMigratable(vmName, image, "small")
+		_ = vmClient.CreateSync(vm)
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Deleting vm " + vmName)
+		vmClient.DeleteSync(vmName)
+
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+		ginkgo.By("Waiting for IP " + portName + " to be cleaned up")
+		err := ipClient.WaitToDisappear(portName, time.Second, 2*time.Minute)
+		framework.ExpectNoError(err)
+	})
+
+	getVMPod := func() *corev1.Pod {
+		ginkgo.GinkgoHelper()
+		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
+		var result *corev1.Pod
+		gomega.Eventually(func(g gomega.Gomega) {
+			podList, err := podClient.List(context.TODO(), metav1.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: "status.phase=Running",
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(podList.Items).To(gomega.HaveLen(1),
+				"expected exactly 1 running pod for vm %s, got %d", vmName, len(podList.Items))
+			result = &podList.Items[0]
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
+		return result
+	}
+
+	framework.ConformanceIt("should maintain network connectivity during live migration with masquerade interface", func() {
+		ginkgo.By("Getting pod of vm " + vmName)
+		pod := getVMPod()
+		vmIP := pod.Status.PodIPs[0].IP
+		framework.Logf("VM pod IP: %s, node: %s", vmIP, pod.Spec.NodeName)
+
+		proberName := "prober-" + framework.RandomSuffix()
+		ginkgo.By("Creating prober pod " + proberName)
+		proberPod := framework.MakePod(namespaceName, proberName, nil, nil, framework.AgnhostImage, nil, []string{"pause"})
+		_ = podClient.CreateSync(proberPod)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting prober pod " + proberName)
+			podClient.DeleteSync(proberName)
+		})
+
+		ginkgo.By("Verifying initial connectivity from prober to VM")
+		stdout, _, err := framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+		framework.ExpectNoError(err, "initial connectivity check failed")
+		framework.Logf("Initial ping output:\n%s", stdout)
+
+		migrationName := "mig-" + framework.RandomSuffix()
+		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName + " (non-blocking)")
+		migration := framework.MakeVMIMigration(migrationName, vmName)
+		_ = migrationClient.Create(migration)
+
+		ginkgo.By("Running continuous ping from prober to VM " + vmIP + " during migration")
+		pingCmd := fmt.Sprintf("ping -c 400 -i 0.1 -w 60 %s 2>&1 || true", vmIP)
+		stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, pingCmd)
+		framework.ExpectNoError(err)
+		framework.Logf("Continuous ping output:\n%s", stdout)
+
+		ginkgo.By("Parsing ping statistics for packet loss")
+		re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
+		matches := re.FindStringSubmatch(stdout)
+		framework.ExpectNotEmpty(matches, "failed to parse ping statistics from output")
+
+		transmitted, err := strconv.Atoi(matches[1])
+		framework.ExpectNoError(err)
+		received, err := strconv.Atoi(matches[2])
+		framework.ExpectNoError(err)
+		lost := transmitted - received
+		framework.Logf("Ping results: %d transmitted, %d received, %d lost", transmitted, received, lost)
+
+		ginkgo.By("Verifying migration succeeded")
+		err = migrationClient.WaitForPhase(migrationName, v1.MigrationSucceeded, 5*time.Minute)
+		framework.ExpectNoError(err)
+
+		maxAcceptableLoss := 5
+		ginkgo.By(fmt.Sprintf("Asserting packet loss (%d) is within acceptable threshold (%d)", lost, maxAcceptableLoss))
+		gomega.Expect(lost).To(gomega.BeNumerically("<=", maxAcceptableLoss),
+			"expected at most %d lost packets (0.5s downtime at 0.1s interval), but lost %d out of %d", maxAcceptableLoss, lost, transmitted)
+
+		ginkgo.By("Verifying post-migration connectivity")
+		stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+		framework.ExpectNoError(err, "post-migration connectivity check failed")
+		framework.Logf("Post-migration ping output:\n%s", stdout)
+	})
+})
+
+var _ = framework.Describe("[group:kubevirt]", func() {
+	f := framework.NewDefaultFramework("kubevirt")
+
+	var vmName, namespaceName, subnetName, nadName string
+	var podClient *framework.PodClient
+	var vmClient *framework.VMClient
+	var ipClient *framework.IPClient
+	var subnetClient *framework.SubnetClient
+	var nadClient *framework.NetworkAttachmentDefinitionClient
+	var migrationClient *framework.VMIMigrationClient
+
+	ginkgo.BeforeEach(func() {
+		f.SkipVersionPriorTo(1, 13, "Live migration e2e tests require v1.13 or later.")
+
+		namespaceName = f.Namespace.Name
+
+		ginkgo.By("Checking if Multus CRD is available")
+		_, resources, err := f.ClientSet.Discovery().ServerGroupsAndResources()
+		if err != nil {
+			ginkgo.Skip("failed to discover API resources: " + err.Error())
+		}
+		nadFound := false
+		for _, rl := range resources {
+			if rl.GroupVersion == "k8s.cni.cncf.io/v1" {
+				for _, r := range rl.APIResources {
+					if r.Kind == "NetworkAttachmentDefinition" {
+						nadFound = true
+						break
+					}
+				}
+			}
+		}
+		if !nadFound {
+			ginkgo.Skip("Multus CRD (NetworkAttachmentDefinition) not installed, skipping multi-NIC test")
+		}
+
+		vmName = "vm-" + framework.RandomSuffix()
+		subnetName = "subnet-" + framework.RandomSuffix()
+		nadName = "nad-" + framework.RandomSuffix()
+		podClient = f.PodClientNS(namespaceName)
+		vmClient = f.VMClientNS(namespaceName)
+		ipClient = f.IPClient()
+		subnetClient = f.SubnetClient()
+		nadClient = f.NetworkAttachmentDefinitionClientNS(namespaceName)
+		migrationClient = f.VMIMigrationClientNS(namespaceName)
+	})
+
+	ginkgo.AfterEach(func() {
+		if vmName == "" {
+			return
+		}
+
+		ginkgo.By("Deleting vm " + vmName)
+		vmClient.DeleteSync(vmName)
+
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+		ginkgo.By("Waiting for IP " + portName + " to be cleaned up")
+		err := ipClient.WaitToDisappear(portName, time.Second, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Deleting NAD " + nadName)
+		nadClient.Delete(nadName)
+
+		ginkgo.By("Deleting subnet " + subnetName)
+		subnetClient.DeleteSync(subnetName)
+	})
+
+	getVMPod := func() *corev1.Pod {
+		ginkgo.GinkgoHelper()
+		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
+		var result *corev1.Pod
+		gomega.Eventually(func(g gomega.Gomega) {
+			podList, err := podClient.List(context.TODO(), metav1.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: "status.phase=Running",
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(podList.Items).To(gomega.HaveLen(1),
+				"expected exactly 1 running pod for vm %s, got %d", vmName, len(podList.Items))
+			result = &podList.Items[0]
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
+		return result
+	}
+
+	framework.ConformanceIt("should preserve all NICs through live migration of a multi-NIC vm", func() {
+		provider := fmt.Sprintf("%s.%s.%s", nadName, namespaceName, util.OvnProvider)
+
+		ginkgo.By("Creating secondary subnet " + subnetName)
+		cidr := framework.RandomCIDR(f.ClusterIPFamily)
+		subnet := framework.MakeSubnet(subnetName, "", cidr, "", "", provider, nil, nil, []string{namespaceName})
+		_ = subnetClient.CreateSync(subnet)
+
+		ginkgo.By("Creating NAD " + nadName)
+		nad := framework.MakeOVNNetworkAttachmentDefinition(nadName, namespaceName, provider, nil)
+		_ = nadClient.Create(nad)
+
+		ginkgo.By("Creating multi-NIC live-migratable vm " + vmName)
+		nadFullName := fmt.Sprintf("%s/%s", namespaceName, nadName)
+		vm := framework.MakeVMLiveMigratableMultiNIC(vmName, image, "small", nadFullName)
+		_ = vmClient.CreateSync(vm)
+
+		ginkgo.By("Getting pod of vm " + vmName)
+		pod := getVMPod()
+		origNode := pod.Spec.NodeName
+
+		ginkgo.By("Checking default NIC annotations")
+		origIPs := pod.Status.PodIPs
+		origMAC := pod.Annotations[util.MacAddressAnnotation]
+		framework.ExpectMAC(origMAC)
+
+		ginkgo.By("Checking secondary NIC annotations")
+		secondaryIPKey := fmt.Sprintf(util.IPAddressAnnotationTemplate, provider)
+		secondaryMACKey := fmt.Sprintf(util.MacAddressAnnotationTemplate, provider)
+		origSecondaryIP := pod.Annotations[secondaryIPKey]
+		origSecondaryMAC := pod.Annotations[secondaryMACKey]
+		framework.ExpectNotEmpty(origSecondaryIP, "secondary IP should be allocated")
+		framework.ExpectMAC(origSecondaryMAC)
+		framework.Logf("Before migration — node: %s, default IP: %v, MAC: %s, secondary IP: %s, MAC: %s",
+			origNode, origIPs, origMAC, origSecondaryIP, origSecondaryMAC)
+
+		migrationName := "mig-" + framework.RandomSuffix()
+		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+		migration := framework.MakeVMIMigration(migrationName, vmName)
+		migration = migrationClient.Create(migration)
+
+		ginkgo.By("Waiting for migration to succeed")
+		err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for vm " + vmName + " to be ready")
+		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Getting pod of vm " + vmName + " after migration")
+		pod = getVMPod()
+		framework.Logf("After migration — node: %s", pod.Spec.NodeName)
+
+		ginkgo.By("Checking that the vm moved to a different node")
+		framework.ExpectNotEqual(pod.Spec.NodeName, origNode)
+
+		ginkgo.By("Checking default NIC IP and MAC are unchanged")
+		framework.ExpectEqual(pod.Status.PodIPs, origIPs)
+		framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
+
+		ginkgo.By("Checking secondary NIC IP and MAC are unchanged")
+		framework.ExpectEqual(pod.Annotations[secondaryIPKey], origSecondaryIP)
+		framework.ExpectEqual(pod.Annotations[secondaryMACKey], origSecondaryMAC)
+
+		ginkgo.By("Checking default NIC OVN LSP cleanup")
+		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+		cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
+		output, _, err := framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+		framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+
+		ginkgo.By("Checking secondary NIC OVN LSP cleanup")
+		secondaryPortName := ovs.PodNameToPortName(vmName, namespaceName, provider)
+		cmd = "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + secondaryPortName
+		output, _, err = framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+		framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+
+		framework.Logf("After migration — default IP: %v, MAC: %s, secondary IP: %s, MAC: %s",
+			pod.Status.PodIPs, pod.Annotations[util.MacAddressAnnotation],
+			pod.Annotations[secondaryIPKey], pod.Annotations[secondaryMACKey])
 	})
 })

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -532,10 +532,6 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		vmClient = f.VMClientNS(namespaceName)
 		ipClient = f.IPClient()
 		migrationClient = f.VMIMigrationClientNS(namespaceName)
-
-		ginkgo.By("Creating live-migratable bridge vm " + vmName)
-		vm := framework.MakeVMLiveMigratableBridge(vmName, image, "small")
-		_ = vmClient.CreateSync(vm)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -565,385 +561,335 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 		return result
 	}
 
-	framework.ConformanceIt("should keep pod ip and mac unchanged after live migration", func() {
-		ginkgo.By("Getting pod of vm " + vmName)
-		pod := getVMPod()
-		origNode := pod.Spec.NodeName
-
-		ginkgo.By("Validating pod annotations")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
-		origIPs := pod.Status.PodIPs
-		origMAC := pod.Annotations[util.MacAddressAnnotation]
-		framework.ExpectMAC(origMAC)
-
-		migrationName := "mig-" + framework.RandomSuffix()
-		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
-		migration := framework.MakeVMIMigration(migrationName, vmName)
-		migration = migrationClient.Create(migration)
-
-		ginkgo.By("Waiting for migration to succeed")
-		err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Waiting for vm " + vmName + " to be ready")
-		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Getting pod of vm " + vmName + " after migration")
-		pod = getVMPod()
-
-		ginkgo.By("Checking that the vm moved to a different node")
-		framework.ExpectNotEqual(pod.Spec.NodeName, origNode)
-
-		ginkgo.By("Validating pod annotations after migration")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-		framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
-
-		ginkgo.By("Checking that IP and MAC are unchanged")
-		framework.ExpectEqual(pod.Status.PodIPs, origIPs)
-		framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
-	})
-
-	framework.ConformanceIt("should clean up OVN LSP migrate options after successful migration", func() {
-		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
-
-		migrationName := "mig-" + framework.RandomSuffix()
-		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
-		migration := framework.MakeVMIMigration(migrationName, vmName)
-		migration = migrationClient.Create(migration)
-
-		ginkgo.By("Waiting for migration to succeed")
-		err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Waiting for vm " + vmName + " to be ready")
-		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Checking OVN LSP options for " + portName)
-		cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
-		output, _, err := framework.NBExec(cmd)
-		framework.ExpectNoError(err)
-		outputStr := string(output)
-
-		ginkgo.By("Verifying activation-strategy is removed")
-		framework.ExpectNotContainSubstring(outputStr, "activation-strategy")
-
-		ginkgo.By("Verifying requested-chassis does not contain a comma (dual-node binding)")
-		if strings.Contains(outputStr, "requested-chassis") {
-			// requested-chassis should be a single node, not "src,target"
-			for _, field := range strings.Fields(outputStr) {
-				if strings.HasPrefix(field, "requested-chassis=") {
-					chassisValue := strings.TrimPrefix(field, "requested-chassis=")
-					framework.ExpectNotContainSubstring(chassisValue, ",")
-				}
-			}
-		}
-	})
-
-	framework.ConformanceIt("should preserve IP CRD resource through live migration", func() {
-		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
-
-		ginkgo.By("Getting pod of vm " + vmName)
-		pod := getVMPod()
-		origNode := pod.Spec.NodeName
-
-		ginkgo.By("Getting IP CRD " + portName + " before migration")
-		origIP := ipClient.Get(portName)
-		framework.ExpectNotEmpty(origIP.Spec.IPAddress)
-		origUID := origIP.UID
-		framework.ExpectEqual(origIP.Spec.NodeName, origNode)
-
-		migrationName := "mig-" + framework.RandomSuffix()
-		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
-		migration := framework.MakeVMIMigration(migrationName, vmName)
-		migration = migrationClient.Create(migration)
-
-		ginkgo.By("Waiting for migration to succeed")
-		err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Waiting for vm " + vmName + " to be ready")
-		err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Getting pod of vm " + vmName + " after migration")
-		pod = getVMPod()
-		newNode := pod.Spec.NodeName
-		framework.ExpectNotEqual(newNode, origNode)
-
-		ginkgo.By("Getting IP CRD " + portName + " after migration")
-		gomega.Eventually(func(g gomega.Gomega) {
-			newIP := ipClient.Get(portName)
-			g.Expect(string(newIP.UID)).To(gomega.Equal(string(origUID)), "IP CRD should not be recreated")
-			g.Expect(newIP.Spec.IPAddress).To(gomega.Equal(origIP.Spec.IPAddress))
-			g.Expect(newIP.Spec.MacAddress).To(gomega.Equal(origIP.Spec.MacAddress))
-			g.Expect(newIP.Spec.Subnet).To(gomega.Equal(origIP.Spec.Subnet))
-			g.Expect(newIP.Spec.PodName).To(gomega.Equal(origIP.Spec.PodName))
-			g.Expect(newIP.Spec.NodeName).To(gomega.Equal(newNode),
-				"IP CRD NodeName should be updated to %s", newNode)
-		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
-	})
-
-	framework.ConformanceIt("should preserve network identity when migration is aborted", func() {
-		ginkgo.By("Getting pod of vm " + vmName)
-		pod := getVMPod()
-		origIPs := pod.Status.PodIPs
-		origMAC := pod.Annotations[util.MacAddressAnnotation]
-		framework.ExpectMAC(origMAC)
-
-		migrationName := "mig-" + framework.RandomSuffix()
-		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
-		migration := framework.MakeVMIMigration(migrationName, vmName)
-		migration = migrationClient.Create(migration)
-
-		ginkgo.By("Aborting migration " + migrationName)
-		migrationClient.Abort(migration.Name)
-
-		ginkgo.By("Waiting for migration to reach a terminal phase (Succeeded or Failed)")
-		var finalPhase v1.VirtualMachineInstanceMigrationPhase
-		gomega.Eventually(func(g gomega.Gomega) {
-			m := migrationClient.Get(migration.Name)
-			g.Expect(m.Status.Phase == v1.MigrationSucceeded || m.Status.Phase == v1.MigrationFailed).To(gomega.BeTrue(),
-				"expected terminal phase, got %s", m.Status.Phase)
-			finalPhase = m.Status.Phase
-		}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
-		framework.Logf("Migration %s finished with phase: %s", migrationName, finalPhase)
-
-		ginkgo.By("Waiting for vm " + vmName + " to be ready")
-		err := vmClient.WaitToBeReady(vmName, 2*time.Minute)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Getting pod of vm " + vmName + " after migration")
-		pod = getVMPod()
-
-		ginkgo.By("Checking that IP and MAC are unchanged regardless of migration outcome")
-		framework.ExpectEqual(pod.Status.PodIPs, origIPs)
-		framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
-
-		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
-		ginkgo.By("Checking OVN LSP options for " + portName)
-		cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
-		output, _, err := framework.NBExec(cmd)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Verifying activation-strategy is removed after migration completes")
-		framework.ExpectNotContainSubstring(string(output), "activation-strategy")
-	})
-
-	framework.ConformanceIt("should maintain network connectivity through multiple sequential migrations", func() {
-		ginkgo.By("Getting pod of vm " + vmName)
-		pod := getVMPod()
-		vmIP := pod.Status.PodIPs[0].IP
-		origIPs := pod.Status.PodIPs
-		origMAC := pod.Annotations[util.MacAddressAnnotation]
-		framework.ExpectMAC(origMAC)
-		framework.Logf("VM pod IP: %s, node: %s", vmIP, pod.Spec.NodeName)
-
-		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
-		origIP := ipClient.Get(portName)
-		origUID := origIP.UID
-
-		proberName := "prober-" + framework.RandomSuffix()
-		ginkgo.By("Creating prober pod " + proberName)
-		proberPod := framework.MakePod(namespaceName, proberName, nil, nil, framework.AgnhostImage, nil, []string{"pause"})
-		_ = podClient.CreateSync(proberPod)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting prober pod " + proberName)
-			podClient.DeleteSync(proberName)
+	ginkgo.Context("with bridge interface", func() {
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Creating live-migratable bridge vm " + vmName)
+			vm := framework.MakeVMLiveMigratableBridge(vmName, image, "small")
+			_ = vmClient.CreateSync(vm)
 		})
 
-		ginkgo.By("Verifying initial connectivity from prober to VM")
-		stdout, _, err := framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
-		framework.ExpectNoError(err, "initial connectivity check failed")
-		framework.Logf("Initial ping output:\n%s", stdout)
+		framework.ConformanceIt("should keep pod ip and mac unchanged after live migration", func() {
+			ginkgo.By("Getting pod of vm " + vmName)
+			pod := getVMPod()
+			origNode := pod.Spec.NodeName
 
-		re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
-		maxAcceptableLoss := 5
+			ginkgo.By("Validating pod annotations")
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+			origIPs := pod.Status.PodIPs
+			origMAC := pod.Annotations[util.MacAddressAnnotation]
+			framework.ExpectMAC(origMAC)
 
-		const migrationCount = 3
-		for i := 1; i <= migrationCount; i++ {
-			prevNode := getVMPod().Spec.NodeName
-			migrationName := fmt.Sprintf("mig-%d-%s", i, framework.RandomSuffix())
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Creating migration %s (non-blocking)", i, migrationCount, migrationName))
+			migrationName := "mig-" + framework.RandomSuffix()
+			ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+			migration := framework.MakeVMIMigration(migrationName, vmName)
+			migration = migrationClient.Create(migration)
+
+			ginkgo.By("Waiting for migration to succeed")
+			err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for vm " + vmName + " to be ready")
+			err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Getting pod of vm " + vmName + " after migration")
+			pod = getVMPod()
+
+			ginkgo.By("Checking that the vm moved to a different node")
+			framework.ExpectNotEqual(pod.Spec.NodeName, origNode)
+
+			ginkgo.By("Validating pod annotations after migration")
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+			framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+
+			ginkgo.By("Checking that IP and MAC are unchanged")
+			framework.ExpectEqual(pod.Status.PodIPs, origIPs)
+			framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
+		})
+
+		framework.ConformanceIt("should clean up OVN LSP migrate options after successful migration", func() {
+			portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+
+			migrationName := "mig-" + framework.RandomSuffix()
+			ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+			migration := framework.MakeVMIMigration(migrationName, vmName)
+			migration = migrationClient.Create(migration)
+
+			ginkgo.By("Waiting for migration to succeed")
+			err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for vm " + vmName + " to be ready")
+			err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Checking OVN LSP options for " + portName)
+			cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
+			output, _, err := framework.NBExec(cmd)
+			framework.ExpectNoError(err)
+			outputStr := string(output)
+
+			ginkgo.By("Verifying activation-strategy is removed")
+			framework.ExpectNotContainSubstring(outputStr, "activation-strategy")
+
+			ginkgo.By("Verifying requested-chassis does not contain a comma (dual-node binding)")
+			if strings.Contains(outputStr, "requested-chassis") {
+				// requested-chassis should be a single node, not "src,target"
+				for _, field := range strings.Fields(outputStr) {
+					if strings.HasPrefix(field, "requested-chassis=") {
+						chassisValue := strings.TrimPrefix(field, "requested-chassis=")
+						framework.ExpectNotContainSubstring(chassisValue, ",")
+					}
+				}
+			}
+		})
+
+		framework.ConformanceIt("should preserve IP CRD resource through live migration", func() {
+			portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+
+			ginkgo.By("Getting pod of vm " + vmName)
+			pod := getVMPod()
+			origNode := pod.Spec.NodeName
+
+			ginkgo.By("Getting IP CRD " + portName + " before migration")
+			origIP := ipClient.Get(portName)
+			framework.ExpectNotEmpty(origIP.Spec.IPAddress)
+			origUID := origIP.UID
+			framework.ExpectEqual(origIP.Spec.NodeName, origNode)
+
+			migrationName := "mig-" + framework.RandomSuffix()
+			ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+			migration := framework.MakeVMIMigration(migrationName, vmName)
+			migration = migrationClient.Create(migration)
+
+			ginkgo.By("Waiting for migration to succeed")
+			err := migrationClient.WaitForPhase(migration.Name, v1.MigrationSucceeded, 5*time.Minute)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for vm " + vmName + " to be ready")
+			err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Getting pod of vm " + vmName + " after migration")
+			pod = getVMPod()
+			newNode := pod.Spec.NodeName
+			framework.ExpectNotEqual(newNode, origNode)
+
+			ginkgo.By("Getting IP CRD " + portName + " after migration")
+			gomega.Eventually(func(g gomega.Gomega) {
+				newIP := ipClient.Get(portName)
+				g.Expect(string(newIP.UID)).To(gomega.Equal(string(origUID)), "IP CRD should not be recreated")
+				g.Expect(newIP.Spec.IPAddress).To(gomega.Equal(origIP.Spec.IPAddress))
+				g.Expect(newIP.Spec.MacAddress).To(gomega.Equal(origIP.Spec.MacAddress))
+				g.Expect(newIP.Spec.Subnet).To(gomega.Equal(origIP.Spec.Subnet))
+				g.Expect(newIP.Spec.PodName).To(gomega.Equal(origIP.Spec.PodName))
+				g.Expect(newIP.Spec.NodeName).To(gomega.Equal(newNode),
+					"IP CRD NodeName should be updated to %s", newNode)
+			}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+		})
+
+		framework.ConformanceIt("should preserve network identity when migration is aborted", func() {
+			ginkgo.By("Getting pod of vm " + vmName)
+			pod := getVMPod()
+			origIPs := pod.Status.PodIPs
+			origMAC := pod.Annotations[util.MacAddressAnnotation]
+			framework.ExpectMAC(origMAC)
+
+			migrationName := "mig-" + framework.RandomSuffix()
+			ginkgo.By("Creating migration " + migrationName + " for vm " + vmName)
+			migration := framework.MakeVMIMigration(migrationName, vmName)
+			migration = migrationClient.Create(migration)
+
+			ginkgo.By("Aborting migration " + migrationName)
+			migrationClient.Delete(migration.Name)
+
+			ginkgo.By("Getting pod of vm " + vmName + " after canceled migration")
+			pod = getVMPod()
+
+			ginkgo.By("Checking that IP and MAC are unchanged regardless of migration outcome")
+			framework.ExpectEqual(pod.Status.PodIPs, origIPs)
+			framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
+
+			portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+			ginkgo.By("Checking OVN LSP options for " + portName)
+			cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
+			output, _, err := framework.NBExec(cmd)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Verifying activation-strategy is removed after migration completes")
+			framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+		})
+
+		framework.ConformanceIt("should maintain network connectivity through multiple sequential migrations", func() {
+			ginkgo.By("Getting pod of vm " + vmName)
+			pod := getVMPod()
+			vmIP := pod.Status.PodIPs[0].IP
+			origIPs := pod.Status.PodIPs
+			origMAC := pod.Annotations[util.MacAddressAnnotation]
+			framework.ExpectMAC(origMAC)
+			framework.Logf("VM pod IP: %s, node: %s", vmIP, pod.Spec.NodeName)
+
+			portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
+			origIP := ipClient.Get(portName)
+			origUID := origIP.UID
+
+			proberName := "prober-" + framework.RandomSuffix()
+			ginkgo.By("Creating prober pod " + proberName)
+			proberPod := framework.MakePod(namespaceName, proberName, nil, nil, framework.AgnhostImage, nil, []string{"pause"})
+			_ = podClient.CreateSync(proberPod)
+			ginkgo.DeferCleanup(func() {
+				ginkgo.By("Deleting prober pod " + proberName)
+				podClient.DeleteSync(proberName)
+			})
+
+			ginkgo.By("Verifying initial connectivity from prober to VM")
+			stdout, _, err := framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+			framework.ExpectNoError(err, "initial connectivity check failed")
+			framework.Logf("Initial ping output:\n%s", stdout)
+
+			re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
+			maxAcceptableLoss := 5
+
+			const migrationCount = 3
+			for i := 1; i <= migrationCount; i++ {
+				prevNode := getVMPod().Spec.NodeName
+				migrationName := fmt.Sprintf("mig-%d-%s", i, framework.RandomSuffix())
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Creating migration %s (non-blocking)", i, migrationCount, migrationName))
+				migration := framework.MakeVMIMigration(migrationName, vmName)
+				_ = migrationClient.Create(migration)
+
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Running continuous ping during migration", i, migrationCount))
+				pingCmd := fmt.Sprintf("ping -c 400 -i 0.1 -w 60 %s 2>&1 || true", vmIP)
+				stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, pingCmd)
+				framework.ExpectNoError(err)
+
+				matches := re.FindStringSubmatch(stdout)
+				framework.ExpectNotEmpty(matches, "failed to parse ping statistics from output")
+				transmitted, err := strconv.Atoi(matches[1])
+				framework.ExpectNoError(err)
+				received, err := strconv.Atoi(matches[2])
+				framework.ExpectNoError(err)
+				lost := transmitted - received
+				framework.Logf("[migration %d/%d] Ping: %d transmitted, %d received, %d lost", i, migrationCount, transmitted, received, lost)
+
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Verifying migration succeeded", i, migrationCount))
+				err = migrationClient.WaitForPhase(migrationName, v1.MigrationSucceeded, 5*time.Minute)
+				framework.ExpectNoError(err)
+
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Asserting packet loss (%d) within threshold (%d)", i, migrationCount, lost, maxAcceptableLoss))
+				gomega.Expect(lost).To(gomega.BeNumerically("<=", maxAcceptableLoss),
+					"migration %d/%d: expected at most %d lost packets, but lost %d out of %d", i, migrationCount, maxAcceptableLoss, lost, transmitted)
+
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Waiting for vm to be ready", i, migrationCount))
+				err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
+				framework.ExpectNoError(err)
+
+				pod = getVMPod()
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking node changed from %s to %s", i, migrationCount, prevNode, pod.Spec.NodeName))
+				framework.ExpectNotEqual(pod.Spec.NodeName, prevNode)
+
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking IP and MAC unchanged", i, migrationCount))
+				framework.ExpectEqual(pod.Status.PodIPs, origIPs)
+				framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
+
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking annotations", i, migrationCount))
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
+				framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
+
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking IP CRD preserved", i, migrationCount))
+				gomega.Eventually(func(g gomega.Gomega) {
+					currentIP := ipClient.Get(portName)
+					g.Expect(string(currentIP.UID)).To(gomega.Equal(string(origUID)))
+					g.Expect(currentIP.Spec.IPAddress).To(gomega.Equal(origIP.Spec.IPAddress))
+					g.Expect(currentIP.Spec.MacAddress).To(gomega.Equal(origIP.Spec.MacAddress))
+					g.Expect(currentIP.Spec.NodeName).To(gomega.Equal(pod.Spec.NodeName),
+						"IP CRD NodeName should be updated to %s", pod.Spec.NodeName)
+				}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+
+				ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking OVN LSP cleanup", i, migrationCount))
+				cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
+				output, _, err := framework.NBExec(cmd)
+				framework.ExpectNoError(err)
+				framework.ExpectNotContainSubstring(string(output), "activation-strategy")
+
+				framework.Logf("[migration %d/%d] PASSED — node: %s, IP: %v, MAC: %s, lost packets: %d", i, migrationCount, pod.Spec.NodeName, pod.Status.PodIPs, origMAC, lost)
+			}
+
+			ginkgo.By("Verifying post-migration connectivity")
+			stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+			framework.ExpectNoError(err, "post-migration connectivity check failed")
+			framework.Logf("Post-migration ping output:\n%s", stdout)
+		})
+	})
+
+	ginkgo.Context("with masquerade interface", func() {
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Creating live-migratable masquerade vm " + vmName)
+			vm := framework.MakeVMLiveMigratable(vmName, image, "small")
+			_ = vmClient.CreateSync(vm)
+		})
+
+		framework.ConformanceIt("should maintain network connectivity during live migration with masquerade interface", func() {
+			ginkgo.By("Getting pod of vm " + vmName)
+			pod := getVMPod()
+			vmIP := pod.Status.PodIPs[0].IP
+			framework.Logf("VM pod IP: %s, node: %s", vmIP, pod.Spec.NodeName)
+
+			proberName := "prober-" + framework.RandomSuffix()
+			ginkgo.By("Creating prober pod " + proberName)
+			proberPod := framework.MakePod(namespaceName, proberName, nil, nil, framework.AgnhostImage, nil, []string{"pause"})
+			_ = podClient.CreateSync(proberPod)
+			ginkgo.DeferCleanup(func() {
+				ginkgo.By("Deleting prober pod " + proberName)
+				podClient.DeleteSync(proberName)
+			})
+
+			ginkgo.By("Verifying initial connectivity from prober to VM")
+			stdout, _, err := framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+			framework.ExpectNoError(err, "initial connectivity check failed")
+			framework.Logf("Initial ping output:\n%s", stdout)
+
+			migrationName := "mig-" + framework.RandomSuffix()
+			ginkgo.By("Creating migration " + migrationName + " for vm " + vmName + " (non-blocking)")
 			migration := framework.MakeVMIMigration(migrationName, vmName)
 			_ = migrationClient.Create(migration)
 
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Running continuous ping during migration", i, migrationCount))
+			ginkgo.By("Running continuous ping from prober to VM " + vmIP + " during migration")
 			pingCmd := fmt.Sprintf("ping -c 400 -i 0.1 -w 60 %s 2>&1 || true", vmIP)
 			stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, pingCmd)
 			framework.ExpectNoError(err)
+			framework.Logf("Continuous ping output:\n%s", stdout)
 
+			ginkgo.By("Parsing ping statistics for packet loss")
+			re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
 			matches := re.FindStringSubmatch(stdout)
 			framework.ExpectNotEmpty(matches, "failed to parse ping statistics from output")
+
 			transmitted, err := strconv.Atoi(matches[1])
 			framework.ExpectNoError(err)
 			received, err := strconv.Atoi(matches[2])
 			framework.ExpectNoError(err)
 			lost := transmitted - received
-			framework.Logf("[migration %d/%d] Ping: %d transmitted, %d received, %d lost", i, migrationCount, transmitted, received, lost)
+			framework.Logf("Ping results: %d transmitted, %d received, %d lost", transmitted, received, lost)
 
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Verifying migration succeeded", i, migrationCount))
+			ginkgo.By("Verifying migration succeeded")
 			err = migrationClient.WaitForPhase(migrationName, v1.MigrationSucceeded, 5*time.Minute)
 			framework.ExpectNoError(err)
 
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Asserting packet loss (%d) within threshold (%d)", i, migrationCount, lost, maxAcceptableLoss))
+			maxAcceptableLoss := 5
+			ginkgo.By(fmt.Sprintf("Asserting packet loss (%d) is within acceptable threshold (%d)", lost, maxAcceptableLoss))
 			gomega.Expect(lost).To(gomega.BeNumerically("<=", maxAcceptableLoss),
-				"migration %d/%d: expected at most %d lost packets, but lost %d out of %d", i, migrationCount, maxAcceptableLoss, lost, transmitted)
+				"expected at most %d lost packets (0.5s downtime at 0.1s interval), but lost %d out of %d", maxAcceptableLoss, lost, transmitted)
 
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Waiting for vm to be ready", i, migrationCount))
-			err = vmClient.WaitToBeReady(vmName, 2*time.Minute)
-			framework.ExpectNoError(err)
-
-			pod = getVMPod()
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking node changed from %s to %s", i, migrationCount, prevNode, pod.Spec.NodeName))
-			framework.ExpectNotEqual(pod.Spec.NodeName, prevNode)
-
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking IP and MAC unchanged", i, migrationCount))
-			framework.ExpectEqual(pod.Status.PodIPs, origIPs)
-			framework.ExpectEqual(pod.Annotations[util.MacAddressAnnotation], origMAC)
-
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking annotations", i, migrationCount))
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, util.VMAnnotation, vmName)
-
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking IP CRD preserved", i, migrationCount))
-			gomega.Eventually(func(g gomega.Gomega) {
-				currentIP := ipClient.Get(portName)
-				g.Expect(string(currentIP.UID)).To(gomega.Equal(string(origUID)))
-				g.Expect(currentIP.Spec.IPAddress).To(gomega.Equal(origIP.Spec.IPAddress))
-				g.Expect(currentIP.Spec.MacAddress).To(gomega.Equal(origIP.Spec.MacAddress))
-				g.Expect(currentIP.Spec.NodeName).To(gomega.Equal(pod.Spec.NodeName),
-					"IP CRD NodeName should be updated to %s", pod.Spec.NodeName)
-			}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
-
-			ginkgo.By(fmt.Sprintf("[migration %d/%d] Checking OVN LSP cleanup", i, migrationCount))
-			cmd := "ovn-nbctl --format=csv --data=bare --no-heading --columns=options list Logical_Switch_Port " + portName
-			output, _, err := framework.NBExec(cmd)
-			framework.ExpectNoError(err)
-			framework.ExpectNotContainSubstring(string(output), "activation-strategy")
-
-			framework.Logf("[migration %d/%d] PASSED — node: %s, IP: %v, MAC: %s, lost packets: %d", i, migrationCount, pod.Spec.NodeName, pod.Status.PodIPs, origMAC, lost)
-		}
-
-		ginkgo.By("Verifying post-migration connectivity")
-		stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
-		framework.ExpectNoError(err, "post-migration connectivity check failed")
-		framework.Logf("Post-migration ping output:\n%s", stdout)
-	})
-})
-
-var _ = framework.Describe("[group:kubevirt]", func() {
-	f := framework.NewDefaultFramework("kubevirt")
-
-	var vmName, namespaceName string
-	var podClient *framework.PodClient
-	var vmClient *framework.VMClient
-	var ipClient *framework.IPClient
-	var migrationClient *framework.VMIMigrationClient
-
-	ginkgo.BeforeEach(func() {
-		f.SkipVersionPriorTo(1, 13, "Live migration e2e tests require v1.13 or later.")
-
-		namespaceName = f.Namespace.Name
-		vmName = "vm-" + framework.RandomSuffix()
-		podClient = f.PodClientNS(namespaceName)
-		vmClient = f.VMClientNS(namespaceName)
-		ipClient = f.IPClient()
-		migrationClient = f.VMIMigrationClientNS(namespaceName)
-
-		ginkgo.By("Creating live-migratable masquerade vm " + vmName)
-		vm := framework.MakeVMLiveMigratable(vmName, image, "small")
-		_ = vmClient.CreateSync(vm)
-	})
-
-	ginkgo.AfterEach(func() {
-		ginkgo.By("Deleting vm " + vmName)
-		vmClient.DeleteSync(vmName)
-
-		portName := ovs.PodNameToPortName(vmName, namespaceName, util.OvnProvider)
-		ginkgo.By("Waiting for IP " + portName + " to be cleaned up")
-		err := ipClient.WaitToDisappear(portName, time.Second, 2*time.Minute)
-		framework.ExpectNoError(err)
-	})
-
-	getVMPod := func() *corev1.Pod {
-		ginkgo.GinkgoHelper()
-		labelSelector := fmt.Sprintf("%s=%s", v1.VirtualMachineInstanceIDLabel, vmName)
-		var result *corev1.Pod
-		gomega.Eventually(func(g gomega.Gomega) {
-			podList, err := podClient.List(context.TODO(), metav1.ListOptions{
-				LabelSelector: labelSelector,
-				FieldSelector: "status.phase=Running",
-			})
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			g.Expect(podList.Items).To(gomega.HaveLen(1),
-				"expected exactly 1 running pod for vm %s, got %d", vmName, len(podList.Items))
-			result = &podList.Items[0]
-		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
-		return result
-	}
-
-	framework.ConformanceIt("should maintain network connectivity during live migration with masquerade interface", func() {
-		ginkgo.By("Getting pod of vm " + vmName)
-		pod := getVMPod()
-		vmIP := pod.Status.PodIPs[0].IP
-		framework.Logf("VM pod IP: %s, node: %s", vmIP, pod.Spec.NodeName)
-
-		proberName := "prober-" + framework.RandomSuffix()
-		ginkgo.By("Creating prober pod " + proberName)
-		proberPod := framework.MakePod(namespaceName, proberName, nil, nil, framework.AgnhostImage, nil, []string{"pause"})
-		_ = podClient.CreateSync(proberPod)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting prober pod " + proberName)
-			podClient.DeleteSync(proberName)
+			ginkgo.By("Verifying post-migration connectivity")
+			stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+			framework.ExpectNoError(err, "post-migration connectivity check failed")
+			framework.Logf("Post-migration ping output:\n%s", stdout)
 		})
-
-		ginkgo.By("Verifying initial connectivity from prober to VM")
-		stdout, _, err := framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
-		framework.ExpectNoError(err, "initial connectivity check failed")
-		framework.Logf("Initial ping output:\n%s", stdout)
-
-		migrationName := "mig-" + framework.RandomSuffix()
-		ginkgo.By("Creating migration " + migrationName + " for vm " + vmName + " (non-blocking)")
-		migration := framework.MakeVMIMigration(migrationName, vmName)
-		_ = migrationClient.Create(migration)
-
-		ginkgo.By("Running continuous ping from prober to VM " + vmIP + " during migration")
-		pingCmd := fmt.Sprintf("ping -c 400 -i 0.1 -w 60 %s 2>&1 || true", vmIP)
-		stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, pingCmd)
-		framework.ExpectNoError(err)
-		framework.Logf("Continuous ping output:\n%s", stdout)
-
-		ginkgo.By("Parsing ping statistics for packet loss")
-		re := regexp.MustCompile(`(\d+) packets transmitted, (\d+) packets received`)
-		matches := re.FindStringSubmatch(stdout)
-		framework.ExpectNotEmpty(matches, "failed to parse ping statistics from output")
-
-		transmitted, err := strconv.Atoi(matches[1])
-		framework.ExpectNoError(err)
-		received, err := strconv.Atoi(matches[2])
-		framework.ExpectNoError(err)
-		lost := transmitted - received
-		framework.Logf("Ping results: %d transmitted, %d received, %d lost", transmitted, received, lost)
-
-		ginkgo.By("Verifying migration succeeded")
-		err = migrationClient.WaitForPhase(migrationName, v1.MigrationSucceeded, 5*time.Minute)
-		framework.ExpectNoError(err)
-
-		maxAcceptableLoss := 5
-		ginkgo.By(fmt.Sprintf("Asserting packet loss (%d) is within acceptable threshold (%d)", lost, maxAcceptableLoss))
-		gomega.Expect(lost).To(gomega.BeNumerically("<=", maxAcceptableLoss),
-			"expected at most %d lost packets (0.5s downtime at 0.1s interval), but lost %d out of %d", maxAcceptableLoss, lost, transmitted)
-
-		ginkgo.By("Verifying post-migration connectivity")
-		stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
-		framework.ExpectNoError(err, "post-migration connectivity check failed")
-		framework.Logf("Post-migration ping output:\n%s", stdout)
 	})
 })
 

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/kubernetes/test/e2e"
 	k8sframework "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 
@@ -544,6 +545,12 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 	ginkgo.BeforeEach(func() {
 		f.SkipVersionPriorTo(1, 13, "Live migration e2e tests require v1.13 or later.")
 
+		nodes, err := e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			ginkgo.Skip("live migration requires at least 2 schedulable nodes")
+		}
+
 		namespaceName = f.Namespace.Name
 		vmName = "vm-" + framework.RandomSuffix()
 		podClient = f.PodClientNS(namespaceName)
@@ -854,9 +861,13 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 				podClient.DeleteSync(proberName)
 			})
 
+			var stdout string
+			var err error
 			ginkgo.By("Verifying initial connectivity from prober to VM")
-			stdout, _, err := framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
-			framework.ExpectNoError(err, "initial connectivity check failed")
+			gomega.Eventually(func() error {
+				stdout, _, err = framework.ExecShellInPod(context.TODO(), f, namespaceName, proberName, fmt.Sprintf("ping -c 3 -W 2 %s", vmIP))
+				return err
+			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(gomega.Succeed(), "initial connectivity check failed")
 			framework.Logf("Initial ping output:\n%s", stdout)
 
 			migrationName := "mig-" + framework.RandomSuffix()
@@ -912,6 +923,12 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 
 	ginkgo.BeforeEach(func() {
 		f.SkipVersionPriorTo(1, 13, "Multus live migration e2e tests require v1.14 or later.")
+
+		nodes, err := e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			ginkgo.Skip("live migration requires at least 2 schedulable nodes")
+		}
 
 		namespaceName = f.Namespace.Name
 

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 )
 
-var image = "quay.io/kubevirt/cirros-container-disk-demo:v1.7.2"
+var image = "quay.io/kubevirt/cirros-container-disk-demo:v1.8.1"
 
 func getVMPod(podClient *framework.PodClient, vmName string) *corev1.Pod {
 	ginkgo.GinkgoHelper()

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -1,6 +1,7 @@
 package kubevirt
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"flag"
@@ -638,11 +639,16 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 			ginkgo.By("Verifying requested-chassis does not contain a comma (dual-node binding)")
 			if strings.Contains(outputStr, "requested-chassis") {
 				// requested-chassis should be a single node, not "src,target"
-				for _, field := range strings.Fields(outputStr) {
-					if strings.HasPrefix(field, "requested-chassis=") {
-						chassisValue := strings.TrimPrefix(field, "requested-chassis=")
+				scanner := bufio.NewScanner(strings.NewReader(outputStr))
+				scanner.Split(bufio.ScanWords)
+				for scanner.Scan() {
+					field := scanner.Text()
+					if chassisValue, ok := strings.CutPrefix(field, "requested-chassis="); ok {
 						framework.ExpectNotContainSubstring(chassisValue, ",")
 					}
+				}
+				if err := scanner.Err(); err != nil {
+					framework.ExpectNoError(err)
 				}
 			}
 		})

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -90,7 +90,7 @@ func parsePingStats(stdout string) (transmitted, received, lost int) {
 	received, err = strconv.Atoi(matches[2])
 	framework.ExpectNoError(err)
 	lost = transmitted - received
-	return
+	return transmitted, received, lost
 }
 
 func init() {

--- a/test/e2e/kubevirt/e2e_test.go
+++ b/test/e2e/kubevirt/e2e_test.go
@@ -911,29 +911,9 @@ var _ = framework.Describe("[group:kubevirt]", func() {
 	var migrationClient *framework.VMIMigrationClient
 
 	ginkgo.BeforeEach(func() {
-		f.SkipVersionPriorTo(1, 13, "Live migration e2e tests require v1.13 or later.")
+		f.SkipVersionPriorTo(1, 13, "Multus live migration e2e tests require v1.14 or later.")
 
 		namespaceName = f.Namespace.Name
-
-		ginkgo.By("Checking if Multus CRD is available")
-		_, resources, err := f.ClientSet.Discovery().ServerGroupsAndResources()
-		if err != nil {
-			ginkgo.Skip("failed to discover API resources: " + err.Error())
-		}
-		nadFound := false
-		for _, rl := range resources {
-			if rl.GroupVersion == "k8s.cni.cncf.io/v1" {
-				for _, r := range rl.APIResources {
-					if r.Kind == "NetworkAttachmentDefinition" {
-						nadFound = true
-						break
-					}
-				}
-			}
-		}
-		if !nadFound {
-			ginkgo.Fail("Multus CRD (NetworkAttachmentDefinition) not installed, skipping multi-NIC test")
-		}
 
 		vmName = "vm-" + framework.RandomSuffix()
 		subnetName = "subnet-" + framework.RandomSuffix()


### PR DESCRIPTION
# Pull Request

   - [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

   ## What type of this PR

   - Bug fixes
   - Tests

   ## Description

   Add KubeVirt live migration e2e tests and fix a controller bug discovered during testing.

   ### Bug fix: Run chart testing only against the v2 chart.
   Added chart directory to ct.yaml

   ### Bug fix: terminating pods overwriting IP CRD during repeated migrations

   During sequential live migrations, a terminating source pod from a previous migration can still carry the `MigrationJobNameAnnotation`. If `isPodAlive()` returns true
  (within grace period), `needAllocateSubnets()` treats it as a migration candidate and re-triggers subnet allocation, overwriting the IP CRD `NodeName` that was
  correctly set by the current migration's target pod. Fixed by adding a `DeletionTimestamp.IsZero()` guard.

   ### New e2e tests (7 tests)

   **Bridge mode (primary, 5 tests):**
   - IP/MAC preserved after live migration with node change verification
   - OVN LSP migrate options cleaned up after successful migration
   - IP CRD resource preserved with NodeName update verification
   - Network identity preserved when migration is aborted
   - Network connectivity maintained through 3 sequential migrations (continuous ping probe, ≤5 packet loss per migration)

   **Masquerade mode (1 test):**
   - Network connectivity maintained during live migration

   **Multi-NIC (1 test):**
   - Both default and secondary OVN NICs preserved through migration

   ### Framework additions
   - `MakeVMLiveMigratable()` — masquerade VM with EvictionStrategy
   - `MakeVMLiveMigratableBridge()` — bridge VM with migration annotation
   - `MakeVMLiveMigratableMultiNIC()` — multi-NIC VM via Multus NAD

   ## Which issue(s) this PR fixes

   N/A — new test coverage for KubeVirt live migration support.