### PR TITLE
feat: retry NetworkPolicy ACL sampling independently

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -266,12 +266,14 @@ type Controller struct {
 	deploymentsLister appsv1.DeploymentLister
 	deploymentsSynced cache.InformerSynced
 
-	npsLister     netv1.NetworkPolicyLister
-	npsSynced     cache.InformerSynced
-	npIndexer     cache.Indexer
-	updateNpQueue workqueue.TypedRateLimitingInterface[string]
-	deleteNpQueue workqueue.TypedRateLimitingInterface[string]
-	npKeyMutex    keymutex.KeyMutex
+	npsLister          netv1.NetworkPolicyLister
+	npsSynced          cache.InformerSynced
+	npIndexer          cache.Indexer
+	updateNpQueue      workqueue.TypedRateLimitingInterface[string]
+	deleteNpQueue      workqueue.TypedRateLimitingInterface[string]
+	npSamplingQueue    workqueue.TypedRateLimitingInterface[string]
+	npSamplingRequests *xsync.Map[string, *ovs.NetworkPolicySamplingRequest]
+	npKeyMutex         keymutex.KeyMutex
 
 	sgsLister          kubeovnlister.SecurityGroupLister
 	sgSynced           cache.InformerSynced
@@ -719,6 +721,10 @@ func Run(ctx context.Context, config *Configuration) {
 		controller.npIndexer = npInformer.Informer().GetIndexer()
 		controller.updateNpQueue = newTypedRateLimitingQueue[string]("UpdateNetworkPolicy", nil)
 		controller.deleteNpQueue = newTypedRateLimitingQueue[string]("DeleteNetworkPolicy", nil)
+		if config.ACLSampling.Enabled {
+			controller.npSamplingQueue = newTypedRateLimitingQueue[string]("SampleNetworkPolicyACL", nil)
+			controller.npSamplingRequests = xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest]()
+		}
 		controller.npKeyMutex = keymutex.NewHashed(numKeyLocks)
 	}
 
@@ -1344,6 +1350,9 @@ func (c *Controller) shutdown() {
 	if c.config.EnableNP {
 		c.updateNpQueue.ShutDown()
 		c.deleteNpQueue.ShutDown()
+		if c.npSamplingQueue != nil {
+			c.npSamplingQueue.ShutDown()
+		}
 	}
 	if c.config.EnableANP {
 		c.addAnpQueue.ShutDown()
@@ -1478,6 +1487,9 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		if c.config.EnableNP {
 			go wait.Until(runWorker("update network policy", c.updateNpQueue, c.handleUpdateNp), time.Second, ctx.Done())
 			go wait.Until(runWorker("delete network policy", c.deleteNpQueue, c.handleDeleteNp), time.Second, ctx.Done())
+			if c.npSamplingQueue != nil {
+				go wait.Until(runWorker("sample network policy ACL", c.npSamplingQueue, c.handleNetworkPolicyACLSampling), time.Second, ctx.Done())
+			}
 		}
 
 		go wait.Until(runWorker("delete vlan", c.delVlanQueue, c.handleDelVlan), time.Second, ctx.Done())

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/scylladb/go-set/strset"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -169,6 +170,15 @@ func (c *Controller) handleUpdateNp(key string) error {
 	if err = c.OVNNbClient.PortGroupSetPorts(pgName, ports); err != nil {
 		klog.Errorf("failed to set ports of port group %s to %v: %v", pgName, ports, err)
 		return err
+	}
+
+	var samplingRequest *ovs.NetworkPolicySamplingRequest
+	if c.config.ACLSampling.Enabled {
+		samplingRequest, err = c.OVNNbClient.PrepareNetworkPolicyACLSampling(pgName, np.Namespace, np.Name, string(np.UID))
+		if err != nil {
+			// Sampling is best-effort and must never block NetworkPolicy enforcement.
+			klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
+		}
 	}
 
 	ingressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil)
@@ -505,6 +515,27 @@ func (c *Controller) handleUpdateNp(key string) error {
 			return err
 		}
 	}
+	if samplingRequest != nil {
+		c.npSamplingRequests.Store(key, samplingRequest)
+		c.npSamplingQueue.Add(key)
+	}
+	return nil
+}
+
+func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
+	request, ok := c.npSamplingRequests.Load(key)
+	if !ok {
+		return nil
+	}
+	if err := c.OVNNbClient.ApplyNetworkPolicyACLSampling(c.config.ACLSampling, request); err != nil {
+		return err
+	}
+	c.npSamplingRequests.Compute(key, func(current *ovs.NetworkPolicySamplingRequest, loaded bool) (*ovs.NetworkPolicySamplingRequest, xsync.ComputeOp) {
+		if loaded && current == request {
+			return nil, xsync.DeleteOp
+		}
+		return current, xsync.CancelOp
+	})
 	return nil
 }
 

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	mockovs "github.com/kubeovn/kube-ovn/mocks/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+)
+
+func TestHandleNetworkPolicyACLSamplingRetriesOnlySampling(t *testing.T) {
+	mockController := gomock.NewController(t)
+	nbClient := mockovs.NewMockNbClient(mockController)
+	config := aclsampling.ControllerConfig{Enabled: true}
+	controller := &Controller{
+		config:             &Configuration{ACLSampling: config},
+		OVNNbClient:        nbClient,
+		npSamplingRequests: xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest](),
+	}
+	request := new(ovs.NetworkPolicySamplingRequest)
+	controller.npSamplingRequests.Store("default/test", request)
+
+	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(errors.New("injected sampling failure"))
+	require.ErrorContains(t, controller.handleNetworkPolicyACLSampling("default/test"), "injected sampling failure")
+	actual, ok := controller.npSamplingRequests.Load("default/test")
+	require.True(t, ok)
+	require.Same(t, request, actual)
+
+	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(nil)
+	require.NoError(t, controller.handleNetworkPolicyACLSampling("default/test"))
+	_, ok = controller.npSamplingRequests.Load("default/test")
+	require.False(t, ok)
+}


### PR DESCRIPTION
Related to #7146.

## Summary

- capture the prior sampling metadata snapshot before ingress enforcement replaces ACLs
- enqueue sampling only after ingress, egress, logging, and helper ACL enforcement succeeds
- run sampling through a dedicated rate-limited queue so sampling failures never re-run or fail NetworkPolicy enforcement
- retain failed sampling requests for retry and remove only the exact request that completed successfully

## Stack

1. #7149 - configuration
2. #7150 - stable metadata allocator
3. #7148 - OVN sampling object reconciler
4. #7151 - NetworkPolicy ACL attachment
5. **this PR - sampling-only retry and enforcement isolation**
6. #7153 - ownership-aware disable and cleanup
7. #7154 - controller availability metrics

Base: `feature/acl-sampling-network-policy-attachment`

## Verification

- `GOMAXPROCS=2 go test ./pkg/controller -count=1`
- targeted retry-retention unit test
- targeted `go test -race`
- `GOMAXPROCS=2 go vet ./pkg/ovs ./pkg/controller`

Local golangci-lint was intentionally not run because of its high memory usage; GitHub CI remains the lint gate.
