### PR TITLE
controller, daemon: record pod network lifecycle events

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -320,6 +320,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		OVNSbClient:             mockOvnSbClient,
 		ipam:                    ovnipam.NewIPAM(),
 		recorder:                record.NewFakeRecorder(100),
+		podKeyMutex:             keymutex.NewHashed(0),
 		subnetKeyMutex:          keymutex.NewHashed(0),
 		nsKeyMutex:              keymutex.NewHashed(0),
 		addOrUpdateSubnetQueue:  newTypedRateLimitingQueue[string]("AddOrUpdateSubnet", nil),

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -342,6 +342,7 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 	podNets, err := c.getPodKubeovnNets(newPod)
 	if err != nil {
 		klog.Errorf("failed to get newPod nets %v", err)
+		c.recorder.Eventf(newPod, v1.EventTypeWarning, "AcquireAddressFailed", "%s", err.Error())
 		return
 	}
 
@@ -1430,6 +1431,7 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to pod nets %v", err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", "%s", err.Error())
 		return err
 	}
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2170,11 +2170,12 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 				}
 			}
 			if !foundSubnet {
+				err = fmt.Errorf("provider %s is not bound to any subnet", providerName)
 				if ignoreSubnetNotExist {
-					klog.Errorf("deleting pod %s/%s IPAM network %s has no matching subnet, gc will clean its ip cr", pod.Namespace, pod.Name, providerName)
+					klog.Errorf("deleting pod %s/%s IPAM network %s %v, gc will clean its ip cr", pod.Namespace, pod.Name, providerName, err)
 					continue
 				}
-				return nil, fmt.Errorf("no subnet found for IPAM network %s", providerName)
+				return nil, err
 			}
 		}
 	}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1165,6 +1165,9 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 	stage := "prepare"
 	released := []string{}
 	var podNets []*kubeovnNet
+	var keepIPCR, isOwnerRefToDel, isOwnerRefDeleted bool
+	var ipcrToDelete []string
+	var vmOrphanedPorts map[string]bool
 	c.podKeyMutex.LockKey(key)
 	defer func() {
 		_ = c.podKeyMutex.UnlockKey(key)
@@ -1172,8 +1175,10 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkReleaseFailed", "stage=%s error=%v", stage, err)
 		} else if changed {
 			details := strings.Join(released, "; ")
-			if networkDetails := c.podNetworkEventDetails(pod, podNets); networkDetails != "" {
-				details += "; " + networkDetails
+			if !keepIPCR {
+				if networkDetails := c.podNetworkEventDetails(pod, podNets); networkDetails != "" {
+					details += "; " + networkDetails
+				}
 			}
 			c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkReleased", "%s", strings.TrimPrefix(details, "; "))
 		}
@@ -1204,9 +1209,6 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, podName)
 
-	var keepIPCR, isOwnerRefToDel, isOwnerRefDeleted bool
-	var ipcrToDelete []string
-	var vmOrphanedPorts map[string]bool
 	isStsPod, stsName, stsUID := isStatefulSetPod(pod)
 	if isStsPod {
 		if !pod.DeletionTimestamp.IsZero() {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -576,7 +576,11 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	}
 
 	if len(needAllocatePodNets) != 0 {
-		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkAllocated", "%s", c.podNetworkEventDetails(pod, needAllocatePodNets))
+		details := c.podNetworkEventDetails(pod, needAllocatePodNets)
+		if hotplugDetails != "" {
+			details += "; " + hotplugDetails
+		}
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkAllocated", "%s", details)
 	} else if hotplugDetails != "" || len(needRoutePodNets) != 0 {
 		details := []string{hotplugDetails}
 		if routeDetails := c.podNetworkEventDetails(pod, needRoutePodNets); routeDetails != "" {
@@ -1298,6 +1302,12 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			switch {
 			case vmOrphanedPorts[port.Name]:
 				// Orphaned attachment LSP from NAD hotplug: delete and release its IP.
+				stage = "getIPCR"
+				ipCR, getErr := c.ipsLister.Get(port.Name)
+				if getErr != nil && !k8serrors.IsNotFound(getErr) {
+					klog.Errorf("failed to get ip %s: %v", port.Name, getErr)
+					return getErr
+				}
 				klog.Infof("delete orphaned vm attachment lsp %s", port.Name)
 				stage = "deleteLogicalSwitchPort"
 				if err := c.OVNNbClient.DeleteLogicalSwitchPort(port.Name); err != nil {
@@ -1306,14 +1316,8 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 				}
 				changed = true
 				released = append(released, "logicalSwitchPort="+port.Name)
-				ipCR, err := c.ipsLister.Get(port.Name)
-				if err != nil {
-					if k8serrors.IsNotFound(err) {
-						continue
-					}
-					stage = "getIPCR"
-					klog.Errorf("failed to get ip %s: %v", port.Name, err)
-					return err
+				if k8serrors.IsNotFound(getErr) {
+					continue
 				}
 				if ipCR.Labels[util.IPReservedLabel] != "true" {
 					klog.Infof("delete orphaned vm attachment ip CR %s", ipCR.Name)
@@ -1570,6 +1574,26 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 // there is no mac or ip address request here in the object generated from here
 // interface name in providerName is used for annotation for ip address
 
+func stalePortNetworkDetails(pod *v1.Pod, podName string, port ovnnb.LogicalSwitchPort) (string, string, error) {
+	portPrefix := ovs.PodNameToPortName(podName, pod.Namespace, util.OvnProvider)
+	providerName := util.OvnProvider
+	if port.Name != portPrefix {
+		var ok bool
+		providerName, ok = strings.CutPrefix(port.Name, portPrefix+".")
+		if !ok || providerName == "" {
+			return "", "", fmt.Errorf("logical switch port %q does not match pod prefix %q", port.Name, portPrefix)
+		}
+	}
+	details := fmt.Sprintf("provider=%s subnet=%s ip=%s mac=%s logicalSwitchPort=%s",
+		providerName,
+		port.ExternalIDs["ls"],
+		pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerName)],
+		pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, providerName)],
+		port.Name,
+	)
+	return providerName, details, nil
+}
+
 func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, string, error) {
 	podName := c.getNameByPod(pod)
 	key := cache.NewObjectName(pod.Namespace, podName).String()
@@ -1609,17 +1633,14 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 
 	for _, port := range ports {
 		if !targetPortNameList.Has(port.Name) {
+			providerName, details, parseErr := stalePortNetworkDetails(pod, podName, port)
+			if parseErr != nil {
+				klog.Warning(parseErr)
+				continue
+			}
 			portsNeedToDel = append(portsNeedToDel, port.Name)
 			subnetUsedByPort[port.Name] = port.ExternalIDs["ls"]
-			portNameSlice := strings.Split(port.Name, ".")
-			providerName := strings.Join(portNameSlice[2:], ".")
-			hotplugDetails = append(hotplugDetails, fmt.Sprintf("provider=%s subnet=%s ip=%s mac=%s logicalSwitchPort=%s",
-				providerName,
-				port.ExternalIDs["ls"],
-				pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerName)],
-				pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, providerName)],
-				port.Name,
-			))
+			hotplugDetails = append(hotplugDetails, details)
 			if providerName == util.OvnProvider {
 				continue
 			}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -530,8 +530,8 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	}
 
 	// check and do hotnoplug nic
-	var hotplugChanged bool
-	if pod, hotplugChanged, err = c.syncKubeOvnNet(pod, podNets); err != nil {
+	var hotplugDetails string
+	if pod, hotplugDetails, err = c.syncKubeOvnNet(pod, podNets); err != nil {
 		klog.Errorf("failed to sync pod nets %v", err)
 		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=syncKubeOvnNet error=%v", err)
 		return err
@@ -575,11 +575,14 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 		return err
 	}
 
-	details := c.podNetworkEventDetails(pod, podNets)
 	if len(needAllocatePodNets) != 0 {
-		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkAllocated", "%s", details)
-	} else if hotplugChanged || len(needRoutePodNets) != 0 {
-		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkUpdated", "%s", details)
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkAllocated", "%s", c.podNetworkEventDetails(pod, needAllocatePodNets))
+	} else if hotplugDetails != "" || len(needRoutePodNets) != 0 {
+		details := []string{hotplugDetails}
+		if routeDetails := c.podNetworkEventDetails(pod, needRoutePodNets); routeDetails != "" {
+			details = append(details, routeDetails)
+		}
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkUpdated", "%s", strings.TrimPrefix(strings.Join(details, "; "), "; "))
 	}
 	return nil
 }
@@ -663,7 +666,6 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	name := pod.Name
 	klog.Infof("sync pod %s/%s allocated", namespace, name)
 
-	vipsMap := c.getVirtualIPs(pod, needAllocatePodNets)
 	isVMPod, vmName := isVMPod(pod)
 	podType := getPodType(pod)
 	podName := c.getNameByPod(pod)
@@ -737,7 +739,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 				portSecurity = true
 			}
 
-			vips := vipsMap[fmt.Sprintf("%s.%s", podNet.Subnet.Name, podNet.ProviderName)]
+			vips := c.getVirtualIPs(pod, []*kubeovnNet{podNet})[fmt.Sprintf("%s.%s", podNet.Subnet.Name, podNet.ProviderName)]
 			for ip := range strings.SplitSeq(vips, ",") {
 				if ip != "" && net.ParseIP(ip) == nil {
 					klog.Errorf("invalid vip address '%s' for pod %s", ip, name)
@@ -1212,6 +1214,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 		}
 		if keepIPCR {
+			stage = "checkStatefulSetOwner"
 			isOwnerRefDeleted, ipcrToDelete, err = appendCheckPodNetToDel(c, pod, stsName, util.KindStatefulSet)
 			if err != nil {
 				klog.Error(err)
@@ -1254,6 +1257,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 				// running the VM. If another live sibling exists (e.g. a
 				// live-migration destination while the completed source is being
 				// GC'd), its memberships must not be wiped out.
+				stage = "listVMPodSiblings"
 				siblings, listErr := c.podsLister.Pods(pod.Namespace).List(labels.Everything())
 				if listErr != nil {
 					klog.Errorf("failed to list pods in namespace %s: %v", pod.Namespace, listErr)
@@ -1263,6 +1267,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 		}
 		if keepIPCR {
+			stage = "checkVMOwner"
 			isOwnerRefDeleted, ipcrToDelete, err = appendCheckPodNetToDel(c, pod, vmName, util.KindVirtualMachineInstance)
 			if err != nil {
 				klog.Error(err)
@@ -1303,10 +1308,12 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 				released = append(released, "logicalSwitchPort="+port.Name)
 				ipCR, err := c.ipsLister.Get(port.Name)
 				if err != nil {
-					if !k8serrors.IsNotFound(err) {
-						klog.Errorf("failed to get ip %s: %v", port.Name, err)
+					if k8serrors.IsNotFound(err) {
+						continue
 					}
-					continue
+					stage = "getIPCR"
+					klog.Errorf("failed to get ip %s: %v", port.Name, err)
+					return err
 				}
 				if ipCR.Labels[util.IPReservedLabel] != "true" {
 					klog.Infof("delete orphaned vm attachment ip CR %s", ipCR.Name)
@@ -1563,7 +1570,7 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 // there is no mac or ip address request here in the object generated from here
 // interface name in providerName is used for annotation for ip address
 
-func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, bool, error) {
+func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, string, error) {
 	podName := c.getNameByPod(pod)
 	key := cache.NewObjectName(pod.Namespace, podName).String()
 	targetPortNameList := strset.NewWithSize(len(podNets))
@@ -1571,25 +1578,33 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	annotationsNeedToDel := []string{}
 	annotationsNeedToAdd := make(map[string]string)
 	subnetUsedByPort := make(map[string]string)
+	changedPodNets := []*kubeovnNet{}
+	hotplugDetails := []string{}
 
 	for _, podNet := range podNets {
 		portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
 		targetPortNameList.Add(portName)
+		changed := false
 		if podNet.IPRequest != "" && pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] != podNet.IPRequest {
 			klog.Infof("pod %s/%s use custom IP %s for provider %s", pod.Namespace, pod.Name, podNet.IPRequest, podNet.ProviderName)
 			annotationsNeedToAdd[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] = podNet.IPRequest
+			changed = true
 		}
 
 		if podNet.MacRequest != "" && pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)] != podNet.MacRequest {
 			klog.Infof("pod %s/%s use custom MAC %s for provider %s", pod.Namespace, pod.Name, podNet.MacRequest, podNet.ProviderName)
 			annotationsNeedToAdd[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)] = podNet.MacRequest
+			changed = true
+		}
+		if changed {
+			changedPodNets = append(changedPodNets, podNet)
 		}
 	}
 
 	ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": key})
 	if err != nil {
 		klog.Errorf("failed to list lsps of pod '%s', %v", pod.Name, err)
-		return nil, false, err
+		return nil, "", err
 	}
 
 	for _, port := range ports {
@@ -1598,6 +1613,13 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 			subnetUsedByPort[port.Name] = port.ExternalIDs["ls"]
 			portNameSlice := strings.Split(port.Name, ".")
 			providerName := strings.Join(portNameSlice[2:], ".")
+			hotplugDetails = append(hotplugDetails, fmt.Sprintf("provider=%s subnet=%s ip=%s mac=%s logicalSwitchPort=%s",
+				providerName,
+				port.ExternalIDs["ls"],
+				pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerName)],
+				pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, providerName)],
+				port.Name,
+			))
 			if providerName == util.OvnProvider {
 				continue
 			}
@@ -1606,7 +1628,7 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	if len(portsNeedToDel) == 0 && len(annotationsNeedToAdd) == 0 {
-		return pod, false, nil
+		return pod, "", nil
 	}
 
 	for _, portNeedDel := range portsNeedToDel {
@@ -1614,12 +1636,12 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 		c.ipam.ReleaseAddressByNic(key, portNeedDel, subnetUsedByPort[portNeedDel])
 		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portNeedDel); err != nil {
 			klog.Errorf("failed to delete lsp %s, %v", portNeedDel, err)
-			return nil, false, err
+			return nil, "", err
 		}
 		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), portNeedDel, metav1.DeleteOptions{}); err != nil {
 			if !k8serrors.IsNotFound(err) {
 				klog.Errorf("failed to delete ip %s, %v", portNeedDel, err)
-				return nil, false, err
+				return nil, "", err
 			}
 		}
 	}
@@ -1638,26 +1660,29 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	if len(patch) == 0 {
-		return pod, len(portsNeedToDel) != 0, nil
+		return pod, strings.Join(hotplugDetails, "; "), nil
 	}
 
 	if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(pod.Namespace), pod.Name, patch); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, false, nil
+			return nil, "", nil
 		}
 		klog.Errorf("failed to clean annotations for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		return nil, false, err
+		return nil, "", err
 	}
 
 	if pod, err = c.config.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, false, nil
+			return nil, "", nil
 		}
 		klog.Errorf("failed to get pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		return nil, false, err
+		return nil, "", err
 	}
 
-	return pod, true, nil
+	if details := c.podNetworkEventDetails(pod, changedPodNets); details != "" {
+		hotplugDetails = append(hotplugDetails, details)
+	}
+	return pod, strings.Join(hotplugDetails, "; "), nil
 }
 
 func (c *Controller) podNetworkEventDetails(pod *v1.Pod, podNets []*kubeovnNet) string {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -16,6 +16,7 @@ import (
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	"github.com/scylladb/go-set/strset"
+	multustypes "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -523,6 +524,7 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to get pod nets %v", err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", "%s", err.Error())
 		return err
 	}
 
@@ -2144,7 +2146,11 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			}
 			result = append(result, ret)
 		} else {
+			if !isKubeOVNIPAMNetwork(netCfg) {
+				continue
+			}
 			providerName = fmt.Sprintf("%s.%s", attach.Name, attach.Namespace)
+			foundSubnet := false
 			for _, subnet := range subnets {
 				if subnet.Spec.Provider == providerName {
 					result = append(result, &kubeovnNet{
@@ -2157,12 +2163,32 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 						NadNamespace:  attach.Namespace,
 						InterfaceName: attach.InterfaceRequest,
 					})
+					foundSubnet = true
 					break
 				}
+			}
+			if !foundSubnet {
+				if ignoreSubnetNotExist {
+					klog.Errorf("deleting pod %s/%s IPAM network %s has no matching subnet, gc will clean its ip cr", pod.Namespace, pod.Name, providerName)
+					continue
+				}
+				return nil, fmt.Errorf("no subnet found for IPAM network %s", providerName)
 			}
 		}
 	}
 	return result, nil
+}
+
+func isKubeOVNIPAMNetwork(netCfg *multustypes.DelegateNetConf) bool {
+	if netCfg.Conf.IPAM.Type == util.CniTypeName {
+		return true
+	}
+	for _, plugin := range netCfg.ConfList.Plugins {
+		if plugin.IPAM.Type == util.CniTypeName {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Controller) validatePodIP(podName, subnetName, ipv4, ipv6 string) (bool, bool, error) {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1633,13 +1633,14 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 
 	for _, port := range ports {
 		if !targetPortNameList.Has(port.Name) {
+			portsNeedToDel = append(portsNeedToDel, port.Name)
+			subnetUsedByPort[port.Name] = port.ExternalIDs["ls"]
 			providerName, details, parseErr := stalePortNetworkDetails(pod, podName, port)
 			if parseErr != nil {
 				klog.Warning(parseErr)
+				hotplugDetails = append(hotplugDetails, fmt.Sprintf("provider=unknown subnet=%s ip= mac= logicalSwitchPort=%s", port.ExternalIDs["ls"], port.Name))
 				continue
 			}
-			portsNeedToDel = append(portsNeedToDel, port.Name)
-			subnetUsedByPort[port.Name] = port.ExternalIDs["ls"]
 			hotplugDetails = append(hotplugDetails, details)
 			if providerName == util.OvnProvider {
 				continue

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -683,10 +683,11 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		// the subnet may changed when alloc static ip from the latter subnet after ns supports multi subnets
 		v4IP, v6IP, mac, subnet, err := c.acquireAddress(pod, podNet)
 		if err != nil {
-			c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", "%s", err.Error())
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", "stage=acquireAddress error=%v", err)
 			klog.Error(err)
 			return nil, err
 		}
+		podNet.Subnet = subnet
 		ipStr := util.GetStringIP(v4IP, v6IP)
 		patch[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] = ipStr
 		if mac == "" {
@@ -711,7 +712,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		}
 		if err := util.ValidateNetworkBroadcast(podNet.Subnet.Spec.CIDRBlock, ipStr); err != nil {
 			klog.Errorf("validate pod %s/%s failed: %v", namespace, name, err)
-			c.recorder.Eventf(pod, v1.EventTypeWarning, "ValidatePodNetworkFailed", "%s", err.Error())
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "ValidatePodNetworkFailed", "stage=validateNetworkBroadcast error=%v", err)
 			return nil, err
 		}
 
@@ -724,7 +725,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 				vlan, err := c.vlansLister.Get(subnet.Spec.Vlan)
 				if err != nil {
 					klog.Error(err)
-					c.recorder.Eventf(pod, v1.EventTypeWarning, "GetVlanInfoFailed", "%s", err.Error())
+					c.recorder.Eventf(pod, v1.EventTypeWarning, "GetVlanInfoFailed", "stage=getVlanInfo error=%v", err)
 					return nil, err
 				}
 				patch[fmt.Sprintf(util.VlanIDAnnotationTemplate, podNet.ProviderName)] = strconv.Itoa(vlan.Spec.ID)
@@ -793,14 +794,14 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			securityGroupAnnotation := pod.Annotations[fmt.Sprintf(util.SecurityGroupAnnotationTemplate, podNet.ProviderName)]
 			if err := c.OVNNbClient.CreateLogicalSwitchPort(subnet.Name, portName, ipStr, mac, podName, pod.Namespace,
 				portSecurity, securityGroupAnnotation, vips, enableDHCP, dhcpOptions, subnet.Spec.Vpc); err != nil {
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "CreateOVNPortFailed", "%s", err.Error())
+				c.recorder.Eventf(pod, v1.EventTypeWarning, "CreateOVNPortFailed", "stage=createLogicalSwitchPort error=%v", err)
 				klog.Errorf("%v", err)
 				return nil, err
 			}
 
 			if pod.Annotations[fmt.Sprintf(util.Layer2ForwardAnnotationTemplate, podNet.ProviderName)] == "true" {
 				if err := c.OVNNbClient.EnablePortLayer2forward(portName); err != nil {
-					c.recorder.Eventf(pod, v1.EventTypeWarning, "SetOVNPortL2ForwardFailed", "%s", err.Error())
+					c.recorder.Eventf(pod, v1.EventTypeWarning, "SetOVNPortL2ForwardFailed", "stage=setLogicalSwitchPortLayer2Forward error=%v", err)
 					klog.Errorf("%v", err)
 					return nil, err
 				}
@@ -1510,7 +1511,7 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 	}
 
 	vipsMap := c.getVirtualIPs(pod, podNets)
-	processed := false
+	updatedPodNets := make([]*kubeovnNet, 0, len(podNets))
 
 	// associated with security group
 	for _, podNet := range podNets {
@@ -1550,10 +1551,10 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodSecurityUpdateFailed", "stage=reconcilePortSg error=%v", err)
 			return err
 		}
-		processed = true
+		updatedPodNets = append(updatedPodNets, podNet)
 	}
-	if processed {
-		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodSecurityUpdated", "%s", c.podNetworkEventDetails(pod, podNets))
+	if len(updatedPodNets) != 0 {
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodSecurityUpdated", "%s", c.podNetworkEventDetails(pod, updatedPodNets))
 	}
 	return nil
 }

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -342,7 +342,7 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 	podNets, err := c.getPodKubeovnNets(newPod)
 	if err != nil {
 		klog.Errorf("failed to get newPod nets %v", err)
-		c.recorder.Eventf(newPod, v1.EventTypeWarning, "AcquireAddressFailed", "%s", err.Error())
+		c.recorder.Eventf(newPod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=getPodKubeovnNets error=%v", err)
 		return
 	}
 
@@ -525,13 +525,15 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to get pod nets %v", err)
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", "%s", err.Error())
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=getPodKubeovnNets error=%v", err)
 		return err
 	}
 
 	// check and do hotnoplug nic
-	if pod, err = c.syncKubeOvnNet(pod, podNets); err != nil {
+	var hotplugChanged bool
+	if pod, hotplugChanged, err = c.syncKubeOvnNet(pod, podNets); err != nil {
 		klog.Errorf("failed to sync pod nets %v", err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=syncKubeOvnNet error=%v", err)
 		return err
 	}
 	if pod == nil {
@@ -562,11 +564,24 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	// Reconcile per-port DHCP options for pods that carry DHCP annotations.
 	// This handles annotation add/change on already-running pods without requiring a pod restart.
 	if err = c.reconcilePodDHCPOptions(pod, podNets); err != nil {
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=reconcilePodDHCPOptions error=%v", err)
 		return err
 	}
 
 	// check if route subnet is need.
-	return c.reconcileRouteSubnets(pod, needRouteSubnets(pod, podNets))
+	needRoutePodNets := needRouteSubnets(pod, podNets)
+	if err = c.reconcileRouteSubnets(pod, needRoutePodNets); err != nil {
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=reconcileRouteSubnets error=%v", err)
+		return err
+	}
+
+	details := c.podNetworkEventDetails(pod, podNets)
+	if len(needAllocatePodNets) != 0 {
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkAllocated", "%s", details)
+	} else if hotplugChanged || len(needRoutePodNets) != 0 {
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkUpdated", "%s", details)
+	}
+	return nil
 }
 
 // subnetDHCPOptionsUUIDs returns the subnet-level DHCP option UUIDs from the subnet status.
@@ -655,6 +670,9 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	// todo: isVmPod, getPodType, getNameByPod has duplicated logic
 
 	var err error
+	recordFailure := func(stage string, err error) {
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkAllocationFailed", "stage=%s error=%v", stage, err)
+	}
 	var vmKey string
 	if isVMPod && c.config.EnableKeepVMIP {
 		vmKey = fmt.Sprintf("%s/%s", namespace, vmName)
@@ -737,6 +755,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			var gateway string
 			if dhcpV4 != "" || dhcpV6 != "" {
 				if mtu, err = c.getSubnetMTU(subnet); err != nil {
+					recordFailure("getSubnetMTU", err)
 					return nil, err
 				}
 				gateway = subnet.Spec.Gateway
@@ -751,6 +770,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			)
 			if err != nil {
 				klog.Errorf("failed to reconcile DHCP options for port %s: %v", portName, err)
+				recordFailure("reconcilePortDHCPOptions", err)
 				return nil, err
 			}
 
@@ -762,6 +782,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 				existingLsp, err := c.OVNNbClient.GetLogicalSwitchPort(portName, true)
 				if err != nil {
 					klog.Errorf("failed to get logical switch port %s: %v", portName, err)
+					recordFailure("getLogicalSwitchPort", err)
 					return nil, err
 				}
 				if existingLsp != nil {
@@ -805,6 +826,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		if err := c.createOrUpdateIPCR(ipCRName, podName, ipStr, mac, subnet.Name, pod.Namespace, pod.Spec.NodeName, podType); err != nil {
 			err = fmt.Errorf("failed to create ips CR %s.%s: %w", podName, pod.Namespace, err)
 			klog.Error(err)
+			recordFailure("createOrUpdateIPCR", err)
 			return nil, err
 		}
 	}
@@ -818,6 +840,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			return nil, nil
 		}
 		klog.Errorf("failed to patch pod %s/%s: %v", namespace, name, err)
+		recordFailure("patchPodAnnotations", err)
 		return nil, err
 	}
 
@@ -830,6 +853,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			return nil, nil
 		}
 		klog.Errorf("failed to get pod %s/%s: %v", namespace, name, err)
+		recordFailure("getPatchedPod", err)
 		return nil, err
 	}
 
@@ -1130,9 +1154,22 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 	now := time.Now()
 	klog.Infof("handle delete pod %s", key)
 	podName := c.getNameByPod(pod)
+	changed := false
+	stage := "prepare"
+	released := []string{}
+	var podNets []*kubeovnNet
 	c.podKeyMutex.LockKey(key)
 	defer func() {
 		_ = c.podKeyMutex.UnlockKey(key)
+		if err != nil {
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkReleaseFailed", "stage=%s error=%v", stage, err)
+		} else if changed {
+			details := strings.Join(released, "; ")
+			if networkDetails := c.podNetworkEventDetails(pod, podNets); networkDetails != "" {
+				details += "; " + networkDetails
+			}
+			c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkReleased", "%s", strings.TrimPrefix(details, "; "))
+		}
 		if err == nil {
 			c.deletingPodObjMap.Delete(key)
 		}
@@ -1185,16 +1222,19 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 		}
 	}
+	stage = "listLogicalSwitchPorts"
 	ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": podKey})
 	if err != nil {
 		klog.Errorf("failed to list lsps of pod %s: %v", podKey, err)
 		return err
 	}
+	stage = "releaseNetworkResources"
 
 	var hasAliveVMSibling bool
 	isVMPod, vmName := isVMPod(pod)
 	if isVMPod && c.config.EnableKeepVMIP {
 		for _, port := range ports {
+			stage = "cleanLogicalSwitchPortMigrateOptions"
 			if err := c.OVNNbClient.CleanLogicalSwitchPortMigrateOptions(port.Name); err != nil {
 				err = fmt.Errorf("failed to clean migrate options for vm lsp %s, %w", port.Name, err)
 				klog.Error(err)
@@ -1241,9 +1281,11 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 		}
 	}
 
-	podNets, err := c.getPodKubeovnNets(pod)
+	stage = "getPodKubeovnNets"
+	podNets, err = c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to get kube-ovn nets of pod %s: %v", podKey, err)
+		return err
 	}
 	if keepIPCR {
 		for _, port := range ports {
@@ -1251,10 +1293,13 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			case vmOrphanedPorts[port.Name]:
 				// Orphaned attachment LSP from NAD hotplug: delete and release its IP.
 				klog.Infof("delete orphaned vm attachment lsp %s", port.Name)
+				stage = "deleteLogicalSwitchPort"
 				if err := c.OVNNbClient.DeleteLogicalSwitchPort(port.Name); err != nil {
 					klog.Errorf("failed to delete orphaned lsp %s: %v", port.Name, err)
 					return err
 				}
+				changed = true
+				released = append(released, "logicalSwitchPort="+port.Name)
 				ipCR, err := c.ipsLister.Get(port.Name)
 				if err != nil {
 					if !k8serrors.IsNotFound(err) {
@@ -1264,14 +1309,23 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 				}
 				if ipCR.Labels[util.IPReservedLabel] != "true" {
 					klog.Infof("delete orphaned vm attachment ip CR %s", ipCR.Name)
+					stage = "deleteIPCR"
 					if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipCR.Name, metav1.DeleteOptions{}); err != nil {
 						if !k8serrors.IsNotFound(err) {
 							klog.Errorf("failed to delete ip %s: %v", ipCR.Name, err)
 							return err
 						}
+					} else {
+						changed = true
+						released = append(released, fmt.Sprintf("ipCR=%s subnet=%s", ipCR.Name, ipCR.Spec.Subnet))
 					}
 					if subnetName := ipCR.Spec.Subnet; subnetName != "" {
+						addressCount := len(c.ipam.GetPodAddress(podKey))
 						c.ipam.ReleaseAddressByNic(podKey, port.Name, subnetName)
+						if len(c.ipam.GetPodAddress(podKey)) < addressCount {
+							changed = true
+							released = append(released, fmt.Sprintf("ipam=%s subnet=%s", port.Name, subnetName))
+						}
 						c.updateSubnetStatusQueue.Add(subnetName)
 					}
 				}
@@ -1279,6 +1333,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 				klog.Infof("skip removing lsp %s from port groups: another alive virt-launcher pod exists for vm %s/%s", port.Name, pod.Namespace, vmName)
 			default:
 				klog.Infof("remove lsp %s from all port groups", port.Name)
+				stage = "removeLogicalSwitchPortFromPortGroups"
 				if err = c.OVNNbClient.RemovePortFromPortGroups(port.Name); err != nil {
 					klog.Errorf("failed to remove lsp %s from all port groups: %v", port.Name, err)
 					return err
@@ -1337,10 +1392,13 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 		for _, port := range ports {
 			// when lsp is deleted, the port of pod is deleted from any port-group automatically.
 			klog.Infof("delete logical switch port %s", port.Name)
+			stage = "deleteLogicalSwitchPort"
 			if err := c.OVNNbClient.DeleteLogicalSwitchPort(port.Name); err != nil {
 				klog.Errorf("failed to delete lsp %s, %v", port.Name, err)
 				return err
 			}
+			changed = true
+			released = append(released, "logicalSwitchPort="+port.Name)
 		}
 		klog.Infof("try release all ip address for deleting pod %s", podKey)
 		for _, podNet := range podNets {
@@ -1361,23 +1419,39 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 			if ipCR.Labels[util.IPReservedLabel] != "true" {
 				klog.Infof("delete ip CR %s", ipCR.Name)
+				stage = "deleteIPCR"
 				if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipCR.Name, metav1.DeleteOptions{}); err != nil {
 					if !k8serrors.IsNotFound(err) {
 						klog.Errorf("failed to delete ip %s, %v", ipCR.Name, err)
 						return err
 					}
+				} else {
+					changed = true
+					released = append(released, fmt.Sprintf("ipCR=%s subnet=%s", ipCR.Name, podNet.Subnet.Name))
 				}
 				// release ipam address after delete ip CR
+				addressCount := len(c.ipam.GetPodAddress(podKey))
 				c.ipam.ReleaseAddressByNic(podKey, portName, podNet.Subnet.Name)
+				if len(c.ipam.GetPodAddress(podKey)) < addressCount {
+					changed = true
+					released = append(released, fmt.Sprintf("ipam=%s subnet=%s", portName, podNet.Subnet.Name))
+				}
 				// Trigger subnet status update after IPAM release
 				// This is needed when IP CR is deleted without finalizer (race condition)
 				c.updateSubnetStatusQueue.Add(podNet.Subnet.Name)
 			}
 		}
 		if pod.Annotations[util.VipAnnotation] != "" {
+			vip, vipErr := c.virtualIpsLister.Get(pod.Annotations[util.VipAnnotation])
+			vipWillChange := vipErr == nil && vip.Labels[util.IPReservedLabel] != ""
+			stage = "releaseVIP"
 			if err = c.releaseVip(pod.Annotations[util.VipAnnotation]); err != nil {
 				klog.Errorf("failed to clean label from vip %s, %v", pod.Annotations[util.VipAnnotation], err)
 				return err
+			}
+			if vipWillChange {
+				changed = true
+				released = append(released, "vip="+pod.Annotations[util.VipAnnotation])
 			}
 		}
 	}
@@ -1431,11 +1505,12 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to pod nets %v", err)
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", "%s", err.Error())
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodSecurityUpdateFailed", "stage=getPodKubeovnNets error=%v", err)
 		return err
 	}
 
 	vipsMap := c.getVirtualIPs(pod, podNets)
+	processed := false
 
 	// associated with security group
 	for _, podNet := range podNets {
@@ -1455,6 +1530,7 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 		portName := ovs.PodNameToPortName(podName, namespace, podNet.ProviderName)
 		if err = c.OVNNbClient.SetLogicalSwitchPortSecurity(portSecurity, portName, mac, ipStr, vips); err != nil {
 			klog.Errorf("failed to set security for logical switch port %s: %v", portName, err)
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodSecurityUpdateFailed", "stage=setLogicalSwitchPortSecurity error=%v", err)
 			return err
 		}
 
@@ -1471,8 +1547,13 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 		}
 		if err = c.reconcilePortSg(portName, securityGroups); err != nil {
 			klog.Errorf("reconcilePortSg failed. %v", err)
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodSecurityUpdateFailed", "stage=reconcilePortSg error=%v", err)
 			return err
 		}
+		processed = true
+	}
+	if processed {
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodSecurityUpdated", "%s", c.podNetworkEventDetails(pod, podNets))
 	}
 	return nil
 }
@@ -1481,7 +1562,7 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 // there is no mac or ip address request here in the object generated from here
 // interface name in providerName is used for annotation for ip address
 
-func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, error) {
+func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, bool, error) {
 	podName := c.getNameByPod(pod)
 	key := cache.NewObjectName(pod.Namespace, podName).String()
 	targetPortNameList := strset.NewWithSize(len(podNets))
@@ -1493,12 +1574,12 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	for _, podNet := range podNets {
 		portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
 		targetPortNameList.Add(portName)
-		if podNet.IPRequest != "" {
+		if podNet.IPRequest != "" && pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] != podNet.IPRequest {
 			klog.Infof("pod %s/%s use custom IP %s for provider %s", pod.Namespace, pod.Name, podNet.IPRequest, podNet.ProviderName)
 			annotationsNeedToAdd[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] = podNet.IPRequest
 		}
 
-		if podNet.MacRequest != "" {
+		if podNet.MacRequest != "" && pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)] != podNet.MacRequest {
 			klog.Infof("pod %s/%s use custom MAC %s for provider %s", pod.Namespace, pod.Name, podNet.MacRequest, podNet.ProviderName)
 			annotationsNeedToAdd[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)] = podNet.MacRequest
 		}
@@ -1507,7 +1588,7 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": key})
 	if err != nil {
 		klog.Errorf("failed to list lsps of pod '%s', %v", pod.Name, err)
-		return nil, err
+		return nil, false, err
 	}
 
 	for _, port := range ports {
@@ -1524,7 +1605,7 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	if len(portsNeedToDel) == 0 && len(annotationsNeedToAdd) == 0 {
-		return pod, nil
+		return pod, false, nil
 	}
 
 	for _, portNeedDel := range portsNeedToDel {
@@ -1532,12 +1613,12 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 		c.ipam.ReleaseAddressByNic(key, portNeedDel, subnetUsedByPort[portNeedDel])
 		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portNeedDel); err != nil {
 			klog.Errorf("failed to delete lsp %s, %v", portNeedDel, err)
-			return nil, err
+			return nil, false, err
 		}
 		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), portNeedDel, metav1.DeleteOptions{}); err != nil {
 			if !k8serrors.IsNotFound(err) {
 				klog.Errorf("failed to delete ip %s, %v", portNeedDel, err)
-				return nil, err
+				return nil, false, err
 			}
 		}
 	}
@@ -1556,26 +1637,42 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	if len(patch) == 0 {
-		return pod, nil
+		return pod, len(portsNeedToDel) != 0, nil
 	}
 
 	if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(pod.Namespace), pod.Name, patch); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, nil
+			return nil, false, nil
 		}
 		klog.Errorf("failed to clean annotations for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		return nil, err
+		return nil, false, err
 	}
 
 	if pod, err = c.config.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, nil
+			return nil, false, nil
 		}
 		klog.Errorf("failed to get pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		return nil, err
+		return nil, false, err
 	}
 
-	return pod, nil
+	return pod, true, nil
+}
+
+func (c *Controller) podNetworkEventDetails(pod *v1.Pod, podNets []*kubeovnNet) string {
+	podName := c.getNameByPod(pod)
+	details := make([]string, 0, len(podNets))
+	for _, podNet := range podNets {
+		details = append(details, fmt.Sprintf(
+			"provider=%s subnet=%s ip=%s mac=%s logicalSwitchPort=%s",
+			podNet.ProviderName,
+			podNet.Subnet.Name,
+			pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)],
+			pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)],
+			ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName),
+		))
+	}
+	return strings.Join(details, "; ")
 }
 
 func isStatefulSetPod(pod *v1.Pod) (bool, string, types.UID) {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -1356,4 +1358,46 @@ func TestGetPodAttachmentNetIPAMOnlyNADGone(t *testing.T) {
 	require.Len(t, nets, 1)
 	assert.Equal(t, "net1.default", nets[0].ProviderName)
 	assert.Equal(t, "ipam-net1", nets[0].Subnet.Name)
+}
+
+func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: `[{"name": "net1"}]`,
+			},
+		},
+	}
+
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods: []*corev1.Pod{pod},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "net1",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: nadv1.NetworkAttachmentDefinitionSpec{
+					Config: `{"cniVersion":"0.3.1","name":"net1","type":"macvlan","ipam":{"type":"kube-ovn"}}`,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	controller := fakeController.fakeController
+	controller.config.EnableNonPrimaryCNI = true
+
+	err = controller.handleAddOrUpdatePod("default/test-pod")
+	require.Error(t, err)
+
+	recorder := controller.recorder.(*record.FakeRecorder)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "Warning AcquireAddressFailed")
+		assert.Contains(t, event, "no subnet found for IPAM network net1.default")
+	case <-time.After(time.Second):
+		t.Fatal("expected pod event")
+	}
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1361,16 +1361,16 @@ func TestGetPodAttachmentNetIPAMOnlyNADGone(t *testing.T) {
 }
 
 func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
-	controller := newIPAMSubnetMissingController(t)
+	controller := newIPAMSubnetMissingController(t, util.CniTypeName)
 
 	err := controller.handleAddOrUpdatePod("default/test-pod")
 	require.Error(t, err)
 
-	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "no subnet found for IPAM network net1.default")
+	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "provider net1.default is not bound to any subnet")
 }
 
 func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
-	controller := newIPAMSubnetMissingController(t)
+	controller := newIPAMSubnetMissingController(t, util.CniTypeName)
 	oldPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test-pod",
@@ -1386,19 +1386,29 @@ func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 
 	controller.enqueueUpdatePod(oldPod, newPod)
 
-	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "no subnet found for IPAM network net1.default")
+	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "provider net1.default is not bound to any subnet")
 }
 
 func TestHandleUpdatePodSecurityRecordsIPAMSubnetMissingEvent(t *testing.T) {
-	controller := newIPAMSubnetMissingController(t)
+	controller := newIPAMSubnetMissingController(t, util.CniTypeName)
 
 	err := controller.handleUpdatePodSecurity("default/test-pod")
 	require.Error(t, err)
 
-	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "no subnet found for IPAM network net1.default")
+	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "provider net1.default is not bound to any subnet")
 }
 
-func newIPAMSubnetMissingController(t *testing.T) *Controller {
+func TestGetPodAttachmentNetIgnoresNonKubeOVNIPAMWithoutSubnet(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t, "host-local")
+	pod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
+	require.NoError(t, err)
+
+	nets, err := controller.getPodAttachmentNet(pod)
+	require.NoError(t, err)
+	assert.Empty(t, nets)
+}
+
+func newIPAMSubnetMissingController(t *testing.T, ipamType string) *Controller {
 	t.Helper()
 
 	pod := &corev1.Pod{
@@ -1420,7 +1430,7 @@ func newIPAMSubnetMissingController(t *testing.T) *Controller {
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: nadv1.NetworkAttachmentDefinitionSpec{
-					Config: `{"cniVersion":"0.3.1","name":"net1","type":"macvlan","ipam":{"type":"kube-ovn"}}`,
+					Config: fmt.Sprintf(`{"cniVersion":"0.3.1","name":"net1","type":"macvlan","ipam":{"type":%q}}`, ipamType),
 				},
 			},
 		},

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1361,6 +1361,46 @@ func TestGetPodAttachmentNetIPAMOnlyNADGone(t *testing.T) {
 }
 
 func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t)
+
+	err := controller.handleAddOrUpdatePod("default/test-pod")
+	require.Error(t, err)
+
+	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "no subnet found for IPAM network net1.default")
+}
+
+func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t)
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-pod",
+			Namespace:       metav1.NamespaceDefault,
+			ResourceVersion: "1",
+			Annotations:     map[string]string{},
+		},
+	}
+	newPod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
+	require.NoError(t, err)
+	newPod = newPod.DeepCopy()
+	newPod.ResourceVersion = "2"
+
+	controller.enqueueUpdatePod(oldPod, newPod)
+
+	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "no subnet found for IPAM network net1.default")
+}
+
+func TestHandleUpdatePodSecurityRecordsIPAMSubnetMissingEvent(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t)
+
+	err := controller.handleUpdatePodSecurity("default/test-pod")
+	require.Error(t, err)
+
+	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "no subnet found for IPAM network net1.default")
+}
+
+func newIPAMSubnetMissingController(t *testing.T) *Controller {
+	t.Helper()
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
@@ -1388,15 +1428,18 @@ func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 	require.NoError(t, err)
 	controller := fakeController.fakeController
 	controller.config.EnableNonPrimaryCNI = true
+	return controller
+}
 
-	err = controller.handleAddOrUpdatePod("default/test-pod")
-	require.Error(t, err)
+func assertPodEvent(t *testing.T, controller *Controller, parts ...string) {
+	t.Helper()
 
 	recorder := controller.recorder.(*record.FakeRecorder)
 	select {
 	case event := <-recorder.Events:
-		assert.Contains(t, event, "Warning AcquireAddressFailed")
-		assert.Contains(t, event, "no subnet found for IPAM network net1.default")
+		for _, part := range parts {
+			assert.Contains(t, event, part)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("expected pod event")
 	}

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1548,20 +1548,45 @@ func TestSyncKubeOvnNetParsesStalePortProviders(t *testing.T) {
 	})
 
 	t.Run("unmatched pod prefix", func(t *testing.T) {
+		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Name: "test-pod", Namespace: metav1.NamespaceDefault,
-			Annotations: map[string]string{keepKey: "true"},
+			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
 		}}
-		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+		_, subnet := podEventFixture()
+		portName := "legacy-port-name"
+		ipCR := &kubeovnv1.IP{ObjectMeta: metav1.ObjectMeta{Name: portName}, Spec: kubeovnv1.IPSpec{Subnet: subnet.Name}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}, IPs: []*kubeovnv1.IP{ipCR},
+		})
 		require.NoError(t, err)
-		portName := ovs.PodNameToPortName("other-pod", pod.Namespace, provider)
-		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+		fc.fakeController.config.EnableNonPrimaryCNI = true
+		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+		_, _, _, err = fc.fakeController.ipam.GetStaticAddress("default/test-pod", portName, "10.0.0.2", nil, subnet.Name, false)
+		require.NoError(t, err)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{
+			Name: portName,
+			ExternalIDs: map[string]string{
+				"pod": "default/test-pod",
+				"ls":  subnet.Name,
+			},
+		}}, nil)
+		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
 
-		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+		err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
 
 		require.NoError(t, err)
+		updatedPod, err := fc.fakeController.config.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "true", updatedPod.Annotations[providerKey])
 		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
-		assert.Empty(t, details)
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
+		assert.True(t, k8serrors.IsNotFound(err))
+		assert.Empty(t, fc.fakeController.ipam.GetPodAddress("default/test-pod"))
+		event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider=unknown", "subnet="+subnet.Name, "logicalSwitchPort="+portName)
+		assert.NotContains(t, event, "provider="+provider)
+		assert.NotContains(t, event, "provider= ")
+		assertNoPodEvent(t, fc.fakeController)
 	})
 }
 

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1677,7 +1677,7 @@ func TestHandleDeletePodRecordsReleasedPort(t *testing.T) {
 	err = fc.fakeController.handleDeletePod("default/test-pod")
 
 	require.NoError(t, err)
-	assertPodEvent(t, fc.fakeController, "Normal PodNetworkReleased", "logicalSwitchPort=test-pod.default", "subnet=subnet-a")
+	assertPodEvent(t, fc.fakeController, "Normal PodNetworkReleased", "provider=ovn", "subnet=subnet-a", "logicalSwitchPort=test-pod.default")
 }
 
 func TestHandleDeletePodRecordsFailure(t *testing.T) {
@@ -1764,7 +1764,8 @@ func TestHandleDeletePodRetriesOrphanedVMPortIPLookupFailure(t *testing.T) {
 	_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
 	assert.True(t, k8serrors.IsNotFound(err))
 	assert.Empty(t, fc.fakeController.ipam.GetPodAddress("default/test-vm"))
-	assertPodEvent(t, fc.fakeController, "Normal PodNetworkReleased", "logicalSwitchPort="+portName, "ipCR="+portName, "ipam="+portName)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkReleased", "logicalSwitchPort="+portName, "ipCR="+portName, "ipam="+portName)
+	assert.NotContains(t, event, "provider=ovn")
 	assertNoPodEvent(t, fc.fakeController)
 }
 

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -15,10 +15,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/internal"
 	"github.com/kubeovn/kube-ovn/pkg/ipam"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -1507,6 +1509,40 @@ func TestHandleUpdatePodSecuritySkipsNonOVNNetworkWithoutSuccess(t *testing.T) {
 	assertNoPodEvent(t, controller)
 }
 
+func TestHandleUpdatePodSecurityReportsOnlyProcessedOVNNetworks(t *testing.T) {
+	const ipamProvider = "net1.default"
+	pod, ovnSubnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[util.MacAddressAnnotation] = "00:00:00:00:00:01"
+	pod.Annotations[nadv1.NetworkAttachmentAnnot] = `[{"name":"net1"}]`
+	pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, ipamProvider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, ipamProvider)] = "10.1.0.2"
+	ipamSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "ipam-subnet"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Protocol: kubeovnv1.ProtocolIPv4, Provider: ipamProvider,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{ovnSubnet, ipamSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: ipamNADConfig(util.CniTypeName)},
+		}},
+	})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortSecurity(false, portName, "00:00:00:00:00:01", "10.0.0.2", "").Return(nil)
+	fc.mockOvnClient.EXPECT().GetLogicalSwitchPort(portName, false).Return(&ovnnb.LogicalSwitchPort{Name: portName, ExternalIDs: map[string]string{}}, nil)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortExternalIDs(portName, map[string]string{"security_groups": ""}).Return(nil)
+
+	err = fc.fakeController.handleUpdatePodSecurity("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodSecurityUpdated", "provider=ovn", "logicalSwitchPort=test-pod.default")
+	assert.NotContains(t, event, "provider="+ipamProvider)
+	assert.NotContains(t, event, "logicalSwitchPort=test-pod.default.net1.default")
+}
+
 func TestHandleDeletePodRecordsReleasedPort(t *testing.T) {
 	pod, subnet := podEventFixture()
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
@@ -1595,6 +1631,119 @@ func TestHandleAddOrUpdatePodRecordsAllocationDHCPFailureOnce(t *testing.T) {
 	require.EqualError(t, err, "allocate dhcp failed")
 	assertPodEvent(t, fc.fakeController, "Warning PodNetworkAllocationFailed", "stage=reconcilePortDHCPOptions", "allocate dhcp failed")
 	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestReconcileAllocateSubnetsSpecificFailureEventsIncludeStage(t *testing.T) {
+	t.Run("acquire address", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.Error(t, err)
+		assertPodEvent(t, fc.fakeController, "Warning AcquireAddressFailed", "stage=acquireAddress", err.Error())
+	})
+
+	t.Run("validate network broadcast", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		pod.Annotations[util.VipAnnotation] = "broadcast-vip"
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+		vip := &kubeovnv1.Vip{
+			ObjectMeta: metav1.ObjectMeta{Name: "broadcast-vip", Labels: map[string]string{}},
+			Spec:       kubeovnv1.VipSpec{Subnet: subnet.Name},
+			Status:     kubeovnv1.VipStatus{V4ip: "10.0.0.0", Mac: "00:00:00:00:00:01"},
+		}
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Create(context.Background(), vip, metav1.CreateOptions{})
+		require.NoError(t, err)
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		require.NoError(t, indexer.Add(vip))
+		fc.fakeController.virtualIpsLister = kubeovnlister.NewVipLister(indexer)
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.Error(t, err)
+		assertPodEvent(t, fc.fakeController, "Warning ValidatePodNetworkFailed", "stage=validateNetworkBroadcast", err.Error())
+	})
+
+	t.Run("get vlan info", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		subnet.Spec.Vlan = "missing-vlan"
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.Error(t, err)
+		assertPodEvent(t, fc.fakeController, "Warning GetVlanInfoFailed", "stage=getVlanInfo", err.Error())
+	})
+
+	t.Run("create logical switch port", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+		fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+		fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("create port failed"))
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.EqualError(t, err, "create port failed")
+		assertPodEvent(t, fc.fakeController, "Warning CreateOVNPortFailed", "stage=createLogicalSwitchPort", err.Error())
+	})
+
+	t.Run("set logical switch port layer2 forward", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		pod.Annotations[fmt.Sprintf(util.Layer2ForwardAnnotationTemplate, util.OvnProvider)] = "true"
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+		fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+		fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		fc.mockOvnClient.EXPECT().EnablePortLayer2forward(gomock.Any()).Return(errors.New("enable layer2 forward failed"))
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.EqualError(t, err, "enable layer2 forward failed")
+		assertPodEvent(t, fc.fakeController, "Warning SetOVNPortL2ForwardFailed", "stage=setLogicalSwitchPortLayer2Forward", err.Error())
+	})
+}
+
+func TestHandleAddOrUpdatePodReportsActualAllocatedSubnet(t *testing.T) {
+	pod, subnetA := podEventFixture()
+	pod.Annotations = map[string]string{
+		util.IPAddressAnnotation:  "10.1.0.2",
+		util.MacAddressAnnotation: "00:00:00:00:00:01",
+	}
+	subnetB := subnetA.DeepCopy()
+	subnetB.Name = "subnet-b"
+	subnetB.Spec.CIDRBlock = "10.1.0.0/24"
+	subnetB.Spec.Gateway = "10.1.0.1"
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			util.LogicalSwitchAnnotation: "subnet-a,subnet-b",
+		},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:       []*corev1.Pod{pod},
+		Subnets:    []*kubeovnv1.Subnet{subnetA, subnetB},
+		Namespaces: []*corev1.Namespace{namespace},
+	})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnetA.Name, subnetA.Spec.CIDRBlock, subnetA.Spec.Gateway, nil))
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnetB.Name, subnetB.Spec.CIDRBlock, subnetB.Spec.Gateway, nil))
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort("subnet-b", gomock.Any(), "10.1.0.2", "00:00:00:00:00:01", pod.Name, pod.Namespace, false, "", "", false, gomock.Any(), util.DefaultVpc).Return(nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkAllocated", "provider=ovn", "subnet=subnet-b", "ip=10.1.0.2")
+	assert.NotContains(t, event, "subnet=subnet-a")
 }
 
 func TestHandleAddOrUpdatePodRecordsHotplugUpdate(t *testing.T) {
@@ -1821,7 +1970,7 @@ func ipamNADConfig(ipamType string) string {
 	return fmt.Sprintf(`{"cniVersion":"0.3.1","name":"net1","type":"macvlan","ipam":{"type":%q}}`, ipamType)
 }
 
-func assertPodEvent(t *testing.T, controller *Controller, parts ...string) {
+func assertPodEvent(t *testing.T, controller *Controller, parts ...string) string {
 	t.Helper()
 
 	recorder := controller.recorder.(*record.FakeRecorder)
@@ -1830,8 +1979,10 @@ func assertPodEvent(t *testing.T, controller *Controller, parts ...string) {
 		for _, part := range parts {
 			assert.Contains(t, event, part)
 		}
+		return event
 	case <-time.After(time.Second):
 		t.Fatal("expected pod event")
+		return ""
 	}
 }
 

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -2,13 +2,16 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +22,7 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/internal"
 	"github.com/kubeovn/kube-ovn/pkg/ipam"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -1366,7 +1370,7 @@ func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 	err := controller.handleAddOrUpdatePod("default/test-pod")
 	require.Error(t, err)
 
-	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "provider net1.default is not bound to any subnet")
+	assertPodEvent(t, controller, "Warning PodNetworkUpdateFailed", "stage=getPodKubeovnNets", "provider net1.default is not bound to any subnet")
 }
 
 func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
@@ -1386,7 +1390,7 @@ func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 
 	controller.enqueueUpdatePod(oldPod, newPod)
 
-	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "provider net1.default is not bound to any subnet")
+	assertPodEvent(t, controller, "Warning PodNetworkUpdateFailed", "stage=getPodKubeovnNets", "provider net1.default is not bound to any subnet")
 }
 
 func TestHandleUpdatePodSecurityRecordsIPAMSubnetMissingEvent(t *testing.T) {
@@ -1395,7 +1399,332 @@ func TestHandleUpdatePodSecurityRecordsIPAMSubnetMissingEvent(t *testing.T) {
 	err := controller.handleUpdatePodSecurity("default/test-pod")
 	require.Error(t, err)
 
-	assertPodEvent(t, controller, "Warning AcquireAddressFailed", "provider net1.default is not bound to any subnet")
+	assertPodEvent(t, controller, "Warning PodSecurityUpdateFailed", "stage=getPodKubeovnNets", "provider net1.default is not bound to any subnet")
+}
+
+func TestPodNetworkEventDetailsIncludesMultipleNetworks(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			util.IPAddressAnnotation:  "10.0.0.2",
+			util.MacAddressAnnotation: "00:00:00:00:00:01",
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, "net1.default.ovn"):  "10.1.0.2",
+			fmt.Sprintf(util.MacAddressAnnotationTemplate, "net1.default.ovn"): "00:00:00:00:00:02",
+		},
+	}}
+	controller := newFakeController(t).fakeController
+	nets := []*kubeovnNet{
+		{ProviderName: util.OvnProvider, Subnet: &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}},
+		{ProviderName: "net1.default.ovn", Subnet: &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}}},
+	}
+
+	details := controller.podNetworkEventDetails(pod, nets)
+
+	for _, part := range []string{
+		"provider=ovn", "subnet=subnet-a", "ip=10.0.0.2", "mac=00:00:00:00:00:01", "logicalSwitchPort=test-pod.default",
+		"provider=net1.default.ovn", "subnet=subnet-b", "ip=10.1.0.2", "mac=00:00:00:00:00:02", "logicalSwitchPort=test-pod.default.net1.default.ovn",
+		"; ",
+	} {
+		assert.Contains(t, details, part)
+	}
+}
+
+func TestSyncKubeOvnNetReportsAnnotationChange(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: metav1.NamespaceDefault, Annotations: map[string]string{}}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+
+	updatedPod, changed, err := fc.fakeController.syncKubeOvnNet(pod, []*kubeovnNet{{
+		ProviderName: util.OvnProvider,
+		IPRequest:    "10.0.0.2",
+	}})
+
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, "10.0.0.2", updatedPod.Annotations[util.IPAddressAnnotation])
+}
+
+func TestSyncKubeOvnNetReportsNoChange(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:        "test-pod",
+		Namespace:   metav1.NamespaceDefault,
+		Annotations: map[string]string{util.IPAddressAnnotation: "10.0.0.2"},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+
+	_, changed, err := fc.fakeController.syncKubeOvnNet(pod, []*kubeovnNet{{
+		ProviderName: util.OvnProvider,
+		IPRequest:    "10.0.0.2",
+	}})
+
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleUpdatePodSecurityRecordsSuccess(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[util.MacAddressAnnotation] = "00:00:00:00:00:01"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortSecurity(false, portName, "00:00:00:00:00:01", "10.0.0.2", "").Return(nil)
+	fc.mockOvnClient.EXPECT().GetLogicalSwitchPort(portName, false).Return(&ovnnb.LogicalSwitchPort{Name: portName, ExternalIDs: map[string]string{}}, nil)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortExternalIDs(portName, map[string]string{"security_groups": ""}).Return(nil)
+
+	err = fc.fakeController.handleUpdatePodSecurity("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController, "Normal PodSecurityUpdated", "provider=ovn", "subnet=subnet-a", "ip=10.0.0.2", "mac=00:00:00:00:00:01", "logicalSwitchPort=test-pod.default")
+}
+
+func TestHandleUpdatePodSecurityRecordsFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortSecurity(false, portName, "", "", "").Return(errors.New("set security failed"))
+
+	err = fc.fakeController.handleUpdatePodSecurity("default/test-pod")
+
+	require.EqualError(t, err, "set security failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodSecurityUpdateFailed", "stage=setLogicalSwitchPortSecurity", "set security failed")
+}
+
+func TestHandleUpdatePodSecuritySkipsNonOVNNetworkWithoutSuccess(t *testing.T) {
+	controller := newIPAMNetworkController(t)
+
+	err := controller.handleUpdatePodSecurity("default/test-pod")
+
+	require.NoError(t, err)
+	assertNoPodEvent(t, controller)
+}
+
+func TestHandleDeletePodRecordsReleasedPort(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-pod"}).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController, "Normal PodNetworkReleased", "logicalSwitchPort=test-pod.default", "subnet=subnet-a")
+}
+
+func TestHandleDeletePodRecordsFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-pod"}).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(errors.New("delete lsp failed"))
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.EqualError(t, err, "delete lsp failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=deleteLogicalSwitchPort", "delete lsp failed")
+}
+
+func TestHandleDeletePodWithoutResourcesDoesNotRecordSuccess(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-pod"}).Return(nil, nil)
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleDeletePodWithReplacementDoesNotRecordSuccess(t *testing.T) {
+	deletedPod, subnet := podEventFixture()
+	livePod := deletedPod.DeepCopy()
+	livePod.UID = "replacement-uid"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{livePod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	storeDeletingPod(fc.fakeController, deletedPod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleAddOrUpdatePodRecordsAllocationSuccess(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.MacAddressAnnotation] = "00:00:00:00:00:01"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(subnet.Name, portName, gomock.Any(), subnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(subnet.Name, portName, gomock.Any(), gomock.Any(), pod.Name, pod.Namespace, false, "", "", false, gomock.Any(), util.DefaultVpc).Return(nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController, "Normal PodNetworkAllocated", "provider=ovn", "subnet=subnet-a", "ip=10.0.0.", "mac=00:00:00:00:00:01", "logicalSwitchPort=test-pod.default")
+}
+
+func TestHandleAddOrUpdatePodRecordsAllocationDHCPFailureOnce(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(subnet.Name, portName, gomock.Any(), subnet.Spec.CIDRBlock, "", "", "", 0).Return(nil, false, errors.New("allocate dhcp failed"))
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.EqualError(t, err, "allocate dhcp failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkAllocationFailed", "stage=reconcilePortDHCPOptions", "allocate dhcp failed")
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleAddOrUpdatePodRecordsHotplugUpdate(t *testing.T) {
+	const provider = "net1.default.ovn"
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			nadv1.NetworkAttachmentAnnot:                                `[{"name":"net1","ips":["10.1.0.2"]}]`,
+			fmt.Sprintf(util.AllocatedAnnotationTemplate, provider):     "true",
+			fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider): "subnet-b",
+			fmt.Sprintf(util.MacAddressAnnotationTemplate, provider):    "00:00:00:00:00:02",
+			fmt.Sprintf(util.RoutedAnnotationTemplate, provider):        "true",
+		},
+	}}
+	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Gateway: "10.1.0.1", Protocol: kubeovnv1.ProtocolIPv4, Provider: provider, Vpc: util.DefaultVpc,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{subnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion":"0.3.1","name":"net1","type":"kube-ovn","provider":"net1.default.ovn"}`},
+		}},
+	})
+	require.NoError(t, err)
+	fc.fakeController.config.EnableNonPrimaryCNI = true
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(subnet.Name, portName, gomock.Any(), subnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider=net1.default.ovn", "subnet=subnet-b", "ip=10.1.0.2", "mac=00:00:00:00:00:02", "logicalSwitchPort=test-pod.default.net1.default.ovn")
+}
+
+func TestHandleAddOrUpdatePodRecordsDHCPUpdateFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false, errors.New("update dhcp failed"))
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.EqualError(t, err, "update dhcp failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkUpdateFailed", "stage=reconcilePodDHCPOptions", "update dhcp failed")
+}
+
+func TestHandleAddOrUpdatePodRecordsRouteFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Spec.NodeName = "missing-node"
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-node")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkUpdateFailed", "stage=reconcileRouteSubnets", "missing-node")
+}
+
+func TestHandleAddOrUpdatePodWithoutWorkDoesNotRecordSuccess(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func podEventFixture() (*corev1.Pod, *kubeovnv1.Subnet) {
+	return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: metav1.NamespaceDefault, UID: "pod-uid", Annotations: map[string]string{
+				util.LogicalSwitchAnnotation: "subnet-a",
+			}},
+		}, &kubeovnv1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"},
+			Spec: kubeovnv1.SubnetSpec{
+				CIDRBlock: "10.0.0.0/24",
+				Gateway:   "10.0.0.1",
+				Protocol:  kubeovnv1.ProtocolIPv4,
+				Provider:  util.OvnProvider,
+				Vpc:       util.DefaultVpc,
+				Default:   true,
+			},
+			Status: kubeovnv1.SubnetStatus{V4AvailableIPs: internal.NewBigInt(253)},
+		}
+}
+
+func storeDeletingPod(controller *Controller, pod *corev1.Pod) {
+	controller.deletingPodObjMap = xsync.NewMap[string, *corev1.Pod]()
+	controller.deletingPodObjMap.Store("default/test-pod", pod)
+}
+
+func newIPAMNetworkController(t *testing.T) *Controller {
+	t.Helper()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			nadv1.NetworkAttachmentAnnot: `[{"name":"net1"}]`,
+		},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods: []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{{ObjectMeta: metav1.ObjectMeta{Name: "ipam-subnet"}, Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.1.0.0/24", Provider: "net1.default", Protocol: kubeovnv1.ProtocolIPv4,
+		}}},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: ipamNADConfig(util.CniTypeName)},
+		}},
+	})
+	require.NoError(t, err)
+	fc.fakeController.config.EnableNonPrimaryCNI = true
+	return fc.fakeController
 }
 
 func TestGetPodAttachmentNetIgnoresNonKubeOVNIPAMWithoutSubnet(t *testing.T) {
@@ -1503,5 +1832,16 @@ func assertPodEvent(t *testing.T, controller *Controller, parts ...string) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected pod event")
+	}
+}
+
+func assertNoPodEvent(t *testing.T, controller *Controller) {
+	t.Helper()
+
+	recorder := controller.recorder.(*record.FakeRecorder)
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected pod event: %s", event)
+	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -15,9 +15,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
@@ -1438,13 +1443,14 @@ func TestSyncKubeOvnNetReportsAnnotationChange(t *testing.T) {
 	require.NoError(t, err)
 	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
 
-	updatedPod, changed, err := fc.fakeController.syncKubeOvnNet(pod, []*kubeovnNet{{
+	updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, []*kubeovnNet{{
 		ProviderName: util.OvnProvider,
 		IPRequest:    "10.0.0.2",
+		Subnet:       &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}},
 	}})
 
 	require.NoError(t, err)
-	assert.True(t, changed)
+	assert.NotEmpty(t, details)
 	assert.Equal(t, "10.0.0.2", updatedPod.Annotations[util.IPAddressAnnotation])
 }
 
@@ -1458,13 +1464,13 @@ func TestSyncKubeOvnNetReportsNoChange(t *testing.T) {
 	require.NoError(t, err)
 	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
 
-	_, changed, err := fc.fakeController.syncKubeOvnNet(pod, []*kubeovnNet{{
+	_, details, err := fc.fakeController.syncKubeOvnNet(pod, []*kubeovnNet{{
 		ProviderName: util.OvnProvider,
 		IPRequest:    "10.0.0.2",
 	}})
 
 	require.NoError(t, err)
-	assert.False(t, changed)
+	assert.Empty(t, details)
 	assertNoPodEvent(t, fc.fakeController)
 }
 
@@ -1573,6 +1579,76 @@ func TestHandleDeletePodRecordsFailure(t *testing.T) {
 	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=deleteLogicalSwitchPort", "delete lsp failed")
 }
 
+func TestHandleDeletePodRetriesOrphanedVMPortIPLookupFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+	pod.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: kubevirtv1.SchemeGroupVersion.String(),
+		Kind:       util.KindVirtualMachineInstance,
+		Name:       "test-vm",
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.fakeController.config.EnableKeepVMIP = true
+	fc.fakeController.ipsLister = errorIPLister{err: errors.New("get ip failed")}
+
+	mockCtrl := gomock.NewController(t)
+	mockVMIs := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
+	mockVMs := kubecli.NewMockVirtualMachineInterface(mockCtrl)
+	mockKubevirt := kubecli.NewMockKubevirtClient(mockCtrl)
+	mockKubevirt.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(mockVMIs)
+	mockVMIs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(&kubevirtv1.VirtualMachineInstance{}, nil)
+	mockKubevirt.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(mockVMs).Times(2)
+	vm := &kubevirtv1.VirtualMachine{Spec: kubevirtv1.VirtualMachineSpec{Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.LogicalSwitchAnnotation: subnet.Name}},
+		Spec: kubevirtv1.VirtualMachineInstanceSpec{Networks: []kubevirtv1.Network{{
+			Name: "net1",
+			NetworkSource: kubevirtv1.NetworkSource{Multus: &kubevirtv1.MultusNetwork{
+				NetworkName: "default/net1",
+			}},
+		}}},
+	}}}
+	mockVMs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(vm, nil).Times(2)
+	fc.fakeController.config.KubevirtClient = mockKubevirt
+
+	portName := ovs.PodNameToPortName("test-vm", pod.Namespace, "old.default.ovn")
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-vm"}).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().CleanLogicalSwitchPortMigrateOptions(portName).Return(nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.EqualError(t, err, "get ip failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=getIPCR", "get ip failed")
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleDeletePodReportsStatefulSetOwnerCheckStage(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Name = "test-sts-0"
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+	pod.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+		Kind:       util.KindStatefulSet,
+		Name:       "test-sts",
+		UID:        "sts-uid",
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.fakeController.config.KubeClient.(*k8sfake.Clientset).PrependReactor("get", "statefulsets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("get statefulset failed")
+	})
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.EqualError(t, err, "get statefulset failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=checkStatefulSetOwner", "get statefulset failed")
+}
+
 func TestHandleDeletePodWithoutResourcesDoesNotRecordSuccess(t *testing.T) {
 	pod, subnet := podEventFixture()
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
@@ -1615,6 +1691,79 @@ func TestHandleAddOrUpdatePodRecordsAllocationSuccess(t *testing.T) {
 
 	require.NoError(t, err)
 	assertPodEvent(t, fc.fakeController, "Normal PodNetworkAllocated", "provider=ovn", "subnet=subnet-a", "ip=10.0.0.", "mac=00:00:00:00:00:01", "logicalSwitchPort=test-pod.default")
+}
+
+func TestHandleAddOrUpdatePodReportsOnlyAllocatedNetworks(t *testing.T) {
+	const provider = "net1.default.ovn"
+	pod, defaultSubnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[nadv1.NetworkAttachmentAnnot] = `[{"name":"net1"}]`
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] = "subnet-b"
+	attachmentSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Gateway: "10.1.0.1", Protocol: kubeovnv1.ProtocolIPv4, Provider: provider, Vpc: util.DefaultVpc,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{defaultSubnet, attachmentSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion":"0.3.1","name":"net1","type":"kube-ovn","provider":"net1.default.ovn"}`},
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(attachmentSubnet.Name, attachmentSubnet.Spec.CIDRBlock, attachmentSubnet.Spec.Gateway, nil))
+	defaultPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	attachmentPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: defaultPort}}, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(attachmentSubnet.Name, attachmentPort, gomock.Any(), attachmentSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(defaultSubnet.Name, defaultPort, gomock.Any(), defaultSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(attachmentSubnet.Name, attachmentPort, gomock.Any(), gomock.Any(), pod.Name, pod.Namespace, false, "", "", false, gomock.Any(), util.DefaultVpc).Return(nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkAllocated", "provider="+provider, "subnet=subnet-b", "logicalSwitchPort="+attachmentPort)
+	assert.NotContains(t, event, "provider=ovn")
+}
+
+func TestHandleAddOrUpdatePodReportsOnlyRoutedNetworks(t *testing.T) {
+	const provider = "net1.default.ovn"
+	pod, defaultSubnet := podEventFixture()
+	pod.Spec.NodeName = "node-a"
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[nadv1.NetworkAttachmentAnnot] = `[{"name":"net1"}]`
+	pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] = "subnet-b"
+	pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, provider)] = "10.1.0.2"
+	attachmentSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Gateway: "10.1.0.1", Protocol: kubeovnv1.ProtocolIPv4, Provider: provider, Vpc: "other-vpc",
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Nodes:   []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: pod.Spec.NodeName}}},
+		Subnets: []*kubeovnv1.Subnet{defaultSubnet, attachmentSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion":"0.3.1","name":"net1","type":"kube-ovn","provider":"net1.default.ovn"}`},
+		}},
+	})
+	require.NoError(t, err)
+	defaultPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	attachmentPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: defaultPort}, {Name: attachmentPort}}, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(defaultSubnet.Name, defaultPort, gomock.Any(), defaultSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(attachmentSubnet.Name, attachmentPort, gomock.Any(), attachmentSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+	fc.mockOvnClient.EXPECT().ListPortGroups(gomock.Any()).Return(nil, nil).Times(2)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider="+provider, "subnet=subnet-b", "logicalSwitchPort="+attachmentPort)
+	assert.NotContains(t, event, "provider=ovn")
 }
 
 func TestHandleAddOrUpdatePodRecordsAllocationDHCPFailureOnce(t *testing.T) {
@@ -1714,8 +1863,9 @@ func TestReconcileAllocateSubnetsSpecificFailureEventsIncludeStage(t *testing.T)
 func TestHandleAddOrUpdatePodReportsActualAllocatedSubnet(t *testing.T) {
 	pod, subnetA := podEventFixture()
 	pod.Annotations = map[string]string{
-		util.IPAddressAnnotation:  "10.1.0.2",
-		util.MacAddressAnnotation: "00:00:00:00:00:01",
+		util.IPAddressAnnotation:                                      "10.1.0.2",
+		util.MacAddressAnnotation:                                     "00:00:00:00:00:01",
+		fmt.Sprintf(util.PortVipAnnotationTemplate, util.OvnProvider): "10.1.0.100",
 	}
 	subnetB := subnetA.DeepCopy()
 	subnetB.Name = "subnet-b"
@@ -1737,7 +1887,7 @@ func TestHandleAddOrUpdatePodReportsActualAllocatedSubnet(t *testing.T) {
 	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnetB.Name, subnetB.Spec.CIDRBlock, subnetB.Spec.Gateway, nil))
 	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
 	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
-	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort("subnet-b", gomock.Any(), "10.1.0.2", "00:00:00:00:00:01", pod.Name, pod.Namespace, false, "", "", false, gomock.Any(), util.DefaultVpc).Return(nil)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort("subnet-b", gomock.Any(), "10.1.0.2", "00:00:00:00:00:01", pod.Name, pod.Namespace, false, "", "10.1.0.100", false, gomock.Any(), util.DefaultVpc).Return(nil)
 
 	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
 
@@ -1780,6 +1930,35 @@ func TestHandleAddOrUpdatePodRecordsHotplugUpdate(t *testing.T) {
 
 	require.NoError(t, err)
 	assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider=net1.default.ovn", "subnet=subnet-b", "ip=10.1.0.2", "mac=00:00:00:00:00:02", "logicalSwitchPort=test-pod.default.net1.default.ovn")
+}
+
+func TestHandleAddOrUpdatePodReportsRemovedHotplugNetwork(t *testing.T) {
+	const removedProvider = "old.default.ovn"
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, removedProvider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, removedProvider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, removedProvider)] = "subnet-old"
+	pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, removedProvider)] = "10.2.0.2"
+	pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, removedProvider)] = "00:00:00:00:00:03"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	defaultPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	removedPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, removedProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{
+		{Name: defaultPort},
+		{Name: removedPort, ExternalIDs: map[string]string{"ls": "subnet-old"}},
+	}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(removedPort).Return(nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(subnet.Name, defaultPort, gomock.Any(), subnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider="+removedProvider, "subnet=subnet-old", "logicalSwitchPort="+removedPort)
+	assert.NotContains(t, event, "provider=ovn")
 }
 
 func TestHandleAddOrUpdatePodRecordsDHCPUpdateFailure(t *testing.T) {
@@ -1850,6 +2029,18 @@ func podEventFixture() (*corev1.Pod, *kubeovnv1.Subnet) {
 func storeDeletingPod(controller *Controller, pod *corev1.Pod) {
 	controller.deletingPodObjMap = xsync.NewMap[string, *corev1.Pod]()
 	controller.deletingPodObjMap.Store("default/test-pod", pod)
+}
+
+type errorIPLister struct {
+	err error
+}
+
+func (l errorIPLister) List(labels.Selector) ([]*kubeovnv1.IP, error) {
+	return nil, l.err
+}
+
+func (l errorIPLister) Get(string) (*kubeovnv1.IP, error) {
+	return nil, l.err
 }
 
 func newIPAMNetworkController(t *testing.T) *Controller {
@@ -1993,6 +2184,6 @@ func assertNoPodEvent(t *testing.T, controller *Controller) {
 	select {
 	case event := <-recorder.Events:
 		t.Fatalf("unexpected pod event: %s", event)
-	case <-time.After(50 * time.Millisecond):
+	default:
 	}
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1361,7 +1361,7 @@ func TestGetPodAttachmentNetIPAMOnlyNADGone(t *testing.T) {
 }
 
 func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
-	controller := newIPAMSubnetMissingController(t, util.CniTypeName)
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
 
 	err := controller.handleAddOrUpdatePod("default/test-pod")
 	require.Error(t, err)
@@ -1370,7 +1370,7 @@ func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 }
 
 func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
-	controller := newIPAMSubnetMissingController(t, util.CniTypeName)
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
 	oldPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test-pod",
@@ -1390,7 +1390,7 @@ func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 }
 
 func TestHandleUpdatePodSecurityRecordsIPAMSubnetMissingEvent(t *testing.T) {
-	controller := newIPAMSubnetMissingController(t, util.CniTypeName)
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
 
 	err := controller.handleUpdatePodSecurity("default/test-pod")
 	require.Error(t, err)
@@ -1399,7 +1399,7 @@ func TestHandleUpdatePodSecurityRecordsIPAMSubnetMissingEvent(t *testing.T) {
 }
 
 func TestGetPodAttachmentNetIgnoresNonKubeOVNIPAMWithoutSubnet(t *testing.T) {
-	controller := newIPAMSubnetMissingController(t, "host-local")
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig("host-local"))
 	pod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
 	require.NoError(t, err)
 
@@ -1408,7 +1408,54 @@ func TestGetPodAttachmentNetIgnoresNonKubeOVNIPAMWithoutSubnet(t *testing.T) {
 	assert.Empty(t, nets)
 }
 
-func newIPAMSubnetMissingController(t *testing.T, ipamType string) *Controller {
+func TestGetPodAttachmentNetIPAMConflistWithoutSubnet(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr bool
+	}{
+		{
+			name:    "Kube-OVN IPAM returns an error",
+			config:  `{"cniVersion":"0.3.1","name":"net1","plugins":[{"type":"macvlan","ipam":{"type":"kube-ovn"}}]}`,
+			wantErr: true,
+		},
+		{
+			name:   "non-Kube-OVN IPAM is ignored",
+			config: `{"cniVersion":"0.3.1","name":"net1","plugins":[{"type":"macvlan","ipam":{"type":"host-local"}}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := newIPAMSubnetMissingController(t, tt.config)
+			pod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
+			require.NoError(t, err)
+
+			nets, err := controller.getPodAttachmentNet(pod)
+			if tt.wantErr {
+				require.EqualError(t, err, "provider net1.default is not bound to any subnet")
+				return
+			}
+			require.NoError(t, err)
+			assert.Empty(t, nets)
+		})
+	}
+}
+
+func TestGetPodAttachmentNetIgnoresMissingKubeOVNIPAMSubnetForDeletingPod(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
+	pod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
+	require.NoError(t, err)
+	pod = pod.DeepCopy()
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+
+	nets, err := controller.getPodAttachmentNet(pod)
+	require.NoError(t, err)
+	assert.Empty(t, nets)
+}
+
+func newIPAMSubnetMissingController(t *testing.T, config string) *Controller {
 	t.Helper()
 
 	pod := &corev1.Pod{
@@ -1430,7 +1477,7 @@ func newIPAMSubnetMissingController(t *testing.T, ipamType string) *Controller {
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: nadv1.NetworkAttachmentDefinitionSpec{
-					Config: fmt.Sprintf(`{"cniVersion":"0.3.1","name":"net1","type":"macvlan","ipam":{"type":%q}}`, ipamType),
+					Config: config,
 				},
 			},
 		},
@@ -1439,6 +1486,10 @@ func newIPAMSubnetMissingController(t *testing.T, ipamType string) *Controller {
 	controller := fakeController.fakeController
 	controller.config.EnableNonPrimaryCNI = true
 	return controller
+}
+
+func ipamNADConfig(ipamType string) string {
+	return fmt.Sprintf(`{"cniVersion":"0.3.1","name":"net1","type":"macvlan","ipam":{"type":%q}}`, ipamType)
 }
 
 func assertPodEvent(t *testing.T, controller *Controller, parts ...string) {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1474,6 +1475,96 @@ func TestSyncKubeOvnNetReportsNoChange(t *testing.T) {
 	assertNoPodEvent(t, fc.fakeController)
 }
 
+func TestSyncKubeOvnNetParsesStalePortProviders(t *testing.T) {
+	const (
+		provider = "net1.default.ovn"
+		keepKey  = "example.com/keep"
+	)
+
+	t.Run("default OVN port", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{util.AllocatedAnnotation: "true", keepKey: "true"},
+		}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+		require.NoError(t, err)
+		portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "true", updatedPod.Annotations[util.AllocatedAnnotation])
+		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
+		assert.Contains(t, details, "provider="+util.OvnProvider)
+		assert.Contains(t, details, "logicalSwitchPort="+portName)
+	})
+
+	t.Run("attachment provider containing dots", func(t *testing.T) {
+		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
+		}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+		require.NoError(t, err)
+		portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+		require.NoError(t, err)
+		assert.NotContains(t, updatedPod.Annotations, providerKey)
+		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
+		assert.Contains(t, details, "provider="+provider)
+		assert.Contains(t, details, "logicalSwitchPort="+portName)
+	})
+
+	t.Run("VM name containing dots", func(t *testing.T) {
+		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "virt-launcher-test", Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: kubevirtv1.SchemeGroupVersion.String(), Kind: util.KindVirtualMachineInstance, Name: "test.vm",
+			}},
+		}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+		require.NoError(t, err)
+		fc.fakeController.config.EnableKeepVMIP = true
+		portName := ovs.PodNameToPortName("test.vm", pod.Namespace, provider)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+		require.NoError(t, err)
+		assert.NotContains(t, updatedPod.Annotations, providerKey)
+		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
+		assert.Contains(t, details, "provider="+provider)
+		assert.Contains(t, details, "logicalSwitchPort="+portName)
+	})
+
+	t.Run("unmatched pod prefix", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{keepKey: "true"},
+		}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+		require.NoError(t, err)
+		portName := ovs.PodNameToPortName("other-pod", pod.Namespace, provider)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+
+		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
+		assert.Empty(t, details)
+	})
+}
+
 func TestHandleUpdatePodSecurityRecordsSuccess(t *testing.T) {
 	pod, subnet := podEventFixture()
 	pod.Annotations[util.AllocatedAnnotation] = "true"
@@ -1588,18 +1679,28 @@ func TestHandleDeletePodRetriesOrphanedVMPortIPLookupFailure(t *testing.T) {
 		Kind:       util.KindVirtualMachineInstance,
 		Name:       "test-vm",
 	}}
-	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	portName := ovs.PodNameToPortName("test-vm", pod.Namespace, "old.default.ovn")
+	ipCR := &kubeovnv1.IP{ObjectMeta: metav1.ObjectMeta{Name: portName}, Spec: kubeovnv1.IPSpec{
+		PodName: "test-vm", Namespace: pod.Namespace, Subnet: subnet.Name,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}, IPs: []*kubeovnv1.IP{ipCR},
+	})
 	require.NoError(t, err)
 	fc.fakeController.config.EnableKeepVMIP = true
-	fc.fakeController.ipsLister = errorIPLister{err: errors.New("get ip failed")}
+	ipLister := &errorOnceIPLister{ip: ipCR, err: errors.New("get ip failed")}
+	fc.fakeController.ipsLister = ipLister
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	_, _, _, err = fc.fakeController.ipam.GetStaticAddress("default/test-vm", portName, "10.0.0.2", nil, subnet.Name, false)
+	require.NoError(t, err)
 
 	mockCtrl := gomock.NewController(t)
 	mockVMIs := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
 	mockVMs := kubecli.NewMockVirtualMachineInterface(mockCtrl)
 	mockKubevirt := kubecli.NewMockKubevirtClient(mockCtrl)
-	mockKubevirt.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(mockVMIs)
-	mockVMIs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(&kubevirtv1.VirtualMachineInstance{}, nil)
-	mockKubevirt.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(mockVMs).Times(2)
+	mockKubevirt.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(mockVMIs).Times(2)
+	mockVMIs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(&kubevirtv1.VirtualMachineInstance{}, nil).Times(2)
+	mockKubevirt.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(mockVMs).Times(4)
 	vm := &kubevirtv1.VirtualMachine{Spec: kubevirtv1.VirtualMachineSpec{Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.LogicalSwitchAnnotation: subnet.Name}},
 		Spec: kubevirtv1.VirtualMachineInstanceSpec{Networks: []kubevirtv1.Network{{
@@ -1609,19 +1710,36 @@ func TestHandleDeletePodRetriesOrphanedVMPortIPLookupFailure(t *testing.T) {
 			}},
 		}}},
 	}}}
-	mockVMs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(vm, nil).Times(2)
+	mockVMs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(vm, nil).Times(4)
 	fc.fakeController.config.KubevirtClient = mockKubevirt
 
-	portName := ovs.PodNameToPortName("test-vm", pod.Namespace, "old.default.ovn")
-	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-vm"}).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
-	fc.mockOvnClient.EXPECT().CleanLogicalSwitchPortMigrateOptions(portName).Return(nil)
-	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-vm"}).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil).Times(2)
+	fc.mockOvnClient.EXPECT().CleanLogicalSwitchPortMigrateOptions(portName).Return(nil).Times(2)
+	deleteCalls := 0
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).DoAndReturn(func(string) error {
+		deleteCalls++
+		return nil
+	}).AnyTimes()
 	storeDeletingPod(fc.fakeController, pod)
 
 	err = fc.fakeController.handleDeletePod("default/test-pod")
 
 	require.EqualError(t, err, "get ip failed")
 	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=getIPCR", "get ip failed")
+	assertNoPodEvent(t, fc.fakeController)
+	assert.Zero(t, deleteCalls)
+	_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, fc.fakeController.ipam.GetPodAddress("default/test-vm"))
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleteCalls)
+	_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
+	assert.True(t, k8serrors.IsNotFound(err))
+	assert.Empty(t, fc.fakeController.ipam.GetPodAddress("default/test-vm"))
+	assertPodEvent(t, fc.fakeController, "Normal PodNetworkReleased", "logicalSwitchPort="+portName, "ipCR="+portName, "ipam="+portName)
 	assertNoPodEvent(t, fc.fakeController)
 }
 
@@ -1726,6 +1844,57 @@ func TestHandleAddOrUpdatePodReportsOnlyAllocatedNetworks(t *testing.T) {
 	require.NoError(t, err)
 	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkAllocated", "provider="+provider, "subnet=subnet-b", "logicalSwitchPort="+attachmentPort)
 	assert.NotContains(t, event, "provider=ovn")
+}
+
+func TestHandleAddOrUpdatePodCombinesAllocatedAndRemovedNetworks(t *testing.T) {
+	const (
+		allocatedProvider = "net1.default.ovn"
+		removedProvider   = "old.default.ovn"
+	)
+	pod, defaultSubnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[nadv1.NetworkAttachmentAnnot] = `[{"name":"net1"}]`
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, allocatedProvider)] = "subnet-b"
+	pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, removedProvider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, removedProvider)] = "subnet-old"
+	attachmentSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Gateway: "10.1.0.1", Protocol: kubeovnv1.ProtocolIPv4, Provider: allocatedProvider, Vpc: util.DefaultVpc,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{defaultSubnet, attachmentSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion":"0.3.1","name":"net1","type":"kube-ovn","provider":"net1.default.ovn"}`},
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(attachmentSubnet.Name, attachmentSubnet.Spec.CIDRBlock, attachmentSubnet.Spec.Gateway, nil))
+	defaultPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	allocatedPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, allocatedProvider)
+	removedPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, removedProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{
+		{Name: defaultPort},
+		{Name: removedPort, ExternalIDs: map[string]string{"ls": "subnet-old"}},
+	}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(removedPort).Return(nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(attachmentSubnet.Name, allocatedPort, gomock.Any(), attachmentSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(defaultSubnet.Name, defaultPort, gomock.Any(), defaultSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(attachmentSubnet.Name, allocatedPort, gomock.Any(), gomock.Any(), pod.Name, pod.Namespace, false, "", "", false, gomock.Any(), util.DefaultVpc).Return(nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController,
+		"Normal PodNetworkAllocated",
+		"provider="+allocatedProvider,
+		"logicalSwitchPort="+allocatedPort,
+		"provider="+removedProvider,
+		"logicalSwitchPort="+removedPort,
+	)
+	assertNoPodEvent(t, fc.fakeController)
 }
 
 func TestHandleAddOrUpdatePodReportsOnlyRoutedNetworks(t *testing.T) {
@@ -2031,16 +2200,22 @@ func storeDeletingPod(controller *Controller, pod *corev1.Pod) {
 	controller.deletingPodObjMap.Store("default/test-pod", pod)
 }
 
-type errorIPLister struct {
-	err error
+type errorOnceIPLister struct {
+	ip    *kubeovnv1.IP
+	err   error
+	calls int
 }
 
-func (l errorIPLister) List(labels.Selector) ([]*kubeovnv1.IP, error) {
-	return nil, l.err
+func (l *errorOnceIPLister) List(labels.Selector) ([]*kubeovnv1.IP, error) {
+	return []*kubeovnv1.IP{l.ip}, nil
 }
 
-func (l errorIPLister) Get(string) (*kubeovnv1.IP, error) {
-	return nil, l.err
+func (l *errorOnceIPLister) Get(string) (*kubeovnv1.IP, error) {
+	l.calls++
+	if l.calls == 1 {
+		return nil, l.err
+	}
+	return l.ip, nil
 }
 
 func newIPAMNetworkController(t *testing.T) *Controller {

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -39,6 +39,12 @@ const (
 	kernelModuleIP6Tables = "ip6_tables"
 )
 
+var (
+	setInterfaceBandwidth = ovs.SetInterfaceBandwidth
+	configInterfaceMirror = ovs.ConfigInterfaceMirror
+	setNetemQos           = ovs.SetNetemQos
+)
+
 // ControllerRuntime represents runtime specific controller members
 type ControllerRuntime struct {
 	iptables         map[string]*iptables.IPTables
@@ -887,31 +893,35 @@ func (c *Controller) handleUpdatePod(key string) error {
 	ovsEgress := pod.Annotations[util.IngressRateAnnotation]
 	ovsIngressBurst := pod.Annotations[util.EgressBurstAnnotation]
 	ovsEgressBurst := pod.Annotations[util.IngressBurstAnnotation]
-	err = ovs.SetInterfaceBandwidth(podName, pod.Namespace, ifaceID, ovsIngress, ovsEgress, ovsIngressBurst, ovsEgressBurst)
+	err = setInterfaceBandwidth(podName, pod.Namespace, ifaceID, ovsIngress, ovsEgress, ovsIngressBurst, ovsEgressBurst)
 	if err != nil {
 		klog.Error(err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=bandwidth provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
 		return err
 	}
-	err = ovs.ConfigInterfaceMirror(c.config.EnableMirror, pod.Annotations[util.MirrorControlAnnotation], ifaceID)
+	err = configInterfaceMirror(c.config.EnableMirror, pod.Annotations[util.MirrorControlAnnotation], ifaceID)
 	if err != nil {
 		klog.Error(err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
 		return err
 	}
 	// set linux-netem qos
-	err = ovs.SetNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[util.NetemQosLatencyAnnotation], pod.Annotations[util.NetemQosLimitAnnotation], pod.Annotations[util.NetemQosLossAnnotation], pod.Annotations[util.NetemQosJitterAnnotation])
+	err = setNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[util.NetemQosLatencyAnnotation], pod.Annotations[util.NetemQosLimitAnnotation], pod.Annotations[util.NetemQosLossAnnotation], pod.Annotations[util.NetemQosJitterAnnotation])
 	if err != nil {
 		klog.Error(err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
 		return err
 	}
+	processed := []string{fmt.Sprintf("provider=%s interface=%s", util.OvnProvider, ifaceID)}
 
 	// set multus-nic bandwidth
 	attachNets, err := nadutils.ParsePodNetworkAnnotation(pod)
 	if err != nil {
-		if _, ok := err.(*nadv1.NoK8sNetworkError); ok {
-			return nil
+		if _, ok := err.(*nadv1.NoK8sNetworkError); !ok {
+			klog.Error(err)
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=parseNetworkAttachment provider=unknown interface=unknown node=%s: %v", c.config.NodeName, err)
+			return err
 		}
-		klog.Error(err)
-		return err
 	}
 	for _, multiNet := range attachNets {
 		provider := fmt.Sprintf("%s.%s.%s", multiNet.Name, multiNet.Namespace, util.OvnProvider)
@@ -921,28 +931,33 @@ func (c *Controller) handleUpdatePod(key string) error {
 		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] == "true" {
 			ifaceID = ovs.PodNameToPortName(podName, pod.Namespace, provider)
 
-			err = ovs.SetInterfaceBandwidth(podName, pod.Namespace, ifaceID,
+			err = setInterfaceBandwidth(podName, pod.Namespace, ifaceID,
 				pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)],
 				pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)],
 				pod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, provider)],
 				pod.Annotations[fmt.Sprintf(util.IngressBurstAnnotationTemplate, provider)])
 			if err != nil {
 				klog.Error(err)
+				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=bandwidth provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
-			err = ovs.ConfigInterfaceMirror(c.config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, provider)], ifaceID)
+			err = configInterfaceMirror(c.config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, provider)], ifaceID)
 			if err != nil {
 				klog.Error(err)
+				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
-			err = ovs.SetNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)])
+			err = setNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)])
 			if err != nil {
 				klog.Error(err)
+				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
+			processed = append(processed, fmt.Sprintf("provider=%s interface=%s", provider, ifaceID))
 		}
 	}
 
+	c.recorder.Eventf(pod, v1.EventTypeNormal, "PodQoSUpdated", "Updated pod QoS: node=%s %s", c.config.NodeName, strings.Join(processed, ", "))
 	return nil
 }
 

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -925,13 +925,13 @@ func (c *Controller) handleUpdatePod(key string) error {
 	}
 	for _, multiNet := range attachNets {
 		provider := fmt.Sprintf("%s.%s.%s", multiNet.Name, multiNet.Namespace, util.OvnProvider)
+		multiNetPodName := pod.Name
 		if pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)] != "" {
-			podName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)]
+			multiNetPodName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)]
 		}
 		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] == "true" {
-			ifaceID = ovs.PodNameToPortName(podName, pod.Namespace, provider)
-
-			err = setInterfaceBandwidth(podName, pod.Namespace, ifaceID,
+			ifaceID = ovs.PodNameToPortName(multiNetPodName, pod.Namespace, provider)
+			err = setInterfaceBandwidth(multiNetPodName, pod.Namespace, ifaceID,
 				pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)],
 				pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)],
 				pod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, provider)],
@@ -947,7 +947,7 @@ func (c *Controller) handleUpdatePod(key string) error {
 				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
-			err = setNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)])
+			err = setNetemQos(multiNetPodName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)])
 			if err != nil {
 				klog.Error(err)
 				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)

--- a/pkg/daemon/controller_linux_test.go
+++ b/pkg/daemon/controller_linux_test.go
@@ -171,6 +171,29 @@ func TestHandleUpdatePodSuccessEmitsOneEventWithProcessedInterfaces(t *testing.T
 	requireNoPodEvent(t, recorder)
 }
 
+func TestHandleUpdatePodKeepsMultusPodNamesIndependent(t *testing.T) {
+	pod := newPodQoSTestPod("default/net1,default/net2")
+	pod.Annotations["net1.default.ovn.kubernetes.io/virtualmachine"] = "vm-one"
+	pod.Annotations["net2.default.ovn.kubernetes.io/allocated"] = "true"
+	calls := stubPodQoSFunctions(t, "", "", nil)
+	controller, recorder := newPodQoSTestController(t, pod)
+
+	require.NoError(t, controller.handleUpdatePod("default/pod"))
+	expectedInterfaces := []string{
+		"pod.default",
+		"vm-one.default.net1.default.ovn",
+		"pod.default.net2.default.ovn",
+	}
+	for _, stage := range []string{"bandwidth", "mirror", "netem"} {
+		require.Equal(t, expectedInterfaces, calls[stage])
+	}
+	requirePodEvent(t, recorder,
+		"Normal", "PodQoSUpdated",
+		"provider=net1.default.ovn interface=vm-one.default.net1.default.ovn",
+		"provider=net2.default.ovn interface=pod.default.net2.default.ovn")
+	requireNoPodEvent(t, recorder)
+}
+
 func TestHandleUpdatePodNetworkAttachmentParseFailureEmitsOneEvent(t *testing.T) {
 	stubPodQoSFunctions(t, "", "", nil)
 	pod := newPodQoSTestPod("[")

--- a/pkg/daemon/controller_linux_test.go
+++ b/pkg/daemon/controller_linux_test.go
@@ -1,9 +1,12 @@
 package daemon
 
 import (
+	"errors"
 	"net"
 	"testing"
+	"time"
 
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -11,10 +14,246 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func newPodQoSTestController(t *testing.T, pod *v1.Pod) (*Controller, *record.FakeRecorder) {
+	t.Helper()
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	require.NoError(t, indexer.Add(pod))
+	recorder := record.NewFakeRecorder(10)
+	return &Controller{
+		config:     &Configuration{NodeName: "node-a"},
+		podsLister: listerv1.NewPodLister(indexer),
+		recorder:   recorder,
+	}, recorder
+}
+
+func requirePodEvent(t *testing.T, recorder *record.FakeRecorder, parts ...string) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		for _, part := range parts {
+			require.Contains(t, event, part)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected pod event")
+	}
+}
+
+func requireNoPodEvent(t *testing.T, recorder *record.FakeRecorder) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected pod event: %s", event)
+	default:
+	}
+}
+
+func TestHandleUpdatePodValidationFailureEmitsOnlyValidationEvent(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "pod",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			util.IPAddressAnnotation: "invalid",
+		},
+	}}
+	controller, recorder := newPodQoSTestController(t, pod)
+
+	require.Error(t, controller.handleUpdatePod("default/pod"))
+	requirePodEvent(t, recorder, "Warning", "ValidatePodNetworkFailed", "invalid")
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodBandwidthFailureEmitsQoSFailureEvent(t *testing.T) {
+	failErr := errors.New("default bandwidth failure")
+	stubPodQoSFunctions(t, "bandwidth", "pod.default", failErr)
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:        "pod",
+		Namespace:   metav1.NamespaceDefault,
+		Annotations: map[string]string{},
+	}}
+	controller, recorder := newPodQoSTestController(t, pod)
+
+	require.ErrorIs(t, controller.handleUpdatePod("default/pod"), failErr)
+	requirePodEvent(t, recorder,
+		"Warning", "PodQoSUpdateFailed", "stage=bandwidth", "provider=ovn",
+		"interface=pod.default", "node=node-a", failErr.Error())
+	requireNoPodEvent(t, recorder)
+}
+
+func stubPodQoSFunctions(t *testing.T, failStage, failInterface string, failErr error) map[string][]string {
+	t.Helper()
+
+	originalBandwidth := setInterfaceBandwidth
+	originalMirror := configInterfaceMirror
+	originalNetem := setNetemQos
+	t.Cleanup(func() {
+		setInterfaceBandwidth = originalBandwidth
+		configInterfaceMirror = originalMirror
+		setNetemQos = originalNetem
+	})
+
+	calls := map[string][]string{}
+	setInterfaceBandwidth = func(_, _, iface, _, _, _, _ string) error {
+		calls["bandwidth"] = append(calls["bandwidth"], iface)
+		if failStage == "bandwidth" && iface == failInterface {
+			return failErr
+		}
+		return nil
+	}
+	configInterfaceMirror = func(_ bool, _, iface string) error {
+		calls["mirror"] = append(calls["mirror"], iface)
+		if failStage == "mirror" && iface == failInterface {
+			return failErr
+		}
+		return nil
+	}
+	setNetemQos = func(_, _, iface, _, _, _, _ string) error {
+		calls["netem"] = append(calls["netem"], iface)
+		if failStage == "netem" && iface == failInterface {
+			return failErr
+		}
+		return nil
+	}
+	return calls
+}
+
+func newPodQoSTestPod(networkAnnotation string) *v1.Pod {
+	annotations := map[string]string{}
+	if networkAnnotation != "" {
+		annotations[nadv1.NetworkAttachmentAnnot] = networkAnnotation
+		annotations["net1.default.ovn.kubernetes.io/allocated"] = "true"
+	}
+	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:        "pod",
+		Namespace:   metav1.NamespaceDefault,
+		Annotations: annotations,
+	}}
+}
+
+func TestHandleUpdatePodQoSCallFailuresEmitOneEvent(t *testing.T) {
+	const multusInterface = "pod.default.net1.default.ovn"
+	failErr := errors.New("injected QoS failure")
+
+	for _, stage := range []string{"bandwidth", "mirror", "netem"} {
+		t.Run(stage, func(t *testing.T) {
+			calls := stubPodQoSFunctions(t, stage, multusInterface, failErr)
+			controller, recorder := newPodQoSTestController(t, newPodQoSTestPod("default/net1"))
+
+			require.ErrorIs(t, controller.handleUpdatePod("default/pod"), failErr)
+			require.Contains(t, calls[stage], multusInterface)
+			requirePodEvent(t, recorder,
+				"Warning", "PodQoSUpdateFailed", "stage="+stage,
+				"provider=net1.default.ovn", "interface="+multusInterface,
+				"node=node-a", failErr.Error())
+			requireNoPodEvent(t, recorder)
+		})
+	}
+}
+
+func TestHandleUpdatePodSuccessEmitsOneEventWithProcessedInterfaces(t *testing.T) {
+	calls := stubPodQoSFunctions(t, "", "", nil)
+	controller, recorder := newPodQoSTestController(t, newPodQoSTestPod("default/net1"))
+
+	require.NoError(t, controller.handleUpdatePod("default/pod"))
+	require.Equal(t, []string{"pod.default", "pod.default.net1.default.ovn"}, calls["netem"])
+	requirePodEvent(t, recorder,
+		"Normal", "PodQoSUpdated", "node=node-a",
+		"provider=ovn interface=pod.default",
+		"provider=net1.default.ovn interface=pod.default.net1.default.ovn")
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodNetworkAttachmentParseFailureEmitsOneEvent(t *testing.T) {
+	stubPodQoSFunctions(t, "", "", nil)
+	pod := newPodQoSTestPod("[")
+	controller, recorder := newPodQoSTestController(t, pod)
+
+	err := controller.handleUpdatePod("default/pod")
+	require.Error(t, err)
+	requirePodEvent(t, recorder,
+		"Warning", "PodQoSUpdateFailed", "stage=parseNetworkAttachment",
+		"provider=unknown", "interface=unknown", "node=node-a", err.Error())
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodWithoutMultusEmitsDefaultInterfaceSuccess(t *testing.T) {
+	stubPodQoSFunctions(t, "", "", nil)
+	controller, recorder := newPodQoSTestController(t, newPodQoSTestPod(""))
+
+	require.NoError(t, controller.handleUpdatePod("default/pod"))
+	requirePodEvent(t, recorder,
+		"Normal", "PodQoSUpdated", "node=node-a", "provider=ovn interface=pod.default")
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodNotFoundEmitsNoEvent(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	recorder := record.NewFakeRecorder(1)
+	controller := &Controller{
+		config:     &Configuration{NodeName: "node-a"},
+		podsLister: listerv1.NewPodLister(indexer),
+		recorder:   recorder,
+	}
+
+	require.NoError(t, controller.handleUpdatePod("default/missing"))
+	requireNoPodEvent(t, recorder)
+}
+
+func TestEnqueueUpdatePodOnlyQueuesRelevantAnnotationChanges(t *testing.T) {
+	basePod := newPodQoSTestPod("default/net1")
+	basePod.Annotations[util.IngressRateAnnotation] = "10"
+	basePod.Annotations[util.MirrorControlAnnotation] = "true"
+	basePod.Annotations[util.NetemQosLatencyAnnotation] = "5"
+	basePod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	basePod.Annotations["net1.default.ovn.kubernetes.io/ingress_rate"] = "20"
+
+	tests := []struct {
+		name       string
+		annotation string
+		value      string
+		wantQueue  bool
+	}{
+		{name: "unchanged", wantQueue: false},
+		{name: "unrelated annotation", annotation: "example.com/unrelated", value: "changed", wantQueue: false},
+		{name: "default bandwidth", annotation: util.IngressRateAnnotation, value: "11", wantQueue: true},
+		{name: "default mirror", annotation: util.MirrorControlAnnotation, value: "false", wantQueue: true},
+		{name: "default netem", annotation: util.NetemQosLatencyAnnotation, value: "6", wantQueue: true},
+		{name: "default IP", annotation: util.IPAddressAnnotation, value: "10.0.0.3", wantQueue: true},
+		{name: "multus bandwidth", annotation: "net1.default.ovn.kubernetes.io/ingress_rate", value: "21", wantQueue: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldPod := basePod.DeepCopy()
+			newPod := basePod.DeepCopy()
+			if tt.annotation != "" {
+				newPod.Annotations[tt.annotation] = tt.value
+			}
+			recorder := record.NewFakeRecorder(1)
+			controller := &Controller{
+				updatePodQueue: newTypedRateLimitingQueue[string]("test-update-pod", nil),
+				recorder:       recorder,
+			}
+			t.Cleanup(controller.updatePodQueue.ShutDown)
+
+			controller.enqueueUpdatePod(oldPod, newPod)
+			if tt.wantQueue {
+				require.Equal(t, 1, controller.updatePodQueue.Len())
+			} else {
+				require.Zero(t, controller.updatePodQueue.Len())
+			}
+			requireNoPodEvent(t, recorder)
+		})
+	}
+}
 
 func newPodForPolicyRouting(name, namespace, subnetName, podIP string, podIPs []v1.PodIP) *v1.Pod {
 	return &v1.Pod{

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -91,7 +91,7 @@ func (csh cniServerHandler) recordCNIPodEvent(pod *v1.Pod, podRequest *request.C
 	if ifName == "" {
 		ifName = "eth0"
 	}
-	details := []string{podRequest.ContainerID, podRequest.NetNs}
+	details := []string{podRequest.ContainerID, podRequest.NetNs, podRequest.DeviceID}
 	details = append(details, cniEventInterfaceNames(podRequest.ContainerID, podRequest.IfName)...)
 	for _, detail := range details {
 		if detail != "" {

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -46,6 +46,32 @@ func createCniServerHandler(config *Configuration, controller *Controller) *cniS
 	return csh
 }
 
+func podForCNIEvent(pod *v1.Pod, podRequest *request.CniRequest) *v1.Pod {
+	if pod != nil {
+		return pod
+	}
+	return &v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: podRequest.PodNamespace,
+			Name:      podRequest.PodName,
+		},
+	}
+}
+
+func (csh cniServerHandler) recordCNIPodEvent(pod *v1.Pod, podRequest *request.CniRequest, eventType, reason, message string) {
+	ifName := podRequest.IfName
+	if ifName == "" {
+		ifName = "eth0"
+	}
+	for _, detail := range []string{podRequest.ContainerID, podRequest.NetNs} {
+		if detail != "" {
+			message = strings.ReplaceAll(message, detail, "<redacted>")
+		}
+	}
+	csh.Controller.recorder.Eventf(pod, eventType, reason, "%s provider=%s interface=%s node=%s", message, podRequest.Provider, ifName, csh.Config.NodeName)
+}
+
 // gatewayForCNIIPFamily returns only the gateway entries matching the address
 // families configured on the container interface. A single-family pod can still
 // carry a dual-stack subnet gateway annotation, but CNI route and gateway checks
@@ -115,11 +141,16 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 		return
 	}
+	eventPod := podForCNIEvent(nil, &podRequest)
+	recordFailure := func(stage string, err error) {
+		csh.recordCNIPodEvent(eventPod, &podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed", fmt.Sprintf("stage=%s error=%v", stage, err))
+	}
 	klog.V(5).Infof("request body is %v", podRequest)
 	podSubnet, exist := csh.providerExists(podRequest.Provider, podRequest.IfName)
 	if !exist {
 		errMsg := fmt.Errorf("provider %s is not bound to any subnet", podRequest.Provider)
 		klog.Error(errMsg)
+		recordFailure("provider", errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -129,6 +160,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	klog.Infof("add port request: %v", podRequest)
 	if err := csh.validatePodRequest(&podRequest); err != nil {
 		klog.Error(err)
+		recordFailure("validate-request", err)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -149,11 +181,13 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if pod, err = csh.Controller.podsLister.Pods(podRequest.PodNamespace).Get(podRequest.PodName); err != nil {
 			errMsg := fmt.Errorf("get pod %s/%s failed %w", podRequest.PodNamespace, podRequest.PodName, err)
 			klog.Error(errMsg)
+			recordFailure("get-pod", errMsg)
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
 			return
 		}
+		eventPod = pod
 
 		// in case of multiple nics from same subnet
 		_, ok := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerWithIfName)]
@@ -200,6 +234,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if err != nil {
 			errMsg := fmt.Errorf("failed to get ip address with mask, %w", err)
 			klog.Error(errMsg)
+			recordFailure("parse-address", errMsg)
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -212,6 +247,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			if err = json.Unmarshal([]byte(s), &routes); err != nil {
 				errMsg := fmt.Errorf("invalid routes for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 				klog.Error(errMsg)
+				recordFailure("parse-routes", errMsg)
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)
 				}
@@ -234,6 +270,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			nicType = util.DpdkType
 			if err = createShortSharedDir(pod, podRequest.VhostUserSocketVolumeName, podRequest.VhostUserSocketConsumption, csh.Config.KubeletDir); err != nil {
 				klog.Error(err.Error())
+				recordFailure("prepare-dpdk", err)
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)
 				}
@@ -269,6 +306,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	if !macOnly && util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate, appendIfName) == "" {
 		err := fmt.Errorf("no address allocated to pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
 		klog.Error(err)
+		recordFailure("wait-address", err)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -280,6 +318,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	}
 	if !noIPAM {
 		if err := csh.UpdateIPCR(podRequest, subnet, ip, appendIfName); err != nil {
+			recordFailure("update-ip-cr", err)
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -290,6 +329,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	if !macOnly && isDefaultRoute && pod.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, podRequest.Provider)] != "true" && util.IsOvnProvider(podRequest.Provider) {
 		err := fmt.Errorf("route is not ready for pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
 		klog.Error(err)
+		recordFailure("wait-route", err)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -303,6 +343,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if err != nil {
 			errMsg := fmt.Errorf("failed to get subnet %s: %w", subnet, err)
 			klog.Error(errMsg)
+			recordFailure("get-subnet", errMsg)
 			if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response: %v", err)
 			}
@@ -312,6 +353,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if podSubnet.Status.U2OInterconnectionIP == "" && podSubnet.Spec.U2OInterconnection {
 			errMsg := fmt.Errorf("failed to generate u2o ip on subnet %s", podSubnet.Name)
 			klog.Error(errMsg)
+			recordFailure("u2o-address", errMsg)
 			return
 		}
 
@@ -351,6 +393,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 				if err != nil {
 					errMsg := fmt.Errorf("failed to get node %s: %w", csh.Config.NodeName, err)
 					klog.Error(errMsg)
+					recordFailure("get-node", errMsg)
 					if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 						klog.Errorf("failed to write response: %v", err)
 					}
@@ -366,6 +409,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 					}
 					if errMsg != nil {
 						klog.Error(errMsg)
+						recordFailure("mtu", errMsg)
 						if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 							klog.Errorf("failed to write response: %v", err)
 						}
@@ -397,6 +441,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			if err != nil {
 				errMsg := fmt.Errorf("failed to get encap IP for node network %s: %w", podSubnet.Spec.NodeNetwork, err)
 				klog.Error(errMsg)
+				recordFailure("encap-ip", errMsg)
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)
 				}
@@ -419,6 +464,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if err != nil {
 			errMsg := fmt.Errorf("configure nic %s for pod %s/%s failed: %w", ifName, podRequest.PodName, podRequest.PodNamespace, err)
 			klog.Error(errMsg)
+			recordFailure("configure-nic", errMsg)
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -428,12 +474,14 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		ifaceID := ovs.PodNameToPortName(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider)
 		if err = ovs.ConfigInterfaceMirror(csh.Config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, podRequest.Provider)], ifaceID); err != nil {
 			klog.Errorf("failed mirror to mirror0, %v", err)
+			recordFailure("mirror", err)
 			return
 		}
 
 		if err = csh.Controller.addEgressConfig(podSubnet, ip); err != nil {
 			errMsg := fmt.Errorf("failed to add egress configuration: %w", err)
 			klog.Error(errMsg)
+			recordFailure("egress", errMsg)
 			if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -457,6 +505,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			if err = csh.removeDefaultRoute(podRequest.NetNs, hasDefaultRoute[kubeovnv1.ProtocolIPv4], hasDefaultRoute[kubeovnv1.ProtocolIPv6]); err != nil {
 				errMsg := fmt.Errorf("failed to remove existing default route for interface %s of pod %s/%s: %w", podRequest.IfName, podRequest.PodNamespace, podRequest.PodName, err)
 				klog.Error(errMsg)
+				recordFailure("remove-default-route", errMsg)
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)
 				}
@@ -492,6 +541,11 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		Routes:     routes,
 		Mtu:        mtu,
 	}
+	eventMAC := macAddr
+	if eventMAC == "" {
+		eventMAC = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.MacAddressAnnotationTemplate, appendIfName)
+	}
+	csh.recordCNIPodEvent(eventPod, &podRequest, v1.EventTypeNormal, "PodNetworkConfigured", fmt.Sprintf("subnet=%s ip=%s mac=%s", subnet, ip, eventMAC))
 	if err := resp.WriteHeaderAndEntity(http.StatusOK, response); err != nil {
 		klog.Errorf("failed to write response, %v", err)
 	}
@@ -552,16 +606,24 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		}
 		return
 	}
+	eventPod := podForCNIEvent(nil, &podRequest)
+	recordFailure := func(stage string, err error) {
+		csh.recordCNIPodEvent(eventPod, &podRequest, v1.EventTypeWarning, "PodNetworkRemoveFailed", fmt.Sprintf("stage=%s error=%v", stage, err))
+	}
 
 	// Try to get the Pod, but if it fails due to not being found, log a warning and continue.
 	pod, err := csh.Controller.podsLister.Pods(podRequest.PodNamespace).Get(podRequest.PodName)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		errMsg := fmt.Errorf("failed to retrieve Pod %s/%s: %w", podRequest.PodNamespace, podRequest.PodName, err)
 		klog.Error(errMsg)
+		recordFailure("get-pod", errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
 		return
+	}
+	if pod != nil {
+		eventPod = pod
 	}
 
 	providerWithIfName := fmt.Sprintf("%s.%s", podRequest.Provider, podRequest.IfName)
@@ -574,6 +636,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 	klog.Infof("del port request: %v", podRequest)
 	if err := csh.validatePodRequest(&podRequest); err != nil {
 		klog.Error(err)
+		recordFailure("validate-request", err)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -596,6 +659,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 				if err = csh.Controller.removeEgressConfig(subnet, ip); err != nil {
 					errMsg := fmt.Errorf("failed to remove egress configuration: %w", err)
 					klog.Error(errMsg)
+					recordFailure("remove-egress", errMsg)
 					if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 						klog.Errorf("failed to write response, %v", err)
 					}
@@ -610,6 +674,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 				nicType = util.DpdkType
 				if err = removeShortSharedDir(pod, podRequest.VhostUserSocketVolumeName, podRequest.VhostUserSocketConsumption); err != nil {
 					klog.Error(err.Error())
+					recordFailure("remove-dpdk-dir", err)
 					if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 						klog.Errorf("failed to write response: %v", err)
 					}
@@ -647,10 +712,12 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 	if err != nil {
 		errMsg := fmt.Errorf("del nic failed %w", err)
 		klog.Error(errMsg)
+		recordFailure("delete-nic", errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
 		return
 	}
+	csh.recordCNIPodEvent(eventPod, &podRequest, v1.EventTypeNormal, "PodNetworkRemoved", "removed pod network")
 	resp.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -59,12 +59,41 @@ func podForCNIEvent(pod *v1.Pod, podRequest *request.CniRequest) *v1.Pod {
 	}
 }
 
+func cniEventInterfaceNames(containerID, ifName string) []string {
+	ifNames := []string{ifName}
+	if ifName == "" {
+		ifNames = append(ifNames, "eth0")
+	}
+
+	var names []string
+	for _, name := range ifNames {
+		if name == "eth0" {
+			if len(containerID) >= 12 {
+				names = append(names, containerID[:12]+"_h", containerID[:12]+"_c")
+			}
+			continue
+		}
+		if strings.HasPrefix(name, "pod") && len(name) == 14 {
+			name = name[3 : len(name)-4]
+		}
+		prefixLen := 12 - len(name)
+		if prefixLen < 0 || len(containerID) < prefixLen {
+			continue
+		}
+		prefix := containerID[:prefixLen] + "_" + name
+		names = append(names, prefix+"_h", prefix+"_c")
+	}
+	return names
+}
+
 func (csh cniServerHandler) recordCNIPodEvent(pod *v1.Pod, podRequest *request.CniRequest, eventType, reason, message string) {
 	ifName := podRequest.IfName
 	if ifName == "" {
 		ifName = "eth0"
 	}
-	for _, detail := range []string{podRequest.ContainerID, podRequest.NetNs} {
+	details := []string{podRequest.ContainerID, podRequest.NetNs}
+	details = append(details, cniEventInterfaceNames(podRequest.ContainerID, podRequest.IfName)...)
+	for _, detail := range details {
 		if detail != "" {
 			message = strings.ReplaceAll(message, detail, "<redacted>")
 		}

--- a/pkg/daemon/handler_test.go
+++ b/pkg/daemon/handler_test.go
@@ -86,11 +86,11 @@ func TestRecordCNIPodEventRedactsRuntimeDetails(t *testing.T) {
 	handler := cniEventTestHandler(t, nil, nil, recorder)
 	podRequest := &request.CniRequest{
 		PodName: "pod", PodNamespace: "ns", Provider: "provider",
-		ContainerID: "1234567890abcdef", NetNs: "/runtime/netns/pod",
+		ContainerID: "1234567890abcdef", NetNs: "/runtime/netns/pod", DeviceID: "0000:65:00.1",
 	}
 	handler.recordCNIPodEvent(
 		podForCNIEvent(nil, podRequest), podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed",
-		`stage=configure-nic error=failed on 1234567890ab_h in /runtime/netns/pod for 1234567890abcdef: boom`,
+		`stage=configure-nic error=failed on device 0000:65:00.1 and 1234567890ab_h in /runtime/netns/pod for 1234567890abcdef: boom`,
 	)
 
 	event := requireSingleCNIEvent(t, recorder)
@@ -100,6 +100,7 @@ func TestRecordCNIPodEventRedactsRuntimeDetails(t *testing.T) {
 	require.NotContains(t, event.message, "1234567890ab")
 	require.NotContains(t, event.message, podRequest.ContainerID)
 	require.NotContains(t, event.message, podRequest.NetNs)
+	require.NotContains(t, event.message, podRequest.DeviceID)
 }
 
 func TestRecordCNIPodEventHandlesUnsafeDerivedNameInputs(t *testing.T) {

--- a/pkg/daemon/handler_test.go
+++ b/pkg/daemon/handler_test.go
@@ -90,14 +90,31 @@ func TestRecordCNIPodEventRedactsRuntimeDetails(t *testing.T) {
 	}
 	handler.recordCNIPodEvent(
 		podForCNIEvent(nil, podRequest), podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed",
-		`stage=configure-nic error=failed in /runtime/netns/pod for 1234567890abcdef: boom`,
+		`stage=configure-nic error=failed on 1234567890ab_h in /runtime/netns/pod for 1234567890abcdef: boom`,
 	)
 
 	event := requireSingleCNIEvent(t, recorder)
 	require.Contains(t, event.message, "stage=configure-nic")
 	require.Contains(t, event.message, "boom")
+	require.NotContains(t, event.message, "1234567890ab_h")
+	require.NotContains(t, event.message, "1234567890ab")
 	require.NotContains(t, event.message, podRequest.ContainerID)
 	require.NotContains(t, event.message, podRequest.NetNs)
+}
+
+func TestRecordCNIPodEventHandlesUnsafeDerivedNameInputs(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+	podRequest := &request.CniRequest{
+		PodName: "pod", PodNamespace: "ns", Provider: "provider",
+		ContainerID: "short", IfName: "interface-name-longer-than-twelve",
+	}
+	require.NotPanics(t, func() {
+		handler.recordCNIPodEvent(
+			podForCNIEvent(nil, podRequest), podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed", "stage=configure-nic error=boom",
+		)
+	})
+	require.Contains(t, requireSingleCNIEvent(t, recorder).message, "error=boom")
 }
 
 func TestHandleAddSuccessEvent(t *testing.T) {
@@ -200,6 +217,8 @@ func TestHandleDelFailureEvent(t *testing.T) {
 	require.Equal(t, "PodNetworkRemoveFailed", event.reason)
 	require.Contains(t, event.message, "stage=delete-nic")
 	require.Contains(t, event.message, "exit status 1")
+	require.NotContains(t, event.message, "12345678_net1_h")
+	require.NotContains(t, event.message, "12345678")
 	pod := event.object.(*v1.Pod)
 	require.Equal(t, "deleted", pod.Name)
 	require.Equal(t, "ns", pod.Namespace)

--- a/pkg/daemon/handler_test.go
+++ b/pkg/daemon/handler_test.go
@@ -1,0 +1,282 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/request"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+type recordedCNIEvent struct {
+	object    runtime.Object
+	eventType string
+	reason    string
+	message   string
+}
+
+type cniEventRecorder struct {
+	events []recordedCNIEvent
+}
+
+func (r *cniEventRecorder) Event(object runtime.Object, eventType, reason, message string) {
+	r.events = append(r.events, recordedCNIEvent{object: object, eventType: eventType, reason: reason, message: message})
+}
+
+func (r *cniEventRecorder) Eventf(object runtime.Object, eventType, reason, messageFmt string, args ...any) {
+	r.Event(object, eventType, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (r *cniEventRecorder) AnnotatedEventf(object runtime.Object, _ map[string]string, eventType, reason, messageFmt string, args ...any) {
+	r.Eventf(object, eventType, reason, messageFmt, args...)
+}
+
+func TestPodForCNIEvent(t *testing.T) {
+	t.Run("real pod", func(t *testing.T) {
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns", UID: types.UID("uid")}}
+		require.Same(t, pod, podForCNIEvent(pod, &request.CniRequest{}))
+		require.Equal(t, types.UID("uid"), podForCNIEvent(pod, &request.CniRequest{}).UID)
+	})
+
+	t.Run("synthetic pod", func(t *testing.T) {
+		pod := podForCNIEvent(nil, &request.CniRequest{PodName: "pod", PodNamespace: "ns"})
+		require.Equal(t, "v1", pod.APIVersion)
+		require.Equal(t, "Pod", pod.Kind)
+		require.Equal(t, "ns", pod.Namespace)
+		require.Equal(t, "pod", pod.Name)
+	})
+}
+
+func TestRecordCNIPodEvent(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+	podRequest := &request.CniRequest{PodName: "pod", PodNamespace: "ns", Provider: "provider"}
+	handler.recordCNIPodEvent(podForCNIEvent(nil, podRequest), podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed", "stage=get-pod error=boom")
+
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeWarning, event.eventType)
+	require.Equal(t, "PodNetworkConfigureFailed", event.reason)
+	require.Contains(t, event.message, "stage=get-pod")
+	require.Contains(t, event.message, "error=boom")
+	require.Contains(t, event.message, "provider=provider")
+	require.Contains(t, event.message, "interface=eth0")
+	require.Contains(t, event.message, "node=node-a")
+}
+
+func TestRecordCNIPodEventRedactsRuntimeDetails(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+	podRequest := &request.CniRequest{
+		PodName: "pod", PodNamespace: "ns", Provider: "provider",
+		ContainerID: "1234567890abcdef", NetNs: "/runtime/netns/pod",
+	}
+	handler.recordCNIPodEvent(
+		podForCNIEvent(nil, podRequest), podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed",
+		`stage=configure-nic error=failed in /runtime/netns/pod for 1234567890abcdef: boom`,
+	)
+
+	event := requireSingleCNIEvent(t, recorder)
+	require.Contains(t, event.message, "stage=configure-nic")
+	require.Contains(t, event.message, "boom")
+	require.NotContains(t, event.message, podRequest.ContainerID)
+	require.NotContains(t, event.message, podRequest.NetNs)
+}
+
+func TestHandleAddSuccessEvent(t *testing.T) {
+	const (
+		provider = "macvlan.default"
+		subnet   = "underlay"
+		ip       = "10.0.0.2"
+		mac      = "00:00:00:00:00:02"
+	)
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "pod", Namespace: "ns", UID: types.UID("real-uid"),
+		Annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, provider):     ip,
+			fmt.Sprintf(util.CidrAnnotationTemplate, provider):          "10.0.0.0/24",
+			fmt.Sprintf(util.MacAddressAnnotationTemplate, provider):    mac,
+			fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider): subnet,
+		},
+	}}
+	podSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: subnet}, Spec: kubeovnv1.SubnetSpec{Provider: provider}}
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, pod, podSubnet, recorder)
+	ipCRName := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+	handler.KubeOvnClient = kubeovnfake.NewSimpleClientset(&kubeovnv1.IP{
+		ObjectMeta: metav1.ObjectMeta{Name: ipCRName},
+		Spec:       kubeovnv1.IPSpec{NodeName: "node-a"},
+	})
+
+	response := serveCNIRequest(t, handler, "/api/v1/add", request.CniRequest{
+		CniType: util.CniTypeName, PodName: pod.Name, PodNamespace: pod.Namespace,
+		Provider: provider, IfName: "net1",
+	})
+	require.Equal(t, http.StatusOK, response.Code)
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeNormal, event.eventType)
+	require.Equal(t, "PodNetworkConfigured", event.reason)
+	require.Same(t, pod, event.object)
+	for _, part := range []string{"subnet=" + subnet, "ip=" + ip, "mac=" + mac, "provider=" + provider, "interface=net1", "node=node-a"} {
+		require.Contains(t, event.message, part)
+	}
+}
+
+func TestHandleAddFailureEvent(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+
+	response := serveCNIRequest(t, handler, "/api/v1/add", request.CniRequest{
+		PodName: "missing", PodNamespace: "ns", Provider: util.OvnProvider,
+	})
+	require.Equal(t, http.StatusInternalServerError, response.Code)
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeWarning, event.eventType)
+	require.Equal(t, "PodNetworkConfigureFailed", event.reason)
+	require.Contains(t, event.message, "stage=get-pod")
+	require.Contains(t, event.message, `pod "missing" not found`)
+	pod, ok := event.object.(*v1.Pod)
+	require.True(t, ok)
+	require.Equal(t, "missing", pod.Name)
+	require.Equal(t, "ns", pod.Namespace)
+}
+
+func TestHandleDelSuccessEventPreservesPodReference(t *testing.T) {
+	useFakeOVSVsctl(t, true)
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "virt-launcher", Namespace: "ns", UID: types.UID("real-uid"),
+		Annotations: map[string]string{
+			fmt.Sprintf(util.VMAnnotationTemplate, util.OvnProvider): "vm-name",
+		},
+	}}
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, pod, nil, recorder)
+
+	response := serveCNIRequest(t, handler, "/api/v1/del", request.CniRequest{
+		CniType: util.CniTypeName, PodName: pod.Name, PodNamespace: pod.Namespace,
+		ContainerID: "1234567890abcdef", NetNs: "/missing/netns", Provider: util.OvnProvider,
+	})
+	require.Equal(t, http.StatusNoContent, response.Code)
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeNormal, event.eventType)
+	require.Equal(t, "PodNetworkRemoved", event.reason)
+	require.Same(t, pod, event.object)
+	require.Equal(t, "virt-launcher", event.object.(*v1.Pod).Name)
+	require.NotContains(t, event.message, "vm-name")
+	for _, part := range []string{"provider=ovn", "interface=eth0", "node=node-a"} {
+		require.Contains(t, event.message, part)
+	}
+}
+
+func TestHandleDelFailureEvent(t *testing.T) {
+	useFakeOVSVsctl(t, false)
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+
+	response := serveCNIRequest(t, handler, "/api/v1/del", request.CniRequest{
+		PodName: "deleted", PodNamespace: "ns", ContainerID: "1234567890abcdef",
+		NetNs: "/missing/netns", Provider: util.OvnProvider, IfName: "net1",
+	})
+	require.Equal(t, http.StatusInternalServerError, response.Code)
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeWarning, event.eventType)
+	require.Equal(t, "PodNetworkRemoveFailed", event.reason)
+	require.Contains(t, event.message, "stage=delete-nic")
+	require.Contains(t, event.message, "exit status 1")
+	pod := event.object.(*v1.Pod)
+	require.Equal(t, "deleted", pod.Name)
+	require.Equal(t, "ns", pod.Namespace)
+}
+
+func TestHandleDelNoNetNSHasNoEvent(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+
+	response := serveCNIRequest(t, handler, "/api/v1/del", request.CniRequest{
+		PodName: "deleted", PodNamespace: "ns", Provider: util.OvnProvider,
+	})
+	require.Equal(t, http.StatusNoContent, response.Code)
+	require.Empty(t, recorder.events)
+}
+
+func TestHandleAddAndDelInvalidRequestHaveNoEvent(t *testing.T) {
+	for _, path := range []string{"/api/v1/add", "/api/v1/del"} {
+		t.Run(path, func(t *testing.T) {
+			recorder := &cniEventRecorder{}
+			handler := cniEventTestHandler(t, nil, nil, recorder)
+			request := httptest.NewRequest(http.MethodPost, path, nil)
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+
+			createHandler(handler).ServeHTTP(response, request)
+
+			require.Equal(t, http.StatusBadRequest, response.Code)
+			require.Empty(t, recorder.events)
+		})
+	}
+}
+
+func cniEventTestHandler(t *testing.T, pod *v1.Pod, subnet *kubeovnv1.Subnet, recorder *cniEventRecorder) *cniServerHandler {
+	t.Helper()
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if pod != nil {
+		require.NoError(t, podIndexer.Add(pod))
+	}
+	subnetIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if subnet != nil {
+		require.NoError(t, subnetIndexer.Add(subnet))
+	}
+	config := &Configuration{NodeName: "node-a"}
+	controller := &Controller{
+		config:        config,
+		podsLister:    listerv1.NewPodLister(podIndexer),
+		subnetsLister: kubeovnlister.NewSubnetLister(subnetIndexer),
+		recorder:      recorder,
+	}
+	return createCniServerHandler(config, controller)
+}
+
+func serveCNIRequest(t *testing.T, handler *cniServerHandler, path string, podRequest request.CniRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(podRequest)
+	require.NoError(t, err)
+	request := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	createHandler(handler).ServeHTTP(response, request)
+	return response
+}
+
+func requireSingleCNIEvent(t *testing.T, recorder *cniEventRecorder) recordedCNIEvent {
+	t.Helper()
+	require.Len(t, recorder.events, 1)
+	return recorder.events[0]
+}
+
+func useFakeOVSVsctl(t *testing.T, succeed bool) {
+	t.Helper()
+	target := "/bin/false"
+	if succeed {
+		target = "/bin/true"
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.Symlink(target, filepath.Join(dir, "ovs-vsctl")))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}


### PR DESCRIPTION
## Summary

- preserve the existing warning behavior when a Kube-OVN IPAM network attachment has no matching subnet
- record controller pod network allocation, update, security, and release outcomes with auditable network details
- record daemon pod QoS and CNI ADD/DEL outcomes with provider, interface, node, stage, and error context
- suppress successful controller events for no-op reconciles and preserve the no-op CNI DEL path
- use synthetic pod references for cleanup after pod deletion and redact runtime identifiers from daemon events

## Tests

- `go test ./pkg/controller -count=1`
- `go test ./pkg/daemon -count=1`
- `env CGO_ENABLED=1 go test -race ./pkg/daemon -run 'TestHandleUpdatePod|TestEnqueueUpdatePodOnlyQueuesRelevantAnnotationChanges|TestPodForCNIEvent|TestRecordCNIPodEvent|TestHandle(Add|Del).*Event|TestHandleDelNoNetNSHasNoEvent' -count=1`
- `CI=true make lint`
- `git diff --check origin/master...HEAD`
