### PR TITLE
kind: enable OwnerReferencesPermissionEnforcement

### DIFF
--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -75,6 +75,11 @@ nodes:
 {%- if ip_family != "ipv4" %}
             node-cidr-mask-size-ipv6: "120"
 {%- endif %}
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            enable-admission-plugins: OwnerReferencesPermissionEnforcement
 {%- if auditing is equalto "true" %}
       - |
         kind: ClusterConfiguration


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

Enable the `OwnerReferencesPermissionEnforcement` admission plugin in the kind control-plane kube-apiserver config so local kind clusters can validate owner references in kind-based test environments.

## Which issue(s) this PR fixes

Fixes #none
