### PR TITLE
[release-1.15] fix(ovn-central): tolerate transient duplicate leaders

### DIFF
--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -604,8 +604,12 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 	} else {
 		icNbLeader, icNbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICNB)
 		icSbLeader, icSbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICSB)
-		checkDuplicateDBLeader(cfg, icNbLeader, icNbLeaderErr, "ovn-ic-nb", util.DatabaseICNB, 1, isDBLeader)
-		checkDuplicateDBLeader(cfg, icSbLeader, icSbLeaderErr, "ovn-ic-sb", util.DatabaseICSB, 1, isDBLeader)
+		if icNbLeaderErr != nil {
+			klog.Error(icNbLeaderErr)
+		}
+		if icSbLeaderErr != nil {
+			klog.Error(icSbLeaderErr)
+		}
 
 		patch := util.KVPatch{
 			"ovn-ic-nb-leader": strconv.FormatBool(icNbLeader),
@@ -621,6 +625,13 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 				klog.Errorf("update ts num failed err: %v", err)
 				return
 			}
+		}
+
+		if icNbLeaderErr == nil {
+			checkDuplicateDBLeader(cfg, icNbLeader, nil, "ovn-ic-nb", util.DatabaseICNB, 1, isDBLeader)
+		}
+		if icSbLeaderErr == nil {
+			checkDuplicateDBLeader(cfg, icSbLeader, nil, "ovn-ic-sb", util.DatabaseICSB, 1, isDBLeader)
 		}
 	}
 }

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -214,8 +214,8 @@ func checkOvnIsAlive() bool {
 	return true
 }
 
-// isDBLeader checks whether the ovn db at address is leader for the given database
-func isDBLeader(address, database string) bool {
+// isDBLeader checks whether the ovn db at address is leader for the given database.
+func isDBLeader(address, database string) (bool, error) {
 	var dbAddr string
 	switch database {
 	case ovnnb.DatabaseName:
@@ -227,8 +227,7 @@ func isDBLeader(address, database string) bool {
 	case util.DatabaseICSB:
 		dbAddr = ovs.OvsdbServerAddress(address, intstr.FromInt32(util.ICSBDatabasePort))
 	default:
-		klog.Errorf("isDBLeader: unsupported database %s", database)
-		return false
+		return logDBLeaderQueryError(fmt.Errorf("unsupported database %s", database))
 	}
 
 	result, err := ovs.Query(dbAddr, serverdb.DatabaseName, 1, ovsdb.Operation{
@@ -242,29 +241,29 @@ func isDBLeader(address, database string) bool {
 		Columns: []string{"leader"},
 	})
 	if err != nil {
-		klog.Errorf("failed to query leader info from ovsdb-server %s for database %s: %v", address, database, err)
-		return false
+		return logDBLeaderQueryError(fmt.Errorf("failed to query leader info from ovsdb-server %s for database %s: %w", address, database, err))
 	}
 	if len(result) != 1 {
-		klog.Errorf("unexpected number of results when querying leader info from ovsdb-server %s for database %s: %d", address, database, len(result))
-		return false
+		return logDBLeaderQueryError(fmt.Errorf("unexpected number of results when querying leader info from ovsdb-server %s for database %s: %d", address, database, len(result)))
 	}
 	if len(result[0].Rows) == 0 {
-		klog.Errorf("no rows returned when querying leader info from ovsdb-server %s for database %s", address, database)
-		return false
+		return logDBLeaderQueryError(fmt.Errorf("no rows returned when querying leader info from ovsdb-server %s for database %s", address, database))
 	}
 	if len(result[0].Rows) != 1 {
-		klog.Errorf("unexpected number of rows when querying leader info from ovsdb-server %s for database %s: %d", address, database, len(result[0].Rows))
-		return false
+		return logDBLeaderQueryError(fmt.Errorf("unexpected number of rows when querying leader info from ovsdb-server %s for database %s: %d", address, database, len(result[0].Rows)))
 	}
 
 	leader, ok := result[0].Rows[0]["leader"].(bool)
 	if !ok {
-		klog.Errorf("unexpected data format for leader info from ovsdb-server %s for database %s: %v", address, database, result[0].Rows[0]["leader"])
-		return false
+		return logDBLeaderQueryError(fmt.Errorf("unexpected data format for leader info from ovsdb-server %s for database %s: %v", address, database, result[0].Rows[0]["leader"]))
 	}
 
-	return leader
+	return leader, nil
+}
+
+func logDBLeaderQueryError(err error) (bool, error) {
+	klog.Error(err)
+	return false, err
 }
 
 func checkNorthdActive() bool {
@@ -482,21 +481,45 @@ func validateRaftHeader(data map[string]any, dbCID string) error {
 	return nil
 }
 
-func checkDuplicateDBLeader(cfg *Configuration, localLeader bool, component, database string) {
+type dbLeaderQueryFunc func(address, database string) (bool, error)
+
+func checkDuplicateDBLeader(
+	cfg *Configuration,
+	localLeader bool,
+	localQueryErr error,
+	component, database string,
+	queryLeader dbLeaderQueryFunc,
+) {
+	if localQueryErr != nil {
+		return
+	}
+	if !localLeader {
+		cfg.observeDuplicateLeader(database, false)
+		return
+	}
+
 	var remoteLeader string
-	if localLeader {
-		for addr := range slices.Values(cfg.remoteAddresses) {
-			if isDBLeader(addr, database) {
-				remoteLeader = addr
-				break
-			}
+	remoteQueryFailed := false
+	for addr := range slices.Values(cfg.remoteAddresses) {
+		leader, err := queryLeader(addr, database)
+		if err != nil {
+			remoteQueryFailed = true
+			continue
+		}
+		if leader {
+			remoteLeader = addr
+			break
 		}
 	}
 
-	count, confirmed := cfg.observeDuplicateLeader(database, remoteLeader != "")
 	if remoteLeader == "" {
+		if !remoteQueryFailed {
+			cfg.observeDuplicateLeader(database, false)
+		}
 		return
 	}
+
+	count, confirmed := cfg.observeDuplicateLeader(database, true)
 	if !confirmed {
 		klog.Warningf("found another %s leader at %s (%d/%d consecutive observations), waiting for raft convergence",
 			component, remoteLeader, count, maxDuplicateLeaderObservations)
@@ -551,8 +574,8 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			return
 		}
 
-		nbLeader := isDBLeader(cfg.localAddress, ovnnb.DatabaseName)
-		sbLeader := isDBLeader(cfg.localAddress, ovnsb.DatabaseName)
+		nbLeader, nbLeaderErr := isDBLeader(cfg.localAddress, ovnnb.DatabaseName)
+		sbLeader, sbLeaderErr := isDBLeader(cfg.localAddress, ovnsb.DatabaseName)
 		northdActive := checkNorthdActive()
 		patch := util.KVPatch{
 			"ovn-nb-leader":     strconv.FormatBool(nbLeader),
@@ -570,8 +593,8 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			}
 		}
 
-		checkDuplicateDBLeader(cfg, nbLeader, "ovn-nb", ovnnb.DatabaseName)
-		checkDuplicateDBLeader(cfg, sbLeader, "ovn-sb", ovnsb.DatabaseName)
+		checkDuplicateDBLeader(cfg, nbLeader, nbLeaderErr, "ovn-nb", ovnnb.DatabaseName, isDBLeader)
+		checkDuplicateDBLeader(cfg, sbLeader, sbLeaderErr, "ovn-sb", ovnsb.DatabaseName, isDBLeader)
 
 		if cfg.EnableCompact {
 			compactOvnDatabase("nb")
@@ -581,8 +604,8 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 		backupRaftHeader("nb")
 		backupRaftHeader("sb")
 	} else {
-		icNbLeader := isDBLeader(cfg.localAddress, util.DatabaseICNB)
-		icSbLeader := isDBLeader(cfg.localAddress, util.DatabaseICSB)
+		icNbLeader, icNbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICNB)
+		icSbLeader, icSbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICSB)
 		patch := util.KVPatch{
 			"ovn-ic-nb-leader": strconv.FormatBool(icNbLeader),
 			"ovn-ic-sb-leader": strconv.FormatBool(icSbLeader),
@@ -599,8 +622,8 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			}
 		}
 
-		checkDuplicateDBLeader(cfg, icNbLeader, "ovn-ic-nb", util.DatabaseICNB)
-		checkDuplicateDBLeader(cfg, icSbLeader, "ovn-ic-sb", util.DatabaseICSB)
+		checkDuplicateDBLeader(cfg, icNbLeader, icNbLeaderErr, "ovn-ic-nb", util.DatabaseICNB, isDBLeader)
+		checkDuplicateDBLeader(cfg, icSbLeader, icSbLeaderErr, "ovn-ic-sb", util.DatabaseICSB, isDBLeader)
 	}
 }
 

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -62,7 +62,7 @@ type Configuration struct {
 	duplicateLeaderObservations map[string]int
 }
 
-func (c *Configuration) observeDuplicateLeader(database string, duplicate bool) (int, bool) {
+func (c *Configuration) observeDuplicateLeader(database string, duplicate bool, requiredObservations int) (int, bool) {
 	if !duplicate {
 		delete(c.duplicateLeaderObservations, database)
 		return 0, false
@@ -73,7 +73,7 @@ func (c *Configuration) observeDuplicateLeader(database string, duplicate bool) 
 
 	c.duplicateLeaderObservations[database]++
 	count := c.duplicateLeaderObservations[database]
-	return count, count >= maxDuplicateLeaderObservations
+	return count, count >= requiredObservations
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -227,7 +227,7 @@ func isDBLeader(address, database string) (bool, error) {
 	case util.DatabaseICSB:
 		dbAddr = ovs.OvsdbServerAddress(address, intstr.FromInt32(util.ICSBDatabasePort))
 	default:
-		return logDBLeaderQueryError(fmt.Errorf("unsupported database %s", database))
+		return false, fmt.Errorf("unsupported database %s", database)
 	}
 
 	result, err := ovs.Query(dbAddr, serverdb.DatabaseName, 1, ovsdb.Operation{
@@ -241,29 +241,24 @@ func isDBLeader(address, database string) (bool, error) {
 		Columns: []string{"leader"},
 	})
 	if err != nil {
-		return logDBLeaderQueryError(fmt.Errorf("failed to query leader info from ovsdb-server %s for database %s: %w", address, database, err))
+		return false, fmt.Errorf("failed to query leader info from ovsdb-server %s for database %s: %w", address, database, err)
 	}
 	if len(result) != 1 {
-		return logDBLeaderQueryError(fmt.Errorf("unexpected number of results when querying leader info from ovsdb-server %s for database %s: %d", address, database, len(result)))
+		return false, fmt.Errorf("unexpected number of results when querying leader info from ovsdb-server %s for database %s: %d", address, database, len(result))
 	}
 	if len(result[0].Rows) == 0 {
-		return logDBLeaderQueryError(fmt.Errorf("no rows returned when querying leader info from ovsdb-server %s for database %s", address, database))
+		return false, fmt.Errorf("no rows returned when querying leader info from ovsdb-server %s for database %s", address, database)
 	}
 	if len(result[0].Rows) != 1 {
-		return logDBLeaderQueryError(fmt.Errorf("unexpected number of rows when querying leader info from ovsdb-server %s for database %s: %d", address, database, len(result[0].Rows)))
+		return false, fmt.Errorf("unexpected number of rows when querying leader info from ovsdb-server %s for database %s: %d", address, database, len(result[0].Rows))
 	}
 
 	leader, ok := result[0].Rows[0]["leader"].(bool)
 	if !ok {
-		return logDBLeaderQueryError(fmt.Errorf("unexpected data format for leader info from ovsdb-server %s for database %s: %v", address, database, result[0].Rows[0]["leader"]))
+		return false, fmt.Errorf("unexpected data format for leader info from ovsdb-server %s for database %s: %v", address, database, result[0].Rows[0]["leader"])
 	}
 
 	return leader, nil
-}
-
-func logDBLeaderQueryError(err error) (bool, error) {
-	klog.Error(err)
-	return false, err
 }
 
 func checkNorthdActive() bool {
@@ -488,13 +483,15 @@ func checkDuplicateDBLeader(
 	localLeader bool,
 	localQueryErr error,
 	component, database string,
+	requiredObservations int,
 	queryLeader dbLeaderQueryFunc,
 ) {
 	if localQueryErr != nil {
+		klog.Error(localQueryErr)
 		return
 	}
 	if !localLeader {
-		cfg.observeDuplicateLeader(database, false)
+		cfg.observeDuplicateLeader(database, false, requiredObservations)
 		return
 	}
 
@@ -503,6 +500,7 @@ func checkDuplicateDBLeader(
 	for addr := range slices.Values(cfg.remoteAddresses) {
 		leader, err := queryLeader(addr, database)
 		if err != nil {
+			klog.Error(err)
 			remoteQueryFailed = true
 			continue
 		}
@@ -514,15 +512,15 @@ func checkDuplicateDBLeader(
 
 	if remoteLeader == "" {
 		if !remoteQueryFailed {
-			cfg.observeDuplicateLeader(database, false)
+			cfg.observeDuplicateLeader(database, false, requiredObservations)
 		}
 		return
 	}
 
-	count, confirmed := cfg.observeDuplicateLeader(database, true)
+	count, confirmed := cfg.observeDuplicateLeader(database, true, requiredObservations)
 	if !confirmed {
 		klog.Warningf("found another %s leader at %s (%d/%d consecutive observations), waiting for raft convergence",
-			component, remoteLeader, count, maxDuplicateLeaderObservations)
+			component, remoteLeader, count, requiredObservations)
 		return
 	}
 
@@ -576,6 +574,9 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 
 		nbLeader, nbLeaderErr := isDBLeader(cfg.localAddress, ovnnb.DatabaseName)
 		sbLeader, sbLeaderErr := isDBLeader(cfg.localAddress, ovnsb.DatabaseName)
+		checkDuplicateDBLeader(cfg, nbLeader, nbLeaderErr, "ovn-nb", ovnnb.DatabaseName, maxDuplicateLeaderObservations, isDBLeader)
+		checkDuplicateDBLeader(cfg, sbLeader, sbLeaderErr, "ovn-sb", ovnsb.DatabaseName, maxDuplicateLeaderObservations, isDBLeader)
+
 		northdActive := checkNorthdActive()
 		patch := util.KVPatch{
 			"ovn-nb-leader":     strconv.FormatBool(nbLeader),
@@ -593,9 +594,6 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			}
 		}
 
-		checkDuplicateDBLeader(cfg, nbLeader, nbLeaderErr, "ovn-nb", ovnnb.DatabaseName, isDBLeader)
-		checkDuplicateDBLeader(cfg, sbLeader, sbLeaderErr, "ovn-sb", ovnsb.DatabaseName, isDBLeader)
-
 		if cfg.EnableCompact {
 			compactOvnDatabase("nb")
 			compactOvnDatabase("sb")
@@ -606,6 +604,9 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 	} else {
 		icNbLeader, icNbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICNB)
 		icSbLeader, icSbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICSB)
+		checkDuplicateDBLeader(cfg, icNbLeader, icNbLeaderErr, "ovn-ic-nb", util.DatabaseICNB, 1, isDBLeader)
+		checkDuplicateDBLeader(cfg, icSbLeader, icSbLeaderErr, "ovn-ic-sb", util.DatabaseICSB, 1, isDBLeader)
+
 		patch := util.KVPatch{
 			"ovn-ic-nb-leader": strconv.FormatBool(icNbLeader),
 			"ovn-ic-sb-leader": strconv.FormatBool(icSbLeader),
@@ -621,9 +622,6 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 				return
 			}
 		}
-
-		checkDuplicateDBLeader(cfg, icNbLeader, icNbLeaderErr, "ovn-ic-nb", util.DatabaseICNB, isDBLeader)
-		checkDuplicateDBLeader(cfg, icSbLeader, icSbLeaderErr, "ovn-ic-sb", util.DatabaseICSB, isDBLeader)
 	}
 }
 

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -37,11 +37,12 @@ import (
 )
 
 const (
-	OvnNorthdServiceName = "ovn-northd"
-	OvnNorthdPid         = "/var/run/ovn/ovn-northd.pid"
-	DefaultProbeInterval = 5
-	MaxFailCount         = 3
-	northdDialTimeout    = 3 * time.Second
+	OvnNorthdServiceName           = "ovn-northd"
+	OvnNorthdPid                   = "/var/run/ovn/ovn-northd.pid"
+	DefaultProbeInterval           = 5
+	MaxFailCount                   = 3
+	maxDuplicateLeaderObservations = 3
+	northdDialTimeout              = 3 * time.Second
 )
 
 var failCount int
@@ -50,14 +51,29 @@ var labelSelector = labels.Set{discoveryv1.LabelServiceName: OvnNorthdServiceNam
 
 // Configuration is the controller conf
 type Configuration struct {
-	KubeConfigFile  string
-	KubeClient      kubernetes.Interface
-	ProbeInterval   int
-	EnableCompact   bool
-	IsICDBServer    bool
-	localAddress    string
-	remoteAddresses []string
-	singleReplica   bool
+	KubeConfigFile              string
+	KubeClient                  kubernetes.Interface
+	ProbeInterval               int
+	EnableCompact               bool
+	IsICDBServer                bool
+	localAddress                string
+	remoteAddresses             []string
+	singleReplica               bool
+	duplicateLeaderObservations map[string]int
+}
+
+func (c *Configuration) observeDuplicateLeader(database string, duplicate bool) (int, bool) {
+	if !duplicate {
+		delete(c.duplicateLeaderObservations, database)
+		return 0, false
+	}
+	if c.duplicateLeaderObservations == nil {
+		c.duplicateLeaderObservations = make(map[string]int)
+	}
+
+	c.duplicateLeaderObservations[database]++
+	count := c.duplicateLeaderObservations[database]
+	return count, count >= maxDuplicateLeaderObservations
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -466,6 +482,31 @@ func validateRaftHeader(data map[string]any, dbCID string) error {
 	return nil
 }
 
+func checkDuplicateDBLeader(cfg *Configuration, localLeader bool, component, database string) {
+	var remoteLeader string
+	if localLeader {
+		for addr := range slices.Values(cfg.remoteAddresses) {
+			if isDBLeader(addr, database) {
+				remoteLeader = addr
+				break
+			}
+		}
+	}
+
+	count, confirmed := cfg.observeDuplicateLeader(database, remoteLeader != "")
+	if remoteLeader == "" {
+		return
+	}
+	if !confirmed {
+		klog.Warningf("found another %s leader at %s (%d/%d consecutive observations), waiting for raft convergence",
+			component, remoteLeader, count, maxDuplicateLeaderObservations)
+		return
+	}
+
+	klog.Fatalf("found another %s leader at %s for %d consecutive observations, exiting process to restart",
+		component, remoteLeader, count)
+}
+
 func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 	if podName == "" || podNamespace == "" {
 		util.LogFatalAndExit(nil, "env variables POD_NAME and POD_NAMESPACE must be set")
@@ -529,14 +570,8 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			}
 		}
 
-		for addr := range slices.Values(cfg.remoteAddresses) {
-			if nbLeader && isDBLeader(addr, ovnnb.DatabaseName) {
-				klog.Fatalf("found another ovn-nb leader at %s, exiting process to restart", addr)
-			}
-			if sbLeader && isDBLeader(addr, ovnsb.DatabaseName) {
-				klog.Fatalf("found another ovn-sb leader at %s, exiting process to restart", addr)
-			}
-		}
+		checkDuplicateDBLeader(cfg, nbLeader, "ovn-nb", ovnnb.DatabaseName)
+		checkDuplicateDBLeader(cfg, sbLeader, "ovn-sb", ovnsb.DatabaseName)
 
 		if cfg.EnableCompact {
 			compactOvnDatabase("nb")
@@ -564,14 +599,8 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 			}
 		}
 
-		for addr := range slices.Values(cfg.remoteAddresses) {
-			if icNbLeader && isDBLeader(addr, util.DatabaseICNB) {
-				klog.Fatalf("found another ovn-ic-nb leader at %s, exiting process to restart", addr)
-			}
-			if icSbLeader && isDBLeader(addr, util.DatabaseICSB) {
-				klog.Fatalf("found another ovn-ic-sb leader at %s, exiting process to restart", addr)
-			}
-		}
+		checkDuplicateDBLeader(cfg, icNbLeader, "ovn-ic-nb", util.DatabaseICNB)
+		checkDuplicateDBLeader(cfg, icSbLeader, "ovn-ic-sb", util.DatabaseICSB)
 	}
 }
 

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -62,7 +62,7 @@ type Configuration struct {
 	duplicateLeaderObservations map[string]int
 }
 
-func (c *Configuration) observeDuplicateLeader(database string, duplicate bool, requiredObservations int) (int, bool) {
+func (c *Configuration) observeDuplicateLeader(database string, duplicate bool) (int, bool) {
 	if !duplicate {
 		delete(c.duplicateLeaderObservations, database)
 		return 0, false
@@ -73,7 +73,7 @@ func (c *Configuration) observeDuplicateLeader(database string, duplicate bool, 
 
 	c.duplicateLeaderObservations[database]++
 	count := c.duplicateLeaderObservations[database]
-	return count, count >= requiredObservations
+	return count, count >= maxDuplicateLeaderObservations
 }
 
 // ParseFlags parses cmd args then init kubeclient and conf
@@ -483,7 +483,6 @@ func checkDuplicateDBLeader(
 	localLeader bool,
 	localQueryErr error,
 	component, database string,
-	requiredObservations int,
 	queryLeader dbLeaderQueryFunc,
 ) {
 	if localQueryErr != nil {
@@ -491,7 +490,7 @@ func checkDuplicateDBLeader(
 		return
 	}
 	if !localLeader {
-		cfg.observeDuplicateLeader(database, false, requiredObservations)
+		cfg.observeDuplicateLeader(database, false)
 		return
 	}
 
@@ -512,20 +511,66 @@ func checkDuplicateDBLeader(
 
 	if remoteLeader == "" {
 		if !remoteQueryFailed {
-			cfg.observeDuplicateLeader(database, false, requiredObservations)
+			cfg.observeDuplicateLeader(database, false)
 		}
 		return
 	}
 
-	count, confirmed := cfg.observeDuplicateLeader(database, true, requiredObservations)
+	count, confirmed := cfg.observeDuplicateLeader(database, true)
 	if !confirmed {
 		klog.Warningf("found another %s leader at %s (%d/%d consecutive observations), waiting for raft convergence",
-			component, remoteLeader, count, requiredObservations)
+			component, remoteLeader, count, maxDuplicateLeaderObservations)
 		return
 	}
 
 	klog.Fatalf("found another %s leader at %s for %d consecutive observations, exiting process to restart",
 		component, remoteLeader, count)
+}
+
+func doICDBLeaderCheck(cfg *Configuration, podName, podNamespace string) {
+	icNbLeader, icNbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICNB)
+	icSbLeader, icSbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICSB)
+	if icNbLeaderErr != nil {
+		klog.Error(icNbLeaderErr)
+	}
+	if icSbLeaderErr != nil {
+		klog.Error(icSbLeaderErr)
+	}
+
+	patch := util.KVPatch{
+		"ovn-ic-nb-leader": strconv.FormatBool(icNbLeader),
+		"ovn-ic-sb-leader": strconv.FormatBool(icSbLeader),
+	}
+	if err := util.PatchLabels(cfg.KubeClient.CoreV1().Pods(podNamespace), podName, patch); err != nil {
+		klog.Errorf("failed to patch labels for pod %s/%s: %v", podNamespace, podName, err)
+		return
+	}
+
+	if icNbLeader {
+		if err := updateTS(); err != nil {
+			klog.Errorf("update ts num failed err: %v", err)
+			return
+		}
+	}
+
+	for addr := range slices.Values(cfg.remoteAddresses) {
+		if icNbLeader {
+			remoteLeader, err := isDBLeader(addr, util.DatabaseICNB)
+			if err != nil {
+				klog.Error(err)
+			} else if remoteLeader {
+				klog.Fatalf("found another ovn-ic-nb leader at %s, exiting process to restart", addr)
+			}
+		}
+		if icSbLeader {
+			remoteLeader, err := isDBLeader(addr, util.DatabaseICSB)
+			if err != nil {
+				klog.Error(err)
+			} else if remoteLeader {
+				klog.Fatalf("found another ovn-ic-sb leader at %s, exiting process to restart", addr)
+			}
+		}
+	}
 }
 
 func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
@@ -574,8 +619,8 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 
 		nbLeader, nbLeaderErr := isDBLeader(cfg.localAddress, ovnnb.DatabaseName)
 		sbLeader, sbLeaderErr := isDBLeader(cfg.localAddress, ovnsb.DatabaseName)
-		checkDuplicateDBLeader(cfg, nbLeader, nbLeaderErr, "ovn-nb", ovnnb.DatabaseName, maxDuplicateLeaderObservations, isDBLeader)
-		checkDuplicateDBLeader(cfg, sbLeader, sbLeaderErr, "ovn-sb", ovnsb.DatabaseName, maxDuplicateLeaderObservations, isDBLeader)
+		checkDuplicateDBLeader(cfg, nbLeader, nbLeaderErr, "ovn-nb", ovnnb.DatabaseName, isDBLeader)
+		checkDuplicateDBLeader(cfg, sbLeader, sbLeaderErr, "ovn-sb", ovnsb.DatabaseName, isDBLeader)
 
 		northdActive := checkNorthdActive()
 		patch := util.KVPatch{
@@ -602,37 +647,7 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 		backupRaftHeader("nb")
 		backupRaftHeader("sb")
 	} else {
-		icNbLeader, icNbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICNB)
-		icSbLeader, icSbLeaderErr := isDBLeader(cfg.localAddress, util.DatabaseICSB)
-		if icNbLeaderErr != nil {
-			klog.Error(icNbLeaderErr)
-		}
-		if icSbLeaderErr != nil {
-			klog.Error(icSbLeaderErr)
-		}
-
-		patch := util.KVPatch{
-			"ovn-ic-nb-leader": strconv.FormatBool(icNbLeader),
-			"ovn-ic-sb-leader": strconv.FormatBool(icSbLeader),
-		}
-		if err := util.PatchLabels(cfg.KubeClient.CoreV1().Pods(podNamespace), podName, patch); err != nil {
-			klog.Errorf("failed to patch labels for pod %s/%s: %v", podNamespace, podName, err)
-			return
-		}
-
-		if icNbLeader {
-			if err := updateTS(); err != nil {
-				klog.Errorf("update ts num failed err: %v", err)
-				return
-			}
-		}
-
-		if icNbLeaderErr == nil {
-			checkDuplicateDBLeader(cfg, icNbLeader, nil, "ovn-ic-nb", util.DatabaseICNB, 1, isDBLeader)
-		}
-		if icSbLeaderErr == nil {
-			checkDuplicateDBLeader(cfg, icSbLeader, nil, "ovn-ic-sb", util.DatabaseICSB, 1, isDBLeader)
-		}
+		doICDBLeaderCheck(cfg, podName, podNamespace)
 	}
 }
 

--- a/pkg/ovn_leader_checker/ovn_test.go
+++ b/pkg/ovn_leader_checker/ovn_test.go
@@ -24,7 +24,7 @@ func TestObserveDuplicateLeaderRequiresConsecutiveObservations(t *testing.T) {
 	cfg := &Configuration{}
 
 	for i := 1; i < maxDuplicateLeaderObservations; i++ {
-		count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true)
+		count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true, maxDuplicateLeaderObservations)
 		if confirmed {
 			t.Fatalf("duplicate leader confirmed after only %d observations", i)
 		}
@@ -33,19 +33,24 @@ func TestObserveDuplicateLeaderRequiresConsecutiveObservations(t *testing.T) {
 		}
 	}
 
-	count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, false)
+	count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, false, maxDuplicateLeaderObservations)
 	if confirmed || count != 0 {
 		t.Fatalf("normal leader observation did not reset state: count = %d, confirmed = %t", count, confirmed)
 	}
 
 	for i := 1; i <= maxDuplicateLeaderObservations; i++ {
-		count, confirmed = cfg.observeDuplicateLeader(ovnnb.DatabaseName, true)
+		count, confirmed = cfg.observeDuplicateLeader(ovnnb.DatabaseName, true, maxDuplicateLeaderObservations)
 		if count != i {
 			t.Fatalf("unexpected duplicate leader observation count after reset: got %d, want %d", count, i)
 		}
 		if confirmed != (i == maxDuplicateLeaderObservations) {
 			t.Fatalf("confirmation after observation %d: got %t, want %t", i, confirmed, i == maxDuplicateLeaderObservations)
 		}
+	}
+
+	count, confirmed = cfg.observeDuplicateLeader(ovnsb.DatabaseName, true, 1)
+	if count != 1 || !confirmed {
+		t.Fatalf("single required observation was not confirmed: count = %d, confirmed = %t", count, confirmed)
 	}
 }
 
@@ -81,12 +86,12 @@ func TestCheckDuplicateDBLeaderPreservesObservationsOnUnknownResult(t *testing.T
 				},
 			}
 
-			checkDuplicateDBLeader(cfg, tt.localLeader, tt.localQueryErr, "ovn-nb", ovnnb.DatabaseName, tt.queryLeader)
+			checkDuplicateDBLeader(cfg, tt.localLeader, tt.localQueryErr, "ovn-nb", ovnnb.DatabaseName, maxDuplicateLeaderObservations, tt.queryLeader)
 
 			if got := cfg.duplicateLeaderObservations[ovnnb.DatabaseName]; got != 2 {
 				t.Fatalf("unknown leader result changed observation count: got %d, want 2", got)
 			}
-			if count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true); count != 3 || !confirmed {
+			if count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true, maxDuplicateLeaderObservations); count != 3 || !confirmed {
 				t.Fatalf("duplicate observation after unknown result was not confirmed: count = %d, confirmed = %t", count, confirmed)
 			}
 		})
@@ -123,7 +128,7 @@ func TestCheckDuplicateDBLeaderResetsOnlyConfirmedNormalObservation(t *testing.T
 				},
 			}
 
-			checkDuplicateDBLeader(cfg, tt.localLeader, nil, "ovn-nb", ovnnb.DatabaseName, tt.queryLeader)
+			checkDuplicateDBLeader(cfg, tt.localLeader, nil, "ovn-nb", ovnnb.DatabaseName, maxDuplicateLeaderObservations, tt.queryLeader)
 
 			if _, ok := cfg.duplicateLeaderObservations[ovnnb.DatabaseName]; ok {
 				t.Fatal("confirmed normal observation did not reset the database count")

--- a/pkg/ovn_leader_checker/ovn_test.go
+++ b/pkg/ovn_leader_checker/ovn_test.go
@@ -24,7 +24,7 @@ func TestObserveDuplicateLeaderRequiresConsecutiveObservations(t *testing.T) {
 	cfg := &Configuration{}
 
 	for i := 1; i < maxDuplicateLeaderObservations; i++ {
-		count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true, maxDuplicateLeaderObservations)
+		count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true)
 		if confirmed {
 			t.Fatalf("duplicate leader confirmed after only %d observations", i)
 		}
@@ -33,24 +33,19 @@ func TestObserveDuplicateLeaderRequiresConsecutiveObservations(t *testing.T) {
 		}
 	}
 
-	count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, false, maxDuplicateLeaderObservations)
+	count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, false)
 	if confirmed || count != 0 {
 		t.Fatalf("normal leader observation did not reset state: count = %d, confirmed = %t", count, confirmed)
 	}
 
 	for i := 1; i <= maxDuplicateLeaderObservations; i++ {
-		count, confirmed = cfg.observeDuplicateLeader(ovnnb.DatabaseName, true, maxDuplicateLeaderObservations)
+		count, confirmed = cfg.observeDuplicateLeader(ovnnb.DatabaseName, true)
 		if count != i {
 			t.Fatalf("unexpected duplicate leader observation count after reset: got %d, want %d", count, i)
 		}
 		if confirmed != (i == maxDuplicateLeaderObservations) {
 			t.Fatalf("confirmation after observation %d: got %t, want %t", i, confirmed, i == maxDuplicateLeaderObservations)
 		}
-	}
-
-	count, confirmed = cfg.observeDuplicateLeader(ovnsb.DatabaseName, true, 1)
-	if count != 1 || !confirmed {
-		t.Fatalf("single required observation was not confirmed: count = %d, confirmed = %t", count, confirmed)
 	}
 }
 
@@ -86,12 +81,12 @@ func TestCheckDuplicateDBLeaderPreservesObservationsOnUnknownResult(t *testing.T
 				},
 			}
 
-			checkDuplicateDBLeader(cfg, tt.localLeader, tt.localQueryErr, "ovn-nb", ovnnb.DatabaseName, maxDuplicateLeaderObservations, tt.queryLeader)
+			checkDuplicateDBLeader(cfg, tt.localLeader, tt.localQueryErr, "ovn-nb", ovnnb.DatabaseName, tt.queryLeader)
 
 			if got := cfg.duplicateLeaderObservations[ovnnb.DatabaseName]; got != 2 {
 				t.Fatalf("unknown leader result changed observation count: got %d, want 2", got)
 			}
-			if count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true, maxDuplicateLeaderObservations); count != 3 || !confirmed {
+			if count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true); count != 3 || !confirmed {
 				t.Fatalf("duplicate observation after unknown result was not confirmed: count = %d, confirmed = %t", count, confirmed)
 			}
 		})
@@ -128,7 +123,7 @@ func TestCheckDuplicateDBLeaderResetsOnlyConfirmedNormalObservation(t *testing.T
 				},
 			}
 
-			checkDuplicateDBLeader(cfg, tt.localLeader, nil, "ovn-nb", ovnnb.DatabaseName, maxDuplicateLeaderObservations, tt.queryLeader)
+			checkDuplicateDBLeader(cfg, tt.localLeader, nil, "ovn-nb", ovnnb.DatabaseName, tt.queryLeader)
 
 			if _, ok := cfg.duplicateLeaderObservations[ovnnb.DatabaseName]; ok {
 				t.Fatal("confirmed normal observation did not reset the database count")

--- a/pkg/ovn_leader_checker/ovn_test.go
+++ b/pkg/ovn_leader_checker/ovn_test.go
@@ -1,6 +1,7 @@
 package ovn_leader_checker
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnsb"
 )
 
 const (
@@ -44,6 +46,92 @@ func TestObserveDuplicateLeaderRequiresConsecutiveObservations(t *testing.T) {
 		if confirmed != (i == maxDuplicateLeaderObservations) {
 			t.Fatalf("confirmation after observation %d: got %t, want %t", i, confirmed, i == maxDuplicateLeaderObservations)
 		}
+	}
+}
+
+func TestCheckDuplicateDBLeaderPreservesObservationsOnUnknownResult(t *testing.T) {
+	queryErr := errors.New("leader query failed")
+	tests := []struct {
+		name            string
+		localLeader     bool
+		localQueryErr   error
+		remoteAddresses []string
+		queryLeader     dbLeaderQueryFunc
+	}{
+		{
+			name:          "local query failure",
+			localQueryErr: queryErr,
+		},
+		{
+			name:            "remote query failure",
+			localLeader:     true,
+			remoteAddresses: []string{"10.0.0.2"},
+			queryLeader: func(_, _ string) (bool, error) {
+				return false, queryErr
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Configuration{
+				remoteAddresses: tt.remoteAddresses,
+				duplicateLeaderObservations: map[string]int{
+					ovnnb.DatabaseName: 2,
+				},
+			}
+
+			checkDuplicateDBLeader(cfg, tt.localLeader, tt.localQueryErr, "ovn-nb", ovnnb.DatabaseName, tt.queryLeader)
+
+			if got := cfg.duplicateLeaderObservations[ovnnb.DatabaseName]; got != 2 {
+				t.Fatalf("unknown leader result changed observation count: got %d, want 2", got)
+			}
+			if count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true); count != 3 || !confirmed {
+				t.Fatalf("duplicate observation after unknown result was not confirmed: count = %d, confirmed = %t", count, confirmed)
+			}
+		})
+	}
+}
+
+func TestCheckDuplicateDBLeaderResetsOnlyConfirmedNormalObservation(t *testing.T) {
+	tests := []struct {
+		name            string
+		localLeader     bool
+		remoteAddresses []string
+		queryLeader     dbLeaderQueryFunc
+	}{
+		{
+			name: "local server is not leader",
+		},
+		{
+			name:            "all remote servers are not leaders",
+			localLeader:     true,
+			remoteAddresses: []string{"10.0.0.2", "10.0.0.3"},
+			queryLeader: func(_, _ string) (bool, error) {
+				return false, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Configuration{
+				remoteAddresses: tt.remoteAddresses,
+				duplicateLeaderObservations: map[string]int{
+					ovnnb.DatabaseName: 2,
+					ovnsb.DatabaseName: 1,
+				},
+			}
+
+			checkDuplicateDBLeader(cfg, tt.localLeader, nil, "ovn-nb", ovnnb.DatabaseName, tt.queryLeader)
+
+			if _, ok := cfg.duplicateLeaderObservations[ovnnb.DatabaseName]; ok {
+				t.Fatal("confirmed normal observation did not reset the database count")
+			}
+			if got := cfg.duplicateLeaderObservations[ovnsb.DatabaseName]; got != 1 {
+				t.Fatalf("reset changed another database count: got %d, want 1", got)
+			}
+		})
 	}
 }
 

--- a/pkg/ovn_leader_checker/ovn_test.go
+++ b/pkg/ovn_leader_checker/ovn_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
 
 const (
@@ -15,6 +17,35 @@ const (
 	zeroClusterID  = "00000000-0000-0000-0000-000000000000"
 	otherClusterID = "d401ddf6-deac-4e26-aeb5-cc4ce07f6515"
 )
+
+func TestObserveDuplicateLeaderRequiresConsecutiveObservations(t *testing.T) {
+	cfg := &Configuration{}
+
+	for i := 1; i < maxDuplicateLeaderObservations; i++ {
+		count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, true)
+		if confirmed {
+			t.Fatalf("duplicate leader confirmed after only %d observations", i)
+		}
+		if count != i {
+			t.Fatalf("unexpected duplicate leader observation count: got %d, want %d", count, i)
+		}
+	}
+
+	count, confirmed := cfg.observeDuplicateLeader(ovnnb.DatabaseName, false)
+	if confirmed || count != 0 {
+		t.Fatalf("normal leader observation did not reset state: count = %d, confirmed = %t", count, confirmed)
+	}
+
+	for i := 1; i <= maxDuplicateLeaderObservations; i++ {
+		count, confirmed = cfg.observeDuplicateLeader(ovnnb.DatabaseName, true)
+		if count != i {
+			t.Fatalf("unexpected duplicate leader observation count after reset: got %d, want %d", count, i)
+		}
+		if confirmed != (i == maxDuplicateLeaderObservations) {
+			t.Fatalf("confirmation after observation %d: got %t, want %t", i, confirmed, i == maxDuplicateLeaderObservations)
+		}
+	}
+}
 
 func TestBackupRaftHeaderDoesNotReplaceValidHeaderWithZeroClusterID(t *testing.T) {
 	dbDir := t.TempDir()


### PR DESCRIPTION
Backport of #7138 to `release-1.15`.

Require three consecutive duplicate-leader observations before `ovn-leader-checker` restarts `ovn-central`. A confirmed normal observation resets the counter independently for each OVN database, while query errors preserve the current count. OVN-IC keeps its existing immediate duplicate-leader restart behavior.

## Verification

- `go test ./pkg/ovn_leader_checker -count=1`
- `go test -race ./pkg/ovn_leader_checker -count=1`
- `go vet ./pkg/ovn_leader_checker`
- `golangci-lint run --concurrency 2 ./pkg/ovn_leader_checker/...`
- Duplicate-leader regression tests repeated 100 times
- `git diff --check origin/release-1.15...HEAD`