### PR TITLE
fix(controller): skip service/endpointslice enqueueing when lb is disabled

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -338,6 +338,10 @@ func ParseFlags() (*Configuration, error) {
 		return nil, errors.New("no host nic for vlan")
 	}
 
+	if config.EnableLbSvc && !config.EnableLb {
+		klog.Warning("--enable-lb-svc requires --enable-lb, the loadbalancer service feature will not work")
+	}
+
 	if config.DefaultGateway == "" {
 		gw, err := util.GetGwByCidr(config.DefaultCIDR)
 		if err != nil {

--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -42,6 +42,10 @@ func findServiceKey(endpointSlice *discoveryv1.EndpointSlice) string {
 }
 
 func (c *Controller) enqueueAddEndpointSlice(obj any) {
+	if !c.config.EnableLb {
+		return
+	}
+
 	key := findServiceKey(obj.(*discoveryv1.EndpointSlice))
 	if key != "" {
 		klog.V(3).Infof("enqueue add endpointSlice %s", key)
@@ -50,6 +54,10 @@ func (c *Controller) enqueueAddEndpointSlice(obj any) {
 }
 
 func (c *Controller) enqueueUpdateEndpointSlice(oldObj, newObj any) {
+	if !c.config.EnableLb {
+		return
+	}
+
 	oldEndpointSlice := oldObj.(*discoveryv1.EndpointSlice)
 	newEndpointSlice := newObj.(*discoveryv1.EndpointSlice)
 	if oldEndpointSlice.ResourceVersion == newEndpointSlice.ResourceVersion {

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -46,7 +46,8 @@ func (c *Controller) enqueueAddService(obj any) {
 		c.addOrUpdateEndpointSliceQueue.Add(key)
 	}
 
-	if c.config.EnableLbSvc {
+	// the add service worker also only runs when EnableLb is set
+	if c.config.EnableLb && c.config.EnableLbSvc {
 		klog.V(3).Infof("enqueue add lb service %s", key)
 		c.addServiceQueue.Add(key)
 	}

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -38,8 +38,13 @@ type updateSvcObject struct {
 func (c *Controller) enqueueAddService(obj any) {
 	svc := obj.(*v1.Service)
 	key := cache.MetaObjectToName(svc).String()
-	klog.V(3).Infof("enqueue add service %s", key)
-	c.addOrUpdateEndpointSliceQueue.Add(key)
+
+	// the queue consumers only run when EnableLb is set, so skip
+	// enqueueing to avoid unbounded accumulation when it is not
+	if c.config.EnableLb {
+		klog.V(3).Infof("enqueue add service %s", key)
+		c.addOrUpdateEndpointSliceQueue.Add(key)
+	}
 
 	if c.config.EnableLbSvc {
 		klog.V(3).Infof("enqueue add lb service %s", key)
@@ -48,6 +53,10 @@ func (c *Controller) enqueueAddService(obj any) {
 }
 
 func (c *Controller) enqueueDeleteService(obj any) {
+	if !c.config.EnableLb {
+		return
+	}
+
 	var svc *v1.Service
 	switch t := obj.(type) {
 	case *v1.Service:
@@ -84,6 +93,10 @@ func (c *Controller) enqueueDeleteService(obj any) {
 }
 
 func (c *Controller) enqueueUpdateService(oldObj, newObj any) {
+	if !c.config.EnableLb {
+		return
+	}
+
 	oldSvc := oldObj.(*v1.Service)
 	newSvc := newObj.(*v1.Service)
 	if oldSvc.ResourceVersion == newSvc.ResourceVersion {

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -218,11 +218,17 @@ func Test_enqueueServiceGatedByEnableLb(t *testing.T) {
 		require.Equal(t, 1, c.addOrUpdateEndpointSliceQueue.Len())
 	})
 
-	t.Run("EnableLbSvc=true still feeds addServiceQueue when EnableLb=false", func(t *testing.T) {
+	t.Run("EnableLbSvc=true feeds addServiceQueue only when EnableLb is set", func(t *testing.T) {
 		t.Parallel()
-		c := newController(false, true)
+		c := newController(true, true)
 		c.enqueueAddService(svc)
 		require.Equal(t, 1, c.addServiceQueue.Len())
+		require.Equal(t, 1, c.addOrUpdateEndpointSliceQueue.Len())
+
+		// the add service worker is gated by EnableLb, so the producer must be too
+		c = newController(false, true)
+		c.enqueueAddService(svc)
+		require.Zero(t, c.addServiceQueue.Len())
 		require.Zero(t, c.addOrUpdateEndpointSliceQueue.Len())
 	})
 }

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -144,6 +145,86 @@ func Test_getVipIps(t *testing.T) {
 			require.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func Test_enqueueServiceGatedByEnableLb(t *testing.T) {
+	t.Parallel()
+
+	newController := func(enableLb, enableLbSvc bool) *Controller {
+		return &Controller{
+			config: &Configuration{
+				EnableLb:    enableLb,
+				EnableLbSvc: enableLbSvc,
+			},
+			addServiceQueue:               newTypedRateLimitingQueue[string]("AddService", nil),
+			deleteServiceQueue:            newTypedRateLimitingQueue[*vpcService]("DeleteService", nil),
+			updateServiceQueue:            newTypedRateLimitingQueue[*updateSvcObject]("UpdateService", nil),
+			addOrUpdateEndpointSliceQueue: newTypedRateLimitingQueue[string]("UpdateEndpointSlice", nil),
+		}
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:  "10.96.0.10",
+			ClusterIPs: []string{"10.96.0.10"},
+			Ports:      []v1.ServicePort{{Name: "tcp", Port: 80, Protocol: v1.ProtocolTCP}},
+		},
+	}
+	updatedSvc := svc.DeepCopy()
+	updatedSvc.ResourceVersion = "2"
+	updatedSvc.Spec.Ports[0].Port = 8080
+
+	eps := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-abc12",
+			Namespace: metav1.NamespaceDefault,
+			Labels:    map[string]string{discoveryv1.LabelServiceName: "svc"},
+		},
+		Endpoints: []discoveryv1.Endpoint{{Addresses: []string{"10.16.0.2"}}},
+	}
+	updatedEps := eps.DeepCopy()
+	updatedEps.ResourceVersion = "2"
+
+	enqueueAll := func(c *Controller) {
+		c.enqueueAddService(svc)
+		c.enqueueUpdateService(svc, updatedSvc)
+		c.enqueueDeleteService(svc)
+		c.enqueueAddEndpointSlice(eps)
+		c.enqueueUpdateEndpointSlice(eps, updatedEps)
+	}
+
+	t.Run("EnableLb=false skips enqueueing", func(t *testing.T) {
+		t.Parallel()
+		c := newController(false, false)
+		enqueueAll(c)
+		require.Zero(t, c.addServiceQueue.Len())
+		require.Zero(t, c.deleteServiceQueue.Len())
+		require.Zero(t, c.updateServiceQueue.Len())
+		require.Zero(t, c.addOrUpdateEndpointSliceQueue.Len())
+	})
+
+	t.Run("EnableLb=true enqueues", func(t *testing.T) {
+		t.Parallel()
+		c := newController(true, false)
+		enqueueAll(c)
+		require.Zero(t, c.addServiceQueue.Len())
+		require.Equal(t, 1, c.deleteServiceQueue.Len())
+		require.Equal(t, 1, c.updateServiceQueue.Len())
+		// the same service key from the service/endpointSlice events is deduplicated
+		require.Equal(t, 1, c.addOrUpdateEndpointSliceQueue.Len())
+	})
+
+	t.Run("EnableLbSvc=true still feeds addServiceQueue when EnableLb=false", func(t *testing.T) {
+		t.Parallel()
+		c := newController(false, true)
+		c.enqueueAddService(svc)
+		require.Equal(t, 1, c.addServiceQueue.Len())
+		require.Zero(t, c.addOrUpdateEndpointSliceQueue.Len())
+	})
 }
 
 func Test_checkServiceLBIPBelongToSubnet(t *testing.T) {


### PR DESCRIPTION
## Summary
- The service/endpointSlice informer handlers enqueue events unconditionally, while all consumers of `addServiceQueue` / `deleteServiceQueue` / `updateServiceQueue` / `addOrUpdateEndpointSliceQueue` only start when `--enable-lb` is set, so with `EnableLb=false` these queues accumulate forever. `updateServiceQueue` and `deleteServiceQueue` hold pointer items (`*updateSvcObject` / `*vpcService`) that never deduplicate, and each `*vpcService` pins the whole Service object, leaking memory slowly on service churn.
- Gate all five producers on `EnableLb` (`enqueueAddService` / `enqueueUpdateService` / `enqueueDeleteService` / `enqueueAddEndpointSlice` / `enqueueUpdateEndpointSlice`). The `addServiceQueue` producer now requires both `EnableLb` and `EnableLbSvc`, since its worker also only starts under `EnableLb`.
- Warn at startup when `--enable-lb-svc` is set without `--enable-lb`, since the loadbalancer service workers never start in that configuration.

## Test plan
- [x] `go test ./pkg/controller/ -run 'Test_enqueueServiceGatedByEnableLb|Test_getVipIps|Test_checkService'` passes (new unit test covers EnableLb=false skipping, EnableLb=true enqueueing with key dedup, and the EnableLb+EnableLbSvc gating of addServiceQueue)
- [x] `make lint` passes with 0 issues
- [x] CI E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)