### PR TITLE
fix: misc bug fixes from code audit

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -294,8 +294,7 @@ func (c *Controller) gcVip() error {
 						klog.Errorf("failed to clean label from vip %s, %v", vip.Name, err)
 						return err
 					}
-					klog.Infof("finish to gc vips")
-					return nil
+					continue
 				}
 				klog.Error(err)
 				return err

--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -528,7 +528,7 @@ func (c *Controller) createOrUpdateIPCR(ipCRName, podName, ip, mac, subnetName, 
 		controllerutil.AddFinalizer(newIPCR, util.KubeOVNControllerFinalizer)
 
 		if _, err = c.config.KubeOvnClient.KubeovnV1().IPs().Update(context.Background(), newIPCR, metav1.UpdateOptions{}); err != nil {
-			err := fmt.Errorf("failed to update ip CR %s: %w", ipCRName, err)
+			err := fmt.Errorf("failed to update ip CR %s: %w", ipName, err)
 			klog.Error(err)
 			return err
 		}

--- a/pkg/controller/provider_network.go
+++ b/pkg/controller/provider_network.go
@@ -87,11 +87,15 @@ func (c *Controller) resyncProviderNetworkStatus() {
 		for _, n := range expectNodes {
 			expectNodeSet[n] = struct{}{}
 		}
-		for _, c := range pn.Status.Conditions {
-			if _, ok := expectNodeSet[c.Node]; !ok {
-				if pn.Status.RemoveNodeConditions(c.Node) {
-					conditionsUpdated = true
-				}
+		var staleNodes []string
+		for _, cond := range pn.Status.Conditions {
+			if _, ok := expectNodeSet[cond.Node]; !ok {
+				staleNodes = append(staleNodes, cond.Node)
+			}
+		}
+		for _, node := range staleNodes {
+			if pn.Status.RemoveNodeConditions(node) {
+				conditionsUpdated = true
 			}
 		}
 

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -529,6 +529,14 @@ func (config *Configuration) setEncapIPs() error {
 	return nil
 }
 
+// SetDefaultEncapIP updates the default encap IP under the node networks lock,
+// as setEncapIPs/GetEncapIPByNetwork read it concurrently from other goroutines
+func (config *Configuration) SetDefaultEncapIP(ip string) {
+	config.nodeNetworksMutex.Lock()
+	config.DefaultEncapIP = ip
+	config.nodeNetworksMutex.Unlock()
+}
+
 func (config *Configuration) UpdateNodeNetworks(node *corev1.Node) error {
 	newNetworks, err := parseNodeNetworks(node)
 	if err != nil {
@@ -543,12 +551,12 @@ func (config *Configuration) UpdateNodeNetworks(node *corev1.Node) error {
 }
 
 func (config *Configuration) GetEncapIPByNetwork(networkName string) (string, error) {
+	config.nodeNetworksMutex.RLock()
+	defer config.nodeNetworksMutex.RUnlock()
+
 	if networkName == "" {
 		return config.DefaultEncapIP, nil
 	}
-
-	config.nodeNetworksMutex.RLock()
-	defer config.nodeNetworksMutex.RUnlock()
 
 	if ip, ok := config.NodeNetworks[networkName]; ok {
 		return ip, nil

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -999,9 +999,9 @@ func (c *Controller) loopEncapIPCheck() {
 
 		c.config.Iface = nodeTunnelName
 		klog.Infof("Update node tunnel interface %v", nodeTunnelName)
-		c.config.DefaultEncapIP = encapIP
+		c.config.SetDefaultEncapIP(encapIP)
 		if err = c.config.setEncapIPs(); err != nil {
-			klog.Errorf("failed to set encap ip %s for iface %s", c.config.DefaultEncapIP, c.config.Iface)
+			klog.Errorf("failed to set encap ip %s for iface %s", encapIP, nodeTunnelName)
 			return
 		}
 	}

--- a/pkg/daemon/ipsec.go
+++ b/pkg/daemon/ipsec.go
@@ -30,7 +30,7 @@ import (
 const (
 	ipsecCADir   = "/etc/ipsec.d/cacerts"
 	ipsecKeyDir  = "/etc/ovs_ipsec_keys"
-	ipsecReqPath = ipsecKeyDir + "ipsec-req.pem"
+	ipsecReqPath = ipsecKeyDir + "/ipsec-req.pem"
 
 	ipsecPrivKeyPathSpec = ipsecKeyDir + "/ipsec-privkey-%d.pem"
 	ipsecCertPathSpec    = ipsecKeyDir + "/ipsec-cert-%d.pem"

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -143,6 +143,7 @@ func InitMetrics() {
 	registerSystemParameterMetrics()
 	metrics.Registry.MustRegister(cniOperationHistogram)
 	metrics.Registry.MustRegister(cniWaitAddressResult)
+	metrics.Registry.MustRegister(cniWaitRouteResult)
 	metrics.Registry.MustRegister(cniConnectivityResult)
 }
 

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -719,7 +719,6 @@ func configureNodeNic(cs kubernetes.Interface, nodeName, portName, ip, gw, joinC
 
 	actualMac := hostLink.Attrs().HardwareAddr
 	if actualMac.String() != macAddr.String() {
-		macAddr = actualMac
 		err := fmt.Errorf("MAC address mismatch on %s: expected %s, actual %s", util.NodeNic, macAddr.String(), actualMac.String())
 		klog.Error(err)
 		return err

--- a/pkg/ovnmonitor/exporter.go
+++ b/pkg/ovnmonitor/exporter.go
@@ -17,11 +17,10 @@ import (
 const metricNamespace = "kube_ovn"
 
 var (
-	appName          = "ovn-monitor"
-	isClusterEnabled = true
-	tryConnectCnt    = 0
-	checkNbDbCnt     = 0
-	checkSbDbCnt     = 0
+	appName       = "ovn-monitor"
+	tryConnectCnt = 0
+	checkNbDbCnt  = 0
+	checkSbDbCnt  = 0
 )
 
 // Exporter collects OVN data from the given server and exports them using
@@ -156,9 +155,11 @@ func (e *Exporter) ovnMetricsUpdate() {
 		e.exportLogicalSwitchGauge()
 		e.exportLogicalSwitchPortGauge()
 
-		e.exportOvnClusterEnableGauge()
-		if isClusterEnabled {
+		if e.exportOvnClusterEnableGauge() {
 			e.exportOvnClusterInfoGauge()
+		} else {
+			// clear stale cluster info series exported by previous clustered polls
+			resetOvnClusterMetrics()
 		}
 
 		time.Sleep(time.Duration(e.pollInterval) * time.Second)
@@ -246,7 +247,7 @@ func (e *Exporter) exportLogicalSwitchPortGauge() {
 	e.setLogicalSwitchPortInfoMetric()
 }
 
-func (e *Exporter) exportOvnClusterEnableGauge() {
+func (e *Exporter) exportOvnClusterEnableGauge() bool {
 	metricClusterEnabled.Reset()
 	isClusterEnabled, err := getClusterEnableState(e.Client.Database.Northbound.File.Data.Path)
 	if err != nil {
@@ -257,6 +258,7 @@ func (e *Exporter) exportOvnClusterEnableGauge() {
 	} else {
 		metricClusterEnabled.WithLabelValues(e.Client.System.Hostname, e.Client.Database.Northbound.File.Data.Path).Set(0)
 	}
+	return isClusterEnabled
 }
 
 func (e *Exporter) exportOvnClusterInfoGauge() {


### PR DESCRIPTION
## Summary

A batch of small fixes for issues found during a code audit, one commit per issue:

- **controller/gc**: `gcVip` returned right after releasing the first stale reserved VIP, so the remaining ones were never processed. Since `gc()` runs only once at controller startup, stale `ip_reserved` labels persisted for the whole controller lifetime, blocking new pods from reusing those VIPs via the `ovn.kubernetes.io/vip` annotation.
- **controller/ip**: the update branch of `createOrUpdateIPCR` formatted its error with `ipCRName`, which is empty on the node/u2o/mcast querier paths; use the resolved `ipName` like the create branch.
- **controller/provider_network**: `resyncProviderNetworkStatus` called `RemoveNodeConditions` while ranging over the same conditions slice; `slices.Delete` shifts the backing array, skipping the condition adjacent to each removed one. Collect stale node names first, then remove them.
- **daemon/config**: `loopEncapIPCheck` wrote `DefaultEncapIP` without holding `nodeNetworksMutex` while `setEncapIPs` reads it under `RLock` from the updateNode worker goroutine (data race). Added a locked setter; also moved the `networkName==""` early return in `GetEncapIPByNetwork` under the `RLock` (same unguarded read).
- **daemon/ipsec**: `ipsecReqPath` was missing the path separator, producing `/etc/ovs_ipsec_keysipsec-req.pem` outside the keys directory, so `clearIPSecKeysDir` could never clean the CSR up after rotation.
- **daemon/metrics**: register `cni_wait_route_seconds_total`, which has been incremented but never registered since v1.10.
- **daemon/ovs**: the ovn0 MAC mismatch error overwrote the expected MAC with the actual one before formatting, so "expected" and "actual" always rendered identically.
- **ovn-monitor**: `exportOvnClusterEnableGauge` shadowed the package-level `isClusterEnabled` with `:=`, so the guard in `ovnMetricsUpdate` stayed permanently true and cluster info collection ran against non-clustered DBs, failing every poll cycle. Return the state from the function, drop the mutable package-level variable, and reset cluster info metrics when cluster mode is off so stale series are not served.

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `go build` on affected packages
- [x] `go test ./pkg/controller/... ./pkg/daemon/... ./pkg/ovnmonitor/...` passes
- [ ] CI e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)