### PR TITLE
fix(vpcnatgw): keep eth0 on primary CNI in non-primary CNI mode

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -969,7 +969,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 
 	// Generate StatefulSet Pod template annotations.
 	// User-defined annotations (gw.Spec.Annotations) are used as base, system annotations are set on top.
-	templateAnnotations, err := util.GenNatGwPodAnnotations(gw.Spec.Annotations, gw, externalNadNamespace, externalNadName, eth0SubnetProvider, additionalNetworks)
+	templateAnnotations, err := util.GenNatGwPodAnnotations(gw.Spec.Annotations, gw, externalNadNamespace, externalNadName, eth0SubnetProvider, additionalNetworks, c.config.EnableNonPrimaryCNI)
 	if err != nil {
 		klog.Errorf("vpc nat gateway annotation generation failed: %s", err.Error())
 		return nil, err

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -125,19 +125,24 @@ func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.Vpc
 	result[fmt.Sprintf(LogicalSwitchAnnotationTemplate, p)] = gw.Spec.Subnet
 	result[fmt.Sprintf(IPAddressAnnotationTemplate, p)] = gw.Spec.LanIP
 
-	// We're using a custom provider under primary CNI mode: override the default network of the
-	// pod so that the default VPC/Subnet of the cluster isn't accidentally injected.
-	// In non-primary CNI mode eth0 belongs to the cluster's primary CNI, and overriding it with a
-	// tenant NAD would break pod/control-plane connectivity (see issue #6632).
-	if p != OvnProvider && !enableNonPrimaryCNI {
+	// Validate the custom provider string whenever it isn't the built-in ovn one, regardless of
+	// the CNI mode, so that malformed providers are caught early rather than producing bogus
+	// annotation keys for LogicalSwitch/IPAddress.
+	if p != OvnProvider {
 		// Subdivide the provider so we can infer the namespace/name of the NetworkAttachmentDefinition
 		providerSplit := strings.Split(provider, ".")
 		if len(providerSplit) != 3 || providerSplit[2] != OvnProvider {
 			return nil, fmt.Errorf("name of the provider must have syntax 'name.namespace.ovn', got %s", provider)
 		}
 
-		name, namespace := providerSplit[0], providerSplit[1]
-		result[DefaultNetworkAnnotation] = fmt.Sprintf("%s/%s", namespace, name)
+		// Override the default network of the pod only under primary CNI mode, so the default
+		// VPC/Subnet of the cluster isn't accidentally injected. In non-primary CNI mode eth0
+		// belongs to the cluster's primary CNI and overriding it with a tenant NAD would break
+		// pod/control-plane connectivity (see issue #6632).
+		if !enableNonPrimaryCNI {
+			name, namespace := providerSplit[0], providerSplit[1]
+			result[DefaultNetworkAnnotation] = fmt.Sprintf("%s/%s", namespace, name)
+		}
 	}
 
 	return result, nil

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -100,8 +100,11 @@ func GenNatGwSelectors(selectors []string) map[string]string {
 // GenNatGwPodAnnotations generates StatefulSet Pod template annotations for a NAT gateway.
 // userAnnotations contains user-defined annotations from gw.Spec.Annotations. System annotations
 // are set on top of it, overwriting any conflicts. additionalNetworks is optional, used when
-// users specify extra NADs in gw.Annotations.
-func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.VpcNatGateway, externalNadNamespace, externalNadName, provider, additionalNetworks string) (map[string]string, error) {
+// users specify extra NADs in gw.Annotations. enableNonPrimaryCNI indicates whether Kube-OVN is
+// running as a non-primary CNI; in that mode eth0 must stay on the cluster's primary CNI pod
+// network (e.g. Calico) so the gateway pod can reach the Kubernetes control plane, so the
+// v1.multus-cni.io/default-network override is skipped.
+func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.VpcNatGateway, externalNadNamespace, externalNadName, provider, additionalNetworks string, enableNonPrimaryCNI bool) (map[string]string, error) {
 	p := provider
 	if p == "" {
 		p = OvnProvider
@@ -122,9 +125,11 @@ func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.Vpc
 	result[fmt.Sprintf(LogicalSwitchAnnotationTemplate, p)] = gw.Spec.Subnet
 	result[fmt.Sprintf(IPAddressAnnotationTemplate, p)] = gw.Spec.LanIP
 
-	// We're using a custom provider, we need to override the default network of the pod so that the
-	// default VPC/Subnet of the cluster isn't accidentally injected.
-	if p != OvnProvider {
+	// We're using a custom provider under primary CNI mode: override the default network of the
+	// pod so that the default VPC/Subnet of the cluster isn't accidentally injected.
+	// In non-primary CNI mode eth0 belongs to the cluster's primary CNI, and overriding it with a
+	// tenant NAD would break pod/control-plane connectivity (see issue #6632).
+	if p != OvnProvider && !enableNonPrimaryCNI {
 		// Subdivide the provider so we can infer the namespace/name of the NetworkAttachmentDefinition
 		providerSplit := strings.Split(provider, ".")
 		if len(providerSplit) != 3 || providerSplit[2] != OvnProvider {

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -472,6 +472,25 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 			expected:             nil,
 			expectError:          true,
 		},
+		{
+			name: "Invalid provider syntax under non-primary CNI still returns error",
+			gw: v1.VpcNatGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway",
+				},
+				Spec: v1.VpcNatGatewaySpec{
+					Subnet: "internal-subnet",
+					LanIP:  "10.20.30.40",
+				},
+			},
+			externalNadName:      "external-subnet",
+			externalNadNamespace: metav1.NamespaceSystem,
+			provider:             "invalid-provider",
+			additionalNetworks:   "",
+			enableNonPrimaryCNI:  true,
+			expected:             nil,
+			expectError:          true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -285,6 +285,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 		externalNadName      string
 		provider             string
 		additionalNetworks   string
+		enableNonPrimaryCNI  bool
 		expected             map[string]string
 		expectError          bool
 	}{
@@ -335,7 +336,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "All fields provided with NAD provider",
+			name: "Primary CNI with NAD provider overrides default network",
 			gw: v1.VpcNatGateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-gateway",
@@ -359,7 +360,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "With additional networks for secondary CNI",
+			name: "Primary CNI with NAD provider and additional networks",
 			gw: v1.VpcNatGateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-gateway",
@@ -379,6 +380,54 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 				fmt.Sprintf(LogicalSwitchAnnotationTemplate, "subnet.namespace.ovn"): "internal-subnet",
 				fmt.Sprintf(IPAddressAnnotationTemplate, "subnet.namespace.ovn"):     "10.20.30.40",
 				DefaultNetworkAnnotation: "namespace/subnet",
+			},
+			expectError: false,
+		},
+		{
+			name: "Non-primary CNI with NAD provider skips default network override",
+			gw: v1.VpcNatGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway",
+				},
+				Spec: v1.VpcNatGatewaySpec{
+					Subnet: "internal-subnet",
+					LanIP:  "10.20.30.40",
+				},
+			},
+			externalNadName:      "external-subnet",
+			externalNadNamespace: metav1.NamespaceSystem,
+			provider:             "subnet.namespace.ovn",
+			additionalNetworks:   "",
+			enableNonPrimaryCNI:  true,
+			expected: map[string]string{
+				VpcNatGatewayAnnotation:      "test-gateway",
+				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
+				fmt.Sprintf(LogicalSwitchAnnotationTemplate, "subnet.namespace.ovn"): "internal-subnet",
+				fmt.Sprintf(IPAddressAnnotationTemplate, "subnet.namespace.ovn"):     "10.20.30.40",
+			},
+			expectError: false,
+		},
+		{
+			name: "Non-primary CNI with NAD provider and additional networks",
+			gw: v1.VpcNatGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway",
+				},
+				Spec: v1.VpcNatGatewaySpec{
+					Subnet: "internal-subnet",
+					LanIP:  "10.20.30.40",
+				},
+			},
+			externalNadName:      "external-subnet",
+			externalNadNamespace: metav1.NamespaceSystem,
+			provider:             "subnet.namespace.ovn",
+			additionalNetworks:   "default/tenant-nad",
+			enableNonPrimaryCNI:  true,
+			expected: map[string]string{
+				VpcNatGatewayAnnotation:      "test-gateway",
+				nadv1.NetworkAttachmentAnnot: "default/tenant-nad, kube-system/external-subnet",
+				fmt.Sprintf(LogicalSwitchAnnotationTemplate, "subnet.namespace.ovn"): "internal-subnet",
+				fmt.Sprintf(IPAddressAnnotationTemplate, "subnet.namespace.ovn"):     "10.20.30.40",
 			},
 			expectError: false,
 		},
@@ -406,7 +455,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "Invalid provider syntax",
+			name: "Invalid provider syntax under primary CNI returns error",
 			gw: v1.VpcNatGateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-gateway",
@@ -427,7 +476,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := GenNatGwPodAnnotations(nil, &tc.gw, tc.externalNadNamespace, tc.externalNadName, tc.provider, tc.additionalNetworks)
+			result, err := GenNatGwPodAnnotations(nil, &tc.gw, tc.externalNadNamespace, tc.externalNadName, tc.provider, tc.additionalNetworks, tc.enableNonPrimaryCNI)
 			if (err != nil) != tc.expectError {
 				t.Errorf("expected error: %v, but got: %v", tc.expectError, err)
 			}


### PR DESCRIPTION
## Summary

- PR #6212 unconditionally wrote `v1.multus-cni.io/default-network` on the NAT gateway pod whenever `gw.Spec.Subnet` had a non-default provider. That is the right behavior when Kube-OVN is the primary CNI (fixes #6202), but in non-primary CNI mode (e.g. Harvester, `--non-primary-cni-mode=true`) it hijacks eth0 onto the tenant NAD and breaks control-plane reachability and external connectivity (issue #6632).
- Thread the controller's `EnableNonPrimaryCNI` flag into `util.GenNatGwPodAnnotations` and skip the `default-network` override in that mode, leaving eth0 on the primary CNI pod network as expected by Harvester's VPC NAT gateway topology.
- Supersedes the conditional proposed in #6633 (`additionalNetworks == ""`), per @SkalaNetworks's review there: the real discriminator is the non-primary CNI flag, not whether the user added extra Multus attachments.

## Test plan

- [x] `go test ./pkg/util/ -run TestGenNatGwPodAnnotations` — extended with cases for primary vs. non-primary CNI + NAD provider (with and without `additionalNetworks`)
- [x] `make lint` — 0 issues
- [ ] Manual verification on a Harvester-style cluster (`--non-primary-cni-mode=true`, tenant NAD, external NAD): NAT gateway pod eth0 stays on the primary CNI pod network; VM→external ping succeeds through SNAT/DNAT
- [ ] Regression check under primary CNI mode: custom-provider NAT gateway still gets `v1.multus-cni.io/default-network` set (existing #6202 fix unchanged)

Fixes #6632