### PR TITLE
fix(controller): serialize centralized subnet reconcile in node update path

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -570,7 +570,10 @@ func (c *Controller) handleUpdateNode(key string) error {
 		}
 
 		if util.GatewayContains(cachedSubnet.Spec.GatewayNode, node.Name) {
-			if err := c.reconcileOvnDefaultVpcRoute(cachedSubnet); err != nil {
+			err = c.withSubnetLock(cachedSubnet.Name, func() error {
+				return c.reconcileOvnDefaultVpcRoute(cachedSubnet.DeepCopy())
+			})
+			if err != nil {
 				klog.Error(err)
 				return err
 			}
@@ -613,6 +616,12 @@ func (c *Controller) checkSubnetGateway() {
 	}
 }
 
+func (c *Controller) withSubnetLock(subnetName string, fn func() error) error {
+	c.subnetKeyMutex.LockKey(subnetName)
+	defer func() { _ = c.subnetKeyMutex.UnlockKey(subnetName) }()
+	return fn()
+}
+
 func (c *Controller) checkSubnetGatewayNode() error {
 	klog.V(3).Infoln("start to check subnet gateway node")
 	subnetList, err := c.subnetsLister.List(labels.Everything())
@@ -640,87 +649,93 @@ func (c *Controller) checkSubnetGatewayNode() error {
 			continue
 		}
 
-		for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
-			nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
-			if err != nil {
-				klog.Errorf("failed to get ecmp policy route paras for subnet %s: %v", subnet.Name, err)
-				continue
-			}
-			for _, node := range nodes {
-				ipStr := node.Annotations[util.IPAddressAnnotation]
-				for ip := range strings.SplitSeq(ipStr, ",") {
-					if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) {
-						continue
-					}
-
-					exist := nameIPMap[node.Name] == ip
-					if util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
-						pinger, err := goping.NewPinger(ip)
-						if err != nil {
-							return fmt.Errorf("failed to init pinger, %w", err)
-						}
-						pinger.SetPrivileged(true)
-
-						count := 5
-						pinger.Count = count
-						pinger.Timeout = time.Duration(count) * time.Second
-						pinger.Interval = 1 * time.Second
-
-						var pingSucceeded bool
-						pinger.OnRecv = func(_ *goping.Packet) {
-							pingSucceeded = true
-							pinger.Stop()
-						}
-						if err = pinger.Run(); err != nil {
-							klog.Errorf("failed to run pinger for destination %s: %v", ip, err)
-							return err
+		err = c.withSubnetLock(subnet.Name, func() error {
+			for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+				nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
+				if err != nil {
+					klog.Errorf("failed to get ecmp policy route paras for subnet %s: %v", subnet.Name, err)
+					continue
+				}
+				for _, node := range nodes {
+					ipStr := node.Annotations[util.IPAddressAnnotation]
+					for ip := range strings.SplitSeq(ipStr, ",") {
+						if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) {
+							continue
 						}
 
-						nodeIsReady := nodeReady(node)
-						if !pingSucceeded || !nodeIsReady {
-							if exist {
-								if !pingSucceeded {
-									klog.Warningf("failed to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
+						exist := nameIPMap[node.Name] == ip
+						if util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
+							pinger, err := goping.NewPinger(ip)
+							if err != nil {
+								return fmt.Errorf("failed to init pinger, %w", err)
+							}
+							pinger.SetPrivileged(true)
+
+							count := 5
+							pinger.Count = count
+							pinger.Timeout = time.Duration(count) * time.Second
+							pinger.Interval = 1 * time.Second
+
+							var pingSucceeded bool
+							pinger.OnRecv = func(_ *goping.Packet) {
+								pingSucceeded = true
+								pinger.Stop()
+							}
+							if err = pinger.Run(); err != nil {
+								klog.Errorf("failed to run pinger for destination %s: %v", ip, err)
+								return err
+							}
+
+							nodeIsReady := nodeReady(node)
+							if !pingSucceeded || !nodeIsReady {
+								if exist {
+									if !pingSucceeded {
+										klog.Warningf("failed to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
+									}
+									if !nodeIsReady {
+										klog.Warningf("node %s is not ready", node.Name)
+									}
+									klog.Warningf("delete ecmp policy route for node %s ip %s", node.Name, ip)
+									nextHops.Remove(ip)
+									delete(nameIPMap, node.Name)
+									klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+									if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+										klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+										return err
+									}
 								}
-								if !nodeIsReady {
-									klog.Warningf("node %s is not ready", node.Name)
-								}
-								klog.Warningf("delete ecmp policy route for node %s ip %s", node.Name, ip)
-								nextHops.Remove(ip)
-								delete(nameIPMap, node.Name)
-								klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-								if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-									klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-									return err
+							} else {
+								klog.V(3).Infof("succeeded to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
+								if !exist {
+									nextHops.Add(ip)
+									if nameIPMap == nil {
+										nameIPMap = make(map[string]string, 1)
+									}
+									nameIPMap[node.Name] = ip
+									klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+									if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+										klog.Errorf("failed to add ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+										return err
+									}
 								}
 							}
-						} else {
-							klog.V(3).Infof("succeeded to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
-							if !exist {
-								nextHops.Add(ip)
-								if nameIPMap == nil {
-									nameIPMap = make(map[string]string, 1)
-								}
-								nameIPMap[node.Name] = ip
-								klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-								if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-									klog.Errorf("failed to add ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-									return err
-								}
+						} else if exist {
+							klog.Infof("subnet %s gateway nodes does not contain node %s, delete policy route for node ip %s", subnet.Name, node.Name, ip)
+							nextHops.Remove(ip)
+							delete(nameIPMap, node.Name)
+							klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+							if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+								klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+								return err
 							}
-						}
-					} else if exist {
-						klog.Infof("subnet %s gateway nodes does not contain node %s, delete policy route for node ip %s", subnet.Name, node.Name, ip)
-						nextHops.Remove(ip)
-						delete(nameIPMap, node.Name)
-						klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-						if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-							klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-							return err
 						}
 					}
 				}
 			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -974,44 +989,50 @@ func (c *Controller) deletePolicyRouteForNode(nodeName, portName string) error {
 		}
 
 		if subnet.Spec.GatewayType == kubeovnv1.GWCentralizedType {
-			if subnet.Spec.EnableEcmp {
-				for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
-					nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
-					if err != nil {
-						klog.Errorf("get ecmp policy route paras for subnet %v, error %v", subnet.Name, err)
-						continue
-					}
+			err = c.withSubnetLock(subnet.Name, func() error {
+				if subnet.Spec.EnableEcmp {
+					for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+						nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
+						if err != nil {
+							klog.Errorf("get ecmp policy route paras for subnet %v, error %v", subnet.Name, err)
+							continue
+						}
 
-					exist := false
-					if _, ok := nameIPMap[nodeName]; ok {
-						exist = true
-					}
+						exist := false
+						if _, ok := nameIPMap[nodeName]; ok {
+							exist = true
+						}
 
-					if exist {
-						nextHops.Remove(nameIPMap[nodeName])
-						delete(nameIPMap, nodeName)
+						if exist {
+							nextHops.Remove(nameIPMap[nodeName])
+							delete(nameIPMap, nodeName)
 
-						if nextHops.Size() == 0 {
-							klog.Infof("delete policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-							if err := c.deletePolicyRouteForCentralizedSubnet(subnet); err != nil {
-								klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
-								return err
-							}
-						} else {
-							klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-							if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-								klog.Errorf("failed to update policy route for subnet %s on node %s, %v", subnet.Name, nodeName, err)
-								return err
+							if nextHops.Size() == 0 {
+								klog.Infof("delete policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+								if err := c.deletePolicyRouteForCentralizedSubnet(subnet); err != nil {
+									klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
+									return err
+								}
+							} else {
+								klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+								if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+									klog.Errorf("failed to update policy route for subnet %s on node %s, %v", subnet.Name, nodeName, err)
+									return err
+								}
 							}
 						}
 					}
+				} else {
+					klog.Infof("reconcile policy route for centralized subnet %s", subnet.Name)
+					if err := c.reconcileDefaultCentralizedSubnetRouteInDefaultVpc(subnet); err != nil {
+						klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
+						return err
+					}
 				}
-			} else {
-				klog.Infof("reconcile policy route for centralized subnet %s", subnet.Name)
-				if err := c.reconcileDefaultCentralizedSubnetRouteInDefaultVpc(subnet); err != nil {
-					klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
-					return err
-				}
+				return nil
+			})
+			if err != nil {
+				return err
 			}
 		}
 	}
@@ -1029,49 +1050,55 @@ func (c *Controller) addPolicyRouteForCentralizedSubnetOnNode(node *v1.Node, nod
 		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType {
 			continue
 		}
-		nodeName := node.Name
-		if subnet.Spec.EnableEcmp {
-			if !util.GatewayContains(subnet.Spec.GatewayNode, nodeName) &&
-				(subnet.Spec.GatewayNode != "" || !util.MatchLabelSelectors(subnet.Spec.GatewayNodeSelectors, node.Labels)) {
-				continue
-			}
+		err = c.withSubnetLock(subnet.Name, func() error {
+			nodeName := node.Name
+			if subnet.Spec.EnableEcmp {
+				if !util.GatewayContains(subnet.Spec.GatewayNode, nodeName) &&
+					(subnet.Spec.GatewayNode != "" || !util.MatchLabelSelectors(subnet.Spec.GatewayNodeSelectors, node.Labels)) {
+					return nil
+				}
 
-			for nextHop := range strings.SplitSeq(nodeIP, ",") {
-				for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
-					if util.CheckProtocol(cidrBlock) != util.CheckProtocol(nextHop) {
-						continue
-					}
+				for nextHop := range strings.SplitSeq(nodeIP, ",") {
+					for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+						if util.CheckProtocol(cidrBlock) != util.CheckProtocol(nextHop) {
+							continue
+						}
 
-					nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
-					if err != nil {
-						klog.Errorf("get ecmp policy route paras for subnet %v, error %v", subnet.Name, err)
-						continue
-					}
-					if nameIPMap[nodeName] == nextHop {
-						continue
-					}
+						nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
+						if err != nil {
+							klog.Errorf("get ecmp policy route paras for subnet %v, error %v", subnet.Name, err)
+							continue
+						}
+						if nameIPMap[nodeName] == nextHop {
+							continue
+						}
 
-					nextHops.Add(nextHop)
-					if nameIPMap == nil {
-						nameIPMap = make(map[string]string, 1)
-					}
-					nameIPMap[nodeName] = nextHop
-					klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-					if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-						klog.Errorf("failed to update policy route for subnet %s on node %s, %v", subnet.Name, nodeName, err)
-						return err
+						nextHops.Add(nextHop)
+						if nameIPMap == nil {
+							nameIPMap = make(map[string]string, 1)
+						}
+						nameIPMap[nodeName] = nextHop
+						klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+						if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+							klog.Errorf("failed to update policy route for subnet %s on node %s, %v", subnet.Name, nodeName, err)
+							return err
+						}
 					}
 				}
+			} else {
+				if subnet.Status.ActivateGateway != nodeName {
+					return nil
+				}
+				klog.Infof("add policy route for centralized subnet %s, on node %s, ip %s", subnet.Name, nodeName, nodeIP)
+				if err = c.addPolicyRouteForCentralizedSubnet(subnet, nodeName, nil, strings.Split(nodeIP, ",")); err != nil {
+					klog.Errorf("failed to add active-backup policy route for centralized subnet %s: %v", subnet.Name, err)
+					return err
+				}
 			}
-		} else {
-			if subnet.Status.ActivateGateway != nodeName {
-				continue
-			}
-			klog.Infof("add policy route for centralized subnet %s, on node %s, ip %s", subnet.Name, nodeName, nodeIP)
-			if err = c.addPolicyRouteForCentralizedSubnet(subnet, nodeName, nil, strings.Split(nodeIP, ",")); err != nil {
-				klog.Errorf("failed to add active-backup policy route for centralized subnet %s: %v", subnet.Name, err)
-				return err
-			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -570,9 +570,11 @@ func (c *Controller) handleUpdateNode(key string) error {
 		}
 
 		if util.GatewayContains(cachedSubnet.Spec.GatewayNode, node.Name) {
-			err = c.withSubnetLock(cachedSubnet.Name, func() error {
+			c.subnetKeyMutex.LockKey(cachedSubnet.Name)
+			err = func() error {
+				defer func() { _ = c.subnetKeyMutex.UnlockKey(cachedSubnet.Name) }()
 				return c.reconcileOvnDefaultVpcRoute(cachedSubnet.DeepCopy())
-			})
+			}()
 			if err != nil {
 				klog.Error(err)
 				return err
@@ -611,30 +613,157 @@ func (c *Controller) syncDistributedSubnetRoutes() {
 }
 
 func (c *Controller) checkSubnetGateway() {
-	if err := c.checkSubnetGatewayNode(); err != nil {
+	checkResults, nodes, err := c.checkSubnetGatewayNode()
+	if err != nil {
 		klog.Errorf("failed to check subnet gateway node: %v", err)
+		return
+	}
+	if err = c.applySubnetGatewayNode(checkResults, nodes); err != nil {
+		klog.Errorf("failed to apply subnet gateway node policy: %v", err)
 	}
 }
 
-func (c *Controller) withSubnetLock(subnetName string, fn func() error) error {
-	c.subnetKeyMutex.LockKey(subnetName)
-	defer func() { _ = c.subnetKeyMutex.UnlockKey(subnetName) }()
-	return fn()
+type subnetGatewayPingState struct {
+	pingSucceeded bool
+	nodeIsReady   bool
 }
 
-func (c *Controller) checkSubnetGatewayNode() error {
+type subnetGatewayCIDRCheckResult struct {
+	subnet     *kubeovnv1.Subnet
+	cidrBlock  string
+	pingStates map[string]subnetGatewayPingState
+}
+
+func subnetGatewayStateKey(nodeName, ip string) string {
+	return nodeName + "/" + ip
+}
+
+func (c *Controller) probeSubnetGatewayIPs(subnet *kubeovnv1.Subnet, cidrBlock string, nodes []*v1.Node) (map[string]subnetGatewayPingState, error) {
+	pingStates := make(map[string]subnetGatewayPingState, len(nodes))
+	for _, node := range nodes {
+		ipStr := node.Annotations[util.IPAddressAnnotation]
+		for ip := range strings.SplitSeq(ipStr, ",") {
+			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) || !util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
+				continue
+			}
+
+			pingSucceeded := false
+			pinger, err := goping.NewPinger(ip)
+			if err != nil {
+				return nil, fmt.Errorf("failed to init pinger, %w", err)
+			}
+			pinger.SetPrivileged(true)
+
+			count := 5
+			pinger.Count = count
+			pinger.Timeout = time.Duration(count) * time.Second
+			pinger.Interval = 1 * time.Second
+
+			pinger.OnRecv = func(_ *goping.Packet) {
+				pingSucceeded = true
+				pinger.Stop()
+			}
+			if err = pinger.Run(); err != nil {
+				klog.Errorf("failed to run pinger for destination %s: %v", ip, err)
+				return nil, err
+			}
+			if pingSucceeded {
+				klog.V(3).Infof("succeeded to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
+			}
+
+			pingStates[subnetGatewayStateKey(node.Name, ip)] = subnetGatewayPingState{
+				pingSucceeded: pingSucceeded,
+				nodeIsReady:   nodeReady(node),
+			}
+		}
+	}
+
+	return pingStates, nil
+}
+
+func (c *Controller) applySubnetGatewayCIDRPolicy(subnet *kubeovnv1.Subnet, cidrBlock string, nodes []*v1.Node, pingStates map[string]subnetGatewayPingState) (bool, error) {
+	getRouteParamsFailed := false
+	c.subnetKeyMutex.LockKey(subnet.Name)
+	defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
+
+	nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
+	if err != nil {
+		klog.Errorf("failed to get ecmp policy route paras for subnet %s: %v", subnet.Name, err)
+		getRouteParamsFailed = true
+		return getRouteParamsFailed, nil
+	}
+
+	for _, node := range nodes {
+		ipStr := node.Annotations[util.IPAddressAnnotation]
+		for ip := range strings.SplitSeq(ipStr, ",") {
+			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) {
+				continue
+			}
+
+			exist := nameIPMap[node.Name] == ip
+			if util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
+				state := pingStates[subnetGatewayStateKey(node.Name, ip)]
+				if !state.pingSucceeded || !state.nodeIsReady {
+					if exist {
+						if !state.pingSucceeded {
+							klog.Warningf("failed to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
+						}
+						if !state.nodeIsReady {
+							klog.Warningf("node %s is not ready", node.Name)
+						}
+						klog.Warningf("delete ecmp policy route for node %s ip %s", node.Name, ip)
+						nextHops.Remove(ip)
+						delete(nameIPMap, node.Name)
+						klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+						if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+							klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+							return false, err
+						}
+					}
+				} else {
+					if !exist {
+						nextHops.Add(ip)
+						if nameIPMap == nil {
+							nameIPMap = make(map[string]string, 1)
+						}
+						nameIPMap[node.Name] = ip
+						klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+						if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+							klog.Errorf("failed to add ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+							return false, err
+						}
+					}
+				}
+			} else if exist {
+				klog.Infof("subnet %s gateway nodes does not contain node %s, delete policy route for node ip %s", subnet.Name, node.Name, ip)
+				nextHops.Remove(ip)
+				delete(nameIPMap, node.Name)
+				klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+				if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+					klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+					return false, err
+				}
+			}
+		}
+	}
+
+	return getRouteParamsFailed, nil
+}
+
+func (c *Controller) checkSubnetGatewayNode() ([]subnetGatewayCIDRCheckResult, []*v1.Node, error) {
 	klog.V(3).Infoln("start to check subnet gateway node")
 	subnetList, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets: %v", err)
-		return err
+		return nil, nil, err
 	}
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list nodes: %v", err)
-		return err
+		return nil, nil, err
 	}
 
+	checkResults := make([]subnetGatewayCIDRCheckResult, 0, len(subnetList))
 	for _, subnet := range subnetList {
 		if (subnet.Spec.Vlan != "" && (subnet.Spec.U2OInterconnection || !subnet.Spec.LogicalGateway)) ||
 			subnet.Spec.Vpc != c.config.ClusterRouter ||
@@ -649,95 +778,33 @@ func (c *Controller) checkSubnetGatewayNode() error {
 			continue
 		}
 
-		err = c.withSubnetLock(subnet.Name, func() error {
-			for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
-				nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
-				if err != nil {
-					klog.Errorf("failed to get ecmp policy route paras for subnet %s: %v", subnet.Name, err)
-					continue
-				}
-				for _, node := range nodes {
-					ipStr := node.Annotations[util.IPAddressAnnotation]
-					for ip := range strings.SplitSeq(ipStr, ",") {
-						if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) {
-							continue
-						}
-
-						exist := nameIPMap[node.Name] == ip
-						if util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
-							pinger, err := goping.NewPinger(ip)
-							if err != nil {
-								return fmt.Errorf("failed to init pinger, %w", err)
-							}
-							pinger.SetPrivileged(true)
-
-							count := 5
-							pinger.Count = count
-							pinger.Timeout = time.Duration(count) * time.Second
-							pinger.Interval = 1 * time.Second
-
-							var pingSucceeded bool
-							pinger.OnRecv = func(_ *goping.Packet) {
-								pingSucceeded = true
-								pinger.Stop()
-							}
-							if err = pinger.Run(); err != nil {
-								klog.Errorf("failed to run pinger for destination %s: %v", ip, err)
-								return err
-							}
-
-							nodeIsReady := nodeReady(node)
-							if !pingSucceeded || !nodeIsReady {
-								if exist {
-									if !pingSucceeded {
-										klog.Warningf("failed to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
-									}
-									if !nodeIsReady {
-										klog.Warningf("node %s is not ready", node.Name)
-									}
-									klog.Warningf("delete ecmp policy route for node %s ip %s", node.Name, ip)
-									nextHops.Remove(ip)
-									delete(nameIPMap, node.Name)
-									klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-									if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-										klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-										return err
-									}
-								}
-							} else {
-								klog.V(3).Infof("succeeded to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
-								if !exist {
-									nextHops.Add(ip)
-									if nameIPMap == nil {
-										nameIPMap = make(map[string]string, 1)
-									}
-									nameIPMap[node.Name] = ip
-									klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-									if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-										klog.Errorf("failed to add ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-										return err
-									}
-								}
-							}
-						} else if exist {
-							klog.Infof("subnet %s gateway nodes does not contain node %s, delete policy route for node ip %s", subnet.Name, node.Name, ip)
-							nextHops.Remove(ip)
-							delete(nameIPMap, node.Name)
-							klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-							if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-								klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-								return err
-							}
-						}
-					}
-				}
+		for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+			pingStates, err := c.probeSubnetGatewayIPs(subnet, cidrBlock, nodes)
+			if err != nil {
+				return nil, nil, err
 			}
-			return nil
-		})
+			checkResults = append(checkResults, subnetGatewayCIDRCheckResult{
+				subnet:     subnet,
+				cidrBlock:  cidrBlock,
+				pingStates: pingStates,
+			})
+		}
+	}
+
+	return checkResults, nodes, nil
+}
+
+func (c *Controller) applySubnetGatewayNode(checkResults []subnetGatewayCIDRCheckResult, nodes []*v1.Node) error {
+	for _, checkResult := range checkResults {
+		getRouteParamsFailed, err := c.applySubnetGatewayCIDRPolicy(checkResult.subnet, checkResult.cidrBlock, nodes, checkResult.pingStates)
 		if err != nil {
 			return err
 		}
+		if getRouteParamsFailed {
+			continue
+		}
 	}
+
 	return nil
 }
 
@@ -989,7 +1056,9 @@ func (c *Controller) deletePolicyRouteForNode(nodeName, portName string) error {
 		}
 
 		if subnet.Spec.GatewayType == kubeovnv1.GWCentralizedType {
-			err = c.withSubnetLock(subnet.Name, func() error {
+			c.subnetKeyMutex.LockKey(subnet.Name)
+			err = func() error {
+				defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
 				if subnet.Spec.EnableEcmp {
 					for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
 						nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
@@ -1030,7 +1099,7 @@ func (c *Controller) deletePolicyRouteForNode(nodeName, portName string) error {
 					}
 				}
 				return nil
-			})
+			}()
 			if err != nil {
 				return err
 			}
@@ -1050,7 +1119,9 @@ func (c *Controller) addPolicyRouteForCentralizedSubnetOnNode(node *v1.Node, nod
 		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType {
 			continue
 		}
-		err = c.withSubnetLock(subnet.Name, func() error {
+		c.subnetKeyMutex.LockKey(subnet.Name)
+		err = func() error {
+			defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
 			nodeName := node.Name
 			if subnet.Spec.EnableEcmp {
 				if !util.GatewayContains(subnet.Spec.GatewayNode, nodeName) &&
@@ -1096,7 +1167,7 @@ func (c *Controller) addPolicyRouteForCentralizedSubnetOnNode(node *v1.Node, nod
 				}
 			}
 			return nil
-		})
+		}()
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -613,157 +613,24 @@ func (c *Controller) syncDistributedSubnetRoutes() {
 }
 
 func (c *Controller) checkSubnetGateway() {
-	checkResults, nodes, err := c.checkSubnetGatewayNode()
-	if err != nil {
+	if err := c.checkSubnetGatewayNode(); err != nil {
 		klog.Errorf("failed to check subnet gateway node: %v", err)
-		return
-	}
-	if err = c.applySubnetGatewayNode(checkResults, nodes); err != nil {
-		klog.Errorf("failed to apply subnet gateway node policy: %v", err)
 	}
 }
 
-type subnetGatewayPingState struct {
-	pingSucceeded bool
-	nodeIsReady   bool
-}
-
-type subnetGatewayCIDRCheckResult struct {
-	subnet     *kubeovnv1.Subnet
-	cidrBlock  string
-	pingStates map[string]subnetGatewayPingState
-}
-
-func subnetGatewayStateKey(nodeName, ip string) string {
-	return nodeName + "/" + ip
-}
-
-func (c *Controller) probeSubnetGatewayIPs(subnet *kubeovnv1.Subnet, cidrBlock string, nodes []*v1.Node) (map[string]subnetGatewayPingState, error) {
-	pingStates := make(map[string]subnetGatewayPingState, len(nodes))
-	for _, node := range nodes {
-		ipStr := node.Annotations[util.IPAddressAnnotation]
-		for ip := range strings.SplitSeq(ipStr, ",") {
-			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) || !util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
-				continue
-			}
-
-			pingSucceeded := false
-			pinger, err := goping.NewPinger(ip)
-			if err != nil {
-				return nil, fmt.Errorf("failed to init pinger, %w", err)
-			}
-			pinger.SetPrivileged(true)
-
-			count := 5
-			pinger.Count = count
-			pinger.Timeout = time.Duration(count) * time.Second
-			pinger.Interval = 1 * time.Second
-
-			pinger.OnRecv = func(_ *goping.Packet) {
-				pingSucceeded = true
-				pinger.Stop()
-			}
-			if err = pinger.Run(); err != nil {
-				klog.Errorf("failed to run pinger for destination %s: %v", ip, err)
-				return nil, err
-			}
-			if pingSucceeded {
-				klog.V(3).Infof("succeeded to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
-			}
-
-			pingStates[subnetGatewayStateKey(node.Name, ip)] = subnetGatewayPingState{
-				pingSucceeded: pingSucceeded,
-				nodeIsReady:   nodeReady(node),
-			}
-		}
-	}
-
-	return pingStates, nil
-}
-
-func (c *Controller) applySubnetGatewayCIDRPolicy(subnet *kubeovnv1.Subnet, cidrBlock string, nodes []*v1.Node, pingStates map[string]subnetGatewayPingState) (bool, error) {
-	getRouteParamsFailed := false
-	c.subnetKeyMutex.LockKey(subnet.Name)
-	defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
-
-	nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
-	if err != nil {
-		klog.Errorf("failed to get ecmp policy route paras for subnet %s: %v", subnet.Name, err)
-		getRouteParamsFailed = true
-		return getRouteParamsFailed, nil
-	}
-
-	for _, node := range nodes {
-		ipStr := node.Annotations[util.IPAddressAnnotation]
-		for ip := range strings.SplitSeq(ipStr, ",") {
-			if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) {
-				continue
-			}
-
-			exist := nameIPMap[node.Name] == ip
-			if util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
-				state := pingStates[subnetGatewayStateKey(node.Name, ip)]
-				if !state.pingSucceeded || !state.nodeIsReady {
-					if exist {
-						if !state.pingSucceeded {
-							klog.Warningf("failed to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
-						}
-						if !state.nodeIsReady {
-							klog.Warningf("node %s is not ready", node.Name)
-						}
-						klog.Warningf("delete ecmp policy route for node %s ip %s", node.Name, ip)
-						nextHops.Remove(ip)
-						delete(nameIPMap, node.Name)
-						klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-						if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-							klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-							return false, err
-						}
-					}
-				} else {
-					if !exist {
-						nextHops.Add(ip)
-						if nameIPMap == nil {
-							nameIPMap = make(map[string]string, 1)
-						}
-						nameIPMap[node.Name] = ip
-						klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-						if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-							klog.Errorf("failed to add ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-							return false, err
-						}
-					}
-				}
-			} else if exist {
-				klog.Infof("subnet %s gateway nodes does not contain node %s, delete policy route for node ip %s", subnet.Name, node.Name, ip)
-				nextHops.Remove(ip)
-				delete(nameIPMap, node.Name)
-				klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-				if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-					klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-					return false, err
-				}
-			}
-		}
-	}
-
-	return getRouteParamsFailed, nil
-}
-
-func (c *Controller) checkSubnetGatewayNode() ([]subnetGatewayCIDRCheckResult, []*v1.Node, error) {
+func (c *Controller) checkSubnetGatewayNode() error {
 	klog.V(3).Infoln("start to check subnet gateway node")
 	subnetList, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets: %v", err)
-		return nil, nil, err
+		return err
 	}
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list nodes: %v", err)
-		return nil, nil, err
+		return err
 	}
 
-	checkResults := make([]subnetGatewayCIDRCheckResult, 0, len(subnetList))
 	for _, subnet := range subnetList {
 		if (subnet.Spec.Vlan != "" && (subnet.Spec.U2OInterconnection || !subnet.Spec.LogicalGateway)) ||
 			subnet.Spec.Vpc != c.config.ClusterRouter ||
@@ -779,29 +646,109 @@ func (c *Controller) checkSubnetGatewayNode() ([]subnetGatewayCIDRCheckResult, [
 		}
 
 		for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
-			pingStates, err := c.probeSubnetGatewayIPs(subnet, cidrBlock, nodes)
-			if err != nil {
-				return nil, nil, err
+			skipCIDR := false
+			for _, node := range nodes {
+				if skipCIDR {
+					break
+				}
+
+				ipStr := node.Annotations[util.IPAddressAnnotation]
+				for ip := range strings.SplitSeq(ipStr, ",") {
+					if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) {
+						continue
+					}
+
+					isGateway := util.GatewayContains(subnet.Spec.GatewayNode, node.Name)
+					pingSucceeded := false
+					nodeIsReady := nodeReady(node)
+					if isGateway {
+						pinger, err := goping.NewPinger(ip)
+						if err != nil {
+							return fmt.Errorf("failed to init pinger, %w", err)
+						}
+						pinger.SetPrivileged(true)
+
+						count := 5
+						pinger.Count = count
+						pinger.Timeout = time.Duration(count) * time.Second
+						pinger.Interval = 1 * time.Second
+
+						pinger.OnRecv = func(_ *goping.Packet) {
+							pingSucceeded = true
+							pinger.Stop()
+						}
+						if err = pinger.Run(); err != nil {
+							klog.Errorf("failed to run pinger for destination %s: %v", ip, err)
+							return err
+						}
+						if pingSucceeded {
+							klog.V(3).Infof("succeeded to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
+						}
+					}
+
+					err = func() error {
+						c.subnetKeyMutex.LockKey(subnet.Name)
+						defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
+
+						nextHops, nameIPMap, err := c.getPolicyRouteParams(cidrBlock, util.GatewayRouterPolicyPriority)
+						if err != nil {
+							klog.Errorf("failed to get ecmp policy route paras for subnet %s: %v", subnet.Name, err)
+							skipCIDR = true
+							return nil
+						}
+
+						exist := nameIPMap[node.Name] == ip
+						if isGateway {
+							if !pingSucceeded || !nodeIsReady {
+								if exist {
+									if !pingSucceeded {
+										klog.Warningf("failed to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
+									}
+									if !nodeIsReady {
+										klog.Warningf("node %s is not ready", node.Name)
+									}
+									klog.Warningf("delete ecmp policy route for node %s ip %s", node.Name, ip)
+									nextHops.Remove(ip)
+									delete(nameIPMap, node.Name)
+									klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+									if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+										klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+										return err
+									}
+								}
+							} else if !exist {
+								nextHops.Add(ip)
+								if nameIPMap == nil {
+									nameIPMap = make(map[string]string, 1)
+								}
+								nameIPMap[node.Name] = ip
+								klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+								if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+									klog.Errorf("failed to add ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+									return err
+								}
+							}
+						} else if exist {
+							klog.Infof("subnet %s gateway nodes does not contain node %s, delete policy route for node ip %s", subnet.Name, node.Name, ip)
+							nextHops.Remove(ip)
+							delete(nameIPMap, node.Name)
+							klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+							if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+								klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+								return err
+							}
+						}
+
+						return nil
+					}()
+					if err != nil {
+						return err
+					}
+					if skipCIDR {
+						break
+					}
+				}
 			}
-			checkResults = append(checkResults, subnetGatewayCIDRCheckResult{
-				subnet:     subnet,
-				cidrBlock:  cidrBlock,
-				pingStates: pingStates,
-			})
-		}
-	}
-
-	return checkResults, nodes, nil
-}
-
-func (c *Controller) applySubnetGatewayNode(checkResults []subnetGatewayCIDRCheckResult, nodes []*v1.Node) error {
-	for _, checkResult := range checkResults {
-		getRouteParamsFailed, err := c.applySubnetGatewayCIDRPolicy(checkResult.subnet, checkResult.cidrBlock, nodes, checkResult.pingStates)
-		if err != nil {
-			return err
-		}
-		if getRouteParamsFailed {
-			continue
 		}
 	}
 


### PR DESCRIPTION
## Problem
Concurrent handleUpdateNode workers may reconcile the same centralized subnet simultaneously. This can cause policy-route updates to overwrite each other.
<img width="1022" height="303" alt="企业微信截图_17758112665291" src="https://github.com/user-attachments/assets/8d52a00e-c6e5-49cf-a3c4-fd8ccc2a3228" />

## Fix
- Add subnet-scoped locking in handleUpdateNode before calling reconcileOvnDefaultVpcRoute.
- Use defer to guarantee lock release.

## Validation
- go test ./pkg/controller -run TestNonExistent -count=1 (compile-level check)