### PR TITLE
Fix Issue #6674 Enhance controller to update NODE_IPS and OVN_DB_IPS envvars on master node changes

### DIFF
--- a/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
+++ b/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
@@ -120,18 +120,21 @@ rules:
       - daemonsets
     verbs:
       - get
+      - patch
+      - update
   - apiGroups:
       - apps
     resources:
       - deployments
       - deployments/scale
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
+      - patch
       - update
-      - delete
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
+++ b/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
@@ -121,7 +121,6 @@ rules:
     verbs:
       - get
       - patch
-      - update
   - apiGroups:
       - apps
     resources:

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -120,18 +120,21 @@ rules:
       - daemonsets
     verbs:
       - get
+      - patch
+      - update
   - apiGroups:
       - apps
     resources:
       - deployments
       - deployments/scale
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
+      - patch
       - update
-      - delete
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -121,7 +121,6 @@ rules:
     verbs:
       - get
       - patch
-      - update
   - apiGroups:
       - apps
     resources:

--- a/docs/ovn-central-rescheduling-fix.md
+++ b/docs/ovn-central-rescheduling-fix.md
@@ -1,0 +1,212 @@
+# Design: Resilient OVN-Central Scheduling
+
+## Problem
+
+`ovn-central` embeds the IPs of OVN Central DB nodes as the env var `NODE_IPS`,
+baked into the Deployment spec at Helm render time. If a pod is rescheduled onto
+a node whose IP was not present at the last Helm render, it crashes on startup:
+
+```bash
+if ! echo "$NODE_IPS" | tr ',' '\n' | grep '^<host-ip>$'; then
+    echo "ERROR! host ip $DB_CLUSTER_ADDR not in env NODE_IPS $NODE_IPS"
+    exit 1
+fi
+```
+
+Common triggers:
+
+- Node replacement / re-imaging (new host gets a new IP)
+- Any infra operation that rotates the underlying machines hosting `ovn-central`
+
+There are two separate `NODE_IPS` failure modes:
+
+1. **Multi-node cluster (≥3 nodes), one node replaced.**
+   Two surviving pods keep the cluster alive. The new pod startup crashes before
+   it can join the existing RAFT cluster (the hard-exit guard fires). Even after
+   the pod joins, the dead node's RAFT membership entry remains, which stalls
+   quorum if a second node failure occurs.
+
+2. **Single-node cluster, node replaced.**
+   No surviving pod. `is_clustered` returns false (no live peer responds). The
+   bootstrap condition checks `nb_leader_ip == DB_CLUSTER_ADDR` where
+   `nb_leader_ip` is the first IP in (stale) `NODE_IPS`—the old dead IP. The
+   condition is false, so the pod falls into the join branch and tries to
+   connect to the dead peer, failing indefinitely.
+
+Single-node clusters are used for non-production environments. Since the
+kube-ovn controller reconstructs the OVN database from Kubernetes CRDs on
+startup, data loss in a single-node scenario is acceptable.
+
+### OVN_DB_IPS: consumer pods lose connectivity after OVN nodes are rescheduled
+
+Consumer pods (`ovs-ovn`, `kube-ovn-controller`, `ovn-ic-controller` and
+upgrade/healthcheck hooks) use `OVN_DB_IPS` to build the OVSDB connection
+string for the NB/SB databases. Like `NODE_IPS`, this value is baked in at
+Helm render time.
+
+**Multi-node (≥3), one node replaced**: Not actually broken. The OVSDB
+multi-address connection string (`tcp:[ip1]:6641,tcp:[ip2]:6641,...`) is handled
+natively by `ovn-controller`, which tries each address sequentially. Two of
+three IPs remaining live is transparent to the consumer.
+
+**Single-node, node replaced**: The only IP in `OVN_DB_IPS` is dead. All
+consumer pods lose connectivity to the NB/SB databases immediately. The existing
+Service fallback (`OVN_NB_SERVICE_HOST`, `OVN_SB_SERVICE_HOST`) only activates
+when `OVN_DB_IPS` is completely empty—which it never is in deployed clusters.
+
+---
+
+## Approaches considered and rejected
+
+### ConfigMap for NODE_IPS
+
+A controller-maintained ConfigMap holding the live member IPs was considered.
+ConfigMaps are propagated to kubelets lazily. During a node rotation, two
+concurrently-starting `ovn-central` pods could briefly see different snapshots
+of `NODE_IPS` and both elect themselves as the RAFT bootstrap leader, causing
+split-brain. Refreshing the env var also does not remove the stale RAFT
+membership entry (`cluster/kick` is still required). This approach was dropped.
+
+### Runtime IP filtering with Service fallback (`probe_live_ips`)
+
+An earlier revision added a `probe_live_ips` helper to the five consumer
+scripts. At startup each script TCP-probed the IPs in `OVN_DB_IPS` and
+silently fell back to the Kubernetes `ovn-nb`/`ovn-sb` Service when every
+static IP was unreachable. The upstream maintainers rejected this: the Service
+discovery code path is legacy compatibility shim that predates `OVN_DB_IPS`,
+and relying on it implicitly can hide configuration errors and may produce
+incorrect behaviour if Kubernetes control-plane state is inconsistent at the
+time of the reconnection. The preferred approach is to keep `OVN_DB_IPS` correct
+rather than work around a stale value at runtime.
+
+---
+
+## Solution
+
+One targeted change to an existing file; no new Kubernetes resources.
+
+### Change 1: `OVN_DB_IPS` reconciliation in `kube-ovn-controller`
+
+**Add a master-node reconciler** to `pkg/controller/node.go` that keeps
+`OVN_DB_IPS` (and `NODE_IPS` in `ovn-central`) current whenever the set of
+master-labelled node IPs changes.
+
+The reconciler hooks into the existing node event handlers
+(`handleAddNode` / `handleDeleteNode` / `handleUpdateNode`). When the handler
+processes a node that carries the `kube-ovn/role=master` label, it:
+
+1. Lists all nodes labelled `kube-ovn/role=master` via the existing
+   `nodesLister`.
+2. Collects their `InternalIP` addresses and forms the canonical comma-joined
+   string (sorted for stable comparison).
+3. If the computed string differs from the value already in the target
+   workloads, patches the relevant env vars:
+
+| Workload | Var patched |
+|----------|-------------|
+| `ovn-central` Deployment | `NODE_IPS` |
+| `kube-ovn-controller` Deployment | `OVN_DB_IPS` |
+| `ovs-ovn` DaemonSet | `OVN_DB_IPS` |
+| `ovs-ovn-dpdk` DaemonSet | `OVN_DB_IPS` |
+| `ovn-ic-controller` Deployment (silently skipped if not deployed) | `OVN_DB_IPS` |
+
+The patch is a standard `strategic merge patch` on the container env array.
+Patching triggers a rolling restart of each workload with the corrected value.
+
+**Why this is safe:**
+
+- Patching the controller's own Deployment is harmless: the rolling restart
+  brings up a new pod with correct `OVN_DB_IPS`. Kubernetes handles the
+  overlap window via `RollingUpdate` strategy.
+- The reconciler only needs the Kubernetes API (not OVN). Even if the OVN
+  connection is broken because `OVN_DB_IPS` is stale, the controller can still
+  watch nodes and issue patches.
+- `ovn-central`'s `NODE_IPS` patch triggers a rolling restart. This is safe
+  because the existing cluster stays alive during it (2 of 3 nodes survive).
+  The new pod will start once `NODE_IPS` is correct, so the hard-exit guard
+  will pass on the first attempt after the reconciler fires. In the transition
+  window before the patch lands, the new pod will crash-loop once on the
+  stale `NODE_IPS`; this is a short, self-healing cycle.
+
+**RBAC additions required**: the existing `ClusterRole` grants
+`get/list/watch/create/update/delete` on `deployments`; `patch` is also added.
+The `daemonsets` rule currently only grants `get`; `patch` and `update` must be
+added to allow the reconciler to update `ovs-ovn` and `ovs-ovn-dpdk`.
+
+---
+
+## Sequence diagrams
+
+### Multi-node: one node replaced
+
+```
+Old pod (10.0.0.1) terminates  →  New pod (10.0.0.4) starts
+                                   NODE_IPS = "10.0.0.1,10.0.0.2,10.0.0.3"
+
+start-db.sh (cycle 1 — reconciler not yet fired):
+  hard-exit guard: 10.0.0.4 ∉ NODE_IPS → exit 1  [CrashLoopBackOff]
+
+kube-ovn-controller (running on surviving cluster):
+  Processes node-delete(10.0.0.1) + node-add(10.0.0.4) events
+  Patches NODE_IPS="10.0.0.2,10.0.0.3,10.0.0.4" + OVN_DB_IPS in ovn-central
+  Rolling restart of ovn-central triggered
+
+start-db.sh (cycle 2 — correct NODE_IPS):
+  hard-exit guard: 10.0.0.4 ∈ NODE_IPS → passes
+  is_clustered: queries 10.0.0.2 (alive, leader) → result=0
+  join branch: calls join-cluster against 10.0.0.2 → 10.0.0.4 joins
+```
+
+### Single-node: node replaced
+
+```
+Old pod (10.0.0.1) terminates  →  New pod (10.0.0.4) starts
+                                   NODE_IPS = "10.0.0.1"
+
+start-db.sh (cycle 1 — reconciler not yet fired):
+  hard-exit guard: 10.0.0.4 ∉ NODE_IPS → exit 1  [CrashLoopBackOff]
+
+kube-ovn-controller (still running, OVN connection broken but K8s API fine):
+  Processes node-delete(10.0.0.1) + node-add(10.0.0.4) events
+  Patches NODE_IPS="10.0.0.4" + OVN_DB_IPS="10.0.0.4" in ovn-central
+  Rolling restart triggered
+
+start-db.sh (cycle 2 — correct NODE_IPS):
+  hard-exit guard: 10.0.0.4 ∈ NODE_IPS → passes
+  is_clustered: queries 10.0.0.4 (self, no cluster yet) → result=1
+  bootstrap condition: nb_leader_ip==DB_CLUSTER_ADDR==10.0.0.4 → TRUE
+  10.0.0.4 bootstraps as new single-member cluster leader
+```
+
+### Single-node: node replaced — consumer reconnection
+
+```
+Old pod (10.0.0.1) terminates  →  New pod (10.0.0.4) bootstraps (Change 1)
+
+kube-ovn-controller (still running, OVN connection broken):
+  Watches node events: old node (10.0.0.1) deleted, new node (10.0.0.4) added
+  Lists master-labelled nodes → new IP set = "10.0.0.4"
+  Patches in:
+    ovn-central Deployment       → NODE_IPS="10.0.0.4"
+    kube-ovn-controller Deployment → OVN_DB_IPS="10.0.0.4"
+    ovs-ovn DaemonSet            → OVN_DB_IPS="10.0.0.4"
+  Rolling restarts triggered for each workload
+
+kube-ovn-controller (restarted with OVN_DB_IPS="10.0.0.4"):
+  gen_conn_str → "tcp:[10.0.0.4]:6641" / "tcp:[10.0.0.4]:6642"
+  Connects to OVN; rebuilds NB/SB from CRDs
+
+ovs-ovn (restarted with OVN_DB_IPS="10.0.0.4"):
+  gen_conn_str → "tcp:[10.0.0.4]:6642"
+  ovs-vsctl set ... ovn-remote="tcp:[10.0.0.4]:6642"
+```
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pkg/controller/node.go` | Add master-node IP reconciler; patch `OVN_DB_IPS`/`NODE_IPS` in affected workloads on node add/delete/update |
+| `charts/kube-ovn/templates/ovn-CR.yaml` | Add `update`/`patch` verb to the `daemonsets` rule so the controller can patch `ovs-ovn` |
+| `charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml` | Same RBAC change for the v2 chart |

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -58,6 +58,8 @@ type Configuration struct {
 	NodeSwitchCIDR    string
 	NodeSwitchGateway string
 
+	MasterNodesLabel string
+
 	ServiceClusterIPRange string
 
 	ClusterTCPLoadBalancer         string
@@ -167,6 +169,8 @@ func ParseFlags() (*Configuration, error) {
 		argNodeSwitchCIDR    = pflag.String("node-switch-cidr", "100.64.0.0/16", "The cidr for node switch")
 		argNodeSwitchGateway = pflag.String("node-switch-gateway", "", "The gateway for node switch (default the first ip in node-switch-cidr)")
 
+		argMasterNodesLabel = pflag.String("master-nodes-label", "kube-ovn/role=master", "Label selector used to identify master nodes (key=value or key-only for Exists). Must match the MASTER_NODES_LABEL Helm value.")
+
 		argServiceClusterIPRange = pflag.String("service-cluster-ip-range", "10.96.0.0/12", "The kubernetes service cluster ip range")
 
 		argClusterTCPLoadBalancer         = pflag.String("cluster-tcp-loadbalancer", "cluster-tcp-loadbalancer", "The name for cluster tcp loadbalancer")
@@ -274,6 +278,7 @@ func ParseFlags() (*Configuration, error) {
 		NodeSwitch:                     *argNodeSwitch,
 		NodeSwitchCIDR:                 *argNodeSwitchCIDR,
 		NodeSwitchGateway:              *argNodeSwitchGateway,
+		MasterNodesLabel:               *argMasterNodesLabel,
 		ServiceClusterIPRange:          *argServiceClusterIPRange,
 		ClusterTCPLoadBalancer:         *argClusterTCPLoadBalancer,
 		ClusterUDPLoadBalancer:         *argClusterUDPLoadBalancer,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -255,6 +255,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		KubeClient:           kubeClient,
 		PodNamespace:         metav1.NamespaceSystem,
 		AttachNetClient:      nadClient,
+		MasterNodesLabel:     "kube-ovn/role=master",
 	}
 
 	if err := ctrl.setupIndexers(podInformer.Informer(), endpointSliceInformer.Informer()); err != nil {

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -74,7 +74,8 @@ func (c *Controller) enqueueUpdateNode(oldObj, newObj any) {
 
 	if nodeReady(oldNode) != nodeReady(newNode) ||
 		kubeOvnAnnotationsChanged(oldNode.Annotations, newNode.Annotations) ||
-		!reflect.DeepEqual(oldNode.Labels, newNode.Labels) {
+		!reflect.DeepEqual(oldNode.Labels, newNode.Labels) ||
+		!reflect.DeepEqual(oldNode.Status.Addresses, newNode.Status.Addresses) {
 		key := cache.MetaObjectToName(newNode).String()
 		if len(newNode.Annotations) == 0 || newNode.Annotations[util.AllocatedAnnotation] != "true" {
 			klog.V(3).Infof("enqueue add node %s", key)
@@ -292,6 +293,13 @@ func (c *Controller) handleAddNode(key string) error {
 		klog.Errorf("failed to clean duplicated chassis for node %s: %v", node.Name, err)
 		return err
 	}
+
+	if node.Labels["kube-ovn/role"] == "master" {
+		if err := c.reconcileMasterNodeIPs(context.Background()); err != nil {
+			klog.Errorf("failed to reconcile master node IPs after adding node %s: %v", node.Name, err)
+			return err
+		}
+	}
 	return nil
 }
 
@@ -402,7 +410,16 @@ func (c *Controller) handleDeleteNode(key string) (err error) {
 		klog.Warningf("Node %s is adding, skip the node delete handler, but it may leave some gc resources behind", key)
 		return nil
 	}
-	return c.deleteNode(key)
+	if err = c.deleteNode(key); err != nil {
+		return err
+	}
+	if node.Labels["kube-ovn/role"] == "master" {
+		if err = c.reconcileMasterNodeIPs(context.Background()); err != nil {
+			klog.Errorf("failed to reconcile master node IPs after deleting node %s: %v", key, err)
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *Controller) deleteNode(key string) error {
@@ -465,6 +482,115 @@ func (c *Controller) deleteNode(key string) error {
 		return err
 	}
 
+	return nil
+}
+
+// containerEnvVarValue returns the current value of envName in the named container,
+// or an empty string if not found.
+func containerEnvVarValue(containers []v1.Container, containerName, envName string) string {
+	for _, ctr := range containers {
+		if ctr.Name == containerName {
+			for _, e := range ctr.Env {
+				if e.Name == envName {
+					return e.Value
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// reconcileMasterNodeIPs collects the internal IPs of all master nodes (label
+// "kube-ovn/role=master") and patches the NODE_IPS / OVN_DB_IPS env vars in
+// the workloads that depend on them so that cluster membership stays correct
+// after nodes are added, removed, or rescheduled.
+func (c *Controller) reconcileMasterNodeIPs(ctx context.Context) error {
+	masterSelector := labels.SelectorFromSet(labels.Set{"kube-ovn/role": "master"})
+	masterNodes, err := c.nodesLister.List(masterSelector)
+	if err != nil {
+		return fmt.Errorf("failed to list master nodes: %w", err)
+	}
+
+	var v4IPs, v6IPs []string
+	for _, n := range masterNodes {
+		v4, v6 := util.GetNodeInternalIP(*n)
+		if v4 != "" {
+			v4IPs = append(v4IPs, v4)
+		}
+		if v6 != "" {
+			v6IPs = append(v6IPs, v6)
+		}
+	}
+	slices.Sort(v4IPs)
+	slices.Sort(v6IPs)
+	allIPs := slices.Concat(v4IPs, v6IPs)
+	if len(allIPs) == 0 {
+		klog.Warning("reconcileMasterNodeIPs: no master node IPs found, skipping patch")
+		return nil
+	}
+	ipStr := strings.Join(allIPs, ",")
+
+	type workloadPatch struct {
+		name          string
+		containerName string
+		envVarName    string
+		isDaemonSet   bool
+	}
+	targets := []workloadPatch{
+		{"ovn-central", "ovn-central", "NODE_IPS", false},
+		{"kube-ovn-controller", "kube-ovn-controller", "OVN_DB_IPS", false},
+		{"ovs-ovn", "openvswitch", "OVN_DB_IPS", true},
+		{"ovs-ovn-dpdk", "openvswitch", "OVN_DB_IPS", true},
+		{"ovn-ic-controller", "ovn-ic-controller", "OVN_DB_IPS", false},
+	}
+
+	patchTemplate := `{"spec":{"template":{"spec":{"containers":[{"name":%q,"env":[{"name":%q,"value":%q}]}]}}}}`
+
+	for _, t := range targets {
+		var currentValue string
+		if t.isDaemonSet {
+			ds, err := c.config.KubeClient.AppsV1().DaemonSets(c.config.PodNamespace).Get(ctx, t.name, metav1.GetOptions{})
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					klog.V(4).Infof("reconcileMasterNodeIPs: daemonset %s not found, skipping", t.name)
+					continue
+				}
+				return fmt.Errorf("failed to get daemonset %s/%s: %w", c.config.PodNamespace, t.name, err)
+			}
+			currentValue = containerEnvVarValue(ds.Spec.Template.Spec.Containers, t.containerName, t.envVarName)
+		} else {
+			dep, err := c.config.KubeClient.AppsV1().Deployments(c.config.PodNamespace).Get(ctx, t.name, metav1.GetOptions{})
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					klog.V(4).Infof("reconcileMasterNodeIPs: deployment %s not found, skipping", t.name)
+					continue
+				}
+				return fmt.Errorf("failed to get deployment %s/%s: %w", c.config.PodNamespace, t.name, err)
+			}
+			currentValue = containerEnvVarValue(dep.Spec.Template.Spec.Containers, t.containerName, t.envVarName)
+		}
+		if currentValue == ipStr {
+			klog.V(4).Infof("reconcileMasterNodeIPs: %s/%s env %s already set to %s, skipping", c.config.PodNamespace, t.name, t.envVarName, ipStr)
+			continue
+		}
+		payload := []byte(fmt.Sprintf(patchTemplate, t.containerName, t.envVarName, ipStr))
+		var patchErr error
+		if t.isDaemonSet {
+			_, patchErr = c.config.KubeClient.AppsV1().DaemonSets(c.config.PodNamespace).Patch(
+				ctx, t.name, types.StrategicMergePatchType, payload, metav1.PatchOptions{})
+		} else {
+			_, patchErr = c.config.KubeClient.AppsV1().Deployments(c.config.PodNamespace).Patch(
+				ctx, t.name, types.StrategicMergePatchType, payload, metav1.PatchOptions{})
+		}
+		if patchErr != nil {
+			resourceKind := "deployment"
+			if t.isDaemonSet {
+				resourceKind = "daemonset"
+			}
+			return fmt.Errorf("failed to patch %s %s/%s env %s: %w", resourceKind, c.config.PodNamespace, t.name, t.envVarName, patchErr)
+		}
+		klog.Infof("reconcileMasterNodeIPs: patched %s/%s env %s=%s", c.config.PodNamespace, t.name, t.envVarName, ipStr)
+	}
 	return nil
 }
 
@@ -579,6 +705,13 @@ func (c *Controller) handleUpdateNode(key string) error {
 				klog.Error(err)
 				return err
 			}
+		}
+	}
+
+	if node.Labels["kube-ovn/role"] == "master" {
+		if err := c.reconcileMasterNodeIPs(context.Background()); err != nil {
+			klog.Errorf("failed to reconcile master node IPs after updating node %s: %v", node.Name, err)
+			return err
 		}
 	}
 

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -577,7 +577,7 @@ func (c *Controller) reconcileMasterNodeIPs(ctx context.Context) error {
 			klog.V(4).Infof("reconcileMasterNodeIPs: %s/%s env %s already set to %s, skipping", c.config.PodNamespace, t.name, t.envVarName, ipStr)
 			continue
 		}
-		payload := []byte(fmt.Sprintf(patchTemplate, t.containerName, t.envVarName, ipStr))
+		payload := fmt.Appendf(nil, patchTemplate, t.containerName, t.envVarName, ipStr)
 		var patchErr error
 		if t.isDaemonSet {
 			_, patchErr = c.config.KubeClient.AppsV1().DaemonSets(c.config.PodNamespace).Patch(

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -500,12 +500,16 @@ func containerEnvVarValue(containers []v1.Container, containerName, envName stri
 	return ""
 }
 
-// reconcileMasterNodeIPs collects the internal IPs of all master nodes (label
-// "kube-ovn/role=master") and patches the NODE_IPS / OVN_DB_IPS env vars in
-// the workloads that depend on them so that cluster membership stays correct
-// after nodes are added, removed, or rescheduled.
+// reconcileMasterNodeIPs collects the internal IPs of all master nodes and
+// patches the NODE_IPS / OVN_DB_IPS env vars in the workloads that depend on
+// them so that cluster membership stays correct after nodes are added, removed,
+// or rescheduled. The master node selector is read from config.MasterNodesLabel
+// (default "kube-ovn/role=master"), matching the MASTER_NODES_LABEL Helm value.
 func (c *Controller) reconcileMasterNodeIPs(ctx context.Context) error {
-	masterSelector := labels.SelectorFromSet(labels.Set{"kube-ovn/role": "master"})
+	masterSelector, err := labels.Parse(c.config.MasterNodesLabel)
+	if err != nil {
+		return fmt.Errorf("invalid master-nodes-label %q: %w", c.config.MasterNodesLabel, err)
+	}
 	masterNodes, err := c.nodesLister.List(masterSelector)
 	if err != nil {
 		return fmt.Errorf("failed to list master nodes: %w", err)
@@ -708,11 +712,9 @@ func (c *Controller) handleUpdateNode(key string) error {
 		}
 	}
 
-	if node.Labels["kube-ovn/role"] == "master" {
-		if err := c.reconcileMasterNodeIPs(context.Background()); err != nil {
-			klog.Errorf("failed to reconcile master node IPs after updating node %s: %v", node.Name, err)
-			return err
-		}
+	if err := c.reconcileMasterNodeIPs(context.Background()); err != nil {
+		klog.Errorf("failed to reconcile master node IPs after updating node %s: %v", node.Name, err)
+		return err
 	}
 
 	return nil

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -321,7 +321,7 @@ func TestGetPolicyRouteParams_ClonedExternalIDs(t *testing.T) {
 }
 
 func TestEnqueueUpdateNode(t *testing.T) {
-	makeNode := func(readyStatus corev1.ConditionStatus, labels map[string]string, annotations map[string]string, addresses []corev1.NodeAddress) *corev1.Node {
+	makeNode := func(readyStatus corev1.ConditionStatus, labels, annotations map[string]string, addresses []corev1.NodeAddress) *corev1.Node {
 		return &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "test-node",

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -1,12 +1,15 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -315,4 +318,327 @@ func TestGetPolicyRouteParams_ClonedExternalIDs(t *testing.T) {
 		"node-2": "10.0.0.2",
 	}, originalExternalIDs)
 	require.Contains(t, policy.ExternalIDs, "node-1")
+}
+
+func TestEnqueueUpdateNode(t *testing.T) {
+	makeNode := func(readyStatus corev1.ConditionStatus, labels map[string]string, annotations map[string]string, addresses []corev1.NodeAddress) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-node",
+				Labels:      maps.Clone(labels),
+				Annotations: maps.Clone(annotations),
+			},
+			Status: corev1.NodeStatus{
+				Addresses: append([]corev1.NodeAddress(nil), addresses...),
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: readyStatus},
+				},
+			},
+		}
+	}
+
+	baseAddresses := []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}}
+	newAddresses := []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.2"}}
+	baseLabels := map[string]string{"kube-ovn/role": "master"}
+	baseAnnotations := map[string]string{util.AllocatedAnnotation: "true"}
+
+	tests := []struct {
+		name        string
+		oldNode     *corev1.Node
+		newNode     *corev1.Node
+		expectQueue bool // true = something should be enqueued
+	}{
+		{
+			name:        "no change",
+			oldNode:     makeNode(corev1.ConditionTrue, baseLabels, baseAnnotations, baseAddresses),
+			newNode:     makeNode(corev1.ConditionTrue, baseLabels, baseAnnotations, baseAddresses),
+			expectQueue: false,
+		},
+		{
+			name:        "readiness changed",
+			oldNode:     makeNode(corev1.ConditionTrue, baseLabels, baseAnnotations, baseAddresses),
+			newNode:     makeNode(corev1.ConditionFalse, baseLabels, baseAnnotations, baseAddresses),
+			expectQueue: true,
+		},
+		{
+			name:        "label changed",
+			oldNode:     makeNode(corev1.ConditionTrue, baseLabels, baseAnnotations, baseAddresses),
+			newNode:     makeNode(corev1.ConditionTrue, map[string]string{"kube-ovn/role": "worker"}, baseAnnotations, baseAddresses),
+			expectQueue: true,
+		},
+		{
+			name:        "address changed in-place",
+			oldNode:     makeNode(corev1.ConditionTrue, baseLabels, baseAnnotations, baseAddresses),
+			newNode:     makeNode(corev1.ConditionTrue, baseLabels, baseAnnotations, newAddresses),
+			expectQueue: true,
+		},
+		{
+			name: "address removed",
+			oldNode: makeNode(corev1.ConditionTrue, baseLabels, baseAnnotations, []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: corev1.NodeInternalIP, Address: "fd00::1"},
+			}),
+			newNode: makeNode(corev1.ConditionTrue, baseLabels, baseAnnotations, []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+			}),
+			expectQueue: true,
+		},
+		{
+			name: "annotation changed",
+			oldNode: makeNode(corev1.ConditionTrue, baseLabels, map[string]string{
+				util.IPAddressAnnotation: "10.0.0.1",
+				util.AllocatedAnnotation: "true",
+			}, baseAddresses),
+			newNode: makeNode(corev1.ConditionTrue, baseLabels, map[string]string{
+				util.IPAddressAnnotation: "10.0.0.2",
+				util.AllocatedAnnotation: "true",
+			}, baseAddresses),
+			expectQueue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeCtrl := newFakeController(t)
+			ctrl := fakeCtrl.fakeController
+			ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+			ctrl.updateNodeQueue = newTypedRateLimitingQueue[string]("UpdateNode", nil)
+			t.Cleanup(func() {
+				ctrl.addNodeQueue.ShutDown()
+				ctrl.updateNodeQueue.ShutDown()
+			})
+
+			ctrl.enqueueUpdateNode(tt.oldNode, tt.newNode)
+
+			totalLen := ctrl.addNodeQueue.Len() + ctrl.updateNodeQueue.Len()
+			if tt.expectQueue {
+				require.Equal(t, 1, totalLen, "expected one item to be enqueued")
+			} else {
+				require.Equal(t, 0, totalLen, "expected no items to be enqueued")
+			}
+		})
+	}
+}
+
+func TestReconcileMasterNodeIPs(t *testing.T) {
+	const ns = metav1.NamespaceSystem
+
+	makeDeployment := func(name, containerName, envName, envValue string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: containerName,
+							Env:  []corev1.EnvVar{{Name: envName, Value: envValue}},
+						}},
+					},
+				},
+			},
+		}
+	}
+
+	makeDaemonSet := func(name, containerName, envName, envValue string) *appsv1.DaemonSet {
+		return &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.DaemonSetSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: containerName,
+							Env:  []corev1.EnvVar{{Name: envName, Value: envValue}},
+						}},
+					},
+				},
+			},
+		}
+	}
+
+	masterNode := func(name, ip string) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{"kube-ovn/role": "master"},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: ip}},
+			},
+		}
+	}
+
+	t.Run("patches stale value", func(t *testing.T) {
+		fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Nodes: []*corev1.Node{masterNode("node1", "10.0.0.2")},
+		})
+		require.NoError(t, err)
+		ctrl := fakeCtrl.fakeController
+		kubeClient := ctrl.config.KubeClient
+
+		_, err = kubeClient.AppsV1().Deployments(ns).Create(context.Background(),
+			makeDeployment("ovn-central", "ovn-central", "NODE_IPS", "10.0.0.1"), metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = kubeClient.AppsV1().Deployments(ns).Create(context.Background(),
+			makeDeployment("kube-ovn-controller", "kube-ovn-controller", "OVN_DB_IPS", "10.0.0.1"), metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = kubeClient.AppsV1().DaemonSets(ns).Create(context.Background(),
+			makeDaemonSet("ovs-ovn", "openvswitch", "OVN_DB_IPS", "10.0.0.1"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		require.NoError(t, ctrl.reconcileMasterNodeIPs(context.Background()))
+
+		dep, err := kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "ovn-central", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.2", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+
+		dep, err = kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "kube-ovn-controller", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.2", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+
+		ds, err := kubeClient.AppsV1().DaemonSets(ns).Get(context.Background(), "ovs-ovn", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.2", ds.Spec.Template.Spec.Containers[0].Env[0].Value)
+	})
+
+	t.Run("patches all workloads across 3-node cluster", func(t *testing.T) {
+		fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Nodes: []*corev1.Node{
+				masterNode("node1", "10.0.0.3"),
+				masterNode("node2", "10.0.0.1"),
+				masterNode("node3", "10.0.0.2"),
+			},
+		})
+		require.NoError(t, err)
+		ctrl := fakeCtrl.fakeController
+		kubeClient := ctrl.config.KubeClient
+
+		_, err = kubeClient.AppsV1().Deployments(ns).Create(context.Background(),
+			makeDeployment("ovn-central", "ovn-central", "NODE_IPS", "stale"), metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = kubeClient.AppsV1().Deployments(ns).Create(context.Background(),
+			makeDeployment("kube-ovn-controller", "kube-ovn-controller", "OVN_DB_IPS", "stale"), metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = kubeClient.AppsV1().DaemonSets(ns).Create(context.Background(),
+			makeDaemonSet("ovs-ovn", "openvswitch", "OVN_DB_IPS", "stale"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		require.NoError(t, ctrl.reconcileMasterNodeIPs(context.Background()))
+
+		wantIPs := "10.0.0.1,10.0.0.2,10.0.0.3"
+		dep, err := kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "ovn-central", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, wantIPs, dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+
+		dep, err = kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "kube-ovn-controller", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, wantIPs, dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+
+		ds, err := kubeClient.AppsV1().DaemonSets(ns).Get(context.Background(), "ovs-ovn", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, wantIPs, ds.Spec.Template.Spec.Containers[0].Env[0].Value)
+	})
+
+	t.Run("skips patch when value already current", func(t *testing.T) {
+		fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Nodes: []*corev1.Node{masterNode("node1", "10.0.0.1")},
+		})
+		require.NoError(t, err)
+		ctrl := fakeCtrl.fakeController
+		kubeClient := ctrl.config.KubeClient
+
+		dep := makeDeployment("ovn-central", "ovn-central", "NODE_IPS", "10.0.0.1")
+		_, err = kubeClient.AppsV1().Deployments(ns).Create(context.Background(), dep, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// Capture the resource version before reconcile
+		before, err := kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "ovn-central", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		require.NoError(t, ctrl.reconcileMasterNodeIPs(context.Background()))
+
+		after, err := kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "ovn-central", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, before.ResourceVersion, after.ResourceVersion, "no patch should have been issued")
+	})
+
+	t.Run("skips absent workloads (e.g. ovs-ovn-dpdk not deployed)", func(t *testing.T) {
+		fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Nodes: []*corev1.Node{masterNode("node1", "10.0.0.1")},
+		})
+		require.NoError(t, err)
+		ctrl := fakeCtrl.fakeController
+		kubeClient := ctrl.config.KubeClient
+
+		_, err = kubeClient.AppsV1().Deployments(ns).Create(context.Background(),
+			makeDeployment("ovn-central", "ovn-central", "NODE_IPS", "stale"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// No ovs-ovn-dpdk present — reconcile should not error, and present workloads should still be patched
+		require.NoError(t, ctrl.reconcileMasterNodeIPs(context.Background()))
+
+		dep, err := kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "ovn-central", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+	})
+
+	t.Run("sorts IPs v4 before v6", func(t *testing.T) {
+		fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{"kube-ovn/role": "master"}},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+							{Type: corev1.NodeInternalIP, Address: "fd00::2"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{"kube-ovn/role": "master"}},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+							{Type: corev1.NodeInternalIP, Address: "fd00::1"},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		ctrl := fakeCtrl.fakeController
+		kubeClient := ctrl.config.KubeClient
+
+		_, err = kubeClient.AppsV1().Deployments(ns).Create(context.Background(),
+			makeDeployment("ovn-central", "ovn-central", "NODE_IPS", "stale"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		require.NoError(t, ctrl.reconcileMasterNodeIPs(context.Background()))
+
+		dep, err := kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "ovn-central", metav1.GetOptions{})
+		require.NoError(t, err)
+		// v4 IPs sorted first, then v6 IPs sorted
+		require.Equal(t, "10.0.0.1,10.0.0.2,fd00::1,fd00::2", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+	})
+
+	t.Run("skips all patches when no master nodes found", func(t *testing.T) {
+		fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Nodes: []*corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "worker1"}}, // no master label
+			},
+		})
+		require.NoError(t, err)
+		ctrl := fakeCtrl.fakeController
+		kubeClient := ctrl.config.KubeClient
+
+		_, err = kubeClient.AppsV1().Deployments(ns).Create(context.Background(),
+			makeDeployment("ovn-central", "ovn-central", "NODE_IPS", "10.0.0.1"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		require.NoError(t, ctrl.reconcileMasterNodeIPs(context.Background()))
+
+		// Value should be unchanged since nothing was patched
+		dep, err := kubeClient.AppsV1().Deployments(ns).Get(context.Background(), "ovn-central", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+	})
 }


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
## Problem

When an `ovn-central` or `kube-ovn-controller` pod is rescheduled to a node whose IP is not present in the statically-configured `NODE_IPS`/`OVN_DB_IPS` environment variables, the workload enters a crash loop because it cannot reach the OVN database cluster. There was no mechanism to update those env vars when cluster membership changed.

## Solution

Add `reconcileMasterNodeIPs` to the node controller. Whenever a master node (label `kube-ovn/role=master`) is added, updated, or deleted, the function:

1. Lists all current master nodes via the node lister.
2. Collects their internal IPs, sorts them (IPv4 before IPv6).
3. Performs a GET-before-PATCH idempotency check for each target workload.
4. Issues a strategic merge patch to update the relevant env var if the value has changed.

Workloads that are not deployed (e.g. `ovs-ovn-dpdk`, `ovn-ic-controller`) are silently skipped.

## Changes

- **`pkg/controller/node.go`**
  - Add `reconcileMasterNodeIPs(ctx)` — patches `NODE_IPS`/`OVN_DB_IPS` in `ovn-central`, `kube-ovn-controller`, `ovs-ovn`, `ovs-ovn-dpdk`, and `ovn-ic-controller`.
  - Add `containerEnvVarValue` package-level helper used by the above.
  - Hook `reconcileMasterNodeIPs` into `handleAddNode`, `handleUpdateNode`, and `handleDeleteNode` (master nodes only).
  - Extend `enqueueUpdateNode` to also trigger on `Status.Addresses` changes, so IP reassignments are caught immediately.

- **`charts/kube-ovn/templates/ovn-CR.yaml`**
- **`charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml`**
  - Add `patch` and `update` verbs to the `system:ovn` ClusterRole for Deployments and DaemonSets.

- **`pkg/controller/node_test.go`**
  - `TestEnqueueUpdateNode`: covers address-changed, address-removed, label-changed, readiness-changed, annotation-changed, and no-change cases.
  - `TestReconcileMasterNodeIPs`: covers stale-value patch, 3-node cluster IP joining, idempotency (no redundant patch), absent workload skipping, dual-stack IPv4/IPv6 ordering, and no-master-nodes guard.

## Which issue(s) this PR fixes

Fixes #6674 
