### PR TITLE
fix: improve BGP BFD metrics, logging, type safety and peer state check

### DIFF
--- a/pkg/speaker/bfd.go
+++ b/pkg/speaker/bfd.go
@@ -24,14 +24,9 @@ func bfdSessionStateString(state api.BfdSessionState) string {
 }
 
 // logBFDStatus logs the BFD status for all peers.
-// Guarded by klog verbosity to avoid unnecessary gRPC calls when logging is off.
+// Error/recovery stats are always checked; per-peer state dump is gated by V(3).
 func (c *Controller) logBFDStatus() {
 	if !c.config.EnableBFD {
-		return
-	}
-
-	// Guard with Enabled() to skip gRPC calls when log level is insufficient.
-	if !klog.V(3).Enabled() {
 		return
 	}
 
@@ -45,6 +40,11 @@ func (c *Controller) logBFDStatus() {
 				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
 		}
 		c.lastBFDStatsHasErrors = hasErrors
+	}
+
+	// Guard per-peer BFD state dump with V(3) to skip gRPC calls when log level is insufficient.
+	if !klog.V(3).Enabled() {
+		return
 	}
 
 	if c.lastBFDPeerStates == nil {

--- a/pkg/speaker/bfd.go
+++ b/pkg/speaker/bfd.go
@@ -7,6 +7,47 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type bfdErrorCounters struct {
+	receivedDrop  uint64
+	receivedError uint64
+	invalidPacket uint64
+	unknownPeer   uint64
+}
+
+func bfdErrorCountersFromStats(stats *api.BfdState) bfdErrorCounters {
+	return bfdErrorCounters{
+		receivedDrop:  stats.ReceivedDrop,
+		receivedError: stats.ReceivedError,
+		invalidPacket: stats.InvalidPacket,
+		unknownPeer:   stats.UnknownPeer,
+	}
+}
+
+func (curr bfdErrorCounters) hasIncreaseSince(prev bfdErrorCounters) bool {
+	return curr.receivedDrop > prev.receivedDrop ||
+		curr.receivedError > prev.receivedError ||
+		curr.invalidPacket > prev.invalidPacket ||
+		curr.unknownPeer > prev.unknownPeer
+}
+
+func (curr bfdErrorCounters) isResetComparedTo(prev bfdErrorCounters) bool {
+	return curr.receivedDrop < prev.receivedDrop ||
+		curr.receivedError < prev.receivedError ||
+		curr.invalidPacket < prev.invalidPacket ||
+		curr.unknownPeer < prev.unknownPeer
+}
+
+// sub returns the per-counter increase of curr over prev.
+// Callers must ensure curr >= prev (no counter reset) to avoid underflow.
+func (curr bfdErrorCounters) sub(prev bfdErrorCounters) bfdErrorCounters {
+	return bfdErrorCounters{
+		receivedDrop:  curr.receivedDrop - prev.receivedDrop,
+		receivedError: curr.receivedError - prev.receivedError,
+		invalidPacket: curr.invalidPacket - prev.invalidPacket,
+		unknownPeer:   curr.unknownPeer - prev.unknownPeer,
+	}
+}
+
 // bfdSessionStateString converts a BFD session state enum to a human-readable string.
 func bfdSessionStateString(state api.BfdSessionState) string {
 	switch state {
@@ -31,15 +72,31 @@ func (c *Controller) logBFDStatus() {
 	}
 
 	if stats := c.config.BgpServer.GetBfdServerStats(); stats != nil {
-		hasErrors := stats.ReceivedDrop > 0 || stats.ReceivedError > 0 || stats.InvalidPacket > 0 || stats.UnknownPeer > 0
-		if hasErrors {
-			klog.Warningf("BFD server stats: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d",
+		curr := bfdErrorCountersFromStats(stats)
+
+		hasNewErrors := false
+		if c.hasLastBFDStatsSample {
+			if curr.isResetComparedTo(c.lastBFDErrorCounters) {
+				// Counter reset/rollover: re-baseline and avoid false positives.
+				hasNewErrors = false
+			} else {
+				hasNewErrors = curr.hasIncreaseSince(c.lastBFDErrorCounters)
+			}
+		}
+
+		if hasNewErrors {
+			delta := curr.sub(c.lastBFDErrorCounters)
+			klog.Warningf("BFD server stats: new errors since last check: dropped=+%d, errors=+%d, invalid=+%d, unknownPeer=+%d (cumulative: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d)",
+				delta.receivedDrop, delta.receivedError, delta.invalidPacket, delta.unknownPeer,
 				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
 		} else if c.lastBFDStatsHasErrors {
 			klog.Infof("BFD server stats recovered: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d",
 				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
 		}
-		c.lastBFDStatsHasErrors = hasErrors
+
+		c.lastBFDErrorCounters = curr
+		c.hasLastBFDStatsSample = true
+		c.lastBFDStatsHasErrors = hasNewErrors
 	}
 
 	// Guard per-peer BFD state dump with V(3) to skip gRPC calls when log level is insufficient.

--- a/pkg/speaker/bfd.go
+++ b/pkg/speaker/bfd.go
@@ -30,31 +30,60 @@ func (c *Controller) logBFDStatus() {
 		return
 	}
 
-	// Log BFD server statistics
-	if klog.V(4).Enabled() {
-		if stats := c.config.BgpServer.GetBfdServerStats(); stats != nil {
-			klog.V(4).Infof("BFD server stats: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d",
-				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
-		}
+	// Guard with Enabled() to skip gRPC calls when log level is insufficient.
+	if !klog.V(3).Enabled() {
+		return
 	}
 
-	if !klog.V(5).Enabled() {
-		return
+	if stats := c.config.BgpServer.GetBfdServerStats(); stats != nil {
+		hasErrors := stats.ReceivedDrop > 0 || stats.ReceivedError > 0 || stats.InvalidPacket > 0 || stats.UnknownPeer > 0
+		if hasErrors {
+			klog.Warningf("BFD server stats: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d",
+				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
+		} else if c.lastBFDStatsHasErrors {
+			klog.Infof("BFD server stats recovered: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d",
+				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
+		}
+		c.lastBFDStatsHasErrors = hasErrors
+	}
+
+	if c.lastBFDPeerStates == nil {
+		c.lastBFDPeerStates = make(map[string]string)
 	}
 
 	c.config.BgpServer.ListBfdPeer(context.Background(), func(addr string, state *api.BfdPeerState) {
 		if state == nil {
-			klog.V(5).Infof("BFD peer %s: no state available", addr)
+			klog.Warningf("BFD peer %s: no state available", addr)
 			return
 		}
 
+		current := bfdSessionStateString(state.SessionState)
+		if prev, ok := c.lastBFDPeerStates[addr]; ok && prev == current {
+			return
+		}
+		c.lastBFDPeerStates[addr] = current
+
 		if async := state.BfdAsync; async != nil {
-			klog.V(5).Infof("BFD peer %s: state=%s, tx=%d, rx=%d",
-				addr, bfdSessionStateString(state.SessionState),
-				async.TransmittedPackets, async.ReceivedPackets)
+			klog.Infof("BFD peer %s: state=%s, tx=%d, rx=%d",
+				addr, current, async.TransmittedPackets, async.ReceivedPackets)
 		} else {
-			klog.V(5).Infof("BFD peer %s: state=%s",
-				addr, bfdSessionStateString(state.SessionState))
+			klog.Infof("BFD peer %s: state=%s", addr, current)
 		}
 	})
+}
+
+// newBFDPeerConfig creates a BfdPeerConfig from the speaker Configuration.
+// Returns nil when BFD is disabled.
+// GoBGP expects BFD intervals in microseconds (RFC 5880), while CLI flags
+// accept milliseconds for user convenience; this function performs the conversion.
+func newBFDPeerConfig(config *Configuration) *api.BfdPeerConfig {
+	if !config.EnableBFD {
+		return nil
+	}
+	return &api.BfdPeerConfig{
+		Enabled:                  true,
+		DesiredMinimumTxInterval: config.BFDMinTX * 1000, // ms → μs
+		RequiredMinimumReceive:   config.BFDMinRX * 1000, // ms → μs
+		DetectionMultiplier:      uint32(config.BFDDetectionMultiplier),
+	}
 }

--- a/pkg/speaker/bfd_test.go
+++ b/pkg/speaker/bfd_test.go
@@ -1,6 +1,7 @@
 package speaker
 
 import (
+	"math"
 	"net"
 	"testing"
 
@@ -124,19 +125,7 @@ func TestValidateBFDFlags(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "detection multiplier too large",
-			config: &Configuration{
-				EnableBFD:              true,
-				BFDMinTX:               1000,
-				BFDMinRX:               1000,
-				BFDDetectionMultiplier: 256,
-				NeighborAs:             65001,
-				ClusterAs:              65000,
-				NodeName:               "test-node",
-			},
-			wantErr: true,
-		},
-		{
+			// Upper bound (255) is enforced by the uint8 type, so no >255 test case is needed.
 			name: "detection multiplier zero",
 			config: &Configuration{
 				EnableBFD:              true,
@@ -179,12 +168,51 @@ func TestValidateBFDFlags(t *testing.T) {
 			name: "BFD disabled skips validation",
 			config: &Configuration{
 				EnableBFD:              false,
-				BFDDetectionMultiplier: 999,
+				BFDDetectionMultiplier: 255,
 				NeighborAs:             65001,
 				ClusterAs:              65000,
 				NodeName:               "test-node",
 			},
 			wantErr: false,
+		},
+		{
+			name: "min-tx at overflow boundary is valid",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               math.MaxUint32 / 1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: false,
+		},
+		{
+			name: "min-tx exceeds overflow boundary",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               math.MaxUint32/1000 + 1,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "min-rx exceeds overflow boundary",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               math.MaxUint32/1000 + 1,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
 		},
 	}
 

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"os"
 	"slices"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 	"github.com/spf13/pflag"
@@ -69,7 +71,7 @@ type Configuration struct {
 	EnableBFD              bool
 	BFDMinTX               uint32 // minimum transmit interval in milliseconds (converted to microseconds for GoBGP)
 	BFDMinRX               uint32 // minimum receive interval in milliseconds (converted to microseconds for GoBGP)
-	BFDDetectionMultiplier uint32 // detection multiplier (must be <= 255)
+	BFDDetectionMultiplier uint8  // RFC 5880 §6.8.1: valid range 1-255
 
 	NodeName       string
 	KubeConfigFile string
@@ -108,9 +110,9 @@ func ParseFlags() (*Configuration, error) {
 		argEnableMetrics               = pflag.BoolP("enable-metrics", "", true, "Whether to support metrics query")
 		argLogPerm                     = pflag.String("log-perm", "640", "The permission for the log file")
 		argEnableBFD                   = pflag.BoolP("enable-bfd", "", false, "Enable BFD (Bidirectional Forwarding Detection) for fast failure detection")
-		argBFDMinTX                    = pflag.Uint32("bfd-min-tx", 1000, "BFD minimum transmit interval in milliseconds (default 1000ms)")
-		argBFDMinRX                    = pflag.Uint32("bfd-min-rx", 1000, "BFD minimum receive interval in milliseconds (default 1000ms)")
-		argBFDDetectionMultiplier      = pflag.Uint32("bfd-detection-multiplier", 3, "BFD detection multiplier (default 3)")
+		argBFDMinTX                    = pflag.Uint32("bfd-min-tx", 1000, "BFD minimum transmit interval in milliseconds (default 1000, max 4294967)")
+		argBFDMinRX                    = pflag.Uint32("bfd-min-rx", 1000, "BFD minimum receive interval in milliseconds (default 1000, max 4294967)")
+		argBFDDetectionMultiplier      = pflag.Uint8("bfd-detection-multiplier", 3, "BFD detection multiplier (default 3, valid range 1-255 per RFC 5880)")
 	)
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -273,14 +275,18 @@ func (config *Configuration) validateRequiredFlags() error {
 	}
 
 	if config.EnableBFD {
-		if config.BFDDetectionMultiplier == 0 || config.BFDDetectionMultiplier > 255 {
+		if config.BFDDetectionMultiplier == 0 {
 			missingFlags = append(missingFlags, "--bfd-detection-multiplier must be between 1 and 255")
 		}
 		if config.BFDMinTX == 0 {
 			missingFlags = append(missingFlags, "--bfd-min-tx must be > 0")
+		} else if config.BFDMinTX > math.MaxUint32/1000 {
+			missingFlags = append(missingFlags, "--bfd-min-tx must be <= 4294967 ms to avoid uint32 overflow in ms-to-μs conversion")
 		}
 		if config.BFDMinRX == 0 {
 			missingFlags = append(missingFlags, "--bfd-min-rx must be > 0")
+		} else if config.BFDMinRX > math.MaxUint32/1000 {
+			missingFlags = append(missingFlags, "--bfd-min-rx must be <= 4294967 ms to avoid uint32 overflow in ms-to-μs conversion")
 		}
 	}
 
@@ -337,22 +343,6 @@ func (config *Configuration) checkGracefulRestartOptions() error {
 	}
 
 	return nil
-}
-
-// newBFDPeerConfig creates a BfdPeerConfig from the speaker Configuration.
-// Returns nil when BFD is disabled.
-// GoBGP expects BFD intervals in microseconds (RFC 5880), while CLI flags
-// accept milliseconds for user convenience; this function performs the conversion.
-func newBFDPeerConfig(config *Configuration) *api.BfdPeerConfig {
-	if !config.EnableBFD {
-		return nil
-	}
-	return &api.BfdPeerConfig{
-		Enabled:                  true,
-		DesiredMinimumTxInterval: config.BFDMinTX * 1000, // ms → μs
-		RequiredMinimumReceive:   config.BFDMinRX * 1000, // ms → μs
-		DetectionMultiplier:      config.BFDDetectionMultiplier,
-	}
 }
 
 func (config *Configuration) initBgpServer() error {
@@ -472,12 +462,11 @@ func (config *Configuration) initBgpServer() error {
 				})
 			}
 
-			// Enable BFD if configured
-			if config.EnableBFD {
-				peer.Bfd = newBFDPeerConfig(config)
+			peer.Bfd = newBFDPeerConfig(config)
+			if peer.Bfd != nil {
 				klog.Infof("BFD enabled for peer %s: MinTX=%dms(%dμs), MinRX=%dms(%dμs), Multiplier=%d",
-					addr.String(), config.BFDMinTX, peer.Bfd.DesiredMinimumTxInterval,
-					config.BFDMinRX, peer.Bfd.RequiredMinimumReceive, config.BFDDetectionMultiplier)
+					addr.String(), config.BFDMinTX, config.BFDMinTX*1000,
+					config.BFDMinRX, config.BFDMinRX*1000, config.BFDDetectionMultiplier)
 			}
 
 			logBgpPeer(peer)
@@ -490,6 +479,10 @@ func (config *Configuration) initBgpServer() error {
 	}
 
 	config.BgpServer = s
+
+	// Start watching peer state changes for detailed logging
+	go config.watchPeerState()
+
 	return nil
 }
 
@@ -513,7 +506,7 @@ func addPeerWithRetry(s *gobgp.BgpServer, peer *api.Peer) error {
 	return err
 }
 
-// logBgpPeer logs the BGP peer configuration for debugging purposes.
+// logBgpPeer logs the BGP peer configuration details, masking sensitive information.
 func logBgpPeer(peer *api.Peer) {
 	klog.Infof("BGP Peer Configuration: NeighborAddress=%s, LocalAddress=%s, PeerAsn=%d, HoldTime=%d, PassiveMode=%v, EbgpMultihop=%v, GracefulRestart=%v, AfiSafis=%v, BFD=%v",
 		peer.Conf.NeighborAddress,
@@ -525,6 +518,40 @@ func logBgpPeer(peer *api.Peer) {
 		peer.GracefulRestart,
 		peer.AfiSafis,
 		peer.Bfd)
+}
+
+// watchPeerState monitors BGP peer state changes and logs detailed information
+// including local address when peers go up or down.
+func (config *Configuration) watchPeerState() {
+	err := config.BgpServer.WatchEvent(context.Background(), gobgp.WatchEventMessageCallbacks{
+		OnPeerUpdate: func(peer *apiutil.WatchEventMessage_PeerEvent, _ time.Time) {
+			if peer == nil || peer.Type != apiutil.PEER_EVENT_STATE {
+				return
+			}
+			p := peer.Peer
+			neighborAddr := p.Conf.NeighborAddress.String()
+
+			var bfdState string
+			if config.EnableBFD {
+				config.BgpServer.ListBfdPeer(context.Background(), func(addr string, st *api.BfdPeerState) {
+					if addr == neighborAddr && st != nil {
+						bfdState = bfdSessionStateString(st.SessionState)
+					}
+				})
+			}
+
+			if bfdState != "" {
+				klog.Infof("BGP peer state changed: neighbor=%s, state=%s, localAddress=%s, peerAS=%d, bfd=%s",
+					neighborAddr, p.State.SessionState, p.Transport.LocalAddress, p.Conf.PeerASN, bfdState)
+			} else {
+				klog.Infof("BGP peer state changed: neighbor=%s, state=%s, localAddress=%s, peerAS=%d",
+					neighborAddr, p.State.SessionState, p.Transport.LocalAddress, p.Conf.PeerASN)
+			}
+		},
+	}, gobgp.WatchPeer())
+	if err != nil {
+		klog.Errorf("failed to watch peer state: %v", err)
+	}
 }
 
 func (config *Configuration) initNeighborLocalAddresses() error {

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -52,6 +52,15 @@ type Controller struct {
 	lastBFDErrorCounters  bfdErrorCounters
 	hasLastBFDStatsSample bool
 	lastBFDStatsHasErrors bool
+
+	// lastBGPPeers / lastBFDPeers track the per-peer series exported in the
+	// previous metrics collection cycle, keyed by peer address (BGP also keeps
+	// the peer ASN needed to delete its label set). They let collectBGPMetrics /
+	// collectBFDMetrics delete only the series of peers that disappeared, instead
+	// of Reset()-ing every series each cycle, which would expose a brief empty
+	// window to a concurrent Prometheus scrape (metric flapping).
+	lastBGPPeers map[string]string
+	lastBFDPeers map[string]struct{}
 }
 
 func NewController(config *Configuration) *Controller {

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -49,6 +49,8 @@ type Controller struct {
 	// lastBFDPeerStates caches the most recent BFD session state per peer address.
 	// Used by logBFDStatus to suppress repeated logs when state is unchanged.
 	lastBFDPeerStates     map[string]string
+	lastBFDErrorCounters  bfdErrorCounters
+	hasLastBFDStatsSample bool
 	lastBFDStatsHasErrors bool
 }
 
@@ -103,6 +105,10 @@ func NewController(config *Configuration) *Controller {
 		recorder:               recorder,
 	}
 
+	if config.EnableMetrics {
+		registerSpeakerMetrics()
+	}
+
 	return controller
 }
 
@@ -135,4 +141,8 @@ func (c *Controller) Reconcile() {
 	}
 
 	c.logBFDStatus()
+
+	if c.config.EnableMetrics {
+		c.collectMetrics()
+	}
 }

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -45,6 +45,11 @@ type Controller struct {
 	podInformerFactory     kubeinformers.SharedInformerFactory
 	kubeovnInformerFactory kubeovninformer.SharedInformerFactory
 	recorder               record.EventRecorder
+
+	// lastBFDPeerStates caches the most recent BFD session state per peer address.
+	// Used by logBFDStatus to suppress repeated logs when state is unchanged.
+	lastBFDPeerStates     map[string]string
+	lastBFDStatsHasErrors bool
 }
 
 func NewController(config *Configuration) *Controller {
@@ -129,8 +134,5 @@ func (c *Controller) Reconcile() {
 		c.syncSubnetRoutes()
 	}
 
-	// Log BFD status if enabled
-	if c.config.EnableBFD {
-		c.logBFDStatus()
-	}
+	c.logBFDStatus()
 }

--- a/pkg/speaker/metrics.go
+++ b/pkg/speaker/metrics.go
@@ -118,14 +118,14 @@ var (
 	metricBFDPeerRemoteState = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kube_ovn_speaker_bfd_peer_remote_session_state",
-			Help: "Remote BFD session state of the peer (0=unspecified,1=up,2=down,3=admin_down,4=init).",
+			Help: "Remote BFD session state of the peer (0=unspecified,1=up,2=down,3=admin_down,4=init). Not reported by GoBGP v4.6.0 (always 0); will become meaningful once upstream populates it.",
 		},
 		[]string{"node", "peer"})
 
 	metricBFDPeerFailureTransitions = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kube_ovn_speaker_bfd_peer_failure_transitions",
-			Help: "Cumulative number of BFD session failure transitions for the peer.",
+			Help: "Cumulative number of BFD session failure transitions for the peer. Not reported by GoBGP v4.6.0 (always 0); will become meaningful once upstream populates it.",
 		},
 		[]string{"node", "peer"})
 
@@ -347,6 +347,10 @@ func (c *Controller) collectBFDMetrics() {
 
 		metricBFDPeerUp.WithLabelValues(node, addr).Set(bfdPeerUpValue(state.SessionState))
 		metricBFDPeerState.WithLabelValues(node, addr).Set(float64(state.SessionState))
+		// GoBGP v4.6.0's getPeerStateList only populates SessionState and BfdAsync,
+		// so RemoteSessionState and FailureTransitions are always 0 here. The series
+		// are still exported (with a note in their Help text) so they start reporting
+		// real values automatically once upstream fills these fields.
 		metricBFDPeerRemoteState.WithLabelValues(node, addr).Set(float64(state.RemoteSessionState))
 		metricBFDPeerFailureTransitions.WithLabelValues(node, addr).Set(float64(state.FailureTransitions))
 

--- a/pkg/speaker/metrics.go
+++ b/pkg/speaker/metrics.go
@@ -220,6 +220,52 @@ func bgpMessageCounts(m *api.Message) map[string]float64 {
 	}
 }
 
+// deleteStaleBGPPeerSeries removes the per-peer BGP series for peers that were
+// exported in the previous collection cycle (last) but are no longer reported
+// in the current one (current), or whose ASN changed. A changed ASN keeps the
+// peer address but yields a new peer_asn label set, so the previous asn-labeled
+// series must be dropped to avoid a stale series lingering forever.
+//
+// With the current speaker the neighbor set is fixed at startup (no runtime
+// DeletePeer), so this is normally a no-op; it only deletes when a peer stops
+// appearing in ListPeer, e.g. a future runtime neighbor reconfiguration, an ASN
+// change, or a cycle where the peer was skipped because Conf/State was nil.
+func deleteStaleBGPPeerSeries(node string, last, current map[string]string) {
+	for addr, asn := range last {
+		// Skip only when the peer is still present with the same ASN.
+		if newASN, ok := current[addr]; ok && newASN == asn {
+			continue
+		}
+		metricBGPPeerUp.DeleteLabelValues(node, addr, asn)
+		metricBGPPeerState.DeleteLabelValues(node, addr, asn)
+		metricBGPPeerFlapCount.DeleteLabelValues(node, addr, asn)
+		metricBGPPeerOutQueue.DeleteLabelValues(node, addr, asn)
+		for _, typ := range bgpMessageTypes {
+			metricBGPPeerReceivedMessages.DeleteLabelValues(node, addr, typ)
+			metricBGPPeerSentMessages.DeleteLabelValues(node, addr, typ)
+		}
+	}
+}
+
+// deleteStaleBFDPeerSeries removes the per-peer BFD series for peers that were
+// exported in the previous cycle (last) but are no longer reported (current).
+// Like the BGP variant this is normally a no-op because BFD peers are created
+// once at startup and never removed at runtime; it only deletes when a peer
+// stops appearing in ListBfdPeer (future reconfiguration, or a nil-state skip).
+func deleteStaleBFDPeerSeries(node string, last, current map[string]struct{}) {
+	for addr := range last {
+		if _, ok := current[addr]; ok {
+			continue
+		}
+		metricBFDPeerUp.DeleteLabelValues(node, addr)
+		metricBFDPeerState.DeleteLabelValues(node, addr)
+		metricBFDPeerRemoteState.DeleteLabelValues(node, addr)
+		metricBFDPeerFailureTransitions.DeleteLabelValues(node, addr)
+		metricBFDPeerTransmittedPackets.DeleteLabelValues(node, addr)
+		metricBFDPeerReceivedPackets.DeleteLabelValues(node, addr)
+	}
+}
+
 // collectMetrics refreshes all BGP/BFD Prometheus metrics from the GoBGP server.
 // It is invoked from the reconcile loop and only performs gRPC queries when
 // metrics are enabled.
@@ -271,22 +317,7 @@ func (c *Controller) collectBGPMetrics() {
 		return
 	}
 
-	for addr, asn := range c.lastBGPPeers {
-		// Skip only when the peer is still present with the same ASN. A peer whose
-		// ASN changed keeps its addr but exports a new label set, so its previous
-		// asn-labeled series must still be deleted here to avoid a stale series.
-		if newASN, ok := currentPeers[addr]; ok && newASN == asn {
-			continue
-		}
-		metricBGPPeerUp.DeleteLabelValues(node, addr, asn)
-		metricBGPPeerState.DeleteLabelValues(node, addr, asn)
-		metricBGPPeerFlapCount.DeleteLabelValues(node, addr, asn)
-		metricBGPPeerOutQueue.DeleteLabelValues(node, addr, asn)
-		for _, typ := range bgpMessageTypes {
-			metricBGPPeerReceivedMessages.DeleteLabelValues(node, addr, typ)
-			metricBGPPeerSentMessages.DeleteLabelValues(node, addr, typ)
-		}
-	}
+	deleteStaleBGPPeerSeries(node, c.lastBGPPeers, currentPeers)
 	c.lastBGPPeers = currentPeers
 }
 
@@ -325,16 +356,6 @@ func (c *Controller) collectBFDMetrics() {
 		}
 	})
 
-	for addr := range c.lastBFDPeers {
-		if _, ok := currentPeers[addr]; ok {
-			continue
-		}
-		metricBFDPeerUp.DeleteLabelValues(node, addr)
-		metricBFDPeerState.DeleteLabelValues(node, addr)
-		metricBFDPeerRemoteState.DeleteLabelValues(node, addr)
-		metricBFDPeerFailureTransitions.DeleteLabelValues(node, addr)
-		metricBFDPeerTransmittedPackets.DeleteLabelValues(node, addr)
-		metricBFDPeerReceivedPackets.DeleteLabelValues(node, addr)
-	}
+	deleteStaleBFDPeerSeries(node, c.lastBFDPeers, currentPeers)
 	c.lastBFDPeers = currentPeers
 }

--- a/pkg/speaker/metrics.go
+++ b/pkg/speaker/metrics.go
@@ -1,0 +1,303 @@
+package speaker
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Prometheus metrics for the BGP speaker and its optional BFD sessions.
+//
+// Counters reported by GoBGP (BGP message counters, BFD packet/error counters)
+// are cumulative monotonic values that reset only when the underlying GoBGP
+// server restarts. They are exposed as gauges holding the latest cumulative
+// snapshot so that PromQL rate()/increase() can derive per-interval deltas,
+// which is the standard way to alert on such counters (mirrors Cilium's
+// cilium_bgp_control_plane_* gauge design).
+var (
+	// BGP per-peer metrics.
+	metricBGPPeerUp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bgp_peer_up",
+			Help: "Whether the BGP session with the peer is established (1) or not (0).",
+		},
+		[]string{"node", "peer", "peer_asn"})
+
+	metricBGPPeerState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bgp_peer_session_state",
+			Help: "BGP session FSM state of the peer (0=unspecified,1=idle,2=connect,3=active,4=opensent,5=openconfirm,6=established).",
+		},
+		[]string{"node", "peer", "peer_asn"})
+
+	metricBGPPeerFlapCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bgp_peer_flap_count",
+			Help: "Number of times the BGP session with the peer has flapped.",
+		},
+		[]string{"node", "peer", "peer_asn"})
+
+	metricBGPPeerOutQueue = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bgp_peer_out_queue",
+			Help: "Number of BGP messages queued to be sent to the peer.",
+		},
+		[]string{"node", "peer", "peer_asn"})
+
+	metricBGPPeerReceivedMessages = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bgp_peer_received_messages",
+			Help: "Cumulative number of BGP messages received from the peer, by message type.",
+		},
+		[]string{"node", "peer", "type"})
+
+	metricBGPPeerSentMessages = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bgp_peer_sent_messages",
+			Help: "Cumulative number of BGP messages sent to the peer, by message type.",
+		},
+		[]string{"node", "peer", "type"})
+
+	// BFD server-wide metrics.
+	metricBFDServerReceivedPackets = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_server_received_packets",
+			Help: "Cumulative number of BFD packets received by the server.",
+		},
+		[]string{"node"})
+
+	metricBFDServerReceivedDrop = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_server_received_drop",
+			Help: "Cumulative number of BFD packets dropped by the server.",
+		},
+		[]string{"node"})
+
+	metricBFDServerReceivedError = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_server_received_error",
+			Help: "Cumulative number of BFD packets received with errors by the server.",
+		},
+		[]string{"node"})
+
+	metricBFDServerInvalidPacket = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_server_invalid_packet",
+			Help: "Cumulative number of invalid BFD packets received by the server.",
+		},
+		[]string{"node"})
+
+	metricBFDServerUnknownPeer = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_server_unknown_peer",
+			Help: "Cumulative number of BFD packets received from unknown peers.",
+		},
+		[]string{"node"})
+
+	// BFD per-peer metrics.
+	metricBFDPeerUp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_peer_up",
+			Help: "Whether the BFD session with the peer is UP (1) or not (0).",
+		},
+		[]string{"node", "peer"})
+
+	metricBFDPeerState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_peer_session_state",
+			Help: "Local BFD session state of the peer (0=unspecified,1=admin_down,2=down,3=init,4=up).",
+		},
+		[]string{"node", "peer"})
+
+	metricBFDPeerRemoteState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_peer_remote_session_state",
+			Help: "Remote BFD session state of the peer (0=unspecified,1=admin_down,2=down,3=init,4=up).",
+		},
+		[]string{"node", "peer"})
+
+	metricBFDPeerFailureTransitions = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_peer_failure_transitions",
+			Help: "Cumulative number of BFD session failure transitions for the peer.",
+		},
+		[]string{"node", "peer"})
+
+	metricBFDPeerTransmittedPackets = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_peer_transmitted_packets",
+			Help: "Cumulative number of BFD control packets transmitted to the peer.",
+		},
+		[]string{"node", "peer"})
+
+	metricBFDPeerReceivedPackets = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kube_ovn_speaker_bfd_peer_received_packets",
+			Help: "Cumulative number of BFD control packets received from the peer.",
+		},
+		[]string{"node", "peer"})
+)
+
+var registerSpeakerMetricsOnce sync.Once
+
+// registerSpeakerMetrics registers all BGP/BFD metrics with the controller-runtime
+// registry. It is safe to call multiple times; registration happens only once.
+func registerSpeakerMetrics() {
+	registerSpeakerMetricsOnce.Do(func() {
+		metrics.Registry.MustRegister(
+			metricBGPPeerUp,
+			metricBGPPeerState,
+			metricBGPPeerFlapCount,
+			metricBGPPeerOutQueue,
+			metricBGPPeerReceivedMessages,
+			metricBGPPeerSentMessages,
+			metricBFDServerReceivedPackets,
+			metricBFDServerReceivedDrop,
+			metricBFDServerReceivedError,
+			metricBFDServerInvalidPacket,
+			metricBFDServerUnknownPeer,
+			metricBFDPeerUp,
+			metricBFDPeerState,
+			metricBFDPeerRemoteState,
+			metricBFDPeerFailureTransitions,
+			metricBFDPeerTransmittedPackets,
+			metricBFDPeerReceivedPackets,
+		)
+	})
+}
+
+// resetBGPPeerMetrics clears all per-peer BGP series so that peers which no
+// longer exist do not leave stale time series behind. Called before each
+// collection cycle, then the vectors are repopulated with the current peers.
+func resetBGPPeerMetrics() {
+	metricBGPPeerUp.Reset()
+	metricBGPPeerState.Reset()
+	metricBGPPeerFlapCount.Reset()
+	metricBGPPeerOutQueue.Reset()
+	metricBGPPeerReceivedMessages.Reset()
+	metricBGPPeerSentMessages.Reset()
+}
+
+// resetBFDPeerMetrics clears all per-peer BFD series to avoid stale time series.
+func resetBFDPeerMetrics() {
+	metricBFDPeerUp.Reset()
+	metricBFDPeerState.Reset()
+	metricBFDPeerRemoteState.Reset()
+	metricBFDPeerFailureTransitions.Reset()
+	metricBFDPeerTransmittedPackets.Reset()
+	metricBFDPeerReceivedPackets.Reset()
+}
+
+// bgpPeerUpValue returns 1 when the BGP session is established, otherwise 0.
+func bgpPeerUpValue(state api.PeerState_SessionState) float64 {
+	if state == api.PeerState_SESSION_STATE_ESTABLISHED {
+		return 1
+	}
+	return 0
+}
+
+// bfdPeerUpValue returns 1 when the BFD session is UP, otherwise 0.
+func bfdPeerUpValue(state api.BfdSessionState) float64 {
+	if state == api.BfdSessionState_BFD_SESSION_STATE_UP {
+		return 1
+	}
+	return 0
+}
+
+// bgpMessageCounts flattens a BGP *Message counter set into (type, value) pairs.
+// A nil message yields no entries.
+func bgpMessageCounts(m *api.Message) map[string]float64 {
+	if m == nil {
+		return nil
+	}
+	return map[string]float64{
+		"open":            float64(m.Open),
+		"update":          float64(m.Update),
+		"keepalive":       float64(m.Keepalive),
+		"notification":    float64(m.Notification),
+		"refresh":         float64(m.Refresh),
+		"withdraw_update": float64(m.WithdrawUpdate),
+		"withdraw_prefix": float64(m.WithdrawPrefix),
+		"discarded":       float64(m.Discarded),
+		"total":           float64(m.Total),
+	}
+}
+
+// collectMetrics refreshes all BGP/BFD Prometheus metrics from the GoBGP server.
+// It is invoked from the reconcile loop and only performs gRPC queries when
+// metrics are enabled.
+func (c *Controller) collectMetrics() {
+	c.collectBGPMetrics()
+	if c.config.EnableBFD {
+		c.collectBFDMetrics()
+	}
+}
+
+// collectBGPMetrics lists all BGP peers and exports their session state and
+// message counters as Prometheus metrics.
+func (c *Controller) collectBGPMetrics() {
+	node := c.config.NodeName
+
+	resetBGPPeerMetrics()
+	if err := c.config.BgpServer.ListPeer(context.Background(), &api.ListPeerRequest{}, func(peer *api.Peer) {
+		if peer == nil || peer.Conf == nil || peer.State == nil {
+			return
+		}
+
+		addr := peer.Conf.NeighborAddress
+		asn := strconv.FormatUint(uint64(peer.Conf.PeerAsn), 10)
+		state := peer.State.SessionState
+
+		metricBGPPeerUp.WithLabelValues(node, addr, asn).Set(bgpPeerUpValue(state))
+		metricBGPPeerState.WithLabelValues(node, addr, asn).Set(float64(state))
+		metricBGPPeerFlapCount.WithLabelValues(node, addr, asn).Set(float64(peer.State.Flops))
+		metricBGPPeerOutQueue.WithLabelValues(node, addr, asn).Set(float64(peer.State.OutQ))
+
+		if msgs := peer.State.Messages; msgs != nil {
+			for typ, val := range bgpMessageCounts(msgs.Received) {
+				metricBGPPeerReceivedMessages.WithLabelValues(node, addr, typ).Set(val)
+			}
+			for typ, val := range bgpMessageCounts(msgs.Sent) {
+				metricBGPPeerSentMessages.WithLabelValues(node, addr, typ).Set(val)
+			}
+		}
+	}); err != nil {
+		klog.Errorf("failed to list BGP peers for metrics: %v", err)
+	}
+}
+
+// collectBFDMetrics exports the BFD server statistics and per-peer session
+// state as Prometheus metrics.
+func (c *Controller) collectBFDMetrics() {
+	node := c.config.NodeName
+
+	if stats := c.config.BgpServer.GetBfdServerStats(); stats != nil {
+		metricBFDServerReceivedPackets.WithLabelValues(node).Set(float64(stats.ReceivedPacket))
+		metricBFDServerReceivedDrop.WithLabelValues(node).Set(float64(stats.ReceivedDrop))
+		metricBFDServerReceivedError.WithLabelValues(node).Set(float64(stats.ReceivedError))
+		metricBFDServerInvalidPacket.WithLabelValues(node).Set(float64(stats.InvalidPacket))
+		metricBFDServerUnknownPeer.WithLabelValues(node).Set(float64(stats.UnknownPeer))
+	}
+
+	resetBFDPeerMetrics()
+	c.config.BgpServer.ListBfdPeer(context.Background(), func(addr string, state *api.BfdPeerState) {
+		if state == nil {
+			return
+		}
+
+		metricBFDPeerUp.WithLabelValues(node, addr).Set(bfdPeerUpValue(state.SessionState))
+		metricBFDPeerState.WithLabelValues(node, addr).Set(float64(state.SessionState))
+		metricBFDPeerRemoteState.WithLabelValues(node, addr).Set(float64(state.RemoteSessionState))
+		metricBFDPeerFailureTransitions.WithLabelValues(node, addr).Set(float64(state.FailureTransitions))
+
+		if async := state.BfdAsync; async != nil {
+			metricBFDPeerTransmittedPackets.WithLabelValues(node, addr).Set(float64(async.TransmittedPackets))
+			metricBFDPeerReceivedPackets.WithLabelValues(node, addr).Set(float64(async.ReceivedPackets))
+		}
+	})
+}

--- a/pkg/speaker/metrics.go
+++ b/pkg/speaker/metrics.go
@@ -110,14 +110,14 @@ var (
 	metricBFDPeerState = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kube_ovn_speaker_bfd_peer_session_state",
-			Help: "Local BFD session state of the peer (0=unspecified,1=admin_down,2=down,3=init,4=up).",
+			Help: "Local BFD session state of the peer (0=unspecified,1=up,2=down,3=admin_down,4=init).",
 		},
 		[]string{"node", "peer"})
 
 	metricBFDPeerRemoteState = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kube_ovn_speaker_bfd_peer_remote_session_state",
-			Help: "Remote BFD session state of the peer (0=unspecified,1=admin_down,2=down,3=init,4=up).",
+			Help: "Remote BFD session state of the peer (0=unspecified,1=up,2=down,3=admin_down,4=init).",
 		},
 		[]string{"node", "peer"})
 

--- a/pkg/speaker/metrics.go
+++ b/pkg/speaker/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/osrg/gobgp/v4/api"
 	"github.com/prometheus/client_golang/prometheus"
@@ -171,26 +172,17 @@ func registerSpeakerMetrics() {
 	})
 }
 
-// resetBGPPeerMetrics clears all per-peer BGP series so that peers which no
-// longer exist do not leave stale time series behind. Called before each
-// collection cycle, then the vectors are repopulated with the current peers.
-func resetBGPPeerMetrics() {
-	metricBGPPeerUp.Reset()
-	metricBGPPeerState.Reset()
-	metricBGPPeerFlapCount.Reset()
-	metricBGPPeerOutQueue.Reset()
-	metricBGPPeerReceivedMessages.Reset()
-	metricBGPPeerSentMessages.Reset()
-}
+// metricsCollectTimeout bounds each GoBGP gRPC query issued during metrics
+// collection. The reconcile loop runs serially, so an unbounded gRPC call to a
+// hung GoBGP server would block the whole loop (including route sync), not just
+// metrics; the timeout isolates that failure to the metrics path.
+const metricsCollectTimeout = 3 * time.Second
 
-// resetBFDPeerMetrics clears all per-peer BFD series to avoid stale time series.
-func resetBFDPeerMetrics() {
-	metricBFDPeerUp.Reset()
-	metricBFDPeerState.Reset()
-	metricBFDPeerRemoteState.Reset()
-	metricBFDPeerFailureTransitions.Reset()
-	metricBFDPeerTransmittedPackets.Reset()
-	metricBFDPeerReceivedPackets.Reset()
+// bgpMessageTypes enumerates the "type" label values produced by
+// bgpMessageCounts. It is used to delete stale per-peer message series.
+var bgpMessageTypes = []string{
+	"open", "update", "keepalive", "notification", "refresh",
+	"withdraw_update", "withdraw_prefix", "discarded", "total",
 }
 
 // bgpPeerUpValue returns 1 when the BGP session is established, otherwise 0.
@@ -239,12 +231,17 @@ func (c *Controller) collectMetrics() {
 }
 
 // collectBGPMetrics lists all BGP peers and exports their session state and
-// message counters as Prometheus metrics.
+// message counters as Prometheus metrics. Series belonging to peers that have
+// disappeared since the previous cycle are deleted individually so that a
+// concurrent scrape never observes an empty/partial set of series.
 func (c *Controller) collectBGPMetrics() {
 	node := c.config.NodeName
 
-	resetBGPPeerMetrics()
-	if err := c.config.BgpServer.ListPeer(context.Background(), &api.ListPeerRequest{}, func(peer *api.Peer) {
+	currentPeers := make(map[string]string)
+	ctx, cancel := context.WithTimeout(context.Background(), metricsCollectTimeout)
+	defer cancel()
+
+	if err := c.config.BgpServer.ListPeer(ctx, &api.ListPeerRequest{}, func(peer *api.Peer) {
 		if peer == nil || peer.Conf == nil || peer.State == nil {
 			return
 		}
@@ -252,6 +249,7 @@ func (c *Controller) collectBGPMetrics() {
 		addr := peer.Conf.NeighborAddress
 		asn := strconv.FormatUint(uint64(peer.Conf.PeerAsn), 10)
 		state := peer.State.SessionState
+		currentPeers[addr] = asn
 
 		metricBGPPeerUp.WithLabelValues(node, addr, asn).Set(bgpPeerUpValue(state))
 		metricBGPPeerState.WithLabelValues(node, addr, asn).Set(float64(state))
@@ -267,12 +265,34 @@ func (c *Controller) collectBGPMetrics() {
 			}
 		}
 	}); err != nil {
+		// Keep the previous series on error so a transient gRPC failure does not
+		// blank out the metrics; stale peers are reconciled on the next success.
 		klog.Errorf("failed to list BGP peers for metrics: %v", err)
+		return
 	}
+
+	for addr, asn := range c.lastBGPPeers {
+		// Skip only when the peer is still present with the same ASN. A peer whose
+		// ASN changed keeps its addr but exports a new label set, so its previous
+		// asn-labeled series must still be deleted here to avoid a stale series.
+		if newASN, ok := currentPeers[addr]; ok && newASN == asn {
+			continue
+		}
+		metricBGPPeerUp.DeleteLabelValues(node, addr, asn)
+		metricBGPPeerState.DeleteLabelValues(node, addr, asn)
+		metricBGPPeerFlapCount.DeleteLabelValues(node, addr, asn)
+		metricBGPPeerOutQueue.DeleteLabelValues(node, addr, asn)
+		for _, typ := range bgpMessageTypes {
+			metricBGPPeerReceivedMessages.DeleteLabelValues(node, addr, typ)
+			metricBGPPeerSentMessages.DeleteLabelValues(node, addr, typ)
+		}
+	}
+	c.lastBGPPeers = currentPeers
 }
 
 // collectBFDMetrics exports the BFD server statistics and per-peer session
-// state as Prometheus metrics.
+// state as Prometheus metrics. Disappeared peers are deleted individually to
+// avoid metric flapping during scrapes.
 func (c *Controller) collectBFDMetrics() {
 	node := c.config.NodeName
 
@@ -284,11 +304,15 @@ func (c *Controller) collectBFDMetrics() {
 		metricBFDServerUnknownPeer.WithLabelValues(node).Set(float64(stats.UnknownPeer))
 	}
 
-	resetBFDPeerMetrics()
-	c.config.BgpServer.ListBfdPeer(context.Background(), func(addr string, state *api.BfdPeerState) {
+	currentPeers := make(map[string]struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), metricsCollectTimeout)
+	defer cancel()
+
+	c.config.BgpServer.ListBfdPeer(ctx, func(addr string, state *api.BfdPeerState) {
 		if state == nil {
 			return
 		}
+		currentPeers[addr] = struct{}{}
 
 		metricBFDPeerUp.WithLabelValues(node, addr).Set(bfdPeerUpValue(state.SessionState))
 		metricBFDPeerState.WithLabelValues(node, addr).Set(float64(state.SessionState))
@@ -300,4 +324,17 @@ func (c *Controller) collectBFDMetrics() {
 			metricBFDPeerReceivedPackets.WithLabelValues(node, addr).Set(float64(async.ReceivedPackets))
 		}
 	})
+
+	for addr := range c.lastBFDPeers {
+		if _, ok := currentPeers[addr]; ok {
+			continue
+		}
+		metricBFDPeerUp.DeleteLabelValues(node, addr)
+		metricBFDPeerState.DeleteLabelValues(node, addr)
+		metricBFDPeerRemoteState.DeleteLabelValues(node, addr)
+		metricBFDPeerFailureTransitions.DeleteLabelValues(node, addr)
+		metricBFDPeerTransmittedPackets.DeleteLabelValues(node, addr)
+		metricBFDPeerReceivedPackets.DeleteLabelValues(node, addr)
+	}
+	c.lastBFDPeers = currentPeers
 }

--- a/pkg/speaker/metrics_test.go
+++ b/pkg/speaker/metrics_test.go
@@ -1,0 +1,89 @@
+package speaker
+
+import (
+	"testing"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBGPPeerUpValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    api.PeerState_SessionState
+		expected float64
+	}{
+		{"established is up", api.PeerState_SESSION_STATE_ESTABLISHED, 1},
+		{"idle is down", api.PeerState_SESSION_STATE_IDLE, 0},
+		{"active is down", api.PeerState_SESSION_STATE_ACTIVE, 0},
+		{"opensent is down", api.PeerState_SESSION_STATE_OPENSENT, 0},
+		{"unspecified is down", api.PeerState_SESSION_STATE_UNSPECIFIED, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, bgpPeerUpValue(tt.state))
+		})
+	}
+}
+
+func TestBFDPeerUpValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    api.BfdSessionState
+		expected float64
+	}{
+		{"up", api.BfdSessionState_BFD_SESSION_STATE_UP, 1},
+		{"down", api.BfdSessionState_BFD_SESSION_STATE_DOWN, 0},
+		{"init", api.BfdSessionState_BFD_SESSION_STATE_INIT, 0},
+		{"admin_down", api.BfdSessionState_BFD_SESSION_STATE_ADMIN_DOWN, 0},
+		{"unspecified", api.BfdSessionState_BFD_SESSION_STATE_UNSPECIFIED, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, bfdPeerUpValue(tt.state))
+		})
+	}
+}
+
+func TestBGPMessageCounts(t *testing.T) {
+	t.Run("nil message yields no entries", func(t *testing.T) {
+		require.Nil(t, bgpMessageCounts(nil))
+	})
+
+	t.Run("flattens all counter fields", func(t *testing.T) {
+		msg := &api.Message{
+			Open:           1,
+			Update:         2,
+			Keepalive:      3,
+			Notification:   4,
+			Refresh:        5,
+			WithdrawUpdate: 6,
+			WithdrawPrefix: 7,
+			Discarded:      8,
+			Total:          9,
+		}
+		got := bgpMessageCounts(msg)
+		require.Equal(t, map[string]float64{
+			"open":            1,
+			"update":          2,
+			"keepalive":       3,
+			"notification":    4,
+			"refresh":         5,
+			"withdraw_update": 6,
+			"withdraw_prefix": 7,
+			"discarded":       8,
+			"total":           9,
+		}, got)
+	})
+}
+
+func TestRegisterSpeakerMetricsIdempotent(t *testing.T) {
+	// registerSpeakerMetrics must be safe to call multiple times without panicking
+	// on duplicate registration.
+	require.NotPanics(t, func() {
+		registerSpeakerMetrics()
+		registerSpeakerMetrics()
+	})
+}

--- a/pkg/speaker/metrics_test.go
+++ b/pkg/speaker/metrics_test.go
@@ -4,8 +4,25 @@ import (
 	"testing"
 
 	"github.com/osrg/gobgp/v4/api"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
+
+// countSeries returns the number of series currently exported by a collector.
+// It mirrors what a Prometheus scrape would observe without pulling in the
+// testutil package, which would add a new module dependency.
+func countSeries(c prometheus.Collector) int {
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+	n := 0
+	for range ch {
+		n++
+	}
+	return n
+}
 
 func TestBGPPeerUpValue(t *testing.T) {
 	tests := []struct {
@@ -86,4 +103,133 @@ func TestRegisterSpeakerMetricsIdempotent(t *testing.T) {
 		registerSpeakerMetrics()
 		registerSpeakerMetrics()
 	})
+}
+
+// resetBGPPeerMetricVecs clears every per-peer BGP metric vector so a test starts
+// from a clean slate regardless of other tests mutating the package globals.
+func resetBGPPeerMetricVecs() {
+	metricBGPPeerUp.Reset()
+	metricBGPPeerState.Reset()
+	metricBGPPeerFlapCount.Reset()
+	metricBGPPeerOutQueue.Reset()
+	metricBGPPeerReceivedMessages.Reset()
+	metricBGPPeerSentMessages.Reset()
+}
+
+// setBGPPeerSeries populates a full per-peer BGP series set for (node, addr, asn),
+// mirroring what collectBGPMetrics writes for a single peer.
+func setBGPPeerSeries(node, addr, asn string) {
+	metricBGPPeerUp.WithLabelValues(node, addr, asn).Set(1)
+	metricBGPPeerState.WithLabelValues(node, addr, asn).Set(6)
+	metricBGPPeerFlapCount.WithLabelValues(node, addr, asn).Set(0)
+	metricBGPPeerOutQueue.WithLabelValues(node, addr, asn).Set(0)
+	for _, typ := range bgpMessageTypes {
+		metricBGPPeerReceivedMessages.WithLabelValues(node, addr, typ).Set(1)
+		metricBGPPeerSentMessages.WithLabelValues(node, addr, typ).Set(1)
+	}
+}
+
+func TestDeleteStaleBGPPeerSeries(t *testing.T) {
+	const node = "node1"
+
+	t.Run("present peer with same ASN is retained", func(t *testing.T) {
+		resetBGPPeerMetricVecs()
+		setBGPPeerSeries(node, "10.0.0.1", "65001")
+
+		deleteStaleBGPPeerSeries(node,
+			map[string]string{"10.0.0.1": "65001"},
+			map[string]string{"10.0.0.1": "65001"})
+
+		require.Equal(t, 1, countSeries(metricBGPPeerUp))
+		require.Equal(t, len(bgpMessageTypes), countSeries(metricBGPPeerReceivedMessages))
+		require.Equal(t, len(bgpMessageTypes), countSeries(metricBGPPeerSentMessages))
+	})
+
+	t.Run("disappeared peer has all series deleted", func(t *testing.T) {
+		resetBGPPeerMetricVecs()
+		setBGPPeerSeries(node, "10.0.0.1", "65001")
+
+		deleteStaleBGPPeerSeries(node,
+			map[string]string{"10.0.0.1": "65001"},
+			map[string]string{})
+
+		require.Zero(t, countSeries(metricBGPPeerUp))
+		require.Zero(t, countSeries(metricBGPPeerState))
+		require.Zero(t, countSeries(metricBGPPeerFlapCount))
+		require.Zero(t, countSeries(metricBGPPeerOutQueue))
+		require.Zero(t, countSeries(metricBGPPeerReceivedMessages))
+		require.Zero(t, countSeries(metricBGPPeerSentMessages))
+	})
+
+	t.Run("changed ASN drops the old series and keeps the new one", func(t *testing.T) {
+		resetBGPPeerMetricVecs()
+		// Old asn series remain from the previous cycle; the new asn series was
+		// already written by the collection callback for the current cycle.
+		setBGPPeerSeries(node, "10.0.0.1", "65001")
+		setBGPPeerSeries(node, "10.0.0.1", "65002")
+		require.Equal(t, 2, countSeries(metricBGPPeerUp))
+
+		deleteStaleBGPPeerSeries(node,
+			map[string]string{"10.0.0.1": "65001"},
+			map[string]string{"10.0.0.1": "65002"})
+
+		// Exactly one series must remain, and it must be the new-ASN one. Using
+		// DeleteLabelValues as an assertion: it returns true only if the series
+		// existed, so the old-ASN lookup must be false and the new-ASN true.
+		require.Equal(t, 1, countSeries(metricBGPPeerUp))
+		require.False(t, metricBGPPeerUp.DeleteLabelValues(node, "10.0.0.1", "65001"))
+		require.True(t, metricBGPPeerUp.DeleteLabelValues(node, "10.0.0.1", "65002"))
+	})
+
+	resetBGPPeerMetricVecs()
+}
+
+func TestDeleteStaleBFDPeerSeries(t *testing.T) {
+	const node = "node1"
+
+	resetBFD := func() {
+		metricBFDPeerUp.Reset()
+		metricBFDPeerState.Reset()
+		metricBFDPeerRemoteState.Reset()
+		metricBFDPeerFailureTransitions.Reset()
+		metricBFDPeerTransmittedPackets.Reset()
+		metricBFDPeerReceivedPackets.Reset()
+	}
+	setBFD := func(addr string) {
+		metricBFDPeerUp.WithLabelValues(node, addr).Set(1)
+		metricBFDPeerState.WithLabelValues(node, addr).Set(1)
+		metricBFDPeerRemoteState.WithLabelValues(node, addr).Set(1)
+		metricBFDPeerFailureTransitions.WithLabelValues(node, addr).Set(0)
+		metricBFDPeerTransmittedPackets.WithLabelValues(node, addr).Set(1)
+		metricBFDPeerReceivedPackets.WithLabelValues(node, addr).Set(1)
+	}
+
+	t.Run("present peer is retained", func(t *testing.T) {
+		resetBFD()
+		setBFD("10.0.0.1")
+
+		deleteStaleBFDPeerSeries(node,
+			map[string]struct{}{"10.0.0.1": {}},
+			map[string]struct{}{"10.0.0.1": {}})
+
+		require.Equal(t, 1, countSeries(metricBFDPeerUp))
+	})
+
+	t.Run("disappeared peer has all series deleted", func(t *testing.T) {
+		resetBFD()
+		setBFD("10.0.0.1")
+
+		deleteStaleBFDPeerSeries(node,
+			map[string]struct{}{"10.0.0.1": {}},
+			map[string]struct{}{})
+
+		require.Zero(t, countSeries(metricBFDPeerUp))
+		require.Zero(t, countSeries(metricBFDPeerState))
+		require.Zero(t, countSeries(metricBFDPeerRemoteState))
+		require.Zero(t, countSeries(metricBFDPeerFailureTransitions))
+		require.Zero(t, countSeries(metricBFDPeerTransmittedPackets))
+		require.Zero(t, countSeries(metricBFDPeerReceivedPackets))
+	})
+
+	resetBFD()
 }


### PR DESCRIPTION
- BFDDetectionMultiplier: uint32 → uint8 with pflag.Uint8 (RFC 5880 §6.8.1)
- Add ms→μs overflow validation (MaxUint32/1000 boundary)
- BFD stats: log only on errors (Warningf) or recovery (Infof)
- BFD peer state: diff caching, log only on state change
- Add watchPeerState() for BGP peer state change monitoring with BFD state
- Move newBFDPeerConfig() to bfd.go with explicit uint32 cast

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
