### PR TITLE
[release-1.14] fix: skip non-security-group port groups in sg gc

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -822,8 +822,12 @@ func (c *Controller) gcSecurityGroup() error {
 		if pg.Name == denyAllPg || pg.Name == defaultPg || pg.ExternalIDs[networkPolicyKey] != "" {
 			continue
 		}
+		sg := pg.ExternalIDs[sgKey]
+		if sg == "" {
+			continue
+		}
 		// if port group not exist in security group, delete it
-		if !sgSet.Has(pg.ExternalIDs["sg"]) {
+		if !sgSet.Has(sg) {
 			klog.Infof("ready to gc port group %s", pg.Name)
 			needToDelPgs = append(needToDelPgs, pg.Name)
 		}

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
@@ -46,4 +47,22 @@ func Test_logicalRouterPortFilter(t *testing.T) {
 			require.True(t, filterFunc(lrp))
 		}
 	}
+}
+
+func TestGcSecurityGroupSkipsVpcEgressGatewayPortGroup(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+
+	mockOvnClient.EXPECT().ListPortGroups(nil).Return([]ovnnb.PortGroup{{
+		Name: "VEG.0b5177562709",
+		ExternalIDs: map[string]string{
+			"af":                 "4",
+			"vendor":             "kube-ovn",
+			"vpc-egress-gateway": "default/egress-ha-a",
+		},
+	}}, nil)
+	mockOvnClient.EXPECT().DeletePortGroup(gomock.Any()).Times(0)
+
+	require.NoError(t, ctrl.gcSecurityGroup())
 }

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -711,7 +711,7 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 		// update/delete existing policies
 		for _, policy := range policies {
 			nexthop := rules[policy.Match]
-			bfdSessions := set.New(bfdMap[nexthop]).Delete("")
+			bfdSessions := localGatewayPolicyBFDSessions(bfdMap, nexthop)
 			if nexthop == "" {
 				if err = c.OVNNbClient.DeleteLogicalRouterPolicyByUUID(lrName, policy.UUID); err != nil {
 					err = fmt.Errorf("failed to delete ovn lr policy %q: %w", policy.Match, err)
@@ -741,7 +741,7 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 		// create new policies
 		for match, nexthop := range rules {
 			if err = c.OVNNbClient.AddLogicalRouterPolicy(lrName, util.EgressGatewayLocalPolicyPriority, match,
-				ovnnb.LogicalRouterPolicyActionReroute, []string{nexthop}, []string{bfdMap[nexthop]}, externalIDs); err != nil {
+				ovnnb.LogicalRouterPolicyActionReroute, []string{nexthop}, localGatewayPolicyBFDSessions(bfdMap, nexthop).UnsortedList(), externalIDs); err != nil {
 				klog.Error(err)
 				return err
 			}
@@ -832,6 +832,10 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 	}
 
 	return nil
+}
+
+func localGatewayPolicyBFDSessions(bfdMap map[string]string, nexthop string) set.Set[string] {
+	return set.New(bfdMap[nexthop]).Delete("")
 }
 
 func mergeNodeSelector(nodeSelector []kubeovnv1.VpcEgressGatewayNodeSelector) *corev1.NodeSelector {


### PR DESCRIPTION
## Summary
- Backport #6959 to release-1.14.
- Skip port groups without the security-group external ID during security group GC.
- Add a regression test for VPC egress gateway port groups like VEG.*.

## Test Plan
- go test ./pkg/controller -run TestGcSecurityGroupSkipsVpcEgressGatewayPortGroup -count=1
- go test ./pkg/controller -count=1
- make lint (fails on existing gosec G703 in cmd/daemon/cniserver.go, unrelated to this change)