### PR TITLE
fix: return an error instead of panicking on a CIDR without a mask

### DIFF
--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -376,9 +376,9 @@ func GetIPAddrWithMaskForCNI(ip, cidr string) (string, bool, error) {
 			default:
 				return "", false, fmt.Errorf("invalid ip %s", ip)
 			}
-			_, mask, ok := strings.Cut(cidrBlock, "/")
-			if !ok || mask == "" {
-				return "", false, fmt.Errorf("invalid cidr %s", cidrBlock)
+			mask, err := maskFromCIDR(cidrBlock)
+			if err != nil {
+				return "", false, err
 			}
 			ipAddrs = append(ipAddrs, fmt.Sprintf("%s/%s", ip, mask))
 		}
@@ -388,30 +388,55 @@ func GetIPAddrWithMaskForCNI(ip, cidr string) (string, bool, error) {
 	return ipAddr, false, err
 }
 
+// maskFromCIDR returns the mask length of a CIDR block, e.g. "24" for "10.16.0.0/24".
+// It returns an error when the CIDR carries no mask, so that callers report a failure
+// instead of panicking on a malformed value.
+func maskFromCIDR(cidr string) (string, error) {
+	_, mask, ok := strings.Cut(cidr, "/")
+	if !ok || mask == "" {
+		return "", fmt.Errorf("invalid cidr %s", cidr)
+	}
+	return mask, nil
+}
+
 func GetIPAddrWithMask(ip, cidr string) (string, error) {
 	var ipAddr string
 	ips := strings.Split(ip, ",")
 	if CheckProtocol(cidr) == kubeovnv1.ProtocolDual {
 		cidrBlocks := strings.Split(cidr, ",")
-		if len(cidrBlocks) == 2 {
-			if len(ips) == 2 {
-				v4IP := fmt.Sprintf("%s/%s", ips[0], strings.Split(cidrBlocks[0], "/")[1])
-				v6IP := fmt.Sprintf("%s/%s", ips[1], strings.Split(cidrBlocks[1], "/")[1])
-				ipAddr = v4IP + "," + v6IP
-			} else {
-				err := fmt.Errorf("ip %s should be dualstack", ip)
-				klog.Error(err)
-				return "", err
-			}
+		if len(cidrBlocks) != 2 {
+			err := fmt.Errorf("invalid dualstack cidr %s", cidr)
+			klog.Error(err)
+			return "", err
 		}
+		if len(ips) != 2 {
+			err := fmt.Errorf("ip %s should be dualstack", ip)
+			klog.Error(err)
+			return "", err
+		}
+		v4Mask, err := maskFromCIDR(cidrBlocks[0])
+		if err != nil {
+			klog.Error(err)
+			return "", err
+		}
+		v6Mask, err := maskFromCIDR(cidrBlocks[1])
+		if err != nil {
+			klog.Error(err)
+			return "", err
+		}
+		ipAddr = fmt.Sprintf("%s/%s,%s/%s", ips[0], v4Mask, ips[1], v6Mask)
 	} else {
-		if len(ips) == 1 {
-			ipAddr = fmt.Sprintf("%s/%s", ip, strings.Split(cidr, "/")[1])
-		} else {
+		if len(ips) != 1 {
 			err := fmt.Errorf("ip %s should be singlestack", ip)
 			klog.Error(err)
-			return ipAddr, err
+			return "", err
 		}
+		mask, err := maskFromCIDR(cidr)
+		if err != nil {
+			klog.Error(err)
+			return "", err
+		}
+		ipAddr = fmt.Sprintf("%s/%s", ip, mask)
 	}
 	return ipAddr, nil
 }

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -1049,6 +1049,46 @@ func TestGetIPAddrWithMask(t *testing.T) {
 	}
 }
 
+// TestGetIPAddrWithMaskCIDRWithoutMask makes sure a CIDR carrying no mask is reported
+// as an error instead of panicking with an index out of range.
+func TestGetIPAddrWithMaskCIDRWithoutMask(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		cidr string
+	}{
+		{name: "empty cidr", ip: "192.168.1.1", cidr: ""},
+		{name: "bare ip as cidr", ip: "192.168.1.1", cidr: "192.168.1.0"},
+		{name: "cidr with trailing slash", ip: "192.168.1.1", cidr: "192.168.1.0/"},
+		{name: "empty ip and cidr", ip: "", cidr: ""},
+		{name: "bare ipv6 as cidr", ip: "2001:db8::1", cidr: "2001:db8::"},
+		{name: "dualstack cidr missing ipv6 mask", ip: "192.168.1.1,2001:db8::1", cidr: "192.168.1.0/24,2001:db8::"},
+		{name: "dualstack cidr missing ipv4 mask", ip: "192.168.1.1,2001:db8::1", cidr: "192.168.1.0,2001:db8::/32"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				got, err := GetIPAddrWithMask(tt.ip, tt.cidr)
+				require.Error(t, err)
+				require.Empty(t, got)
+			})
+		})
+	}
+}
+
+// TestGetIPAddrWithMaskForCNICIDRWithoutMask covers the single stack branch of
+// GetIPAddrWithMaskForCNI, which delegates to GetIPAddrWithMask. The dual stack
+// branch already rejected such input.
+func TestGetIPAddrWithMaskForCNICIDRWithoutMask(t *testing.T) {
+	require.NotPanics(t, func() {
+		got, noIPAM, err := GetIPAddrWithMaskForCNI("192.168.1.1", "192.168.1.0")
+		require.Error(t, err)
+		require.Empty(t, got)
+		require.False(t, noIPAM)
+	})
+}
+
 func TestGetIPAddrWithMaskForCNI(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
### What type of this PR

Bug fix.

### Which issue(s) this PR fixes

None — found by fuzzing the parsers in `pkg/util/net.go`.

### What this PR does

`GetIPAddrWithMask` builds its result with `strings.Split(cidr, "/")[1]` in both the dual stack and the single stack branch. When the CIDR carries no mask, the split yields a single element and indexing it panics:

```
panic: runtime error: index out of range [1] with length 1
```

Reproducer (before this PR):

```go
util.GetIPAddrWithMask("192.168.1.1", "192.168.1.0")   // panic
util.GetIPAddrWithMask("192.168.1.1", "")              // panic
```

#### Why the single stack branch is reachable

`GetIPAddrWithMaskForCNI` already guards its **dual stack** branch with `strings.Cut`, but the **single stack** case is delegated straight to `GetIPAddrWithMask`, so that guard does not apply. Its only caller is `pkg/daemon/handler.go:262`, on the CNI ADD path, and the CIDR comes from the pod annotation `<provider>.kubernetes.io/cidr`.

The guard in front of it, `ValidatePodNetwork` (`handler.go:241`), only validates the fixed key `ovn.kubernetes.io/cidr` of the default provider (`CheckCidrs`, `validator.go:378`), while the handler reads a key built per provider. For an additional interface (multus / custom attachment) the annotation therefore reaches the parser unchecked. A panic there takes down kube-ovn-cni and breaks pod creation on the whole node.

Subnet-sourced callers are not affected: `formatCIDR` (`pkg/controller/subnet.go:243`) rejects and normalizes `Spec.CIDRBlock` before anything downstream sees it.

#### The fix

Extract `maskFromCIDR()` and use it in both branches, so a malformed value is reported through the `error` return the function already had. The helper also replaces the inline check in `GetIPAddrWithMaskForCNI`, keeping the two functions consistent. The dual stack branch additionally returns an explicit error when the CIDR does not split into two blocks, instead of silently returning an empty string.

### Tests

- `TestGetIPAddrWithMaskCIDRWithoutMask` — 7 cases (empty CIDR, bare IPv4/IPv6 as CIDR, trailing slash, dual stack missing either mask), each asserting no panic and an error return.
- `TestGetIPAddrWithMaskForCNICIDRWithoutMask` — covers the delegating single stack branch.
- Existing `TestGetIPAddrWithMask` / `TestGetIPAddrWithMaskForCNI` unchanged and passing.
- `go test ./pkg/util/` and `make lint` (0 issues) pass.