### PR TITLE
[release-1.16] fix: drop orphan centralized nat outgoing tcp packets

### DIFF
--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -620,6 +620,14 @@ func (c *Controller) updateIptablesChain(ipt *iptables.IPTables, table, chain, p
 	return nil
 }
 
+func centralizedNatOutgoingNonSynDropRule(cidr, matchset string) util.IPTableRule {
+	return util.IPTableRule{
+		Table: MANGLE,
+		Chain: OvnPostrouting,
+		Rule:  strings.Fields(fmt.Sprintf(`-s %s -p tcp -m tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -m set ! --match-set %s dst -j DROP`, cidr, matchset)),
+	}
+}
+
 func (c *Controller) setIptables() error {
 	klog.V(3).Infoln("start to set up iptables")
 	node, err := c.nodesLister.Get(c.config.NodeName)
@@ -909,6 +917,8 @@ func (c *Controller) setIptables() error {
 			// insert the rule before the one for nat outgoing
 			n := len(natPostroutingRules)
 			natPostroutingRules = append(natPostroutingRules[:n-1], rule, natPostroutingRules[n-1])
+			// Drop orphan non-SYN packets before conntrack confirm to avoid poisoning later SNAT.
+			manglePostroutingRules = append(manglePostroutingRules, centralizedNatOutgoingNonSynDropRule(cidr, matchset))
 		}
 
 		if err = c.reconcileNatOutgoingPolicyIptablesChain(protocol); err != nil {

--- a/pkg/daemon/gateway_linux_test.go
+++ b/pkg/daemon/gateway_linux_test.go
@@ -1,0 +1,15 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentralizedNatOutgoingNonSynDropRule(t *testing.T) {
+	rule := centralizedNatOutgoingNonSynDropRule("10.26.0.0/16", "ovn40subnets")
+	require.Equal(t, MANGLE, rule.Table)
+	require.Equal(t, OvnPostrouting, rule.Chain)
+	require.Equal(t, strings.Fields(`-s 10.26.0.0/16 -p tcp -m tcp --tcp-flags SYN NONE -m conntrack --ctstate NEW -m set ! --match-set ovn40subnets dst -j DROP`), rule.Rule)
+}


### PR DESCRIPTION
Backport of #6998 to release-1.16.

Cherry-picked from `15883c6521390b3eb4f048b2c82b39eb2f88c240`.

#### Tests

- `go test ./pkg/daemon -count=1`