### PR TITLE
fix: harden provider network cleanup to prevent orphaned bridges and routes

### DIFF
--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -154,7 +154,11 @@ func (c *Controller) ovsCleanProviderNetwork(provider string) error {
 
 	brName := mappings[provider]
 	if brName == "" {
-		return nil
+		// The mapping may have been cleared before cleanup finished (e.g., daemon restart
+		// or race with bridge setup failure). Fall back to the default bridge name to clean
+		// up any orphaned bridge and restore the original NIC name.
+		brName = util.ExternalBridgeName(provider)
+		klog.Infof("no ovn-bridge-mappings entry for provider %s, trying default bridge name %s", provider, brName)
 	}
 
 	output, err := ovs.Exec("list-br")
@@ -162,8 +166,17 @@ func (c *Controller) ovsCleanProviderNetwork(provider string) error {
 		return fmt.Errorf("failed to list OVS bridges: %w, %q", err, output)
 	}
 
-	if !slices.Contains(strings.Split(output, "\n"), brName) {
+	bridges := strings.Split(output, "\n")
+	if !slices.Contains(bridges, brName) {
 		klog.V(3).Infof("ovs bridge %s not found", brName)
+		// Even if no OVS bridge exists, check if a NIC was renamed to br-<provider>
+		// and needs to be restored (e.g., exchangeLinkName was used but bridge setup failed).
+		if br := util.ExternalBridgeName(provider); br != brName {
+			if _, err = c.changeProviderNicName(br, brName); err != nil {
+				klog.Errorf("failed to change provider nic name from %s to %s: %v", br, brName, err)
+				return err
+			}
+		}
 		return nil
 	}
 

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1553,14 +1553,18 @@ func (c *Controller) removeProviderNic(nicName, brName string) error {
 
 	nic, err := netlink.LinkByName(nicName)
 	if err != nil {
-		if _, ok := err.(netlink.LinkNotFoundError); ok {
-			klog.Warningf("failed to get nic by name %s: %v", nicName, err)
-			return nil
+		if _, ok := err.(netlink.LinkNotFoundError); !ok {
+			return fmt.Errorf("failed to get nic by name %s: %w", nicName, err)
 		}
-		return fmt.Errorf("failed to get nic by name %s: %w", nicName, err)
+		klog.Warningf("nic %s not found, will still clean up addresses and routes on bridge %s", nicName, brName)
 	}
+
 	bridge, err := netlink.LinkByName(brName)
 	if err != nil {
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
+			klog.Warningf("bridge %s not found, skip cleanup", brName)
+			return nil
+		}
 		return fmt.Errorf("failed to get bridge by name %s: %w", brName, err)
 	}
 
@@ -1591,16 +1595,20 @@ func (c *Controller) removeProviderNic(nicName, brName string) error {
 		}
 		klog.Infof("address %q has been deleted from link %s", addr.String(), brName)
 
-		addr.Label = ""
-		if err = netlink.AddrReplace(nic, &addr); err != nil {
-			return fmt.Errorf("failed to replace address %q on nic %s: %w", addr.String(), nicName, err)
+		if nic != nil {
+			addr.Label = ""
+			if err = netlink.AddrReplace(nic, &addr); err != nil {
+				return fmt.Errorf("failed to replace address %q on nic %s: %w", addr.String(), nicName, err)
+			}
+			klog.Infof("address %q has been added/replaced to link %s", addr.String(), nicName)
 		}
-		klog.Infof("address %q has been added/replaced to link %s", addr.String(), nicName)
 	}
 
-	if err = netlink.LinkSetUp(nic); err != nil {
-		klog.Errorf("failed to set link %s up: %v", nicName, err)
-		return err
+	if nic != nil {
+		if err = netlink.LinkSetUp(nic); err != nil {
+			klog.Errorf("failed to set link %s up: %v", nicName, err)
+			return err
+		}
 	}
 
 	for _, scope := range routeScopeOrders {
@@ -1610,11 +1618,18 @@ func (c *Controller) removeProviderNic(nicName, brName string) error {
 				continue
 			}
 			if route.Scope == scope {
-				route.LinkIndex = nic.Attrs().Index
-				if err = netlink.RouteReplace(&route); err != nil {
-					return fmt.Errorf("failed to add/replace route %s: %w", route.String(), err)
+				if nic != nil {
+					route.LinkIndex = nic.Attrs().Index
+					if err = netlink.RouteReplace(&route); err != nil {
+						return fmt.Errorf("failed to add/replace route %s: %w", route.String(), err)
+					}
+					klog.Infof("route %q has been added/replaced to link %s", route.String(), nicName)
+				} else {
+					if err = netlink.RouteDel(&route); err != nil {
+						return fmt.Errorf("failed to delete route %s from bridge %s: %w", route.String(), brName, err)
+					}
+					klog.Infof("route %q has been deleted from link %s (nic %s not found)", route.String(), brName, nicName)
 				}
-				klog.Infof("route %q has been added/replaced to link %s", route.String(), nicName)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- **removeProviderNic**: When the host NIC disappears before daemon cleanup (e.g., Docker disconnects the node first), continue cleaning up addresses and routes on the OVS bridge instead of returning early. Routes are deleted directly rather than migrated, preventing stale kernel routes that cause Docker subnet conflicts.
- **ovsCleanProviderNetwork**: When `ovn-bridge-mappings` has no entry for a provider (e.g., bridge setup failed or daemon restarted), fall back to the default bridge name `br-<provider>` and attempt cleanup. Also check for renamed NICs that need restoration even when no OVS bridge exists (exchangeLinkName scenario).

## Root Cause
Two race conditions in provider network cleanup were causing flaky E2E test failures:

1. **Route conflict** (`removeProviderNic`): If the host NIC is removed externally (Docker disconnect) before the daemon's cleanup runs, the function returned `nil` immediately without removing addresses/routes from the OVS bridge. When `del-br` later removes the bridge, kernel routes can linger, causing "cannot program address — conflicts with existing route" errors.

2. **Orphaned bridge/NIC** (`ovsCleanProviderNetwork`): If `ovn-bridge-mappings` was cleared before cleanup finished (e.g., bridge creation failed, daemon restarted), the function returned immediately. This left orphaned OVS bridges and NICs renamed to `br-<provider>` that were never restored to their original names.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make build-go` — builds successfully
- [ ] Existing underlay E2E tests (`should exchange link names`, `should create vlan subinterface`) should be more stable with these fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)