### PR TITLE
refactor(daemon): drop redundant Node DeepCopy in provider network sync

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -393,9 +393,9 @@ func (c *Controller) handleAddOrUpdateProviderNetwork(key string) error {
 
 	if excluded {
 		c.recordProviderNetworkErr(pn.Name, "")
-		return c.cleanProviderNetwork(pn.DeepCopy(), node.DeepCopy())
+		return c.cleanProviderNetwork(pn.DeepCopy(), node)
 	}
-	return c.initProviderNetwork(pn.DeepCopy(), node.DeepCopy())
+	return c.initProviderNetwork(pn.DeepCopy(), node)
 }
 
 func providerNetworkNic(pn *kubeovnv1.ProviderNetwork, nodeName string) string {
@@ -407,6 +407,8 @@ func providerNetworkNic(pn *kubeovnv1.ProviderNetwork, nodeName string) string {
 	return pn.Spec.DefaultInterface
 }
 
+// initProviderNetwork configures the provider network on the local node.
+// node must not be mutated; it is backed by the shared informer cache.
 func (c *Controller) initProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v1.Node) error {
 	nic := providerNetworkNic(pn, node.Name)
 
@@ -543,6 +545,8 @@ func (c *Controller) recordProviderNetworkErr(providerNetwork, errMsg string) {
 	}
 }
 
+// cleanProviderNetwork tears down the provider network from the local node.
+// node must not be mutated; it is backed by the shared informer cache.
 func (c *Controller) cleanProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v1.Node) error {
 	patch := util.KVPatch{
 		fmt.Sprintf(util.ProviderNetworkReadyTemplate, pn.Name):     nil,


### PR DESCRIPTION
## Summary
- `handleAddOrUpdateProviderNetwork` passed `node.DeepCopy()` into `cleanProviderNetwork` / `initProviderNetwork`, but both callees only read `node.Name` — the copy is dead weight on every reconcile.
- Pass the shared-informer `Node` reference through directly, and document on each callee signature that the argument must not be mutated.
- Mirrors the same hot-path cleanup happening upstream in ovn-org/ovn-kubernetes#6423.

## Test plan
- [x] `make lint` (0 issues)
- [x] `go build ./pkg/daemon/...`
- [x] Verified both callees only read `node.Name` and never write back to the Node object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)