### PR TITLE
test(metallb): disable frr-k8s ServiceMonitor in kind install

### DIFF
--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -516,7 +516,8 @@ kind-install-metallb:
 		--version $(METALLB_VERSION:v%=%) \
 		--namespace metallb-system \
 		--create-namespace \
-		--set speaker.frr.image.tag=$(FRR_VERSION)
+		--set speaker.frr.image.tag=$(FRR_VERSION) \
+		--set frr-k8s.prometheus.serviceMonitor.enabled=false
 	$(call kubectl_wait_exist_and_ready,metallb-system,deployment,metallb-controller)
 	$(call kubectl_wait_exist,metallb-system,secret,metallb-memberlist)
 	$(call kubectl_wait_exist,metallb-system,daemonset,metallb-speaker)


### PR DESCRIPTION
The metallb v0.16.0 chart bundles an `frr-k8s` subchart whose `templates/service-monitor.yaml` unconditionally evaluates `.Values.prometheus.serviceMonitor.enabled`, which fails to render with `nil pointer evaluating interface {}.serviceMonitor` because no prometheus values are supplied.

Pass `--set frr-k8s.prometheus.serviceMonitor.enabled=false` in `kind-install-metallb` so the chart renders without a Prometheus operator installed.

Verified locally with `helm template`: the flag is a no-op on the currently pinned v0.15.3 chart and makes v0.16.0 render. This unblocks the metallb e2e jobs on #6763 (renovate bump to metallb v0.16.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)