### PR TITLE
perf(controller): skip irrelevant service and endpointslice updates

### DIFF
--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -65,6 +66,15 @@ func (c *Controller) enqueueUpdateEndpointSlice(oldObj, newObj any) {
 	}
 
 	if len(oldEndpointSlice.Endpoints) == 0 && len(newEndpointSlice.Endpoints) == 0 {
+		return
+	}
+
+	// skip metadata-only churn, e.g. the endpoints.kubernetes.io/last-change-trigger-time
+	// annotation refresh: the LB backends are computed solely from endpoints, ports and
+	// the owning service.
+	if getServiceForEndpointSlice(oldEndpointSlice) == getServiceForEndpointSlice(newEndpointSlice) &&
+		reflect.DeepEqual(oldEndpointSlice.Endpoints, newEndpointSlice.Endpoints) &&
+		reflect.DeepEqual(oldEndpointSlice.Ports, newEndpointSlice.Ports) {
 		return
 	}
 

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -110,6 +110,19 @@ func (c *Controller) enqueueUpdateService(oldObj, newObj any) {
 
 	oldClusterIps := getVipIps(oldSvc)
 	newClusterIps := getVipIps(newSvc)
+
+	// skip updates that touch none of the fields consumed by handleUpdateService,
+	// e.g. status noise or third-party annotation churn bumping the resource version.
+	// LoadBalancer services are always enqueued: their reconcile also depends on
+	// status.loadBalancer.ingress and the lb-svc attachment deployment.
+	if newSvc.Spec.Type != v1.ServiceTypeLoadBalancer &&
+		oldSvc.DeletionTimestamp.Equal(newSvc.DeletionTimestamp) &&
+		oldSvc.Annotations[util.VpcAnnotation] == newSvc.Annotations[util.VpcAnnotation] &&
+		slices.Equal(oldClusterIps, newClusterIps) &&
+		reflect.DeepEqual(oldSvc.Spec, newSvc.Spec) {
+		return
+	}
+
 	var ipsToDel []string
 	for _, oldClusterIP := range oldClusterIps {
 		if !slices.Contains(newClusterIps, oldClusterIP) {

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -233,6 +233,208 @@ func Test_enqueueServiceGatedByEnableLb(t *testing.T) {
 	})
 }
 
+func Test_enqueueUpdateServiceSkipsIrrelevantUpdates(t *testing.T) {
+	t.Parallel()
+
+	newController := func() *Controller {
+		return &Controller{
+			config:             &Configuration{EnableLb: true},
+			updateServiceQueue: newTypedRateLimitingQueue[*updateSvcObject]("UpdateService", nil),
+		}
+	}
+
+	baseSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "svc",
+			Namespace:       metav1.NamespaceDefault,
+			ResourceVersion: "1",
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:  "10.96.0.10",
+			ClusterIPs: []string{"10.96.0.10"},
+			Ports:      []v1.ServicePort{{Name: "tcp", Port: 80, Protocol: v1.ProtocolTCP}},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		mutateOld func(svc *v1.Service)
+		mutate    func(svc *v1.Service)
+		enqueued  bool
+	}{
+		{
+			name: "third-party annotation churn is skipped",
+			mutate: func(svc *v1.Service) {
+				svc.Annotations = map[string]string{"third-party/annotation": "changed"}
+			},
+			enqueued: false,
+		},
+		{
+			name: "status-only update is skipped",
+			mutate: func(svc *v1.Service) {
+				svc.Status.Conditions = []metav1.Condition{{Type: "Foo", Status: metav1.ConditionTrue}}
+			},
+			enqueued: false,
+		},
+		{
+			name: "port change is enqueued",
+			mutate: func(svc *v1.Service) {
+				svc.Spec.Ports[0].Port = 8080
+			},
+			enqueued: true,
+		},
+		{
+			name: "vpc annotation change is enqueued",
+			mutate: func(svc *v1.Service) {
+				svc.Annotations = map[string]string{util.VpcAnnotation: "custom-vpc"}
+			},
+			enqueued: true,
+		},
+		{
+			name: "switch lb rule vip annotation change is enqueued",
+			mutate: func(svc *v1.Service) {
+				svc.Annotations = map[string]string{util.SwitchLBRuleVipsAnnotation: "10.0.0.1"}
+			},
+			enqueued: true,
+		},
+		{
+			name: "cluster ip change is enqueued",
+			mutate: func(svc *v1.Service) {
+				svc.Spec.ClusterIP = "10.96.0.11"
+				svc.Spec.ClusterIPs = []string{"10.96.0.11"}
+			},
+			enqueued: true,
+		},
+		{
+			name: "deletion timestamp change is enqueued",
+			mutate: func(svc *v1.Service) {
+				now := metav1.Now()
+				svc.DeletionTimestamp = &now
+			},
+			enqueued: true,
+		},
+		{
+			name: "loadbalancer service is enqueued even on annotation churn",
+			mutateOld: func(svc *v1.Service) {
+				svc.Spec.Type = v1.ServiceTypeLoadBalancer
+			},
+			mutate: func(svc *v1.Service) {
+				svc.Spec.Type = v1.ServiceTypeLoadBalancer
+				svc.Annotations = map[string]string{"third-party/annotation": "changed"}
+			},
+			enqueued: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			oldSvc := baseSvc.DeepCopy()
+			newSvc := baseSvc.DeepCopy()
+			newSvc.ResourceVersion = "2"
+			if tt.mutateOld != nil {
+				tt.mutateOld(oldSvc)
+			}
+			tt.mutate(newSvc)
+
+			c := newController()
+			c.enqueueUpdateService(oldSvc, newSvc)
+			if tt.enqueued {
+				require.Equal(t, 1, c.updateServiceQueue.Len())
+			} else {
+				require.Zero(t, c.updateServiceQueue.Len())
+			}
+		})
+	}
+}
+
+func Test_enqueueUpdateEndpointSliceSkipsContentlessUpdates(t *testing.T) {
+	t.Parallel()
+
+	newController := func() *Controller {
+		return &Controller{
+			config:                        &Configuration{EnableLb: true},
+			addOrUpdateEndpointSliceQueue: newTypedRateLimitingQueue[string]("UpdateEndpointSlice", nil),
+		}
+	}
+
+	ready := true
+	baseEps := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "svc-abc12",
+			Namespace:       metav1.NamespaceDefault,
+			ResourceVersion: "1",
+			Labels:          map[string]string{discoveryv1.LabelServiceName: "svc"},
+		},
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses:  []string{"10.16.0.2"},
+			Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+		}},
+		Ports: []discoveryv1.EndpointPort{{Port: &[]int32{80}[0]}},
+	}
+
+	tests := []struct {
+		name     string
+		mutate   func(eps *discoveryv1.EndpointSlice)
+		enqueued bool
+	}{
+		{
+			name: "trigger-time annotation churn is skipped",
+			mutate: func(eps *discoveryv1.EndpointSlice) {
+				eps.Annotations = map[string]string{"endpoints.kubernetes.io/last-change-trigger-time": "changed"}
+			},
+			enqueued: false,
+		},
+		{
+			name: "endpoint ready condition change is enqueued",
+			mutate: func(eps *discoveryv1.EndpointSlice) {
+				notReady := false
+				eps.Endpoints[0].Conditions.Ready = &notReady
+			},
+			enqueued: true,
+		},
+		{
+			name: "endpoint address change is enqueued",
+			mutate: func(eps *discoveryv1.EndpointSlice) {
+				eps.Endpoints[0].Addresses = []string{"10.16.0.3"}
+			},
+			enqueued: true,
+		},
+		{
+			name: "port change is enqueued",
+			mutate: func(eps *discoveryv1.EndpointSlice) {
+				eps.Ports[0].Port = &[]int32{8080}[0]
+			},
+			enqueued: true,
+		},
+		{
+			name: "service-name label change is enqueued",
+			mutate: func(eps *discoveryv1.EndpointSlice) {
+				eps.Labels[discoveryv1.LabelServiceName] = "svc2"
+			},
+			enqueued: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			oldEps := baseEps.DeepCopy()
+			newEps := baseEps.DeepCopy()
+			newEps.ResourceVersion = "2"
+			tt.mutate(newEps)
+
+			c := newController()
+			c.enqueueUpdateEndpointSlice(oldEps, newEps)
+			if tt.enqueued {
+				require.Equal(t, 1, c.addOrUpdateEndpointSliceQueue.Len())
+			} else {
+				require.Zero(t, c.addOrUpdateEndpointSliceQueue.Len())
+			}
+		})
+	}
+}
+
 func Test_checkServiceLBIPBelongToSubnet(t *testing.T) {
 	const (
 		ns         = metav1.NamespaceDefault


### PR DESCRIPTION
## 📑 Description

Both `enqueueUpdateService` and `enqueueUpdateEndpointSlice` gated updates on the resource version only, so updates that touch nothing the handlers consume still triggered real work:

- **Service**: any RV bump (third-party annotation churn from tools like ArgoCD, status-only writes) allocated an `updateSvcObject` into the non-deduplicating pointer queue, and `handleUpdateService` then issued per-protocol `GetLoadBalancer` lookups plus per-VIP `LoadBalancerDeleteVip` attempts for nothing.
- **EndpointSlice**: the EndpointSlice controller refreshes metadata such as the `endpoints.kubernetes.io/last-change-trigger-time` annotation; each such event re-issued the whole OVN LB VIP transaction chain for the service.

This PR adds field-level short circuits in front of both queues:

- Service updates are skipped when the spec (whole-spec `DeepEqual`, following the `enqueueUpdateSubnet` pattern), the VIP set (`getVipIps`, which covers cluster IPs, the SLR/RLR VIP annotations and the external-IP-from-subnet ingress IPs), the VPC annotation and the deletion timestamp are all unchanged. **LoadBalancer services are always enqueued** because `handleUpdateService` additionally consumes `status.loadBalancer.ingress` (via `checkServiceLBIPBelongToSubnet`) and the lb-svc attachment deployment.
- EndpointSlice updates are skipped when the endpoints, ports and the owning `kubernetes.io/service-name` label are unchanged.

Spec changes to fields kube-ovn does not consume (e.g. selector) still enqueue and run one idempotent no-op pass — that trade-off keeps the filter simple and future-proof.

Unit tests cover both filters (skip and enqueue directions, including the LoadBalancer carve-out and the deletion-timestamp path).

## ✅ Checks
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required

## How to verify it

`go test ./pkg/controller/ -run 'Test_enqueueUpdateService|Test_enqueueUpdateEndpointSlice|Test_enqueueServiceGatedByEnableLb'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)