### PR TITLE
fix: default QoS interface based on direction when not specified

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -1438,8 +1438,16 @@ func (c *Controller) execNatGwQoSInPod(
 		klog.Error(err)
 		return err
 	}
+	iface := r.Interface
+	if iface == "" {
+		if r.Direction == kubeovnv1.QoSDirectionEgress {
+			iface = "net1"
+		} else {
+			iface = "eth0"
+		}
+	}
 	rule := fmt.Sprintf("%s,%s,%d,%s,%s,%s,%s,%s,%s",
-		r.Direction, r.Interface, r.Priority,
+		r.Direction, iface, r.Priority,
 		classifierType, r.MatchType, matchDirection,
 		cidr, r.RateMax, r.BurstMax)
 	addRules = append(addRules, rule)


### PR DESCRIPTION
## Summary

When `bandwidthLimitRules` in a QoSPolicy omit the `interface` field (which is optional per the CRD), the controller constructs a `tc` command with an empty device name:

```
tc filter add dev  parent 1:0 protocol ip prio 1 matchall ...
              ^^ empty
```

This causes the NAT gateway QoS setup to fail with `command terminated with exit code 1`.

## Fix

Default the interface based on direction before building the rule string:
- `egress` → `net1` (external-facing interface)
- `ingress` → `eth0` (VPC-facing interface)

This matches the convention in `nat-gateway.sh` (`EXTERNAL_INTERFACE=net1`, `VPC_INTERFACE=eth0`).

## Test plan

- [x] `GOOS=linux go build ./...` — compiles clean
- [x] `make lint` — no new issues (only pre-existing platform-specific typecheck errors on macOS)
- [x] Manual reproduction on v1.12.35 cluster — confirmed `tc` failure with empty `dev`
- [x] Deployed patched image (`docker.io/cmrmahesh/kube-ovn:v1.12.35-fix-qos`) — tc rules applied correctly on both `eth0` (ingress) and `net1` (egress)

### Before fix
```
E0516 08:34:36 vpc_nat_gateway.go:724] failed to ExecuteCommandInContainer, errOutput: What is "1:0"? Try "tc filter help"
failed to exec command "tc filter add dev  parent 1:0 protocol ip prio 1 matchall action police rate 1Mbit burst 1Mb drop flowid :1"
```

### After fix
```
# tc filter show dev eth0 ingress
filter parent ffff: protocol ip pref 1 matchall chain 0 handle 0x1 flowid :1
  action order 1: police 0x2 rate 1Mbit burst 1Mb mtu 2Kb action drop

# tc qdisc show dev net1
qdisc htb 1: dev net1 root refcnt 2 r2q 10 default 0
```

Fixes #6729