### PR TITLE
chore(ovs): drop unused DeleteGatewayChassises helpers

### DIFF
--- a/pkg/ovs/ovn-nb-gateway_chassis.go
+++ b/pkg/ovs/ovn-nb-gateway_chassis.go
@@ -48,49 +48,6 @@ func (c *OVNNbClient) UpdateGatewayChassis(gwChassis *ovnnb.GatewayChassis, fiel
 	return nil
 }
 
-// DeleteGatewayChassises delete multiple gateway chassis once
-func (c *OVNNbClient) DeleteGatewayChassises(lrpName string, chassises []string) error {
-	if len(chassises) == 0 {
-		return nil
-	}
-
-	lrp, err := c.GetLogicalRouterPort(lrpName, false)
-	if err != nil {
-		klog.Error(err)
-		return err
-	}
-
-	ops := make([]ovsdb.Operation, 0, len(chassises)*2)
-	for _, chassisName := range chassises {
-		gwChassisName := lrpName + "-" + chassisName
-		uuid, delOps, err := c.DeleteGatewayChassisOp(gwChassisName)
-		if err != nil {
-			klog.Error(err)
-			return nil
-		}
-
-		mutateOps, err := c.Where(lrp).Mutate(lrp, model.Mutation{
-			Field:   &lrp.GatewayChassis,
-			Value:   []string{uuid},
-			Mutator: ovsdb.MutateOperationDelete,
-		})
-		if err != nil {
-			klog.Error(err)
-			return nil
-		}
-
-		ops = append(ops, mutateOps...)
-		ops = append(ops, delOps...)
-	}
-
-	if err := c.Transact("gateway-chassises-delete", ops); err != nil {
-		klog.Error(err)
-		return fmt.Errorf("delete gateway chassises %v from logical router port %s: %w", chassises, lrpName, err)
-	}
-
-	return nil
-}
-
 // ListGatewayChassisByLogicalRouterPort get gateway chassis by lrp name
 func (c *OVNNbClient) ListGatewayChassisByLogicalRouterPort(lrpName string, ignoreNotFound bool) ([]ovnnb.GatewayChassis, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
@@ -213,25 +170,4 @@ func (c *OVNNbClient) CreateGatewayChassisesOp(lrpName string, chassises []strin
 	ops = append(ops, gwChassisAddOp...)
 
 	return ops, nil
-}
-
-// DeleteGatewayChassisOp create operation which delete gateway chassis
-func (c *OVNNbClient) DeleteGatewayChassisOp(chassisName string) (uuid string, ops []ovsdb.Operation, err error) {
-	gwChassis, err := c.GetGatewayChassis(chassisName, true)
-	if err != nil {
-		klog.Error(err)
-		return "", nil, err
-	}
-
-	// not found, skip
-	if gwChassis == nil {
-		return "", nil, nil
-	}
-
-	if ops, err = c.Where(gwChassis).Delete(); err != nil {
-		klog.Error(err)
-		return "", nil, err
-	}
-
-	return gwChassis.UUID, ops, nil
 }

--- a/pkg/ovs/ovn-nb-gateway_chassis_test.go
+++ b/pkg/ovs/ovn-nb-gateway_chassis_test.go
@@ -3,10 +3,7 @@ package ovs
 import (
 	"testing"
 
-	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 	"github.com/stretchr/testify/require"
-
-	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
 
 func (suite *OvnClientTestSuite) testCreateGatewayChassises() {
@@ -83,90 +80,6 @@ func (suite *OvnClientTestSuite) testUpdateGatewayChassis() {
 
 	err = nbClient.UpdateGatewayChassis(gwChassis, nil)
 	require.ErrorContains(t, err, "failed to generate operations for gateway chassis")
-}
-
-func (suite *OvnClientTestSuite) testDeleteGatewayChassises() {
-	t := suite.T()
-	t.Parallel()
-
-	nbClient := suite.ovnNBClient
-	lrName := "test-gateway-chassis-del-lr"
-	lrpName := "test-gateway-chassis-del-lrp"
-	chassises := []string{"ea8368a0-28cd-4549-9da5-a7ea67262619", "b25ffb94-8b32-4c7e-b5b0-0f343bf6bdd8", "62265268-8af7-4b36-a550-ab5ad38375e3"}
-
-	err := nbClient.CreateLogicalRouter(lrName)
-	require.NoError(t, err)
-
-	// delete gateway chassis for non-existent logical router port
-	err = nbClient.DeleteGatewayChassises(lrpName, append(chassises, "73bbe5d4-2b9b-47d0-aba8-94e86941881a"))
-	require.ErrorContains(t, err, "get logical router port test-gateway-chassis-del-lrp: object not found")
-
-	err = nbClient.CreateLogicalRouterPort(lrName, lrpName, "00:11:22:37:af:62", []string{"fd00::c0a8:1001/120"})
-	require.NoError(t, err)
-
-	err = nbClient.CreateGatewayChassises(lrpName, chassises...)
-	require.NoError(t, err)
-
-	err = nbClient.DeleteGatewayChassises(lrpName, append(chassises, "73bbe5d4-2b9b-47d0-aba8-94e86941881a"))
-	require.NoError(t, err)
-
-	// delete gateway chassis with nil chassises
-	err = nbClient.DeleteGatewayChassises(lrpName, nil)
-	require.NoError(t, err)
-
-	lrp, err := nbClient.GetLogicalRouterPort(lrpName, false)
-	require.NoError(t, err)
-	require.NotNil(t, lrp)
-	require.Len(t, lrp.GatewayChassis, 0)
-
-	for _, chassisName := range chassises {
-		gwChassisName := lrpName + "-" + chassisName
-		_, err := nbClient.GetGatewayChassis(gwChassisName, false)
-		require.ErrorContains(t, err, "object not found")
-	}
-}
-
-func (suite *OvnClientTestSuite) testDeleteGatewayChassisOp() {
-	t := suite.T()
-	t.Parallel()
-
-	nbClient := suite.ovnNBClient
-	lrName := "test-gateway-chassis-del-op-lr"
-	lrpName := "test-gateway-chassis-del-op-lrp"
-	chassis := "6c322ce8-02b7-42b3-925b-ae24020272a9"
-	gwChassisName := lrpName + "-" + chassis
-
-	err := nbClient.CreateLogicalRouter(lrName)
-	require.NoError(t, err)
-
-	err = nbClient.CreateLogicalRouterPort(lrName, lrpName, "00:11:22:37:af:62", []string{"fd00::c0a8:1001/120"})
-	require.NoError(t, err)
-
-	err = nbClient.CreateGatewayChassises(lrpName, chassis)
-	require.NoError(t, err)
-
-	gwChassis, err := nbClient.GetGatewayChassis(gwChassisName, false)
-	require.NoError(t, err)
-
-	uuid, ops, err := nbClient.DeleteGatewayChassisOp(gwChassisName)
-	require.NoError(t, err)
-	require.Equal(t, gwChassis.UUID, uuid)
-	require.Len(t, ops, 1)
-
-	require.Equal(t,
-		ovsdb.Operation{
-			Op:    ovsdb.OperationDelete,
-			Table: ovnnb.GatewayChassisTable,
-			Where: []ovsdb.Condition{
-				{
-					Column:   "_uuid",
-					Function: ovsdb.ConditionEqual,
-					Value: ovsdb.UUID{
-						GoUUID: gwChassis.UUID,
-					},
-				},
-			},
-		}, ops[0])
 }
 
 func (suite *OvnClientTestSuite) testNewGatewayChassis() {

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -489,14 +489,6 @@ func (suite *OvnClientTestSuite) Test_UpdateGatewayChassis() {
 	suite.testUpdateGatewayChassis()
 }
 
-func (suite *OvnClientTestSuite) Test_DeleteGatewayChassises() {
-	suite.testDeleteGatewayChassises()
-}
-
-func (suite *OvnClientTestSuite) Test_DeleteGatewayChassisOp() {
-	suite.testDeleteGatewayChassisOp()
-}
-
 func (suite *OvnClientTestSuite) Test_NewGatewayChassis() {
 	suite.testNewGatewayChassis()
 }


### PR DESCRIPTION
## Summary
- `DeleteGatewayChassises` and `DeleteGatewayChassisOp` in `pkg/ovs/ovn-nb-gateway_chassis.go` have no production callers — only their own unit tests referenced them. Actual gateway-chassis cleanup happens via `DeleteLogicalRouterPort`, which lets OVN northd orphan the `Gateway_Chassis` rows.
- `DeleteGatewayChassises` also carried a silent-error pattern: two `klog.Error + return nil` branches inside the per-chassis loop swallowed op-generation failures and let the caller believe the delete succeeded while no transaction was ever sent — same anti-pattern reported upstream in [antrea-io/antrea#8025](https://github.com/antrea-io/antrea/pull/8025).
- Rather than patch the swallowed errors on a helper nobody calls, drop both functions plus their tests (`testDeleteGatewayChassises`, `testDeleteGatewayChassisOp`, suite entries `Test_DeleteGatewayChassises` / `Test_DeleteGatewayChassisOp`) and the now-unused `ovsdb` / `ovnnb` imports in the test file. 159 lines removed, no behavior change.

## What stays
- `CreateGatewayChassises` (wired into the `OVNNbClient` interface and used by subnet/LRP setup)
- `UpdateGatewayChassis` (used by BFD priority manipulation in `pkg/ovs/ovn-nb-bfd.go`)
- `ListGatewayChassisByLogicalRouterPort`, `GetGatewayChassis`, `GatewayChassisExist`, `newGatewayChassis`, `CreateGatewayChassisesOp`

## Test plan
- [x] `make lint` — 0 issues
- [x] `go build ./pkg/ovs/...`
- [x] `go vet ./pkg/ovs/...`
- [x] Remaining gateway-chassis suite tests pass (`Test_CreateGatewayChassises`, `Test_UpdateGatewayChassis`, `Test_NewGatewayChassis`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)