### PR TITLE
ci: clean up chart releases and keep latest release correct

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -31,8 +31,48 @@ jobs:
         with:
           skip_existing: true
           packages_with_index: true
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Clean up chart releases
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: "${{ github.repository }}"
+        run: |
+          version=$(awk '/^version:/ {print $2}' charts/kube-ovn/Chart.yaml)
+
+          # chart-releaser creates one release per chart: kube-ovn-<version> and
+          # kube-ovn-v2-<version>. The v2 one is redundant (the chart itself is
+          # served from the gh-pages index and the OCI registry), so delete it.
+          if gh release view "kube-ovn-v2-${version}" >/dev/null 2>&1; then
+            gh release delete "kube-ovn-v2-${version}" --yes
+          fi
+
+          # Rename the kube-ovn-<version> release so it becomes the release of
+          # the plain git tag v1.x.y, unless that release already exists.
+          if gh release view "kube-ovn-${version}" >/dev/null 2>&1; then
+            if gh release view "${version}" >/dev/null 2>&1; then
+              gh release delete "kube-ovn-${version}" --yes
+            elif git rev-parse -q --verify "refs/tags/${version}" >/dev/null; then
+              gh release edit "kube-ovn-${version}" --tag "${version}" --title "${version}"
+            fi
+          fi
+
+      - name: Mark highest version as latest release
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: "${{ github.repository }}"
+        run: |
+          latest=$(gh api "repos/${GH_REPO}/releases" --paginate \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' | \
+            grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+          if [ -n "${latest}" ]; then
+            echo "Marking ${latest} as the latest release"
+            release_id=$(gh api "repos/${GH_REPO}/releases/tags/${latest}" --jq '.id')
+            gh api -X PATCH "repos/${GH_REPO}/releases/${release_id}" \
+              -f make_latest=true >/dev/null
+          fi
 
       - name: Login to GitHub Container Registry
         run: |


### PR DESCRIPTION
## Summary

The chart-releaser workflow creates two extra releases per version tag (`kube-ovn-<version>` and `kube-ovn-v2-<version>`), and since GitHub marks the newest created release as latest by default, a release from an older branch could override the latest release. Until now these had to be cleaned up manually after every release. This PR automates the cleanup:

* pass `mark_as_latest: false` to chart-releaser so chart releases never grab the latest marker
* delete the redundant `kube-ovn-v2-<version>` release after chart-releaser runs
* rename the `kube-ovn-<version>` release (tag and title) to the plain `v1.x.y`, so it becomes the release of the version git tag; if that release already exists (e.g. workflow re-run), drop the duplicate instead
* re-point the latest marker to the highest semver release

Git tags created by chart-releaser are intentionally left untouched. The helm repo is unaffected: with `packages_with_index: true` the gh-pages `index.yaml` references charts by relative path, not by release asset URL.

Needs to be cherry-picked to release-1.16/release-1.15 after merge, since tag pushes run the workflow file from the tagged commit.

## Test plan

- [x] YAML syntax validated
- [x] Cleanup logic mirrors the manual steps performed on existing releases (verified against the live repo state with a dry-run script)
- [ ] Verify on the next version tag push that only the plain `v1.x.y` release remains and latest points to the highest semver release

🤖 Generated with [Claude Code](https://claude.com/claude-code)