### PR TITLE
fix(daemon): close netns handles to prevent fd leaks

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -274,6 +274,7 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 		klog.Error(err)
 		return nil, err
 	}
+	defer podNS.Close()
 	finalRoutes, err := csh.configureContainerNic(podName, podNamespace, containerNicName, ifName, ip, gateway, isDefaultRoute, vmMigration, routes, macAddr, podNS, mtu, gwCheckMode, u2oInterconnectionIP)
 	if err != nil {
 		klog.Error(err)
@@ -1132,6 +1133,7 @@ func (c *Controller) loopOvnExt0Check() {
 			return
 		}
 	}
+	defer gwNS.Close()
 	nodeExtIP := cachedEip.Spec.V4Ip
 	ipAddr, err := util.GetIPAddrWithMask(ips, cachedSubnet.Spec.CIDRBlock)
 	if err != nil {
@@ -1878,6 +1880,7 @@ func (csh cniServerHandler) removeDefaultRoute(netns string, ipv4, ipv6 bool) er
 	if err != nil {
 		return fmt.Errorf("failed to open netns %q: %w", netns, err)
 	}
+	defer podNS.Close()
 
 	return ns.WithNetNSPath(podNS.Path(), func(_ ns.NetNS) error {
 		if ipv4 {

--- a/pkg/daemon/tproxy_linux.go
+++ b/pkg/daemon/tproxy_linux.go
@@ -328,6 +328,7 @@ func probePortInNs(podIP string, probePort int32, isTProxyProbe bool, conn net.C
 		klog.V(3).Infof("netns %s not found", podNs)
 		return
 	}
+	defer podNS.Close()
 
 	_ = ns.WithNetNSPath(podNS.Path(), func(_ ns.NetNS) error {
 		// Packet's src and dst IP are both PodIP in netns


### PR DESCRIPTION
## Summary
- Add missing `defer Close()` for `ns.GetNS()` results at four daemon call sites that currently leak one fd per call.
- The most severe is `probePortInNs` in `tproxy_linux.go`, which is invoked from a 1-second `wait.Until` loop and scales with the number of custom-VPC pods on the node.
- Mirrors upstream [ovn-kubernetes/ovn-kubernetes#6276](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6276) which fixed the same anti-pattern in their VRF manager.

## Affected sites
| File | Function | Trigger | Frequency |
|---|---|---|---|
| `pkg/daemon/ovs_linux.go:271` | `configureNic` | CNI Add | per pod creation |
| `pkg/daemon/ovs_linux.go:1120/1130` | `loopOvnExt0Check` | OVN EIP gateway feature | every 5s |
| `pkg/daemon/ovs_linux.go:1877` | `removeDefaultRoute` | CNI Add with custom routes | per matching pod |
| `pkg/daemon/tproxy_linux.go:325` | `probePortInNs` | `--enable-tproxy` + custom VPC pod | every 1s × N pods |

`releaseVf` at `ovs_linux.go:302-312` already follows the correct `defer netns.Close()` pattern and is the reference used here.

## Test plan
- [x] `make lint` — 0 issues
- [ ] Unit test `make ut` (no behavioral change, but verify nothing regresses)
- [ ] Manual verification on a daemon under load: `ls /proc/$(pidof kube-ovn-daemon)/fd | wc -l` should stay stable instead of growing over time
- [ ] E2E sanity: CNI add/del, EIP gateway up/down, tproxy probe on a custom VPC pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)