### PR TITLE
fix(daemon): make tproxy work with kube-ovn as secondary CNI

### DIFF
--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -2,10 +2,13 @@ package daemon
 
 import (
 	"fmt"
+	"net"
+	"slices"
 	"sort"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
@@ -232,16 +235,82 @@ func (c *Controller) getEgressNatIPByNode(subnets []*kubeovnv1.Subnet, nodeName 
 	return subnetsNatIP
 }
 
+// getPodPrimaryNetworkProvider returns the kube-ovn network provider whose allocated
+// IP addresses cover all the pod's primary network IPs, i.e. the network kubelet
+// probes go through. It returns false if the pod's primary network is not managed
+// by kube-ovn, e.g. when kube-ovn works as a secondary CNI.
+func getPodPrimaryNetworkProvider(pod *v1.Pod) (string, bool) {
+	podIPs := util.PodIPs(*pod)
+	if len(podIPs) == 0 {
+		return "", false
+	}
+
+	// check the default provider first so that the common case is deterministic
+	if providerCoversIPs(pod, util.OvnProvider, podIPs) {
+		return util.OvnProvider, true
+	}
+
+	suffix := fmt.Sprintf(util.IPAddressAnnotationTemplate, "")
+	providers := make([]string, 0, 1)
+	for key := range pod.Annotations {
+		if provider, ok := strings.CutSuffix(key, suffix); ok && provider != "" && provider != util.OvnProvider {
+			providers = append(providers, provider)
+		}
+	}
+	slices.Sort(providers)
+	for _, provider := range providers {
+		if providerCoversIPs(pod, provider, podIPs) {
+			return provider, true
+		}
+	}
+	return "", false
+}
+
+// providerCoversIPs returns true if every IP in podIPs is allocated by the given
+// provider according to the pod's ip_address annotation.
+func providerCoversIPs(pod *v1.Pod, provider string, podIPs []string) bool {
+	annotatedIPs := strings.Split(pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, provider)], ",")
+	allocated := make([]net.IP, 0, len(annotatedIPs))
+	for _, ip := range annotatedIPs {
+		if parsed := net.ParseIP(strings.TrimSpace(ip)); parsed != nil {
+			allocated = append(allocated, parsed)
+		}
+	}
+	if len(allocated) == 0 {
+		return false
+	}
+
+	for _, podIP := range podIPs {
+		parsed := net.ParseIP(podIP)
+		if parsed == nil || !slices.ContainsFunc(allocated, parsed.Equal) {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *Controller) getTProxyConditionPod(pods []*v1.Pod, needSort bool) ([]*v1.Pod, error) {
 	var filteredPods []*v1.Pod
 	for _, pod := range pods {
-		subnetName, ok := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, util.OvnProvider)]
+		provider, ok := getPodPrimaryNetworkProvider(pod)
+		if !ok {
+			// The pod's primary network is not managed by kube-ovn, e.g. kube-ovn works
+			// as a secondary CNI. Kubelet probes go through the primary CNI in that case,
+			// so tproxy must not intercept them.
+			continue
+		}
+
+		subnetName, ok := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
 		if !ok {
 			continue
 		}
 
 		subnet, err := c.subnetsLister.Get(subnetName)
 		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.Warningf("subnet %q of pod %s/%s not found, skip", subnetName, pod.Namespace, pod.Name)
+				continue
+			}
 			return nil, fmt.Errorf("failed to get subnet %q: %w", subnetName, err)
 		}
 

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -1145,9 +1145,9 @@ func (c *Controller) reconcileTProxyIPTableRules(allPods []*v1.Pod, protocol str
 
 	for _, pod := range pods {
 		var podIP string
-		for _, ip := range pod.Status.PodIPs {
-			if util.CheckProtocol(ip.IP) == protocol {
-				podIP = ip.IP
+		for _, ip := range util.PodIPs(*pod) {
+			if util.CheckProtocol(ip) == protocol {
+				podIP = ip
 				break
 			}
 		}

--- a/pkg/daemon/gateway_test.go
+++ b/pkg/daemon/gateway_test.go
@@ -1,11 +1,17 @@
 package daemon
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	kubeovninformerfactory "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func TestGetCidrByProtocol(t *testing.T) {
@@ -58,4 +64,144 @@ func TestGetCidrByProtocol(t *testing.T) {
 			require.Equal(t, c.expected, got)
 		})
 	}
+}
+
+func mkTProxyPod(ns, name string, annotations map[string]string, podIPs ...string) *corev1.Pod {
+	ips := make([]corev1.PodIP, 0, len(podIPs))
+	for _, ip := range podIPs {
+		ips = append(ips, corev1.PodIP{IP: ip})
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Annotations: annotations},
+		Status:     corev1.PodStatus{PodIPs: ips},
+	}
+}
+
+func TestGetPodPrimaryNetworkProvider(t *testing.T) {
+	attachProvider := "macvlan.default.ovn"
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		podIPs      []string
+		expected    string
+		found       bool
+	}{{
+		name: "primary cni",
+		annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "10.16.0.5",
+		},
+		podIPs:   []string{"10.16.0.5"},
+		expected: util.OvnProvider,
+		found:    true,
+	}, {
+		name: "primary cni dual stack",
+		annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "10.16.0.5,fd00:10:16::5",
+		},
+		podIPs:   []string{"10.16.0.5", "fd00:10:16::5"},
+		expected: util.OvnProvider,
+		found:    true,
+	}, {
+		name: "attachment network as multus default network",
+		annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, attachProvider): "172.17.0.5",
+		},
+		podIPs:   []string{"172.17.0.5"},
+		expected: attachProvider,
+		found:    true,
+	}, {
+		name: "pure secondary cni",
+		annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "10.16.0.5",
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, attachProvider):   "172.17.0.5",
+		},
+		podIPs: []string{"192.168.0.5"},
+	}, {
+		name: "default provider preferred on identical ips",
+		annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "10.16.0.5",
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, attachProvider):   "10.16.0.5",
+		},
+		podIPs:   []string{"10.16.0.5"},
+		expected: util.OvnProvider,
+		found:    true,
+	}, {
+		name: "partial ip coverage does not match",
+		annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "10.16.0.5",
+		},
+		podIPs: []string{"10.16.0.5", "fd00:10:16::5"},
+	}, {
+		name: "no pod ips",
+		annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "10.16.0.5",
+		},
+	}, {
+		name:   "no annotations",
+		podIPs: []string{"10.16.0.5"},
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pod := mkTProxyPod("default", "pod", c.annotations, c.podIPs...)
+			provider, found := getPodPrimaryNetworkProvider(pod)
+			require.Equal(t, c.found, found)
+			require.Equal(t, c.expected, provider)
+		})
+	}
+}
+
+func TestGetTProxyConditionPod(t *testing.T) {
+	attachProvider := "macvlan.default.ovn"
+	subnets := []*kubeovnv1.Subnet{{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-subnet"},
+		Spec:       kubeovnv1.SubnetSpec{Vpc: "custom-vpc"},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{Name: "default-subnet"},
+		Spec:       kubeovnv1.SubnetSpec{Vpc: util.DefaultVpc},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{Name: "attach-subnet"},
+		Spec:       kubeovnv1.SubnetSpec{Vpc: "custom-vpc"},
+	}}
+
+	kubeovnClient := kubeovnfake.NewSimpleClientset()
+	informerFactory := kubeovninformerfactory.NewSharedInformerFactory(kubeovnClient, 0)
+	subnetInformer := informerFactory.Kubeovn().V1().Subnets()
+	for _, subnet := range subnets {
+		require.NoError(t, subnetInformer.Informer().GetStore().Add(subnet))
+	}
+
+	c := &Controller{
+		subnetsLister: subnetInformer.Lister(),
+		config:        &Configuration{ClusterRouter: util.DefaultVpc},
+	}
+
+	primaryPod := mkTProxyPod("default", "primary", map[string]string{
+		fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider):     "10.16.0.5",
+		fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, util.OvnProvider): "custom-subnet",
+	}, "10.16.0.5")
+	defaultVpcPod := mkTProxyPod("default", "default-vpc", map[string]string{
+		fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider):     "10.17.0.5",
+		fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, util.OvnProvider): "default-subnet",
+	}, "10.17.0.5")
+	attachPod := mkTProxyPod("default", "attach", map[string]string{
+		fmt.Sprintf(util.IPAddressAnnotationTemplate, attachProvider):     "172.17.0.5",
+		fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, attachProvider): "attach-subnet",
+	}, "172.17.0.5")
+	// kube-ovn allocated an unused address for the default provider while another
+	// CNI provides the primary network; tproxy must not intercept its probes
+	secondaryPod := mkTProxyPod("default", "secondary", map[string]string{
+		fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider):     "10.16.0.6",
+		fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, util.OvnProvider): "custom-subnet",
+	}, "192.168.0.6")
+	staleSubnetPod := mkTProxyPod("default", "stale", map[string]string{
+		fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider):     "10.18.0.5",
+		fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, util.OvnProvider): "missing-subnet",
+	}, "10.18.0.5")
+
+	pods := []*corev1.Pod{secondaryPod, primaryPod, defaultVpcPod, attachPod, staleSubnetPod}
+	filtered, err := c.getTProxyConditionPod(pods, true)
+	require.NoError(t, err)
+	require.Len(t, filtered, 2)
+	require.Equal(t, "attach", filtered[0].Name)
+	require.Equal(t, "primary", filtered[1].Name)
 }

--- a/pkg/daemon/tproxy_linux.go
+++ b/pkg/daemon/tproxy_linux.go
@@ -110,11 +110,16 @@ func (c *Controller) StartTProxyTCPPortProbe() {
 	}
 
 	for _, pod := range pods {
+		provider, ok := getPodPrimaryNetworkProvider(pod)
+		if !ok {
+			continue
+		}
+
 		podName := pod.Name
 		if vmName := pod.Annotations[util.VMAnnotation]; vmName != "" {
 			podName = vmName
 		}
-		iface := ovs.PodNameToPortName(podName, pod.Namespace, util.OvnProvider)
+		iface := ovs.PodNameToPortName(podName, pod.Namespace, provider)
 		nsName, err := ovs.GetInterfacePodNs(iface)
 		if err != nil {
 			klog.Errorf("failed to get netns for pod %s/%s: %v", pod.Namespace, pod.Name, err)
@@ -126,10 +131,10 @@ func (c *Controller) StartTProxyTCPPortProbe() {
 		}
 
 		ports := getProbePorts(pod)
-		for _, podIP := range pod.Status.PodIPs {
-			customVPCPodIPToNs.Store(podIP.IP, nsName)
+		for _, podIP := range util.PodIPs(*pod) {
+			customVPCPodIPToNs.Store(podIP, nsName)
 			for _, port := range ports.UnsortedList() {
-				probePortInNs(podIP.IP, port, true, nil)
+				probePortInNs(podIP, port, true, nil)
 			}
 		}
 	}

--- a/pkg/daemon/tproxy_linux.go
+++ b/pkg/daemon/tproxy_linux.go
@@ -116,7 +116,7 @@ func (c *Controller) StartTProxyTCPPortProbe() {
 		}
 
 		podName := pod.Name
-		if vmName := pod.Annotations[util.VMAnnotation]; vmName != "" {
+		if vmName := pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)]; vmName != "" {
 			podName = vmName
 		}
 		iface := ovs.PodNameToPortName(podName, pod.Namespace, provider)


### PR DESCRIPTION
## Summary

Fixes tproxy-based health checks for custom VPC pods when kube-ovn is not the primary CNI (reported symptom: probes fail and ovn-cni logs `netns for pod <ns>/<pod> not found`).

Two problems with the current implementation:

- `StartTProxyTCPPortProbe` hardcodes the default provider `ovn` when building the OVS iface-id (`<pod>.<ns>`), so pods whose primary network comes from a kube-ovn attachment network (e.g. via the multus `v1.multus-cni.io/default-network` annotation, iface-id `<pod>.<ns>.<nad>.<nad-ns>.ovn`) never get their netns resolved, and probe connections intercepted by TPROXY are dropped.
- When another CNI provides the primary network (kube-ovn as a pure secondary CNI), TPROXY iptables rules are still generated from `pod.Status.PodIPs` — i.e. the other CNI's addresses — actively breaking health checks that would otherwise work.

Fix: match `pod.Status.PodIPs` against the `<provider>.kubernetes.io/ip_address` annotations to find the kube-ovn provider that actually owns the pod's primary network:

- no provider matches (pure secondary CNI): skip the pod so tproxy does not intercept its probes;
- a provider matches: use it to look up the logical switch subnet for the custom VPC condition and to build the correct OVS iface-id.

Also skip pods referencing a deleted subnet instead of failing the whole tproxy reconciliation.

## Test plan

- [x] Unit tests for the provider matching logic (primary CNI, dual stack, attachment network as multus default network, pure secondary CNI, partial IP coverage) and for the tproxy pod filtering (custom VPC / default VPC / secondary CNI / stale subnet)
- [x] `go test ./pkg/daemon/...` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)