### PR TITLE
fix: restore ip_src hash for policy route ECMP

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -49,6 +49,7 @@ ADD patches/ffd2328d4a55271569e2b89e54a2c18f4e186af8.patch $SRC_DIR
 ADD patches/d088c5d8c263552c5a31d87813991aee30ab74de.patch $SRC_DIR
 ADD patches/1b31f07dc60c016153fa35d936cdda0e02e58492.patch $SRC_DIR
 ADD patches/54b767822916606dbb78335a3197983f435b5b8a.patch $SRC_DIR
+ADD patches/e490f5ac0b644101913c2a3db8e03d85e859deff.patch $SRC_DIR
 ADD patches/9ee66bd91be65605cffb9a490b4dba3bc13358e9.patch $SRC_DIR
 ADD patches/e889d46924085ca0fe38a2847da973dfe6ea100e.patch $SRC_DIR
 ADD patches/f9e97031b56ab5747b5d73629198331a6daacdfd.patch $SRC_DIR
@@ -102,6 +103,8 @@ RUN cd /usr/src/ && \
 
 RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
+    # change default hash type from dp_hash to hash with field src_ip
+    git apply $SRC_DIR/e490f5ac0b644101913c2a3db8e03d85e859deff.patch && \
     # modify src route priority
     git apply $SRC_DIR/9ee66bd91be65605cffb9a490b4dba3bc13358e9.patch && \
     # fix reaching resubmit limit in underlay

--- a/dist/images/patches/e490f5ac0b644101913c2a3db8e03d85e859deff.patch
+++ b/dist/images/patches/e490f5ac0b644101913c2a3db8e03d85e859deff.patch
@@ -1,0 +1,34 @@
+From e490f5ac0b644101913c2a3db8e03d85e859deff Mon Sep 17 00:00:00 2001
+From: Mengxin Liu <mengxin@alauda.io>
+Date: Thu, 10 Apr 2025 01:28:59 +0000
+Subject: [PATCH] change default hash type from dp_hash to hash with field
+ src_ip
+
+---
+ lib/actions.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/lib/actions.c b/lib/actions.c
+index ed9b70882..12e5e6bb0 100644
+--- a/lib/actions.c
++++ b/lib/actions.c
+@@ -1653,13 +1653,14 @@ encode_SELECT(const struct ovnact_select *select,
+     struct ofpact_group *og;
+ 
+     struct ds ds = DS_EMPTY_INITIALIZER;
+-    ds_put_format(&ds, "type=select,selection_method=%s",
+-                  select->hash_fields ? "hash": "dp_hash");
+     if (select->hash_fields) {
+-      ds_put_format(&ds, ",fields(%s)", select->hash_fields);
++        ds_put_format(&ds, "type=select,selection_method=hash,fields(%s)",
++                      select->hash_fields);
++    } else {
++        ds_put_format(&ds, "type=select,selection_method=hash,fields=ip_src");
+     }
+ 
+     if (ovs_feature_is_supported(OVS_DP_HASH_L4_SYM_SUPPORT) &&
+         !select->hash_fields) {
+         /* Select dp-hash l4_symmetric by setting the upper 32bits of
+          * selection_method_param to value 1 (1 << 32): */
+-- 
+2.43.0


### PR DESCRIPTION
## 背景

之前升级 OVN 到 25.03 时删掉了这个 downstream patch：

```text
change hash type from dp_hash to hash with field src_ip
```

当时删除的原因是：OVN 25.03 已经支持 `selection_fields`，看起来可以通过 upstream 的正式能力配置 ECMP hash 字段，因此误以为旧 patch 已经不再需要。

## 问题

后续确认下来，OVN 25.03 的 `selection_fields` 只支持在 `Logical_Router_Static_Route` 上配置，也就是只覆盖 static route ECMP。

但 Kube-OVN 子网 centralized gateway 的 ECMP 实际走的是：

```text
Logical_Router_Policy.nexthops
```

而 `Logical_Router_Policy` 没有 `selection_fields` 字段。

因此删掉旧 patch 后，子网 ECMP 的 policy route 仍然会生成 `select(...)`，但没有 `hash_fields`，最终会回到 OVN 默认的：

```text
selection_method=dp_hash
```

这会丢失原来依赖的 `ip_src` hash 语义。

## 修复

把该 patch 加回来，恢复默认 `select()` 使用：

```text
selection_method=hash,fields=ip_src
```

同时保留 OVN 25.03 的新能力：如果 `select()` 已经显式传入 `hash_fields`，仍然优先使用显式字段；只有没有显式 `hash_fields` 的默认路径才使用 `ip_src`。

这样可以恢复 policy route ECMP 的 `ip_src` hash 行为，同时不破坏 static route `selection_fields` 的显式配置能力。

## 验证

- 确认当前 Kube-OVN master 中 `LogicalRouterPolicy` 没有 `SelectionFields`，`LogicalRouterStaticRoute` 才有。
- 在干净的 `ovn-org/ovn:branch-25.03` checkout 上，按 `dist/images/Dockerfile.base` 中的顺序应用完整 OVN patch 序列，全部可以 cleanly apply。
- 验证最终 `lib/actions.c::encode_SELECT()`：
  - 没有 `hash_fields` 时使用 `selection_method=hash,fields=ip_src`
  - 有显式 `hash_fields` 时使用显式字段
- 执行 `git diff --check`，无 whitespace 问题。