### PR TITLE
perf(controller): list VMs cluster-wide once per GC cycle

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -461,8 +461,14 @@ func (c *Controller) markAndCleanLSP() error {
 		}
 	}
 
-	// The lsp for vm pod should not be deleted if vm still exists
-	ipMap.Add(c.getVMLsps()...)
+	// The lsp for vm pod should not be deleted if vm still exists.
+	// Abort the GC cycle on a list failure so we never delete live VM LSPs based on an incomplete keep-set.
+	vmLsps, err := c.getVMLsps()
+	if err != nil {
+		klog.Errorf("failed to get vm lsps, %v", err)
+		return err
+	}
+	ipMap.Add(vmLsps...)
 
 	vips, err := c.virtualIpsLister.List(labels.Everything())
 	if err != nil {
@@ -1086,69 +1092,67 @@ func (c *Controller) isOVNProvided(providerName string, pod *corev1.Pod) (bool, 
 	return false, nil
 }
 
-func (c *Controller) getVMLsps() []string {
+func (c *Controller) getVMLsps() ([]string, error) {
 	var vmLsps []string
 
 	if !c.config.EnableKeepVMIP {
-		return vmLsps
+		return vmLsps, nil
 	}
 
-	nss, err := c.namespacesLister.List(labels.Everything())
+	// A single cluster-wide list avoids a per-namespace apiserver round-trip every GC cycle.
+	// On clusters without the KubeVirt CRD the request returns NotFound, which is treated as
+	// "no VMs" rather than an error. Any other failure is returned so the caller can skip the
+	// GC cycle instead of deleting live VM LSPs based on an incomplete keep-set.
+	vms, err := c.config.KubevirtClient.VirtualMachine(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		klog.Errorf("failed to list namespaces, %v", err)
-		return vmLsps
+		if k8serrors.IsNotFound(err) {
+			return vmLsps, nil
+		}
+		klog.Errorf("failed to list vm, %v", err)
+		return nil, err
 	}
 
-	for _, ns := range nss {
-		vms, err := c.config.KubevirtClient.VirtualMachine(ns.Name).List(context.Background(), metav1.ListOptions{})
-		if err != nil {
-			if !k8serrors.IsNotFound(err) {
-				klog.Errorf("failed to list vm in namespace %s, %v", ns, err)
+	for _, vm := range vms.Items {
+		defaultMultus := false
+		for _, network := range vm.Spec.Template.Spec.Networks {
+			if network.Multus != nil && network.Multus.Default {
+				defaultMultus = true
+				break
 			}
-			continue
 		}
-		for _, vm := range vms.Items {
-			defaultMultus := false
-			for _, network := range vm.Spec.Template.Spec.Networks {
-				if network.Multus != nil && network.Multus.Default {
-					defaultMultus = true
-					break
-				}
+		if !defaultMultus {
+			vmLsp := ovs.PodNameToPortName(vm.Name, vm.Namespace, util.OvnProvider)
+			vmLsps = append(vmLsps, vmLsp)
+		}
+
+		nadAnnotation := vm.Spec.Template.ObjectMeta.Annotations[nadv1.NetworkAttachmentAnnot]
+		if nadAnnotation != "" {
+			attachNets, err := nadutils.ParseNetworkAnnotation(nadAnnotation, vm.Namespace)
+			if err != nil {
+				klog.Errorf("failed to get attachment subnet of vm %s, %v", vm.Name, err)
+				continue
 			}
-			if !defaultMultus {
-				vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, util.OvnProvider)
+			for _, multiNet := range attachNets {
+				provider := fmt.Sprintf("%s.%s.%s", multiNet.Name, multiNet.Namespace, util.OvnProvider)
+				vmLsp := ovs.PodNameToPortName(vm.Name, vm.Namespace, provider)
 				vmLsps = append(vmLsps, vmLsp)
 			}
+		}
 
-			nadAnnotation := vm.Spec.Template.ObjectMeta.Annotations[nadv1.NetworkAttachmentAnnot]
-			if nadAnnotation != "" {
-				attachNets, err := nadutils.ParseNetworkAnnotation(nadAnnotation, vm.Namespace)
-				if err != nil {
-					klog.Errorf("failed to get attachment subnet of vm %s, %v", vm.Name, err)
-					continue
+		for _, network := range vm.Spec.Template.Spec.Networks {
+			if network.Multus != nil && network.Multus.NetworkName != "" {
+				items := strings.Split(network.Multus.NetworkName, "/")
+				if len(items) != 2 {
+					items = []string{vm.GetNamespace(), items[0]}
 				}
-				for _, multiNet := range attachNets {
-					provider := fmt.Sprintf("%s.%s.%s", multiNet.Name, multiNet.Namespace, util.OvnProvider)
-					vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, provider)
-					vmLsps = append(vmLsps, vmLsp)
-				}
-			}
-
-			for _, network := range vm.Spec.Template.Spec.Networks {
-				if network.Multus != nil && network.Multus.NetworkName != "" {
-					items := strings.Split(network.Multus.NetworkName, "/")
-					if len(items) != 2 {
-						items = []string{vm.GetNamespace(), items[0]}
-					}
-					provider := fmt.Sprintf("%s.%s.%s", items[1], items[0], util.OvnProvider)
-					vmLsp := ovs.PodNameToPortName(vm.Name, ns.Name, provider)
-					vmLsps = append(vmLsps, vmLsp)
-				}
+				provider := fmt.Sprintf("%s.%s.%s", items[1], items[0], util.OvnProvider)
+				vmLsp := ovs.PodNameToPortName(vm.Name, vm.Namespace, provider)
+				vmLsps = append(vmLsps, vmLsp)
 			}
 		}
 	}
 
-	return vmLsps
+	return vmLsps, nil
 }
 
 func (c *Controller) gcLbSvcPods() error {

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -1108,8 +1108,7 @@ func (c *Controller) getVMLsps() ([]string, error) {
 		if k8serrors.IsNotFound(err) {
 			return vmLsps, nil
 		}
-		klog.Errorf("failed to list vm, %v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to list vms: %w", err)
 	}
 
 	for _, vm := range vms.Items {

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -1,11 +1,21 @@
 package controller
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
 
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -48,4 +58,103 @@ func Test_logicalRouterPortFilter(t *testing.T) {
 			require.True(t, filterFunc(lrp))
 		}
 	}
+}
+
+func vmTemplate(networks []kubevirtv1.Network, annotations map[string]string) *kubevirtv1.VirtualMachineInstanceTemplateSpec {
+	return &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+		Spec:       kubevirtv1.VirtualMachineInstanceSpec{Networks: networks},
+	}
+}
+
+// mockKubevirtList wires a MockKubevirtClient so that a cluster-wide
+// VirtualMachine(NamespaceAll).List returns the given list/error exactly once.
+func mockKubevirtList(t *testing.T, list *kubevirtv1.VirtualMachineList, listErr error) kubecli.KubevirtClient {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockVMI := kubecli.NewMockVirtualMachineInterface(ctrl)
+	mockVMI.EXPECT().List(gomock.Any(), gomock.Any()).Return(list, listErr)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockClient.EXPECT().VirtualMachine(metav1.NamespaceAll).Return(mockVMI)
+	return mockClient
+}
+
+func TestGetVMLsps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled keeps no vm lsp and never lists", func(t *testing.T) {
+		// KubevirtClient is intentionally a mock with no expectations: if getVMLsps
+		// touched the apiserver while disabled, gomock would fail the test.
+		ctrl := gomock.NewController(t)
+		c := &Controller{config: &Configuration{
+			EnableKeepVMIP: false,
+			KubevirtClient: kubecli.NewMockKubevirtClient(ctrl),
+		}}
+		lsps, err := c.getVMLsps()
+		require.NoError(t, err)
+		require.Empty(t, lsps)
+	})
+
+	t.Run("missing kubevirt crd resolves to empty set", func(t *testing.T) {
+		notFound := k8serrors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, "")
+		c := &Controller{config: &Configuration{
+			EnableKeepVMIP: true,
+			KubevirtClient: mockKubevirtList(t, nil, notFound),
+		}}
+		lsps, err := c.getVMLsps()
+		require.NoError(t, err)
+		require.Empty(t, lsps)
+	})
+
+	t.Run("transient list failure is propagated", func(t *testing.T) {
+		c := &Controller{config: &Configuration{
+			EnableKeepVMIP: true,
+			KubevirtClient: mockKubevirtList(t, nil, errors.New("boom")),
+		}}
+		lsps, err := c.getVMLsps()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to list vms")
+		require.Nil(t, lsps)
+	})
+
+	t.Run("lists vms cluster-wide using their own namespace", func(t *testing.T) {
+		vms := &kubevirtv1.VirtualMachineList{Items: []kubevirtv1.VirtualMachine{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "vm-primary", Namespace: "ns1"},
+				Spec:       kubevirtv1.VirtualMachineSpec{Template: vmTemplate(nil, nil)},
+			},
+			{
+				// Default multus network: primary lsp is skipped, but the attachment
+				// network derived from NetworkName must still be kept.
+				ObjectMeta: metav1.ObjectMeta{Name: "vm-default-multus", Namespace: "ns2"},
+				Spec: kubevirtv1.VirtualMachineSpec{Template: vmTemplate([]kubevirtv1.Network{{
+					Name: "secondary",
+					NetworkSource: kubevirtv1.NetworkSource{
+						Multus: &kubevirtv1.MultusNetwork{Default: true, NetworkName: "ns2/net2"},
+					},
+				}}, nil)},
+			},
+			{
+				// NAD annotation contributes an attachment lsp on top of the primary one.
+				ObjectMeta: metav1.ObjectMeta{Name: "vm-nad", Namespace: "ns3"},
+				Spec:       kubevirtv1.VirtualMachineSpec{Template: vmTemplate(nil, map[string]string{nadv1.NetworkAttachmentAnnot: "netx"})},
+			},
+		}}
+		c := &Controller{config: &Configuration{
+			EnableKeepVMIP: true,
+			KubevirtClient: mockKubevirtList(t, vms, nil),
+		}}
+
+		lsps, err := c.getVMLsps()
+		require.NoError(t, err)
+
+		net2Provider := fmt.Sprintf("%s.%s.%s", "net2", "ns2", util.OvnProvider)
+		nadProvider := fmt.Sprintf("%s.%s.%s", "netx", "ns3", util.OvnProvider)
+		require.ElementsMatch(t, []string{
+			ovs.PodNameToPortName("vm-primary", "ns1", util.OvnProvider),
+			ovs.PodNameToPortName("vm-default-multus", "ns2", net2Provider),
+			ovs.PodNameToPortName("vm-nad", "ns3", util.OvnProvider),
+			ovs.PodNameToPortName("vm-nad", "ns3", nadProvider),
+		}, lsps)
+	})
 }

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -722,7 +722,12 @@ func (c *Controller) syncIPCR() error {
 		return err
 	}
 
-	ipMap := strset.New(c.getVMLsps()...)
+	vmLsps, err := c.getVMLsps()
+	if err != nil {
+		klog.Errorf("failed to get vm lsps, %v", err)
+		return err
+	}
+	ipMap := strset.New(vmLsps...)
 	for _, ip := range ips {
 		if !ip.DeletionTimestamp.IsZero() {
 			klog.Infof("enqueue update for removing finalizer to delete ip %s", ip.Name)


### PR DESCRIPTION
## Summary
- `getVMLsps` listed every namespace and then issued a `VirtualMachine().List` **per namespace** on every GC cycle (default 360s) and at startup. Gated only by `EnableKeepVMIP` (default `true`), so it fanned out a direct apiserver round-trip per namespace even on non-KubeVirt clusters. Replaced with a single cluster-wide `VirtualMachine(metav1.NamespaceAll).List`, which the existing ClusterRole (`virtualmachines: get/list/watch`) already permits.
- Hardened error handling: `getVMLsps` now returns `([]string, error)`. A missing KubeVirt CRD still resolves to an empty set via `IsNotFound`, but any other (transient) list failure is propagated so `markAndCleanLSP` and `syncIPCR` abort the cycle instead of deleting live VM LSPs based on an incomplete keep-set.
- Per-namespace `ns.Name` port-name construction switched to `vm.Namespace` (semantically equivalent after the cluster-wide list).

## Test plan
- [x] `go build ./pkg/controller/`
- [x] `golangci-lint run ./pkg/controller/` — 0 issues
- [ ] e2e: KubeVirt keep-vm-ip GC still retains LSPs for running VMs
- [ ] verify GC cycle no longer issues one VM List per namespace (non-KubeVirt cluster issues a single 404 instead of N)

🤖 Generated with [Claude Code](https://claude.com/claude-code)