### PR TITLE
feat(veg): allow co-located active-active replicas

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -3700,6 +3700,17 @@ spec:
                       type: object
                   type: object
                 type: array
+              podAntiAffinity:
+                default: Required
+                description: |-
+                  Pod anti-affinity mode for gateway workload replicas.
+                  Required spreads replicas across nodes and is the default. Preferred allows
+                  co-located replicas but does not provide node-level HA. Changing from
+                  Preferred to Required only takes effect when pods are recreated.
+                enum:
+                - Required
+                - Preferred
+                type: string
               policies:
                 description: |-
                   egress policies

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -3724,6 +3724,17 @@ spec:
                       type: object
                   type: object
                 type: array
+              podAntiAffinity:
+                default: Required
+                description: |-
+                  Pod anti-affinity mode for gateway workload replicas.
+                  Required spreads replicas across nodes and is the default. Preferred allows
+                  co-located replicas but does not provide node-level HA. Changing from
+                  Preferred to Required only takes effect when pods are recreated.
+                enum:
+                - Required
+                - Preferred
+                type: string
               policies:
                 description: |-
                   egress policies

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -4109,6 +4109,17 @@ spec:
                       type: object
                   type: object
                 type: array
+              podAntiAffinity:
+                default: Required
+                description: |-
+                  Pod anti-affinity mode for gateway workload replicas.
+                  Required spreads replicas across nodes and is the default. Preferred allows
+                  co-located replicas but does not provide node-level HA. Changing from
+                  Preferred to Required only takes effect when pods are recreated.
+                enum:
+                - Required
+                - Preferred
+                type: string
               policies:
                 description: |-
                   egress policies

--- a/pkg/apis/kubeovn/v1/vpc-egress-gateway.go
+++ b/pkg/apis/kubeovn/v1/vpc-egress-gateway.go
@@ -8,6 +8,9 @@ import (
 const (
 	TrafficPolicyLocal   = "Local"
 	TrafficPolicyCluster = "Cluster"
+
+	PodAntiAffinityRequired  = "Required"
+	PodAntiAffinityPreferred = "Preferred"
 )
 
 // Phase represents resource phase
@@ -129,6 +132,13 @@ type VpcEgressGatewaySpec struct {
 	// +kubebuilder:default=Cluster
 	// +kubebuilder:validation:Enum=Local;Cluster
 	TrafficPolicy string `json:"trafficPolicy,omitempty"`
+	// Pod anti-affinity mode for gateway workload replicas.
+	// Required spreads replicas across nodes and is the default. Preferred allows
+	// co-located replicas but does not provide node-level HA. Changing from
+	// Preferred to Required only takes effect when pods are recreated.
+	// +kubebuilder:default=Required
+	// +kubebuilder:validation:Enum=Required;Preferred
+	PodAntiAffinity string `json:"podAntiAffinity,omitempty"`
 
 	// BFD configuration
 	BFD VpcEgressGatewayBFDConfig `json:"bfd"`

--- a/pkg/client/applyconfiguration/kubeovn/v1/vpcegressgatewayspec.go
+++ b/pkg/client/applyconfiguration/kubeovn/v1/vpcegressgatewayspec.go
@@ -60,6 +60,11 @@ type VpcEgressGatewaySpecApplyConfiguration struct {
 	// if set to "Local", traffic will be routed to the gateway pod/instance on the same node when available
 	// currently it works only for the default vpc
 	TrafficPolicy *string `json:"trafficPolicy,omitempty"`
+	// Pod anti-affinity mode for gateway workload replicas.
+	// Required spreads replicas across nodes and is the default. Preferred allows
+	// co-located replicas but does not provide node-level HA. Changing from
+	// Preferred to Required only takes effect when pods are recreated.
+	PodAntiAffinity *string `json:"podAntiAffinity,omitempty"`
 	// BFD configuration
 	BFD *VpcEgressGatewayBFDConfigApplyConfiguration `json:"bfd,omitempty"`
 	// egress policies
@@ -185,6 +190,14 @@ func (b *VpcEgressGatewaySpecApplyConfiguration) WithSelectors(values ...*VpcEgr
 // If called multiple times, the TrafficPolicy field is set to the value of the last call.
 func (b *VpcEgressGatewaySpecApplyConfiguration) WithTrafficPolicy(value string) *VpcEgressGatewaySpecApplyConfiguration {
 	b.TrafficPolicy = &value
+	return b
+}
+
+// WithPodAntiAffinity sets the PodAntiAffinity field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PodAntiAffinity field is set to the value of the last call.
+func (b *VpcEgressGatewaySpecApplyConfiguration) WithPodAntiAffinity(value string) *VpcEgressGatewaySpecApplyConfiguration {
+	b.PodAntiAffinity = &value
 	return b
 }
 

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -81,9 +81,33 @@ func podReady(pod *corev1.Pod) bool {
 	return false
 }
 
-func collectVpcEgressGatewayWorkloadStatus(gw *kubeovnv1.VpcEgressGateway, pods []*corev1.Pod, attachmentNetworkName string) (map[string]string, map[string]string, []string) {
-	nodeNexthopIPv4 := make(map[string]string, int(gw.Spec.Replicas))
-	nodeNexthopIPv6 := make(map[string]string, int(gw.Spec.Replicas))
+func insertNodeNexthop(nodeNexthops map[string]set.Set[string], nodeName, nexthop string) {
+	if nodeNexthops[nodeName] == nil {
+		nodeNexthops[nodeName] = set.New[string]()
+	}
+	nodeNexthops[nodeName].Insert(nexthop)
+}
+
+func flattenVpcEgressGatewayNexthops(nodeNexthops map[string]set.Set[string]) set.Set[string] {
+	nextHops := set.New[string]()
+	for _, nodeNextHops := range nodeNexthops {
+		nextHops.Insert(nodeNextHops.UnsortedList()...)
+	}
+	return nextHops
+}
+
+func updateVpcEgressGatewayPolicyNexthops(policy *ovnnb.LogicalRouterPolicy, nextHops, bfdSessions set.Set[string]) bool {
+	if nextHops.Equal(set.New(policy.Nexthops...)) && bfdSessions.Equal(set.New(policy.BFDSessions...)) {
+		return false
+	}
+	policy.Nexthops = nextHops.UnsortedList()
+	policy.BFDSessions = bfdSessions.UnsortedList()
+	return true
+}
+
+func collectVpcEgressGatewayWorkloadStatus(gw *kubeovnv1.VpcEgressGateway, pods []*corev1.Pod, attachmentNetworkName string) (map[string]set.Set[string], map[string]set.Set[string], []string) {
+	nodeNexthopIPv4 := make(map[string]set.Set[string], int(gw.Spec.Replicas))
+	nodeNexthopIPv6 := make(map[string]set.Set[string], int(gw.Spec.Replicas))
 	notReadyMessages := make([]string, 0)
 	workloadNodes := set.New[string]()
 
@@ -119,10 +143,10 @@ func collectVpcEgressGatewayWorkloadStatus(gw *kubeovnv1.VpcEgressGateway, pods 
 
 		ipv4, ipv6 := util.SplitIpsByProtocol(ips)
 		if len(ipv4) != 0 {
-			nodeNexthopIPv4[pod.Spec.NodeName] = ipv4[0]
+			insertNodeNexthop(nodeNexthopIPv4, pod.Spec.NodeName, ipv4[0])
 		}
 		if len(ipv6) != 0 {
-			nodeNexthopIPv6[pod.Spec.NodeName] = ipv6[0]
+			insertNodeNexthop(nodeNexthopIPv6, pod.Spec.NodeName, ipv6[0])
 		}
 		gw.Status.InternalIPs = append(gw.Status.InternalIPs, strings.Join(ips, ","))
 		gw.Status.ExternalIPs = append(gw.Status.ExternalIPs, strings.Join(extIPs, ","))
@@ -671,8 +695,9 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 	return attachmentNetworkName, ipv4Src, ipv6Src, deploy, nil
 }
 
-func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressGateway, af int, lrName, lrpName, bfdIP string, nextHops map[string]string, sources set.Set[string]) error {
-	if len(nextHops) == 0 {
+func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressGateway, af int, lrName, lrpName, bfdIP string, nodeNexthops map[string]set.Set[string], sources set.Set[string]) error {
+	nextHops := flattenVpcEgressGatewayNexthops(nodeNexthops)
+	if nextHops.Len() == 0 {
 		return nil
 	}
 
@@ -770,8 +795,8 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 
 	// reconcile LR policy
 	if gw.Spec.TrafficPolicy == kubeovnv1.TrafficPolicyLocal {
-		rules := make(map[string]string, len(nextHops))
-		for nodeName, nexthop := range nextHops {
+		rules := make(map[string]set.Set[string], len(nodeNexthops))
+		for nodeName, nodeNextHops := range nodeNexthops {
 			node, err := c.nodesLister.Get(nodeName)
 			if err != nil {
 				if k8serrors.IsNotFound(err) {
@@ -787,8 +812,8 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 				return err
 			}
 			localPgName := strings.ReplaceAll(portName, "-", ".")
-			rules[fmt.Sprintf("ip%d.src == $%s_ip%d && ip%d.src == $%s_ip%d", af, localPgName, af, af, pgName, af)] = nexthop
-			rules[fmt.Sprintf("ip%d.src == $%s_ip%d && ip%d.src == $%s", af, localPgName, af, af, asName)] = nexthop
+			rules[fmt.Sprintf("ip%d.src == $%s_ip%d && ip%d.src == $%s_ip%d", af, localPgName, af, af, pgName, af)] = nodeNextHops
+			rules[fmt.Sprintf("ip%d.src == $%s_ip%d && ip%d.src == $%s", af, localPgName, af, af, asName)] = nodeNextHops
 		}
 		policies, err := c.OVNNbClient.ListLogicalRouterPolicies(lrName, util.EgressGatewayLocalPolicyPriority, externalIDs, false)
 		if err != nil {
@@ -797,25 +822,16 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 		}
 		// update/delete existing policies
 		for _, policy := range policies {
-			nexthop := rules[policy.Match]
-			bfdSessions := localGatewayPolicyBFDSessions(bfdMap, nexthop)
-			if nexthop == "" {
+			nextHops := rules[policy.Match]
+			if nextHops.Len() == 0 {
 				if err = c.OVNNbClient.DeleteLogicalRouterPolicyByUUID(lrName, policy.UUID); err != nil {
 					err = fmt.Errorf("failed to delete ovn lr policy %q: %w", policy.Match, err)
 					klog.Error(err)
 					return err
 				}
 			} else {
-				var changed bool
-				if len(policy.Nexthops) != 1 || policy.Nexthops[0] != nexthop {
-					policy.Nexthops = []string{nexthop}
-					changed = true
-				}
-				if !bfdSessions.Equal(set.New(policy.BFDSessions...)) {
-					policy.BFDSessions = bfdSessions.UnsortedList()
-					changed = true
-				}
-				if changed {
+				bfdSessions := localGatewayPolicyBFDSessions(bfdMap, nextHops)
+				if updateVpcEgressGatewayPolicyNexthops(policy, nextHops, bfdSessions) {
 					if err = c.OVNNbClient.UpdateLogicalRouterPolicy(policy, &policy.Nexthops, &policy.BFDSessions); err != nil {
 						err = fmt.Errorf("failed to update logical router policy %s: %w", policy.UUID, err)
 						klog.Error(err)
@@ -826,9 +842,9 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 			delete(rules, policy.Match)
 		}
 		// create new policies
-		for match, nexthop := range rules {
+		for match, nextHops := range rules {
 			if err = c.OVNNbClient.AddLogicalRouterPolicy(lrName, util.EgressGatewayLocalPolicyPriority, match,
-				ovnnb.LogicalRouterPolicyActionReroute, []string{nexthop}, localGatewayPolicyBFDSessions(bfdMap, nexthop).UnsortedList(), externalIDs); err != nil {
+				ovnnb.LogicalRouterPolicyActionReroute, nextHops.UnsortedList(), localGatewayPolicyBFDSessions(bfdMap, nextHops).UnsortedList(), externalIDs); err != nil {
 				klog.Error(err)
 				return err
 			}
@@ -848,12 +864,9 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 		fmt.Sprintf("ip%d.src == $%s_ip%d", af, pgName, af),
 		fmt.Sprintf("ip%d.src == $%s", af, asName),
 	)
-	bfdIPs := set.New(slices.Collect(maps.Values(nextHops))...)
-	bfdSessions := bfdIDs.UnsortedList()
 	for _, policy := range policies {
 		if matches.Has(policy.Match) {
-			if !bfdIPs.Equal(set.New(policy.Nexthops...)) || !bfdIDs.Equal(set.New(policy.BFDSessions...)) {
-				policy.Nexthops, policy.BFDSessions = bfdIPs.UnsortedList(), bfdSessions
+			if updateVpcEgressGatewayPolicyNexthops(policy, nextHops, bfdIDs) {
 				if err = c.OVNNbClient.UpdateLogicalRouterPolicy(policy, &policy.Nexthops, &policy.BFDSessions); err != nil {
 					err = fmt.Errorf("failed to update bfd sessions of logical router policy %s: %w", policy.UUID, err)
 					klog.Error(err)
@@ -871,7 +884,7 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 	}
 	for _, match := range matches.UnsortedList() {
 		if err = c.OVNNbClient.AddLogicalRouterPolicy(lrName, util.EgressGatewayPolicyPriority, match,
-			ovnnb.LogicalRouterPolicyActionReroute, bfdIPs.UnsortedList(), bfdSessions, externalIDs); err != nil {
+			ovnnb.LogicalRouterPolicyActionReroute, nextHops.UnsortedList(), bfdIDs.UnsortedList(), externalIDs); err != nil {
 			klog.Error(err)
 			return err
 		}
@@ -918,8 +931,14 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 	return nil
 }
 
-func localGatewayPolicyBFDSessions(bfdMap map[string]string, nexthop string) set.Set[string] {
-	return set.New(bfdMap[nexthop]).Delete("")
+func localGatewayPolicyBFDSessions(bfdMap map[string]string, nextHops set.Set[string]) set.Set[string] {
+	bfdSessions := set.New[string]()
+	for nextHop := range nextHops {
+		if bfdID := bfdMap[nextHop]; bfdID != "" {
+			bfdSessions.Insert(bfdID)
+		}
+	}
+	return bfdSessions
 }
 
 func mergeNodeSelector(nodeSelector []kubeovnv1.VpcEgressGatewayNodeSelector) *corev1.NodeSelector {

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -697,9 +697,6 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 
 func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressGateway, af int, lrName, lrpName, bfdIP string, nodeNexthops map[string]set.Set[string], sources set.Set[string]) error {
 	nextHops := flattenVpcEgressGatewayNexthops(nodeNexthops)
-	if nextHops.Len() == 0 {
-		return nil
-	}
 
 	externalIDs := map[string]string{
 		ovs.ExternalIDVendor:           util.CniTypeName,
@@ -860,10 +857,13 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 		klog.Error(err)
 		return err
 	}
-	matches := set.New(
-		fmt.Sprintf("ip%d.src == $%s_ip%d", af, pgName, af),
-		fmt.Sprintf("ip%d.src == $%s", af, asName),
-	)
+	matches := set.New[string]()
+	if nextHops.Len() != 0 {
+		matches.Insert(
+			fmt.Sprintf("ip%d.src == $%s_ip%d", af, pgName, af),
+			fmt.Sprintf("ip%d.src == $%s", af, asName),
+		)
+	}
 	for _, policy := range policies {
 		if matches.Has(policy.Match) {
 			if updateVpcEgressGatewayPolicyNexthops(policy, nextHops, bfdIDs) {

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -536,7 +536,7 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 				},
 				Spec: corev1.PodSpec{
 					Affinity: mergeGatewayAffinity(
-						genGatewayPodAntiAffinity(labels),
+						genGatewayPodAntiAffinity(labels, gw.Spec.PodAntiAffinity),
 						&corev1.Affinity{
 							NodeAffinity: &corev1.NodeAffinity{
 								RequiredDuringSchedulingIgnoredDuringExecution: mergeNodeSelector(gw.Spec.NodeSelector),

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -85,10 +85,11 @@ func collectVpcEgressGatewayWorkloadStatus(gw *kubeovnv1.VpcEgressGateway, pods 
 	nodeNexthopIPv4 := make(map[string]string, int(gw.Spec.Replicas))
 	nodeNexthopIPv6 := make(map[string]string, int(gw.Spec.Replicas))
 	notReadyMessages := make([]string, 0)
+	workloadNodes := set.New[string]()
 
 	gw.Status.InternalIPs = nil
 	gw.Status.ExternalIPs = nil
-	gw.Status.Workload.Nodes = make([]string, 0, len(pods))
+	gw.Status.Workload.Nodes = nil
 
 	for _, pod := range pods {
 		if !pod.DeletionTimestamp.IsZero() {
@@ -125,8 +126,9 @@ func collectVpcEgressGatewayWorkloadStatus(gw *kubeovnv1.VpcEgressGateway, pods 
 		}
 		gw.Status.InternalIPs = append(gw.Status.InternalIPs, strings.Join(ips, ","))
 		gw.Status.ExternalIPs = append(gw.Status.ExternalIPs, strings.Join(extIPs, ","))
-		gw.Status.Workload.Nodes = append(gw.Status.Workload.Nodes, pod.Spec.NodeName)
+		workloadNodes.Insert(pod.Spec.NodeName)
 	}
+	gw.Status.Workload.Nodes = workloadNodes.SortedList()
 
 	if len(gw.Status.ExternalIPs) != int(gw.Spec.Replicas) {
 		notReadyMessages = append(notReadyMessages, fmt.Sprintf("expected %d ready workload pods with network %s, got %d", gw.Spec.Replicas, attachmentNetworkName, len(gw.Status.ExternalIPs)))

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -72,14 +72,20 @@ func TestLocalGatewayPolicyBFDSessions(t *testing.T) {
 	require.Empty(t, localGatewayPolicyBFDSessions(nil, set.New("10.16.1.10")))
 }
 
-func TestReconcileVpcEgressGatewayOVNRoutesConvergesLocalBFDNexthops(t *testing.T) {
-	const (
-		nodeName = "node-1"
-		lrName   = "vpc-router"
-		lrpName  = "bfd-lrp"
-		bfdIP    = "10.0.0.1"
-	)
+type vegOVNRouteFixture struct {
+	fc                               *fakeController
+	gw                               *kubeovnv1.VpcEgressGateway
+	nodeName, lrName, lrpName, bfdIP string
+	externalIDs                      map[string]string
+	pgName, asName                   string
+	localPolicies                    []*ovnnb.LogicalRouterPolicy
+	clusterPolicies                  []*ovnnb.LogicalRouterPolicy
+	dropPolicies                     []*ovnnb.LogicalRouterPolicy
+	allPolicies                      []*ovnnb.LogicalRouterPolicy
+}
 
+func newVegOVNRouteFixture(t *testing.T) *vegOVNRouteFixture {
+	const nodeName = "node-1"
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Nodes: []*corev1.Node{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nodeName,
@@ -88,114 +94,157 @@ func TestReconcileVpcEgressGatewayOVNRoutesConvergesLocalBFDNexthops(t *testing.
 	}}})
 	require.NoError(t, err)
 
-	gw := &kubeovnv1.VpcEgressGateway{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "veg"},
-		Spec: kubeovnv1.VpcEgressGatewaySpec{
-			TrafficPolicy: kubeovnv1.TrafficPolicyLocal,
-			BFD: kubeovnv1.VpcEgressGatewayBFDConfig{
-				Enabled:    true,
-				MinTX:      100,
-				MinRX:      200,
-				Multiplier: 3,
+	f := &vegOVNRouteFixture{
+		fc:       fc,
+		nodeName: nodeName,
+		lrName:   "vpc-router",
+		lrpName:  "bfd-lrp",
+		bfdIP:    "10.0.0.1",
+		gw: &kubeovnv1.VpcEgressGateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "veg"},
+			Spec: kubeovnv1.VpcEgressGatewaySpec{
+				TrafficPolicy: kubeovnv1.TrafficPolicyLocal,
+				BFD: kubeovnv1.VpcEgressGatewayBFDConfig{
+					Enabled:    true,
+					MinTX:      100,
+					MinRX:      200,
+					Multiplier: 3,
+				},
 			},
 		},
+		externalIDs: map[string]string{
+			ovs.ExternalIDVendor:           util.CniTypeName,
+			ovs.ExternalIDVpcEgressGateway: "default/veg",
+			"af":                           "4",
+		},
+		pgName: vegPortGroupName("default/veg"),
+		asName: vegAddressSetName("default/veg", 4),
 	}
-	externalIDs := map[string]string{
-		ovs.ExternalIDVendor:           util.CniTypeName,
-		ovs.ExternalIDVpcEgressGateway: "default/veg",
-		"af":                           "4",
-	}
-	pgName := vegPortGroupName("default/veg")
-	asName := vegAddressSetName("default/veg", 4)
 	localPgName := "node.node.1"
 	localMatches := []string{
-		fmt.Sprintf("ip4.src == $%s_ip4 && ip4.src == $%s_ip4", localPgName, pgName),
-		fmt.Sprintf("ip4.src == $%s_ip4 && ip4.src == $%s", localPgName, asName),
+		fmt.Sprintf("ip4.src == $%s_ip4 && ip4.src == $%s_ip4", localPgName, f.pgName),
+		fmt.Sprintf("ip4.src == $%s_ip4 && ip4.src == $%s", localPgName, f.asName),
 	}
 	clusterMatches := []string{
-		fmt.Sprintf("ip4.src == $%s_ip4", pgName),
-		fmt.Sprintf("ip4.src == $%s", asName),
+		fmt.Sprintf("ip4.src == $%s_ip4", f.pgName),
+		fmt.Sprintf("ip4.src == $%s", f.asName),
 	}
-	localPolicies := []*ovnnb.LogicalRouterPolicy{
+	f.localPolicies = []*ovnnb.LogicalRouterPolicy{
 		{UUID: "local-1", Match: localMatches[0], Nexthops: []string{"10.16.1.10", "10.16.1.11"}, BFDSessions: []string{"bfd-1", "bfd-2"}},
 		{UUID: "local-2", Match: localMatches[1], Nexthops: []string{"10.16.1.10", "10.16.1.11"}, BFDSessions: []string{"bfd-1", "bfd-2"}},
 	}
-	clusterPolicies := []*ovnnb.LogicalRouterPolicy{
+	f.clusterPolicies = []*ovnnb.LogicalRouterPolicy{
 		{UUID: "cluster-1", Match: clusterMatches[0], Nexthops: []string{"10.16.1.10", "10.16.1.11"}, BFDSessions: []string{"bfd-1", "bfd-2"}},
 		{UUID: "cluster-2", Match: clusterMatches[1], Nexthops: []string{"10.16.1.10", "10.16.1.11"}, BFDSessions: []string{"bfd-1", "bfd-2"}},
 	}
-	dropPolicies := []*ovnnb.LogicalRouterPolicy{
+	f.dropPolicies = []*ovnnb.LogicalRouterPolicy{
 		{UUID: "drop-1", Match: clusterMatches[0]},
 		{UUID: "drop-2", Match: clusterMatches[1]},
 	}
-	allPolicies := append(append([]*ovnnb.LogicalRouterPolicy{}, localPolicies...), clusterPolicies...)
+	f.allPolicies = append(append([]*ovnnb.LogicalRouterPolicy{}, f.localPolicies...), f.clusterPolicies...)
+	return f
+}
 
-	expectResources := func() {
-		fc.mockOvnClient.EXPECT().CreatePortGroup(pgName, externalIDs).Return(nil)
-		fc.mockOvnClient.EXPECT().PortGroupSetPorts(pgName, gomock.Any()).Return(nil)
-		fc.mockOvnClient.EXPECT().CreateAddressSet(asName, externalIDs).Return(nil)
-		fc.mockOvnClient.EXPECT().AddressSetUpdateAddress(asName).Return(nil)
+func (f *vegOVNRouteFixture) expectResources() {
+	f.fc.mockOvnClient.EXPECT().CreatePortGroup(f.pgName, f.externalIDs).Return(nil)
+	f.fc.mockOvnClient.EXPECT().PortGroupSetPorts(f.pgName, gomock.Any()).Return(nil)
+	f.fc.mockOvnClient.EXPECT().CreateAddressSet(f.asName, f.externalIDs).Return(nil)
+	f.fc.mockOvnClient.EXPECT().AddressSetUpdateAddress(f.asName).Return(nil)
+}
+
+func (f *vegOVNRouteFixture) expectPolicyUpdates(bfdEnabled bool) {
+	f.fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(f.lrName, util.EgressGatewayLocalPolicyPriority, f.externalIDs, false).Return(f.localPolicies, nil)
+	f.fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(f.lrName, util.EgressGatewayPolicyPriority, f.externalIDs, false).Return(f.clusterPolicies, nil)
+	f.fc.mockOvnClient.EXPECT().UpdateLogicalRouterPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(4)
+	if bfdEnabled {
+		f.fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(f.lrName, util.EgressGatewayDropPolicyPriority, f.externalIDs, false).Return(f.dropPolicies, nil)
+	} else {
+		f.fc.mockOvnClient.EXPECT().DeleteLogicalRouterPolicies(f.lrName, util.EgressGatewayDropPolicyPriority, f.externalIDs).Return(nil)
 	}
-	expectPolicies := func(bfdEnabled bool) {
-		fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(lrName, util.EgressGatewayLocalPolicyPriority, externalIDs, false).Return(localPolicies, nil)
-		fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(lrName, util.EgressGatewayPolicyPriority, externalIDs, false).Return(clusterPolicies, nil)
-		fc.mockOvnClient.EXPECT().UpdateLogicalRouterPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		if bfdEnabled {
-			fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(lrName, util.EgressGatewayDropPolicyPriority, externalIDs, false).Return(dropPolicies, nil)
-		} else {
-			fc.mockOvnClient.EXPECT().DeleteLogicalRouterPolicies(lrName, util.EgressGatewayDropPolicyPriority, externalIDs).Return(nil)
-		}
+}
+
+func (f *vegOVNRouteFixture) requirePolicyState(t *testing.T, nextHops, bfdSessions set.Set[string]) {
+	for _, policy := range f.allPolicies {
+		require.Equal(t, nextHops, set.New(policy.Nexthops...))
+		require.Equal(t, bfdSessions, set.New(policy.BFDSessions...))
 	}
-	requirePolicyState := func(nextHops, bfdSessions set.Set[string]) {
-		for _, policy := range allPolicies {
-			require.Equal(t, nextHops, set.New(policy.Nexthops...))
-			require.Equal(t, bfdSessions, set.New(policy.BFDSessions...))
-		}
+}
+
+func TestReconcileVpcEgressGatewayOVNRoutesDeletesRoutesWithoutNexthops(t *testing.T) {
+	f := newVegOVNRouteFixture(t)
+	for _, policy := range f.allPolicies {
+		policy.Nexthops = []string{"10.16.1.10"}
+		policy.BFDSessions = []string{"bfd-1"}
 	}
+
+	f.expectResources()
+	f.fc.mockOvnClient.EXPECT().FindBFD(f.externalIDs).Return([]ovnnb.BFD{{
+		UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: f.lrpName,
+	}}, nil)
+	f.fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(f.lrName, util.EgressGatewayLocalPolicyPriority, f.externalIDs, false).
+		Return(f.localPolicies, nil)
+	for _, policy := range f.localPolicies {
+		f.fc.mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(f.lrName, policy.UUID).Return(nil)
+	}
+	f.fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(f.lrName, util.EgressGatewayPolicyPriority, f.externalIDs, false).
+		Return(f.clusterPolicies, nil)
+	for _, policy := range f.clusterPolicies {
+		f.fc.mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(f.lrName, policy.UUID).Return(nil)
+	}
+	f.fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(f.lrName, util.EgressGatewayDropPolicyPriority, f.externalIDs, false).
+		Return(f.dropPolicies, nil)
+	f.fc.mockOvnClient.EXPECT().DeleteBFD("bfd-1").Return(nil)
+
+	err := f.fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(f.gw, 4, f.lrName, f.lrpName, f.bfdIP, nil, nil)
+	require.NoError(t, err)
+}
+
+func TestReconcileVpcEgressGatewayOVNRoutesConvergesLocalBFDNexthops(t *testing.T) {
+	f := newVegOVNRouteFixture(t)
 
 	// Converge from two nexthops to one and delete the stale BFD row.
-	expectResources()
-	fc.mockOvnClient.EXPECT().FindBFD(externalIDs).Return([]ovnnb.BFD{
-		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: lrpName},
-		{UUID: "bfd-2", DstIP: "10.16.1.11", LogicalPort: lrpName},
+	f.expectResources()
+	f.fc.mockOvnClient.EXPECT().FindBFD(f.externalIDs).Return([]ovnnb.BFD{
+		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: f.lrpName},
+		{UUID: "bfd-2", DstIP: "10.16.1.11", LogicalPort: f.lrpName},
 	}, nil)
-	expectPolicies(true)
-	fc.mockOvnClient.EXPECT().DeleteBFD("bfd-2").Return(nil)
-	err = fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(gw, 4, lrName, lrpName, bfdIP, map[string]set.Set[string]{
-		nodeName: set.New("10.16.1.10"),
+	f.expectPolicyUpdates(true)
+	f.fc.mockOvnClient.EXPECT().DeleteBFD("bfd-2").Return(nil)
+	err := f.fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(f.gw, 4, f.lrName, f.lrpName, f.bfdIP, map[string]set.Set[string]{
+		f.nodeName: set.New("10.16.1.10"),
 	}, nil)
 	require.NoError(t, err)
-	requirePolicyState(set.New("10.16.1.10"), set.New("bfd-1"))
+	f.requirePolicyState(t, set.New("10.16.1.10"), set.New("bfd-1"))
 
 	// Restore the second nexthop and its BFD row.
-	expectResources()
-	fc.mockOvnClient.EXPECT().FindBFD(externalIDs).Return([]ovnnb.BFD{
-		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: lrpName},
+	f.expectResources()
+	f.fc.mockOvnClient.EXPECT().FindBFD(f.externalIDs).Return([]ovnnb.BFD{
+		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: f.lrpName},
 	}, nil)
-	fc.mockOvnClient.EXPECT().CreateBFD(lrpName, "10.16.1.11", 100, 200, 3, externalIDs).
+	f.fc.mockOvnClient.EXPECT().CreateBFD(f.lrpName, "10.16.1.11", 100, 200, 3, f.externalIDs).
 		Return(&ovnnb.BFD{UUID: "bfd-2", DstIP: "10.16.1.11"}, nil)
-	expectPolicies(true)
-	err = fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(gw, 4, lrName, lrpName, bfdIP, map[string]set.Set[string]{
-		nodeName: set.New("10.16.1.10", "10.16.1.11"),
+	f.expectPolicyUpdates(true)
+	err = f.fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(f.gw, 4, f.lrName, f.lrpName, f.bfdIP, map[string]set.Set[string]{
+		f.nodeName: set.New("10.16.1.10", "10.16.1.11"),
 	}, nil)
 	require.NoError(t, err)
-	requirePolicyState(set.New("10.16.1.10", "10.16.1.11"), set.New("bfd-1", "bfd-2"))
+	f.requirePolicyState(t, set.New("10.16.1.10", "10.16.1.11"), set.New("bfd-1", "bfd-2"))
 
 	// Disabling BFD keeps ECMP nexthops and removes policy sessions and BFD rows.
-	gw.Spec.BFD.Enabled = false
-	expectResources()
-	fc.mockOvnClient.EXPECT().FindBFD(externalIDs).Return([]ovnnb.BFD{
-		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: lrpName},
-		{UUID: "bfd-2", DstIP: "10.16.1.11", LogicalPort: lrpName},
+	f.gw.Spec.BFD.Enabled = false
+	f.expectResources()
+	f.fc.mockOvnClient.EXPECT().FindBFD(f.externalIDs).Return([]ovnnb.BFD{
+		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: f.lrpName},
+		{UUID: "bfd-2", DstIP: "10.16.1.11", LogicalPort: f.lrpName},
 	}, nil)
-	expectPolicies(false)
-	fc.mockOvnClient.EXPECT().DeleteBFD("bfd-1").Return(nil)
-	fc.mockOvnClient.EXPECT().DeleteBFD("bfd-2").Return(nil)
-	err = fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(gw, 4, lrName, lrpName, "", map[string]set.Set[string]{
-		nodeName: set.New("10.16.1.10", "10.16.1.11"),
+	f.expectPolicyUpdates(false)
+	f.fc.mockOvnClient.EXPECT().DeleteBFD("bfd-1").Return(nil)
+	f.fc.mockOvnClient.EXPECT().DeleteBFD("bfd-2").Return(nil)
+	err = f.fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(f.gw, 4, f.lrName, f.lrpName, "", map[string]set.Set[string]{
+		f.nodeName: set.New("10.16.1.10", "10.16.1.11"),
 	}, nil)
 	require.NoError(t, err)
-	requirePolicyState(set.New("10.16.1.10", "10.16.1.11"), set.New[string]())
+	f.requirePolicyState(t, set.New("10.16.1.10", "10.16.1.11"), set.New[string]())
 }
 
 func newVegWorkloadPod(name, node, podIP, attachment string) *corev1.Pod {

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/set"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
 
 func TestVpcEgressGatewayContainerBFDDDefaultResources(t *testing.T) {
@@ -23,9 +24,48 @@ func TestVpcEgressGatewayContainerBFDDDefaultResources(t *testing.T) {
 	require.Equal(t, "1Gi", ephemeralStorage.String())
 }
 
-func TestLocalGatewayPolicyBFDSessionsSkipsEmptySession(t *testing.T) {
-	require.Empty(t, localGatewayPolicyBFDSessions(map[string]string{"10.244.10.4": ""}, "10.244.10.4"))
-	require.Equal(t, set.New("bfd-1"), localGatewayPolicyBFDSessions(map[string]string{"10.244.10.4": "bfd-1"}, "10.244.10.4"))
+func TestFlattenVpcEgressGatewayNexthops(t *testing.T) {
+	nextHops := flattenVpcEgressGatewayNexthops(map[string]set.Set[string]{
+		"node-1": set.New("10.16.1.10", "10.16.1.11"),
+		"node-2": set.New("10.16.2.10"),
+	})
+	require.Equal(t, set.New("10.16.1.10", "10.16.1.11", "10.16.2.10"), nextHops)
+}
+
+func TestUpdateVpcEgressGatewayPolicyNexthops(t *testing.T) {
+	policy := &ovnnb.LogicalRouterPolicy{
+		Nexthops:    []string{"10.16.1.10", "10.16.1.11"},
+		BFDSessions: []string{"bfd-1", "bfd-2"},
+	}
+
+	changed := updateVpcEgressGatewayPolicyNexthops(policy, set.New("10.16.1.10"), set.New("bfd-1"))
+	require.True(t, changed)
+	require.Equal(t, set.New("10.16.1.10"), set.New(policy.Nexthops...))
+	require.Equal(t, set.New("bfd-1"), set.New(policy.BFDSessions...))
+
+	changed = updateVpcEgressGatewayPolicyNexthops(policy, set.New("10.16.1.10", "10.16.1.11"), set.New[string]())
+	require.True(t, changed)
+	require.Equal(t, set.New("10.16.1.10", "10.16.1.11"), set.New(policy.Nexthops...))
+	require.Empty(t, policy.BFDSessions)
+
+	require.False(t, updateVpcEgressGatewayPolicyNexthops(
+		policy,
+		set.New("10.16.1.11", "10.16.1.10"),
+		set.New[string](),
+	))
+}
+
+func TestLocalGatewayPolicyBFDSessions(t *testing.T) {
+	bfdMap := map[string]string{
+		"10.16.1.10": "bfd-1",
+		"10.16.1.11": "bfd-2",
+		"10.16.2.10": "bfd-3",
+	}
+	require.Equal(t,
+		set.New("bfd-1", "bfd-2"),
+		localGatewayPolicyBFDSessions(bfdMap, set.New("10.16.1.10", "10.16.1.11")),
+	)
+	require.Empty(t, localGatewayPolicyBFDSessions(nil, set.New("10.16.1.10")))
 }
 
 func newVegWorkloadPod(name, node, podIP, attachment string) *corev1.Pod {
@@ -59,6 +99,10 @@ func newVegWorkloadPod(name, node, podIP, attachment string) *corev1.Pod {
 func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 	attachmentNetwork := "default/eth1"
 	readyAttachment := `[{"name":"default/eth1","ips":["172.17.1.10"]}]`
+	sameNodePod1 := newVegWorkloadPod("veg-1", "node-1", "10.16.1.10", readyAttachment)
+	sameNodePod1.Status.PodIPs = append(sameNodePod1.Status.PodIPs, corev1.PodIP{IP: "fd00:10::10"})
+	sameNodePod2 := newVegWorkloadPod("veg-2", "node-1", "10.16.1.11", `[{"name":"default/eth1","ips":["172.17.1.11"]}]`)
+	sameNodePod2.Status.PodIPs = append(sameNodePod2.Status.PodIPs, corev1.PodIP{IP: "fd00:10::11"})
 
 	tests := []struct {
 		name                string
@@ -66,7 +110,8 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 		wantInternalIPs     []string
 		wantExternalIPs     []string
 		wantNodes           []string
-		wantNodeNexthopIPv4 map[string]string
+		wantNodeNexthopIPv4 map[string]set.Set[string]
+		wantNodeNexthopIPv6 map[string]set.Set[string]
 		wantNotReadyCount   int
 	}{
 		{
@@ -78,18 +123,17 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 			wantInternalIPs:     []string{"10.16.1.10", "10.16.1.11"},
 			wantExternalIPs:     []string{"172.17.1.10", "172.17.1.11"},
 			wantNodes:           []string{"node-1", "node-2"},
-			wantNodeNexthopIPv4: map[string]string{"node-1": "10.16.1.10", "node-2": "10.16.1.11"},
+			wantNodeNexthopIPv4: map[string]set.Set[string]{"node-1": set.New("10.16.1.10"), "node-2": set.New("10.16.1.11")},
+			wantNodeNexthopIPv6: map[string]set.Set[string]{},
 		},
 		{
-			name: "workload pods on the same node",
-			pods: []*corev1.Pod{
-				newVegWorkloadPod("veg-1", "node-1", "10.16.1.10", readyAttachment),
-				newVegWorkloadPod("veg-2", "node-1", "10.16.1.11", `[{"name":"default/eth1","ips":["172.17.1.11"]}]`),
-			},
-			wantInternalIPs:     []string{"10.16.1.10", "10.16.1.11"},
+			name:                "workload pods on the same node",
+			pods:                []*corev1.Pod{sameNodePod1, sameNodePod2},
+			wantInternalIPs:     []string{"10.16.1.10,fd00:10::10", "10.16.1.11,fd00:10::11"},
 			wantExternalIPs:     []string{"172.17.1.10", "172.17.1.11"},
 			wantNodes:           []string{"node-1"},
-			wantNodeNexthopIPv4: map[string]string{"node-1": "10.16.1.11"},
+			wantNodeNexthopIPv4: map[string]set.Set[string]{"node-1": set.New("10.16.1.10", "10.16.1.11")},
+			wantNodeNexthopIPv6: map[string]set.Set[string]{"node-1": set.New("fd00:10::10", "fd00:10::11")},
 		},
 		{
 			name: "one workload pod misses attachment network",
@@ -100,7 +144,8 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 			wantInternalIPs:     []string{"10.16.1.10"},
 			wantExternalIPs:     []string{"172.17.1.10"},
 			wantNodes:           []string{"node-1"},
-			wantNodeNexthopIPv4: map[string]string{"node-1": "10.16.1.10"},
+			wantNodeNexthopIPv4: map[string]set.Set[string]{"node-1": set.New("10.16.1.10")},
+			wantNodeNexthopIPv6: map[string]set.Set[string]{},
 			wantNotReadyCount:   2,
 		},
 		{
@@ -112,7 +157,8 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 			wantInternalIPs:     []string{"10.16.1.10"},
 			wantExternalIPs:     []string{"172.17.1.10"},
 			wantNodes:           []string{"node-1"},
-			wantNodeNexthopIPv4: map[string]string{"node-1": "10.16.1.10"},
+			wantNodeNexthopIPv4: map[string]set.Set[string]{"node-1": set.New("10.16.1.10")},
+			wantNodeNexthopIPv6: map[string]set.Set[string]{},
 			wantNotReadyCount:   2,
 		},
 	}
@@ -125,12 +171,13 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 				},
 			}
 
-			nodeNexthopIPv4, _, messages := collectVpcEgressGatewayWorkloadStatus(gw, tt.pods, attachmentNetwork)
+			nodeNexthopIPv4, nodeNexthopIPv6, messages := collectVpcEgressGatewayWorkloadStatus(gw, tt.pods, attachmentNetwork)
 
 			require.Equal(t, tt.wantInternalIPs, gw.Status.InternalIPs)
 			require.Equal(t, tt.wantExternalIPs, gw.Status.ExternalIPs)
 			require.Equal(t, tt.wantNodes, gw.Status.Workload.Nodes)
 			require.Equal(t, tt.wantNodeNexthopIPv4, nodeNexthopIPv4)
+			require.Equal(t, tt.wantNodeNexthopIPv6, nodeNexthopIPv6)
 			require.Len(t, messages, tt.wantNotReadyCount)
 		})
 	}

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -61,12 +61,13 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 	readyAttachment := `[{"name":"default/eth1","ips":["172.17.1.10"]}]`
 
 	tests := []struct {
-		name              string
-		pods              []*corev1.Pod
-		wantInternalIPs   []string
-		wantExternalIPs   []string
-		wantNodes         []string
-		wantNotReadyCount int
+		name                string
+		pods                []*corev1.Pod
+		wantInternalIPs     []string
+		wantExternalIPs     []string
+		wantNodes           []string
+		wantNodeNexthopIPv4 map[string]string
+		wantNotReadyCount   int
 	}{
 		{
 			name: "all workload pods have attachment network",
@@ -74,9 +75,21 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 				newVegWorkloadPod("veg-1", "node-1", "10.16.1.10", readyAttachment),
 				newVegWorkloadPod("veg-2", "node-2", "10.16.1.11", `[{"name":"default/eth1","ips":["172.17.1.11"]}]`),
 			},
-			wantInternalIPs: []string{"10.16.1.10", "10.16.1.11"},
-			wantExternalIPs: []string{"172.17.1.10", "172.17.1.11"},
-			wantNodes:       []string{"node-1", "node-2"},
+			wantInternalIPs:     []string{"10.16.1.10", "10.16.1.11"},
+			wantExternalIPs:     []string{"172.17.1.10", "172.17.1.11"},
+			wantNodes:           []string{"node-1", "node-2"},
+			wantNodeNexthopIPv4: map[string]string{"node-1": "10.16.1.10", "node-2": "10.16.1.11"},
+		},
+		{
+			name: "workload pods on the same node",
+			pods: []*corev1.Pod{
+				newVegWorkloadPod("veg-1", "node-1", "10.16.1.10", readyAttachment),
+				newVegWorkloadPod("veg-2", "node-1", "10.16.1.11", `[{"name":"default/eth1","ips":["172.17.1.11"]}]`),
+			},
+			wantInternalIPs:     []string{"10.16.1.10", "10.16.1.11"},
+			wantExternalIPs:     []string{"172.17.1.10", "172.17.1.11"},
+			wantNodes:           []string{"node-1"},
+			wantNodeNexthopIPv4: map[string]string{"node-1": "10.16.1.11"},
 		},
 		{
 			name: "one workload pod misses attachment network",
@@ -84,10 +97,11 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 				newVegWorkloadPod("veg-1", "node-1", "10.16.1.10", readyAttachment),
 				newVegWorkloadPod("veg-2", "node-2", "10.16.1.11", `[{"name":"kube-ovn","ips":["10.16.1.11"]}]`),
 			},
-			wantInternalIPs:   []string{"10.16.1.10"},
-			wantExternalIPs:   []string{"172.17.1.10"},
-			wantNodes:         []string{"node-1"},
-			wantNotReadyCount: 2,
+			wantInternalIPs:     []string{"10.16.1.10"},
+			wantExternalIPs:     []string{"172.17.1.10"},
+			wantNodes:           []string{"node-1"},
+			wantNodeNexthopIPv4: map[string]string{"node-1": "10.16.1.10"},
+			wantNotReadyCount:   2,
 		},
 		{
 			name: "one workload pod has attachment network without ip",
@@ -95,10 +109,11 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 				newVegWorkloadPod("veg-1", "node-1", "10.16.1.10", readyAttachment),
 				newVegWorkloadPod("veg-2", "node-2", "10.16.1.11", `[{"name":"default/eth1","ips":[]}]`),
 			},
-			wantInternalIPs:   []string{"10.16.1.10"},
-			wantExternalIPs:   []string{"172.17.1.10"},
-			wantNodes:         []string{"node-1"},
-			wantNotReadyCount: 2,
+			wantInternalIPs:     []string{"10.16.1.10"},
+			wantExternalIPs:     []string{"172.17.1.10"},
+			wantNodes:           []string{"node-1"},
+			wantNodeNexthopIPv4: map[string]string{"node-1": "10.16.1.10"},
+			wantNotReadyCount:   2,
 		},
 	}
 
@@ -110,11 +125,12 @@ func TestCollectVpcEgressGatewayWorkloadStatus(t *testing.T) {
 				},
 			}
 
-			_, _, messages := collectVpcEgressGatewayWorkloadStatus(gw, tt.pods, attachmentNetwork)
+			nodeNexthopIPv4, _, messages := collectVpcEgressGatewayWorkloadStatus(gw, tt.pods, attachmentNetwork)
 
 			require.Equal(t, tt.wantInternalIPs, gw.Status.InternalIPs)
 			require.Equal(t, tt.wantExternalIPs, gw.Status.ExternalIPs)
 			require.Equal(t, tt.wantNodes, gw.Status.Workload.Nodes)
+			require.Equal(t, tt.wantNodeNexthopIPv4, nodeNexthopIPv4)
 			require.Len(t, messages, tt.wantNotReadyCount)
 		})
 	}

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -1,16 +1,20 @@
 package controller
 
 import (
+	"fmt"
 	"testing"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/set"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func TestVpcEgressGatewayContainerBFDDDefaultResources(t *testing.T) {
@@ -66,6 +70,132 @@ func TestLocalGatewayPolicyBFDSessions(t *testing.T) {
 		localGatewayPolicyBFDSessions(bfdMap, set.New("10.16.1.10", "10.16.1.11")),
 	)
 	require.Empty(t, localGatewayPolicyBFDSessions(nil, set.New("10.16.1.10")))
+}
+
+func TestReconcileVpcEgressGatewayOVNRoutesConvergesLocalBFDNexthops(t *testing.T) {
+	const (
+		nodeName = "node-1"
+		lrName   = "vpc-router"
+		lrpName  = "bfd-lrp"
+		bfdIP    = "10.0.0.1"
+	)
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Nodes: []*corev1.Node{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{util.PortNameAnnotation: "node-node-1"},
+		},
+	}}})
+	require.NoError(t, err)
+
+	gw := &kubeovnv1.VpcEgressGateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "veg"},
+		Spec: kubeovnv1.VpcEgressGatewaySpec{
+			TrafficPolicy: kubeovnv1.TrafficPolicyLocal,
+			BFD: kubeovnv1.VpcEgressGatewayBFDConfig{
+				Enabled:    true,
+				MinTX:      100,
+				MinRX:      200,
+				Multiplier: 3,
+			},
+		},
+	}
+	externalIDs := map[string]string{
+		ovs.ExternalIDVendor:           util.CniTypeName,
+		ovs.ExternalIDVpcEgressGateway: "default/veg",
+		"af":                           "4",
+	}
+	pgName := vegPortGroupName("default/veg")
+	asName := vegAddressSetName("default/veg", 4)
+	localPgName := "node.node.1"
+	localMatches := []string{
+		fmt.Sprintf("ip4.src == $%s_ip4 && ip4.src == $%s_ip4", localPgName, pgName),
+		fmt.Sprintf("ip4.src == $%s_ip4 && ip4.src == $%s", localPgName, asName),
+	}
+	clusterMatches := []string{
+		fmt.Sprintf("ip4.src == $%s_ip4", pgName),
+		fmt.Sprintf("ip4.src == $%s", asName),
+	}
+	localPolicies := []*ovnnb.LogicalRouterPolicy{
+		{UUID: "local-1", Match: localMatches[0], Nexthops: []string{"10.16.1.10", "10.16.1.11"}, BFDSessions: []string{"bfd-1", "bfd-2"}},
+		{UUID: "local-2", Match: localMatches[1], Nexthops: []string{"10.16.1.10", "10.16.1.11"}, BFDSessions: []string{"bfd-1", "bfd-2"}},
+	}
+	clusterPolicies := []*ovnnb.LogicalRouterPolicy{
+		{UUID: "cluster-1", Match: clusterMatches[0], Nexthops: []string{"10.16.1.10", "10.16.1.11"}, BFDSessions: []string{"bfd-1", "bfd-2"}},
+		{UUID: "cluster-2", Match: clusterMatches[1], Nexthops: []string{"10.16.1.10", "10.16.1.11"}, BFDSessions: []string{"bfd-1", "bfd-2"}},
+	}
+	dropPolicies := []*ovnnb.LogicalRouterPolicy{
+		{UUID: "drop-1", Match: clusterMatches[0]},
+		{UUID: "drop-2", Match: clusterMatches[1]},
+	}
+	allPolicies := append(append([]*ovnnb.LogicalRouterPolicy{}, localPolicies...), clusterPolicies...)
+
+	expectResources := func() {
+		fc.mockOvnClient.EXPECT().CreatePortGroup(pgName, externalIDs).Return(nil)
+		fc.mockOvnClient.EXPECT().PortGroupSetPorts(pgName, gomock.Any()).Return(nil)
+		fc.mockOvnClient.EXPECT().CreateAddressSet(asName, externalIDs).Return(nil)
+		fc.mockOvnClient.EXPECT().AddressSetUpdateAddress(asName).Return(nil)
+	}
+	expectPolicies := func(bfdEnabled bool) {
+		fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(lrName, util.EgressGatewayLocalPolicyPriority, externalIDs, false).Return(localPolicies, nil)
+		fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(lrName, util.EgressGatewayPolicyPriority, externalIDs, false).Return(clusterPolicies, nil)
+		fc.mockOvnClient.EXPECT().UpdateLogicalRouterPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		if bfdEnabled {
+			fc.mockOvnClient.EXPECT().ListLogicalRouterPolicies(lrName, util.EgressGatewayDropPolicyPriority, externalIDs, false).Return(dropPolicies, nil)
+		} else {
+			fc.mockOvnClient.EXPECT().DeleteLogicalRouterPolicies(lrName, util.EgressGatewayDropPolicyPriority, externalIDs).Return(nil)
+		}
+	}
+	requirePolicyState := func(nextHops, bfdSessions set.Set[string]) {
+		for _, policy := range allPolicies {
+			require.Equal(t, nextHops, set.New(policy.Nexthops...))
+			require.Equal(t, bfdSessions, set.New(policy.BFDSessions...))
+		}
+	}
+
+	// Converge from two nexthops to one and delete the stale BFD row.
+	expectResources()
+	fc.mockOvnClient.EXPECT().FindBFD(externalIDs).Return([]ovnnb.BFD{
+		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: lrpName},
+		{UUID: "bfd-2", DstIP: "10.16.1.11", LogicalPort: lrpName},
+	}, nil)
+	expectPolicies(true)
+	fc.mockOvnClient.EXPECT().DeleteBFD("bfd-2").Return(nil)
+	err = fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(gw, 4, lrName, lrpName, bfdIP, map[string]set.Set[string]{
+		nodeName: set.New("10.16.1.10"),
+	}, nil)
+	require.NoError(t, err)
+	requirePolicyState(set.New("10.16.1.10"), set.New("bfd-1"))
+
+	// Restore the second nexthop and its BFD row.
+	expectResources()
+	fc.mockOvnClient.EXPECT().FindBFD(externalIDs).Return([]ovnnb.BFD{
+		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: lrpName},
+	}, nil)
+	fc.mockOvnClient.EXPECT().CreateBFD(lrpName, "10.16.1.11", 100, 200, 3, externalIDs).
+		Return(&ovnnb.BFD{UUID: "bfd-2", DstIP: "10.16.1.11"}, nil)
+	expectPolicies(true)
+	err = fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(gw, 4, lrName, lrpName, bfdIP, map[string]set.Set[string]{
+		nodeName: set.New("10.16.1.10", "10.16.1.11"),
+	}, nil)
+	require.NoError(t, err)
+	requirePolicyState(set.New("10.16.1.10", "10.16.1.11"), set.New("bfd-1", "bfd-2"))
+
+	// Disabling BFD keeps ECMP nexthops and removes policy sessions and BFD rows.
+	gw.Spec.BFD.Enabled = false
+	expectResources()
+	fc.mockOvnClient.EXPECT().FindBFD(externalIDs).Return([]ovnnb.BFD{
+		{UUID: "bfd-1", DstIP: "10.16.1.10", LogicalPort: lrpName},
+		{UUID: "bfd-2", DstIP: "10.16.1.11", LogicalPort: lrpName},
+	}, nil)
+	expectPolicies(false)
+	fc.mockOvnClient.EXPECT().DeleteBFD("bfd-1").Return(nil)
+	fc.mockOvnClient.EXPECT().DeleteBFD("bfd-2").Return(nil)
+	err = fc.fakeController.reconcileVpcEgressGatewayOVNRoutes(gw, 4, lrName, lrpName, "", map[string]set.Set[string]{
+		nodeName: set.New("10.16.1.10", "10.16.1.11"),
+	}, nil)
+	require.NoError(t, err)
+	requirePolicyState(set.New("10.16.1.10", "10.16.1.11"), set.New[string]())
 }
 
 func newVegWorkloadPod(name, node, podIP, attachment string) *corev1.Pod {

--- a/pkg/controller/vpc_gateway_common.go
+++ b/pkg/controller/vpc_gateway_common.go
@@ -174,19 +174,22 @@ func genGatewaySleepContainer(image string) corev1.Container {
 	}
 }
 
-// genGatewayPodAntiAffinity creates pod anti-affinity rules to ensure gateway instances
-// run on different nodes. This is essential for HA deployments.
-func genGatewayPodAntiAffinity(labels map[string]string) *corev1.Affinity {
-	return &corev1.Affinity{
-		PodAntiAffinity: &corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: labels,
-				},
-				TopologyKey: corev1.LabelHostname,
-			}},
-		},
+// genGatewayPodAntiAffinity creates pod anti-affinity rules for gateway instances.
+func genGatewayPodAntiAffinity(labels map[string]string, mode string) *corev1.Affinity {
+	term := corev1.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{MatchLabels: labels},
+		TopologyKey:   corev1.LabelHostname,
 	}
+	antiAffinity := &corev1.PodAntiAffinity{}
+	if mode == kubeovnv1.PodAntiAffinityPreferred {
+		antiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.WeightedPodAffinityTerm{{
+			Weight:          100,
+			PodAffinityTerm: term,
+		}}
+	} else {
+		antiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = []corev1.PodAffinityTerm{term}
+	}
+	return &corev1.Affinity{PodAntiAffinity: antiAffinity}
 }
 
 // genGatewayDeploymentStrategy creates the standard rolling update strategy for gateway deployments.

--- a/pkg/controller/vpc_gateway_common.go
+++ b/pkg/controller/vpc_gateway_common.go
@@ -236,7 +236,7 @@ func mergeGatewayAffinity(affinities ...*corev1.Affinity) *corev1.Affinity {
 //   - ovnClient: OVN northbound client for BFD operations
 //   - bfdIP: BFD port IP (empty string disables BFD)
 //   - lrpName: Logical router port name for BFD sessions
-//   - nextHops: Map of node names to nexthop IPs
+//   - nextHops: Set of nexthop IPs
 //   - minTX, minRX, multiplier: BFD timing parameters
 //   - externalIDs: External IDs for tagging BFD sessions
 //
@@ -248,7 +248,7 @@ func reconcileGatewayBFD(
 	ovnClient ovs.NbClient,
 	bfdIP string,
 	lrpName string,
-	nextHops map[string]string,
+	nextHops set.Set[string],
 	minTX, minRX, multiplier int32,
 	externalIDs map[string]string,
 ) (bfdIDs set.Set[string], bfdMap map[string]string, staleBFDIDs set.Set[string], err error) {
@@ -260,7 +260,7 @@ func reconcileGatewayBFD(
 
 	bfdIDs = set.New[string]()
 	staleBFDIDs = set.New[string]()
-	bfdDstIPs := set.New(slices.Collect(maps.Values(nextHops))...)
+	bfdDstIPs := nextHops.Clone()
 	bfdMap = make(map[string]string, bfdDstIPs.Len())
 
 	// Process existing BFD sessions
@@ -318,7 +318,7 @@ func cleanupStaleBFD(ovnClient ovs.NbClient, staleBFDIDs set.Set[string]) error 
 //   - ovnClient: OVN northbound client for BFD operations
 //   - bfdIP: BFD port IP (empty string disables BFD)
 //   - lrpName: Logical router port name for BFD sessions
-//   - nextHops: Map of node names to nexthop IPs
+//   - nextHops: Set of nexthop IPs
 //   - minTX, minRX, multiplier: BFD timing parameters
 //   - externalIDs: External IDs for tagging BFD sessions (should include gateway-specific identifiers)
 //
@@ -329,7 +329,7 @@ func reconcileGatewayBFDWithCleanup(
 	ovnClient ovs.NbClient,
 	bfdIP string,
 	lrpName string,
-	nextHops map[string]string,
+	nextHops set.Set[string],
 	minTX, minRX, multiplier int32,
 	externalIDs map[string]string,
 ) (set.Set[string], error) {

--- a/pkg/controller/vpc_gateway_common_test.go
+++ b/pkg/controller/vpc_gateway_common_test.go
@@ -178,13 +178,38 @@ func TestGenGatewaySleepContainer(t *testing.T) {
 
 func TestGenGatewayPodAntiAffinity(t *testing.T) {
 	labels := map[string]string{"app": "vpc-nat-gw", "vpc": "test-vpc"}
-	affinity := genGatewayPodAntiAffinity(labels)
+	tests := []struct {
+		name      string
+		mode      string
+		required  bool
+		preferred bool
+	}{
+		{name: "empty defaults to required", required: true},
+		{name: "required", mode: kubeovnv1.PodAntiAffinityRequired, required: true},
+		{name: "preferred", mode: kubeovnv1.PodAntiAffinityPreferred, preferred: true},
+	}
 
-	assert.NotNil(t, affinity.PodAntiAffinity)
-	terms := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-	assert.Len(t, terms, 1)
-	assert.Equal(t, labels, terms[0].LabelSelector.MatchLabels)
-	assert.Equal(t, corev1.LabelHostname, terms[0].TopologyKey)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			affinity := genGatewayPodAntiAffinity(labels, tt.mode)
+			assert.NotNil(t, affinity.PodAntiAffinity)
+			if tt.required {
+				terms := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+				assert.Len(t, terms, 1)
+				assert.Equal(t, labels, terms[0].LabelSelector.MatchLabels)
+				assert.Equal(t, corev1.LabelHostname, terms[0].TopologyKey)
+				assert.Empty(t, affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+			}
+			if tt.preferred {
+				terms := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+				assert.Len(t, terms, 1)
+				assert.Equal(t, int32(100), terms[0].Weight)
+				assert.Equal(t, labels, terms[0].PodAffinityTerm.LabelSelector.MatchLabels)
+				assert.Equal(t, corev1.LabelHostname, terms[0].PodAffinityTerm.TopologyKey)
+				assert.Empty(t, affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+			}
+		})
+	}
 }
 
 func TestGenGatewayDeploymentStrategy(t *testing.T) {

--- a/pkg/controller/vpc_gateway_common_test.go
+++ b/pkg/controller/vpc_gateway_common_test.go
@@ -355,23 +355,24 @@ func TestReconcileGatewayBFD(t *testing.T) {
 
 	t.Run("no existing BFD sessions, create new", func(t *testing.T) {
 		m := new(mockOvnNbClient)
-		nextHops := map[string]string{"node1": "10.0.1.10"}
+		nextHops := set.New("10.0.1.10", "10.0.1.11")
 
 		m.On("FindBFD", externalIDs).Return([]ovnnb.BFD{}, nil)
 		m.On("CreateBFD", lrpName, "10.0.1.10", int(minTX), int(minRX), int(multiplier), externalIDs).Return(&ovnnb.BFD{UUID: "uuid-1", DstIP: "10.0.1.10"}, nil)
+		m.On("CreateBFD", lrpName, "10.0.1.11", int(minTX), int(minRX), int(multiplier), externalIDs).Return(&ovnnb.BFD{UUID: "uuid-2", DstIP: "10.0.1.11"}, nil)
 
 		bfdIDs, bfdMap, staleBFDIDs, err := reconcileGatewayBFD(m, bfdIP, lrpName, nextHops, minTX, minRX, multiplier, externalIDs)
 
 		assert.NoError(t, err)
-		assert.True(t, bfdIDs.Equal(set.New("uuid-1")))
-		assert.Equal(t, map[string]string{"10.0.1.10": "uuid-1"}, bfdMap)
+		assert.True(t, bfdIDs.Equal(set.New("uuid-1", "uuid-2")))
+		assert.Equal(t, map[string]string{"10.0.1.10": "uuid-1", "10.0.1.11": "uuid-2"}, bfdMap)
 		assert.Equal(t, 0, staleBFDIDs.Len())
 		m.AssertExpectations(t)
 	})
 
 	t.Run("existing valid and stale BFD sessions", func(t *testing.T) {
 		m := new(mockOvnNbClient)
-		nextHops := map[string]string{"node1": "10.0.1.10"}
+		nextHops := set.New("10.0.1.10")
 		existingBFDs := []ovnnb.BFD{
 			{UUID: "uuid-valid", DstIP: "10.0.1.10", LogicalPort: lrpName},
 			{UUID: "uuid-stale-ip", DstIP: "10.0.1.11", LogicalPort: lrpName},
@@ -391,7 +392,7 @@ func TestReconcileGatewayBFD(t *testing.T) {
 
 	t.Run("bfdIP is empty, disable BFD", func(t *testing.T) {
 		m := new(mockOvnNbClient)
-		nextHops := map[string]string{"node1": "10.0.1.10"}
+		nextHops := set.New("10.0.1.10")
 		existingBFDs := []ovnnb.BFD{
 			{UUID: "uuid-any", DstIP: "10.0.1.10", LogicalPort: lrpName},
 		}

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
+	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -1989,7 +1990,7 @@ func (c *Controller) reconcileVpcNatGatewayOVNRoutesAF(gw *kubeovnv1.VpcNatGatew
 		c.OVNNbClient,
 		bfdIP,
 		bfdLrp,
-		nextHopsAF,
+		set.New(slices.Collect(maps.Values(nextHopsAF))...),
 		gw.Spec.BFD.MinTX,
 		gw.Spec.BFD.MinRX,
 		gw.Spec.BFD.Multiplier,

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -1478,7 +1478,7 @@ func (c *Controller) genNatGwDeployment(gw *kubeovnv1.VpcNatGateway) (*v1.Deploy
 					Tolerations:  gw.Spec.Tolerations,
 					// Merge pod anti-affinity for HA with user-specified affinity
 					Affinity: mergeGatewayAffinity(
-						genGatewayPodAntiAffinity(labels),
+						genGatewayPodAntiAffinity(labels, kubeovnv1.PodAntiAffinityRequired),
 						&gw.Spec.Affinity,
 					),
 				},

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/config"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	"k8s.io/utils/set"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -43,7 +44,10 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/kind"
 )
 
-var uuidRegexp = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+var (
+	uuidRegexp    = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	ipTokenRegexp = regexp.MustCompile(`[0-9A-Fa-f:.]+`)
+)
 
 func init() {
 	klog.SetOutput(ginkgo.GinkgoWriter)
@@ -904,6 +908,43 @@ func waitPortGroupExists(pgName string) {
 	}, "Port_Group "+pgName+" to exist")
 }
 
+func waitVpcEgressGatewayPolicyNexthops(vegKey string, priority, af int, expected []string) {
+	ginkgo.GinkgoHelper()
+	want := set.New(expected...)
+
+	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		cmd := fmt.Sprintf(
+			"ovn-nbctl --format=csv --data=bare --no-heading --columns=nexthops find Logical_Router_Policy priority=%d external_ids:vpc-egress-gateway=%s external_ids:af=%d",
+			priority,
+			shellQuote(vegKey),
+			af,
+		)
+		stdout, _, err := framework.NBExec(cmd)
+		if err != nil {
+			framework.Logf("failed to query policies for %s: %v", vegKey, err)
+			return false, nil
+		}
+
+		lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")
+		if len(lines) == 0 || lines[0] == "" {
+			return false, nil
+		}
+		for _, line := range lines {
+			got := set.New[string]()
+			for _, token := range ipTokenRegexp.FindAllString(line, -1) {
+				if net.ParseIP(token) != nil {
+					got.Insert(token)
+				}
+			}
+			if !want.Equal(got) {
+				framework.Logf("gateway %s policy nexthops are %v, expected %v", vegKey, got.UnsortedList(), expected)
+				return false, nil
+			}
+		}
+		return true, nil
+	}, fmt.Sprintf("gateway %s priority %d IPv%d policy nexthops", vegKey, priority, af))
+}
+
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
@@ -1207,7 +1248,7 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 			framework.ExpectNotContainElement(podNodes, pod.Spec.NodeName)
 		}
 		podNodes = append(podNodes, pod.Spec.NodeName)
-		intIPs[pod.Spec.NodeName] = util.PodIPs(pod)
+		intIPs[pod.Spec.NodeName] = append(intIPs[pod.Spec.NodeName], util.PodIPs(pod)...)
 	}
 	uniquePodNodes := slices.Clone(podNodes)
 	slices.Sort(uniquePodNodes)
@@ -1215,6 +1256,20 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	framework.ExpectEqual(veg.Status.Workload.Nodes, uniquePodNodes)
 	if len(expectedNodes) != 0 {
 		framework.ExpectConsistOf(uniquePodNodes, expectedNodes)
+	}
+	expectedNexthops := make([]string, 0, len(veg.Status.InternalIPs)*2)
+	for _, ips := range veg.Status.InternalIPs {
+		expectedNexthops = append(expectedNexthops, strings.Split(ips, ",")...)
+	}
+	expectedIPv4, expectedIPv6 := util.SplitIpsByProtocol(expectedNexthops)
+	if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
+		vegKey := namespaceName + "/" + vegName
+		if len(expectedIPv4) != 0 {
+			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayPolicyPriority, 4, expectedIPv4)
+		}
+		if len(expectedIPv6) != 0 {
+			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayPolicyPriority, 6, expectedIPv6)
+		}
 	}
 	if bfd && !f.VersionPriorTo(1, 15) {
 		verifyBFDDZeroSessionsTriggersRestart(f, namespaceName, workloadPods.Items[0])
@@ -1247,11 +1302,30 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	for _, ips := range veg.Status.ExternalIPs {
 		extIPs = append(extIPs, strings.Split(ips, ",")...)
 	}
+	checkAccess := func(nodeName string) {
+		checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, snatSubnetName, nodeName, snatLabelValue, true)
+		checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, forwardSubnetName, nodeName, snatLabelValue, false)
+	}
 
 	var nodeName string
 	if veg.Spec.TrafficPolicy == apiv1.TrafficPolicyLocal {
 		nodeName = veg.Status.Workload.Nodes[0]
 	}
-	checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, snatSubnetName, nodeName, snatLabelValue, true)
-	checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, forwardSubnetName, nodeName, snatLabelValue, false)
+	checkAccess(nodeName)
+
+	if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
+		original := veg.DeepCopy()
+		modified := veg.DeepCopy()
+		modified.Spec.TrafficPolicy = apiv1.TrafficPolicyLocal
+		veg = vegClient.PatchSync(original, modified)
+
+		vegKey := namespaceName + "/" + vegName
+		if len(expectedIPv4) != 0 {
+			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayLocalPolicyPriority, 4, expectedIPv4)
+		}
+		if len(expectedIPv6) != 0 {
+			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayLocalPolicyPriority, 6, expectedIPv6)
+		}
+		checkAccess(veg.Status.Workload.Nodes[0])
+	}
 }

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -926,7 +926,8 @@ func waitVpcEgressGatewayPolicyNexthops(vegKey string, priority, af int, expecte
 		}
 
 		lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")
-		if len(lines) == 0 || lines[0] == "" {
+		if len(lines) != 2 || lines[0] == "" {
+			framework.Logf("gateway %s has %d matching policies, expected 2", vegKey, len(lines))
 			return false, nil
 		}
 		for _, line := range lines {

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -174,7 +174,7 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		})
 		_ = subnetClient.CreateSync(externalSubnet)
 
-		vegTest(f, false, provider, nadName, "", internalSubnetName, externalSubnetName, int32(len(controlPlaneNodeNames)), controlPlaneNodeNames)
+		vegTest(f, false, provider, nadName, "", internalSubnetName, externalSubnetName, int32(len(controlPlaneNodeNames)), "", controlPlaneNodeNames)
 	})
 
 	framework.ConformanceIt("should be able to create vpc-egress-gateway with underlay subnet", func() {
@@ -276,7 +276,7 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		vpcName := util.DefaultVpc
 		vpc := vpcClient.Get(vpcName)
 		ginkgo.By("Validating local traffic policy without BFD")
-		vegTest(f, false, provider, nadName, vpcName, vpc.Status.DefaultLogicalSwitch, externalSubnetName, replicas, nil)
+		vegTest(f, false, provider, nadName, vpcName, vpc.Status.DefaultLogicalSwitch, externalSubnetName, replicas, "", nil)
 
 		cidr := framework.RandomCIDR(f.ClusterIPFamily)
 		bfdIP := framework.RandomIPs(cidr, ";", 1)
@@ -315,7 +315,7 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 
 		// TODO: check ovn LRP
 
-		vegTest(f, true, provider, nadName, vpcName, vpc.Status.DefaultLogicalSwitch, externalSubnetName, replicas, nil)
+		vegTest(f, true, provider, nadName, vpcName, vpc.Status.DefaultLogicalSwitch, externalSubnetName, replicas, "", nil)
 	})
 
 	framework.ConformanceIt("should be able to create vpc-egress-gateway with macvlan", func() {
@@ -366,7 +366,58 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		})
 		_ = subnetClient.CreateSync(externalSubnet)
 
-		vegTest(f, false, provider, nadName, vpcName, internalSubnetName, externalSubnetName, replicas, nil)
+		vegTest(f, false, provider, nadName, vpcName, internalSubnetName, externalSubnetName, replicas, "", nil)
+	})
+
+	framework.ConformanceIt("should allow preferred pod anti-affinity", func() {
+		f.SkipVersionPriorTo(1, 17, "VpcEgressGateway preferred pod anti-affinity requires v1.17+")
+
+		provider := fmt.Sprintf("%s.%s", nadName, namespaceName)
+
+		ginkgo.By("Creating network attachment definition " + nadName)
+		nad := framework.MakeMacvlanNetworkAttachmentDefinition(nadName, namespaceName, "eth0", "bridge", provider, nil)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting network attachment definition " + nadName)
+			nadClient.Delete(nadName)
+		})
+		nad = nadClient.Create(nad)
+		framework.Logf("created network attachment definition config:\n%s", nad.Spec.Config)
+
+		vpcName := "vpc-" + framework.RandomSuffix()
+		ginkgo.By("Creating vpc " + vpcName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting vpc " + vpcName)
+			vpcClient.DeleteSync(vpcName)
+		})
+		vpc := &apiv1.Vpc{ObjectMeta: metav1.ObjectMeta{Name: vpcName}}
+		_ = vpcClient.CreateSync(vpc)
+
+		internalSubnetName := "int-" + framework.RandomSuffix()
+		ginkgo.By("Creating internal subnet " + internalSubnetName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting internal subnet " + internalSubnetName)
+			subnetClient.DeleteSync(internalSubnetName)
+		})
+		cidr := framework.RandomCIDR(f.ClusterIPFamily)
+		internalSubnet := framework.MakeSubnet(internalSubnetName, "", cidr, "", vpcName, "", nil, nil, nil)
+		_ = subnetClient.CreateSync(internalSubnet)
+
+		ginkgo.By("Getting docker network " + kindNetwork)
+		network, err := docker.NetworkInspect(kindNetwork)
+		framework.ExpectNoError(err, "getting docker network "+kindNetwork)
+
+		externalSubnet := generateSubnetFromDockerNetwork(externalSubnetName, network, f.HasIPv4(), f.HasIPv6())
+		externalSubnet.Spec.Provider = provider
+
+		ginkgo.By("Creating macvlan subnet " + externalSubnetName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting external subnet " + externalSubnetName)
+			subnetClient.DeleteSync(externalSubnetName)
+		})
+		_ = subnetClient.CreateSync(externalSubnet)
+
+		vegTest(f, false, provider, nadName, vpcName, internalSubnetName, externalSubnetName,
+			2, apiv1.PodAntiAffinityPreferred, []string{schedulableNodes[0].Name})
 	})
 
 	framework.ConformanceIt("should be ready with default dual-stack internal subnet and IPv4-only external subnet", func() {
@@ -1022,7 +1073,7 @@ func containerRestartCount(pod corev1.Pod, containerName string) int32 {
 	return 0
 }
 
-func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, internalSubnetName, externalSubnetName string, replicas int32, expectedNodes []string) {
+func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, internalSubnetName, externalSubnetName string, replicas int32, antiAffinityMode string, expectedNodes []string) {
 	ginkgo.GinkgoHelper()
 
 	namespaceName := f.Namespace.Name
@@ -1055,21 +1106,28 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 		veg.Spec.Prefix = fmt.Sprintf("e2e-%s-", framework.RandomSuffix())
 	}
 	veg.Spec.BFD.Enabled = bfd
+	veg.Spec.PodAntiAffinity = antiAffinityMode
 	veg.Spec.Policies = []apiv1.VpcEgressGatewayPolicy{{
 		SNAT:     false,
 		IPBlocks: strings.Split(forwardSubnet.Spec.CIDRBlock, ","),
 	}}
 	if len(expectedNodes) != 0 {
-		// test vpc egress gateway with node selector and tolerations
-		veg.Spec.NodeSelector = []apiv1.VpcEgressGatewayNodeSelector{{
-			MatchLabels: map[string]string{
-				constants.LabelNodeRoleControlPlane: "",
-			},
-		}}
-		veg.Spec.Tolerations = []corev1.Toleration{{
-			Key:    constants.LabelNodeRoleControlPlane,
-			Effect: corev1.TaintEffectNoSchedule,
-		}}
+		if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
+			veg.Spec.NodeSelector = []apiv1.VpcEgressGatewayNodeSelector{{
+				MatchLabels: map[string]string{corev1.LabelHostname: expectedNodes[0]},
+			}}
+		} else {
+			// test vpc egress gateway with node selector and tolerations
+			veg.Spec.NodeSelector = []apiv1.VpcEgressGatewayNodeSelector{{
+				MatchLabels: map[string]string{
+					constants.LabelNodeRoleControlPlane: "",
+				},
+			}}
+			veg.Spec.Tolerations = []corev1.Toleration{{
+				Key:    constants.LabelNodeRoleControlPlane,
+				Effect: corev1.TaintEffectNoSchedule,
+			}}
+		}
 	}
 	if vpcName == util.DefaultVpc {
 		veg.Spec.VPC = "" // test whether the veg works without specifying VPC
@@ -1116,13 +1174,17 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	gvk := appsv1.SchemeGroupVersion.WithKind(reflect.TypeFor[appsv1.Deployment]().Name())
 	framework.ExpectEqual(veg.Status.Workload.APIVersion, gvk.GroupVersion().String())
 	framework.ExpectEqual(veg.Status.Workload.Kind, gvk.Kind)
-	framework.ExpectHaveLen(veg.Status.Workload.Nodes, int(replicas))
+	expectedNodeCount := int(replicas)
+	if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
+		expectedNodeCount = 1
+	}
+	framework.ExpectHaveLen(veg.Status.Workload.Nodes, expectedNodeCount)
 	workloadPods, err := deployClient.GetPods(deploy)
 	framework.ExpectNoError(err)
 	framework.ExpectHaveLen(workloadPods.Items, int(replicas))
 	podNodes := make([]string, 0, len(workloadPods.Items))
 	intIPs := make(map[string][]string, len(workloadPods.Items))
-	podAntiAffinity := []corev1.PodAffinityTerm{{
+	requiredPodAntiAffinity := []corev1.PodAffinityTerm{{
 		LabelSelector: &metav1.LabelSelector{
 			MatchLabels: maps.Clone(deploy.Spec.Selector.MatchLabels),
 		},
@@ -1132,15 +1194,27 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 		framework.ExpectEmpty(pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
 		framework.ExpectNil(pod.Spec.Affinity.PodAffinity)
 		framework.ExpectNotNil(pod.Spec.Affinity.PodAntiAffinity)
-		framework.ExpectNil(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
-		framework.ExpectEqual(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, podAntiAffinity)
-		framework.ExpectNotContainElement(podNodes, pod.Spec.NodeName)
+		if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
+			framework.ExpectEmpty(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+			preferred := pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			framework.ExpectHaveLen(preferred, 1)
+			framework.ExpectEqual(preferred[0].Weight, int32(100))
+			framework.ExpectEqual(preferred[0].PodAffinityTerm, requiredPodAntiAffinity[0])
+			framework.ExpectEqual(pod.Spec.NodeName, expectedNodes[0])
+		} else {
+			framework.ExpectNil(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+			framework.ExpectEqual(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, requiredPodAntiAffinity)
+			framework.ExpectNotContainElement(podNodes, pod.Spec.NodeName)
+		}
 		podNodes = append(podNodes, pod.Spec.NodeName)
 		intIPs[pod.Spec.NodeName] = util.PodIPs(pod)
 	}
-	framework.ExpectConsistOf(veg.Status.Workload.Nodes, podNodes)
+	uniquePodNodes := slices.Clone(podNodes)
+	slices.Sort(uniquePodNodes)
+	uniquePodNodes = slices.Compact(uniquePodNodes)
+	framework.ExpectEqual(veg.Status.Workload.Nodes, uniquePodNodes)
 	if len(expectedNodes) != 0 {
-		framework.ExpectConsistOf(podNodes, expectedNodes)
+		framework.ExpectConsistOf(uniquePodNodes, expectedNodes)
 	}
 	if bfd && !f.VersionPriorTo(1, 15) {
 		verifyBFDDZeroSessionsTriggersRestart(f, namespaceName, workloadPods.Items[0])

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -142,6 +142,52 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		replicas = min(int32(len(schedulableNodes)), 3)
 	})
 
+	createMacvlanVpc := func() (string, *apiv1.Vpc, string) {
+		ginkgo.GinkgoHelper()
+
+		provider := fmt.Sprintf("%s.%s", nadName, namespaceName)
+		ginkgo.By("Creating network attachment definition " + nadName)
+		nad := framework.MakeMacvlanNetworkAttachmentDefinition(nadName, namespaceName, "eth0", "bridge", provider, nil)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting network attachment definition " + nadName)
+			nadClient.Delete(nadName)
+		})
+		nad = nadClient.Create(nad)
+		framework.Logf("created network attachment definition config:\n%s", nad.Spec.Config)
+
+		vpcName := "vpc-" + framework.RandomSuffix()
+		ginkgo.By("Creating vpc " + vpcName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting vpc " + vpcName)
+			vpcClient.DeleteSync(vpcName)
+		})
+		vpc := vpcClient.CreateSync(&apiv1.Vpc{ObjectMeta: metav1.ObjectMeta{Name: vpcName}})
+
+		internalSubnetName := "int-" + framework.RandomSuffix()
+		ginkgo.By("Creating internal subnet " + internalSubnetName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting internal subnet " + internalSubnetName)
+			subnetClient.DeleteSync(internalSubnetName)
+		})
+		cidr := framework.RandomCIDR(f.ClusterIPFamily)
+		internalSubnet := framework.MakeSubnet(internalSubnetName, "", cidr, "", vpcName, "", nil, nil, nil)
+		_ = subnetClient.CreateSync(internalSubnet)
+
+		ginkgo.By("Getting docker network " + kindNetwork)
+		network, err := docker.NetworkInspect(kindNetwork)
+		framework.ExpectNoError(err, "getting docker network "+kindNetwork)
+		externalSubnet := generateSubnetFromDockerNetwork(externalSubnetName, network, f.HasIPv4(), f.HasIPv6())
+		externalSubnet.Spec.Provider = provider
+		ginkgo.By("Creating macvlan subnet " + externalSubnetName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting external subnet " + externalSubnetName)
+			subnetClient.DeleteSync(externalSubnetName)
+		})
+		_ = subnetClient.CreateSync(externalSubnet)
+
+		return provider, vpc, internalSubnetName
+	}
+
 	framework.ConformanceIt("should be able to specify tolerations", func() {
 		provider := fmt.Sprintf("%s.%s", nadName, namespaceName)
 
@@ -323,104 +369,20 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 	})
 
 	framework.ConformanceIt("should be able to create vpc-egress-gateway with macvlan", func() {
-		provider := fmt.Sprintf("%s.%s", nadName, namespaceName)
-
-		ginkgo.By("Creating network attachment definition " + nadName)
-		nad := framework.MakeMacvlanNetworkAttachmentDefinition(nadName, namespaceName, "eth0", "bridge", provider, nil)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting network attachment definition " + nadName)
-			nadClient.Delete(nadName)
-		})
-		nad = nadClient.Create(nad)
-		framework.Logf("created network attachment definition config:\n%s", nad.Spec.Config)
-
-		vpcName := "vpc-" + framework.RandomSuffix()
-		ginkgo.By("Creating vpc " + vpcName)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting vpc " + vpcName)
-			vpcClient.DeleteSync(vpcName)
-		})
-		vpc := &apiv1.Vpc{ObjectMeta: metav1.ObjectMeta{Name: vpcName}}
-		vpc = vpcClient.CreateSync(vpc)
+		provider, vpc, internalSubnetName := createMacvlanVpc()
 		framework.ExpectEmpty(vpc.Status.BFDPort.Name)
 		framework.ExpectEmpty(vpc.Status.BFDPort.IP)
 		framework.ExpectEmpty(vpc.Status.BFDPort.Nodes)
 
-		internalSubnetName := "int-" + framework.RandomSuffix()
-		ginkgo.By("Creating internal subnet " + internalSubnetName)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting internal subnet " + internalSubnetName)
-			subnetClient.DeleteSync(internalSubnetName)
-		})
-		cidr := framework.RandomCIDR(f.ClusterIPFamily)
-		internalSubnet := framework.MakeSubnet(internalSubnetName, "", cidr, "", vpcName, "", nil, nil, nil)
-		_ = subnetClient.CreateSync(internalSubnet)
-
-		ginkgo.By("Getting docker network " + kindNetwork)
-		network, err := docker.NetworkInspect(kindNetwork)
-		framework.ExpectNoError(err, "getting docker network "+kindNetwork)
-
-		externalSubnet := generateSubnetFromDockerNetwork(externalSubnetName, network, f.HasIPv4(), f.HasIPv6())
-		externalSubnet.Spec.Provider = provider
-
-		ginkgo.By("Creating macvlan subnet " + externalSubnetName)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting external subnet " + externalSubnetName)
-			subnetClient.DeleteSync(externalSubnetName)
-		})
-		_ = subnetClient.CreateSync(externalSubnet)
-
-		vegTest(f, false, provider, nadName, vpcName, internalSubnetName, externalSubnetName, replicas, "", nil)
+		vegTest(f, false, provider, nadName, vpc.Name, internalSubnetName, externalSubnetName, replicas, "", nil)
 	})
 
 	framework.ConformanceIt("should allow preferred pod anti-affinity", func() {
 		f.SkipVersionPriorTo(1, 17, "VpcEgressGateway preferred pod anti-affinity requires v1.17+")
 
-		provider := fmt.Sprintf("%s.%s", nadName, namespaceName)
+		provider, vpc, internalSubnetName := createMacvlanVpc()
 
-		ginkgo.By("Creating network attachment definition " + nadName)
-		nad := framework.MakeMacvlanNetworkAttachmentDefinition(nadName, namespaceName, "eth0", "bridge", provider, nil)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting network attachment definition " + nadName)
-			nadClient.Delete(nadName)
-		})
-		nad = nadClient.Create(nad)
-		framework.Logf("created network attachment definition config:\n%s", nad.Spec.Config)
-
-		vpcName := "vpc-" + framework.RandomSuffix()
-		ginkgo.By("Creating vpc " + vpcName)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting vpc " + vpcName)
-			vpcClient.DeleteSync(vpcName)
-		})
-		vpc := &apiv1.Vpc{ObjectMeta: metav1.ObjectMeta{Name: vpcName}}
-		_ = vpcClient.CreateSync(vpc)
-
-		internalSubnetName := "int-" + framework.RandomSuffix()
-		ginkgo.By("Creating internal subnet " + internalSubnetName)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting internal subnet " + internalSubnetName)
-			subnetClient.DeleteSync(internalSubnetName)
-		})
-		cidr := framework.RandomCIDR(f.ClusterIPFamily)
-		internalSubnet := framework.MakeSubnet(internalSubnetName, "", cidr, "", vpcName, "", nil, nil, nil)
-		_ = subnetClient.CreateSync(internalSubnet)
-
-		ginkgo.By("Getting docker network " + kindNetwork)
-		network, err := docker.NetworkInspect(kindNetwork)
-		framework.ExpectNoError(err, "getting docker network "+kindNetwork)
-
-		externalSubnet := generateSubnetFromDockerNetwork(externalSubnetName, network, f.HasIPv4(), f.HasIPv6())
-		externalSubnet.Spec.Provider = provider
-
-		ginkgo.By("Creating macvlan subnet " + externalSubnetName)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Deleting external subnet " + externalSubnetName)
-			subnetClient.DeleteSync(externalSubnetName)
-		})
-		_ = subnetClient.CreateSync(externalSubnet)
-
-		vegTest(f, false, provider, nadName, vpcName, internalSubnetName, externalSubnetName,
+		vegTest(f, false, provider, nadName, vpc.Name, internalSubnetName, externalSubnetName,
 			2, apiv1.PodAntiAffinityPreferred, []string{schedulableNodes[0].Name})
 	})
 
@@ -1115,7 +1077,7 @@ func containerRestartCount(pod corev1.Pod, containerName string) int32 {
 	return 0
 }
 
-func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, internalSubnetName, externalSubnetName string, replicas int32, antiAffinityMode string, expectedNodes []string) {
+func createVegTestGateway(f *framework.Framework, bfd bool, provider, vpcName, internalSubnetName, externalSubnetName string, replicas int32, antiAffinityMode string, expectedNodes []string) (*apiv1.VpcEgressGateway, *apiv1.Subnet, string, string) {
 	ginkgo.GinkgoHelper()
 
 	namespaceName := f.Namespace.Name
@@ -1123,8 +1085,6 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	forwardSubnetName := "forward-" + framework.RandomSuffix()
 	subnetClient := f.SubnetClient()
 	vegClient := f.VpcEgressGatewayClient()
-	deployClient := f.DeploymentClient()
-	podClient := f.PodClient()
 
 	var forwardSubnet *apiv1.Subnet
 	for _, subnetName := range []string{snatSubnetName, forwardSubnetName} {
@@ -1207,23 +1167,29 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	framework.ExpectEqual(veg.Status.Phase, apiv1.PhaseCompleted)
 	framework.ExpectHaveLen(veg.Status.InternalIPs, int(replicas))
 	framework.ExpectHaveLen(veg.Status.ExternalIPs, int(replicas))
+	return veg, forwardSubnet, snatSubnetName, snatLabelValue
+}
+
+func validateVegTestWorkload(f *framework.Framework, veg *apiv1.VpcEgressGateway, expectedNodes []string) ([]corev1.Pod, map[string][]string) {
+	ginkgo.GinkgoHelper()
 
 	ginkgo.By("Validating vpc egress gateway workload")
 	framework.ExpectEqual(veg.Status.Workload.Name, veg.Spec.Prefix+veg.Name)
+	deployClient := f.DeploymentClient()
 	deploy := deployClient.Get(veg.Status.Workload.Name)
-	framework.ExpectEqual(deploy.Status.Replicas, replicas)
-	framework.ExpectEqual(deploy.Status.ReadyReplicas, replicas)
+	framework.ExpectEqual(deploy.Status.Replicas, veg.Spec.Replicas)
+	framework.ExpectEqual(deploy.Status.ReadyReplicas, veg.Spec.Replicas)
 	gvk := appsv1.SchemeGroupVersion.WithKind(reflect.TypeFor[appsv1.Deployment]().Name())
 	framework.ExpectEqual(veg.Status.Workload.APIVersion, gvk.GroupVersion().String())
 	framework.ExpectEqual(veg.Status.Workload.Kind, gvk.Kind)
-	expectedNodeCount := int(replicas)
-	if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
+	expectedNodeCount := int(veg.Spec.Replicas)
+	if veg.Spec.PodAntiAffinity == apiv1.PodAntiAffinityPreferred {
 		expectedNodeCount = 1
 	}
 	framework.ExpectHaveLen(veg.Status.Workload.Nodes, expectedNodeCount)
 	workloadPods, err := deployClient.GetPods(deploy)
 	framework.ExpectNoError(err)
-	framework.ExpectHaveLen(workloadPods.Items, int(replicas))
+	framework.ExpectHaveLen(workloadPods.Items, int(veg.Spec.Replicas))
 	podNodes := make([]string, 0, len(workloadPods.Items))
 	intIPs := make(map[string][]string, len(workloadPods.Items))
 	requiredPodAntiAffinity := []corev1.PodAffinityTerm{{
@@ -1236,7 +1202,7 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 		framework.ExpectEmpty(pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
 		framework.ExpectNil(pod.Spec.Affinity.PodAffinity)
 		framework.ExpectNotNil(pod.Spec.Affinity.PodAntiAffinity)
-		if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
+		if veg.Spec.PodAntiAffinity == apiv1.PodAntiAffinityPreferred {
 			framework.ExpectEmpty(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
 			preferred := pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 			framework.ExpectHaveLen(preferred, 1)
@@ -1263,8 +1229,8 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 		expectedNexthops = append(expectedNexthops, strings.Split(ips, ",")...)
 	}
 	expectedIPv4, expectedIPv6 := util.SplitIpsByProtocol(expectedNexthops)
-	if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
-		vegKey := namespaceName + "/" + vegName
+	if veg.Spec.PodAntiAffinity == apiv1.PodAntiAffinityPreferred {
+		vegKey := veg.Namespace + "/" + veg.Name
 		if len(expectedIPv4) != 0 {
 			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayPolicyPriority, 4, expectedIPv4)
 		}
@@ -1272,10 +1238,17 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayPolicyPriority, 6, expectedIPv6)
 		}
 	}
-	if bfd && !f.VersionPriorTo(1, 15) {
-		verifyBFDDZeroSessionsTriggersRestart(f, namespaceName, workloadPods.Items[0])
+	if veg.Spec.BFD.Enabled && !f.VersionPriorTo(1, 15) {
+		verifyBFDDZeroSessionsTriggersRestart(f, veg.Namespace, workloadPods.Items[0])
 	}
+	return workloadPods.Items, intIPs
+}
 
+func validateVegTestAccess(f *framework.Framework, veg *apiv1.VpcEgressGateway, provider, nadName string, forwardSubnet *apiv1.Subnet, snatSubnetName, snatLabelValue string, workloadPods []corev1.Pod, intIPs map[string][]string) {
+	ginkgo.GinkgoHelper()
+
+	namespaceName := f.Namespace.Name
+	podClient := f.PodClient()
 	svrPodName := "svr-" + framework.RandomSuffix()
 	ginkgo.By("Creating netexec server pod " + svrPodName)
 	routes := util.NewPodRoutes()
@@ -1298,14 +1271,14 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	svrIPs, err := util.PodAttachmentIPs(svrPod, attachmentNetworkName)
 	framework.ExpectNoError(err)
 
-	image := workloadPods.Items[0].Spec.Containers[0].Image
+	image := workloadPods[0].Spec.Containers[0].Image
 	extIPs := make([]string, 0, len(veg.Status.ExternalIPs)*2)
 	for _, ips := range veg.Status.ExternalIPs {
 		extIPs = append(extIPs, strings.Split(ips, ",")...)
 	}
 	checkAccess := func(nodeName string) {
 		checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, snatSubnetName, nodeName, snatLabelValue, true)
-		checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, forwardSubnetName, nodeName, snatLabelValue, false)
+		checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, forwardSubnet.Name, nodeName, snatLabelValue, false)
 	}
 
 	var nodeName string
@@ -1314,13 +1287,19 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	}
 	checkAccess(nodeName)
 
-	if antiAffinityMode == apiv1.PodAntiAffinityPreferred {
+	if veg.Spec.PodAntiAffinity == apiv1.PodAntiAffinityPreferred {
+		expectedNexthops := make([]string, 0, len(veg.Status.InternalIPs)*2)
+		for _, ips := range veg.Status.InternalIPs {
+			expectedNexthops = append(expectedNexthops, strings.Split(ips, ",")...)
+		}
+		expectedIPv4, expectedIPv6 := util.SplitIpsByProtocol(expectedNexthops)
 		original := veg.DeepCopy()
 		modified := veg.DeepCopy()
 		modified.Spec.TrafficPolicy = apiv1.TrafficPolicyLocal
+		vegClient := f.VpcEgressGatewayClient()
 		veg = vegClient.PatchSync(original, modified)
 
-		vegKey := namespaceName + "/" + vegName
+		vegKey := namespaceName + "/" + veg.Name
 		if len(expectedIPv4) != 0 {
 			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayLocalPolicyPriority, 4, expectedIPv4)
 		}
@@ -1329,4 +1308,14 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 		}
 		checkAccess(veg.Status.Workload.Nodes[0])
 	}
+}
+
+func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, internalSubnetName, externalSubnetName string, replicas int32, antiAffinityMode string, expectedNodes []string) {
+	ginkgo.GinkgoHelper()
+
+	veg, forwardSubnet, snatSubnetName, snatLabelValue := createVegTestGateway(
+		f, bfd, provider, vpcName, internalSubnetName, externalSubnetName, replicas, antiAffinityMode, expectedNodes,
+	)
+	workloadPods, intIPs := validateVegTestWorkload(f, veg, expectedNodes)
+	validateVegTestAccess(f, veg, provider, nadName, forwardSubnet, snatSubnetName, snatLabelValue, workloadPods, intIPs)
 }


### PR DESCRIPTION
## Summary

- keep `VpcEgressGateway.status.workload.nodes` unique and sorted
- add `spec.podAntiAffinity` with `Required` as the default and `Preferred` for co-located replicas
- use every ready gateway pod as an OVN ECMP nexthop, including per-node ECMP for `Local` traffic policy
- maintain one BFD session per nexthop and remove stale sessions when replicas change

## Tests

- `go test ./pkg/controller -count=1`
- `go test ./test/e2e/vpc-egress-gateway -run '^$' -count=1`
- `make gen-crd`
- `make lint`

Closes #7042
