### PR TITLE
perf(controller): index IP CRs by subnet for subnet status calc

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -154,6 +154,7 @@ type Controller struct {
 
 	ipsLister     kubeovnlister.IPLister
 	ipSynced      cache.InformerSynced
+	ipIndexer     cache.Indexer
 	addIPQueue    workqueue.TypedRateLimitingInterface[string]
 	updateIPQueue workqueue.TypedRateLimitingInterface[string]
 	delIPQueue    workqueue.TypedRateLimitingInterface[*kubeovnv1.IP]
@@ -731,7 +732,7 @@ func Run(ctx context.Context, config *Configuration) {
 		controller.deleteDNSNameResolverQueue = newTypedRateLimitingQueue[*kubeovnv1.DNSNameResolver]("DeleteDNSNameResolver", nil)
 	}
 
-	if err := controller.setupIndexers(podInformer.Informer(), endpointSliceInformer.Informer()); err != nil {
+	if err := controller.setupIndexers(podInformer.Informer(), endpointSliceInformer.Informer(), ipInformer.Informer()); err != nil {
 		util.LogFatalAndExit(err, "failed to set up informer indexers")
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -258,7 +258,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		AttachNetClient:      nadClient,
 	}
 
-	if err := ctrl.setupIndexers(podInformer.Informer(), endpointSliceInformer.Informer()); err != nil {
+	if err := ctrl.setupIndexers(podInformer.Informer(), endpointSliceInformer.Informer(), ipInformer.Informer()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/indexers.go
+++ b/pkg/controller/indexers.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"slices"
+
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/client-go/tools/cache"
@@ -12,6 +14,7 @@ const (
 	IndexPodByNode             = "byNodeName"
 	IndexEPSByService          = "byServiceName"
 	IndexDNSNameResolverByName = "byDNSName"
+	IndexIPBySubnet            = "bySubnet"
 )
 
 func indexPodByNode(obj any) ([]string, error) {
@@ -42,17 +45,42 @@ func indexDNSNameResolverByName(obj any) ([]string, error) {
 	return []string{string(r.Spec.Name)}, nil
 }
 
+// indexIPBySubnet indexes an IP CR by its primary subnet plus any attach
+// subnets, mirroring the subnets enqueued to updateSubnetStatusQueue on IP
+// add/update/delete. This lets calcSubnetStatusIP look up the IPs of a single
+// subnet in O(matched) instead of scanning the whole IP store.
+func indexIPBySubnet(obj any) ([]string, error) {
+	ip, ok := obj.(*kubeovnv1.IP)
+	if !ok {
+		return nil, nil
+	}
+	subnets := make([]string, 0, 1+len(ip.Spec.AttachSubnets))
+	if ip.Spec.Subnet != "" {
+		subnets = append(subnets, ip.Spec.Subnet)
+	}
+	for _, as := range ip.Spec.AttachSubnets {
+		if as != "" && !slices.Contains(subnets, as) {
+			subnets = append(subnets, as)
+		}
+	}
+	return subnets, nil
+}
+
 // setupIndexers registers custom informer indexers used by hot-path
 // reconciliation loops to avoid O(N) full-store scans. Must be called before
 // the informer factory is started.
-func (c *Controller) setupIndexers(podInformer, epsInformer cache.SharedIndexInformer) error {
+func (c *Controller) setupIndexers(podInformer, epsInformer, ipInformer cache.SharedIndexInformer) error {
 	if err := podInformer.AddIndexers(cache.Indexers{IndexPodByNode: indexPodByNode}); err != nil {
 		return err
 	}
 	if err := epsInformer.AddIndexers(cache.Indexers{IndexEPSByService: indexEPSByService}); err != nil {
 		return err
 	}
+	if err := ipInformer.AddIndexers(cache.Indexers{IndexIPBySubnet: indexIPBySubnet}); err != nil {
+		return err
+	}
 	c.podIndexer = podInformer.GetIndexer()
 	c.epsIndexer = epsInformer.GetIndexer()
+	c.ipIndexer = ipInformer.GetIndexer()
 	return nil
 }

--- a/pkg/controller/indexers_test.go
+++ b/pkg/controller/indexers_test.go
@@ -7,6 +7,8 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
 
 func TestIndexPodByNode(t *testing.T) {
@@ -96,6 +98,57 @@ func TestIndexEPSByService(t *testing.T) {
 	}
 }
 
+func TestIndexIPBySubnet(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  any
+		want []string
+	}{
+		{
+			name: "ip on primary subnet only",
+			obj:  &kubeovnv1.IP{Spec: kubeovnv1.IPSpec{Subnet: "subnet-1"}},
+			want: []string{"subnet-1"},
+		},
+		{
+			name: "ip with attach subnets",
+			obj:  &kubeovnv1.IP{Spec: kubeovnv1.IPSpec{Subnet: "subnet-1", AttachSubnets: []string{"attach-1", "attach-2"}}},
+			want: []string{"subnet-1", "attach-1", "attach-2"},
+		},
+		{
+			name: "ip with duplicate and empty attach subnets",
+			obj:  &kubeovnv1.IP{Spec: kubeovnv1.IPSpec{Subnet: "subnet-1", AttachSubnets: []string{"subnet-1", "", "attach-1"}}},
+			want: []string{"subnet-1", "attach-1"},
+		},
+		{
+			name: "ip without primary subnet",
+			obj:  &kubeovnv1.IP{Spec: kubeovnv1.IPSpec{AttachSubnets: []string{"attach-1"}}},
+			want: []string{"attach-1"},
+		},
+		{
+			name: "ip without any subnet",
+			obj:  &kubeovnv1.IP{Spec: kubeovnv1.IPSpec{}},
+			want: []string{},
+		},
+		{
+			name: "non-ip object",
+			obj:  &v1.Pod{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := indexIPBySubnet(tt.obj)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalStringSlice(got, tt.want) {
+				t.Fatalf("indexIPBySubnet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIndexersLookup(t *testing.T) {
 	podIdx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{IndexPodByNode: indexPodByNode})
 	for _, pod := range []*v1.Pod{
@@ -133,6 +186,25 @@ func TestIndexersLookup(t *testing.T) {
 	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 eps for ns/svc-a, got %d", len(got))
+	}
+
+	ipIdx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{IndexIPBySubnet: indexIPBySubnet})
+	for _, ip := range []*kubeovnv1.IP{
+		{ObjectMeta: metav1.ObjectMeta{Name: "ip1"}, Spec: kubeovnv1.IPSpec{Subnet: "subnet-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ip2"}, Spec: kubeovnv1.IPSpec{Subnet: "subnet-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ip3"}, Spec: kubeovnv1.IPSpec{Subnet: "subnet-b", AttachSubnets: []string{"subnet-a"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ip4"}, Spec: kubeovnv1.IPSpec{Subnet: "subnet-b"}},
+	} {
+		if err := ipIdx.Add(ip); err != nil {
+			t.Fatalf("add ip: %v", err)
+		}
+	}
+	got, err = ipIdx.ByIndex(IndexIPBySubnet, "subnet-a")
+	if err != nil {
+		t.Fatalf("ByIndex: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 ips for subnet-a (incl. attach), got %d", len(got))
 	}
 }
 

--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -175,10 +175,18 @@ func (c *Controller) calcSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv1.Su
 		return nil, err
 	}
 
-	podUsedIPs, err := c.ipsLister.List(labels.SelectorFromSet(labels.Set{subnet.Name: ""}))
+	// Look up the subnet's IPs via the bySubnet indexer instead of scanning the
+	// whole IP store with a label selector, keeping this hot path O(matched).
+	ipObjs, err := c.ipIndexer.ByIndex(IndexIPBySubnet, subnet.Name)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
+	}
+	podUsedIPs := make([]*kubeovnv1.IP, 0, len(ipObjs))
+	for _, obj := range ipObjs {
+		if ip, ok := obj.(*kubeovnv1.IP); ok {
+			podUsedIPs = append(podUsedIPs, ip)
+		}
 	}
 
 	noGWExcludeIPs := filterNonGatewayExcludeIPs(subnet)


### PR DESCRIPTION
## Summary
- `calcSubnetStatusIP` previously listed the **entire** IP store with a label selector on every subnet status reconcile — an O(all-IPs) scan on a hot path.
- Add a `bySubnet` informer indexer (keyed on `Spec.Subnet` + `AttachSubnets`, mirroring the subnets enqueued to `updateSubnetStatusQueue`), following the existing `IndexPodByNode` / `IndexEPSByService` pattern.
- `calcSubnetStatusIP` now does `ipIndexer.ByIndex(IndexIPBySubnet, subnet.Name)`, walking only the target subnet's IPs — O(matched) instead of O(all).

**Behaviour is unchanged.** Every IP CR is created at a single site (`ip.go` `createOrUpdateIPCR`) that always sets `Spec.Subnet` and the dynamic per-subnet label together, so `ByIndex(Spec.Subnet)` returns the same set as the old `{subnet.Name: ""}` selector. `AttachSubnets` is never populated non-empty today, so that branch is a forward-compatible no-op.

## Test plan
- [x] `go build ./pkg/controller/...`
- [x] `go test ./pkg/controller/` (full package) — passes
- [x] New `TestIndexIPBySubnet` + extended `TestIndexersLookup` covering the IP indexer end-to-end
- [x] `gofmt` / `go vet` clean
- [x] `golangci-lint run ./pkg/controller/` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)