### PR TITLE
Fix Helm chart CNI config directory override

### DIFF
--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -82,7 +82,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - /kube-ovn/install-cni.sh
-          - --cni-conf-dir={{ .Values.cni.mountConfigDirectory }}
+          - --cni-conf-dir={{ .Values.cni.configDirectory }}
           - --cni-conf-file={{ .Values.cni.localConfigFile }}
           - --cni-conf-name={{- .Values.cni.configPriority -}}-kube-ovn.conflist
         env:
@@ -96,7 +96,7 @@ spec:
         volumeMounts:
           - mountPath: /opt/cni/bin
             name: cni-bin
-          - mountPath: {{ .Values.cni.mountConfigDirectory }}
+          - mountPath: {{ .Values.cni.configDirectory }}
             name: cni-conf
           {{- if .Values.cni.mountToolingDirectory }}
           - mountPath: /usr/local/bin

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -241,9 +241,15 @@ features:
 # @section -- CNI configuration
 # @default -- "{}"
 cni:
-  # -- Location of the CNI configuration on the node.
+  # -- Location of the CNI configuration on the node. This value controls both
+  # the hostPath source and the pod mountPath for the CNI configuration.
   # @section -- CNI configuration
   configDirectory: "/etc/cni/net.d"
+  # -- Deprecated: compatibility alias retained for chart consumers upgrading
+  # from releases that still set this value. Use `configDirectory` instead.
+  # Keep for at least one release so upgrades do not silently ignore existing configuration.
+  # @section -- CNI configuration
+  mountConfigDirectory: false
   # -- Location on the node where the agent will inject the Kube-OVN binary.
   # @section -- CNI configuration
   binaryDirectory: "/opt/cni/bin"

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -244,9 +244,6 @@ cni:
   # -- Location of the CNI configuration on the node.
   # @section -- CNI configuration
   configDirectory: "/etc/cni/net.d"
-  # -- Location of the CNI configuration to be mounted inside the pod.
-  # @section -- CNI configuration
-  mountConfigDirectory: "/etc/cni/net.d"
   # -- Location on the node where the agent will inject the Kube-OVN binary.
   # @section -- CNI configuration
   binaryDirectory: "/opt/cni/bin"

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -80,7 +80,7 @@ spec:
         volumeMounts:
           - mountPath: /opt/cni/bin
             name: cni-bin
-          - mountPath: {{ .Values.cni_conf.CNI_CONF_DIR }}
+          - mountPath: {{ if and .Values.cni_conf.MOUNT_CNI_CONF_DIR (ne .Values.cni_conf.MOUNT_CNI_CONF_DIR false) }}{{ .Values.cni_conf.MOUNT_CNI_CONF_DIR }}{{ else }}{{ .Values.cni_conf.CNI_CONF_DIR }}{{ end }}
             name: cni-conf
           {{- if .Values.cni_conf.MOUNT_LOCAL_BIN_DIR }}
           - mountPath: /usr/local/bin

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -66,7 +66,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - /kube-ovn/install-cni.sh
-          - --cni-conf-dir={{ .Values.cni_conf.MOUNT_CNI_CONF_DIR }}
+          - --cni-conf-dir={{ .Values.cni_conf.CNI_CONF_DIR }}
           - --cni-conf-file={{ .Values.cni_conf.CNI_CONF_FILE }}
           - --cni-conf-name={{- .Values.cni_conf.CNI_CONFIG_PRIORITY -}}-kube-ovn.conflist
         env:
@@ -80,7 +80,7 @@ spec:
         volumeMounts:
           - mountPath: /opt/cni/bin
             name: cni-bin
-          - mountPath: {{ .Values.cni_conf.MOUNT_CNI_CONF_DIR }}
+          - mountPath: {{ .Values.cni_conf.CNI_CONF_DIR }}
             name: cni-conf
           {{- if .Values.cni_conf.MOUNT_LOCAL_BIN_DIR }}
           - mountPath: /usr/local/bin

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -123,7 +123,6 @@ debug:
 cni_conf:
   CNI_CONFIG_PRIORITY: "01"
   CNI_CONF_DIR: "/etc/cni/net.d"
-  MOUNT_CNI_CONF_DIR: "/etc/cni/net.d"
   CNI_BIN_DIR: "/opt/cni/bin"
   CNI_CONF_FILE: "/kube-ovn/01-kube-ovn.conflist"
   LOCAL_BIN_DIR: "/usr/local/bin"

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -127,6 +127,10 @@ cni_conf:
   CNI_CONF_FILE: "/kube-ovn/01-kube-ovn.conflist"
   LOCAL_BIN_DIR: "/usr/local/bin"
   MOUNT_LOCAL_BIN_DIR: false
+  # -- Deprecated: compatibility alias retained for chart consumers upgrading
+  # from releases that still set this value. Keep for at least one release
+  # so upgrades do not silently ignore existing configuration.
+  MOUNT_CNI_CONF_DIR: false
   NON_PRIMARY_CNI: false
 
 kubelet_conf:


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

## Which issue(s) this PR fixes

Fixes #6644

---

The charts had two separate values for the CNI config directory - one for the command argument, one for the volumeMount. If someone tried to override it via environment variables, only one would actually change.

Consolidated to a single value so overrides work consistently across both the command and the mount. Removed the duplicate `mountConfigDirectory` and `MOUNT_CNI_CONF_DIR` fields while we're at it.