### PR TITLE
feat: rotate kube-ovn TLS secret

### DIFF
--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -176,6 +176,8 @@ spec:
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.enableSsl }}"
+            - name: KUBE_OVN_TLS_ROTATION_INTERVAL
+              value: "{{ .Values.networking.kubeOvnTlsRotationInterval }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
+++ b/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
@@ -248,6 +248,14 @@ rules:
       - get
       - create
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - kube-ovn-tls
+    verbs:
+      - update
+  - apiGroups:
       - certificates.k8s.io
     resourceNames:
       - kubeovn.io/signer

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -137,6 +137,9 @@ networking:
   # -- Deploy the CNI with SSL encryption in between components.
   # @section -- Network parameters of the CNI
   enableSsl: false
+  # -- How often kube-ovn-controller checks kube-ovn-tls for renewal. Set to 0 to disable.
+  # @section -- Network parameters of the CNI
+  kubeOvnTlsRotationInterval: "8760h"
   # -- Network type can be "geneve" or "vlan".
   # @section -- Network parameters of the CNI
   networkType: geneve

--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -195,6 +195,18 @@ true
 {{- end -}}
 
 {{/*
+Kube-OVN TLS is owned by the management cluster in dataPlaneOnly installs.
+Disable local rotation there so a tenant cluster cannot replace the shared CA.
+*/}}
+{{- define "kubeovn.kubeOVNTLSRotationInterval" -}}
+{{- if eq .Values.installMode "dataPlaneOnly" -}}
+0
+{{- else -}}
+{{ .Values.networking.KUBE_OVN_TLS_ROTATION_INTERVAL }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Determine the updateStrategy type for the ovs-ovn DaemonSet.
 If ovs-ovn.updateStrategy.type is set, use it directly.
 Otherwise, auto-detect based on the currently deployed DaemonSet.

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -167,6 +167,8 @@ spec:
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"
+            - name: KUBE_OVN_TLS_ROTATION_INTERVAL
+              value: "{{ include "kubeovn.kubeOVNTLSRotationInterval" . }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -255,6 +255,14 @@ rules:
     - get
     - create
   - apiGroups:
+    - ""
+    resources:
+    - secrets
+    resourceNames:
+    - kube-ovn-tls
+    verbs:
+    - update
+  - apiGroups:
     - certificates.k8s.io
     resourceNames:
     - kubeovn.io/signer

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -56,6 +56,7 @@ networking:
   # NET_STACK could be dual_stack, ipv4, ipv6
   NET_STACK: ipv4
   ENABLE_SSL: false
+  KUBE_OVN_TLS_ROTATION_INTERVAL: "8760h"
   # network type could be geneve or vlan
   NETWORK_TYPE: geneve
   # tunnel type could be geneve, vxlan or stt

--- a/cmd/frr/frr.go
+++ b/cmd/frr/frr.go
@@ -28,7 +28,7 @@ type Config struct {
 	VNI           string
 	RouteTargets  []string
 	EnableEVPN    bool
-	Password      string
+	Password      string //nolint:gosec // BGP password is runtime configuration, not a hardcoded secret.
 	HoldTime      string
 	KeepaliveTime string
 	ConnectTime   string

--- a/cmd/ovn_ic_controller/ovn_ic_controller.go
+++ b/cmd/ovn_ic_controller/ovn_ic_controller.go
@@ -32,7 +32,8 @@ func CmdMain() {
 	}
 	util.InitLogFilePerm("kube-ovn-ic-controller", os.FileMode(logFilePerm))
 
-	stopCh := signals.SetupSignalHandler().Done()
+	ctx := signals.SetupSignalHandler()
+	stopCh := ctx.Done()
 	ctl := ovn_ic_controller.NewController(config)
 	ctl.Run(stopCh)
 }

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -8,6 +8,7 @@ DEL_NON_HOST_NET_POD=${DEL_NON_HOST_NET_POD:-true}
 IPV6=${IPV6:-false}
 DUAL_STACK=${DUAL_STACK:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
+KUBE_OVN_TLS_ROTATION_INTERVAL=${KUBE_OVN_TLS_ROTATION_INTERVAL:-8760h}
 ENABLE_VLAN=${ENABLE_VLAN:-false}
 CHECK_GATEWAY=${CHECK_GATEWAY:-true}
 LOGICAL_GATEWAY=${LOGICAL_GATEWAY:-false}
@@ -7218,6 +7219,14 @@ rules:
     - get
     - create
   - apiGroups:
+    - ""
+    resourceNames:
+    - kube-ovn-tls
+    resources:
+    - secrets
+    verbs:
+    - update
+  - apiGroups:
     - certificates.k8s.io
     resourceNames:
     - kubeovn.io/signer
@@ -8273,6 +8282,8 @@ spec:
           env:
             - name: ENABLE_SSL
               value: "$ENABLE_SSL"
+            - name: KUBE_OVN_TLS_ROTATION_INTERVAL
+              value: "$KUBE_OVN_TLS_ROTATION_INTERVAL"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/dist/images/kube-ovn-tls-reload.sh
+++ b/dist/images/kube-ovn-tls-reload.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+set -uo pipefail
+
+COMPONENT=${1:-}
+MODE=${2:-loop}
+ENABLE_SSL=${ENABLE_SSL:-false}
+TLS_RELOAD_INTERVAL=${TLS_RELOAD_INTERVAL:-5}
+TLS_DIR=${TLS_DIR:-/var/run/tls}
+TLS_FILES=(
+  "${TLS_DIR}/cacert"
+  "${TLS_DIR}/cert"
+  "${TLS_DIR}/key"
+)
+OVN_CTL=${OVN_CTL:-/usr/share/ovn/scripts/ovn-ctl}
+OVN_NB_CTL=${OVN_NB_CTL:-/var/run/ovn/ovnnb_db.ctl}
+OVN_SB_CTL=${OVN_SB_CTL:-/var/run/ovn/ovnsb_db.ctl}
+NB_PORT=${NB_PORT:-6641}
+SB_PORT=${SB_PORT:-6642}
+NB_CLUSTER_PORT=${NB_CLUSTER_PORT:-6643}
+SB_CLUSTER_PORT=${SB_CLUSTER_PORT:-6644}
+DB_CLUSTER_ADDR=${DB_CLUSTER_ADDR:-${POD_IP:-}}
+DB_ADDR=::
+if [[ "${ENABLE_BIND_LOCAL_IP:-false}" == "true" ]]; then
+  DB_ADDR=${POD_IP:-}
+fi
+SSL_OPTIONS="-p ${TLS_DIR}/key -c ${TLS_DIR}/cert -C ${TLS_DIR}/cacert"
+
+case "$COMPONENT" in
+  ovs)
+    TLS_HASH_FILE=${TLS_HASH_FILE:-/tmp/kube-ovn-tls.hash}
+    ;;
+  ovn-central)
+    TLS_HASH_FILE=${TLS_HASH_FILE:-/tmp/kube-ovn-central-tls.hash}
+    ;;
+  *)
+    echo "usage: $0 {ovs|ovn-central} [once|loop]"
+    exit 1
+    ;;
+esac
+TLS_LOCK_FILE=${TLS_LOCK_FILE:-${TLS_HASH_FILE}.lock}
+
+function tls_files_hash {
+  for file in "${TLS_FILES[@]}"; do
+    if [[ ! -s "$file" ]]; then
+      echo "kube-ovn TLS file $file is missing or empty" >&2
+      return 1
+    fi
+  done
+  sha256sum "${TLS_FILES[@]}" | sha256sum | awk '{print $1}'
+}
+
+function write_tls_hash {
+  local hash=$1
+  local tmp_file
+  tmp_file="${TLS_HASH_FILE}.$$"
+  printf "%s" "$hash" > "$tmp_file"
+  mv -f "$tmp_file" "$TLS_HASH_FILE"
+}
+
+function reload_ovs_tls {
+  echo "kube-ovn TLS files changed, restarting ovn-controller"
+  /usr/share/ovn/scripts/ovn-ctl \
+    --ovn-controller-ssl-key="${TLS_DIR}/key" \
+    --ovn-controller-ssl-cert="${TLS_DIR}/cert" \
+    --ovn-controller-ssl-ca-cert="${TLS_DIR}/cacert" \
+    --ovn-controller-wrapper="${DEBUG_WRAPPER:-}" \
+    restart_controller
+}
+
+function ovn_central_conn_addr {
+  local ip=$1
+  local port=$2
+
+  echo "ssl:[${ip}]:${port}"
+}
+
+function ovn_central_conn_str {
+  local port=$1
+  local endpoints=()
+
+  for ip in ${NODE_IPS//,/ }; do
+    endpoints+=("$(ovn_central_conn_addr "$ip" "$port")")
+  done
+  local IFS=,
+  echo "${endpoints[*]}"
+}
+
+function ovn_central_ssl_args {
+  printf "%s\n" \
+    "--ovn-nb-db-ssl-key=${TLS_DIR}/key" \
+    "--ovn-nb-db-ssl-cert=${TLS_DIR}/cert" \
+    "--ovn-nb-db-ssl-ca-cert=${TLS_DIR}/cacert" \
+    "--ovn-sb-db-ssl-key=${TLS_DIR}/key" \
+    "--ovn-sb-db-ssl-cert=${TLS_DIR}/cert" \
+    "--ovn-sb-db-ssl-ca-cert=${TLS_DIR}/cacert" \
+    "--ovn-northd-ssl-key=${TLS_DIR}/key" \
+    "--ovn-northd-ssl-cert=${TLS_DIR}/cert" \
+    "--ovn-northd-ssl-ca-cert=${TLS_DIR}/cacert"
+}
+
+function wait_ovn_ctl_status {
+  local status_cmd=$1
+
+  for _ in $(seq 1 30); do
+    if "$OVN_CTL" "$status_cmd" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+function reload_ovsdb_server_tls {
+  local ctl=$1
+
+  ovn-appctl -t "$ctl" ovsdb-server/set-ssl "${TLS_DIR}/key" "${TLS_DIR}/cert" "${TLS_DIR}/cacert"
+  ovn-appctl -t "$ctl" ovsdb-server/reconnect
+}
+
+function reload_ovn_central_ovsdb_tls {
+  reload_ovsdb_server_tls "$OVN_NB_CTL"
+  reload_ovsdb_server_tls "$OVN_SB_CTL"
+}
+
+function ovn_ctl_restart_or_status {
+  local status_cmd=$1
+  shift
+
+  if "$OVN_CTL" "$@"; then
+    return 0
+  fi
+
+  echo "ovn-ctl $* failed, checking ${status_cmd} before retrying" >&2
+  wait_ovn_ctl_status "$status_cmd"
+}
+
+function restart_standalone_ovn_central_tls {
+  local ssl_args
+  mapfile -t ssl_args < <(ovn_central_ssl_args)
+  ovn_ctl_restart_or_status status_northd "${ssl_args[@]}" --ovn-northd-n-threads="${OVN_NORTHD_N_THREADS:-1}" restart_northd
+}
+
+function restart_clustered_ovn_northd_tls {
+  if [[ -z "$DB_CLUSTER_ADDR" || -z "$DB_ADDR" ]]; then
+    echo "failed to determine local OVN DB address" >&2
+    return 1
+  fi
+
+  local ovn_ctl_args
+  mapfile -t ovn_ctl_args < <(ovn_central_ssl_args)
+  ovn_ctl_args+=(
+    "--ovn-northd-nb-db=$(ovn_central_conn_str "$NB_PORT")"
+    "--ovn-northd-sb-db=$(ovn_central_conn_str "$SB_PORT")"
+  )
+
+  ovn_ctl_restart_or_status status_northd "${ovn_ctl_args[@]}" \
+    --ovn-manage-ovsdb=no \
+    --ovn-northd-n-threads="${OVN_NORTHD_N_THREADS:-1}" \
+    restart_northd
+}
+
+function reload_ovn_central_tls {
+  echo "kube-ovn TLS files changed, reloading ovn-central TLS"
+  reload_ovn_central_ovsdb_tls || return 1
+
+  if [[ -z "${NODE_IPS:-}" ]]; then
+    restart_standalone_ovn_central_tls
+    return $?
+  fi
+  restart_clustered_ovn_northd_tls
+}
+
+function reload_tls {
+  case "$COMPONENT" in
+    ovs)
+      reload_ovs_tls
+      ;;
+    ovn-central)
+      reload_ovn_central_tls
+      ;;
+  esac
+}
+
+function check_tls_once {
+  if [[ "$ENABLE_SSL" != "true" ]]; then
+    return 0
+  fi
+
+  local lock_fd
+  exec {lock_fd}>"$TLS_LOCK_FILE"
+  if ! flock -n "$lock_fd"; then
+    exec {lock_fd}>&-
+    return 0
+  fi
+
+  local current_hash
+  current_hash=$(tls_files_hash) || {
+    exec {lock_fd}>&-
+    return 1
+  }
+  if [[ ! -f "$TLS_HASH_FILE" ]]; then
+    write_tls_hash "$current_hash"
+    exec {lock_fd}>&-
+    return 0
+  fi
+
+  local previous_hash
+  previous_hash=$(cat "$TLS_HASH_FILE" 2>/dev/null || true)
+  if [[ "$current_hash" == "$previous_hash" ]]; then
+    exec {lock_fd}>&-
+    return 0
+  fi
+
+  # Keep the parent lock during reload, but do not let restarted daemons inherit it.
+  if (exec {lock_fd}>&-; reload_tls); then
+    write_tls_hash "$current_hash"
+    exec {lock_fd}>&-
+    return 0
+  fi
+
+  exec {lock_fd}>&-
+  echo "failed to reload kube-ovn TLS files, will retry" >&2
+  return 1
+}
+
+if [[ "$MODE" == "once" ]]; then
+  check_tls_once
+  exit $?
+fi
+
+while true; do
+  check_tls_once || true
+  sleep "$TLS_RELOAD_INTERVAL"
+done

--- a/dist/images/ovn-healthcheck.sh
+++ b/dist/images/ovn-healthcheck.sh
@@ -4,6 +4,8 @@ shopt -s expand_aliases
 
 alias ovn-ctl='/usr/share/ovn/scripts/ovn-ctl'
 
+ENABLE_SSL=${ENABLE_SSL:-false}
+
 ovn-ctl status_northd
 ovn-ctl status_ovnnb | grep -q '^running'
 ovn-ctl status_ovnsb | grep -q '^running'

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -574,6 +574,10 @@ fi
 ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/memory-trim-on-compaction on
 ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/memory-trim-on-compaction on
 
+if [[ "$ENABLE_SSL" == "true" ]]; then
+    bash /kube-ovn/kube-ovn-tls-reload.sh ovn-central &
+fi
+
 chmod 600 /etc/ovn/*
 /kube-ovn/kube-ovn-leader-checker \
     --probeInterval=${OVN_LEADER_PROBE_INTERVAL} \

--- a/dist/images/start-ovs-dpdk-v2.sh
+++ b/dist/images/start-ovs-dpdk-v2.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 OVN_REMOTE_PROBE_INTERVAL=${OVN_REMOTE_PROBE_INTERVAL:-10000}
 OVN_REMOTE_OPENFLOW_INTERVAL=${OVN_REMOTE_OPENFLOW_INTERVAL:-180}
+ENABLE_SSL=${ENABLE_SSL:-false}
 
 echo "OVN_REMOTE_PROBE_INTERVAL is set to $OVN_REMOTE_PROBE_INTERVAL"
 echo "OVN_REMOTE_OPENFLOW_INTERVAL is set to $OVN_REMOTE_OPENFLOW_INTERVAL"
@@ -125,13 +126,22 @@ ovs-vsctl --may-exist add-br br-int \
   -- set bridge br-int fail-mode=secure
 
 # Set remote ovn-sb for ovn-controller to connect to
-ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
+if [[ "$ENABLE_SSL" == "true" ]]; then
+  ovs-vsctl set open . external-ids:ovn-remote=ssl:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
+else
+  ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
+fi
 ovs-vsctl set open . external-ids:ovn-remote-probe-interval="${OVN_REMOTE_PROBE_INTERVAL}"
 ovs-vsctl set open . external-ids:ovn-openflow-probe-interval="${OVN_REMOTE_OPENFLOW_INTERVAL}"
 ovs-vsctl set open . external-ids:ovn-match-northd-version="true"
 ovs-vsctl set open . external-ids:ovn-encap-type="${TUNNEL_TYPE}"
 
 # Start ovn-controller
-ovn-ctl restart_controller
+if [[ "$ENABLE_SSL" == "true" ]]; then
+  ovn-ctl --ovn-controller-ssl-key=/var/run/tls/key --ovn-controller-ssl-cert=/var/run/tls/cert --ovn-controller-ssl-ca-cert=/var/run/tls/cacert restart_controller
+  bash /kube-ovn/kube-ovn-tls-reload.sh ovs &
+else
+  ovn-ctl restart_controller
+fi
 
 tail --follow=name --retry /var/log/openvswitch/ovs-vswitchd.log

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -153,6 +153,7 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
   /usr/share/ovn/scripts/ovn-ctl --ovn-controller-wrapper="$DEBUG_WRAPPER" restart_controller
 else
   /usr/share/ovn/scripts/ovn-ctl --ovn-controller-ssl-key=/var/run/tls/key --ovn-controller-ssl-cert=/var/run/tls/cert --ovn-controller-ssl-ca-cert=/var/run/tls/cacert --ovn-controller-wrapper="$DEBUG_WRAPPER" restart_controller
+  bash /kube-ovn/kube-ovn-tls-reload.sh ovs &
 fi
 
 chmod 600 /etc/openvswitch/*

--- a/pkg/apis/kubeovn/v1/bgp_conf.go
+++ b/pkg/apis/kubeovn/v1/bgp_conf.go
@@ -27,7 +27,7 @@ type BgpConfSpec struct {
 	PeerASN       uint32          `json:"peerASN"`
 	RouterID      string          `json:"routerId,omitempty"`
 	Neighbours    []string        `json:"neighbours"`
-	Password      string          `json:"password,omitempty"`
+	Password      string          `json:"password,omitempty"` //nolint:gosec // BGP password is runtime configuration, not a hardcoded secret.
 	HoldTime      metav1.Duration `json:"holdTime,omitempty"`
 	KeepaliveTime metav1.Duration `json:"keepaliveTime,omitempty"`
 	ConnectTime   metav1.Duration `json:"connectTime,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1170,6 +1170,8 @@ func (c *Controller) Run(ctx context.Context) {
 		}
 	}
 
+	c.startKubeOVNTLSManager(ctx)
+
 	// start workers to do all the network operations
 	c.startWorkers(ctx)
 

--- a/pkg/controller/kube_ovn_tls.go
+++ b/pkg/controller/kube_ovn_tls.go
@@ -1,0 +1,201 @@
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+const (
+	kubeOVNTLSSecretName              = "kube-ovn-tls" // #nosec G101 -- Kubernetes Secret resource name, not a credential.
+	kubeOVNTLSDefaultRotationInterval = 365 * 24 * time.Hour
+	kubeOVNTLSCADuration              = 10 * 365 * 24 * time.Hour
+	kubeOVNTLSCertDuration            = 10 * 365 * 24 * time.Hour
+	kubeOVNTLSCommonName              = "ovn"
+
+	kubeOVNTLSCertHashAnnotation = "kube-ovn.io/kube-ovn-tls-cert-hash"
+)
+
+func (c *Controller) startKubeOVNTLSManager(ctx context.Context) {
+	if os.Getenv(util.EnvSSLEnabled) != "true" {
+		return
+	}
+	interval, err := kubeOVNTLSRotationInterval()
+	if err != nil {
+		klog.Errorf("failed to parse kube-ovn TLS rotation interval: %v", err)
+		return
+	}
+	if interval <= 0 {
+		return
+	}
+
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		if err := c.reconcileKubeOVNTLS(ctx); err != nil {
+			klog.Errorf("failed to reconcile kube-ovn TLS secret: %v", err)
+		}
+	}, interval)
+}
+
+func kubeOVNTLSRotationInterval() (time.Duration, error) {
+	value := strings.TrimSpace(os.Getenv(util.EnvKubeOVNTLSRotationInterval))
+	if value == "" {
+		return kubeOVNTLSDefaultRotationInterval, nil
+	}
+	interval, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s=%q: %w", util.EnvKubeOVNTLSRotationInterval, value, err)
+	}
+	return interval, nil
+}
+
+func (c *Controller) reconcileKubeOVNTLS(ctx context.Context) error {
+	secret, err := c.config.KubeClient.CoreV1().Secrets(c.config.PodNamespace).Get(ctx, kubeOVNTLSSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		data, hash, genErr := generateKubeOVNTLSData(time.Now(), kubeOVNTLSCADuration, kubeOVNTLSCertDuration)
+		if genErr != nil {
+			return genErr
+		}
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kubeOVNTLSSecretName,
+				Namespace: c.config.PodNamespace,
+				Annotations: map[string]string{
+					kubeOVNTLSCertHashAnnotation: hash,
+				},
+			},
+			Data: data,
+		}
+		if _, err = c.config.KubeClient.CoreV1().Secrets(c.config.PodNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// kube-ovn-tls keeps the legacy cacert/cert/key schema. The manager only
+	// adds metadata on first adoption so upgrades do not restart OVN workloads.
+	hash, err := kubeOVNTLSHash(secret.Data)
+	if err != nil {
+		return err
+	}
+
+	if secret.Annotations[kubeOVNTLSCertHashAnnotation] != hash {
+		if err = c.setKubeOVNTLSHash(ctx, hash); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	renew, err := kubeOVNTLSNeedsRenewal(time.Now(), secret.Data)
+	if err != nil {
+		return err
+	}
+	if renew {
+		data, newHash, genErr := generateKubeOVNTLSData(time.Now(), kubeOVNTLSCADuration, kubeOVNTLSCertDuration)
+		if genErr != nil {
+			return genErr
+		}
+		if err = c.updateKubeOVNTLSSecretData(ctx, data, newHash); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func kubeOVNTLSNeedsRenewal(now time.Time, data map[string][]byte) (bool, error) {
+	cert, err := parseKubeOVNTLSCert(data)
+	if err != nil {
+		return false, err
+	}
+	refreshTime := cert.NotBefore.Add(cert.NotAfter.Sub(cert.NotBefore) / 2)
+	return !now.Before(refreshTime), nil
+}
+
+func parseKubeOVNTLSCert(data map[string][]byte) (*x509.Certificate, error) {
+	cert, err := decodeCertificate(data["cert"])
+	if err != nil {
+		return nil, fmt.Errorf("parse kube-ovn-tls cert: %w", err)
+	}
+	return cert, nil
+}
+
+func generateKubeOVNTLSData(now time.Time, caDuration, certDuration time.Duration) (map[string][]byte, string, error) {
+	data, err := util.GenerateKubeOVNTLSSecretData(now, caDuration, certDuration, kubeOVNTLSCommonName)
+	if err != nil {
+		return nil, "", err
+	}
+	hash, err := kubeOVNTLSHash(data)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, hash, nil
+}
+
+func kubeOVNTLSHash(data map[string][]byte) (string, error) {
+	for _, key := range []string{"cacert", "cert", "key"} {
+		if len(data[key]) == 0 {
+			return "", fmt.Errorf("kube-ovn-tls missing %s", key)
+		}
+	}
+	h := sha256.New()
+	for _, key := range []string{"cacert", "cert", "key"} {
+		h.Write([]byte(key))
+		h.Write([]byte{0})
+		h.Write(data[key])
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (c *Controller) updateKubeOVNTLSSecretData(ctx context.Context, data map[string][]byte, hash string) error {
+	secrets := c.config.KubeClient.CoreV1().Secrets(c.config.PodNamespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := secrets.Get(ctx, kubeOVNTLSSecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		secret = secret.DeepCopy()
+		secret.Data = data
+		setKubeOVNTLSAnnotation(secret, kubeOVNTLSCertHashAnnotation, hash)
+		_, err = secrets.Update(ctx, secret, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func (c *Controller) setKubeOVNTLSHash(ctx context.Context, hash string) error {
+	secrets := c.config.KubeClient.CoreV1().Secrets(c.config.PodNamespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := secrets.Get(ctx, kubeOVNTLSSecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		secret = secret.DeepCopy()
+		setKubeOVNTLSAnnotation(secret, kubeOVNTLSCertHashAnnotation, hash)
+		_, err = secrets.Update(ctx, secret, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func setKubeOVNTLSAnnotation(secret *corev1.Secret, key, value string) {
+	if secret.Annotations == nil {
+		secret.Annotations = map[string]string{}
+	}
+	secret.Annotations[key] = value
+}

--- a/pkg/controller/kube_ovn_tls_test.go
+++ b/pkg/controller/kube_ovn_tls_test.go
@@ -1,0 +1,211 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"slices"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestReconcileKubeOVNTLSAddsBaselineAnnotation(t *testing.T) {
+	const namespace = "kube-system"
+	data, hash, err := generateKubeOVNTLSData(time.Now(), kubeOVNTLSCADuration, kubeOVNTLSCertDuration)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+	client := fake.NewSimpleClientset(
+		testKubeOVNTLSSecret(namespace, data, nil),
+	)
+	c := &Controller{config: &Configuration{KubeClient: client, PodNamespace: namespace}}
+
+	if err = c.reconcileKubeOVNTLS(context.Background()); err != nil {
+		t.Fatalf("reconcileKubeOVNTLS returned error: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), kubeOVNTLSSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get kube-ovn-tls secret: %v", err)
+	}
+	if got := secret.Annotations[kubeOVNTLSCertHashAnnotation]; got != hash {
+		t.Fatalf("cert hash annotation = %q, want %q", got, hash)
+	}
+}
+
+func TestReconcileKubeOVNTLSOnlyAdoptsExpiredLegacySecret(t *testing.T) {
+	const namespace = "kube-system"
+	expiredData, hash, err := generateKubeOVNTLSData(time.Now().Add(-20*24*time.Hour), 10*24*time.Hour, 10*24*time.Hour)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+	client := fake.NewSimpleClientset(
+		testKubeOVNTLSSecret(namespace, expiredData, nil),
+	)
+	c := &Controller{config: &Configuration{KubeClient: client, PodNamespace: namespace}}
+
+	if err = c.reconcileKubeOVNTLS(context.Background()); err != nil {
+		t.Fatalf("reconcileKubeOVNTLS returned error: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), kubeOVNTLSSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get kube-ovn-tls secret: %v", err)
+	}
+	if got := secret.Annotations[kubeOVNTLSCertHashAnnotation]; got != hash {
+		t.Fatalf("cert hash annotation = %q, want %q", got, hash)
+	}
+	assertSecretDataEqual(t, secret.Data, expiredData)
+}
+
+func TestReconcileKubeOVNTLSRotatesExpiredSecret(t *testing.T) {
+	const namespace = "kube-system"
+	expiredData, oldHash, err := generateKubeOVNTLSData(time.Now().Add(-20*24*time.Hour), 10*24*time.Hour, 10*24*time.Hour)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+	client := fake.NewSimpleClientset(
+		testKubeOVNTLSSecret(namespace, expiredData, map[string]string{
+			kubeOVNTLSCertHashAnnotation: oldHash,
+		}),
+	)
+	c := &Controller{config: &Configuration{KubeClient: client, PodNamespace: namespace}}
+
+	if err = c.reconcileKubeOVNTLS(context.Background()); err != nil {
+		t.Fatalf("reconcileKubeOVNTLS returned error: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), kubeOVNTLSSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get kube-ovn-tls secret: %v", err)
+	}
+	newHash := secret.Annotations[kubeOVNTLSCertHashAnnotation]
+	if newHash == "" || newHash == oldHash {
+		t.Fatalf("cert hash annotation = %q, want non-empty value different from %q", newHash, oldHash)
+	}
+}
+
+func TestGenerateKubeOVNTLSDataAddsServingAndClientIdentity(t *testing.T) {
+	data, _, err := generateKubeOVNTLSData(time.Now(), kubeOVNTLSCADuration, kubeOVNTLSCertDuration)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+
+	cert, err := parseKubeOVNTLSCert(data)
+	if err != nil {
+		t.Fatalf("parseKubeOVNTLSCert returned error: %v", err)
+	}
+
+	if !containsExtKeyUsage(cert.ExtKeyUsage, x509.ExtKeyUsageServerAuth) {
+		t.Fatalf("leaf certificate ExtKeyUsage = %v, want ServerAuth", cert.ExtKeyUsage)
+	}
+	if !containsExtKeyUsage(cert.ExtKeyUsage, x509.ExtKeyUsageClientAuth) {
+		t.Fatalf("leaf certificate ExtKeyUsage = %v, want ClientAuth", cert.ExtKeyUsage)
+	}
+	if !containsString(cert.DNSNames, kubeOVNTLSCommonName) {
+		t.Fatalf("leaf certificate DNSNames = %v, want %q", cert.DNSNames, kubeOVNTLSCommonName)
+	}
+}
+
+func TestStartKubeOVNTLSManagerPeriodicallyRotatesExpiredSecret(t *testing.T) {
+	const namespace = "kube-system"
+	expiredData, oldHash, err := generateKubeOVNTLSData(time.Now().Add(-20*24*time.Hour), 10*24*time.Hour, 10*24*time.Hour)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+	client := fake.NewSimpleClientset(
+		testKubeOVNTLSSecret(namespace, expiredData, map[string]string{
+			kubeOVNTLSCertHashAnnotation: oldHash,
+		}),
+	)
+	c := &Controller{config: &Configuration{KubeClient: client, PodNamespace: namespace}}
+	t.Setenv(util.EnvSSLEnabled, "true")
+	t.Setenv(util.EnvKubeOVNTLSRotationInterval, "10ms")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	c.startKubeOVNTLSManager(ctx)
+
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		secret, err := client.CoreV1().Secrets(namespace).Get(ctx, kubeOVNTLSSecretName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		newHash, err := kubeOVNTLSHash(secret.Data)
+		if err != nil {
+			return false, err
+		}
+		return newHash != oldHash && secret.Annotations[kubeOVNTLSCertHashAnnotation] == newHash, nil
+	})
+	if err != nil {
+		t.Fatalf("startKubeOVNTLSManager did not rotate expired kube-ovn-tls secret: %v", err)
+	}
+}
+
+func TestKubeOVNTLSRotationInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "empty uses default", value: "", want: 365 * 24 * time.Hour},
+		{name: "zero disables rotation", value: "0", want: 0},
+		{name: "custom interval", value: "12h", want: 12 * time.Hour},
+		{name: "invalid interval", value: "bad", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KUBE_OVN_TLS_ROTATION_INTERVAL", tt.value)
+			got, err := kubeOVNTLSRotationInterval()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("kubeOVNTLSRotationInterval returned nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("kubeOVNTLSRotationInterval returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("interval = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func assertSecretDataEqual(t *testing.T, got, want map[string][]byte) {
+	t.Helper()
+	for _, key := range []string{"cacert", "cert", "key"} {
+		if !bytes.Equal(got[key], want[key]) {
+			t.Fatalf("secret data %s changed during adoption", key)
+		}
+	}
+}
+
+func containsExtKeyUsage(usages []x509.ExtKeyUsage, want x509.ExtKeyUsage) bool {
+	return slices.Contains(usages, want)
+}
+
+func containsString(values []string, want string) bool {
+	return slices.Contains(values, want)
+}
+
+func testKubeOVNTLSSecret(namespace string, data map[string][]byte, annotations map[string]string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        kubeOVNTLSSecretName,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Data: data,
+	}
+}

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -86,22 +86,10 @@ func NewOvsDbClient(
 		backOff = bo
 	}
 	if ssl {
-		cert, err := tls.LoadX509KeyPair(util.SslCertPath, util.SslKeyPath)
+		tlsConfig, err := newKubeOVNTLSConfig()
 		if err != nil {
 			klog.Error(err)
-			return nil, fmt.Errorf("failed to load x509 cert key pair: %w", err)
-		}
-		caCert, err := os.ReadFile(util.SslCACert)
-		if err != nil {
-			klog.Error(err)
-			return nil, fmt.Errorf("failed to read ca cert: %w", err)
-		}
-		certPool := x509.NewCertPool()
-		certPool.AppendCertsFromPEM(caCert)
-		tlsConfig := &tls.Config{
-			Certificates:       []tls.Certificate{cert},
-			RootCAs:            certPool,
-			InsecureSkipVerify: true, // #nosec G402
+			return nil, err
 		}
 		options = append(options, client.WithTLSConfig(tlsConfig))
 	}
@@ -145,4 +133,25 @@ func NewOvsDbClient(
 	}
 
 	return c, nil
+}
+
+func newKubeOVNTLSConfig() (*tls.Config, error) {
+	caCert, err := os.ReadFile(util.SslCACert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ca cert: %w", err)
+	}
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(caCert)
+
+	return &tls.Config{
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(util.SslCertPath, util.SslKeyPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load x509 cert key pair: %w", err)
+			}
+			return &cert, nil
+		},
+		RootCAs:            certPool,
+		InsecureSkipVerify: true, // #nosec G402
+	}, nil
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -380,8 +380,9 @@ const (
 	EnvHostIP       = "HOST_IP"
 	EnvHostIPs      = "HOST_IPS"
 
-	EnvSSLEnabled  = "ENABLE_SSL"
-	EnvGatewayName = "GATEWAY_NAME"
+	EnvSSLEnabled                 = "ENABLE_SSL"
+	EnvKubeOVNTLSRotationInterval = "KUBE_OVN_TLS_ROTATION_INTERVAL"
+	EnvGatewayName                = "GATEWAY_NAME"
 )
 
 const (

--- a/pkg/util/kube_ovn_tls_cert.go
+++ b/pkg/util/kube_ovn_tls_cert.go
@@ -1,0 +1,119 @@
+package util
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+const kubeOVNTLSOrganization = "kube-ovn"
+
+// GenerateKubeOVNTLSSecretData returns the legacy cacert/cert/key Secret data
+// used by OVN components.
+func GenerateKubeOVNTLSSecretData(now time.Time, caDuration, certDuration time.Duration, commonName string) (map[string][]byte, error) {
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generate kube-ovn-tls CA key: %w", err)
+	}
+	caSerial, err := newCertificateSerialNumber()
+	if err != nil {
+		return nil, err
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber: caSerial,
+		Subject: pkix.Name{
+			CommonName:   commonName + "-ca",
+			Organization: []string{kubeOVNTLSOrganization},
+		},
+		NotBefore:             now.Add(-time.Second),
+		NotAfter:              now.Add(caDuration),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCert, err := createCertificate(caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("create kube-ovn-tls CA certificate: %w", err)
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generate kube-ovn-tls key: %w", err)
+	}
+	serial, err := newCertificateSerialNumber()
+	if err != nil {
+		return nil, err
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{kubeOVNTLSOrganization},
+		},
+		NotBefore:             now.Add(-time.Second),
+		NotAfter:              now.Add(certDuration),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:              []string{commonName},
+		BasicConstraintsValid: true,
+	}
+	cert, err := createCertificate(template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("create kube-ovn-tls certificate: %w", err)
+	}
+
+	caCertPEM, err := encodeCertificates(caCert)
+	if err != nil {
+		return nil, fmt.Errorf("encode kube-ovn-tls CA certificate: %w", err)
+	}
+	certPEM, err := encodeCertificates(cert)
+	if err != nil {
+		return nil, fmt.Errorf("encode kube-ovn-tls certificate: %w", err)
+	}
+
+	return map[string][]byte{
+		"cacert": caCertPEM,
+		"cert":   certPEM,
+		"key":    encodeRSAPrivateKeyPEM(key),
+	}, nil
+}
+
+func newCertificateSerialNumber() (*big.Int, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generate serial number: %w", err)
+	}
+	return serial, nil
+}
+
+func createCertificate(template, issuer *x509.Certificate, publicKey, issuerKey any) (*x509.Certificate, error) {
+	der, err := x509.CreateCertificate(rand.Reader, template, issuer, publicKey, issuerKey)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse generated certificate: %w", err)
+	}
+	return cert, nil
+}
+
+func encodeCertificates(certs ...*x509.Certificate) ([]byte, error) {
+	b := bytes.Buffer{}
+	for _, cert := range certs {
+		if err := pem.Encode(&b, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+			return nil, err
+		}
+	}
+	return b.Bytes(), nil
+}
+
+func encodeRSAPrivateKeyPEM(key *rsa.PrivateKey) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+}

--- a/test/e2e/security/e2e_test.go
+++ b/test/e2e/security/e2e_test.go
@@ -9,9 +9,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e"
@@ -49,6 +51,8 @@ func checkDeployment(f *framework.Framework, name, process string, ports ...stri
 	framework.ExpectNoError(err, "failed to get deployment")
 	err = deployment.WaitForDeploymentComplete(f.ClientSet, deploy)
 	framework.ExpectNoError(err, "deployment failed to complete")
+	deploy, err = f.ClientSet.AppsV1().Deployments(framework.KubeOvnNamespace).Get(context.TODO(), name, metav1.GetOptions{})
+	framework.ExpectNoError(err, "failed to get deployment")
 
 	ginkgo.By("Getting pods")
 	pods, err := deployment.GetPodsForDeployment(context.Background(), f.ClientSet, deploy)
@@ -92,33 +96,71 @@ func checkPods(f *framework.Framework, pods []corev1.Pod, process string, ports 
 
 		c, err := docker.ContainerInspect(pod.Spec.NodeName)
 		framework.ExpectNoError(err)
-		stdout, _, err := docker.Exec(c.ID, nil, "sh", "-c", cmd)
-		framework.ExpectNoError(err)
 
-		listenAddresses := strings.Split(string(bytes.TrimSpace(stdout)), "\n")
-		if len(ports) != 0 {
-			expected := make([]string, 0, len(pod.Status.PodIPs)*len(ports))
-			for _, port := range ports {
-				if listenPodIP {
-					for _, ip := range pod.Status.PodIPs {
-						expected = append(expected, net.JoinHostPort(ip.IP, port))
+		var lastReason string
+		err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, time.Minute, true, func(_ context.Context) (bool, error) {
+			stdout, _, err := docker.Exec(c.ID, nil, "sh", "-c", cmd)
+			if err != nil {
+				lastReason = err.Error()
+				return false, nil
+			}
+
+			listenAddresses := strings.Split(string(bytes.TrimSpace(stdout)), "\n")
+			if len(ports) != 0 {
+				expected := expectedListenAddresses(pod, listenPodIP, ports...)
+				if !sameStringElements(listenAddresses, expected) {
+					lastReason = fmt.Sprintf("got listen addresses %v, expected %v", listenAddresses, expected)
+					return false, nil
+				}
+			} else {
+				podIPPrefix := strings.TrimSuffix(net.JoinHostPort(pod.Status.PodIP, "999"), "999")
+				for _, addr := range listenAddresses {
+					if listenPodIP && !strings.HasPrefix(addr, podIPPrefix) {
+						lastReason = fmt.Sprintf("got listen address %q, expected prefix %q", addr, podIPPrefix)
+						return false, nil
 					}
-				} else {
-					expected = append(expected, net.JoinHostPort("*", port))
+					if !listenPodIP && !strings.HasPrefix(addr, "*:") {
+						lastReason = fmt.Sprintf("got listen address %q, expected wildcard address", addr)
+						return false, nil
+					}
 				}
 			}
-			framework.ExpectConsistOf(listenAddresses, expected)
+			return true, nil
+		})
+		framework.ExpectNoError(err, "failed to validate %s listen addresses in pod %s/%s on node %s: %s", process, pod.Namespace, pod.Name, pod.Spec.NodeName, lastReason)
+	}
+}
+
+func expectedListenAddresses(pod corev1.Pod, listenPodIP bool, ports ...string) []string {
+	expected := make([]string, 0, len(pod.Status.PodIPs)*len(ports))
+	for _, port := range ports {
+		if listenPodIP {
+			for _, ip := range pod.Status.PodIPs {
+				expected = append(expected, net.JoinHostPort(ip.IP, port))
+			}
 		} else {
-			podIPPrefix := strings.TrimSuffix(net.JoinHostPort(pod.Status.PodIP, "999"), "999")
-			for _, addr := range listenAddresses {
-				if listenPodIP {
-					framework.ExpectTrue(strings.HasPrefix(addr, podIPPrefix))
-				} else {
-					framework.ExpectTrue(strings.HasPrefix(addr, "*:"))
-				}
-			}
+			expected = append(expected, net.JoinHostPort("*", port))
 		}
 	}
+	return expected
+}
+
+func sameStringElements(actual, expected []string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+
+	counts := make(map[string]int, len(expected))
+	for _, value := range expected {
+		counts[value]++
+	}
+	for _, value := range actual {
+		if counts[value] == 0 {
+			return false
+		}
+		counts[value]--
+	}
+	return true
 }
 
 var _ = framework.Describe("[group:security]", func() {

--- a/test/e2e/security/kube_ovn_tls_rotation_test.go
+++ b/test/e2e/security/kube_ovn_tls_rotation_test.go
@@ -1,0 +1,611 @@
+package security
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+const (
+	kubeOVNTLSSecretName        = "kube-ovn-tls"
+	kubeOVNSSLEnabled           = "ENABLE_SSL"
+	kubeOVNControllerDeployment = "kube-ovn-controller"
+	kubeOVNControllerContainer  = "kube-ovn-controller"
+	kubeOVNMonitorDeployment    = "kube-ovn-monitor"
+	kubeOVNMonitorContainer     = "kube-ovn-monitor"
+	kubeOVNPingerDaemonSet      = "kube-ovn-pinger"
+	kubeOVNPingerContainer      = "pinger"
+	ovnCentralDeployment        = "ovn-central"
+	ovnCentralContainer         = "ovn-central"
+	ovsOVNDaemonSet             = "ovs-ovn"
+	ovnCentralTLSHashFile       = "/tmp/kube-ovn-central-tls.hash"
+	ovsOVNTLSHashFile           = "/tmp/kube-ovn-tls.hash"
+
+	kubeOVNTLSCertHashAnnotation = "kube-ovn.io/kube-ovn-tls-cert-hash"
+)
+
+var kubeOVNTLSDataKeys = []string{"cacert", "cert", "key"}
+
+var _ = framework.Describe("[group:security] kube-ovn TLS rotation", func() {
+	f := framework.NewDefaultFramework("security-kube-ovn-tls-rotation")
+	f.SkipNamespaceCreation = true
+
+	framework.ConformanceIt("should reload components without restarting pods when kube-ovn-tls secret is updated", func() {
+		f.SkipVersionPriorTo(1, 17, "kube-ovn TLS rotation was introduced in v1.17")
+
+		cs := f.ClientSet
+		deployClient := f.DeploymentClientNS(framework.KubeOvnNamespace)
+		deploy := deployClient.Get(kubeOVNControllerDeployment)
+		if !deploymentEnvEnabled(deploy, kubeOVNSSLEnabled) {
+			ginkgo.Skip("kube-ovn TLS is disabled")
+		}
+
+		ginkgo.By("Saving current kube-ovn-tls secret")
+		originalSecret, err := cs.CoreV1().Secrets(framework.KubeOvnNamespace).Get(context.Background(), kubeOVNTLSSecretName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		originalData := copySecretData(originalSecret.Data)
+		originalHash := kubeOVNTLSDataHash(originalData)
+		originalSerial := kubeOVNTLSCertSerial(originalData)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Restoring kube-ovn-tls secret")
+			restoreSecretData(cs, originalData)
+		})
+
+		ginkgo.By("Recording kube-ovn-controller restart counts")
+		restartCounts := deploymentContainerRestartCounts(cs, deploy, kubeOVNControllerContainer)
+
+		ginkgo.By("Recording kube-ovn-monitor restart counts")
+		monitorDeploy := deployClient.Get(kubeOVNMonitorDeployment)
+		monitorRestartCounts := deploymentContainerRestartCounts(cs, monitorDeploy, kubeOVNMonitorContainer)
+
+		ginkgo.By("Recording kube-ovn-pinger restart counts")
+		daemonSetClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
+		pingerDS := daemonSetClient.Get(kubeOVNPingerDaemonSet)
+		pingerRestartCounts := daemonSetContainerRestartCounts(daemonSetClient, pingerDS, kubeOVNPingerContainer)
+
+		ginkgo.By("Recording ovn-central restart counts")
+		centralDeploy := deployClient.Get(ovnCentralDeployment)
+		centralRestartCounts := deploymentContainerRestartCounts(cs, centralDeploy, ovnCentralContainer)
+		seedOVNCentralTLSHash(cs, centralDeploy)
+		centralTLSHashes := deploymentTLSHashes(cs, centralDeploy)
+
+		ginkgo.By("Recording ovn-controller pid")
+		ovsPods := ovsOVNPods(f)
+		seedOVSTLSHashes(ovsPods)
+		initialOVNControllerPIDs := ovnControllerPIDs(ovsPods)
+
+		ginkgo.By("Installing updated kube-ovn-tls secret")
+		updatedData, err := generateUpdatedKubeOVNTLSSecretData()
+		framework.ExpectNoError(err)
+		updatedHash := kubeOVNTLSDataHash(updatedData)
+		framework.ExpectNotEqual(updatedHash, originalHash)
+		framework.ExpectNotEqual(kubeOVNTLSCertSerial(updatedData), originalSerial)
+		updateKubeOVNTLSSecretData(cs, updatedData)
+
+		ginkgo.By("Waiting for kube-ovn-tls files to be projected")
+		expectedFileHashes := kubeOVNTLSFileHashes(updatedData)
+		waitDeploymentTLSFilesProjected(cs, deploy, expectedFileHashes, "kube-ovn-controller")
+		waitDeploymentTLSFilesProjected(cs, monitorDeploy, expectedFileHashes, "kube-ovn-monitor")
+		waitDaemonSetTLSFilesProjected(daemonSetClient, pingerDS, expectedFileHashes, "kube-ovn-pinger")
+		waitDeploymentTLSFilesProjected(cs, centralDeploy, expectedFileHashes, "ovn-central")
+		waitPodListTLSFilesProjected(&corev1.PodList{Items: ovsPods}, expectedFileHashes, "ovs-ovn")
+
+		ginkgo.By("Waiting for ovn-central to reload TLS")
+		waitOVNCentralTLSReloaded(cs, centralDeploy, centralTLSHashes)
+		waitDeploymentTLSHashFiles(cs, centralDeploy, ovnCentralTLSHashFile, "ovn-central")
+
+		ginkgo.By("Waiting for ovn-controller to restart from TLS file change")
+		waitOVNControllersRestarted(ovsPods, initialOVNControllerPIDs)
+		waitPodListTLSHashFiles(&corev1.PodList{Items: ovsPods}, ovsOVNTLSHashFile, "ovs-ovn")
+
+		ginkgo.By("Ensuring new TLS files can connect to OVN databases")
+		assertDeploymentOVNDBSSLConnectivity(cs, deploy)
+		assertPodListOVNDBSSLConnectivity(&corev1.PodList{Items: ovsPods}, "ovs-ovn")
+
+		ginkgo.By("Ensuring Go components do not restart from TLS file change")
+		time.Sleep(35 * time.Second)
+		assertDeploymentContainerNotRestarted(cs, deploy, kubeOVNControllerContainer, restartCounts, "kube-ovn-controller")
+		assertDeploymentContainerNotRestarted(cs, monitorDeploy, kubeOVNMonitorContainer, monitorRestartCounts, "kube-ovn-monitor")
+		assertDaemonSetContainerNotRestarted(daemonSetClient, pingerDS, kubeOVNPingerContainer, pingerRestartCounts, "kube-ovn-pinger")
+		assertDeploymentContainerNotRestarted(cs, centralDeploy, ovnCentralContainer, centralRestartCounts, "ovn-central")
+	})
+})
+
+func deploymentEnvEnabled(deploy *appsv1.Deployment, name string) bool {
+	ginkgo.GinkgoHelper()
+
+	value, ok := deploymentEnvValue(deploy, name)
+	return ok && value == "true"
+}
+
+func deploymentEnvValue(deploy *appsv1.Deployment, name string) (string, bool) {
+	ginkgo.GinkgoHelper()
+
+	for _, container := range deploy.Spec.Template.Spec.Containers {
+		if container.Name != kubeOVNControllerContainer {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == name {
+				return env.Value, true
+			}
+		}
+	}
+	return "", false
+}
+
+func copySecretData(data map[string][]byte) map[string][]byte {
+	ginkgo.GinkgoHelper()
+
+	copied := make(map[string][]byte, len(data))
+	for key, value := range data {
+		copied[key] = bytes.Clone(value)
+	}
+	return copied
+}
+
+func restoreSecretData(cs kubernetes.Interface, data map[string][]byte) {
+	ginkgo.GinkgoHelper()
+
+	updateKubeOVNTLSSecretData(cs, data)
+}
+
+func updateKubeOVNTLSSecretData(cs kubernetes.Interface, data map[string][]byte) *corev1.Secret {
+	ginkgo.GinkgoHelper()
+
+	hash := kubeOVNTLSDataHash(data)
+	var updated *corev1.Secret
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := cs.CoreV1().Secrets(framework.KubeOvnNamespace).Get(context.Background(), kubeOVNTLSSecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		secret = secret.DeepCopy()
+		secret.Data = copySecretData(data)
+		if secret.Annotations == nil {
+			secret.Annotations = map[string]string{}
+		}
+		secret.Annotations[kubeOVNTLSCertHashAnnotation] = hash
+		updated, err = cs.CoreV1().Secrets(framework.KubeOvnNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+		return err
+	})
+	framework.ExpectNoError(err)
+	return updated
+}
+
+func kubeOVNTLSDataHash(data map[string][]byte) string {
+	ginkgo.GinkgoHelper()
+
+	h := sha256.New()
+	for _, key := range kubeOVNTLSDataKeys {
+		if len(data[key]) == 0 {
+			framework.Failf("kube-ovn-tls missing %s", key)
+		}
+		h.Write([]byte(key))
+		h.Write([]byte{0})
+		h.Write(data[key])
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func kubeOVNTLSFileHashes(data map[string][]byte) map[string]string {
+	ginkgo.GinkgoHelper()
+
+	hashes := make(map[string]string, len(kubeOVNTLSDataKeys))
+	for _, key := range kubeOVNTLSDataKeys {
+		if len(data[key]) == 0 {
+			framework.Failf("kube-ovn-tls missing %s", key)
+		}
+		sum := sha256.Sum256(data[key])
+		hashes[key] = hex.EncodeToString(sum[:])
+	}
+	return hashes
+}
+
+func kubeOVNTLSCertSerial(data map[string][]byte) string {
+	ginkgo.GinkgoHelper()
+
+	cert := parseKubeOVNTLSCert(data)
+	return cert.SerialNumber.String()
+}
+
+func parseKubeOVNTLSCert(data map[string][]byte) *x509.Certificate {
+	ginkgo.GinkgoHelper()
+
+	cert, err := parseKubeOVNTLSCertWithError(data)
+	framework.ExpectNoError(err)
+	return cert
+}
+
+func parseKubeOVNTLSCertWithError(data map[string][]byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(data["cert"])
+	if block == nil {
+		return nil, errors.New("failed to decode kube-ovn-tls cert")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
+}
+
+func generateUpdatedKubeOVNTLSSecretData() (map[string][]byte, error) {
+	return generateKubeOVNTLSSecretDataAt(time.Now(), 10*365*24*time.Hour, 10*365*24*time.Hour)
+}
+
+func generateKubeOVNTLSSecretDataAt(now time.Time, caDuration, certDuration time.Duration) (map[string][]byte, error) {
+	return util.GenerateKubeOVNTLSSecretData(now, caDuration, certDuration, "ovn")
+}
+
+func deploymentContainerRestartCounts(cs kubernetes.Interface, deploy *appsv1.Deployment, containerName string) map[string]int32 {
+	ginkgo.GinkgoHelper()
+
+	pods := deploymentPods(cs, deploy)
+	framework.ExpectNotEmpty(pods.Items, "no %s pod found", deploy.Name)
+
+	counts := make(map[string]int32, len(pods.Items))
+	for _, pod := range pods.Items {
+		counts[pod.Name] = containerRestartCount(pod, containerName)
+	}
+	return counts
+}
+
+func daemonSetContainerRestartCounts(client *framework.DaemonSetClient, ds *appsv1.DaemonSet, containerName string) map[string]int32 {
+	ginkgo.GinkgoHelper()
+
+	pods, err := client.GetPods(ds)
+	framework.ExpectNoError(err)
+	framework.ExpectNotEmpty(pods.Items, "no %s pod found", ds.Name)
+
+	counts := make(map[string]int32, len(pods.Items))
+	for _, pod := range pods.Items {
+		counts[pod.Name] = containerRestartCount(pod, containerName)
+	}
+	return counts
+}
+
+func assertDeploymentContainerNotRestarted(cs kubernetes.Interface, deploy *appsv1.Deployment, containerName string, previous map[string]int32, name string) {
+	ginkgo.GinkgoHelper()
+
+	assertPodsContainerNotRestarted(deploymentPods(cs, deploy), containerName, previous, name)
+}
+
+func assertDaemonSetContainerNotRestarted(client *framework.DaemonSetClient, ds *appsv1.DaemonSet, containerName string, previous map[string]int32, name string) {
+	ginkgo.GinkgoHelper()
+
+	pods, err := client.GetPods(ds)
+	framework.ExpectNoError(err)
+	assertPodsContainerNotRestarted(pods, containerName, previous, name)
+}
+
+func assertPodsContainerNotRestarted(pods *corev1.PodList, containerName string, previous map[string]int32, name string) {
+	ginkgo.GinkgoHelper()
+
+	framework.ExpectNotEmpty(pods.Items, "no %s pod found", name)
+	for _, pod := range pods.Items {
+		oldCount, ok := previous[pod.Name]
+		if !ok {
+			framework.Failf("%s pod %s/%s was replaced after TLS Secret update", name, pod.Namespace, pod.Name)
+		}
+		if got := containerRestartCount(pod, containerName); got != oldCount {
+			framework.Failf("%s container in pod %s/%s restarted after TLS Secret update: got %d, want %d", name, pod.Namespace, pod.Name, got, oldCount)
+		}
+	}
+}
+
+func deploymentPods(cs kubernetes.Interface, deploy *appsv1.Deployment) *corev1.PodList {
+	ginkgo.GinkgoHelper()
+
+	selector, err := metav1.LabelSelectorAsSelector(deploy.Spec.Selector)
+	framework.ExpectNoError(err)
+	pods, err := cs.CoreV1().Pods(deploy.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: selector.String()})
+	framework.ExpectNoError(err)
+	return pods
+}
+
+func containerRestartCount(pod corev1.Pod, containerName string) int32 {
+	ginkgo.GinkgoHelper()
+
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == containerName {
+			return status.RestartCount
+		}
+	}
+	framework.Failf("container %s not found in pod %s/%s", containerName, pod.Namespace, pod.Name)
+	return 0
+}
+
+func seedOVNCentralTLSHash(cs kubernetes.Interface, deploy *appsv1.Deployment) {
+	ginkgo.GinkgoHelper()
+
+	pods := deploymentPods(cs, deploy)
+	framework.ExpectNotEmpty(pods.Items, "no ovn-central pod found")
+	for _, pod := range pods.Items {
+		_, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "bash /kube-ovn/kube-ovn-tls-reload.sh ovn-central once")
+		framework.ExpectNoError(err)
+	}
+}
+
+func deploymentTLSHashes(cs kubernetes.Interface, deploy *appsv1.Deployment) map[string]string {
+	ginkgo.GinkgoHelper()
+
+	pods := deploymentPods(cs, deploy)
+	framework.ExpectNotEmpty(pods.Items, "no %s pod found", deploy.Name)
+	hashes := make(map[string]string, len(pods.Items))
+	for _, pod := range pods.Items {
+		hashes[pod.Name] = podTLSHash(pod)
+	}
+	return hashes
+}
+
+func waitDeploymentTLSFilesProjected(cs kubernetes.Interface, deploy *appsv1.Deployment, expectedHashes map[string]string, name string) {
+	ginkgo.GinkgoHelper()
+
+	waitPodListTLSFilesProjected(deploymentPods(cs, deploy), expectedHashes, name)
+}
+
+func waitDaemonSetTLSFilesProjected(client *framework.DaemonSetClient, ds *appsv1.DaemonSet, expectedHashes map[string]string, name string) {
+	ginkgo.GinkgoHelper()
+
+	pods, err := client.GetPods(ds)
+	framework.ExpectNoError(err)
+	waitPodListTLSFilesProjected(pods, expectedHashes, name)
+}
+
+func waitPodListTLSFilesProjected(pods *corev1.PodList, expectedHashes map[string]string, name string) {
+	ginkgo.GinkgoHelper()
+
+	framework.ExpectNotEmpty(pods.Items, "no %s pod found", name)
+	framework.WaitUntil(5*time.Second, 90*time.Second, func(_ context.Context) (bool, error) {
+		for _, pod := range pods.Items {
+			hashes, err := podTLSFileHashes(pod)
+			if err != nil {
+				return false, nil
+			}
+			if !stringMapEqual(hashes, expectedHashes) {
+				return false, nil
+			}
+		}
+		return true, nil
+	}, fmt.Sprintf("%s projected kube-ovn-tls files", name))
+}
+
+func podTLSFileHashes(pod corev1.Pod) (map[string]string, error) {
+	ginkgo.GinkgoHelper()
+
+	output, err := e2epodoutput.RunHostCmd(
+		pod.Namespace,
+		pod.Name,
+		`set -eu
+for file in cacert cert key; do
+  test -s "/var/run/tls/${file}"
+  printf "%s %s\n" "${file}" "$(sha256sum "/var/run/tls/${file}" | awk '{print $1}')"
+done`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	hashes := make(map[string]string, len(kubeOVNTLSDataKeys))
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("unexpected TLS file hash output from pod %s/%s: %q", pod.Namespace, pod.Name, output)
+		}
+		hashes[fields[0]] = fields[1]
+	}
+	return hashes, nil
+}
+
+func stringMapEqual(actual, expected map[string]string) bool {
+	for _, key := range kubeOVNTLSDataKeys {
+		if actual[key] != expected[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func waitOVNCentralTLSReloaded(cs kubernetes.Interface, deploy *appsv1.Deployment, previousHashes map[string]string) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(5*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+		pods := deploymentPods(cs, deploy)
+		if len(pods.Items) == 0 {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			oldHash, ok := previousHashes[pod.Name]
+			if !ok {
+				return false, nil
+			}
+			if podTLSHash(pod) == oldHash {
+				return false, nil
+			}
+			if _, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "/kube-ovn/ovn-healthcheck.sh"); err != nil {
+				return false, nil
+			}
+		}
+		return true, nil
+	}, "ovn-central reloaded TLS after TLS Secret update")
+}
+
+func waitDeploymentTLSHashFiles(cs kubernetes.Interface, deploy *appsv1.Deployment, hashFile, name string) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(5*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+		return podListTLSHashFilesMatch(deploymentPods(cs, deploy), hashFile, name)
+	}, fmt.Sprintf("%s TLS hash files match mounted TLS files", name))
+}
+
+func waitPodListTLSHashFiles(pods *corev1.PodList, hashFile, name string) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(5*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+		return podListTLSHashFilesMatch(pods, hashFile, name)
+	}, fmt.Sprintf("%s TLS hash files match mounted TLS files", name))
+}
+
+func podListTLSHashFilesMatch(pods *corev1.PodList, hashFile, name string) (bool, error) {
+	ginkgo.GinkgoHelper()
+
+	framework.ExpectNotEmpty(pods.Items, "no %s pod found", name)
+	for _, pod := range pods.Items {
+		expected := podTLSHash(pod)
+		actual, err := podFileContent(pod, hashFile)
+		if err != nil || actual != expected {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func podFileContent(pod corev1.Pod, path string) (string, error) {
+	ginkgo.GinkgoHelper()
+
+	output, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, fmt.Sprintf("cat %s", path))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+func ovsOVNPods(f *framework.Framework) []corev1.Pod {
+	ginkgo.GinkgoHelper()
+
+	daemonSetClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
+	ds := daemonSetClient.Get(ovsOVNDaemonSet)
+	pods, err := daemonSetClient.GetPods(ds)
+	framework.ExpectNoError(err)
+	framework.ExpectNotEmpty(pods.Items, "no ovs-ovn pod found")
+	return pods.Items
+}
+
+func seedOVSTLSHashes(pods []corev1.Pod) {
+	ginkgo.GinkgoHelper()
+
+	for _, pod := range pods {
+		_, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "bash /kube-ovn/kube-ovn-tls-reload.sh ovs once")
+		framework.ExpectNoError(err)
+	}
+}
+
+func podTLSHash(pod corev1.Pod) string {
+	ginkgo.GinkgoHelper()
+
+	output, err := e2epodoutput.RunHostCmd(
+		pod.Namespace,
+		pod.Name,
+		"sha256sum /var/run/tls/cacert /var/run/tls/cert /var/run/tls/key | sha256sum | awk '{print $1}'",
+	)
+	framework.ExpectNoError(err)
+	return strings.TrimSpace(output)
+}
+
+func ovnControllerPIDs(pods []corev1.Pod) map[string]string {
+	ginkgo.GinkgoHelper()
+
+	pids := make(map[string]string, len(pods))
+	for _, pod := range pods {
+		output, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, "cat /var/run/ovn/ovn-controller.pid")
+		framework.ExpectNoError(err)
+		pids[pod.Name] = strings.TrimSpace(output)
+	}
+	return pids
+}
+
+func waitOVNControllersRestarted(pods []corev1.Pod, initialPIDs map[string]string) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(5*time.Second, time.Minute, func(_ context.Context) (bool, error) {
+		for _, pod := range pods {
+			output, err := e2epodoutput.RunHostCmd(
+				pod.Namespace,
+				pod.Name,
+				"/kube-ovn/ovs-healthcheck.sh >/dev/null && cat /var/run/ovn/ovn-controller.pid",
+			)
+			if err != nil {
+				return false, nil
+			}
+			pid := strings.TrimSpace(output)
+			if pid == "" || pid == initialPIDs[pod.Name] {
+				return false, nil
+			}
+		}
+		return true, nil
+	}, "ovn-controller restarted on every ovs-ovn pod after TLS Secret update")
+}
+
+func assertDeploymentOVNDBSSLConnectivity(cs kubernetes.Interface, deploy *appsv1.Deployment) {
+	ginkgo.GinkgoHelper()
+
+	pods := deploymentPods(cs, deploy)
+	framework.ExpectNotEmpty(pods.Items, "no %s pod found", deploy.Name)
+	for _, pod := range pods.Items {
+		output, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, ovnDBSSLConnectivityCommand(true))
+		framework.ExpectNoError(err, "failed to connect to OVN DBs over SSL from pod %s/%s: %s", pod.Namespace, pod.Name, output)
+	}
+}
+
+func assertPodListOVNDBSSLConnectivity(pods *corev1.PodList, name string) {
+	ginkgo.GinkgoHelper()
+
+	framework.ExpectNotEmpty(pods.Items, "no %s pod found", name)
+	for _, pod := range pods.Items {
+		output, err := e2epodoutput.RunHostCmd(pod.Namespace, pod.Name, ovnDBSSLConnectivityCommand(false))
+		framework.ExpectNoError(err, "failed to connect to OVN SB DB over SSL from pod %s/%s: %s", pod.Namespace, pod.Name, output)
+	}
+}
+
+func ovnDBSSLConnectivityCommand(includeNB bool) string {
+	command := `set -eu
+gen_conn_str() {
+  db="$1"
+  if [ "${db}" = "nb" ]; then
+    port="${KUBE_OVN_NB_PORT:-6641}"
+  else
+    port="${KUBE_OVN_SB_PORT:-6642}"
+  fi
+  if [ -z "${OVN_DB_IPS:-}" ]; then
+    if [ "${db}" = "nb" ]; then
+      echo "ssl:[${OVN_NB_SERVICE_HOST}]:${OVN_NB_SERVICE_PORT}"
+    else
+      echo "ssl:[${OVN_SB_SERVICE_HOST}]:${OVN_SB_SERVICE_PORT}"
+    fi
+    return
+  fi
+  endpoints=""
+  for ip in $(printf "%s" "${OVN_DB_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g'); do
+    endpoints="${endpoints}ssl:[${ip}]:${port},"
+  done
+  echo "${endpoints%,}"
+}
+ssl_options="-p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert"
+`
+	if includeNB {
+		command += `ovn-nbctl ${ssl_options} --db="$(gen_conn_str nb)" --timeout=10 get NB_Global . _uuid >/dev/null
+`
+	}
+	command += `ovn-sbctl ${ssl_options} --db="$(gen_conn_str sb)" --timeout=10 get SB_Global . _uuid >/dev/null
+`
+	return command
+}


### PR DESCRIPTION
## 功能概述

本 PR 为现有 `kube-ovn-tls` Secret 增加自动轮转与无 Pod 重启的证书生效能力。

目标是解决当前 SSL 模式下 `kube-ovn-tls` 仅在安装时生成、后续缺少统一维护的问题，同时保持现有 Secret schema（`cacert` / `cert` / `key`）和现有部署模型不变，不引入新的 server/client Secret 拆分，也不依赖通过 patch workload 触发滚动重启来完成证书切换。

## 设计框架

整体设计拆成两层：

1. 控制面负责维护 `kube-ovn-tls` Secret 的生命周期。
2. 数据面和控制面组件在 Pod 内感知挂载文件变化，并各自完成 TLS reload。

对应关系如下：

```text
kube-ovn-controller
    |
    |-- 创建 / adoption / 轮转 kube-ovn-tls Secret
    |
    `-- Secret 数据更新
          |
          |-- ovn-central: 更新 ovsdb-server TLS 配置，并重启 northd
          |-- ovs-ovn: 重新拉起 ovn-controller 并带入新 TLS 参数
          `-- Go 组件: 新握手 / 重连时重新读取 client cert/key
```

这个框架的关键点是把“证书生成与更新”和“证书生效”分离：controller 只负责 Secret，组件只负责 reload，从而避免把 Secret 更新权限、workload 变更权限、运行时 reload 逻辑耦合在一起。

## 核心实现

### 1. `kube-ovn-controller` 接管 `kube-ovn-tls` 生命周期

新增 `kube-ovn-tls` manager，在 `ENABLE_SSL=true` 且 `KUBE_OVN_TLS_ROTATION_INTERVAL > 0` 时启用。

其职责包括：

- `kube-ovn-tls` 不存在时创建 Secret
- 已存在但缺少 hash 注解时执行 adoption，只补充 `kube-ovn.io/kube-ovn-tls-cert-hash`
- 已完成 adoption 且证书进入更新窗口后，重新生成 CA 和 leaf cert 并更新同一个 Secret

`KUBE_OVN_TLS_ROTATION_INTERVAL` 表示检查间隔，不是强制换证周期：

- 默认值为 `8760h`
- `0` 表示关闭自动轮转
- 实际是否轮转仍由证书有效期决定，目前在证书生命周期过半后才触发更新

这样可以避免升级后第一次看到老 Secret 就立即轮转，先把现有 Secret 纳入管理，再在后续检查周期中判断是否需要更新。

### 2. 引入独立 TLS reload loop，移除 probe 中的 reload 逻辑

新增 `dist/images/kube-ovn-tls-reload.sh`，由启动脚本后台拉起，持续检测 `/var/run/tls/cacert`、`/var/run/tls/cert`、`/var/run/tls/key` 的内容变化。

相较于把 reload 放在 liveness/readiness probe 中，这个方案把健康检查和 reload 解耦，避免 probe 并发、失败重试和 reload 行为互相放大。

脚本中补了几项关键保护：

- 使用 `flock` 避免并发 reload
- 仅在 reload 成功后推进 hash
- 通过原子写方式更新 hash 文件，避免读到中间态

### 3. `ovn-central` 走运行时 TLS 更新路径

`ovn-central` 侧不再通过重启 `ovsdb-server` 来切换证书，而是对 NB/SB `ovsdb-server` 执行：

- `ovsdb-server/set-ssl`
- `ovsdb-server/reconnect`

这样可以直接让 `ovsdb-server` 重新加载新的 key/cert/ca。由于 `ovn-northd` 也会使用挂载的 client cert 访问 NB/SB，因此在更新 DB 侧 TLS 配置后，仅重启 `ovn-northd`，使其重新读取证书。

### 4. `ovs-ovn` 通过重新拉起 `ovn-controller` 完成切换

`ovn-controller` 这边没有复用 `ovsdb-server/set-ssl` 这种运行时接口，而是通过：

- `ovn-ctl --ovn-controller-ssl-key=... --ovn-controller-ssl-cert=... --ovn-controller-ssl-ca-cert=... restart_controller`

重新拉起 `ovn-controller` 进程，使其带着新的 TLS 参数启动。

这里重启的是容器内的 `ovn-controller` 进程，不是 Pod，也不依赖 kubelet 的容器重建。

### 5. Go 组件改为在新握手时重读 client cert

libovsdb client 的 TLS 配置增加 `GetClientCertificate`，后续新握手或重连时会重新从 `/var/run/tls/cert` 和 `/var/run/tls/key` 读取证书，而不是只在进程启动时加载一次。

这样可以覆盖 kube-ovn controller、monitor、pinger 等 Go 组件在长生命周期运行中的证书切换场景。

### 6. RBAC 收敛到最小权限

本 PR 不通过 patch Deployment/DaemonSet 注解来触发重启，因此 controller 不需要额外的 workload update 权限。

对应地，Helm chart 和 `dist/images/install.sh` 中只增加了对 `kube-ovn-tls` 的定向 `update` 权限，并通过 `resourceNames: [kube-ovn-tls]` 收敛权限范围。

## 重点代码

本次改动虽然覆盖文件较多，但核心代码主要集中在以下几块：

- `pkg/controller/kube_ovn_tls.go`
  - 新增 `kube-ovn-tls` manager 与 reconcile 逻辑
  - 负责创建、adoption、轮转判断和 Secret 更新

- `pkg/util/kube_ovn_tls_cert.go`
  - 收敛 `kube-ovn-tls` 的证书生成与编码逻辑

- `dist/images/kube-ovn-tls-reload.sh`
  - 新增独立 TLS reload loop
  - 封装 `ovn-central` 与 `ovs-ovn` 两条 reload 路径

- `dist/images/start-db.sh`
  - 拉起 `ovn-central` 的 TLS reload loop

- `dist/images/start-ovs.sh`
  - 拉起 `ovs-ovn` 的 TLS reload loop

- `dist/images/start-ovs-dpdk-v2.sh`
  - 为 DPDK 场景接入相同的 reload 逻辑

- `pkg/ovsdb/client/client.go`
  - TLS client 改为在新握手时重新读取 client cert/key

- `charts/kube-ovn/*`、`charts/kube-ovn-v2/*`、`dist/images/install.sh`
  - 注入 `KUBE_OVN_TLS_ROTATION_INTERVAL`
  - 收敛 Secret update RBAC

- `test/e2e/security/kube_ovn_tls_rotation_test.go`
  - 新增 / 调整 e2e，验证 Secret 更新后各组件完成 reload，且容器不重启

## 测试与验证

本 PR 的验证分成两层：

1. 单元测试覆盖 controller 的创建、adoption、轮转判断与 Secret 更新逻辑。
2. e2e 验证在直接更新 `kube-ovn-tls` Secret 后，组件可以完成 reload，且不会触发容器重启。

已执行：

```bash
bash -n dist/images/kube-ovn-tls-reload.sh dist/images/ovn-healthcheck.sh dist/images/ovs-healthcheck.sh
go test ./pkg/controller -run 'Test(ReconcileKubeOVNTLS|GenerateKubeOVNTLS|StartKubeOVNTLS|KubeOVNTLS)'
go test ./test/e2e/security -run TestNonExistent
make lint
```
