### PR TITLE
fix(daemon): also compare gateway when checking if route already exists

### DIFF
--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -644,10 +644,12 @@ func routeDiff(nodeNicRoutes, allRoutes []netlink.Route, cidrs, joinCIDR []strin
 					klog.V(3).Infof("[routeDiff] joinCIDR route already exists in allRoutes: %v", ar)
 					break
 				} else if (ar.Src == nil && src == nil) || (ar.Src != nil && src != nil && ar.Src.Equal(src)) {
-					// For non-join subnets, both Dst and Src must be the same
-					found = true
-					klog.V(3).Infof("[routeDiff] route already exists in allRoutes: %v", ar)
-					break
+					// For non-join subnets, Dst, Src, and Gw must all be the same
+					if (ar.Gw == nil && gw == nil) || (ar.Gw != nil && gw != nil && ar.Gw.Equal(gw)) {
+						found = true
+						klog.V(3).Infof("[routeDiff] route already exists in allRoutes: %v", ar)
+						break
+					}
 				}
 			}
 		}
@@ -659,8 +661,10 @@ func routeDiff(nodeNicRoutes, allRoutes []netlink.Route, cidrs, joinCIDR []strin
 				continue
 			}
 			if (src == nil && r.Src == nil) || (src != nil && r.Src != nil && src.Equal(r.Src)) {
-				found = true
-				break
+				if (r.Gw == nil && gw == nil) || (r.Gw != nil && gw != nil && gw.Equal(r.Gw)) {
+					found = true
+					break
+				}
 			}
 		}
 		if !found {


### PR DESCRIPTION
When the join subnet gains an IPv6 gateway after routes were already added without one (Gw=nil), the existing routeDiff logic only compared Dst and Src, causing the stale no-gateway route to never be replaced.

Add Gw comparison to both the allRoutes and nodeNicRoutes checks so that a route with a mismatched (or missing) gateway is treated as absent and replaced via netlink.RouteReplace.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
