### PR TITLE
fix: install CNI config and binaries atomically

### DIFF
--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -191,8 +191,17 @@ func mvCNIConf(configDir, configFile, confName string) error {
 		return err
 	}
 
+	// Clean up temp files left over from a previous interrupted install.
+	if leftovers, _ := filepath.Glob(cniConfPath + ".tmp.*"); len(leftovers) > 0 {
+		for _, f := range leftovers {
+			if err := os.Remove(f); err != nil && !os.IsNotExist(err) {
+				klog.Warningf("failed to remove stale temp file %s: %v", f, err)
+			}
+		}
+	}
+
 	klog.Infof("Installing cni config file %q to %q", configFile, cniConfPath)
-	return os.WriteFile(cniConfPath, data, 0o600) // #nosec G306,G703
+	return util.AtomicWriteFile(cniConfPath, data, 0o600)
 }
 
 func Retry(attempts, sleep int, f func(configuration *daemon.Configuration) error, cfg *daemon.Configuration) (err error) {

--- a/dist/images/install-cni.sh
+++ b/dist/images/install-cni.sh
@@ -2,8 +2,27 @@
 
 set -u -e
 
+exit_with_error(){
+  echo "$1"
+  exit 1
+}
+
+# Copy to a temp file on the same filesystem, then rename over the
+# destination. A plain `cp -f` truncates and rewrites the destination
+# inode in place, so kubelet may exec a partially written binary
+# during the copy window.
+install_binary(){
+  local src=$1 dst=$2
+  local tmp="${dst}.tmp.$$"
+  rm -f "${dst}".tmp.*
+  if ! cp -f "$src" "$tmp" || ! mv -f "$tmp" "$dst"; then
+    rm -f "$tmp"
+    exit_with_error "Failed to install $src to $dst"
+  fi
+}
+
 mkdir -p /usr/local/bin
-cp -f /kube-ovn/kubectl-ko /usr/local/bin/
+install_binary /kube-ovn/kubectl-ko /usr/local/bin/kubectl-ko
 chmod +x /usr/local/bin/kubectl-ko
 
 for ip in $(echo "${POD_IPS}" | tr ',' ' '); do
@@ -16,11 +35,6 @@ for ip in $(echo "${POD_IPS}" | tr ',' ' '); do
     echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter;
   fi
 done
-
-exit_with_error(){
-  echo "$1"
-  exit 1
-}
 
 CNI_BIN_SRC=/kube-ovn/kube-ovn
 CNI_BIN_DST=/opt/cni/bin/kube-ovn
@@ -37,10 +51,10 @@ MACVLAN_BIN_DST=/opt/cni/bin/macvlan
 IPVLAN_BIN_SRC=/ipvlan
 IPVLAN_BIN_DST=/opt/cni/bin/ipvlan
 
-yes | cp -f $LOOPBACK_BIN_SRC $LOOPBACK_BIN_DST || exit_with_error "Failed to copy $LOOPBACK_BIN_SRC to $LOOPBACK_BIN_DST"
-yes | cp -f $PORTMAP_BIN_SRC $PORTMAP_BIN_DST || exit_with_error "Failed to copy $PORTMAP_BIN_SRC to $PORTMAP_BIN_DST"
-yes | cp -f $CNI_BIN_SRC $CNI_BIN_DST || exit_with_error "Failed to copy $CNI_BIN_SRC to $CNI_BIN_DST"
-yes | cp -f $MACVLAN_BIN_SRC $MACVLAN_BIN_DST || exit_with_error "Failed to copy $MACVLAN_BIN_SRC to $MACVLAN_BIN_DST"
-yes | cp -f $IPVLAN_BIN_SRC $IPVLAN_BIN_DST || exit_with_error "Failed to copy $IPVLAN_BIN_SRC to $IPVLAN_BIN_DST"
+install_binary "$LOOPBACK_BIN_SRC" "$LOOPBACK_BIN_DST"
+install_binary "$PORTMAP_BIN_SRC" "$PORTMAP_BIN_DST"
+install_binary "$CNI_BIN_SRC" "$CNI_BIN_DST"
+install_binary "$MACVLAN_BIN_SRC" "$MACVLAN_BIN_DST"
+install_binary "$IPVLAN_BIN_SRC" "$IPVLAN_BIN_DST"
 
 ./kube-ovn-daemon --install-cni-config $@ || exit_with_error "Failed to install cni config"

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteFile writes data to a temporary file in the target directory,
+// fsyncs it, then renames it to path. Concurrent readers never observe a
+// partially written file, and a crash mid-write cannot leave a truncated
+// file at the final path.
+func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if err = tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err = tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmpName, path); err != nil {
+		return err
+	}
+
+	// fsync the parent directory so the rename itself survives a power loss;
+	// otherwise the journal may replay the rename before the data blocks are
+	// on disk, leaving a zero-length file.
+	d, err := os.Open(dir) // #nosec G304
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -1,0 +1,80 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicWriteFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		perm     os.FileMode
+		existing string
+		data     string
+	}{
+		{
+			name: "create new file",
+			perm: 0o600,
+			data: "hello",
+		},
+		{
+			name:     "overwrite existing file",
+			perm:     0o600,
+			existing: "old content longer than the new one",
+			data:     "new",
+		},
+		{
+			name: "custom permission",
+			perm: 0o644,
+			data: "perm test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "target.conf")
+			if tt.existing != "" {
+				if err := os.WriteFile(path, []byte(tt.existing), 0o600); err != nil {
+					t.Fatalf("failed to prepare existing file: %v", err)
+				}
+			}
+
+			if err := AtomicWriteFile(path, []byte(tt.data), tt.perm); err != nil {
+				t.Fatalf("AtomicWriteFile: %v", err)
+			}
+
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read result: %v", err)
+			}
+			if string(got) != tt.data {
+				t.Errorf("content = %q, want %q", string(got), tt.data)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("failed to stat result: %v", err)
+			}
+			if info.Mode().Perm() != tt.perm {
+				t.Errorf("perm = %o, want %o", info.Mode().Perm(), tt.perm)
+			}
+
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("failed to read dir: %v", err)
+			}
+			if len(entries) != 1 {
+				t.Errorf("expected only the target file in dir, got %d entries", len(entries))
+			}
+		})
+	}
+
+	t.Run("missing directory", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "no-such-dir", "target.conf")
+		if err := AtomicWriteFile(path, []byte("x"), 0o600); err == nil {
+			t.Error("expected error when the target directory does not exist")
+		}
+	})
+}


### PR DESCRIPTION
## Description

Two non-atomic file installations can expose partially written files to kubelet:

1. **CNI conflist (`mvCNIConf`)**: the config was written with a plain `os.WriteFile`. A crash or power loss mid-write can leave a truncated file at the final path, and since `mvCNIConf` skips existing files with correct permissions, the broken file is **never rewritten** — kubelet keeps failing to parse it until someone removes it by hand. Now the config is written to a temp file in the same directory, fsynced, and renamed into place (with a parent-directory fsync so the rename survives power loss). Stale temp files from an interrupted install are cleaned up.

2. **CNI plugin binaries (`install-cni.sh`)**: the plugins were copied with a bare `cp -f`, which truncates and rewrites the destination inode in place when no process is currently executing it. Kubelet may exec a partially written plugin ("exec format error") during the copy window, which opens on **every daemonset restart or upgrade on every node** — and `loopback` is invoked for every sandbox creation. Binaries are now copied to a temp file on the same filesystem and renamed over the destination, so an exec always sees either the complete old or the complete new binary.

The new `util.AtomicWriteFile` helper is covered by unit tests. Prior art for the same pattern: Calico `install-cni`, containernetworking plugins install scripts; flannel is fixing the same class of issue in flannel-io/flannel#2486 / k3s-io/k3s#14342.

## Verification

- `make lint` — 0 issues
- `go test ./pkg/util/ -run TestAtomicWriteFile` — pass
- `bash -n dist/images/install-cni.sh` — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)