### PR TITLE
fix(ovs): check error before dereferencing logical router on static route deletion

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -150,7 +150,11 @@ func (c *OVNNbClient) DeleteLogicalRouterStaticRoute(lrName string, routeTable, 
 	}
 
 	lr, err := c.GetLogicalRouter(lrName, true)
-	if lr == nil && err == nil {
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if lr == nil {
 		return nil
 	}
 
@@ -250,7 +254,11 @@ func (c *OVNNbClient) DeleteLogicalRouterStaticRouteByExternalIDs(lrName string,
 // BatchDeleteLogicalRouterStaticRoute batch delete a logical router static route
 func (c *OVNNbClient) BatchDeleteLogicalRouterStaticRoute(lrName string, staticRoutes []*ovnnb.LogicalRouterStaticRoute) error {
 	lr, err := c.GetLogicalRouter(lrName, true)
-	if lr == nil && err == nil {
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if lr == nil {
 		return nil
 	}
 

--- a/pkg/ovs/ovn-nb-logical_router_route_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_route_test.go
@@ -336,6 +336,16 @@ func (suite *OvnClientTestSuite) testDeleteLogicalRouterStaticRoute() {
 		require.NoError(t, err)
 	})
 
+	t.Run("delete static route for duplicate logical router", func(t *testing.T) {
+		dupLrName := "test-del-route-dup-lr"
+		dupLr := &ovnnb.LogicalRouter{Name: dupLrName}
+		require.NoError(t, createLogicalRouter(nbClient, dupLr))
+		require.NoError(t, createLogicalRouter(nbClient, dupLr))
+
+		err := nbClient.DeleteLogicalRouterStaticRoute(dupLrName, &routeTable, &policy, "192.168.30.0/24", "192.168.30.1")
+		require.ErrorContains(t, err, "more than one logical router with same name")
+	})
+
 	t.Run("ecmp policy route", func(t *testing.T) {
 		ipPrefix := "192.168.40.0/24"
 		nexthops := []string{"192.168.50.1", "192.168.60.1"}
@@ -908,5 +918,15 @@ func (suite *OvnClientTestSuite) testBatchDeleteLogicalRouterStaticRoute() {
 	t.Run("delete static route for non-exist logical router", func(t *testing.T) {
 		err := nbClient.BatchDeleteLogicalRouterStaticRoute("non-exist-lrName", []*ovnnb.LogicalRouterStaticRoute{staticRouter})
 		require.NoError(t, err)
+	})
+
+	t.Run("delete static route for duplicate logical router", func(t *testing.T) {
+		dupLrName := "test-batch-del-route-dup-lr"
+		dupLr := &ovnnb.LogicalRouter{Name: dupLrName}
+		require.NoError(t, createLogicalRouter(nbClient, dupLr))
+		require.NoError(t, createLogicalRouter(nbClient, dupLr))
+
+		err := nbClient.BatchDeleteLogicalRouterStaticRoute(dupLrName, []*ovnnb.LogicalRouterStaticRoute{staticRouter})
+		require.ErrorContains(t, err, "more than one logical router with same name")
 	})
 }


### PR DESCRIPTION
## Summary
- `BatchDeleteLogicalRouterStaticRoute` only guarded the not-found-without-error case (`lr == nil && err == nil`) after `GetLogicalRouter`, so a lookup failure (NB connection loss, cache timeout, or duplicate router names) fell through with a nil router and crashed kube-ovn-controller on `lr.StaticRoutes` during node route initialization, masking the real error behind a nil pointer panic.
- `DeleteLogicalRouterStaticRoute` had the same guard pattern; it did not panic but silently swallowed the lookup error. Both now return the error first, matching `DeleteLogicalRouterStaticRouteByUUID`.
- Added unit tests that deterministically hit the `(nil, err)` path via duplicate logical router names; the batch-variant test reproduces the nil pointer panic on the previous code.

## Test plan
- [x] New unit tests `delete static route for duplicate logical router` for both functions pass
- [x] Verified the new batch test panics with `nil pointer dereference` on the code before this fix
- [x] `make lint` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)