### PR TITLE
fix: prevent subnet status update loop in patchSubnetStatus

### DIFF
--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -50,22 +50,25 @@ func (c *Controller) updateNatOutgoingPolicyRulesStatus(subnet *kubeovnv1.Subnet
 func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr string) error {
 	if errStr != "" {
 		subnet.Status.SetError(reason, errStr)
-		if reason == "ValidateLogicalSwitchFailed" {
+		switch reason {
+		case "ValidateLogicalSwitchFailed":
 			subnet.Status.NotValidated(reason, errStr)
-		} else {
+		case "ValidateLogicalSwitchSuccess":
 			subnet.Status.Validated(reason, "")
 		}
 		subnet.Status.NotReady(reason, errStr)
 		c.recorder.Eventf(subnet, v1.EventTypeWarning, reason, "%s", errStr)
 	} else {
-		subnet.Status.Validated(reason, "")
-		c.recorder.Eventf(subnet, v1.EventTypeNormal, reason, "%s", errStr)
-		if reason == "SetPrivateLogicalSwitchSuccess" ||
-			reason == "ResetLogicalSwitchAclSuccess" ||
-			reason == "ReconcileCentralizedGatewaySuccess" ||
-			reason == "SetNonOvnSubnetSuccess" {
+		switch reason {
+		case "ValidateLogicalSwitchSuccess":
+			subnet.Status.Validated(reason, "")
+		case "SetPrivateLogicalSwitchSuccess",
+			"ResetLogicalSwitchAclSuccess",
+			"ReconcileCentralizedGatewaySuccess",
+			"SetNonOvnSubnetSuccess":
 			subnet.Status.Ready(reason, "")
 		}
+		c.recorder.Eventf(subnet, v1.EventTypeNormal, reason, "%s", errStr)
 	}
 
 	bytes, err := subnet.Status.Bytes()


### PR DESCRIPTION
The Validated condition in patchSubnetStatus was being updated on every call regardless of the reason, causing the condition's reason to oscillate between ValidateLogicalSwitchSuccess and ResetLogicalSwitchAclSuccess on each handler execution. 

Fix: Only update the Validated condition when the reason is ValidateLogicalSwitchSuccess or ValidateLogicalSwitchFailed. Other reasons should not overwrite the Validated condition.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->


- Bug fixes


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
