### PR TITLE
fix(controller): serialize centralized subnet reconcile in node updat…

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -575,7 +575,12 @@ func (c *Controller) handleUpdateNode(key string) error {
 		}
 
 		if util.GatewayContains(cachedSubnet.Spec.GatewayNode, node.Name) {
-			if err := c.reconcileOvnDefaultVpcRoute(cachedSubnet); err != nil {
+			c.subnetKeyMutex.LockKey(cachedSubnet.Name)
+			err = func() error {
+				defer func() { _ = c.subnetKeyMutex.UnlockKey(cachedSubnet.Name) }()
+				return c.reconcileOvnDefaultVpcRoute(cachedSubnet.DeepCopy())
+			}()
+			if err != nil {
 				klog.Error(err)
 				return err
 			}
@@ -646,20 +651,22 @@ func (c *Controller) checkSubnetGatewayNode() error {
 		}
 
 		for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
-			nextHops, nameIPMap, err := c.getPolicyRouteParas(cidrBlock, util.GatewayRouterPolicyPriority)
-			if err != nil {
-				klog.Errorf("failed to get ecmp policy route paras for subnet %s: %v", subnet.Name, err)
-				continue
-			}
+			skipCIDR := false
 			for _, node := range nodes {
+				if skipCIDR {
+					break
+				}
+
 				ipStr := node.Annotations[util.IPAddressAnnotation]
 				for ip := range strings.SplitSeq(ipStr, ",") {
 					if util.CheckProtocol(cidrBlock) != util.CheckProtocol(ip) {
 						continue
 					}
 
-					exist := nameIPMap[node.Name] == ip
-					if util.GatewayContains(subnet.Spec.GatewayNode, node.Name) {
+					isGateway := util.GatewayContains(subnet.Spec.GatewayNode, node.Name)
+					pingSucceeded := false
+					nodeIsReady := nodeReady(node)
+					if isGateway {
 						pinger, err := goping.NewPinger(ip)
 						if err != nil {
 							return fmt.Errorf("failed to init pinger, %w", err)
@@ -671,7 +678,6 @@ func (c *Controller) checkSubnetGatewayNode() error {
 						pinger.Timeout = time.Duration(count) * time.Second
 						pinger.Interval = 1 * time.Second
 
-						var pingSucceeded bool
 						pinger.OnRecv = func(_ *goping.Packet) {
 							pingSucceeded = true
 							pinger.Stop()
@@ -680,28 +686,42 @@ func (c *Controller) checkSubnetGatewayNode() error {
 							klog.Errorf("failed to run pinger for destination %s: %v", ip, err)
 							return err
 						}
-
-						nodeIsReady := nodeReady(node)
-						if !pingSucceeded || !nodeIsReady {
-							if exist {
-								if !pingSucceeded {
-									klog.Warningf("failed to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
-								}
-								if !nodeIsReady {
-									klog.Warningf("node %s is not ready", node.Name)
-								}
-								klog.Warningf("delete ecmp policy route for node %s ip %s", node.Name, ip)
-								nextHops.Remove(ip)
-								delete(nameIPMap, node.Name)
-								klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-								if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-									klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-									return err
-								}
-							}
-						} else {
+						if pingSucceeded {
 							klog.V(3).Infof("succeeded to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
-							if !exist {
+						}
+					}
+
+					err = func() error {
+						c.subnetKeyMutex.LockKey(subnet.Name)
+						defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
+
+						nextHops, nameIPMap, err := c.getPolicyRouteParas(cidrBlock, util.GatewayRouterPolicyPriority)
+						if err != nil {
+							klog.Errorf("failed to get ecmp policy route paras for subnet %s: %v", subnet.Name, err)
+							skipCIDR = true
+							return nil
+						}
+
+						exist := nameIPMap[node.Name] == ip
+						if isGateway {
+							if !pingSucceeded || !nodeIsReady {
+								if exist {
+									if !pingSucceeded {
+										klog.Warningf("failed to ping %s ip %s on node %s", util.NodeNic, ip, node.Name)
+									}
+									if !nodeIsReady {
+										klog.Warningf("node %s is not ready", node.Name)
+									}
+									klog.Warningf("delete ecmp policy route for node %s ip %s", node.Name, ip)
+									nextHops.Remove(ip)
+									delete(nameIPMap, node.Name)
+									klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+									if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+										klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+										return err
+									}
+								}
+							} else if !exist {
 								nextHops.Add(ip)
 								if nameIPMap == nil {
 									nameIPMap = make(map[string]string, 1)
@@ -713,21 +733,30 @@ func (c *Controller) checkSubnetGatewayNode() error {
 									return err
 								}
 							}
+						} else if exist {
+							klog.Infof("subnet %s gateway nodes does not contain node %s, delete policy route for node ip %s", subnet.Name, node.Name, ip)
+							nextHops.Remove(ip)
+							delete(nameIPMap, node.Name)
+							klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+							if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+								klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
+								return err
+							}
 						}
-					} else if exist {
-						klog.Infof("subnet %s gateway nodes does not contain node %s, delete policy route for node ip %s", subnet.Name, node.Name, ip)
-						nextHops.Remove(ip)
-						delete(nameIPMap, node.Name)
-						klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-						if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-							klog.Errorf("failed to delete ecmp policy route for subnet %s on node %s, %v", subnet.Name, node.Name, err)
-							return err
-						}
+
+						return nil
+					}()
+					if err != nil {
+						return err
+					}
+					if skipCIDR {
+						break
 					}
 				}
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -1013,44 +1042,52 @@ func (c *Controller) deletePolicyRouteForNode(nodeName, portName string) error {
 		}
 
 		if subnet.Spec.GatewayType == kubeovnv1.GWCentralizedType {
-			if subnet.Spec.EnableEcmp {
-				for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
-					nextHops, nameIPMap, err := c.getPolicyRouteParas(cidrBlock, util.GatewayRouterPolicyPriority)
-					if err != nil {
-						klog.Errorf("get ecmp policy route paras for subnet %v, error %v", subnet.Name, err)
-						continue
-					}
+			c.subnetKeyMutex.LockKey(subnet.Name)
+			err = func() error {
+				defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
+				if subnet.Spec.EnableEcmp {
+					for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+						nextHops, nameIPMap, err := c.getPolicyRouteParas(cidrBlock, util.GatewayRouterPolicyPriority)
+						if err != nil {
+							klog.Errorf("get ecmp policy route paras for subnet %v, error %v", subnet.Name, err)
+							continue
+						}
 
-					exist := false
-					if _, ok := nameIPMap[nodeName]; ok {
-						exist = true
-					}
+						exist := false
+						if _, ok := nameIPMap[nodeName]; ok {
+							exist = true
+						}
 
-					if exist {
-						nextHops.Remove(nameIPMap[nodeName])
-						delete(nameIPMap, nodeName)
+						if exist {
+							nextHops.Remove(nameIPMap[nodeName])
+							delete(nameIPMap, nodeName)
 
-						if nextHops.Size() == 0 {
-							klog.Infof("delete policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-							if err := c.deletePolicyRouteForCentralizedSubnet(subnet); err != nil {
-								klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
-								return err
-							}
-						} else {
-							klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-							if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-								klog.Errorf("failed to update policy route for subnet %s on node %s, %v", subnet.Name, nodeName, err)
-								return err
+							if nextHops.Size() == 0 {
+								klog.Infof("delete policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+								if err := c.deletePolicyRouteForCentralizedSubnet(subnet); err != nil {
+									klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
+									return err
+								}
+							} else {
+								klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+								if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+									klog.Errorf("failed to update policy route for subnet %s on node %s, %v", subnet.Name, nodeName, err)
+									return err
+								}
 							}
 						}
 					}
+				} else {
+					klog.Infof("reconcile policy route for centralized subnet %s", subnet.Name)
+					if err := c.reconcileDefaultCentralizedSubnetRouteInDefaultVpc(subnet); err != nil {
+						klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
+						return err
+					}
 				}
-			} else {
-				klog.Infof("reconcile policy route for centralized subnet %s", subnet.Name)
-				if err := c.reconcileDefaultCentralizedSubnetRouteInDefaultVpc(subnet); err != nil {
-					klog.Errorf("failed to delete policy route for centralized subnet %s, %v", subnet.Name, err)
-					return err
-				}
+				return nil
+			}()
+			if err != nil {
+				return err
 			}
 		}
 	}
@@ -1068,49 +1105,57 @@ func (c *Controller) addPolicyRouteForCentralizedSubnetOnNode(node *v1.Node, nod
 		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType {
 			continue
 		}
-		nodeName := node.Name
-		if subnet.Spec.EnableEcmp {
-			if !util.GatewayContains(subnet.Spec.GatewayNode, nodeName) &&
-				(subnet.Spec.GatewayNode != "" || !util.MatchLabelSelectors(subnet.Spec.GatewayNodeSelectors, node.Labels)) {
-				continue
-			}
+		c.subnetKeyMutex.LockKey(subnet.Name)
+		err = func() error {
+			defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
+			nodeName := node.Name
+			if subnet.Spec.EnableEcmp {
+				if !util.GatewayContains(subnet.Spec.GatewayNode, nodeName) &&
+					(subnet.Spec.GatewayNode != "" || !util.MatchLabelSelectors(subnet.Spec.GatewayNodeSelectors, node.Labels)) {
+					return nil
+				}
 
-			for nextHop := range strings.SplitSeq(nodeIP, ",") {
-				for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
-					if util.CheckProtocol(cidrBlock) != util.CheckProtocol(nextHop) {
-						continue
-					}
+				for nextHop := range strings.SplitSeq(nodeIP, ",") {
+					for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+						if util.CheckProtocol(cidrBlock) != util.CheckProtocol(nextHop) {
+							continue
+						}
 
-					nextHops, nameIPMap, err := c.getPolicyRouteParas(cidrBlock, util.GatewayRouterPolicyPriority)
-					if err != nil {
-						klog.Errorf("get ecmp policy route paras for subnet %v, error %v", subnet.Name, err)
-						continue
-					}
-					if nameIPMap[nodeName] == nextHop {
-						continue
-					}
+						nextHops, nameIPMap, err := c.getPolicyRouteParas(cidrBlock, util.GatewayRouterPolicyPriority)
+						if err != nil {
+							klog.Errorf("get ecmp policy route paras for subnet %v, error %v", subnet.Name, err)
+							continue
+						}
+						if nameIPMap[nodeName] == nextHop {
+							continue
+						}
 
-					nextHops.Add(nextHop)
-					if nameIPMap == nil {
-						nameIPMap = make(map[string]string, 1)
-					}
-					nameIPMap[nodeName] = nextHop
-					klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
-					if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
-						klog.Errorf("failed to update policy route for subnet %s on node %s, %v", subnet.Name, nodeName, err)
-						return err
+						nextHops.Add(nextHop)
+						if nameIPMap == nil {
+							nameIPMap = make(map[string]string, 1)
+						}
+						nameIPMap[nodeName] = nextHop
+						klog.Infof("update policy route for centralized subnet %s, nextHops %s", subnet.Name, nextHops)
+						if err = c.updatePolicyRouteForCentralizedSubnet(subnet.Name, cidrBlock, nextHops.List(), nameIPMap); err != nil {
+							klog.Errorf("failed to update policy route for subnet %s on node %s, %v", subnet.Name, nodeName, err)
+							return err
+						}
 					}
 				}
+			} else {
+				if subnet.Status.ActivateGateway != nodeName {
+					return nil
+				}
+				klog.Infof("add policy route for centralized subnet %s, on node %s, ip %s", subnet.Name, nodeName, nodeIP)
+				if err = c.addPolicyRouteForCentralizedSubnet(subnet, nodeName, nil, strings.Split(nodeIP, ",")); err != nil {
+					klog.Errorf("failed to add active-backup policy route for centralized subnet %s: %v", subnet.Name, err)
+					return err
+				}
 			}
-		} else {
-			if subnet.Status.ActivateGateway != nodeName {
-				continue
-			}
-			klog.Infof("add policy route for centralized subnet %s, on node %s, ip %s", subnet.Name, nodeName, nodeIP)
-			if err = c.addPolicyRouteForCentralizedSubnet(subnet, nodeName, nil, strings.Split(nodeIP, ",")); err != nil {
-				klog.Errorf("failed to add active-backup policy route for centralized subnet %s: %v", subnet.Name, err)
-				return err
-			}
+			return nil
+		}()
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
…e path (#6627)

* controller: serialize centralized subnet route updates

Use per-subnet key mutex to serialize concurrent policy route operations for centralized subnets, preventing race conditions when multiple nodes trigger route updates simultaneously.



* refactor checkSubnetGateway



* fix



---------

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
