### PR TITLE
fix(controller): avoid panic in external VPC sync when no logical switch is found

### DIFF
--- a/pkg/controller/external_vpc.go
+++ b/pkg/controller/external_vpc.go
@@ -61,10 +61,10 @@ func (c *Controller) syncExternalVpc() {
 				return
 			}
 
+			vpc.Status.Subnets = []string{}
 			for _, logicalSwitch := range logicalRouter.LogicalSwitches {
 				vpc.Status.Subnets = append(vpc.Status.Subnets, logicalSwitch.Name)
 			}
-			vpc.Status.Subnets = []string{}
 			vpc.Status.DefaultLogicalSwitch = ""
 			vpc.Status.Router = routerName
 			vpc.Status.Standby = true
@@ -115,24 +115,30 @@ func (c *Controller) getNonKubeovnRouterStatus() (logicalRouters map[string]util
 			peerPorts, err := c.OVNNbClient.ListLogicalSwitchPorts(false, nil, func(lsp *ovnnb.LogicalSwitchPort) bool {
 				return len(lsp.Options) != 0 && lsp.Options["router-port"] == port.Name
 			})
-			if err != nil || len(peerPorts) > 1 {
-				klog.Errorf("failed to list peer port of %s, %v", port, err)
+			if err != nil {
+				klog.Errorf("failed to list peer port of %s: %v", port.Name, err)
 				continue
 			}
 			if len(peerPorts) == 0 {
+				continue
+			}
+			if len(peerPorts) > 1 {
+				klog.Errorf("expected at most one peer port for %s, got %d", port.Name, len(peerPorts))
 				continue
 			}
 			lsp := peerPorts[0]
 			switches, err := c.OVNNbClient.ListLogicalSwitch(false, func(ls *ovnnb.LogicalSwitch) bool {
 				return slices.Contains(ls.Ports, lsp.UUID)
 			})
-			if err != nil || len(switches) > 1 {
-				klog.Errorf("failed to get logical switch of LSP %s: %v", lsp.Name, err)
+			if err != nil {
+				klog.Errorf("failed to list logical switch of LSP %s: %v", lsp.Name, err)
 				continue
 			}
-			var aLogicalSwitch util.LogicalSwitch
-			aLogicalSwitch.Name = switches[0].Name
-			tmpRouter.LogicalSwitches = append(tmpRouter.LogicalSwitches, aLogicalSwitch)
+			if len(switches) != 1 {
+				klog.Warningf("expected exactly one logical switch for LSP %s, got %d", lsp.Name, len(switches))
+				continue
+			}
+			tmpRouter.LogicalSwitches = append(tmpRouter.LogicalSwitches, util.LogicalSwitch{Name: switches[0].Name})
 		}
 		logicalRouters[routerName] = tmpRouter
 	}


### PR DESCRIPTION
## Summary
- Fix `index out of range [0] with length 0` panic in `getNonKubeovnRouterStatus` reported in #6774: the guard `err != nil || len(switches) > 1` did not reject the `len == 0` case, so `switches[0].Name` panicked when `ListLogicalSwitch` returned an empty slice without error. Tightened to `len(switches) != 1` and split the combined error / length checks so each failure mode logs distinctly.
- Fix a long-standing dead-code bug a few lines above: when adopting a new external logical router as a kube-ovn `Vpc`, the subnet list was appended in a loop and then immediately overwritten with `[]string{}`, so external VPCs were always created with an empty `Status.Subnets`. Moved the reset to before the loop, matching the symmetric branch at L33–36.
- Drive-by cleanup on the symmetric `peerPorts` block: same split-the-guard treatment, fixed `%s` formatting of a `util.Port` struct, and inlined the temporary `aLogicalSwitch` variable.

A repo-wide scan for the same `if err != nil || len(x) > 1 { ... }` then `x[0]` pattern found no other unguarded call sites — every other `pkg/ovs` and `pkg/controller` use of List-then-`[0]` already guards `len == 0` (or uses `len != 1`). This is an isolated regression, not a recurring anti-pattern.

Closes #6774

## Test plan
- [x] `make lint` passes
- [x] `go build ./pkg/controller/...` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)