### PR TITLE
[release-1.16] backport #6793 and #6978

### DIFF
--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -142,6 +142,49 @@ TLS arguments for kube-ovn components that expose HTTPS endpoints.
 {{- end }}
 {{- end -}}
 
+{{- define "kubeovn.centralNamespace" -}}
+{{- if .Values.central.hcp.enabled -}}
+{{- default .Values.namespace .Values.central.hcp.namespace -}}
+{{- else -}}
+{{- .Values.namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.centralReplicas" -}}
+{{- if .Values.central.hcp.enabled -}}
+{{- .Values.central.hcp.replicas -}}
+{{- else -}}
+{{- include "kubeovn.nodeCount" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.centralRaftAddresses" -}}
+{{- $namespace := include "kubeovn.centralNamespace" . -}}
+{{- $addresses := list -}}
+{{- range $i := until (int .Values.central.hcp.replicas) -}}
+{{- $addresses = append $addresses (printf "ovn-central-%d.ovn-central.%s.svc" $i $namespace) -}}
+{{- end -}}
+{{- join "," $addresses -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnDbAddresses" -}}
+{{- include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnNbAddress" -}}
+{{- if not .Values.central.hcp.nbAddress -}}
+{{- fail "central.hcp.nbAddress must be set when central.hcp.enabled is true" -}}
+{{- end -}}
+{{- .Values.central.hcp.nbAddress -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnSbAddress" -}}
+{{- if not .Values.central.hcp.sbAddress -}}
+{{- fail "central.hcp.sbAddress must be set when central.hcp.enabled is true" -}}
+{{- end -}}
+{{- .Values.central.hcp.sbAddress -}}
+{{- end -}}
+
 {{- define "kubeovn.ovs-ovn.updateStrategy" -}}
   {{- $ds := lookup "apps/v1" "DaemonSet" $.Values.namespace "ovs-ovn" -}}
   {{- if $ds -}}

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -1,8 +1,8 @@
-kind: Deployment
+kind: {{ ternary "StatefulSet" "Deployment" .Values.central.hcp.enabled }}
 apiVersion: apps/v1
 metadata:
   name: ovn-central
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
   {{- with .Values.central.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -12,12 +12,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ include "kubeovn.nodeCount" . }}
+  replicas: {{ include "kubeovn.centralReplicas" . }}
+  {{- if .Values.central.hcp.enabled }}
+  serviceName: ovn-central
+  podManagementPolicy: Parallel
+  {{- end }}
+  {{- if not .Values.central.hcp.enabled }}
   strategy:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: ovn-central
@@ -48,21 +54,23 @@ spec:
           operator: Exists
       affinity:
         {{- include "kube-ovn.affinities.nodeAffinity" (dict "hardcodedRequired" (include "kubeovn.masterNodeRequired" . | fromYamlArray) "userPreferred" .Values.central.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.central.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) | nindent 8 }}
+        {{- if not .Values.central.hcp.enabled }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/name: ovn-central
               topologyKey: kubernetes.io/hostname
+        {{- end }}
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn-ovs
+      serviceAccountName: {{ ternary "ovn-central" "ovn-ovs" .Values.central.hcp.enabled }}
       automountServiceAccountToken: true
-      hostNetwork: true
+      hostNetwork: {{ ternary "false" "true" .Values.central.hcp.enabled }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        - name: hostpath-init
+        - name: {{ ternary "volume-init" "hostpath-init" .Values.central.hcp.enabled }}
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
@@ -70,19 +78,23 @@ spec:
             - -c
             - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
           securityContext:
-            allowPrivilegeEscalation: true
+            allowPrivilegeEscalation: {{ ternary "false" "true" .Values.central.hcp.enabled }}
             capabilities:
+              {{- if .Values.central.hcp.enabled }}
+              add:
+                - CHOWN
+              {{- end }}
               drop:
                 - ALL
-            privileged: true
+            privileged: {{ ternary "false" "true" .Values.central.hcp.enabled }}
             runAsUser: 0
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: host-run-ovn
+              name: {{ ternary "run-ovn" "host-run-ovn" .Values.central.hcp.enabled }}
             - mountPath: /etc/ovn
-              name: host-config-ovn
+              name: {{ ternary "ovn-data" "host-config-ovn" .Values.central.hcp.enabled }}
             - mountPath: /var/log/ovn
-              name: host-log-ovn
+              name: {{ ternary "log-ovn" "host-log-ovn" .Values.central.hcp.enabled }}
       containers:
         - name: ovn-central
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
@@ -99,12 +111,7 @@ spec:
                 - SYS_NICE
           env:
 {{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
-            - name: NODE_IPS
-              value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+            {{- if .Values.central.hcp.enabled }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -113,12 +120,37 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- end }}
+            - name: NODE_IPS
+              value: "{{ ternary (include "kubeovn.centralRaftAddresses" .) (include "kubeovn.ovnDbAddresses" .) .Values.central.hcp.enabled }}"
+            {{- if .Values.central.hcp.enabled }}
+            - name: DB_CLUSTER_ADDR
+              value: "$(POD_NAME).ovn-central.$(POD_NAMESPACE).svc"
+            {{- end }}
+            - name: POD_IP
+              {{- if .Values.central.hcp.enabled }}
+              value: "$(DB_CLUSTER_ADDR)"
+              {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+              {{- end }}
+            {{- if not .Values.central.hcp.enabled }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             - name: POD_IPS
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "{{- .Values.features.ENABLE_BIND_LOCAL_IP }}"
+              value: "{{ ternary false .Values.features.ENABLE_BIND_LOCAL_IP .Values.central.hcp.enabled }}"
             - name: PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.probeInterval }}"
             - name: OVN_NORTHD_PROBE_INTERVAL
@@ -140,14 +172,16 @@ spec:
           {{- end }}
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: host-run-ovn
+              name: {{ ternary "run-ovn" "host-run-ovn" .Values.central.hcp.enabled }}
             - mountPath: /etc/ovn
-              name: host-config-ovn
+              name: {{ ternary "ovn-data" "host-config-ovn" .Values.central.hcp.enabled }}
             - mountPath: /var/log/ovn
-              name: host-log-ovn
+              name: {{ ternary "log-ovn" "host-log-ovn" .Values.central.hcp.enabled }}
+            {{- if not .Values.central.hcp.enabled }}
             - mountPath: /etc/localtime
               name: localtime
               readOnly: true
+            {{- end }}
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -169,6 +203,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        {{- if .Values.central.hcp.enabled }}
+        - name: run-ovn
+          emptyDir: {}
+        - name: log-ovn
+          emptyDir: {}
+        {{- else }}
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
@@ -181,8 +221,26 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        {{- end }}
         - name: kube-ovn-tls
           secret:
             optional: true
             secretName: kube-ovn-tls
-
+  {{- if .Values.central.hcp.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: ovn-data
+        labels:
+          app.kubernetes.io/name: ovn-central
+          app.kubernetes.io/part-of: kube-ovn
+          app: ovn-central
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.central.hcp.storage.size }}
+        {{- if .Values.central.hcp.storage.storageClassName }}
+        storageClassName: {{ .Values.central.hcp.storage.storageClassName | quote }}
+        {{- end }}
+  {{- end }}

--- a/charts/kube-ovn-v2/templates/central/central-rbac.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-rbac.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.central.hcp.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+automountServiceAccountToken: false
+{{-  if .Values.global.registry.imagePullSecrets }}
+imagePullSecrets:
+{{- range $index, $secret := .Values.global.registry.imagePullSecrets }}
+{{- if $secret }}
+  - name: {{ $secret | quote}}
+{{- end }}
+{{- end }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ovn-central
+subjects:
+  - kind: ServiceAccount
+    name: ovn-central
+    namespace: {{ include "kubeovn.centralNamespace" . }}
+{{- end }}

--- a/charts/kube-ovn-v2/templates/central/central-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-service.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.central.hcp.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
-  name: ovn-northd
+  name: ovn-central
   namespace: {{ include "kubeovn.centralNamespace" . }}
   {{- with .Values.central.annotations }}
   annotations:
@@ -12,17 +13,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
   ports:
-    - name: ovn-northd
+    - name: nb-raft
       protocol: TCP
       port: 6643
       targetPort: 6643
-  type: ClusterIP
-  {{- if eq .Values.networking.stack "Dual" }}
-  ipFamilyPolicy: PreferDualStack
-  {{- end }}
+    - name: sb-raft
+      protocol: TCP
+      port: 6644
+      targetPort: 6644
   selector:
     app.kubernetes.io/name: ovn-central
     app.kubernetes.io/part-of: kube-ovn
-    ovn-northd-leader: "true"
-  sessionAffinity: None
+{{- end }}

--- a/charts/kube-ovn-v2/templates/central/northbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/northbound-service.yaml
@@ -2,7 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
   {{- with .Values.central.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,7 +17,10 @@ spec:
       protocol: TCP
       port: 6641
       targetPort: 6641
-  type: ClusterIP
+      {{- if and .Values.central.hcp.enabled (or (eq .Values.central.hcp.service.type "NodePort") (eq .Values.central.hcp.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.central.hcp.service.nbNodePort }}
+      {{- end }}
+  type: {{ ternary (.Values.central.hcp.service.type | default "ClusterIP") "ClusterIP" .Values.central.hcp.enabled }}
   {{- if eq .Values.networking.stack "Dual" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn-v2/templates/central/southbound-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/southbound-service.yaml
@@ -2,7 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ovn-sb
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
   {{- with .Values.central.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,7 +17,10 @@ spec:
       protocol: TCP
       port: 6642
       targetPort: 6642
-  type: ClusterIP
+      {{- if and .Values.central.hcp.enabled (or (eq .Values.central.hcp.service.type "NodePort") (eq .Values.central.hcp.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.central.hcp.service.sbNodePort }}
+      {{- end }}
+  type: {{ ternary (.Values.central.hcp.service.type | default "ClusterIP") "ClusterIP" .Values.central.hcp.enabled }}
   {{- if eq .Values.networking.stack "Dual" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -189,8 +189,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.central.hcp.enabled }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.ovnNbAddress" . }}"
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
-              value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnDbAddresses" . }}"
+            {{- end }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -140,8 +140,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.central.hcp.enabled }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
-              value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnDbAddresses" . }}"
+            {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.ovnRemoteProbeInterval }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
@@ -21,8 +21,8 @@ spec:
     type: {{ .Values.ovsOvn.updateStrategy.type }}
     {{- if eq .Values.ovsOvn.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxSurge: {{ .Values.ovsOvn.strategy.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ .Values.ovsOvn.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.ovsOvn.updateStrategy.maxSurge }}
+      maxUnavailable: {{ .Values.ovsOvn.updateStrategy.maxUnavailable }}
     {{- end }}
   template:
     metadata:
@@ -77,8 +77,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.central.hcp.enabled }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+            {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.ovnRemoteProbeInterval }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -1,0 +1,246 @@
+suite: OVN central HCP deployment (v2)
+templates:
+  - central/central-deployment.yaml
+  - central/central-service.yaml
+  - central/northbound-service.yaml
+  - central/southbound-service.yaml
+  - central/central-rbac.yaml
+  - controller/controller-deployment.yaml
+  - ovs-ovn/ovs-ovn-daemonset.yaml
+  - ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+tests:
+  - it: renders ovn-central as a PVC-backed StatefulSet in the HCP namespace
+    template: central/central-deployment.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+      central.hcp.replicas: 3
+      central.hcp.storage.size: 5Gi
+      central.hcp.storage.storageClassName: topolvm
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.serviceName
+          value: ovn-central
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: ovn-central
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      - notExists:
+          path: spec.template.spec.affinity.podAntiAffinity
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_IPS
+            value: ovn-central-0.ovn-central.hcp.svc,ovn-central-1.ovn-central.hcp.svc,ovn-central-2.ovn-central.hcp.svc
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_CLUSTER_ADDR
+            value: $(POD_NAME).ovn-central.$(POD_NAMESPACE).svc
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 5Gi
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: topolvm
+
+  - it: creates dedicated namespaced RBAC for HCP ovn-central
+    template: central/central-rbac.yaml
+    documentIndex: 0
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ovn-central
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: creates a headless service for StatefulSet raft DNS
+    template: central/central-service.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ovn-central
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+
+  - it: exposes only nb and sb services through fixed node ports
+    template: central/northbound-service.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: NodePort
+      central.hcp.service.nbNodePort: 30641
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30641
+
+  - it: exposes southbound through a fixed node port
+    template: central/southbound-service.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: NodePort
+      central.hcp.service.sbNodePort: 30642
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30642
+
+  - it: omits node ports when HCP services are rendered as ClusterIP
+    template: central/northbound-service.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: ClusterIP
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: defaults empty HCP NB service type to ClusterIP
+    template: central/northbound-service.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: ""
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: defaults empty HCP SB service type to ClusterIP
+    template: central/southbound-service.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.service.type: ""
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: points workload components at independent HCP OVN DB addresses
+    template: controller/controller-deployment.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_NB_ADDR
+            value: tcp:ovn-nb.example.com:6641
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs-ovn at the HCP OVN SB address
+    template: ovs-ovn/ovs-ovn-daemonset.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs-ovn-dpdk at the HCP OVN SB address
+    template: ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+      ovsOvn.dpdkHybrid.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -800,6 +800,24 @@ central:
   #  - name: CUSTOM_ENV_VAR
   #    value: "custom-value"
 
+  # -- Deploy ovn-central as a PVC-backed StatefulSet that can be exposed to workload clusters.
+  # @section -- OVN-central daemon configuration
+  hcp:
+    enabled: false
+    namespace: hcp
+    replicas: 3
+    # -- OVN NB address used by workload clusters, for example tcp:ovn-nb.example.com:6641.
+    nbAddress: ""
+    # -- OVN SB address used by workload clusters, for example tcp:ovn-sb.example.com:6642.
+    sbAddress: ""
+    service:
+      type: NodePort
+      nbNodePort: 30641
+      sbNodePort: 30642
+    storage:
+      size: 5Gi
+      storageClassName: ""
+
   # -- ovn-central resource limits & requests.
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # @section -- OVN-central daemon configuration

--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -105,6 +105,137 @@ Disable local rotation there so a tenant cluster cannot replace the shared CA.
 {{- end -}}
 
 {{/*
+Replica count for the ovn-central Deployment. Single mode always uses 1;
+cluster mode uses one replica per master node.
+*/}}
+{{- define "kubeovn.ovnCentralReplicas" -}}
+{{- if eq .Values.OVN_CENTRAL_MODE "single" -}}
+1
+{{- else -}}
+{{- include "kubeovn.nodeCount" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Replica count for the kube-ovn-controller Deployment.
+- dataPlaneOnly: tenant cluster typically has no `kube-ovn/role=master` node
+  label and kube-ovn-controller can run with replicas=1 (active/standby HA is
+  configured via leader election, not horizontal scale). Use 1 by default,
+  letting operators override via `kube-ovn-controller.replicas`.
+- everywhere else: keep the historical behaviour of one replica per master.
+*/}}
+{{- define "kubeovn.controllerReplicas" -}}
+{{- $override := dig "replicas" nil (index .Values "kube-ovn-controller") -}}
+{{- if $override -}}
+{{ $override }}
+{{- else if eq .Values.installMode "dataPlaneOnly" -}}
+1
+{{- else -}}
+{{- include "kubeovn.nodeCount" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Value of the NODE_IPS / OVN_DB_IPS env variable.
+  - dataPlaneOnly: emit externalOvnCentral.endpoint so agents/controller dial
+    the management cluster's exposed ovn-nb / ovn-sb via the configured LB IP.
+    Required — empty would fall back to OVN_NB_SERVICE_HOST which is not
+    injected in this mode because no local ovn-nb Service is rendered.
+  - single (control-plane / full): emit empty so start-db.sh takes the
+    standalone path and clients fall back to Service ClusterIP via the
+    auto-injected OVN_*_SERVICE_HOST env vars.
+  - cluster (default raft): emit comma-separated master node IPs.
+*/}}
+{{- define "kubeovn.ovnCentralNodeIPs" -}}
+{{- if eq .Values.installMode "dataPlaneOnly" -}}
+{{ required "installMode=dataPlaneOnly requires externalOvnCentral.endpoint (the management cluster's ovn-nb / ovn-sb VIP)" .Values.externalOvnCentral.endpoint }}
+{{- else if eq .Values.OVN_CENTRAL_MODE "single" -}}
+{{- else -}}
+{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate the ovn-central.service block. Currently the only invariant we
+enforce is that LoadBalancer service type must come with an explicit
+loadBalancerIP, because externalOvnCentral.endpoint is a single IP and we
+need all three Services (ovn-nb / ovn-sb / ovn-northd) to land on the same
+VIP. Without it cloud LBs allocate three different IPs and tenant clusters
+can only reach one DB. Use {{- include "kubeovn.validateService" . }}
+anywhere a Service is rendered so the validation runs on every template.
+*/}}
+{{- define "kubeovn.validateService" -}}
+{{- $svc := index .Values "ovn-central" "service" -}}
+{{- if eq $svc.type "LoadBalancer" -}}
+{{- if not $svc.loadBalancerIP -}}
+{{- fail "ovn-central.service.type=LoadBalancer requires ovn-central.service.loadBalancerIP to be set so the three OVN Services share a single VIP. Without it cloud LB controllers allocate three separate IPs and externalOvnCentral.endpoint (single IP) can only reach one of NB/SB/northd. Pick a VIP, configure your LB controller to assign it (MetalLB allow-shared-ip annotation is emitted automatically), then re-run helm." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Port the agents/controller should use to connect to ovn-nb. In dataPlaneOnly
+mode this picks up externalOvnCentral.nbPort so NodePort or non-default
+LoadBalancer port mappings work. Other modes use the in-cluster Service port
+6641.
+*/}}
+{{- define "kubeovn.ovnNbPort" -}}
+{{- if eq .Values.installMode "dataPlaneOnly" -}}
+{{ .Values.externalOvnCentral.nbPort | default 6641 }}
+{{- else -}}
+6641
+{{- end -}}
+{{- end -}}
+
+{{/*
+Port the agents/controller should use to connect to ovn-sb. Mirror of
+kubeovn.ovnNbPort for the southbound DB.
+*/}}
+{{- define "kubeovn.ovnSbPort" -}}
+{{- if eq .Values.installMode "dataPlaneOnly" -}}
+{{ .Values.externalOvnCentral.sbPort | default 6642 }}
+{{- else -}}
+6642
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render gate for control-plane resources (ovn-central + Services + its RBAC).
+Emits "true" when this Helm release should render control-plane resources;
+empty otherwise. Use with {{- if include "kubeovn.renderControlPlane" . }}.
+*/}}
+{{- define "kubeovn.renderControlPlane" -}}
+{{- if or (eq .Values.installMode "full") (eq .Values.installMode "controlPlaneOnly") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render gate for data-plane resources (CRDs + kube-ovn-controller + ovs-ovn +
+kube-ovn-cni + kube-ovn-pinger + kube-ovn-monitor + their RBAC).
+*/}}
+{{- define "kubeovn.renderDataPlane" -}}
+{{- if or (eq .Values.installMode "full") (eq .Values.installMode "dataPlaneOnly") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render gate for components that only make sense in a single-cluster install:
+- ovn-dpdk DaemonSet (start-ovs-dpdk-v2.sh still talks to OVN_SB_SERVICE_HOST,
+  no externalOvnCentral support yet)
+- pre-upgrade-ovs-ovn / upgrade-ovs-ovn hooks (upgrade-ovs.sh waits on a local
+  deploy/ovn-central, so it fails on tenant-only installs)
+Use `kubeovn.renderFullOnly` when the resource is not yet ready for the
+Kamaji-style split deployments.
+*/}}
+{{- define "kubeovn.renderFullOnly" -}}
+{{- if eq .Values.installMode "full" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 Determine the updateStrategy type for the ovs-ovn DaemonSet.
 If ovs-ovn.updateStrategy.type is set, use it directly.
 Otherwise, auto-detect based on the currently deployed DaemonSet.

--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -64,6 +64,37 @@ Number of master nodes
 {{- end -}}
 
 {{/*
+Replica count for the ovn-central Deployment. Single mode always uses 1;
+cluster mode uses one replica per master node.
+*/}}
+{{- define "kubeovn.ovnCentralReplicas" -}}
+{{- if index .Values "ovn-central" "hcp" "enabled" -}}
+{{- index .Values "ovn-central" "hcp" "replicas" -}}
+{{- else if eq .Values.OVN_CENTRAL_MODE "single" -}}
+1
+{{- else -}}
+{{- include "kubeovn.nodeCount" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.centralNamespace" -}}
+{{- if index .Values "ovn-central" "hcp" "enabled" -}}
+{{- default .Values.namespace (index .Values "ovn-central" "hcp" "namespace") -}}
+{{- else -}}
+{{- .Values.namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.centralRaftAddresses" -}}
+{{- $namespace := include "kubeovn.centralNamespace" . -}}
+{{- $addresses := list -}}
+{{- range $i := until (int (index .Values "ovn-central" "hcp" "replicas")) -}}
+{{- $addresses = append $addresses (printf "ovn-central-%d.ovn-central.%s.svc" $i $namespace) -}}
+{{- end -}}
+{{- join "," $addresses -}}
+{{- end -}}
+
+{{/*
 Environment variables used by the OVN NB/SB database server TLS setup.
 */}}
 {{- define "kubeovn.ovnCentralTLSEnv" -}}
@@ -105,18 +136,6 @@ Disable local rotation there so a tenant cluster cannot replace the shared CA.
 {{- end -}}
 
 {{/*
-Replica count for the ovn-central Deployment. Single mode always uses 1;
-cluster mode uses one replica per master node.
-*/}}
-{{- define "kubeovn.ovnCentralReplicas" -}}
-{{- if eq .Values.OVN_CENTRAL_MODE "single" -}}
-1
-{{- else -}}
-{{- include "kubeovn.nodeCount" . -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Replica count for the kube-ovn-controller Deployment.
 - dataPlaneOnly: tenant cluster typically has no `kube-ovn/role=master` node
   label and kube-ovn-controller can run with replicas=1 (active/standby HA is
@@ -147,12 +166,28 @@ Value of the NODE_IPS / OVN_DB_IPS env variable.
   - cluster (default raft): emit comma-separated master node IPs.
 */}}
 {{- define "kubeovn.ovnCentralNodeIPs" -}}
-{{- if eq .Values.installMode "dataPlaneOnly" -}}
+{{- if index .Values "ovn-central" "hcp" "enabled" -}}
+{{- include "kubeovn.centralRaftAddresses" . -}}
+{{- else if eq .Values.installMode "dataPlaneOnly" -}}
 {{ required "installMode=dataPlaneOnly requires externalOvnCentral.endpoint (the management cluster's ovn-nb / ovn-sb VIP)" .Values.externalOvnCentral.endpoint }}
 {{- else if eq .Values.OVN_CENTRAL_MODE "single" -}}
 {{- else -}}
 {{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}
 {{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnNbAddress" -}}
+{{- if not (index .Values "ovn-central" "hcp" "nbAddress") -}}
+{{- fail "ovn-central.hcp.nbAddress must be set when ovn-central.hcp.enabled is true" -}}
+{{- end -}}
+{{- index .Values "ovn-central" "hcp" "nbAddress" -}}
+{{- end -}}
+
+{{- define "kubeovn.ovnSbAddress" -}}
+{{- if not (index .Values "ovn-central" "hcp" "sbAddress") -}}
+{{- fail "ovn-central.hcp.sbAddress must be set when ovn-central.hcp.enabled is true" -}}
+{{- end -}}
+{{- index .Values "ovn-central" "hcp" "sbAddress" -}}
 {{- end -}}
 
 {{/*

--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -1,3 +1,26 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- /*
+Guard against in-place mode switches that would silently drop the live OVN
+DB. Switching from raft cluster (hostPath /etc/ovn) to single (PVC) leaves
+the new pod starting against an empty PVC; reverse direction loses the
+PVC-backed DB. Detect the existing Deployment's volume type via `lookup` and
+fail with explicit migration instructions if it disagrees with the rendered
+OVN_CENTRAL_MODE. `lookup` returns empty during dry-run / template, so this
+only fires on a real install/upgrade against a cluster.
+*/}}
+{{- $existing := lookup "apps/v1" "Deployment" .Values.namespace "ovn-central" }}
+{{- if $existing }}
+  {{- range $existing.spec.template.spec.volumes }}
+    {{- if eq .name "host-config-ovn" }}
+      {{- if and (eq $.Values.OVN_CENTRAL_MODE "single") .hostPath }}
+        {{- fail "Refusing to switch OVN_CENTRAL_MODE in place from raft (hostPath) to single (PVC). The new render would start ovn-central against an empty PVC and lose live OVN state. Migrate explicitly: (1) snapshot the current DB with `bash dist/images/restore-ovn-nb-db.sh` style backup; (2) `helm uninstall` the current release; (3) `helm install` with OVN_CENTRAL_MODE=single onto a fresh namespace or after clearing the existing ovn-central Deployment; (4) restore the snapshot via `bash dist/images/restore-ovn-nb-db.sh single <backup.db>`." }}
+      {{- end }}
+      {{- if and (ne $.Values.OVN_CENTRAL_MODE "single") .persistentVolumeClaim }}
+        {{- fail "Refusing to switch OVN_CENTRAL_MODE in place from single (PVC) to raft (hostPath). The new render would lose the PVC-backed DB. Migrate explicitly: snapshot the DB, helm uninstall, then helm install in the target mode and restore the snapshot." }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -7,12 +30,16 @@ metadata:
     kubernetes.io/description: |
       OVN components: northd, nb and sb.
 spec:
-  replicas: {{ include "kubeovn.nodeCount" . }}
+  replicas: {{ include "kubeovn.ovnCentralReplicas" . }}
   strategy:
+    {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
+    type: Recreate
+    {{- else }}
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
+    {{- end }}
   selector:
     matchLabels:
       app: ovn-central
@@ -31,12 +58,14 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
                   app: ovn-central
               topologyKey: kubernetes.io/hostname
+        {{- end }}
         {{- include "kubeovn.masterNodeAffinity" . | nindent 8 }}
       priorityClassName: system-cluster-critical
       serviceAccountName: ovn-ovs
@@ -52,7 +81,15 @@ spec:
           command:
             - sh
             - -c
+            {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
+            # /etc/ovn comes from a PVC in single-replica mode. Backends like
+            # root-squashed NFS reject chown by root, so make the OVN DB
+            # directory chown best-effort; the OVN containers run as `nobody`
+            # and will create new files with the correct owner regardless.
+            - "chown -R nobody: /var/run/ovn /var/log/ovn && (chown -R nobody: /etc/ovn 2>/dev/null || echo 'chown /etc/ovn skipped (likely root-squashed NFS); ovn will write as nobody anyway')"
+            {{- else }}
             - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:
@@ -84,7 +121,7 @@ spec:
           env:
 {{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
             - name: NODE_IPS
-              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -158,8 +195,13 @@ spec:
           hostPath:
             path: /run/ovn
         - name: host-config-ovn
+          {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
+          persistentVolumeClaim:
+            claimName: {{ (index .Values "ovn-central" "storage").existingClaim | default "ovn-central-data" }}
+          {{- else }}
           hostPath:
             path: {{ .Values.OVN_DIR }}
+          {{- end }}
         - name: host-log-ovn
           hostPath:
             path: {{ .Values.log_conf.LOG_DIR }}/ovn
@@ -171,3 +213,5 @@ spec:
             optional: true
             secretName: kube-ovn-tls
 
+
+{{- end }}

--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -9,6 +9,7 @@ OVN_CENTRAL_MODE. `lookup` returns empty during dry-run / template, so this
 only fires on a real install/upgrade against a cluster.
 */}}
 {{- $existing := lookup "apps/v1" "Deployment" .Values.namespace "ovn-central" }}
+{{- if not (index .Values "ovn-central" "hcp" "enabled") }}
 {{- if $existing }}
   {{- range $existing.spec.template.spec.volumes }}
     {{- if eq .name "host-config-ovn" }}
@@ -21,16 +22,21 @@ only fires on a real install/upgrade against a cluster.
     {{- end }}
   {{- end }}
 {{- end }}
-kind: Deployment
+{{- end }}
+kind: {{ ternary "StatefulSet" "Deployment" (index .Values "ovn-central" "hcp" "enabled") }}
 apiVersion: apps/v1
 metadata:
   name: ovn-central
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
   annotations:
     kubernetes.io/description: |
       OVN components: northd, nb and sb.
 spec:
   replicas: {{ include "kubeovn.ovnCentralReplicas" . }}
+  {{- if index .Values "ovn-central" "hcp" "enabled" }}
+  serviceName: ovn-central
+  podManagementPolicy: Parallel
+  {{- else }}
   strategy:
     {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
     type: Recreate
@@ -40,6 +46,7 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
     {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       app: ovn-central
@@ -58,6 +65,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
+        {{- if not (index .Values "ovn-central" "hcp" "enabled") }}
         {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -66,21 +74,25 @@ spec:
                   app: ovn-central
               topologyKey: kubernetes.io/hostname
         {{- end }}
+        {{- end }}
         {{- include "kubeovn.masterNodeAffinity" . | nindent 8 }}
       priorityClassName: system-cluster-critical
-      serviceAccountName: ovn-ovs
+      serviceAccountName: {{ ternary "ovn-central" "ovn-ovs" (index .Values "ovn-central" "hcp" "enabled") }}
       automountServiceAccountToken: true
-      hostNetwork: true
+      hostNetwork: {{ ternary "false" "true" (index .Values "ovn-central" "hcp" "enabled") }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        - name: hostpath-init
+        - name: {{ ternary "volume-init" "hostpath-init" (index .Values "ovn-central" "hcp" "enabled") }}
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
             - -c
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
+            {{- else }}
             {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
             # /etc/ovn comes from a PVC in single-replica mode. Backends like
             # root-squashed NFS reject chown by root, so make the OVN DB
@@ -90,20 +102,25 @@ spec:
             {{- else }}
             - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
             {{- end }}
+            {{- end }}
           securityContext:
-            allowPrivilegeEscalation: true
+            allowPrivilegeEscalation: {{ ternary "false" "true" (index .Values "ovn-central" "hcp" "enabled") }}
             capabilities:
+              {{- if index .Values "ovn-central" "hcp" "enabled" }}
+              add:
+                - CHOWN
+              {{- end }}
               drop:
                 - ALL
-            privileged: true
+            privileged: {{ ternary "false" "true" (index .Values "ovn-central" "hcp" "enabled") }}
             runAsUser: 0
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: host-run-ovn
+              name: {{ ternary "run-ovn" "host-run-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /etc/ovn
-              name: host-config-ovn
+              name: {{ ternary "ovn-data" "host-config-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /var/log/ovn
-              name: host-log-ovn
+              name: {{ ternary "log-ovn" "host-log-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
       containers:
         - name: ovn-central
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
@@ -120,12 +137,7 @@ spec:
                 - SYS_NICE
           env:
 {{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
-            - name: NODE_IPS
-              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -134,12 +146,37 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- end }}
+            - name: NODE_IPS
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: DB_CLUSTER_ADDR
+              value: "$(POD_NAME).ovn-central.$(POD_NAMESPACE).svc"
+            {{- end }}
+            - name: POD_IP
+              {{- if index .Values "ovn-central" "hcp" "enabled" }}
+              value: "$(DB_CLUSTER_ADDR)"
+              {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+              {{- end }}
+            {{- if not (index .Values "ovn-central" "hcp" "enabled") }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             - name: POD_IPS
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: ENABLE_BIND_LOCAL_IP
-              value: "{{- .Values.func.ENABLE_BIND_LOCAL_IP }}"
+              value: "{{ ternary false .Values.func.ENABLE_BIND_LOCAL_IP (index .Values "ovn-central" "hcp" "enabled") }}"
             - name: PROBE_INTERVAL
               value: "{{ .Values.networking.PROBE_INTERVAL }}"
             - name: OVN_NORTHD_PROBE_INTERVAL
@@ -162,14 +199,16 @@ spec:
               ephemeral-storage: {{ index .Values "ovn-central" "limits" "ephemeral-storage" }}
           volumeMounts:
             - mountPath: /var/run/ovn
-              name: host-run-ovn
+              name: {{ ternary "run-ovn" "host-run-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /etc/ovn
-              name: host-config-ovn
+              name: {{ ternary "ovn-data" "host-config-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /var/log/ovn
-              name: host-log-ovn
+              name: {{ ternary "log-ovn" "host-log-ovn" (index .Values "ovn-central" "hcp" "enabled") }}
+            {{- if not (index .Values "ovn-central" "hcp" "enabled") }}
             - mountPath: /etc/localtime
               name: localtime
               readOnly: true
+            {{- end }}
             - mountPath: /var/run/tls
               name: kube-ovn-tls
           readinessProbe:
@@ -191,6 +230,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
+        {{- if index .Values "ovn-central" "hcp" "enabled" }}
+        - name: run-ovn
+          emptyDir: {}
+        - name: log-ovn
+          emptyDir: {}
+        {{- else }}
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
@@ -208,10 +253,27 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
+        {{- end }}
         - name: kube-ovn-tls
           secret:
             optional: true
             secretName: kube-ovn-tls
+  {{- if index .Values "ovn-central" "hcp" "enabled" }}
+  volumeClaimTemplates:
+    - metadata:
+        name: ovn-data
+        labels:
+          app: ovn-central
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ index .Values "ovn-central" "hcp" "storage" "size" }}
+        {{- if index .Values "ovn-central" "hcp" "storage" "storageClassName" }}
+        storageClassName: {{ index .Values "ovn-central" "hcp" "storage" "storageClassName" | quote }}
+        {{- end }}
+  {{- end }}
 
 
 {{- end }}

--- a/charts/kube-ovn/templates/central-hcp-rbac.yaml
+++ b/charts/kube-ovn/templates/central-hcp-rbac.yaml
@@ -1,0 +1,62 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- if index .Values "ovn-central" "hcp" "enabled" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+automountServiceAccountToken: false
+{{-  if .Values.global.registry.imagePullSecrets }}
+imagePullSecrets:
+{{- range $index, $secret := .Values.global.registry.imagePullSecrets }}
+{{- if $secret }}
+  - name: {{ $secret | quote}}
+{{- end }}
+{{- end }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ovn-central
+subjects:
+  - kind: ServiceAccount
+    name: ovn-central
+    namespace: {{ include "kubeovn.centralNamespace" . }}
+{{- end }}
+{{- end }}

--- a/charts/kube-ovn/templates/central-pvc.yaml
+++ b/charts/kube-ovn/templates/central-pvc.yaml
@@ -1,0 +1,36 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- if eq .Values.OVN_CENTRAL_MODE "single" }}
+{{- $storage := index .Values "ovn-central" "storage" }}
+{{- /*
+PVC for the standalone OVN DB. Always created in single-replica mode because
+the Deployment unconditionally mounts a PVC claim. Set
+ovn-central.storage.existingClaim=<name> to point the Deployment at an
+externally-managed claim and skip in-chart PVC creation.
+*/ -}}
+{{- if not $storage.existingClaim }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ovn-central-data
+  namespace: {{ .Values.namespace }}
+  annotations:
+    # Pin the PVC so an installMode switch (e.g. full -> dataPlaneOnly) that
+    # stops rendering this template does NOT delete the volume holding the
+    # standalone OVN DB. Operators can `kubectl delete pvc ovn-central-data`
+    # explicitly when they really mean to discard the DB.
+    helm.sh/resource-policy: keep
+    kubernetes.io/description: |
+      Persistent storage for the ovn-central standalone OVN DB files.
+spec:
+  accessModes:
+{{ toYaml $storage.accessModes | indent 4 }}
+  resources:
+    requests:
+      storage: {{ $storage.size }}
+  {{- with $storage.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/kube-ovn/templates/central-svc.yaml
+++ b/charts/kube-ovn/templates/central-svc.yaml
@@ -1,0 +1,23 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- if index .Values "ovn-central" "hcp" "enabled" }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-central
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: nb-raft
+      protocol: TCP
+      port: 6643
+      targetPort: 6643
+    - name: sb-raft
+      protocol: TCP
+      port: 6644
+      targetPort: 6644
+  selector:
+    app: ovn-central
+{{- end }}
+{{- end }}

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -181,12 +181,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.ovnNbAddress" . }}"
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: KUBE_OVN_NB_PORT
               value: "{{ include "kubeovn.ovnNbPort" . }}"
             - name: KUBE_OVN_SB_PORT
               value: "{{ include "kubeovn.ovnSbPort" . }}"
+            {{- end }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -7,7 +8,7 @@ metadata:
     kubernetes.io/description: |
       kube-ovn controller
 spec:
-  replicas: {{ include "kubeovn.nodeCount" . }}
+  replicas: {{ include "kubeovn.controllerReplicas" . }}
   selector:
     matchLabels:
       app: kube-ovn-controller
@@ -181,7 +182,11 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
+            - name: KUBE_OVN_NB_PORT
+              value: "{{ include "kubeovn.ovnNbPort" . }}"
+            - name: KUBE_OVN_SB_PORT
+              value: "{{ include "kubeovn.ovnSbPort" . }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -243,3 +248,5 @@ spec:
           secret:
             optional: true
             secretName: kube-ovn-tls
+
+{{- end }}

--- a/charts/kube-ovn/templates/controller-svc.yaml
+++ b/charts/kube-ovn/templates/controller-svc.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -14,3 +15,5 @@ spec:
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}
+
+{{- end }}

--- a/charts/kube-ovn/templates/ic-controller-deploy.yaml
+++ b/charts/kube-ovn/templates/ic-controller-deploy.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 {{- if .Values.func.ENABLE_IC }}
 kind: Deployment
 apiVersion: apps/v1
@@ -93,7 +94,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OVN_DB_IPS
-              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
+            - name: KUBE_OVN_NB_PORT
+              value: "{{ include "kubeovn.ovnNbPort" . }}"
+            - name: KUBE_OVN_SB_PORT
+              value: "{{ include "kubeovn.ovnSbPort" . }}"
           resources:
             requests:
               cpu: 300m
@@ -132,4 +137,6 @@ spec:
           secret:
             optional: true
             secretName: kube-ovn-tls
+{{- end }}
+
 {{- end }}

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -1,8 +1,10 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: bgp-confs.kubeovn.io
 spec:
@@ -71,6 +73,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: dnsnameresolvers.kubeovn.io
 spec:
@@ -284,6 +287,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: evpn-confs.kubeovn.io
 spec:
@@ -335,6 +339,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ippools.kubeovn.io
 spec:
@@ -491,6 +496,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ips.kubeovn.io
 spec:
@@ -600,6 +606,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: iptables-dnat-rules.kubeovn.io
 spec:
@@ -758,6 +765,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: iptables-eips.kubeovn.io
 spec:
@@ -895,6 +903,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: iptables-fip-rules.kubeovn.io
 spec:
@@ -1026,6 +1035,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: iptables-snat-rules.kubeovn.io
 spec:
@@ -1157,6 +1167,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ovn-dnat-rules.kubeovn.io
 spec:
@@ -1336,6 +1347,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ovn-eips.kubeovn.io
 spec:
@@ -1479,6 +1491,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ovn-fips.kubeovn.io
 spec:
@@ -1637,6 +1650,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ovn-snat-rules.kubeovn.io
 spec:
@@ -1780,6 +1794,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: provider-networks.kubeovn.io
 spec:
@@ -1986,6 +2001,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: qos-policies.kubeovn.io
 spec:
@@ -2161,6 +2177,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: security-groups.kubeovn.io
 spec:
@@ -2320,6 +2337,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: subnets.kubeovn.io
 spec:
@@ -2762,6 +2780,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: switch-lb-rules.kubeovn.io
 spec:
@@ -2902,6 +2921,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: vips.kubeovn.io
 spec:
@@ -3057,6 +3077,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: vlans.kubeovn.io
 spec:
@@ -3178,6 +3199,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: vpc-dnses.kubeovn.io
 spec:
@@ -3298,6 +3320,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: vpc-egress-gateways.kubeovn.io
 spec:
@@ -3875,6 +3898,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: vpc-nat-gateways.kubeovn.io
 spec:
@@ -5947,6 +5971,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.20.1
   name: vpcs.kubeovn.io
 spec:
@@ -6234,3 +6259,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/kube-ovn/templates/monitor-deploy.yaml
+++ b/charts/kube-ovn/templates/monitor-deploy.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderFullOnly" . }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -172,3 +173,5 @@ spec:
         - name: kube-ovn-log
           hostPath:
             path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+
+{{- end }}

--- a/charts/kube-ovn/templates/monitor-svc.yaml
+++ b/charts/kube-ovn/templates/monitor-svc.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderFullOnly" . }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -16,3 +17,5 @@ spec:
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}
+
+{{- end }}

--- a/charts/kube-ovn/templates/nb-svc.yaml
+++ b/charts/kube-ovn/templates/nb-svc.yaml
@@ -1,12 +1,16 @@
 {{- if include "kubeovn.renderControlPlane" . }}
 {{- $svc := index .Values "ovn-central" "service" }}
+{{- $hcp := index .Values "ovn-central" "hcp" }}
+{{- $hcpSvc := index .Values "ovn-central" "hcp" "service" }}
+{{- if not $hcp.enabled }}
 {{- include "kubeovn.validateService" . }}
+{{- end }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
-  namespace: {{ .Values.namespace }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   annotations:
     # MetalLB allows multiple Services to share a single VIP only when they
     # carry the same allow-shared-ip annotation. The three ovn-* Services all
@@ -21,11 +25,14 @@ spec:
       protocol: TCP
       port: 6641
       targetPort: 6641
-  type: {{ $svc.type | default "ClusterIP" }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+      {{- if and $hcp.enabled (or (eq $hcpSvc.type "NodePort") (eq $hcpSvc.type "LoadBalancer")) }}
+      nodePort: {{ $hcpSvc.nbNodePort }}
+      {{- end }}
+  type: {{ ternary ($hcpSvc.type | default "ClusterIP") ($svc.type | default "ClusterIP") $hcp.enabled }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
   {{- end }}
-  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  {{- if and (not $hcp.enabled) (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
   externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
   {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
@@ -33,7 +40,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
-    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
+    {{- if or $hcp.enabled (ne .Values.OVN_CENTRAL_MODE "single") }}
     ovn-nb-leader: "true"
     {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/templates/nb-svc.yaml
+++ b/charts/kube-ovn/templates/nb-svc.yaml
@@ -1,19 +1,41 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- $svc := index .Values "ovn-central" "service" }}
+{{- include "kubeovn.validateService" . }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
   namespace: {{ .Values.namespace }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  annotations:
+    # MetalLB allows multiple Services to share a single VIP only when they
+    # carry the same allow-shared-ip annotation. The three ovn-* Services all
+    # opt into the same group so a Kamaji-style data plane can dial nb / sb /
+    # northd on one VIP, distinguished only by port. Harmless on non-MetalLB
+    # load balancers; remove the annotation if your provider rejects it.
+    metallb.universe.tf/allow-shared-ip: kube-ovn-central
+  {{- end }}
 spec:
   ports:
     - name: ovn-nb
       protocol: TCP
       port: 6641
       targetPort: 6641
-  type: ClusterIP
+  type: {{ $svc.type | default "ClusterIP" }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}
   selector:
     app: ovn-central
+    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
     ovn-nb-leader: "true"
+    {{- end }}
   sessionAffinity: None
+
+{{- end }}

--- a/charts/kube-ovn/templates/northd-svc.yaml
+++ b/charts/kube-ovn/templates/northd-svc.yaml
@@ -1,12 +1,15 @@
 {{- if include "kubeovn.renderControlPlane" . }}
 {{- $svc := index .Values "ovn-central" "service" }}
+{{- $hcp := index .Values "ovn-central" "hcp" }}
+{{- if not $hcp.enabled }}
 {{- include "kubeovn.validateService" . }}
+{{- end }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-northd
-  namespace: {{ .Values.namespace }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   annotations:
     metallb.universe.tf/allow-shared-ip: kube-ovn-central
   {{- end }}
@@ -16,11 +19,11 @@ spec:
       protocol: TCP
       port: 6643
       targetPort: 6643
-  type: {{ $svc.type | default "ClusterIP" }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  type: {{ ternary "ClusterIP" ($svc.type | default "ClusterIP") $hcp.enabled }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
   {{- end }}
-  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  {{- if and (not $hcp.enabled) (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
   externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
   {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
@@ -28,7 +31,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
-    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
+    {{- if or $hcp.enabled (ne .Values.OVN_CENTRAL_MODE "single") }}
     ovn-northd-leader: "true"
     {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/templates/northd-svc.yaml
+++ b/charts/kube-ovn/templates/northd-svc.yaml
@@ -1,19 +1,36 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- $svc := index .Values "ovn-central" "service" }}
+{{- include "kubeovn.validateService" . }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-northd
   namespace: {{ .Values.namespace }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  annotations:
+    metallb.universe.tf/allow-shared-ip: kube-ovn-central
+  {{- end }}
 spec:
   ports:
     - name: ovn-northd
       protocol: TCP
       port: 6643
       targetPort: 6643
-  type: ClusterIP
+  type: {{ $svc.type | default "ClusterIP" }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}
   selector:
     app: ovn-central
+    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
     ovn-northd-leader: "true"
+    {{- end }}
   sessionAffinity: None
+
+{{- end }}

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -1,3 +1,11 @@
+{{- /*
+ClusterRoles / Role partitioned by installMode:
+- system:ovn          : data plane (kube-ovn-controller, ic-controller)
+- system:ovn-ovs      : both planes (ovn-central in mgmt, ovs-ovn in tenant)
+- system:kube-ovn-cni : data plane
+- secret-reader-ovn-ipsec / system:kube-ovn-app : data plane
+*/}}
+{{- if include "kubeovn.renderDataPlane" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -267,6 +275,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -301,6 +310,7 @@ rules:
     verbs:
       - get
       - list
+{{- if include "kubeovn.renderDataPlane" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -430,3 +440,4 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+{{- end }}

--- a/charts/kube-ovn/templates/ovn-CRB.yaml
+++ b/charts/kube-ovn/templates/ovn-CRB.yaml
@@ -1,3 +1,11 @@
+{{- /*
+ClusterRoleBindings / RoleBindings partitioned by installMode:
+- ovn          : data plane (kube-ovn-controller, ic-controller)
+- ovn-ovs      : both planes (ovn-central in mgmt, ovs-ovn in tenant)
+- kube-ovn-cni : data plane
+- kube-ovn-app : data plane
+*/}}
+{{- if include "kubeovn.renderDataPlane" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -25,6 +33,7 @@ subjects:
     name: ovn
     namespace: {{ .Values.namespace }}
 ---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -38,6 +47,7 @@ subjects:
     name: ovn-ovs
     namespace: {{ .Values.namespace }}
 
+{{- if include "kubeovn.renderDataPlane" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -106,3 +116,4 @@ subjects:
   - kind: ServiceAccount
     name: kube-ovn-app
     namespace: {{ .Values.namespace }}
+{{- end }}

--- a/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
+++ b/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
@@ -59,8 +59,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+            {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
+++ b/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderFullOnly" . }}
 {{- if .Values.HYBRID_DPDK }}
 kind: DaemonSet
 apiVersion: apps/v1
@@ -164,4 +165,6 @@ spec:
           secret:
             optional: true
             secretName: kube-ovn-tls
+{{- end }}
+
 {{- end }}

--- a/charts/kube-ovn/templates/ovn-sa.yaml
+++ b/charts/kube-ovn/templates/ovn-sa.yaml
@@ -1,3 +1,11 @@
+{{- /*
+ServiceAccounts. Partitioned by installMode:
+- ovn          : used by kube-ovn-controller / ic-controller   → data plane
+- ovn-ovs      : used by ovn-central AND ovs-ovn               → both planes
+- kube-ovn-cni : used by kube-ovn-cni DaemonSet                → data plane
+- kube-ovn-app : used by kube-ovn-monitor / kube-ovn-pinger    → data plane
+*/}}
+{{- if include "kubeovn.renderDataPlane" . }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,6 +22,7 @@ imagePullSecrets:
 {{- end }}
 
 ---
+{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -29,6 +38,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
+{{- if include "kubeovn.renderDataPlane" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -57,6 +67,7 @@ imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}
 {{- if $secret }}
 - name: {{ $secret | quote}}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-ovn/templates/ovn-tls-secret.yaml
+++ b/charts/kube-ovn/templates/ovn-tls-secret.yaml
@@ -1,4 +1,16 @@
 {{- if .Values.networking.ENABLE_SSL }}
+{{- $existingSecret := lookup "v1" "Secret" .Values.namespace "kube-ovn-tls" }}
+{{- if eq .Values.installMode "dataPlaneOnly" }}
+  {{- if not $existingSecret }}
+    {{- fail (printf "installMode=dataPlaneOnly with networking.ENABLE_SSL=true requires the kube-ovn-tls Secret in namespace %q to be pre-seeded with the SAME CA/cert/key as the management cluster's ovn-central. Self-signing locally would produce certs the management cluster does not trust, breaking every NB/SB connection. Sync the Secret from the mgmt cluster (kubectl get secret kube-ovn-tls -o yaml | kubectl --context=tenant apply -f -) and re-run helm." .Values.namespace) }}
+  {{- end }}
+  {{- /*
+  Intentionally do NOT render the Secret manifest in dataPlaneOnly: the
+  operator owns its lifecycle (out-of-band sync from the management
+  cluster). Rendering it here would make Helm try to create or adopt the
+  pre-seeded Secret and fail with "resource already exists".
+  */ -}}
+{{- else }}
 {{- $cn := "ovn" -}}
 {{- $ca := genCA "ovn-ca" 3650 -}}
 ---
@@ -8,7 +20,6 @@ metadata:
   name: kube-ovn-tls
   namespace: {{ .Values.namespace }}
 data:
-{{- $existingSecret := lookup "v1" "Secret" .Values.namespace "kube-ovn-tls" }}
   {{- if $existingSecret }}
   cacert: {{ index $existingSecret.data "cacert" }}
   cert: {{ index $existingSecret.data "cert" }}
@@ -20,4 +31,5 @@ data:
   key: {{ b64enc .Key }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -290,3 +291,5 @@ spec:
           hostPath:
             path: {{ .Values.OVN_IPSEC_KEY_DIR }}
         {{- end }}
+
+{{- end }}

--- a/charts/kube-ovn/templates/ovncni-svc.yaml
+++ b/charts/kube-ovn/templates/ovncni-svc.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -14,3 +15,5 @@ spec:
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}
+
+{{- end }}

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -123,10 +123,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: KUBE_OVN_SB_PORT
               value: "{{ include "kubeovn.ovnSbPort" . }}"
+            {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -123,7 +124,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
+            - name: KUBE_OVN_SB_PORT
+              value: "{{ include "kubeovn.ovnSbPort" . }}"
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.networking.OVN_REMOTE_PROBE_INTERVAL }}"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL
@@ -210,3 +213,5 @@ spec:
         - hostPath:
             path: /var/run/containerd
           name: cruntime
+
+{{- end }}

--- a/charts/kube-ovn/templates/pinger-ds.yaml
+++ b/charts/kube-ovn/templates/pinger-ds.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -177,3 +178,5 @@ spec:
           secret:
             optional: true
             secretName: kube-ovn-tls
+
+{{- end }}

--- a/charts/kube-ovn/templates/pinger-svc.yaml
+++ b/charts/kube-ovn/templates/pinger-svc.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -14,3 +15,5 @@ spec:
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}
+
+{{- end }}

--- a/charts/kube-ovn/templates/post-delete-hook.yaml
+++ b/charts/kube-ovn/templates/post-delete-hook.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -138,3 +139,5 @@ spec:
         - name: kube-ovn-log
           hostPath:
             path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+
+{{- end }}

--- a/charts/kube-ovn/templates/pre-upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn/templates/pre-upgrade-ovs-ovn.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderFullOnly" . }}
 {{- if include "kubeovn.ovn.versionCompatibility" . -}}
 ---
 apiVersion: v1
@@ -130,3 +131,5 @@ spec:
           hostPath:
             path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
 {{- end -}}
+
+{{- end }}

--- a/charts/kube-ovn/templates/sb-svc.yaml
+++ b/charts/kube-ovn/templates/sb-svc.yaml
@@ -1,19 +1,36 @@
+{{- if include "kubeovn.renderControlPlane" . }}
+{{- $svc := index .Values "ovn-central" "service" }}
+{{- include "kubeovn.validateService" . }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-sb
   namespace: {{ .Values.namespace }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  annotations:
+    metallb.universe.tf/allow-shared-ip: kube-ovn-central
+  {{- end }}
 spec:
   ports:
     - name: ovn-sb
       protocol: TCP
       port: 6642
       targetPort: 6642
-  type: ClusterIP
+  type: {{ $svc.type | default "ClusterIP" }}
+  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
   ipFamilyPolicy: PreferDualStack
   {{- end }}
   selector:
     app: ovn-central
+    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
     ovn-sb-leader: "true"
+    {{- end }}
   sessionAffinity: None
+
+{{- end }}

--- a/charts/kube-ovn/templates/sb-svc.yaml
+++ b/charts/kube-ovn/templates/sb-svc.yaml
@@ -1,12 +1,16 @@
 {{- if include "kubeovn.renderControlPlane" . }}
 {{- $svc := index .Values "ovn-central" "service" }}
+{{- $hcp := index .Values "ovn-central" "hcp" }}
+{{- $hcpSvc := index .Values "ovn-central" "hcp" "service" }}
+{{- if not $hcp.enabled }}
 {{- include "kubeovn.validateService" . }}
+{{- end }}
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-sb
-  namespace: {{ .Values.namespace }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+  namespace: {{ include "kubeovn.centralNamespace" . }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   annotations:
     metallb.universe.tf/allow-shared-ip: kube-ovn-central
   {{- end }}
@@ -16,11 +20,14 @@ spec:
       protocol: TCP
       port: 6642
       targetPort: 6642
-  type: {{ $svc.type | default "ClusterIP" }}
-  {{- if and (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
+      {{- if and $hcp.enabled (or (eq $hcpSvc.type "NodePort") (eq $hcpSvc.type "LoadBalancer")) }}
+      nodePort: {{ $hcpSvc.sbNodePort }}
+      {{- end }}
+  type: {{ ternary ($hcpSvc.type | default "ClusterIP") ($svc.type | default "ClusterIP") $hcp.enabled }}
+  {{- if and (not $hcp.enabled) (eq $svc.type "LoadBalancer") $svc.loadBalancerIP }}
   loadBalancerIP: {{ $svc.loadBalancerIP | quote }}
   {{- end }}
-  {{- if and (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
+  {{- if and (not $hcp.enabled) (or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort")) $svc.externalTrafficPolicy }}
   externalTrafficPolicy: {{ $svc.externalTrafficPolicy }}
   {{- end }}
   {{- if eq .Values.networking.NET_STACK "dual_stack" }}
@@ -28,7 +35,7 @@ spec:
   {{- end }}
   selector:
     app: ovn-central
-    {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
+    {{- if or $hcp.enabled (ne .Values.OVN_CENTRAL_MODE "single") }}
     ovn-sb-leader: "true"
     {{- end }}
   sessionAffinity: None

--- a/charts/kube-ovn/templates/upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn/templates/upgrade-ovs-ovn.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderFullOnly" . }}
 {{- if include "kubeovn.ovn.versionCompatibility" . -}}
 ---
 apiVersion: v1
@@ -178,3 +179,5 @@ spec:
             optional: true
             secretName: kube-ovn-tls
 {{- end -}}
+
+{{- end }}

--- a/charts/kube-ovn/templates/vpc-nat-config.yaml
+++ b/charts/kube-ovn/templates/vpc-nat-config.yaml
@@ -1,3 +1,4 @@
+{{- if include "kubeovn.renderDataPlane" . }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -17,3 +18,5 @@ metadata:
   namespace: {{ .Values.namespace }}
 data:
   enable-vpc-nat-gw: "{{ .Values.func.ENABLE_NAT_GW }}"
+
+{{- end }}

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -1,0 +1,224 @@
+suite: OVN central HCP deployment
+templates:
+  - central-deploy.yaml
+  - central-hcp-rbac.yaml
+  - central-svc.yaml
+  - nb-svc.yaml
+  - sb-svc.yaml
+  - controller-deploy.yaml
+  - ovsovn-ds.yaml
+  - ovn-dpdk-ds.yaml
+tests:
+  - it: renders ovn-central as a PVC-backed StatefulSet in the HCP namespace
+    template: central-deploy.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+      ovn-central.hcp.replicas: 3
+      ovn-central.hcp.storage.size: 5Gi
+      ovn-central.hcp.storage.storageClassName: topolvm
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.serviceName
+          value: ovn-central
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: ovn-central
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_IPS
+            value: ovn-central-0.ovn-central.hcp.svc,ovn-central-1.ovn-central.hcp.svc,ovn-central-2.ovn-central.hcp.svc
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_CLUSTER_ADDR
+            value: $(POD_NAME).ovn-central.$(POD_NAMESPACE).svc
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 5Gi
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: topolvm
+
+  - it: creates dedicated namespaced RBAC for HCP ovn-central
+    template: central-hcp-rbac.yaml
+    documentIndex: 0
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ovn-central
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: creates a headless service for StatefulSet raft DNS
+    template: central-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ovn-central
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+
+  - it: exposes nb and sb through HCP node ports
+    template: nb-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.service.type: NodePort
+      ovn-central.hcp.service.nbNodePort: 30641
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: hcp
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30641
+
+  - it: omits node ports when HCP services are rendered as ClusterIP
+    template: nb-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.service.type: ClusterIP
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: defaults empty HCP NB service type to ClusterIP
+    template: nb-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.service.type: ""
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: defaults empty HCP SB service type to ClusterIP
+    template: sb-svc.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.service.type: ""
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: points workload components at independent HCP OVN DB addresses
+    template: controller-deploy.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_NB_ADDR
+            value: tcp:ovn-nb.example.com:6641
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs-ovn at the HCP OVN SB address
+    template: ovsovn-ds.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs-ovn-dpdk at the HCP OVN SB address
+    template: ovn-dpdk-ds.yaml
+    set:
+      HYBRID_DPDK: true
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -191,6 +191,21 @@ DPDK_CPU: "1000m"  # Default CPU configuration
 DPDK_MEMORY: "2Gi"  # Default Memory configuration
 
 ovn-central:
+  hcp:
+    enabled: false
+    namespace: hcp
+    replicas: 3
+    # OVN NB address used by workload clusters, for example tcp:ovn-nb.example.com:6641.
+    nbAddress: ""
+    # OVN SB address used by workload clusters, for example tcp:ovn-sb.example.com:6642.
+    sbAddress: ""
+    service:
+      type: NodePort
+      nbNodePort: 30641
+      sbNodePort: 30642
+    storage:
+      size: 5Gi
+      storageClassName: ""
   requests:
     cpu: "300m"
     memory: "200Mi"

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -21,6 +21,37 @@ namespace: kube-system
 MASTER_NODES: ""
 MASTER_NODES_LABEL: "kube-ovn/role=master"
 
+# OVN_CENTRAL_MODE controls how ovn-central is deployed.
+#   cluster: multi-replica raft cluster, one pod per master node (default).
+#   single:  single-replica Deployment backed by a PVC, can drift to another
+#            node when the host fails. Uses ovsdb standalone mode (no raft).
+OVN_CENTRAL_MODE: "cluster"
+
+# installMode controls which slice of the chart this Helm release renders.
+#   full:             all components in one cluster (default, classic install).
+#   controlPlaneOnly: only ovn-central + ovn-nb/ovn-sb/ovn-northd Services and
+#                     their RBAC. Use on the management cluster of a Kamaji-
+#                     style split deployment.
+#   dataPlaneOnly:    CRDs + kube-ovn-controller + kube-ovn-cni + ovs-ovn +
+#                     pinger and their RBAC. Use on tenant data-plane
+#                     clusters that connect back to an external ovn-central via
+#                     externalOvnCentral below. kube-ovn-monitor is intentionally
+#                     skipped: it reads local OVN Unix sockets / DB files and
+#                     does not yet know how to talk to a remote ovn-central.
+installMode: full
+
+# When installMode=dataPlaneOnly, the agents and controller cannot rely on a
+# local ovn-central Service. Set externalOvnCentral.endpoint to the IP address
+# that exposes the management cluster's ovn-nb / ovn-sb Services (typically a
+# LoadBalancer VIP reachable from this cluster). DNS hostnames work with OVN
+# >= 22.03 but use an IP literal if you need to support older OVN versions —
+# the OVN connection string format `tcp:[host]:port` parses brackets only as
+# IP literals in older code paths.
+externalOvnCentral:
+  endpoint: ""
+  nbPort: 6641
+  sbPort: 6642
+
 networking:
   # NET_STACK could be dual_stack, ipv4, ipv6
   NET_STACK: ipv4
@@ -167,6 +198,34 @@ ovn-central:
     cpu: "3"
     memory: "4Gi"
     ephemeral-storage: 1Gi
+  # Persistent storage for the OVN DB files. Only used when OVN_CENTRAL_MODE=single.
+  # The StorageClass should support cross-node attach (e.g. NFS, Ceph RBD, cloud
+  # block storage with attach/detach) if you want ovn-central to drift between
+  # nodes on host failure.
+  storage:
+    storageClassName: ""
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+    # Set existingClaim to skip in-chart PVC creation and point the
+    # Deployment at a PVC the operator manages out-of-band (e.g. via a
+    # storage operator). The value is the name of the existing PVC; the
+    # Deployment's host-config-ovn volume mounts whatever you set here.
+    # Leaving this empty makes the chart create a PVC named
+    # "ovn-central-data" itself.
+    existingClaim: ""
+  # Service exposure for ovn-nb / ovn-sb / ovn-northd. Default ClusterIP is
+  # only reachable from inside the cluster. Switch to LoadBalancer (or
+  # NodePort) to expose the OVN DB to data-plane components running outside
+  # the management cluster — for example a Kamaji-style topology where
+  # ovn-controller / kube-ovn-cni / kube-ovn-controller run in a separate
+  # tenant cluster and connect back over a stable VIP.
+  service:
+    type: ClusterIP
+    # Optional, only honoured when type=LoadBalancer; provider-dependent.
+    loadBalancerIP: ""
+    # Optional, only honoured when type=LoadBalancer / NodePort.
+    externalTrafficPolicy: ""
 ovs-ovn:
   updateStrategy:
     type: ""  # Override the DaemonSet update strategy. Leave empty to auto-detect based on the deployed version.

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -76,6 +76,24 @@ function ovn_central_tls_env {
 EOF
 }
 
+# Single-replica ovn-central mode: deploy a single Deployment-managed pod with
+# OVN DB stored on a PVC, so the pod can drift to another node on host failure.
+# When enabled, NODE_IPS/OVN_DB_IPS are passed empty so clients fall back to the
+# ovn-nb / ovn-sb Service ClusterIPs auto-injected via OVN_*_SERVICE_HOST.
+ENABLE_SINGLE_REPLICA_OVN=${ENABLE_SINGLE_REPLICA_OVN:-false}
+OVN_CENTRAL_PVC_SIZE=${OVN_CENTRAL_PVC_SIZE:-10Gi}
+# Empty means use the cluster's default StorageClass. For real cross-node drift
+# pick one that supports cross-node attach (NFS-CSI, Ceph RBD, cloud EBS, ...).
+OVN_CENTRAL_STORAGE_CLASS=${OVN_CENTRAL_STORAGE_CLASS:-}
+
+# Service exposure for ovn-nb / ovn-sb / ovn-northd. Default ClusterIP is
+# only reachable from inside the cluster. Switch to LoadBalancer (or NodePort)
+# to expose the OVN DB to data-plane components running outside the
+# management cluster (e.g. Kamaji-style separated control/data planes).
+OVN_CENTRAL_SERVICE_TYPE=${OVN_CENTRAL_SERVICE_TYPE:-ClusterIP}
+OVN_CENTRAL_LB_IP=${OVN_CENTRAL_LB_IP:-}
+OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY=${OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY:-}
+
 PROBE_HTTP_SCHEME="HTTP"
 if [ "$SECURE_SERVING" = "true" ]; then
   PROBE_HTTP_SCHEME="HTTPS"
@@ -262,7 +280,123 @@ echo ""
 echo "[Step 2/6] Install OVN components"
 addresses=$(kubectl get no -lkube-ovn/role=master --no-headers -o wide | awk '{print $6}' | tr \\n ',' | sed 's/,$//')
 count=$(kubectl get no -lkube-ovn/role=master --no-headers | wc -l)
-echo "Install OVN DB in $addresses"
+
+# Reject in-place OVN_CENTRAL_MODE switches that would silently drop the live
+# OVN DB. Mirror the Helm chart's lookup-based guard so install.sh users get
+# the same protection. The Deployment's host-config-ovn volume tells us
+# whether the existing release is raft (hostPath) or single (PVC).
+if kubectl get deployment -n kube-system ovn-central >/dev/null 2>&1; then
+  existing_host_path=$(kubectl get deployment -n kube-system ovn-central \
+    -o jsonpath='{.spec.template.spec.volumes[?(@.name=="host-config-ovn")].hostPath.path}' 2>/dev/null)
+  existing_pvc=$(kubectl get deployment -n kube-system ovn-central \
+    -o jsonpath='{.spec.template.spec.volumes[?(@.name=="host-config-ovn")].persistentVolumeClaim.claimName}' 2>/dev/null)
+  if [ "$ENABLE_SINGLE_REPLICA_OVN" = "true" ] && [ -n "$existing_host_path" ]; then
+    echo "ERROR: Refusing to switch in place from raft cluster mode (hostPath /etc/ovn) to single-replica mode (PVC)."
+    echo "       The new ovn-central pod would start against an empty PVC and lose all live OVN state."
+    echo "       Migrate explicitly: backup the DB, kubectl delete deployment ovn-central, then re-run install.sh."
+    exit 1
+  fi
+  if [ "$ENABLE_SINGLE_REPLICA_OVN" != "true" ] && [ -n "$existing_pvc" ]; then
+    echo "ERROR: Refusing to switch in place from single-replica mode (PVC) to raft cluster mode (hostPath)."
+    echo "       The cluster-mode ovn-central would start without the PVC-backed DB. Migrate explicitly."
+    exit 1
+  fi
+fi
+
+if [ "$ENABLE_SINGLE_REPLICA_OVN" = "true" ]; then
+  # In single-replica mode the OVN DB lives on a PVC, so NODE_IPS/OVN_DB_IPS
+  # must be empty (clients use the Service ClusterIPs) and the Deployment runs
+  # exactly one pod.
+  addresses=""
+  count=1
+  echo "Install ovn-central as a single-replica Deployment backed by PVC ovn-central-data"
+else
+  echo "Install OVN DB in $addresses"
+fi
+
+# Pre-compute the YAML fragments that differ between cluster and single mode.
+# These are injected into the ovn.yaml HEREDOC below via ${VAR} expansion.
+if [ "$ENABLE_SINGLE_REPLICA_OVN" = "true" ]; then
+  OVN_NB_LEADER_SELECTOR=""
+  OVN_SB_LEADER_SELECTOR=""
+  OVN_NORTHD_LEADER_SELECTOR=""
+  OVN_CENTRAL_STRATEGY_BODY="    type: Recreate"
+  OVN_CENTRAL_AFFINITY_BLOCK=""
+  OVN_CENTRAL_CONFIG_VOLUME="        - name: host-config-ovn
+          persistentVolumeClaim:
+            claimName: ovn-central-data"
+  OVN_CENTRAL_PVC_BLOCK="---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ovn-central-data
+  namespace: kube-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${OVN_CENTRAL_PVC_SIZE}"
+  if [ -n "${OVN_CENTRAL_STORAGE_CLASS}" ]; then
+    OVN_CENTRAL_PVC_BLOCK="${OVN_CENTRAL_PVC_BLOCK}
+  storageClassName: \"${OVN_CENTRAL_STORAGE_CLASS}\""
+  fi
+else
+  OVN_NB_LEADER_SELECTOR='    ovn-nb-leader: "true"'
+  OVN_SB_LEADER_SELECTOR='    ovn-sb-leader: "true"'
+  OVN_NORTHD_LEADER_SELECTOR='    ovn-northd-leader: "true"'
+  OVN_CENTRAL_STRATEGY_BODY="    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate"
+  OVN_CENTRAL_AFFINITY_BLOCK="      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: ovn-central
+              topologyKey: kubernetes.io/hostname"
+  OVN_CENTRAL_CONFIG_VOLUME="        - name: host-config-ovn
+          hostPath:
+            path: /etc/origin/ovn"
+  OVN_CENTRAL_PVC_BLOCK=""
+fi
+
+# Optional LoadBalancer / NodePort tweaks for the three ovn-central Services.
+OVN_CENTRAL_LB_BLOCK=""
+if [ "$OVN_CENTRAL_SERVICE_TYPE" = "LoadBalancer" ] && [ -n "$OVN_CENTRAL_LB_IP" ]; then
+  OVN_CENTRAL_LB_BLOCK="  loadBalancerIP: \"$OVN_CENTRAL_LB_IP\""
+fi
+OVN_CENTRAL_ETP_BLOCK=""
+if { [ "$OVN_CENTRAL_SERVICE_TYPE" = "LoadBalancer" ] || [ "$OVN_CENTRAL_SERVICE_TYPE" = "NodePort" ]; } && [ -n "$OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY" ]; then
+  OVN_CENTRAL_ETP_BLOCK="  externalTrafficPolicy: $OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY"
+fi
+# MetalLB shared-IP annotation for the three Services so they can colocate on
+# the same loadBalancerIP. Harmless on non-MetalLB providers.
+OVN_CENTRAL_SVC_ANNOTATIONS=""
+if [ "$OVN_CENTRAL_SERVICE_TYPE" = "LoadBalancer" ] && [ -n "$OVN_CENTRAL_LB_IP" ]; then
+  OVN_CENTRAL_SVC_ANNOTATIONS="  annotations:
+    metallb.universe.tf/allow-shared-ip: kube-ovn-central"
+fi
+# externalOvnCentral.endpoint is a single IP, so all three OVN Services must
+# land on the same VIP. Without an explicit loadBalancerIP cloud LB controllers
+# assign three separate IPs and tenant clusters can only reach one of NB/SB/
+# northd. Mirror the Helm chart's kubeovn.validateService guard here.
+if [ "$OVN_CENTRAL_SERVICE_TYPE" = "LoadBalancer" ] && [ -z "$OVN_CENTRAL_LB_IP" ]; then
+  echo "ERROR: OVN_CENTRAL_SERVICE_TYPE=LoadBalancer requires OVN_CENTRAL_LB_IP to be set so the three OVN Services share a single VIP."
+  echo "       Pick a VIP, configure your LB controller to assign it (MetalLB allow-shared-ip annotation is emitted automatically), then re-run install.sh."
+  exit 1
+fi
+
+# /etc/ovn is mounted from a PVC in single-replica mode. Some backends (e.g.
+# root-squashed NFS, which the docs recommend for failover) reject chown by
+# root, so make the OVN DB directory's chown best-effort there. ovn-central
+# runs as `nobody` and creates new files with the right owner regardless.
+if [ "$ENABLE_SINGLE_REPLICA_OVN" = "true" ]; then
+  OVN_CENTRAL_INIT_CHOWN_CMD="chown -R nobody: /var/run/ovn /var/log/ovn && (chown -R nobody: /etc/ovn 2>/dev/null || echo 'chown /etc/ovn skipped (likely root-squashed NFS); ovn will write as nobody anyway')"
+else
+  OVN_CENTRAL_INIT_CHOWN_CMD="chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
+fi
 
 # BEGIN GENERATED KUBE-OVN CRD BUNDLE
 cat <<'EOF' > kube-ovn-crd.yaml
@@ -7101,23 +7235,27 @@ kubectl apply -f kube-ovn-cni-sa.yaml
 kubectl apply -f kube-ovn-app-sa.yaml
 
 cat <<EOF > ovn.yaml
+${OVN_CENTRAL_PVC_BLOCK}
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
   namespace: kube-system
+${OVN_CENTRAL_SVC_ANNOTATIONS}
 spec:
   ports:
     - name: ovn-nb
       protocol: TCP
       port: 6641
       targetPort: 6641
-  type: ClusterIP
+  type: ${OVN_CENTRAL_SERVICE_TYPE}
+${OVN_CENTRAL_LB_BLOCK}
+${OVN_CENTRAL_ETP_BLOCK}
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central
-    ovn-nb-leader: "true"
+${OVN_NB_LEADER_SELECTOR}
   sessionAffinity: None
 
 ---
@@ -7126,17 +7264,20 @@ apiVersion: v1
 metadata:
   name: ovn-sb
   namespace: kube-system
+${OVN_CENTRAL_SVC_ANNOTATIONS}
 spec:
   ports:
     - name: ovn-sb
       protocol: TCP
       port: 6642
       targetPort: 6642
-  type: ClusterIP
+  type: ${OVN_CENTRAL_SERVICE_TYPE}
+${OVN_CENTRAL_LB_BLOCK}
+${OVN_CENTRAL_ETP_BLOCK}
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central
-    ovn-sb-leader: "true"
+${OVN_SB_LEADER_SELECTOR}
   sessionAffinity: None
 
 ---
@@ -7145,17 +7286,20 @@ apiVersion: v1
 metadata:
   name: ovn-northd
   namespace: kube-system
+${OVN_CENTRAL_SVC_ANNOTATIONS}
 spec:
   ports:
     - name: ovn-northd
       protocol: TCP
       port: 6643
       targetPort: 6643
-  type: ClusterIP
+  type: ${OVN_CENTRAL_SERVICE_TYPE}
+${OVN_CENTRAL_LB_BLOCK}
+${OVN_CENTRAL_ETP_BLOCK}
   ${SVC_YAML_IPFAMILYPOLICY}
   selector:
     app: ovn-central
-    ovn-northd-leader: "true"
+${OVN_NORTHD_LEADER_SELECTOR}
   sessionAffinity: None
 ---
 kind: Deployment
@@ -7169,10 +7313,7 @@ metadata:
 spec:
   replicas: $count
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
-    type: RollingUpdate
+${OVN_CENTRAL_STRATEGY_BODY}
   selector:
     matchLabels:
       app: ovn-central
@@ -7190,13 +7331,7 @@ spec:
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: ovn-central
-              topologyKey: kubernetes.io/hostname
+${OVN_CENTRAL_AFFINITY_BLOCK}
       priorityClassName: system-cluster-critical
       serviceAccountName: ovn-ovs
       automountServiceAccountToken: true
@@ -7210,7 +7345,7 @@ spec:
           command:
             - sh
             - -c
-            - "chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn"
+            - "$OVN_CENTRAL_INIT_CHOWN_CMD"
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:
@@ -7242,7 +7377,7 @@ spec:
           env:
 $(ovn_central_tls_env)
             - name: NODE_IPS
-              value: $addresses
+              value: "$addresses"
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -7316,9 +7451,7 @@ $(ovn_central_tls_env)
         - name: host-run-ovn
           hostPath:
             path: /run/ovn
-        - name: host-config-ovn
-          hostPath:
-            path: /etc/origin/ovn
+${OVN_CENTRAL_CONFIG_VOLUME}
         - name: host-log-ovn
           hostPath:
             path: $LOG_DIR/ovn
@@ -7447,7 +7580,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: $addresses
+              value: "$addresses"
             - name: DEBUG_WRAPPER
               value: "$DEBUG_WRAPPER"
             - name: OVN_REMOTE_PROBE_INTERVAL
@@ -7599,7 +7732,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: $addresses
+              value: "$addresses"
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "10000"
             - name: OVN_REMOTE_OPENFLOW_INTERVAL
@@ -7879,7 +8012,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OVN_DB_IPS
-              value: $addresses
+              value: "$addresses"
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -8510,7 +8643,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OVN_DB_IPS
-              value: $addresses
+              value: "$addresses"
           resources:
             requests:
               cpu: 300m

--- a/dist/images/ovn-healthcheck.sh
+++ b/dist/images/ovn-healthcheck.sh
@@ -10,6 +10,22 @@ ovn-ctl status_northd
 ovn-ctl status_ovnnb | grep -q '^running'
 ovn-ctl status_ovnsb | grep -q '^running'
 
+# Standalone (single-replica) mode has no raft cluster, so `cluster/status` is
+# not applicable. Fall back to a storage-status check on each local DB.
+if [[ -z "${NODE_IPS:-}" ]]; then
+    nb_storage=$(ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/get-db-storage-status OVN_Northbound)
+    sb_storage=$(ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/get-db-storage-status OVN_Southbound)
+    if echo "${nb_storage}" | grep -q "inconsistent"; then
+        echo "nb health check failed: ${nb_storage}"
+        exit 1
+    fi
+    if echo "${sb_storage}" | grep -q "inconsistent"; then
+        echo "sb health check failed: ${sb_storage}"
+        exit 1
+    fi
+    exit 0
+fi
+
 nb_status=$(ovn-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound | grep Status)
 sb_status=$(ovn-appctl -t /var/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound | grep Status)
 nb_role=$(ovn-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound | grep Role)

--- a/dist/images/ovn-is-leader.sh
+++ b/dist/images/ovn-is-leader.sh
@@ -11,6 +11,32 @@ ovn-ctl status_ovnsb
 POD_NAMESPACE=${POD_NAMESPACE:-kube-system}
 BIND_LOCAL_ADDR=[${POD_IP:-127.0.0.1}]
 
+# Single-replica (standalone) mode: there is exactly one ovn-central pod and the
+# DB is not clustered, so there is no raft leader to query and no ovn_northd
+# lock to contend. Always mark this pod as the leader for nb/sb/northd, then run
+# the DB consistency check and compaction.
+if [[ -z "${NODE_IPS:-}" ]]; then
+    kubectl label --overwrite pod "$POD_NAME" -n "$POD_NAMESPACE" \
+        ovn-nb-leader=true ovn-sb-leader=true ovn-northd-leader=true
+
+    nb_status=$(ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/get-db-storage-status OVN_Northbound)
+    echo "nb $nb_status"
+    if [[ $nb_status =~ "inconsistent" ]]; then
+        exit 1
+    fi
+    sb_status=$(ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/get-db-storage-status OVN_Southbound)
+    echo "sb $sb_status"
+    if [[ $sb_status =~ "inconsistent" ]]; then
+        exit 1
+    fi
+
+    set +e
+    ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/compact
+    ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/compact
+    echo ""
+    exit 0
+fi
+
 # For data consistency, only store leader address in endpoint
 # Store ovn-nb leader to svc kube-system/ovn-nb
 if [[ "$ENABLE_SSL" == "false" ]]; then

--- a/dist/images/restore-ovn-nb-db.sh
+++ b/dist/images/restore-ovn-nb-db.sh
@@ -1,6 +1,127 @@
 #!/bin/bash
 
 KUBE_OVN_NS=kube-system
+MODE=${1:-cluster}
+# Override RESTORE_HELPER_IMAGE in air-gapped or private-registry environments
+# where docker.io/busybox:1.36 is not reachable. The image only needs `sh`,
+# `mv`, `chown`, and `ls`, so any small Linux base works.
+RESTORE_HELPER_IMAGE=${RESTORE_HELPER_IMAGE:-docker.io/library/busybox:1.36}
+
+usage() {
+  cat >&2 <<USAGE
+Usage:
+  $0                        # cluster (raft) mode: convert local clustered DB to standalone and push to all masters
+  $0 cluster                # same as above (explicit)
+  $0 single <backup.db>     # single-replica mode: write <backup.db> into the ovn-central-data PVC
+
+Single-replica mode expects an already-standalone ovnnb_db.db file as input
+(produced earlier by 'ovsdb-tool cluster-to-standalone' or copied from a
+healthy single-replica pod).
+USAGE
+}
+
+if [ "$MODE" = "single" ]; then
+  BACKUP_FILE=${2:-}
+  if [ -z "$BACKUP_FILE" ] || [ ! -f "$BACKUP_FILE" ]; then
+    echo "ERROR: missing or unreadable backup file: '$BACKUP_FILE'"
+    usage
+    exit 1
+  fi
+
+  # Discover the actual PVC name from the Deployment so this also works when
+  # the operator pointed ovn-central at a custom claim via
+  # ovn-central.storage.existingClaim.
+  pvc_name=$(kubectl get deployment -n $KUBE_OVN_NS ovn-central \
+    -o jsonpath='{.spec.template.spec.volumes[?(@.name=="host-config-ovn")].persistentVolumeClaim.claimName}' 2>/dev/null)
+  if [ -z "$pvc_name" ]; then
+    echo "ERROR: ovn-central Deployment does not mount host-config-ovn from a PVC."
+    echo "       This script's 'single' mode only applies when ovn-central was"
+    echo "       installed with OVN_CENTRAL_MODE=single (or ENABLE_SINGLE_REPLICA_OVN=true)."
+    exit 1
+  fi
+  if ! kubectl get pvc -n $KUBE_OVN_NS "$pvc_name" >/dev/null 2>&1; then
+    echo "ERROR: PVC $KUBE_OVN_NS/$pvc_name (from ovn-central Deployment) not found."
+    exit 1
+  fi
+
+  echo "Restoring ovn-central from $BACKUP_FILE into PVC $KUBE_OVN_NS/$pvc_name"
+
+  replicas=$(kubectl get deployment -n $KUBE_OVN_NS ovn-central -o jsonpath='{.spec.replicas}')
+  kubectl scale deployment -n $KUBE_OVN_NS ovn-central --replicas=0
+  echo "ovn-central scaled to 0 (was $replicas)"
+
+  # Wait until the existing pod is fully gone so the PVC is detachable.
+  kubectl wait --for=delete pod -l app=ovn-central -n $KUBE_OVN_NS --timeout=120s || true
+
+  helper_pod="ovn-central-restore-$(date +%s)"
+  cat <<HELPER | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $helper_pod
+  namespace: $KUBE_OVN_NS
+spec:
+  restartPolicy: Never
+  # Mirror ovn-central's tolerations so the helper can schedule onto the
+  # same nodes (typically control-plane / master) that host the PVC.
+  tolerations:
+    - effect: NoSchedule
+      operator: Exists
+    - effect: NoExecute
+      operator: Exists
+    - key: CriticalAddonsOnly
+      operator: Exists
+  containers:
+    - name: restore
+      image: $RESTORE_HELPER_IMAGE
+      command: ["sh", "-c", "sleep 600"]
+      volumeMounts:
+        - name: ovn-data
+          mountPath: /etc/ovn
+  volumes:
+    - name: ovn-data
+      persistentVolumeClaim:
+        claimName: $pvc_name
+HELPER
+
+  kubectl wait --for=condition=Ready pod/$helper_pod -n $KUBE_OVN_NS --timeout=120s
+
+  echo "Copying $BACKUP_FILE into the PVC"
+  kubectl cp -n $KUBE_OVN_NS "$BACKUP_FILE" "$helper_pod:/etc/ovn/ovnnb_db.db.restore"
+  kubectl exec -n $KUBE_OVN_NS $helper_pod -- sh -c '
+    set -e
+    [ -f /etc/ovn/ovnnb_db.db ] && mv /etc/ovn/ovnnb_db.db /etc/ovn/ovnnb_db.db.bak.$(date +%s) || true
+    [ -f /etc/ovn/ovnsb_db.db ] && mv /etc/ovn/ovnsb_db.db /etc/ovn/ovnsb_db.db.bak.$(date +%s) || true
+    mv /etc/ovn/ovnnb_db.db.restore /etc/ovn/ovnnb_db.db
+    # kubectl cp extracts as the helper pods uid (root). ovn-central runs as
+    # nobody (uid 65534), so chown the restored DB. On root-squashed NFS the
+    # chown may be a no-op (root is already mapped to nobody) and that is OK.
+    chown -R 65534:65534 /etc/ovn 2>/dev/null || echo "chown /etc/ovn skipped (root-squashed NFS likely); restored file ownership left as-is"
+    ls -l /etc/ovn/
+  '
+
+  kubectl delete pod -n $KUBE_OVN_NS $helper_pod --wait=true
+
+  kubectl scale deployment -n $KUBE_OVN_NS ovn-central --replicas="${replicas:-1}"
+  echo "ovn-central scaled back to ${replicas:-1}"
+
+  # Best-effort ovs-ovn restart. In a Kamaji-style controlPlaneOnly install
+  # there is no ovs-ovn DaemonSet on this cluster, so missing is expected.
+  if kubectl -n $KUBE_OVN_NS get ds ovs-ovn >/dev/null 2>&1; then
+    echo "restart ovs-ovn"
+    kubectl -n $KUBE_OVN_NS rollout restart ds ovs-ovn
+  else
+    echo "ovs-ovn DaemonSet not present on this cluster — skipping restart"
+    echo "  (expected in controlPlaneOnly installs; restart ovs-ovn on the data-plane cluster yourself)"
+  fi
+  exit 0
+fi
+
+if [ "$MODE" != "cluster" ]; then
+  usage
+  exit 1
+fi
+
 # set ovn-central replicas to 0
 replicas=$(kubectl get deployment -n $KUBE_OVN_NS ovn-central -o jsonpath={.spec.replicas})
 kubectl scale deployment -n $KUBE_OVN_NS ovn-central --replicas=0

--- a/dist/images/start-controller.sh
+++ b/dist/images/start-controller.sh
@@ -2,10 +2,14 @@
 set -euo pipefail
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
+# Default to the in-cluster Service ports. Override when reaching an
+# externally-exposed ovn-central whose NodePort/LoadBalancer remaps ports.
+KUBE_OVN_NB_PORT=${KUBE_OVN_NB_PORT:-6641}
+KUBE_OVN_SB_PORT=${KUBE_OVN_SB_PORT:-6642}
 
 function gen_conn_str {
   if [[ -z "${OVN_DB_IPS}" ]]; then
-    if [[ "$1" == "6641" ]]; then
+    if [[ "$1" == "$KUBE_OVN_NB_PORT" ]]; then
       if [[ "$ENABLE_SSL" == "false" ]]; then
         x="tcp:[${OVN_NB_SERVICE_HOST}]:${OVN_NB_SERVICE_PORT}"
       else
@@ -29,8 +33,8 @@ function gen_conn_str {
   echo "$x"
 }
 
-nb_addr="$(gen_conn_str 6641)"
-sb_addr="$(gen_conn_str 6642)"
+nb_addr="$(gen_conn_str "$KUBE_OVN_NB_PORT")"
+sb_addr="$(gen_conn_str "$KUBE_OVN_SB_PORT")"
 
 exec ./kube-ovn-controller --ovn-nb-addr="$nb_addr" \
                            --ovn-sb-addr="$sb_addr" \

--- a/dist/images/start-controller.sh
+++ b/dist/images/start-controller.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
+OVN_NB_ADDR=${OVN_NB_ADDR:-}
+OVN_SB_ADDR=${OVN_SB_ADDR:-}
 # Default to the in-cluster Service ports. Override when reaching an
 # externally-exposed ovn-central whose NodePort/LoadBalancer remaps ports.
 KUBE_OVN_NB_PORT=${KUBE_OVN_NB_PORT:-6641}
@@ -33,8 +35,8 @@ function gen_conn_str {
   echo "$x"
 }
 
-nb_addr="$(gen_conn_str "$KUBE_OVN_NB_PORT")"
-sb_addr="$(gen_conn_str "$KUBE_OVN_SB_PORT")"
+nb_addr="${OVN_NB_ADDR:-$(gen_conn_str "$KUBE_OVN_NB_PORT")}"
+sb_addr="${OVN_SB_ADDR:-$(gen_conn_str "$KUBE_OVN_SB_PORT")}"
 
 exec ./kube-ovn-controller --ovn-nb-addr="$nb_addr" \
                            --ovn-sb-addr="$sb_addr" \

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -300,7 +300,11 @@ function ovn_db_pre_start() {
 trap quit EXIT
 if [[ "$ENABLE_SSL" == "false" ]]; then
     if [[ -z "$NODE_IPS" ]]; then
-        /usr/share/ovn/scripts/ovn-ctl restart_northd
+        # Standalone (single-replica) mode. The pod can drift between nodes when
+        # backed by a PV, so clean up any leftover sockets/pids on the host before
+        # starting ovsdb-server.
+        rm -f /var/run/ovn/*.pid /var/run/ovn/*.ctl 2>/dev/null || true
+        /usr/share/ovn/scripts/ovn-ctl --ovn-northd-n-threads="${OVN_NORTHD_N_THREADS}" restart_northd
         ovn-nbctl --no-leader-only set-connection ptcp:"${NB_PORT}":["${DB_ADDR}"]
         ovn-nbctl --no-leader-only set Connection . inactivity_probe=${PROBE_INTERVAL}
         ovn-nbctl --no-leader-only set NB_Global . options:northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL}
@@ -424,6 +428,9 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
     fi
 else
     if [[ -z "$NODE_IPS" ]]; then
+        # Standalone (single-replica) mode. Same rationale as the non-SSL branch:
+        # clean up stale sockets/pids so a drifted pod can come up on a new node.
+        rm -f /var/run/ovn/*.pid /var/run/ovn/*.ctl 2>/dev/null || true
         /usr/share/ovn/scripts/ovn-ctl $(ovn_db_ssl_args /var/run/tls) \
             --ovn-northd-n-threads="${OVN_NORTHD_N_THREADS}" \
             restart_northd

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -74,25 +74,64 @@ function gen_listen_addr {
     fi
 }
 
+function format_ovsdb_addr {
+    if [[ "$1" =~ ^[0-9.]+$ || "$1" == *:* ]]; then
+        echo "[$1]"
+    else
+        echo "$1"
+    fi
+}
+
+function expand_k8s_svc_addr {
+    if [[ "$1" != *.svc ]]; then
+        echo "$1"
+        return
+    fi
+
+    local fqdn
+    fqdn=$(getent hosts "$1" | awk -v addr="$1" '{ for (i = 2; i <= NF; i++) { if ($i ~ "^" addr "\\.") { print $i; exit } } }')
+    if [[ -z "$fqdn" ]]; then
+        echo "ERROR! failed to resolve Kubernetes service address $1 to a FQDN" >&2
+        exit 1
+    fi
+    echo "$fqdn"
+}
+
+function normalize_raft_addrs {
+    local old_db_cluster_addr="$DB_CLUSTER_ADDR"
+    DB_CLUSTER_ADDR="$(expand_k8s_svc_addr "$DB_CLUSTER_ADDR")"
+    POD_IP="$(expand_k8s_svc_addr "${POD_IP:-}")"
+    if [[ -n "$old_db_cluster_addr" && "${POD_IP:-}" == "$old_db_cluster_addr" ]]; then
+        POD_IP="$DB_CLUSTER_ADDR"
+    fi
+
+    local addrs=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
+    local normalized=()
+    for addr in ${addrs}; do
+        normalized=(${normalized[*]} "$(expand_k8s_svc_addr "$addr")")
+    done
+    NODE_IPS="$(IFS=,; echo "${normalized[*]}")"
+}
+
 function gen_conn_addr {
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        echo "tcp:[$1]:$2"
+        echo "tcp:$(format_ovsdb_addr "$1"):$2"
     else
-        echo "ssl:[$1]:$2"
+        echo "ssl:$(format_ovsdb_addr "$1"):$2"
     fi
 }
 
 function gen_conn_str {
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "tcp:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     else
-        x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "ssl:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     fi
     echo "$x"
 }
 
-function get_leader_ip {
+function get_leader_addr {
     # Always use first node ip as leader, this option only take effect
     # when first bootstrap the cluster.
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
@@ -155,6 +194,10 @@ function set_nb_version_compatibility() {
         fi
     fi
 }
+
+if [[ -n "${NODE_IPS:-}" ]]; then
+    normalize_raft_addrs
+fi
 
 # create a new db file and join it to the cluster
 # if the nb/sb db file is corrupted
@@ -321,19 +364,19 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
         ovn_db_pre_start nb
         ovn_db_pre_start sb
 
-        nb_leader_ip=$(get_leader_ip nb)
-        sb_leader_ip=$(get_leader_ip sb)
+        nb_leader_addr=$(get_leader_addr nb)
+        sb_leader_addr=$(get_leader_addr sb)
         set +eo pipefail
         is_clustered
         result=$?
         set -eo pipefail
         # leader up only when no cluster and on the first/only node
-        if [[ ${result} -eq 1 && "$nb_leader_ip" == "$DB_CLUSTER_ADDR" ]]; then
+        if [[ ${result} -eq 1 && "$nb_leader_addr" == "$DB_CLUSTER_ADDR" ]]; then
             ovn_ctl_args="$DEBUG_OPT \
                 --db-nb-create-insecure-remote=yes \
                 --db-sb-create-insecure-remote=yes \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-addr=[$DB_ADDR] \
@@ -370,7 +413,7 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                     nb_leader=$(ovndb_query_leader nb $i)
                     if [[ $nb_leader =~ "true" ]]
                     then
-                        nb_leader_ip=${i}
+                        nb_leader_addr=${i}
                         break
                     fi
                 done
@@ -379,7 +422,7 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
                     sb_leader=$(ovndb_query_leader sb $i)
                     if [[ $sb_leader =~ "true" ]]
                     then
-                        sb_leader_ip=${i}
+                        sb_leader_addr=${i}
                         break
                     fi
                 done
@@ -389,10 +432,10 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
             ovn_ctl_args="$DEBUG_OPT \
                 --db-nb-create-insecure-remote=yes \
                 --db-sb-create-insecure-remote=yes \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-nb-cluster-remote-addr=[$nb_leader_ip] \
-                --db-sb-cluster-remote-addr=[$sb_leader_ip] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-nb-cluster-remote-addr=$(format_ovsdb_addr "$nb_leader_addr") \
+                --db-sb-cluster-remote-addr=$(format_ovsdb_addr "$sb_leader_addr") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-cluster-remote-port=$NB_CLUSTER_PORT \
@@ -449,21 +492,21 @@ else
         ovn_db_pre_start nb
         ovn_db_pre_start sb
 
-        nb_leader_ip=$(get_leader_ip nb)
-        sb_leader_ip=$(get_leader_ip sb)
+        nb_leader_addr=$(get_leader_addr nb)
+        sb_leader_addr=$(get_leader_addr sb)
         set +eo pipefail
         is_clustered
         result=$?
         set -eo pipefail
-        if [[ ${result} -eq 1  &&  "$nb_leader_ip" == "${DB_CLUSTER_ADDR}" ]]; then
+        if [[ ${result} -eq 1  &&  "$nb_leader_addr" == "${DB_CLUSTER_ADDR}" ]]; then
             ovn_ctl_args="$DEBUG_OPT
                 $(ovn_db_ssl_args /var/run/tls) \
                 --db-nb-cluster-local-proto=ssl \
                 --db-sb-cluster-local-proto=ssl \
                 --db-nb-cluster-remote-proto=ssl \
                 --db-sb-cluster-remote-proto=ssl \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
                 --db-nb-addr=[$DB_ADDR] \
                 --db-sb-addr=[$DB_ADDR] \
                 --db-nb-port=$NB_PORT \
@@ -495,7 +538,7 @@ else
                     nb_leader=$(ovndb_query_leader nb $i)
                     if [[ $nb_leader =~ "true" ]]
                     then
-                      nb_leader_ip=${i}
+                      nb_leader_addr=${i}
                       break
                     fi
                 done
@@ -504,7 +547,7 @@ else
                     sb_leader=$(ovndb_query_leader sb $i)
                     if [[ $sb_leader =~ "true" ]]
                     then
-                      sb_leader_ip=${i}
+                      sb_leader_addr=${i}
                       break
                     fi
                 done
@@ -516,10 +559,10 @@ else
                 --db-sb-cluster-local-proto=ssl \
                 --db-nb-cluster-remote-proto=ssl \
                 --db-sb-cluster-remote-proto=ssl \
-                --db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR] \
-                --db-nb-cluster-remote-addr=[$nb_leader_ip] \
-                --db-sb-cluster-remote-addr=[$sb_leader_ip] \
+                --db-nb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-sb-cluster-local-addr=$(format_ovsdb_addr "$DB_CLUSTER_ADDR") \
+                --db-nb-cluster-remote-addr=$(format_ovsdb_addr "$nb_leader_addr") \
+                --db-sb-cluster-remote-addr=$(format_ovsdb_addr "$sb_leader_addr") \
                 --db-nb-cluster-local-port=$NB_CLUSTER_PORT \
                 --db-sb-cluster-local-port=$SB_CLUSTER_PORT \
                 --db-nb-cluster-remote-port=$NB_CLUSTER_PORT \

--- a/dist/images/start-ic-controller.sh
+++ b/dist/images/start-ic-controller.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
+KUBE_OVN_NB_PORT=${KUBE_OVN_NB_PORT:-6641}
+KUBE_OVN_SB_PORT=${KUBE_OVN_SB_PORT:-6642}
 
 function gen_conn_str {
   if [[ -z "${OVN_DB_IPS}" ]]; then
-    if [[ "$1" == "6641" ]]; then
+    if [[ "$1" == "$KUBE_OVN_NB_PORT" ]]; then
       if [[ "$ENABLE_SSL" == "false" ]]; then
         x="tcp:[${OVN_NB_SERVICE_HOST}]:${OVN_NB_SERVICE_PORT}"
       else
@@ -29,8 +31,8 @@ function gen_conn_str {
   echo "$x"
 }
 
-nb_addr="$(gen_conn_str 6641)"
-sb_addr="$(gen_conn_str 6642)"
+nb_addr="$(gen_conn_str "$KUBE_OVN_NB_PORT")"
+sb_addr="$(gen_conn_str "$KUBE_OVN_SB_PORT")"
 
 for ((i=0; i<3; i++)); do
   if [[ "$ENABLE_SSL" == "false" ]]; then

--- a/dist/images/start-ic-db.sh
+++ b/dist/images/start-ic-db.sh
@@ -10,7 +10,7 @@ if [[ $ENABLE_BIND_LOCAL_IP == "true" ]]; then
     DB_ADDR="$POD_IP"
 fi
 
-function get_leader_ip {
+function get_leader_addr {
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     echo -n "${t}" | cut -f 1 -d " "
 }
@@ -47,21 +47,29 @@ function ovndb_query_leader {
     fi
 }
 
+function format_ovsdb_addr {
+    if [[ "$1" =~ ^[0-9.]+$ || "$1" == *:* ]]; then
+        echo "[$1]"
+    else
+        echo "$1"
+    fi
+}
+
 function gen_conn_str {
     t=$(echo -n "${NODE_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "tcp:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     else
-        x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+        x=$(for i in ${t}; do echo -n "ssl:$(format_ovsdb_addr "$i"):$1",; done| sed 's/,$//')
     fi
     echo "$x"
 }
 
 function gen_conn_addr {
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        echo "tcp:[$1]:$2"
+        echo "tcp:$(format_ovsdb_addr "$1"):$2"
     else
-        echo "ssl:[$1]:$2"
+        echo "ssl:$(format_ovsdb_addr "$1"):$2"
     fi
 }
 
@@ -162,14 +170,14 @@ if [[ -z "$NODE_IPS" && -z "$LOCAL_IP" ]]; then
     /usr/share/ovn/scripts/ovn-ctl --db-ic-nb-create-insecure-remote=yes --db-ic-sb-create-insecure-remote=yes --db-ic-nb-addr="[::]" --db-ic-sb-addr="[::]" start_ic_ovsdb
     /usr/share/ovn/scripts/ovn-ctl status_ic_ovsdb
 else
-    ic_nb_leader_ip=$(get_leader_ip nb)
-    ic_sb_leader_ip=$(get_leader_ip sb)
+    ic_nb_leader_addr=$(get_leader_addr nb)
+    ic_sb_leader_addr=$(get_leader_addr sb)
     set +eo pipefail
     is_clustered
     result=$?
     set -eo pipefail
     # leader up only when no cluster and on first node
-    if [[ ${result} -eq 1 &&  "$ic_nb_leader_ip" == "${POD_IP}" ]]; then
+    if [[ ${result} -eq 1 &&  "$ic_nb_leader_addr" == "${POD_IP}" ]]; then
         echo "leader start with local ${LOCAL_IP} and cluster $(gen_conn_str 6647)"
         /usr/share/ovn/scripts/ovn-ctl  --db-ic-nb-create-insecure-remote=yes \
         --db-ic-sb-create-insecure-remote=yes \
@@ -191,7 +199,7 @@ else
                 nb_leader=$(ovndb_query_leader nb $i)
                 if [[ $nb_leader =~ "true" ]]
                 then
-                    nb_leader_ip=${i}
+                    ic_nb_leader_addr=${i}
                     break
                 fi
             done
@@ -200,19 +208,19 @@ else
                 sb_leader=$(ovndb_query_leader sb $i)
                 if [[ $sb_leader =~ "true" ]]
                 then
-                    sb_leader_ip=${i}
+                    ic_sb_leader_addr=${i}
                     break
                 fi
             done
         fi
         set -eo pipefail
-        echo "follower start with local ${LOCAL_IP}, ovn-ic-nb leader ${ic_nb_leader_ip} ovn-ic-sb leader ${ic_sb_leader_ip}"
+        echo "follower start with local ${LOCAL_IP}, ovn-ic-nb leader ${ic_nb_leader_addr} ovn-ic-sb leader ${ic_sb_leader_addr}"
         /usr/share/ovn/scripts/ovn-ctl  --db-ic-nb-create-insecure-remote=yes \
         --db-ic-sb-create-insecure-remote=yes \
         --db-ic-sb-cluster-local-addr="[${LOCAL_IP}]" \
         --db-ic-nb-cluster-local-addr="[${LOCAL_IP}]" \
-        --db-ic-nb-cluster-remote-addr="[${ic_nb_leader_ip}]" \
-        --db-ic-sb-cluster-remote-addr="[${ic_sb_leader_ip}]" \
+        --db-ic-nb-cluster-remote-addr="[${ic_nb_leader_addr}]" \
+        --db-ic-sb-cluster-remote-addr="[${ic_sb_leader_addr}]" \
         --ovn-ic-nb-db="$(gen_conn_str 6647)" \
         --ovn-ic-sb-db="$(gen_conn_str 6648)" \
         --db-ic-nb-addr=[$DB_ADDR] \

--- a/dist/images/start-ovs-dpdk-v2.sh
+++ b/dist/images/start-ovs-dpdk-v2.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 OVN_REMOTE_PROBE_INTERVAL=${OVN_REMOTE_PROBE_INTERVAL:-10000}
 OVN_REMOTE_OPENFLOW_INTERVAL=${OVN_REMOTE_OPENFLOW_INTERVAL:-180}
 ENABLE_SSL=${ENABLE_SSL:-false}
+OVN_SB_ADDR=${OVN_SB_ADDR:-}
 
 echo "OVN_REMOTE_PROBE_INTERVAL is set to $OVN_REMOTE_PROBE_INTERVAL"
 echo "OVN_REMOTE_OPENFLOW_INTERVAL is set to $OVN_REMOTE_OPENFLOW_INTERVAL"
@@ -126,7 +127,9 @@ ovs-vsctl --may-exist add-br br-int \
   -- set bridge br-int fail-mode=secure
 
 # Set remote ovn-sb for ovn-controller to connect to
-if [[ "$ENABLE_SSL" == "true" ]]; then
+if [[ -n "$OVN_SB_ADDR" ]]; then
+  ovs-vsctl set open . external-ids:ovn-remote="$OVN_SB_ADDR"
+elif [[ "$ENABLE_SSL" == "true" ]]; then
   ovs-vsctl set open . external-ids:ovn-remote=ssl:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
 else
   ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
+OVN_SB_ADDR=${OVN_SB_ADDR:-}
 TUNNEL_TYPE=${TUNNEL_TYPE:-geneve}
 FLOW_LIMIT=${FLOW_LIMIT:-10}
 DEBUG_WRAPPER=${DEBUG_WRAPPER:-}
@@ -140,7 +141,7 @@ function gen_conn_str {
   echo "$x"
 }
 # Set remote ovn-sb for ovn-controller to connect to
-ovs-vsctl set open . external-ids:ovn-remote="$(gen_conn_str "${KUBE_OVN_SB_PORT:-6642}")"
+ovs-vsctl set open . external-ids:ovn-remote="${OVN_SB_ADDR:-$(gen_conn_str "${KUBE_OVN_SB_PORT:-6642}")}"
 ovs-vsctl set open . external-ids:ovn-remote-probe-interval="${OVN_REMOTE_PROBE_INTERVAL}"
 ovs-vsctl set open . external-ids:ovn-openflow-probe-interval="${OVN_REMOTE_OPENFLOW_INTERVAL}"
 

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -130,16 +130,17 @@ function gen_conn_str {
     fi
   else
     t=$(echo -n "${OVN_DB_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
+    local port=${1:-${KUBE_OVN_SB_PORT:-6642}}
     if [[ "$ENABLE_SSL" == "false" ]]; then
-      x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "tcp:[$i]:${port}",; done| sed 's/,$//')
     else
-      x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "ssl:[$i]:${port}",; done| sed 's/,$//')
     fi
   fi
   echo "$x"
 }
 # Set remote ovn-sb for ovn-controller to connect to
-ovs-vsctl set open . external-ids:ovn-remote="$(gen_conn_str 6642)"
+ovs-vsctl set open . external-ids:ovn-remote="$(gen_conn_str "${KUBE_OVN_SB_PORT:-6642}")"
 ovs-vsctl set open . external-ids:ovn-remote-probe-interval="${OVN_REMOTE_PROBE_INTERVAL}"
 ovs-vsctl set open . external-ids:ovn-openflow-probe-interval="${OVN_REMOTE_OPENFLOW_INTERVAL}"
 

--- a/docs/kamaji-deployment.md
+++ b/docs/kamaji-deployment.md
@@ -1,0 +1,227 @@
+# Kamaji-style split-cluster deployment
+
+In a Kamaji-style topology the tenant's Kubernetes control plane (apiserver,
+controller-manager, scheduler, etcd) runs as pods in a **management cluster**
+while the tenant's worker nodes run in a separate **data-plane cluster**. Each
+tenant gets its own apiserver instance hosted in the management cluster.
+
+Kube-OVN can be split along the same boundary:
+
+```
+┌────────────────────────────────────────┐         ┌────────────────────────────────────────┐
+│  Management cluster                    │         │  Tenant data-plane cluster             │
+│                                        │         │                                        │
+│  ┌────────────────┐                    │         │  ┌────────────────┐                    │
+│  │ ovn-central    │  (single replica   │         │  │ kube-ovn-      │                    │
+│  │  + PVC         │   recommended)     │  TLS    │  │ controller     │                    │
+│  └─────────┬──────┘                    │ <─────> │  └────────────────┘                    │
+│            │                           │ ovn-nb  │  ┌────────────────┐                    │
+│  ┌─────────▼──────┐                    │ ovn-sb  │  │ ovs-ovn (DS)   │                    │
+│  │ ovn-nb /       │  (LoadBalancer)    │         │  │ kube-ovn-cni   │                    │
+│  │ ovn-sb /       │ ──── 10.99.99.99 ──┼─────────┼─►│ kube-ovn-pinger│                    │
+│  │ ovn-northd svc │                    │         │  └────────────────┘                    │
+│  └────────────────┘                    │         │  + Subnet / IP / Vpc CRDs in tenant   │
+│                                        │         │    apiserver                           │
+└────────────────────────────────────────┘         └────────────────────────────────────────┘
+```
+
+The same Helm chart is installed twice, with different `installMode` values
+targeting different `--kube-context`s.
+
+## Component placement
+
+| Component | Where it runs | Why |
+|---|---|---|
+| `ovn-central` (Deployment + PVC + nb/sb/northd Services) | Management cluster | Centralised OVN DB; PVC keeps DB durable across pod drift |
+| `kube-ovn-controller` | Tenant cluster | Watches tenant Subnet/IP/Vpc CRs — best done with in-cluster auth |
+| `ovs-ovn`, `kube-ovn-cni`, `kube-ovn-pinger` (DaemonSets) | Tenant cluster | They program local OVS on every tenant node |
+| `kube-ovn-monitor` (Deployment) | **`full` mode only** | Reads ovn-central's local Unix sockets and DB files; would crashloop in a tenant-only install. Tracked as follow-up. |
+| Kube-OVN CRDs (`kubeovn.io/v1` …) | Tenant apiserver | Tenants `kubectl create subnet` against their own apiserver |
+| `kube-ovn-tls` Secret | **Both clusters** | ovn-central serves SSL listeners (mgmt); controller / ovs-ovn use client certs (tenant) |
+
+## Prerequisites
+
+- Two reachable clusters with separate kubeconfigs / contexts (`mgmt`, `tenant`).
+- A LoadBalancer (or NodePort / Ingress) in the management cluster that exposes
+  ports 6641 (NB) and 6642 (SB) of the `ovn-nb` / `ovn-sb` Services. The
+  tenant cluster's pods must be able to reach that VIP/hostname.
+- A StorageClass in the management cluster that supports cross-node attach
+  (NFS-CSI, Ceph RBD, cloud block storage) — see
+  [single-replica-deployment.md](./single-replica-deployment.md).
+- Recommended: enable SSL (`networking.ENABLE_SSL=true`) before exposing OVN DB
+  ports outside the cluster. Plain TCP across cluster boundaries should be
+  considered insecure.
+
+## Install
+
+### 1. Management cluster — `controlPlaneOnly`
+
+```yaml
+# mgmt-values.yaml
+namespace: kube-system
+
+installMode: controlPlaneOnly
+OVN_CENTRAL_MODE: single
+
+ovn-central:
+  storage:
+    storageClassName: my-csi
+    size: 10Gi
+  service:
+    type: LoadBalancer
+    loadBalancerIP: 10.99.99.99        # provider-dependent; omit for auto
+    externalTrafficPolicy: Local       # preserves tenant source IPs (optional)
+
+networking:
+  ENABLE_SSL: true                     # strongly recommended
+```
+
+```bash
+helm install --kube-context=mgmt kube-ovn ./charts/kube-ovn -f mgmt-values.yaml
+```
+
+This release renders:
+
+- `ovn-central` Deployment + `ovn-central-data` PVC
+- `ovn-nb` / `ovn-sb` / `ovn-northd` Services (`type: LoadBalancer`)
+- `kube-ovn-tls` Secret (SSL keying material)
+- `ovn-ovs` ServiceAccount + `system:ovn-ovs` ClusterRole + binding
+
+…and nothing else. No CRDs, no agents.
+
+After install, capture the LoadBalancer's ingress IP/hostname and copy the
+`kube-ovn-tls` Secret out of the management cluster — the tenant cluster
+needs the same TLS material.
+
+```bash
+# Pull the assigned VIP (if you let the LB pick)
+kubectl --context=mgmt -n kube-system get svc ovn-nb \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+
+# Export the TLS Secret for syncing to the tenant cluster
+kubectl --context=mgmt -n kube-system get secret kube-ovn-tls -o yaml > kube-ovn-tls.yaml
+```
+
+### 2. Tenant data-plane cluster — `dataPlaneOnly`
+
+First seed the TLS Secret into the tenant cluster's `kube-system` namespace
+(or whatever you set `.Values.namespace` to). In production, use tooling like
+`external-secrets`, `sealed-secrets`, or Argo CD's secret syncing rather than
+`kubectl apply -f kube-ovn-tls.yaml`.
+
+```bash
+kubectl --context=tenant -n kube-system apply -f kube-ovn-tls.yaml
+```
+
+Then install the data-plane release pointing at the management cluster's LB:
+
+```yaml
+# tenant-values.yaml
+namespace: kube-system
+
+installMode: dataPlaneOnly
+externalOvnCentral:
+  endpoint: 10.99.99.99                # or DNS name of the mgmt cluster LB
+  nbPort: 6641
+  sbPort: 6642
+
+networking:
+  ENABLE_SSL: true                     # must match mgmt cluster
+```
+
+```bash
+helm install --kube-context=tenant kube-ovn ./charts/kube-ovn -f tenant-values.yaml
+```
+
+This release renders:
+
+- Kube-OVN CRDs (Subnet / IP / Vpc / …) — installed into the **tenant apiserver**
+- `kube-ovn-controller` Deployment with `OVN_DB_IPS=10.99.99.99` →
+  start-controller.sh builds `tcp:[10.99.99.99]:6641` and `tcp:[…]:6642`
+- `ovs-ovn`, `kube-ovn-cni`, `kube-ovn-pinger` DaemonSets — also pointing at
+  the management cluster's LB via `OVN_DB_IPS`
+- All the related ServiceAccounts / ClusterRoles / RoleBindings
+
+…and **does not** render `ovn-central` or its Services.
+
+## Verifying connectivity
+
+After both installs, on the tenant cluster:
+
+```bash
+# kube-ovn-controller must be Ready
+kubectl --context=tenant -n kube-system rollout status deploy/kube-ovn-controller
+
+# Active TCP connection from ovn-controller (in the ovs-ovn DS) to the LB
+kubectl --context=tenant -n kube-system exec ds/ovs-ovn -- \
+  ss -tnp | grep ':6642'
+
+# Should show ESTAB ... <node IP>:<port> 10.99.99.99:6642 users:(("ovn-controller",...))
+
+# Sanity: create a tenant Subnet, watch a pod get an IP
+kubectl --context=tenant create -f - <<EOF
+apiVersion: kubeovn.io/v1
+kind: Subnet
+metadata: {name: smoke}
+spec:
+  cidrBlock: 10.50.0.0/16
+  default: false
+EOF
+```
+
+## Version lockstep
+
+The chart enforces that both installs use the same `kube-ovn` image tag (via
+`global.images.kubeovn.tag`). Keep them aligned — if you upgrade the
+management cluster's chart, upgrade the tenant cluster's chart in the same
+window. Cross-version OVN schema drift can wedge `ovn-northd` reconciliation
+in ways that are painful to diagnose.
+
+Using one of the cross-cluster GitOps patterns helps:
+
+- **Argo CD `ApplicationSet`** with two `Application`s sharing one Helm values
+  fragment (the version) and overriding only `installMode` + the
+  `externalOvnCentral.endpoint`.
+- **Flux `Kustomization`** per cluster, each pointing at the same Helm chart
+  revision.
+
+## Limitations
+
+- The CRD bundle is intentionally rendered **only** in the data-plane release,
+  but its content matches the chart version used by the management release.
+  Apply the data-plane release before the management release does its first
+  reconcile loop, otherwise the controller will spam "CRD not found" until
+  the tenant CRDs land.
+- ovn-northd's port (6643) does **not** need to be exposed across the cluster
+  boundary — only the management cluster components talk to it. The chart
+  still defines the Service so internal traffic works.
+- Single-cluster IC (interconnect) deployments are still rendered under
+  `installMode: full`. Multi-cluster IC topologies need their own design and
+  are out of scope here.
+- `externalOvnCentral.endpoint` should be an **IP address** (IPv4 or IPv6).
+  DNS hostnames work with recent OVN releases but the connection string
+  format `tcp:[host]:port` is fragile against older OVN parsers. If you
+  expose ovn-central behind a hostname, prefer a static VIP that hostname
+  resolves to and put the VIP in `endpoint`.
+- The three OVN Services (ovn-nb / ovn-sb / ovn-northd) share the single
+  `ovn-central.service.loadBalancerIP`. With MetalLB the chart emits the
+  `metallb.universe.tf/allow-shared-ip: kube-ovn-central` annotation so
+  the three Services land on one VIP distinguished by port. With cloud
+  LoadBalancer providers that reject duplicate `loadBalancerIP`, you have
+  two options: (a) use NodePort instead and front the node IPs with an
+  external LB you control, or (b) extend the chart to render
+  per-Service VIPs and have `externalOvnCentral` accept separate `nbEndpoint`
+  / `sbEndpoint` fields. The chart does not currently support (b) — track it
+  as follow-up work.
+- In `installMode=dataPlaneOnly` with `networking.ENABLE_SSL=true`, you
+  **must** pre-seed the `kube-ovn-tls` Secret in the tenant cluster
+  before installing the chart. Self-signing locally would produce certs
+  the management cluster does not trust. The chart fails with a clear
+  message in this case rather than silently generating an incompatible
+  CA.
+- `kube-ovn-monitor`, DPDK (`HYBRID_DPDK=true`), and the OVS upgrade hooks
+  (`pre-upgrade-ovs-ovn` / `upgrade-ovs-ovn`) are currently disabled outside
+  `installMode: full` because they reference a local ovn-central. Running
+  Kamaji with DPDK or doing in-place OVS upgrades on the tenant cluster
+  requires a follow-up to make `start-ovs-dpdk-v2.sh` and `upgrade-ovs.sh`
+  honor `OVN_DB_IPS` / `externalOvnCentral`.

--- a/docs/single-replica-deployment.md
+++ b/docs/single-replica-deployment.md
@@ -1,0 +1,205 @@
+# Single-replica ovn-central deployment
+
+Kube-OVN can run `ovn-central` as a single-replica Deployment with the OVN DB
+stored on a PersistentVolume, instead of the default multi-replica raft cluster.
+On host failure the pod is rescheduled to another node and reattaches to the
+PV, recovering the DB state.
+
+## When to use it
+
+| | Cluster (raft) mode | Single-replica mode |
+|---|---|---|
+| `ovn-central` replicas | one per master | exactly 1 |
+| DB consistency | raft quorum | single ovsdb-server, no consensus |
+| Storage | hostPath per master | one PVC, must be attachable on the new node after a failover |
+| Failover time | seconds (leader election) | PV detach/attach time, typically minutes |
+| Operational complexity | higher (quorum, raft repair) | lower |
+| Suitable cluster size | medium / large | small to medium, or constrained environments |
+
+Pick single-replica when you do not have three master nodes available, or when
+you prefer a simpler failure model and can tolerate a multi-minute recovery
+window during host loss.
+
+## StorageClass requirements
+
+The PVC is `ReadWriteOnce`. For the pod to actually drift between nodes the
+StorageClass must support **detach from the failed node and attach on the new
+node**. This is true for most network block / file CSIs:
+
+- NFS (`csi-driver-nfs`) — easy to set up, well-tested for failover
+- Cloud block storage (EBS, GCE PD, Azure Disk) — works, but detach from a
+  dead node can take several minutes
+- Ceph RBD, Longhorn, Portworx, etc. — work, see vendor docs for fencing
+- `hostPath` provisioners (e.g. local-path-provisioner) **will not drift** —
+  the PV is bound to the original node and the new pod will stay `Pending`
+
+`volumeBindingMode: WaitForFirstConsumer` is recommended so the PV topology is
+chosen at first pod schedule rather than at PVC creation time.
+
+## Install
+
+### Helm
+
+```yaml
+# values.yaml
+OVN_CENTRAL_MODE: single
+
+ovn-central:
+  storage:
+    storageClassName: my-csi          # leave empty to use the cluster default
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+    # existingClaim: ""               # set to use a pre-created PVC instead
+```
+
+```bash
+helm install kube-ovn ./charts/kube-ovn -f values.yaml
+```
+
+### install.sh
+
+```bash
+ENABLE_SINGLE_REPLICA_OVN=true \
+  OVN_CENTRAL_STORAGE_CLASS=my-csi \
+  OVN_CENTRAL_PVC_SIZE=10Gi \
+  bash dist/images/install.sh
+```
+
+After install, verify:
+
+```bash
+kubectl get pod  -n kube-system -l app=ovn-central          # should be 1 pod
+kubectl get pvc  -n kube-system ovn-central-data
+kubectl get svc  -n kube-system ovn-nb -o jsonpath='{.spec.selector}'
+# Expected: {"app":"ovn-central"}  — no ovn-nb-leader selector
+```
+
+## Failover drill
+
+```bash
+node=$(kubectl get pod -n kube-system -l app=ovn-central \
+  -o jsonpath='{.items[0].spec.nodeName}')
+
+# Simulate node loss
+kubectl cordon "$node"
+kubectl delete pod -n kube-system -l app=ovn-central
+
+# Wait for the new pod to come up on a different node and the DB to respond
+kubectl wait pod -n kube-system -l app=ovn-central \
+  --for=condition=Ready --timeout=5m
+kubectl exec -n kube-system -l app=ovn-central -- ovn-nbctl show
+```
+
+For a real host-loss test (rather than `cordon` + delete), the CSI driver must
+support **fencing** — otherwise the volume will stay attached to the dead node
+and the new pod will hang in `ContainerCreating` until Kubernetes force-detaches
+(typically 6+ minutes).
+
+## Exposing the OVN DB to data planes outside the cluster
+
+In a Kamaji-style topology the kube-ovn control plane (apiserver controllers,
+`ovn-central`) runs in a *management* cluster while `ovn-controller`,
+`kube-ovn-cni` and `kube-ovn-controller` run in one or more *tenant* clusters.
+The tenant components cannot reach a `ClusterIP` Service of the management
+cluster, so the `ovn-nb` / `ovn-sb` / `ovn-northd` Services need to be exposed
+via `LoadBalancer` (or `NodePort`).
+
+Single-replica mode is a prerequisite: with a stable, non-elected single backend
+the LoadBalancer always has exactly one healthy endpoint and there is no leader
+flapping when the LB does its own health checks.
+
+### Helm
+
+```yaml
+# values.yaml on the management cluster
+OVN_CENTRAL_MODE: single
+
+ovn-central:
+  storage:
+    storageClassName: my-csi
+    size: 10Gi
+  service:
+    type: LoadBalancer
+    loadBalancerIP: 10.99.99.99       # provider-dependent; omit to let LB pick
+    externalTrafficPolicy: Local      # optional; preserves source IPs
+```
+
+### install.sh
+
+```bash
+ENABLE_SINGLE_REPLICA_OVN=true \
+  OVN_CENTRAL_STORAGE_CLASS=my-csi \
+  OVN_CENTRAL_SERVICE_TYPE=LoadBalancer \
+  OVN_CENTRAL_LB_IP=10.99.99.99 \
+  OVN_CENTRAL_EXTERNAL_TRAFFIC_POLICY=Local \
+  bash dist/images/install.sh
+```
+
+### Wiring tenant clusters
+
+The tenant data plane deploys only `ovs-ovn` / `kube-ovn-cni` /
+`kube-ovn-controller` (not `ovn-central`) and is told where to connect via
+`OVN_DB_IPS`:
+
+```yaml
+# data-plane values (or chart fork) — pseudo-config
+OVN_DB_IPS: 10.99.99.99      # the LoadBalancer VIP from above
+```
+
+The startup scripts already handle a single-entry `OVN_DB_IPS` correctly,
+producing `tcp:[10.99.99.99]:6641` / `:6642` connection strings.
+
+> **Security note.** Exposing OVN DB over plain TCP outside the cluster is
+> usually unacceptable. Enable SSL (`networking.ENABLE_SSL=true`) and
+> distribute the OVN certs to the tenant clusters before pointing them at
+> the LB; the existing kube-ovn SSL machinery covers everything once the
+> certs are in place.
+
+For a full Kamaji-style split-cluster deployment (management cluster runs
+`ovn-central` while tenant clusters run only the agents and connect back
+via a LoadBalancer), see [kamaji-deployment.md](./kamaji-deployment.md)
+which walks through the `installMode: controlPlaneOnly` / `dataPlaneOnly`
+flow.
+
+## Backup and restore
+
+Take a hot backup of the standalone DB at any time:
+
+```bash
+pod=$(kubectl get pod -n kube-system -l app=ovn-central -o name | head -n1)
+kubectl exec -n kube-system "$pod" -- \
+  ovsdb-client backup unix:/var/run/ovn/ovnnb_db.sock > ovnnb_backup.db
+```
+
+Restore using the bundled script:
+
+```bash
+bash dist/images/restore-ovn-nb-db.sh single ovnnb_backup.db
+```
+
+The script scales `ovn-central` to 0, runs a helper pod that mounts the same
+PVC to copy the backup into place, then scales back to 1.
+
+## Migrating between modes
+
+**Cluster → single**: scale the existing cluster `ovn-central` to 0, run
+`ovsdb-tool cluster-to-standalone` against one of the raft member DB files to
+produce a standalone NB DB, reinstall in single mode pointing at an empty PVC,
+then use `restore-ovn-nb-db.sh single` to load the standalone DB.
+
+**Single → cluster**: take a backup, reinstall in cluster mode on a fresh
+hostPath, and load the backup into the leader using `ovsdb-client`. Verify the
+NB DB content matches the backup before deleting the PVC.
+
+## Limitations
+
+- The `kube-ovn-leader-checker` raft queries, `ovn_northd` lock stealing and
+  raft header backup are all skipped in single-replica mode. Compaction and DB
+  storage-status checks still run.
+- `ovn-healthcheck.sh` uses `ovsdb-server/get-db-storage-status` instead of
+  `cluster/status`, so the readiness probe will not detect raft-specific issues
+  (there are none in this mode).
+- During failover all kube-ovn-controller / ovs-ovn / ovn-controller clients
+  will see Service connect errors until the new pod is `Ready`. They reconnect
+  automatically; in-flight ovsdb transactions during the outage may be retried.

--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -45,7 +45,35 @@ CHART_V1_CRD_PATH="charts/kube-ovn/templates/kube-ovn-crd.yaml"
 CHART_V2_CRD_PATH="charts/kube-ovn-v2/crds/kube-ovn-crd.yaml"
 INSTALL_PATH="dist/images/install.sh"
 
-cp "$BUNDLE_FILE" "$CHART_V1_CRD_PATH"
+# The v1 chart bundles CRDs as a template so they can be gated by
+# installMode (see charts/kube-ovn/templates/_helpers.tpl). Wrap the generated
+# CRD bundle with the data-plane render gate so dataPlaneOnly installs ship the
+# CRDs and controlPlaneOnly installs skip them.
+#
+# We also inject `helm.sh/resource-policy: keep` onto each CRD so a release
+# that flips installMode (e.g. full -> controlPlaneOnly) does not delete the
+# CRDs and cascade-delete all custom resources. Helm normally treats missing
+# templates on upgrade as resources to remove; the annotation pins CRDs in
+# place. Operators who really want to drop CRDs can `kubectl delete crd ...`
+# explicitly.
+{
+  echo '{{- if include "kubeovn.renderDataPlane" . }}'
+  awk '
+    /^kind: CustomResourceDefinition$/ { in_crd = 1 }
+    # controller-gen always emits a `metadata.annotations:` block right after
+    # `metadata:`. Inject the keep annotation as an extra key inside that
+    # existing block so YAML does not collapse to a single annotations map
+    # and silently lose one set.
+    in_crd && /^  annotations:$/ {
+      print
+      print "    helm.sh/resource-policy: keep"
+      next
+    }
+    /^---$/ { in_crd = 0 }
+    { print }
+  ' "$BUNDLE_FILE"
+  echo '{{- end }}'
+} > "$CHART_V1_CRD_PATH"
 cp "$BUNDLE_FILE" "$CHART_V2_CRD_PATH"
 
 START_ANCHOR="# BEGIN GENERATED KUBE-OVN CRD BUNDLE"

--- a/hack/kamaji-e2e.sh
+++ b/hack/kamaji-e2e.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+#
+# Set up / tear down a local Kamaji-style split-cluster environment to
+# exercise kube-ovn's `installMode=controlPlaneOnly` + `dataPlaneOnly`
+# Helm flow end to end.
+#
+# Layout the script produces:
+#
+#   kind cluster `mgmt`         -- runs Kamaji + cert-manager + MetalLB.
+#       └── kube-ovn controlPlaneOnly install: ovn-central (single-replica,
+#           PVC-backed) + ovn-nb/ovn-sb/ovn-northd Services exposed on a
+#           MetalLB VIP (shared via the allow-shared-ip annotation).
+#   docker container `tenant-worker-0`
+#       └── kubeadm-joined to the Kamaji-hosted tenant apiserver (also on a
+#           MetalLB VIP), running ovs-ovn / kube-ovn-cni / kube-ovn-controller
+#           via the dataPlaneOnly install pointed at the mgmt LB.
+#
+# Subcommands:
+#   setup      bring the whole thing up
+#   teardown   tear it down
+#   kubeconfig print the path to the tenant kubeconfig
+#   vars       print the env variables for the tenant setup
+#
+# Notes:
+# - The tenant worker uses containerd's native snapshotter to dodge a known
+#   limitation of nested overlayfs whiteout handling.
+# - All defaults are configurable via env vars; see the block below.
+
+set -euo pipefail
+
+MGMT_KIND_NAME=${MGMT_KIND_NAME:-mgmt}
+MGMT_KIND_NODE_IMAGE=${MGMT_KIND_NODE_IMAGE:-kindest/node:v1.31.4}
+TENANT_KIND_NODE_IMAGE=${TENANT_KIND_NODE_IMAGE:-kindest/node:v1.30.0}
+TENANT_K8S_VERSION=${TENANT_K8S_VERSION:-v1.30.2}
+
+MGMT_LB_VIP=${MGMT_LB_VIP:-172.18.255.210}
+TENANT_LB_VIP_RANGE_START=${TENANT_LB_VIP_RANGE_START:-172.18.255.200}
+TENANT_LB_VIP_RANGE_END=${TENANT_LB_VIP_RANGE_END:-172.18.255.250}
+
+CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-v1.15.3}
+METALLB_VERSION=${METALLB_VERSION:-v0.14.8}
+
+KUBEOVN_IMAGE=${KUBEOVN_IMAGE:-kubeovn/kube-ovn:dev}
+JOB_DIR=${JOB_DIR:-/tmp/kamaji-e2e}
+REGISTRY_NAME=${REGISTRY_NAME:-kamaji-e2e-reg}
+
+CHART_DIR=${CHART_DIR:-$(cd "$(dirname "$0")/.." && pwd)/charts/kube-ovn}
+
+cmd_vars() {
+  cat <<EOF
+JOB_DIR=$JOB_DIR
+KUBECONFIG=$JOB_DIR/tenant.kubeconfig
+KUBE_OVN_KAMAJI_MGMT_VIP=$MGMT_LB_VIP
+KUBE_OVN_KAMAJI_TENANT_WORKER=tenant-worker-0
+EOF
+}
+
+cmd_kubeconfig() {
+  echo "$JOB_DIR/tenant.kubeconfig"
+}
+
+require_tools() {
+  local missing=()
+  for t in docker kind kubectl helm; do
+    command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: missing required tools: ${missing[*]}" >&2
+    exit 1
+  fi
+}
+
+ensure_image() {
+  if ! docker image inspect "$KUBEOVN_IMAGE" >/dev/null 2>&1; then
+    echo "ERROR: $KUBEOVN_IMAGE not found in local docker; build it first (make build-dev)" >&2
+    exit 1
+  fi
+}
+
+setup_mgmt_cluster() {
+  echo ">>> Creating mgmt kind cluster ($MGMT_KIND_NAME)..."
+  cat > "$JOB_DIR/mgmt-kind.yaml" <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: $MGMT_KIND_NAME
+networking:
+  apiServerAddress: 127.0.0.1
+nodes:
+  - role: control-plane
+    image: $MGMT_KIND_NODE_IMAGE
+EOF
+  kind create cluster --config "$JOB_DIR/mgmt-kind.yaml"
+  kubectl --context="kind-$MGMT_KIND_NAME" label node "$MGMT_KIND_NAME-control-plane" \
+    kube-ovn/role=master --overwrite
+  kind load docker-image "$KUBEOVN_IMAGE" --name "$MGMT_KIND_NAME"
+}
+
+setup_prereqs() {
+  echo ">>> Installing cert-manager $CERT_MANAGER_VERSION..."
+  kubectl --context="kind-$MGMT_KIND_NAME" apply \
+    -f "https://github.com/cert-manager/cert-manager/releases/download/$CERT_MANAGER_VERSION/cert-manager.yaml"
+  kubectl --context="kind-$MGMT_KIND_NAME" wait --for=condition=Available deploy --all \
+    -n cert-manager --timeout=180s
+
+  echo ">>> Installing MetalLB $METALLB_VERSION..."
+  kubectl --context="kind-$MGMT_KIND_NAME" apply \
+    -f "https://raw.githubusercontent.com/metallb/metallb/$METALLB_VERSION/config/manifests/metallb-native.yaml"
+  kubectl --context="kind-$MGMT_KIND_NAME" -n metallb-system wait \
+    --for=condition=Available deploy/controller --timeout=180s
+  kubectl --context="kind-$MGMT_KIND_NAME" -n metallb-system rollout status \
+    ds/speaker --timeout=180s
+
+  cat <<EOF | kubectl --context="kind-$MGMT_KIND_NAME" apply -f -
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata: {name: kind-pool, namespace: metallb-system}
+spec:
+  addresses:
+    - $TENANT_LB_VIP_RANGE_START-$TENANT_LB_VIP_RANGE_END
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata: {name: empty, namespace: metallb-system}
+EOF
+
+  echo ">>> Installing Kamaji operator..."
+  helm repo add clastix https://clastix.github.io/charts --force-update >/dev/null
+  helm repo update clastix >/dev/null
+  helm upgrade --install --kube-context="kind-$MGMT_KIND_NAME" \
+    kamaji clastix/kamaji \
+    --namespace kamaji-system --create-namespace \
+    --set 'resources=null'
+  kubectl --context="kind-$MGMT_KIND_NAME" -n kamaji-system wait \
+    --for=condition=Available deploy --all --timeout=180s
+}
+
+install_control_plane() {
+  echo ">>> Installing kube-ovn (controlPlaneOnly) on mgmt..."
+  cat > "$JOB_DIR/mgmt-values.yaml" <<EOF
+namespace: kube-system
+installMode: controlPlaneOnly
+OVN_CENTRAL_MODE: single
+
+image:
+  pullPolicy: Never
+
+global:
+  registry:
+    address: docker.io/kubeovn
+  images:
+    kubeovn:
+      repository: kube-ovn
+      tag: dev
+
+ovn-central:
+  storage:
+    storageClassName: standard
+    size: 5Gi
+  service:
+    type: LoadBalancer
+    loadBalancerIP: $MGMT_LB_VIP
+    externalTrafficPolicy: Local
+
+networking:
+  ENABLE_SSL: false
+EOF
+  helm install --kube-context="kind-$MGMT_KIND_NAME" \
+    kube-ovn "$CHART_DIR" \
+    -n kube-system -f "$JOB_DIR/mgmt-values.yaml"
+  kubectl --context="kind-$MGMT_KIND_NAME" wait --for=condition=Ready \
+    pod -n kube-system -l app=ovn-central --timeout=300s
+}
+
+create_tenant_control_plane() {
+  echo ">>> Creating TenantControlPlane via Kamaji..."
+  cat > "$JOB_DIR/tenant-tcp.yaml" <<EOF
+apiVersion: kamaji.clastix.io/v1alpha1
+kind: TenantControlPlane
+metadata:
+  name: tenant
+  namespace: default
+spec:
+  dataStore: default
+  controlPlane:
+    deployment:
+      replicas: 1
+      resources:
+        apiServer:
+          requests: {cpu: 100m, memory: 256Mi}
+          limits:   {cpu: "1", memory: 1Gi}
+        controllerManager:
+          requests: {cpu: 100m, memory: 128Mi}
+          limits:   {cpu: 500m, memory: 512Mi}
+        scheduler:
+          requests: {cpu: 100m, memory: 128Mi}
+          limits:   {cpu: 500m, memory: 512Mi}
+    service:
+      serviceType: LoadBalancer
+  kubernetes:
+    version: $TENANT_K8S_VERSION
+    kubelet:
+      cgroupfs: systemd
+    admissionControllers: [ResourceQuota, LimitRanger]
+  networkProfile:
+    port: 6443
+  addons:
+    coreDNS: {}
+    kubeProxy: {}
+EOF
+  kubectl --context="kind-$MGMT_KIND_NAME" apply -f "$JOB_DIR/tenant-tcp.yaml"
+
+  echo ">>> Waiting for TenantControlPlane Ready..."
+  for i in $(seq 1 60); do
+    if [ "$(kubectl --context="kind-$MGMT_KIND_NAME" get tcp tenant -n default \
+        -o jsonpath='{.status.kubernetesResources.version.status}' 2>/dev/null)" = "Ready" ]; then
+      break
+    fi
+    sleep 5
+  done
+
+  kubectl --context="kind-$MGMT_KIND_NAME" -n default get secret tenant-admin-kubeconfig \
+    -o jsonpath='{.data.admin\.conf}' | base64 -d > "$JOB_DIR/tenant.kubeconfig"
+  echo ">>> tenant kubeconfig written to $JOB_DIR/tenant.kubeconfig"
+}
+
+setup_local_registry() {
+  echo ">>> Starting local registry on the kind network..."
+  docker rm -f "$REGISTRY_NAME" >/dev/null 2>&1 || true
+  docker run -d --name "$REGISTRY_NAME" --network=kind --restart=always \
+    -p 5000:5000 registry:2 >/dev/null
+  sleep 3
+  REG_IP=$(docker inspect "$REGISTRY_NAME" \
+    -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+  docker tag "$KUBEOVN_IMAGE" "localhost:5000/${KUBEOVN_IMAGE#*/}"
+  docker push "localhost:5000/${KUBEOVN_IMAGE#*/}" >/dev/null
+  echo "$REG_IP" > "$JOB_DIR/reg-ip"
+}
+
+setup_tenant_worker() {
+  local reg_ip
+  reg_ip=$(cat "$JOB_DIR/reg-ip")
+  echo ">>> Spawning tenant-worker-0..."
+  docker rm -f tenant-worker-0 >/dev/null 2>&1 || true
+  docker run -d --name tenant-worker-0 \
+    --privileged --network=kind \
+    --hostname tenant-worker-0 \
+    --tmpfs /run --tmpfs /tmp \
+    -v /lib/modules:/lib/modules:ro \
+    --security-opt apparmor=unconfined \
+    --security-opt seccomp=unconfined \
+    --cgroupns=host \
+    "$TENANT_KIND_NODE_IMAGE" >/dev/null
+  sleep 8
+
+  echo ">>> Reconfiguring containerd to use native snapshotter + allow local registry..."
+  docker exec tenant-worker-0 sh -c "
+    sed -i 's/snapshotter = \"overlayfs\"/snapshotter = \"native\"/' /etc/containerd/config.toml
+    mkdir -p /etc/containerd/certs.d/$reg_ip:5000
+    cat > /etc/containerd/certs.d/$reg_ip:5000/hosts.toml <<HOSTS
+server = \"http://$reg_ip:5000\"
+[host.\"http://$reg_ip:5000\"]
+  capabilities = [\"pull\", \"resolve\"]
+  skip_verify = true
+HOSTS
+    cat >> /etc/containerd/config.toml <<CFG
+
+[plugins.\"io.containerd.grpc.v1.cri\".registry]
+  config_path = \"/etc/containerd/certs.d\"
+CFG
+    systemctl restart containerd
+  "
+  sleep 6
+
+  echo ">>> Pre-pulling $KUBEOVN_IMAGE on tenant worker..."
+  docker exec tenant-worker-0 crictl pull "$reg_ip:5000/${KUBEOVN_IMAGE#*/}"
+  docker exec tenant-worker-0 ctr -n k8s.io images tag --force \
+    "$reg_ip:5000/${KUBEOVN_IMAGE#*/}" "docker.io/${KUBEOVN_IMAGE#*/}"
+}
+
+join_tenant_worker() {
+  echo ">>> Generating kubeadm join command..."
+  docker run --rm --network=kind -v "$JOB_DIR/tenant.kubeconfig:/kc:ro" \
+    --entrypoint kubeadm "$TENANT_KIND_NODE_IMAGE" \
+    --kubeconfig=/kc token create --print-join-command > "$JOB_DIR/join.txt"
+  local join_cmd
+  join_cmd=$(grep "^kubeadm join" "$JOB_DIR/join.txt")
+  echo ">>> Joining tenant-worker-0 to tenant apiserver..."
+  docker exec tenant-worker-0 bash -c "$join_cmd --ignore-preflight-errors=all"
+}
+
+install_data_plane() {
+  echo ">>> Installing kube-ovn (dataPlaneOnly) on tenant..."
+  cat > "$JOB_DIR/tenant-values.yaml" <<EOF
+namespace: kube-system
+installMode: dataPlaneOnly
+
+externalOvnCentral:
+  endpoint: $MGMT_LB_VIP
+  nbPort: 6641
+  sbPort: 6642
+
+image:
+  pullPolicy: Never
+
+global:
+  registry:
+    address: docker.io/kubeovn
+  images:
+    kubeovn:
+      repository: kube-ovn
+      tag: dev
+
+networking:
+  ENABLE_SSL: false
+EOF
+  helm install --kubeconfig "$JOB_DIR/tenant.kubeconfig" \
+    kube-ovn "$CHART_DIR" \
+    -n kube-system --create-namespace -f "$JOB_DIR/tenant-values.yaml"
+
+  echo ">>> Waiting for tenant data-plane components..."
+  KUBECONFIG="$JOB_DIR/tenant.kubeconfig" kubectl -n kube-system rollout status \
+    deploy/kube-ovn-controller --timeout=300s
+  KUBECONFIG="$JOB_DIR/tenant.kubeconfig" kubectl -n kube-system rollout status \
+    ds/ovs-ovn --timeout=300s
+  KUBECONFIG="$JOB_DIR/tenant.kubeconfig" kubectl -n kube-system rollout status \
+    ds/kube-ovn-cni --timeout=300s
+}
+
+cmd_setup() {
+  require_tools
+  ensure_image
+  mkdir -p "$JOB_DIR"
+  setup_mgmt_cluster
+  setup_prereqs
+  install_control_plane
+  create_tenant_control_plane
+  setup_local_registry
+  setup_tenant_worker
+  join_tenant_worker
+  install_data_plane
+  echo ""
+  echo "=== Kamaji e2e environment ready ==="
+  cmd_vars
+}
+
+cmd_teardown() {
+  echo ">>> Tearing down Kamaji e2e environment..."
+  kind delete cluster --name "$MGMT_KIND_NAME" 2>/dev/null || true
+  docker rm -f tenant-worker-0 "$REGISTRY_NAME" 2>/dev/null || true
+  docker rmi "localhost:5000/${KUBEOVN_IMAGE#*/}" 2>/dev/null || true
+  rm -rf "$JOB_DIR"
+}
+
+case "${1:-}" in
+  setup)      cmd_setup ;;
+  teardown)   cmd_teardown ;;
+  kubeconfig) cmd_kubeconfig ;;
+  vars)       cmd_vars ;;
+  *)
+    cat >&2 <<USAGE
+Usage: $0 <setup|teardown|kubeconfig|vars>
+
+  setup       Bring up the mgmt kind cluster + Kamaji + tenant worker and
+              install both halves of kube-ovn.
+  teardown    Tear everything down.
+  kubeconfig  Print the path to the tenant kubeconfig (used by the e2e job).
+  vars        Print the env vars consumed by the Ginkgo e2e suite.
+USAGE
+    exit 1 ;;
+esac

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -285,6 +285,23 @@ kind-install-ipv6:
 kind-install-dual:
 	@DUAL_STACK=true $(MAKE) kind-install
 
+.PHONY: kind-install-single-replica
+kind-install-single-replica:
+	@ENABLE_SINGLE_REPLICA_OVN=true OVN_CENTRAL_STORAGE_CLASS=standard $(MAKE) kind-install
+
+# Kamaji split-cluster setup: brings up a mgmt kind cluster running Kamaji +
+# kube-ovn controlPlaneOnly, plus a docker-container tenant worker joined to
+# the Kamaji-hosted tenant apiserver and running kube-ovn dataPlaneOnly.
+# Requires `kubeovn/kube-ovn:dev` to already exist locally (run
+# `make build-dev` first).
+.PHONY: kind-install-kamaji
+kind-install-kamaji:
+	@KUBEOVN_IMAGE=$(REGISTRY)/kube-ovn:$(DEV_TAG) ./hack/kamaji-e2e.sh setup
+
+.PHONY: kind-clean-kamaji
+kind-clean-kamaji:
+	@./hack/kamaji-e2e.sh teardown
+
 .PHONY: kind-install-overlay
 kind-install-overlay: kind-install-overlay-ipv4
 

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -56,6 +56,7 @@ type Configuration struct {
 	IsICDBServer    bool
 	localAddress    string
 	remoteAddresses []string
+	singleReplica   bool
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -95,16 +96,47 @@ func ParseFlags() (*Configuration, error) {
 		return nil, err
 	}
 
+	// Determine single-replica mode from the *raw* flag input, not from the
+	// filtered remoteAddresses slice. A one-node raft cluster passes a single
+	// IP equal to the local address, which DeleteFunc removes — that must
+	// stay in raft mode (with raft header backup and northd lock stealing),
+	// not be conflated with the single-replica standalone deployment that
+	// passes --remoteAddresses="" explicitly.
+	singleReplica := true
+	for _, addr := range *remoteAddresses {
+		if addr != "" {
+			singleReplica = false
+			break
+		}
+	}
+
 	config := &Configuration{
-		KubeConfigFile:  *argKubeConfigFile,
-		ProbeInterval:   *argProbeInterval,
-		EnableCompact:   *argEnableCompact,
-		IsICDBServer:    *argIsICDBServer,
-		localAddress:    *localAddress,
-		remoteAddresses: slices.DeleteFunc(*remoteAddresses, func(s string) bool { return s == *localAddress }),
+		KubeConfigFile: *argKubeConfigFile,
+		ProbeInterval:  *argProbeInterval,
+		EnableCompact:  *argEnableCompact,
+		IsICDBServer:   *argIsICDBServer,
+		localAddress:   *localAddress,
+		remoteAddresses: slices.DeleteFunc(*remoteAddresses, func(s string) bool {
+			// Drop the local address (already covered by isDBLeader on localAddress)
+			// and any empty entries produced by --remoteAddresses="" in single-replica
+			// mode.
+			return s == "" || s == *localAddress
+		}),
+		singleReplica: singleReplica,
 	}
 
 	return config, nil
+}
+
+// isSingleReplicaMode reports whether ovn-central is running as a single
+// standalone pod (no raft cluster, no peers). In that mode the leader-checker
+// skips raft leader queries and ovn_northd lock stealing because they are
+// meaningless with only one DB instance. This is computed from the original
+// --remoteAddresses flag, not the filtered slice, so a one-node raft cluster
+// stays in cluster behaviour (raft header backup, lock stealing) rather than
+// being mistakenly demoted to standalone semantics.
+func (c *Configuration) isSingleReplicaMode() bool {
+	return c.singleReplica
 }
 
 // KubeClientInit funcs to check apiserver alive
@@ -400,6 +432,27 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 	}
 
 	if !cfg.IsICDBServer {
+		if cfg.isSingleReplicaMode() {
+			// Standalone DB: no raft leader to query, no peers to detect a split
+			// brain against, no ovn_northd lock contention. Just keep the pod
+			// labelled as the leader for all three services and run compaction.
+			northdActive := checkNorthdActive()
+			patch := util.KVPatch{
+				"ovn-nb-leader":     "true",
+				"ovn-sb-leader":     "true",
+				"ovn-northd-leader": strconv.FormatBool(northdActive),
+			}
+			if err := util.PatchLabels(cfg.KubeClient.CoreV1().Pods(podNamespace), podName, patch); err != nil {
+				klog.Errorf("failed to patch labels for pod %s/%s: %v", podNamespace, podName, err)
+				return
+			}
+			if cfg.EnableCompact {
+				compactOvnDatabase("nb")
+				compactOvnDatabase("sb")
+			}
+			return
+		}
+
 		nbLeader := isDBLeader(cfg.localAddress, ovnnb.DatabaseName)
 		sbLeader := isDBLeader(cfg.localAddress, ovnsb.DatabaseName)
 		northdActive := checkNorthdActive()

--- a/pkg/ovs/start_db_script_test.go
+++ b/pkg/ovs/start_db_script_test.go
@@ -1,0 +1,194 @@
+package ovs
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestStartDBAddressFunctions(t *testing.T) {
+	bash := requireBash(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	for _, script := range []struct {
+		name      string
+		path      string
+		endMarker string
+	}{
+		{
+			name:      "start-db",
+			path:      filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh"),
+			endMarker: "function get_leader_addr",
+		},
+		{
+			name:      "start-ic-db",
+			path:      filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-ic-db.sh"),
+			endMarker: "function ovn_db_pre_start",
+		},
+	} {
+		t.Run(script.name, func(t *testing.T) {
+			content, err := os.ReadFile(script.path)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", script.path, err)
+			}
+
+			functions := extractStartDBAddressFunctions(t, string(content), script.endMarker)
+
+			tests := []struct {
+				name     string
+				command  string
+				expected string
+			}{
+				{
+					name:     "hostname connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr ovn-central-0.ovn-central.hcp.svc.cluster.local 6643",
+					expected: "tcp:ovn-central-0.ovn-central.hcp.svc.cluster.local:6643",
+				},
+				{
+					name:     "ssl hostname connection address",
+					command:  "ENABLE_SSL=true; gen_conn_addr ovn-central-0.ovn-central.hcp.svc.cluster.local 6643",
+					expected: "ssl:ovn-central-0.ovn-central.hcp.svc.cluster.local:6643",
+				},
+				{
+					name:     "ipv4 connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr 10.3.0.58 6643",
+					expected: "tcp:[10.3.0.58]:6643",
+				},
+				{
+					name:     "ipv6 connection address",
+					command:  "ENABLE_SSL=false; gen_conn_addr fd00::58 6643",
+					expected: "tcp:[fd00::58]:6643",
+				},
+				{
+					name:     "hostname connection string",
+					command:  "ENABLE_SSL=false; NODE_IPS='ovn-central-0.ovn-central.hcp.svc.cluster.local, ovn-central-1.ovn-central.hcp.svc.cluster.local'; gen_conn_str 6641",
+					expected: "tcp:ovn-central-0.ovn-central.hcp.svc.cluster.local:6641,tcp:ovn-central-1.ovn-central.hcp.svc.cluster.local:6641",
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					output, err := exec.Command(bash, "-c", functions+"\n"+tt.command).CombinedOutput() // #nosec G204
+					if err != nil {
+						t.Fatalf("command failed: %v\noutput: %s", err, output)
+					}
+
+					got := strings.TrimSpace(string(output))
+					if got != tt.expected {
+						t.Fatalf("expected %q, got %q", tt.expected, got)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestStartDBClusterAddressArgsUseFormatter(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	scriptPath := filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", scriptPath, err)
+	}
+	script := string(content)
+
+	for _, oldArg := range []string{
+		"--db-nb-cluster-local-addr=[$DB_CLUSTER_ADDR]",
+		"--db-sb-cluster-local-addr=[$DB_CLUSTER_ADDR]",
+		"--db-nb-cluster-remote-addr=[$nb_leader_addr]",
+		"--db-sb-cluster-remote-addr=[$sb_leader_addr]",
+	} {
+		if strings.Contains(script, oldArg) {
+			t.Fatalf("cluster address argument %q should use format_ovsdb_addr", oldArg)
+		}
+	}
+}
+
+func TestStartDBExpandsSvcAddressesFromDNSResponse(t *testing.T) {
+	bash := requireBash(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+
+	scriptPath := filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "start-db.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", scriptPath, err)
+	}
+
+	functions := extractStartDBAddressFunctions(t, string(content), "function gen_conn_addr")
+	command := strings.Join([]string{
+		`function getent { case "$2" in ovn-central-0.ovn-central.hcp.svc) echo "10.3.0.67 ovn-central-0.ovn-central.hcp.svc.acme.local" ;; ovn-central-1.ovn-central.hcp.svc) echo "10.3.0.68 ovn-central-1.ovn-central.hcp.svc.acme.local" ;; esac; }`,
+		"POD_NAMESPACE=hcp",
+		"DB_CLUSTER_ADDR=ovn-central-0.ovn-central.hcp.svc",
+		"POD_IP=$DB_CLUSTER_ADDR",
+		"NODE_IPS=ovn-central-0.ovn-central.hcp.svc,ovn-central-1.ovn-central.hcp.svc",
+		"normalize_raft_addrs",
+		"printf '%s\\n%s\\n%s\\n' \"$DB_CLUSTER_ADDR\" \"$POD_IP\" \"$NODE_IPS\"",
+	}, "; ")
+
+	output, err := exec.Command(bash, "-c", functions+"\n"+command).CombinedOutput() // #nosec G204
+	if err != nil {
+		t.Fatalf("command failed: %v\noutput: %s", err, output)
+	}
+
+	expected := strings.Join([]string{
+		"ovn-central-0.ovn-central.hcp.svc.acme.local",
+		"ovn-central-0.ovn-central.hcp.svc.acme.local",
+		"ovn-central-0.ovn-central.hcp.svc.acme.local,ovn-central-1.ovn-central.hcp.svc.acme.local",
+	}, "\n")
+	if got := strings.TrimSpace(string(output)); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func requireBash(t *testing.T) string {
+	t.Helper()
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required to test start-db.sh snippets")
+	}
+	return bash
+}
+
+func extractStartDBAddressFunctions(t *testing.T, script, endMarker string) string {
+	t.Helper()
+
+	start := strings.Index(script, "function format_ovsdb_addr")
+	if start == -1 {
+		start = firstFunctionIndex(script, "function gen_conn_addr", "function gen_conn_str")
+	}
+	if start == -1 {
+		t.Fatal("failed to find address functions")
+	}
+	end := strings.Index(script[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("failed to find %s", endMarker)
+	}
+	return script[start : start+end]
+}
+
+func firstFunctionIndex(script string, markers ...string) int {
+	first := -1
+	for _, marker := range markers {
+		index := strings.Index(script, marker)
+		if index != -1 && (first == -1 || index < first) {
+			first = index
+		}
+	}
+	return first
+}


### PR DESCRIPTION
Backport PRs to release-1.16:

- #6793 feat: single-replica ovn-central + PVC + LoadBalancer + Kamaji split-cluster deployment
- #6978 feat: support HCP ovn-central chart deployment

Backport notes:

- Omitted the new master-only `test/e2e/single-replica` and `test/e2e/kamaji` packages and their Make targets because release-1.16 does not have `test/e2e/framework`.
- Kept release-1.16 chart image conventions for `charts/kube-ovn-v2` instead of backporting master-only `kubeovn.imageSpec`.

Verification:

- `go test -count=1 ./pkg/ovn_leader_checker ./pkg/ovs`
- `helm lint charts/kube-ovn`
- `helm lint charts/kube-ovn-v2`
- `helm template charts/kube-ovn`
- `helm template charts/kube-ovn --set installMode=controlPlaneOnly --set OVN_CENTRAL_MODE=single`
- `helm template charts/kube-ovn --set installMode=dataPlaneOnly --set externalOvnCentral.endpoint=1.2.3.4`
- `helm template charts/kube-ovn --set ovn-central.hcp.enabled=true --set ovn-central.hcp.nbAddress=tcp:ovn-nb.example.com:6641 --set ovn-central.hcp.sbAddress=tcp:ovn-sb.example.com:6642`
- `helm template charts/kube-ovn-v2 --set central.hcp.enabled=true --set central.hcp.nbAddress=tcp:ovn-nb.example.com:6641 --set central.hcp.sbAddress=tcp:ovn-sb.example.com:6642`
- `bash -n dist/images/install.sh dist/images/restore-ovn-nb-db.sh dist/images/start-controller.sh dist/images/start-db.sh dist/images/start-ic-controller.sh dist/images/start-ic-db.sh dist/images/start-ovs.sh dist/images/start-ovs-dpdk-v2.sh hack/kamaji-e2e.sh hack/gen-crd.sh`
- `git diff --check`