### PR TITLE
ci: replace default base image with Azure Linux 3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ include makefiles/e2e.mk
 COMMA = ,
 HELM_OVN_DB_TLS_ARGS = $(if $(TLS_MIN_VERSION),--set networking.TLS_MIN_VERSION=$(TLS_MIN_VERSION),) $(if $(TLS_MAX_VERSION),--set networking.TLS_MAX_VERSION=$(TLS_MAX_VERSION),) $(if $(TLS_CIPHER_SUITES),--set 'networking.TLS_CIPHER_SUITES={$(TLS_CIPHER_SUITES)}',)
 HELM_OVN_DB_TLS_ARGS_V2 = $(if $(TLS_MIN_VERSION),--set networking.tlsMinVersion=$(TLS_MIN_VERSION),) $(if $(TLS_MAX_VERSION),--set networking.tlsMaxVersion=$(TLS_MAX_VERSION),) $(if $(TLS_CIPHER_SUITES),--set 'networking.tlsCipherSuites={$(TLS_CIPHER_SUITES)}',)
+HELM_WAIT_TIMEOUT ?= 10m
 
 REGISTRY = kubeovn
 DEV_TAG = dev
@@ -191,7 +192,7 @@ check-kube-ovn-pod-restarts:
 install-chart:
 	@timeout 120 bash -c 'until kubectl get node -l node-role.kubernetes.io/control-plane -o name 2>/dev/null | grep -q .; do echo "Waiting for control-plane nodes to be labeled..."; sleep 2; done'
 	kubectl label node --overwrite -l node-role.kubernetes.io/control-plane kube-ovn/role=master
-	helm install kubeovn ./charts/kube-ovn --wait \
+	helm install kubeovn ./charts/kube-ovn --wait --timeout=$(HELM_WAIT_TIMEOUT) \
 		--set global.images.kubeovn.tag=$(VERSION) \
 		--set image.pullPolicy=$(or $(IMAGE_PULL_POLICY),IfNotPresent) \
 		--set OVN_DIR=$(or $(OVN_DIR),/etc/origin/ovn) \
@@ -223,7 +224,7 @@ install-chart:
 
 .PHONY: upgrade-chart
 upgrade-chart:
-	helm upgrade kubeovn ./charts/kube-ovn --wait \
+	helm upgrade kubeovn ./charts/kube-ovn --wait --timeout=$(HELM_WAIT_TIMEOUT) \
 		--set global.images.kubeovn.tag=$(VERSION) \
 		--set image.pullPolicy=$(or $(IMAGE_PULL_POLICY),IfNotPresent) \
 		--set OVN_DIR=$(or $(OVN_DIR),/etc/origin/ovn) \
@@ -258,7 +259,7 @@ upgrade-chart:
 install-chart-v2:
 	@timeout 120 bash -c 'until kubectl get node -l node-role.kubernetes.io/control-plane -o name 2>/dev/null | grep -q .; do echo "Waiting for control-plane nodes to be labeled..."; sleep 2; done'
 	kubectl label node --overwrite -l node-role.kubernetes.io/control-plane kube-ovn/role=master
-	helm install kubeovn ./charts/kube-ovn-v2 --wait \
+	helm install kubeovn ./charts/kube-ovn-v2 --wait --timeout=$(HELM_WAIT_TIMEOUT) \
 		--set global.images.kubeovn.tag=$(VERSION) \
 		$(HELM_OVN_DB_TLS_ARGS_V2) \
 		--set cni.nonPrimaryCNI=$(or $(ENABLE_NON_PRIMARY_CNI),false) \
@@ -266,7 +267,7 @@ install-chart-v2:
 
 .PHONY: upgrade-chart-v2
 upgrade-chart-v2:
-	helm upgrade kubeovn ./charts/kube-ovn-v2 --wait \
+	helm upgrade kubeovn ./charts/kube-ovn-v2 --wait --timeout=$(HELM_WAIT_TIMEOUT) \
 		--set global.images.kubeovn.tag=$(VERSION) \
 		$(HELM_OVN_DB_TLS_ARGS_V2) \
 		--set cni.nonPrimaryCNI=$(or $(ENABLE_NON_PRIMARY_CNI),false) \

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -74,7 +74,10 @@ spec:
               chown -R nobody: /var/run/ovn /var/log/ovn /etc/openvswitch /var/run/openvswitch /var/log/openvswitch
               iptables -V
               {{- if not .Values.ovsOvn.disableModulesManagement }}
-              /usr/share/openvswitch/scripts/ovs-ctl load-kmod
+              /usr/share/openvswitch/scripts/ovs-ctl load-kmod || true
+              ln -sf /bin/true /usr/local/sbin/modprobe
+              ln -sf /bin/true /usr/local/sbin/modinfo
+              ln -sf /bin/true /usr/local/sbin/rmmod
               {{- else }}
               ln -sf /bin/true /usr/local/sbin/modprobe
               ln -sf /bin/true /usr/local/sbin/modinfo

--- a/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -56,7 +56,10 @@ spec:
               chown -R nobody: /var/run/ovn /var/log/ovn /etc/openvswitch /var/run/openvswitch /var/log/openvswitch
               iptables -V
               {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
-              /usr/share/openvswitch/scripts/ovs-ctl load-kmod
+              /usr/share/openvswitch/scripts/ovs-ctl load-kmod || true
+              ln -sf /bin/true /usr/local/sbin/modprobe
+              ln -sf /bin/true /usr/local/sbin/modinfo
+              ln -sf /bin/true /usr/local/sbin/rmmod
               {{- else }}
               ln -sf /bin/true /usr/local/sbin/modprobe
               ln -sf /bin/true /usr/local/sbin/modinfo

--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -2,40 +2,11 @@
 # renovate: datasource=golang-version depName=go
 ARG GO_VERSION=1.26.5
 
-FROM ubuntu:24.04 AS openssl-builder
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    sed -i 's/^Types: deb$/Types: deb deb-src/g' /etc/apt/sources.list.d/ubuntu.sources && \
-    apt update && \
-    apt install -y apt-src && \
-    apt-src update && \
-    apt-src install openssl
-
-RUN cd openssl-* && \
-    sed -i '/^CONFARGS/a CONFARGS += enable-fips no-unit-test' debian/rules && \
-    echo >> debian/control && \
-    echo 'Package: libssl3t64-fips' >> debian/control && \
-    echo 'Section: libs' >> debian/control && \
-    echo 'Architecture: any' >> debian/control && \
-    echo 'Multi-Arch: same' >> debian/control && \
-    echo 'Depends: libssl3t64 (= ${binary:Version}), ${misc:Depends}' >> debian/control && \
-    echo 'Description: OpenSSL fips module' >> debian/control && \
-    echo 'usr/lib/ssl/fipsmodule.cnf' >> debian/libssl3t64-fips.install && \
-    echo 'usr/lib/*/ossl-modules/fips.so' >> debian/libssl3t64-fips.install && \
-    DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary
-
-RUN mkdir /packages/ && \
-    cp *fips*.deb /packages
-
-FROM ubuntu:24.04 AS ovs-builder
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS ovs-builder
 
 ARG ARCH
 ARG LEGACY
-ARG DEBIAN_FRONTEND=noninteractive
-ARG SRC_DIR='/usr/src'
+ARG SRC_DIR='/usr/src/'
 
 ADD patches/4228eab1d722087ba795e310eadc9e25c4513ec1.patch $SRC_DIR
 ADD patches/54056ea65dc28aa1c4c721a2a34d7913f79f8376.patch $SRC_DIR
@@ -46,6 +17,7 @@ ADD patches/a6cb8215a80635129e4fada4c0d25c25fb746bf7.patch $SRC_DIR
 ADD patches/d4d76ddb2e12cdd9e73bb5e008ebb9fd1b4d6ca6.patch $SRC_DIR
 ADD patches/53b9837f7fe89cd63af735b039b8c26107d6579d.patch $SRC_DIR
 ADD patches/ffd2328d4a55271569e2b89e54a2c18f4e186af8.patch $SRC_DIR
+ADD patches/fix-netdev-get-ifindex-type.patch $SRC_DIR
 ADD patches/d088c5d8c263552c5a31d87813991aee30ab74de.patch $SRC_DIR
 ADD patches/1b31f07dc60c016153fa35d936cdda0e02e58492.patch $SRC_DIR
 ADD patches/54b767822916606dbb78335a3197983f435b5b8a.patch $SRC_DIR
@@ -69,9 +41,12 @@ ADD patches/52b727b3315463668669ff423ce8bfa129861162.patch $SRC_DIR
 ADD patches/sbrec-delete-null-check.patch $SRC_DIR
 ADD patches/pinctrl-adapt-ovs-compose-nd-ns.patch $SRC_DIR
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt update && apt install -y git curl
+RUN tdnf -y install \
+        autoconf automake binutils bzip2 ca-certificates checkpolicy curl diffutils file findutils gcc gcc-c++ git glibc-devel \
+        graphviz hostname iproute libcap-ng libcap-ng-devel libtool make openssl openssl-devel \
+        kernel-headers pkgconf-pkg-config procps-ng python3-devel python3-setuptools python3-sphinx \
+        rpm-build selinux-policy-devel systemd-rpm-macros unbound unbound-devel wget which && \
+    tdnf clean all
 
 RUN cd /usr/src/ && \
     git clone -b branch-3.5 --depth=1 https://github.com/openvswitch/ovs.git && \
@@ -94,6 +69,8 @@ RUN cd /usr/src/ && \
     git apply $SRC_DIR/53b9837f7fe89cd63af735b039b8c26107d6579d.patch && \
     # netdev: reduce cpu utilization for getting device addresses
     git apply $SRC_DIR/ffd2328d4a55271569e2b89e54a2c18f4e186af8.patch && \
+    # netdev: fix get_ifindex type for rpm build
+    git apply $SRC_DIR/fix-netdev-get-ifindex-type.patch && \
     # ovs-router: skip getting source address for kube-ipvs0
     git apply $SRC_DIR/d088c5d8c263552c5a31d87813991aee30ab74de.patch && \
     # increase the default probe interval for large cluster
@@ -101,9 +78,13 @@ RUN cd /usr/src/ && \
     # update ovs-sandbox for docker run
     git apply $SRC_DIR/54b767822916606dbb78335a3197983f435b5b8a.patch && \
     ovs_commit=$(git rev-parse --short=12 HEAD) && \
-    sed -i -E "s/^(AC_INIT\(\[?openvswitch\]?, \[?[^],)]+)(\]?)(,.*)$/\1+g${ovs_commit}\2\3/" configure.ac
+    sed -i -E "s/^(AC_INIT\(\[?openvswitch\]?, \[?[^],)]+)(\]?)(,.*)$/\1.g${ovs_commit}\2\3/" configure.ac && \
+    sed -i \
+        -e 's/module-init-tools/kmod/g' \
+        rhel/openvswitch-fedora.spec.in
 
-RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-org/ovn.git && \
+RUN cd /usr/src/ && \
+    git clone -b branch-25.03 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
     # change default hash type from dp_hash to hash with field src_ip
     git apply $SRC_DIR/e490f5ac0b644101913c2a3db8e03d85e859deff.patch && \
@@ -123,14 +104,14 @@ RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-o
     git apply $SRC_DIR/a297b840c2c9f118c7ce6133077087b5999f12dd.patch && \
     # ovn-controller: make activation strategy work for single chassis
     git apply $SRC_DIR/03e35ed9c5b4de0fa8acbc2c057cdd5957a8d605.patch && \
-	# skip node local dns ip conntrack when set acl
+    # skip node local dns ip conntrack when set acl
     git apply $SRC_DIR/e7d3ba53cdcbc524bb29c54ddb07b83cc4258ed7.patch && \
-	# loadbalancer select local backend first
+    # loadbalancer select local backend first
     git apply $SRC_DIR/9286e1fd578fdb8f565a0f4aa9066b538295e1ac.patch && \
     # fix lr-lb dnat with multiple distributed gateway ports
     git apply $SRC_DIR/e5916eb53abc3b7d28c407c3c47566c46116090a.patch && \
     # support dedicated BFD LRP
-    git apply $SRC_DIR/e4e6ea9c5f4ba080b719924e470daa8094ff38a7.patch && \	
+    git apply $SRC_DIR/e4e6ea9c5f4ba080b719924e470daa8094ff38a7.patch && \
     # northd: add nb option version_compatibility
     git apply $SRC_DIR/e76880e792af56b2a3836098105079f5f8f1ff26.patch && \
     # northd: skip arp/nd request for lrp addresses from localnet ports
@@ -144,34 +125,37 @@ RUN cd /usr/src/ && git clone -b branch-25.03 --depth=1 https://github.com/ovn-o
     # adapt to the compose_nd_ns() signature change in ovs branch-3.5 commit 33825c273
     git apply $SRC_DIR/pinctrl-adapt-ovs-compose-nd-ns.patch && \
     ovn_commit=$(git rev-parse --short=12 HEAD) && \
-    sed -i -E "s/^(AC_INIT\(\[?ovn\]?, \[?[^],)]+)(\]?)(,.*)$/\1+g${ovn_commit}\2\3/" configure.ac
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt update && \
-    apt install -y wget build-essential fakeroot && \
-    apt install -y autoconf automake bzip2 debhelper-compat dh-exec dh-python dh-sequence-python3 dh-sequence-sphinxdoc \
-    graphviz iproute2 libcap-ng-dev libdbus-1-dev libnuma-dev libpcap-dev libssl-dev libtool libunbound-dev \
-    pkg-config procps python3-all-dev python3-setuptools python3-sortedcontainers python3-sphinx
+    sed -i -E "s/^(AC_INIT\(\[?ovn\]?, \[?[^],)]+)(\]?)(,.*)$/\1.g${ovn_commit}\2\3/" configure.ac && \
+    sed -i 's/module-init-tools/kmod/g' rhel/ovn-fedora.spec.in
 
 RUN cd /usr/src/ovs && \
     ./boot.sh && \
-    ./configure && \
-    rm -rf .git && \
-    CONFIGURE_OPTS='CFLAGS="-fPIC"' && \
-    if [ "$ARCH" = "amd64" ] && [ "$LEGACY" != "true" ]; then CONFIGURE_OPTS='CFLAGS="-O2 -g -msse4.2 -mpopcnt -fPIC"'; fi && \
-    DATAPATH_CONFIGURE_OPTS='--prefix=/usr' EXTRA_CONFIGURE_OPTS=$CONFIGURE_OPTS make debian-deb
+    if [ "$ARCH" = "amd64" ] && [ "$LEGACY" != "true" ]; then export CFLAGS="-O2 -g -msse4.2 -mpopcnt -fPIC"; else export CFLAGS="-fPIC"; fi && \
+    ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc && \
+    make rpm-fedora RPMBUILD_OPT="--nodeps --without check --without dpdk --without afxdp --without usdt --define 'debug_package %{nil}'"
 
 RUN cd /usr/src/ovn && \
-    sed -i 's/OVN/ovn/g' debian/changelog && \
-    rm -rf .git && \
     ./boot.sh && \
-    CONFIGURE_OPTS='--with-ovs-build=/usr/src/ovs/_debian CFLAGS="-fPIC"' && \
-    if [ "$ARCH" = "amd64" ] && [ "$LEGACY" != "true" ]; then CONFIGURE_OPTS="--with-ovs-build=/usr/src/ovs/_debian CFLAGS='-O2 -g -msse4.2 -mpopcnt -fPIC'"; fi && \
-    OVSDIR=/usr/src/ovs EXTRA_CONFIGURE_OPTS=$CONFIGURE_OPTS DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary
+    if [ "$ARCH" = "amd64" ] && [ "$LEGACY" != "true" ]; then export CFLAGS="-O2 -g -msse4.2 -mpopcnt -fPIC"; else export CFLAGS="-fPIC"; fi && \
+    ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-ovs-source=/usr/src/ovs --with-ovs-build=/usr/src/ovs && \
+    make rpm-fedora RPMBUILD_OPT="--nodeps --without check --define 'debug_package %{nil}'"
+
+RUN mkdir -p /packages && \
+    find /usr/src/ovs/rpm/rpmbuild/RPMS -type f \( \
+        -name 'openvswitch-[0-9]*.rpm' -o \
+        -name 'python3-openvswitch-*.rpm' \
+    \) -exec cp -v {} /packages/ \; && \
+    find /usr/src/ovn/rpm/rpmbuild/RPMS -type f \( \
+        -name 'ovn-[0-9]*.rpm' -o \
+        -name 'ovn-central-[0-9]*.rpm' -o \
+        -name 'ovn-host-[0-9]*.rpm' \
+    \) -exec cp -v {} /packages/ \; && \
+    install -m 0755 /usr/src/ovs/tutorial/ovs-sandbox /packages/ovs-sandbox && \
+    install -m 0755 /usr/src/ovs/ipsec/ovs-monitor-ipsec.in /packages/ovs-monitor-ipsec && \
+    sed -i 's|@PYTHON3@|/usr/bin/python3|g' /packages/ovs-monitor-ipsec
 
 RUN mkdir -p /usr/src/openbfdd && \
-    curl -sSf -L --retry 5 https://github.com/dyninc/OpenBFDD/archive/e35f43ad8d2b3f084e96a84c392528a90d05a287.tar.gz | \
+    curl -sSf -L --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 --max-time 300 https://github.com/dyninc/OpenBFDD/archive/e35f43ad8d2b3f084e96a84c392528a90d05a287.tar.gz | \
     tar -xz -C /usr/src/openbfdd --strip-components=1
 
 ADD OpenBFDD-compile.patch /usr/src/
@@ -184,15 +168,22 @@ RUN cd /usr/src/openbfdd && \
     autoupdate && \
     ./autogen.sh && \
     ./configure --enable-silent-rules && \
-    make -j8
+    make -j8 && \
+    install -m 0755 bfdd-beacon bfdd-control /packages/
 
-RUN mkdir /packages/ && \
-    mv /usr/src/openbfdd/bfdd-beacon /usr/src/openbfdd/bfdd-control /packages/ && \
-    cp /usr/src/openvswitch-*deb /packages && \
-    cp /usr/src/python3-openvswitch*deb /packages && \
-    cp /usr/src/ovn-*deb /packages && \
-    cp /usr/src/ovs/tutorial/ovs-sandbox /packages && \
-    cd /packages && rm -f *source* *doc* *datapath* *docker* *vtep* *test* *dev*
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS ndisc6-builder
+
+ARG NDISC6_VERSION=1.0.8
+RUN tdnf -y install binutils bzip2 ca-certificates curl gawk gcc glibc-devel kernel-headers make tar && \
+    cd /tmp && \
+    curl -sSf -L --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 --max-time 300 \
+        https://www.remlab.net/files/ndisc6/ndisc6-${NDISC6_VERSION}.tar.bz2 | \
+    tar -xj && \
+    cd ndisc6-${NDISC6_VERSION} && \
+    CPP='gcc -E' ./configure --disable-nls && \
+    make -j8 && \
+    mkdir -p /packages && \
+    install -m 0755 ndisc6 /packages/ndisc6
 
 FROM ghcr.io/aquasecurity/trivy:latest AS trivy
 
@@ -213,99 +204,87 @@ FROM golang:$GO_VERSION-alpine AS go-deps
 
 RUN apk --no-cache add bash curl jq git
 ADD go-deps/rebuild-go-deps.sh /
-RUN --mount=type=bind,target=/trivy,from=trivy,source=/godeps \
-    bash -x /rebuild-go-deps.sh
+COPY --from=trivy /godeps /trivy
+RUN TRIVY_DIR=/trivy bash -x /rebuild-go-deps.sh
 
-FROM ubuntu:24.04 AS ubuntu
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS runtime
 
-RUN rm -rf /etc/localtime
-RUN rm -f /usr/lib/apt/methods/mirror
-RUN usermod -s /usr/sbin/nologin sync
-RUN usermod -s /usr/sbin/nologin ubuntu
-RUN apt remove -y --allow-remove-essential --auto-remove login
-
-FROM scratch
-
-LABEL "org.opencontainers.image.ref.name"="ubuntu"
-LABEL "org.opencontainers.image.version"="24.04"
+LABEL "org.opencontainers.image.ref.name"="azurelinux3"
+LABEL "org.opencontainers.image.version"="3.0"
 
 ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 CMD ["/bin/bash"]
 
-COPY --from=ubuntu / /
-
 ARG ARCH
-ARG DEBIAN_FRONTEND=noninteractive
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt update && apt upgrade -y && \
-    apt install ca-certificates netbase ethtool iproute2 ncat libunbound8 \
-        kmod iptables python3-netifaces python3-sortedcontainers tcpdump ipvsadm ipset curl \
-        uuid-runtime openssl inetutils-ping arping ndisc6 conntrack traceroute iputils-tracepath \
-        logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
-        libcharon-extauth-plugins libstrongswan-extra-plugins libstrongswan-standard-plugins \
-        -y --no-install-recommends --auto-remove && \
-    apt remove -y --allow-remove-essential --auto-remove login && \
-    setcap CAP_NET_ADMIN+eip $(readlink -f $(which conntrack)) && \
-    setcap CAP_NET_ADMIN+eip $(readlink -f $(which ethtool)) && \
-    setcap CAP_NET_ADMIN+eip $(readlink -f $(which ip)) && \
-    setcap CAP_NET_ADMIN+eip $(readlink -f $(which ipset)) && \
-    setcap CAP_NET_ADMIN+eip $(readlink -f $(which traceroute)) && \
-    setcap CAP_NET_ADMIN,CAP_NET_RAW+eip $(readlink -f $(which xtables-legacy-multi)) && \
-    setcap CAP_NET_ADMIN,CAP_NET_RAW+eip $(readlink -f $(which xtables-nft-multi)) && \
-    setcap CAP_NET_RAW+eip $(readlink -f $(which arping)) && \
-    setcap CAP_NET_RAW+eip $(readlink -f $(which ndisc6)) && \
-    setcap CAP_NET_RAW+eip $(readlink -f $(which tcpdump)) && \
-    setcap CAP_SYS_ADMIN+eip $(readlink -f $(which nsenter)) && \
-    setcap CAP_SYS_ADMIN+eip $(readlink -f $(which sysctl)) && \
-    setcap CAP_SYS_MODULE+eip $(readlink -f $(which modprobe)) && \
-    setcap CAP_SYS_NICE+eip $(readlink -f $(which nice)) && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /etc/localtime && \
-    rm -f /usr/bin/nc && \
-    rm -f /usr/bin/netcat && \
-    rm -f /usr/lib/apt/methods/mirror
-
-RUN mkdir -p /var/run/openvswitch && \
-    mkdir -p /var/run/ovn && \
-    mkdir -p /etc/cni/net.d && \
-    mkdir -p /opt/cni/bin
-
-ARG DUMB_INIT_VERSION="1.2.5"
-RUN curl -sSf -L --retry 5 -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_$(arch) && \
-    chmod +x /usr/bin/dumb-init
-
-RUN --mount=type=bind,target=/godeps,from=go-deps,source=/godeps \
-    cp /godeps/loopback /godeps/portmap /godeps/macvlan /godeps/ipvlan ./ && \
-    cp /godeps/kubectl /godeps/gobgp /usr/bin/
-
+COPY --from=ovs-builder /packages /packages
+COPY --from=ndisc6-builder /packages /packages
 ARG DEBUG=false
 
-RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages \
-    cp /packages/bfdd-beacon /packages/bfdd-control /usr/bin/ && \
-    cp /packages/ovs-sandbox /usr/bin/ && chmod +x /usr/bin/ovs-sandbox && \
-    setcap CAP_NET_BIND_SERVICE+eip /usr/bin/bfdd-beacon && \
-    dpkg -i /packages/openvswitch-*.deb /packages/python3-openvswitch*.deb /packages/ovn-*.deb && \
-    rm -rf /var/lib/openvswitch/pki/ && \
-    chown -R nobody: /var/lib/logrotate && \
-    setcap CAP_NET_ADMIN+eip $(readlink -f $(which ovs-dpctl)) && \
-    if [ "${DEBUG}" != "true" ]; then \
-        setcap CAP_NET_BIND_SERVICE+eip $(readlink -f $(which ovsdb-server)) && \
-        setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip $(readlink -f $(which ovs-vswitchd)) && \
-        dpkg --purge gpgv apt; \
-    else \
-        apt update && apt install -y --no-install-recommends gdb valgrind && \
-        rm -rf /var/lib/apt/lists/* && \
-        dpkg -i /packages/*.ddeb; \
-    fi
+RUN tdnf -y upgrade && \
+    tdnf -y install \
+        bind-utils ca-certificates conntrack-tools coreutils curl ethtool findutils gawk grep initscripts \
+        iproute ipset iptables iputils ipvsadm kmod libcap logrotate net-tools nmap-ncat openssl procps-ng sed \
+        python3-netifaces python3-sortedcontainers strongswan tcpdump traceroute \
+        unbound util-linux && \
+    tdnf -y install \
+        /packages/openvswitch-[0-9]*.rpm /packages/python3-openvswitch-*.rpm \
+        /packages/ovn-[0-9]*.rpm /packages/ovn-central-[0-9]*.rpm /packages/ovn-host-[0-9]*.rpm && \
+    if [ "$DEBUG" = "true" ]; then \
+        tdnf -y --enablerepo=azurelinux-official-base-debuginfo install gdb valgrind; \
+    fi && \
+    install -m 0755 /packages/ovs-sandbox /packages/bfdd-beacon /packages/bfdd-control /packages/ndisc6 /usr/bin/ && \
+    install -m 0755 /packages/ovs-monitor-ipsec /usr/share/openvswitch/scripts/ovs-monitor-ipsec && \
+    ln -s /usr/sbin/strongswan /usr/sbin/ipsec && \
+    ln -s /etc/strongswan/ipsec.conf /etc/ipsec.conf && \
+    ln -s /etc/strongswan/ipsec.secrets /etc/ipsec.secrets && \
+    ln -s /etc/strongswan/ipsec.d /etc/ipsec.d && \
+    mkdir -p /etc/strongswan.d && \
+    touch /etc/strongswan.d/ovs.conf && \
+    mkdir -p /etc/init.d && \
+    printf '%s\n' '#!/bin/sh' 'exec /usr/sbin/strongswan "$@"' > /etc/init.d/ipsec && \
+    printf '%s\n' '#!/bin/sh' 'case "$1" in' \
+        '  start) exec /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=strongswan start-ovs-ipsec ;;' \
+        '  stop) exec /usr/share/openvswitch/scripts/ovs-ctl stop-ovs-ipsec ;;' \
+        '  restart|force-reload) /usr/share/openvswitch/scripts/ovs-ctl stop-ovs-ipsec || true; exec /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=strongswan start-ovs-ipsec ;;' \
+        '  status) pgrep -f ovs-monitor-ipsec >/dev/null ;;' \
+        '  *) echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2; exit 2 ;;' \
+        'esac' > /etc/init.d/openvswitch-ipsec && \
+    chmod +x /etc/init.d/ipsec /etc/init.d/openvswitch-ipsec && \
+    tdnf clean all && \
+    rm -rf /packages /var/cache/tdnf /var/tmp/* /tmp/* /etc/localtime && \
+    rm -f /usr/bin/nc /usr/bin/netcat
 
-RUN --mount=type=bind,target=/packages,from=openssl-builder,source=/packages \
-    dpkg -i /packages/*.deb && \
-    openssl fipsinstall -out /usr/lib/ssl/fipsmodule.cnf -module $(find / -name fips.so) && \
-    sed -i --follow-symlinks \
-        -e '/^\[provider_sect\]/a fips = fips_sect' \
-        -e '/^\[default_sect\]/a activate = 1' \
-        -e '$a \\n.include /usr/lib/ssl/fipsmodule.cnf' \
-        /usr/lib/ssl/openssl.cnf
+RUN mkdir -p /var/run/openvswitch /var/run/ovn /etc/cni/net.d /opt/cni/bin
+
+ARG DUMB_INIT_VERSION="1.2.5"
+RUN curl -sSf -L --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 --max-time 300 -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_$(arch) && \
+    chmod +x /usr/bin/dumb-init
+
+COPY --from=go-deps /godeps/loopback /godeps/portmap /godeps/macvlan /godeps/ipvlan /
+COPY --from=go-deps /godeps/kubectl /godeps/gobgp /usr/bin/
+
+RUN ldconfig && \
+    chown -R nobody: /var/lib/logrotate && \
+    setcap CAP_NET_ADMIN+eip $(readlink -f $(command -v conntrack)) && \
+    setcap CAP_NET_BIND_SERVICE+eip /usr/bin/bfdd-beacon && \
+    setcap CAP_NET_ADMIN+eip $(readlink -f $(command -v ethtool)) && \
+    setcap CAP_NET_ADMIN+eip $(readlink -f $(command -v ip)) && \
+    setcap CAP_NET_ADMIN+eip $(readlink -f $(command -v ipset)) && \
+    setcap CAP_NET_ADMIN+eip $(readlink -f $(command -v traceroute)) && \
+    setcap CAP_NET_ADMIN,CAP_NET_RAW+eip $(readlink -f $(command -v xtables-legacy-multi)) && \
+    setcap CAP_NET_ADMIN,CAP_NET_RAW+eip $(readlink -f $(command -v xtables-nft-multi)) && \
+    setcap CAP_NET_RAW+eip $(readlink -f $(command -v arping)) && \
+    setcap CAP_NET_RAW+eip $(readlink -f $(command -v ndisc6)) && \
+    setcap CAP_NET_RAW+eip $(readlink -f $(command -v tcpdump)) && \
+    setcap CAP_SYS_ADMIN+eip $(readlink -f $(command -v nsenter)) && \
+    setcap CAP_SYS_ADMIN+eip $(readlink -f $(command -v sysctl)) && \
+    setcap CAP_SYS_MODULE+eip $(readlink -f $(command -v modprobe)) && \
+    setcap CAP_SYS_NICE+eip $(readlink -f $(command -v nice)) && \
+    setcap CAP_NET_ADMIN+eip $(readlink -f $(command -v ovs-dpctl)) && \
+    if [ "$DEBUG" != "true" ]; then \
+        setcap CAP_NET_BIND_SERVICE+eip $(readlink -f $(command -v ovsdb-server)) && \
+        setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip $(readlink -f $(command -v ovs-vswitchd)); \
+    fi && \
+    rm -rf /var/lib/openvswitch/pki/
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/dist/images/go-deps/download-go-deps.sh
+++ b/dist/images/go-deps/download-go-deps.sh
@@ -12,14 +12,24 @@ DEPS_DIR=/godeps
 
 mkdir -p "$DEPS_DIR"
 
-curl -sSf -L --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGINS_VERSION}.tgz | \
-    tar -xz -C "$DEPS_DIR" ./loopback ./portmap ./macvlan ./ipvlan
+download_archive() {
+    url=$1
+    file=$(mktemp)
+    curl -sSf -L --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 --max-time 300 -o "$file" "$url"
+    echo "$file"
+}
 
-curl -sSf -L --retry 5 https://dl.k8s.io/${KUBECTL_VERSION}/kubernetes-client-linux-${ARCH}.tar.gz | \
-    tar -xz -C "$DEPS_DIR" --strip-components=3 kubernetes/client/bin/kubectl
+cni_archive=$(download_archive "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGINS_VERSION}.tgz")
+tar -xz -f "$cni_archive" -C "$DEPS_DIR" ./loopback ./portmap ./macvlan ./ipvlan
+rm -f "$cni_archive"
 
-curl -sSf -L --retry 5 https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/gobgp_${GOBGP_VERSION}_linux_${ARCH}.tar.gz | \
-    tar -xz -C "$DEPS_DIR" gobgp
+kubectl_archive=$(download_archive "https://dl.k8s.io/${KUBECTL_VERSION}/kubernetes-client-linux-${ARCH}.tar.gz")
+tar -xz -f "$kubectl_archive" -C "$DEPS_DIR" --strip-components=3 kubernetes/client/bin/kubectl
+rm -f "$kubectl_archive"
+
+gobgp_archive=$(download_archive "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/gobgp_${GOBGP_VERSION}_linux_${ARCH}.tar.gz")
+tar -xz -f "$gobgp_archive" -C "$DEPS_DIR" gobgp
+rm -f "$gobgp_archive"
 
 ls -lh "$DEPS_DIR"
 

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -7863,7 +7863,10 @@ spec:
               chmod +t /usr/local/sbin
               chown -R nobody: /var/run/ovn /var/log/ovn /etc/openvswitch /var/run/openvswitch /var/log/openvswitch
               iptables -V
-              /usr/share/openvswitch/scripts/ovs-ctl load-kmod
+              /usr/share/openvswitch/scripts/ovs-ctl load-kmod || true
+              ln -sf /bin/true /usr/local/sbin/modprobe
+              ln -sf /bin/true /usr/local/sbin/modinfo
+              ln -sf /bin/true /usr/local/sbin/rmmod
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:

--- a/dist/images/iptables-wrapper-installer.sh
+++ b/dist/images/iptables-wrapper-installer.sh
@@ -139,15 +139,24 @@ case "${altstyle}" in
     fedora)
 cat >> "${sbin}/iptables-wrapper" <<EOF
 # Update links to point to the selected binaries
-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null 2>&1 || true
+alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null 2>&1 || true
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "/usr/local/sbin/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "/usr/local/sbin/\${cmd}"
+done 2>/dev/null || failed=1
 EOF
     ;;
 
     debian)
 cat >> "${sbin}/iptables-wrapper" <<EOF
 # Update links to point to the selected binaries
-update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
-update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null 2>&1 || true
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null 2>&1 || true
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "/usr/local/sbin/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "/usr/local/sbin/\${cmd}"
+done 2>/dev/null || failed=1
 EOF
     ;;
 
@@ -182,10 +191,11 @@ case "${altstyle}" in
 	alternatives \
             --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
             --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
-            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
-            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
-            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
-            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
 	;;
 
     debian)

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -370,8 +370,8 @@ trace(){
           cmd="ndisc6 -q $gateway $nicName"
           output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- sh -c "$nsenterCmd ndisc6 -q $gateway $nicName")
         else
-          cmd="arping -c3 -C1 -i1 -I $nicName $gateway"
-          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- sh -c "$nsenterCmd arping -c3 -C1 -i1 -I $nicName $gateway")
+          cmd="arping -c3 -f -i1 -I $nicName $gateway"
+          output=$(kubectl exec "$ovnCni" -c cni-server -n $KUBE_OVN_NS -- sh -c "$nsenterCmd arping -c3 -f -i1 -I $nicName $gateway")
         fi
 
         if [ $? -ne 0 ]; then

--- a/dist/images/patches/fix-netdev-get-ifindex-type.patch
+++ b/dist/images/patches/fix-netdev-get-ifindex-type.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/netdev-linux.c b/lib/netdev-linux.c
+index 01701c8d450..391f7cc2c6f 100644
+--- a/lib/netdev-linux.c
++++ b/lib/netdev-linux.c
+@@ -3552,7 +3552,7 @@ netdev_linux_get_addr_list(const struct netdev *netdev_,
+     int ifindex;
+     int error;
+
+-    error = get_ifindex(netdev, &ifindex);
++    error = get_ifindex(netdev_, &ifindex);
+     if (error) {
+         return error;
+     }

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -1,7 +1,36 @@
 #!/bin/bash
-set -euo pipefail
+set -Eeuo pipefail
 
+function report_error {
+  local exit_code=$?
+  echo "start-ovs.sh failed at line $1: $2 (exit ${exit_code})" | tee -a /dev/termination-log
+  dump_ovs_diagnostics
+  return "${exit_code}"
+}
+trap 'report_error "$LINENO" "$BASH_COMMAND"' ERR
 
+function dump_ovs_diagnostics {
+  {
+    echo "----- ovs diagnostics -----"
+    id || true
+    getcap -v /usr/sbin/ovs-vswitchd /usr/sbin/ovsdb-server /usr/bin/nice /usr/bin/kmod 2>&1 || true
+    ls -ld /sys/module/openvswitch "/lib/modules/$(uname -r)" /etc/openvswitch /var/run/openvswitch /var/log/openvswitch 2>&1 || true
+    tail -n 80 /var/log/openvswitch/*.log 2>&1 || true
+  } >> /dev/termination-log
+}
+
+function run_or_log {
+  local output
+  local rc
+  set +e
+  output="$("$@" 2>&1)"
+  rc=$?
+  set -e
+  if [ "${rc}" -ne 0 ]; then
+    printf '%s\n' "${output}" | tee -a /dev/termination-log >&2
+  fi
+  return "${rc}"
+}
 
 HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
@@ -45,6 +74,8 @@ function cgroup_match {
 }
 
 function quit {
+  exit_code=$?
+  set +e
   set -x
   gen_name=$(kubectl -n "${POD_NAMESPACE}" get pod "${POD_NAME}" -o jsonpath='{.metadata.generateName}')
   revision_hash=$(kubectl -n "${POD_NAMESPACE}" get pod "${POD_NAME}" -o jsonpath='{.metadata.labels.controller-revision-hash}')
@@ -67,7 +98,7 @@ function quit {
     fi
   fi
 
-  exit 0
+  exit "${exit_code}"
 }
 trap quit EXIT
 
@@ -75,7 +106,7 @@ trap quit EXIT
 iptables -V
 
 # Start ovsdb
-/usr/share/openvswitch/scripts/ovs-ctl restart --no-ovs-vswitchd --system-id=random --ovsdb-server-wrapper="${DEBUG_WRAPPER}"
+run_or_log /usr/share/openvswitch/scripts/ovs-ctl restart --no-ovs-vswitchd --system-id=random --ovsdb-server-wrapper="${DEBUG_WRAPPER}"
 # Restrict the number of pthreads ovs-vswitchd creates to reduce the
 # amount of RSS it uses on hosts with many cores
 # https://bugzilla.redhat.com/show_bug.cgi?id=1571379
@@ -119,7 +150,7 @@ function handle_underlay_bridges() {
 handle_underlay_bridges
 
 # Start vswitchd. restart will automatically set/unset flow-restore-wait which is not what we want
-/usr/share/openvswitch/scripts/ovs-ctl restart --no-ovsdb-server --system-id=random --no-mlockall --ovs-vswitchd-wrapper="$DEBUG_WRAPPER"
+run_or_log /usr/share/openvswitch/scripts/ovs-ctl restart --no-ovsdb-server --system-id=random --no-mlockall --ovs-vswitchd-wrapper="$DEBUG_WRAPPER"
 /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
 
 function gen_conn_str {

--- a/hack/verify-azurelinux3-base.sh
+++ b/hack/verify-azurelinux3-base.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_file() {
+  local file="$1"
+  [[ -f "$ROOT_DIR/$file" ]] || fail "missing $file"
+}
+
+reject_file() {
+  local file="$1"
+  [[ ! -e "$ROOT_DIR/$file" ]] || fail "unexpected $file"
+}
+
+require_pattern() {
+  local file="$1"
+  local pattern="$2"
+  grep -Eq -- "$pattern" "$ROOT_DIR/$file" || fail "$file missing pattern: $pattern"
+}
+
+reject_pattern() {
+  local file="$1"
+  local pattern="$2"
+  if grep -En -- "$pattern" "$ROOT_DIR/$file"; then
+    fail "$file contains forbidden pattern: $pattern"
+  fi
+}
+
+require_file dist/images/Dockerfile.base
+reject_file dist/images/Dockerfile.base-azurelinux3
+
+require_pattern dist/images/Dockerfile.base 'FROM mcr\.microsoft\.com/azurelinux/base/core:3\.0 AS ovs-builder'
+require_pattern dist/images/Dockerfile.base 'FROM mcr\.microsoft\.com/azurelinux/base/core:3\.0 AS ndisc6-builder'
+require_pattern dist/images/Dockerfile.base 'FROM mcr\.microsoft\.com/azurelinux/base/core:3\.0 AS runtime'
+require_pattern dist/images/Dockerfile.base 'LABEL "org.opencontainers.image.ref.name"="azurelinux3"'
+require_pattern dist/images/Dockerfile.base 'LABEL "org.opencontainers.image.version"="3\.0"'
+require_pattern dist/images/Dockerfile.base "ARG SRC_DIR='/usr/src/'"
+require_pattern dist/images/Dockerfile.base 'tdnf -y install'
+require_pattern dist/images/Dockerfile.base 'tdnf clean all'
+require_pattern dist/images/Dockerfile.base 'autoconf automake binutils bzip2 ca-certificates checkpolicy'
+require_pattern dist/images/Dockerfile.base 'gcc gcc-c\+\+ git glibc-devel'
+require_pattern dist/images/Dockerfile.base 'kernel-headers pkgconf-pkg-config'
+require_pattern dist/images/Dockerfile.base 'binutils bzip2 ca-certificates curl gawk gcc glibc-devel kernel-headers make tar'
+require_pattern dist/images/Dockerfile.base 'rpm-build'
+require_pattern dist/images/Dockerfile.base 'make rpm-fedora'
+require_pattern dist/images/Dockerfile.base '--without check --without dpdk --without afxdp --without usdt'
+require_pattern dist/images/Dockerfile.base 'ovs_commit=\$\(git rev-parse --short=12 HEAD\)'
+require_pattern dist/images/Dockerfile.base 'ovn_commit=\$\(git rev-parse --short=12 HEAD\)'
+require_pattern dist/images/Dockerfile.base 'AC_INIT'
+reject_pattern dist/images/Dockerfile.base '\+g\$\{ovs_commit\}|\+g\$\{ovn_commit\}'
+require_pattern dist/images/Dockerfile.base 'conntrack-tools'
+require_pattern dist/images/Dockerfile.base 'coreutils'
+require_pattern dist/images/Dockerfile.base 'gawk grep'
+require_pattern dist/images/Dockerfile.base 'ipset iptables'
+require_pattern dist/images/Dockerfile.base 'iputils'
+require_pattern dist/images/Dockerfile.base 'ipvsadm'
+require_pattern dist/images/Dockerfile.base 'procps-ng sed'
+require_pattern dist/images/Dockerfile.base 'NDISC6_VERSION=1\.0\.8'
+require_pattern dist/images/Dockerfile.base 'www\.remlab\.net/files/ndisc6/ndisc6-\$\{NDISC6_VERSION\}\.tar\.bz2'
+require_pattern dist/images/Dockerfile.base "CPP='gcc -E' ./configure --disable-nls"
+require_pattern dist/images/Dockerfile.base 'ndisc6'
+require_pattern dist/images/Dockerfile.base 'strongswan'
+require_pattern dist/images/Dockerfile.base 'initscripts'
+require_pattern dist/images/Dockerfile.base 'ln -s /usr/sbin/strongswan /usr/sbin/ipsec'
+require_pattern dist/images/Dockerfile.base 'ln -s /etc/strongswan/ipsec\.d /etc/ipsec\.d'
+require_pattern dist/images/Dockerfile.base 'touch /etc/strongswan\.d/ovs\.conf'
+require_pattern dist/images/Dockerfile.base '/etc/init\.d/openvswitch-ipsec'
+require_pattern dist/images/Dockerfile.base 'ovs-monitor-ipsec'
+require_pattern dist/images/Dockerfile.base 'fix-netdev-get-ifindex-type\.patch'
+require_pattern dist/images/Dockerfile.base 'command -v ovs-vswitchd'
+require_pattern dist/images/Dockerfile.base '^ARG DEBUG=false$'
+require_pattern dist/images/Dockerfile.base 'azurelinux-official-base-debuginfo'
+require_pattern dist/images/Dockerfile.base '--enablerepo=azurelinux-official-base-debuginfo install gdb valgrind'
+require_pattern dist/images/Dockerfile.base 'gdb valgrind'
+require_pattern dist/images/Dockerfile.base 'command -v xtables-legacy-multi'
+require_pattern dist/images/Dockerfile.base 'if \[ "\$DEBUG" != "true" \]; then'
+require_pattern dist/images/Dockerfile.base 'setcap CAP_NET_BIND_SERVICE\+eip \$\(readlink -f \$\(command -v ovsdb-server\)\)'
+require_pattern dist/images/Dockerfile.base 'setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN\+eip \$\(readlink -f \$\(command -v ovs-vswitchd\)\)'
+reject_pattern dist/images/Dockerfile.base 'FROM ubuntu:24\.04|FROM almalinux:10|apt-get|[[:space:]]apt[[:space:]]|[[:space:]]dnf[[:space:]]|HTTP_PROXY|HTTPS_PROXY|NO_PROXY|http_proxy|https_proxy|no_proxy'
+reject_pattern dist/images/Dockerfile.base 'rpmbuild -bb --with legacy|baseos-source|crb|epel-release|iptables-legacy-\[0-9\]\*\.rpm|iptables-legacy-libs-\[0-9\]\*\.rpm|iptables-nft|curl-minimal|unbound-libs|initscripts-service'
+
+reject_pattern pkg/daemon/controller_linux.go 'isLegacyIptablesAvailable|exec\.ErrNotFound|failed to check iptables-legacy availability'
+reject_pattern pkg/daemon/controller_linux_test.go 'TestIsLegacyIptablesMode|TestIsLegacyIptablesAvailable|writeExecutable'
+
+require_pattern makefiles/build.mk 'Dockerfile\.base dist/images/'
+require_pattern makefiles/build.mk 'kube-ovn-base:\$\(RELEASE_TAG\)-amd64'
+require_pattern makefiles/build.mk 'kube-ovn-base:\$\(LEGACY_TAG\)'
+require_pattern makefiles/build.mk 'kube-ovn-base:\$\(DEBUG_TAG\)-amd64'
+require_pattern makefiles/build.mk 'kube-ovn-base:\$\(RELEASE_TAG\)-arm64'
+require_pattern makefiles/build.mk 'kube-ovn-base:\$\(DEBUG_TAG\)-arm64'
+require_pattern makefiles/build.mk '--build-arg DEBUG=true -t \$\(REGISTRY\)/kube-ovn-base:\$\(DEBUG_TAG\)-amd64'
+require_pattern makefiles/build.mk '--build-arg DEBUG=true -t \$\(REGISTRY\)/kube-ovn-base:\$\(DEBUG_TAG\)-arm64'
+reject_pattern makefiles/build.mk 'Dockerfile\.base-azurelinux3|KUBE_OVN_IMAGE_TAG_SUFFIX|KUBE_OVN_VERSION|-azurelinux3|PROXY_BUILD_ARGS|HTTP_PROXY|HTTPS_PROXY|NO_PROXY|http_proxy|https_proxy|no_proxy'
+
+reject_pattern Makefile 'KUBE_OVN_IMAGE_TAG_SUFFIX|KUBE_OVN_VERSION|VPC_NAT_VERSION'
+require_pattern Makefile 'HELM_WAIT_TIMEOUT \?= 10m'
+require_pattern Makefile 'helm install kubeovn \./charts/kube-ovn --wait --timeout=\$\(HELM_WAIT_TIMEOUT\)'
+require_pattern Makefile 'helm upgrade kubeovn \./charts/kube-ovn --wait --timeout=\$\(HELM_WAIT_TIMEOUT\)'
+require_pattern Makefile 'helm install kubeovn \./charts/kube-ovn-v2 --wait --timeout=\$\(HELM_WAIT_TIMEOUT\)'
+require_pattern Makefile 'helm upgrade kubeovn \./charts/kube-ovn-v2 --wait --timeout=\$\(HELM_WAIT_TIMEOUT\)'
+reject_pattern dist/images/install.sh 'VPC_NAT_VERSION'
+reject_pattern makefiles/kind.mk 'KUBE_OVN_IMAGE_TAG_SUFFIX|KUBE_OVN_VERSION'
+require_pattern dist/images/install.sh '/usr/share/openvswitch/scripts/ovs-ctl load-kmod \|\| true'
+require_pattern charts/kube-ovn/templates/ovsovn-ds.yaml '/usr/share/openvswitch/scripts/ovs-ctl load-kmod \|\| true'
+require_pattern charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml '/usr/share/openvswitch/scripts/ovs-ctl load-kmod \|\| true'
+require_pattern dist/images/install.sh 'ln -sf /bin/true /usr/local/sbin/modprobe'
+require_pattern charts/kube-ovn/templates/ovsovn-ds.yaml 'ln -sf /bin/true /usr/local/sbin/modprobe'
+require_pattern charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml 'ln -sf /bin/true /usr/local/sbin/modprobe'
+reject_pattern dist/images/install.sh 'SYS_MODULE'
+reject_pattern charts/kube-ovn/templates/ovsovn-ds.yaml 'SYS_MODULE'
+reject_pattern charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml 'SYS_MODULE'
+
+require_pattern test/e2e/metallb/e2e_test.go 'arping -c 5 -w 10'
+reject_pattern test/e2e/metallb/e2e_test.go 'arping -c 5 -W 2'
+
+reject_pattern .github/workflows/build-x86-image.yaml 'azurelinux3|KUBE_OVN_IMAGE_TAG_SUFFIX|tag_suffix'
+reject_pattern .github/workflows/build-arm64-image.yaml 'azurelinux3|KUBE_OVN_IMAGE_TAG_SUFFIX'
+reject_pattern .github/workflows/build-kube-ovn-base.yaml 'azurelinux3'
+reject_pattern .github/workflows/publish.yaml 'azurelinux3'
+reject_pattern hack/release.sh 'azurelinux3'
+
+require_pattern dist/images/go-deps/download-go-deps.sh 'download_archive\(\)'
+require_pattern dist/images/go-deps/download-go-deps.sh '--retry-all-errors'
+require_pattern dist/images/go-deps/download-go-deps.sh '--connect-timeout'
+require_pattern dist/images/go-deps/download-go-deps.sh '--max-time'
+
+require_pattern dist/images/start-ovs.sh 'set -Eeuo pipefail'
+require_pattern dist/images/start-ovs.sh 'start-ovs\.sh failed at line'
+require_pattern dist/images/start-ovs.sh 'ovs diagnostics'
+require_pattern dist/images/start-ovs.sh 'run_or_log /usr/share/openvswitch/scripts/ovs-ctl restart --no-ovsdb-server'
+require_pattern dist/images/start-ovs.sh 'set \+e'
+
+require_pattern dist/images/iptables-wrapper-installer.sh 'alternatives --set ip6tables'
+require_pattern dist/images/iptables-wrapper-installer.sh 'alternatives --set iptables .* > /dev/null 2>&1 \|\| true'
+require_pattern dist/images/iptables-wrapper-installer.sh 'alternatives --set ip6tables .* > /dev/null 2>&1 \|\| true'
+require_pattern dist/images/iptables-wrapper-installer.sh '--install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100'

--- a/pkg/daemon/ipsec.go
+++ b/pkg/daemon/ipsec.go
@@ -28,14 +28,15 @@ import (
 )
 
 const (
-	ipsecCADir   = "/etc/ipsec.d/cacerts"
-	ipsecKeyDir  = "/etc/ovs_ipsec_keys"
-	ipsecReqPath = ipsecKeyDir + "/ipsec-req.pem"
+	ipsecCADir  = "/etc/ipsec.d/cacerts"
+	ipsecKeyDir = "/etc/ovs_ipsec_keys"
 
 	ipsecPrivKeyPathSpec = ipsecKeyDir + "/ipsec-privkey-%d.pem"
 	ipsecCertPathSpec    = ipsecKeyDir + "/ipsec-cert-%d.pem"
 	ipsecCACertPathSpec  = ipsecKeyDir + "/ipsec-cacert-%s.pem"
 )
+
+var ipsecReqPath = ipsecKeyDir + "/ipsec-req.pem"
 
 type pkiFiles struct {
 	privateKeyPath  string
@@ -219,8 +220,8 @@ func generateCSRCode(newPrivKeyPath string) ([]byte, error) {
 	klog.Infof("ovs system id: %s", cn)
 
 	cmd := exec.Command("openssl", "req", "-new", "-text",
-		"-extensions", "v3_req",
 		"-addext", "subjectAltName = DNS:"+cn,
+		"-addext", "extendedKeyUsage = ipsecTunnel",
 		"-subj", "/C=CN/O=kubeovn/OU=kube-ovn/CN="+cn,
 		"-key", newPrivKeyPath,
 		"-out", ipsecReqPath) // #nosec

--- a/pkg/daemon/ipsec_test.go
+++ b/pkg/daemon/ipsec_test.go
@@ -1,0 +1,74 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateCSRCodeIncludesIPSecTunnelEKU(t *testing.T) {
+	tempDir := t.TempDir()
+
+	oldReqPath := ipsecReqPath
+	ipsecReqPath = filepath.Join(tempDir, "ipsec-req.pem")
+	t.Cleanup(func() {
+		ipsecReqPath = oldReqPath
+	})
+
+	argsPath := filepath.Join(tempDir, "openssl.args")
+	t.Setenv("TEST_OPENSSL_ARGS", argsPath)
+
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestScript(t, filepath.Join(binDir, "ovs-vsctl"), `#!/bin/sh
+printf 'node-1\n'
+`)
+	writeTestScript(t, filepath.Join(binDir, "openssl"), `#!/bin/sh
+printf '%s\n' "$*" > "$TEST_OPENSSL_ARGS"
+out=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-out" ]; then
+    shift
+    out=$1
+    break
+  fi
+  shift
+done
+[ -n "$out" ] || exit 1
+printf 'csr-bytes' > "$out"
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	csr, err := generateCSRCode(filepath.Join(tempDir, "ipsec.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(csr) != "csr-bytes" {
+		t.Fatalf("unexpected csr bytes %q", csr)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(args)
+	for _, want := range []string{
+		"-addext subjectAltName = DNS:node-1",
+		"-addext extendedKeyUsage = ipsecTunnel",
+		"-subj /C=CN/O=kubeovn/OU=kube-ovn/CN=node-1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("openssl args %q do not contain %q", got, want)
+		}
+	}
+}
+
+func writeTestScript(t *testing.T, path, script string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e/metallb/e2e_test.go
+++ b/test/e2e/metallb/e2e_test.go
@@ -546,7 +546,7 @@ func checkReachable(f *framework.Framework, containerID, sourceIPv4, sourceIPv6,
 
 	ginkgo.By("checking vip node is same as backend pod's host")
 	if !isIPv6 {
-		cmd = strings.Fields(fmt.Sprintf("arping -c 5 -W 2 %s", targetIP))
+		cmd = strings.Fields(fmt.Sprintf("arping -c 5 -w 10 %s", targetIP))
 		output, _, err := docker.Exec(containerID, nil, cmd...)
 		if err != nil {
 			framework.Failf("arping failed: %v, output: %s", err, output)


### PR DESCRIPTION
## Summary
- Replace the default base image build path with Azure Linux 3.0 (`mcr.microsoft.com/azurelinux/base/core:3.0`).
- Build OVS/OVN through upstream `make rpm-fedora` and install the runtime RPMs in the final image.
- Use Azure Linux `tdnf` package names, keep built-in iptables legacy support, and build the missing `ndisc6` utility from source.
- Add an Azure Linux 3.0 base verification script.
- Reference PR #6902 for the RPM-based base image conversion pattern.

## Verification
- `hack/verify-azurelinux3-base.sh`
- `git diff --check origin/master...HEAD`
- `bash -n hack/verify-azurelinux3-base.sh dist/images/go-deps/download-go-deps.sh dist/images/iptables-wrapper-installer.sh`
- Azure Linux 3.0 repo metadata package check for Dockerfile package names
- `ndisc6-1.0.8` local source build check

Note: full Docker build was not run locally because this user cannot access `/var/run/docker.sock`.
