### PR TITLE
test(e2e): extend multus ip family coverage

### DIFF
--- a/test/e2e/multus/e2e_test.go
+++ b/test/e2e/multus/e2e_test.go
@@ -228,9 +228,14 @@ func (e multusAttachmentExpecter) expectAttachmentInterfaceIPFamily(pod *corev1.
 	framework.ExpectNotContainElement(actualRoutes, request.Route{Destination: otherFamilyCIDR})
 	framework.ExpectTrue(hasNonLinkLocalConnectedRouteForFamily(actualRoutes, attachment.family))
 	framework.ExpectFalse(hasNonLinkLocalConnectedRouteForFamily(actualRoutes, oppositeIPFamily(attachment.family)))
-	framework.ExpectContainElement(actualRoutes, request.Route{Destination: "default", Gateway: familyGateway})
+	if pod.Annotations[fmt.Sprintf(util.DefaultRouteAnnotationTemplate, attachment.provider)] == "true" {
+		framework.ExpectContainElement(actualRoutes, request.Route{Destination: "default", Gateway: familyGateway})
+		framework.ExpectTrue(podHasDefaultRouteForFamily(pod, attachment.ifaceName, attachment.family))
+	} else {
+		framework.ExpectNotContainElement(actualRoutes, request.Route{Destination: "default", Gateway: familyGateway})
+		framework.ExpectFalse(podHasDefaultRouteForFamily(pod, attachment.ifaceName, attachment.family))
+	}
 	framework.ExpectNotContainElement(actualRoutes, request.Route{Destination: "default", Gateway: otherFamilyGateway})
-	framework.ExpectTrue(podHasDefaultRouteForFamily(pod, attachment.ifaceName, attachment.family))
 	framework.ExpectFalse(podHasDefaultRouteForFamily(pod, attachment.ifaceName, oppositeIPFamily(attachment.family)))
 }
 
@@ -475,7 +480,6 @@ var _ = framework.SerialDescribe("[group:multus]", func() {
 			nadv1.NetworkAttachmentAnnot:                               string(networksAnnotation),
 			fmt.Sprintf(util.IPFamilyAnnotationTemplate, providerNet1): strings.ToLower(apiv1.ProtocolIPv4),
 			fmt.Sprintf(util.IPFamilyAnnotationTemplate, providerNet2): strings.ToLower(apiv1.ProtocolIPv6),
-			fmt.Sprintf(util.DefaultRouteAnnotationTemplate, provider): "true",
 		}
 		cmd := []string{"sleep", "infinity"}
 		pod := framework.MakePrivilegedPod(namespaceName, podName, nil, annotations, f.KubeOVNImage, cmd, nil)

--- a/test/e2e/multus/e2e_test.go
+++ b/test/e2e/multus/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -43,6 +44,238 @@ func init() {
 func TestE2E(t *testing.T) {
 	k8sframework.AfterReadingAllFlags(&k8sframework.TestContext)
 	e2e.RunE2ETests(t)
+}
+
+type multusAttachment struct {
+	provider  string
+	ifaceName string
+	family    string
+	ip        string
+	mac       string
+}
+
+type multusAttachmentExpecter struct {
+	ipClient   *framework.IPClient
+	subnet     *apiv1.Subnet
+	subnetName string
+}
+
+func valuesForIPFamily(family, ipv4Value, ipv6Value string) (value, oppositeValue string) {
+	ginkgo.GinkgoHelper()
+
+	switch family {
+	case apiv1.ProtocolIPv4:
+		return ipv4Value, ipv6Value
+	case apiv1.ProtocolIPv6:
+		return ipv6Value, ipv4Value
+	default:
+		framework.Failf("unexpected IP family %q", family)
+	}
+	return "", ""
+}
+
+func oppositeIPFamily(family string) string {
+	ginkgo.GinkgoHelper()
+
+	switch family {
+	case apiv1.ProtocolIPv4:
+		return apiv1.ProtocolIPv6
+	case apiv1.ProtocolIPv6:
+		return apiv1.ProtocolIPv4
+	default:
+		framework.Failf("unexpected IP family %q", family)
+	}
+	return ""
+}
+
+func (e multusAttachmentExpecter) expectPodAttachment(
+	pod *corev1.Pod,
+	nad *nadv1.NetworkAttachmentDefinition,
+	provider, ifaceName, family string,
+) multusAttachment {
+	ginkgo.GinkgoHelper()
+
+	attachment := e.expectAttachmentIPFamily(pod, provider, ifaceName, family)
+	e.expectAttachmentIPCR(pod, attachment)
+	expectNetworkStatus(pod, nad, attachment)
+	e.expectAttachmentInterfaceIPFamily(pod, attachment)
+	expectAttachmentDHCPOptions(pod, attachment)
+	return attachment
+}
+
+func (e multusAttachmentExpecter) expectAttachmentIPFamily(pod *corev1.Pod, provider, ifaceName, family string) multusAttachment {
+	ginkgo.GinkgoHelper()
+
+	ip := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, provider)]
+	cidr := pod.Annotations[fmt.Sprintf(util.CidrAnnotationTemplate, provider)]
+	gateway := pod.Annotations[fmt.Sprintf(util.GatewayAnnotationTemplate, provider)]
+	mac := pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, provider)]
+	framework.ExpectHaveKeyWithValue(pod.Annotations, fmt.Sprintf(util.AllocatedAnnotationTemplate, provider), "true")
+	framework.ExpectHaveKeyWithValue(pod.Annotations, fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider), e.subnet.Name)
+	framework.ExpectIPInCIDR(ip, cidr)
+	framework.ExpectMAC(mac)
+
+	ipv4, ipv6 := util.SplitStringIP(ip)
+	gatewayV4, gatewayV6 := util.SplitStringIP(gateway)
+	familyIP, otherFamilyIP := valuesForIPFamily(family, ipv4, ipv6)
+	familyGateway, _ := valuesForIPFamily(family, gatewayV4, gatewayV6)
+	framework.ExpectNotEmpty(familyIP)
+	framework.ExpectEmpty(otherFamilyIP)
+	framework.ExpectNotEmpty(familyGateway)
+
+	return multusAttachment{
+		provider:  provider,
+		ifaceName: ifaceName,
+		family:    family,
+		ip:        ip,
+		mac:       mac,
+	}
+}
+
+func (e multusAttachmentExpecter) expectAttachmentIPCR(pod *corev1.Pod, attachment multusAttachment) {
+	ginkgo.GinkgoHelper()
+
+	ipName := ovs.PodNameToPortName(pod.Name, pod.Namespace, attachment.provider)
+	ginkgo.By("Validating IP resource " + ipName)
+	ipCR := e.ipClient.Get(ipName)
+	framework.ExpectEqual(ipCR.Spec.Subnet, e.subnetName)
+	framework.ExpectEqual(ipCR.Spec.PodName, pod.Name)
+	framework.ExpectEqual(ipCR.Spec.Namespace, pod.Namespace)
+	framework.ExpectEqual(ipCR.Spec.NodeName, pod.Spec.NodeName)
+	framework.ExpectEqual(ipCR.Spec.IPAddress, attachment.ip)
+	framework.ExpectEqual(ipCR.Spec.MacAddress, attachment.mac)
+	ipv4, ipv6 := util.SplitStringIP(attachment.ip)
+	framework.ExpectEqual(ipCR.Spec.V4IPAddress, ipv4)
+	framework.ExpectEqual(ipCR.Spec.V6IPAddress, ipv6)
+}
+
+func expectNetworkStatus(pod *corev1.Pod, nad *nadv1.NetworkAttachmentDefinition, attachment multusAttachment) {
+	ginkgo.GinkgoHelper()
+
+	statuses, err := nadutils.GetNetworkStatus(pod)
+	framework.ExpectNoError(err)
+	nadKey := cache.MetaObjectToName(nad).String()
+	found := false
+	for _, status := range statuses {
+		if status.Name == nadKey && status.Interface == attachment.ifaceName {
+			framework.ExpectConsistOf(status.IPs, strings.Split(attachment.ip, ","))
+			framework.ExpectEqual(status.Mac, attachment.mac)
+			found = true
+			break
+		}
+	}
+	framework.ExpectTrue(found, "network status should contain %s interface %s", nadKey, attachment.ifaceName)
+}
+
+func expectAttachmentDHCPOptions(pod *corev1.Pod, attachment multusAttachment) {
+	ginkgo.GinkgoHelper()
+
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, attachment.provider)
+	ginkgo.By("Validating DHCP options for logical switch port " + portName)
+	dhcpV4, _, err := framework.NBExec("ovn-nbctl get logical_switch_port " + portName + " dhcpv4_options")
+	framework.ExpectNoError(err)
+	dhcpV6, _, err := framework.NBExec("ovn-nbctl get logical_switch_port " + portName + " dhcpv6_options")
+	framework.ExpectNoError(err)
+	dhcpUUID, otherDHCPUUID := valuesForIPFamily(attachment.family, parseDHCPOptionUUID(dhcpV4), parseDHCPOptionUUID(dhcpV6))
+	framework.ExpectNotEmpty(dhcpUUID)
+	framework.ExpectEmpty(otherDHCPUUID)
+	framework.ExpectEqual(util.CheckProtocol(getDHCPOptionCIDR(dhcpUUID)), attachment.family)
+}
+
+func parseDHCPOptionUUID(output []byte) string {
+	uuid := strings.TrimSpace(string(output))
+	if uuid == "[]" {
+		return ""
+	}
+	uuid = strings.TrimPrefix(uuid, "[")
+	uuid = strings.TrimSuffix(uuid, "]")
+	uuid = strings.TrimSpace(uuid)
+	return strings.Trim(uuid, `"`)
+}
+
+func getDHCPOptionCIDR(uuid string) string {
+	ginkgo.GinkgoHelper()
+
+	output, _, err := framework.NBExec("ovn-nbctl get DHCP_Options " + uuid + " cidr")
+	framework.ExpectNoError(err)
+	return strings.Trim(strings.TrimSpace(string(output)), `"`)
+}
+
+func (e multusAttachmentExpecter) expectAttachmentInterfaceIPFamily(pod *corev1.Pod, attachment multusAttachment) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By("Validating attachment interface IPs")
+	links, err := iproute.AddressShow(attachment.ifaceName, func(cmd ...string) ([]byte, []byte, error) {
+		return framework.KubectlExec(pod.Namespace, pod.Name, cmd...)
+	})
+	framework.ExpectNoError(err)
+	framework.ExpectHaveLen(links, 1)
+	framework.ExpectEqual(links[0].Address, attachment.mac)
+	framework.ExpectConsistOf(links[0].NonLinkLocalIPs(), strings.Split(attachment.ip, ","))
+
+	ginkgo.By("Validating attachment interface routes")
+	podRoutes, err := iproute.RouteShow("", attachment.ifaceName, func(cmd ...string) ([]byte, []byte, error) {
+		return framework.KubectlExec(pod.Namespace, pod.Name, cmd...)
+	})
+	framework.ExpectNoError(err)
+	actualRoutes := routesWithDestinationOrGateway(podRoutes)
+	nadIPv4CIDR, nadIPv6CIDR := util.SplitStringIP(e.subnet.Spec.CIDRBlock)
+	familyCIDR, otherFamilyCIDR := valuesForIPFamily(attachment.family, nadIPv4CIDR, nadIPv6CIDR)
+	nadIPv4Gateway, nadIPv6Gateway := util.SplitStringIP(pod.Annotations[fmt.Sprintf(util.GatewayAnnotationTemplate, attachment.provider)])
+	familyGateway, otherFamilyGateway := valuesForIPFamily(attachment.family, nadIPv4Gateway, nadIPv6Gateway)
+
+	framework.ExpectContainElement(actualRoutes, request.Route{Destination: familyCIDR})
+	framework.ExpectNotContainElement(actualRoutes, request.Route{Destination: otherFamilyCIDR})
+	framework.ExpectTrue(hasNonLinkLocalConnectedRouteForFamily(actualRoutes, attachment.family))
+	framework.ExpectFalse(hasNonLinkLocalConnectedRouteForFamily(actualRoutes, oppositeIPFamily(attachment.family)))
+	framework.ExpectContainElement(actualRoutes, request.Route{Destination: "default", Gateway: familyGateway})
+	framework.ExpectNotContainElement(actualRoutes, request.Route{Destination: "default", Gateway: otherFamilyGateway})
+	framework.ExpectTrue(podHasDefaultRouteForFamily(pod, attachment.ifaceName, attachment.family))
+	framework.ExpectFalse(podHasDefaultRouteForFamily(pod, attachment.ifaceName, oppositeIPFamily(attachment.family)))
+}
+
+func routesWithDestinationOrGateway(routes []iproute.Route) []request.Route {
+	actualRoutes := make([]request.Route, 0, len(routes))
+	for _, r := range routes {
+		if r.Gateway != "" || r.Dst != "" {
+			actualRoutes = append(actualRoutes, request.Route{Destination: r.Dst, Gateway: r.Gateway})
+		}
+	}
+	return actualRoutes
+}
+
+func podHasDefaultRouteForFamily(pod *corev1.Pod, ifaceName, family string) bool {
+	ginkgo.GinkgoHelper()
+
+	args := []string{"ip", "-j", "route", "show", "default", "dev", ifaceName}
+	if family == apiv1.ProtocolIPv6 {
+		args = []string{"ip", "-j", "-6", "route", "show", "default", "dev", ifaceName}
+	}
+	output, _, err := framework.KubectlExec(pod.Namespace, pod.Name, args...)
+	framework.ExpectNoError(err)
+	var routes []iproute.Route
+	framework.ExpectNoError(json.Unmarshal(output, &routes))
+	return len(routes) != 0
+}
+
+func hasNonLinkLocalConnectedRouteForFamily(actualRoutes []request.Route, family string) bool {
+	ginkgo.GinkgoHelper()
+
+	for _, route := range actualRoutes {
+		if route.Gateway != "" || route.Destination == "" || route.Destination == "default" ||
+			route.Destination == "0.0.0.0/0" || route.Destination == "::/0" {
+			continue
+		}
+		ip, _, err := net.ParseCIDR(route.Destination)
+		framework.ExpectNoError(err)
+		if ip.IsLinkLocalUnicast() {
+			continue
+		}
+		if util.CheckProtocol(route.Destination) == family {
+			return true
+		}
+	}
+	return false
 }
 
 var _ = framework.SerialDescribe("[group:multus]", func() {
@@ -171,14 +404,17 @@ var _ = framework.SerialDescribe("[group:multus]", func() {
 
 		ginkgo.By("Creating subnet " + subnetName)
 		subnet = framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
+		subnet.Spec.EnableDHCP = true
 		subnet.Spec.Provider = provider
 		subnet = subnetClient.CreateSync(subnet)
+		attachmentExpecter := multusAttachmentExpecter{ipClient: ipClient, subnet: subnet, subnetName: subnetName}
 
 		for _, family := range []string{apiv1.ProtocolIPv4, apiv1.ProtocolIPv6} {
 			ginkgo.By("Creating pod " + podName + " with " + family + " attachment IP family")
 			annotations := map[string]string{
-				nadv1.NetworkAttachmentAnnot:                           fmt.Sprintf("%s/%s", nad.Namespace, nad.Name),
-				fmt.Sprintf(util.IPFamilyAnnotationTemplate, provider): strings.ToLower(family),
+				nadv1.NetworkAttachmentAnnot:                               fmt.Sprintf("%s/%s", nad.Namespace, nad.Name),
+				fmt.Sprintf(util.IPFamilyAnnotationTemplate, provider):     strings.ToLower(family),
+				fmt.Sprintf(util.DefaultRouteAnnotationTemplate, provider): "true",
 			}
 			cmd := []string{"sleep", "infinity"}
 			pod := framework.MakePrivilegedPod(namespaceName, podName, nil, annotations, f.KubeOVNImage, cmd, nil)
@@ -187,68 +423,69 @@ var _ = framework.SerialDescribe("[group:multus]", func() {
 			ginkgo.By("Validating pod annotations")
 			framework.ExpectHaveKey(pod.Annotations, nadv1.NetworkStatusAnnot)
 			framework.Logf("pod network status:\n%s", pod.Annotations[nadv1.NetworkStatusAnnot])
-			ip := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, provider)]
-			cidr := pod.Annotations[fmt.Sprintf(util.CidrAnnotationTemplate, provider)]
-			gateway := pod.Annotations[fmt.Sprintf(util.GatewayAnnotationTemplate, provider)]
-			mac := pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, provider)]
-			framework.ExpectHaveKeyWithValue(pod.Annotations, fmt.Sprintf(util.AllocatedAnnotationTemplate, provider), "true")
-			framework.ExpectHaveKeyWithValue(pod.Annotations, fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider), subnet.Name)
-			framework.ExpectIPInCIDR(ip, cidr)
-			framework.ExpectMAC(mac)
-
-			ipv4, ipv6 := util.SplitStringIP(ip)
-			gatewayV4, gatewayV6 := util.SplitStringIP(gateway)
-			switch family {
-			case apiv1.ProtocolIPv4:
-				framework.ExpectNotEmpty(ipv4)
-				framework.ExpectEmpty(ipv6)
-				framework.ExpectNotEmpty(gatewayV4)
-			case apiv1.ProtocolIPv6:
-				framework.ExpectEmpty(ipv4)
-				framework.ExpectNotEmpty(ipv6)
-				framework.ExpectNotEmpty(gatewayV6)
-			}
-
-			ipName := ovs.PodNameToPortName(podName, namespaceName, provider)
-			ginkgo.By("Validating IP resource " + ipName)
-			ipCR := ipClient.Get(ipName)
-			framework.ExpectEqual(ipCR.Spec.Subnet, subnetName)
-			framework.ExpectEqual(ipCR.Spec.PodName, podName)
-			framework.ExpectEqual(ipCR.Spec.Namespace, namespaceName)
-			framework.ExpectEqual(ipCR.Spec.NodeName, pod.Spec.NodeName)
-			framework.ExpectEqual(ipCR.Spec.IPAddress, ip)
-			framework.ExpectEqual(ipCR.Spec.MacAddress, mac)
-			framework.ExpectEqual(ipCR.Spec.V4IPAddress, ipv4)
-			framework.ExpectEqual(ipCR.Spec.V6IPAddress, ipv6)
-
-			ginkgo.By("Getting attachment interface name")
-			statuses, err := nadutils.GetNetworkStatus(pod)
-			framework.ExpectNoError(err)
-			var ifaceName string
-			nadKey := cache.MetaObjectToName(nad).String()
-			for _, status := range statuses {
-				if status.Name == nadKey {
-					framework.ExpectConsistOf(status.IPs, strings.Split(ip, ","))
-					framework.ExpectEqual(status.Mac, mac)
-					ifaceName = status.Interface
-					break
-				}
-			}
-			framework.ExpectNotEmpty(ifaceName)
-
-			ginkgo.By("Validating attachment interface IPs")
-			links, err := iproute.AddressShow(ifaceName, func(cmd ...string) ([]byte, []byte, error) {
-				return framework.KubectlExec(pod.Namespace, pod.Name, cmd...)
-			})
-			framework.ExpectNoError(err)
-			framework.ExpectHaveLen(links, 1)
-			framework.ExpectEqual(links[0].Address, mac)
-			framework.ExpectConsistOf(links[0].NonLinkLocalIPs(), strings.Split(ip, ","))
+			attachmentExpecter.expectPodAttachment(pod, nad, provider, "net1", family)
 
 			ginkgo.By("Deleting pod " + podName)
 			podClient.DeleteSync(podName)
-			ipClient.DeleteSync(ipName)
+			ipClient.DeleteSync(ovs.PodNameToPortName(podName, namespaceName, provider))
 		}
+	})
+
+	framework.ConformanceIt("should allocate requested IP families for multiple interfaces from the same NAD", func() {
+		f.SkipVersionPriorTo(1, 17, "Per-pod IP family selection was introduced in v1.17")
+		if !f.IsDual() {
+			ginkgo.Skip("This test requires a dual-stack cluster")
+		}
+
+		provider := fmt.Sprintf("%s.%s.%s", nadName, namespaceName, util.OvnProvider)
+		providerNet1 := provider + ".net1"
+		providerNet2 := provider + ".net2"
+
+		ginkgo.By("Creating network attachment definition " + nadName)
+		nad := framework.MakeOVNNetworkAttachmentDefinition(nadName, namespaceName, provider, nil)
+		nad = nadClient.Create(nad)
+		framework.Logf("created network attachment definition config:\n%s", nad.Spec.Config)
+
+		ginkgo.By("Creating subnet " + subnetName)
+		subnet = framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
+		subnet.Spec.EnableDHCP = true
+		subnet.Spec.Provider = provider
+		subnet = subnetClient.CreateSync(subnet)
+		attachmentExpecter := multusAttachmentExpecter{ipClient: ipClient, subnet: subnet, subnetName: subnetName}
+
+		ginkgo.By("Generating networks annotation with the same NAD attached as net1 and net2")
+		networks := []*nadv1.NetworkSelectionElement{
+			{
+				Name:             nad.Name,
+				Namespace:        nad.Namespace,
+				InterfaceRequest: "net1",
+			},
+			{
+				Name:             nad.Name,
+				Namespace:        nad.Namespace,
+				InterfaceRequest: "net2",
+			},
+		}
+		networksAnnotation, err := json.Marshal(networks)
+		framework.ExpectNoError(err)
+		framework.Logf("networks annotation: %s", string(networksAnnotation))
+
+		ginkgo.By("Creating pod " + podName + " with different IP families per interface")
+		annotations := map[string]string{
+			nadv1.NetworkAttachmentAnnot:                               string(networksAnnotation),
+			fmt.Sprintf(util.IPFamilyAnnotationTemplate, providerNet1): strings.ToLower(apiv1.ProtocolIPv4),
+			fmt.Sprintf(util.IPFamilyAnnotationTemplate, providerNet2): strings.ToLower(apiv1.ProtocolIPv6),
+			fmt.Sprintf(util.DefaultRouteAnnotationTemplate, provider): "true",
+		}
+		cmd := []string{"sleep", "infinity"}
+		pod := framework.MakePrivilegedPod(namespaceName, podName, nil, annotations, f.KubeOVNImage, cmd, nil)
+		pod = podClient.CreateSync(pod)
+
+		ginkgo.By("Validating net1 IPv4-only allocation")
+		attachmentExpecter.expectPodAttachment(pod, nad, providerNet1, "net1", apiv1.ProtocolIPv4)
+
+		ginkgo.By("Validating net2 IPv6-only allocation")
+		attachmentExpecter.expectPodAttachment(pod, nad, providerNet2, "net2", apiv1.ProtocolIPv6)
 	})
 
 	framework.ConformanceIt("should reject ovn attachment provider without matching subnet", func() {


### PR DESCRIPTION
## Summary

Follow-up coverage for #6985, which is now merged in `master`.

- assert that Multus single-family attachment allocation produces only the requested-family IP while keeping a matching gateway available
- assert that the configured attachment interface does not retain the opposite-family connected route or default route
- assert that logical switch port DHCP options and the selected `DHCP_Options.cidr` match the requested IP family
- add same-NAD multi-interface coverage with provider-scoped `ip_family` annotations for `net1` and `net2`
- keep the new checks scoped to v1.17+ dual-stack clusters
- move the new validation helpers outside the `SerialDescribe` closure and bundle attachment context to keep the E2E code within the documented style boundary

## Testing

- `gofmt -w test/e2e/multus/e2e_test.go && git diff --exit-code -- test/e2e/multus/e2e_test.go`
- `TMPDIR=/root/workspace/output/W-20260729-14/go-tmp GOTMPDIR=/root/workspace/output/W-20260729-14/go-tmp go test ./pkg/daemon -run TestGatewayForCNIIPFamily -count=1`
- `TMPDIR=/root/workspace/output/W-20260729-14/go-tmp GOTMPDIR=/root/workspace/output/W-20260729-14/go-tmp go test ./pkg/controller -run TestDHCPOptionsForPodIPFamily -count=1`
- `TMPDIR=/root/workspace/output/W-20260729-14/go-tmp GOTMPDIR=/root/workspace/output/W-20260729-14/go-tmp go test ./test/e2e/kube-ovn/ipam ./test/e2e/webhook/pod ./test/e2e/multus -run '^$' -count=1`
- `git diff --check`

Note: `make lint` passed before the helper-extraction fix, but was not rerun after the final refactor because this local workspace now prohibits known high-memory tasks. GitHub Actions remain the authoritative full CI signal for the final commit.
