### PR TITLE
revert(ha): undo cluster integrity check (#6363) — crashes ovn-central during master upgrade with kicked nodes

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -2978,15 +2978,21 @@ jobs:
           make kube-ovn-security-e2e
           make kube-ovn-ha-e2e
 
+
+      - name: Check kube ovn pod restarts
+        id: check-restarts
+        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')) }}
+        run: make check-kube-ovn-pod-restarts
+
       - name: kubectl ko log
-        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
           name: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log
           path: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -313,51 +313,6 @@ func checkNorthdEpAlive(cfg *Configuration, namespace, service string, expectedA
 	return false
 }
 
-// checkDBClusterIntegrity verifies that a leader node has the expected number
-// of cluster members. After a split-brain recovery with an incomplete snapshot,
-// a leader may have fewer members than expected (e.g., some servers missing from
-// its cluster configuration). This causes the missing servers to be permanently
-// excluded from the cluster.
-//
-// When detected, the corrupted db file is removed so that on restart,
-// ovn_db_pre_start can rebuild it from the raft header file and rejoin the
-// cluster with a clean state.
-func checkDBClusterIntegrity(db string, expectedMembers int) {
-	if expectedMembers <= 1 {
-		return
-	}
-
-	dbName := ovnnb.DatabaseName
-	if db == "sb" {
-		dbName = ovnsb.DatabaseName
-	}
-
-	output, err := ovs.OvnDatabaseControl(db, "cluster/status", dbName)
-	if err != nil {
-		klog.Warningf("failed to get %s cluster status: %v", db, err)
-		return
-	}
-
-	serverCount := 0
-	for line := range strings.SplitSeq(output, "\n") {
-		if slices.Contains(strings.Fields(line), "at") {
-			serverCount++
-		}
-	}
-
-	if serverCount > 0 && serverCount < expectedMembers {
-		dbFile := fmt.Sprintf("/etc/ovn/ovn%s_db.db", db)
-		klog.Errorf("ovn-%s leader has only %d cluster members, expected %d; "+
-			"cluster may have incomplete membership from a split-brain recovery; "+
-			"removing db file %s to force clean rejoin on restart",
-			db, serverCount, expectedMembers, dbFile)
-		if err := os.Remove(dbFile); err != nil && !os.IsNotExist(err) {
-			klog.Errorf("failed to remove db file %s: %v", dbFile, err)
-		}
-		klog.Fatalf("exiting to trigger re-election with clean state")
-	}
-}
-
 func compactOvnDatabase(db string) {
 	output, err := ovs.OvnDatabaseControl(db, "ovsdb-server/compact")
 	if err != nil {
@@ -471,14 +426,6 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			if sbLeader && isDBLeader(addr, ovnsb.DatabaseName) {
 				klog.Fatalf("found another ovn-sb leader at %s, exiting process to restart", addr)
 			}
-		}
-
-		expectedMembers := len(cfg.remoteAddresses) + 1
-		if nbLeader {
-			checkDBClusterIntegrity("nb", expectedMembers)
-		}
-		if sbLeader {
-			checkDBClusterIntegrity("sb", expectedMembers)
 		}
 
 		if cfg.EnableCompact {


### PR DESCRIPTION
## Summary
- Revert #6363, which introduced `checkDBClusterIntegrity` in the ovn leader checker.
- That check compared the live OVN raft `cluster/status` server count against `len(NODE_IPS)`. When the count was lower, it removed the local db file and called `klog.Fatalf`.
- This assumption holds for the original split-brain scenario, but breaks during routine k8s master upgrades when our upgrade flow actively `kubectl ko nb/sb kick`s the node being removed. `NODE_IPS` is baked into the pod env at install time and does not shrink, so post-kick we always have `serverCount = N-1 < expectedMembers = N`.

## Impact observed
With a 3-master cluster, removing one master via the standard upgrade flow now produces a crash loop:
1. Upgrade flow kicks the leaving node out of the raft cluster → `cluster/status` shows 2 servers.
2. ovn-central pods still have `NODE_IPS=A,B,C` (3 IPs).
3. Leader checker fires `checkDBClusterIntegrity`, deletes `/etc/ovn/ovn{nb,sb}_db.db`, and `Fatalf`s.
4. Pod restarts → a new leader is elected → the same check fires again → CrashLoopBackOff.
5. The deleted db cannot rejoin because the node was explicitly kicked from the cluster.

So instead of preventing a split-brain, the check causes a 2/3-healthy cluster to lose its remaining replicas and the affected pods cannot recover automatically.

## Why revert vs. fix
The check has no way to distinguish "split-brain after corrupted snapshot" from "operator-initiated kick", because `NODE_IPS` is static and `cluster/status` is the only source of truth post-kick. Any safe replacement (e.g. only running the check during a startup window, or only when the db file is near-empty) needs more design, so revert first and re-do it properly later. The original split-brain bug it fixed is rare; running the cluster without this safety net is strictly better than the current behavior.

## Follow-ups
- Re-design the split-brain detection so it cannot fire during normal kicks (startup window, db size threshold, or reading expected member count from the kube-apiserver instead of env).
- Revert the matching commits on `release-1.16` (`e229c02ad`) and `release-1.15` (`b54aa2140` + `8ff5589a7`).

## Test plan
- [x] `make lint` on `pkg/ovn_leader_checker/...` clean
- [x] `go build ./pkg/ovn_leader_checker/...` succeeds
- [ ] HA e2e (the original failing test will re-fail without this patch — that is acceptable until a proper fix lands)
- [ ] Manual: 3-master cluster, kick one node via `kubectl ko nb/sb kick`, confirm remaining ovn-central pods stay healthy