### PR TITLE
fix: avoid error log for missing VPC annotation on underlay pods

### DIFF
--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -884,14 +884,11 @@ func getSubnetByProvider(pod *v1.Pod, provider string) (string, error) {
 	return subnetName, nil
 }
 
-// getVpcByProvider returns the VPC linked to a provider on a pod
-func getVpcByProvider(pod *v1.Pod, provider string) (string, error) {
-	vpcName, exists := pod.Annotations[fmt.Sprintf(util.LogicalRouterAnnotationTemplate, provider)]
-	if !exists {
-		return "", fmt.Errorf("couldn't find vpc linked to provider %s", provider)
-	}
-
-	return vpcName, nil
+// getVpcByProvider returns the VPC linked to a provider on a pod.
+// For underlay subnets without LogicalGateway or U2OInterconnection,
+// the logical_router annotation is not set, so an empty string is returned.
+func getVpcByProvider(pod *v1.Pod, provider string) string {
+	return pod.Annotations[fmt.Sprintf(util.LogicalRouterAnnotationTemplate, provider)]
 }
 
 // getEndpointVpcAndSubnet returns the VPC/subnet for a pod and a set of addresses attached to it
@@ -913,10 +910,7 @@ func (c *Controller) getEndpointVpcAndSubnet(pod *v1.Pod, addresses []string) (s
 	}
 
 	// Retrieve the VPC
-	vpc, err := getVpcByProvider(pod, provider)
-	if err != nil {
-		return "", "", err
-	}
+	vpc := getVpcByProvider(pod, provider)
 
 	return vpc, subnet, nil
 }


### PR DESCRIPTION
## Summary
- In underlay networks (subnet with Vlan, without LogicalGateway or U2OInterconnection), the `logical_router` annotation is intentionally not set on pods
- The endpoint_slice controller treated this missing annotation as an error, causing frequent `couldn't find vpc linked to provider ovn` log messages
- Changed `getVpcByProvider` to return an empty string instead of an error, allowing the existing fallback in `getDefaultVpcAndSubnet` to correctly resolve to the default VPC

## Test plan
- [ ] Deploy with underlay network and verify no more `couldn't find vpc linked to provider ovn` error logs
- [ ] Verify Service LB rules are correctly created for underlay pods (VIP → backends mapping in default VPC's LB)
- [ ] Verify overlay network behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)