### PR TITLE
fix(controller): correct EIP v6 label update in SNAT/DNAT status patch

### DIFF
--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -529,10 +529,11 @@ func (c *Controller) patchOvnDnatStatus(key, vpcName, v4Eip, v6Eip, internalV4Ip
 			util.EipV4IpLabel: v4Eip,
 			util.EipV6IpLabel: v6Eip,
 		}
-	} else if dnat.Labels[util.EipV4IpLabel] != v4Eip {
+	} else if dnat.Labels[util.EipV4IpLabel] != v4Eip || dnat.Labels[util.EipV6IpLabel] != v6Eip {
 		op = "replace"
 		needUpdateLabel = true
 		dnat.Labels[util.EipV4IpLabel] = v4Eip
+		dnat.Labels[util.EipV6IpLabel] = v6Eip
 	}
 	if needUpdateLabel {
 		patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -390,11 +390,11 @@ func (c *Controller) patchOvnSnatStatus(key, vpc, v4Eip, v6Eip, v4IpCidr, v6IpCi
 			util.EipV4IpLabel: v4Eip,
 			util.EipV6IpLabel: v6Eip,
 		}
-	} else if snat.Labels[util.EipV4IpLabel] != v4Eip {
+	} else if snat.Labels[util.EipV4IpLabel] != v4Eip || snat.Labels[util.EipV6IpLabel] != v6Eip {
 		op = "replace"
 		needUpdateLabel = true
 		snat.Labels[util.EipV4IpLabel] = v4Eip
-		snat.Labels[util.EipV6IpLabel] = v4Eip
+		snat.Labels[util.EipV6IpLabel] = v6Eip
 	}
 	if needUpdateLabel {
 		patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`


### PR DESCRIPTION
## Summary
- `patchOvnSnatStatus`: the label replace branch assigned the IPv4 EIP value to `EipV6IpLabel` (copy-paste error); now assigns `v6Eip`.
- `patchOvnDnatStatus`: the replace branch did not update `EipV6IpLabel` at all, leaving it stale; now updates it alongside the v4 label.
- Both replace branches now also trigger when only the v6 EIP differs, so IPv6-only EIP changes are not missed (previously the condition only checked the v4 label, which is always empty on IPv6-only clusters).

A wrong/stale v6 label breaks the validating webhook's `isOvnEipInUse` check, which lists NAT rules by matching both `EipV4IpLabel` and `EipV6IpLabel`, allowing the deletion of an OvnEip that is still referenced by a SNAT/DNAT rule.

## Test plan
- [x] `make lint` passes (0 issues)
- [x] `go build ./pkg/controller/...` compiles
- [x] Verified the replace branches now mirror the add branches for both labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)