### PR TITLE
feat(speaker): add GoBGP BFD support for fast failure detection

### DIFF
--- a/pkg/speaker/bfd.go
+++ b/pkg/speaker/bfd.go
@@ -1,0 +1,60 @@
+package speaker
+
+import (
+	"context"
+
+	"github.com/osrg/gobgp/v4/api"
+	"k8s.io/klog/v2"
+)
+
+// bfdSessionStateString converts a BFD session state enum to a human-readable string.
+func bfdSessionStateString(state api.BfdSessionState) string {
+	switch state {
+	case api.BfdSessionState_BFD_SESSION_STATE_UP:
+		return "UP"
+	case api.BfdSessionState_BFD_SESSION_STATE_DOWN:
+		return "DOWN"
+	case api.BfdSessionState_BFD_SESSION_STATE_INIT:
+		return "INIT"
+	case api.BfdSessionState_BFD_SESSION_STATE_ADMIN_DOWN:
+		return "ADMIN_DOWN"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// logBFDStatus logs the BFD status for all peers.
+// Guarded by klog verbosity to avoid unnecessary gRPC calls when logging is off.
+func (c *Controller) logBFDStatus() {
+	if !c.config.EnableBFD {
+		return
+	}
+
+	// Log BFD server statistics
+	if klog.V(4).Enabled() {
+		if stats := c.config.BgpServer.GetBfdServerStats(); stats != nil {
+			klog.V(4).Infof("BFD server stats: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d",
+				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
+		}
+	}
+
+	if !klog.V(5).Enabled() {
+		return
+	}
+
+	c.config.BgpServer.ListBfdPeer(context.Background(), func(addr string, state *api.BfdPeerState) {
+		if state == nil {
+			klog.V(5).Infof("BFD peer %s: no state available", addr)
+			return
+		}
+
+		if async := state.BfdAsync; async != nil {
+			klog.V(5).Infof("BFD peer %s: state=%s, tx=%d, rx=%d",
+				addr, bfdSessionStateString(state.SessionState),
+				async.TransmittedPackets, async.ReceivedPackets)
+		} else {
+			klog.V(5).Infof("BFD peer %s: state=%s",
+				addr, bfdSessionStateString(state.SessionState))
+		}
+	})
+}

--- a/pkg/speaker/bfd_test.go
+++ b/pkg/speaker/bfd_test.go
@@ -1,0 +1,203 @@
+package speaker
+
+import (
+	"net"
+	"testing"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBFDPeerConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *Configuration
+		expected *api.BfdPeerConfig
+	}{
+		{
+			name: "BFD disabled returns nil",
+			config: &Configuration{
+				EnableBFD: false,
+			},
+			expected: nil,
+		},
+		{
+			name: "default values converts ms to us",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+			},
+			expected: &api.BfdPeerConfig{
+				Enabled:                  true,
+				DesiredMinimumTxInterval: 1000000, // 1000ms = 1,000,000μs
+				RequiredMinimumReceive:   1000000,
+				DetectionMultiplier:      3,
+			},
+		},
+		{
+			name: "custom values converts ms to us",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               300,
+				BFDMinRX:               500,
+				BFDDetectionMultiplier: 5,
+			},
+			expected: &api.BfdPeerConfig{
+				Enabled:                  true,
+				DesiredMinimumTxInterval: 300000, // 300ms = 300,000μs
+				RequiredMinimumReceive:   500000,
+				DetectionMultiplier:      5,
+			},
+		},
+		{
+			name: "aggressive timers",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               100,
+				BFDMinRX:               100,
+				BFDDetectionMultiplier: 3,
+			},
+			expected: &api.BfdPeerConfig{
+				Enabled:                  true,
+				DesiredMinimumTxInterval: 100000, // 100ms = 100,000μs
+				RequiredMinimumReceive:   100000,
+				DetectionMultiplier:      3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newBFDPeerConfig(tt.config)
+			if tt.expected == nil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.expected.Enabled, got.Enabled)
+			require.Equal(t, tt.expected.DesiredMinimumTxInterval, got.DesiredMinimumTxInterval)
+			require.Equal(t, tt.expected.RequiredMinimumReceive, got.RequiredMinimumReceive)
+			require.Equal(t, tt.expected.DetectionMultiplier, got.DetectionMultiplier)
+		})
+	}
+}
+
+func TestBfdSessionStateString(t *testing.T) {
+	tests := []struct {
+		state    api.BfdSessionState
+		expected string
+	}{
+		{api.BfdSessionState_BFD_SESSION_STATE_UP, "UP"},
+		{api.BfdSessionState_BFD_SESSION_STATE_DOWN, "DOWN"},
+		{api.BfdSessionState_BFD_SESSION_STATE_INIT, "INIT"},
+		{api.BfdSessionState_BFD_SESSION_STATE_ADMIN_DOWN, "ADMIN_DOWN"},
+		{api.BfdSessionState_BFD_SESSION_STATE_UNSPECIFIED, "UNKNOWN"},
+		{api.BfdSessionState(99), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			require.Equal(t, tt.expected, bfdSessionStateString(tt.state))
+		})
+	}
+}
+
+func TestValidateBFDFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Configuration
+		wantErr bool
+	}{
+		{
+			name: "valid BFD config",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: false,
+		},
+		{
+			name: "detection multiplier too large",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 256,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "detection multiplier zero",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 0,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero min-tx",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               0,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero min-rx",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               0,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "BFD disabled skips validation",
+			config: &Configuration{
+				EnableBFD:              false,
+				BFDDetectionMultiplier: 999,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Need at least one neighbor for validation to pass
+			tt.config.NeighborAddresses = []net.IP{net.ParseIP("10.0.0.1")}
+			err := tt.config.validateRequiredFlags()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -65,6 +65,12 @@ type Configuration struct {
 	NatGwMode                   bool
 	EnableMetrics               bool
 
+	// BFD (Bidirectional Forwarding Detection) configuration
+	EnableBFD              bool
+	BFDMinTX               uint32 // minimum transmit interval in milliseconds (converted to microseconds for GoBGP)
+	BFDMinRX               uint32 // minimum receive interval in milliseconds (converted to microseconds for GoBGP)
+	BFDDetectionMultiplier uint32 // detection multiplier (must be <= 255)
+
 	NodeName       string
 	KubeConfigFile string
 	KubeClient     kubernetes.Interface
@@ -101,6 +107,10 @@ func ParseFlags() (*Configuration, error) {
 		argNatGwMode                   = pflag.BoolP("nat-gw-mode", "", false, "Make the BGP speaker announce EIPs from inside a NAT gateway, Pod IP/Service/Subnet announcements will be disabled")
 		argEnableMetrics               = pflag.BoolP("enable-metrics", "", true, "Whether to support metrics query")
 		argLogPerm                     = pflag.String("log-perm", "640", "The permission for the log file")
+		argEnableBFD                   = pflag.BoolP("enable-bfd", "", false, "Enable BFD (Bidirectional Forwarding Detection) for fast failure detection")
+		argBFDMinTX                    = pflag.Uint32("bfd-min-tx", 1000, "BFD minimum transmit interval in milliseconds (default 1000ms)")
+		argBFDMinRX                    = pflag.Uint32("bfd-min-rx", 1000, "BFD minimum receive interval in milliseconds (default 1000ms)")
+		argBFDDetectionMultiplier      = pflag.Uint32("bfd-detection-multiplier", 3, "BFD detection multiplier (default 3)")
 	)
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -173,6 +183,10 @@ func ParseFlags() (*Configuration, error) {
 		NatGwMode:                   *argNatGwMode,
 		EnableMetrics:               *argEnableMetrics,
 		LogPerm:                     *argLogPerm,
+		EnableBFD:                   *argEnableBFD,
+		BFDMinTX:                    *argBFDMinTX,
+		BFDMinRX:                    *argBFDMinRX,
+		BFDDetectionMultiplier:      *argBFDDetectionMultiplier,
 	}
 
 	if podIPv4 != "" {
@@ -258,6 +272,18 @@ func (config *Configuration) validateRequiredFlags() error {
 		missingFlags = append(missingFlags, "--node-name must be specified (usually via NODE_NAME env from downward API)")
 	}
 
+	if config.EnableBFD {
+		if config.BFDDetectionMultiplier == 0 || config.BFDDetectionMultiplier > 255 {
+			missingFlags = append(missingFlags, "--bfd-detection-multiplier must be between 1 and 255")
+		}
+		if config.BFDMinTX == 0 {
+			missingFlags = append(missingFlags, "--bfd-min-tx must be > 0")
+		}
+		if config.BFDMinRX == 0 {
+			missingFlags = append(missingFlags, "--bfd-min-rx must be > 0")
+		}
+	}
+
 	if len(missingFlags) > 0 {
 		return fmt.Errorf("missing required flags: %s", strings.Join(missingFlags, "; "))
 	}
@@ -311,6 +337,22 @@ func (config *Configuration) checkGracefulRestartOptions() error {
 	}
 
 	return nil
+}
+
+// newBFDPeerConfig creates a BfdPeerConfig from the speaker Configuration.
+// Returns nil when BFD is disabled.
+// GoBGP expects BFD intervals in microseconds (RFC 5880), while CLI flags
+// accept milliseconds for user convenience; this function performs the conversion.
+func newBFDPeerConfig(config *Configuration) *api.BfdPeerConfig {
+	if !config.EnableBFD {
+		return nil
+	}
+	return &api.BfdPeerConfig{
+		Enabled:                  true,
+		DesiredMinimumTxInterval: config.BFDMinTX * 1000, // ms → μs
+		RequiredMinimumReceive:   config.BFDMinRX * 1000, // ms → μs
+		DetectionMultiplier:      config.BFDDetectionMultiplier,
+	}
 }
 
 func (config *Configuration) initBgpServer() error {
@@ -430,6 +472,14 @@ func (config *Configuration) initBgpServer() error {
 				})
 			}
 
+			// Enable BFD if configured
+			if config.EnableBFD {
+				peer.Bfd = newBFDPeerConfig(config)
+				klog.Infof("BFD enabled for peer %s: MinTX=%dms(%dμs), MinRX=%dms(%dμs), Multiplier=%d",
+					addr.String(), config.BFDMinTX, peer.Bfd.DesiredMinimumTxInterval,
+					config.BFDMinRX, peer.Bfd.RequiredMinimumReceive, config.BFDDetectionMultiplier)
+			}
+
 			logBgpPeer(peer)
 			if err := addPeerWithRetry(s, peer); err != nil {
 				err = fmt.Errorf("failed to add peer %s: %w", addr.String(), err)
@@ -465,7 +515,7 @@ func addPeerWithRetry(s *gobgp.BgpServer, peer *api.Peer) error {
 
 // logBgpPeer logs the BGP peer configuration for debugging purposes.
 func logBgpPeer(peer *api.Peer) {
-	klog.Infof("BGP Peer Configuration: NeighborAddress=%s, LocalAddress=%s, PeerAsn=%d, HoldTime=%d, PassiveMode=%v, EbgpMultihop=%v, GracefulRestart=%v, AfiSafis=%v",
+	klog.Infof("BGP Peer Configuration: NeighborAddress=%s, LocalAddress=%s, PeerAsn=%d, HoldTime=%d, PassiveMode=%v, EbgpMultihop=%v, GracefulRestart=%v, AfiSafis=%v, BFD=%v",
 		peer.Conf.NeighborAddress,
 		peer.Transport.LocalAddress,
 		peer.Conf.PeerAsn,
@@ -473,7 +523,8 @@ func logBgpPeer(peer *api.Peer) {
 		peer.Transport.PassiveMode,
 		peer.EbgpMultihop,
 		peer.GracefulRestart,
-		peer.AfiSafis)
+		peer.AfiSafis,
+		peer.Bfd)
 }
 
 func (config *Configuration) initNeighborLocalAddresses() error {

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -128,4 +128,9 @@ func (c *Controller) Reconcile() {
 	} else {
 		c.syncSubnetRoutes()
 	}
+
+	// Log BFD status if enabled
+	if c.config.EnableBFD {
+		c.logBFDStatus()
+	}
 }


### PR DESCRIPTION
Add Bidirectional Forwarding Detection (BFD) support integrated with GoBGP BGP speaker. BFD enables fast failure detection (sub-second to seconds) for BGP sessions, significantly improving failover time compared to BGP hold timer alone (default 90s).

## Features

- Enable BFD via `--enable-bfd` flag (disabled by default, pure extension)
- Configurable parameters: `--bfd-min-tx`, `--bfd-min-rx` (milliseconds), `--bfd-detection-multiplier`
- BFD status monitoring with periodic logging (guarded by klog verbosity)
- BFD server statistics tracking
- Parameter validation (intervals > 0, detection multiplier 1-255)
- Millisecond to microsecond conversion for GoBGP (RFC 5880)

## Implementation Details

- Uses GoBGP native BFD support (`BfdPeerConfig` per peer)
- BFD is only activated when `--enable-bfd` flag is explicitly set
- All BFD code is guarded by `config.EnableBFD` checks
- `newBFDPeerConfig()` returns nil when BFD is disabled for safety
- `logBFDStatus()` guarded by `klog.V()` to avoid unnecessary gRPC calls
- Backward compatible: no behavior change when BFD is disabled

## Usage

```yaml
args:
  - --enable-bfd=true
  # Optional (defaults shown):
  - --bfd-min-tx=1000              # ms, converted to μs for GoBGP
  - --bfd-min-rx=1000              # ms, converted to μs for GoBGP
  - --bfd-detection-multiplier=3   # failure detection = min-rx × multiplier
```

Default failure detection time: `1000ms × 3 = 3 seconds`

## Tests

- Unit tests for `newBFDPeerConfig` (ms→μs conversion, nil when disabled)
- Unit tests for `bfdSessionStateString` (state enum mapping)
- Unit tests for `validateRequiredFlags` (BFD parameter validation)

# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Features

## Which issue(s) this PR fixes

N/A - new feature