### PR TITLE
test(iptables-vpc-nat-gw): skip image+annotations spec on v1.15-

### DIFF
--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -535,6 +535,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 	})
 
 	framework.ConformanceIt("[1] change gateway image, custom annotations and custom namespace", func() {
+		f.SkipVersionPriorTo(1, 16, "VpcNatGateway image override and custom annotations were introduced in v1.16")
 		overlaySubnetV4Cidr := "10.0.2.0/24"
 		overlaySubnetV4Gw := "10.0.2.1"
 		lanIP := "10.0.2.254"


### PR DESCRIPTION
## Summary

- Restore the top-level \`f.SkipVersionPriorTo(1, 16, ...)\` guard on the \`[1] change gateway image, custom annotations and custom namespace\` spec that #6676 (commit f2cf6628c) accidentally dropped.
- The \`customAnnotations\` assertion exercises \`VpcNatGateway.Spec.Annotations\`, which was introduced by #6256 and does not exist on release-1.15 — apiserver silently drops the unknown field and the test fails deterministically on every release-1.15 PR (e.g. #6710, the Go 1.26.3 bump for release-1.15).
- The internal \`VersionPriorTo(1, 17)\` gates around the namespace / \`IptablesEIP.spec.namespace\` sub-cases are kept as-is.

## Why

\`#6676\` correctly identified the v1.17+ namespace plumbing problem on release-1.16, but in the process it also lifted the v1.16+ guard. On release-1.15 builds, the framework now runs the whole spec, hits \`Spec.Annotations\`, and fails with the smoking-gun \`Warning: unknown field \"spec.annotations\"\` followed by \`framework.ExpectHaveKeyWithValue(pod.Annotations, …)\` failure. release-1.15 has gone from green to 100% deterministic fail since 2026-04-22.

## Test plan

- [x] \`make lint\` (0 issues)
- [ ] On release-1.15 PRs the \`Iptables VPC NAT Gateway E2E\` job goes from FAIL to PASS (the spec is skipped).
- [ ] On release-1.16 / master the spec still runs end-to-end as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)