### PR TITLE
ovn_eip: rewrite IPv6 addresses for label-value safety when creating OvnEip CRs

### DIFF
--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -308,7 +308,10 @@ func (c *Controller) createOrUpdateOvnEipCR(key, subnet, v4ip, v6ip, mac, usageT
 						util.SubnetNameLabel: subnet,
 						util.OvnEipTypeLabel: usageType,
 						util.EipV4IpLabel:    v4ip,
-						util.EipV6IpLabel:    v6ip,
+						// IPv6 addresses contain ':' which is not a valid
+						// label-value character; rewrite via util.IPForLabel
+						// so the CR Create doesn't fail (#6643).
+						util.EipV6IpLabel: util.IPForLabel(v6ip),
 					},
 				},
 				Spec: kubeovnv1.OvnEipSpec{
@@ -348,7 +351,7 @@ func (c *Controller) createOrUpdateOvnEipCR(key, subnet, v4ip, v6ip, mac, usageT
 		ovnEip.Labels[util.SubnetNameLabel] = subnet
 		ovnEip.Labels[util.OvnEipTypeLabel] = usageType
 		ovnEip.Labels[util.EipV4IpLabel] = v4ip
-		ovnEip.Labels[util.EipV6IpLabel] = v6ip
+		ovnEip.Labels[util.EipV6IpLabel] = util.IPForLabel(v6ip)
 
 		needUpdate := false
 		if mac != "" && ovnEip.Spec.MacAddress != mac {

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -20,4 +21,24 @@ func NormalizeLabelValue(value string) string {
 	hash := Sha256Hash([]byte(value))[:labelValueHashLength]
 	prefixLen := validation.LabelValueMaxLength - labelValueHashLength - 1
 	return fmt.Sprintf("%s-%s", value[:prefixLen], hash)
+}
+
+// IPForLabel rewrites an IP address into a Kubernetes-label-value-safe form.
+// IPv4 addresses already satisfy the `[a-zA-Z0-9._-]` rule and are returned
+// as-is. IPv6 addresses contain `:`, which isn't a permitted character, so
+// colons are replaced with `.` and any leading/trailing `.` (from `::`) is
+// padded with `v6` so the result still starts and ends with alphanumerics.
+// Empty input is passed through unchanged.
+func IPForLabel(ip string) string {
+	if ip == "" || !strings.Contains(ip, ":") {
+		return ip
+	}
+	s := strings.ReplaceAll(ip, ":", ".")
+	if strings.HasPrefix(s, ".") {
+		s = "v6" + s
+	}
+	if strings.HasSuffix(s, ".") {
+		s = s + "v6"
+	}
+	return s
 }


### PR DESCRIPTION
## Summary

`createOrUpdateOvnEipCR` stores the allocated V6 IP straight into the `EipV6IpLabel` label value. Kubernetes label values only permit `[a-zA-Z0-9._-]`, so any IPv6 address (which contains `:`) makes the OvnEip Create fail with:

```
OvnEip.kubeovn.io "tenant-vpc-external" is invalid:
  metadata.labels: Invalid value: "1001:11d0:303:21c1:2000::100":
    a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.',
    and must start and end with an alphanumeric character
```

The controller then CrashLoops whenever a VPC sets `enableExternal` with an IPv6 or dual-stack external subnet (#6643).

Fixes #6643.

## Change

Add a small `util.IPForLabel` helper that:

- Returns empty input and IPv4 addresses unchanged.
- Replaces `:` with `.` for IPv6 so the string only contains `[a-zA-Z0-9.]`.
- Pads any leading/trailing `.` (which comes from `::` zero-compression) with `v6` so the result still starts and ends with alphanumerics.

Use it at both the Create and Update call sites in `ovn_eip.go`. The V4 selector at `ovn_eip.go:~610` only uses `EipV4IpLabel`, so it's unaffected.

Examples:

| IP | IPForLabel |
| --- | --- |
| `10.0.0.1` | `10.0.0.1` |
| `2001:db8::1` | `2001.db8..1` |
| `::1` | `v6..1` |
| `2001::` | `2001..v6` |

## Testing

- `make test` passes.
- Added a local regression: applying the reporter's VPC + IPv6 subnet manifest now creates the `OvnEip` CR successfully; previously the Create was rejected by the API server and the controller crashed.
