### PR TITLE
fix: reconcile VPC BFD HA chassis on node changes

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -93,6 +93,7 @@ type Controller struct {
 
 	vpcsLister           kubeovnlister.VpcLister
 	vpcSynced            cache.InformerSynced
+	vpcIndexer           cache.Indexer
 	addOrUpdateVpcQueue  workqueue.TypedRateLimitingInterface[string]
 	vpcLastPoliciesMap   *xsync.Map[string, string]
 	delVpcQueue          workqueue.TypedRateLimitingInterface[*kubeovnv1.Vpc]
@@ -756,7 +757,7 @@ func Run(ctx context.Context, config *Configuration) {
 		controller.deleteDNSNameResolverQueue = newTypedRateLimitingQueue[*kubeovnv1.DNSNameResolver]("DeleteDNSNameResolver", nil)
 	}
 
-	if err := controller.setupIndexers(podInformer.Informer(), endpointSliceInformer.Informer(), ipInformer.Informer()); err != nil {
+	if err := controller.setupIndexers(vpcInformer.Informer(), podInformer.Informer(), endpointSliceInformer.Informer(), ipInformer.Informer()); err != nil {
 		util.LogFatalAndExit(err, "failed to set up informer indexers")
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -307,7 +307,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		AttachNetClient:      nadClient,
 	}
 
-	if err := ctrl.setupIndexers(podInformer.Informer(), endpointSliceInformer.Informer(), ipInformer.Informer()); err != nil {
+	if err := ctrl.setupIndexers(vpcInformer.Informer(), podInformer.Informer(), endpointSliceInformer.Informer(), ipInformer.Informer()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/indexers.go
+++ b/pkg/controller/indexers.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 const (
@@ -15,6 +16,8 @@ const (
 	IndexEPSByService          = "byServiceName"
 	IndexDNSNameResolverByName = "byDNSName"
 	IndexIPBySubnet            = "bySubnet"
+	IndexVpcByBFDPort          = "byBFDPort"
+	IndexVpcBFDPortEnabled     = "enabled"
 )
 
 func indexPodByNode(obj any) ([]string, error) {
@@ -45,6 +48,20 @@ func indexDNSNameResolverByName(obj any) ([]string, error) {
 	return []string{string(r.Spec.Name)}, nil
 }
 
+func indexVpcByBFDPort(obj any) ([]string, error) {
+	vpc, ok := obj.(*kubeovnv1.Vpc)
+	if !ok {
+		return nil, nil
+	}
+	if vpc.Labels != nil && vpc.Labels[util.VpcExternalLabel] == "true" {
+		return nil, nil
+	}
+	if !vpc.Spec.BFDPort.IsEnabled() {
+		return nil, nil
+	}
+	return []string{IndexVpcBFDPortEnabled}, nil
+}
+
 // indexIPBySubnet indexes an IP CR by its primary subnet plus any attach
 // subnets, mirroring the subnets enqueued to updateSubnetStatusQueue on IP
 // add/update/delete. This lets calcSubnetStatusIP look up the IPs of a single
@@ -69,7 +86,10 @@ func indexIPBySubnet(obj any) ([]string, error) {
 // setupIndexers registers custom informer indexers used by hot-path
 // reconciliation loops to avoid O(N) full-store scans. Must be called before
 // the informer factory is started.
-func (c *Controller) setupIndexers(podInformer, epsInformer, ipInformer cache.SharedIndexInformer) error {
+func (c *Controller) setupIndexers(vpcInformer, podInformer, epsInformer, ipInformer cache.SharedIndexInformer) error {
+	if err := vpcInformer.AddIndexers(cache.Indexers{IndexVpcByBFDPort: indexVpcByBFDPort}); err != nil {
+		return err
+	}
 	if err := podInformer.AddIndexers(cache.Indexers{IndexPodByNode: indexPodByNode}); err != nil {
 		return err
 	}
@@ -79,6 +99,7 @@ func (c *Controller) setupIndexers(podInformer, epsInformer, ipInformer cache.Sh
 	if err := ipInformer.AddIndexers(cache.Indexers{IndexIPBySubnet: indexIPBySubnet}); err != nil {
 		return err
 	}
+	c.vpcIndexer = vpcInformer.GetIndexer()
 	c.podIndexer = podInformer.GetIndexer()
 	c.epsIndexer = epsInformer.GetIndexer()
 	c.ipIndexer = ipInformer.GetIndexer()

--- a/pkg/controller/indexers_test.go
+++ b/pkg/controller/indexers_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func TestIndexPodByNode(t *testing.T) {
@@ -205,6 +206,50 @@ func TestIndexersLookup(t *testing.T) {
 	}
 	if len(got) != 3 {
 		t.Fatalf("expected 3 ips for subnet-a (incl. attach), got %d", len(got))
+	}
+}
+
+func TestIndexVpcByBFDPort(t *testing.T) {
+	idx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{IndexVpcByBFDPort: indexVpcByBFDPort})
+	vpcs := []*kubeovnv1.Vpc{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "bfd-enabled"},
+			Spec: kubeovnv1.VpcSpec{
+				BFDPort: &kubeovnv1.BFDPort{Enabled: true},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "bfd-disabled"},
+			Spec: kubeovnv1.VpcSpec{
+				BFDPort: &kubeovnv1.BFDPort{Enabled: false},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "external",
+				Labels: map[string]string{util.VpcExternalLabel: "true"},
+			},
+			Spec: kubeovnv1.VpcSpec{
+				BFDPort: &kubeovnv1.BFDPort{Enabled: true},
+			},
+		},
+	}
+	for _, vpc := range vpcs {
+		if err := idx.Add(vpc); err != nil {
+			t.Fatalf("add vpc: %v", err)
+		}
+	}
+
+	got, err := idx.ByIndex(IndexVpcByBFDPort, IndexVpcBFDPortEnabled)
+	if err != nil {
+		t.Fatalf("ByIndex: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 indexed VPC, got %d", len(got))
+	}
+	vpc, ok := got[0].(*kubeovnv1.Vpc)
+	if !ok || vpc.Name != "bfd-enabled" {
+		t.Fatalf("expected bfd-enabled VPC, got %#v", got[0])
 	}
 }
 

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -36,9 +35,11 @@ func (e *ErrChassisNotFound) Error() string {
 }
 
 func (c *Controller) enqueueAddNode(obj any) {
-	key := cache.MetaObjectToName(obj.(*v1.Node)).String()
+	node := obj.(*v1.Node)
+	key := cache.MetaObjectToName(node).String()
 	klog.V(3).Infof("enqueue add node %s", key)
 	c.addNodeQueue.Add(key)
+	c.enqueueVpcBFDPortByNodeChange(nil, node)
 }
 
 func nodeReady(node *v1.Node) bool {
@@ -68,14 +69,69 @@ func kubeOvnAnnotationsChanged(oldAnnotations, newAnnotations map[string]string)
 	return !maps.Equal(filterKubeOvnAnnotations(oldAnnotations), filterKubeOvnAnnotations(newAnnotations))
 }
 
+func (c *Controller) listVpcBFDPorts() ([]*kubeovnv1.Vpc, error) {
+	if c.vpcIndexer == nil {
+		return c.vpcsLister.List(labels.Everything())
+	}
+
+	objs, err := c.vpcIndexer.ByIndex(IndexVpcByBFDPort, IndexVpcBFDPortEnabled)
+	if err != nil {
+		return nil, err
+	}
+	vpcs := make([]*kubeovnv1.Vpc, 0, len(objs))
+	for _, obj := range objs {
+		vpc, ok := obj.(*kubeovnv1.Vpc)
+		if !ok {
+			klog.Warningf("unexpected object type in VPC BFDPort indexer: %T", obj)
+			continue
+		}
+		vpcs = append(vpcs, vpc)
+	}
+	return vpcs, nil
+}
+
+func (c *Controller) enqueueVpcBFDPortByNodeChange(oldNode, newNode *v1.Node) {
+	vpcs, err := c.listVpcBFDPorts()
+	if err != nil {
+		klog.Errorf("failed to list VPC BFD ports for node update: %v", err)
+		return
+	}
+
+	for _, vpc := range vpcs {
+		if vpc.Labels != nil && vpc.Labels[util.VpcExternalLabel] == "true" {
+			continue
+		}
+		if !vpc.Spec.BFDPort.IsEnabled() {
+			continue
+		}
+
+		selector := labels.Everything()
+		if vpc.Spec.BFDPort.NodeSelector != nil {
+			selector, err = metav1.LabelSelectorAsSelector(vpc.Spec.BFDPort.NodeSelector)
+			if err != nil {
+				klog.Errorf("failed to parse BFD port node selector of vpc %s: %v", vpc.Name, err)
+				c.addOrUpdateVpcQueue.Add(vpc.Name)
+				continue
+			}
+		}
+
+		oldMatched := oldNode != nil && selector.Matches(labels.Set(oldNode.Labels))
+		newMatched := newNode != nil && selector.Matches(labels.Set(newNode.Labels))
+		if oldMatched || newMatched {
+			klog.V(3).Infof("enqueue update vpc %s for BFD port triggered by node change", vpc.Name)
+			c.addOrUpdateVpcQueue.Add(vpc.Name)
+		}
+	}
+}
+
 func (c *Controller) enqueueUpdateNode(oldObj, newObj any) {
 	oldNode := oldObj.(*v1.Node)
 	newNode := newObj.(*v1.Node)
+	nodeReadyChanged := nodeReady(oldNode) != nodeReady(newNode)
+	nodeLabelsChanged := !maps.Equal(oldNode.Labels, newNode.Labels)
 
-	if nodeReady(oldNode) != nodeReady(newNode) ||
-		kubeOvnAnnotationsChanged(oldNode.Annotations, newNode.Annotations) ||
-		!reflect.DeepEqual(oldNode.Labels, newNode.Labels) {
-		key := cache.MetaObjectToName(newNode).String()
+	key := cache.MetaObjectToName(newNode).String()
+	if nodeReadyChanged || kubeOvnAnnotationsChanged(oldNode.Annotations, newNode.Annotations) {
 		if len(newNode.Annotations) == 0 || newNode.Annotations[util.AllocatedAnnotation] != "true" {
 			klog.V(3).Infof("enqueue add node %s", key)
 			c.addNodeQueue.Add(key)
@@ -83,6 +139,12 @@ func (c *Controller) enqueueUpdateNode(oldObj, newObj any) {
 			klog.V(3).Infof("enqueue update node %s", key)
 			c.updateNodeQueue.Add(key)
 		}
+	} else if nodeLabelsChanged && newNode.Annotations[util.AllocatedAnnotation] == "true" {
+		klog.V(3).Infof("enqueue update node %s for label change", key)
+		c.updateNodeQueue.Add(key)
+	}
+	if nodeReadyChanged || nodeLabelsChanged {
+		c.enqueueVpcBFDPortByNodeChange(oldNode, newNode)
 	}
 }
 
@@ -107,6 +169,7 @@ func (c *Controller) enqueueDeleteNode(obj any) {
 	klog.V(3).Infof("enqueue delete node %s", key)
 	c.deletingNodeObjMap.Store(key, node)
 	c.deleteNodeQueue.Add(key)
+	c.enqueueVpcBFDPortByNodeChange(node, nil)
 }
 
 func nodeUnderlayAddressSetName(node string, af int) string {

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -3,13 +3,17 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	ovs "github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnsb"
@@ -186,6 +190,173 @@ func TestKubeOvnAnnotationsChanged(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newBFDPortVpc(name string, selector map[string]string) *kubeovnv1.Vpc {
+	return &kubeovnv1.Vpc{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kubeovnv1.VpcSpec{
+			BFDPort: &kubeovnv1.BFDPort{
+				Enabled: true,
+				IP:      "169.254.0.1/32",
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: selector,
+				},
+			},
+		},
+	}
+}
+
+func prepareNodeQueueTestController(t *testing.T, vpcs ...*kubeovnv1.Vpc) *Controller {
+	t.Helper()
+
+	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Vpcs: vpcs})
+	require.NoError(t, err)
+
+	ctrl := fakeCtrl.fakeController
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+	ctrl.updateNodeQueue = newTypedRateLimitingQueue[string]("UpdateNode", nil)
+	ctrl.deleteNodeQueue = newTypedRateLimitingQueue[string]("DeleteNode", nil)
+	ctrl.deletingNodeObjMap = xsync.NewMap[string, *corev1.Node]()
+	ctrl.addOrUpdateVpcQueue = newTypedRateLimitingQueue[string]("AddOrUpdateVpc", nil)
+	return ctrl
+}
+
+func drainVpcQueue(t *testing.T, ctrl *Controller) []string {
+	t.Helper()
+
+	keys := make([]string, 0, ctrl.addOrUpdateVpcQueue.Len())
+	for ctrl.addOrUpdateVpcQueue.Len() > 0 {
+		key, shutdown := ctrl.addOrUpdateVpcQueue.Get()
+		require.False(t, shutdown)
+		keys = append(keys, key)
+		ctrl.addOrUpdateVpcQueue.Done(key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func TestEnqueueAddNodeEnqueuesMatchingVpcBFDPort(t *testing.T) {
+	ctrl := prepareNodeQueueTestController(t,
+		newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}),
+		newBFDPortVpc("unselected-vpc", map[string]string{"egress": "false"}),
+	)
+
+	ctrl.enqueueAddNode(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{"egress": "true"},
+		},
+	})
+
+	require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
+}
+
+func TestEnqueueUpdateNodeEnqueuesVpcBFDPortOnSelectorMembershipChange(t *testing.T) {
+	t.Run("node starts matching selector", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"egress": "true"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Zero(t, ctrl.addNodeQueue.Len())
+		require.Zero(t, ctrl.updateNodeQueue.Len())
+		require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("node stops matching selector", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-a",
+				Labels: map[string]string{"egress": "true"},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"egress": "false"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Zero(t, ctrl.addNodeQueue.Len())
+		require.Zero(t, ctrl.updateNodeQueue.Len())
+		require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("unallocated node unrelated label change does not enqueue node or vpc", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-a",
+				Labels: map[string]string{"role": "worker"},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"role": "gateway"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Zero(t, ctrl.addNodeQueue.Len())
+		require.Zero(t, ctrl.updateNodeQueue.Len())
+		require.Empty(t, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("allocated node unrelated label change enqueues update node only", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "node-a",
+				Labels:      map[string]string{"role": "worker"},
+				Annotations: map[string]string{util.AllocatedAnnotation: "true"},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"role": "gateway"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Zero(t, ctrl.addNodeQueue.Len())
+		require.Equal(t, 1, ctrl.updateNodeQueue.Len())
+		require.Empty(t, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("matching node readiness change enqueues", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-a",
+				Labels: map[string]string{"egress": "true"},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+				},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Status.Conditions = []corev1.NodeCondition{
+			{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+		}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
+	})
+}
+
+func TestEnqueueDeleteNodeEnqueuesMatchingVpcBFDPort(t *testing.T) {
+	ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{"egress": "true"},
+		},
+	}
+
+	ctrl.enqueueDeleteNode(cache.DeletedFinalStateUnknown{Obj: node})
+
+	require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
 }
 
 func TestCleanDuplicatedChassis(t *testing.T) {

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -819,9 +819,7 @@ func (c *Controller) reconcileVpcBfdLRP(vpc *kubeovnv1.Vpc) (string, []string, e
 		return portName, nil, err
 	}
 	if len(nodes) == 0 {
-		err = fmt.Errorf("no nodes found by selector %q", selector.String())
-		klog.Error(err)
-		return portName, nil, err
+		klog.Warningf("no nodes found by selector %q for BFD LRP %s, clearing HA chassis group", selector.String(), portName)
 	}
 
 	nodeNames := make([]string, 0, len(nodes))

--- a/pkg/controller/vpc_test.go
+++ b/pkg/controller/vpc_test.go
@@ -474,3 +474,35 @@ func TestDiffPolicyRouteWithLogical_HandlesLegacyNextHopField(t *testing.T) {
 	require.Empty(t, dels)
 	require.Empty(t, adds)
 }
+
+func TestReconcileVpcBfdLRPClearsHAChassisGroupWhenSelectorMatchesNoNodes(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+
+	vpc := &kubeovnv1.Vpc{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vpc-bfd"},
+		Spec: kubeovnv1.VpcSpec{
+			BFDPort: &kubeovnv1.BFDPort{
+				Enabled: true,
+				IP:      "169.254.0.1/32",
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"egress": "true"},
+				},
+			},
+		},
+	}
+
+	portName := "bfd@test-vpc-bfd"
+	networks := []string{"169.254.0.1/32"}
+	mockOvnClient.EXPECT().CreateLogicalRouterPort(vpc.Name, portName, "", networks).Return(nil)
+	mockOvnClient.EXPECT().UpdateLogicalRouterPortNetworks(portName, networks).Return(nil)
+	mockOvnClient.EXPECT().UpdateLogicalRouterPortOptions(portName, map[string]string{"bfd-only": "true"}).Return(nil)
+	mockOvnClient.EXPECT().CreateHAChassisGroup(portName, []string{}, map[string]string{"lrp": portName}).Return(nil)
+	mockOvnClient.EXPECT().SetLogicalRouterPortHAChassisGroup(portName, portName).Return(nil)
+
+	name, nodes, err := ctrl.reconcileVpcBfdLRP(vpc)
+	require.NoError(t, err)
+	require.Equal(t, portName, name)
+	require.Empty(t, nodes)
+}

--- a/pkg/ovs/ovn-nb-ha_chassis_group_test.go
+++ b/pkg/ovs/ovn-nb-ha_chassis_group_test.go
@@ -46,6 +46,7 @@ func (suite *OvnClientTestSuite) testCreateHAChassisGroup() {
 	require.NotNil(t, group)
 	require.Equal(t, group.ExternalIDs, map[string]string{"vendor": util.CniTypeName, "k2": "v2"})
 	require.Len(t, group.HaChassis, len(chassises))
+	staleHAChassisUUIDs := slices.Clone(group.HaChassis)
 	for _, uuid := range group.HaChassis {
 		chassis := &ovnnb.HAChassis{UUID: uuid}
 		err = nbClient.Get(context.Background(), chassis)
@@ -53,6 +54,20 @@ func (suite *OvnClientTestSuite) testCreateHAChassisGroup() {
 		require.Contains(t, chassises, chassis.ChassisName)
 		require.Equal(t, chassis.Priority, 100-slices.Index(chassises, chassis.ChassisName))
 		require.Equal(t, chassis.ExternalIDs, map[string]string{"group": name, "vendor": util.CniTypeName})
+	}
+
+	err = nbClient.CreateHAChassisGroup(name, nil, map[string]string{"k3": "v3"})
+	require.NoError(t, err)
+
+	group, err = nbClient.GetHAChassisGroup(name, false)
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	require.Equal(t, group.ExternalIDs, map[string]string{"vendor": util.CniTypeName, "k3": "v3"})
+	require.Empty(t, group.HaChassis)
+	for _, uuid := range staleHAChassisUUIDs {
+		chassis := &ovnnb.HAChassis{UUID: uuid}
+		err = nbClient.Get(context.Background(), chassis)
+		require.Error(t, err)
 	}
 }
 

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2"
 	"net"
 	"reflect"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -19,6 +20,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -39,6 +42,8 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/iproute"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/kind"
 )
+
+var uuidRegexp = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
 
 func init() {
 	klog.SetOutput(ginkgo.GinkgoWriter)
@@ -361,6 +366,124 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		vegTest(f, false, provider, nadName, vpcName, internalSubnetName, externalSubnetName, replicas, nil)
 	})
 
+	framework.ConformanceIt("should update BFD HA chassis group when selected nodes change", func() {
+		f.SkipVersionPriorTo(1, 14, "VPC BFDPort for VpcEgressGateway BFD requires v1.14+")
+		if len(schedulableNodes) < 2 {
+			ginkgo.Skip("at least two schedulable nodes are required")
+		}
+
+		provider := fmt.Sprintf("%s.%s", nadName, namespaceName)
+		selectedNode1 := schedulableNodes[0].Name
+		selectedNode2 := schedulableNodes[1].Name
+		labelKey := "veg-bfd-e2e-" + framework.RandomSuffix()
+		labelValue := "selected"
+
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Cleaning up BFD selector labels")
+			setNodeLabel(f.ClientSet, selectedNode1, labelKey, "")
+			setNodeLabel(f.ClientSet, selectedNode2, labelKey, "")
+		})
+
+		ginkgo.By("Selecting the initial BFD node " + selectedNode1)
+		setNodeLabel(f.ClientSet, selectedNode1, labelKey, labelValue)
+
+		ginkgo.By("Creating network attachment definition " + nadName)
+		nad := framework.MakeMacvlanNetworkAttachmentDefinition(nadName, namespaceName, "eth0", "bridge", provider, nil)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting network attachment definition " + nadName)
+			nadClient.Delete(nadName)
+		})
+		nad = nadClient.Create(nad)
+		framework.Logf("created network attachment definition config:\n%s", nad.Spec.Config)
+
+		vpcName := "vpc-" + framework.RandomSuffix()
+		internalSubnetName := "int-" + framework.RandomSuffix()
+		internalCIDR := framework.RandomCIDR(f.ClusterIPFamily)
+		bfdIP := framework.RandomIPs(internalCIDR, ";", 1)
+
+		ginkgo.By("Creating VPC " + vpcName + " with BFDPort nodeSelector")
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting vpc " + vpcName)
+			vpcClient.DeleteSync(vpcName)
+		})
+		vpc := framework.MakeVpc(vpcName, "", false, false, nil)
+		vpc.Spec.BFDPort = &apiv1.BFDPort{
+			Enabled: true,
+			IP:      bfdIP,
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					labelKey: labelValue,
+				},
+			},
+		}
+		_ = vpcClient.CreateSync(vpc)
+
+		ginkgo.By("Creating internal subnet " + internalSubnetName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting internal subnet " + internalSubnetName)
+			subnetClient.DeleteSync(internalSubnetName)
+		})
+		internalSubnet := framework.MakeSubnet(internalSubnetName, "", internalCIDR, "", vpcName, "", nil, nil, nil)
+		_ = subnetClient.CreateSync(internalSubnet)
+
+		ginkgo.By("Getting docker network " + kindNetwork)
+		network, err := docker.NetworkInspect(kindNetwork)
+		framework.ExpectNoError(err, "getting docker network "+kindNetwork)
+
+		externalSubnet := generateSubnetFromDockerNetwork(externalSubnetName, network, f.HasIPv4(), f.HasIPv6())
+		externalSubnet.Spec.Provider = provider
+
+		ginkgo.By("Creating macvlan subnet " + externalSubnetName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting external subnet " + externalSubnetName)
+			subnetClient.DeleteSync(externalSubnetName)
+		})
+		_ = subnetClient.CreateSync(externalSubnet)
+
+		vegClient := f.VpcEgressGatewayClient()
+		vegName := "veg-" + framework.RandomSuffix()
+		veg := framework.MakeVpcEgressGateway(namespaceName, vegName, vpcName, 2, internalSubnetName, externalSubnetName)
+		veg.Spec.BFD.Enabled = true
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting vpc egress gateway " + vegName)
+			vegClient.DeleteSync(vegName)
+		})
+
+		ginkgo.By(fmt.Sprintf("Creating BFD vpc egress gateway %s:\n%s", vegName, format.Object(veg, 2)))
+		veg = vegClient.CreateSync(veg)
+		framework.ExpectTrue(veg.Status.Ready)
+		framework.ExpectHaveLen(veg.Status.Workload.Nodes, 2)
+		framework.ExpectHaveLen(veg.Status.InternalIPs, 2)
+		framework.ExpectHaveLen(veg.Status.ExternalIPs, 2)
+
+		groupName := "bfd@" + vpcName
+		waitVpcBFDNodes(vpcClient, vpcName, []string{selectedNode1})
+		waitHAChassisCount(groupName, 1)
+		waitHAChassisGroupCount(groupName, 1)
+		waitLRPHAChassisGroup(groupName, groupName)
+
+		ginkgo.By("Adding BFD selector label to " + selectedNode2)
+		setNodeLabel(f.ClientSet, selectedNode2, labelKey, labelValue)
+		waitVpcBFDNodes(vpcClient, vpcName, []string{selectedNode1, selectedNode2})
+		waitHAChassisCount(groupName, 2)
+		waitHAChassisGroupCount(groupName, 2)
+		waitLRPHAChassisGroup(groupName, groupName)
+
+		ginkgo.By("Removing BFD selector label from " + selectedNode1)
+		setNodeLabel(f.ClientSet, selectedNode1, labelKey, "")
+		waitVpcBFDNodes(vpcClient, vpcName, []string{selectedNode2})
+		waitHAChassisCount(groupName, 1)
+		waitHAChassisGroupCount(groupName, 1)
+		waitLRPHAChassisGroup(groupName, groupName)
+
+		ginkgo.By("Removing all BFD selector labels")
+		setNodeLabel(f.ClientSet, selectedNode2, labelKey, "")
+		waitVpcBFDNodes(vpcClient, vpcName, nil)
+		waitHAChassisCount(groupName, 0)
+		waitHAChassisGroupCount(groupName, 0)
+		waitLRPHAChassisGroup(groupName, groupName)
+	})
+
 	framework.ConformanceIt("should report not ready when workload pod attachment network status is missing", func() {
 		f.SkipVersionPriorTo(1, 17, "VpcEgressGateway workload network status validation was introduced in v1.17")
 
@@ -491,6 +614,128 @@ func generateSubnetFromDockerNetwork(subnetName string, network *dockernetwork.I
 	}
 
 	return framework.MakeSubnet(subnetName, "", strings.Join(cidr, ","), strings.Join(gateway, ","), "", "", excludeIPs, nil, nil)
+}
+
+func setNodeLabel(cs clientset.Interface, nodeName, key, value string) {
+	ginkgo.GinkgoHelper()
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		node, err := cs.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if node.Labels == nil {
+			node.Labels = map[string]string{}
+		}
+		if value == "" {
+			delete(node.Labels, key)
+		} else {
+			node.Labels[key] = value
+		}
+		_, err = cs.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+		return err
+	})
+	framework.ExpectNoError(err, "updating label %s on node %s", key, nodeName)
+}
+
+func waitVpcBFDNodes(vpcClient *framework.VpcClient, vpcName string, expected []string) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		vpc := vpcClient.Get(vpcName)
+		nodes := slices.Clone(vpc.Status.BFDPort.Nodes)
+		expectedNodes := slices.Clone(expected)
+		slices.Sort(nodes)
+		slices.Sort(expectedNodes)
+		if slices.Equal(nodes, expectedNodes) {
+			return true, nil
+		}
+		framework.Logf("VPC %s BFDPort nodes are %v, expected %v", vpcName, vpc.Status.BFDPort.Nodes, expected)
+		return false, nil
+	}, "VPC "+vpcName+" BFDPort nodes to match")
+}
+
+func waitHAChassisCount(groupName string, expected int) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		cmd := fmt.Sprintf("ovn-nbctl --format=csv --data=bare --no-heading --columns=_uuid find HA_Chassis external_ids:group=%s", groupName)
+		stdout, _, err := framework.NBExec(cmd)
+		if err != nil {
+			framework.Logf("failed to query HA_Chassis for group %s: %v", groupName, err)
+			return false, nil
+		}
+		count := countNonEmptyLines(string(stdout))
+		if count == expected {
+			return true, nil
+		}
+		framework.Logf("HA_Chassis count for group %s is %d, expected %d: %s", groupName, count, expected, strings.TrimSpace(string(stdout)))
+		return false, nil
+	}, fmt.Sprintf("HA_Chassis count for group %s to be %d", groupName, expected))
+}
+
+func waitHAChassisGroupCount(groupName string, expected int) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		cmd := fmt.Sprintf("ovn-nbctl --format=csv --data=bare --no-heading --columns=ha_chassis find HA_Chassis_Group name=%s", groupName)
+		stdout, _, err := framework.NBExec(cmd)
+		if err != nil {
+			framework.Logf("failed to query HA_Chassis_Group %s: %v", groupName, err)
+			return false, nil
+		}
+		count := countUUIDs(string(stdout))
+		if count == expected {
+			return true, nil
+		}
+		framework.Logf("HA_Chassis_Group %s has %d HA chassis refs, expected %d: %s", groupName, count, expected, strings.TrimSpace(string(stdout)))
+		return false, nil
+	}, fmt.Sprintf("HA_Chassis_Group %s HA chassis refs to be %d", groupName, expected))
+}
+
+func waitLRPHAChassisGroup(lrpName, groupName string) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		groupCmd := fmt.Sprintf("ovn-nbctl --format=csv --data=bare --no-heading --columns=_uuid find HA_Chassis_Group name=%s", groupName)
+		groupStdout, _, err := framework.NBExec(groupCmd)
+		if err != nil {
+			framework.Logf("failed to query HA_Chassis_Group %s uuid: %v", groupName, err)
+			return false, nil
+		}
+		groupUUID := strings.TrimSpace(string(groupStdout))
+		if groupUUID == "" {
+			framework.Logf("HA_Chassis_Group %s does not exist yet", groupName)
+			return false, nil
+		}
+
+		lrpCmd := fmt.Sprintf("ovn-nbctl --format=csv --data=bare --no-heading --columns=ha_chassis_group find Logical_Router_Port name=%s", lrpName)
+		lrpStdout, _, err := framework.NBExec(lrpCmd)
+		if err != nil {
+			framework.Logf("failed to query Logical_Router_Port %s HA chassis group: %v", lrpName, err)
+			return false, nil
+		}
+		lrpGroupUUID := strings.TrimSpace(string(lrpStdout))
+		if lrpGroupUUID == groupUUID {
+			return true, nil
+		}
+		framework.Logf("Logical_Router_Port %s is bound to HA chassis group %q, expected %q", lrpName, lrpGroupUUID, groupUUID)
+		return false, nil
+	}, fmt.Sprintf("Logical_Router_Port %s to bind HA_Chassis_Group %s", lrpName, groupName))
+}
+
+func countNonEmptyLines(output string) int {
+	count := 0
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func countUUIDs(output string) int {
+	return len(uuidRegexp.FindAllString(output, -1))
 }
 
 func checkEgressAccess(f *framework.Framework, namespaceName, svrPodName, image, svrPort string, svrIPs, extIPs []string, intIPs map[string][]string, subnetName, nodeName string, snat bool) {


### PR DESCRIPTION
## Summary
- Enqueue VPC BFDPort reconciliation when selected nodes are added, deleted, relabeled, or change readiness.
- Allow empty BFD node selector results to clear the HA chassis group instead of leaving stale chassis refs.
- Add focused unit coverage and a VEG e2e case for BFD HA chassis group updates on node label changes.

## Test Plan
- `go test ./test/e2e/vpc-egress-gateway -run TestE2E -count=0`
- `go test ./pkg/controller ./pkg/ovs -count=1`
- `make lint`
