### PR TITLE
feat: support share type iptables DNAT with nft map-based LB

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -635,6 +635,9 @@ spec:
     - jsonPath: .spec.internalPort
       name: InternalPort
       type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
     - jsonPath: .status.natGwDp
       name: NatGwDp
       type: string
@@ -678,6 +681,23 @@ spec:
                 type: string
               protocol:
                 description: Protocol type (TCP or UDP)
+                type: string
+              type:
+                default: exclusive
+                description: |-
+                  Type of the DNAT rule, controls whether the EIP:Port identity can be shared
+                  by multiple internal backends:
+                  - "exclusive" (default): The EIP:Port is exclusively owned by this single DNAT rule.
+                    Uses iptables DNAT for 1:1 port forwarding. This was the only mode before the
+                    nft LB feature was introduced; any duplicate identity is rejected.
+                  - "share": Multiple DNAT rules may share the same EIP:Port identity, each
+                    contributing a different internal IP:Port as a backend. Traffic is distributed
+                    across backends using nftables numgen random map-based DNAT: each new connection
+                    picks a backend at random and is then pinned by conntrack (connection-level
+                    balancing, no client-IP affinity).
+                enum:
+                - exclusive
+                - share
                 type: string
             type: object
           status:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -642,6 +642,9 @@ spec:
     - jsonPath: .spec.internalPort
       name: InternalPort
       type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
     - jsonPath: .status.natGwDp
       name: NatGwDp
       type: string
@@ -685,6 +688,23 @@ spec:
                 type: string
               protocol:
                 description: Protocol type (TCP or UDP)
+                type: string
+              type:
+                default: exclusive
+                description: |-
+                  Type of the DNAT rule, controls whether the EIP:Port identity can be shared
+                  by multiple internal backends:
+                  - "exclusive" (default): The EIP:Port is exclusively owned by this single DNAT rule.
+                    Uses iptables DNAT for 1:1 port forwarding. This was the only mode before the
+                    nft LB feature was introduced; any duplicate identity is rejected.
+                  - "share": Multiple DNAT rules may share the same EIP:Port identity, each
+                    contributing a different internal IP:Port as a backend. Traffic is distributed
+                    across backends using nftables numgen random map-based DNAT: each new connection
+                    picks a backend at random and is then pinned by conntrack (connection-level
+                    balancing, no client-IP affinity).
+                enum:
+                - exclusive
+                - share
                 type: string
             type: object
           status:

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG VERSION
+ARG VERSION=latest
 ARG BASE_TAG=$VERSION
 FROM kubeovn/kube-ovn-base:$BASE_TAG AS setcap
 

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1044,6 +1044,9 @@ spec:
     - jsonPath: .spec.internalPort
       name: InternalPort
       type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
     - jsonPath: .status.natGwDp
       name: NatGwDp
       type: string
@@ -1087,6 +1090,23 @@ spec:
                 type: string
               protocol:
                 description: Protocol type (TCP or UDP)
+                type: string
+              type:
+                default: exclusive
+                description: |-
+                  Type of the DNAT rule, controls whether the EIP:Port identity can be shared
+                  by multiple internal backends:
+                  - "exclusive" (default): The EIP:Port is exclusively owned by this single DNAT rule.
+                    Uses iptables DNAT for 1:1 port forwarding. This was the only mode before the
+                    nft LB feature was introduced; any duplicate identity is rejected.
+                  - "share": Multiple DNAT rules may share the same EIP:Port identity, each
+                    contributing a different internal IP:Port as a backend. Traffic is distributed
+                    across backends using nftables numgen random map-based DNAT: each new connection
+                    picks a backend at random and is then pinned by conntrack (connection-level
+                    balancing, no client-IP affinity).
+                enum:
+                - exclusive
+                - share
                 type: string
             type: object
           status:

--- a/dist/images/vpcnatgateway/Dockerfile
+++ b/dist/images/vpcnatgateway/Dockerfile
@@ -7,6 +7,7 @@ RUN set -ex \
     bash \
     iproute2 \
     iptables iptables-legacy \
+    nftables \
     iputils \
     tcpdump \
     conntrack-tools

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -73,6 +73,8 @@ function show_help() {
     echo "  floating-ip-del          - Delete floating IP mapping"
     echo "  dnat-add                 - Add DNAT rule"
     echo "  dnat-del                 - Delete DNAT rule"
+    echo "  nft-dnat-map-add         - Add nft map-based DNAT rule (Share type)"
+    echo "  nft-dnat-map-del         - Delete nft map-based DNAT rule (Share type)"
     echo "  snat-add                 - Add SNAT rule"
     echo "  snat-del                 - Delete SNAT rule"
     echo "  qos-add                  - Add QoS rule"
@@ -521,6 +523,213 @@ function del_dnat() {
           exec_cmd "$iptables_cmd -t nat -D $existingRule"
           conntrack -D -d "$eip" -p "$protocol" --dport "$dport" 2>/dev/null || true
         fi
+    done
+}
+
+# ===== nftables share DNAT (follows kube-proxy nftables pattern) =====
+#
+# Architecture (two-layer dispatch, same as kube-proxy):
+#   Table: kube-ovn
+#   ├── Base chain: prerouting (type nat hook prerouting priority -150)
+#   │   └── Rule: ip daddr . meta l4proto . th dport vmap @service-ips
+#   ├── Named vmap: service-ips
+#   │   └── Elements: { eip . protocol . port : goto dnat-XXXXX }  (element-level add/delete)
+#   └── Per-identity chains: dnat-XXXXX (one per eip:port:protocol)
+#       └── Rule: numgen random mod N dnat to ip addr . port map { backends }
+#
+# Atomicity: all operations use `nft -f` (single netlink batch transaction).
+# When backends change, only the per-identity chain is flushed + rebuilt.
+# The vmap element is stable (only added/removed when an identity is created/destroyed).
+#
+# Naming conventions:
+#   Shell variables: UPPER_CASE
+#   nft object names: lower_case (Linux/nftables convention, case-sensitive)
+
+NFT_TABLE="kube-ovn"
+NFT_SERVICES_MAP="service-ips"
+# WARNING: this base chain is owned exclusively by the share-dnat feature. add_nft_dnat_map
+# flushes it on every add/update and re-adds its single vmap dispatch rule, so any other rule
+# injected into this chain would be silently wiped. Do NOT reuse NFT_PREROUTING_CHAIN for other
+# components; add a separate chain (or a different priority hook) if new prerouting rules are needed.
+NFT_PREROUTING_CHAIN="prerouting"
+
+# Generate a per-identity chain name from eip:port:protocol.
+# Uses md5 hash prefix for uniqueness (same idea as kube-proxy's hashAndTruncate).
+# Tradeoff: only the first 12 hex chars (48 bits) of the md5 are used. Collision probability
+# is negligible for the number of identities on a single gateway; a collision would make two
+# identities share (and mutually flush) the same per-identity chain. Widen the prefix if the
+# per-gateway identity count ever grows large enough for this to matter.
+function nft_identity_chain_name() {
+    local eip=$1 dport=$2 protocol=$3
+    local hash
+    hash=$(echo -n "${eip}:${dport}:${protocol}" | md5sum | cut -c1-12)
+    echo "dnat-${hash}"
+}
+
+# Execute an atomic nft transaction. All arguments are nft commands (one per arg).
+# Submitted as a single netlink batch via `nft -f`.
+# Returns 0 on success, non-zero on failure.
+function nft_transaction() {
+    printf '%s\n' "$@" | nft -f -
+}
+
+# Same as nft_transaction but ignores errors (for idempotent cleanup).
+function nft_transaction_ignore_errors() {
+    printf '%s\n' "$@" | nft -f - 2>/dev/null || true
+}
+
+function add_nft_dnat_map() {
+    # Add or update share-type DNAT backends for a given identity.
+    # Uses atomic nft transaction: ensure infrastructure + flush per-identity chain + re-add rule.
+    # All nft add operations are idempotent (no-op if already exists).
+    # Format: eip,dport,protocol,ip1:port1@ip2:port2@ip3:port3
+    # Backends are '@'-separated (not ';') because the rule is passed as a single argument
+    # through pod-exec into a shell context, where ';' would act as a command separator.
+    check_inited
+    for rule in "$@"
+    do
+        IFS=',' read -r eip dport protocol backends <<< "$rule"
+
+        if [ -z "$eip" ] || [ -z "$dport" ] || [ -z "$protocol" ] || [ -z "$backends" ]; then
+            echo "Error: invalid nft-dnat-map rule: $rule"
+            exit 1
+        fi
+
+        # Defense-in-depth format validation: the controller and webhook already validate
+        # these fields, but the shell must not blindly interpolate values into the nft
+        # transaction if an upstream check is ever bypassed (manual call / future call site).
+        if ! [[ "$eip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+            echo "Error: invalid eip in nft-dnat-map rule: $eip"
+            exit 1
+        fi
+        if ! [[ "$dport" =~ ^[0-9]+$ ]] || [ "$dport" -lt 1 ] || [ "$dport" -gt 65535 ]; then
+            echo "Error: invalid external port in nft-dnat-map rule: $dport"
+            exit 1
+        fi
+        if [ "$protocol" != "tcp" ] && [ "$protocol" != "udp" ] && [ "$protocol" != "TCP" ] && [ "$protocol" != "UDP" ]; then
+            echo "Error: invalid protocol in nft-dnat-map rule: $protocol"
+            exit 1
+        fi
+
+        # Parse backends and count them
+        IFS='@' read -ra backend_list <<< "$backends"
+        local count=${#backend_list[@]}
+
+        if [ "$count" -eq 0 ]; then
+            echo "Error: no backends specified in rule: $rule"
+            exit 1
+        fi
+
+        # Determine per-identity chain name
+        local identity_chain
+        identity_chain=$(nft_identity_chain_name "$eip" "$dport" "$protocol")
+
+        # Build numgen random mod N map entries (following kube-proxy pattern)
+        local map_entries=""
+        for i in "${!backend_list[@]}"; do
+            IFS=':' read -r ip port <<< "${backend_list[$i]}"
+            if ! [[ "$ip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+                echo "Error: invalid backend ip in nft-dnat-map rule: $ip"
+                exit 1
+            fi
+            if ! [[ "$port" =~ ^[0-9]+$ ]] || [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+                echo "Error: invalid backend port in nft-dnat-map rule: $port"
+                exit 1
+            fi
+            if [ -n "$map_entries" ]; then
+                map_entries="$map_entries, "
+            fi
+            map_entries="$map_entries$i : $ip . $port"
+        done
+
+        # Map protocol name to nft inet_proto keyword
+        local nft_proto
+        nft_proto=$(echo "$protocol" | tr '[:upper:]' '[:lower:]')
+
+        # Atomic transaction:
+        # 1. Ensure table, base chain, vmap exist (idempotent)
+        # 2. Flush + re-add dispatch rule in base chain
+        #    (base chain is share-dnat-exclusive; flush wipes any other rule in it, see NFT_PREROUTING_CHAIN)
+        # 3. Flush per-identity chain + add new dnat rule
+        #    (the `meta l4proto $nft_proto` match is technically redundant here, since a packet
+        #     only reaches this chain via the vmap key that already selects by protocol; it is
+        #     kept for parity with kube-proxy's per-service dnat rule and as an explicit guard)
+        # 4. Ensure vmap element points to this chain
+        if ! nft_transaction \
+            "add table ip $NFT_TABLE" \
+            "add chain ip $NFT_TABLE $NFT_PREROUTING_CHAIN { type nat hook prerouting priority -150 ; }" \
+            "add map ip $NFT_TABLE $NFT_SERVICES_MAP { type ipv4_addr . inet_proto . inet_service : verdict ; }" \
+            "flush chain ip $NFT_TABLE $NFT_PREROUTING_CHAIN" \
+            "add rule ip $NFT_TABLE $NFT_PREROUTING_CHAIN ip daddr . meta l4proto . th dport vmap @$NFT_SERVICES_MAP" \
+            "add chain ip $NFT_TABLE $identity_chain" \
+            "flush chain ip $NFT_TABLE $identity_chain" \
+            "add rule ip $NFT_TABLE $identity_chain meta l4proto $nft_proto dnat ip addr . port to numgen random mod $count map { $map_entries }" \
+            "add element ip $NFT_TABLE $NFT_SERVICES_MAP { $eip . $nft_proto . $dport : goto $identity_chain }"
+        then
+            echo "Error: failed to update nft share dnat for $eip:$dport ($protocol)"
+            exit 1
+        fi
+
+        echo "Updated nft share dnat: $eip:$dport ($protocol) -> $backends (chain=$identity_chain)"
+    done
+}
+
+function del_nft_dnat_map() {
+    # Delete a share-type DNAT identity entirely.
+    # Removes vmap element + flushes and deletes per-identity chain.
+    # Format: eip,dport,protocol
+    check_inited
+
+    # Check if table exists (global precondition): if absent there is nothing to delete
+    # for any rule, so return early. Kept outside the loop so a missing table does not
+    # silently skip the remaining rules in a batch call.
+    if ! nft list table ip $NFT_TABLE >/dev/null 2>&1; then
+        echo "NFT table $NFT_TABLE does not exist, nothing to delete"
+        return 0
+    fi
+
+    for rule in "$@"
+    do
+        IFS=',' read -r eip dport protocol <<< "$rule"
+
+        if [ -z "$eip" ] || [ -z "$dport" ] || [ -z "$protocol" ]; then
+            echo "Error: invalid nft-dnat-map identity: $rule"
+            exit 1
+        fi
+
+        # Defense-in-depth format validation, matching add_nft_dnat_map: the shell must not
+        # blindly interpolate values into nft delete element / conntrack if an upstream check
+        # is ever bypassed (manual call / future call site).
+        if ! [[ "$eip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+            echo "Error: invalid eip in nft-dnat-map identity: $eip"
+            exit 1
+        fi
+        if ! [[ "$dport" =~ ^[0-9]+$ ]] || [ "$dport" -lt 1 ] || [ "$dport" -gt 65535 ]; then
+            echo "Error: invalid external port in nft-dnat-map identity: $dport"
+            exit 1
+        fi
+        if [ "$protocol" != "tcp" ] && [ "$protocol" != "udp" ] && [ "$protocol" != "TCP" ] && [ "$protocol" != "UDP" ]; then
+            echo "Error: invalid protocol in nft-dnat-map identity: $protocol"
+            exit 1
+        fi
+
+        local identity_chain nft_proto
+        identity_chain=$(nft_identity_chain_name "$eip" "$dport" "$protocol")
+        nft_proto=$(echo "$protocol" | tr '[:upper:]' '[:lower:]')
+
+        # Delete vmap element and per-identity chain.
+        # These are separate operations because nft -f is transactional (all-or-nothing):
+        # if the element doesn't exist, a single transaction would roll back and
+        # leave the chain behind. By splitting, each step is independently idempotent.
+        nft delete element ip $NFT_TABLE $NFT_SERVICES_MAP "{ $eip . $nft_proto . $dport }" 2>/dev/null || true
+        nft_transaction_ignore_errors \
+            "flush chain ip $NFT_TABLE $identity_chain" \
+            "delete chain ip $NFT_TABLE $identity_chain"
+
+        # Clean up conntrack entries for this identity
+        conntrack -D -d "$eip" -p "$nft_proto" --dport "$dport" 2>/dev/null || true
+
+        echo "Deleted nft share dnat: $eip:$dport ($protocol) (chain=$identity_chain)"
     done
 }
 
@@ -1569,6 +1778,14 @@ case $opt in
     dnat-del)
         echo "dnat-del $*"
         del_dnat "$@"
+        ;;
+    nft-dnat-map-add)
+        echo "nft-dnat-map-add $*"
+        add_nft_dnat_map "$@"
+        ;;
+    nft-dnat-map-del)
+        echo "nft-dnat-map-del $*"
+        del_nft_dnat_map "$@"
         ;;
     snat-add)
         echo "snat-add $*"

--- a/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
+++ b/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
@@ -29,6 +29,7 @@ type IptablesDnatRuleList struct {
 // +kubebuilder:printcolumn:name="InternalIp",type="string",JSONPath=".spec.internalIp"
 // +kubebuilder:printcolumn:name="ExternalPort",type="string",JSONPath=".spec.externalPort"
 // +kubebuilder:printcolumn:name="InternalPort",type="string",JSONPath=".spec.internalPort"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="NatGwDp",type="string",JSONPath=".status.natGwDp"
 // +kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.ready"
 type IptablesDnatRule struct {
@@ -38,6 +39,24 @@ type IptablesDnatRule struct {
 	Spec   IptablesDnatRuleSpec   `json:"spec"`
 	Status IptablesDnatRuleStatus `json:"status"`
 }
+
+const (
+	// DnatRuleTypeExclusive means the EIP:Port is exclusively used by this DNAT rule.
+	// Only one internal IP:Port can be mapped to a given EIP:Port identity (eip + externalPort + protocol).
+	// This is the original (default) behavior: uses a single iptables DNAT rule for 1:1 port forwarding.
+	// Creating another DNAT rule with the same identity is rejected.
+	DnatRuleTypeExclusive = "exclusive"
+
+	// DnatRuleTypeShare means multiple DNAT rules can share the same EIP:Port.
+	// Different internal IP:Port backends are allowed to coexist under the same identity,
+	// enabling load-balancing across backends. Implemented via nftables numgen random
+	// map-based DNAT: new connections are distributed randomly across backends and then
+	// pinned by conntrack (connection-level balancing, no client-IP affinity).
+	// IPv4 only: the nft rules use `ip daddr`/`ip saddr`, so share requires an EIP with an
+	// IPv4 address; the webhook rejects share on an IPv6-only EIP and the controller requeues
+	// while the EIP is still being allocated (v4 not yet assigned).
+	DnatRuleTypeShare = "share"
+)
 
 type IptablesDnatRuleSpec struct {
 	// EIP name for DNAT rule
@@ -50,6 +69,20 @@ type IptablesDnatRuleSpec struct {
 	InternalIP string `json:"internalIp"`
 	// Internal port number to forward traffic to
 	InternalPort string `json:"internalPort"`
+	// Type of the DNAT rule, controls whether the EIP:Port identity can be shared
+	// by multiple internal backends:
+	// - "exclusive" (default): The EIP:Port is exclusively owned by this single DNAT rule.
+	//   Uses iptables DNAT for 1:1 port forwarding. This was the only mode before the
+	//   nft LB feature was introduced; any duplicate identity is rejected.
+	// - "share": Multiple DNAT rules may share the same EIP:Port identity, each
+	//   contributing a different internal IP:Port as a backend. Traffic is distributed
+	//   across backends using nftables numgen random map-based DNAT: each new connection
+	//   picks a backend at random and is then pinned by conntrack (connection-level
+	//   balancing, no client-IP affinity).
+	// +kubebuilder:validation:Enum=exclusive;share
+	// +kubebuilder:default=exclusive
+	// +optional
+	Type string `json:"type,omitempty"`
 }
 
 type IptablesDnatRuleStatus struct {

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -1,0 +1,301 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+)
+
+// nft share DNAT architecture (follows kube-proxy nftables pattern):
+//
+//   Table: kube-ovn
+//   ├── Base chain: prerouting (type nat hook prerouting priority -150)
+//   │   └── Rule: ip daddr . meta l4proto . th dport vmap @service-ips
+//   ├── Named vmap: service-ips
+//   │   └── Elements: { eip . protocol . port : goto dnat-XXXXX }  (element-level add/delete)
+//   └── Per-identity chains: dnat-XXXXX
+//       └── Rule: numgen random mod N map { 0 : ip1 . port1, 1 : ip2 . port2, ... }
+//
+// Operations:
+//   - Add/remove backend: flush per-identity chain + re-add rule (atomic batch via nft -f)
+//   - Add new identity: create chain + add rule + add vmap element
+//   - Remove identity: delete vmap element + flush & delete chain
+//
+// Coexistence with exclusive (iptables) DNAT:
+//   Two DNAT paths run in the same gateway pod. Exclusive-type rules use iptables
+//   nat/PREROUTING (priority NF_IP_PRI_NAT_DST, ~ -100), while share-type rules use this nft
+//   base chain at priority -150, so the nft hook runs first. This is not a functional conflict
+//   because the webhook enforces that a given identity (eip + externalPort + protocol) is
+//   mutually exclusive across types, and DNAT/FIP for the same EIP are also mutually exclusive;
+//   a packet is therefore only ever matched by one path. The ordering matters mainly for
+//   troubleshooting boundary cases, e.g. when a rule's type is switched after conntrack has
+//   already pinned a connection (existing flows keep their old destination until they expire).
+//   Recommendation: within a single gateway, prefer using one mode consistently (share/nft) so
+//   there is a single DNAT path to reason about and debug.
+//
+// Naming conventions:
+//   - Shell variables: UPPER_CASE (NFT_TABLE, NFT_SERVICES_MAP, ...)
+//   - nft object names: lower_case with hyphens/underscores (Linux/nftables convention)
+//   - Per-identity chain: "dnat-" + md5(eip:port:protocol)[:12]  (generated in shell)
+//
+// TODO(share-dnat): source-IP session affinity is not supported yet. Backends are selected
+// purely at random (numgen random) and then pinned per-connection by conntrack; there is no
+// client-IP affinity. kube-proxy's nftables backend implements ClientIP affinity by recording
+// the source IP in a dynamic nftables set ("update @affinity-set { ip saddr }" in the per-endpoint
+// chain, plus a preceding "ip saddr @affinity-set goto <ep>" lookup), layered on top of the same
+// numgen random dispatch (not jhash). The same approach could be adopted here if per-client
+// affinity is needed in the future.
+
+const (
+	// natGwNftDnatMapAdd is the shell command for adding/updating a share DNAT identity.
+	natGwNftDnatMapAdd = "nft-dnat-map-add"
+
+	// natGwNftDnatMapDel is the shell command for deleting a share DNAT identity.
+	natGwNftDnatMapDel = "nft-dnat-map-del"
+)
+
+// createNftDnatMapInPod creates or updates an nftables map-based DNAT rule for Share type.
+// This is the core function for the nft LB feature: it builds an nft transaction that
+// atomically updates the per-identity chain with the full set of backends.
+//
+// The transaction (submitted via nft -f) contains:
+//  1. Ensure table, base chain, and vmap exist
+//  2. Flush the per-identity chain (remove old rule)
+//  3. Add new rule with numgen random mod N map { all backends }
+//  4. Ensure vmap element dispatches to this chain
+//
+// The backends format passed to the gateway script is "ip1:port1@ip2:port2@...".
+// '@' is used as the separator (not ';') because the rule string is passed as a single
+// argument through the pod-exec API into a shell context, where ';' would be interpreted
+// as a command separator; '@' never appears in an ip:port and is shell-safe.
+func (c *Controller) createNftDnatMapInPod(dp, protocol, v4ip, externalPort string, backends []string) error {
+	if v4ip == "" {
+		// Share DNAT is implemented with `ip daddr`/`ip saddr` nft rules and only supports IPv4.
+		return errors.New("cannot create nft dnat map: empty IPv4 EIP (share dnat does not support IPv6)")
+	}
+	// Normalize the backend set: dedup and sort so that an unchanged set of backends always
+	// produces an identical nft map. Without this, the lister's non-deterministic order would
+	// rewrite the numgen random map on every rebuild/redo even when nothing changed, causing
+	// gratuitous nft rule churn (and reshuffling index->backend, which only affects the random
+	// choice for new connections; established connections stay pinned by conntrack).
+	backends = dedupSortedBackends(backends)
+	if len(backends) == 0 {
+		return fmt.Errorf("cannot create nft dnat map for %s:%s (%s): no backends", v4ip, externalPort, protocol)
+	}
+
+	gwPod, err := c.getNatGwPod(dp, c.natGwNamespaceByName(dp))
+	if err != nil {
+		klog.Errorf("failed to get nat gw pod, %v", err)
+		return err
+	}
+
+	backendStr := strings.Join(backends, "@")
+	rule := fmt.Sprintf("%s,%s,%s,%s", v4ip, externalPort, protocol, backendStr)
+	if err = c.execNatGwRules(gwPod, natGwNftDnatMapAdd, []string{rule}); err != nil {
+		klog.Errorf("failed to create nft dnat map, err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// deleteNftDnatMapInPod deletes an nftables map-based DNAT rule by identity.
+// It removes the vmap element and the per-identity chain atomically.
+func (c *Controller) deleteNftDnatMapInPod(dp, protocol, v4ip, externalPort string) error {
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
+	gwPod, err := c.getNatGwPod(dp, c.natGwNamespaceByName(dp))
+	if err != nil {
+		klog.Errorf("failed to get nat gw pod, %v", err)
+		return err
+	}
+
+	rule := fmt.Sprintf("%s,%s,%s", v4ip, externalPort, protocol)
+	if err = c.execNatGwRules(gwPod, natGwNftDnatMapDel, []string{rule}); err != nil {
+		klog.Errorf("failed to delete nft dnat map, err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// dedupSortedBackends returns the unique backends in sorted order, dropping empty entries.
+func dedupSortedBackends(backends []string) []string {
+	if len(backends) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(backends))
+	uniq := make([]string, 0, len(backends))
+	for _, b := range backends {
+		if b == "" {
+			continue
+		}
+		if _, ok := seen[b]; ok {
+			continue
+		}
+		seen[b] = struct{}{}
+		uniq = append(uniq, b)
+	}
+	if len(uniq) == 0 {
+		return nil
+	}
+	sort.Strings(uniq)
+	return uniq
+}
+
+// getShareBackends queries all Share-type DNAT rules with the same identity (eip, externalPort, protocol)
+// and returns their backends. The current DNAT (identified by dnatName) is excluded from the results.
+//
+// Backends are derived from each sibling's Spec (not Status) on purpose: the nft map for a given
+// identity is global and is rebuilt in full by whichever sibling reconciles last. Relying on
+// Status.Ready would create a race across the add/update/delete queues, where a sibling that is
+// momentarily not-yet-Ready gets excluded and silently dropped from the map by the last writer.
+// A sibling's Spec backend is populated as soon as it exists, so using it makes the rebuild
+// order-independent. Siblings that are being deleted are skipped so their backend is not re-added.
+//
+// This relies on the informer cache being in sync: a sibling's Spec must already be visible in
+// the lister for its backend to be included. If a sibling was just created and its create event
+// has not yet propagated to this lister cache, the last writer will build a map that temporarily
+// omits that backend. This is not a bug: the missing sibling's own add/update event triggers a
+// later reconcile that rebuilds the full map, so the set self-heals to the complete backend list.
+func (c *Controller) getShareBackends(gwName, eipName, externalPort, protocol, dnatName string) ([]string, error) {
+	// The label selector only coarse-filters by gateway name + external port; the EIP
+	// identity is intentionally enforced as a Spec post-filter below (d.Spec.EIP != eipName)
+	// rather than added to the selector:
+	//   - EIP name cannot be a label value: IptablesEIP is a cluster-scoped CR whose name may be
+	//     up to 253 chars, exceeding the 63-char Kubernetes label-value limit, which would make
+	//     patchDnatLabel fail and stall reconcile. The authoritative identity is therefore matched
+	//     by name in the Spec post-filter, which has no length limit.
+	//   - EIP IP (EipV4IpLabel) could technically be added to the selector, but it gives no real
+	//     benefit. The informer registers only a namespace indexer (no label index), so
+	//     lister.List(selector) always does cache.ListAll: a full O(all-DNATs) scan that applies
+	//     selector.Matches per object. Adding EipV4IpLabel does not shrink that scan; it only moves
+	//     the EIP comparison from the post-filter loop into the per-object selector match during the
+	//     same full scan, so total work is unchanged (arguably a hair more). It would also couple
+	//     every call site (including the redo path, which only has cachedDnat.Status.V4ip and no eip
+	//     object) to the Spec.V4ip == Status.IP backfill invariant. We keep EIP as a single-source
+	//     Spec post-filter. A genuine speedup would require a dedicated label indexer, which is
+	//     over-engineering for this small per-(gw,eport) set.
+	// gwName + externalPort are safe selector dimensions: both are always populated, immutable
+	// (NatGwDp is webhook-immutable, externalPort comes straight from the DNAT Spec), and short.
+	// gwName is explicitly length-validated by the VpcNatGateway webhook via
+	// ValidateNatGwStatefulSetNameLength (<=52 chars, derived from the 63-char label-value limit
+	// minus the StatefulSet revision-hash suffix), so it always fits in a label value; IptablesEIP
+	// has no such name-length webhook, which is the real reason its name cannot be used as a label.
+	dnats, err := c.iptablesDnatRulesLister.List(labels.SelectorFromSet(labels.Set{
+		util.VpcNatGatewayNameLabel: gwName,
+		util.VpcDnatEPortLabel:      externalPort,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	var backends []string
+	for _, d := range dnats {
+		if d.Name == dnatName {
+			continue
+		}
+		if d.Spec.EIP != eipName || d.Spec.Protocol != protocol || d.Spec.ExternalPort != externalPort {
+			continue
+		}
+		if d.Spec.Type != kubeovnv1.DnatRuleTypeShare {
+			continue
+		}
+		if !d.DeletionTimestamp.IsZero() {
+			klog.V(4).Infof("skipping share dnat %s: being deleted", d.Name)
+			continue
+		}
+		if d.Spec.InternalIP == "" || d.Spec.InternalPort == "" {
+			klog.V(4).Infof("skipping share dnat %s: incomplete spec", d.Name)
+			continue
+		}
+		backends = append(backends, fmt.Sprintf("%s:%s", d.Spec.InternalIP, d.Spec.InternalPort))
+	}
+	return backends, nil
+}
+
+// cleanupShareDnatInPod rebuilds the share nft map with the remaining backends for the given
+// identity, or deletes the rule entirely when no backend is left after excluding dnatName.
+//
+// When a single backend is removed while the identity still has other backends, this rebuilds
+// the per-identity map in place without deleting the identity or flushing conntrack. Backends are
+// balanced with numgen random, so established connections are pinned by conntrack: connections to
+// surviving backends are unaffected, and connections to the removed backend are not flushed here
+// (they simply break once that backend is gone). New connections are distributed by the rebuilt
+// numgen random map. This is the expected behavior when detaching a backend from a load balancer.
+// Conntrack is only cleared on full identity deletion (see deleteNftDnatMapInPod /
+// del_nft_dnat_map in the gateway script).
+func (c *Controller) cleanupShareDnatInPod(key, gwName, eipName, protocol, v4ip, externalPort, dnatName string) error {
+	remainingBackends, err := c.getShareBackends(gwName, eipName, externalPort, protocol, dnatName)
+	if err != nil {
+		return fmt.Errorf("failed to get share backends for dnat %s: %w", key, err)
+	}
+	if len(remainingBackends) == 0 {
+		// No remaining backends, delete the nft rule
+		if err := c.deleteNftDnatMapInPod(gwName, protocol, v4ip, externalPort); err != nil {
+			return fmt.Errorf("failed to delete nft dnat map for %s: %w", key, err)
+		}
+		return nil
+	}
+	// Rebuild nft rule with remaining backends
+	if err := c.createNftDnatMapInPod(gwName, protocol, v4ip, externalPort, remainingBackends); err != nil {
+		return fmt.Errorf("failed to rebuild nft dnat map for %s: %w", key, err)
+	}
+	return nil
+}
+
+// isDnatDuplicated checks if a DNAT rule with the same identity already exists.
+// For Share type rules, multiple rules with the same identity can coexist.
+// For Exclusive type, only one rule per identity is allowed.
+//
+// Consistency note: this check (and the equivalent webhook check in ValidateIptablesDnat) reads
+// the informer lister / controller-runtime cache, which is only eventually consistent. If two
+// conflicting exclusive rules are created concurrently before either is visible in the cache,
+// both can pass this check and be admitted. This is a pre-existing limitation of the cache-based
+// duplicate detection, not specific to the share feature (the share feature only widens the set
+// of legitimately-coexisting objects under one identity). The reconcile loop is the eventual
+// authority: it re-runs this check on every sync, so a conflict that slipped through is detected
+// on a subsequent reconcile and the offending rule fails to become Ready (last-writer-wins /
+// eventual consistency). The webhook is best-effort admission-time protection, not a hard guarantee.
+func (c *Controller) isDnatDuplicated(gwName, eipName, dnatName, externalPort, protocol, dnatType string) (bool, error) {
+	// Check if the tuple "eip:external port:protocol" is already used by another DNAT rule.
+	// EIP identity is enforced via the Spec post-filter (d.Spec.EIP != eipName) below rather
+	// than in the selector; see getShareBackends for why EIP name/IP cannot be used as labels.
+	dnats, err := c.iptablesDnatRulesLister.List(labels.SelectorFromSet(labels.Set{
+		util.VpcNatGatewayNameLabel: gwName,
+		util.VpcDnatEPortLabel:      externalPort,
+	}))
+	if err != nil {
+		return false, err
+	}
+	if len(dnats) == 0 {
+		return false, nil
+	}
+
+	for _, d := range dnats {
+		if d.Name == dnatName || d.Spec.EIP != eipName || d.Spec.Protocol != protocol {
+			continue
+		}
+		// Found a DNAT with same identity
+		if dnatType == kubeovnv1.DnatRuleTypeShare && d.Spec.Type == kubeovnv1.DnatRuleTypeShare {
+			// Both are Share type, allow coexistence
+			continue
+		}
+		// Type conflict: Exclusive vs Share, or Exclusive vs Exclusive
+		err = fmt.Errorf("failed to create dnat %s, duplicate, same eip %s, same external port '%s', same protocol '%s' is used by dnat %s (type=%s)",
+			dnatName, eipName, externalPort, protocol, d.Name, d.Spec.Type)
+		return true, err
+	}
+	return false, nil
+}

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -553,7 +553,7 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
 	}
-	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, dnat.Spec.EIP, dnat.Name, dnat.Spec.ExternalPort, dnat.Spec.Protocol); dup || err != nil {
+	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, dnat.Spec.EIP, dnat.Name, dnat.Spec.ExternalPort, dnat.Spec.Protocol, dnat.Spec.Type); dup || err != nil {
 		klog.Error(err)
 		return err
 	}
@@ -564,11 +564,29 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		klog.Errorf("failed to handle add finalizer for dnat, %v", err)
 		return err
 	}
-	if err = c.createDnatInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol,
-		eip.Status.IP, dnat.Spec.InternalIP,
-		dnat.Spec.ExternalPort, dnat.Spec.InternalPort); err != nil {
-		klog.Errorf("failed to create dnat, %v", err)
-		return err
+
+	switch dnat.Spec.Type {
+	case kubeovnv1.DnatRuleTypeShare:
+		// Share type: use nft map-based DNAT
+		backends, err := c.getShareBackends(eip.Spec.NatGwDp, dnat.Spec.EIP, dnat.Spec.ExternalPort, dnat.Spec.Protocol, dnat.Name)
+		if err != nil {
+			klog.Errorf("failed to get share backends for dnat %s: %v", key, err)
+			return err
+		}
+		// Add current DNAT's backend
+		backends = append(backends, fmt.Sprintf("%s:%s", dnat.Spec.InternalIP, dnat.Spec.InternalPort))
+		if err = c.createNftDnatMapInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol, eip.Status.IP, dnat.Spec.ExternalPort, backends); err != nil {
+			klog.Errorf("failed to create nft dnat map, %v", err)
+			return err
+		}
+	default:
+		// Exclusive type (default): use iptables DNAT
+		if err = c.createDnatInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol,
+			eip.Status.IP, dnat.Spec.InternalIP,
+			dnat.Spec.ExternalPort, dnat.Spec.InternalPort); err != nil {
+			klog.Errorf("failed to create dnat, %v", err)
+			return err
+		}
 	}
 	if err = c.patchDnatStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 		klog.Errorf("failed to patch status for dnat %s, %v", key, err)
@@ -642,6 +660,13 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 	}
 	klog.V(3).Infof("handle update dnat %s", key)
 
+	// add or update should make sure vpc nat enabled. Checked before validateDnatRule and the
+	// isDnatDuplicated lister scan (matching handleAddIptablesDnatRule) so we do not scan when
+	// the NAT GW is disabled.
+	if vpcNatEnabled != "true" {
+		return errors.New("iptables nat gw not enable")
+	}
+
 	if err := c.validateDnatRule(cachedDnat); err != nil {
 		return err
 	}
@@ -651,13 +676,9 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
 	}
-	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Name, cachedDnat.Spec.ExternalPort, cachedDnat.Spec.Protocol); dup || err != nil {
+	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Name, cachedDnat.Spec.ExternalPort, cachedDnat.Spec.Protocol, cachedDnat.Spec.Type); dup || err != nil {
 		klog.Errorf("failed to update dnat, %v", err)
 		return err
-	}
-	// add or update should make sure vpc nat enabled
-	if vpcNatEnabled != "true" {
-		return errors.New("iptables nat gw not enable")
 	}
 
 	if eip.Spec.NatGwDp == "" {
@@ -717,11 +738,28 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		if err = c.finalDeleteDnatInPod(key, cachedDnat); err != nil {
 			return err
 		}
-		if err = c.createDnatInPod(eip.Spec.NatGwDp, newProtocol,
-			newV4ip, newInternalIP,
-			newExternalPort, newInternalPort); err != nil {
-			klog.Errorf("failed to create dnat %s, %v", key, err)
-			return err
+
+		switch cachedDnat.Spec.Type {
+		case kubeovnv1.DnatRuleTypeShare:
+			// Share type: rebuild nft rule with updated backends
+			backends, err := c.getShareBackends(eip.Spec.NatGwDp, cachedDnat.Spec.EIP, newExternalPort, newProtocol, cachedDnat.Name)
+			if err != nil {
+				klog.Errorf("failed to get share backends for dnat %s: %v", key, err)
+				return err
+			}
+			backends = append(backends, fmt.Sprintf("%s:%s", newInternalIP, newInternalPort))
+			if err = c.createNftDnatMapInPod(eip.Spec.NatGwDp, newProtocol, newV4ip, newExternalPort, backends); err != nil {
+				klog.Errorf("failed to create nft dnat map for %s, %v", key, err)
+				return err
+			}
+		default:
+			// Exclusive type: use iptables DNAT
+			if err = c.createDnatInPod(eip.Spec.NatGwDp, newProtocol,
+				newV4ip, newInternalIP,
+				newExternalPort, newInternalPort); err != nil {
+				klog.Errorf("failed to create dnat %s, %v", key, err)
+				return err
+			}
 		}
 		if err = c.patchDnatStatus(key, newV4ip, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 			klog.Errorf("failed to patch status for dnat %s, %v", key, err)
@@ -776,11 +814,33 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 			klog.V(3).Infof("dnat %s: all pods started before redo mark, rules intact, skip", key)
 			return nil
 		}
-		if err = c.createDnatInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol,
-			cachedDnat.Status.V4ip, cachedDnat.Status.InternalIP,
-			cachedDnat.Status.ExternalPort, cachedDnat.Status.InternalPort); err != nil {
-			klog.Errorf("failed to create dnat %s, %v", key, err)
-			return err
+
+		switch cachedDnat.Spec.Type {
+		case kubeovnv1.DnatRuleTypeShare:
+			// Share type: rebuild nft rule with all backends.
+			// Identity fields are read from Status (redo replays the last successfully-applied
+			// state after a gateway pod restart), except eipName which uses Spec.EIP on purpose:
+			// getShareBackends filters siblings by their Spec.EIP, so the lookup key must also be
+			// Spec.EIP to match. In the normal redo case Spec.EIP == Status EIP; they can only
+			// diverge in the rare "EIP renamed while not-yet-Ready + pod restart" corner case.
+			backends, err := c.getShareBackends(cachedDnat.Status.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Status.ExternalPort, cachedDnat.Status.Protocol, cachedDnat.Name)
+			if err != nil {
+				klog.Errorf("failed to get share backends for dnat %s: %v", key, err)
+				return err
+			}
+			backends = append(backends, fmt.Sprintf("%s:%s", cachedDnat.Status.InternalIP, cachedDnat.Status.InternalPort))
+			if err = c.createNftDnatMapInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol, cachedDnat.Status.V4ip, cachedDnat.Status.ExternalPort, backends); err != nil {
+				klog.Errorf("failed to create nft dnat map for %s, %v", key, err)
+				return err
+			}
+		default:
+			// Exclusive type: use iptables DNAT
+			if err = c.createDnatInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol,
+				cachedDnat.Status.V4ip, cachedDnat.Status.InternalIP,
+				cachedDnat.Status.ExternalPort, cachedDnat.Status.InternalPort); err != nil {
+				klog.Errorf("failed to create dnat %s, %v", key, err)
+				return err
+			}
 		}
 		if err = c.patchDnatStatus(key, "", "", "", "", true); err != nil {
 			klog.Errorf("failed to patch status for dnat %s, %v", key, err)
@@ -1842,6 +1902,12 @@ func (c *Controller) finalDeleteDnatInPod(key string, cachedDnat *kubeovnv1.Ipta
 	}
 	if statusV4ip == "" || statusNatGwDp == "" {
 		klog.Warningf("dnat %s: skip status-based cleanup due to incomplete identity (v4ip=%q, natGwDp=%q)", key, statusV4ip, statusNatGwDp)
+	} else if cachedDnat.Spec.Type == kubeovnv1.DnatRuleTypeShare {
+		// Share type: rebuild nft rule with remaining backends, or delete if none are left
+		if err := c.cleanupShareDnatInPod(key, statusNatGwDp, cachedDnat.Spec.EIP, statusProtocol, statusV4ip, statusExternalPort, cachedDnat.Name); err != nil {
+			klog.Error(err)
+			firstErr = err
+		}
 	} else if err := c.deleteDnatInPod(statusNatGwDp, statusProtocol,
 		statusV4ip, statusExternalPort); err != nil {
 		klog.Errorf("failed to delete dnat %s, %v", key, err)
@@ -1869,7 +1935,16 @@ func (c *Controller) finalDeleteDnatInPod(key string, cachedDnat *kubeovnv1.Ipta
 			return firstErr
 		}
 		if specV4ip != statusV4ip || specNatGwDp != statusNatGwDp || specProtocol != statusProtocol || specExternalPort != statusExternalPort {
-			if err = c.deleteDnatInPod(specNatGwDp, specProtocol, specV4ip, specExternalPort); err != nil {
+			if cachedDnat.Spec.Type == kubeovnv1.DnatRuleTypeShare {
+				// Share type: the stale rule lives in nftables, not iptables.
+				// Rebuild the nft map without this DNAT's backend, or delete entirely.
+				if err = c.cleanupShareDnatInPod(key, specNatGwDp, cachedDnat.Spec.EIP, specProtocol, specV4ip, specExternalPort, cachedDnat.Name); err != nil {
+					klog.Errorf("failed spec-based nft cleanup for dnat %s, %v", key, err)
+					if firstErr == nil {
+						firstErr = err
+					}
+				}
+			} else if err = c.deleteDnatInPod(specNatGwDp, specProtocol, specV4ip, specExternalPort); err != nil {
 				klog.Errorf("failed spec-based cleanup for dnat %s, %v", key, err)
 				if firstErr == nil {
 					firstErr = err
@@ -2123,28 +2198,6 @@ func (c *Controller) deleteSnatInPod(dp, v4ip, internalCIDR string) error {
 		}
 	}
 	return firstErr
-}
-
-func (c *Controller) isDnatDuplicated(gwName, eipName, dnatName, externalPort, protocol string) (bool, error) {
-	// Check if the tuple "eip:external port:protocol" is already used by another DNAT rule
-	dnats, err := c.iptablesDnatRulesLister.List(labels.SelectorFromSet(labels.Set{
-		util.VpcNatGatewayNameLabel: gwName,
-		util.VpcDnatEPortLabel:      externalPort,
-	}))
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return false, err
-		}
-	}
-	if len(dnats) != 0 {
-		for _, d := range dnats {
-			if d.Name != dnatName && d.Spec.EIP == eipName && d.Spec.Protocol == protocol {
-				err = fmt.Errorf("failed to create dnat %s, duplicate, same eip %s, same external port '%s', same protocol'%s' is used by dnat %s", dnatName, eipName, externalPort, protocol, d.Name)
-				return true, err
-			}
-		}
-	}
-	return false, nil
 }
 
 func (c *Controller) updateIptableLabels(name, op, natType string, labels map[string]string) error {

--- a/pkg/controller/vpc_nat_gw_nat_test.go
+++ b/pkg/controller/vpc_nat_gw_nat_test.go
@@ -2,12 +2,16 @@ package controller
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func TestValidateDnat(t *testing.T) {
@@ -547,4 +551,144 @@ func TestDeleteSnatInPod_NatGwExistsPodMissing(t *testing.T) {
 	require.NoError(t, err)
 	err = fc.fakeController.deleteSnatInPod("test-gw", "10.0.0.1", "192.168.1.0/24")
 	require.Error(t, err, "should return error to retry when pod is temporarily absent")
+}
+
+// shareDnat builds an IptablesDnatRule with the identity labels that getShareBackends
+// and isDnatDuplicated select on. dnatType may be "" (defaults to exclusive behavior).
+func shareDnat(name, gw, eip, eport, proto, intIP, intPort, dnatType string) *kubeovnv1.IptablesDnatRule {
+	return &kubeovnv1.IptablesDnatRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				util.VpcNatGatewayNameLabel: gw,
+				util.VpcDnatEPortLabel:      eport,
+			},
+		},
+		Spec: kubeovnv1.IptablesDnatRuleSpec{
+			EIP:          eip,
+			ExternalPort: eport,
+			Protocol:     proto,
+			InternalIP:   intIP,
+			InternalPort: intPort,
+			Type:         dnatType,
+		},
+	}
+}
+
+// dnatListerController returns a Controller whose iptablesDnatRulesLister is backed by the
+// given objects, so lister-based helpers can be unit tested without a running informer.
+func dnatListerController(t *testing.T, dnats ...*kubeovnv1.IptablesDnatRule) *Controller {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, d := range dnats {
+		require.NoError(t, indexer.Add(d))
+	}
+	return &Controller{iptablesDnatRulesLister: kubeovnlister.NewIptablesDnatRuleLister(indexer)}
+}
+
+func TestDedupSortedBackends(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "nil", in: nil, want: nil},
+		{name: "empty entries dropped", in: []string{"", ""}, want: nil},
+		{
+			name: "dedup and sort",
+			in:   []string{"10.0.0.2:80", "10.0.0.1:80", "10.0.0.2:80", "", "10.0.0.3:80"},
+			want: []string{"10.0.0.1:80", "10.0.0.2:80", "10.0.0.3:80"},
+		},
+		{
+			name: "already unique stays sorted",
+			in:   []string{"10.0.0.1:80", "10.0.0.2:80"},
+			want: []string{"10.0.0.1:80", "10.0.0.2:80"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, dedupSortedBackends(tt.in))
+		})
+	}
+}
+
+func TestGetShareBackends(t *testing.T) {
+	t.Parallel()
+
+	deleting := shareDnat("deleting", "gw", "eip", "80", "tcp", "10.0.0.5", "8080", kubeovnv1.DnatRuleTypeShare)
+	deleting.DeletionTimestamp = &metav1.Time{Time: time.Unix(1, 0)}
+
+	c := dnatListerController(t,
+		shareDnat("self", "gw", "eip", "80", "tcp", "10.0.0.9", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("d1", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("d2", "gw", "eip", "80", "tcp", "10.0.0.2", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("exclusive", "gw", "eip", "80", "tcp", "10.0.0.3", "8080", kubeovnv1.DnatRuleTypeExclusive),
+		shareDnat("other-proto", "gw", "eip", "80", "udp", "10.0.0.4", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("other-eip", "gw", "eip2", "80", "tcp", "10.0.0.6", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("incomplete", "gw", "eip", "80", "tcp", "", "8080", kubeovnv1.DnatRuleTypeShare),
+		deleting,
+	)
+
+	backends, err := c.getShareBackends("gw", "eip", "80", "tcp", "self")
+	require.NoError(t, err)
+	// Self is excluded; only ready share siblings with the same identity are returned.
+	// Exclusive, other protocol/eip, incomplete spec and deleting rules are filtered out.
+	assert.ElementsMatch(t, []string{"10.0.0.1:8080", "10.0.0.2:8080"}, backends)
+}
+
+func TestIsDnatDuplicated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		existing *kubeovnv1.IptablesDnatRule
+		newType  string
+		wantDup  bool
+	}{
+		{
+			name:     "exclusive vs existing exclusive is duplicate",
+			existing: shareDnat("other", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeExclusive),
+			newType:  kubeovnv1.DnatRuleTypeExclusive,
+			wantDup:  true,
+		},
+		{
+			name:     "share vs existing share coexist",
+			existing: shareDnat("other", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeShare),
+			newType:  kubeovnv1.DnatRuleTypeShare,
+			wantDup:  false,
+		},
+		{
+			name:     "exclusive vs existing share is duplicate",
+			existing: shareDnat("other", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeShare),
+			newType:  kubeovnv1.DnatRuleTypeExclusive,
+			wantDup:  true,
+		},
+		{
+			name:     "share vs existing exclusive is duplicate",
+			existing: shareDnat("other", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeExclusive),
+			newType:  kubeovnv1.DnatRuleTypeShare,
+			wantDup:  true,
+		},
+		{
+			name:     "different protocol is not duplicate",
+			existing: shareDnat("other", "gw", "eip", "80", "udp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeExclusive),
+			newType:  kubeovnv1.DnatRuleTypeExclusive,
+			wantDup:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := dnatListerController(t, tt.existing)
+			dup, err := c.isDnatDuplicated("gw", "eip", "new", "80", "tcp", tt.newType)
+			assert.Equal(t, tt.wantDup, dup)
+			if tt.wantDup {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -244,6 +243,19 @@ func (v *ValidatingHook) iptablesDnatUpdateHook(ctx context.Context, req admissi
 	}
 
 	if dnatNew.Spec != dnatOld.Spec {
+		// Type is immutable after creation
+		oldType := dnatOld.Spec.Type
+		if oldType == "" {
+			oldType = ovnv1.DnatRuleTypeExclusive
+		}
+		newType := dnatNew.Spec.Type
+		if newType == "" {
+			newType = ovnv1.DnatRuleTypeExclusive
+		}
+		if oldType != newType {
+			return ctrlwebhook.Errored(http.StatusBadRequest, fmt.Errorf("dnat type is immutable after creation: cannot change from %q to %q", oldType, newType))
+		}
+
 		if err := v.ValidateVpcNatConfig(ctx); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
@@ -521,20 +533,12 @@ func (v *ValidatingHook) ValidateIptablesDnat(ctx context.Context, dnat *ovnv1.I
 		return errors.New("parameter \"internalPort\" cannot be empty")
 	}
 
-	if port, err := strconv.Atoi(dnat.Spec.ExternalPort); err != nil {
-		errMsg := fmt.Errorf("failed to parse externalPort %s: %w", dnat.Spec.ExternalPort, err)
-		return errMsg
-	} else if port < 0 || port > 65535 {
-		err := fmt.Errorf("externalPort %s is not a valid port", dnat.Spec.ExternalPort)
-		return err
+	if err := util.ValidatePort(dnat.Spec.ExternalPort); err != nil {
+		return fmt.Errorf("externalPort %s is not a valid port: %w", dnat.Spec.ExternalPort, err)
 	}
 
-	if port, err := strconv.Atoi(dnat.Spec.InternalPort); err != nil {
-		errMsg := fmt.Errorf("failed to parse internalIP %s: %w", dnat.Spec.InternalPort, err)
-		return errMsg
-	} else if port < 0 || port > 65535 {
-		err := fmt.Errorf("internalIP %s is not a valid port", dnat.Spec.InternalPort)
-		return err
+	if err := util.ValidatePort(dnat.Spec.InternalPort); err != nil {
+		return fmt.Errorf("internalPort %s is not a valid port: %w", dnat.Spec.InternalPort, err)
 	}
 
 	if net.ParseIP(dnat.Spec.InternalIP) == nil {
@@ -546,6 +550,53 @@ func (v *ValidatingHook) ValidateIptablesDnat(ctx context.Context, dnat *ovnv1.I
 		!strings.EqualFold(dnat.Spec.Protocol, "udp") {
 		err := fmt.Errorf("invalid iptable protocol: %s,supported params: \"tcp\", \"udp\"", dnat.Spec.Protocol)
 		return err
+	}
+
+	// Default type to Exclusive if empty
+	dnatType := dnat.Spec.Type
+	if dnatType == "" {
+		dnatType = ovnv1.DnatRuleTypeExclusive
+	}
+
+	// Share type DNAT is implemented with IPv4-only nft rules (ip daddr / ip saddr).
+	// Reject it for a v6-only EIP. EIPs that are still being allocated (both addresses
+	// empty) are allowed here; the controller requeues until the IPv4 address is ready.
+	if dnatType == ovnv1.DnatRuleTypeShare && eip.Spec.V4ip == "" && eip.Spec.V6ip != "" {
+		return fmt.Errorf("dnat %q cannot use type=share: EIP %q is IPv6-only, share dnat only supports IPv4", dnat.Name, dnat.Spec.EIP)
+	}
+
+	// Check type conflict with existing DNAT rules sharing the same identity
+	if eip.Spec.NatGwDp != "" {
+		dnatList := &ovnv1.IptablesDnatRuleList{}
+		if err := v.cache.List(ctx, dnatList, cli.MatchingLabels{
+			util.VpcNatGatewayNameLabel: eip.Spec.NatGwDp,
+			util.VpcDnatEPortLabel:      dnat.Spec.ExternalPort,
+		}); err != nil {
+			return fmt.Errorf("failed to list iptables DNAT rules: %w", err)
+		}
+
+		for _, existing := range dnatList.Items {
+			// Skip self (for update hooks)
+			if existing.Name == dnat.Name {
+				continue
+			}
+			// Only check same identity (EIP + Protocol)
+			if existing.Spec.EIP != dnat.Spec.EIP || existing.Spec.Protocol != dnat.Spec.Protocol {
+				continue
+			}
+
+			existingType := existing.Spec.Type
+			if existingType == "" {
+				existingType = ovnv1.DnatRuleTypeExclusive
+			}
+
+			// Both must be Share type to coexist
+			if dnatType != ovnv1.DnatRuleTypeShare || existingType != ovnv1.DnatRuleTypeShare {
+				return fmt.Errorf("dnat %q (type=%s) conflicts with existing dnat %q (type=%s) sharing the same identity (eip=%s, port=%s, protocol=%s): both must be type=share to coexist",
+					dnat.Name, dnatType, existing.Name, existingType,
+					dnat.Spec.EIP, dnat.Spec.ExternalPort, dnat.Spec.Protocol)
+			}
+		}
 	}
 
 	// Check FIP/DNAT exclusivity: FIP claims all traffic to the EIP (EXCLUSIVE_DNAT),

--- a/pkg/webhook/vpc_nat_gateway_test.go
+++ b/pkg/webhook/vpc_nat_gateway_test.go
@@ -41,6 +41,8 @@ func (m *mockCache) Get(_ context.Context, key client.ObjectKey, obj client.Obje
 		*t = *(o.(*corev1.ConfigMap))
 	case *ovnv1.QoSPolicy:
 		*t = *(o.(*ovnv1.QoSPolicy))
+	case *ovnv1.IptablesEIP:
+		*t = *(o.(*ovnv1.IptablesEIP))
 	default:
 		return fmt.Errorf("unsupported type in mock cache: %T", obj)
 	}
@@ -462,4 +464,55 @@ func TestVpcNatGwCreateOrUpdateHook(t *testing.T) {
 		require.False(t, resp.Allowed)
 		require.Equal(t, int32(http.StatusBadRequest), resp.Result.Code)
 	})
+}
+
+func TestValidateIptablesDnat(t *testing.T) {
+	newDnat := func(externalPort, internalPort string) *ovnv1.IptablesDnatRule {
+		return &ovnv1.IptablesDnatRule{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dnat"},
+			Spec: ovnv1.IptablesDnatRuleSpec{
+				EIP:          "test-eip",
+				ExternalPort: externalPort,
+				InternalPort: internalPort,
+				InternalIP:   "10.0.0.10",
+				Protocol:     "tcp",
+			},
+		}
+	}
+
+	cache := &mockCache{
+		objects: map[string]runtime.Object{
+			"/test-eip": &ovnv1.IptablesEIP{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-eip"},
+				Spec:       ovnv1.IptablesEIPSpec{V4ip: "192.168.0.1"},
+			},
+		},
+	}
+	v := &ValidatingHook{cache: cache}
+
+	tests := []struct {
+		name         string
+		externalPort string
+		internalPort string
+		wantErr      bool
+	}{
+		{name: "valid ports", externalPort: "8080", internalPort: "80", wantErr: false},
+		{name: "min valid port", externalPort: "1", internalPort: "1", wantErr: false},
+		{name: "max valid port", externalPort: "65535", internalPort: "65535", wantErr: false},
+		{name: "external port zero rejected", externalPort: "0", internalPort: "80", wantErr: true},
+		{name: "internal port zero rejected", externalPort: "8080", internalPort: "0", wantErr: true},
+		{name: "external port over range rejected", externalPort: "65536", internalPort: "80", wantErr: true},
+		{name: "external port non-numeric rejected", externalPort: "abc", internalPort: "80", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateIptablesDnat(context.Background(), newDnat(tt.externalPort, tt.internalPort))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/test/e2e/framework/iptables-dnat.go
+++ b/test/e2e/framework/iptables-dnat.go
@@ -51,6 +51,13 @@ func (c *IptablesDnatClient) Create(dnat *apiv1.IptablesDnatRule) *apiv1.Iptable
 	return dnat.DeepCopy()
 }
 
+// CreateRaw creates a new iptables dnat and returns the result without auto-failing on error.
+// Use this when testing expected validation failures.
+func (c *IptablesDnatClient) CreateRaw(dnat *apiv1.IptablesDnatRule) (*apiv1.IptablesDnatRule, error) {
+	ginkgo.GinkgoHelper()
+	return c.IptablesDnatRuleInterface.Create(context.TODO(), dnat, metav1.CreateOptions{})
+}
+
 // CreateSync creates a new iptables dnat according to the framework specifications, and waits for it to be ready.
 func (c *IptablesDnatClient) CreateSync(dnat *apiv1.IptablesDnatRule) *apiv1.IptablesDnatRule {
 	ginkgo.GinkgoHelper()
@@ -173,5 +180,12 @@ func MakeIptablesDnatRule(name, eip, externalPort, protocol, internalIP, interna
 			InternalPort: internalPort,
 		},
 	}
+	return dnat
+}
+
+// MakeShareIptablesDnatRule creates a share type iptables DNAT rule.
+func MakeShareIptablesDnatRule(name, eip, externalPort, protocol, internalIP, internalPort string) *apiv1.IptablesDnatRule {
+	dnat := MakeIptablesDnatRule(name, eip, externalPort, protocol, internalIP, internalPort)
+	dnat.Spec.Type = apiv1.DnatRuleTypeShare
 	return dnat
 }

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -286,6 +286,40 @@ func iptablesSaveNat(natGwPodName string) string {
 	return string(stdout)
 }
 
+// nftDnatMapRuleExists checks if the nft map-based DNAT rule exists in the NAT gateway pod.
+// Architecture: table kube-ovn → named vmap "service-ips" → per-identity chain "dnat-XXXXXXXX"
+// The per-identity chain contains: numgen random mod N dnat to ip addr . port map { backends }
+func nftDnatMapRuleExists(natGwPodName, eip, externalPort, protocol string, backends []string) bool {
+	// List the entire table to see all chains and their rules
+	cmd := []string{"nft list table ip kube-ovn 2>/dev/null || true"}
+	stdout, _, err := framework.KubectlExec(framework.KubeOvnNamespace, natGwPodName, cmd...)
+	if err != nil {
+		return false
+	}
+	output := string(stdout)
+
+	// Check if the vmap element for this identity exists (eip . proto . port : goto chain)
+	nftProto := strings.ToLower(protocol)
+	vmapEntry := fmt.Sprintf("%s . %s . %s : goto", eip, nftProto, externalPort)
+	if !strings.Contains(output, vmapEntry) {
+		return false
+	}
+
+	// Check if the rule contains the expected number of backends (mod N)
+	modPattern := fmt.Sprintf(`numgen random mod %d map`, len(backends))
+	if !strings.Contains(output, modPattern) {
+		return false
+	}
+
+	// Check if all backends are present in the rule
+	for _, backend := range backends {
+		if !strings.Contains(output, backend) {
+			return false
+		}
+	}
+	return true
+}
+
 // hairpinSnatChainExists checks if the HAIRPIN_SNAT chain exists in the NAT gateway pod.
 // Returns false on older versions that don't support this feature.
 func hairpinSnatChainExists(natGwPodName string) bool {
@@ -1017,6 +1051,399 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 			"DNAT rule should be removed from iptables after DNAT deletion")
 
 		// All cleanup is handled by DeferCleanup above, no need for manual cleanup
+	})
+
+	framework.ConformanceIt("[share-dnat] manage share type DNAT rules with nft map-based LB", func() {
+		f.SkipVersionPriorTo(1, 17, "Share type DNAT was introduced in v1.17")
+
+		// Test-specific variables
+		randomSuffix := framework.RandomSuffix()
+		shareDnatEipName := "share-dnat-eip-" + randomSuffix
+		shareDnatVip1Name := "share-dnat-vip1-" + randomSuffix
+		shareDnatVip2Name := "share-dnat-vip2-" + randomSuffix
+		shareDnatVip3Name := "share-dnat-vip3-" + randomSuffix
+		shareDnatName1 := "share-dnat-1-" + randomSuffix
+		shareDnatName2 := "share-dnat-2-" + randomSuffix
+		shareDnatName3 := "share-dnat-3-" + randomSuffix
+
+		overlaySubnetV4Cidr := "10.0.4.0/24"
+		overlaySubnetV4Gw := "10.0.4.1"
+		lanIP := "10.0.4.254"
+		natgwQoS := ""
+		setupVpcNatGwTestEnvironment(
+			f, dockerExtNet1Network, attachNetClient,
+			subnetClient, vpcClient, vpcNatGwClient,
+			vpcName, overlaySubnetName, vpcNatGwName, natgwQoS,
+			overlaySubnetV4Cidr, overlaySubnetV4Gw, lanIP,
+			dockerExtNet1Name, networkAttachDefName, net1NicName,
+			externalSubnetProvider,
+			true, // skipNADSetup: shared NAD created in BeforeAll
+			nil,  // no custom annotations
+			"",   // gwNamespace: use default (PodNamespace)
+			0,
+		)
+
+		ginkgo.By("Creating iptables vip for share dnat")
+		shareDnatVip1 := framework.MakeVip(f.Namespace.Name, shareDnatVip1Name, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(shareDnatVip1)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat vip1 " + shareDnatVip1Name)
+			vipClient.DeleteSync(shareDnatVip1Name)
+		})
+		shareDnatVip1 = vipClient.Get(shareDnatVip1Name)
+
+		shareDnatVip2 := framework.MakeVip(f.Namespace.Name, shareDnatVip2Name, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(shareDnatVip2)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat vip2 " + shareDnatVip2Name)
+			vipClient.DeleteSync(shareDnatVip2Name)
+		})
+		shareDnatVip2 = vipClient.Get(shareDnatVip2Name)
+
+		shareDnatVip3 := framework.MakeVip(f.Namespace.Name, shareDnatVip3Name, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(shareDnatVip3)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat vip3 " + shareDnatVip3Name)
+			vipClient.DeleteSync(shareDnatVip3Name)
+		})
+		shareDnatVip3 = vipClient.Get(shareDnatVip3Name)
+
+		ginkgo.By("Creating iptables eip for share dnat")
+		shareDnatEip := framework.MakeIptablesEIP(shareDnatEipName, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(shareDnatEip)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat eip " + shareDnatEipName)
+			iptablesEIPClient.DeleteSync(shareDnatEipName)
+		})
+		shareDnatEip = iptablesEIPClient.Get(shareDnatEipName)
+
+		ginkgo.By("Creating first share type DNAT rule")
+		vpcNatGwPodName := util.GenNatGwPodName(vpcNatGwName)
+		shareDnat1 := framework.MakeShareIptablesDnatRule(shareDnatName1, shareDnatEipName, "80", "tcp", shareDnatVip1.Status.V4ip, "8080")
+		_ = iptablesDnatRuleClient.CreateSync(shareDnat1)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat1 " + shareDnatName1)
+			iptablesDnatRuleClient.DeleteSync(shareDnatName1)
+		})
+
+		ginkgo.By("Verifying nft DNAT map rule exists with 1 backend")
+		gomega.Eventually(func() bool {
+			return nftDnatMapRuleExists(vpcNatGwPodName, shareDnatEip.Status.IP, "80", "tcp",
+				[]string{shareDnatVip1.Status.V4ip + " . 8080"})
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"nft DNAT map rule should exist with 1 backend after first share DNAT creation")
+
+		ginkgo.By("Creating second share type DNAT rule with same identity")
+		shareDnat2 := framework.MakeShareIptablesDnatRule(shareDnatName2, shareDnatEipName, "80", "tcp", shareDnatVip2.Status.V4ip, "8080")
+		_ = iptablesDnatRuleClient.CreateSync(shareDnat2)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat2 " + shareDnatName2)
+			iptablesDnatRuleClient.DeleteSync(shareDnatName2)
+		})
+
+		ginkgo.By("Verifying nft DNAT map rule exists with 2 backends")
+		gomega.Eventually(func() bool {
+			return nftDnatMapRuleExists(vpcNatGwPodName, shareDnatEip.Status.IP, "80", "tcp",
+				[]string{shareDnatVip1.Status.V4ip + " . 8080", shareDnatVip2.Status.V4ip + " . 8080"})
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"nft DNAT map rule should exist with 2 backends after second share DNAT creation")
+
+		ginkgo.By("Creating third share type DNAT rule with same identity")
+		shareDnat3 := framework.MakeShareIptablesDnatRule(shareDnatName3, shareDnatEipName, "80", "tcp", shareDnatVip3.Status.V4ip, "8080")
+		_ = iptablesDnatRuleClient.CreateSync(shareDnat3)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat3 " + shareDnatName3)
+			iptablesDnatRuleClient.DeleteSync(shareDnatName3)
+		})
+
+		ginkgo.By("Verifying nft DNAT map rule exists with 3 backends")
+		gomega.Eventually(func() bool {
+			return nftDnatMapRuleExists(vpcNatGwPodName, shareDnatEip.Status.IP, "80", "tcp",
+				[]string{shareDnatVip1.Status.V4ip + " . 8080", shareDnatVip2.Status.V4ip + " . 8080", shareDnatVip3.Status.V4ip + " . 8080"})
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"nft DNAT map rule should exist with 3 backends after third share DNAT creation")
+
+		ginkgo.By("Deleting second share DNAT rule")
+		iptablesDnatRuleClient.DeleteSync(shareDnatName2)
+
+		ginkgo.By("Verifying nft DNAT map rule is rebuilt with 2 backends")
+		gomega.Eventually(func() bool {
+			return nftDnatMapRuleExists(vpcNatGwPodName, shareDnatEip.Status.IP, "80", "tcp",
+				[]string{shareDnatVip1.Status.V4ip + " . 8080", shareDnatVip3.Status.V4ip + " . 8080"})
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"nft DNAT map rule should be rebuilt with 2 backends after deleting one share DNAT")
+
+		ginkgo.By("Deleting remaining share DNAT rules")
+		iptablesDnatRuleClient.DeleteSync(shareDnatName1)
+		iptablesDnatRuleClient.DeleteSync(shareDnatName3)
+
+		ginkgo.By("Verifying nft DNAT map rule is removed after all share DNATs are deleted")
+		gomega.Eventually(func() bool {
+			return nftDnatMapRuleExists(vpcNatGwPodName, shareDnatEip.Status.IP, "80", "tcp", nil)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"nft DNAT map rule should be removed after all share DNATs are deleted")
+	})
+
+	framework.ConformanceIt("[share-dnat-dataplane] share DNAT distributes traffic and manages conntrack", func() {
+		f.SkipVersionPriorTo(1, 17, "Share type DNAT was introduced in v1.17")
+
+		randomSuffix := framework.RandomSuffix()
+		dpEipName := "share-dp-eip-" + randomSuffix
+		dpSrv1Name := "share-dp-srv1-" + randomSuffix
+		dpSrv2Name := "share-dp-srv2-" + randomSuffix
+		dpClientName := "share-dp-client-" + randomSuffix
+		dpDnat1Name := "share-dp-dnat1-" + randomSuffix
+		dpDnat2Name := "share-dp-dnat2-" + randomSuffix
+		const backendPort = "8080"
+		const extPort = "80"
+
+		overlaySubnetV4Cidr := "10.0.7.0/24"
+		overlaySubnetV4Gw := "10.0.7.1"
+		lanIP := "10.0.7.254"
+		setupVpcNatGwTestEnvironment(
+			f, dockerExtNet1Network, attachNetClient,
+			subnetClient, vpcClient, vpcNatGwClient,
+			vpcName, overlaySubnetName, vpcNatGwName, "",
+			overlaySubnetV4Cidr, overlaySubnetV4Gw, lanIP,
+			dockerExtNet1Name, networkAttachDefName, net1NicName,
+			externalSubnetProvider,
+			true, // skipNADSetup: shared NAD created in BeforeAll
+			nil,  // no custom annotations
+			"",   // gwNamespace: use default (PodNamespace)
+			0,
+		)
+		vpcNatGwPodName := util.GenNatGwPodName(vpcNatGwName)
+
+		// conntrackHasEntries reports whether the NAT gateway has any conntrack entry
+		// for the share DNAT external port. KubectlExec joins args with a space and runs
+		// them via "/bin/sh -c", so pass the whole script as a single string.
+		conntrackHasEntries := func() bool {
+			cmd := []string{fmt.Sprintf("conntrack -L 2>/dev/null | grep -q 'dport=%s' && echo yes || echo no", extPort)}
+			stdout, _, err := framework.KubectlExec(framework.KubeOvnNamespace, vpcNatGwPodName, cmd...)
+			if err != nil {
+				return false
+			}
+			return strings.Contains(string(stdout), "yes")
+		}
+		// curlHostnames curls the EIP a number of times and returns the set of backend
+		// hostnames (agnhost /hostname) that answered, proving traffic distribution.
+		curlHostnames := func(eip string, times int) map[string]int {
+			cmd := []string{fmt.Sprintf("for i in $(seq 1 %d); do curl -s -m 5 http://%s:%s/hostname; echo; done", times, eip, extPort)}
+			stdout, _, err := framework.KubectlExec(f.Namespace.Name, dpClientName, cmd...)
+			hits := map[string]int{}
+			if err != nil {
+				return hits
+			}
+			for line := range strings.SplitSeq(strings.TrimSpace(string(stdout)), "\n") {
+				if h := strings.TrimSpace(line); h != "" {
+					hits[h]++
+				}
+			}
+			return hits
+		}
+
+		ginkgo.By("Creating two agnhost backend servers in the overlay subnet")
+		serverArgs := []string{"netexec", "--http-port", backendPort}
+		serverAnnotations := map[string]string{util.LogicalSwitchAnnotation: overlaySubnetName}
+		srv1 := framework.MakePod(f.Namespace.Name, dpSrv1Name, nil, serverAnnotations, framework.AgnhostImage, nil, serverArgs)
+		_ = podClient.CreateSync(srv1)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat server1 " + dpSrv1Name)
+			podClient.DeleteSync(dpSrv1Name)
+		})
+		srv2 := framework.MakePod(f.Namespace.Name, dpSrv2Name, nil, serverAnnotations, framework.AgnhostImage, nil, serverArgs)
+		_ = podClient.CreateSync(srv2)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat server2 " + dpSrv2Name)
+			podClient.DeleteSync(dpSrv2Name)
+		})
+		srv1IP := podClient.GetPod(dpSrv1Name).Annotations[util.IPAddressAnnotation]
+		srv2IP := podClient.GetPod(dpSrv2Name).Annotations[util.IPAddressAnnotation]
+		framework.ExpectNotEmpty(srv1IP, "server1 should have an IP assigned")
+		framework.ExpectNotEmpty(srv2IP, "server2 should have an IP assigned")
+
+		ginkgo.By("Creating EIP for share dnat data-plane test")
+		dpEip := framework.MakeIptablesEIP(dpEipName, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(dpEip)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat dp eip " + dpEipName)
+			iptablesEIPClient.DeleteSync(dpEipName)
+		})
+		dpEip = iptablesEIPClient.Get(dpEipName)
+		framework.ExpectNotEmpty(dpEip.Status.IP, "share dnat dp EIP should have an IP assigned")
+
+		ginkgo.By("Creating two share DNAT rules pointing to the two backends")
+		dnat1 := framework.MakeShareIptablesDnatRule(dpDnat1Name, dpEipName, extPort, "tcp", srv1IP, backendPort)
+		_ = iptablesDnatRuleClient.CreateSync(dnat1)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat dp dnat1 " + dpDnat1Name)
+			iptablesDnatRuleClient.DeleteSync(dpDnat1Name)
+		})
+		dnat2 := framework.MakeShareIptablesDnatRule(dpDnat2Name, dpEipName, extPort, "tcp", srv2IP, backendPort)
+		_ = iptablesDnatRuleClient.CreateSync(dnat2)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat dp dnat2 " + dpDnat2Name)
+			iptablesDnatRuleClient.DeleteSync(dpDnat2Name)
+		})
+
+		ginkgo.By("Waiting for the nft map to contain both backends")
+		gomega.Eventually(func() bool {
+			return nftDnatMapRuleExists(vpcNatGwPodName, dpEip.Status.IP, extPort, "tcp",
+				[]string{srv1IP + " . " + backendPort, srv2IP + " . " + backendPort})
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"nft map should contain both share DNAT backends")
+
+		ginkgo.By("Creating a client pod in the overlay subnet")
+		clientPod := framework.MakePod(f.Namespace.Name, dpClientName, nil,
+			map[string]string{util.LogicalSwitchAnnotation: overlaySubnetName},
+			framework.AgnhostImage, nil, []string{"pause"})
+		_ = podClient.CreateSync(clientPod)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up share dnat dp client " + dpClientName)
+			podClient.DeleteSync(dpClientName)
+		})
+
+		ginkgo.By("Verifying traffic is distributed across BOTH backends")
+		gomega.Eventually(func() bool {
+			hits := curlHostnames(dpEip.Status.IP, 20)
+			return hits[dpSrv1Name] > 0 && hits[dpSrv2Name] > 0
+		}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+			"share DNAT should distribute traffic across both backends (numgen random)")
+
+		ginkgo.By("Verifying conntrack entries were established for the identity")
+		gomega.Expect(conntrackHasEntries()).To(gomega.BeTrue(),
+			"conntrack should have entries for the share DNAT identity after traffic")
+
+		ginkgo.By("Removing one backend: identity remains, conntrack must NOT be flushed")
+		iptablesDnatRuleClient.DeleteSync(dpDnat2Name)
+		gomega.Eventually(func() bool {
+			return nftDnatMapRuleExists(vpcNatGwPodName, dpEip.Status.IP, extPort, "tcp",
+				[]string{srv1IP + " . " + backendPort})
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			"nft map should be rebuilt with the surviving backend only")
+		gomega.Expect(conntrackHasEntries()).To(gomega.BeTrue(),
+			"removing a single backend must not flush conntrack (surviving backends unaffected)")
+
+		ginkgo.By("Verifying new traffic only hits the surviving backend")
+		gomega.Eventually(func() bool {
+			hits := curlHostnames(dpEip.Status.IP, 10)
+			return hits[dpSrv1Name] > 0 && hits[dpSrv2Name] == 0
+		}, 30*time.Second, 3*time.Second).Should(gomega.BeTrue(),
+			"after removing backend2, new traffic should only hit backend1")
+
+		ginkgo.By("Deleting the identity entirely: conntrack must be flushed")
+		iptablesDnatRuleClient.DeleteSync(dpDnat1Name)
+		gomega.Eventually(func() bool {
+			return nftDnatMapRuleExists(vpcNatGwPodName, dpEip.Status.IP, extPort, "tcp", nil)
+		}, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"nft map rule should be removed after deleting all share DNATs")
+		gomega.Eventually(conntrackHasEntries, 30*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+			"deleting the whole identity should flush conntrack entries")
+	})
+
+	framework.ConformanceIt("[share-dnat-conflict] verify type conflict between exclusive and share DNAT", func() {
+		f.SkipVersionPriorTo(1, 17, "Share type DNAT was introduced in v1.17")
+
+		// Test-specific variables
+		randomSuffix := framework.RandomSuffix()
+		conflictEipName := "conflict-eip-" + randomSuffix
+		conflictVip1Name := "conflict-vip1-" + randomSuffix
+		conflictVip2Name := "conflict-vip2-" + randomSuffix
+		exclusiveDnatName := "exclusive-dnat-" + randomSuffix
+		shareDnatName := "share-dnat-" + randomSuffix
+
+		overlaySubnetV4Cidr := "10.0.5.0/24"
+		overlaySubnetV4Gw := "10.0.5.1"
+		lanIP := "10.0.5.254"
+		natgwQoS := ""
+		setupVpcNatGwTestEnvironment(
+			f, dockerExtNet1Network, attachNetClient,
+			subnetClient, vpcClient, vpcNatGwClient,
+			vpcName, overlaySubnetName, vpcNatGwName, natgwQoS,
+			overlaySubnetV4Cidr, overlaySubnetV4Gw, lanIP,
+			dockerExtNet1Name, networkAttachDefName, net1NicName,
+			externalSubnetProvider,
+			true, // skipNADSetup: shared NAD created in BeforeAll
+			nil,  // no custom annotations
+			"",   // gwNamespace: use default (PodNamespace)
+			0,
+		)
+
+		ginkgo.By("Creating vips for conflict test")
+		conflictVip1 := framework.MakeVip(f.Namespace.Name, conflictVip1Name, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(conflictVip1)
+		ginkgo.DeferCleanup(func() {
+			vipClient.DeleteSync(conflictVip1Name)
+		})
+		conflictVip1 = vipClient.Get(conflictVip1Name)
+
+		conflictVip2 := framework.MakeVip(f.Namespace.Name, conflictVip2Name, overlaySubnetName, "", "", "")
+		_ = vipClient.CreateSync(conflictVip2)
+		ginkgo.DeferCleanup(func() {
+			vipClient.DeleteSync(conflictVip2Name)
+		})
+		conflictVip2 = vipClient.Get(conflictVip2Name)
+
+		ginkgo.By("Creating eip for conflict test")
+		conflictEip := framework.MakeIptablesEIP(conflictEipName, "", "", "", vpcNatGwName, "", "")
+		_ = iptablesEIPClient.CreateSync(conflictEip)
+		ginkgo.DeferCleanup(func() {
+			iptablesEIPClient.DeleteSync(conflictEipName)
+		})
+
+		ginkgo.By("Creating exclusive type DNAT rule")
+		exclusiveDnat := framework.MakeIptablesDnatRule(exclusiveDnatName, conflictEipName, "80", "tcp", conflictVip1.Status.V4ip, "8080")
+		_ = iptablesDnatRuleClient.CreateSync(exclusiveDnat)
+		ginkgo.DeferCleanup(func() {
+			iptablesDnatRuleClient.DeleteSync(exclusiveDnatName)
+		})
+
+		ginkgo.By("Verifying share type DNAT with same identity is rejected or never becomes ready")
+		shareDnat := framework.MakeShareIptablesDnatRule(shareDnatName, conflictEipName, "80", "tcp", conflictVip2.Status.V4ip, "8080")
+		_, err := iptablesDnatRuleClient.CreateRaw(shareDnat)
+		if err != nil {
+			// Webhook is deployed and rejected the creation - expected
+			framework.Logf("share DNAT creation rejected by webhook: %v", err)
+		} else {
+			// Webhook is not deployed; the controller's isDnatDuplicated check
+			// will prevent the DNAT from becoming Ready. Verify it stays not-ready.
+			framework.Logf("share DNAT created (no webhook), verifying it does not become ready")
+			gomega.Consistently(func() bool {
+				d := iptablesDnatRuleClient.Get(shareDnatName)
+				return d.Status.Ready
+			}, 15*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+				"share type DNAT should NOT become ready when exclusive type DNAT with same identity exists")
+			// Clean up the conflicting share DNAT before proceeding
+			iptablesDnatRuleClient.Delete(shareDnatName)
+		}
+
+		ginkgo.By("Deleting exclusive DNAT")
+		iptablesDnatRuleClient.DeleteSync(exclusiveDnatName)
+
+		ginkgo.By("Creating share type DNAT after exclusive is deleted")
+		shareDnat = framework.MakeShareIptablesDnatRule(shareDnatName, conflictEipName, "80", "tcp", conflictVip2.Status.V4ip, "8080")
+		_ = iptablesDnatRuleClient.CreateSync(shareDnat)
+		ginkgo.DeferCleanup(func() {
+			iptablesDnatRuleClient.DeleteSync(shareDnatName)
+		})
+
+		ginkgo.By("Verifying exclusive type DNAT with same identity is rejected or never becomes ready")
+		exclusiveDnat = framework.MakeIptablesDnatRule(exclusiveDnatName, conflictEipName, "80", "tcp", conflictVip1.Status.V4ip, "8080")
+		_, err = iptablesDnatRuleClient.CreateRaw(exclusiveDnat)
+		if err != nil {
+			// Webhook is deployed and rejected the creation - expected
+			framework.Logf("exclusive DNAT creation rejected by webhook: %v", err)
+		} else {
+			// Webhook is not deployed; verify it stays not-ready due to isDnatDuplicated
+			framework.Logf("exclusive DNAT created (no webhook), verifying it does not become ready")
+			gomega.Consistently(func() bool {
+				d := iptablesDnatRuleClient.Get(exclusiveDnatName)
+				return d.Status.Ready
+			}, 15*time.Second, 2*time.Second).Should(gomega.BeFalse(),
+				"exclusive type DNAT should NOT become ready when share type DNAT with same identity exists")
+			// Clean up the conflicting exclusive DNAT
+			iptablesDnatRuleClient.Delete(exclusiveDnatName)
+		}
 	})
 
 	framework.ConformanceIt("[3] manage IptablesEIP lifecycle with finalizer and update subnet status", func() {


### PR DESCRIPTION
在 iptables-dnat 的粒度基础之上，满足一种基本的 LB 后端配置的需求。

Add 'type' field to IptablesDnatRule CRD to support two modes:
- exclusive (default): EIP:Port is exclusively used by one DNAT rule, using iptables DNAT for 1:1 mapping (existing behavior)
- share: Multiple DNAT rules can share the same EIP:Port, using nftables map-based DNAT with numgen random for connection-level load balancing (new connections are distributed randomly across backends and then pinned by conntrack; no client-IP affinity)

Changes:
- CRD: Add 'type' field with enum [exclusive, share], default exclusive
- Controller: Aggregate share DNAT backends and call nft-dnat-map-add/del
- Webhook: Validate type immutability and exclusive/share conflict
- Shell: Add nft-dnat-map-add/del functions using nft_dnat table
- E2E: Add tests for share DNAT lifecycle and type conflict rejection

Shell interface:
- Existing: dnat-add/dnat-del (unchanged)
- New: nft-dnat-map-add/nft-dnat-map-del (for share type)

nft rule structure:
- Table: nft_dnat
- Chain: dnat_map (priority -150, before iptables -100)
- Rule: numgen random mod N map { backends }

Note: load balancing uses `numgen random` (per-connection random distribution pinned by conntrack), the same primitive kube-proxy's nftables backend uses for endpoint selection — not jhash / consistent hashing. Source-IP session affinity is not supported yet.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
