### PR TITLE
Fix NAT gateway primary interface in non-primary CNI mode

### DIFF
--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -85,8 +85,9 @@ func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.Vpc
 	result[fmt.Sprintf(IPAddressAnnotationTemplate, p)] = gw.Spec.LanIP
 
 	// We're using a custom provider, we need to override the default network of the pod so that the
-	// default VPC/Subnet of the cluster isn't accidentally injected.
-	if p != OvnProvider {
+	// default VPC/Subnet of the cluster isn't accidentally injected. In non-primary CNI mode
+	// (additionalNetworks != ""), Multus handles the default network, so skip this.
+	if p != OvnProvider && additionalNetworks == "" {
 		// Subdivide the provider so we can infer the namespace/name of the NetworkAttachmentDefinition
 		providerSplit := strings.Split(provider, ".")
 		if len(providerSplit) != 3 || providerSplit[2] != OvnProvider {

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -85,8 +85,8 @@ func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.Vpc
 	result[fmt.Sprintf(IPAddressAnnotationTemplate, p)] = gw.Spec.LanIP
 
 	// We're using a custom provider, we need to override the default network of the pod so that the
-	// default VPC/Subnet of the cluster isn't accidentally injected. In non-primary CNI mode
-	// (additionalNetworks != ""), Multus handles the default network, so skip this.
+	// default VPC/Subnet of the cluster isn't accidentally injected. When additional Multus
+	// attachments are explicitly requested (additionalNetworks != ""), skip this override.
 	if p != OvnProvider && additionalNetworks == "" {
 		// Subdivide the provider so we can infer the namespace/name of the NetworkAttachmentDefinition
 		providerSplit := strings.Split(provider, ".")

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -361,7 +361,6 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 				nadv1.NetworkAttachmentAnnot: "default/extra-net1, default/extra-net2, kube-system/external-subnet",
 				fmt.Sprintf(LogicalSwitchAnnotationTemplate, "subnet.namespace.ovn"): "internal-subnet",
 				fmt.Sprintf(IPAddressAnnotationTemplate, "subnet.namespace.ovn"):     "10.20.30.40",
-				DefaultNetworkAnnotation: "namespace/subnet",
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
Fixes #6632

Running into an issue where NAT gateway pods in non-primary CNI mode were getting their primary interface attached to the internal network instead of the pod network. The problem was in the annotation logic - when additionalNetworks is set (non-primary CNI mode), we shouldn't force the default network annotation because Multus is already handling that.

Added a check for additionalNetworks being empty alongside the existing provider check. If we're using additional networks, skip the default network annotation override and let Multus do its thing. Also cleaned up the test that was expecting that annotation in this scenario.