### PR TITLE
fix(controller): avoid nil pointer panic in chassis and static route gc

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -1013,13 +1013,18 @@ func (c *Controller) gcStaticRoute() error {
 			if exist {
 				continue
 			}
+			// policy is optional in the OVN schema; an unset value defaults to dst-ip
+			policy := ovnnb.LogicalRouterStaticRoutePolicyDstIP
+			if route.Policy != nil {
+				policy = *route.Policy
+			}
 			klog.Infof("gc static route %s %v %s %s", route.RouteTable, route.Policy, route.IPPrefix, route.Nexthop)
 			if err = c.deleteStaticRouteFromVpc(
 				c.config.ClusterRouter,
 				route.RouteTable,
 				route.IPPrefix,
 				route.Nexthop,
-				reversePolicy(*route.Policy),
+				reversePolicy(policy),
 			); err != nil {
 				klog.Errorf("failed to delete stale route %s %v %s %s: %v", route.RouteTable, route.Policy, route.IPPrefix, route.Nexthop, err)
 			}
@@ -1034,6 +1039,7 @@ func (c *Controller) gcChassis() error {
 	chassises, err := c.OVNSbClient.ListChassis()
 	if err != nil {
 		klog.Errorf("failed to get all chassis, %v", err)
+		return err
 	}
 	chassisNodes := make(map[string]string, len(*chassises))
 	for _, chassis := range *chassises {

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -1018,7 +1018,7 @@ func (c *Controller) gcStaticRoute() error {
 			if route.Policy != nil {
 				policy = *route.Policy
 			}
-			klog.Infof("gc static route %s %v %s %s", route.RouteTable, route.Policy, route.IPPrefix, route.Nexthop)
+			klog.Infof("gc static route %s %v %s %s", route.RouteTable, policy, route.IPPrefix, route.Nexthop)
 			if err = c.deleteStaticRouteFromVpc(
 				c.config.ClusterRouter,
 				route.RouteTable,
@@ -1026,7 +1026,7 @@ func (c *Controller) gcStaticRoute() error {
 				route.Nexthop,
 				reversePolicy(policy),
 			); err != nil {
-				klog.Errorf("failed to delete stale route %s %v %s %s: %v", route.RouteTable, route.Policy, route.IPPrefix, route.Nexthop, err)
+				klog.Errorf("failed to delete stale route %s %v %s %s: %v", route.RouteTable, policy, route.IPPrefix, route.Nexthop, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- `gcChassis` logged the `ListChassis` error but did not return, then dereferenced the nil result. Since libovsdb `List` runs an echo RPC and returns `ErrNotConnected` during the SB DB disconnect/reconnect window, a transient SB DB outage panicked the whole controller process. Now it returns the error like every other `gc*` function.
- `gcStaticRoute` dereferenced `route.Policy` unconditionally, but `policy` is optional in the OVN schema (`omitempty`) and may be nil for manually or third-party created routes. Normalize an unset policy to the `dst-ip` default, matching the convention in `ovn-nb-logical_router_route.go`.

## Test plan
- [x] `go build ./pkg/controller/`
- [x] `make lint` (0 issues, CRDs in sync)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)