### PR TITLE
fix(gateway): prevent probe disconnects from restarting bfdd

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -176,11 +176,13 @@ RUN mkdir -p /usr/src/openbfdd && \
 
 ADD OpenBFDD-compile.patch /usr/src/
 ADD OpenBFDD-allow-ttl-254.patch /usr/src/
+ADD OpenBFDD-control-no-sigpipe.patch /usr/src/
 
 RUN cd /usr/src/openbfdd && \
     rm -vf missing && \
-    git apply --no-apply /usr/src/OpenBFDD-compile.patch && \
+    git apply /usr/src/OpenBFDD-compile.patch && \
     git apply --no-apply /usr/src/OpenBFDD-allow-ttl-254.patch && \
+    git apply /usr/src/OpenBFDD-control-no-sigpipe.patch && \
     autoupdate && \
     ./autogen.sh && \
     ./configure --enable-silent-rules && \

--- a/dist/images/OpenBFDD-control-no-sigpipe.patch
+++ b/dist/images/OpenBFDD-control-no-sigpipe.patch
@@ -1,0 +1,43 @@
+From 9b195569201a77a23d7a80491d672ab64e08bf68 Mon Sep 17 00:00:00 2001
+From: zhangzujian <zhangzujian.7@gmail.com>
+Date: Thu, 6 Aug 2026 11:00:00 +0800
+Subject: [PATCH] Avoid SIGPIPE when a control client disconnects
+
+Control clients may disconnect while the beacon is preparing or sending a
+multi-line reply. Prevent that connection-local failure from terminating the
+daemon, and stop sending the remainder of the reply after the first failure.
+
+Signed-off-by: zhangzujian <zhangzujian.7@gmail.com>
+---
+ CommandProcessor.cpp | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/CommandProcessor.cpp b/CommandProcessor.cpp
+index f6f9191..2d61561 100755
+--- a/CommandProcessor.cpp
++++ b/CommandProcessor.cpp
+@@ -27,3 +27,4 @@ protected:
+   Socket m_listenSocket;
+   Socket m_replySocket;
++  bool m_replyFailed;
+   RecvMsg m_inCommand;
+@@ -50,3 +51,4 @@ public:
+      m_listenSocket(),
+      m_replySocket(),
++     m_replyFailed(false),
+      m_inCommand(MaxCommandSize, 0),
+@@ -327,2 +329,3 @@ protected:
+     m_replySocket = connectedSocket; // note connectedSocket still 'owns' the socket.
++    m_replyFailed = false;
+     m_replySocket.SetLogName(connectedSocket.LogName());
+@@ -2053,5 +2056,8 @@ protected:
+   void doMessageReply(const char *reply, size_t length)
+   {
+-    // TODO timeout? Check for shutdown?
+-    m_replySocket.Send(reply, length);
++    if (m_replyFailed)
++      return;
++
++    if (!m_replySocket.Send(reply, length, MSG_NOSIGNAL))
++      m_replyFailed = true;
+   }

--- a/pkg/controller/vpc_gateway_common.go
+++ b/pkg/controller/vpc_gateway_common.go
@@ -107,6 +107,7 @@ func genGatewayBFDDContainer(image, bfdIP string, minTX, minRX, multiplier int32
 			},
 			InitialDelaySeconds: 3,
 			PeriodSeconds:       3,
+			TimeoutSeconds:      10,
 			FailureThreshold:    1,
 		},
 		Resources: corev1.ResourceRequirements{

--- a/pkg/controller/vpc_gateway_common_test.go
+++ b/pkg/controller/vpc_gateway_common_test.go
@@ -61,6 +61,7 @@ func TestGenGatewayBFDDContainer(t *testing.T) {
 	assert.Equal(t, []string{"bfdd-control", "status"}, container.ReadinessProbe.Exec.Command)
 	assert.Equal(t, int32(3), container.ReadinessProbe.InitialDelaySeconds)
 	assert.Equal(t, int32(3), container.ReadinessProbe.PeriodSeconds)
+	assert.Equal(t, int32(10), container.ReadinessProbe.TimeoutSeconds, "readiness probe must allow bfdd-control enough time to respond")
 	assert.Equal(t, int32(1), container.ReadinessProbe.FailureThreshold)
 
 	assert.Equal(t, gwBFDDResourceCPU, container.Resources.Requests[corev1.ResourceCPU])
@@ -69,6 +70,35 @@ func TestGenGatewayBFDDContainer(t *testing.T) {
 
 	assert.False(t, *container.SecurityContext.Privileged)
 	assert.Equal(t, int64(65534), *container.SecurityContext.RunAsUser)
+}
+
+func TestOpenBFDDControlReplyPatch(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current filename")
+	}
+	imagesDir := filepath.Join(filepath.Dir(filename), "..", "..", "dist", "images")
+
+	startScript, err := os.ReadFile(filepath.Join(imagesDir, "start-bfdd.sh"))
+	if assert.NoError(t, err) {
+		assert.NotContains(t, string(startScript), "trap '' PIPE", "SIGPIPE handling must be limited to OpenBFDD control replies")
+	}
+
+	patchName := "OpenBFDD-control-no-sigpipe.patch"
+	patchContent, err := os.ReadFile(filepath.Join(imagesDir, patchName))
+	if assert.NoError(t, err) {
+		assert.Contains(t, string(patchContent), "m_replySocket.Send(reply, length, MSG_NOSIGNAL)")
+		assert.Contains(t, string(patchContent), "m_replyFailed")
+	}
+
+	dockerfile, err := os.ReadFile(filepath.Join(imagesDir, "Dockerfile.base"))
+	if assert.NoError(t, err) {
+		assert.Contains(t, string(dockerfile), "git apply /usr/src/OpenBFDD-compile.patch")
+		assert.NotContains(t, string(dockerfile), "git apply --no-apply /usr/src/OpenBFDD-compile.patch")
+		assert.Contains(t, string(dockerfile), "ADD "+patchName+" /usr/src/")
+		assert.Contains(t, string(dockerfile), "git apply /usr/src/"+patchName)
+		assert.NotContains(t, string(dockerfile), "git apply --no-apply /usr/src/"+patchName)
+	}
 }
 
 func TestBFDDHealthcheck(t *testing.T) {


### PR DESCRIPTION
## What this PR does

- apply an OpenBFDD source patch that uses `MSG_NOSIGNAL` only when sending replies to control clients
- stop sending the remainder of a control reply after the first send failure
- keep the BFD peer packet path and process-wide signal disposition unchanged
- set the VPC gateway BFD readiness probe timeout to 10 seconds, matching the liveness probe
- add regression coverage for patch packaging, application, and the readiness timeout

The existing OpenBFDD compile patch is now actually applied rather than only checked. It adds the pthread/time includes required to rebuild the pinned source on the current Ubuntu toolchain and does not change runtime behavior. The existing TTL patch behavior is unchanged.

## Why this is needed

`bfdd-control status` uses a TCP control connection. When an exec probe times out, kubelet terminates `bfdd-control`, which closes that connection. OpenBFDD sends control replies with a plain `send(2)` call. If it writes after the probe disconnects, the daemon receives `SIGPIPE` and exits with status 141, after which the container restart policy restarts it.

The BFD peer path is separate: `Session::send()` sends UDP packets with `MSG_NOSIGNAL` already. Applying the same flag only to `CommandProcessorImp::doMessageReply()` fixes the control disconnect without ignoring `SIGPIPE` for the whole daemon or changing peer session behavior.

With the OpenBFDD commit bundled in the image (`e35f43ad8d2b3f084e96a84c392528a90d05a287`), disconnecting the control client while a response was being written terminated the unpatched daemon in 5/5 reproductions. After applying this source patch, two daemons established an Up BFD session and the test sent 20 valid, multi-line `status` requests followed by immediate TCP RST disconnects. The daemon stayed alive, both peer sessions remained Up, and `/proc/<pid>/status` confirmed that `SIGPIPE` was not ignored process-wide.

The explicit 10-second readiness timeout also prevents the Kubernetes default one-second timeout from unnecessarily aborting a slow status request.

Command logging remains disabled by default because readiness and liveness probes would otherwise generate about 32 routine command records per minute per gateway Pod. Send failures continue to use the existing socket error logging.

## Tests

- apply both patches to the pinned OpenBFDD source and build it with `make -j2`
- run two patched OpenBFDD daemons with an Up BFD peer session; inject 20 valid `status` requests followed by TCP RST and verify both daemons and the peer session remain healthy
- `bash -n dist/images/start-bfdd.sh`
- `go test ./pkg/controller -run 'TestGenGatewayBFDDContainer|TestOpenBFDDControlReplyPatch|TestBFDDHealthcheck' -count=1`
- `go test ./pkg/controller -run 'TestGenGatewayBFDDContainer|TestOpenBFDDControlReplyPatch' -count=10`
- `git diff --check`

Full lint and image builds run in GitHub Actions.
