### PR TITLE
fix(controller): mark vpc dns inactive when reconciliation fails

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 
 type fakeControllerInformers struct {
 	vpcInformer       kubeovninformer.VpcInformer
+	vpcDNSInformer    kubeovninformer.VpcDnsInformer
 	vpcNatGwInformer  kubeovninformer.VpcNatGatewayInformer
 	subnetInformer    kubeovninformer.SubnetInformer
 	ipInformer        kubeovninformer.IPInformer
@@ -197,6 +198,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		}),
 	)
 	vpcInformer := kubeovnInformerFactory.Kubeovn().V1().Vpcs()
+	vpcDNSInformer := kubeovnInformerFactory.Kubeovn().V1().VpcDnses()
 	subnetInformer := kubeovnInformerFactory.Kubeovn().V1().Subnets()
 	ipInformer := kubeovnInformerFactory.Kubeovn().V1().IPs()
 	vpcNatGwInformer := kubeovnInformerFactory.Kubeovn().V1().VpcNatGateways()
@@ -206,6 +208,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 
 	fakeInformers := &fakeControllerInformers{
 		vpcInformer:       vpcInformer,
+		vpcDNSInformer:    vpcDNSInformer,
 		vpcNatGwInformer:  vpcNatGwInformer,
 		subnetInformer:    subnetInformer,
 		ipInformer:        ipInformer,
@@ -230,6 +233,8 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		endpointSlicesLister:    endpointSliceInformer.Lister(),
 		vpcsLister:              vpcInformer.Lister(),
 		vpcSynced:               alwaysReady,
+		vpcDNSLister:            vpcDNSInformer.Lister(),
+		vpcDNSSynced:            alwaysReady,
 		subnetsLister:           subnetInformer.Lister(),
 		subnetSynced:            alwaysReady,
 		ippoolLister:            ippoolInformer.Lister(),

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -85,7 +85,9 @@ func (c *Controller) createAsForNetpol(ns, name, direction, asName string, addre
 	return nil
 }
 
-func (c *Controller) handleUpdateNp(key string) error {
+// handleUpdateNp uses a named return value so that the deferred event recorder
+// observes failures from branches that shadow err with their own declarations.
+func (c *Controller) handleUpdateNp(key string) (err error) {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))

--- a/pkg/controller/vpc_dns.go
+++ b/pkg/controller/vpc_dns.go
@@ -89,7 +89,7 @@ func (c *Controller) enqueueDeleteVPCDNS(obj any) {
 	c.delVpcDNSQueue.Add(key)
 }
 
-func (c *Controller) handleAddOrUpdateVPCDNS(key string) error {
+func (c *Controller) handleAddOrUpdateVPCDNS(key string) (err error) {
 	klog.Infof("handle add or update vpc dns %s", key)
 	if !enableCoreDNS {
 		return errors.New("failed to add or update vpc-dns, not enabled")
@@ -104,68 +104,71 @@ func (c *Controller) handleAddOrUpdateVPCDNS(key string) error {
 	}
 
 	defer func() {
-		newVPCDNS := vpcDNS.DeepCopy()
-		newVPCDNS.Status.Active = true
-		if err != nil {
-			newVPCDNS.Status.Active = false
+		active := err == nil
+		if vpcDNS.Status.Active == active {
+			return
 		}
-
-		if _, err = c.config.KubeOvnClient.KubeovnV1().VpcDnses().UpdateStatus(context.Background(),
-			newVPCDNS, metav1.UpdateOptions{}); err != nil {
-			err := fmt.Errorf("failed to update vpc dns status, %w", err)
-			klog.Error(err)
+		newVPCDNS := vpcDNS.DeepCopy()
+		newVPCDNS.Status.Active = active
+		if _, updateErr := c.config.KubeOvnClient.KubeovnV1().VpcDnses().UpdateStatus(context.Background(),
+			newVPCDNS, metav1.UpdateOptions{}); updateErr != nil {
+			updateErr = fmt.Errorf("failed to update vpc dns status, %w", updateErr)
+			klog.Error(updateErr)
+			if err == nil {
+				err = updateErr
+			}
 		}
 	}()
 
 	if len(corednsImage) == 0 {
-		err := errors.New("vpc-dns coredns image should be set")
+		err = errors.New("vpc-dns coredns image should be set")
 		klog.Error(err)
 		return err
 	}
 
 	if len(corednsVip) == 0 {
-		err := errors.New("vpc-dns corednsVip should be set")
+		err = errors.New("vpc-dns corednsVip should be set")
 		klog.Error(err)
 		return err
 	}
 
-	if _, err := c.vpcsLister.Get(vpcDNS.Spec.Vpc); err != nil {
-		err := fmt.Errorf("failed to get vpc '%s', err: %w", vpcDNS.Spec.Vpc, err)
+	if _, err = c.vpcsLister.Get(vpcDNS.Spec.Vpc); err != nil {
+		err = fmt.Errorf("failed to get vpc '%s', err: %w", vpcDNS.Spec.Vpc, err)
 		klog.Error(err)
 		return err
 	}
 
-	if _, err := c.subnetsLister.Get(vpcDNS.Spec.Subnet); err != nil {
-		err := fmt.Errorf("failed to get subnet '%s', err: %w", vpcDNS.Spec.Subnet, err)
+	if _, err = c.subnetsLister.Get(vpcDNS.Spec.Subnet); err != nil {
+		err = fmt.Errorf("failed to get subnet '%s', err: %w", vpcDNS.Spec.Subnet, err)
 		klog.Error(err)
 		return err
 	}
 
-	if err := c.checkOvnNad(); err != nil {
-		err := fmt.Errorf("failed to check nad, %w", err)
+	if err = c.checkOvnNad(); err != nil {
+		err = fmt.Errorf("failed to check nad, %w", err)
 		klog.Error(err)
 		return err
 	}
 
-	if err := c.checkVpcDNSDuplicated(vpcDNS); err != nil {
+	if err = c.checkVpcDNSDuplicated(vpcDNS); err != nil {
 		err = fmt.Errorf("failed to deploy %s, %w", vpcDNS.Name, err)
 		klog.Error(err)
 		return err
 	}
 
-	if err := c.createOrUpdateVpcDNSDep(vpcDNS); err != nil {
+	if err = c.createOrUpdateVpcDNSDep(vpcDNS); err != nil {
 		err = fmt.Errorf("failed to create or update vpc dns %s, %w", vpcDNS.Name, err)
 		klog.Error(err)
 		return err
 	}
 
-	if err := c.createOrUpdateVpcDNSSlr(vpcDNS); err != nil {
+	if err = c.createOrUpdateVpcDNSSlr(vpcDNS); err != nil {
 		err = fmt.Errorf("failed to create or update slr for vpc dns %s, %w", vpcDNS.Name, err)
 		klog.Error(err)
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func (c *Controller) handleDelVpcDNS(key string) error {

--- a/pkg/controller/vpc_dns_test.go
+++ b/pkg/controller/vpc_dns_test.go
@@ -1,0 +1,98 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+func setVpcDNSGlobals(t *testing.T) {
+	enableCoreDNSBak, corednsImageBak, corednsVipBak := enableCoreDNS, corednsImage, corednsVip
+	t.Cleanup(func() {
+		enableCoreDNS, corednsImage, corednsVip = enableCoreDNSBak, corednsImageBak, corednsVipBak
+	})
+	enableCoreDNS = true
+	corednsImage = "registry.k8s.io/coredns/coredns:v1.13.1"
+	corednsVip = "10.96.0.3"
+}
+
+func TestHandleAddOrUpdateVPCDNS(t *testing.T) {
+	setVpcDNSGlobals(t)
+
+	t.Run("mark vpc dns inactive when reconciliation fails", func(t *testing.T) {
+		fakeController := newFakeController(t)
+		ctrl := fakeController.fakeController
+
+		vpcDNS := &kubeovnv1.VpcDns{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dns"},
+			Spec: kubeovnv1.VpcDNSSpec{
+				Vpc:    "missing-vpc",
+				Subnet: "missing-subnet",
+			},
+			Status: kubeovnv1.VpcDNSStatus{Active: true},
+		}
+		_, err := ctrl.config.KubeOvnClient.KubeovnV1().VpcDnses().Create(context.Background(), vpcDNS, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NoError(t, fakeController.fakeInformers.vpcDNSInformer.Informer().GetStore().Add(vpcDNS))
+
+		require.Error(t, ctrl.handleAddOrUpdateVPCDNS(vpcDNS.Name))
+
+		updated, err := ctrl.config.KubeOvnClient.KubeovnV1().VpcDnses().Get(context.Background(), vpcDNS.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.False(t, updated.Status.Active, "vpc dns should be marked inactive when reconciliation fails")
+	})
+
+	t.Run("keep vpc dns inactive when reconciliation keeps failing", func(t *testing.T) {
+		fakeController := newFakeController(t)
+		ctrl := fakeController.fakeController
+
+		vpcDNS := &kubeovnv1.VpcDns{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dns"},
+			Spec: kubeovnv1.VpcDNSSpec{
+				Vpc:    "missing-vpc",
+				Subnet: "missing-subnet",
+			},
+		}
+		_, err := ctrl.config.KubeOvnClient.KubeovnV1().VpcDnses().Create(context.Background(), vpcDNS, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NoError(t, fakeController.fakeInformers.vpcDNSInformer.Informer().GetStore().Add(vpcDNS))
+
+		require.Error(t, ctrl.handleAddOrUpdateVPCDNS(vpcDNS.Name))
+
+		updated, err := ctrl.config.KubeOvnClient.KubeovnV1().VpcDnses().Get(context.Background(), vpcDNS.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.False(t, updated.Status.Active)
+	})
+}
+
+func TestCheckVpcDNSDuplicated(t *testing.T) {
+	addVpcDNS := func(t *testing.T, fakeController *fakeController, name, vpc string, active bool) *kubeovnv1.VpcDns {
+		vpcDNS := &kubeovnv1.VpcDns{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       kubeovnv1.VpcDNSSpec{Vpc: vpc},
+			Status:     kubeovnv1.VpcDNSStatus{Active: active},
+		}
+		require.NoError(t, fakeController.fakeInformers.vpcDNSInformer.Informer().GetStore().Add(vpcDNS))
+		return vpcDNS
+	}
+
+	t.Run("reject when another active vpc dns exists in the same vpc", func(t *testing.T) {
+		fakeController := newFakeController(t)
+		addVpcDNS(t, fakeController, "existing-dns", "vpc1", true)
+		newDNS := addVpcDNS(t, fakeController, "new-dns", "vpc1", false)
+
+		require.Error(t, fakeController.fakeController.checkVpcDNSDuplicated(newDNS))
+	})
+
+	t.Run("allow when the other vpc dns in the same vpc is inactive", func(t *testing.T) {
+		fakeController := newFakeController(t)
+		addVpcDNS(t, fakeController, "existing-dns", "vpc1", false)
+		newDNS := addVpcDNS(t, fakeController, "new-dns", "vpc1", false)
+
+		require.NoError(t, fakeController.fakeController.checkVpcDNSDuplicated(newDNS))
+	})
+}

--- a/pkg/controller/vpc_dns_test.go
+++ b/pkg/controller/vpc_dns_test.go
@@ -61,11 +61,13 @@ func TestHandleAddOrUpdateVPCDNS(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, fakeController.fakeInformers.vpcDNSInformer.Informer().GetStore().Add(vpcDNS))
 
-		require.Error(t, ctrl.handleAddOrUpdateVPCDNS(vpcDNS.Name))
+		for range 2 {
+			require.Error(t, ctrl.handleAddOrUpdateVPCDNS(vpcDNS.Name))
 
-		updated, err := ctrl.config.KubeOvnClient.KubeovnV1().VpcDnses().Get(context.Background(), vpcDNS.Name, metav1.GetOptions{})
-		require.NoError(t, err)
-		require.False(t, updated.Status.Active)
+			updated, err := ctrl.config.KubeOvnClient.KubeovnV1().VpcDnses().Get(context.Background(), vpcDNS.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.False(t, updated.Status.Active)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary
- `handleAddOrUpdateVPCDNS` decided `Status.Active` in a deferred closure based on the outer `err`, but every failure branch shadowed it with an if-scoped variable, so any reconciliation failure (missing vpc/subnet, missing nad, duplicated vpc dns, deployment/SLR API errors) still wrote `Status.Active=true` while the workqueue kept retrying.
- Since `checkVpcDNSDuplicated` uses `Status.Active` to enforce "only one vpc-dns per vpc", a falsely active vpc dns also blocked a legitimate one created later in the same vpc; the two could end up rejecting each other indefinitely with neither deployed, which is unrecoverable without deleting one CR.
- Fix: switch the handler to a named return value and assign the outer `err` in every branch so the deferred closure observes the real outcome. Also skip the status update when `Active` is unchanged (avoids rewriting the same value on every retry) and requeue when the status update itself fails instead of silently dropping it.
- `handleUpdateNp` has the same shadowing pattern defeating its deferred `CreateACLFailed` event recorder; a named return value fixes it as well.

## Test plan
- [x] New unit tests in `pkg/controller/vpc_dns_test.go`: reconciliation failure marks the vpc dns inactive (fails on the old code), repeated failure keeps it inactive, and `checkVpcDNSDuplicated` rejects/allows based on the peer's active state.
- [x] `go test ./pkg/controller/` passes.
- [x] `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)