### PR TITLE
fix(ci): correct cnp-domain e2e events artifact name

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -2523,8 +2523,8 @@ jobs:
       - name: Collect k8s events
         if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         run: |
-          kubectl get events -A -o yaml > kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
-          tar zcf kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz kube-ovn-anp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
+          kubectl get events -A -o yaml > kube-ovn-cnp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
+          tar zcf kube-ovn-cnp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.tar.gz kube-ovn-cnp-domain-e2e-${{ matrix.mode }}-${{ matrix.ip-family }}-events.yaml
 
       - name: Upload k8s events
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- The `Collect k8s events` step in the `kube-ovn-cnp-domain-e2e` job archived events as `kube-ovn-anp-domain-e2e-*-events.tar.gz` (copy-paste leftover from the ANP job), while the following `Upload k8s events` step references the `kube-ovn-cnp-domain-e2e-*-events.tar.gz` path.
- Because the archive name never matched the upload path, the k8s events artifact was silently skipped whenever a CNP domain e2e run failed — losing diagnostics exactly when they're needed.
- Aligned the archive name with the upload path (`anp` → `cnp`, 2 lines). The shared `make kind-install-anp-dns-resolver` target is intentionally left unchanged (CNP/ANP share it).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-x86-image.yaml'))"` passes
- [x] Verified the `kube-ovn-cnp-domain-e2e` job now uses `cnp-domain-e2e` consistently for both the archive and the upload path
- [x] Confirmed no other workflow contains a `cnp-domain` job with the same mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)