### PR TITLE
refactor(security): pass argv to exec instead of shell concatenation

### DIFF
--- a/dist/images/vpcnatgateway/lb-svc.sh
+++ b/dist/images/vpcnatgateway/lb-svc.sh
@@ -80,24 +80,24 @@ function del_dnat() {
     done
 }
 
-rules=${@:2:${#}}
 opt=$1
+shift
 case $opt in
     init)
-        echo "init $rules"
-        init $rules
+        echo "init $*"
+        init "$@"
         ;;
     eip-add)
-        echo "eip-add $rules"
-        add_eip $rules
+        echo "eip-add $*"
+        add_eip "$@"
         ;;
     dnat-add)
-        echo "dnat-add $rules"
-        add_dnat $rules
+        echo "dnat-add $*"
+        add_dnat "$@"
         ;;
     dnat-del)
-        echo "dnat-del $rules"
-        del_dnat $rules
+        echo "dnat-del $*"
+        del_dnat "$@"
         ;;
     *)
         echo "Usage: $0 [init|eip-add|dnat-add] ..."

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -1535,84 +1535,87 @@ function eip_egress_qos_del() {
 }
 
 
-rules=${@:2:${#}}
 opt=$1
+shift
 case $opt in
     init)
         # get user interfaces if provided from input
-        interfaces="$rules"
-        init "$interfaces"
+        # Use "$*" so manual invocations like `init net1, net2` (with whitespace
+        # after the comma, as documented in show_help) get re-joined into a single
+        # comma-separated argument. Controller-driven calls always pass a single
+        # pre-joined arg, so behavior is unchanged for them.
+        init "$*"
         ;;
     subnet-route-add)
-        echo "subnet-route-add $rules"
-        add_vpc_internal_route $rules
+        echo "subnet-route-add $*"
+        add_vpc_internal_route "$@"
         ;;
     subnet-route-del)
-        echo "subnet-route-del $rules"
-        del_vpc_internal_route $rules
+        echo "subnet-route-del $*"
+        del_vpc_internal_route "$@"
         ;;
     eip-add)
-        echo "eip-add $rules"
-        add_eip $rules
+        echo "eip-add $*"
+        add_eip "$@"
         ;;
     eip-del)
-        echo "eip-del $rules"
-        del_eip $rules
+        echo "eip-del $*"
+        del_eip "$@"
         ;;
     dnat-add)
-        echo "dnat-add $rules"
-        add_dnat $rules
+        echo "dnat-add $*"
+        add_dnat "$@"
         ;;
     dnat-del)
-        echo "dnat-del $rules"
-        del_dnat $rules
+        echo "dnat-del $*"
+        del_dnat "$@"
         ;;
     snat-add)
-        echo "snat-add $rules"
-        add_snat $rules
+        echo "snat-add $*"
+        add_snat "$@"
         ;;
     snat-del)
-        echo "snat-del $rules"
-        del_snat $rules
+        echo "snat-del $*"
+        del_snat "$@"
         ;;
     floating-ip-add)
-        echo "floating-ip-add $rules"
-        add_floating_ip $rules
+        echo "floating-ip-add $*"
+        add_floating_ip "$@"
         ;;
     floating-ip-del)
-        echo "floating-ip-del $rules"
-        del_floating_ip $rules
+        echo "floating-ip-del $*"
+        del_floating_ip "$@"
         ;;
     get-iptables-version)
-        echo "get-iptables-version $rules"
-        get_iptables_version $rules
+        echo "get-iptables-version $*"
+        get_iptables_version "$@"
         ;;
     help|--help|-h)
         show_help
         ;;
     eip-ingress-qos-add)
-        echo "eip-ingress-qos-add $rules"
-        eip_ingress_qos_add $rules
+        echo "eip-ingress-qos-add $*"
+        eip_ingress_qos_add "$@"
         ;;
     eip-egress-qos-add)
-        echo "eip-egress-qos-add $rules"
-        eip_egress_qos_add $rules
+        echo "eip-egress-qos-add $*"
+        eip_egress_qos_add "$@"
         ;;
     eip-ingress-qos-del)
-        echo "eip-ingress-qos-del $rules"
-        eip_ingress_qos_del $rules
+        echo "eip-ingress-qos-del $*"
+        eip_ingress_qos_del "$@"
         ;;
     eip-egress-qos-del)
-        echo "eip-egress-qos-del $rules"
-        eip_egress_qos_del $rules
+        echo "eip-egress-qos-del $*"
+        eip_egress_qos_del "$@"
         ;;
     qos-add)
-        echo "qos-add $rules"
-        qos_add $rules
+        echo "qos-add $*"
+        qos_add "$@"
         ;;
     qos-del)
-        echo "qos-del $rules"
-        qos_del $rules
+        echo "qos-del $*"
+        qos_del "$@"
         ;;
     *)
         echo "Unknown command: $opt"

--- a/pkg/controller/service_lb.go
+++ b/pkg/controller/service_lb.go
@@ -276,9 +276,9 @@ func (c *Controller) deleteLbSvc(svc *corev1.Service) error {
 }
 
 func (c *Controller) execNatRules(pod *corev1.Pod, operation string, rules []string) error {
-	cmd := fmt.Sprintf("bash /kube-ovn/lb-svc.sh %s %s", operation, strings.Join(rules, " "))
-	klog.V(3).Info(cmd)
-	stdOutput, errOutput, err := util.ExecuteCommandInContainer(c.config.KubeClient, c.config.KubeRestConfig, pod.Namespace, pod.Name, "lb-svc", []string{"/bin/bash", "-c", cmd}...)
+	args := append([]string{"bash", "/kube-ovn/lb-svc.sh", operation}, rules...)
+	klog.V(3).Info(strings.Join(args, " "))
+	stdOutput, errOutput, err := util.ExecuteCommandInContainer(c.config.KubeClient, c.config.KubeRestConfig, pod.Namespace, pod.Name, "lb-svc", args...)
 	if err != nil {
 		if len(errOutput) > 0 {
 			klog.Errorf("failed to ExecuteCommandInContainer, errOutput: %v", errOutput)

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -797,16 +797,6 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 	return nil
 }
 
-// TODO: Refactor to avoid shell command injection vulnerability.
-// Current implementation uses "bash -c" with string concatenation, which could be exploited
-// if any element in the rules slice contains shell metacharacters.
-// Recommended fix: Pass arguments directly as a slice instead of joining them into a shell command:
-//
-//	args := append([]string{"/kube-ovn/nat-gateway.sh", operation}, rules...)
-//	util.ExecuteCommandInContainer(..., args...)
-//
-// This requires updating nat-gateway.sh to accept arguments via $@ instead of parsing a single string.
-// Current risk is mitigated by CIDR format validation on all data sources reaching this function.
 func (c *Controller) execNatGwRules(pod *corev1.Pod, operation string, rules []string) error {
 	lockKey := fmt.Sprintf("nat-gw-exec:%s/%s", pod.Namespace, pod.Name)
 
@@ -815,9 +805,9 @@ func (c *Controller) execNatGwRules(pod *corev1.Pod, operation string, rules []s
 		_ = c.vpcNatGwExecKeyMutex.UnlockKey(lockKey)
 	}()
 
-	cmd := fmt.Sprintf("bash /kube-ovn/nat-gateway.sh %s %s", operation, strings.Join(rules, " "))
-	klog.V(3).Infof("executing NAT gateway command: %s", cmd)
-	stdOutput, errOutput, err := util.ExecuteCommandInContainer(c.config.KubeClient, c.config.KubeRestConfig, pod.Namespace, pod.Name, "vpc-nat-gw", []string{"/bin/bash", "-c", cmd}...)
+	args := append([]string{"bash", "/kube-ovn/nat-gateway.sh", operation}, rules...)
+	klog.V(3).Infof("executing NAT gateway command: %s", strings.Join(args, " "))
+	stdOutput, errOutput, err := util.ExecuteCommandInContainer(c.config.KubeClient, c.config.KubeRestConfig, pod.Namespace, pod.Name, "vpc-nat-gw", args...)
 	if err != nil {
 		if len(errOutput) > 0 {
 			klog.Errorf("NAT gateway command failed - stderr: %v", errOutput)

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1356,10 +1356,26 @@ func configureNic(link, ip string, macAddr net.HardwareAddr, mtu int, detectIPv4
 	}
 
 	if setUfoOff {
-		cmd := fmt.Sprintf("if ethtool -k %s | grep -q ^udp-fragmentation-offload; then ethtool -K %s ufo off; fi", link, link)
-		if output, err := exec.Command("sh", "-xc", cmd).CombinedOutput(); err != nil {
-			klog.Error(err)
-			return fmt.Errorf("failed to disable udp-fragmentation-offload feature of device %s to off: %w, %s", link, err, output)
+		// Probe is best-effort: some kernels/devices reject `ethtool -k` (e.g. restricted netns,
+		// certain veth setups). Treat probe failure or absence of the udp-fragmentation-offload
+		// feature as "nothing to disable" and continue, matching the previous shell behavior.
+		probe, probeErr := exec.Command("ethtool", "-k", link).CombinedOutput() // #nosec G204
+		if probeErr != nil {
+			klog.Warningf("failed to query offload features of device %s, skip disabling ufo: %v, %s", link, probeErr, probe)
+		} else {
+			var hasUFO bool
+			for line := range strings.SplitSeq(string(probe), "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "udp-fragmentation-offload") {
+					hasUFO = true
+					break
+				}
+			}
+			if hasUFO {
+				if output, err := exec.Command("ethtool", "-K", link, "ufo", "off").CombinedOutput(); err != nil { // #nosec G204
+					klog.Error(err)
+					return fmt.Errorf("failed to disable udp-fragmentation-offload feature of device %s to off: %w, %s", link, err, output)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Replace three `bash -c` / `sh -xc` exec sites with direct argv invocations to eliminate shell parsing of constructed strings.
- Sites: `pkg/daemon/ovs_linux.go` (ethtool UFO probe + disable), `pkg/controller/vpc_nat_gateway.go` → `nat-gateway.sh`, `pkg/controller/service_lb.go` → `lb-svc.sh`. The TODO in `vpc_nat_gateway.go` has been resolved.
- Inspired by [flannel-io/flannel#2400](https://github.com/flannel-io/flannel/pull/2400). Defense-in-depth: every field reaching these calls is already validated (`net.ParseIP`, port `int`, protocol whitelist), so no exploitable path is closed today; the goal is to prevent regressions from future fields slipping through unvalidated.

## Behavior preservation

- `ovs_linux.go`: the original `if ethtool -k ...; then ethtool -K ufo off; fi` swallowed `ethtool -k` failures. The new code keeps that semantic by demoting probe failures to a warning and continuing, while leaving `ethtool -K ufo off` failures as a hard error.
- `nat-gateway.sh`: `init` dispatch uses `"$*"` so the documented `init net1, net2` (with whitespace) form continues to work; controller-driven calls always pass a single pre-joined arg either way.
- All other dispatch cases use `"$@"`, treating each rule as its own positional arg — equivalent to the prior unquoted-`$rules` word-splitting because each rule is whitespace-free.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go build ./pkg/daemon/... ./pkg/controller/...`
- [ ] CI: unit tests
- [ ] CI: e2e (kube-ovn-iptables-vpc-nat-gw + lb-svc paths exercise the touched scripts)
- [ ] Manual smoke on a node where `ethtool -k veth*` returns non-zero — confirm pod NIC setup still proceeds with a warning log

🤖 Generated with [Claude Code](https://claude.com/claude-code)