### PR TITLE
fix(webhook): reject same-family duplicates in ip_address annotation

### DIFF
--- a/pkg/webhook/static_ip.go
+++ b/pkg/webhook/static_ip.go
@@ -161,6 +161,9 @@ func (v *ValidatingHook) validateIPConflict(ctx context.Context, annotations map
 	}
 
 	if ipAddress := annotations[util.IPAddressAnnotation]; ipAddress != "" {
+		if err := checkIPAddressFamilyUniqueness(ipAddress); err != nil {
+			return err
+		}
 		if err := v.checkIPConflict(ipAddress, annoSubnet, name, ipList); err != nil {
 			return err
 		}
@@ -176,6 +179,41 @@ func (v *ValidatingHook) validateIPConflict(ctx context.Context, annotations map
 		} else if err := v.checkIPConflict(ipPool, annoSubnet, name, ipList); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// checkIPAddressFamilyUniqueness rejects ip_address annotation values that
+// carry more than one address of the same IP family. The annotation is a
+// single static address per family (optionally one IPv4 + one IPv6 for
+// dual-stack), so values like "10.0.0.1,10.0.0.2" are ambiguous and would
+// silently corrupt IPAM accounting and dual-stack auto-completion downstream.
+func checkIPAddressFamilyUniqueness(ipAddress string) error {
+	var v4Count, v6Count int
+	for ip := range strings.SplitSeq(ipAddress, ",") {
+		ip = strings.TrimSpace(ip)
+		var ipAddr net.IP
+		if strings.Contains(ip, "/") {
+			ipAddr, _, _ = net.ParseCIDR(ip)
+		} else {
+			ipAddr = net.ParseIP(ip)
+		}
+		if ipAddr == nil {
+			// Leave the invalid-IP error to checkIPConflict so the wording
+			// stays consistent across callers.
+			return nil
+		}
+		if ipAddr.To4() != nil {
+			v4Count++
+		} else {
+			v6Count++
+		}
+	}
+	if v4Count > 1 {
+		return fmt.Errorf("multiple IPv4 addresses in ip_address annotation %q", ipAddress)
+	}
+	if v6Count > 1 {
+		return fmt.Errorf("multiple IPv6 addresses in ip_address annotation %q", ipAddress)
 	}
 	return nil
 }

--- a/pkg/webhook/static_ip_test.go
+++ b/pkg/webhook/static_ip_test.go
@@ -1,0 +1,86 @@
+package webhook
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckIPAddressFamilyUniqueness(t *testing.T) {
+	tests := []struct {
+		name      string
+		ipAddress string
+		wantErr   string
+	}{
+		{
+			name:      "single IPv4",
+			ipAddress: "10.0.0.1",
+		},
+		{
+			name:      "single IPv6",
+			ipAddress: "fd00::1",
+		},
+		{
+			name:      "dual-stack v4 first",
+			ipAddress: "10.0.0.1,fd00::1",
+		},
+		{
+			name:      "dual-stack v6 first",
+			ipAddress: "fd00::1,10.0.0.1",
+		},
+		{
+			name:      "dual-stack with spaces",
+			ipAddress: "10.0.0.1, fd00::1",
+		},
+		{
+			name:      "single IPv4 with CIDR suffix",
+			ipAddress: "10.0.0.1/24",
+		},
+		{
+			name:      "dual-stack with CIDR suffix",
+			ipAddress: "10.0.0.1/24,fd00::1/64",
+		},
+		{
+			name:      "two IPv4 addresses rejected",
+			ipAddress: "10.0.0.1,10.0.0.2",
+			wantErr:   `multiple IPv4 addresses in ip_address annotation "10.0.0.1,10.0.0.2"`,
+		},
+		{
+			name:      "two IPv6 addresses rejected",
+			ipAddress: "fd00::1,fd00::2",
+			wantErr:   `multiple IPv6 addresses in ip_address annotation "fd00::1,fd00::2"`,
+		},
+		{
+			name:      "v4 + v4 + v6 rejected on v4 count",
+			ipAddress: "10.0.0.1,10.0.0.2,fd00::1",
+			wantErr:   `multiple IPv4 addresses in ip_address annotation "10.0.0.1,10.0.0.2,fd00::1"`,
+		},
+		{
+			name:      "v4 + v6 + v6 rejected on v6 count",
+			ipAddress: "10.0.0.1,fd00::1,fd00::2",
+			wantErr:   `multiple IPv6 addresses in ip_address annotation "10.0.0.1,fd00::1,fd00::2"`,
+		},
+		{
+			// Defer reporting to checkIPConflict for consistent error wording.
+			name:      "invalid IP is left for checkIPConflict",
+			ipAddress: "10.0.0.1,not-an-ip",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkIPAddressFamilyUniqueness(tc.ipAddress)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Reject `ovn.kubernetes.io/ip_address` values that carry more than one IPv4 or more than one IPv6 (e.g. `10.0.0.1,10.0.0.2`); dual-stack `<v4>,<v6>` keeps working.
- Closes a real downstream bug: IPAM's `V4NicToIP`/`V6NicToIP` are single-value maps (second allocation overwrites the first → IP leak on Pod delete), and `checkAndAppendIpsForDual` is fooled by `len(ips) == 2` into skipping IPv6 auto-completion on a dual-stack subnet.
- `ovn.kubernetes.io/ip_pool` is deliberately left untouched: candidate-pool semantics, StatefulSet ordinal indexing relies on same-family lists.
- Aligned with upstream antrea fix antrea-io/antrea#7994 (same error wording).

## Test plan
- [x] `go test ./pkg/webhook/ -run TestCheckIPAddressFamilyUniqueness -v` — 12 cases (single v4 / v6, dual-stack both orderings, CIDR-suffixed, spaces, double v4 rejected, double v6 rejected, three-IP variants, invalid IP deferred to checkIPConflict)
- [x] `make lint` — 0 issues (includes verify-crd, golangci-lint, modernize)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)