### PR TITLE
fix(controller): reuse addPolicyRouteToVpc to handle empty NextHopIP

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -563,8 +563,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 	// add new policies
 	for _, item := range policyRouteNeedAdd {
 		klog.Infof("add policy route for router: %s, match %s, action %s, nexthop %s, externalID %v", vpc.Name, item.Match, string(item.Action), item.NextHopIP, externalIDs)
-		if err = c.OVNNbClient.AddLogicalRouterPolicy(vpc.Name, item.Priority, item.Match, string(item.Action), strings.Split(item.NextHopIP, ","), nil, externalIDs); err != nil {
-			klog.Errorf("add policy route to vpc %s failed, %v", vpc.Name, err)
+		if err = c.addPolicyRouteToVpc(vpc.Name, item, externalIDs); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/vpc_test.go
+++ b/pkg/controller/vpc_test.go
@@ -300,6 +300,70 @@ func Test_handleAddOrUpdateVpc_policyRoutes_ecmpNextHops(t *testing.T) {
 
 	vpcName := "test-vpc-policy"
 
+	t.Run("empty NextHopIP with non-reroute action should pass nil next-hops", func(t *testing.T) {
+		fakeController := newFakeController(t)
+		ctrl := fakeController.fakeController
+		fakeinformers := fakeController.fakeInformers
+		mockOvnClient := fakeController.mockOvnClient
+
+		ctrl.vpcKeyMutex = keymutex.NewHashed(500)
+
+		vpc := &kubeovnv1.Vpc{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: vpcName,
+			},
+			Spec: kubeovnv1.VpcSpec{
+				StaticRoutes:   []*kubeovnv1.StaticRoute{},
+				EnableExternal: false,
+				PolicyRoutes: []*kubeovnv1.PolicyRoute{
+					{
+						Priority:  200,
+						Match:     "ip4.src == 10.0.0.0/8",
+						Action:    kubeovnv1.PolicyRouteActionDrop,
+						NextHopIP: "",
+					},
+				},
+			},
+			Status: kubeovnv1.VpcStatus{
+				Subnets:        []string{},
+				EnableExternal: false,
+			},
+		}
+
+		_, err := ctrl.config.KubeOvnClient.KubeovnV1().Vpcs().Create(context.Background(), vpc, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		err = fakeinformers.vpcInformer.Informer().GetStore().Add(vpc)
+		require.NoError(t, err)
+
+		externalIDs := map[string]string{"vendor": util.CniTypeName}
+
+		mockOvnClient.EXPECT().CreateLogicalRouter(vpcName).Return(nil)
+		mockOvnClient.EXPECT().UpdateLogicalRouter(gomock.Any(), gomock.Any()).Return(nil)
+		mockOvnClient.EXPECT().ListLogicalRouterStaticRoutes(vpcName, nil, nil, "", externalIDs).Return(nil, nil)
+		mockOvnClient.EXPECT().GetLogicalRouter(vpcName, false).Return(&ovnnb.LogicalRouter{
+			Name: vpcName,
+			Nat:  []string{},
+		}, nil)
+		mockOvnClient.EXPECT().ListLogicalRouterPolicies(vpcName, -1, nil, true).Return(nil, nil)
+		// The key assertion: empty NextHopIP must produce nil next-hops, not [""]
+		mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+			vpcName,
+			200,
+			"ip4.src == 10.0.0.0/8",
+			string(kubeovnv1.PolicyRouteActionDrop),
+			([]string)(nil),
+			([]string)(nil),
+			externalIDs,
+		).Return(nil)
+		mockOvnClient.EXPECT().ListLogicalSwitch(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalSwitch{}, nil).AnyTimes()
+		mockOvnClient.EXPECT().ListLogicalRouter(gomock.Any(), gomock.Any()).Return([]ovnnb.LogicalRouter{}, nil).AnyTimes()
+		mockOvnClient.EXPECT().DeleteLogicalRouterPort(fmt.Sprintf("bfd@%s", vpcName)).Return(nil)
+		mockOvnClient.EXPECT().DeleteHAChassisGroup(fmt.Sprintf("bfd@%s", vpcName)).Return(nil)
+		err = ctrl.handleAddOrUpdateVpc(vpcName)
+		require.NoError(t, err)
+	})
+
 	t.Run("ECMP next-hops are split correctly for custom VPC policy routes", func(t *testing.T) {
 		fakeController := newFakeController(t)
 		ctrl := fakeController.fakeController


### PR DESCRIPTION
## Summary
- Replaced inline `strings.Split(item.NextHopIP, ",")` in `handleAddOrUpdateVpc` with `addPolicyRouteToVpc`, which correctly handles empty `NextHopIP` by passing `nil` instead of `[""]` to OVN
- Added unit test for empty `NextHopIP` with non-reroute (drop) action to verify `nil` next-hops are passed

## Test plan
- [x] `go test ./pkg/controller/ -run Test_handleAddOrUpdateVpc_policyRoutes` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)