### PR TITLE
feat(lb): enable ct_flush for UDP load balancers

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -1744,6 +1744,20 @@ func (mr *MockLoadBalancerMockRecorder) SetLoadBalancerAffinityTimeout(lbName, t
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerAffinityTimeout", reflect.TypeOf((*MockLoadBalancer)(nil).SetLoadBalancerAffinityTimeout), lbName, timeout)
 }
 
+// SetLoadBalancerCtFlush mocks base method.
+func (m *MockLoadBalancer) SetLoadBalancerCtFlush(lbName string, ctFlush bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLoadBalancerCtFlush", lbName, ctFlush)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLoadBalancerCtFlush indicates an expected call of SetLoadBalancerCtFlush.
+func (mr *MockLoadBalancerMockRecorder) SetLoadBalancerCtFlush(lbName, ctFlush any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerCtFlush", reflect.TypeOf((*MockLoadBalancer)(nil).SetLoadBalancerCtFlush), lbName, ctFlush)
+}
+
 // SetLoadBalancerPreferLocalBackend mocks base method.
 func (m *MockLoadBalancer) SetLoadBalancerPreferLocalBackend(lbName string, preferLocalBackend bool) error {
 	m.ctrl.T.Helper()
@@ -5392,6 +5406,20 @@ func (m *MockNbClient) SetLoadBalancerAffinityTimeout(lbName string, timeout int
 func (mr *MockNbClientMockRecorder) SetLoadBalancerAffinityTimeout(lbName, timeout any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerAffinityTimeout", reflect.TypeOf((*MockNbClient)(nil).SetLoadBalancerAffinityTimeout), lbName, timeout)
+}
+
+// SetLoadBalancerCtFlush mocks base method.
+func (m *MockNbClient) SetLoadBalancerCtFlush(lbName string, ctFlush bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLoadBalancerCtFlush", lbName, ctFlush)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLoadBalancerCtFlush indicates an expected call of SetLoadBalancerCtFlush.
+func (mr *MockNbClientMockRecorder) SetLoadBalancerCtFlush(lbName, ctFlush any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerCtFlush", reflect.TypeOf((*MockNbClient)(nil).SetLoadBalancerCtFlush), lbName, ctFlush)
 }
 
 // SetLoadBalancerPreferLocalBackend mocks base method.

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -286,6 +286,13 @@ func (c *Controller) initLB(name, protocol string, sessionAffinity bool) error {
 		return err
 	}
 
+	if protocol == "udp" {
+		if err = c.OVNNbClient.SetLoadBalancerCtFlush(name, true); err != nil {
+			klog.Errorf("failed to set ct_flush for load balancer %s: %v", name, err)
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -110,7 +110,7 @@ func (c *Controller) handleAddOvnDnatRule(key string) error {
 		return err
 	}
 
-	if cachedDnat.Status.Ready && cachedDnat.Status.V4Ip != "" {
+	if cachedDnat.Status.Ready && (cachedDnat.Status.V4Ip != "" || cachedDnat.Status.V6Ip != "") {
 		// backfill ct_flush for existing UDP DNAT load balancers
 		if strings.EqualFold(cachedDnat.Spec.Protocol, "udp") {
 			if err = c.OVNNbClient.SetLoadBalancerCtFlush(cachedDnat.Name, true); err != nil {

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -110,7 +111,13 @@ func (c *Controller) handleAddOvnDnatRule(key string) error {
 	}
 
 	if cachedDnat.Status.Ready && cachedDnat.Status.V4Ip != "" {
-		// already ok
+		// backfill ct_flush for existing UDP DNAT load balancers
+		if strings.EqualFold(cachedDnat.Spec.Protocol, "udp") {
+			if err = c.OVNNbClient.SetLoadBalancerCtFlush(cachedDnat.Name, true); err != nil {
+				klog.Errorf("failed to set ct_flush for load balancer %s: %v", cachedDnat.Name, err)
+				return err
+			}
+		}
 		return nil
 	}
 	klog.Infof("handle add dnat %s", key)
@@ -604,6 +611,13 @@ func (c *Controller) AddDnatRule(vpcName, dnatName, externalIP, internalIP, exte
 	if err = c.OVNNbClient.CreateLoadBalancer(dnatName, protocol); err != nil {
 		klog.Errorf("create loadBalancer %s: %v", dnatName, err)
 		return err
+	}
+
+	if strings.EqualFold(protocol, "udp") {
+		if err = c.OVNNbClient.SetLoadBalancerCtFlush(dnatName, true); err != nil {
+			klog.Errorf("failed to set ct_flush for load balancer %s: %v", dnatName, err)
+			return err
+		}
 	}
 
 	if err = c.OVNNbClient.LoadBalancerAddVip(dnatName, externalEndpoint, internalEndpoint); err != nil {

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -140,6 +140,7 @@ type LoadBalancer interface {
 	LoadBalancerDeleteHealthCheck(lbName, uuid string) error
 	SetLoadBalancerAffinityTimeout(lbName string, timeout int) error
 	SetLoadBalancerPreferLocalBackend(lbName string, preferLocalBackend bool) error
+	SetLoadBalancerCtFlush(lbName string, ctFlush bool) error
 	DeleteLoadBalancers(filter func(lb *ovnnb.LoadBalancer) bool) error
 	GetLoadBalancer(lbName string, ignoreNotFound bool) (*ovnnb.LoadBalancer, error)
 	ListLoadBalancers(filter func(lb *ovnnb.LoadBalancer) bool) ([]ovnnb.LoadBalancer, error)

--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -268,6 +268,41 @@ func (c *OVNNbClient) SetLoadBalancerPreferLocalBackend(lbName string, preferLoc
 	return nil
 }
 
+// SetLoadBalancerCtFlush sets the LB's ct_flush option to flush conntrack entries when backends are removed
+func (c *OVNNbClient) SetLoadBalancerCtFlush(lbName string, ctFlush bool) error {
+	var (
+		options map[string]string
+		lb      *ovnnb.LoadBalancer
+		value   string
+		err     error
+	)
+
+	if lb, err = c.GetLoadBalancer(lbName, false); err != nil {
+		klog.Errorf("failed to get lb: %v", err)
+		return err
+	}
+
+	if ctFlush {
+		value = "true"
+	} else {
+		value = "false"
+	}
+	if len(lb.Options) != 0 && lb.Options["ct_flush"] == value {
+		return nil
+	}
+
+	options = make(map[string]string, len(lb.Options)+1)
+	maps.Copy(options, lb.Options)
+	options["ct_flush"] = value
+
+	lb.Options = options
+	if err = c.UpdateLoadBalancer(lb, &lb.Options); err != nil {
+		klog.Error(err)
+		return fmt.Errorf("failed to set ct_flush of lb %s to %s: %w", lbName, value, err)
+	}
+	return nil
+}
+
 // DeleteLoadBalancers delete several loadbalancer once
 func (c *OVNNbClient) DeleteLoadBalancers(filter func(lb *ovnnb.LoadBalancer) bool) error {
 	var (

--- a/pkg/ovs/ovn-nb-load_balancer_test.go
+++ b/pkg/ovs/ovn-nb-load_balancer_test.go
@@ -392,6 +392,88 @@ func (suite *OvnClientTestSuite) testSetLoadBalancerAffinityTimeout() {
 	)
 }
 
+func (suite *OvnClientTestSuite) testSetLoadBalancerCtFlush() {
+	t := suite.T()
+	t.Parallel()
+
+	nbClient := suite.ovnNBClient
+	lbName := "test-set-lb-ct-flush"
+
+	err := nbClient.CreateLoadBalancer(lbName, "udp")
+	require.NoError(t, err)
+
+	lb, err := nbClient.GetLoadBalancer(lbName, false)
+	require.NoError(t, err)
+
+	oldOptions := make(map[string]string, 1)
+	oldOptions["affinity_timeout"] = "30"
+	lb.Options = oldOptions
+	err = nbClient.UpdateLoadBalancer(lb, &lb.Options)
+	require.NoError(t, err)
+
+	t.Run("set ct_flush to true", func(t *testing.T) {
+		err := nbClient.SetLoadBalancerCtFlush(lbName, true)
+		require.NoError(t, err)
+
+		lb, err := nbClient.GetLoadBalancer(lbName, false)
+		require.NoError(t, err)
+
+		require.Equal(t, "true", lb.Options["ct_flush"])
+		require.Equal(t, "30", lb.Options["affinity_timeout"])
+	})
+
+	t.Run("set ct_flush to true repeatedly", func(t *testing.T) {
+		err := nbClient.SetLoadBalancerCtFlush(lbName, true)
+		require.NoError(t, err)
+
+		lb, err := nbClient.GetLoadBalancer(lbName, false)
+		require.NoError(t, err)
+
+		require.Equal(t, "true", lb.Options["ct_flush"])
+	})
+
+	t.Run("set ct_flush to false", func(t *testing.T) {
+		err := nbClient.SetLoadBalancerCtFlush(lbName, false)
+		require.NoError(t, err)
+
+		lb, err := nbClient.GetLoadBalancer(lbName, false)
+		require.NoError(t, err)
+
+		require.Equal(t, "false", lb.Options["ct_flush"])
+	})
+
+	t.Run("set ct_flush when multiple load balancer exist",
+		func(t *testing.T) {
+			lbName := "test-set-lb-ct-flush-dup"
+
+			lb1 := &ovnnb.LoadBalancer{
+				UUID:     ovsclient.NamedUUID(),
+				Name:     lbName,
+				Protocol: ptr.To(ovnnb.LoadBalancerProtocolUDP),
+			}
+			ops, err := nbClient.Create(lb1)
+			require.NoError(t, err)
+			require.NotNil(t, ops)
+			err = nbClient.Transact("lb-add", ops)
+			require.NoError(t, err)
+
+			lb2 := &ovnnb.LoadBalancer{
+				UUID:     ovsclient.NamedUUID(),
+				Name:     lbName,
+				Protocol: ptr.To(ovnnb.LoadBalancerProtocolUDP),
+			}
+			ops, err = nbClient.Create(lb2)
+			require.NoError(t, err)
+			require.NotNil(t, ops)
+			err = nbClient.Transact("lb-add", ops)
+			require.NoError(t, err)
+
+			err = nbClient.SetLoadBalancerCtFlush(lbName, true)
+			require.ErrorContains(t, err, "more than one load balancer with same name")
+		},
+	)
+}
+
 func (suite *OvnClientTestSuite) testLoadBalancerAddVip() {
 	t := suite.T()
 	t.Parallel()

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -559,6 +559,10 @@ func (suite *OvnClientTestSuite) Test_SetLoadBalancerAffinityTimeout() {
 	suite.testSetLoadBalancerAffinityTimeout()
 }
 
+func (suite *OvnClientTestSuite) Test_SetLoadBalancerCtFlush() {
+	suite.testSetLoadBalancerCtFlush()
+}
+
 func (suite *OvnClientTestSuite) Test_LoadBalancerAddIPPortMapping() {
 	suite.testLoadBalancerAddIPPortMapping()
 }


### PR DESCRIPTION
## Summary
- Add `SetLoadBalancerCtFlush` to set OVN per-LB `ct_flush=true` option, which automatically flushes conntrack entries when backends are removed from a load balancer
- Enable `ct_flush` for all UDP load balancers: VPC-level Service LBs (via `initLB`), DNAT LBs (via `AddDnatRule`), and existing ready DNAT rules (backfill on controller restart)
- This prevents UDP traffic blackholing during Service rolling updates, where stale conntrack entries continue forwarding packets to deleted backends for 30-120 seconds until conntrack timeout

## Background
OVN 23.06+ supports per-LB `ct_flush` configuration. When enabled, OVN automatically clears conntrack state for removed backends. This is only needed for UDP — TCP/SCTP connections terminate naturally. Kube-OVN uses OVN branch-25.03 which fully supports this feature. Reference: [ovn-org/ovn-kubernetes#6201](https://github.com/ovn-org/ovn-kubernetes/pull/6201)

## Test plan
- [x] Unit tests for `SetLoadBalancerCtFlush` (set true, idempotency, toggle false, duplicate LB error)
- [x] `make lint` passes with 0 issues
- [x] `make ut` passes for `pkg/ovs` and `pkg/controller`
- [ ] E2E: deploy UDP Service, rolling update pods, verify no traffic loss during backend transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)