### PR TITLE
fix(subnet): allow all-ones host as gateway for IPv6 subnet

### DIFF
--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -401,7 +401,9 @@ func ValidateNetworkBroadcast(cidr, ip string) error {
 			}
 
 			ipStr := IPToString(ipAddr)
-			if SubnetBroadcast(cidrBlock) == ipStr {
+			// IPv6 has no broadcast address (RFC 4291), so the all-ones host
+			// address is a valid unicast IP and must not be rejected here.
+			if CheckProtocol(cidrBlock) == kubeovnv1.ProtocolIPv4 && SubnetBroadcast(cidrBlock) == ipStr {
 				return fmt.Errorf("%s is the broadcast ip in cidr %s", ipStr, cidrBlock)
 			}
 			if SubnetNumber(cidrBlock) == ipStr {

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -1111,6 +1111,26 @@ func TestValidateNetworkBroadcast(t *testing.T) {
 			ip:   "",
 			err:  "",
 		},
+		{
+			// IPv6 has no broadcast address, the all-ones host is a valid unicast IP
+			name: "allOnesHostV6",
+			cidr: "190:255::1:0/112",
+			ip:   "190:255::1:ffff",
+			err:  "",
+		},
+		{
+			name: "networkNumberV6",
+			cidr: "190:255::1:0/112",
+			ip:   "190:255::1:0",
+			err:  "190:255::1:0 is the network number ip in cidr 190:255::1:0/112",
+		},
+		{
+			// IPv6 all-ones host must be accepted even in a dual-stack subnet
+			name: "allOnesHostDual",
+			cidr: "10.16.0.0/16,190:255::1:0/112",
+			ip:   "10.16.0.1,190:255::1:ffff",
+			err:  "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- IPv6 has no broadcast address (RFC 4291), but `ValidateNetworkBroadcast` applied the broadcast check to both IPv4 and IPv6, rejecting the all-ones host address (e.g. `190:255::1:ffff` in `190:255::1:0/112`) as a broadcast IP.
- Skip the broadcast check for IPv6 so the all-ones host can be used as a subnet gateway or pod IP. The network-number check is kept (IPv6 all-zeros host is the subnet-router anycast per RFC 4291 §2.6.1).
- Fixes #6878.

## Test plan
- [x] `go test ./pkg/util/ -run TestValidateNetworkBroadcast` (added IPv6 all-ones / network-number / dual-stack cases; existing IPv4 cases unchanged)
- [x] `make lint` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)