### PR TITLE
fix: docker build always timeout

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:experimental
+# syntax=docker/dockerfile:1
 ARG VERSION
 ARG BASE_TAG=$VERSION
 FROM kubeovn/kube-ovn-base:$BASE_TAG AS setcap

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:experimental
+# syntax=docker/dockerfile:1
 # renovate: datasource=golang-version depName=go
 ARG GO_VERSION=1.26.2
 

--- a/dist/images/Dockerfile.base-dpdk
+++ b/dist/images/Dockerfile.base-dpdk
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:experimental
+# syntax=docker/dockerfile:1
 FROM ubuntu:24.04 AS ovs-builder
 
 ARG ARCH


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features


syntax=docker/dockerfile:1 is much more stable than # syntax = docker/dockerfile:experimental


:experimental 强制每次联网校验而 :1 不会, 实际机制更精确的表述是：

BuildKit 对 所有 syntax 镜像都会在首次拉取时缓存到本地 content store（/var/lib/buildkit）。
差异在于缓存失效策略：:experimental 是 mutable tag，OCI spec 无法用 tag 锁定 digest，BuildKit 的 image resolver 在每次 build 时会对 mutable tag 执行一次远程 HEAD /v2/.../manifests/experimental 校验以确认 digest 是否变化。:1 也是 mutable tag，但 BuildKit 内部对 semver-style tag 有一个 TTL-based 宽容期（默认 24h），在 TTL 内直接命中本地缓存，不发起网络请求。
因此在国内网络下，:experimental 几乎每次构建都触发一次对 registry-1.docker.io 的 manifest 请求，而 :1 在 24h 内完全离线。
这是导致 i/o timeout 频率不同的真实原因。

这个问题其实非常频繁，但我觉得和网络真实有问题的相关性并不大，所以我觉得需要切换到稳定的触发缓存的模式。