### PR TITLE
test(e2e): require v1.17+ for non-primary CNI iptables cleanup test

### DIFF
--- a/test/e2e/non-primary-cni/e2e_test.go
+++ b/test/e2e/non-primary-cni/e2e_test.go
@@ -696,7 +696,7 @@ var _ = framework.SerialDescribe("[group:non-primary-cni]", func() {
 
 		ginkgo.BeforeEach(func() {
 			cs = f.ClientSet
-			f.SkipVersionPriorTo(1, 16, "iptables cleanup in non-primary CNI mode requires v1.16+")
+			f.SkipVersionPriorTo(1, 17, "iptables cleanup in non-primary CNI mode requires v1.17+")
 		})
 
 		ginkgo.It("Should not have kube-ovn iptables chains or rules in non-primary CNI mode", func() {


### PR DESCRIPTION
## Summary
- The non-primary CNI iptables cleanup test (`Should not have kube-ovn iptables chains or rules in non-primary CNI mode`) was guarded with `f.SkipVersionPriorTo(1, 16, ...)`, but the feature it covers (#6462) only landed on **master** (`VERSION` v1.17.0) and was **not** backported to release branches.
- Release-branch CI checks out the **default-branch (master)** e2e source and runs it against the PR branch's image. So on every `release-1.16` PR this test ran against a cluster **without** #6462 and failed deterministically — `runGateway`→`setIptables` keeps creating the `OVN-PREROUTING/POSTROUTING/MASQUERADE/NAT-POLICY` chains.
- `SkipVersionPriorTo` uses **strict less-than** (`KubeOVNVersion.LessThan`), so `(1, 16)` does **not** skip on 1.16. Bump to `(1, 17)` — the version where the feature actually ships.

## Effect

| guard | master CI (999.999) | release-1.16 (1.16) | release-1.15 (1.15) |
|-------|--------------------|---------------------|---------------------|
| `(1,16)` before | runs ✅ | **runs → fails ❌** | skipped ✅ |
| `(1,17)` after  | runs ✅ | skipped ✅ | skipped ✅ |

master CI keeps running the test because `E2E_BRANCH` is unset there → framework version `999.999` (`test/e2e/framework/framework.go:89`).

## Test Plan
- `make lint` (0 issues)
- Behavior verified by reasoning over `framework.SkipVersionPriorTo` semantics; no functional code changed (test guard only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)