### PR TITLE
[release-1.16] fix(chart): correct v2 agent capability name

### DIFF
--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -157,7 +157,7 @@ spec:
               - NET_BIND_SERVICE
               - NET_RAW
               - SYS_ADMIN
-              - CAP_SYS_PTRACE
+              - SYS_PTRACE
               - SYS_NICE
         env:
           - name: ENABLE_SSL

--- a/charts/kube-ovn-v2/tests/agent_capabilities_test.yaml
+++ b/charts/kube-ovn-v2/tests/agent_capabilities_test.yaml
@@ -1,0 +1,15 @@
+suite: Agent capabilities (v2)
+templates:
+  - agent/agent-daemonset.yaml
+tests:
+  - it: uses the Kubernetes capability name without the CAP_ prefix
+    set:
+      masterNodes:
+        - "10.0.0.1"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: SYS_PTRACE
+      - notContains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: CAP_SYS_PTRACE


### PR DESCRIPTION
## Changes

- backport the v2 agent capability correction from #7073
- add a release-compatible Helm regression test for the capability name

## Verification

- `helm unittest charts/kube-ovn-v2` (22/22 passed)
- `helm lint charts/kube-ovn-v2 --set masterNodes[0]=10.0.0.1`
- `make lint`

Backport of #7073.