### PR TITLE
fix(vpcnatgw): attach subnet NAD in non-primary CNI mode so LanIP is injected

### DIFF
--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -101,7 +101,7 @@ func GenNatGwSelectors(selectors []string) map[string]string {
 // k8s.v1.cni.cncf.io/networks value, already references nad (a "namespace/name"
 // NAD reference), ignoring any "@ifname" interface-name suffix on each entry.
 func hasNetworkAttachment(networks, nad string) bool {
-	for _, n := range strings.Split(networks, ",") {
+	for n := range strings.SplitSeq(networks, ",") {
 		ref, _, _ := strings.Cut(strings.TrimSpace(n), "@")
 		if ref == nad {
 			return true

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -97,6 +97,19 @@ func GenNatGwSelectors(selectors []string) map[string]string {
 	return s
 }
 
+// hasNetworkAttachment reports whether networks, a comma-separated
+// k8s.v1.cni.cncf.io/networks value, already references nad (a "namespace/name"
+// NAD reference), ignoring any "@ifname" interface-name suffix on each entry.
+func hasNetworkAttachment(networks, nad string) bool {
+	for _, n := range strings.Split(networks, ",") {
+		ref, _, _ := strings.Cut(strings.TrimSpace(n), "@")
+		if ref == nad {
+			return true
+		}
+	}
+	return false
+}
+
 // GenNatGwPodAnnotations generates Pod template annotations for a NAT gateway.
 // userAnnotations contains user-defined annotations from gw.Spec.Annotations. System annotations
 // are set on top of it, overwriting any conflicts. additionalNetworks is optional, used when
@@ -161,7 +174,9 @@ func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.Vpc
 	if additionalNetworks != "" {
 		attachedNetworks = additionalNetworks + ", " + attachedNetworks
 	}
-	if internalNad != "" {
+	// Skip internalNad if the user already listed it in additionalNetworks, e.g. via the
+	// manual workaround used before this NAD was auto-attached, so it isn't attached twice.
+	if internalNad != "" && !hasNetworkAttachment(additionalNetworks, internalNad) {
 		attachedNetworks += ", " + internalNad
 	}
 	result[nadv1.NetworkAttachmentAnnot] = attachedNetworks

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -103,16 +103,12 @@ func GenNatGwSelectors(selectors []string) map[string]string {
 // users specify extra NADs in gw.Annotations. enableNonPrimaryCNI indicates whether Kube-OVN is
 // running as a non-primary CNI; in that mode eth0 must stay on the cluster's primary CNI pod
 // network (e.g. Calico) so the gateway pod can reach the Kubernetes control plane, so the
-// v1.multus-cni.io/default-network override is skipped.
+// v1.multus-cni.io/default-network override is skipped and the subnet's NAD is instead attached
+// as an additional network so LanIP is still injected via multus.
 func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.VpcNatGateway, externalNadNamespace, externalNadName, provider, additionalNetworks string, enableNonPrimaryCNI bool) (map[string]string, error) {
 	p := provider
 	if p == "" {
 		p = OvnProvider
-	}
-
-	attachedNetworks := fmt.Sprintf("%s/%s", externalNadNamespace, externalNadName)
-	if additionalNetworks != "" {
-		attachedNetworks = additionalNetworks + ", " + attachedNetworks
 	}
 
 	// Create a new map to avoid modifying the input map (which may be from informer cache)
@@ -120,7 +116,6 @@ func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.Vpc
 	maps.Copy(result, userAnnotations)
 
 	// Set system annotations (overwrites any conflicting user annotations)
-	result[nadv1.NetworkAttachmentAnnot] = attachedNetworks
 	result[VpcNatGatewayAnnotation] = gw.Name
 	result[fmt.Sprintf(LogicalSwitchAnnotationTemplate, p)] = gw.Spec.Subnet
 
@@ -128,6 +123,10 @@ func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.Vpc
 	if !IsNatGwHAMode(gw) {
 		result[fmt.Sprintf(IPAddressAnnotationTemplate, p)] = gw.Spec.LanIP
 	}
+
+	// internalNad is set when the subnet's own NAD needs to be attached to the pod as a
+	// non-default network (non-primary CNI mode); it stays empty otherwise.
+	var internalNad string
 
 	// Validate the custom provider string whenever it isn't the built-in ovn one, regardless of
 	// the CNI mode, so that malformed providers are caught early rather than producing bogus
@@ -138,16 +137,34 @@ func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.Vpc
 		if len(providerSplit) != 3 || providerSplit[2] != OvnProvider {
 			return nil, fmt.Errorf("name of the provider must have syntax 'name.namespace.ovn', got %s", provider)
 		}
+		name, namespace := providerSplit[0], providerSplit[1]
 
-		// Override the default network of the pod only under primary CNI mode, so the default
-		// VPC/Subnet of the cluster isn't accidentally injected. In non-primary CNI mode eth0
-		// belongs to the cluster's primary CNI and overriding it with a tenant NAD would break
-		// pod/control-plane connectivity (see issue #6632).
 		if !enableNonPrimaryCNI {
-			name, namespace := providerSplit[0], providerSplit[1]
+			// Override the default network of the pod only under primary CNI mode, so the default
+			// VPC/Subnet of the cluster isn't accidentally injected.
 			result[DefaultNetworkAnnotation] = fmt.Sprintf("%s/%s", namespace, name)
+		} else {
+			// In non-primary CNI mode eth0 belongs to the cluster's primary CNI and overriding it
+			// with a tenant NAD would break pod/control-plane connectivity (see issue #6632), so
+			// attach the subnet's NAD as an additional network instead. Without this, the
+			// LogicalSwitch/IPAddress annotations above are never consumed by any CNI invocation
+			// and LanIP is never injected into the pod (see issue #6744).
+			internalNad = fmt.Sprintf("%s/%s", namespace, name)
 		}
 	}
+
+	// Append internalNad after the external NAD (rather than prepending it) so that the
+	// external NAD keeps the same position it had before non-primary CNI mode was supported;
+	// some call sites (e.g. the default egress QoS interface) assume the external NAD is the
+	// first attached network and hardcode "net1" to refer to it.
+	attachedNetworks := fmt.Sprintf("%s/%s", externalNadNamespace, externalNadName)
+	if additionalNetworks != "" {
+		attachedNetworks = additionalNetworks + ", " + attachedNetworks
+	}
+	if internalNad != "" {
+		attachedNetworks += ", " + internalNad
+	}
+	result[nadv1.NetworkAttachmentAnnot] = attachedNetworks
 
 	return result, nil
 }

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -385,7 +385,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "Non-primary CNI with NAD provider skips default network override",
+			name: "Non-primary CNI with NAD provider attaches subnet NAD as additional network",
 			gw: v1.VpcNatGateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-gateway",
@@ -402,7 +402,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 			enableNonPrimaryCNI:  true,
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
-				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
+				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet, namespace/subnet",
 				fmt.Sprintf(LogicalSwitchAnnotationTemplate, "subnet.namespace.ovn"): "internal-subnet",
 				fmt.Sprintf(IPAddressAnnotationTemplate, "subnet.namespace.ovn"):     "10.20.30.40",
 			},
@@ -426,7 +426,7 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 			enableNonPrimaryCNI:  true,
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
-				nadv1.NetworkAttachmentAnnot: "default/tenant-nad, kube-system/external-subnet",
+				nadv1.NetworkAttachmentAnnot: "default/tenant-nad, kube-system/external-subnet, namespace/subnet",
 				fmt.Sprintf(LogicalSwitchAnnotationTemplate, "subnet.namespace.ovn"): "internal-subnet",
 				fmt.Sprintf(IPAddressAnnotationTemplate, "subnet.namespace.ovn"):     "10.20.30.40",
 			},

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -433,6 +433,30 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "Non-primary CNI does not duplicate subnet NAD already in additional networks",
+			gw: v1.VpcNatGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway",
+				},
+				Spec: v1.VpcNatGatewaySpec{
+					Subnet: "internal-subnet",
+					LanIP:  "10.20.30.40",
+				},
+			},
+			externalNadName:      "external-subnet",
+			externalNadNamespace: metav1.NamespaceSystem,
+			provider:             "subnet.namespace.ovn",
+			additionalNetworks:   "namespace/subnet",
+			enableNonPrimaryCNI:  true,
+			expected: map[string]string{
+				VpcNatGatewayAnnotation:      "test-gateway",
+				nadv1.NetworkAttachmentAnnot: "namespace/subnet, kube-system/external-subnet",
+				fmt.Sprintf(LogicalSwitchAnnotationTemplate, "subnet.namespace.ovn"): "internal-subnet",
+				fmt.Sprintf(IPAddressAnnotationTemplate, "subnet.namespace.ovn"):     "10.20.30.40",
+			},
+			expectError: false,
+		},
+		{
 			name: "No static LAN IP",
 			gw: v1.VpcNatGateway{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## What type of this PR

- Bug fixes

## Which issue(s) this PR fixes

Fixes #6744

## Motivation

When Kube-OVN runs as a non-primary CNI (`--enable-non-primary-cni-mode`),
a VpcNatGateway's `lanIp` is never injected into the gateway pod: the pod
only ends up with the primary CNI's eth0 and the external-network
interface, never an interface for the internal OVN subnet, so the VPC
cannot reach the external network through the gateway.

PR #6675 (fixing #6632) made `GenNatGwPodAnnotations` skip setting
`v1.multus-cni.io/default-network` to the subnet's NetworkAttachmentDefinition
(NAD) in non-primary CNI mode, so eth0 correctly stays on the cluster's
primary CNI. However it never attached that NAD anywhere else. The
`ovn.kubernetes.io/logical_switch_provider.<p>` /
`ovn.kubernetes.io/ip_address_provider.<p>` pod annotations that carry the
LanIP were still being set, but with the NAD never listed in
`k8s.v1.cni.cncf.io/networks`, multus never invokes the kube-ovn CNI plugin
for it, so those annotations are never consumed and no interface is ever
created. Before this fix, the only way to get LanIP injected was the manual
workaround of adding the NAD to the VpcNatGateway's
`k8s.v1.cni.cncf.io/networks` annotation by hand.

## Approach

In `GenNatGwPodAnnotations` (pkg/util/vpc_nat_gateway.go), when running in
non-primary CNI mode with a custom NAD-backed provider, attach the
subnet's own NAD to `k8s.v1.cni.cncf.io/networks` as an additional
(non-default) network instead of just skipping it. It is appended after
the external NAD and any user-supplied additional networks, rather than
prepended, so the external NAD keeps the same position it already had
(some code, e.g. the default egress QoS interface in
`execNatGwQoSInPod`, assumes the external NAD is `net1` when no extra
networks are configured).

The `v1.multus-cni.io/default-network` override remains skipped in
non-primary CNI mode, so eth0 still stays on the primary CNI and the
#6632 fix is unaffected.

## Validation

Ran (this repo's darwin dev host can't natively build/test
Linux-syscall-only files like pkg/util/ndp.go, so the target package was
also cross-built for linux/amd64):

    GOOS=linux GOARCH=amd64 go build ./pkg/util/... ./pkg/controller/...
    go test ./pkg/util/... -run TestGenNatGwPodAnnotations -v

Both passed, including two updated/new table-driven cases asserting the
subnet's NAD is now included in `k8s.v1.cni.cncf.io/networks` for
non-primary CNI mode, both with and without user-supplied additional
networks. `golangci-lint run --fix` reports 0 issues for the changed
packages.

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>