### PR TITLE
speaker: cache startup-selected bgp source addresses

### DIFF
--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -675,6 +675,7 @@ bgpSpeaker:
   #  - --neighbor-address=10.32.32.1
   #  - --neighbor-as=65030
   #  - --cluster-as=65000
+  #  - --allowed-source-addresses=10.32.32.2,10.32.32.3,10.32.32.4,10.32.32.5
 
 # -- Configuration for kube-ovn-pinger, the agent monitoring and returning metrics for OVS/external connectivity.
 # @section -- Ping daemon configuration

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -198,11 +198,17 @@ func (c *Controller) getPathRequest(route string) ([][]*apiutil.Path, error) {
 	return paths, nil
 }
 
-// getNextHopAttribute returns the next hop we should advertise for a specific BGP neighbor
+// getNextHopAttribute returns the next hop we should advertise for a specific BGP neighbor.
+// When source address whitelisting is enabled, the startup-selected local address is reused.
+// Otherwise, keep the historical behavior and resolve the source address dynamically.
 func (c *Controller) getNextHopAttribute(neighborAddress net.IP) net.IP {
+	if localAddr := c.config.getNeighborLocalAddress(neighborAddress); localAddr != nil {
+		return localAddr
+	}
+
 	nextHop := c.config.RouterID // If no route is found, fallback to router ID
 
-	// Retrieve the route we use to speak to this neighbor and consider the source as next hop
+	// Retrieve the route we use to speak to this neighbor and consider the source as next hop.
 	routes, err := netlink.RouteGet(neighborAddress)
 	if err == nil && len(routes) == 1 && routes[0].Src != nil {
 		nextHop = routes[0].Src
@@ -210,9 +216,7 @@ func (c *Controller) getNextHopAttribute(neighborAddress net.IP) net.IP {
 
 	proto := util.CheckProtocol(nextHop.String()) // Is next hop IPv4 or IPv6
 
-	// This takes care of a special case where the speaker might not be running in host mode
-	// If this happens, the nextHopIP will be the IP of a Pod (probably unreachable for the neighbors)
-	// For this case, the configuration allows for manually specifying the IPs to use as next hop (per protocol)
+	// Preserve the historical fallback for non-whitelist mode.
 	nodeIP := c.config.NodeIPs[proto]
 	if nodeIP != nil && nextHop.Equal(c.config.PodIPs[proto]) {
 		nextHop = nodeIP

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -501,10 +501,6 @@ func (config *Configuration) initNeighborLocalAddresses() error {
 		}
 	}
 
-	for neighbor, localAddr := range config.NeighborLocalAddresses {
-		klog.Infof("Using BGP local address %s for neighbor %s", localAddr, neighbor)
-	}
-
 	return nil
 }
 
@@ -512,41 +508,82 @@ func (config *Configuration) getNeighborLocalAddress(neighborAddress net.IP) net
 	if localAddr := config.NeighborLocalAddresses[neighborAddress.String()]; localAddr != nil {
 		return localAddr
 	}
+
+	neighborIsIPv4 := neighborAddress.To4() != nil
+	if neighborIsIPv4 && len(config.AllowedSourceAddresses) > 0 {
+		panic(fmt.Sprintf("invariant violated: failed to determine local address for BGP neighbor %s: no allowed source address matched the whitelist", neighborAddress))
+	}
+	if !neighborIsIPv4 && len(config.AllowedSourceIPv6Addresses) > 0 {
+		panic(fmt.Sprintf("invariant violated: failed to determine local address for BGP neighbor %s: no allowed IPv6 source address matched the whitelist", neighborAddress))
+	}
+
 	return nil
 }
 
 func (config *Configuration) resolveWhitelistedNeighborLocalAddress(neighborAddress net.IP, allowedLocalAddresses []net.IP) (net.IP, error) {
-	var localAddr net.IP
 	routes, err := netlink.RouteGet(neighborAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine local address for BGP neighbor %s from route lookup: %w", neighborAddress, err)
 	}
+	localAddr, err := selectNeighborLocalAddressFromRoutes(neighborAddress, routes, allowedLocalAddresses)
+	if err != nil {
+		return nil, err
+	}
+	klog.Infof("Route lookup selected BGP local address %s for neighbor %s from whitelist %v", localAddr, neighborAddress, allowedLocalAddresses)
+	return localAddr, nil
+}
+
+func selectNeighborLocalAddressFromRoutes(neighborAddress net.IP, routes []netlink.Route, allowedLocalAddresses []net.IP) (net.IP, error) {
+	// Track the most useful failure reason across all route candidates so callers get
+	// a deterministic error when no source address satisfies the whitelist.
+	var (
+		sawSource         bool
+		firstFamilyErr    error
+		firstWhitelistErr error
+	)
+
 	// RouteGet reflects the kernel's effective route decision for this neighbor.
-	// We only need the first non-nil source address from the returned routes.
+	// Prefer the first source address that matches both the neighbor family and the whitelist.
 	for _, route := range routes {
-		if route.Src != nil {
-			localAddr = route.Src
-			break
+		if route.Src == nil {
+			continue
 		}
+		sawSource = true
+		if err := validateLocalAddressFamily(neighborAddress, route.Src); err != nil {
+			if firstFamilyErr == nil {
+				firstFamilyErr = err
+			}
+			klog.V(4).Infof("Skipping candidate BGP local address %s for neighbor %s: %v", route.Src, neighborAddress, err)
+			continue
+		}
+		if err := validateAllowedLocalAddress(neighborAddress, route.Src, allowedLocalAddresses); err != nil {
+			if firstWhitelistErr == nil {
+				firstWhitelistErr = err
+			}
+			klog.V(4).Infof("Skipping candidate BGP local address %s for neighbor %s: %v", route.Src, neighborAddress, err)
+			continue
+		}
+		return route.Src, nil
 	}
 
-	if localAddr == nil {
+	if !sawSource {
 		return nil, fmt.Errorf("failed to determine local address for BGP neighbor %s: route lookup returned no source address", neighborAddress)
 	}
-	klog.Infof("Route lookup selected BGP local address %s for neighbor %s", localAddr, neighborAddress)
-	if err := validateLocalAddressFamily(neighborAddress, localAddr); err != nil {
-		return nil, err
+	if firstWhitelistErr != nil {
+		return nil, firstWhitelistErr
 	}
-	if err := validateAllowedLocalAddress(neighborAddress, localAddr, allowedLocalAddresses); err != nil {
-		return nil, err
+	if firstFamilyErr != nil {
+		if len(allowedLocalAddresses) > 0 {
+			return nil, fmt.Errorf("no route source matched the required address family for whitelist evaluation; first family error: %w", firstFamilyErr)
+		}
+		return nil, firstFamilyErr
 	}
-	klog.Infof("Selected BGP local address %s for neighbor %s is allowed by whitelist %v", localAddr, neighborAddress, allowedLocalAddresses)
-	return localAddr, nil
+	return nil, fmt.Errorf("failed to determine local address for BGP neighbor %s: route lookup returned no valid source address", neighborAddress)
 }
 
 func validateLocalAddressFamily(neighborAddress, localAddr net.IP) error {
 	if neighborAddress == nil {
-		return fmt.Errorf("invalid nil BGP neighbor address")
+		return errors.New("invalid nil BGP neighbor address")
 	}
 	if localAddr == nil {
 		return fmt.Errorf("invalid nil local address for BGP neighbor %s", neighborAddress)

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 	"github.com/spf13/pflag"
+	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -46,6 +48,9 @@ type Configuration struct {
 	NodeIPs                     map[string]net.IP
 	NeighborAddresses           []net.IP
 	NeighborIPv6Addresses       []net.IP
+	AllowedSourceAddresses      []net.IP
+	AllowedSourceIPv6Addresses  []net.IP
+	NeighborLocalAddresses      map[string]net.IP
 	NeighborAs                  uint32
 	AuthPassword                string
 	HoldTime                    float64
@@ -82,6 +87,8 @@ func ParseFlags() (*Configuration, error) {
 		argNodeIPs                     = pflag.IPSlice("node-ips", nil, "The comma-separated list of node IP addresses to use instead of the pod IP address for the next hop router IP address.")
 		argNeighborAddress             = pflag.IPSlice("neighbor-address", nil, "Comma separated IPv4 router addresses the speaker connects to.")
 		argNeighborIPv6Address         = pflag.IPSlice("neighbor-ipv6-address", nil, "Comma separated IPv6 router addresses the speaker connects to.")
+		argAllowedSourceAddresses      = pflag.IPSlice("allowed-source-addresses", nil, "Comma separated IPv4 source addresses allowed for BGP peering and next-hop advertisement.")
+		argAllowedSourceIPv6Addresses  = pflag.IPSlice("allowed-source-ipv6-addresses", nil, "Comma separated IPv6 source addresses allowed for BGP peering and next-hop advertisement.")
 		argNeighborAs                  = pflag.Uint32("neighbor-as", 0, "The AS number of the BGP neighbor/peer (required)")
 		argAuthPassword                = pflag.String("auth-password", "", "bgp peer auth password")
 		argHoldTime                    = pflag.Duration("holdtime", DefaultBGPHoldtime, "ovn-speaker goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3s to 65536s. (default 90s)")
@@ -137,13 +144,15 @@ func ParseFlags() (*Configuration, error) {
 	}
 
 	config := &Configuration{
-		AnnounceClusterIP:     *argAnnounceClusterIP,
-		GrpcHost:              *argGrpcHost,
-		GrpcPort:              *argGrpcPort,
-		ClusterAs:             *argClusterAs,
-		RouterID:              *argRouterID,
-		NeighborAddresses:     *argNeighborAddress,
-		NeighborIPv6Addresses: *argNeighborIPv6Address,
+		AnnounceClusterIP:          *argAnnounceClusterIP,
+		GrpcHost:                   *argGrpcHost,
+		GrpcPort:                   *argGrpcPort,
+		ClusterAs:                  *argClusterAs,
+		RouterID:                   *argRouterID,
+		NeighborAddresses:          *argNeighborAddress,
+		NeighborIPv6Addresses:      *argNeighborIPv6Address,
+		AllowedSourceAddresses:     *argAllowedSourceAddresses,
+		AllowedSourceIPv6Addresses: *argAllowedSourceIPv6Addresses,
 		NodeIPs: map[string]net.IP{
 			kubeovnv1.ProtocolIPv4: nodeIPv4,
 			kubeovnv1.ProtocolIPv6: nodeIPv6,
@@ -193,6 +202,16 @@ func ParseFlags() (*Configuration, error) {
 	for _, addr := range config.NeighborIPv6Addresses {
 		if addr.To4() != nil {
 			return nil, fmt.Errorf("invalid neighbor-ipv6-address format: %s is not an IPv6 address", addr)
+		}
+	}
+	for _, addr := range config.AllowedSourceAddresses {
+		if addr.To4() == nil {
+			return nil, fmt.Errorf("invalid allowed-source-addresses format: %s is not an IPv4 address", addr)
+		}
+	}
+	for _, addr := range config.AllowedSourceIPv6Addresses {
+		if addr.To4() != nil {
+			return nil, fmt.Errorf("invalid allowed-source-ipv6-addresses format: %s is not an IPv6 address", addr)
 		}
 	}
 
@@ -323,6 +342,12 @@ func (config *Configuration) initBgpServer() error {
 		listenPort = bgp.BGP_PORT
 	}
 
+	if err := config.initNeighborLocalAddresses(); err != nil {
+		err = fmt.Errorf("failed to initialize BGP peer local addresses: %w", err)
+		klog.Error(err)
+		return err
+	}
+
 	klog.Infof("Starting bgp server with asn %d, routerId %s on port %d",
 		config.ClusterAs,
 		config.RouterID,
@@ -342,15 +367,19 @@ func (config *Configuration) initBgpServer() error {
 	}
 	for ipFamily, addresses := range peersMap {
 		for _, addr := range addresses {
+			transport := &api.Transport{
+				PassiveMode: config.PassiveMode,
+			}
+			if localAddr := config.getNeighborLocalAddress(addr); localAddr != nil {
+				transport.LocalAddress = localAddr.String()
+			}
 			peer := &api.Peer{
 				Timers: &api.Timers{Config: &api.TimersConfig{HoldTime: uint64(config.HoldTime)}},
 				Conf: &api.PeerConf{
 					NeighborAddress: addr.String(),
 					PeerAsn:         config.NeighborAs,
 				},
-				Transport: &api.Transport{
-					PassiveMode: config.PassiveMode,
-				},
+				Transport: transport,
 			}
 			if config.EbgpMultihopTTL != DefaultEbgpMultiHop {
 				peer.EbgpMultihop = &api.EbgpMultihop{
@@ -436,12 +465,111 @@ func addPeerWithRetry(s *gobgp.BgpServer, peer *api.Peer) error {
 
 // logBgpPeer logs the BGP peer configuration for debugging purposes.
 func logBgpPeer(peer *api.Peer) {
-	klog.Infof("BGP Peer Configuration: NeighborAddress=%s, PeerAsn=%d, HoldTime=%d, PassiveMode=%v, EbgpMultihop=%v, GracefulRestart=%v, AfiSafis=%v",
+	klog.Infof("BGP Peer Configuration: NeighborAddress=%s, LocalAddress=%s, PeerAsn=%d, HoldTime=%d, PassiveMode=%v, EbgpMultihop=%v, GracefulRestart=%v, AfiSafis=%v",
 		peer.Conf.NeighborAddress,
+		peer.Transport.LocalAddress,
 		peer.Conf.PeerAsn,
 		peer.Timers.Config.HoldTime,
 		peer.Transport.PassiveMode,
 		peer.EbgpMultihop,
 		peer.GracefulRestart,
 		peer.AfiSafis)
+}
+
+func (config *Configuration) initNeighborLocalAddresses() error {
+	config.NeighborLocalAddresses = make(map[string]net.IP, len(config.NeighborAddresses)+len(config.NeighborIPv6Addresses))
+
+	for _, neighbor := range config.NeighborAddresses {
+		if len(config.AllowedSourceAddresses) != 0 {
+			klog.Infof("Resolving BGP local address for neighbor %s with allowed IPv4 source addresses %v", neighbor, config.AllowedSourceAddresses)
+			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor, config.AllowedSourceAddresses)
+			if err != nil {
+				return err
+			}
+			config.NeighborLocalAddresses[neighbor.String()] = localAddr
+		}
+	}
+
+	for _, neighbor := range config.NeighborIPv6Addresses {
+		if len(config.AllowedSourceIPv6Addresses) != 0 {
+			klog.Infof("Resolving BGP local address for neighbor %s with allowed IPv6 source addresses %v", neighbor, config.AllowedSourceIPv6Addresses)
+			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor, config.AllowedSourceIPv6Addresses)
+			if err != nil {
+				return err
+			}
+			config.NeighborLocalAddresses[neighbor.String()] = localAddr
+		}
+	}
+
+	for neighbor, localAddr := range config.NeighborLocalAddresses {
+		klog.Infof("Using BGP local address %s for neighbor %s", localAddr, neighbor)
+	}
+
+	return nil
+}
+
+func (config *Configuration) getNeighborLocalAddress(neighborAddress net.IP) net.IP {
+	if localAddr := config.NeighborLocalAddresses[neighborAddress.String()]; localAddr != nil {
+		return localAddr
+	}
+	return nil
+}
+
+func (config *Configuration) resolveWhitelistedNeighborLocalAddress(neighborAddress net.IP, allowedLocalAddresses []net.IP) (net.IP, error) {
+	var localAddr net.IP
+	routes, err := netlink.RouteGet(neighborAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine local address for BGP neighbor %s from route lookup: %w", neighborAddress, err)
+	}
+	// RouteGet reflects the kernel's effective route decision for this neighbor.
+	// We only need the first non-nil source address from the returned routes.
+	for _, route := range routes {
+		if route.Src != nil {
+			localAddr = route.Src
+			break
+		}
+	}
+
+	if localAddr == nil {
+		return nil, fmt.Errorf("failed to determine local address for BGP neighbor %s: route lookup returned no source address", neighborAddress)
+	}
+	klog.Infof("Route lookup selected BGP local address %s for neighbor %s", localAddr, neighborAddress)
+	if err := validateLocalAddressFamily(neighborAddress, localAddr); err != nil {
+		return nil, err
+	}
+	if err := validateAllowedLocalAddress(neighborAddress, localAddr, allowedLocalAddresses); err != nil {
+		return nil, err
+	}
+	klog.Infof("Selected BGP local address %s for neighbor %s is allowed by whitelist %v", localAddr, neighborAddress, allowedLocalAddresses)
+	return localAddr, nil
+}
+
+func validateLocalAddressFamily(neighborAddress, localAddr net.IP) error {
+	if neighborAddress == nil {
+		return fmt.Errorf("invalid nil BGP neighbor address")
+	}
+	if localAddr == nil {
+		return fmt.Errorf("invalid nil local address for BGP neighbor %s", neighborAddress)
+	}
+
+	neighborIsIPv4 := neighborAddress.To4() != nil
+	localIsIPv4 := localAddr.To4() != nil
+	if neighborIsIPv4 == localIsIPv4 {
+		return nil
+	}
+
+	if neighborIsIPv4 {
+		return fmt.Errorf("invalid local address %s for IPv4 BGP neighbor %s", localAddr, neighborAddress)
+	}
+	return fmt.Errorf("invalid local address %s for IPv6 BGP neighbor %s", localAddr, neighborAddress)
+}
+
+func validateAllowedLocalAddress(neighborAddress, localAddr net.IP, allowedLocalAddresses []net.IP) error {
+	if len(allowedLocalAddresses) == 0 {
+		return nil
+	}
+	if slices.ContainsFunc(allowedLocalAddresses, localAddr.Equal) {
+		return nil
+	}
+	return fmt.Errorf("selected local address %s for BGP neighbor %s is not in allowed source address list %v; speaker startup is rejected until route lookup selects an allowed source address", localAddr, neighborAddress, allowedLocalAddresses)
 }

--- a/pkg/speaker/config_test.go
+++ b/pkg/speaker/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
 )
 
 func TestValidateRequiredFlags(t *testing.T) {
@@ -212,6 +213,83 @@ func TestValidateAllowedLocalAddress(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestSelectNeighborLocalAddressFromRoutes(t *testing.T) {
+	tests := []struct {
+		name                string
+		neighborAddress     net.IP
+		routes              []netlink.Route
+		allowedLocalAddrs   []net.IP
+		expectedLocalAddr   net.IP
+		expectedErrContains string
+	}{
+		{
+			name:            "skip non-whitelisted source and use first whitelisted match",
+			neighborAddress: net.ParseIP("10.32.32.1"),
+			routes: []netlink.Route{
+				{Src: net.ParseIP("10.32.32.2")},
+				{Src: net.ParseIP("10.32.32.3")},
+			},
+			allowedLocalAddrs: []net.IP{net.ParseIP("10.32.32.3")},
+			expectedLocalAddr: net.ParseIP("10.32.32.3"),
+		},
+		{
+			name:            "reject when no source address matches whitelist",
+			neighborAddress: net.ParseIP("10.32.32.1"),
+			routes: []netlink.Route{
+				{Src: net.ParseIP("10.32.32.2")},
+				{Src: net.ParseIP("10.32.32.4")},
+			},
+			allowedLocalAddrs:   []net.IP{net.ParseIP("10.32.32.3")},
+			expectedErrContains: "not in allowed source address list",
+		},
+		{
+			name:            "skip non-whitelisted ipv6 source and use first whitelisted match",
+			neighborAddress: net.ParseIP("fd00::1"),
+			routes: []netlink.Route{
+				{Src: net.ParseIP("fd00::2")},
+				{Src: net.ParseIP("fd00::3")},
+			},
+			allowedLocalAddrs: []net.IP{net.ParseIP("fd00::3")},
+			expectedLocalAddr: net.ParseIP("fd00::3"),
+		},
+		{
+			name:            "reject when all source addresses have wrong family",
+			neighborAddress: net.ParseIP("10.32.32.1"),
+			routes: []netlink.Route{
+				{Src: net.ParseIP("fd00::2")},
+				{Src: net.ParseIP("fd00::3")},
+			},
+			allowedLocalAddrs:   []net.IP{net.ParseIP("10.32.32.3")},
+			expectedErrContains: "no route source matched the required address family for whitelist evaluation",
+		},
+		{
+			name:            "reject when route lookup returns no source addresses",
+			neighborAddress: net.ParseIP("10.32.32.1"),
+			routes: []netlink.Route{
+				{},
+				{},
+			},
+			allowedLocalAddrs:   []net.IP{net.ParseIP("10.32.32.3")},
+			expectedErrContains: "route lookup returned no source address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localAddr, err := selectNeighborLocalAddressFromRoutes(tt.neighborAddress, tt.routes, tt.allowedLocalAddrs)
+			if tt.expectedErrContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedErrContains)
+				require.Nil(t, localAddr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, tt.expectedLocalAddr.Equal(localAddr))
 		})
 	}
 }

--- a/pkg/speaker/config_test.go
+++ b/pkg/speaker/config_test.go
@@ -117,3 +117,112 @@ func TestValidateRequiredFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateLocalAddressFamily(t *testing.T) {
+	tests := []struct {
+		name                string
+		neighborAddress     net.IP
+		localAddress        net.IP
+		expectedErrContains string
+	}{
+		{
+			name:            "allow ipv4 local address for ipv4 neighbor",
+			neighborAddress: net.ParseIP("10.32.32.1"),
+			localAddress:    net.ParseIP("10.32.32.2"),
+		},
+		{
+			name:            "allow ipv6 local address for ipv6 neighbor",
+			neighborAddress: net.ParseIP("fd00::254"),
+			localAddress:    net.ParseIP("fd00::10"),
+		},
+		{
+			name:                "reject ipv6 local address for ipv4 neighbor",
+			neighborAddress:     net.ParseIP("10.32.32.1"),
+			localAddress:        net.ParseIP("fd00::10"),
+			expectedErrContains: "invalid local address",
+		},
+		{
+			name:                "reject ipv4 local address for ipv6 neighbor",
+			neighborAddress:     net.ParseIP("fd00::254"),
+			localAddress:        net.ParseIP("10.32.32.2"),
+			expectedErrContains: "invalid local address",
+		},
+		{
+			name:                "reject nil neighbor address",
+			localAddress:        net.ParseIP("10.32.32.2"),
+			expectedErrContains: "invalid nil BGP neighbor address",
+		},
+		{
+			name:                "reject nil local address",
+			neighborAddress:     net.ParseIP("10.32.32.1"),
+			expectedErrContains: "invalid nil local address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLocalAddressFamily(tt.neighborAddress, tt.localAddress)
+			if tt.expectedErrContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateAllowedLocalAddress(t *testing.T) {
+	tests := []struct {
+		name                string
+		neighborAddress     net.IP
+		localAddress        net.IP
+		allowedLocalAddrs   []net.IP
+		expectedErrContains string
+	}{
+		{
+			name:              "allow when whitelist is empty",
+			neighborAddress:   net.ParseIP("10.32.32.1"),
+			localAddress:      net.ParseIP("10.32.32.2"),
+			allowedLocalAddrs: nil,
+		},
+		{
+			name:              "allow selected source address inside whitelist",
+			neighborAddress:   net.ParseIP("10.32.32.1"),
+			localAddress:      net.ParseIP("10.32.32.2"),
+			allowedLocalAddrs: []net.IP{net.ParseIP("10.32.32.2"), net.ParseIP("10.32.32.3")},
+		},
+		{
+			name:                "reject selected source address outside whitelist",
+			neighborAddress:     net.ParseIP("10.32.32.1"),
+			localAddress:        net.ParseIP("10.32.32.2"),
+			allowedLocalAddrs:   []net.IP{net.ParseIP("10.32.32.3")},
+			expectedErrContains: "not in allowed source address list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAllowedLocalAddress(tt.neighborAddress, tt.localAddress, tt.allowedLocalAddrs)
+			if tt.expectedErrContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestInitNeighborLocalAddressesPureExtensionMode(t *testing.T) {
+	config := &Configuration{
+		NeighborAddresses:     []net.IP{net.ParseIP("10.32.32.1")},
+		NeighborIPv6Addresses: []net.IP{net.ParseIP("fd00::254")},
+	}
+
+	require.NoError(t, config.initNeighborLocalAddresses())
+	require.Nil(t, config.getNeighborLocalAddress(net.ParseIP("10.32.32.1")))
+	require.Nil(t, config.getNeighborLocalAddress(net.ParseIP("fd00::254")))
+}

--- a/yamls/speaker.yaml
+++ b/yamls/speaker.yaml
@@ -45,7 +45,8 @@ spec:
             - --neighbor-address=10.32.32.1
             - --neighbor-as=65030
             - --cluster-as=65000
-            - --allowed-source-addresses=10.32.32.2,10.32.32.3,10.32.32.4,10.32.32.5
+            # Optional: set --allowed-source-addresses to make sure nexthop in the allowed-source-addresses is valid.
+            # - --allowed-source-addresses=10.32.32.2,10.32.32.3,10.32.32.4,10.32.32.5
           env:
             - name: NODE_NAME
               valueFrom:

--- a/yamls/speaker.yaml
+++ b/yamls/speaker.yaml
@@ -45,6 +45,7 @@ spec:
             - --neighbor-address=10.32.32.1
             - --neighbor-as=65030
             - --cluster-as=65000
+            - --allowed-source-addresses=10.32.32.2,10.32.32.3,10.32.32.4,10.32.32.5
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features

<img width="1708" height="499" alt="企业微信截图_818fb255-33e6-410c-82da-17c294c8367c" src="https://github.com/user-attachments/assets/f09c90ef-5269-4e26-95c6-38cf012db0ab" />

支持 BGP speaker 校验，缓存，固定 nexthop ip




<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
