### PR TITLE
fix(crd): restore vpc egress gateway validations

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -3582,6 +3582,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               externalSubnet:
                 description: external subnet used to create the workload
                 type: string
@@ -3594,10 +3595,11 @@ spec:
                 description: |-
                   optional internal/external IPs used to create the workload
                   these IPs must be in the internal/external subnet
-                  the IPs count must NOT be less than the replicas count
+                  when specified, the IPs count must NOT be less than the replicas count
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               internalSubnet:
                 description: |-
                   optional internal subnet used to create the workload
@@ -3677,7 +3679,7 @@ spec:
               policies:
                 description: |-
                   egress policies
-                  at least one policy must be specified
+                  at least one policy or selector must be specified
                 items:
                   properties:
                     ipBlocks:
@@ -3685,6 +3687,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     snat:
                       default: false
                       description: whether to enable SNAT/MASQUERADE for the egress
@@ -3694,17 +3697,27 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                   type: object
+                  x-kubernetes-validations:
+                  - message: Each policy MUST have at least one ipBlocks or subnets
+                    rule: has(self.ipBlocks) || has(self.subnets)
                 type: array
               prefix:
                 description: |-
                   optional name prefix used to generate the workload
                   the workload name will be generated as <prefix><vpc-egress-gateway-name>
+                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*[-\.]?$
                 type: string
+                x-kubernetes-validations:
+                - message: This field is immutable.
+                  rule: self == oldSelf
               replicas:
                 default: 1
                 description: workload replicas
                 format: int32
+                maximum: 10
+                minimum: 0
                 type: integer
               resources:
                 description: |-
@@ -3820,6 +3833,10 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                      - message: Each namespace selector MUST have at least one matchLabels
+                          or matchExpressions
+                        rule: has(self.matchLabels) || has(self.matchExpressions)
                     podSelector:
                       description: |-
                         A label selector is a label query over a set of resources. The result of matchLabels and
@@ -3869,6 +3886,10 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                      - message: Each pod selector MUST have at least one matchLabels
+                          or matchExpressions
+                        rule: has(self.matchLabels) || has(self.matchExpressions)
                   type: object
                 type: array
               tolerations:
@@ -3918,6 +3939,9 @@ spec:
                   if not specified, the default traffic policy "Cluster" will be used
                   if set to "Local", traffic will be routed to the gateway pod/instance on the same node when available
                   currently it works only for the default vpc
+                enum:
+                - Local
+                - Cluster
                 type: string
               vpc:
                 description: |-
@@ -3927,6 +3951,18 @@ spec:
             required:
             - externalSubnet
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .internalIPs
+              message: Size of Internal IPs MUST be equal to or greater than Replicas
+              rule: '!has(self.internalIPs) || size(self.internalIPs) == 0 || size(self.internalIPs)
+                >= self.replicas'
+            - fieldPath: .externalIPs
+              message: Size of External IPs MUST be equal to or greater than Replicas
+              rule: '!has(self.externalIPs) || size(self.externalIPs) == 0 || size(self.externalIPs)
+                >= self.replicas'
+            - message: Each VPC Egress Gateway MUST have at least one policy or selector
+              rule: (has(self.policies) && size(self.policies) != 0) || (has(self.selectors)
+                && size(self.selectors) != 0)
           status:
             properties:
               conditions:
@@ -3984,6 +4020,10 @@ spec:
                 default: Pending
                 description: Current phase of the egress gateway (Pending, Processing,
                   or Completed)
+                enum:
+                - Pending
+                - Processing
+                - Completed
                 type: string
               ready:
                 default: false
@@ -3992,6 +4032,8 @@ spec:
               replicas:
                 description: used by the scale subresource
                 format: int32
+                maximum: 10
+                minimum: 0
                 type: integer
               workload:
                 description: workload information

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -3606,6 +3606,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               externalSubnet:
                 description: external subnet used to create the workload
                 type: string
@@ -3618,10 +3619,11 @@ spec:
                 description: |-
                   optional internal/external IPs used to create the workload
                   these IPs must be in the internal/external subnet
-                  the IPs count must NOT be less than the replicas count
+                  when specified, the IPs count must NOT be less than the replicas count
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               internalSubnet:
                 description: |-
                   optional internal subnet used to create the workload
@@ -3701,7 +3703,7 @@ spec:
               policies:
                 description: |-
                   egress policies
-                  at least one policy must be specified
+                  at least one policy or selector must be specified
                 items:
                   properties:
                     ipBlocks:
@@ -3709,6 +3711,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     snat:
                       default: false
                       description: whether to enable SNAT/MASQUERADE for the egress
@@ -3718,17 +3721,27 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                   type: object
+                  x-kubernetes-validations:
+                  - message: Each policy MUST have at least one ipBlocks or subnets
+                    rule: has(self.ipBlocks) || has(self.subnets)
                 type: array
               prefix:
                 description: |-
                   optional name prefix used to generate the workload
                   the workload name will be generated as <prefix><vpc-egress-gateway-name>
+                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*[-\.]?$
                 type: string
+                x-kubernetes-validations:
+                - message: This field is immutable.
+                  rule: self == oldSelf
               replicas:
                 default: 1
                 description: workload replicas
                 format: int32
+                maximum: 10
+                minimum: 0
                 type: integer
               resources:
                 description: |-
@@ -3844,6 +3857,10 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                      - message: Each namespace selector MUST have at least one matchLabels
+                          or matchExpressions
+                        rule: has(self.matchLabels) || has(self.matchExpressions)
                     podSelector:
                       description: |-
                         A label selector is a label query over a set of resources. The result of matchLabels and
@@ -3893,6 +3910,10 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                      - message: Each pod selector MUST have at least one matchLabels
+                          or matchExpressions
+                        rule: has(self.matchLabels) || has(self.matchExpressions)
                   type: object
                 type: array
               tolerations:
@@ -3942,6 +3963,9 @@ spec:
                   if not specified, the default traffic policy "Cluster" will be used
                   if set to "Local", traffic will be routed to the gateway pod/instance on the same node when available
                   currently it works only for the default vpc
+                enum:
+                - Local
+                - Cluster
                 type: string
               vpc:
                 description: |-
@@ -3951,6 +3975,18 @@ spec:
             required:
             - externalSubnet
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .internalIPs
+              message: Size of Internal IPs MUST be equal to or greater than Replicas
+              rule: '!has(self.internalIPs) || size(self.internalIPs) == 0 || size(self.internalIPs)
+                >= self.replicas'
+            - fieldPath: .externalIPs
+              message: Size of External IPs MUST be equal to or greater than Replicas
+              rule: '!has(self.externalIPs) || size(self.externalIPs) == 0 || size(self.externalIPs)
+                >= self.replicas'
+            - message: Each VPC Egress Gateway MUST have at least one policy or selector
+              rule: (has(self.policies) && size(self.policies) != 0) || (has(self.selectors)
+                && size(self.selectors) != 0)
           status:
             properties:
               conditions:
@@ -4008,6 +4044,10 @@ spec:
                 default: Pending
                 description: Current phase of the egress gateway (Pending, Processing,
                   or Completed)
+                enum:
+                - Pending
+                - Processing
+                - Completed
                 type: string
               ready:
                 default: false
@@ -4016,6 +4056,8 @@ spec:
               replicas:
                 description: used by the scale subresource
                 format: int32
+                maximum: 10
+                minimum: 0
                 type: integer
               workload:
                 description: workload information

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3967,6 +3967,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               externalSubnet:
                 description: external subnet used to create the workload
                 type: string
@@ -3979,10 +3980,11 @@ spec:
                 description: |-
                   optional internal/external IPs used to create the workload
                   these IPs must be in the internal/external subnet
-                  the IPs count must NOT be less than the replicas count
+                  when specified, the IPs count must NOT be less than the replicas count
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               internalSubnet:
                 description: |-
                   optional internal subnet used to create the workload
@@ -4062,7 +4064,7 @@ spec:
               policies:
                 description: |-
                   egress policies
-                  at least one policy must be specified
+                  at least one policy or selector must be specified
                 items:
                   properties:
                     ipBlocks:
@@ -4070,6 +4072,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     snat:
                       default: false
                       description: whether to enable SNAT/MASQUERADE for the egress
@@ -4079,17 +4082,27 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                   type: object
+                  x-kubernetes-validations:
+                  - message: Each policy MUST have at least one ipBlocks or subnets
+                    rule: has(self.ipBlocks) || has(self.subnets)
                 type: array
               prefix:
                 description: |-
                   optional name prefix used to generate the workload
                   the workload name will be generated as <prefix><vpc-egress-gateway-name>
+                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*[-\.]?$
                 type: string
+                x-kubernetes-validations:
+                - message: This field is immutable.
+                  rule: self == oldSelf
               replicas:
                 default: 1
                 description: workload replicas
                 format: int32
+                maximum: 10
+                minimum: 0
                 type: integer
               resources:
                 description: |-
@@ -4205,6 +4218,10 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                      - message: Each namespace selector MUST have at least one matchLabels
+                          or matchExpressions
+                        rule: has(self.matchLabels) || has(self.matchExpressions)
                     podSelector:
                       description: |-
                         A label selector is a label query over a set of resources. The result of matchLabels and
@@ -4254,6 +4271,10 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                      - message: Each pod selector MUST have at least one matchLabels
+                          or matchExpressions
+                        rule: has(self.matchLabels) || has(self.matchExpressions)
                   type: object
                 type: array
               tolerations:
@@ -4303,6 +4324,9 @@ spec:
                   if not specified, the default traffic policy "Cluster" will be used
                   if set to "Local", traffic will be routed to the gateway pod/instance on the same node when available
                   currently it works only for the default vpc
+                enum:
+                - Local
+                - Cluster
                 type: string
               vpc:
                 description: |-
@@ -4312,6 +4336,18 @@ spec:
             required:
             - externalSubnet
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .internalIPs
+              message: Size of Internal IPs MUST be equal to or greater than Replicas
+              rule: '!has(self.internalIPs) || size(self.internalIPs) == 0 || size(self.internalIPs)
+                >= self.replicas'
+            - fieldPath: .externalIPs
+              message: Size of External IPs MUST be equal to or greater than Replicas
+              rule: '!has(self.externalIPs) || size(self.externalIPs) == 0 || size(self.externalIPs)
+                >= self.replicas'
+            - message: Each VPC Egress Gateway MUST have at least one policy or selector
+              rule: (has(self.policies) && size(self.policies) != 0) || (has(self.selectors)
+                && size(self.selectors) != 0)
           status:
             properties:
               conditions:
@@ -4369,6 +4405,10 @@ spec:
                 default: Pending
                 description: Current phase of the egress gateway (Pending, Processing,
                   or Completed)
+                enum:
+                - Pending
+                - Processing
+                - Completed
                 type: string
               ready:
                 default: false
@@ -4377,6 +4417,8 @@ spec:
               replicas:
                 description: used by the scale subresource
                 format: int32
+                maximum: 10
+                minimum: 0
                 type: integer
               workload:
                 description: workload information

--- a/pkg/apis/kubeovn/v1/vpc-egress-gateway.go
+++ b/pkg/apis/kubeovn/v1/vpc-egress-gateway.go
@@ -80,6 +80,9 @@ type BandwidthLimit struct {
 	Egress int64 `json:"egress,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!has(self.internalIPs) || size(self.internalIPs) == 0 || size(self.internalIPs) >= self.replicas",message="Size of Internal IPs MUST be equal to or greater than Replicas",fieldPath=".internalIPs"
+// +kubebuilder:validation:XValidation:rule="!has(self.externalIPs) || size(self.externalIPs) == 0 || size(self.externalIPs) >= self.replicas",message="Size of External IPs MUST be equal to or greater than Replicas",fieldPath=".externalIPs"
+// +kubebuilder:validation:XValidation:rule="(has(self.policies) && size(self.policies) != 0) || (has(self.selectors) && size(self.selectors) != 0)",message="Each VPC Egress Gateway MUST have at least one policy or selector"
 type VpcEgressGatewaySpec struct {
 	// optional VPC name
 	// if not specified, the default VPC will be used
@@ -92,9 +95,13 @@ type VpcEgressGatewaySpec struct {
 	EvpnConf string `json:"evpnConf,omitempty"`
 	// workload replicas
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=10
 	Replicas int32 `json:"replicas,omitempty"`
 	// optional name prefix used to generate the workload
 	// the workload name will be generated as <prefix><vpc-egress-gateway-name>
+	// +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*[-\.]?$`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="This field is immutable."
 	Prefix string `json:"prefix,omitempty"`
 	// optional image used by the workload
 	// if not specified, the default image passed in by kube-ovn-controller will be used
@@ -107,9 +114,11 @@ type VpcEgressGatewaySpec struct {
 	ExternalSubnet string `json:"externalSubnet"`
 	// optional internal/external IPs used to create the workload
 	// these IPs must be in the internal/external subnet
-	// the IPs count must NOT be less than the replicas count
+	// when specified, the IPs count must NOT be less than the replicas count
+	// +listType=set
 	InternalIPs []string `json:"internalIPs,omitempty"`
 	// External IP addresses for the egress gateway
+	// +listType=set
 	ExternalIPs []string `json:"externalIPs,omitempty"`
 	// namespace/pod selectors
 	Selectors []VpcEgressGatewaySelector `json:"selectors,omitempty"`
@@ -118,12 +127,13 @@ type VpcEgressGatewaySpec struct {
 	// if set to "Local", traffic will be routed to the gateway pod/instance on the same node when available
 	// currently it works only for the default vpc
 	// +kubebuilder:default=Cluster
+	// +kubebuilder:validation:Enum=Local;Cluster
 	TrafficPolicy string `json:"trafficPolicy,omitempty"`
 
 	// BFD configuration
 	BFD VpcEgressGatewayBFDConfig `json:"bfd"`
 	// egress policies
-	// at least one policy must be specified
+	// at least one policy or selector must be specified
 	Policies []VpcEgressGatewayPolicy `json:"policies,omitempty"`
 	// optional node selector used to select the nodes where the workload will be running
 	NodeSelector []VpcEgressGatewayNodeSelector `json:"nodeSelector,omitempty"`
@@ -140,8 +150,10 @@ type VpcEgressGatewaySpec struct {
 }
 
 type VpcEgressGatewaySelector struct {
+	// +kubebuilder:validation:XValidation:rule="has(self.matchLabels) || has(self.matchExpressions)",message="Each namespace selector MUST have at least one matchLabels or matchExpressions"
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
-	PodSelector       *metav1.LabelSelector `json:"podSelector,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="has(self.matchLabels) || has(self.matchExpressions)",message="Each pod selector MUST have at least one matchLabels or matchExpressions"
+	PodSelector *metav1.LabelSelector `json:"podSelector,omitempty"`
 }
 
 type VpcEgressGatewayBFDConfig struct {
@@ -165,13 +177,16 @@ type VpcEgressGatewayBFDConfig struct {
 	Multiplier int32 `json:"multiplier,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="has(self.ipBlocks) || has(self.subnets)",message="Each policy MUST have at least one ipBlocks or subnets"
 type VpcEgressGatewayPolicy struct {
 	// whether to enable SNAT/MASQUERADE for the egress traffic
 	// +kubebuilder:default=false
 	SNAT bool `json:"snat"`
 	// CIDRs/subnets targeted by the egress traffic policy
+	// +listType=set
 	IPBlocks []string `json:"ipBlocks,omitempty"`
-	Subnets  []string `json:"subnets,omitempty"`
+	// +listType=set
+	Subnets []string `json:"subnets,omitempty"`
 }
 
 type VpcEgressGatewayNodeSelector struct {
@@ -182,6 +197,8 @@ type VpcEgressGatewayNodeSelector struct {
 
 type VpcEgressGatewayStatus struct {
 	// used by the scale subresource
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=10
 	Replicas int32 `json:"replicas,omitempty"`
 	// Label selector for the egress gateway
 	LabelSelector string `json:"labelSelector,omitempty"`
@@ -192,6 +209,7 @@ type VpcEgressGatewayStatus struct {
 	// Current phase of the egress gateway (Pending, Processing, or Completed)
 	// +kubebuilder:default=Pending
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=Pending;Processing;Completed
 	Phase Phase `json:"phase"`
 	// internal/external IPs used by the workload
 	InternalIPs []string `json:"internalIPs,omitempty"`

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -444,6 +444,9 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		vegName := "veg-" + framework.RandomSuffix()
 		veg := framework.MakeVpcEgressGateway(namespaceName, vegName, vpcName, 2, internalSubnetName, externalSubnetName)
 		veg.Spec.BFD.Enabled = true
+		veg.Spec.Policies = []apiv1.VpcEgressGatewayPolicy{{
+			Subnets: []string{internalSubnetName},
+		}}
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Deleting vpc egress gateway " + vegName)
 			vegClient.DeleteSync(vegName)
@@ -527,6 +530,9 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		podClient := f.PodClient()
 		vegName := "veg-" + framework.RandomSuffix()
 		veg := framework.MakeVpcEgressGateway(namespaceName, vegName, "", 1, internalSubnetName, externalSubnetName)
+		veg.Spec.Policies = []apiv1.VpcEgressGatewayPolicy{{
+			Subnets: []string{internalSubnetName},
+		}}
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Deleting vpc egress gateway " + vegName)
 			vegClient.DeleteSync(vegName)


### PR DESCRIPTION
## What type of this PR

Bug fixes

## What this PR does

Restore VpcEgressGateway CRD validations that were dropped when CRDs started being generated in #6569, including policy/selector requirements, policy content checks, prefix validation, replica bounds, list set semantics, and trafficPolicy/phase enums.

Also makes the BFD HA chassis e2e VEG object valid under the restored policy validation.

## Verification

- make gen-crd
- make lint
- go test ./test/e2e/vpc-egress-gateway -run TestNonExistent -count=0

Signed-off-by: zhangzujian <zhangzujian.7@gmail.com>