### PR TITLE
fix: limit vswitch client schema to core tables

### DIFF
--- a/pkg/ovs/ovs-vswitch.go
+++ b/pkg/ovs/ovs-vswitch.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
-	"k8s.io/klog/v2"
+	"github.com/ovn-kubernetes/libovsdb/model"
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/vswitch"
@@ -16,28 +16,16 @@ type VswitchClient struct {
 	ovsDbClient
 }
 
+var vswitchCoreTables = []string{
+	vswitch.BridgeTable,
+	vswitch.InterfaceTable,
+	vswitch.OpenvSwitchTable,
+	vswitch.PortTable,
+}
+
 // NewVswitchClient creates a new vswitch client
 func NewVswitchClient(addr string, connTimeout, transactTimeout int) (*VswitchClient, error) {
-	dbModel, err := vswitch.FullDatabaseModel()
-	if err != nil {
-		klog.Error(err)
-		return nil, err
-	}
-
-	monitors := []client.MonitorOption{
-		client.WithTable(&vswitch.Bridge{}),
-		client.WithTable(&vswitch.Interface{}),
-		client.WithTable(&vswitch.OpenvSwitch{}),
-		client.WithTable(&vswitch.Port{}),
-	}
-	c, err := ovsclient.NewOvsDbClient(
-		vswitch.DatabaseName,
-		addr,
-		dbModel,
-		monitors,
-		connTimeout,
-		0,
-	)
+	c, err := newCoreVswitchClient(addr, connTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create vswitch client: %w", err)
 	}
@@ -48,4 +36,32 @@ func NewVswitchClient(addr string, connTimeout, transactTimeout int) (*VswitchCl
 			Timeout: time.Duration(transactTimeout) * time.Second,
 		},
 	}, nil
+}
+
+func newCoreVswitchClient(addr string, connTimeout int) (client.Client, error) {
+	dbModel, err := model.NewClientDBModel(vswitch.DatabaseName, map[string]model.Model{
+		vswitch.BridgeTable:      &vswitch.Bridge{},
+		vswitch.InterfaceTable:   &vswitch.Interface{},
+		vswitch.OpenvSwitchTable: &vswitch.OpenvSwitch{},
+		vswitch.PortTable:        &vswitch.Port{},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client db model: %w", err)
+	}
+
+	monitors := make([]client.MonitorOption, 0, len(vswitchCoreTables))
+	for _, tableName := range vswitchCoreTables {
+		switch tableName {
+		case vswitch.BridgeTable:
+			monitors = append(monitors, client.WithTable(&vswitch.Bridge{}))
+		case vswitch.InterfaceTable:
+			monitors = append(monitors, client.WithTable(&vswitch.Interface{}))
+		case vswitch.OpenvSwitchTable:
+			monitors = append(monitors, client.WithTable(&vswitch.OpenvSwitch{}))
+		case vswitch.PortTable:
+			monitors = append(monitors, client.WithTable(&vswitch.Port{}))
+		}
+	}
+
+	return ovsclient.NewOvsDbClient(vswitch.DatabaseName, addr, dbModel, monitors, connTimeout, 0)
 }

--- a/pkg/ovs/ovs-vswitch_test.go
+++ b/pkg/ovs/ovs-vswitch_test.go
@@ -1,0 +1,59 @@
+package ovs
+
+import (
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ovn-kubernetes/libovsdb/model"
+	"github.com/ovn-kubernetes/libovsdb/modelgen"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/vswitch"
+)
+
+func TestNewVswitchClientWithLegacySchema(t *testing.T) {
+	schema := vswitch.Schema()
+	delete(schema.Tables[vswitch.MirrorTable].Columns, "filter")
+	delete(schema.Tables[vswitch.FlowSampleCollectorSetTable].Columns, "local_group_id")
+
+	dbModel, err := newDynamicDBModelFromSchema(vswitch.DatabaseName, schema)
+	require.NoError(t, err)
+
+	_, sock := newOVSDBServer(t, "legacy-vswitch", dbModel, schema)
+	client, err := NewVswitchClient("unix:"+sock, 1, 1)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	_, err = client.ListBridge(false, nil)
+	require.NoError(t, err)
+}
+
+func newDynamicDBModelFromSchema(dbName string, schema ovsdb.DatabaseSchema) (model.ClientDBModel, error) {
+	models := make(map[string]model.Model, len(schema.Tables))
+	for tableName, table := range schema.Tables {
+		models[tableName] = newDynamicTestTableModel(table.Columns)
+	}
+	return model.NewClientDBModel(dbName, models)
+}
+
+func newDynamicTestTableModel(columns map[string]*ovsdb.ColumnSchema) model.Model {
+	sortedColumns := append([]string{"_uuid"}, slices.Sorted(maps.Keys(columns))...)
+	fields := make([]reflect.StructField, 0, len(sortedColumns))
+	for _, column := range sortedColumns {
+		columnSchema := &ovsdb.UUIDColumn
+		if column != "_uuid" {
+			columnSchema = columns[column]
+		}
+		fields = append(fields, reflect.StructField{
+			Name: modelgen.FieldName(column),
+			Type: ovsdb.NativeType(columnSchema),
+			Tag:  reflect.StructTag(strings.Trim(modelgen.Tag(column), "`")),
+		})
+	}
+
+	return reflect.New(reflect.StructOf(fields)).Interface().(model.Model)
+}


### PR DESCRIPTION
## Summary
- limit the local Open_vSwitch client model to the core tables used by kube-ovn-cni
- avoid validating unrelated tables like Mirror and Flow_Sample_Collector_Set during cni startup
- add a regression test that simulates a legacy OVS schema without the filter and local_group_id columns

## Original Error
```text
failed to connect to Open_vSwitch database server unix:/var/run/openvswitch/db.sock: failed to
connect to unix:/var/run/openvswitch/db.sock: database Open_vSwitch validation error (2): Mapper Error. Object type vswitch.Mirror contains field Filter (*string) ovs tag
filter: Column does not exist in schema. Mapper Error. Object type vswitch.FlowSampleCollectorSet contains field LocalGroupID (*int) ovs tag local_group_id: Column does
not exist in schema
E0408 17:02:27.522024 2198798 klog.go:10] "failed to create controller" err="failed to create vswitch client: failed to create vswitch client: failed to connect to unix:/
var/run/openvswitch/db.sock: database Open_vSwitch validation error (2): Mapper Error. Object type vswitch.Mirror contains field Filter (*string) ovs tag filter: Column
does not exist in schema. Mapper Error. Object type vswitch.FlowSampleCollectorSet contains field LocalGroupID (*int) ovs tag local_group_id: Column does not exist in
schema"
```

## Context
This happens during upgrade windows when kube-ovn-cni is newer than the node local Open_vSwitch schema. The old local schema does not contain the filter and local_group_id columns, but the full generated vswitch model validates them during client startup.

## Fix
Use a reduced Open_vSwitch client model for kube-ovn-cni that only includes the core tables it actually depends on:
- Bridge
- Interface
- Open_vSwitch
- Port

That keeps startup compatible with older local schemas and avoids blocking cni-server on unrelated table fields.

## Testing
- go test ./pkg/ovs -run 'TestNewVswitchClientWithLegacySchema|TestOvsdbServerAddress'
- make lint was started earlier but not waited to completion after switching to PR creation
