### PR TITLE
test(gateway): limit bfdd zero-session recovery to v1.15+

### DIFF
--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -1142,7 +1142,7 @@ func vegTest(f *framework.Framework, bfd bool, provider, nadName, vpcName, inter
 	if len(expectedNodes) != 0 {
 		framework.ExpectConsistOf(podNodes, expectedNodes)
 	}
-	if bfd {
+	if bfd && !f.VersionPriorTo(1, 15) {
 		verifyBFDDZeroSessionsTriggersRestart(f, namespaceName, workloadPods.Items[0])
 	}
 


### PR DESCRIPTION
## Summary
- run the bfdd zero-session recovery e2e assertion only for Kube-OVN v1.15+
- keep the existing VPC egress gateway BFD flow unchanged for older branches

## Test Plan
- go test ./test/e2e/vpc-egress-gateway -run '^$'
- git diff --check
