### PR TITLE
fix(controller): skip in-pod cleanup when VPC NAT gateway CRD is deleted (#6784) [backport release-1.16]

### DIFF
--- a/pkg/controller/vpc_nat_gw_cleanup_test.go
+++ b/pkg/controller/vpc_nat_gw_cleanup_test.go
@@ -1,0 +1,125 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	fakeversioned "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	kubeovninformerfactory "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
+)
+
+// newNatGwCleanupController builds a minimal Controller exposing only the
+// dependencies needed by the in-pod cleanup helpers: vpcNatGatewayLister to act
+// as the deletion sentinel and an (always empty) podsLister so that getNatGwPod
+// reports the gateway pod as not found. When gwExists is true a VpcNatGateway
+// CRD named dp is registered; otherwise the lister returns NotFound for it.
+func newNatGwCleanupController(t *testing.T, dp string, gwExists bool) *Controller {
+	t.Helper()
+
+	kubeOvnClient := fakeversioned.NewSimpleClientset()
+	kubeOvnFactory := kubeovninformerfactory.NewSharedInformerFactory(kubeOvnClient, 0)
+	gwInformer := kubeOvnFactory.Kubeovn().V1().VpcNatGateways()
+	if gwExists {
+		gw := &kubeovnv1.VpcNatGateway{ObjectMeta: metav1.ObjectMeta{Name: dp}}
+		require.NoError(t, gwInformer.Informer().GetIndexer().Add(gw))
+	}
+
+	kubeClient := fake.NewSimpleClientset()
+	kubeFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	podInformer := kubeFactory.Core().V1().Pods()
+
+	return &Controller{
+		config:              &Configuration{PodNamespace: "kube-system"},
+		vpcNatGatewayLister: gwInformer.Lister(),
+		podsLister:          podInformer.Lister(),
+	}
+}
+
+func TestNatGwDeleted(t *testing.T) {
+	t.Run("CRD missing returns true", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", false)
+		deleted, err := c.natGwDeleted("gw1")
+		require.NoError(t, err)
+		require.True(t, deleted)
+	})
+	t.Run("CRD present returns false", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", true)
+		deleted, err := c.natGwDeleted("gw1")
+		require.NoError(t, err)
+		require.False(t, deleted)
+	})
+}
+
+// Each in-pod cleanup helper must skip cleanup (return nil) when the gateway CRD
+// is gone, and must return an error (so the reconciler retries) when the CRD
+// still exists but the gateway pod is temporarily absent.
+func TestDeleteEipInPod(t *testing.T) {
+	t.Run("gateway gone skips cleanup", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", false)
+		require.NoError(t, c.deleteEipInPod("gw1", "10.0.0.1"))
+	})
+	t.Run("gateway present but pod absent retries", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", true)
+		err := c.deleteEipInPod("gw1", "10.0.0.1")
+		require.Error(t, err)
+		require.True(t, k8serrors.IsNotFound(err))
+	})
+}
+
+func TestDelEipQoSInPod(t *testing.T) {
+	t.Run("gateway gone skips cleanup", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", false)
+		require.NoError(t, c.delEipQoSInPod("gw1", "10.0.0.1", kubeovnv1.QoSDirectionIngress))
+	})
+	t.Run("gateway present but pod absent retries", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", true)
+		err := c.delEipQoSInPod("gw1", "10.0.0.1", kubeovnv1.QoSDirectionIngress)
+		require.Error(t, err)
+		require.True(t, k8serrors.IsNotFound(err))
+	})
+}
+
+func TestDeleteFipInPod(t *testing.T) {
+	t.Run("gateway gone skips cleanup", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", false)
+		require.NoError(t, c.deleteFipInPod("gw1", "10.0.0.1"))
+	})
+	t.Run("gateway present but pod absent retries", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", true)
+		err := c.deleteFipInPod("gw1", "10.0.0.1")
+		require.Error(t, err)
+		require.True(t, k8serrors.IsNotFound(err))
+	})
+}
+
+func TestDeleteDnatInPod(t *testing.T) {
+	t.Run("gateway gone skips cleanup", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", false)
+		require.NoError(t, c.deleteDnatInPod("gw1", "tcp", "10.0.0.1", "80"))
+	})
+	t.Run("gateway present but pod absent retries", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", true)
+		err := c.deleteDnatInPod("gw1", "tcp", "10.0.0.1", "80")
+		require.Error(t, err)
+		require.True(t, k8serrors.IsNotFound(err))
+	})
+}
+
+func TestDeleteSnatInPod(t *testing.T) {
+	t.Run("gateway gone skips cleanup", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", false)
+		require.NoError(t, c.deleteSnatInPod("gw1", "10.0.0.1", "10.16.0.0/16"))
+	})
+	t.Run("gateway present but pod absent retries", func(t *testing.T) {
+		c := newNatGwCleanupController(t, "gw1", true)
+		err := c.deleteSnatInPod("gw1", "10.0.0.1", "10.16.0.0/16")
+		require.Error(t, err)
+		require.True(t, k8serrors.IsNotFound(err))
+	})
+}

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -384,13 +384,41 @@ func (c *Controller) createEipInPod(dp, addrV4 string) error {
 	return c.execNatGwRules(gwPod, natGwEipAdd, []string{addrV4})
 }
 
+// natGwDeleted returns true when the VpcNatGateway CRD with the given name no
+// longer exists. A (true, nil) result means the gateway has been fully removed
+// and any in-pod cleanup can be safely skipped. Other errors are returned
+// as-is for the caller to handle.
+func (c *Controller) natGwDeleted(dp string) (bool, error) {
+	if _, err := c.vpcNatGatewayLister.Get(dp); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
 func (c *Controller) deleteEipInPod(dp, v4Cidr string) error {
+	// If the NAT gateway CRD is gone the gateway (and its pod) have been deleted;
+	// there is nothing to clean up. If the CRD still exists but the pod is
+	// temporarily absent (e.g. being recreated), return the error so the
+	// reconciler retries until the pod is ready.
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			// Pod is temporarily absent (e.g. being recreated); retry quietly.
+			klog.V(4).Infof("nat gw pod %s not found, will retry eip pod cleanup", dp)
+		} else {
+			klog.Error(err)
 		}
-		klog.Error(err)
 		return err
 	}
 	var delRules []string
@@ -499,9 +527,23 @@ func (c *Controller) addEipQoSInPod(
 
 func (c *Controller) delEipQoSInPod(dp, v4ip string, direction kubeovnv1.QoSPolicyRuleDirection) error {
 	var operation string
-	gwPod, err := c.getNatGwPod(dp)
+	// Same CRD / pod sentinel logic as deleteEipInPod: skip when the gateway is
+	// gone, retry when the pod is temporarily absent.
+	deleted, err := c.natGwDeleted(dp)
 	if err != nil {
 		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
+	gwPod, err := c.getNatGwPod(dp)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			klog.V(4).Infof("nat gw pod %s not found, will retry eip qos cleanup", dp)
+		} else {
+			klog.Error(err)
+		}
 		return err
 	}
 	var delRules []string

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -1904,12 +1904,25 @@ func (c *Controller) finalDeleteSnatInPod(key string, cachedSnat *kubeovnv1.Ipta
 }
 
 func (c *Controller) deleteFipInPod(dp, v4ip string) error {
+	// If the NAT gateway CRD is gone the gateway (and its pod) have been deleted;
+	// there is nothing to clean up. If the CRD still exists but the pod is
+	// temporarily absent (e.g. being recreated), return the error so the
+	// reconciler retries until the pod is ready.
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			klog.V(4).Infof("nat gw pod %s not found, will retry fip pod cleanup", dp)
+		} else {
+			klog.Error(err)
 		}
-		klog.Error(err)
 		return err
 	}
 	// del_floating_ip matches by EIP only (FIP is 1:1, identity = EIP)
@@ -1938,12 +1951,25 @@ func (c *Controller) createDnatInPod(dp, protocol, v4ip, internalIP, externalPor
 }
 
 func (c *Controller) deleteDnatInPod(dp, protocol, v4ip, externalPort string) error {
+	// If the NAT gateway CRD is gone the gateway (and its pod) have been deleted;
+	// there is nothing to clean up. If the CRD still exists but the pod is
+	// temporarily absent (e.g. being recreated), return the error so the
+	// reconciler retries until the pod is ready.
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			klog.V(4).Infof("nat gw pod %s not found, will retry dnat pod cleanup", dp)
+		} else {
+			klog.Error(err)
 		}
-		klog.Error(err)
 		return err
 	}
 
@@ -1983,12 +2009,25 @@ func (c *Controller) createSnatInPod(dp, v4ip, internalCIDR string) error {
 }
 
 func (c *Controller) deleteSnatInPod(dp, v4ip, internalCIDR string) error {
+	// If the NAT gateway CRD is gone the gateway (and its pod) have been deleted;
+	// there is nothing to clean up. If the CRD still exists but the pod is
+	// temporarily absent (e.g. being recreated), return the error so the
+	// reconciler retries until the pod is ready.
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
 	gwPod, err := c.getNatGwPod(dp)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			klog.V(4).Infof("nat gw pod %s not found, will retry snat pod cleanup", dp)
+		} else {
+			klog.Error(err)
 		}
-		klog.Error(err)
 		return err
 	}
 	// del nat


### PR DESCRIPTION
Backport of #6784 to `release-1.16`.

## Problem
When deleting an `IptablesEIP` (and FIP/DNAT/SNAT), the controller cleans up iptables/tc rules inside the NAT gateway pod via `deleteEipInPod` / `delEipQoSInPod` / `deleteFipInPod` / `deleteDnatInPod` / `deleteSnatInPod`. These used the **pod** existence as the termination sentinel:

- `delEipQoSInPod` returned the raw error when the pod was missing → reconciler retried **indefinitely**, EIP stuck in deletion.
- the others returned `nil` whenever the pod was missing → silently skipped cleanup even when the gateway was only being recreated.

## Fix
Introduce the `natGwDeleted` helper that uses the **VpcNatGateway CRD** as the authoritative sentinel:

- CRD gone → gateway (and its pod) truly deleted, nothing to clean up → `return nil`, let EIP deletion proceed.
- CRD present but pod temporarily absent (e.g. recreating) → return the error so the reconciler retries until the pod is ready (logged at `klog.V(4)` to avoid noise during rolling updates).

Applied to all five in-pod cleanup helpers.

## Backport notes (manual adaptation)
A clean cherry-pick of `f331bbb07` conflicts because `release-1.16` differs from master:
- helpers take a single-arg `getNatGwPod(dp)` (master added a namespace arg);
- `natGwNamespaceByName` and `normalizeSnatInternalCIDR` do not exist on this branch.

The fix was therefore applied manually. The upstream unit tests rely on harness internals that differ here, so the tests are provided as a **self-contained** `vpc_nat_gw_cleanup_test.go` that builds the minimal `Controller` dependencies directly.

## Verification on release-1.16
- `go build ./pkg/controller/` ✅
- `go vet ./pkg/controller/` ✅
- `golangci-lint run` on changed files → 0 issues ✅
- `go test ./pkg/controller/ -run 'NatGwDeleted|DeleteEipInPod|DelEipQoSInPod|DeleteFipInPod|DeleteDnatInPod|DeleteSnatInPod'` → PASS ✅
