### PR TITLE
fix: adds env NODE_NAME in speaker pod

### DIFF
--- a/charts/kube-ovn-v2/templates/speaker/speaker.yaml
+++ b/charts/kube-ovn-v2/templates/speaker/speaker.yaml
@@ -82,6 +82,10 @@ spec:
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: POD_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

Adds a `NODE_NAME` variable in the kube-ovn-speaker pod, which is necessary to determine the host on which the speaker is running for use BGP Local Announcement Policy, if you look at [1](https://github.com/kubeovn/kube-ovn/blob/b49190cbb9d1ee17a4ce47a76005827b2ca42a3e/pkg/speaker/subnet.go#L94), [2](https://github.com/kubeovn/kube-ovn/blob/master/pkg/speaker/config.go#L89), [3](https://github.com/kubeovn/kube-ovn/blob/master/pkg/util/const.go#L368).

## Which issue(s) this PR fixes

Fixes #6654
