### PR TITLE
feat: infer pod subnet from named IPPool

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1830,6 +1830,18 @@ func (c *Controller) getPodDefaultSubnet(pod *v1.Pod) (*kubeovnv1.Subnet, error)
 		}
 		return subnet, nil
 	}
+	if poolName := strings.TrimSpace(pod.Annotations[util.IPPoolAnnotation]); poolName != "" &&
+		!strings.ContainsAny(poolName, ",;") && net.ParseIP(poolName) == nil {
+		pool, err := c.ippoolLister.Get(poolName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get ippool %s: %w", poolName, err)
+		}
+		subnet, err := c.subnetsLister.Get(pool.Spec.Subnet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get subnet %s for ippool %s: %w", pool.Spec.Subnet, poolName, err)
+		}
+		return subnet, nil
+	}
 
 	ns, err := c.namespacesLister.Get(pod.Namespace)
 	if err != nil {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -992,6 +992,62 @@ func TestIPPoolHasAvailableIPFamily(t *testing.T) {
 	assert.False(t, ippoolHasAvailableIPFamily(ippool, kubeovnv1.ProtocolDual, ""))
 }
 
+func TestGetPodDefaultSubnetUsesNamedIPPoolSubnet(t *testing.T) {
+	const (
+		namespaceName   = "test-ns"
+		namespaceSubnet = "namespace-subnet"
+		poolName        = "pool-a"
+		poolSubnet      = "pool-subnet"
+	)
+
+	ctrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Namespaces: []*corev1.Namespace{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+				Annotations: map[string]string{
+					util.LogicalSwitchAnnotation: namespaceSubnet,
+				},
+			},
+		}},
+		Subnets: []*kubeovnv1.Subnet{
+			{ObjectMeta: metav1.ObjectMeta{Name: namespaceSubnet}},
+			{ObjectMeta: metav1.ObjectMeta{Name: poolSubnet}},
+		},
+		IPPools: []*kubeovnv1.IPPool{{
+			ObjectMeta: metav1.ObjectMeta{Name: poolName},
+			Spec:       kubeovnv1.IPPoolSpec{Subnet: poolSubnet},
+		}},
+	})
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod",
+		Namespace: namespaceName,
+		Annotations: map[string]string{
+			util.IPPoolAnnotation: poolName,
+		},
+	}}
+
+	subnet, err := ctrl.fakeController.getPodDefaultSubnet(pod)
+	require.NoError(t, err)
+	require.NotNil(t, subnet)
+	assert.Equal(t, poolSubnet, subnet.Name)
+
+	for _, staticPool := range []string{
+		"10.0.0.10",
+		"10.0.0.10,10.0.0.11",
+		"10.0.0.10;10.0.0.11",
+	} {
+		t.Run("legacy static pool "+staticPool, func(t *testing.T) {
+			pod.Annotations[util.IPPoolAnnotation] = staticPool
+			subnet, err := ctrl.fakeController.getPodDefaultSubnet(pod)
+			require.NoError(t, err)
+			require.NotNil(t, subnet)
+			assert.Equal(t, namespaceSubnet, subnet.Name)
+		})
+	}
+}
+
 func TestDHCPOptionsForPodIPFamily(t *testing.T) {
 	dhcpOptions := &ovs.DHCPOptionsUUIDs{
 		DHCPv4OptionsUUID: "v4-uuid",

--- a/test/e2e/kube-ovn/ipam/ipam.go
+++ b/test/e2e/kube-ovn/ipam/ipam.go
@@ -33,6 +33,7 @@ var _ = framework.Describe("[group:ipam]", func() {
 	var stsClient *framework.StatefulSetClient
 	var subnetClient *framework.SubnetClient
 	var ippoolClient *framework.IPPoolClient
+	var ipClient *framework.IPClient
 	var namespaceName, subnetName, subnetName2, ippoolName, ippoolName2, podName, deployName, stsName, stsName2 string
 	var subnet *apiv1.Subnet
 	var cidr string
@@ -45,6 +46,7 @@ var _ = framework.Describe("[group:ipam]", func() {
 		stsClient = f.StatefulSetClient()
 		subnetClient = f.SubnetClient()
 		ippoolClient = f.IPPoolClient()
+		ipClient = f.IPClient()
 		namespaceName = f.Namespace.Name
 		subnetName = "subnet-" + framework.RandomSuffix()
 		subnetName2 = "subnet2-" + framework.RandomSuffix()
@@ -412,6 +414,64 @@ var _ = framework.Describe("[group:ipam]", func() {
 			framework.ExpectMAC(pod.Annotations[util.MacAddressAnnotation])
 			framework.ExpectHaveKeyWithValue(pod.Annotations, util.RoutedAnnotation, "true")
 		}
+	})
+
+	framework.ConformanceIt("should infer the default subnet from a named ippool", func() {
+		f.SkipVersionPriorTo(1, 17, "Default subnet inference from a named IPPool was introduced in v1.17")
+
+		poolCIDR := framework.RandomCIDR(f.ClusterIPFamily)
+		ginkgo.By("Creating subnet " + subnetName2 + " without binding it to the namespace")
+		poolSubnet := framework.MakeSubnet(subnetName2, "", poolCIDR, "", "", "", nil, nil, nil)
+		poolSubnet = subnetClient.CreateSync(poolSubnet)
+
+		poolIPs := framework.RandomIPPool(poolCIDR, 3)
+		poolV4, poolV6 := util.SplitIpsByProtocol(poolIPs)
+		v4Range, err := ipam.NewIPRangeListFrom(poolV4...)
+		framework.ExpectNoError(err)
+		v6Range, err := ipam.NewIPRangeListFrom(poolV6...)
+		framework.ExpectNoError(err)
+		ginkgo.By("Creating ippool " + ippoolName2 + " in subnet " + subnetName2)
+		ippool := framework.MakeIPPool(ippoolName2, subnetName2, poolIPs, nil)
+		_ = ippoolClient.CreateSync(ippool)
+
+		ginkgo.By("Creating deployment " + deployName + " with only the ippool annotation")
+		annotations := map[string]string{util.IPPoolAnnotation: ippoolName2}
+		deploy := framework.MakeDeployment(deployName, 1, map[string]string{"app": deployName}, annotations, "pause", framework.PauseImage, "")
+		deploy = deployClient.CreateSync(deploy)
+
+		pods, err := deployClient.GetPods(deploy)
+		framework.ExpectNoError(err)
+		framework.ExpectHaveLen(pods.Items, 1)
+		pod := pods.Items[0]
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.AllocatedAnnotation, "true")
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.LogicalSwitchAnnotation, poolSubnet.Name)
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.CidrAnnotation, poolSubnet.Spec.CIDRBlock)
+		framework.ExpectHaveKeyWithValue(pod.Annotations, util.GatewayAnnotation, poolSubnet.Spec.Gateway)
+		for _, podIP := range util.PodIPs(pod) {
+			ip, err := ipam.NewIP(podIP)
+			framework.ExpectNoError(err)
+			poolRange := v4Range
+			if strings.ContainsRune(podIP, ':') {
+				poolRange = v6Range
+			}
+			framework.ExpectTrue(poolRange.Contains(ip), "Pod IP %s should be contained by IPPool %v", podIP, poolIPs)
+		}
+
+		ginkgo.By("Waiting for ippool usage to reflect the pod allocation")
+		framework.WaitUntil(time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+			pool := ippoolClient.Get(ippoolName2)
+			v4Allocated := !f.HasIPv4() || !pool.Status.V4UsingIPs.EqualInt64(0)
+			v6Allocated := !f.HasIPv6() || !pool.Status.V6UsingIPs.EqualInt64(0)
+			return v4Allocated && v6Allocated, nil
+		}, "")
+
+		ginkgo.By("Deleting deployment " + deployName + " and waiting for ippool addresses to be released")
+		deployClient.DeleteSync(deployName)
+		framework.ExpectNoError(ipClient.WaitToDisappear(fmt.Sprintf("%s.%s", pod.Name, pod.Namespace), 0, 30*time.Second))
+		framework.WaitUntil(time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+			pool := ippoolClient.Get(ippoolName2)
+			return pool.Status.V4UsingIPs.EqualInt64(0) && pool.Status.V6UsingIPs.EqualInt64(0), nil
+		}, "")
 	})
 
 	framework.ConformanceIt("should support IPPool feature", func() {

--- a/test/e2e/kube-ovn/ipam/ipam.go
+++ b/test/e2e/kube-ovn/ipam/ipam.go
@@ -417,7 +417,7 @@ var _ = framework.Describe("[group:ipam]", func() {
 	})
 
 	framework.ConformanceIt("should infer the default subnet from a named ippool", func() {
-		f.SkipVersionPriorTo(1, 17, "Default subnet inference from a named IPPool was introduced in v1.17")
+		f.SkipVersionPriorTo(1, 15, "Default subnet inference from a named IPPool was introduced in v1.15")
 
 		poolCIDR := framework.RandomCIDR(f.ClusterIPFamily)
 		ginkgo.By("Creating subnet " + subnetName2 + " without binding it to the namespace")


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Features
- Bug fixes
- Tests

## What this PR does

- Uses `IPPool.spec.subnet` when a Pod specifies one named IPPool without an explicit `logical_switch`.
- Rejects explicit subnet conflicts and enforces non-empty `IPPool.spec.namespaces` as an allowlist while keeping empty lists backward compatible.
- Supports both the default network and attachment providers without changing legacy single-IP, comma-list, or semicolon-list annotations.
- Keeps Pod cleanup working when the IPPool is deleted or the namespace subnet is exhausted, using the IP CR subnet and a Pod index for efficient release.
- Validates named pools in admission without listing all IP CRs unless a static-address conflict check is required.

## Test plan

- [x] `go test ./pkg/controller ./pkg/webhook -count=1`
- [x] `go test ./pkg/util -count=1 -skip "^(TestExecuteCommandInContainer|TestExecuteWithOptions)$" -timeout=2m`
- [x] `golangci-lint run --new-from-rev=origin/master` (`0 issues`)
- [x] `git diff --check`

`make lint` was also run and only reports the existing `pkg/util/file.go:36` G703 finding. The Ginkgo suite passes 35/35; the full `make ut` command is blocked by the two existing localhost SPDY tests excluded above.

## Which issue(s) this PR fixes

None.