### PR TITLE
fix: avoid wrapping nil error with %w in Errorf

### DIFF
--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -524,9 +524,14 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 			}
 			// extract vpc nad interface name
 			providers, err := c.getPodProviders(pod)
-			if err != nil || len(providers) == 0 {
+			if err != nil {
 				klog.Errorf("failed to get providers for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 				return fmt.Errorf("failed to get providers for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+			}
+			if len(providers) == 0 {
+				err = fmt.Errorf("no kube-ovn providers found for pod %s/%s", pod.Namespace, pod.Name)
+				klog.Error(err)
+				return err
 			}
 			// if more than one provider exists, use the first one
 			provider := providers[0]

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -358,8 +358,13 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 				}
 				mtuStr := node.Labels[fmt.Sprintf(util.ProviderNetworkMtuTemplate, providerNetwork)]
 				if mtuStr != "" {
-					if mtu, err = strconv.Atoi(mtuStr); err != nil || mtu <= 0 {
-						errMsg := fmt.Errorf("failed to parse provider network MTU %s: %w", mtuStr, err)
+					var errMsg error
+					if mtu, err = strconv.Atoi(mtuStr); err != nil {
+						errMsg = fmt.Errorf("failed to parse provider network MTU %s: %w", mtuStr, err)
+					} else if mtu <= 0 {
+						errMsg = fmt.Errorf("invalid provider network MTU %q: must be a positive integer", mtuStr)
+					}
+					if errMsg != nil {
 						klog.Error(errMsg)
 						if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 							klog.Errorf("failed to write response: %v", err)


### PR DESCRIPTION
## Summary
- `handleInitVpcNatGw` (`pkg/controller/vpc_nat_gateway.go`): `getPodProviders` can return `(empty, nil)` when a pod has no kube-ovn networks. The old combined `if err != nil || len(providers) == 0` branch then did `fmt.Errorf("...: %w", ..., err)` with `err == nil`, yielding a misleading `%!w(<nil>)` error string and a nil-wrapped error that breaks `errors.Is`/`errors.Unwrap`. Split into two branches so the empty-providers case returns a clean, self-describing error.
- `handleAdd` (`pkg/daemon/handler.go`): a provider-network MTU node label of `"0"`/`"-1"` parses fine (`err == nil`) but is `<= 0`, hitting the same combined branch and the same `%!w(<nil>)`. Split the `Atoi` error from the non-positive-value case; the latter now returns `invalid provider network MTU %q: must be a positive integer`.

Both changes are behavior-preserving (still return an error / 500 CNI response) — only the error construction is fixed. Aligns with upstream [ovn-kubernetes#6626](https://github.com/ovn-org/ovn-kubernetes/pull/6626).

## Test plan
- [x] `go build ./pkg/controller/... ./pkg/daemon/...`
- [x] `golangci-lint run ./pkg/controller/... ./pkg/daemon/...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)