### PR TITLE
fix(controller): keep VM LSP port-group memberships when a sibling pod is alive

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1222,7 +1222,8 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 	}
 	if keepIPCR {
 		for _, port := range ports {
-			if vmOrphanedPorts[port.Name] {
+			switch {
+			case vmOrphanedPorts[port.Name]:
 				// Orphaned attachment LSP from NAD hotplug: delete and release its IP.
 				klog.Infof("delete orphaned vm attachment lsp %s", port.Name)
 				if err := c.OVNNbClient.DeleteLogicalSwitchPort(port.Name); err != nil {
@@ -1249,9 +1250,9 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 						c.updateSubnetStatusQueue.Add(subnetName)
 					}
 				}
-			} else if hasAliveVMSibling {
+			case hasAliveVMSibling:
 				klog.Infof("skip removing lsp %s from port groups: another alive virt-launcher pod exists for vm %s/%s", port.Name, pod.Namespace, vmName)
-			} else {
+			default:
 				klog.Infof("remove lsp %s from all port groups", port.Name)
 				if err = c.OVNNbClient.RemovePortFromPortGroups(port.Name); err != nil {
 					klog.Errorf("failed to remove lsp %s from all port groups: %v", port.Name, err)

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1166,6 +1166,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 		return err
 	}
 
+	var hasAliveVMSibling bool
 	isVMPod, vmName := isVMPod(pod)
 	if isVMPod && c.config.EnableKeepVMIP {
 		for _, port := range ports {
@@ -1181,6 +1182,18 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			if !isOwnerRefToDel {
 				klog.Infof("try keep ip for vm pod %s", podKey)
 				keepIPCR = true
+				// The VM LSP is shared across every virt-launcher pod of the VM
+				// (ExternalIDs["pod"] is keyed by VM name). Port-group memberships,
+				// however, belong to whichever virt-launcher pod is currently
+				// running the VM. If another live sibling exists (e.g. a
+				// live-migration destination while the completed source is being
+				// GC'd), its memberships must not be wiped out.
+				siblings, listErr := c.podsLister.Pods(pod.Namespace).List(labels.Everything())
+				if listErr != nil {
+					klog.Errorf("failed to list pods in namespace %s: %v", pod.Namespace, listErr)
+					return listErr
+				}
+				hasAliveVMSibling = hasAliveSiblingVMPod(siblings, vmName, pod.Name)
 			}
 		}
 		if keepIPCR {
@@ -1236,6 +1249,8 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 						c.updateSubnetStatusQueue.Add(subnetName)
 					}
 				}
+			} else if hasAliveVMSibling {
+				klog.Infof("skip removing lsp %s from port groups: another alive virt-launcher pod exists for vm %s/%s", port.Name, pod.Namespace, vmName)
 			} else {
 				klog.Infof("remove lsp %s from all port groups", port.Name)
 				if err = c.OVNNbClient.RemovePortFromPortGroups(port.Name); err != nil {
@@ -2667,6 +2682,27 @@ func isVMPod(pod *v1.Pod) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+// hasAliveSiblingVMPod reports whether pods contains any alive virt-launcher
+// pod owned by the VMI vmName, excluding the pod with name excludePodName.
+// It is used to decide whether a VM LSP's port-group memberships are still
+// owned by another running sibling (e.g. a live-migration destination) when a
+// completed/GC'd source pod is being processed.
+func hasAliveSiblingVMPod(pods []*v1.Pod, vmName, excludePodName string) bool {
+	for _, p := range pods {
+		if p == nil || p.Name == excludePodName {
+			continue
+		}
+		isVM, name := isVMPod(p)
+		if !isVM || name != vmName {
+			continue
+		}
+		if isPodAlive(p) {
+			return true
+		}
+	}
+	return false
 }
 
 func isOwnsByTheVM(vmi metav1.Object) (bool, string) {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/internal"
@@ -839,4 +840,106 @@ func TestDeleteNamedPortByPodWithRestartableInitContainers(t *testing.T) {
 	np.DeleteNamedPortByPod(pod)
 	result = np.GetNamedPortByNs("test-ns")
 	assert.Empty(t, result, "both regular and sidecar init container named ports should be deleted")
+}
+
+func TestHasAliveSiblingVMPod(t *testing.T) {
+	vmiOwner := func(vmName string) []metav1.OwnerReference {
+		return []metav1.OwnerReference{
+			{
+				APIVersion: kubevirtv1.SchemeGroupVersion.String(),
+				Kind:       util.KindVirtualMachineInstance,
+				Name:       vmName,
+			},
+		}
+	}
+	vmPod := func(name, vmName string, phase corev1.PodPhase, deleted bool) *corev1.Pod {
+		p := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "ns",
+				Name:            name,
+				OwnerReferences: vmiOwner(vmName),
+			},
+			Status: corev1.PodStatus{Phase: phase},
+		}
+		if deleted {
+			now := metav1.Now()
+			p.DeletionTimestamp = &now
+			grace := int64(0)
+			p.DeletionGracePeriodSeconds = &grace
+		}
+		return p
+	}
+
+	tests := []struct {
+		name           string
+		pods           []*corev1.Pod
+		vmName         string
+		excludePodName string
+		want           bool
+	}{
+		{
+			name:           "no siblings",
+			pods:           []*corev1.Pod{vmPod("virt-launcher-vm-aaa", "vm", corev1.PodRunning, false)},
+			vmName:         "vm",
+			excludePodName: "virt-launcher-vm-aaa",
+			want:           false,
+		},
+		{
+			name: "alive sibling exists",
+			pods: []*corev1.Pod{
+				vmPod("virt-launcher-vm-aaa", "vm", corev1.PodSucceeded, true),
+				vmPod("virt-launcher-vm-bbb", "vm", corev1.PodRunning, false),
+			},
+			vmName:         "vm",
+			excludePodName: "virt-launcher-vm-aaa",
+			want:           true,
+		},
+		{
+			name: "only completed siblings",
+			pods: []*corev1.Pod{
+				vmPod("virt-launcher-vm-aaa", "vm", corev1.PodSucceeded, true),
+				vmPod("virt-launcher-vm-bbb", "vm", corev1.PodSucceeded, false),
+			},
+			vmName:         "vm",
+			excludePodName: "virt-launcher-vm-aaa",
+			want:           false,
+		},
+		{
+			name: "sibling belongs to different vm",
+			pods: []*corev1.Pod{
+				vmPod("virt-launcher-other-xxx", "other", corev1.PodRunning, false),
+			},
+			vmName:         "vm",
+			excludePodName: "virt-launcher-vm-aaa",
+			want:           false,
+		},
+		{
+			name: "non-vm pod ignored",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "plain-pod"},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+				},
+			},
+			vmName:         "vm",
+			excludePodName: "virt-launcher-vm-aaa",
+			want:           false,
+		},
+		{
+			name: "excluded pod ignored even when alive",
+			pods: []*corev1.Pod{
+				vmPod("virt-launcher-vm-aaa", "vm", corev1.PodRunning, false),
+			},
+			vmName:         "vm",
+			excludePodName: "virt-launcher-vm-aaa",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasAliveSiblingVMPod(tt.pods, tt.vmName, tt.excludePodName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

For VM pods with `EnableKeepVMIP=true` a single LSP is shared across every virt-launcher pod of the VM (`ExternalIDs["pod"]` is keyed by VM name, not by pod name). When kubernetes GCs a completed virt-launcher pod — most commonly the source of a successful live migration — `handleDeletePod` finds that LSP, and because `isVMToDel` is false it calls `RemovePortFromPortGroups(port.Name)` with no port-group names, which strips the LSP from every port group (node, subnet, security group, network policy).

The LSP is still in use by the currently running destination pod, so the active VM pod loses its memberships and connectivity until `kube-ovn-controller` is restarted and all pods are re-synced.

Before stripping port-group memberships in the `keepIPCR` branch, check whether another alive virt-launcher pod exists for the same VMI. If so, the memberships belong to that sibling and must be preserved. Added a unit test covering the sibling-detection logic.

## Which issue(s) this PR fixes

Fixes #6665
