### PR TITLE
feat: add --disable-svc-iptables-rule flag to skip service-related ip…

### DIFF
--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -144,6 +144,7 @@ spec:
           - --secure-serving={{- .Values.features.enableSecureServing }}
           - --enable-ovn-ipsec={{- .Values.features.enableOvnIpsec }}
           - --non-primary-cni-mode={{- .Values.cni.nonPrimaryCNI }}
+          - --disable-svc-iptables-rule={{- .Values.cni.disableSvcIptablesRule }}
         securityContext:
           runAsGroup: 0
           runAsUser: 0

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -267,6 +267,10 @@ cni:
   # Interfaces are created using Network Attachment Definitions (NADs)
   # @section -- CNI configuration
   nonPrimaryCNI: false
+  # -- Whether to disable service-related iptables rules (MARK, REJECT, SNAT, NodePort).
+  # Use when another CNI handles service traffic (e.g. Cilium, Calico with kube-proxy IPVS).
+  # @section -- CNI configuration
+  disableSvcIptablesRule: false
 
 # -- Configuration of the validating webhook used to verify custom resources before they are pushed to Kubernetes.
 # Make sure cert-manager is installed for the generation of certificates for the webhook.

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -126,6 +126,7 @@ spec:
           - --enable-ovn-ipsec={{- .Values.func.ENABLE_OVN_IPSEC }}
           - --set-vxlan-tx-off={{- .Values.func.SET_VXLAN_TX_OFF }}
           - --non-primary-cni-mode={{- .Values.cni_conf.NON_PRIMARY_CNI }}
+          - --disable-svc-iptables-rule={{- .Values.cni_conf.DISABLE_SVC_IPTABLES_RULE }}
         securityContext:
           runAsUser: 0
           privileged: false

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -129,6 +129,7 @@ cni_conf:
   LOCAL_BIN_DIR: "/usr/local/bin"
   MOUNT_LOCAL_BIN_DIR: false
   NON_PRIMARY_CNI: false
+  DISABLE_SVC_IPTABLES_RULE: false
 
 kubelet_conf:
   KUBELET_DIR: "/var/lib/kubelet"

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -84,6 +84,7 @@ type Configuration struct {
 	SetVxlanTxOff             bool
 	LogPerm                   string
 	EnableNonPrimaryCNI       bool
+	DisableSvcIptablesRule    bool
 
 	// TLS configuration for secure serving
 	TLSMinVersion   string
@@ -146,7 +147,8 @@ func ParseFlags() *Configuration {
 		argTLSMinVersion   = pflag.String("tls-min-version", "", "The minimum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
 		argTLSMaxVersion   = pflag.String("tls-max-version", "", "The maximum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
 		argTLSCipherSuites = pflag.StringSlice("tls-cipher-suites", nil, "Comma-separated list of TLS cipher suite names to use for secure serving (e.g., 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'). Names must match Go's crypto/tls package. See Go documentation for available suites. If not set, defaults are used. Users are responsible for selecting secure cipher suites.")
-		argNonPrimaryCNI   = pflag.Bool("non-primary-cni-mode", false, "Use Kube-OVN in non primary cni mode. When true, skip setting NetworkUnavailable node condition")
+		argNonPrimaryCNI             = pflag.Bool("non-primary-cni-mode", false, "Use Kube-OVN in non primary cni mode. When true, skip setting NetworkUnavailable node condition")
+		argDisableSvcIptablesRule    = pflag.Bool("disable-svc-iptables-rule", false, "Disable service-related iptables rules (MARK, REJECT, SNAT, NodePort). Use when another CNI (e.g. Calico) handles service traffic")
 	)
 
 	// mute info log for ipset lib
@@ -218,6 +220,7 @@ func ParseFlags() *Configuration {
 		CertManagerIssuerName:     *argCertManagerIssuerName,
 		IPSecCertDuration:         *argOVNIPSecCertDuration,
 		EnableNonPrimaryCNI:       *argNonPrimaryCNI,
+		DisableSvcIptablesRule:    *argDisableSvcIptablesRule,
 	}
 
 	return config

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -741,16 +741,25 @@ func (c *Controller) setIptables() error {
 			return err
 		}
 		if ipsetExists {
-			iptablesRules[0].Rule = strings.Fields(fmt.Sprintf(`-i %s -m set --match-set %s src -m set --match-set %s dst,dst -j MARK --set-xmark 0x4000/0x4000`, util.NodeNic, matchset, ipset))
 			rejectRule := strings.Fields(fmt.Sprintf(`-p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set %s dst -m conntrack --ctstate NEW -j REJECT`, svcMatchset))
 			obsoleteRejectRule := strings.Fields(fmt.Sprintf(`-m mark ! --mark 0x4000/0x4000 -m set --match-set %s dst -m conntrack --ctstate NEW -j REJECT`, svcMatchset))
-			iptablesRules = append(iptablesRules,
-				util.IPTableRule{Table: "filter", Chain: "INPUT", Rule: rejectRule},
-				util.IPTableRule{Table: "filter", Chain: "OUTPUT", Rule: rejectRule},
-			)
+			if !c.config.DisableSvcIptablesRule {
+				iptablesRules[0].Rule = strings.Fields(fmt.Sprintf(`-i %s -m set --match-set %s src -m set --match-set %s dst,dst -j MARK --set-xmark 0x4000/0x4000`, util.NodeNic, matchset, ipset))
+				iptablesRules = append(iptablesRules,
+					util.IPTableRule{Table: "filter", Chain: "INPUT", Rule: rejectRule},
+					util.IPTableRule{Table: "filter", Chain: "OUTPUT", Rule: rejectRule},
+				)
+			}
 			obsoleteRejectRules := []util.IPTableRule{
 				{Table: "filter", Chain: "INPUT", Rule: obsoleteRejectRule},
 				{Table: "filter", Chain: "OUTPUT", Rule: obsoleteRejectRule},
+			}
+			if c.config.DisableSvcIptablesRule {
+				// Also clean up current reject rules when service iptables rules are disabled
+				obsoleteRejectRules = append(obsoleteRejectRules,
+					util.IPTableRule{Table: "filter", Chain: "INPUT", Rule: rejectRule},
+					util.IPTableRule{Table: "filter", Chain: "OUTPUT", Rule: rejectRule},
+				)
 			}
 			for _, rule := range obsoleteRejectRules {
 				if err = deleteIptablesRule(ipt, rule); err != nil {
@@ -767,35 +776,66 @@ func (c *Controller) setIptables() error {
 				{Table: NAT, Chain: Postrouting, Rule: strings.Fields(fmt.Sprintf(`! -s %s -m set ! --match-set %s src -m set --match-set %s dst -j MASQUERADE`, nodeIP, matchset, matchset))},
 			}
 
-			rules := make([]util.IPTableRule, len(iptablesRules)+1)
-			copy(rules, iptablesRules[:1])
-			copy(rules[2:], iptablesRules[1:])
-			rules[1] = util.IPTableRule{
-				Table: NAT,
-				Chain: OvnPostrouting,
-				Rule:  strings.Fields(fmt.Sprintf(`-m set --match-set %s src -m set --match-set %s dst -m mark --mark 0x4000/0x4000 -j SNAT --to-source %s`, svcMatchset, matchset, nodeIP)),
-			}
-			iptablesRules = rules
-
-			for _, p := range [...]string{"tcp", "udp"} {
-				ipset := fmt.Sprintf("KUBE-%sNODE-PORT-LOCAL-%s", kubeProxyIpsetProtocol, strings.ToUpper(p))
-				ipsetExists, err := c.ipsetExists(ipset)
-				if err != nil {
-					klog.Errorf("failed to check existence of ipset %s: %v", ipset, err)
-					return err
+			if !c.config.DisableSvcIptablesRule {
+				rules := make([]util.IPTableRule, len(iptablesRules)+1)
+				copy(rules, iptablesRules[:1])
+				copy(rules[2:], iptablesRules[1:])
+				rules[1] = util.IPTableRule{
+					Table: NAT,
+					Chain: OvnPostrouting,
+					Rule:  strings.Fields(fmt.Sprintf(`-m set --match-set %s src -m set --match-set %s dst -m mark --mark 0x4000/0x4000 -j SNAT --to-source %s`, svcMatchset, matchset, nodeIP)),
 				}
-				if !ipsetExists {
-					klog.V(5).Infof("ipset %s does not exist", ipset)
+				iptablesRules = rules
+
+				for _, p := range [...]string{"tcp", "udp"} {
+					ipset := fmt.Sprintf("KUBE-%sNODE-PORT-LOCAL-%s", kubeProxyIpsetProtocol, strings.ToUpper(p))
+					ipsetExists, err := c.ipsetExists(ipset)
+					if err != nil {
+						klog.Errorf("failed to check existence of ipset %s: %v", ipset, err)
+						return err
+					}
+					if !ipsetExists {
+						klog.V(5).Infof("ipset %s does not exist", ipset)
+						continue
+					}
+					rule := fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL -m set --match-set %s dst -j MARK --set-xmark 0x80000/0x80000", p, ipset)
+					rule2 := fmt.Sprintf("-p %s -m set --match-set %s src -m set --match-set %s dst -j MARK --set-xmark 0x4000/0x4000", p, nodeMatchSet, ipset)
+					obsoleteRules = append(obsoleteRules, util.IPTableRule{Table: NAT, Chain: Prerouting, Rule: strings.Fields(rule)})
+					iptablesRules = append(iptablesRules,
+						util.IPTableRule{Table: NAT, Chain: OvnPrerouting, Rule: strings.Fields(rule)},
+						util.IPTableRule{Table: NAT, Chain: OvnPrerouting, Rule: strings.Fields(rule2)},
+					)
+				}
+			}
+		}
+
+		// When DisableSvcIptablesRule is enabled, filter out service-related rules
+		// from iptablesRules and clean up any existing service rules in standard chains.
+		// Rules in custom chains (OvnPrerouting, OvnPostrouting) are automatically
+		// reconciled by updateIptablesChain.
+		if c.config.DisableSvcIptablesRule {
+			var filteredRules []util.IPTableRule
+			for _, rule := range iptablesRules {
+				ruleStr := strings.Join(rule.Rule, " ")
+				// Skip MARK 0x4000 rule in OvnPrerouting (pod → service marking)
+				if rule.Table == NAT && rule.Chain == OvnPrerouting && strings.Contains(ruleStr, "0x4000/0x4000") {
 					continue
 				}
-				rule := fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL -m set --match-set %s dst -j MARK --set-xmark 0x80000/0x80000", p, ipset)
-				rule2 := fmt.Sprintf("-p %s -m set --match-set %s src -m set --match-set %s dst -j MARK --set-xmark 0x4000/0x4000", p, nodeMatchSet, ipset)
-				obsoleteRules = append(obsoleteRules, util.IPTableRule{Table: NAT, Chain: Prerouting, Rule: strings.Fields(rule)})
-				iptablesRules = append(iptablesRules,
-					util.IPTableRule{Table: NAT, Chain: OvnPrerouting, Rule: strings.Fields(rule)},
-					util.IPTableRule{Table: NAT, Chain: OvnPrerouting, Rule: strings.Fields(rule2)},
-				)
+				// Skip 0x4000 MASQUERADE rule in OvnPostrouting
+				if rule.Table == NAT && rule.Chain == OvnPostrouting && strings.Contains(ruleStr, "0x4000/0x4000") && strings.Contains(ruleStr, OvnMasquerade) {
+					continue
+				}
+				// Clean up and skip service ACCEPT rules in filter chains
+				if rule.Table == "filter" && strings.Contains(ruleStr, svcMatchset) {
+					if err = deleteIptablesRule(ipt, rule); err != nil {
+						klog.Errorf("failed to delete service iptables rule %v: %v", rule, err)
+						return err
+					}
+					continue
+				}
+				filteredRules = append(filteredRules, rule)
 			}
+			iptablesRules = filteredRules
 		}
 
 		_, subnetCidrs, err := c.getDefaultVpcSubnetsCIDR(protocol)


### PR DESCRIPTION
…tables rules

In non-primary CNI scenarios (Cilium, Calico with kube-proxy IPVS), kube-ovn's service-related iptables rules (MARK, REJECT, SNAT, NodePort) are redundant and can interfere with the primary CNI's service handling.

Add a new --disable-svc-iptables-rule flag that, when enabled:
- Skips MARK 0x4000 and MASQUERADE rules for pod-to-service traffic
- Skips REJECT rules for unmatched service traffic
- Skips SNAT rules for service-to-pod traffic
- Skips NodePort MARK rules (0x80000 and 0x4000)
- Skips service ACCEPT rules in filter INPUT/FORWARD chains
- Cleans up any previously installed service rules

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
