### PR TITLE
fix: reconcile attachSubnets for switch_lb_vip VIP

### DIFF
--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -42,6 +44,10 @@ func (c *Controller) enqueueUpdateVirtualIP(oldObj, newObj any) {
 	if !slices.Equal(oldVip.Spec.Selector, newVip.Spec.Selector) {
 		klog.Infof("enqueue update virtual parents for %s", key)
 		c.updateVirtualParentsQueue.Add(key)
+	}
+	if !slices.Equal(oldVip.Spec.AttachSubnets, newVip.Spec.AttachSubnets) {
+		klog.Infof("enqueue update vip %s for attachSubnets change", key)
+		c.updateVirtualIPQueue.Add(key)
 	}
 }
 
@@ -170,6 +176,12 @@ func (c *Controller) handleAddVirtualIP(key string) error {
 		return err
 	}
 
+	if vip.Spec.Type == util.SwitchLBRuleVip {
+		if err := c.reconcileVipAttachSubnets(vip); err != nil {
+			return err
+		}
+	}
+
 	// Trigger subnet status update after all operations complete
 	// At this point: IPAM allocated, VIP CR created with labels+status+finalizer
 	c.updateSubnetStatusQueue.Add(subnetName)
@@ -212,6 +224,12 @@ func (c *Controller) handleUpdateVirtualIP(key string) error {
 		// Release IP from IPAM before removing finalizer
 		c.ipam.ReleaseAddressByPod(vip.Name, vip.Spec.Subnet)
 
+		if vip.Spec.Type == util.SwitchLBRuleVip {
+			if err := c.detachAllVipAttachSubnets(vip); err != nil {
+				return err
+			}
+		}
+
 		// Now remove finalizer, which will trigger subnet status update
 		if err = c.handleDelVipFinalizer(key); err != nil {
 			klog.Errorf("failed to handle vip finalizer %v", err)
@@ -253,6 +271,11 @@ func (c *Controller) handleUpdateVirtualIP(key string) error {
 	if err = c.handleAddOrUpdateVipFinalizer(key); err != nil {
 		klog.Errorf("failed to handle vip finalizer %v", err)
 		return err
+	}
+	if vip.Spec.Type == util.SwitchLBRuleVip {
+		if err := c.reconcileVipAttachSubnets(vip); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -588,6 +611,137 @@ func (c *Controller) handleDelVipFinalizer(key string) error {
 	// This ensures subnet status reflects the IP release
 	// Add delay to ensure API server completes the finalizer removal
 	c.updateSubnetStatusQueue.AddAfter(cachedVip.Spec.Subnet, 300*time.Millisecond)
+	return nil
+}
+
+// reconcileVipAttachSubnets attaches the home VPC's LBs to every subnet listed in
+// vip.Spec.AttachSubnets and detaches them from any subnet that was previously
+// attached (tracked via annotation) but is no longer in the spec.
+func (c *Controller) reconcileVipAttachSubnets(vip *kubeovnv1.Vip) error {
+	homeSubnet, err := c.subnetsLister.Get(vip.Spec.Subnet)
+	if err != nil {
+		klog.Errorf("failed to get subnet %s for vip %s: %v", vip.Spec.Subnet, vip.Name, err)
+		return err
+	}
+	vpc, err := c.vpcsLister.Get(homeSubnet.Spec.Vpc)
+	if err != nil {
+		klog.Errorf("failed to get vpc %s for vip %s: %v", homeSubnet.Spec.Vpc, vip.Name, err)
+		return err
+	}
+
+	var lbs []string
+	for _, lb := range []string{
+		vpc.Status.TCPLoadBalancer,
+		vpc.Status.TCPSessionLoadBalancer,
+		vpc.Status.UDPLoadBalancer,
+		vpc.Status.UDPSessionLoadBalancer,
+		vpc.Status.SctpLoadBalancer,
+		vpc.Status.SctpSessionLoadBalancer,
+	} {
+		if lb != "" {
+			lbs = append(lbs, lb)
+		}
+	}
+	if len(lbs) == 0 {
+		return nil
+	}
+
+	// Determine which subnets were previously attached via annotation.
+	var prevSubnets []string
+	if ann := vip.Annotations[util.VipAttachSubnetsAnnotation]; ann != "" {
+		prevSubnets = strings.Split(ann, ",")
+	}
+	desired := vip.Spec.AttachSubnets
+
+	// Detach from subnets that were previously attached but are no longer desired.
+	for _, s := range prevSubnets {
+		if !slices.Contains(desired, s) {
+			if err := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(s, ovsdb.MutateOperationDelete, lbs...); err != nil {
+				klog.Errorf("failed to detach vpc %s load balancers from subnet %s for vip %s: %v", vpc.Name, s, vip.Name, err)
+				return err
+			}
+			klog.Infof("detached vpc %s load balancers from subnet %s for vip %s", vpc.Name, s, vip.Name)
+		}
+	}
+
+	// Attach to all desired subnets (idempotent INSERT).
+	for _, s := range desired {
+		if err := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(s, ovsdb.MutateOperationInsert, lbs...); err != nil {
+			klog.Errorf("failed to attach vpc %s load balancers to subnet %s for vip %s: %v", vpc.Name, s, vip.Name, err)
+			return err
+		}
+		klog.Infof("attached vpc %s load balancers to subnet %s for vip %s", vpc.Name, s, vip.Name)
+	}
+
+	// Persist the current desired list so future reconciles can diff against it.
+	desiredAnn := strings.Join(desired, ",")
+	existingAnn := ""
+	if vip.Annotations != nil {
+		existingAnn = vip.Annotations[util.VipAttachSubnetsAnnotation]
+	}
+	if desiredAnn != existingAnn {
+		patch := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, util.VipAttachSubnetsAnnotation, desiredAnn)
+		if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(
+			context.Background(), vip.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{},
+		); err != nil && !k8serrors.IsNotFound(err) {
+			klog.Errorf("failed to update attach-subnets annotation for vip %s: %v", vip.Name, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// detachAllVipAttachSubnets removes the home VPC's LBs from every subnet that was
+// listed in vip.Spec.AttachSubnets or tracked by the annotation. Called on VIP deletion.
+func (c *Controller) detachAllVipAttachSubnets(vip *kubeovnv1.Vip) error {
+	toDetach := vip.Spec.AttachSubnets
+	// Union with annotation in case the spec was partially updated before deletion.
+	if ann := vip.Annotations[util.VipAttachSubnetsAnnotation]; ann != "" {
+		for s := range strings.SplitSeq(ann, ",") {
+			if s != "" && !slices.Contains(toDetach, s) {
+				toDetach = append(toDetach, s)
+			}
+		}
+	}
+	if len(toDetach) == 0 {
+		return nil
+	}
+
+	homeSubnet, err := c.subnetsLister.Get(vip.Spec.Subnet)
+	if err != nil {
+		klog.Errorf("failed to get subnet %s for vip %s: %v", vip.Spec.Subnet, vip.Name, err)
+		return err
+	}
+	vpc, err := c.vpcsLister.Get(homeSubnet.Spec.Vpc)
+	if err != nil {
+		klog.Errorf("failed to get vpc %s for vip %s: %v", homeSubnet.Spec.Vpc, vip.Name, err)
+		return err
+	}
+
+	var lbs []string
+	for _, lb := range []string{
+		vpc.Status.TCPLoadBalancer,
+		vpc.Status.TCPSessionLoadBalancer,
+		vpc.Status.UDPLoadBalancer,
+		vpc.Status.UDPSessionLoadBalancer,
+		vpc.Status.SctpLoadBalancer,
+		vpc.Status.SctpSessionLoadBalancer,
+	} {
+		if lb != "" {
+			lbs = append(lbs, lb)
+		}
+	}
+	if len(lbs) == 0 {
+		return nil
+	}
+
+	for _, s := range toDetach {
+		if err := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(s, ovsdb.MutateOperationDelete, lbs...); err != nil {
+			klog.Errorf("failed to detach vpc %s load balancers from subnet %s for vip %s: %v", vpc.Name, s, vip.Name, err)
+			return err
+		}
+		klog.Infof("detached vpc %s load balancers from subnet %s for deleted vip %s", vpc.Name, s, vip.Name)
+	}
 	return nil
 }
 

--- a/pkg/controller/vip_test.go
+++ b/pkg/controller/vip_test.go
@@ -1,0 +1,314 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func Test_reconcileVipAttachSubnets(t *testing.T) {
+	makeSubnet := func(name, vpc string) *kubeovnv1.Subnet {
+		return &kubeovnv1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       kubeovnv1.SubnetSpec{Vpc: vpc},
+		}
+	}
+	makeVpc := func(name, tcpLB string) *kubeovnv1.Vpc {
+		return &kubeovnv1.Vpc{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status:     kubeovnv1.VpcStatus{TCPLoadBalancer: tcpLB},
+		}
+	}
+	makeVip := func(name, subnet string, attach []string, annotations map[string]string) *kubeovnv1.Vip {
+		return &kubeovnv1.Vip{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+			Spec: kubeovnv1.VipSpec{
+				Subnet:        subnet,
+				AttachSubnets: attach,
+				Type:          util.SwitchLBRuleVip,
+			},
+		}
+	}
+
+	t.Run("home subnet not found returns error", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, nil)
+		require.NoError(t, err)
+		vip := makeVip("vip1", "missing-subnet", []string{"attach1"}, nil)
+		assert.Error(t, fc.fakeController.reconcileVipAttachSubnets(vip))
+	})
+
+	t.Run("vpc not found returns error", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "missing-vpc")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"attach1"}, nil)
+		assert.Error(t, fc.fakeController.reconcileVipAttachSubnets(vip))
+	})
+
+	t.Run("vpc with no load balancers is a no-op", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"attach1"}, nil)
+		// No mock expectations — any OVN call would fail the test.
+		assert.NoError(t, fc.fakeController.reconcileVipAttachSubnets(vip))
+	})
+
+	t.Run("happy path attaches to desired subnets and persists annotation", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "vpc1-tcp-lb")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"attach1", "attach2"}, nil)
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Create(
+			context.Background(), vip, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("attach1", ovsdb.MutateOperationInsert, "vpc1-tcp-lb").
+			Return(nil)
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("attach2", ovsdb.MutateOperationInsert, "vpc1-tcp-lb").
+			Return(nil)
+
+		require.NoError(t, fc.fakeController.reconcileVipAttachSubnets(vip))
+
+		updated, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Get(
+			context.Background(), "vip1", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "attach1,attach2", updated.Annotations[util.VipAttachSubnetsAnnotation])
+	})
+
+	t.Run("detaches subnet dropped from desired list and keeps still-desired one", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "vpc1-tcp-lb")},
+		})
+		require.NoError(t, err)
+		// Previously attached to "old" and "keep"; now only "keep" is desired.
+		vip := makeVip("vip1", "home", []string{"keep"}, map[string]string{
+			util.VipAttachSubnetsAnnotation: "old,keep",
+		})
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Create(
+			context.Background(), vip, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("old", ovsdb.MutateOperationDelete, "vpc1-tcp-lb").
+			Return(nil)
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("keep", ovsdb.MutateOperationInsert, "vpc1-tcp-lb").
+			Return(nil)
+
+		require.NoError(t, fc.fakeController.reconcileVipAttachSubnets(vip))
+
+		updated, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Get(
+			context.Background(), "vip1", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "keep", updated.Annotations[util.VipAttachSubnetsAnnotation])
+	})
+
+	t.Run("desired list unchanged skips patch", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "vpc1-tcp-lb")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"attach1"}, map[string]string{
+			util.VipAttachSubnetsAnnotation: "attach1",
+			"unrelated":                     "keep-me",
+		})
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Create(
+			context.Background(), vip, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("attach1", ovsdb.MutateOperationInsert, "vpc1-tcp-lb").
+			Return(nil)
+
+		require.NoError(t, fc.fakeController.reconcileVipAttachSubnets(vip))
+
+		updated, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Get(
+			context.Background(), "vip1", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "keep-me", updated.Annotations["unrelated"], "unrelated annotations must survive a no-op reconcile")
+	})
+
+	t.Run("detach error is propagated before attach loop runs", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "vpc1-tcp-lb")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"keep"}, map[string]string{
+			util.VipAttachSubnetsAnnotation: "old,keep",
+		})
+
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("old", ovsdb.MutateOperationDelete, "vpc1-tcp-lb").
+			Return(assert.AnError)
+		// No INSERT expectation — attach loop must not run once detach fails.
+
+		assert.Error(t, fc.fakeController.reconcileVipAttachSubnets(vip))
+	})
+
+	t.Run("attach error is propagated", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "vpc1-tcp-lb")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"attach1"}, nil)
+
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("attach1", ovsdb.MutateOperationInsert, "vpc1-tcp-lb").
+			Return(assert.AnError)
+
+		assert.Error(t, fc.fakeController.reconcileVipAttachSubnets(vip))
+	})
+}
+
+func Test_detachAllVipAttachSubnets(t *testing.T) {
+	makeSubnet := func(name, vpc string) *kubeovnv1.Subnet {
+		return &kubeovnv1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       kubeovnv1.SubnetSpec{Vpc: vpc},
+		}
+	}
+	makeVpc := func(name, tcpLB string) *kubeovnv1.Vpc {
+		return &kubeovnv1.Vpc{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status:     kubeovnv1.VpcStatus{TCPLoadBalancer: tcpLB},
+		}
+	}
+	makeVip := func(name, subnet string, attach []string, annotations map[string]string) *kubeovnv1.Vip {
+		return &kubeovnv1.Vip{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+			Spec: kubeovnv1.VipSpec{
+				Subnet:        subnet,
+				AttachSubnets: attach,
+				Type:          util.SwitchLBRuleVip,
+			},
+		}
+	}
+
+	t.Run("nothing to detach is a no-op", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, nil)
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", nil, nil)
+		// No lister data and no mock expectations — the function must return
+		// before ever touching the subnet/vpc listers.
+		assert.NoError(t, fc.fakeController.detachAllVipAttachSubnets(vip))
+	})
+
+	t.Run("home subnet not found returns error", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, nil)
+		require.NoError(t, err)
+		vip := makeVip("vip1", "missing-subnet", []string{"attach1"}, nil)
+		assert.Error(t, fc.fakeController.detachAllVipAttachSubnets(vip))
+	})
+
+	t.Run("vpc not found returns error", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "missing-vpc")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"attach1"}, nil)
+		assert.Error(t, fc.fakeController.detachAllVipAttachSubnets(vip))
+	})
+
+	t.Run("vpc with no load balancers is a no-op", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"attach1"}, nil)
+		assert.NoError(t, fc.fakeController.detachAllVipAttachSubnets(vip))
+	})
+
+	t.Run("union of spec and annotation subnets is deduped and detached", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "vpc1-tcp-lb")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"shared", "spec-only"}, map[string]string{
+			util.VipAttachSubnetsAnnotation: "shared,anno-only",
+		})
+
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("shared", ovsdb.MutateOperationDelete, "vpc1-tcp-lb").
+			Return(nil).Times(1)
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("spec-only", ovsdb.MutateOperationDelete, "vpc1-tcp-lb").
+			Return(nil)
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("anno-only", ovsdb.MutateOperationDelete, "vpc1-tcp-lb").
+			Return(nil)
+
+		assert.NoError(t, fc.fakeController.detachAllVipAttachSubnets(vip))
+	})
+
+	t.Run("OVN error is propagated", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{makeSubnet("home", "vpc1")},
+			Vpcs:    []*kubeovnv1.Vpc{makeVpc("vpc1", "vpc1-tcp-lb")},
+		})
+		require.NoError(t, err)
+		vip := makeVip("vip1", "home", []string{"attach1"}, nil)
+
+		fc.mockOvnClient.EXPECT().
+			LogicalSwitchUpdateLoadBalancers("attach1", ovsdb.MutateOperationDelete, "vpc1-tcp-lb").
+			Return(assert.AnError)
+
+		assert.Error(t, fc.fakeController.detachAllVipAttachSubnets(vip))
+	})
+}
+
+func Test_enqueueUpdateVirtualIP_attachSubnetsChange(t *testing.T) {
+	fc, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+	ctrl.updateVirtualIPQueue = newTypedRateLimitingQueue[string]("UpdateVirtualIPTest", nil)
+	ctrl.updateVirtualParentsQueue = newTypedRateLimitingQueue[string]("UpdateVirtualParentsTest", nil)
+
+	base := &kubeovnv1.Vip{
+		ObjectMeta: metav1.ObjectMeta{Name: "vip1"},
+		Spec: kubeovnv1.VipSpec{
+			Subnet:        "subnet1",
+			AttachSubnets: []string{"attach1"},
+		},
+	}
+
+	t.Run("no change does not enqueue", func(t *testing.T) {
+		newVip := base.DeepCopy()
+		ctrl.enqueueUpdateVirtualIP(base, newVip)
+		assert.Equal(t, 0, ctrl.updateVirtualIPQueue.Len())
+		assert.Equal(t, 0, ctrl.updateVirtualParentsQueue.Len())
+	})
+
+	t.Run("AttachSubnets change enqueues update", func(t *testing.T) {
+		newVip := base.DeepCopy()
+		newVip.Spec.AttachSubnets = []string{"attach1", "attach2"}
+		ctrl.enqueueUpdateVirtualIP(base, newVip)
+
+		require.Equal(t, 1, ctrl.updateVirtualIPQueue.Len())
+		item, _ := ctrl.updateVirtualIPQueue.Get()
+		ctrl.updateVirtualIPQueue.Done(item)
+		assert.Equal(t, "vip1", item)
+		assert.Equal(t, 0, ctrl.updateVirtualParentsQueue.Len())
+	})
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -60,6 +60,7 @@ const (
 	SwitchLBRuleVip            = "switch_lb_vip"
 	KubeHostVMVip              = "kube_host_vm_vip"
 	SwitchLBRuleSubnet         = "switch_lb_subnet"
+	VipAttachSubnetsAnnotation = "ovn.kubernetes.io/vip-last-attach-subnets"
 
 	LogicalRouterAnnotation = "ovn.kubernetes.io/logical_router"
 	VpcAnnotation           = "ovn.kubernetes.io/vpc"

--- a/test/e2e/framework/vip.go
+++ b/test/e2e/framework/vip.go
@@ -136,17 +136,18 @@ func (c *VipClient) WaitToDisappear(name string, _, timeout time.Duration) error
 	return nil
 }
 
-func MakeVip(namespaceName, name, subnet, v4ip, v6ip, vipType string) *apiv1.Vip {
+func MakeVip(namespaceName, name, subnet, v4ip, v6ip, vipType string, attachSubnets []string) *apiv1.Vip {
 	vip := &apiv1.Vip{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: apiv1.VipSpec{
-			Namespace: namespaceName,
-			Subnet:    subnet,
-			V4ip:      v4ip,
-			V6ip:      v6ip,
-			Type:      vipType,
+			Namespace:     namespaceName,
+			Subnet:        subnet,
+			V4ip:          v4ip,
+			V6ip:          v6ip,
+			Type:          vipType,
+			AttachSubnets: attachSubnets,
 		},
 	}
 	return vip

--- a/test/e2e/iptables-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/iptables-vpc-nat-gw/e2e_test.go
@@ -730,7 +730,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		)
 
 		ginkgo.By("Creating iptables vip for fip")
-		fipVip := framework.MakeVip(f.Namespace.Name, fipVipName, overlaySubnetName, "", "", "")
+		fipVip := framework.MakeVip(f.Namespace.Name, fipVipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(fipVip)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up fip vip " + fipVipName)
@@ -872,7 +872,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		}
 
 		ginkgo.By("Creating iptables vip for dnat")
-		dnatVip := framework.MakeVip(f.Namespace.Name, dnatVipName, overlaySubnetName, "", "", "")
+		dnatVip := framework.MakeVip(f.Namespace.Name, dnatVipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(dnatVip)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up dnat vip " + dnatVipName)
@@ -908,7 +908,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 
 		// share eip case
 		ginkgo.By("Creating share vip")
-		shareVip := framework.MakeVip(f.Namespace.Name, sharedVipName, overlaySubnetName, "", "", "")
+		shareVip := framework.MakeVip(f.Namespace.Name, sharedVipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(shareVip)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up shared vip " + sharedVipName)
@@ -1084,7 +1084,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		)
 
 		ginkgo.By("Creating iptables vip for share dnat")
-		shareDnatVip1 := framework.MakeVip(f.Namespace.Name, shareDnatVip1Name, overlaySubnetName, "", "", "")
+		shareDnatVip1 := framework.MakeVip(f.Namespace.Name, shareDnatVip1Name, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(shareDnatVip1)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up share dnat vip1 " + shareDnatVip1Name)
@@ -1092,7 +1092,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		})
 		shareDnatVip1 = vipClient.Get(shareDnatVip1Name)
 
-		shareDnatVip2 := framework.MakeVip(f.Namespace.Name, shareDnatVip2Name, overlaySubnetName, "", "", "")
+		shareDnatVip2 := framework.MakeVip(f.Namespace.Name, shareDnatVip2Name, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(shareDnatVip2)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up share dnat vip2 " + shareDnatVip2Name)
@@ -1100,7 +1100,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		})
 		shareDnatVip2 = vipClient.Get(shareDnatVip2Name)
 
-		shareDnatVip3 := framework.MakeVip(f.Namespace.Name, shareDnatVip3Name, overlaySubnetName, "", "", "")
+		shareDnatVip3 := framework.MakeVip(f.Namespace.Name, shareDnatVip3Name, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(shareDnatVip3)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up share dnat vip3 " + shareDnatVip3Name)
@@ -1370,14 +1370,14 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		)
 
 		ginkgo.By("Creating vips for conflict test")
-		conflictVip1 := framework.MakeVip(f.Namespace.Name, conflictVip1Name, overlaySubnetName, "", "", "")
+		conflictVip1 := framework.MakeVip(f.Namespace.Name, conflictVip1Name, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(conflictVip1)
 		ginkgo.DeferCleanup(func() {
 			vipClient.DeleteSync(conflictVip1Name)
 		})
 		conflictVip1 = vipClient.Get(conflictVip1Name)
 
-		conflictVip2 := framework.MakeVip(f.Namespace.Name, conflictVip2Name, overlaySubnetName, "", "", "")
+		conflictVip2 := framework.MakeVip(f.Namespace.Name, conflictVip2Name, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(conflictVip2)
 		ginkgo.DeferCleanup(func() {
 			vipClient.DeleteSync(conflictVip2Name)
@@ -1674,7 +1674,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 
 		ginkgo.By("1. Create a VIP for FIP")
 		vipName := "test-vip-" + framework.RandomSuffix()
-		vip := framework.MakeVip(f.Namespace.Name, vipName, overlaySubnetName, "", "", "")
+		vip := framework.MakeVip(f.Namespace.Name, vipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(vip)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up vip " + vipName)
@@ -1875,7 +1875,7 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 
 		ginkgo.By("9. Testing VIP and FIP with manual EIP")
 		vipName := "test-vip-no-ipam-" + framework.RandomSuffix()
-		vip := framework.MakeVip(f.Namespace.Name, vipName, overlaySubnetName, "", "", "")
+		vip := framework.MakeVip(f.Namespace.Name, vipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(vip)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up vip " + vipName)
@@ -2016,11 +2016,11 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		ginkgo.By("5. Creating VIPs for DNAT/FIP testing")
 		fipVipName := "ha-fip-vip-" + randomSuffix
 		dnatVipName := "ha-dnat-vip-" + randomSuffix
-		fipVip := framework.MakeVip(f.Namespace.Name, fipVipName, haOverlaySubnetName, "", "", "")
+		fipVip := framework.MakeVip(f.Namespace.Name, fipVipName, haOverlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(fipVip)
 		fipVip = vipClient.Get(fipVipName)
 
-		dnatVip := framework.MakeVip(f.Namespace.Name, dnatVipName, haOverlaySubnetName, "", "", "")
+		dnatVip := framework.MakeVip(f.Namespace.Name, dnatVipName, haOverlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(dnatVip)
 		dnatVip = vipClient.Get(dnatVipName)
 
@@ -2249,12 +2249,12 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		randomSuffix := framework.RandomSuffix()
 		oldFipVipName := "old-fip-vip-" + randomSuffix
 		newFipVipName := "new-fip-vip-" + randomSuffix
-		oldFipVip := framework.MakeVip(f.Namespace.Name, oldFipVipName, overlaySubnetName, "", "", "")
+		oldFipVip := framework.MakeVip(f.Namespace.Name, oldFipVipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(oldFipVip)
 		ginkgo.DeferCleanup(func() { vipClient.DeleteSync(oldFipVipName) })
 		oldFipVip = vipClient.Get(oldFipVipName)
 
-		newFipVip := framework.MakeVip(f.Namespace.Name, newFipVipName, overlaySubnetName, "", "", "")
+		newFipVip := framework.MakeVip(f.Namespace.Name, newFipVipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(newFipVip)
 		ginkgo.DeferCleanup(func() { vipClient.DeleteSync(newFipVipName) })
 		newFipVip = vipClient.Get(newFipVipName)
@@ -2331,12 +2331,12 @@ var _ = framework.OrderedDescribe("[group:iptables-vpc-nat-gw]", func() {
 		ginkgo.By("10. Creating VIPs for DNAT (old and new InternalIP)")
 		oldDnatVipName := "old-dnat-vip-" + randomSuffix
 		newDnatVipName := "new-dnat-vip-" + randomSuffix
-		oldDnatVip := framework.MakeVip(f.Namespace.Name, oldDnatVipName, overlaySubnetName, "", "", "")
+		oldDnatVip := framework.MakeVip(f.Namespace.Name, oldDnatVipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(oldDnatVip)
 		ginkgo.DeferCleanup(func() { vipClient.DeleteSync(oldDnatVipName) })
 		oldDnatVip = vipClient.Get(oldDnatVipName)
 
-		newDnatVip := framework.MakeVip(f.Namespace.Name, newDnatVipName, overlaySubnetName, "", "", "")
+		newDnatVip := framework.MakeVip(f.Namespace.Name, newDnatVipName, overlaySubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(newDnatVip)
 		ginkgo.DeferCleanup(func() { vipClient.DeleteSync(newDnatVipName) })
 		newDnatVip = vipClient.Get(newDnatVipName)

--- a/test/e2e/ovn-vpc-nat-gw/e2e_test.go
+++ b/test/e2e/ovn-vpc-nat-gw/e2e_test.go
@@ -56,8 +56,8 @@ func makeOvnEip(name, subnet, v4ip, v6ip, mac, usage string) *kubeovnv1.OvnEip {
 	return framework.MakeOvnEip(name, subnet, v4ip, v6ip, mac, usage)
 }
 
-func makeOvnVip(namespaceName, name, subnet, v4ip, v6ip, vipType string) *kubeovnv1.Vip {
-	return framework.MakeVip(namespaceName, name, subnet, v4ip, v6ip, vipType)
+func makeOvnVip(namespaceName, name, subnet, v4ip, v6ip, vipType string, attachSubnets []string) *kubeovnv1.Vip {
+	return framework.MakeVip(namespaceName, name, subnet, v4ip, v6ip, vipType, attachSubnets)
 }
 
 func makeOvnFip(name, ovnEip, ipType, ipName, vpc, v4Ip string) *kubeovnv1.OvnFip {
@@ -697,7 +697,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		framework.ExpectHaveKeyWithValue(lrpEipSnat.Labels, util.EipV4IpLabel, noBfdLrpEip.Spec.V4Ip)
 
 		ginkgo.By("Creating share vip")
-		shareVip := framework.MakeVip(namespaceName, sharedVipName, noBfdSubnetName, "", "", "")
+		shareVip := framework.MakeVip(namespaceName, sharedVipName, noBfdSubnetName, "", "", "", nil)
 		_ = vipClient.CreateSync(shareVip)
 		ginkgo.By("Creating the first ovn fip with share eip vip should be ok")
 		shareFipShouldOk := framework.MakeOvnFip(sharedEipFipShouldOkName, noBfdlrpEipName, util.Vip, sharedVipName, "", "")
@@ -1000,12 +1000,12 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 		framework.ExpectNotEmpty(multiFipEip2.Status.V4Ip)
 
 		ginkgo.By("Creating ovn vip " + multiFipVip1Name)
-		multiFipVip1 := makeOvnVip(namespaceName, multiFipVip1Name, noBfdSubnetName, "", "", "")
+		multiFipVip1 := makeOvnVip(namespaceName, multiFipVip1Name, noBfdSubnetName, "", "", "", nil)
 		multiFipVip1 = vipClient.CreateSync(multiFipVip1)
 		framework.ExpectNotEmpty(multiFipVip1.Status.V4ip)
 
 		ginkgo.By("Creating ovn vip " + multiFipVip2Name)
-		multiFipVip2 := makeOvnVip(namespaceName, multiFipVip2Name, noBfdSubnetName, "", "", "")
+		multiFipVip2 := makeOvnVip(namespaceName, multiFipVip2Name, noBfdSubnetName, "", "", "", nil)
 		multiFipVip2 = vipClient.CreateSync(multiFipVip2)
 		framework.ExpectNotEmpty(multiFipVip2.Status.V4ip)
 
@@ -1145,7 +1145,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 
 		ginkgo.By("Test ovn fip with eip name and ip")
 		ginkgo.By("Creating ovn vip " + ipFipVipName)
-		ipFipVip := makeOvnVip(namespaceName, ipFipVipName, bfdSubnetName, "", "", "")
+		ipFipVip := makeOvnVip(namespaceName, ipFipVipName, bfdSubnetName, "", "", "", nil)
 		ipFipVip = vipClient.CreateSync(ipFipVip)
 		framework.ExpectNotEmpty(ipFipVip.Status.V4ip)
 		ginkgo.By("Creating ovn eip " + ipFipEipName)
@@ -1160,7 +1160,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 
 		ginkgo.By("Test ovn dnat with eip name and ip")
 		ginkgo.By("Creating ovn vip " + ipDnatVipName)
-		ipDnatVip := makeOvnVip(namespaceName, ipDnatVipName, bfdSubnetName, "", "", "")
+		ipDnatVip := makeOvnVip(namespaceName, ipDnatVipName, bfdSubnetName, "", "", "", nil)
 		ipDnatVip = vipClient.CreateSync(ipDnatVip)
 		framework.ExpectNotEmpty(ipDnatVip.Status.V4ip)
 		ginkgo.By("Creating ovn eip " + ipDnatEipName)
@@ -1188,7 +1188,7 @@ var _ = framework.Describe("[group:ovn-vpc-nat-gw]", func() {
 
 		ginkgo.By("Test ovn snat with eip name and ip")
 		ginkgo.By("Creating ovn vip " + ipSnatVipName)
-		ipSnatVip := makeOvnVip(namespaceName, ipSnatVipName, bfdSubnetName, "", "", "")
+		ipSnatVip := makeOvnVip(namespaceName, ipSnatVipName, bfdSubnetName, "", "", "", nil)
 		ipSnatVip = vipClient.CreateSync(ipSnatVip)
 		framework.ExpectNotEmpty(ipSnatVip.Status.V4ip)
 		ginkgo.By("Creating ovn eip " + ipSnatEipName)

--- a/test/e2e/vip/e2e_test.go
+++ b/test/e2e/vip/e2e_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 )
 
-func makeOvnVip(namespaceName, name, subnet, v4ip, v6ip, vipType string) *apiv1.Vip {
-	return framework.MakeVip(namespaceName, name, subnet, v4ip, v6ip, vipType)
+func makeOvnVip(namespaceName, name, subnet, v4ip, v6ip, vipType string, attachSubnets []string) *apiv1.Vip {
+	return framework.MakeVip(namespaceName, name, subnet, v4ip, v6ip, vipType, attachSubnets)
 }
 
 func makeSecurityGroup(name string, allowSameGroupTraffic bool, ingressRules, egressRules []apiv1.SecurityGroupRule) *apiv1.SecurityGroup {
@@ -217,7 +217,7 @@ var _ = framework.Describe("[group:vip]", func() {
 
 		ginkgo.By("2. Create a VIP and verify finalizer is added")
 		testVipName := "test-vip-finalizer-" + framework.RandomSuffix()
-		testVip := makeOvnVip(namespaceName, testVipName, subnetName, "", "", "")
+		testVip := makeOvnVip(namespaceName, testVipName, subnetName, "", "", "", nil)
 		testVip = vipClient.CreateSync(testVip)
 		// Ensure the VIP is cleaned up even if the test fails early,
 		// otherwise the subnet deletion in AfterEach will time out.
@@ -381,7 +381,7 @@ var _ = framework.Describe("[group:vip]", func() {
 		f.SkipVersionPriorTo(1, 13, "This feature was introduced in v1.13")
 		ginkgo.By("0. Test subnet status counting vip")
 		oldSubnet := subnetClient.Get(subnetName)
-		countingVip := makeOvnVip(namespaceName, countingVipName, subnetName, "", "", "")
+		countingVip := makeOvnVip(namespaceName, countingVipName, subnetName, "", "", "", nil)
 		countingVip = vipClient.CreateSync(countingVip)
 
 		// Wait for finalizer to be added
@@ -430,11 +430,11 @@ var _ = framework.Describe("[group:vip]", func() {
 		ginkgo.By("1. Test allowed address pair vip")
 		if f.IsIPv6() {
 			ginkgo.By("Should create lower case static ipv6 address vip " + lowerCaseStaticIpv6VipName)
-			lowerCaseStaticIpv6Vip := makeOvnVip(namespaceName, lowerCaseStaticIpv6VipName, util.DefaultSubnet, "", lowerCaseV6IP, "")
+			lowerCaseStaticIpv6Vip := makeOvnVip(namespaceName, lowerCaseStaticIpv6VipName, util.DefaultSubnet, "", lowerCaseV6IP, "", nil)
 			lowerCaseStaticIpv6Vip = vipClient.CreateSync(lowerCaseStaticIpv6Vip)
 			framework.ExpectEqual(lowerCaseStaticIpv6Vip.Status.V6ip, lowerCaseV6IP)
 			ginkgo.By("Should not create upper case static ipv6 address vip " + upperCaseStaticIpv6VipName)
-			upperCaseStaticIpv6Vip := makeOvnVip(namespaceName, upperCaseStaticIpv6VipName, util.DefaultSubnet, "", upperCaseV6IP, "")
+			upperCaseStaticIpv6Vip := makeOvnVip(namespaceName, upperCaseStaticIpv6VipName, util.DefaultSubnet, "", upperCaseV6IP, "", nil)
 			_ = vipClient.Create(upperCaseStaticIpv6Vip)
 			time.Sleep(10 * time.Second)
 			upperCaseStaticIpv6Vip = vipClient.Get(upperCaseStaticIpv6VipName)
@@ -443,11 +443,11 @@ var _ = framework.Describe("[group:vip]", func() {
 		// create vip1 and vip2, should have different ip and mac
 		ginkgo.By("Creating allowed address pair vip, should have different ip and mac")
 		ginkgo.By("Creating allowed address pair vip " + vip1Name)
-		vip1 := makeOvnVip(namespaceName, vip1Name, subnetName, "", "", "")
+		vip1 := makeOvnVip(namespaceName, vip1Name, subnetName, "", "", "", nil)
 		vip1 = vipClient.CreateSync(vip1)
 
 		ginkgo.By("Creating allowed address pair vip " + vip2Name)
-		vip2 := makeOvnVip(namespaceName, vip2Name, subnetName, "", "", "")
+		vip2 := makeOvnVip(namespaceName, vip2Name, subnetName, "", "", "", nil)
 		vip2 = vipClient.CreateSync(vip2)
 		virtualIP1 := util.GetStringIP(vip1.Status.V4ip, vip1.Status.V6ip)
 		virtualIP2 := util.GetStringIP(vip2.Status.V4ip, vip2.Status.V6ip)
@@ -559,10 +559,10 @@ var _ = framework.Describe("[group:vip]", func() {
 		ginkgo.By("3. Test switch lb vip")
 		ginkgo.By("Creating two arp proxy vips, should have the same mac which is from gw subnet mac")
 		ginkgo.By("Creating arp proxy switch lb vip " + switchLbVip1Name)
-		switchLbVip1 := makeOvnVip(namespaceName, switchLbVip1Name, subnetName, "", "", util.SwitchLBRuleVip)
+		switchLbVip1 := makeOvnVip(namespaceName, switchLbVip1Name, subnetName, "", "", util.SwitchLBRuleVip, nil)
 		switchLbVip1 = vipClient.CreateSync(switchLbVip1)
 		ginkgo.By("Creating arp proxy switch lb vip " + switchLbVip2Name)
-		switchLbVip2 := makeOvnVip(namespaceName, switchLbVip2Name, subnetName, "", "", util.SwitchLBRuleVip)
+		switchLbVip2 := makeOvnVip(namespaceName, switchLbVip2Name, subnetName, "", "", util.SwitchLBRuleVip, nil)
 		switchLbVip2 = vipClient.CreateSync(switchLbVip2)
 		// arp proxy vip only used in switch lb rule, the lb vip use the subnet gw mac to use lb nat flow
 		framework.ExpectEqual(switchLbVip1.Status.Mac, switchLbVip2.Status.Mac)
@@ -571,6 +571,92 @@ var _ = framework.Describe("[group:vip]", func() {
 		} else {
 			framework.ExpectNotEqual(vip1.Status.V6ip, vip2.Status.V6ip)
 		}
+	})
+
+	framework.ConformanceIt("Test switch lb vip attachSubnets", func() {
+		f.SkipVersionPriorTo(1, 17, "This feature was introduced in v1.17")
+
+		randomSuffix := framework.RandomSuffix()
+		vipName := "attach-vip-" + randomSuffix
+		attachSubnetName1 := "attach-subnet1-" + randomSuffix
+		attachSubnetName2 := "attach-subnet2-" + randomSuffix
+
+		ginkgo.By("Creating attach subnet " + attachSubnetName1)
+		attachSubnet1 := framework.MakeSubnet(attachSubnetName1, "", framework.RandomCIDR(f.ClusterIPFamily), "", vpcName, "", nil, nil, []string{namespaceName})
+		_ = subnetClient.CreateSync(attachSubnet1)
+
+		ginkgo.By("Creating attach subnet " + attachSubnetName2)
+		attachSubnet2 := framework.MakeSubnet(attachSubnetName2, "", framework.RandomCIDR(f.ClusterIPFamily), "", vpcName, "", nil, nil, []string{namespaceName})
+		_ = subnetClient.CreateSync(attachSubnet2)
+
+		ginkgo.By("Getting VPC load balancer names")
+		vpc := vpcClient.Get(vpcName)
+		tcpLBName := vpc.Status.TCPLoadBalancer
+		framework.ExpectNotEmpty(tcpLBName, "VPC should have a TCP load balancer")
+
+		ginkgo.By("Getting LB UUID from name " + tcpLBName)
+		cmd := fmt.Sprintf("ovn-nbctl --format=list --data=bare --no-heading --columns=_uuid find Load_Balancer name=%s", tcpLBName)
+		output, _, err := framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+		lbUUID := strings.TrimSpace(string(output))
+		framework.ExpectNotEmpty(lbUUID, "LB UUID should exist in OVN")
+
+		ginkgo.By("Creating switch lb vip " + vipName + " with AttachSubnets=[" + attachSubnetName1 + "]")
+		vip := makeOvnVip(namespaceName, vipName, subnetName, "", "", util.SwitchLBRuleVip, []string{attachSubnetName1})
+		vip = vipClient.CreateSync(vip)
+
+		// Verify annotation is set
+		framework.ExpectEqual(vip.Annotations[util.VipAttachSubnetsAnnotation], attachSubnetName1)
+
+		// Verify OVN: VPC's LB is attached to attachSubnetName1's logical switch
+		ginkgo.By("Verifying load balancer is attached to " + attachSubnetName1 + " in OVN")
+		cmd = fmt.Sprintf("ovn-nbctl --format=list --data=bare --no-heading --columns=load_balancer list Logical_Switch %s", attachSubnetName1)
+		output, _, err = framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+		framework.ExpectTrue(strings.Contains(string(output), lbUUID),
+			"Logical switch %q should reference VPC LB %q", attachSubnetName1, lbUUID)
+
+		// Update AttachSubnets to point to attachSubnetName2
+		ginkgo.By("Updating AttachSubnets to [" + attachSubnetName2 + "]")
+		modified := vip.DeepCopy()
+		modified.Spec.AttachSubnets = []string{attachSubnetName2}
+		vip = vipClient.Patch(vip, modified, 30*time.Second)
+		framework.ExpectEqual(vip.Spec.AttachSubnets, []string{attachSubnetName2})
+
+		// Wait for controller to reconcile
+		time.Sleep(5 * time.Second)
+
+		// Verify old subnet no longer has LB
+		ginkgo.By("Verifying LB is detached from " + attachSubnetName1)
+		cmd = fmt.Sprintf("ovn-nbctl --format=list --data=bare --no-heading --columns=load_balancer list Logical_Switch %s", attachSubnetName1)
+		output, _, err = framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+		framework.ExpectFalse(strings.Contains(string(output), lbUUID),
+			"Logical switch %q should no longer reference VPC LB %q", attachSubnetName1, lbUUID)
+
+		// Verify new subnet has LB
+		ginkgo.By("Verifying LB is attached to " + attachSubnetName2)
+		cmd = fmt.Sprintf("ovn-nbctl --format=list --data=bare --no-heading --columns=load_balancer list Logical_Switch %s", attachSubnetName2)
+		output, _, err = framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+		framework.ExpectTrue(strings.Contains(string(output), lbUUID),
+			"Logical switch %q should reference VPC LB %q", attachSubnetName2, lbUUID)
+
+		// Delete VIP and verify LB is detached
+		ginkgo.By("Deleting vip " + vipName)
+		vipClient.DeleteSync(vipName)
+
+		ginkgo.By("Verifying LB is detached from " + attachSubnetName2 + " after VIP deletion")
+		cmd = fmt.Sprintf("ovn-nbctl --format=list --data=bare --no-heading --columns=load_balancer list Logical_Switch %s", attachSubnetName2)
+		output, _, err = framework.NBExec(cmd)
+		framework.ExpectNoError(err)
+		framework.ExpectFalse(strings.Contains(string(output), lbUUID),
+			"Logical switch %q should no longer reference VPC LB %q after VIP deletion", attachSubnetName2, lbUUID)
+
+		ginkgo.By("Deleting attach subnet " + attachSubnetName1)
+		subnetClient.DeleteSync(attachSubnetName1)
+		ginkgo.By("Deleting attach subnet " + attachSubnetName2)
+		subnetClient.DeleteSync(attachSubnetName2)
 	})
 })
 

--- a/test/e2e/webhook/vip/vip.go
+++ b/test/e2e/webhook/vip/vip.go
@@ -53,7 +53,7 @@ var _ = framework.Describe("[group:webhook-vip]", func() {
 
 	framework.ConformanceIt("check create vip with different errors", func() {
 		ginkgo.By("Creating vip " + vipName)
-		vip = framework.MakeVip(namespaceName, vipName, "", "", "", "")
+		vip = framework.MakeVip(namespaceName, vipName, "", "", "", "", nil)
 
 		ginkgo.By("validating subnet")
 		vip.Spec.Subnet = ""


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

Reconcile `spec.attachSubnets` on `switch_lb_vip` VIPs by calling `ls-lb-add`/`ls-lb-del` on create, update, and delete, so cross-VPC clients can reach the LB VIP.

## Which issue(s) this PR fixes

Fixes #6954