### PR TITLE
fix: avoid panic decoding invalid CA private keys

### DIFF
--- a/pkg/controller/signer.go
+++ b/pkg/controller/signer.go
@@ -297,7 +297,6 @@ func decodeCertificate(pemBytes []byte) (*x509.Certificate, error) {
 func decodePrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil || block.Type != "PRIVATE KEY" {
-		fmt.Println(block.Type)
 		err := errors.New("certificate PEM block type must be PRIVATE KEY")
 		return nil, err
 	}

--- a/pkg/controller/signer_test.go
+++ b/pkg/controller/signer_test.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodePrivateKeyReturnsRSAPrivateKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	got, err := decodePrivateKey(pemBytes)
+	require.NoError(t, err)
+	require.Equal(t, key.N, got.N)
+}
+
+func TestDecodePrivateKeyReturnsErrorForInvalidPEM(t *testing.T) {
+	require.NotPanics(t, func() {
+		_, err := decodePrivateKey([]byte("not pem"))
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

## What this does

Tiny footgun fix tbh: if the ovn-ipsec-ca Secret has a bad cakey value, decodePrivateKey tries to print block.Type even when pem.Decode returned nil. That panics the controller instead of going down the existing CorruptCAKey error path.

This drops the stray stdout print and adds tests for valid PKCS#8 RSA keys + invalid PEM.

## How to reproduce

On master, add/run the invalid PEM regression test:

```bash
go test ./pkg/controller -run TestDecodePrivateKeyReturnsErrorForInvalidPEM -count=1
```

It crashes with a nil pointer panic. With this patch, it returns an error, no drama.

## Related

Related context: #5073 and #5972, both around IPSec CSR/signing behavior.

## Tests

```bash
go test ./pkg/controller -run TestDecodePrivateKey -count=1 -v
go test ./pkg/controller -count=1
make lint
```