### PR TITLE
fix ipam only ip leak (#7034)

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1993,6 +1993,12 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 					providerName = fmt.Sprintf("%s.%s", providerName, attach.InterfaceRequest)
 				}
 
+				// IPAM-only attachments (e.g. ipvlan/macvlan with ipam.type kube-ovn) bind to a
+				// subnet whose provider is "<nad>.<namespace>" without the ".ovn" suffix, and the
+				// add path never appends the interface name to it. Match this form as well so the
+				// IP is released here instead of leaking (the periodic gc does not reclaim it).
+				ipamProviderName := fmt.Sprintf("%s.%s", attach.Name, attach.Namespace)
+
 				// if interface name is provided this means providerName will contain interface name
 				// say vm-overlay.default.ovn.net1 which will not match the `provider` definition in the config object
 				// for each interface then we need annotation
@@ -2001,8 +2007,11 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 				subnetName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, providerName)]
 				if subnetName == "" {
 					for _, subnet := range subnets {
-						if subnet.Spec.Provider == providerName {
+						if subnet.Spec.Provider == providerName || subnet.Spec.Provider == ipamProviderName {
 							subnetName = subnet.Name
+							// use the subnet's real provider so the released IP CR name
+							// (pod.namespace.provider) matches what was allocated
+							providerName = subnet.Spec.Provider
 							break
 						}
 					}

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1313,3 +1313,47 @@ func TestGetPodAttachmentNetDefaultSubnetGone(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, nets)
 }
+
+// TestGetPodAttachmentNetIPAMOnlyNADGone reproduces issue #6943: when an IPAM-only
+// attachment (e.g. ipvlan with ipam.type kube-ovn) is deleted after its NAD has
+// already been removed, the cleanup path must still resolve the attachment to its
+// subnet so the IP is released. The subnet provider is "<nad>.<namespace>" without
+// the ".ovn" suffix, so the returned net must carry that exact provider name so the
+// released IP CR name matches what was allocated.
+func TestGetPodAttachmentNetIPAMOnlyNADGone(t *testing.T) {
+	now := metav1.Now()
+	grace := int64(0)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       "test-pod",
+			Namespace:                  metav1.NamespaceDefault,
+			DeletionTimestamp:          &now,
+			DeletionGracePeriodSeconds: &grace,
+			Annotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: `[{"name": "net1"}]`,
+			},
+		},
+	}
+
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		// NAD intentionally absent: it was deleted before the pod.
+		Subnets: []*kubeovnv1.Subnet{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ipam-net1"},
+				Spec: kubeovnv1.SubnetSpec{
+					CIDRBlock: "10.1.0.0/16",
+					// IPAM-only provider: no ".ovn" suffix
+					Provider: "net1.default",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	controller := fakeController.fakeController
+
+	nets, err := controller.getPodAttachmentNet(pod)
+	require.NoError(t, err)
+	require.Len(t, nets, 1)
+	assert.Equal(t, "net1.default", nets[0].ProviderName)
+	assert.Equal(t, "ipam-net1", nets[0].Subnet.Name)
+}


### PR DESCRIPTION
## What type of this PR
- Bug fixes

Forward-port of #7034 (merged into release-1.16) to master.

PR #7034 was merged directly into release-1.16, so master (future 1.17) still carries the bug: IPAM-only attachments (e.g. ipvlan/macvlan with `ipam.type: kube-ovn`) use a subnet provider of the form `<nad>.<namespace>` without the `.ovn` suffix, so the pod deletion cleanup path in `getPodAttachmentNet` fails to match the subnet and the IP CR leaks (the periodic gc does not reclaim it).

Ref https://github.com/kubeovn/kube-ovn/issues/6943

Cherry-picked cleanly from af46e9a92653dd50801bac7b10c7a942714c1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)