### PR TITLE
fix(controller): skip orphaned subnet instead of breaking namespace subnet loop

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -202,6 +202,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	vpcNatGwInformer := kubeovnInformerFactory.Kubeovn().V1().VpcNatGateways()
 	vlanInformer := kubeovnInformerFactory.Kubeovn().V1().Vlans()
 	providerNetworkInformer := kubeovnInformerFactory.Kubeovn().V1().ProviderNetworks()
+	ippoolInformer := kubeovnInformerFactory.Kubeovn().V1().IPPools()
 
 	fakeInformers := &fakeControllerInformers{
 		vpcInformer:       vpcInformer,
@@ -231,6 +232,8 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		vpcSynced:               alwaysReady,
 		subnetsLister:           subnetInformer.Lister(),
 		subnetSynced:            alwaysReady,
+		ippoolLister:            ippoolInformer.Lister(),
+		ippoolSynced:            alwaysReady,
 		ipsLister:               ipInformer.Lister(),
 		ipSynced:                alwaysReady,
 		vlansLister:             vlanInformer.Lister(),
@@ -243,6 +246,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		ipam:                    ovnipam.NewIPAM(),
 		recorder:                record.NewFakeRecorder(100),
 		subnetKeyMutex:          keymutex.NewHashed(0),
+		nsKeyMutex:              keymutex.NewHashed(0),
 		addOrUpdateSubnetQueue:  newTypedRateLimitingQueue[string]("AddOrUpdateSubnet", nil),
 		syncVirtualPortsQueue:   newTypedRateLimitingQueue[string]("SyncVirtualPort", nil),
 		updateSubnetStatusQueue: newTypedRateLimitingQueue[string]("UpdateSubnetStatus", nil),

--- a/pkg/controller/namespace.go
+++ b/pkg/controller/namespace.go
@@ -156,9 +156,10 @@ func (c *Controller) handleAddNamespace(key string) error {
 			vpc, err := c.vpcsLister.Get(s.Spec.Vpc)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					// this subnet is broken (it references a non-existent VPC) - we just ignore it.
+					// this subnet is broken (it references a non-existent VPC) - we just ignore it
+					// and keep evaluating the remaining subnets.
 					klog.Errorf("vpc %q is not found. Ignoring subnet %q: %v", s.Spec.Vpc, s.Name, err)
-					break
+					continue
 				}
 				klog.Errorf("failed to get vpc %q: %v", s.Spec.Vpc, err)
 				return err

--- a/pkg/controller/namespace_test.go
+++ b/pkg/controller/namespace_test.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+// Test_handleAddNamespace_orphanedSubnet is a regression guard for the bug where
+// a subnet referencing a non-existent VPC aborted evaluation of the whole subnet
+// list. The orphan handling used to `break` the `for _, s := range subnets` loop,
+// so any valid subnet returned by the lister after the orphaned one was never
+// bound to the namespace. The fix replaces `break` with `continue`, so the valid
+// subnet must always be bound regardless of the (random) lister iteration order.
+func Test_handleAddNamespace_orphanedSubnet(t *testing.T) {
+	const nsName = "test-ns"
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: nsName},
+	}
+	// A broken subnet whose referenced VPC does not exist - it must not stop the
+	// loop from reaching the valid subnet below.
+	orphanSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       "ghost-vpc",
+			CIDRBlock: "10.16.0.0/16",
+		},
+	}
+	// A valid subnet that binds the namespace via Spec.Namespaces.
+	validSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "valid-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			Namespaces: []string{nsName},
+			CIDRBlock:  "10.17.0.0/16",
+		},
+	}
+
+	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Namespaces: []*corev1.Namespace{ns},
+		Subnets:    []*kubeovnv1.Subnet{orphanSubnet, validSubnet},
+	})
+	require.NoError(t, err)
+	ctrl := fakeCtrl.fakeController
+
+	require.NoError(t, ctrl.handleAddNamespace(nsName))
+
+	got, err := ctrl.config.KubeClient.CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	lss := strings.Split(got.Annotations[util.LogicalSwitchAnnotation], ",")
+	require.Contains(t, lss, validSubnet.Name, "valid subnet must be bound even when an orphaned subnet is present")
+	require.NotContains(t, lss, orphanSubnet.Name, "broken subnet must not be bound to the namespace")
+}


### PR DESCRIPTION
## Summary
- In `handleAddNamespace`, a subnet referencing a non-existent VPC triggered `break`, which terminated the entire `for _, s := range subnets` loop instead of skipping only that broken subnet.
- Because lister iteration order is non-deterministic, any valid subnet returned after an orphaned one was never evaluated for namespace binding, leaving the namespace with incomplete/wrong `logical_switch`/`cidr`/`exclude_ips` annotations — new pods could then land on the wrong subnet or fall back to the default subnet, breaking network isolation.
- Replace `break` with `continue` so only the broken subnet is skipped, matching the intent of the existing "we just ignore it" comment.

## Test plan
- [x] `make lint` — 0 issues
- [x] `go build ./pkg/controller/` passes
- [ ] Existing namespace/subnet e2e remain green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)