### PR TITLE
fix(images): adapt OVN pinctrl to new OVS compose_nd_ns signature

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -66,6 +66,7 @@ ADD patches/9286e1fd578fdb8f565a0f4aa9066b538295e1ac.patch $SRC_DIR
 ADD patches/737d9f932edada5a91f315b5f382daada8dee952.patch $SRC_DIR
 ADD patches/52b727b3315463668669ff423ce8bfa129861162.patch $SRC_DIR
 ADD patches/sbrec-delete-null-check.patch $SRC_DIR
+ADD patches/pinctrl-adapt-ovs-compose-nd-ns.patch $SRC_DIR
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -134,7 +135,9 @@ RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-o
     # set dl_src for packets redirected by router port
     git apply $SRC_DIR/52b727b3315463668669ff423ce8bfa129861162.patch && \
     # add null check before sbrec delete calls
-    git apply $SRC_DIR/sbrec-delete-null-check.patch
+    git apply $SRC_DIR/sbrec-delete-null-check.patch && \
+    # adapt to the compose_nd_ns() signature change in ovs branch-3.5 commit 33825c273
+    git apply $SRC_DIR/pinctrl-adapt-ovs-compose-nd-ns.patch
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/dist/images/patches/pinctrl-adapt-ovs-compose-nd-ns.patch
+++ b/dist/images/patches/pinctrl-adapt-ovs-compose-nd-ns.patch
@@ -1,0 +1,32 @@
+Adapt pinctrl to the new compose_nd_ns() signature introduced by OVS
+branch-3.5 commit 33825c273 ("packets: Add support for unicast ND NS
+compose."). Passing multicast=true keeps the previous behavior: eth_dst
+is derived from the solicited-node multicast address internally, so the
+eth_addr_zero argument is only a placeholder.
+
+Remove this patch once OVN branch-25.03 adapts to the new signature
+upstream (git apply will fail loudly when that happens).
+diff --git a/controller/pinctrl.c b/controller/pinctrl.c
+index 26e17fd..c13bf06 100644
+--- a/controller/pinctrl.c
++++ b/controller/pinctrl.c
+@@ -5465,7 +5465,7 @@ send_self_originated_neigh_packet(struct rconn *swconn,
+                     in6_addr_get_mapped_ipv4(local),
+                     in6_addr_get_mapped_ipv4(target));
+     } else {
+-        compose_nd_ns(&packet, eth, local, target);
++        compose_nd_ns(&packet, true, eth, eth_addr_zero, local, target);
+     }
+ 
+     /* Inject GARP request. */
+@@ -7171,8 +7171,8 @@ pinctrl_handle_nd_ns(struct rconn *swconn, const struct flow *ip_flow,
+             hton128(flow_get_xxreg(&pin->flow_metadata.flow, 0));
+         memcpy(&ipv6_dst, &nexthop_be, sizeof ipv6_dst);
+     }
+-    compose_nd_ns(&packet, ip_flow->dl_src, &ipv6_src,
+-                  &ipv6_dst);
++    compose_nd_ns(&packet, true, ip_flow->dl_src, eth_addr_zero,
++                  &ipv6_src, &ipv6_dst);
+ 
+     /* Reload previous packet metadata and set actions from userdata. */
+     set_actions_and_enqueue_msg(swconn, &packet,


### PR DESCRIPTION
## What this PR does

The nightly base image build ([Build Base](https://github.com/kubeovn/kube-ovn/actions/workflows/build-kube-ovn-base.yaml)) has been failing across the whole matrix since 2026-06-06. OVS branch-3.5 commit [33825c273](https://github.com/openvswitch/ovs/commit/33825c273) ("packets: Add support for unicast ND NS compose.") changed the `compose_nd_ns()` signature by adding `multicast` and `eth_dst` parameters, while OVN branch-25.03 (and even OVN main) has not adapted its two call sites in `controller/pinctrl.c` yet. Since Dockerfile.base tracks both branch HEADs, the OVN compile fails:

```
controller/pinctrl.c:7174:45: error: incompatible type for argument 3 of 'compose_nd_ns'
make[2]: *** [Makefile:2504: controller/pinctrl.o] Error 1
```

With the nightly build stuck, the base images are frozen at the 2026-06-05 package baseline, which is why trivy keeps failing the `Push Images` security scan on every PR (openssl CVE-2026-45447 etc. are fixed in newer ubuntu packages that never roll in).

This PR adds a temporary patch updating both `compose_nd_ns()` call sites with `multicast=true`, which keeps the previous behavior byte-for-byte (eth_dst is still derived from the solicited-node multicast address internally; `eth_addr_zero` is just a placeholder — same adaptation OVS applied to its own caller in `ofproto-dpif-xlate.c`). The patch should be dropped once OVN branch-25.03 adapts upstream; `git apply` will then fail loudly as a reminder.

## Verification

Built the `ovs-builder` stage locally with this fix: all 18 OVN patches apply cleanly, `controller/pinctrl.o` compiles, and `ovn-controller` links successfully.

Note: release-1.16/1.15 share the same branch pair and need this same patch; release-1.14/1.13 hit the identical backport on OVS branch-3.3 ([3430a01a6](https://github.com/openvswitch/ovs/commit/3430a01a6)) against pinned OVN branch-24.03 and need an adjusted variant (call-site context differs slightly).