### PR TITLE
controller: exit when ovn db cache init fails

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -613,36 +613,22 @@ func Run(ctx context.Context, config *Configuration) {
 		anpInformerFactory:     anpInformerFactory,
 	}
 
-	if err = initWithTimeout(time.Duration(config.OvnTimeout)*time.Second, "ovn nb client", func() error {
-		nbClient, err := ovs.NewOvnNbClient(
-			config.OvnNbAddr,
-			config.OvnTimeout,
-			config.OvsDbConnectTimeout,
-			config.OvsDbInactivityTimeout,
-			config.OvsDbConnectMaxRetry,
-		)
-		if err != nil {
-			return err
-		}
-		controller.OVNNbClient = nbClient
-		return nil
-	}); err != nil {
+	if controller.OVNNbClient, err = ovs.NewOvnNbClient(
+		config.OvnNbAddr,
+		config.OvnTimeout,
+		config.OvsDbConnectTimeout,
+		config.OvsDbInactivityTimeout,
+		config.OvsDbConnectMaxRetry,
+	); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn nb client")
 	}
-	if err = initWithTimeout(time.Duration(config.OvnTimeout)*time.Second, "ovn sb client", func() error {
-		sbClient, err := ovs.NewOvnSbClient(
-			config.OvnSbAddr,
-			config.OvnTimeout,
-			config.OvsDbConnectTimeout,
-			config.OvsDbInactivityTimeout,
-			config.OvsDbConnectMaxRetry,
-		)
-		if err != nil {
-			return err
-		}
-		controller.OVNSbClient = sbClient
-		return nil
-	}); err != nil {
+	if controller.OVNSbClient, err = ovs.NewOvnSbClient(
+		config.OvnSbAddr,
+		config.OvnTimeout,
+		config.OvsDbConnectTimeout,
+		config.OvsDbInactivityTimeout,
+		config.OvsDbConnectMaxRetry,
+	); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn sb client")
 	}
 	if config.EnableLb {
@@ -1594,20 +1580,6 @@ func getWorkItemKey(obj any) string {
 			return ""
 		}
 		return key
-	}
-}
-
-func initWithTimeout(timeout time.Duration, name string, fn func() error) error {
-	done := make(chan error, 1)
-	go func() {
-		done <- fn()
-	}()
-
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(timeout):
-		return fmt.Errorf("timeout after %s while creating %s", timeout, name)
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -613,22 +613,36 @@ func Run(ctx context.Context, config *Configuration) {
 		anpInformerFactory:     anpInformerFactory,
 	}
 
-	if controller.OVNNbClient, err = ovs.NewOvnNbClient(
-		config.OvnNbAddr,
-		config.OvnTimeout,
-		config.OvsDbConnectTimeout,
-		config.OvsDbInactivityTimeout,
-		config.OvsDbConnectMaxRetry,
-	); err != nil {
+	if err = initWithTimeout(time.Duration(config.OvnTimeout)*time.Second, "ovn nb client", func() error {
+		nbClient, err := ovs.NewOvnNbClient(
+			config.OvnNbAddr,
+			config.OvnTimeout,
+			config.OvsDbConnectTimeout,
+			config.OvsDbInactivityTimeout,
+			config.OvsDbConnectMaxRetry,
+		)
+		if err != nil {
+			return err
+		}
+		controller.OVNNbClient = nbClient
+		return nil
+	}); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn nb client")
 	}
-	if controller.OVNSbClient, err = ovs.NewOvnSbClient(
-		config.OvnSbAddr,
-		config.OvnTimeout,
-		config.OvsDbConnectTimeout,
-		config.OvsDbInactivityTimeout,
-		config.OvsDbConnectMaxRetry,
-	); err != nil {
+	if err = initWithTimeout(time.Duration(config.OvnTimeout)*time.Second, "ovn sb client", func() error {
+		sbClient, err := ovs.NewOvnSbClient(
+			config.OvnSbAddr,
+			config.OvnTimeout,
+			config.OvsDbConnectTimeout,
+			config.OvsDbInactivityTimeout,
+			config.OvsDbConnectMaxRetry,
+		)
+		if err != nil {
+			return err
+		}
+		controller.OVNSbClient = sbClient
+		return nil
+	}); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn sb client")
 	}
 	if err = controller.waitForDBReady(); err != nil {
@@ -1628,6 +1642,20 @@ func getWorkItemKey(obj any) string {
 			return ""
 		}
 		return key
+	}
+}
+
+func initWithTimeout(timeout time.Duration, name string, fn func() error) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- fn()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout after %s while creating %s", timeout, name)
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -645,9 +645,6 @@ func Run(ctx context.Context, config *Configuration) {
 	}); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn sb client")
 	}
-	if err = controller.waitForDBReady(); err != nil {
-		util.LogFatalAndExit(err, "failed to initialize ovn db cache")
-	}
 	if config.EnableLb {
 		controller.switchLBRuleLister = switchLBRuleInformer.Lister()
 		controller.switchLBRuleSynced = switchLBRuleInformer.Informer().HasSynced
@@ -1144,51 +1141,6 @@ func (c *Controller) dbStatus() {
 		klog.Infof("OVN database connection recovered after %d failures", c.dbFailureCount)
 		c.dbFailureCount = 0
 	}
-}
-
-func (c *Controller) waitForDBReady() error {
-	const maxFailures = 5
-
-	var lastErr error
-	for i := 1; i <= maxFailures; i++ {
-		done := make(chan error, 2)
-		go func() {
-			_, err := c.OVNNbClient.GetNbGlobal()
-			done <- err
-		}()
-		go func() {
-			_, err := c.OVNSbClient.ListChassis()
-			done <- err
-		}()
-
-		resultsReceived := 0
-		timeout := time.After(time.Duration(c.config.OvnTimeout) * time.Second)
-		ready := true
-
-		for resultsReceived < 2 {
-			select {
-			case err := <-done:
-				resultsReceived++
-				if err != nil {
-					lastErr = err
-					ready = false
-				}
-			case <-timeout:
-				lastErr = fmt.Errorf("timeout after %ds", c.config.OvnTimeout)
-				ready = false
-				resultsReceived = 2
-			}
-		}
-
-		if ready {
-			return nil
-		}
-
-		klog.Errorf("OVN database cache is not ready (%d/%d): %v", i, maxFailures, lastErr)
-		time.Sleep(time.Second)
-	}
-
-	return fmt.Errorf("OVN database cache is not ready after %d attempts: %w", maxFailures, lastErr)
 }
 
 func (c *Controller) shutdown() {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -631,6 +631,9 @@ func Run(ctx context.Context, config *Configuration) {
 	); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn sb client")
 	}
+	if err = controller.waitForDBReady(); err != nil {
+		util.LogFatalAndExit(err, "failed to initialize ovn db cache")
+	}
 	if config.EnableLb {
 		controller.switchLBRuleLister = switchLBRuleInformer.Lister()
 		controller.switchLBRuleSynced = switchLBRuleInformer.Informer().HasSynced
@@ -1127,6 +1130,51 @@ func (c *Controller) dbStatus() {
 		klog.Infof("OVN database connection recovered after %d failures", c.dbFailureCount)
 		c.dbFailureCount = 0
 	}
+}
+
+func (c *Controller) waitForDBReady() error {
+	const maxFailures = 5
+
+	var lastErr error
+	for i := 1; i <= maxFailures; i++ {
+		done := make(chan error, 2)
+		go func() {
+			_, err := c.OVNNbClient.GetNbGlobal()
+			done <- err
+		}()
+		go func() {
+			_, err := c.OVNSbClient.ListChassis()
+			done <- err
+		}()
+
+		resultsReceived := 0
+		timeout := time.After(time.Duration(c.config.OvnTimeout) * time.Second)
+		ready := true
+
+		for resultsReceived < 2 {
+			select {
+			case err := <-done:
+				resultsReceived++
+				if err != nil {
+					lastErr = err
+					ready = false
+				}
+			case <-timeout:
+				lastErr = fmt.Errorf("timeout after %ds", c.config.OvnTimeout)
+				ready = false
+				resultsReceived = 2
+			}
+		}
+
+		if ready {
+			return nil
+		}
+
+		klog.Errorf("OVN database cache is not ready (%d/%d): %v", i, maxFailures, lastErr)
+		time.Sleep(time.Second)
+	}
+
+	return fmt.Errorf("OVN database cache is not ready after %d attempts: %w", maxFailures, lastErr)
 }
 
 func (c *Controller) shutdown() {

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -125,10 +125,9 @@ func NewOvsDbClient(
 		return nil, err
 	}
 
+	klog.Infof("connecting to %s database server %s", db, addr)
 	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer cancel()
-
-	klog.Infof("connecting to %s database server %s", db, addr)
 	if err = c.Connect(ctx); err != nil {
 		klog.Errorf("failed to connect to %s database server %s: %v", db, addr, err)
 		return nil, err

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -125,11 +125,11 @@ func NewOvsDbClient(
 		return nil, err
 	}
 
-	initCtx, cancel := context.WithTimeout(context.Background(), connectTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer cancel()
 
 	klog.Infof("connecting to %s database server %s", db, addr)
-	if err = c.Connect(initCtx); err != nil {
+	if err = c.Connect(ctx); err != nil {
 		klog.Errorf("failed to connect to %s database server %s: %v", db, addr, err)
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func NewOvsDbClient(
 		klog.Infof("setting up monitors for %s database on server %s", db, addr)
 		monitor := c.NewMonitor(monitors...)
 		monitor.Method = ovsdb.ConditionalMonitorRPC
-		if _, err = c.Monitor(initCtx, monitor); err != nil {
+		if _, err = c.Monitor(ctx, monitor); err != nil {
 			c.Close()
 			klog.Errorf("failed to monitor database on %s server %s: %v", db, addr, err)
 			return nil, err

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -125,10 +125,11 @@ func NewOvsDbClient(
 		return nil, err
 	}
 
-	klog.Infof("connecting to %s database server %s", db, addr)
-	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
+	initCtx, cancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer cancel()
-	if err = c.Connect(ctx); err != nil {
+
+	klog.Infof("connecting to %s database server %s", db, addr)
+	if err = c.Connect(initCtx); err != nil {
 		klog.Errorf("failed to connect to %s database server %s: %v", db, addr, err)
 		return nil, err
 	}
@@ -137,7 +138,7 @@ func NewOvsDbClient(
 		klog.Infof("setting up monitors for %s database on server %s", db, addr)
 		monitor := c.NewMonitor(monitors...)
 		monitor.Method = ovsdb.ConditionalMonitorRPC
-		if _, err = c.Monitor(context.TODO(), monitor); err != nil {
+		if _, err = c.Monitor(initCtx, monitor); err != nil {
 			c.Close()
 			klog.Errorf("failed to monitor database on %s server %s: %v", db, addr, err)
 			return nil, err


### PR DESCRIPTION
## Summary
- add a startup-time OVN DB cache readiness check in controller
- exit the controller when NB/SB cache initialization keeps failing
- let the deployment restart the pod instead of staying alive in a bad state

## Testing
- verified in local environment that the controller exits on startup cache init failure and recovers after restart

## description 
sometimes kube-ovn-controller start err with log：
```
 [root@master-0 ~]# kubectl logs -n kube-system    kube-ovn-controller-69c546b9df-xt4fn
  Defaulted container "kube-ovn-controller" out of: kube-ovn-controller, hostpath-init (init)
  I0313 03:34:39.648243       7 controller.go:40]
  -------------------------------------------------------------------------------
  Kube-OVN:
    Version:       v1.14.34
    Build:         2026-03-12_12:59:44
    Commit:        git-6274ca3
    Go Version:    go1.26.1
    Arch:          arm64
  -------------------------------------------------------------------------------
  I0313 03:34:39.648356       7 controller.go:43] current capabilities: cap_net_bind_service,cap_net_raw=ep
  I0313 03:34:39.648600       7 config.go:365] no --kubeconfig, use in-cluster kubernetes config
  I0313 03:34:39.654293       7 k8s.go:48] succeeded to dial host "https://10.4.0.1:443"
  I0313 03:34:39.655490       7 config.go:437] no --kubeconfig, use in-cluster kubernetes config
  I0313 03:34:39.655871       7 config.go:357] config is &{OvnNbAddr:tcp:[10.161.10.56]:6641 OvnSbAddr:tcp:[10.161.10.56]:6642 OvnTimeout:60 OvsDbConnectTimeout:3 OvsDbConnectMa
  xRetry:60 OvsDbInactivityTimeout:0 CustCrdRetryMaxDelay:20 CustCrdRetryMinDelay:1 KubeConfigFile: KubeRestConfig:&rest.Config{Host:"https://10.4.0.1:443", APIPath:"", ContentC
  onfig:rest.ContentConfig{AcceptContentTypes:"application/vnd.kubernetes.protobuf,application/json", ContentType:"application/vnd.kubernetes.protobuf", GroupVersion:(*schema.Gr
  oupVersion)(nil), NegotiatedSerializer:runtime.NegotiatedSerializer(nil)}, Username:"", Password:"", BearerToken:"--- REDACTED ---", BearerTokenFile:"/var/run/secrets/kubernet
  es.io/serviceaccount/token", Impersonate:rest.ImpersonationConfig{UserName:"", UID:"", Groups:[]string(nil), Extra:map[string][]string(nil)}, AuthProvider:<nil>, AuthConfigPer
  sister:rest.AuthProviderConfigPersister(nil), ExecProvider:<nil>, TLSClientConfig:rest.sanitizedTLSClientConfig{Insecure:false, ServerName:"", CertFile:"", KeyFile:"", CAFile:
  "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", CertData:[]uint8(nil), KeyData:[]uint8(nil), CAData:[]uint8(nil), NextProtos:[]string(nil)}, UserAgent:"", DisableCompr
  ession:false, Transport:http.RoundTripper(nil), WrapTransport:(transport.WrapperFunc)(nil), QPS:1000, Burst:2000, RateLimiter:flowcontrol.RateLimiter(nil), WarningHandler:rest
  .WarningHandler(nil), Timeout:0, Dial:(func(context.Context, string, string) (net.Conn, error))(nil), Proxy:(func(*http.Request) (*url.URL, error))(nil)} KubeClient:0x6db1fc09
  6a80 KubeOvnClient:0x6db1fbcbb9b0 AnpClient:0x6db1fbcbb980 AttachNetClient:0x6db1fbcba9e0 KubevirtClient:0x6db1fc1bc140 ExtClient:0x6db1fbfe5c08 KubeFactoryClient:0x6db1fc096c
  40 KubeOvnFactoryClient:0x6db1fbcbbe40 DefaultLogicalSwitch:ovn-default DefaultCIDR:10.180.148.0/22,2341::10:180:148:0/112 DefaultGateway:10.180.148.1,2341::10:180:148:1 Defau
  ltExcludeIps:10.180.148.1,2341::10:180:148:1 DefaultGatewayCheck:true DefaultLogicalGateway:false DefaultU2OInterconnection:false ClusterRouter:ovn-cluster NodeSwitch:join Nod
  eSwitchCIDR:100.64.0.0/16,fd00:100:64::/64 NodeSwitchGateway:100.64.0.1,fd00:100:64::1 ServiceClusterIPRange:10.4.0.0/16,fd00:10:96::/112 ClusterTCPLoadBalancer:cluster-tcp-lo
  adbalancer ClusterUDPLoadBalancer:cluster-udp-loadbalancer ClusterSctpLoadBalancer:cluster-sctp-loadbalancer ClusterTCPSessionLoadBalancer:cluster-tcp-session-loadbalancer Clu
  sterUDPSessionLoadBalancer:cluster-udp-session-loadbalancer ClusterSctpSessionLoadBalancer:cluster-sctp-session-loadbalancer PodName:kube-ovn-controller-69c546b9df-xt4fn PodNa
  mespace:kube-system PodNicType:veth-pair WorkerNum:3 PprofPort:10660 EnablePprof:false SecureServing:true NodePgProbeTime:1 NetworkType:vlan DefaultProviderName:provider Defau
  ltHostInterface:eee562 DefaultExchangeLinkName:false DefaultVlanName:ovn-vlan DefaultVlanID:341 LsDnatModDlDst:true LsCtSkipDstLportIPs:true EnableLb:true EnableNP:true Enable
  EipSnat:false EnableExternalVpc:false EnableEcmp:false EnableKeepVMIP:true EnableLbSvc:false EnableOVNLBPreferLocal:false EnableMetrics:true EnableANP:true EnableOVNIPSec:false
  EnableLiveMigrationOptimize:true ExternalGatewaySwitch:external ExternalGatewayConfigNS:kube-system ExternalGatewayNet:external ExternalGatewayVlanID:0 GCInterval:90 InspectIn
  terval:20 BfdMinTx:100 BfdMinRx:100 BfdDetectMult:3 NodeLocalDNSIPs:[] Image:global-g3-7tntrv--idp.alaudatech.net/acp/kube-ovn:v1.14.34 LogPerm:640 TLSMinVersion:TLS12 TLSMaxV
  ersion:TLS12 TLSCipherSuites:[TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_ECDSA_WITH_CH
  ACHA20_POLY1305_SHA256]}
  I0313 03:34:39.671881       7 leaderelection.go:257] attempting to acquire leader lease kube-system/kube-ovn-controller...
  I0313 03:34:39.988031       7 leaderelection.go:271] successfully acquired lease kube-system/kube-ovn-controller
  I0313 03:34:39.990815       7 ovn.go:74] ovn nb table Logical_Router_Policy client index []model.ClientIndex{model.ClientIndex{Columns:
  []model.ColumnKey{model.ColumnKey{Column:"match", Key:interface {}(nil)}, model.ColumnKey{Column:"priority", Key:interface {}(nil)}}}, model.ClientIndex{Columns:
  []model.ColumnKey{model.ColumnKey{Column:"priority", Key:interface {}(nil)}}}, model.ClientIndex{Columns:[]model.ColumnKey{model.ColumnKey{Column:"match", Key:interface {}
  (nil)}}}}
  I0313 03:34:39.990870       7 client.go:72] creating ovsdb client for nbdb database at tcp:[10.161.10.56]:6641
  I0313 03:34:39.990932       7 client.go:133] connecting to nbdb database server tcp:[10.161.10.56]:6641
  {"level":"info","ts":1773344079.9909585,"logger":"libovsdb","caller":"client/client.go:342","msg":"trying to connect","db":"nbdb","database":"OVN_Northbound","endpoint":"tcp:
  connected","db":"nbdb","database":"OVN_Northbound","endpoint":"tcp:[10.161.10.56]:6641","sid":"1984e9bf-f08e-439a-b411-d4a38fbc7888"}
  {"level":"error","ts":1773344080.188898,"logger":"libovsdb.cache","caller":"cache/cache.go:932","msg":"during libovsdb cache
  populate2","db":"nbdb","database":"OVN_Northbound","error":"cache inconsistent: row with uuid 62ad90a0-50a6-4c35-bf07-c5a7f323d6c3 does not exist","stacktrace":"github.com/ovn-
  kubernetes/libovsdb/cache.(*TableCache).Update2\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/cache/cache.go:932\ngithub.com/ovn-kubernetes/libovsdb/client.
  (*ovsdbClient).update2\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/client/client.go:701\ngithub.com/ovn-kubernetes/libovsdb/client.
  (*ovsdbClient).createRPC2Client.func3\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/client/client.go:455\nreflect.Value.call\n\treflect/
  value.go:586\nreflect.Value.Call\n\treflect/value.go:369\ngithub.com/cenkalti/rpc2.(*Client).handleRequest\n\tgithub.com/cenkalti/rpc2@v1.0.5/client.go:135\ngithub.com/
  cenkalti/rpc2.(*Client).readRequest\n\tgithub.com/cenkalti/rpc2@v1.0.5/client.go:185\ngithub.com/cenkalti/rpc2.(*Client).readLoop\n\tgithub.com/cenkalti/rpc2@v1.0.5/
  client.go:94\ngithub.com/cenkalti/rpc2.(*Client).Run\n\tgithub.com/cenkalti/rpc2@v1.0.5/client.go:63"}
  {"level":"error","ts":1773344080.1890347,"logger":"libovsdb.cache","caller":"cache/cache.go:932","msg":"during libovsdb cache
  populate2","db":"nbdb","database":"OVN_Northbound","error":"cache inconsistent: row with uuid 62ad90a0-50a6-4c35-bf07-c5a7f323d6c3 does not exist","stacktrace":"github.com/ovn-
  kubernetes/libovsdb/cache.(*TableCache).Update2\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/cache/cache.go:932\ngithub.com/ovn-kubernetes/libovsdb/client.
  (*ovsdbClient).update2\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/client/client.go:701\ngithub.com/ovn-kubernetes/libovsdb/client.
  (*ovsdbClient).createRPC2Client.func3\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/client/client.go:455\nreflect.Value.call\n\treflect/
  populate2","db":"nbdb","database":"OVN_Northbound","error":"cache inconsistent: row with uuid 62ad90a0-50a6-4c35-bf07-c5a7f323d6c3 does not exist","stacktrace":"github.com/ovn-
  kubernetes/libovsdb/cache.(*TableCache).Update2\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/cache/cache.go:932\ngithub.com/ovn-kubernetes/libovsdb/client.
  (*ovsdbClient).update2\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/client/client.go:701\ngithub.com/ovn-kubernetes/libovsdb/client.
  (*ovsdbClient).createRPC2Client.func3\n\tgithub.com/ovn-kubernetes/libovsdb@v0.8.1/client/client.go:455\nreflect.Value.call\n\treflect/
  value.go:586\nreflect.Value.Call\n\treflect/value.go:369\ngithub.com/cenkalti/rpc2.(*Client).handleRequest\n\tgithub.com/cenkalti/rpc2@v1.0.5/client.go:135\ngithub.com/
  cenkalti/rpc2.(*Client).readRequest\n\tgithub.com/cenkalti/rpc2@v1.0.5/client.go:185\ngithub.com/cenkalti/rpc2.(*Client).readLoop\n\tgithub.com/cenkalti/rpc2@v1.0.5/
  client.go:94\ngithub.com/cenkalti/rpc2.(*Client).Run\n\tgithub.com/cenkalti/rpc2@v1.0.5/client.go:63"}
  I0313 03:34:40.512033       7 server.go:208] "Starting metrics server" logger="controller-runtime.metrics"
  I0313 03:34:40.522776       7 tlsconfig.go:243] "Starting DynamicServingCertificateController"
  I0313 03:34:40.522861       7 dynamic_cert_key.go:242] Starting dynamic in-memory cert/key pair controller
  I0313 03:34:40.607858       7 dynamic_cert_key.go:213] Generating new cert/key pair for localhost
  I0313 03:34:40.813696       7 dynamic_cert_key.go:224] Loaded newly generated cert/key pair with expiration time 2027-03-13T02:34:40+08:00
  I0313 03:34:40.814342       7 server.go:208] "Starting metrics server" logger="controller-runtime.metrics"
  I0313 03:34:40.827173       7 tlsconfig.go:243] "Starting DynamicServingCertificateController"
  I0313 03:34:40.827268       7 dynamic_cert_key.go:242] Starting dynamic in-memory cert/key pair controller
  I0313 03:34:41.117637       7 server.go:247] "Serving metrics server" logger="controller-runtime.metrics" bindAddress="[2335::10:161:5:201]:10660" secure=true
  I0313 03:34:41.247894       7 server.go:247] "Serving metrics server" logger="controller-runtime.metrics" bindAddress="10.161.5.201:10660" secure=true 

```
	
	

