### PR TITLE
kubectl-ko: fix trace failure when arping returns multiple MAC matches

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -379,7 +379,7 @@ trace(){
           exit 1
         fi
 
-        dstMac=$(echo "$output" | grep -oE '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}')
+        dstMac=$(echo "$output" | grep -oEm1 '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}')
       fi
     fi
 


### PR DESCRIPTION
## Summary
- `kubectl ko trace` fails intermittently in underlay mode with `error parsing flow: Syntax error at '<mac>' expecting end of input`
- Root cause: `grep -oE` at `dist/images/kubectl-ko:382` outputs every MAC match on a separate line. When `arping` output contains multiple MAC matches (e.g. multiple ARP replies in Kind/Docker environments), `$dstMac` contains newlines that break `ovn-trace` and `ovs-appctl ofproto/trace` flow syntax
- Fix: use `grep -oEm1` to return only the first match

## Test plan
- [ ] Verify `kubectl ko trace <pod> <dst> icmp` works in underlay mode
- [ ] Run Conformance E2E (ipv4, underlay) kubectl-ko tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)