### PR TITLE
fix(controller): enable ARP learning on VPC routers that have peerings

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -289,7 +289,7 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 		return err
 	}
 
-	learnFromARPRequest := vpc.Spec.EnableExternal
+	learnFromARPRequest := vpc.Spec.EnableExternal || len(vpc.Spec.VpcPeerings) != 0
 	if !learnFromARPRequest {
 		for _, subnetName := range vpc.Status.Subnets {
 			subnet, err := c.subnetsLister.Get(subnetName)


### PR DESCRIPTION
## Description

VPC peering requires ARP learning on the logical router.

When traffic arrives from a peered VPC, it enters via the peer LRP. If `always_learn_from_arp_request=false`, the destination pod's MAC is never learned into `mac_binding`, so the router mis-forwards the packet (tunnels it instead of delivering locally).

Currently `learnFromARPRequest` is only set for `EnableExternal` and the U2O interconnection case. This change also enables it when the VPC has any `VpcPeerings`.


## Impact

- Fixes cross-VPC L2 delivery for peered VPCs.
- No behavior change for VPCs without peerings.
- Minimal and safe.