### PR TITLE
fix(controller): reject V6Ip changes in enqueueUpdateOvnEip guard

### DIFF
--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -43,6 +43,7 @@ func (c *Controller) enqueueUpdateOvnEip(oldObj, newObj any) {
 	}
 	oldEip := oldObj.(*kubeovnv1.OvnEip)
 	if oldEip.Spec.V4Ip != "" && oldEip.Spec.V4Ip != newEip.Spec.V4Ip ||
+		oldEip.Spec.V6Ip != "" && oldEip.Spec.V6Ip != newEip.Spec.V6Ip ||
 		oldEip.Spec.MacAddress != "" && oldEip.Spec.MacAddress != newEip.Spec.MacAddress {
 		klog.Infof("not support change ip or mac for eip %s", key)
 		c.resetOvnEipQueue.Add(key)

--- a/pkg/controller/ovn_eip_test.go
+++ b/pkg/controller/ovn_eip_test.go
@@ -10,6 +10,77 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
+func Test_enqueueUpdateOvnEip(t *testing.T) {
+	newTestController := func() *Controller {
+		return &Controller{
+			updateOvnEipQueue: newTypedRateLimitingQueue[string]("UpdateOvnEip", nil),
+			resetOvnEipQueue:  newTypedRateLimitingQueue[string]("ResetOvnEip", nil),
+		}
+	}
+
+	t.Run("v6 ip change is rejected via resetOvnEipQueue, not updateOvnEipQueue", func(t *testing.T) {
+		ctrl := newTestController()
+		oldEip := &kubeovnv1.OvnEip{
+			ObjectMeta: metav1.ObjectMeta{Name: "eip-v6"},
+			Spec:       kubeovnv1.OvnEipSpec{V6Ip: "fc00:1::a"},
+		}
+		newEip := oldEip.DeepCopy()
+		newEip.Spec.V6Ip = "fc00:1::b"
+
+		ctrl.enqueueUpdateOvnEip(oldEip, newEip)
+
+		require.Equal(t, 1, ctrl.resetOvnEipQueue.Len())
+		require.Equal(t, 0, ctrl.updateOvnEipQueue.Len())
+		key, _ := ctrl.resetOvnEipQueue.Get()
+		require.Equal(t, "eip-v6", key)
+	})
+
+	t.Run("v4 ip change is rejected via resetOvnEipQueue", func(t *testing.T) {
+		ctrl := newTestController()
+		oldEip := &kubeovnv1.OvnEip{
+			ObjectMeta: metav1.ObjectMeta{Name: "eip-v4"},
+			Spec:       kubeovnv1.OvnEipSpec{V4Ip: "192.168.0.5"},
+		}
+		newEip := oldEip.DeepCopy()
+		newEip.Spec.V4Ip = "192.168.0.6"
+
+		ctrl.enqueueUpdateOvnEip(oldEip, newEip)
+
+		require.Equal(t, 1, ctrl.resetOvnEipQueue.Len())
+		require.Equal(t, 0, ctrl.updateOvnEipQueue.Len())
+	})
+
+	t.Run("v4 ip assigned from empty is queued via updateOvnEipQueue", func(t *testing.T) {
+		ctrl := newTestController()
+		oldEip := &kubeovnv1.OvnEip{
+			ObjectMeta: metav1.ObjectMeta{Name: "eip-assign"},
+			Spec:       kubeovnv1.OvnEipSpec{V4Ip: "", V6Ip: "fc00:1::a"},
+		}
+		newEip := oldEip.DeepCopy()
+		newEip.Spec.V4Ip = "192.168.0.5"
+
+		ctrl.enqueueUpdateOvnEip(oldEip, newEip)
+
+		require.Equal(t, 0, ctrl.resetOvnEipQueue.Len())
+		require.Equal(t, 1, ctrl.updateOvnEipQueue.Len())
+	})
+
+	t.Run("v6 ip assigned from empty is queued via updateOvnEipQueue", func(t *testing.T) {
+		ctrl := newTestController()
+		oldEip := &kubeovnv1.OvnEip{
+			ObjectMeta: metav1.ObjectMeta{Name: "eip-assign-v6"},
+			Spec:       kubeovnv1.OvnEipSpec{V4Ip: "192.168.0.5", V6Ip: ""},
+		}
+		newEip := oldEip.DeepCopy()
+		newEip.Spec.V6Ip = "fc00:1::a"
+
+		ctrl.enqueueUpdateOvnEip(oldEip, newEip)
+
+		require.Equal(t, 0, ctrl.resetOvnEipQueue.Len())
+		require.Equal(t, 1, ctrl.updateOvnEipQueue.Len())
+	})
+}
+
 func Test_getOvnEipNat(t *testing.T) {
 	// NAT rules always carry an eip_v4_ip label, so a pure-IPv6 rule still has
 	// eip_v4_ip="" together with its own eip_v6_ip label.

--- a/pkg/controller/ovn_eip_test.go
+++ b/pkg/controller/ovn_eip_test.go
@@ -11,15 +11,20 @@ import (
 )
 
 func Test_enqueueUpdateOvnEip(t *testing.T) {
-	newTestController := func() *Controller {
-		return &Controller{
+	newTestController := func(t *testing.T) *Controller {
+		ctrl := &Controller{
 			updateOvnEipQueue: newTypedRateLimitingQueue[string]("UpdateOvnEip", nil),
 			resetOvnEipQueue:  newTypedRateLimitingQueue[string]("ResetOvnEip", nil),
 		}
+		t.Cleanup(func() {
+			ctrl.updateOvnEipQueue.ShutDown()
+			ctrl.resetOvnEipQueue.ShutDown()
+		})
+		return ctrl
 	}
 
 	t.Run("v6 ip change is rejected via resetOvnEipQueue, not updateOvnEipQueue", func(t *testing.T) {
-		ctrl := newTestController()
+		ctrl := newTestController(t)
 		oldEip := &kubeovnv1.OvnEip{
 			ObjectMeta: metav1.ObjectMeta{Name: "eip-v6"},
 			Spec:       kubeovnv1.OvnEipSpec{V6Ip: "fc00:1::a"},
@@ -36,7 +41,7 @@ func Test_enqueueUpdateOvnEip(t *testing.T) {
 	})
 
 	t.Run("v4 ip change is rejected via resetOvnEipQueue", func(t *testing.T) {
-		ctrl := newTestController()
+		ctrl := newTestController(t)
 		oldEip := &kubeovnv1.OvnEip{
 			ObjectMeta: metav1.ObjectMeta{Name: "eip-v4"},
 			Spec:       kubeovnv1.OvnEipSpec{V4Ip: "192.168.0.5"},
@@ -51,7 +56,7 @@ func Test_enqueueUpdateOvnEip(t *testing.T) {
 	})
 
 	t.Run("v4 ip assigned from empty is queued via updateOvnEipQueue", func(t *testing.T) {
-		ctrl := newTestController()
+		ctrl := newTestController(t)
 		oldEip := &kubeovnv1.OvnEip{
 			ObjectMeta: metav1.ObjectMeta{Name: "eip-assign"},
 			Spec:       kubeovnv1.OvnEipSpec{V4Ip: "", V6Ip: "fc00:1::a"},
@@ -66,7 +71,7 @@ func Test_enqueueUpdateOvnEip(t *testing.T) {
 	})
 
 	t.Run("v6 ip assigned from empty is queued via updateOvnEipQueue", func(t *testing.T) {
-		ctrl := newTestController()
+		ctrl := newTestController(t)
 		oldEip := &kubeovnv1.OvnEip{
 			ObjectMeta: metav1.ObjectMeta{Name: "eip-assign-v6"},
 			Spec:       kubeovnv1.OvnEipSpec{V4Ip: "192.168.0.5", V6Ip: ""},


### PR DESCRIPTION
Motivation:
enqueueUpdateOvnEip guards against unsupported mutations to an
existing OvnEip by routing them to resetOvnEipQueue, which quietly
marks the EIP not-ready without erroring. That guard only checked
V4Ip and MacAddress, not V6Ip. A V6Ip-only spec change on a Ready
OvnEip therefore skipped the guard and instead went to
updateOvnEipQueue -> handleUpdateOvnEip, which already rejects the
Status/Spec V6Ip mismatch but returns a persistent error. Since
runWorker keeps re-queuing on error, this produces indefinite
rate-limited retries and repeated klog.Error log lines instead of
the same clean, silent rejection the V4Ip/MacAddress paths get.

This does not cause a crash or outage: the change is still
ultimately rejected (both by this downstream check and, when
deployed, by the validating webhook in pkg/webhook/ovn_nat_gateway.go
for Ready OvnEips). User-visible behavior for a successful update is
unchanged. The fix only closes the gap between how V6Ip and V4Ip
mutations are handled, eliminating the retry-loop/log-spam path for
V6Ip.

Approach:
Add a `V6Ip != "" && V6Ip != newV6Ip` clause to the guard in
enqueueUpdateOvnEip, mirroring the existing V4Ip clause exactly, so
V6Ip changes on an existing EIP are caught at the same point as
V4Ip/MacAddress changes and routed to resetOvnEipQueue.

Validation:
This sandbox's host is native macOS, and pkg/util (transitively
imported by pkg/controller) does not build natively on darwin
(pkg/util/ndp.go uses the Linux-only unix.ETH_P_IPV6 constant) -
verified this is pre-existing and unrelated to this change via
`git stash && go test -run TestNothing ./pkg/controller/...`, which
fails identically before this diff. No Docker/VM/qemu is available
in this sandbox to execute a cross-compiled Linux test binary, so
`go test` itself could not be run and is not claimed to have been
run. Instead:
  - `GOOS=linux GOARCH=amd64 go build ./pkg/controller/...` passes
  - `GOOS=linux GOARCH=amd64 go vet ./pkg/controller/...` passes
  - `GOOS=linux GOARCH=amd64 go test -c -o /dev/null ./pkg/controller/...`
    passes, proving the new test compiles and links against the real
    Controller struct/queues
  - `GOOS=linux GOARCH=amd64 golangci-lint run ./pkg/controller/...`
    reports 0 issues
  - The corrected boolean guard expression was extracted verbatim into
    a standalone throwaway Go program (no repo deps) and run natively
    with `go run` against 5 scenarios (v6 change, v4 change, mac
    change, v6/v4 assigned from empty, no change); all 5 produced the
    expected accept/reject verdict. The scratch file was removed
    afterward and is not part of this commit.
Added Test_enqueueUpdateOvnEip to pkg/controller/ovn_eip_test.go,
covering: V6Ip change routed to resetOvnEipQueue (not
updateOvnEipQueue), V4Ip change routed to resetOvnEipQueue
(regression guard), and V4Ip/V6Ip initial assignment from empty
routed to updateOvnEipQueue (must not be rejected).

Fixes #6800

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>