### PR TITLE
fix(chart): correct ovs-ipsec-keys volume indentation and Talos IPSEC docs

### DIFF
--- a/charts/kube-ovn-v2/README.md
+++ b/charts/kube-ovn-v2/README.md
@@ -39,9 +39,14 @@ ovsOvn:
   disableModulesManagement: true
   ovsDirectory: "/var/lib/openvswitch"
   ovnDirectory: "/var/lib/ovn"
+  ovsIpsecKeysDirectory: "/var/lib/ovs_ipsec_keys"
 cni:
   mountToolingDirectory: false
 ```
+
+All three `ovsOvn` directories must point outside `/etc`, which is read-only on Talos. `ovsIpsecKeysDirectory`
+only becomes a host mount when `features.enableOvnIpsec` is enabled, but setting it up front keeps IPSEC
+from failing later with `mkdir /etc/origin: read-only file system`.
 
 ## Migrate from v1 to v2 Chart
 
@@ -2202,6 +2207,15 @@ false
 			<td>Directory on the node where Open vSwitch (OVS) lives.</td>
 		</tr>
 		<tr>
+			<td>ovsOvn.ovsIpsecKeysDirectory</td>
+			<td>string</td>
+			<td><pre lang="json">
+"/etc/origin/ovs_ipsec_keys"
+</pre>
+</td>
+			<td>Directory on the node where Open vSwitch (OVS) IPSEC keys live.</td>
+		</tr>
+		<tr>
 			<td>ovsOvn.podAnnotations</td>
 			<td>object</td>
 			<td><pre lang="json">
@@ -2715,15 +2729,6 @@ false
 </pre>
 </td>
 		<td>- antarctica-west1</td>
-	</tr>
-	<tr>
-		<td>ovsOvn.ovsIpsecKeysDirectory</td>
-		<td>string</td>
-		<td><pre lang="json">
-"/etc/origin/ovs_ipsec_keys"
-</pre>
-</td>
-		<td>Directory on the node where Open vSwitch (OVS) IPSEC keys live.</td>
 	</tr>
 	<tr>
 		<td>ovsOvn.upgrade.enabled</td>

--- a/charts/kube-ovn-v2/README.md.gotmpl
+++ b/charts/kube-ovn-v2/README.md.gotmpl
@@ -39,9 +39,14 @@ ovsOvn:
   disableModulesManagement: true
   ovsDirectory: "/var/lib/openvswitch"
   ovnDirectory: "/var/lib/ovn"
+  ovsIpsecKeysDirectory: "/var/lib/ovs_ipsec_keys"
 cni:
   mountToolingDirectory: false
 ```
+
+All three `ovsOvn` directories must point outside `/etc`, which is read-only on Talos. `ovsIpsecKeysDirectory`
+only becomes a host mount when `features.enableOvnIpsec` is enabled, but setting it up front keeps IPSEC
+from failing later with `mkdir /etc/origin: read-only file system`.
 
 ## Migrate from v1 to v2 Chart
 

--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -309,7 +309,7 @@ spec:
             path: {{ .Values.cni.toolingDirectory }}
         {{- end }}
         {{- if .Values.features.enableOvnIpsec }}
-          - name: ovs-ipsec-keys
-            hostPath:
-              path: {{ .Values.ovsOvn.ovsIpsecKeysDirectory }}
+        - name: ovs-ipsec-keys
+          hostPath:
+            path: {{ .Values.ovsOvn.ovsIpsecKeysDirectory }}
         {{- end }}

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -564,6 +564,7 @@ ovsOvn:
   # @section -- OVS/OVN daemons configuration
   ovsDirectory: "/etc/origin/openvswitch"
   # -- Directory on the node where Open vSwitch (OVS) IPSEC keys live.
+  # @section -- OVS/OVN daemons configuration
   ovsIpsecKeysDirectory: "/etc/origin/ovs_ipsec_keys"
   # -- Directory on the node where Open Virtual Network (OVN) lives.
   # @section -- OVS/OVN daemons configuration

--- a/charts/kube-ovn/README.md
+++ b/charts/kube-ovn/README.md
@@ -53,5 +53,9 @@ and use the following options to install this Helm-chart:
 --set cni_conf.MOUNT_LOCAL_BIN_DIR=false
 --set OPENVSWITCH_DIR=/var/lib/openvswitch
 --set OVN_DIR=/var/lib/ovn
+--set OVN_IPSEC_KEY_DIR=/var/lib/ovs_ipsec_keys
 --set DISABLE_MODULES_MANAGEMENT=true
 ```
+
+`OVN_IPSEC_KEY_DIR` only becomes a host mount when `func.ENABLE_OVN_IPSEC` is enabled, but setting it up
+front keeps IPSEC from failing later with `mkdir /etc/origin: read-only file system`.


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Docs

The `kube-ovn-v2` chart cannot be rendered at all when `features.enableOvnIpsec` is enabled. The `ovs-ipsec-keys` entry in the agent DaemonSet `volumes` list is indented two spaces deeper than its siblings, which produces invalid YAML:

```console
$ helm template kube-ovn ./charts/kube-ovn-v2 --set features.enableOvnIpsec=true
Error: YAML parse error on kube-ovn-v2/templates/agent/agent-daemonset.yaml: error converting YAML to JSON: yaml: line 263: did not find expected key
```

The rendered output shows the entry nested under the preceding volume instead of alongside it:

```yaml
        - name: host-log-ovn
          hostPath:
            path: /var/log/ovn
          - name: ovs-ipsec-keys      # <- two spaces too deep
            hostPath:
              path: /etc/origin/ovs_ipsec_keys
```

The matching `volumeMounts` entry is correct; only the `volumes` entry is affected. This has been present since the value was introduced and reaches the released v1.15 and v1.16 charts. It went unnoticed because `enableOvnIpsec` defaults to `false` and no CI job sets it — `grep -r enableOvnIpsec .github/ test/` returns nothing.

Note that `helm lint` does not catch this, because it only renders the default value set:

```console
$ helm lint ./charts/kube-ovn-v2
1 chart(s) linted, 0 chart(s) failed

$ helm lint ./charts/kube-ovn-v2 --set features.enableOvnIpsec=true
[ERROR] templates/agent/agent-daemonset.yaml: unable to parse YAML: ...
Error: 1 chart(s) linted, 1 chart(s) failed
```

A `ci/ipsec-values.yaml` file would make `ct` cover this permanently, but `ct install` would then try to bring IPSEC up on a kind cluster, which I could not verify is workable in CI. I left it out to keep this PR to the fix — happy to add it if you would like it.

I also checked every other toggle under `features` with `helm template`, on both the fixed and unfixed chart. `enableOvnIpsec` is the only one that fails to render, so this indentation mistake is not repeated elsewhere.

### Talos Linux documentation

Both charts document a Talos install, and both list only two of the three host directories. `OVN_IPSEC_KEY_DIR` (v1) / `ovsOvn.ovsIpsecKeysDirectory` (v2) was added after those sections were written and kept the `/etc/origin` default that the other two have. Following the documented instructions and then enabling IPSEC gives:

```console
Error: failed to generate container spec: failed to apply OCI options: failed to mkdir "/etc/origin/ovs_ipsec_keys": mkdir /etc/origin: read-only file system
```

`/etc` is read-only on Talos, so the kubelet cannot create the directory and `kube-ovn-cni` stays in `CreateContainerError`. The value is overridable, so this is only a gap in the documented value list — I am not proposing to change any default. The same applies to other distributions with a read-only `/etc`.

Read-only `/etc` on Talos has come up before: [kubeovn/kube-ovn#2707](https://github.com/kubeovn/kube-ovn/issues/2707) is where these directories were made configurable in the first place, and [kubeovn/kube-ovn#4468](https://github.com/kubeovn/kube-ovn/issues/4468) reports the same kubelet error for `OPENVSWITCH_DIR` (a stale published chart, since resolved). Neither concerns the IPSEC directory, which did not exist yet — I mention them only because they show the documented override list is the mechanism users are pointed at, which is why it is worth keeping complete.

This PR adds the missing directory to both Talos sections and gives `ovsIpsecKeysDirectory` the `@section` annotation its two neighbours already have, so helm-docs groups it with them instead of listing it under "Other Values".

I edited the generated `charts/kube-ovn-v2/README.md` by hand to match. Running helm-docs 1.14.2 locally reformats large unrelated parts of that file, and the repository does not pin a version, so I kept the diff to the intended change.

The two halves are separate commits. If you would rather land the render fix on its own and discuss the docs separately, say so and I will drop the docs commit from this PR.

## Which issue(s) this PR fixes

None.
