### PR TITLE
fix(controller): stop overwriting VPC status on bootstrap

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -343,23 +343,7 @@ func (c *Controller) initLoadBalancer() error {
 			return err
 		}
 
-		lbPatch := struct {
-			Status struct {
-				TCPLoadBalancer         string `json:"tcpLoadBalancer"`
-				TCPSessionLoadBalancer  string `json:"tcpSessionLoadBalancer"`
-				UDPLoadBalancer         string `json:"udpLoadBalancer"`
-				UDPSessionLoadBalancer  string `json:"udpSessionLoadBalancer"`
-				SctpLoadBalancer        string `json:"sctpLoadBalancer"`
-				SctpSessionLoadBalancer string `json:"sctpSessionLoadBalancer"`
-			} `json:"status"`
-		}{}
-		lbPatch.Status.TCPLoadBalancer = vpcLb.TCPLoadBalancer
-		lbPatch.Status.TCPSessionLoadBalancer = vpcLb.TCPSessLoadBalancer
-		lbPatch.Status.UDPLoadBalancer = vpcLb.UDPLoadBalancer
-		lbPatch.Status.UDPSessionLoadBalancer = vpcLb.UDPSessLoadBalancer
-		lbPatch.Status.SctpLoadBalancer = vpcLb.SctpLoadBalancer
-		lbPatch.Status.SctpSessionLoadBalancer = vpcLb.SctpSessLoadBalancer
-		body, err := json.Marshal(lbPatch)
+		body, err := buildVpcLBStatusPatch(vpcLb)
 		if err != nil {
 			klog.Error(err)
 			return err
@@ -370,6 +354,31 @@ func (c *Controller) initLoadBalancer() error {
 		}
 	}
 	return nil
+}
+
+// buildVpcLBStatusPatch builds a merge-patch body that updates only the six
+// LB-name fields of VpcStatus. It deliberately excludes every other field so
+// the merge patch cannot overwrite state owned by InitDefaultVpc (Standby,
+// Default, Router, DefaultLogicalSwitch) when the caller reads from a stale
+// lister cache.
+func buildVpcLBStatusPatch(vpcLb *VpcLoadBalancer) ([]byte, error) {
+	patch := struct {
+		Status struct {
+			TCPLoadBalancer         string `json:"tcpLoadBalancer"`
+			TCPSessionLoadBalancer  string `json:"tcpSessionLoadBalancer"`
+			UDPLoadBalancer         string `json:"udpLoadBalancer"`
+			UDPSessionLoadBalancer  string `json:"udpSessionLoadBalancer"`
+			SctpLoadBalancer        string `json:"sctpLoadBalancer"`
+			SctpSessionLoadBalancer string `json:"sctpSessionLoadBalancer"`
+		} `json:"status"`
+	}{}
+	patch.Status.TCPLoadBalancer = vpcLb.TCPLoadBalancer
+	patch.Status.TCPSessionLoadBalancer = vpcLb.TCPSessLoadBalancer
+	patch.Status.UDPLoadBalancer = vpcLb.UDPLoadBalancer
+	patch.Status.UDPSessionLoadBalancer = vpcLb.UDPSessLoadBalancer
+	patch.Status.SctpLoadBalancer = vpcLb.SctpLoadBalancer
+	patch.Status.SctpSessionLoadBalancer = vpcLb.SctpSessLoadBalancer
+	return json.Marshal(patch)
 }
 
 func (c *Controller) InitIPAM() error {

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -296,7 +297,18 @@ func (c *Controller) initLB(name, protocol string, sessionAffinity bool) error {
 	return nil
 }
 
-// InitLoadBalancer init the default tcp and udp cluster loadbalancer
+// InitLoadBalancer creates the default TCP/UDP/SCTP cluster load balancers in
+// OVN for every existing VPC and records their names in each VPC's status so
+// the subnet worker can attach them to its logical switch on its first
+// reconcile.
+//
+// The status write uses a targeted merge patch that contains only the six
+// LB-name fields. An earlier version serialized the whole VpcStatus via
+// vpc.Status.Bytes() and raced InitDefaultVpc: if the VPC lister cache still
+// held the pre-UpdateStatus copy (Standby=false) the whole-status merge patch
+// would silently overwrite the Standby/Default/Router/DefaultLogicalSwitch
+// fields that InitDefaultVpc had just written, deadlocking the subnet worker.
+// A field-scoped patch avoids that class of overwrite entirely.
 func (c *Controller) initLoadBalancer() error {
 	vpcs, err := c.vpcsLister.List(labels.Everything())
 	if err != nil {
@@ -305,8 +317,7 @@ func (c *Controller) initLoadBalancer() error {
 	}
 
 	for _, cachedVpc := range vpcs {
-		vpc := cachedVpc.DeepCopy()
-		vpcLb := c.GenVpcLoadBalancer(vpc.Name)
+		vpcLb := c.GenVpcLoadBalancer(cachedVpc.Name)
 		if err = c.initLB(vpcLb.TCPLoadBalancer, string(v1.ProtocolTCP), false); err != nil {
 			klog.Error(err)
 			return err
@@ -332,18 +343,28 @@ func (c *Controller) initLoadBalancer() error {
 			return err
 		}
 
-		vpc.Status.TCPLoadBalancer = vpcLb.TCPLoadBalancer
-		vpc.Status.TCPSessionLoadBalancer = vpcLb.TCPSessLoadBalancer
-		vpc.Status.UDPLoadBalancer = vpcLb.UDPLoadBalancer
-		vpc.Status.UDPSessionLoadBalancer = vpcLb.UDPSessLoadBalancer
-		vpc.Status.SctpLoadBalancer = vpcLb.SctpLoadBalancer
-		vpc.Status.SctpSessionLoadBalancer = vpcLb.SctpSessLoadBalancer
-		bytes, err := vpc.Status.Bytes()
+		lbPatch := struct {
+			Status struct {
+				TCPLoadBalancer         string `json:"tcpLoadBalancer"`
+				TCPSessionLoadBalancer  string `json:"tcpSessionLoadBalancer"`
+				UDPLoadBalancer         string `json:"udpLoadBalancer"`
+				UDPSessionLoadBalancer  string `json:"udpSessionLoadBalancer"`
+				SctpLoadBalancer        string `json:"sctpLoadBalancer"`
+				SctpSessionLoadBalancer string `json:"sctpSessionLoadBalancer"`
+			} `json:"status"`
+		}{}
+		lbPatch.Status.TCPLoadBalancer = vpcLb.TCPLoadBalancer
+		lbPatch.Status.TCPSessionLoadBalancer = vpcLb.TCPSessLoadBalancer
+		lbPatch.Status.UDPLoadBalancer = vpcLb.UDPLoadBalancer
+		lbPatch.Status.UDPSessionLoadBalancer = vpcLb.UDPSessLoadBalancer
+		lbPatch.Status.SctpLoadBalancer = vpcLb.SctpLoadBalancer
+		lbPatch.Status.SctpSessionLoadBalancer = vpcLb.SctpSessLoadBalancer
+		body, err := json.Marshal(lbPatch)
 		if err != nil {
 			klog.Error(err)
 			return err
 		}
-		if _, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), vpc.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status"); err != nil {
+		if _, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), cachedVpc.Name, types.MergePatchType, body, metav1.PatchOptions{}, "status"); err != nil {
 			klog.Error(err)
 			return err
 		}

--- a/pkg/controller/init_test.go
+++ b/pkg/controller/init_test.go
@@ -1,8 +1,10 @@
 package controller
 
 import (
+	"encoding/json"
 	"testing"
 
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,4 +75,86 @@ func TestHasAllocatedAnnotation(t *testing.T) {
 			require.Equal(t, tt.expected, hasAllocatedAnnotation(pod))
 		})
 	}
+}
+
+// TestBuildVpcLBStatusPatch_PreservesInitDefaultVpcFields is the regression
+// guard for the bootstrap deadlock fix: initLoadBalancer's status patch must
+// only set the six LB-name fields, and must never carry Standby/Default/
+// Router/DefaultLogicalSwitch. If someone reintroduces a whole-VpcStatus
+// serialization here, the merge-patch body would overwrite fields that
+// InitDefaultVpc wrote moments earlier, reproducing the race that bricked
+// fresh-install HA E2E runs.
+func TestBuildVpcLBStatusPatch_PreservesInitDefaultVpcFields(t *testing.T) {
+	t.Parallel()
+
+	vpcLb := &VpcLoadBalancer{
+		TCPLoadBalancer:      "cluster-tcp-loadbalancer",
+		TCPSessLoadBalancer:  "cluster-tcp-session-loadbalancer",
+		UDPLoadBalancer:      "cluster-udp-loadbalancer",
+		UDPSessLoadBalancer:  "cluster-udp-session-loadbalancer",
+		SctpLoadBalancer:     "cluster-sctp-loadbalancer",
+		SctpSessLoadBalancer: "cluster-sctp-session-loadbalancer",
+	}
+
+	body, err := buildVpcLBStatusPatch(vpcLb)
+	require.NoError(t, err)
+
+	// The patch body must not reference any non-LB field. A regression that
+	// reintroduces vpc.Status.Bytes() would immediately trip these asserts
+	// because VpcStatus has non-omitempty booleans/strings that always get
+	// serialized.
+	var raw struct {
+		Status map[string]json.RawMessage `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.ElementsMatch(t,
+		[]string{
+			"tcpLoadBalancer", "tcpSessionLoadBalancer",
+			"udpLoadBalancer", "udpSessionLoadBalancer",
+			"sctpLoadBalancer", "sctpSessionLoadBalancer",
+		},
+		keysOf(raw.Status),
+	)
+
+	// Simulate the etcd state right after InitDefaultVpc UpdateStatus and
+	// verify the merge patch keeps Standby/Default/Router/DefaultLogicalSwitch
+	// intact while writing the six LB fields.
+	target, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{"name": "ovn-cluster"},
+		"status": map[string]any{
+			"standby":              true,
+			"default":              true,
+			"router":               "ovn-cluster",
+			"defaultLogicalSwitch": "ovn-default",
+		},
+	})
+	require.NoError(t, err)
+
+	merged, err := jsonpatch.MergePatch(target, body)
+	require.NoError(t, err)
+
+	var got struct {
+		Status map[string]any `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(merged, &got))
+
+	require.Equal(t, true, got.Status["standby"], "Standby must survive the LB patch")
+	require.Equal(t, true, got.Status["default"], "Default must survive the LB patch")
+	require.Equal(t, "ovn-cluster", got.Status["router"], "Router must survive the LB patch")
+	require.Equal(t, "ovn-default", got.Status["defaultLogicalSwitch"], "DefaultLogicalSwitch must survive the LB patch")
+
+	require.Equal(t, vpcLb.TCPLoadBalancer, got.Status["tcpLoadBalancer"])
+	require.Equal(t, vpcLb.TCPSessLoadBalancer, got.Status["tcpSessionLoadBalancer"])
+	require.Equal(t, vpcLb.UDPLoadBalancer, got.Status["udpLoadBalancer"])
+	require.Equal(t, vpcLb.UDPSessLoadBalancer, got.Status["udpSessionLoadBalancer"])
+	require.Equal(t, vpcLb.SctpLoadBalancer, got.Status["sctpLoadBalancer"])
+	require.Equal(t, vpcLb.SctpSessLoadBalancer, got.Status["sctpSessionLoadBalancer"])
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
## Summary

- Fixes an occasional deadlock at `helm install` time where the kube-ovn-controller kept looping on `logical switch join not ready, requeue vpc ovn-cluster` while the subnet worker reported `the vpc 'ovn-cluster' not standby yet`, ultimately timing out `helm install --wait`.
- Root cause: `initLoadBalancer` used `vpc.Status.Bytes()` + `MergePatch`, which serializes the whole `VpcStatus`. When the VPC informer cache had absorbed only the ADD watch event (Standby=false) but not the subsequent MODIFY event from `InitDefaultVpc` (Standby=true), the patch body carried `"standby":false` and the merge patch silently overwrote `Standby/Default/Router/DefaultLogicalSwitch` in etcd.
- Fix: replace the whole-status patch with a field-scoped merge patch that only carries the six LB-name fields. Standby and the other `InitDefaultVpc`-owned fields are no longer touched here, so the race cannot regress them. The subnet worker still sees the LB names on its first reconcile and continues to attach them to the logical switch as before.

See [HA E2E (false, false, ipv6) run 24622570643](https://github.com/kubeovn/kube-ovn/actions/runs/24622570643) for the original failure.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go test ./pkg/controller/ -run 'Test_handleAddOrUpdateVpc|Test_allSubnetReady|TestDiffPolicy'`
- [x] Offline merge-patch simulation confirming that the new body preserves `standby/default/router/defaultLogicalSwitch` under an `InitDefaultVpc`'d status while writing the six LB fields
- [ ] Kube-OVN HA E2E (ipv4/ipv6/dual) green on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)