### PR TITLE
feature(metallb): internal underlay pod traffic to LB service VIP node

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -4053,7 +4053,7 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          n_worker=2 make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         id: install

--- a/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
+++ b/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
@@ -167,6 +167,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - metallb.io
+    resources:
+      - servicel2statuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - statefulsets

--- a/charts/kube-ovn/templates/ovn-CR.yaml
+++ b/charts/kube-ovn/templates/ovn-CR.yaml
@@ -174,6 +174,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - metallb.io
+    resources:
+      - servicel2statuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - statefulsets

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -7227,6 +7227,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - metallb.io
+    resources:
+      - servicel2statuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - statefulsets

--- a/dist/images/patches/9286e1fd578fdb8f565a0f4aa9066b538295e1ac.patch
+++ b/dist/images/patches/9286e1fd578fdb8f565a0f4aa9066b538295e1ac.patch
@@ -5,14 +5,15 @@ Subject: [PATCH] add select local lb backend
 
 Signed-off-by: clyi <clyi@alauda.io>
 ---
- northd/lb.c     |  34 +++++++++++
- northd/lb.h     |   1 +
- northd/northd.c | 146 +++++++++++++++++++++++++++++++++++++++++++++---
- northd/northd.h |  10 ++++
- 4 files changed, 184 insertions(+), 7 deletions(-)
+ northd/lb.c         |  34 ++++++++
+ northd/lb.h         |   1 +
+ northd/northd.c     | 238 ++++++++++++++++++++++++++++++++++++++++++++++++++--
+ northd/northd.h     |  10 +++
+ northd/ovn-northd.c |   1 -
+ 5 files changed, 276 insertions(+), 8 deletions(-)
 
 diff --git a/northd/lb.c b/northd/lb.c
-index ef92249ce..f64a64cff 100644
+index ef92249..f64a64c 100644
 --- a/northd/lb.c
 +++ b/northd/lb.c
 @@ -150,6 +150,36 @@ ovn_lb_vip_backends_health_check_init(const struct ovn_northd_lb *lb,
@@ -71,7 +72,7 @@ index ef92249ce..f64a64cff 100644
      }
  
 diff --git a/northd/lb.h b/northd/lb.h
-index 4696b4d98..4aa9e665f 100644
+index 4696b4d..4aa9e66 100644
 --- a/northd/lb.h
 +++ b/northd/lb.h
 @@ -65,6 +65,7 @@ struct ovn_northd_lb {
@@ -83,10 +84,10 @@ index 4696b4d98..4aa9e665f 100644
  
      struct sset ips_v4;
 diff --git a/northd/northd.c b/northd/northd.c
-index 7e8616df0..31fb61c10 100644
+index df18d72..1a72fcd 100644
 --- a/northd/northd.c
 +++ b/northd/northd.c
-@@ -3748,7 +3748,9 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
+@@ -3761,7 +3761,9 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
                       struct ds *skip_snat_action,
                       struct ds *force_snat_action,
                       bool ls_dp,
@@ -97,7 +98,7 @@ index 7e8616df0..31fb61c10 100644
  {
      bool reject = !lb_vip->n_backends && lb_vip->empty_backend_rej;
      bool drop = !lb_vip->n_backends && !lb_vip->empty_backend_rej;
-@@ -3772,6 +3774,12 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
+@@ -3785,6 +3787,12 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
              struct ovn_northd_lb_backend *backend_nb =
                  &lb_vip_nb->backends_nb[i];
  
@@ -110,7 +111,7 @@ index 7e8616df0..31fb61c10 100644
              if (!backend_nb->health_check) {
                  continue;
              }
-@@ -3805,8 +3813,11 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
+@@ -3818,8 +3826,11 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
          drop = !n_active_backends && !lb_vip->empty_backend_rej;
          reject = !n_active_backends && lb_vip->empty_backend_rej;
      } else {
@@ -124,7 +125,53 @@ index 7e8616df0..31fb61c10 100644
      }
  
      if (reject) {
-@@ -8234,7 +8245,8 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
+@@ -8425,9 +8436,54 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
++static void
++build_underlay_vip_backend_l2_lookup_flows(
++    struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
++    const struct ovn_lb_vip *lb_vip,
++    const struct ovn_northd_lb_vip *lb_vip_nb,
++    const struct chassis_lp_entry *vip_node_entry,
++    const char *vip_node_lsp, const struct hmap *ls_ports,
++    struct ds *match, struct ds *action)
++{
++    const char *ip_match =
++        lb_vip->address_family == AF_INET ? "ip4" : "ip6";
++
++    for (size_t i = 0; i < lb_vip->n_backends; i++) {
++        const struct ovn_lb_backend *backend = &lb_vip->backends[i];
++        const struct ovn_northd_lb_backend *backend_nb =
++            &lb_vip_nb->backends_nb[i];
++        if (!backend_nb->logical_port) {
++            continue;
++        }
++
++        struct ovn_port *op = ovn_port_find(ls_ports,
++                                            backend_nb->logical_port);
++        if (!op || !op->od || !op->nbsp || !op->sb ||
++            op->sb->chassis != vip_node_entry->chassis ||
++            !op->od->n_router_ports || !op->od->n_localnet_ports ||
++            op->n_lsp_addrs != 1 || !strlen(op->lsp_addrs[0].ea_s)) {
++            continue;
++        }
++
++        ds_clear(match);
++        ds_put_format(match,
++                      REGBIT_CONNTRACK_NAT" != 0 && %s.dst == %s && "
++                      "is_chassis_resident(\"%s\")",
++                      ip_match, backend->ip_str, vip_node_lsp);
++        ds_clear(action);
++        ds_put_format(action, "eth.dst = %s; outport = \"%s\"; output;",
++                      op->lsp_addrs[0].ea_s, op->key);
++        ovn_lflow_add_with_hint(lflows, op->od, S_SWITCH_IN_L2_LKUP, 55,
++                                ds_cstr(match), ds_cstr(action),
++                                &lb_dps->lb->nlb->header_,
++                                lb_dps->lflow_ref);
++    }
++}
++
+ static void
+ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
                 const struct ovn_datapaths *ls_datapaths,
                 struct ds *match, struct ds *action,
                 const struct shash *meter_groups,
@@ -134,7 +181,7 @@ index 7e8616df0..31fb61c10 100644
  {
      const struct ovn_northd_lb *lb = lb_dps->lb;
      for (size_t i = 0; i < lb->n_vips; i++) {
-@@ -8245,13 +8257,129 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
+@@ -8438,13 +8494,177 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
  
          ds_clear(action);
          ds_clear(match);
@@ -179,7 +226,49 @@ index 7e8616df0..31fb61c10 100644
 +            }
 +
 +            struct chassis_lp_entry *entry = NULL;
++            struct chassis_lp_entry *vip_node_entry = NULL;
++            const char *vip_node_lsp = NULL;
++            if (lb_vip->port_str) {
++                char *vip_key = xasprintf(
++                    IN6_IS_ADDR_V4MAPPED(&lb_vip->vip)
++                    ? "kube-ovn.io/local-external-vip/%s:%s"
++                    : "kube-ovn.io/local-external-vip/[%s]:%s",
++                    lb_vip->vip_str, lb_vip->port_str);
++                vip_node_lsp = smap_get(&lb->nlb->external_ids, vip_key);
++                free(vip_key);
++            }
++            if (vip_node_lsp) {
++                struct ovn_port *vip_node_op = ovn_port_find(ls_ports,
++                                                              vip_node_lsp);
++                if (vip_node_op && vip_node_op->sb &&
++                    vip_node_op->sb->chassis) {
++                    HMAP_FOR_EACH_WITH_HASH (
++                        entry, hmap_node,
++                        hash_string(vip_node_op->sb->chassis->name, 0),
++                        &chassis_lsp_map) {
++                        if (entry->chassis == vip_node_op->sb->chassis) {
++                            vip_node_entry = entry;
++                            break;
++                        }
++                    }
++                }
++            }
++            if (vip_node_entry) {
++                build_underlay_vip_backend_l2_lookup_flows(
++                    lflows, lb_dps, lb_vip, lb_vip_nb, vip_node_entry,
++                    vip_node_lsp, ls_ports, match, action);
++
++                ds_clear(match);
++                ds_put_format(match, "ct.new && %s.dst == %s && %s.dst == %s",
++                              ip_match, lb_vip->vip_str, lb->proto, lb_vip->port_str);
++                ovn_lflow_add_with_dp_group(lflows, lb_dps->nb_ls_map,
++                    ods_size(ls_datapaths), S_SWITCH_IN_LB, 139, ds_cstr(match), "next;",
++                    &lb->nlb->header_, lb_dps->lflow_ref);
++            }
 +            HMAP_FOR_EACH (entry, hmap_node, &chassis_lsp_map) {
++                if (vip_node_entry && entry != vip_node_entry) {
++                    continue;
++                }
 +                ds_clear(match);
 +                ds_clear(action);
 +
@@ -200,8 +289,14 @@ index 7e8616df0..31fb61c10 100644
 +                                lb_vip->port_str);
 +                    priority = 140;
 +                }
-+                ds_put_format(match, " && is_chassis_resident(\"%s\")",
-+                        entry->lp_array[0]->key);
++
++                if (vip_node_entry) {
++                    ds_put_format(match, " && is_chassis_resident(\"%s\")",
++                                  vip_node_lsp);
++                } else {
++                    ds_put_format(match, " && is_chassis_resident(\"%s\")",
++                            entry->lp_array[0]->key);
++                }
 +
 +                build_lb_affinity_ls_flows(lflows, lb_dps, lb_vip, ls_datapaths,
 +                                        lb_dps->lflow_ref);
@@ -265,7 +360,7 @@ index 7e8616df0..31fb61c10 100644
  
          ds_put_format(match, "ct.new && %s.dst == %s", ip_match,
                        lb_vip->vip_str);
-@@ -12329,7 +12457,7 @@ build_lrouter_nat_flows_for_lb(
+@@ -12725,7 +12945,7 @@ build_lrouter_nat_flows_for_lb(
      bool reject = build_lb_vip_actions(lb, lb_vip, vips_nb, action,
                                         lb->selection_fields, &skip_snat_act,
                                         &force_snat_act, false,
@@ -274,7 +369,7 @@ index 7e8616df0..31fb61c10 100644
  
      /* Higher priority rules are added for load-balancing in DNAT
       * table.  For every match (on a VIP[:port]), we add two flows.
-@@ -12486,6 +12614,7 @@ build_lswitch_flows_for_lb(struct ovn_lb_datapaths *lb_dps,
+@@ -12882,6 +13102,7 @@ build_lswitch_flows_for_lb(struct ovn_lb_datapaths *lb_dps,
                             const struct shash *meter_groups,
                             const struct ovn_datapaths *ls_datapaths,
                             const struct hmap *svc_monitor_map,
@@ -282,7 +377,7 @@ index 7e8616df0..31fb61c10 100644
                             struct ds *match, struct ds *action)
  {
      if (!lb_dps->n_nb_ls) {
-@@ -12529,7 +12658,7 @@ build_lswitch_flows_for_lb(struct ovn_lb_datapaths *lb_dps,
+@@ -12925,7 +13146,7 @@ build_lswitch_flows_for_lb(struct ovn_lb_datapaths *lb_dps,
       * REGBIT_CONNTRACK_COMMIT. */
      build_lb_rules_pre_stateful(lflows, lb_dps, ls_datapaths, match, action);
      build_lb_rules(lflows, lb_dps, ls_datapaths, match, action,
@@ -291,7 +386,7 @@ index 7e8616df0..31fb61c10 100644
  }
  
  static void
-@@ -18042,6 +18171,7 @@ build_lflows_thread(void *arg)
+@@ -18560,6 +18781,7 @@ build_lflows_thread(void *arg)
                                                 lsi->meter_groups,
                                                 lsi->ls_datapaths,
                                                 lsi->svc_monitor_map,
@@ -299,7 +394,7 @@ index 7e8616df0..31fb61c10 100644
                                                 &lsi->match, &lsi->actions);
                  }
              }
-@@ -18276,6 +18406,7 @@ build_lswitch_and_lrouter_flows(
+@@ -18794,6 +19016,7 @@ build_lswitch_and_lrouter_flows(
              build_lswitch_flows_for_lb(lb_dps, lsi.lflows, lsi.meter_groups,
                                         lsi.ls_datapaths,
                                         lsi.svc_monitor_map,
@@ -307,7 +402,7 @@ index 7e8616df0..31fb61c10 100644
                                         &lsi.match, &lsi.actions);
          }
          stopwatch_stop(LFLOWS_LBS_STOPWATCH_NAME, time_msec());
-@@ -18645,6 +18776,7 @@ lflow_handle_northd_lb_changes(struct ovsdb_idl_txn *ovnsb_txn,
+@@ -19126,6 +19349,7 @@ lflow_handle_northd_lb_changes(struct ovsdb_idl_txn *ovnsb_txn,
                                     lflow_input->meter_groups,
                                     lflow_input->ls_datapaths,
                                     lflow_input->svc_monitor_map,
@@ -316,10 +411,10 @@ index 7e8616df0..31fb61c10 100644
  
          ds_destroy(&match);
 diff --git a/northd/northd.h b/northd/northd.h
-index ba86ac5c9..855f5908a 100644
+index 30f9ca3..c1f0b83 100644
 --- a/northd/northd.h
 +++ b/northd/northd.h
-@@ -813,6 +813,16 @@ find_route_outport(const struct hmap *lr_ports, const char *output_port,
+@@ -818,6 +818,16 @@ find_route_outport(const struct hmap *lr_ports, const char *output_port,
                     bool force_out_port,
                     struct ovn_port **out_port, const char **lrp_addr_s);
  
@@ -336,6 +431,17 @@ index ba86ac5c9..855f5908a 100644
  void ovnnb_db_run(struct northd_input *input_data,
                    struct northd_data *data,
                    struct ovsdb_idl_txn *ovnnb_txn,
+diff --git a/northd/ovn-northd.c b/northd/ovn-northd.c
+index 5eb2c4b..05143f9 100644
+--- a/northd/ovn-northd.c
++++ b/northd/ovn-northd.c
+@@ -898,7 +898,6 @@ main(int argc, char *argv[])
+         &nbrec_gateway_chassis_col_external_ids,
+         &nbrec_ha_chassis_col_external_ids,
+         &nbrec_ha_chassis_group_col_external_ids,
+-        &nbrec_load_balancer_col_external_ids,
+         &nbrec_load_balancer_health_check_col_external_ids,
+         &nbrec_logical_router_policy_col_external_ids,
+         &nbrec_logical_router_static_route_col_external_ids,
 -- 
 2.34.1
-

--- a/dist/images/patches/9286e1fd578fdb8f565a0f4aa9066b538295e1ac.patch
+++ b/dist/images/patches/9286e1fd578fdb8f565a0f4aa9066b538295e1ac.patch
@@ -1,16 +1,16 @@
-From fe95c6134f3827adf6017a95c8b8ec2a01a77902 Mon Sep 17 00:00:00 2001
+From 76e93c074afb2cc489ba4ba5e870b8bc6e3c9296 Mon Sep 17 00:00:00 2001
 From: clyi <clyi@alauda.io>
-Date: Thu, 22 Jan 2026 10:41:30 +0800
+Date: Sat, 25 Jul 2026 16:11:59 +0800
 Subject: [PATCH] add select local lb backend
 
 Signed-off-by: clyi <clyi@alauda.io>
 ---
- northd/lb.c         |  34 ++++++++
+ northd/lb.c         |  34 ++++++
  northd/lb.h         |   1 +
- northd/northd.c     | 238 ++++++++++++++++++++++++++++++++++++++++++++++++++--
- northd/northd.h     |  10 +++
+ northd/northd.c     | 280 ++++++++++++++++++++++++++++++++++++++++++--
+ northd/northd.h     |  10 ++
  northd/ovn-northd.c |   1 -
- 5 files changed, 276 insertions(+), 8 deletions(-)
+ 5 files changed, 315 insertions(+), 11 deletions(-)
 
 diff --git a/northd/lb.c b/northd/lb.c
 index ef92249..f64a64c 100644
@@ -84,7 +84,7 @@ index 4696b4d..4aa9e66 100644
  
      struct sset ips_v4;
 diff --git a/northd/northd.c b/northd/northd.c
-index df18d72..1a72fcd 100644
+index df18d72..e1138f6 100644
 --- a/northd/northd.c
 +++ b/northd/northd.c
 @@ -3761,7 +3761,9 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
@@ -98,12 +98,14 @@ index df18d72..1a72fcd 100644
  {
      bool reject = !lb_vip->n_backends && lb_vip->empty_backend_rej;
      bool drop = !lb_vip->n_backends && !lb_vip->empty_backend_rej;
-@@ -3785,6 +3787,12 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
+@@ -3785,6 +3787,14 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
              struct ovn_northd_lb_backend *backend_nb =
                  &lb_vip_nb->backends_nb[i];
  
 +            if (chassis_logical_ports) {
-+                if (!sset_contains(chassis_logical_ports, backend_nb->logical_port)) {
++                if (!backend_nb->logical_port ||
++                    !sset_contains(chassis_logical_ports,
++                                   backend_nb->logical_port)) {
 +                    continue;
 +                }
 +            }
@@ -111,7 +113,7 @@ index df18d72..1a72fcd 100644
              if (!backend_nb->health_check) {
                  continue;
              }
-@@ -3818,8 +3826,11 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
+@@ -3818,8 +3828,11 @@ build_lb_vip_actions(const struct ovn_northd_lb *lb,
          drop = !n_active_backends && !lb_vip->empty_backend_rej;
          reject = !n_active_backends && lb_vip->empty_backend_rej;
      } else {
@@ -125,7 +127,62 @@ index df18d72..1a72fcd 100644
      }
  
      if (reject) {
-@@ -8425,9 +8436,54 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
+@@ -8268,8 +8281,11 @@ static void
+ build_lb_affinity_ls_flows(struct lflow_table *lflows,
+                            struct ovn_lb_datapaths *lb_dps,
+                            struct ovn_lb_vip *lb_vip,
++                           const struct ovn_northd_lb_vip *lb_vip_nb,
+                            const struct ovn_datapaths *ls_datapaths,
+-                           struct lflow_ref *lflow_ref)
++                           struct lflow_ref *lflow_ref,
++                           const struct sset *logical_ports,
++                           const char *resident_lsp)
+ {
+     if (!lb_dps->lb->affinity_timeout || !lb_dps->n_nb_ls) {
+         return;
+@@ -8288,6 +8304,10 @@ build_lb_affinity_ls_flows(struct lflow_table *lflows,
+         ds_put_format(&new_lb_match, " && %s && %s.dst == %s",
+                       lb->proto, lb->proto, lb_vip->port_str);
+     }
++    if (resident_lsp) {
++        ds_put_format(&new_lb_match, " && is_chassis_resident(\"%s\")",
++                      resident_lsp);
++    }
+ 
+     static char *aff_check = REGBIT_KNOWN_LB_SESSION" = chk_lb_aff(); next;";
+ 
+@@ -8344,6 +8364,14 @@ build_lb_affinity_ls_flows(struct lflow_table *lflows,
+ 
+     for (size_t i = 0; i < lb_vip->n_backends; i++) {
+         struct ovn_lb_backend *backend = &lb_vip->backends[i];
++        if (logical_ports && lb_vip_nb) {
++            struct ovn_northd_lb_backend *backend_nb =
++                &lb_vip_nb->backends_nb[i];
++            if (!backend_nb->logical_port ||
++                !sset_contains(logical_ports, backend_nb->logical_port)) {
++                continue;
++            }
++        }
+ 
+         ds_put_cstr(&aff_match_learn, backend->ip_str);
+         ds_put_cstr(&aff_match, backend->ip_str);
+@@ -8369,6 +8397,12 @@ build_lb_affinity_ls_flows(struct lflow_table *lflows,
+         if (lb_vip->port_str) {
+             ds_put_format(&aff_action_learn, ", proto = %s", lb->proto);
+         }
++        if (resident_lsp) {
++            ds_put_format(&aff_match_learn, " && is_chassis_resident(\"%s\")",
++                          resident_lsp);
++            ds_put_format(&aff_match, " && is_chassis_resident(\"%s\")",
++                          resident_lsp);
++        }
+ 
+         ds_put_format(&aff_action_learn, ", timeout = %d); /* drop */",
+                       lb->affinity_timeout);
+@@ -8422,12 +8456,57 @@ build_lrouter_lb_affinity_default_flows(struct ovn_datapath *od,
+                   lflow_ref);
+ }
+ 
 +static void
 +build_underlay_vip_backend_l2_lookup_flows(
 +    struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
@@ -181,10 +238,11 @@ index df18d72..1a72fcd 100644
  {
      const struct ovn_northd_lb *lb = lb_dps->lb;
      for (size_t i = 0; i < lb->n_vips; i++) {
-@@ -8438,13 +8494,177 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
+@@ -8438,13 +8517,187 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
  
          ds_clear(action);
          ds_clear(match);
++        const char *vip_node_lsp = NULL;
 +        if (lb->prefer_local_backend) {
 +            struct hmap chassis_lsp_map;
 +            hmap_init(&chassis_lsp_map);
@@ -199,7 +257,13 @@ index df18d72..1a72fcd 100644
 +                if (!op || !op->sb || !op->sb->chassis) {
 +                    continue;
 +                }
-+                struct chassis_lp_entry *entry = (struct chassis_lp_entry *)hmap_first_with_hash(&chassis_lsp_map, hash_string(op->sb->chassis->name, 0));
++                struct chassis_lp_entry *entry = NULL;
++                HMAP_FOR_EACH_WITH_HASH (entry, hmap_node,
++                    hash_string(op->sb->chassis->name, 0), &chassis_lsp_map) {
++                    if (entry->chassis == op->sb->chassis) {
++                        break;
++                    }
++                }
 +                if (!entry) {
 +                    entry = xmalloc(sizeof *entry);
 +                    entry->chassis = op->sb->chassis;
@@ -227,7 +291,6 @@ index df18d72..1a72fcd 100644
 +
 +            struct chassis_lp_entry *entry = NULL;
 +            struct chassis_lp_entry *vip_node_entry = NULL;
-+            const char *vip_node_lsp = NULL;
 +            if (lb_vip->port_str) {
 +                char *vip_key = xasprintf(
 +                    IN6_IS_ADDR_V4MAPPED(&lb_vip->vip)
@@ -253,11 +316,7 @@ index df18d72..1a72fcd 100644
 +                    }
 +                }
 +            }
-+            if (vip_node_entry) {
-+                build_underlay_vip_backend_l2_lookup_flows(
-+                    lflows, lb_dps, lb_vip, lb_vip_nb, vip_node_entry,
-+                    vip_node_lsp, ls_ports, match, action);
-+
++            if (vip_node_lsp) {
 +                ds_clear(match);
 +                ds_put_format(match, "ct.new && %s.dst == %s && %s.dst == %s",
 +                              ip_match, lb_vip->vip_str, lb->proto, lb_vip->port_str);
@@ -265,8 +324,14 @@ index df18d72..1a72fcd 100644
 +                    ods_size(ls_datapaths), S_SWITCH_IN_LB, 139, ds_cstr(match), "next;",
 +                    &lb->nlb->header_, lb_dps->lflow_ref);
 +            }
++            if (vip_node_entry) {
++                build_underlay_vip_backend_l2_lookup_flows(
++                    lflows, lb_dps, lb_vip, lb_vip_nb, vip_node_entry,
++                    vip_node_lsp, ls_ports, match, action);
++            }
 +            HMAP_FOR_EACH (entry, hmap_node, &chassis_lsp_map) {
-+                if (vip_node_entry && entry != vip_node_entry) {
++                if (vip_node_lsp &&
++                    (!vip_node_entry || entry != vip_node_entry)) {
 +                    continue;
 +                }
 +                ds_clear(match);
@@ -298,8 +363,10 @@ index df18d72..1a72fcd 100644
 +                            entry->lp_array[0]->key);
 +                }
 +
-+                build_lb_affinity_ls_flows(lflows, lb_dps, lb_vip, ls_datapaths,
-+                                        lb_dps->lflow_ref);
++                build_lb_affinity_ls_flows(lflows, lb_dps, lb_vip, lb_vip_nb,
++                                           ls_datapaths, lb_dps->lflow_ref,
++                                           &entry->logical_ports,
++                                           vip_node_entry ? vip_node_lsp : NULL);
 +
 +                unsigned long *dp_non_meter = NULL;
 +                bool build_non_meter = false;
@@ -360,7 +427,21 @@ index df18d72..1a72fcd 100644
  
          ds_put_format(match, "ct.new && %s.dst == %s", ip_match,
                        lb_vip->vip_str);
-@@ -12725,7 +12945,7 @@ build_lrouter_nat_flows_for_lb(
+@@ -8455,8 +8708,11 @@ build_lb_rules(struct lflow_table *lflows, struct ovn_lb_datapaths *lb_dps,
+             priority = 120;
+         }
+ 
+-        build_lb_affinity_ls_flows(lflows, lb_dps, lb_vip, ls_datapaths,
+-                                   lb_dps->lflow_ref);
++        if (!vip_node_lsp) {
++            build_lb_affinity_ls_flows(lflows, lb_dps, lb_vip, lb_vip_nb,
++                                       ls_datapaths, lb_dps->lflow_ref, NULL,
++                                       NULL);
++        }
+ 
+         unsigned long *dp_non_meter = NULL;
+         bool build_non_meter = false;
+@@ -12725,7 +12981,7 @@ build_lrouter_nat_flows_for_lb(
      bool reject = build_lb_vip_actions(lb, lb_vip, vips_nb, action,
                                         lb->selection_fields, &skip_snat_act,
                                         &force_snat_act, false,
@@ -369,7 +450,7 @@ index df18d72..1a72fcd 100644
  
      /* Higher priority rules are added for load-balancing in DNAT
       * table.  For every match (on a VIP[:port]), we add two flows.
-@@ -12882,6 +13102,7 @@ build_lswitch_flows_for_lb(struct ovn_lb_datapaths *lb_dps,
+@@ -12882,6 +13138,7 @@ build_lswitch_flows_for_lb(struct ovn_lb_datapaths *lb_dps,
                             const struct shash *meter_groups,
                             const struct ovn_datapaths *ls_datapaths,
                             const struct hmap *svc_monitor_map,
@@ -377,7 +458,7 @@ index df18d72..1a72fcd 100644
                             struct ds *match, struct ds *action)
  {
      if (!lb_dps->n_nb_ls) {
-@@ -12925,7 +13146,7 @@ build_lswitch_flows_for_lb(struct ovn_lb_datapaths *lb_dps,
+@@ -12925,7 +13182,7 @@ build_lswitch_flows_for_lb(struct ovn_lb_datapaths *lb_dps,
       * REGBIT_CONNTRACK_COMMIT. */
      build_lb_rules_pre_stateful(lflows, lb_dps, ls_datapaths, match, action);
      build_lb_rules(lflows, lb_dps, ls_datapaths, match, action,
@@ -386,7 +467,7 @@ index df18d72..1a72fcd 100644
  }
  
  static void
-@@ -18560,6 +18781,7 @@ build_lflows_thread(void *arg)
+@@ -18560,6 +18817,7 @@ build_lflows_thread(void *arg)
                                                 lsi->meter_groups,
                                                 lsi->ls_datapaths,
                                                 lsi->svc_monitor_map,
@@ -394,7 +475,7 @@ index df18d72..1a72fcd 100644
                                                 &lsi->match, &lsi->actions);
                  }
              }
-@@ -18794,6 +19016,7 @@ build_lswitch_and_lrouter_flows(
+@@ -18794,6 +19052,7 @@ build_lswitch_and_lrouter_flows(
              build_lswitch_flows_for_lb(lb_dps, lsi.lflows, lsi.meter_groups,
                                         lsi.ls_datapaths,
                                         lsi.svc_monitor_map,
@@ -402,7 +483,7 @@ index df18d72..1a72fcd 100644
                                         &lsi.match, &lsi.actions);
          }
          stopwatch_stop(LFLOWS_LBS_STOPWATCH_NAME, time_msec());
-@@ -19126,6 +19349,7 @@ lflow_handle_northd_lb_changes(struct ovsdb_idl_txn *ovnsb_txn,
+@@ -19126,6 +19385,7 @@ lflow_handle_northd_lb_changes(struct ovsdb_idl_txn *ovnsb_txn,
                                     lflow_input->meter_groups,
                                     lflow_input->ls_datapaths,
                                     lflow_input->svc_monitor_map,
@@ -445,3 +526,4 @@ index 5eb2c4b..05143f9 100644
          &nbrec_logical_router_static_route_col_external_ids,
 -- 
 2.34.1
+

--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -354,6 +354,9 @@ kube-ovn-connectivity-e2e:
 
 .PHONY: kube-ovn-underlay-metallb-e2e
 kube-ovn-underlay-metallb-e2e:
+	kubectl -n kube-system get configmap kube-proxy -o json | jq '.data["config.conf"] |= sub("strictARP: false"; "strictARP: true")' | kubectl apply -f -
+	kubectl -n kube-system rollout restart daemonset/kube-proxy
+	kubectl -n kube-system rollout status daemonset/kube-proxy --timeout=180s
 	$(call kind_load_image,kube-ovn,$(AGNHOST_IMAGE),1)
 	$(GINKGO_E2E_BUILD) ./test/e2e/metallb
 	E2E_BRANCH=$(E2E_BRANCH) \

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -1772,6 +1772,20 @@ func (mr *MockLoadBalancerMockRecorder) SetLoadBalancerPreferLocalBackend(lbName
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerPreferLocalBackend", reflect.TypeOf((*MockLoadBalancer)(nil).SetLoadBalancerPreferLocalBackend), lbName, preferLocalBackend)
 }
 
+// SetLoadBalancerVIPExternalTrafficLocal mocks base method.
+func (m *MockLoadBalancer) SetLoadBalancerVIPExternalTrafficLocal(lbName, vip, vipNodeLSP string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLoadBalancerVIPExternalTrafficLocal", lbName, vip, vipNodeLSP)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLoadBalancerVIPExternalTrafficLocal indicates an expected call of SetLoadBalancerVIPExternalTrafficLocal.
+func (mr *MockLoadBalancerMockRecorder) SetLoadBalancerVIPExternalTrafficLocal(lbName, vip, vipNodeLSP any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerVIPExternalTrafficLocal", reflect.TypeOf((*MockLoadBalancer)(nil).SetLoadBalancerVIPExternalTrafficLocal), lbName, vip, vipNodeLSP)
+}
+
 // MockLoadBalancerHealthCheck is a mock of LoadBalancerHealthCheck interface.
 type MockLoadBalancerHealthCheck struct {
 	ctrl     *gomock.Controller
@@ -5434,6 +5448,20 @@ func (m *MockNbClient) SetLoadBalancerPreferLocalBackend(lbName string, preferLo
 func (mr *MockNbClientMockRecorder) SetLoadBalancerPreferLocalBackend(lbName, preferLocalBackend any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerPreferLocalBackend", reflect.TypeOf((*MockNbClient)(nil).SetLoadBalancerPreferLocalBackend), lbName, preferLocalBackend)
+}
+
+// SetLoadBalancerVIPExternalTrafficLocal mocks base method.
+func (m *MockNbClient) SetLoadBalancerVIPExternalTrafficLocal(lbName, vip, vipNodeLSP string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLoadBalancerVIPExternalTrafficLocal", lbName, vip, vipNodeLSP)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLoadBalancerVIPExternalTrafficLocal indicates an expected call of SetLoadBalancerVIPExternalTrafficLocal.
+func (mr *MockNbClientMockRecorder) SetLoadBalancerVIPExternalTrafficLocal(lbName, vip, vipNodeLSP any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerVIPExternalTrafficLocal", reflect.TypeOf((*MockNbClient)(nil).SetLoadBalancerVIPExternalTrafficLocal), lbName, vip, vipNodeLSP)
 }
 
 // SetLogicalRouterPortHAChassisGroup mocks base method.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -258,6 +258,10 @@ type Controller struct {
 	epsIndexer                    cache.Indexer
 	addOrUpdateEndpointSliceQueue workqueue.TypedRateLimitingInterface[string]
 	epKeyMutex                    keymutex.KeyMutex
+	serviceL2StatusMutex          sync.RWMutex
+	serviceL2StatusIndexer        cache.Indexer
+	serviceL2StatusSynced         cache.InformerSynced
+	serviceL2StatusStarted        bool
 
 	deploymentsLister appsv1.DeploymentLister
 	deploymentsSynced cache.InformerSynced
@@ -776,6 +780,10 @@ func Run(ctx context.Context, config *Configuration) {
 	// They may be missing on clusters upgraded from <v1.16 via Helm, which does not
 	// re-apply the `crds/` directory on `helm upgrade`. Best-effort start with periodic retry.
 	controller.StartBgpEvpnConfInformerFactory(ctx)
+
+	// MetalLB is optional. When its ServiceL2Status API is available, use it to
+	// identify the chassis announcing each underlay LoadBalancer VIP.
+	controller.StartServiceL2StatusInformer(ctx)
 
 	// Wait for the caches to be synced before starting workers
 	controller.informerFactory.Start(ctx.Done())

--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -118,6 +118,8 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 	var (
 		lbVips                   []string
 		vip, vpcName, subnetName string
+		externalVIPNode          string
+		serviceL2StatusReady     = true
 		ok                       bool
 		ignoreHealthCheck        = true
 		isPreferLocalBackend     = false
@@ -155,6 +157,10 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 				}
 			}
 			isPreferLocalBackend = true
+			externalVIPNode, serviceL2StatusReady, err = c.getServiceL2StatusNode(namespace, name)
+			if err != nil {
+				return err
+			}
 		} else if svc.Spec.Type == v1.ServiceTypeClusterIP && svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == v1.ServiceInternalTrafficPolicyLocal {
 			isPreferLocalBackend = true
 		}
@@ -195,6 +201,11 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 	oldTCPLb, oldUDPLb, oldSctpLb := vpc.Status.TCPSessionLoadBalancer, vpc.Status.UDPSessionLoadBalancer, vpc.Status.SctpSessionLoadBalancer
 	if svc.Spec.SessionAffinity == v1.ServiceAffinityClientIP {
 		tcpLb, udpLb, sctpLb, oldTCPLb, oldUDPLb, oldSctpLb = oldTCPLb, oldUDPLb, oldSctpLb, tcpLb, udpLb, sctpLb
+	}
+	if c.config.EnableOVNLBPreferLocal {
+		if err = c.clearLoadBalancerVIPExternalTrafficLocal(svc, tcpLb, udpLb, sctpLb); err != nil {
+			return err
+		}
 	}
 
 	for _, lbVip := range lbVips {
@@ -247,6 +258,21 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 				if err = c.OVNNbClient.LoadBalancerAddVip(lb, vip, backends...); err != nil {
 					klog.Errorf("failed to add vip %s with backends %s to LB %s: %v", lbVip, backends, lb, err)
 					return err
+				}
+				if isPreferLocalBackend &&
+					svc.Spec.Type == v1.ServiceTypeLoadBalancer &&
+					svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal &&
+					serviceL2StatusReady &&
+					slices.ContainsFunc(svc.Status.LoadBalancer.Ingress, func(ingress v1.LoadBalancerIngress) bool {
+						return ingress.IP == lbVip
+					}) {
+					vipNodeLSP := ""
+					if externalVIPNode != "" {
+						vipNodeLSP = util.NodeLspName(externalVIPNode)
+					}
+					if err = c.OVNNbClient.SetLoadBalancerVIPExternalTrafficLocal(lb, vip, vipNodeLSP); err != nil {
+						return fmt.Errorf("couldn't mark external local vip %s on LB %s: %w", vip, lb, err)
+					}
 				}
 
 				if isPreferLocalBackend && len(ipPortMapping) != 0 {
@@ -374,6 +400,38 @@ func (c *Controller) replaceEndpointAddressesWithSecondaryIPs(endpointSlices []*
 		}
 	}
 
+	return nil
+}
+
+func (c *Controller) clearLoadBalancerVIPExternalTrafficLocal(svc *v1.Service, tcpLb, udpLb, sctpLb string) error {
+	if svc.Spec.Type != v1.ServiceTypeLoadBalancer ||
+		svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
+		return nil
+	}
+
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		if ingress.IP == "" {
+			continue
+		}
+		for _, port := range svc.Spec.Ports {
+			var lb string
+			switch port.Protocol {
+			case v1.ProtocolTCP:
+				lb = tcpLb
+			case v1.ProtocolUDP:
+				lb = udpLb
+			case v1.ProtocolSCTP:
+				lb = sctpLb
+			}
+			if lb == "" {
+				continue
+			}
+			vip := util.JoinHostPort(ingress.IP, port.Port)
+			if err := c.OVNNbClient.SetLoadBalancerVIPExternalTrafficLocal(lb, vip, ""); err != nil {
+				return fmt.Errorf("couldn't clear external local vip marker %s on LB %s: %w", vip, lb, err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -148,18 +148,18 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 	}
 
 	if c.config.EnableLb && c.config.EnableOVNLBPreferLocal {
-		if svc.Spec.Type == v1.ServiceTypeLoadBalancer && svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
-			if len(svc.Status.LoadBalancer.Ingress) > 0 {
-				for _, ingress := range svc.Status.LoadBalancer.Ingress {
-					if ingress.IP != "" {
-						lbVips = append(lbVips, ingress.IP)
-					}
+		if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+			for _, ingress := range svc.Status.LoadBalancer.Ingress {
+				if ingress.IP != "" {
+					lbVips = append(lbVips, ingress.IP)
 				}
 			}
-			isPreferLocalBackend = true
-			externalVIPNode, serviceL2StatusReady, err = c.getServiceL2StatusNode(namespace, name)
-			if err != nil {
-				return err
+			if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
+				isPreferLocalBackend = true
+				externalVIPNode, serviceL2StatusReady, err = c.getServiceL2StatusNode(namespace, name)
+				if err != nil {
+					return err
+				}
 			}
 		} else if svc.Spec.Type == v1.ServiceTypeClusterIP && svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == v1.ServiceInternalTrafficPolicyLocal {
 			isPreferLocalBackend = true
@@ -204,6 +204,9 @@ func (c *Controller) handleUpdateEndpointSlice(key string) error {
 	}
 	if c.config.EnableOVNLBPreferLocal {
 		if err = c.clearLoadBalancerVIPExternalTrafficLocal(svc, tcpLb, udpLb, sctpLb); err != nil {
+			return err
+		}
+		if err = c.clearLoadBalancerVIPExternalTrafficLocal(svc, oldTCPLb, oldUDPLb, oldSctpLb); err != nil {
 			return err
 		}
 	}
@@ -429,6 +432,9 @@ func (c *Controller) clearLoadBalancerVIPExternalTrafficLocal(svc *v1.Service, t
 			vip := util.JoinHostPort(ingress.IP, port.Port)
 			if err := c.OVNNbClient.SetLoadBalancerVIPExternalTrafficLocal(lb, vip, ""); err != nil {
 				return fmt.Errorf("couldn't clear external local vip marker %s on LB %s: %w", vip, lb, err)
+			}
+			if err := c.OVNNbClient.LoadBalancerDeleteIPPortMapping(lb, vip); err != nil {
+				return fmt.Errorf("couldn't clear external local vip ip port mapping %s on LB %s: %w", vip, lb, err)
 			}
 		}
 	}

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -143,6 +143,11 @@ func (c *Controller) enqueueUpdateService(oldObj, newObj any) {
 		newPorts: newSvc.Spec.Ports,
 	}
 	c.updateServiceQueue.Add(updateSvc)
+	if c.config.EnableOVNLBPreferLocal &&
+		newSvc.Spec.Type == v1.ServiceTypeLoadBalancer &&
+		oldSvc.Spec.ExternalTrafficPolicy != newSvc.Spec.ExternalTrafficPolicy {
+		c.addOrUpdateEndpointSliceQueue.Add(cache.MetaObjectToName(newSvc).String())
+	}
 }
 
 func (c *Controller) handleDeleteService(service *vpcService) error {

--- a/pkg/controller/service_l2_status.go
+++ b/pkg/controller/service_l2_status.go
@@ -1,0 +1,204 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+const serviceL2StatusServiceIndex = "service"
+
+func serviceL2StatusServiceKey(status *metallbv1beta1.ServiceL2Status) (string, bool) {
+	if status == nil || status.Status.ServiceNamespace == "" || status.Status.ServiceName == "" {
+		return "", false
+	}
+	return status.Status.ServiceNamespace + "/" + status.Status.ServiceName, true
+}
+
+func indexServiceL2StatusByService(obj any) ([]string, error) {
+	status, ok := obj.(*metallbv1beta1.ServiceL2Status)
+	if !ok {
+		return nil, fmt.Errorf("expected ServiceL2Status but got %T", obj)
+	}
+	key, ok := serviceL2StatusServiceKey(status)
+	if !ok {
+		return nil, nil
+	}
+	return []string{key}, nil
+}
+
+func (c *Controller) getServiceL2StatusNode(namespace, serviceName string) (string, bool, error) {
+	c.serviceL2StatusMutex.RLock()
+	started := c.serviceL2StatusStarted
+	indexer := c.serviceL2StatusIndexer
+	synced := c.serviceL2StatusSynced
+	c.serviceL2StatusMutex.RUnlock()
+	if !started {
+		return "", true, nil
+	}
+	if indexer == nil || synced == nil || !synced() {
+		return "", false, nil
+	}
+
+	objects, err := indexer.ByIndex(serviceL2StatusServiceIndex, namespace+"/"+serviceName)
+	if err != nil {
+		return "", true, fmt.Errorf("failed to list ServiceL2Statuses for service %s/%s: %w", namespace, serviceName, err)
+	}
+
+	var node string
+	for _, obj := range objects {
+		status, ok := obj.(*metallbv1beta1.ServiceL2Status)
+		if !ok || status.Status.Node == "" {
+			continue
+		}
+		if node != "" && node != status.Status.Node {
+			return "", true, fmt.Errorf("multiple announcing nodes found for service %s/%s: %s and %s", namespace, serviceName, node, status.Status.Node)
+		}
+		node = status.Status.Node
+	}
+	return node, true, nil
+}
+
+func (c *Controller) enqueueServiceL2Status(obj any) {
+	status, ok := obj.(*metallbv1beta1.ServiceL2Status)
+	if !ok {
+		tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown)
+		if !isTombstone {
+			return
+		}
+		status, ok = tombstone.Obj.(*metallbv1beta1.ServiceL2Status)
+		if !ok {
+			return
+		}
+	}
+	key, ok := serviceL2StatusServiceKey(status)
+	if !ok || c.addOrUpdateEndpointSliceQueue == nil {
+		return
+	}
+	c.addOrUpdateEndpointSliceQueue.Add(key)
+}
+
+func newMetalLBRESTClient(config *rest.Config) (rest.Interface, error) {
+	if config == nil {
+		return nil, errors.New("kubernetes REST config is nil")
+	}
+
+	scheme := runtime.NewScheme()
+	if err := metallbv1beta1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to register MetalLB API types: %w", err)
+	}
+
+	metalLBConfig := rest.CopyConfig(config)
+	metalLBConfig.GroupVersion = &metallbv1beta1.GroupVersion
+	metalLBConfig.APIPath = "/apis"
+	metalLBConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme).WithoutConversion()
+	client, err := rest.RESTClientFor(metalLBConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MetalLB REST client: %w", err)
+	}
+	return client, nil
+}
+
+func (c *Controller) tryStartServiceL2StatusInformer(ctx context.Context) bool {
+	c.serviceL2StatusMutex.RLock()
+	started := c.serviceL2StatusStarted
+	c.serviceL2StatusMutex.RUnlock()
+	if started {
+		return true
+	}
+
+	exists, err := util.APIResourceExists(
+		c.config.KubeClient.Discovery(),
+		metallbv1beta1.GroupVersion.String(),
+		util.ObjectKind[*metallbv1beta1.ServiceL2Status](),
+	)
+	if err != nil {
+		klog.Warningf("failed to check ServiceL2Status API: %v", err)
+		return false
+	}
+	if !exists {
+		return false
+	}
+
+	client, err := newMetalLBRESTClient(c.config.KubeRestConfig)
+	if err != nil {
+		klog.Warningf("failed to initialize ServiceL2Status informer: %v", err)
+		return false
+	}
+	informer := cache.NewSharedIndexInformer(
+		cache.NewListWatchFromClient(client, "servicel2statuses", metav1.NamespaceAll, fields.Everything()),
+		&metallbv1beta1.ServiceL2Status{},
+		0,
+		cache.Indexers{serviceL2StatusServiceIndex: indexServiceL2StatusByService},
+	)
+	if _, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: c.enqueueServiceL2Status,
+		UpdateFunc: func(_, newObj any) {
+			c.enqueueServiceL2Status(newObj)
+		},
+		DeleteFunc: c.enqueueServiceL2Status,
+	}); err != nil {
+		klog.Warningf("failed to add ServiceL2Status event handler: %v", err)
+		return false
+	}
+
+	c.serviceL2StatusMutex.Lock()
+	if c.serviceL2StatusStarted {
+		c.serviceL2StatusMutex.Unlock()
+		return true
+	}
+	c.serviceL2StatusIndexer = informer.GetIndexer()
+	c.serviceL2StatusSynced = informer.HasSynced
+	c.serviceL2StatusStarted = true
+	c.serviceL2StatusMutex.Unlock()
+
+	go informer.Run(ctx.Done())
+	go func() {
+		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+			return
+		}
+		for _, obj := range informer.GetIndexer().List() {
+			c.enqueueServiceL2Status(obj)
+		}
+	}()
+	klog.Info("ServiceL2Status API found, informer started")
+	return true
+}
+
+func (c *Controller) StartServiceL2StatusInformer(ctx context.Context) {
+	if !c.config.EnableLb || !c.config.EnableOVNLBPreferLocal {
+		return
+	}
+
+	if c.tryStartServiceL2StatusInformer(ctx) {
+		return
+	}
+
+	klog.Info("ServiceL2Status API not found at startup, will check periodically in background")
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if c.tryStartServiceL2StatusInformer(ctx) {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/pkg/controller/service_l2_status_test.go
+++ b/pkg/controller/service_l2_status_test.go
@@ -1,0 +1,172 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestStartServiceL2StatusInformerDisabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Configuration
+	}{
+		{
+			name: "load balancer disabled",
+			config: &Configuration{
+				EnableOVNLBPreferLocal: true,
+			},
+		},
+		{
+			name: "prefer local disabled",
+			config: &Configuration{
+				EnableLb: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := &Controller{config: tt.config}
+			require.NotPanics(t, func() {
+				controller.StartServiceL2StatusInformer(context.Background())
+			})
+		})
+	}
+}
+
+func TestServiceL2StatusServiceKey(t *testing.T) {
+	status := &metallbv1beta1.ServiceL2Status{
+		Status: metallbv1beta1.MetalLBServiceL2Status{
+			ServiceNamespace: "test-ns",
+			ServiceName:      "test-svc",
+		},
+	}
+
+	key, ok := serviceL2StatusServiceKey(status)
+	require.True(t, ok)
+	require.Equal(t, "test-ns/test-svc", key)
+
+	_, ok = serviceL2StatusServiceKey(&metallbv1beta1.ServiceL2Status{})
+	require.False(t, ok)
+}
+
+func TestGetServiceL2StatusNode(t *testing.T) {
+	controller := &Controller{}
+	node, ready, err := controller.getServiceL2StatusNode("test-ns", "test-svc")
+	require.NoError(t, err)
+	require.True(t, ready)
+	require.Empty(t, node)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		serviceL2StatusServiceIndex: indexServiceL2StatusByService,
+	})
+	controller = &Controller{
+		serviceL2StatusIndexer: indexer,
+		serviceL2StatusStarted: true,
+		serviceL2StatusSynced:  func() bool { return false },
+	}
+
+	node, ready, err = controller.getServiceL2StatusNode("test-ns", "test-svc")
+	require.NoError(t, err)
+	require.False(t, ready)
+	require.Empty(t, node)
+
+	controller.serviceL2StatusSynced = func() bool { return true }
+
+	node, ready, err = controller.getServiceL2StatusNode("test-ns", "test-svc")
+	require.NoError(t, err)
+	require.True(t, ready)
+	require.Empty(t, node)
+
+	status := &metallbv1beta1.ServiceL2Status{
+		ObjectMeta: metav1.ObjectMeta{Name: "l2-status", Namespace: "metallb-system"},
+		Status: metallbv1beta1.MetalLBServiceL2Status{
+			Node:             "worker-1",
+			ServiceNamespace: "test-ns",
+			ServiceName:      "test-svc",
+		},
+	}
+	require.NoError(t, indexer.Add(status))
+
+	node, ready, err = controller.getServiceL2StatusNode("test-ns", "test-svc")
+	require.NoError(t, err)
+	require.True(t, ready)
+	require.Equal(t, "worker-1", node)
+
+	conflictingStatus := status.DeepCopy()
+	conflictingStatus.Name = "l2-status-conflict"
+	conflictingStatus.Status.Node = "worker-2"
+	require.NoError(t, indexer.Add(conflictingStatus))
+
+	_, ready, err = controller.getServiceL2StatusNode("test-ns", "test-svc")
+	require.True(t, ready)
+	require.ErrorContains(t, err, "multiple announcing nodes")
+}
+
+func TestEnqueueServiceL2Status(t *testing.T) {
+	controller := &Controller{
+		addOrUpdateEndpointSliceQueue: newTypedRateLimitingQueue[string]("test-service-l2-status", nil),
+	}
+	t.Cleanup(controller.addOrUpdateEndpointSliceQueue.ShutDown)
+
+	status := &metallbv1beta1.ServiceL2Status{
+		Status: metallbv1beta1.MetalLBServiceL2Status{
+			ServiceNamespace: "test-ns",
+			ServiceName:      "test-svc",
+		},
+	}
+	controller.enqueueServiceL2Status(status)
+
+	key, shutdown := controller.addOrUpdateEndpointSliceQueue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "test-ns/test-svc", key)
+	controller.addOrUpdateEndpointSliceQueue.Done(key)
+
+	controller.enqueueServiceL2Status(cache.DeletedFinalStateUnknown{
+		Key: "metallb-system/l2-status",
+		Obj: status,
+	})
+	key, shutdown = controller.addOrUpdateEndpointSliceQueue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "test-ns/test-svc", key)
+	controller.addOrUpdateEndpointSliceQueue.Done(key)
+}
+
+func TestClearLoadBalancerVIPExternalTrafficLocal(t *testing.T) {
+	fakeController := newFakeController(t)
+	service := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Type:                  corev1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+			Ports: []corev1.ServicePort{{
+				Port:     80,
+				Protocol: corev1.ProtocolTCP,
+			}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.10"}},
+			},
+		},
+	}
+
+	fakeController.mockOvnClient.EXPECT().
+		SetLoadBalancerVIPExternalTrafficLocal("tcp-lb", "10.0.0.10:80", "").
+		Return(nil)
+
+	err := fakeController.fakeController.clearLoadBalancerVIPExternalTrafficLocal(
+		service, "tcp-lb", "udp-lb", "sctp-lb",
+	)
+	require.NoError(t, err)
+
+	service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+	require.NoError(t, fakeController.fakeController.clearLoadBalancerVIPExternalTrafficLocal(
+		service, "tcp-lb", "udp-lb", "sctp-lb",
+	))
+}

--- a/pkg/controller/service_l2_status_test.go
+++ b/pkg/controller/service_l2_status_test.go
@@ -159,6 +159,9 @@ func TestClearLoadBalancerVIPExternalTrafficLocal(t *testing.T) {
 	fakeController.mockOvnClient.EXPECT().
 		SetLoadBalancerVIPExternalTrafficLocal("tcp-lb", "10.0.0.10:80", "").
 		Return(nil)
+	fakeController.mockOvnClient.EXPECT().
+		LoadBalancerDeleteIPPortMapping("tcp-lb", "10.0.0.10:80").
+		Return(nil)
 
 	err := fakeController.fakeController.clearLoadBalancerVIPExternalTrafficLocal(
 		service, "tcp-lb", "udp-lb", "sctp-lb",

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -348,6 +348,52 @@ func Test_enqueueUpdateServiceSkipsIrrelevantUpdates(t *testing.T) {
 	}
 }
 
+func TestEnqueueUpdateServiceReconcilesEndpointSliceOnExternalTrafficPolicyChange(t *testing.T) {
+	oldSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "svc",
+			Namespace:       metav1.NamespaceDefault,
+			ResourceVersion: "1",
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ClusterIP:             "10.96.0.10",
+			ClusterIPs:            []string{"10.96.0.10"},
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			Ports:                 []v1.ServicePort{{Name: "tcp", Port: 80, Protocol: v1.ProtocolTCP}},
+		},
+	}
+	newSvc := oldSvc.DeepCopy()
+	newSvc.ResourceVersion = "2"
+	newSvc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster
+
+	c := &Controller{
+		config: &Configuration{
+			EnableLb:               true,
+			EnableOVNLBPreferLocal: true,
+		},
+		updateServiceQueue:            newTypedRateLimitingQueue[*updateSvcObject]("UpdateService", nil),
+		addOrUpdateEndpointSliceQueue: newTypedRateLimitingQueue[string]("UpdateEndpointSlice", nil),
+	}
+	t.Cleanup(c.updateServiceQueue.ShutDown)
+	t.Cleanup(c.addOrUpdateEndpointSliceQueue.ShutDown)
+
+	c.enqueueUpdateService(oldSvc, newSvc)
+
+	require.Equal(t, 1, c.updateServiceQueue.Len())
+	require.Equal(t, 1, c.addOrUpdateEndpointSliceQueue.Len())
+	key, shutdown := c.addOrUpdateEndpointSliceQueue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "default/svc", key)
+	c.addOrUpdateEndpointSliceQueue.Done(key)
+
+	c.config.EnableOVNLBPreferLocal = false
+	c.addOrUpdateEndpointSliceQueue = newTypedRateLimitingQueue[string]("UpdateEndpointSliceDisabled", nil)
+	t.Cleanup(c.addOrUpdateEndpointSliceQueue.ShutDown)
+	c.enqueueUpdateService(oldSvc, newSvc)
+	require.Zero(t, c.addOrUpdateEndpointSliceQueue.Len())
+}
+
 func Test_enqueueUpdateEndpointSliceSkipsContentlessUpdates(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -136,6 +136,7 @@ type LoadBalancer interface {
 	LoadBalancerAddIPPortMapping(lbName, vip string, ipPortMappings map[string]string) error
 	LoadBalancerUpdateIPPortMapping(lbName, vip string, ipPortMappings map[string]string) error
 	LoadBalancerDeleteIPPortMapping(lbName, vip string) error
+	SetLoadBalancerVIPExternalTrafficLocal(lbName, vip, vipNodeLSP string) error
 	LoadBalancerAddHealthCheck(lbName, vip string, ignoreHealthCheck bool, ipPortMapping, externals map[string]string) error
 	LoadBalancerDeleteHealthCheck(lbName, uuid string) error
 	SetLoadBalancerAffinityTimeout(lbName string, timeout int) error

--- a/pkg/ovs/ovn-nb-load_balancer.go
+++ b/pkg/ovs/ovn-nb-load_balancer.go
@@ -19,6 +19,8 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
+const localExternalVIPKeyPrefix = "kube-ovn.io/local-external-vip/"
+
 // CreateLoadBalancer create loadbalancer
 func (c *OVNNbClient) CreateLoadBalancer(lbName, protocol string, selectFields ...string) error {
 	var (
@@ -179,13 +181,22 @@ func (c *OVNNbClient) LoadBalancerDeleteVip(lbName, vipEndpoint string, ignoreHe
 	ops, err = c.LoadBalancerOp(
 		lbName,
 		func(lb *ovnnb.LoadBalancer) []model.Mutation {
-			return []model.Mutation{
+			mutations := []model.Mutation{
 				{
 					Field:   &lb.Vips,
 					Value:   map[string]string{vipEndpoint: lb.Vips[vipEndpoint]},
 					Mutator: ovsdb.MutateOperationDelete,
 				},
 			}
+			key := localExternalVIPKeyPrefix + vipEndpoint
+			if value, ok := lb.ExternalIDs[key]; ok {
+				mutations = append(mutations, model.Mutation{
+					Field:   &lb.ExternalIDs,
+					Value:   map[string]string{key: value},
+					Mutator: ovsdb.MutateOperationDelete,
+				})
+			}
+			return mutations
 		},
 	)
 	if err != nil {
@@ -199,6 +210,53 @@ func (c *OVNNbClient) LoadBalancerDeleteVip(lbName, vipEndpoint string, ignoreHe
 	if err = c.Transact("lb-add", ops); err != nil {
 		klog.Error(err)
 		return fmt.Errorf("failed to delete vip %s from load balancers %s: %w", vipEndpoint, lbName, err)
+	}
+	return nil
+}
+
+// SetLoadBalancerVIPExternalTrafficLocal records the node LSP of the chassis
+// announcing an external VIP of a LoadBalancer Service with
+// externalTrafficPolicy=Local.
+func (c *OVNNbClient) SetLoadBalancerVIPExternalTrafficLocal(lbName, vip, vipNodeLSP string) error {
+	key := localExternalVIPKeyPrefix + vip
+	ops, err := c.LoadBalancerOp(lbName, func(lb *ovnnb.LoadBalancer) []model.Mutation {
+		if vipNodeLSP != "" {
+			if lb.ExternalIDs[key] == vipNodeLSP {
+				return nil
+			}
+			mutations := make([]model.Mutation, 0, 2)
+			if oldValue, ok := lb.ExternalIDs[key]; ok {
+				mutations = append(mutations, model.Mutation{
+					Field:   &lb.ExternalIDs,
+					Value:   map[string]string{key: oldValue},
+					Mutator: ovsdb.MutateOperationDelete,
+				})
+			}
+			mutations = append(mutations, model.Mutation{
+				Field:   &lb.ExternalIDs,
+				Value:   map[string]string{key: vipNodeLSP},
+				Mutator: ovsdb.MutateOperationInsert,
+			})
+			return mutations
+		}
+
+		if _, ok := lb.ExternalIDs[key]; !ok {
+			return nil
+		}
+		return []model.Mutation{{
+			Field:   &lb.ExternalIDs,
+			Value:   map[string]string{key: lb.ExternalIDs[key]},
+			Mutator: ovsdb.MutateOperationDelete,
+		}}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to generate operations when updating external traffic local marker for vip %s on load balancer %s: %w", vip, lbName, err)
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	if err = c.Transact("lb-update-external-vip", ops); err != nil {
+		return fmt.Errorf("failed to update external traffic local marker for vip %s on load balancer %s: %w", vip, lbName, err)
 	}
 	return nil
 }

--- a/pkg/ovs/ovn-nb-load_balancer_test.go
+++ b/pkg/ovs/ovn-nb-load_balancer_test.go
@@ -15,6 +15,7 @@ import (
 
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func (suite *OvnClientTestSuite) testCreateLoadBalancer() {
@@ -620,6 +621,8 @@ func (suite *OvnClientTestSuite) testLoadBalancerDeleteVip() {
 	t := suite.T()
 	t.Parallel()
 
+	const markedVIP = "10.96.0.3:443"
+
 	var (
 		nbClient    = suite.ovnNBClient
 		lbName      = "test-lb-del-vip"
@@ -645,9 +648,10 @@ func (suite *OvnClientTestSuite) testLoadBalancerDeleteVip() {
 		err = nbClient.LoadBalancerAddVip(lbName, vip, strings.Split(backends, ",")...)
 		require.NoError(t, err)
 	}
+	require.NoError(t, nbClient.SetLoadBalancerVIPExternalTrafficLocal(lbName, markedVIP, "node-worker-1"))
 
 	deletedVips = []string{
-		"10.96.0.3:443",
+		markedVIP,
 		"[fd00:10:96::e84f]:8080",
 		"10.96.0.100:1443", // non-existent vip
 	}
@@ -661,6 +665,7 @@ func (suite *OvnClientTestSuite) testLoadBalancerDeleteVip() {
 	lb, err = nbClient.GetLoadBalancer(lbName, false)
 	require.NoError(t, err)
 	require.Equal(t, vips, lb.Vips)
+	require.NotContains(t, lb.ExternalIDs, localExternalVIPKeyPrefix+markedVIP)
 
 	err = nbClient.LoadBalancerAddHealthCheck(lbName, "10.107.43.239:8080", false, nil, nil)
 	require.NoError(t, err)
@@ -698,6 +703,45 @@ func (suite *OvnClientTestSuite) testLoadBalancerDeleteVip() {
 
 	err = nbClient.LoadBalancerDeleteVip(lbName, "10.107.43.239:8080", ignoreHealthCheck)
 	require.ErrorContains(t, err, "more than one load balancer with same name")
+}
+
+func (suite *OvnClientTestSuite) testSetLoadBalancerVIPExternalTrafficLocal() {
+	t := suite.T()
+	t.Parallel()
+
+	const (
+		lbName = "test-lb-external-vip-marker"
+		vipA   = "10.96.0.100:80"
+		vipB   = "10.96.0.101:80"
+	)
+
+	nbClient := suite.ovnNBClient
+	require.NoError(t, nbClient.CreateLoadBalancer(lbName, "tcp"))
+	require.NoError(t, nbClient.SetLoadBalancerVIPExternalTrafficLocal(lbName, vipA, "node-worker-1"))
+	require.NoError(t, nbClient.SetLoadBalancerVIPExternalTrafficLocal(lbName, vipB, "node-worker-2"))
+
+	lb, err := nbClient.GetLoadBalancer(lbName, false)
+	require.NoError(t, err)
+	require.Equal(t, util.CniTypeName, lb.ExternalIDs["vendor"])
+	require.Equal(t, "node-worker-1", lb.ExternalIDs[localExternalVIPKeyPrefix+vipA])
+	require.Equal(t, "node-worker-2", lb.ExternalIDs[localExternalVIPKeyPrefix+vipB])
+
+	require.NoError(t, nbClient.SetLoadBalancerVIPExternalTrafficLocal(lbName, vipA, "node-worker-1"))
+	require.NoError(t, nbClient.SetLoadBalancerVIPExternalTrafficLocal(lbName, vipA, "node-worker-3"))
+
+	lb, err = nbClient.GetLoadBalancer(lbName, false)
+	require.NoError(t, err)
+	require.Equal(t, "node-worker-3", lb.ExternalIDs[localExternalVIPKeyPrefix+vipA])
+	require.Equal(t, "node-worker-2", lb.ExternalIDs[localExternalVIPKeyPrefix+vipB])
+
+	require.NoError(t, nbClient.SetLoadBalancerVIPExternalTrafficLocal(lbName, vipA, ""))
+
+	lb, err = nbClient.GetLoadBalancer(lbName, false)
+	require.NoError(t, err)
+	_, exists := lb.ExternalIDs[localExternalVIPKeyPrefix+vipA]
+	require.False(t, exists)
+	require.Equal(t, "node-worker-2", lb.ExternalIDs[localExternalVIPKeyPrefix+vipB])
+	require.Equal(t, util.CniTypeName, lb.ExternalIDs["vendor"])
 }
 
 func (suite *OvnClientTestSuite) testLoadBalancerAddIPPortMapping() {

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -531,6 +531,10 @@ func (suite *OvnClientTestSuite) Test_LoadBalancerDeleteVip() {
 	suite.testLoadBalancerDeleteVip()
 }
 
+func (suite *OvnClientTestSuite) Test_SetLoadBalancerVIPExternalTrafficLocal() {
+	suite.testSetLoadBalancerVIPExternalTrafficLocal()
+}
+
 func (suite *OvnClientTestSuite) Test_GetLoadBalancer() {
 	suite.testGetLoadBalancer()
 }

--- a/test/e2e/framework/metallb.go
+++ b/test/e2e/framework/metallb.go
@@ -51,6 +51,18 @@ func (c *MetallbClientSet) CreateL2Advertisement(advertisement *metallbv1beta1.L
 	return result, err
 }
 
+func (c *MetallbClientSet) UpdateL2Advertisement(advertisement *metallbv1beta1.L2Advertisement) (*metallbv1beta1.L2Advertisement, error) {
+	result := &metallbv1beta1.L2Advertisement{}
+	err := c.client.Put().
+		Namespace("metallb-system").
+		Resource("l2advertisements").
+		Name(advertisement.Name).
+		Body(advertisement).
+		Do(context.TODO()).
+		Into(result)
+	return result, err
+}
+
 func (c *MetallbClientSet) MakeL2Advertisement(name string, ipAddressPools []string) *metallbv1beta1.L2Advertisement {
 	return &metallbv1beta1.L2Advertisement{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/metallb/e2e_test.go
+++ b/test/e2e/metallb/e2e_test.go
@@ -2,6 +2,7 @@ package kubevirt
 
 import (
 	"context"
+	"encoding/csv"
 	"flag"
 	"fmt"
 	"net"
@@ -27,6 +28,7 @@ import (
 
 	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ipam"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/docker"
@@ -35,9 +37,45 @@ import (
 )
 
 const (
-	dockerNetworkName = "kube-ovn-vlan"
-	curlListenPort    = 80
+	dockerNetworkName         = "kube-ovn-vlan"
+	localExternalVIPKeyPrefix = "kube-ovn.io/local-external-vip/"
+	curlListenPort            = 80
 )
+
+type underlayTestEnvironment struct {
+	cidrV4          string
+	annotations     map[string]string
+	subnet          *apiv1.Subnet
+	l2Advertisement *metallbv1beta1.L2Advertisement
+}
+
+type internalVIPTestEnvironment struct {
+	*underlayTestEnvironment
+	service           *corev1.Service
+	vip               string
+	vipNode           string
+	nonVIPBackendNode string
+	nonVIPNode        string
+	backendPods       []corev1.Pod
+	vipNodeBackend    *corev1.Pod
+	nonVIPNodeBackend *corev1.Pod
+}
+
+type internalVIPClientTopology string
+
+const (
+	internalVIPClientOnVIPNode           internalVIPClientTopology = "VIP node"
+	internalVIPClientOnNonVIPBackendNode internalVIPClientTopology = "non-VIP node with a local backend"
+	internalVIPClientOnNonBackendNode    internalVIPClientTopology = "node without a local backend"
+)
+
+type logicalFlow struct {
+	pipeline string
+	tableID  int
+	priority int
+	match    string
+	actions  string
+}
 
 func init() {
 	klog.SetOutput(ginkgo.GinkgoWriter)
@@ -71,11 +109,12 @@ func makeProviderNetwork(providerNetworkName string, exchangeLinkName bool, link
 	return framework.MakeProviderNetwork(providerNetworkName, exchangeLinkName, defaultInterface, customInterfaces, nil)
 }
 
-var _ = framework.Describe("[group:metallb]", func() {
+var _ = framework.SerialDescribe("[group:metallb]", func() {
 	f := framework.NewDefaultFramework("metallb")
 
 	var cs clientset.Interface
 	var nodeNames []string
+	var nodeExecMap map[string]*kind.Node
 	var clusterName, providerNetworkName, vlanName, subnetName, deployName, containerName, serviceName, serviceName2, containerID, metallbIPPoolName string
 	var linkMap map[string]*iproute.Link
 	var routeMap map[string][]iproute.Route
@@ -86,6 +125,7 @@ var _ = framework.Describe("[group:metallb]", func() {
 	var dockerNetwork *dockernetwork.Inspect
 	var deployClient *framework.DeploymentClient
 	var clientIPv4, clientIPv6 string
+	var internalDeployName, externalServiceName string
 
 	ginkgo.BeforeEach(func() {
 		f.SkipVersionPriorTo(1, 14, "This feature was introduced in v1.14.")
@@ -100,9 +140,11 @@ var _ = framework.Describe("[group:metallb]", func() {
 		providerNetworkClient = f.ProviderNetworkClient()
 		containerName = "client-" + framework.RandomSuffix()
 		deployName = "deploy-" + framework.RandomSuffix()
+		internalDeployName = "internal-deploy-" + framework.RandomSuffix()
 		metallbIPPoolName = "metallb-ip-pool-" + framework.RandomSuffix()
 		serviceName = "service-" + framework.RandomSuffix()
 		serviceName2 = "service2-" + framework.RandomSuffix()
+		externalServiceName = "external-service-" + framework.RandomSuffix()
 
 		if clusterName == "" {
 			ginkgo.By("Getting k8s nodes")
@@ -140,7 +182,9 @@ var _ = framework.Describe("[group:metallb]", func() {
 		linkMap = make(map[string]*iproute.Link, len(nodes))
 		routeMap = make(map[string][]iproute.Route, len(nodes))
 		nodeNames = make([]string, 0, len(nodes))
-		for _, node := range nodes {
+		nodeExecMap = make(map[string]*kind.Node, len(nodes))
+		for i := range nodes {
+			node := &nodes[i]
 			links, err := node.ListLinks()
 			framework.ExpectNoError(err, "failed to list links on node %s: %v", node.Name(), err)
 			routes, err := node.ListRoutes(true)
@@ -168,6 +212,7 @@ var _ = framework.Describe("[group:metallb]", func() {
 			linkMap[node.Name()] = linkMap[node.ID]
 			routeMap[node.Name()] = routeMap[node.ID]
 			nodeNames = append(nodeNames, node.Name())
+			nodeExecMap[node.Name()] = node
 		}
 
 		ginkgo.By("Creating a new kind node as Client and connecting it to the docker network")
@@ -194,6 +239,9 @@ var _ = framework.Describe("[group:metallb]", func() {
 		if serviceName2 != "" {
 			f.ServiceClient().DeleteSync(serviceName2)
 		}
+		if externalServiceName != "" {
+			f.ServiceClient().DeleteSync(externalServiceName)
+		}
 
 		ginkgo.By("Deleting the IPAddressPool for metallb")
 		f.MetallbClientSet.DeleteIPAddressPool(metallbIPPoolName) // nolint:errcheck
@@ -203,6 +251,7 @@ var _ = framework.Describe("[group:metallb]", func() {
 
 		ginkgo.By("Deleting the deployment " + deployName)
 		deployClient.DeleteSync(deployName)
+		deployClient.DeleteSync(internalDeployName)
 
 		ginkgo.By("Deleting subnet " + subnetName)
 		subnetClient.DeleteSync(subnetName)
@@ -237,12 +286,11 @@ var _ = framework.Describe("[group:metallb]", func() {
 		}
 	})
 
-	framework.ConformanceIt("should support metallb and underlay combine", func() {
-		underlayCidr := make([]string, 0, 2)
-		gateway := make([]string, 0, 2)
+	setupUnderlayEnvironment := func() *underlayTestEnvironment {
+		underlayCIDRs := make([]string, 0, 2)
+		gateways := make([]string, 0, 2)
 		var metallbVIPv4s, metallbVIPv6s []string
-		var metallbVIPv4Str, metallbVIPv6Str string
-		var err error
+		var metallbVIPv4Range, metallbVIPv6Range string
 
 		ginkgo.By("Creating provider network " + providerNetworkName)
 		pn := makeProviderNetwork(providerNetworkName, false, linkMap)
@@ -256,7 +304,6 @@ var _ = framework.Describe("[group:metallb]", func() {
 		vlan := framework.MakeVlan(vlanName, providerNetworkName, 0)
 		_ = vlanClient.Create(vlan)
 
-		ginkgo.By("Creating underlay subnet " + subnetName)
 		var cidrV4, cidrV6, gatewayV4, gatewayV6 string
 		for _, config := range dockerNetwork.IPAM.Config {
 			switch util.CheckProtocol(config.Subnet.String()) {
@@ -276,35 +323,33 @@ var _ = framework.Describe("[group:metallb]", func() {
 		}
 
 		if f.HasIPv4() {
-			underlayCidr = append(underlayCidr, cidrV4)
+			underlayCIDRs = append(underlayCIDRs, cidrV4)
 			if gatewayV4 != "" {
-				gateway = append(gateway, gatewayV4)
+				gateways = append(gateways, gatewayV4)
 			}
 			for index := range 10 {
 				startIP, _, _ := strings.Cut(cidrV4, "/")
 				ip, _ := ipam.NewIP(startIP)
 				metallbVIPv4s = append(metallbVIPv4s, ip.Add(100+int64(index)).String())
 			}
-			metallbVIPv4Str = fmt.Sprintf("%s-%s", metallbVIPv4s[0], metallbVIPv4s[len(metallbVIPv4s)-1])
+			metallbVIPv4Range = fmt.Sprintf("%s-%s", metallbVIPv4s[0], metallbVIPv4s[len(metallbVIPv4s)-1])
 			framework.Logf("metallbVIPv4s: %v", metallbVIPv4s)
 		}
 		if f.HasIPv6() {
-			underlayCidr = append(underlayCidr, cidrV6)
+			underlayCIDRs = append(underlayCIDRs, cidrV6)
 			if gatewayV6 != "" {
-				gateway = append(gateway, gatewayV6)
+				gateways = append(gateways, gatewayV6)
 			}
 			for index := range 10 {
 				startIP, _, _ := strings.Cut(cidrV6, "/")
 				ip, _ := ipam.NewIP(startIP)
 				metallbVIPv6s = append(metallbVIPv6s, ip.Add(100+int64(index)).String())
 			}
-			metallbVIPv6Str = fmt.Sprintf("%s-%s", metallbVIPv6s[0], metallbVIPv6s[len(metallbVIPv6s)-1])
+			metallbVIPv6Range = fmt.Sprintf("%s-%s", metallbVIPv6s[0], metallbVIPv6s[len(metallbVIPv6s)-1])
 			framework.Logf("metallbVIPv6s: %v", metallbVIPv6s)
 		}
 
-		framework.Logf("Final gateway array: %v", gateway)
-
-		excludeIPs := make([]string, 0, len(network.Containers)*2)
+		excludeIPs := make([]string, 0, len(network.Containers)*2+len(metallbVIPv4s)+len(metallbVIPv6s))
 		for _, container := range network.Containers {
 			if container.IPv4Address.IsValid() && f.HasIPv4() {
 				excludeIPs = append(excludeIPs, container.IPv4Address.Addr().String())
@@ -313,58 +358,251 @@ var _ = framework.Describe("[group:metallb]", func() {
 				excludeIPs = append(excludeIPs, container.IPv6Address.Addr().String())
 			}
 		}
-		if len(metallbVIPv4s) > 0 {
-			excludeIPs = append(excludeIPs, metallbVIPv4s...)
-		}
-		if len(metallbVIPv6s) > 0 {
-			excludeIPs = append(excludeIPs, metallbVIPv6s...)
-		}
+		excludeIPs = append(excludeIPs, metallbVIPv4s...)
+		excludeIPs = append(excludeIPs, metallbVIPv6s...)
 
-		framework.Logf("Final excludeIPs array: %v, len: %d", excludeIPs, len(excludeIPs))
-
-		ginkgo.By("Creating an IPAddressPool for metallb with address " + metallbVIPv4Str + " and " + metallbVIPv6Str)
+		ginkgo.By("Creating an IPAddressPool for metallb")
 		ipAddressPool := &metallbv1beta1.IPAddressPool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: metallbIPPoolName,
-			},
-			Spec: metallbv1beta1.IPAddressPoolSpec{
-				Addresses: []string{},
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: metallbIPPoolName},
 		}
-		if metallbVIPv4Str != "" {
-			ipAddressPool.Spec.Addresses = append(ipAddressPool.Spec.Addresses, metallbVIPv4Str)
+		if metallbVIPv4Range != "" {
+			ipAddressPool.Spec.Addresses = append(ipAddressPool.Spec.Addresses, metallbVIPv4Range)
 		}
-		if metallbVIPv6Str != "" {
-			ipAddressPool.Spec.Addresses = append(ipAddressPool.Spec.Addresses, metallbVIPv6Str)
+		if metallbVIPv6Range != "" {
+			ipAddressPool.Spec.Addresses = append(ipAddressPool.Spec.Addresses, metallbVIPv6Range)
 		}
 		_, err = f.MetallbClientSet.CreateIPAddressPool(ipAddressPool)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating an L2Advertisement for metallb")
-		l2Advertisement := &metallbv1beta1.L2Advertisement{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: metallbIPPoolName,
-			},
-			Spec: metallbv1beta1.L2AdvertisementSpec{
-				IPAddressPools: []string{metallbIPPoolName},
-			},
-		}
-		_, err = f.MetallbClientSet.CreateL2Advertisement(l2Advertisement)
+		l2Advertisement := f.MetallbClientSet.MakeL2Advertisement(metallbIPPoolName, []string{metallbIPPoolName})
+		l2Advertisement, err = f.MetallbClientSet.CreateL2Advertisement(l2Advertisement)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating underlay subnet " + subnetName)
-		subnet := framework.MakeSubnet(subnetName, vlanName, strings.Join(underlayCidr, ","), strings.Join(gateway, ","), "", "", excludeIPs, nil, []string{})
+		subnet := framework.MakeSubnet(
+			subnetName,
+			vlanName,
+			strings.Join(underlayCIDRs, ","),
+			strings.Join(gateways, ","),
+			"",
+			"",
+			excludeIPs,
+			nil,
+			[]string{},
+		)
 		subnet.Spec.EnableExternalLBAddress = true
-		_ = subnetClient.CreateSync(subnet)
+		subnet = subnetClient.CreateSync(subnet)
+
+		return &underlayTestEnvironment{
+			cidrV4: cidrV4,
+			annotations: map[string]string{
+				util.LogicalSwitchAnnotation: subnetName,
+			},
+			subnet:          subnet,
+			l2Advertisement: l2Advertisement,
+		}
+	}
+
+	setupInternalVIPEnvironment := func() *internalVIPTestEnvironment {
+		f.SkipVersionPriorTo(1, 17, "Internal underlay MetalLB VIP access was introduced in v1.17.")
+		if !f.HasIPv4() {
+			ginkgo.Skip("internal MetalLB VIP topology cases require IPv4")
+		}
+		framework.ExpectTrue(len(nodeNames) >= 3, "the internal VIP topology test requires three nodes")
+
+		underlayEnv := setupUnderlayEnvironment()
+		internalPodLabels := map[string]string{"app": "nginx-internal"}
+		args := []string{"netexec", "--http-port", strconv.Itoa(curlListenPort)}
+
+		ginkgo.By("Creating two underlay backends for the internal VIP topology test")
+		internalDeploy := framework.MakeDeployment(internalDeployName, 2, internalPodLabels, underlayEnv.annotations, "nginx", framework.AgnhostImage, "")
+		internalDeploy.Spec.Template.Spec.Containers[0].Args = args
+		internalDeploy.Spec.Template.Spec.Affinity = &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+					LabelSelector: &metav1.LabelSelector{MatchLabels: internalPodLabels},
+					TopologyKey:   "kubernetes.io/hostname",
+				}},
+			},
+		}
+		_ = deployClient.CreateSync(internalDeploy)
+
+		ginkgo.By("Creating a LoadBalancer service for the internal VIP topology test")
+		ports := []corev1.ServicePort{{
+			Name:       "http",
+			Port:       80,
+			TargetPort: intstr.FromInt(80),
+			Protocol:   corev1.ProtocolTCP,
+		}}
+		service := framework.MakeService(externalServiceName, corev1.ServiceTypeLoadBalancer, nil, internalPodLabels, ports, "")
+		service.Spec.IPFamilyPolicy = ptr.To(corev1.IPFamilyPolicySingleStack)
+		service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+		service = serviceClient.CreateSync(service, func(s *corev1.Service) (bool, error) {
+			return len(s.Status.LoadBalancer.Ingress) != 0, nil
+		}, "LoadBalancer service for internal topology has an ingress IP")
+
+		var vip string
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+				vip = ingress.IP
+				break
+			}
+		}
+		framework.ExpectNotEmpty(vip, "no IPv4 LoadBalancer ingress IP was assigned")
+		waitUnderlayServiceFlowOnAnyNode(nodeNames, providerNetworkName, vip, curlListenPort, 30*time.Second)
+		for _, clusterIP := range service.Spec.ClusterIPs {
+			if util.CheckProtocol(clusterIP) == apiv1.ProtocolIPv4 {
+				expectNoUnderlayVIPBypassLFlow(clusterIP, curlListenPort)
+			}
+		}
+
+		vipNode := getVIPNodeFromService(f, service.Name)
+		waitUnderlayVIPBypassLFlow(vip, curlListenPort, 30*time.Second)
+		waitUnderlayVIPNodeLFlow(vip, util.NodeLspName(vipNode), curlListenPort, 30*time.Second)
+
+		backendPodList, err := cs.CoreV1().Pods(f.Namespace.Name).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=nginx-internal",
+		})
+		framework.ExpectNoError(err, "listing MetalLB backends")
+		framework.ExpectHaveLen(backendPodList.Items, 2, "internal VIP topology requires exactly two backends")
+
+		env := &internalVIPTestEnvironment{
+			underlayTestEnvironment: underlayEnv,
+			service:                 service,
+			vip:                     vip,
+			vipNode:                 vipNode,
+			backendPods:             backendPodList.Items,
+		}
+		backendNodes := make(map[string]*corev1.Pod, len(env.backendPods))
+		for i := range env.backendPods {
+			pod := &env.backendPods[i]
+			backendNodes[pod.Spec.NodeName] = pod
+			if pod.Spec.NodeName == vipNode {
+				env.vipNodeBackend = pod
+			}
+		}
+		framework.ExpectNotNil(env.vipNodeBackend, "no backend is available on VIP node %s", vipNode)
+
+		for _, nodeName := range nodeNames {
+			if nodeName == vipNode {
+				continue
+			}
+			if backend := backendNodes[nodeName]; backend != nil {
+				env.nonVIPBackendNode = nodeName
+				env.nonVIPNodeBackend = backend
+			} else {
+				env.nonVIPNode = nodeName
+			}
+		}
+		framework.ExpectNotEmpty(env.nonVIPBackendNode, "no non-VIP node with a local backend is available")
+		framework.ExpectNotEmpty(env.nonVIPNode, "no node without a local backend is available")
+		waitUnderlayVIPBackendLFlowAbsent(env.backendPods, vipNode, 30*time.Second)
+		return env
+	}
+
+	runInternalVIPTopologyCase := func(env *internalVIPTestEnvironment, topology internalVIPClientTopology) {
+		var nodeName string
+		switch topology {
+		case internalVIPClientOnVIPNode:
+			nodeName = env.vipNode
+		case internalVIPClientOnNonVIPBackendNode:
+			nodeName = env.nonVIPBackendNode
+		case internalVIPClientOnNonBackendNode:
+			nodeName = env.nonVIPNode
+		default:
+			framework.Failf("unknown internal VIP client topology %q", topology)
+		}
+
+		ginkgo.By("Creating an underlay client on the " + string(topology))
+		client := framework.MakePod(
+			f.Namespace.Name,
+			"internal-client-"+framework.RandomSuffix(),
+			map[string]string{"app": "metallb-internal-client"},
+			env.annotations,
+			framework.AgnhostImage,
+			[]string{"sleep", "infinity"},
+			nil,
+		)
+		client.Spec.NodeName = nodeName
+		client = f.PodClient().CreateSync(client)
+		defer f.PodClient().DeleteSync(client.Name)
+		checkInternalPodVIPBackend(f, client, env.vip, env.vipNode)
+	}
+
+	enableU2O := func(env *internalVIPTestEnvironment) {
+		ginkgo.By("Enabling u2oInterconnection on subnet")
+		subnet := subnetClient.Get(subnetName)
+		subnet.Spec.U2OInterconnection = true
+		env.subnet = subnetClient.UpdateSync(subnet, metav1.UpdateOptions{}, 30*time.Second)
+
+		ginkgo.By("Waiting for u2oInterconnection MAC to be set")
+		framework.WaitUntil(5*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+			env.subnet = subnetClient.Get(subnetName)
+			return env.subnet.Status.U2OInterconnectionMAC != "", nil
+		}, "u2oInterconnection MAC not set")
+		waitUnderlayVIPBackendLFlows(env.backendPods, env.vipNode, 30*time.Second)
+	}
+
+	disableU2O := func(env *internalVIPTestEnvironment) {
+		ginkgo.By("Disabling u2oInterconnection on subnet")
+		subnet := subnetClient.Get(subnetName)
+		subnet.Spec.U2OInterconnection = false
+		env.subnet = subnetClient.UpdateSync(subnet, metav1.UpdateOptions{}, 30*time.Second)
+
+		ginkgo.By("Waiting for u2oInterconnection MAC to be cleared")
+		framework.WaitUntil(5*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+			env.subnet = subnetClient.Get(subnetName)
+			return env.subnet.Status.U2OInterconnectionMAC == "", nil
+		}, "u2oInterconnection MAC not cleared")
+		waitUnderlayVIPBackendLFlowAbsent(env.backendPods, env.vipNode, 30*time.Second)
+	}
+
+	addUnderlayPolicyRoutes := func(cidrV4 string) {
+		ginkgo.By("Adding policy routes to the underlay CIDR through ovn0 on all nodes")
+		const policyRouteTable = "10001"
+		ginkgo.DeferCleanup(func() {
+			for _, nodeName := range nodeNames {
+				node := nodeExecMap[nodeName]
+				if node == nil {
+					continue
+				}
+				_, _, _ = node.Exec("ip", "rule", "del", "priority", "10001", "to", cidrV4, "table", policyRouteTable)
+				_, _, _ = node.Exec("ip", "route", "del", cidrV4, "table", policyRouteTable)
+			}
+		})
+
+		for _, nodeName := range nodeNames {
+			node := nodeExecMap[nodeName]
+			framework.ExpectNotNil(node, "kind node %s not found", nodeName)
+			output, stderr, err := node.Exec("sh", "-c", "ip -4 route show dev ovn0 | awk '/ via / {print $3; exit}'")
+			framework.ExpectNoError(err, "getting ovn0 gateway on node %s: %s", nodeName, stderr)
+			ovn0Gateway := strings.TrimSpace(string(output))
+			framework.ExpectNotEmpty(ovn0Gateway, "ovn0 gateway not found on node %s", nodeName)
+			_, _, _ = node.Exec("ip", "rule", "del", "priority", "10001", "to", cidrV4, "table", policyRouteTable)
+			_, _, _ = node.Exec("ip", "route", "del", cidrV4, "table", policyRouteTable)
+			_, stderr, err = node.Exec("ip", "route", "add", cidrV4, "via", ovn0Gateway, "dev", "ovn0", "table", policyRouteTable)
+			framework.ExpectNoError(err, "adding policy route for underlay CIDR on node %s: %s", nodeName, stderr)
+			_, stderr, err = node.Exec("ip", "rule", "add", "priority", "10001", "to", cidrV4, "table", policyRouteTable)
+			framework.ExpectNoError(err, "adding policy rule for underlay CIDR on node %s: %s", nodeName, stderr)
+
+			route, stderr, err := node.Exec("ip", "-4", "route", "show", "table", policyRouteTable, "exact", cidrV4)
+			framework.ExpectNoError(err, "getting policy route for underlay CIDR on node %s: %s", nodeName, stderr)
+			framework.ExpectContainSubstring(string(route), "dev ovn0", "policy route for underlay CIDR should use ovn0 on node %s, output: %s", nodeName, route)
+			rule, stderr, err := node.Exec("ip", "-4", "rule", "show", "priority", "10001")
+			framework.ExpectNoError(err, "getting policy rule for underlay CIDR on node %s: %s", nodeName, stderr)
+			framework.ExpectContainSubstring(string(rule), "to "+cidrV4, "policy rule for underlay CIDR not found on node %s, output: %s", nodeName, rule)
+		}
+	}
+
+	framework.ConformanceIt("should support MetalLB underlay service lifecycle", func() {
+		env := setupUnderlayEnvironment()
 
 		ginkgo.By("Create deploy in underlay subnet")
-		annotations := map[string]string{
-			util.LogicalSwitchAnnotation: subnetName,
-		}
 		podLabels := map[string]string{"app": "nginx"}
 
 		args := []string{"netexec", "--http-port", strconv.Itoa(curlListenPort)}
-		deploy := framework.MakeDeployment(deployName, 3, podLabels, annotations, "nginx", framework.AgnhostImage, "")
+		deploy := framework.MakeDeployment(deployName, 3, podLabels, env.annotations, "nginx", framework.AgnhostImage, "")
 		deploy.Spec.Template.Spec.Containers[0].Args = args
 		_ = deployClient.CreateSync(deploy)
 
@@ -402,11 +640,31 @@ var _ = framework.Describe("[group:metallb]", func() {
 
 		service = f.ServiceClient().Get(serviceName)
 		service2 = f.ServiceClient().Get(serviceName2)
+		tcpLoadBalancer := f.VpcClient().Get(util.DefaultVpc).Status.TCPLoadBalancer
+		framework.ExpectNotEmpty(tcpLoadBalancer, "default VPC TCP load balancer should be set")
+		vipNodes := make(map[string]string, 2)
+		for _, svc := range []*corev1.Service{service, service2} {
+			for _, clusterIP := range svc.Spec.ClusterIPs {
+				if util.CheckProtocol(clusterIP) == apiv1.ProtocolIPv4 {
+					expectNoUnderlayVIPBypassLFlow(clusterIP, curlListenPort)
+				}
+			}
+			for _, ingress := range svc.Status.LoadBalancer.Ingress {
+				if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
+					continue
+				}
+				vipNode := getVIPNodeFromService(f, svc.Name)
+				vipNodes[ingress.IP] = vipNode
+				waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, util.NodeLspName(vipNode), 30*time.Second)
+				waitUnderlayVIPBypassLFlow(ingress.IP, curlListenPort, 30*time.Second)
+				waitUnderlayVIPNodeLFlow(ingress.IP, util.NodeLspName(vipNode), curlListenPort, 30*time.Second)
+			}
+		}
 
 		ginkgo.By("Waiting for underlay OpenFlow rules to be installed for both services")
 		for _, svc := range []*corev1.Service{service, service2} {
 			for _, ingress := range svc.Status.LoadBalancer.Ingress {
-				waitUnderlayServiceFlowOnAnyNode(nodeNames, providerNetworkName, ingress.IP, curlListenPort, 15*time.Second)
+				waitUnderlayServiceFlowOnAnyNode(nodeNames, providerNetworkName, ingress.IP, curlListenPort, 30*time.Second)
 			}
 		}
 
@@ -419,18 +677,57 @@ var _ = framework.Describe("[group:metallb]", func() {
 			}
 		}
 
+		ginkgo.By("Switching the first service to externalTrafficPolicy=Cluster")
+		modifiedService := service.DeepCopy()
+		modifiedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+		service = serviceClient.PatchSync(service, modifiedService, func(s *corev1.Service) (bool, error) {
+			return s.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeCluster, nil
+		}, "externalTrafficPolicy is Cluster")
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
+				continue
+			}
+			waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, "", 30*time.Second)
+			waitUnderlayVIPBypassLFlowCleaned(ingress.IP, curlListenPort, 30*time.Second)
+			waitUnderlayVIPNodeLFlowCleaned(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
+		}
+		waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
+
+		ginkgo.By("Checking the first service remains reachable with externalTrafficPolicy=Cluster")
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+				checkReachable(f, containerID, clientIPv4, clientIPv6, ingress.IP, "80", clusterName, true)
+			}
+		}
+
+		ginkgo.By("Switching the first service back to externalTrafficPolicy=Local")
+		modifiedService = service.DeepCopy()
+		modifiedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+		service = serviceClient.PatchSync(service, modifiedService, func(s *corev1.Service) (bool, error) {
+			return s.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal, nil
+		}, "externalTrafficPolicy is Local")
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
+				continue
+			}
+			waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), 30*time.Second)
+			waitUnderlayVIPBypassLFlow(ingress.IP, curlListenPort, 30*time.Second)
+			waitUnderlayVIPNodeLFlow(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
+		}
+		waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
+
 		ginkgo.By("Restarting ds kube-ovn-cni")
 		daemonSetClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
 		ds := daemonSetClient.Get("kube-ovn-cni")
 		daemonSetClient.RestartSync(ds)
 
-		ginkgo.By("Waiting for underlay OpenFlow rules to be restored within 15s")
+		ginkgo.By("Waiting for underlay OpenFlow rules to be restored within 30s")
 		for i, ingress := range service.Status.LoadBalancer.Ingress {
 			lbsvcIP := ingress.IP
 			ginkgo.By(fmt.Sprintf("Checking flow restoration for service %s[%d] with IP %s", service.Name, i, lbsvcIP))
 			vipNode := getVIPNode(containerID, lbsvcIP, clusterName)
-			flowRestored := waitUnderlayServiceFlow(vipNode, providerNetworkName, lbsvcIP, curlListenPort, 15*time.Second)
-			framework.ExpectEqual(flowRestored, true, "underlay service OpenFlow should be restored within 15s")
+			flowRestored := waitUnderlayServiceFlow(vipNode, providerNetworkName, lbsvcIP, curlListenPort, 30*time.Second)
+			framework.ExpectEqual(flowRestored, true, "underlay service OpenFlow should be restored within 30s")
 		}
 
 		ginkgo.By("Deleting the first service")
@@ -438,8 +735,14 @@ var _ = framework.Describe("[group:metallb]", func() {
 
 		ginkgo.By("Waiting for first service's underlay OpenFlow rules to be cleaned up")
 		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			waitUnderlayServiceFlowCleaned(nodeNames, providerNetworkName, ingress.IP, curlListenPort, 15*time.Second)
+			waitUnderlayServiceFlowCleaned(nodeNames, providerNetworkName, ingress.IP, curlListenPort, 30*time.Second)
+			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+				waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, "", 30*time.Second)
+				waitUnderlayVIPBypassLFlowCleaned(ingress.IP, curlListenPort, 30*time.Second)
+				waitUnderlayVIPNodeLFlowCleaned(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
+			}
 		}
+		waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
 
 		ginkgo.By("Checking the second service is still reachable after first service deletion")
 		for i, ingress := range service2.Status.LoadBalancer.Ingress {
@@ -449,11 +752,9 @@ var _ = framework.Describe("[group:metallb]", func() {
 		}
 
 		ginkgo.By("Enabling u2oInterconnection on subnet")
-		subnet = subnetClient.Get(subnetName)
+		subnet := subnetClient.Get(subnetName)
 		subnet.Spec.U2OInterconnection = true
 		subnet = subnetClient.UpdateSync(subnet, metav1.UpdateOptions{}, 30*time.Second)
-
-		ginkgo.By("Waiting for u2oInterconnection MAC to be set")
 		framework.WaitUntil(5*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
 			subnet = subnetClient.Get(subnetName)
 			return subnet.Status.U2OInterconnectionMAC != "", nil
@@ -501,7 +802,348 @@ var _ = framework.Describe("[group:metallb]", func() {
 			checkReachable(f, containerID, clientIPv4, clientIPv6, lbsvcIP2, "80", clusterName, true)
 		}
 	})
+
+	framework.ConformanceIt("should allow an internal client on the VIP node to access an underlay VIP", func() {
+		env := setupInternalVIPEnvironment()
+		runInternalVIPTopologyCase(env, internalVIPClientOnVIPNode)
+	})
+
+	framework.ConformanceIt("should allow an internal client on a non-VIP backend node to access an underlay VIP", func() {
+		env := setupInternalVIPEnvironment()
+		runInternalVIPTopologyCase(env, internalVIPClientOnNonVIPBackendNode)
+	})
+
+	framework.ConformanceIt("should allow an internal client on a node without backends to access an underlay VIP", func() {
+		env := setupInternalVIPEnvironment()
+		runInternalVIPTopologyCase(env, internalVIPClientOnNonBackendNode)
+	})
+
+	framework.ConformanceIt("should allow a U2O client on the VIP node to access an underlay VIP with policy routes", func() {
+		env := setupInternalVIPEnvironment()
+		enableU2O(env)
+		addUnderlayPolicyRoutes(env.cidrV4)
+		runInternalVIPTopologyCase(env, internalVIPClientOnVIPNode)
+		disableU2O(env)
+	})
+
+	framework.ConformanceIt("should allow a U2O client on a non-VIP backend node to access an underlay VIP with policy routes", func() {
+		env := setupInternalVIPEnvironment()
+		enableU2O(env)
+		addUnderlayPolicyRoutes(env.cidrV4)
+		runInternalVIPTopologyCase(env, internalVIPClientOnNonVIPBackendNode)
+		disableU2O(env)
+	})
+
+	framework.ConformanceIt("should allow a U2O client on a node without backends to access an underlay VIP with policy routes", func() {
+		env := setupInternalVIPEnvironment()
+		enableU2O(env)
+		addUnderlayPolicyRoutes(env.cidrV4)
+		runInternalVIPTopologyCase(env, internalVIPClientOnNonBackendNode)
+		disableU2O(env)
+	})
+
+	framework.ConformanceIt("should move internal underlay VIP traffic when the announcing node changes", func() {
+		env := setupInternalVIPEnvironment()
+		enableU2O(env)
+		addUnderlayPolicyRoutes(env.cidrV4)
+
+		firstVIPNode := env.vipNode
+		secondVIPNode := env.nonVIPBackendNode
+
+		tcpLoadBalancer := f.VpcClient().Get(util.DefaultVpc).Status.TCPLoadBalancer
+		framework.ExpectNotEmpty(tcpLoadBalancer, "default VPC TCP load balancer should be set")
+		waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, env.vip, util.NodeLspName(firstVIPNode), 30*time.Second)
+
+		moveVIP := func(oldVIPNode, newVIPNode string) {
+			ginkgo.By(fmt.Sprintf("Moving the L2Advertisement from %s to %s", oldVIPNode, newVIPNode))
+			advertisement := env.l2Advertisement.DeepCopy()
+			advertisement.Spec.NodeSelectors = []metav1.LabelSelector{{
+				MatchLabels: map[string]string{
+					"kubernetes.io/hostname": newVIPNode,
+				},
+			}}
+			updatedAdvertisement, err := f.MetallbClientSet.UpdateL2Advertisement(advertisement)
+			framework.ExpectNoError(err)
+			env.l2Advertisement = updatedAdvertisement
+			waitVIPNodeFromService(f, env.service.Name, newVIPNode, 30*time.Second)
+
+			waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, env.vip, util.NodeLspName(newVIPNode), 30*time.Second)
+			waitUnderlayVIPBypassLFlow(env.vip, curlListenPort, 30*time.Second)
+			waitUnderlayVIPNodeLFlowCleaned(env.vip, util.NodeLspName(oldVIPNode), curlListenPort, 30*time.Second)
+			waitUnderlayVIPNodeLFlow(env.vip, util.NodeLspName(newVIPNode), curlListenPort, 30*time.Second)
+			waitUnderlayVIPBackendLFlowAbsent(env.backendPods, oldVIPNode, 30*time.Second)
+			waitUnderlayVIPBackendLFlows(env.backendPods, newVIPNode, 30*time.Second)
+		}
+
+		moveVIP(firstVIPNode, secondVIPNode)
+		moveVIP(secondVIPNode, firstVIPNode)
+		moveVIP(firstVIPNode, secondVIPNode)
+
+		env.vipNode = secondVIPNode
+		env.nonVIPBackendNode = firstVIPNode
+		runInternalVIPTopologyCase(env, internalVIPClientOnVIPNode)
+		runInternalVIPTopologyCase(env, internalVIPClientOnNonVIPBackendNode)
+		runInternalVIPTopologyCase(env, internalVIPClientOnNonBackendNode)
+		disableU2O(env)
+	})
 })
+
+func checkInternalPodVIPBackend(f *framework.Framework, client *corev1.Pod, vip, vipNode string) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By("Checking the backend observes the original client Pod IP")
+	clientIPCommand := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s/clientip", net.JoinHostPort(vip, "80"))
+	framework.WaitUntil(2*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+		output, _, err := framework.ExecShellInPod(context.Background(), f, client.Namespace, client.Name, clientIPCommand)
+		if err != nil {
+			return false, nil
+		}
+		observedClientIP, _, err := net.SplitHostPort(strings.TrimSpace(output))
+		if err != nil {
+			return false, nil
+		}
+		return observedClientIP == client.Status.PodIP, nil
+	}, "underlay VIP backend should observe the original client Pod IP")
+
+	ginkgo.By("Checking the selected backend is on the VIP announcing node")
+	hostnameCommand := fmt.Sprintf("curl -q -s --connect-timeout 2 --max-time 2 %s/hostname", net.JoinHostPort(vip, "80"))
+	framework.WaitUntil(2*time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
+		output, _, err := framework.ExecShellInPod(context.Background(), f, client.Namespace, client.Name, hostnameCommand)
+		if err != nil {
+			return false, nil
+		}
+
+		backend, err := f.PodClient().Get(ctx, strings.TrimSpace(output), metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return backend.Spec.NodeName == vipNode, nil
+	}, "underlay pod traffic to VIP should be DNATed on the VIP node")
+}
+
+func waitServiceVIPNodeMarkers(lbName string, service *corev1.Service, vipNodes map[string]string, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	for _, ingress := range service.Status.LoadBalancer.Ingress {
+		if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+			framework.ExpectHaveKey(vipNodes, ingress.IP)
+			waitLoadBalancerVIPNodeMarker(lbName, ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), timeout)
+		}
+	}
+}
+
+func waitLoadBalancerVIPNodeMarker(lbName, vip, expectedNodeLSP string, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	key := localExternalVIPKeyPrefix + util.JoinHostPort(vip, curlListenPort)
+	description := fmt.Sprintf("load balancer %s external ID %s should be absent", lbName, key)
+	if expectedNodeLSP != "" {
+		description = fmt.Sprintf("load balancer %s external ID %s should equal %q", lbName, key, expectedNodeLSP)
+	}
+	framework.WaitUntil(time.Second, timeout, func(_ context.Context) (bool, error) {
+		exists, err := hasLoadBalancerExternalID(lbName, key, expectedNodeLSP)
+		if err != nil {
+			return false, nil
+		}
+		if expectedNodeLSP == "" {
+			return !exists, nil
+		}
+		return exists, nil
+	}, description)
+}
+
+func hasLoadBalancerExternalID(lbName, key, value string) (bool, error) {
+	condition := fmt.Sprintf(`'external_ids:"%s"!=[]'`, key)
+	if value != "" {
+		condition = fmt.Sprintf(`'external_ids:"%s"="%s"'`, key, value)
+	}
+	stdout, stderr, err := framework.NBExec(
+		"ovn-nbctl",
+		"--data=bare",
+		"--format=csv",
+		"--no-heading",
+		"--columns=_uuid",
+		"find",
+		"Load_Balancer",
+		"name="+lbName,
+		condition,
+	)
+	if err != nil {
+		return false, fmt.Errorf("finding load balancer %s external ID %s: %w, stderr: %s", lbName, key, err, stderr)
+	}
+	return strings.TrimSpace(string(stdout)) != "", nil
+}
+
+func waitUnderlayVIPBypassLFlow(vip string, port int32, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	match := fmt.Sprintf("ct.new && ip4.dst == %s && tcp.dst == %d", vip, port)
+	waitLogicalFlowCount(1, timeout, "exactly one VIP bypass lflow should exist", func(flow logicalFlow) bool {
+		return flow.pipeline == "ingress" && flow.tableID == 13 && flow.priority == 139 &&
+			flow.match == match && flow.actions == "next;"
+	})
+}
+
+func expectNoUnderlayVIPBypassLFlow(vip string, port int32) {
+	ginkgo.GinkgoHelper()
+
+	waitUnderlayVIPBypassLFlowCleaned(vip, port, 5*time.Second)
+}
+
+func waitUnderlayVIPBypassLFlowCleaned(vip string, port int32, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	match := fmt.Sprintf("ct.new && ip4.dst == %s && tcp.dst == %d", vip, port)
+	waitLogicalFlowCount(0, timeout, "VIP bypass lflow should be absent", func(flow logicalFlow) bool {
+		return flow.pipeline == "ingress" && flow.tableID == 13 && flow.priority == 139 &&
+			flow.match == match && flow.actions == "next;"
+	})
+}
+
+func waitUnderlayVIPNodeLFlow(vip, vipNodeLSP string, port int32, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	match := fmt.Sprintf(
+		"ct.new && ip4.dst == %s && tcp.dst == %d && is_chassis_resident(\"%s\")",
+		vip,
+		port,
+		vipNodeLSP,
+	)
+	waitLogicalFlowCount(1, timeout, "exactly one VIP DNAT lflow should be resident on the announcing node", func(flow logicalFlow) bool {
+		return flow.pipeline == "ingress" && flow.tableID == 13 && flow.priority == 140 &&
+			flow.match == match && strings.Contains(flow.actions, "ct_lb_mark")
+	})
+}
+
+func waitUnderlayVIPNodeLFlowCleaned(vip, vipNodeLSP string, port int32, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	match := fmt.Sprintf(
+		"ct.new && ip4.dst == %s && tcp.dst == %d && is_chassis_resident(\"%s\")",
+		vip,
+		port,
+		vipNodeLSP,
+	)
+	waitLogicalFlowCount(0, timeout, "VIP DNAT lflow should be absent from the old announcing node", func(flow logicalFlow) bool {
+		return flow.pipeline == "ingress" && flow.tableID == 13 && flow.priority == 140 && flow.match == match
+	})
+}
+
+func waitUnderlayVIPBackendLFlows(backendPods []corev1.Pod, vipNode string, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	vipNodeBackendFound := false
+	for i := range backendPods {
+		pod := &backendPods[i]
+		expectedCount := 0
+		if pod.Spec.NodeName == vipNode {
+			expectedCount = 1
+			vipNodeBackendFound = true
+		}
+		waitUnderlayVIPBackendLFlow(*pod, vipNode, expectedCount, timeout)
+	}
+	framework.ExpectTrue(vipNodeBackendFound, "no backend is available on VIP node %s", vipNode)
+}
+
+func waitUnderlayVIPBackendLFlowAbsent(backendPods []corev1.Pod, vipNode string, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	for i := range backendPods {
+		waitUnderlayVIPBackendLFlow(backendPods[i], vipNode, 0, timeout)
+	}
+}
+
+func waitUnderlayVIPBackendLFlow(backendPod corev1.Pod, vipNode string, expectedCount int, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	backendIP := podIPv4(backendPod)
+	backendMAC := backendPod.Annotations[util.MacAddressAnnotation]
+	framework.ExpectNotEmpty(backendMAC, "backend Pod %s has no MAC annotation", backendPod.Name)
+	backendLSP := ovs.PodNameToPortName(backendPod.Name, backendPod.Namespace, util.OvnProvider)
+	vipNodeLSP := util.NodeLspName(vipNode)
+	match := fmt.Sprintf(
+		"reg0[2] != 0 && ip4.dst == %s && is_chassis_resident(\"%s\")",
+		backendIP,
+		vipNodeLSP,
+	)
+	actions := fmt.Sprintf("eth.dst = %s; outport = \"%s\"; output;", backendMAC, backendLSP)
+	description := fmt.Sprintf("targeted backend lflow count for Pod %s on VIP node %s should be %d", backendPod.Name, vipNode, expectedCount)
+	waitLogicalFlowCount(expectedCount, timeout, description, func(flow logicalFlow) bool {
+		return flow.pipeline == "ingress" && flow.tableID == 28 && flow.priority == 55 &&
+			flow.match == match && flow.actions == actions
+	})
+}
+
+func podIPv4(pod corev1.Pod) string {
+	ginkgo.GinkgoHelper()
+
+	for _, podIP := range pod.Status.PodIPs {
+		if util.CheckProtocol(podIP.IP) == apiv1.ProtocolIPv4 {
+			return podIP.IP
+		}
+	}
+	framework.Failf("Pod %s/%s has no IPv4 address", pod.Namespace, pod.Name)
+	return ""
+}
+
+func waitLogicalFlowCount(expectedCount int, timeout time.Duration, description string, match func(logicalFlow) bool) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(time.Second, timeout, func(_ context.Context) (bool, error) {
+		flows, err := listLogicalFlows()
+		if err != nil {
+			return false, nil
+		}
+		count := 0
+		for _, flow := range flows {
+			if match(flow) {
+				count++
+			}
+		}
+		return count == expectedCount, nil
+	}, description)
+}
+
+func listLogicalFlows() ([]logicalFlow, error) {
+	output, err := exec.Command(
+		"kubectl", "ko", "sbctl",
+		"--format=csv",
+		"--data=bare",
+		"--no-heading",
+		"--columns=pipeline,table_id,priority,match,actions",
+		"find", "Logical_Flow",
+	).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("listing OVN logical flows: %w, output: %s", err, output)
+	}
+
+	records, err := csv.NewReader(strings.NewReader(string(output))).ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("parsing OVN logical flows: %w", err)
+	}
+	flows := make([]logicalFlow, 0, len(records))
+	for _, record := range records {
+		if len(record) != 5 {
+			return nil, fmt.Errorf("unexpected logical flow record with %d columns: %q", len(record), record)
+		}
+		tableID, err := strconv.Atoi(record[1])
+		if err != nil {
+			return nil, fmt.Errorf("parsing logical flow table ID %q: %w", record[1], err)
+		}
+		priority, err := strconv.Atoi(record[2])
+		if err != nil {
+			return nil, fmt.Errorf("parsing logical flow priority %q: %w", record[2], err)
+		}
+		flows = append(flows, logicalFlow{
+			pipeline: record[0],
+			tableID:  tableID,
+			priority: priority,
+			match:    record[3],
+			actions:  record[4],
+		})
+	}
+	return flows, nil
+}
 
 func checkReachable(f *framework.Framework, containerID, sourceIPv4, sourceIPv6, targetIP, targetPort, clusterName string, expectReachable bool) {
 	ginkgo.GinkgoHelper()
@@ -576,6 +1218,48 @@ func checkReachable(f *framework.Framework, containerID, sourceIPv4, sourceIPv6,
 	backendPod := f.PodClient().GetPod(backendPodName)
 	backendPodNode := backendPod.Spec.NodeName
 	framework.ExpectEqual(backendPodNode, vipNode)
+}
+
+func getVIPNodeFromService(f *framework.Framework, serviceName string) string {
+	ginkgo.GinkgoHelper()
+
+	var vipNode string
+	framework.WaitUntil(time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+		statuses, err := f.MetallbClientSet.ListServiceL2Statuses()
+		if err != nil {
+			return false, err
+		}
+		for _, status := range statuses.Items {
+			if status.Status.ServiceNamespace == f.Namespace.Name && status.Status.ServiceName == serviceName {
+				vipNode = status.Status.Node
+			}
+			if vipNode != "" {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, "MetalLB did not assign a VIP node for service "+serviceName)
+	framework.Logf("VIP node for service %s is %s", serviceName, vipNode)
+	return vipNode
+}
+
+func waitVIPNodeFromService(f *framework.Framework, serviceName, expectedNode string, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	framework.WaitUntil(time.Second, timeout, func(_ context.Context) (bool, error) {
+		statuses, err := f.MetallbClientSet.ListServiceL2Statuses()
+		if err != nil {
+			return false, nil
+		}
+		for _, status := range statuses.Items {
+			if status.Status.ServiceNamespace == f.Namespace.Name &&
+				status.Status.ServiceName == serviceName &&
+				status.Status.Node == expectedNode {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, fmt.Sprintf("MetalLB service %s should be announced from node %s", serviceName, expectedNode))
 }
 
 func getVIPNode(containerID, targetIP, clusterName string) string {

--- a/test/e2e/metallb/e2e_test.go
+++ b/test/e2e/metallb/e2e_test.go
@@ -501,7 +501,7 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 		return env
 	}
 
-	runInternalVIPTopologyCase := func(env *internalVIPTestEnvironment, topology internalVIPClientTopology) {
+	createInternalVIPClient := func(env *internalVIPTestEnvironment, topology internalVIPClientTopology) *corev1.Pod {
 		var nodeName string
 		switch topology {
 		case internalVIPClientOnVIPNode:
@@ -525,9 +525,38 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 			nil,
 		)
 		client.Spec.NodeName = nodeName
-		client = f.PodClient().CreateSync(client)
+		return f.PodClient().CreateSync(client)
+	}
+
+	runInternalVIPTopologyCase := func(env *internalVIPTestEnvironment, topology internalVIPClientTopology) {
+		client := createInternalVIPClient(env, topology)
 		defer f.PodClient().DeleteSync(client.Name)
 		checkInternalPodVIPBackend(f, client, env.vip, env.vipNode)
+	}
+
+	moveInternalVIPNode := func(env *internalVIPTestEnvironment, newVIPNode, lbName string, expectBackendL2Lookup bool) {
+		oldVIPNode := env.vipNode
+		ginkgo.By(fmt.Sprintf("Moving the L2Advertisement from %s to %s", oldVIPNode, newVIPNode))
+		advertisement := env.l2Advertisement.DeepCopy()
+		advertisement.Spec.NodeSelectors = []metav1.LabelSelector{{
+			MatchLabels: map[string]string{
+				"kubernetes.io/hostname": newVIPNode,
+			},
+		}}
+		updatedAdvertisement, err := f.MetallbClientSet.UpdateL2Advertisement(advertisement)
+		framework.ExpectNoError(err)
+		env.l2Advertisement = updatedAdvertisement
+		waitVIPNodeFromService(f, env.service.Name, newVIPNode, 30*time.Second)
+
+		waitLoadBalancerVIPNodeMarker(lbName, env.vip, util.NodeLspName(newVIPNode), 30*time.Second)
+		waitUnderlayVIPBypassLFlow(env.vip, curlListenPort, 30*time.Second)
+		waitUnderlayVIPNodeLFlowCleaned(env.vip, util.NodeLspName(oldVIPNode), curlListenPort, 30*time.Second)
+		waitUnderlayVIPNodeLFlow(env.vip, util.NodeLspName(newVIPNode), curlListenPort, 30*time.Second)
+		if expectBackendL2Lookup {
+			waitUnderlayVIPBackendLFlowAbsent(env.backendPods, oldVIPNode, 30*time.Second)
+			waitUnderlayVIPBackendLFlows(env.backendPods, newVIPNode, 30*time.Second)
+		}
+		env.vipNode = newVIPNode
 	}
 
 	enableU2O := func(env *internalVIPTestEnvironment) {
@@ -700,6 +729,22 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 			}
 		}
 
+		ginkgo.By("Refreshing endpoints while the first service uses externalTrafficPolicy=Cluster")
+		deployClient.SetScale(deployName, 2)
+		deployClient.RolloutStatus(deployName)
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+				waitLoadBalancerVIPBackendCount(tcpLoadBalancer, ingress.IP, curlListenPort, 2, 30*time.Second)
+			}
+		}
+		deployClient.SetScale(deployName, 3)
+		deployClient.RolloutStatus(deployName)
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+				waitLoadBalancerVIPBackendCount(tcpLoadBalancer, ingress.IP, curlListenPort, 3, 30*time.Second)
+			}
+		}
+
 		ginkgo.By("Switching the first service back to externalTrafficPolicy=Local")
 		modifiedService = service.DeepCopy()
 		modifiedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
@@ -855,24 +900,8 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 		waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, env.vip, util.NodeLspName(firstVIPNode), 30*time.Second)
 
 		moveVIP := func(oldVIPNode, newVIPNode string) {
-			ginkgo.By(fmt.Sprintf("Moving the L2Advertisement from %s to %s", oldVIPNode, newVIPNode))
-			advertisement := env.l2Advertisement.DeepCopy()
-			advertisement.Spec.NodeSelectors = []metav1.LabelSelector{{
-				MatchLabels: map[string]string{
-					"kubernetes.io/hostname": newVIPNode,
-				},
-			}}
-			updatedAdvertisement, err := f.MetallbClientSet.UpdateL2Advertisement(advertisement)
-			framework.ExpectNoError(err)
-			env.l2Advertisement = updatedAdvertisement
-			waitVIPNodeFromService(f, env.service.Name, newVIPNode, 30*time.Second)
-
-			waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, env.vip, util.NodeLspName(newVIPNode), 30*time.Second)
-			waitUnderlayVIPBypassLFlow(env.vip, curlListenPort, 30*time.Second)
-			waitUnderlayVIPNodeLFlowCleaned(env.vip, util.NodeLspName(oldVIPNode), curlListenPort, 30*time.Second)
-			waitUnderlayVIPNodeLFlow(env.vip, util.NodeLspName(newVIPNode), curlListenPort, 30*time.Second)
-			waitUnderlayVIPBackendLFlowAbsent(env.backendPods, oldVIPNode, 30*time.Second)
-			waitUnderlayVIPBackendLFlows(env.backendPods, newVIPNode, 30*time.Second)
+			framework.ExpectEqual(env.vipNode, oldVIPNode)
+			moveInternalVIPNode(env, newVIPNode, tcpLoadBalancer, true)
 		}
 
 		moveVIP(firstVIPNode, secondVIPNode)
@@ -885,6 +914,31 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 		runInternalVIPTopologyCase(env, internalVIPClientOnNonVIPBackendNode)
 		runInternalVIPTopologyCase(env, internalVIPClientOnNonBackendNode)
 		disableU2O(env)
+	})
+
+	framework.ConformanceIt("should keep ClientIP session affinity on the announcing node when the internal underlay VIP moves", func() {
+		env := setupInternalVIPEnvironment()
+		client := createInternalVIPClient(env, internalVIPClientOnNonBackendNode)
+		defer f.PodClient().DeleteSync(client.Name)
+
+		ginkgo.By("Enabling ClientIP session affinity on the LoadBalancer service")
+		modifiedService := env.service.DeepCopy()
+		modifiedService.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
+		env.service = serviceClient.PatchSync(env.service, modifiedService, func(s *corev1.Service) (bool, error) {
+			return s.Spec.SessionAffinity == corev1.ServiceAffinityClientIP, nil
+		}, "sessionAffinity is ClientIP")
+
+		tcpSessionLoadBalancer := f.VpcClient().Get(util.DefaultVpc).Status.TCPSessionLoadBalancer
+		framework.ExpectNotEmpty(tcpSessionLoadBalancer, "default VPC TCP session load balancer should be set")
+		waitLoadBalancerVIPNodeMarker(tcpSessionLoadBalancer, env.vip, util.NodeLspName(env.vipNode), 30*time.Second)
+		waitUnderlayVIPAffinityLFlow(env.vip, util.NodeLspName(env.vipNode), 30*time.Second)
+		checkInternalPodVIPBackend(f, client, env.vip, env.vipNode)
+
+		oldVIPNodeLSP := util.NodeLspName(env.vipNode)
+		moveInternalVIPNode(env, env.nonVIPBackendNode, tcpSessionLoadBalancer, false)
+		waitUnderlayVIPAffinityLFlowCleaned(env.vip, oldVIPNodeLSP, 30*time.Second)
+		waitUnderlayVIPAffinityLFlow(env.vip, util.NodeLspName(env.vipNode), 30*time.Second)
+		checkInternalPodVIPBackend(f, client, env.vip, env.vipNode)
 	})
 })
 
@@ -972,6 +1026,38 @@ func hasLoadBalancerExternalID(lbName, key, value string) (bool, error) {
 		return false, fmt.Errorf("finding load balancer %s external ID %s: %w, stderr: %s", lbName, key, err, stderr)
 	}
 	return strings.TrimSpace(string(stdout)) != "", nil
+}
+
+func waitLoadBalancerVIPBackendCount(lbName, vip string, port int32, expectedCount int, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	vipKey := util.JoinHostPort(vip, port)
+	framework.WaitUntil(time.Second, timeout, func(_ context.Context) (bool, error) {
+		backendList, err := getLoadBalancerVIPBackends(lbName, vipKey)
+		if err != nil {
+			return false, nil
+		}
+		if backendList == "" {
+			return expectedCount == 0, nil
+		}
+		return len(strings.Split(backendList, ",")) == expectedCount, nil
+	}, fmt.Sprintf("load balancer %s VIP %s should have %d backends", lbName, vipKey, expectedCount))
+}
+
+func getLoadBalancerVIPBackends(lbName, vipKey string) (string, error) {
+	stdout, stderr, err := framework.NBExec(
+		"ovn-nbctl",
+		"--data=bare",
+		"--no-heading",
+		"get",
+		"Load_Balancer",
+		lbName,
+		fmt.Sprintf("'vips:%q'", vipKey),
+	)
+	if err != nil {
+		return "", fmt.Errorf("getting load balancer %s vip %s backends: %w, stderr: %s", lbName, vipKey, err, stderr)
+	}
+	return strings.Trim(strings.TrimSpace(string(stdout)), `"`), nil
 }
 
 func waitUnderlayVIPBypassLFlow(vip string, port int32, timeout time.Duration) {
@@ -1072,6 +1158,29 @@ func waitUnderlayVIPBackendLFlow(backendPod corev1.Pod, vipNode string, expected
 		return flow.pipeline == "ingress" && flow.tableID == 28 && flow.priority == 55 &&
 			flow.match == match && flow.actions == actions
 	})
+}
+
+func waitUnderlayVIPAffinityLFlow(vip, vipNodeLSP string, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	waitLogicalFlowCount(1, timeout, "session affinity lflow should be resident on the announcing node", func(flow logicalFlow) bool {
+		return isUnderlayVIPAffinityLFlow(flow, vip, vipNodeLSP)
+	})
+}
+
+func waitUnderlayVIPAffinityLFlowCleaned(vip, vipNodeLSP string, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	waitLogicalFlowCount(0, timeout, "session affinity lflow should be absent from the old announcing node", func(flow logicalFlow) bool {
+		return isUnderlayVIPAffinityLFlow(flow, vip, vipNodeLSP)
+	})
+}
+
+func isUnderlayVIPAffinityLFlow(flow logicalFlow, vip, vipNodeLSP string) bool {
+	return flow.pipeline == "ingress" && flow.tableID == 13 && flow.priority == 150 &&
+		strings.Contains(flow.match, fmt.Sprintf("ip4.dst == %s", vip)) &&
+		strings.Contains(flow.match, fmt.Sprintf("is_chassis_resident(\"%s\")", vipNodeLSP)) &&
+		strings.Contains(flow.actions, "ct_lb_mark")
 }
 
 func podIPv4(pod corev1.Pod) string {

--- a/test/e2e/metallb/e2e_test.go
+++ b/test/e2e/metallb/e2e_test.go
@@ -405,7 +405,7 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 	}
 
 	setupInternalVIPEnvironment := func() *internalVIPTestEnvironment {
-		f.SkipVersionPriorTo(1, 17, "Internal underlay MetalLB VIP access was introduced in v1.17.")
+		f.SkipVersionPriorTo(1, 15, "Internal underlay MetalLB VIP access was introduced in v1.15.")
 		if !f.HasIPv4() {
 			ginkgo.Skip("internal MetalLB VIP topology cases require IPv4")
 		}


### PR DESCRIPTION
## Summary

- watch MetalLB `ServiceL2Status` and record the announcing node LSP for each external VIP of a LoadBalancer Service with `externalTrafficPolicy=Local`
- defer external VIP DNAT until traffic reaches the announcing chassis and select only backends local to that chassis
- add a targeted `ls_in_l2_lkup` priority 55 flow to rewrite the destination MAC and output DNAT traffic directly to the selected backend LSP on underlay switches
- reconcile `externalTrafficPolicy` changes so switching from `Local` to `Cluster` removes the VIP marker and generated local flows, while switching back restores them
- split the MetalLB underlay coverage into eight independent cases and verify flow creation, cleanup, client IP preservation, and announcing-node changes

## Traffic flow

### External client to underlay VIP

```mermaid
flowchart LR
    client["External client"] -->|"ARP: VIP → VIP-node MAC"| underlay["Underlay L2 network"]
    underlay --> localnet["VIP announcing node<br/>localnet port"]
    localnet --> lb140["ls_in_lb priority 140<br/>VIP:port + is_chassis_resident(VIP-node LSP)<br/>DNAT to a backend on the VIP node"]
    lb140 --> l255["ls_in_l2_lkup priority 55<br/>eth.dst = backend MAC<br/>outport = backend LSP"]
    l255 --> backend["Backend Pod on VIP node"]
    backend -. "conntrack reverse NAT<br/>source = VIP" .-> client
```

### Internal Pod on the VIP node

The client is already on the chassis selected by MetalLB, so the request is DNATed locally. The priority 139 bypass flow is not used.

```mermaid
flowchart LR
    subgraph vipNode["VIP announcing node"]
        client["Internal client Pod"]
        lb140["ls_in_lb priority 140<br/>is_chassis_resident(VIP-node LSP) = true<br/>DNAT VIP → local backend IP"]
        l255["ls_in_l2_lkup priority 55<br/>eth.dst = backend MAC<br/>outport = backend LSP"]
        backend["Backend Pod on VIP node"]

        client --> lb140 --> l255 --> backend
        backend -. "conntrack reverse NAT<br/>source = VIP" .-> client
    end
```

### Internal Pod on a non-VIP node

Whether the client node has another backend or has no backend does not change the forwarding path. DNAT must wait until the packet reaches the VIP announcing node.

```mermaid
flowchart LR
    withBackend["Client Pod on non-VIP node<br/>a local backend exists but is ignored"]
    withoutBackend["Client Pod on non-VIP node<br/>no local backend"]

    subgraph clientNode["Non-VIP client node"]
        lb140Miss["ls_in_lb priority 140 does not match<br/>VIP-node LSP is not chassis-resident"]
        lb139["ls_in_lb priority 139: next<br/>prevent generic priority 120 DNAT"]
        preserve["Preserve destination<br/>IP = VIP<br/>MAC = VIP-node MAC"]
        lb140Miss --> lb139 --> preserve
    end

    withBackend --> lb140Miss
    withoutBackend --> lb140Miss
    preserve --> underlay["Underlay L2 forwarding<br/>to VIP announcing node"]

    subgraph vipNode["VIP announcing node"]
        localnet["Packet enters through localnet"]
        lb140Hit["ls_in_lb priority 140 matches<br/>is_chassis_resident(VIP-node LSP) = true<br/>DNAT VIP → backend IP"]
        l255["ls_in_l2_lkup priority 55<br/>eth.dst = backend MAC<br/>outport = backend LSP"]
        backend["Backend Pod on VIP node"]
        localnet --> lb140Hit --> l255 --> backend
    end

    underlay --> localnet
    backend -. "conntrack reverse NAT<br/>source = VIP" .-> withBackend
    backend -. "conntrack reverse NAT<br/>source = VIP" .-> withoutBackend
```


## Generated logical flow templates

The controller records the announcing node LSP for each marked external VIP:

```text
Load_Balancer.external_ids:
  kube-ovn.io/local-external-vip/<VIP:port> = <VIP-node-LSP>
```

northd uses that marker to generate three related logical flows.

For cross-node internal traffic, the packet first leaves the non-VIP chassis through its localnet port while retaining the VIP IP and VIP-node MAC. When the physical frame reaches the announcing node, the provider bridge maps it back to the logical switch localnet LSP. The packet therefore traverses the logical switch ingress pipeline a second time on the VIP chassis, where priority 140 and then priority 55 can match.

### Priority 140: DNAT only on the VIP chassis

```text
table=13 (ls_in_lb), priority=140
match=(ct.new &&
       <ip4|ip6>.dst == <VIP> &&
       <tcp|udp|sctp>.dst == <port> &&
       is_chassis_resident("<VIP-node-LSP>"))
action=(ct_lb_mark(backends=<backends-on-VIP-node>);)
```

This flow selects only backends resident on the chassis currently announcing the VIP. It wins over priority 139 on that chassis.

### Priority 139: preserve the VIP on every other chassis

```text
table=13 (ls_in_lb), priority=139
match=(ct.new &&
       <ip4|ip6>.dst == <VIP> &&
       <tcp|udp|sctp>.dst == <port>)
action=(next;)
```

On a non-VIP chassis the priority 140 residency condition is false, so priority 139 wins. It prevents the packet from falling through to the generic priority 120 load-balancer flow, which would DNAT the packet before it reaches the VIP node. The packet therefore keeps both the VIP destination IP and VIP-node destination MAC while crossing the underlay network.

### Priority 55: repair L2 forwarding after DNAT on the VIP chassis

```text
table=28 (ls_in_l2_lkup), priority=55
match=(<conntrack-NAT-bit> != 0 &&
       <ip4|ip6>.dst == <backend-IP-on-VIP-node> &&
       is_chassis_resident("<VIP-node-LSP>"))
action=(eth.dst = <backend-MAC>;
        outport = "<backend-LSP>";
        output;)
```

The priority 140 flow changes the destination IP from the VIP to the backend IP, but it does not change the Ethernet destination. The packet still carries the VIP MAC, so normal L2 lookup would continue following the VIP/localnet path instead of delivering the packet to the backend Pod.

The existing generic priority 55 flow generated by `build_lswitch_dnat_mod_dl_dst_rules()` cannot cover this case because it deliberately returns when the logical switch has a router port:

```c
if (!op->nbsp || !op->od || !op->od->nbs || op->od->n_router_ports) {
    return;
}
```

An underlay logical switch has both router and localnet ports, so that generic flow is not generated. This PR adds only the targeted exception: a priority 55 flow is generated when the Load Balancer has a VIP-node marker, the backend is resident on that VIP chassis, and the backend logical switch is an underlay switch. This rewrites the destination MAC and directly outputs to the selected backend LSP without broadening the existing generic DNAT behavior.

## Flow ownership

- The controller consumes MetalLB `ServiceL2Status` and stores `VIP:port -> announcing node LSP` in the OVN Load Balancer `external_ids`.
- OVN northd uses that marker to generate the priority 139 and 140 `ls_in_lb` flows and the targeted priority 55 `ls_in_l2_lkup` backend flows.
- Marker removal, Service deletion, `externalTrafficPolicy` changes, and announcing-node changes clean up stale flows before installing the new set.
- ClusterIP entries are not marked and do not receive the priority 139 bypass flow.

## Validation

- `go test ./pkg/controller -count=1`
- `go test ./test/e2e/metallb -run '^$' -count=1`
- replayed the complete OVN patch chain on OVN revision `38e1a5c635aa8c8aacb051b24efd00adfdb46569`
- local three-node kind run 1: `8 Passed`, `0 Failed`, `536 Skipped`
- local three-node kind run 2: `8 Passed`, `0 Failed`, `536 Skipped`
- remote MetalLB IPv4 E2E: `8 Passed`, `0 Failed`, `536 Skipped`
- remote MetalLB IPv4, IPv6, and dual-stack jobs all passed: https://github.com/kubeovn/kube-ovn/actions/runs/29693385205
- `make lint` is blocked only by the pre-existing `pkg/util/file.go:36` G703 finding
