### PR TITLE
dist: add 25.03 ACL compatibility for OVN patch

### DIFF
--- a/dist/images/patches/e76880e792af56b2a3836098105079f5f8f1ff26.patch
+++ b/dist/images/patches/e76880e792af56b2a3836098105079f5f8f1ff26.patch
@@ -1,19 +1,19 @@
 From e76880e792af56b2a3836098105079f5f8f1ff26 Mon Sep 17 00:00:00 2001
 From: clyi <clyi@alauda.io>
 Date: Fri, 8 Aug 2025 17:27:38 +0800
-Subject: [PATCH] [PATCH] northd: add nb option version_compatibility
+Subject: [PATCH] northd: add nb option version_compatibility
 
 Signed-off-by: clyi <clyi@alauda.io>
 ---
- northd/en-global-config.c |   5 ++
- northd/northd.c           | 137 +++++++++++++++++++++++++++-----------
- 2 files changed, 103 insertions(+), 39 deletions(-)
+ northd/en-global-config.c |   5 +
+ northd/northd.c           | 197 +++++++++++++++++++++++++-------------
+ 2 files changed, 137 insertions(+), 65 deletions(-)
 
 diff --git a/northd/en-global-config.c b/northd/en-global-config.c
-index 26d89b6676..3f934ccfff 100644
+index 65c060cc7..a21ba082d 100644
 --- a/northd/en-global-config.c
 +++ b/northd/en-global-config.c
-@@ -664,6 +664,11 @@ check_nb_options_out_of_sync(
+@@ -669,6 +669,11 @@ check_nb_options_out_of_sync(
          return true;
      }
  
@@ -26,10 +26,10 @@ index 26d89b6676..3f934ccfff 100644
  }
  
 diff --git a/northd/northd.c b/northd/northd.c
-index 8ab525b8be..505e27103f 100644
+index 969cefe79..a1bb7169a 100644
 --- a/northd/northd.c
 +++ b/northd/northd.c
-@@ -107,6 +107,11 @@ static bool ls_ct_skip_dst_lport_ips = false;
+@@ -113,6 +113,11 @@ static bool ls_ct_skip_dst_lport_ips = false;
  
  static bool ls_dnat_mod_dl_dst = false;
  
@@ -41,7 +41,7 @@ index 8ab525b8be..505e27103f 100644
  #define MAX_OVN_TAGS 4096
  
  
-@@ -140,6 +145,10 @@ static bool ls_dnat_mod_dl_dst = false;
+@@ -146,6 +151,10 @@ static bool ls_dnat_mod_dl_dst = false;
  #define REGBIT_ACL_PERSIST_ID     "reg0[20]"
  #define REGBIT_ACL_HINT_ALLOW_PERSISTED "reg0[21]"
  
@@ -52,7 +52,7 @@ index 8ab525b8be..505e27103f 100644
  /* Register definitions for switches and routers. */
  
  /* Registers used for LB Affinity.
-@@ -5769,8 +5778,11 @@ build_lswitch_port_sec_op(struct ovn_port *op, struct lflow_table *lflows,
+@@ -5831,8 +5840,11 @@ build_lswitch_port_sec_op(struct ovn_port *op, struct lflow_table *lflows,
                                            op->key, &op->nbsp->header_,
                                            op->lflow_ref);
      } else if (queue_id) {
@@ -66,7 +66,7 @@ index 8ab525b8be..505e27103f 100644
          ovn_lflow_add_with_lport_and_hint(lflows, op->od,
                                            S_SWITCH_IN_CHECK_PORT_SEC, 70,
                                            ds_cstr(match), ds_cstr(actions),
-@@ -5831,7 +5843,7 @@ build_lswitch_learn_fdb_op(
+@@ -5893,7 +5905,7 @@ build_lswitch_learn_fdb_op(
          ds_clear(match);
          ds_clear(actions);
          ds_put_format(match, "inport == %s", op->json_key);
@@ -75,7 +75,7 @@ index 8ab525b8be..505e27103f 100644
              ds_put_cstr(actions, "flags.localnet = 1; ");
          }
          ds_put_format(actions, REGBIT_LKUP_FDB
-@@ -5888,8 +5900,10 @@ build_lswitch_output_port_sec_od(struct ovn_datapath *od,
+@@ -5950,8 +5962,10 @@ build_lswitch_output_port_sec_od(struct ovn_datapath *od,
      ovn_lflow_add(lflows, od, S_SWITCH_OUT_CHECK_PORT_SEC, 100,
                    "eth.mcast", REGBIT_PORT_SEC_DROP" = 0; next;",
                    lflow_ref);
@@ -87,7 +87,57 @@ index 8ab525b8be..505e27103f 100644
                    lflow_ref);
  
      ovn_lflow_add_drop_with_desc(
-@@ -8346,7 +8360,7 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
+@@ -7819,26 +7833,29 @@ build_acls(const struct ls_stateful_record *ls_stateful_rec,
+          * Allow traffic that is established if the ACL has a persistent
+          * conntrack ID configured.
+          */
+-        ds_clear(&match);
+-        const char *pre_lb_persisted_acl_action =
+-            REGBIT_ACL_HINT_ALLOW_PERSISTED" = 1; "
+-            REGBIT_ACL_VERDICT_ALLOW" = 1; next;";
+-        const char *persisted_acl_action =
+-            REGBIT_ACL_VERDICT_ALLOW" = 1; next;";
+-        ds_put_format(&match, "ct.est && ct_mark.allow_established == 1");
+-        ovn_lflow_add(lflows, od, S_SWITCH_IN_ACL_EVAL, UINT16_MAX - 3,
+-                      ds_cstr(&match),
+-                      pre_lb_persisted_acl_action,
+-                      lflow_ref);
+-        ovn_lflow_add(lflows, od, S_SWITCH_OUT_ACL_EVAL, UINT16_MAX - 3,
+-                      ds_cstr(&match),
+-                      persisted_acl_action,
+-                      lflow_ref);
+-        ovn_lflow_add(lflows, od, S_SWITCH_IN_ACL_AFTER_LB_EVAL,
+-                      UINT16_MAX - 3,
+-                      REGBIT_ACL_HINT_ALLOW_PERSISTED" == 1",
+-                      persisted_acl_action,
+-                      lflow_ref);
++        if (!(compatible_24_03 || compatible_22_03 ||
++              compatible_22_12)) {
++            ds_clear(&match);
++            const char *pre_lb_persisted_acl_action =
++                REGBIT_ACL_HINT_ALLOW_PERSISTED" = 1; "
++                REGBIT_ACL_VERDICT_ALLOW" = 1; next;";
++            const char *persisted_acl_action =
++                REGBIT_ACL_VERDICT_ALLOW" = 1; next;";
++            ds_put_format(&match, "ct.est && ct_mark.allow_established == 1");
++            ovn_lflow_add(lflows, od, S_SWITCH_IN_ACL_EVAL, UINT16_MAX - 3,
++                          ds_cstr(&match),
++                          pre_lb_persisted_acl_action,
++                          lflow_ref);
++            ovn_lflow_add(lflows, od, S_SWITCH_OUT_ACL_EVAL, UINT16_MAX - 3,
++                          ds_cstr(&match),
++                          persisted_acl_action,
++                          lflow_ref);
++            ovn_lflow_add(lflows, od, S_SWITCH_IN_ACL_AFTER_LB_EVAL,
++                          UINT16_MAX - 3,
++                          REGBIT_ACL_HINT_ALLOW_PERSISTED" == 1",
++                          persisted_acl_action,
++                          lflow_ref);
++        }
+     }
+ 
+     /* Ingress and Egress ACL Table (Priority 65532).
+@@ -8430,7 +8447,7 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
                 struct ds *match, struct ds *action,
                 const struct shash *meter_groups,
                 const struct hmap *svc_monitor_map,
@@ -96,7 +146,7 @@ index 8ab525b8be..505e27103f 100644
  {
      const struct ovn_northd_lb *lb = lb_dps->lb;
      for (size_t i = 0; i < lb->n_vips; i++) {
-@@ -8578,6 +8592,7 @@ build_stateful(struct ovn_datapath *od,
+@@ -8669,6 +8686,7 @@ build_stateful(struct ovn_datapath *od,
                 struct lflow_ref *lflow_ref)
  {
      struct ds actions = DS_EMPTY_INITIALIZER;
@@ -104,7 +154,7 @@ index 8ab525b8be..505e27103f 100644
  
      /* Ingress LB, Ingress and Egress stateful Table (Priority 0): Packets are
       * allowed by default. */
-@@ -8593,15 +8608,22 @@ build_stateful(struct ovn_datapath *od,
+@@ -8684,15 +8702,22 @@ build_stateful(struct ovn_datapath *od,
       * We always set ct_mark.blocked to 0 here as
       * any packet that makes it this far is part of a connection we
       * want to allow to continue. */
@@ -136,7 +186,31 @@ index 8ab525b8be..505e27103f 100644
      ovn_lflow_add(lflows, od, S_SWITCH_IN_STATEFUL, 100,
                    REGBIT_CONNTRACK_COMMIT" == 1 && "
                    REGBIT_ACL_LABEL" == 1",
-@@ -8668,16 +8690,19 @@ build_lb_hairpin(const struct ls_stateful_record *ls_stateful_rec,
+@@ -8709,12 +8734,17 @@ build_stateful(struct ovn_datapath *od,
+      * any packet that makes it this far is part of a connection we
+      * want to allow to continue. */
+     ds_clear(&actions);
+-    ds_put_cstr(&actions,
+-                "ct_commit { "
+-                   "ct_mark.blocked = 0; "
+-                   "ct_mark.allow_established = " REGBIT_ACL_PERSIST_ID "; "
+-                   "ct_label.acl_id = " REG_ACL_ID "; "
+-                "}; next;");
++    if (compatible_24_03 || compatible_22_03 || compatible_22_12) {
++        ds_put_format(&actions, "ct_commit { %s = 0; }; next;",
++                      ct_block_action);
++    } else {
++        ds_put_cstr(&actions,
++                    "ct_commit { "
++                       "ct_mark.blocked = 0; "
++                       "ct_mark.allow_established = " REGBIT_ACL_PERSIST_ID "; "
++                       "ct_label.acl_id = " REG_ACL_ID "; "
++                    "}; next;");
++    }
+     ovn_lflow_add(lflows, od, S_SWITCH_IN_STATEFUL, 100,
+                   REGBIT_CONNTRACK_COMMIT" == 1 && "
+                   REGBIT_ACL_LABEL" == 0",
+@@ -8759,16 +8789,19 @@ build_lb_hairpin(const struct ls_stateful_record *ls_stateful_rec,
           * after conntrack.  It is the kernel datapath conntrack behavior.
           * We need to find a better way to handle the fragmented packets.
           * */
@@ -166,7 +240,7 @@ index 8ab525b8be..505e27103f 100644
  
          /* Set REGBIT_HAIRPIN in the original direction and
           * REGBIT_HAIRPIN_REPLY in the reply direction.
-@@ -8987,8 +9012,9 @@ build_lswitch_rport_arp_req_self_orig_flow(struct ovn_port *op,
+@@ -9078,8 +9111,9 @@ build_lswitch_rport_arp_req_self_orig_flow(struct ovn_port *op,
  
      ds_put_format(&match,
                    "eth.src == %s && eth.dst == ff:ff:ff:ff:ff:ff && "
@@ -178,7 +252,7 @@ index 8ab525b8be..505e27103f 100644
      ovn_lflow_add(lflows, od, S_SWITCH_IN_L2_LKUP, priority, ds_cstr(&match),
                    "outport = \""MC_FLOOD_L2"\"; output;", lflow_ref);
  
-@@ -9713,12 +9739,14 @@ build_lswitch_lflows_admission_control(struct ovn_datapath *od,
+@@ -9804,12 +9838,14 @@ build_lswitch_lflows_admission_control(struct ovn_datapath *od,
  {
      ovs_assert(od->nbs);
  
@@ -199,7 +273,7 @@ index 8ab525b8be..505e27103f 100644
  
      /* Logical VLANs not supported. */
      if (!is_vlan_transparent(od)) {
-@@ -9736,8 +9764,10 @@ build_lswitch_lflows_admission_control(struct ovn_datapath *od,
+@@ -9827,8 +9863,10 @@ build_lswitch_lflows_admission_control(struct ovn_datapath *od,
          "eth.src[40]", "Incoming Broadcast/multicast source"
          " address is invalid", lflow_ref);
  
@@ -211,7 +285,7 @@ index 8ab525b8be..505e27103f 100644
                    lflow_ref);
  
      ovn_lflow_add_drop_with_desc(
-@@ -13411,6 +13441,10 @@ build_lrouter_icmp_packet_toobig_admin_flows(
+@@ -13673,6 +13711,10 @@ build_lrouter_icmp_packet_toobig_admin_flows(
  {
      ovs_assert(op->nbrp);
  
@@ -222,7 +296,7 @@ index 8ab525b8be..505e27103f 100644
      if (!lrp_is_l3dgw(op)) {
          return;
      }
-@@ -13436,6 +13470,10 @@ build_lswitch_icmp_packet_toobig_admin_flows(
+@@ -13698,6 +13740,10 @@ build_lswitch_icmp_packet_toobig_admin_flows(
  {
      ovs_assert(op->nbsp);
  
@@ -233,7 +307,7 @@ index 8ab525b8be..505e27103f 100644
      if (!lsp_is_router(op->nbsp)) {
          for (size_t i = 0; i < op->n_lsp_addrs; i++) {
              ds_clear(match);
-@@ -13702,11 +13740,13 @@ build_adm_ctrl_flows_for_lrouter(
+@@ -13964,11 +14010,13 @@ build_adm_ctrl_flows_for_lrouter(
  {
      ovs_assert(od->nbr);
  
@@ -252,7 +326,7 @@ index 8ab525b8be..505e27103f 100644
  
      /* Logical VLANs not supported.
       * Broadcast/multicast source address is invalid. */
-@@ -13971,8 +14011,11 @@ build_neigh_learning_flows_for_lrouter(
+@@ -14239,8 +14287,11 @@ build_neigh_learning_flows_for_lrouter(
      ds_put_format(match, REGBIT_LOOKUP_NEIGHBOR_RESULT" == 1%s",
                    learn_from_arp_request ? "" :
                    " || "REGBIT_LOOKUP_NEIGHBOR_IP_RESULT" == 0");
@@ -265,7 +339,7 @@ index 8ab525b8be..505e27103f 100644
                    lflow_ref);
  
      ovn_lflow_metered(lflows, od, S_ROUTER_IN_LEARN_NEIGHBOR, 90,
-@@ -19540,6 +19583,22 @@ ovnnb_db_run(struct northd_input *input_data,
+@@ -19997,6 +20048,22 @@ ovnnb_db_run(struct northd_input *input_data,
      ls_dnat_mod_dl_dst = smap_get_bool(input_data->nb_options,
                                         "ls_dnat_mod_dl_dst", false);
  
@@ -288,3 +362,5 @@ index 8ab525b8be..505e27103f 100644
      build_datapaths(ovnsb_txn,
                      input_data->nbrec_logical_switch_table,
                      input_data->nbrec_logical_router_table,
+-- 
+2.34.1


### PR DESCRIPTION
## Summary
- add `compatible_25_03` handling to `dist/images/patches/e76880e792af56b2a3836098105079f5f8f1ff26.patch`
- skip generating ACL flows that match on `ct_mark.allow_established` in compatibility mode
- keep `build_stateful()` and `build_acls()` consistent during mixed-version rolling upgrades

## Why
OVN 25.03 introduces `ct_mark.allow_established` for ACL persistence. `ovn-northd` can generate flows that write and later match on this field so established connections can continue to pass without re-evaluating the full ACL path.

That field is not understood by older `ovn-controller` versions such as 24.03. During a rolling upgrade, if `northd` starts emitting flows with `ct_mark.allow_established` before all controllers are upgraded, old controllers can fail to parse those flows.

This change adds `compatible_25_03` so compatibility mode disables both sides of that feature:
- the `ct_commit` action that writes `ct_mark.allow_established`
- the ACL flow that matches `ct_mark.allow_established == 1`

## What `ct_mark.allow_established` does
`ct_mark.allow_established` is an OVN conntrack mark used by ACL persistence.

It is written when the first packet of a connection is committed, and then read by later ACL flows for established/reply traffic. The purpose is to let an already-established connection continue to pass without re-running the full ACL decision path.

In practice:
- `build_stateful()` writes it into conntrack state
- `build_acls()` matches it for established traffic
- older `ovn-controller` versions cannot parse this field

## Validation
- `make lint`