### PR TITLE
fix: support hostnames for OVN raft addresses

### DIFF
--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -70,20 +70,59 @@ function gen_listen_addr {
     fi
 }
 
+function format_ovsdb_addr {
+    if [[ "$1" =~ ^[0-9.]+$ || "$1" == *:* ]]; then
+        echo "[$1]"
+    else
+        echo "$1"
+    fi
+}
+
+function expand_k8s_svc_addr {
+    if [[ "$1" != *.svc ]]; then
+        echo "$1"
+        return
+    fi
+
+    local fqdn
+    fqdn=$(getent hosts "$1" | awk -v addr="$1" '{ for (i = 2; i <= NF; i++) { if ($i ~ "^" addr "\\.") { print $i; exit } } }')
+    if [[ -z "$fqdn" ]]; then
+        echo "ERROR! failed to resolve Kubernetes service address $1 to a FQDN" >&2
+        exit 1
+    fi
+    echo "$fqdn"
+}
+
+function normalize_raft_addrs {
+    local old_db_cluster_addr="$DB_CLUSTER_ADDR"
+    DB_CLUSTER_ADDR="$(expand_k8s_svc_addr "$DB_CLUSTER_ADDR")"
+    POD_IP="$(expand_k8s_svc_addr "${POD_IP:-}")"
+    if [[ -n "$old_db_cluster_addr" && "${POD_IP:-}" == "$old_db_cluster_addr" ]]; then
+        POD_IP="$DB_CLUSTER_ADDR"
+    fi
+
+    local addrs=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
+    local normalized=()
+    for addr in ${addrs}; do
+        normalized=(${normalized[*]} "$(expand_k8s_svc_addr "$addr")")
+    done
+    NODE_IPS="$(IFS=,; echo "${normalized[*]}")"
+}
+
 function gen_conn_addr {
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        echo "tcp:[$1]:$2"
+        echo "tcp:$(format_ovsdb_addr "$1"):$2"
     else
-        echo "ssl:[$1]:$2"
+        echo "ssl:$(format_ovsdb_addr "$1"):$2"
     fi
 }
 
 function gen_conn_str {
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "tcp:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     else
-        x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "ssl:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     fi
     echo "$x"
 }
@@ -151,6 +190,10 @@ function set_nb_version_compatibility() {
         fi
     fi
 }
+
+if [[ -n "${NODE_IPS:-}" ]]; then
+    normalize_raft_addrs
+fi
 
 # create a new db file and join it to the cluster
 # if the nb/sb db file is corrupted
@@ -317,19 +360,19 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
         ovn_db_pre_start nb
         ovn_db_pre_start sb
 
-        nb_leader_ip=$(get_leader_ip nb)
-        sb_leader_ip=$(get_leader_ip sb)
+        nb_leader_addr=$(get_leader_ip nb)
+        sb_leader_addr=$(get_leader_ip sb)
         set +eo pipefail
         is_clustered
         result=$?
         set -eo pipefail
         # leader up only when no cluster and on the first/only node
-        if [[ ${result} -eq 1 && "$nb_leader_ip" == "$DB_CLUSTER_ADDR" ]]; then
+        if [[ ${result} -eq 1 && "$nb_leader_addr" == "$DB_CLUSTER_ADDR" ]]; then
             ovn_ctl_args="$DEBUG_OPT \
                 --db-nb-create-insecure-remote=yes \
                 --db-sb-create-insecure-remote=yes \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-addr=[$DB_ADDR] \
@@ -366,7 +409,7 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                     nb_leader=$(ovndb_query_leader nb $i)
                     if [[ $nb_leader =~ "true" ]]
                     then
-                        nb_leader_ip=${i}
+                        nb_leader_addr=${i}
                         break
                     fi
                 done
@@ -375,7 +418,7 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                     sb_leader=$(ovndb_query_leader sb $i)
                     if [[ $sb_leader =~ "true" ]]
                     then
-                        sb_leader_ip=${i}
+                        sb_leader_addr=${i}
                         break
                     fi
                 done
@@ -385,10 +428,10 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
             ovn_ctl_args="$DEBUG_OPT \
                 --db-nb-create-insecure-remote=yes \
                 --db-sb-create-insecure-remote=yes \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-nb-cluster-remote-addr=[$nb_leader_ip] \
-                --db-sb-cluster-remote-addr=[$sb_leader_ip] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-nb-cluster-remote-addr=$(format_ovsdb_addr "$nb_leader_addr") \
+                --db-sb-cluster-remote-addr=$(format_ovsdb_addr "$sb_leader_addr") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-cluster-remote-port=$NB_CLUSTER_PORT \
@@ -454,13 +497,13 @@ else
         ovn_db_pre_start nb
         ovn_db_pre_start sb
 
-        nb_leader_ip=$(get_leader_ip nb)
-        sb_leader_ip=$(get_leader_ip sb)
+        nb_leader_addr=$(get_leader_ip nb)
+        sb_leader_addr=$(get_leader_ip sb)
         set +eo pipefail
         is_clustered
         result=$?
         set -eo pipefail
-        if [[ ${result} -eq 1  &&  "$nb_leader_ip" == "${DB_CLUSTER_ADDR}" ]]; then
+        if [[ ${result} -eq 1  &&  "$nb_leader_addr" == "${DB_CLUSTER_ADDR}" ]]; then
             ovn_ctl_args="$DEBUG_OPT
                 --ovn-nb-db-ssl-key=/var/run/tls/key \
                 --ovn-nb-db-ssl-cert=/var/run/tls/cert \
@@ -475,8 +518,8 @@ else
                 --db-sb-cluster-local-proto=ssl \
                 --db-nb-cluster-remote-proto=ssl \
                 --db-sb-cluster-remote-proto=ssl \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
                 --db-nb-addr=[$DB_ADDR] \
                 --db-sb-addr=[$DB_ADDR] \
                 --db-nb-port=$NB_PORT \
@@ -508,7 +551,7 @@ else
                     nb_leader=$(ovndb_query_leader nb $i)
                     if [[ $nb_leader =~ "true" ]]
                     then
-                      nb_leader_ip=${i}
+                      nb_leader_addr=${i}
                       break
                     fi
                 done
@@ -517,7 +560,7 @@ else
                     sb_leader=$(ovndb_query_leader sb $i)
                     if [[ $sb_leader =~ "true" ]]
                     then
-                      sb_leader_ip=${i}
+                      sb_leader_addr=${i}
                       break
                     fi
                 done
@@ -537,10 +580,10 @@ else
                 --db-sb-cluster-local-proto=ssl \
                 --db-nb-cluster-remote-proto=ssl \
                 --db-sb-cluster-remote-proto=ssl \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-nb-cluster-remote-addr=[$nb_leader_ip] \
-                --db-sb-cluster-remote-addr=[$sb_leader_ip] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-nb-cluster-remote-addr=$(format_ovsdb_addr "$nb_leader_addr") \
+                --db-sb-cluster-remote-addr=$(format_ovsdb_addr "$sb_leader_addr") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-cluster-remote-port=$NB_CLUSTER_PORT \

--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -47,21 +47,29 @@ function ovndb_query_leader {
     fi
 }
 
+function format_ovsdb_addr {
+    if [[ "$1" =~ ^[0-9.]+$ || "$1" == *:* ]]; then
+        echo "[$1]"
+    else
+        echo "$1"
+    fi
+}
+
 function gen_conn_str {
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "tcp:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     else
-        x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "ssl:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     fi
     echo "$x"
 }
 
 function gen_conn_addr {
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        echo "tcp:[$1]:$2"
+        echo "tcp:$(format_ovsdb_addr "$1"):$2"
     else
-        echo "ssl:[$1]:$2"
+        echo "ssl:$(format_ovsdb_addr "$1"):$2"
     fi
 }
 

--- a/pkg/ovs/start_db_script_test.go
+++ b/pkg/ovs/start_db_script_test.go
@@ -1,0 +1,194 @@
+package ovs
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestStartDBAddressFunctions(t *testing.T) {
+	bash := requireBash(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	for _, script := range []struct {
+		name      string
+		path      string
+		endMarker string
+	}{
+		{
+			name:      "start-db",
+			path:      filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh"),
+			endMarker: "function get_leader_ip",
+		},
+		{
+			name:      "start-ic-db",
+			path:      filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-ic-db.sh"),
+			endMarker: "function ovn_db_pre_start",
+		},
+	} {
+		t.Run(script.name, func(t *testing.T) {
+			content, err := os.ReadFile(script.path)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", script.path, err)
+			}
+
+			functions := extractStartDBAddressFunctions(t, string(content), script.endMarker)
+
+			tests := []struct {
+				name     string
+				command  string
+				expected string
+			}{
+				{
+					name:     "hostname connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr ovn-central-0.ovn-central.hcp.svc.cluster.local 6643",
+					expected: "tcp:ovn-central-0.ovn-central.hcp.svc.cluster.local:6643",
+				},
+				{
+					name:     "ssl hostname connection address",
+					command:  "ENABLE_SSL=true; gen_conn_addr ovn-central-0.ovn-central.hcp.svc.cluster.local 6643",
+					expected: "ssl:ovn-central-0.ovn-central.hcp.svc.cluster.local:6643",
+				},
+				{
+					name:     "ipv4 connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr 10.3.0.58 6643",
+					expected: "tcp:[10.3.0.58]:6643",
+				},
+				{
+					name:     "ipv6 connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr fd00::58 6643",
+					expected: "tcp:[fd00::58]:6643",
+				},
+				{
+					name:     "hostname connection string",
+					command:  "ENABLE_SSL=false; NODE_IPS='ovn-central-0.ovn-central.hcp.svc.cluster.local, ovn-central-1.ovn-central.hcp.svc.cluster.local'; gen_conn_str 6641",
+					expected: "tcp:ovn-central-0.ovn-central.hcp.svc.cluster.local:6641,tcp:ovn-central-1.ovn-central.hcp.svc.cluster.local:6641",
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					output, err := exec.Command(bash, "-c", functions+"\n"+tt.command).CombinedOutput() // #nosec G204
+					if err != nil {
+						t.Fatalf("command failed: %v\noutput: %s", err, output)
+					}
+
+					got := strings.TrimSpace(string(output))
+					if got != tt.expected {
+						t.Fatalf("expected %q, got %q", tt.expected, got)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestStartDBClusterAddressArgsUseFormatter(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	scriptPath := filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", scriptPath, err)
+	}
+	script := string(content)
+
+	for _, oldArg := range []string{
+		"--db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR]",
+		"--db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR]",
+		"--db-nb-cluster-remote-addr=[$nb_leader_addr]",
+		"--db-sb-cluster-remote-addr=[$sb_leader_addr]",
+	} {
+		if strings.Contains(script, oldArg) {
+			t.Fatalf("cluster address argument %q should use format_ovsdb_addr", oldArg)
+		}
+	}
+}
+
+func TestStartDBExpandsSvcAddressesFromDNSResponse(t *testing.T) {
+	bash := requireBash(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	scriptPath := filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", scriptPath, err)
+	}
+
+	functions := extractStartDBAddressFunctions(t, string(content), "function gen_conn_addr")
+	command := strings.Join([]string{
+		`function getent { case "$2" in ovn-central-0.ovn-central.hcp.svc) echo "10.3.0.67 ovn-central-0.ovn-central.hcp.svc.acme.local" ;; ovn-central-1.ovn-central.hcp.svc) echo "10.3.0.68 ovn-central-1.ovn-central.hcp.svc.acme.local" ;; esac; }`,
+		"POD_NAMESPACE=hcp",
+		"DB_CLUSTER_ADDR=ovn-central-0.ovn-central.hcp.svc",
+		"POD_IP=$DB_CLUSTER_ADDR",
+		"NODE_IPS=ovn-central-0.ovn-central.hcp.svc,ovn-central-1.ovn-central.hcp.svc",
+		"normalize_raft_addrs",
+		"printf '%s\\n%s\\n%s\\n' \"$DB_CLUSTER_ADDR\" \"$POD_IP\" \"$NODE_IPS\"",
+	}, "; ")
+
+	output, err := exec.Command(bash, "-c", functions+"\n"+command).CombinedOutput() // #nosec G204
+	if err != nil {
+		t.Fatalf("command failed: %v\noutput: %s", err, output)
+	}
+
+	expected := strings.Join([]string{
+		"ovn-central-0.ovn-central.hcp.svc.acme.local",
+		"ovn-central-0.ovn-central.hcp.svc.acme.local",
+		"ovn-central-0.ovn-central.hcp.svc.acme.local,ovn-central-1.ovn-central.hcp.svc.acme.local",
+	}, "\n")
+	if got := strings.TrimSpace(string(output)); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func requireBash(t *testing.T) string {
+	t.Helper()
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required to test start-db.sh snippets")
+	}
+	return bash
+}
+
+func extractStartDBAddressFunctions(t *testing.T, script, endMarker string) string {
+	t.Helper()
+
+	start := strings.Index(script, "function format_ovsdb_addr")
+	if start == -1 {
+		start = firstFunctionIndex(script, "function gen_conn_addr", "function gen_conn_str")
+	}
+	if start == -1 {
+		t.Fatal("failed to find address functions")
+	}
+	end := strings.Index(script[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("failed to find %s", endMarker)
+	}
+	return script[start : start+end]
+}
+
+func firstFunctionIndex(script string, markers ...string) int {
+	first := -1
+	for _, marker := range markers {
+		index := strings.Index(script, marker)
+		if index != -1 && (first == -1 || index < first) {
+			first = index
+		}
+	}
+	return first
+}


### PR DESCRIPTION
## Summary
- Format OVN clustered DB connection addresses without square brackets when the address is a hostname or FQDN.
- Preserve the existing bracketed format for IPv4 and IPv6 literals in OVN and OVN-IC DB startup scripts.
- Add regression coverage for start-db.sh and start-ic-db.sh address generation.

Example:

```txt
1d4f
Name: OVN_Northbound
Cluster ID: 7ca7 (7ca7b9f6-1f99-455d-914b-5953383af625)
Server ID: 1d4f (1d4fbe6d-2095-429d-9501-75511e60d11d)
Address: tcp:ovn-central-2.ovn-central.hcp.svc.cluster.local:6643
Status: cluster member
Role: leader
Term: 5
Leader: self
Vote: self

Last Election started 34451 ms ago, reason: leadership_transfer
Last Election won: 34443 ms ago
Election timer: 5000
Log: [2, 335]
Entries not yet committed: 0
Entries not yet applied: 0
Connections: (->8094) ->074e <-074e <-8094
Disconnections: 0
Servers:
    8094 (8094 at tcp:ovn-central-0.ovn-central.hcp.svc.cluster.local:6643) next_index=335 match_index=334 last msg 1094 ms ago
    074e (074e at tcp:ovn-central-1.ovn-central.hcp.svc.cluster.local:6643) next_index=335 match_index=334 last msg 1094 ms ago
    1d4f (1d4f at tcp:ovn-central-2.ovn-central.hcp.svc.cluster.local:6643) (self) next_index=334 match_index=334
```

## Test Plan
- go test ./pkg/ovs -count=1
- make lint