### PR TITLE
fix(gateway): recover missing BFD sessions

### DIFF
--- a/dist/images/bfdd-healthcheck.sh
+++ b/dist/images/bfdd-healthcheck.sh
@@ -8,13 +8,5 @@ output="$(bfdd-control status)"
 # local BFD session table is empty, so inspect its output explicitly.
 if grep -q '^There are 0 sessions:' <<< "${output}"; then
   printf '%s\n' "${output}" >&2
-
-  IFS=',' read -r -a peer_ips <<< "${BFD_PEER_IPS:-}"
-  for peer_ip in "${peer_ips[@]}"; do
-    if [[ -n "${peer_ip}" ]]; then
-      bfdd-control allow "${peer_ip}"
-    fi
-  done
-
   exit 1
 fi

--- a/dist/images/bfdd-healthcheck.sh
+++ b/dist/images/bfdd-healthcheck.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output="$(bfdd-control status)"
+
+# bfdd-control exits successfully when the daemon is reachable even if the
+# local BFD session table is empty, so inspect its output explicitly.
+if grep -q '^There are 0 sessions:' <<< "${output}"; then
+  printf '%s\n' "${output}" >&2
+
+  IFS=',' read -r -a peer_ips <<< "${BFD_PEER_IPS:-}"
+  for peer_ip in "${peer_ips[@]}"; do
+    if [[ -n "${peer_ip}" ]]; then
+      bfdd-control allow "${peer_ip}"
+    fi
+  done
+
+  exit 1
+fi

--- a/pkg/controller/vpc_gateway_common.go
+++ b/pkg/controller/vpc_gateway_common.go
@@ -91,7 +91,7 @@ func genGatewayBFDDContainer(image, bfdIP string, minTX, minRX, multiplier int32
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
-					// Re-register BFD peers when the daemon reports zero sessions.
+					// Restart bfdd when its local session table remains empty.
 					Command: []string{"bash", "/kube-ovn/bfdd-healthcheck.sh"},
 				},
 			},

--- a/pkg/controller/vpc_gateway_common.go
+++ b/pkg/controller/vpc_gateway_common.go
@@ -91,11 +91,13 @@ func genGatewayBFDDContainer(image, bfdIP string, minTX, minRX, multiplier int32
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"bfdd-control", "status"},
+					// Re-register BFD peers when the daemon reports zero sessions.
+					Command: []string{"bash", "/kube-ovn/bfdd-healthcheck.sh"},
 				},
 			},
 			InitialDelaySeconds: 1,
 			PeriodSeconds:       5,
+			TimeoutSeconds:      3,
 		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{

--- a/pkg/controller/vpc_gateway_common_test.go
+++ b/pkg/controller/vpc_gateway_common_test.go
@@ -3,6 +3,11 @@ package controller
 import (
 	"context"
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +54,14 @@ func TestGenGatewayBFDDContainer(t *testing.T) {
 	assert.NotNil(t, container.StartupProbe)
 	assert.NotNil(t, container.LivenessProbe)
 	assert.NotNil(t, container.ReadinessProbe)
+	assert.Equal(t, []string{"bash", "/kube-ovn/bfdd-healthcheck.sh"}, container.LivenessProbe.Exec.Command)
+	assert.Equal(t, int32(1), container.LivenessProbe.InitialDelaySeconds)
+	assert.Equal(t, int32(5), container.LivenessProbe.PeriodSeconds)
+	assert.Equal(t, int32(3), container.LivenessProbe.TimeoutSeconds, "liveness probe must terminate blocked bfdd-control calls")
+	assert.Equal(t, []string{"bfdd-control", "status"}, container.ReadinessProbe.Exec.Command)
+	assert.Equal(t, int32(3), container.ReadinessProbe.InitialDelaySeconds)
+	assert.Equal(t, int32(3), container.ReadinessProbe.PeriodSeconds)
+	assert.Equal(t, int32(1), container.ReadinessProbe.FailureThreshold)
 
 	assert.Equal(t, gwBFDDResourceCPU, container.Resources.Requests[corev1.ResourceCPU])
 	assert.Equal(t, gwBFDDResourceMemory, container.Resources.Requests[corev1.ResourceMemory])
@@ -56,6 +69,101 @@ func TestGenGatewayBFDDContainer(t *testing.T) {
 
 	assert.False(t, *container.SecurityContext.Privileged)
 	assert.Equal(t, int64(65534), *container.SecurityContext.RunAsUser)
+}
+
+func TestBFDDHealthcheck(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required to test the BFD health check")
+	}
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+	healthcheckPath := filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images", "bfdd-healthcheck.sh")
+
+	tests := []struct {
+		name           string
+		statusOutput   string
+		statusExitCode string
+		wantHealthy    bool
+		wantAllowed    []string
+	}{
+		{
+			name:         "existing session is healthy",
+			statusOutput: "There are 1 sessions:",
+			wantHealthy:  true,
+		},
+		{
+			name:         "zero sessions re-registers peers and fails",
+			statusOutput: "There are 0 sessions:",
+			wantAllowed:  []string{"10.0.0.1", "fd00::1"},
+		},
+		{
+			name:           "status failure fails without re-registering peers",
+			statusOutput:   "control socket unavailable",
+			statusExitCode: "2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			binDir := filepath.Join(testDir, "bin")
+			if err := os.Mkdir(binDir, 0o755); err != nil {
+				t.Fatalf("failed to create mock binary directory: %v", err)
+			}
+
+			allowLog := filepath.Join(testDir, "allow.log")
+			mockControl := filepath.Join(binDir, "bfdd-control")
+			mockScript := `#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  status)
+    printf '%s\n' "${STATUS_OUTPUT:-}"
+    exit "${STATUS_EXIT_CODE:-0}"
+    ;;
+  allow)
+    printf '%s\n' "${2:-}" >> "${ALLOW_LOG}"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`
+			if err := os.WriteFile(mockControl, []byte(mockScript), 0o755); err != nil {
+				t.Fatalf("failed to create mock bfdd-control: %v", err)
+			}
+
+			cmd := exec.Command(bash, healthcheckPath) // #nosec G204 -- path is derived from the test source location
+			cmd.Env = append(os.Environ(),
+				"PATH="+binDir+":"+os.Getenv("PATH"),
+				"STATUS_OUTPUT="+tt.statusOutput,
+				"STATUS_EXIT_CODE="+tt.statusExitCode,
+				"ALLOW_LOG="+allowLog,
+				"BFD_PEER_IPS=10.0.0.1,fd00::1",
+			)
+			output, err := cmd.CombinedOutput()
+			if tt.wantHealthy {
+				assert.NoError(t, err, "health check output: %s", output)
+			} else {
+				assert.Error(t, err, "health check output: %s", output)
+			}
+
+			var allowed []string
+			content, err := os.ReadFile(allowLog)
+			switch {
+			case err == nil:
+				allowed = strings.Fields(string(content))
+			case os.IsNotExist(err):
+			default:
+				t.Fatalf("failed to read allowed peer log: %v", err)
+			}
+			assert.Equal(t, tt.wantAllowed, allowed)
+		})
+	}
 }
 
 func TestGenGatewaySleepContainer(t *testing.T) {

--- a/pkg/controller/vpc_gateway_common_test.go
+++ b/pkg/controller/vpc_gateway_common_test.go
@@ -96,12 +96,11 @@ func TestBFDDHealthcheck(t *testing.T) {
 			wantHealthy:  true,
 		},
 		{
-			name:         "zero sessions re-registers peers and fails",
+			name:         "zero sessions fails without mutating peer configuration",
 			statusOutput: "There are 0 sessions:",
-			wantAllowed:  []string{"10.0.0.1", "fd00::1"},
 		},
 		{
-			name:           "status failure fails without re-registering peers",
+			name:           "status failure fails without mutating peer configuration",
 			statusOutput:   "control socket unavailable",
 			statusExitCode: "2",
 		},

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -956,6 +956,72 @@ func addEcmpRoutes(namespaceName, podName string, destinations, nextHops []strin
 	}
 }
 
+func verifyBFDDZeroSessionsTriggersRestart(f *framework.Framework, namespaceName string, pod corev1.Pod) {
+	ginkgo.GinkgoHelper()
+
+	const bfddContainer = "bfdd"
+	podClient := f.PodClientNS(namespaceName)
+
+	ginkgo.By("Waiting for the BFD session in gateway pod " + pod.Name)
+	framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		stdout, stderr, err := framework.ExecCommandInContainer(f, namespaceName, pod.Name, bfddContainer, "bfdd-control", "status")
+		if err != nil {
+			framework.Logf("failed to get BFD status from pod %s/%s: %v, stderr: %s", namespaceName, pod.Name, err, stderr)
+			return false, nil
+		}
+		return strings.Contains(stdout, "There are ") && !strings.Contains(stdout, "There are 0 sessions:"), nil
+	}, "BFD session to be established in gateway pod "+pod.Name)
+
+	pod = *podClient.GetPod(pod.Name)
+	initialRestartCount := containerRestartCount(pod, bfddContainer)
+
+	ginkgo.By("Continuously removing BFD sessions from gateway pod " + pod.Name)
+	const injectZeroSessions = `nohup bash -c '
+while true; do
+  IFS=, read -ra peers <<< "${BFD_PEER_IPS:-}"
+  for peer in "${peers[@]}"; do
+    if [[ -n "${peer}" ]]; then
+      bfdd-control block "${peer}"
+    fi
+  done
+  bfdd-control session all kill
+  sleep 0.1
+done
+' >/tmp/bfdd-zero-sessions-inject.log 2>&1 </dev/null &`
+	_, stderr, err := framework.ExecShellInContainer(f, namespaceName, pod.Name, bfddContainer, injectZeroSessions)
+	framework.ExpectNoError(err, "failed to inject zero BFD sessions in pod %s/%s: %s", namespaceName, pod.Name, stderr)
+
+	ginkgo.By("Validating the gateway pod reports zero BFD sessions")
+	framework.WaitUntil(200*time.Millisecond, 10*time.Second, func(_ context.Context) (bool, error) {
+		stdout, _, err := framework.ExecCommandInContainer(f, namespaceName, pod.Name, bfddContainer, "bfdd-control", "status")
+		return err == nil && strings.Contains(stdout, "There are 0 sessions:"), nil
+	}, "gateway pod to report zero BFD sessions")
+
+	ginkgo.By("Waiting for the bfdd liveness probe to restart the container")
+	framework.WaitUntil(time.Second, 45*time.Second, func(_ context.Context) (bool, error) {
+		currentPod := podClient.GetPod(pod.Name)
+		return containerRestartCount(*currentPod, bfddContainer) > initialRestartCount, nil
+	}, "bfdd container to restart after consecutive zero-session health check failures")
+
+	ginkgo.By("Validating the BFD session recovers after the bfdd container restart")
+	framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		stdout, _, err := framework.ExecCommandInContainer(f, namespaceName, pod.Name, bfddContainer, "bfdd-control", "status")
+		return err == nil && strings.Contains(stdout, "There are ") && !strings.Contains(stdout, "There are 0 sessions:"), nil
+	}, "BFD session to recover after bfdd container restart")
+}
+
+func containerRestartCount(pod corev1.Pod, containerName string) int32 {
+	ginkgo.GinkgoHelper()
+
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == containerName {
+			return status.RestartCount
+		}
+	}
+	framework.Failf("container %s not found in pod %s/%s", containerName, pod.Namespace, pod.Name)
+	return 0
+}
+
 func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, internalSubnetName, externalSubnetName string, replicas int32, expectedNodes []string) {
 	ginkgo.GinkgoHelper()
 
@@ -1075,6 +1141,9 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	framework.ExpectConsistOf(veg.Status.Workload.Nodes, podNodes)
 	if len(expectedNodes) != 0 {
 		framework.ExpectConsistOf(podNodes, expectedNodes)
+	}
+	if bfd {
+		verifyBFDDZeroSessionsTriggersRestart(f, namespaceName, workloadPods.Items[0])
 	}
 
 	svrPodName := "svr-" + framework.RandomSuffix()


### PR DESCRIPTION
## Summary

- detect when `bfdd-control status` reports zero BFD sessions
- fail the liveness check without mutating BFD peer configuration
- restart `bfdd` after consecutive zero-session probe failures
- use the shared health check for VPC Egress and NAT gateways
- keep readiness behavior unchanged to avoid blocking BFD reconciliation

## Why

`bfdd-control status` returns exit code 0 when the daemon is reachable even if it reports `There are 0 sessions:`. The existing exec probe therefore treats the container as healthy and never restarts it.

The health check only translates an empty local BFD session table into a liveness failure. Peer configuration remains the responsibility of the existing startup probe.

## Test Plan

- `go test ./pkg/controller`
- compile the VPC Egress Gateway E2E package
- VPC Egress Gateway E2E injects persistent zero sessions and verifies the `bfdd` container restart count increases
- verify the BFD session recovers after the container restart in IPv4, IPv6, and dual-stack jobs