### PR TITLE
fix(controller): remove Service ClusterIP from NetworkPolicy address sets

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -719,12 +719,6 @@ func (c *Controller) fetchPolicySelectedAddresses(namespace, protocol string, np
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to list pod, %w", err)
 		}
-		svcs, err := c.servicesLister.Services(ns).List(labels.Everything())
-		if err != nil {
-			klog.Errorf("failed to list svc, %v", err)
-			return nil, nil, fmt.Errorf("failed to list svc, %w", err)
-		}
-
 		for _, pod := range pods {
 			podNets, err := c.getPodKubeovnNets(pod)
 			if err != nil {
@@ -746,18 +740,6 @@ func (c *Controller) fetchPolicySelectedAddresses(namespace, protocol string, np
 						selectedAddresses = append(selectedAddresses, podIP)
 					}
 				}
-				if len(svcs) == 0 {
-					continue
-				}
-				if !shouldIncludeServiceIPs(podNet) {
-					continue
-				}
-
-				svcIPs, err := svcMatchPods(svcs, pod, protocol)
-				if err != nil {
-					return nil, nil, err
-				}
-				selectedAddresses = append(selectedAddresses, svcIPs...)
 			}
 			if providers != nil && !matchedProvider {
 				klog.V(4).Infof("skip pod %s/%s: no network attachment matches network_policy_for", pod.Namespace, pod.Name)
@@ -765,39 +747,6 @@ func (c *Controller) fetchPolicySelectedAddresses(namespace, protocol string, np
 		}
 	}
 	return selectedAddresses, exceptAddresses, nil
-}
-
-func shouldIncludeServiceIPs(podNet *kubeovnNet) bool {
-	return podNet != nil && podNet.Subnet != nil && podNet.Subnet.Spec.Vpc == util.DefaultVpc
-}
-
-func svcMatchPods(svcs []*corev1.Service, pod *corev1.Pod, protocol string) ([]string, error) {
-	matchSvcs := []string{}
-	// find svc ip by pod's info
-	for _, svc := range svcs {
-		if isSvcMatchPod(svc, pod) {
-			clusterIPs := util.ServiceClusterIPs(*svc)
-			protocolClusterIPs := getProtocolSvcIP(clusterIPs, protocol)
-			if len(protocolClusterIPs) != 0 {
-				matchSvcs = append(matchSvcs, protocolClusterIPs...)
-			}
-		}
-	}
-	return matchSvcs, nil
-}
-
-func getProtocolSvcIP(clusterIPs []string, protocol string) []string {
-	protocolClusterIPs := []string{}
-	for _, clusterIP := range clusterIPs {
-		if clusterIP != "" && clusterIP != corev1.ClusterIPNone && util.CheckProtocol(clusterIP) == protocol {
-			protocolClusterIPs = append(protocolClusterIPs, clusterIP)
-		}
-	}
-	return protocolClusterIPs
-}
-
-func isSvcMatchPod(svc *corev1.Service, pod *corev1.Pod) bool {
-	return labels.Set(svc.Spec.Selector).AsSelector().Matches(labels.Set(pod.Labels))
 }
 
 func (c *Controller) podMatchNetworkPolicies(pod *corev1.Pod) []string {


### PR DESCRIPTION
## Summary
- Remove unnecessary Service ClusterIP addresses from NetworkPolicy egress allow address sets
- Clean up 4 unused helper functions: `shouldIncludeServiceIPs`, `svcMatchPods`, `getProtocolSvcIP`, `isSvcMatchPod`

## Background

NetworkPolicy egress ACLs use OVN's `apply-after-lb=true` option, meaning they execute **after** LB DNAT. At that stage, the destination IP is already the Pod IP, so having Service ClusterIPs in the egress allow address set is unnecessary.

This redundancy causes a **race condition** that manifests as flaky e2e test failures:
1. When LB logical flows haven't been compiled by northd yet, `ovn-trace` sees the un-DNAT'd Service ClusterIP at the `ls_in_acl_after_lb_eval` stage
2. Since the Service ClusterIP is in the allow address set, the packet is incorrectly allowed through
3. The packet routes to the node instead of the target pod, and every retry produces the same wrong result
4. This causes the `"kubectl ko trace ..." should work with network policy` test to time out intermittently

By removing Service ClusterIPs from the address set, un-DNAT'd packets will be correctly dropped by the NetworkPolicy ACL, allowing the test to retry until LB flows are ready.

The original logic was added in commit `4187a329b` (2021) as a workaround before OVN's `apply-after-lb` feature existed. With `apply-after-lb=true` now in use, the workaround is no longer needed.

## Test plan
- [x] `make lint` passes
- [ ] Existing e2e test `"kubectl ko trace ..." should work with network policy` should become more stable
- [ ] NetworkPolicy e2e tests should continue to pass (Service access through NP is handled by LB DNAT + Pod IP matching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)