### PR TITLE
feat: load BGP speaker parameters from yaml config file

### DIFF
--- a/charts/kube-ovn-v2/README.md
+++ b/charts/kube-ovn-v2/README.md
@@ -523,6 +523,24 @@ false
 			<td>Args passed to the kube-ovn-speaker pod.</td>
 		</tr>
 		<tr>
+			<td>bgpSpeaker.configMap</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>The name of the configMap that will be mounted in the kube-ovn-speaker pod. The ConfigMap can provide YAML configuration files for kube-ovn-speaker. To use a specific file, pass its mounted file path via '--config' or set 'KUBE_OVN_BGP_SPEAKER_CONFIG_FILE'.</td>
+		</tr>
+		<tr>
+			<td>bgpSpeaker.configMapMountPath</td>
+			<td>string</td>
+			<td><pre lang="json">
+"/etc/kube-ovn/"
+</pre>
+</td>
+			<td>Directory where the ConfigMap will be mounted in the kube-ovn-speaker pod.</td>
+		</tr>
+		<tr>
 			<td>bgpSpeaker.enabled</td>
 			<td>bool</td>
 			<td><pre lang="json">
@@ -530,15 +548,6 @@ false
 </pre>
 </td>
 			<td>Enable the kube-ovn-speaker.</td>
-		</tr>
-		<tr>
-			<td>bgpSpeaker.extraEnv</td>
-			<td>list</td>
-			<td><pre lang="json">
-[]
-</pre>
-</td>
-			<td>Extra environment variables to be added to kube-ovn-speaker pods.</td>
 		</tr>
 		<tr>
 			<td>bgpSpeaker.labels</td>

--- a/charts/kube-ovn-v2/templates/speaker/speaker.yaml
+++ b/charts/kube-ovn-v2/templates/speaker/speaker.yaml
@@ -108,6 +108,10 @@ spec:
               add:
                 - NET_BIND_SERVICE
           volumeMounts:
+            {{- if .Values.bgpSpeaker.configMap }}
+            - mountPath: {{ .Values.bgpSpeaker.configMapMountPath }}
+              name: kube-ovn-bgp-speaker-config
+            {{- end }}
             - mountPath: /var/log/kube-ovn
               name: kube-ovn-log
       {{- with .Values.bgpSpeaker.nodeSelector }}
@@ -115,6 +119,11 @@ spec:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if .Values.bgpSpeaker.configMap }}
+        - name: kube-ovn-bgp-speaker-config
+          configMap:
+            name: {{ .Values.bgpSpeaker.configMap }}
+        {{- end }}
         - name: kube-ovn-log
           hostPath:
             path: {{ .Values.logging.directory }}/kube-ovn

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -667,6 +667,15 @@ bgpSpeaker:
   # @section -- BGP speaker configuration
   podLabels: {}
 
+  # -- The name of the configMap that will be mounted in the kube-ovn-speaker pod.
+  # The ConfigMap can provide YAML configuration files for kube-ovn-speaker.
+  # To use a specific file, pass its mounted file path via '--config' or set 'KUBE_OVN_BGP_SPEAKER_CONFIG_FILE'.
+  # @section -- BGP speaker configuration
+  configMap: ""
+  # -- Directory where the ConfigMap will be mounted in the kube-ovn-speaker pod.
+  # @section -- BGP speaker configuration
+  configMapMountPath: "/etc/kube-ovn/"
+
   # -- Extra environment variables to be added to kube-ovn-speaker pods.
   # @section -- BGP speaker configuration
   extraEnv: []

--- a/cmd/speaker/speaker.go
+++ b/cmd/speaker/speaker.go
@@ -28,7 +28,7 @@ func CmdMain() {
 	}
 
 	// Do not try to redirect the logs on the node if we're running in a NAT gateway
-	if !config.NatGwMode {
+	if config.NatGwMode == nil || !*config.NatGwMode {
 		perm, err := strconv.ParseUint(config.LogPerm, 8, 32)
 		if err != nil {
 			util.LogFatalAndExit(err, "failed to parse log-perm")
@@ -39,7 +39,7 @@ func CmdMain() {
 	ctrl.SetLogger(klog.NewKlogr())
 	ctx := signals.SetupSignalHandler()
 	go func() {
-		if config.EnableMetrics {
+		if config.EnableMetrics != nil && *config.EnableMetrics {
 			metrics.InitKlogMetrics()
 			if err = metrics.Run(ctx, nil, util.JoinHostPort("0.0.0.0", config.PprofPort), false, false, "", "", nil); err != nil {
 				util.LogFatalAndExit(err, "failed to run metrics server")

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	golang.org/x/tools v0.48.0
 	google.golang.org/grpc v1.82.0
 	gopkg.in/k8snetworkplumbingwg/multus-cni.v4 v4.3.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
 	k8s.io/apiextensions-apiserver v0.36.2
 	k8s.io/apimachinery v0.36.2
@@ -256,7 +257,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/cli-runtime v0.36.2 // indirect
 	k8s.io/cloud-provider v0.36.1 // indirect
 	k8s.io/cluster-bootstrap v0.36.1 // indirect

--- a/pkg/speaker/bfd.go
+++ b/pkg/speaker/bfd.go
@@ -67,7 +67,7 @@ func bfdSessionStateString(state api.BfdSessionState) string {
 // logBFDStatus logs the BFD status for all peers.
 // Error/recovery stats are always checked; per-peer state dump is gated by V(3).
 func (c *Controller) logBFDStatus() {
-	if !c.config.EnableBFD {
+	if c.config.EnableBFD == nil || !*c.config.EnableBFD {
 		return
 	}
 
@@ -134,7 +134,7 @@ func (c *Controller) logBFDStatus() {
 // GoBGP expects BFD intervals in microseconds (RFC 5880), while CLI flags
 // accept milliseconds for user convenience; this function performs the conversion.
 func newBFDPeerConfig(config *Configuration) *api.BfdPeerConfig {
-	if !config.EnableBFD {
+	if config.EnableBFD == nil || !*config.EnableBFD {
 		return nil
 	}
 	return &api.BfdPeerConfig{

--- a/pkg/speaker/bfd_test.go
+++ b/pkg/speaker/bfd_test.go
@@ -18,14 +18,14 @@ func TestNewBFDPeerConfig(t *testing.T) {
 		{
 			name: "BFD disabled returns nil",
 			config: &Configuration{
-				EnableBFD: false,
+				EnableBFD: boolPtr(false),
 			},
 			expected: nil,
 		},
 		{
 			name: "default values converts ms to us",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               1000,
 				BFDMinRX:               1000,
 				BFDDetectionMultiplier: 3,
@@ -40,7 +40,7 @@ func TestNewBFDPeerConfig(t *testing.T) {
 		{
 			name: "custom values converts ms to us",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               300,
 				BFDMinRX:               500,
 				BFDDetectionMultiplier: 5,
@@ -55,7 +55,7 @@ func TestNewBFDPeerConfig(t *testing.T) {
 		{
 			name: "aggressive timers",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               100,
 				BFDMinRX:               100,
 				BFDDetectionMultiplier: 3,
@@ -114,7 +114,7 @@ func TestValidateBFDFlags(t *testing.T) {
 		{
 			name: "valid BFD config",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               1000,
 				BFDMinRX:               1000,
 				BFDDetectionMultiplier: 3,
@@ -128,7 +128,7 @@ func TestValidateBFDFlags(t *testing.T) {
 			// Upper bound (255) is enforced by the uint8 type, so no >255 test case is needed.
 			name: "detection multiplier zero",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               1000,
 				BFDMinRX:               1000,
 				BFDDetectionMultiplier: 0,
@@ -141,7 +141,7 @@ func TestValidateBFDFlags(t *testing.T) {
 		{
 			name: "zero min-tx",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               0,
 				BFDMinRX:               1000,
 				BFDDetectionMultiplier: 3,
@@ -154,7 +154,7 @@ func TestValidateBFDFlags(t *testing.T) {
 		{
 			name: "zero min-rx",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               1000,
 				BFDMinRX:               0,
 				BFDDetectionMultiplier: 3,
@@ -167,7 +167,7 @@ func TestValidateBFDFlags(t *testing.T) {
 		{
 			name: "BFD disabled skips validation",
 			config: &Configuration{
-				EnableBFD:              false,
+				EnableBFD:              boolPtr(false),
 				BFDDetectionMultiplier: 255,
 				NeighborAs:             65001,
 				ClusterAs:              65000,
@@ -178,7 +178,7 @@ func TestValidateBFDFlags(t *testing.T) {
 		{
 			name: "min-tx at overflow boundary is valid",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               math.MaxUint32 / 1000,
 				BFDMinRX:               1000,
 				BFDDetectionMultiplier: 3,
@@ -191,7 +191,7 @@ func TestValidateBFDFlags(t *testing.T) {
 		{
 			name: "min-tx exceeds overflow boundary",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               math.MaxUint32/1000 + 1,
 				BFDMinRX:               1000,
 				BFDDetectionMultiplier: 3,
@@ -204,7 +204,7 @@ func TestValidateBFDFlags(t *testing.T) {
 		{
 			name: "min-rx exceeds overflow boundary",
 			config: &Configuration{
-				EnableBFD:              true,
+				EnableBFD:              boolPtr(true),
 				BFDMinTX:               1000,
 				BFDMinRX:               math.MaxUint32/1000 + 1,
 				BFDDetectionMultiplier: 3,
@@ -219,7 +219,7 @@ func TestValidateBFDFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Need at least one neighbor for validation to pass
-			tt.config.NeighborAddresses = []net.IP{net.ParseIP("10.0.0.1")}
+			tt.config.NeighborAddresses = []IP{{IP: net.ParseIP("10.0.0.1")}}
 			err := tt.config.validateRequiredFlags()
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -19,14 +19,14 @@ import (
 // reconcileRoutes configures the BGP speaker to announce only the routes we are expected to announce
 // and to withdraw the ones that should not be announced anymore
 func (c *Controller) reconcileRoutes(expectedPrefixes prefixMap) error {
-	if c.config.ExtendedNexthop || len(c.config.NeighborAddresses) != 0 {
+	if (c.config.ExtendedNexthop != nil && *c.config.ExtendedNexthop) || len(c.config.NeighborAddresses) != 0 {
 		err := c.reconcileIPFamily(api.Family_AFI_IP, expectedPrefixes)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile IPv4 routes: %w", err)
 		}
 	}
 
-	if c.config.ExtendedNexthop || len(c.config.NeighborIPv6Addresses) != 0 {
+	if (c.config.ExtendedNexthop != nil && *c.config.ExtendedNexthop) || len(c.config.NeighborIPv6Addresses) != 0 {
 		err := c.reconcileIPFamily(api.Family_AFI_IP6, expectedPrefixes)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile IPv6 routes: %w", err)
@@ -53,7 +53,7 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 			klog.V(5).Infof("announcing route with prefix %s and nexthop: %s", prefix, nextHop)
 
 			route, _ := netlink.RouteGet(nextHop)
-			if len(route) == 1 && route[0].Type == unix.RTN_LOCAL || nextHop.Equal(c.config.RouterID) {
+			if len(route) == 1 && route[0].Type == unix.RTN_LOCAL || nextHop.Equal(c.config.RouterID.IP) {
 				existingPrefixes.Insert(prefix.String())
 				return
 			}
@@ -138,7 +138,7 @@ func (c *Controller) getPathRequest(route string) ([][]*apiutil.Path, error) {
 	// Should this route be advertised to IPv4 or IPv6 peers
 	// If extended-nexthop is enabled, we advertise IPv4 NLRIs to IPv6 peers and IPv6 NLRIs to IPv4 peers
 	neighborAddresses := c.config.NeighborAddresses
-	if c.config.ExtendedNexthop {
+	if c.config.ExtendedNexthop != nil && *c.config.ExtendedNexthop {
 		neighborAddresses = append(neighborAddresses, c.config.NeighborIPv6Addresses...)
 	} else if util.CheckProtocol(route) == kubeovnv1.ProtocolIPv6 {
 		neighborAddresses = c.config.NeighborIPv6Addresses
@@ -173,7 +173,7 @@ func (c *Controller) getPathRequest(route string) ([][]*apiutil.Path, error) {
 			}, {
 				Attr: &api.Attribute_NextHop{
 					NextHop: &api.NextHopAttribute{
-						NextHop: c.getNextHopAttribute(addr).String(),
+						NextHop: c.getNextHopAttribute(addr.IP).String(),
 					},
 				},
 			}},
@@ -206,7 +206,7 @@ func (c *Controller) getNextHopAttribute(neighborAddress net.IP) net.IP {
 		return localAddr
 	}
 
-	nextHop := c.config.RouterID // If no route is found, fallback to router ID
+	nextHop := c.config.RouterID.IP // If no route is found, fallback to router ID
 
 	// Retrieve the route we use to speak to this neighbor and consider the source as next hop.
 	routes, err := netlink.RouteGet(neighborAddress)
@@ -217,7 +217,7 @@ func (c *Controller) getNextHopAttribute(neighborAddress net.IP) net.IP {
 	proto := util.CheckProtocol(nextHop.String()) // Is next hop IPv4 or IPv6
 
 	// Preserve the historical fallback for non-whitelist mode.
-	nodeIP := c.config.NodeIPs[proto]
+	nodeIP := c.config.NodeIPs[proto].IP
 	if nodeIP != nil && nextHop.Equal(c.config.PodIPs[proto]) {
 		nextHop = nodeIP
 	}

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
+	"gopkg.in/yaml.v3"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -41,45 +42,147 @@ const (
 	addPeerRetryInterval               = 5 * time.Second
 )
 
+// Duration is a wrapper around time.Duration for YAML serialization.
+// Supported formats: string (e.g., "90s", "5m", "1h") or integer (seconds).
+type Duration struct {
+	time.Duration
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for time.Duration support.
+// Accepts both string format ("90s", "5m", "1h") and integer seconds (360).
+func (d *Duration) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		// Check if it's a string scalar
+		if node.Tag == "!!str" {
+			dur, err := time.ParseDuration(node.Value)
+			if err != nil {
+				return fmt.Errorf("invalid duration %q: %w", node.Value, err)
+			}
+			d.Duration = dur
+			return nil
+		}
+
+		// Check if it's an integer value (seconds)
+		if node.Tag == "!!int" {
+			var n int64
+			if err := node.Decode(&n); err != nil {
+				return fmt.Errorf("invalid duration value: %w", err)
+			}
+			d.Duration = time.Duration(n) * time.Second
+			return nil
+		}
+
+		return fmt.Errorf("invalid duration value: expected string (e.g., '90s') or integer seconds, got %q", node.Value)
+	default:
+		return fmt.Errorf("invalid duration value: expected scalar, got %v", node.Kind)
+	}
+}
+
+func (d Duration) MarshalYAML() (any, error) {
+	return d.String(), nil
+}
+
+// Seconds returns the duration in seconds as uint32.
+func (d Duration) Seconds() uint32 {
+	return uint32(d.Duration.Seconds())
+}
+
+// IsZero returns true if the duration is not set.
+func (d Duration) IsZero() bool {
+	return d.Duration == 0
+}
+
+// IP is a wrapper around net.IP for YAML serialization.
+// It supports string format for both IPv4 and IPv6 addresses (e.g., "192.168.1.1", "2001:db8::1").
+// The embedded net.IP provides all standard IP operations while adding YAML marshaling support.
+type IP struct {
+	net.IP
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for net.IP support.
+// Accepts string format for IPv4 and IPv6 addresses.
+// Returns an error if the value is not a valid IP address string.
+func (ip *IP) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("invalid IP value: expected scalar, got %v", node.Kind)
+	}
+	// Treat null / empty string as "unset".
+	if node.Tag == "!!null" || (node.Tag == "!!str" && node.Value == "") {
+		ip.IP = nil
+		return nil
+	}
+	if node.Tag != "!!str" {
+		return fmt.Errorf("invalid IP value: expected string, got %s", node.Tag)
+	}
+
+	parsedIP := net.ParseIP(node.Value)
+	if parsedIP == nil {
+		return fmt.Errorf("invalid IP address %q", node.Value)
+	}
+	ip.IP = parsedIP
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler for net.IP support.
+// Returns the string representation of the IP address.
+func (ip IP) MarshalYAML() (any, error) {
+	if ip.IP == nil {
+		return nil, nil
+	}
+	return ip.IP.String(), nil
+}
+
+// String returns the string representation of the IP address.
+// Returns an empty string if the IP is nil.
+func (ip IP) String() string {
+	if ip.IP == nil {
+		return ""
+	}
+	return ip.IP.String()
+}
+
 type Configuration struct {
-	GrpcHost                    net.IP
-	GrpcPort                    int32
-	ClusterAs                   uint32
-	RouterID                    net.IP
-	PodIPs                      map[string]net.IP
-	NodeIPs                     map[string]net.IP
-	NeighborAddresses           []net.IP
-	NeighborIPv6Addresses       []net.IP
-	AllowedSourceAddresses      []net.IP
-	AllowedSourceIPv6Addresses  []net.IP
-	NeighborLocalAddresses      map[string]net.IP
-	NeighborAs                  uint32
-	AuthPassword                string
-	HoldTime                    float64
-	BgpServer                   *gobgp.BgpServer
-	AnnounceClusterIP           bool
-	GracefulRestart             bool
-	GracefulRestartDeferralTime time.Duration
-	GracefulRestartTime         time.Duration
-	PassiveMode                 bool
-	EbgpMultihopTTL             uint8
-	ExtendedNexthop             bool
-	NatGwMode                   bool
-	EnableMetrics               bool
+	GrpcHost                    IP                `yaml:"grpc-host,omitempty"`
+	GrpcPort                    int32             `yaml:"grpc-port,omitempty"`
+	ClusterAs                   uint32            `yaml:"cluster-as,omitempty"`
+	RouterID                    IP                `yaml:"router-id,omitempty"`
+	PodIPs                      map[string]net.IP `yaml:"-"`
+	NodeIPs                     map[string]IP     `yaml:"node-ips,omitempty"`
+	NeighborAddresses           []IP              `yaml:"neighbor-address,omitempty"`
+	NeighborIPv6Addresses       []IP              `yaml:"neighbor-ipv6-address,omitempty"`
+	AllowedSourceAddresses      []IP              `yaml:"allowed-source-addresses,omitempty"`
+	AllowedSourceIPv6Addresses  []IP              `yaml:"allowed-source-ipv6-addresses,omitempty"`
+	NeighborLocalAddresses      map[string]net.IP `yaml:"-"`
+	NeighborAs                  uint32            `yaml:"neighbor-as,omitempty"`
+	AuthPassword                string            `yaml:"auth-password,omitempty"`
+	HoldTime                    Duration          `yaml:"holdtime,omitempty"`
+	BgpServer                   *gobgp.BgpServer  `yaml:"-"`
+	AnnounceClusterIP           *bool             `yaml:"announce-cluster-ip,omitempty"`
+	GracefulRestart             *bool             `yaml:"graceful-restart,omitempty"`
+	GracefulRestartDeferralTime Duration          `yaml:"graceful-restart-deferral-time,omitempty"`
+	GracefulRestartTime         Duration          `yaml:"graceful-restart-time,omitempty"`
+	PassiveMode                 *bool             `yaml:"passivemode,omitempty"`
+	EbgpMultihopTTL             uint8             `yaml:"ebgp-multihop,omitempty"`
+	ExtendedNexthop             *bool             `yaml:"extended-nexthop,omitempty"`
+	NatGwMode                   *bool             `yaml:"nat-gw-mode,omitempty"`
+	EnableMetrics               *bool             `yaml:"enable-metrics,omitempty"`
 
 	// BFD (Bidirectional Forwarding Detection) configuration
-	EnableBFD              bool
-	BFDMinTX               uint32 // minimum transmit interval in milliseconds (converted to microseconds for GoBGP)
-	BFDMinRX               uint32 // minimum receive interval in milliseconds (converted to microseconds for GoBGP)
-	BFDDetectionMultiplier uint8  // RFC 5880 §6.8.1: valid range 1-255
+	EnableBFD              *bool  `yaml:"enable-bfd,omitempty"`
+	BFDMinTX               uint32 `yaml:"bfd-min-tx,omitempty"`               // minimum transmit interval in milliseconds (converted to microseconds for GoBGP)
+	BFDMinRX               uint32 `yaml:"bfd-min-rx,omitempty"`               // minimum receive interval in milliseconds (converted to microseconds for GoBGP)
+	BFDDetectionMultiplier uint8  `yaml:"bfd-detection-multiplier,omitempty"` // RFC 5880 §6.8.1: valid range 1-255
 
-	NodeName       string
-	KubeConfigFile string
-	KubeClient     kubernetes.Interface
-	KubeOvnClient  clientset.Interface
+	NodeName       string               `yaml:"node-name,omitempty"`
+	KubeConfigFile string               `yaml:"kubeconfig,omitempty"`
+	KubeClient     kubernetes.Interface `yaml:"-"`
+	KubeOvnClient  clientset.Interface  `yaml:"-"`
 
-	PprofPort int32
-	LogPerm   string
+	PprofPort int32  `yaml:"pprof-port,omitempty"`
+	LogPerm   string `yaml:"log-perm,omitempty"`
+
+	ConfigFile string `yaml:"-"`
 }
 
 func ParseFlags() (*Configuration, error) {
@@ -113,6 +216,7 @@ func ParseFlags() (*Configuration, error) {
 		argBFDMinTX                    = pflag.Uint32("bfd-min-tx", 1000, "BFD minimum transmit interval in milliseconds (default 1000, max 4294967)")
 		argBFDMinRX                    = pflag.Uint32("bfd-min-rx", 1000, "BFD minimum receive interval in milliseconds (default 1000, max 4294967)")
 		argBFDDetectionMultiplier      = pflag.Uint8("bfd-detection-multiplier", 3, "BFD detection multiplier (default 3, valid range 1-255 per RFC 5880)")
+		argConfigFile                  = pflag.String("config", os.Getenv(util.EnvKubeOVNBGPSpeakerConfigFile), "Path to speaker config file in yaml format")
 	)
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -132,14 +236,6 @@ func ParseFlags() (*Configuration, error) {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	ht := argHoldTime.Seconds()
-	if ht > 65536 || ht < 3 {
-		return nil, errors.New("the bgp holdtime must be in the range 3s to 65536s")
-	}
-	if *argEbgpMultihopTTL == 0 {
-		return nil, errors.New("the bgp MultihopTtl must be in the range 1 to 255")
-	}
-
 	podIpsEnv := os.Getenv(util.EnvPodIPs)
 	if podIpsEnv == "" {
 		podIpsEnv = os.Getenv(util.EnvPodIP)
@@ -155,40 +251,67 @@ func ParseFlags() (*Configuration, error) {
 		}
 	}
 
+	// Convert []net.IP from pflag to []IP for YAML support.
+	neighborAddresses := make([]IP, 0, len(*argNeighborAddress))
+	for _, ip := range *argNeighborAddress {
+		neighborAddresses = append(neighborAddresses, IP{IP: ip})
+	}
+	neighborIPv6Addresses := make([]IP, 0, len(*argNeighborIPv6Address))
+	for _, ip := range *argNeighborIPv6Address {
+		neighborIPv6Addresses = append(neighborIPv6Addresses, IP{IP: ip})
+	}
+	allowedSourceAddresses := make([]IP, 0, len(*argAllowedSourceAddresses))
+	for _, ip := range *argAllowedSourceAddresses {
+		allowedSourceAddresses = append(allowedSourceAddresses, IP{IP: ip})
+	}
+	allowedSourceIPv6Addresses := make([]IP, 0, len(*argAllowedSourceIPv6Addresses))
+	for _, ip := range *argAllowedSourceIPv6Addresses {
+		allowedSourceIPv6Addresses = append(allowedSourceIPv6Addresses, IP{IP: ip})
+	}
+
 	config := &Configuration{
-		AnnounceClusterIP:          *argAnnounceClusterIP,
-		GrpcHost:                   *argGrpcHost,
-		GrpcPort:                   *argGrpcPort,
-		ClusterAs:                  *argClusterAs,
-		RouterID:                   *argRouterID,
-		NeighborAddresses:          *argNeighborAddress,
-		NeighborIPv6Addresses:      *argNeighborIPv6Address,
-		AllowedSourceAddresses:     *argAllowedSourceAddresses,
-		AllowedSourceIPv6Addresses: *argAllowedSourceIPv6Addresses,
-		NodeIPs: map[string]net.IP{
-			kubeovnv1.ProtocolIPv4: nodeIPv4,
-			kubeovnv1.ProtocolIPv6: nodeIPv6,
-		},
+		AnnounceClusterIP:           argAnnounceClusterIP,
+		GrpcHost:                    IP{IP: *argGrpcHost},
+		GrpcPort:                    *argGrpcPort,
+		ClusterAs:                   *argClusterAs,
+		RouterID:                    IP{IP: *argRouterID},
+		NeighborAddresses:           neighborAddresses,
+		NeighborIPv6Addresses:       neighborIPv6Addresses,
+		AllowedSourceAddresses:      allowedSourceAddresses,
+		AllowedSourceIPv6Addresses:  allowedSourceIPv6Addresses,
+		NodeIPs:                     map[string]IP{kubeovnv1.ProtocolIPv4: {IP: nodeIPv4}, kubeovnv1.ProtocolIPv6: {IP: nodeIPv6}},
 		PodIPs:                      make(map[string]net.IP, 2),
 		NeighborAs:                  *argNeighborAs,
 		AuthPassword:                *argAuthPassword,
-		HoldTime:                    ht,
+		HoldTime:                    Duration{Duration: *argHoldTime},
 		PprofPort:                   *argPprofPort,
 		NodeName:                    strings.ToLower(*argNodeName),
 		KubeConfigFile:              *argKubeConfigFile,
-		GracefulRestart:             *argGracefulRestart,
-		GracefulRestartDeferralTime: *argGracefulRestartDeferralTime,
-		GracefulRestartTime:         *argDefaultGracefulTime,
-		PassiveMode:                 *argPassiveMode,
+		GracefulRestart:             argGracefulRestart,
+		GracefulRestartDeferralTime: Duration{Duration: *argGracefulRestartDeferralTime},
+		GracefulRestartTime:         Duration{Duration: *argDefaultGracefulTime},
+		PassiveMode:                 argPassiveMode,
 		EbgpMultihopTTL:             *argEbgpMultihopTTL,
-		ExtendedNexthop:             *argExtendedNexthop,
-		NatGwMode:                   *argNatGwMode,
-		EnableMetrics:               *argEnableMetrics,
+		ExtendedNexthop:             argExtendedNexthop,
+		NatGwMode:                   argNatGwMode,
+		EnableMetrics:               argEnableMetrics,
 		LogPerm:                     *argLogPerm,
-		EnableBFD:                   *argEnableBFD,
+		EnableBFD:                   argEnableBFD,
 		BFDMinTX:                    *argBFDMinTX,
 		BFDMinRX:                    *argBFDMinRX,
 		BFDDetectionMultiplier:      *argBFDDetectionMultiplier,
+		ConfigFile:                  *argConfigFile,
+	}
+
+	if config.ConfigFile != "" {
+		fileConfig, err := config.loadFileConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load speaker config, %w", err)
+		}
+
+		if fileConfig != nil {
+			config.mergeFileConfig(fileConfig)
+		}
 	}
 
 	if podIPv4 != "" {
@@ -210,35 +333,49 @@ func ParseFlags() (*Configuration, error) {
 		return nil, err
 	}
 
+	// Validate holdtime range after merging file config
+	if config.HoldTime.Duration > 65536*time.Second || config.HoldTime.Duration < 3*time.Second {
+		return nil, errors.New("the bgp holdtime must be in the range 3s to 65536s")
+	}
+
+	if config.EbgpMultihopTTL == 0 {
+		return nil, errors.New("the bgp MultihopTtl must be in the range 1 to 255")
+	}
+
 	for _, addr := range config.NeighborAddresses {
 		if addr.To4() == nil {
-			return nil, fmt.Errorf("invalid neighbor-address format: %s", *argNeighborAddress)
+			return nil, fmt.Errorf("invalid neighbor-address format: expected IPv4, got %v", addr.IP)
 		}
 	}
 	for _, addr := range config.NeighborIPv6Addresses {
 		if addr.To4() != nil {
-			return nil, fmt.Errorf("invalid neighbor-ipv6-address format: %s is not an IPv6 address", addr)
+			return nil, fmt.Errorf("invalid neighbor-ipv6-address format: expected IPv6, got %v", addr.IP)
 		}
 	}
 	for _, addr := range config.AllowedSourceAddresses {
 		if addr.To4() == nil {
-			return nil, fmt.Errorf("invalid allowed-source-addresses format: %s is not an IPv4 address", addr)
+			return nil, fmt.Errorf("invalid allowed-source-addresses format: expected IPv4, got %v", addr.IP)
 		}
 	}
 	for _, addr := range config.AllowedSourceIPv6Addresses {
 		if addr.To4() != nil {
-			return nil, fmt.Errorf("invalid allowed-source-ipv6-addresses format: %s is not an IPv6 address", addr)
+			return nil, fmt.Errorf("invalid allowed-source-ipv6-addresses format: expected IPv6, got %v", addr.IP)
 		}
 	}
 
-	if config.RouterID == nil {
+	// RouterID must be IPv4 per BGP spec (32-bit). Reject IPv6 values early.
+	if config.RouterID.IP != nil && config.RouterID.To4() == nil {
+		return nil, fmt.Errorf("invalid router-id: expected IPv4, got %v", config.RouterID.IP)
+	}
+
+	if config.RouterID.IP == nil {
 		if podIPv4 != "" {
-			config.RouterID = net.ParseIP(podIPv4)
+			config.RouterID = IP{IP: net.ParseIP(podIPv4)}
 		}
 
-		if config.RouterID == nil {
+		if config.RouterID.IP == nil {
 			// RouterID must be an IPv4. If no IPv4 exists on the speaker, fallback to 0.0.0.0 to avoid GoBGP crashing.
-			config.RouterID = net.ParseIP("0.0.0.0")
+			config.RouterID = IP{IP: net.ParseIP("0.0.0.0")}
 		}
 	}
 
@@ -251,6 +388,121 @@ func ParseFlags() (*Configuration, error) {
 	}
 
 	return config, nil
+}
+
+// loadFileConfig loads the speaker config from the file.
+func (config *Configuration) loadFileConfig() (*Configuration, error) {
+	data, err := os.ReadFile(config.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg Configuration
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// mergeFileConfig merges the file config into the current config.
+// Variables from the file will override command line arguments and the default configuration.
+func (config *Configuration) mergeFileConfig(cfg *Configuration) {
+	if cfg.GrpcHost.IP != nil {
+		config.GrpcHost = cfg.GrpcHost
+	}
+	if cfg.GrpcPort != 0 {
+		config.GrpcPort = cfg.GrpcPort
+	}
+	if cfg.ClusterAs != 0 {
+		config.ClusterAs = cfg.ClusterAs
+	}
+	if cfg.RouterID.IP != nil {
+		config.RouterID = cfg.RouterID
+	}
+	if len(cfg.NodeIPs) != 0 {
+		if config.NodeIPs == nil {
+			config.NodeIPs = map[string]IP{}
+		}
+		for k, v := range cfg.NodeIPs {
+			if v.IP != nil {
+				config.NodeIPs[k] = v
+			}
+		}
+	}
+	if len(cfg.NeighborAddresses) != 0 {
+		config.NeighborAddresses = cfg.NeighborAddresses
+	}
+	if len(cfg.NeighborIPv6Addresses) != 0 {
+		config.NeighborIPv6Addresses = cfg.NeighborIPv6Addresses
+	}
+	if len(cfg.AllowedSourceAddresses) != 0 {
+		config.AllowedSourceAddresses = cfg.AllowedSourceAddresses
+	}
+	if len(cfg.AllowedSourceIPv6Addresses) != 0 {
+		config.AllowedSourceIPv6Addresses = cfg.AllowedSourceIPv6Addresses
+	}
+	if cfg.NeighborAs != 0 {
+		config.NeighborAs = cfg.NeighborAs
+	}
+	if cfg.AuthPassword != "" {
+		config.AuthPassword = cfg.AuthPassword
+	}
+	if !cfg.HoldTime.IsZero() {
+		config.HoldTime = cfg.HoldTime
+	}
+	// Boolean pointer fields: only merge if explicitly set in YAML (non-nil)
+	if cfg.AnnounceClusterIP != nil {
+		config.AnnounceClusterIP = cfg.AnnounceClusterIP
+	}
+	if cfg.GracefulRestart != nil {
+		config.GracefulRestart = cfg.GracefulRestart
+	}
+	if !cfg.GracefulRestartDeferralTime.IsZero() {
+		config.GracefulRestartDeferralTime = cfg.GracefulRestartDeferralTime
+	}
+	if !cfg.GracefulRestartTime.IsZero() {
+		config.GracefulRestartTime = cfg.GracefulRestartTime
+	}
+	if cfg.PassiveMode != nil {
+		config.PassiveMode = cfg.PassiveMode
+	}
+	if cfg.EbgpMultihopTTL != 0 {
+		config.EbgpMultihopTTL = cfg.EbgpMultihopTTL
+	}
+	if cfg.ExtendedNexthop != nil {
+		config.ExtendedNexthop = cfg.ExtendedNexthop
+	}
+	if cfg.NatGwMode != nil {
+		config.NatGwMode = cfg.NatGwMode
+	}
+	if cfg.EnableMetrics != nil {
+		config.EnableMetrics = cfg.EnableMetrics
+	}
+	if cfg.EnableBFD != nil {
+		config.EnableBFD = cfg.EnableBFD
+	}
+	if cfg.BFDMinTX != 0 {
+		config.BFDMinTX = cfg.BFDMinTX
+	}
+	if cfg.BFDMinRX != 0 {
+		config.BFDMinRX = cfg.BFDMinRX
+	}
+	if cfg.BFDDetectionMultiplier != 0 {
+		config.BFDDetectionMultiplier = cfg.BFDDetectionMultiplier
+	}
+	if cfg.NodeName != "" {
+		config.NodeName = strings.ToLower(cfg.NodeName)
+	}
+	if cfg.KubeConfigFile != "" {
+		config.KubeConfigFile = cfg.KubeConfigFile
+	}
+	if cfg.PprofPort != 0 {
+		config.PprofPort = cfg.PprofPort
+	}
+	if cfg.LogPerm != "" {
+		config.LogPerm = cfg.LogPerm
+	}
 }
 
 // validateRequiredFlags checks that all required BGP configuration flags are provided.
@@ -270,11 +522,11 @@ func (config *Configuration) validateRequiredFlags() error {
 	// NodeName is only used for the BGP "local" policy match in syncSubnetRoutes;
 	// NAT GW mode runs syncEIPRoutes exclusively and never reads NodeName, so skip
 	// the requirement there to stay compatible with GenNatGwBgpSpeakerContainer.
-	if !config.NatGwMode && config.NodeName == "" {
+	if (config.NatGwMode == nil || !*config.NatGwMode) && config.NodeName == "" {
 		missingFlags = append(missingFlags, "--node-name must be specified (usually via NODE_NAME env from downward API)")
 	}
 
-	if config.EnableBFD {
+	if config.EnableBFD != nil && *config.EnableBFD {
 		if config.BFDDetectionMultiplier == 0 {
 			missingFlags = append(missingFlags, "--bfd-detection-multiplier must be between 1 and 255")
 		}
@@ -335,10 +587,10 @@ func (config *Configuration) initKubeClient() error {
 }
 
 func (config *Configuration) checkGracefulRestartOptions() error {
-	if config.GracefulRestartTime > time.Second*4095 || config.GracefulRestartTime <= 0 {
+	if config.GracefulRestartTime.Duration > 4095*time.Second || config.GracefulRestartTime.Duration <= 0 {
 		return errors.New("GracefulRestartTime should be less than 4095 seconds or more than 0")
 	}
-	if config.GracefulRestartDeferralTime > time.Hour*18 || config.GracefulRestartDeferralTime <= 0 {
+	if config.GracefulRestartDeferralTime.Duration > 18*time.Hour || config.GracefulRestartDeferralTime.Duration <= 0 {
 		return errors.New("GracefulRestartDeferralTime should be less than 18 hours or more than 0")
 	}
 
@@ -359,18 +611,18 @@ func (config *Configuration) initBgpServer() error {
 
 	grpcOpts := []grpc.ServerOption{grpc.MaxRecvMsgSize(maxSize), grpc.MaxSendMsgSize(maxSize)}
 	s := gobgp.NewBgpServer(
-		gobgp.GrpcListenAddress(util.JoinHostPort(config.GrpcHost.String(), config.GrpcPort)),
+		gobgp.GrpcListenAddress(util.JoinHostPort(config.GrpcHost.IP.String(), config.GrpcPort)),
 		gobgp.GrpcOption(grpcOpts),
 		gobgp.LoggerOption(slog.Default(), &logLevel),
 	)
 	go s.Serve()
 
-	peersMap := map[api.Family_Afi][]net.IP{
+	peersMap := map[api.Family_Afi][]IP{
 		api.Family_AFI_IP:  config.NeighborAddresses,
 		api.Family_AFI_IP6: config.NeighborIPv6Addresses,
 	}
 
-	if config.PassiveMode {
+	if config.PassiveMode != nil && *config.PassiveMode {
 		listenPort = bgp.BGP_PORT
 	}
 
@@ -400,15 +652,15 @@ func (config *Configuration) initBgpServer() error {
 	for ipFamily, addresses := range peersMap {
 		for _, addr := range addresses {
 			transport := &api.Transport{
-				PassiveMode: config.PassiveMode,
+				PassiveMode: config.PassiveMode != nil && *config.PassiveMode,
 			}
-			if localAddr := config.getNeighborLocalAddress(addr); localAddr != nil {
+			if localAddr := config.getNeighborLocalAddress(addr.IP); localAddr != nil {
 				transport.LocalAddress = localAddr.String()
 			}
 			peer := &api.Peer{
-				Timers: &api.Timers{Config: &api.TimersConfig{HoldTime: uint64(config.HoldTime)}},
+				Timers: &api.Timers{Config: &api.TimersConfig{HoldTime: uint64(config.HoldTime.Seconds())}},
 				Conf: &api.PeerConf{
-					NeighborAddress: addr.String(),
+					NeighborAddress: addr.IP.String(),
 					PeerAsn:         config.NeighborAs,
 				},
 				Transport: transport,
@@ -422,7 +674,7 @@ func (config *Configuration) initBgpServer() error {
 			if config.AuthPassword != "" {
 				peer.Conf.AuthPassword = config.AuthPassword
 			}
-			if config.GracefulRestart {
+			if config.GracefulRestart != nil && *config.GracefulRestart {
 				if err := config.checkGracefulRestartOptions(); err != nil {
 					err = fmt.Errorf("failed to check graceful restart options: %w", err)
 					klog.Error(err)
@@ -430,8 +682,8 @@ func (config *Configuration) initBgpServer() error {
 				}
 				peer.GracefulRestart = &api.GracefulRestart{
 					Enabled:         true,
-					RestartTime:     uint32(config.GracefulRestartTime.Seconds()),
-					DeferralTime:    uint32(config.GracefulRestartDeferralTime.Seconds()),
+					RestartTime:     config.GracefulRestartTime.Seconds(),
+					DeferralTime:    config.GracefulRestartDeferralTime.Seconds(),
 					LocalRestarting: true,
 				}
 				peer.AfiSafis = []*api.AfiSafi{
@@ -451,7 +703,7 @@ func (config *Configuration) initBgpServer() error {
 
 			// If extended nexthop is enabled, advertise the IPv4 unicast AFI/SAFI even if
 			// we have no IPv4 neighbor
-			if config.ExtendedNexthop {
+			if config.ExtendedNexthop != nil && *config.ExtendedNexthop {
 				peer.AfiSafis = append(peer.AfiSafis, &api.AfiSafi{
 					Config: &api.AfiSafiConfig{
 						Family: &api.Family{
@@ -532,7 +784,7 @@ func (config *Configuration) watchPeerState() {
 			neighborAddr := p.Conf.NeighborAddress.String()
 
 			var bfdState string
-			if config.EnableBFD {
+			if config.EnableBFD != nil && *config.EnableBFD {
 				config.BgpServer.ListBfdPeer(context.Background(), func(addr string, st *api.BfdPeerState) {
 					if addr == neighborAddr && st != nil {
 						bfdState = bfdSessionStateString(st.SessionState)
@@ -559,23 +811,23 @@ func (config *Configuration) initNeighborLocalAddresses() error {
 
 	for _, neighbor := range config.NeighborAddresses {
 		if len(config.AllowedSourceAddresses) != 0 {
-			klog.Infof("Resolving BGP local address for neighbor %s with allowed IPv4 source addresses %v", neighbor, config.AllowedSourceAddresses)
-			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor, config.AllowedSourceAddresses)
+			klog.Infof("Resolving BGP local address for neighbor %s with allowed IPv4 source addresses %v", neighbor.String(), config.AllowedSourceAddresses)
+			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor.IP, toNetIPs(config.AllowedSourceAddresses))
 			if err != nil {
 				return err
 			}
-			config.NeighborLocalAddresses[neighbor.String()] = localAddr
+			config.NeighborLocalAddresses[neighbor.IP.String()] = localAddr
 		}
 	}
 
 	for _, neighbor := range config.NeighborIPv6Addresses {
 		if len(config.AllowedSourceIPv6Addresses) != 0 {
-			klog.Infof("Resolving BGP local address for neighbor %s with allowed IPv6 source addresses %v", neighbor, config.AllowedSourceIPv6Addresses)
-			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor, config.AllowedSourceIPv6Addresses)
+			klog.Infof("Resolving BGP local address for neighbor %s with allowed IPv6 source addresses %v", neighbor.String(), config.AllowedSourceIPv6Addresses)
+			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor.IP, toNetIPs(config.AllowedSourceIPv6Addresses))
 			if err != nil {
 				return err
 			}
-			config.NeighborLocalAddresses[neighbor.String()] = localAddr
+			config.NeighborLocalAddresses[neighbor.IP.String()] = localAddr
 		}
 	}
 
@@ -687,4 +939,16 @@ func validateAllowedLocalAddress(neighborAddress, localAddr net.IP, allowedLocal
 		return nil
 	}
 	return fmt.Errorf("selected local address %s for BGP neighbor %s is not in allowed source address list %v; speaker startup is rejected until route lookup selects an allowed source address", localAddr, neighborAddress, allowedLocalAddresses)
+}
+
+// toNetIPs converts a slice of IP wrappers to a slice of net.IP.
+// It filters out nil IP addresses to prevent downstream errors.
+func toNetIPs(ips []IP) []net.IP {
+	result := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if ip.IP != nil {
+			result = append(result, ip.IP)
+		}
+	}
+	return result
 }

--- a/pkg/speaker/config_test.go
+++ b/pkg/speaker/config_test.go
@@ -3,10 +3,15 @@ package speaker
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"gopkg.in/yaml.v3"
 )
+
+// boolPtr returns a pointer to a bool value.
+func boolPtr(b bool) *bool { p := new(bool); *p = b; return p }
 
 func TestValidateRequiredFlags(t *testing.T) {
 	tests := []struct {
@@ -18,7 +23,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 		{
 			name: "all required flags provided with IPv4 neighbor",
 			config: &Configuration{
-				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				NeighborAddresses: []IP{{IP: net.ParseIP("192.168.1.1")}},
 				ClusterAs:         65000,
 				NeighborAs:        65001,
 				NodeName:          "node1",
@@ -28,7 +33,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 		{
 			name: "all required flags provided with IPv6 neighbor",
 			config: &Configuration{
-				NeighborIPv6Addresses: []net.IP{net.ParseIP("2001:db8::1")},
+				NeighborIPv6Addresses: []IP{{IP: net.ParseIP("2001:db8::1")}},
 				ClusterAs:             65000,
 				NeighborAs:            65001,
 				NodeName:              "node1",
@@ -38,8 +43,8 @@ func TestValidateRequiredFlags(t *testing.T) {
 		{
 			name: "all required flags provided with both IPv4 and IPv6 neighbors",
 			config: &Configuration{
-				NeighborAddresses:     []net.IP{net.ParseIP("192.168.1.1")},
-				NeighborIPv6Addresses: []net.IP{net.ParseIP("2001:db8::1")},
+				NeighborAddresses:     []IP{{IP: net.ParseIP("192.168.1.1")}},
+				NeighborIPv6Addresses: []IP{{IP: net.ParseIP("2001:db8::1")}},
 				ClusterAs:             65000,
 				NeighborAs:            65001,
 				NodeName:              "node1",
@@ -59,7 +64,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 		{
 			name: "missing cluster-as",
 			config: &Configuration{
-				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				NeighborAddresses: []IP{{IP: net.ParseIP("192.168.1.1")}},
 				NeighborAs:        65001,
 				NodeName:          "node1",
 			},
@@ -69,7 +74,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 		{
 			name: "missing neighbor-as",
 			config: &Configuration{
-				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				NeighborAddresses: []IP{{IP: net.ParseIP("192.168.1.1")}},
 				ClusterAs:         65000,
 				NodeName:          "node1",
 			},
@@ -79,7 +84,7 @@ func TestValidateRequiredFlags(t *testing.T) {
 		{
 			name: "missing node-name",
 			config: &Configuration{
-				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				NeighborAddresses: []IP{{IP: net.ParseIP("192.168.1.1")}},
 				ClusterAs:         65000,
 				NeighborAs:        65001,
 			},
@@ -89,10 +94,10 @@ func TestValidateRequiredFlags(t *testing.T) {
 		{
 			name: "nat-gw mode does not require node-name",
 			config: &Configuration{
-				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				NeighborAddresses: []IP{{IP: net.ParseIP("192.168.1.1")}},
 				ClusterAs:         65000,
 				NeighborAs:        65001,
-				NatGwMode:         true,
+				NatGwMode:         boolPtr(true),
 			},
 			expectError: false,
 		},
@@ -296,11 +301,849 @@ func TestSelectNeighborLocalAddressFromRoutes(t *testing.T) {
 
 func TestInitNeighborLocalAddressesPureExtensionMode(t *testing.T) {
 	config := &Configuration{
-		NeighborAddresses:     []net.IP{net.ParseIP("10.32.32.1")},
-		NeighborIPv6Addresses: []net.IP{net.ParseIP("fd00::254")},
+		NeighborAddresses:     []IP{{IP: net.ParseIP("10.32.32.1")}},
+		NeighborIPv6Addresses: []IP{{IP: net.ParseIP("fd00::254")}},
 	}
 
 	require.NoError(t, config.initNeighborLocalAddresses())
 	require.Nil(t, config.getNeighborLocalAddress(net.ParseIP("10.32.32.1")))
 	require.Nil(t, config.getNeighborLocalAddress(net.ParseIP("fd00::254")))
+}
+
+func TestIP_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		yamlValue   string
+		expectError bool
+		expectIP    net.IP
+		errorMsg    string
+	}{
+		{
+			name:        "valid IPv4 address",
+			yamlValue:   "192.168.1.1",
+			expectIP:    net.ParseIP("192.168.1.1"),
+			expectError: false,
+		},
+		{
+			name:        "valid IPv6 address",
+			yamlValue:   "2001:db8::1",
+			expectIP:    net.ParseIP("2001:db8::1"),
+			expectError: false,
+		},
+		{
+			name:        "IPv6 loopback",
+			yamlValue:   "::1",
+			expectIP:    net.ParseIP("::1"),
+			expectError: false,
+		},
+		{
+			name:        "IPv4 zero",
+			yamlValue:   "0.0.0.0",
+			expectIP:    net.ParseIP("0.0.0.0"),
+			expectError: false,
+		},
+		{
+			name:        "invalid IP string",
+			yamlValue:   "invalid-ip",
+			expectError: true,
+			errorMsg:    "invalid IP address",
+		},
+		{
+			name:        "empty string",
+			yamlValue:   "",
+			expectError: false,
+		},
+		{
+			name:        "non-string value",
+			yamlValue:   "123",
+			expectError: true,
+			errorMsg:    "invalid IP value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ip IP
+			err := yaml.Unmarshal([]byte(tt.yamlValue), &ip)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					require.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				require.NoError(t, err)
+				require.True(t, tt.expectIP.Equal(ip.IP), "expected %v, got %v", tt.expectIP, ip.IP)
+			}
+		})
+	}
+}
+
+func TestIP_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       IP
+		expected string
+	}{
+		{
+			name:     "IPv4 address",
+			ip:       IP{IP: net.ParseIP("192.168.1.1")},
+			expected: "192.168.1.1\n",
+		},
+		{
+			name:     "IPv6 address",
+			ip:       IP{IP: net.ParseIP("2001:db8::1")},
+			expected: "2001:db8::1\n",
+		},
+		{
+			name:     "IPv6 loopback",
+			ip:       IP{IP: net.ParseIP("::1")},
+			expected: "::1\n",
+		},
+		{
+			name:     "nil IP",
+			ip:       IP{IP: nil},
+			expected: "null\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tt.ip)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestIP_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       IP
+		expected string
+	}{
+		{
+			name:     "IPv4 address",
+			ip:       IP{IP: net.ParseIP("192.168.1.1")},
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "IPv6 address",
+			ip:       IP{IP: net.ParseIP("2001:db8::1")},
+			expected: "2001:db8::1",
+		},
+		{
+			name:     "nil IP",
+			ip:       IP{IP: nil},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.ip.String())
+		})
+	}
+}
+
+// Tests for Duration type YAML marshaling/unmarshaling
+func TestConfiguration_LoadFileConfigWithIP(t *testing.T) {
+	tests := []struct {
+		name           string
+		yamlContent    string
+		expectError    bool
+		expectedConfig *Configuration
+	}{
+		{
+			name: "load config with IPv4 neighbor addresses",
+			yamlContent: `
+neighbor-address:
+  - 192.168.1.1
+  - 192.168.1.2
+grpc-host: 10.0.0.1
+router-id: 10.0.0.254
+`,
+			expectError: false,
+			expectedConfig: &Configuration{
+				NeighborAddresses: []IP{
+					{IP: net.ParseIP("192.168.1.1")},
+					{IP: net.ParseIP("192.168.1.2")},
+				},
+				GrpcHost: IP{IP: net.ParseIP("10.0.0.1")},
+				RouterID: IP{IP: net.ParseIP("10.0.0.254")},
+			},
+		},
+		{
+			name: "load config with IPv6 neighbor addresses",
+			yamlContent: `
+neighbor-ipv6-address:
+  - 2001:db8::1
+  - 2001:db8::2
+grpc-host: fd00::1
+router-id: fd00::254
+`,
+			expectError: false,
+			expectedConfig: &Configuration{
+				NeighborIPv6Addresses: []IP{
+					{IP: net.ParseIP("2001:db8::1")},
+					{IP: net.ParseIP("2001:db8::2")},
+				},
+				GrpcHost: IP{IP: net.ParseIP("fd00::1")},
+				RouterID: IP{IP: net.ParseIP("fd00::254")},
+			},
+		},
+		{
+			name: "load config with mixed IPv4 and IPv6",
+			yamlContent: `
+neighbor-address:
+  - 192.168.1.1
+neighbor-ipv6-address:
+  - 2001:db8::1
+allowed-source-addresses:
+  - 10.0.0.1
+  - 10.0.0.2
+allowed-source-ipv6-addresses:
+  - fd00::1
+grpc-host: 192.168.1.100
+router-id: 192.168.1.254
+`,
+			expectError: false,
+			expectedConfig: &Configuration{
+				NeighborAddresses:     []IP{{IP: net.ParseIP("192.168.1.1")}},
+				NeighborIPv6Addresses: []IP{{IP: net.ParseIP("2001:db8::1")}},
+				AllowedSourceAddresses: []IP{
+					{IP: net.ParseIP("10.0.0.1")},
+					{IP: net.ParseIP("10.0.0.2")},
+				},
+				AllowedSourceIPv6Addresses: []IP{{IP: net.ParseIP("fd00::1")}},
+				GrpcHost:                   IP{IP: net.ParseIP("192.168.1.100")},
+				RouterID:                   IP{IP: net.ParseIP("192.168.1.254")},
+			},
+		},
+		{
+			name: "load config with invalid IPv4 address",
+			yamlContent: `
+neighbor-address:
+  - 192.168.1.256
+`,
+			expectError: true,
+		},
+		{
+			name: "load config with invalid IP format",
+			yamlContent: `
+neighbor-address:
+  - not-an-ip
+`,
+			expectError: true,
+		},
+		{
+			name: "load config with node-ips",
+			yamlContent: `
+node-ips:
+   IPv4: 10.0.0.1
+   IPv6: fd00::1
+`,
+			expectError: false,
+			expectedConfig: &Configuration{
+				NodeIPs: map[string]IP{
+					"IPv4": {IP: net.ParseIP("10.0.0.1")},
+					"IPv6": {IP: net.ParseIP("fd00::1")},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Configuration
+			err := yaml.Unmarshal([]byte(tt.yamlContent), &cfg)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.expectedConfig.GrpcHost.IP != nil {
+					require.True(t, tt.expectedConfig.GrpcHost.Equal(cfg.GrpcHost.IP), "GrpcHost mismatch")
+				}
+				if tt.expectedConfig.RouterID.IP != nil {
+					require.True(t, tt.expectedConfig.RouterID.Equal(cfg.RouterID.IP), "RouterID mismatch")
+				}
+				require.Len(t, cfg.NeighborAddresses, len(tt.expectedConfig.NeighborAddresses), "NeighborAddresses length mismatch")
+				for i, addr := range cfg.NeighborAddresses {
+					require.True(t, addr.Equal(tt.expectedConfig.NeighborAddresses[i].IP), "NeighborAddresses[%d] mismatch", i)
+				}
+				require.Len(t, cfg.NeighborIPv6Addresses, len(tt.expectedConfig.NeighborIPv6Addresses), "NeighborIPv6Addresses length mismatch")
+				for i, addr := range cfg.NeighborIPv6Addresses {
+					require.True(t, addr.Equal(tt.expectedConfig.NeighborIPv6Addresses[i].IP), "NeighborIPv6Addresses[%d] mismatch", i)
+				}
+				require.Len(t, cfg.AllowedSourceAddresses, len(tt.expectedConfig.AllowedSourceAddresses), "AllowedSourceAddresses length mismatch")
+				for i, addr := range cfg.AllowedSourceAddresses {
+					require.True(t, addr.Equal(tt.expectedConfig.AllowedSourceAddresses[i].IP), "AllowedSourceAddresses[%d] mismatch", i)
+				}
+				require.Len(t, cfg.AllowedSourceIPv6Addresses, len(tt.expectedConfig.AllowedSourceIPv6Addresses), "AllowedSourceIPv6Addresses length mismatch")
+				for i, addr := range cfg.AllowedSourceIPv6Addresses {
+					require.True(t, addr.Equal(tt.expectedConfig.AllowedSourceIPv6Addresses[i].IP), "AllowedSourceIPv6Addresses[%d] mismatch", i)
+				}
+				if len(tt.expectedConfig.NodeIPs) != 0 {
+					require.Len(t, cfg.NodeIPs, len(tt.expectedConfig.NodeIPs), "NodeIPs length mismatch")
+					for k, v := range tt.expectedConfig.NodeIPs {
+						cfgVal, ok := cfg.NodeIPs[k]
+						require.True(t, ok, "NodeIPs key %s not found", k)
+						require.True(t, v.Equal(cfgVal.IP), "NodeIPs[%s] mismatch", k)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestConfiguration_LoadFileConfigWithBooleans(t *testing.T) {
+	tests := []struct {
+		name        string
+		yamlContent string
+		expectError bool
+		checkFunc   func(*testing.T, *Configuration)
+	}{
+		{
+			name: "YAML with announce-cluster-ip true",
+			yamlContent: `
+announce-cluster-ip: true
+`,
+			expectError: false,
+			checkFunc: func(t *testing.T, cfg *Configuration) {
+				require.NotNil(t, cfg.AnnounceClusterIP)
+				require.True(t, *cfg.AnnounceClusterIP)
+			},
+		},
+		{
+			name: "YAML with announce-cluster-ip false",
+			yamlContent: `
+announce-cluster-ip: false
+`,
+			expectError: false,
+			checkFunc: func(t *testing.T, cfg *Configuration) {
+				require.NotNil(t, cfg.AnnounceClusterIP)
+				require.False(t, *cfg.AnnounceClusterIP)
+			},
+		},
+		{
+			name: "YAML omits boolean field",
+			yamlContent: `
+grpc-host: 10.0.0.1
+`,
+			expectError: false,
+			checkFunc: func(t *testing.T, cfg *Configuration) {
+				// Omitted boolean should be nil, not false
+				require.Nil(t, cfg.AnnounceClusterIP)
+				require.Nil(t, cfg.GracefulRestart)
+				require.Nil(t, cfg.PassiveMode)
+			},
+		},
+		{
+			name: "YAML with multiple boolean fields",
+			yamlContent: `
+graceful-restart: true
+passivemode: false
+enable-metrics: true
+enable-bfd: true
+`,
+			expectError: false,
+			checkFunc: func(t *testing.T, cfg *Configuration) {
+				require.NotNil(t, cfg.GracefulRestart)
+				require.True(t, *cfg.GracefulRestart)
+				require.NotNil(t, cfg.PassiveMode)
+				require.False(t, *cfg.PassiveMode)
+				require.NotNil(t, cfg.EnableMetrics)
+				require.True(t, *cfg.EnableMetrics)
+				require.NotNil(t, cfg.EnableBFD)
+				require.True(t, *cfg.EnableBFD)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Configuration
+			err := yaml.Unmarshal([]byte(tt.yamlContent), &cfg)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				tt.checkFunc(t, &cfg)
+			}
+		})
+	}
+}
+
+func TestDuration_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name           string
+		yamlValue      string
+		expectError    bool
+		expectDuration time.Duration
+		errorContains  string
+	}{
+		{
+			name:           "string format seconds",
+			yamlValue:      "90s",
+			expectDuration: 90 * time.Second,
+			expectError:    false,
+		},
+		{
+			name:           "string format minutes",
+			yamlValue:      "6m",
+			expectDuration: 6 * time.Minute,
+			expectError:    false,
+		},
+		{
+			name:           "string format hours",
+			yamlValue:      "1h",
+			expectDuration: 1 * time.Hour,
+			expectError:    false,
+		},
+		{
+			name:           "string format complex",
+			yamlValue:      "1h30m",
+			expectDuration: 1*time.Hour + 30*time.Minute,
+			expectError:    false,
+		},
+		{
+			name:           "integer seconds",
+			yamlValue:      "360",
+			expectDuration: 360 * time.Second,
+			expectError:    false,
+		},
+		{
+			name:           "integer zero",
+			yamlValue:      "0",
+			expectDuration: 0,
+			expectError:    false,
+		},
+		{
+			name:          "invalid string format",
+			yamlValue:     "invalid",
+			expectError:   true,
+			errorContains: "invalid duration",
+		},
+		{
+			name:          "string without unit",
+			yamlValue:     "\"360\"",
+			expectError:   true,
+			errorContains: "missing unit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d Duration
+
+			// Parse the YAML value
+			err := yaml.Unmarshal([]byte(tt.yamlValue), &d)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					require.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectDuration, d.Duration)
+			}
+		})
+	}
+}
+
+func TestDuration_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration Duration
+		expected string
+	}{
+		{
+			name:     "seconds",
+			duration: Duration{Duration: 90 * time.Second},
+			expected: "1m30s",
+		},
+		{
+			name:     "minutes",
+			duration: Duration{Duration: 6 * time.Minute},
+			expected: "6m0s",
+		},
+		{
+			name:     "hours",
+			duration: Duration{Duration: 1 * time.Hour},
+			expected: "1h0m0s",
+		},
+		{
+			name:     "zero duration",
+			duration: Duration{Duration: 0},
+			expected: "0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tt.duration)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected+"\n", string(data))
+		})
+	}
+}
+
+func TestDuration_Seconds(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration Duration
+		expected uint32
+	}{
+		{
+			name:     "90 seconds",
+			duration: Duration{Duration: 90 * time.Second},
+			expected: 90,
+		},
+		{
+			name:     "6 minutes",
+			duration: Duration{Duration: 6 * time.Minute},
+			expected: 360,
+		},
+		{
+			name:     "1 hour",
+			duration: Duration{Duration: 1 * time.Hour},
+			expected: 3600,
+		},
+		{
+			name:     "zero duration",
+			duration: Duration{Duration: 0},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.duration.Seconds())
+		})
+	}
+}
+
+func TestDuration_IsZero(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration Duration
+		expected bool
+	}{
+		{
+			name:     "zero duration",
+			duration: Duration{Duration: 0},
+			expected: true,
+		},
+		{
+			name:     "non-zero duration",
+			duration: Duration{Duration: 90 * time.Second},
+			expected: false,
+		},
+		{
+			name:     "negative duration",
+			duration: Duration{Duration: -90 * time.Second},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.duration.IsZero())
+		})
+	}
+}
+
+func TestToNetIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []IP
+		expected []net.IP
+	}{
+		{
+			name:     "empty slice",
+			input:    []IP{},
+			expected: []net.IP{},
+		},
+		{
+			name:     "single IPv4",
+			input:    []IP{{IP: net.ParseIP("192.168.1.1")}},
+			expected: []net.IP{net.ParseIP("192.168.1.1")},
+		},
+		{
+			name: "multiple IPv4 and IPv6",
+			input: []IP{
+				{IP: net.ParseIP("192.168.1.1")},
+				{IP: net.ParseIP("2001:db8::1")},
+				{IP: net.ParseIP("10.0.0.1")},
+			},
+			expected: []net.IP{
+				net.ParseIP("192.168.1.1"),
+				net.ParseIP("2001:db8::1"),
+				net.ParseIP("10.0.0.1"),
+			},
+		},
+		{
+			name: "skip nil IPs",
+			input: []IP{
+				{IP: net.ParseIP("192.168.1.1")},
+				{IP: nil},
+				{IP: net.ParseIP("10.0.0.1")},
+			},
+			expected: []net.IP{
+				net.ParseIP("192.168.1.1"),
+				net.ParseIP("10.0.0.1"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toNetIPs(tt.input)
+			require.Len(t, result, len(tt.expected))
+			for i, ip := range result {
+				require.True(t, ip.Equal(tt.expected[i]), "index %d: expected %v, got %v", i, tt.expected[i], ip)
+			}
+		})
+	}
+}
+
+func TestConfiguration_LoadFileConfigWithDuration(t *testing.T) {
+	tests := []struct {
+		name           string
+		yamlContent    string
+		expectError    bool
+		expectedConfig *Configuration
+	}{
+		{
+			name: "load config with string duration format",
+			yamlContent: `
+holdtime: 90s
+graceful-restart-time: 90s
+graceful-restart-deferral-time: 360s
+`,
+			expectError: false,
+			expectedConfig: &Configuration{
+				HoldTime:                    Duration{Duration: 90 * time.Second},
+				GracefulRestartTime:         Duration{Duration: 90 * time.Second},
+				GracefulRestartDeferralTime: Duration{Duration: 360 * time.Second},
+			},
+		},
+		{
+			name: "load config with integer duration format",
+			yamlContent: `
+holdtime: 90
+graceful-restart-time: 90
+graceful-restart-deferral-time: 360
+`,
+			expectError: false,
+			expectedConfig: &Configuration{
+				HoldTime:                    Duration{Duration: 90 * time.Second},
+				GracefulRestartTime:         Duration{Duration: 90 * time.Second},
+				GracefulRestartDeferralTime: Duration{Duration: 360 * time.Second},
+			},
+		},
+		{
+			name: "load config with mixed duration format",
+			yamlContent: `
+holdtime: 90s
+graceful-restart-time: 90
+graceful-restart-deferral-time: 6m
+`,
+			expectError: false,
+			expectedConfig: &Configuration{
+				HoldTime:                    Duration{Duration: 90 * time.Second},
+				GracefulRestartTime:         Duration{Duration: 90 * time.Second},
+				GracefulRestartDeferralTime: Duration{Duration: 6 * time.Minute},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Configuration
+			err := yaml.Unmarshal([]byte(tt.yamlContent), &cfg)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedConfig.HoldTime, cfg.HoldTime)
+				require.Equal(t, tt.expectedConfig.GracefulRestartTime, cfg.GracefulRestartTime)
+				require.Equal(t, tt.expectedConfig.GracefulRestartDeferralTime, cfg.GracefulRestartDeferralTime)
+			}
+		})
+	}
+}
+
+func TestConfiguration_CheckGracefulRestartOptions(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        *Configuration
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "valid graceful restart options",
+			config: &Configuration{
+				GracefulRestartTime:         Duration{Duration: 90 * time.Second},
+				GracefulRestartDeferralTime: Duration{Duration: 360 * time.Second},
+			},
+			expectError: false,
+		},
+		{
+			name: "graceful restart time too large",
+			config: &Configuration{
+				GracefulRestartTime:         Duration{Duration: 4096 * time.Second},
+				GracefulRestartDeferralTime: Duration{Duration: 360 * time.Second},
+			},
+			expectError:   true,
+			errorContains: "less than 4095 seconds",
+		},
+		{
+			name: "graceful restart time zero",
+			config: &Configuration{
+				GracefulRestartTime:         Duration{Duration: 0},
+				GracefulRestartDeferralTime: Duration{Duration: 360 * time.Second},
+			},
+			expectError:   true,
+			errorContains: "more than 0",
+		},
+		{
+			name: "graceful restart deferral time too large",
+			config: &Configuration{
+				GracefulRestartTime:         Duration{Duration: 90 * time.Second},
+				GracefulRestartDeferralTime: Duration{Duration: 19 * time.Hour},
+			},
+			expectError:   true,
+			errorContains: "less than 18 hours",
+		},
+		{
+			name: "graceful restart deferral time zero",
+			config: &Configuration{
+				GracefulRestartTime:         Duration{Duration: 90 * time.Second},
+				GracefulRestartDeferralTime: Duration{Duration: 0},
+			},
+			expectError:   true,
+			errorContains: "more than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.checkGracefulRestartOptions()
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					require.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfiguration_MergeFileConfig_BooleanPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		baseConfig     *Configuration
+		fileConfig     *Configuration
+		expectedResult *Configuration
+		description    string
+	}{
+		{
+			name: "YAML omits boolean - CLI value preserved",
+			baseConfig: &Configuration{
+				AnnounceClusterIP: boolPtr(true),
+				GracefulRestart:   boolPtr(true),
+				PassiveMode:       boolPtr(true),
+			},
+			fileConfig: &Configuration{
+				// All boolean fields are nil (not set in YAML)
+				GrpcHost: IP{IP: net.ParseIP("10.0.0.1")},
+			},
+			expectedResult: &Configuration{
+				AnnounceClusterIP: boolPtr(true),
+				GracefulRestart:   boolPtr(true),
+				PassiveMode:       boolPtr(true),
+				GrpcHost:          IP{IP: net.ParseIP("10.0.0.1")},
+			},
+			description: "When YAML omits boolean fields, CLI values should be preserved",
+		},
+		{
+			name: "YAML explicitly sets false - overrides CLI true",
+			baseConfig: &Configuration{
+				AnnounceClusterIP: boolPtr(true),
+				GracefulRestart:   boolPtr(true),
+			},
+			fileConfig: &Configuration{
+				AnnounceClusterIP: boolPtr(false),
+				GracefulRestart:   boolPtr(false),
+			},
+			expectedResult: &Configuration{
+				AnnounceClusterIP: boolPtr(false),
+				GracefulRestart:   boolPtr(false),
+			},
+			description: "When YAML explicitly sets false, it should override CLI true",
+		},
+		{
+			name: "YAML sets true - overrides CLI false",
+			baseConfig: &Configuration{
+				PassiveMode: boolPtr(false),
+			},
+			fileConfig: &Configuration{
+				PassiveMode: boolPtr(true),
+			},
+			expectedResult: &Configuration{
+				PassiveMode: boolPtr(true),
+			},
+			description: "When YAML sets true, it should override CLI false",
+		},
+		{
+			name: "Mixed - some set, some omitted",
+			baseConfig: &Configuration{
+				AnnounceClusterIP: boolPtr(true),
+				GracefulRestart:   boolPtr(false),
+				PassiveMode:       boolPtr(true),
+			},
+			fileConfig: &Configuration{
+				GracefulRestart: boolPtr(true),
+				// AnnounceClusterIP and PassiveMode omitted
+			},
+			expectedResult: &Configuration{
+				AnnounceClusterIP: boolPtr(true), // preserved from CLI
+				GracefulRestart:   boolPtr(true), // overridden by YAML
+				PassiveMode:       boolPtr(true), // preserved from CLI
+			},
+			description: "Mixed scenario - only explicitly set YAML fields override CLI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.baseConfig.mergeFileConfig(tt.fileConfig)
+
+			if tt.expectedResult.AnnounceClusterIP != nil {
+				require.NotNil(t, tt.baseConfig.AnnounceClusterIP, "AnnounceClusterIP")
+				require.Equal(t, *tt.expectedResult.AnnounceClusterIP, *tt.baseConfig.AnnounceClusterIP,
+					"AnnounceClusterIP: %s", tt.description)
+			}
+			if tt.expectedResult.GracefulRestart != nil {
+				require.NotNil(t, tt.baseConfig.GracefulRestart, "GracefulRestart")
+				require.Equal(t, *tt.expectedResult.GracefulRestart, *tt.baseConfig.GracefulRestart,
+					"GracefulRestart: %s", tt.description)
+			}
+			if tt.expectedResult.PassiveMode != nil {
+				require.NotNil(t, tt.baseConfig.PassiveMode, "PassiveMode")
+				require.Equal(t, *tt.expectedResult.PassiveMode, *tt.baseConfig.PassiveMode,
+					"PassiveMode: %s", tt.description)
+			}
+			if tt.expectedResult.GrpcHost.IP != nil {
+				require.True(t, tt.expectedResult.GrpcHost.Equal(tt.baseConfig.GrpcHost.IP), "GrpcHost")
+			}
+		})
+	}
 }

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -114,7 +114,7 @@ func NewController(config *Configuration) *Controller {
 		recorder:               recorder,
 	}
 
-	if config.EnableMetrics {
+	if config.EnableMetrics != nil && *config.EnableMetrics {
 		registerSpeakerMetrics()
 	}
 
@@ -140,7 +140,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 }
 
 func (c *Controller) Reconcile() {
-	if c.config.NatGwMode {
+	if c.config.NatGwMode != nil && *c.config.NatGwMode {
 		err := c.syncEIPRoutes()
 		if err != nil {
 			klog.Errorf("failed to reconcile EIPs: %s", err.Error())
@@ -151,7 +151,7 @@ func (c *Controller) Reconcile() {
 
 	c.logBFDStatus()
 
-	if c.config.EnableMetrics {
+	if c.config.EnableMetrics != nil && *c.config.EnableMetrics {
 		c.collectMetrics()
 	}
 }

--- a/pkg/speaker/metrics.go
+++ b/pkg/speaker/metrics.go
@@ -271,7 +271,7 @@ func deleteStaleBFDPeerSeries(node string, last, current map[string]struct{}) {
 // metrics are enabled.
 func (c *Controller) collectMetrics() {
 	c.collectBGPMetrics()
-	if c.config.EnableBFD {
+	if c.config.EnableBFD != nil && *c.config.EnableBFD {
 		c.collectBFDMetrics()
 	}
 }

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -41,7 +41,7 @@ func (c *Controller) syncSubnetRoutes() {
 		return
 	}
 
-	if c.config.AnnounceClusterIP {
+	if c.config.AnnounceClusterIP != nil && *c.config.AnnounceClusterIP {
 		services, err := c.servicesLister.List(labels.Everything())
 		if err != nil {
 			klog.Errorf("failed to list services, %v", err)

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -382,9 +382,10 @@ const (
 	EnvHostIP       = "HOST_IP"
 	EnvHostIPs      = "HOST_IPS"
 
-	EnvSSLEnabled                 = "ENABLE_SSL"
-	EnvKubeOVNTLSRotationInterval = "KUBE_OVN_TLS_ROTATION_INTERVAL"
-	EnvGatewayName                = "GATEWAY_NAME"
+	EnvSSLEnabled                  = "ENABLE_SSL"
+	EnvKubeOVNBGPSpeakerConfigFile = "KUBE_OVN_BGP_SPEAKER_CONFIG_FILE"
+	EnvKubeOVNTLSRotationInterval  = "KUBE_OVN_TLS_ROTATION_INTERVAL"
+	EnvGatewayName                 = "GATEWAY_NAME"
 )
 
 const (


### PR DESCRIPTION
## What type of this PR

    Added custom IP type for YAML serialization

     - Wrapper around net.IP for proper YAML parsing
     - Supports string format ("192.168.1.1", "2001:db8::1")
     - Implements UnmarshalYAML()

    Added custom Duration type for YAML serialization

     - Supports string format ("90s", "5m", "1h") and integer seconds (360)
     - Implements UnmarshalYAML()

    Updated Configuration struct

     - Added YAML tags to all configurable fields
     - Changed GrpcHost, RouterID to use IP type
     - Changed NodeIPs to map[string]IP
     - Changed NeighborAddresses, NeighborIPv6Addresses to []IP
     - Changed AllowedSourceAddresses, AllowedSourceIPv6Addresses to []IP
     - Changed HoldTime, GracefulRestartTime, GracefulRestartDeferralTime to use Duration type

    Implemented YAML config file loading

     - New --config flag for config file path
     - loadFileConfig() method for reading YAML configs
     - mergeFileConfig() method for merging file config with CLI flags

    Updated Helm charts

     - Added config file volume mount to speaker deployment
     - Updated values.yaml with BGP speaker config options
     - Updated README.md with configuration examples

## Use to override host kube-ovn-speaker configuration

The host configuration can be overridden using built-in Kubernetes functionality. For this, you can use the ConfigMap structure

```
apiVersion: v1
data:
  ix-m3-sm14-k8s-worker01.srv.hwaas.ru.yaml: |
    cluster-as: 4294386121
    graceful-restart: true
    neighbor-address:
      - 10.120.254.254
    neighbor-as: 4294386121
    router-id: 127.0.0.1
  ix-m3-sm14-k8s-worker02.srv.hwaas.ru.yaml: |
    cluster-as: 4294386117
    graceful-restart: true
    neighbor-address:
      - 10.120.254.254
    neighbor-as: 4294386117
    router-id: 127.0.0.1
kind: ConfigMap
```

Which is mounted in the kube-ovn-speaker pod

```
  volumes:
  - configMap:
      name: kube-ovn-bgp-speaker-config
    name: kube-ovn-bgp-speaker-config
```

```
    volumeMounts:
    - mountPath: /etc/kube-ovn/
      name: kube-ovn-bgp-speaker-config
```

```
nobody@ix-m3-sm14-k8s-worker01:/kube-ovn$ ls -al /etc/kube-ovn/
total 12
drwxrwxrwx 3 root root 4096 Jun 25 13:27 .
drwxr-xr-x 1 root root 4096 Jun 25 13:28 ..
drwxr-xr-x 2 root root 4096 Jun 25 13:27 ..2026_06_25_13_27_59.2175855446
lrwxrwxrwx 1 root root   32 Jun 25 13:27 ..data -> ..2026_06_25_13_27_59.2175855446
lrwxrwxrwx 1 root root   56 Jun 25 13:27 ix-m3-sm14-k8s-worker01.srv.hwaas.ru.yaml -> ..data/ix-m3-sm14-k8s-worker01.srv.hwaas.ru.yaml
lrwxrwxrwx 1 root root   56 Jun 25 13:27 ix-m3-sm14-k8s-worker02.srv.hwaas.ru.yaml -> ..data/ix-m3-sm14-k8s-worker02.srv.hwaas.ru.yaml
```

And can be used as an individual host configuration by defining the pod env variable `KUBE_OVN_BGP_SPEAKER_CONFIG_FILE`. Used by the kube-ovn-speaker to define the configuration file

```
    - name: KUBE_OVN_BGP_SPEAKER_CONFIG_FILE
      value: /etc/kube-ovn/$(NODE_NAME).yaml
```

```
nobody@ix-m3-sm14-k8s-worker01:/kube-ovn$ export
declare -x KUBE_OVN_BGP_SPEAKER_CONFIG_FILE="/etc/kube-ovn/ix-m3-sm14-k8s-worker01.srv.hwaas.ru.yaml"
```

## Which issue(s) this PR fixes

Fixes #6702
