### PR TITLE
feat: reconcile OVN ACL sampling objects

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	aclsampling "github.com/kubeovn/kube-ovn/pkg/aclsampling"
 	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	ovs "github.com/kubeovn/kube-ovn/pkg/ovs"
 	ovnnb "github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -2472,6 +2473,44 @@ func (m *MockACL) UpdateSgACL(sg *v1.SecurityGroup, direction string) error {
 func (mr *MockACLMockRecorder) UpdateSgACL(sg, direction any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSgACL", reflect.TypeOf((*MockACL)(nil).UpdateSgACL), sg, direction)
+}
+
+// MockACLSampling is a mock of ACLSampling interface.
+type MockACLSampling struct {
+	ctrl     *gomock.Controller
+	recorder *MockACLSamplingMockRecorder
+	isgomock struct{}
+}
+
+// MockACLSamplingMockRecorder is the mock recorder for MockACLSampling.
+type MockACLSamplingMockRecorder struct {
+	mock *MockACLSampling
+}
+
+// NewMockACLSampling creates a new mock instance.
+func NewMockACLSampling(ctrl *gomock.Controller) *MockACLSampling {
+	mock := &MockACLSampling{ctrl: ctrl}
+	mock.recorder = &MockACLSamplingMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockACLSampling) EXPECT() *MockACLSamplingMockRecorder {
+	return m.recorder
+}
+
+// ReconcileACLSampling mocks base method.
+func (m *MockACLSampling) ReconcileACLSampling(config aclsampling.ControllerConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileACLSampling", config)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileACLSampling indicates an expected call of ReconcileACLSampling.
+func (mr *MockACLSamplingMockRecorder) ReconcileACLSampling(config any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileACLSampling", reflect.TypeOf((*MockACLSampling)(nil).ReconcileACLSampling), config)
 }
 
 // MockAddressSet is a mock of AddressSet interface.
@@ -5434,10 +5473,24 @@ func (m *MockNbClient) ReconcileGatewayChassises(lrpName string, chassises []str
 	return ret0
 }
 
+// ReconcileACLSampling mocks base method.
+func (m *MockNbClient) ReconcileACLSampling(config aclsampling.ControllerConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileACLSampling", config)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
 // ReconcileGatewayChassises indicates an expected call of ReconcileGatewayChassises.
 func (mr *MockNbClientMockRecorder) ReconcileGatewayChassises(lrpName, chassises any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileGatewayChassises", reflect.TypeOf((*MockNbClient)(nil).ReconcileGatewayChassises), lrpName, chassises)
+}
+
+// ReconcileACLSampling indicates an expected call of ReconcileACLSampling.
+func (mr *MockNbClientMockRecorder) ReconcileACLSampling(config any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileACLSampling", reflect.TypeOf((*MockNbClient)(nil).ReconcileACLSampling), config)
 }
 
 // ReconcilePortDHCPOptions mocks base method.

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -8,6 +8,7 @@ import (
 	v1alpha1 "sigs.k8s.io/network-policy-api/apis/v1alpha1"
 	v1alpha2 "sigs.k8s.io/network-policy-api/apis/v1alpha2"
 
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnsb"
@@ -198,6 +199,10 @@ type ACL interface {
 	CleanNoParentKeyAcls() error
 }
 
+type ACLSampling interface {
+	ReconcileACLSampling(config aclsampling.ControllerConfig) error
+}
+
 type AddressSet interface {
 	CreateAddressSet(asName string, externalIDs map[string]string) error
 	AddressSetUpdateAddress(asName string, addresses ...string) error
@@ -265,6 +270,7 @@ type Meter interface {
 
 type NbClient interface {
 	ACL
+	ACLSampling
 	AddressSet
 	BFD
 	DHCPOptions

--- a/pkg/ovs/ovn-nb-acl-sampling.go
+++ b/pkg/ovs/ovn-nb-acl-sampling.go
@@ -56,8 +56,14 @@ func (c *OVNNbClient) ReconcileACLSampling(config aclsampling.ControllerConfig) 
 		return err
 	}
 
-	allowProbability, _ := aclsampling.ProbabilityFromPercent(config.AllowProbabilityPercent)
-	defaultDenyProbability, _ := aclsampling.ProbabilityFromPercent(config.DefaultDenyProbabilityPercent)
+	allowProbability, err := aclsampling.ProbabilityFromPercent(config.AllowProbabilityPercent)
+	if err != nil {
+		return fmt.Errorf("convert allow sampling probability: %w", err)
+	}
+	defaultDenyProbability, err := aclsampling.ProbabilityFromPercent(config.DefaultDenyProbabilityPercent)
+	if err != nil {
+		return fmt.Errorf("convert default-deny sampling probability: %w", err)
+	}
 
 	apps, err := c.listSamplingApps()
 	if err != nil {

--- a/pkg/ovs/ovn-nb-acl-sampling.go
+++ b/pkg/ovs/ovn-nb-acl-sampling.go
@@ -1,0 +1,313 @@
+package ovs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+
+	"github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+var ErrACLSamplingUnsupported = errors.New("OVN northbound ACL sampling is unsupported")
+
+const (
+	aclSamplingFeatureExternalID = "kube-ovn.io/feature"
+	aclSamplingFeature           = "acl-sampling"
+	aclSamplingKindExternalID    = "kube-ovn.io/acl-sampling-kind"
+	aclSamplingRoleExternalID    = "kube-ovn.io/acl-sampling-role"
+
+	aclSamplingKindApplication = "application"
+	aclSamplingKindCollector   = "collector"
+	aclSamplingRoleAllow       = "allow"
+	aclSamplingRoleDefaultDeny = "default-deny"
+)
+
+type desiredSamplingApp struct {
+	appType ovnnb.SamplingAppType
+	id      uint32
+}
+
+type desiredSampleCollector struct {
+	role        string
+	id          uint32
+	name        string
+	probability int
+}
+
+// ReconcileACLSampling idempotently creates or reconciles the OVN sampling
+// applications and collectors owned by Kube-OVN. Matching unowned
+// Sampling_App rows are reused without modification; unowned collectors are
+// never adopted.
+func (c *OVNNbClient) ReconcileACLSampling(config aclsampling.ControllerConfig) error {
+	if !config.Enabled {
+		return nil
+	}
+	if err := config.Validate(); err != nil {
+		return fmt.Errorf("invalid ACL sampling configuration: %w", err)
+	}
+	if err := c.ensureACLSamplingMonitor(); err != nil {
+		return err
+	}
+
+	allowProbability, _ := aclsampling.ProbabilityFromPercent(config.AllowProbabilityPercent)
+	defaultDenyProbability, _ := aclsampling.ProbabilityFromPercent(config.DefaultDenyProbabilityPercent)
+
+	apps, err := c.listSamplingApps()
+	if err != nil {
+		return err
+	}
+	collectors, err := c.listSampleCollectors()
+	if err != nil {
+		return err
+	}
+
+	desiredApps := []desiredSamplingApp{
+		{appType: ovnnb.SamplingAppTypeACLNew, id: config.AppIDNew},
+		{appType: ovnnb.SamplingAppTypeACLEst, id: config.AppIDEstablished},
+	}
+	desiredAppIDs := make(map[ovnnb.SamplingAppType]uint32, len(desiredApps))
+	for _, desired := range desiredApps {
+		desiredAppIDs[desired.appType] = desired.id
+	}
+
+	operations := make([]ovsdb.Operation, 0, 8)
+	for _, desired := range desiredApps {
+		ops, err := c.reconcileSamplingApp(apps, desired, desiredAppIDs)
+		if err != nil {
+			return err
+		}
+		operations = append(operations, ops...)
+	}
+
+	desiredCollectors := []desiredSampleCollector{
+		{
+			role:        aclSamplingRoleAllow,
+			id:          config.CollectorIDAllow,
+			name:        "kube-ovn-network-policy-allow",
+			probability: allowProbability,
+		},
+		{
+			role:        aclSamplingRoleDefaultDeny,
+			id:          config.CollectorIDDefaultDeny,
+			name:        "kube-ovn-network-policy-default-deny",
+			probability: defaultDenyProbability,
+		},
+	}
+	desiredCollectorIDs := make(map[string]uint32, len(desiredCollectors))
+	for _, desired := range desiredCollectors {
+		desiredCollectorIDs[desired.role] = desired.id
+	}
+	for _, desired := range desiredCollectors {
+		ops, err := c.reconcileSampleCollector(collectors, desired, desiredCollectorIDs, config.SetID)
+		if err != nil {
+			return err
+		}
+		operations = append(operations, ops...)
+	}
+
+	if err := c.Transact("acl-sampling-reconcile", operations); err != nil {
+		return fmt.Errorf("reconcile OVN ACL sampling objects: %w", err)
+	}
+	return nil
+}
+
+func (c *OVNNbClient) ensureACLSamplingMonitor() error {
+	c.aclSamplingMonitorMu.Lock()
+	defer c.aclSamplingMonitorMu.Unlock()
+
+	if c.aclSamplingMonitored {
+		return nil
+	}
+	if err := validateACLSamplingSchema(c.Schema()); err != nil {
+		return err
+	}
+
+	monitor := c.NewMonitor(
+		client.WithTable(&ovnnb.SamplingApp{}),
+		client.WithTable(&ovnnb.SampleCollector{}),
+		client.WithTable(&ovnnb.Sample{}),
+	)
+	if len(monitor.Errors) != 0 {
+		return fmt.Errorf("build OVN ACL sampling monitor: %w", errors.Join(monitor.Errors...))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	if _, err := c.Monitor(ctx, monitor); err != nil {
+		return fmt.Errorf("monitor OVN ACL sampling tables: %w", err)
+	}
+	c.aclSamplingMonitored = true
+	return nil
+}
+
+func validateACLSamplingSchema(schema ovsdb.DatabaseSchema) error {
+	required := map[string][]string{
+		ovnnb.ACLTable:             {"external_ids", "sample_new", "sample_est"},
+		ovnnb.SamplingAppTable:     {"external_ids", "id", "type"},
+		ovnnb.SampleCollectorTable: {"external_ids", "id", "name", "probability", "set_id"},
+		ovnnb.SampleTable:          {"collectors", "metadata"},
+	}
+	for tableName, columns := range required {
+		table, ok := schema.Tables[tableName]
+		if !ok {
+			return fmt.Errorf("%w: table %s is missing", ErrACLSamplingUnsupported, tableName)
+		}
+		for _, column := range columns {
+			if _, ok := table.Columns[column]; !ok {
+				return fmt.Errorf("%w: column %s.%s is missing", ErrACLSamplingUnsupported, tableName, column)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *OVNNbClient) listSamplingApps() ([]ovnnb.SamplingApp, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	apps := make([]ovnnb.SamplingApp, 0)
+	if err := c.WhereCache(func(*ovnnb.SamplingApp) bool { return true }).List(ctx, &apps); err != nil {
+		return nil, fmt.Errorf("list OVN sampling applications: %w", err)
+	}
+	return apps, nil
+}
+
+func (c *OVNNbClient) listSampleCollectors() ([]ovnnb.SampleCollector, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	collectors := make([]ovnnb.SampleCollector, 0)
+	if err := c.WhereCache(func(*ovnnb.SampleCollector) bool { return true }).List(ctx, &collectors); err != nil {
+		return nil, fmt.Errorf("list OVN sample collectors: %w", err)
+	}
+	return collectors, nil
+}
+
+func (c *OVNNbClient) reconcileSamplingApp(apps []ovnnb.SamplingApp, desired desiredSamplingApp, desiredIDs map[ovnnb.SamplingAppType]uint32) ([]ovsdb.Operation, error) {
+	var current *ovnnb.SamplingApp
+	for i := range apps {
+		app := &apps[i]
+		if app.ID == int(desired.id) && app.Type != desired.appType {
+			targetID, managed := desiredIDs[app.Type]
+			if !isOwnedACLSamplingObject(app.ExternalIDs) || !managed || targetID == desired.id {
+				return nil, fmt.Errorf("sampling application ID %d is already used by type %s", desired.id, app.Type)
+			}
+		}
+		if app.Type == desired.appType {
+			current = app
+		}
+	}
+
+	desiredExternalIDs := ownedACLSamplingExternalIDs(aclSamplingKindApplication, desired.appType)
+	if current == nil {
+		app := &ovnnb.SamplingApp{
+			UUID:        ovsclient.NamedUUID(),
+			ExternalIDs: desiredExternalIDs,
+			ID:          int(desired.id),
+			Type:        desired.appType,
+		}
+		ops, err := c.Create(app)
+		if err != nil {
+			return nil, fmt.Errorf("build create operation for sampling application %s: %w", desired.appType, err)
+		}
+		return ops, nil
+	}
+
+	if !isOwnedACLSamplingObject(current.ExternalIDs) {
+		if current.ID != int(desired.id) {
+			return nil, fmt.Errorf("unowned sampling application %s uses ID %d instead of configured ID %d", current.Type, current.ID, desired.id)
+		}
+		return nil, nil
+	}
+	if current.ID == int(desired.id) && maps.Equal(current.ExternalIDs, desiredExternalIDs) {
+		return nil, nil
+	}
+
+	current.ID = int(desired.id)
+	current.ExternalIDs = desiredExternalIDs
+	ops, err := c.Where(current).Update(current, &current.ID, &current.ExternalIDs)
+	if err != nil {
+		return nil, fmt.Errorf("build update operation for sampling application %s: %w", desired.appType, err)
+	}
+	return ops, nil
+}
+
+func (c *OVNNbClient) reconcileSampleCollector(collectors []ovnnb.SampleCollector, desired desiredSampleCollector, desiredIDs map[string]uint32, setID uint32) ([]ovsdb.Operation, error) {
+	var current *ovnnb.SampleCollector
+	for i := range collectors {
+		collector := &collectors[i]
+		ownedRole := collector.ExternalIDs[aclSamplingRoleExternalID]
+		if collector.ID == int(desired.id) && (!isOwnedACLSamplingObject(collector.ExternalIDs) || ownedRole != desired.role) {
+			targetID, managed := desiredIDs[ownedRole]
+			if !isOwnedACLSamplingObject(collector.ExternalIDs) || !managed || targetID == desired.id {
+				return nil, fmt.Errorf("sample collector ID %d is owned by another application", desired.id)
+			}
+		}
+		if isOwnedACLSamplingObject(collector.ExternalIDs) && ownedRole == desired.role {
+			if current != nil {
+				return nil, fmt.Errorf("multiple owned sample collectors have role %s", desired.role)
+			}
+			current = collector
+		}
+	}
+
+	desiredExternalIDs := ownedACLSamplingExternalIDs(aclSamplingKindCollector, desired.role)
+	if current == nil {
+		collector := &ovnnb.SampleCollector{
+			UUID:        ovsclient.NamedUUID(),
+			ExternalIDs: desiredExternalIDs,
+			ID:          int(desired.id),
+			Name:        desired.name,
+			Probability: desired.probability,
+			SetID:       int(setID),
+		}
+		ops, err := c.Create(collector)
+		if err != nil {
+			return nil, fmt.Errorf("build create operation for %s sample collector: %w", desired.role, err)
+		}
+		return ops, nil
+	}
+
+	if current.ID == int(desired.id) && current.Name == desired.name &&
+		current.Probability == desired.probability && current.SetID == int(setID) &&
+		maps.Equal(current.ExternalIDs, desiredExternalIDs) {
+		return nil, nil
+	}
+
+	current.ID = int(desired.id)
+	current.Name = desired.name
+	current.Probability = desired.probability
+	current.SetID = int(setID)
+	current.ExternalIDs = desiredExternalIDs
+	ops, err := c.Where(current).Update(current,
+		&current.ID,
+		&current.Name,
+		&current.Probability,
+		&current.SetID,
+		&current.ExternalIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build update operation for %s sample collector: %w", desired.role, err)
+	}
+	return ops, nil
+}
+
+func ownedACLSamplingExternalIDs(kind, role string) map[string]string {
+	return map[string]string{
+		ExternalIDVendor:             util.CniTypeName,
+		aclSamplingFeatureExternalID: aclSamplingFeature,
+		aclSamplingKindExternalID:    kind,
+		aclSamplingRoleExternalID:    role,
+	}
+}
+
+func isOwnedACLSamplingObject(externalIDs map[string]string) bool {
+	return externalIDs[ExternalIDVendor] == util.CniTypeName &&
+		externalIDs[aclSamplingFeatureExternalID] == aclSamplingFeature
+}

--- a/pkg/ovs/ovn-nb-acl-sampling_test.go
+++ b/pkg/ovs/ovn-nb-acl-sampling_test.go
@@ -1,0 +1,243 @@
+package ovs
+
+import (
+	"fmt"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+)
+
+func newACLSamplingTestClient(t *testing.T, schemaName string) *OVNNbClient {
+	t.Helper()
+	dbModel, err := ovnnb.FullDatabaseModel()
+	require.NoError(t, err)
+	_, socket := newOVSDBServer(t, fmt.Sprintf("acl-sampling-%s-%d", schemaName, time.Now().UnixNano()), dbModel, ovnnb.Schema())
+	client, err := newOvnNbClient(t, "unix:"+socket, 3)
+	require.NoError(t, err)
+	return client
+}
+
+func validACLSamplingConfig() aclsampling.ControllerConfig {
+	return aclsampling.ControllerConfig{
+		Enabled:                       true,
+		SetID:                         aclsampling.DefaultSetID,
+		AppIDNew:                      aclsampling.DefaultAppIDNew,
+		AppIDEstablished:              aclsampling.DefaultAppIDEstablished,
+		CollectorIDAllow:              aclsampling.DefaultCollectorIDAllow,
+		CollectorIDDefaultDeny:        aclsampling.DefaultCollectorIDDefaultDeny,
+		AllowProbabilityPercent:       aclsampling.DefaultAllowProbabilityPercent,
+		DefaultDenyProbabilityPercent: aclsampling.DefaultDefaultDenyProbabilityPercent,
+	}
+}
+
+func TestReconcileACLSamplingCreatesAndReusesObjects(t *testing.T) {
+	client := newACLSamplingTestClient(t, "create")
+	config := validACLSamplingConfig()
+
+	require.NoError(t, client.ReconcileACLSampling(config))
+	apps, collectors := waitForACLSamplingObjects(t, client)
+	require.Len(t, apps, 2)
+	require.Len(t, collectors, 2)
+
+	appUUIDs := make(map[string]string, len(apps))
+	for _, app := range apps {
+		appUUIDs[app.Type] = app.UUID
+		require.True(t, isOwnedACLSamplingObject(app.ExternalIDs))
+	}
+	require.Equal(t, int(config.AppIDNew), appByType(t, apps, ovnnb.SamplingAppTypeACLNew).ID)
+	require.Equal(t, int(config.AppIDEstablished), appByType(t, apps, ovnnb.SamplingAppTypeACLEst).ID)
+
+	allow := collectorByRole(t, collectors, aclSamplingRoleAllow)
+	require.Equal(t, int(config.CollectorIDAllow), allow.ID)
+	require.Equal(t, int(config.SetID), allow.SetID)
+	require.Equal(t, 655, allow.Probability)
+	defaultDeny := collectorByRole(t, collectors, aclSamplingRoleDefaultDeny)
+	require.Equal(t, int(config.CollectorIDDefaultDeny), defaultDeny.ID)
+	require.Equal(t, 65535, defaultDeny.Probability)
+
+	require.NoError(t, client.ReconcileACLSampling(config))
+	apps, collectors = waitForACLSamplingObjects(t, client)
+	require.Len(t, apps, 2)
+	require.Len(t, collectors, 2)
+	for _, app := range apps {
+		require.Equal(t, appUUIDs[app.Type], app.UUID)
+	}
+}
+
+func TestReconcileACLSamplingReusesMatchingUnownedApplication(t *testing.T) {
+	client := newACLSamplingTestClient(t, "reuse-app")
+	externalIDs := map[string]string{"owner": "external-observer"}
+	app := &ovnnb.SamplingApp{
+		UUID:        ovsclient.NamedUUID(),
+		ExternalIDs: externalIDs,
+		ID:          int(aclsampling.DefaultAppIDNew),
+		Type:        ovnnb.SamplingAppTypeACLNew,
+	}
+	ops, err := client.Create(app)
+	require.NoError(t, err)
+	require.NoError(t, client.Transact("seed-unowned-sampling-app", ops))
+
+	require.NoError(t, client.ReconcileACLSampling(validACLSamplingConfig()))
+	apps, _ := waitForACLSamplingObjects(t, client)
+	actual := appByType(t, apps, ovnnb.SamplingAppTypeACLNew)
+	require.Equal(t, externalIDs, actual.ExternalIDs)
+}
+
+func TestReconcileACLSamplingRejectsUnownedConflicts(t *testing.T) {
+	t.Run("application type uses another ID", func(t *testing.T) {
+		client := newACLSamplingTestClient(t, "app-conflict")
+		app := &ovnnb.SamplingApp{
+			UUID:        ovsclient.NamedUUID(),
+			ExternalIDs: map[string]string{"owner": "external-observer"},
+			ID:          200,
+			Type:        ovnnb.SamplingAppTypeACLNew,
+		}
+		ops, err := client.Create(app)
+		require.NoError(t, err)
+		require.NoError(t, client.Transact("seed-conflicting-sampling-app", ops))
+
+		err = client.ReconcileACLSampling(validACLSamplingConfig())
+		require.ErrorContains(t, err, "unowned sampling application acl-new uses ID 200")
+	})
+
+	t.Run("collector ID is unowned", func(t *testing.T) {
+		client := newACLSamplingTestClient(t, "collector-conflict")
+		collector := &ovnnb.SampleCollector{
+			UUID:        ovsclient.NamedUUID(),
+			ExternalIDs: map[string]string{"owner": "external-observer"},
+			ID:          int(aclsampling.DefaultCollectorIDAllow),
+			Name:        "external",
+			Probability: 123,
+			SetID:       int(aclsampling.DefaultSetID),
+		}
+		ops, err := client.Create(collector)
+		require.NoError(t, err)
+		require.NoError(t, client.Transact("seed-conflicting-sample-collector", ops))
+
+		err = client.ReconcileACLSampling(validACLSamplingConfig())
+		require.ErrorContains(t, err, "sample collector ID 1 is owned by another application")
+		actual, listErr := client.listSampleCollectors()
+		require.NoError(t, listErr)
+		require.Len(t, actual, 1)
+		require.Equal(t, "external", actual[0].Name)
+		require.Equal(t, 123, actual[0].Probability)
+	})
+}
+
+func TestReconcileACLSamplingUpdatesOwnedObjectsAndSwapsIDs(t *testing.T) {
+	client := newACLSamplingTestClient(t, "update-owned")
+	apps := []*ovnnb.SamplingApp{
+		{
+			UUID:        ovsclient.NamedUUID(),
+			ExternalIDs: ownedACLSamplingExternalIDs(aclSamplingKindApplication, ovnnb.SamplingAppTypeACLNew),
+			ID:          int(aclsampling.DefaultAppIDEstablished),
+			Type:        ovnnb.SamplingAppTypeACLNew,
+		},
+		{
+			UUID:        ovsclient.NamedUUID(),
+			ExternalIDs: ownedACLSamplingExternalIDs(aclSamplingKindApplication, ovnnb.SamplingAppTypeACLEst),
+			ID:          int(aclsampling.DefaultAppIDNew),
+			Type:        ovnnb.SamplingAppTypeACLEst,
+		},
+	}
+	collectors := []*ovnnb.SampleCollector{
+		{
+			UUID:        ovsclient.NamedUUID(),
+			ExternalIDs: ownedACLSamplingExternalIDs(aclSamplingKindCollector, aclSamplingRoleAllow),
+			ID:          int(aclsampling.DefaultCollectorIDDefaultDeny),
+			Name:        "stale-allow",
+			Probability: 10,
+			SetID:       100,
+		},
+		{
+			UUID:        ovsclient.NamedUUID(),
+			ExternalIDs: ownedACLSamplingExternalIDs(aclSamplingKindCollector, aclSamplingRoleDefaultDeny),
+			ID:          int(aclsampling.DefaultCollectorIDAllow),
+			Name:        "stale-deny",
+			Probability: 20,
+			SetID:       100,
+		},
+	}
+
+	operations := make([]ovsdb.Operation, 0, 4)
+	for _, object := range apps {
+		ops, err := client.Create(object)
+		require.NoError(t, err)
+		operations = append(operations, ops...)
+	}
+	for _, object := range collectors {
+		ops, err := client.Create(object)
+		require.NoError(t, err)
+		operations = append(operations, ops...)
+	}
+	require.NoError(t, client.Transact("seed-owned-acl-sampling-objects", operations))
+
+	config := validACLSamplingConfig()
+	require.NoError(t, client.ReconcileACLSampling(config))
+	actualApps, actualCollectors := waitForACLSamplingObjects(t, client)
+	require.Equal(t, int(config.AppIDNew), appByType(t, actualApps, ovnnb.SamplingAppTypeACLNew).ID)
+	require.Equal(t, int(config.AppIDEstablished), appByType(t, actualApps, ovnnb.SamplingAppTypeACLEst).ID)
+	allow := collectorByRole(t, actualCollectors, aclSamplingRoleAllow)
+	require.Equal(t, int(config.CollectorIDAllow), allow.ID)
+	require.Equal(t, 655, allow.Probability)
+	require.Equal(t, int(config.SetID), allow.SetID)
+	defaultDeny := collectorByRole(t, actualCollectors, aclSamplingRoleDefaultDeny)
+	require.Equal(t, int(config.CollectorIDDefaultDeny), defaultDeny.ID)
+	require.Equal(t, 65535, defaultDeny.Probability)
+}
+
+func TestValidateACLSamplingSchema(t *testing.T) {
+	schema := ovnnb.Schema()
+	require.NoError(t, validateACLSamplingSchema(schema))
+
+	delete(schema.Tables, ovnnb.SampleTable)
+	err := validateACLSamplingSchema(schema)
+	require.ErrorIs(t, err, ErrACLSamplingUnsupported)
+	require.ErrorContains(t, err, "table Sample is missing")
+}
+
+func waitForACLSamplingObjects(t *testing.T, client *OVNNbClient) ([]ovnnb.SamplingApp, []ovnnb.SampleCollector) {
+	t.Helper()
+	var apps []ovnnb.SamplingApp
+	var collectors []ovnnb.SampleCollector
+	require.Eventually(t, func() bool {
+		var err error
+		apps, err = client.listSamplingApps()
+		if err != nil || len(apps) != 2 {
+			return false
+		}
+		collectors, err = client.listSampleCollectors()
+		return err == nil && len(collectors) == 2
+	}, time.Second, 10*time.Millisecond)
+	return apps, collectors
+}
+
+func appByType(t *testing.T, apps []ovnnb.SamplingApp, appType string) ovnnb.SamplingApp {
+	t.Helper()
+	for _, app := range apps {
+		if app.Type == appType {
+			return app
+		}
+	}
+	t.Fatalf("sampling application %s not found", appType)
+	return ovnnb.SamplingApp{}
+}
+
+func collectorByRole(t *testing.T, collectors []ovnnb.SampleCollector, role string) ovnnb.SampleCollector {
+	t.Helper()
+	for _, collector := range collectors {
+		if collector.ExternalIDs[aclSamplingRoleExternalID] == role &&
+			maps.Equal(collector.ExternalIDs, ownedACLSamplingExternalIDs(aclSamplingKindCollector, role)) {
+			return collector
+		}
+	}
+	t.Fatalf("sample collector with role %s not found", role)
+	return ovnnb.SampleCollector{}
+}

--- a/pkg/ovs/ovn.go
+++ b/pkg/ovs/ovn.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
@@ -30,6 +31,8 @@ type LegacyClient struct {
 
 type OVNNbClient struct {
 	ovsDbClient
+	aclSamplingMonitorMu sync.Mutex
+	aclSamplingMonitored bool
 }
 
 type OVNSbClient struct {


### PR DESCRIPTION
Related to #7146.

## Summary

- validate runtime OVN ACL sampling schema support before mutation
- dynamically monitor `Sampling_App`, `Sample_Collector`, and `Sample`
- reconcile owned `acl-new` and `acl-est` applications plus separate allow and default-deny collectors
- reuse only matching unowned applications and reject unowned collector or ID conflicts
- preserve object UUIDs across idempotent reconciliation and support owned ID swaps

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. **#7148 — OVN sampling object reconciler**
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-metadata`

## Validation

- `go test -race ./pkg/ovs -run TestReconcileACLSampling -count=1`
- `go test ./pkg/controller ./pkg/daemon -run ^$ -count=1`
- diff-scoped `golangci-lint` with one worker: 0 issues
- `git diff --check`