### PR TITLE
fix(chart): correct v2 agent capability name

### DIFF
--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -162,7 +162,7 @@ spec:
               - NET_BIND_SERVICE
               - NET_RAW
               - SYS_ADMIN
-              - CAP_SYS_PTRACE
+              - SYS_PTRACE
               - SYS_NICE
         env:
           - name: ENABLE_SSL

--- a/charts/kube-ovn-v2/tests/component_image_overrides_test.yaml
+++ b/charts/kube-ovn-v2/tests/component_image_overrides_test.yaml
@@ -35,3 +35,16 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: docker.io/kubeovn/kube-ovn:v1.17.0
+
+  - it: uses the Kubernetes capability name without the CAP_ prefix
+    template: agent/agent-daemonset.yaml
+    set:
+      masterNodes:
+        - "10.0.0.1"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: SYS_PTRACE
+      - notContains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: CAP_SYS_PTRACE


### PR DESCRIPTION
## Changes

- replace `CAP_SYS_PTRACE` with the Kubernetes manifest capability name `SYS_PTRACE` in the v2 agent DaemonSet
- add a Helm regression test to prevent the `CAP_` prefix from returning

## Verification

- `helm unittest charts/kube-ovn-v2` (24/24 passed)
- `helm lint charts/kube-ovn-v2 --set masterNodes[0]=10.0.0.1`
- `make lint`

Fixes #7068