### PR TITLE
fix(loadbalancer): clean ipv6 ip_port_mappings without health check

### DIFF
--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -155,15 +155,14 @@ func (c *OVNNbClient) LoadBalancerDeleteVip(lbName, vipEndpoint string, ignoreHe
 		return err
 	}
 	if len(lb.IPPortMappings) != 0 {
-		ignoreHealthCheck = false
-	}
-	if !ignoreHealthCheck && lbhc != nil {
-		klog.Infof("clean health check for lb %s with vip %s", lbName, vipEndpoint)
-		// delete ip port mapping
+		klog.Infof("clean ip port mapping for lb %s with vip %s", lbName, vipEndpoint)
 		if err = c.LoadBalancerDeleteIPPortMapping(lbName, vipEndpoint); err != nil {
 			klog.Errorf("failed to delete lb ip port mapping: %v", err)
 			return err
 		}
+	}
+	if !ignoreHealthCheck && lbhc != nil {
+		klog.Infof("clean health check for lb %s with vip %s", lbName, vipEndpoint)
 		if err = c.LoadBalancerDeleteHealthCheck(lbName, lbhc.UUID); err != nil {
 			klog.Errorf("failed to delete lb health check: %v", err)
 			return err
@@ -580,8 +579,11 @@ func (c *OVNNbClient) findUnusedBackendIPs(lb *ovnnb.LoadBalancer, targetVIP str
 
 	for backendIP := range targetBackendIPs {
 		if !c.isBackendIPStillUsed(lb, targetVIP, backendIP) {
-			if portMapping, exists := lb.IPPortMappings[backendIP]; exists {
-				unusedBackendIPs[backendIP] = portMapping
+			cleanBackendIP := strings.Trim(backendIP, "[]")
+			for mappingKey, portMapping := range lb.IPPortMappings {
+				if strings.Trim(mappingKey, "[]") == cleanBackendIP {
+					unusedBackendIPs[mappingKey] = portMapping
+				}
 			}
 		}
 	}

--- a/pkg/ovs/ovn-nb-load_balancer_test.go
+++ b/pkg/ovs/ovn-nb-load_balancer_test.go
@@ -662,6 +662,42 @@ func (suite *OvnClientTestSuite) testLoadBalancerDeleteVip() {
 	require.NoError(t, err)
 	require.Equal(t, vips, lb.Vips)
 
+	t.Run("delete vip cleans ipv6 ip port mappings without health check", func(t *testing.T) {
+		lbName := "test-lb-del-vip-ipv6-ip-port-mapping"
+		vip1 := "[fd00:10:96::1]:80"
+		vip2 := "[fd00:10:96::2]:80"
+
+		err := nbClient.CreateLoadBalancer(lbName, "tcp")
+		require.NoError(t, err)
+
+		err = nbClient.LoadBalancerAddVip(lbName, vip1, "[fc00::1]:80", "[fc00::2]:80")
+		require.NoError(t, err)
+		err = nbClient.LoadBalancerAddVip(lbName, vip2, "[fc00::2]:80", "[fc00::3]:80")
+		require.NoError(t, err)
+
+		err = nbClient.LoadBalancerUpdateIPPortMapping(lbName, vip1, map[string]string{
+			"[fc00::1]": "pod-a.ns:0.0.0.0",
+			"[fc00::2]": "pod-shared.ns:0.0.0.0",
+		})
+		require.NoError(t, err)
+		err = nbClient.LoadBalancerUpdateIPPortMapping(lbName, vip2, map[string]string{
+			"[fc00::2]": "pod-shared.ns:0.0.0.0",
+			"[fc00::3]": "pod-b.ns:0.0.0.0",
+		})
+		require.NoError(t, err)
+
+		err = nbClient.LoadBalancerDeleteVip(lbName, vip1, true)
+		require.NoError(t, err)
+
+		lb, err := nbClient.GetLoadBalancer(lbName, false)
+		require.NoError(t, err)
+		require.NotContains(t, lb.Vips, vip1)
+		require.Contains(t, lb.Vips, vip2)
+		require.NotContains(t, lb.IPPortMappings, "[fc00::1]")
+		require.Contains(t, lb.IPPortMappings, "[fc00::2]")
+		require.Contains(t, lb.IPPortMappings, "[fc00::3]")
+	})
+
 	err = nbClient.LoadBalancerAddHealthCheck(lbName, "10.107.43.239:8080", false, nil, nil)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- clean `ip_port_mappings` when deleting a VIP even if the VIP has no load balancer health check
- keep health check deletion controlled by `ignoreHealthCheck` and `lbhc != nil`
- normalize IPv6 mapping keys while deleting unused backend mappings so bracketed NBDB keys such as `[fc00::1]` are removed correctly

## Why
The MetalLB underlay IPv6 e2e path has prefer-local `ip_port_mappings` but no load balancer health check. Deleting LB-A removed the VIP but left LB-A backend mappings on the shared cluster TCP load balancer.

## Test Plan
- `go test ./pkg/ovs -run 'TestOvnClientTestSuite/Test_LoadBalancerDeleteVip' -count=1`
- `go test ./pkg/ovs -run 'TestOvnClientTestSuite/Test_LoadBalancer(DeleteVip|DeleteIPPortMapping|WithHealthCheck)' -count=1`