### PR TITLE
feat(cni): package ipvlan plugin in kube-ovn image (#6747)

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -266,7 +266,7 @@ RUN curl -sSf -L --retry 5 -o /usr/bin/dumb-init https://github.com/Yelp/dumb-in
     chmod +x /usr/bin/dumb-init
 
 RUN --mount=type=bind,target=/godeps,from=go-deps,source=/godeps \
-    cp /godeps/loopback /godeps/portmap /godeps/macvlan ./ && \
+    cp /godeps/loopback /godeps/portmap /godeps/macvlan /godeps/ipvlan ./ && \
     cp /godeps/kubectl /godeps/gobgp /usr/bin/
 
 ARG DEBUG=false

--- a/dist/images/go-deps/download-go-deps.sh
+++ b/dist/images/go-deps/download-go-deps.sh
@@ -13,7 +13,7 @@ DEPS_DIR=/godeps
 mkdir -p "$DEPS_DIR"
 
 curl -sSf -L --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGINS_VERSION}.tgz | \
-    tar -xz -C "$DEPS_DIR" ./loopback ./portmap ./macvlan
+    tar -xz -C "$DEPS_DIR" ./loopback ./portmap ./macvlan ./ipvlan
 
 curl -sSf -L --retry 5 https://dl.k8s.io/${KUBECTL_VERSION}/kubernetes-client-linux-${ARCH}.tar.gz | \
     tar -xz -C "$DEPS_DIR" --strip-components=3 kubernetes/client/bin/kubectl
@@ -33,7 +33,7 @@ TARGETS_FILE="$DEPS_DIR/trivy-targets.txt"
 jq -r '.Results[] | select((.Type=="gobinary") and (.Vulnerabilities!=null)) | .Target' trivy.json | while read f; do
     name=$(basename $f)
     case $name in
-        loopback|macvlan|portmap)
+        loopback|macvlan|portmap|ipvlan)
             echo "$name@$CNI_PLUGINS_VERSION" >> "$TARGETS_FILE"
             ;;
         kubectl)

--- a/dist/images/go-deps/rebuild-go-deps.sh
+++ b/dist/images/go-deps/rebuild-go-deps.sh
@@ -20,7 +20,7 @@ for t in $(cat "$TRIVY_DIR/trivy-targets.txt"); do
     name=${t%@*}
     version=${t#*@}
     case $name in
-        loopback|macvlan)
+        loopback|macvlan|ipvlan)
             build_flags="-ldflags '-extldflags -static -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$version'"
             eval $GO_INSTALL $build_flags github.com/containernetworking/plugins/plugins/main/$name@$version
             ;;

--- a/dist/images/install-cni.sh
+++ b/dist/images/install-cni.sh
@@ -34,9 +34,13 @@ PORTMAP_BIN_DST=/opt/cni/bin/portmap
 MACVLAN_BIN_SRC=/macvlan
 MACVLAN_BIN_DST=/opt/cni/bin/macvlan
 
+IPVLAN_BIN_SRC=/ipvlan
+IPVLAN_BIN_DST=/opt/cni/bin/ipvlan
+
 yes | cp -f $LOOPBACK_BIN_SRC $LOOPBACK_BIN_DST || exit_with_error "Failed to copy $LOOPBACK_BIN_SRC to $LOOPBACK_BIN_DST"
 yes | cp -f $PORTMAP_BIN_SRC $PORTMAP_BIN_DST || exit_with_error "Failed to copy $PORTMAP_BIN_SRC to $PORTMAP_BIN_DST"
 yes | cp -f $CNI_BIN_SRC $CNI_BIN_DST || exit_with_error "Failed to copy $CNI_BIN_SRC to $CNI_BIN_DST"
 yes | cp -f $MACVLAN_BIN_SRC $MACVLAN_BIN_DST || exit_with_error "Failed to copy $MACVLAN_BIN_SRC to $MACVLAN_BIN_DST"
+yes | cp -f $IPVLAN_BIN_SRC $IPVLAN_BIN_DST || exit_with_error "Failed to copy $IPVLAN_BIN_SRC to $IPVLAN_BIN_DST"
 
 ./kube-ovn-daemon --install-cni-config $@ || exit_with_error "Failed to install cni config"


### PR DESCRIPTION
## Summary
Cherry-pick of #6747 onto release-1.15.

Bundle the upstream containernetworking ipvlan plugin alongside the existing loopback/portmap/macvlan binaries so workloads relying on ipvlan attachments work out of the box. The plugin flows through the same download / trivy scan / source rebuild / install path as the other CNI binaries.

## Test plan
- [ ] Image build succeeds and ships `/opt/cni/bin/ipvlan`
- [ ] Existing CNI-binary install path (loopback/portmap/macvlan) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)