### PR TITLE
fix(build): always rebuild CNI plugins from source to avoid stale Go stdlib

### DIFF
--- a/dist/images/go-deps/download-go-deps.sh
+++ b/dist/images/go-deps/download-go-deps.sh
@@ -49,4 +49,14 @@ jq -r '.Results[] | select((.Type=="gobinary") and (.Vulnerabilities!=null)) | .
     esac
 done
 
+# Always rebuild the CNI plugins from source. The trivy scan above only enlists
+# binaries that are vulnerable at build time, but the upstream prebuilt plugins
+# embed whatever Go toolchain they were released with, so a plugin that is clean
+# today silently ships an outdated stdlib and becomes vulnerable once a new stdlib
+# CVE is published. The plugins are cheap to build (unlike kubectl), so rebuild
+# them unconditionally instead of leaving them pinned to the upstream binaries.
+for name in loopback macvlan portmap ipvlan; do
+    grep -q "^$name@" "$TARGETS_FILE" || echo "$name@$CNI_PLUGINS_VERSION" >> "$TARGETS_FILE"
+done
+
 cat "$TARGETS_FILE"


### PR DESCRIPTION
## What this fixes

The `Security Scan` step (`make scan`) on master started failing because Trivy reported 3 Go stdlib CVEs (`CVE-2026-27145`, `CVE-2026-42504`, `CVE-2026-42507`, all fixed in Go `1.26.4`) **only** in the `ipvlan` gobinary, while `macvlan` / `portmap` / `loopback` and every other binary scanned clean.

## Root cause

All four CNI plugins come from the **same** upstream prebuilt tarball (`containernetworking/plugins`), so they are originally compiled with the same Go toolchain (`1.26.3` in this case).

The go-deps pipeline then rebuilds binaries **selectively**:

- `download-go-deps.sh` downloads the prebuilt binaries, runs `trivy rootfs`, and only writes the binaries that are **vulnerable at build time** into `trivy-targets.txt`.
- `rebuild-go-deps.sh` rebuilds only those targets from source with the current Go toolchain; everything else is shipped as the upstream prebuilt binary.

Because Trivy did not flag `ipvlan` when the base image was built (the three June stdlib CVEs were not in the DB yet, and `ipvlan` had no other fixable vuln), it was **not** rebuilt and kept the upstream Go `1.26.3` build. `macvlan` / `portmap` / `loopback` happened to be enlisted (module-level findings) and were rebuilt with Go `1.26.4`, so they stayed clean. When `make scan` later ran with a fresher Trivy DB, only the stale `ipvlan` was caught.

This is a structural weakness of the conditional rebuild — it affects **all** CNI plugins equally; `ipvlan` (packaged only recently in #6747) was just the one that drew the short straw this time. Any plugin that scans clean at base-build time but is later hit by a new stdlib CVE will silently ship a vulnerable binary until the base image happens to be rebuilt.

## The change

Always enlist the CNI plugins (`loopback` / `macvlan` / `portmap` / `ipvlan`) for rebuild from source, regardless of the point-in-time Trivy scan. They are cheap to build (unlike `kubectl`, which keeps the trivy gate). A `grep -q` guard avoids duplicate entries when Trivy has already flagged a plugin.

```sh
for name in loopback macvlan portmap ipvlan; do
    grep -q "^$name@" "$TARGETS_FILE" || echo "$name@$CNI_PLUGINS_VERSION" >> "$TARGETS_FILE"
done
```

`rebuild-go-deps.sh` already knows how to build all four plugins, so no change is needed there.

## Verification

- `sh -n` passes on the modified script.
- Simulated the new loop: when Trivy already flagged `ipvlan` + `kubectl`, the result enlists each plugin exactly once (no duplicates) and preserves `kubectl`.
- Note: the actual scan only turns green once the base image (`kube-ovn-base`) is rebuilt with this script so `ipvlan` gets recompiled with Go `1.26.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)