### PR TITLE
fix(ci): fetch pinned OVN commit directly for release-1.13

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -62,9 +62,12 @@ RUN cd /usr/src/ && \
     # update ovs-sandbox for docker run
     git apply $SRC_DIR/54b767822916606dbb78335a3197983f435b5b8a.patch
 
-RUN cd /usr/src/ && git clone -b branch-24.03 --depth=50 https://github.com/ovn-org/ovn.git && \
+RUN cd /usr/src/ && \
+    git init ovn && \
     cd ovn && \
-    git checkout ef8f5c1ac63e8094eaf13507013e310991db45a2 && \
+    git remote add origin https://github.com/ovn-org/ovn.git && \
+    git fetch --depth=1 origin ef8f5c1ac63e8094eaf13507013e310991db45a2 && \
+    git checkout FETCH_HEAD && \
     # change hash type from dp_hash to hash with field src_ip
     git apply $SRC_DIR/e490f5ac0b644101913c2a3db8e03d85e859deff.patch && \
     # modify src route priority


### PR DESCRIPTION
## Summary
- Fix the base image build on `release-1.13` by fetching the pinned OVN commit directly.
- Replace `git clone --depth=50 branch-24.03 && git checkout <sha>` with a depth-1 fetch of the exact commit used by the Dockerfile.
- Avoid depending on the pinned commit remaining within the latest 50 commits of `branch-24.03`.

## Root cause
The scheduled Build Base workflow failed because the Dockerfile cloned `branch-24.03` with `--depth=50`, then checked out `ef8f5c1ac63e8094eaf13507013e310991db45a2`. That commit is no longer included in the shallow clone window, so checkout failed with:

```text
fatal: reference is not a tree: ef8f5c1ac63e8094eaf13507013e310991db45a2
```

## Verification
- Reproduced the failing shallow clone/checkout locally.
- Verified `git fetch --depth=1 origin ef8f5c1ac63e8094eaf13507013e310991db45a2` can fetch and check out the pinned commit.
- Verified all `release-1.13` OVN patches apply cleanly on the fetched commit.
- Ran `make lint`; it failed on existing gosec taint findings unrelated to this Dockerfile change. Per request, no lint issues were fixed.
