### PR TITLE
fix(controller): avoid wiping priority-0 CNP map entries on zero-value key

### DIFF
--- a/pkg/controller/cluster_network_policy.go
+++ b/pkg/controller/cluster_network_policy.go
@@ -1005,8 +1005,13 @@ func (c *Controller) wipeCnpPriorityMapEntries(cnp *v1alpha2.ClusterNetworkPolic
 			return fmt.Errorf("failed to get priority maps for cnp %s: %w", cnp.Name, err)
 		}
 
-		delete(priorityNameMap, namePriorityMap[cnp.Name])
-		delete(namePriorityMap, cnp.Name)
+		// Only delete by priority when the CNP actually has an entry in this tier;
+		// otherwise the zero value 0 would wipe the entry of the CNP legitimately
+		// registered at priority 0 in this tier.
+		if priority, ok := namePriorityMap[cnp.Name]; ok {
+			delete(priorityNameMap, priority)
+			delete(namePriorityMap, cnp.Name)
+		}
 	}
 
 	return nil

--- a/pkg/controller/cluster_network_policy_test.go
+++ b/pkg/controller/cluster_network_policy_test.go
@@ -1335,6 +1335,31 @@ func TestUpdateCnpPriorityMapEntries(t *testing.T) {
 		require.Equal(t, "test3", ctrl.bnpPrioNameMap[1004])
 		require.Equal(t, int32(1004), ctrl.bnpNamePrioMap[cnp.Name])
 	})
+
+	t.Run("new cnp should not wipe priority 0 entries", func(t *testing.T) {
+		ctrl.anpPrioNameMap = map[int32]string{0: "admin-zero"}
+		ctrl.anpNamePrioMap = map[string]int32{"admin-zero": 0}
+		ctrl.bnpPrioNameMap = map[int32]string{0: "baseline-zero"}
+		ctrl.bnpNamePrioMap = map[string]int32{"baseline-zero": 0}
+
+		cnp := &v1alpha2.ClusterNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "newcomer",
+			},
+			Spec: v1alpha2.ClusterNetworkPolicySpec{
+				Tier:     v1alpha2.AdminTier,
+				Priority: 5,
+			},
+		}
+
+		err := ctrl.updateCnpPriorityMapEntries(cnp)
+		require.NoError(t, err)
+		require.Equal(t, "admin-zero", ctrl.anpPrioNameMap[0])
+		require.Equal(t, "newcomer", ctrl.anpPrioNameMap[5])
+		require.Equal(t, int32(5), ctrl.anpNamePrioMap["newcomer"])
+		require.Equal(t, "baseline-zero", ctrl.bnpPrioNameMap[0])
+		require.Equal(t, int32(0), ctrl.bnpNamePrioMap["baseline-zero"])
+	})
 }
 
 func TestWipeCnpPriorityMapEntries(t *testing.T) {
@@ -1396,6 +1421,30 @@ func TestWipeCnpPriorityMapEntries(t *testing.T) {
 		require.Equal(t, "", ctrl.anpPrioNameMap[1003])
 		require.Equal(t, int32(0), ctrl.bnpNamePrioMap[cnp.Name])
 		require.Equal(t, "", ctrl.bnpPrioNameMap[1003])
+	})
+
+	t.Run("absent cnp should not wipe priority 0 entries", func(t *testing.T) {
+		ctrl.anpPrioNameMap = map[int32]string{0: "admin-zero"}
+		ctrl.anpNamePrioMap = map[string]int32{"admin-zero": 0}
+		ctrl.bnpPrioNameMap = map[int32]string{0: "baseline-zero"}
+		ctrl.bnpNamePrioMap = map[string]int32{"baseline-zero": 0}
+
+		cnp := &v1alpha2.ClusterNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "newcomer",
+			},
+			Spec: v1alpha2.ClusterNetworkPolicySpec{
+				Tier:     v1alpha2.AdminTier,
+				Priority: 5,
+			},
+		}
+
+		err := ctrl.wipeCnpPriorityMapEntries(cnp)
+		require.NoError(t, err)
+		require.Equal(t, "admin-zero", ctrl.anpPrioNameMap[0])
+		require.Equal(t, int32(0), ctrl.anpNamePrioMap["admin-zero"])
+		require.Equal(t, "baseline-zero", ctrl.bnpPrioNameMap[0])
+		require.Equal(t, int32(0), ctrl.bnpNamePrioMap["baseline-zero"])
 	})
 }
 


### PR DESCRIPTION
## Summary

- `wipeCnpPriorityMapEntries` deleted entries from the priority->name map of both tiers using `namePriorityMap[cnp.Name]` as the key. When the CNP has no entry in a tier's name->priority map (always true for the other tier, and also for the CNP's own tier on first creation), the map read returns the zero value `int32(0)`, so `delete(priorityNameMap, 0)` silently removed the entry of whatever CNP legitimately occupies priority 0 in that tier.
- Since `checkCnpPriorities` relies on these in-memory maps as the only guard against duplicate priorities within a tier (no webhook / CRD constraint), a second CNP could then be admitted at priority 0, producing two CNPs with identical OVN ACL priorities (`30000 - priority*25 - index`) and undefined match ordering. The corruption also cascades: a later delete of the original priority-0 CNP removes the newcomer's entry as well, and a controller restart does not reliably self-heal because the informer replay re-triggers the same wipe.
- Fix: guard the deletion with a comma-ok lookup so the priority->name entry is only removed when the CNP actually has a mapping in that tier.

## Test plan

- [x] New regression subtests `TestWipeCnpPriorityMapEntries/absent cnp should not wipe priority 0 entries` and `TestUpdateCnpPriorityMapEntries/new cnp should not wipe priority 0 entries` (both fail on the old code)
- [x] `go test ./pkg/controller/ -run 'TestWipeCnpPriorityMapEntries|TestUpdateCnpPriorityMapEntries|TestCheckCnpPriorities|TestDeleteCnpPriorityMapEntries'` passes
- [x] `make lint` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)