### PR TITLE
[release-1.15] fix(controller): extend BFD liveness probe timeout

### DIFF
--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -1021,7 +1021,7 @@ func vpcEgressGatewayContainerBFDD(image, bfdIP string, minTX, minRX, multiplier
 			},
 			InitialDelaySeconds: 1,
 			PeriodSeconds:       5,
-			TimeoutSeconds:      3,
+			TimeoutSeconds:      10,
 		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -32,7 +32,7 @@ func TestVpcEgressGatewayContainerBFDDDefaultResources(t *testing.T) {
 	require.NotNil(t, container.ReadinessProbe)
 	require.Equal(t, []string{"bash", "/kube-ovn/bfdd-prestart.sh"}, container.StartupProbe.Exec.Command)
 	require.Equal(t, []string{"bash", "/kube-ovn/bfdd-healthcheck.sh"}, container.LivenessProbe.Exec.Command)
-	require.EqualValues(t, 3, container.LivenessProbe.TimeoutSeconds)
+	require.EqualValues(t, 10, container.LivenessProbe.TimeoutSeconds)
 	require.Equal(t, []string{"bfdd-control", "status"}, container.ReadinessProbe.Exec.Command)
 }
 


### PR DESCRIPTION
## Summary
- Backport PR #7060 to release-1.15.
- Extend the VPC egress gateway BFD liveness probe timeout from 3s to 10s.
- Update the release-1.15 BFD container unit test expectation.

## Notes
The master PR also touched `yamls/bfdd-daemonset.yaml`, but this file does not exist on release-1.15, so the release backport only updates the equivalent controller implementation and test.

## Test Plan
- [x] go test ./pkg/controller -run "TestVpcEgressGatewayContainerBFDDDefaultResources" -count=1
- [x] make lint
