### PR TITLE
fix: bump Go version to 1.26.4

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 # renovate: datasource=golang-version depName=go
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 FROM ubuntu:24.04 AS openssl-builder
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeovn/kube-ovn
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
## Summary
- bump the module Go version from 1.26.3 to 1.26.4
- update the base image Go build argument to 1.26.4

## CVE
- fixes Go stdlib vulnerabilities reported against binaries built with Go 1.26.3
- fixed version: Go 1.26.4

## Verification
- go mod tidy
- rg -n "go 1\.26\.3|GO_VERSION=1\.26\.3|golang:1\.26\.3|1\.26\.3" "go.mod" "dist/images" ".github" "Makefile" "build.mk" -g '!CHANGELOG.md'
