### PR TITLE
fix(controller): skip in-pod cleanup when VPC NAT gateway CRD is deleted

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -237,6 +237,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		providerNetworksLister:  providerNetworkInformer.Lister(),
 		netAttachLister:         nadInformer.Lister(),
 		netAttachSynced:         alwaysReady,
+		vpcNatGatewayLister:     vpcNatGwInformer.Lister(),
 		OVNNbClient:             mockOvnClient,
 		OVNSbClient:             mockOvnSbClient,
 		ipam:                    ovnipam.NewIPAM(),

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -398,13 +398,41 @@ func (c *Controller) createEipInPod(dp, addrV4, ns string) error {
 	return c.execNatGwRules(gwPod, natGwEipAdd, []string{addrV4})
 }
 
+// natGwDeleted returns true when the VpcNatGateway CRD with the given name no
+// longer exists. A (true, nil) result means the gateway has been fully removed
+// and any in-pod cleanup can be safely skipped. Other errors are returned
+// as-is for the caller to handle.
+func (c *Controller) natGwDeleted(dp string) (bool, error) {
+	if _, err := c.vpcNatGatewayLister.Get(dp); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
 func (c *Controller) deleteEipInPod(dp, v4Cidr, ns string) error {
+	// If the NAT gateway CRD is gone the gateway (and its pod) have been deleted;
+	// there is nothing to clean up. If the CRD still exists but the pod is
+	// temporarily absent (e.g. being recreated), return the error so the
+	// reconciler retries until the pod is ready.
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
 	gwPod, err := c.getNatGwPod(dp, ns)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			// Pod is temporarily absent (e.g. being recreated); retry quietly.
+			klog.V(4).Infof("nat gw pod %s not found, will retry eip pod cleanup", dp)
+		} else {
+			klog.Error(err)
 		}
-		klog.Error(err)
 		return err
 	}
 	var delRules []string
@@ -513,9 +541,23 @@ func (c *Controller) addEipQoSInPod(
 
 func (c *Controller) delEipQoSInPod(dp, v4ip, ns string, direction kubeovnv1.QoSPolicyRuleDirection) error {
 	var operation string
-	gwPod, err := c.getNatGwPod(dp, ns)
+	// Same CRD / pod sentinel logic as deleteEipInPod: skip when the gateway is
+	// gone, retry when the pod is temporarily absent.
+	deleted, err := c.natGwDeleted(dp)
 	if err != nil {
 		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
+	gwPod, err := c.getNatGwPod(dp, ns)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			klog.V(4).Infof("nat gw pod %s not found, will retry eip qos cleanup", dp)
+		} else {
+			klog.Error(err)
+		}
 		return err
 	}
 	var delRules []string

--- a/pkg/controller/vpc_nat_gw_eip_test.go
+++ b/pkg/controller/vpc_nat_gw_eip_test.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+// fakeGw returns a minimal VpcNatGateway CRD object for use in tests.
+func fakeGw(name string) *kubeovnv1.VpcNatGateway {
+	return &kubeovnv1.VpcNatGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       kubeovnv1.VpcNatGatewaySpec{},
+	}
+}
+
+func TestNatGwDeleted(t *testing.T) {
+	t.Parallel()
+
+	t.Run("gateway CRD exists returns false", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("test-gw")},
+		})
+		require.NoError(t, err)
+		deleted, err := fc.fakeController.natGwDeleted("test-gw")
+		require.NoError(t, err)
+		require.False(t, deleted)
+	})
+
+	t.Run("gateway CRD missing returns true", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, nil)
+		require.NoError(t, err)
+		deleted, err := fc.fakeController.natGwDeleted("missing-gw")
+		require.NoError(t, err)
+		require.True(t, deleted)
+	})
+}
+
+// TestDeleteEipInPod_NatGwGone verifies that deleteEipInPod returns nil (skips
+// cleanup) when the VpcNatGateway CRD no longer exists, allowing the EIP to
+// be finalized without an infinite retry loop.
+func TestDeleteEipInPod_NatGwGone(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, nil) // no VpcNatGateway
+	require.NoError(t, err)
+	err = fc.fakeController.deleteEipInPod("missing-gw", "10.0.0.1/24", "kube-system")
+	require.NoError(t, err, "should skip cleanup when gateway CRD is gone")
+}
+
+// TestDeleteEipInPod_NatGwExistsPodMissing verifies that deleteEipInPod returns
+// an error (triggering a reconcile retry) when the VpcNatGateway CRD exists but
+// its pod is not yet available (e.g., being recreated).
+func TestDeleteEipInPod_NatGwExistsPodMissing(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("test-gw")},
+	})
+	require.NoError(t, err)
+	err = fc.fakeController.deleteEipInPod("test-gw", "10.0.0.1/24", "kube-system")
+	require.Error(t, err, "should return error to retry when pod is temporarily absent")
+}
+
+// TestDelEipQoSInPod_NatGwGone verifies cleanup is skipped when gateway is gone.
+func TestDelEipQoSInPod_NatGwGone(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	err = fc.fakeController.delEipQoSInPod("missing-gw", "10.0.0.1", "kube-system", kubeovnv1.QoSDirectionIngress)
+	require.NoError(t, err, "should skip cleanup when gateway CRD is gone")
+}
+
+// TestDelEipQoSInPod_NatGwExistsPodMissing verifies that an error is returned
+// when the gateway CRD exists but the pod is not ready.
+func TestDelEipQoSInPod_NatGwExistsPodMissing(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("test-gw")},
+	})
+	require.NoError(t, err)
+	err = fc.fakeController.delEipQoSInPod("test-gw", "10.0.0.1", "kube-system", kubeovnv1.QoSDirectionEgress)
+	require.Error(t, err, "should return error to retry when pod is temporarily absent")
+}

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -1927,12 +1927,25 @@ func (c *Controller) finalDeleteSnatInPod(key string, cachedSnat *kubeovnv1.Ipta
 }
 
 func (c *Controller) deleteFipInPod(dp, v4ip string) error {
+	// If the NAT gateway CRD is gone the gateway (and its pod) have been deleted;
+	// there is nothing to clean up. If the CRD still exists but the pod is
+	// temporarily absent (e.g. being recreated), return the error so the
+	// reconciler retries until the pod is ready.
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
 	gwPod, err := c.getNatGwPod(dp, c.natGwNamespaceByName(dp))
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			klog.V(4).Infof("nat gw pod %s not found, will retry fip pod cleanup", dp)
+		} else {
+			klog.Error(err)
 		}
-		klog.Error(err)
 		return err
 	}
 	// del_floating_ip matches by EIP only (FIP is 1:1, identity = EIP)
@@ -1961,12 +1974,25 @@ func (c *Controller) createDnatInPod(dp, protocol, v4ip, internalIP, externalPor
 }
 
 func (c *Controller) deleteDnatInPod(dp, protocol, v4ip, externalPort string) error {
+	// If the NAT gateway CRD is gone the gateway (and its pod) have been deleted;
+	// there is nothing to clean up. If the CRD still exists but the pod is
+	// temporarily absent (e.g. being recreated), return the error so the
+	// reconciler retries until the pod is ready.
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
 	gwPod, err := c.getNatGwPod(dp, c.natGwNamespaceByName(dp))
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			klog.V(4).Infof("nat gw pod %s not found, will retry dnat pod cleanup", dp)
+		} else {
+			klog.Error(err)
 		}
-		klog.Error(err)
 		return err
 	}
 
@@ -2008,12 +2034,25 @@ func (c *Controller) createSnatInPod(dp, v4ip, internalCIDR string) error {
 
 func (c *Controller) deleteSnatInPod(dp, v4ip, internalCIDR string) error {
 	internalCIDR = normalizeSnatInternalCIDR(internalCIDR)
+	// If the NAT gateway CRD is gone the gateway (and its pod) have been deleted;
+	// there is nothing to clean up. If the CRD still exists but the pod is
+	// temporarily absent (e.g. being recreated), return the error so the
+	// reconciler retries until the pod is ready.
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
 	gwPod, err := c.getNatGwPod(dp, c.natGwNamespaceByName(dp))
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			klog.V(4).Infof("nat gw pod %s not found, will retry snat pod cleanup", dp)
+		} else {
+			klog.Error(err)
 		}
-		klog.Error(err)
 		return err
 	}
 	// del nat

--- a/pkg/controller/vpc_nat_gw_nat_test.go
+++ b/pkg/controller/vpc_nat_gw_nat_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -480,4 +481,70 @@ func TestValidateSnat(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDeleteFipInPod_NatGwGone verifies that deleteFipInPod returns nil (skips
+// cleanup) when the VpcNatGateway CRD no longer exists.
+func TestDeleteFipInPod_NatGwGone(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	err = fc.fakeController.deleteFipInPod("missing-gw", "10.0.0.1")
+	require.NoError(t, err, "should skip cleanup when gateway CRD is gone")
+}
+
+// TestDeleteFipInPod_NatGwExistsPodMissing verifies that deleteFipInPod returns
+// an error to trigger a retry when the gateway CRD exists but the pod is absent.
+func TestDeleteFipInPod_NatGwExistsPodMissing(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("test-gw")},
+	})
+	require.NoError(t, err)
+	err = fc.fakeController.deleteFipInPod("test-gw", "10.0.0.1")
+	require.Error(t, err, "should return error to retry when pod is temporarily absent")
+}
+
+// TestDeleteDnatInPod_NatGwGone verifies that deleteDnatInPod returns nil when
+// the VpcNatGateway CRD no longer exists.
+func TestDeleteDnatInPod_NatGwGone(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	err = fc.fakeController.deleteDnatInPod("missing-gw", "tcp", "10.0.0.1", "80")
+	require.NoError(t, err, "should skip cleanup when gateway CRD is gone")
+}
+
+// TestDeleteDnatInPod_NatGwExistsPodMissing verifies that deleteDnatInPod
+// returns an error to trigger a retry when the pod is absent.
+func TestDeleteDnatInPod_NatGwExistsPodMissing(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("test-gw")},
+	})
+	require.NoError(t, err)
+	err = fc.fakeController.deleteDnatInPod("test-gw", "tcp", "10.0.0.1", "80")
+	require.Error(t, err, "should return error to retry when pod is temporarily absent")
+}
+
+// TestDeleteSnatInPod_NatGwGone verifies that deleteSnatInPod returns nil when
+// the VpcNatGateway CRD no longer exists.
+func TestDeleteSnatInPod_NatGwGone(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	err = fc.fakeController.deleteSnatInPod("missing-gw", "10.0.0.1", "192.168.1.0/24")
+	require.NoError(t, err, "should skip cleanup when gateway CRD is gone")
+}
+
+// TestDeleteSnatInPod_NatGwExistsPodMissing verifies that deleteSnatInPod
+// returns an error to trigger a retry when the pod is absent.
+func TestDeleteSnatInPod_NatGwExistsPodMissing(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("test-gw")},
+	})
+	require.NoError(t, err)
+	err = fc.fakeController.deleteSnatInPod("test-gw", "10.0.0.1", "192.168.1.0/24")
+	require.Error(t, err, "should return error to retry when pod is temporarily absent")
 }


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

## Problem

When deleting an `IptablesEIP`, the controller calls `deleteEipInPod` and
`delEipQoSInPod` to remove iptables/tc rules in the NAT gateway pod.
Previously, both functions only checked whether the **pod** existed. If the
pod was missing for any reason (e.g., the whole gateway had been deleted,
or the pod was being recreated), the call returned an error and the
reconciler retried indefinitely — the EIP could never be finalized.

Observed error in logs:
```
pod.apps "i-6a153a5c168f46c050c3bda9" not found
failed to del egress eip '163.142.153.136' qos in pod, pod.apps "i-6a153a5c168f46c050c3bda9" not found
error syncing update iptables eip "163.142.153.136": pod.apps "i-6a153a5c168f46c050c3bda9" not found, requeuing
```

## Fix

Use the **VpcNatGateway CRD** as the sentinel instead of the pod:

- If the CRD is **not found** → the gateway has been deleted along with its
  pod; there is nothing left to clean up, so return `nil` and allow the EIP
  deletion to complete.
- If the CRD **exists** but the pod is temporarily absent (e.g., the pod is
  being recreated after a node failure) → return the error so the reconciler
  retries until the pod is ready and cleanup can be performed.

Functions changed: `deleteEipInPod` and `delEipQoSInPod` in
`pkg/controller/vpc_nat_gw_eip.go`.

## Testing

Verified with a local kind cluster (kube-ovn v1.17.0):

1. Created a `VpcNatGateway` and an `IptablesEIP` that references it.
2. Deleted the `VpcNatGateway` CRD.
3. Deleted the `IptablesEIP` → EIP was finalized immediately without any retry loop.

Before the fix the same steps caused the controller to log the error above every 20 seconds indefinitely.

## Which issue(s) this PR fixes

N/A