### PR TITLE
build: include ovs and ovn commits in version

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -98,7 +98,9 @@ RUN cd /usr/src/ && \
     # increase the default probe interval for large cluster
     git apply $SRC_DIR/1b31f07dc60c016153fa35d936cdda0e02e58492.patch && \
     # update ovs-sandbox for docker run
-    git apply $SRC_DIR/54b767822916606dbb78335a3197983f435b5b8a.patch
+    git apply $SRC_DIR/54b767822916606dbb78335a3197983f435b5b8a.patch && \
+    ovs_commit=$(git rev-parse --short=12 HEAD) && \
+    sed -i -E "s/^(AC_INIT\(\[?openvswitch\]?, \[?[^],)]+)(\]?)(,.*)$/\1+g${ovs_commit}\2\3/" configure.ac
 
 RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
@@ -137,7 +139,9 @@ RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-o
     # add null check before sbrec delete calls
     git apply $SRC_DIR/sbrec-delete-null-check.patch && \
     # adapt to the compose_nd_ns() signature change in ovs branch-3.5 commit 33825c273
-    git apply $SRC_DIR/pinctrl-adapt-ovs-compose-nd-ns.patch
+    git apply $SRC_DIR/pinctrl-adapt-ovs-compose-nd-ns.patch && \
+    ovn_commit=$(git rev-parse --short=12 HEAD) && \
+    sed -i -E "s/^(AC_INIT\(\[?ovn\]?, \[?[^],)]+)(\]?)(,.*)$/\1+g${ovn_commit}\2\3/" configure.ac
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/dist/images/Dockerfile.base-dpdk
+++ b/dist/images/Dockerfile.base-dpdk
@@ -48,7 +48,9 @@ RUN cd /usr/src/ && \
     # ovs-router: skip getting source address for kube-ipvs0
     git apply $SRC_DIR/d088c5d8c263552c5a31d87813991aee30ab74de.patch && \
     # increase the default probe interval for large cluster
-    git apply $SRC_DIR/1b31f07dc60c016153fa35d936cdda0e02e58492.patch
+    git apply $SRC_DIR/1b31f07dc60c016153fa35d936cdda0e02e58492.patch && \
+    ovs_commit=$(git rev-parse --short=12 HEAD) && \
+    sed -i -E "s/^(AC_INIT\(\[?openvswitch\]?, \[?[^],)]+)(\]?)(,.*)$/\1+g${ovs_commit}\2\3/" configure.ac
 
 RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
@@ -59,7 +61,9 @@ RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-o
     # ovn-controller: do not send GARP on localnet for Kube-OVN ports
     git apply $SRC_DIR/f9e97031b56ab5747b5d73629198331a6daacdfd.patch && \
     # adapt to the compose_nd_ns() signature change in ovs branch-3.5 commit 33825c273
-    git apply $SRC_DIR/pinctrl-adapt-ovs-compose-nd-ns.patch
+    git apply $SRC_DIR/pinctrl-adapt-ovs-compose-nd-ns.patch && \
+    ovn_commit=$(git rev-parse --short=12 HEAD) && \
+    sed -i -E "s/^(AC_INIT\(\[?ovn\]?, \[?[^],)]+)(\]?)(,.*)$/\1+g${ovn_commit}\2\3/" configure.ac
 
 RUN apt install -y build-essential fakeroot \
     autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \


### PR DESCRIPTION
## Summary
- Append the OVS HEAD commit to the Open vSwitch AC_INIT version during base image builds.
- Append the OVN HEAD commit to the OVN AC_INIT version during base and DPDK base image builds.

Example output:

```shell
root@dev:/# ovs-vsctl -V
ovs-vsctl (Open vSwitch) 3.5.5+ge7b28080f1ae
DB Schema 8.8.0
root@dev:/# ovn-controller -V
ovn-controller 25.03.4+g6b756b40d6cb
Open vSwitch Library 3.5.5+ge7b28080f1ae
OpenFlow versions 0x6:0x6
SB DB Schema 20.41.0
```

## Test Plan
- git diff --check
- Verified each Dockerfile has OVS and OVN commit injection before ./boot.sh
