### PR TITLE
[release-1.15] fix: reject subnet gateway static IP allocation

### DIFF
--- a/hack/ci-check-crash.sh
+++ b/hack/ci-check-crash.sh
@@ -23,14 +23,28 @@ for pod in `kubectl get pod -n $namespace -l component=network -o name`; do
   podName=${pod#*/}
   containerTypes=(initContainer container)
   for containerType in ${containerTypes[@]}; do
-    restartCounts=(`kubectl get -n $namespace $pod -o jsonpath="{.status.${containerType}Statuses[*].restartCount}"`)
+    restartCounts=(`kubectl get -n $namespace $pod -o jsonpath="{.status.${containerType}Statuses[*].restartCount}" 2>/dev/null || true`)
+    names=(`kubectl get -n $namespace $pod -o jsonpath="{.status.${containerType}Statuses[*].name}" 2>/dev/null || true`)
+    if [ ${#restartCounts[@]} -eq 0 -a ${#names[@]} -eq 0 ]; then
+      if ! kubectl get -n $namespace $pod >/dev/null 2>&1; then
+        echo ">>> pod $namespace/$podName disappeared while checking restarts, skipping"
+        continue
+      fi
+    fi
     for ((i=0; i<${#restartCounts[@]}; i++)); do
       restartCount=${restartCounts[i]}
       if [ $restartCount -eq 0 ]; then
         continue
       fi
 
-      name=`kubectl get -n $namespace $pod -o jsonpath="{.status.${containerType}Statuses[*].name}"`
+      name=${names[i]}
+      if [ -z "$name" ]; then
+        name=$(kubectl get -n $namespace $pod -o jsonpath="{.status.${containerType}Statuses[$i].name}" 2>/dev/null || true)
+      fi
+      if [ -z "$name" ]; then
+        echo ">>> $containerType #$i in pod $namespace/$podName has restart count but no container name, skipping"
+        continue
+      fi
       echo ">>> $containerType $name in pod $namespace/$podName restarted $restartCount time(s). Logs of the previous instance:"
       prevLogs=$(kubectl logs -p -n $namespace $pod -c $name 2>&1) || true
       printf '%s\n' "$prevLogs"

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2187,6 +2187,7 @@ func (c *Controller) acquireStaticAddressHelper(pod *v1.Pod, podNet *kubeovnNet,
 
 					if assignedPod, ok := c.ipam.IsIPAssignedToOtherPod(checkIP, net.Subnet.Name, key); ok {
 						klog.Errorf("static address %s for %s has been assigned to %s", staticIP, key, assignedPod)
+						err = ipam.ErrConflict
 						continue
 					}
 
@@ -2197,6 +2198,9 @@ func (c *Controller) acquireStaticAddressHelper(pod *v1.Pod, podNet *kubeovnNet,
 				}
 			}
 			klog.Errorf("acquire address from ippool %s for %s failed, %v", ippoolStr, key, err)
+			if err != nil {
+				return "", "", "", podNet.Subnet, err
+			}
 		} else {
 			tempStrs := strings.Split(pod.Name, "-")
 			numStr := tempStrs[len(tempStrs)-1]
@@ -2210,6 +2214,9 @@ func (c *Controller) acquireStaticAddressHelper(pod *v1.Pod, podNet *kubeovnNet,
 					}
 				}
 				klog.Errorf("acquire address %s for %s failed, %v", ipPool[index], key, err)
+				if err != nil {
+					return "", "", "", podNet.Subnet, err
+				}
 			}
 		}
 	}

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -572,6 +572,55 @@ func TestAcquireAddressWithSpecifiedSubnet(t *testing.T) {
 	}
 }
 
+func TestAcquireStaticAddressHelperReturnsConflictForGatewayLiteralIPPool(t *testing.T) {
+	subnetName := "test-subnet"
+	staticIP := "10.0.0.2"
+	testSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock:  "10.0.0.0/30",
+			Gateway:    staticIP,
+			Protocol:   kubeovnv1.ProtocolIPv4,
+			Provider:   util.OvnProvider,
+			ExcludeIps: []string{staticIP},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.IPPoolAnnotation: staticIP,
+			},
+		},
+	}
+	podNet := &kubeovnNet{
+		Subnet:       testSubnet,
+		ProviderName: util.OvnProvider,
+	}
+
+	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{testSubnet},
+		Pods:    []*corev1.Pod{pod},
+	})
+	require.NoError(t, err)
+	ctrl := fakeCtrl.fakeController
+	ctrl.ipam = newIPAMForTest([]*kubeovnv1.Subnet{testSubnet})
+	ctrl.ipam.Subnets[subnetName].V4Gw = staticIP
+
+	_, _, _, _, err = ctrl.acquireStaticAddressHelper(
+		pod,
+		podNet,
+		"default.test-pod",
+		nil,
+		staticIP,
+		[]*kubeovnNet{podNet},
+		false,
+		"default/test-pod",
+	)
+	require.ErrorIs(t, err, ipam.ErrConflict)
+}
+
 func newIPAMForTest(subnets []*kubeovnv1.Subnet) *ipam.IPAM {
 	ipamInstance := ipam.NewIPAM()
 	for _, subnet := range subnets {

--- a/pkg/ipam/ip_test.go
+++ b/pkg/ipam/ip_test.go
@@ -462,7 +462,7 @@ func TestAddOrUpdateSubnet(t *testing.T) {
 
 	pod1 := "pod1.ns"
 	pod1Nic1 := "pod1nic1.ns"
-	freeIP1 := ipam.Subnets[subnetName].V4Free.At(0).Start().String()
+	freeIP1 := "1.1.1.2"
 	ip, _, _, err := ipam.GetStaticAddress(pod1, pod1Nic1, freeIP1, nil, subnetName, true)
 	require.NoError(t, err)
 	require.Equal(t, freeIP1, ip)
@@ -606,6 +606,10 @@ func TestAddOrUpdateSubnet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ip, "10.16.10.10")
 
+	ip, _, _, err = ipam.GetStaticAddress("pod2.ns", "pod2.ns", "10.16.10.1", nil, subnetName, true)
+	require.ErrorIs(t, err, ErrConflict)
+	require.Empty(t, ip)
+
 	v4UsingIPStr, _, v4AvailableIPStr, _ := ipam.GetSubnetIPRangeString(subnetName, []string{"10.16.10.10"})
 	require.Equal(t, v4UsingIPStr, "")
 	require.Equal(t, v4AvailableIPStr, "10.16.10.2-10.16.10.9,10.16.10.11-10.16.10.14")
@@ -650,7 +654,7 @@ func TestAddOrUpdateSubnet(t *testing.T) {
 
 	pod1 = "pod1.ns"
 	pod1Nic1 = "pod1nic1.ns"
-	freeIP1 = ipam.Subnets[subnetName].V6Free.At(0).Start().String()
+	freeIP1 = "fd00::2"
 	_, ip, _, err = ipam.GetStaticAddress(pod1, pod1Nic1, freeIP1, nil, subnetName, true)
 	require.NoError(t, err)
 	require.Equal(t, freeIP1, ip)
@@ -809,8 +813,8 @@ func TestAddOrUpdateSubnet(t *testing.T) {
 
 	pod1 = "pod1.ns"
 	pod1Nic1 = "pod1nic1.ns"
-	freeIP41 := ipam.Subnets[subnetName].V4Free.At(0).Start().String()
-	freeIP61 := ipam.Subnets[subnetName].V6Free.At(0).Start().String()
+	freeIP41 := "10.0.0.2"
+	freeIP61 := "fd00::2"
 	dualIP := fmt.Sprintf("%s,%s", freeIP41, freeIP61)
 	ip4, ip6, _, err := ipam.GetStaticAddress(pod1, pod1Nic1, dualIP, nil, subnetName, true)
 	require.NoError(t, err)

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -350,6 +350,40 @@ func (s *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *string, f
 		v6 = s.V6CIDR != nil
 	}
 
+	if v4 && !s.V4CIDR.Contains(net.IP(ip)) {
+		klog.Errorf("ip %s is out of range", ip)
+		return nil, "", ErrOutOfRange
+	}
+	if v6 && !s.V6CIDR.Contains(net.IP(ip)) {
+		klog.Errorf("ip %s is out of range", ip)
+		return nil, "", ErrOutOfRange
+	}
+
+	var pool *IPPool
+	for _, p := range s.IPPools {
+		if v4 && p.V4IPs.Contains(ip) {
+			pool = p
+			break
+		}
+		if v6 && p.V6IPs.Contains(ip) {
+			pool = p
+			break
+		}
+	}
+
+	if pool == nil {
+		klog.Errorf("ip %s is out of range", ip)
+		return nil, "", ErrOutOfRange
+	}
+	gateway := s.V4Gw
+	if v6 {
+		gateway = s.V6Gw
+	}
+	if checkConflict && net.IP(ip).Equal(net.ParseIP(gateway)) {
+		klog.Errorf("ip %s conflicts with subnet gateway", ip)
+		return nil, "", ErrConflict
+	}
+
 	// Release existing address for this nicName if it exists and is different from requested IP
 	// For dual-stack scenarios, preserve the other protocol's address
 	if v4 && s.V4NicToIP[nicName] != nil && !s.V4NicToIP[nicName].Equal(ip) {
@@ -392,31 +426,6 @@ func (s *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *string, f
 				s.MacToPod[preservedMac] = podName
 			}
 		}
-	}
-	if v4 && !s.V4CIDR.Contains(net.IP(ip)) {
-		klog.Errorf("ip %s is out of range", ip)
-		return nil, "", ErrOutOfRange
-	}
-	if v6 && !s.V6CIDR.Contains(net.IP(ip)) {
-		klog.Errorf("ip %s is out of range", ip)
-		return nil, "", ErrOutOfRange
-	}
-
-	var pool *IPPool
-	for _, p := range s.IPPools {
-		if v4 && p.V4IPs.Contains(ip) {
-			pool = p
-			break
-		}
-		if v6 && p.V6IPs.Contains(ip) {
-			pool = p
-			break
-		}
-	}
-
-	if pool == nil {
-		klog.Errorf("ip %s is out of range", ip)
-		return nil, "", ErrOutOfRange
 	}
 
 	defer func() {

--- a/pkg/ipam/subnet_test.go
+++ b/pkg/ipam/subnet_test.go
@@ -207,6 +207,45 @@ func TestGetV4StaticAddress(t *testing.T) {
 	require.Equal(t, "pod1.default", usingPod)
 }
 
+func TestGetStaticAddressRejectsGatewayIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		cidr    string
+		gateway string
+		ip      string
+	}{
+		{
+			name:    "IPv4",
+			cidr:    "10.0.0.0/24",
+			gateway: "10.0.0.1",
+			ip:      "10.0.0.1",
+		},
+		{
+			name:    "IPv6Canonical",
+			cidr:    "2001:db8::/64",
+			gateway: "2001:0db8:0000:0000:0000:0000:0000:0001",
+			ip:      "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnet, err := NewSubnet(tt.name, tt.cidr, nil)
+			require.NoError(t, err)
+			subnet.V4Gw = tt.gateway
+			subnet.V6Gw = tt.gateway
+
+			ip, err := NewIP(tt.ip)
+			require.NoError(t, err)
+
+			allocatedIP, mac, err := subnet.GetStaticAddress("pod.default", "pod.default", ip, nil, false, true)
+			require.ErrorIs(t, err, ErrConflict)
+			require.Nil(t, allocatedIP)
+			require.Empty(t, mac)
+		})
+	}
+}
+
 func TestGetV4StaticAddressPTP(t *testing.T) {
 	excludeIps := []string{
 		"10.0.0.0",
@@ -266,7 +305,7 @@ func TestGetV6StaticAddress(t *testing.T) {
 	// 2. pod2 has v6 ip and mac should get specified ip and mac
 	podName = "pod2.default"
 	nicName = "pod2.default"
-	v6 = "2001:db8::4"
+	v6 = "2001:db8::5"
 	macIn := "00:11:22:33:44:56"
 	v6IP, err = NewIP(v6)
 	require.NoError(t, err)
@@ -295,7 +334,7 @@ func TestGetV6StaticAddress(t *testing.T) {
 	// 4. pod4 has the same mac with pod2 should get error
 	podName = "pod4.default"
 	nicName = "pod4.default"
-	v6 = "2001:db8::5"
+	v6 = "2001:db8::6"
 	macIn = "00:11:22:33:44:56"
 	v6IP, err = NewIP(v6)
 	require.NoError(t, err)
@@ -1179,6 +1218,58 @@ func TestGetStaticAddressReleaseExisting(t *testing.T) {
 		_, exists := subnet.V4IPToPod["10.0.0.5"]
 		require.False(t, exists)
 		require.False(t, subnet.V4Using.Contains(firstIP))
+	})
+
+	t.Run("IPv4_KeepExistingAddressOnGatewayIPConflict", func(t *testing.T) {
+		subnet, err := NewSubnet("v4Subnet", "10.0.0.0/24", nil)
+		require.NoError(t, err)
+		subnet.V4Gw = "10.0.0.2"
+
+		podName := "pod1.default"
+		nicName := "nic1"
+		firstIP, err := NewIP("10.0.0.5")
+		require.NoError(t, err)
+		gatewayIP, err := NewIP("10.0.0.2")
+		require.NoError(t, err)
+
+		_, mac, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
+		require.NoError(t, err)
+
+		_, _, err = subnet.GetStaticAddress(podName, nicName, gatewayIP, nil, false, true)
+		require.ErrorIs(t, err, ErrConflict)
+		require.Equal(t, firstIP, subnet.V4NicToIP[nicName])
+		require.Equal(t, podName, subnet.V4IPToPod[firstIP.String()])
+		require.True(t, subnet.V4Using.Contains(firstIP))
+		require.False(t, subnet.V4Available.Contains(firstIP))
+		require.Empty(t, subnet.V4IPToPod[gatewayIP.String()])
+		require.False(t, subnet.V4Using.Contains(gatewayIP))
+		require.Equal(t, mac, subnet.NicToMac[nicName])
+	})
+
+	t.Run("IPv6_KeepExistingAddressOnGatewayIPConflict", func(t *testing.T) {
+		subnet, err := NewSubnet("v6Subnet", "2001:db8::/64", nil)
+		require.NoError(t, err)
+		subnet.V6Gw = "2001:db8::2"
+
+		podName := "pod1.default"
+		nicName := "nic1"
+		firstIP, err := NewIP("2001:db8::5")
+		require.NoError(t, err)
+		gatewayIP, err := NewIP("2001:db8::2")
+		require.NoError(t, err)
+
+		_, mac, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
+		require.NoError(t, err)
+
+		_, _, err = subnet.GetStaticAddress(podName, nicName, gatewayIP, nil, false, true)
+		require.ErrorIs(t, err, ErrConflict)
+		require.Equal(t, firstIP, subnet.V6NicToIP[nicName])
+		require.Equal(t, podName, subnet.V6IPToPod[firstIP.String()])
+		require.True(t, subnet.V6Using.Contains(firstIP))
+		require.False(t, subnet.V6Available.Contains(firstIP))
+		require.Empty(t, subnet.V6IPToPod[gatewayIP.String()])
+		require.False(t, subnet.V6Using.Contains(gatewayIP))
+		require.Equal(t, mac, subnet.NicToMac[nicName])
 	})
 
 	// Test IPv6 scenario

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -201,6 +201,15 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 				subnet.Spec.U2OInterconnectionIP,
 				subnet.Name, subnet.Spec.CIDRBlock)
 		}
+		gatewayV4, gatewayV6 := SplitStringIP(subnet.Spec.Gateway)
+		u2oV4, u2oV6 := SplitStringIP(subnet.Spec.U2OInterconnectionIP)
+		gatewayV4IP, gatewayV6IP := net.ParseIP(gatewayV4), net.ParseIP(gatewayV6)
+		u2oV4IP, u2oV6IP := net.ParseIP(u2oV4), net.ParseIP(u2oV6)
+		if (u2oV4IP != nil && gatewayV4IP != nil && u2oV4IP.Equal(gatewayV4IP)) ||
+			(u2oV6IP != nil && gatewayV6IP != nil && u2oV6IP.Equal(gatewayV6IP)) {
+			return fmt.Errorf("u2oInterconnectionIP %s conflicts with subnet gateway %s",
+				subnet.Spec.U2OInterconnectionIP, subnet.Spec.Gateway)
+		}
 	}
 
 	return nil

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -799,6 +799,44 @@ func TestValidateSubnet(t *testing.T) {
 			},
 			err: "validate gateway 10.16.0.0 for cidr 10.16.0.0/32 failed: subnet 10.16.0.0/32 is configured with /32 or /128 netmask",
 		},
+		{
+			name: "U2OInterconnectionIPConflictsWithGateway",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-interconnection-ip-gateway-err",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Vpc:                  DefaultVpc,
+					Protocol:             kubeovnv1.ProtocolIPv4,
+					CIDRBlock:            "10.16.0.0/16",
+					Gateway:              "10.16.0.1",
+					Provider:             OvnProvider,
+					GatewayType:          kubeovnv1.GWDistributedType,
+					U2OInterconnection:   true,
+					U2OInterconnectionIP: "10.16.0.1",
+				},
+			},
+			err: "u2oInterconnectionIP 10.16.0.1 conflicts with subnet gateway 10.16.0.1",
+		},
+		{
+			name: "U2OInterconnectionIPv6CanonicalConflictsWithGateway",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-interconnection-ip-v6-gateway-err",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Vpc:                  DefaultVpc,
+					Protocol:             kubeovnv1.ProtocolIPv6,
+					CIDRBlock:            "2001:db8::/64",
+					Gateway:              "2001:0db8:0000:0000:0000:0000:0000:0001",
+					Provider:             OvnProvider,
+					GatewayType:          kubeovnv1.GWDistributedType,
+					U2OInterconnection:   true,
+					U2OInterconnectionIP: "2001:db8::1",
+				},
+			},
+			err: "u2oInterconnectionIP 2001:db8::1 conflicts with subnet gateway 2001:0db8:0000:0000:0000:0000:0000:0001",
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -203,6 +203,10 @@ var _ = ginkgo.Describe("[IPAM]", func() {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(ip).To(gomega.Equal("10.16.10.10"))
 
+				ip, _, _, err = im.GetStaticAddress("pod2.ns", "pod2.ns", "10.16.10.1", nil, subnetName, true)
+				gomega.Expect(err).Should(gomega.MatchError(ipam.ErrConflict))
+				gomega.Expect(ip).To(gomega.BeEmpty())
+
 				v4UsingIPStr, _, v4AvailableIPStr, _ := im.GetSubnetIPRangeString(subnetName, []string{"10.16.10.10"})
 				gomega.Expect(v4UsingIPStr).To(gomega.Equal(""))
 				gomega.Expect(v4AvailableIPStr).To(gomega.Equal("10.16.10.2-10.16.10.9,10.16.10.11-10.16.10.14"))


### PR DESCRIPTION
## Summary
- reject pod static IP allocation when the requested IP conflicts with the subnet gateway
- compare gateway conflicts with parsed IP equality so equivalent IPv6 text forms are caught
- reject U2O interconnection IP values that conflict with the subnet gateway, while keeping ordinary excluded IP static allocation allowed
- keep the crash-check helper aligned with the master PR fallback for missing container names

## Test Plan
- bash -n hack/ci-check-crash.sh
- go test ./pkg/ipam -count=1
- go test ./pkg/util -count=1
- go test ./pkg/controller -count=1