### PR TITLE
perf(ovs): list NAT and static routes via single WhereCache scan

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -455,6 +455,10 @@ func (c *OVNNbClient) listLogicalRouterStaticRoutesByFilter(lrName string, filte
 		return nil, err
 	}
 
+	if len(lr.StaticRoutes) == 0 {
+		return nil, nil
+	}
+
 	uuidSet := set.New(lr.StaticRoutes...)
 	predicate := func(route *ovnnb.LogicalRouterStaticRoute) bool {
 		if !uuidSet.Has(route.UUID) {

--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/model"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 	"github.com/scylladb/go-set/strset"
@@ -323,20 +322,6 @@ func (c *OVNNbClient) ClearLogicalRouterStaticRoute(lrName string) error {
 	return nil
 }
 
-// GetLogicalRouterStaticRouteByUUID get logical router static route by UUID
-func (c *OVNNbClient) GetLogicalRouterStaticRouteByUUID(uuid string) (*ovnnb.LogicalRouterStaticRoute, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
-	defer cancel()
-
-	route := &ovnnb.LogicalRouterStaticRoute{UUID: uuid}
-	if err := c.Get(ctx, route); err != nil {
-		klog.Error(err)
-		return nil, err
-	}
-
-	return route, nil
-}
-
 // GetLogicalRouterStaticRoute get logical router static route by some attribute,
 // a static route is uniquely identified by router(lrName), policy and ipPrefix when route is not ecmp
 // a static route is uniquely identified by router(lrName), policy, ipPrefix and nexthop when route is ecmp
@@ -470,19 +455,18 @@ func (c *OVNNbClient) listLogicalRouterStaticRoutesByFilter(lrName string, filte
 		return nil, err
 	}
 
+	uuidSet := set.New(lr.StaticRoutes...)
+	predicate := func(route *ovnnb.LogicalRouterStaticRoute) bool {
+		if !uuidSet.Has(route.UUID) {
+			return false
+		}
+		return filter == nil || filter(route)
+	}
+
 	routeList := make([]*ovnnb.LogicalRouterStaticRoute, 0, len(lr.StaticRoutes))
-	for _, uuid := range lr.StaticRoutes {
-		route, err := c.GetLogicalRouterStaticRouteByUUID(uuid)
-		if err != nil {
-			if errors.Is(err, client.ErrNotFound) {
-				continue
-			}
-			klog.Error(err)
-			return nil, err
-		}
-		if filter == nil || filter(route) {
-			routeList = append(routeList, route)
-		}
+	if err = c.WhereCache(predicate).List(context.Background(), &routeList); err != nil {
+		klog.Error(err)
+		return nil, err
 	}
 
 	return routeList, nil

--- a/pkg/ovs/ovn-nb-logical_router_route_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_route_test.go
@@ -561,6 +561,14 @@ func (suite *OvnClientTestSuite) testListLogicalRouterStaticRoutes() {
 		require.Len(t, result, 1)
 		require.Equal(t, "192.168.70.0/24", result[0].IPPrefix)
 	})
+
+	t.Run("empty logical router returns no routes without scanning cache", func(t *testing.T) {
+		emptyLR := "test-list-routes-empty-lr"
+		require.NoError(t, nbClient.CreateLogicalRouter(emptyLR))
+		result, err := nbClient.ListLogicalRouterStaticRoutes(emptyLR, nil, nil, "", nil)
+		require.NoError(t, err)
+		require.Empty(t, result)
+	})
 }
 
 func (suite *OvnClientTestSuite) testNewLogicalRouterStaticRoute() {

--- a/pkg/ovs/ovn-nb-nat.go
+++ b/pkg/ovs/ovn-nb-nat.go
@@ -460,6 +460,10 @@ func (c *OVNNbClient) listLogicalRouterNatByFilter(lrName string, filter func(ro
 		return nil, err
 	}
 
+	if len(lr.Nat) == 0 {
+		return nil, nil
+	}
+
 	uuidSet := set.New(lr.Nat...)
 	predicate := func(nat *ovnnb.NAT) bool {
 		if !uuidSet.Has(nat.UUID) {

--- a/pkg/ovs/ovn-nb-nat.go
+++ b/pkg/ovs/ovn-nb-nat.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"maps"
 
-	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/model"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/set"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
@@ -460,19 +460,18 @@ func (c *OVNNbClient) listLogicalRouterNatByFilter(lrName string, filter func(ro
 		return nil, err
 	}
 
+	uuidSet := set.New(lr.Nat...)
+	predicate := func(nat *ovnnb.NAT) bool {
+		if !uuidSet.Has(nat.UUID) {
+			return false
+		}
+		return filter == nil || filter(nat)
+	}
+
 	natList := make([]*ovnnb.NAT, 0, len(lr.Nat))
-	for _, uuid := range lr.Nat {
-		nat, err := c.GetNATByUUID(uuid)
-		if err != nil {
-			if errors.Is(err, client.ErrNotFound) {
-				continue
-			}
-			klog.Error(err)
-			return nil, err
-		}
-		if filter == nil || filter(nat) {
-			natList = append(natList, nat)
-		}
+	if err = c.WhereCache(predicate).List(context.Background(), &natList); err != nil {
+		klog.Error(err)
+		return nil, err
 	}
 
 	return natList, nil

--- a/pkg/ovs/ovn-nb-nat_test.go
+++ b/pkg/ovs/ovn-nb-nat_test.go
@@ -554,6 +554,14 @@ func (suite *OvnClientTestSuite) testGetNat() {
 	err := nbClient.CreateLogicalRouter(lrName)
 	require.NoError(t, err)
 
+	t.Run("empty logical router returns no nats without scanning cache", func(t *testing.T) {
+		emptyLR := "test_get_nat_empty_lr"
+		require.NoError(t, nbClient.CreateLogicalRouter(emptyLR))
+		nats, err := nbClient.ListNats(emptyLR, "", "", nil)
+		require.NoError(t, err)
+		require.Empty(t, nats)
+	})
+
 	t.Run("snat", func(t *testing.T) {
 		t.Parallel()
 		natType := "snat"

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -1326,7 +1326,7 @@ func Test_scratch(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func newOVSDBServer(t *testing.T, name string, dbModel model.ClientDBModel, schema ovsdb.DatabaseSchema) (*server.OvsdbServer, string) {
+func newOVSDBServer(t testing.TB, name string, dbModel model.ClientDBModel, schema ovsdb.DatabaseSchema) (*server.OvsdbServer, string) {
 	serverDBModel, err := serverdb.FullDatabaseModel()
 	require.NoError(t, err)
 	serverSchema := serverdb.Schema()
@@ -1366,7 +1366,7 @@ func newOVSDBServer(t *testing.T, name string, dbModel model.ClientDBModel, sche
 	return server, tmpfile
 }
 
-func newOvnNbClient(t *testing.T, ovnNbAddr string, ovnNbTimeout int) (*OVNNbClient, error) {
+func newOvnNbClient(t testing.TB, ovnNbAddr string, ovnNbTimeout int) (*OVNNbClient, error) {
 	nbClient, err := newNbClient(ovnNbAddr, ovnNbTimeout)
 	require.NoError(t, err)
 

--- a/pkg/ovs/wherecache_bench_test.go
+++ b/pkg/ovs/wherecache_bench_test.go
@@ -1,0 +1,115 @@
+package ovs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+)
+
+// benchNatSink keeps benchmark results live so the compiler can't elide the work.
+var benchNatSink []*ovnnb.NAT
+
+// listNatOldLoop reproduces the pre-optimization helper: one GetNATByUUID
+// (context.WithTimeout + reflection + double deep clone) per UUID in lr.Nat.
+func listNatOldLoop(c *OVNNbClient, lrName string) ([]*ovnnb.NAT, error) {
+	lr, err := c.GetLogicalRouter(lrName, false)
+	if err != nil {
+		return nil, err
+	}
+	natList := make([]*ovnnb.NAT, 0, len(lr.Nat))
+	for _, uuid := range lr.Nat {
+		nat, err := c.GetNATByUUID(uuid)
+		if err != nil {
+			if errors.Is(err, client.ErrNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		natList = append(natList, nat)
+	}
+	return natList, nil
+}
+
+func newBenchNbClient(b testing.TB, name string) *OVNNbClient {
+	b.Helper()
+	dbModel, err := ovnnb.FullDatabaseModel()
+	require.NoError(b, err)
+	_, sock := newOVSDBServer(b, name, dbModel, ovnnb.Schema())
+	c, err := newOvnNbClient(b, "unix:"+sock, 10)
+	require.NoError(b, err)
+	return c
+}
+
+// seedNats creates `count` snat rules on lrName (single transaction).
+func seedNats(b testing.TB, c *OVNNbClient, lrName string, count int) {
+	b.Helper()
+	require.NoError(b, c.CreateLogicalRouter(lrName))
+	nats := make([]*ovnnb.NAT, 0, count)
+	for i := range count {
+		logicalIP := fmt.Sprintf("10.16.%d.%d", i/256, i%256)
+		nat, err := c.newNat(lrName, "snat", "192.168.0.1", logicalIP, "", "")
+		require.NoError(b, err)
+		nats = append(nats, nat)
+	}
+	require.NoError(b, c.CreateNats(lrName, nats...))
+}
+
+// BenchmarkListNAT compares the per-UUID Get loop against the single
+// WhereCache().List() scan. `target` is the NAT count on the router we list;
+// `others` is unrelated NAT rows on a second router that bloat the table but
+// must be filtered out (the N << T boundary case).
+func BenchmarkListNAT(b *testing.B) {
+	cases := []struct {
+		label  string
+		target int
+		others int
+	}{
+		{"AllOnOneLR_N100", 100, 0},
+		{"AllOnOneLR_N1000", 1000, 0},
+		{"SmallLR_N10_inBigTable_T2010", 10, 2000},
+	}
+
+	for idx, tc := range cases {
+		c := newBenchNbClient(b, fmt.Sprintf("bench-nb-%d", idx))
+		const lrName = "bench-target-lr"
+		seedNats(b, c, lrName, tc.target)
+		if tc.others > 0 {
+			seedNats(b, c, "bench-other-lr", tc.others)
+		}
+
+		b.Run(tc.label+"/old_GetLoop", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				res, err := listNatOldLoop(c, lrName)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchNatSink = res
+			}
+		})
+
+		b.Run(tc.label+"/new_WhereCache", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				res, err := c.listLogicalRouterNatByFilter(lrName, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchNatSink = res
+			}
+		})
+
+		// sanity: both paths must return the same number of rows
+		oldRes, err := listNatOldLoop(c, lrName)
+		require.NoError(b, err)
+		newRes, err := c.listLogicalRouterNatByFilter(lrName, nil)
+		require.NoError(b, err)
+		require.Len(b, newRes, len(oldRes))
+		require.Len(b, newRes, tc.target)
+	}
+}


### PR DESCRIPTION
## Summary
- Rewrite `listLogicalRouterNatByFilter` and `listLogicalRouterStaticRoutesByFilter` to do a single `WhereCache().List()` filtered by a UUID set, instead of looping `GetXByUUID` per UUID in `lr.Nat` / `lr.StaticRoutes`.
- This mirrors the already-merged pattern in `listLogicalRouterPoliciesByFilter` (#4895) and the in-tree `batchListLogicalRouterStaticRoutesForDelete`.
- Drops the per-row `context.WithTimeout` allocation and the second deep clone done for every row; only matched rows are cloned. Also removes the now-unused `GetLogicalRouterStaticRouteByUUID` helper.

## Notes
- Behavior is equivalent except result ordering, which becomes non-deterministic (map iteration). Audited all callers of `ListNats` / `ListLogicalRouterStaticRoutes` / `ListLogicalRouterStaticRoutesByOption`: every consumer iterates the full list by key or only checks `len()==0` — none index `[0]` or rely on order. The single-result getters (`GetNat`, `GetLogicalRouterStaticRoute`) filter by a unique key and error on `>1`, so they are unaffected.
- `GetNATByUUID` is kept (still used by `pkg/controller/vpc.go` and the `OVNNbClient` interface).

## Test plan
- [x] `go build ./pkg/...`
- [x] `go vet ./pkg/ovs`
- [x] `make lint` (0 issues)
- [x] Targeted unit tests: `Test_GetNat`, `Test_ListNats`, `Test_DeleteNats`, `Test_AddNat`, `Test_GetNATByUUID`, `Test_*LogicalRouterStaticRoute*` (incl. ecmp, edge cases, batch delete) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)