### PR TITLE
fix(cniserver): probe unix socket from /livez to detect missing bind

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
@@ -22,6 +24,8 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/versions"
 )
+
+const cniLivezDialTimeout = 2 * time.Second
 
 func main() {
 	defer klog.Flush()
@@ -129,6 +133,16 @@ func main() {
 		}
 	}
 
+	// Bind the CNI unix socket synchronously before the health server
+	// starts so that the liveness probe (registered below) cannot
+	// produce a false negative during startup.
+	cniListener, cniCleanup, err := daemon.NewCNIListener(config)
+	if err != nil {
+		util.LogFatalAndExit(err, "failed to listen on %s", config.BindSocket)
+	}
+	defer cniCleanup()
+	util.RegisterLivezProbe(cniSocketProbe(config.BindSocket))
+
 	servePprofInMetricsServer := config.EnableMetrics && slices.Contains(addrs, "0.0.0.0")
 	metrics.StartPprofServerIfNeeded(ctx, config.EnablePprof, servePprofInMetricsServer, "127.0.0.1", int(config.PprofPort))
 	if config.EnableMetrics {
@@ -138,9 +152,25 @@ func main() {
 
 	klog.Info("start daemon controller")
 	go ctl.Run(stopCh)
-	go daemon.RunServer(config, ctl)
+	go daemon.RunCNIServer(config, ctl, cniListener)
 
 	<-stopCh
+}
+
+// cniSocketProbe returns a liveness probe that dials the CNI unix
+// socket with a short timeout. It catches the failure mode reported
+// in issue #6775: the socket file disappearing (bash EXIT trap or
+// external cleanup of /run/openvswitch) while the daemon process
+// keeps a stale listener fd. A connect+close also detects a hung
+// accept queue, which a simple os.Stat would not.
+func cniSocketProbe(socket string) func() error {
+	return func() error {
+		conn, err := net.DialTimeout("unix", socket, cniLivezDialTimeout)
+		if err != nil {
+			return fmt.Errorf("dial cni socket %q: %w", socket, err)
+		}
+		return conn.Close()
+	}
 }
 
 func mvCNIConf(configDir, configFile, confName string) error {

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -18,19 +19,24 @@ const (
 	responseLogFormat = "[%s] Outgoing response %s %s with %d status code in %vms"
 )
 
-// RunServer runs the cniserver
-func RunServer(config *Configuration, controller *Controller) {
+// NewCNIListener binds the unix socket synchronously and returns the
+// listener plus a cleanup that removes the socket file. Binding before
+// the health server starts lets the liveness probe dial the socket
+// without racing the daemon's own startup.
+func NewCNIListener(config *Configuration) (net.Listener, func(), error) {
+	return listen(config.BindSocket)
+}
+
+// RunCNIServer serves CNI requests on the supplied listener. The
+// listener must come from NewCNIListener so that bind has completed
+// before the caller starts announcing readiness.
+func RunCNIServer(config *Configuration, controller *Controller, listener net.Listener) {
 	nodeName = config.NodeName
 	csh := createCniServerHandler(config, controller)
 	server := http.Server{
 		Handler:           createHandler(csh),
 		ReadHeaderTimeout: 3 * time.Second,
 	}
-	listener, cleanFunc, err := listen(config.BindSocket)
-	if err != nil {
-		util.LogFatalAndExit(err, "failed to listen on %s", config.BindSocket)
-	}
-	defer cleanFunc()
 	klog.Infof("start listen on %s", config.BindSocket)
 	util.LogFatalAndExit(server.Serve(listener), "failed to serve on %s", config.BindSocket)
 }

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -115,7 +115,7 @@ func ServeWithListener(ctx context.Context, config *rest.Config, listener net.Li
 
 	mux.Handle("/metrics", metricsHandler)
 	mux.HandleFunc("/healthz", util.DefaultHealthCheckHandler)
-	mux.HandleFunc("/livez", util.DefaultHealthCheckHandler)
+	mux.HandleFunc("/livez", util.LivezHandler)
 	mux.HandleFunc("/readyz", util.DefaultHealthCheckHandler)
 	if withPprof {
 		pprofHandlers := map[string]http.Handler{

--- a/pkg/metrics/servers.go
+++ b/pkg/metrics/servers.go
@@ -59,7 +59,7 @@ func NewHealthOnlyServer(addr string, port int) (*manager.Server, error) {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", util.DefaultHealthCheckHandler)
-	mux.HandleFunc("/livez", util.DefaultHealthCheckHandler)
+	mux.HandleFunc("/livez", util.LivezHandler)
 	mux.HandleFunc("/readyz", util.DefaultHealthCheckHandler)
 	return &manager.Server{
 		Name: "health-check",

--- a/pkg/util/health_check.go
+++ b/pkg/util/health_check.go
@@ -2,12 +2,45 @@ package util
 
 import (
 	"net/http"
+	"sync/atomic"
 
 	"k8s.io/klog/v2"
 )
+
+type livenessProbe func() error
+
+var livezProbe atomic.Pointer[livenessProbe]
+
+// RegisterLivezProbe installs a custom liveness probe consulted by
+// LivezHandler. A non-nil error returned by the probe causes the
+// /livez endpoint to respond with HTTP 503. Passing nil clears any
+// previously registered probe. Safe to call concurrently.
+func RegisterLivezProbe(p func() error) {
+	if p == nil {
+		livezProbe.Store(nil)
+		return
+	}
+	fn := livenessProbe(p)
+	livezProbe.Store(&fn)
+}
 
 func DefaultHealthCheckHandler(w http.ResponseWriter, _ *http.Request) {
 	if _, err := w.Write([]byte("ok")); err != nil {
 		klog.Errorf("failed to write health check response: %v", err)
 	}
+}
+
+// LivezHandler responds to /livez requests. When a probe has been
+// installed via RegisterLivezProbe it is invoked on every request; a
+// non-nil error becomes an HTTP 503. Otherwise the behaviour matches
+// DefaultHealthCheckHandler.
+func LivezHandler(w http.ResponseWriter, r *http.Request) {
+	if p := livezProbe.Load(); p != nil {
+		if err := (*p)(); err != nil {
+			klog.Warningf("liveness probe failed: %v", err)
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+	}
+	DefaultHealthCheckHandler(w, r)
 }

--- a/pkg/util/health_check.go
+++ b/pkg/util/health_check.go
@@ -32,13 +32,16 @@ func DefaultHealthCheckHandler(w http.ResponseWriter, _ *http.Request) {
 
 // LivezHandler responds to /livez requests. When a probe has been
 // installed via RegisterLivezProbe it is invoked on every request; a
-// non-nil error becomes an HTTP 503. Otherwise the behaviour matches
-// DefaultHealthCheckHandler.
+// non-nil error becomes an HTTP 503 with a generic body, and the
+// detailed error is logged. Otherwise the behaviour matches
+// DefaultHealthCheckHandler. The generic body avoids leaking internal
+// details (e.g. filesystem paths) to unauthenticated callers, since
+// /livez is exempt from the metrics-server auth filter.
 func LivezHandler(w http.ResponseWriter, r *http.Request) {
 	if p := livezProbe.Load(); p != nil {
 		if err := (*p)(); err != nil {
 			klog.Warningf("liveness probe failed: %v", err)
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			http.Error(w, "probe failed", http.StatusServiceUnavailable)
 			return
 		}
 	}

--- a/pkg/util/health_check_test.go
+++ b/pkg/util/health_check_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -39,8 +40,8 @@ func TestLivezHandlerProbeHealthy(t *testing.T) {
 }
 
 func TestLivezHandlerProbeFailing(t *testing.T) {
-	probeErr := errors.New("socket unreachable")
-	RegisterLivezProbe(func() error { return probeErr })
+	const secret = "socket-/run/openvswitch/secret.sock-unreachable"
+	RegisterLivezProbe(func() error { return errors.New(secret) })
 	t.Cleanup(func() { RegisterLivezProbe(nil) })
 
 	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
@@ -49,6 +50,10 @@ func TestLivezHandlerProbeFailing(t *testing.T) {
 
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected status 503, got %d", rec.Code)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if strings.Contains(string(body), secret) {
+		t.Fatalf("response body leaked probe error: %q", string(body))
 	}
 }
 

--- a/pkg/util/health_check_test.go
+++ b/pkg/util/health_check_test.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLivezHandlerDefault(t *testing.T) {
+	RegisterLivezProbe(nil)
+	t.Cleanup(func() { RegisterLivezProbe(nil) })
+
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	rec := httptest.NewRecorder()
+	LivezHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if string(body) != "ok" {
+		t.Fatalf("expected body %q, got %q", "ok", string(body))
+	}
+}
+
+func TestLivezHandlerProbeHealthy(t *testing.T) {
+	RegisterLivezProbe(func() error { return nil })
+	t.Cleanup(func() { RegisterLivezProbe(nil) })
+
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	rec := httptest.NewRecorder()
+	LivezHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+}
+
+func TestLivezHandlerProbeFailing(t *testing.T) {
+	probeErr := errors.New("socket unreachable")
+	RegisterLivezProbe(func() error { return probeErr })
+	t.Cleanup(func() { RegisterLivezProbe(nil) })
+
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	rec := httptest.NewRecorder()
+	LivezHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", rec.Code)
+	}
+}
+
+func TestRegisterLivezProbeNilClears(t *testing.T) {
+	RegisterLivezProbe(func() error { return errors.New("boom") })
+	RegisterLivezProbe(nil)
+	t.Cleanup(func() { RegisterLivezProbe(nil) })
+
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	rec := httptest.NewRecorder()
+	LivezHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 after clearing probe, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #6775 — kube-ovn-cni's `/livez` was a stub that always returned "ok", so a missing `/run/openvswitch/kube-ovn-daemon.sock` (bash `EXIT` trap or host-side cleanup) left the daemon "live" while every kubelet CNI call failed with `connect: no such file or directory`.
- Adds `util.RegisterLivezProbe` / `util.LivezHandler`, wires `/livez` through it in `pkg/metrics`, and registers a `net.DialTimeout("unix", BindSocket, 2s)` probe in `cmd/daemon/cniserver.go`. A failing dial now produces HTTP 503, so kubelet restarts the container after the existing failure threshold — the same manual workaround the reporter applied.
- Refactors `pkg/daemon/server.go` into `NewCNIListener` (synchronous bind) + `RunCNIServer` (serve on a pre-bound listener) so the socket is up before `/livez` starts answering and the probe can't false-negative during startup. Same pattern as #6478.

## Test plan
- [x] `go test ./pkg/util/...` (new `health_check_test.go` covers default, healthy probe, failing probe → 503, probe clearing)
- [x] `make lint` — 0 issues
- [x] `go build ./...` clean
- [ ] Smoke: delete `/run/openvswitch/kube-ovn-daemon.sock` on a node, confirm `/livez` returns 503 and the kube-ovn-cni container is restarted within ~21s
- [ ] Smoke: normal pod-create traffic across rolling restart of kube-ovn-cni still works (probe doesn't false-negative during startup)

Refs: #6775, #5836 (related closed report), #6478 (synchronous-listener pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)