### PR TITLE
fix(cni): refresh IPv6 neighbor caches

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1381,6 +1381,11 @@ func configureNic(link, ip string, macAddr net.HardwareAddr, mtu int, detectIPv4
 			klog.Error(err)
 			return fmt.Errorf("can not add address %s to nic %s: %w", addr, link, err)
 		}
+		if addr.IP.To4() == nil && !addr.IP.IsLinkLocalUnicast() {
+			if err := util.AnnounceNDPAddress(link, addr.IP.String(), macAddr, 1, time.Second); err != nil {
+				klog.Warningf("failed to send unsolicited neighbor advertisement: %v", err)
+			}
+		}
 	}
 
 	if setUfoOff {

--- a/pkg/util/ndp.go
+++ b/pkg/util/ndp.go
@@ -29,6 +29,16 @@ var ipv6LLAPrefix = netip.MustParseAddr("fe80::").AsSlice()
 
 var icmpv6NAFilter []bpf.RawInstruction
 
+type ndpPacketWriter interface {
+	Close() error
+	SetWriteDeadline(time.Time) error
+	WriteTo([]byte, net.Addr) (int, error)
+}
+
+var listenNDPPacket = func(ifi *net.Interface) (ndpPacketWriter, error) {
+	return packet.Listen(ifi, packet.Raw, unix.ETH_P_IPV6, &packet.Config{})
+}
+
 func init() {
 	instructions := []bpf.Instruction{
 		// length must be at least 86 bytes
@@ -256,4 +266,80 @@ LOOP:
 	default:
 		return true, nil, nil
 	}
+}
+
+// AnnounceNDPAddress sends unsolicited Neighbor Advertisements for an IPv6 address.
+func AnnounceNDPAddress(iface, ip string, mac net.HardwareAddr, announceNum int, announceInterval time.Duration) error {
+	target, err := netip.ParseAddr(ip)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP address %q: %w", ip, err)
+	}
+	if !target.Is6() {
+		return fmt.Errorf("IP address %q is not IPv6", ip)
+	}
+	if len(mac) != 6 {
+		return fmt.Errorf("invalid MAC address %q", mac)
+	}
+
+	ifi, err := net.InterfaceByName(iface)
+	if err != nil {
+		return fmt.Errorf("failed to get interface %q: %w", iface, err)
+	}
+
+	dstIP := netip.MustParseAddr("ff02::1")
+	dstMAC := net.HardwareAddr{0x33, 0x33, 0, 0, 0, 1}
+	na := &ndp.NeighborAdvertisement{
+		Override:      true,
+		TargetAddress: target,
+		Options: []ndp.Option{
+			&ndp.LinkLayerAddress{
+				Direction: ndp.Target,
+				Addr:      mac,
+			},
+		},
+	}
+	msg, err := ndp.MarshalMessageChecksum(na, target, dstIP)
+	if err != nil {
+		return fmt.Errorf("failed to marshal neighbor advertisement message: %w", err)
+	}
+
+	sb := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	if err = gopacket.SerializeLayers(sb, opts,
+		&layers.Ethernet{
+			SrcMAC:       mac,
+			DstMAC:       dstMAC,
+			EthernetType: layers.EthernetTypeIPv6,
+		},
+		&layers.IPv6{
+			Version:    6,
+			SrcIP:      target.AsSlice(),
+			DstIP:      dstIP.AsSlice(),
+			HopLimit:   0xff,
+			NextHeader: layers.IPProtocolICMPv6,
+		},
+		gopacket.Payload(msg),
+	); err != nil {
+		return fmt.Errorf("failed to serialize neighbor advertisement packet: %w", err)
+	}
+
+	conn, err := listenNDPPacket(ifi)
+	if err != nil {
+		return fmt.Errorf("failed to listen on interface %s: %w", ifi.Name, err)
+	}
+	defer conn.Close()
+
+	for i := range announceNum {
+		if err = conn.SetWriteDeadline(time.Now().Add(announceInterval)); err != nil {
+			return fmt.Errorf("failed to set write deadline: %w", err)
+		}
+		if _, err = conn.WriteTo(sb.Bytes(), &packet.Addr{HardwareAddr: dstMAC}); err != nil {
+			return fmt.Errorf("failed to send neighbor advertisement message: %w", err)
+		}
+		if i != announceNum-1 {
+			time.Sleep(announceInterval)
+		}
+	}
+
+	return nil
 }

--- a/pkg/util/ndp_test.go
+++ b/pkg/util/ndp_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/mdlayher/ndp"
+	"github.com/stretchr/testify/require"
+)
+
+type captureNDPWriter struct {
+	packet []byte
+	addr   net.Addr
+}
+
+func (w *captureNDPWriter) Close() error { return nil }
+
+func (w *captureNDPWriter) SetWriteDeadline(time.Time) error { return nil }
+
+func (w *captureNDPWriter) WriteTo(packet []byte, addr net.Addr) (int, error) {
+	w.packet = append([]byte(nil), packet...)
+	w.addr = addr
+	return len(packet), nil
+}
+
+func TestAnnounceNDPAddressSendsUnsolicitedNeighborAdvertisement(t *testing.T) {
+	iface, err := net.InterfaceByName("lo")
+	require.NoError(t, err)
+
+	writer := new(captureNDPWriter)
+	originalListenNDPPacket := listenNDPPacket
+	listenNDPPacket = func(actualIface *net.Interface) (ndpPacketWriter, error) {
+		require.Equal(t, iface, actualIface)
+		return writer, nil
+	}
+	t.Cleanup(func() { listenNDPPacket = originalListenNDPPacket })
+
+	target := netip.MustParseAddr("fd00:10:96::fa51")
+	mac := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0xfa, 0x51}
+	require.NoError(t, AnnounceNDPAddress(iface.Name, target.String(), mac, 1, time.Millisecond))
+	require.Equal(t, "33:33:00:00:00:01", writer.addr.String())
+
+	packet := gopacket.NewPacket(writer.packet, layers.LayerTypeEthernet, gopacket.Default)
+	ethernetLayer := packet.Layer(layers.LayerTypeEthernet)
+	require.NotNil(t, ethernetLayer)
+	ethernet := ethernetLayer.(*layers.Ethernet)
+	require.Equal(t, mac, ethernet.SrcMAC)
+	require.Equal(t, net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0x01}, ethernet.DstMAC)
+
+	ipv6Layer := packet.Layer(layers.LayerTypeIPv6)
+	require.NotNil(t, ipv6Layer)
+	ipv6Packet := ipv6Layer.(*layers.IPv6)
+	require.Equal(t, net.IP(target.AsSlice()), ipv6Packet.SrcIP)
+	require.Equal(t, net.ParseIP("ff02::1"), ipv6Packet.DstIP)
+	require.Equal(t, uint8(255), ipv6Packet.HopLimit)
+	require.Equal(t, layers.IPProtocolICMPv6, ipv6Packet.NextHeader)
+
+	message, err := ndp.ParseMessage(writer.packet[14+40:])
+	require.NoError(t, err)
+	advertisement, ok := message.(*ndp.NeighborAdvertisement)
+	require.True(t, ok)
+	require.False(t, advertisement.Router)
+	require.False(t, advertisement.Solicited)
+	require.True(t, advertisement.Override)
+	require.Equal(t, target, advertisement.TargetAddress)
+	require.Equal(t, []ndp.Option{
+		&ndp.LinkLayerAddress{Direction: ndp.Target, Addr: mac},
+	}, advertisement.Options)
+}

--- a/test/e2e/kube-ovn/pod/fixed_ip_recreation.go
+++ b/test/e2e/kube-ovn/pod/fixed_ip_recreation.go
@@ -1,0 +1,113 @@
+package pod
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"net"
+	"strconv"
+	"time"
+
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+
+	"github.com/onsi/ginkgo/v2"
+
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+var _ = framework.SerialDescribe("[group:pod]", func() {
+	f := framework.NewDefaultFramework("static-ip-recreation")
+
+	var podClient *framework.PodClient
+	var subnetClient *framework.SubnetClient
+	var namespaceName, subnetName, backendName, clientName string
+
+	ginkgo.BeforeEach(func() {
+		podClient = f.PodClient()
+		subnetClient = f.SubnetClient()
+		namespaceName = f.Namespace.Name
+		subnetName = "subnet-" + framework.RandomSuffix()
+		backendName = "backend-" + framework.RandomSuffix()
+		clientName = "client-" + framework.RandomSuffix()
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Deleting backend pod " + backendName)
+		podClient.DeleteGracefully(backendName)
+		ginkgo.By("Deleting client pod " + clientName)
+		podClient.DeleteGracefully(clientName)
+		podClient.WaitForNotFound(backendName)
+		podClient.WaitForNotFound(clientName)
+		ginkgo.By("Deleting subnet " + subnetName)
+		subnetClient.DeleteSync(subnetName)
+	})
+
+	framework.ConformanceIt("should immediately reach a recreated static IPv6 pod after its MAC changes", func() {
+		f.SkipVersionPriorTo(1, 17, "Unsolicited IPv6 neighbor advertisements were introduced in v1.17")
+		if !f.HasIPv6() {
+			ginkgo.Skip("This case requires IPv6")
+		}
+
+		nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			ginkgo.Skip("This case requires at least two ready schedulable nodes")
+		}
+
+		cidr := framework.RandomCIDR(apiv1.ProtocolIPv6)
+		firstIP, err := util.FirstIP(cidr)
+		framework.ExpectNoError(err)
+		fixedIP := util.BigInt2Ip(new(big.Int).Add(util.IP2BigInt(firstIP), big.NewInt(10)))
+
+		ginkgo.By("Creating IPv6 subnet " + subnetName)
+		subnet := framework.MakeSubnet(subnetName, "", cidr, "", "", "", nil, nil, nil)
+		_ = subnetClient.CreateSync(subnet)
+
+		ginkgo.By("Creating client pod " + clientName)
+		clientAnnotations := map[string]string{util.LogicalSwitchAnnotation: subnetName}
+		client := framework.MakePod(namespaceName, clientName, nil, clientAnnotations, framework.AgnhostImage, nil, nil)
+		client.Spec.NodeName = nodes.Items[0].Name
+		_ = podClient.CreateSync(client)
+
+		const (
+			oldMAC = "02:00:00:00:00:11"
+			newMAC = "02:00:00:00:00:12"
+			port   = 8080
+		)
+		makeBackend := func(mac string) {
+			ginkgo.GinkgoHelper()
+			annotations := map[string]string{
+				util.LogicalSwitchAnnotation: subnetName,
+				util.IPAddressAnnotation:     fixedIP,
+				util.MacAddressAnnotation:    mac,
+			}
+			args := []string{"netexec", "--http-port", strconv.Itoa(port)}
+			backend := framework.MakePod(namespaceName, backendName, nil, annotations, framework.AgnhostImage, nil, args)
+			backend.Spec.NodeName = nodes.Items[1].Name
+			backend = podClient.CreateSync(backend)
+			framework.ExpectHaveKeyWithValue(backend.Annotations, util.IPAddressAnnotation, fixedIP)
+			framework.ExpectHaveKeyWithValue(backend.Annotations, util.MacAddressAnnotation, mac)
+		}
+
+		url := "http://" + net.JoinHostPort(fixedIP, strconv.Itoa(port)) + "/hostname"
+		curlCommand := fmt.Sprintf("curl -q -s --connect-timeout 1 --max-time 1 %s", url)
+
+		ginkgo.By("Creating the first backend and priming the client's IPv6 neighbor cache")
+		makeBackend(oldMAC)
+		framework.WaitUntil(time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+			_, err := e2epodoutput.RunHostCmd(namespaceName, clientName, curlCommand)
+			return err == nil, nil
+		}, "the client can reach the first backend")
+
+		ginkgo.By("Recreating the backend with the same IPv6 address and a different MAC address")
+		podClient.DeleteSync(backendName)
+		makeBackend(newMAC)
+
+		ginkgo.By("Checking the first direct request after the recreated backend becomes ready")
+		_, err = e2epodoutput.RunHostCmd(namespaceName, clientName, curlCommand)
+		framework.ExpectNoError(err, "the recreated static IPv6 pod should be reachable without waiting for neighbor discovery timeout")
+	})
+})

--- a/test/e2e/kube-ovn/pod/fixed_ip_recreation.go
+++ b/test/e2e/kube-ovn/pod/fixed_ip_recreation.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
-	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 )
@@ -46,7 +45,7 @@ var _ = framework.SerialDescribe("[group:pod]", func() {
 	})
 
 	framework.ConformanceIt("should immediately reach a recreated static IPv6 pod after its MAC changes", func() {
-		f.SkipVersionPriorTo(1, 17, "Unsolicited IPv6 neighbor advertisements were introduced in v1.17")
+		f.SkipVersionPriorTo(1, 15, "Unsolicited IPv6 neighbor advertisements were introduced in v1.15")
 		if !f.HasIPv6() {
 			ginkgo.Skip("This case requires IPv6")
 		}
@@ -57,7 +56,7 @@ var _ = framework.SerialDescribe("[group:pod]", func() {
 			ginkgo.Skip("This case requires at least two ready schedulable nodes")
 		}
 
-		cidr := framework.RandomCIDR(apiv1.ProtocolIPv6)
+		cidr := framework.RandomCIDR(framework.IPv6)
 		firstIP, err := util.FirstIP(cidr)
 		framework.ExpectNoError(err)
 		fixedIP := util.BigInt2Ip(new(big.Int).Add(util.IP2BigInt(firstIP), big.NewInt(10)))


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

## Summary

- send an unsolicited IPv6 Neighbor Advertisement after assigning each non-link-local IPv6 address
- set the Override flag and advertise the new MAC to the all-nodes multicast address
- keep announcement failures best-effort, matching the existing gratuitous ARP behavior
- verify the emitted Ethernet, IPv6, and ICMPv6 fields with a raw-packet regression test
- cover the first direct request after a static IPv6 backend is recreated with a different MAC in the Kube-OVN E2E suite

## Why

When a Pod is recreated on another node with the same fixed IPv6 address but a different MAC address, peers can retain the old MAC in their IPv6 neighbor cache. Direct traffic then waits for Linux NUD to transition through DELAY and PROBE before learning the new MAC, causing a reproducible 6-9 second outage.

IPv4 does not exhibit this outage because the CNI already sends a gratuitous ARP before adding an IPv4 address. This change provides the equivalent cache-refresh signal for IPv6.

## Test Plan

- `go test ./pkg/util -count=1`
- `go test ./pkg/daemon -count=1`
- `go test ./pkg/util -run '^TestAnnounceNDPAddressSendsUnsolicitedNeighborAdvertisement$' -count=10`
- `golangci-lint run --concurrency 1 ./pkg/util ./pkg/daemon`
- `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./pkg/util ./pkg/daemon`
- `go test ./test/e2e/kube-ovn/pod -run '^$' -count=1`
- `go test ./test/e2e/kube-ovn -run '^$' -count=1`
- `golangci-lint run --concurrency 1 ./test/e2e/kube-ovn/pod`
- `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./test/e2e/kube-ovn/pod`

## Which issue(s) this PR fixes

N/A
