### PR TITLE
feat: add ACL sampling configuration

### DIFF
--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -136,6 +136,14 @@ spec:
           - --enable-lb={{- .Values.func.ENABLE_LB }}
           - --enable-np={{- .Values.func.ENABLE_NP }}
           - --np-enforcement={{- .Values.func.NP_ENFORCEMENT }}
+          - --enable-acl-sampling={{- .Values.aclSampling.enabled }}
+          - --acl-sampling-set-id={{- .Values.aclSampling.setID }}
+          - --acl-sampling-app-id-new={{- .Values.aclSampling.appIDNew }}
+          - --acl-sampling-app-id-established={{- .Values.aclSampling.appIDEstablished }}
+          - --acl-sampling-collector-id-allow={{- .Values.aclSampling.collectorIDAllow }}
+          - --acl-sampling-collector-id-default-deny={{- .Values.aclSampling.collectorIDDefaultDeny }}
+          - --acl-sampling-allow-probability-percent={{- .Values.aclSampling.allowProbabilityPercent }}
+          - --acl-sampling-default-deny-probability-percent={{- .Values.aclSampling.defaultDenyProbabilityPercent }}
           - --enable-eip-snat={{- .Values.networking.ENABLE_EIP_SNAT }}
           {{- if .Values.networking.EXTERNAL_GATEWAY_CONFIG_NS }}
           - --external-gateway-config-ns={{- .Values.networking.EXTERNAL_GATEWAY_CONFIG_NS }}

--- a/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -134,6 +134,9 @@ spec:
           - --set-vxlan-tx-off={{- .Values.func.SET_VXLAN_TX_OFF }}
           - --host-tunnel-src={{- .Values.func.HOST_TUNNEL_SRC | default false }}
           - --non-primary-cni-mode={{- .Values.cni_conf.NON_PRIMARY_CNI }}
+          - --enable-acl-sampling={{- .Values.aclSampling.enabled }}
+          - --acl-sampling-set-id={{- .Values.aclSampling.setID }}
+          - --acl-sampling-local-group-id={{- .Values.aclSampling.localGroupID }}
         securityContext:
           runAsUser: 0
           privileged: false

--- a/charts/kube-ovn/tests/acl_sampling_test.yaml
+++ b/charts/kube-ovn/tests/acl_sampling_test.yaml
@@ -1,0 +1,71 @@
+suite: ACL sampling configuration
+templates:
+  - controller-deploy.yaml
+  - ovncni-ds.yaml
+tests:
+  - it: keeps ACL sampling disabled by default
+    template: controller-deploy.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-acl-sampling=false
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-allow-probability-percent=1
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-default-deny-probability-percent=100
+
+  - it: renders controller ACL sampling overrides
+    template: controller-deploy.yaml
+    set:
+      aclSampling.enabled: true
+      aclSampling.setID: 240
+      aclSampling.appIDNew: 104
+      aclSampling.appIDEstablished: 105
+      aclSampling.collectorIDAllow: 3
+      aclSampling.collectorIDDefaultDeny: 4
+      aclSampling.allowProbabilityPercent: 0.5
+      aclSampling.defaultDenyProbabilityPercent: 75
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-acl-sampling=true
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-set-id=240
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-app-id-new=104
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-app-id-established=105
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-collector-id-allow=3
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-collector-id-default-deny=4
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-allow-probability-percent=0.5
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-default-deny-probability-percent=75
+
+  - it: renders daemon local ACL sampling overrides
+    template: ovncni-ds.yaml
+    set:
+      aclSampling.enabled: true
+      aclSampling.setID: 240
+      aclSampling.localGroupID: 241
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-acl-sampling=true
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-set-id=240
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-local-group-id=241

--- a/charts/kube-ovn/tests/acl_sampling_test.yaml
+++ b/charts/kube-ovn/tests/acl_sampling_test.yaml
@@ -16,6 +16,13 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --acl-sampling-default-deny-probability-percent=100
 
+  - it: keeps local ACL sampling disabled by default
+    template: ovncni-ds.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-acl-sampling=false
+
   - it: renders controller ACL sampling overrides
     template: controller-deploy.yaml
     set:

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -126,6 +126,18 @@ func:
   ENABLE_LIVE_MIGRATION_OPTIMIZE: true
   ENABLE_OVN_LB_PREFER_LOCAL: false
 
+# Experimental OVN ACL sampling for NetworkPolicy events.
+aclSampling:
+  enabled: false
+  setID: 142
+  localGroupID: 142
+  appIDNew: 102
+  appIDEstablished: 103
+  collectorIDAllow: 1
+  collectorIDDefaultDeny: 2
+  allowProbabilityPercent: 1
+  defaultDenyProbabilityPercent: 100
+
 ipv4:
   POD_CIDR: "10.16.0.0/16"
   POD_GATEWAY: "10.16.0.1"

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -39,6 +39,9 @@ func main() {
 		}
 		return
 	}
+	if err := config.ACLSampling.Validate(); err != nil {
+		util.LogFatalAndExit(err, "invalid ACL sampling configuration")
+	}
 	perm, err := strconv.ParseUint(config.LogPerm, 8, 32)
 	if err != nil {
 		util.LogFatalAndExit(err, "failed to parse log-perm")

--- a/pkg/aclsampling/config.go
+++ b/pkg/aclsampling/config.go
@@ -1,0 +1,92 @@
+package aclsampling
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+const (
+	DefaultSetID                         uint32  = 142
+	DefaultLocalGroupID                  uint32  = 142
+	DefaultAppIDNew                      uint32  = 102
+	DefaultAppIDEstablished              uint32  = 103
+	DefaultCollectorIDAllow              uint32  = 1
+	DefaultCollectorIDDefaultDeny        uint32  = 2
+	DefaultAllowProbabilityPercent       float64 = 1
+	DefaultDefaultDenyProbabilityPercent float64 = 100
+
+	maxOVNObjectID    uint32  = 255
+	maxOVNProbability float64 = 65535
+)
+
+// ControllerConfig contains the controller-side ACL sampling configuration.
+type ControllerConfig struct {
+	Enabled                       bool
+	SetID                         uint32
+	AppIDNew                      uint32
+	AppIDEstablished              uint32
+	CollectorIDAllow              uint32
+	CollectorIDDefaultDeny        uint32
+	AllowProbabilityPercent       float64
+	DefaultDenyProbabilityPercent float64
+}
+
+// NodeConfig contains the node-side ACL sampling configuration.
+type NodeConfig struct {
+	Enabled      bool
+	SetID        uint32
+	LocalGroupID uint32
+}
+
+// Validate checks whether the controller configuration can be represented by
+// the OVN northbound sampling schema.
+func (c ControllerConfig) Validate() error {
+	if c.SetID == 0 {
+		return errors.New("collector set ID must be greater than zero")
+	}
+
+	for name, id := range map[string]uint32{
+		"new application ID":         c.AppIDNew,
+		"established application ID": c.AppIDEstablished,
+		"allow collector ID":         c.CollectorIDAllow,
+		"default-deny collector ID":  c.CollectorIDDefaultDeny,
+	} {
+		if id == 0 || id > maxOVNObjectID {
+			return fmt.Errorf("%s must be in the range 1-255", name)
+		}
+	}
+
+	if c.AppIDNew == c.AppIDEstablished {
+		return errors.New("new and established application IDs must be different")
+	}
+	if c.CollectorIDAllow == c.CollectorIDDefaultDeny {
+		return errors.New("allow and default-deny collector IDs must be different")
+	}
+	if _, err := ProbabilityFromPercent(c.AllowProbabilityPercent); err != nil {
+		return fmt.Errorf("invalid allow probability: %w", err)
+	}
+	if _, err := ProbabilityFromPercent(c.DefaultDenyProbabilityPercent); err != nil {
+		return fmt.Errorf("invalid default-deny probability: %w", err)
+	}
+
+	return nil
+}
+
+// Validate checks whether the node configuration can identify the OVN sample
+// collector set used for local delivery.
+func (c NodeConfig) Validate() error {
+	if c.SetID == 0 {
+		return errors.New("collector set ID must be greater than zero")
+	}
+	return nil
+}
+
+// ProbabilityFromPercent converts a percentage to OVN's 16-bit probability
+// representation using round(percent * 65535 / 100).
+func ProbabilityFromPercent(percent float64) (int, error) {
+	if math.IsNaN(percent) || math.IsInf(percent, 0) || percent < 0 || percent > 100 {
+		return 0, errors.New("percentage must be in the range 0-100")
+	}
+	return int(math.Round(percent * maxOVNProbability / 100)), nil
+}

--- a/pkg/aclsampling/config_test.go
+++ b/pkg/aclsampling/config_test.go
@@ -1,0 +1,87 @@
+package aclsampling
+
+import (
+	"math"
+	"testing"
+)
+
+func validControllerConfig() ControllerConfig {
+	return ControllerConfig{
+		Enabled:                       true,
+		SetID:                         DefaultSetID,
+		AppIDNew:                      DefaultAppIDNew,
+		AppIDEstablished:              DefaultAppIDEstablished,
+		CollectorIDAllow:              DefaultCollectorIDAllow,
+		CollectorIDDefaultDeny:        DefaultCollectorIDDefaultDeny,
+		AllowProbabilityPercent:       DefaultAllowProbabilityPercent,
+		DefaultDenyProbabilityPercent: DefaultDefaultDenyProbabilityPercent,
+	}
+}
+
+func TestControllerConfigValidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*ControllerConfig)
+	}{
+		{name: "valid", mutate: func(*ControllerConfig) {}},
+		{name: "zero set ID", mutate: func(c *ControllerConfig) { c.SetID = 0 }},
+		{name: "zero application ID", mutate: func(c *ControllerConfig) { c.AppIDNew = 0 }},
+		{name: "large application ID", mutate: func(c *ControllerConfig) { c.AppIDEstablished = 256 }},
+		{name: "duplicate application ID", mutate: func(c *ControllerConfig) { c.AppIDEstablished = c.AppIDNew }},
+		{name: "duplicate collector ID", mutate: func(c *ControllerConfig) { c.CollectorIDDefaultDeny = c.CollectorIDAllow }},
+		{name: "negative allow probability", mutate: func(c *ControllerConfig) { c.AllowProbabilityPercent = -1 }},
+		{name: "large default-deny probability", mutate: func(c *ControllerConfig) { c.DefaultDenyProbabilityPercent = 101 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := validControllerConfig()
+			tt.mutate(&config)
+			err := config.Validate()
+			if tt.name == "valid" && err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			if tt.name != "valid" && err == nil {
+				t.Fatal("Validate() expected an error")
+			}
+		})
+	}
+}
+
+func TestNodeConfigValidate(t *testing.T) {
+	if err := (NodeConfig{SetID: DefaultSetID, LocalGroupID: 0}).Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if err := (NodeConfig{SetID: 0, LocalGroupID: DefaultLocalGroupID}).Validate(); err == nil {
+		t.Fatal("Validate() expected an error")
+	}
+}
+
+func TestProbabilityFromPercent(t *testing.T) {
+	tests := []struct {
+		name    string
+		percent float64
+		want    int
+		wantErr bool
+	}{
+		{name: "disabled", percent: 0, want: 0},
+		{name: "default allow", percent: 1, want: 655},
+		{name: "fractional", percent: 12.5, want: 8192},
+		{name: "always", percent: 100, want: 65535},
+		{name: "negative", percent: -0.1, wantErr: true},
+		{name: "too large", percent: 100.1, wantErr: true},
+		{name: "not a number", percent: math.NaN(), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ProbabilityFromPercent(tt.percent)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ProbabilityFromPercent() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("ProbabilityFromPercent() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -20,6 +20,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	anpclientset "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned"
 
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
 	clientset "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -184,6 +185,7 @@ type Configuration struct {
 
 	// Enforcement level of network policies (standard, lax)
 	NetworkPolicyEnforcement string
+	ACLSampling              aclsampling.ControllerConfig
 
 	// Skip conntrack for specific destination IP CIDRs
 	SkipConntrackDstCidrs string
@@ -247,6 +249,14 @@ func ParseFlags() (*Configuration, error) {
 		argEnableLb                    = pflag.Bool("enable-lb", true, "Enable load balancer")
 		argEnableNP                    = pflag.Bool("enable-np", true, "Enable network policy support")
 		argNPEnforcement               = pflag.String("np-enforcement", "standard", "Network policy enforcement mode: standard or lax")
+		argEnableACLSampling           = pflag.Bool("enable-acl-sampling", false, "Enable experimental ACL sampling for NetworkPolicy events")
+		argACLSamplingSetID            = pflag.Uint32("acl-sampling-set-id", aclsampling.DefaultSetID, "Observation domain ID used by ACL sample collectors")
+		argACLSamplingAppIDNew         = pflag.Uint32("acl-sampling-app-id-new", aclsampling.DefaultAppIDNew, "Observation point ID for new ACL sessions")
+		argACLSamplingAppIDEstablished = pflag.Uint32("acl-sampling-app-id-established", aclsampling.DefaultAppIDEstablished, "Observation point ID for established ACL sessions")
+		argACLSamplingCollectorIDAllow = pflag.Uint32("acl-sampling-collector-id-allow", aclsampling.DefaultCollectorIDAllow, "Collector ID for allowed ACL decisions")
+		argACLSamplingCollectorIDDeny  = pflag.Uint32("acl-sampling-collector-id-default-deny", aclsampling.DefaultCollectorIDDefaultDeny, "Collector ID for default-deny ACL decisions")
+		argACLSamplingAllowProbability = pflag.Float64("acl-sampling-allow-probability-percent", aclsampling.DefaultAllowProbabilityPercent, "Sampling probability percentage for allowed ACL decisions")
+		argACLSamplingDenyProbability  = pflag.Float64("acl-sampling-default-deny-probability-percent", aclsampling.DefaultDefaultDenyProbabilityPercent, "Sampling probability percentage for default-deny ACL decisions")
 		argEnableEipSnat               = pflag.Bool("enable-eip-snat", true, "Enable EIP and SNAT")
 		argEnableExternalVpc           = pflag.Bool("enable-external-vpc", false, "Enable external vpc support")
 		argEnableEcmp                  = pflag.Bool("enable-ecmp", false, "Enable ecmp route for centralized subnet")
@@ -352,37 +362,47 @@ func ParseFlags() (*Configuration, error) {
 		LeaderElection:                 leaderElectionConfig,
 		EnableLb:                       *argEnableLb,
 		EnableNP:                       *argEnableNP,
-		EnableEipSnat:                  *argEnableEipSnat,
-		EnableExternalVpc:              *argEnableExternalVpc,
-		ExternalGatewayConfigNS:        *argExternalGatewayConfigNS,
-		ExternalGatewaySwitch:          *argExternalGatewaySwitch,
-		ExternalGatewayNet:             *argExternalGatewayNet,
-		ExternalGatewayVlanID:          *argExternalGatewayVlanID,
-		EnableEcmp:                     *argEnableEcmp,
-		EnableKeepVMIP:                 *argKeepVMIP,
-		NodePgProbeTime:                *argNodePgProbeTime,
-		GCInterval:                     *argGCInterval,
-		InspectInterval:                *argInspectInterval,
-		EnableLbSvc:                    *argEnableLbSvc,
-		EnableOVNLBPreferLocal:         *argEnableOVNLBPreferLocal,
-		EnableMetrics:                  *argEnableMetrics,
-		EnableOVNIPSec:                 *argEnableOVNIPSec,
-		CertManagerIPSecCert:           *argCertManagerIPSecCert,
-		EnableLiveMigrationOptimize:    *argEnableLiveMigrationOptimize,
-		BfdMinTx:                       *argBfdMinTx,
-		BfdMinRx:                       *argBfdMinRx,
-		BfdDetectMult:                  *argBfdDetectMult,
-		EnableANP:                      *argEnableANP,
-		EnableDNSNameResolver:          *argEnableDNSNameResolver,
-		Image:                          *argImage,
-		FRRImage:                       *argFRRImage,
-		LogPerm:                        *argLogPerm,
-		TLSMinVersion:                  *argTLSMinVersion,
-		TLSMaxVersion:                  *argTLSMaxVersion,
-		TLSCipherSuites:                *argTLSCipherSuites,
-		EnableNonPrimaryCNI:            *argNonPrimaryCNI,
-		NetworkPolicyEnforcement:       *argNPEnforcement,
-		SkipConntrackDstCidrs:          *argSkipConntrackDstCidrs,
+		ACLSampling: aclsampling.ControllerConfig{
+			Enabled:                       *argEnableACLSampling,
+			SetID:                         *argACLSamplingSetID,
+			AppIDNew:                      *argACLSamplingAppIDNew,
+			AppIDEstablished:              *argACLSamplingAppIDEstablished,
+			CollectorIDAllow:              *argACLSamplingCollectorIDAllow,
+			CollectorIDDefaultDeny:        *argACLSamplingCollectorIDDeny,
+			AllowProbabilityPercent:       *argACLSamplingAllowProbability,
+			DefaultDenyProbabilityPercent: *argACLSamplingDenyProbability,
+		},
+		EnableEipSnat:               *argEnableEipSnat,
+		EnableExternalVpc:           *argEnableExternalVpc,
+		ExternalGatewayConfigNS:     *argExternalGatewayConfigNS,
+		ExternalGatewaySwitch:       *argExternalGatewaySwitch,
+		ExternalGatewayNet:          *argExternalGatewayNet,
+		ExternalGatewayVlanID:       *argExternalGatewayVlanID,
+		EnableEcmp:                  *argEnableEcmp,
+		EnableKeepVMIP:              *argKeepVMIP,
+		NodePgProbeTime:             *argNodePgProbeTime,
+		GCInterval:                  *argGCInterval,
+		InspectInterval:             *argInspectInterval,
+		EnableLbSvc:                 *argEnableLbSvc,
+		EnableOVNLBPreferLocal:      *argEnableOVNLBPreferLocal,
+		EnableMetrics:               *argEnableMetrics,
+		EnableOVNIPSec:              *argEnableOVNIPSec,
+		CertManagerIPSecCert:        *argCertManagerIPSecCert,
+		EnableLiveMigrationOptimize: *argEnableLiveMigrationOptimize,
+		BfdMinTx:                    *argBfdMinTx,
+		BfdMinRx:                    *argBfdMinRx,
+		BfdDetectMult:               *argBfdDetectMult,
+		EnableANP:                   *argEnableANP,
+		EnableDNSNameResolver:       *argEnableDNSNameResolver,
+		Image:                       *argImage,
+		FRRImage:                    *argFRRImage,
+		LogPerm:                     *argLogPerm,
+		TLSMinVersion:               *argTLSMinVersion,
+		TLSMaxVersion:               *argTLSMaxVersion,
+		TLSCipherSuites:             *argTLSCipherSuites,
+		EnableNonPrimaryCNI:         *argNonPrimaryCNI,
+		NetworkPolicyEnforcement:    *argNPEnforcement,
+		SkipConntrackDstCidrs:       *argSkipConntrackDstCidrs,
 	}
 	if err := config.LeaderElection.validate(); err != nil {
 		return nil, err
@@ -397,6 +417,9 @@ func ParseFlags() (*Configuration, error) {
 
 	if config.EnableLbSvc && !config.EnableLb {
 		klog.Warning("--enable-lb-svc requires --enable-lb, the loadbalancer service feature will not work")
+	}
+	if err := config.ACLSampling.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid ACL sampling configuration: %w", err)
 	}
 
 	if config.DefaultGateway == "" {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	clientset "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -84,6 +85,7 @@ type Configuration struct {
 	SetVxlanTxOff             bool
 	LogPerm                   string
 	EnableNonPrimaryCNI       bool
+	ACLSampling               aclsampling.NodeConfig
 
 	// TLS configuration for secure serving
 	TLSMinVersion   string
@@ -143,10 +145,13 @@ func ParseFlags() *Configuration {
 		argSetVxlanTxOff             = pflag.Bool("set-vxlan-tx-off", false, "Whether to set vxlan_sys_4789 tx off")
 		argLogPerm                   = pflag.String("log-perm", "640", "The permission for the log file")
 
-		argTLSMinVersion   = pflag.String("tls-min-version", "", "The minimum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
-		argTLSMaxVersion   = pflag.String("tls-max-version", "", "The maximum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
-		argTLSCipherSuites = pflag.StringSlice("tls-cipher-suites", nil, "Comma-separated list of TLS cipher suite names to use for secure serving (e.g., 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'). Names must match Go's crypto/tls package. See Go documentation for available suites. If not set, defaults are used. Users are responsible for selecting secure cipher suites.")
-		argNonPrimaryCNI   = pflag.Bool("non-primary-cni-mode", false, "Use Kube-OVN in non primary cni mode. When true, skip setting NetworkUnavailable node condition")
+		argTLSMinVersion           = pflag.String("tls-min-version", "", "The minimum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
+		argTLSMaxVersion           = pflag.String("tls-max-version", "", "The maximum TLS version to use for secure serving. Supported values: TLS10, TLS11, TLS12, TLS13. If not set, the default is used based on the Go version.")
+		argTLSCipherSuites         = pflag.StringSlice("tls-cipher-suites", nil, "Comma-separated list of TLS cipher suite names to use for secure serving (e.g., 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'). Names must match Go's crypto/tls package. See Go documentation for available suites. If not set, defaults are used. Users are responsible for selecting secure cipher suites.")
+		argNonPrimaryCNI           = pflag.Bool("non-primary-cni-mode", false, "Use Kube-OVN in non primary cni mode. When true, skip setting NetworkUnavailable node condition")
+		argEnableACLSampling       = pflag.Bool("enable-acl-sampling", false, "Enable experimental local ACL sample delivery")
+		argACLSamplingSetID        = pflag.Uint32("acl-sampling-set-id", aclsampling.DefaultSetID, "Observation domain ID used by ACL sample collectors")
+		argACLSamplingLocalGroupID = pflag.Uint32("acl-sampling-local-group-id", aclsampling.DefaultLocalGroupID, "Local psample group ID used to deliver ACL samples")
 	)
 
 	// mute info log for ipset lib
@@ -218,12 +223,21 @@ func ParseFlags() *Configuration {
 		CertManagerIssuerName:     *argCertManagerIssuerName,
 		IPSecCertDuration:         *argOVNIPSecCertDuration,
 		EnableNonPrimaryCNI:       *argNonPrimaryCNI,
+		ACLSampling: aclsampling.NodeConfig{
+			Enabled:      *argEnableACLSampling,
+			SetID:        *argACLSamplingSetID,
+			LocalGroupID: *argACLSamplingLocalGroupID,
+		},
 	}
 
 	return config
 }
 
 func (config *Configuration) Init(nicBridgeMappings map[string]string) error {
+	if err := config.ACLSampling.Validate(); err != nil {
+		return fmt.Errorf("invalid ACL sampling configuration: %w", err)
+	}
+
 	if config.NodeName == "" {
 		klog.Info("node name not specified in command line parameters, fall back to the environment variable")
 		if config.NodeName = strings.ToLower(os.Getenv(util.EnvNodeName)); config.NodeName == "" {


### PR DESCRIPTION
Related to #7146.

## Summary

- add disabled-by-default controller and daemon ACL sampling flags
- validate OVN IDs and sampling percentages through shared configuration
- expose classic Helm chart settings and cover default and overridden rendering

## Stack

1. **#7149 — configuration**
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `master`

## Validation

- `go test ./pkg/aclsampling ./pkg/controller ./pkg/daemon ./cmd/daemon`
- `helm unittest -f tests/acl_sampling_test.yaml charts/kube-ovn` (4/4 passed)
- `git diff --check`