### PR TITLE
fix: persist node IP annotation to API server during IPAM init

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -537,7 +537,13 @@ func (c *Controller) InitIPAM() error {
 				klog.Errorf("failed to init node %s.%s address %s: %v", node.Name, node.Namespace, node.Annotations[util.IPAddressAnnotation], err)
 			}
 			if v4IP != "" && v6IP != "" {
-				node.Annotations[util.IPAddressAnnotation] = util.GetStringIP(v4IP, v6IP)
+				ipStr := util.GetStringIP(v4IP, v6IP)
+				if ipStr != node.Annotations[util.IPAddressAnnotation] {
+					patch := util.KVPatch{util.IPAddressAnnotation: ipStr}
+					if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
+						klog.Errorf("failed to patch node %s IP annotation: %v", node.Name, err)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- During `InitIPAM()`, when `GetStaticAddress` returns normalized dual-stack IPs that differ from the node's current annotation, the corrected value was only written to the local informer cache without being patched to the API server
- This violated client-go's shared cache immutability contract and the fix was lost on controller restart
- Now uses `PatchAnnotations` to persist the corrected annotation, with a guard to skip unnecessary patches

## Test plan
- [ ] Verify dual-stack node annotation is correctly persisted after controller restart
- [ ] Confirm no unnecessary patch calls when annotation already matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)