### PR TITLE
fix(util): handle zero-compressed IPv6 addresses in IPv6ToLabelValue

### DIFF
--- a/pkg/util/ip.go
+++ b/pkg/util/ip.go
@@ -24,7 +24,20 @@ func Uint32ToIPv6(n [4]uint32) string {
 	)
 }
 
-// IPv6ToLabelValue sanitizes an IPv6 address for use as a Kubernetes label value (colons are not allowed).
+// IPv6ToLabelValue sanitizes an IPv6 address for use as a Kubernetes label value.
+// Colons are not allowed in label values, and a label value must start and end
+// with an alphanumeric character, which a zero-compressed address (e.g. "::1"
+// or "fd00::") would otherwise violate after the colons are replaced.
 func IPv6ToLabelValue(ip string) string {
-	return strings.ReplaceAll(ip, ":", "-")
+	if ip == "" {
+		return ""
+	}
+	v := strings.ReplaceAll(ip, ":", "-")
+	if v[0] == '-' {
+		v = "0" + v
+	}
+	if v[len(v)-1] == '-' {
+		v += "0"
+	}
+	return v
 }

--- a/pkg/util/ip_test.go
+++ b/pkg/util/ip_test.go
@@ -3,6 +3,8 @@ package util
 import (
 	"net"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func TestUint32ToIPv4(t *testing.T) {
@@ -61,6 +63,29 @@ func TestUint32ToIPv6(t *testing.T) {
 		result := Uint32ToIPv6(tt.input)
 		if result != tt.expected {
 			t.Errorf("Uint32ToIPv6(%v) = %s; want %s", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestIPv6ToLabelValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"1001:11d0:303:21c1:2000::100", "1001-11d0-303-21c1-2000--100"},
+		{"::1", "0--1"},
+		{"fd00:100::", "fd00-100--0"},
+		{"::", "0--0"},
+	}
+
+	for _, tt := range tests {
+		result := IPv6ToLabelValue(tt.input)
+		if result != tt.expected {
+			t.Errorf("IPv6ToLabelValue(%s) = %s; want %s", tt.input, result, tt.expected)
+		}
+		if errs := validation.IsValidLabelValue(result); len(errs) != 0 {
+			t.Errorf("IPv6ToLabelValue(%s) = %s is not a valid label value: %v", tt.input, result, errs)
 		}
 	}
 }


### PR DESCRIPTION
Motivation:
Issue #6643 reports that the controller crash-loops when a VPC sets
spec.enableExternal: true with an IPv6/dual-stack external subnet,
because createOrUpdateOvnEipCR() stored the raw IPv6 address (which
contains ':') as a Kubernetes label value. Label values only allow
[a-zA-Z0-9._-] and must start/end with an alphanumeric character.

The main crash from the issue's reported repro address is already
fixed on master (util.IPv6ToLabelValue, added in c16eb3219, replaces
':' with '-' and is used consistently at every eip_v6_ip label
read/write site). This commit does not re-fix that crash; it closes
a residual edge case in the already-merged helper: when the address
itself starts or ends with '::' (zero-compression), e.g. "::1" or
"fd00:100::", the '-' substitution alone still produces a label
value starting or ending with '-', which fails the same Kubernetes
label validation and reproduces the same crash-loop for that
narrower set of addresses.

Approach:
Pad IPv6ToLabelValue's output with a leading/trailing "0" whenever
the ':'->'-' substitution would otherwise leave a leading or
trailing '-'. The function is used as a one-way, write-and-compare
label encoding only (no decode-back-to-IP path exists anywhere in
the codebase), so this remains deterministic and valid without
needing to be reversible.

Validation:
- go test (via a GOOS=linux/amd64 build, since pkg/util does not
  build on darwin due to an unrelated, pre-existing Linux-only NDP
  dependency) confirms the new TestIPv6ToLabelValue passes, covering
  "", a normal middle-"::" address, "::1", "fd00:100::", and "::",
  and asserting each output satisfies
  k8s.io/apimachinery/pkg/util/validation.IsValidLabelValue.
- golangci-lint run (GOOS=linux/amd64) on pkg/util: 0 issues.
- No CRD/kubebuilder annotations touched, so make gen-crd is not
  required.

Fixes #6643

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>