### PR TITLE
feat: rotate kube-ovn TLS certificates (backport to release-1.16)

### DIFF
--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -172,6 +172,8 @@ spec:
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.enableSsl }}"
+            - name: KUBE_OVN_TLS_ROTATION_INTERVAL
+              value: "{{ .Values.networking.kubeOvnTlsRotationInterval }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
+++ b/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
@@ -237,6 +237,14 @@ rules:
       - get
       - create
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - kube-ovn-tls
+    verbs:
+      - update
+  - apiGroups:
       - certificates.k8s.io
     resourceNames:
       - kubeovn.io/signer

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -137,6 +137,9 @@ networking:
   # -- Deploy the CNI with SSL encryption in between components.
   # @section -- Network parameters of the CNI
   enableSsl: false
+  # -- How often kube-ovn-controller checks kube-ovn-tls for renewal. Set to 0 to disable.
+  # @section -- Network parameters of the CNI
+  kubeOvnTlsRotationInterval: "8760h"
   # -- Network type can be "geneve" or "vlan".
   # @section -- Network parameters of the CNI
   networkType: geneve

--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -64,6 +64,18 @@ Number of master nodes
 {{- end -}}
 
 {{/*
+Kube-OVN TLS is owned by the management cluster in dataPlaneOnly installs.
+Disable local rotation there so a tenant cluster cannot replace the shared CA.
+*/}}
+{{- define "kubeovn.kubeOVNTLSRotationInterval" -}}
+{{- if eq .Values.installMode "dataPlaneOnly" -}}
+0
+{{- else -}}
+{{ .Values.networking.KUBE_OVN_TLS_ROTATION_INTERVAL }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Determine the updateStrategy type for the ovs-ovn DaemonSet.
 If ovs-ovn.updateStrategy.type is set, use it directly.
 Otherwise, auto-detect based on the currently deployed DaemonSet.

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -163,6 +163,8 @@ spec:
           env:
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"
+            - name: KUBE_OVN_TLS_ROTATION_INTERVAL
+              value: "{{ include "kubeovn.kubeOVNTLSRotationInterval" . }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -237,6 +237,14 @@ rules:
     - get
     - create
   - apiGroups:
+    - ""
+    resources:
+    - secrets
+    resourceNames:
+    - kube-ovn-tls
+    verbs:
+    - update
+  - apiGroups:
     - certificates.k8s.io
     resourceNames:
     - kubeovn.io/signer

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -25,6 +25,7 @@ networking:
   # NET_STACK could be dual_stack, ipv4, ipv6
   NET_STACK: ipv4
   ENABLE_SSL: false
+  KUBE_OVN_TLS_ROTATION_INTERVAL: "8760h"
   # network type could be geneve or vlan
   NETWORK_TYPE: geneve
   # tunnel type could be geneve, vxlan or stt

--- a/cmd/frr/frr.go
+++ b/cmd/frr/frr.go
@@ -28,7 +28,7 @@ type Config struct {
 	VNI           string
 	RouteTargets  []string
 	EnableEVPN    bool
-	Password      string
+	Password      string //nolint:gosec // BGP password is runtime configuration, not a hardcoded secret.
 	HoldTime      string
 	KeepaliveTime string
 	ConnectTime   string

--- a/cmd/ovn_ic_controller/ovn_ic_controller.go
+++ b/cmd/ovn_ic_controller/ovn_ic_controller.go
@@ -32,7 +32,8 @@ func CmdMain() {
 	}
 	util.InitLogFilePerm("kube-ovn-ic-controller", os.FileMode(logFilePerm))
 
-	stopCh := signals.SetupSignalHandler().Done()
+	ctx := signals.SetupSignalHandler()
+	stopCh := ctx.Done()
 	ctl := ovn_ic_controller.NewController(config)
 	ctl.Run(stopCh)
 }

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -8,6 +8,7 @@ DEL_NON_HOST_NET_POD=${DEL_NON_HOST_NET_POD:-true}
 IPV6=${IPV6:-false}
 DUAL_STACK=${DUAL_STACK:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
+KUBE_OVN_TLS_ROTATION_INTERVAL=${KUBE_OVN_TLS_ROTATION_INTERVAL:-8760h}
 ENABLE_VLAN=${ENABLE_VLAN:-false}
 CHECK_GATEWAY=${CHECK_GATEWAY:-true}
 LOGICAL_GATEWAY=${LOGICAL_GATEWAY:-false}
@@ -6792,6 +6793,14 @@ rules:
     - get
     - create
   - apiGroups:
+    - ""
+    resourceNames:
+    - kube-ovn-tls
+    resources:
+    - secrets
+    verbs:
+    - update
+  - apiGroups:
     - certificates.k8s.io
     resourceNames:
     - kubeovn.io/signer
@@ -7840,6 +7849,8 @@ spec:
           env:
             - name: ENABLE_SSL
               value: "$ENABLE_SSL"
+            - name: KUBE_OVN_TLS_ROTATION_INTERVAL
+              value: "$KUBE_OVN_TLS_ROTATION_INTERVAL"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/dist/images/kube-ovn-tls-reload.sh
+++ b/dist/images/kube-ovn-tls-reload.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+set -uo pipefail
+
+COMPONENT=${1:-}
+MODE=${2:-loop}
+ENABLE_SSL=${ENABLE_SSL:-false}
+TLS_RELOAD_INTERVAL=${TLS_RELOAD_INTERVAL:-5}
+TLS_DIR=${TLS_DIR:-/var/run/tls}
+TLS_FILES=(
+  "${TLS_DIR}/cacert"
+  "${TLS_DIR}/cert"
+  "${TLS_DIR}/key"
+)
+OVN_CTL=${OVN_CTL:-/usr/share/ovn/scripts/ovn-ctl}
+OVN_NB_CTL=${OVN_NB_CTL:-/var/run/ovn/ovnnb_db.ctl}
+OVN_SB_CTL=${OVN_SB_CTL:-/var/run/ovn/ovnsb_db.ctl}
+NB_PORT=${NB_PORT:-6641}
+SB_PORT=${SB_PORT:-6642}
+NB_CLUSTER_PORT=${NB_CLUSTER_PORT:-6643}
+SB_CLUSTER_PORT=${SB_CLUSTER_PORT:-6644}
+DB_CLUSTER_ADDR=${DB_CLUSTER_ADDR:-${POD_IP:-}}
+DB_ADDR=::
+if [[ "${ENABLE_BIND_LOCAL_IP:-false}" == "true" ]]; then
+  DB_ADDR=${POD_IP:-}
+fi
+SSL_OPTIONS="-p ${TLS_DIR}/key -c ${TLS_DIR}/cert -C ${TLS_DIR}/cacert"
+
+case "$COMPONENT" in
+  ovs)
+    TLS_HASH_FILE=${TLS_HASH_FILE:-/tmp/kube-ovn-tls.hash}
+    ;;
+  ovn-central)
+    TLS_HASH_FILE=${TLS_HASH_FILE:-/tmp/kube-ovn-central-tls.hash}
+    ;;
+  *)
+    echo "usage: $0 {ovs|ovn-central} [once|loop]"
+    exit 1
+    ;;
+esac
+TLS_LOCK_FILE=${TLS_LOCK_FILE:-${TLS_HASH_FILE}.lock}
+
+function tls_files_hash {
+  for file in "${TLS_FILES[@]}"; do
+    if [[ ! -s "$file" ]]; then
+      echo "kube-ovn TLS file $file is missing or empty" >&2
+      return 1
+    fi
+  done
+  sha256sum "${TLS_FILES[@]}" | sha256sum | awk '{print $1}'
+}
+
+function write_tls_hash {
+  local hash=$1
+  local tmp_file
+  tmp_file="${TLS_HASH_FILE}.$$"
+  printf "%s" "$hash" > "$tmp_file"
+  mv -f "$tmp_file" "$TLS_HASH_FILE"
+}
+
+function reload_ovs_tls {
+  echo "kube-ovn TLS files changed, restarting ovn-controller"
+  /usr/share/ovn/scripts/ovn-ctl \
+    --ovn-controller-ssl-key="${TLS_DIR}/key" \
+    --ovn-controller-ssl-cert="${TLS_DIR}/cert" \
+    --ovn-controller-ssl-ca-cert="${TLS_DIR}/cacert" \
+    --ovn-controller-wrapper="${DEBUG_WRAPPER:-}" \
+    restart_controller
+}
+
+function ovn_central_conn_addr {
+  local ip=$1
+  local port=$2
+
+  echo "ssl:[${ip}]:${port}"
+}
+
+function ovn_central_conn_str {
+  local port=$1
+  local endpoints=()
+
+  for ip in ${NODE_IPS//,/ }; do
+    endpoints+=("$(ovn_central_conn_addr "$ip" "$port")")
+  done
+  local IFS=,
+  echo "${endpoints[*]}"
+}
+
+function ovn_central_ssl_args {
+  printf "%s\n" \
+    "--ovn-nb-db-ssl-key=${TLS_DIR}/key" \
+    "--ovn-nb-db-ssl-cert=${TLS_DIR}/cert" \
+    "--ovn-nb-db-ssl-ca-cert=${TLS_DIR}/cacert" \
+    "--ovn-sb-db-ssl-key=${TLS_DIR}/key" \
+    "--ovn-sb-db-ssl-cert=${TLS_DIR}/cert" \
+    "--ovn-sb-db-ssl-ca-cert=${TLS_DIR}/cacert" \
+    "--ovn-northd-ssl-key=${TLS_DIR}/key" \
+    "--ovn-northd-ssl-cert=${TLS_DIR}/cert" \
+    "--ovn-northd-ssl-ca-cert=${TLS_DIR}/cacert"
+}
+
+function wait_ovn_ctl_status {
+  local status_cmd=$1
+
+  for _ in $(seq 1 30); do
+    if "$OVN_CTL" "$status_cmd" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+function reload_ovsdb_server_tls {
+  local ctl=$1
+
+  ovn-appctl -t "$ctl" ovsdb-server/set-ssl "${TLS_DIR}/key" "${TLS_DIR}/cert" "${TLS_DIR}/cacert"
+  ovn-appctl -t "$ctl" ovsdb-server/reconnect
+}
+
+function reload_ovn_central_ovsdb_tls {
+  reload_ovsdb_server_tls "$OVN_NB_CTL"
+  reload_ovsdb_server_tls "$OVN_SB_CTL"
+}
+
+function ovn_ctl_restart_or_status {
+  local status_cmd=$1
+  shift
+
+  if "$OVN_CTL" "$@"; then
+    return 0
+  fi
+
+  echo "ovn-ctl $* failed, checking ${status_cmd} before retrying" >&2
+  wait_ovn_ctl_status "$status_cmd"
+}
+
+function restart_standalone_ovn_central_tls {
+  local ssl_args
+  mapfile -t ssl_args < <(ovn_central_ssl_args)
+  ovn_ctl_restart_or_status status_northd "${ssl_args[@]}" --ovn-northd-n-threads="${OVN_NORTHD_N_THREADS:-1}" restart_northd
+}
+
+function restart_clustered_ovn_northd_tls {
+  if [[ -z "$DB_CLUSTER_ADDR" || -z "$DB_ADDR" ]]; then
+    echo "failed to determine local OVN DB address" >&2
+    return 1
+  fi
+
+  local ovn_ctl_args
+  mapfile -t ovn_ctl_args < <(ovn_central_ssl_args)
+  ovn_ctl_args+=(
+    "--ovn-northd-nb-db=$(ovn_central_conn_str "$NB_PORT")"
+    "--ovn-northd-sb-db=$(ovn_central_conn_str "$SB_PORT")"
+  )
+
+  ovn_ctl_restart_or_status status_northd "${ovn_ctl_args[@]}" \
+    --ovn-manage-ovsdb=no \
+    --ovn-northd-n-threads="${OVN_NORTHD_N_THREADS:-1}" \
+    restart_northd
+}
+
+function reload_ovn_central_tls {
+  echo "kube-ovn TLS files changed, reloading ovn-central TLS"
+  reload_ovn_central_ovsdb_tls || return 1
+
+  if [[ -z "${NODE_IPS:-}" ]]; then
+    restart_standalone_ovn_central_tls
+    return $?
+  fi
+  restart_clustered_ovn_northd_tls
+}
+
+function reload_tls {
+  case "$COMPONENT" in
+    ovs)
+      reload_ovs_tls
+      ;;
+    ovn-central)
+      reload_ovn_central_tls
+      ;;
+  esac
+}
+
+function check_tls_once {
+  if [[ "$ENABLE_SSL" != "true" ]]; then
+    return 0
+  fi
+
+  local lock_fd
+  exec {lock_fd}>"$TLS_LOCK_FILE"
+  if ! flock -n "$lock_fd"; then
+    exec {lock_fd}>&-
+    return 0
+  fi
+
+  local current_hash
+  current_hash=$(tls_files_hash) || {
+    exec {lock_fd}>&-
+    return 1
+  }
+  if [[ ! -f "$TLS_HASH_FILE" ]]; then
+    write_tls_hash "$current_hash"
+    exec {lock_fd}>&-
+    return 0
+  fi
+
+  local previous_hash
+  previous_hash=$(cat "$TLS_HASH_FILE" 2>/dev/null || true)
+  if [[ "$current_hash" == "$previous_hash" ]]; then
+    exec {lock_fd}>&-
+    return 0
+  fi
+
+  # Keep the parent lock during reload, but do not let restarted daemons inherit it.
+  if (exec {lock_fd}>&-; reload_tls); then
+    write_tls_hash "$current_hash"
+    exec {lock_fd}>&-
+    return 0
+  fi
+
+  exec {lock_fd}>&-
+  echo "failed to reload kube-ovn TLS files, will retry" >&2
+  return 1
+}
+
+if [[ "$MODE" == "once" ]]; then
+  check_tls_once
+  exit $?
+fi
+
+while true; do
+  check_tls_once || true
+  sleep "$TLS_RELOAD_INTERVAL"
+done

--- a/dist/images/ovn-healthcheck.sh
+++ b/dist/images/ovn-healthcheck.sh
@@ -4,6 +4,8 @@ shopt -s expand_aliases
 
 alias ovn-ctl='/usr/share/ovn/scripts/ovn-ctl'
 
+ENABLE_SSL=${ENABLE_SSL:-false}
+
 ovn-ctl status_northd
 ovn-ctl status_ovnnb | grep -q '^running'
 ovn-ctl status_ovnsb | grep -q '^running'

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -567,6 +567,10 @@ fi
 ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/memory-trim-on-compaction on
 ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/memory-trim-on-compaction on
 
+if [[ "$ENABLE_SSL" == "true" ]]; then
+    bash /kube-ovn/kube-ovn-tls-reload.sh ovn-central &
+fi
+
 chmod 600 /etc/ovn/*
 /kube-ovn/kube-ovn-leader-checker \
     --probeInterval=${OVN_LEADER_PROBE_INTERVAL} \

--- a/dist/images/start-ovs-dpdk-v2.sh
+++ b/dist/images/start-ovs-dpdk-v2.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 OVN_REMOTE_PROBE_INTERVAL=${OVN_REMOTE_PROBE_INTERVAL:-10000}
 OVN_REMOTE_OPENFLOW_INTERVAL=${OVN_REMOTE_OPENFLOW_INTERVAL:-180}
+ENABLE_SSL=${ENABLE_SSL:-false}
 
 echo "OVN_REMOTE_PROBE_INTERVAL is set to $OVN_REMOTE_PROBE_INTERVAL"
 echo "OVN_REMOTE_OPENFLOW_INTERVAL is set to $OVN_REMOTE_OPENFLOW_INTERVAL"
@@ -125,13 +126,22 @@ ovs-vsctl --may-exist add-br br-int \
   -- set bridge br-int fail-mode=secure
 
 # Set remote ovn-sb for ovn-controller to connect to
-ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
+if [[ "$ENABLE_SSL" == "true" ]]; then
+  ovs-vsctl set open . external-ids:ovn-remote=ssl:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
+else
+  ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
+fi
 ovs-vsctl set open . external-ids:ovn-remote-probe-interval="${OVN_REMOTE_PROBE_INTERVAL}"
 ovs-vsctl set open . external-ids:ovn-openflow-probe-interval="${OVN_REMOTE_OPENFLOW_INTERVAL}"
 ovs-vsctl set open . external-ids:ovn-match-northd-version="true"
 ovs-vsctl set open . external-ids:ovn-encap-type="${TUNNEL_TYPE}"
 
 # Start ovn-controller
-ovn-ctl restart_controller
+if [[ "$ENABLE_SSL" == "true" ]]; then
+  ovn-ctl --ovn-controller-ssl-key=/var/run/tls/key --ovn-controller-ssl-cert=/var/run/tls/cert --ovn-controller-ssl-ca-cert=/var/run/tls/cacert restart_controller
+  bash /kube-ovn/kube-ovn-tls-reload.sh ovs &
+else
+  ovn-ctl restart_controller
+fi
 
 tail --follow=name --retry /var/log/openvswitch/ovs-vswitchd.log

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -152,6 +152,7 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
   /usr/share/ovn/scripts/ovn-ctl --ovn-controller-wrapper="$DEBUG_WRAPPER" restart_controller
 else
   /usr/share/ovn/scripts/ovn-ctl --ovn-controller-ssl-key=/var/run/tls/key --ovn-controller-ssl-cert=/var/run/tls/cert --ovn-controller-ssl-ca-cert=/var/run/tls/cacert --ovn-controller-wrapper="$DEBUG_WRAPPER" restart_controller
+  bash /kube-ovn/kube-ovn-tls-reload.sh ovs &
 fi
 
 chmod 600 /etc/openvswitch/*

--- a/pkg/apis/kubeovn/v1/bgp_conf.go
+++ b/pkg/apis/kubeovn/v1/bgp_conf.go
@@ -27,7 +27,7 @@ type BgpConfSpec struct {
 	PeerASN       uint32          `json:"peerASN"`
 	RouterID      string          `json:"routerId,omitempty"`
 	Neighbours    []string        `json:"neighbours"`
-	Password      string          `json:"password,omitempty"`
+	Password      string          `json:"password,omitempty"` //nolint:gosec // BGP password is runtime configuration, not a hardcoded secret.
 	HoldTime      metav1.Duration `json:"holdTime,omitempty"`
 	KeepaliveTime metav1.Duration `json:"keepaliveTime,omitempty"`
 	ConnectTime   metav1.Duration `json:"connectTime,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1098,6 +1098,8 @@ func (c *Controller) Run(ctx context.Context) {
 		}
 	}
 
+	c.startKubeOVNTLSManager(ctx)
+
 	// start workers to do all the network operations
 	c.startWorkers(ctx)
 

--- a/pkg/controller/kube_ovn_tls.go
+++ b/pkg/controller/kube_ovn_tls.go
@@ -1,0 +1,201 @@
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+const (
+	kubeOVNTLSSecretName              = "kube-ovn-tls" // #nosec G101 -- Kubernetes Secret resource name, not a credential.
+	kubeOVNTLSDefaultRotationInterval = 365 * 24 * time.Hour
+	kubeOVNTLSCADuration              = 10 * 365 * 24 * time.Hour
+	kubeOVNTLSCertDuration            = 10 * 365 * 24 * time.Hour
+	kubeOVNTLSCommonName              = "ovn"
+
+	kubeOVNTLSCertHashAnnotation = "kube-ovn.io/kube-ovn-tls-cert-hash"
+)
+
+func (c *Controller) startKubeOVNTLSManager(ctx context.Context) {
+	if os.Getenv(util.EnvSSLEnabled) != "true" {
+		return
+	}
+	interval, err := kubeOVNTLSRotationInterval()
+	if err != nil {
+		klog.Errorf("failed to parse kube-ovn TLS rotation interval: %v", err)
+		return
+	}
+	if interval <= 0 {
+		return
+	}
+
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		if err := c.reconcileKubeOVNTLS(ctx); err != nil {
+			klog.Errorf("failed to reconcile kube-ovn TLS secret: %v", err)
+		}
+	}, interval)
+}
+
+func kubeOVNTLSRotationInterval() (time.Duration, error) {
+	value := strings.TrimSpace(os.Getenv(util.EnvKubeOVNTLSRotationInterval))
+	if value == "" {
+		return kubeOVNTLSDefaultRotationInterval, nil
+	}
+	interval, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s=%q: %w", util.EnvKubeOVNTLSRotationInterval, value, err)
+	}
+	return interval, nil
+}
+
+func (c *Controller) reconcileKubeOVNTLS(ctx context.Context) error {
+	secret, err := c.config.KubeClient.CoreV1().Secrets(c.config.PodNamespace).Get(ctx, kubeOVNTLSSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		data, hash, genErr := generateKubeOVNTLSData(time.Now(), kubeOVNTLSCADuration, kubeOVNTLSCertDuration)
+		if genErr != nil {
+			return genErr
+		}
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kubeOVNTLSSecretName,
+				Namespace: c.config.PodNamespace,
+				Annotations: map[string]string{
+					kubeOVNTLSCertHashAnnotation: hash,
+				},
+			},
+			Data: data,
+		}
+		if _, err = c.config.KubeClient.CoreV1().Secrets(c.config.PodNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// kube-ovn-tls keeps the legacy cacert/cert/key schema. The manager only
+	// adds metadata on first adoption so upgrades do not restart OVN workloads.
+	hash, err := kubeOVNTLSHash(secret.Data)
+	if err != nil {
+		return err
+	}
+
+	if secret.Annotations[kubeOVNTLSCertHashAnnotation] != hash {
+		if err = c.setKubeOVNTLSHash(ctx, hash); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	renew, err := kubeOVNTLSNeedsRenewal(time.Now(), secret.Data)
+	if err != nil {
+		return err
+	}
+	if renew {
+		data, newHash, genErr := generateKubeOVNTLSData(time.Now(), kubeOVNTLSCADuration, kubeOVNTLSCertDuration)
+		if genErr != nil {
+			return genErr
+		}
+		if err = c.updateKubeOVNTLSSecretData(ctx, data, newHash); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func kubeOVNTLSNeedsRenewal(now time.Time, data map[string][]byte) (bool, error) {
+	cert, err := parseKubeOVNTLSCert(data)
+	if err != nil {
+		return false, err
+	}
+	refreshTime := cert.NotBefore.Add(cert.NotAfter.Sub(cert.NotBefore) / 2)
+	return !now.Before(refreshTime), nil
+}
+
+func parseKubeOVNTLSCert(data map[string][]byte) (*x509.Certificate, error) {
+	cert, err := decodeCertificate(data["cert"])
+	if err != nil {
+		return nil, fmt.Errorf("parse kube-ovn-tls cert: %w", err)
+	}
+	return cert, nil
+}
+
+func generateKubeOVNTLSData(now time.Time, caDuration, certDuration time.Duration) (map[string][]byte, string, error) {
+	data, err := util.GenerateKubeOVNTLSSecretData(now, caDuration, certDuration, kubeOVNTLSCommonName)
+	if err != nil {
+		return nil, "", err
+	}
+	hash, err := kubeOVNTLSHash(data)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, hash, nil
+}
+
+func kubeOVNTLSHash(data map[string][]byte) (string, error) {
+	for _, key := range []string{"cacert", "cert", "key"} {
+		if len(data[key]) == 0 {
+			return "", fmt.Errorf("kube-ovn-tls missing %s", key)
+		}
+	}
+	h := sha256.New()
+	for _, key := range []string{"cacert", "cert", "key"} {
+		h.Write([]byte(key))
+		h.Write([]byte{0})
+		h.Write(data[key])
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (c *Controller) updateKubeOVNTLSSecretData(ctx context.Context, data map[string][]byte, hash string) error {
+	secrets := c.config.KubeClient.CoreV1().Secrets(c.config.PodNamespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := secrets.Get(ctx, kubeOVNTLSSecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		secret = secret.DeepCopy()
+		secret.Data = data
+		setKubeOVNTLSAnnotation(secret, kubeOVNTLSCertHashAnnotation, hash)
+		_, err = secrets.Update(ctx, secret, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func (c *Controller) setKubeOVNTLSHash(ctx context.Context, hash string) error {
+	secrets := c.config.KubeClient.CoreV1().Secrets(c.config.PodNamespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := secrets.Get(ctx, kubeOVNTLSSecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		secret = secret.DeepCopy()
+		setKubeOVNTLSAnnotation(secret, kubeOVNTLSCertHashAnnotation, hash)
+		_, err = secrets.Update(ctx, secret, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func setKubeOVNTLSAnnotation(secret *corev1.Secret, key, value string) {
+	if secret.Annotations == nil {
+		secret.Annotations = map[string]string{}
+	}
+	secret.Annotations[key] = value
+}

--- a/pkg/controller/kube_ovn_tls_test.go
+++ b/pkg/controller/kube_ovn_tls_test.go
@@ -1,0 +1,211 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"slices"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestReconcileKubeOVNTLSAddsBaselineAnnotation(t *testing.T) {
+	const namespace = "kube-system"
+	data, hash, err := generateKubeOVNTLSData(time.Now(), kubeOVNTLSCADuration, kubeOVNTLSCertDuration)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+	client := fake.NewSimpleClientset(
+		testKubeOVNTLSSecret(namespace, data, nil),
+	)
+	c := &Controller{config: &Configuration{KubeClient: client, PodNamespace: namespace}}
+
+	if err = c.reconcileKubeOVNTLS(context.Background()); err != nil {
+		t.Fatalf("reconcileKubeOVNTLS returned error: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), kubeOVNTLSSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get kube-ovn-tls secret: %v", err)
+	}
+	if got := secret.Annotations[kubeOVNTLSCertHashAnnotation]; got != hash {
+		t.Fatalf("cert hash annotation = %q, want %q", got, hash)
+	}
+}
+
+func TestReconcileKubeOVNTLSOnlyAdoptsExpiredLegacySecret(t *testing.T) {
+	const namespace = "kube-system"
+	expiredData, hash, err := generateKubeOVNTLSData(time.Now().Add(-20*24*time.Hour), 10*24*time.Hour, 10*24*time.Hour)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+	client := fake.NewSimpleClientset(
+		testKubeOVNTLSSecret(namespace, expiredData, nil),
+	)
+	c := &Controller{config: &Configuration{KubeClient: client, PodNamespace: namespace}}
+
+	if err = c.reconcileKubeOVNTLS(context.Background()); err != nil {
+		t.Fatalf("reconcileKubeOVNTLS returned error: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), kubeOVNTLSSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get kube-ovn-tls secret: %v", err)
+	}
+	if got := secret.Annotations[kubeOVNTLSCertHashAnnotation]; got != hash {
+		t.Fatalf("cert hash annotation = %q, want %q", got, hash)
+	}
+	assertSecretDataEqual(t, secret.Data, expiredData)
+}
+
+func TestReconcileKubeOVNTLSRotatesExpiredSecret(t *testing.T) {
+	const namespace = "kube-system"
+	expiredData, oldHash, err := generateKubeOVNTLSData(time.Now().Add(-20*24*time.Hour), 10*24*time.Hour, 10*24*time.Hour)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+	client := fake.NewSimpleClientset(
+		testKubeOVNTLSSecret(namespace, expiredData, map[string]string{
+			kubeOVNTLSCertHashAnnotation: oldHash,
+		}),
+	)
+	c := &Controller{config: &Configuration{KubeClient: client, PodNamespace: namespace}}
+
+	if err = c.reconcileKubeOVNTLS(context.Background()); err != nil {
+		t.Fatalf("reconcileKubeOVNTLS returned error: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), kubeOVNTLSSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get kube-ovn-tls secret: %v", err)
+	}
+	newHash := secret.Annotations[kubeOVNTLSCertHashAnnotation]
+	if newHash == "" || newHash == oldHash {
+		t.Fatalf("cert hash annotation = %q, want non-empty value different from %q", newHash, oldHash)
+	}
+}
+
+func TestGenerateKubeOVNTLSDataAddsServingAndClientIdentity(t *testing.T) {
+	data, _, err := generateKubeOVNTLSData(time.Now(), kubeOVNTLSCADuration, kubeOVNTLSCertDuration)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+
+	cert, err := parseKubeOVNTLSCert(data)
+	if err != nil {
+		t.Fatalf("parseKubeOVNTLSCert returned error: %v", err)
+	}
+
+	if !containsExtKeyUsage(cert.ExtKeyUsage, x509.ExtKeyUsageServerAuth) {
+		t.Fatalf("leaf certificate ExtKeyUsage = %v, want ServerAuth", cert.ExtKeyUsage)
+	}
+	if !containsExtKeyUsage(cert.ExtKeyUsage, x509.ExtKeyUsageClientAuth) {
+		t.Fatalf("leaf certificate ExtKeyUsage = %v, want ClientAuth", cert.ExtKeyUsage)
+	}
+	if !containsString(cert.DNSNames, kubeOVNTLSCommonName) {
+		t.Fatalf("leaf certificate DNSNames = %v, want %q", cert.DNSNames, kubeOVNTLSCommonName)
+	}
+}
+
+func TestStartKubeOVNTLSManagerPeriodicallyRotatesExpiredSecret(t *testing.T) {
+	const namespace = "kube-system"
+	expiredData, oldHash, err := generateKubeOVNTLSData(time.Now().Add(-20*24*time.Hour), 10*24*time.Hour, 10*24*time.Hour)
+	if err != nil {
+		t.Fatalf("generateKubeOVNTLSData returned error: %v", err)
+	}
+	client := fake.NewSimpleClientset(
+		testKubeOVNTLSSecret(namespace, expiredData, map[string]string{
+			kubeOVNTLSCertHashAnnotation: oldHash,
+		}),
+	)
+	c := &Controller{config: &Configuration{KubeClient: client, PodNamespace: namespace}}
+	t.Setenv(util.EnvSSLEnabled, "true")
+	t.Setenv(util.EnvKubeOVNTLSRotationInterval, "10ms")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	c.startKubeOVNTLSManager(ctx)
+
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		secret, err := client.CoreV1().Secrets(namespace).Get(ctx, kubeOVNTLSSecretName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		newHash, err := kubeOVNTLSHash(secret.Data)
+		if err != nil {
+			return false, err
+		}
+		return newHash != oldHash && secret.Annotations[kubeOVNTLSCertHashAnnotation] == newHash, nil
+	})
+	if err != nil {
+		t.Fatalf("startKubeOVNTLSManager did not rotate expired kube-ovn-tls secret: %v", err)
+	}
+}
+
+func TestKubeOVNTLSRotationInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "empty uses default", value: "", want: 365 * 24 * time.Hour},
+		{name: "zero disables rotation", value: "0", want: 0},
+		{name: "custom interval", value: "12h", want: 12 * time.Hour},
+		{name: "invalid interval", value: "bad", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KUBE_OVN_TLS_ROTATION_INTERVAL", tt.value)
+			got, err := kubeOVNTLSRotationInterval()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("kubeOVNTLSRotationInterval returned nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("kubeOVNTLSRotationInterval returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("interval = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func assertSecretDataEqual(t *testing.T, got, want map[string][]byte) {
+	t.Helper()
+	for _, key := range []string{"cacert", "cert", "key"} {
+		if !bytes.Equal(got[key], want[key]) {
+			t.Fatalf("secret data %s changed during adoption", key)
+		}
+	}
+}
+
+func containsExtKeyUsage(usages []x509.ExtKeyUsage, want x509.ExtKeyUsage) bool {
+	return slices.Contains(usages, want)
+}
+
+func containsString(values []string, want string) bool {
+	return slices.Contains(values, want)
+}
+
+func testKubeOVNTLSSecret(namespace string, data map[string][]byte, annotations map[string]string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        kubeOVNTLSSecretName,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Data: data,
+	}
+}

--- a/pkg/ovsdb/client/client.go
+++ b/pkg/ovsdb/client/client.go
@@ -86,22 +86,10 @@ func NewOvsDbClient(
 		backOff = bo
 	}
 	if ssl {
-		cert, err := tls.LoadX509KeyPair(util.SslCertPath, util.SslKeyPath)
+		tlsConfig, err := newKubeOVNTLSConfig()
 		if err != nil {
 			klog.Error(err)
-			return nil, fmt.Errorf("failed to load x509 cert key pair: %w", err)
-		}
-		caCert, err := os.ReadFile(util.SslCACert)
-		if err != nil {
-			klog.Error(err)
-			return nil, fmt.Errorf("failed to read ca cert: %w", err)
-		}
-		certPool := x509.NewCertPool()
-		certPool.AppendCertsFromPEM(caCert)
-		tlsConfig := &tls.Config{
-			Certificates:       []tls.Certificate{cert},
-			RootCAs:            certPool,
-			InsecureSkipVerify: true, // #nosec G402
+			return nil, err
 		}
 		options = append(options, client.WithTLSConfig(tlsConfig))
 	}
@@ -145,4 +133,25 @@ func NewOvsDbClient(
 	}
 
 	return c, nil
+}
+
+func newKubeOVNTLSConfig() (*tls.Config, error) {
+	caCert, err := os.ReadFile(util.SslCACert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ca cert: %w", err)
+	}
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(caCert)
+
+	return &tls.Config{
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(util.SslCertPath, util.SslKeyPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load x509 cert key pair: %w", err)
+			}
+			return &cert, nil
+		},
+		RootCAs:            certPool,
+		InsecureSkipVerify: true, // #nosec G402
+	}, nil
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -368,8 +368,9 @@ const (
 	EnvHostIP       = "HOST_IP"
 	EnvHostIPs      = "HOST_IPS"
 
-	EnvSSLEnabled  = "ENABLE_SSL"
-	EnvGatewayName = "GATEWAY_NAME"
+	EnvSSLEnabled                 = "ENABLE_SSL"
+	EnvKubeOVNTLSRotationInterval = "KUBE_OVN_TLS_ROTATION_INTERVAL"
+	EnvGatewayName                = "GATEWAY_NAME"
 )
 
 const (

--- a/pkg/util/kube_ovn_tls_cert.go
+++ b/pkg/util/kube_ovn_tls_cert.go
@@ -1,0 +1,119 @@
+package util
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+const kubeOVNTLSOrganization = "kube-ovn"
+
+// GenerateKubeOVNTLSSecretData returns the legacy cacert/cert/key Secret data
+// used by OVN components.
+func GenerateKubeOVNTLSSecretData(now time.Time, caDuration, certDuration time.Duration, commonName string) (map[string][]byte, error) {
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generate kube-ovn-tls CA key: %w", err)
+	}
+	caSerial, err := newCertificateSerialNumber()
+	if err != nil {
+		return nil, err
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber: caSerial,
+		Subject: pkix.Name{
+			CommonName:   commonName + "-ca",
+			Organization: []string{kubeOVNTLSOrganization},
+		},
+		NotBefore:             now.Add(-time.Second),
+		NotAfter:              now.Add(caDuration),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCert, err := createCertificate(caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("create kube-ovn-tls CA certificate: %w", err)
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generate kube-ovn-tls key: %w", err)
+	}
+	serial, err := newCertificateSerialNumber()
+	if err != nil {
+		return nil, err
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{kubeOVNTLSOrganization},
+		},
+		NotBefore:             now.Add(-time.Second),
+		NotAfter:              now.Add(certDuration),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:              []string{commonName},
+		BasicConstraintsValid: true,
+	}
+	cert, err := createCertificate(template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("create kube-ovn-tls certificate: %w", err)
+	}
+
+	caCertPEM, err := encodeCertificates(caCert)
+	if err != nil {
+		return nil, fmt.Errorf("encode kube-ovn-tls CA certificate: %w", err)
+	}
+	certPEM, err := encodeCertificates(cert)
+	if err != nil {
+		return nil, fmt.Errorf("encode kube-ovn-tls certificate: %w", err)
+	}
+
+	return map[string][]byte{
+		"cacert": caCertPEM,
+		"cert":   certPEM,
+		"key":    encodeRSAPrivateKeyPEM(key),
+	}, nil
+}
+
+func newCertificateSerialNumber() (*big.Int, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generate serial number: %w", err)
+	}
+	return serial, nil
+}
+
+func createCertificate(template, issuer *x509.Certificate, publicKey, issuerKey any) (*x509.Certificate, error) {
+	der, err := x509.CreateCertificate(rand.Reader, template, issuer, publicKey, issuerKey)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse generated certificate: %w", err)
+	}
+	return cert, nil
+}
+
+func encodeCertificates(certs ...*x509.Certificate) ([]byte, error) {
+	b := bytes.Buffer{}
+	for _, cert := range certs {
+		if err := pem.Encode(&b, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+			return nil, err
+		}
+	}
+	return b.Bytes(), nil
+}
+
+func encodeRSAPrivateKeyPEM(key *rsa.PrivateKey) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+}


### PR DESCRIPTION
Backport of TLS certificate rotation feature from feat/kube-ovn-tls-rotation to release-1.16.

**Changes:**
- Add kube-ovn TLS certificate rotation controller
- Add TLS reload script for runtime certificate updates
- Add E2E tests for TLS rotation
- Add Helm chart values for TLS rotation interval

**Conflicts resolved:**
- `charts/kube-ovn/templates/_helpers.tpl`: merged only TLS-specific helper `kubeovn.kubeOVNTLSRotationInterval`

Signed-off-by: clyi <clyi@alauda.io>