### PR TITLE
feat(qos): support configurable ingress/egress burst via annotation

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -711,6 +711,8 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 
 	if oldPod.Annotations[util.IngressRateAnnotation] != newPod.Annotations[util.IngressRateAnnotation] ||
 		oldPod.Annotations[util.EgressRateAnnotation] != newPod.Annotations[util.EgressRateAnnotation] ||
+		oldPod.Annotations[util.IngressBurstAnnotation] != newPod.Annotations[util.IngressBurstAnnotation] ||
+		oldPod.Annotations[util.EgressBurstAnnotation] != newPod.Annotations[util.EgressBurstAnnotation] ||
 		oldPod.Annotations[util.NetemQosLatencyAnnotation] != newPod.Annotations[util.NetemQosLatencyAnnotation] ||
 		oldPod.Annotations[util.NetemQosJitterAnnotation] != newPod.Annotations[util.NetemQosJitterAnnotation] ||
 		oldPod.Annotations[util.NetemQosLimitAnnotation] != newPod.Annotations[util.NetemQosLimitAnnotation] ||
@@ -730,6 +732,8 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 		if newPod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] == "true" {
 			if oldPod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)] != newPod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)] ||
 				oldPod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)] != newPod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)] ||
+				oldPod.Annotations[fmt.Sprintf(util.IngressBurstAnnotationTemplate, provider)] != newPod.Annotations[fmt.Sprintf(util.IngressBurstAnnotationTemplate, provider)] ||
+				oldPod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, provider)] != newPod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, provider)] ||
 				oldPod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)] != newPod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)] ||
 				oldPod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)] != newPod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)] ||
 				oldPod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)] != newPod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)] ||

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -885,7 +885,9 @@ func (c *Controller) handleUpdatePod(key string) error {
 	ifaceID := ovs.PodNameToPortName(podName, pod.Namespace, util.OvnProvider)
 	ovsIngress := pod.Annotations[util.EgressRateAnnotation]
 	ovsEgress := pod.Annotations[util.IngressRateAnnotation]
-	err = ovs.SetInterfaceBandwidth(podName, pod.Namespace, ifaceID, ovsIngress, ovsEgress)
+	ovsIngressBurst := pod.Annotations[util.EgressBurstAnnotation]
+	ovsEgressBurst := pod.Annotations[util.IngressBurstAnnotation]
+	err = ovs.SetInterfaceBandwidth(podName, pod.Namespace, ifaceID, ovsIngress, ovsEgress, ovsIngressBurst, ovsEgressBurst)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -919,7 +921,11 @@ func (c *Controller) handleUpdatePod(key string) error {
 		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] == "true" {
 			ifaceID = ovs.PodNameToPortName(podName, pod.Namespace, provider)
 
-			err = ovs.SetInterfaceBandwidth(podName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)])
+			err = ovs.SetInterfaceBandwidth(podName, pod.Namespace, ifaceID,
+				pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)],
+				pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)],
+				pod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, provider)],
+				pod.Annotations[fmt.Sprintf(util.IngressBurstAnnotationTemplate, provider)])
 			if err != nil {
 				klog.Error(err)
 				return err

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -44,13 +44,14 @@ func (c *Controller) setGatewayBandwidth() error {
 		return err
 	}
 	ingress, egress := node.Annotations[util.IngressRateAnnotation], node.Annotations[util.EgressRateAnnotation]
+	ingressBurst, egressBurst := node.Annotations[util.IngressBurstAnnotation], node.Annotations[util.EgressBurstAnnotation]
 	ifaceID := util.NodeLspName(c.config.NodeName)
 	if ingress == "" && egress == "" {
 		if htbQos, _ := ovs.IsHtbQos(ifaceID); !htbQos {
 			return nil
 		}
 	}
-	return ovs.SetInterfaceBandwidth("", "", ifaceID, egress, ingress)
+	return ovs.SetInterfaceBandwidth("", "", ifaceID, egress, ingress, egressBurst, ingressBurst)
 }
 
 func (c *Controller) setICGateway() error {

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -90,7 +90,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	}
 
 	var gatewayCheckMode int
-	var macAddr, ip, ipAddr, cidr, gw, subnet, ingress, egress, providerNetwork, ifName, nicType, podNicName, vmName, latency, limit, loss, jitter, u2oInterconnectionIP, oldPodName string
+	var macAddr, ip, ipAddr, cidr, gw, subnet, ingress, egress, ingressBurst, egressBurst, providerNetwork, ifName, nicType, podNicName, vmName, latency, limit, loss, jitter, u2oInterconnectionIP, oldPodName string
 	var routes []request.Route
 	var isDefaultRoute, noIPAM bool
 	var pod *v1.Pod
@@ -125,6 +125,8 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		subnet = pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podRequest.Provider)]
 		ingress = pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, podRequest.Provider)]
 		egress = pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, podRequest.Provider)]
+		ingressBurst = pod.Annotations[fmt.Sprintf(util.IngressBurstAnnotationTemplate, podRequest.Provider)]
+		egressBurst = pod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, podRequest.Provider)]
 		latency = pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, podRequest.Provider)]
 		limit = pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, podRequest.Provider)]
 		loss = pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, podRequest.Provider)]
@@ -329,10 +331,10 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 
 		switch nicType {
 		case util.DpdkType:
-			err = csh.configureDpdkNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, getShortSharedDir(pod.UID, podRequest.VhostUserSocketVolumeName), podRequest.VhostUserSocketName, podRequest.VhostUserSocketConsumption)
+			err = csh.configureDpdkNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, ingressBurst, egressBurst, getShortSharedDir(pod.UID, podRequest.VhostUserSocketVolumeName), podRequest.VhostUserSocketName, podRequest.VhostUserSocketConsumption)
 			routes = nil
 		default:
-			routes, err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, vmMigration, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, podRequest.DeviceID, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet)
+			routes, err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, vmMigration, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, ingressBurst, egressBurst, podRequest.DeviceID, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet)
 		}
 		if err != nil {
 			errMsg := fmt.Errorf("configure nic %s for pod %s/%s failed: %w", ifName, podRequest.PodName, podRequest.PodNamespace, err)

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -42,7 +42,7 @@ import (
 
 var pciAddrRegexp = regexp.MustCompile(`\b([0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}.\d{1}\S*)`)
 
-func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, netns, containerID, ifName, _ string, _ int, ip, _, ingress, egress, shortSharedDir, socketName, socketConsumption string) error {
+func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, netns, containerID, ifName, _ string, _ int, ip, _, ingress, egress, ingressBurst, egressBurst, shortSharedDir, socketName, socketConsumption string) error {
 	sharedDir := filepath.Join("/var", shortSharedDir)
 	hostNicName, _ := generateNicName(containerID, ifName)
 
@@ -68,10 +68,10 @@ func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, ne
 	if err != nil {
 		return fmt.Errorf("add nic to ovs failed %w: %q", err, output)
 	}
-	return ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress)
+	return ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress, egressBurst, ingressBurst)
 }
 
-func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, _, _ []string, ingress, egress, deviceID, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet string) ([]request.Route, error) {
+func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, _, _ []string, ingress, egress, ingressBurst, egressBurst, deviceID, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet string) ([]request.Route, error) {
 	var err error
 	var hostNicName, containerNicName, pfPci string
 	var vfID int
@@ -203,7 +203,7 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 			return nil, err
 		}
 	}
-	if err = ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress); err != nil {
+	if err = ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress, egressBurst, ingressBurst); err != nil {
 		klog.Error(err)
 		return nil, err
 	}

--- a/pkg/ovs/ovs-vsctl_linux.go
+++ b/pkg/ovs/ovs-vsctl_linux.go
@@ -10,11 +10,38 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
+// computeIngressPolicingBurstKbit returns the ingress_policing_burst value (kbit) to write.
+// burstMbit is the user-supplied value in Mbit. An empty string preserves the historical
+// default of 80% of rate; an explicit "0" is honored as-is (strict policing, no burst).
+func computeIngressPolicingBurstKbit(rateKbit int, burstMbit string) int {
+	if burstMbit == "" {
+		return rateKbit * 8 / 10
+	}
+	v, _ := strconv.Atoi(burstMbit)
+	return v * 1000
+}
+
+// computeHtbBurstBytes returns the linux-htb other_config:burst value (bytes) to write.
+// burstMbit is the user-supplied value in Mbit. An empty string defaults to 80% of one
+// second worth of rate (rate*0.8/8 bytes); an explicit "0" is honored as-is.
+func computeHtbBurstBytes(rateBPS int, burstMbit string) int {
+	if burstMbit == "" {
+		return rateBPS / 10
+	}
+	v, _ := strconv.Atoi(burstMbit)
+	return v * 125000
+}
+
 // SetInterfaceBandwidth set ingress/egress qos for given pod, annotation values are for node/pod
-// but ingress/egress parameters here are from the point of ovs port/interface view, so reverse input parameters when call func SetInterfaceBandwidth
-func SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress string) error {
+// but ingress/egress parameters here are from the point of ovs port/interface view, so reverse input parameters when call func SetInterfaceBandwidth.
+//
+// ingress and egress are rate values in Mbps; ingressBurst and egressBurst are burst
+// values in Mbit. An empty burst falls back to 80% of the corresponding rate; an
+// explicit "0" is passed through verbatim.
+func SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress, ingressBurst, egressBurst string) error {
 	ingressMPS, _ := strconv.Atoi(ingress)
 	ingressKPS := ingressMPS * 1000
+	ingressBurstKbit := computeIngressPolicingBurstKbit(ingressKPS, ingressBurst)
 	interfaceList, err := ovsFind("interface", "name", "external-ids:iface-id="+iface)
 	if err != nil {
 		klog.Error(err)
@@ -34,8 +61,8 @@ func SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress string)
 	}
 
 	for _, ifName := range interfaceList {
-		// ingress_policing_rate is in Kbps
-		err := Set("interface", ifName, fmt.Sprintf("ingress_policing_rate=%d", ingressKPS), fmt.Sprintf("ingress_policing_burst=%d", ingressKPS*8/10))
+		// ingress_policing_rate and ingress_policing_burst are in Kbit
+		err := Set("interface", ifName, fmt.Sprintf("ingress_policing_rate=%d", ingressKPS), fmt.Sprintf("ingress_policing_burst=%d", ingressBurstKbit))
 		if err != nil {
 			klog.Error(err)
 			return err
@@ -43,9 +70,10 @@ func SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress string)
 
 		egressMPS, _ := strconv.Atoi(egress)
 		egressBPS := egressMPS * 1000 * 1000
+		egressBurstBytes := computeHtbBurstBytes(egressBPS, egressBurst)
 
 		if egressBPS > 0 {
-			queueUID, err := SetHtbQosQueueRecord(podName, podNamespace, iface, egressBPS, queueIfaceUIDMap)
+			queueUID, err := SetHtbQosQueueRecord(podName, podNamespace, iface, egressBPS, egressBurstBytes, queueIfaceUIDMap)
 			if err != nil {
 				klog.Error(err)
 				return err
@@ -74,6 +102,10 @@ func SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress string)
 				if _, err := Exec("remove", "queue", queueID, "other_config", "max-rate"); err != nil {
 					klog.Error(err)
 					return fmt.Errorf("failed to remove rate limit for queue in pod %v/%v, %w", podNamespace, podName, err)
+				}
+				// burst may not exist on legacy queues; ignore the error in that case.
+				if _, err := Exec("remove", "queue", queueID, "other_config", "burst"); err != nil {
+					klog.V(3).Infof("failed to remove burst limit for queue in pod %v/%v: %v", podNamespace, podName, err)
 				}
 			}
 		}
@@ -144,12 +176,16 @@ func IsHtbQos(iface string) (bool, error) {
 	return false, nil
 }
 
-func SetHtbQosQueueRecord(podName, podNamespace, iface string, maxRateBPS int, queueIfaceUIDMap map[string]string) (string, error) {
+func SetHtbQosQueueRecord(podName, podNamespace, iface string, maxRateBPS, burstBytes int, queueIfaceUIDMap map[string]string) (string, error) {
 	var queueCommandValues []string
 	var err error
 	if maxRateBPS > 0 {
 		queueCommandValues = append(queueCommandValues, fmt.Sprintf("other_config:max-rate=%d", maxRateBPS))
 	}
+	// Always write burst so an explicit "0" from the user is honored (strict
+	// shaping with no burst tolerance) and old values on existing queues are
+	// overwritten rather than silently retained.
+	queueCommandValues = append(queueCommandValues, fmt.Sprintf("other_config:burst=%d", burstBytes))
 
 	if queueUID, ok := queueIfaceUIDMap[iface]; ok {
 		if err := Set("queue", queueUID, queueCommandValues...); err != nil {

--- a/pkg/ovs/ovs-vsctl_linux.go
+++ b/pkg/ovs/ovs-vsctl_linux.go
@@ -13,22 +13,40 @@ import (
 // computeIngressPolicingBurstKbit returns the ingress_policing_burst value (kbit) to write.
 // burstMbit is the user-supplied value in Mbit. An empty string preserves the historical
 // default of 80% of rate; an explicit "0" is honored as-is (strict policing, no burst).
+// When the rate is non-positive the burst is forced to 0 to keep ingress_policing_rate
+// and ingress_policing_burst consistent. Unparseable input falls back to the default so
+// a typo cannot silently disable the burst budget.
 func computeIngressPolicingBurstKbit(rateKbit int, burstMbit string) int {
+	if rateKbit <= 0 {
+		return 0
+	}
 	if burstMbit == "" {
 		return rateKbit * 8 / 10
 	}
-	v, _ := strconv.Atoi(burstMbit)
+	v, err := strconv.Atoi(burstMbit)
+	if err != nil {
+		klog.Warningf("invalid ingress burst value %q, falling back to default", burstMbit)
+		return rateKbit * 8 / 10
+	}
 	return v * 1000
 }
 
 // computeHtbBurstBytes returns the linux-htb other_config:burst value (bytes) to write.
 // burstMbit is the user-supplied value in Mbit. An empty string defaults to 80% of one
-// second worth of rate (rate*0.8/8 bytes); an explicit "0" is honored as-is.
+// second worth of rate (rate*0.8/8 bytes); an explicit "0" is honored as-is. A
+// non-positive rate forces burst to 0, and unparseable input falls back to the default.
 func computeHtbBurstBytes(rateBPS int, burstMbit string) int {
+	if rateBPS <= 0 {
+		return 0
+	}
 	if burstMbit == "" {
 		return rateBPS / 10
 	}
-	v, _ := strconv.Atoi(burstMbit)
+	v, err := strconv.Atoi(burstMbit)
+	if err != nil {
+		klog.Warningf("invalid egress burst value %q, falling back to default", burstMbit)
+		return rateBPS / 10
+	}
 	return v * 125000
 }
 

--- a/pkg/ovs/ovs-vsctl_linux_test.go
+++ b/pkg/ovs/ovs-vsctl_linux_test.go
@@ -28,6 +28,8 @@ func TestComputeIngressPolicingBurstKbit(t *testing.T) {
 		{name: "literal zero is honored", rateKbit: 10000, burst: "0", want: 0},
 		{name: "explicit value in Mbit", rateKbit: 10000, burst: "5", want: 5000},
 		{name: "default with zero rate", rateKbit: 0, burst: "", want: 0},
+		{name: "non-empty burst with zero rate is forced to 0", rateKbit: 0, burst: "5", want: 0},
+		{name: "unparseable burst falls back to default", rateKbit: 10000, burst: "abc", want: 8000},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -48,6 +50,8 @@ func TestComputeHtbBurstBytes(t *testing.T) {
 		{name: "default 80% when burst empty", rateBPS: 100_000_000, burst: "", want: 10_000_000},
 		{name: "literal zero is honored", rateBPS: 100_000_000, burst: "0", want: 0},
 		{name: "explicit value in Mbit", rateBPS: 100_000_000, burst: "5", want: 625_000},
+		{name: "non-empty burst with zero rate is forced to 0", rateBPS: 0, burst: "5", want: 0},
+		{name: "unparseable burst falls back to default", rateBPS: 100_000_000, burst: "abc", want: 10_000_000},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ovs/ovs-vsctl_linux_test.go
+++ b/pkg/ovs/ovs-vsctl_linux_test.go
@@ -1,6 +1,8 @@
 package ovs
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -8,9 +10,50 @@ func (suite *OvnClientTestSuite) testSetInterfaceBandwidth() {
 	t := suite.T()
 	t.Parallel()
 
-	err := SetInterfaceBandwidth("podName", "podNS", "eth0", "10", "10")
+	err := SetInterfaceBandwidth("podName", "podNS", "eth0", "10", "10", "", "")
 	// no ovs-vsctl command
 	require.Error(t, err)
+}
+
+func TestComputeIngressPolicingBurstKbit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rateKbit int
+		burst    string
+		want     int
+	}{
+		{name: "default 80% when burst empty", rateKbit: 10000, burst: "", want: 8000},
+		{name: "literal zero is honored", rateKbit: 10000, burst: "0", want: 0},
+		{name: "explicit value in Mbit", rateKbit: 10000, burst: "5", want: 5000},
+		{name: "default with zero rate", rateKbit: 0, burst: "", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, computeIngressPolicingBurstKbit(tt.rateKbit, tt.burst))
+		})
+	}
+}
+
+func TestComputeHtbBurstBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rateBPS int
+		burst   string
+		want    int
+	}{
+		{name: "default 80% when burst empty", rateBPS: 100_000_000, burst: "", want: 10_000_000},
+		{name: "literal zero is honored", rateBPS: 100_000_000, burst: "0", want: 0},
+		{name: "explicit value in Mbit", rateBPS: 100_000_000, burst: "5", want: 625_000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, computeHtbBurstBytes(tt.rateBPS, tt.burst))
+		})
+	}
 }
 
 func (suite *OvnClientTestSuite) testClearHtbQosQueue() {
@@ -34,14 +77,14 @@ func (suite *OvnClientTestSuite) testSetHtbQosQueueRecord() {
 	t := suite.T()
 	t.Parallel()
 	// get a new id
-	id, err := SetHtbQosQueueRecord("podName", "podNS", "eth0", 10, nil)
+	id, err := SetHtbQosQueueRecord("podName", "podNS", "eth0", 10, 0, nil)
 	// no ovs-vsctl command
 	require.Error(t, err)
 	require.Empty(t, id)
 	// get a exist id
 	queueIfaceUIDMap := make(map[string]string)
 	queueIfaceUIDMap["eth0"] = "123"
-	id, err = SetHtbQosQueueRecord("podName", "podNS", "eth0", 10, queueIfaceUIDMap)
+	id, err = SetHtbQosQueueRecord("podName", "podNS", "eth0", 10, 8, queueIfaceUIDMap)
 	// no ovs-vsctl command
 	require.Error(t, err)
 	require.Empty(t, id)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -81,6 +81,8 @@ const (
 	VlanIDAnnotationTemplate        = "%s.kubernetes.io/vlan_id"
 	IngressRateAnnotationTemplate   = "%s.kubernetes.io/ingress_rate"
 	EgressRateAnnotationTemplate    = "%s.kubernetes.io/egress_rate"
+	IngressBurstAnnotationTemplate  = "%s.kubernetes.io/ingress_burst"
+	EgressBurstAnnotationTemplate   = "%s.kubernetes.io/egress_burst"
 	SecurityGroupAnnotationTemplate = "%s.kubernetes.io/security_groups"
 	DefaultRouteAnnotationTemplate  = "%s.kubernetes.io/default_route"
 	VfRepresentorNameTemplate       = "%s.kubernetes.io/vf_representor"
@@ -102,8 +104,10 @@ const (
 
 	ExcludeIpsAnnotation = "ovn.kubernetes.io/exclude_ips"
 
-	IngressRateAnnotation = "ovn.kubernetes.io/ingress_rate"
-	EgressRateAnnotation  = "ovn.kubernetes.io/egress_rate"
+	IngressRateAnnotation  = "ovn.kubernetes.io/ingress_rate"
+	EgressRateAnnotation   = "ovn.kubernetes.io/egress_rate"
+	IngressBurstAnnotation = "ovn.kubernetes.io/ingress_burst"
+	EgressBurstAnnotation  = "ovn.kubernetes.io/egress_burst"
 
 	PortNameAnnotation      = "ovn.kubernetes.io/port_name"
 	LogicalSwitchAnnotation = "ovn.kubernetes.io/logical_switch"

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -349,6 +349,22 @@ func ValidatePodNetwork(annotations map[string]string) error {
 		}
 	}
 
+	for _, key := range []string{IngressBurstAnnotation, EgressBurstAnnotation} {
+		burst := annotations[key]
+		if burst == "" {
+			continue
+		}
+		v, err := strconv.Atoi(burst)
+		if err != nil {
+			klog.Error(err)
+			errors = append(errors, fmt.Errorf("%s is not a valid %s", burst, key))
+			continue
+		}
+		if v < 0 {
+			errors = append(errors, fmt.Errorf("%s is not a valid %s", burst, key))
+		}
+	}
+
 	return utilerrors.NewAggregate(errors)
 }
 

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -333,32 +333,32 @@ func ValidatePodNetwork(annotations map[string]string) error {
 		}
 	}
 
-	ingress := annotations[IngressRateAnnotation]
-	if ingress != "" {
-		if _, err := strconv.Atoi(ingress); err != nil {
-			klog.Error(err)
-			errors = append(errors, fmt.Errorf("%s is not a valid %s", ingress, IngressRateAnnotation))
-		}
+	// Validate rate and burst annotations across both the unscoped keys
+	// (ovn.kubernetes.io/{ingress,egress}_{rate,burst}) and any
+	// provider-scoped variants used for multus attachment networks
+	// ({provider}.kubernetes.io/{ingress,egress}_{rate,burst}). All forms
+	// share the same suffix, so a single scan covers everything. Rate
+	// annotations historically only validated the unscoped key, leaving
+	// typos on attachment networks silently parsed as 0 and disabling the
+	// limit; treating both rates and bursts uniformly closes that gap.
+	bandwidthSuffixes := []string{
+		".kubernetes.io/ingress_rate",
+		".kubernetes.io/egress_rate",
+		".kubernetes.io/ingress_burst",
+		".kubernetes.io/egress_burst",
 	}
-
-	egress := annotations[EgressRateAnnotation]
-	if egress != "" {
-		if _, err := strconv.Atoi(egress); err != nil {
-			klog.Error(err)
-			errors = append(errors, fmt.Errorf("%s is not a valid %s", egress, EgressRateAnnotation))
-		}
-	}
-
-	// Validate burst annotations across both the unscoped key
-	// (ovn.kubernetes.io/{ingress,egress}_burst) and any provider-scoped
-	// variants used for multus attachment networks
-	// ({provider}.kubernetes.io/{ingress,egress}_burst). Both forms share
-	// the same suffix, so a single scan is enough.
 	for k, v := range annotations {
 		if v == "" {
 			continue
 		}
-		if !strings.HasSuffix(k, ".kubernetes.io/ingress_burst") && !strings.HasSuffix(k, ".kubernetes.io/egress_burst") {
+		matched := false
+		for _, s := range bandwidthSuffixes {
+			if strings.HasSuffix(k, s) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
 			continue
 		}
 		n, err := strconv.Atoi(v)

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -349,19 +349,21 @@ func ValidatePodNetwork(annotations map[string]string) error {
 		}
 	}
 
-	for _, key := range []string{IngressBurstAnnotation, EgressBurstAnnotation} {
-		burst := annotations[key]
-		if burst == "" {
+	// Validate burst annotations across both the unscoped key
+	// (ovn.kubernetes.io/{ingress,egress}_burst) and any provider-scoped
+	// variants used for multus attachment networks
+	// ({provider}.kubernetes.io/{ingress,egress}_burst). Both forms share
+	// the same suffix, so a single scan is enough.
+	for k, v := range annotations {
+		if v == "" {
 			continue
 		}
-		v, err := strconv.Atoi(burst)
-		if err != nil {
-			klog.Error(err)
-			errors = append(errors, fmt.Errorf("%s is not a valid %s", burst, key))
+		if !strings.HasSuffix(k, ".kubernetes.io/ingress_burst") && !strings.HasSuffix(k, ".kubernetes.io/egress_burst") {
 			continue
 		}
-		if v < 0 {
-			errors = append(errors, fmt.Errorf("%s is not a valid %s", burst, key))
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			errors = append(errors, fmt.Errorf("%s is not a valid %s", v, k))
 		}
 	}
 

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -912,6 +912,16 @@ func TestValidatePodNetwork(t *testing.T) {
 			},
 			err: "abc is not a valid net1.ns1.kubernetes.io/ingress_burst",
 		},
+		{
+			name: "ProviderScopedRateNotNumber",
+			annotations: map[string]string{
+				IPAddressAnnotation:                  "10.16.0.15",
+				MacAddressAnnotation:                 "00:00:00:54:17:2A",
+				CidrAnnotation:                       "10.16.0.0/16",
+				"net1.ns1.kubernetes.io/egress_rate": "10m",
+			},
+			err: "10m is not a valid net1.ns1.kubernetes.io/egress_rate",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -867,6 +867,41 @@ func TestValidatePodNetwork(t *testing.T) {
 			},
 			err: "a1 is not a valid " + EgressRateAnnotation,
 		},
+		{
+			name: "BurstOk",
+			annotations: map[string]string{
+				IPAddressAnnotation:    "10.16.0.15",
+				MacAddressAnnotation:   "00:00:00:54:17:2A",
+				IngressRateAnnotation:  "10",
+				EgressRateAnnotation:   "10",
+				IngressBurstAnnotation: "8",
+				EgressBurstAnnotation:  "0",
+				CidrAnnotation:         "10.16.0.0/16",
+			},
+			err: "",
+		},
+		{
+			name: "IngressBurstNotNumber",
+			annotations: map[string]string{
+				IPAddressAnnotation:    "10.16.0.15",
+				MacAddressAnnotation:   "00:00:00:54:17:2A",
+				IngressRateAnnotation:  "10",
+				IngressBurstAnnotation: "abc",
+				CidrAnnotation:         "10.16.0.0/16",
+			},
+			err: "abc is not a valid " + IngressBurstAnnotation,
+		},
+		{
+			name: "EgressBurstNegative",
+			annotations: map[string]string{
+				IPAddressAnnotation:   "10.16.0.15",
+				MacAddressAnnotation:  "00:00:00:54:17:2A",
+				EgressRateAnnotation:  "10",
+				EgressBurstAnnotation: "-1",
+				CidrAnnotation:        "10.16.0.0/16",
+			},
+			err: "-1 is not a valid " + EgressBurstAnnotation,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -902,6 +902,16 @@ func TestValidatePodNetwork(t *testing.T) {
 			},
 			err: "-1 is not a valid " + EgressBurstAnnotation,
 		},
+		{
+			name: "ProviderScopedBurstNotNumber",
+			annotations: map[string]string{
+				IPAddressAnnotation:                    "10.16.0.15",
+				MacAddressAnnotation:                   "00:00:00:54:17:2A",
+				CidrAnnotation:                         "10.16.0.0/16",
+				"net1.ns1.kubernetes.io/ingress_burst": "abc",
+			},
+			err: "abc is not a valid net1.ns1.kubernetes.io/ingress_burst",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Introduce `ovn.kubernetes.io/ingress_burst` and `ovn.kubernetes.io/egress_burst` annotations (plus provider-scoped templates) so users can tune the QoS burst budget, which was previously hardcoded to 80% of rate on ingress and not set at all on egress.
- Values are Mbit; empty preserves the historical 80% default, an explicit `0` is honored verbatim (strict shaping with no burst tolerance). Internally the values land in `ingress_policing_burst` (kbit) for ingress and the linux-htb queue's `other_config:burst` (bytes) for egress, with unit conversion hidden in two helpers.
- Wire the annotations through every daemon reconciliation path — CNI add (veth / sriov / dpdk), pod reconcile (main + multus attachment networks) and node gateway — and make `enqueueUpdatePod` watch the burst annotations so live updates reconcile without waiting for an unrelated change.
- Compute helpers short-circuit to 0 when the rate is non-positive (keeping `rate` and `burst` consistent) and fall back to the default with a warning when the burst string fails to parse, so a typo cannot silently clamp the budget to strict shaping.
- Fold the existing pod rate annotations into the same suffix-based validator scan as the new burst keys. Previously only the unscoped `ovn.kubernetes.io/{ingress,egress}_rate` was validated, so a typo on a multus attachment-network rate annotation (e.g. `"10m"`) slipped through and was silently parsed as 0, disabling the limit without any signal.

## Test plan
- [x] `go build ./...`
- [x] `make lint`
- [x] `go test ./pkg/util/ ./pkg/ovs/ ./pkg/daemon/`
- [x] New unit tests cover: default 80%, literal `0`, explicit Mbit value, rate-zero short-circuit, unparseable fallback, provider-scoped burst validation, provider-scoped rate validation
- [ ] Manual: set `ingress_burst` / `egress_burst` on a running pod and verify `ovs-vsctl get interface <if> ingress_policing_burst` and `ovs-vsctl get queue <q> other_config:burst` reflect the new value, including across live annotation updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)