### PR TITLE
fix: drop orphan centralized nat outgoing tcp packets

### DIFF
--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -628,6 +628,14 @@ func (c *Controller) updateIptablesChain(ipt *iptables.IPTables, table, chain, p
 	return nil
 }
 
+func centralizedNatOutgoingNonSynDropRule(cidr, matchset string) util.IPTableRule {
+	return util.IPTableRule{
+		Table: MANGLE,
+		Chain: OvnPostrouting,
+		Rule:  strings.Fields(fmt.Sprintf(`-s %s -p tcp -m tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -m set ! --match-set %s dst -j DROP`, cidr, matchset)),
+	}
+}
+
 func (c *Controller) setIptables() error {
 	klog.V(3).Infoln("start to set up iptables")
 	node, err := c.nodesLister.Get(c.config.NodeName)
@@ -928,6 +936,8 @@ func (c *Controller) setIptables() error {
 			// insert the rule before the one for nat outgoing
 			n := len(natPostroutingRules)
 			natPostroutingRules = append(natPostroutingRules[:n-1], rule, natPostroutingRules[n-1])
+			// Drop orphan non-SYN packets before conntrack confirm to avoid poisoning later SNAT.
+			manglePostroutingRules = append(manglePostroutingRules, centralizedNatOutgoingNonSynDropRule(cidr, matchset))
 		}
 
 		if err = c.reconcileNatOutgoingPolicyIptablesChain(allSubnets, protocol); err != nil {

--- a/pkg/daemon/gateway_linux_test.go
+++ b/pkg/daemon/gateway_linux_test.go
@@ -1,12 +1,20 @@
 package daemon
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func TestCentralizedNatOutgoingNonSynDropRule(t *testing.T) {
+	rule := centralizedNatOutgoingNonSynDropRule("10.26.0.0/16", "ovn40subnets")
+	require.Equal(t, MANGLE, rule.Table)
+	require.Equal(t, OvnPostrouting, rule.Chain)
+	require.Equal(t, strings.Fields(`-s 10.26.0.0/16 -p tcp -m tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -m set ! --match-set ovn40subnets dst -j DROP`), rule.Rule)
+}
 
 func TestFindRulePositionsInList(t *testing.T) {
 	jumpRule := util.IPTableRule{


### PR DESCRIPTION
#### What this PR does

Drop TCP non-SYN NEW packets from centralized natOutgoing gateway CIDRs in mangle POSTROUTING before conntrack confirmation.

#### Why this is needed

In centralized gateway ECMP mode, tail ACK packets from a Pod can land on a different gateway node that has no NAT conntrack state. With TCP loose tracking, the packet is treated as NEW and the existing direct-routing NAT RETURN rule lets it leave without SNAT, confirming a no-NAT conntrack entry. If the Pod later reuses the same source port for a new SYN, the stale no-NAT entry is reused and the SYN leaves with the Pod IP, causing intermittent connection failures.

The direct-routing RETURN rule is kept unchanged because it is needed for Pod IPs advertised directly with BGP, including asymmetric ingress and egress nodes. The new DROP rule is generated only for `centralGwNatIPs` CIDRs on centralized natOutgoing gateway nodes, so it targets the ECMP natOutgoing poison path instead of using interface matching such as `-o ovn0`.

#### Tests

- `go test ./pkg/daemon -count=1`