### PR TITLE
fix(controller): avoid nil pointer panic when attachment default subnet is gone

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2091,6 +2091,12 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 					}
 					return nil, err
 				}
+				if subnet == nil {
+					// getPodDefaultSubnet returns (nil, nil) when the deleting pod's default subnet
+					// no longer exists, leave the orphaned ip cr to gc instead of dereferencing nil
+					klog.Errorf("deleting pod %s/%s default subnet for attach %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, attach.Name)
+					continue
+				}
 				// default subnet may change after pod restart
 				klog.Infof("pod %s/%s attachment network %s use default subnet %s", pod.Namespace, pod.Name, attach.Name, subnet.Name)
 			} else {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -943,3 +943,51 @@ func TestHasAliveSiblingVMPod(t *testing.T) {
 		})
 	}
 }
+
+// TestGetPodAttachmentNetDefaultSubnetGone guards against a nil pointer panic:
+// for a terminating pod whose OVN attachment network resolves to no subnet
+// (no per-provider logical_switch annotation and no matching Subnet.Spec.Provider),
+// getPodAttachmentNet falls back to getPodDefaultSubnet, which returns (nil, nil)
+// when the pod's top-level logical_switch annotation points at an already-deleted
+// subnet. The attachment must be skipped so gc can clean its ip cr.
+func TestGetPodAttachmentNetDefaultSubnetGone(t *testing.T) {
+	now := metav1.Now()
+	grace := int64(0)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       "test-pod",
+			Namespace:                  metav1.NamespaceDefault,
+			DeletionTimestamp:          &now,
+			DeletionGracePeriodSeconds: &grace,
+			Annotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: `[{"name": "net1"}]`,
+				// top-level default subnet points at a subnet that no longer exists
+				util.LogicalSwitchAnnotation: "deleted-subnet",
+				// no per-provider net1.default.ovn logical_switch annotation, so the
+				// attachment cannot resolve a subnet and falls back to the default
+			},
+		},
+	}
+
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		// NAD is an OVN network but no Subnet has Provider == net1.default.ovn
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "net1",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: nadv1.NetworkAttachmentDefinitionSpec{
+					Config: `{"cniVersion": "0.3.1", "name": "net1", "type": "kube-ovn"}`,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	controller := fakeController.fakeController
+
+	// must not panic; the unresolvable attachment is skipped
+	nets, err := controller.getPodAttachmentNet(pod)
+	require.NoError(t, err)
+	assert.Empty(t, nets)
+}


### PR DESCRIPTION
## Summary
- `getPodAttachmentNet` falls back to `getPodDefaultSubnet` when an OVN attachment network resolves to no subnet (no per-provider `logical_switch` annotation and no matching `Subnet.Spec.Provider`).
- For a terminating pod whose top-level `ovn.kubernetes.io/logical_switch` annotation points at an already-deleted subnet, `getPodDefaultSubnet` returns `(nil, nil)` to leave the orphaned ip cr for gc. The caller only checked the error and then dereferenced `subnet.Name`, panicking the controller process (no recover in the worker loop → crashloop while the pod stays Terminating).
- Skip the unresolvable attachment when the default subnet is nil, matching the other not-found branches in the same function.

The missing nil check was introduced together with the `(nil, nil)` contract in #5364; `getPodKubeovnNets` got the guard but `getPodAttachmentNet` did not. release-1.16 and release-1.15 carry the same unguarded code and need the backport.

## Test plan
- [x] New unit test `TestGetPodAttachmentNetDefaultSubnetGone` reproduces the exact `nil pointer dereference` panic without the fix and passes with it.
- [x] `make lint` → 0 issues.
- [x] `go test ./pkg/controller/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)