### PR TITLE
fix(ovs): make DeleteNat idempotent when target NAT row is absent

### DIFF
--- a/pkg/ovs/ovn-nb-nat.go
+++ b/pkg/ovs/ovn-nb-nat.go
@@ -232,10 +232,16 @@ func (c *OVNNbClient) DeleteNats(lrName, natType, logicalIP string) error {
 
 // DeleteNat delete nat rule
 func (c *OVNNbClient) DeleteNat(lrName, natType, externalIP, logicalIP string) error {
-	nat, err := c.GetNat(lrName, natType, externalIP, logicalIP, false)
+	nat, err := c.GetNat(lrName, natType, externalIP, logicalIP, true)
 	if err != nil {
 		klog.Error(err)
 		return err
+	}
+	if nat == nil {
+		// The NAT row may have already been removed (by another reconcile
+		// or direct lr-nat-del). Return success so callers (e.g. OvnFip)
+		// can clear their finalizer without requeuing forever.
+		return nil
 	}
 
 	// remove nat from logical router

--- a/pkg/ovs/ovn-nb-nat_test.go
+++ b/pkg/ovs/ovn-nb-nat_test.go
@@ -395,6 +395,29 @@ func (suite *OvnClientTestSuite) testDeleteNat() {
 	})
 }
 
+// testDeleteNatIsIdempotent verifies that DeleteNat returns success (nil)
+// when the target NAT row is already absent. This prevents callers such as
+// the OvnFip delete handler from entering a stuck requeue loop on the finalizer.
+func (suite *OvnClientTestSuite) testDeleteNatIsIdempotent() {
+	t := suite.T()
+	t.Parallel()
+	nbClient := suite.ovnNBClient
+	lrName := "test-lr-nat-del-idempotent"
+	eip := "192.168.31.100"
+	logicalIP := "10.16.0.42"
+
+	require.NoError(t, nbClient.CreateLogicalRouter(lrName))
+	defer func() { _ = nbClient.DeleteLogicalRouter(lrName) }()
+
+	// (a) Delete a never-existent NAT -> success.
+	require.NoError(t, nbClient.DeleteNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, logicalIP))
+
+	// (b) Create -> Delete -> Delete: second delete must be a no-op.
+	require.NoError(t, nbClient.AddNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, logicalIP, "00:00:00:cc:cc:cc", "pod-c.ns", nil))
+	require.NoError(t, nbClient.DeleteNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, logicalIP))
+	require.NoError(t, nbClient.DeleteNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, logicalIP))
+}
+
 func (suite *OvnClientTestSuite) testDeleteNats() {
 	t := suite.T()
 	t.Parallel()

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -917,6 +917,10 @@ func (suite *OvnClientTestSuite) Test_DeleteNat() {
 	suite.testDeleteNat()
 }
 
+func (suite *OvnClientTestSuite) Test_DeleteNatIsIdempotent() {
+	suite.testDeleteNatIsIdempotent()
+}
+
 func (suite *OvnClientTestSuite) Test_GetNat() {
 	suite.testGetNat()
 }


### PR DESCRIPTION
## Problem

`DeleteNat` currently returns an error (`not found logical router ... nat ...`) when the target NAT row no longer exists. This happens in real scenarios such as:

- A previous reconcile already removed the row
- A manual `lr-nat-del` was performed
- Race between multiple controllers

This error propagates to callers (notably the OvnFip delete handler in `pkg/controller/ovn_fip.go`), causing the finalizer to get stuck and the object to requeue forever.

## Solution

Make `DeleteNat` idempotent:

- Call `GetNat` with `ignoreNotFound=true`
- If no row is found, return `nil` (success) instead of an error

This allows finalizers to be cleared cleanly even when the NAT rule has already disappeared.

## Changes

- `pkg/ovs/ovn-nb-nat.go`: Update `DeleteNat` to treat missing row as success
- `pkg/ovs/ovn-nb-nat_test.go`: Add `testDeleteNatIsIdempotent`
- `pkg/ovs/ovn-nb-suite_test.go`: Register `Test_DeleteNatIsIdempotent`

The new test covers:
- Deleting a never-existent NAT
- Create → Delete → Delete (double delete must succeed)

## Impact

- Fixes stuck finalizers for EIP/FIP (OvnFip) and other NAT-based resources
- Low risk — only changes error handling on the "not found" path
- No behavior change when the NAT row actually exists