### PR TITLE
[release-1.16] fix: restore ip_src hash for policy route ECMP

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -49,6 +49,7 @@ ADD patches/ffd2328d4a55271569e2b89e54a2c18f4e186af8.patch $SRC_DIR
 ADD patches/d088c5d8c263552c5a31d87813991aee30ab74de.patch $SRC_DIR
 ADD patches/1b31f07dc60c016153fa35d936cdda0e02e58492.patch $SRC_DIR
 ADD patches/54b767822916606dbb78335a3197983f435b5b8a.patch $SRC_DIR
+ADD patches/e490f5ac0b644101913c2a3db8e03d85e859deff.patch $SRC_DIR
 ADD patches/9ee66bd91be65605cffb9a490b4dba3bc13358e9.patch $SRC_DIR
 ADD patches/e889d46924085ca0fe38a2847da973dfe6ea100e.patch $SRC_DIR
 ADD patches/f9e97031b56ab5747b5d73629198331a6daacdfd.patch $SRC_DIR
@@ -104,6 +105,8 @@ RUN cd /usr/src/ && \
 
 RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
+    # change default hash type from dp_hash to hash with field src_ip
+    git apply $SRC_DIR/e490f5ac0b644101913c2a3db8e03d85e859deff.patch && \
     # modify src route priority
     git apply $SRC_DIR/9ee66bd91be65605cffb9a490b4dba3bc13358e9.patch && \
     # fix reaching resubmit limit in underlay

--- a/dist/images/patches/e490f5ac0b644101913c2a3db8e03d85e859deff.patch
+++ b/dist/images/patches/e490f5ac0b644101913c2a3db8e03d85e859deff.patch
@@ -1,0 +1,34 @@
+From e490f5ac0b644101913c2a3db8e03d85e859deff Mon Sep 17 00:00:00 2001
+From: Mengxin Liu <mengxin@alauda.io>
+Date: Thu, 10 Apr 2025 01:28:59 +0000
+Subject: [PATCH] change default hash type from dp_hash to hash with field
+ src_ip
+
+---
+ lib/actions.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/lib/actions.c b/lib/actions.c
+index ed9b70882..12e5e6bb0 100644
+--- a/lib/actions.c
++++ b/lib/actions.c
+@@ -1653,13 +1653,14 @@ encode_SELECT(const struct ovnact_select *select,
+     struct ofpact_group *og;
+ 
+     struct ds ds = DS_EMPTY_INITIALIZER;
+-    ds_put_format(&ds, "type=select,selection_method=%s",
+-                  select->hash_fields ? "hash": "dp_hash");
+     if (select->hash_fields) {
+-      ds_put_format(&ds, ",fields(%s)", select->hash_fields);
++        ds_put_format(&ds, "type=select,selection_method=hash,fields(%s)",
++                      select->hash_fields);
++    } else {
++        ds_put_format(&ds, "type=select,selection_method=hash,fields=ip_src");
+     }
+ 
+     if (ovs_feature_is_supported(OVS_DP_HASH_L4_SYM_SUPPORT) &&
+         !select->hash_fields) {
+         /* Select dp-hash l4_symmetric by setting the upper 32bits of
+          * selection_method_param to value 1 (1 << 32): */
+-- 
+2.43.0


### PR DESCRIPTION
Backport #6953 to release-1.16.\n\nCherry-picked from 218268ec12c329a19fc815ef1aa32bf2e89a691e.