### PR TITLE
fix: ignore deleting NAT rules when resetting OVN EIP status (#6982)

### DIFF
--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -611,6 +611,19 @@ func (c *Controller) handleDelOvnEipFinalizer(cachedEip *kubeovnv1.OvnEip) error
 	return nil
 }
 
+// hasActiveNat reports whether any of the listed NAT rules is still active, i.e.
+// not marked for deletion. A NAT rule that already carries a DeletionTimestamp is
+// on its way out but may still linger in the lister cache; counting it would keep
+// the EIP's status.nat from being reset once the rule is finally gone.
+func hasActiveNat[T metav1.Object](nats []T) bool {
+	for _, nat := range nats {
+		if nat.GetDeletionTimestamp().IsZero() {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Controller) getOvnEipNat(eipV4IP, eipV6IP string) (string, error) {
 	usingDnat, usingFip, usingSnat := false, false, false
 	check := func(selector labels.Selector) error {
@@ -619,7 +632,7 @@ func (c *Controller) getOvnEipNat(eipV4IP, eipV6IP string) (string, error) {
 			klog.Errorf("failed to get ovn dnats, %v", err)
 			return err
 		}
-		if len(dnats) != 0 {
+		if hasActiveNat(dnats) {
 			usingDnat = true
 		}
 		fips, err := c.ovnFipsLister.List(selector)
@@ -627,7 +640,7 @@ func (c *Controller) getOvnEipNat(eipV4IP, eipV6IP string) (string, error) {
 			klog.Errorf("failed to get ovn fips, %v", err)
 			return err
 		}
-		if len(fips) != 0 {
+		if hasActiveNat(fips) {
 			usingFip = true
 		}
 		snats, err := c.ovnSnatRulesLister.List(selector)
@@ -635,7 +648,7 @@ func (c *Controller) getOvnEipNat(eipV4IP, eipV6IP string) (string, error) {
 			klog.Errorf("failed to get ovn snats, %v", err)
 			return err
 		}
-		if len(snats) != 0 {
+		if hasActiveNat(snats) {
 			usingSnat = true
 		}
 		return nil

--- a/pkg/controller/ovn_eip_test.go
+++ b/pkg/controller/ovn_eip_test.go
@@ -96,4 +96,70 @@ func Test_getOvnEipNat(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, nat)
 	})
+
+	// Regression for #6982: a NAT rule that is being deleted still lingers in the
+	// lister cache with a DeletionTimestamp set. It must not be counted, otherwise
+	// the EIP's status.nat can never be reset once the rule is finally gone.
+	now := metav1.Now()
+	deletingSnat := &kubeovnv1.OvnSnatRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "snat-deleting",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{util.KubeOVNControllerFinalizer},
+			Labels:            map[string]string{util.EipV4IpLabel: "192.168.0.5"},
+		},
+	}
+
+	t.Run("NAT rule marked for deletion is not counted", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			OvnSnatRules: []*kubeovnv1.OvnSnatRule{deletingSnat},
+		})
+		require.NoError(t, err)
+		nat, err := fc.fakeController.getOvnEipNat("192.168.0.5", "")
+		require.NoError(t, err)
+		require.Empty(t, nat)
+	})
+
+	t.Run("active NAT is counted while a deleting sibling is ignored", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			OvnDnatRules: []*kubeovnv1.OvnDnatRule{ipv4Dnat},
+			OvnSnatRules: []*kubeovnv1.OvnSnatRule{deletingSnat},
+		})
+		require.NoError(t, err)
+		nat, err := fc.fakeController.getOvnEipNat("192.168.0.5", "")
+		require.NoError(t, err)
+		require.Equal(t, util.DnatUsingEip, nat)
+	})
+}
+
+func TestHasActiveNat(t *testing.T) {
+	now := metav1.Now()
+	active := &kubeovnv1.OvnSnatRule{ObjectMeta: metav1.ObjectMeta{Name: "active"}}
+	deleting := &kubeovnv1.OvnSnatRule{ObjectMeta: metav1.ObjectMeta{
+		Name:              "deleting",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{util.KubeOVNControllerFinalizer},
+	}}
+
+	tests := []struct {
+		name string
+		nats []*kubeovnv1.OvnSnatRule
+		want bool
+	}{
+		{"empty", nil, false},
+		{"single active", []*kubeovnv1.OvnSnatRule{active}, true},
+		{"single deleting", []*kubeovnv1.OvnSnatRule{deleting}, false},
+		{"all deleting", []*kubeovnv1.OvnSnatRule{deleting, deleting}, false},
+		{"mixed active and deleting", []*kubeovnv1.OvnSnatRule{deleting, active}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, hasActiveNat(tt.nats))
+		})
+	}
+
+	// Exercise the generic across the other NAT types to ensure they all satisfy
+	// the metav1.Object constraint.
+	require.True(t, hasActiveNat([]*kubeovnv1.OvnDnatRule{{ObjectMeta: metav1.ObjectMeta{Name: "dnat"}}}))
+	require.True(t, hasActiveNat([]*kubeovnv1.OvnFip{{ObjectMeta: metav1.ObjectMeta{Name: "fip"}}}))
 }


### PR DESCRIPTION
## What this fixes

Fixes #6982 — deleting `ofip`/`osnat`/`odnat` sometimes fails to reset `oeip.status.nat` back to empty.

## Root cause

`getOvnEipNat()` (`pkg/controller/ovn_eip.go`) counts every NAT rule returned by the lister, including rules that already carry a `DeletionTimestamp` but still linger in the informer cache.

When a NAT rule is deleted, `handleDelOvn{Fip,Snat,Dnat}Rule` enqueues the EIP reset **before** removing the finalizer, and enqueues it **again right after** — at which point the watch DELETE event usually hasn't landed yet, so the rule is still cached. The reset worker `handleResetOvnEip` is **one-shot** (no requeue), so once the reset reads the still-cached, being-deleted rule and counts it as "in use", `status.nat` is left at a stale value and no later event triggers another reset.

By contrast, the EIP *delete* path (`handleUpdateOvnEip`) uses the same helper as a gate but `return err` retries until the rule leaves the cache, so it self-heals — only the reset path could not. This asymmetry matches the reporter's "sometimes recovers, sometimes doesn't" symptom.

## Fix

Filter out NAT rules whose `DeletionTimestamp` is set in `getOvnEipNat` (a small generic `hasActiveNat` helper), applied uniformly to the dnat/fip/snat queries.

## Tests

- `TestHasActiveNat` — table-driven coverage of the helper (empty / active / deleting / mixed) across all three NAT types.
- `Test_getOvnEipNat` — added subtests: a NAT rule marked for deletion is not counted; an active NAT is still counted while a deleting sibling is ignored.

`make lint` (verify-crd + golangci-lint + modernize) passes with 0 issues.

## Backport

Buggy code exists on release-1.16 / release-1.15 / release-1.14 as well; suggest backporting after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)