### PR TITLE
fix(speaker): require NODE_NAME and inject POD_IPS in v2 chart

### DIFF
--- a/charts/kube-ovn-v2/templates/speaker/speaker.yaml
+++ b/charts/kube-ovn-v2/templates/speaker/speaker.yaml
@@ -90,6 +90,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
             {{- with .Values.bgpSpeaker.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -232,6 +232,9 @@ func (config *Configuration) validateRequiredFlags() error {
 	if config.NeighborAs == 0 {
 		missingFlags = append(missingFlags, "--neighbor-as must be specified")
 	}
+	if config.NodeName == "" {
+		missingFlags = append(missingFlags, "--node-name must be specified (usually via NODE_NAME env from downward API)")
+	}
 
 	if len(missingFlags) > 0 {
 		return fmt.Errorf("missing required flags: %s", strings.Join(missingFlags, "; "))

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -232,7 +232,10 @@ func (config *Configuration) validateRequiredFlags() error {
 	if config.NeighborAs == 0 {
 		missingFlags = append(missingFlags, "--neighbor-as must be specified")
 	}
-	if config.NodeName == "" {
+	// NodeName is only used for the BGP "local" policy match in syncSubnetRoutes;
+	// NAT GW mode runs syncEIPRoutes exclusively and never reads NodeName, so skip
+	// the requirement there to stay compatible with GenNatGwBgpSpeakerContainer.
+	if !config.NatGwMode && config.NodeName == "" {
 		missingFlags = append(missingFlags, "--node-name must be specified (usually via NODE_NAME env from downward API)")
 	}
 

--- a/pkg/speaker/config_test.go
+++ b/pkg/speaker/config_test.go
@@ -20,6 +20,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
 				ClusterAs:         65000,
 				NeighborAs:        65001,
+				NodeName:          "node1",
 			},
 			expectError: false,
 		},
@@ -29,6 +30,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 				NeighborIPv6Addresses: []net.IP{net.ParseIP("2001:db8::1")},
 				ClusterAs:             65000,
 				NeighborAs:            65001,
+				NodeName:              "node1",
 			},
 			expectError: false,
 		},
@@ -39,6 +41,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 				NeighborIPv6Addresses: []net.IP{net.ParseIP("2001:db8::1")},
 				ClusterAs:             65000,
 				NeighborAs:            65001,
+				NodeName:              "node1",
 			},
 			expectError: false,
 		},
@@ -47,6 +50,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 			config: &Configuration{
 				ClusterAs:  65000,
 				NeighborAs: 65001,
+				NodeName:   "node1",
 			},
 			expectError: true,
 			errContains: []string{"neighbor-address", "neighbor-ipv6-address"},
@@ -56,6 +60,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 			config: &Configuration{
 				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
 				NeighborAs:        65001,
+				NodeName:          "node1",
 			},
 			expectError: true,
 			errContains: []string{"cluster-as"},
@@ -65,15 +70,26 @@ func TestValidateRequiredFlags(t *testing.T) {
 			config: &Configuration{
 				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
 				ClusterAs:         65000,
+				NodeName:          "node1",
 			},
 			expectError: true,
 			errContains: []string{"neighbor-as"},
 		},
 		{
+			name: "missing node-name",
+			config: &Configuration{
+				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				ClusterAs:         65000,
+				NeighborAs:        65001,
+			},
+			expectError: true,
+			errContains: []string{"node-name"},
+		},
+		{
 			name:        "missing all required flags",
 			config:      &Configuration{},
 			expectError: true,
-			errContains: []string{"neighbor-address", "cluster-as", "neighbor-as"},
+			errContains: []string{"neighbor-address", "cluster-as", "neighbor-as", "node-name"},
 		},
 	}
 

--- a/pkg/speaker/config_test.go
+++ b/pkg/speaker/config_test.go
@@ -86,6 +86,16 @@ func TestValidateRequiredFlags(t *testing.T) {
 			errContains: []string{"node-name"},
 		},
 		{
+			name: "nat-gw mode does not require node-name",
+			config: &Configuration{
+				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				ClusterAs:         65000,
+				NeighborAs:        65001,
+				NatGwMode:         true,
+			},
+			expectError: false,
+		},
+		{
 			name:        "missing all required flags",
 			config:      &Configuration{},
 			expectError: true,


### PR DESCRIPTION
## Summary

Follow-up to #6664 / #6654. Two related hardening changes to the BGP speaker:

- **Add `POD_IPS` env to the kube-ovn-v2 speaker DaemonSet.** `pkg/speaker/config.go` prefers `POD_IPS` and only falls back to `POD_IP`, so dual-stack nodes were losing the second protocol stack after the v2 chart rewrite. `yamls/speaker.yaml` already had this env — the chart is now aligned.
- **Fail speaker startup when `--node-name` is empty.** Without `NODE_NAME` env, the speaker silently mismatches every pod under the `ovn.kubernetes.io/bgp=local` policy (see issue #6654 for the painful debugging trail). The new check is aggregated into the existing `validateRequiredFlags` so startup fails fast with a clear error.

## Test plan

- [x] `go test ./pkg/speaker/... -run TestValidateRequiredFlags -v` — all 8 subcases pass, including the new `missing node-name` case
- [x] `go test ./pkg/speaker/...` — full package green
- [x] `make lint` — 0 issues
- [x] `helm template charts/kube-ovn-v2 --set bgpSpeaker.enabled=true` renders `NODE_NAME`, `POD_IP`, `POD_IPS` in the speaker DaemonSet
- [ ] Manual check in a dual-stack cluster that speaker picks up both v4/v6 pod IPs after upgrade

## Fixes

Follow-up hardening around #6654 / #6664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)