### PR TITLE
PR introduces changes to correctly support multiple network interfaces from same subnet

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2093,10 +2093,10 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			// helper function to try and identify correct subnet when interface name is provided in request, this is for the case when multiple attach with same NAD but different interface name and the providerName contains interface name but subnet spec does not contain it
 			subnetMatches := func(subnet *kubeovnv1.Subnet, providerName, ifName string) bool {
 				var subnetProviderName string
-				if ifName != "" {
-					providerNameElements := strings.Split(providerName, ".")
-					subnetProviderName = fmt.Sprintf("%s.%s.%s", providerNameElements[0], providerNameElements[1], util.OvnProvider)
-				}
+				// if providerName contains ifName, then we trim it from the providerName to match with subnet spec
+				subnetProviderName, _ = strings.CutSuffix(providerName, "."+ifName)
+				klog.Infof("subnet %s, subnet provider %s, providername %s, trimmed subnetprovider %s, ifName %s", subnet.Name, subnet.Spec.Provider, providerName, subnetProviderName, ifName)
+
 				if subnet.Spec.Provider == subnetProviderName {
 					klog.Infof("matched to subnet %s", subnet.Name)
 					return true
@@ -2115,6 +2115,7 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 					}
 				}
 			}
+			klog.V(5).Infof("found subnet %s for provider %s", subnetName, providerName)
 			var subnet *kubeovnv1.Subnet
 			if subnetName == "" {
 				// attachment network not specify subnet, use pod default subnet or namespace subnet

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1451,6 +1451,10 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 	return nil
 }
 
+// we send pod net generated from     k8s.v1.cni.cncf.io/networks: '[{"name": "vm-overlay", "namespace": "default", "interface": "net1"}, {"name": "vm-overlay", "namespace": "default", "interface": "net2"}]'
+// there is no mac or ip address request here in the object generated from here
+// interface name in providerName is used for annotation for ip address
+
 func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, error) {
 	podName := c.getNameByPod(pod)
 	key := cache.NewObjectName(pod.Namespace, podName).String()
@@ -1954,9 +1958,36 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			if k8serrors.IsNotFound(err) && ignoreSubnetNotExist {
 				// NAD deleted before pod, find subnet for cleanup
 				providerName := fmt.Sprintf("%s.%s.%s", attach.Name, attach.Namespace, util.OvnProvider)
+				// k8s.v1.cni.cncf.io/networks: '[{"name": "vm-overlay", "namespace": "default", "interface": "net1"}, {"name": "vm-overlay", "namespace": "default", "interface": "net2"}]'
+				// will make providerName to be "vm-overlay.default.ovn.net1" and "vm-overlay.default.ovn.net2", but the subnet annotation is "vm-overlay.default.ovn"
 				if nadCounts[nadKey] > 1 && attach.InterfaceRequest != "" {
 					providerName = fmt.Sprintf("%s.%s", providerName, attach.InterfaceRequest)
 				}
+
+				// if interface name is provided this means providerName will contain interface name
+				// say vm-overlay.default.ovn.net1 which will not match the `provider` definition in the config object
+				/*
+									apiVersion: k8s.cni.cncf.io/v1
+					kind: NetworkAttachmentDefinition
+					metadata:
+					  creationTimestamp: "2026-05-18T00:49:37Z"
+					  finalizers:
+					  - wrangler.cattle.io/harvester-network-manager-nad-controller
+					  generation: 1
+					  labels:
+					    network.harvesterhci.io/clusternetwork: mgmt
+					    network.harvesterhci.io/ready: "true"
+					    network.harvesterhci.io/type: OverlayNetwork
+					  name: vm-overlay
+					  namespace: default
+					  resourceVersion: "23021"
+					  uid: c281375e-d7eb-4495-980e-ec4c09ac7be9
+					spec:
+					  config: '{"cniVersion":"0.3.1","name":"vm-overlay","type":"kube-ovn","provider":"vm-overlay.default.ovn","server_socket":"/run/openvswitch/kube-ovn-daemon.sock"}'
+				*/
+				// for each interface then we need annotation
+				// vm-overlay.default.ovn.net1.kubernetes.io/logical_switch = "subnetName" to allow it to identify correct switch to be associated with this interface
+				// interfaceName is included in the name
 				subnetName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, providerName)]
 				if subnetName == "" {
 					for _, subnet := range subnets {
@@ -2013,18 +2044,72 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			allowLiveMigration := false
 			isDefault := util.IsDefaultNet(pod.Annotations[util.DefaultNetworkAnnotation], attach)
 
+			// same logic as above we adding ifName in providerName
+
+			// vm-overlay.default.ovn
 			providerName = fmt.Sprintf("%s.%s.%s", attach.Name, attach.Namespace, util.OvnProvider)
 			if nadCounts[nadKey] > 1 && attach.InterfaceRequest != "" {
+				// due to interface name in request this becomes
+				// vm-overlay.default.ovn.net1
 				providerName = fmt.Sprintf("%s.%s", providerName, attach.InterfaceRequest)
 			}
 			if pod.Annotations[kubevirtv1.MigrationJobNameAnnotation] != "" {
 				allowLiveMigration = true
 			}
 
+			/*
+				apiVersion: kubeovn.io/v1
+				kind: Subnet
+				metadata:
+				  creationTimestamp: "2026-05-18T00:50:05Z"
+				  finalizers:
+				  - kubeovn.io/kube-ovn-controller
+				  generation: 6
+				  name: vm-overlay
+				  resourceVersion: "166506"
+				  uid: 094aca79-e976-42ba-bf52-3e65e6b02fc2
+				spec:
+				  cidrBlock: 192.168.0.0/24
+				  default: false
+				  dhcpV4Options: ""
+				  dhcpV6Options: ""
+				  enableDHCP: true
+				  enableLb: true
+				  excludeIps:
+				  - 192.168.0.1..192.168.0.100
+				  gateway: 192.168.0.1
+				  gatewayNode: ""
+				  gatewayType: distributed
+				  natOutgoing: false
+				  private: false
+				  protocol: IPv4
+				  provider: vm-overlay.default.ovn
+				  vpc: ovn-cluster
+			*/
+			// as a result when default subnetName i not provided then it will not match subnet spec.. as a result we find nothing and subnet is set to empty
+			// key is vm-overlay.default.ovn.net1.kubernetes.io/logical_switch: vm-overlay
 			subnetName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, providerName)]
+
+			// helper function to try and identify correct subnet when interface name is provided in request, this is for the case when multiple attach with same NAD but different interface name and the providerName contains interface name but subnet spec does not contain it
+			subnetMatches := func(subnet *kubeovnv1.Subnet, providerName, ifName string) bool {
+				var subnetProviderName string
+				if ifName != "" {
+					providerNameElements := strings.Split(providerName, ".")
+					subnetProviderName = fmt.Sprintf("%s.%s", providerNameElements[0], providerNameElements[1])
+				}
+				if subnet.Spec.Provider == subnetProviderName {
+					klog.Infof("matched to subnet %s", subnet.Name)
+					return true
+				}
+
+				return false
+			}
 			if subnetName == "" {
+				// when ifName is provided in request, the `provider` in subnet spec will not match
+				// since it does not contain substring for interface name and wrong subnet will be selected
+				// and it goes to default subnet
 				for _, subnet := range subnets {
-					if subnet.Spec.Provider == providerName {
+					if subnetMatches(subnet, providerName, attach.InterfaceRequest) {
 						subnetName = subnet.Name
 						break
 					}
@@ -2033,6 +2118,30 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			var subnet *kubeovnv1.Subnet
 			if subnetName == "" {
 				// attachment network not specify subnet, use pod default subnet or namespace subnet
+				// uses default subnet based on namespace annotation
+				/*
+					apiVersion: v1
+					kind: Namespace
+					metadata:
+					  annotations:
+					    ovn.kubernetes.io/cidr: 10.54.0.0/16
+					    ovn.kubernetes.io/exclude_ips: 10.54.0.1
+					    ovn.kubernetes.io/logical_switch: ovn-default
+					  creationTimestamp: "2026-05-18T00:29:34Z"
+					  finalizers:
+					  - wrangler.cattle.io/harvester-namespace-controller
+					  labels:
+					    kubernetes.io/metadata.name: default
+					  name: default
+					  resourceVersion: "21589"
+					  uid: f38759d7-0439-44bd-94bf-89e7c766723b
+					spec:
+					  finalizers:
+					  - kubernetes
+					status:
+					  phase: Active
+				*/
+				// in this it goes to `ovn-default` and that explains the ipam error because the address is not in the range
 				subnet, err = c.getPodDefaultSubnet(pod)
 				if err != nil {
 					klog.Errorf("failed to pod default subnet, %v", err)
@@ -2062,6 +2171,7 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 				}
 			}
 
+			// we send no macrequest or ip request so these should be empty in the response here
 			ret := &kubeovnNet{
 				Type:               providerTypeOriginal,
 				ProviderName:       providerName,
@@ -2128,6 +2238,7 @@ func (c *Controller) validatePodIP(podName, subnetName, ipv4, ipv6 string) (bool
 }
 
 func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, string, string, *kubeovnv1.Subnet, error) {
+	// becomes vmNAme when pod is owned by a kubevirt VM
 	podName := c.getNameByPod(pod)
 	key := cache.NewObjectName(pod.Namespace, podName).String()
 	portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
@@ -2153,6 +2264,7 @@ func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, st
 
 	var macPointer *string
 	if podNet.NadName != "" && podNet.NadNamespace != "" && podNet.InterfaceName != "" {
+		// will not use the mac address vm-overlay.default.kubernetes.io/mac_address.net1
 		key := perInterfaceMACAnnotationKey(podNet.NadName, podNet.NadNamespace, podNet.InterfaceName)
 		if macStr := pod.Annotations[key]; macStr != "" {
 			if _, err := net.ParseMAC(macStr); err != nil {
@@ -2250,11 +2362,13 @@ func (c *Controller) acquireAddress(pod *v1.Pod, podNet *kubeovnNet) (string, st
 		}
 	}
 
-	// Random allocate
+	// will be subnet.namespace.interface.ovn.kubernetes.io/ip_address in case of multiple interfaces with
+	// interface name provided or subnet.namespace.ovn.kubernetes.io/ip_address in case of single interface or multiple interfaces without interface name provided
 	if pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] == "" &&
 		ippoolStr == "" {
 		// check new IP annotation
 		if podNet.NadName != "" && podNet.NadNamespace != "" && podNet.InterfaceName != "" {
+			// subnet.namespace.kubernetes.io/ip_address.ifName = ipAddress
 			annoKey := perInterfaceIPAnnotationKey(podNet.NadName, podNet.NadNamespace, podNet.InterfaceName)
 			if ipStr := pod.Annotations[annoKey]; ipStr != "" {
 				return c.acquireStaticAddressHelper(pod, podNet, portName, macPointer, ippoolStr, nsNets, isStsPod, key)

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1966,25 +1966,6 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 
 				// if interface name is provided this means providerName will contain interface name
 				// say vm-overlay.default.ovn.net1 which will not match the `provider` definition in the config object
-				/*
-									apiVersion: k8s.cni.cncf.io/v1
-					kind: NetworkAttachmentDefinition
-					metadata:
-					  creationTimestamp: "2026-05-18T00:49:37Z"
-					  finalizers:
-					  - wrangler.cattle.io/harvester-network-manager-nad-controller
-					  generation: 1
-					  labels:
-					    network.harvesterhci.io/clusternetwork: mgmt
-					    network.harvesterhci.io/ready: "true"
-					    network.harvesterhci.io/type: OverlayNetwork
-					  name: vm-overlay
-					  namespace: default
-					  resourceVersion: "23021"
-					  uid: c281375e-d7eb-4495-980e-ec4c09ac7be9
-					spec:
-					  config: '{"cniVersion":"0.3.1","name":"vm-overlay","type":"kube-ovn","provider":"vm-overlay.default.ovn","server_socket":"/run/openvswitch/kube-ovn-daemon.sock"}'
-				*/
 				// for each interface then we need annotation
 				// vm-overlay.default.ovn.net1.kubernetes.io/logical_switch = "subnetName" to allow it to identify correct switch to be associated with this interface
 				// interfaceName is included in the name
@@ -2057,35 +2038,6 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 				allowLiveMigration = true
 			}
 
-			/*
-				apiVersion: kubeovn.io/v1
-				kind: Subnet
-				metadata:
-				  creationTimestamp: "2026-05-18T00:50:05Z"
-				  finalizers:
-				  - kubeovn.io/kube-ovn-controller
-				  generation: 6
-				  name: vm-overlay
-				  resourceVersion: "166506"
-				  uid: 094aca79-e976-42ba-bf52-3e65e6b02fc2
-				spec:
-				  cidrBlock: 192.168.0.0/24
-				  default: false
-				  dhcpV4Options: ""
-				  dhcpV6Options: ""
-				  enableDHCP: true
-				  enableLb: true
-				  excludeIps:
-				  - 192.168.0.1..192.168.0.100
-				  gateway: 192.168.0.1
-				  gatewayNode: ""
-				  gatewayType: distributed
-				  natOutgoing: false
-				  private: false
-				  protocol: IPv4
-				  provider: vm-overlay.default.ovn
-				  vpc: ovn-cluster
-			*/
 			// as a result when default subnetName i not provided then it will not match subnet spec.. as a result we find nothing and subnet is set to empty
 			// key is vm-overlay.default.ovn.net1.kubernetes.io/logical_switch: vm-overlay
 			subnetName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, providerName)]
@@ -2120,28 +2072,6 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			if subnetName == "" {
 				// attachment network not specify subnet, use pod default subnet or namespace subnet
 				// uses default subnet based on namespace annotation
-				/*
-					apiVersion: v1
-					kind: Namespace
-					metadata:
-					  annotations:
-					    ovn.kubernetes.io/cidr: 10.54.0.0/16
-					    ovn.kubernetes.io/exclude_ips: 10.54.0.1
-					    ovn.kubernetes.io/logical_switch: ovn-default
-					  creationTimestamp: "2026-05-18T00:29:34Z"
-					  finalizers:
-					  - wrangler.cattle.io/harvester-namespace-controller
-					  labels:
-					    kubernetes.io/metadata.name: default
-					  name: default
-					  resourceVersion: "21589"
-					  uid: f38759d7-0439-44bd-94bf-89e7c766723b
-					spec:
-					  finalizers:
-					  - kubernetes
-					status:
-					  phase: Active
-				*/
 				// in this it goes to `ovn-default` and that explains the ipam error because the address is not in the range
 				subnet, err = c.getPodDefaultSubnet(pod)
 				if err != nil {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2095,7 +2095,7 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 				var subnetProviderName string
 				if ifName != "" {
 					providerNameElements := strings.Split(providerName, ".")
-					subnetProviderName = fmt.Sprintf("%s.%s", providerNameElements[0], providerNameElements[1])
+					subnetProviderName = fmt.Sprintf("%s.%s.%s", providerNameElements[0], providerNameElements[1], util.OvnProvider)
 				}
 				if subnet.Spec.Provider == subnetProviderName {
 					klog.Infof("matched to subnet %s", subnet.Name)

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -440,7 +440,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 func (csh cniServerHandler) UpdateIPCR(podRequest request.CniRequest, subnet, ip string) error {
 	klog.V(4).Infof("found subnet %s", subnet)
 	ipCRName := ovs.PodNameToPortName(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider)
-	if podRequest.IfName != "" {
+	if podRequest.IfName != util.DefaultPodInterfaceName {
 		// append ifname to ipCRName
 		ipCRName = fmt.Sprintf("%s.%s", ipCRName, podRequest.IfName)
 	}
@@ -481,6 +481,7 @@ func (csh cniServerHandler) UpdateIPCR(podRequest request.CniRequest, subnet, ip
 
 func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Response) {
 	var podRequest request.CniRequest
+
 	if err := req.ReadEntity(&podRequest); err != nil {
 		errMsg := fmt.Errorf("parse del request failed %w", err)
 		klog.Error(errMsg)

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -46,13 +46,20 @@ func createCniServerHandler(config *Configuration, controller *Controller) *cniS
 	return csh
 }
 
-func (csh cniServerHandler) providerExists(provider string) (*kubeovnv1.Subnet, bool) {
+func (csh cniServerHandler) providerExists(provider, ifName string) (*kubeovnv1.Subnet, bool) {
 	if util.IsOvnProvider(provider) {
 		return nil, true
 	}
 	subnets, _ := csh.Controller.subnetsLister.List(labels.Everything())
+	// for multi interface attachments the ifname is included in provider, for example, vm-overlay.default.ovn.net1
+	// as a result if ifname is set, we need to append it to subnet provider when comparing with request provider
+	// else no subnet will be found
 	for _, subnet := range subnets {
-		if subnet.Spec.Provider == provider {
+		subnetProvider := subnet.Spec.Provider
+		if ifName != "" {
+			subnetProvider = fmt.Sprintf("%s.%s", subnet.Spec.Provider, ifName)
+		}
+		if subnetProvider == provider {
 			return subnet.DeepCopy(), true
 		}
 	}
@@ -70,7 +77,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		return
 	}
 	klog.V(5).Infof("request body is %v", podRequest)
-	podSubnet, exist := csh.providerExists(podRequest.Provider)
+	podSubnet, exist := csh.providerExists(podRequest.Provider, podRequest.IfName)
 	if !exist {
 		errMsg := fmt.Errorf("provider %s not bind to any subnet", podRequest.Provider)
 		klog.Error(errMsg)
@@ -104,7 +111,9 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			}
 			return
 		}
-		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podRequest.Provider)] != "true" {
+
+		ip = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate)
+		if ip == "" {
 			klog.Infof("wait address for pod %s/%s provider %s", podRequest.PodNamespace, podRequest.PodName, podRequest.Provider)
 			// wait controller assign an address
 			cniWaitAddressResult.WithLabelValues(nodeName).Inc()
@@ -119,20 +128,20 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			time.Sleep(1 * time.Second)
 			continue
 		}
-		ip = pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podRequest.Provider)]
-		cidr = pod.Annotations[fmt.Sprintf(util.CidrAnnotationTemplate, podRequest.Provider)]
-		gw = pod.Annotations[fmt.Sprintf(util.GatewayAnnotationTemplate, podRequest.Provider)]
-		subnet = pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podRequest.Provider)]
-		ingress = pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, podRequest.Provider)]
-		egress = pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, podRequest.Provider)]
-		ingressBurst = pod.Annotations[fmt.Sprintf(util.IngressBurstAnnotationTemplate, podRequest.Provider)]
-		egressBurst = pod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, podRequest.Provider)]
-		latency = pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, podRequest.Provider)]
-		limit = pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, podRequest.Provider)]
-		loss = pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, podRequest.Provider)]
-		jitter = pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, podRequest.Provider)]
-		providerNetwork = pod.Annotations[fmt.Sprintf(util.ProviderNetworkTemplate, podRequest.Provider)]
-		vmName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, podRequest.Provider)]
+
+		cidr = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.CidrAnnotationTemplate)
+		gw = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.GatewayAnnotationTemplate)
+		subnet = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.LogicalSwitchAnnotationTemplate)
+		ingress = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IngressRateAnnotationTemplate)
+		egress = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.EgressRateAnnotationTemplate)
+		ingressBurst = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IngressBurstAnnotationTemplate)
+		egressBurst = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.EgressBurstAnnotationTemplate)
+		latency = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLatencyAnnotationTemplate)
+		limit = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLimitAnnotationTemplate)
+		loss = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLossAnnotationTemplate)
+		jitter = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosJitterAnnotationTemplate)
+		providerNetwork = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.ProviderNetworkTemplate)
+		vmName = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.VMAnnotationTemplate)
 		ipAddr, noIPAM, err = util.GetIPAddrWithMaskForCNI(ip, cidr)
 		if err != nil {
 			errMsg := fmt.Errorf("failed to get ip address with mask, %w", err)
@@ -201,7 +210,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		break
 	}
 
-	if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podRequest.Provider)] != "true" {
+	if util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate) == "" {
 		err := fmt.Errorf("no address allocated to pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
 		klog.Error(err)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
@@ -317,8 +326,9 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			}
 		}
 
-		macAddr = pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podRequest.Provider)]
+		macAddr = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.MacAddressAnnotationTemplate)
 		klog.Infof("create container interface %s mac %s, ip %s, cidr %s, gw %s, custom routes %v", ifName, macAddr, ipAddr, cidr, gw, routes)
+
 		podNicName = ifName
 
 		var encapIP string
@@ -428,7 +438,12 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 }
 
 func (csh cniServerHandler) UpdateIPCR(podRequest request.CniRequest, subnet, ip string) error {
+	klog.V(4).Infof("found subnet %s", subnet)
 	ipCRName := ovs.PodNameToPortName(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider)
+	if podRequest.IfName != "" {
+		// append ifname to ipCRName
+		ipCRName = fmt.Sprintf("%s.%s", ipCRName, podRequest.IfName)
+	}
 	for range 20 {
 		ipCR, err := csh.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), ipCRName, metav1.GetOptions{})
 		if err != nil {
@@ -509,7 +524,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		if pod.Annotations != nil && (util.IsOvnProvider(podRequest.Provider) || podRequest.CniType == util.CniTypeName) {
 			subnet := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podRequest.Provider)]
 			if subnet != "" {
-				ip := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podRequest.Provider)]
+				ip := util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate)
 				if err = csh.Controller.removeEgressConfig(subnet, ip); err != nil {
 					errMsg := fmt.Errorf("failed to remove egress configuration: %w", err)
 					klog.Error(errMsg)

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -54,12 +54,9 @@ func (csh cniServerHandler) providerExists(provider, ifName string) (*kubeovnv1.
 	// for multi interface attachments the ifname is included in provider, for example, vm-overlay.default.ovn.net1
 	// as a result if ifname is set, we need to append it to subnet provider when comparing with request provider
 	// else no subnet will be found
+	providerName, _ := strings.CutSuffix(provider, fmt.Sprintf(".%s", ifName))
 	for _, subnet := range subnets {
-		subnetProvider := subnet.Spec.Provider
-		if ifName != "" {
-			subnetProvider = fmt.Sprintf("%s.%s", subnet.Spec.Provider, ifName)
-		}
-		if subnetProvider == provider {
+		if subnet.Spec.Provider == providerName {
 			return subnet.DeepCopy(), true
 		}
 	}
@@ -102,6 +99,10 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	var isDefaultRoute, noIPAM bool
 	var pod *v1.Pod
 	var err error
+
+	providerWithIfName := fmt.Sprintf("%s.%s", podRequest.Provider, podRequest.IfName)
+	var appendIfName bool
+
 	for range 20 {
 		if pod, err = csh.Controller.podsLister.Pods(podRequest.PodNamespace).Get(podRequest.PodName); err != nil {
 			errMsg := fmt.Errorf("get pod %s/%s failed %w", podRequest.PodNamespace, podRequest.PodName, err)
@@ -112,7 +113,13 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			return
 		}
 
-		ip = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate)
+		// in case of multiple nics from same subnet
+		_, ok := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerWithIfName)]
+		if ok {
+			appendIfName = true
+		}
+
+		ip = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate, appendIfName)
 		if ip == "" {
 			klog.Infof("wait address for pod %s/%s provider %s", podRequest.PodNamespace, podRequest.PodName, podRequest.Provider)
 			// wait controller assign an address
@@ -129,19 +136,19 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			continue
 		}
 
-		cidr = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.CidrAnnotationTemplate)
-		gw = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.GatewayAnnotationTemplate)
-		subnet = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.LogicalSwitchAnnotationTemplate)
-		ingress = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IngressRateAnnotationTemplate)
-		egress = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.EgressRateAnnotationTemplate)
-		ingressBurst = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IngressBurstAnnotationTemplate)
-		egressBurst = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.EgressBurstAnnotationTemplate)
-		latency = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLatencyAnnotationTemplate)
-		limit = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLimitAnnotationTemplate)
-		loss = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLossAnnotationTemplate)
-		jitter = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosJitterAnnotationTemplate)
-		providerNetwork = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.ProviderNetworkTemplate)
-		vmName = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.VMAnnotationTemplate)
+		cidr = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.CidrAnnotationTemplate, appendIfName)
+		gw = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.GatewayAnnotationTemplate, appendIfName)
+		subnet = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.LogicalSwitchAnnotationTemplate, appendIfName)
+		ingress = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IngressRateAnnotationTemplate, appendIfName)
+		egress = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.EgressRateAnnotationTemplate, appendIfName)
+		ingressBurst = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IngressBurstAnnotationTemplate, appendIfName)
+		egressBurst = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.EgressBurstAnnotationTemplate, appendIfName)
+		latency = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLatencyAnnotationTemplate, appendIfName)
+		limit = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLimitAnnotationTemplate, appendIfName)
+		loss = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosLossAnnotationTemplate, appendIfName)
+		jitter = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosJitterAnnotationTemplate, appendIfName)
+		providerNetwork = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.ProviderNetworkTemplate, appendIfName)
+		vmName = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.VMAnnotationTemplate, appendIfName)
 		ipAddr, noIPAM, err = util.GetIPAddrWithMaskForCNI(ip, cidr)
 		if err != nil {
 			errMsg := fmt.Errorf("failed to get ip address with mask, %w", err)
@@ -151,6 +158,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			}
 			return
 		}
+
 		oldPodName = podRequest.PodName
 		if s := pod.Annotations[fmt.Sprintf(util.RoutesAnnotationTemplate, podRequest.Provider)]; s != "" {
 			if err = json.Unmarshal([]byte(s), &routes); err != nil {
@@ -210,7 +218,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		break
 	}
 
-	if util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate) == "" {
+	if util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate, appendIfName) == "" {
 		err := fmt.Errorf("no address allocated to pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
 		klog.Error(err)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
@@ -223,7 +231,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		subnet = podSubnet.Name
 	}
 	if !noIPAM {
-		if err := csh.UpdateIPCR(podRequest, subnet, ip); err != nil {
+		if err := csh.UpdateIPCR(podRequest, subnet, ip, appendIfName); err != nil {
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -326,9 +334,8 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			}
 		}
 
-		macAddr = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.MacAddressAnnotationTemplate)
+		macAddr = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.MacAddressAnnotationTemplate, appendIfName)
 		klog.Infof("create container interface %s mac %s, ip %s, cidr %s, gw %s, custom routes %v", ifName, macAddr, ipAddr, cidr, gw, routes)
-
 		podNicName = ifName
 
 		var encapIP string
@@ -354,7 +361,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			err = csh.configureDpdkNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, ingressBurst, egressBurst, getShortSharedDir(pod.UID, podRequest.VhostUserSocketVolumeName), podRequest.VhostUserSocketName, podRequest.VhostUserSocketConsumption)
 			routes = nil
 		default:
-			routes, err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, vmMigration, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, ingressBurst, egressBurst, podRequest.DeviceID, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet)
+			routes, err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, vmMigration, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, ingressBurst, egressBurst, podRequest.DeviceID, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet, appendIfName)
 		}
 		if err != nil {
 			errMsg := fmt.Errorf("configure nic %s for pod %s/%s failed: %w", ifName, podRequest.PodName, podRequest.PodNamespace, err)
@@ -437,11 +444,12 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	}
 }
 
-func (csh cniServerHandler) UpdateIPCR(podRequest request.CniRequest, subnet, ip string) error {
+func (csh cniServerHandler) UpdateIPCR(podRequest request.CniRequest, subnet, ip string, appendIfName bool) error {
 	klog.V(4).Infof("found subnet %s", subnet)
 	ipCRName := ovs.PodNameToPortName(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider)
-	if podRequest.IfName != util.DefaultPodInterfaceName {
-		// append ifname to ipCRName
+
+	// for backward compatibility we will check if annotation ip address exists with ifName first and subsequently with ifname
+	if appendIfName {
 		ipCRName = fmt.Sprintf("%s.%s", ipCRName, podRequest.IfName)
 	}
 	for range 20 {
@@ -481,6 +489,7 @@ func (csh cniServerHandler) UpdateIPCR(podRequest request.CniRequest, subnet, ip
 
 func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Response) {
 	var podRequest request.CniRequest
+	var appendIfName bool
 
 	if err := req.ReadEntity(&podRequest); err != nil {
 		errMsg := fmt.Errorf("parse del request failed %w", err)
@@ -502,6 +511,11 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		return
 	}
 
+	providerWithIfName := fmt.Sprintf("%s.%s", podRequest.Provider, podRequest.IfName)
+	_, ok := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerWithIfName)]
+	if ok {
+		appendIfName = true
+	}
 	if podRequest.NetNs == "" {
 		klog.Infof("skip del port request: %v", podRequest)
 		resp.WriteHeader(http.StatusNoContent)
@@ -525,7 +539,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		if pod.Annotations != nil && (util.IsOvnProvider(podRequest.Provider) || podRequest.CniType == util.CniTypeName) {
 			subnet := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podRequest.Provider)]
 			if subnet != "" {
-				ip := util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate)
+				ip := util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate, appendIfName)
 				if err = csh.Controller.removeEgressConfig(subnet, ip); err != nil {
 					errMsg := fmt.Errorf("failed to remove egress configuration: %w", err)
 					klog.Error(errMsg)

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -512,10 +512,6 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 	}
 
 	providerWithIfName := fmt.Sprintf("%s.%s", podRequest.Provider, podRequest.IfName)
-	_, ok := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerWithIfName)]
-	if ok {
-		appendIfName = true
-	}
 	if podRequest.NetNs == "" {
 		klog.Infof("skip del port request: %v", podRequest)
 		resp.WriteHeader(http.StatusNoContent)
@@ -537,7 +533,11 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 	// If the Pod was found, process its annotations and labels.
 	if pod != nil {
 		if pod.Annotations != nil && (util.IsOvnProvider(podRequest.Provider) || podRequest.CniType == util.CniTypeName) {
-			subnet := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podRequest.Provider)]
+			_, ok := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerWithIfName)]
+			if ok {
+				appendIfName = true
+			}
+			subnet := util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.LogicalSwitchAnnotationTemplate, appendIfName)
 			if subnet != "" {
 				ip := util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate, appendIfName)
 				if err = csh.Controller.removeEgressConfig(subnet, ip); err != nil {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -110,6 +110,12 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 
 	ipStr := util.GetIPWithoutMask(ip)
 	ifaceID := ovs.PodNameToPortName(podName, podNamespace, provider)
+	// in case of multiple interfaces the interface name is used to distinguish different interfaces
+	// currently ovs.PodNameToPortName ignores the ifname which results in same port being returned
+	// for default nics the ifname is set to eth0 by the handler, so we can use that to distinguish default nics and non default nics, for non default nics we can append the ifname to the ifaceID to make it unique for ovs port creation and later retrieval, this is required to avoid the issue of same port being returned for multiple interfaces which results in wrong port being configured and attached to the pod, and also results in wrong port being deleted during pod deletion which affects other interfaces attached to the same pod.
+	if ifName != "eth0" {
+		ifaceID = fmt.Sprintf("%s.%s", ifaceID, ifName)
+	}
 	ovs.CleanDuplicatePort(ifaceID, hostNicName)
 	if yusur.IsYusurSmartNic(deviceID) {
 		klog.Infof("add Yusur smartnic vfr %s to ovs", hostNicName)

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -71,7 +71,7 @@ func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, ne
 	return ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress, egressBurst, ingressBurst)
 }
 
-func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, _, _ []string, ingress, egress, ingressBurst, egressBurst, deviceID, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet string) ([]request.Route, error) {
+func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, _, _ []string, ingress, egress, ingressBurst, egressBurst, deviceID, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet string, appendIfName bool) ([]request.Route, error) {
 	var err error
 	var hostNicName, containerNicName, pfPci string
 	var vfID int
@@ -113,7 +113,7 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 	// in case of multiple interfaces the interface name is used to distinguish different interfaces
 	// currently ovs.PodNameToPortName ignores the ifname which results in same port being returned
 	// for default nics the ifname is set to eth0 by the handler, so we can use that to distinguish default nics and non default nics, for non default nics we can append the ifname to the ifaceID to make it unique for ovs port creation and later retrieval, this is required to avoid the issue of same port being returned for multiple interfaces which results in wrong port being configured and attached to the pod, and also results in wrong port being deleted during pod deletion which affects other interfaces attached to the same pod.
-	if ifName != "eth0" {
+	if appendIfName {
 		ifaceID = fmt.Sprintf("%s.%s", ifaceID, ifName)
 	}
 	ovs.CleanDuplicatePort(ifaceID, hostNicName)

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -831,12 +831,13 @@ func PerInterfaceIPAnnotationKey(nadName, nadNamespace, ifaceName string) string
 }
 
 // GetAnnotationWithIfNameOverride returns the annotation value with interface name override if ifName is provided, otherwise return the annotation value without interface name.
-func GetAnnotationWithIfNameOverride(annotations map[string]string, provider, ifName, annotationTemplate string) string {
+func GetAnnotationWithIfNameOverride(annotations map[string]string, provider, ifName, annotationTemplate string, appendIfName bool) string {
 	// default behaviour when no interface name is specified
 	// verify if a custom ifname is provided then annotation will be of form
 	// vm-overlay.default.ovn.net1.kubernetes.io/xxx: xxx
-	if ifName != DefaultPodInterfaceName {
+	if appendIfName {
 		provider = fmt.Sprintf("%s.%s", provider, ifName)
 	}
+
 	return annotations[fmt.Sprintf(annotationTemplate, provider)]
 }

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -824,3 +824,18 @@ func ValidateProtocol(protocol string) error {
 	}
 	return nil
 }
+
+func PerInterfaceIPAnnotationKey(nadName, nadNamespace, ifaceName string) string {
+	return fmt.Sprintf("%s.%s.kubernetes.io/ip_address.%s", nadName, nadNamespace, ifaceName)
+}
+
+// GetAnnotationWithIfNameOverride returns the annotation value with interface name override if ifName is provided, otherwise return the annotation value without interface name.
+func GetAnnotationWithIfNameOverride(annotations map[string]string, provider, ifName, annotationTemplate string) string {
+	// default behaviour when no interface name is specified
+	// verify if a custom ifname is provided then annotation will be of form
+	// vm-overlay.default.ovn.net1.kubernetes.io/xxx: xxx
+	if ifName != "" {
+		provider = fmt.Sprintf("%s.%s", provider, ifName)
+	}
+	return annotations[fmt.Sprintf(annotationTemplate, provider)]
+}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -31,10 +31,11 @@ const (
 	IPv4Zero             = "0.0.0.0/32"
 	IPv4LinkLocalUnicast = "169.254.0.0/16"
 
-	IPv6Unspecified      = "::/128"
-	IPv6Loopback         = "::1/128"
-	IPv6Multicast        = "ff00::/8"
-	IPv6LinkLocalUnicast = "FE80::/10"
+	IPv6Unspecified         = "::/128"
+	IPv6Loopback            = "::1/128"
+	IPv6Multicast           = "ff00::/8"
+	IPv6LinkLocalUnicast    = "FE80::/10"
+	DefaultPodInterfaceName = "eth0"
 )
 
 // GenerateMac generates mac address.
@@ -834,7 +835,7 @@ func GetAnnotationWithIfNameOverride(annotations map[string]string, provider, if
 	// default behaviour when no interface name is specified
 	// verify if a custom ifname is provided then annotation will be of form
 	// vm-overlay.default.ovn.net1.kubernetes.io/xxx: xxx
-	if ifName != "" {
+	if ifName != DefaultPodInterfaceName {
 		provider = fmt.Sprintf("%s.%s", provider, ifName)
 	}
 	return annotations[fmt.Sprintf(annotationTemplate, provider)]

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -826,10 +826,6 @@ func ValidateProtocol(protocol string) error {
 	return nil
 }
 
-func PerInterfaceIPAnnotationKey(nadName, nadNamespace, ifaceName string) string {
-	return fmt.Sprintf("%s.%s.kubernetes.io/ip_address.%s", nadName, nadNamespace, ifaceName)
-}
-
 // GetAnnotationWithIfNameOverride returns the annotation value with interface name override if ifName is provided, otherwise return the annotation value without interface name.
 func GetAnnotationWithIfNameOverride(annotations map[string]string, provider, ifName, annotationTemplate string, appendIfName bool) string {
 	// default behaviour when no interface name is specified

--- a/test/e2e/non-primary-cni/e2e_test.go
+++ b/test/e2e/non-primary-cni/e2e_test.go
@@ -232,7 +232,7 @@ var _ = framework.SerialDescribe("[group:non-primary-cni]", func() {
 
 	ginkgo.Context("VPC Simple", ginkgo.Label("Feature:VPC-Simple"), func() {
 		namespaceName := "vpc-simple-ns"
-		podNames := []string{"vpc-simple-pod1", "vpc-simple-pod2"}
+		podNames := []string{"vpc-simple-pod1", "vpc-simple-pod2", "vpc-multi-nic-pod"}
 		yamlFile := getTestConfigFile("VPC/00-vpc-simple.yaml")
 
 		var nodeNames []string

--- a/test/e2e/non-primary-cni/testconfigs/VPC/00-vpc-simple.yaml
+++ b/test/e2e/non-primary-cni/testconfigs/VPC/00-vpc-simple.yaml
@@ -89,3 +89,20 @@ spec:
   containers:
     - name: vpc-simple-pod2
       image: docker.io/library/nginx:alpine
+---
+# Test Pod 3 with multiple interfaces
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vpc-multi-nic-pod
+  namespace: vpc-simple-ns
+  labels:
+    config-stage: "1"
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[{"name": "vpc-simple-nad", "namespace": "vpc-simple-ns", "interface": "net1"}, {"name": "vpc-simple-nad", "namespace": "vpc-simple-ns", "interface": "net2"}]'
+    vpc-simple-nad.vpc-simple-ns.ovn.net1.kubernetes.io/logical_switch: vpc-simple-subnet
+    vpc-simple-nad.vpc-simple-ns.ovn.net2.kubernetes.io/logical_switch: vpc-simple-subnet
+spec:
+  containers:
+    - name: vpc-multi-nic-pod
+      image: docker.io/library/nginx:alpine


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
bug fix to ensure kubeovn can correctly handle multiple interface attachments from the same subnet.


Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->
- Bug fixes

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes
Fixes #(issue-number)
https://github.com/kubeovn/kube-ovn/issues/6762

To test this PR 
* install a build with this PR to a k8s cluster
* create a subnet `vm-network`
```
apiVersion: kubeovn.io/v1
kind: Subnet
metadata:
  creationTimestamp: "2026-05-20T04:14:56Z"
  finalizers:
  - kubeovn.io/kube-ovn-controller
  generation: 2
  name: vm-overlay
  resourceVersion: "1037835"
  uid: c0a4ad6f-6a77-4b33-87e1-8d0e5193fa1f
spec:
  cidrBlock: 192.168.0.0/24
  default: false
  enableDHCP: true
  enableLb: true
  excludeIps:
  - 192.168.0.1..192.168.0.100
  gateway: 192.168.0.1
  gatewayNode: ""
  gatewayType: distributed
  natOutgoing: false
  private: false
  protocol: IPv4
  provider: vm-overlay.default.ovn
  vpc: ovn-cluster
```
* create `net-attach-def` referencing this subnet
```
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  creationTimestamp: "2026-05-20T04:13:46Z"
  finalizers:
  - wrangler.cattle.io/harvester-network-manager-nad-controller
  generation: 1
  labels:
    network.harvesterhci.io/clusternetwork: mgmt
    network.harvesterhci.io/ready: "true"
    network.harvesterhci.io/type: OverlayNetwork
  name: vm-overlay
  namespace: default
  resourceVersion: "942296"
  uid: 589422b4-2181-4b96-bf97-8e34a4314cd1
spec:
  config: '{"cniVersion":"0.3.1","name":"vm-overlay","type":"kube-ovn","provider":"vm-overlay.default.ovn","server_socket":"/run/openvswitch/kube-ovn-daemon.sock"}'
```

* create a pod with static ip allocation
```
apiVersion: v1
kind: Pod
metadata:
  name: multi-if-static
  namespace: default
  annotations:
    k8s.v1.cni.cncf.io/networks: '[{"name": "vm-overlay", "namespace": "default", "interface": "net1"}, {"name": "vm-overlay", "namespace": "default", "interface": "net2"}]'
    vm-overlay.default.ovn.net1.kubernetes.io/logical_switch: vm-overlay
    vm-overlay.default.ovn.net2.kubernetes.io/logical_switch: vm-overlay
    vm-overlay.default.kubernetes.io/ip_address.net1: 192.168.0.10
    vm-overlay.default.kubernetes.io/ip_address.net2: 192.168.0.11
spec:
  containers:
  - name: multi-if-static
    image: docker.io/library/nginx:alpine
```
* verify interface address `kubectl exec multi-if-static -n default -- ip add show` should show correct ip address allocated to the pod interfaces