### PR TITLE
fix(daemon): reconcile in-place changes to node nic routes and tproxy rules

### DIFF
--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -595,6 +595,15 @@ func getNicExistRoutes(nic netlink.Link, gateway string) ([]netlink.Route, error
 	return existRoutes, nil
 }
 
+// routeIPEqual reports whether two route IP fields (Src/Gw) are equal, treating an
+// unset (nil) value as distinct from any assigned address.
+func routeIPEqual(a, b net.IP) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Equal(b)
+}
+
 func routeDiff(nodeNicRoutes, allRoutes []netlink.Route, cidrs, joinCIDR []string, joinIPv4, joinIPv6, gateway string, srcIPv4, srcIPv6 net.IP) (toAdd, toDel []netlink.Route) {
 	// joinIPv6 is not used for now
 	_ = joinIPv6
@@ -635,57 +644,53 @@ func routeDiff(nodeNicRoutes, allRoutes []netlink.Route, cidrs, joinCIDR []strin
 			src, gw = srcIPv6, gwV6
 		}
 
+		// Compute the desired route attributes up front so the existence check below can
+		// compare them. Comparing Gw/Scope in addition to Dst/Src lets the periodic
+		// reconcile repair routes whose gateway or scope were modified in place, instead
+		// of only detecting added/removed routes.
+		var priority int
+		scope := netlink.SCOPE_UNIVERSE
+		proto := netlink.RouteProtocol(syscall.RTPROT_STATIC)
+		isJoin := slices.Contains(joinCIDR, c)
+		if isJoin {
+			if util.CheckProtocol(c) == kubeovnv1.ProtocolIPv4 {
+				src = net.ParseIP(joinIPv4)
+			} else {
+				src, priority = nil, 256
+			}
+			gw, scope = nil, netlink.SCOPE_LINK
+			proto = netlink.RouteProtocol(unix.RTPROT_KERNEL)
+		}
+
+		// A route is considered present only when its Dst and the attributes we manage
+		// (Src/Gw/Scope) match the desired values. Priority is intentionally not compared:
+		// it is part of the route key, so re-adding on a priority mismatch would create a
+		// duplicate instead of replacing in place, and the metric of a link route does not
+		// affect connectivity anyway. allRoutes already contains the node nic routes, so a
+		// separate pass over nodeNicRoutes is unnecessary.
 		found := false
 		for _, ar := range allRoutes {
-			if ar.Dst != nil && ar.Dst.String() == c {
-				if slices.Contains(joinCIDR, c) {
-					// Only compare Dst for join subnets
-					found = true
-					klog.V(3).Infof("[routeDiff] joinCIDR route already exists in allRoutes: %v", ar)
-					break
-				} else if (ar.Src == nil && src == nil) || (ar.Src != nil && src != nil && ar.Src.Equal(src)) {
-					// For non-join subnets, both Dst and Src must be the same
-					found = true
-					klog.V(3).Infof("[routeDiff] route already exists in allRoutes: %v", ar)
-					break
-				}
+			if ar.Dst == nil || ar.Dst.String() != c {
+				continue
+			}
+			if routeIPEqual(ar.Src, src) && routeIPEqual(ar.Gw, gw) && ar.Scope == scope {
+				found = true
+				klog.V(3).Infof("[routeDiff] route already exists in allRoutes: %v", ar)
+				break
 			}
 		}
 		if found {
 			continue
 		}
-		for _, r := range nodeNicRoutes {
-			if r.Dst == nil || r.Dst.String() != c {
-				continue
-			}
-			if (src == nil && r.Src == nil) || (src != nil && r.Src != nil && src.Equal(r.Src)) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			var priority int
-			scope := netlink.SCOPE_UNIVERSE
-			proto := netlink.RouteProtocol(syscall.RTPROT_STATIC)
-			if slices.Contains(joinCIDR, c) {
-				if util.CheckProtocol(c) == kubeovnv1.ProtocolIPv4 {
-					src = net.ParseIP(joinIPv4)
-				} else {
-					src, priority = nil, 256
-				}
-				gw, scope = nil, netlink.SCOPE_LINK
-				proto = netlink.RouteProtocol(unix.RTPROT_KERNEL)
-			}
-			_, cidr, _ := net.ParseCIDR(c)
-			toAdd = append(toAdd, netlink.Route{
-				Dst:      cidr,
-				Src:      src,
-				Gw:       gw,
-				Protocol: proto,
-				Scope:    scope,
-				Priority: priority,
-			})
-		}
+		_, cidr, _ := net.ParseCIDR(c)
+		toAdd = append(toAdd, netlink.Route{
+			Dst:      cidr,
+			Src:      src,
+			Gw:       gw,
+			Protocol: proto,
+			Scope:    scope,
+			Priority: priority,
+		})
 	}
 	if len(toAdd) > 0 {
 		klog.Infof("routes to add: %v", toAdd)

--- a/pkg/daemon/controller_linux_test.go
+++ b/pkg/daemon/controller_linux_test.go
@@ -32,6 +32,143 @@ func newPodForPolicyRouting(name, namespace, subnetName, podIP string, podIPs []
 	}
 }
 
+func TestRouteDiff(t *testing.T) {
+	t.Parallel()
+
+	mustCIDR := func(s string) *net.IPNet {
+		_, ipNet, err := net.ParseCIDR(s)
+		require.NoError(t, err)
+		return ipNet
+	}
+
+	const (
+		overlayCIDR = "10.16.0.0/16"
+		joinV4CIDR  = "100.64.0.0/16"
+		joinV6CIDR  = "fd00:100:64::/64"
+		gateway     = "100.64.0.1"
+		joinIPv4    = "100.64.0.2"
+	)
+	nodeIPv4 := net.ParseIP("192.168.0.2")
+
+	// overlayRoute builds a kernel route for the overlay subnet with the given gw/scope.
+	overlayRoute := func(gw net.IP, scope netlink.Scope) netlink.Route {
+		return netlink.Route{Dst: mustCIDR(overlayCIDR), Src: nodeIPv4, Gw: gw, Scope: scope}
+	}
+
+	tests := []struct {
+		name        string
+		nodeNic     []netlink.Route
+		allRoutes   []netlink.Route
+		cidrs       []string
+		joinCIDR    []string
+		wantAddDst  []string
+		wantDelDst  []string
+		validateAdd func(t *testing.T, toAdd []netlink.Route)
+	}{
+		{
+			name:      "correct overlay route present -> no add",
+			allRoutes: []netlink.Route{overlayRoute(net.ParseIP(gateway), netlink.SCOPE_UNIVERSE)},
+			cidrs:     []string{overlayCIDR},
+		},
+		{
+			name:       "overlay route with tampered gw -> re-add to repair",
+			allRoutes:  []netlink.Route{overlayRoute(net.ParseIP("100.64.0.99"), netlink.SCOPE_UNIVERSE)},
+			cidrs:      []string{overlayCIDR},
+			wantAddDst: []string{overlayCIDR},
+			validateAdd: func(t *testing.T, toAdd []netlink.Route) {
+				require.True(t, toAdd[0].Gw.Equal(net.ParseIP(gateway)))
+				require.Equal(t, netlink.SCOPE_UNIVERSE, toAdd[0].Scope)
+			},
+		},
+		{
+			name:       "overlay route with tampered scope -> re-add to repair",
+			allRoutes:  []netlink.Route{overlayRoute(net.ParseIP(gateway), netlink.SCOPE_LINK)},
+			cidrs:      []string{overlayCIDR},
+			wantAddDst: []string{overlayCIDR},
+		},
+		{
+			name:       "overlay route missing -> add",
+			cidrs:      []string{overlayCIDR},
+			wantAddDst: []string{overlayCIDR},
+		},
+		{
+			name: "correct join route present -> no add",
+			allRoutes: []netlink.Route{
+				{Dst: mustCIDR(joinV4CIDR), Src: net.ParseIP(joinIPv4), Scope: netlink.SCOPE_LINK},
+			},
+			cidrs:    []string{joinV4CIDR},
+			joinCIDR: []string{joinV4CIDR},
+		},
+		{
+			name: "join route with tampered gw -> re-add to repair",
+			allRoutes: []netlink.Route{
+				{Dst: mustCIDR(joinV4CIDR), Src: net.ParseIP(joinIPv4), Gw: net.ParseIP(gateway), Scope: netlink.SCOPE_LINK},
+			},
+			cidrs:      []string{joinV4CIDR},
+			joinCIDR:   []string{joinV4CIDR},
+			wantAddDst: []string{joinV4CIDR},
+			validateAdd: func(t *testing.T, toAdd []netlink.Route) {
+				require.Nil(t, toAdd[0].Gw)
+				require.Equal(t, netlink.SCOPE_LINK, toAdd[0].Scope)
+			},
+		},
+		{
+			name: "join IPv6 route present (priority ignored) -> no add",
+			allRoutes: []netlink.Route{
+				// metric differs from the desired 256, but priority is not compared so the
+				// route is still considered present and is not re-added.
+				{Dst: mustCIDR(joinV6CIDR), Scope: netlink.SCOPE_LINK, Priority: 100},
+			},
+			cidrs:    []string{joinV6CIDR},
+			joinCIDR: []string{joinV6CIDR},
+		},
+		{
+			name: "join IPv6 route with tampered scope -> re-add to repair",
+			allRoutes: []netlink.Route{
+				{Dst: mustCIDR(joinV6CIDR), Scope: netlink.SCOPE_UNIVERSE, Priority: 256},
+			},
+			cidrs:      []string{joinV6CIDR},
+			joinCIDR:   []string{joinV6CIDR},
+			wantAddDst: []string{joinV6CIDR},
+			validateAdd: func(t *testing.T, toAdd []netlink.Route) {
+				require.Equal(t, netlink.SCOPE_LINK, toAdd[0].Scope)
+				require.Equal(t, 256, toAdd[0].Priority)
+			},
+		},
+		{
+			name:       "stale route on node nic not in cidrs -> delete",
+			nodeNic:    []netlink.Route{{Dst: mustCIDR("10.99.0.0/16"), Scope: netlink.SCOPE_UNIVERSE}},
+			cidrs:      []string{overlayCIDR},
+			wantAddDst: []string{overlayCIDR},
+			wantDelDst: []string{"10.99.0.0/16"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			toAdd, toDel := routeDiff(tt.nodeNic, tt.allRoutes, tt.cidrs, tt.joinCIDR, joinIPv4, "", gateway, nodeIPv4, nil)
+
+			gotAddDst := make([]string, 0, len(toAdd))
+			for _, r := range toAdd {
+				gotAddDst = append(gotAddDst, r.Dst.String())
+			}
+			require.ElementsMatch(t, tt.wantAddDst, gotAddDst)
+
+			gotDelDst := make([]string, 0, len(toDel))
+			for _, r := range toDel {
+				gotDelDst = append(gotDelDst, r.Dst.String())
+			}
+			require.ElementsMatch(t, tt.wantDelDst, gotDelDst)
+
+			if tt.validateAdd != nil {
+				tt.validateAdd(t, toAdd)
+			}
+		})
+	}
+}
+
 func TestGetPolicyRouting(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/daemon/tproxy_linux.go
+++ b/pkg/daemon/tproxy_linux.go
@@ -195,24 +195,41 @@ func (c *Controller) cleanTProxyRoutes(protocol string) {
 	}
 }
 
+// tproxyRulesToCleanup scans the existing rules sharing a tproxy mark and reports which
+// ones must be removed (stale rules pointing at a different table/mask, plus any duplicate
+// of the desired rule) and whether a rule already matching the desired table+mask remains.
+// Returning the full set to delete - instead of stopping at the first match - ensures a
+// stale rule is never left behind to shadow the correct one, regardless of list ordering.
+func tproxyRulesToCleanup(curRules []netlink.Rule, mask uint32, table int) (toDel []netlink.Rule, found bool) {
+	for i := range curRules {
+		if !found && curRules[i].Table == table && curRules[i].Mask != nil && *curRules[i].Mask == mask {
+			found = true
+			continue
+		}
+		toDel = append(toDel, curRules[i])
+	}
+	return toDel, found
+}
+
 func addRuleIfNotExist(family int, mark, mask uint32, table int) error {
 	curRules, err := netlink.RuleListFiltered(family, &netlink.Rule{Mark: mark}, netlink.RT_FILTER_MARK)
 	if err != nil {
 		return fmt.Errorf("list rules with mark %x failed err: %w", mark, err)
 	}
 
-	// Only treat the rule as present when its table and mask also match the desired
-	// values. A rule that shares the mark but points at a different table/mask (left over
-	// from a previous configuration or modified externally) would shadow the correct one,
-	// so delete it here and recreate it below instead of skipping silently.
-	for i := range curRules {
-		if curRules[i].Table == table && curRules[i].Mask != nil && *curRules[i].Mask == mask {
-			return nil
-		}
-		klog.Infof("deleting stale tproxy rule %v conflicting with mark %#x table %d", curRules[i], mark, table)
-		if err = netlink.RuleDel(&curRules[i]); err != nil && !errors.Is(err, syscall.ENOENT) {
+	// A rule that shares the mark but points at a different table/mask (left over from a
+	// previous configuration or modified externally) would shadow the correct one, so
+	// delete every non-matching or duplicate rule and only skip recreation when a rule
+	// with the desired table+mask is already present.
+	toDel, found := tproxyRulesToCleanup(curRules, mask, table)
+	for i := range toDel {
+		klog.Infof("deleting stale tproxy rule %v conflicting with mark %#x table %d", toDel[i], mark, table)
+		if err = netlink.RuleDel(&toDel[i]); err != nil && !errors.Is(err, syscall.ENOENT) {
 			return fmt.Errorf("delete stale rule with mark %x failed err: %w", mark, err)
 		}
+	}
+	if found {
+		return nil
 	}
 
 	rule := netlink.NewRule()

--- a/pkg/daemon/tproxy_linux.go
+++ b/pkg/daemon/tproxy_linux.go
@@ -201,8 +201,18 @@ func addRuleIfNotExist(family int, mark, mask uint32, table int) error {
 		return fmt.Errorf("list rules with mark %x failed err: %w", mark, err)
 	}
 
-	if len(curRules) != 0 {
-		return nil
+	// Only treat the rule as present when its table and mask also match the desired
+	// values. A rule that shares the mark but points at a different table/mask (left over
+	// from a previous configuration or modified externally) would shadow the correct one,
+	// so delete it here and recreate it below instead of skipping silently.
+	for i := range curRules {
+		if curRules[i].Table == table && curRules[i].Mask != nil && *curRules[i].Mask == mask {
+			return nil
+		}
+		klog.Infof("deleting stale tproxy rule %v conflicting with mark %#x table %d", curRules[i], mark, table)
+		if err = netlink.RuleDel(&curRules[i]); err != nil && !errors.Is(err, syscall.ENOENT) {
+			return fmt.Errorf("delete stale rule with mark %x failed err: %w", mark, err)
+		}
 	}
 
 	rule := netlink.NewRule()

--- a/pkg/daemon/tproxy_linux_test.go
+++ b/pkg/daemon/tproxy_linux_test.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+)
+
+func TestTproxyRulesToCleanup(t *testing.T) {
+	t.Parallel()
+
+	const (
+		table = 10001
+		mask  = uint32(0x90003)
+	)
+
+	rule := func(t int, m *uint32) netlink.Rule {
+		return netlink.Rule{Table: t, Mask: m}
+	}
+	maskPtr := func(v uint32) *uint32 { return &v }
+
+	tests := []struct {
+		name       string
+		curRules   []netlink.Rule
+		wantDelLen int
+		wantFound  bool
+	}{
+		{
+			name:      "no existing rules",
+			curRules:  nil,
+			wantFound: false,
+		},
+		{
+			name:      "single matching rule kept",
+			curRules:  []netlink.Rule{rule(table, maskPtr(mask))},
+			wantFound: true,
+		},
+		{
+			name:       "stale rule wrong table deleted",
+			curRules:   []netlink.Rule{rule(20002, maskPtr(mask))},
+			wantDelLen: 1,
+			wantFound:  false,
+		},
+		{
+			name:       "stale rule wrong mask deleted",
+			curRules:   []netlink.Rule{rule(table, maskPtr(0x12345))},
+			wantDelLen: 1,
+			wantFound:  false,
+		},
+		{
+			name:       "stale rule nil mask deleted",
+			curRules:   []netlink.Rule{rule(table, nil)},
+			wantDelLen: 1,
+			wantFound:  false,
+		},
+		{
+			name:       "correct rule first then stale rule still cleaned up",
+			curRules:   []netlink.Rule{rule(table, maskPtr(mask)), rule(20002, maskPtr(mask))},
+			wantDelLen: 1,
+			wantFound:  true,
+		},
+		{
+			name:       "stale rule first then correct rule",
+			curRules:   []netlink.Rule{rule(20002, maskPtr(mask)), rule(table, maskPtr(mask))},
+			wantDelLen: 1,
+			wantFound:  true,
+		},
+		{
+			name:       "duplicate correct rule deleted keeping one",
+			curRules:   []netlink.Rule{rule(table, maskPtr(mask)), rule(table, maskPtr(mask))},
+			wantDelLen: 1,
+			wantFound:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			toDel, found := tproxyRulesToCleanup(tt.curRules, mask, table)
+			require.Equal(t, tt.wantFound, found)
+			require.Len(t, toDel, tt.wantDelLen)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `routeDiff` only matched managed ovn0 routes by `Dst` (join) or `Dst`+`Src` (non-join), so a route whose **gateway or scope was modified in place** was never repaired by the 3s reconcile loop (only added/removed routes were detected). It now also compares `Src`/`Gw`/`Scope`, letting drifted routes fall through to the existing `RouteReplace`. `Priority` is intentionally excluded — it is part of the route key, so a mismatch would create a duplicate instead of replacing in place, and a link route's metric does not affect connectivity. The redundant second pass over `nodeNicRoutes` is dropped (`allRoutes` already contains them).
- tproxy `addRuleIfNotExist` previously skipped whenever *any* rule with the mark existed; it now verifies the `table` and `mask` match too and deletes stale rules so the correct one is recreated.
- `getRulesToAdd` was reviewed and left unchanged: it diffs desired-vs-desired policy-routing rules and already compares every field that `getPolicyRouting` populates (`Table`/`Priority`/`Family`/`Src`).

## Test plan
- [x] `go build ./pkg/daemon/`
- [x] `golangci-lint run ./pkg/daemon/...` — 0 issues
- [x] `modernize` — clean
- [x] New `TestRouteDiff` unit test covers overlay/join (v4+v6): correct route (no churn), tampered gw, tampered scope, missing route, and stale-route deletion
- [x] `go test ./pkg/daemon/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)