### PR TITLE
revert(ha): undo cluster integrity check (#6363) for release-1.15

### DIFF
--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -343,9 +343,7 @@ func checkDBClusterIntegrity(db string, expectedMembers int) {
 		dbName = ovnsb.DatabaseName
 	}
 
-	ctlFile := fmt.Sprintf("/var/run/ovn/ovn%s_db.ctl", db)
-	out, err := exec.Command("ovn-appctl", "-t", ctlFile, "cluster/status", dbName).CombinedOutput() // #nosec G204
-	output := string(out)
+	output, err := ovs.OvnDatabaseControl(db, "cluster/status", dbName)
 	if err != nil {
 		klog.Warningf("failed to get %s cluster status: %v", db, err)
 		return

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -324,51 +324,6 @@ func checkNorthdEpAlive(cfg *Configuration, namespace, service string, expectedA
 	return false
 }
 
-// checkDBClusterIntegrity verifies that a leader node has the expected number
-// of cluster members. After a split-brain recovery with an incomplete snapshot,
-// a leader may have fewer members than expected (e.g., some servers missing from
-// its cluster configuration). This causes the missing servers to be permanently
-// excluded from the cluster.
-//
-// When detected, the corrupted db file is removed so that on restart,
-// ovn_db_pre_start can rebuild it from the raft header file and rejoin the
-// cluster with a clean state.
-func checkDBClusterIntegrity(db string, expectedMembers int) {
-	if expectedMembers <= 1 {
-		return
-	}
-
-	dbName := ovnnb.DatabaseName
-	if db == "sb" {
-		dbName = ovnsb.DatabaseName
-	}
-
-	output, err := ovs.OvnDatabaseControl(db, "cluster/status", dbName)
-	if err != nil {
-		klog.Warningf("failed to get %s cluster status: %v", db, err)
-		return
-	}
-
-	serverCount := 0
-	for line := range strings.SplitSeq(output, "\n") {
-		if slices.Contains(strings.Fields(line), "at") {
-			serverCount++
-		}
-	}
-
-	if serverCount > 0 && serverCount < expectedMembers {
-		dbFile := fmt.Sprintf("/etc/ovn/ovn%s_db.db", db)
-		klog.Errorf("ovn-%s leader has only %d cluster members, expected %d; "+
-			"cluster may have incomplete membership from a split-brain recovery; "+
-			"removing db file %s to force clean rejoin on restart",
-			db, serverCount, expectedMembers, dbFile)
-		if err := os.Remove(dbFile); err != nil && !os.IsNotExist(err) {
-			klog.Errorf("failed to remove db file %s: %v", dbFile, err)
-		}
-		klog.Fatalf("exiting to trigger re-election with clean state")
-	}
-}
-
 func compactOvnDatabase(db string) {
 	args := []string{
 		"-t",
@@ -487,14 +442,6 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			if sbLeader && isDBLeader(addr, ovnsb.DatabaseName) {
 				klog.Fatalf("found another ovn-sb leader at %s, exiting process to restart", addr)
 			}
-		}
-
-		expectedMembers := len(cfg.remoteAddresses) + 1
-		if nbLeader {
-			checkDBClusterIntegrity("nb", expectedMembers)
-		}
-		if sbLeader {
-			checkDBClusterIntegrity("sb", expectedMembers)
 		}
 
 		if cfg.EnableCompact {


### PR DESCRIPTION
## Summary
Backport of #6721 to `release-1.15`.

Reverts two commits:
- `b54aa2140` — the original `checkDBClusterIntegrity` introduction.
- `8ff5589a7` — the release-1.15 compatibility shim (`exec.Command` instead of `ovs.OvnDatabaseControl`); no longer needed after the revert above.

The check compares the live OVN raft `cluster/status` server count against `len(NODE_IPS)` and, when the count is lower, deletes the local db file and `Fatalf`s. Our upgrade flow `kubectl ko nb/sb kick`s a master before removing it, so `cluster/status` legitimately shrinks below `NODE_IPS` — which is baked into the pod env at install time and never shrinks. Every leader fires the check on every iteration, turning a healthy 2/3 cluster into a crash loop; the affected pods cannot rejoin because they were explicitly kicked.

See https://github.com/kubeovn/kube-ovn/pull/6721 for the full analysis.

## Test plan
- [x] `make lint` clean
- [x] `go build ./pkg/ovn_leader_checker/...`
- [ ] Manual: 3-master cluster, kick one node, confirm remaining ovn-central pods stay healthy