### PR TITLE
fix(image): rebase OVN patches for branch-25.03 ARP/ND localnet rename (backport #6707)

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -52,6 +52,7 @@ jobs:
           cat > "$tmp_dir/on_changes.txt" <<EOF
           dist/images/Dockerfile.base
           dist/images/OpenBFDD-compile.patch
+          dist/images/patches/
           dist/images/go-deps/download-go-deps.sh
           dist/images/go-deps/rebuild-go-deps.sh
           EOF
@@ -115,9 +116,15 @@ jobs:
           if [ ${{ github.event_name }} != 'pull_request' ]; then
             exit
           fi
-          if ! git diff --exit-code HEAD^...HEAD -- dist/images/Dockerfile.base-dpdk; then
+          tmp_dir=`mktemp -d`
+          cat > "$tmp_dir/on_changes.txt" <<EOF
+          dist/images/Dockerfile.base-dpdk
+          dist/images/patches/
+          EOF
+          if git diff --name-only HEAD^ HEAD | grep -Ff "$tmp_dir/on_changes.txt"; then
             echo build-dpdk-base=1 >> "$GITHUB_OUTPUT"
           fi
+          rm -frv "$tmp_dir"
 
       - uses: jlumbroso/free-disk-space@v1.3.1
         if: steps.check.outputs.build-dpdk-base == 1

--- a/dist/images/patches/a297b840c2c9f118c7ce6133077087b5999f12dd.patch
+++ b/dist/images/patches/a297b840c2c9f118c7ce6133077087b5999f12dd.patch
@@ -6,15 +6,11 @@ Subject: [PATCH] direct output to lsp for dnat packets in logical switch
 
 Signed-off-by: zhangzujian <zhangzujian.7@gmail.com>
 ---
- northd/en-global-config.c |  5 ++++
- northd/northd.c           | 58 ++++++++++++++++++++++++++++++++++++++-
- 2 files changed, 62 insertions(+), 1 deletion(-)
-
 diff --git a/northd/en-global-config.c b/northd/en-global-config.c
-index 6503239ed6..26d89b6676 100644
+index 6c944af..65c060c 100644
 --- a/northd/en-global-config.c
 +++ b/northd/en-global-config.c
-@@ -659,6 +659,11 @@ check_nb_options_out_of_sync(
+@@ -664,6 +664,11 @@ check_nb_options_out_of_sync(
          return true;
      }
  
@@ -27,10 +23,10 @@ index 6503239ed6..26d89b6676 100644
  }
  
 diff --git a/northd/northd.c b/northd/northd.c
-index 4a7fdf80b9..10f74f99b8 100644
+index e8390e5..987753b 100644
 --- a/northd/northd.c
 +++ b/northd/northd.c
-@@ -105,6 +105,8 @@ static struct sset node_local_dns_ip_v6 = SSET_INITIALIZER(&node_local_dns_ip_v6
+@@ -111,6 +111,8 @@ static struct sset node_local_dns_ip_v6 = SSET_INITIALIZER(&node_local_dns_ip_v6
  
  static bool ls_ct_skip_dst_lport_ips = false;
  
@@ -39,7 +35,7 @@ index 4a7fdf80b9..10f74f99b8 100644
  #define MAX_OVN_TAGS 4096
  
  
-@@ -8365,7 +8367,58 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
+@@ -8463,7 +8465,58 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
  }
  
  static void
@@ -99,15 +95,15 @@ index 4a7fdf80b9..10f74f99b8 100644
                 struct lflow_ref *lflow_ref)
  {
      struct ds actions = DS_EMPTY_INITIALIZER;
-@@ -17783,6 +17836,7 @@ build_lswitch_and_lrouter_iterate_by_lsp(struct ovn_port *op,
-     build_lswitch_arp_nd_responder_skip_local(op, lflows, match);
+@@ -18294,6 +18347,7 @@ build_lswitch_and_lrouter_iterate_by_lsp(struct ovn_port *op,
+     build_lswitch_from_localnet_op(op, lflows, match);
      build_lswitch_arp_nd_responder_known_ips(op, lflows, ls_ports,
                                               meter_groups, actions, match);
 +    build_lswitch_dnat_mod_dl_dst_rules(op, lflows, lr_ports, actions, match);
      build_lswitch_arp_nd_forward_for_unknown_ips(op, lflows, actions, match);
      build_lswitch_dhcp_options_and_response(op, lflows, meter_groups);
      build_lswitch_external_port(op, lflows);
-@@ -19271,6 +19325,8 @@ ovnnb_db_run(struct northd_input *input_data,
+@@ -19797,6 +19851,8 @@ ovnnb_db_run(struct northd_input *input_data,
      ls_ct_skip_dst_lport_ips = smap_get_bool(input_data->nb_options,
                                               "ls_ct_skip_dst_lport_ips",
                                               false);

--- a/dist/images/patches/e889d46924085ca0fe38a2847da973dfe6ea100e.patch
+++ b/dist/images/patches/e889d46924085ca0fe38a2847da973dfe6ea100e.patch
@@ -1,5 +1,5 @@
 diff --git a/northd/en-global-config.c b/northd/en-global-config.c
-index 86274d896..34fd6818d 100644
+index 86274d8..34fd681 100644
 --- a/northd/en-global-config.c
 +++ b/northd/en-global-config.c
 @@ -649,6 +649,11 @@ check_nb_options_out_of_sync(
@@ -15,7 +15,7 @@ index 86274d896..34fd6818d 100644
  }
  
 diff --git a/northd/northd.c b/northd/northd.c
-index 90514df8e..6263249fd 100644
+index f0ff711..17c36d4 100644
 --- a/northd/northd.c
 +++ b/northd/northd.c
 @@ -104,6 +104,9 @@ static bool vxlan_mode;
@@ -28,7 +28,7 @@ index 90514df8e..6263249fd 100644
  #define MAX_OVN_TAGS 4096
  
  
-@@ -9431,6 +9434,11 @@ build_lswitch_lflows_l2_unknown(struct ovn_datapath *od,
+@@ -9435,6 +9438,11 @@ build_lswitch_lflows_l2_unknown(struct ovn_datapath *od,
                        "outport == \"none\"",
                        "outport = \""MC_UNKNOWN "\"; output;",
                        lflow_ref);
@@ -40,7 +40,7 @@ index 90514df8e..6263249fd 100644
      } else {
          ovn_lflow_add_drop_with_desc(
              lflows, od, S_SWITCH_IN_L2_UNKNOWN, 50, "outport == \"none\"",
-@@ -9905,6 +9913,49 @@ build_lswitch_arp_nd_responder_default(struct ovn_datapath *od,
+@@ -9934,6 +9942,49 @@ build_lswitch_arp_nd_responder_default(struct ovn_datapath *od,
                    lflow_ref);
  }
  
@@ -90,15 +90,15 @@ index 90514df8e..6263249fd 100644
  /* Ingress table 19: ARP/ND responder for service monitor source ip.
   * (priority 110)*/
  static void
-@@ -18034,6 +18085,7 @@ build_lswitch_and_lrouter_iterate_by_lsp(struct ovn_port *op,
-     build_lswitch_arp_nd_responder_skip_local(op, lflows, match);
+@@ -18120,6 +18171,7 @@ build_lswitch_and_lrouter_iterate_by_lsp(struct ovn_port *op,
+     build_lswitch_from_localnet_op(op, lflows, match);
      build_lswitch_arp_nd_responder_known_ips(op, lflows, ls_ports,
                                               meter_groups, actions, match);
 +    build_lswitch_arp_nd_forward_for_unknown_ips(op, lflows, actions, match);
      build_lswitch_dhcp_options_and_response(op, lflows, meter_groups);
      build_lswitch_external_port(op, lflows);
      build_lswitch_icmp_packet_toobig_admin_flows(op, lflows, match, actions);
-@@ -19485,6 +19537,8 @@ ovnnb_db_run(struct northd_input *input_data,
+@@ -19571,6 +19623,8 @@ ovnnb_db_run(struct northd_input *input_data,
                                       "use_ct_inv_match", true);
      acl_ct_translation = smap_get_bool(input_data->nb_options,
                                         "acl_ct_translation", false);


### PR DESCRIPTION
## Summary

Backport of #6707 to `release-1.15` to unblock the `Build kube-ovn-base` job.

Upstream OVN `branch-25.03` commit `95286d6` ("northd: Enable ARP/ND responder for localnet-sourced requests") renamed `build_lswitch_arp_nd_responder_skip_local()` to `build_lswitch_from_localnet_op()` in `northd/northd.c` around line 18034. Two of our patches use the old function name as hunk context, so every base-image build on `release-1.15` since 2026-05-06 fails with:

```
error: patch failed: northd/northd.c:18034
error: northd/northd.c: patch does not apply
```

(Example failure on this branch: run [25537363583](https://github.com/kubeovn/kube-ovn/actions/runs/25537363583).)

This cherry-picks the master fix (`ec8b28019`):

- Realign hunks in `dist/images/patches/e889d46924...patch` and `dist/images/patches/a297b840c2...patch` to use `build_lswitch_from_localnet_op` and the new line numbers.
- Add `dist/images/patches/` to the `on_changes` path filter in `.github/workflows/build-x86-image.yaml` (both kube-ovn-base and dpdk-base) so future patch updates actually trigger a base rebuild.

Cherry-pick was clean (no manual conflict resolution).

## Test plan

- [ ] CI `Build kube-ovn-base` succeeds on this PR
- [ ] CI `Build kube-ovn-base-dpdk` succeeds on this PR
- [ ] Verified locally that all 17 OVN patches apply cleanly against `git clone -b branch-25.03 --depth=1 https://github.com/ovn-org/ovn.git`

🤖 Generated with [Claude Code](https://claude.com/claude-code)