### PR TITLE
fix(base): clear stale OVN BFD remote discriminator

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -66,6 +66,7 @@ ADD patches/9286e1fd578fdb8f565a0f4aa9066b538295e1ac.patch $SRC_DIR
 ADD patches/737d9f932edada5a91f315b5f382daada8dee952.patch $SRC_DIR
 ADD patches/52b727b3315463668669ff423ce8bfa129861162.patch $SRC_DIR
 ADD patches/sbrec-delete-null-check.patch $SRC_DIR
+ADD patches/ovn-bfd-clear-remote-disc-on-timeout.patch $SRC_DIR
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -134,7 +135,9 @@ RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-o
     # set dl_src for packets redirected by router port
     git apply $SRC_DIR/52b727b3315463668669ff423ce8bfa129861162.patch && \
     # add null check before sbrec delete calls
-    git apply $SRC_DIR/sbrec-delete-null-check.patch
+    git apply $SRC_DIR/sbrec-delete-null-check.patch && \
+    # ovn-controller: clear stale BFD remote discriminator on timeout
+    git apply $SRC_DIR/ovn-bfd-clear-remote-disc-on-timeout.patch
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/dist/images/patches/ovn-bfd-clear-remote-disc-on-timeout.patch
+++ b/dist/images/patches/ovn-bfd-clear-remote-disc-on-timeout.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhangzujian <zhangzujian.7@gmail.com>
+Date: Wed, 27 May 2026 11:00:00 +0800
+Subject: [PATCH] ovn-controller: clear BFD remote discriminator on timeout
+
+RFC 5880 requires bfd.RemoteDiscr to be set to zero after a Detection
+Time passes without receiving a valid BFD packet from the remote system.
+
+ovn-controller already cleared remote_disc when synchronizing a down BFD
+state to the Southbound database, but that made packet transmission depend
+on the later SB synchronization path.  If the local BFD entry was already
+down while remote_disc still held the peer's stale discriminator,
+ovn-controller could keep sending Down packets with your_disc set to the
+old peer discriminator.  A restarted peer no longer has that session and
+will discard those packets, so the BFD session cannot be re-established.
+
+Clear remote_disc immediately when the detection timer expires.  Also keep
+clearing it while the entry is already down and the detection window has
+expired, so an existing down entry with stale remote_disc can recover
+without waiting for a BFD row rebuild.
+
+Signed-off-by: zhangzujian <zhangzujian.7@gmail.com>
+---
+ controller/pinctrl.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/controller/pinctrl.c b/controller/pinctrl.c
+index b8ceb536d..939fd0437 100644
+--- a/controller/pinctrl.c
++++ b/controller/pinctrl.c
+@@ -8196,8 +8196,7 @@ update:
+ static void
+ bfd_check_detection_timeout(struct bfd_entry *entry)
+ {
+-    if (entry->state == BFD_STATE_ADMIN_DOWN ||
+-        entry->state == BFD_STATE_DOWN) {
++    if (entry->state == BFD_STATE_ADMIN_DOWN) {
+         return;
+     }
+ 
+@@ -8210,7 +8209,13 @@ bfd_check_detection_timeout(struct bfd_entry *entry)
+         return;
+     }
+ 
++    if (entry->state == BFD_STATE_DOWN) {
++        entry->remote_disc = 0;
++        return;
++    }
++
+     entry->state = BFD_STATE_DOWN;
++    entry->remote_disc = 0;
+     entry->change_state = true;
+     bfd_last_update = cur_time;
+     bfd_pending_update = 0;
+-- 
+2.43.0
+


### PR DESCRIPTION
## What this PR does

Adds a kube-ovn base image patch for OVN `branch-25.03` that clears `ovn-controller`'s local BFD `remote_disc` when the BFD detection timer expires.

## Why this is needed

We debugged a stuck VPC egress gateway BFD failure where:

- the SB BFD row stayed `down` and did not recover automatically;
- packet capture showed OVN continuously sending BFD `Down` packets with `your_disc=<old peer discriminator>`;
- the VEG `bfdd` process had restarted and no longer had that old session;
- OpenBFDD logged `no session found for yourDisc` and correctly discarded those packets;
- no `VEG -> OVN` BFD packets were sent afterwards, so the session could not be re-established.

RFC 5880 requires `bfd.RemoteDiscr` to be set to zero after a Detection Time passes without receiving a valid BFD packet from the remote system. OVN already clears `remote_disc` while synchronizing a down state to SB, but packet transmission could keep using the stale value if the local entry was already down before that synchronization path cleared it.

## Fix

The OVN patch updates `bfd_check_detection_timeout()` to:

- clear `remote_disc` immediately when detection timeout transitions a session to `Down`;
- keep clearing stale `remote_disc` while an entry is already `Down` and the detection window has expired.

This makes OVN send `Down your_disc=0`, allowing a restarted BFD peer to create a fresh session instead of discarding packets for an old discriminator.

## Validation

- `git apply --check` passed against a clean OVN `origin/branch-25.03` worktree.
- `make lint` passed.
