### PR TITLE
fix(cni): refresh IPv6 neighbor caches

### DIFF
--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -1337,6 +1337,11 @@ func configureNic(link, ip string, macAddr net.HardwareAddr, mtu int, detectIPv4
 			klog.Error(err)
 			return fmt.Errorf("can not add address %s to nic %s: %w", addr, link, err)
 		}
+		if addr.IP.To4() == nil && !addr.IP.IsLinkLocalUnicast() {
+			if err := util.AnnounceNDPAddress(link, addr.IP.String(), macAddr, 1, time.Second); err != nil {
+				klog.Warningf("failed to send unsolicited neighbor advertisement: %v", err)
+			}
+		}
 	}
 
 	if setUfoOff {

--- a/pkg/util/ndp.go
+++ b/pkg/util/ndp.go
@@ -29,6 +29,16 @@ var ipv6LLAPrefix = netip.MustParseAddr("fe80::").AsSlice()
 
 var icmpv6NAFilter []bpf.RawInstruction
 
+type ndpPacketWriter interface {
+	Close() error
+	SetWriteDeadline(time.Time) error
+	WriteTo([]byte, net.Addr) (int, error)
+}
+
+var listenNDPPacket = func(ifi *net.Interface) (ndpPacketWriter, error) {
+	return packet.Listen(ifi, packet.Raw, unix.ETH_P_IPV6, &packet.Config{})
+}
+
 func init() {
 	instructions := []bpf.Instruction{
 		// length must be at least 86 bytes
@@ -256,4 +266,80 @@ LOOP:
 	default:
 		return true, nil, nil
 	}
+}
+
+// AnnounceNDPAddress sends unsolicited Neighbor Advertisements for an IPv6 address.
+func AnnounceNDPAddress(iface, ip string, mac net.HardwareAddr, announceNum int, announceInterval time.Duration) error {
+	target, err := netip.ParseAddr(ip)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP address %q: %w", ip, err)
+	}
+	if !target.Is6() {
+		return fmt.Errorf("IP address %q is not IPv6", ip)
+	}
+	if len(mac) != 6 {
+		return fmt.Errorf("invalid MAC address %q", mac)
+	}
+
+	ifi, err := net.InterfaceByName(iface)
+	if err != nil {
+		return fmt.Errorf("failed to get interface %q: %w", iface, err)
+	}
+
+	dstIP := netip.MustParseAddr("ff02::1")
+	dstMAC := net.HardwareAddr{0x33, 0x33, 0, 0, 0, 1}
+	na := &ndp.NeighborAdvertisement{
+		Override:      true,
+		TargetAddress: target,
+		Options: []ndp.Option{
+			&ndp.LinkLayerAddress{
+				Direction: ndp.Target,
+				Addr:      mac,
+			},
+		},
+	}
+	msg, err := ndp.MarshalMessageChecksum(na, target, dstIP)
+	if err != nil {
+		return fmt.Errorf("failed to marshal neighbor advertisement message: %w", err)
+	}
+
+	sb := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	if err = gopacket.SerializeLayers(sb, opts,
+		&layers.Ethernet{
+			SrcMAC:       mac,
+			DstMAC:       dstMAC,
+			EthernetType: layers.EthernetTypeIPv6,
+		},
+		&layers.IPv6{
+			Version:    6,
+			SrcIP:      target.AsSlice(),
+			DstIP:      dstIP.AsSlice(),
+			HopLimit:   0xff,
+			NextHeader: layers.IPProtocolICMPv6,
+		},
+		gopacket.Payload(msg),
+	); err != nil {
+		return fmt.Errorf("failed to serialize neighbor advertisement packet: %w", err)
+	}
+
+	conn, err := listenNDPPacket(ifi)
+	if err != nil {
+		return fmt.Errorf("failed to listen on interface %s: %w", ifi.Name, err)
+	}
+	defer conn.Close()
+
+	for i := range announceNum {
+		if err = conn.SetWriteDeadline(time.Now().Add(announceInterval)); err != nil {
+			return fmt.Errorf("failed to set write deadline: %w", err)
+		}
+		if _, err = conn.WriteTo(sb.Bytes(), &packet.Addr{HardwareAddr: dstMAC}); err != nil {
+			return fmt.Errorf("failed to send neighbor advertisement message: %w", err)
+		}
+		if i != announceNum-1 {
+			time.Sleep(announceInterval)
+		}
+	}
+
+	return nil
 }

--- a/pkg/util/ndp_test.go
+++ b/pkg/util/ndp_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/mdlayher/ndp"
+	"github.com/stretchr/testify/require"
+)
+
+type captureNDPWriter struct {
+	packet []byte
+	addr   net.Addr
+}
+
+func (w *captureNDPWriter) Close() error { return nil }
+
+func (w *captureNDPWriter) SetWriteDeadline(time.Time) error { return nil }
+
+func (w *captureNDPWriter) WriteTo(packet []byte, addr net.Addr) (int, error) {
+	w.packet = append([]byte(nil), packet...)
+	w.addr = addr
+	return len(packet), nil
+}
+
+func TestAnnounceNDPAddressSendsUnsolicitedNeighborAdvertisement(t *testing.T) {
+	iface, err := net.InterfaceByName("lo")
+	require.NoError(t, err)
+
+	writer := new(captureNDPWriter)
+	originalListenNDPPacket := listenNDPPacket
+	listenNDPPacket = func(actualIface *net.Interface) (ndpPacketWriter, error) {
+		require.Equal(t, iface, actualIface)
+		return writer, nil
+	}
+	t.Cleanup(func() { listenNDPPacket = originalListenNDPPacket })
+
+	target := netip.MustParseAddr("fd00:10:96::fa51")
+	mac := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0xfa, 0x51}
+	require.NoError(t, AnnounceNDPAddress(iface.Name, target.String(), mac, 1, time.Millisecond))
+	require.Equal(t, "33:33:00:00:00:01", writer.addr.String())
+
+	packet := gopacket.NewPacket(writer.packet, layers.LayerTypeEthernet, gopacket.Default)
+	ethernetLayer := packet.Layer(layers.LayerTypeEthernet)
+	require.NotNil(t, ethernetLayer)
+	ethernet := ethernetLayer.(*layers.Ethernet)
+	require.Equal(t, mac, ethernet.SrcMAC)
+	require.Equal(t, net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0x01}, ethernet.DstMAC)
+
+	ipv6Layer := packet.Layer(layers.LayerTypeIPv6)
+	require.NotNil(t, ipv6Layer)
+	ipv6Packet := ipv6Layer.(*layers.IPv6)
+	require.Equal(t, net.IP(target.AsSlice()), ipv6Packet.SrcIP)
+	require.Equal(t, net.ParseIP("ff02::1"), ipv6Packet.DstIP)
+	require.Equal(t, uint8(255), ipv6Packet.HopLimit)
+	require.Equal(t, layers.IPProtocolICMPv6, ipv6Packet.NextHeader)
+
+	message, err := ndp.ParseMessage(writer.packet[14+40:])
+	require.NoError(t, err)
+	advertisement, ok := message.(*ndp.NeighborAdvertisement)
+	require.True(t, ok)
+	require.False(t, advertisement.Router)
+	require.False(t, advertisement.Solicited)
+	require.True(t, advertisement.Override)
+	require.Equal(t, target, advertisement.TargetAddress)
+	require.Equal(t, []ndp.Option{
+		&ndp.LinkLayerAddress{Direction: ndp.Target, Addr: mac},
+	}, advertisement.Options)
+}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

## Summary

Backport of #7139 to `release-1.16`.

- send an unsolicited IPv6 Neighbor Advertisement after assigning each non-link-local IPv6 address
- set the Override flag and advertise the new MAC to the all-nodes multicast address
- keep announcement failures best-effort, matching the existing gratuitous ARP behavior
- verify the emitted Ethernet, IPv6, and ICMPv6 fields with a raw-packet regression test

## Why

When a Pod is recreated on another node with the same fixed IPv6 address but a different MAC address, peers can retain the old MAC in their IPv6 neighbor cache. Direct traffic then waits for Linux NUD to transition through DELAY and PROBE before learning the new MAC, causing a reproducible 6-9 second outage.

IPv4 does not exhibit this outage because the CNI already sends a gratuitous ARP before adding an IPv4 address. This change provides the equivalent cache-refresh signal for IPv6.

## Test Plan

- `go test -cover ./pkg/util -count=1`
- `go test ./pkg/daemon -count=1`
- `golangci-lint run --concurrency 1 ./pkg/util ./pkg/daemon`
- `git diff --check HEAD^..HEAD`

## Which issue(s) this PR fixes

N/A
