### PR TITLE
fix(daemon): handle tombstone objects in subnet and service delete handlers

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -604,7 +604,19 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 }
 
 func (c *Controller) enqueueDeleteSubnet(obj any) {
-	c.subnetQueue.Add(&subnetEvent{oldObj: obj})
+	switch t := obj.(type) {
+	case *kubeovnv1.Subnet:
+		c.subnetQueue.Add(&subnetEvent{oldObj: t})
+	case cache.DeletedFinalStateUnknown:
+		subnet, ok := t.Obj.(*kubeovnv1.Subnet)
+		if !ok {
+			klog.Warningf("unexpected object type in tombstone: %T", t.Obj)
+			return
+		}
+		c.subnetQueue.Add(&subnetEvent{oldObj: subnet})
+	default:
+		klog.Warningf("unexpected type: %T", obj)
+	}
 }
 
 func (c *Controller) runSubnetWorker() {
@@ -621,7 +633,19 @@ func (c *Controller) enqueueUpdateService(oldObj, newObj any) {
 }
 
 func (c *Controller) enqueueDeleteService(obj any) {
-	c.serviceQueue.Add(&serviceEvent{oldObj: obj})
+	switch t := obj.(type) {
+	case *v1.Service:
+		c.serviceQueue.Add(&serviceEvent{oldObj: t})
+	case cache.DeletedFinalStateUnknown:
+		svc, ok := t.Obj.(*v1.Service)
+		if !ok {
+			klog.Warningf("unexpected object type in tombstone: %T", t.Obj)
+			return
+		}
+		c.serviceQueue.Add(&serviceEvent{oldObj: svc})
+	default:
+		klog.Warningf("unexpected type: %T", obj)
+	}
 }
 
 func (c *Controller) runAddOrUpdateServiceWorker() {


### PR DESCRIPTION
## Summary

- Fix `enqueueDeleteSubnet` and `enqueueDeleteService` to properly unwrap `cache.DeletedFinalStateUnknown` tombstone objects before enqueuing delete events
- Without this fix, when an informer reconnects after a watch interruption, delete events are silently dropped, leaving stale routes and iptables/ipset rules uncleaned

## Details

When a Kubernetes informer reconnects after a watch interruption, it may deliver a `cache.DeletedFinalStateUnknown` tombstone instead of the original typed object. The two affected functions passed the raw `obj` directly into the work queue. Downstream consumers (`reconcileRouters` at L275 and `reconcileServices` at L531) then failed the type assertion and returned `nil`, silently dropping the delete event.

This is the same pattern already correctly handled by `enqueueDeleteProviderNetwork` in the same file (L272-287). All controller-side delete handlers in `pkg/controller/` also handle tombstones correctly.

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify existing unit tests pass
- [ ] Manual: delete a subnet/service while the API server is temporarily unreachable to the daemon, confirm the delete is still processed after reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)