### PR TITLE
fix(helm): fix pinger external-address and add v2 image overrides

### DIFF
--- a/charts/kube-ovn-v2/ct.yaml
+++ b/charts/kube-ovn-v2/ct.yaml
@@ -1,3 +1,4 @@
+charts: charts/kube-ovn-v2
 validate-maintainers: false
 check-version-increment: false
 namespace: kube-system

--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -199,5 +199,3 @@ nodeAffinity:
   {{- end }}
 {{- end -}}
 {{- end -}}
-=======
->>>>>>> Stashed changes

--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -148,6 +148,23 @@ Get IPs of master nodes from values
   {{- end -}}
 {{- end -}}
 
+{{- define "kubeovn.imageSpec" -}}
+  {{- $root := .root -}}
+  {{- $image := .image | default dict -}}
+  {{- $address := $root.Values.global.registry.address -}}
+  {{- if hasKey $image "registry" -}}
+    {{- $address = get $image "registry" -}}
+  {{- end -}}
+  {{- $repository := .defaultRepository | default $root.Values.global.images.kubeovn.repository -}}
+  {{- $tag := .defaultTag | default $root.Values.global.images.kubeovn.tag -}}
+  {{- dict
+      "address" $address
+      "repository" (get $image "repository" | default $repository)
+      "tag" (get $image "tag" | default $tag)
+      "pullPolicy" (get $image "pullPolicy" | default $root.Values.image.pullPolicy)
+    | toYaml -}}
+{{- end -}}
+
 {{/*
 Merge hardcoded node affinity expressions with user-provided values.
 Usage: include "kube-ovn.affinities.nodeAffinity" (dict "hardcodedPreferred" $hardcodedPreferred "hardcodedRequired" $hardcodedRequired "userPreferred" .Values.component.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.component.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution)

--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -151,14 +151,16 @@ Get IPs of master nodes from values
 {{- define "kubeovn.imageSpec" -}}
   {{- $root := .root -}}
   {{- $image := .image | default dict -}}
-  {{- $address := $root.Values.global.registry.address -}}
-  {{- if hasKey $image "registry" -}}
-    {{- $address = get $image "registry" -}}
-  {{- end -}}
+  {{- $address := get $image "registry" | default $root.Values.global.registry.address -}}
   {{- $repository := .defaultRepository | default $root.Values.global.images.kubeovn.repository -}}
   {{- $tag := .defaultTag | default $root.Values.global.images.kubeovn.tag -}}
+  {{- $prefix := "" -}}
+  {{- if $address -}}
+    {{- $prefix = printf "%s/" $address -}}
+  {{- end -}}
   {{- dict
       "address" $address
+      "prefix" $prefix
       "repository" (get $image "repository" | default $repository)
       "tag" (get $image "tag" | default $tag)
       "pullPolicy" (get $image "pullPolicy" | default $root.Values.image.pullPolicy)
@@ -197,3 +199,5 @@ nodeAffinity:
   {{- end }}
 {{- end -}}
 {{- end -}}
+=======
+>>>>>>> Stashed changes

--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- $agentImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.agent.image) | fromYaml -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -50,8 +51,8 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: hostpath-init
-        image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ $agentImage.address }}/{{ $agentImage.repository }}:{{ $agentImage.tag }}
+        imagePullPolicy: {{ $agentImage.pullPolicy }}
         command:
           - sh
           - -xec
@@ -78,8 +79,8 @@ spec:
           - name: kube-ovn-log
             mountPath: /var/log/kube-ovn
       - name: install-cni
-        image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ $agentImage.address }}/{{ $agentImage.repository }}:{{ $agentImage.tag }}
+        imagePullPolicy: {{ $agentImage.pullPolicy }}
         command:
           - /kube-ovn/install-cni.sh
           - --cni-conf-dir={{ .Values.cni.mountConfigDirectory }}
@@ -104,8 +105,8 @@ spec:
           {{- end }}
       containers:
       - name: cni-server
-        image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ $agentImage.address }}/{{ $agentImage.repository }}:{{ $agentImage.tag }}
+        imagePullPolicy: {{ $agentImage.pullPolicy }}
         command:
           - bash
           - /kube-ovn/start-cniserver.sh

--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -51,7 +51,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: hostpath-init
-        image: {{ $agentImage.address }}/{{ $agentImage.repository }}:{{ $agentImage.tag }}
+        image: {{ $agentImage.prefix }}{{ $agentImage.repository }}:{{ $agentImage.tag }}
         imagePullPolicy: {{ $agentImage.pullPolicy }}
         command:
           - sh
@@ -79,7 +79,7 @@ spec:
           - name: kube-ovn-log
             mountPath: /var/log/kube-ovn
       - name: install-cni
-        image: {{ $agentImage.address }}/{{ $agentImage.repository }}:{{ $agentImage.tag }}
+        image: {{ $agentImage.prefix }}{{ $agentImage.repository }}:{{ $agentImage.tag }}
         imagePullPolicy: {{ $agentImage.pullPolicy }}
         command:
           - /kube-ovn/install-cni.sh
@@ -105,7 +105,7 @@ spec:
           {{- end }}
       containers:
       - name: cni-server
-        image: {{ $agentImage.address }}/{{ $agentImage.repository }}:{{ $agentImage.tag }}
+        image: {{ $agentImage.prefix }}{{ $agentImage.repository }}:{{ $agentImage.tag }}
         imagePullPolicy: {{ $agentImage.pullPolicy }}
         command:
           - bash

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $centralImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.central.image) | fromYaml -}}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -63,8 +64,8 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $centralImage.address }}/{{ $centralImage.repository }}:{{ $centralImage.tag }}
+          imagePullPolicy: {{ $centralImage.pullPolicy }}
           command:
             - sh
             - -c
@@ -85,8 +86,8 @@ spec:
               name: host-log-ovn
       containers:
         - name: ovn-central
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $centralImage.address }}/{{ $centralImage.repository }}:{{ $centralImage.tag }}
+          imagePullPolicy: {{ $centralImage.pullPolicy }}
           command: 
           - bash
           - /kube-ovn/start-db.sh
@@ -186,4 +187,3 @@ spec:
           secret:
             optional: true
             secretName: kube-ovn-tls
-

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -64,7 +64,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ $centralImage.address }}/{{ $centralImage.repository }}:{{ $centralImage.tag }}
+          image: {{ $centralImage.prefix }}{{ $centralImage.repository }}:{{ $centralImage.tag }}
           imagePullPolicy: {{ $centralImage.pullPolicy }}
           command:
             - sh
@@ -86,7 +86,7 @@ spec:
               name: host-log-ovn
       containers:
         - name: ovn-central
-          image: {{ $centralImage.address }}/{{ $centralImage.repository }}:{{ $centralImage.tag }}
+          image: {{ $centralImage.prefix }}{{ $centralImage.repository }}:{{ $centralImage.tag }}
           imagePullPolicy: {{ $centralImage.pullPolicy }}
           command: 
           - bash

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $controllerImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.controller.image) | fromYaml -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,8 +63,8 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $controllerImage.address }}/{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
+          imagePullPolicy: {{ $controllerImage.pullPolicy }}
           command:
             - sh
             - -c
@@ -80,8 +81,8 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: kube-ovn-controller
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $controllerImage.address }}/{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
+          imagePullPolicy: {{ $controllerImage.pullPolicy }}
           args:
           - /kube-ovn/start-controller.sh
           - --default-ls={{ .Values.networking.pods.subnetName }}
@@ -159,7 +160,7 @@ spec:
           - --ovsdb-inactivity-timeout={{- .Values.features.OVSDB_INACTIVITY_TIMEOUT }}
           - --enable-live-migration-optimize={{- .Values.features.enableLiveMigrationOptimization }}
           - --enable-ovn-lb-prefer-local={{- .Values.features.ENABLE_OVN_LB_PREFER_LOCAL }}
-          - --image={{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
+          - --image={{ $controllerImage.address }}/{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
           - --non-primary-cni-mode={{- .Values.cni.nonPrimaryCNI }}
           - --np-enforcement={{- .Values.networkPolicies.enforcement | quote }}
           securityContext:
@@ -246,4 +247,3 @@ spec:
           secret:
             optional: true
             secretName: kube-ovn-tls
-

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -63,7 +63,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ $controllerImage.address }}/{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
+          image: {{ $controllerImage.prefix }}{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
           imagePullPolicy: {{ $controllerImage.pullPolicy }}
           command:
             - sh
@@ -81,7 +81,7 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: kube-ovn-controller
-          image: {{ $controllerImage.address }}/{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
+          image: {{ $controllerImage.prefix }}{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
           imagePullPolicy: {{ $controllerImage.pullPolicy }}
           args:
           - /kube-ovn/start-controller.sh
@@ -160,7 +160,7 @@ spec:
           - --ovsdb-inactivity-timeout={{- .Values.features.OVSDB_INACTIVITY_TIMEOUT }}
           - --enable-live-migration-optimize={{- .Values.features.enableLiveMigrationOptimization }}
           - --enable-ovn-lb-prefer-local={{- .Values.features.ENABLE_OVN_LB_PREFER_LOCAL }}
-          - --image={{ $controllerImage.address }}/{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
+          - --image={{ $controllerImage.prefix }}{{ $controllerImage.repository }}:{{ $controllerImage.tag }}
           - --non-primary-cni-mode={{- .Values.cni.nonPrimaryCNI }}
           - --np-enforcement={{- .Values.networkPolicies.enforcement | quote }}
           securityContext:

--- a/charts/kube-ovn-v2/templates/ic/ic-controller-deploy.yaml
+++ b/charts/kube-ovn-v2/templates/ic/ic-controller-deploy.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ $icImage.address }}/{{ $icImage.repository }}:{{ $icImage.tag }}
+          image: {{ $icImage.prefix }}{{ $icImage.repository }}:{{ $icImage.tag }}
           imagePullPolicy: {{ $icImage.pullPolicy }}
           command:
             - sh
@@ -71,7 +71,7 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: ovn-ic-controller
-          image: {{ $icImage.address }}/{{ $icImage.repository }}:{{ $icImage.tag }}
+          image: {{ $icImage.prefix }}{{ $icImage.repository }}:{{ $icImage.tag }}
           imagePullPolicy: {{ $icImage.pullPolicy }}
           command: ["/kube-ovn/start-ic-controller.sh"]
           args:

--- a/charts/kube-ovn-v2/templates/ic/ic-controller-deploy.yaml
+++ b/charts/kube-ovn-v2/templates/ic/ic-controller-deploy.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.features.enableOvnInterconnections }}
+{{- $icImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.ic.image) | fromYaml -}}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -48,8 +49,8 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $icImage.address }}/{{ $icImage.repository }}:{{ $icImage.tag }}
+          imagePullPolicy: {{ $icImage.pullPolicy }}
           command:
             - sh
             - -c
@@ -70,8 +71,8 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: ovn-ic-controller
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $icImage.address }}/{{ $icImage.repository }}:{{ $icImage.tag }}
+          imagePullPolicy: {{ $icImage.pullPolicy }}
           command: ["/kube-ovn/start-ic-controller.sh"]
           args:
           - --log_file=/var/log/kube-ovn/kube-ovn-ic-controller.log

--- a/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ $monitorImage.address }}/{{ $monitorImage.repository }}:{{ $monitorImage.tag }}
+          image: {{ $monitorImage.prefix }}{{ $monitorImage.repository }}:{{ $monitorImage.tag }}
           imagePullPolicy: {{ $monitorImage.pullPolicy }}
           command:
             - sh
@@ -80,7 +80,7 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: kube-ovn-monitor
-          image: {{ $monitorImage.address }}/{{ $monitorImage.repository }}:{{ $monitorImage.tag }}
+          image: {{ $monitorImage.prefix }}{{ $monitorImage.repository }}:{{ $monitorImage.tag }}
           imagePullPolicy: {{ $monitorImage.pullPolicy }}
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:

--- a/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $monitorImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.monitor.image) | fromYaml -}}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -61,8 +62,8 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $monitorImage.address }}/{{ $monitorImage.repository }}:{{ $monitorImage.tag }}
+          imagePullPolicy: {{ $monitorImage.pullPolicy }}
           command:
             - sh
             - -c
@@ -79,8 +80,8 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: kube-ovn-monitor
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $monitorImage.address }}/{{ $monitorImage.repository }}:{{ $monitorImage.tag }}
+          imagePullPolicy: {{ $monitorImage.pullPolicy }}
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:
           - --secure-serving={{- .Values.features.enableSecureServing }}

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- $ovsOvnImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.ovsOvn.image) | fromYaml -}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -63,8 +64,8 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $ovsOvnImage.address }}/{{ $ovsOvnImage.repository }}:{{ $ovsOvnImage.tag }}
+          imagePullPolicy: {{ $ovsOvnImage.pullPolicy }}
           command:
             - sh
             - -xec
@@ -104,8 +105,8 @@ spec:
               name: host-log-ovs
       containers:
         - name: openvswitch
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $ovsOvnImage.address }}/{{ $ovsOvnImage.repository }}:{{ $ovsOvnImage.tag }}
+          imagePullPolicy: {{ $ovsOvnImage.pullPolicy }}
           command: ["/kube-ovn/start-ovs.sh"]
           securityContext:
             runAsUser: {{ include "kubeovn.runAsUser" . }}

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -64,7 +64,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ $ovsOvnImage.address }}/{{ $ovsOvnImage.repository }}:{{ $ovsOvnImage.tag }}
+          image: {{ $ovsOvnImage.prefix }}{{ $ovsOvnImage.repository }}:{{ $ovsOvnImage.tag }}
           imagePullPolicy: {{ $ovsOvnImage.pullPolicy }}
           command:
             - sh
@@ -105,7 +105,7 @@ spec:
               name: host-log-ovs
       containers:
         - name: openvswitch
-          image: {{ $ovsOvnImage.address }}/{{ $ovsOvnImage.repository }}:{{ $ovsOvnImage.tag }}
+          image: {{ $ovsOvnImage.prefix }}{{ $ovsOvnImage.repository }}:{{ $ovsOvnImage.tag }}
           imagePullPolicy: {{ $ovsOvnImage.pullPolicy }}
           command: ["/kube-ovn/start-ovs.sh"]
           securityContext:

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ovsOvn.dpdkHybrid.enabled }}
+{{- $ovsOvnDpdkImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.ovsOvn.dpdkHybrid.image "defaultRepository" .Values.global.images.kubeovn.repository "defaultTag" .Values.ovsOvn.dpdkHybrid.tag) | fromYaml -}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -54,8 +55,8 @@ spec:
       hostPID: true
       containers:
         - name: openvswitch
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.ovsOvn.dpdkHybrid.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $ovsOvnDpdkImage.address }}/{{ $ovsOvnDpdkImage.repository }}:{{ $ovsOvnDpdkImage.tag }}
+          imagePullPolicy: {{ $ovsOvnDpdkImage.pullPolicy }}
           command: ["/kube-ovn/start-ovs-dpdk-v2.sh"]
           securityContext:
             runAsUser: 0

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
@@ -55,7 +55,7 @@ spec:
       hostPID: true
       containers:
         - name: openvswitch
-          image: {{ $ovsOvnDpdkImage.address }}/{{ $ovsOvnDpdkImage.repository }}:{{ $ovsOvnDpdkImage.tag }}
+          image: {{ $ovsOvnDpdkImage.prefix }}{{ $ovsOvnDpdkImage.repository }}:{{ $ovsOvnDpdkImage.tag }}
           imagePullPolicy: {{ $ovsOvnDpdkImage.pullPolicy }}
           command: ["/kube-ovn/start-ovs-dpdk-v2.sh"]
           securityContext:

--- a/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- $pingerImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.pinger.image) | fromYaml -}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -51,8 +52,8 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $pingerImage.address }}/{{ $pingerImage.repository }}:{{ $pingerImage.tag }}
+          imagePullPolicy: {{ $pingerImage.pullPolicy }}
           command:
             - sh
             - -c
@@ -69,7 +70,7 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: pinger
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
+          image: {{ $pingerImage.address }}/{{ $pingerImage.repository }}:{{ $pingerImage.tag }}
           command:
           - /kube-ovn/kube-ovn-pinger
           args:
@@ -80,7 +81,7 @@ spec:
           - --log_file=/var/log/kube-ovn/kube-ovn-pinger.log
           - --log_file_max_size=200
           - --enable-metrics={{- .Values.networking.enableMetrics }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ $pingerImage.pullPolicy }}
           securityContext:
             runAsUser: {{ include "kubeovn.runAsUser" . }}
             privileged: false

--- a/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ $pingerImage.address }}/{{ $pingerImage.repository }}:{{ $pingerImage.tag }}
+          image: {{ $pingerImage.prefix }}{{ $pingerImage.repository }}:{{ $pingerImage.tag }}
           imagePullPolicy: {{ $pingerImage.pullPolicy }}
           command:
             - sh
@@ -70,7 +70,7 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: pinger
-          image: {{ $pingerImage.address }}/{{ $pingerImage.repository }}:{{ $pingerImage.tag }}
+          image: {{ $pingerImage.prefix }}{{ $pingerImage.repository }}:{{ $pingerImage.tag }}
           command:
           - /kube-ovn/kube-ovn-pinger
           args:

--- a/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/pinger/pinger-daemonset.yaml
@@ -73,22 +73,8 @@ spec:
           command:
           - /kube-ovn/kube-ovn-pinger
           args:
-          - --external-address=
-          {{- if eq .Values.networking.stack "Dual" -}}
-          {{ .Values.pinger.targets.externalAddresses.v4 }},{{ .Values.pinger.targets.externalAddresses.v6 }}
-          {{- else if eq .Values.networking.stack "IPv4" -}}
-          {{ .Values.pinger.targets.externalAddresses.v4 }}
-          {{- else if eq .Values.networking.stack "IPv6" -}}
-          {{ .Values.pinger.targets.externalAddresses.v6 }}
-          {{- end }}
-          - --external-dns=
-          {{- if eq .Values.networking.stack "Dual" -}}
-          {{ .Values.pinger.targets.externalDomain.v6 }}
-          {{- else if eq .Values.networking.stack "IPv4" -}}
-          {{ .Values.pinger.targets.externalDomain.v4 }}
-          {{- else if eq .Values.networking.stack "IPv6" -}}
-          {{ .Values.pinger.targets.externalDomain.v6 }}
-          {{- end }}
+          - --external-address={{ if eq .Values.networking.stack "Dual" }}{{ .Values.pinger.targets.externalAddresses.v4 }},{{ .Values.pinger.targets.externalAddresses.v6 }}{{ else if eq .Values.networking.stack "IPv4" }}{{ .Values.pinger.targets.externalAddresses.v4 }}{{ else if eq .Values.networking.stack "IPv6" }}{{ .Values.pinger.targets.externalAddresses.v6 }}{{ end }}
+          - --external-dns={{ if eq .Values.networking.stack "Dual" }}{{ .Values.pinger.targets.externalDomain.v6 }}{{ else if eq .Values.networking.stack "IPv4" }}{{ .Values.pinger.targets.externalDomain.v4 }}{{ else if eq .Values.networking.stack "IPv6" }}{{ .Values.pinger.targets.externalDomain.v6 }}{{ end }}
           - --logtostderr=false
           - --alsologtostderr=true
           - --log_file=/var/log/kube-ovn/kube-ovn-pinger.log

--- a/charts/kube-ovn-v2/templates/speaker/speaker.yaml
+++ b/charts/kube-ovn-v2/templates/speaker/speaker.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.bgpSpeaker.enabled }}
+{{- $bgpSpeakerImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.bgpSpeaker.image) | fromYaml -}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -50,8 +51,8 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $bgpSpeakerImage.address }}/{{ $bgpSpeakerImage.repository }}:{{ $bgpSpeakerImage.tag }}
+          imagePullPolicy: {{ $bgpSpeakerImage.pullPolicy }}
           command:
             - sh
             - -c
@@ -68,8 +69,8 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: kube-ovn-speaker
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $bgpSpeakerImage.address }}/{{ $bgpSpeakerImage.repository }}:{{ $bgpSpeakerImage.tag }}
+          imagePullPolicy: {{ $bgpSpeakerImage.pullPolicy }}
           command:
             - /kube-ovn/kube-ovn-speaker
           args:

--- a/charts/kube-ovn-v2/templates/speaker/speaker.yaml
+++ b/charts/kube-ovn-v2/templates/speaker/speaker.yaml
@@ -51,7 +51,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: hostpath-init
-          image: {{ $bgpSpeakerImage.address }}/{{ $bgpSpeakerImage.repository }}:{{ $bgpSpeakerImage.tag }}
+          image: {{ $bgpSpeakerImage.prefix }}{{ $bgpSpeakerImage.repository }}:{{ $bgpSpeakerImage.tag }}
           imagePullPolicy: {{ $bgpSpeakerImage.pullPolicy }}
           command:
             - sh
@@ -69,7 +69,7 @@ spec:
               mountPath: /var/log/kube-ovn
       containers:
         - name: kube-ovn-speaker
-          image: {{ $bgpSpeakerImage.address }}/{{ $bgpSpeakerImage.repository }}:{{ $bgpSpeakerImage.tag }}
+          image: {{ $bgpSpeakerImage.prefix }}{{ $bgpSpeakerImage.repository }}:{{ $bgpSpeakerImage.tag }}
           imagePullPolicy: {{ $bgpSpeakerImage.pullPolicy }}
           command:
             - /kube-ovn/kube-ovn-speaker

--- a/charts/kube-ovn-v2/templates/webhook/webhook-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/webhook/webhook-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.validatingWebhook.enabled }}
+{{- $webhookImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.validatingWebhook.image) | fromYaml -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,8 +51,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kube-ovn-webhook
-          image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ $webhookImage.address }}/{{ $webhookImage.repository }}:{{ $webhookImage.tag }}
+          imagePullPolicy: {{ $webhookImage.pullPolicy }}
           command:
             - /kube-ovn/kube-ovn-webhook
           args:

--- a/charts/kube-ovn-v2/templates/webhook/webhook-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/webhook/webhook-deployment.yaml
@@ -51,7 +51,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kube-ovn-webhook
-          image: {{ $webhookImage.address }}/{{ $webhookImage.repository }}:{{ $webhookImage.tag }}
+          image: {{ $webhookImage.prefix }}{{ $webhookImage.repository }}:{{ $webhookImage.tag }}
           imagePullPolicy: {{ $webhookImage.pullPolicy }}
           command:
             - /kube-ovn/kube-ovn-webhook

--- a/charts/kube-ovn-v2/tests/component_image_overrides_test.yaml
+++ b/charts/kube-ovn-v2/tests/component_image_overrides_test.yaml
@@ -1,0 +1,37 @@
+suite: Component image overrides (v2)
+templates:
+  - controller/controller-deployment.yaml
+  - agent/agent-daemonset.yaml
+tests:
+  - it: overrides only the controller image
+    template: controller/controller-deployment.yaml
+    set:
+      masterNodes:
+        - "10.0.0.1"
+      controller.image.repository: kube-ovn-controller-dev
+      controller.image.tag: custom-controller
+      controller.image.registry: ghcr.io/example
+      controller.image.pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: ghcr.io/example/kube-ovn-controller-dev:custom-controller
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/example/kube-ovn-controller-dev:custom-controller
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --image=ghcr.io/example/kube-ovn-controller-dev:custom-controller
+
+  - it: keeps other components on the global image by default
+    template: agent/agent-daemonset.yaml
+    set:
+      masterNodes:
+        - "10.0.0.1"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/kubeovn/kube-ovn:v1.16.0

--- a/charts/kube-ovn-v2/tests/component_image_overrides_test.yaml
+++ b/charts/kube-ovn-v2/tests/component_image_overrides_test.yaml
@@ -34,4 +34,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/kubeovn/kube-ovn:v1.16.0
+          value: docker.io/kubeovn/kube-ovn:v1.17.0

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -277,6 +277,9 @@ validatingWebhook:
   # -- Enable the deployment of the validating webhook.
   # @section -- Validating webhook configuration
   enabled: false
+  # -- Override image settings for kube-ovn-webhook. Empty fields fall back to the global kube-ovn image.
+  # @section -- Validating webhook configuration
+  image: {}
   # -- Annotations to be added to all top-level kube-ovn-webhook objects (resources under templates/webhook)
   # @section -- Validating webhook configuration
   annotations: {}
@@ -383,6 +386,9 @@ apiNad:
 # @section -- OVS/OVN daemons configuration
 # @default -- "{}"
 ovsOvn:
+  # -- Override image settings for ovs-ovn. Empty fields fall back to the global kube-ovn image.
+  # @section -- OVS/OVN daemons configuration
+  image: {}
   # -- Annotations to be added to all top-level ovs-ovn objects (resources under templates/ovs-ovn)
   # @section -- OVS/OVN daemons configuration
   annotations: {}
@@ -467,6 +473,9 @@ ovsOvn:
     # -- Enables DPDK-hybrid support on OVS.
     # @section -- OVS/OVN daemons configuration
     enabled: false
+    # -- Override image settings for ovs-ovn-dpdk. Empty fields fall back to the global kube-ovn image and the DPDK tag below.
+    # @section -- OVS/OVN daemons configuration
+    image: {}
     # -- DPDK image tag.
     # @section -- OVS/OVN daemons configuration
     tag: v1.17.0
@@ -498,6 +507,9 @@ bgpSpeaker:
   # -- Enable the kube-ovn-speaker.
   # @section -- BGP speaker configuration
   enabled: false
+  # -- Override image settings for kube-ovn-speaker. Empty fields fall back to the global kube-ovn image.
+  # @section -- BGP speaker configuration
+  image: {}
   # -- Annotations to be added to all top-level kube-ovn-speaker objects (resources under templates/speaker)
   # @section -- BGP speaker configuration
   annotations: {}
@@ -543,6 +555,9 @@ bgpSpeaker:
 # @section -- Ping daemon configuration
 # @default -- "{}"
 pinger:
+  # -- Override image settings for kube-ovn-pinger. Empty fields fall back to the global kube-ovn image.
+  # @section -- Ping daemon configuration
+  image: {}
   # -- Annotations to be added to all top-level kube-ovn-pinger objects (resources under templates/pinger)
   # @section -- Ping daemon configuration
   annotations: {}
@@ -621,6 +636,9 @@ pinger:
 # @section -- OVN monitoring daemon configuration
 # @default -- "{}"
 monitor:
+  # -- Override image settings for kube-ovn-monitor. Empty fields fall back to the global kube-ovn image.
+  # @section -- OVN monitoring daemon configuration
+  image: {}
   # -- Annotations to be added to all top-level kube-ovn-monitor objects (resources under templates/monitor)
   # @section -- OVN monitoring daemon configuration
   annotations: {}
@@ -695,6 +713,9 @@ monitor:
 # @section -- Kube-OVN controller configuration
 # @default -- "{}"
 controller:
+  # -- Override image settings for kube-ovn-controller. Empty fields fall back to the global kube-ovn image.
+  # @section -- Kube-OVN controller configuration
+  image: {}
   # -- Annotations to be added to all top-level kube-ovn-controller objects (resources under templates/controller)
   # @section -- Kube-OVN controller configuration
   annotations: {}
@@ -769,6 +790,9 @@ controller:
 # @section -- OVN-central daemon configuration
 # @default -- "{}"
 central:
+  # -- Override image settings for ovn-central. Empty fields fall back to the global kube-ovn image.
+  # @section -- OVN-central daemon configuration
+  image: {}
   # -- Annotations to be added to all top-level ovn-central objects (resources under templates/central)
   # @section -- OVN-central daemon configuration
   annotations: {}
@@ -838,6 +862,9 @@ central:
 # @section -- OVN IC controller configuration
 # @default -- "{}"
 ic:
+  # -- Override image settings for the OVN IC controller. Empty fields fall back to the global kube-ovn image.
+  # @section -- OVN IC controller configuration
+  image: {}
   # -- Node affinity configuration for the OVN IC controller.
   # -- More information on formatting nodeAffinity can be found at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   # @section -- OVN IC controller configuration
@@ -871,6 +898,9 @@ ic:
 # @section -- CNI agent configuration
 # @default -- "{}"
 agent:
+  # -- Override image settings for kube-ovn-cni. Empty fields fall back to the global kube-ovn image.
+  # @section -- CNI agent configuration
+  image: {}
   # -- Annotations to be added to all top-level agent objects (resources under templates/agent)
   # @section -- CNI agent configuration
   annotations: {}

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -279,7 +279,19 @@ validatingWebhook:
   enabled: false
   # -- Override image settings for kube-ovn-webhook. Empty fields fall back to the global kube-ovn image.
   # @section -- Validating webhook configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- Validating webhook configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- Validating webhook configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- Validating webhook configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- Validating webhook configuration
+    pullPolicy: ""
   # -- Annotations to be added to all top-level kube-ovn-webhook objects (resources under templates/webhook)
   # @section -- Validating webhook configuration
   annotations: {}
@@ -388,7 +400,19 @@ apiNad:
 ovsOvn:
   # -- Override image settings for ovs-ovn. Empty fields fall back to the global kube-ovn image.
   # @section -- OVS/OVN daemons configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- OVS/OVN daemons configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- OVS/OVN daemons configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- OVS/OVN daemons configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- OVS/OVN daemons configuration
+    pullPolicy: ""
   # -- Annotations to be added to all top-level ovs-ovn objects (resources under templates/ovs-ovn)
   # @section -- OVS/OVN daemons configuration
   annotations: {}
@@ -475,7 +499,19 @@ ovsOvn:
     enabled: false
     # -- Override image settings for ovs-ovn-dpdk. Empty fields fall back to the global kube-ovn image and the DPDK tag below.
     # @section -- OVS/OVN daemons configuration
-    image: {}
+    image:
+      # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+      # @section -- OVS/OVN daemons configuration
+      registry: ""
+      # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+      # @section -- OVS/OVN daemons configuration
+      repository: ""
+      # -- Tag override for this component image. Defaults to `.ovsOvn.dpdkHybrid.tag`.
+      # @section -- OVS/OVN daemons configuration
+      tag: ""
+      # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+      # @section -- OVS/OVN daemons configuration
+      pullPolicy: ""
     # -- DPDK image tag.
     # @section -- OVS/OVN daemons configuration
     tag: v1.17.0
@@ -509,7 +545,19 @@ bgpSpeaker:
   enabled: false
   # -- Override image settings for kube-ovn-speaker. Empty fields fall back to the global kube-ovn image.
   # @section -- BGP speaker configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- BGP speaker configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- BGP speaker configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- BGP speaker configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- BGP speaker configuration
+    pullPolicy: ""
   # -- Annotations to be added to all top-level kube-ovn-speaker objects (resources under templates/speaker)
   # @section -- BGP speaker configuration
   annotations: {}
@@ -557,7 +605,19 @@ bgpSpeaker:
 pinger:
   # -- Override image settings for kube-ovn-pinger. Empty fields fall back to the global kube-ovn image.
   # @section -- Ping daemon configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- Ping daemon configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- Ping daemon configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- Ping daemon configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- Ping daemon configuration
+    pullPolicy: ""
   # -- Annotations to be added to all top-level kube-ovn-pinger objects (resources under templates/pinger)
   # @section -- Ping daemon configuration
   annotations: {}
@@ -638,7 +698,19 @@ pinger:
 monitor:
   # -- Override image settings for kube-ovn-monitor. Empty fields fall back to the global kube-ovn image.
   # @section -- OVN monitoring daemon configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- OVN monitoring daemon configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- OVN monitoring daemon configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- OVN monitoring daemon configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- OVN monitoring daemon configuration
+    pullPolicy: ""
   # -- Annotations to be added to all top-level kube-ovn-monitor objects (resources under templates/monitor)
   # @section -- OVN monitoring daemon configuration
   annotations: {}
@@ -715,7 +787,19 @@ monitor:
 controller:
   # -- Override image settings for kube-ovn-controller. Empty fields fall back to the global kube-ovn image.
   # @section -- Kube-OVN controller configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- Kube-OVN controller configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- Kube-OVN controller configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- Kube-OVN controller configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- Kube-OVN controller configuration
+    pullPolicy: ""
   # -- Annotations to be added to all top-level kube-ovn-controller objects (resources under templates/controller)
   # @section -- Kube-OVN controller configuration
   annotations: {}
@@ -792,7 +876,19 @@ controller:
 central:
   # -- Override image settings for ovn-central. Empty fields fall back to the global kube-ovn image.
   # @section -- OVN-central daemon configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- OVN-central daemon configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- OVN-central daemon configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- OVN-central daemon configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- OVN-central daemon configuration
+    pullPolicy: ""
   # -- Annotations to be added to all top-level ovn-central objects (resources under templates/central)
   # @section -- OVN-central daemon configuration
   annotations: {}
@@ -864,7 +960,19 @@ central:
 ic:
   # -- Override image settings for the OVN IC controller. Empty fields fall back to the global kube-ovn image.
   # @section -- OVN IC controller configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- OVN IC controller configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- OVN IC controller configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- OVN IC controller configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- OVN IC controller configuration
+    pullPolicy: ""
   # -- Node affinity configuration for the OVN IC controller.
   # -- More information on formatting nodeAffinity can be found at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   # @section -- OVN IC controller configuration
@@ -900,7 +1008,19 @@ ic:
 agent:
   # -- Override image settings for kube-ovn-cni. Empty fields fall back to the global kube-ovn image.
   # @section -- CNI agent configuration
-  image: {}
+  image:
+    # -- Registry override for this component image. This becomes the rendered image address. Defaults to `.global.registry.address`.
+    # @section -- CNI agent configuration
+    registry: ""
+    # -- Repository override for this component image. Defaults to `.global.images.kubeovn.repository`.
+    # @section -- CNI agent configuration
+    repository: ""
+    # -- Tag override for this component image. Defaults to `.global.images.kubeovn.tag`.
+    # @section -- CNI agent configuration
+    tag: ""
+    # -- Pull policy override for this component image. Defaults to `.image.pullPolicy`.
+    # @section -- CNI agent configuration
+    pullPolicy: ""
   # -- Annotations to be added to all top-level agent objects (resources under templates/agent)
   # @section -- CNI agent configuration
   annotations: {}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Features
- Bug fixes
- Tests

## Description

This PR updates the `kube-ovn-v2` chart to:

- fix the invalid `external-address` rendering for the pinger daemon
- allow per-component image overrides while keeping global kube-ovn image values as the default fallback
- simplify template image rendering by resolving image settings once per component
- limit chart-testing to `charts/kube-ovn-v2` only

The v2 chart now supports component-specific `registry`, `repository`, `tag`, and `pullPolicy` overrides for controller, agent, central, monitor, pinger, ovs-ovn, ovs-ovn DPDK, IC, BGP speaker, and validating webhook.

## Which issue(s) this PR fixes

Fixes #(issue-number)
