### PR TITLE
fix(controller): correct egress sync status field on ACL update failure

### DIFF
--- a/pkg/controller/security_group.go
+++ b/pkg/controller/security_group.go
@@ -238,7 +238,7 @@ func (c *Controller) handleAddOrUpdateSg(key string, force bool) error {
 	}
 	if egressNeedUpdate {
 		if err = c.OVNNbClient.UpdateSgACL(sg, ovnnb.ACLDirectionFromLport); err != nil {
-			sg.Status.IngressLastSyncSuccess = false
+			sg.Status.EgressLastSyncSuccess = false
 			c.patchSgStatus(sg)
 			klog.Error(err)
 			return err


### PR DESCRIPTION
Fixes #6803

When the egress ACL update fails in `handleAddOrUpdateSg`, `IngressLastSyncSuccess` was incorrectly set to `false` instead of `EgressLastSyncSuccess`. This is a copy-paste bug from the ingress block above.

The incorrect status field causes:
- Ingress status to become falsely negative — monitoring/alerting thinks ingress rules are broken when they are fine.
- Egress status to become falsely positive — real egress sync failures are missed.

This change corrects line 241 to set `EgressLastSyncSuccess = false` in the egress error path.
