### PR TITLE
[release-1.16] fix: skip VEG init routes for missing IP family

### DIFF
--- a/dist/images/init-vpc-egress-gateway.sh
+++ b/dist/images/init-vpc-egress-gateway.sh
@@ -22,7 +22,7 @@ external_iface="net1"
 masquerade_chain="VEG-MASQUERADE"
 
 if [ "${ENABLE_BGP}" != "true" ]; then
-  if [ -n "${INTERNAL_GATEWAY_IPV4}" ]; then
+  if [ -n "${INTERNAL_GATEWAY_IPV4}" ] && [ -n "${EXTERNAL_GATEWAY_IPV4}" ]; then
     internal_ipv4=`ip -o route get "${INTERNAL_GATEWAY_IPV4}" | grep -o 'src [^ ]*' | awk '{print $2}'`
     external_ipv4=`ip -o route get "${EXTERNAL_GATEWAY_IPV4}" | grep -o 'src [^ ]*' | awk '{print $2}'`
     internal_iface=`ip -o route get "${INTERNAL_GATEWAY_IPV4}" | grep -o 'dev [^ ]*' | awk '{print $2}'`
@@ -55,7 +55,7 @@ if [ "${ENABLE_BGP}" != "true" ]; then
     done
   fi
 
-  if [ -n "${INTERNAL_GATEWAY_IPV6}" ]; then
+  if [ -n "${INTERNAL_GATEWAY_IPV6}" ] && [ -n "${EXTERNAL_GATEWAY_IPV6}" ]; then
     internal_ipv6=`ip -o route get "${INTERNAL_GATEWAY_IPV6}" | grep -o 'src [^ ]*' | awk '{print $2}'`
     external_ipv6=`ip -o route get "${EXTERNAL_GATEWAY_IPV6}" | grep -o 'src [^ ]*' | awk '{print $2}'`
     internal_iface=`ip -o route get "${INTERNAL_GATEWAY_IPV6}" | grep -o 'dev [^ ]*' | awk '{print $2}'`

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -359,6 +359,63 @@ var _ = framework.SerialDescribe("[group:veg]", func() {
 		vegTest(f, false, provider, nadName, vpcName, internalSubnetName, externalSubnetName, replicas, nil)
 	})
 
+	framework.ConformanceIt("should be ready with default dual-stack internal subnet and IPv4-only external subnet", func() {
+		if !f.IsDual() {
+			ginkgo.Skip("dual-stack cluster is required")
+		}
+
+		provider := fmt.Sprintf("%s.%s", nadName, namespaceName)
+
+		ginkgo.By("Creating network attachment definition " + nadName)
+		nad := framework.MakeMacvlanNetworkAttachmentDefinition(nadName, namespaceName, "eth0", "bridge", provider, nil)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting network attachment definition " + nadName)
+			nadClient.Delete(nadName)
+		})
+		nad = nadClient.Create(nad)
+		framework.Logf("created network attachment definition config:\n%s", nad.Spec.Config)
+
+		defaultVpc := vpcClient.Get(util.DefaultVpc)
+		defaultSubnet := subnetClient.Get(defaultVpc.Status.DefaultLogicalSwitch)
+		if util.CheckProtocol(defaultSubnet.Spec.CIDRBlock) != apiv1.ProtocolDual {
+			ginkgo.Skip("default subnet is not dual-stack")
+		}
+
+		ginkgo.By("Getting docker network " + kindNetwork)
+		network, err := docker.NetworkInspect(kindNetwork)
+		framework.ExpectNoError(err, "getting docker network "+kindNetwork)
+
+		externalSubnet := generateSubnetFromDockerNetwork(externalSubnetName, network, true, false)
+		externalSubnet.Spec.Provider = provider
+		framework.ExpectEqual(util.CheckProtocol(externalSubnet.Spec.CIDRBlock), apiv1.ProtocolIPv4)
+
+		ginkgo.By("Creating IPv4-only macvlan subnet " + externalSubnetName)
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting external subnet " + externalSubnetName)
+			subnetClient.DeleteSync(externalSubnetName)
+		})
+		_ = subnetClient.CreateSync(externalSubnet)
+
+		vegClient := f.VpcEgressGatewayClient()
+		vegName := "veg-" + framework.RandomSuffix()
+		veg := framework.MakeVpcEgressGateway(namespaceName, vegName, "", 1, "", externalSubnetName)
+		veg.Spec.Policies = []apiv1.VpcEgressGatewayPolicy{{
+			Subnets: []string{defaultSubnet.Name},
+		}}
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting vpc egress gateway " + vegName)
+			vegClient.DeleteSync(vegName)
+		})
+
+		ginkgo.By(fmt.Sprintf("Creating vpc egress gateway %s:\n%s", vegName, format.Object(veg, 2)))
+		veg = vegClient.CreateSync(veg)
+		framework.ExpectTrue(veg.Status.Ready)
+		framework.ExpectHaveLen(veg.Status.InternalIPs, 1)
+		framework.ExpectHaveLen(veg.Status.ExternalIPs, 1)
+		_, externalIPv6 := util.SplitStringIP(veg.Status.ExternalIPs[0])
+		framework.ExpectEmpty(externalIPv6)
+	})
+
 	framework.ConformanceIt("should report not ready when workload pod attachment network status is missing", func() {
 		f.SkipVersionPriorTo(1, 17, "VpcEgressGateway workload network status validation was introduced in v1.17")
 


### PR DESCRIPTION
## Summary
- Backport ACP-53658 fix from #6958.
- Skip VEG init route/SNAT setup for an IP family when its external gateway is absent.
- Keep release-1.16 VEG e2e coverage for dual-stack internal plus IPv4-only external subnet.

## Test Plan
- bash -n dist/images/init-vpc-egress-gateway.sh
- git diff --check origin/release-1.16..HEAD
- go test -count=1 ./test/e2e/vpc-egress-gateway -run '^$'

(cherry picked from commit 3c378ef69b4091da8d0c3706985d424a2b3214e6)