### PR TITLE
ci: raise Iptables VPC NAT Gateway E2E timeout to 45m

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -3275,7 +3275,7 @@ jobs:
       - build-vpc-nat-gateway
       - build-e2e-binaries
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: jlumbroso/free-disk-space@v1.3.1
         with:

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -1277,7 +1277,7 @@ jobs:
   iptables-vpc-nat-gw-conformance-e2e:
     name: Iptables VPC NAT Gateway E2E
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Raise `timeout-minutes` from 30→45 in `build-x86-image.yaml` and from 15→45 in `scheduled-e2e.yaml` for the `Iptables VPC NAT Gateway E2E` job.
- Recent successful runs consistently take ~25–26 min, leaving <5 min of slack on the 30 min cap. Run [24733377791](https://github.com/kubeovn/kube-ovn/actions/runs/24733377791) was cancelled at 30m13s with all observed tests passing, blocked only by the test suite budget.
- 45 min matches other e2e jobs in the same workflow and covers runner-level jitter plus the naturally growing per-case runtime of `iptables-eip-qos` (2m34s → 3m19s → 4m11s across the first three ConformanceIt cases).

## Test plan
- [ ] `Build x86 Image / Iptables VPC NAT Gateway E2E` completes under the new 45 min cap on this PR.
- [ ] No other job is affected (only two `timeout-minutes` values touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)