### PR TITLE
chore: update renovate branches to track release-1.16

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -152,8 +152,8 @@ else
   sed -ri 's#(\s+)(- master)#\1\2\n\1- '$RELEASE_BRANCH'#' .github/workflows/scheduled-e2e.yaml
 
   echo "update renovate.json: keep only master and the latest 2 release branches"
-  PREV_RELEASE_BRANCH=$(echo $RELEASE_BRANCH | awk -F '[.-]' '{print $1"-"$2"."$3-1}')
-  OLD_RELEASE_BRANCH=$(echo $RELEASE_BRANCH | awk -F '[.-]' '{print $1"-"$2"."$3-2}')
+  PREV_RELEASE_BRANCH=$(echo $RELEASE_BRANCH | awk -F '[.-]' '{print $1"-"$2"."($3-1)}')
+  OLD_RELEASE_BRANCH=$(echo $RELEASE_BRANCH | awk -F '[.-]' '{print $1"-"$2"."($3-2)}')
   sed -i 's/"'"$PREV_RELEASE_BRANCH"'"/"'"$RELEASE_BRANCH"'"/' renovate.json
   sed -i 's/"'"$OLD_RELEASE_BRANCH"'"/"'"$PREV_RELEASE_BRANCH"'"/' renovate.json
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -151,6 +151,13 @@ else
   sed -ri 's#(\s+)(- master)#\1\2\n\1- '$RELEASE_BRANCH'#' .github/workflows/build-kube-ovn-base-dpdk.yaml
   sed -ri 's#(\s+)(- master)#\1\2\n\1- '$RELEASE_BRANCH'#' .github/workflows/scheduled-e2e.yaml
 
+  echo "update renovate.json: keep only master and the latest 2 release branches"
+  PREV_RELEASE_BRANCH=$(echo $RELEASE_BRANCH | awk -F '[.-]' '{print $1"-"$2"."$3-1}')
+  OLD_RELEASE_BRANCH=$(echo $RELEASE_BRANCH | awk -F '[.-]' '{print $1"-"$2"."$3-2}')
+  sed -i 's/"'"$PREV_RELEASE_BRANCH"'"/"'"$RELEASE_BRANCH"'"/' renovate.json
+  sed -i 's/"'"$OLD_RELEASE_BRANCH"'"/"'"$PREV_RELEASE_BRANCH"'"/' renovate.json
+
+  git add renovate.json
   git add dist/images/install.sh
   git add charts/kube-ovn/values.yaml
   git add charts/kube-ovn/Chart.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,8 @@
   ],
   "baseBranchPatterns": [
     "master",
-    "release-1.15",
-    "release-1.14"
+    "release-1.16",
+    "release-1.15"
   ],
   "postUpdateOptions": [
     "gomodTidy"


### PR DESCRIPTION
## Summary
- Update `renovate.json` baseBranchPatterns: drop `release-1.14`, add `release-1.16` (keeping master + 2 most recent release branches)
- Add automatic `renovate.json` update logic to `hack/release.sh` so each minor release rotates the tracked branches automatically

## Test plan
- [ ] Verify `renovate.json` is valid JSON and baseBranchPatterns contains `[master, release-1.16, release-1.15]`
- [ ] Verify `hack/release.sh` awk computation produces correct branch names (tested locally: `release-1.16` → prev=`release-1.15`, old=`release-1.14`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)