### PR TITLE
[release-1.16] fix(ovn-central): recover from invalid raft headers

### DIFF
--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -7,6 +7,7 @@ PROBE_INTERVAL=${PROBE_INTERVAL:-180000}
 OVN_NORTHD_N_THREADS=${OVN_NORTHD_N_THREADS:-1}
 OVN_NORTHD_PROBE_INTERVAL=${OVN_NORTHD_PROBE_INTERVAL:-5000}
 OVN_VERSION_COMPATIBILITY=${OVN_VERSION_COMPATIBILITY:-}
+readonly UUID_RE='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 DEBUG_OPT="--ovn-northd-wrapper=$DEBUG_WRAPPER --ovsdb-nb-wrapper=$DEBUG_WRAPPER --ovsdb-sb-wrapper=$DEBUG_WRAPPER"
 
 echo "PROBE_INTERVAL is set to $PROBE_INTERVAL"
@@ -138,7 +139,7 @@ function get_leader_addr {
     echo -n "${t}" | cut -f 1 -d " "
 }
 
-function ovndb_query_leader {
+function ovndb_query_database {
     local db=""
     local db_eval=""
     case $1 in
@@ -157,12 +158,69 @@ function ovndb_query_leader {
     esac
 
     eval port="\$${db_eval}_PORT"
-    query='["_Server",{"table":"Database","where":[["name","==","'$db'"]],"columns":["leader"],"op":"select"}]'
+    local query
+    case "$3" in
+    leader)
+        query='["_Server",{"table":"Database","where":[["name","==","'$db'"]],"columns":["leader"],"op":"select"}]'
+        ;;
+    cid)
+        query='["_Server",{"table":"Database","where":[["name","==","'$db'"]],"columns":["cid"],"op":"select"}]'
+        ;;
+    *)
+        echo "invalid database query field: $3"
+        return 2
+        ;;
+    esac
+
     if [[ "$ENABLE_SSL" == "false" ]]; then
-        timeout 10 ovsdb-client query $(gen_conn_addr $2 $port) "$query"
+        timeout 10 ovsdb-client query "$(gen_conn_addr "$2" "$port")" "$query"
     else
-        timeout 10 ovsdb-client $SSL_OPTIONS query $(gen_conn_addr $2 $port) "$query"
+        timeout 10 ovsdb-client $SSL_OPTIONS query "$(gen_conn_addr "$2" "$port")" "$query"
     fi
+}
+
+function ovndb_query_leader {
+    ovndb_query_database "$1" "$2" leader
+}
+
+function ovndb_query_cluster_id {
+    local result
+    result=$(ovndb_query_database "$1" "$2" cid) || return 1
+    grep -oEm1 "$UUID_RE" <<< "$result"
+}
+
+function is_valid_uuid {
+    local uuid="${1,,}"
+    [[ "$uuid" =~ ^${UUID_RE}$ ]] && \
+        [[ "$uuid" != "00000000-0000-0000-0000-000000000000" ]]
+}
+
+function get_live_cluster_id {
+    local db_type="$1"
+    local live_cid=""
+    local node_ip
+    for node_ip in ${NODE_IPS//,/ }; do
+        if [[ "$node_ip" == "$DB_CLUSTER_ADDR" ]]; then
+            continue
+        fi
+
+        local cid=""
+        cid=$(ovndb_query_cluster_id "$db_type" "$node_ip" 2>/dev/null || true)
+        if ! is_valid_uuid "$cid"; then
+            continue
+        fi
+        cid="${cid,,}"
+        if [[ -n "$live_cid" && "$live_cid" != "$cid" ]]; then
+            echo "conflicting live cluster IDs $live_cid and $cid for $db_type" >&2
+            return 2
+        fi
+        live_cid="$cid"
+    done
+
+    if [[ -z "$live_cid" ]]; then
+        return 1
+    fi
+    echo "$live_cid"
 }
 
 function quit {
@@ -199,6 +257,182 @@ if [[ -n "${NODE_IPS:-}" ]]; then
     normalize_raft_addrs
 fi
 
+function archive_recovery_file {
+    local source_file="$1"
+    local backup_base="$2"
+    local suffix="$3"
+    local description="$4"
+    if [[ ! -e "$source_file" ]]; then
+        return 0
+    fi
+
+    local backup_file="$backup_base.$suffix-$(date +%s)-$(random_str)"
+    echo "backup $description $source_file to $backup_file"
+    mv "$source_file" "$backup_file"
+}
+
+function rejoin_db_from_raft_header() {
+    local db_file="$1"
+    local hdr_file="$2"
+    local db_name="$3"
+    local db_type="$4"
+    local local_addr="$5"
+    shift 5
+    local remote_addr=("$@")
+
+    if [[ ${#remote_addr[@]} -eq 0 ]]; then
+        echo "cannot rejoin cluster from raft header file $hdr_file without a remote address"
+        archive_recovery_file "$hdr_file" "$hdr_file" invalid "unusable raft header file" || return 2
+        return 1
+    fi
+
+    local header_cid=""
+    local server_id=""
+    header_cid=$(sed -nE 's/.*"cluster_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$hdr_file" | head -n 1)
+    server_id=$(sed -nE 's/.*"server_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$hdr_file" | head -n 1)
+    header_cid="${header_cid,,}"
+    server_id="${server_id,,}"
+    if ! is_valid_uuid "$server_id"; then
+        echo "raft header file $hdr_file has a missing or zero server ID"
+        archive_recovery_file "$hdr_file" "$hdr_file" invalid "unusable raft header file" || return 2
+        return 1
+    fi
+
+    local live_cid=""
+    local lookup_status=0
+    local max_lookup_attempts=7
+    local attempt
+    for ((attempt = 1; attempt <= max_lookup_attempts; attempt++)); do
+        lookup_status=0
+        live_cid=$(get_live_cluster_id "$db_type") || lookup_status=$?
+        if [[ $lookup_status -ne 1 || $attempt -eq $max_lookup_attempts ]]; then
+            break
+        fi
+        echo "no reachable $db_type cluster found, retrying live cluster ID lookup ($attempt/$max_lookup_attempts)" >&2
+        sleep 10
+    done
+    if [[ $lookup_status -eq 2 ]]; then
+        return 2
+    fi
+
+    if is_valid_uuid "$header_cid" && { [[ $lookup_status -eq 1 ]] || [[ "$header_cid" == "$live_cid" ]]; }; then
+        echo "generating new db file $db_file from raft header file $hdr_file"
+        if ovsdb-tool rejoin-cluster "$db_file" "$hdr_file" "$local_addr" "${remote_addr[@]}"; then
+            return 0
+        fi
+        echo "failed to generate db file $db_file from raft header file $hdr_file"
+        archive_recovery_file "$db_file" "$db_file" failed-rejoin "database file left by failed rejoin" || return 2
+    else
+        echo "raft header cluster ID ${header_cid:-<missing>} does not match live cluster ID $live_cid"
+    fi
+
+    if [[ $lookup_status -eq 1 ]]; then
+        echo "no reachable $db_name cluster found; continue with clean bootstrap"
+        archive_recovery_file "$hdr_file" "$hdr_file" invalid "unusable raft header file" || return 2
+        return 1
+    fi
+
+    local db_rejoin="$db_file.rejoin-$(date +%s)-$(random_str)"
+    echo "rejoining $db_name cluster $live_cid with server ID $server_id"
+    if ! ovsdb-tool --cid "$live_cid" --sid "$server_id" join-cluster "$db_rejoin" "$db_name" "$local_addr" "${remote_addr[@]}"; then
+        echo "failed to rejoin $db_name cluster $live_cid with server ID $server_id"
+        archive_recovery_file "$db_rejoin" "$db_file" failed-rejoin "database file left by failed join" || return 2
+        return 2
+    fi
+
+    echo "use database file $db_rejoin"
+    mv "$db_rejoin" "$db_file" || return 2
+    archive_recovery_file "$hdr_file" "$hdr_file" invalid "unusable raft header file" || return 2
+    return 0
+}
+
+function recover_clustered_database {
+    local db_file="$1"
+    local hdr_file="$2"
+    local db_name="$3"
+    local db_type="$4"
+    local local_addr="$5"
+    shift 5
+    local remote_addr=("$@")
+
+    local message
+    message=$(ovsdb-tool check-cluster "$db_file" 2>&1) || true
+    if grep -q 'has not joined the cluster' <<< "$message"; then
+        local birth_time
+        birth_time=$(stat --format=%W "$db_file")
+        local now
+        now=$(date +%s)
+        if ((now - birth_time >= 120)); then
+            echo "ovn db file $db_file exists for more than 120s, archive it."
+            archive_recovery_file "$db_file" "$db_file" failed-join "database file" || return 1
+            archive_recovery_file "$hdr_file" "$hdr_file" invalid "stale raft header file" || return 1
+        fi
+        return 0
+    fi
+    if ovsdb-tool check-cluster "$db_file"; then
+        return 0
+    fi
+
+    local db_backup="$db_file.backup-$(date +%s)-$(random_str)"
+    echo "backup $db_file to $db_backup"
+    cp "$db_file" "$db_backup" || return 1
+    echo "detected database corruption for file $db_file, try to fix it."
+    if ovsdb-tool fix-cluster "$db_file" && ovsdb-tool check-cluster "$db_file"; then
+        return 0
+    fi
+
+    local server_id=""
+    server_id=$(ovsdb-tool db-sid "$db_file" || true)
+    if ! is_valid_uuid "$server_id"; then
+        echo "failed to get server ID from db file $db_file"
+        return 1
+    fi
+    local live_cid=""
+    live_cid=$(get_live_cluster_id "$db_type") || {
+        echo "failed to get live cluster ID for $db_name"
+        return 1
+    }
+
+    local db_new="$db_file.init-$(date +%s)-$(random_str)"
+    echo "rebuilding $db_name database with cluster ID $live_cid and server ID $server_id"
+    if ! ovsdb-tool --cid "$live_cid" --sid "$server_id" join-cluster "$db_new" "$db_name" "$local_addr" "${remote_addr[@]}"; then
+        archive_recovery_file "$db_new" "$db_file" failed-rejoin "database file left by failed join" || return 1
+        return 1
+    fi
+    mv "$db_new" "$db_file" || return 1
+    archive_recovery_file "$hdr_file" "$hdr_file" invalid "stale raft header file" || return 1
+}
+
+function create_local_config {
+    local db_type="$1"
+    local db_eval="$2"
+    local config_db="/etc/ovn/ovn${db_type}_local_config.db"
+    test -e "$config_db" && rm -f "$config_db"
+    ovsdb-tool create "$config_db" /usr/share/openvswitch/local-config.ovsschema
+    eval port="\$${db_eval}_PORT"
+
+    local index=0
+    local ip
+    for ip in ${DB_ADDRESSES//,/ }; do
+        local addr
+        addr="$(gen_listen_addr "$ip" "$port")"
+        if [[ $index -eq 0 ]]; then
+            ovsdb-tool transact "$config_db" '[
+                "Local_Config",
+                {"op": "insert", "table": "Config", "row": {"connections": ["named-uuid", "nameduuid"]}},
+                {"op": "insert", "table": "Connection", "uuid-name": "nameduuid", "row": {"target": "'$addr'"}}
+            ]'
+        else
+            ovsdb-tool transact "$config_db" '[
+                "Local_Config",
+                {"op": "insert", "table": "Connection", "uuid-name": "nameduuid", "row": {"target": "'$addr'"}},
+                {"op": "mutate", "table": "Config", "where": [], "mutations": [["connections", "insert", ["set", [["named-uuid", "nameduuid"]]]]]}
+            ]'
+        fi
+        index=$((index + 1))
+    done
+}
+
 # create a new db file and join it to the cluster
 # if the nb/sb db file is corrupted
 function ovn_db_pre_start() {
@@ -220,124 +454,45 @@ function ovn_db_pre_start() {
     esac
 
     eval port="\$${db_eval}_CLUSTER_PORT"
-    local local_addr="$(gen_conn_addr $DB_CLUSTER_ADDR $port)"
+    local local_addr
+    local_addr="$(gen_conn_addr "$DB_CLUSTER_ADDR" "$port")"
     echo "local address: $local_addr"
 
     local remote_addr=()
-    local node_ips=$(echo -n "${NODE_IPS}" | sed 's/,/ /g')
-    for node_ip in ${node_ips[*]}; do
-        if [ ! "$node_ip" = "$DB_CLUSTER_ADDR" ]; then
-            remote_addr=(${remote_addr[*]} "$(gen_conn_addr $node_ip $port)")
+    local node_ip
+    for node_ip in ${NODE_IPS//,/ }; do
+        if [[ "$node_ip" != "$DB_CLUSTER_ADDR" ]]; then
+            remote_addr+=("$(gen_conn_addr "$node_ip" "$port")")
         fi
     done
     echo "remote addresses: ${remote_addr[*]}"
 
     local db_file="/etc/ovn/ovn${1}_db.db"
     local hdr_file="/etc/ovn/ovn${1}_db.hdr"
-    if [ -e "$db_file" ]; then
-        # check whether db file is corrupted
-        db_name=$(ovsdb-tool db-name "$db_file" || true)
-        if [ "$db_name" != "$db" ]; then
-            # db file is corrupted and we cannot get the sid from it
-            # we have a chance to rebuild it from raft header
-            echo "ovn db file $db_file is corrupted, mv it away."
-            local db_bak="$db_file.backup-$(date +%s)-$(random_str)"
-            echo "backup $db_file to $db_bak"
-            mv "$db_file" "$db_bak" || return 1
-            if [ ${#remote_addr[*]} -ne 0 -a -e "$hdr_file" ]; then
-                # rebuild db file from raft header generated by the leader check process
-                echo "generating new db file $db_file from raft header file $hdr_file"
-                ovsdb-tool rejoin-cluster "$db_file" "$hdr_file" "$local_addr" ${remote_addr[*]}
-            fi
-            return
+    if [[ -e "$db_file" ]]; then
+        local actual_db_name=""
+        actual_db_name=$(ovsdb-tool db-name "$db_file" || true)
+        if [[ "$actual_db_name" != "$db" ]]; then
+            echo "ovn db file $db_file is corrupted, archive it."
+            archive_recovery_file "$db_file" "$db_file" backup "database file" || return 1
         fi
-
-        # check whether the db file is standalone or clustered
-        if ovsdb-tool db-is-clustered "$db_file"; then
-            # if the db file is clustered, check whether it has joined the cluster
-            local msg=$(ovsdb-tool check-cluster "$db_file" 2>&1) || true
-            if echo $msg | grep -q 'has not joined the cluster'; then
-                local birth_time=$(stat --format=%W $db_file)
-                local now=$(date +%s)
-                if [ $(($now - $birth_time)) -ge 120 ]; then
-                    echo "ovn db file $db_file exists for more than 120s, remove it."
-                    rm -f "$db_file" || return 1
-                fi
-                return
-            fi
-
-            if ! ovsdb-tool check-cluster "$db_file"; then
-                # clustered db file is corrupted
-                local db_bak="$db_file.backup-$(date +%s)-$(random_str)"
-                echo "backup $db_file to $db_bak"
-                cp "$db_file" "$db_bak" || return 1
-
-                echo "detected database corruption for file $db_file, try to fix it."
-                local fixed=0
-                if ovsdb-tool fix-cluster "$db_file"; then
-                    echo "checking whether database file $db_file has been fixed."
-                    if ovsdb-tool check-cluster "$db_file"; then
-                        fixed=1
-                    fi
-                fi
-                if [ $fixed -ne 1 -a ${#remote_addr[*]} -ne 0 ]; then
-                    echo "failed to fix database file $db_file, rebuild it."
-                    local db_new="$db_file.init-$(date +%s)-$(random_str)"
-                    if [ -e "$hdr_file" ]; then
-                        echo "generating new db file $db_new from raft header file $hdr_file"
-                        if ovsdb-tool rejoin-cluster "$db_new" "$hdr_file" "$local_addr" ${remote_addr[*]}; then
-                            echo "use new database file $db_new"
-                            mv "$db_new" "$db_file"
-                            return
-                        fi
-                    fi
-
-                    # no raft header file, try to reuse the sid from the corrupted db file
-                    local sid=$(ovsdb-tool db-sid "$db_file")
-                    if ! echo -n "$sid" | grep -qE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
-                        echo "failed to get sid from db file $db_file"
-                        return 1
-                    fi
-                    echo "generating new database file $db_new with sid $sid"
-                    ovsdb-tool --sid $sid join-cluster "$db_new" $db $local_addr ${remote_addr[*]} || return 1
-                    echo "use new database file $db_new"
-                    mv "$db_new" "$db_file"
-                fi
-            fi
-        fi
-    elif [ -e "$hdr_file" ]; then
-        echo "db file $db_file is missing, while raft header file $hdr_file exists."
-        if [ ${#remote_addr[*]} -ne 0 -a -e "$hdr_file" ]; then
-            # rebuild db file from raft header generated by the leader check process
-            echo "generating new db file $db_file from raft header file $hdr_file"
-            ovsdb-tool rejoin-cluster "$db_file" "$hdr_file" "$local_addr" ${remote_addr[*]}
-        fi
-        return
     fi
 
-    # create local config
-    local config_db="/etc/ovn/ovn${1}_local_config.db"
-    test -e $config_db && rm -f $config_db
-    ovsdb-tool create $config_db /usr/share/openvswitch/local-config.ovsschema
-    eval port="\$${db_eval}_PORT"
-    local i=0
-    for ip in ${DB_ADDRESSES//,/ }; do
-        addr="$(gen_listen_addr $ip $port)"
-        if [ $i -eq 0 ]; then
-            ovsdb-tool transact $config_db '[
-                "Local_Config",
-                {"op": "insert", "table": "Config", "row": {"connections": ["named-uuid", "nameduuid"]}},
-                {"op": "insert", "table": "Connection", "uuid-name": "nameduuid", "row": {"target": "'$addr'"}}
-            ]'
-        else
-            ovsdb-tool transact $config_db '[
-                "Local_Config",
-                {"op": "insert", "table": "Connection", "uuid-name": "nameduuid", "row": {"target": "'$addr'"}},
-                {"op": "mutate", "table": "Config", "where": [], "mutations": [["connections", "insert", ["set", [["named-uuid", "nameduuid"]]]]]}
-            ]'
+    if [[ ! -e "$db_file" && -e "$hdr_file" ]]; then
+        echo "db file $db_file is missing, while raft header file $hdr_file exists."
+        local rejoin_status=0
+        rejoin_db_from_raft_header "$db_file" "$hdr_file" "$db" "$1" "$local_addr" "${remote_addr[@]}" || rejoin_status=$?
+        if [[ $rejoin_status -eq 0 ]]; then
+            return 0
+        elif [[ $rejoin_status -ne 1 ]]; then
+            return 1
         fi
-        i=$((i+1))
-    done
+    fi
+
+    if [[ -e "$db_file" ]] && ovsdb-tool db-is-clustered "$db_file"; then
+        recover_clustered_database "$db_file" "$hdr_file" "$db" "$1" "$local_addr" "${remote_addr[@]}" || return 1
+    fi
+    create_local_config "$1" "$db_eval"
 }
 
 trap quit EXIT

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -370,7 +371,12 @@ func compactOvnDatabase(db string) {
 //	  "cluster_id": "6d240b86-177e-4f17-aded-ed1b7b364d97"
 //	}
 func backupRaftHeader(db string) {
-	args := []string{"db-raft-header", fmt.Sprintf("/etc/ovn/ovn%s_db.db", db)}
+	backupRaftHeaderAt(db, "/etc/ovn")
+}
+
+func backupRaftHeaderAt(db, dbDir string) {
+	dbFile := filepath.Join(dbDir, fmt.Sprintf("ovn%s_db.db", db))
+	args := []string{"db-raft-header", dbFile}
 	hdr, err := exec.Command("ovsdb-tool", args...).CombinedOutput() // #nosec G204
 	if err != nil {
 		klog.Errorf("failed to backup raft header of ovn%s database: error = %v, output = %s", db, err, string(hdr))
@@ -383,8 +389,22 @@ func backupRaftHeader(db string) {
 		return
 	}
 
-	hdr, _ = json.MarshalIndent(data, "", "  ")
-	hdrFile := fmt.Sprintf("/etc/ovn/ovn%s_db.hdr", db)
+	dbCID, err := exec.Command("ovsdb-tool", "db-cid", dbFile).CombinedOutput() // #nosec G204
+	if err != nil {
+		klog.Errorf("failed to get cluster ID of ovn%s database: error = %v, output = %s", db, err, string(dbCID))
+		return
+	}
+	if err := validateRaftHeader(data, strings.TrimSpace(string(dbCID))); err != nil {
+		klog.Errorf("refusing to backup invalid raft header of ovn%s database: %v", db, err)
+		return
+	}
+
+	hdr, err = json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		klog.Errorf("failed to marshal raft header json content for ovn%s database: %v", db, err)
+		return
+	}
+	hdrFile := filepath.Join(dbDir, fmt.Sprintf("ovn%s_db.hdr", db))
 	content, err := os.ReadFile(hdrFile)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -401,12 +421,33 @@ func backupRaftHeader(db string) {
 	klog.Infof("Found changes in raft header for ovn%s database, updating file %s", db, hdrFile)
 	klog.Infof("Previous content of raft header file %s:\n%s", hdrFile, string(content))
 
-	if err = os.WriteFile(hdrFile, hdr, 0o600); err != nil {
+	if err = util.AtomicWriteFile(hdrFile, hdr, 0o600); err != nil {
 		klog.Errorf("failed to write raft header file %s: %v", hdrFile, err)
 		return
 	}
 
 	klog.Infof("succeeded to backup raft header of ovn%s database to file %s with content:\n%s", db, hdrFile, string(hdr))
+}
+
+func validateRaftHeader(data map[string]any, dbCID string) error {
+	const zeroUUID = "00000000-0000-0000-0000-000000000000"
+
+	clusterID, ok := data["cluster_id"].(string)
+	if !ok || clusterID == "" || clusterID == zeroUUID {
+		return errors.New("missing or zero cluster ID")
+	}
+	if dbCID == "" || dbCID == zeroUUID {
+		return errors.New("database has missing or zero cluster ID")
+	}
+	if clusterID != dbCID {
+		return fmt.Errorf("header cluster ID %s does not match database cluster ID %s", clusterID, dbCID)
+	}
+
+	serverID, ok := data["server_id"].(string)
+	if !ok || serverID == "" || serverID == zeroUUID {
+		return errors.New("missing or zero server ID")
+	}
+	return nil
 }
 
 func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {

--- a/pkg/ovn_leader_checker/ovn_test.go
+++ b/pkg/ovn_leader_checker/ovn_test.go
@@ -1,0 +1,509 @@
+package ovn_leader_checker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	validClusterID = "6d240b86-177e-4f17-aded-ed1b7b364d97"
+	validServerID  = "8d77699d-8dc6-4f32-b1ba-b66aad05ba46"
+	zeroClusterID  = "00000000-0000-0000-0000-000000000000"
+	otherClusterID = "d401ddf6-deac-4e26-aeb5-cc4ce07f6515"
+)
+
+func TestBackupRaftHeaderDoesNotReplaceValidHeaderWithZeroClusterID(t *testing.T) {
+	dbDir := t.TempDir()
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	validHeader := raftHeaderJSON(validClusterID, validServerID)
+	if err := os.WriteFile(hdrFile, []byte(validHeader), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	installFakeOvsdbTool(t)
+	t.Setenv("FAKE_RAFT_HEADER", raftHeaderJSON(zeroClusterID, validServerID))
+	t.Setenv("FAKE_DB_CID", validClusterID)
+
+	backupRaftHeaderAt("nb", dbDir)
+
+	got, err := os.ReadFile(hdrFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != validHeader {
+		t.Fatalf("valid raft header was replaced by an invalid header:\n%s", got)
+	}
+}
+
+func TestBackupRaftHeaderDoesNotReplaceHeaderWhenClusterIDDoesNotMatchDatabase(t *testing.T) {
+	dbDir := t.TempDir()
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	validHeader := raftHeaderJSON(validClusterID, validServerID)
+	if err := os.WriteFile(hdrFile, []byte(validHeader), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	installFakeOvsdbTool(t)
+	t.Setenv("FAKE_RAFT_HEADER", raftHeaderJSON(otherClusterID, validServerID))
+	t.Setenv("FAKE_DB_CID", validClusterID)
+
+	backupRaftHeaderAt("nb", dbDir)
+
+	got, err := os.ReadFile(hdrFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != validHeader {
+		t.Fatalf("valid raft header was replaced by a header from another cluster:\n%s", got)
+	}
+}
+
+func TestBackupRaftHeaderWritesHeaderMatchingDatabaseClusterID(t *testing.T) {
+	dbDir := t.TempDir()
+	expected := raftHeaderJSON(validClusterID, validServerID)
+
+	installFakeOvsdbTool(t)
+	t.Setenv("FAKE_RAFT_HEADER", expected)
+	t.Setenv("FAKE_DB_CID", validClusterID)
+
+	backupRaftHeaderAt("nb", dbDir)
+
+	got, err := os.ReadFile(filepath.Join(dbDir, "ovnnb_db.hdr"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != expected {
+		t.Fatalf("unexpected raft header content:\n%s", got)
+	}
+}
+
+func TestOvnDBPreStartRejoinsLiveClusterWithHeaderServerID(t *testing.T) {
+	for name, headerCID := range map[string]string{
+		"zero cluster ID":       zeroClusterID,
+		"mismatched cluster ID": otherClusterID,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dbDir := t.TempDir()
+			hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+			if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(headerCID, validServerID)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			runOvnDBPreStartHarness(t, dbDir, validClusterID, `
+        rejoin-cluster) return 99 ;;
+        --cid)
+            test "$2" = "$TEST_LIVE_CID"
+            test "$3" = --sid
+            test "$4" = "`+validServerID+`"
+            test "$5" = join-cluster
+            test "$7" = OVN_Northbound
+            test "$8" = tcp:10.0.0.1:6643
+            test "$9" = tcp:10.0.0.2:6643
+            printf 'joined-with-live-cluster-id' > "$6"
+            ;;
+`, `
+grep -q 'joined-with-live-cluster-id' "$TEST_DB_FILE"
+test ! -e "$TEST_HDR_FILE"
+test ! -e "$TEST_CONFIG_FILE"
+compgen -G "$TEST_HDR_FILE.invalid-*" >/dev/null
+! compgen -G "$TEST_DB_FILE.failed-rejoin-*" >/dev/null
+`)
+		})
+	}
+}
+
+func TestOvnDBPreStartRetriesTransientLiveClusterIDLookup(t *testing.T) {
+	for name, headerCID := range map[string]string{
+		"zero cluster ID":  zeroClusterID,
+		"stale cluster ID": otherClusterID,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dbDir := t.TempDir()
+			hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+			if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(headerCID, validServerID)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			enableLookupAttemptCounter(t, dbDir)
+			t.Setenv("TEST_LOOKUP_FAILURES", "6")
+
+			runOvnDBPreStartHarness(t, dbDir, validClusterID, `
+        --cid)
+            test "$2" = "$TEST_LIVE_CID"
+            test "$3" = --sid
+            test "$4" = "`+validServerID+`"
+            printf 'joined-after-transient-lookup-failures' > "$6"
+            ;;
+`, `
+grep -q 'joined-after-transient-lookup-failures' "$TEST_DB_FILE"
+test "$(cat "$TEST_LOOKUP_COUNTER")" -eq 7
+test ! -e "$TEST_HDR_FILE"
+test ! -e "$TEST_CONFIG_FILE"
+`)
+		})
+	}
+}
+
+func TestOvnDBPreStartUsesMatchingRaftHeader(t *testing.T) {
+	dbDir := t.TempDir()
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(validClusterID, validServerID)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runOvnDBPreStartHarness(t, dbDir, validClusterID, `
+        rejoin-cluster) printf 'rejoined-from-header' > "$2" ;;
+        --cid) return 99 ;;
+`, `
+grep -q 'rejoined-from-header' "$TEST_DB_FILE"
+test -e "$TEST_HDR_FILE"
+test ! -e "$TEST_CONFIG_FILE"
+	`)
+}
+
+func TestOvnDBPreStartUsesValidRaftHeaderWithoutReachablePeer(t *testing.T) {
+	dbDir := t.TempDir()
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(validClusterID, validServerID)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runOvnDBPreStartHarness(t, dbDir, "", `
+        rejoin-cluster) printf 'rejoined-without-reachable-peer' > "$2" ;;
+        --cid) return 99 ;;
+`, `
+grep -q 'rejoined-without-reachable-peer' "$TEST_DB_FILE"
+test -e "$TEST_HDR_FILE"
+test ! -e "$TEST_CONFIG_FILE"
+`)
+}
+
+func TestOvnDBPreStartFallsBackWhenMatchingRaftHeaderCannotRejoin(t *testing.T) {
+	dbDir := t.TempDir()
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(validClusterID, validServerID)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runOvnDBPreStartHarness(t, dbDir, validClusterID, `
+        rejoin-cluster) printf 'partial-rejoin' > "$2"; return 1 ;;
+        --cid)
+            test "$2" = "$TEST_LIVE_CID"
+            test "$3" = --sid
+            test "$4" = "`+validServerID+`"
+            printf 'joined-after-rejoin-failure' > "$6"
+            ;;
+`, `
+grep -q 'joined-after-rejoin-failure' "$TEST_DB_FILE"
+test ! -e "$TEST_HDR_FILE"
+test ! -e "$TEST_CONFIG_FILE"
+compgen -G "$TEST_DB_FILE.failed-rejoin-*" >/dev/null
+compgen -G "$TEST_HDR_FILE.invalid-*" >/dev/null
+`)
+}
+
+func TestOvnDBPreStartFallsBackToCleanBootstrapWithoutLiveCluster(t *testing.T) {
+	dbDir := t.TempDir()
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(zeroClusterID, validServerID)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	enableLookupAttemptCounter(t, dbDir)
+
+	runOvnDBPreStartHarness(t, dbDir, "", `
+        rejoin-cluster|--cid) return 99 ;;
+`, `
+test ! -e "$TEST_DB_FILE"
+test ! -e "$TEST_HDR_FILE"
+test -e "$TEST_CONFIG_FILE"
+test "$(cat "$TEST_LOOKUP_COUNTER")" -eq 7
+compgen -G "$TEST_HDR_FILE.invalid-*" >/dev/null
+`)
+}
+
+func TestOvnDBPreStartDoesNotRetryConflictingLiveClusterIDs(t *testing.T) {
+	dbDir := t.TempDir()
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(zeroClusterID, validServerID)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	enableLookupAttemptCounter(t, dbDir)
+	t.Setenv("TEST_LOOKUP_STATUS", "2")
+	t.Setenv("TEST_EXPECTED_PRE_START_STATUS", "1")
+
+	runOvnDBPreStartHarness(t, dbDir, "", `
+        --cid) return 99 ;;
+`, `
+test "$(cat "$TEST_LOOKUP_COUNTER")" -eq 1
+test -e "$TEST_HDR_FILE"
+test ! -e "$TEST_CONFIG_FILE"
+`)
+}
+
+func TestOvnDBPreStartRecoversWrongDatabaseWithLiveCluster(t *testing.T) {
+	dbDir := t.TempDir()
+	dbFile := filepath.Join(dbDir, "ovnnb_db.db")
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	if err := os.WriteFile(dbFile, []byte("wrong-database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(zeroClusterID, validServerID)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runOvnDBPreStartHarness(t, dbDir, validClusterID, `
+        db-name) echo Wrong_Database ;;
+        --cid) printf 'recovered-wrong-database' > "$6" ;;
+`, `
+grep -q 'recovered-wrong-database' "$TEST_DB_FILE"
+test ! -e "$TEST_HDR_FILE"
+test ! -e "$TEST_CONFIG_FILE"
+compgen -G "$TEST_DB_FILE.backup-*" >/dev/null
+compgen -G "$TEST_HDR_FILE.invalid-*" >/dev/null
+`)
+}
+
+func TestOvnDBPreStartRebuildsCorruptClusterWithLiveIDs(t *testing.T) {
+	dbDir := t.TempDir()
+	dbFile := filepath.Join(dbDir, "ovnnb_db.db")
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	if err := os.WriteFile(dbFile, []byte("corrupt-cluster"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hdrFile, []byte(raftHeaderJSON(otherClusterID, validServerID)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runOvnDBPreStartHarness(t, dbDir, validClusterID, `
+        db-name) echo OVN_Northbound ;;
+        db-is-clustered) return 0 ;;
+        check-cluster) return 1 ;;
+        fix-cluster) return 1 ;;
+        db-sid) echo "`+validServerID+`" ;;
+        --cid)
+            test "$2" = "$TEST_LIVE_CID"
+            test "$4" = "`+validServerID+`"
+            printf 'rebuilt-corrupt-cluster' > "$6"
+            ;;
+`, `
+grep -q 'rebuilt-corrupt-cluster' "$TEST_DB_FILE"
+test ! -e "$TEST_HDR_FILE"
+test -e "$TEST_CONFIG_FILE"
+compgen -G "$TEST_DB_FILE.backup-*" >/dev/null
+compgen -G "$TEST_HDR_FILE.invalid-*" >/dev/null
+	`)
+}
+
+func TestGetLiveClusterIDReadsPeerCIDWithoutLeader(t *testing.T) {
+	binDir := t.TempDir()
+	client := filepath.Join(binDir, "ovsdb-client")
+	script := `#!/usr/bin/env bash
+test "$1" = query
+! grep -q '"leader","==",true' <<< "$3"
+grep -q '"columns":\["cid"\]' <<< "$3"
+case "$2" in
+    *10.0.0.2*) printf '%s' '[{"rows":[{"cid":["set",[["uuid","` + validClusterID + `"]]]}]}]' ;;
+    *10.0.0.3*) printf '%s' '[{"rows":[{"cid":["set",[["uuid","` + otherClusterID + `"]]]}]}]' ;;
+    *) printf '%s' '[{"rows":[]}]' ;;
+esac
+`
+	if err := os.WriteFile(client, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	functions := loadStartDBShell(t, "", "ovndb_query_database", "ovndb_query_cluster_id", "is_valid_uuid", "get_live_cluster_id")
+
+	harness := fmt.Sprintf(`set -eu
+PATH=%q:"$PATH"
+DB_CLUSTER_ADDR=10.0.0.1
+NODE_IPS=10.0.0.1,10.0.0.2
+NB_PORT=6641
+ENABLE_SSL=false
+gen_conn_addr() { echo "tcp:$1:$2"; }
+jq() { return 99; }
+%s
+test "$(get_live_cluster_id nb)" = %q
+NODE_IPS=10.0.0.1,10.0.0.2,10.0.0.3
+status=0
+get_live_cluster_id nb >/dev/null || status=$?
+test "$status" -eq 2
+`, binDir, functions, validClusterID)
+	cmd := exec.Command("bash", "-c", harness)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("get_live_cluster_id did not read the leader CID: %v\n%s", err, output)
+	}
+}
+
+func installFakeOvsdbTool(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	tool := filepath.Join(binDir, "ovsdb-tool")
+	script := `#!/usr/bin/env bash
+case "$1" in
+    db-raft-header) printf '%s' "$FAKE_RAFT_HEADER" ;;
+    db-cid) printf '%s\n' "$FAKE_DB_CID" ;;
+    *) exit 1 ;;
+esac
+`
+	if err := os.WriteFile(tool, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func raftHeaderJSON(clusterID, serverID string) string {
+	return fmt.Sprintf(`{
+  "cluster_id": %q,
+  "local_address": "tcp:[10.0.0.1]:6643",
+  "name": "OVN_Northbound",
+  "server_id": %q
+}`, clusterID, serverID)
+}
+
+func enableLookupAttemptCounter(t *testing.T, dbDir string) {
+	t.Helper()
+	counterFile := filepath.Join(dbDir, "lookup-attempts")
+	if err := os.WriteFile(counterFile, []byte("0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TEST_LOOKUP_COUNTER", counterFile)
+}
+
+func runOvnDBPreStartHarness(t *testing.T, dbDir, liveClusterID, ovsdbToolCases, assertions string) {
+	t.Helper()
+	functions := loadStartDBFunctions(t, dbDir)
+	dbFile := filepath.Join(dbDir, "ovnnb_db.db")
+	hdrFile := filepath.Join(dbDir, "ovnnb_db.hdr")
+	configFile := filepath.Join(dbDir, "ovnnb_local_config.db")
+
+	harness := fmt.Sprintf(`set -eu
+DB_CLUSTER_ADDR=10.0.0.1
+NODE_IPS=10.0.0.1,10.0.0.2
+NB_CLUSTER_PORT=6643
+NB_PORT=6641
+DB_ADDRESSES=::
+ENABLE_SSL=false
+TEST_LIVE_CID=%q
+TEST_DB_FILE=%q
+TEST_HDR_FILE=%q
+TEST_CONFIG_FILE=%q
+gen_conn_addr() { echo "tcp:$1:$2"; }
+gen_listen_addr() { echo "ptcp:$2:[$1]"; }
+random_str() { echo abc123; }
+jq() { return 99; }
+sleep() { :; }
+get_live_cluster_id() {
+    local count=1
+    if [ -n "${TEST_LOOKUP_COUNTER:-}" ]; then
+        count=$(cat "$TEST_LOOKUP_COUNTER")
+        count=$((count + 1))
+        echo "$count" > "$TEST_LOOKUP_COUNTER"
+    fi
+    local failures="${TEST_LOOKUP_FAILURES:-0}"
+    if ((count <= failures)); then
+        return 1
+    fi
+    if [ -n "${TEST_LOOKUP_STATUS:-}" ]; then
+        return "$TEST_LOOKUP_STATUS"
+    fi
+    if [ -z "$TEST_LIVE_CID" ]; then
+        return 1
+    fi
+    echo "$TEST_LIVE_CID"
+}
+ovsdb-tool() {
+    case "$1" in
+%s
+        create) : > "$2" ;;
+        transact) return 0 ;;
+        db-is-clustered) return 1 ;;
+        *) return 1 ;;
+    esac
+}
+%s
+status=0
+ovn_db_pre_start nb || status=$?
+test "$status" -eq "${TEST_EXPECTED_PRE_START_STATUS:-0}"
+%s
+`, liveClusterID, dbFile, hdrFile, configFile, ovsdbToolCases, functions, assertions)
+
+	cmd := exec.Command("bash", "-c", harness)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ovn_db_pre_start harness failed: %v\n%s", err, output)
+	}
+}
+
+func loadStartDBFunctions(t *testing.T, dbDir string) string {
+	t.Helper()
+	return loadStartDBShell(t, dbDir,
+		"is_valid_uuid",
+		"archive_recovery_file",
+		"rejoin_db_from_raft_header",
+		"recover_clustered_database",
+		"create_local_config",
+		"ovn_db_pre_start",
+	)
+}
+
+func loadStartDBShell(t *testing.T, dbDir string, functionNames ...string) string {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	startDBPath := filepath.Join(repoRoot, "dist", "images", "start-db.sh")
+	content, err := os.ReadFile(startDBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var functions strings.Builder
+	readonly, err := extractShellReadonly(string(content), "UUID_RE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	functions.WriteString(readonly)
+	functions.WriteByte('\n')
+	for _, name := range functionNames {
+		function, err := extractShellFunction(string(content), name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		functions.WriteString(function)
+		functions.WriteByte('\n')
+	}
+	if dbDir == "" {
+		return functions.String()
+	}
+	return strings.ReplaceAll(functions.String(), "/etc/ovn", dbDir)
+}
+
+func extractShellReadonly(script, name string) (string, error) {
+	prefix := "readonly " + name + "="
+	for line := range strings.SplitSeq(script, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return line, nil
+		}
+	}
+	return "", fmt.Errorf("readonly variable %s not found", name)
+}
+
+func extractShellFunction(script, name string) (string, error) {
+	start := -1
+	for _, marker := range []string{"function " + name + "() {", "function " + name + " {"} {
+		start = strings.Index(script, marker)
+		if start != -1 {
+			break
+		}
+	}
+	if start == -1 {
+		return "", fmt.Errorf("function %s not found", name)
+	}
+
+	end := strings.Index(script[start:], "\n}\n")
+	if end == -1 {
+		return "", fmt.Errorf("end of function %s not found", name)
+	}
+	end += start + len("\n}")
+	return script[start:end], nil
+}

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteFile writes data to a temporary file in the target directory,
+// fsyncs it, then renames it to path. Concurrent readers never observe a
+// partially written file, and a crash mid-write cannot leave a truncated
+// file at the final path.
+func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if err = tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err = tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmpName, path); err != nil {
+		return err
+	}
+
+	// fsync the parent directory so the rename itself survives a power loss;
+	// otherwise the journal may replay the rename before the data blocks are
+	// on disk, leaving a zero-length file.
+	d, err := os.Open(dir) // #nosec G304
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -33,7 +33,7 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	if err = tmp.Close(); err != nil {
 		return err
 	}
-	if err = os.Rename(tmpName, path); err != nil {
+	if err = os.Rename(tmpName, path); err != nil { // #nosec G703 -- writing to the caller-selected destination is the purpose of this helper.
 		return err
 	}
 

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -1,0 +1,80 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicWriteFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		perm     os.FileMode
+		existing string
+		data     string
+	}{
+		{
+			name: "create new file",
+			perm: 0o600,
+			data: "hello",
+		},
+		{
+			name:     "overwrite existing file",
+			perm:     0o600,
+			existing: "old content longer than the new one",
+			data:     "new",
+		},
+		{
+			name: "custom permission",
+			perm: 0o644,
+			data: "perm test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "target.conf")
+			if tt.existing != "" {
+				if err := os.WriteFile(path, []byte(tt.existing), 0o600); err != nil {
+					t.Fatalf("failed to prepare existing file: %v", err)
+				}
+			}
+
+			if err := AtomicWriteFile(path, []byte(tt.data), tt.perm); err != nil {
+				t.Fatalf("AtomicWriteFile: %v", err)
+			}
+
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read result: %v", err)
+			}
+			if string(got) != tt.data {
+				t.Errorf("content = %q, want %q", string(got), tt.data)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("failed to stat result: %v", err)
+			}
+			if info.Mode().Perm() != tt.perm {
+				t.Errorf("perm = %o, want %o", info.Mode().Perm(), tt.perm)
+			}
+
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("failed to read dir: %v", err)
+			}
+			if len(entries) != 1 {
+				t.Errorf("expected only the target file in dir, got %d entries", len(entries))
+			}
+		})
+	}
+
+	t.Run("missing directory", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "no-such-dir", "target.conf")
+		if err := AtomicWriteFile(path, []byte("x"), 0o600); err == nil {
+			t.Error("expected error when the target directory does not exist")
+		}
+	})
+}


### PR DESCRIPTION
## What type of this PR

- [x] Bug fixes
- [x] Tests

## What this PR does

This backports #7112 to `release-1.16` from squash commit `bdec52c1e85d1cee4b9a891c5d74fafe7f36a8c0`.

- Rejects zero, missing, or mismatched RAFT header cluster IDs and zero server IDs.
- Discovers and validates the live cluster ID for up to 60 seconds before recovery fallback.
- Preserves the original server ID when rebuilding a member, avoiding a stale fourth RAFT member.
- Archives failed recovery artifacts and only uses clean bootstrap when no valid recovery path remains.
- Writes RAFT header snapshots atomically.
- Adds deterministic leader-checker recovery regression tests.
- Adds the existing `AtomicWriteFile` helper from #7035 because this maintenance branch predates that helper; unrelated CNI changes from #7035 are not included.

The master-only `test/e2e/ha` package does not exist on this maintenance branch, so the HA E2E part of #7112 is intentionally excluded instead of introducing a new E2E suite during a backport.

## Verification

- `bash -n dist/images/start-db.sh`
- `GOMEMLIMIT=2GiB GOMAXPROCS=2 go test ./pkg/ovn_leader_checker ./pkg/util -count=20`
- `GOMEMLIMIT=2GiB GOMAXPROCS=2 go test -race ./pkg/ovn_leader_checker ./pkg/util -count=1`
- `GOMEMLIMIT=2GiB GOMAXPROCS=2 go vet ./pkg/ovn_leader_checker ./pkg/util`
- targeted `golangci-lint` for `pkg/ovn_leader_checker` and `pkg/util`
- `git diff --check origin/release-1.16...HEAD`

This branch does not provide the repository `tools/modernize` tool, so the equivalent targeted `modernize` command is unavailable here; the existing branch lint workflow remains the authoritative full lint check.

## Related issue

- Backport of #7112
- #7110
