### PR TITLE
feat: report ACL sampling availability

### DIFF
--- a/pkg/controller/acl_sampling.go
+++ b/pkg/controller/acl_sampling.go
@@ -1,0 +1,31 @@
+package controller
+
+import "k8s.io/klog/v2"
+
+const (
+	aclSamplingOperationReconcile = "reconcile"
+	aclSamplingOperationPrepare   = "prepare"
+	aclSamplingOperationAttach    = "attach"
+)
+
+func (c *Controller) reconcileACLSampling() {
+	if err := c.OVNNbClient.ReconcileACLSampling(c.config.ACLSampling); err != nil {
+		recordACLSamplingFailure(aclSamplingOperationReconcile)
+		klog.Warningf("ACL sampling is unavailable: %v", err)
+		return
+	}
+	if c.config.ACLSampling.Enabled {
+		metricACLSamplingControllerAvailable.Set(1)
+	} else {
+		metricACLSamplingControllerAvailable.Set(0)
+	}
+}
+
+func recordACLSamplingFailure(operation string) {
+	metricACLSamplingControllerAvailable.Set(0)
+	metricACLSamplingControllerFailures.WithLabelValues(operation).Inc()
+}
+
+func recordACLSamplingSuccess() {
+	metricACLSamplingControllerAvailable.Set(1)
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -672,6 +672,7 @@ func Run(ctx context.Context, config *Configuration) {
 	); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn sb client")
 	}
+	controller.reconcileACLSampling()
 	if config.EnableLb {
 		controller.routerLBRuleLister = routerLBRuleInformer.Lister()
 		controller.routerLBRuleSynced = routerLBRuleInformer.Informer().HasSynced

--- a/pkg/controller/net_metrics.go
+++ b/pkg/controller/net_metrics.go
@@ -66,6 +66,20 @@ var (
 			"ip",
 			"pod_name",
 		})
+
+	metricACLSamplingControllerAvailable = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "acl_sampling_controller_available",
+			Help: "Whether the controller ACL sampling path is enabled and its latest operation succeeded.",
+		})
+
+	metricACLSamplingControllerFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "acl_sampling_controller_failures_total",
+			Help: "The number of best-effort controller ACL sampling failures by operation.",
+		},
+		[]string{"operation"},
+	)
 )
 
 func registerMetrics() {
@@ -74,4 +88,6 @@ func registerMetrics() {
 	metrics.Registry.MustRegister(metricCentralSubnetInfo)
 	metrics.Registry.MustRegister(metricSubnetIPAMInfo)
 	metrics.Registry.MustRegister(metricSubnetIPAssignedInfo)
+	metrics.Registry.MustRegister(metricACLSamplingControllerAvailable)
+	metrics.Registry.MustRegister(metricACLSamplingControllerFailures)
 }

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -177,6 +177,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 		samplingRequest, err = c.OVNNbClient.PrepareNetworkPolicyACLSampling(pgName, np.Namespace, np.Name, string(np.UID))
 		if err != nil {
 			// Sampling is best-effort and must never block NetworkPolicy enforcement.
+			recordACLSamplingFailure(aclSamplingOperationPrepare)
 			klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
 		}
 	}
@@ -528,8 +529,10 @@ func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
 		return nil
 	}
 	if err := c.OVNNbClient.ApplyNetworkPolicyACLSampling(c.config.ACLSampling, request); err != nil {
+		recordACLSamplingFailure(aclSamplingOperationAttach)
 		return err
 	}
+	recordACLSamplingSuccess()
 	c.npSamplingRequests.Compute(key, func(current *ovs.NetworkPolicySamplingRequest, loaded bool) (*ovs.NetworkPolicySamplingRequest, xsync.ComputeOp) {
 		if loaded && current == request {
 			return nil, xsync.DeleteOp

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -24,15 +25,45 @@ func TestHandleNetworkPolicyACLSamplingRetriesOnlySampling(t *testing.T) {
 	}
 	request := new(ovs.NetworkPolicySamplingRequest)
 	controller.npSamplingRequests.Store("default/test", request)
+	failuresBefore := testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationAttach))
 
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(errors.New("injected sampling failure"))
 	require.ErrorContains(t, controller.handleNetworkPolicyACLSampling("default/test"), "injected sampling failure")
+	require.Equal(t, failuresBefore+1, testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationAttach)))
+	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 	actual, ok := controller.npSamplingRequests.Load("default/test")
 	require.True(t, ok)
 	require.Same(t, request, actual)
 
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(nil)
 	require.NoError(t, controller.handleNetworkPolicyACLSampling("default/test"))
+	require.Equal(t, float64(1), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 	_, ok = controller.npSamplingRequests.Load("default/test")
 	require.False(t, ok)
+}
+
+func TestReconcileACLSamplingRecordsAvailability(t *testing.T) {
+	mockController := gomock.NewController(t)
+	nbClient := mockovs.NewMockNbClient(mockController)
+	config := aclsampling.ControllerConfig{Enabled: true}
+	controller := &Controller{
+		config:      &Configuration{ACLSampling: config},
+		OVNNbClient: nbClient,
+	}
+
+	failuresBefore := testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationReconcile))
+	nbClient.EXPECT().ReconcileACLSampling(config).Return(errors.New("injected schema conflict"))
+	controller.reconcileACLSampling()
+	require.Equal(t, failuresBefore+1, testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationReconcile)))
+	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingControllerAvailable))
+
+	nbClient.EXPECT().ReconcileACLSampling(config).Return(nil)
+	controller.reconcileACLSampling()
+	require.Equal(t, float64(1), testutil.ToFloat64(metricACLSamplingControllerAvailable))
+
+	config.Enabled = false
+	controller.config.ACLSampling = config
+	nbClient.EXPECT().ReconcileACLSampling(config).Return(nil)
+	controller.reconcileACLSampling()
+	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 }


### PR DESCRIPTION
Related to #7146.

## Summary

- reconcile ACL sampling objects on controller startup without blocking controller availability
- trigger ownership-aware cleanup on startup when ACL sampling is disabled
- expose `acl_sampling_controller_available` for the latest reconciliation state
- count `reconcile`, `prepare`, and `attach` failures with `acl_sampling_controller_failures_total`
- restore the availability gauge after a successful ACL attachment retry

## Stack

1. #7149 - configuration
2. #7150 - stable metadata allocator
3. #7148 - OVN sampling object reconciler
4. #7151 - NetworkPolicy ACL attachment
5. #7152 - sampling-only retry and enforcement isolation
6. #7153 - ownership-aware disable and cleanup
7. **this PR - controller availability metrics**
8. #7155 - node-local psample delivery

Base: `feature/acl-sampling-cleanup`

## Verification

- `GOMAXPROCS=2 go test ./pkg/controller -count=1`
- targeted startup reconciliation and metrics unit tests
- targeted `go test -race`
- `GOMAXPROCS=2 go vet ./pkg/ovs ./pkg/controller`
- `git diff --check`

Local golangci-lint was intentionally not run because of its high memory usage; GitHub CI remains the lint gate.
