### PR TITLE
Revert "fix: prevent subnet status update loop in patchSubnetStatus (#7058)"

### DIFF
--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -50,25 +50,22 @@ func (c *Controller) updateNatOutgoingPolicyRulesStatus(subnet *kubeovnv1.Subnet
 func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr string) error {
 	if errStr != "" {
 		subnet.Status.SetError(reason, errStr)
-		switch reason {
-		case "ValidateLogicalSwitchFailed":
+		if reason == "ValidateLogicalSwitchFailed" {
 			subnet.Status.NotValidated(reason, errStr)
-		case "ValidateLogicalSwitchSuccess":
+		} else {
 			subnet.Status.Validated(reason, "")
 		}
 		subnet.Status.NotReady(reason, errStr)
 		c.recorder.Eventf(subnet, v1.EventTypeWarning, reason, "%s", errStr)
 	} else {
-		switch reason {
-		case "ValidateLogicalSwitchSuccess":
-			subnet.Status.Validated(reason, "")
-		case "SetPrivateLogicalSwitchSuccess",
-			"ResetLogicalSwitchAclSuccess",
-			"ReconcileCentralizedGatewaySuccess",
-			"SetNonOvnSubnetSuccess":
+		subnet.Status.Validated(reason, "")
+		c.recorder.Eventf(subnet, v1.EventTypeNormal, reason, "%s", errStr)
+		if reason == "SetPrivateLogicalSwitchSuccess" ||
+			reason == "ResetLogicalSwitchAclSuccess" ||
+			reason == "ReconcileCentralizedGatewaySuccess" ||
+			reason == "SetNonOvnSubnetSuccess" {
 			subnet.Status.Ready(reason, "")
 		}
-		c.recorder.Eventf(subnet, v1.EventTypeNormal, reason, "%s", errStr)
 	}
 
 	bytes, err := subnet.Status.Bytes()


### PR DESCRIPTION
This reverts #7058 to restore subnet e2e behavior on master while we revisit a smaller follow-up fix for the status update loop.