### PR TITLE
fix(controller): avoid nil queue panic in DNS name resolver handlers

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -720,6 +720,9 @@ func Run(ctx context.Context, config *Configuration) {
 	}
 
 	if config.EnableDNSNameResolver {
+		if !config.EnableANP {
+			klog.Warning("DNS name resolver is enabled but ANP support is disabled, DNSNameResolver resources will not take effect")
+		}
 		controller.dnsNameResolversLister = dnsNameResolverInformer.Lister()
 		controller.dnsNameResolversSynced = dnsNameResolverInformer.Informer().HasSynced
 		if err := dnsNameResolverInformer.Informer().AddIndexers(cache.Indexers{

--- a/pkg/controller/dns_name_resolver.go
+++ b/pkg/controller/dns_name_resolver.go
@@ -57,6 +57,12 @@ func (c *Controller) enqueueDeleteDNSNameResolver(obj any) {
 func (c *Controller) handleAddOrUpdateDNSNameResolver(key string) error {
 	klog.Infof("DNSNameResolver add/update handler called for key: %s", key)
 
+	// the ANP/CNP update queues are constructed only when ANP support is enabled
+	if !c.config.EnableANP {
+		klog.Warningf("DNSNameResolver %s is ignored because ANP support is disabled", key)
+		return nil
+	}
+
 	dnsNameResolver, err := c.dnsNameResolversLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -90,6 +96,12 @@ func (c *Controller) handleAddOrUpdateDNSNameResolver(key string) error {
 
 func (c *Controller) handleDeleteDNSNameResolver(dnsNameResolver *kubeovnv1.DNSNameResolver) error {
 	klog.Infof("DNSNameResolver delete handler called for: %s", dnsNameResolver.Name)
+
+	// the ANP/CNP update queues are constructed only when ANP support is enabled
+	if !c.config.EnableANP {
+		klog.Warningf("DNSNameResolver %s is ignored because ANP support is disabled", dnsNameResolver.Name)
+		return nil
+	}
 
 	anpName, exists := dnsNameResolver.Labels[adminNetworkPolicyKey]
 	if !exists {

--- a/pkg/controller/dns_name_resolver_test.go
+++ b/pkg/controller/dns_name_resolver_test.go
@@ -1,0 +1,80 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	kubeovninformerfactory "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
+)
+
+func newFakeDNSNameResolverController(t *testing.T, enableANP bool, resolvers ...*kubeovnv1.DNSNameResolver) *Controller {
+	informerFactory := kubeovninformerfactory.NewSharedInformerFactory(kubeovnfake.NewSimpleClientset(), 0)
+	informer := informerFactory.Kubeovn().V1().DNSNameResolvers()
+	for _, resolver := range resolvers {
+		require.NoError(t, informer.Informer().GetIndexer().Add(resolver))
+	}
+
+	ctrl := &Controller{
+		config:                 &Configuration{EnableANP: enableANP, EnableDNSNameResolver: true},
+		dnsNameResolversLister: informer.Lister(),
+	}
+	if enableANP {
+		ctrl.updateAnpQueue = newTypedRateLimitingQueue[*AdminNetworkPolicyChangedDelta]("UpdateAdminNetworkPolicy", nil)
+		ctrl.updateCnpQueue = newTypedRateLimitingQueue[*ClusterNetworkPolicyChangedDelta]("UpdateClusterNetworkPolicy", nil)
+	}
+	return ctrl
+}
+
+func newTestDNSNameResolver() *kubeovnv1.DNSNameResolver {
+	return &kubeovnv1.DNSNameResolver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "anp-test-12345678",
+			Labels: map[string]string{adminNetworkPolicyKey: "test-anp"},
+		},
+		Spec: kubeovnv1.DNSNameResolverSpec{Name: "example.com"},
+	}
+}
+
+func Test_handleAddOrUpdateDNSNameResolver(t *testing.T) {
+	t.Run("anp disabled", func(t *testing.T) {
+		// the ANP/CNP update queues are nil when ANP support is disabled,
+		// the handler must not enqueue into them
+		resolver := newTestDNSNameResolver()
+		ctrl := newFakeDNSNameResolverController(t, false, resolver)
+		require.NotPanics(t, func() {
+			require.NoError(t, ctrl.handleAddOrUpdateDNSNameResolver(resolver.Name))
+		})
+	})
+
+	t.Run("anp enabled", func(t *testing.T) {
+		resolver := newTestDNSNameResolver()
+		ctrl := newFakeDNSNameResolverController(t, true, resolver)
+		require.NoError(t, ctrl.handleAddOrUpdateDNSNameResolver(resolver.Name))
+		require.Equal(t, 1, ctrl.updateAnpQueue.Len())
+		require.Equal(t, 1, ctrl.updateCnpQueue.Len())
+	})
+}
+
+func Test_handleDeleteDNSNameResolver(t *testing.T) {
+	t.Run("anp disabled", func(t *testing.T) {
+		// the ANP/CNP update queues are nil when ANP support is disabled,
+		// the handler must not enqueue into them
+		resolver := newTestDNSNameResolver()
+		ctrl := newFakeDNSNameResolverController(t, false)
+		require.NotPanics(t, func() {
+			require.NoError(t, ctrl.handleDeleteDNSNameResolver(resolver))
+		})
+	})
+
+	t.Run("anp enabled", func(t *testing.T) {
+		resolver := newTestDNSNameResolver()
+		ctrl := newFakeDNSNameResolverController(t, true)
+		require.NoError(t, ctrl.handleDeleteDNSNameResolver(resolver))
+		require.Equal(t, 1, ctrl.updateAnpQueue.Len())
+		require.Equal(t, 1, ctrl.updateCnpQueue.Len())
+	})
+}


### PR DESCRIPTION
## Summary

- With `--enable-dns-name-resolver=true` and `--enable-anp=false`, `updateAnpQueue`/`updateCnpQueue` are never constructed (they are only built inside the `EnableANP` block in `Run()`), but the DNSNameResolver informer and workers are wired independently by `EnableDNSNameResolver`.
- Any DNSNameResolver CR carrying the `anp` label (typically left over after disabling ANP, since nothing garbage-collects them) drives `handleAddOrUpdateDNSNameResolver`/`handleDeleteDNSNameResolver` into calling `Add` on a nil workqueue. The worker chain has no recover, so the panic kills the whole kube-ovn-controller process, and the informer's initial list replays the event after every restart — an unrecoverable crash loop.
- Fix: skip both handlers when ANP support is disabled, and log a startup warning that the configuration is ineffective. Added unit tests covering both the disabled (nil queues, no panic) and enabled (deltas enqueued) paths.

## Test plan

- [x] `go test ./pkg/controller/ -run 'Test_handleAddOrUpdateDNSNameResolver|Test_handleDeleteDNSNameResolver' -count=1`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)