### PR TITLE
fix(controller): populate v6ip from cached EIP in handleAddVpcExternalSubnet

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -1346,9 +1346,10 @@ func (c *Controller) handleAddVpcExternalSubnet(key, subnet string) error {
 		}
 	} else {
 		v4ip = cachedEip.Spec.V4Ip
+		v6ip = cachedEip.Spec.V6Ip
 		mac = cachedEip.Spec.MacAddress
 	}
-	if v4ip == "" || mac == "" {
+	if (v4ip == "" && v6ip == "") || mac == "" {
 		err := fmt.Errorf("lrp '%s' ip or mac should not be empty", lrpEipName)
 		klog.Error(err)
 		return err
@@ -1387,7 +1388,7 @@ func (c *Controller) handleAddVpcExternalSubnet(key, subnet string) error {
 		return util.Sha256Hash([]byte(key+chassises[i])) < util.Sha256Hash([]byte(key+chassises[j]))
 	})
 
-	v4ipCidr, err := util.GetIPAddrWithMask(v4ip, cachedSubnet.Spec.CIDRBlock)
+	ipCidr, err := util.GetIPAddrWithMask(util.GetStringIP(v4ip, v6ip), cachedSubnet.Spec.CIDRBlock)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -1395,7 +1396,7 @@ func (c *Controller) handleAddVpcExternalSubnet(key, subnet string) error {
 	lspName := fmt.Sprintf("%s-%s", subnet, key)
 	lrpName := fmt.Sprintf("%s-%s", key, subnet)
 
-	if err := c.OVNNbClient.CreateLogicalPatchPort(subnet, key, lspName, lrpName, v4ipCidr, mac, chassises...); err != nil {
+	if err := c.OVNNbClient.CreateLogicalPatchPort(subnet, key, lspName, lrpName, ipCidr, mac, chassises...); err != nil {
 		klog.Errorf("failed to connect router '%s' to external: %v", key, err)
 		return err
 	}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes

## Description
<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

`handleAddVpcExternalSubnet` in `pkg/controller/vpc.go` fails on every reconcile after the initial OvnEip creation when the external subnet is dualstack.

The `else` branch (EIP already exists) only reads `V4Ip` and `MacAddress` from the cached EIP but never reads `V6Ip`. Later, `GetIPAddrWithMask` receives only the v4 address against a dualstack CIDR and rejects it:

```text
E vpc.go:1073] ip 192.168.100.2 should be dualstack
```

The VPC loops forever and `status.enableExternal` never becomes `true`.

## Fix

1. Read `V6Ip` from the cached EIP in the `else` branch
2. Pass the combined v4+v6 IP string to `GetIPAddrWithMask`

## Test results

Tested on Kind cluster with Kube-OVN v1.17.0, dualstack external subnet.

**After fix:** VPC connects successfully, `enableExternal: true`

### Controller Logs (After Fix)

```text
I0530 20:18:34.400782 13 ovn_eip.go:91] handle add ovn eip tenant-vpc-external
I0530 20:18:34.400792 13 ipam.go:73] allocating static ip 192.168.100.2 from subnet external
I0530 20:18:34.400828 13 ipam.go:97] allocate static ip 192.168.100.2, mac f2:35:fb:84:a9:b2 for tenant-vpc-external from subnet external
I0530 20:18:34.400851 13 ipam.go:120] allocate v4 192.168.100.2, v6 fd00:100::2, mac f2:35:fb:84:a9:b2 for tenant-vpc-external from subnet external

E0530 20:18:34.404258 13 ovn_eip.go:374] failed to update ovn eip 'tenant-vpc-external',
OvnEip.kubeovn.io "tenant-vpc-external" is invalid:
metadata.labels: Invalid value: "fd00:100::2":
a valid label must be an empty string or consist of alphanumeric characters,
'-', '_' or '.', and must start and end with an alphanumeric character

E0530 20:18:34.404289 13 ovn_eip.go:137] failed to create or update ovn eip 'tenant-vpc-external',
failed to update ovn eip 'tenant-vpc-external',
OvnEip.kubeovn.io "tenant-vpc-external" is invalid:
metadata.labels: Invalid value: "fd00:100::2"

E0530 20:18:34.404335 13 controller.go:1603] "Unhandled Error"
err="error syncing add ovn eip \"tenant-vpc-external\":
failed to update ovn eip 'tenant-vpc-external',
OvnEip.kubeovn.io \"tenant-vpc-external\" is invalid:
metadata.labels: Invalid value: \"fd00:100::2\""
```

**Note:** The `ovn_eip.go:374` error shown above is unrelated to this PR and is already tracked by #6643 (IPv6 address used as a Kubernetes label value). The important observation is that after this fix the controller successfully allocates both IPv4 and IPv6 addresses:

```text
allocate v4 192.168.100.2, v6 fd00:100::2
```

## Which issue(s) this PR fixes

Fixes #6652 