### PR TITLE
[release-1.15] fix: skip non-security-group port groups in sg gc

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -835,8 +835,12 @@ func (c *Controller) gcSecurityGroup() error {
 		if pg.Name == denyAllPg || pg.Name == defaultPg || pg.ExternalIDs[networkPolicyKey] != "" {
 			continue
 		}
+		sg := pg.ExternalIDs[sgKey]
+		if sg == "" {
+			continue
+		}
 		// if port group not exist in security group, delete it
-		if !sgSet.Has(pg.ExternalIDs["sg"]) {
+		if !sgSet.Has(sg) {
 			klog.Infof("ready to gc port group %s", pg.Name)
 			needToDelPgs = append(needToDelPgs, pg.Name)
 		}

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -48,4 +50,22 @@ func Test_logicalRouterPortFilter(t *testing.T) {
 			require.True(t, filterFunc(lrp))
 		}
 	}
+}
+
+func TestGcSecurityGroupSkipsVpcEgressGatewayPortGroup(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+
+	mockOvnClient.EXPECT().ListPortGroups(map[string]string{"vendor": util.CniTypeName}).Return([]ovnnb.PortGroup{{
+		Name: "VEG.0b5177562709",
+		ExternalIDs: map[string]string{
+			"af":                           "4",
+			ovs.ExternalIDVendor:           util.CniTypeName,
+			ovs.ExternalIDVpcEgressGateway: "default/egress-ha-a",
+		},
+	}}, nil)
+	mockOvnClient.EXPECT().DeletePortGroup(gomock.Any()).Times(0)
+
+	require.NoError(t, ctrl.gcSecurityGroup())
 }


### PR DESCRIPTION
## Summary
- Backport #6959 to release-1.15.
- Skip port groups without the security-group external ID during security group GC.
- Add a regression test for VPC egress gateway port groups like VEG.*.

## Test Plan
- go test ./pkg/controller -run TestGcSecurityGroupSkipsVpcEgressGatewayPortGroup -count=1
- go test ./pkg/controller -count=1
- make lint (fails on existing gosec G703 in cmd/daemon/cniserver.go, unrelated to this change)