### PR TITLE
fix: reconcile VPC BFD HA chassis on node changes

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -36,9 +35,11 @@ func (e *ErrChassisNotFound) Error() string {
 }
 
 func (c *Controller) enqueueAddNode(obj any) {
-	key := cache.MetaObjectToName(obj.(*v1.Node)).String()
+	node := obj.(*v1.Node)
+	key := cache.MetaObjectToName(node).String()
 	klog.V(3).Infof("enqueue add node %s", key)
 	c.addNodeQueue.Add(key)
+	c.enqueueVpcBFDPortByNodeChange(nil, node)
 }
 
 func nodeReady(node *v1.Node) bool {
@@ -68,14 +69,61 @@ func kubeOvnAnnotationsChanged(oldAnnotations, newAnnotations map[string]string)
 	return !maps.Equal(filterKubeOvnAnnotations(oldAnnotations), filterKubeOvnAnnotations(newAnnotations))
 }
 
+func (c *Controller) listVpcBFDPorts() ([]*kubeovnv1.Vpc, error) {
+	vpcs, err := c.vpcsLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	bfdVpcs := make([]*kubeovnv1.Vpc, 0, len(vpcs))
+	for _, vpc := range vpcs {
+		if vpc.Labels != nil && vpc.Labels[util.VpcExternalLabel] == "true" {
+			continue
+		}
+		if !vpc.Spec.BFDPort.IsEnabled() {
+			continue
+		}
+		bfdVpcs = append(bfdVpcs, vpc)
+	}
+	return bfdVpcs, nil
+}
+
+func (c *Controller) enqueueVpcBFDPortByNodeChange(oldNode, newNode *v1.Node) {
+	vpcs, err := c.listVpcBFDPorts()
+	if err != nil {
+		klog.Errorf("failed to list VPC BFD ports for node change: %v", err)
+		return
+	}
+
+	for _, vpc := range vpcs {
+		selector := labels.Everything()
+		if vpc.Spec.BFDPort.NodeSelector != nil {
+			selector, err = metav1.LabelSelectorAsSelector(vpc.Spec.BFDPort.NodeSelector)
+			if err != nil {
+				klog.Errorf("failed to parse BFD port node selector of vpc %s: %v", vpc.Name, err)
+				c.addOrUpdateVpcQueue.Add(vpc.Name)
+				continue
+			}
+		}
+
+		oldMatched := oldNode != nil && selector.Matches(labels.Set(oldNode.Labels))
+		newMatched := newNode != nil && selector.Matches(labels.Set(newNode.Labels))
+		nodeReadyChanged := oldNode != nil && newNode != nil && oldMatched && newMatched && nodeReady(oldNode) != nodeReady(newNode)
+		if oldMatched != newMatched || nodeReadyChanged {
+			klog.V(3).Infof("enqueue update vpc %s for BFD port triggered by node change", vpc.Name)
+			c.addOrUpdateVpcQueue.Add(vpc.Name)
+		}
+	}
+}
+
 func (c *Controller) enqueueUpdateNode(oldObj, newObj any) {
 	oldNode := oldObj.(*v1.Node)
 	newNode := newObj.(*v1.Node)
+	nodeReadyChanged := nodeReady(oldNode) != nodeReady(newNode)
+	nodeLabelsChanged := !maps.Equal(oldNode.Labels, newNode.Labels)
 
-	if nodeReady(oldNode) != nodeReady(newNode) ||
-		kubeOvnAnnotationsChanged(oldNode.Annotations, newNode.Annotations) ||
-		!reflect.DeepEqual(oldNode.Labels, newNode.Labels) {
-		key := cache.MetaObjectToName(newNode).String()
+	key := cache.MetaObjectToName(newNode).String()
+	if nodeReadyChanged || kubeOvnAnnotationsChanged(oldNode.Annotations, newNode.Annotations) {
 		if len(newNode.Annotations) == 0 || newNode.Annotations[util.AllocatedAnnotation] != "true" {
 			klog.V(3).Infof("enqueue add node %s", key)
 			c.addNodeQueue.Add(key)
@@ -83,6 +131,12 @@ func (c *Controller) enqueueUpdateNode(oldObj, newObj any) {
 			klog.V(3).Infof("enqueue update node %s", key)
 			c.updateNodeQueue.Add(key)
 		}
+	} else if nodeLabelsChanged && newNode.Annotations[util.AllocatedAnnotation] == "true" {
+		klog.V(3).Infof("enqueue update node %s for label change", key)
+		c.updateNodeQueue.Add(key)
+	}
+	if nodeReadyChanged || nodeLabelsChanged {
+		c.enqueueVpcBFDPortByNodeChange(oldNode, newNode)
 	}
 }
 
@@ -107,6 +161,7 @@ func (c *Controller) enqueueDeleteNode(obj any) {
 	klog.V(3).Infof("enqueue delete node %s", key)
 	c.deletingNodeObjMap.Store(key, node)
 	c.deleteNodeQueue.Add(key)
+	c.enqueueVpcBFDPortByNodeChange(node, nil)
 }
 
 func nodeUnderlayAddressSetName(node string, af int) string {

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -3,8 +3,10 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -12,7 +14,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	netlisters "k8s.io/client-go/listers/networking/v1"
+	"k8s.io/client-go/tools/cache"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	ovs "github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnsb"
@@ -339,4 +343,198 @@ func TestGetPolicyRouteParams_ClonedExternalIDs(t *testing.T) {
 		"node-2": "10.0.0.2",
 	}, originalExternalIDs)
 	require.Contains(t, policy.ExternalIDs, "node-1")
+}
+
+func newBFDPortVpc(name string, selector map[string]string) *kubeovnv1.Vpc {
+	return &kubeovnv1.Vpc{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kubeovnv1.VpcSpec{
+			BFDPort: &kubeovnv1.BFDPort{
+				Enabled: true,
+				IP:      "169.254.0.1/32",
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: selector,
+				},
+			},
+		},
+	}
+}
+
+func newBFDPortVpcWithoutNodeSelector(name string) *kubeovnv1.Vpc {
+	return &kubeovnv1.Vpc{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kubeovnv1.VpcSpec{
+			BFDPort: &kubeovnv1.BFDPort{
+				Enabled: true,
+				IP:      "169.254.0.1/32",
+			},
+		},
+	}
+}
+
+func prepareNodeQueueTestController(t *testing.T, vpcs ...*kubeovnv1.Vpc) *Controller {
+	t.Helper()
+
+	fakeController := newFakeController(t)
+	for _, vpc := range vpcs {
+		require.NoError(t, fakeController.fakeInformers.vpcInformer.Informer().GetStore().Add(vpc))
+	}
+
+	ctrl := fakeController.fakeController
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+	ctrl.updateNodeQueue = newTypedRateLimitingQueue[string]("UpdateNode", nil)
+	ctrl.deleteNodeQueue = newTypedRateLimitingQueue[string]("DeleteNode", nil)
+	ctrl.deletingNodeObjMap = xsync.NewMap[string, *corev1.Node]()
+	ctrl.addOrUpdateVpcQueue = newTypedRateLimitingQueue[string]("AddOrUpdateVpc", nil)
+	return ctrl
+}
+
+func drainVpcQueue(t *testing.T, ctrl *Controller) []string {
+	t.Helper()
+
+	keys := make([]string, 0, ctrl.addOrUpdateVpcQueue.Len())
+	for ctrl.addOrUpdateVpcQueue.Len() > 0 {
+		key, shutdown := ctrl.addOrUpdateVpcQueue.Get()
+		require.False(t, shutdown)
+		keys = append(keys, key)
+		ctrl.addOrUpdateVpcQueue.Done(key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func TestEnqueueAddNodeEnqueuesMatchingVpcBFDPort(t *testing.T) {
+	ctrl := prepareNodeQueueTestController(t,
+		newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}),
+		newBFDPortVpc("unselected-vpc", map[string]string{"egress": "false"}),
+	)
+
+	ctrl.enqueueAddNode(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{"egress": "true"},
+		},
+	})
+
+	require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
+}
+
+func TestEnqueueUpdateNodeEnqueuesVpcBFDPortOnSelectorMembershipChange(t *testing.T) {
+	t.Run("node starts matching selector", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"egress": "true"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Zero(t, ctrl.addNodeQueue.Len())
+		require.Zero(t, ctrl.updateNodeQueue.Len())
+		require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("node stops matching selector", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-a",
+				Labels: map[string]string{"egress": "true"},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"egress": "false"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Zero(t, ctrl.addNodeQueue.Len())
+		require.Zero(t, ctrl.updateNodeQueue.Len())
+		require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("allocated node unrelated label change enqueues update node only", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "node-a",
+				Labels:      map[string]string{"role": "worker"},
+				Annotations: map[string]string{util.AllocatedAnnotation: "true"},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"role": "gateway"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Zero(t, ctrl.addNodeQueue.Len())
+		require.Equal(t, 1, ctrl.updateNodeQueue.Len())
+		require.Empty(t, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("matching node readiness change enqueues vpc", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-a",
+				Labels: map[string]string{"egress": "true"},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Status.Conditions[0].Status = corev1.ConditionTrue
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("node keeps matching selector does not enqueue vpc on label change", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-a",
+				Labels: map[string]string{"egress": "true", "role": "worker"},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"egress": "true", "role": "gateway"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Empty(t, drainVpcQueue(t, ctrl))
+	})
+
+	t.Run("default selector does not enqueue vpc on label change", func(t *testing.T) {
+		ctrl := prepareNodeQueueTestController(t, newBFDPortVpcWithoutNodeSelector("default-vpc"))
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-a",
+				Labels: map[string]string{"role": "worker"},
+			},
+		}
+		newNode := oldNode.DeepCopy()
+		newNode.Labels = map[string]string{"role": "gateway"}
+
+		ctrl.enqueueUpdateNode(oldNode, newNode)
+
+		require.Empty(t, drainVpcQueue(t, ctrl))
+	})
+}
+
+func TestEnqueueDeleteNodeEnqueuesMatchingVpcBFDPort(t *testing.T) {
+	ctrl := prepareNodeQueueTestController(t, newBFDPortVpc("selected-vpc", map[string]string{"egress": "true"}))
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{"egress": "true"},
+		},
+	}
+
+	ctrl.enqueueDeleteNode(cache.DeletedFinalStateUnknown{Obj: node})
+
+	require.Equal(t, []string{"selected-vpc"}, drainVpcQueue(t, ctrl))
 }

--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -819,15 +819,25 @@ func (c *Controller) reconcileVpcBfdLRP(vpc *kubeovnv1.Vpc) (string, []string, e
 		return portName, nil, err
 	}
 	if len(nodes) == 0 {
-		err = fmt.Errorf("no nodes found by selector %q", selector.String())
-		klog.Error(err)
-		return portName, nil, err
+		klog.Warningf("no nodes found by selector %q for BFD LRP %s, clearing HA chassis group", selector.String(), portName)
 	}
+	readyNodes := make([]*v1.Node, 0, len(nodes))
+	for _, node := range nodes {
+		if nodeReady(node) {
+			readyNodes = append(readyNodes, node)
+		}
+	}
+	if len(nodes) != 0 && len(readyNodes) == 0 {
+		klog.Warningf("no ready nodes found by selector %q for BFD LRP %s, clearing HA chassis group", selector.String(), portName)
+	}
+	sort.Slice(readyNodes, func(i, j int) bool {
+		return readyNodes[i].Name < readyNodes[j].Name
+	})
 
-	nodeNames := make([]string, 0, len(nodes))
-	chassisCount = min(chassisCount, len(nodes))
+	nodeNames := make([]string, 0, len(readyNodes))
+	chassisCount = min(chassisCount, len(readyNodes))
 	chassisNames := make([]string, 0, chassisCount)
-	for _, node := range nodes[:chassisCount] {
+	for _, node := range readyNodes[:chassisCount] {
 		chassis, err := c.OVNSbClient.GetChassisByHost(node.Name)
 		if err != nil {
 			err = fmt.Errorf("failed to get chassis of node %s: %w", node.Name, err)

--- a/pkg/controller/vpc_test.go
+++ b/pkg/controller/vpc_test.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/keymutex"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnsb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -473,4 +475,133 @@ func TestDiffPolicyRouteWithLogical_HandlesLegacyNextHopField(t *testing.T) {
 	dels, adds := diffPolicyRouteWithLogical(existing, target)
 	require.Empty(t, dels)
 	require.Empty(t, adds)
+}
+
+func TestReconcileVpcBfdLRPClearsHAChassisGroupWhenSelectorMatchesNoNodes(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+
+	vpc := &kubeovnv1.Vpc{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vpc-bfd"},
+		Spec: kubeovnv1.VpcSpec{
+			BFDPort: &kubeovnv1.BFDPort{
+				Enabled: true,
+				IP:      "169.254.0.1/32",
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"egress": "true"},
+				},
+			},
+		},
+	}
+
+	portName := "bfd@test-vpc-bfd"
+	networks := []string{"169.254.0.1/32"}
+	mockOvnClient.EXPECT().CreateLogicalRouterPort(vpc.Name, portName, "", networks).Return(nil)
+	mockOvnClient.EXPECT().UpdateLogicalRouterPortNetworks(portName, networks).Return(nil)
+	mockOvnClient.EXPECT().UpdateLogicalRouterPortOptions(portName, map[string]string{"bfd-only": "true"}).Return(nil)
+	mockOvnClient.EXPECT().CreateHAChassisGroup(portName, []string{}, map[string]string{"lrp": portName}).Return(nil)
+	mockOvnClient.EXPECT().SetLogicalRouterPortHAChassisGroup(portName, portName).Return(nil)
+
+	name, nodes, err := ctrl.reconcileVpcBfdLRP(vpc)
+	require.NoError(t, err)
+	require.Equal(t, portName, name)
+	require.Empty(t, nodes)
+}
+
+func TestReconcileVpcBfdLRPUsesReadyNodesInStableOrder(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	mockSbClient := fakeController.mockOvnSbClient
+
+	for _, node := range []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-b", Labels: map[string]string{"egress": "true"}},
+			Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodeReady, Status: corev1.ConditionTrue,
+			}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-c", Labels: map[string]string{"egress": "true"}},
+			Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodeReady, Status: corev1.ConditionFalse,
+			}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-a", Labels: map[string]string{"egress": "true"}},
+			Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodeReady, Status: corev1.ConditionTrue,
+			}}},
+		},
+	} {
+		require.NoError(t, fakeController.fakeInformers.nodeInformer.Informer().GetStore().Add(node))
+	}
+
+	vpc := &kubeovnv1.Vpc{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vpc-bfd"},
+		Spec: kubeovnv1.VpcSpec{
+			BFDPort: &kubeovnv1.BFDPort{
+				Enabled: true,
+				IP:      "169.254.0.1/32",
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"egress": "true"},
+				},
+			},
+		},
+	}
+
+	portName := "bfd@test-vpc-bfd"
+	networks := []string{"169.254.0.1/32"}
+	mockSbClient.EXPECT().GetChassisByHost("node-a").Return(&ovnsb.Chassis{Name: "chassis-a"}, nil)
+	mockSbClient.EXPECT().GetChassisByHost("node-b").Return(&ovnsb.Chassis{Name: "chassis-b"}, nil)
+	mockOvnClient.EXPECT().CreateLogicalRouterPort(vpc.Name, portName, "", networks).Return(nil)
+	mockOvnClient.EXPECT().UpdateLogicalRouterPortNetworks(portName, networks).Return(nil)
+	mockOvnClient.EXPECT().UpdateLogicalRouterPortOptions(portName, map[string]string{"bfd-only": "true"}).Return(nil)
+	mockOvnClient.EXPECT().CreateHAChassisGroup(portName, []string{"chassis-a", "chassis-b"}, map[string]string{"lrp": portName}).Return(nil)
+	mockOvnClient.EXPECT().SetLogicalRouterPortHAChassisGroup(portName, portName).Return(nil)
+
+	name, nodes, err := ctrl.reconcileVpcBfdLRP(vpc)
+	require.NoError(t, err)
+	require.Equal(t, portName, name)
+	require.Equal(t, []string{"node-a", "node-b"}, nodes)
+}
+
+func TestReconcileVpcBfdLRPClearsHAChassisGroupWhenSelectorMatchesNoReadyNodes(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+
+	require.NoError(t, fakeController.fakeInformers.nodeInformer.Informer().GetStore().Add(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a", Labels: map[string]string{"egress": "true"}},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type: corev1.NodeReady, Status: corev1.ConditionFalse,
+		}}},
+	}))
+
+	vpc := &kubeovnv1.Vpc{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vpc-bfd"},
+		Spec: kubeovnv1.VpcSpec{
+			BFDPort: &kubeovnv1.BFDPort{
+				Enabled: true,
+				IP:      "169.254.0.1/32",
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"egress": "true"},
+				},
+			},
+		},
+	}
+
+	portName := "bfd@test-vpc-bfd"
+	networks := []string{"169.254.0.1/32"}
+	mockOvnClient.EXPECT().CreateLogicalRouterPort(vpc.Name, portName, "", networks).Return(nil)
+	mockOvnClient.EXPECT().UpdateLogicalRouterPortNetworks(portName, networks).Return(nil)
+	mockOvnClient.EXPECT().UpdateLogicalRouterPortOptions(portName, map[string]string{"bfd-only": "true"}).Return(nil)
+	mockOvnClient.EXPECT().CreateHAChassisGroup(portName, []string{}, map[string]string{"lrp": portName}).Return(nil)
+	mockOvnClient.EXPECT().SetLogicalRouterPortHAChassisGroup(portName, portName).Return(nil)
+
+	name, nodes, err := ctrl.reconcileVpcBfdLRP(vpc)
+	require.NoError(t, err)
+	require.Equal(t, portName, name)
+	require.Empty(t, nodes)
 }

--- a/pkg/ovs/ovn-nb-ha_chassis_group_test.go
+++ b/pkg/ovs/ovn-nb-ha_chassis_group_test.go
@@ -46,6 +46,7 @@ func (suite *OvnClientTestSuite) testCreateHAChassisGroup() {
 	require.NotNil(t, group)
 	require.Equal(t, group.ExternalIDs, map[string]string{"vendor": util.CniTypeName, "k2": "v2"})
 	require.Len(t, group.HaChassis, len(chassises))
+	staleHAChassisUUIDs := slices.Clone(group.HaChassis)
 	for _, uuid := range group.HaChassis {
 		chassis := &ovnnb.HAChassis{UUID: uuid}
 		err = nbClient.Get(context.Background(), chassis)
@@ -53,6 +54,20 @@ func (suite *OvnClientTestSuite) testCreateHAChassisGroup() {
 		require.Contains(t, chassises, chassis.ChassisName)
 		require.Equal(t, chassis.Priority, 100-slices.Index(chassises, chassis.ChassisName))
 		require.Equal(t, chassis.ExternalIDs, map[string]string{"group": name, "vendor": util.CniTypeName})
+	}
+
+	err = nbClient.CreateHAChassisGroup(name, nil, map[string]string{"k3": "v3"})
+	require.NoError(t, err)
+
+	group, err = nbClient.GetHAChassisGroup(name, false)
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	require.Equal(t, group.ExternalIDs, map[string]string{"vendor": util.CniTypeName, "k3": "v3"})
+	require.Empty(t, group.HaChassis)
+	for _, uuid := range staleHAChassisUUIDs {
+		chassis := &ovnnb.HAChassis{UUID: uuid}
+		err = nbClient.Get(context.Background(), chassis)
+		require.Error(t, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Backport VPC BFDPort HA chassis reconciliation on node add/delete/label/readiness changes.
- Clear the BFD HA chassis group when a selector matches no nodes.
- Excludes `test/e2e/...` changes from the master PR.

Backport of #6891.

## Test Plan
- `go test ./pkg/controller ./pkg/ovs -count=1`
- `CI=true make lint` in a clean remote clone: fails on existing issues outside this backport: `pkg/util/k8s.go:232` (govet inline), `test/e2e/framework/ovn_address_set.go:52` (govet inline).
