### PR TITLE
fix: require subnet for attachment provider

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1059,7 +1059,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2088,7 +2088,6 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			if subnetName == "" {
 				// when ifName is provided in request, the `provider` in subnet spec will not match
 				// since it does not contain substring for interface name and wrong subnet will be selected
-				// and it goes to default subnet
 				for _, subnet := range subnets {
 					if subnetMatches(subnet, providerName, attach.InterfaceRequest) {
 						subnetName = subnet.Name
@@ -2099,42 +2098,26 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			klog.V(5).Infof("found subnet %s for provider %s", subnetName, providerName)
 			var subnet *kubeovnv1.Subnet
 			if subnetName == "" {
-				// attachment network not specify subnet, use pod default subnet or namespace subnet
-				// uses default subnet based on namespace annotation
-				// in this it goes to `ovn-default` and that explains the ipam error because the address is not in the range
-				subnet, err = c.getPodDefaultSubnet(pod)
-				if err != nil {
-					klog.Errorf("failed to pod default subnet, %v", err)
-					if k8serrors.IsNotFound(err) {
-						if ignoreSubnetNotExist {
-							klog.Errorf("deleting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
-							continue
-						}
-					}
-					return nil, err
-				}
-				if subnet == nil {
-					// getPodDefaultSubnet returns (nil, nil) when the deleting pod's default subnet
-					// no longer exists, leave the orphaned ip cr to gc instead of dereferencing nil
-					klog.Errorf("deleting pod %s/%s default subnet for attach %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, attach.Name)
+				err = fmt.Errorf("provider %s is not bound to any subnet", providerName)
+				if ignoreSubnetNotExist {
+					klog.Errorf("deleting pod %s/%s attach %s %v, gc will clean its ip cr", pod.Namespace, pod.Name, attach.Name, err)
 					continue
 				}
-				// default subnet may change after pod restart
-				klog.Infof("pod %s/%s attachment network %s use default subnet %s", pod.Namespace, pod.Name, attach.Name, subnet.Name)
-			} else {
-				subnet, err = c.subnetsLister.Get(subnetName)
-				if err != nil {
-					klog.Errorf("failed to get subnet %s, %v", subnetName, err)
-					if k8serrors.IsNotFound(err) {
-						if ignoreSubnetNotExist {
-							klog.Errorf("deleting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
-							// just continue to next attach subnet
-							// ip name is unique, so it is ok if the other subnet release it
-							continue
-						}
+				klog.Error(err)
+				return nil, err
+			}
+			subnet, err = c.subnetsLister.Get(subnetName)
+			if err != nil {
+				klog.Errorf("failed to get subnet %s, %v", subnetName, err)
+				if k8serrors.IsNotFound(err) {
+					if ignoreSubnetNotExist {
+						klog.Errorf("deleting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
+						// just continue to next attach subnet
+						// ip name is unique, so it is ok if the other subnet release it
+						continue
 					}
-					return nil, err
 				}
+				return nil, err
 			}
 
 			// we send no macrequest or ip request so these should be empty in the response here

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -490,6 +490,63 @@ func TestGetPodKubeovnNetsNonPrimaryCNI(t *testing.T) {
 	}
 }
 
+func TestGetPodKubeovnNetsReturnsErrorWhenAttachmentProviderHasNoSubnet(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: `[{"name": "attachnet-a"}]`,
+			},
+		},
+	}
+	nad := &nadv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "attachnet-a",
+			Namespace: "default",
+		},
+		Spec: nadv1.NetworkAttachmentDefinitionSpec{
+			Config: `{
+				"cniVersion": "0.3.1",
+				"name": "attachnet-a",
+				"type": "kube-ovn",
+				"server_socket": "/run/openvswitch/kube-ovn-daemon.sock",
+				"provider": "attachnet-a.default.ovn"
+			}`,
+		},
+	}
+	subnets := []*kubeovnv1.Subnet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: util.DefaultSubnet},
+			Spec: kubeovnv1.SubnetSpec{
+				CIDRBlock: "10.3.0.0/16",
+				Provider:  util.OvnProvider,
+				Default:   true,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "mismatch-subnet"},
+			Spec: kubeovnv1.SubnetSpec{
+				CIDRBlock: "10.244.0.0/24",
+				Provider:  "attachnet-b.default.ovn",
+			},
+		},
+	}
+
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{nad},
+		Subnets:            subnets,
+		Pods:               []*corev1.Pod{pod},
+	})
+	require.NoError(t, err)
+
+	nets, err := fakeController.fakeController.getPodKubeovnNets(pod)
+
+	require.Error(t, err)
+	require.Nil(t, nets)
+	require.Contains(t, err.Error(), "provider attachnet-a.default.ovn is not bound to any subnet")
+}
+
 func TestAcquireAddressWithSpecifiedSubnet(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/daemon/gateway_test.go
+++ b/pkg/daemon/gateway_test.go
@@ -1,18 +1,30 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
 	kubeovninformerfactory "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+type errSubnetLister struct{}
+
+func (errSubnetLister) List(labels.Selector) ([]*kubeovnv1.Subnet, error) {
+	return nil, errors.New("list failed")
+}
+
+func (errSubnetLister) Get(string) (*kubeovnv1.Subnet, error) {
+	return nil, errors.New("get failed")
+}
 
 func TestGetCidrByProtocol(t *testing.T) {
 	cases := []struct {
@@ -204,4 +216,42 @@ func TestGetTProxyConditionPod(t *testing.T) {
 	require.Len(t, filtered, 2)
 	require.Equal(t, "attach", filtered[0].Name)
 	require.Equal(t, "primary", filtered[1].Name)
+}
+
+func TestProviderExistsRequiresSubnetForNamedOvnProvider(t *testing.T) {
+	subnets := []*kubeovnv1.Subnet{{
+		ObjectMeta: metav1.ObjectMeta{Name: util.DefaultSubnet},
+		Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{Name: "attach-subnet"},
+		Spec:       kubeovnv1.SubnetSpec{Provider: "attachnet-a.default.ovn"},
+	}}
+
+	kubeovnClient := kubeovnfake.NewSimpleClientset()
+	informerFactory := kubeovninformerfactory.NewSharedInformerFactory(kubeovnClient, 0)
+	subnetInformer := informerFactory.Kubeovn().V1().Subnets()
+	for _, subnet := range subnets {
+		require.NoError(t, subnetInformer.Informer().GetStore().Add(subnet))
+	}
+
+	handler := cniServerHandler{Controller: &Controller{subnetsLister: subnetInformer.Lister()}}
+
+	_, ok := handler.providerExists(util.OvnProvider, "")
+	require.True(t, ok)
+
+	subnet, ok := handler.providerExists("attachnet-a.default.ovn", "")
+	require.True(t, ok)
+	require.NotNil(t, subnet)
+	require.Equal(t, "attach-subnet", subnet.Name)
+
+	_, ok = handler.providerExists("attachnet-b.default.ovn", "")
+	require.False(t, ok)
+}
+
+func TestProviderExistsAllowsOnSubnetListError(t *testing.T) {
+	handler := cniServerHandler{Controller: &Controller{subnetsLister: errSubnetLister{}}}
+
+	subnet, ok := handler.providerExists("attachnet-a.default.ovn", "")
+	require.True(t, ok)
+	require.Nil(t, subnet)
 }

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -74,10 +74,14 @@ func gatewayForCNIIPFamily(ipAddr, gateway string) string {
 }
 
 func (csh cniServerHandler) providerExists(provider, ifName string) (*kubeovnv1.Subnet, bool) {
-	if util.IsOvnProvider(provider) {
+	if provider == "" || provider == util.OvnProvider {
 		return nil, true
 	}
-	subnets, _ := csh.Controller.subnetsLister.List(labels.Everything())
+	subnets, err := csh.Controller.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets while checking provider %s: %v", provider, err)
+		return nil, true
+	}
 	// for multi interface attachments the ifname is included in provider, for example, vm-overlay.default.ovn.net1
 	// as a result if ifname is set, we need to append it to subnet provider when comparing with request provider
 	// else no subnet will be found
@@ -114,7 +118,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	klog.V(5).Infof("request body is %v", podRequest)
 	podSubnet, exist := csh.providerExists(podRequest.Provider, podRequest.IfName)
 	if !exist {
-		errMsg := fmt.Errorf("provider %s not bind to any subnet", podRequest.Provider)
+		errMsg := fmt.Errorf("provider %s is not bound to any subnet", podRequest.Provider)
 		klog.Error(errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)

--- a/test/e2e/multus/e2e_test.go
+++ b/test/e2e/multus/e2e_test.go
@@ -1,21 +1,27 @@
 package multus
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e"
 	k8sframework "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -148,6 +154,48 @@ var _ = framework.SerialDescribe("[group:multus]", func() {
 			framework.ExpectContainElement(actualRoutes, request.Route{Destination: nadIPv6CIDR})
 			framework.ExpectNotContainElement(actualRoutes, request.Route{Destination: "default", Gateway: nadIPv6Gateway})
 		}
+	})
+
+	framework.ConformanceIt("should reject ovn attachment provider without matching subnet", func() {
+		f.SkipVersionPriorTo(1, 15, "multiple network attachment validation requires v1.15+")
+
+		provider := fmt.Sprintf("%s.%s.%s", nadName, namespaceName, util.OvnProvider)
+		mismatchProvider := fmt.Sprintf("%s-mismatch.%s.%s", nadName, namespaceName, util.OvnProvider)
+
+		ginkgo.By("Creating subnet " + subnetName + " with a different provider")
+		subnet = framework.MakeSubnet(subnetName, "", cidr, "", util.DefaultVpc, mismatchProvider, nil, nil, nil)
+		subnet = subnetClient.CreateSync(subnet)
+
+		ginkgo.By("Creating network attachment definition " + nadName)
+		nad := framework.MakeOVNNetworkAttachmentDefinition(nadName, namespaceName, provider, nil)
+		nad = nadClient.Create(nad)
+		framework.Logf("created network attachment definition config:\n%s", nad.Spec.Config)
+
+		ginkgo.By("Creating pod " + podName)
+		annotations := map[string]string{nadv1.NetworkAttachmentAnnot: fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)}
+		pod := framework.MakePod(namespaceName, podName, nil, annotations, "", nil, nil)
+		_ = podClient.Create(pod)
+
+		ginkgo.By("Waiting for kubelet to report sandbox creation failure")
+		wantMessage := fmt.Sprintf("no address allocated to pod %s/%s provider %s", namespaceName, podName, util.OvnProvider)
+		gomega.Eventually(func() bool {
+			events, err := f.ClientSet.CoreV1().Events(namespaceName).List(context.Background(), metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("involvedObject.kind=%s,involvedObject.name=%s,type=%s,reason=%s", util.KindPod, podName, corev1.EventTypeWarning, kubeletevents.FailedCreatePodSandBox),
+			})
+			if err != nil {
+				return false
+			}
+			for _, event := range events.Items {
+				if strings.Contains(event.Message, wantMessage) {
+					return true
+				}
+			}
+			return false
+		}, 60*time.Second, time.Second).Should(gomega.BeTrue(), "expected pod event to contain %q", wantMessage)
+
+		pod = podClient.GetPod(podName)
+		framework.ExpectNotEqual(pod.Status.Phase, corev1.PodRunning, "pod should not run when attachment provider has no subnet")
+		framework.ExpectEmpty(pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)], "attachment should not fall back to the default subnet")
 	})
 
 	framework.ConformanceIt("should be able to create attachment interface with custom routes", func() {


### PR DESCRIPTION
## What
- Return an error when an OVN attachment provider has no matching Subnet instead of falling back to the pod default subnet.
- Make kube-ovn-daemon validate named OVN providers against Subnet.Spec.Provider while keeping the default ovn provider path unchanged.
- Add a non-primary CNI e2e case for mismatched NAD/Subnet providers.

## Why
ACP-53740 reported that a Multus attachment with provider attachnet-a.default.ovn could receive an IP from ovn-default when the only attachment subnet used provider attachnet-b.default.ovn. The controller fallback silently polluted default IPAM and let the pod become Ready.

## Tests
- go test ./pkg/controller -count=1
- go test ./pkg/daemon -count=1
- go test ./test/e2e/non-primary-cni -run TestE2E -count=0
- make lint