### PR TITLE
fix(release): clean up next-version base image tags

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -109,7 +109,9 @@ if [ "$current_branch" != "master" ]; then
     kubeovn/kube-ovn-base:${VERSION}-amd64-legacy \
     kubeovn/kube-ovn-base:${VERSION}-dpdk \
     kubeovn/kube-ovn-base:${VERSION}-debug-amd64 \
-    kubeovn/kube-ovn-base:${VERSION}-debug-arm64
+    kubeovn/kube-ovn-base:${VERSION}-debug-arm64 \
+    kubeovn/kube-ovn-base:${NEXT_VERSION}-amd64-legacy \
+    kubeovn/kube-ovn-base:${NEXT_VERSION}-dpdk
 
   echo "Manually update the release note with the new changelog"
 else
@@ -169,6 +171,22 @@ else
   git add .github/workflows/scheduled-e2e.yaml
   git commit -m "prepare for next release"
   git push
+
+  echo "clean up images"
+  docker rmi kubeovn/kube-ovn:${VERSION}-x86 \
+    kubeovn/kube-ovn:${VERSION}-arm \
+    kubeovn/vpc-nat-gateway:${VERSION}-x86 \
+    kubeovn/vpc-nat-gateway:${VERSION}-arm \
+    kubeovn/kube-ovn:${VERSION}-debug-x86 \
+    kubeovn/kube-ovn:${VERSION}-debug-arm \
+    kubeovn/kube-ovn-base:${VERSION}-amd64 \
+    kubeovn/kube-ovn-base:${VERSION}-arm64 \
+    kubeovn/kube-ovn-base:${VERSION}-amd64-legacy \
+    kubeovn/kube-ovn-base:${VERSION}-dpdk \
+    kubeovn/kube-ovn-base:${VERSION}-debug-amd64 \
+    kubeovn/kube-ovn-base:${VERSION}-debug-arm64 \
+    kubeovn/kube-ovn-base:${NEXT_VERSION}-amd64-legacy \
+    kubeovn/kube-ovn-base:${NEXT_VERSION}-dpdk
 
   echo "prepare next release in release branch"
   git checkout $RELEASE_BRANCH

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -126,6 +126,7 @@ else
   echo "create and push base images for the master branch"
   git checkout master
   git pull
+  PATCH_NEXT_VERSION=${NEXT_VERSION}
   NEXT_VERSION=$(cat VERSION | awk -F '.' '{print $1"."$2+1"."$3}')
   set +e
   docker manifest rm kubeovn/kube-ovn-base:${NEXT_VERSION}
@@ -185,6 +186,8 @@ else
     kubeovn/kube-ovn-base:${VERSION}-dpdk \
     kubeovn/kube-ovn-base:${VERSION}-debug-amd64 \
     kubeovn/kube-ovn-base:${VERSION}-debug-arm64 \
+    kubeovn/kube-ovn-base:${PATCH_NEXT_VERSION}-amd64-legacy \
+    kubeovn/kube-ovn-base:${PATCH_NEXT_VERSION}-dpdk \
     kubeovn/kube-ovn-base:${NEXT_VERSION}-amd64-legacy \
     kubeovn/kube-ovn-base:${NEXT_VERSION}-dpdk
 


### PR DESCRIPTION
## Summary
- `hack/release.sh` leaves behind `kubeovn/kube-ovn-base:${NEXT_VERSION}-amd64-legacy` and `kubeovn/kube-ovn-base:${NEXT_VERSION}-dpdk` local tags after a release, because the patch-branch cleanup list only covers `${VERSION}-*` images.
- The master-branch path has no cleanup block at all, so all of the local `${VERSION}-*` and `${NEXT_VERSION}-{amd64-legacy,dpdk}` tags accumulate across releases.
- Add the two next-version tags to the patch-branch cleanup, and mirror the full cleanup list into the master-branch path before `NEXT_VERSION` is reassigned for the release-branch patch bump.

## Test plan
- [x] Visually inspect the diff: cleanup lists now match the set of images introduced by `docker pull` + `docker tag` on each path.
- [ ] Next release dry-run: after `hack/release.sh` completes, confirm `docker images | grep kube-ovn-base` has no `${NEXT_VERSION}-amd64-legacy` / `${NEXT_VERSION}-dpdk` entries remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)