### PR TITLE
fix(veg): raise default bfdd CPU limit

### DIFF
--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -34,7 +34,7 @@ var (
 	// default resource requirements for the vpc egress gateway container if not specified by the user
 	vegSleepResourceCPU         = resource.MustParse("10m")
 	vegSleepResourceMemory      = resource.MustParse("10Mi")
-	vegBFDDResourceCPU          = resource.MustParse("50m")
+	vegBFDDResourceCPU          = resource.MustParse("200m")
 	vegBFDDResourceMemory       = resource.MustParse("50Mi")
 	vegResourceEphemeralStorage = resource.MustParse("1Gi")
 )

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -1,0 +1,19 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestVpcEgressGatewayContainerBFDDDefaultResources(t *testing.T) {
+	container := vpcEgressGatewayContainerBFDD("kube-ovn", "10.255.255.255", 100, 100, 5)
+
+	require.Equal(t, "200m", container.Resources.Requests.Cpu().String())
+	require.Equal(t, "200m", container.Resources.Limits.Cpu().String())
+	require.Equal(t, "50Mi", container.Resources.Requests.Memory().String())
+	require.Equal(t, "50Mi", container.Resources.Limits.Memory().String())
+	ephemeralStorage := container.Resources.Limits[corev1.ResourceEphemeralStorage]
+	require.Equal(t, "1Gi", ephemeralStorage.String())
+}


### PR DESCRIPTION
## Summary

Increase the default CPU request and limit for the vpc-egress-gateway `bfdd` container from `50m` to `200m`.

This default is only used when `VpcEgressGateway.spec.resources` is not set, so explicit user resource settings continue to take precedence.

## Motivation

While debugging VEG BFD flaps with 100 gateway pods and aggressive BFD intervals, `bfdd` occasionally delayed packet/timer processing long enough to trigger transient BFD detection timeouts. Raising the default CPU budget gives `bfdd` more scheduling headroom and reduces the chance of false BFD down transitions under load.

## Tests

- `go test ./pkg/controller`
- `make lint`
