### PR TITLE
feat: allow kube-ovn TLS rotation e2e test to run on v1.15+

### DIFF
--- a/test/e2e/security/kube_ovn_tls_rotation_test.go
+++ b/test/e2e/security/kube_ovn_tls_rotation_test.go
@@ -50,7 +50,7 @@ var _ = framework.Describe("[group:security] kube-ovn TLS rotation", func() {
 	f.SkipNamespaceCreation = true
 
 	framework.ConformanceIt("should reload components without restarting pods when kube-ovn-tls secret is updated", func() {
-		f.SkipVersionPriorTo(1, 17, "kube-ovn TLS rotation was introduced in v1.17")
+		f.SkipVersionPriorTo(1, 15, "kube-ovn TLS rotation was introduced in v1.15")
 
 		cs := f.ClientSet
 		deployClient := f.DeploymentClientNS(framework.KubeOvnNamespace)


### PR DESCRIPTION
将 kube-ovn TLS rotation e2e 测试的版本限制从 v1.17 降低到 v1.15，使该测试能在 v1.15 及以上版本运行。

Signed-off-by: clyi <clyi@alauda.io>