### PR TITLE
feat: add u2o overlay only routing

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -2649,6 +2649,14 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              u2oFeatures:
+                description: Feature configurations for underlay to overlay interconnection.
+                properties:
+                  overlayOnlyRouting:
+                    description: OverlayOnlyRouting controls whether only overlay
+                      CIDRs use U2O routing.
+                    type: boolean
+                type: object
               u2oInterconnection:
                 description: Enable underlay to overlay interconnection.
                 type: boolean

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -2649,6 +2649,14 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              u2oFeatures:
+                description: Feature configurations for underlay to overlay interconnection.
+                properties:
+                  overlayOnlyRouting:
+                    description: OverlayOnlyRouting controls whether only overlay
+                      CIDRs use U2O routing.
+                    type: boolean
+                type: object
               u2oInterconnection:
                 description: Enable underlay to overlay interconnection.
                 type: boolean

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2900,6 +2900,14 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              u2oFeatures:
+                description: Feature configurations for underlay to overlay interconnection.
+                properties:
+                  overlayOnlyRouting:
+                    description: OverlayOnlyRouting controls whether only overlay
+                      CIDRs use U2O routing.
+                    type: boolean
+                type: object
               u2oInterconnection:
                 description: Enable underlay to overlay interconnection.
                 type: boolean

--- a/pkg/apis/kubeovn/v1/subnet.go
+++ b/pkg/apis/kubeovn/v1/subnet.go
@@ -136,6 +136,8 @@ type SubnetSpec struct {
 	U2OInterconnectionIP string `json:"u2oInterconnectionIP,omitempty"`
 	// Enable underlay to overlay interconnection.
 	U2OInterconnection bool `json:"u2oInterconnection,omitempty"`
+	// Feature configurations for underlay to overlay interconnection.
+	U2OFeatures U2OFeatures `json:"u2oFeatures,omitempty"`
 	// Enable LoadBalancer on this subnet.
 	EnableLb *bool `json:"enableLb,omitempty"`
 	// Enable ECMP for centralized gateway.
@@ -151,6 +153,11 @@ type SubnetSpec struct {
 	NamespaceSelectors []metav1.LabelSelector `json:"namespaceSelectors,omitempty"`
 	// Node network name for underlay.
 	NodeNetwork string `json:"nodeNetwork,omitempty"`
+}
+
+type U2OFeatures struct {
+	// OverlayOnlyRouting controls whether only overlay CIDRs use U2O routing.
+	OverlayOnlyRouting bool `json:"overlayOnlyRouting,omitempty"`
 }
 
 type ACL struct {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -74,6 +74,10 @@ func readyToRemoveFinalizer(subnet *kubeovnv1.Subnet) bool {
 	return false
 }
 
+func u2oOverlayOnlyRoutingEnabled(subnet *kubeovnv1.Subnet) bool {
+	return subnet != nil && subnet.Spec.U2OFeatures.OverlayOnlyRouting
+}
+
 func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 	oldSubnet := oldObj.(*kubeovnv1.Subnet)
 	newSubnet := newObj.(*kubeovnv1.Subnet)
@@ -854,6 +858,13 @@ func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) error {
 		}
 	}
 
+	if subnet.Spec.Vlan == "" {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, subnet.Name); err != nil {
+			klog.Errorf("failed to sync u2o overlay cidrs after deleting subnet %s, %v", subnet.Name, err)
+			return err
+		}
+	}
+
 	klog.Infof("delete policy route for %s subnet %s", subnet.Spec.GatewayType, subnet.Name)
 	if err := c.deletePolicyRouteByGatewayType(subnet, subnet.Spec.GatewayType, true); err != nil {
 		klog.Errorf("failed to delete policy route for overlay subnet %s, %v", subnet.Name, err)
@@ -936,6 +947,13 @@ func (c *Controller) reconcileSubnet(subnet *kubeovnv1.Subnet) error {
 	} else if err := c.reconcileCustomVpcStaticRoute(subnet); err != nil {
 		klog.Errorf("reconcile custom vpc ovn route for subnet %s failed: %v", subnet.Name, err)
 		return err
+	}
+
+	if subnet.Spec.Vlan == "" {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, ""); err != nil {
+			klog.Errorf("sync u2o overlay cidrs for subnet %s failed: %v", subnet.Name, err)
+			return err
+		}
 	}
 
 	if err := c.reconcileVlan(subnet); err != nil {
@@ -2360,8 +2378,12 @@ func (c *Controller) deletePolicyRouteByGatewayType(subnet *kubeovnv1.Subnet, ga
 
 func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) error {
 	v4Gw, v6Gw := util.SplitStringIP(subnet.Spec.Gateway)
+	overlayOnly := u2oOverlayOnlyRoutingEnabled(subnet)
 
 	externalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{"isU2ORoutePolicy": "true"})
+
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
 
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
@@ -2380,9 +2402,6 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			nodesIPv6 = append(nodesIPv6, nodeIPv6)
 		}
 	}
-
-	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
-	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
 
 	if err := c.OVNNbClient.CreateAddressSet(u2oExcludeIP4Ag, externalIDs); err != nil {
 		klog.Errorf("create address set %s: %v", u2oExcludeIP4Ag, err)
@@ -2408,35 +2427,69 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 		}
 	}
 
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	if overlayOnly {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, ""); err != nil {
+			return err
+		}
+	}
+
+	overlayOnlyExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{
+		"isU2ORoutePolicy":            "true",
+		"isU2OOverlayOnlyRoutePolicy": "true",
+	})
+	desiredPolicies := make(map[string]struct{})
+
 	for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
 		ipSuffix := getIPSuffix(util.CheckProtocol(cidrBlock))
 		nextHop := v4Gw
 		U2OexcludeIPAs := u2oExcludeIP4Ag
+		overlayCIDRsAg := overlayCIDRs4Ag
 		if ipSuffix == "ip6" {
 			nextHop = v6Gw
 			U2OexcludeIPAs = u2oExcludeIP6Ag
+			overlayCIDRsAg = overlayCIDRs6Ag
 		}
 
 		match1 := fmt.Sprintf("%s.dst == %s", ipSuffix, cidrBlock)
 		match2 := fmt.Sprintf("%s.dst == $%s && %s.src == %s", ipSuffix, U2OexcludeIPAs, ipSuffix, cidrBlock)
 		match3 := fmt.Sprintf("%s.src == %s", ipSuffix, cidrBlock)
+		matchSameSubnet := fmt.Sprintf("%s.src == %s && %s.dst == %s", ipSuffix, cidrBlock, ipSuffix, cidrBlock)
+		matchOverlayToUnderlay := fmt.Sprintf("%s.src == $%s && %s.dst == %s", ipSuffix, overlayCIDRsAg, ipSuffix, cidrBlock)
 
 		/*
-			policy1:
-			priority 29400 match: "ip4.dst == underlay subnet cidr"                         action: allow
+			default u2o:
+			policy1 priority 29400 match: "ip4.dst == underlay subnet cidr"                         action: allow
+			policy2 priority 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reroute physical gw
+			policy3 priority 29000 match: "ip4.src == underlay subnet cidr"                         action: reroute physical gw
 
-			policy2:
-			priority 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reroute physical gw
-
-			policy3:
-			priority 29000 match: "ip4.src == underlay subnet cidr"                         action: reroute physical gw
-
-			comment:
-			policy1 and policy2 allow overlay pod access underlay but when overlay pod access node ip, it should go join subnet,
-			policy3: underlay pod first access u2o interconnection lrp and then reroute to physical gw
+			overlay only u2o:
+			baseline priority 31000 match: "ip4.dst == overlay cidr"                          action: allow
+			baseline priority 31000 match: "ip4.dst == join cidr"                             action: allow
+			policy1 priority 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reroute physical gw
+			policy2 priority 30060 match: "ip4.src == underlay subnet cidr && ip4.dst == underlay subnet cidr" action: allow
+			policy3 priority 30050 match: "ip4.src == underlay cidr"                          action: reroute physical gw
+			policy4 priority 29400 match: "ip4.src == overlay cidrs && ip4.dst == underlay cidr" action: allow
 		*/
 		action := kubeovnv1.PolicyRouteActionAllow
-		if subnet.Spec.Vpc == c.config.ClusterRouter {
+		if overlayOnly {
+			klog.Infof("add u2o overlay only policy for router: %s, match %s, action %s", subnet.Spec.Vpc, matchOverlayToUnderlay, action)
+			if err := c.addPolicyRouteToVpc(
+				subnet.Spec.Vpc,
+				&kubeovnv1.PolicyRoute{
+					Priority: util.U2OSubnetPolicyPriority,
+					Match:    matchOverlayToUnderlay,
+					Action:   action,
+				},
+				overlayOnlyExternalIDs,
+			); err != nil {
+				klog.Errorf("failed to add u2o overlay to underlay policy for subnet %s %v", subnet.Name, err)
+				return err
+			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSubnetPolicyPriority, matchOverlayToUnderlay)] = struct{}{}
+		}
+
+		if !overlayOnly && subnet.Spec.Vpc == c.config.ClusterRouter {
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match1, action)
 			if err := c.addPolicyRouteToVpc(
 				subnet.Spec.Vpc,
@@ -2450,9 +2503,16 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 				klog.Errorf("failed to add u2o interconnection policy1 for subnet %s %v", subnet.Name, err)
 				return err
 			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSubnetPolicyPriority, match1)] = struct{}{}
+		}
 
+		if overlayOnly || subnet.Spec.Vpc == c.config.ClusterRouter {
 			action = kubeovnv1.PolicyRouteActionReroute
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match2, action)
+			externalIDs := externalIDs
+			if overlayOnly {
+				externalIDs = overlayOnlyExternalIDs
+			}
 			if err := c.addPolicyRouteToVpc(
 				subnet.Spec.Vpc,
 				&kubeovnv1.PolicyRoute{
@@ -2466,14 +2526,36 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 				klog.Errorf("failed to add u2o interconnection policy2 for subnet %s %v", subnet.Name, err)
 				return err
 			}
+			desiredPolicies[logicalRouterPolicyKey(util.SubnetRouterPolicyPriority, match2)] = struct{}{}
+		}
+
+		if overlayOnly {
+			klog.Infof("add u2o overlay only same-subnet policy for router: %s, match %s, action %s", subnet.Spec.Vpc, matchSameSubnet, kubeovnv1.PolicyRouteActionAllow)
+			if err := c.addPolicyRouteToVpc(
+				subnet.Spec.Vpc,
+				&kubeovnv1.PolicyRoute{
+					Priority: util.U2OSameSubnetPolicyPriority,
+					Match:    matchSameSubnet,
+					Action:   kubeovnv1.PolicyRouteActionAllow,
+				},
+				overlayOnlyExternalIDs,
+			); err != nil {
+				klog.Errorf("failed to add u2o overlay only same-subnet policy for subnet %s %v", subnet.Name, err)
+				return err
+			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSameSubnetPolicyPriority, matchSameSubnet)] = struct{}{}
 		}
 
 		action = kubeovnv1.PolicyRouteActionReroute
+		physicalGatewayPolicyPriority := util.GatewayRouterPolicyPriority
+		if overlayOnly {
+			physicalGatewayPolicyPriority = util.U2OPhysicalGatewayPolicyPriority
+		}
 		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s, nexthop %s", subnet.Spec.Vpc, match3, action, nextHop)
 		if err := c.addPolicyRouteToVpc(
 			subnet.Spec.Vpc,
 			&kubeovnv1.PolicyRoute{
-				Priority:  util.GatewayRouterPolicyPriority,
+				Priority:  physicalGatewayPolicyPriority,
 				Match:     match3,
 				Action:    action,
 				NextHopIP: nextHop,
@@ -2481,6 +2563,118 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			externalIDs,
 		); err != nil {
 			klog.Errorf("failed to add u2o interconnection policy3 for subnet %s %v", subnet.Name, err)
+			return err
+		}
+		desiredPolicies[logicalRouterPolicyKey(physicalGatewayPolicyPriority, match3)] = struct{}{}
+	}
+	if err := c.deleteStaleU2ORoutePolicies(subnet, desiredPolicies); err != nil {
+		return err
+	}
+	return nil
+}
+
+func logicalRouterPolicyKey(priority int, match string) string {
+	return fmt.Sprintf("%d/%s", priority, match)
+}
+
+func u2oOverlayCIDRsAddressSetNames(vpcName string) (string, string) {
+	v4Name := strings.ReplaceAll(fmt.Sprintf(util.U2OOverlayCIDRs, vpcName, "ip4"), "-", ".")
+	v6Name := strings.ReplaceAll(fmt.Sprintf(util.U2OOverlayCIDRs, vpcName, "ip6"), "-", ".")
+	return v4Name, v6Name
+}
+
+func u2oOverlayCIDRsAddressSetExternalIDs(vpcName string) map[string]string {
+	// These ExternalIDs mark OVN address sets that cache overlay CIDRs per VPC.
+	// They are resource ownership metadata for lookup/debugging, not route policy labels.
+	return map[string]string{
+		"isU2OOverlayCIDRs": "true",
+		"vpc":               vpcName,
+	}
+}
+
+func (c *Controller) syncU2OOverlayCIDRsAddressSet(vpcName, excludeSubnet string) (v4CIDRs, v6CIDRs []string, err error) {
+	if vpcName == "" {
+		return nil, nil, nil
+	}
+
+	v4Name, v6Name := u2oOverlayCIDRsAddressSetNames(vpcName)
+	externalIDs := u2oOverlayCIDRsAddressSetExternalIDs(vpcName)
+	if v4CIDRs, v6CIDRs, err = c.buildU2OOverlayCIDRs(vpcName, excludeSubnet); err != nil {
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.CreateAddressSet(v4Name, externalIDs); err != nil {
+		klog.Errorf("create address set %s: %v", v4Name, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.CreateAddressSet(v6Name, externalIDs); err != nil {
+		klog.Errorf("create address set %s: %v", v6Name, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.AddressSetUpdateAddress(v4Name, v4CIDRs...); err != nil {
+		klog.Errorf("set v4 address set %s with address %v: %v", v4Name, v4CIDRs, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.AddressSetUpdateAddress(v6Name, v6CIDRs...); err != nil {
+		klog.Errorf("set v6 address set %s with address %v: %v", v6Name, v6CIDRs, err)
+		return nil, nil, err
+	}
+	return v4CIDRs, v6CIDRs, nil
+}
+
+func (c *Controller) buildU2OOverlayCIDRs(vpcName, excludeSubnet string) (v4CIDRs, v6CIDRs []string, err error) {
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets: %v", err)
+		return nil, nil, err
+	}
+
+	for _, subnet := range subnets {
+		if subnet.Name == excludeSubnet || subnet.Spec.Vpc != vpcName || subnet.Spec.Vlan != "" {
+			continue
+		}
+		for cidr := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+			switch util.CheckProtocol(cidr) {
+			case kubeovnv1.ProtocolIPv4:
+				v4CIDRs = append(v4CIDRs, cidr)
+			case kubeovnv1.ProtocolIPv6:
+				v6CIDRs = append(v6CIDRs, cidr)
+			}
+		}
+	}
+	return v4CIDRs, v6CIDRs, nil
+}
+
+func (c *Controller) deleteStaleU2ORoutePolicies(subnet *kubeovnv1.Subnet, desiredPolicies map[string]struct{}) error {
+	lr := subnet.Status.U2OInterconnectionVPC
+	if lr == "" {
+		lr = subnet.Spec.Vpc
+	}
+	if !c.logicalRouterExists(lr) {
+		return nil
+	}
+
+	policies, err := c.OVNNbClient.ListLogicalRouterPolicies(lr, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true)
+	if err != nil {
+		klog.Errorf("failed to list u2o logical router policies: %v", err)
+		return err
+	}
+	for _, policy := range policies {
+		// No-LB U2O policies are managed by add/deletePolicyRouteForU2ONoLoadBalancer.
+		// They share the generic isU2ORoutePolicy label, so skip them here to avoid
+		// deleting policies that are outside this reconcile loop.
+		if policy.ExternalIDs["isU2ONoLBRoutePolicy"] == "true" {
+			continue
+		}
+		if _, ok := desiredPolicies[logicalRouterPolicyKey(policy.Priority, policy.Match)]; ok {
+			continue
+		}
+		klog.Infof("delete stale u2o policy for router %s with match %s priority %d", lr, policy.Match, policy.Priority)
+		if err := c.OVNNbClient.DeleteLogicalRouterPolicyByUUID(lr, policy.UUID); err != nil {
+			klog.Errorf("failed to delete stale u2o policy for subnet %s: %v", subnet.Name, err)
 			return err
 		}
 	}

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -403,6 +403,90 @@ func TestAddPolicyRouteForU2OInterconn_LegacyRoutingDeletesOverlayOnlyPolicies(t
 	require.NoError(t, err)
 }
 
+func TestSyncU2OOverlayCIDRsAddressSet_UpdatesAfterOverlaySubnetDeletion(t *testing.T) {
+	t.Parallel()
+
+	const (
+		vpcName      = util.DefaultVpc
+		overlayAName = "overlay-a"
+		overlayBName = "overlay-b"
+		underlayName = "underlay-a"
+		overlayAV4   = "10.244.0.0/16"
+		overlayAV6   = "fd00:244::/64"
+		overlayBV4   = "10.245.0.0/16"
+		overlayBV6   = "fd00:245::/64"
+		underlayCIDR = "10.16.1.0/24"
+		underlayVlan = "vlan1"
+	)
+
+	overlayA := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: overlayAName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       vpcName,
+			CIDRBlock: overlayAV4 + "," + overlayAV6,
+		},
+	}
+	overlayB := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: overlayBName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       vpcName,
+			CIDRBlock: overlayBV4 + "," + overlayBV6,
+		},
+	}
+	underlay := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: underlayName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       vpcName,
+			Vlan:      underlayVlan,
+			CIDRBlock: underlayCIDR,
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{overlayA, overlayB, underlay},
+	})
+	require.NoError(t, err)
+
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(vpcName)
+	overlayExternalIDs := u2oOverlayCIDRsAddressSetExternalIDs(vpcName)
+
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs4Ag, overlayExternalIDs).Return(nil).Times(2)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs6Ag, overlayExternalIDs).Return(nil).Times(2)
+	mockOvnClient.EXPECT().
+		AddressSetUpdateAddress(overlayCIDRs4Ag, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ string, addresses ...string) error {
+			require.ElementsMatch(t, []string{overlayAV4, overlayBV4}, addresses)
+			return nil
+		})
+	mockOvnClient.EXPECT().
+		AddressSetUpdateAddress(overlayCIDRs6Ag, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ string, addresses ...string) error {
+			require.ElementsMatch(t, []string{overlayAV6, overlayBV6}, addresses)
+			return nil
+		})
+	mockOvnClient.EXPECT().
+		AddressSetUpdateAddress(overlayCIDRs4Ag, overlayAV4).
+		Return(nil)
+	mockOvnClient.EXPECT().
+		AddressSetUpdateAddress(overlayCIDRs6Ag, overlayAV6).
+		Return(nil)
+
+	v4CIDRs, v6CIDRs, err := ctrl.syncU2OOverlayCIDRsAddressSet(vpcName, "")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{overlayAV4, overlayBV4}, v4CIDRs)
+	require.ElementsMatch(t, []string{overlayAV6, overlayBV6}, v6CIDRs)
+
+	err = fc.fakeInformers.subnetInformer.Informer().GetStore().Delete(overlayB)
+	require.NoError(t, err)
+
+	v4CIDRs, v6CIDRs, err = ctrl.syncU2OOverlayCIDRsAddressSet(vpcName, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{overlayAV4}, v4CIDRs)
+	require.Equal(t, []string{overlayAV6}, v6CIDRs)
+}
+
 func Test_reconcileVips(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,6 +108,299 @@ func Test_readyToRemoveFinalizer(t *testing.T) {
 			require.Equal(t, tc.want, readyToRemoveFinalizer(tc.subnet))
 		})
 	}
+}
+
+func TestAddPolicyRouteForU2OInterconn_OverlayOnlyRouting(t *testing.T) {
+	t.Parallel()
+
+	const (
+		subnetName  = "subnet-a"
+		overlayName = "overlay-a"
+		vlanName    = "vlan1"
+		cidr        = "10.16.1.0/24"
+		overlayCIDR = "10.244.0.0/16"
+		gateway     = "10.16.1.1"
+	)
+
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:                util.DefaultVpc,
+			Vlan:               vlanName,
+			CIDRBlock:          cidr,
+			Gateway:            gateway,
+			U2OInterconnection: true,
+			U2OFeatures: kubeovnv1.U2OFeatures{
+				OverlayOnlyRouting: true,
+			},
+		},
+		Status: kubeovnv1.SubnetStatus{
+			U2OInterconnectionVPC: util.DefaultVpc,
+		},
+	}
+	overlaySubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: overlayName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       util.DefaultVpc,
+			CIDRBlock: overlayCIDR,
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{subnet, overlaySubnet},
+	})
+	require.NoError(t, err)
+
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	overlayExternalIDs := u2oOverlayCIDRsAddressSetExternalIDs(subnet.Spec.Vpc)
+	overlayPolicyExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{
+		"isU2ORoutePolicy":            "true",
+		"isU2OOverlayOnlyRoutePolicy": "true",
+	})
+	routeExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{"isU2ORoutePolicy": "true"})
+
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP4Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP6Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs4Ag, overlayExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs6Ag, overlayExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs4Ag, overlayCIDR).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs6Ag).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSubnetPolicyPriority, fmt.Sprintf("ip4.src == $%s && ip4.dst == %s", overlayCIDRs4Ag, cidr), string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.SubnetRouterPolicyPriority, fmt.Sprintf("ip4.dst == $%s && ip4.src == %s", u2oExcludeIP4Ag, cidr), string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSameSubnetPolicyPriority, fmt.Sprintf("ip4.src == %s && ip4.dst == %s", cidr, cidr), string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OPhysicalGatewayPolicyPriority, fmt.Sprintf("ip4.src == %s", cidr), string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().GetLogicalRouter(util.DefaultVpc, true).Return(&ovnnb.LogicalRouter{Name: util.DefaultVpc}, nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies(util.DefaultVpc, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true).Return(nil, nil)
+
+	err = ctrl.addPolicyRouteForU2OInterconn(subnet)
+	require.NoError(t, err)
+}
+
+func TestAddPolicyRouteForU2OInterconn_OverlayOnlyRoutingDeletesLegacyPolicies(t *testing.T) {
+	t.Parallel()
+
+	const (
+		subnetName  = "subnet-a"
+		overlayName = "overlay-a"
+		vlanName    = "vlan1"
+		cidr        = "10.16.1.0/24"
+		overlayCIDR = "10.244.0.0/16"
+		gateway     = "10.16.1.1"
+	)
+
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:                util.DefaultVpc,
+			Vlan:               vlanName,
+			CIDRBlock:          cidr,
+			Gateway:            gateway,
+			U2OInterconnection: true,
+			U2OFeatures: kubeovnv1.U2OFeatures{
+				OverlayOnlyRouting: true,
+			},
+		},
+		Status: kubeovnv1.SubnetStatus{
+			U2OInterconnectionVPC: util.DefaultVpc,
+		},
+	}
+	overlaySubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: overlayName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       util.DefaultVpc,
+			CIDRBlock: overlayCIDR,
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{subnet, overlaySubnet},
+	})
+	require.NoError(t, err)
+
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	overlayExternalIDs := u2oOverlayCIDRsAddressSetExternalIDs(subnet.Spec.Vpc)
+	overlayPolicyExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{
+		"isU2ORoutePolicy":            "true",
+		"isU2OOverlayOnlyRoutePolicy": "true",
+	})
+	routeExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{"isU2ORoutePolicy": "true"})
+
+	legacyAllowMatch := fmt.Sprintf("ip4.dst == %s", cidr)
+	legacyNodeMatch := fmt.Sprintf("ip4.dst == $%s && ip4.src == %s", u2oExcludeIP4Ag, cidr)
+	overlayToUnderlayMatch := fmt.Sprintf("ip4.src == $%s && ip4.dst == %s", overlayCIDRs4Ag, cidr)
+	underlayToOverlayMatch := fmt.Sprintf("ip4.src == %s && ip4.dst == $%s", cidr, overlayCIDRs4Ag)
+	sameSubnetMatch := fmt.Sprintf("ip4.src == %s && ip4.dst == %s", cidr, cidr)
+	physicalGwMatch := fmt.Sprintf("ip4.src == %s", cidr)
+
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP4Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP6Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs4Ag, overlayExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs6Ag, overlayExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs4Ag, overlayCIDR).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs6Ag).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSubnetPolicyPriority, overlayToUnderlayMatch, string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.SubnetRouterPolicyPriority, legacyNodeMatch, string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSameSubnetPolicyPriority, sameSubnetMatch, string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OPhysicalGatewayPolicyPriority, physicalGwMatch, string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().GetLogicalRouter(util.DefaultVpc, true).Return(&ovnnb.LogicalRouter{Name: util.DefaultVpc}, nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies(util.DefaultVpc, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true).Return([]*ovnnb.LogicalRouterPolicy{
+		{
+			UUID:     "legacy-allow",
+			Priority: util.U2OSubnetPolicyPriority,
+			Match:    legacyAllowMatch,
+		},
+		{
+			UUID:     "legacy-node",
+			Priority: util.SubnetRouterPolicyPriority,
+			Match:    legacyNodeMatch,
+		},
+		{
+			UUID:     "overlay-to-underlay",
+			Priority: util.U2OSubnetPolicyPriority,
+			Match:    overlayToUnderlayMatch,
+		},
+		{
+			UUID:     "underlay-to-overlay",
+			Priority: util.U2OSubnetPolicyPriority,
+			Match:    underlayToOverlayMatch,
+		},
+		{
+			UUID:     "old-physical-gw",
+			Priority: util.GatewayRouterPolicyPriority,
+			Match:    physicalGwMatch,
+		},
+		{
+			UUID:     "physical-gw",
+			Priority: util.U2OPhysicalGatewayPolicyPriority,
+			Match:    physicalGwMatch,
+		},
+		{
+			UUID:     "same-subnet",
+			Priority: util.U2OSameSubnetPolicyPriority,
+			Match:    sameSubnetMatch,
+		},
+	}, nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "legacy-allow").Return(nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "underlay-to-overlay").Return(nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "old-physical-gw").Return(nil)
+
+	err = ctrl.addPolicyRouteForU2OInterconn(subnet)
+	require.NoError(t, err)
+}
+
+func TestAddPolicyRouteForU2OInterconn_LegacyRoutingDeletesOverlayOnlyPolicies(t *testing.T) {
+	t.Parallel()
+
+	const (
+		subnetName = "subnet-a"
+		vlanName   = "vlan1"
+		cidr       = "10.16.1.0/24"
+		gateway    = "10.16.1.1"
+	)
+
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:                util.DefaultVpc,
+			Vlan:               vlanName,
+			CIDRBlock:          cidr,
+			Gateway:            gateway,
+			U2OInterconnection: true,
+		},
+		Status: kubeovnv1.SubnetStatus{
+			U2OInterconnectionVPC: util.DefaultVpc,
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{subnet},
+	})
+	require.NoError(t, err)
+
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
+	overlayCIDRs4Ag, _ := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	routeExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{"isU2ORoutePolicy": "true"})
+
+	legacyAllowMatch := fmt.Sprintf("ip4.dst == %s", cidr)
+	legacyNodeMatch := fmt.Sprintf("ip4.dst == $%s && ip4.src == %s", u2oExcludeIP4Ag, cidr)
+	physicalGwMatch := fmt.Sprintf("ip4.src == %s", cidr)
+	overlayToUnderlayMatch := fmt.Sprintf("ip4.src == $%s && ip4.dst == %s", overlayCIDRs4Ag, cidr)
+	underlayToOverlayMatch := fmt.Sprintf("ip4.src == %s && ip4.dst == $%s", cidr, overlayCIDRs4Ag)
+	sameSubnetMatch := fmt.Sprintf("ip4.src == %s && ip4.dst == %s", cidr, cidr)
+
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP4Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP6Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSubnetPolicyPriority, legacyAllowMatch, string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.SubnetRouterPolicyPriority, legacyNodeMatch, string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.GatewayRouterPolicyPriority, physicalGwMatch, string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().GetLogicalRouter(util.DefaultVpc, true).Return(&ovnnb.LogicalRouter{Name: util.DefaultVpc}, nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies(util.DefaultVpc, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true).Return([]*ovnnb.LogicalRouterPolicy{
+		{
+			UUID:     "legacy-allow",
+			Priority: util.U2OSubnetPolicyPriority,
+			Match:    legacyAllowMatch,
+		},
+		{
+			UUID:     "legacy-node",
+			Priority: util.SubnetRouterPolicyPriority,
+			Match:    legacyNodeMatch,
+		},
+		{
+			UUID:     "physical-gw",
+			Priority: util.GatewayRouterPolicyPriority,
+			Match:    physicalGwMatch,
+		},
+		{
+			UUID:     "overlay-to-underlay",
+			Priority: util.U2OSubnetPolicyPriority,
+			Match:    overlayToUnderlayMatch,
+		},
+		{
+			UUID:     "underlay-to-overlay",
+			Priority: util.U2OSubnetPolicyPriority,
+			Match:    underlayToOverlayMatch,
+		},
+		{
+			UUID:     "overlay-only-physical-gw",
+			Priority: util.U2OPhysicalGatewayPolicyPriority,
+			Match:    physicalGwMatch,
+		},
+		{
+			UUID:     "overlay-only-same-subnet",
+			Priority: util.U2OSameSubnetPolicyPriority,
+			Match:    sameSubnetMatch,
+		},
+	}, nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "overlay-to-underlay").Return(nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "underlay-to-overlay").Return(nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "overlay-only-physical-gw").Return(nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "overlay-only-same-subnet").Return(nil)
+
+	err = ctrl.addPolicyRouteForU2OInterconn(subnet)
+	require.NoError(t, err)
 }
 
 func Test_reconcileVips(t *testing.T) {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -264,6 +264,8 @@ const (
 	U2OSubnetPolicyPriority          = 29400
 	OvnICPolicyPriority              = 29500
 	NodeRouterPolicyPriority         = 30000
+	U2OPhysicalGatewayPolicyPriority = 30050
+	U2OSameSubnetPolicyPriority      = 30060
 	NodeLocalDNSPolicyPriority       = 30100
 	SubnetRouterPolicyPriority       = 31000
 
@@ -308,6 +310,7 @@ const (
 
 	U2OInterconnName = "u2o-interconnection.%s.%s"
 	U2OExcludeIPAg   = "%s.u2o_exclude_ip.%s"
+	U2OOverlayCIDRs  = "%s.u2o_overlay_cidrs.%s"
 
 	McastQuerierName = "mcast-querier.%s"
 

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -183,6 +183,15 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		return errors.New("logicalGateway and u2oInterconnection can't be opened at the same time")
 	}
 
+	if subnet.Spec.U2OFeatures.OverlayOnlyRouting {
+		if !subnet.Spec.U2OInterconnection {
+			return errors.New("u2oFeatures.overlayOnlyRouting can only be enabled when u2OInterconnection is true")
+		}
+		if subnet.Spec.Vlan == "" {
+			return errors.New("u2oFeatures.overlayOnlyRouting can only be enabled on underlay subnets (vlan must be set)")
+		}
+	}
+
 	if len(subnet.Spec.NatOutgoingPolicyRules) != 0 {
 		if err := validateNatOutgoingPolicyRules(subnet); err != nil {
 			klog.Error(err)

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -262,6 +262,72 @@ func TestValidateSubnet(t *testing.T) {
 			err: "logicalGateway and u2oInterconnection can't be opened at the same time",
 		},
 		{
+			name: "U2OOverlayOnlyRoutingWithoutU2OErr",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-without-u2o",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolIPv4,
+					CIDRBlock:   "10.16.0.0/16",
+					Gateway:     "10.16.0.1",
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Vlan:        "vlan1",
+					U2OFeatures: kubeovnv1.U2OFeatures{
+						OverlayOnlyRouting: true,
+					},
+				},
+			},
+			err: "u2oFeatures.overlayOnlyRouting can only be enabled when u2OInterconnection is true",
+		},
+		{
+			name: "U2OOverlayOnlyRoutingWithoutVlanErr",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-without-vlan",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:            true,
+					Vpc:                DefaultVpc,
+					Protocol:           kubeovnv1.ProtocolIPv4,
+					CIDRBlock:          "10.16.0.0/16",
+					Gateway:            "10.16.0.1",
+					Provider:           OvnProvider,
+					GatewayType:        kubeovnv1.GWDistributedType,
+					U2OInterconnection: true,
+					U2OFeatures: kubeovnv1.U2OFeatures{
+						OverlayOnlyRouting: true,
+					},
+				},
+			},
+			err: "u2oFeatures.overlayOnlyRouting can only be enabled on underlay subnets (vlan must be set)",
+		},
+		{
+			name: "U2OOverlayOnlyRoutingCorrect",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-correct",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:            true,
+					Vpc:                DefaultVpc,
+					Protocol:           kubeovnv1.ProtocolIPv4,
+					CIDRBlock:          "10.16.0.0/16",
+					Gateway:            "10.16.0.1",
+					Provider:           OvnProvider,
+					GatewayType:        kubeovnv1.GWDistributedType,
+					Vlan:               "vlan1",
+					U2OInterconnection: true,
+					U2OFeatures: kubeovnv1.U2OFeatures{
+						OverlayOnlyRouting: true,
+					},
+				},
+			},
+		},
+		{
 			name: "ValidateNatOutgoingPolicyRulesErr",
 			subnet: kubeovnv1.Subnet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -13,7 +13,9 @@ import (
 	dockernetwork "github.com/moby/moby/api/types/network"
 	"github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
@@ -31,8 +33,9 @@ import (
 )
 
 const (
-	dockerNetworkName = "kube-ovn-vlan"
-	curlListenPort    = 8081
+	dockerNetworkName            = "kube-ovn-vlan"
+	curlListenPort               = 8081
+	underlayReservedStartIPCount = 20
 )
 
 func makeProviderNetwork(providerNetworkName string, exchangeLinkName bool, linkMap map[string]*iproute.Link) *apiv1.ProviderNetwork {
@@ -53,6 +56,15 @@ func makeProviderNetwork(providerNetworkName string, exchangeLinkName bool, link
 	return framework.MakeProviderNetwork(providerNetworkName, exchangeLinkName, defaultInterface, customInterfaces, nil)
 }
 
+func nodeDockerNetworkSettings(node kind.Node, networkID string) *dockernetwork.EndpointSettings {
+	for _, settings := range node.NetworkSettings.Networks {
+		if settings != nil && settings.NetworkID == networkID {
+			return settings
+		}
+	}
+	return nil
+}
+
 func waitSubnetStatusUpdate(subnetName string, subnetClient *framework.SubnetClient, expectedUsingIPs int64) {
 	ginkgo.GinkgoHelper()
 
@@ -67,6 +79,124 @@ func waitSubnetStatusUpdate(subnetName string, subnetClient *framework.SubnetCli
 		}
 		return true, nil
 	}, fmt.Sprintf("using IPs count of subnet %s to be %d", subnetName, expectedUsingIPs))
+}
+
+func waitServiceEndpointsReady(cs clientset.Interface, namespace, serviceName string) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By("Waiting for endpoints " + serviceName + " to be ready")
+	framework.WaitUntil(time.Second, time.Minute, func(_ context.Context) (bool, error) {
+		eps, err := cs.CoreV1().Endpoints(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+		if err == nil {
+			for _, subset := range eps.Subsets {
+				if len(subset.Addresses) > 0 {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}, fmt.Sprintf("endpoints %s has at least one ready address", serviceName))
+}
+
+func underlayExcludeIPs(f *framework.Framework, network *dockernetwork.Inspect, nodes []kind.Node, networkID string) []string {
+	ginkgo.GinkgoHelper()
+
+	excludeIPs := make([]string, 0, len(network.Containers)*2+len(nodes)*2)
+	seen := make(map[string]struct{}, cap(excludeIPs))
+	appendIP := func(ip string) {
+		if ip == "" {
+			return
+		}
+		if _, ok := seen[ip]; ok {
+			return
+		}
+		seen[ip] = struct{}{}
+		excludeIPs = append(excludeIPs, ip)
+	}
+
+	for _, container := range network.Containers {
+		if container.IPv4Address.IsValid() && f.HasIPv4() {
+			appendIP(container.IPv4Address.Addr().String())
+		}
+		if container.IPv6Address.IsValid() && f.HasIPv6() {
+			appendIP(container.IPv6Address.Addr().String())
+		}
+	}
+
+	for _, node := range nodes {
+		networkSettings := nodeDockerNetworkSettings(node, networkID)
+		framework.ExpectNotNil(networkSettings, "node %s should be connected to docker network %s", node.Name(), dockerNetworkName)
+		if networkSettings.IPAddress.IsValid() && f.HasIPv4() {
+			appendIP(networkSettings.IPAddress.String())
+		}
+		if networkSettings.GlobalIPv6Address.IsValid() && f.HasIPv6() {
+			appendIP(networkSettings.GlobalIPv6Address.String())
+		}
+	}
+
+	return excludeIPs
+}
+
+func reservedStartIPsForCIDRBlock(cidrBlock string, count int) []string {
+	ginkgo.GinkgoHelper()
+
+	if count <= 0 {
+		return nil
+	}
+
+	excludeIPs := make([]string, 0, 2)
+	for cidr := range strings.SplitSeq(cidrBlock, ",") {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		framework.ExpectNoError(err)
+		ipRange := ipam.NewIPRangeFromCIDR(*ipNet)
+
+		firstIP, err := util.FirstIP(cidr)
+		framework.ExpectNoError(err)
+		start, err := ipam.NewIP(firstIP)
+		framework.ExpectNoError(err)
+
+		end := start.Add(int64(count - 1))
+		if ipRange.End().LessThan(end) {
+			end = ipRange.End()
+		}
+
+		if start.Equal(end) {
+			excludeIPs = append(excludeIPs, start.String())
+		} else {
+			excludeIPs = append(excludeIPs, start.String()+".."+end.String())
+		}
+	}
+
+	return excludeIPs
+}
+
+func removeNodeIPsFromProviderBridge(providerNetworkName string, nodes []kind.Node) {
+	ginkgo.GinkgoHelper()
+
+	bridgeName := util.ExternalBridgeName(providerNetworkName)
+	for _, node := range nodes {
+		links, err := node.ListLinks()
+		framework.ExpectNoError(err, "failed to list links on node %s: %v", node.Name(), err)
+
+		var bridge *iproute.Link
+		for i, link := range links {
+			if link.IfName == bridgeName {
+				bridge = &links[i]
+				break
+			}
+		}
+		framework.ExpectNotNil(bridge, "bridge %s should exist on node %s", bridgeName, node.Name())
+
+		for _, addr := range bridge.NonLinkLocalAddresses() {
+			ginkgo.By(fmt.Sprintf("Deleting node IP %s from provider bridge %s on node %s", addr, bridgeName, node.Name()))
+			err = iproute.AddressDel(bridgeName, addr, node.Exec)
+			framework.ExpectNoError(err, "failed to delete address %s from bridge %s on node %s", addr, bridgeName, node.Name())
+		}
+	}
 }
 
 func waitSubnetU2OStatus(f *framework.Framework, subnetName string, subnetClient *framework.SubnetClient, enableU2O bool) {
@@ -110,7 +240,8 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 	var nodeNames []string
 	var clusterName, providerNetworkName, providerNetworkName2, vlanName, subnetName, podName, namespaceName, netpolName string
 	var vpcName string
-	var u2oPodNameUnderlay, u2oOverlaySubnetName, u2oPodNameOverlay, u2oOverlaySubnetNameCustomVPC, u2oPodOverlayCustomVPC string
+	var u2oPodNameUnderlay, sameSubnetUnderlayPodName, sameSubnetOverlayPodName, u2oOverlaySubnetName, u2oPodNameOverlay, u2oOverlaySubnetNameCustomVPC, u2oPodOverlayCustomVPC, overlayOnlyOverlaySubnetName string
+	var clusterIPServiceName, overlayClusterIPServiceName string
 	var linkMap map[string]*iproute.Link
 	var routeMap map[string][]iproute.Route
 	var eventClient *framework.EventClient
@@ -137,15 +268,20 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		podName = "pod-" + framework.RandomSuffix()
 		u2oPodNameOverlay = "pod-" + framework.RandomSuffix()
 		u2oPodNameUnderlay = "pod-" + framework.RandomSuffix()
+		sameSubnetUnderlayPodName = "pod-" + framework.RandomSuffix()
+		sameSubnetOverlayPodName = "pod-" + framework.RandomSuffix()
 		u2oPodOverlayCustomVPC = "pod-" + framework.RandomSuffix()
 		subnetName = "subnet-" + framework.RandomSuffix()
 		u2oOverlaySubnetName = "subnet-" + framework.RandomSuffix()
 		u2oOverlaySubnetNameCustomVPC = "subnet-" + framework.RandomSuffix()
+		overlayOnlyOverlaySubnetName = "subnet-" + framework.RandomSuffix()
 		vlanName = "vlan-" + framework.RandomSuffix()
 		providerNetworkName = "pn-" + framework.RandomSuffix()
 		providerNetworkName2 = "p2-" + framework.RandomSuffix()
 		vpcName = "vpc-" + framework.RandomSuffix()
 		netpolName = "netpol-" + framework.RandomSuffix()
+		clusterIPServiceName = "svc-" + framework.RandomSuffix()
+		overlayClusterIPServiceName = "svc-" + framework.RandomSuffix()
 		containerID = ""
 		conflictVlan1Name = "conflict-vlan1-" + framework.RandomSuffix()
 		conflictVlanSubnet1Name = "conflict-vlan-subnet1-" + framework.RandomSuffix()
@@ -192,6 +328,9 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		routeMap = make(map[string][]iproute.Route, len(nodes))
 		nodeNames = make([]string, 0, len(nodes))
 		for _, node := range nodes {
+			networkSettings := nodeDockerNetworkSettings(node, dockerNetwork.ID)
+			framework.ExpectNotNil(networkSettings, "node %s should be connected to docker network %s", node.Name(), dockerNetworkName)
+
 			links, err := node.ListLinks()
 			framework.ExpectNoError(err, "failed to list links on node %s: %v", node.Name(), err)
 
@@ -199,7 +338,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 			framework.ExpectNoError(err, "failed to list routes on node %s: %v", node.Name(), err)
 
 			for _, link := range links {
-				if link.Address == node.NetworkSettings.Networks[dockerNetworkName].MacAddress.String() {
+				if link.Address == networkSettings.MacAddress.String() {
 					linkMap[node.ID] = &link
 					break
 				}
@@ -207,6 +346,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 			framework.ExpectHaveKey(linkMap, node.ID)
 
 			link := linkMap[node.ID]
+			routeMap[node.ID] = []iproute.Route{}
 			for _, route := range routes {
 				if route.Dev == link.IfName {
 					r := iproute.Route{
@@ -218,7 +358,6 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 					routeMap[node.ID] = append(routeMap[node.ID], r)
 				}
 			}
-			framework.ExpectHaveKey(routeMap, node.ID)
 
 			linkMap[node.Name()] = linkMap[node.ID]
 			routeMap[node.Name()] = routeMap[node.ID]
@@ -359,17 +498,32 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		ginkgo.By("Deleting pod " + u2oPodNameUnderlay)
 		podClient.DeleteSync(u2oPodNameUnderlay)
 
+		ginkgo.By("Deleting pod " + sameSubnetUnderlayPodName)
+		podClient.DeleteSync(sameSubnetUnderlayPodName)
+
 		ginkgo.By("Deleting pod " + u2oPodNameOverlay)
 		podClient.DeleteSync(u2oPodNameOverlay)
 
+		ginkgo.By("Deleting pod " + sameSubnetOverlayPodName)
+		podClient.DeleteSync(sameSubnetOverlayPodName)
+
 		ginkgo.By("Deleting pod " + u2oPodOverlayCustomVPC)
 		podClient.DeleteSync(u2oPodOverlayCustomVPC)
+
+		ginkgo.By("Deleting service " + clusterIPServiceName)
+		f.ServiceClientNS(namespaceName).DeleteSync(clusterIPServiceName)
+
+		ginkgo.By("Deleting service " + overlayClusterIPServiceName)
+		f.ServiceClientNS(namespaceName).DeleteSync(overlayClusterIPServiceName)
 
 		ginkgo.By("Deleting subnet " + u2oOverlaySubnetNameCustomVPC)
 		subnetClient.DeleteSync(u2oOverlaySubnetNameCustomVPC)
 
 		ginkgo.By("Deleting subnet " + u2oOverlaySubnetName)
 		subnetClient.DeleteSync(u2oOverlaySubnetName)
+
+		ginkgo.By("Deleting subnet " + overlayOnlyOverlaySubnetName)
+		subnetClient.DeleteSync(overlayOnlyOverlaySubnetName)
 
 		ginkgo.By("Deleting subnet " + subnetName)
 		subnetClient.DeleteSync(subnetName)
@@ -620,7 +774,6 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 			underlayCidr = append(underlayCidr, cidrV6)
 			gateway = append(gateway, gatewayV6)
 		}
-
 		excludeIPs := make([]string, 0, len(network.Containers)*2)
 		for _, container := range network.Containers {
 			if container.IPv4Address.IsValid() && f.HasIPv4() {
@@ -887,6 +1040,381 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 		ginkgo.By("10. waiting for U2OInterconnection status of subnet " + subnetName + " to be false")
 		waitSubnetU2OStatus(f, subnetName, subnetClient, false)
 		checkU2OItems(f, subnet, underlayPod, overlayPod, false)
+	})
+
+	framework.ConformanceIt("should support U2O overlay only routing", func() {
+		f.SkipVersionPriorTo(1, 14, "overlayOnlyRouting was introduced in v1.14")
+
+		ginkgo.By("Creating provider network " + providerNetworkName)
+		pn := makeProviderNetwork(providerNetworkName, false, linkMap)
+		_ = providerNetworkClient.CreateSync(pn)
+
+		ginkgo.By("Getting kind nodes")
+		kindNodes, err := kind.ListNodes(clusterName, "")
+		framework.ExpectNoError(err, "getting nodes in kind cluster")
+		removeNodeIPsFromProviderBridge(providerNetworkName, kindNodes)
+
+		ginkgo.By("Getting docker network " + dockerNetworkName)
+		network, err := docker.NetworkInspect(dockerNetworkName)
+		framework.ExpectNoError(err, "getting docker network "+dockerNetworkName)
+
+		ginkgo.By("Creating vlan " + vlanName)
+		vlan := framework.MakeVlan(vlanName, providerNetworkName, 0)
+		_ = vlanClient.Create(vlan)
+
+		var cidrV4, cidrV6, gatewayV4, gatewayV6 string
+		for _, config := range dockerNetwork.IPAM.Config {
+			switch util.CheckProtocol(config.Subnet.String()) {
+			case apiv1.ProtocolIPv4:
+				if f.HasIPv4() {
+					cidrV4 = config.Subnet.String()
+					gatewayV4 = config.Gateway.String()
+				}
+			case apiv1.ProtocolIPv6:
+				if f.HasIPv6() {
+					cidrV6 = config.Subnet.String()
+					gatewayV6 = config.Gateway.String()
+				}
+			}
+		}
+		underlayCidr := make([]string, 0, 2)
+		gateway := make([]string, 0, 2)
+		if f.HasIPv4() {
+			underlayCidr = append(underlayCidr, cidrV4)
+			gateway = append(gateway, gatewayV4)
+		}
+		if f.HasIPv6() {
+			underlayCidr = append(underlayCidr, cidrV6)
+			gateway = append(gateway, gatewayV6)
+		}
+		framework.ExpectNotEmpty(underlayCidr)
+		framework.ExpectNotEmpty(gateway)
+
+		excludeIPs := underlayExcludeIPs(f, network, kindNodes, dockerNetwork.ID)
+		excludeIPs = append(excludeIPs, reservedStartIPsForCIDRBlock(strings.Join(underlayCidr, ","), underlayReservedStartIPCount)...)
+
+		ginkgo.By("Creating underlay subnet " + subnetName + " with overlayOnlyRouting")
+		subnet := framework.MakeSubnet(subnetName, vlanName, strings.Join(underlayCidr, ","), strings.Join(gateway, ","), "", "", excludeIPs, nil, []string{namespaceName})
+		subnet.Spec.U2OInterconnection = true
+		subnet.Spec.U2OFeatures.OverlayOnlyRouting = true
+		subnet = subnetClient.CreateSync(subnet)
+		waitSubnetU2OStatus(f, subnetName, subnetClient, true)
+
+		args := []string{"netexec", "--http-port", strconv.Itoa(curlListenPort)}
+		ginkgo.By("Creating underlay pod " + u2oPodNameUnderlay)
+		underlayLabels := map[string]string{"app": u2oPodNameUnderlay}
+		underlayPod := framework.MakePod(namespaceName, u2oPodNameUnderlay, nil, map[string]string{
+			util.LogicalSwitchAnnotation: subnet.Name,
+		}, framework.AgnhostImage, nil, args)
+		underlayPod.Labels = underlayLabels
+		underlayPod = podClient.CreateSync(underlayPod)
+		waitSubnetStatusUpdate(subnet.Name, subnetClient, 2)
+
+		sameSubnetUnderlayLabels := map[string]string{"app": sameSubnetUnderlayPodName}
+		ginkgo.By("Creating same subnet underlay pod " + sameSubnetUnderlayPodName)
+		sameSubnetUnderlayPod := framework.MakePod(namespaceName, sameSubnetUnderlayPodName, sameSubnetUnderlayLabels, map[string]string{
+			util.LogicalSwitchAnnotation: subnet.Name,
+		}, framework.AgnhostImage, nil, args)
+		sameSubnetUnderlayPod = podClient.CreateSync(sameSubnetUnderlayPod)
+		waitSubnetStatusUpdate(subnet.Name, subnetClient, 3)
+
+		ginkgo.By("Creating same underlay backend ClusterIP service " + clusterIPServiceName)
+		service := framework.MakeService(clusterIPServiceName, corev1.ServiceTypeClusterIP, nil, sameSubnetUnderlayLabels, []corev1.ServicePort{{
+			Name:       "tcp",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       curlListenPort,
+			TargetPort: intstr.FromInt(curlListenPort),
+		}}, corev1.ServiceAffinityNone)
+		service = f.ServiceClientNS(namespaceName).CreateSync(service, func(s *corev1.Service) (bool, error) {
+			return len(util.ServiceClusterIPs(*s)) != 0, nil
+		}, "cluster ip is allocated")
+		waitServiceEndpointsReady(cs, namespaceName, service.Name)
+
+		peerUnderlaySubnetName := "subnet-" + framework.RandomSuffix()
+		defer subnetClient.DeleteSync(peerUnderlaySubnetName)
+		ginkgo.By("Creating peer underlay subnet " + peerUnderlaySubnetName + " with overlayOnlyRouting")
+		peerUnderlayCIDR := framework.RandomCIDR(f.ClusterIPFamily)
+		peerUnderlayGateway := firstIPsForCIDRBlock(peerUnderlayCIDR)
+		peerUnderlaySubnet := framework.MakeSubnet(peerUnderlaySubnetName, vlanName, peerUnderlayCIDR, peerUnderlayGateway, "", "", nil, nil, nil)
+		peerUnderlaySubnet.Spec.U2OInterconnection = true
+		peerUnderlaySubnet.Spec.U2OFeatures.OverlayOnlyRouting = true
+		peerUnderlaySubnet = subnetClient.CreateSync(peerUnderlaySubnet)
+		waitSubnetU2OStatus(f, peerUnderlaySubnetName, subnetClient, true)
+
+		overlayCIDR := framework.RandomCIDR(f.ClusterIPFamily)
+		ginkgo.By("Creating overlay subnet " + overlayOnlyOverlaySubnetName)
+		overlaySubnet := framework.MakeSubnet(overlayOnlyOverlaySubnetName, "", overlayCIDR, "", "", "", nil, nil, nil)
+		overlaySubnet = subnetClient.CreateSync(overlaySubnet)
+
+		ginkgo.By("Creating overlay pod " + u2oPodNameOverlay)
+		overlayLabels := map[string]string{"app": u2oPodNameOverlay}
+		overlayPod := framework.MakePod(namespaceName, u2oPodNameOverlay, overlayLabels, map[string]string{
+			util.LogicalSwitchAnnotation: overlaySubnet.Name,
+		}, framework.AgnhostImage, nil, args)
+		overlayPod = podClient.CreateSync(overlayPod)
+
+		ginkgo.By("Creating same subnet overlay pod " + sameSubnetOverlayPodName)
+		sameSubnetOverlayPod := framework.MakePod(namespaceName, sameSubnetOverlayPodName, nil, map[string]string{
+			util.LogicalSwitchAnnotation: overlaySubnet.Name,
+		}, framework.AgnhostImage, nil, args)
+		sameSubnetOverlayPod = podClient.CreateSync(sameSubnetOverlayPod)
+
+		ginkgo.By("Creating overlay backend ClusterIP service " + overlayClusterIPServiceName)
+		overlayService := framework.MakeService(overlayClusterIPServiceName, corev1.ServiceTypeClusterIP, nil, overlayLabels, []corev1.ServicePort{{
+			Name:       "tcp",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       curlListenPort,
+			TargetPort: intstr.FromInt(curlListenPort),
+		}}, corev1.ServiceAffinityNone)
+		overlayService = f.ServiceClientNS(namespaceName).CreateSync(overlayService, func(s *corev1.Service) (bool, error) {
+			return len(util.ServiceClusterIPs(*s)) != 0, nil
+		}, "overlay backend cluster ip is allocated")
+		waitServiceEndpointsReady(cs, namespaceName, overlayService.Name)
+
+		waitSubnetU2OStatus(f, subnetName, subnetClient, true)
+		subnet = subnetClient.Get(subnetName)
+
+		overlayCIDRs4As := strings.ReplaceAll(fmt.Sprintf(util.U2OOverlayCIDRs, subnet.Spec.Vpc, "ip4"), "-", ".")
+		overlayCIDRs6As := strings.ReplaceAll(fmt.Sprintf(util.U2OOverlayCIDRs, subnet.Spec.Vpc, "ip6"), "-", ".")
+		u2oExcludeIP4As := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+		u2oExcludeIP6As := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
+		overlayV4CIDR, overlayV6CIDR := util.SplitStringIP(overlaySubnet.Spec.CIDRBlock)
+		v4Gateway, v6Gateway := util.SplitStringIP(subnet.Spec.Gateway)
+		checkOverlayOnlyPolicies := func(expectOverlayOnly bool) {
+			ginkgo.GinkgoHelper()
+
+			for cidr := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+				ipSuffix := "ip4"
+				overlayCIDRsAs := overlayCIDRs4As
+				u2oExcludeIPAs := u2oExcludeIP4As
+				overlayCIDRForProtocol := overlayV4CIDR
+				gatewayForProtocol := v4Gateway
+				if util.CheckProtocol(cidr) == apiv1.ProtocolIPv6 {
+					ipSuffix = "ip6"
+					overlayCIDRsAs = overlayCIDRs6As
+					u2oExcludeIPAs = u2oExcludeIP6As
+					overlayCIDRForProtocol = overlayV6CIDR
+					gatewayForProtocol = v6Gateway
+				}
+				if overlayCIDRForProtocol == "" {
+					continue
+				}
+
+				ginkgo.By("Checking overlay only u2o policies for " + ipSuffix)
+				checkPolicy(fmt.Sprintf("%d %s.src == $%s && %s.dst == %s allow", util.U2OSubnetPolicyPriority, ipSuffix, overlayCIDRsAs, ipSuffix, cidr), expectOverlayOnly, subnet.Spec.Vpc)
+				checkPolicy(fmt.Sprintf("%d %s.dst == $%s && %s.src == %s reroute %s", util.SubnetRouterPolicyPriority, ipSuffix, u2oExcludeIPAs, ipSuffix, cidr, gatewayForProtocol), true, subnet.Spec.Vpc)
+				checkPolicy(fmt.Sprintf("%d %s.src == %s && %s.dst == %s allow", util.U2OSameSubnetPolicyPriority, ipSuffix, cidr, ipSuffix, cidr), expectOverlayOnly, subnet.Spec.Vpc)
+				checkPolicy(fmt.Sprintf("%d %s.src == %s reroute %s", util.U2OPhysicalGatewayPolicyPriority, ipSuffix, cidr, gatewayForProtocol), expectOverlayOnly, subnet.Spec.Vpc)
+				checkPolicy(fmt.Sprintf("%d %s.src == %s reroute %s", util.GatewayRouterPolicyPriority, ipSuffix, cidr, gatewayForProtocol), !expectOverlayOnly, subnet.Spec.Vpc)
+
+				ginkgo.By("Checking legacy u2o policies for " + ipSuffix)
+				checkPolicy(fmt.Sprintf("%d %s.dst == %s allow", util.U2OSubnetPolicyPriority, ipSuffix, cidr), !expectOverlayOnly, subnet.Spec.Vpc)
+			}
+		}
+		checkOverlayOnlyReachability := func() {
+			ginkgo.GinkgoHelper()
+
+			for _, protocol := range u2oTraceProtocols(f) {
+				underlayPodIP := podIPForProtocol(underlayPod, protocol)
+				framework.ExpectNotEmpty(underlayPodIP)
+				overlayPodIP := podIPForProtocol(overlayPod, protocol)
+				framework.ExpectNotEmpty(overlayPodIP)
+
+				ginkgo.By("Checking underlay pod access to overlay pod with overlayOnlyRouting " + protocol)
+				checkReachable(underlayPod.Name, underlayPod.Namespace, underlayPodIP, overlayPodIP, strconv.Itoa(curlListenPort), true)
+
+				ginkgo.By("Checking overlay pod access to underlay pod with overlayOnlyRouting " + protocol)
+				checkReachable(overlayPod.Name, overlayPod.Namespace, overlayPodIP, underlayPodIP, strconv.Itoa(curlListenPort), true)
+
+				sameSubnetClusterIP := serviceClusterIPForProtocol(service, protocol)
+				framework.ExpectNotEmpty(sameSubnetClusterIP)
+				ginkgo.By("Checking underlay pod access to same underlay subnet backend ClusterIP with overlayOnlyRouting " + protocol)
+				checkReachable(underlayPod.Name, underlayPod.Namespace, underlayPodIP, sameSubnetClusterIP, strconv.Itoa(curlListenPort), true)
+			}
+		}
+
+		checkOverlayOnlyPolicies(true)
+		checkOverlayOnlyReachability()
+
+		ginkgo.By("Disabling overlayOnlyRouting for subnet " + subnetName)
+		modifiedSubnet := subnet.DeepCopy()
+		modifiedSubnet.Spec.U2OFeatures.OverlayOnlyRouting = false
+		subnetClient.PatchSync(subnet, modifiedSubnet)
+		waitSubnetU2OStatus(f, subnetName, subnetClient, true)
+		subnet = subnetClient.Get(subnetName)
+		checkOverlayOnlyPolicies(false)
+
+		ginkgo.By("Enabling overlayOnlyRouting again for subnet " + subnetName)
+		modifiedSubnet = subnet.DeepCopy()
+		modifiedSubnet.Spec.U2OFeatures.OverlayOnlyRouting = true
+		subnetClient.PatchSync(subnet, modifiedSubnet)
+		waitSubnetU2OStatus(f, subnetName, subnetClient, true)
+		subnet = subnetClient.Get(subnetName)
+		checkOverlayOnlyPolicies(true)
+		checkOverlayOnlyReachability()
+
+		traceProtocol := u2oTraceProtocols(f)[0]
+		traceCIDR := cidrForProtocol(subnet.Spec.CIDRBlock, traceProtocol)
+		tracePeerCIDR := cidrForProtocol(peerUnderlaySubnet.Spec.CIDRBlock, traceProtocol)
+		traceOverlayCIDR := cidrForProtocol(overlaySubnet.Spec.CIDRBlock, traceProtocol)
+		traceJoinCIDR := cidrForProtocol(subnetClient.Get("join").Spec.CIDRBlock, traceProtocol)
+		traceIPSuffix := ipSuffixForProtocol(traceProtocol)
+		traceOverlayCIDRsAs := overlayCIDRs4As
+		if traceProtocol == apiv1.ProtocolIPv6 {
+			traceOverlayCIDRsAs = overlayCIDRs6As
+		}
+		traceOverlayRouteMatch := fmt.Sprintf("%s.dst == %s", traceIPSuffix, traceOverlayCIDR)
+		traceJoinRouteMatch := fmt.Sprintf("%s.dst == %s", traceIPSuffix, traceJoinCIDR)
+		var traceNodeRouteMatch string
+		traceUnderlayNodeRouteMatch := fmt.Sprintf("%s.dst == $%s && %s.src == %s", traceIPSuffix, map[bool]string{true: u2oExcludeIP6As, false: u2oExcludeIP4As}[traceProtocol == apiv1.ProtocolIPv6], traceIPSuffix, traceCIDR)
+		traceUnderlaySameSubnetMatch := fmt.Sprintf("%s.src == %s && %s.dst == %s", traceIPSuffix, traceCIDR, traceIPSuffix, traceCIDR)
+		traceUnderlayPhysicalGwMatch := fmt.Sprintf("%s.src == %s", traceIPSuffix, traceCIDR)
+		traceOverlayToUnderlayMatch := fmt.Sprintf("%s.src == $%s && %s.dst == %s", traceIPSuffix, traceOverlayCIDRsAs, traceIPSuffix, traceCIDR)
+		traceOverlayToPeerUnderlayMatch := fmt.Sprintf("%s.src == $%s && %s.dst == %s", traceIPSuffix, traceOverlayCIDRsAs, traceIPSuffix, tracePeerCIDR)
+		traceOverlayPodIP := podIPForProtocol(overlayPod, traceProtocol)
+		framework.ExpectNotEmpty(traceOverlayPodIP)
+		traceUnderlayPodIP := podIPForProtocol(underlayPod, traceProtocol)
+		framework.ExpectNotEmpty(traceUnderlayPodIP)
+		tracePeerUnderlayIP, err := util.FirstIP(tracePeerCIDR)
+		framework.ExpectNoError(err)
+		traceSameOverlayPodIP := podIPForProtocol(sameSubnetOverlayPod, traceProtocol)
+		framework.ExpectNotEmpty(traceSameOverlayPodIP)
+
+		// overlayOnlyRouting relies on existing baseline routes for overlay and
+		// join destinations, and adds an overlay->underlay allow policy plus
+		// underlay-specific routing for node IPs, same-subnet traffic, and the
+		// physical gateway fallback. The same-subnet allow was added after
+		// reproducing that U2O gateway readiness probes could not reach the U2O IP
+		// without an explicit underlay same-subnet exception.
+		// - underlay pod -> overlay pod: hit existing 31000 dst overlay CIDR allow.
+		// - underlay pod -> U2O IP: hit 30060 src/dst underlay CIDR allow because the
+		//   U2O interconnection IP is an LRP-local destination.
+		// - underlay pod -> same underlay subnet pod: same-subnet local/L2 path, do not hit
+		//   overlay-only policy.
+		// - underlay pod -> peer underlay CIDR: hit 30050 src underlay reroute physical gw.
+		// - underlay pod -> ServiceIP backed by overlay pod: DNAT to overlay pod, then hit existing 31000 dst overlay CIDR allow.
+		// - underlay pod -> ServiceIP backed by same underlay subnet pod: DNAT to underlay pod,
+		//   then hit 30060 src/dst underlay CIDR allow.
+		// - underlay pod -> node IP: hit 31000 dst excluded IP and src underlay CIDR reroute physical gw.
+		// - underlay pod -> join IP: keep baseline behavior and hit existing 31000 dst join CIDR allow.
+		// - overlay pod -> overlay pod: do not hit overlay-only policy.
+		// - overlay pod -> underlay pod: hit overlay-to-underlay allow policy.
+		// - overlay pod -> ServiceIP backed by overlay pod: DNAT to overlay pod and do not hit overlay-only policy.
+		// - overlay pod -> ServiceIP backed by underlay pod: DNAT to underlay pod, then hit overlay-to-underlay allow policy.
+		// - overlay pod -> node IP: keep baseline behavior and hit 30000 dst node IP reroute join IP.
+		// - overlay pod -> join IP: keep baseline behavior and hit existing 31000 dst join CIDR allow.
+		ginkgo.By("Tracing underlay pod to overlay pod: should hit existing overlay CIDR route " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, underlayPod.Name, traceOverlayPodIP, "underlay to overlay "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceOverlayRouteMatch,
+			fmt.Sprintf("priority %d", util.SubnetRouterPolicyPriority),
+		})
+
+		ginkgo.By("Tracing overlay pod to underlay pod: should hit overlayOnlyRouting allow policy " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, overlayPod.Name, traceUnderlayPodIP, "overlay to underlay "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceOverlayToUnderlayMatch,
+			fmt.Sprintf("priority %d", util.U2OSubnetPolicyPriority),
+		})
+
+		u2oIPv4, u2oIPv6 := util.SplitStringIP(subnet.Status.U2OInterconnectionIP)
+		u2oIP := u2oIPv4
+		if traceProtocol == apiv1.ProtocolIPv6 {
+			u2oIP = u2oIPv6
+		}
+		framework.ExpectNotEmpty(u2oIP)
+		ginkgo.By("Tracing underlay pod to U2O IP: should hit same-subnet allow policy " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, underlayPod.Name, u2oIP, "underlay to u2o ip "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceUnderlaySameSubnetMatch,
+			fmt.Sprintf("priority %d", util.U2OSameSubnetPolicyPriority),
+		})
+
+		sameSubnetPodIP := podIPForProtocol(sameSubnetUnderlayPod, traceProtocol)
+		framework.ExpectNotEmpty(sameSubnetPodIP)
+		ginkgo.By("Tracing underlay pod to same underlay subnet: should not hit overlayOnlyRouting policy " + traceIPSuffix)
+		checkKoOvnTracePolicyNotMatched(namespaceName, underlayPod.Name, sameSubnetPodIP, "underlay to same underlay subnet "+traceIPSuffix, []string{
+			traceOverlayToUnderlayMatch,
+			traceUnderlaySameSubnetMatch,
+			traceUnderlayPhysicalGwMatch,
+		})
+
+		ginkgo.By("Tracing underlay pod to peer underlay CIDR: should hit physical gateway policy " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, underlayPod.Name, tracePeerUnderlayIP, "underlay to peer underlay "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceUnderlayPhysicalGwMatch,
+			fmt.Sprintf("priority %d", util.U2OPhysicalGatewayPolicyPriority),
+		})
+
+		nodeIP := nodeIPForProtocol(cs, traceProtocol)
+		framework.ExpectNotEmpty(nodeIP)
+		traceNodeRouteMatch = fmt.Sprintf("%s.dst == %s", traceIPSuffix, nodeIP)
+		ginkgo.By("Tracing underlay pod to node IP: should hit excluded node IP physical gateway policy " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, underlayPod.Name, nodeIP, "underlay to node IP "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceUnderlayNodeRouteMatch,
+			fmt.Sprintf("priority %d", util.SubnetRouterPolicyPriority),
+		})
+
+		clusterIP := serviceClusterIPForProtocol(service, traceProtocol)
+		framework.ExpectNotEmpty(clusterIP)
+		ginkgo.By("Tracing underlay pod to same underlay backend ClusterIP: should hit same-subnet allow policy after DNAT " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, underlayPod.Name, clusterIP, "underlay to same underlay backend ClusterIP "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceUnderlaySameSubnetMatch,
+			fmt.Sprintf("priority %d", util.U2OSameSubnetPolicyPriority),
+		})
+
+		overlayClusterIP := serviceClusterIPForProtocol(overlayService, traceProtocol)
+		framework.ExpectNotEmpty(overlayClusterIP)
+		ginkgo.By("Tracing underlay pod to overlay backend ClusterIP: should hit existing overlay CIDR route after DNAT " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, underlayPod.Name, overlayClusterIP, "underlay to overlay backend ClusterIP "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceOverlayRouteMatch,
+			fmt.Sprintf("priority %d", util.SubnetRouterPolicyPriority),
+		})
+
+		joinIP := nodeJoinIPForProtocol(cs, traceProtocol)
+		framework.ExpectNotEmpty(joinIP)
+		ginkgo.By("Tracing underlay pod to join IP: should hit existing join CIDR route " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, underlayPod.Name, joinIP, "underlay to join IP "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceJoinRouteMatch,
+			fmt.Sprintf("priority %d", util.SubnetRouterPolicyPriority),
+		})
+
+		ginkgo.By("Tracing overlay pod to overlay pod: should not hit overlayOnlyRouting allow policy " + traceIPSuffix)
+		checkKoOvnTracePolicyNotMatched(namespaceName, overlayPod.Name, traceSameOverlayPodIP, "overlay to overlay "+traceIPSuffix, []string{
+			traceOverlayToUnderlayMatch,
+			traceOverlayToPeerUnderlayMatch,
+		})
+
+		ginkgo.By("Tracing overlay pod to overlay backend ClusterIP: should not hit overlayOnlyRouting allow policy " + traceIPSuffix)
+		checkKoOvnTracePolicyNotMatched(namespaceName, overlayPod.Name, overlayClusterIP, "overlay to overlay backend ClusterIP "+traceIPSuffix, []string{
+			traceOverlayToUnderlayMatch,
+			traceOverlayToPeerUnderlayMatch,
+		})
+
+		ginkgo.By("Tracing overlay pod to underlay backend ClusterIP: should hit overlayOnlyRouting allow policy after DNAT " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, overlayPod.Name, clusterIP, "overlay to underlay backend ClusterIP "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceOverlayToUnderlayMatch,
+			fmt.Sprintf("priority %d", util.U2OSubnetPolicyPriority),
+		})
+
+		ginkgo.By("Tracing overlay pod to node IP: should hit baseline node IP route " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, overlayPod.Name, nodeIP, "overlay to node IP "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceNodeRouteMatch,
+			fmt.Sprintf("priority %d", util.NodeRouterPolicyPriority),
+		})
+
+		ginkgo.By("Tracing overlay pod to join IP: should hit existing join CIDR route " + traceIPSuffix)
+		checkKoOvnTracePolicy(namespaceName, overlayPod.Name, joinIP, "overlay to join IP "+traceIPSuffix, []string{
+			"lr_in_policy",
+			traceJoinRouteMatch,
+			fmt.Sprintf("priority %d", util.SubnetRouterPolicyPriority),
+		})
 	})
 
 	framework.ConformanceIt(`should drop ARP/ND request from localnet port to LRP`, func() {
@@ -1453,6 +1981,156 @@ func checkReachable(podName, podNamespace, sourceIP, targetIP, targetPort string
 	} else {
 		framework.ExpectError(err)
 	}
+}
+
+func u2oTraceProtocols(f *framework.Framework) []string {
+	protocols := make([]string, 0, 2)
+	if f.HasIPv4() {
+		protocols = append(protocols, apiv1.ProtocolIPv4)
+	}
+	if f.HasIPv6() {
+		protocols = append(protocols, apiv1.ProtocolIPv6)
+	}
+	return protocols
+}
+
+func ipSuffixForProtocol(protocol string) string {
+	if protocol == apiv1.ProtocolIPv4 {
+		return "ip4"
+	}
+	return "ip6"
+}
+
+func cidrForProtocol(cidrBlock, protocol string) string {
+	ginkgo.GinkgoHelper()
+
+	for cidr := range strings.SplitSeq(cidrBlock, ",") {
+		if util.CheckProtocol(cidr) == protocol {
+			return cidr
+		}
+	}
+	framework.Failf("CIDR block %q has no %s CIDR", cidrBlock, protocol)
+	return ""
+}
+
+func firstIPsForCIDRBlock(cidrBlock string) string {
+	ginkgo.GinkgoHelper()
+
+	ips := make([]string, 0, 2)
+	for cidr := range strings.SplitSeq(cidrBlock, ",") {
+		ip, err := util.FirstIP(cidr)
+		framework.ExpectNoError(err)
+		ips = append(ips, ip)
+	}
+	return strings.Join(ips, ",")
+}
+
+func podIPForProtocol(pod *corev1.Pod, protocol string) string {
+	ginkgo.GinkgoHelper()
+
+	for _, podIP := range pod.Status.PodIPs {
+		if util.CheckProtocol(podIP.IP) == protocol {
+			return podIP.IP
+		}
+	}
+	return ""
+}
+
+func serviceClusterIPForProtocol(service *corev1.Service, protocol string) string {
+	ginkgo.GinkgoHelper()
+
+	for _, ip := range util.ServiceClusterIPs(*service) {
+		if util.CheckProtocol(ip) == protocol {
+			return ip
+		}
+	}
+	return ""
+}
+
+func nodeIPForProtocol(cs clientset.Interface, protocol string) string {
+	ginkgo.GinkgoHelper()
+
+	nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), cs)
+	framework.ExpectNoError(err)
+	for _, node := range nodes.Items {
+		nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(node)
+		if protocol == apiv1.ProtocolIPv4 && nodeIPv4 != "" {
+			return nodeIPv4
+		}
+		if protocol == apiv1.ProtocolIPv6 && nodeIPv6 != "" {
+			return nodeIPv6
+		}
+	}
+	return ""
+}
+
+func nodeJoinIPForProtocol(cs clientset.Interface, protocol string) string {
+	ginkgo.GinkgoHelper()
+
+	nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), cs)
+	framework.ExpectNoError(err)
+	for _, node := range nodes.Items {
+		nodeIPv4, nodeIPv6 := util.SplitStringIP(node.Annotations[util.IPAddressAnnotation])
+		if protocol == apiv1.ProtocolIPv4 && nodeIPv4 != "" {
+			return nodeIPv4
+		}
+		if protocol == apiv1.ProtocolIPv6 && nodeIPv6 != "" {
+			return nodeIPv6
+		}
+	}
+	return ""
+}
+
+func checkKoOvnTracePolicy(namespace, podName, targetIP, description string, keywords []string) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(3*time.Second, 60*time.Second, func(_ context.Context) (bool, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, "kubectl", "ko", "ovn-trace", namespace+"/"+podName, targetIP, "tcp", strconv.Itoa(curlListenPort))
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			framework.Logf("ovn-trace %s failed: %v\n%s", description, err, output)
+			return false, nil
+		}
+
+		trace := string(output)
+		for _, keyword := range keywords {
+			if !strings.Contains(trace, keyword) {
+				framework.Logf("ovn-trace %s does not contain %q\n%s", description, keyword, trace)
+				return false, nil
+			}
+		}
+		framework.Logf("ovn-trace %s matched keywords: %s", description, strings.Join(keywords, ", "))
+		return true, nil
+	}, "ovn-trace "+description+" should contain policy keywords: "+strings.Join(keywords, ", "))
+}
+
+func checkKoOvnTracePolicyNotMatched(namespace, podName, targetIP, description string, keywords []string) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(3*time.Second, 60*time.Second, func(_ context.Context) (bool, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, "kubectl", "ko", "ovn-trace", namespace+"/"+podName, targetIP, "tcp", strconv.Itoa(curlListenPort))
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			framework.Logf("ovn-trace %s failed: %v\n%s", description, err, output)
+			return false, nil
+		}
+
+		trace := string(output)
+		for _, keyword := range keywords {
+			if strings.Contains(trace, keyword) {
+				framework.Logf("ovn-trace %s unexpectedly contains %q\n%s", description, keyword, trace)
+				return false, nil
+			}
+		}
+		framework.Logf("ovn-trace %s did not match keywords: %s", description, strings.Join(keywords, ", "))
+		return true, nil
+	}, "ovn-trace "+description+" should not contain policy keywords: "+strings.Join(keywords, ", "))
 }
 
 func checkPolicy(hitPolicyStr string, expectPolicyExist bool, vpcName string) {


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Features
- Tests

## What this PR does

This PR adds an optional U2O feature for underlay subnets:

```yaml
spec:
  u2oFeatures:
    overlayOnlyRouting: true
```

When enabled, underlay pods still use the U2O gateway, so traffic enters the OVN logical router. The logical router policies only keep U2O for overlay/join destinations and overlay-to-underlay return traffic. Other underlay-originated traffic is sent to the physical gateway.

## Design

The controller maintains one shared overlay CIDR address set per VPC and IP family:

- `<vpc>.u2o_overlay_cidrs.ip4`
- `<vpc>.u2o_overlay_cidrs.ip6`

The address set contains CIDRs of subnets that:

- belong to the same VPC
- are overlay subnets (`vlan` is empty)

Service CIDRs are not added separately because ClusterIP traffic is DNATed before route policy matching and then follows the backend pod IP destination.

When `overlayOnlyRouting` is enabled on a U2O underlay subnet, this PR now adds these policies per IP family:

| Priority | Match | Action |
| ---: | --- | --- |
| `31000` | `ipX.dst == $<subnet>.u2o_exclude_ip.ipX && ipX.src == <underlay-cidr>` | `reroute <physical-gw>` |
| `30060` | `ipX.src == <underlay-cidr> && ipX.dst == <underlay-cidr>` | `allow` |
| `30050` | `ipX.src == <underlay-cidr>` | `reroute <physical-gw>` |
| `29400` | `ipX.src == $<vpc>.u2o_overlay_cidrs.ipX && ipX.dst == <underlay-cidr>` | `allow` |

It still does not add an explicit underlay-to-overlay allow policy. Underlay-to-overlay traffic is already covered by the existing baseline subnet policy:

| Priority | Match | Action |
| ---: | --- | --- |
| `31000` | `ipX.dst == <overlay-cidr>` | `allow` |
| `31000` | `ipX.dst == <join-cidr>` | `allow` |
| `30000` | `ipX.dst == <node-ip>` | `reroute <join-ip>` |
| `29000` | `ipX.src == $<node-overlay-address-set>` | `reroute <join-ip>` |

The `29400` overlay-to-underlay allow policy is higher than the baseline `29000` source-based node reroute policy, so overlay-to-underlay traffic is not captured by the existing join-IP reroute path. The `31000` excluded-IP reroute keeps underlay-to-node-IP traffic on the physical gateway path even when node/provider IPs belong to the same underlay CIDR. The `30050` physical gateway policy remains lower than the existing overlay/join allow policies, so underlay-to-overlay and underlay-to-join-IP keep the baseline OVN/U2O behavior.

### Patch after local reproduction

During local reproduction on kind, underlay pod creation could fail in IPv6 single-stack and dual-stack because the gateway readiness check kept probing the U2O interconnection IP and never received a reply.

What we observed during troubleshooting:

- neighbor discovery to the U2O IP was working
- the failure was specifically `underlay pod -> U2OInterconnectionIP`
- in overlay-only mode, that traffic could still fall into the broad `30050 ipX.src == <underlay-cidr> reroute <physical-gw>` fallback

Based on that reproduction result, this PR adds the `30060 ipX.src == <underlay-cidr> && ipX.dst == <underlay-cidr> allow` patch so traffic to the U2O interconnection IP no longer falls through to the physical-gateway fallback. The higher-priority `31000` excluded-IP reroute is still preserved so `underlay -> node/provider IP` behavior does not regress.

If `overlayOnlyRouting` is disabled again, stale overlay-only policies are removed and the legacy U2O policies are restored.

## Expected trace behavior

| Source | Destination | Expected policy behavior |
| --- | --- | --- |
| underlay | overlay pod | hit existing `31000 dst overlay-cidr allow` |
| underlay | same underlay subnet pod | same subnet local/L2 path, no overlay-only policy |
| underlay | peer underlay CIDR | hit `30050 src underlay reroute physical-gw` |
| underlay | U2O interconnection IP | hit `30060 src/dst underlay-cidr allow` |
| underlay | ServiceIP -> overlay backend | DNAT to overlay pod IP, then hit `31000 dst overlay-cidr allow` |
| underlay | ServiceIP -> underlay backend | DNAT to underlay pod IP, then hit `30060 src/dst underlay-cidr allow` |
| underlay | node IP | hit `31000 dst excludedIP && src underlay reroute physical-gw`, not baseline `30000 dst nodeIP reroute joinIP` |
| underlay | join IP | keep baseline, hit `31000 dst join-cidr allow` |
| overlay | overlay pod | existing overlay route, no overlay-only policy |
| overlay | underlay pod | hit `29400 overlay -> underlay allow` |
| overlay | ServiceIP -> overlay backend | DNAT to overlay pod IP, no overlay-only policy |
| overlay | ServiceIP -> underlay backend | DNAT to underlay pod IP, then hit `29400 overlay -> underlay allow` |
| overlay | node IP | keep baseline, hit `30000 dst nodeIP reroute joinIP` |
| overlay | join IP | keep baseline, hit `31000 dst join-cidr allow` |

## Tests

- Added validator/unit coverage for `u2oFeatures.overlayOnlyRouting`.
- Added controller unit tests for overlay CIDR address set sync, overlay-only policy generation, and stale policy cleanup when switching between legacy and overlay-only modes.
- Expanded underlay E2E coverage for policy presence/absence after toggling `overlayOnlyRouting` off and on.
- Added reachability checks for underlay-to-overlay, overlay-to-underlay, and same-underlay-subnet ClusterIP traffic while `overlayOnlyRouting` is enabled.
- Expanded underlay E2E `ovn-trace` coverage for the expected matrix above.
- Fixed missing cleanup for the same-subnet overlay pod and overlay backend ClusterIP service in the overlay-only case.
- Changed the relevant `ovn-trace` helpers to fail after a single trace attempt and print the full trace on mismatch.

Local verification run in this iteration:

```text
go test ./pkg/controller -run 'TestAddPolicyRouteForU2OInterconn'
go test ./test/e2e/kube-ovn/underlay -run '^$'
```

`make lint` was not run per maintainer request during this iteration.

## Which issue(s) this PR fixes

Fixes #(issue-number)
