### PR TITLE
fix(ovs): delete the actual duplicate policy instead of the kept one in batch dedup

### DIFF
--- a/pkg/ovs/ovn-nb-logical_router_policy.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy.go
@@ -276,6 +276,8 @@ func (c *OVNNbClient) BatchDeleteLogicalRouterPolicyByUUID(lrName string, uuidLi
 		return nil
 	}
 	start := time.Now()
+	// ovsdb-server rejects a mutate set containing duplicate uuids with "set contains duplicate"
+	uuidList = set.New(uuidList...).UnsortedList()
 	ops, err := c.LogicalRouterUpdatePolicyOp(lrName, uuidList, ovsdb.MutateOperationDelete)
 	if err != nil {
 		err := fmt.Errorf("generate operations for removing policies '%v' from logical router %s: %w", uuidList, lrName, err)
@@ -565,7 +567,7 @@ func (c *OVNNbClient) matchLogicalRouterPolicies(policy *ovnnb.LogicalRouterPoli
 			continue
 		}
 		if policyFound != nil {
-			duplicate = append(duplicate, policyFound.UUID)
+			duplicate = append(duplicate, policyOld.UUID)
 		} else {
 			policyFound = policyOld
 		}

--- a/pkg/ovs/ovn-nb-logical_router_policy_test.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy_test.go
@@ -775,6 +775,26 @@ func (suite *OvnClientTestSuite) testBatchAddLogicalRouterPolicy() {
 		require.Len(t, finalPolicyList, 1)
 	})
 
+	t.Run("clean up multiple exact duplicate policies in one pass", func(t *testing.T) {
+		dup1 := nbClient.newLogicalRouterPolicy(priority, match, action, nextHops, nil, nil)
+		dup2 := nbClient.newLogicalRouterPolicy(priority, match, action, nextHops, nil, nil)
+		err = nbClient.CreateLogicalRouterPolicies(lrName, dup1, dup2)
+		require.NoError(t, err)
+
+		policyList, err := nbClient.GetLogicalRouterPolicy(lrName, priority, match, false)
+		require.NoError(t, err)
+		require.Len(t, policyList, 3)
+
+		lrp.ExternalIDs = map[string]string{"dedup": "survivor"}
+		err = nbClient.BatchAddLogicalRouterPolicy(lrName, lrp)
+		require.NoError(t, err)
+
+		finalPolicyList, err := nbClient.GetLogicalRouterPolicy(lrName, priority, match, false)
+		require.NoError(t, err)
+		require.Len(t, finalPolicyList, 1)
+		require.Equal(t, lrp.ExternalIDs, finalPolicyList[0].ExternalIDs)
+	})
+
 	t.Run("update policy with different externalIDs", func(t *testing.T) {
 		initialExternalIDs := map[string]string{"key1": "value1"}
 		lrp.ExternalIDs = initialExternalIDs


### PR DESCRIPTION
## Summary

- `matchLogicalRouterPolicies` is supposed to keep the first policy that matches the incoming one on (priority, match, action, nexthops) and queue every subsequent match for deletion, but the duplicate branch appended `policyFound.UUID` (the keeper) instead of `policyOld.UUID` (the current extra row). As a result the survivor was queued for deletion while the real duplicates leaked, diverging from the reference logic in `AddLogicalRouterPolicy`.
- With 3+ identical rows the keeper UUID was queued twice, so ovsdb-server rejected the delete transaction with `set contains duplicate`. Since the only caller is the startup path `syncNodeRoutes → batchMigrateNodeRoute → BatchAddLogicalRouterPolicy`, the error escalates to `LogFatalAndExit` before workers start, crash-looping kube-ovn-controller with no self-healing path until the duplicate rows are removed by hand.
- Fix the duplicate branch to append the current duplicate's UUID, and defensively dedup the uuid list in `BatchDeleteLogicalRouterPolicyByUUID` so a repeated uuid can never poison the delete transaction again.

## Test plan

- [x] New regression subtest "clean up multiple exact duplicate policies in one pass" creates 3 identical policies and verifies one `BatchAddLogicalRouterPolicy` call converges to a single row with the updated external-ids (the existing duplicate test only covered 2 rows, where the bug also converges to 1 row and stays invisible)
- [x] Verified the new subtest fails on the unfixed code (`should have 1 item(s), but has 2`)
- [x] `go test ./pkg/ovs/ -run TestOvnClientTestSuite` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)