### PR TITLE
fix(e2e): wait for BFD port status to be cleared in VPC egress gateway test

### DIFF
--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -289,9 +289,11 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 			ginkgo.By("Disabling BFD Port for VPC " + vpcName)
 			patchedVpc := updatedVpc.DeepCopy()
 			patchedVpc.Spec.BFDPort = nil
-			updatedVpc := vpcClient.PatchSync(updatedVpc, patchedVpc, 10*time.Second)
-			framework.ExpectEmpty(updatedVpc.Status.BFDPort.Name)
-			framework.ExpectEmpty(updatedVpc.Status.BFDPort.Nodes)
+			vpcClient.PatchSync(updatedVpc, patchedVpc, 10*time.Second)
+			framework.WaitUntil(time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+				vpc := vpcClient.Get(vpcName)
+				return vpc.Status.BFDPort.Name == "" && len(vpc.Status.BFDPort.Nodes) == 0, nil
+			}, "BFD port status to be cleared for VPC "+vpcName)
 		})
 
 		framework.ExpectNotEmpty(updatedVpc.Status.BFDPort.Name)


### PR DESCRIPTION
## Summary
- Fix flaky VPC Egress Gateway E2E test (`should be able to create vpc-egress-gateway with underlay subnet`) that fails intermittently in DeferCleanup
- Root cause: VPC controller updates status in two phases — first setting `Standby=true`, then clearing `BFDPort` — creating a race window where `PatchSync` returns before BFDPort is cleared
- Replace immediate `ExpectEmpty` assertions with a polling `WaitUntil` (30s timeout) that explicitly waits for `BFDPort.Name` and `BFDPort.Nodes` to be empty

## Test plan
- [ ] VPC Egress Gateway E2E (ipv4) passes consistently
- [ ] VPC Egress Gateway E2E (ipv6) passes consistently
- [ ] VPC Egress Gateway E2E (dual) passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)