### PR TITLE
fix(crd): make vlanInterfaces item validation actually take effect

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -1940,6 +1940,8 @@ spec:
                 description: Optional explicit list of VLAN interface names to preserve
                   (e.g., eth0.10, bond0.20)
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z0-9_-]+\.[0-9]{1,4}$
                   type: string
                 type: array
             required:

--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -1962,6 +1962,8 @@ spec:
                 description: Optional explicit list of VLAN interface names to preserve
                   (e.g., eth0.10, bond0.20)
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z0-9_-]+\.[0-9]{1,4}$
                   type: string
                 type: array
             required:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -1955,6 +1955,8 @@ spec:
                 description: Optional explicit list of VLAN interface names to preserve
                   (e.g., eth0.10, bond0.20)
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z0-9_-]+\.[0-9]{1,4}$
                   type: string
                 type: array
             required:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -1977,6 +1977,8 @@ spec:
                 description: Optional explicit list of VLAN interface names to preserve
                   (e.g., eth0.10, bond0.20)
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z0-9_-]+\.[0-9]{1,4}$
                   type: string
                 type: array
             required:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2349,6 +2349,8 @@ spec:
                 description: Optional explicit list of VLAN interface names to preserve
                   (e.g., eth0.10, bond0.20)
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z0-9_-]+\.[0-9]{1,4}$
                   type: string
                 type: array
             required:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -2387,6 +2387,8 @@ spec:
                 description: Optional explicit list of VLAN interface names to preserve
                   (e.g., eth0.10, bond0.20)
                 items:
+                  maxLength: 15
+                  pattern: ^[a-zA-Z0-9_-]+\.[0-9]{1,4}$
                   type: string
                 type: array
             required:

--- a/pkg/apis/kubeovn/v1/provider-network.go
+++ b/pkg/apis/kubeovn/v1/provider-network.go
@@ -58,7 +58,8 @@ type ProviderNetworkSpec struct {
 	// Enable automatic detection and preservation of VLAN interfaces
 	PreserveVlanInterfaces bool `json:"preserveVlanInterfaces,omitempty"`
 	// Optional explicit list of VLAN interface names to preserve (e.g., eth0.10, bond0.20)
-	// +kubebuilder:validation:Items={Type=string,Pattern=`^[a-zA-Z0-9_-]+\\.[0-9]{1,4}$`}
+	// +kubebuilder:validation:items:Pattern=`^[a-zA-Z0-9_-]+\.[0-9]{1,4}$`
+	// +kubebuilder:validation:items:MaxLength=15
 	VlanInterfaces []string `json:"vlanInterfaces,omitempty"`
 }
 


### PR DESCRIPTION
### What

`ProviderNetwork.Spec.VlanInterfaces` carried this marker:

```go
// +kubebuilder:validation:Items={Type=string,Pattern=`^[a-zA-Z0-9_-]+\\.[0-9]{1,4}$`}
```

`Items={...}` is not a marker controller-gen recognises, so it was silently
dropped. The generated CRD ships a bare `items: {type: string}` — the field
accepts any string today.

The pattern was wrong too: inside a Go raw string literal `\\.` is a literal
backslash followed by any character, not an escaped dot, so the expression
rejects every legal value such as `eth0.10`. **Fixing only the marker name
would have turned a silent no-op into a hard regression** — worth knowing for
anyone reviewing similar markers.

### Change

Use the `items:` marker prefix controller-gen supports, escape the dot once,
and cap the length at `IFNAMSIZ-1` to match `defaultInterface` and
`customInterfaces[].interface`:

```go
// +kubebuilder:validation:items:Pattern=`^[a-zA-Z0-9_-]+\.[0-9]{1,4}$`
// +kubebuilder:validation:items:MaxLength=15
```

Regenerated CRDs via `make gen-crd` (charts v1/v2 + `install.sh`).

### Why this shape

The pattern encodes exactly what the daemon accepts. `createVlanSubinterfaces`
splits the name on the first dot and requires the parent to match the provider
network's default interface, and `ExtractVlanIDFromInterface` derives the VLAN
ID from the suffix. A name the daemon cannot parse is only reported as a
`klog.Warningf` and then skipped, so today a typo in this field is invisible to
the user — the resource is accepted and the interface is silently never
programmed.

### Validation

Checked against the regenerated schema:

| value | before | after |
|---|---|---|
| `eth0.10`, `bond0.4094`, `enp1s0f0.100`, `eth-0.1`, `eth_0.4094` | accepted (no check) | accepted |
| `eth0`, `vlan100`, `eth0.10.20`, `eth0.99999`, `.10`, `eth0.` | accepted (no check) | rejected |

`make lint` (includes `verify-crd`) passes with 0 issues; `go build ./...` and
`go test ./pkg/util/...` pass.

### Compatibility

Existing `ProviderNetwork` resources that already hold a value the daemon
accepts stay valid — the pattern is strictly narrower than "any string" but
strictly wider than what the daemon has ever been able to program. A resource
holding an unparseable name (which never worked) will be rejected on its next
update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)