### PR TITLE
feat: decode NetworkPolicy ACL samples

### DIFF
--- a/pkg/aclsampling/event.go
+++ b/pkg/aclsampling/event.go
@@ -1,0 +1,151 @@
+package aclsampling
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const (
+	ApplicationACLNew = "acl-new"
+	ApplicationACLEst = "acl-est"
+
+	VerdictAllow       = "allow"
+	VerdictDefaultDeny = "default-deny"
+
+	ReasonNetworkPolicyDefaultDeny = "network-policy-default-deny"
+	AttributionNonExclusive        = "non-exclusive"
+)
+
+// SampleReference identifies the OVN observation attached to a local psample
+// event. ApplicationID is nil when the input contains metadata only.
+type SampleReference struct {
+	ObservationDomain *uint32 `json:"observationDomain,omitempty" yaml:"observationDomain,omitempty"`
+	ApplicationID     *uint32 `json:"applicationID,omitempty" yaml:"applicationID,omitempty"`
+	DatapathKey       *uint32 `json:"datapathKey,omitempty" yaml:"datapathKey,omitempty"`
+	Metadata          uint32  `json:"metadata" yaml:"metadata"`
+}
+
+// PolicyReference identifies the Kubernetes NetworkPolicy data stored on an
+// eligible ACL.
+type PolicyReference struct {
+	APIVersion string `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string `json:"kind" yaml:"kind"`
+	Namespace  string `json:"namespace" yaml:"namespace"`
+	Name       string `json:"name" yaml:"name"`
+	UID        string `json:"uid" yaml:"uid"`
+	Direction  string `json:"direction" yaml:"direction"`
+	RuleIndex  *int   `json:"ruleIndex,omitempty" yaml:"ruleIndex,omitempty"`
+}
+
+// OVNACLReference describes the OVN ACL that owns a sample reference.
+type OVNACLReference struct {
+	UUID      string `json:"aclUUID" yaml:"aclUUID"`
+	Name      string `json:"aclName,omitempty" yaml:"aclName,omitempty"`
+	Action    string `json:"action" yaml:"action"`
+	Priority  int    `json:"priority" yaml:"priority"`
+	Tier      int    `json:"tier" yaml:"tier"`
+	Direction string `json:"direction" yaml:"direction"`
+	MatchHash string `json:"matchHash" yaml:"matchHash"`
+}
+
+// SampleDetails describes how OVN encoded a resolved sample.
+type SampleDetails struct {
+	App               string  `json:"app,omitempty" yaml:"app,omitempty"`
+	ObservationDomain *uint32 `json:"observationDomain,omitempty" yaml:"observationDomain,omitempty"`
+	ApplicationID     *uint32 `json:"applicationID,omitempty" yaml:"applicationID,omitempty"`
+	DatapathKey       *uint32 `json:"datapathKey,omitempty" yaml:"datapathKey,omitempty"`
+	Metadata          uint32  `json:"metadata" yaml:"metadata"`
+}
+
+// Event is the stable debug representation of a sampled NetworkPolicy ACL
+// decision. Allow events populate Policy; default-deny events populate
+// PolicyOwner to avoid claiming exclusive policy attribution.
+type Event struct {
+	SchemaVersion string           `json:"schemaVersion" yaml:"schemaVersion"`
+	Feature       string           `json:"feature" yaml:"feature"`
+	Verdict       string           `json:"verdict" yaml:"verdict"`
+	Reason        string           `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Attribution   string           `json:"attribution,omitempty" yaml:"attribution,omitempty"`
+	Policy        *PolicyReference `json:"policy,omitempty" yaml:"policy,omitempty"`
+	PolicyOwner   *PolicyReference `json:"policyOwner,omitempty" yaml:"policyOwner,omitempty"`
+	OVN           OVNACLReference  `json:"ovn" yaml:"ovn"`
+	Sample        SampleDetails    `json:"sample" yaml:"sample"`
+}
+
+// ParseSampleReference accepts a decimal or 0x-prefixed hexadecimal metadata
+// value or local-sampling cookie. A cookie stores the observation domain in
+// the high 32 bits and the ACL metadata in the low 32 bits. OVN puts the
+// application ID in the domain's high byte and the datapath key in its low 24
+// bits.
+func ParseSampleReference(value string) (SampleReference, error) {
+	if value == "" {
+		return SampleReference{}, errors.New("ACL sample cookie or metadata must not be empty")
+	}
+	if strings.TrimSpace(value) != value || strings.HasPrefix(value, "+") || strings.HasPrefix(value, "-") {
+		return SampleReference{}, fmt.Errorf("invalid ACL sample cookie or metadata %q", value)
+	}
+
+	base := 10
+	digits := value
+	if strings.HasPrefix(value, "0x") || strings.HasPrefix(value, "0X") {
+		base = 16
+		digits = value[2:]
+	}
+	if digits == "" {
+		return SampleReference{}, fmt.Errorf("invalid ACL sample cookie or metadata %q", value)
+	}
+
+	raw, err := strconv.ParseUint(digits, base, 64)
+	if err != nil {
+		return SampleReference{}, fmt.Errorf("invalid ACL sample cookie or metadata %q: %w", value, err)
+	}
+	if raw == 0 {
+		return SampleReference{}, errors.New("ACL sample metadata must be greater than zero")
+	}
+	if raw <= math.MaxUint32 {
+		return SampleReference{Metadata: uint32(raw)}, nil
+	}
+
+	observationDomain := uint32(raw >> 32)
+	applicationID := observationDomain >> 24
+	datapathKey := observationDomain & 0x00ffffff
+	metadata := uint32(raw)
+	if applicationID == 0 || applicationID > maxOVNObjectID {
+		return SampleReference{}, fmt.Errorf("ACL sample application ID %d must be in the range 1-255", applicationID)
+	}
+	if metadata == 0 {
+		return SampleReference{}, errors.New("ACL sample cookie metadata must be greater than zero")
+	}
+	return SampleReference{
+		ObservationDomain: &observationDomain,
+		ApplicationID:     &applicationID,
+		DatapathKey:       &datapathKey,
+		Metadata:          metadata,
+	}, nil
+}
+
+// Validate checks whether a programmatically constructed sample reference can
+// be resolved through the OVN northbound sampling schema.
+func (r SampleReference) Validate() error {
+	if r.Metadata == 0 {
+		return errors.New("ACL sample metadata must be greater than zero")
+	}
+	if r.ApplicationID != nil && (*r.ApplicationID == 0 || *r.ApplicationID > maxOVNObjectID) {
+		return fmt.Errorf("ACL sample application ID %d must be in the range 1-255", *r.ApplicationID)
+	}
+	if (r.ObservationDomain == nil) != (r.ApplicationID == nil) || (r.DatapathKey == nil) != (r.ApplicationID == nil) {
+		return errors.New("ACL sample observation domain, application ID, and datapath key must be provided together")
+	}
+	if r.ObservationDomain != nil {
+		if *r.ApplicationID != *r.ObservationDomain>>24 {
+			return errors.New("ACL sample application ID does not match the observation domain")
+		}
+		if *r.DatapathKey != *r.ObservationDomain&0x00ffffff {
+			return errors.New("ACL sample datapath key does not match the observation domain")
+		}
+	}
+	return nil
+}

--- a/pkg/aclsampling/event_test.go
+++ b/pkg/aclsampling/event_test.go
@@ -1,0 +1,80 @@
+package aclsampling
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSampleReference(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		observationDomain *uint32
+		applicationID     *uint32
+		datapathKey       *uint32
+		metadata          uint32
+	}{
+		{name: "decimal metadata", input: "200", metadata: 200},
+		{name: "hex metadata", input: "0xc8", metadata: 200},
+		{name: "maximum metadata", input: "4294967295", metadata: 4294967295},
+		{
+			name:              "decimal cookie",
+			input:             strconv.FormatUint(uint64(0x640abcde)<<32|200, 10),
+			observationDomain: uint32Pointer(0x640abcde),
+			applicationID:     uint32Pointer(100),
+			datapathKey:       uint32Pointer(0x0abcde),
+			metadata:          200,
+		},
+		{
+			name:              "hex cookie",
+			input:             "0x640abcde000000c8",
+			observationDomain: uint32Pointer(0x640abcde),
+			applicationID:     uint32Pointer(100),
+			datapathKey:       uint32Pointer(0x0abcde),
+			metadata:          200,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reference, err := ParseSampleReference(test.input)
+			require.NoError(t, err)
+			require.Equal(t, test.observationDomain, reference.ObservationDomain)
+			require.Equal(t, test.applicationID, reference.ApplicationID)
+			require.Equal(t, test.datapathKey, reference.DatapathKey)
+			require.Equal(t, test.metadata, reference.Metadata)
+			require.NoError(t, reference.Validate())
+		})
+	}
+}
+
+func TestParseSampleReferenceRejectsInvalidInput(t *testing.T) {
+	tests := []string{
+		"",
+		"0",
+		"0x",
+		"-1",
+		"+1",
+		" 1",
+		"1 ",
+		"0xgg",
+		"18446744073709551616",
+		"0x64000000c8",
+		"0x0000010000000001",
+		"0x6400000000000000",
+	}
+
+	for _, input := range tests {
+		t.Run(fmt.Sprintf("input_%q", input), func(t *testing.T) {
+			_, err := ParseSampleReference(input)
+			require.Error(t, err)
+		})
+	}
+}
+
+func uint32Pointer(value uint32) *uint32 {
+	return &value
+}

--- a/pkg/ovs/ovn-nb-acl-sample-event.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event.go
@@ -1,0 +1,221 @@
+package ovs
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+var (
+	ErrACLSampleNotFound  = errors.New("ACL sample event was not found")
+	ErrACLSampleAmbiguous = errors.New("ACL sample event is ambiguous")
+)
+
+// ResolveNetworkPolicyACLSample resolves a local psample cookie or metadata
+// value to the single Kube-OVN NetworkPolicy ACL that owns the sample. The
+// caller does not need to understand OVN strong references or external IDs.
+func (c *OVNNbClient) ResolveNetworkPolicyACLSample(reference aclsampling.SampleReference) (*aclsampling.Event, error) {
+	if err := reference.Validate(); err != nil {
+		return nil, err
+	}
+	if err := c.ensureACLSamplingMonitor(); err != nil {
+		return nil, err
+	}
+
+	application, err := c.resolveACLSampleApplication(reference.ApplicationID)
+	if err != nil {
+		return nil, err
+	}
+	sample, err := c.resolveSampleMetadata(reference.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	acls, err := c.ListAcls("", map[string]string{sampleFeatureExternalID: networkPolicySampleFeature})
+	if err != nil {
+		return nil, fmt.Errorf("list NetworkPolicy ACL sample owners: %w", err)
+	}
+	matches := make([]ovnnb.ACL, 0, 1)
+	for i := range acls {
+		if aclReferencesSample(acls[i], sample.UUID, application) {
+			matches = append(matches, acls[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("%w: no Kube-OVN NetworkPolicy ACL references metadata %d", ErrACLSampleNotFound, reference.Metadata)
+	}
+	if len(matches) != 1 {
+		return nil, fmt.Errorf("%w: metadata %d is referenced by %d Kube-OVN NetworkPolicy ACLs", ErrACLSampleAmbiguous, reference.Metadata, len(matches))
+	}
+
+	event, err := networkPolicyACLSampleEvent(matches[0], reference, application)
+	if err != nil {
+		return nil, fmt.Errorf("decode NetworkPolicy ACL %s: %w", matches[0].UUID, err)
+	}
+	return event, nil
+}
+
+func (c *OVNNbClient) resolveACLSampleApplication(applicationID *uint32) (string, error) {
+	if applicationID == nil {
+		return "", nil
+	}
+	apps, err := c.listSamplingApps()
+	if err != nil {
+		return "", err
+	}
+	matches := make([]ovnnb.SamplingApp, 0, 1)
+	for i := range apps {
+		if apps[i].ID == int(*applicationID) {
+			matches = append(matches, apps[i])
+		}
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("%w: sampling application ID %d does not exist", ErrACLSampleNotFound, *applicationID)
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("%w: sampling application ID %d has %d rows", ErrACLSampleAmbiguous, *applicationID, len(matches))
+	}
+	switch matches[0].Type {
+	case ovnnb.SamplingAppTypeACLNew:
+		return aclsampling.ApplicationACLNew, nil
+	case ovnnb.SamplingAppTypeACLEst:
+		return aclsampling.ApplicationACLEst, nil
+	default:
+		return "", fmt.Errorf("%w: sampling application ID %d has unsupported type %s", ErrACLSampleNotFound, *applicationID, matches[0].Type)
+	}
+}
+
+func (c *OVNNbClient) resolveSampleMetadata(metadata uint32) (*ovnnb.Sample, error) {
+	samples, err := c.listSamples()
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]ovnnb.Sample, 0, 1)
+	for i := range samples {
+		if samples[i].Metadata == int(metadata) {
+			matches = append(matches, samples[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("%w: sample metadata %d does not exist", ErrACLSampleNotFound, metadata)
+	}
+	if len(matches) != 1 {
+		return nil, fmt.Errorf("%w: sample metadata %d has %d rows", ErrACLSampleAmbiguous, metadata, len(matches))
+	}
+	return &matches[0], nil
+}
+
+func aclReferencesSample(acl ovnnb.ACL, sampleUUID, application string) bool {
+	switch application {
+	case aclsampling.ApplicationACLNew:
+		return acl.SampleNew != nil && *acl.SampleNew == sampleUUID
+	case aclsampling.ApplicationACLEst:
+		return acl.SampleEst != nil && *acl.SampleEst == sampleUUID
+	default:
+		return (acl.SampleNew != nil && *acl.SampleNew == sampleUUID) ||
+			(acl.SampleEst != nil && *acl.SampleEst == sampleUUID)
+	}
+}
+
+func networkPolicyACLSampleEvent(acl ovnnb.ACL, reference aclsampling.SampleReference, application string) (*aclsampling.Event, error) {
+	externalIDs := acl.ExternalIDs
+	if externalIDs[sampleSchemaVersionExternalID] != aclsampling.SchemaVersionV1 {
+		return nil, fmt.Errorf("unsupported sample schema version %q", externalIDs[sampleSchemaVersionExternalID])
+	}
+	if externalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
+		return nil, fmt.Errorf("unsupported sample feature %q", externalIDs[sampleFeatureExternalID])
+	}
+	if externalIDs[policyAPIVersionExternalID] != networkPolicyAPIVersion || externalIDs[policyKindExternalID] != networkPolicyKind {
+		return nil, fmt.Errorf("unsupported policy identity %s %s", externalIDs[policyAPIVersionExternalID], externalIDs[policyKindExternalID])
+	}
+	if acl.Tier != util.NetpolACLTier {
+		return nil, fmt.Errorf("ACL tier %d is not the NetworkPolicy tier", acl.Tier)
+	}
+
+	for _, key := range []string{policyNamespaceExternalID, policyNameExternalID, policyUIDExternalID, policyDirectionExternalID} {
+		if externalIDs[key] == "" {
+			return nil, fmt.Errorf("required external ID %s is missing", key)
+		}
+	}
+	direction, ok := networkPolicyDirection(acl.Direction)
+	if !ok || externalIDs[policyDirectionExternalID] != direction {
+		return nil, fmt.Errorf("policy direction %q does not match ACL direction %q", externalIDs[policyDirectionExternalID], acl.Direction)
+	}
+	if externalIDs[ovnActionExternalID] != acl.Action {
+		return nil, fmt.Errorf("OVN action external ID %q does not match ACL action %q", externalIDs[ovnActionExternalID], acl.Action)
+	}
+	matchHash := aclsampling.HashACLMatch(acl.Match)
+	if externalIDs[aclMatchHashExternalID] != matchHash {
+		return nil, errors.New("ACL match hash does not match the current ACL match")
+	}
+	mapping, err := storedNetworkPolicySampleMapping(externalIDs)
+	if err != nil {
+		return nil, err
+	}
+	if mapping.Metadata != reference.Metadata {
+		return nil, fmt.Errorf("sample metadata external ID %d does not match observed metadata %d", mapping.Metadata, reference.Metadata)
+	}
+
+	policy := &aclsampling.PolicyReference{
+		APIVersion: networkPolicyAPIVersion,
+		Kind:       networkPolicyKind,
+		Namespace:  externalIDs[policyNamespaceExternalID],
+		Name:       externalIDs[policyNameExternalID],
+		UID:        externalIDs[policyUIDExternalID],
+		Direction:  direction,
+	}
+	event := &aclsampling.Event{
+		SchemaVersion: aclsampling.SchemaVersionV1,
+		Feature:       networkPolicySampleFeature,
+		OVN: aclsampling.OVNACLReference{
+			UUID:      acl.UUID,
+			Action:    acl.Action,
+			Priority:  acl.Priority,
+			Tier:      acl.Tier,
+			Direction: acl.Direction,
+			MatchHash: matchHash,
+		},
+		Sample: aclsampling.SampleDetails{
+			App:               application,
+			ObservationDomain: reference.ObservationDomain,
+			ApplicationID:     reference.ApplicationID,
+			DatapathKey:       reference.DatapathKey,
+			Metadata:          reference.Metadata,
+		},
+	}
+	if acl.Name != nil {
+		event.OVN.Name = *acl.Name
+	}
+
+	switch externalIDs[sampleRoleExternalID] {
+	case aclsampling.RoleRuleAllow:
+		if externalIDs[policyVerdictExternalID] != aclsampling.VerdictAllow || acl.Action != ovnnb.ACLActionAllowRelated {
+			return nil, errors.New("rule-allow sample metadata does not describe an allow-related ACL")
+		}
+		ruleIndex, err := strconv.Atoi(externalIDs[policyRuleIndexExternalID])
+		if err != nil || ruleIndex < 0 {
+			return nil, fmt.Errorf("invalid NetworkPolicy rule index %q", externalIDs[policyRuleIndexExternalID])
+		}
+		policy.RuleIndex = &ruleIndex
+		event.Verdict = aclsampling.VerdictAllow
+		event.Policy = policy
+	case aclsampling.RoleDefaultDeny:
+		if externalIDs[policyVerdictExternalID] != aclsampling.VerdictDefaultDeny || acl.Action != ovnnb.ACLActionDrop {
+			return nil, errors.New("default-deny sample metadata does not describe a drop ACL")
+		}
+		if _, exists := externalIDs[policyRuleIndexExternalID]; exists {
+			return nil, errors.New("default-deny sample metadata must not include a rule index")
+		}
+		event.Verdict = aclsampling.VerdictDefaultDeny
+		event.Reason = aclsampling.ReasonNetworkPolicyDefaultDeny
+		event.Attribution = aclsampling.AttributionNonExclusive
+		event.PolicyOwner = policy
+	default:
+		return nil, fmt.Errorf("unsupported NetworkPolicy ACL sample role %q", externalIDs[sampleRoleExternalID])
+	}
+	return event, nil
+}

--- a/pkg/ovs/ovn-nb-acl-sample-event_test.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event_test.go
@@ -1,0 +1,127 @@
+package ovs
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestResolveNetworkPolicyACLSample(t *testing.T) {
+	client := newACLSamplingTestClient(t, "event-resolver")
+	const pgName = "decoded-policy.default"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+
+	allowACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/decoded-policy.default/ingress/IPv4/3")
+	denyACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionFromLport, util.EgressDefaultDrop, ovnnb.ACLActionDrop, "default/decoded-policy")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, allowACL, denyACL))
+	waitForACLCount(t, client, pgName, 2)
+
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "decoded-policy", "11111111-2222-3333-4444-555555555555")
+	require.NoError(t, err)
+	config := validACLSamplingConfig()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.NoError(collect, client.ApplyNetworkPolicyACLSampling(config, request))
+	}, 3*time.Second, 20*time.Millisecond)
+
+	var sampled []ovnnb.ACL
+	require.Eventually(t, func() bool {
+		sampled, err = client.ListAcls("", map[string]string{sampleFeatureExternalID: networkPolicySampleFeature})
+		return err == nil && len(sampled) == 2
+	}, 3*time.Second, 20*time.Millisecond)
+
+	allow := aclByName(t, sampled, "np/decoded-policy.default/ingress/IPv4/3")
+	allowMetadata := parseSampleMetadataForTest(t, allow)
+	const datapathKey = uint32(0x0abcde)
+	newCookie := aclSampleCookieForTest(config.AppIDNew, datapathKey, allowMetadata)
+	reference, err := aclsampling.ParseSampleReference(newCookie)
+	require.NoError(t, err)
+	event, err := client.ResolveNetworkPolicyACLSample(reference)
+	require.NoError(t, err)
+	require.Equal(t, aclsampling.VerdictAllow, event.Verdict)
+	require.NotNil(t, event.Policy)
+	require.Nil(t, event.PolicyOwner)
+	require.Equal(t, 3, *event.Policy.RuleIndex)
+	require.Equal(t, aclsampling.ApplicationACLNew, event.Sample.App)
+	require.Equal(t, config.AppIDNew, *event.Sample.ApplicationID)
+	require.Equal(t, datapathKey, *event.Sample.DatapathKey)
+	require.Equal(t, config.AppIDNew<<24|datapathKey, *event.Sample.ObservationDomain)
+	require.Equal(t, allowMetadata, event.Sample.Metadata)
+	require.Equal(t, allow.UUID, event.OVN.UUID)
+
+	establishedCookie := aclSampleCookieForTest(config.AppIDEstablished, datapathKey, allowMetadata)
+	reference, err = aclsampling.ParseSampleReference(establishedCookie)
+	require.NoError(t, err)
+	event, err = client.ResolveNetworkPolicyACLSample(reference)
+	require.NoError(t, err)
+	require.Equal(t, aclsampling.ApplicationACLEst, event.Sample.App)
+	require.Equal(t, aclsampling.VerdictAllow, event.Verdict)
+
+	metadataOnly, err := aclsampling.ParseSampleReference(strconv.FormatUint(uint64(allowMetadata), 10))
+	require.NoError(t, err)
+	event, err = client.ResolveNetworkPolicyACLSample(metadataOnly)
+	require.NoError(t, err)
+	require.Empty(t, event.Sample.App)
+	require.Nil(t, event.Sample.ObservationDomain)
+	require.Nil(t, event.Sample.ApplicationID)
+	require.Nil(t, event.Sample.DatapathKey)
+
+	deny := aclByNameAndAction(t, sampled, "default/decoded-policy", ovnnb.ACLActionDrop)
+	denyMetadata := parseSampleMetadataForTest(t, deny)
+	denyCookie := aclSampleCookieForTest(config.AppIDNew, datapathKey, denyMetadata)
+	reference, err = aclsampling.ParseSampleReference(denyCookie)
+	require.NoError(t, err)
+	event, err = client.ResolveNetworkPolicyACLSample(reference)
+	require.NoError(t, err)
+	require.Equal(t, aclsampling.VerdictDefaultDeny, event.Verdict)
+	require.Nil(t, event.Policy)
+	require.NotNil(t, event.PolicyOwner)
+	require.Nil(t, event.PolicyOwner.RuleIndex)
+	require.Equal(t, aclsampling.ReasonNetworkPolicyDefaultDeny, event.Reason)
+	require.Equal(t, aclsampling.AttributionNonExclusive, event.Attribution)
+
+	establishedCookie = aclSampleCookieForTest(config.AppIDEstablished, datapathKey, denyMetadata)
+	reference, err = aclsampling.ParseSampleReference(establishedCookie)
+	require.NoError(t, err)
+	_, err = client.ResolveNetworkPolicyACLSample(reference)
+	require.ErrorIs(t, err, ErrACLSampleNotFound)
+}
+
+func TestResolveNetworkPolicyACLSampleRejectsUnknownValues(t *testing.T) {
+	client := newACLSamplingTestClient(t, "event-resolver-not-found")
+	require.NoError(t, client.ReconcileACLSampling(validACLSamplingConfig()))
+	waitForACLSamplingObjects(t, client)
+
+	_, err := client.ResolveNetworkPolicyACLSample(aclsampling.SampleReference{Metadata: 999})
+	require.ErrorIs(t, err, ErrACLSampleNotFound)
+
+	reference, parseErr := aclsampling.ParseSampleReference(aclSampleCookieForTest(200, 1, 999))
+	require.NoError(t, parseErr)
+	_, err = client.ResolveNetworkPolicyACLSample(reference)
+	require.ErrorIs(t, err, ErrACLSampleNotFound)
+
+	_, err = client.ResolveNetworkPolicyACLSample(aclsampling.SampleReference{})
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrACLSampleNotFound))
+}
+
+func parseSampleMetadataForTest(t *testing.T, acl ovnnb.ACL) uint32 {
+	t.Helper()
+	metadata, err := strconv.ParseUint(acl.ExternalIDs[sampleMetadataExternalID], 10, 32)
+	require.NoError(t, err)
+	return uint32(metadata)
+}
+
+func aclSampleCookieForTest(applicationID, datapathKey, metadata uint32) string {
+	observationDomain := applicationID<<24 | datapathKey
+	return fmt.Sprintf("0x%08x%08x", observationDomain, metadata)
+}


### PR DESCRIPTION
Related to #7146.

## Summary

- parse decimal or hexadecimal ACL sample metadata and 64-bit local-sampling cookies
- decode the OVN observation domain into its application byte and 24-bit datapath key
- resolve the OVN sampling application, Sample row, and owning Kube-OVN NetworkPolicy ACL through one narrow interface
- emit stable allow and default-deny event models while preserving non-exclusive default-deny attribution
- reject unknown applications, missing metadata, ambiguous owners, and inconsistent ACL external IDs

## Stack

1. #7149 - configuration
2. #7150 - stable metadata allocator
3. #7148 - OVN sampling object reconciler
4. #7151 - NetworkPolicy ACL attachment
5. #7152 - sampling-only retry and enforcement isolation
6. #7153 - ownership-aware disable and cleanup
7. #7154 - controller availability metrics
8. #7155 - node-local psample delivery
9. **this PR - cookie and metadata event decoder**
10. #7157 - Linux psample listener

Base: `feature/acl-sampling-node-delivery`

## Validation

All Go commands ran in a transient systemd scope with `MemoryMax=2G`, `MemorySwapMax=0`, `GOMAXPROCS=2`, `GOMEMLIMIT=1700MiB`, and `GOFLAGS=-p=1`.

- `go test ./pkg/aclsampling ./pkg/ovs -count=1`
- `go test -race ./pkg/aclsampling ./pkg/ovs -run "Test(ParseSampleReference|ResolveNetworkPolicyACLSample)" -count=1`
- `go vet ./pkg/aclsampling ./pkg/ovs`
- `git diff --cached --check`

Local golangci-lint was intentionally not run because of its high memory usage; GitHub CI remains the lint gate.
