### PR TITLE
fix: use status variable instead of hardcoded ConditionTrue in loopOv…

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -837,7 +837,7 @@ func (c *Controller) loopOvn0Check() {
 
 	var alreadySet bool
 	for _, condition := range node.Status.Conditions {
-		if condition.Type == corev1.NodeNetworkUnavailable && condition.Status == corev1.ConditionTrue &&
+		if condition.Type == corev1.NodeNetworkUnavailable && condition.Status == status &&
 			condition.Reason == reason && condition.Message == message {
 			alreadySet = true
 			break


### PR DESCRIPTION
…n0Check

The alreadySet check hardcoded condition.Status == ConditionTrue, so when ping succeeded (status == ConditionFalse) the condition was never detected as already set, causing repeated SetNodeNetworkUnavailableCondition calls every loop iteration.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
