### PR TITLE
fix(daemon): race condition between setExGateway and configProviderNic

### DIFF
--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -1526,12 +1526,8 @@ func (c *Controller) setExGateway() error {
 		}
 
 		for _, pn := range providerNetworks {
-			// if external nic already attached into another bridge
-			if existBr, err := ovs.Exec("port-to-br", pn.Spec.DefaultInterface); err == nil {
-				if existBr == externalBridge {
-					// delete switch after related provider network not exist
-					return nil
-				}
+			if util.ExternalBridgeName(pn.Name) == externalBridge {
+				return nil
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Fix a race condition where `setExGateway()` deletes `br-external` while `configProviderNic()` is actively transferring IP addresses to it, causing permanent address loss on the bridge
- Replace OVS runtime check (`port-to-br`) with declarative bridge name match from ProviderNetwork CR, eliminating the race window entirely

## Root Cause

`setExGateway()` (gateway loop, every 3s) checks if `br-external` is used by a provider network via `ovs-vsctl port-to-br eth1`. But `configProviderNic()` executes `transferAddrsAndRoutes()` (which removes IPs from eth1) **before** `add-port` (which adds eth1 to the bridge). During this window, `port-to-br eth1` always fails, causing `setExGateway` to mistakenly delete the bridge.

Once deleted, retry cannot recover: eth1's addresses were already removed in the first attempt, so `transferAddrsAndRoutes` finds nothing to transfer.

Evidence from CI run [#23208722848](https://github.com/kubeovn/kube-ovn/actions/runs/23208722848):
```
18:20:37.288  addr "172.19.0.2/16" removed from eth1        ← transferAddrsAndRoutes
18:20:37.288  port-to-br eth1 → ERROR                       ← setExGateway check
18:20:37.288  delete external bridge br-external             ← bridge deleted!
18:20:37.310  LinkSetUp(br-external) → "no such device"      ← too late
```

## Fix

Replace the OVS `port-to-br` runtime check with `util.ExternalBridgeName(pn.Name) == externalBridge`. The ProviderNetwork CR exists in the informer cache before bridge creation begins, so there is no race window.

## Test plan

- [ ] Existing `ovn-vpc-nat-gw-conformance-e2e` tests pass (this was the flaky test)
- [ ] Verify `setExGateway` still correctly cleans up bridges when no provider network exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)