### PR TITLE
feat: allocate stable ACL sample metadata

### DIFF
--- a/pkg/aclsampling/metadata.go
+++ b/pkg/aclsampling/metadata.go
@@ -1,0 +1,211 @@
+package aclsampling
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const (
+	SchemaVersionV1 = "v1"
+
+	DirectionIngress = "Ingress"
+	DirectionEgress  = "Egress"
+
+	RoleRuleAllow   = "rule-allow"
+	RoleDefaultDeny = "default-deny"
+
+	ActionAllowRelated = "allow-related"
+	ActionDrop         = "drop"
+)
+
+// SampleKey contains the stable identity of an eligible NetworkPolicy ACL.
+type SampleKey struct {
+	SchemaVersion string
+	PolicyUID     string
+	Direction     string
+	RuleIndex     *int
+	Role          string
+	Protocol      string
+	ACLMatchHash  string
+	OVNAction     string
+}
+
+// OccupiedMetadata describes a metadata value already present in OVN. KeyHash
+// may be empty when the value is not attributable to a Kube-OVN ACL.
+type OccupiedMetadata struct {
+	Metadata uint32
+	KeyHash  string
+}
+
+// Allocation is the stable metadata allocated for a sample key.
+type Allocation struct {
+	Metadata uint32
+	KeyHash  string
+}
+
+// Allocator reserves globally unique, non-zero OVN sample metadata values.
+// Allocations made through one instance are visible to subsequent calls so a
+// controller can reserve values for a complete transaction before committing.
+type Allocator struct {
+	mu                sync.Mutex
+	metadataToKeyHash map[uint32]string
+	keyHashToMetadata map[string]uint32
+}
+
+// NewAllocator creates an allocator from existing OVN Sample rows and known
+// ACL key hashes.
+func NewAllocator(occupied []OccupiedMetadata) (*Allocator, error) {
+	a := &Allocator{
+		metadataToKeyHash: make(map[uint32]string, len(occupied)),
+		keyHashToMetadata: make(map[string]uint32, len(occupied)),
+	}
+	for _, item := range occupied {
+		if item.Metadata == 0 {
+			return nil, errors.New("occupied sample metadata must be non-zero")
+		}
+
+		if current, ok := a.metadataToKeyHash[item.Metadata]; ok {
+			if current != "" && item.KeyHash != "" && current != item.KeyHash {
+				return nil, fmt.Errorf("sample metadata %d has conflicting key hashes", item.Metadata)
+			}
+			if current == "" && item.KeyHash != "" {
+				a.metadataToKeyHash[item.Metadata] = item.KeyHash
+			}
+		} else {
+			a.metadataToKeyHash[item.Metadata] = item.KeyHash
+		}
+
+		if item.KeyHash == "" {
+			continue
+		}
+		if current, ok := a.keyHashToMetadata[item.KeyHash]; ok && current != item.Metadata {
+			return nil, fmt.Errorf("sample key hash %s has multiple metadata values", item.KeyHash)
+		}
+		a.keyHashToMetadata[item.KeyHash] = item.Metadata
+	}
+	return a, nil
+}
+
+// Allocate returns the existing allocation for the same canonical key or
+// deterministically probes for the next available non-zero metadata value.
+func (a *Allocator) Allocate(key SampleKey) (Allocation, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	canonical, err := key.canonical()
+	if err != nil {
+		return Allocation{}, err
+	}
+
+	sum := sha256.Sum256([]byte(canonical))
+	keyHash := hex.EncodeToString(sum[:])
+	if metadata, ok := a.keyHashToMetadata[keyHash]; ok {
+		return Allocation{Metadata: metadata, KeyHash: keyHash}, nil
+	}
+
+	initial := metadataCandidate(sum)
+	metadata := initial
+	for {
+		if _, occupied := a.metadataToKeyHash[metadata]; !occupied {
+			a.metadataToKeyHash[metadata] = keyHash
+			a.keyHashToMetadata[keyHash] = metadata
+			return Allocation{Metadata: metadata, KeyHash: keyHash}, nil
+		}
+		metadata = nextMetadata(metadata)
+		if metadata == initial {
+			return Allocation{}, errors.New("no non-zero ACL sample metadata is available")
+		}
+	}
+}
+
+// HashACLMatch returns the lowercase SHA-256 digest stored instead of the full
+// generated ACL match.
+func HashACLMatch(match string) string {
+	sum := sha256.Sum256([]byte(match))
+	return hex.EncodeToString(sum[:])
+}
+
+func (key SampleKey) canonical() (string, error) {
+	if err := key.validate(); err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "schema-version=%s\n", key.SchemaVersion)
+	fmt.Fprintf(&b, "policy-uid=%s\n", key.PolicyUID)
+	fmt.Fprintf(&b, "direction=%s\n", key.Direction)
+	if key.RuleIndex != nil {
+		fmt.Fprintf(&b, "rule-index=%d\n", *key.RuleIndex)
+	}
+	fmt.Fprintf(&b, "acl-role=%s\n", key.Role)
+	fmt.Fprintf(&b, "protocol=%s\n", key.Protocol)
+	fmt.Fprintf(&b, "acl-match-hash=%s\n", key.ACLMatchHash)
+	fmt.Fprintf(&b, "ovn-action=%s\n", key.OVNAction)
+	return b.String(), nil
+}
+
+func (key SampleKey) validate() error {
+	if key.SchemaVersion != SchemaVersionV1 {
+		return fmt.Errorf("unsupported sample schema version %q", key.SchemaVersion)
+	}
+	if key.PolicyUID == "" {
+		return errors.New("policy UID must not be empty")
+	}
+	if key.Direction != DirectionIngress && key.Direction != DirectionEgress {
+		return fmt.Errorf("unsupported policy direction %q", key.Direction)
+	}
+	if key.Protocol == "" {
+		return errors.New("protocol must not be empty")
+	}
+	if len(key.ACLMatchHash) != sha256.Size*2 {
+		return errors.New("ACL match hash must be a SHA-256 digest")
+	}
+	if _, err := hex.DecodeString(key.ACLMatchHash); err != nil {
+		return errors.New("ACL match hash must be a lowercase SHA-256 digest")
+	}
+	if strings.ToLower(key.ACLMatchHash) != key.ACLMatchHash {
+		return errors.New("ACL match hash must be a lowercase SHA-256 digest")
+	}
+
+	switch key.Role {
+	case RoleRuleAllow:
+		if key.RuleIndex == nil || *key.RuleIndex < 0 {
+			return errors.New("rule-allow sample key requires a non-negative rule index")
+		}
+		if key.OVNAction != ActionAllowRelated {
+			return fmt.Errorf("rule-allow sample key requires OVN action %q", ActionAllowRelated)
+		}
+	case RoleDefaultDeny:
+		if key.RuleIndex != nil {
+			return errors.New("default-deny sample key must not include a rule index")
+		}
+		if key.OVNAction != ActionDrop {
+			return fmt.Errorf("default-deny sample key requires OVN action %q", ActionDrop)
+		}
+	default:
+		return fmt.Errorf("unsupported ACL sample role %q", key.Role)
+	}
+
+	return nil
+}
+
+func metadataCandidate(sum [sha256.Size]byte) uint32 {
+	candidate := binary.BigEndian.Uint32(sum[:4])
+	if candidate == 0 {
+		return 1
+	}
+	return candidate
+}
+
+func nextMetadata(metadata uint32) uint32 {
+	metadata++
+	if metadata == 0 {
+		return 1
+	}
+	return metadata
+}

--- a/pkg/aclsampling/metadata.go
+++ b/pkg/aclsampling/metadata.go
@@ -14,26 +14,35 @@ import (
 const (
 	SchemaVersionV1 = "v1"
 
-	DirectionIngress = "Ingress"
-	DirectionEgress  = "Egress"
+	DirectionIngress PolicyDirection = "Ingress"
+	DirectionEgress  PolicyDirection = "Egress"
 
-	RoleRuleAllow   = "rule-allow"
-	RoleDefaultDeny = "default-deny"
+	RoleRuleAllow   ACLRole = "rule-allow"
+	RoleDefaultDeny ACLRole = "default-deny"
 
-	ActionAllowRelated = "allow-related"
-	ActionDrop         = "drop"
+	ActionAllowRelated OVNAction = "allow-related"
+	ActionDrop         OVNAction = "drop"
 )
+
+// PolicyDirection identifies NetworkPolicy traffic direction.
+type PolicyDirection string
+
+// ACLRole identifies why an eligible NetworkPolicy ACL exists.
+type ACLRole string
+
+// OVNAction identifies action enforced by an eligible NetworkPolicy ACL.
+type OVNAction string
 
 // SampleKey contains the stable identity of an eligible NetworkPolicy ACL.
 type SampleKey struct {
 	SchemaVersion string
 	PolicyUID     string
-	Direction     string
+	Direction     PolicyDirection
 	RuleIndex     *int
-	Role          string
+	Role          ACLRole
 	Protocol      string
 	ACLMatchHash  string
-	OVNAction     string
+	OVNAction     OVNAction
 }
 
 // OccupiedMetadata describes a metadata value already present in OVN. KeyHash
@@ -139,16 +148,16 @@ func (key SampleKey) canonical() (string, error) {
 	fields := []string{
 		"schema-version=" + key.SchemaVersion,
 		"policy-uid=" + key.PolicyUID,
-		"direction=" + key.Direction,
+		"direction=" + string(key.Direction),
 	}
 	if key.RuleIndex != nil {
 		fields = append(fields, "rule-index="+strconv.Itoa(*key.RuleIndex))
 	}
 	fields = append(fields,
-		"acl-role="+key.Role,
+		"acl-role="+string(key.Role),
 		"protocol="+key.Protocol,
 		"acl-match-hash="+key.ACLMatchHash,
-		"ovn-action="+key.OVNAction,
+		"ovn-action="+string(key.OVNAction),
 	)
 	return strings.Join(fields, "\n") + "\n", nil
 }

--- a/pkg/aclsampling/metadata.go
+++ b/pkg/aclsampling/metadata.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -135,18 +136,21 @@ func (key SampleKey) canonical() (string, error) {
 		return "", err
 	}
 
-	var b strings.Builder
-	fmt.Fprintf(&b, "schema-version=%s\n", key.SchemaVersion)
-	fmt.Fprintf(&b, "policy-uid=%s\n", key.PolicyUID)
-	fmt.Fprintf(&b, "direction=%s\n", key.Direction)
-	if key.RuleIndex != nil {
-		fmt.Fprintf(&b, "rule-index=%d\n", *key.RuleIndex)
+	fields := []string{
+		"schema-version=" + key.SchemaVersion,
+		"policy-uid=" + key.PolicyUID,
+		"direction=" + key.Direction,
 	}
-	fmt.Fprintf(&b, "acl-role=%s\n", key.Role)
-	fmt.Fprintf(&b, "protocol=%s\n", key.Protocol)
-	fmt.Fprintf(&b, "acl-match-hash=%s\n", key.ACLMatchHash)
-	fmt.Fprintf(&b, "ovn-action=%s\n", key.OVNAction)
-	return b.String(), nil
+	if key.RuleIndex != nil {
+		fields = append(fields, "rule-index="+strconv.Itoa(*key.RuleIndex))
+	}
+	fields = append(fields,
+		"acl-role="+key.Role,
+		"protocol="+key.Protocol,
+		"acl-match-hash="+key.ACLMatchHash,
+		"ovn-action="+key.OVNAction,
+	)
+	return strings.Join(fields, "\n") + "\n", nil
 }
 
 func (key SampleKey) validate() error {

--- a/pkg/aclsampling/metadata_test.go
+++ b/pkg/aclsampling/metadata_test.go
@@ -1,0 +1,264 @@
+package aclsampling
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+)
+
+func validAllowSampleKey() SampleKey {
+	return SampleKey{
+		SchemaVersion: SchemaVersionV1,
+		PolicyUID:     "11111111-2222-3333-4444-555555555555",
+		Direction:     DirectionIngress,
+		RuleIndex:     new(0),
+		Role:          RoleRuleAllow,
+		Protocol:      "IPv4",
+		ACLMatchHash:  HashACLMatch("outport == @policy && ip4.src == $allow"),
+		OVNAction:     ActionAllowRelated,
+	}
+}
+
+func TestSampleKeyCanonicalHash(t *testing.T) {
+	allocator, err := NewAllocator(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allocation, err := allocator.Allocate(validAllowSampleKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const wantKeyHash = "cbef9de432159cede19e36ee3748e823a814fa28805569c45977be4ace46181d"
+	if allocation.KeyHash != wantKeyHash {
+		t.Fatalf("key hash = %q, want %q", allocation.KeyHash, wantKeyHash)
+	}
+	if allocation.Metadata != 3421478372 {
+		t.Fatalf("metadata = %d, want 3421478372", allocation.Metadata)
+	}
+}
+
+func TestAllocatorReusesExistingCanonicalKey(t *testing.T) {
+	key := validAllowSampleKey()
+	first, err := NewAllocator(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allocation, err := first.Allocate(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allocator, err := NewAllocator([]OccupiedMetadata{{Metadata: 42, KeyHash: allocation.KeyHash}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reused, err := allocator.Allocate(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused.Metadata != 42 {
+		t.Fatalf("metadata = %d, want 42", reused.Metadata)
+	}
+}
+
+func TestAllocatorProbesPastCollisions(t *testing.T) {
+	key := validAllowSampleKey()
+	canonical, err := key.canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial := metadataCandidate(sha256.Sum256([]byte(canonical)))
+	second := nextMetadata(initial)
+	want := nextMetadata(second)
+
+	allocator, err := NewAllocator([]OccupiedMetadata{
+		{Metadata: initial},
+		{Metadata: second, KeyHash: HashACLMatch("another canonical key")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	allocation, err := allocator.Allocate(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allocation.Metadata != want {
+		t.Fatalf("metadata = %d, want %d", allocation.Metadata, want)
+	}
+}
+
+func TestAllocatorReservesTransactionMetadata(t *testing.T) {
+	allocator, err := NewAllocator(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstKey := validAllowSampleKey()
+	first, err := allocator.Allocate(firstKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := allocator.Allocate(firstKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != first {
+		t.Fatalf("repeated allocation = %#v, want %#v", again, first)
+	}
+
+	secondKey := firstKey
+	secondKey.RuleIndex = new(1)
+	second, err := allocator.Allocate(secondKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Metadata == first.Metadata {
+		t.Fatalf("distinct keys reused metadata %d", first.Metadata)
+	}
+}
+
+func TestAllocatorAllocatesDefaultDenyWithoutRuleIndex(t *testing.T) {
+	key := validAllowSampleKey()
+	key.RuleIndex = nil
+	key.Role = RoleDefaultDeny
+	key.Protocol = "IP"
+	key.OVNAction = ActionDrop
+
+	allocator, err := NewAllocator(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allocation, err := allocator.Allocate(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allocation.Metadata == 0 {
+		t.Fatal("Allocate() returned zero metadata")
+	}
+}
+
+func TestAllocatorSupportsConcurrentReservations(t *testing.T) {
+	allocator, err := NewAllocator(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const count = 100
+	results := make(chan Allocation, count)
+	errors := make(chan error, count)
+	var wg sync.WaitGroup
+	for i := range count {
+		wg.Go(func() {
+			key := validAllowSampleKey()
+			key.PolicyUID = fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+			allocation, err := allocator.Allocate(key)
+			if err != nil {
+				errors <- err
+				return
+			}
+			results <- allocation
+		})
+	}
+	wg.Wait()
+	close(results)
+	close(errors)
+
+	for err := range errors {
+		t.Errorf("Allocate() error = %v", err)
+	}
+	seen := make(map[uint32]struct{}, count)
+	for allocation := range results {
+		if _, ok := seen[allocation.Metadata]; ok {
+			t.Errorf("metadata %d allocated more than once", allocation.Metadata)
+		}
+		seen[allocation.Metadata] = struct{}{}
+	}
+	if len(seen) != count {
+		t.Fatalf("allocated %d unique metadata values, want %d", len(seen), count)
+	}
+}
+
+func TestNewAllocatorRejectsConflictingMappings(t *testing.T) {
+	tests := []struct {
+		name     string
+		occupied []OccupiedMetadata
+	}{
+		{
+			name: "zero metadata",
+			occupied: []OccupiedMetadata{
+				{Metadata: 0},
+			},
+		},
+		{
+			name: "metadata has multiple keys",
+			occupied: []OccupiedMetadata{
+				{Metadata: 1, KeyHash: "first"},
+				{Metadata: 1, KeyHash: "second"},
+			},
+		},
+		{
+			name: "key has multiple metadata values",
+			occupied: []OccupiedMetadata{
+				{Metadata: 1, KeyHash: "same"},
+				{Metadata: 2, KeyHash: "same"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewAllocator(tt.occupied); err == nil {
+				t.Fatal("NewAllocator() expected an error")
+			}
+		})
+	}
+}
+
+func TestSampleKeyValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*SampleKey)
+	}{
+		{name: "unsupported schema", mutate: func(key *SampleKey) { key.SchemaVersion = "v2" }},
+		{name: "empty policy UID", mutate: func(key *SampleKey) { key.PolicyUID = "" }},
+		{name: "invalid direction", mutate: func(key *SampleKey) { key.Direction = "Inbound" }},
+		{name: "missing rule index", mutate: func(key *SampleKey) { key.RuleIndex = nil }},
+		{name: "negative rule index", mutate: func(key *SampleKey) { key.RuleIndex = new(-1) }},
+		{name: "invalid role", mutate: func(key *SampleKey) { key.Role = "exception" }},
+		{name: "invalid action", mutate: func(key *SampleKey) { key.OVNAction = ActionDrop }},
+		{name: "empty protocol", mutate: func(key *SampleKey) { key.Protocol = "" }},
+		{name: "invalid match hash", mutate: func(key *SampleKey) { key.ACLMatchHash = "invalid" }},
+		{name: "uppercase match hash", mutate: func(key *SampleKey) {
+			key.ACLMatchHash = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		}},
+		{name: "default deny with rule index", mutate: func(key *SampleKey) {
+			key.Role = RoleDefaultDeny
+			key.OVNAction = ActionDrop
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := validAllowSampleKey()
+			tt.mutate(&key)
+			allocator, err := NewAllocator(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := allocator.Allocate(key); err == nil {
+				t.Fatal("Allocate() expected an error")
+			}
+		})
+	}
+}
+
+func TestMetadataCandidateAndWrap(t *testing.T) {
+	if got := metadataCandidate([sha256.Size]byte{}); got != 1 {
+		t.Fatalf("zero candidate remapped to %d, want 1", got)
+	}
+	if got := nextMetadata(math.MaxUint32); got != 1 {
+		t.Fatalf("wrapped metadata = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
Related to #7146.

## Summary

- define canonical NetworkPolicy ACL sample keys
- allocate non-zero 32-bit metadata from SHA-256 with deterministic collision probing
- preserve prior key-to-metadata mappings and transaction-local reservations
- cover validation, collisions, wraparound, reuse, and concurrent allocation

## Stack

1. #7149 — configuration
2. **#7150 — stable metadata allocator**
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch. This PR intentionally contains only pure metadata allocation.

Base: `feature/acl-sampling-config`

## Validation

- `go test -race ./pkg/aclsampling -count=1`
- diff-scoped `golangci-lint` with one worker: 0 issues
- `git diff --check`