### PR TITLE
feat(subnet): add per-subnet allowAllocateFirstLast for full CIDR IP …

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -2565,6 +2565,12 @@ spec:
                       type: integer
                   type: object
                 type: array
+              allowAllocateFirstLast:
+                description: |-
+                  AllowAllocateFirstLast allows allocating all IPs in the CIDR including the
+                  network address (first IP) and broadcast address (last IP).
+                  For /31 and /32 IPv4 subnets this is always effective per RFC 3021.
+                type: boolean
               allowEWTraffic:
                 description: Allow east-west traffic across subnets.
                 type: boolean

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -2584,6 +2584,12 @@ spec:
                       type: integer
                   type: object
                 type: array
+              allowAllocateFirstLast:
+                description: |-
+                  AllowAllocateFirstLast allows allocating all IPs in the CIDR including the
+                  network address (first IP) and broadcast address (last IP).
+                  For /31 and /32 IPv4 subnets this is always effective per RFC 3021.
+                type: boolean
               allowEWTraffic:
                 description: Allow east-west traffic across subnets.
                 type: boolean

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2950,6 +2950,12 @@ spec:
                       type: integer
                   type: object
                 type: array
+              allowAllocateFirstLast:
+                description: |-
+                  AllowAllocateFirstLast allows allocating all IPs in the CIDR including the
+                  network address (first IP) and broadcast address (last IP).
+                  For /31 and /32 IPv4 subnets this is always effective per RFC 3021.
+                type: boolean
               allowEWTraffic:
                 description: Allow east-west traffic across subnets.
                 type: boolean

--- a/pkg/apis/kubeovn/v1/subnet.go
+++ b/pkg/apis/kubeovn/v1/subnet.go
@@ -147,6 +147,11 @@ type SubnetSpec struct {
 	// Enable external LB address support.
 	EnableExternalLBAddress bool `json:"enableExternalLBAddress,omitempty"`
 
+	// AllowAllocateFirstLast allows allocating all IPs in the CIDR including the
+	// network address (first IP) and broadcast address (last IP).
+	// For /31 and /32 IPv4 subnets this is always effective per RFC 3021.
+	AllowAllocateFirstLast bool `json:"allowAllocateFirstLast,omitempty"`
+
 	// Route table associated with the subnet.
 	RouteTable string `json:"routeTable,omitempty"`
 	// Namespace label selectors to associate with this subnet.

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -397,7 +397,7 @@ func (c *Controller) InitIPAM() error {
 	for _, subnet := range subnets {
 		klog.Infof("Init subnet %s", subnet.Name)
 		subnetProviderMaps[subnet.Name] = subnet.Spec.Provider
-		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
+		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps, subnet.Spec.AllowAllocateFirstLast); err != nil {
 			klog.Errorf("failed to init subnet %s: %v", subnet.Name, err)
 		}
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -667,7 +667,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		if vmKey != "" {
 			patch[fmt.Sprintf(util.VMAnnotationTemplate, podNet.ProviderName)] = vmName
 		}
-		if err := util.ValidateNetworkBroadcast(podNet.Subnet.Spec.CIDRBlock, ipStr); err != nil {
+		if err := util.ValidateNetworkBroadcast(podNet.Subnet.Spec.CIDRBlock, ipStr, podNet.Subnet.Spec.AllowAllocateFirstLast); err != nil {
 			klog.Errorf("validate pod %s/%s failed: %v", namespace, name, err)
 			c.recorder.Eventf(pod, v1.EventTypeWarning, "ValidatePodNetworkFailed", "%s", err.Error())
 			return nil, err
@@ -1866,17 +1866,17 @@ func (c *Controller) getPodDefaultSubnet(pod *v1.Pod) (*kubeovnv1.Subnet, error)
 
 func (c *Controller) podCanUseExcludeIPs(pod *v1.Pod, subnet *kubeovnv1.Subnet) bool {
 	if ipAddr := pod.Annotations[util.IPAddressAnnotation]; ipAddr != "" {
-		return c.checkIPsInExcludeList(ipAddr, subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock)
+		return c.checkIPsInExcludeList(ipAddr, subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock, subnet.Spec.AllowAllocateFirstLast)
 	}
 	if ipPool := pod.Annotations[util.IPPoolAnnotation]; ipPool != "" {
-		return c.checkIPsInExcludeList(ipPool, subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock)
+		return c.checkIPsInExcludeList(ipPool, subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock, subnet.Spec.AllowAllocateFirstLast)
 	}
 
 	return false
 }
 
-func (c *Controller) checkIPsInExcludeList(ips string, excludeIPs []string, cidr string) bool {
-	expandedExcludeIPs := util.ExpandExcludeIPs(excludeIPs, cidr)
+func (c *Controller) checkIPsInExcludeList(ips string, excludeIPs []string, cidr string, allowAllocateFirstLast ...bool) bool {
+	expandedExcludeIPs := util.ExpandExcludeIPs(excludeIPs, cidr, allowAllocateFirstLast...)
 
 	for ipAddr := range strings.SplitSeq(strings.TrimSpace(ips), ",") {
 		ipAddr = strings.TrimSpace(ipAddr)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -568,7 +568,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		return err
 	}
 
-	if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
+	if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps, subnet.Spec.AllowAllocateFirstLast); err != nil {
 		klog.Error(err)
 		return err
 	}

--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -203,20 +203,20 @@ func (c *Controller) calcSubnetStatusIP(subnet *kubeovnv1.Subnet) (*kubeovnv1.Su
 	case kubeovnv1.ProtocolDual:
 		v4ExcludeIPs, v6ExcludeIPs := util.SplitIpsByProtocol(subnet.Spec.ExcludeIps)
 		cidrBlocks := strings.Split(subnet.Spec.CIDRBlock, ",")
-		v4toSubIPs := util.ExpandExcludeIPs(v4ExcludeIPs, cidrBlocks[0])
-		v6toSubIPs := util.ExpandExcludeIPs(v6ExcludeIPs, cidrBlocks[1])
+		v4toSubIPs := util.ExpandExcludeIPs(v4ExcludeIPs, cidrBlocks[0], subnet.Spec.AllowAllocateFirstLast)
+		v6toSubIPs := util.ExpandExcludeIPs(v6ExcludeIPs, cidrBlocks[1], subnet.Spec.AllowAllocateFirstLast)
 		_, v4CIDR, _ := net.ParseCIDR(cidrBlocks[0])
 		_, v6CIDR, _ := net.ParseCIDR(cidrBlocks[1])
-		v4availableIPs = util.AddressCountBigInt(v4CIDR).Sub(util.CountIPNumsBigInt(v4toSubIPs)).Sub(usingIPs)
-		v6availableIPs = util.AddressCountBigInt(v6CIDR).Sub(util.CountIPNumsBigInt(v6toSubIPs)).Sub(usingIPs)
+		v4availableIPs = util.AddressCountBigInt(v4CIDR, subnet.Spec.AllowAllocateFirstLast).Sub(util.CountIPNumsBigInt(v4toSubIPs)).Sub(usingIPs)
+		v6availableIPs = util.AddressCountBigInt(v6CIDR, subnet.Spec.AllowAllocateFirstLast).Sub(util.CountIPNumsBigInt(v6toSubIPs)).Sub(usingIPs)
 	case kubeovnv1.ProtocolIPv4:
 		_, cidr, _ := net.ParseCIDR(subnet.Spec.CIDRBlock)
-		toSubIPs := util.ExpandExcludeIPs(subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock)
-		v4availableIPs = util.AddressCountBigInt(cidr).Sub(util.CountIPNumsBigInt(toSubIPs)).Sub(usingIPs)
+		toSubIPs := util.ExpandExcludeIPs(subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock, subnet.Spec.AllowAllocateFirstLast)
+		v4availableIPs = util.AddressCountBigInt(cidr, subnet.Spec.AllowAllocateFirstLast).Sub(util.CountIPNumsBigInt(toSubIPs)).Sub(usingIPs)
 	case kubeovnv1.ProtocolIPv6:
 		_, cidr, _ := net.ParseCIDR(subnet.Spec.CIDRBlock)
-		toSubIPs := util.ExpandExcludeIPs(subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock)
-		v6availableIPs = util.AddressCountBigInt(cidr).Sub(util.CountIPNumsBigInt(toSubIPs)).Sub(usingIPs)
+		toSubIPs := util.ExpandExcludeIPs(subnet.Spec.ExcludeIps, subnet.Spec.CIDRBlock, subnet.Spec.AllowAllocateFirstLast)
+		v6availableIPs = util.AddressCountBigInt(cidr, subnet.Spec.AllowAllocateFirstLast).Sub(util.CountIPNumsBigInt(toSubIPs)).Sub(usingIPs)
 	}
 
 	if v4availableIPs.Sign() < 0 {

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -177,8 +177,9 @@ func (ipam *IPAM) ReleaseAddressByNic(podName, nicName, subnetName string) {
 	}
 }
 
-func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []string) error {
-	excludeIps = util.ExpandExcludeIPs(excludeIps, cidrStr)
+func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []string, allowAllocateFirstLast ...bool) error {
+	allocAll := len(allowAllocateFirstLast) > 0 && allowAllocateFirstLast[0]
+	excludeIps = util.ExpandExcludeIPs(excludeIps, cidrStr, allocAll)
 
 	ipam.mutex.Lock()
 	defer ipam.mutex.Unlock()
@@ -234,12 +235,13 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 			return err
 		}
 		if (protocol == kubeovnv1.ProtocolDual || protocol == kubeovnv1.ProtocolIPv4) &&
-			(subnet.V4CIDR.String() != v4cidrStr || subnet.V4Gw != v4Gw || !subnet.V4Reserved.Equal(v4Reserved)) {
+			(subnet.V4CIDR.String() != v4cidrStr || subnet.V4Gw != v4Gw || !subnet.V4Reserved.Equal(v4Reserved) || subnet.AllowAllocateFirstLast != allocAll) {
 			_, cidr, _ := net.ParseCIDR(v4cidrStr)
 			subnet.V4CIDR = cidr
 			subnet.V4Reserved = v4Reserved
-			firstIP, _ := util.FirstIP(v4cidrStr)
-			lastIP, _ := util.LastIP(v4cidrStr)
+			subnet.AllowAllocateFirstLast = allocAll
+			firstIP, _ := util.FirstIP(v4cidrStr, allocAll)
+			lastIP, _ := util.LastIP(v4cidrStr, allocAll)
 			ips, _ := NewIPRangeListFrom(fmt.Sprintf("%s..%s", firstIP, lastIP))
 			subnet.V4Using = subnet.V4Using.Intersect(ips)
 			subnet.V4Free = ips.Separate(subnet.V4Reserved).Separate(subnet.V4Using)
@@ -281,12 +283,13 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 			}
 		}
 		if (protocol == kubeovnv1.ProtocolDual || protocol == kubeovnv1.ProtocolIPv6) &&
-			(subnet.V6CIDR.String() != v6cidrStr || subnet.V6Gw != v6Gw || !subnet.V6Reserved.Equal(v6Reserved)) {
+			(subnet.V6CIDR.String() != v6cidrStr || subnet.V6Gw != v6Gw || !subnet.V6Reserved.Equal(v6Reserved) || subnet.AllowAllocateFirstLast != allocAll) {
 			_, cidr, _ := net.ParseCIDR(v6cidrStr)
 			subnet.V6CIDR = cidr
 			subnet.V6Reserved = v6Reserved
-			firstIP, _ := util.FirstIP(v6cidrStr)
-			lastIP, _ := util.LastIP(v6cidrStr)
+			subnet.AllowAllocateFirstLast = allocAll
+			firstIP, _ := util.FirstIP(v6cidrStr, allocAll)
+			lastIP, _ := util.LastIP(v6cidrStr, allocAll)
 			ips, _ := NewIPRangeListFrom(fmt.Sprintf("%s..%s", firstIP, lastIP))
 			subnet.V6Using = subnet.V6Using.Intersect(ips)
 			subnet.V6Free = ips.Separate(subnet.V6Reserved).Separate(subnet.V6Using)
@@ -337,7 +340,7 @@ func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr, gw string, excludeIps []strin
 		return nil
 	}
 
-	subnet, err := NewSubnet(name, cidrStr, excludeIps)
+	subnet, err := NewSubnet(name, cidrStr, excludeIps, allocAll)
 	if err != nil {
 		klog.Errorf("failed to create subnet %s, %v", name, err)
 		return err

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -990,3 +990,80 @@ func TestGetSubnetV4Mask(t *testing.T) {
 	require.Equal(t, err, ErrNoAvailable)
 	require.Empty(t, mask)
 }
+
+func TestIPAMAllowAllocateFirstLast(t *testing.T) {
+	ipam := NewIPAM()
+
+	// /28 subnet with allowAllocateFirstLast=true: first and last IPs should be allocatable
+	subnetName := "allocateAll"
+	cidr := "10.0.0.0/28"
+	gw := "10.0.0.1"
+	err := ipam.AddOrUpdateSubnet(subnetName, cidr, gw, []string{gw}, true)
+	require.NoError(t, err)
+
+	subnet := ipam.Subnets[subnetName]
+	require.True(t, subnet.AllowAllocateFirstLast)
+
+	// Allocate the network address (10.0.0.0)
+	v4, _, mac, err := ipam.GetStaticAddress("pod1", "pod1.ns", "10.0.0.0", nil, subnetName, true)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.0", v4)
+	require.NotEmpty(t, mac)
+
+	// Allocate the broadcast address (10.0.0.15)
+	v4, _, mac, err = ipam.GetStaticAddress("pod2", "pod2.ns", "10.0.0.15", nil, subnetName, true)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.15", v4)
+	require.NotEmpty(t, mac)
+}
+
+func TestIPAMAllowAllocateFirstLastSlash31(t *testing.T) {
+	ipam := NewIPAM()
+
+	// /31 should auto-enable allocateAll (RFC 3021)
+	subnetName := "slash31"
+	cidr := "10.0.0.0/31"
+	gw := "10.0.0.0"
+	err := ipam.AddOrUpdateSubnet(subnetName, cidr, gw, nil)
+	require.NoError(t, err)
+
+	subnet := ipam.Subnets[subnetName]
+	// AllowAllocateFirstLast is not explicitly set, but ShouldAllocateAll returns true
+	_ = subnet
+
+	// Both IPs should be allocatable
+	v4, _, _, err := ipam.GetStaticAddress("pod1", "pod1.ns", "10.0.0.0", nil, subnetName, true)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.0", v4)
+
+	v4, _, _, err = ipam.GetStaticAddress("pod2", "pod2.ns", "10.0.0.1", nil, subnetName, true)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.1", v4)
+
+	// Random allocation should work
+	ipam2 := NewIPAM()
+	err = ipam2.AddOrUpdateSubnet(subnetName, cidr, gw, []string{gw})
+	require.NoError(t, err)
+	v4, _, _, err = ipam2.GetRandomAddress("pod3", "pod3.ns", nil, subnetName, "", nil, true)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.1", v4) // .0 is gw (excluded), so .1 is allocated
+}
+
+func TestIPAMAllowAllocateFirstLastDisabled(t *testing.T) {
+	ipam := NewIPAM()
+
+	// /28 without allowAllocateFirstLast: first and last IPs should NOT be allocatable
+	subnetName := "noAllocateAll"
+	cidr := "10.0.0.0/28"
+	gw := "10.0.0.1"
+	err := ipam.AddOrUpdateSubnet(subnetName, cidr, gw, []string{gw})
+	require.NoError(t, err)
+
+	// Try to allocate the network address (10.0.0.0) - should fail
+	_, _, _, err = ipam.GetStaticAddress("pod1", "pod1.ns", "10.0.0.0", nil, subnetName, true)
+	require.Error(t, err) // out of range
+
+	// Try to allocate the broadcast address (10.0.0.15) - should fail
+	_, _, _, err = ipam.GetStaticAddress("pod2", "pod2.ns", "10.0.0.15", nil, subnetName, true)
+	require.Error(t, err) // out of range
+}

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -40,10 +40,12 @@ type Subnet struct {
 	V6Gw         string
 	GatewayMAC   string
 
-	IPPools map[string]*IPPool
+	AllowAllocateFirstLast bool
+	IPPools                map[string]*IPPool
 }
 
-func NewSubnet(name, cidrStr string, excludeIps []string) (*Subnet, error) {
+func NewSubnet(name, cidrStr string, excludeIps []string, allowAllocateFirstLast ...bool) (*Subnet, error) {
+	allocAll := len(allowAllocateFirstLast) > 0 && allowAllocateFirstLast[0]
 	var cidrs []*net.IPNet
 	for cidrBlock := range strings.SplitSeq(cidrStr, ",") {
 		_, cidr, err := net.ParseCIDR(cidrBlock)
@@ -55,7 +57,7 @@ func NewSubnet(name, cidrStr string, excludeIps []string) (*Subnet, error) {
 	}
 
 	// subnet.Spec.ExcludeIps contains both v4 and v6 addresses
-	excludeIps = util.ExpandExcludeIPs(excludeIps, cidrStr)
+	excludeIps = util.ExpandExcludeIPs(excludeIps, cidrStr, allocAll)
 	v4ExcludeIps, v6ExcludeIps := util.SplitIpsByProtocol(excludeIps)
 	v4Reserved, err := NewIPRangeListFrom(v4ExcludeIps...)
 	if err != nil {
@@ -70,43 +72,44 @@ func NewSubnet(name, cidrStr string, excludeIps []string) (*Subnet, error) {
 
 	protocol := util.CheckProtocol(cidrStr)
 	subnet := &Subnet{
-		Name:         name,
-		CIDR:         cidrStr,
-		Protocol:     protocol,
-		V4Free:       NewEmptyIPRangeList(),
-		V6Free:       NewEmptyIPRangeList(),
-		V4Reserved:   v4Reserved,
-		V6Reserved:   v6Reserved,
-		V4Using:      NewEmptyIPRangeList(),
-		V6Using:      NewEmptyIPRangeList(),
-		V4NicToIP:    map[string]IP{},
-		V6NicToIP:    map[string]IP{},
-		V4IPToPod:    map[string]string{},
-		V6IPToPod:    map[string]string{},
-		MacToPod:     map[string]string{},
-		NicToMac:     map[string]string{},
-		PodToNicList: map[string][]string{},
-		IPPools:      make(map[string]*IPPool, 0),
+		Name:                   name,
+		CIDR:                   cidrStr,
+		Protocol:               protocol,
+		V4Free:                 NewEmptyIPRangeList(),
+		V6Free:                 NewEmptyIPRangeList(),
+		V4Reserved:             v4Reserved,
+		V6Reserved:             v6Reserved,
+		V4Using:                NewEmptyIPRangeList(),
+		V6Using:                NewEmptyIPRangeList(),
+		V4NicToIP:              map[string]IP{},
+		V6NicToIP:              map[string]IP{},
+		V4IPToPod:              map[string]string{},
+		V6IPToPod:              map[string]string{},
+		MacToPod:               map[string]string{},
+		NicToMac:               map[string]string{},
+		PodToNicList:           map[string][]string{},
+		AllowAllocateFirstLast: allocAll,
+		IPPools:                make(map[string]*IPPool, 0),
 	}
 	switch protocol {
 	case kubeovnv1.ProtocolIPv4:
-		firstIP, _ := util.FirstIP(cidrStr)
-		lastIP, _ := util.LastIP(cidrStr)
+		firstIP, _ := util.FirstIP(cidrStr, allocAll)
+		lastIP, _ := util.LastIP(cidrStr, allocAll)
 		subnet.V4CIDR = cidrs[0]
 		subnet.V4Free, _ = NewIPRangeListFrom(fmt.Sprintf("%s..%s", firstIP, lastIP))
 	case kubeovnv1.ProtocolIPv6:
-		firstIP, _ := util.FirstIP(cidrStr)
-		lastIP, _ := util.LastIP(cidrStr)
+		firstIP, _ := util.FirstIP(cidrStr, allocAll)
+		lastIP, _ := util.LastIP(cidrStr, allocAll)
 		subnet.V6CIDR = cidrs[0]
 		subnet.V6Free, _ = NewIPRangeListFrom(fmt.Sprintf("%s..%s", firstIP, lastIP))
 	default:
 		subnet.V4CIDR = cidrs[0]
 		subnet.V6CIDR = cidrs[1]
 		cidrBlocks := strings.Split(cidrStr, ",")
-		v4FirstIP, _ := util.FirstIP(cidrBlocks[0])
-		v4LastIP, _ := util.LastIP(cidrBlocks[0])
-		v6FirstIP, _ := util.FirstIP(cidrBlocks[1])
-		v6LastIP, _ := util.LastIP(cidrBlocks[1])
+		v4FirstIP, _ := util.FirstIP(cidrBlocks[0], allocAll)
+		v4LastIP, _ := util.LastIP(cidrBlocks[0], allocAll)
+		v6FirstIP, _ := util.FirstIP(cidrBlocks[1], allocAll)
+		v6LastIP, _ := util.LastIP(cidrBlocks[1], allocAll)
 		subnet.V4Free, _ = NewIPRangeListFrom(fmt.Sprintf("%s..%s", v4FirstIP, v4LastIP))
 		subnet.V6Free, _ = NewIPRangeListFrom(fmt.Sprintf("%s..%s", v6FirstIP, v6LastIP))
 	}
@@ -750,8 +753,8 @@ func (s *Subnet) AddOrUpdateIPPool(name string, ips []string) error {
 			}
 		}
 
-		firstIP, _ := util.FirstIP(s.V4CIDR.String())
-		lastIP, _ := util.LastIP(s.V4CIDR.String())
+		firstIP, _ := util.FirstIP(s.V4CIDR.String(), s.AllowAllocateFirstLast)
+		lastIP, _ := util.LastIP(s.V4CIDR.String(), s.AllowAllocateFirstLast)
 		pool.V4Reserved = s.V4Reserved.Intersect(pool.V4IPs)
 		pool.V4Using = s.V4Using.Intersect(pool.V4IPs)
 		pool.V4Free, _ = NewIPRangeListFrom(fmt.Sprintf("%s..%s", firstIP, lastIP))
@@ -771,8 +774,8 @@ func (s *Subnet) AddOrUpdateIPPool(name string, ips []string) error {
 			}
 		}
 
-		firstIP, _ := util.FirstIP(s.V6CIDR.String())
-		lastIP, _ := util.LastIP(s.V6CIDR.String())
+		firstIP, _ := util.FirstIP(s.V6CIDR.String(), s.AllowAllocateFirstLast)
+		lastIP, _ := util.LastIP(s.V6CIDR.String(), s.AllowAllocateFirstLast)
 		pool.V6Reserved = s.V6Reserved.Intersect(pool.V6IPs)
 		pool.V6Using = s.V6Using.Intersect(pool.V6IPs)
 		pool.V6Free, _ = NewIPRangeListFrom(fmt.Sprintf("%s..%s", firstIP, lastIP))

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -81,6 +81,28 @@ func BigInt2Ip(ipInt *big.Int) string {
 	return ip.String()
 }
 
+// ShouldAllocateAll returns true if all IPs in the CIDR (including network
+// address and broadcast address) should be allocatable. This is always true
+// for IPv4 /31 and /32 subnets per RFC 3021, or when explicitly enabled.
+func ShouldAllocateAll(cidr *net.IPNet, specAllow bool) bool {
+	if cidr == nil {
+		return false
+	}
+	ones, bits := cidr.Mask.Size()
+	if cidr.IP.To4() != nil {
+		// /31 and /32: RFC 3021 point-to-point and host routes
+		if ones >= 31 {
+			return true
+		}
+	} else {
+		// /128: IPv6 host route
+		if ones == bits {
+			return true
+		}
+	}
+	return specAllow
+}
+
 func SubnetNumber(subnet string) string {
 	_, cidr, err := net.ParseCIDR(subnet)
 	if err != nil {
@@ -107,14 +129,19 @@ func SubnetBroadcast(subnet string) string {
 	return BigInt2Ip(ipInt.Add(ipInt, size))
 }
 
-// FirstIP returns first usable ip address in the subnet
-func FirstIP(subnet string) (string, error) {
+// FirstIP returns first usable ip address in the subnet.
+// When allowAllocateFirstLast is true, the network address itself is included.
+func FirstIP(subnet string, allowAllocateFirstLast ...bool) (string, error) {
 	_, cidr, err := net.ParseCIDR(subnet)
 	if err != nil {
 		klog.Error(err)
 		return "", fmt.Errorf("%s is not a valid cidr", subnet)
 	}
-	// Handle ptp network case specially
+	allocAll := len(allowAllocateFirstLast) > 0 && allowAllocateFirstLast[0]
+	if ShouldAllocateAll(cidr, allocAll) {
+		return cidr.IP.String(), nil
+	}
+	// Handle ptp network case specially (/31 is already handled above)
 	if ones, bits := cidr.Mask.Size(); ones+1 == bits {
 		return cidr.IP.String(), nil
 	}
@@ -122,24 +149,26 @@ func FirstIP(subnet string) (string, error) {
 	return BigInt2Ip(ipInt.Add(ipInt, big.NewInt(1))), nil
 }
 
-// LastIP returns last usable ip address in the subnet
-func LastIP(subnet string) (string, error) {
+// LastIP returns last usable ip address in the subnet.
+// When allowAllocateFirstLast is true, the broadcast address is included.
+func LastIP(subnet string, allowAllocateFirstLast ...bool) (string, error) {
 	_, cidr, err := net.ParseCIDR(subnet)
 	if err != nil {
 		klog.Error(err)
 		return "", fmt.Errorf("%s is not a valid cidr", subnet)
 	}
 
+	allocAll := len(allowAllocateFirstLast) > 0 && allowAllocateFirstLast[0]
 	ipInt := IP2BigInt(cidr.IP.String())
-	size := getCIDRSize(cidr)
+	size := getCIDRSize(cidr, ShouldAllocateAll(cidr, allocAll))
 	return BigInt2Ip(ipInt.Add(ipInt, size)), nil
 }
 
-func getCIDRSize(cidr *net.IPNet) *big.Int {
+func getCIDRSize(cidr *net.IPNet, allocateAll bool) *big.Int {
 	ones, bits := cidr.Mask.Size()
 	zeros := uint(bits - ones) // #nosec G115
 	size := big.NewInt(0).Lsh(big.NewInt(1), zeros)
-	if ones+1 == bits {
+	if allocateAll || ones+1 == bits {
 		return big.NewInt(0).Sub(size, big.NewInt(1))
 	}
 	return big.NewInt(0).Sub(size, big.NewInt(2))
@@ -228,12 +257,13 @@ func CheckProtocol(address string) string {
 	return ""
 }
 
-func AddressCountBigInt(network *net.IPNet) internal.BigInt {
+func AddressCountBigInt(network *net.IPNet, allowAllocateFirstLast ...bool) internal.BigInt {
+	allocAll := len(allowAllocateFirstLast) > 0 && allowAllocateFirstLast[0]
 	prefixLen, bits := network.Mask.Size()
 	zeros := uint(bits - prefixLen) // #nosec G115
 	count := big.NewInt(0).Lsh(big.NewInt(1), zeros)
-	// Special case handling for /31 and /32 subnets.
-	if bits-prefixLen >= 2 {
+	if !ShouldAllocateAll(network, allocAll) && bits-prefixLen >= 2 {
+		// Subtract network address and broadcast address
 		count.Sub(count, big.NewInt(2))
 	}
 	return internal.BigInt{Int: *count}
@@ -418,7 +448,8 @@ func SplitStringIP(ipStr string) (string, string) {
 }
 
 // ExpandExcludeIPs used to get exclude ips in range of subnet cidr, excludes cidr addr and broadcast addr
-func ExpandExcludeIPs(excludeIPs []string, cidr string) []string {
+func ExpandExcludeIPs(excludeIPs []string, cidr string, allowAllocateFirstLast ...bool) []string {
+	allocAll := len(allowAllocateFirstLast) > 0 && allowAllocateFirstLast[0]
 	rv := []string{}
 	for _, excludeIP := range excludeIPs {
 		if strings.Contains(excludeIP, "..") {
@@ -438,12 +469,14 @@ func ExpandExcludeIPs(excludeIPs []string, cidr string) []string {
 					continue
 				}
 
-				firstIP, err := FirstIP(cidrBlock)
+				_, parsedCIDR, _ := net.ParseCIDR(cidrBlock)
+				blockAllocAll := ShouldAllocateAll(parsedCIDR, allocAll)
+				firstIP, err := FirstIP(cidrBlock, blockAllocAll)
 				if err != nil {
 					klog.Error(err)
 					continue
 				}
-				lastIP, _ := LastIP(cidrBlock)
+				lastIP, _ := LastIP(cidrBlock, blockAllocAll)
 				s1, e1 := s, e
 				if s1.Cmp(IP2BigInt(firstIP)) < 0 {
 					s1 = IP2BigInt(firstIP)
@@ -463,8 +496,12 @@ func ExpandExcludeIPs(excludeIPs []string, cidr string) []string {
 			for cidrBlock := range strings.SplitSeq(cidr, ",") {
 				// exclude ip should be the same protocol with cidr
 				if CheckProtocol(cidrBlock) == CheckProtocol(excludeIP) {
-					// exclude ip should be in the range of cidr and not cidr addr and broadcast addr
-					if CIDRContainIP(cidrBlock, excludeIP) && excludeIP != SubnetNumber(cidrBlock) && excludeIP != SubnetBroadcast(cidrBlock) {
+					_, parsedCIDR, _ := net.ParseCIDR(cidrBlock)
+					blockAllocAll := ShouldAllocateAll(parsedCIDR, allocAll)
+					// exclude ip should be in the range of cidr
+					// when allowAllocateFirstLast, network/broadcast addresses are valid exclude targets
+					if CIDRContainIP(cidrBlock, excludeIP) &&
+						(blockAllocAll || (excludeIP != SubnetNumber(cidrBlock) && excludeIP != SubnetBroadcast(cidrBlock))) {
 						rv = append(rv, excludeIP)
 						break
 					}

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -286,7 +286,7 @@ func TestFirstIP(t *testing.T) {
 		{
 			name:   "controversy",
 			subnet: "192.168.0.23/32",
-			expect: "192.168.0.24",
+			expect: "192.168.0.23",
 		},
 		{
 			name:   "base31netmask",
@@ -549,6 +549,104 @@ func TestAddressCountBigInt(t *testing.T) {
 			result := AddressCountBigInt(c.network)
 			if result.Int.Cmp(c.want) != 0 {
 				t.Errorf("%v expected %v, but %v got", c.network, c.want, result)
+			}
+		})
+	}
+}
+
+func TestShouldAllocateAll(t *testing.T) {
+	tests := []struct {
+		name      string
+		cidr      string
+		specAllow bool
+		want      bool
+	}{
+		{"ipv4_24_false", "10.0.0.0/24", false, false},
+		{"ipv4_24_true", "10.0.0.0/24", true, true},
+		{"ipv4_30_false", "10.0.0.0/30", false, false},
+		{"ipv4_30_true", "10.0.0.0/30", true, true},
+		{"ipv4_31_auto", "10.0.0.0/31", false, true},
+		{"ipv4_32_auto", "10.0.0.1/32", false, true},
+		{"ipv6_64_false", "fd00::/64", false, false},
+		{"ipv6_64_true", "fd00::/64", true, true},
+		{"ipv6_128_auto", "fd00::1/128", false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cidr, _ := net.ParseCIDR(tc.cidr)
+			got := ShouldAllocateAll(cidr, tc.specAllow)
+			if got != tc.want {
+				t.Errorf("ShouldAllocateAll(%s, %v) = %v, want %v", tc.cidr, tc.specAllow, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFirstIPWithAllocateAll(t *testing.T) {
+	tests := []struct {
+		name   string
+		subnet string
+		want   string
+	}{
+		{"ipv4_24", "10.0.0.0/24", "10.0.0.0"},
+		{"ipv4_30", "10.0.0.0/30", "10.0.0.0"},
+		{"ipv4_31", "10.0.0.0/31", "10.0.0.0"},
+		{"ipv4_32", "10.0.0.1/32", "10.0.0.1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := FirstIP(tc.subnet, true)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("FirstIP(%s, true) = %s, want %s", tc.subnet, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLastIPWithAllocateAll(t *testing.T) {
+	tests := []struct {
+		name   string
+		subnet string
+		want   string
+	}{
+		{"ipv4_24", "10.0.0.0/24", "10.0.0.255"},
+		{"ipv4_30", "10.0.0.0/30", "10.0.0.3"},
+		{"ipv4_31", "10.0.0.0/31", "10.0.0.1"},
+		{"ipv4_32", "10.0.0.1/32", "10.0.0.1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := LastIP(tc.subnet, true)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("LastIP(%s, true) = %s, want %s", tc.subnet, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAddressCountBigIntWithAllocateAll(t *testing.T) {
+	tests := []struct {
+		name string
+		cidr string
+		want int64
+	}{
+		{"ipv4_24", "10.0.0.0/24", 256}, // all 256 IPs
+		{"ipv4_30", "10.0.0.0/30", 4},   // all 4 IPs
+		{"ipv4_31", "10.0.0.0/31", 2},   // auto-enabled, 2 IPs
+		{"ipv4_32", "10.0.0.1/32", 1},   // auto-enabled, 1 IP
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, network, _ := net.ParseCIDR(tc.cidr)
+			got := AddressCountBigInt(network, true)
+			if !got.EqualInt64(tc.want) {
+				t.Errorf("AddressCountBigInt(%s, true) = %v, want %d", tc.cidr, got, tc.want)
 			}
 		})
 	}

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -25,7 +25,7 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		if !CIDRContainIP(subnet.Spec.CIDRBlock, subnet.Spec.Gateway) {
 			return fmt.Errorf("gateway %s is not in cidr %s", subnet.Spec.Gateway, subnet.Spec.CIDRBlock)
 		}
-		if err := ValidateNetworkBroadcast(subnet.Spec.CIDRBlock, subnet.Spec.Gateway); err != nil {
+		if err := ValidateNetworkBroadcast(subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.AllowAllocateFirstLast); err != nil {
 			klog.Error(err)
 			return fmt.Errorf("validate gateway %s for cidr %s failed: %w", subnet.Spec.Gateway, subnet.Spec.CIDRBlock, err)
 		}
@@ -86,10 +86,13 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 			return err
 		}
 		// check network mask is 32 in ipv4 or 128 in ipv6
-		if err = InvalidNetworkMask(network); err != nil {
-			err = fmt.Errorf("subnet %s cidr %s mask is invalid, due to %w", subnet.Name, cidr, err)
-			klog.Error(err)
-			return err
+		// /32 IPv4 and /128 IPv6 are allowed when allocateAll is effective
+		if !ShouldAllocateAll(network, subnet.Spec.AllowAllocateFirstLast) {
+			if err = InvalidNetworkMask(network); err != nil {
+				err = fmt.Errorf("subnet %s cidr %s mask is invalid, due to %w", subnet.Name, cidr, err)
+				klog.Error(err)
+				return err
+			}
 		}
 	}
 
@@ -389,13 +392,17 @@ func ValidatePodNetwork(annotations map[string]string) error {
 	return utilerrors.NewAggregate(errors)
 }
 
-func ValidateNetworkBroadcast(cidr, ip string) error {
+func ValidateNetworkBroadcast(cidr, ip string, allowAllocateFirstLast ...bool) error {
+	allocAll := len(allowAllocateFirstLast) > 0 && allowAllocateFirstLast[0]
 	for cidrBlock := range strings.SplitSeq(cidr, ",") {
 		for ipAddr := range strings.SplitSeq(ip, ",") {
 			if CheckProtocol(cidrBlock) != CheckProtocol(ipAddr) {
 				continue
 			}
 			_, network, _ := net.ParseCIDR(cidrBlock)
+			if ShouldAllocateAll(network, allocAll) {
+				continue
+			}
 			if AddressCountBigInt(network).EqualInt64(1) {
 				return fmt.Errorf("subnet %s is configured with /32 or /128 netmask", cidrBlock)
 			}

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -780,7 +780,7 @@ func TestValidateSubnet(t *testing.T) {
 			},
 		},
 		{
-			name: "Invalid/32Subnet",
+			name: "Valid/32SubnetWithAllocateAll",
 			subnet: kubeovnv1.Subnet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "utest-ptpsubnet",
@@ -796,7 +796,7 @@ func TestValidateSubnet(t *testing.T) {
 					GatewayType: kubeovnv1.GWDistributedType,
 				},
 			},
-			err: "validate gateway 10.16.0.0 for cidr 10.16.0.0/32 failed: subnet 10.16.0.0/32 is configured with /32 or /128 netmask",
+			err: "",
 		},
 		{
 			name: "IPv6MTUBelowMinimum",

--- a/test/e2e/kube-ovn/subnet/subnet.go
+++ b/test/e2e/kube-ovn/subnet/subnet.go
@@ -1446,6 +1446,76 @@ var _ = framework.Describe("[group:subnet]", func() {
 			return false, nil
 		}, fmt.Sprintf("pod %s should have AddressConflict warning event", podName))
 	})
+
+	framework.ConformanceIt("should support allowAllocateFirstLast to allocate network and broadcast addresses", func() {
+		f.SkipVersionPriorTo(1, 17, "AllowAllocateFirstLast is introduced in v1.17")
+
+		ginkgo.By("Creating a /28 subnet with allowAllocateFirstLast enabled")
+		var subnetCIDR, gw, networkAddr, broadcastAddr string
+
+		switch f.ClusterIPFamily {
+		case "ipv4":
+			subnetCIDR = "192.168.210.0/28"
+			gw = "192.168.210.1"
+			networkAddr = "192.168.210.0"
+			broadcastAddr = "192.168.210.15"
+		case "ipv6":
+			subnetCIDR = "fd00:210::/124"
+			gw = "fd00:210::1"
+			networkAddr = "fd00:210::"
+			broadcastAddr = "fd00:210::f"
+		case "dual":
+			subnetCIDR = "192.168.210.0/28,fd00:210::/124"
+			gw = "192.168.210.1,fd00:210::1"
+			networkAddr = "192.168.210.0"
+			broadcastAddr = "192.168.210.15"
+		}
+
+		subnetName = "allocate-first-last-" + framework.RandomSuffix()
+		subnet = framework.MakeSubnet(subnetName, "", subnetCIDR, gw, "", "", nil, nil, []string{namespaceName})
+		subnet.Spec.AllowAllocateFirstLast = true
+		subnet = subnetClient.CreateSync(subnet)
+
+		ginkgo.By("Verifying subnet status accounts for all IPs")
+		// With allowAllocateFirstLast, available IPs should include network and broadcast
+		// For /28 IPv4: 16 total - 1 (gateway) = 15 available
+		if f.ClusterIPFamily == "ipv4" || f.ClusterIPFamily == "dual" {
+			// 16 IPs total, minus gateway = 15 available
+			framework.ExpectTrue(subnet.Status.V4AvailableIPs.Int64() >= 15,
+				fmt.Sprintf("expected >= 15 available v4 IPs, got %d", subnet.Status.V4AvailableIPs.Int64()))
+		}
+
+		ginkgo.By("Creating pod with the network address (first IP)")
+		annotations := map[string]string{
+			util.IPAddressAnnotation: networkAddr,
+		}
+		podName = "pod-network-addr-" + framework.RandomSuffix()
+		cmd := []string{"sleep", "infinity"}
+		pod := framework.MakePrivilegedPod(namespaceName, podName, nil, annotations, f.KubeOVNImage, cmd, nil)
+		pod = podClient.CreateSync(pod)
+
+		ginkgo.By("Verifying pod got the network address")
+		ipAddr := pod.Annotations[util.IPAddressAnnotation]
+		framework.ExpectContainSubstring(ipAddr, networkAddr)
+
+		ginkgo.By("Deleting the first pod")
+		podClient.DeleteSync(podName)
+
+		ginkgo.By("Creating pod with the broadcast address (last IP)")
+		annotations = map[string]string{
+			util.IPAddressAnnotation: broadcastAddr,
+		}
+		podName = "pod-broadcast-addr-" + framework.RandomSuffix()
+		pod = framework.MakePrivilegedPod(namespaceName, podName, nil, annotations, f.KubeOVNImage, cmd, nil)
+		pod = podClient.CreateSync(pod)
+
+		ginkgo.By("Verifying pod got the broadcast address")
+		ipAddr = pod.Annotations[util.IPAddressAnnotation]
+		framework.ExpectContainSubstring(ipAddr, broadcastAddr)
+
+		ginkgo.By("Deleting the second pod")
+		podClient.DeleteSync(podName)
+	})
 })
 
 func checkNatPolicyIPsets(f *framework.Framework, cs clientset.Interface, subnet *apiv1.Subnet, cidrV4, cidrV6 string, shouldExist bool) {


### PR DESCRIPTION
Add SubnetSpec.AllowAllocateFirstLast field that allows allocating all IPs in the CIDR range including the network address (first IP) and broadcast address (last IP).

Design:
- Per-subnet control via spec.allowAllocateFirstLast (no global flag)
- IPv4 /31 and /32 subnets automatically enable this per RFC 3021
- IPv6 /128 subnets also auto-enable (host routes)
- When enabled, AddressCountBigInt returns the full CIDR size
- ExpandExcludeIPs and ValidateNetworkBroadcast respect the flag
- Subnet validation allows /32 and /128 masks when effective

This replaces the previous global --allow-first-ipv4-address approach(https://github.com/kubeovn/kube-ovn/pull/6541) with a more flexible per-subnet design inspired by Cilium's handling of small prefix lengths(https://github.com/cilium/cilium/pull/46323).



# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
