### PR TITLE
fix(ovs): improve dnat_and_snat Add with delete+create for pod swap

### DIFF
--- a/pkg/ovs/ovn-nb-nat.go
+++ b/pkg/ovs/ovn-nb-nat.go
@@ -361,8 +361,8 @@ func (c *OVNNbClient) GetNat(lrName, natType, externalIP, logicalIP string, igno
 			return nat.Type == natType && nat.LogicalIP == logicalIP
 		}
 		// For DNATAndSNAT: if logicalIP given, require externalIP+logicalIP.
-	// Prevents stale Delete (old logicalIP) from clobbering new row.
-	// Empty logicalIP keeps compat for Update/NatExists.
+		// Prevents stale Delete (old logicalIP) from clobbering new row.
+		// Empty logicalIP keeps compat for Update/NatExists.
 		if natType == ovnnb.NATTypeDNATAndSNAT {
 			if nat.Type != natType || nat.ExternalIP != externalIP {
 				return false

--- a/pkg/ovs/ovn-nb-nat.go
+++ b/pkg/ovs/ovn-nb-nat.go
@@ -28,6 +28,10 @@ func (c *OVNNbClient) AddNat(lrName, natType, externalIP, logicalIP, logicalMac,
 	// This includes ARP replies for the external_ip, which return the value of external_mac.
 	// All packets transmitted with source IP address equal to external_ip will be sent using the external_mac.
 
+	if natType == ovnnb.NATTypeDNATAndSNAT {
+		return c.addOrUpdateDnatAndSnat(lrName, externalIP, logicalIP, logicalMac, port, options)
+	}
+
 	nat, err := c.newNat(lrName, natType, externalIP, logicalIP, logicalMac, port, func(nat *ovnnb.NAT) {
 		if len(options) == 0 {
 			return
@@ -42,6 +46,46 @@ func (c *OVNNbClient) AddNat(lrName, natType, externalIP, logicalIP, logicalMac,
 		return err
 	}
 
+	return c.CreateNats(lrName, nat)
+}
+
+// addOrUpdateDnatAndSnat is the robust path for dnat_and_snat.
+// On EIP primary-pod swap we do a broad Delete (by externalIP) + fresh
+// Create. This avoids libovsdb cache staleness. We bypass newNat to skip
+// the stale "found, ignore".
+func (c *OVNNbClient) addOrUpdateDnatAndSnat(lrName, externalIP, logicalIP, logicalMac, port string, options map[string]string) error {
+	if externalIP == "" {
+		err := fmt.Errorf("external ip is required when nat type is %s", ovnnb.NATTypeDNATAndSNAT)
+		klog.Error(err)
+		return err
+	}
+
+	// Broad delete clears any previous row for this EIP (old logicalIP may differ).
+	if err := c.DeleteNat(lrName, ovnnb.NATTypeDNATAndSNAT, externalIP, ""); err != nil {
+		klog.Errorf("failed to clear prior dnat_and_snat external_ip=%s: %v", externalIP, err)
+		return err
+	}
+
+	// Fresh create, direct construction + CreateNats to bypass newNat's cache check.
+	nat := &ovnnb.NAT{
+		UUID:       ovsclient.NamedUUID(),
+		Type:       ovnnb.NATTypeDNATAndSNAT,
+		ExternalIP: externalIP,
+		LogicalIP:  logicalIP,
+	}
+	if logicalMac != "" {
+		nat.ExternalMAC = &logicalMac
+	}
+	if port != "" {
+		nat.LogicalPort = &port
+	}
+	if len(options) > 0 {
+		nat.Options = make(map[string]string, len(options))
+		maps.Copy(nat.Options, options)
+	}
+
+	klog.V(2).Infof("installing dnat_and_snat external_ip=%s logical_ip=%s logical_port=%s",
+		externalIP, logicalIP, port)
 	return c.CreateNats(lrName, nat)
 }
 
@@ -315,6 +359,18 @@ func (c *OVNNbClient) GetNat(lrName, natType, externalIP, logicalIP string, igno
 		}
 		if natType == ovnnb.NATTypeSNAT {
 			return nat.Type == natType && nat.LogicalIP == logicalIP
+		}
+		// For DNATAndSNAT: if logicalIP given, require externalIP+logicalIP.
+	// Prevents stale Delete (old logicalIP) from clobbering new row.
+	// Empty logicalIP keeps compat for Update/NatExists.
+		if natType == ovnnb.NATTypeDNATAndSNAT {
+			if nat.Type != natType || nat.ExternalIP != externalIP {
+				return false
+			}
+			if logicalIP != "" && nat.LogicalIP != logicalIP {
+				return false
+			}
+			return true
 		}
 		return nat.Type == natType && nat.ExternalIP == externalIP
 	}

--- a/pkg/ovs/ovn-nb-nat_test.go
+++ b/pkg/ovs/ovn-nb-nat_test.go
@@ -418,6 +418,123 @@ func (suite *OvnClientTestSuite) testDeleteNatIsIdempotent() {
 	require.NoError(t, nbClient.DeleteNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, logicalIP))
 }
 
+// testAddNatDeleteAndCreateOnSwap verifies that on EIP primary-pod swap
+// we end up with a fresh row for the new pod (different UUID) and no
+// leftover fields from the old pod.
+func (suite *OvnClientTestSuite) testAddNatDeleteAndCreateOnSwap() {
+	t := suite.T()
+	t.Parallel()
+	nbClient := suite.ovnNBClient
+	lrName := "test-lr-nat-swap-delete-create"
+	eip := "192.168.32.100"
+	podA := "10.16.0.20"
+	podB := "10.16.0.21"
+	macA := "00:00:00:aa:aa:01"
+	macB := "00:00:00:bb:bb:02"
+	portA := "pod-a-swap.ns"
+	portB := "pod-b-swap.ns"
+
+	require.NoError(t, nbClient.CreateLogicalRouter(lrName))
+	defer func() { _ = nbClient.DeleteLogicalRouter(lrName) }()
+
+	// Install A
+	require.NoError(t, nbClient.AddNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, podA, macA, portA, nil))
+	natA, err := nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, "", false)
+	require.NoError(t, err)
+	require.Equal(t, podA, natA.LogicalIP)
+	uuidA := natA.UUID
+
+	// Swap to B on same EIP: must create a fresh row
+	require.NoError(t, nbClient.AddNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, podB, macB, portB, nil))
+	natB, err := nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, "", false)
+	require.NoError(t, err)
+	require.Equal(t, podB, natB.LogicalIP, "LogicalIP must reflect B (no leftover A)")
+	require.NotNil(t, natB.LogicalPort)
+	require.Equal(t, portB, *natB.LogicalPort, "LogicalPort must reflect B")
+	require.NotNil(t, natB.ExternalMAC)
+	require.Equal(t, macB, *natB.ExternalMAC, "ExternalMAC must reflect B")
+	require.NotEqual(t, uuidA, natB.UUID, "must create a fresh row (UUID changed)")
+
+	// Idempotent re-add of B still produces correct row
+	require.NoError(t, nbClient.AddNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, podB, macB, portB, nil))
+	natB2, err := nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, "", false)
+	require.NoError(t, err)
+	require.Equal(t, podB, natB2.LogicalIP)
+	require.Equal(t, portB, *natB2.LogicalPort)
+}
+
+// testGetNatTupleMatchForDnatAndSnat ensures that when logicalIP is
+// supplied, GetNat only returns the row if both externalIP and logicalIP match.
+func (suite *OvnClientTestSuite) testGetNatTupleMatchForDnatAndSnat() {
+	t := suite.T()
+	t.Parallel()
+	nbClient := suite.ovnNBClient
+	lrName := "test-lr-nat-tuple"
+	eip := "192.168.33.100"
+	logicalIP := "10.16.0.30"
+	otherIP := "10.16.0.31"
+
+	require.NoError(t, nbClient.CreateLogicalRouter(lrName))
+	defer func() { _ = nbClient.DeleteLogicalRouter(lrName) }()
+
+	require.NoError(t, nbClient.AddNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, logicalIP, "00:00:00:cc:cc:01", "pod-c.ns", nil))
+
+	// exact match returns the row
+	nat, err := nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, logicalIP, true)
+	require.NoError(t, err)
+	require.NotNil(t, nat)
+	require.Equal(t, logicalIP, nat.LogicalIP)
+
+	// wrong logicalIP returns nil (even with ignoreNotFound)
+	nat, err = nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, otherIP, true)
+	require.NoError(t, err)
+	require.Nil(t, nat, "tuple mismatch must return nil")
+
+	// wrong logicalIP with ignoreNotFound=false returns error
+	_, err = nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, otherIP, false)
+	require.Error(t, err)
+
+	// empty logicalIP still does externalIP-only match (backward compat)
+	nat, err = nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, "", true)
+	require.NoError(t, err)
+	require.NotNil(t, nat)
+	require.Equal(t, logicalIP, nat.LogicalIP)
+}
+
+// testDeleteNatStaleLogicalIPSkipped ensures a DeleteNat carrying a stale
+// logicalIP does not wipe the current row for the same EIP.
+func (suite *OvnClientTestSuite) testDeleteNatStaleLogicalIPSkipped() {
+	t := suite.T()
+	t.Parallel()
+	nbClient := suite.ovnNBClient
+	lrName := "test-lr-nat-stale-delete"
+	eip := "192.168.34.100"
+	livePodIP := "10.16.0.40"
+	stalePodIP := "10.16.0.41"
+
+	require.NoError(t, nbClient.CreateLogicalRouter(lrName))
+	defer func() { _ = nbClient.DeleteLogicalRouter(lrName) }()
+
+	// Install live row
+	require.NoError(t, nbClient.AddNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, livePodIP, "00:00:00:dd:dd:01", "live-pod.ns", nil))
+
+	// Stale delete with wrong logicalIP must be a no-op
+	require.NoError(t, nbClient.DeleteNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, stalePodIP),
+		"stale DeleteNat with mismatched logicalIP must succeed as no-op")
+
+	// Live row must still be present
+	nat, err := nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, livePodIP, false)
+	require.NoError(t, err)
+	require.NotNil(t, nat)
+	require.Equal(t, livePodIP, nat.LogicalIP, "live row must survive stale delete")
+
+	// Proper delete with correct logicalIP removes it
+	require.NoError(t, nbClient.DeleteNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, livePodIP))
+	nat, err = nbClient.GetNat(lrName, ovnnb.NATTypeDNATAndSNAT, eip, "", true)
+	require.NoError(t, err)
+	require.Nil(t, nat)
+}
+
 func (suite *OvnClientTestSuite) testDeleteNats() {
 	t := suite.T()
 	t.Parallel()

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -921,6 +921,18 @@ func (suite *OvnClientTestSuite) Test_DeleteNatIsIdempotent() {
 	suite.testDeleteNatIsIdempotent()
 }
 
+func (suite *OvnClientTestSuite) Test_AddNatDeleteAndCreateOnSwap() {
+	suite.testAddNatDeleteAndCreateOnSwap()
+}
+
+func (suite *OvnClientTestSuite) Test_GetNatTupleMatchForDnatAndSnat() {
+	suite.testGetNatTupleMatchForDnatAndSnat()
+}
+
+func (suite *OvnClientTestSuite) Test_DeleteNatStaleLogicalIPSkipped() {
+	suite.testDeleteNatStaleLogicalIPSkipped()
+}
+
 func (suite *OvnClientTestSuite) Test_GetNat() {
 	suite.testGetNat()
 }


### PR DESCRIPTION
## Problem

When the primary pod for a `dnat_and_snat` EIP changes, previous `AddNat` paths could silently no-op due to libovsdb cache staleness right after a delete. This left the NAT rule either missing or pointing at the old pod.

## Solution

For `DNATAndSNAT` we now go through a dedicated path:

- Do a broad `DeleteNat` by `externalIP` only (#6911)
- Then do a fresh `CreateNats` (bypassing `newNat`)

Additionally, `GetNat` for `DNATAndSNAT` now does tuple matching: when `logicalIP` is supplied, both `externalIP` **and** `logicalIP` must match. This prevents a stale `DeleteNat` event (carrying an old `logicalIP`) from removing the newly installed row.

## Changes

- `AddNat` now dispatches `DNATAndSNAT` to `addOrUpdateDnatAndSnat`
- `addOrUpdateDnatAndSnat` always does Delete + fresh Create
- `GetNat` for `DNATAndSNAT` now supports tuple matching when `logicalIP` is provided
- Added regression tests for swap, tuple match, and stale-logicalIP protection

## Tests

New tests cover:
- Delete + Create on swap produces a fresh row with correct fields (UUID changes)
- Tuple match behavior in `GetNat`
- Stale `logicalIP` in `DeleteNat` is a no-op for the live row

This builds directly on the idempotent `DeleteNat` from #6911.