### PR TITLE
feat(controller): distribute gateway chassis priority across VPCs

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -1382,6 +1382,11 @@ func (c *Controller) handleAddVpcExternalSubnet(key, subnet string) error {
 		return err
 	}
 
+	// distribute active gateway chassis across VPCs
+	sort.Slice(chassises, func(i, j int) bool {
+		return util.Sha256Hash([]byte(key+chassises[i])) < util.Sha256Hash([]byte(key+chassises[j]))
+	})
+
 	v4ipCidr, err := util.GetIPAddrWithMask(v4ip, cachedSubnet.Spec.CIDRBlock)
 	if err != nil {
 		klog.Error(err)

--- a/pkg/util/hash_test.go
+++ b/pkg/util/hash_test.go
@@ -1,6 +1,9 @@
 package util
 
-import "testing"
+import (
+	"sort"
+	"testing"
+)
 
 func TestSha256Hash(t *testing.T) {
 	tests := []struct {
@@ -69,5 +72,40 @@ func TestSha256HashObject(t *testing.T) {
 				t.Errorf("got hash %v, but want %v", hash, tt.hash)
 			}
 		})
+	}
+}
+
+func TestSha256HashGatewayChassisDistribution(t *testing.T) {
+	chassises := []string{
+		"efa09809-38e5-4c6d-b0a3-c8729fc40313",
+		"672a26c8-c12b-4853-907c-d3243c20e77d",
+		"4ac8c950-8839-4b72-93e5-3bab702657db",
+	}
+
+	getFirstChassis := func(vpcName string) string {
+		sorted := make([]string, len(chassises))
+		copy(sorted, chassises)
+		sort.Slice(sorted, func(i, j int) bool {
+			return Sha256Hash([]byte(vpcName+sorted[i])) < Sha256Hash([]byte(vpcName+sorted[j]))
+		})
+		return sorted[0]
+	}
+
+	// deterministic: same VPC always gets same result
+	first := getFirstChassis("vpc-a")
+	for range 10 {
+		if getFirstChassis("vpc-a") != first {
+			t.Fatal("not deterministic")
+		}
+	}
+
+	// distributed: not all VPCs get the same chassis
+	results := map[string]int{}
+	vpcs := []string{"vpc-a", "vpc-b", "vpc-c", "vpc-d", "vpc-e", "vpc-f", "vpc-g", "vpc-h", "vpc-i", "vpc-j"}
+	for _, vpc := range vpcs {
+		results[getFirstChassis(vpc)]++
+	}
+	if len(results) == 1 {
+		t.Fatalf("all VPCs got same chassis: %v", results)
 	}
 }


### PR DESCRIPTION
# Pull Request

  - [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

  ## What type of this PR

  - Features

  ## Description

  Currently `handleAddVpcExternalSubnet()` iterates gateway nodes from `nodesLister.List()` which returns nodes in a non-deterministic order. The chassis priority is assigned as `100-i`, making the first chassis in the list always
  active. Since the iteration order is timing-dependent, this causes:

  1. Multiple VPCs to collide on the same active gateway node
  2. Assignment changes on VPC recreation (non-deterministic)

  This PR sorts the chassis list using `util.Sha256Hash(vpcName + chassisName)` before passing it to `CreateLogicalPatchPort`, so each VPC gets a deterministic and distributed priority ordering. Uses the existing `util.Sha256Hash`
  function — no new dependencies.

  ### Before fix

  3 VPCs with `enableExternal: true`, 3 gateway nodes. VPCs deleted and recreated twice:

  **First creation:**

  test-vpc-1 → active gateway: kube-ovn-worker3
  test-vpc-2 → active gateway: kube-ovn-worker2
  test-vpc-3 → active gateway: kube-ovn-worker2  ← collision with vpc-2

  **After delete + recreate (same VPCs):**

  test-vpc-1 → active gateway: kube-ovn-worker2
  test-vpc-2 → active gateway: kube-ovn-worker2  ← collision with vpc-1
  test-vpc-3 → active gateway: kube-ovn-worker3

  Ordering changes between runs and VPCs collide on the same node.
  
  
<img width="1266" height="552" alt="image" src="https://github.com/user-attachments/assets/4f4459cd-c8a5-44e7-a7dd-c39efc942bb6" />

When the VPC are deleted, and created again in the run


<img width="1200" height="363" alt="image" src="https://github.com/user-attachments/assets/20d4a8a6-add1-43b7-9f5d-eab3ecd34497" />



  ### After fix

  **Fresh VPC creation:**

  test-vpc-1 → active gateway: kube-ovn-worker3
  test-vpc-2 → active gateway: kube-ovn-worker
  test-vpc-3 → active gateway: kube-ovn-worker

  Distribution is hash-based — each VPC's ordering is determined by `sha256(vpcName + chassisName)`.
  
  
<img width="1802" height="216" alt="image" src="https://github.com/user-attachments/assets/ee561d40-eb3e-402e-b8f0-9544f194b996" />


  **Unit test passes:**

<img width="1309" height="155" alt="image" src="https://github.com/user-attachments/assets/dfbf12ed-18f2-4859-9d14-13078ca5c1ed" />


  ### Behavior

  | Scenario | Before | After |
  |----------|--------|-------|
  | New VPC created | Random gateway (timing-dependent) | Hash-based deterministic gateway |
  | Controller restart | Existing VPCs unchanged | Existing VPCs unchanged |
  | Existing VPCs after upgrade | No change | No change (skip logic preserves existing entries) |

  ### Known limitation

  `CreateGatewayChassisesOp` skips gateway chassis entries that already exist (does not update their priority). This means during rapid VPC delete/recreate, stale entries from OVN's async cleanup can briefly persist with old
  priorities. This is pre-existing behavior unrelated to this change. A follow-up could add priority updates for existing entries.

  ## Which issue(s) this PR fixes

  Fixes #6732