### PR TITLE
fix: add webhook self-exclusion to prevent recovery deadlock

### DIFF
--- a/charts/kube-ovn-v2/templates/webhook/webhook-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/webhook/webhook-deployment.yaml
@@ -42,6 +42,7 @@ spec:
                   app.kubernetes.io/name: kube-ovn-webhook
                   app.kubernetes.io/part-of: kube-ovn
               topologyKey: kubernetes.io/hostname
+      priorityClassName: system-cluster-critical
       serviceAccountName: ovn
       automountServiceAccountToken: true
       securityContext:

--- a/charts/kube-ovn-v2/templates/webhook/webhook.yaml
+++ b/charts/kube-ovn-v2/templates/webhook/webhook.yaml
@@ -59,6 +59,12 @@ webhooks:
           - iptables-dnat-rules
           - iptables-snat-rules
           - iptables-fip-rules
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: NotIn
+          values:
+            - kube-ovn-webhook
     failurePolicy: Ignore
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None

--- a/yamls/webhook.yaml
+++ b/yamls/webhook.yaml
@@ -29,6 +29,7 @@ spec:
                 matchLabels:
                   app: kube-ovn-webhook
               topologyKey: kubernetes.io/hostname
+      priorityClassName: system-cluster-critical
       serviceAccountName: ovn
       automountServiceAccountToken: true
       hostNetwork: true
@@ -159,6 +160,12 @@ webhooks:
         - iptables-dnat-rules
         - iptables-snat-rules
         - iptables-fip-rules
+  objectSelector:
+    matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+          - kube-ovn-webhook
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   sideEffects: None


### PR DESCRIPTION
## Summary
- Add `objectSelector` to `ValidatingWebhookConfiguration` to exclude webhook's own pods from validation, preventing self-referential blocking when all webhook pods are down
- Add `priorityClassName: system-cluster-critical` to webhook Deployment for high-priority scheduling

## Background
When all webhook pods crash simultaneously, new pod creation goes through the webhook admission. Although `failurePolicy: Ignore` mitigates most scenarios, during the brief window where endpoints are stale but not yet cleaned up, the API server attempts to reach the unavailable webhook and must wait for `timeoutSeconds` (5s) before proceeding. Adding `objectSelector` eliminates this delay entirely for webhook pods.

This follows the same approach as [ovn-org/ovn-kubernetes#6053](https://github.com/ovn-org/ovn-kubernetes/pull/6053), which uses CEL `matchConditions` to exclude their webhook pod (`ovnkube-identity`). We use `objectSelector` instead for broader Kubernetes version compatibility (no K8s 1.28+ requirement).

## Changes
| File | Change |
|------|--------|
| `yamls/webhook.yaml` | Add `objectSelector` (exclude `app=kube-ovn-webhook`), add `priorityClassName` |
| `charts/kube-ovn-v2/templates/webhook/webhook.yaml` | Add `objectSelector` (exclude `app.kubernetes.io/name=kube-ovn-webhook`) |
| `charts/kube-ovn-v2/templates/webhook/webhook-deployment.yaml` | Add `priorityClassName: system-cluster-critical` |

## Test plan
- [ ] Deploy webhook with updated configuration
- [ ] Verify webhook still validates pods with static IP annotations in kube-system
- [ ] Verify webhook pods themselves are not intercepted (check API server audit logs)
- [ ] Simulate webhook pod crash and verify new pods are created without delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)