### PR TITLE
fix(e2e): wait for OVS bridge cleanup before Docker disconnect in vlan subinterface tests

### DIFF
--- a/test/e2e/kube-ovn/underlay/vlan_subinterfaces.go
+++ b/test/e2e/kube-ovn/underlay/vlan_subinterfaces.go
@@ -14,6 +14,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/docker"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/kind"
@@ -98,6 +99,23 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		for i := len(providerNetworkNames) - 1; i >= 0; i-- {
 			providerNetworkClient.DeleteSync(providerNetworkNames[i])
 		}
+
+		// Wait for OVS bridges to disappear on all nodes before disconnecting
+		// the Docker network. Without this, the daemon may still be processing
+		// the provider network deletion (configProviderNic / add-port) when Docker
+		// removes the NIC. A failed add-port leaves a stale netdev cache entry in
+		// ovs-vswitchd, which causes EEXIST errors for subsequent bridge creation
+		// with exchangeLinkName=true.
+		ginkgo.By("Waiting for ovs bridges to disappear")
+		deadline := time.Now().Add(2 * time.Minute)
+		for _, pnName := range providerNetworkNames {
+			brName := util.ExternalBridgeName(pnName)
+			for _, node := range kindNodes {
+				err := node.WaitLinkToDisappear(brName, time.Second, deadline)
+				framework.ExpectNoError(err, "timed out waiting for ovs bridge %s to disappear in node %s", brName, node.Name())
+			}
+		}
+
 		if dockerNetwork != nil {
 			ginkgo.By(fmt.Sprintf("Disconnecting nodes from docker network %s", dockerNetworkName))
 			framework.ExpectNoError(kind.NetworkDisconnect(dockerNetwork.ID, kindNodes))


### PR DESCRIPTION
## Summary

- Fix the root cause of flaky `should exchange link names` underlay E2E test failures
- Add "Waiting for ovs bridges to disappear" step in `vlan_subinterfaces.go` AfterEach, between provider network deletion and Docker network disconnect
- This matches the pattern already used in `underlay.go` (L393-398)

## Root Cause Analysis

When `vlan_subinterfaces.go` AfterEach runs, it deletes provider network CRs then **immediately** disconnects the Docker network. But the daemon may still be running `configProviderNic` → `ovs-vsctl add-port eth1` at that moment. The race:

1. Daemon calls `add-port eth1` on bridge `br-tpn-xxx`
2. Docker disconnects the network, removing `eth1` from the kernel
3. `ovs-vswitchd` processes add-port but `eth1` no longer exists → `dpif: failed to add eth1: No such device`
4. The failed add-port leaves a **stale netdev cache entry** for `eth1` in `ovs-vswitchd`
5. Next test with `exchangeLinkName=true` renames `eth1` → `br-pn-xxx`, then tries `add-br eth1`
6. `ovs-vswitchd` hits the stale cache → `could not open network device eth1 (File exists)` — permanently stuck for 2 minutes until test timeout

Evidence from CI run [23284436161](https://github.com/kubeovn/kube-ovn/actions/runs/23284436161): control-plane node's `add-port` was ~20ms slower than worker node's. Worker completed add→delete→cache-cleanup before Docker disconnect; control-plane did not.

## Test plan

- [ ] Run underlay E2E tests multiple times to verify `should exchange link names` no longer flakes
- [ ] Verify vlan subinterface tests still pass (the wait adds up to 2 min timeout but should complete in seconds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)