### PR TITLE
ovs: skip address set update when the addresses are unchanged

### DIFF
--- a/pkg/ovs/ovn-nb-address_set.go
+++ b/pkg/ovs/ovn-nb-address_set.go
@@ -59,6 +59,26 @@ func (c *OVNNbClient) CreateAddressSet(asName string, externalIDs map[string]str
 	return nil
 }
 
+// normalizeAddresses formats CIDR addresses to keep them the same in both nb and sb,
+// and drops duplicate elements which would make the update fail. An address whose CIDR
+// cannot be parsed is kept as is. The returned set is order independent, so it can be
+// compared against the addresses currently stored in the database.
+// The given slice is never modified: it may be owned by the caller.
+func normalizeAddresses(addresses []string) *strset.Set {
+	result := strset.NewWithSize(len(addresses))
+	for _, addr := range addresses {
+		if strings.ContainsRune(addr, '/') {
+			if _, ipNet, err := net.ParseCIDR(addr); err != nil {
+				klog.Warningf("failed to parse CIDR %q: %v", addr, err)
+			} else {
+				addr = ipNet.String()
+			}
+		}
+		result.Add(addr)
+	}
+	return result
+}
+
 // AddressSetUpdateAddress update addresses,
 // clear addresses when addresses is empty
 func (c *OVNNbClient) AddressSetUpdateAddress(asName string, addresses ...string) error {
@@ -68,27 +88,19 @@ func (c *OVNNbClient) AddressSetUpdateAddress(asName string, addresses ...string
 		return fmt.Errorf("get address set %s: %w", asName, err)
 	}
 
-	// format CIDR to keep addresses the same in both nb and sb
-	for i, addr := range addresses {
-		if strings.ContainsRune(addr, '/') {
-			_, ipNet, err := net.ParseCIDR(addr)
-			if err != nil {
-				klog.Warningf("failed to parse CIDR %q: %v", addr, err)
-				continue
-			}
-			addresses[i] = ipNet.String()
-		}
+	// the current addresses are read from the local ovsdb cache, so comparing them
+	// costs nothing and saves a needless nb transaction when nothing has changed
+	expected := normalizeAddresses(addresses)
+	if expected.IsEqual(strset.New(as.Addresses...)) {
+		return nil
 	}
 
-	// update will failed when slice contains duplicate elements
-	addresses = strset.New(addresses...).List()
-
 	// clear addresses when addresses is empty
-	as.Addresses = addresses
+	as.Addresses = expected.List()
 
 	if err := c.UpdateAddressSet(as, &as.Addresses); err != nil {
 		klog.Error(err)
-		return fmt.Errorf("set address set %s addresses %v: %w", asName, addresses, err)
+		return fmt.Errorf("set address set %s addresses %v: %w", asName, as.Addresses, err)
 	}
 
 	return nil

--- a/pkg/ovs/ovn-nb-address_set_test.go
+++ b/pkg/ovs/ovn-nb-address_set_test.go
@@ -2,6 +2,7 @@ package ovs
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,49 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func Test_normalizeAddresses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("format CIDR and keep the unparsable ones", func(t *testing.T) {
+		t.Parallel()
+
+		result := normalizeAddresses([]string{"192.168.1.5/24", "2001:db8::1/64", "192.168.1.1", "192.168.1.1/xx"})
+		require.ElementsMatch(t, []string{"192.168.1.0/24", "2001:db8::/64", "192.168.1.1", "192.168.1.1/xx"}, result.List())
+	})
+
+	t.Run("drop duplicate elements after formatting", func(t *testing.T) {
+		t.Parallel()
+
+		result := normalizeAddresses([]string{"192.168.1.1", "192.168.1.1", "192.168.1.5/24", "192.168.1.9/24"})
+		require.ElementsMatch(t, []string{"192.168.1.1", "192.168.1.0/24"}, result.List())
+	})
+
+	// the result is used to decide whether the address set needs to be updated,
+	// so addresses given in a different order must compare as equal
+	t.Run("compare equal regardless of the input order", func(t *testing.T) {
+		t.Parallel()
+
+		addresses := []string{"1.2.3.4", "1.2.3.5", "1.2.3.6", "10.0.0.0/8", "fe80::1"}
+		reversed := slices.Clone(addresses)
+		slices.Reverse(reversed)
+		require.True(t, normalizeAddresses(addresses).IsEqual(normalizeAddresses(reversed)))
+	})
+
+	t.Run("leave the given slice untouched", func(t *testing.T) {
+		t.Parallel()
+
+		addresses := []string{"192.168.1.5/24", "192.168.1.1"}
+		normalizeAddresses(addresses)
+		require.Equal(t, []string{"192.168.1.5/24", "192.168.1.1"}, addresses)
+	})
+
+	t.Run("empty addresses", func(t *testing.T) {
+		t.Parallel()
+
+		require.Empty(t, normalizeAddresses(nil).List())
+	})
+}
 
 func newAddressSet(name string, externalIDs map[string]string) *ovnnb.AddressSet {
 	return &ovnnb.AddressSet{
@@ -170,6 +214,30 @@ func (suite *OvnClientTestSuite) testAddressSetUpdateAddress() {
 	t.Run("update address set with invalid address", func(t *testing.T) {
 		err := nbClient.AddressSetUpdateAddress(asName, "192.168.1.1/xx")
 		require.NoError(t, err)
+	})
+
+	t.Run("keep the addresses when nothing changes", func(t *testing.T) {
+		addresses := []string{"10.16.0.1", "10.16.0.2", "10.16.0.3"}
+		require.NoError(t, nbClient.AddressSetUpdateAddress(asName, addresses...))
+
+		// updating with the same addresses in a different order is a no-op
+		reversed := slices.Clone(addresses)
+		slices.Reverse(reversed)
+		require.NoError(t, nbClient.AddressSetUpdateAddress(asName, reversed...))
+
+		as, err := nbClient.GetAddressSet(asName, false)
+		require.NoError(t, err)
+		require.ElementsMatch(t, addresses, as.Addresses)
+	})
+
+	t.Run("leave the given addresses untouched", func(t *testing.T) {
+		addresses := []string{"192.168.100.5/24", "192.168.100.1"}
+		require.NoError(t, nbClient.AddressSetUpdateAddress(asName, addresses...))
+		require.Equal(t, []string{"192.168.100.5/24", "192.168.100.1"}, addresses)
+
+		as, err := nbClient.GetAddressSet(asName, false)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"192.168.100.0/24", "192.168.100.1"}, as.Addresses)
 	})
 }
 


### PR DESCRIPTION
## What

`AddressSetUpdateAddress` read the current address set and then overwrote it unconditionally — there was not a single comparison in the function body, so every call issued an nb transaction even when nothing had changed.

Neither layer below it short-circuits either: libovsdb's `api.Update` always emits an `OperationUpdate`, and `Transact` only skips when the operation list is empty, which never happens here.

## Why it matters

All the call sites sit on reconcile paths — network policy, anp, cnp, security group, subnet u2o, ippool and vpc egress gateway — and two of them are structural amplifiers:

- **Network policy `except` address sets are always given a `nil` address list** (`network_policy.go:240/274/403/437`). Their content is permanently empty, yet each one is rewritten on every reconcile. With the surrounding `for protocol := range protocolSet` loop, a single `handleUpdateNp` fires `2 (protocol) x (len(Ingress)+len(Egress)) x 2 (allow+except)` separate transactions — 20 for a dual-stack policy with 3 ingress and 2 egress rules, half of them writing an empty set over an empty set.
- **The u2o overlay CIDRs address set is named after the vpc** (`u2oOverlayCIDRsAddressSetNames(vpcName)`) but written from each subnet's `addPolicyRouteForU2OInterconn`, so N subnets in a vpc means N writes of identical content.

To be precise about the cost: ovsdb-server does detect this. `determine_changes()` in `ovsdb/transaction.c` compares each column and drops unchanged rows, so an empty transaction is never written to storage and never reaches raft — northd and ovn-controller are not woken up. What is actually being spent is a synchronous JSON-RPC round trip per address set, the serialization of the full address set content, and datum parsing plus comparison on the single-threaded ovsdb-server main loop. On a large cluster those address sets hold thousands of entries.

## The fix

The current addresses come from the local libovsdb cache (`api.Get` reads `tableCache.RowByModel`, no RPC), so comparing them costs nothing.

The comparison has to be set-based: `strset.List()` iterates a Go map, so the same content comes back in a different order every time and `slices.Equal` would report a change on every call.

Cache staleness is safe in this direction — the cache can lag but never leads, so a stale read makes us write again (idempotent) rather than skip a needed write. External tampering via `ovn-nbctl` reaches the cache through the monitor, so it still self-heals.

Also stops formatting the CIDRs in place. The variadic slice shares its backing array with the caller's at every `f(name, slice...)` call site, so the old code silently rewrote the caller's data. Verified that no call site depends on that side effect: `subnet.go`'s returned CIDRs are discarded by all three callers via `_, _, err :=`, and the sg / node IP slices are unused after the call.

## Tests

- `Test_normalizeAddresses` covers CIDR formatting, dedup after formatting, order-independent comparison (the trap above), leaving the caller's slice untouched, and empty input.
- Two new sub-tests in the existing suite cover the no-op path and the caller's slice.
- Verified the new tests are not vacuous: temporarily restoring the in-place write makes `leave the given addresses untouched` fail with `192.168.100.5/24` turning into `192.168.100.0/24`.

`make lint` clean, `go test ./pkg/ovs/...` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)