### PR TITLE
fix(e2e): ignore VPC egress gateway node order

### DIFF
--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -1220,7 +1220,7 @@ func validateVegTestWorkload(f *framework.Framework, veg *apiv1.VpcEgressGateway
 	uniquePodNodes := slices.Clone(podNodes)
 	slices.Sort(uniquePodNodes)
 	uniquePodNodes = slices.Compact(uniquePodNodes)
-	framework.ExpectEqual(veg.Status.Workload.Nodes, uniquePodNodes)
+	framework.ExpectConsistOf(veg.Status.Workload.Nodes, uniquePodNodes)
 	if len(expectedNodes) != 0 {
 		framework.ExpectConsistOf(uniquePodNodes, expectedNodes)
 	}


### PR DESCRIPTION
## What type of this PR

- [x] Tests

## What this PR does

Compare VPC Egress Gateway workload nodes as an unordered collection.

Release workflows run E2E tests from `master` against release images. The `master` controller sorts `status.workload.nodes`, but release-1.15 and release-1.16 controllers do not. This made all six VPC Egress Gateway jobs in #7079 and #7080 fail when the same two nodes appeared in a different order.

## Verification

- `go test ./test/e2e/vpc-egress-gateway -run "^$" -count=1`
- `git diff --check`

## Which issue(s) this PR fixes

Related to #7079 and #7080.