### PR TITLE
[release-1.15] fix: require subnet for attachment provider

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1888,40 +1888,26 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			}
 			var subnet *kubeovnv1.Subnet
 			if subnetName == "" {
-				// attachment network not specify subnet, use pod default subnet or namespace subnet
-				subnet, err = c.getPodDefaultSubnet(pod)
-				if err != nil {
-					klog.Errorf("failed to pod default subnet, %v", err)
-					if k8serrors.IsNotFound(err) {
-						if ignoreSubnetNotExist {
-							klog.Errorf("deleting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
-							continue
-						}
-					}
-					return nil, err
-				}
-				if subnet == nil {
-					// getPodDefaultSubnet returns (nil, nil) when the deleting pod's default subnet
-					// no longer exists, leave the orphaned ip cr to gc instead of dereferencing nil
-					klog.Errorf("deleting pod %s/%s default subnet for attach %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, attach.Name)
+				err = fmt.Errorf("provider %s is not bound to any subnet", providerName)
+				if ignoreSubnetNotExist {
+					klog.Errorf("deleting pod %s/%s attach %s %v, gc will clean its ip cr", pod.Namespace, pod.Name, attach.Name, err)
 					continue
 				}
-				// default subnet may change after pod restart
-				klog.Infof("pod %s/%s attachment network %s use default subnet %s", pod.Namespace, pod.Name, attach.Name, subnet.Name)
-			} else {
-				subnet, err = c.subnetsLister.Get(subnetName)
-				if err != nil {
-					klog.Errorf("failed to get subnet %s, %v", subnetName, err)
-					if k8serrors.IsNotFound(err) {
-						if ignoreSubnetNotExist {
-							klog.Errorf("deleting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
-							// just continue to next attach subnet
-							// ip name is unique, so it is ok if the other subnet release it
-							continue
-						}
+				klog.Error(err)
+				return nil, err
+			}
+			subnet, err = c.subnetsLister.Get(subnetName)
+			if err != nil {
+				klog.Errorf("failed to get subnet %s, %v", subnetName, err)
+				if k8serrors.IsNotFound(err) {
+					if ignoreSubnetNotExist {
+						klog.Errorf("deleting pod %s/%s attach subnet %s already not exist, gc will clean its ip cr", pod.Namespace, pod.Name, subnetName)
+						// just continue to next attach subnet
+						// ip name is unique, so it is ok if the other subnet release it
+						continue
 					}
-					return nil, err
 				}
+				return nil, err
 			}
 
 			ret := &kubeovnNet{

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -332,6 +332,63 @@ func TestGetPodKubeovnNetsNonPrimaryCNI(t *testing.T) {
 	}
 }
 
+func TestGetPodKubeovnNetsReturnsErrorWhenAttachmentProviderHasNoSubnet(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: `[{"name": "attachnet-a"}]`,
+			},
+		},
+	}
+	nad := &nadv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "attachnet-a",
+			Namespace: "default",
+		},
+		Spec: nadv1.NetworkAttachmentDefinitionSpec{
+			Config: `{
+				"cniVersion": "0.3.1",
+				"name": "attachnet-a",
+				"type": "kube-ovn",
+				"server_socket": "/run/openvswitch/kube-ovn-daemon.sock",
+				"provider": "attachnet-a.default.ovn"
+			}`,
+		},
+	}
+	subnets := []*kubeovnv1.Subnet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: util.DefaultSubnet},
+			Spec: kubeovnv1.SubnetSpec{
+				CIDRBlock: "10.3.0.0/16",
+				Provider:  util.OvnProvider,
+				Default:   true,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "mismatch-subnet"},
+			Spec: kubeovnv1.SubnetSpec{
+				CIDRBlock: "10.244.0.0/24",
+				Provider:  "attachnet-b.default.ovn",
+			},
+		},
+	}
+
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{nad},
+		Subnets:            subnets,
+		Pods:               []*corev1.Pod{pod},
+	})
+	require.NoError(t, err)
+
+	nets, err := fakeController.fakeController.getPodKubeovnNets(pod)
+
+	require.Error(t, err)
+	require.Nil(t, nets)
+	require.Contains(t, err.Error(), "provider attachnet-a.default.ovn is not bound to any subnet")
+}
+
 func TestAcquireAddressWithSpecifiedSubnet(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/daemon/gateway_test.go
+++ b/pkg/daemon/gateway_test.go
@@ -1,12 +1,28 @@
 package daemon
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	kubeovninformerfactory "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+type errSubnetLister struct{}
+
+func (errSubnetLister) List(labels.Selector) ([]*kubeovnv1.Subnet, error) {
+	return nil, errors.New("list failed")
+}
+
+func (errSubnetLister) Get(string) (*kubeovnv1.Subnet, error) {
+	return nil, errors.New("get failed")
+}
 
 func TestGetCidrByProtocol(t *testing.T) {
 	cases := []struct {
@@ -58,4 +74,42 @@ func TestGetCidrByProtocol(t *testing.T) {
 			require.Equal(t, c.expetced, got)
 		})
 	}
+}
+
+func TestProviderExistsRequiresSubnetForNamedOvnProvider(t *testing.T) {
+	subnets := []*kubeovnv1.Subnet{{
+		ObjectMeta: metav1.ObjectMeta{Name: util.DefaultSubnet},
+		Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{Name: "attach-subnet"},
+		Spec:       kubeovnv1.SubnetSpec{Provider: "attachnet-a.default.ovn"},
+	}}
+
+	kubeovnClient := kubeovnfake.NewSimpleClientset()
+	informerFactory := kubeovninformerfactory.NewSharedInformerFactory(kubeovnClient, 0)
+	subnetInformer := informerFactory.Kubeovn().V1().Subnets()
+	for _, subnet := range subnets {
+		require.NoError(t, subnetInformer.Informer().GetStore().Add(subnet))
+	}
+
+	handler := cniServerHandler{Controller: &Controller{subnetsLister: subnetInformer.Lister()}}
+
+	_, ok := handler.providerExists(util.OvnProvider)
+	require.True(t, ok)
+
+	subnet, ok := handler.providerExists("attachnet-a.default.ovn")
+	require.True(t, ok)
+	require.NotNil(t, subnet)
+	require.Equal(t, "attach-subnet", subnet.Name)
+
+	_, ok = handler.providerExists("attachnet-b.default.ovn")
+	require.False(t, ok)
+}
+
+func TestProviderExistsAllowsOnSubnetListError(t *testing.T) {
+	handler := cniServerHandler{Controller: &Controller{subnetsLister: errSubnetLister{}}}
+
+	subnet, ok := handler.providerExists("attachnet-a.default.ovn")
+	require.True(t, ok)
+	require.Nil(t, subnet)
 }

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -47,10 +47,14 @@ func createCniServerHandler(config *Configuration, controller *Controller) *cniS
 }
 
 func (csh cniServerHandler) providerExists(provider string) (*kubeovnv1.Subnet, bool) {
-	if util.IsOvnProvider(provider) {
+	if provider == "" || provider == util.OvnProvider {
 		return nil, true
 	}
-	subnets, _ := csh.Controller.subnetsLister.List(labels.Everything())
+	subnets, err := csh.Controller.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets while checking provider %s: %v", provider, err)
+		return nil, true
+	}
 	for _, subnet := range subnets {
 		if subnet.Spec.Provider == provider {
 			return subnet.DeepCopy(), true
@@ -72,7 +76,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	klog.V(5).Infof("request body is %v", podRequest)
 	podSubnet, exist := csh.providerExists(podRequest.Provider)
 	if !exist {
-		errMsg := fmt.Errorf("provider %s not bind to any subnet", podRequest.Provider)
+		errMsg := fmt.Errorf("provider %s is not bound to any subnet", podRequest.Provider)
 		klog.Error(errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)


### PR DESCRIPTION
## What
Backport of #6957 to release-1.15.

- Return an error when an OVN attachment provider has no matching Subnet instead of falling back to the pod default subnet.
- Make kube-ovn-daemon validate named OVN providers against Subnet.Spec.Provider while keeping the default ovn provider path unchanged.

## Notes
release-1.15 does not have the non-primary-cni e2e file from master, so this backport keeps the production fix plus unit coverage only.

## Tests
- go test ./pkg/controller -count=1
- go test ./pkg/daemon -count=1
- git diff --check origin/release-1.15..HEAD

## Local lint
- make lint currently fails on pre-existing release-1.15 issue outside this backport: cmd/daemon/cniserver.go:223 G703 Path traversal via taint analysis.