### PR TITLE
chore: apply modernize fixes flagged by latest gopls modernize

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -308,7 +308,7 @@ func (config *Configuration) initNicConfig(nicBridgeMappings map[string]string) 
 			}
 
 			// exclude link-local and loopback addresses
-			ipStr := strings.Split(addr.String(), "/")[0]
+			ipStr, _, _ := strings.Cut(addr.String(), "/")
 			if ip := net.ParseIP(ipStr); ip == nil || ip.IsLinkLocalUnicast() || ip.IsLoopback() {
 				continue
 			}

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -985,7 +985,7 @@ func (c *Controller) loopEncapIPCheck() {
 
 		var encapIP string
 		for _, addr := range addrs {
-			ipStr := strings.Split(addr.String(), "/")[0]
+			ipStr, _, _ := strings.Cut(addr.String(), "/")
 			if ip := net.ParseIP(ipStr); ip == nil || ip.IsLinkLocalUnicast() || ip.IsLoopback() {
 				continue
 			}

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -1076,7 +1076,7 @@ func (c *Controller) generateNatOutgoingPolicyChainRules(protocol string) ([]uti
 	sort.Strings(subnetNames)
 
 	getMatchProtocol := func(ips string) string {
-		ip := strings.Split(ips, ",")[0]
+		ip, _, _ := strings.Cut(ips, ",")
 		return util.CheckProtocol(ip)
 	}
 

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -666,7 +666,7 @@ func waitNetworkReady(nic, ipAddr, gateway string, preferARP, verbose bool, maxR
 		return fmt.Errorf("the count of ip addresses and gateways mismatch: ips %q, gateways %q", ipAddr, gateway)
 	}
 	for i, gw := range gws {
-		src := strings.Split(ips[i], "/")[0]
+		src, _, _ := strings.Cut(ips[i], "/")
 		if preferARP && util.CheckProtocol(gw) == kubeovnv1.ProtocolIPv4 {
 			mac, count, err := util.ArpResolve(nic, gw, time.Second, maxRetry, done)
 			cniConnectivityResult.WithLabelValues(nodeName).Add(float64(count))

--- a/pkg/ovs/util.go
+++ b/pkg/ovs/util.go
@@ -345,7 +345,7 @@ func (m groupACLMatch) String() string {
 
 type Limiter struct {
 	limit   int32
-	current int32
+	current atomic.Int32
 }
 
 func (l *Limiter) Limit() int32 {
@@ -353,7 +353,7 @@ func (l *Limiter) Limit() int32 {
 }
 
 func (l *Limiter) Current() int32 {
-	return atomic.LoadInt32(&l.current)
+	return l.current.Load()
 }
 
 func (l *Limiter) Update(limit int32) {
@@ -367,12 +367,12 @@ func (l *Limiter) Wait(ctx context.Context) error {
 			return errors.New("context canceled by timeout")
 		default:
 			if l.limit == 0 {
-				atomic.AddInt32(&l.current, 1)
+				l.current.Add(1)
 				return nil
 			}
 
-			if atomic.LoadInt32(&l.current) < l.limit {
-				atomic.AddInt32(&l.current, 1)
+			if l.current.Load() < l.limit {
+				l.current.Add(1)
 				return nil
 			}
 			time.Sleep(10 * time.Millisecond)
@@ -381,5 +381,5 @@ func (l *Limiter) Wait(ctx context.Context) error {
 }
 
 func (l *Limiter) Done() {
-	atomic.AddInt32(&l.current, -1)
+	l.current.Add(-1)
 }

--- a/pkg/util/security_group.go
+++ b/pkg/util/security_group.go
@@ -14,8 +14,7 @@ func (s *securityGroupTierValidationError) Error() string {
 }
 
 func (s *securityGroupTierValidationError) Is(err error) bool {
-	var sgError *securityGroupTierValidationError
-	if errors.As(err, &sgError) {
+	if sgError, ok := errors.AsType[*securityGroupTierValidationError](err); ok {
 		return sgError.invalidTier == s.invalidTier
 	}
 	return false

--- a/pkg/util/servicecidr_store_test.go
+++ b/pkg/util/servicecidr_store_test.go
@@ -140,15 +140,15 @@ func TestServiceCIDRStoreDebounceCoalesces(t *testing.T) {
 	s := NewServiceCIDRStore("10.96.0.0/12")
 	s.debounceInterval = 30 * time.Millisecond
 
-	var fired int32
-	s.OnChange(func() { atomic.AddInt32(&fired, 1) })
+	var fired atomic.Int32
+	s.OnChange(func() { fired.Add(1) })
 
 	for range 5 {
 		s.UpsertFromAPI("k", []string{"10.97.0.0/16"})
 		s.UpsertFromAPI("k", []string{"10.98.0.0/16"})
 	}
 	time.Sleep(120 * time.Millisecond)
-	if got := atomic.LoadInt32(&fired); got > 2 {
+	if got := fired.Load(); got > 2 {
 		t.Fatalf("debounce should coalesce bursts, fired=%d", got)
 	}
 }

--- a/test/e2e/kube-ovn/underlay/underlay.go
+++ b/test/e2e/kube-ovn/underlay/underlay.go
@@ -772,12 +772,12 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 				var availIPs []string
 				v4Cidr, v6Cidr := util.SplitStringIP(subnet.Spec.CIDRBlock)
 				if v4Cidr != "" {
-					startIP := strings.Split(v4Cidr, "/")[0]
+					startIP, _, _ := strings.Cut(v4Cidr, "/")
 					ip, _ := ipam.NewIP(startIP)
 					availIPs = append(availIPs, ip.Add(100+int64(index)).String())
 				}
 				if v6Cidr != "" {
-					startIP := strings.Split(v6Cidr, "/")[0]
+					startIP, _, _ := strings.Cut(v6Cidr, "/")
 					ip, _ := ipam.NewIP(startIP)
 					availIPs = append(availIPs, ip.Add(100+int64(index)).String())
 				}
@@ -1065,7 +1065,7 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 			}
 		}
 		framework.ExpectNotEmpty(nodeIPv6, "No node with IPv6 address found")
-		ipv6Addr := strings.Split(nodeIPv6, "/")[0]
+		ipv6Addr, _, _ := strings.Cut(nodeIPv6, "/")
 
 		ginkgo.By(fmt.Sprintf("Creating pod %s that pings IPv6 node IP %s on node %s", podName, ipv6Addr, selectedNode.Name()))
 		// Use ping6 with one attempt and 1s timeout, checking the return code

--- a/test/e2e/kube-ovn/underlay/vlan_subinterfaces.go
+++ b/test/e2e/kube-ovn/underlay/vlan_subinterfaces.go
@@ -3,6 +3,7 @@ package underlay
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -96,8 +97,8 @@ var _ = framework.SerialDescribe("[group:underlay]", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		for i := len(providerNetworkNames) - 1; i >= 0; i-- {
-			providerNetworkClient.DeleteSync(providerNetworkNames[i])
+		for _, providerNetworkName := range slices.Backward(providerNetworkNames) {
+			providerNetworkClient.DeleteSync(providerNetworkName)
 		}
 
 		// Wait for OVS bridges to disappear on all nodes before disconnecting

--- a/test/e2e/metallb/e2e_test.go
+++ b/test/e2e/metallb/e2e_test.go
@@ -281,7 +281,7 @@ var _ = framework.Describe("[group:metallb]", func() {
 				gateway = append(gateway, gatewayV4)
 			}
 			for index := range 10 {
-				startIP := strings.Split(cidrV4, "/")[0]
+				startIP, _, _ := strings.Cut(cidrV4, "/")
 				ip, _ := ipam.NewIP(startIP)
 				metallbVIPv4s = append(metallbVIPv4s, ip.Add(100+int64(index)).String())
 			}
@@ -294,7 +294,7 @@ var _ = framework.Describe("[group:metallb]", func() {
 				gateway = append(gateway, gatewayV6)
 			}
 			for index := range 10 {
-				startIP := strings.Split(cidrV6, "/")[0]
+				startIP, _, _ := strings.Cut(cidrV6, "/")
 				ip, _ := ipam.NewIP(startIP)
 				metallbVIPv6s = append(metallbVIPv6s, ip.Add(100+int64(index)).String())
 			}

--- a/test/e2e/non-primary-cni/e2e_test.go
+++ b/test/e2e/non-primary-cni/e2e_test.go
@@ -655,7 +655,7 @@ func verifySNATRule(snatRule *kubeovnv1.IptablesSnatRule, expectedPodIP string, 
 	framework.ExpectNotEmpty(snatRule.Spec.EIP, "SNAT rule %s should specify an EIP", snatRule.Name)
 
 	if expectedPodIP != "" {
-		internalIP := strings.Split(snatRule.Spec.InternalCIDR, "/")[0]
+		internalIP, _, _ := strings.Cut(snatRule.Spec.InternalCIDR, "/")
 		framework.ExpectEqual(internalIP, expectedPodIP, "SNAT rule %s should map correct internal CIDR", snatRule.Name)
 	}
 	if expectedEIP != nil {


### PR DESCRIPTION
## Summary

`makefiles/build.mk:160` invokes `modernize@latest`, which always pulls the latest version. A new modernize release added analyzers that now flag 14 existing locations in master, breaking CI lint for every open PR (e.g. #6755, #6756, and master itself — run [26021596127](https://github.com/kubeovn/kube-ovn/actions/runs/26021596127)).

This is a mechanical cleanup PR generated by `make lint` (which runs `modernize -fix` in local mode).

### Fixes applied
| Category | Files |
|---|---|
| `var int32` + `atomic.LoadInt32`/`AddInt32` → `atomic.Int32` type | `pkg/ovs/util.go`, `pkg/util/servicecidr_store_test.go` |
| `errors.As(err, &v)` + `var v T` → `errors.AsType[T](err)` | `pkg/util/security_group.go` |
| Backward `for i := n-1; i >= 0; i--` → `for _, x := range slices.Backward(s)` | `test/e2e/kube-ovn/underlay/vlan_subinterfaces.go` |
| `strings.Split(s, sep)[0]` → `strings.Cut(s, sep)` (only takes `before`) | `pkg/daemon/{config,controller_linux,gateway_linux,ovs_linux}.go`, `test/e2e/kube-ovn/underlay/underlay.go`, `test/e2e/metallb/e2e_test.go`, `test/e2e/non-primary-cni/e2e_test.go` |

### Follow-up (separate PR)
Consider pinning `modernize` to a specific version in `makefiles/build.mk` (instead of `@latest`) and letting renovate track it, so future toolchain releases don't silently break all PRs at once.

## Test plan
- [x] `make lint` passes locally (both interactive and `CI=true` modes)
- [x] `go build ./...` succeeds
- [x] `go test ./pkg/ovs/... ./pkg/util/...` for `Limiter` and `ServiceCIDR` (the two atomic-migration sites) passes
- [ ] CI lint job green on this PR