### PR TITLE
fix(underlay): wait for localnet patch port before IPv6 DAD

### DIFF
--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -322,12 +322,17 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			}
 		}
 
+		var localnetSubnet string
+		if subnetHasVlan && !podSubnet.Spec.LogicalGateway {
+			localnetSubnet = subnet
+		}
+
 		switch nicType {
 		case util.DpdkType:
 			err = csh.configureDpdkNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, getShortSharedDir(pod.UID, podRequest.VhostUserSocketVolumeName), podRequest.VhostUserSocketName, podRequest.VhostUserSocketConsumption)
 			routes = nil
 		default:
-			routes, err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, vmMigration, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, podRequest.DeviceID, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP, oldPodName, encapIP)
+			routes, err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, vmMigration, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, podRequest.DeviceID, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet)
 		}
 		if err != nil {
 			errMsg := fmt.Errorf("configure nic %s for pod %s/%s failed: %w", ifName, podRequest.PodName, podRequest.PodNamespace, err)

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -71,7 +71,7 @@ func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, ne
 	return ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress)
 }
 
-func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, _, _ []string, ingress, egress, deviceID, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, oldPodName, encapIP string) ([]request.Route, error) {
+func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, _, _ []string, ingress, egress, deviceID, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet string) ([]request.Route, error) {
 	var err error
 	var hostNicName, containerNicName, pfPci string
 	var vfID int
@@ -256,6 +256,18 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 		return nil, err
 	}
 
+	// For underlay subnets, wait for the localnet patch port to be created by
+	// ovn-controller before configuring the container NIC. This ensures L2
+	// connectivity is established before kernel IPv6 DAD sends Neighbor
+	// Solicitation packets, preventing false DAD success due to NS packets
+	// being black-holed when the patch port does not yet exist.
+	if localnetSubnet != "" {
+		if err := waitForLocalnetPatchPort(localnetSubnet); err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+	}
+
 	podNS, err := ns.GetNS(netns)
 	if err != nil {
 		err = fmt.Errorf("failed to open netns %q: %w", netns, err)
@@ -268,6 +280,16 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 		return nil, err
 	}
 	return finalRoutes, nil
+}
+
+func waitForLocalnetPatchPort(subnetName string) error {
+	patchPort := fmt.Sprintf("patch-localnet.%s-to-br-int", subnetName)
+	klog.Infof("waiting for localnet patch port %s to be ready", patchPort)
+	if _, err := ovs.Exec("wait-until", "interface", patchPort, "name="+patchPort); err != nil {
+		return fmt.Errorf("timeout waiting for localnet patch port %s: %w", patchPort, err)
+	}
+	klog.Infof("localnet patch port %s is ready", patchPort)
+	return nil
 }
 
 func (csh cniServerHandler) releaseVf(podName, podNamespace, podNetns, ifName, nicType, deviceID string) error {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -286,7 +286,7 @@ func waitForLocalnetPatchPort(subnetName string) error {
 	patchPort := fmt.Sprintf("patch-localnet.%s-to-br-int", subnetName)
 	klog.Infof("waiting for localnet patch port %s to be ready", patchPort)
 	if _, err := ovs.Exec("wait-until", "interface", patchPort, "name="+patchPort); err != nil {
-		return fmt.Errorf("timeout waiting for localnet patch port %s: %w", patchPort, err)
+		return fmt.Errorf("failed waiting for localnet patch port %s: %w", patchPort, err)
 	}
 	klog.Infof("localnet patch port %s is ready", patchPort)
 	return nil


### PR DESCRIPTION
## Summary
- In underlay subnets, kernel IPv6 DAD can run before the localnet patch port (created asynchronously by ovn-controller) is ready, causing DAD Neighbor Solicitation packets to be silently dropped and duplicate address conflicts to go undetected.
- Added `waitForLocalnetPatchPort()` using `ovs-vsctl wait-until` to block until the localnet patch port exists in OVS, placed after `ovn-installed=true` and before container NIC configuration.
- The fix only applies to underlay subnets (`subnetHasVlan && !LogicalGateway`); overlay subnets are unaffected.

## Background
CI run [24277706062](https://github.com/kubeovn/kube-ovn/actions/runs/24277706062) showed the underlay E2E test "should be able to detect duplicate address" failing intermittently in IPv6 mode. Root cause: a 383ms race window between IPv6 address assignment (kernel DAD starts) and localnet patch port creation (L2 connectivity established).

## Test plan
- [ ] Existing E2E: `[CNI:Kube-OVN] [group:underlay] should be able to detect duplicate address` should pass reliably in IPv6 mode
- [ ] Verify overlay subnet pod creation is not affected (no localnet wait)
- [ ] Verify underlay subnet pod creation still works correctly with the added wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)