### PR TITLE
feat: backport u2o overlay only routing to release-1.16

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -2638,6 +2638,13 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              u2oFeatures:
+                description: Feature configurations for underlay to overlay interconnection.
+                properties:
+                  overlayOnlyRouting:
+                    description: Overlay-only routing controls whether only overlay CIDRs use U2O routing.
+                    type: boolean
+                type: object
               u2oInterconnection:
                 description: Enable underlay to overlay interconnection.
                 type: boolean

--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -2639,10 +2639,8 @@ spec:
                 description: Route table associated with the subnet.
                 type: string
               u2oFeatures:
-                description: Feature configurations for underlay to overlay interconnection.
                 properties:
                   overlayOnlyRouting:
-                    description: Overlay-only routing controls whether only overlay CIDRs use U2O routing.
                     type: boolean
                 type: object
               u2oInterconnection:

--- a/charts/kube-ovn-v2/ct.yaml
+++ b/charts/kube-ovn-v2/ct.yaml
@@ -1,5 +1,7 @@
 validate-maintainers: false
 check-version-increment: false
+chart-dirs:
+  - charts/kube-ovn-v2
 namespace: kube-system
 release-label: app.kubernetes.io/instance
 skip-clean-up: true

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -2638,6 +2638,13 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              u2oFeatures:
+                description: Feature configurations for underlay to overlay interconnection.
+                properties:
+                  overlayOnlyRouting:
+                    description: Overlay-only routing controls whether only overlay CIDRs use U2O routing.
+                    type: boolean
+                type: object
               u2oInterconnection:
                 description: Enable underlay to overlay interconnection.
                 type: boolean

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -2639,10 +2639,8 @@ spec:
                 description: Route table associated with the subnet.
                 type: string
               u2oFeatures:
-                description: Feature configurations for underlay to overlay interconnection.
                 properties:
                   overlayOnlyRouting:
-                    description: Overlay-only routing controls whether only overlay CIDRs use U2O routing.
                     type: boolean
                 type: object
               u2oInterconnection:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2889,6 +2889,11 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              u2oFeatures:
+                properties:
+                  overlayOnlyRouting:
+                    type: boolean
+                type: object
               u2oInterconnection:
                 description: Enable underlay to overlay interconnection.
                 type: boolean

--- a/pkg/apis/kubeovn/v1/subnet.go
+++ b/pkg/apis/kubeovn/v1/subnet.go
@@ -135,7 +135,8 @@ type SubnetSpec struct {
 	// Underlay to overlay interconnection IP.
 	U2OInterconnectionIP string `json:"u2oInterconnectionIP,omitempty"`
 	// Enable underlay to overlay interconnection.
-	U2OInterconnection bool `json:"u2oInterconnection,omitempty"`
+	U2OInterconnection bool        `json:"u2oInterconnection,omitempty"`
+	U2OFeatures        U2OFeatures `json:"u2oFeatures,omitempty"`
 	// Enable LoadBalancer on this subnet.
 	EnableLb *bool `json:"enableLb,omitempty"`
 	// Enable ECMP for centralized gateway.
@@ -151,6 +152,10 @@ type SubnetSpec struct {
 	NamespaceSelectors []metav1.LabelSelector `json:"namespaceSelectors,omitempty"`
 	// Node network name for underlay.
 	NodeNetwork string `json:"nodeNetwork,omitempty"`
+}
+
+type U2OFeatures struct {
+	OverlayOnlyRouting bool `json:"overlayOnlyRouting,omitempty"`
 }
 
 type ACL struct {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2100,6 +2100,7 @@ func (c *Controller) checkSubnetGwNodesExist(subnet *kubeovnv1.Subnet) bool {
 
 	return false
 }
+
 func getIPSuffix(protocol string) string {
 	if protocol == kubeovnv1.ProtocolIPv6 {
 		return "ip6"

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -74,6 +74,10 @@ func readyToRemoveFinalizer(subnet *kubeovnv1.Subnet) bool {
 	return false
 }
 
+func u2oOverlayOnlyRoutingEnabled(subnet *kubeovnv1.Subnet) bool {
+	return subnet != nil && subnet.Spec.U2OFeatures.OverlayOnlyRouting
+}
+
 func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 	oldSubnet := oldObj.(*kubeovnv1.Subnet)
 	newSubnet := newObj.(*kubeovnv1.Subnet)
@@ -83,6 +87,11 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 		klog.Infof("enqueue update subnet %s triggered by ready to remove finalizer", key)
 		c.addOrUpdateSubnetQueue.Add(key)
 		return
+	}
+
+	if oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection {
+		klog.Infof("enqueue update vpc %s triggered by u2o interconnection change of subnet %s", newSubnet.Spec.Vpc, key)
+		c.addOrUpdateVpcQueue.Add(newSubnet.Spec.Vpc)
 	}
 
 	if !reflect.DeepEqual(oldSubnet.Spec, newSubnet.Spec) {
@@ -845,6 +854,12 @@ func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) error {
 		klog.Errorf("failed to delete policy route for overlay subnet %s, %v", subnet.Name, err)
 		return err
 	}
+	if subnet.Spec.Vlan == "" {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, subnet.Name); err != nil {
+			klog.Errorf("sync u2o overlay cidrs address set for deleted subnet %s failed, %v", subnet.Name, err)
+			return err
+		}
+	}
 
 	err := c.handleDeleteLogicalSwitch(subnet.Name)
 	if err != nil {
@@ -932,6 +947,12 @@ func (c *Controller) reconcileSubnet(subnet *kubeovnv1.Subnet) error {
 	if err := c.reconcileVips(subnet); err != nil {
 		klog.Errorf("reconcile vips for subnet %s failed, %v", subnet.Name, err)
 		return err
+	}
+	if subnet.Spec.Vlan == "" {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, ""); err != nil {
+			klog.Errorf("sync u2o overlay cidrs address set for subnet %s failed, %v", subnet.Name, err)
+			return err
+		}
 	}
 	return nil
 }
@@ -2079,7 +2100,6 @@ func (c *Controller) checkSubnetGwNodesExist(subnet *kubeovnv1.Subnet) bool {
 
 	return false
 }
-
 func getIPSuffix(protocol string) string {
 	if protocol == kubeovnv1.ProtocolIPv6 {
 		return "ip6"
@@ -2346,8 +2366,12 @@ func (c *Controller) deletePolicyRouteByGatewayType(subnet *kubeovnv1.Subnet, ga
 
 func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) error {
 	v4Gw, v6Gw := util.SplitStringIP(subnet.Spec.Gateway)
+	overlayOnly := u2oOverlayOnlyRoutingEnabled(subnet)
 
 	externalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{"isU2ORoutePolicy": "true"})
+
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
 
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
@@ -2366,9 +2390,6 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			nodesIPv6 = append(nodesIPv6, nodeIPv6)
 		}
 	}
-
-	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
-	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
 
 	if err := c.OVNNbClient.CreateAddressSet(u2oExcludeIP4Ag, externalIDs); err != nil {
 		klog.Errorf("create address set %s: %v", u2oExcludeIP4Ag, err)
@@ -2394,35 +2415,55 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 		}
 	}
 
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	if overlayOnly {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, ""); err != nil {
+			return err
+		}
+	}
+
+	overlayOnlyExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{
+		"isU2ORoutePolicy":            "true",
+		"isU2OOverlayOnlyRoutePolicy": "true",
+	})
+	desiredPolicies := make(map[string]struct{})
+
 	for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
 		ipSuffix := getIPSuffix(util.CheckProtocol(cidrBlock))
 		nextHop := v4Gw
-		U2OexcludeIPAs := u2oExcludeIP4Ag
+		u2oExcludeIPAs := u2oExcludeIP4Ag
+		overlayCIDRsAg := overlayCIDRs4Ag
 		if ipSuffix == "ip6" {
 			nextHop = v6Gw
-			U2OexcludeIPAs = u2oExcludeIP6Ag
+			u2oExcludeIPAs = u2oExcludeIP6Ag
+			overlayCIDRsAg = overlayCIDRs6Ag
 		}
 
 		match1 := fmt.Sprintf("%s.dst == %s", ipSuffix, cidrBlock)
-		match2 := fmt.Sprintf("%s.dst == $%s && %s.src == %s", ipSuffix, U2OexcludeIPAs, ipSuffix, cidrBlock)
+		match2 := fmt.Sprintf("%s.dst == $%s && %s.src == %s", ipSuffix, u2oExcludeIPAs, ipSuffix, cidrBlock)
 		match3 := fmt.Sprintf("%s.src == %s", ipSuffix, cidrBlock)
+		matchSameSubnet := fmt.Sprintf("%s.src == %s && %s.dst == %s", ipSuffix, cidrBlock, ipSuffix, cidrBlock)
+		matchOverlayToUnderlay := fmt.Sprintf("%s.src == $%s && %s.dst == %s", ipSuffix, overlayCIDRsAg, ipSuffix, cidrBlock)
 
-		/*
-			policy1:
-			priority 29400 match: "ip4.dst == underlay subnet cidr"                         action: allow
-
-			policy2:
-			priority 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reroute physical gw
-
-			policy3:
-			priority 29000 match: "ip4.src == underlay subnet cidr"                         action: reroute physical gw
-
-			comment:
-			policy1 and policy2 allow overlay pod access underlay but when overlay pod access node ip, it should go join subnet,
-			policy3: underlay pod first access u2o interconnection lrp and then reroute to physical gw
-		*/
 		action := kubeovnv1.PolicyRouteActionAllow
-		if subnet.Spec.Vpc == c.config.ClusterRouter {
+		if overlayOnly {
+			klog.Infof("add u2o overlay only policy for router: %s, match %s, action %s", subnet.Spec.Vpc, matchOverlayToUnderlay, action)
+			if err := c.addPolicyRouteToVpc(
+				subnet.Spec.Vpc,
+				&kubeovnv1.PolicyRoute{
+					Priority: util.U2OSubnetPolicyPriority,
+					Match:    matchOverlayToUnderlay,
+					Action:   action,
+				},
+				overlayOnlyExternalIDs,
+			); err != nil {
+				klog.Errorf("failed to add u2o overlay to underlay policy for subnet %s %v", subnet.Name, err)
+				return err
+			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSubnetPolicyPriority, matchOverlayToUnderlay)] = struct{}{}
+		}
+
+		if !overlayOnly && subnet.Spec.Vpc == c.config.ClusterRouter {
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match1, action)
 			if err := c.addPolicyRouteToVpc(
 				subnet.Spec.Vpc,
@@ -2436,9 +2477,16 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 				klog.Errorf("failed to add u2o interconnection policy1 for subnet %s %v", subnet.Name, err)
 				return err
 			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSubnetPolicyPriority, match1)] = struct{}{}
+		}
 
+		if overlayOnly || subnet.Spec.Vpc == c.config.ClusterRouter {
 			action = kubeovnv1.PolicyRouteActionReroute
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match2, action)
+			currentExternalIDs := externalIDs
+			if overlayOnly {
+				currentExternalIDs = overlayOnlyExternalIDs
+			}
 			if err := c.addPolicyRouteToVpc(
 				subnet.Spec.Vpc,
 				&kubeovnv1.PolicyRoute{
@@ -2447,19 +2495,41 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 					Action:    action,
 					NextHopIP: nextHop,
 				},
-				externalIDs,
+				currentExternalIDs,
 			); err != nil {
 				klog.Errorf("failed to add u2o interconnection policy2 for subnet %s %v", subnet.Name, err)
 				return err
 			}
+			desiredPolicies[logicalRouterPolicyKey(util.SubnetRouterPolicyPriority, match2)] = struct{}{}
+		}
+
+		if overlayOnly {
+			klog.Infof("add u2o overlay only same-subnet policy for router: %s, match %s, action %s", subnet.Spec.Vpc, matchSameSubnet, kubeovnv1.PolicyRouteActionAllow)
+			if err := c.addPolicyRouteToVpc(
+				subnet.Spec.Vpc,
+				&kubeovnv1.PolicyRoute{
+					Priority: util.U2OSameSubnetPolicyPriority,
+					Match:    matchSameSubnet,
+					Action:   kubeovnv1.PolicyRouteActionAllow,
+				},
+				overlayOnlyExternalIDs,
+			); err != nil {
+				klog.Errorf("failed to add u2o overlay only same-subnet policy for subnet %s %v", subnet.Name, err)
+				return err
+			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSameSubnetPolicyPriority, matchSameSubnet)] = struct{}{}
 		}
 
 		action = kubeovnv1.PolicyRouteActionReroute
+		physicalGatewayPolicyPriority := util.GatewayRouterPolicyPriority
+		if overlayOnly {
+			physicalGatewayPolicyPriority = util.U2OPhysicalGatewayPolicyPriority
+		}
 		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s, nexthop %s", subnet.Spec.Vpc, match3, action, nextHop)
 		if err := c.addPolicyRouteToVpc(
 			subnet.Spec.Vpc,
 			&kubeovnv1.PolicyRoute{
-				Priority:  util.GatewayRouterPolicyPriority,
+				Priority:  physicalGatewayPolicyPriority,
 				Match:     match3,
 				Action:    action,
 				NextHopIP: nextHop,
@@ -2467,6 +2537,120 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			externalIDs,
 		); err != nil {
 			klog.Errorf("failed to add u2o interconnection policy3 for subnet %s %v", subnet.Name, err)
+			return err
+		}
+		desiredPolicies[logicalRouterPolicyKey(physicalGatewayPolicyPriority, match3)] = struct{}{}
+	}
+	if err := c.deleteStaleU2ORoutePolicies(subnet, desiredPolicies); err != nil {
+		return err
+	}
+	return nil
+}
+
+func logicalRouterPolicyKey(priority int, match string) string {
+	return fmt.Sprintf("%d/%s", priority, match)
+}
+
+func u2oOverlayCIDRsAddressSetNames(vpcName string) (string, string) {
+	v4Name := strings.ReplaceAll(fmt.Sprintf(util.U2OOverlayCIDRs, vpcName, "ip4"), "-", ".")
+	v6Name := strings.ReplaceAll(fmt.Sprintf(util.U2OOverlayCIDRs, vpcName, "ip6"), "-", ".")
+	return v4Name, v6Name
+}
+
+func u2oOverlayCIDRsAddressSetExternalIDs(vpcName string) map[string]string {
+	return map[string]string{
+		"isU2OOverlayCIDRs": "true",
+		"vpc":               vpcName,
+	}
+}
+
+func (c *Controller) syncU2OOverlayCIDRsAddressSet(vpcName, excludeSubnet string) (v4CIDRs, v6CIDRs []string, err error) {
+	if vpcName == "" {
+		return nil, nil, nil
+	}
+
+	v4Name, v6Name := u2oOverlayCIDRsAddressSetNames(vpcName)
+	externalIDs := u2oOverlayCIDRsAddressSetExternalIDs(vpcName)
+	if v4CIDRs, v6CIDRs, err = c.buildU2OOverlayCIDRs(vpcName, excludeSubnet); err != nil {
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.CreateAddressSet(v4Name, externalIDs); err != nil {
+		klog.Errorf("create address set %s: %v", v4Name, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.CreateAddressSet(v6Name, externalIDs); err != nil {
+		klog.Errorf("create address set %s: %v", v6Name, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.AddressSetUpdateAddress(v4Name, v4CIDRs...); err != nil {
+		klog.Errorf("set v4 address set %s with address %v: %v", v4Name, v4CIDRs, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.AddressSetUpdateAddress(v6Name, v6CIDRs...); err != nil {
+		klog.Errorf("set v6 address set %s with address %v: %v", v6Name, v6CIDRs, err)
+		return nil, nil, err
+	}
+	return v4CIDRs, v6CIDRs, nil
+}
+
+func (c *Controller) buildU2OOverlayCIDRs(vpcName, excludeSubnet string) (v4CIDRs, v6CIDRs []string, err error) {
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets: %v", err)
+		return nil, nil, err
+	}
+
+	for _, subnet := range subnets {
+		if subnet.Name == excludeSubnet || subnet.Spec.Vpc != vpcName || subnet.Spec.Vlan != "" {
+			continue
+		}
+		for cidr := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+			switch util.CheckProtocol(cidr) {
+			case kubeovnv1.ProtocolIPv4:
+				v4CIDRs = append(v4CIDRs, cidr)
+			case kubeovnv1.ProtocolIPv6:
+				v6CIDRs = append(v6CIDRs, cidr)
+			}
+		}
+	}
+	return v4CIDRs, v6CIDRs, nil
+}
+
+func (c *Controller) deleteStaleU2ORoutePolicies(subnet *kubeovnv1.Subnet, desiredPolicies map[string]struct{}) error {
+	lr := subnet.Status.U2OInterconnectionVPC
+	if lr == "" {
+		lr = subnet.Spec.Vpc
+	}
+
+	logicalRouter, err := c.OVNNbClient.GetLogicalRouter(lr, true)
+	if err != nil {
+		klog.Errorf("failed to get logical router %s: %v", lr, err)
+		return err
+	}
+	if logicalRouter == nil {
+		klog.Infof("logical router %s already deleted", lr)
+		return nil
+	}
+
+	policies, err := c.OVNNbClient.ListLogicalRouterPolicies(lr, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true)
+	if err != nil {
+		klog.Errorf("failed to list u2o logical router policies: %v", err)
+		return err
+	}
+	for _, policy := range policies {
+		if policy.ExternalIDs["isU2ONoLBRoutePolicy"] == "true" {
+			continue
+		}
+		if _, ok := desiredPolicies[logicalRouterPolicyKey(policy.Priority, policy.Match)]; ok {
+			continue
+		}
+		klog.Infof("delete stale u2o policy for router %s with match %s priority %d", lr, policy.Match, policy.Priority)
+		if err := c.OVNNbClient.DeleteLogicalRouterPolicyByUUID(lr, policy.UUID); err != nil {
+			klog.Errorf("failed to delete stale u2o policy for subnet %s: %v", subnet.Name, err)
 			return err
 		}
 	}

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,6 +108,140 @@ func Test_readyToRemoveFinalizer(t *testing.T) {
 			require.Equal(t, tc.want, readyToRemoveFinalizer(tc.subnet))
 		})
 	}
+}
+
+func TestAddPolicyRouteForU2OInterconn_OverlayOnlyRouting(t *testing.T) {
+	t.Parallel()
+
+	const (
+		subnetName  = "subnet-a"
+		overlayName = "overlay-a"
+		vlanName    = "vlan1"
+		cidr        = "10.16.1.0/24"
+		overlayCIDR = "10.244.0.0/16"
+		gateway     = "10.16.1.1"
+	)
+
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:                util.DefaultVpc,
+			Vlan:               vlanName,
+			CIDRBlock:          cidr,
+			Gateway:            gateway,
+			U2OInterconnection: true,
+			U2OFeatures: kubeovnv1.U2OFeatures{
+				OverlayOnlyRouting: true,
+			},
+		},
+		Status: kubeovnv1.SubnetStatus{
+			U2OInterconnectionVPC: util.DefaultVpc,
+		},
+	}
+	overlaySubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: overlayName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       util.DefaultVpc,
+			CIDRBlock: overlayCIDR,
+		},
+	}
+
+	fc := newFakeController(t)
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(subnet))
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(overlaySubnet))
+
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	overlayExternalIDs := u2oOverlayCIDRsAddressSetExternalIDs(subnet.Spec.Vpc)
+	overlayPolicyExternalIDs := map[string]string{
+		"vendor":                      util.CniTypeName,
+		"subnet":                      subnet.Name,
+		"isU2ORoutePolicy":            "true",
+		"isU2OOverlayOnlyRoutePolicy": "true",
+	}
+	routeExternalIDs := map[string]string{
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+		"isU2ORoutePolicy": "true",
+	}
+
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP4Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP6Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs4Ag, overlayExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs6Ag, overlayExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs4Ag, overlayCIDR).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs6Ag).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSubnetPolicyPriority, fmt.Sprintf("ip4.src == $%s && ip4.dst == %s", overlayCIDRs4Ag, cidr), string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.SubnetRouterPolicyPriority, fmt.Sprintf("ip4.dst == $%s && ip4.src == %s", u2oExcludeIP4Ag, cidr), string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSameSubnetPolicyPriority, fmt.Sprintf("ip4.src == %s && ip4.dst == %s", cidr, cidr), string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OPhysicalGatewayPolicyPriority, fmt.Sprintf("ip4.src == %s", cidr), string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().GetLogicalRouter(util.DefaultVpc, true).Return(&ovnnb.LogicalRouter{Name: util.DefaultVpc}, nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies(util.DefaultVpc, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true).Return(nil, nil)
+
+	err := ctrl.addPolicyRouteForU2OInterconn(subnet)
+	require.NoError(t, err)
+}
+
+func TestSyncU2OOverlayCIDRsAddressSet_UpdatesAfterOverlaySubnetDeletion(t *testing.T) {
+	t.Parallel()
+
+	const (
+		vpcName      = util.DefaultVpc
+		overlayAName = "overlay-a"
+		overlayBName = "overlay-b"
+		underlayName = "underlay-a"
+		overlayAV4   = "10.244.0.0/16"
+		overlayAV6   = "fd00:244::/64"
+		overlayBV4   = "10.245.0.0/16"
+		overlayBV6   = "fd00:245::/64"
+		underlayCIDR = "10.16.1.0/24"
+		underlayVlan = "vlan1"
+	)
+
+	overlayA := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: overlayAName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, CIDRBlock: overlayAV4 + "," + overlayAV6}}
+	overlayB := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: overlayBName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, CIDRBlock: overlayBV4 + "," + overlayBV6}}
+	underlay := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: underlayName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, Vlan: underlayVlan, CIDRBlock: underlayCIDR}}
+
+	fc := newFakeController(t)
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(overlayA))
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(overlayB))
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(underlay))
+
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(vpcName)
+	overlayExternalIDs := u2oOverlayCIDRsAddressSetExternalIDs(vpcName)
+
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs4Ag, overlayExternalIDs).Return(nil).Times(2)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs6Ag, overlayExternalIDs).Return(nil).Times(2)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs4Ag, gomock.Any(), gomock.Any()).DoAndReturn(func(_ string, addresses ...string) error {
+		require.ElementsMatch(t, []string{overlayAV4, overlayBV4}, addresses)
+		return nil
+	})
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs6Ag, gomock.Any(), gomock.Any()).DoAndReturn(func(_ string, addresses ...string) error {
+		require.ElementsMatch(t, []string{overlayAV6, overlayBV6}, addresses)
+		return nil
+	})
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs4Ag, overlayAV4).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs6Ag, overlayAV6).Return(nil)
+
+	v4CIDRs, v6CIDRs, err := ctrl.syncU2OOverlayCIDRsAddressSet(vpcName, "")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{overlayAV4, overlayBV4}, v4CIDRs)
+	require.ElementsMatch(t, []string{overlayAV6, overlayBV6}, v6CIDRs)
+
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Delete(overlayB))
+	v4CIDRs, v6CIDRs, err = ctrl.syncU2OOverlayCIDRsAddressSet(vpcName, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{overlayAV4}, v4CIDRs)
+	require.Equal(t, []string{overlayAV6}, v6CIDRs)
 }
 
 func Test_reconcileVips(t *testing.T) {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -255,6 +255,8 @@ const (
 	U2OSubnetPolicyPriority          = 29400
 	OvnICPolicyPriority              = 29500
 	NodeRouterPolicyPriority         = 30000
+	U2OPhysicalGatewayPolicyPriority = 30050
+	U2OSameSubnetPolicyPriority      = 30060
 	NodeLocalDNSPolicyPriority       = 30100
 	SubnetRouterPolicyPriority       = 31000
 
@@ -299,6 +301,7 @@ const (
 
 	U2OInterconnName = "u2o-interconnection.%s.%s"
 	U2OExcludeIPAg   = "%s.u2o_exclude_ip.%s"
+	U2OOverlayCIDRs  = "%s.u2o_overlay_cidrs.%s"
 
 	McastQuerierName = "mcast-querier.%s"
 

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -173,6 +173,15 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		return errors.New("logicalGateway and u2oInterconnection can't be opened at the same time")
 	}
 
+	if subnet.Spec.U2OFeatures.OverlayOnlyRouting {
+		if !subnet.Spec.U2OInterconnection {
+			return errors.New("u2oFeatures.overlayOnlyRouting can only be enabled when u2oInterconnection is true")
+		}
+		if subnet.Spec.Vlan == "" {
+			return errors.New("u2oFeatures.overlayOnlyRouting can only be enabled on underlay subnets (vlan must be set)")
+		}
+	}
+
 	if len(subnet.Spec.NatOutgoingPolicyRules) != 0 {
 		if err := validateNatOutgoingPolicyRules(subnet); err != nil {
 			klog.Error(err)

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -262,6 +262,73 @@ func TestValidateSubnet(t *testing.T) {
 			err: "logicalGateway and u2oInterconnection can't be opened at the same time",
 		},
 		{
+			name: "U2OOverlayOnlyRoutingWithoutU2OErr",
+			subnet: kubeovnv1.Subnet{
+				TypeMeta: metav1.TypeMeta{Kind: "Subnet", APIVersion: "kubeovn.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-without-u2o",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         "ovn-cluster",
+					Protocol:    kubeovnv1.ProtocolIPv4,
+					CIDRBlock:   "10.16.0.0/16",
+					Gateway:     "10.16.0.1",
+					Provider:    "ovn",
+					GatewayType: kubeovnv1.GWDistributedType,
+					Vlan:        "vlan1",
+					U2OFeatures: kubeovnv1.U2OFeatures{OverlayOnlyRouting: true},
+				},
+				Status: kubeovnv1.SubnetStatus{},
+			},
+			err: "u2oFeatures.overlayOnlyRouting can only be enabled when u2oInterconnection is true",
+		},
+		{
+			name: "U2OOverlayOnlyRoutingWithoutVlanErr",
+			subnet: kubeovnv1.Subnet{
+				TypeMeta: metav1.TypeMeta{Kind: "Subnet", APIVersion: "kubeovn.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-without-vlan",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:            true,
+					Vpc:                "ovn-cluster",
+					Protocol:           kubeovnv1.ProtocolIPv4,
+					CIDRBlock:          "10.16.0.0/16",
+					Gateway:            "10.16.0.1",
+					Provider:           "ovn",
+					GatewayType:        kubeovnv1.GWDistributedType,
+					U2OInterconnection: true,
+					U2OFeatures:        kubeovnv1.U2OFeatures{OverlayOnlyRouting: true},
+				},
+				Status: kubeovnv1.SubnetStatus{},
+			},
+			err: "u2oFeatures.overlayOnlyRouting can only be enabled on underlay subnets (vlan must be set)",
+		},
+		{
+			name: "U2OOverlayOnlyRoutingCorrect",
+			subnet: kubeovnv1.Subnet{
+				TypeMeta: metav1.TypeMeta{Kind: "Subnet", APIVersion: "kubeovn.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-correct",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:            true,
+					Vpc:                "ovn-cluster",
+					Protocol:           kubeovnv1.ProtocolIPv4,
+					CIDRBlock:          "10.16.0.0/16",
+					Gateway:            "10.16.0.1",
+					Provider:           "ovn",
+					GatewayType:        kubeovnv1.GWDistributedType,
+					Vlan:               "vlan1",
+					U2OInterconnection: true,
+					U2OFeatures:        kubeovnv1.U2OFeatures{OverlayOnlyRouting: true},
+				},
+				Status: kubeovnv1.SubnetStatus{},
+			},
+			err: "",
+		},
+		{
 			name: "ValidateNatOutgoingPolicyRulesErr",
 			subnet: kubeovnv1.Subnet{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## 问题修复

### 问题描述
回捞 commit ca6231a54047407da2a5df409e321c6cead0e0e0 到 release-1.16，为 underlay to overlay interconnection 增加 overlay-only routing 支持。

### 修复方案
- 回捞 U2O overlay-only routing 主逻辑
- 补充 Subnet API/CRD 对 `u2oFeatures.overlayOnlyRouting` 的支持
- 补充对应单元测试
- 不包含 e2e 测试同步

### 测试验证
- [x] `go test ./pkg/util -run TestValidateSubnet`
- [x] `go test ./pkg/controller -run 'TestAddPolicyRouteForU2OInterconn_OverlayOnlyRouting|TestSyncU2OOverlayCIDRsAddressSet_UpdatesAfterOverlaySubnetDeletion|Test_readyToRemoveFinalizer'`

Cherry-pick of: ca6231a54047407da2a5df409e321c6cead0e0e0