### PR TITLE
perf(daemon): list subnets and pods once per gateway setter

### DIFF
--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -94,11 +94,16 @@ func (c *Controller) isSubnetNeedNat(subnet *kubeovnv1.Subnet, protocol string) 
 func (c *Controller) getSubnetsNeedNAT(subnets []*kubeovnv1.Subnet, protocol string) []string {
 	var subnetsNeedNat []string
 	for _, subnet := range subnets {
-		if c.isSubnetNeedNat(subnet, protocol) {
-			cidrBlock, err := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
-			if err == nil && cidrBlock != "" {
-				subnetsNeedNat = append(subnetsNeedNat, cidrBlock)
-			}
+		if !c.isSubnetNeedNat(subnet, protocol) {
+			continue
+		}
+		cidrBlock, err := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
+		if err != nil {
+			klog.Errorf("failed to get subnet %s CIDR block by protocol: %v", subnet.Name, err)
+			continue
+		}
+		if cidrBlock != "" {
+			subnetsNeedNat = append(subnetsNeedNat, cidrBlock)
 		}
 	}
 	return subnetsNeedNat
@@ -124,7 +129,11 @@ func (c *Controller) getSubnetsDistributedGateway(subnets []*kubeovnv1.Subnet, p
 			subnet.Spec.GatewayType == kubeovnv1.GWDistributedType &&
 			(subnet.Spec.Protocol == kubeovnv1.ProtocolDual || subnet.Spec.Protocol == protocol) {
 			cidrBlock, err := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
-			if err == nil && cidrBlock != "" {
+			if err != nil {
+				klog.Errorf("failed to get subnet %s CIDR block by protocol: %v", subnet.Name, err)
+				continue
+			}
+			if cidrBlock != "" {
 				result = append(result, cidrBlock)
 			}
 		}
@@ -146,7 +155,11 @@ func (c *Controller) getDefaultVpcSubnetsCIDR(subnets []*kubeovnv1.Subnet, proto
 	for _, subnet := range subnets {
 		if subnet.Spec.Vpc == c.config.ClusterRouter && (subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway) && subnet.Spec.CIDRBlock != "" {
 			cidrBlock, err := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
-			if err == nil && cidrBlock != "" {
+			if err != nil {
+				klog.Errorf("failed to get subnet %s CIDR block by protocol: %v", subnet.Name, err)
+				continue
+			}
+			if cidrBlock != "" {
 				ret = append(ret, cidrBlock)
 				subnetMap[subnet.Name] = cidrBlock
 			}

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -91,14 +91,8 @@ func (c *Controller) isSubnetNeedNat(subnet *kubeovnv1.Subnet, protocol string) 
 	return false
 }
 
-func (c *Controller) getSubnetsNeedNAT(protocol string) ([]string, error) {
+func (c *Controller) getSubnetsNeedNAT(subnets []*kubeovnv1.Subnet, protocol string) []string {
 	var subnetsNeedNat []string
-	subnets, err := c.subnetsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("list subnets failed, %v", err)
-		return nil, err
-	}
-
 	for _, subnet := range subnets {
 		if c.isSubnetNeedNat(subnet, protocol) {
 			cidrBlock, err := getCidrByProtocol(subnet.Spec.CIDRBlock, protocol)
@@ -107,32 +101,20 @@ func (c *Controller) getSubnetsNeedNAT(protocol string) ([]string, error) {
 			}
 		}
 	}
-	return subnetsNeedNat, nil
+	return subnetsNeedNat
 }
 
-func (c *Controller) getSubnetsNatOutGoingPolicy(protocol string) ([]*kubeovnv1.Subnet, error) {
-	subnets, err := c.subnetsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("list subnets failed, %v", err)
-		return nil, err
-	}
-
+func (c *Controller) getSubnetsNatOutGoingPolicy(subnets []*kubeovnv1.Subnet, protocol string) []*kubeovnv1.Subnet {
 	var subnetsWithNatPolicy []*kubeovnv1.Subnet
 	for _, subnet := range subnets {
 		if c.isSubnetNeedNat(subnet, protocol) && len(subnet.Status.NatOutgoingPolicyRules) != 0 {
 			subnetsWithNatPolicy = append(subnetsWithNatPolicy, subnet)
 		}
 	}
-	return subnetsWithNatPolicy, nil
+	return subnetsWithNatPolicy
 }
 
-func (c *Controller) getSubnetsDistributedGateway(protocol string) ([]string, error) {
-	subnets, err := c.subnetsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list subnets: %v", err)
-		return nil, err
-	}
-
+func (c *Controller) getSubnetsDistributedGateway(subnets []*kubeovnv1.Subnet, protocol string) []string {
 	var result []string
 	for _, subnet := range subnets {
 		if subnet.DeletionTimestamp.IsZero() &&
@@ -147,7 +129,7 @@ func (c *Controller) getSubnetsDistributedGateway(protocol string) ([]string, er
 			}
 		}
 	}
-	return result, nil
+	return result
 }
 
 func (c *Controller) getServicesCIDR(protocol string) []string {
@@ -157,13 +139,7 @@ func (c *Controller) getServicesCIDR(protocol string) []string {
 	return c.serviceCIDRStore.V4CIDRs()
 }
 
-func (c *Controller) getDefaultVpcSubnetsCIDR(protocol string) ([]string, map[string]string, error) {
-	subnets, err := c.subnetsLister.List(labels.Everything())
-	if err != nil {
-		klog.Error("failed to list subnets")
-		return nil, nil, err
-	}
-
+func (c *Controller) getDefaultVpcSubnetsCIDR(subnets []*kubeovnv1.Subnet, protocol string) ([]string, map[string]string) {
 	ret := make([]string, 0, len(subnets)+1)
 	subnetMap := make(map[string]string, len(subnets)+1)
 
@@ -176,7 +152,7 @@ func (c *Controller) getDefaultVpcSubnetsCIDR(protocol string) ([]string, map[st
 			}
 		}
 	}
-	return ret, subnetMap, nil
+	return ret, subnetMap
 }
 
 func (c *Controller) getOtherNodes(protocol string) ([]string, error) {
@@ -215,15 +191,9 @@ func getCidrByProtocol(cidr, protocol string) (string, error) {
 	return "", nil
 }
 
-func (c *Controller) getEgressNatIPByNode(nodeName string) (map[string]string, error) {
+func (c *Controller) getEgressNatIPByNode(subnets []*kubeovnv1.Subnet, nodeName string) map[string]string {
 	subnetsNatIP := make(map[string]string)
-	subnetList, err := c.subnetsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list subnets %v", err)
-		return subnetsNatIP, err
-	}
-
-	for _, subnet := range subnetList {
+	for _, subnet := range subnets {
 		if !subnet.Spec.NatOutgoing ||
 			(subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) ||
 			subnet.Spec.GatewayType != kubeovnv1.GWCentralizedType ||
@@ -246,17 +216,11 @@ func (c *Controller) getEgressNatIPByNode(nodeName string) (map[string]string, e
 			}
 		}
 	}
-	return subnetsNatIP, nil
+	return subnetsNatIP
 }
 
-func (c *Controller) getTProxyConditionPod(needSort bool) ([]*v1.Pod, error) {
+func (c *Controller) getTProxyConditionPod(pods []*v1.Pod, needSort bool) ([]*v1.Pod, error) {
 	var filteredPods []*v1.Pod
-	pods, err := c.podsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("list pods failed, %v", err)
-		return nil, err
-	}
-
 	for _, pod := range pods {
 		subnetName, ok := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, util.OvnProvider)]
 		if !ok {

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubeovn/go-iptables/iptables"
 	"github.com/scylladb/go-set/strset"
 	"github.com/vishvananda/netlink"
+	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -84,26 +85,20 @@ func (c *Controller) setIPSet() error {
 		protocols = append(protocols, c.protocol)
 	}
 
+	allSubnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets: %v", err)
+		return err
+	}
+
 	for _, protocol := range protocols {
 		if c.ipsets[protocol] == nil {
 			continue
 		}
 		services := c.getServicesCIDR(protocol)
-		subnets, _, err := c.getDefaultVpcSubnetsCIDR(protocol)
-		if err != nil {
-			klog.Errorf("get subnets failed, %+v", err)
-			return err
-		}
-		subnetsNeedNat, err := c.getSubnetsNeedNAT(protocol)
-		if err != nil {
-			klog.Errorf("get need nat subnets failed, %+v", err)
-			return err
-		}
-		subnetsDistributedGateway, err := c.getSubnetsDistributedGateway(protocol)
-		if err != nil {
-			klog.Errorf("failed to get subnets with centralized gateway: %v", err)
-			return err
-		}
+		subnets, _ := c.getDefaultVpcSubnetsCIDR(allSubnets, protocol)
+		subnetsNeedNat := c.getSubnetsNeedNAT(allSubnets, protocol)
+		subnetsDistributedGateway := c.getSubnetsDistributedGateway(allSubnets, protocol)
 		otherNode, err := c.getOtherNodes(protocol)
 		if err != nil {
 			klog.Errorf("failed to get node, %+v", err)
@@ -139,7 +134,7 @@ func (c *Controller) setIPSet() error {
 			SetID:   OtherNodeSet,
 			Type:    ipsets.IPSetTypeHashNet,
 		}, otherNode)
-		c.reconcileNatOutGoingPolicyIPset(protocol)
+		c.reconcileNatOutGoingPolicyIPset(allSubnets, protocol)
 		c.ipsets[protocol].ApplyUpdates()
 	}
 	return nil
@@ -197,13 +192,8 @@ func (c *Controller) removeNatOutGoingPolicyRuleIPset(protocol string, natPolicy
 	}
 }
 
-func (c *Controller) reconcileNatOutGoingPolicyIPset(protocol string) {
-	subnets, err := c.getSubnetsNatOutGoingPolicy(protocol)
-	if err != nil {
-		klog.Errorf("failed to get subnets with NAT outgoing policy rule: %v", err)
-		return
-	}
-
+func (c *Controller) reconcileNatOutGoingPolicyIPset(allSubnets []*kubeovnv1.Subnet, protocol string) {
+	subnets := c.getSubnetsNatOutGoingPolicy(allSubnets, protocol)
 	subnetCidrs := make([]string, 0, len(subnets))
 	natPolicyRuleIDs := strset.New()
 	for _, subnet := range subnets {
@@ -242,17 +232,24 @@ func (c *Controller) setPolicyRouting() error {
 		protocols = append(protocols, c.protocol)
 	}
 
+	allSubnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets: %v", err)
+		return err
+	}
+	allPods, err := c.podsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list pods: %v", err)
+		return err
+	}
+
 	for _, protocol := range protocols {
 		if c.ipsets[protocol] == nil {
 			continue
 		}
 
-		localPodIPs, err := c.getLocalPodIPsNeedPR(protocol)
-		if err != nil {
-			klog.Errorf("failed to get local pod ips failed: %+v", err)
-			return err
-		}
-		subnetsNeedPR, err := c.getSubnetsNeedPR(protocol)
+		localPodIPs := c.getLocalPodIPsNeedPR(allPods, protocol)
+		subnetsNeedPR, err := c.getSubnetsNeedPR(allSubnets, protocol)
 		if err != nil {
 			klog.Errorf("failed to get subnets that need policy routing: %+v", err)
 			return err
@@ -635,11 +632,22 @@ func (c *Controller) setIptables() error {
 		kubeovnv1.ProtocolIPv6: nodeIPv6,
 	}
 
-	centralGwNatIPs, err := c.getEgressNatIPByNode(c.config.NodeName)
+	allSubnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
-		klog.Errorf("failed to get centralized subnets nat ips on node %s, %v", c.config.NodeName, err)
+		klog.Errorf("failed to list subnets: %v", err)
 		return err
 	}
+
+	// pods are only needed for TProxy rules; skip the full list otherwise
+	var allPods []*v1.Pod
+	if c.config.EnableTProxy {
+		if allPods, err = c.podsLister.List(labels.Everything()); err != nil {
+			klog.Errorf("failed to list pods: %v", err)
+			return err
+		}
+	}
+
+	centralGwNatIPs := c.getEgressNatIPByNode(allSubnets, c.config.NodeName)
 	klog.V(3).Infof("centralized subnets nat ips %v", centralGwNatIPs)
 
 	var (
@@ -814,11 +822,7 @@ func (c *Controller) setIptables() error {
 			}
 		}
 
-		_, subnetCidrs, err := c.getDefaultVpcSubnetsCIDR(protocol)
-		if err != nil {
-			klog.Errorf("get subnets failed, %+v", err)
-			return err
-		}
+		_, subnetCidrs := c.getDefaultVpcSubnetsCIDR(allSubnets, protocol)
 
 		subnetNames := set.New[string]()
 		for _, name := range slices.Sorted(maps.Keys(subnetCidrs)) {
@@ -916,12 +920,12 @@ func (c *Controller) setIptables() error {
 			natPostroutingRules = append(natPostroutingRules[:n-1], rule, natPostroutingRules[n-1])
 		}
 
-		if err = c.reconcileNatOutgoingPolicyIptablesChain(protocol); err != nil {
+		if err = c.reconcileNatOutgoingPolicyIptablesChain(allSubnets, protocol); err != nil {
 			klog.Error(err)
 			return err
 		}
 
-		if err = c.reconcileTProxyIPTableRules(protocol); err != nil {
+		if err = c.reconcileTProxyIPTableRules(allPods, protocol); err != nil {
 			klog.Error(err)
 			return err
 		}
@@ -1114,7 +1118,7 @@ func clearAndDeleteChainIfExists(ipt *iptables.IPTables, table, chain string) er
 	return nil
 }
 
-func (c *Controller) reconcileTProxyIPTableRules(protocol string) error {
+func (c *Controller) reconcileTProxyIPTableRules(allPods []*v1.Pod, protocol string) error {
 	if !c.config.EnableTProxy {
 		return nil
 	}
@@ -1123,7 +1127,7 @@ func (c *Controller) reconcileTProxyIPTableRules(protocol string) error {
 	tproxyPreRoutingRules := make([]util.IPTableRule, 0)
 	tproxyOutputRules := make([]util.IPTableRule, 0)
 
-	pods, err := c.getTProxyConditionPod(true)
+	pods, err := c.getTProxyConditionPod(allPods, true)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -1185,10 +1189,10 @@ func (c *Controller) cleanTProxyIPTableRules(protocol string) {
 	}
 }
 
-func (c *Controller) reconcileNatOutgoingPolicyIptablesChain(protocol string) error {
+func (c *Controller) reconcileNatOutgoingPolicyIptablesChain(allSubnets []*kubeovnv1.Subnet, protocol string) error {
 	ipt := c.iptables[protocol]
 
-	natPolicySubnetIptables, natPolicyRuleIptablesMap, gcNatPolicySubnetChains, err := c.generateNatOutgoingPolicyChainRules(protocol)
+	natPolicySubnetIptables, natPolicyRuleIptablesMap, gcNatPolicySubnetChains, err := c.generateNatOutgoingPolicyChainRules(allSubnets, protocol)
 	if err != nil {
 		klog.Errorf(`failed to get nat policy post routing rules with err %v `, err)
 		return err
@@ -1217,7 +1221,7 @@ func (c *Controller) reconcileNatOutgoingPolicyIptablesChain(protocol string) er
 	return nil
 }
 
-func (c *Controller) generateNatOutgoingPolicyChainRules(protocol string) ([]util.IPTableRule, map[string][]util.IPTableRule, []string, error) {
+func (c *Controller) generateNatOutgoingPolicyChainRules(allSubnets []*kubeovnv1.Subnet, protocol string) ([]util.IPTableRule, map[string][]util.IPTableRule, []string, error) {
 	natPolicySubnetIptables := make([]util.IPTableRule, 0)
 	natPolicyRuleIptablesMap := make(map[string][]util.IPTableRule)
 	natPolicySubnetUIDs := strset.New()
@@ -1225,12 +1229,7 @@ func (c *Controller) generateNatOutgoingPolicyChainRules(protocol string) ([]uti
 	subnetNames := make([]string, 0)
 	subnetMap := make(map[string]*kubeovnv1.Subnet)
 
-	subnets, err := c.getSubnetsNatOutGoingPolicy(protocol)
-	if err != nil {
-		klog.Errorf("failed to get subnets with NAT outgoing policy rule: %v", err)
-		return nil, nil, nil, err
-	}
-
+	subnets := c.getSubnetsNatOutGoingPolicy(allSubnets, protocol)
 	for _, subnet := range subnets {
 		subnetNames = append(subnetNames, subnet.Name)
 		subnetMap[subnet.Name] = subnet
@@ -1762,15 +1761,9 @@ func (c *Controller) setExGateway() error {
 	return nil
 }
 
-func (c *Controller) getLocalPodIPsNeedPR(protocol string) (map[policyRouteMeta][]string, error) {
-	allPods, err := c.podsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list pods: %+v", err)
-		return nil, err
-	}
-
+func (c *Controller) getLocalPodIPsNeedPR(pods []*v1.Pod, protocol string) map[policyRouteMeta][]string {
 	localPodIPs := make(map[policyRouteMeta][]string)
-	for _, pod := range allPods {
+	for _, pod := range pods {
 		if !pod.DeletionTimestamp.IsZero() ||
 			pod.Annotations[util.LogicalSwitchAnnotation] == "" ||
 			pod.Annotations[util.IPAddressAnnotation] == "" {
@@ -1834,17 +1827,11 @@ func (c *Controller) getLocalPodIPsNeedPR(protocol string) (map[policyRouteMeta]
 		}
 	}
 
-	return localPodIPs, nil
+	return localPodIPs
 }
 
-func (c *Controller) getSubnetsNeedPR(protocol string) (map[policyRouteMeta]string, error) {
+func (c *Controller) getSubnetsNeedPR(subnets []*kubeovnv1.Subnet, protocol string) (map[policyRouteMeta]string, error) {
 	subnetsNeedPR := make(map[policyRouteMeta]string)
-	subnets, err := c.subnetsLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to list subnets: %v", err)
-		return nil, err
-	}
-
 	node, err := c.nodesLister.Get(c.config.NodeName)
 	if err != nil {
 		klog.Errorf("failed to get node %s: %v", c.config.NodeName, err)

--- a/pkg/daemon/tproxy_linux.go
+++ b/pkg/daemon/tproxy_linux.go
@@ -105,6 +105,7 @@ func (c *Controller) StartTProxyTCPPortProbe() {
 	}
 	pods, err := c.getTProxyConditionPod(allPods, false)
 	if err != nil {
+		klog.Errorf("failed to get tproxy condition pods: %v", err)
 		return
 	}
 

--- a/pkg/daemon/tproxy_linux.go
+++ b/pkg/daemon/tproxy_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/set"
@@ -97,7 +98,12 @@ func getProbePorts(pod *corev1.Pod) set.Set[int32] {
 }
 
 func (c *Controller) StartTProxyTCPPortProbe() {
-	pods, err := c.getTProxyConditionPod(false)
+	allPods, err := c.podsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list pods: %v", err)
+		return
+	}
+	pods, err := c.getTProxyConditionPod(allPods, false)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- `runGateway` runs every 3s; each of `setIPSet` / `setPolicyRouting` / `setIptables` independently re-listed the full subnet informer cache — up to **15 full subnet lists per dual-stack tick** (and pods 2–4×).
- List subnets (and pods) **once per setter** and thread the slice through the helpers, cutting it to **3 subnet lists/tick** and **1–2 pod lists/tick**.
- Scoped per-setter (not one global snapshot) to keep each setter's existing independent-snapshot boundary — minimal behavioral change.
- Dropped the now-redundant `error` returns from helpers whose only error source was the removed `List` call; callers simplified accordingly. `StartTProxyTCPPortProbe` (separate path) now lists pods itself.

## Test plan
- [x] `go build ./pkg/daemon/...` + `go vet`
- [x] `make lint` — 0 issues (golangci-lint + modernize)
- [x] `make ut` — Ginkgo suite + all `pkg` `go test` pass
- [ ] No functional change expected; gateway iptables/ipset/policy-routing reconcile behavior is identical (same data, fewer cache reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)