### PR TITLE
fix: limit vswitch client schema to core tables

### DIFF
--- a/pkg/ovs/ovs-vswitch.go
+++ b/pkg/ovs/ovs-vswitch.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/model"
 	"k8s.io/klog/v2"
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
@@ -18,10 +19,15 @@ type VswitchClient struct {
 
 // NewVswitchClient creates a new vswitch client
 func NewVswitchClient(addr string, connTimeout, transactTimeout int) (*VswitchClient, error) {
-	dbModel, err := vswitch.FullDatabaseModel()
+	dbModel, err := model.NewClientDBModel(vswitch.DatabaseName, map[string]model.Model{
+		vswitch.BridgeTable:      &vswitch.Bridge{},
+		vswitch.InterfaceTable:   &vswitch.Interface{},
+		vswitch.OpenvSwitchTable: &vswitch.OpenvSwitch{},
+		vswitch.PortTable:        &vswitch.Port{},
+	})
 	if err != nil {
 		klog.Error(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create client db model: %w", err)
 	}
 
 	monitors := []client.MonitorOption{

--- a/pkg/ovs/ovs-vswitch_test.go
+++ b/pkg/ovs/ovs-vswitch_test.go
@@ -1,0 +1,32 @@
+package ovs
+
+import (
+	"testing"
+
+	"github.com/ovn-kubernetes/libovsdb/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/vswitch"
+)
+
+func TestNewVswitchClientWithLegacySchema(t *testing.T) {
+	schema := vswitch.Schema()
+	delete(schema.Tables[vswitch.MirrorTable].Columns, "filter")
+	delete(schema.Tables[vswitch.FlowSampleCollectorSetTable].Columns, "local_group_id")
+
+	dbModel, err := model.NewClientDBModel(vswitch.DatabaseName, map[string]model.Model{
+		vswitch.BridgeTable:      &vswitch.Bridge{},
+		vswitch.InterfaceTable:   &vswitch.Interface{},
+		vswitch.OpenvSwitchTable: &vswitch.OpenvSwitch{},
+		vswitch.PortTable:        &vswitch.Port{},
+	})
+	require.NoError(t, err)
+
+	_, sock := newOVSDBServer(t, "legacy-vswitch", dbModel, schema)
+	client, err := NewVswitchClient("unix:"+sock, 1, 1)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	_, err = client.ListBridge(false, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- Use `model.NewClientDBModel` to explicitly specify only the 4 OVS vswitch tables (Bridge, Interface, Open_vSwitch, Port) that kube-ovn actually uses via libovsdb
- Replace `vswitch.FullDatabaseModel()` which loads all tables including unused ones like Mirror, Flow_Sample_Collector_Set
- Add regression test that simulates a legacy OVS schema missing `filter` and `local_group_id` columns

## Problem
During upgrade windows when kube-ovn-cni is newer than the node's local OVS schema, the full vswitch model validates columns that don't exist yet in the old schema, causing cni-server startup failure:
```
database Open_vSwitch validation error: Mapper Error. Object type vswitch.Mirror contains field Filter (*string) ovs tag filter: Column does not exist in schema
```

## Test plan
- [x] `go test ./pkg/ovs/ -run TestNewVswitchClientWithLegacySchema -v`
- [ ] Full CI pass