### PR TITLE
chart: support HCP ovn-central scheduling

### DIFF
--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -138,7 +138,9 @@ TLS arguments for kube-ovn components that expose HTTPS endpoints.
 - --tls-max-version={{ .Values.networking.tlsMaxVersion }}
 {{- end }}
 {{- if .Values.networking.tlsCipherSuites }}
-- --tls-cipher-suites={{ join "," .Values.networking.tlsCipherSuites }}
+{{- range .Values.networking.tlsCipherSuites }}
+- --tls-cipher-suites={{ . }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -17,6 +17,9 @@ spec:
   {{- if .Values.central.hcp.enabled }}
   serviceName: ovn-central
   podManagementPolicy: Parallel
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
   {{- end }}
   {{- if not .Values.central.hcp.enabled }}
   strategy:
@@ -54,15 +57,13 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
-        {{- include "kube-ovn.affinities.nodeAffinity" (dict "hardcodedRequired" (include "kubeovn.masterNodeRequired" . | fromYamlArray) "userPreferred" .Values.central.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.central.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) | nindent 8 }}
-        {{- if not .Values.central.hcp.enabled }}
+        {{- include "kube-ovn.affinities.nodeAffinity" (dict "hardcodedRequired" (ternary (list) (include "kubeovn.masterNodeRequired" . | fromYamlArray) .Values.central.hcp.enabled) "userPreferred" .Values.central.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.central.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) | nindent 8 }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/name: ovn-central
               topologyKey: kubernetes.io/hostname
-        {{- end }}
       priorityClassName: system-cluster-critical
       serviceAccountName: {{ ternary "ovn-central" "ovn-ovs" .Values.central.hcp.enabled }}
       automountServiceAccountToken: true
@@ -203,6 +204,9 @@ spec:
             timeoutSeconds: 45
       nodeSelector:
         kubernetes.io/os: "linux"
+        {{- if not .Values.central.hcp.enabled }}
+        {{ .Values.masterNodesLabels | toYaml | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if .Values.central.hcp.enabled }}
         - name: run-ovn

--- a/charts/kube-ovn-v2/templates/hooks/upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn-v2/templates/hooks/upgrade-ovs-ovn.yaml
@@ -151,8 +151,13 @@ spec:
                   fieldPath: metadata.namespace
             - name: ENABLE_SSL
               value: "{{ .Values.networking.enableSsl }}"
+            {{- if .Values.central.hcp.enabled }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.ovnNbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+            {{- end }}
             - name: OVN_VERSION_COMPATIBILITY
               value: {{ .Values.ovsOvn.upgrade.versionCompatibility | quote }}
           command:

--- a/charts/kube-ovn-v2/templates/ic/ic-controller-deploy.yaml
+++ b/charts/kube-ovn-v2/templates/ic/ic-controller-deploy.yaml
@@ -93,8 +93,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.central.hcp.enabled }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.ovnNbAddress" . }}"
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+            {{- end }}
             {{- with .Values.ic.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -6,8 +6,10 @@ templates:
   - central/southbound-service.yaml
   - central/central-rbac.yaml
   - controller/controller-deployment.yaml
+  - ic/ic-controller-deploy.yaml
   - ovs-ovn/ovs-ovn-daemonset.yaml
   - ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+  - hooks/upgrade-ovs-ovn.yaml
 tests:
   - it: renders ovn-central as a PVC-backed StatefulSet in the HCP namespace
     template: central/central-deployment.yaml
@@ -268,6 +270,25 @@ tests:
             name: OVN_SB_ADDR
             value: tcp:ovn-sb.example.com:6642
 
+  - it: points ic-controller at independent HCP OVN DB addresses
+    template: ic/ic-controller-deploy.yaml
+    set:
+      features.enableOvnInterconnections: true
+      central.hcp.enabled: true
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_NB_ADDR
+            value: tcp:ovn-nb.example.com:6641
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
   - it: points ovs-ovn at the HCP OVN SB address
     template: ovs-ovn/ovs-ovn-daemonset.yaml
     set:
@@ -294,3 +315,19 @@ tests:
           content:
             name: OVN_SB_ADDR
             value: tcp:ovn-sb.example.com:6642
+
+  - it: points ovs upgrade hook at the HCP OVN NB address
+    template: hooks/upgrade-ovs-ovn.yaml
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      central.hcp.enabled: true
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_NB_ADDR
+            value: tcp:ovn-nb.example.com:6641

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -32,6 +32,12 @@ tests:
           path: spec.serviceName
           value: ovn-central
       - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+      - equal:
           path: spec.template.spec.hostNetwork
           value: false
       - equal:
@@ -54,8 +60,10 @@ tests:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-      - notExists:
+      - isNotNull:
           path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity.nodeAffinity
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -72,6 +80,48 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
           value: topolvm
+
+  - it: renders TLS cipher suites as readable repeated args
+    template: controller/controller-deployment.yaml
+    set:
+      masterNodes:
+        - 10.0.0.1
+      networking.tlsCipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+
+  - it: preserves user node affinity for HCP ovn-central
+    template: central/central-deployment.yaml
+    set:
+      central.hcp.enabled: true
+      central.hcp.namespace: hcp
+      central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+      central.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution:
+        - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - zone-a
+    asserts:
+      - contains:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms
+          content:
+            matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                  - zone-a
 
   - it: creates dedicated namespaced RBAC for HCP ovn-central
     template: central/central-rbac.yaml

--- a/charts/kube-ovn-v2/tests/master_node_affinity_test.yaml
+++ b/charts/kube-ovn-v2/tests/master_node_affinity_test.yaml
@@ -97,7 +97,8 @@ tests:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms
           count: 2
 
-  - it: retains only kubernetes.io/os in nodeSelector
+  - it: keeps master labels in nodeSelector when HCP is disabled
+    template: central/central-deployment.yaml
     set:
       masterNodes:
         - "10.0.0.1"
@@ -108,4 +109,6 @@ tests:
       - equal:
           path: spec.template.spec.nodeSelector
           value:
+            kube-ovn/role: master
             kubernetes.io/os: "linux"
+            node-role.kubernetes.io/control-plane: ""

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -998,7 +998,6 @@ central:
   # -- Labels to be added to ovn-central pods.
   # @section -- OVN-central daemon configuration
   podLabels: {}
-
   # -- Extra environment variables to be added to ovn-central pods.
   # @section -- OVN-central daemon configuration
   extraEnv: []

--- a/charts/kube-ovn/templates/_helpers.tpl
+++ b/charts/kube-ovn/templates/_helpers.tpl
@@ -64,6 +64,18 @@ Number of master nodes
 {{- end -}}
 
 {{/*
+Number of Kubernetes nodes, falling back to MASTER_NODES for offline rendering.
+*/}}
+{{- define "kubeovn.k8sNodeCount" -}}
+{{- $nodes := lookup "v1" "Node" "" "" -}}
+{{- if and $nodes $nodes.items -}}
+{{- len $nodes.items -}}
+{{- else -}}
+{{- include "kubeovn.nodeCount" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Replica count for the ovn-central Deployment. Single mode always uses 1;
 cluster mode uses one replica per master node.
 */}}
@@ -119,24 +131,23 @@ TLS arguments for kube-ovn components that expose HTTPS endpoints.
 - --tls-max-version={{ .Values.networking.TLS_MAX_VERSION }}
 {{- end }}
 {{- if .Values.networking.TLS_CIPHER_SUITES }}
-- --tls-cipher-suites={{ join "," .Values.networking.TLS_CIPHER_SUITES }}
+{{- range .Values.networking.TLS_CIPHER_SUITES }}
+- --tls-cipher-suites={{ . }}
+{{- end }}
 {{- end }}
 {{- end -}}
 
 {{/*
 Replica count for the kube-ovn-controller Deployment.
-- dataPlaneOnly: tenant cluster typically has no `kube-ovn/role=master` node
-  label and kube-ovn-controller can run with replicas=1 (active/standby HA is
-  configured via leader election, not horizontal scale). Use 1 by default,
-  letting operators override via `kube-ovn-controller.replicas`.
-- everywhere else: keep the historical behaviour of one replica per master.
+dataPlaneOnly runs against external HCP ovn-central, so cap controller
+replicas at two while allowing single-node clusters to run one.
 */}}
 {{- define "kubeovn.controllerReplicas" -}}
 {{- $override := dig "replicas" nil (index .Values "kube-ovn-controller") -}}
-{{- if $override -}}
+{{- if eq .Values.installMode "dataPlaneOnly" -}}
+{{- min 2 (include "kubeovn.k8sNodeCount" . | int) -}}
+{{- else if $override -}}
 {{ $override }}
-{{- else if eq .Values.installMode "dataPlaneOnly" -}}
-1
 {{- else -}}
 {{- include "kubeovn.nodeCount" . -}}
 {{- end -}}
@@ -144,10 +155,7 @@ Replica count for the kube-ovn-controller Deployment.
 
 {{/*
 Value of the NODE_IPS / OVN_DB_IPS env variable.
-  - dataPlaneOnly: emit externalOvnCentral.endpoint so agents/controller dial
-    the management cluster's exposed ovn-nb / ovn-sb via the configured LB IP.
-    Required — empty would fall back to OVN_NB_SERVICE_HOST which is not
-    injected in this mode because no local ovn-nb Service is rendered.
+  - dataPlaneOnly: invalid; workload components use OVN_NB_ADDR/OVN_SB_ADDR.
   - single (control-plane / full): emit empty so start-db.sh takes the
     standalone path and clients fall back to Service ClusterIP via the
     auto-injected OVN_*_SERVICE_HOST env vars.
@@ -157,10 +165,28 @@ Value of the NODE_IPS / OVN_DB_IPS env variable.
 {{- if index .Values "ovn-central" "hcp" "enabled" -}}
 {{- include "kubeovn.centralRaftAddresses" . -}}
 {{- else if eq .Values.installMode "dataPlaneOnly" -}}
-{{ required "installMode=dataPlaneOnly requires externalOvnCentral.endpoint (the management cluster's ovn-nb / ovn-sb VIP)" .Values.externalOvnCentral.endpoint }}
+{{- fail "installMode=dataPlaneOnly uses OVN_NB_ADDR/OVN_SB_ADDR; do not render OVN_DB_IPS" -}}
 {{- else if eq .Values.OVN_CENTRAL_MODE "single" -}}
 {{- else -}}
 {{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubeovn.externalOvnNbAddress" -}}
+{{- $endpoint := required "installMode=dataPlaneOnly requires externalOvnCentral.nbEndpoint" .Values.externalOvnCentral.nbEndpoint -}}
+tcp:{{ include "kubeovn.externalOvnHost" $endpoint }}:{{ .Values.externalOvnCentral.nbPort | default 6641 }}
+{{- end -}}
+
+{{- define "kubeovn.externalOvnSbAddress" -}}
+{{- $endpoint := required "installMode=dataPlaneOnly requires externalOvnCentral.sbEndpoint" .Values.externalOvnCentral.sbEndpoint -}}
+tcp:{{ include "kubeovn.externalOvnHost" $endpoint }}:{{ .Values.externalOvnCentral.sbPort | default 6642 }}
+{{- end -}}
+
+{{- define "kubeovn.externalOvnHost" -}}
+{{- if and (contains ":" .) (not (hasPrefix "[" .)) -}}
+[{{ . }}]
+{{- else -}}
+{{ . }}
 {{- end -}}
 {{- end -}}
 
@@ -181,17 +207,16 @@ Value of the NODE_IPS / OVN_DB_IPS env variable.
 {{/*
 Validate the ovn-central.service block. Currently the only invariant we
 enforce is that LoadBalancer service type must come with an explicit
-loadBalancerIP, because externalOvnCentral.endpoint is a single IP and we
-need all three Services (ovn-nb / ovn-sb / ovn-northd) to land on the same
-VIP. Without it cloud LBs allocate three different IPs and tenant clusters
-can only reach one DB. Use {{- include "kubeovn.validateService" . }}
+loadBalancerIP, because ovn-nb / ovn-sb / ovn-northd should land on the same
+stable VIP when exposed through that Service type. Without it cloud LBs may
+allocate three different IPs unexpectedly. Use {{- include "kubeovn.validateService" . }}
 anywhere a Service is rendered so the validation runs on every template.
 */}}
 {{- define "kubeovn.validateService" -}}
 {{- $svc := index .Values "ovn-central" "service" -}}
 {{- if eq $svc.type "LoadBalancer" -}}
 {{- if not $svc.loadBalancerIP -}}
-{{- fail "ovn-central.service.type=LoadBalancer requires ovn-central.service.loadBalancerIP to be set so the three OVN Services share a single VIP. Without it cloud LB controllers allocate three separate IPs and externalOvnCentral.endpoint (single IP) can only reach one of NB/SB/northd. Pick a VIP, configure your LB controller to assign it (MetalLB allow-shared-ip annotation is emitted automatically), then re-run helm." -}}
+{{- fail "ovn-central.service.type=LoadBalancer requires ovn-central.service.loadBalancerIP to be set so ovn-nb / ovn-sb / ovn-northd share a stable VIP. Pick a VIP, configure your LB controller to assign it (MetalLB allow-shared-ip annotation is emitted automatically), then re-run helm." -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -36,6 +36,9 @@ spec:
   {{- if index .Values "ovn-central" "hcp" "enabled" }}
   serviceName: ovn-central
   podManagementPolicy: Parallel
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
   {{- else }}
   strategy:
     {{- if eq .Values.OVN_CENTRAL_MODE "single" }}
@@ -58,15 +61,13 @@ spec:
         type: infra
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
+        {{- with (index .Values "ovn-central" "tolerations") }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
-        {{- if not (index .Values "ovn-central" "hcp" "enabled") }}
-        {{- if ne .Values.OVN_CENTRAL_MODE "single" }}
+        {{- if or (index .Values "ovn-central" "hcp" "enabled") (ne .Values.OVN_CENTRAL_MODE "single") }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -74,8 +75,9 @@ spec:
                   app: ovn-central
               topologyKey: kubernetes.io/hostname
         {{- end }}
-        {{- end }}
+        {{- if not (index .Values "ovn-central" "hcp" "enabled") }}
         {{- include "kubeovn.masterNodeAffinity" . | nindent 8 }}
+        {{- end }}
       priorityClassName: system-cluster-critical
       serviceAccountName: {{ ternary "ovn-central" "ovn-ovs" (index .Values "ovn-central" "hcp" "enabled") }}
       automountServiceAccountToken: true
@@ -227,8 +229,11 @@ spec:
             periodSeconds: 15
             failureThreshold: 5
             timeoutSeconds: 45
+      {{- $nodeSelector := index .Values "ovn-central" "nodeSelector" }}
+      {{- if $nodeSelector }}
       nodeSelector:
-        kubernetes.io/os: "linux"
+        {{- toYaml $nodeSelector | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if index .Values "ovn-central" "hcp" "enabled" }}
         - name: run-ovn

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -189,6 +189,11 @@ spec:
               value: "{{ include "kubeovn.ovnNbAddress" . }}"
             - name: OVN_SB_ADDR
               value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else if eq .Values.installMode "dataPlaneOnly" }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.externalOvnNbAddress" . }}"
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.externalOvnSbAddress" . }}"
             {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"

--- a/charts/kube-ovn/templates/ic-controller-deploy.yaml
+++ b/charts/kube-ovn/templates/ic-controller-deploy.yaml
@@ -93,12 +93,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if eq .Values.installMode "dataPlaneOnly" }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.externalOvnNbAddress" . }}"
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.externalOvnSbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"
             - name: KUBE_OVN_NB_PORT
               value: "{{ include "kubeovn.ovnNbPort" . }}"
             - name: KUBE_OVN_SB_PORT
               value: "{{ include "kubeovn.ovnSbPort" . }}"
+            {{- end }}
           resources:
             requests:
               cpu: 300m

--- a/charts/kube-ovn/templates/ic-controller-deploy.yaml
+++ b/charts/kube-ovn/templates/ic-controller-deploy.yaml
@@ -93,7 +93,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if eq .Values.installMode "dataPlaneOnly" }}
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.ovnNbAddress" . }}"
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else if eq .Values.installMode "dataPlaneOnly" }}
             - name: OVN_NB_ADDR
               value: "{{ include "kubeovn.externalOvnNbAddress" . }}"
             - name: OVN_SB_ADDR

--- a/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
+++ b/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
@@ -62,6 +62,9 @@ spec:
             {{- if index .Values "ovn-central" "hcp" "enabled" }}
             - name: OVN_SB_ADDR
               value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else if eq .Values.installMode "dataPlaneOnly" }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.externalOvnSbAddress" . }}"
             {{- else }}
             - name: OVN_DB_IPS
               value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -126,6 +126,9 @@ spec:
             {{- if index .Values "ovn-central" "hcp" "enabled" }}
             - name: OVN_SB_ADDR
               value: "{{ include "kubeovn.ovnSbAddress" . }}"
+            {{- else if eq .Values.installMode "dataPlaneOnly" }}
+            - name: OVN_SB_ADDR
+              value: "{{ include "kubeovn.externalOvnSbAddress" . }}"
             {{- else }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnCentralNodeIPs" . }}"

--- a/charts/kube-ovn/templates/upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn/templates/upgrade-ovs-ovn.yaml
@@ -152,8 +152,13 @@ spec:
                   fieldPath: metadata.namespace
             - name: ENABLE_SSL
               value: "{{ .Values.networking.ENABLE_SSL }}"
+            {{- if index .Values "ovn-central" "hcp" "enabled" }}
+            - name: OVN_NB_ADDR
+              value: "{{ include "kubeovn.ovnNbAddress" . }}"
+            {{- else }}
             - name: OVN_DB_IPS
               value: "{{ .Values.MASTER_NODES | default (include "kubeovn.nodeIPs" .) }}"
+            {{- end }}
             - name: OVN_VERSION_COMPATIBILITY
               value: '{{ include "kubeovn.ovn.versionCompatibility" . }}'
           command:

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -6,6 +6,7 @@ templates:
   - nb-svc.yaml
   - sb-svc.yaml
   - controller-deploy.yaml
+  - ic-controller-deploy.yaml
   - ovsovn-ds.yaml
   - ovn-dpdk-ds.yaml
 tests:
@@ -207,6 +208,25 @@ tests:
   - it: points workload components at independent HCP OVN DB addresses
     template: controller-deploy.yaml
     set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_NB_ADDR
+            value: tcp:ovn-nb.example.com:6641
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:ovn-sb.example.com:6642
+
+  - it: points ic-controller at independent HCP OVN DB addresses
+    template: ic-controller-deploy.yaml
+    set:
+      func.ENABLE_IC: true
       ovn-central.hcp.enabled: true
       ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
       ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -19,6 +19,12 @@ tests:
       ovn-central.hcp.replicas: 3
       ovn-central.hcp.storage.size: 5Gi
       ovn-central.hcp.storage.storageClassName: topolvm
+      ovn-central.nodeSelector.dedicated: hcp-ovn
+      ovn-central.tolerations:
+        - key: dedicated
+          operator: Equal
+          value: hcp-ovn
+          effect: NoSchedule
     asserts:
       - isKind:
           of: StatefulSet
@@ -32,6 +38,12 @@ tests:
           path: spec.serviceName
           value: ovn-central
       - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+      - equal:
           path: spec.template.spec.hostNetwork
           value: false
       - equal:
@@ -40,6 +52,20 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: true
+      - isNotNull:
+          path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity.nodeAffinity
+      - equal:
+          path: spec.template.spec.nodeSelector.dedicated
+          value: hcp-ovn
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: hcp-ovn
+            effect: NoSchedule
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/kube-ovn/tests/controller_data_plane_test.yaml
+++ b/charts/kube-ovn/tests/controller_data_plane_test.yaml
@@ -1,0 +1,133 @@
+suite: Kube-OVN controller data plane deployment
+templates:
+  - controller-deploy.yaml
+tests:
+  - it: preserves controller replica override outside dataPlaneOnly
+    set:
+      installMode: full
+      MASTER_NODES: "10.0.0.1,10.0.0.2,10.0.0.3"
+      kube-ovn-controller.replicas: 4
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 4
+
+  - it: renders TLS cipher suites as readable repeated args
+    set:
+      installMode: full
+      MASTER_NODES: "10.0.0.1"
+      networking.TLS_CIPHER_SUITES:
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+
+  - it: uses one dataPlaneOnly controller replica for one node
+    set:
+      installMode: dataPlaneOnly
+      MASTER_NODES: "10.0.0.1"
+      externalOvnCentral.nbEndpoint: 10.0.0.10
+      externalOvnCentral.sbEndpoint: 10.0.0.10
+      kube-ovn-controller.replicas: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: caps dataPlaneOnly controller replicas at two
+    set:
+      installMode: dataPlaneOnly
+      MASTER_NODES: "10.0.0.1,10.0.0.2,10.0.0.3"
+      externalOvnCentral.nbEndpoint: 10.0.0.10
+      externalOvnCentral.sbEndpoint: 10.0.0.10
+      kube-ovn-controller.replicas: 1
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: uses Kubernetes node count instead of master node count for dataPlaneOnly replicas
+    kubernetesProvider:
+      scheme:
+        "v1/Node":
+          gvr:
+            version: v1
+            resource: nodes
+          namespaced: false
+      objects:
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node-1
+            labels: {}
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node-2
+            labels: {}
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node-3
+            labels: {}
+    set:
+      installMode: dataPlaneOnly
+      MASTER_NODES: "10.0.0.1"
+      externalOvnCentral.nbEndpoint: 10.0.0.10
+      externalOvnCentral.sbEndpoint: 10.0.0.10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: renders independent external OVN DB addresses for dataPlaneOnly
+    set:
+      installMode: dataPlaneOnly
+      MASTER_NODES: "10.0.0.1"
+      externalOvnCentral.nbEndpoint: 10.0.0.11
+      externalOvnCentral.nbPort: 30641
+      externalOvnCentral.sbEndpoint: 10.0.0.12
+      externalOvnCentral.sbPort: 30642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_NB_ADDR
+            value: tcp:10.0.0.11:30641
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:10.0.0.12:30642
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_DB_IPS
+
+  - it: renders IPv6 external OVN DB addresses for dataPlaneOnly
+    set:
+      installMode: dataPlaneOnly
+      MASTER_NODES: "10.0.0.1"
+      externalOvnCentral.nbEndpoint: "fd00::11"
+      externalOvnCentral.nbPort: 30641
+      externalOvnCentral.sbEndpoint: "[fd00::12]"
+      externalOvnCentral.sbPort: 30642
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_NB_ADDR
+            value: tcp:[fd00::11]:30641
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OVN_SB_ADDR
+            value: tcp:[fd00::12]:30642

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -41,14 +41,11 @@ OVN_CENTRAL_MODE: "cluster"
 installMode: full
 
 # When installMode=dataPlaneOnly, the agents and controller cannot rely on a
-# local ovn-central Service. Set externalOvnCentral.endpoint to the IP address
-# that exposes the management cluster's ovn-nb / ovn-sb Services (typically a
-# LoadBalancer VIP reachable from this cluster). DNS hostnames work with OVN
-# >= 22.03 but use an IP literal if you need to support older OVN versions —
-# the OVN connection string format `tcp:[host]:port` parses brackets only as
-# IP literals in older code paths.
+# local ovn-central Service. Set nbEndpoint/sbEndpoint to the addresses that
+# expose the management cluster's ovn-nb / ovn-sb Services.
 externalOvnCentral:
-  endpoint: ""
+  nbEndpoint: ""
+  sbEndpoint: ""
   nbPort: 6641
   sbPort: 6642
 
@@ -195,6 +192,13 @@ DPDK_CPU: "1000m"  # Default CPU configuration
 DPDK_MEMORY: "2Gi"  # Default Memory configuration
 
 ovn-central:
+  tolerations:
+    - effect: NoSchedule
+      operator: Exists
+    - effect: NoExecute
+      operator: Exists
+  nodeSelector:
+    kubernetes.io/os: "linux"
   hcp:
     enabled: false
     namespace: hcp

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -322,7 +322,13 @@ if [ "$ENABLE_SINGLE_REPLICA_OVN" = "true" ]; then
   OVN_SB_LEADER_SELECTOR=""
   OVN_NORTHD_LEADER_SELECTOR=""
   OVN_CENTRAL_STRATEGY_BODY="    type: Recreate"
-  OVN_CENTRAL_AFFINITY_BLOCK=""
+  OVN_CENTRAL_AFFINITY_BLOCK="      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: ovn-central
+              topologyKey: kubernetes.io/hostname"
   OVN_CENTRAL_CONFIG_VOLUME="        - name: host-config-ovn
           persistentVolumeClaim:
             claimName: ovn-central-data"

--- a/dist/images/start-connection-env_test.sh
+++ b/dist/images/start-connection-env_test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+assert_contains() {
+  local file="$1"
+  local text="$2"
+  grep -Fq -- "$text" "$file" || {
+    echo "expected $file to contain: $text" >&2
+    echo "actual:" >&2
+    cat "$file" >&2
+    exit 1
+  }
+}
+
+test_start_controller_uses_explicit_ovn_addresses() {
+  local tmp out
+  tmp="$(mktemp -d)"
+  out="$tmp/args"
+  trap 'rm -rf "$tmp"' RETURN
+
+  cp "$script_dir/start-controller.sh" "$tmp/"
+  cat > "$tmp/kube-ovn-controller" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$OUT"
+EOF
+  chmod +x "$tmp/kube-ovn-controller"
+
+  (
+    cd "$tmp"
+    OUT="$out" \
+    ENABLE_SSL=false \
+    OVN_NB_ADDR=tcp:nb.example.com:30641 \
+    OVN_SB_ADDR=tcp:sb.example.com:30642 \
+    bash ./start-controller.sh --extra-flag
+  )
+
+  assert_contains "$out" "--ovn-nb-addr=tcp:nb.example.com:30641"
+  assert_contains "$out" "--ovn-sb-addr=tcp:sb.example.com:30642"
+  assert_contains "$out" "--extra-flag"
+}
+
+test_start_ic_controller_uses_explicit_ovn_addresses() {
+  local tmp out
+  tmp="$(mktemp -d)"
+  out="$tmp/args"
+  trap 'rm -rf "$tmp"' RETURN
+
+  cp "$script_dir/start-ic-controller.sh" "$tmp/"
+  mkdir -p "$tmp/bin"
+  cat > "$tmp/bin/ovn-nbctl" <<'EOF'
+#!/usr/bin/env bash
+printf '/var/run/ovn/ovn-nbctl.123.ctl\n'
+EOF
+  cat > "$tmp/kube-ovn-ic-controller" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$OUT"
+EOF
+  chmod +x "$tmp/bin/ovn-nbctl" "$tmp/kube-ovn-ic-controller"
+
+  (
+    cd "$tmp"
+    PATH="$tmp/bin:$PATH" \
+    OUT="$out" \
+    ENABLE_SSL=false \
+    OVN_NB_ADDR=tcp:nb.example.com:30641 \
+    OVN_SB_ADDR=tcp:sb.example.com:30642 \
+    bash ./start-ic-controller.sh --extra-flag
+  )
+
+  assert_contains "$out" "--ovn-nb-addr=tcp:nb.example.com:30641"
+  assert_contains "$out" "--ovn-sb-addr=tcp:sb.example.com:30642"
+  assert_contains "$out" "--extra-flag"
+}
+
+test_upgrade_ovs_uses_explicit_ovn_nb_address() {
+  local tmp out
+  tmp="$(mktemp -d)"
+  out="$tmp/args"
+  trap 'rm -rf "$tmp"' RETURN
+
+  cp "$script_dir/upgrade-ovs.sh" "$tmp/"
+  mkdir -p "$tmp/bin"
+  cat > "$tmp/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"jsonpath={.spec.updateStrategy.type}"* ]]; then
+  printf 'RollingUpdate'
+fi
+EOF
+  cat > "$tmp/bin/ovn-nbctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$OUT"
+if [[ "$*" == *"options:version_compatibility"* ]]; then
+  printf '_25.03\n'
+elif [[ "$*" == *"get NB_Global . options"* ]]; then
+  printf 'version_compatibility='
+fi
+EOF
+  chmod +x "$tmp/bin/kubectl" "$tmp/bin/ovn-nbctl"
+
+  (
+    cd "$tmp"
+    PATH="$tmp/bin:$PATH" \
+    OUT="$out" \
+    ENABLE_SSL=false \
+    OVN_NB_ADDR=tcp:nb.example.com:30641 \
+    OVN_VERSION_COMPATIBILITY=25.03 \
+    bash ./upgrade-ovs.sh
+  )
+
+  assert_contains "$out" "--db=tcp:nb.example.com:30641"
+}
+
+test_start_controller_uses_explicit_ovn_addresses
+test_start_ic_controller_uses_explicit_ovn_addresses
+test_upgrade_ovs_uses_explicit_ovn_nb_address

--- a/dist/images/start-ic-controller.sh
+++ b/dist/images/start-ic-controller.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
+OVN_NB_ADDR=${OVN_NB_ADDR:-}
+OVN_SB_ADDR=${OVN_SB_ADDR:-}
 KUBE_OVN_NB_PORT=${KUBE_OVN_NB_PORT:-6641}
 KUBE_OVN_SB_PORT=${KUBE_OVN_SB_PORT:-6642}
 
@@ -31,8 +33,8 @@ function gen_conn_str {
   echo "$x"
 }
 
-nb_addr="$(gen_conn_str "$KUBE_OVN_NB_PORT")"
-sb_addr="$(gen_conn_str "$KUBE_OVN_SB_PORT")"
+nb_addr="${OVN_NB_ADDR:-$(gen_conn_str "$KUBE_OVN_NB_PORT")}"
+sb_addr="${OVN_SB_ADDR:-$(gen_conn_str "$KUBE_OVN_SB_PORT")}"
 
 for ((i=0; i<3; i++)); do
   if [[ "$ENABLE_SSL" == "false" ]]; then

--- a/dist/images/upgrade-ovs.sh
+++ b/dist/images/upgrade-ovs.sh
@@ -3,6 +3,7 @@
 set -ex
 
 OVN_DB_IPS=${OVN_DB_IPS:-}
+OVN_NB_ADDR=${OVN_NB_ADDR:-}
 ENABLE_SSL=${ENABLE_SSL:-false}
 POD_NAMESPACE=${POD_NAMESPACE:-kube-system}
 OVN_VERSION_COMPATIBILITY=${OVN_VERSION_COMPATIBILITY:-}
@@ -32,7 +33,7 @@ function gen_conn_str {
   echo "$x"
 }
 
-nb_addr="$(gen_conn_str 6641)"
+nb_addr="${OVN_NB_ADDR:-$(gen_conn_str 6641)}"
 while true; do
   if [ x`ovn-nbctl --db=$nb_addr $SSL_OPTIONS get NB_Global . options | grep -o 'version_compatibility='` != "x" ]; then
     value=`ovn-nbctl --db=$nb_addr $SSL_OPTIONS get NB_Global . options:version_compatibility | sed -e 's/^"//' -e 's/"$//'`


### PR DESCRIPTION
## Summary
- add required pod anti-affinity for HCP ovn-central
- keep HCP ovn-central default replicas at 3
- skip master node affinity for HCP ovn-central so replicas can land on different nodes
- keep install.sh ovn-central affinity behavior consistent
- fix dataPlaneOnly kube-ovn-controller replicas to 2 regardless of obsolete value overrides

## Tests
- bash -n dist/images/install.sh
- helm template HCP for charts/kube-ovn and charts/kube-ovn-v2 renders replicas=3
- helm template dataPlaneOnly controller with kube-ovn-controller.replicas=1 renders replicas=2
- helm unittest charts/kube-ovn -f tests/central_hcp_test.yaml -f tests/controller_data_plane_test.yaml
- helm unittest charts/kube-ovn-v2 -f tests/central_hcp_test.yaml