### PR TITLE
feat: support HCP ovn-central chart deployment

### DIFF
--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -143,16 +143,16 @@ TLS arguments for kube-ovn components that expose HTTPS endpoints.
 {{- end -}}
 
 {{- define "kubeovn.centralNamespace" -}}
-{{- if .Values.central.separated.enabled -}}
-{{- default .Values.namespace .Values.central.separated.namespace -}}
+{{- if .Values.central.hcp.enabled -}}
+{{- default .Values.namespace .Values.central.hcp.namespace -}}
 {{- else -}}
 {{- .Values.namespace -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "kubeovn.centralReplicas" -}}
-{{- if .Values.central.separated.enabled -}}
-{{- .Values.central.separated.replicas -}}
+{{- if .Values.central.hcp.enabled -}}
+{{- .Values.central.hcp.replicas -}}
 {{- else -}}
 {{- include "kubeovn.nodeCount" . -}}
 {{- end -}}
@@ -161,34 +161,34 @@ TLS arguments for kube-ovn components that expose HTTPS endpoints.
 {{- define "kubeovn.centralRaftAddresses" -}}
 {{- $namespace := include "kubeovn.centralNamespace" . -}}
 {{- $addresses := list -}}
-{{- range $i := until (int .Values.central.separated.replicas) -}}
+{{- range $i := until (int .Values.central.hcp.replicas) -}}
 {{- $addresses = append $addresses (printf "ovn-central-%d.ovn-central.%s.svc" $i $namespace) -}}
 {{- end -}}
 {{- join "," $addresses -}}
 {{- end -}}
 
 {{- define "kubeovn.ovnDbAddresses" -}}
-{{- if .Values.central.separated.enabled -}}
-{{- if not .Values.central.separated.externalAddresses -}}
-{{- fail "central.separated.externalAddresses must be set when central.separated.enabled is true" -}}
+{{- if .Values.central.hcp.enabled -}}
+{{- if not .Values.central.hcp.externalAddresses -}}
+{{- fail "central.hcp.externalAddresses must be set when central.hcp.enabled is true" -}}
 {{- end -}}
-{{- join "," .Values.central.separated.externalAddresses -}}
+{{- join "," .Values.central.hcp.externalAddresses -}}
 {{- else -}}
 {{- include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "kubeovn.ovnNbPort" -}}
-{{- if .Values.central.separated.enabled -}}
-{{- .Values.central.separated.service.nbNodePort -}}
+{{- if .Values.central.hcp.enabled -}}
+{{- .Values.central.hcp.service.nbNodePort -}}
 {{- else -}}
 6641
 {{- end -}}
 {{- end -}}
 
 {{- define "kubeovn.ovnSbPort" -}}
-{{- if .Values.central.separated.enabled -}}
-{{- .Values.central.separated.service.sbNodePort -}}
+{{- if .Values.central.hcp.enabled -}}
+{{- .Values.central.hcp.service.sbNodePort -}}
 {{- else -}}
 6642
 {{- end -}}

--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -142,6 +142,58 @@ TLS arguments for kube-ovn components that expose HTTPS endpoints.
 {{- end }}
 {{- end -}}
 
+{{- define "kubeovn.centralNamespace" -}}
+{{- if .Values.central.separated.enabled -}}
+{{- default .Values.namespace .Values.central.separated.namespace -}}
+{{- else -}}
+{{- .Values.namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.centralReplicas" -}}
+{{- if .Values.central.separated.enabled -}}
+{{- .Values.central.separated.replicas -}}
+{{- else -}}
+{{- include "kubeovn.nodeCount" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.centralRaftAddresses" -}}
+{{- $namespace := include "kubeovn.centralNamespace" . -}}
+{{- $addresses := list -}}
+{{- range $i := until (int .Values.central.separated.replicas) -}}
+{{- $addresses = append $addresses (printf "ovn-central-%d.ovn-central.%s.svc" $i $namespace) -}}
+{{- end -}}
+{{- join "," $addresses -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnDbAddresses" -}}
+{{- if .Values.central.separated.enabled -}}
+{{- if not .Values.central.separated.externalAddresses -}}
+{{- fail "central.separated.externalAddresses must be set when central.separated.enabled is true" -}}
+{{- end -}}
+{{- join "," .Values.central.separated.externalAddresses -}}
+{{- else -}}
+{{- include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnNbPort" -}}
+{{- if .Values.central.separated.enabled -}}
+{{- .Values.central.separated.service.nbNodePort -}}
+{{- else -}}
+6641
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnSbPort" -}}
+{{- if .Values.central.separated.enabled -}}
+{{- .Values.central.separated.service.sbNodePort -}}
+{{- else -}}
+6642
+{{- end -}}
+{{- end -}}
+
 {{- define "kubeovn.ovs-ovn.updateStrategy" -}}
   {{- $ds := lookup "apps/v1" "DaemonSet" $.Values.namespace "ovs-ovn" -}}
   {{- if $ds -}}

--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -168,30 +168,21 @@ TLS arguments for kube-ovn components that expose HTTPS endpoints.
 {{- end -}}
 
 {{- define "kubeovn.ovnDbAddresses" -}}
-{{- if .Values.central.hcp.enabled -}}
-{{- if not .Values.central.hcp.externalAddresses -}}
-{{- fail "central.hcp.externalAddresses must be set when central.hcp.enabled is true" -}}
-{{- end -}}
-{{- join "," .Values.central.hcp.externalAddresses -}}
-{{- else -}}
 {{- include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) -}}
 {{- end -}}
+
+{{- define "kubeovn.ovnNbAddress" -}}
+{{- if not .Values.central.hcp.nbAddress -}}
+{{- fail "central.hcp.nbAddress must be set when central.hcp.enabled is true" -}}
+{{- end -}}
+{{- .Values.central.hcp.nbAddress -}}
 {{- end -}}
 
-{{- define "kubeovn.ovnNbPort" -}}
-{{- if .Values.central.hcp.enabled -}}
-{{- .Values.central.hcp.service.nbNodePort -}}
-{{- else -}}
-6641
+{{- define "kubeovn.ovnSbAddress" -}}
+{{- if not .Values.central.hcp.sbAddress -}}
+{{- fail "central.hcp.sbAddress must be set when central.hcp.enabled is true" -}}
 {{- end -}}
-{{- end -}}
-
-{{- define "kubeovn.ovnSbPort" -}}
-{{- if .Values.central.hcp.enabled -}}
-{{- .Values.central.hcp.service.sbNodePort -}}
-{{- else -}}
-6642
-{{- end -}}
+{{- .Values.central.hcp.sbAddress -}}
 {{- end -}}
 
 {{- define "kubeovn.ovs-ovn.updateStrategy" -}}

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -64,7 +64,7 @@ spec:
               topologyKey: kubernetes.io/hostname
         {{- end }}
       priorityClassName: system-cluster-critical
-      serviceAccountName: {{ ternary "ovn" "ovn-ovs" .Values.central.separated.enabled }}
+      serviceAccountName: {{ ternary "ovn-central" "ovn-ovs" .Values.central.separated.enabled }}
       automountServiceAccountToken: true
       hostNetwork: {{ ternary "false" "true" .Values.central.separated.enabled }}
       securityContext:

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -112,6 +112,16 @@ spec:
                 - SYS_NICE
           env:
 {{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
+            {{- if .Values.central.hcp.enabled }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             - name: NODE_IPS
               value: "{{ ternary (include "kubeovn.centralRaftAddresses" .) (include "kubeovn.ovnDbAddresses" .) .Values.central.hcp.enabled }}"
             {{- if .Values.central.hcp.enabled }}
@@ -126,6 +136,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
               {{- end }}
+            {{- if not .Values.central.hcp.enabled }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -134,6 +145,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- end }}
             - name: POD_IPS
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -1,9 +1,9 @@
 {{- $centralImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.central.image) | fromYaml -}}
-kind: Deployment
+kind: {{ ternary "StatefulSet" "Deployment" .Values.central.separated.enabled }}
 apiVersion: apps/v1
 metadata:
   name: ovn-central
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
   {{- with .Values.central.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -13,12 +13,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ include "kubeovn.nodeCount" . }}
+  replicas: {{ include "kubeovn.centralReplicas" . }}
+  {{- if .Values.central.separated.enabled }}
+  serviceName: ovn-central
+  podManagementPolicy: Parallel
+  {{- end }}
+  {{- if not .Values.central.separated.enabled }}
   strategy:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: ovn-central
@@ -49,21 +55,23 @@ spec:
           operator: Exists
       affinity:
         {{- include "kube-ovn.affinities.nodeAffinity" (dict "hardcodedRequired" (include "kubeovn.masterNodeRequired" . | fromYamlArray) "userPreferred" .Values.central.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.central.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) | nindent 8 }}
+        {{- if not .Values.central.separated.enabled }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/name: ovn-central
               topologyKey: kubernetes.io/hostname
+        {{- end }}
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn-ovs
+      serviceAccountName: {{ ternary "ovn" "ovn-ovs" .Values.central.separated.enabled }}
       automountServiceAccountToken: true
-      hostNetwork: true
+      hostNetwork: {{ ternary "false" "true" .Values.central.separated.enabled }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        - name: hostpath-init
+        - name: {{ ternary "volume-init" "hostpath-init" .Values.central.separated.enabled }}
           image: {{ $centralImage.prefix }}{{ $centralImage.repository }}:{{ $centralImage.tag }}
           imagePullPolicy: {{ $centralImage.pullPolicy }}
           command:
@@ -71,19 +79,23 @@ spec:
             - -c
             - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
           securityContext:
-            allowPrivilegeEscalation: true
+            allowPrivilegeEscalation: {{ ternary "false" "true" .Values.central.separated.enabled }}
             capabilities:
+              {{- if .Values.central.separated.enabled }}
+              add:
+                - CHOWN
+              {{- end }}
               drop:
                 - ALL
-            privileged: true
+            privileged: {{ ternary "false" "true" .Values.central.separated.enabled }}
             runAsUser: 0
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: host-run-ovn
+              name: {{ ternary "run-ovn" "host-run-ovn" .Values.central.separated.enabled }}
             - mountPath: /etc/ovn
-              name: host-config-ovn
+              name: {{ ternary "ovn-data" "host-config-ovn" .Values.central.separated.enabled }}
             - mountPath: /var/log/ovn
-              name: host-log-ovn
+              name: {{ ternary "log-ovn" "host-log-ovn" .Values.central.separated.enabled }}
       containers:
         - name: ovn-central
           image: {{ $centralImage.prefix }}{{ $centralImage.repository }}:{{ $centralImage.tag }}
@@ -101,11 +113,19 @@ spec:
           env:
 {{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
             - name: NODE_IPS
-              value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ ternary (include "kubeovn.centralRaftAddresses" .) (include "kubeovn.ovnDbAddresses" .) .Values.central.separated.enabled }}"
+            {{- if .Values.central.separated.enabled }}
+            - name: DB_CLUSTER_ADDR
+              value: "$(POD_NAME).ovn-central.$(POD_NAMESPACE).svc"
+            {{- end }}
             - name: POD_IP
+              {{- if .Values.central.separated.enabled }}
+              value: "$(DB_CLUSTER_ADDR)"
+              {{- else }}
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+              {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -119,7 +139,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "{{- .Values.features.ENABLE_BIND_LOCAL_IP }}"
+              value: "{{ ternary false .Values.features.ENABLE_BIND_LOCAL_IP .Values.central.separated.enabled }}"
             - name: PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.probeInterval }}"
             - name: OVN_NORTHD_PROBE_INTERVAL
@@ -141,14 +161,16 @@ spec:
           {{- end }}
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: host-run-ovn
+              name: {{ ternary "run-ovn" "host-run-ovn" .Values.central.separated.enabled }}
             - mountPath: /etc/ovn
-              name: host-config-ovn
+              name: {{ ternary "ovn-data" "host-config-ovn" .Values.central.separated.enabled }}
             - mountPath: /var/log/ovn
-              name: host-log-ovn
+              name: {{ ternary "log-ovn" "host-log-ovn" .Values.central.separated.enabled }}
+            {{- if not .Values.central.separated.enabled }}
             - mountPath: /etc/localtime
               name: localtime
               readOnly: true
+            {{- end }}
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -170,6 +192,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        {{- if .Values.central.separated.enabled }}
+        - name: run-ovn
+          emptyDir: {}
+        - name: log-ovn
+          emptyDir: {}
+        {{- else }}
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
@@ -182,7 +210,26 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        {{- end }}
         - name: kube-ovn-tls
           secret:
             optional: true
             secretName: kube-ovn-tls
+  {{- if .Values.central.separated.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: ovn-data
+        labels:
+          app.kubernetes.io/name: ovn-central
+          app.kubernetes.io/part-of: kube-ovn
+          app: ovn-central
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.central.separated.storage.size }}
+        {{- if .Values.central.separated.storage.storageClassName }}
+        storageClassName: {{ .Values.central.separated.storage.storageClassName | quote }}
+        {{- end }}
+  {{- end }}

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $centralImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.central.image) | fromYaml -}}
-kind: {{ ternary "StatefulSet" "Deployment" .Values.central.separated.enabled }}
+kind: {{ ternary "StatefulSet" "Deployment" .Values.central.hcp.enabled }}
 apiVersion: apps/v1
 metadata:
   name: ovn-central
@@ -14,11 +14,11 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ include "kubeovn.centralReplicas" . }}
-  {{- if .Values.central.separated.enabled }}
+  {{- if .Values.central.hcp.enabled }}
   serviceName: ovn-central
   podManagementPolicy: Parallel
   {{- end }}
-  {{- if not .Values.central.separated.enabled }}
+  {{- if not .Values.central.hcp.enabled }}
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       affinity:
         {{- include "kube-ovn.affinities.nodeAffinity" (dict "hardcodedRequired" (include "kubeovn.masterNodeRequired" . | fromYamlArray) "userPreferred" .Values.central.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.central.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) | nindent 8 }}
-        {{- if not .Values.central.separated.enabled }}
+        {{- if not .Values.central.hcp.enabled }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -64,14 +64,14 @@ spec:
               topologyKey: kubernetes.io/hostname
         {{- end }}
       priorityClassName: system-cluster-critical
-      serviceAccountName: {{ ternary "ovn-central" "ovn-ovs" .Values.central.separated.enabled }}
+      serviceAccountName: {{ ternary "ovn-central" "ovn-ovs" .Values.central.hcp.enabled }}
       automountServiceAccountToken: true
-      hostNetwork: {{ ternary "false" "true" .Values.central.separated.enabled }}
+      hostNetwork: {{ ternary "false" "true" .Values.central.hcp.enabled }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        - name: {{ ternary "volume-init" "hostpath-init" .Values.central.separated.enabled }}
+        - name: {{ ternary "volume-init" "hostpath-init" .Values.central.hcp.enabled }}
           image: {{ $centralImage.prefix }}{{ $centralImage.repository }}:{{ $centralImage.tag }}
           imagePullPolicy: {{ $centralImage.pullPolicy }}
           command:
@@ -79,23 +79,23 @@ spec:
             - -c
             - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
           securityContext:
-            allowPrivilegeEscalation: {{ ternary "false" "true" .Values.central.separated.enabled }}
+            allowPrivilegeEscalation: {{ ternary "false" "true" .Values.central.hcp.enabled }}
             capabilities:
-              {{- if .Values.central.separated.enabled }}
+              {{- if .Values.central.hcp.enabled }}
               add:
                 - CHOWN
               {{- end }}
               drop:
                 - ALL
-            privileged: {{ ternary "false" "true" .Values.central.separated.enabled }}
+            privileged: {{ ternary "false" "true" .Values.central.hcp.enabled }}
             runAsUser: 0
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: {{ ternary "run-ovn" "host-run-ovn" .Values.central.separated.enabled }}
+              name: {{ ternary "run-ovn" "host-run-ovn" .Values.central.hcp.enabled }}
             - mountPath: /etc/ovn
-              name: {{ ternary "ovn-data" "host-config-ovn" .Values.central.separated.enabled }}
+              name: {{ ternary "ovn-data" "host-config-ovn" .Values.central.hcp.enabled }}
             - mountPath: /var/log/ovn
-              name: {{ ternary "log-ovn" "host-log-ovn" .Values.central.separated.enabled }}
+              name: {{ ternary "log-ovn" "host-log-ovn" .Values.central.hcp.enabled }}
       containers:
         - name: ovn-central
           image: {{ $centralImage.prefix }}{{ $centralImage.repository }}:{{ $centralImage.tag }}
@@ -113,13 +113,13 @@ spec:
           env:
 {{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
             - name: NODE_IPS
-              value: "{{ ternary (include "kubeovn.centralRaftAddresses" .) (include "kubeovn.ovnDbAddresses" .) .Values.central.separated.enabled }}"
-            {{- if .Values.central.separated.enabled }}
+              value: "{{ ternary (include "kubeovn.centralRaftAddresses" .) (include "kubeovn.ovnDbAddresses" .) .Values.central.hcp.enabled }}"
+            {{- if .Values.central.hcp.enabled }}
             - name: DB_CLUSTER_ADDR
               value: "$(POD_NAME).ovn-central.$(POD_NAMESPACE).svc"
             {{- end }}
             - name: POD_IP
-              {{- if .Values.central.separated.enabled }}
+              {{- if .Values.central.hcp.enabled }}
               value: "$(DB_CLUSTER_ADDR)"
               {{- else }}
               valueFrom:
@@ -139,7 +139,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "{{ ternary false .Values.features.ENABLE_BIND_LOCAL_IP .Values.central.separated.enabled }}"
+              value: "{{ ternary false .Values.features.ENABLE_BIND_LOCAL_IP .Values.central.hcp.enabled }}"
             - name: PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.probeInterval }}"
             - name: OVN_NORTHD_PROBE_INTERVAL
@@ -161,12 +161,12 @@ spec:
           {{- end }}
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: {{ ternary "run-ovn" "host-run-ovn" .Values.central.separated.enabled }}
+              name: {{ ternary "run-ovn" "host-run-ovn" .Values.central.hcp.enabled }}
             - mountPath: /etc/ovn
-              name: {{ ternary "ovn-data" "host-config-ovn" .Values.central.separated.enabled }}
+              name: {{ ternary "ovn-data" "host-config-ovn" .Values.central.hcp.enabled }}
             - mountPath: /var/log/ovn
-              name: {{ ternary "log-ovn" "host-log-ovn" .Values.central.separated.enabled }}
-            {{- if not .Values.central.separated.enabled }}
+              name: {{ ternary "log-ovn" "host-log-ovn" .Values.central.hcp.enabled }}
+            {{- if not .Values.central.hcp.enabled }}
             - mountPath: /etc/localtime
               name: localtime
               readOnly: true
@@ -192,7 +192,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
-        {{- if .Values.central.separated.enabled }}
+        {{- if .Values.central.hcp.enabled }}
         - name: run-ovn
           emptyDir: {}
         - name: log-ovn
@@ -215,7 +215,7 @@ spec:
           secret:
             optional: true
             secretName: kube-ovn-tls
-  {{- if .Values.central.separated.enabled }}
+  {{- if .Values.central.hcp.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: ovn-data
@@ -228,8 +228,8 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: {{ .Values.central.separated.storage.size }}
-        {{- if .Values.central.separated.storage.storageClassName }}
-        storageClassName: {{ .Values.central.separated.storage.storageClassName | quote }}
+            storage: {{ .Values.central.hcp.storage.size }}
+        {{- if .Values.central.hcp.storage.storageClassName }}
+        storageClassName: {{ .Values.central.hcp.storage.storageClassName | quote }}
         {{- end }}
   {{- end }}

--- a/charts/kube-ovn-v2/templates/central/central-rbac.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-rbac.yaml
@@ -11,7 +11,7 @@ kind: ServiceAccount
 metadata:
   name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
-automountServiceAccountToken: false
+automountServiceAccountToken: true
 {{-  if .Values.global.registry.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}

--- a/charts/kube-ovn-v2/templates/central/central-rbac.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-rbac.yaml
@@ -1,11 +1,4 @@
 {{- if .Values.central.hcp.enabled }}
-{{- if ne (include "kubeovn.centralNamespace" .) .Values.namespace }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ include "kubeovn.centralNamespace" . }}
----
-{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kube-ovn-v2/templates/central/central-rbac.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-rbac.yaml
@@ -11,7 +11,7 @@ kind: ServiceAccount
 metadata:
   name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 {{-  if .Values.global.registry.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}

--- a/charts/kube-ovn-v2/templates/central/central-rbac.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ovn
+  name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
 automountServiceAccountToken: false
 {{-  if .Values.global.registry.imagePullSecrets }}
@@ -24,7 +24,7 @@ imagePullSecrets:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: ovn
+  name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
 rules:
   - apiGroups:
@@ -54,14 +54,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ovn
+  name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: ovn
+  name: ovn-central
 subjects:
   - kind: ServiceAccount
-    name: ovn
+    name: ovn-central
     namespace: {{ include "kubeovn.centralNamespace" . }}
 {{- end }}

--- a/charts/kube-ovn-v2/templates/central/central-rbac.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.central.separated.enabled }}
+{{- if .Values.central.hcp.enabled }}
 {{- if ne (include "kubeovn.centralNamespace" .) .Values.namespace }}
 apiVersion: v1
 kind: Namespace

--- a/charts/kube-ovn-v2/templates/central/central-rbac.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-rbac.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.central.separated.enabled }}
+{{- if ne (include "kubeovn.centralNamespace" .) .Values.namespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "kubeovn.centralNamespace" . }}
+---
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+automountServiceAccountToken: false
+{{-  if .Values.global.registry.imagePullSecrets }}
+imagePullSecrets:
+{{- range $index, $secret := .Values.global.registry.imagePullSecrets }}
+{{- if $secret }}
+  - name: {{ $secret | quote}}
+{{- end }}
+{{- end }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ovn
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ovn
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ovn
+subjects:
+  - kind: ServiceAccount
+    name: ovn
+    namespace: {{ include "kubeovn.centralNamespace" . }}
+{{- end }}

--- a/charts/kube-ovn-v2/templates/central/central-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.central.separated.enabled }}
+{{- if .Values.central.hcp.enabled }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/charts/kube-ovn-v2/templates/central/central-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-service.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.central.separated.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
-  name: ovn-northd
+  name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
   {{- with .Values.central.annotations }}
   annotations:
@@ -12,17 +13,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
   ports:
-    - name: ovn-northd
+    - name: nb-raft
       protocol: TCP
       port: 6643
       targetPort: 6643
-  type: ClusterIP
-  {{- if eq .Values.networking.stack "Dual" }}
-  ipFamilyPolicy: PreferDualStack
-  {{- end }}
+    - name: sb-raft
+      protocol: TCP
+      port: 6644
+      targetPort: 6644
   selector:
     app.kubernetes.io/name: ovn-central
     app.kubernetes.io/part-of: kube-ovn
-    ovn-northd-leader: "true"
-  sessionAffinity: None
+{{- end }}

--- a/charts/kube-ovn-v2/templates/central/northbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/northbound-service.yaml
@@ -17,7 +17,7 @@ spec:
       protocol: TCP
       port: 6641
       targetPort: 6641
-      {{- if .Values.central.separated.enabled }}
+      {{- if and .Values.central.separated.enabled (or (eq .Values.central.separated.service.type "NodePort") (eq .Values.central.separated.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.central.separated.service.nbNodePort }}
       {{- end }}
   type: {{ ternary .Values.central.separated.service.type "ClusterIP" .Values.central.separated.enabled }}

--- a/charts/kube-ovn-v2/templates/central/northbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/northbound-service.yaml
@@ -17,10 +17,10 @@ spec:
       protocol: TCP
       port: 6641
       targetPort: 6641
-      {{- if and .Values.central.separated.enabled (or (eq .Values.central.separated.service.type "NodePort") (eq .Values.central.separated.service.type "LoadBalancer")) }}
-      nodePort: {{ .Values.central.separated.service.nbNodePort }}
+      {{- if and .Values.central.hcp.enabled (or (eq .Values.central.hcp.service.type "NodePort") (eq .Values.central.hcp.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.central.hcp.service.nbNodePort }}
       {{- end }}
-  type: {{ ternary .Values.central.separated.service.type "ClusterIP" .Values.central.separated.enabled }}
+  type: {{ ternary .Values.central.hcp.service.type "ClusterIP" .Values.central.hcp.enabled }}
   {{- if eq .Values.networking.stack "Dual" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn-v2/templates/central/northbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/northbound-service.yaml
@@ -2,7 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
   {{- with .Values.central.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,7 +17,10 @@ spec:
       protocol: TCP
       port: 6641
       targetPort: 6641
-  type: ClusterIP
+      {{- if .Values.central.separated.enabled }}
+      nodePort: {{ .Values.central.separated.service.nbNodePort }}
+      {{- end }}
+  type: {{ ternary .Values.central.separated.service.type "ClusterIP" .Values.central.separated.enabled }}
   {{- if eq .Values.networking.stack "Dual" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn-v2/templates/central/northbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/northbound-service.yaml
@@ -20,7 +20,7 @@ spec:
       {{- if and .Values.central.hcp.enabled (or (eq .Values.central.hcp.service.type "NodePort") (eq .Values.central.hcp.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.central.hcp.service.nbNodePort }}
       {{- end }}
-  type: {{ ternary .Values.central.hcp.service.type "ClusterIP" .Values.central.hcp.enabled }}
+  type: {{ ternary (.Values.central.hcp.service.type | default "ClusterIP") "ClusterIP" .Values.central.hcp.enabled }}
   {{- if eq .Values.networking.stack "Dual" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn-v2/templates/central/southbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/southbound-service.yaml
@@ -2,7 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ovn-sb
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
   {{- with .Values.central.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,7 +17,10 @@ spec:
       protocol: TCP
       port: 6642
       targetPort: 6642
-  type: ClusterIP
+      {{- if .Values.central.separated.enabled }}
+      nodePort: {{ .Values.central.separated.service.sbNodePort }}
+      {{- end }}
+  type: {{ ternary .Values.central.separated.service.type "ClusterIP" .Values.central.separated.enabled }}
   {{- if eq .Values.networking.stack "Dual" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn-v2/templates/central/southbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/southbound-service.yaml
@@ -17,10 +17,10 @@ spec:
       protocol: TCP
       port: 6642
       targetPort: 6642
-      {{- if and .Values.central.separated.enabled (or (eq .Values.central.separated.service.type "NodePort") (eq .Values.central.separated.service.type "LoadBalancer")) }}
-      nodePort: {{ .Values.central.separated.service.sbNodePort }}
+      {{- if and .Values.central.hcp.enabled (or (eq .Values.central.hcp.service.type "NodePort") (eq .Values.central.hcp.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.central.hcp.service.sbNodePort }}
       {{- end }}
-  type: {{ ternary .Values.central.separated.service.type "ClusterIP" .Values.central.separated.enabled }}
+  type: {{ ternary .Values.central.hcp.service.type "ClusterIP" .Values.central.hcp.enabled }}
   {{- if eq .Values.networking.stack "Dual" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn-v2/templates/central/southbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/southbound-service.yaml
@@ -17,7 +17,7 @@ spec:
       protocol: TCP
       port: 6642
       targetPort: 6642
-      {{- if .Values.central.separated.enabled }}
+      {{- if and .Values.central.separated.enabled (or (eq .Values.central.separated.service.type "NodePort") (eq .Values.central.separated.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.central.separated.service.sbNodePort }}
       {{- end }}
   type: {{ ternary .Values.central.separated.service.type "ClusterIP" .Values.central.separated.enabled }}

--- a/charts/kube-ovn-v2/templates/central/southbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/southbound-service.yaml
@@ -20,7 +20,7 @@ spec:
       {{- if and .Values.central.hcp.enabled (or (eq .Values.central.hcp.service.type "NodePort") (eq .Values.central.hcp.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.central.hcp.service.sbNodePort }}
       {{- end }}
-  type: {{ ternary .Values.central.hcp.service.type "ClusterIP" .Values.central.hcp.enabled }}
+  type: {{ ternary (.Values.central.hcp.service.type | default "ClusterIP") "ClusterIP" .Values.central.hcp.enabled }}
   {{- if eq .Values.networking.stack "Dual" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -193,12 +193,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.central.hcp.enabled }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.ovnNbAddress" . }}"
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnDbAddresses" . }}"
-            - name: KUBE_OVN_NB_PORT
-              value: "{{ include "kubeovn.ovnNbPort" . }}"
-            - name: KUBE_OVN_SB_PORT
-              value: "{{ include "kubeovn.ovnSbPort" . }}"
+            {{- end }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -194,7 +194,11 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnDbAddresses" . }}"
+            - name: KUBE_OVN_NB_PORT
+              value: "{{ include "kubeovn.ovnNbPort" . }}"
+            - name: KUBE_OVN_SB_PORT
+              value: "{{ include "kubeovn.ovnSbPort" . }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -142,7 +142,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnDbAddresses" . }}"
+            - name: KUBE_OVN_SB_PORT
+              value: "{{ include "kubeovn.ovnSbPort" . }}"
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.ovnRemoteProbeInterval }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -141,10 +141,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.central.hcp.enabled }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnDbAddresses" . }}"
-            - name: KUBE_OVN_SB_PORT
-              value: "{{ include "kubeovn.ovnSbPort" . }}"
+            {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.ovnRemoteProbeInterval }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
@@ -22,8 +22,8 @@ spec:
     type: {{ .Values.ovsOvn.updateStrategy.type }}
     {{- if eq .Values.ovsOvn.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxSurge: {{ .Values.ovsOvn.strategy.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ .Values.ovsOvn.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.ovsOvn.updateStrategy.maxSurge }}
+      maxUnavailable: {{ .Values.ovsOvn.updateStrategy.maxUnavailable }}
     {{- end }}
   template:
     metadata:
@@ -78,8 +78,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.central.hcp.enabled }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+            {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.ovnRemoteProbeInterval }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -40,15 +40,20 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: true
-      - equal:
-          path: spec.template.spec.containers[0].env[4].name
-          value: POD_NAME
-      - equal:
-          path: spec.template.spec.containers[0].env[5].name
-          value: POD_NAMESPACE
-      - equal:
-          path: spec.template.spec.containers[0].env[7].name
-          value: DB_CLUSTER_ADDR
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       - notExists:
           path: spec.template.spec.affinity.podAntiAffinity
       - contains:

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -170,6 +170,36 @@ tests:
       - notExists:
           path: spec.ports[0].nodePort
 
+  - it: defaults empty HCP NB service type to ClusterIP
+    template: central/northbound-service.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: ""
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: defaults empty HCP SB service type to ClusterIP
+    template: central/southbound-service.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: ""
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
   - it: points workload components at independent HCP OVN DB addresses
     template: controller/controller-deployment.yaml
     set:

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -65,6 +65,27 @@ tests:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
           value: topolvm
 
+  - it: creates dedicated namespaced RBAC for HCP ovn-central
+    template: central/central-rbac.yaml
+    documentIndex: 1
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ovn-central
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
   - it: creates a headless service for StatefulSet raft DNS
     template: central/central-service.yaml
     set:

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -37,6 +37,15 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: ovn-central
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: POD_NAMESPACE
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: DB_CLUSTER_ADDR
       - notExists:
           path: spec.template.spec.affinity.podAntiAffinity
       - contains:

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -1,4 +1,4 @@
-suite: OVN central separated deployment (v2)
+suite: OVN central HCP deployment (v2)
 templates:
   - central/central-deployment.yaml
   - central/central-service.yaml
@@ -11,13 +11,13 @@ tests:
   - it: renders ovn-central as a PVC-backed StatefulSet in the HCP namespace
     template: central/central-deployment.yaml
     set:
-      central.separated.enabled: true
-      central.separated.namespace: hcp
-      central.separated.externalAddresses:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.externalAddresses:
         - 192.168.138.174
-      central.separated.replicas: 3
-      central.separated.storage.size: 5Gi
-      central.separated.storage.storageClassName: topolvm
+      central.hcp.replicas: 3
+      central.hcp.storage.size: 5Gi
+      central.hcp.storage.storageClassName: topolvm
     asserts:
       - isKind:
           of: StatefulSet
@@ -58,9 +58,9 @@ tests:
   - it: creates a headless service for StatefulSet raft DNS
     template: central/central-service.yaml
     set:
-      central.separated.enabled: true
-      central.separated.namespace: hcp
-      central.separated.externalAddresses:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.externalAddresses:
         - 192.168.138.174
     asserts:
       - equal:
@@ -79,11 +79,11 @@ tests:
   - it: exposes only nb and sb services through fixed node ports
     template: central/northbound-service.yaml
     set:
-      central.separated.enabled: true
-      central.separated.namespace: hcp
-      central.separated.service.type: NodePort
-      central.separated.service.nbNodePort: 30641
-      central.separated.externalAddresses:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: NodePort
+      central.hcp.service.nbNodePort: 30641
+      central.hcp.externalAddresses:
         - 192.168.138.174
     asserts:
       - equal:
@@ -99,11 +99,11 @@ tests:
   - it: exposes southbound through a fixed node port
     template: central/southbound-service.yaml
     set:
-      central.separated.enabled: true
-      central.separated.namespace: hcp
-      central.separated.service.type: NodePort
-      central.separated.service.sbNodePort: 30642
-      central.separated.externalAddresses:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: NodePort
+      central.hcp.service.sbNodePort: 30642
+      central.hcp.externalAddresses:
         - 192.168.138.174
     asserts:
       - equal:
@@ -119,10 +119,10 @@ tests:
   - it: omits node ports when HCP services are rendered as ClusterIP
     template: central/northbound-service.yaml
     set:
-      central.separated.enabled: true
-      central.separated.namespace: hcp
-      central.separated.service.type: ClusterIP
-      central.separated.externalAddresses:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: ClusterIP
+      central.hcp.externalAddresses:
         - 192.168.138.174
     asserts:
       - equal:
@@ -134,11 +134,11 @@ tests:
   - it: points workload components at the exposed HCP ovn-central node ports
     template: controller/controller-deployment.yaml
     set:
-      central.separated.enabled: true
-      central.separated.externalAddresses:
+      central.hcp.enabled: true
+      central.hcp.externalAddresses:
         - 192.168.138.174
-      central.separated.service.nbNodePort: 30641
-      central.separated.service.sbNodePort: 30642
+      central.hcp.service.nbNodePort: 30641
+      central.hcp.service.sbNodePort: 30642
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -7,14 +7,15 @@ templates:
   - central/central-rbac.yaml
   - controller/controller-deployment.yaml
   - ovs-ovn/ovs-ovn-daemonset.yaml
+  - ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
 tests:
   - it: renders ovn-central as a PVC-backed StatefulSet in the HCP namespace
     template: central/central-deployment.yaml
     set:
       central.hcp.enabled: true
       central.hcp.namespace: hcp
-      central.hcp.externalAddresses:
-        - 192.168.138.174
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
       central.hcp.replicas: 3
       central.hcp.storage.size: 5Gi
       central.hcp.storage.storageClassName: topolvm
@@ -60,8 +61,8 @@ tests:
     set:
       central.hcp.enabled: true
       central.hcp.namespace: hcp
-      central.hcp.externalAddresses:
-        - 192.168.138.174
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
     asserts:
       - equal:
           path: metadata.name
@@ -83,8 +84,8 @@ tests:
       central.hcp.namespace: hcp
       central.hcp.service.type: NodePort
       central.hcp.service.nbNodePort: 30641
-      central.hcp.externalAddresses:
-        - 192.168.138.174
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
     asserts:
       - equal:
           path: metadata.namespace
@@ -103,8 +104,8 @@ tests:
       central.hcp.namespace: hcp
       central.hcp.service.type: NodePort
       central.hcp.service.sbNodePort: 30642
-      central.hcp.externalAddresses:
-        - 192.168.138.174
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
     asserts:
       - equal:
           path: metadata.namespace
@@ -122,8 +123,8 @@ tests:
       central.hcp.enabled: true
       central.hcp.namespace: hcp
       central.hcp.service.type: ClusterIP
-      central.hcp.externalAddresses:
-        - 192.168.138.174
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
     asserts:
       - equal:
           path: spec.type
@@ -131,27 +132,47 @@ tests:
       - notExists:
           path: spec.ports[0].nodePort
 
-  - it: points workload components at the exposed HCP ovn-central node ports
+  - it: points workload components at independent HCP OVN DB addresses
     template: controller/controller-deployment.yaml
     set:
       central.hcp.enabled: true
-      central.hcp.externalAddresses:
-        - 192.168.138.174
-      central.hcp.service.nbNodePort: 30641
-      central.hcp.service.sbNodePort: 30642
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OVN_DB_IPS
-            value: 192.168.138.174
+            name: OVN_NB_ADDR
+            value: tcp:ovn-nb.example.com:6641
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: KUBE_OVN_NB_PORT
-            value: "30641"
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs-ovn at the HCP OVN SB address
+    template: ovs-ovn/ovs-ovn-daemonset.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: KUBE_OVN_SB_PORT
-            value: "30642"
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs-ovn-dpdk at the HCP OVN SB address
+    template: ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+      ovsOvn.dpdkHybrid.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -38,6 +38,9 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: ovn-central
       - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+      - equal:
           path: spec.template.spec.containers[0].env[4].name
           value: POD_NAME
       - equal:
@@ -84,7 +87,7 @@ tests:
           value: hcp
       - equal:
           path: automountServiceAccountToken
-          value: true
+          value: false
 
   - it: creates a headless service for StatefulSet raft DNS
     template: central/central-service.yaml

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -38,13 +38,13 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: ovn-central
       - equal:
-          path: spec.template.spec.containers[0].env[1].name
+          path: spec.template.spec.containers[0].env[4].name
           value: POD_NAME
       - equal:
-          path: spec.template.spec.containers[0].env[2].name
+          path: spec.template.spec.containers[0].env[5].name
           value: POD_NAMESPACE
       - equal:
-          path: spec.template.spec.containers[0].env[4].name
+          path: spec.template.spec.containers[0].env[7].name
           value: DB_CLUSTER_ADDR
       - notExists:
           path: spec.template.spec.affinity.podAntiAffinity

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -75,7 +75,7 @@ tests:
 
   - it: creates dedicated namespaced RBAC for HCP ovn-central
     template: central/central-rbac.yaml
-    documentIndex: 1
+    documentIndex: 0
     set:
       central.hcp.enabled: true
       central.hcp.namespace: hcp

--- a/charts/kube-ovn-v2/tests/central_separated_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_separated_test.yaml
@@ -33,6 +33,9 @@ tests:
       - equal:
           path: spec.template.spec.hostNetwork
           value: false
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: ovn-central
       - notExists:
           path: spec.template.spec.affinity.podAntiAffinity
       - contains:
@@ -112,6 +115,21 @@ tests:
       - equal:
           path: spec.ports[0].nodePort
           value: 30642
+
+  - it: omits node ports when HCP services are rendered as ClusterIP
+    template: central/northbound-service.yaml
+    set:
+      central.separated.enabled: true
+      central.separated.namespace: hcp
+      central.separated.service.type: ClusterIP
+      central.separated.externalAddresses:
+        - 192.168.138.174
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
 
   - it: points workload components at the exposed HCP ovn-central node ports
     template: controller/controller-deployment.yaml

--- a/charts/kube-ovn-v2/tests/central_separated_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_separated_test.yaml
@@ -1,0 +1,139 @@
+suite: OVN central separated deployment (v2)
+templates:
+  - central/central-deployment.yaml
+  - central/central-service.yaml
+  - central/northbound-service.yaml
+  - central/southbound-service.yaml
+  - central/central-rbac.yaml
+  - controller/controller-deployment.yaml
+  - ovs-ovn/ovs-ovn-daemonset.yaml
+tests:
+  - it: renders ovn-central as a PVC-backed StatefulSet in the HCP namespace
+    template: central/central-deployment.yaml
+    set:
+      central.separated.enabled: true
+      central.separated.namespace: hcp
+      central.separated.externalAddresses:
+        - 192.168.138.174
+      central.separated.replicas: 3
+      central.separated.storage.size: 5Gi
+      central.separated.storage.storageClassName: topolvm
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.serviceName
+          value: ovn-central
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+      - notExists:
+          path: spec.template.spec.affinity.podAntiAffinity
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_IPS
+            value: ovn-central-0.ovn-central.hcp.svc,ovn-central-1.ovn-central.hcp.svc,ovn-central-2.ovn-central.hcp.svc
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_CLUSTER_ADDR
+            value: $(POD_NAME).ovn-central.$(POD_NAMESPACE).svc
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 5Gi
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: topolvm
+
+  - it: creates a headless service for StatefulSet raft DNS
+    template: central/central-service.yaml
+    set:
+      central.separated.enabled: true
+      central.separated.namespace: hcp
+      central.separated.externalAddresses:
+        - 192.168.138.174
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ovn-central
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+
+  - it: exposes only nb and sb services through fixed node ports
+    template: central/northbound-service.yaml
+    set:
+      central.separated.enabled: true
+      central.separated.namespace: hcp
+      central.separated.service.type: NodePort
+      central.separated.service.nbNodePort: 30641
+      central.separated.externalAddresses:
+        - 192.168.138.174
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30641
+
+  - it: exposes southbound through a fixed node port
+    template: central/southbound-service.yaml
+    set:
+      central.separated.enabled: true
+      central.separated.namespace: hcp
+      central.separated.service.type: NodePort
+      central.separated.service.sbNodePort: 30642
+      central.separated.externalAddresses:
+        - 192.168.138.174
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30642
+
+  - it: points workload components at the exposed HCP ovn-central node ports
+    template: controller/controller-deployment.yaml
+    set:
+      central.separated.enabled: true
+      central.separated.externalAddresses:
+        - 192.168.138.174
+      central.separated.service.nbNodePort: 30641
+      central.separated.service.sbNodePort: 30642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_DB_IPS
+            value: 192.168.138.174
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBE_OVN_NB_PORT
+            value: "30641"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBE_OVN_SB_PORT
+            value: "30642"

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -32,7 +32,7 @@ namespace: kube-system
 # @section -- Global parameters
 clusterDomain: cluster.local
 
-# -- Comma-separated list of IPs for each master node.
+# -- Comma-HCP list of IPs for each master node.
 # If not specified, fallback to auto-identifying masters based on "masterNodesLabels"
 # @section -- Global parameters
 masterNodes: []
@@ -172,10 +172,10 @@ networking:
   # Empty means the default "external" is used.
   # @section -- Network parameters of the CNI
   externalGatewaySwitch: ""
-  # -- Comma-separated string of NodeLocal DNS IP addresses.
+  # -- Comma-HCP string of NodeLocal DNS IP addresses.
   # @section -- Network parameters of the CNI
   nodeLocalDnsIp: ""
-  # -- Comma-separated list of destination IP CIDRs that should skip conntrack processing.
+  # -- Comma-HCP list of destination IP CIDRs that should skip conntrack processing.
   # @section -- Network parameters of the CNI
   skipConntrackDstCidrs: ""
   # -- Enable listening on the metrics endpoint for the CNI daemons.
@@ -1007,11 +1007,11 @@ central:
 
   # -- Deploy ovn-central as a PVC-backed StatefulSet that can be exposed to workload clusters.
   # @section -- OVN-central daemon configuration
-  separated:
+  hcp:
     enabled: false
     namespace: hcp
     replicas: 3
-    # -- Addresses workload clusters use to reach the separated ovn-nb/ovn-sb NodePorts.
+    # -- Addresses workload clusters use to reach the HCP ovn-nb/ovn-sb NodePorts.
     externalAddresses: []
     service:
       type: NodePort

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -1011,8 +1011,10 @@ central:
     enabled: false
     namespace: hcp
     replicas: 3
-    # -- Addresses workload clusters use to reach the HCP ovn-nb/ovn-sb NodePorts.
-    externalAddresses: []
+    # -- OVN NB address used by workload clusters, for example tcp:ovn-nb.example.com:6641.
+    nbAddress: ""
+    # -- OVN SB address used by workload clusters, for example tcp:ovn-sb.example.com:6642.
+    sbAddress: ""
     service:
       type: NodePort
       nbNodePort: 30641

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -1005,6 +1005,22 @@ central:
   #  - name: CUSTOM_ENV_VAR
   #    value: "custom-value"
 
+  # -- Deploy ovn-central as a PVC-backed StatefulSet that can be exposed to workload clusters.
+  # @section -- OVN-central daemon configuration
+  separated:
+    enabled: false
+    namespace: hcp
+    replicas: 3
+    # -- Addresses workload clusters use to reach the separated ovn-nb/ovn-sb NodePorts.
+    externalAddresses: []
+    service:
+      type: NodePort
+      nbNodePort: 30641
+      sbNodePort: 30642
+    storage:
+      size: 5Gi
+      storageClassName: ""
+
   # -- ovn-central resource limits & requests.
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # @section -- OVN-central daemon configuration

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -32,7 +32,7 @@ namespace: kube-system
 # @section -- Global parameters
 clusterDomain: cluster.local
 
-# -- Comma-HCP list of IPs for each master node.
+# -- Comma-separated list of IPs for each master node.
 # If not specified, fallback to auto-identifying masters based on "masterNodesLabels"
 # @section -- Global parameters
 masterNodes: []
@@ -172,10 +172,10 @@ networking:
   # Empty means the default "external" is used.
   # @section -- Network parameters of the CNI
   externalGatewaySwitch: ""
-  # -- Comma-HCP string of NodeLocal DNS IP addresses.
+  # -- Comma-separated string of NodeLocal DNS IP addresses.
   # @section -- Network parameters of the CNI
   nodeLocalDnsIp: ""
-  # -- Comma-HCP list of destination IP CIDRs that should skip conntrack processing.
+  # -- Comma-separated list of destination IP CIDRs that should skip conntrack processing.
   # @section -- Network parameters of the CNI
   skipConntrackDstCidrs: ""
   # -- Enable listening on the metrics endpoint for the CNI daemons.

--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -68,11 +68,30 @@ Replica count for the ovn-central Deployment. Single mode always uses 1;
 cluster mode uses one replica per master node.
 */}}
 {{- define "kubeovn.ovnCentralReplicas" -}}
-{{- if eq .Values.OVN_CENTRAL_MODE "single" -}}
+{{- if index .Values "ovn-central" "hcp" "enabled" -}}
+{{- index .Values "ovn-central" "hcp" "replicas" -}}
+{{- else if eq .Values.OVN_CENTRAL_MODE "single" -}}
 1
 {{- else -}}
 {{- include "kubeovn.nodeCount" . -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.centralNamespace" -}}
+{{- if index .Values "ovn-central" "hcp" "enabled" -}}
+{{- default .Values.namespace (index .Values "ovn-central" "hcp" "namespace") -}}
+{{- else -}}
+{{- .Values.namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.centralRaftAddresses" -}}
+{{- $namespace := include "kubeovn.centralNamespace" . -}}
+{{- $addresses := list -}}
+{{- range $i := until (int (index .Values "ovn-central" "hcp" "replicas")) -}}
+{{- $addresses = append $addresses (printf "ovn-central-%d.ovn-central.%s.svc" $i $namespace) -}}
+{{- end -}}
+{{- join "," $addresses -}}
 {{- end -}}
 
 {{/*
@@ -135,12 +154,28 @@ Value of the NODE_IPS / OVN_DB_IPS env variable.
   - cluster (default raft): emit comma-separated master node IPs.
 */}}
 {{- define "kubeovn.ovnCentralNodeIPs" -}}
-{{- if eq .Values.installMode "dataPlaneOnly" -}}
+{{- if index .Values "ovn-central" "hcp" "enabled" -}}
+{{- include "kubeovn.centralRaftAddresses" . -}}
+{{- else if eq .Values.installMode "dataPlaneOnly" -}}
 {{ required "installMode=dataPlaneOnly requires externalOvnCentral.endpoint (the management cluster's ovn-nb / ovn-sb VIP)" .Values.externalOvnCentral.endpoint }}
 {{- else if eq .Values.OVN_CENTRAL_MODE "single" -}}
 {{- else -}}
 {{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}
 {{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnNbAddress" -}}
+{{- if not (index .Values "ovn-central" "hcp" "nbAddress") -}}
+{{- fail "ovn-central.hcp.nbAddress must be set when ovn-central.hcp.enabled is true" -}}
+{{- end -}}
+{{- index .Values "ovn-central" "hcp" "nbAddress" -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnSbAddress" -}}
+{{- if not (index .Values "ovn-central" "hcp" "sbAddress") -}}
+{{- fail "ovn-central.hcp.sbAddress must be set when ovn-central.hcp.enabled is true" -}}
+{{- end -}}
+{{- index .Values "ovn-central" "hcp" "sbAddress" -}}
 {{- end -}}
 
 {{/*

--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -9,6 +9,7 @@ OVN_CENTRAL_MODE. `lookup` returns empty during dry-run / template, so this
 only fires on a real install/upgrade against a cluster.
 */}}
 {{- $existing := lookup "apps/v1" "Deployment" .Values.namespace "ovn-central" }}
+{{- if not (index .Values "ovn-central" "hcp" "enabled") }}
 {{- if $existing }}
   {{- range $existing.spec.template.spec.volumes }}
     {{- if eq .name "host-config-ovn" }}
@@ -21,16 +22,21 @@ only fires on a real install/upgrade against a cluster.
     {{- end }}
   {{- end }}
 {{- end }}
-kind: Deployment
+{{- end }}
+kind: {{ ternary "StatefulSet" "Deployment" (index .Values "ovn-central" "hcp" "enabled") }}
 apiVersion: apps/v1
 metadata:
   name: ovn-central
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
   annotations:
     kubernetes.io/description: |
       OVN components: northd, nb and sb.
 spec:
   replicas: {{ include "kubeovn.ovnCentralReplicas" . }}
+  {{- if index .Values "ovn-central" "hcp" "enabled" }}
+  serviceName: ovn-central
+  podManagementPolicy: Parallel
+  {{- else }}
   strategy:
     {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
     type: Recreate
@@ -40,6 +46,7 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
     {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       app: ovn-central
@@ -58,6 +65,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        {{- if not (index .Values "ovn-central" "hcp" "enabled") }}
         {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -66,21 +74,25 @@ spec:
                   app: ovn-central
               topologyKey: kubernetes.io/hostname
         {{- end }}
+        {{- end }}
         {{- include "kubeovn.masterNodeAffinity" . | nindent 8 }}
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn-ovs
+      serviceAccountName: {{ ternary "ovn-central" "ovn-ovs" (index .Values "ovn-central" "hcp" "enabled") }}
       automountServiceAccountToken: true
-      hostNetwork: true
+      hostNetwork: {{ ternary "false" "true" (index .Values "ovn-central" "hcp" "enabled") }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        - name: hostpath-init
+        - name: {{ ternary "volume-init" "hostpath-init" (index .Values "ovn-central" "hcp" "enabled") }}
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
             - -c
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
+            {{- else }}
             {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
             # /etc/ovn comes from a PVC in single-replica mode. Backends like
             # root-squashed NFS reject chown by root, so make the OVN DB
@@ -90,20 +102,25 @@ spec:
             {{- else }}
             - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
             {{- end }}
+            {{- end }}
           securityContext:
-            allowPrivilegeEscalation: true
+            allowPrivilegeEscalation: {{ ternary "false" "true" (index .Values "ovn-central" "hcp" "enabled") }}
             capabilities:
+              {{- if index .Values "ovn-central" "hcp" "enabled" }}
+              add:
+                - CHOWN
+              {{- end }}
               drop:
                 - ALL
-            privileged: true
+            privileged: {{ ternary "false" "true" (index .Values "ovn-central" "hcp" "enabled") }}
             runAsUser: 0
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: host-run-ovn
+              name: {{ ternary "run-ovn" "host-run-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /etc/ovn
-              name: host-config-ovn
+              name: {{ ternary "ovn-data" "host-config-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /var/log/ovn
-              name: host-log-ovn
+              name: {{ ternary "log-ovn" "host-log-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
       containers:
         - name: ovn-central
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
@@ -120,12 +137,7 @@ spec:
                 - SYS_NICE
           env:
 {{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
-            - name: NODE_IPS
-              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -134,12 +146,37 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- end }}
+            - name: NODE_IPS
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: DB_CLUSTER_ADDR
+              value: "$(POD_NAME).ovn-central.$(POD_NAMESPACE).svc"
+            {{- end }}
+            - name: POD_IP
+              {{- if index .Values "ovn-central" "hcp" "enabled" }}
+              value: "$(DB_CLUSTER_ADDR)"
+              {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+              {{- end }}
+            {{- if not (index .Values "ovn-central" "hcp" "enabled") }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             - name: POD_IPS
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "{{- .Values.func.ENABLE_BIND_LOCAL_IP }}"
+              value: "{{ ternary false .Values.func.ENABLE_BIND_LOCAL_IP (index .Values "ovn-central" "hcp" "enabled") }}"
             - name: PROBE_INTERVAL
               value: "{{ .Values.networking.PROBE_INTERVAL }}"
             - name: OVN_NORTHD_PROBE_INTERVAL
@@ -162,14 +199,16 @@ spec:
               ephemeral-storage: {{ index .Values "ovn-central" "limits" "ephemeral-storage" }}
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: host-run-ovn
+              name: {{ ternary "run-ovn" "host-run-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /etc/ovn
-              name: host-config-ovn
+              name: {{ ternary "ovn-data" "host-config-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /var/log/ovn
-              name: host-log-ovn
+              name: {{ ternary "log-ovn" "host-log-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
+            {{- if not (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /etc/localtime
               name: localtime
               readOnly: true
+            {{- end }}
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -191,6 +230,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        {{- if index .Values "ovn-central" "hcp" "enabled" }}
+        - name: run-ovn
+          emptyDir: {}
+        - name: log-ovn
+          emptyDir: {}
+        {{- else }}
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
@@ -208,10 +253,27 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        {{- end }}
         - name: kube-ovn-tls
           secret:
             optional: true
             secretName: kube-ovn-tls
+  {{- if index .Values "ovn-central" "hcp" "enabled" }}
+  volumeClaimTemplates:
+    - metadata:
+        name: ovn-data
+        labels:
+          app: ovn-central
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ index .Values "ovn-central" "hcp" "storage" "size" }}
+        {{- if index .Values "ovn-central" "hcp" "storage" "storageClassName" }}
+        storageClassName: {{ index .Values "ovn-central" "hcp" "storage" "storageClassName" | quote }}
+        {{- end }}
+  {{- end }}
 
 
 {{- end }}

--- a/charts/kube-ovn/templates/central-hcp-rbac.yaml
+++ b/charts/kube-ovn/templates/central-hcp-rbac.yaml
@@ -12,7 +12,7 @@ kind: ServiceAccount
 metadata:
   name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 {{-  if .Values.global.registry.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}

--- a/charts/kube-ovn/templates/central-hcp-rbac.yaml
+++ b/charts/kube-ovn/templates/central-hcp-rbac.yaml
@@ -12,7 +12,7 @@ kind: ServiceAccount
 metadata:
   name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
-automountServiceAccountToken: false
+automountServiceAccountToken: true
 {{-  if .Values.global.registry.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}

--- a/charts/kube-ovn/templates/central-hcp-rbac.yaml
+++ b/charts/kube-ovn/templates/central-hcp-rbac.yaml
@@ -1,0 +1,69 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- if index .Values "ovn-central" "hcp" "enabled" }}
+{{- if ne (include "kubeovn.centralNamespace" .) .Values.namespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "kubeovn.centralNamespace" . }}
+---
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+automountServiceAccountToken: false
+{{-  if .Values.global.registry.imagePullSecrets }}
+imagePullSecrets:
+{{- range $index, $secret := .Values.global.registry.imagePullSecrets }}
+{{- if $secret }}
+  - name: {{ $secret | quote}}
+{{- end }}
+{{- end }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ovn-central
+subjects:
+  - kind: ServiceAccount
+    name: ovn-central
+    namespace: {{ include "kubeovn.centralNamespace" . }}
+{{- end }}
+{{- end }}

--- a/charts/kube-ovn/templates/central-hcp-rbac.yaml
+++ b/charts/kube-ovn/templates/central-hcp-rbac.yaml
@@ -1,12 +1,5 @@
 {{- if include "kubeovn.renderControlPlane" . }}
 {{- if index .Values "ovn-central" "hcp" "enabled" }}
-{{- if ne (include "kubeovn.centralNamespace" .) .Values.namespace }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ include "kubeovn.centralNamespace" . }}
----
-{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kube-ovn/templates/central-svc.yaml
+++ b/charts/kube-ovn/templates/central-svc.yaml
@@ -1,0 +1,23 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- if index .Values "ovn-central" "hcp" "enabled" }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: nb-raft
+      protocol: TCP
+      port: 6643
+      targetPort: 6643
+    - name: sb-raft
+      protocol: TCP
+      port: 6644
+      targetPort: 6644
+  selector:
+    app: ovn-central
+{{- end }}
+{{- end }}

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -184,12 +184,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.ovnNbAddress" . }}"
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: KUBE_OVN_NB_PORT
               value: "{{ include "kubeovn.ovnNbPort" . }}"
             - name: KUBE_OVN_SB_PORT
               value: "{{ include "kubeovn.ovnSbPort" . }}"
+            {{- end }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn/templates/nb-svc.yaml
+++ b/charts/kube-ovn/templates/nb-svc.yaml
@@ -1,12 +1,16 @@
 {{- if include "kubeovn.renderControlPlane" . }}
 {{- $svc := index .Values "ovn-central" "service" }}
+{{- $hcp := index .Values "ovn-central" "hcp" }}
+{{- $hcpSvc := index .Values "ovn-central" "hcp" "service" }}
+{{- if not $hcp.enabled }}
 {{- include "kubeovn.validateService" . }}
+{{- end }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
-  namespace: {{ .Values.namespace }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   annotations:
     # MetalLB allows multiple Services to share a single VIP only when they
     # carry the same allow-shared-ip annotation. The three ovn-* Services all
@@ -21,11 +25,14 @@ spec:
       protocol: TCP
       port: 6641
       targetPort: 6641
-  type: {{ $svc.type | default "ClusterIP" }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+      {{- if and $hcp.enabled (or (eq $hcpSvc.type "NodePort") (eq $hcpSvc.type "LoadBalancer")) }}
+      nodePort: {{ $hcpSvc.nbNodePort }}
+      {{- end }}
+  type: {{ ternary $hcpSvc.type ($svc.type | default "ClusterIP") $hcp.enabled }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
   {{- end }}
-  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  {{- if and (not $hcp.enabled) (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
   externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
   {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
@@ -33,7 +40,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
-    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
+    {{- if or $hcp.enabled (ne .Values.OVN_CENTRAL_MODE "single") }}
     ovn-nb-leader: "true"
     {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/templates/nb-svc.yaml
+++ b/charts/kube-ovn/templates/nb-svc.yaml
@@ -28,7 +28,7 @@ spec:
       {{- if and $hcp.enabled (or (eq $hcpSvc.type "NodePort") (eq $hcpSvc.type "LoadBalancer")) }}
       nodePort: {{ $hcpSvc.nbNodePort }}
       {{- end }}
-  type: {{ ternary $hcpSvc.type ($svc.type | default "ClusterIP") $hcp.enabled }}
+  type: {{ ternary ($hcpSvc.type | default "ClusterIP") ($svc.type | default "ClusterIP") $hcp.enabled }}
   {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
   {{- end }}

--- a/charts/kube-ovn/templates/northd-svc.yaml
+++ b/charts/kube-ovn/templates/northd-svc.yaml
@@ -1,12 +1,15 @@
 {{- if include "kubeovn.renderControlPlane" . }}
 {{- $svc := index .Values "ovn-central" "service" }}
+{{- $hcp := index .Values "ovn-central" "hcp" }}
+{{- if not $hcp.enabled }}
 {{- include "kubeovn.validateService" . }}
+{{- end }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-northd
-  namespace: {{ .Values.namespace }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   annotations:
     metallb.universe.tf/allow-shared-ip: kube-ovn-central
   {{- end }}
@@ -16,11 +19,11 @@ spec:
       protocol: TCP
       port: 6643
       targetPort: 6643
-  type: {{ $svc.type | default "ClusterIP" }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  type: {{ ternary "ClusterIP" ($svc.type | default "ClusterIP") $hcp.enabled }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
   {{- end }}
-  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  {{- if and (not $hcp.enabled) (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
   externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
   {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
@@ -28,7 +31,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
-    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
+    {{- if or $hcp.enabled (ne .Values.OVN_CENTRAL_MODE "single") }}
     ovn-northd-leader: "true"
     {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
+++ b/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
@@ -59,8 +59,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+            {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -123,10 +123,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: KUBE_OVN_SB_PORT
               value: "{{ include "kubeovn.ovnSbPort" . }}"
+            {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn/templates/sb-svc.yaml
+++ b/charts/kube-ovn/templates/sb-svc.yaml
@@ -23,7 +23,7 @@ spec:
       {{- if and $hcp.enabled (or (eq $hcpSvc.type "NodePort") (eq $hcpSvc.type "LoadBalancer")) }}
       nodePort: {{ $hcpSvc.sbNodePort }}
       {{- end }}
-  type: {{ ternary $hcpSvc.type ($svc.type | default "ClusterIP") $hcp.enabled }}
+  type: {{ ternary ($hcpSvc.type | default "ClusterIP") ($svc.type | default "ClusterIP") $hcp.enabled }}
   {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
   {{- end }}

--- a/charts/kube-ovn/templates/sb-svc.yaml
+++ b/charts/kube-ovn/templates/sb-svc.yaml
@@ -1,12 +1,16 @@
 {{- if include "kubeovn.renderControlPlane" . }}
 {{- $svc := index .Values "ovn-central" "service" }}
+{{- $hcp := index .Values "ovn-central" "hcp" }}
+{{- $hcpSvc := index .Values "ovn-central" "hcp" "service" }}
+{{- if not $hcp.enabled }}
 {{- include "kubeovn.validateService" . }}
+{{- end }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-sb
-  namespace: {{ .Values.namespace }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   annotations:
     metallb.universe.tf/allow-shared-ip: kube-ovn-central
   {{- end }}
@@ -16,11 +20,14 @@ spec:
       protocol: TCP
       port: 6642
       targetPort: 6642
-  type: {{ $svc.type | default "ClusterIP" }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+      {{- if and $hcp.enabled (or (eq $hcpSvc.type "NodePort") (eq $hcpSvc.type "LoadBalancer")) }}
+      nodePort: {{ $hcpSvc.sbNodePort }}
+      {{- end }}
+  type: {{ ternary $hcpSvc.type ($svc.type | default "ClusterIP") $hcp.enabled }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
   {{- end }}
-  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  {{- if and (not $hcp.enabled) (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
   externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
   {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
@@ -28,7 +35,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
-    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
+    {{- if or $hcp.enabled (ne .Values.OVN_CENTRAL_MODE "single") }}
     ovn-sb-leader: "true"
     {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -148,6 +148,36 @@ tests:
       - notExists:
           path: spec.ports[0].nodePort
 
+  - it: defaults empty HCP NB service type to ClusterIP
+    template: nb-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.service.type: ""
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: defaults empty HCP SB service type to ClusterIP
+    template: sb-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.service.type: ""
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
   - it: points workload components at independent HCP OVN DB addresses
     template: controller-deploy.yaml
     set:

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -38,13 +38,13 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: ovn-central
       - equal:
-          path: spec.template.spec.containers[0].env[1].name
+          path: spec.template.spec.containers[0].env[4].name
           value: POD_NAME
       - equal:
-          path: spec.template.spec.containers[0].env[2].name
+          path: spec.template.spec.containers[0].env[5].name
           value: POD_NAMESPACE
       - equal:
-          path: spec.template.spec.containers[0].env[4].name
+          path: spec.template.spec.containers[0].env[7].name
           value: DB_CLUSTER_ADDR
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -38,6 +38,9 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: ovn-central
       - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+      - equal:
           path: spec.template.spec.containers[0].env[4].name
           value: POD_NAME
       - equal:
@@ -77,7 +80,7 @@ tests:
           value: hcp
       - equal:
           path: automountServiceAccountToken
-          value: true
+          value: false
 
   - it: creates a headless service for StatefulSet raft DNS
     template: central-svc.yaml

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -1,0 +1,178 @@
+suite: OVN central HCP deployment
+templates:
+  - central-deploy.yaml
+  - central-hcp-rbac.yaml
+  - central-svc.yaml
+  - nb-svc.yaml
+  - sb-svc.yaml
+  - controller-deploy.yaml
+  - ovsovn-ds.yaml
+  - ovn-dpdk-ds.yaml
+tests:
+  - it: renders ovn-central as a PVC-backed StatefulSet in the HCP namespace
+    template: central-deploy.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+      ovn-central.hcp.replicas: 3
+      ovn-central.hcp.storage.size: 5Gi
+      ovn-central.hcp.storage.storageClassName: topolvm
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.serviceName
+          value: ovn-central
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: ovn-central
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: POD_NAMESPACE
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: DB_CLUSTER_ADDR
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_IPS
+            value: ovn-central-0.ovn-central.hcp.svc,ovn-central-1.ovn-central.hcp.svc,ovn-central-2.ovn-central.hcp.svc
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 5Gi
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: topolvm
+
+  - it: creates dedicated namespaced RBAC for HCP ovn-central
+    template: central-hcp-rbac.yaml
+    documentIndex: 1
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ovn-central
+      - equal:
+          path: metadata.namespace
+          value: hcp
+
+  - it: creates a headless service for StatefulSet raft DNS
+    template: central-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ovn-central
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+
+  - it: exposes nb and sb through HCP node ports
+    template: nb-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.service.type: NodePort
+      ovn-central.hcp.service.nbNodePort: 30641
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30641
+
+  - it: omits node ports when HCP services are rendered as ClusterIP
+    template: nb-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.service.type: ClusterIP
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: points workload components at independent HCP OVN DB addresses
+    template: controller-deploy.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_NB_ADDR
+            value: tcp:ovn-nb.example.com:6641
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs-ovn at the HCP OVN SB address
+    template: ovsovn-ds.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs-ovn-dpdk at the HCP OVN SB address
+    template: ovn-dpdk-ds.yaml
+    set:
+      HYBRID_DPDK: true
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -75,6 +75,9 @@ tests:
       - equal:
           path: metadata.namespace
           value: hcp
+      - equal:
+          path: automountServiceAccountToken
+          value: true
 
   - it: creates a headless service for StatefulSet raft DNS
     template: central-svc.yaml

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -73,7 +73,7 @@ tests:
 
   - it: creates dedicated namespaced RBAC for HCP ovn-central
     template: central-hcp-rbac.yaml
-    documentIndex: 1
+    documentIndex: 0
     set:
       ovn-central.hcp.enabled: true
       ovn-central.hcp.namespace: hcp

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -40,20 +40,30 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: true
-      - equal:
-          path: spec.template.spec.containers[0].env[4].name
-          value: POD_NAME
-      - equal:
-          path: spec.template.spec.containers[0].env[5].name
-          value: POD_NAMESPACE
-      - equal:
-          path: spec.template.spec.containers[0].env[7].name
-          value: DB_CLUSTER_ADDR
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: NODE_IPS
             value: ovn-central-0.ovn-central.hcp.svc,ovn-central-1.ovn-central.hcp.svc,ovn-central-2.ovn-central.hcp.svc
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_CLUSTER_ADDR
+            value: $(POD_NAME).ovn-central.$(POD_NAMESPACE).svc
       - equal:
           path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
           value: 5Gi

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -195,6 +195,21 @@ DPDK_CPU: "1000m"  # Default CPU configuration
 DPDK_MEMORY: "2Gi"  # Default Memory configuration
 
 ovn-central:
+  hcp:
+    enabled: false
+    namespace: hcp
+    replicas: 3
+    # OVN NB address used by workload clusters, for example tcp:ovn-nb.example.com:6641.
+    nbAddress: ""
+    # OVN SB address used by workload clusters, for example tcp:ovn-sb.example.com:6642.
+    sbAddress: ""
+    service:
+      type: NodePort
+      nbNodePort: 30641
+      sbNodePort: 30642
+    storage:
+      size: 5Gi
+      storageClassName: ""
   requests:
     cpu: "300m"
     memory: "200Mi"

--- a/dist/images/start-controller.sh
+++ b/dist/images/start-controller.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
+OVN_NB_ADDR=${OVN_NB_ADDR:-}
+OVN_SB_ADDR=${OVN_SB_ADDR:-}
 # Default to the in-cluster Service ports. Override when reaching an
 # externally-exposed ovn-central whose NodePort/LoadBalancer remaps ports.
 KUBE_OVN_NB_PORT=${KUBE_OVN_NB_PORT:-6641}
@@ -33,8 +35,8 @@ function gen_conn_str {
   echo "$x"
 }
 
-nb_addr="$(gen_conn_str "$KUBE_OVN_NB_PORT")"
-sb_addr="$(gen_conn_str "$KUBE_OVN_SB_PORT")"
+nb_addr="${OVN_NB_ADDR:-$(gen_conn_str "$KUBE_OVN_NB_PORT")}"
+sb_addr="${OVN_SB_ADDR:-$(gen_conn_str "$KUBE_OVN_SB_PORT")}"
 
 exec ./kube-ovn-controller --ovn-nb-addr="$nb_addr" \
                            --ovn-sb-addr="$sb_addr" \

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -131,7 +131,7 @@ function gen_conn_str {
     echo "$x"
 }
 
-function get_leader_ip {
+function get_leader_addr {
     # Always use first node ip as leader, this option only take effect
     # when first bootstrap the cluster.
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
@@ -364,8 +364,8 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
         ovn_db_pre_start nb
         ovn_db_pre_start sb
 
-        nb_leader_addr=$(get_leader_ip nb)
-        sb_leader_addr=$(get_leader_ip sb)
+        nb_leader_addr=$(get_leader_addr nb)
+        sb_leader_addr=$(get_leader_addr sb)
         set +eo pipefail
         is_clustered
         result=$?
@@ -492,8 +492,8 @@ else
         ovn_db_pre_start nb
         ovn_db_pre_start sb
 
-        nb_leader_addr=$(get_leader_ip nb)
-        sb_leader_addr=$(get_leader_ip sb)
+        nb_leader_addr=$(get_leader_addr nb)
+        sb_leader_addr=$(get_leader_addr sb)
         set +eo pipefail
         is_clustered
         result=$?

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -74,20 +74,59 @@ function gen_listen_addr {
     fi
 }
 
+function format_ovsdb_addr {
+    if [[ "$1" =~ ^[0-9.]+$ || "$1" == *:* ]]; then
+        echo "[$1]"
+    else
+        echo "$1"
+    fi
+}
+
+function expand_k8s_svc_addr {
+    if [[ "$1" != *.svc ]]; then
+        echo "$1"
+        return
+    fi
+
+    local fqdn
+    fqdn=$(getent hosts "$1" | awk -v addr="$1" '{ for (i = 2; i <= NF; i++) { if ($i ~ "^" addr "\\.") { print $i; exit } } }')
+    if [[ -z "$fqdn" ]]; then
+        echo "ERROR! failed to resolve Kubernetes service address $1 to a FQDN" >&2
+        exit 1
+    fi
+    echo "$fqdn"
+}
+
+function normalize_raft_addrs {
+    local old_db_cluster_addr="$DB_CLUSTER_ADDR"
+    DB_CLUSTER_ADDR="$(expand_k8s_svc_addr "$DB_CLUSTER_ADDR")"
+    POD_IP="$(expand_k8s_svc_addr "${POD_IP:-}")"
+    if [[ -n "$old_db_cluster_addr" && "${POD_IP:-}" == "$old_db_cluster_addr" ]]; then
+        POD_IP="$DB_CLUSTER_ADDR"
+    fi
+
+    local addrs=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
+    local normalized=()
+    for addr in ${addrs}; do
+        normalized=(${normalized[*]} "$(expand_k8s_svc_addr "$addr")")
+    done
+    NODE_IPS="$(IFS=,; echo "${normalized[*]}")"
+}
+
 function gen_conn_addr {
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        echo "tcp:[$1]:$2"
+        echo "tcp:$(format_ovsdb_addr "$1"):$2"
     else
-        echo "ssl:[$1]:$2"
+        echo "ssl:$(format_ovsdb_addr "$1"):$2"
     fi
 }
 
 function gen_conn_str {
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "tcp:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     else
-        x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "ssl:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     fi
     echo "$x"
 }
@@ -155,6 +194,10 @@ function set_nb_version_compatibility() {
         fi
     fi
 }
+
+if [[ -n "${NODE_IPS:-}" ]]; then
+    normalize_raft_addrs
+fi
 
 # create a new db file and join it to the cluster
 # if the nb/sb db file is corrupted
@@ -321,19 +364,19 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
         ovn_db_pre_start nb
         ovn_db_pre_start sb
 
-        nb_leader_ip=$(get_leader_ip nb)
-        sb_leader_ip=$(get_leader_ip sb)
+        nb_leader_addr=$(get_leader_ip nb)
+        sb_leader_addr=$(get_leader_ip sb)
         set +eo pipefail
         is_clustered
         result=$?
         set -eo pipefail
         # leader up only when no cluster and on the first/only node
-        if [[ ${result} -eq 1 && "$nb_leader_ip" == "$DB_CLUSTER_ADDR" ]]; then
+        if [[ ${result} -eq 1 && "$nb_leader_addr" == "$DB_CLUSTER_ADDR" ]]; then
             ovn_ctl_args="$DEBUG_OPT \
                 --db-nb-create-insecure-remote=yes \
                 --db-sb-create-insecure-remote=yes \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-addr=[$DB_ADDR] \
@@ -370,7 +413,7 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                     nb_leader=$(ovndb_query_leader nb $i)
                     if [[ $nb_leader =~ "true" ]]
                     then
-                        nb_leader_ip=${i}
+                        nb_leader_addr=${i}
                         break
                     fi
                 done
@@ -379,7 +422,7 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                     sb_leader=$(ovndb_query_leader sb $i)
                     if [[ $sb_leader =~ "true" ]]
                     then
-                        sb_leader_ip=${i}
+                        sb_leader_addr=${i}
                         break
                     fi
                 done
@@ -389,10 +432,10 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
             ovn_ctl_args="$DEBUG_OPT \
                 --db-nb-create-insecure-remote=yes \
                 --db-sb-create-insecure-remote=yes \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-nb-cluster-remote-addr=[$nb_leader_ip] \
-                --db-sb-cluster-remote-addr=[$sb_leader_ip] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-nb-cluster-remote-addr=$(format_ovsdb_addr "$nb_leader_addr") \
+                --db-sb-cluster-remote-addr=$(format_ovsdb_addr "$sb_leader_addr") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-cluster-remote-port=$NB_CLUSTER_PORT \
@@ -449,21 +492,21 @@ else
         ovn_db_pre_start nb
         ovn_db_pre_start sb
 
-        nb_leader_ip=$(get_leader_ip nb)
-        sb_leader_ip=$(get_leader_ip sb)
+        nb_leader_addr=$(get_leader_ip nb)
+        sb_leader_addr=$(get_leader_ip sb)
         set +eo pipefail
         is_clustered
         result=$?
         set -eo pipefail
-        if [[ ${result} -eq 1  &&  "$nb_leader_ip" == "${DB_CLUSTER_ADDR}" ]]; then
+        if [[ ${result} -eq 1  &&  "$nb_leader_addr" == "${DB_CLUSTER_ADDR}" ]]; then
             ovn_ctl_args="$DEBUG_OPT
                 $(ovn_db_ssl_args /var/run/tls) \
                 --db-nb-cluster-local-proto=ssl \
                 --db-sb-cluster-local-proto=ssl \
                 --db-nb-cluster-remote-proto=ssl \
                 --db-sb-cluster-remote-proto=ssl \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
                 --db-nb-addr=[$DB_ADDR] \
                 --db-sb-addr=[$DB_ADDR] \
                 --db-nb-port=$NB_PORT \
@@ -495,7 +538,7 @@ else
                     nb_leader=$(ovndb_query_leader nb $i)
                     if [[ $nb_leader =~ "true" ]]
                     then
-                      nb_leader_ip=${i}
+                      nb_leader_addr=${i}
                       break
                     fi
                 done
@@ -504,7 +547,7 @@ else
                     sb_leader=$(ovndb_query_leader sb $i)
                     if [[ $sb_leader =~ "true" ]]
                     then
-                      sb_leader_ip=${i}
+                      sb_leader_addr=${i}
                       break
                     fi
                 done
@@ -516,10 +559,10 @@ else
                 --db-sb-cluster-local-proto=ssl \
                 --db-nb-cluster-remote-proto=ssl \
                 --db-sb-cluster-remote-proto=ssl \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-nb-cluster-remote-addr=[$nb_leader_ip] \
-                --db-sb-cluster-remote-addr=[$sb_leader_ip] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-nb-cluster-remote-addr=$(format_ovsdb_addr "$nb_leader_addr") \
+                --db-sb-cluster-remote-addr=$(format_ovsdb_addr "$sb_leader_addr") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-cluster-remote-port=$NB_CLUSTER_PORT \

--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -10,7 +10,7 @@ if [[ $ENABLE_BIND_LOCAL_IP == "true" ]]; then
     DB_ADDR="$POD_IP"
 fi
 
-function get_leader_ip {
+function get_leader_addr {
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     echo -n "${t}" | cut -f 1 -d " "
 }
@@ -170,14 +170,14 @@ if [[ -z "$NODE_IPS" && -z "$LOCAL_IP" ]]; then
     /usr/share/ovn/scripts/ovn-ctl --db-ic-nb-create-insecure-remote=yes --db-ic-sb-create-insecure-remote=yes --db-ic-nb-addr="[::]" --db-ic-sb-addr="[::]" start_ic_ovsdb
     /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
 else
-    ic_nb_leader_ip=$(get_leader_ip nb)
-    ic_sb_leader_ip=$(get_leader_ip sb)
+    ic_nb_leader_addr=$(get_leader_addr nb)
+    ic_sb_leader_addr=$(get_leader_addr sb)
     set +eo pipefail
     is_clustered
     result=$?
     set -eo pipefail
     # leader up only when no cluster and on first node
-    if [[ ${result} -eq 1 &&  "$ic_nb_leader_ip" == "${POD_IP}" ]]; then
+    if [[ ${result} -eq 1 &&  "$ic_nb_leader_addr" == "${POD_IP}" ]]; then
         echo "leader start with local ${LOCAL_IP} and cluster $(gen_conn_str 6647)"
         /usr/share/ovn/scripts/ovn-ctl  --db-ic-nb-create-insecure-remote=yes \
         --db-ic-sb-create-insecure-remote=yes \
@@ -199,7 +199,7 @@ else
                 nb_leader=$(ovndb_query_leader nb $i)
                 if [[ $nb_leader =~ "true" ]]
                 then
-                    nb_leader_ip=${i}
+                    ic_nb_leader_addr=${i}
                     break
                 fi
             done
@@ -208,19 +208,19 @@ else
                 sb_leader=$(ovndb_query_leader sb $i)
                 if [[ $sb_leader =~ "true" ]]
                 then
-                    sb_leader_ip=${i}
+                    ic_sb_leader_addr=${i}
                     break
                 fi
             done
         fi
         set -eo pipefail
-        echo "follower start with local ${LOCAL_IP}, ovn-ic-nb leader ${ic_nb_leader_ip} ovn-ic-sb leader ${ic_sb_leader_ip}"
+        echo "follower start with local ${LOCAL_IP}, ovn-ic-nb leader ${ic_nb_leader_addr} ovn-ic-sb leader ${ic_sb_leader_addr}"
         /usr/share/ovn/scripts/ovn-ctl  --db-ic-nb-create-insecure-remote=yes \
         --db-ic-sb-create-insecure-remote=yes \
         --db-ic-sb-cluster-local-addr="[${LOCAL_IP}]" \
         --db-ic-nb-cluster-local-addr="[${LOCAL_IP}]" \
-        --db-ic-nb-cluster-remote-addr="[${ic_nb_leader_ip}]" \
-        --db-ic-sb-cluster-remote-addr="[${ic_sb_leader_ip}]" \
+        --db-ic-nb-cluster-remote-addr="[${ic_nb_leader_addr}]" \
+        --db-ic-sb-cluster-remote-addr="[${ic_sb_leader_addr}]" \
         --ovn-ic-nb-db="$(gen_conn_str 6647)" \
         --ovn-ic-sb-db="$(gen_conn_str 6648)" \
         --db-ic-nb-addr=[$DB_ADDR] \

--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -47,21 +47,29 @@ function ovndb_query_leader {
     fi
 }
 
+function format_ovsdb_addr {
+    if [[ "$1" =~ ^[0-9.]+$ || "$1" == *:* ]]; then
+        echo "[$1]"
+    else
+        echo "$1"
+    fi
+}
+
 function gen_conn_str {
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "tcp:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     else
-        x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "ssl:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     fi
     echo "$x"
 }
 
 function gen_conn_addr {
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        echo "tcp:[$1]:$2"
+        echo "tcp:$(format_ovsdb_addr "$1"):$2"
     else
-        echo "ssl:[$1]:$2"
+        echo "ssl:$(format_ovsdb_addr "$1"):$2"
     fi
 }
 

--- a/dist/images/start-ovs-dpdk-v2.sh
+++ b/dist/images/start-ovs-dpdk-v2.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 OVN_REMOTE_PROBE_INTERVAL=${OVN_REMOTE_PROBE_INTERVAL:-10000}
 OVN_REMOTE_OPENFLOW_INTERVAL=${OVN_REMOTE_OPENFLOW_INTERVAL:-180}
 ENABLE_SSL=${ENABLE_SSL:-false}
+OVN_SB_ADDR=${OVN_SB_ADDR:-}
 
 echo "OVN_REMOTE_PROBE_INTERVAL is set to $OVN_REMOTE_PROBE_INTERVAL"
 echo "OVN_REMOTE_OPENFLOW_INTERVAL is set to $OVN_REMOTE_OPENFLOW_INTERVAL"
@@ -126,7 +127,9 @@ ovs-vsctl --may-exist add-br br-int \
   -- set bridge br-int fail-mode=secure
 
 # Set remote ovn-sb for ovn-controller to connect to
-if [[ "$ENABLE_SSL" == "true" ]]; then
+if [[ -n "$OVN_SB_ADDR" ]]; then
+  ovs-vsctl set open . external-ids:ovn-remote="$OVN_SB_ADDR"
+elif [[ "$ENABLE_SSL" == "true" ]]; then
   ovs-vsctl set open . external-ids:ovn-remote=ssl:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
 else
   ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
+OVN_SB_ADDR=${OVN_SB_ADDR:-}
 TUNNEL_TYPE=${TUNNEL_TYPE:-geneve}
 FLOW_LIMIT=${FLOW_LIMIT:-10}
 DEBUG_WRAPPER=${DEBUG_WRAPPER:-}
@@ -140,7 +141,7 @@ function gen_conn_str {
   echo "$x"
 }
 # Set remote ovn-sb for ovn-controller to connect to
-ovs-vsctl set open . external-ids:ovn-remote="$(gen_conn_str "${KUBE_OVN_SB_PORT:-6642}")"
+ovs-vsctl set open . external-ids:ovn-remote="${OVN_SB_ADDR:-$(gen_conn_str "${KUBE_OVN_SB_PORT:-6642}")}"
 ovs-vsctl set open . external-ids:ovn-remote-probe-interval="${OVN_REMOTE_PROBE_INTERVAL}"
 ovs-vsctl set open . external-ids:ovn-openflow-probe-interval="${OVN_REMOTE_OPENFLOW_INTERVAL}"
 

--- a/pkg/ovs/start_db_script_test.go
+++ b/pkg/ovs/start_db_script_test.go
@@ -25,7 +25,7 @@ func TestStartDBAddressFunctions(t *testing.T) {
 		{
 			name:      "start-db",
 			path:      filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh"),
-			endMarker: "function get_leader_ip",
+			endMarker: "function get_leader_addr",
 		},
 		{
 			name:      "start-ic-db",

--- a/pkg/ovs/start_db_script_test.go
+++ b/pkg/ovs/start_db_script_test.go
@@ -1,0 +1,194 @@
+package ovs
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestStartDBAddressFunctions(t *testing.T) {
+	bash := requireBash(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	for _, script := range []struct {
+		name      string
+		path      string
+		endMarker string
+	}{
+		{
+			name:      "start-db",
+			path:      filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh"),
+			endMarker: "function get_leader_ip",
+		},
+		{
+			name:      "start-ic-db",
+			path:      filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-ic-db.sh"),
+			endMarker: "function ovn_db_pre_start",
+		},
+	} {
+		t.Run(script.name, func(t *testing.T) {
+			content, err := os.ReadFile(script.path)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", script.path, err)
+			}
+
+			functions := extractStartDBAddressFunctions(t, string(content), script.endMarker)
+
+			tests := []struct {
+				name     string
+				command  string
+				expected string
+			}{
+				{
+					name:     "hostname connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr ovn-central-0.ovn-central.hcp.svc.cluster.local 6643",
+					expected: "tcp:ovn-central-0.ovn-central.hcp.svc.cluster.local:6643",
+				},
+				{
+					name:     "ssl hostname connection address",
+					command:  "ENABLE_SSL=true; gen_conn_addr ovn-central-0.ovn-central.hcp.svc.cluster.local 6643",
+					expected: "ssl:ovn-central-0.ovn-central.hcp.svc.cluster.local:6643",
+				},
+				{
+					name:     "ipv4 connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr 10.3.0.58 6643",
+					expected: "tcp:[10.3.0.58]:6643",
+				},
+				{
+					name:     "ipv6 connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr fd00::58 6643",
+					expected: "tcp:[fd00::58]:6643",
+				},
+				{
+					name:     "hostname connection string",
+					command:  "ENABLE_SSL=false; NODE_IPS='ovn-central-0.ovn-central.hcp.svc.cluster.local, ovn-central-1.ovn-central.hcp.svc.cluster.local'; gen_conn_str 6641",
+					expected: "tcp:ovn-central-0.ovn-central.hcp.svc.cluster.local:6641,tcp:ovn-central-1.ovn-central.hcp.svc.cluster.local:6641",
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					output, err := exec.Command(bash, "-c", functions+"\n"+tt.command).CombinedOutput() // #nosec G204
+					if err != nil {
+						t.Fatalf("command failed: %v\noutput: %s", err, output)
+					}
+
+					got := strings.TrimSpace(string(output))
+					if got != tt.expected {
+						t.Fatalf("expected %q, got %q", tt.expected, got)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestStartDBClusterAddressArgsUseFormatter(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	scriptPath := filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", scriptPath, err)
+	}
+	script := string(content)
+
+	for _, oldArg := range []string{
+		"--db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR]",
+		"--db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR]",
+		"--db-nb-cluster-remote-addr=[$nb_leader_addr]",
+		"--db-sb-cluster-remote-addr=[$sb_leader_addr]",
+	} {
+		if strings.Contains(script, oldArg) {
+			t.Fatalf("cluster address argument %q should use format_ovsdb_addr", oldArg)
+		}
+	}
+}
+
+func TestStartDBExpandsSvcAddressesFromDNSResponse(t *testing.T) {
+	bash := requireBash(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	scriptPath := filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", scriptPath, err)
+	}
+
+	functions := extractStartDBAddressFunctions(t, string(content), "function gen_conn_addr")
+	command := strings.Join([]string{
+		`function getent { case "$2" in ovn-central-0.ovn-central.hcp.svc) echo "10.3.0.67 ovn-central-0.ovn-central.hcp.svc.acme.local" ;; ovn-central-1.ovn-central.hcp.svc) echo "10.3.0.68 ovn-central-1.ovn-central.hcp.svc.acme.local" ;; esac; }`,
+		"POD_NAMESPACE=hcp",
+		"DB_CLUSTER_ADDR=ovn-central-0.ovn-central.hcp.svc",
+		"POD_IP=$DB_CLUSTER_ADDR",
+		"NODE_IPS=ovn-central-0.ovn-central.hcp.svc,ovn-central-1.ovn-central.hcp.svc",
+		"normalize_raft_addrs",
+		"printf '%s\\n%s\\n%s\\n' \"$DB_CLUSTER_ADDR\" \"$POD_IP\" \"$NODE_IPS\"",
+	}, "; ")
+
+	output, err := exec.Command(bash, "-c", functions+"\n"+command).CombinedOutput() // #nosec G204
+	if err != nil {
+		t.Fatalf("command failed: %v\noutput: %s", err, output)
+	}
+
+	expected := strings.Join([]string{
+		"ovn-central-0.ovn-central.hcp.svc.acme.local",
+		"ovn-central-0.ovn-central.hcp.svc.acme.local",
+		"ovn-central-0.ovn-central.hcp.svc.acme.local,ovn-central-1.ovn-central.hcp.svc.acme.local",
+	}, "\n")
+	if got := strings.TrimSpace(string(output)); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func requireBash(t *testing.T) string {
+	t.Helper()
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required to test start-db.sh snippets")
+	}
+	return bash
+}
+
+func extractStartDBAddressFunctions(t *testing.T, script, endMarker string) string {
+	t.Helper()
+
+	start := strings.Index(script, "function format_ovsdb_addr")
+	if start == -1 {
+		start = firstFunctionIndex(script, "function gen_conn_addr", "function gen_conn_str")
+	}
+	if start == -1 {
+		t.Fatal("failed to find address functions")
+	}
+	end := strings.Index(script[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("failed to find %s", endMarker)
+	}
+	return script[start : start+end]
+}
+
+func firstFunctionIndex(script string, markers ...string) int {
+	first := -1
+	for _, marker := range markers {
+		index := strings.Index(script, marker)
+		if index != -1 && (first == -1 || index < first) {
+			first = index
+		}
+	}
+	return first
+}


### PR DESCRIPTION
## Summary
- support Hosted Control Planes (HCP) by allowing the kube-ovn and kube-ovn-v2 charts to deploy ovn-central as a PVC-backed StatefulSet in an HCP namespace
- expose ovn-nb/ovn-sb through configurable NodePort/LoadBalancer services for workload clusters, while keeping ovn-northd internal
- wire workload-side kube-ovn-controller and ovs-ovn to connect to independently configured HCP OVN NB/SB addresses
- support StatefulSet Pod DNS/FQDN raft addresses required by HCP ovn-central replicas
- use dedicated HCP-mode RBAC resources to avoid name conflicts when the HCP namespace matches the workload namespace

## Tests
- go test ./pkg/ovs
- helm lint charts/kube-ovn
- helm lint charts/kube-ovn-v2
- helm template default charts/kube-ovn
- helm template hcp charts/kube-ovn --set ovn-central.hcp.enabled=true --set ovn-central.hcp.namespace=hcp --set ovn-central.hcp.nbAddress=tcp:ovn-nb.example.com:6641 --set ovn-central.hcp.sbAddress=tcp:ovn-sb.example.com:6642
- helm template hcp-dpdk charts/kube-ovn --set HYBRID_DPDK=true --set ovn-central.hcp.enabled=true --set ovn-central.hcp.nbAddress=tcp:ovn-nb.example.com:6641 --set ovn-central.hcp.sbAddress=tcp:ovn-sb.example.com:6642
- helm template split charts/kube-ovn-v2 --set central.hcp.enabled=true --set central.hcp.namespace=hcp --set central.hcp.nbAddress=tcp:ovn-nb.example.com:6641 --set central.hcp.sbAddress=tcp:ovn-sb.example.com:6642 --set central.hcp.storage.storageClassName=topolvm --set central.hcp.service.nbNodePort=30641 --set central.hcp.service.sbNodePort=30642
- helm template split-clusterip charts/kube-ovn-v2 --set central.hcp.enabled=true --set central.hcp.namespace=kube-system --set central.hcp.service.type=ClusterIP --set central.hcp.nbAddress=tcp:ovn-nb.example.com:6641 --set central.hcp.sbAddress=tcp:ovn-sb.example.com:6642
- helm unittest charts/kube-ovn
- helm unittest charts/kube-ovn-v2
- make lint