### PR TITLE
fix vpc egress local policy without bfd

### DIFF
--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -796,7 +796,7 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 		// update/delete existing policies
 		for _, policy := range policies {
 			nexthop := rules[policy.Match]
-			bfdSessions := set.New(bfdMap[nexthop]).Delete("")
+			bfdSessions := localGatewayPolicyBFDSessions(bfdMap, nexthop)
 			if nexthop == "" {
 				if err = c.OVNNbClient.DeleteLogicalRouterPolicyByUUID(lrName, policy.UUID); err != nil {
 					err = fmt.Errorf("failed to delete ovn lr policy %q: %w", policy.Match, err)
@@ -826,7 +826,7 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 		// create new policies
 		for match, nexthop := range rules {
 			if err = c.OVNNbClient.AddLogicalRouterPolicy(lrName, util.EgressGatewayLocalPolicyPriority, match,
-				ovnnb.LogicalRouterPolicyActionReroute, []string{nexthop}, []string{bfdMap[nexthop]}, externalIDs); err != nil {
+				ovnnb.LogicalRouterPolicyActionReroute, []string{nexthop}, localGatewayPolicyBFDSessions(bfdMap, nexthop).UnsortedList(), externalIDs); err != nil {
 				klog.Error(err)
 				return err
 			}
@@ -914,6 +914,10 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 	}
 
 	return nil
+}
+
+func localGatewayPolicyBFDSessions(bfdMap map[string]string, nexthop string) set.Set[string] {
+	return set.New(bfdMap[nexthop]).Delete("")
 }
 
 func mergeNodeSelector(nodeSelector []kubeovnv1.VpcEgressGatewayNodeSelector) *corev1.NodeSelector {

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/set"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
@@ -20,6 +21,11 @@ func TestVpcEgressGatewayContainerBFDDDefaultResources(t *testing.T) {
 	require.Equal(t, "50Mi", container.Resources.Limits.Memory().String())
 	ephemeralStorage := container.Resources.Limits[corev1.ResourceEphemeralStorage]
 	require.Equal(t, "1Gi", ephemeralStorage.String())
+}
+
+func TestLocalGatewayPolicyBFDSessionsSkipsEmptySession(t *testing.T) {
+	require.Empty(t, localGatewayPolicyBFDSessions(map[string]string{"10.244.10.4": ""}, "10.244.10.4"))
+	require.Equal(t, set.New("bfd-1"), localGatewayPolicyBFDSessions(map[string]string{"10.244.10.4": "bfd-1"}, "10.244.10.4"))
 }
 
 func newVegWorkloadPod(name, node, podIP, attachment string) *corev1.Pod {

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -274,10 +274,13 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		_ = subnetClient.CreateSync(externalSubnet)
 
 		vpcName := util.DefaultVpc
+		vpc := vpcClient.Get(vpcName)
+		ginkgo.By("Validating local traffic policy without BFD")
+		vegTest(f, false, provider, nadName, vpcName, vpc.Status.DefaultLogicalSwitch, externalSubnetName, replicas, nil)
+
 		cidr := framework.RandomCIDR(f.ClusterIPFamily)
 		bfdIP := framework.RandomIPs(cidr, ";", 1)
 		ginkgo.By("Enabling BFD Port with IP " + bfdIP + " for VPC " + vpcName)
-		vpc := vpcClient.Get(vpcName)
 		patchedVpc := vpc.DeepCopy()
 		patchedVpc.Spec.BFDPort = &apiv1.BFDPort{
 			Enabled: true,
@@ -744,12 +747,15 @@ func countUUIDs(output string) int {
 	return len(uuidRegexp.FindAllString(output, -1))
 }
 
-func checkEgressAccess(f *framework.Framework, namespaceName, svrPodName, image, svrPort string, svrIPs, extIPs []string, intIPs map[string][]string, subnetName, nodeName string, snat bool) {
+func checkEgressAccess(f *framework.Framework, namespaceName, svrPodName, image, svrPort string, svrIPs, extIPs []string, intIPs map[string][]string, subnetName, nodeName, snatLabelValue string, snat bool) {
 	ginkgo.GinkgoHelper()
 
 	podName := "pod-" + framework.RandomSuffix()
 	ginkgo.By("Creating client pod " + podName + " within subnet " + subnetName)
 	labels := map[string]string{"snat": strconv.FormatBool(snat)}
+	if snat {
+		labels["snat"] = snatLabelValue
+	}
 	annotations := map[string]string{util.LogicalSwitchAnnotation: subnetName}
 	pod := framework.MakePrivilegedPod(namespaceName, podName, labels, annotations, image, []string{"sleep", "infinity"}, nil)
 	pod.Spec.NodeName = nodeName
@@ -853,6 +859,7 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	}
 
 	vegName := "veg-" + framework.RandomSuffix()
+	snatLabelValue := vegName
 	veg := framework.MakeVpcEgressGateway(namespaceName, vegName, vpcName, replicas, internalSubnetName, externalSubnetName)
 	if rand.Int32N(2) == 0 {
 		veg.Spec.Prefix = fmt.Sprintf("e2e-%s-", framework.RandomSuffix())
@@ -887,7 +894,7 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 			},
 			PodSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"snat": strconv.FormatBool(true),
+					"snat": snatLabelValue,
 				},
 			},
 		}}
@@ -978,6 +985,6 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	if veg.Spec.TrafficPolicy == apiv1.TrafficPolicyLocal {
 		nodeName = veg.Status.Workload.Nodes[0]
 	}
-	checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, snatSubnetName, nodeName, true)
-	checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, forwardSubnetName, nodeName, false)
+	checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, snatSubnetName, nodeName, snatLabelValue, true)
+	checkEgressAccess(f, namespaceName, svrPodName, image, port, svrIPs, extIPs, intIPs, forwardSubnetName, nodeName, snatLabelValue, false)
 }


### PR DESCRIPTION
## Summary
- Filter empty BFD session IDs when creating Local VpcEgressGateway reroute policies.
- Add unit coverage for empty BFD sessions.
- Extend the VpcEgressGateway e2e path to cover default VPC Local traffic policy without BFD, with per-VEG SNAT selector isolation.

## Test Plan
- go test ./pkg/controller -run TestLocalGatewayPolicyBFDSessionsSkipsEmptySession
- go test ./test/e2e/vpc-egress-gateway -run '^$'
- make lint
- Manually verified the reproduced kind VEG changes from false/Processing to true/Completed after the fix.
