### PR TITLE
[release-1.15] fix: skip VEG init routes for missing IP family

### DIFF
--- a/dist/images/init-vpc-egress-gateway.sh
+++ b/dist/images/init-vpc-egress-gateway.sh
@@ -18,7 +18,7 @@ internal_iface="eth0"
 external_iface="net1"
 masquerade_chain="VEG-MASQUERADE"
 
-if [ -n "${INTERNAL_GATEWAY_IPV4}" ]; then
+if [ -n "${INTERNAL_GATEWAY_IPV4}" ] && [ -n "${EXTERNAL_GATEWAY_IPV4}" ]; then
   # ip rules and routes for IPv4
   internal_ipv4=`ip -o route get "${INTERNAL_GATEWAY_IPV4}" | grep -o 'src [^ ]*' | awk '{print $2}'`
   external_ipv4=`ip -o route get "${EXTERNAL_GATEWAY_IPV4}" | grep -o 'src [^ ]*' | awk '{print $2}'`
@@ -57,7 +57,7 @@ if [ -n "${INTERNAL_GATEWAY_IPV4}" ]; then
   done
 fi
 
-if [ -n "${INTERNAL_GATEWAY_IPV6}" ]; then
+if [ -n "${INTERNAL_GATEWAY_IPV6}" ] && [ -n "${EXTERNAL_GATEWAY_IPV6}" ]; then
   # ip rules and routes for IPv6
   internal_ipv6=`ip -o route get "${INTERNAL_GATEWAY_IPV6}" | grep -o 'src [^ ]*' | awk '{print $2}'`
   external_ipv6=`ip -o route get "${EXTERNAL_GATEWAY_IPV6}" | grep -o 'src [^ ]*' | awk '{print $2}'`


### PR DESCRIPTION
## Summary
- Backport ACP-53658 fix from #6958.
- Skip VEG init route/SNAT setup for an IP family when its external gateway is absent.

## Test Plan
- bash -n dist/images/init-vpc-egress-gateway.sh
- git diff --check origin/release-1.15..HEAD

(cherry picked from commit 3c378ef69b4091da8d0c3706985d424a2b3214e6)