### PR TITLE
feat: configure OVN DB server TLS options

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -2966,6 +2966,9 @@ jobs:
           NET_STACK: "${{ matrix.ip-family }}"
           ENABLE_SSL: "${{ matrix.ssl }}"
           ENABLE_BIND_LOCAL_IP: "${{ matrix.bind-local }}"
+          TLS_MIN_VERSION: "${{ matrix.ssl == 'true' && 'TLS12' || '' }}"
+          TLS_MAX_VERSION: "${{ matrix.ssl == 'true' && 'TLS13' || '' }}"
+          TLS_CIPHER_SUITES: "${{ matrix.ssl == 'true' && 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_256_GCM_SHA384' || '' }}"
         run: make kind-install-chart
 
       - name: Run E2E

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -1082,8 +1082,12 @@ jobs:
         working-directory: test/e2e/kube-ovn/branches/${{ matrix.branch }}
         run: |
           version=$(grep -E '^VERSION="v([0-9]+\.){2}[0-9]+"$' dist/images/install.sh | head -n1 | awk -F= '{print $2}' | tr -d '"')
+          tls_env=""
+          if [[ "${{ matrix.ssl }}" == "true" ]]; then
+            tls_env="TLS_MIN_VERSION=TLS12 TLS_MAX_VERSION=TLS13 TLS_CIPHER_SUITES=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_256_GCM_SHA384"
+          fi
           docker pull kubeovn/kube-ovn:$version
-          sudo VERSION=$version ENABLE_SSL=${{ matrix.ssl }} \
+          sudo VERSION=$version ENABLE_SSL=${{ matrix.ssl }} $tls_env \
             ENABLE_BIND_LOCAL_IP=${{ matrix.bind-local }} \
             make kind-install-${{ matrix.ip-family }}
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ include makefiles/talos.mk
 include makefiles/e2e.mk
 
 COMMA = ,
+HELM_OVN_DB_TLS_ARGS = $(if $(TLS_MIN_VERSION),--set networking.TLS_MIN_VERSION=$(TLS_MIN_VERSION),) $(if $(TLS_MAX_VERSION),--set networking.TLS_MAX_VERSION=$(TLS_MAX_VERSION),) $(if $(TLS_CIPHER_SUITES),--set 'networking.TLS_CIPHER_SUITES={$(TLS_CIPHER_SUITES)}',)
+HELM_OVN_DB_TLS_ARGS_V2 = $(if $(TLS_MIN_VERSION),--set networking.tlsMinVersion=$(TLS_MIN_VERSION),) $(if $(TLS_MAX_VERSION),--set networking.tlsMaxVersion=$(TLS_MAX_VERSION),) $(if $(TLS_CIPHER_SUITES),--set 'networking.tlsCipherSuites={$(TLS_CIPHER_SUITES)}',)
 
 REGISTRY = kubeovn
 DEV_TAG = dev
@@ -197,6 +199,7 @@ install-chart:
 		--set DISABLE_MODULES_MANAGEMENT=$(or $(DISABLE_MODULES_MANAGEMENT),false) \
 		--set cni_conf.MOUNT_LOCAL_BIN_DIR=$(or $(MOUNT_LOCAL_BIN_DIR),true) \
 		--set networking.ENABLE_SSL=$(or $(ENABLE_SSL),false) \
+		$(HELM_OVN_DB_TLS_ARGS) \
 		--set networking.NETWORK_TYPE=$(or $(NETWORK_TYPE),geneve) \
 		--set networking.TUNNEL_TYPE=$(or $(TUNNEL_TYPE),geneve) \
 		--set networking.vlan.VLAN_INTERFACE_NAME=$(or $(VLAN_INTERFACE_NAME),) \
@@ -228,6 +231,7 @@ upgrade-chart:
 		--set DISABLE_MODULES_MANAGEMENT=$(or $(DISABLE_MODULES_MANAGEMENT),false) \
 		--set cni_conf.MOUNT_LOCAL_BIN_DIR=$(or $(MOUNT_LOCAL_BIN_DIR),true) \
 		--set networking.ENABLE_SSL=$(or $(ENABLE_SSL),false) \
+		$(HELM_OVN_DB_TLS_ARGS) \
 		--set networking.NETWORK_TYPE=$(or $(NETWORK_TYPE),geneve) \
 		--set networking.TUNNEL_TYPE=$(or $(TUNNEL_TYPE),geneve) \
 		--set networking.vlan.VLAN_INTERFACE_NAME=$(or $(VLAN_INTERFACE_NAME),) \
@@ -256,6 +260,7 @@ install-chart-v2:
 	kubectl label node --overwrite -l node-role.kubernetes.io/control-plane kube-ovn/role=master
 	helm install kubeovn ./charts/kube-ovn-v2 --wait \
 		--set global.images.kubeovn.tag=$(VERSION) \
+		$(HELM_OVN_DB_TLS_ARGS_V2) \
 		--set cni.nonPrimaryCNI=$(or $(ENABLE_NON_PRIMARY_CNI),false) \
 		--set cni.configPriority=$(or $(CNI_CONFIG_PRIORITY),01)
 
@@ -263,6 +268,7 @@ install-chart-v2:
 upgrade-chart-v2:
 	helm upgrade kubeovn ./charts/kube-ovn-v2 --wait \
 		--set global.images.kubeovn.tag=$(VERSION) \
+		$(HELM_OVN_DB_TLS_ARGS_V2) \
 		--set cni.nonPrimaryCNI=$(or $(ENABLE_NON_PRIMARY_CNI),false) \
 		--set cni.configPriority=$(or $(CNI_CONFIG_PRIORITY),01)
 	kubectl -n kube-system wait pod --for=condition=ready -l app=ovs --timeout=60s

--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -113,6 +113,34 @@ Get IPs of master nodes from values
   {{- join "," .Values.masterNodes }}
 {{- end -}}
 
+{{/*
+Environment variables used by the OVN NB/SB database server TLS setup.
+*/}}
+{{- define "kubeovn.ovnCentralTLSEnv" -}}
+- name: ENABLE_SSL
+  value: {{ .Values.networking.enableSsl | quote }}
+- name: TLS_MIN_VERSION
+  value: {{ .Values.networking.tlsMinVersion | quote }}
+- name: TLS_MAX_VERSION
+  value: {{ .Values.networking.tlsMaxVersion | quote }}
+- name: TLS_CIPHER_SUITES
+  value: {{ join "," .Values.networking.tlsCipherSuites | quote }}
+{{- end -}}
+
+{{/*
+TLS arguments for kube-ovn components that expose HTTPS endpoints.
+*/}}
+{{- define "kubeovn.componentTLSArgs" -}}
+{{- if .Values.networking.tlsMinVersion }}
+- --tls-min-version={{ .Values.networking.tlsMinVersion }}
+{{- end }}
+{{- if .Values.networking.tlsMaxVersion }}
+- --tls-max-version={{ .Values.networking.tlsMaxVersion }}
+{{- end }}
+{{- if .Values.networking.tlsCipherSuites }}
+- --tls-cipher-suites={{ join "," .Values.networking.tlsCipherSuites }}
+{{- end }}
+{{- end -}}
 
 {{- define "kubeovn.ovs-ovn.updateStrategy" -}}
   {{- $ds := lookup "apps/v1" "DaemonSet" $.Values.namespace "ovs-ovn" -}}

--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -146,6 +146,9 @@ spec:
           - --enable-tproxy={{ .Values.features.enableTproxy }}
           - --ovs-vsctl-concurrency={{ .Values.performance.ovsVsctlConcurrency }}
           - --secure-serving={{- .Values.features.enableSecureServing }}
+          {{- if or .Values.networking.tlsMinVersion .Values.networking.tlsMaxVersion .Values.networking.tlsCipherSuites }}
+          {{- include "kubeovn.componentTLSArgs" . | nindent 10 }}
+          {{- end }}
           - --enable-ovn-ipsec={{- .Values.features.enableOvnIpsec }}
           - --host-tunnel-src={{- .Values.features.enableHostTunnelSrc | default false }}
           - --non-primary-cni-mode={{- .Values.cni.nonPrimaryCNI }}

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -99,8 +99,7 @@ spec:
                 - NET_BIND_SERVICE
                 - SYS_NICE
           env:
-            - name: ENABLE_SSL
-              value: "{{ .Values.networking.enableSsl }}"
+{{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
             - name: NODE_IPS
               value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
             - name: POD_IP

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -156,6 +156,9 @@ spec:
           - --node-local-dns-ip={{- .Values.networking.nodeLocalDnsIp }}
           - --skip-conntrack-dst-cidrs={{- .Values.networking.skipConntrackDstCidrs }}
           - --secure-serving={{- .Values.features.enableSecureServing }}
+          {{- if or .Values.networking.tlsMinVersion .Values.networking.tlsMaxVersion .Values.networking.tlsCipherSuites }}
+          {{- include "kubeovn.componentTLSArgs" . | nindent 10 }}
+          {{- end }}
           - --enable-ovn-ipsec={{- .Values.features.enableOvnIpsec }}
           - --enable-anp={{- .Values.features.ENABLE_ANP }}
           - --enable-dns-name-resolver={{- .Values.features.ENABLE_DNS_NAME_RESOLVER }}

--- a/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
@@ -85,6 +85,9 @@ spec:
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:
           - --secure-serving={{- .Values.features.enableSecureServing }}
+          {{- if or .Values.networking.tlsMinVersion .Values.networking.tlsMaxVersion .Values.networking.tlsCipherSuites }}
+          {{- include "kubeovn.componentTLSArgs" . | nindent 10 }}
+          {{- end }}
           - --log_file=/var/log/kube-ovn/kube-ovn-monitor.log
           - --logtostderr=false
           - --alsologtostderr=true

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -137,6 +137,15 @@ networking:
   # -- Deploy the CNI with SSL encryption in between components.
   # @section -- Network parameters of the CNI
   enableSsl: false
+  # -- Minimum TLS version for OVN NB/SB database server and kube-ovn secure-serving endpoints. Supported values: TLS10, TLS11, TLS12, TLS13. Empty uses the component default.
+  # @section -- Network parameters of the CNI
+  tlsMinVersion: ""
+  # -- Maximum TLS version for OVN NB/SB database server and kube-ovn secure-serving endpoints. Supported values: TLS10, TLS11, TLS12, TLS13. Empty uses the component default.
+  # @section -- Network parameters of the CNI
+  tlsMaxVersion: ""
+  # -- Go TLS cipher suite names. OVN DB server only supports suites mapped by dist/images/ovn-db-ssl-options.sh.
+  # @section -- Network parameters of the CNI
+  tlsCipherSuites: []
   # -- How often kube-ovn-controller checks kube-ovn-tls for renewal. Set to 0 to disable.
   # @section -- Network parameters of the CNI
   kubeOvnTlsRotationInterval: "8760h"

--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -76,6 +76,35 @@ cluster mode uses one replica per master node.
 {{- end -}}
 
 {{/*
+Environment variables used by the OVN NB/SB database server TLS setup.
+*/}}
+{{- define "kubeovn.ovnCentralTLSEnv" -}}
+- name: ENABLE_SSL
+  value: {{ .Values.networking.ENABLE_SSL | quote }}
+- name: TLS_MIN_VERSION
+  value: {{ .Values.networking.TLS_MIN_VERSION | quote }}
+- name: TLS_MAX_VERSION
+  value: {{ .Values.networking.TLS_MAX_VERSION | quote }}
+- name: TLS_CIPHER_SUITES
+  value: {{ join "," .Values.networking.TLS_CIPHER_SUITES | quote }}
+{{- end -}}
+
+{{/*
+TLS arguments for kube-ovn components that expose HTTPS endpoints.
+*/}}
+{{- define "kubeovn.componentTLSArgs" -}}
+{{- if .Values.networking.TLS_MIN_VERSION }}
+- --tls-min-version={{ .Values.networking.TLS_MIN_VERSION }}
+{{- end }}
+{{- if .Values.networking.TLS_MAX_VERSION }}
+- --tls-max-version={{ .Values.networking.TLS_MAX_VERSION }}
+{{- end }}
+{{- if .Values.networking.TLS_CIPHER_SUITES }}
+- --tls-cipher-suites={{ join "," .Values.networking.TLS_CIPHER_SUITES }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Replica count for the kube-ovn-controller Deployment.
 - dataPlaneOnly: tenant cluster typically has no `kube-ovn/role=master` node
   label and kube-ovn-controller can run with replicas=1 (active/standby HA is

--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -119,8 +119,7 @@ spec:
                 - NET_BIND_SERVICE
                 - SYS_NICE
           env:
-            - name: ENABLE_SSL
-              value: "{{ .Values.networking.ENABLE_SSL }}"
+{{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
             - name: NODE_IPS
               value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: POD_IP

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -147,6 +147,9 @@ spec:
           - --enable-metrics={{- .Values.networking.ENABLE_METRICS }}
           - --node-local-dns-ip={{- .Values.networking.NODE_LOCAL_DNS_IP }}
           - --secure-serving={{- .Values.func.SECURE_SERVING }}
+          {{- if or .Values.networking.TLS_MIN_VERSION .Values.networking.TLS_MAX_VERSION .Values.networking.TLS_CIPHER_SUITES }}
+          {{- include "kubeovn.componentTLSArgs" . | nindent 10 }}
+          {{- end }}
           - --enable-ovn-ipsec={{- .Values.func.ENABLE_OVN_IPSEC }}
           - --enable-anp={{- .Values.func.ENABLE_ANP }}
           - --enable-dns-name-resolver={{- .Values.func.ENABLE_DNS_NAME_RESOLVER }}

--- a/charts/kube-ovn/templates/monitor-deploy.yaml
+++ b/charts/kube-ovn/templates/monitor-deploy.yaml
@@ -69,6 +69,9 @@ spec:
           command: ["/kube-ovn/start-ovn-monitor.sh"]
           args:
           - --secure-serving={{- .Values.func.SECURE_SERVING }}
+          {{- if or .Values.networking.TLS_MIN_VERSION .Values.networking.TLS_MAX_VERSION .Values.networking.TLS_CIPHER_SUITES }}
+          {{- include "kubeovn.componentTLSArgs" . | nindent 10 }}
+          {{- end }}
           - --log_file=/var/log/kube-ovn/kube-ovn-monitor.log
           - --logtostderr=false
           - --alsologtostderr=true

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -127,6 +127,9 @@ spec:
           - --enable-tproxy={{ .Values.func.ENABLE_TPROXY }}
           - --ovs-vsctl-concurrency={{ .Values.performance.OVS_VSCTL_CONCURRENCY }}
           - --secure-serving={{- .Values.func.SECURE_SERVING }}
+          {{- if or .Values.networking.TLS_MIN_VERSION .Values.networking.TLS_MAX_VERSION .Values.networking.TLS_CIPHER_SUITES }}
+          {{- include "kubeovn.componentTLSArgs" . | nindent 10 }}
+          {{- end }}
           - --enable-ovn-ipsec={{- .Values.func.ENABLE_OVN_IPSEC }}
           - --set-vxlan-tx-off={{- .Values.func.SET_VXLAN_TX_OFF }}
           - --host-tunnel-src={{- .Values.func.HOST_TUNNEL_SRC | default false }}

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -56,6 +56,12 @@ networking:
   # NET_STACK could be dual_stack, ipv4, ipv6
   NET_STACK: ipv4
   ENABLE_SSL: false
+  # Minimum TLS version for OVN NB/SB database server and kube-ovn secure-serving endpoints.
+  TLS_MIN_VERSION: ""
+  # Maximum TLS version for OVN NB/SB database server and kube-ovn secure-serving endpoints.
+  TLS_MAX_VERSION: ""
+  # Go TLS cipher suite names. OVN DB server only supports suites mapped by dist/images/ovn-db-ssl-options.sh.
+  TLS_CIPHER_SUITES: []
   KUBE_OVN_TLS_ROTATION_INTERVAL: "8760h"
   # network type could be geneve or vlan
   NETWORK_TYPE: geneve

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -8,6 +8,9 @@ DEL_NON_HOST_NET_POD=${DEL_NON_HOST_NET_POD:-true}
 IPV6=${IPV6:-false}
 DUAL_STACK=${DUAL_STACK:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
+TLS_MIN_VERSION=${TLS_MIN_VERSION:-}
+TLS_MAX_VERSION=${TLS_MAX_VERSION:-}
+TLS_CIPHER_SUITES=${TLS_CIPHER_SUITES:-}
 KUBE_OVN_TLS_ROTATION_INTERVAL=${KUBE_OVN_TLS_ROTATION_INTERVAL:-8760h}
 ENABLE_VLAN=${ENABLE_VLAN:-false}
 CHECK_GATEWAY=${CHECK_GATEWAY:-true}
@@ -60,6 +63,19 @@ OVSDB_CON_TIMEOUT=${OVSDB_CON_TIMEOUT:-3}
 OVSDB_INACTIVITY_TIMEOUT=${OVSDB_INACTIVITY_TIMEOUT:-10}
 ENABLE_LIVE_MIGRATION_OPTIMIZE=${ENABLE_LIVE_MIGRATION_OPTIMIZE:-true}
 ENABLE_OVN_LB_PREFER_LOCAL=${ENABLE_OVN_LB_PREFER_LOCAL:-false}
+
+function ovn_central_tls_env {
+  cat <<EOF
+            - name: ENABLE_SSL
+              value: "$ENABLE_SSL"
+            - name: TLS_MIN_VERSION
+              value: "$TLS_MIN_VERSION"
+            - name: TLS_MAX_VERSION
+              value: "$TLS_MAX_VERSION"
+            - name: TLS_CIPHER_SUITES
+              value: "$TLS_CIPHER_SUITES"
+EOF
+}
 
 # Single-replica ovn-central mode: deploy a single Deployment-managed pod with
 # OVN DB stored on a PVC, so the pod can drift to another node on host failure.
@@ -7702,8 +7718,7 @@ ${OVN_CENTRAL_AFFINITY_BLOCK}
                 - NET_BIND_SERVICE
                 - SYS_NICE
           env:
-            - name: ENABLE_SSL
-              value: "$ENABLE_SSL"
+$(ovn_central_tls_env)
             - name: NODE_IPS
               value: "$addresses"
             - name: POD_IP

--- a/dist/images/kube-ovn-tls-reload.sh
+++ b/dist/images/kube-ovn-tls-reload.sh
@@ -18,12 +18,16 @@ NB_PORT=${NB_PORT:-6641}
 SB_PORT=${SB_PORT:-6642}
 NB_CLUSTER_PORT=${NB_CLUSTER_PORT:-6643}
 SB_CLUSTER_PORT=${SB_CLUSTER_PORT:-6644}
+TLS_MIN_VERSION=${TLS_MIN_VERSION:-}
+TLS_MAX_VERSION=${TLS_MAX_VERSION:-}
+TLS_CIPHER_SUITES=${TLS_CIPHER_SUITES:-}
 DB_CLUSTER_ADDR=${DB_CLUSTER_ADDR:-${POD_IP:-}}
 DB_ADDR=::
 if [[ "${ENABLE_BIND_LOCAL_IP:-false}" == "true" ]]; then
   DB_ADDR=${POD_IP:-}
 fi
 SSL_OPTIONS="-p ${TLS_DIR}/key -c ${TLS_DIR}/cert -C ${TLS_DIR}/cacert"
+. /kube-ovn/ovn-db-ssl-options.sh
 
 case "$COMPONENT" in
   ovs)
@@ -86,16 +90,7 @@ function ovn_central_conn_str {
 }
 
 function ovn_central_ssl_args {
-  printf "%s\n" \
-    "--ovn-nb-db-ssl-key=${TLS_DIR}/key" \
-    "--ovn-nb-db-ssl-cert=${TLS_DIR}/cert" \
-    "--ovn-nb-db-ssl-ca-cert=${TLS_DIR}/cacert" \
-    "--ovn-sb-db-ssl-key=${TLS_DIR}/key" \
-    "--ovn-sb-db-ssl-cert=${TLS_DIR}/cert" \
-    "--ovn-sb-db-ssl-ca-cert=${TLS_DIR}/cacert" \
-    "--ovn-northd-ssl-key=${TLS_DIR}/key" \
-    "--ovn-northd-ssl-cert=${TLS_DIR}/cert" \
-    "--ovn-northd-ssl-ca-cert=${TLS_DIR}/cacert"
+  ovn_db_ssl_args "$TLS_DIR"
 }
 
 function wait_ovn_ctl_status {

--- a/dist/images/ovn-db-ssl-options.sh
+++ b/dist/images/ovn-db-ssl-options.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+function ovn_db_tls_version_index {
+  case "$1" in
+    1.0 | "TLS 1.0" | TLS10) echo 0 ;;
+    1.1 | "TLS 1.1" | TLS11) echo 1 ;;
+    1.2 | "TLS 1.2" | TLS12) echo 2 ;;
+    1.3 | "TLS 1.3" | TLS13) echo 3 ;;
+    *) echo "unsupported TLS version: $1" >&2; return 1 ;;
+  esac
+}
+
+function ovn_db_ssl_protocols {
+  if [[ -z "${TLS_MIN_VERSION:-}" && -z "${TLS_MAX_VERSION:-}" ]]; then
+    return 0
+  fi
+
+  local protocols=(TLSv1 TLSv1.1 TLSv1.2 TLSv1.3)
+  local min=0
+  local max=3
+  if [[ -n "${TLS_MIN_VERSION:-}" ]]; then
+    min=$(ovn_db_tls_version_index "$TLS_MIN_VERSION") || return 1
+  fi
+  if [[ -n "${TLS_MAX_VERSION:-}" ]]; then
+    max=$(ovn_db_tls_version_index "$TLS_MAX_VERSION") || return 1
+  fi
+  if ((min > max)); then
+    echo "TLS_MIN_VERSION ($TLS_MIN_VERSION) must be less than or equal to TLS_MAX_VERSION ($TLS_MAX_VERSION)" >&2
+    return 1
+  fi
+
+  local selected=()
+  for ((i = min; i <= max; i++)); do
+    selected+=("${protocols[$i]}")
+  done
+  local IFS=,
+  echo "${selected[*]}"
+}
+
+function ovn_db_cipher_suite_args {
+  if [[ -z "${TLS_CIPHER_SUITES:-}" ]]; then
+    return 0
+  fi
+
+  local ciphers=()
+  local ciphersuites=()
+  local suites=()
+  IFS=, read -ra suites <<< "$TLS_CIPHER_SUITES"
+  for suite in "${suites[@]}"; do
+    suite="${suite#"${suite%%[![:space:]]*}"}"
+    suite="${suite%"${suite##*[![:space:]]}"}"
+    case "$suite" in
+      TLS_AES_128_GCM_SHA256 | TLS_AES_256_GCM_SHA384 | TLS_CHACHA20_POLY1305_SHA256)
+        ciphersuites+=("$suite")
+        ;;
+      TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA)
+        ciphers+=(ECDHE-ECDSA-AES128-SHA)
+        ;;
+      TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA)
+        ciphers+=(ECDHE-ECDSA-AES256-SHA)
+        ;;
+      TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)
+        ciphers+=(ECDHE-RSA-AES128-SHA)
+        ;;
+      TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA)
+        ciphers+=(ECDHE-RSA-AES256-SHA)
+        ;;
+      TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+        ciphers+=(ECDHE-ECDSA-AES128-GCM-SHA256)
+        ;;
+      TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384)
+        ciphers+=(ECDHE-ECDSA-AES256-GCM-SHA384)
+        ;;
+      TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+        ciphers+=(ECDHE-RSA-AES128-GCM-SHA256)
+        ;;
+      TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
+        ciphers+=(ECDHE-RSA-AES256-GCM-SHA384)
+        ;;
+      TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
+        ciphers+=(ECDHE-RSA-CHACHA20-POLY1305)
+        ;;
+      TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256)
+        ciphers+=(ECDHE-ECDSA-CHACHA20-POLY1305)
+        ;;
+      "")
+        ;;
+      *)
+        echo "unsupported TLS cipher suite: $suite" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if ((${#ciphers[@]} > 0)); then
+    local IFS=:
+    echo "--ovn-nb-db-ssl-ciphers=${ciphers[*]}"
+    echo "--ovn-sb-db-ssl-ciphers=${ciphers[*]}"
+  fi
+  if ((${#ciphersuites[@]} > 0)); then
+    local IFS=:
+    echo "--ovn-nb-db-ssl-ciphersuites=${ciphersuites[*]}"
+    echo "--ovn-sb-db-ssl-ciphersuites=${ciphersuites[*]}"
+  fi
+}
+
+function ovn_db_ssl_args {
+  local tls_dir=${1:-/var/run/tls}
+  local protocols
+  protocols=$(ovn_db_ssl_protocols) || return 1
+  local cipher_args
+  cipher_args=$(ovn_db_cipher_suite_args) || return 1
+
+  printf "%s\n" \
+    "--ovn-nb-db-ssl-key=${tls_dir}/key" \
+    "--ovn-nb-db-ssl-cert=${tls_dir}/cert" \
+    "--ovn-nb-db-ssl-ca-cert=${tls_dir}/cacert" \
+    "--ovn-sb-db-ssl-key=${tls_dir}/key" \
+    "--ovn-sb-db-ssl-cert=${tls_dir}/cert" \
+    "--ovn-sb-db-ssl-ca-cert=${tls_dir}/cacert" \
+    "--ovn-northd-ssl-key=${tls_dir}/key" \
+    "--ovn-northd-ssl-cert=${tls_dir}/cert" \
+    "--ovn-northd-ssl-ca-cert=${tls_dir}/cacert"
+
+  if [[ -n "$protocols" ]]; then
+    echo "--ovn-nb-db-ssl-protocols=$protocols"
+    echo "--ovn-sb-db-ssl-protocols=$protocols"
+  fi
+  if [[ -n "$cipher_args" ]]; then
+    echo "$cipher_args"
+  fi
+}

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -40,6 +40,9 @@ NB_CLUSTER_PORT=${NB_CLUSTER_PORT:-6643}
 SB_CLUSTER_PORT=${SB_CLUSTER_PORT:-6644}
 ENABLE_SSL=${ENABLE_SSL:-false}
 ENABLE_BIND_LOCAL_IP=${ENABLE_BIND_LOCAL_IP:-false}
+TLS_MIN_VERSION=${TLS_MIN_VERSION:-}
+TLS_MAX_VERSION=${TLS_MAX_VERSION:-}
+TLS_CIPHER_SUITES=${TLS_CIPHER_SUITES:-}
 
 echo "ENABLE_SSL is set to $ENABLE_SSL"
 echo "ENABLE_BIND_LOCAL_IP is set to $ENABLE_BIND_LOCAL_IP"
@@ -56,6 +59,7 @@ if [ "$ENABLE_SSL" != "false" ]; then
     SSL_OPTIONS="-p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert"
 fi
 
+. /kube-ovn/ovn-db-ssl-options.sh
 . /usr/share/openvswitch/scripts/ovs-lib || exit 1
 
 function random_str {
@@ -427,16 +431,7 @@ else
         # Standalone (single-replica) mode. Same rationale as the non-SSL branch:
         # clean up stale sockets/pids so a drifted pod can come up on a new node.
         rm -f /var/run/ovn/*.pid /var/run/ovn/*.ctl 2>/dev/null || true
-        /usr/share/ovn/scripts/ovn-ctl \
-            --ovn-nb-db-ssl-key=/var/run/tls/key \
-            --ovn-nb-db-ssl-cert=/var/run/tls/cert \
-            --ovn-nb-db-ssl-ca-cert=/var/run/tls/cacert \
-            --ovn-sb-db-ssl-key=/var/run/tls/key \
-            --ovn-sb-db-ssl-cert=/var/run/tls/cert \
-            --ovn-sb-db-ssl-ca-cert=/var/run/tls/cacert \
-            --ovn-northd-ssl-key=/var/run/tls/key \
-            --ovn-northd-ssl-cert=/var/run/tls/cert \
-            --ovn-northd-ssl-ca-cert=/var/run/tls/cacert \
+        /usr/share/ovn/scripts/ovn-ctl $(ovn_db_ssl_args /var/run/tls) \
             --ovn-northd-n-threads="${OVN_NORTHD_N_THREADS}" \
             restart_northd
         ovn-nbctl --no-leader-only $SSL_OPTIONS set-connection pssl:"${NB_PORT}":["${DB_ADDR}"]
@@ -462,15 +457,7 @@ else
         set -eo pipefail
         if [[ ${result} -eq 1  &&  "$nb_leader_ip" == "${DB_CLUSTER_ADDR}" ]]; then
             ovn_ctl_args="$DEBUG_OPT
-                --ovn-nb-db-ssl-key=/var/run/tls/key \
-                --ovn-nb-db-ssl-cert=/var/run/tls/cert \
-                --ovn-nb-db-ssl-ca-cert=/var/run/tls/cacert \
-                --ovn-sb-db-ssl-key=/var/run/tls/key \
-                --ovn-sb-db-ssl-cert=/var/run/tls/cert \
-                --ovn-sb-db-ssl-ca-cert=/var/run/tls/cacert \
-                --ovn-northd-ssl-key=/var/run/tls/key \
-                --ovn-northd-ssl-cert=/var/run/tls/cert \
-                --ovn-northd-ssl-ca-cert=/var/run/tls/cacert \
+                $(ovn_db_ssl_args /var/run/tls) \
                 --db-nb-cluster-local-proto=ssl \
                 --db-sb-cluster-local-proto=ssl \
                 --db-nb-cluster-remote-proto=ssl \
@@ -524,15 +511,7 @@ else
             fi
             set -eo pipefail
             ovn_ctl_args="$DEBUG_OPT
-                --ovn-nb-db-ssl-key=/var/run/tls/key \
-                --ovn-nb-db-ssl-cert=/var/run/tls/cert \
-                --ovn-nb-db-ssl-ca-cert=/var/run/tls/cacert \
-                --ovn-sb-db-ssl-key=/var/run/tls/key \
-                --ovn-sb-db-ssl-cert=/var/run/tls/cert \
-                --ovn-sb-db-ssl-ca-cert=/var/run/tls/cacert \
-                --ovn-northd-ssl-key=/var/run/tls/key \
-                --ovn-northd-ssl-cert=/var/run/tls/cert \
-                --ovn-northd-ssl-ca-cert=/var/run/tls/cacert \
+                $(ovn_db_ssl_args /var/run/tls) \
                 --db-nb-cluster-local-proto=ssl \
                 --db-sb-cluster-local-proto=ssl \
                 --db-nb-cluster-remote-proto=ssl \

--- a/test/e2e/security/e2e_test.go
+++ b/test/e2e/security/e2e_test.go
@@ -163,6 +163,121 @@ func sameStringElements(actual, expected []string) bool {
 	return true
 }
 
+func containerEnvValues(pods []corev1.Pod, containerName string) map[string]string {
+	ginkgo.GinkgoHelper()
+	framework.ExpectNotEmpty(pods, "no pods found")
+
+	envs := map[string]string{}
+	for _, container := range pods[0].Spec.Containers {
+		if container.Name != containerName {
+			continue
+		}
+		for _, env := range container.Env {
+			envs[env.Name] = env.Value
+		}
+		return envs
+	}
+	framework.Failf("container %s not found in pod %s/%s", containerName, pods[0].Namespace, pods[0].Name)
+	return nil
+}
+
+const ovnDBSSLConfigCommand = `set -euo pipefail
+. /kube-ovn/ovn-db-ssl-options.sh
+expected() {
+  ovn_db_ssl_args /var/run/tls | sed -n "s/^--ovn-$1-db-ssl-$2=//p" | head -n1
+}
+actual() {
+  tr '\000' '\n' < /proc/"$(cat /var/run/ovn/ovn"$1"_db.pid)"/cmdline | sed -n "s/^--ssl-$2=//p" | head -n1
+}
+openssl_probe() {
+  port="$1"
+  shift
+  connect="$POD_IP:$port"
+  case "$POD_IP" in
+    *:*) connect="[$POD_IP]:$port" ;;
+  esac
+  timeout 10 openssl s_client -connect "$connect" -cert /var/run/tls/cert -key /var/run/tls/key -CAfile /var/run/tls/cacert -verify_return_error -brief "$@" </dev/null >/tmp/ovn-db-openssl.out 2>&1
+}
+listening() {
+  ss -Hntl | awk '{print $4}' | grep -Eq "(\]|:)$1$"
+}
+check() {
+  db="$1"
+  field="$2"
+  expected_value="$(expected "$db" "$field")"
+  actual_value="$(actual "$db" "$field")"
+  if [ "$actual_value" != "$expected_value" ]; then
+    echo "ovn-$db ssl_$field: expected <$expected_value>, got <$actual_value>"
+    exit 1
+  fi
+}
+supports_protocol() {
+  protocols="$1"
+  protocol="$2"
+  [ -z "$protocols" ] || [ "$protocols" != "${protocols#*$protocol}" ]
+}
+reject_protocol() {
+  db="$1"
+  port="$2"
+  protocol="$3"
+  option="$4"
+  if openssl_probe "$port" "$option"; then
+    echo "ovn-$db unexpectedly accepted $protocol"
+    exit 1
+  fi
+}
+check_handshake() {
+  db="$1"
+  port="$2"
+  required="${3:-true}"
+  if ! listening "$port"; then
+    if [ "$required" = "true" ]; then
+      echo "ovn-$db is not listening on port $port"
+      exit 1
+    fi
+    return 0
+  fi
+  protocols="$(actual "$db" protocols)"
+  cipher="$(actual "$db" ciphers | cut -d: -f1)"
+  ciphersuite="$(actual "$db" ciphersuites | cut -d: -f1)"
+
+  if [ -n "$cipher" ] && supports_protocol "$protocols" TLSv1.2; then
+    openssl_probe "$port" -tls1_2 -cipher "$cipher" || {
+      echo "ovn-$db rejected expected TLSv1.2 cipher $cipher"
+      cat /tmp/ovn-db-openssl.out
+      exit 1
+    }
+  fi
+  if [ -n "$ciphersuite" ] && supports_protocol "$protocols" TLSv1.3; then
+    openssl_probe "$port" -tls1_3 -ciphersuites "$ciphersuite" || {
+      echo "ovn-$db rejected expected TLSv1.3 ciphersuite $ciphersuite"
+      cat /tmp/ovn-db-openssl.out
+      exit 1
+    }
+  fi
+
+  case "${TLS_MIN_VERSION:-}" in
+    1.2 | "TLS 1.2" | TLS12)
+      reject_protocol "$db" "$port" TLSv1.1 -tls1_1
+      ;;
+    1.3 | "TLS 1.3" | TLS13)
+      reject_protocol "$db" "$port" TLSv1.1 -tls1_1
+      reject_protocol "$db" "$port" TLSv1.2 -tls1_2
+      ;;
+  esac
+}
+check nb protocols
+check nb ciphers
+check nb ciphersuites
+check sb protocols
+check sb ciphers
+check sb ciphersuites
+check_handshake nb "${NB_PORT:-6641}"
+check_handshake sb "${SB_PORT:-6642}"
+check_handshake nb "${NB_CLUSTER_PORT:-6643}" false
+check_handshake sb "${SB_CLUSTER_PORT:-6644}" false
+`
+
 var _ = framework.Describe("[group:security]", func() {
 	f := framework.NewDefaultFramework("security")
 	f.SkipNamespaceCreation = true
@@ -175,6 +290,36 @@ var _ = framework.Describe("[group:security]", func() {
 
 	framework.ConformanceIt("ovn db should listen on specified addresses for client connections", func() {
 		checkDeployment(f, "ovn-central", "ovsdb-server", strconv.Itoa(int(util.NBDatabasePort)), strconv.Itoa(int(util.SBDatabasePort)))
+	})
+
+	framework.ConformanceIt("ovn db should apply configured server TLS options", func() {
+		f.SkipVersionPriorTo(1, 15, "OVN DB server TLS options were introduced in v1.15")
+
+		ginkgo.By("Getting deployment ovn-central")
+		deploy, err := f.ClientSet.AppsV1().Deployments(framework.KubeOvnNamespace).Get(context.TODO(), "ovn-central", metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get deployment")
+		err = deployment.WaitForDeploymentComplete(f.ClientSet, deploy)
+		framework.ExpectNoError(err, "deployment failed to complete")
+		deploy, err = f.ClientSet.AppsV1().Deployments(framework.KubeOvnNamespace).Get(context.TODO(), "ovn-central", metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get deployment")
+
+		ginkgo.By("Getting pods")
+		pods, err := deployment.GetPodsForDeployment(context.Background(), f.ClientSet, deploy)
+		framework.ExpectNoError(err, "failed to get pods")
+		framework.ExpectNotEmpty(pods.Items)
+
+		envs := containerEnvValues(pods.Items, "ovn-central")
+		if envs["ENABLE_SSL"] != "true" {
+			ginkgo.Skip("kube-ovn TLS is disabled")
+		}
+		if envs["TLS_MIN_VERSION"] == "" && envs["TLS_MAX_VERSION"] == "" && envs["TLS_CIPHER_SUITES"] == "" {
+			ginkgo.Skip("OVN DB server TLS options are not configured")
+		}
+
+		for _, pod := range pods.Items {
+			stdout, stderr, err := framework.ExecCommandInContainer(f, pod.Namespace, pod.Name, "ovn-central", "bash", "-c", ovnDBSSLConfigCommand)
+			framework.ExpectNoError(err, "failed to validate OVN DB server TLS options in pod %s/%s\nstdout:\n%s\nstderr:\n%s", pod.Namespace, pod.Name, stdout, stderr)
+		}
 	})
 
 	framework.ConformanceIt("kube-ovn-controller should listen on specified addresses", func() {


### PR DESCRIPTION
## Summary
- add kube-ovn-cni-style TLS settings for ovn-central: `TLS_MIN_VERSION`, `TLS_MAX_VERSION`, and list-based `TLS_CIPHER_SUITES` / `tlsCipherSuites` chart values
- translate those shared settings into OVN NB/SB database server `ovn-ctl` SSL protocol/cipher options
- share the conversion logic between ovn-central startup and TLS reload paths
- extract ovn-central TLS env rendering into chart helpers and an `install.sh` helper so chart/install paths use the same parameter block
- add security e2e coverage that validates configured TLS options are applied to OVN NB/SB `ovsdb-server` process arguments, and uses `openssl s_client` to verify accepted/rejected TLS handshakes on client ports plus listening raft cluster ports
- fix the new e2e validation to run in the `ovn-central` container with `bash -c`, matching the TLS helper script syntax used by the image

## Verification
- `git diff --check`
- `go test ./test/e2e/security -run TestE2E -c -o /tmp/security.test && rm -f /tmp/security.test`
- `golangci-lint run -v ./test/e2e/security`
- `awk '/^const ovnDBSSLConfigCommand = `/{flag=1;next} flag && /^`$/{flag=0;next} flag' test/e2e/security/e2e_test.go | bash -n`
- `bash -n dist/images/install.sh && bash -n dist/images/ovn-db-ssl-options.sh && bash -n dist/images/start-db.sh && bash -n dist/images/kube-ovn-tls-reload.sh`
- `bash -c 'source dist/images/ovn-db-ssl-options.sh; TLS_MIN_VERSION=TLS12 TLS_MAX_VERSION=TLS13 TLS_CIPHER_SUITES=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_256_GCM_SHA384 ovn_db_ssl_args /var/run/tls'`
- invalid TLS range check: `TLS_MIN_VERSION=TLS13 TLS_MAX_VERSION=TLS12` returns non-zero without partial stdout
- `helm template kube-ovn charts/kube-ovn --set networking.ENABLE_SSL=true --set networking.TLS_MIN_VERSION=TLS12 --set networking.TLS_MAX_VERSION=TLS13 --set 'networking.TLS_CIPHER_SUITES={TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_256_GCM_SHA384}'`
- `helm template kube-ovn charts/kube-ovn-v2 --set networking.enableSsl=true --set networking.tlsMinVersion=TLS12 --set networking.tlsMaxVersion=TLS13 --set 'networking.tlsCipherSuites={TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_256_GCM_SHA384}'`
- `yq` checks confirm the TLS version/cipher env vars render only on `Deployment/ovn-central` for both charts
- `make lint` attempted locally, but golangci-lint picked up files from sibling/old worktrees (`../ACP-53740-provider-subnet` and `/home/zhang/kube-ovn`) and failed outside this branch's package set
