### PR TITLE
fix(daemon): sort encap IP list for deterministic ovs-vsctl output

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -494,6 +494,7 @@ func (config *Configuration) setEncapIPs() error {
 			ips = append(ips, ip)
 		}
 	}
+	slices.Sort(ips[1:])
 
 	encapIPStr := strings.Join(ips, ",")
 	// #nosec G204


### PR DESCRIPTION
## Summary
- Sort non-default encap IPs in `setEncapIPs()` to ensure deterministic ordering when iterating over the `NodeNetworks` map
- The default IP is always placed first; remaining IPs are now sorted before joining into the comma-separated string passed to `ovs-vsctl set open . external-ids:ovn-encap-ip=`
- Inspired by [ovn-org/ovn-kubernetes#5967](https://github.com/ovn-org/ovn-kubernetes/pull/5967)

## Test plan
- [ ] Verify `ovn-encap-ip` external-id value is stable across daemon restarts when multiple node networks are configured
- [ ] Existing e2e tests pass (no behavioral change, only ordering stabilization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)