### PR TITLE
fix(slr): snapshot subnet/VPC in SwitchLBRuleInfo to avoid VIP leak

### DIFF
--- a/pkg/controller/switch_lb_rule.go
+++ b/pkg/controller/switch_lb_rule.go
@@ -22,6 +22,8 @@ import (
 type SwitchLBRuleInfo struct {
 	Name       string
 	Namespace  string
+	Subnet     string
+	VPC        string
 	IsRecreate bool
 	Vips       []string
 }
@@ -44,6 +46,8 @@ func NewSwitchLBRuleInfo(slr *kubeovnv1.SwitchLBRule) *SwitchLBRuleInfo {
 	return &SwitchLBRuleInfo{
 		Name:      slr.Name,
 		Namespace: namespace,
+		Subnet:    slr.Annotations[util.LogicalSwitchAnnotation],
+		VPC:       slr.Annotations[util.LogicalRouterAnnotation],
 		Vips:      vips,
 	}
 }
@@ -227,6 +231,16 @@ func (c *Controller) handleDelSwitchLBRule(info *SwitchLBRuleInfo) error {
 		if vpcForSlr = svc.Annotations[util.VpcAnnotation]; vpcForSlr == "" {
 			vpcForSlr = svc.Annotations[util.LogicalRouterAnnotation]
 		}
+	}
+	// Fall back to the SLR's own annotations snapshotted at enqueue time. This keeps
+	// the VIP cleanup path robust when a concurrent service-delete event races ahead
+	// of the SLR delete worker and removes the service from the lister before we can
+	// read its annotations.
+	if subnetForVip == "" {
+		subnetForVip = info.Subnet
+	}
+	if vpcForSlr == "" {
+		vpcForSlr = info.VPC
 	}
 	if err = c.config.KubeClient.CoreV1().Services(info.Namespace).Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
 		if !k8serrors.IsNotFound(err) {

--- a/pkg/controller/switch_lb_rule_test.go
+++ b/pkg/controller/switch_lb_rule_test.go
@@ -337,6 +337,84 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		require.True(t, k8serrors.IsNotFound(err), "VIP %s should have been deleted via fallback path", subnetName)
 	})
 
+	t.Run("service missing from lister falls back to info.Subnet", func(t *testing.T) {
+		fc := setupHandleDelSLRTest(t, vpcName, subnetName, slrName, namespace, tcpLBName)
+
+		// Simulate a racing service-delete event that removed the backing service
+		// from both the informer cache and the API before the SLR delete worker ran.
+		svcName := generateSvcName(slrName)
+		svc, err := fc.fakeController.config.KubeClient.CoreV1().Services(namespace).Get(context.Background(), svcName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeInformers.serviceInformer.Informer().GetStore().Delete(svc))
+		require.NoError(t, fc.fakeController.config.KubeClient.CoreV1().Services(namespace).Delete(context.Background(), svcName, metav1.DeleteOptions{}))
+
+		// With no LBHC matching info.Vips and the service gone, the handler must
+		// still clean up the VIP via the subnet recorded on info.Subnet.
+		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
+		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
+
+		info := &SwitchLBRuleInfo{
+			Name:      slrName,
+			Namespace: namespace,
+			Subnet:    subnetName,
+			Vips:      []string{vip1},
+		}
+		err = fc.fakeController.handleDelSwitchLBRule(info)
+		require.NoError(t, err)
+
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Get(context.Background(), subnetName, metav1.GetOptions{})
+		require.True(t, k8serrors.IsNotFound(err), "VIP %s should have been deleted via info.Subnet fallback", subnetName)
+	})
+
+	t.Run("service missing from lister still honours info.VPC scoping", func(t *testing.T) {
+		fc := setupHandleDelSLRTest(t, vpcName, subnetName, slrName, namespace, tcpLBName)
+
+		svcName := generateSvcName(slrName)
+		svc, err := fc.fakeController.config.KubeClient.CoreV1().Services(namespace).Get(context.Background(), svcName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeInformers.serviceInformer.Informer().GetStore().Delete(svc))
+		require.NoError(t, fc.fakeController.config.KubeClient.CoreV1().Services(namespace).Delete(context.Background(), svcName, metav1.DeleteOptions{}))
+
+		// Matching LBHC is referenced by a DIFFERENT VPC's LB; without info.VPC the
+		// handler would fall back to unscoped deletion and remove a health check
+		// that still belongs to another VPC.  With info.VPC set we must skip it.
+		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return(
+			[]ovnnb.LoadBalancerHealthCheck{{
+				UUID:        lbhcUUID1,
+				Vip:         vip1,
+				ExternalIDs: map[string]string{util.SwitchLBRuleSubnet: subnetName},
+			}}, nil,
+		)
+		fc.mockOvnClient.EXPECT().ListLoadBalancers(gomock.Any()).Return(
+			[]ovnnb.LoadBalancer{{
+				Name:        "vpc-other-tcp-load",
+				HealthCheck: []string{lbhcUUID1},
+			}}, nil,
+		)
+		// Fallback VIP-by-subnet lookup still finds the foreign LBHC, so the VIP
+		// must stay.
+		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return(
+			[]ovnnb.LoadBalancerHealthCheck{{
+				UUID:        lbhcUUID1,
+				Vip:         vip1,
+				ExternalIDs: map[string]string{util.SwitchLBRuleSubnet: subnetName},
+			}}, nil,
+		)
+
+		info := &SwitchLBRuleInfo{
+			Name:      slrName,
+			Namespace: namespace,
+			Subnet:    subnetName,
+			VPC:       vpcName,
+			Vips:      []string{vip1},
+		}
+		err = fc.fakeController.handleDelSwitchLBRule(info)
+		require.NoError(t, err)
+
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Get(context.Background(), subnetName, metav1.GetOptions{})
+		require.NoError(t, err, "VIP %s should still exist (other VPC owns the LBHC)", subnetName)
+	})
+
 	t.Run("multiple orphaned LBHCs for same subnet should all be cleaned up", func(t *testing.T) {
 		fc := setupHandleDelSLRTest(t, vpcName, subnetName, slrName, namespace, tcpLBName)
 

--- a/test/e2e/kube-ovn/switch_lb_rule/ip_port_mapping.go
+++ b/test/e2e/kube-ovn/switch_lb_rule/ip_port_mapping.go
@@ -250,7 +250,6 @@ var _ = framework.Describe("[group:slr-ip-port-mapping]", func() {
 
 		ginkgo.By("Cleanup")
 		switchLBRuleClient.DeleteSync(slrName)
-		serviceClient.Delete(svcName)
 		stsClient.Delete(stsName)
 		framework.ExpectNoError(stsClient.WaitToDisappear(stsName, 0, 2*time.Minute))
 	})
@@ -356,7 +355,6 @@ var _ = framework.Describe("[group:slr-ip-port-mapping]", func() {
 
 		ginkgo.By("Cleanup")
 		switchLBRuleClient.DeleteSync(slrName)
-		serviceClient.Delete(svcName)
 		stsClient.Delete(stsName)
 		framework.ExpectNoError(stsClient.WaitToDisappear(stsName, 0, 2*time.Minute))
 	})
@@ -495,8 +493,6 @@ var _ = framework.Describe("[group:slr-ip-port-mapping]", func() {
 		ginkgo.By("Cleanup")
 		switchLBRuleClient.DeleteSync(slr1Name)
 		switchLBRuleClient.DeleteSync(slr2Name)
-		serviceClient.Delete(svc1Name)
-		serviceClient.Delete(svc2Name)
 		stsClient.Delete(stsName)
 		framework.ExpectNoError(stsClient.WaitToDisappear(stsName, 0, 2*time.Minute))
 	})


### PR DESCRIPTION
## Summary
- Fix a shared health-check VIP leak that strands a subnet in `Terminating` when two SLRs are deleted back-to-back (surfaced by CI run 24631834558, test `should not delete shared backends when updating multiple SwitchLBRules`).
- Snapshot the SLR's `ovn.kubernetes.io/logical_switch` / `logical_router` annotations into `SwitchLBRuleInfo` at enqueue time, so `handleDelSwitchLBRule` can still recover `subnetForVip`/`vpcForSlr` when a racing service-delete event removes the backing service from the lister before the SLR delete worker reads its annotations.
- Drop the redundant explicit `serviceClient.Delete(...)` calls from the three `ip_port_mapping` e2e specs — the SLR delete handler already owns that cleanup, and the extra delete only widens the race window.

## Root cause (detailed)
1. Health-check VIP CR is shared across SLRs in the same subnet (`endpoint_slice.go:577` uses `vipName = subnetName`), ref-counted by LBHCs tagged with `ExternalIDs[SwitchLBRuleSubnet]`.
2. When an SLR is deleted, `handleDeleteService` can run *before* `handleDelSwitchLBRule` (separate workers). Its `LoadBalancerDeleteVip` sees `len(lb.IPPortMappings) != 0` on a shared LB and flips `ignoreHealthCheck=false` (`pkg/ovs/ovn-nb-load_balancer.go:157-170`), deleting the LBHC.
3. `handleDelSwitchLBRule` then finds `servicesLister.Get(name)` → NotFound → `subnetForVip=""`; LBHC lookup by VIP is empty; the existing subnet fallback at `switch_lb_rule.go:332` requires `subnetForVip != ""` → skipped.
4. VIP CR is never deleted → its IP keeps `subnet.v4usingIPs > 0` → finalizer never removed → subnet stuck 120s, AfterEach fails at `ip_port_mapping.go:156`.

## Test plan
- [x] `make lint` — 0 issues
- [x] `go build ./...` — clean
- [ ] CI: Kube-OVN Conformance E2E (ipv4, underlay) — should pass without the prior flake
- [ ] CI: full e2e matrix — should remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)