### PR TITLE
fix(subnet): reject sub-1280 MTU on IPv6 subnets, warn at runtime

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -435,23 +435,37 @@ func (c *Controller) checkSubnetConflict(subnet *kubeovnv1.Subnet) error {
 
 // getSubnetMTU returns the effective MTU for DHCP options of the given subnet.
 func (c *Controller) getSubnetMTU(subnet *kubeovnv1.Subnet) (int, error) {
+	var mtu int
 	if subnet.Spec.Mtu > 0 {
-		return int(subnet.Spec.Mtu), nil
+		mtu = int(subnet.Spec.Mtu)
+	} else {
+		mtu = util.DefaultMTU
+		if subnet.Spec.Vlan == "" {
+			switch c.config.NetworkType {
+			case util.NetworkTypeVlan:
+				// default to geneve
+				fallthrough
+			case util.NetworkTypeGeneve:
+				mtu -= util.GeneveHeaderLength
+			case util.NetworkTypeVxlan:
+				mtu -= util.VxlanHeaderLength
+			case util.NetworkTypeStt:
+				mtu -= util.SttHeaderLength
+			default:
+				return 0, fmt.Errorf("invalid network type: %s", c.config.NetworkType)
+			}
+		}
 	}
-	mtu := util.DefaultMTU
-	if subnet.Spec.Vlan == "" {
-		switch c.config.NetworkType {
-		case util.NetworkTypeVlan:
-			// default to geneve
-			fallthrough
-		case util.NetworkTypeGeneve:
-			mtu -= util.GeneveHeaderLength
-		case util.NetworkTypeVxlan:
-			mtu -= util.VxlanHeaderLength
-		case util.NetworkTypeStt:
-			mtu -= util.SttHeaderLength
-		default:
-			return 0, fmt.Errorf("invalid network type: %s", c.config.NetworkType)
+	// Surface IPv6 MTU misconfiguration without rewriting the value: the path
+	// MTU is set by the underlying link, so silently raising it would only
+	// shift the failure to fragmentation/blackholing of IPv4 traffic. The
+	// webhook rejects new subnets that violate the floor; this branch warns
+	// for upgraded subnets and auto-computed values that can no longer carry
+	// IPv6.
+	if mtu < util.IPv6MinMTU {
+		protocol := util.CheckProtocol(subnet.Spec.CIDRBlock)
+		if protocol == kubeovnv1.ProtocolIPv6 || protocol == kubeovnv1.ProtocolDual {
+			klog.Warningf("subnet %s mtu %d is below the IPv6 minimum %d; IPv6 traffic will be dropped on pod interfaces", subnet.Name, mtu, util.IPv6MinMTU)
 		}
 	}
 	return mtu, nil

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -347,7 +347,15 @@ func (config *Configuration) initNicConfig(nicBridgeMappings map[string]string) 
 		// link, and forcing the value above it would replace silent IPv6
 		// drops with silent IPv4 fragmentation/blackholing.
 		if encapIsIPv6 && config.MTU < util.IPv6MinMTU {
-			klog.Warningf("auto-computed MTU %d on interface %s is below the IPv6 minimum %d; IPv6 traffic on default subnets will be dropped", config.MTU, config.Iface, util.IPv6MinMTU)
+			// tunnelIface is only set when the user pinned config.Iface and
+			// the resolved nic may differ (bridge mapping); fall back to
+			// config.Iface for the auto-discovery path where tunnelIface is
+			// empty.
+			ifaceName := config.tunnelIface
+			if ifaceName == "" {
+				ifaceName = config.Iface
+			}
+			klog.Warningf("auto-computed MTU %d on interface %s is below the IPv6 minimum %d; IPv6 traffic on default subnets will be dropped", config.MTU, ifaceName, util.IPv6MinMTU)
 		}
 	}
 

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -343,6 +343,12 @@ func (config *Configuration) initNicConfig(nicBridgeMappings map[string]string) 
 			// IPv6 header size is 40
 			config.MTU -= 20
 		}
+		// Warn but do not raise: the path MTU is dictated by the underlying
+		// link, and forcing the value above it would replace silent IPv6
+		// drops with silent IPv4 fragmentation/blackholing.
+		if encapIsIPv6 && config.MTU < util.IPv6MinMTU {
+			klog.Warningf("auto-computed MTU %d on interface %s is below the IPv6 minimum %d; IPv6 traffic on default subnets will be dropped", config.MTU, config.Iface, util.IPv6MinMTU)
+		}
 	}
 
 	config.MSS = config.MTU - util.TCPIPHeaderLength

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -307,6 +307,16 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			}
 		}
 
+		// Warn but keep the configured value: the provider-network or subnet
+		// MTU reflects the real link MTU, and inflating it would push pods
+		// to emit packets that the underlay cannot carry, breaking IPv4 too.
+		if mtu > 0 && mtu < util.IPv6MinMTU {
+			subnetProtocol := util.CheckProtocol(podSubnet.Spec.CIDRBlock)
+			if subnetProtocol == kubeovnv1.ProtocolIPv6 || subnetProtocol == kubeovnv1.ProtocolDual {
+				klog.Warningf("subnet %s mtu %d is below the IPv6 minimum %d; IPv6 traffic on pod %s/%s will be dropped", podSubnet.Name, mtu, util.IPv6MinMTU, pod.Namespace, pod.Name)
+			}
+		}
+
 		macAddr = pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podRequest.Provider)]
 		klog.Infof("create container interface %s mac %s, ip %s, cidr %s, gw %s, custom routes %v", ifName, macAddr, ipAddr, cidr, gw, routes)
 		podNicName = ifName

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -210,6 +210,10 @@ const (
 	VxlanHeaderLength  = 50
 	SttHeaderLength    = 72
 	TCPIPHeaderLength  = 40
+	// IPv6MinMTU is the minimum MTU required by IPv6 (RFC 8200).
+	// Linux refuses to initialize inet6_dev on interfaces below this value,
+	// silently dropping every IPv6 packet.
+	IPv6MinMTU = 1280
 
 	OvnProvider                         = "ovn"
 	DefaultNetworkAnnotation            = "v1.multus-cni.io/default-network"

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -119,6 +119,16 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		return fmt.Errorf("%s is not a valid protocol type", protocol)
 	}
 
+	// Reject MTU values that would break IPv6 on the subnet. Linux silently
+	// drops IPv6 traffic on interfaces below 1280 (RFC 8200), so the user
+	// cannot tell apart a misconfiguration from a real network outage.
+	if subnet.Spec.Mtu > 0 && subnet.Spec.Mtu < IPv6MinMTU {
+		cidrProtocol := CheckProtocol(subnet.Spec.CIDRBlock)
+		if cidrProtocol == kubeovnv1.ProtocolIPv6 || cidrProtocol == kubeovnv1.ProtocolDual {
+			return fmt.Errorf("subnet %s mtu %d is below the IPv6 minimum %d", subnet.Name, subnet.Spec.Mtu, IPv6MinMTU)
+		}
+	}
+
 	if subnet.Spec.Vpc == subnet.Name {
 		return fmt.Errorf("subnet %s and vpc %s cannot have the same name", subnet.Name, subnet.Spec.Vpc)
 	}

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -732,6 +732,80 @@ func TestValidateSubnet(t *testing.T) {
 			},
 			err: "validate gateway 10.16.0.0 for cidr 10.16.0.0/32 failed: subnet 10.16.0.0/32 is configured with /32 or /128 netmask",
 		},
+		{
+			name: "IPv6MTUBelowMinimum",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "utest-v6-mtu-low",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolIPv6,
+					CIDRBlock:   "fd00:10:16::/64",
+					Gateway:     "fd00:10:16::1",
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Mtu:         1200,
+				},
+			},
+			err: "subnet utest-v6-mtu-low mtu 1200 is below the IPv6 minimum 1280",
+		},
+		{
+			name: "DualStackMTUBelowMinimum",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "utest-dual-mtu-low",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolDual,
+					CIDRBlock:   "10.16.0.0/16,fd00:10:16::/64",
+					Gateway:     "10.16.0.1,fd00:10:16::1",
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Mtu:         1000,
+				},
+			},
+			err: "subnet utest-dual-mtu-low mtu 1000 is below the IPv6 minimum 1280",
+		},
+		{
+			name: "IPv4MTUBelowIPv6MinimumAllowed",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "utest-v4-mtu-low",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolIPv4,
+					CIDRBlock:   "10.16.0.0/16",
+					Gateway:     "10.16.0.1",
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Mtu:         1000,
+				},
+			},
+		},
+		{
+			name: "IPv6MTUAtMinimumAllowed",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "utest-v6-mtu-min",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolIPv6,
+					CIDRBlock:   "fd00:10:16::/64",
+					Gateway:     "fd00:10:16::1",
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Mtu:         1280,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Webhook rejects new IPv6/dual subnets whose `spec.mtu` is below 1280 (RFC 8200 IPv6 minimum). Linux silently drops every IPv6 packet on interfaces below this threshold because the kernel refuses to initialize `inet6_dev`, and Kube-OVN previously accepted such configurations without surfacing the misconfiguration.
- Controller `getSubnetMTU` and daemon `initNicConfig` / CNI `handleAdd` emit a warning when the resolved MTU on an IPv6/dual path is below 1280 (covers explicit `Spec.Mtu`, auto-computed values, and provider-network labels). The value is intentionally **not** raised — the underlying link MTU caps the path, so inflating it would replace silent IPv6 drops with silent IPv4 fragmentation/blackholing.

Cross-reference: same class of bug as [cilium/cilium#45423](https://github.com/cilium/cilium/issues/45423).

## Test plan

- [x] `go test ./pkg/util/...` — added 4 new cases to `TestValidateSubnet` covering IPv6/dual reject, IPv4 below-1280 still allowed, and IPv6 at-1280 boundary
- [x] `make lint` — 0 issues
- [ ] Manual: create an IPv6/dual subnet with `spec.mtu: 1200` and confirm the webhook rejects it
- [ ] Manual: pre-create a dual-stack subnet with `spec.mtu: 1200` (bypassing webhook), then create a Pod and confirm the warning appears in `kube-ovn-controller` and `kube-ovn-cni` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)