### PR TITLE
Revert "fix: prevent subnet status update loop in patchSubnetStatus"

### DIFF
--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -50,25 +50,22 @@ func (c *Controller) updateNatOutgoingPolicyRulesStatus(subnet *kubeovnv1.Subnet
 func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr string) error {
 	if errStr != "" {
 		subnet.Status.SetError(reason, errStr)
-		switch reason {
-		case "ValidateLogicalSwitchFailed":
+		if reason == "ValidateLogicalSwitchFailed" {
 			subnet.Status.NotValidated(reason, errStr)
-		case "ValidateLogicalSwitchSuccess":
+		} else {
 			subnet.Status.Validated(reason, "")
 		}
 		subnet.Status.NotReady(reason, errStr)
 		c.recorder.Eventf(subnet, v1.EventTypeWarning, reason, errStr)
 	} else {
-		switch reason {
-		case "ValidateLogicalSwitchSuccess":
-			subnet.Status.Validated(reason, "")
-		case "SetPrivateLogicalSwitchSuccess",
-			"ResetLogicalSwitchAclSuccess",
-			"ReconcileCentralizedGatewaySuccess",
-			"SetNonOvnSubnetSuccess":
+		subnet.Status.Validated(reason, "")
+		c.recorder.Eventf(subnet, v1.EventTypeNormal, reason, errStr)
+		if reason == "SetPrivateLogicalSwitchSuccess" ||
+			reason == "ResetLogicalSwitchAclSuccess" ||
+			reason == "ReconcileCentralizedGatewaySuccess" ||
+			reason == "SetNonOvnSubnetSuccess" {
 			subnet.Status.Ready(reason, "")
 		}
-		c.recorder.Eventf(subnet, v1.EventTypeNormal, reason, errStr)
 	}
 
 	bytes, err := subnet.Status.Bytes()


### PR DESCRIPTION
Backport the master revert of #7058 to release-1.16.\n\nThis matches master PR #7063 and removes the subnet status behavior change before continuing the MetalLB underlay VIP backport validation.\n\nValidation:\n- go test -mod=readonly ./pkg/controller