### PR TITLE
fix: recreate ACLs when ANP/BANP/CNP rule is renamed

### DIFF
--- a/pkg/controller/admin_network_policy.go
+++ b/pkg/controller/admin_network_policy.go
@@ -80,9 +80,9 @@ func (c *Controller) enqueueUpdateAnp(oldObj, newObj any) {
 		return
 	}
 
-	// Acls should be updated when name, action or ports of ingress/egress rule has been changed.
-	// The rule name is part of both the acl name and the address set name referenced by the acl match,
-	// so a renamed rule requires the acls to be recreated together with the address sets.
+	// ACLs should be updated when the name, action, or ports of an ingress/egress rule have changed.
+	// The rule name is part of both the ACL name and the address set name referenced by the ACL match,
+	// so a renamed rule requires the ACLs to be recreated together with the address sets.
 	for index, rule := range newAnpObj.Spec.Ingress {
 		oldRule := oldAnpObj.Spec.Ingress[index]
 		if oldRule.Name != rule.Name || oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {

--- a/pkg/controller/admin_network_policy.go
+++ b/pkg/controller/admin_network_policy.go
@@ -33,7 +33,6 @@ const (
 type ChangedName struct {
 	// the rule name can be omitted default, add isMatch to append check for rule update
 	isMatch     bool
-	oldRuleName string
 	curRuleName string
 }
 
@@ -81,10 +80,12 @@ func (c *Controller) enqueueUpdateAnp(oldObj, newObj any) {
 		return
 	}
 
-	// Acls should be updated when action or ports of ingress/egress rule has been changed
+	// Acls should be updated when name, action or ports of ingress/egress rule has been changed.
+	// The rule name is part of both the acl name and the address set name referenced by the acl match,
+	// so a renamed rule requires the acls to be recreated together with the address sets.
 	for index, rule := range newAnpObj.Spec.Ingress {
 		oldRule := oldAnpObj.Spec.Ingress[index]
-		if oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
+		if oldRule.Name != rule.Name || oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
 			// It's difficult to distinguish which rule has changed and update acls for that rule, so go through the anp add process to recreate acls.
 			// If we want to get fine-grained changes over rule, maybe it's a better way to add a new queue to process the change
 			c.addAnpQueue.Add(newAnpObj.Name)
@@ -94,7 +95,7 @@ func (c *Controller) enqueueUpdateAnp(oldObj, newObj any) {
 
 	for index, rule := range newAnpObj.Spec.Egress {
 		oldRule := oldAnpObj.Spec.Egress[index]
-		if oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
+		if oldRule.Name != rule.Name || oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
 			c.addAnpQueue.Add(newAnpObj.Name)
 			return
 		}
@@ -112,15 +113,11 @@ func (c *Controller) enqueueUpdateAnp(oldObj, newObj any) {
 		c.updateAnpQueue.Add(&AdminNetworkPolicyChangedDelta{key: newAnpObj.Name, field: ChangedSubject})
 	}
 
-	// Rule name or peer selector in ingress/egress rule has changed, the corresponding address-set need be updated
+	// Peer selector in ingress/egress rule has changed, the corresponding address-set need be updated
 	ruleChanged := false
 	var changedIngressRuleNames, changedEgressRuleNames [util.AnpMaxRules]ChangedName
 	for index, rule := range newAnpObj.Spec.Ingress {
 		oldRule := oldAnpObj.Spec.Ingress[index]
-		if oldRule.Name != rule.Name {
-			changedIngressRuleNames[index] = ChangedName{oldRuleName: oldRule.Name, curRuleName: rule.Name}
-			ruleChanged = true
-		}
 		if !reflect.DeepEqual(oldRule.From, rule.From) {
 			changedIngressRuleNames[index] = ChangedName{curRuleName: rule.Name}
 			ruleChanged = true
@@ -133,10 +130,6 @@ func (c *Controller) enqueueUpdateAnp(oldObj, newObj any) {
 	ruleChanged = false
 	for index, rule := range newAnpObj.Spec.Egress {
 		oldRule := oldAnpObj.Spec.Egress[index]
-		if oldRule.Name != rule.Name {
-			changedEgressRuleNames[index] = ChangedName{oldRuleName: oldRule.Name, curRuleName: rule.Name}
-			ruleChanged = true
-		}
 		if !reflect.DeepEqual(oldRule.To, rule.To) {
 			changedEgressRuleNames[index] = ChangedName{curRuleName: rule.Name}
 			ruleChanged = true
@@ -470,21 +463,6 @@ func (c *Controller) handleUpdateAnp(changed *AdminNetworkPolicyChangedDelta) er
 					klog.Errorf("failed to set ingress address-set for anp rule %s/%s, %v", anpName, rule.Name, err)
 					return err
 				}
-
-				if changed.ruleNames[index].oldRuleName != "" {
-					oldRuleName := changed.ruleNames[index].oldRuleName
-					// Normally the name can not be changed, but when the name really changes, the old address set should be deleted
-					// There is no description in the Name comments that it cannot be changed
-					oldAsV4Name, oldAsV6Name := getAnpAddressSetName(pgName, oldRuleName, index, true)
-
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV4Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV4Name, err)
-						// just record error log
-					}
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV6Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV6Name, err)
-					}
-				}
 			}
 		}
 	}
@@ -514,21 +492,6 @@ func (c *Controller) handleUpdateAnp(changed *AdminNetworkPolicyChangedDelta) er
 					if err := c.reconcileDNSNameResolversForANP(anpName, currentDomainNames); err != nil {
 						klog.Errorf("failed to reconcile DNSNameResolvers for egress rule %s/%s, %v", anpName, rule.Name, err)
 						return err
-					}
-				}
-
-				if changed.ruleNames[index].oldRuleName != "" {
-					oldRuleName := changed.ruleNames[index].oldRuleName
-					// Normally the name can not be changed, but when the name really changes, the old address set should be deleted
-					// There is no description in the Name comments that it cannot be changed
-					oldAsV4Name, oldAsV6Name := getAnpAddressSetName(pgName, oldRuleName, index, false)
-
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV4Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV4Name, err)
-						// just record error log
-					}
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV6Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV6Name, err)
 					}
 				}
 			}

--- a/pkg/controller/admin_network_policy_test.go
+++ b/pkg/controller/admin_network_policy_test.go
@@ -302,3 +302,89 @@ func TestAnpACLAction(t *testing.T) {
 		})
 	}
 }
+
+func prepareAnpQueueTestController(t *testing.T) *Controller {
+	t.Helper()
+
+	fakeCtrl, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+
+	ctrl := fakeCtrl.fakeController
+	ctrl.addAnpQueue = newTypedRateLimitingQueue[string]("AddAdminNetworkPolicy", nil)
+	ctrl.updateAnpQueue = newTypedRateLimitingQueue[*AdminNetworkPolicyChangedDelta]("UpdateAdminNetworkPolicy", nil)
+	return ctrl
+}
+
+func newTestAnp(ingressRuleName, egressRuleName string, peerLabels map[string]string) *v1alpha1.AdminNetworkPolicy {
+	return &v1alpha1.AdminNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-anp"},
+		Spec: v1alpha1.AdminNetworkPolicySpec{
+			Priority: 10,
+			Subject:  v1alpha1.AdminNetworkPolicySubject{Namespaces: &metav1.LabelSelector{}},
+			Ingress: []v1alpha1.AdminNetworkPolicyIngressRule{{
+				Name:   ingressRuleName,
+				Action: v1alpha1.AdminNetworkPolicyRuleActionDeny,
+				From: []v1alpha1.AdminNetworkPolicyIngressPeer{{
+					Namespaces: &metav1.LabelSelector{MatchLabels: peerLabels},
+				}},
+			}},
+			Egress: []v1alpha1.AdminNetworkPolicyEgressRule{{
+				Name:   egressRuleName,
+				Action: v1alpha1.AdminNetworkPolicyRuleActionDeny,
+				To: []v1alpha1.AdminNetworkPolicyEgressPeer{{
+					Namespaces: &metav1.LabelSelector{MatchLabels: peerLabels},
+				}},
+			}},
+		},
+	}
+}
+
+// A renamed rule must be handled by the add queue: the rule name is part of the acl name and of the
+// address set name referenced by the acl match, so only recreating the acls keeps them consistent.
+func TestEnqueueUpdateAnpRuleRename(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renamed ingress rule recreates acls via add queue", func(t *testing.T) {
+		ctrl := prepareAnpQueueTestController(t)
+		oldAnp := newTestAnp("old-rule", "egress-rule", map[string]string{"app": "a"})
+		newAnp := newTestAnp("new-rule", "egress-rule", map[string]string{"app": "a"})
+
+		ctrl.enqueueUpdateAnp(oldAnp, newAnp)
+
+		require.Equal(t, 1, ctrl.addAnpQueue.Len())
+		require.Zero(t, ctrl.updateAnpQueue.Len())
+	})
+
+	t.Run("renamed egress rule recreates acls via add queue", func(t *testing.T) {
+		ctrl := prepareAnpQueueTestController(t)
+		oldAnp := newTestAnp("ingress-rule", "old-rule", map[string]string{"app": "a"})
+		newAnp := newTestAnp("ingress-rule", "new-rule", map[string]string{"app": "a"})
+
+		ctrl.enqueueUpdateAnp(oldAnp, newAnp)
+
+		require.Equal(t, 1, ctrl.addAnpQueue.Len())
+		require.Zero(t, ctrl.updateAnpQueue.Len())
+	})
+
+	t.Run("renamed rule with peer change recreates acls via add queue", func(t *testing.T) {
+		ctrl := prepareAnpQueueTestController(t)
+		oldAnp := newTestAnp("ingress-rule", "old-rule", map[string]string{"app": "a"})
+		newAnp := newTestAnp("ingress-rule", "new-rule", map[string]string{"app": "b"})
+
+		ctrl.enqueueUpdateAnp(oldAnp, newAnp)
+
+		require.Equal(t, 1, ctrl.addAnpQueue.Len())
+		require.Zero(t, ctrl.updateAnpQueue.Len())
+	})
+
+	t.Run("peer change only goes through update queue", func(t *testing.T) {
+		ctrl := prepareAnpQueueTestController(t)
+		oldAnp := newTestAnp("ingress-rule", "egress-rule", map[string]string{"app": "a"})
+		newAnp := newTestAnp("ingress-rule", "egress-rule", map[string]string{"app": "b"})
+
+		ctrl.enqueueUpdateAnp(oldAnp, newAnp)
+
+		require.Zero(t, ctrl.addAnpQueue.Len())
+		require.Equal(t, 2, ctrl.updateAnpQueue.Len())
+	})
+}

--- a/pkg/controller/baseline_admin_network_policy.go
+++ b/pkg/controller/baseline_admin_network_policy.go
@@ -53,10 +53,12 @@ func (c *Controller) enqueueUpdateBanp(oldObj, newObj any) {
 		return
 	}
 
-	// Acls should be updated when action or ports of ingress/egress rule has been changed
+	// Acls should be updated when name, action or ports of ingress/egress rule has been changed.
+	// The rule name is part of both the acl name and the address set name referenced by the acl match,
+	// so a renamed rule requires the acls to be recreated together with the address sets.
 	for index, rule := range newBanp.Spec.Ingress {
 		oldRule := oldBanp.Spec.Ingress[index]
-		if oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
+		if oldRule.Name != rule.Name || oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
 			c.addBanpQueue.Add(newBanp.Name)
 			return
 		}
@@ -64,7 +66,7 @@ func (c *Controller) enqueueUpdateBanp(oldObj, newObj any) {
 
 	for index, rule := range newBanp.Spec.Egress {
 		oldRule := oldBanp.Spec.Egress[index]
-		if oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
+		if oldRule.Name != rule.Name || oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
 			c.addBanpQueue.Add(newBanp.Name)
 			return
 		}
@@ -82,16 +84,12 @@ func (c *Controller) enqueueUpdateBanp(oldObj, newObj any) {
 		c.updateBanpQueue.Add(&AdminNetworkPolicyChangedDelta{key: newBanp.Name, field: ChangedSubject})
 	}
 
-	// Rule name or peer selector in ingress/egress rule has changed, the corresponding address-set need be updated
+	// Peer selector in ingress/egress rule has changed, the corresponding address-set need be updated
 	ruleChanged := false
 	var changedIngressRuleNames, changedEgressRuleNames [util.AnpMaxRules]ChangedName
 
 	for index, rule := range newBanp.Spec.Ingress {
 		oldRule := oldBanp.Spec.Ingress[index]
-		if oldRule.Name != rule.Name {
-			changedIngressRuleNames[index] = ChangedName{oldRuleName: oldRule.Name, curRuleName: rule.Name}
-			ruleChanged = true
-		}
 		if !reflect.DeepEqual(oldRule.From, rule.From) {
 			changedIngressRuleNames[index] = ChangedName{curRuleName: rule.Name}
 			ruleChanged = true
@@ -104,10 +102,6 @@ func (c *Controller) enqueueUpdateBanp(oldObj, newObj any) {
 	ruleChanged = false
 	for index, rule := range newBanp.Spec.Egress {
 		oldRule := oldBanp.Spec.Egress[index]
-		if oldRule.Name != rule.Name {
-			changedEgressRuleNames[index] = ChangedName{oldRuleName: oldRule.Name, curRuleName: rule.Name}
-			ruleChanged = true
-		}
 		if !reflect.DeepEqual(oldRule.To, rule.To) {
 			changedEgressRuleNames[index] = ChangedName{curRuleName: rule.Name}
 			ruleChanged = true
@@ -393,19 +387,6 @@ func (c *Controller) handleUpdateBanp(changed *AdminNetworkPolicyChangedDelta) e
 					klog.Errorf("failed to set ingress address-set for anp rule %s/%s, %v", banpName, rule.Name, err)
 					return err
 				}
-
-				if changed.ruleNames[index].oldRuleName != "" {
-					oldRuleName := changed.ruleNames[index].oldRuleName
-					oldAsV4Name, oldAsV6Name := getAnpAddressSetName(pgName, oldRuleName, index, true)
-
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV4Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV4Name, err)
-						// just record error log
-					}
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV6Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV6Name, err)
-					}
-				}
 			}
 		}
 	}
@@ -417,19 +398,6 @@ func (c *Controller) handleUpdateBanp(changed *AdminNetworkPolicyChangedDelta) e
 				if err := c.setAddrSetForBaselineAnpRule(banpName, pgName, rule.Name, index, []v1alpha1.AdminNetworkPolicyIngressPeer{}, rule.To, false, true); err != nil {
 					klog.Errorf("failed to set egress address-set for banp rule %s/%s, %v", banpName, rule.Name, err)
 					return err
-				}
-
-				if changed.ruleNames[index].oldRuleName != "" {
-					oldRuleName := changed.ruleNames[index].oldRuleName
-					oldAsV4Name, oldAsV6Name := getAnpAddressSetName(pgName, oldRuleName, index, false)
-
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV4Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV4Name, err)
-						// just record error log
-					}
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV6Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV6Name, err)
-					}
 				}
 			}
 		}

--- a/pkg/controller/baseline_admin_network_policy.go
+++ b/pkg/controller/baseline_admin_network_policy.go
@@ -53,9 +53,9 @@ func (c *Controller) enqueueUpdateBanp(oldObj, newObj any) {
 		return
 	}
 
-	// Acls should be updated when name, action or ports of ingress/egress rule has been changed.
-	// The rule name is part of both the acl name and the address set name referenced by the acl match,
-	// so a renamed rule requires the acls to be recreated together with the address sets.
+	// ACLs should be updated when the name, action, or ports of an ingress/egress rule have changed.
+	// The rule name is part of both the ACL name and the address set name referenced by the ACL match,
+	// so a renamed rule requires the ACLs to be recreated together with the address sets.
 	for index, rule := range newBanp.Spec.Ingress {
 		oldRule := oldBanp.Spec.Ingress[index]
 		if oldRule.Name != rule.Name || oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {

--- a/pkg/controller/baseline_admin_network_policy_test.go
+++ b/pkg/controller/baseline_admin_network_policy_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1alpha1 "sigs.k8s.io/network-policy-api/apis/v1alpha1"
 
 	"github.com/stretchr/testify/require"
@@ -41,4 +42,71 @@ func TestBanpACLAction(t *testing.T) {
 			require.Equal(t, tt.ret, ret)
 		})
 	}
+}
+
+func prepareBanpQueueTestController(t *testing.T) *Controller {
+	t.Helper()
+
+	fakeCtrl, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+
+	ctrl := fakeCtrl.fakeController
+	ctrl.addBanpQueue = newTypedRateLimitingQueue[string]("AddBaseAdminNetworkPolicy", nil)
+	ctrl.updateBanpQueue = newTypedRateLimitingQueue[*AdminNetworkPolicyChangedDelta]("UpdateBaseAdminNetworkPolicy", nil)
+	return ctrl
+}
+
+func newTestBanp(egressRuleName string, peerLabels map[string]string) *v1alpha1.BaselineAdminNetworkPolicy {
+	return &v1alpha1.BaselineAdminNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: v1alpha1.BaselineAdminNetworkPolicySpec{
+			Subject: v1alpha1.AdminNetworkPolicySubject{Namespaces: &metav1.LabelSelector{}},
+			Egress: []v1alpha1.BaselineAdminNetworkPolicyEgressRule{{
+				Name:   egressRuleName,
+				Action: v1alpha1.BaselineAdminNetworkPolicyRuleActionDeny,
+				To: []v1alpha1.BaselineAdminNetworkPolicyEgressPeer{{
+					Namespaces: &metav1.LabelSelector{MatchLabels: peerLabels},
+				}},
+			}},
+		},
+	}
+}
+
+// A renamed rule must be handled by the add queue: the rule name is part of the acl name and of the
+// address set name referenced by the acl match, so only recreating the acls keeps them consistent.
+func TestEnqueueUpdateBanpRuleRename(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renamed rule recreates acls via add queue", func(t *testing.T) {
+		ctrl := prepareBanpQueueTestController(t)
+		oldBanp := newTestBanp("old-rule", map[string]string{"app": "a"})
+		newBanp := newTestBanp("new-rule", map[string]string{"app": "a"})
+
+		ctrl.enqueueUpdateBanp(oldBanp, newBanp)
+
+		require.Equal(t, 1, ctrl.addBanpQueue.Len())
+		require.Zero(t, ctrl.updateBanpQueue.Len())
+	})
+
+	t.Run("renamed rule with peer change recreates acls via add queue", func(t *testing.T) {
+		ctrl := prepareBanpQueueTestController(t)
+		oldBanp := newTestBanp("old-rule", map[string]string{"app": "a"})
+		newBanp := newTestBanp("new-rule", map[string]string{"app": "b"})
+
+		ctrl.enqueueUpdateBanp(oldBanp, newBanp)
+
+		require.Equal(t, 1, ctrl.addBanpQueue.Len())
+		require.Zero(t, ctrl.updateBanpQueue.Len())
+	})
+
+	t.Run("peer change only goes through update queue", func(t *testing.T) {
+		ctrl := prepareBanpQueueTestController(t)
+		oldBanp := newTestBanp("rule", map[string]string{"app": "a"})
+		newBanp := newTestBanp("rule", map[string]string{"app": "b"})
+
+		ctrl.enqueueUpdateBanp(oldBanp, newBanp)
+
+		require.Zero(t, ctrl.addBanpQueue.Len())
+		require.Equal(t, 1, ctrl.updateBanpQueue.Len())
+	})
 }

--- a/pkg/controller/cluster_network_policy.go
+++ b/pkg/controller/cluster_network_policy.go
@@ -326,19 +326,6 @@ func (c *Controller) handleUpdateCnp(changed *ClusterNetworkPolicyChangedDelta) 
 					klog.Errorf("failed to set ingress address-set for cnp rule %s/%s, %v", cnpName, rule.Name, err)
 					return err
 				}
-
-				if changed.ruleNames[index].oldRuleName != "" {
-					oldRuleName := changed.ruleNames[index].oldRuleName
-					oldAsV4Name, oldAsV6Name := getAnpAddressSetName(pgName, oldRuleName, index, true)
-
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV4Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV4Name, err)
-						// just record error log
-					}
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV6Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV6Name, err)
-					}
-				}
 			}
 		}
 	}
@@ -361,19 +348,6 @@ func (c *Controller) handleUpdateCnp(changed *ClusterNetworkPolicyChangedDelta) 
 					if err := c.reconcileDNSNameResolversForANP(cnpName, getCnpDomainsNames(desiredCnp)); err != nil {
 						klog.Errorf("failed to reconcile DNSNameResolvers for egress rule %s/%s, %v", cnpName, rule.Name, err)
 						return err
-					}
-				}
-
-				if changed.ruleNames[index].oldRuleName != "" {
-					oldRuleName := changed.ruleNames[index].oldRuleName
-					oldAsV4Name, oldAsV6Name := getAnpAddressSetName(pgName, oldRuleName, index, false)
-
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV4Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV4Name, err)
-						// just record error log
-					}
-					if err := c.OVNNbClient.DeleteAddressSet(oldAsV6Name); err != nil {
-						klog.Errorf("failed to delete address set %s, %v", oldAsV6Name, err)
 					}
 				}
 			}
@@ -877,33 +851,28 @@ func shouldUpdateCnpPortGroup(oldCnp, newCnp *v1alpha2.ClusterNetworkPolicy) boo
 	return !reflect.DeepEqual(oldCnp.Spec.Subject, newCnp.Spec.Subject)
 }
 
-// getCnpAddressSetsToUpdate returns the ingress/egress address sets that need to be updated following a ClusterNetworkPolicy update
+// getCnpAddressSetsToUpdate returns the ingress/egress address sets that need to be updated following a ClusterNetworkPolicy update.
+// Rule renames are not handled here: they recreate the ACLs from scratch via shouldRecreateCnpACLs.
 func getCnpAddressSetsToUpdate(oldCnp, newCnp *v1alpha2.ClusterNetworkPolicy) (ingress, egress [util.CnpMaxRules]ChangedName) {
-	// Search through every ingress rule for changed names or changed selectors
+	// Search through every ingress rule for changed selectors
 	for index, rule := range newCnp.Spec.Ingress {
 		oldRule := oldCnp.Spec.Ingress[index]
 		change := ChangedName{}
 
-		if !reflect.DeepEqual(oldRule.From, rule.From) || oldRule.Name != rule.Name {
+		if !reflect.DeepEqual(oldRule.From, rule.From) {
 			change.curRuleName = rule.Name
-		}
-		if oldRule.Name != rule.Name {
-			change.oldRuleName = oldRule.Name
 		}
 
 		ingress[index] = change
 	}
 
-	// Search through every egress rule for changed names or changed selectors
+	// Search through every egress rule for changed selectors
 	for index, rule := range newCnp.Spec.Egress {
 		oldRule := oldCnp.Spec.Egress[index]
 		change := ChangedName{}
 
-		if !reflect.DeepEqual(oldRule.To, rule.To) || oldRule.Name != rule.Name {
+		if !reflect.DeepEqual(oldRule.To, rule.To) {
 			change.curRuleName = rule.Name
-		}
-		if oldRule.Name != rule.Name {
-			change.oldRuleName = oldRule.Name
 		}
 
 		egress[index] = change
@@ -930,18 +899,20 @@ func shouldRecreateCnpACLs(oldCnp, newCnp *v1alpha2.ClusterNetworkPolicy) bool {
 		return true
 	}
 
-	// ACLs must be re-created if ingress rules action or ports have changed
+	// ACLs must be re-created if ingress rules name, action or ports have changed.
+	// The rule name is part of both the acl name and the address set name referenced by the acl match,
+	// so a renamed rule requires the acls to be recreated together with the address sets.
 	for index, rule := range newCnp.Spec.Ingress {
 		oldRule := oldCnp.Spec.Ingress[index]
-		if oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
+		if oldRule.Name != rule.Name || oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
 			return true
 		}
 	}
 
-	// ACLs must be re-created if egress rules action or ports have changed
+	// ACLs must be re-created if egress rules name, action or ports have changed
 	for index, rule := range newCnp.Spec.Egress {
 		oldRule := oldCnp.Spec.Egress[index]
-		if oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
+		if oldRule.Name != rule.Name || oldRule.Action != rule.Action || !reflect.DeepEqual(oldRule.Ports, rule.Ports) {
 			return true
 		}
 	}

--- a/pkg/controller/cluster_network_policy_test.go
+++ b/pkg/controller/cluster_network_policy_test.go
@@ -170,6 +170,8 @@ func TestGetCnpAddressSetsToUpdate(t *testing.T) {
 			egress:  false,
 		},
 		{
+			// A renamed rule is handled by recreating the ACLs (see shouldRecreateCnpACLs),
+			// not by the address set update path.
 			name: "changed ingress name",
 			oldCnp: &v1alpha2.ClusterNetworkPolicy{
 				Spec: v1alpha2.ClusterNetworkPolicySpec{
@@ -198,7 +200,7 @@ func TestGetCnpAddressSetsToUpdate(t *testing.T) {
 								{
 									Namespaces: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"label2": "value",
+											"label1": "value",
 										},
 									},
 								},
@@ -207,7 +209,7 @@ func TestGetCnpAddressSetsToUpdate(t *testing.T) {
 					},
 				},
 			},
-			ingress: true,
+			ingress: false,
 			egress:  false,
 		},
 		{
@@ -252,6 +254,8 @@ func TestGetCnpAddressSetsToUpdate(t *testing.T) {
 			egress:  true,
 		},
 		{
+			// A renamed rule is handled by recreating the ACLs (see shouldRecreateCnpACLs),
+			// not by the address set update path.
 			name: "changed egress name",
 			oldCnp: &v1alpha2.ClusterNetworkPolicy{
 				Spec: v1alpha2.ClusterNetworkPolicySpec{
@@ -280,7 +284,7 @@ func TestGetCnpAddressSetsToUpdate(t *testing.T) {
 								{
 									Namespaces: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"label2": "value",
+											"label1": "value",
 										},
 									},
 								},
@@ -290,7 +294,7 @@ func TestGetCnpAddressSetsToUpdate(t *testing.T) {
 				},
 			},
 			ingress: false,
-			egress:  true,
+			egress:  false,
 		},
 		{
 			name: "changed ingress/egress",
@@ -483,6 +487,52 @@ func TestShouldRecreateCnpACLs(t *testing.T) {
 						{
 							Name:   "test2",
 							Action: "test2",
+						},
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			// The rule name is part of the acl name and of the address set name referenced by
+			// the acl match, so a renamed rule must recreate the acls.
+			name: "ingress rule renamed",
+			oldCnp: &v1alpha2.ClusterNetworkPolicy{
+				Spec: v1alpha2.ClusterNetworkPolicySpec{
+					Ingress: []v1alpha2.ClusterNetworkPolicyIngressRule{
+						{
+							Name: "old-name",
+						},
+					},
+				},
+			},
+			newCnp: &v1alpha2.ClusterNetworkPolicy{
+				Spec: v1alpha2.ClusterNetworkPolicySpec{
+					Ingress: []v1alpha2.ClusterNetworkPolicyIngressRule{
+						{
+							Name: "new-name",
+						},
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			name: "egress rule renamed",
+			oldCnp: &v1alpha2.ClusterNetworkPolicy{
+				Spec: v1alpha2.ClusterNetworkPolicySpec{
+					Egress: []v1alpha2.ClusterNetworkPolicyEgressRule{
+						{
+							Name: "old-name",
+						},
+					},
+				},
+			},
+			newCnp: &v1alpha2.ClusterNetworkPolicy{
+				Spec: v1alpha2.ClusterNetworkPolicySpec{
+					Egress: []v1alpha2.ClusterNetworkPolicyEgressRule{
+						{
+							Name: "new-name",
 						},
 					},
 				},


### PR DESCRIPTION
## Problem

The rule name is embedded in both the ACL name and the address set name referenced by the ACL match (`getAnpAddressSetName`). The update fast path (`handleUpdateAnp`/`handleUpdateBanp`/`handleUpdateCnp`) only rebuilds address sets and never touches ACLs, so renaming a rule breaks the link between them:

1. **Rename only**: the update path created the new-name address set and deleted the old-name one, but the ACL match still referenced the deleted set. OVN treats a reference to a nonexistent `$as` as an empty set, so the rule matched nothing — a Deny rule failed open, an Allow rule dropped traffic it should admit.
2. **Rename + peer change in one update**: in `enqueueUpdateAnp`/`enqueueUpdateBanp`/`getCnpAddressSetsToUpdate`, the peer-change delta assignment overwrote the rename delta for the same rule index and lost `oldRuleName`. The old address set leaked in OVN NB with the stale peer addresses, and the ACL kept matching on it — the new peers silently never took effect.

Both states persisted until something triggered the full-rebuild path (priority/rule-count/action/ports change, or a controller restart).

## Fix

Treat a rule rename like an action/ports change: enqueue the policy to the add queue, whose full rebuild already deletes the direction's ACLs, recreates them against the current-name address sets, and diff-cleans unused address sets (`deleteUnusedAddrSetForAnp`). The update fast path now only handles peer-selector changes, and the `oldRuleName` plumbing (delta field + per-index delete branches in all three consumers) is removed.

Same fix applied to ANP, BANP, and CNP.

## Tests

- New `TestEnqueueUpdateAnpRuleRename` / `TestEnqueueUpdateBanpRuleRename`: rename (with and without a simultaneous peer change) goes through the add queue; a pure peer change still uses the update queue.
- `TestShouldRecreateCnpACLs`: new "rule renamed" cases assert the recreate path.
- `TestGetCnpAddressSetsToUpdate`: the "changed name" cases now assert renames are not handled by the address set update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)