### PR TITLE
feat: add ExternalSubnet column to iptables-eip printer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,13 @@
 
 ## Build, Test, and Development Commands
 - `make build-go` – tidy modules and compile Go binaries for linux/amd64 into `dist/images/`.  
-- `make lint` – run `golangci-lint` plus Go “modernize”; auto-fixes when not in CI.  
+- `make gen-crd` – regenerate CRD YAMLs from kubebuilder annotations in `pkg/apis/kubeovn/v1/`; syncs `charts/`, `yamls/gen/`, and `dist/images/install.sh`.  
+- `make lint` – run `golangci-lint` plus Go "modernize"; auto-fixes when not in CI.  
 - `make ut` – run unit tests: Ginkgo suites in `test/unittest` and `go test` with coverage for `pkg`.  
 
 ## General Coding Guidlines
 - Every time after editing code. MUST run `make lint` to detect and fix potential lint issues.
+- After modifying kubebuilder annotations or CRD-related types in `pkg/apis/kubeovn/v1/`, MUST run `make gen-crd` before `make lint` (lint calls `verify-crd` internally and will fail if CRDs are out of sync).
 - When modifying code, try to clean up any related code logic that is no longer needed.
 - Follow `CODE_STYLE.md`: camelCase identifiers, keep functions short (~100 lines), return/log errors instead of discarding, and prefer `if err := ...; err != nil` patterns. 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@
 
 ## Build, Test, and Development Commands
 - `make build-go` – tidy modules and compile Go binaries for linux/amd64 into `dist/images/`.  
-- `make lint` – run `golangci-lint` plus Go “modernize”; auto-fixes when not in CI.  
+- `make gen-crd` – regenerate CRD YAMLs from kubebuilder annotations in `pkg/apis/kubeovn/v1/`; syncs `charts/`, `yamls/gen/`, and `dist/images/install.sh`.  
+- `make lint` – run `golangci-lint` plus Go "modernize"; auto-fixes when not in CI.  
 - `make ut` – run unit tests: Ginkgo suites in `test/unittest` and `go test` with coverage for `pkg`.  
 
 ## General Coding Guidlines
 - Every time after editing code. MUST run `make lint` to detect and fix potential lint issues.
+- After modifying kubebuilder annotations or CRD-related types in `pkg/apis/kubeovn/v1/`, MUST run `make gen-crd` before `make lint` (lint calls `verify-crd` internally and will fail if CRDs are out of sync).
 - When modifying code, try to clean up any related code logic that is no longer needed.
 - Follow `CODE_STYLE.md`: camelCase identifiers, keep functions short (~100 lines), return/log errors instead of discarding, and prefer `if err := ...; err != nil` patterns. 
 

--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -775,6 +775,9 @@ spec:
     - jsonPath: .spec.namespace
       name: Namespace
       type: string
+    - jsonPath: .spec.externalSubnet
+      name: ExternalSubnet
+      type: string
     - jsonPath: .status.ip
       name: IP
       type: string

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -775,6 +775,9 @@ spec:
     - jsonPath: .spec.namespace
       name: Namespace
       type: string
+    - jsonPath: .spec.externalSubnet
+      name: ExternalSubnet
+      type: string
     - jsonPath: .status.ip
       name: IP
       type: string

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1026,6 +1026,9 @@ spec:
     - jsonPath: .spec.namespace
       name: Namespace
       type: string
+    - jsonPath: .spec.externalSubnet
+      name: ExternalSubnet
+      type: string
     - jsonPath: .status.ip
       name: IP
       type: string

--- a/pkg/apis/kubeovn/v1/iptables-eip.go
+++ b/pkg/apis/kubeovn/v1/iptables-eip.go
@@ -23,6 +23,7 @@ type IptablesEIPList struct {
 // +kubebuilder:resource:scope="Cluster",shortName="eip",path="iptables-eips",singular="iptables-eip"
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Namespace",type="string",JSONPath=".spec.namespace"
+// +kubebuilder:printcolumn:name="ExternalSubnet",type="string",JSONPath=".spec.externalSubnet"
 // +kubebuilder:printcolumn:name="IP",type="string",JSONPath=".status.ip"
 // +kubebuilder:printcolumn:name="Mac",type="string",JSONPath=".spec.macAddress"
 // +kubebuilder:printcolumn:name="Nat",type="string",JSONPath=".status.nat"


### PR DESCRIPTION
Add ExternalSubnet as an additionalPrinterColumn for IptablesEIP, displayed after Namespace in 'kubectl get eip' output.

- Add kubebuilder printcolumn annotation in pkg/apis/kubeovn/v1/iptables-eip.go
- Regenerate CRDs via make gen-crd (syncs charts/, yamls/gen/, dist/images/install.sh)
- Document make gen-crd workflow in AGENTS.md and CLAUDE.md

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
