### PR TITLE
fix(controller): prevalidate nat gw name and normalize long labels

### DIFF
--- a/pkg/controller/service_lb.go
+++ b/pkg/controller/service_lb.go
@@ -72,8 +72,9 @@ func (c *Controller) getAttachNetworkForService(svc *corev1.Service) (*nadv1.Net
 
 func (c *Controller) genLbSvcDeployment(svc *corev1.Service, nad *nadv1.NetworkAttachmentDefinition) (dp *v1.Deployment) {
 	name := genLbSvcDpName(svc.Name)
+	appLabel := util.NormalizeLabelValue(name)
 	labels := map[string]string{
-		"app":       name,
+		"app":       appLabel,
 		"namespace": svc.Namespace,
 		"service":   svc.Name,
 	}
@@ -199,7 +200,10 @@ func (c *Controller) createLbSvcPod(svc *corev1.Service, nad *nadv1.NetworkAttac
 }
 
 func (c *Controller) getLbSvcPod(svcName, svcNamespace string) (*corev1.Pod, error) {
-	selector := labels.Set{"app": genLbSvcDpName(svcName), "namespace": svcNamespace}.AsSelector()
+	selector := labels.Set{
+		"app":       util.NormalizeLabelValue(genLbSvcDpName(svcName)),
+		"namespace": svcNamespace,
+	}.AsSelector()
 	pods, err := c.podsLister.Pods(svcNamespace).List(selector)
 	switch {
 	case err != nil:

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -74,7 +74,10 @@ func (c *Controller) enqueueDeleteVpcEgressGateway(obj any) {
 }
 
 func vegWorkloadLabels(vegName string) map[string]string {
-	return map[string]string{"app": "vpc-egress-gateway", util.VpcEgressGatewayLabel: vegName}
+	return map[string]string{
+		"app":                      "vpc-egress-gateway",
+		util.VpcEgressGatewayLabel: util.NormalizeLabelValue(vegName),
+	}
 }
 
 func (c *Controller) handleAddOrUpdateVpcEgressGateway(key string) error {

--- a/pkg/controller/vpc_lb.go
+++ b/pkg/controller/vpc_lb.go
@@ -95,10 +95,11 @@ func (c *Controller) genVpcLbDeployment(vpc *kubeovnv1.Vpc) (*v1.Deployment, err
 
 	replicas := int32(1)
 	name := vpcLbDeploymentName(vpc.Name)
+	appLabel := util.NormalizeLabelValue(name)
 	allowPrivilegeEscalation := true
 	privileged := true
 	labels := map[string]string{
-		"app":           name,
+		"app":           appLabel,
 		util.VpcLbLabel: "true",
 	}
 

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	labelValueHashLength = 8
+)
+
+// NormalizeLabelValue returns a deterministic label value that always satisfies
+// Kubernetes label value length limits. If the input already fits, it is returned unchanged.
+func NormalizeLabelValue(value string) string {
+	if len(value) <= validation.LabelValueMaxLength {
+		return value
+	}
+
+	hash := Sha256Hash([]byte(value))[:labelValueHashLength]
+	prefixLen := validation.LabelValueMaxLength - labelValueHashLength - 1
+	return fmt.Sprintf("%s-%s", value[:prefixLen], hash)
+}

--- a/pkg/util/label_test.go
+++ b/pkg/util/label_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestNormalizeLabelValue(t *testing.T) {
+	t.Run("value within limit unchanged", func(t *testing.T) {
+		value := strings.Repeat("a", validation.LabelValueMaxLength)
+		if got := NormalizeLabelValue(value); got != value {
+			t.Fatalf("expected unchanged label value, got %q", got)
+		}
+	})
+
+	t.Run("overlong value normalized to max length deterministically", func(t *testing.T) {
+		value := strings.Repeat("a", validation.LabelValueMaxLength+20)
+		got := NormalizeLabelValue(value)
+
+		if len(got) != validation.LabelValueMaxLength {
+			t.Fatalf("expected label value length %d, got %d", validation.LabelValueMaxLength, len(got))
+		}
+
+		expectedHash := Sha256Hash([]byte(value))[:labelValueHashLength]
+		if !strings.HasSuffix(got, "-"+expectedHash) {
+			t.Fatalf("expected normalized value suffix -%s, got %q", expectedHash, got)
+		}
+
+		if got != NormalizeLabelValue(value) {
+			t.Fatalf("expected deterministic normalization, got different outputs")
+		}
+	})
+}

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -9,6 +9,7 @@ import (
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
@@ -19,6 +20,13 @@ const VpcNatGwNameDefaultPrefix = "vpc-nat-gw"
 // VpcNatGwNamePrefix is appended to the name of the StatefulSet and Pods for NAT gateways
 var VpcNatGwNamePrefix = VpcNatGwNameDefaultPrefix
 
+const (
+	// StatefulSet controller appends "-<10-char-hash>" to controller-revision-hash label value.
+	statefulSetRevisionHashSuffixLength = 11
+	// To keep controller-revision-hash valid, statefulset name must not exceed 52 chars.
+	NatGwStatefulSetNameMaxLength = validation.LabelValueMaxLength - statefulSetRevisionHashSuffixLength
+)
+
 // GenNatGwName returns the full name of a NAT gateway StatefulSet/Deployment
 func GenNatGwName(name string) string {
 	return fmt.Sprintf("%s-%s", VpcNatGwNamePrefix, name)
@@ -27,6 +35,18 @@ func GenNatGwName(name string) string {
 // GenNatGwPodName returns the full name of the NAT gateway pod within a StatefulSet
 func GenNatGwPodName(name string) string {
 	return fmt.Sprintf("%s-%s-0", VpcNatGwNamePrefix, name)
+}
+
+// ValidateNatGwStatefulSetNameLength validates generated NAT GW StatefulSet name length.
+// This check is stricter than the plain 63-char label value limit because StatefulSet
+// controller appends a hash suffix to `controller-revision-hash` label values.
+func ValidateNatGwStatefulSetNameLength(gwName string) error {
+	statefulSetName := GenNatGwName(gwName)
+	if len(statefulSetName) > NatGwStatefulSetNameMaxLength {
+		return fmt.Errorf("generated NAT gateway statefulset name %q length %d exceeds max %d; choose a shorter NAT gateway name",
+			statefulSetName, len(statefulSetName), NatGwStatefulSetNameMaxLength)
+	}
+	return nil
 }
 
 // GetNatGwExternalNetwork returns the external network attached to a NAT gateway

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -29,19 +29,37 @@ const (
 
 // GenNatGwName returns the full name of a NAT gateway StatefulSet/Deployment
 func GenNatGwName(name string) string {
-	return fmt.Sprintf("%s-%s", VpcNatGwNamePrefix, name)
+	return GenNatGwNameWithPrefix(VpcNatGwNamePrefix, name)
+}
+
+// GenNatGwNameWithPrefix returns the full name of a NAT gateway StatefulSet/Deployment
+// with an explicit name prefix.
+func GenNatGwNameWithPrefix(prefix, name string) string {
+	if prefix == "" {
+		prefix = VpcNatGwNameDefaultPrefix
+	}
+	return fmt.Sprintf("%s-%s", prefix, name)
 }
 
 // GenNatGwPodName returns the full name of the NAT gateway pod within a StatefulSet
 func GenNatGwPodName(name string) string {
-	return fmt.Sprintf("%s-%s-0", VpcNatGwNamePrefix, name)
+	return GenNatGwPodNameWithPrefix(VpcNatGwNamePrefix, name)
+}
+
+// GenNatGwPodNameWithPrefix returns the full name of the NAT gateway pod within a StatefulSet
+// with an explicit name prefix.
+func GenNatGwPodNameWithPrefix(prefix, name string) string {
+	if prefix == "" {
+		prefix = VpcNatGwNameDefaultPrefix
+	}
+	return fmt.Sprintf("%s-%s-0", prefix, name)
 }
 
 // ValidateNatGwStatefulSetNameLength validates generated NAT GW StatefulSet name length.
 // This check is stricter than the plain 63-char label value limit because StatefulSet
 // controller appends a hash suffix to `controller-revision-hash` label values.
-func ValidateNatGwStatefulSetNameLength(gwName string) error {
-	statefulSetName := GenNatGwName(gwName)
+func ValidateNatGwStatefulSetNameLength(prefix, gwName string) error {
+	statefulSetName := GenNatGwNameWithPrefix(prefix, gwName)
 	if len(statefulSetName) > NatGwStatefulSetNameMaxLength {
 		return fmt.Errorf("generated NAT gateway statefulset name %q length %d exceeds max %d; choose a shorter NAT gateway name",
 			statefulSetName, len(statefulSetName), NatGwStatefulSetNameMaxLength)

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -219,6 +220,21 @@ func TestGenNatGwLabels(t *testing.T) {
 				t.Errorf("got %v, but want %v", result, tc.expected)
 			}
 		})
+	}
+}
+
+func TestValidateNatGwStatefulSetNameLength(t *testing.T) {
+	maxGwNameLen := NatGwStatefulSetNameMaxLength - len(VpcNatGwNamePrefix) - 1
+	validGwName := strings.Repeat("a", maxGwNameLen)
+	invalidGwName := strings.Repeat("a", maxGwNameLen+1)
+
+	if err := ValidateNatGwStatefulSetNameLength(validGwName); err != nil {
+		t.Fatalf("expected valid gateway name length, got error: %v", err)
+	}
+
+	err := ValidateNatGwStatefulSetNameLength(invalidGwName)
+	if err == nil {
+		t.Fatalf("expected error for overly long gateway name, got nil")
 	}
 }
 

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -224,15 +224,16 @@ func TestGenNatGwLabels(t *testing.T) {
 }
 
 func TestValidateNatGwStatefulSetNameLength(t *testing.T) {
-	maxGwNameLen := NatGwStatefulSetNameMaxLength - len(VpcNatGwNamePrefix) - 1
+	const explicitPrefix = "vpc-nat-gw"
+	maxGwNameLen := NatGwStatefulSetNameMaxLength - len(explicitPrefix) - 1
 	validGwName := strings.Repeat("a", maxGwNameLen)
 	invalidGwName := strings.Repeat("a", maxGwNameLen+1)
 
-	if err := ValidateNatGwStatefulSetNameLength(validGwName); err != nil {
+	if err := ValidateNatGwStatefulSetNameLength(explicitPrefix, validGwName); err != nil {
 		t.Fatalf("expected valid gateway name length, got error: %v", err)
 	}
 
-	err := ValidateNatGwStatefulSetNameLength(invalidGwName)
+	err := ValidateNatGwStatefulSetNameLength(explicitPrefix, invalidGwName)
 	if err == nil {
 		t.Fatalf("expected error for overly long gateway name, got nil")
 	}

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -319,6 +319,10 @@ func (v *ValidatingHook) iptablesFipUpdateHook(ctx context.Context, req admissio
 }
 
 func (v *ValidatingHook) ValidateVpcNatGW(ctx context.Context, gw *ovnv1.VpcNatGateway) error {
+	if err := util.ValidateNatGwStatefulSetNameLength(gw.Name); err != nil {
+		return err
+	}
+
 	if gw.Spec.Vpc == "" {
 		return errors.New("parameter \"vpc\" cannot be empty")
 	}

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -319,7 +319,11 @@ func (v *ValidatingHook) iptablesFipUpdateHook(ctx context.Context, req admissio
 }
 
 func (v *ValidatingHook) ValidateVpcNatGW(ctx context.Context, gw *ovnv1.VpcNatGateway) error {
-	if err := util.ValidateNatGwStatefulSetNameLength(gw.Name); err != nil {
+	prefix, err := v.getNatGwNamePrefix(ctx)
+	if err != nil {
+		return err
+	}
+	if err := util.ValidateNatGwStatefulSetNameLength(prefix, gw.Name); err != nil {
 		return err
 	}
 
@@ -377,6 +381,20 @@ func (v *ValidatingHook) ValidateVpcNatGW(ctx context.Context, gw *ovnv1.VpcNatG
 	}
 
 	return nil
+}
+
+func (v *ValidatingHook) getNatGwNamePrefix(ctx context.Context) (string, error) {
+	cm := &corev1.ConfigMap{}
+	cmKey := cli.ObjectKey{Namespace: metav1.NamespaceSystem, Name: util.VpcNatConfig}
+	if err := v.cache.Get(ctx, cmKey, cm); err != nil {
+		return "", err
+	}
+
+	prefix := strings.TrimSpace(cm.Data["natGwNamePrefix"])
+	if prefix == "" {
+		return util.VpcNatGwNameDefaultPrefix, nil
+	}
+	return prefix, nil
 }
 
 func (v *ValidatingHook) ValidateVpcNatGatewayConfig(ctx context.Context) error {


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

Prevent name/label length validation failures from surfacing late at StatefulSet/Pod creation time:

- add admission-time prevalidation for `VpcNatGateway` names based on generated StatefulSet name length constraints
- use Kubernetes official `validation.LabelValueMaxLength` as the source of truth for label-value max length
- add deterministic label normalization helper for overlong generated label values
- apply normalization to service-lb, vpc-lb, and vpc-egress-gateway workload labels to avoid runtime invalid label values
- add/extend unit tests for NAT gateway name-length validation and label normalization behavior

## Which issue(s) this PR fixes

Fixes #N/A
