### PR TITLE
fix: validate vlan id within range [0, 4095]

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -3257,6 +3257,8 @@ spec:
             properties:
               id:
                 description: VLAN ID (0-4095). This field is immutable after creation.
+                maximum: 4095
+                minimum: 0
                 type: integer
               provider:
                 description: Provider network name. This field is immutable after
@@ -3267,6 +3269,8 @@ spec:
                 type: string
               vlanId:
                 description: deprecated fields, use ID & Provider instead
+                maximum: 4095
+                minimum: 0
                 type: integer
             required:
             - provider

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -3279,6 +3279,8 @@ spec:
             properties:
               id:
                 description: VLAN ID (0-4095). This field is immutable after creation.
+                maximum: 4095
+                minimum: 0
                 type: integer
               provider:
                 description: Provider network name. This field is immutable after
@@ -3289,6 +3291,8 @@ spec:
                 type: string
               vlanId:
                 description: deprecated fields, use ID & Provider instead
+                maximum: 4095
+                minimum: 0
                 type: integer
             required:
             - provider

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3660,6 +3660,8 @@ spec:
             properties:
               id:
                 description: VLAN ID (0-4095). This field is immutable after creation.
+                maximum: 4095
+                minimum: 0
                 type: integer
               provider:
                 description: Provider network name. This field is immutable after
@@ -3670,6 +3672,8 @@ spec:
                 type: string
               vlanId:
                 description: deprecated fields, use ID & Provider instead
+                maximum: 4095
+                minimum: 0
                 type: integer
             required:
             - provider

--- a/pkg/apis/kubeovn/v1/vlan.go
+++ b/pkg/apis/kubeovn/v1/vlan.go
@@ -32,12 +32,16 @@ type Vlan struct {
 
 type VlanSpec struct {
 	// deprecated fields, use ID & Provider instead
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=4095
 	VlanID int `json:"vlanId,omitempty"`
 	// Deprecated: in favor of provider
 	// +kubebuilder:validation:Optional
 	ProviderInterfaceName string `json:"providerInterfaceName,omitempty"`
 
 	// VLAN ID (0-4095). This field is immutable after creation.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=4095
 	ID int `json:"id"`
 	// Provider network name. This field is immutable after creation.
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
## What type of this PR

Bug fix / hardening.

## Which issue(s) this PR fixes

Inspired by antrea-io/antrea#8149 (validate VLAN range at admission).

## What this PR does

The `Vlan` CRD `id` field (and the deprecated `vlanId` field) had **no schema validation**: the doc comment claimed `0-4095` but nothing enforced it. Out-of-range values (e.g. `5000` or negative) were silently accepted by the apiserver and only rejected much later, when a subnet referencing the vlan tried to create its localnet logical switch port — `SetLogicalSwitchPortVlanTag` / `CreateLocalnetLogicalSwitchPort` returns `invalid vlan id N` (`pkg/ovs/ovn-nb-logical_switch_port.go:608`). The result: the `Vlan` object looks healthy while every subnet using it fails opaquely.

This PR adds `kubebuilder:validation:Minimum=0` / `Maximum=4095` to both fields so invalid VLAN IDs are rejected at **admission time** with a clear message, instead of failing late. The range matches the existing runtime check.

- `pkg/apis/kubeovn/v1/vlan.go`: add Minimum/Maximum markers to `ID` and deprecated `VlanID`.
- Regenerated CRDs via `make gen-crd` (`charts/kube-ovn/templates/kube-ovn-crd.yaml`, `charts/kube-ovn-v2/crds/kube-ovn-crd.yaml`, `dist/images/install.sh`).

Validation is declarative (enforced by the apiserver), so there is no Go code path to unit-test; the deprecated `vlanId` (migrated to `id` at controller startup, `pkg/controller/init.go:861`) gets the same bounds for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)