### PR TITLE
fix(lb): skip ct_flush on session-affinity UDP load balancers

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -287,7 +287,12 @@ func (c *Controller) initLB(name, protocol string, sessionAffinity bool) error {
 		return err
 	}
 
-	if protocol == "udp" {
+	// ct_flush wipes all conntrack entries on the LB's datapath whenever a vip
+	// is mutated. Session-affinity LBs are shared across services, and their
+	// per-client affinity binding is carried in conntrack; enabling ct_flush on
+	// those LBs lets an unrelated service's backend change invalidate another
+	// service's active affinity. Only enable ct_flush on non-session UDP LBs.
+	if protocol == "udp" && !sessionAffinity {
 		if err = c.OVNNbClient.SetLoadBalancerCtFlush(name, true); err != nil {
 			klog.Errorf("failed to set ct_flush for load balancer %s: %v", name, err)
 			return err

--- a/pkg/controller/init_test.go
+++ b/pkg/controller/init_test.go
@@ -6,8 +6,11 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func TestHasAllocatedAnnotation(t *testing.T) {
@@ -157,4 +160,81 @@ func keysOf(m map[string]json.RawMessage) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// TestInitLB_SkipsCtFlushForSessionAffinityUDP is the regression guard for a
+// cross-namespace UDP session-affinity breakage. ct_flush wipes all conntrack
+// entries on the LB's datapath whenever any vip is mutated. Since the session
+// UDP LB (UDPSessLoadBalancer) is shared by every service in the VPC, enabling
+// ct_flush on it lets an unrelated service's backend change invalidate the
+// affinity state of any concurrently running session-affinity service, landing
+// subsequent packets on a different backend. initLB must therefore only set
+// ct_flush=true on the non-session UDP LB.
+func TestInitLB_SkipsCtFlushForSessionAffinityUDP(t *testing.T) {
+	tests := []struct {
+		name              string
+		protocol          string
+		sessionAffinity   bool
+		expectCtFlushCall bool
+	}{
+		{
+			name:              "udp non-session LB enables ct_flush",
+			protocol:          "udp",
+			sessionAffinity:   false,
+			expectCtFlushCall: true,
+		},
+		{
+			name:              "udp session-affinity LB skips ct_flush",
+			protocol:          "udp",
+			sessionAffinity:   true,
+			expectCtFlushCall: false,
+		},
+		{
+			name:              "tcp non-session LB skips ct_flush",
+			protocol:          "tcp",
+			sessionAffinity:   false,
+			expectCtFlushCall: false,
+		},
+		{
+			name:              "tcp session-affinity LB skips ct_flush",
+			protocol:          "tcp",
+			sessionAffinity:   true,
+			expectCtFlushCall: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeCtrl, err := newFakeControllerWithOptions(t, nil)
+			require.NoError(t, err)
+			ctrl := fakeCtrl.fakeController
+			mockOvnClient := fakeCtrl.mockOvnClient
+
+			lbName := "cluster-" + tt.protocol + "-test-loadbalancer"
+
+			mockOvnClient.EXPECT().
+				CreateLoadBalancer(lbName, tt.protocol, gomock.Any()).
+				Return(nil)
+			if tt.sessionAffinity {
+				mockOvnClient.EXPECT().
+					SetLoadBalancerAffinityTimeout(lbName, util.DefaultServiceSessionStickinessTimeout).
+					Return(nil)
+			}
+			mockOvnClient.EXPECT().
+				SetLoadBalancerPreferLocalBackend(lbName, gomock.Any()).
+				Return(nil)
+
+			if tt.expectCtFlushCall {
+				mockOvnClient.EXPECT().
+					SetLoadBalancerCtFlush(lbName, true).
+					Return(nil)
+			} else {
+				mockOvnClient.EXPECT().
+					SetLoadBalancerCtFlush(gomock.Any(), gomock.Any()).
+					Times(0)
+			}
+
+			require.NoError(t, ctrl.initLB(lbName, tt.protocol, tt.sessionAffinity))
+		})
+	}
 }

--- a/pkg/controller/init_test.go
+++ b/pkg/controller/init_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -212,12 +213,20 @@ func TestInitLB_SkipsCtFlushForSessionAffinityUDP(t *testing.T) {
 
 			lbName := "cluster-" + tt.protocol + "-test-loadbalancer"
 
-			mockOvnClient.EXPECT().
-				CreateLoadBalancer(lbName, tt.protocol, gomock.Any()).
-				Return(nil)
 			if tt.sessionAffinity {
 				mockOvnClient.EXPECT().
+					CreateLoadBalancer(
+						lbName, tt.protocol,
+						ovnnb.LoadBalancerSelectionFieldsIPSrc,
+						ovnnb.LoadBalancerSelectionFieldsIpv6Src,
+					).
+					Return(nil)
+				mockOvnClient.EXPECT().
 					SetLoadBalancerAffinityTimeout(lbName, util.DefaultServiceSessionStickinessTimeout).
+					Return(nil)
+			} else {
+				mockOvnClient.EXPECT().
+					CreateLoadBalancer(lbName, tt.protocol).
 					Return(nil)
 			}
 			mockOvnClient.EXPECT().


### PR DESCRIPTION
## Summary
- Stop enabling OVN `ct_flush=true` on the shared per-VPC session UDP LB. ct_flush wipes all conntrack entries on the LB's datapath on any vip mutation; since the session UDP LB is shared by every service in the VPC, that broke `SessionAffinity=ClientIP` whenever another service on the same LB changed its backends mid-session.
- Keep ct_flush on the regular UDP LB (the #6620 goal — avoid rolling-update blackholes) and on per-DNAT UDP LBs (scoped to a single EIP, safe).
- Add `TestInitLB_SkipsCtFlushForSessionAffinityUDP` covering the 4 `{protocol, sessionAffinity}` combinations.

## Background
Surfaced by a flaky k8s dualstack conformance run: `[sig-network] [Feature:IPv6DualStack] ... should function for client IP based session affinity: udp [LinuxOnly]`. Timeline in the failing run:

| t | event |
|---|---|
| 00:19:55 | try 0 → `netserver-0` ✓ (affinity established) |
| 00:20:00 | unrelated namespace `dualstack-8090` removes a backend on the **same** `cluster-udp-session-loadbalancer` |
| 00:20:03 | try 1 → i/o timeout (UDP packet lost during bridge churn) |
| 00:20:05 | try 2 → `netserver-1` ✗ (affinity state wiped by ct_flush) |

Introduced in #6620 which enabled `ct_flush=true` on all UDP LBs including the session one.

## Test plan
- [x] `go test ./pkg/controller/ -run TestInitLB_SkipsCtFlushForSessionAffinityUDP` — 4/4 pass, and confirmed the test goes red if the `!sessionAffinity` guard is reverted
- [x] `make lint` — 0 issues
- [ ] CI: Kubernetes Conformance E2E (dual, overlay) — the flaky case should stop reproducing

🤖 Generated with [Claude Code](https://claude.com/claude-code)