### PR TITLE
feat(ovn-central): add single-replica deployment mode backed by a PVC

### DIFF
--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -64,6 +64,31 @@ Number of master nodes
 {{- end -}}
 
 {{/*
+Replica count for the ovn-central Deployment. Single mode always uses 1;
+cluster mode uses one replica per master node.
+*/}}
+{{- define "kubeovn.ovnCentralReplicas" -}}
+{{- if eq .Values.OVN_CENTRAL_MODE "single" -}}
+1
+{{- else -}}
+{{- include "kubeovn.nodeCount" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Value of the NODE_IPS / OVN_DB_IPS env variable. In single mode this is empty,
+which makes start-db.sh take the standalone path and makes clients fall back to
+the ovn-nb / ovn-sb Service ClusterIP via the OVN_*_SERVICE_HOST env vars
+auto-injected by Kubernetes.
+*/}}
+{{- define "kubeovn.ovnCentralNodeIPs" -}}
+{{- if eq .Values.OVN_CENTRAL_MODE "single" -}}
+{{- else -}}
+{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Determine the updateStrategy type for the ovs-ovn DaemonSet.
 If ovs-ovn.updateStrategy.type is set, use it directly.
 Otherwise, auto-detect based on the currently deployed DaemonSet.

--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -7,12 +7,16 @@ metadata:
     kubernetes.io/description: |
       OVN components: northd, nb and sb.
 spec:
-  replicas: {{ include "kubeovn.nodeCount" . }}
+  replicas: {{ include "kubeovn.ovnCentralReplicas" . }}
   strategy:
+    {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
+    type: Recreate
+    {{- else }}
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
+    {{- end }}
   selector:
     matchLabels:
       app: ovn-central
@@ -31,12 +35,14 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
                   app: ovn-central
               topologyKey: kubernetes.io/hostname
+        {{- end }}
         {{- include "kubeovn.masterNodeAffinity" . | nindent 8 }}
       priorityClassName: system-cluster-critical
       serviceAccountName: ovn-ovs
@@ -85,7 +91,7 @@ spec:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"
             - name: NODE_IPS
-              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -159,8 +165,13 @@ spec:
           hostPath:
             path: /run/ovn
         - name: host-config-ovn
+          {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
+          persistentVolumeClaim:
+            claimName: ovn-central-data
+          {{- else }}
           hostPath:
             path: {{ .Values.OVN_DIR }}
+          {{- end }}
         - name: host-log-ovn
           hostPath:
             path: {{ .Values.log_conf.LOG_DIR }}/ovn

--- a/charts/kube-ovn/templates/central-pvc.yaml
+++ b/charts/kube-ovn/templates/central-pvc.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.OVN_CENTRAL_MODE "single" }}
+{{- $storage := index .Values "ovn-central" "storage" }}
+{{- if $storage.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ovn-central-data
+  namespace: {{ .Values.namespace }}
+  annotations:
+    kubernetes.io/description: |
+      Persistent storage for the ovn-central standalone OVN DB files.
+spec:
+  accessModes:
+{{ toYaml $storage.accessModes | indent 4 }}
+  resources:
+    requests:
+      storage: {{ $storage.size }}
+  {{- with $storage.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -179,7 +179,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn/templates/nb-svc.yaml
+++ b/charts/kube-ovn/templates/nb-svc.yaml
@@ -1,3 +1,4 @@
+{{- $svc := index .Values "ovn-central" "service" }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -9,7 +10,13 @@ spec:
       protocol: TCP
       port: 6641
       targetPort: 6641
-  type: ClusterIP
+  type: {{ $svc.type | default "ClusterIP" }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn/templates/nb-svc.yaml
+++ b/charts/kube-ovn/templates/nb-svc.yaml
@@ -15,5 +15,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
+    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
     ovn-nb-leader: "true"
+    {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/templates/northd-svc.yaml
+++ b/charts/kube-ovn/templates/northd-svc.yaml
@@ -15,5 +15,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
+    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
     ovn-northd-leader: "true"
+    {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/templates/northd-svc.yaml
+++ b/charts/kube-ovn/templates/northd-svc.yaml
@@ -1,3 +1,4 @@
+{{- $svc := index .Values "ovn-central" "service" }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -9,7 +10,13 @@ spec:
       protocol: TCP
       port: 6643
       targetPort: 6643
-  type: ClusterIP
+  type: {{ $svc.type | default "ClusterIP" }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -123,7 +123,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn/templates/sb-svc.yaml
+++ b/charts/kube-ovn/templates/sb-svc.yaml
@@ -1,3 +1,4 @@
+{{- $svc := index .Values "ovn-central" "service" }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -9,7 +10,13 @@ spec:
       protocol: TCP
       port: 6642
       targetPort: 6642
-  type: ClusterIP
+  type: {{ $svc.type | default "ClusterIP" }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn/templates/sb-svc.yaml
+++ b/charts/kube-ovn/templates/sb-svc.yaml
@@ -15,5 +15,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
+    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
     ovn-sb-leader: "true"
+    {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -179,6 +179,18 @@ ovn-central:
     size: 10Gi
     accessModes:
       - ReadWriteOnce
+  # Service exposure for ovn-nb / ovn-sb / ovn-northd. Default ClusterIP is
+  # only reachable from inside the cluster. Switch to LoadBalancer (or
+  # NodePort) to expose the OVN DB to data-plane components running outside
+  # the management cluster — for example a Kamaji-style topology where
+  # ovn-controller / kube-ovn-cni / kube-ovn-controller run in a separate
+  # tenant cluster and connect back over a stable VIP.
+  service:
+    type: ClusterIP
+    # Optional, only honoured when type=LoadBalancer; provider-dependent.
+    loadBalancerIP: ""
+    # Optional, only honoured when type=LoadBalancer / NodePort.
+    externalTrafficPolicy: ""
 ovs-ovn:
   updateStrategy:
     type: ""  # Override the DaemonSet update strategy. Leave empty to auto-detect based on the deployed version.

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -21,6 +21,12 @@ namespace: kube-system
 MASTER_NODES: ""
 MASTER_NODES_LABEL: "kube-ovn/role=master"
 
+# OVN_CENTRAL_MODE controls how ovn-central is deployed.
+#   cluster: multi-replica raft cluster, one pod per master node (default).
+#   single:  single-replica Deployment backed by a PVC, can drift to another
+#            node when the host fails. Uses ovsdb standalone mode (no raft).
+OVN_CENTRAL_MODE: "cluster"
+
 networking:
   # NET_STACK could be dual_stack, ipv4, ipv6
   NET_STACK: ipv4
@@ -163,6 +169,16 @@ ovn-central:
     cpu: "3"
     memory: "4Gi"
     ephemeral-storage: 1Gi
+  # Persistent storage for the OVN DB files. Only used when OVN_CENTRAL_MODE=single.
+  # The StorageClass should support cross-node attach (e.g. NFS, Ceph RBD, cloud
+  # block storage with attach/detach) if you want ovn-central to drift between
+  # nodes on host failure.
+  storage:
+    enabled: true
+    storageClassName: ""
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
 ovs-ovn:
   updateStrategy:
     type: ""  # Override the DaemonSet update strategy. Leave empty to auto-detect based on the deployed version.

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -59,6 +59,16 @@ OVSDB_INACTIVITY_TIMEOUT=${OVSDB_INACTIVITY_TIMEOUT:-10}
 ENABLE_LIVE_MIGRATION_OPTIMIZE=${ENABLE_LIVE_MIGRATION_OPTIMIZE:-true}
 ENABLE_OVN_LB_PREFER_LOCAL=${ENABLE_OVN_LB_PREFER_LOCAL:-false}
 
+# Single-replica ovn-central mode: deploy a single Deployment-managed pod with
+# OVN DB stored on a PVC, so the pod can drift to another node on host failure.
+# When enabled, NODE_IPS/OVN_DB_IPS are passed empty so clients fall back to the
+# ovn-nb / ovn-sb Service ClusterIPs auto-injected via OVN_*_SERVICE_HOST.
+ENABLE_SINGLE_REPLICA_OVN=${ENABLE_SINGLE_REPLICA_OVN:-false}
+OVN_CENTRAL_PVC_SIZE=${OVN_CENTRAL_PVC_SIZE:-10Gi}
+# Empty means use the cluster's default StorageClass. For real cross-node drift
+# pick one that supports cross-node attach (NFS-CSI, Ceph RBD, cloud EBS, ...).
+OVN_CENTRAL_STORAGE_CLASS=${OVN_CENTRAL_STORAGE_CLASS:-}
+
 PROBE_HTTP_SCHEME="HTTP"
 if [ "$SECURE_SERVING" = "true" ]; then
   PROBE_HTTP_SCHEME="HTTPS"
@@ -245,7 +255,64 @@ echo ""
 echo "[Step 2/6] Install OVN components"
 addresses=$(kubectl get no -lkube-ovn/role=master --no-headers -o wide | awk '{print $6}' | tr \\n ',' | sed 's/,$//')
 count=$(kubectl get no -lkube-ovn/role=master --no-headers | wc -l)
-echo "Install OVN DB in $addresses"
+if [ "$ENABLE_SINGLE_REPLICA_OVN" = "true" ]; then
+  # In single-replica mode the OVN DB lives on a PVC, so NODE_IPS/OVN_DB_IPS
+  # must be empty (clients use the Service ClusterIPs) and the Deployment runs
+  # exactly one pod.
+  addresses=""
+  count=1
+  echo "Install ovn-central as a single-replica Deployment backed by PVC ovn-central-data"
+else
+  echo "Install OVN DB in $addresses"
+fi
+
+# Pre-compute the YAML fragments that differ between cluster and single mode.
+# These are injected into the ovn.yaml HEREDOC below via ${VAR} expansion.
+if [ "$ENABLE_SINGLE_REPLICA_OVN" = "true" ]; then
+  OVN_NB_LEADER_SELECTOR=""
+  OVN_SB_LEADER_SELECTOR=""
+  OVN_NORTHD_LEADER_SELECTOR=""
+  OVN_CENTRAL_STRATEGY_BODY="    type: Recreate"
+  OVN_CENTRAL_AFFINITY_BLOCK=""
+  OVN_CENTRAL_CONFIG_VOLUME="        - name: host-config-ovn
+          persistentVolumeClaim:
+            claimName: ovn-central-data"
+  OVN_CENTRAL_PVC_BLOCK="---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ovn-central-data
+  namespace: kube-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${OVN_CENTRAL_PVC_SIZE}"
+  if [ -n "${OVN_CENTRAL_STORAGE_CLASS}" ]; then
+    OVN_CENTRAL_PVC_BLOCK="${OVN_CENTRAL_PVC_BLOCK}
+  storageClassName: \"${OVN_CENTRAL_STORAGE_CLASS}\""
+  fi
+else
+  OVN_NB_LEADER_SELECTOR='    ovn-nb-leader: "true"'
+  OVN_SB_LEADER_SELECTOR='    ovn-sb-leader: "true"'
+  OVN_NORTHD_LEADER_SELECTOR='    ovn-northd-leader: "true"'
+  OVN_CENTRAL_STRATEGY_BODY="    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate"
+  OVN_CENTRAL_AFFINITY_BLOCK="      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: ovn-central
+              topologyKey: kubernetes.io/hostname"
+  OVN_CENTRAL_CONFIG_VOLUME="        - name: host-config-ovn
+          hostPath:
+            path: /etc/origin/ovn"
+  OVN_CENTRAL_PVC_BLOCK=""
+fi
 
 # BEGIN GENERATED KUBE-OVN CRD BUNDLE
 cat <<'EOF' > kube-ovn-crd.yaml
@@ -7114,6 +7181,7 @@ kubectl apply -f kube-ovn-cni-sa.yaml
 kubectl apply -f kube-ovn-app-sa.yaml
 
 cat <<EOF > ovn.yaml
+${OVN_CENTRAL_PVC_BLOCK}
 ---
 kind: Service
 apiVersion: v1
@@ -7130,7 +7198,7 @@ spec:
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central
-    ovn-nb-leader: "true"
+${OVN_NB_LEADER_SELECTOR}
   sessionAffinity: None
 
 ---
@@ -7149,7 +7217,7 @@ spec:
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central
-    ovn-sb-leader: "true"
+${OVN_SB_LEADER_SELECTOR}
   sessionAffinity: None
 
 ---
@@ -7168,7 +7236,7 @@ spec:
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central
-    ovn-northd-leader: "true"
+${OVN_NORTHD_LEADER_SELECTOR}
   sessionAffinity: None
 ---
 kind: Deployment
@@ -7182,10 +7250,7 @@ metadata:
 spec:
   replicas: $count
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
-    type: RollingUpdate
+${OVN_CENTRAL_STRATEGY_BODY}
   selector:
     matchLabels:
       app: ovn-central
@@ -7203,13 +7268,7 @@ spec:
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: ovn-central
-              topologyKey: kubernetes.io/hostname
+${OVN_CENTRAL_AFFINITY_BLOCK}
       priorityClassName: system-cluster-critical
       serviceAccountName: ovn-ovs
       automountServiceAccountToken: true
@@ -7330,9 +7389,7 @@ spec:
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
-        - name: host-config-ovn
-          hostPath:
-            path: /etc/origin/ovn
+${OVN_CENTRAL_CONFIG_VOLUME}
         - name: host-log-ovn
           hostPath:
             path: $LOG_DIR/ovn

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -69,6 +69,14 @@ OVN_CENTRAL_PVC_SIZE=${OVN_CENTRAL_PVC_SIZE:-10Gi}
 # pick one that supports cross-node attach (NFS-CSI, Ceph RBD, cloud EBS, ...).
 OVN_CENTRAL_STORAGE_CLASS=${OVN_CENTRAL_STORAGE_CLASS:-}
 
+# Service exposure for ovn-nb / ovn-sb / ovn-northd. Default ClusterIP is
+# only reachable from inside the cluster. Switch to LoadBalancer (or NodePort)
+# to expose the OVN DB to data-plane components running outside the
+# management cluster (e.g. Kamaji-style separated control/data planes).
+OVN_CENTRAL_SERVICE_TYPE=${OVN_CENTRAL_SERVICE_TYPE:-ClusterIP}
+OVN_CENTRAL_LB_IP=${OVN_CENTRAL_LB_IP:-}
+OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY=${OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY:-}
+
 PROBE_HTTP_SCHEME="HTTP"
 if [ "$SECURE_SERVING" = "true" ]; then
   PROBE_HTTP_SCHEME="HTTPS"
@@ -312,6 +320,16 @@ else
           hostPath:
             path: /etc/origin/ovn"
   OVN_CENTRAL_PVC_BLOCK=""
+fi
+
+# Optional LoadBalancer / NodePort tweaks for the three ovn-central Services.
+OVN_CENTRAL_LB_BLOCK=""
+if [ "$OVN_CENTRAL_SERVICE_TYPE" = "LoadBalancer" ] && [ -n "$OVN_CENTRAL_LB_IP" ]; then
+  OVN_CENTRAL_LB_BLOCK="  loadBalancerIP: \"$OVN_CENTRAL_LB_IP\""
+fi
+OVN_CENTRAL_ETP_BLOCK=""
+if { [ "$OVN_CENTRAL_SERVICE_TYPE" = "LoadBalancer" ] || [ "$OVN_CENTRAL_SERVICE_TYPE" = "NodePort" ]; } && [ -n "$OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY" ]; then
+  OVN_CENTRAL_ETP_BLOCK="  externalTrafficPolicy: $OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY"
 fi
 
 # BEGIN GENERATED KUBE-OVN CRD BUNDLE
@@ -7194,7 +7212,9 @@ spec:
       protocol: TCP
       port: 6641
       targetPort: 6641
-  type: ClusterIP
+  type: ${OVN_CENTRAL_SERVICE_TYPE}
+${OVN_CENTRAL_LB_BLOCK}
+${OVN_CENTRAL_ETP_BLOCK}
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central
@@ -7213,7 +7233,9 @@ spec:
       protocol: TCP
       port: 6642
       targetPort: 6642
-  type: ClusterIP
+  type: ${OVN_CENTRAL_SERVICE_TYPE}
+${OVN_CENTRAL_LB_BLOCK}
+${OVN_CENTRAL_ETP_BLOCK}
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central
@@ -7232,7 +7254,9 @@ spec:
       protocol: TCP
       port: 6643
       targetPort: 6643
-  type: ClusterIP
+  type: ${OVN_CENTRAL_SERVICE_TYPE}
+${OVN_CENTRAL_LB_BLOCK}
+${OVN_CENTRAL_ETP_BLOCK}
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central

--- a/dist/images/ovn-healthcheck.sh
+++ b/dist/images/ovn-healthcheck.sh
@@ -8,6 +8,22 @@ ovn-ctl status_northd
 ovn-ctl status_ovnnb | grep -q '^running'
 ovn-ctl status_ovnsb | grep -q '^running'
 
+# Standalone (single-replica) mode has no raft cluster, so `cluster/status` is
+# not applicable. Fall back to a storage-status check on each local DB.
+if [[ -z "${NODE_IPS:-}" ]]; then
+    nb_storage=$(ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/get-db-storage-status OVN_Northbound)
+    sb_storage=$(ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/get-db-storage-status OVN_Southbound)
+    if echo "${nb_storage}" | grep -q "inconsistent"; then
+        echo "nb health check failed: ${nb_storage}"
+        exit 1
+    fi
+    if echo "${sb_storage}" | grep -q "inconsistent"; then
+        echo "sb health check failed: ${sb_storage}"
+        exit 1
+    fi
+    exit 0
+fi
+
 nb_status=$(ovn-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound | grep Status)
 sb_status=$(ovn-appctl -t /var/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound | grep Status)
 nb_role=$(ovn-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound | grep Role)

--- a/dist/images/ovn-is-leader.sh
+++ b/dist/images/ovn-is-leader.sh
@@ -11,6 +11,32 @@ ovn-ctl status_ovnsb
 POD_NAMESPACE=${POD_NAMESPACE:-kube-system}
 BIND_LOCAL_ADDR=[${POD_IP:-127.0.0.1}]
 
+# Single-replica (standalone) mode: there is exactly one ovn-central pod and the
+# DB is not clustered, so there is no raft leader to query and no ovn_northd
+# lock to contend. Always mark this pod as the leader for nb/sb/northd, then run
+# the DB consistency check and compaction.
+if [[ -z "${NODE_IPS:-}" ]]; then
+    kubectl label --overwrite pod "$POD_NAME" -n "$POD_NAMESPACE" \
+        ovn-nb-leader=true ovn-sb-leader=true ovn-northd-leader=true
+
+    nb_status=$(ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/get-db-storage-status OVN_Northbound)
+    echo "nb $nb_status"
+    if [[ $nb_status =~ "inconsistent" ]]; then
+        exit 1
+    fi
+    sb_status=$(ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/get-db-storage-status OVN_Southbound)
+    echo "sb $sb_status"
+    if [[ $sb_status =~ "inconsistent" ]]; then
+        exit 1
+    fi
+
+    set +e
+    ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/compact
+    ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/compact
+    echo ""
+    exit 0
+fi
+
 # For data consistency, only store leader address in endpoint
 # Store ovn-nb leader to svc kube-system/ovn-nb
 if [[ "$ENABLE_SSL" == "false" ]]; then

--- a/dist/images/restore-ovn-nb-db.sh
+++ b/dist/images/restore-ovn-nb-db.sh
@@ -1,6 +1,94 @@
 #!/bin/bash
 
 KUBE_OVN_NS=kube-system
+MODE=${1:-cluster}
+
+usage() {
+  cat >&2 <<USAGE
+Usage:
+  $0                        # cluster (raft) mode: convert local clustered DB to standalone and push to all masters
+  $0 cluster                # same as above (explicit)
+  $0 single <backup.db>     # single-replica mode: write <backup.db> into the ovn-central-data PVC
+
+Single-replica mode expects an already-standalone ovnnb_db.db file as input
+(produced earlier by 'ovsdb-tool cluster-to-standalone' or copied from a
+healthy single-replica pod).
+USAGE
+}
+
+if [ "$MODE" = "single" ]; then
+  BACKUP_FILE=${2:-}
+  if [ -z "$BACKUP_FILE" ] || [ ! -f "$BACKUP_FILE" ]; then
+    echo "ERROR: missing or unreadable backup file: '$BACKUP_FILE'"
+    usage
+    exit 1
+  fi
+
+  # Verify the PVC exists (sanity check that the cluster really runs in single-replica mode).
+  if ! kubectl get pvc -n $KUBE_OVN_NS ovn-central-data >/dev/null 2>&1; then
+    echo "ERROR: PVC $KUBE_OVN_NS/ovn-central-data not found. This script's 'single' mode only applies"
+    echo "       when ovn-central was installed with ENABLE_SINGLE_REPLICA_OVN=true."
+    exit 1
+  fi
+
+  echo "Restoring ovn-central from $BACKUP_FILE into PVC $KUBE_OVN_NS/ovn-central-data"
+
+  replicas=$(kubectl get deployment -n $KUBE_OVN_NS ovn-central -o jsonpath='{.spec.replicas}')
+  kubectl scale deployment -n $KUBE_OVN_NS ovn-central --replicas=0
+  echo "ovn-central scaled to 0 (was $replicas)"
+
+  # Wait until the existing pod is fully gone so the PVC is detachable.
+  kubectl wait --for=delete pod -l app=ovn-central -n $KUBE_OVN_NS --timeout=120s || true
+
+  helper_pod="ovn-central-restore-$(date +%s)"
+  cat <<HELPER | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $helper_pod
+  namespace: $KUBE_OVN_NS
+spec:
+  restartPolicy: Never
+  containers:
+    - name: restore
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 600"]
+      volumeMounts:
+        - name: ovn-data
+          mountPath: /etc/ovn
+  volumes:
+    - name: ovn-data
+      persistentVolumeClaim:
+        claimName: ovn-central-data
+HELPER
+
+  kubectl wait --for=condition=Ready pod/$helper_pod -n $KUBE_OVN_NS --timeout=120s
+
+  echo "Copying $BACKUP_FILE into the PVC"
+  kubectl cp -n $KUBE_OVN_NS "$BACKUP_FILE" "$helper_pod:/etc/ovn/ovnnb_db.db.restore"
+  kubectl exec -n $KUBE_OVN_NS $helper_pod -- sh -c '
+    set -e
+    [ -f /etc/ovn/ovnnb_db.db ] && mv /etc/ovn/ovnnb_db.db /etc/ovn/ovnnb_db.db.bak.$(date +%s) || true
+    [ -f /etc/ovn/ovnsb_db.db ] && mv /etc/ovn/ovnsb_db.db /etc/ovn/ovnsb_db.db.bak.$(date +%s) || true
+    mv /etc/ovn/ovnnb_db.db.restore /etc/ovn/ovnnb_db.db
+    ls -l /etc/ovn/
+  '
+
+  kubectl delete pod -n $KUBE_OVN_NS $helper_pod --wait=true
+
+  kubectl scale deployment -n $KUBE_OVN_NS ovn-central --replicas="${replicas:-1}"
+  echo "ovn-central scaled back to ${replicas:-1}"
+
+  echo "restart ovs-ovn"
+  kubectl -n $KUBE_OVN_NS rollout restart ds ovs-ovn
+  exit 0
+fi
+
+if [ "$MODE" != "cluster" ]; then
+  usage
+  exit 1
+fi
+
 # set ovn-central replicas to 0
 replicas=$(kubectl get deployment -n $KUBE_OVN_NS ovn-central -o jsonpath={.spec.replicas})
 kubectl scale deployment -n $KUBE_OVN_NS ovn-central --replicas=0

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -296,7 +296,11 @@ function ovn_db_pre_start() {
 trap quit EXIT
 if [[ "$ENABLE_SSL" == "false" ]]; then
     if [[ -z "$NODE_IPS" ]]; then
-        /usr/share/ovn/scripts/ovn-ctl restart_northd
+        # Standalone (single-replica) mode. The pod can drift between nodes when
+        # backed by a PV, so clean up any leftover sockets/pids on the host before
+        # starting ovsdb-server.
+        rm -f /var/run/ovn/*.pid /var/run/ovn/*.ctl 2>/dev/null || true
+        /usr/share/ovn/scripts/ovn-ctl --ovn-northd-n-threads="${OVN_NORTHD_N_THREADS}" restart_northd
         ovn-nbctl --no-leader-only set-connection ptcp:"${NB_PORT}":["${DB_ADDR}"]
         ovn-nbctl --no-leader-only set Connection . inactivity_probe=${PROBE_INTERVAL}
         ovn-nbctl --no-leader-only set NB_Global . options:northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL}
@@ -420,6 +424,9 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
     fi
 else
     if [[ -z "$NODE_IPS" ]]; then
+        # Standalone (single-replica) mode. Same rationale as the non-SSL branch:
+        # clean up stale sockets/pids so a drifted pod can come up on a new node.
+        rm -f /var/run/ovn/*.pid /var/run/ovn/*.ctl 2>/dev/null || true
         /usr/share/ovn/scripts/ovn-ctl \
             --ovn-nb-db-ssl-key=/var/run/tls/key \
             --ovn-nb-db-ssl-cert=/var/run/tls/cert \

--- a/docs/single-replica-deployment.md
+++ b/docs/single-replica-deployment.md
@@ -1,0 +1,139 @@
+# Single-replica ovn-central deployment
+
+Kube-OVN can run `ovn-central` as a single-replica Deployment with the OVN DB
+stored on a PersistentVolume, instead of the default multi-replica raft cluster.
+On host failure the pod is rescheduled to another node and reattaches to the
+PV, recovering the DB state.
+
+## When to use it
+
+| | Cluster (raft) mode | Single-replica mode |
+|---|---|---|
+| `ovn-central` replicas | one per master | exactly 1 |
+| DB consistency | raft quorum | single ovsdb-server, no consensus |
+| Storage | hostPath per master | one PVC, must be attachable on the new node after a failover |
+| Failover time | seconds (leader election) | PV detach/attach time, typically minutes |
+| Operational complexity | higher (quorum, raft repair) | lower |
+| Suitable cluster size | medium / large | small to medium, or constrained environments |
+
+Pick single-replica when you do not have three master nodes available, or when
+you prefer a simpler failure model and can tolerate a multi-minute recovery
+window during host loss.
+
+## StorageClass requirements
+
+The PVC is `ReadWriteOnce`. For the pod to actually drift between nodes the
+StorageClass must support **detach from the failed node and attach on the new
+node**. This is true for most network block / file CSIs:
+
+- NFS (`csi-driver-nfs`) — easy to set up, well-tested for failover
+- Cloud block storage (EBS, GCE PD, Azure Disk) — works, but detach from a
+  dead node can take several minutes
+- Ceph RBD, Longhorn, Portworx, etc. — work, see vendor docs for fencing
+- `hostPath` provisioners (e.g. local-path-provisioner) **will not drift** —
+  the PV is bound to the original node and the new pod will stay `Pending`
+
+`volumeBindingMode: WaitForFirstConsumer` is recommended so the PV topology is
+chosen at first pod schedule rather than at PVC creation time.
+
+## Install
+
+### Helm
+
+```yaml
+# values.yaml
+OVN_CENTRAL_MODE: single
+
+ovn-central:
+  storage:
+    enabled: true
+    storageClassName: my-csi          # leave empty to use the cluster default
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+```
+
+```bash
+helm install kube-ovn ./charts/kube-ovn -f values.yaml
+```
+
+### install.sh
+
+```bash
+ENABLE_SINGLE_REPLICA_OVN=true \
+  OVN_CENTRAL_STORAGE_CLASS=my-csi \
+  OVN_CENTRAL_PVC_SIZE=10Gi \
+  bash dist/images/install.sh
+```
+
+After install, verify:
+
+```bash
+kubectl get pod  -n kube-system -l app=ovn-central          # should be 1 pod
+kubectl get pvc  -n kube-system ovn-central-data
+kubectl get svc  -n kube-system ovn-nb -o jsonpath='{.spec.selector}'
+# Expected: {"app":"ovn-central"}  — no ovn-nb-leader selector
+```
+
+## Failover drill
+
+```bash
+node=$(kubectl get pod -n kube-system -l app=ovn-central \
+  -o jsonpath='{.items[0].spec.nodeName}')
+
+# Simulate node loss
+kubectl cordon "$node"
+kubectl delete pod -n kube-system -l app=ovn-central
+
+# Wait for the new pod to come up on a different node and the DB to respond
+kubectl wait pod -n kube-system -l app=ovn-central \
+  --for=condition=Ready --timeout=5m
+kubectl exec -n kube-system -l app=ovn-central -- ovn-nbctl show
+```
+
+For a real host-loss test (rather than `cordon` + delete), the CSI driver must
+support **fencing** — otherwise the volume will stay attached to the dead node
+and the new pod will hang in `ContainerCreating` until Kubernetes force-detaches
+(typically 6+ minutes).
+
+## Backup and restore
+
+Take a hot backup of the standalone DB at any time:
+
+```bash
+pod=$(kubectl get pod -n kube-system -l app=ovn-central -o name | head -n1)
+kubectl exec -n kube-system "$pod" -- \
+  ovsdb-client backup unix:/var/run/ovn/ovnnb_db.sock > ovnnb_backup.db
+```
+
+Restore using the bundled script:
+
+```bash
+bash dist/images/restore-ovn-nb-db.sh single ovnnb_backup.db
+```
+
+The script scales `ovn-central` to 0, runs a helper pod that mounts the same
+PVC to copy the backup into place, then scales back to 1.
+
+## Migrating between modes
+
+**Cluster → single**: scale the existing cluster `ovn-central` to 0, run
+`ovsdb-tool cluster-to-standalone` against one of the raft member DB files to
+produce a standalone NB DB, reinstall in single mode pointing at an empty PVC,
+then use `restore-ovn-nb-db.sh single` to load the standalone DB.
+
+**Single → cluster**: take a backup, reinstall in cluster mode on a fresh
+hostPath, and load the backup into the leader using `ovsdb-client`. Verify the
+NB DB content matches the backup before deleting the PVC.
+
+## Limitations
+
+- The `kube-ovn-leader-checker` raft queries, `ovn_northd` lock stealing and
+  raft header backup are all skipped in single-replica mode. Compaction and DB
+  storage-status checks still run.
+- `ovn-healthcheck.sh` uses `ovsdb-server/get-db-storage-status` instead of
+  `cluster/status`, so the readiness probe will not detect raft-specific issues
+  (there are none in this mode).
+- During failover all kube-ovn-controller / ovs-ovn / ovn-controller clients
+  will see Service connect errors until the new pod is `Ready`. They reconnect
+  automatically; in-flight ovsdb transactions during the outage may be retried.

--- a/docs/single-replica-deployment.md
+++ b/docs/single-replica-deployment.md
@@ -96,6 +96,71 @@ support **fencing** — otherwise the volume will stay attached to the dead node
 and the new pod will hang in `ContainerCreating` until Kubernetes force-detaches
 (typically 6+ minutes).
 
+## Exposing the OVN DB to data planes outside the cluster
+
+In a Kamaji-style topology the kube-ovn control plane (apiserver controllers,
+`ovn-central`) runs in a *management* cluster while `ovn-controller`,
+`kube-ovn-cni` and `kube-ovn-controller` run in one or more *tenant* clusters.
+The tenant components cannot reach a `ClusterIP` Service of the management
+cluster, so the `ovn-nb` / `ovn-sb` / `ovn-northd` Services need to be exposed
+via `LoadBalancer` (or `NodePort`).
+
+Single-replica mode is a prerequisite: with a stable, non-elected single backend
+the LoadBalancer always has exactly one healthy endpoint and there is no leader
+flapping when the LB does its own health checks.
+
+### Helm
+
+```yaml
+# values.yaml on the management cluster
+OVN_CENTRAL_MODE: single
+
+ovn-central:
+  storage:
+    enabled: true
+    storageClassName: my-csi
+    size: 10Gi
+  service:
+    type: LoadBalancer
+    loadBalancerIP: 10.99.99.99       # provider-dependent; omit to let LB pick
+    externalTrafficPolicy: Local      # optional; preserves source IPs
+```
+
+### install.sh
+
+```bash
+ENABLE_SINGLE_REPLICA_OVN=true \
+  OVN_CENTRAL_STORAGE_CLASS=my-csi \
+  OVN_CENTRAL_SERVICE_TYPE=LoadBalancer \
+  OVN_CENTRAL_LB_IP=10.99.99.99 \
+  OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY=Local \
+  bash dist/images/install.sh
+```
+
+### Wiring tenant clusters
+
+The tenant data plane deploys only `ovs-ovn` / `kube-ovn-cni` /
+`kube-ovn-controller` (not `ovn-central`) and is told where to connect via
+`OVN_DB_IPS`:
+
+```yaml
+# data-plane values (or chart fork) — pseudo-config
+OVN_DB_IPS: 10.99.99.99      # the LoadBalancer VIP from above
+```
+
+The startup scripts already handle a single-entry `OVN_DB_IPS` correctly,
+producing `tcp:[10.99.99.99]:6641` / `:6642` connection strings.
+
+> **Security note.** Exposing OVN DB over plain TCP outside the cluster is
+> usually unacceptable. Enable SSL (`networking.ENABLE_SSL=true`) and
+> distribute the OVN certs to the tenant clusters before pointing them at
+> the LB; the existing kube-ovn SSL machinery covers everything once the
+> certs are in place.
+
+A full Kamaji integration also needs a "data-plane only" rendering of the
+chart that skips `ovn-central` and its PVC — that's tracked separately and
+not part of this change.
+
 ## Backup and restore
 
 Take a hot backup of the standalone DB at any time:

--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -105,6 +105,7 @@ e2e-build:
 	$(GINKGO_E2E_BUILD) ./test/e2e/metallb
 	$(GINKGO_E2E_BUILD) ./test/e2e/anp-domain
 	$(GINKGO_E2E_BUILD) ./test/e2e/cnp-domain
+	$(GINKGO_E2E_BUILD) ./test/e2e/single-replica
 
 .PHONY: k8s-conformance-e2e
 k8s-conformance-e2e:
@@ -250,6 +251,14 @@ kube-ovn-ha-e2e:
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
 	$(GINKGO_E2E_RUN_PARALLEL) --focus=CNI:Kube-OVN ./test/e2e/ha/ha.test -- $(TEST_BIN_ARGS)
+
+.PHONY: kube-ovn-single-replica-e2e
+kube-ovn-single-replica-e2e:
+	$(GINKGO_E2E_BUILD) ./test/e2e/single-replica
+	E2E_BRANCH=$(E2E_BRANCH) \
+	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
+	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
+	$(GINKGO_E2E_RUN_PARALLEL) --focus=CNI:Kube-OVN ./test/e2e/single-replica/single-replica.test -- $(TEST_BIN_ARGS)
 
 .PHONY: kube-ovn-security-e2e
 kube-ovn-security-e2e:

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -285,6 +285,10 @@ kind-install-ipv6:
 kind-install-dual:
 	@DUAL_STACK=true $(MAKE) kind-install
 
+.PHONY: kind-install-single-replica
+kind-install-single-replica:
+	@ENABLE_SINGLE_REPLICA_OVN=true OVN_CENTRAL_STORAGE_CLASS=standard $(MAKE) kind-install
+
 .PHONY: kind-install-overlay
 kind-install-overlay: kind-install-overlay-ipv4
 

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -96,15 +96,28 @@ func ParseFlags() (*Configuration, error) {
 	}
 
 	config := &Configuration{
-		KubeConfigFile:  *argKubeConfigFile,
-		ProbeInterval:   *argProbeInterval,
-		EnableCompact:   *argEnableCompact,
-		IsICDBServer:    *argIsICDBServer,
-		localAddress:    *localAddress,
-		remoteAddresses: slices.DeleteFunc(*remoteAddresses, func(s string) bool { return s == *localAddress }),
+		KubeConfigFile: *argKubeConfigFile,
+		ProbeInterval:  *argProbeInterval,
+		EnableCompact:  *argEnableCompact,
+		IsICDBServer:   *argIsICDBServer,
+		localAddress:   *localAddress,
+		remoteAddresses: slices.DeleteFunc(*remoteAddresses, func(s string) bool {
+			// Drop the local address (already covered by isDBLeader on localAddress)
+			// and any empty entries produced by --remoteAddresses="" in single-replica
+			// mode.
+			return s == "" || s == *localAddress
+		}),
 	}
 
 	return config, nil
+}
+
+// isSingleReplicaMode reports whether ovn-central is running as a single
+// standalone pod (no raft cluster, no peers). In that mode the leader-checker
+// skips raft leader queries and ovn_northd lock stealing because they are
+// meaningless with only one DB instance.
+func (c *Configuration) isSingleReplicaMode() bool {
+	return len(c.remoteAddresses) == 0
 }
 
 // KubeClientInit funcs to check apiserver alive
@@ -400,6 +413,27 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 	}
 
 	if !cfg.IsICDBServer {
+		if cfg.isSingleReplicaMode() {
+			// Standalone DB: no raft leader to query, no peers to detect a split
+			// brain against, no ovn_northd lock contention. Just keep the pod
+			// labelled as the leader for all three services and run compaction.
+			northdActive := checkNorthdActive()
+			patch := util.KVPatch{
+				"ovn-nb-leader":     "true",
+				"ovn-sb-leader":     "true",
+				"ovn-northd-leader": strconv.FormatBool(northdActive),
+			}
+			if err := util.PatchLabels(cfg.KubeClient.CoreV1().Pods(podNamespace), podName, patch); err != nil {
+				klog.Errorf("failed to patch labels for pod %s/%s: %v", podNamespace, podName, err)
+				return
+			}
+			if cfg.EnableCompact {
+				compactOvnDatabase("nb")
+				compactOvnDatabase("sb")
+			}
+			return
+		}
+
 		nbLeader := isDBLeader(cfg.localAddress, ovnnb.DatabaseName)
 		sbLeader := isDBLeader(cfg.localAddress, ovnsb.DatabaseName)
 		northdActive := checkNorthdActive()

--- a/test/e2e/single-replica/single_replica_test.go
+++ b/test/e2e/single-replica/single_replica_test.go
@@ -1,0 +1,196 @@
+package single_replica
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e"
+	k8sframework "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/config"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+func init() {
+	klog.SetOutput(ginkgo.GinkgoWriter)
+
+	config.CopyFlags(config.Flags, flag.CommandLine)
+	k8sframework.RegisterCommonFlags(flag.CommandLine)
+	k8sframework.RegisterClusterFlags(flag.CommandLine)
+}
+
+func TestE2E(t *testing.T) {
+	k8sframework.AfterReadingAllFlags(&k8sframework.TestContext)
+	e2e.RunE2ETests(t)
+}
+
+// isSingleReplicaMode reports whether the cluster was installed with
+// OVN_CENTRAL_MODE=single. The ovn-nb Service has its `ovn-nb-leader: "true"`
+// selector dropped in single mode, which is a reliable, install-method-agnostic
+// signal.
+func isSingleReplicaMode(f *framework.Framework) bool {
+	ginkgo.GinkgoHelper()
+
+	svc, err := f.ClientSet.CoreV1().Services(framework.KubeOvnNamespace).
+		Get(context.TODO(), "ovn-nb", metav1.GetOptions{})
+	framework.ExpectNoError(err, "getting Service kube-system/ovn-nb")
+	_, hasLeaderSelector := svc.Spec.Selector["ovn-nb-leader"]
+	return !hasLeaderSelector
+}
+
+var _ = framework.Describe("[group:single-replica]", func() {
+	f := framework.NewDefaultFramework("single-replica")
+
+	ginkgo.BeforeEach(func() {
+		f.SkipVersionPriorTo(1, 18, "Single-replica ovn-central mode was introduced in v1.18")
+		if !isSingleReplicaMode(f) {
+			ginkgo.Skip("ovn-central is not deployed in single-replica mode; skipping")
+		}
+	})
+
+	ginkgo.It("should deploy ovn-central as a single-replica Deployment backed by a PVC", func() {
+		ginkgo.By("Getting Deployment kube-system/ovn-central")
+		deployClient := f.DeploymentClientNS(framework.KubeOvnNamespace)
+		deploy := deployClient.Get("ovn-central")
+
+		ginkgo.By("Verifying replicas == 1")
+		framework.ExpectNotNil(deploy.Spec.Replicas)
+		gomega.Expect(*deploy.Spec.Replicas).To(gomega.BeEquivalentTo(1))
+
+		ginkgo.By("Verifying strategy is Recreate")
+		gomega.Expect(deploy.Spec.Strategy.Type).To(gomega.Equal(appsv1.RecreateDeploymentStrategyType))
+
+		ginkgo.By("Verifying the host-config-ovn volume is backed by PVC ovn-central-data")
+		var found bool
+		for _, v := range deploy.Spec.Template.Spec.Volumes {
+			if v.Name != "host-config-ovn" {
+				continue
+			}
+			found = true
+			framework.ExpectNotNil(v.PersistentVolumeClaim, "host-config-ovn volume should be a PVC in single-replica mode, not hostPath")
+			gomega.Expect(v.PersistentVolumeClaim.ClaimName).To(gomega.Equal("ovn-central-data"))
+		}
+		gomega.Expect(found).To(gomega.BeTrue(), "host-config-ovn volume must be present on the Deployment")
+
+		ginkgo.By("Verifying PVC kube-system/ovn-central-data is Bound")
+		pvc, err := f.ClientSet.CoreV1().PersistentVolumeClaims(framework.KubeOvnNamespace).
+			Get(context.TODO(), "ovn-central-data", metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		gomega.Expect(string(pvc.Status.Phase)).To(gomega.Equal("Bound"))
+	})
+
+	ginkgo.It("should expose ovn-nb / ovn-sb / ovn-northd via leader-less Services", func() {
+		for _, name := range []string{"ovn-nb", "ovn-sb", "ovn-northd"} {
+			ginkgo.By("Inspecting Service kube-system/" + name)
+			svc, err := f.ClientSet.CoreV1().Services(framework.KubeOvnNamespace).
+				Get(context.TODO(), name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(svc.Spec.Selector).To(gomega.HaveKeyWithValue("app", "ovn-central"))
+			// In single-replica mode the leader-label selectors are dropped so
+			// the single pod is always the Service's endpoint.
+			gomega.Expect(svc.Spec.Selector).NotTo(gomega.HaveKey("ovn-nb-leader"))
+			gomega.Expect(svc.Spec.Selector).NotTo(gomega.HaveKey("ovn-sb-leader"))
+			gomega.Expect(svc.Spec.Selector).NotTo(gomega.HaveKey("ovn-northd-leader"))
+		}
+	})
+
+	ginkgo.It("should keep the ovn-central pod labelled as leader for all three databases", func() {
+		ginkgo.By("Listing pods of ovn-central")
+		pods, err := f.ClientSet.CoreV1().Pods(framework.KubeOvnNamespace).
+			List(context.TODO(), metav1.ListOptions{LabelSelector: "app=ovn-central"})
+		framework.ExpectNoError(err)
+		gomega.Expect(pods.Items).To(gomega.HaveLen(1), "single-replica mode must have exactly one ovn-central pod")
+
+		ginkgo.By("Waiting for the leader-checker to apply ovn-*-leader=true labels")
+		pod := pods.Items[0]
+		framework.WaitUntil(2*time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+			p, err := f.ClientSet.CoreV1().Pods(framework.KubeOvnNamespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			for _, label := range []string{"ovn-nb-leader", "ovn-sb-leader", "ovn-northd-leader"} {
+				if p.Labels[label] != "true" {
+					return false, nil
+				}
+			}
+			return true, nil
+		}, "pod "+pod.Name+" to be labelled as leader for all three databases")
+	})
+
+	ginkgo.It("should support basic subnet+pod networking", func() {
+		subnetClient := f.SubnetClient()
+		podClient := f.PodClient()
+		suffix := framework.RandomSuffix()
+		subnetName := "single-replica-subnet-" + suffix
+		podName := "single-replica-pod-" + suffix
+		cidr := framework.RandomCIDR(f.ClusterIPFamily)
+
+		ginkgo.By("Creating subnet " + subnetName)
+		subnet := framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
+		_ = subnetClient.CreateSync(subnet)
+		ginkgo.DeferCleanup(func() { subnetClient.DeleteSync(subnetName) })
+
+		ginkgo.By("Creating pod " + podName + " on the new subnet")
+		annotations := map[string]string{util.LogicalSwitchAnnotation: subnetName}
+		pod := framework.MakePod(f.Namespace.Name, podName, nil, annotations, framework.AgnhostImage, nil, nil)
+		_ = podClient.CreateSync(pod)
+		ginkgo.DeferCleanup(func() { podClient.DeleteSync(podName) })
+
+		ginkgo.By("Verifying pod got an IP from the new subnet")
+		pod = podClient.GetPod(podName)
+		gomega.Expect(pod.Annotations[util.AllocatedAnnotation]).To(gomega.Equal("true"))
+		gomega.Expect(pod.Annotations[util.IPAddressAnnotation]).NotTo(gomega.BeEmpty())
+	})
+
+	framework.DisruptiveIt("should recover after the ovn-central pod is deleted", func() {
+		ginkgo.By("Recording the current ovn-central pod")
+		deployClient := f.DeploymentClientNS(framework.KubeOvnNamespace)
+		deploy := deployClient.Get("ovn-central")
+		oldPods, err := deployClient.GetAllPods(deploy)
+		framework.ExpectNoError(err)
+		framework.ExpectHaveLen(oldPods.Items, 1)
+		oldPodName := oldPods.Items[0].Name
+
+		ginkgo.By("Deleting pod " + oldPodName)
+		err = f.ClientSet.CoreV1().Pods(framework.KubeOvnNamespace).
+			Delete(context.TODO(), oldPodName, metav1.DeleteOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for a fresh ovn-central pod to become Ready")
+		deployClient.RolloutStatus("ovn-central")
+		newPods, err := deployClient.GetAllPods(deploy)
+		framework.ExpectNoError(err)
+		framework.ExpectHaveLen(newPods.Items, 1)
+		gomega.Expect(newPods.Items[0].Name).NotTo(gomega.Equal(oldPodName), "a new pod should be created after deletion")
+
+		ginkgo.By("Verifying the OVN DB is still functional after recovery")
+		subnetClient := f.SubnetClient()
+		podClient := f.PodClient()
+		suffix := framework.RandomSuffix()
+		subnetName := "single-replica-recover-" + suffix
+		podName := "single-replica-recover-pod-" + suffix
+		cidr := framework.RandomCIDR(f.ClusterIPFamily)
+
+		subnet := framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
+		_ = subnetClient.CreateSync(subnet)
+		ginkgo.DeferCleanup(func() { subnetClient.DeleteSync(subnetName) })
+
+		annotations := map[string]string{util.LogicalSwitchAnnotation: subnetName}
+		pod := framework.MakePod(f.Namespace.Name, podName, nil, annotations, framework.AgnhostImage, nil, nil)
+		_ = podClient.CreateSync(pod)
+		ginkgo.DeferCleanup(func() { podClient.DeleteSync(podName) })
+
+		pod = podClient.GetPod(podName)
+		gomega.Expect(pod.Annotations[util.AllocatedAnnotation]).To(gomega.Equal("true"))
+		gomega.Expect(pod.Annotations[util.IPAddressAnnotation]).NotTo(gomega.BeEmpty())
+	})
+})


### PR DESCRIPTION
## Summary

Adds a new `OVN_CENTRAL_MODE=single` deployment mode where `ovn-central` runs as
a single-replica Deployment with the OVN DB on a PVC, so the pod can drift to
another node on host failure (provided the StorageClass supports cross-node
attach). The existing multi-replica raft cluster mode remains the default and is
unchanged.

- **Commit 1 — chart + scripts + leader-checker:** new `OVN_CENTRAL_MODE`
  value, `ovnCentralReplicas` / `ovnCentralNodeIPs` helpers, a new
  `central-pvc.yaml` template, branched `central-deploy.yaml` (replicas,
  Recreate strategy, no podAntiAffinity, PVC volume), leader-less Service
  selectors in single mode, `start-db.sh` / `ovn-is-leader.sh` /
  `ovn-healthcheck.sh` short-circuiting raft-only paths, and
  `pkg/ovn_leader_checker` skipping raft queries + `ovn_northd` lock steal.
- **Commit 2 — `install.sh` + `restore-ovn-nb-db.sh`:** wires the new mode into
  the non-Helm install path via `ENABLE_SINGLE_REPLICA_OVN=true`
  (+ `OVN_CENTRAL_STORAGE_CLASS` / `OVN_CENTRAL_PVC_SIZE`), and adds a
  `restore-ovn-nb-db.sh single <backup.db>` subcommand that copies a backup
  into the PVC via a helper pod.
- **Commit 3 — docs + e2e + Make targets:** user-facing
  `docs/single-replica-deployment.md`, a new e2e suite at
  `test/e2e/single-replica/` that auto-skips on cluster-mode installs, and
  `kind-install-single-replica` / `kube-ovn-single-replica-e2e` Make targets.

`helm template` with default values renders identically to master in cluster
mode (verified by diff during development).

## Test plan

- [ ] CI: existing cluster-mode e2e suites stay green (no behaviour change in
      cluster mode).
- [ ] Local kind smoke test: `make kind-init && make kind-install-single-replica`,
      then verify:
  - `kubectl get pod -n kube-system -l app=ovn-central` shows exactly 1 pod.
  - `kubectl get pvc -n kube-system ovn-central-data` is Bound.
  - `kubectl get svc -n kube-system ovn-nb -o jsonpath='{.spec.selector}'`
    contains only `app=ovn-central` (no `ovn-nb-leader`).
  - Subnet + Pod creation succeeds and the Pod gets an IP.
  - Deleting the ovn-central pod brings it back Ready on the same node (local-path)
    or a different node (NFS-CSI), and existing subnets/pods are still reachable.
- [ ] Run new e2e job: `make kube-ovn-single-replica-e2e`.
- [ ] Backup/restore round-trip:
      `ovsdb-client backup unix:/var/run/ovn/ovnnb_db.sock > backup.db` →
      `bash dist/images/restore-ovn-nb-db.sh single backup.db` → DB content
      unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)