### PR TITLE
fix(deps): update containerd to v2.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cert-manager/cert-manager v1.20.1
 	github.com/cnf/structhash v0.0.0-20250313080605-df4c6cc74a9a
-	github.com/containerd/containerd/v2 v2.2.4
+	github.com/containerd/containerd/v2 v2.2.5
 	github.com/containerd/nerdctl/v2 v2.2.2
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/containerd/cgroups/v3 v3.1.2 h1:OSosXMtkhI6Qove637tg1XgK4q+DhR0mX8Wi8
 github.com/containerd/cgroups/v3 v3.1.2/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
 github.com/containerd/containerd/api v1.10.0/go.mod h1:NBm1OAk8ZL+LG8R0ceObGxT5hbUYj7CzTmR3xh0DlMM=
-github.com/containerd/containerd/v2 v2.2.4 h1:8x2UdXqww7NYqGNabQ7i1nAgB5LegzjC9KQzO/900iA=
-github.com/containerd/containerd/v2 v2.2.4/go.mod h1:YBcTO8D9149QY9zNmUjy04Mhuc4DlrZQ8FIOwKZEM7o=
+github.com/containerd/containerd/v2 v2.2.5 h1:KTFzB02LviYmmfRmz8r9UFd+n6YlddVFK+5lbgQXUTU=
+github.com/containerd/containerd/v2 v2.2.5/go.mod h1:5t2+xFv2dGd/iDYp9Z8DXB4cmWrWQi1XqxGJPS2gBzU=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/test/e2e/framework/ovn_address_set.go
+++ b/test/e2e/framework/ovn_address_set.go
@@ -49,7 +49,7 @@ var (
 func validateModelStructure(model model.Model, table string, expectedFields map[string]reflect.Type) {
 	ginkgo.GinkgoHelper()
 
-	ExpectEqual(reflect.TypeOf(model).Kind(), reflect.Ptr, "model for table %s is not a pointer type", table)
+	ExpectEqual(reflect.TypeOf(model).Kind(), reflect.Pointer, "model for table %s is not a pointer type", table)
 	ExpectEqual(reflect.TypeOf(model).Elem().Kind(), reflect.Struct, "model for table %s is not a struct type", table)
 
 	for name, typ := range expectedFields {


### PR DESCRIPTION
## Summary
- update github.com/containerd/containerd/v2 to v2.2.5 to resolve Trivy scan failures
- keep the modernize lint fix for reflect.Pointer

## Test Plan
- go test ./pkg/daemon
- go test ./test/e2e/framework
- make lint
- git diff --check

Fixes the image scan failure in https://github.com/kubeovn/kube-ovn/actions/runs/28506039714/job/84506321104