### PR TITLE
fix(controller): extend BFD liveness probe timeout

### DIFF
--- a/pkg/controller/vpc_gateway_common.go
+++ b/pkg/controller/vpc_gateway_common.go
@@ -97,7 +97,7 @@ func genGatewayBFDDContainer(image, bfdIP string, minTX, minRX, multiplier int32
 			},
 			InitialDelaySeconds: 1,
 			PeriodSeconds:       5,
-			TimeoutSeconds:      3,
+			TimeoutSeconds:      10,
 		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{

--- a/pkg/controller/vpc_gateway_common_test.go
+++ b/pkg/controller/vpc_gateway_common_test.go
@@ -57,7 +57,7 @@ func TestGenGatewayBFDDContainer(t *testing.T) {
 	assert.Equal(t, []string{"bash", "/kube-ovn/bfdd-healthcheck.sh"}, container.LivenessProbe.Exec.Command)
 	assert.Equal(t, int32(1), container.LivenessProbe.InitialDelaySeconds)
 	assert.Equal(t, int32(5), container.LivenessProbe.PeriodSeconds)
-	assert.Equal(t, int32(3), container.LivenessProbe.TimeoutSeconds, "liveness probe must terminate blocked bfdd-control calls")
+	assert.Equal(t, int32(10), container.LivenessProbe.TimeoutSeconds, "liveness probe must terminate blocked bfdd-control calls")
 	assert.Equal(t, []string{"bfdd-control", "status"}, container.ReadinessProbe.Exec.Command)
 	assert.Equal(t, int32(3), container.ReadinessProbe.InitialDelaySeconds)
 	assert.Equal(t, int32(3), container.ReadinessProbe.PeriodSeconds)

--- a/yamls/bfdd-daemonset.yaml
+++ b/yamls/bfdd-daemonset.yaml
@@ -192,6 +192,7 @@ spec:
                 - status
             initialDelaySeconds: 1
             periodSeconds: 5
+            timeoutSeconds: 10
           readinessProbe:
             exec:
               command:


### PR DESCRIPTION
## Summary
- Extend the VPC gateway BFD container liveness probe timeout from 3s to 10s.
- Keep the generated container test aligned with the new timeout.
- Set the standalone openbfdd DaemonSet example liveness timeout to 10s.

## Test Plan
- [x] go test ./pkg/controller -run TestGenGatewayBFDDContainer -count=1
- [ ] make lint (fails on existing gosec G703 in pkg/util/file.go:36)
