### PR TITLE
fix: restrict hook log file permissions

### DIFF
--- a/charts/kube-ovn-v2/templates/hooks/post-delete-hook.yaml
+++ b/charts/kube-ovn-v2/templates/hooks/post-delete-hook.yaml
@@ -119,7 +119,10 @@ spec:
           command:
             - sh
             - -c
-            - /kube-ovn/remove-finalizer.sh 2>&1 | tee -a /var/log/kube-ovn/remove-finalizer.log
+            - |
+              touch /var/log/kube-ovn/remove-finalizer.log
+              chmod 640 /var/log/kube-ovn/remove-finalizer.log
+              /kube-ovn/remove-finalizer.sh 2>&1 | tee -a /var/log/kube-ovn/remove-finalizer.log
           resources:
             requests:
               cpu: 100m

--- a/charts/kube-ovn-v2/templates/hooks/pre-upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn-v2/templates/hooks/pre-upgrade-ovs-ovn.yaml
@@ -118,7 +118,10 @@ spec:
             - -eo
             - pipefail
             - -c
-            - bash /kube-ovn/pre-upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/pre-upgrade-ovs.log
+            - |
+              touch /var/log/kube-ovn/pre-upgrade-ovs.log
+              chmod 640 /var/log/kube-ovn/pre-upgrade-ovs.log
+              bash /kube-ovn/pre-upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/pre-upgrade-ovs.log
           volumeMounts:
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log

--- a/charts/kube-ovn-v2/templates/hooks/upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn-v2/templates/hooks/upgrade-ovs-ovn.yaml
@@ -160,7 +160,10 @@ spec:
             - -eo
             - pipefail
             - -c
-            - /kube-ovn/upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/upgrade-ovs.log
+            - |
+              touch /var/log/kube-ovn/upgrade-ovs.log
+              chmod 640 /var/log/kube-ovn/upgrade-ovs.log
+              /kube-ovn/upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/upgrade-ovs.log
           volumeMounts:
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log

--- a/charts/kube-ovn/templates/post-delete-hook.yaml
+++ b/charts/kube-ovn/templates/post-delete-hook.yaml
@@ -119,7 +119,10 @@ spec:
           command:
             - sh
             - -c
-            - /kube-ovn/remove-finalizer.sh 2>&1 | tee -a /var/log/kube-ovn/remove-finalizer.log
+            - |
+              touch /var/log/kube-ovn/remove-finalizer.log
+              chmod 640 /var/log/kube-ovn/remove-finalizer.log
+              /kube-ovn/remove-finalizer.sh 2>&1 | tee -a /var/log/kube-ovn/remove-finalizer.log
           resources:
             requests:
               cpu: 100m

--- a/charts/kube-ovn/templates/pre-upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn/templates/pre-upgrade-ovs-ovn.yaml
@@ -118,7 +118,10 @@ spec:
             - -eo
             - pipefail
             - -c
-            - bash /kube-ovn/pre-upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/pre-upgrade-ovs.log
+            - |
+              touch /var/log/kube-ovn/pre-upgrade-ovs.log
+              chmod 640 /var/log/kube-ovn/pre-upgrade-ovs.log
+              bash /kube-ovn/pre-upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/pre-upgrade-ovs.log
           volumeMounts:
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log

--- a/charts/kube-ovn/templates/upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn/templates/upgrade-ovs-ovn.yaml
@@ -160,7 +160,10 @@ spec:
             - -eo
             - pipefail
             - -c
-            - /kube-ovn/upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/upgrade-ovs.log
+            - |
+              touch /var/log/kube-ovn/upgrade-ovs.log
+              chmod 640 /var/log/kube-ovn/upgrade-ovs.log
+              /kube-ovn/upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/upgrade-ovs.log
           volumeMounts:
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

This PR updates the Helm hook jobs to create their kube-ovn hook log files before appending and set the file mode to `0640`.

## Which issue(s) this PR fixes

None

## Test Plan

- `make lint`
- `helm lint charts/kube-ovn`
- `helm lint charts/kube-ovn-v2`
- `helm template kube-ovn charts/kube-ovn`
- `helm template kube-ovn-v2 charts/kube-ovn-v2`
