### PR TITLE
fix(test): rename SlrInfo to SwitchLBRuleInfo in switch_lb_rule_test

### DIFF
--- a/pkg/controller/switch_lb_rule_test.go
+++ b/pkg/controller/switch_lb_rule_test.go
@@ -245,7 +245,7 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		// Second call: after LBHC deletion, no more LBHCs for this subnet
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
 
-		info := &SlrInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
+		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
 		require.NoError(t, err)
 
@@ -276,7 +276,7 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		fc.mockOvnClient.EXPECT().DeleteLoadBalancerHealthChecks(gomock.Any()).Return(nil)
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
 
-		info := &SlrInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
+		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
 		require.NoError(t, err)
 
@@ -312,7 +312,7 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 			}}, nil,
 		)
 
-		info := &SlrInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
+		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
 		require.NoError(t, err)
 
@@ -329,7 +329,7 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		// Fallback: no LBHC for subnet after deletion check
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
 
-		info := &SlrInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
+		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
 		require.NoError(t, err)
 
@@ -355,7 +355,7 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		// After deletion, no more LBHCs for this subnet
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
 
-		info := &SlrInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1, vip2}}
+		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1, vip2}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- PR #6580 renamed `SlrInfo` → `SwitchLBRuleInfo` but missed `pkg/controller/switch_lb_rule_test.go`, breaking `make ut` on master with 5 `undefined: SlrInfo` errors.
- This patch updates the 5 remaining references in the test file to fix the build.

## Test plan
- [x] `go vet ./pkg/controller/...` passes
- [x] `make lint` reports 0 issues
- [ ] CI `Build kube-ovn` / Unit test job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)