### PR TITLE
Block vpc deletion while SNAT, DNAT or FIP rules are using it

### DIFF
--- a/pkg/webhook/vpc.go
+++ b/pkg/webhook/vpc.go
@@ -62,8 +62,13 @@ func (v *ValidatingHook) VpcDeleteHook(ctx context.Context, req admission.Reques
 	if err := v.cache.List(ctx, dnatList); err != nil {
 		return ctrlwebhook.Errored(http.StatusInternalServerError, err)
 	}
+	// Use Status.Vpc first as vpc may be inferred from spec.ipName if not in spec.
 	for _, item := range dnatList.Items {
-		if item.Spec.Vpc == vpc.Name {
+		referencedVpc := item.Status.Vpc
+		if referencedVpc == "" {
+			referencedVpc = item.Spec.Vpc
+		}
+		if referencedVpc == vpc.Name {
 			return ctrlwebhook.Denied("can't delete vpc when OvnDnatRules still reference it, delete them first")
 		}
 	}
@@ -72,8 +77,13 @@ func (v *ValidatingHook) VpcDeleteHook(ctx context.Context, req admission.Reques
 	if err := v.cache.List(ctx, snatList); err != nil {
 		return ctrlwebhook.Errored(http.StatusInternalServerError, err)
 	}
+	// Use Status.Vpc first as vpc may be inferred from spec.ipName if not in spec.
 	for _, item := range snatList.Items {
-		if item.Spec.Vpc == vpc.Name {
+		referencedVpc := item.Status.Vpc
+		if referencedVpc == "" {
+			referencedVpc = item.Spec.Vpc
+		}
+		if referencedVpc == vpc.Name {
 			return ctrlwebhook.Denied("can't delete vpc when OvnSnatRules still reference it, delete them first")
 		}
 	}

--- a/pkg/webhook/vpc.go
+++ b/pkg/webhook/vpc.go
@@ -49,7 +49,7 @@ func (v *ValidatingHook) VpcUpdateHook(_ context.Context, req admission.Request)
 	return ctrlwebhook.Allowed("bypass")
 }
 
-func (v *ValidatingHook) VpcDeleteHook(_ context.Context, req admission.Request) admission.Response {
+func (v *ValidatingHook) VpcDeleteHook(ctx context.Context, req admission.Request) admission.Response {
 	vpc := ovnv1.Vpc{}
 	if err := v.decoder.DecodeRaw(req.OldObject, &vpc); err != nil {
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
@@ -57,5 +57,26 @@ func (v *ValidatingHook) VpcDeleteHook(_ context.Context, req admission.Request)
 	if len(vpc.Status.Subnets) != 0 {
 		return ctrlwebhook.Denied("can't delete vpc when any subnet in the vpc")
 	}
+
+	dnatList := &ovnv1.OvnDnatRuleList{}
+	if err := v.cache.List(ctx, dnatList); err != nil {
+		return ctrlwebhook.Errored(http.StatusInternalServerError, err)
+	}
+	for _, item := range dnatList.Items {
+		if item.Spec.Vpc == vpc.Name {
+			return ctrlwebhook.Denied("can't delete vpc when OvnDnatRules still reference it, delete them first")
+		}
+	}
+
+	snatList := &ovnv1.OvnSnatRuleList{}
+	if err := v.cache.List(ctx, snatList); err != nil {
+		return ctrlwebhook.Errored(http.StatusInternalServerError, err)
+	}
+	for _, item := range snatList.Items {
+		if item.Spec.Vpc == vpc.Name {
+			return ctrlwebhook.Denied("can't delete vpc when OvnSnatRules still reference it, delete them first")
+		}
+	}
+
 	return ctrlwebhook.Allowed("bypass")
 }

--- a/pkg/webhook/vpc.go
+++ b/pkg/webhook/vpc.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -69,7 +70,7 @@ func (v *ValidatingHook) VpcDeleteHook(ctx context.Context, req admission.Reques
 			referencedVpc = item.Spec.Vpc
 		}
 		if referencedVpc == vpc.Name {
-			return ctrlwebhook.Denied("can't delete vpc when OvnDnatRules still reference it, delete them first")
+			return ctrlwebhook.Denied(fmt.Sprintf("can't delete vpc %q: still referenced by OvnDnatRule %q", vpc.Name, item.Name))
 		}
 	}
 
@@ -84,7 +85,22 @@ func (v *ValidatingHook) VpcDeleteHook(ctx context.Context, req admission.Reques
 			referencedVpc = item.Spec.Vpc
 		}
 		if referencedVpc == vpc.Name {
-			return ctrlwebhook.Denied("can't delete vpc when OvnSnatRules still reference it, delete them first")
+			return ctrlwebhook.Denied(fmt.Sprintf("can't delete vpc %q: still referenced by OvnSnatRule %q", vpc.Name, item.Name))
+		}
+	}
+
+	fipList := &ovnv1.OvnFipList{}
+	if err := v.cache.List(ctx, fipList); err != nil {
+		return ctrlwebhook.Errored(http.StatusInternalServerError, err)
+	}
+	// Use Status.Vpc first as vpc may be inferred from spec.ipName if not in spec.
+	for _, item := range fipList.Items {
+		referencedVpc := item.Status.Vpc
+		if referencedVpc == "" {
+			referencedVpc = item.Spec.Vpc
+		}
+		if referencedVpc == vpc.Name {
+			return ctrlwebhook.Denied(fmt.Sprintf("can't delete vpc %q: still referenced by OvnFip %q", vpc.Name, item.Name))
 		}
 	}
 


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->
Add webhook checks that prevent vpc deletion if there are DNAT or SNAT rules or FIPs using that VPC.

## Which issue(s) this PR fixes

Fixes #6717
