### PR TITLE
feat(servicecidr): support K8s multiple ServiceCIDR (KEP-1880)

### DIFF
--- a/charts/kube-ovn-v2/templates/agent/agent-clusterrole.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-clusterrole.yaml
@@ -83,6 +83,14 @@ rules:
       - "list"
       - "watch"
       - "delete"
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - servicecidrs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
+++ b/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
@@ -107,6 +107,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - servicecidrs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - daemonsets

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -107,6 +107,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - servicecidrs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - daemonsets
@@ -361,16 +369,24 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
-  - apiGroups: 
+  - apiGroups:
       - "certificates.k8s.io"
-    resources: 
+    resources:
       - "certificatesigningrequests"
-    verbs: 
-      - "create" 
+    verbs:
+      - "create"
       - "get"
       - "list"
       - "watch"
       - "delete"
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - servicecidrs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -6676,6 +6676,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - servicecidrs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - daemonsets
@@ -6943,6 +6951,14 @@ rules:
       - "list"
       - "watch"
       - "delete"
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - servicecidrs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -14,12 +14,10 @@ import (
 	"github.com/puzpuzpuz/xsync/v4"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/discovery"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -33,7 +31,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/keymutex"
-	"k8s.io/utils/set"
 	v1alpha1 "sigs.k8s.io/network-policy-api/apis/v1alpha1"
 	netpolv1alpha2 "sigs.k8s.io/network-policy-api/apis/v1alpha2"
 	anpinformer "sigs.k8s.io/network-policy-api/pkg/client/informers/externalversions"
@@ -313,6 +310,11 @@ type Controller struct {
 	netAttachSynced          cache.InformerSynced
 	netAttachInformerFactory netAttach.SharedInformerFactory
 
+	serviceCIDRStore           *util.ServiceCIDRStore
+	serviceCIDRLister          netv1.ServiceCIDRLister
+	serviceCIDRSynced          cache.InformerSynced
+	serviceCIDRInformerFactory kubeinformers.SharedInformerFactory
+
 	recorder               record.EventRecorder
 	informerFactory        kubeinformers.SharedInformerFactory
 	cmInformerFactory      kubeinformers.SharedInformerFactory
@@ -385,6 +387,13 @@ func Run(ctx context.Context, config *Configuration) {
 	)
 	kubevirtInformerFactory := informer.NewKubeVirtInformerFactoryWithOptions(config.KubevirtClient.RestClient(), config.KubevirtClient,
 		informer.WithTransform(util.TrimManagedFields),
+	)
+	// Dedicated factory so that on clusters without the ServiceCIDR API the
+	// failed list/watch does not contaminate the main informer factory.
+	serviceCIDRInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(config.KubeClient, 0,
+		kubeinformers.WithTweakListOptions(func(listOption *metav1.ListOptions) {
+			listOption.AllowWatchBookmarks = true
+		}),
 	)
 
 	vpcInformer := kubeovnInformerFactory.Kubeovn().V1().Vpcs()
@@ -620,6 +629,9 @@ func Run(ctx context.Context, config *Configuration) {
 		netAttachSynced:          netAttachInformer.Informer().HasSynced,
 		netAttachInformerFactory: attachNetInformerFactory,
 
+		serviceCIDRStore:           util.NewServiceCIDRStore(config.ServiceClusterIPRange),
+		serviceCIDRInformerFactory: serviceCIDRInformerFactory,
+
 		recorder:               recorder,
 		informerFactory:        informerFactory,
 		cmInformerFactory:      cmInformerFactory,
@@ -720,6 +732,10 @@ func Run(ctx context.Context, config *Configuration) {
 	// Start and sync NAD informer first, as many resources depend on NAD cache
 	// NAD CRD is optional, so we check if it exists before starting the informer
 	controller.StartNetAttachInformerFactory(ctx)
+
+	// ServiceCIDR (networking.k8s.io/v1) is GA in K8s 1.33; older clusters
+	// don't have the API at all. Best-effort start with periodic retry.
+	controller.StartServiceCIDRInformerFactory(ctx)
 
 	// Wait for the caches to be synced before starting workers
 	controller.informerFactory.Start(ctx.Done())
@@ -1609,27 +1625,4 @@ func runWorker[T comparable](action string, queue workqueue.TypedRateLimitingInt
 		for processNextWorkItem(action, queue, handler, getWorkItemKey) {
 		}
 	}
-}
-
-// apiResourceExists checks if all specified kinds exist in the given group version.
-// It returns true if all kinds are found, false otherwise.
-// Parameters:
-// - discoveryClient: The discovery client to use for querying API resources.
-// - gv: The group version string (e.g., "apps/v1").
-// - kinds: A variadic list of kind names to check for existence (e.g., "Deployment", "StatefulSet").
-func apiResourceExists(discoveryClient discovery.DiscoveryInterface, gv string, kinds ...string) (bool, error) {
-	apiResourceLists, err := discoveryClient.ServerResourcesForGroupVersion(gv)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to discover api resources for %s: %w", gv, err)
-	}
-
-	existingKinds := set.New[string]()
-	for _, apiResource := range apiResourceLists.APIResources {
-		existingKinds.Insert(apiResource.Kind)
-	}
-
-	return existingKinds.HasAll(kinds...), nil
 }

--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -228,7 +228,7 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 }
 
 func (c *Controller) isKubevirtCRDInstalled() (bool, error) {
-	return apiResourceExists(c.config.KubevirtClient.Discovery(),
+	return util.APIResourceExists(c.config.KubevirtClient.Discovery(),
 		kubevirtv1.GroupVersion.String(),
 		util.KindVirtualMachine,
 		util.KindVirtualMachineInstance,

--- a/pkg/controller/network_attachment.go
+++ b/pkg/controller/network_attachment.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (c *Controller) isNetAttachCRDInstalled() (bool, error) {
-	return apiResourceExists(
+	return util.APIResourceExists(
 		c.config.AttachNetClient.Discovery(),
 		nadv1.SchemeGroupVersion.String(),
 		util.ObjectKind[*nadv1.NetworkAttachmentDefinition](),

--- a/pkg/controller/service_cidr.go
+++ b/pkg/controller/service_cidr.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -14,19 +13,11 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-func (c *Controller) isServiceCIDRAPIInstalled() (bool, error) {
-	return util.APIResourceExists(
-		c.config.KubeClient.Discovery(),
-		networkingv1.SchemeGroupVersion.String(),
-		"ServiceCIDR",
-	)
-}
-
 func (c *Controller) startServiceCIDRInformer(ctx context.Context) {
 	informer := c.serviceCIDRInformerFactory.Networking().V1().ServiceCIDRs()
 	if _, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.onServiceCIDRAdd,
-		UpdateFunc: c.onServiceCIDRUpdate,
+		AddFunc:    c.onServiceCIDRChange,
+		UpdateFunc: func(_, newObj any) { c.onServiceCIDRChange(newObj) },
 		DeleteFunc: c.onServiceCIDRDelete,
 	}); err != nil {
 		util.LogFatalAndExit(err, "failed to add ServiceCIDR event handler")
@@ -49,12 +40,16 @@ func (c *Controller) startServiceCIDRInformer(ctx context.Context) {
 		return
 	}
 	for _, sc := range scs {
-		c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+		c.serviceCIDRStore.UpsertFromAPI(sc.Name, util.ReadyServiceCIDRs(sc))
 	}
 }
 
 func (c *Controller) tryStartServiceCIDRInformer(ctx context.Context) bool {
-	exists, err := c.isServiceCIDRAPIInstalled()
+	exists, err := util.APIResourceExists(
+		c.config.KubeClient.Discovery(),
+		networkingv1.SchemeGroupVersion.String(),
+		util.ObjectKind[*networkingv1.ServiceCIDR](),
+	)
 	if err != nil {
 		klog.Warningf("failed to check ServiceCIDR API: %v", err)
 		return false
@@ -92,20 +87,12 @@ func (c *Controller) StartServiceCIDRInformerFactory(ctx context.Context) {
 	}()
 }
 
-func (c *Controller) onServiceCIDRAdd(obj any) {
+func (c *Controller) onServiceCIDRChange(obj any) {
 	sc, ok := obj.(*networkingv1.ServiceCIDR)
 	if !ok {
 		return
 	}
-	c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
-}
-
-func (c *Controller) onServiceCIDRUpdate(_, newObj any) {
-	sc, ok := newObj.(*networkingv1.ServiceCIDR)
-	if !ok {
-		return
-	}
-	c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+	c.serviceCIDRStore.UpsertFromAPI(sc.Name, util.ReadyServiceCIDRs(sc))
 }
 
 func (c *Controller) onServiceCIDRDelete(obj any) {
@@ -123,29 +110,14 @@ func (c *Controller) onServiceCIDRDelete(obj any) {
 	c.serviceCIDRStore.DeleteFromAPI(sc.Name)
 }
 
-// readyServiceCIDRs returns Spec.CIDRs when the object's Ready condition is
-// True. ServiceCIDRs that are still being initialized or already terminating
-// are skipped, matching the apiserver allocator's own behavior.
-func readyServiceCIDRs(sc *networkingv1.ServiceCIDR) []string {
-	if sc == nil {
-		return nil
-	}
-	ready := false
-	for _, cond := range sc.Status.Conditions {
-		if cond.Type == networkingv1.ServiceCIDRConditionReady {
-			ready = cond.Status == metav1.ConditionTrue
-			break
-		}
-	}
-	if !ready {
-		return nil
-	}
-	return sc.Spec.CIDRs
-}
-
 // reconcileForServiceCIDRChange enqueues every object whose data-plane artifact
 // embeds a Service CIDR so that its existing reconciler rebuilds the artifact
 // against the freshly merged set.
+//
+// VpcNatGateways are deliberately skipped: handleAddOrUpdateVpcNatGw only diffs
+// Spec, and handleInitVpcNatGw bails on VpcNatGatewayInitAnnotation. Existing
+// NAT GWs need pod recreation to pick up new routes; new ones already render
+// against the current store.
 func (c *Controller) reconcileForServiceCIDRChange() {
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
@@ -161,21 +133,11 @@ func (c *Controller) reconcileForServiceCIDRChange() {
 	vpcs, err := c.vpcsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list vpcs: %v", err)
-	} else {
-		for _, v := range vpcs {
-			if strings.ToLower(v.Annotations[util.VpcLbAnnotation]) == "on" {
-				c.addOrUpdateVpcQueue.Add(v.Name)
-			}
+		return
+	}
+	for _, v := range vpcs {
+		if strings.ToLower(v.Annotations[util.VpcLbAnnotation]) == "on" {
+			c.addOrUpdateVpcQueue.Add(v.Name)
 		}
 	}
-
-	// VpcNatGateways are intentionally NOT re-enqueued here. The route
-	// annotation is written into the StatefulSet template by
-	// genNatGwStatefulSet, but handleAddOrUpdateVpcNatGw only updates the
-	// StatefulSet when isVpcNatGwChanged() returns true (Spec-only diff),
-	// and handleInitVpcNatGw bails out as soon as the pod carries
-	// VpcNatGatewayInitAnnotation. Newly created NAT gateways still pick up
-	// the current store because their add path runs genNatGwStatefulSet
-	// against c.serviceCIDRStore; existing NAT gateways keep their original
-	// service routes until the pod is recreated by other means.
 }

--- a/pkg/controller/service_cidr.go
+++ b/pkg/controller/service_cidr.go
@@ -1,0 +1,181 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func (c *Controller) isServiceCIDRAPIInstalled() (bool, error) {
+	return util.APIResourceExists(
+		c.config.KubeClient.Discovery(),
+		networkingv1.SchemeGroupVersion.String(),
+		"ServiceCIDR",
+	)
+}
+
+func (c *Controller) startServiceCIDRInformer(ctx context.Context) {
+	informer := c.serviceCIDRInformerFactory.Networking().V1().ServiceCIDRs()
+	if _, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onServiceCIDRAdd,
+		UpdateFunc: c.onServiceCIDRUpdate,
+		DeleteFunc: c.onServiceCIDRDelete,
+	}); err != nil {
+		util.LogFatalAndExit(err, "failed to add ServiceCIDR event handler")
+	}
+	c.serviceCIDRLister = informer.Lister()
+	c.serviceCIDRSynced = informer.Informer().HasSynced
+
+	c.serviceCIDRInformerFactory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), c.serviceCIDRSynced) {
+		util.LogFatalAndExit(nil, "failed to wait for ServiceCIDR cache to sync")
+	}
+	klog.Info("ServiceCIDR informer cache synced")
+
+	c.serviceCIDRStore.OnChange(c.reconcileForServiceCIDRChange)
+
+	// Re-fire after sync so consumers see the merged set even when no events follow.
+	scs, err := c.serviceCIDRLister.List(labels.Everything())
+	if err != nil {
+		klog.Warningf("failed to list ServiceCIDRs after sync: %v", err)
+		return
+	}
+	for _, sc := range scs {
+		c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+	}
+}
+
+func (c *Controller) tryStartServiceCIDRInformer(ctx context.Context) bool {
+	exists, err := c.isServiceCIDRAPIInstalled()
+	if err != nil {
+		klog.Warningf("failed to check ServiceCIDR API: %v", err)
+		return false
+	}
+	if !exists {
+		return false
+	}
+	klog.Info("ServiceCIDR API found, starting informer")
+	c.startServiceCIDRInformer(ctx)
+	return true
+}
+
+// StartServiceCIDRInformerFactory wires up the optional networking.k8s.io/v1
+// ServiceCIDR informer. On clusters without the API (K8s <1.31, or 1.31/1.32
+// with the feature gate disabled) the informer is never started and the
+// ServiceCIDRStore stays at its flag-derived fallback.
+func (c *Controller) StartServiceCIDRInformerFactory(ctx context.Context) {
+	if c.tryStartServiceCIDRInformer(ctx) {
+		return
+	}
+	klog.Info("ServiceCIDR API not found at startup, will check periodically in background")
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if c.tryStartServiceCIDRInformer(ctx) {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (c *Controller) onServiceCIDRAdd(obj any) {
+	sc, ok := obj.(*networkingv1.ServiceCIDR)
+	if !ok {
+		return
+	}
+	c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+}
+
+func (c *Controller) onServiceCIDRUpdate(_, newObj any) {
+	sc, ok := newObj.(*networkingv1.ServiceCIDR)
+	if !ok {
+		return
+	}
+	c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+}
+
+func (c *Controller) onServiceCIDRDelete(obj any) {
+	sc, ok := obj.(*networkingv1.ServiceCIDR)
+	if !ok {
+		tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown)
+		if !isTombstone {
+			return
+		}
+		sc, ok = tombstone.Obj.(*networkingv1.ServiceCIDR)
+		if !ok {
+			return
+		}
+	}
+	c.serviceCIDRStore.DeleteFromAPI(sc.Name)
+}
+
+// readyServiceCIDRs returns Spec.CIDRs when the object's Ready condition is
+// True. ServiceCIDRs that are still being initialized or already terminating
+// are skipped, matching the apiserver allocator's own behavior.
+func readyServiceCIDRs(sc *networkingv1.ServiceCIDR) []string {
+	if sc == nil {
+		return nil
+	}
+	ready := false
+	for _, cond := range sc.Status.Conditions {
+		if cond.Type == networkingv1.ServiceCIDRConditionReady {
+			ready = cond.Status == metav1.ConditionTrue
+			break
+		}
+	}
+	if !ready {
+		return nil
+	}
+	return sc.Spec.CIDRs
+}
+
+// reconcileForServiceCIDRChange enqueues every object whose data-plane artifact
+// embeds a Service CIDR so that its existing reconciler rebuilds the artifact
+// against the freshly merged set.
+func (c *Controller) reconcileForServiceCIDRChange() {
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets: %v", err)
+	} else {
+		for _, s := range subnets {
+			if s.Spec.U2OInterconnection {
+				c.addOrUpdateSubnetQueue.Add(s.Name)
+			}
+		}
+	}
+
+	vpcs, err := c.vpcsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list vpcs: %v", err)
+	} else {
+		for _, v := range vpcs {
+			if strings.ToLower(v.Annotations[util.VpcLbAnnotation]) == "on" {
+				c.addOrUpdateVpcQueue.Add(v.Name)
+			}
+		}
+	}
+
+	// VpcNatGateways are intentionally NOT re-enqueued here. The route
+	// annotation is written into the StatefulSet template by
+	// genNatGwStatefulSet, but handleAddOrUpdateVpcNatGw only updates the
+	// StatefulSet when isVpcNatGwChanged() returns true (Spec-only diff),
+	// and handleInitVpcNatGw bails out as soon as the pod carries
+	// VpcNatGatewayInitAnnotation. Newly created NAT gateways still pick up
+	// the current store because their add path runs genNatGwStatefulSet
+	// against c.serviceCIDRStore; existing NAT gateways keep their original
+	// service routes until the pod is recreated by other means.
+}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2750,6 +2750,21 @@ func (c *Controller) addPolicyRouteForU2ONoLoadBalancer(subnet *kubeovnv1.Subnet
 		klog.Errorf("failed to list nodes: %v", err)
 		return err
 	}
+	// Drop any policies belonging to a previous Service CIDR set so that
+	// shrinking the merged set (e.g. ServiceCIDR object deleted) does not
+	// leave stale OVN entries behind. Port groups are reused, not touched.
+	if c.logicalRouterExists(subnet.Spec.Vpc) {
+		if err := c.OVNNbClient.DeleteLogicalRouterPolicies(subnet.Spec.Vpc, -1, map[string]string{
+			"isU2ONoLBRoutePolicy": "true",
+			"vendor":               util.CniTypeName,
+			"subnet":               subnet.Name,
+		}); err != nil {
+			klog.Errorf("failed to clean stale u2o no-lb policies for subnet %s: %v", subnet.Name, err)
+			return err
+		}
+	}
+	v4Svcs := c.serviceCIDRStore.V4CIDRs()
+	v6Svcs := c.serviceCIDRStore.V6CIDRs()
 	for _, node := range nodes {
 		pgName := getOverlaySubnetsPortGroupName(subnet.Name, node.Name)
 		if err := c.OVNNbClient.CreatePortGroup(pgName, map[string]string{logicalRouterKey: subnet.Spec.Vpc, logicalSwitchKey: subnet.Name, u2oKey: "true"}); err != nil {
@@ -2765,41 +2780,43 @@ func (c *Controller) addPolicyRouteForU2ONoLoadBalancer(subnet *kubeovnv1.Subnet
 			klog.Error(err)
 			return err
 		}
-		v4Svc, v6Svc := util.SplitStringIP(c.config.ServiceClusterIPRange)
 		for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
 			ipSuffix := getIPSuffix(util.CheckProtocol(cidrBlock))
 			nodeIP := ip.Spec.V4IPAddress
-			svcCIDR := v4Svc
+			svcCIDRs := v4Svcs
 			if ipSuffix == "ip6" {
 				nodeIP = ip.Spec.V6IPAddress
-				svcCIDR = v6Svc
+				svcCIDRs = v6Svcs
 			}
-			if nodeIP == "" || svcCIDR == "" {
+			if nodeIP == "" || len(svcCIDRs) == 0 {
 				continue
 			}
 
 			pgAs := fmt.Sprintf("%s_%s", pgName, ipSuffix)
-			match := fmt.Sprintf("%s.src == $%s && %s.dst == %s", ipSuffix, pgAs, ipSuffix, svcCIDR)
 			action := kubeovnv1.PolicyRouteActionReroute
-			externalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{
-				"isU2ORoutePolicy":     "true",
-				"isU2ONoLBRoutePolicy": "true",
-				"node":                 node.Name,
-			})
+			for _, svcCIDR := range svcCIDRs {
+				match := fmt.Sprintf("%s.src == $%s && %s.dst == %s", ipSuffix, pgAs, ipSuffix, svcCIDR)
+				externalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{
+					"isU2ORoutePolicy":     "true",
+					"isU2ONoLBRoutePolicy": "true",
+					"node":                 node.Name,
+					"svcCidr":              svcCIDR,
+				})
 
-			klog.Infof("add u2o interconnection policy without enabling loadbalancer for router: %s, match %s, action %s, nexthop %s", subnet.Spec.Vpc, match, action, nodeIP)
-			if err := c.addPolicyRouteToVpc(
-				c.config.ClusterRouter,
-				&kubeovnv1.PolicyRoute{
-					Priority:  util.U2OSubnetPolicyPriority,
-					Match:     match,
-					Action:    action,
-					NextHopIP: nodeIP,
-				},
-				externalIDs,
-			); err != nil {
-				klog.Errorf("failed to add logical router policy for port-group address-set %s: %v", pgAs, err)
-				return err
+				klog.Infof("add u2o interconnection policy without enabling loadbalancer for router: %s, match %s, action %s, nexthop %s", subnet.Spec.Vpc, match, action, nodeIP)
+				if err := c.addPolicyRouteToVpc(
+					c.config.ClusterRouter,
+					&kubeovnv1.PolicyRoute{
+						Priority:  util.U2OSubnetPolicyPriority,
+						Match:     match,
+						Action:    action,
+						NextHopIP: nodeIP,
+					},
+					externalIDs,
+				); err != nil {
+					klog.Errorf("failed to add logical router policy for port-group address-set %s: %v", pgAs, err)
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/controller/vpc_lb.go
+++ b/pkg/controller/vpc_lb.go
@@ -164,56 +164,12 @@ func (c *Controller) genVpcLbDeployment(vpc *kubeovnv1.Vpc) (*v1.Deployment, err
 	}
 
 	v4Gw, v6Gw := util.SplitStringIP(defaultSubnet.Spec.Gateway)
-	if v4Gw != "" {
-		for i, v4Svc := range c.serviceCIDRStore.V4CIDRs() {
-			deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, corev1.Container{
-				Name:            fmt.Sprintf("init-ipv4-route-%d", i),
-				Image:           vpcNatImage,
-				Command:         []string{"ip"},
-				Args:            strings.Fields(fmt.Sprintf("-4 route replace %s via %s", v4Svc, v4Gw)),
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				SecurityContext: &corev1.SecurityContext{
-					Privileged:               &privileged,
-					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-				},
-			}, corev1.Container{
-				Name:            fmt.Sprintf("init-ipv4-iptables-%d", i),
-				Image:           vpcNatImage,
-				Command:         []string{"iptables"},
-				Args:            strings.Fields(fmt.Sprintf("-t nat -I POSTROUTING -d %s -j MASQUERADE", v4Svc)),
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				SecurityContext: &corev1.SecurityContext{
-					Privileged:               &privileged,
-					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-				},
-			})
-		}
-	}
-	if v6Gw != "" {
-		for i, v6Svc := range c.serviceCIDRStore.V6CIDRs() {
-			deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, corev1.Container{
-				Name:            fmt.Sprintf("init-ipv6-route-%d", i),
-				Image:           vpcNatImage,
-				Command:         []string{"ip"},
-				Args:            strings.Fields(fmt.Sprintf("-6 route replace %s via %s", v6Svc, v6Gw)),
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				SecurityContext: &corev1.SecurityContext{
-					Privileged:               &privileged,
-					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-				},
-			}, corev1.Container{
-				Name:            fmt.Sprintf("init-ipv6-iptables-%d", i),
-				Image:           vpcNatImage,
-				Command:         []string{"ip6tables"},
-				Args:            strings.Fields(fmt.Sprintf("-t nat -I POSTROUTING -d %s -j MASQUERADE", v6Svc)),
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				SecurityContext: &corev1.SecurityContext{
-					Privileged:               &privileged,
-					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-				},
-			})
-		}
-	}
+	deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers,
+		vpcLbInitContainers(4, v4Gw, vpcNatImage, c.serviceCIDRStore.V4CIDRs(), &privileged, &allowPrivilegeEscalation)...,
+	)
+	deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers,
+		vpcLbInitContainers(6, v6Gw, vpcNatImage, c.serviceCIDRStore.V6CIDRs(), &privileged, &allowPrivilegeEscalation)...,
+	)
 
 	if deployment.Annotations == nil {
 		deployment.Annotations = map[string]string{}
@@ -226,4 +182,46 @@ func (c *Controller) genVpcLbDeployment(vpc *kubeovnv1.Vpc) (*v1.Deployment, err
 	deployment.Spec.Template.Annotations[util.ServiceCIDRHashAnnotation] = hash
 
 	return deployment, nil
+}
+
+// vpcLbInitContainers returns the route + MASQUERADE init containers for one
+// IP family. The container names embed the family and CIDR index so that
+// adding/removing ServiceCIDRs translates into a stable, deterministic name
+// list that the Deployment controller can diff cleanly.
+func vpcLbInitContainers(family int, gateway, image string, cidrs []string, privileged, allowPrivEsc *bool) []corev1.Container {
+	if gateway == "" || len(cidrs) == 0 {
+		return nil
+	}
+	iptablesCmd := "iptables"
+	if family == 6 {
+		iptablesCmd = "ip6tables"
+	}
+	out := make([]corev1.Container, 0, len(cidrs)*2)
+	for i, cidr := range cidrs {
+		out = append(out,
+			corev1.Container{
+				Name:            fmt.Sprintf("init-ipv%d-route-%d", family, i),
+				Image:           image,
+				Command:         []string{"ip"},
+				Args:            strings.Fields(fmt.Sprintf("-%d route replace %s via %s", family, cidr, gateway)),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               privileged,
+					AllowPrivilegeEscalation: allowPrivEsc,
+				},
+			},
+			corev1.Container{
+				Name:            fmt.Sprintf("init-ipv%d-iptables-%d", family, i),
+				Image:           image,
+				Command:         []string{iptablesCmd},
+				Args:            strings.Fields(fmt.Sprintf("-t nat -I POSTROUTING -d %s -j MASQUERADE", cidr)),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               privileged,
+					AllowPrivilegeEscalation: allowPrivEsc,
+				},
+			},
+		)
+	}
+	return out
 }

--- a/pkg/controller/vpc_lb.go
+++ b/pkg/controller/vpc_lb.go
@@ -22,26 +22,38 @@ func vpcLbDeploymentName(vpc string) string {
 }
 
 func (c *Controller) createVpcLb(vpc *kubeovnv1.Vpc) error {
-	deployment, err := c.genVpcLbDeployment(vpc)
-	if deployment == nil || err != nil {
+	desired, err := c.genVpcLbDeployment(vpc)
+	if desired == nil || err != nil {
 		klog.Errorf("failed to generate vpc lb deployment for %s: %v", vpc.Name, err)
 		return err
 	}
-	klog.Infof("create vpc lb deployment %s", deployment.Name)
-	_, err = c.config.KubeClient.AppsV1().Deployments(c.config.PodNamespace).Get(context.Background(), deployment.Name, metav1.GetOptions{})
-	if err == nil {
+	deployments := c.config.KubeClient.AppsV1().Deployments(c.config.PodNamespace)
+	existing, err := deployments.Get(context.Background(), desired.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		klog.Infof("create vpc lb deployment %s", desired.Name)
+		if _, err = deployments.Create(context.Background(), desired, metav1.CreateOptions{}); err != nil {
+			klog.Errorf("failed to create LB deployment for VPC %s: %v", vpc.Name, err)
+			return err
+		}
 		return nil
 	}
-	if !k8serrors.IsNotFound(err) {
+	if err != nil {
 		klog.Errorf("failed to check LB deployment for VPC %s: %v", vpc.Name, err)
 		return err
 	}
-
-	if _, err = c.config.KubeClient.AppsV1().Deployments(c.config.PodNamespace).Create(context.Background(), deployment, metav1.CreateOptions{}); err != nil {
-		klog.Errorf("failed to create LB deployment for VPC %s: %v", vpc.Name, err)
+	if existing.Annotations[util.ServiceCIDRHashAnnotation] == desired.Annotations[util.ServiceCIDRHashAnnotation] {
+		return nil
+	}
+	klog.Infof("update vpc lb deployment %s for ServiceCIDR change", desired.Name)
+	existing.Spec = desired.Spec
+	if existing.Annotations == nil {
+		existing.Annotations = map[string]string{}
+	}
+	existing.Annotations[util.ServiceCIDRHashAnnotation] = desired.Annotations[util.ServiceCIDRHashAnnotation]
+	if _, err = deployments.Update(context.Background(), existing, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("failed to update LB deployment for VPC %s: %v", vpc.Name, err)
 		return err
 	}
-
 	return nil
 }
 
@@ -152,53 +164,66 @@ func (c *Controller) genVpcLbDeployment(vpc *kubeovnv1.Vpc) (*v1.Deployment, err
 	}
 
 	v4Gw, v6Gw := util.SplitStringIP(defaultSubnet.Spec.Gateway)
-	v4Svc, v6Svc := util.SplitStringIP(c.config.ServiceClusterIPRange)
-	if v4Gw != "" && v4Svc != "" {
-		deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, corev1.Container{
-			Name:            "init-ipv4-route",
-			Image:           vpcNatImage,
-			Command:         []string{"ip"},
-			Args:            strings.Fields(fmt.Sprintf("-4 route replace %s via %s", v4Svc, v4Gw)),
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged:               &privileged,
-				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-			},
-		}, corev1.Container{
-			Name:            "init-ipv4-iptables",
-			Image:           vpcNatImage,
-			Command:         []string{"iptables"},
-			Args:            strings.Fields(fmt.Sprintf("-t nat -I POSTROUTING -d %s -j MASQUERADE", v4Svc)),
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged:               &privileged,
-				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-			},
-		})
+	if v4Gw != "" {
+		for i, v4Svc := range c.serviceCIDRStore.V4CIDRs() {
+			deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, corev1.Container{
+				Name:            fmt.Sprintf("init-ipv4-route-%d", i),
+				Image:           vpcNatImage,
+				Command:         []string{"ip"},
+				Args:            strings.Fields(fmt.Sprintf("-4 route replace %s via %s", v4Svc, v4Gw)),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               &privileged,
+					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+				},
+			}, corev1.Container{
+				Name:            fmt.Sprintf("init-ipv4-iptables-%d", i),
+				Image:           vpcNatImage,
+				Command:         []string{"iptables"},
+				Args:            strings.Fields(fmt.Sprintf("-t nat -I POSTROUTING -d %s -j MASQUERADE", v4Svc)),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               &privileged,
+					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+				},
+			})
+		}
 	}
-	if v6Gw != "" && v6Svc != "" {
-		deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, corev1.Container{
-			Name:            "init-ipv6-route",
-			Image:           vpcNatImage,
-			Command:         []string{"ip"},
-			Args:            strings.Fields(fmt.Sprintf("-6 route replace %s via %s", v6Svc, v6Gw)),
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged:               &privileged,
-				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-			},
-		}, corev1.Container{
-			Name:            "init-ipv6-iptables",
-			Image:           vpcNatImage,
-			Command:         []string{"ip6tables"},
-			Args:            strings.Fields(fmt.Sprintf("-t nat -I POSTROUTING -d %s -j MASQUERADE", v6Svc)),
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged:               &privileged,
-				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-			},
-		})
+	if v6Gw != "" {
+		for i, v6Svc := range c.serviceCIDRStore.V6CIDRs() {
+			deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, corev1.Container{
+				Name:            fmt.Sprintf("init-ipv6-route-%d", i),
+				Image:           vpcNatImage,
+				Command:         []string{"ip"},
+				Args:            strings.Fields(fmt.Sprintf("-6 route replace %s via %s", v6Svc, v6Gw)),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               &privileged,
+					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+				},
+			}, corev1.Container{
+				Name:            fmt.Sprintf("init-ipv6-iptables-%d", i),
+				Image:           vpcNatImage,
+				Command:         []string{"ip6tables"},
+				Args:            strings.Fields(fmt.Sprintf("-t nat -I POSTROUTING -d %s -j MASQUERADE", v6Svc)),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               &privileged,
+					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+				},
+			})
+		}
 	}
+
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+	hash := c.serviceCIDRStore.Hash()
+	deployment.Annotations[util.ServiceCIDRHashAnnotation] = hash
+	deployment.Spec.Template.Annotations[util.ServiceCIDRHashAnnotation] = hash
 
 	return deployment, nil
 }

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -1008,13 +1008,18 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 
 	// Add routes to join the services (is this still needed?)
 	// It seems like the script inside the NAT GW already does that
-	v4ClusterIPRange, v6ClusterIPRange := util.SplitStringIP(c.config.ServiceClusterIPRange)
-	routes := make([]request.Route, 0, 2)
-	if eth0V4Gateway != "" && v4ClusterIPRange != "" {
-		routes = append(routes, request.Route{Destination: v4ClusterIPRange, Gateway: eth0V4Gateway})
+	v4ClusterIPRanges := c.serviceCIDRStore.V4CIDRs()
+	v6ClusterIPRanges := c.serviceCIDRStore.V6CIDRs()
+	routes := make([]request.Route, 0, len(v4ClusterIPRanges)+len(v6ClusterIPRanges))
+	if eth0V4Gateway != "" {
+		for _, cidr := range v4ClusterIPRanges {
+			routes = append(routes, request.Route{Destination: cidr, Gateway: eth0V4Gateway})
+		}
 	}
-	if eth0V6Gateway != "" && v6ClusterIPRange != "" {
-		routes = append(routes, request.Route{Destination: v6ClusterIPRange, Gateway: eth0V6Gateway})
+	if eth0V6Gateway != "" {
+		for _, cidr := range v6ClusterIPRanges {
+			routes = append(routes, request.Route{Destination: cidr, Gateway: eth0V6Gateway})
+		}
 	}
 
 	// Add gateway to join every subnet in the same VPC? (is this still needed?)

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -156,6 +156,11 @@ func NewController(config *Configuration,
 		ipsecQueue:     newTypedRateLimitingQueue[string]("IPSecCA", nil),
 
 		serviceCIDRStore: util.NewServiceCIDRStore(config.ServiceClusterIPRange),
+		serviceCIDRInformerFactory: informers.NewSharedInformerFactoryWithOptions(config.KubeClient, 0,
+			informers.WithTweakListOptions(func(listOption *metav1.ListOptions) {
+				listOption.AllowWatchBookmarks = true
+			}),
+		),
 
 		recorder: recorder,
 		k8sExec:  k8sexec.New(),

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	listerv1 "k8s.io/client-go/listers/core/v1"
+	netv1lister "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -72,6 +73,11 @@ type Controller struct {
 	caSecretLister listerv1.SecretLister
 	caSecretSynced cache.InformerSynced
 	ipsecQueue     workqueue.TypedRateLimitingInterface[string]
+
+	serviceCIDRStore           *util.ServiceCIDRStore
+	serviceCIDRLister          netv1lister.ServiceCIDRLister
+	serviceCIDRSynced          cache.InformerSynced
+	serviceCIDRInformerFactory informers.SharedInformerFactory
 
 	recorder record.EventRecorder
 
@@ -149,6 +155,8 @@ func NewController(config *Configuration,
 		caSecretSynced: caSecretInformer.Informer().HasSynced,
 		ipsecQueue:     newTypedRateLimitingQueue[string]("IPSecCA", nil),
 
+		serviceCIDRStore: util.NewServiceCIDRStore(config.ServiceClusterIPRange),
+
 		recorder: recorder,
 		k8sExec:  k8sexec.New(),
 
@@ -169,6 +177,7 @@ func NewController(config *Configuration,
 	nodeInformerFactory.Start(stopCh)
 	kubeovnInformerFactory.Start(stopCh)
 	caSecretInformerFactory.Start(stopCh)
+	controller.StartServiceCIDRInformerFactory(stopCh)
 
 	if !cache.WaitForCacheSync(stopCh,
 		controller.providerNetworksSynced, controller.vlansSynced, controller.subnetsSynced,

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -151,13 +151,10 @@ func (c *Controller) getSubnetsDistributedGateway(protocol string) ([]string, er
 }
 
 func (c *Controller) getServicesCIDR(protocol string) []string {
-	ret := make([]string, 0)
-	for cidr := range strings.SplitSeq(c.config.ServiceClusterIPRange, ",") {
-		if util.CheckProtocol(cidr) == protocol {
-			ret = append(ret, cidr)
-		}
+	if protocol == kubeovnv1.ProtocolIPv6 {
+		return c.serviceCIDRStore.V6CIDRs()
 	}
-	return ret
+	return c.serviceCIDRStore.V4CIDRs()
 }
 
 func (c *Controller) getDefaultVpcSubnetsCIDR(protocol string) ([]string, map[string]string, error) {

--- a/pkg/daemon/service_cidr.go
+++ b/pkg/daemon/service_cidr.go
@@ -1,32 +1,21 @@
 package daemon
 
 import (
-	"context"
 	"time"
 
 	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-func (c *Controller) isServiceCIDRAPIInstalled() (bool, error) {
-	return util.APIResourceExists(
-		c.config.KubeClient.Discovery(),
-		networkingv1.SchemeGroupVersion.String(),
-		"ServiceCIDR",
-	)
-}
-
 func (c *Controller) startServiceCIDRInformer(stopCh <-chan struct{}) {
 	informer := c.serviceCIDRInformerFactory.Networking().V1().ServiceCIDRs()
 	if _, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.onServiceCIDRAdd,
-		UpdateFunc: c.onServiceCIDRUpdate,
+		AddFunc:    c.onServiceCIDRChange,
+		UpdateFunc: func(_, newObj any) { c.onServiceCIDRChange(newObj) },
 		DeleteFunc: c.onServiceCIDRDelete,
 	}); err != nil {
 		util.LogFatalAndExit(err, "failed to add ServiceCIDR event handler")
@@ -46,12 +35,16 @@ func (c *Controller) startServiceCIDRInformer(stopCh <-chan struct{}) {
 		return
 	}
 	for _, sc := range scs {
-		c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+		c.serviceCIDRStore.UpsertFromAPI(sc.Name, util.ReadyServiceCIDRs(sc))
 	}
 }
 
 func (c *Controller) tryStartServiceCIDRInformer(stopCh <-chan struct{}) bool {
-	exists, err := c.isServiceCIDRAPIInstalled()
+	exists, err := util.APIResourceExists(
+		c.config.KubeClient.Discovery(),
+		networkingv1.SchemeGroupVersion.String(),
+		util.ObjectKind[*networkingv1.ServiceCIDR](),
+	)
 	if err != nil {
 		klog.Warningf("failed to check ServiceCIDR API: %v", err)
 		return false
@@ -69,11 +62,6 @@ func (c *Controller) tryStartServiceCIDRInformer(stopCh <-chan struct{}) bool {
 // The 3-second setIPSet/setIptables loop in gateway_linux.go automatically
 // picks up the merged set on each tick — no precise enqueue is needed here.
 func (c *Controller) StartServiceCIDRInformerFactory(stopCh <-chan struct{}) {
-	c.serviceCIDRInformerFactory = informers.NewSharedInformerFactoryWithOptions(c.config.KubeClient, 0,
-		informers.WithTweakListOptions(func(listOption *metav1.ListOptions) {
-			listOption.AllowWatchBookmarks = true
-		}),
-	)
 	if c.tryStartServiceCIDRInformer(stopCh) {
 		return
 	}
@@ -81,39 +69,25 @@ func (c *Controller) StartServiceCIDRInformerFactory(stopCh <-chan struct{}) {
 	ticker := time.NewTicker(10 * time.Second)
 	go func() {
 		defer ticker.Stop()
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go func() {
-			<-stopCh
-			cancel()
-		}()
 		for {
 			select {
 			case <-ticker.C:
 				if c.tryStartServiceCIDRInformer(stopCh) {
 					return
 				}
-			case <-ctx.Done():
+			case <-stopCh:
 				return
 			}
 		}
 	}()
 }
 
-func (c *Controller) onServiceCIDRAdd(obj any) {
+func (c *Controller) onServiceCIDRChange(obj any) {
 	sc, ok := obj.(*networkingv1.ServiceCIDR)
 	if !ok {
 		return
 	}
-	c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
-}
-
-func (c *Controller) onServiceCIDRUpdate(_, newObj any) {
-	sc, ok := newObj.(*networkingv1.ServiceCIDR)
-	if !ok {
-		return
-	}
-	c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+	c.serviceCIDRStore.UpsertFromAPI(sc.Name, util.ReadyServiceCIDRs(sc))
 }
 
 func (c *Controller) onServiceCIDRDelete(obj any) {
@@ -129,21 +103,4 @@ func (c *Controller) onServiceCIDRDelete(obj any) {
 		}
 	}
 	c.serviceCIDRStore.DeleteFromAPI(sc.Name)
-}
-
-func readyServiceCIDRs(sc *networkingv1.ServiceCIDR) []string {
-	if sc == nil {
-		return nil
-	}
-	ready := false
-	for _, cond := range sc.Status.Conditions {
-		if cond.Type == networkingv1.ServiceCIDRConditionReady {
-			ready = cond.Status == metav1.ConditionTrue
-			break
-		}
-	}
-	if !ready {
-		return nil
-	}
-	return sc.Spec.CIDRs
 }

--- a/pkg/daemon/service_cidr.go
+++ b/pkg/daemon/service_cidr.go
@@ -1,0 +1,149 @@
+package daemon
+
+import (
+	"context"
+	"time"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func (c *Controller) isServiceCIDRAPIInstalled() (bool, error) {
+	return util.APIResourceExists(
+		c.config.KubeClient.Discovery(),
+		networkingv1.SchemeGroupVersion.String(),
+		"ServiceCIDR",
+	)
+}
+
+func (c *Controller) startServiceCIDRInformer(stopCh <-chan struct{}) {
+	informer := c.serviceCIDRInformerFactory.Networking().V1().ServiceCIDRs()
+	if _, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onServiceCIDRAdd,
+		UpdateFunc: c.onServiceCIDRUpdate,
+		DeleteFunc: c.onServiceCIDRDelete,
+	}); err != nil {
+		util.LogFatalAndExit(err, "failed to add ServiceCIDR event handler")
+	}
+	c.serviceCIDRLister = informer.Lister()
+	c.serviceCIDRSynced = informer.Informer().HasSynced
+
+	c.serviceCIDRInformerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, c.serviceCIDRSynced) {
+		util.LogFatalAndExit(nil, "failed to wait for ServiceCIDR cache to sync")
+	}
+	klog.Info("ServiceCIDR informer cache synced")
+
+	scs, err := c.serviceCIDRLister.List(labels.Everything())
+	if err != nil {
+		klog.Warningf("failed to list ServiceCIDRs after sync: %v", err)
+		return
+	}
+	for _, sc := range scs {
+		c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+	}
+}
+
+func (c *Controller) tryStartServiceCIDRInformer(stopCh <-chan struct{}) bool {
+	exists, err := c.isServiceCIDRAPIInstalled()
+	if err != nil {
+		klog.Warningf("failed to check ServiceCIDR API: %v", err)
+		return false
+	}
+	if !exists {
+		return false
+	}
+	klog.Info("ServiceCIDR API found, starting informer")
+	c.startServiceCIDRInformer(stopCh)
+	return true
+}
+
+// StartServiceCIDRInformerFactory starts the optional ServiceCIDR informer.
+// On clusters without the API the merged set stays at flag-derived fallback.
+// The 3-second setIPSet/setIptables loop in gateway_linux.go automatically
+// picks up the merged set on each tick — no precise enqueue is needed here.
+func (c *Controller) StartServiceCIDRInformerFactory(stopCh <-chan struct{}) {
+	c.serviceCIDRInformerFactory = informers.NewSharedInformerFactoryWithOptions(c.config.KubeClient, 0,
+		informers.WithTweakListOptions(func(listOption *metav1.ListOptions) {
+			listOption.AllowWatchBookmarks = true
+		}),
+	)
+	if c.tryStartServiceCIDRInformer(stopCh) {
+		return
+	}
+	klog.Info("ServiceCIDR API not found at startup, will check periodically in background")
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		defer ticker.Stop()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			<-stopCh
+			cancel()
+		}()
+		for {
+			select {
+			case <-ticker.C:
+				if c.tryStartServiceCIDRInformer(stopCh) {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (c *Controller) onServiceCIDRAdd(obj any) {
+	sc, ok := obj.(*networkingv1.ServiceCIDR)
+	if !ok {
+		return
+	}
+	c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+}
+
+func (c *Controller) onServiceCIDRUpdate(_, newObj any) {
+	sc, ok := newObj.(*networkingv1.ServiceCIDR)
+	if !ok {
+		return
+	}
+	c.serviceCIDRStore.UpsertFromAPI(sc.Name, readyServiceCIDRs(sc))
+}
+
+func (c *Controller) onServiceCIDRDelete(obj any) {
+	sc, ok := obj.(*networkingv1.ServiceCIDR)
+	if !ok {
+		tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown)
+		if !isTombstone {
+			return
+		}
+		sc, ok = tombstone.Obj.(*networkingv1.ServiceCIDR)
+		if !ok {
+			return
+		}
+	}
+	c.serviceCIDRStore.DeleteFromAPI(sc.Name)
+}
+
+func readyServiceCIDRs(sc *networkingv1.ServiceCIDR) []string {
+	if sc == nil {
+		return nil
+	}
+	ready := false
+	for _, cond := range sc.Status.Conditions {
+		if cond.Type == networkingv1.ServiceCIDRConditionReady {
+			ready = cond.Status == metav1.ConditionTrue
+			break
+		}
+	}
+	if !ready {
+		return nil
+	}
+	return sc.Spec.CIDRs
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -17,6 +17,7 @@ const (
 	KubeOVNControllerFinalizer = "kubeovn.io/kube-ovn-controller"
 
 	AllocatedAnnotation          = "ovn.kubernetes.io/allocated"
+	ServiceCIDRHashAnnotation    = "ovn.kubernetes.io/service-cidr-hash"
 	RoutedAnnotation             = "ovn.kubernetes.io/routed"
 	RoutesAnnotation             = "ovn.kubernetes.io/routes"
 	MacAddressAnnotation         = "ovn.kubernetes.io/mac_address"

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -16,16 +16,42 @@ import (
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/scheme"
 )
+
+// APIResourceExists checks if all specified kinds exist in the given group version.
+// It returns true if all kinds are found, false otherwise.
+// Parameters:
+// - discoveryClient: The discovery client to use for querying API resources.
+// - gv: The group version string (e.g., "apps/v1").
+// - kinds: A variadic list of kind names to check for existence (e.g., "Deployment", "StatefulSet").
+func APIResourceExists(discoveryClient discovery.DiscoveryInterface, gv string, kinds ...string) (bool, error) {
+	apiResourceLists, err := discoveryClient.ServerResourcesForGroupVersion(gv)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to discover api resources for %s: %w", gv, err)
+	}
+
+	existingKinds := set.New[string]()
+	for _, apiResource := range apiResourceLists.APIResources {
+		existingKinds.Insert(apiResource.Kind)
+	}
+
+	return existingKinds.HasAll(kinds...), nil
+}
 
 // ObjectMatchesLabelSelector checks if the given object matches the provided label selector.
 // It returns true if the object has labels that match the selector, otherwise false.

--- a/pkg/util/servicecidr_store.go
+++ b/pkg/util/servicecidr_store.go
@@ -1,0 +1,222 @@
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+// ServiceCIDRStore is the merged source of truth for Service CIDRs known to
+// kube-ovn. It combines the values from --service-cluster-ip-range (fallback)
+// with the CIDRs found in networking.k8s.io/v1 ServiceCIDR objects, when the
+// API is available.
+//
+// The store dedupes by string equality, filters by IP family, and notifies
+// registered handlers when the merged set actually changes (debounced 1s to
+// coalesce informer initial-list bursts).
+type ServiceCIDRStore struct {
+	mu       sync.RWMutex
+	fallback []string
+	fromAPI  map[string][]string
+	handlers []func()
+	debounce *time.Timer
+	cached   []string
+
+	debounceInterval time.Duration
+}
+
+// NewServiceCIDRStore parses the --service-cluster-ip-range flag value and
+// returns a store seeded with those CIDRs as the permanent fallback set.
+func NewServiceCIDRStore(flagValue string) *ServiceCIDRStore {
+	v4, v6 := SplitStringIP(flagValue)
+	fallback := make([]string, 0, 2)
+	if v4 != "" {
+		fallback = append(fallback, v4)
+	}
+	if v6 != "" {
+		fallback = append(fallback, v6)
+	}
+	s := &ServiceCIDRStore{
+		fallback:         fallback,
+		fromAPI:          make(map[string][]string),
+		debounceInterval: time.Second,
+	}
+	s.cached = s.merged()
+	return s
+}
+
+// merged returns the deduped + sorted set of effective Service CIDRs. The
+// flag-derived fallback is used only when no ServiceCIDR object has supplied a
+// valid CIDR — the moment the API takes over (e.g. the default `kubernetes`
+// ServiceCIDR is observed) the flag steps aside so that deletions/migrations
+// of ServiceCIDR objects can shrink the live set. If the API set later becomes
+// empty (no Ready objects), the fallback re-engages so the data plane keeps a
+// usable baseline.
+// Caller must hold s.mu.
+func (s *ServiceCIDRStore) merged() []string {
+	seen := make(map[string]struct{}, len(s.fallback)+len(s.fromAPI)*2)
+	out := make([]string, 0, len(s.fallback)+len(s.fromAPI)*2)
+	add := func(cidr string) {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			return
+		}
+		if CheckProtocol(cidr) == "" {
+			return
+		}
+		if _, ok := seen[cidr]; ok {
+			return
+		}
+		seen[cidr] = struct{}{}
+		out = append(out, cidr)
+	}
+	for _, cidrs := range s.fromAPI {
+		for _, cidr := range cidrs {
+			add(cidr)
+		}
+	}
+	if len(out) == 0 {
+		for _, cidr := range s.fallback {
+			add(cidr)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// AllCIDRs returns the merged set in sorted order.
+func (s *ServiceCIDRStore) AllCIDRs() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]string, len(s.cached))
+	copy(out, s.cached)
+	return out
+}
+
+// V4CIDRs returns the IPv4 subset of the merged set.
+func (s *ServiceCIDRStore) V4CIDRs() []string { return s.byProtocol(kubeovnv1.ProtocolIPv4) }
+
+// V6CIDRs returns the IPv6 subset of the merged set.
+func (s *ServiceCIDRStore) V6CIDRs() []string { return s.byProtocol(kubeovnv1.ProtocolIPv6) }
+
+func (s *ServiceCIDRStore) byProtocol(proto string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]string, 0, len(s.cached))
+	for _, cidr := range s.cached {
+		if CheckProtocol(cidr) == proto {
+			out = append(out, cidr)
+		}
+	}
+	return out
+}
+
+// Hash returns a stable SHA-256 over the sorted merged set. Used as a
+// deployment annotation to roll vpc-lb pods when the set changes.
+func (s *ServiceCIDRStore) Hash() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	h := sha256.New()
+	for _, cidr := range s.cached {
+		h.Write([]byte(cidr))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// UpsertFromAPI sets the CIDRs for a given ServiceCIDR object name. Returns
+// true if the merged set changed (handlers will fire after debounce).
+func (s *ServiceCIDRStore) UpsertFromAPI(name string, cidrs []string) bool {
+	s.mu.Lock()
+	cleaned := make([]string, 0, len(cidrs))
+	for _, c := range cidrs {
+		c = strings.TrimSpace(c)
+		if c != "" {
+			cleaned = append(cleaned, c)
+		}
+	}
+	if equalStringSlice(s.fromAPI[name], cleaned) {
+		s.mu.Unlock()
+		return false
+	}
+	s.fromAPI[name] = cleaned
+	changed := s.recomputeLocked()
+	s.mu.Unlock()
+	if changed {
+		s.scheduleFire()
+	}
+	return changed
+}
+
+// DeleteFromAPI removes a ServiceCIDR object from the store.
+func (s *ServiceCIDRStore) DeleteFromAPI(name string) bool {
+	s.mu.Lock()
+	if _, ok := s.fromAPI[name]; !ok {
+		s.mu.Unlock()
+		return false
+	}
+	delete(s.fromAPI, name)
+	changed := s.recomputeLocked()
+	s.mu.Unlock()
+	if changed {
+		s.scheduleFire()
+	}
+	return changed
+}
+
+// recomputeLocked refreshes s.cached. Caller must hold s.mu (write).
+// Returns true if the slice content changed.
+func (s *ServiceCIDRStore) recomputeLocked() bool {
+	next := s.merged()
+	if equalStringSlice(s.cached, next) {
+		return false
+	}
+	s.cached = next
+	return true
+}
+
+// OnChange registers a handler called (off the lock, in a goroutine) whenever
+// the merged set changes. Multiple handlers are supported.
+func (s *ServiceCIDRStore) OnChange(h func()) {
+	s.mu.Lock()
+	s.handlers = append(s.handlers, h)
+	s.mu.Unlock()
+}
+
+// scheduleFire coalesces bursts of updates into a single round of handler
+// invocations after debounceInterval.
+func (s *ServiceCIDRStore) scheduleFire() {
+	s.mu.Lock()
+	if s.debounce != nil {
+		s.debounce.Stop()
+	}
+	s.debounce = time.AfterFunc(s.debounceInterval, s.fireOnChange)
+	s.mu.Unlock()
+}
+
+func (s *ServiceCIDRStore) fireOnChange() {
+	s.mu.RLock()
+	handlers := make([]func(), len(s.handlers))
+	copy(handlers, s.handlers)
+	s.mu.RUnlock()
+	for _, h := range handlers {
+		go h()
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/util/servicecidr_store.go
+++ b/pkg/util/servicecidr_store.go
@@ -3,13 +3,35 @@ package util
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
+
+// ReadyServiceCIDRs returns Spec.CIDRs when the ServiceCIDR object's Ready
+// condition is True. Objects still being initialized or already terminating
+// are skipped, matching the apiserver allocator's own behavior.
+func ReadyServiceCIDRs(sc *networkingv1.ServiceCIDR) []string {
+	if sc == nil {
+		return nil
+	}
+	for _, cond := range sc.Status.Conditions {
+		if cond.Type == networkingv1.ServiceCIDRConditionReady {
+			if cond.Status == metav1.ConditionTrue {
+				return sc.Spec.CIDRs
+			}
+			return nil
+		}
+	}
+	return nil
+}
 
 // ServiceCIDRStore is the merged source of truth for Service CIDRs known to
 // kube-ovn. It combines the values from --service-cluster-ip-range (fallback)
@@ -140,7 +162,7 @@ func (s *ServiceCIDRStore) UpsertFromAPI(name string, cidrs []string) bool {
 			cleaned = append(cleaned, c)
 		}
 	}
-	if equalStringSlice(s.fromAPI[name], cleaned) {
+	if slices.Equal(s.fromAPI[name], cleaned) {
 		s.mu.Unlock()
 		return false
 	}
@@ -173,7 +195,7 @@ func (s *ServiceCIDRStore) DeleteFromAPI(name string) bool {
 // Returns true if the slice content changed.
 func (s *ServiceCIDRStore) recomputeLocked() bool {
 	next := s.merged()
-	if equalStringSlice(s.cached, next) {
+	if slices.Equal(s.cached, next) {
 		return false
 	}
 	s.cached = next
@@ -207,16 +229,4 @@ func (s *ServiceCIDRStore) fireOnChange() {
 	for _, h := range handlers {
 		go h()
 	}
-}
-
-func equalStringSlice(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/util/servicecidr_store_test.go
+++ b/pkg/util/servicecidr_store_test.go
@@ -1,0 +1,168 @@
+package util
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestServiceCIDRStoreFlagOnly(t *testing.T) {
+	s := NewServiceCIDRStore("10.96.0.0/12,fd00::/108")
+	v4 := s.V4CIDRs()
+	v6 := s.V6CIDRs()
+	if len(v4) != 1 || v4[0] != "10.96.0.0/12" {
+		t.Fatalf("unexpected v4: %v", v4)
+	}
+	if len(v6) != 1 || v6[0] != "fd00::/108" {
+		t.Fatalf("unexpected v6: %v", v6)
+	}
+	if got := s.AllCIDRs(); len(got) != 2 {
+		t.Fatalf("expected 2 cidrs, got %v", got)
+	}
+}
+
+func TestServiceCIDRStoreUpsertAndDelete(t *testing.T) {
+	s := NewServiceCIDRStore("10.96.0.0/12")
+	s.debounceInterval = 5 * time.Millisecond
+
+	var fired int32
+	done := make(chan struct{}, 8)
+	s.OnChange(func() {
+		atomic.AddInt32(&fired, 1)
+		done <- struct{}{}
+	})
+
+	// First API entry is identical to the flag — the merged set's content is
+	// unchanged, so UpsertFromAPI returns false even though the source has
+	// shifted from fallback to API. A second, distinct entry is what brings
+	// the set to two CIDRs.
+	if s.UpsertFromAPI("primary", []string{"10.96.0.0/12"}) {
+		t.Fatal("expected no change when API entry equals flag content")
+	}
+	if !s.UpsertFromAPI("extra", []string{"10.97.0.0/16"}) {
+		t.Fatal("expected change on second upsert")
+	}
+
+	v4 := s.V4CIDRs()
+	if len(v4) != 2 || v4[0] != "10.96.0.0/12" || v4[1] != "10.97.0.0/16" {
+		t.Fatalf("unexpected v4: %v", v4)
+	}
+
+	waitFor(t, done, 1)
+	time.Sleep(2 * s.debounceInterval) // ensure first fire's debounce window ended
+
+	if !s.DeleteFromAPI("extra") {
+		t.Fatal("expected change on delete")
+	}
+	if s.DeleteFromAPI("extra") {
+		t.Fatal("expected no change on second delete")
+	}
+	if got := s.AllCIDRs(); len(got) != 1 || got[0] != "10.96.0.0/12" {
+		t.Fatalf("expected only the remaining API entry after delete, got %v", got)
+	}
+
+	waitFor(t, done, 1)
+	if atomic.LoadInt32(&fired) < 2 {
+		t.Fatalf("expected at least 2 fires across upsert+delete, got %d", fired)
+	}
+}
+
+func TestServiceCIDRStoreDedup(t *testing.T) {
+	s := NewServiceCIDRStore("10.96.0.0/12")
+	s.UpsertFromAPI("k", []string{"10.96.0.0/12"})
+	if got := s.AllCIDRs(); len(got) != 1 {
+		t.Fatalf("expected dedup to 1, got %v", got)
+	}
+}
+
+func TestServiceCIDRStoreFlagYieldsToAPI(t *testing.T) {
+	// flag is the initial bootstrap value; it must yield as soon as the API
+	// observes any valid ServiceCIDR, otherwise deletions/migrations cannot
+	// shrink the effective set.
+	s := NewServiceCIDRStore("10.96.0.0/12")
+	if got := s.AllCIDRs(); len(got) != 1 || got[0] != "10.96.0.0/12" {
+		t.Fatalf("flag should be live before any API entry: %v", got)
+	}
+
+	s.UpsertFromAPI("kubernetes", []string{"10.97.0.0/16"})
+	got := s.AllCIDRs()
+	if len(got) != 1 || got[0] != "10.97.0.0/16" {
+		t.Fatalf("flag should yield to API entries: %v", got)
+	}
+
+	// All API entries removed → fallback re-engages so the data plane keeps a
+	// usable set.
+	s.DeleteFromAPI("kubernetes")
+	got = s.AllCIDRs()
+	if len(got) != 1 || got[0] != "10.96.0.0/12" {
+		t.Fatalf("fallback must re-engage when API set empties: %v", got)
+	}
+}
+
+func TestServiceCIDRStoreNonReadyDoesNotShadowFlag(t *testing.T) {
+	// readyServiceCIDRs returns nil for non-Ready objects; UpsertFromAPI then
+	// stores an empty slice. The merged set must still fall back to the flag
+	// so the data plane keeps the baseline programmed.
+	s := NewServiceCIDRStore("10.96.0.0/12")
+	s.UpsertFromAPI("pending", nil)
+	got := s.AllCIDRs()
+	if len(got) != 1 || got[0] != "10.96.0.0/12" {
+		t.Fatalf("non-ready API entries should not shadow flag fallback: %v", got)
+	}
+}
+
+func TestServiceCIDRStoreHashStability(t *testing.T) {
+	a := NewServiceCIDRStore("10.96.0.0/12,fd00::/108")
+	b := NewServiceCIDRStore("fd00::/108,10.96.0.0/12") // order-insensitive after merge
+	if a.Hash() != b.Hash() {
+		t.Fatalf("hash should be order-insensitive: a=%s b=%s", a.Hash(), b.Hash())
+	}
+	original := a.Hash()
+	a.UpsertFromAPI("x", []string{"10.97.0.0/16"})
+	if a.Hash() == original {
+		t.Fatalf("hash should change after upsert")
+	}
+	a.DeleteFromAPI("x")
+	if a.Hash() != original {
+		t.Fatalf("hash should restore after delete: got=%s want=%s", a.Hash(), original)
+	}
+}
+
+func TestServiceCIDRStoreInvalidIgnored(t *testing.T) {
+	s := NewServiceCIDRStore("10.96.0.0/12")
+	s.UpsertFromAPI("bogus", []string{"not-a-cidr", "", " "})
+	if got := s.AllCIDRs(); len(got) != 1 || got[0] != "10.96.0.0/12" {
+		t.Fatalf("invalid entries should be ignored, got %v", got)
+	}
+}
+
+func TestServiceCIDRStoreDebounceCoalesces(t *testing.T) {
+	s := NewServiceCIDRStore("10.96.0.0/12")
+	s.debounceInterval = 30 * time.Millisecond
+
+	var fired int32
+	s.OnChange(func() { atomic.AddInt32(&fired, 1) })
+
+	for range 5 {
+		s.UpsertFromAPI("k", []string{"10.97.0.0/16"})
+		s.UpsertFromAPI("k", []string{"10.98.0.0/16"})
+	}
+	time.Sleep(120 * time.Millisecond)
+	if got := atomic.LoadInt32(&fired); got > 2 {
+		t.Fatalf("debounce should coalesce bursts, fired=%d", got)
+	}
+}
+
+func waitFor(t *testing.T, ch <-chan struct{}, atLeast int) {
+	t.Helper()
+	deadline := time.After(500 * time.Millisecond)
+	got := 0
+	for got < atLeast {
+		select {
+		case <-ch:
+			got++
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d events, got %d", atLeast, got)
+		}
+	}
+}

--- a/test/e2e/kube-ovn/e2e_test.go
+++ b/test/e2e/kube-ovn/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/pod"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/qos"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/service"
+	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/service_cidr"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/subnet"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/switch_lb_rule"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/underlay"

--- a/test/e2e/kube-ovn/service_cidr/service_cidr.go
+++ b/test/e2e/kube-ovn/service_cidr/service_cidr.go
@@ -25,10 +25,13 @@ import (
 // store, so the test is gated on both fronts.
 const skipVersionMajor, skipVersionMinor uint = 1, 17
 
-// extraCIDR sits well outside the kind default (10.96.0.0/12) and the
-// 10.0.0.0/16 pool used by RandomCIDR for subnet tests, so it never collides
-// with parallel cases.
-const extraCIDR = "10.250.0.0/24"
+// extraCIDRs sit well outside the kind defaults (10.96.0.0/12 / fd00:10:96::/112)
+// and the per-family pools used by RandomCIDR for subnet tests, so they never
+// collide with parallel cases.
+const (
+	extraCIDRv4 = "10.250.0.0/24"
+	extraCIDRv6 = "fd99:cafe::/108"
+)
 
 var _ = framework.Describe("[group:service-cidr]", func() {
 	f := framework.NewDefaultFramework("service-cidr")
@@ -52,10 +55,21 @@ var _ = framework.Describe("[group:service-cidr]", func() {
 		f.SkipVersionPriorTo(skipVersionMajor, skipVersionMinor, "ServiceCIDR support landed in v1.17")
 		skipIfNoServiceCIDRAPI(cs)
 
-		ginkgo.By("Creating ServiceCIDR " + name + " (" + extraCIDR + ")")
+		// One CIDR per cluster family. Daemon only manages an ipset for a
+		// family when that family is enabled on the node, so probing the
+		// "wrong" family on a single-stack cluster would deadlock the wait.
+		var cidrs []string
+		if f.HasIPv4() {
+			cidrs = append(cidrs, extraCIDRv4)
+		}
+		if f.HasIPv6() {
+			cidrs = append(cidrs, extraCIDRv6)
+		}
+
+		ginkgo.By(fmt.Sprintf("Creating ServiceCIDR %s with cidrs %v", name, cidrs))
 		sc := &networkingv1.ServiceCIDR{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Spec:       networkingv1.ServiceCIDRSpec{CIDRs: []string{extraCIDR}},
+			Spec:       networkingv1.ServiceCIDRSpec{CIDRs: cidrs},
 		}
 		_, err := cs.NetworkingV1().ServiceCIDRs().Create(context.Background(), sc, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
@@ -79,17 +93,21 @@ var _ = framework.Describe("[group:service-cidr]", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectNotEmpty(nodeList.Items)
 
-		ginkgo.By("Asserting ipset ovn40services contains " + extraCIDR + " on every node")
+		ginkgo.By("Asserting node ipsets contain the new CIDRs")
 		for _, n := range nodeList.Items {
-			expectIPSetContains(f, n, extraCIDR, true)
+			for _, c := range cidrs {
+				expectIPSetContains(f, n, c, true)
+			}
 		}
 
 		ginkgo.By("Deleting ServiceCIDR " + name)
 		framework.ExpectNoError(cs.NetworkingV1().ServiceCIDRs().Delete(context.Background(), name, metav1.DeleteOptions{}))
 
-		ginkgo.By("Asserting ipset ovn40services no longer contains " + extraCIDR + " on every node")
+		ginkgo.By("Asserting node ipsets no longer contain the CIDRs")
 		for _, n := range nodeList.Items {
-			expectIPSetContains(f, n, extraCIDR, false)
+			for _, c := range cidrs {
+				expectIPSetContains(f, n, c, false)
+			}
 		}
 	})
 })
@@ -116,9 +134,19 @@ func skipIfNoServiceCIDRAPI(cs clientset.Interface) {
 	ginkgo.Skip("networking.k8s.io/v1 ServiceCIDR API is not present in this cluster")
 }
 
+// ipsetForCIDR picks the kube-ovn services ipset that matches the given CIDR's
+// IP family. v4 CIDRs land in ovn40services, v6 in ovn60services.
+func ipsetForCIDR(cidr string) string {
+	if strings.Contains(cidr, ":") {
+		return "ovn60services"
+	}
+	return "ovn40services"
+}
+
 // expectIPSetContains polls the ovs-ovn pod on the given node and verifies
-// the membership of cidr in ovn40services. The 3-second daemon reconcile loop
-// means the assertion needs a generous window; 30s comfortably covers it.
+// the membership of cidr in the family-appropriate services ipset. The
+// 3-second daemon reconcile loop means the assertion needs a generous window;
+// 30s comfortably covers it.
 func expectIPSetContains(f *framework.Framework, node corev1.Node, cidr string, want bool) {
 	ginkgo.GinkgoHelper()
 
@@ -127,7 +155,8 @@ func expectIPSetContains(f *framework.Framework, node corev1.Node, cidr string, 
 	pod, err := dsClient.GetPodOnNode(ds, node.Name)
 	framework.ExpectNoError(err)
 
-	cmd := "ipset list ovn40services | sed -n '/^Members:/,$p' | tail -n +2"
+	setName := ipsetForCIDR(cidr)
+	cmd := fmt.Sprintf("ipset list %s | sed -n '/^Members:/,$p' | tail -n +2", setName)
 	framework.WaitUntil(2*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
 		out, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, cmd)
 		if err != nil {
@@ -136,5 +165,5 @@ func expectIPSetContains(f *framework.Framework, node corev1.Node, cidr string, 
 		members := strings.Fields(out)
 		has := slices.Contains(members, cidr)
 		return has == want, nil
-	}, fmt.Sprintf("ipset on node %s contains %s == %v", node.Name, cidr, want))
+	}, fmt.Sprintf("ipset %s on node %s contains %s == %v", setName, node.Name, cidr, want))
 }

--- a/test/e2e/kube-ovn/service_cidr/service_cidr.go
+++ b/test/e2e/kube-ovn/service_cidr/service_cidr.go
@@ -1,0 +1,140 @@
+package service_cidr
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+// ServiceCIDR (KEP-1880) became GA in K8s 1.33. The kube-ovn integration ships
+// in v1.17 — older releases either lack the controller wiring or the daemon
+// store, so the test is gated on both fronts.
+const skipVersionMajor, skipVersionMinor uint = 1, 17
+
+// extraCIDR sits well outside the kind default (10.96.0.0/12) and the
+// 10.0.0.0/16 pool used by RandomCIDR for subnet tests, so it never collides
+// with parallel cases.
+const extraCIDR = "10.250.0.0/24"
+
+var _ = framework.Describe("[group:service-cidr]", func() {
+	f := framework.NewDefaultFramework("service-cidr")
+
+	var cs clientset.Interface
+	var name string
+
+	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
+		name = "extra-" + framework.RandomSuffix()
+	})
+
+	ginkgo.AfterEach(func() {
+		err := cs.NetworkingV1().ServiceCIDRs().Delete(context.Background(), name, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			framework.Failf("failed to delete ServiceCIDR %s: %v", name, err)
+		}
+	})
+
+	framework.ConformanceIt("should propagate a runtime ServiceCIDR object into node ipsets and remove it on deletion", func() {
+		f.SkipVersionPriorTo(skipVersionMajor, skipVersionMinor, "ServiceCIDR support landed in v1.17")
+		skipIfNoServiceCIDRAPI(cs)
+
+		ginkgo.By("Creating ServiceCIDR " + name + " (" + extraCIDR + ")")
+		sc := &networkingv1.ServiceCIDR{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       networkingv1.ServiceCIDRSpec{CIDRs: []string{extraCIDR}},
+		}
+		_, err := cs.NetworkingV1().ServiceCIDRs().Create(context.Background(), sc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for ServiceCIDR " + name + " to become Ready")
+		framework.WaitUntil(2*time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+			got, err := cs.NetworkingV1().ServiceCIDRs().Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			for _, cond := range got.Status.Conditions {
+				if cond.Type == networkingv1.ServiceCIDRConditionReady && cond.Status == metav1.ConditionTrue {
+					return true, nil
+				}
+			}
+			return false, nil
+		}, "ServiceCIDR Ready=True")
+
+		ginkgo.By("Listing ready schedulable nodes")
+		nodeList, err := e2enode.GetReadySchedulableNodes(context.Background(), cs)
+		framework.ExpectNoError(err)
+		framework.ExpectNotEmpty(nodeList.Items)
+
+		ginkgo.By("Asserting ipset ovn40services contains " + extraCIDR + " on every node")
+		for _, n := range nodeList.Items {
+			expectIPSetContains(f, n, extraCIDR, true)
+		}
+
+		ginkgo.By("Deleting ServiceCIDR " + name)
+		framework.ExpectNoError(cs.NetworkingV1().ServiceCIDRs().Delete(context.Background(), name, metav1.DeleteOptions{}))
+
+		ginkgo.By("Asserting ipset ovn40services no longer contains " + extraCIDR + " on every node")
+		for _, n := range nodeList.Items {
+			expectIPSetContains(f, n, extraCIDR, false)
+		}
+	})
+})
+
+// skipIfNoServiceCIDRAPI marks the spec as skipped on clusters where the
+// networking.k8s.io/v1 ServiceCIDR API is unavailable (K8s <1.31 or 1.31/1.32
+// with the MultiCIDRServiceAllocator feature gate disabled). The kube-ovn
+// fallback path is still exercised by every other test on those clusters.
+func skipIfNoServiceCIDRAPI(cs clientset.Interface) {
+	ginkgo.GinkgoHelper()
+
+	list, err := cs.Discovery().ServerResourcesForGroupVersion(networkingv1.SchemeGroupVersion.String())
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			ginkgo.Skip("networking.k8s.io/v1 ServiceCIDR API is not present in this cluster")
+		}
+		framework.ExpectNoError(err)
+	}
+	for _, r := range list.APIResources {
+		if r.Kind == "ServiceCIDR" {
+			return
+		}
+	}
+	ginkgo.Skip("networking.k8s.io/v1 ServiceCIDR API is not present in this cluster")
+}
+
+// expectIPSetContains polls the ovs-ovn pod on the given node and verifies
+// the membership of cidr in ovn40services. The 3-second daemon reconcile loop
+// means the assertion needs a generous window; 30s comfortably covers it.
+func expectIPSetContains(f *framework.Framework, node corev1.Node, cidr string, want bool) {
+	ginkgo.GinkgoHelper()
+
+	dsClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
+	ds := dsClient.Get(framework.DaemonSetOvsOvn)
+	pod, err := dsClient.GetPodOnNode(ds, node.Name)
+	framework.ExpectNoError(err)
+
+	cmd := "ipset list ovn40services | sed -n '/^Members:/,$p' | tail -n +2"
+	framework.WaitUntil(2*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+		out, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, cmd)
+		if err != nil {
+			return false, nil
+		}
+		members := strings.Fields(out)
+		has := slices.Contains(members, cidr)
+		return has == want, nil
+	}, fmt.Sprintf("ipset on node %s contains %s == %v", node.Name, cidr, want))
+}


### PR DESCRIPTION
## Summary

- Watch `networking.k8s.io/v1.ServiceCIDR` and merge with the existing `--service-cluster-ip-range` flag through a single `util.ServiceCIDRStore`. The flag is a startup fallback that yields once the API observes any valid entry and re-engages if the API set ever empties, so K8s <1.31 keeps today's behavior and 1.33+ converges to the API-advertised set with dynamic add/remove.
- Threads the merged slice through every Service CIDR consumer: U2O no-LB OVN policy routes (with stale-policy diff at reconcile entry), `vpc-lb` deployment init containers (now upserted with a `service-cidr-hash` annotation that rolls pods on change), `vpc-nat-gw` eth0 routes, and the daemon `services` ipset / iptables.
- Discovery uses `util.APIResourceExists` with a 10s ticker fallback (same scaffold as NAD/KubeVirt). RBAC for `networking.k8s.io/servicecidrs` get/list/watch is added to `system:ovn` and `system:kube-ovn-cni` in `install.sh` and both Helm charts.

Existing VPC NAT gateways are intentionally **not** re-enqueued — their service routes only refresh when the pod is recreated by other means. Newly created NAT gateways pick up the current store via their normal add path.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./pkg/...` and `go test ./test/unittest/...` — all pass
- [x] `pkg/util/servicecidr_store_test.go` covers: flag-only, flag yields to API, fallback re-engage on empty API, non-Ready entries do not shadow flag, dedup, hash stability, debounce coalescing
- [ ] Manual on K8s 1.30: log shows `ServiceCIDR API not found, will check periodically`; data plane behaves as before
- [ ] Manual on K8s 1.33: applying an extra `ServiceCIDR` adds new ranges to OVN policy route / `ovn40services` ipset / vpc-lb pod (rolled via Recreate); deleting the extra `ServiceCIDR` removes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)