### PR TITLE
revert(ha): undo cluster integrity check (#6363) for release-1.16

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -2978,15 +2978,21 @@ jobs:
           make kube-ovn-security-e2e
           make kube-ovn-ha-e2e
 
+
+      - name: Check kube ovn pod restarts
+        id: check-restarts
+        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')) }}
+        run: make check-kube-ovn-pod-restarts
+
       - name: kubectl ko log
-        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           make kubectl-ko-log
           mv kubectl-ko-log.tar.gz kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
           name: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log
           path: kube-ovn-ha-e2e-${{ matrix.ssl }}-${{ matrix.bind-local }}-${{ matrix.ip-family }}-ko-log.tar.gz

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -313,51 +313,6 @@ func checkNorthdEpAlive(cfg *Configuration, namespace, service string, expectedA
 	return false
 }
 
-// checkDBClusterIntegrity verifies that a leader node has the expected number
-// of cluster members. After a split-brain recovery with an incomplete snapshot,
-// a leader may have fewer members than expected (e.g., some servers missing from
-// its cluster configuration). This causes the missing servers to be permanently
-// excluded from the cluster.
-//
-// When detected, the corrupted db file is removed so that on restart,
-// ovn_db_pre_start can rebuild it from the raft header file and rejoin the
-// cluster with a clean state.
-func checkDBClusterIntegrity(db string, expectedMembers int) {
-	if expectedMembers <= 1 {
-		return
-	}
-
-	dbName := ovnnb.DatabaseName
-	if db == "sb" {
-		dbName = ovnsb.DatabaseName
-	}
-
-	output, err := ovs.OvnDatabaseControl(db, "cluster/status", dbName)
-	if err != nil {
-		klog.Warningf("failed to get %s cluster status: %v", db, err)
-		return
-	}
-
-	serverCount := 0
-	for line := range strings.SplitSeq(output, "\n") {
-		if slices.Contains(strings.Fields(line), "at") {
-			serverCount++
-		}
-	}
-
-	if serverCount > 0 && serverCount < expectedMembers {
-		dbFile := fmt.Sprintf("/etc/ovn/ovn%s_db.db", db)
-		klog.Errorf("ovn-%s leader has only %d cluster members, expected %d; "+
-			"cluster may have incomplete membership from a split-brain recovery; "+
-			"removing db file %s to force clean rejoin on restart",
-			db, serverCount, expectedMembers, dbFile)
-		if err := os.Remove(dbFile); err != nil && !os.IsNotExist(err) {
-			klog.Errorf("failed to remove db file %s: %v", dbFile, err)
-		}
-		klog.Fatalf("exiting to trigger re-election with clean state")
-	}
-}
-
 func compactOvnDatabase(db string) {
 	output, err := ovs.OvnDatabaseControl(db, "ovsdb-server/compact")
 	if err != nil {
@@ -471,14 +426,6 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			if sbLeader && isDBLeader(addr, ovnsb.DatabaseName) {
 				klog.Fatalf("found another ovn-sb leader at %s, exiting process to restart", addr)
 			}
-		}
-
-		expectedMembers := len(cfg.remoteAddresses) + 1
-		if nbLeader {
-			checkDBClusterIntegrity("nb", expectedMembers)
-		}
-		if sbLeader {
-			checkDBClusterIntegrity("sb", expectedMembers)
 		}
 
 		if cfg.EnableCompact {


### PR DESCRIPTION
## Summary
Backport of #6721 to `release-1.16`.

Revert #6363 — the `checkDBClusterIntegrity` check assumes `len(NODE_IPS)` always equals the live raft member count, but our upgrade flow actively `kubectl ko nb/sb kick`s a master node before removing it. After the kick, `cluster/status` shows fewer servers than `NODE_IPS`, so the check deletes the local db file and `Fatalf`s — on every leader, on every iteration — which turns a healthy 2/3 cluster into a crash loop and the affected pods cannot rejoin (they were explicitly kicked).

See https://github.com/kubeovn/kube-ovn/pull/6721 for the full analysis.

## Test plan
- [x] `make lint` clean
- [x] `go build ./pkg/ovn_leader_checker/...`
- [ ] Manual: 3-master cluster, kick one node, confirm remaining ovn-central pods stay healthy