### PR TITLE
fix(ci): repair DPDK base image build

### DIFF
--- a/.github/workflows/build-kube-ovn-base-dpdk.yaml
+++ b/.github/workflows/build-kube-ovn-base-dpdk.yaml
@@ -16,8 +16,6 @@ on:
           - release-1.15
           - release-1.14
           - release-1.13
-          - release-1.12
-          - release-1.12-mc
   schedule:
     - cron: "20 19 * * *"
 
@@ -32,8 +30,6 @@ jobs:
           - release-1.15
           - release-1.14
           - release-1.13
-          - release-1.12
-          - release-1.12-mc
     name: Build AMD64
     runs-on: ubuntu-24.04
     steps:
@@ -69,8 +65,6 @@ jobs:
           - release-1.15
           - release-1.14
           - release-1.13
-          - release-1.12
-          - release-1.12-mc
     needs:
       - build-amd64
     name: push

--- a/dist/images/Dockerfile.base-dpdk
+++ b/dist/images/Dockerfile.base-dpdk
@@ -21,6 +21,7 @@ ADD patches/1b31f07dc60c016153fa35d936cdda0e02e58492.patch $SRC_DIR
 ADD patches/9ee66bd91be65605cffb9a490b4dba3bc13358e9.patch $SRC_DIR
 ADD patches/e889d46924085ca0fe38a2847da973dfe6ea100e.patch $SRC_DIR
 ADD patches/f9e97031b56ab5747b5d73629198331a6daacdfd.patch $SRC_DIR
+ADD patches/pinctrl-adapt-ovs-compose-nd-ns.patch $SRC_DIR
 
 RUN apt update && apt install -y git curl
 
@@ -56,7 +57,9 @@ RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-o
     # fix reaching resubmit limit in underlay
     git apply $SRC_DIR/e889d46924085ca0fe38a2847da973dfe6ea100e.patch && \
     # ovn-controller: do not send GARP on localnet for Kube-OVN ports
-    git apply $SRC_DIR/f9e97031b56ab5747b5d73629198331a6daacdfd.patch
+    git apply $SRC_DIR/f9e97031b56ab5747b5d73629198331a6daacdfd.patch && \
+    # adapt to the compose_nd_ns() signature change in ovs branch-3.5 commit 33825c273
+    git apply $SRC_DIR/pinctrl-adapt-ovs-compose-nd-ns.patch
 
 RUN apt install -y build-essential fakeroot \
     autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \


### PR DESCRIPTION
## Summary
- Align the Build Base DPDK workflow branch matrix with Build Base by removing `release-1.12` and `release-1.12-mc`.
- Apply the existing `pinctrl-adapt-ovs-compose-nd-ns.patch` in the DPDK base image build.
- Fix OVN DPDK builds against the updated OVS `compose_nd_ns()` signature.

## Root cause
The scheduled Build Base DPDK run still targeted old `release-1.12` branches while Build Base no longer does. The remaining master DPDK build failed because OVN `pinctrl.c` still used the old `compose_nd_ns()` call signature after OVS branch-3.5 changed it.

## Verification
- Verified the updated `branch-25.03` OVN patch sequence applies cleanly, including `pinctrl-adapt-ovs-compose-nd-ns.patch`.
- Ran `CI=true make lint` successfully on `master`.
