### PR TITLE
feat: add ACL sample debug commands

### DIFF
--- a/cmd/acl_sample/acl_sample.go
+++ b/cmd/acl_sample/acl_sample.go
@@ -1,0 +1,156 @@
+package acl_sample
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+)
+
+const (
+	CommandName                   = "kube-ovn-acl-sample"
+	defaultOVNTimeout             = 60
+	defaultOVSDBConnectTimeout    = 3
+	defaultOVSDBInactivityTimeout = 10
+)
+
+type sampleResolver interface {
+	ResolveNetworkPolicyACLSample(aclsampling.SampleReference) (*aclsampling.Event, error)
+	Close()
+}
+
+type dependencies struct {
+	newResolver func(string) (sampleResolver, error)
+	listen      func(context.Context, uint32, func(aclsampling.PacketSample) error) error
+}
+
+func defaultDependencies() dependencies {
+	return dependencies{
+		newResolver: func(address string) (sampleResolver, error) {
+			return ovs.NewOvnNbClient(
+				address,
+				defaultOVNTimeout,
+				defaultOVSDBConnectTimeout,
+				defaultOVSDBInactivityTimeout,
+				0,
+			)
+		},
+		listen: aclsampling.ListenPSamples,
+	}
+}
+
+// CmdMain runs the ACL sampling debug command selected through the
+// kube-ovn-acl-sample image symlink.
+func CmdMain() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, os.Args[1:], os.Stdout, os.Stderr, defaultDependencies()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer, deps dependencies) error {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return errors.New("an ACL sample subcommand is required")
+	}
+
+	switch args[0] {
+	case "decode":
+		return runDecode(args[1:], stdout, stderr, deps.newResolver)
+	case "listen":
+		return runListen(ctx, args[1:], stdout, stderr, deps.listen)
+	case "help", "-h", "--help":
+		printUsage(stdout)
+		return nil
+	default:
+		printUsage(stderr)
+		return fmt.Errorf("unknown ACL sample subcommand %q", args[0])
+	}
+}
+
+func runDecode(args []string, stdout, stderr io.Writer, newResolver func(string) (sampleResolver, error)) error {
+	flags := flag.NewFlagSet("decode", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	ovnNBAddress := flags.String("ovn-nb-addr", "", "OVN northbound database address")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *ovnNBAddress == "" {
+		return errors.New("--ovn-nb-addr is required")
+	}
+	if flags.NArg() != 1 {
+		return errors.New("decode requires exactly one cookie or metadata value")
+	}
+
+	reference, err := aclsampling.ParseSampleReference(flags.Arg(0))
+	if err != nil {
+		return err
+	}
+	resolver, err := newResolver(*ovnNBAddress)
+	if err != nil {
+		return fmt.Errorf("connect to OVN northbound database: %w", err)
+	}
+	defer resolver.Close()
+
+	event, err := resolver.ResolveNetworkPolicyACLSample(reference)
+	if err != nil {
+		return fmt.Errorf("resolve ACL sample: %w", err)
+	}
+	output, err := yaml.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("encode ACL sample event: %w", err)
+	}
+	_, err = stdout.Write(output)
+	return err
+}
+
+func runListen(
+	ctx context.Context,
+	args []string,
+	stdout, stderr io.Writer,
+	listen func(context.Context, uint32, func(aclsampling.PacketSample) error) error,
+) error {
+	flags := flag.NewFlagSet("listen", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	groupID := flags.Uint("group-id", uint(aclsampling.DefaultLocalGroupID), "local psample multicast group ID")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("listen does not accept positional arguments")
+	}
+	if uint64(*groupID) > uint64(^uint32(0)) {
+		return fmt.Errorf("psample group ID %d exceeds the uint32 range", *groupID)
+	}
+
+	handle := func(sample aclsampling.PacketSample) error {
+		cookie, err := sample.Reference.Cookie()
+		if err != nil {
+			return fmt.Errorf("format psample cookie: %w", err)
+		}
+		_, err = fmt.Fprintf(stdout, "0x%016x\n", cookie)
+		return err
+	}
+	if err := listen(ctx, uint32(*groupID), handle); err != nil {
+		return fmt.Errorf("listen for ACL psamples: %w", err)
+	}
+	return nil
+}
+
+func printUsage(output io.Writer) {
+	fmt.Fprintln(output, "Usage:")
+	fmt.Fprintf(output, "  %s decode --ovn-nb-addr <address> <cookie-or-metadata>\n", CommandName)
+	fmt.Fprintf(output, "  %s listen [--group-id <id>]\n", CommandName)
+}

--- a/cmd/acl_sample/acl_sample_test.go
+++ b/cmd/acl_sample/acl_sample_test.go
@@ -1,0 +1,101 @@
+package acl_sample
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+)
+
+type fakeResolver struct {
+	reference aclsampling.SampleReference
+	event     *aclsampling.Event
+	closed    bool
+}
+
+func (r *fakeResolver) ResolveNetworkPolicyACLSample(reference aclsampling.SampleReference) (*aclsampling.Event, error) {
+	r.reference = reference
+	return r.event, nil
+}
+
+func (r *fakeResolver) Close() {
+	r.closed = true
+}
+
+func TestRunDecode(t *testing.T) {
+	resolver := &fakeResolver{event: &aclsampling.Event{
+		SchemaVersion: aclsampling.SchemaVersionV1,
+		Feature:       "network-policy",
+		Verdict:       aclsampling.VerdictAllow,
+		OVN:           aclsampling.OVNACLReference{UUID: "acl-uuid"},
+		Sample:        aclsampling.SampleDetails{Metadata: 200},
+	}}
+	var stdout, stderr strings.Builder
+	deps := dependencies{
+		newResolver: func(address string) (sampleResolver, error) {
+			require.Equal(t, "unix:/var/run/ovn/ovnnb_db.sock", address)
+			return resolver, nil
+		},
+	}
+
+	err := run(context.Background(), []string{
+		"decode",
+		"--ovn-nb-addr=unix:/var/run/ovn/ovnnb_db.sock",
+		"0x640abcde000000c8",
+	}, &stdout, &stderr, deps)
+	require.NoError(t, err)
+	require.Empty(t, stderr.String())
+	require.True(t, resolver.closed)
+	require.Equal(t, uint32(200), resolver.reference.Metadata)
+	require.Equal(t, uint32(100), *resolver.reference.ApplicationID)
+	require.Contains(t, stdout.String(), "schemaVersion: v1")
+	require.Contains(t, stdout.String(), "aclUUID: acl-uuid")
+}
+
+func TestRunListen(t *testing.T) {
+	reference, err := aclsampling.ParseSampleReference("0x640abcde000000c8")
+	require.NoError(t, err)
+
+	var stdout, stderr strings.Builder
+	deps := dependencies{
+		listen: func(_ context.Context, groupID uint32, handle func(aclsampling.PacketSample) error) error {
+			require.Equal(t, uint32(5000), groupID)
+			return handle(aclsampling.PacketSample{Reference: reference})
+		},
+	}
+
+	err = run(context.Background(), []string{"listen", "--group-id=5000"}, &stdout, &stderr, deps)
+	require.NoError(t, err)
+	require.Empty(t, stderr.String())
+	require.Equal(t, "0x640abcde000000c8\n", stdout.String())
+}
+
+func TestRunValidatesArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing subcommand", want: "subcommand is required"},
+		{name: "unknown subcommand", args: []string{"unknown"}, want: "unknown ACL sample subcommand"},
+		{name: "missing address", args: []string{"decode", "200"}, want: "--ovn-nb-addr is required"},
+		{name: "missing value", args: []string{"decode", "--ovn-nb-addr=unix:/db.sock"}, want: "exactly one"},
+		{name: "listen positional argument", args: []string{"listen", "unexpected"}, want: "does not accept positional"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			err := run(context.Background(), test.args, &stdout, &stderr, dependencies{
+				newResolver: func(string) (sampleResolver, error) {
+					return nil, errors.New("must not be called")
+				},
+			})
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}

--- a/cmd/daemon/cniserver.go
+++ b/cmd/daemon/cniserver.go
@@ -17,6 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	"github.com/kubeovn/kube-ovn/cmd/acl_sample"
 	kubeovninformer "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	"github.com/kubeovn/kube-ovn/pkg/daemon"
 	"github.com/kubeovn/kube-ovn/pkg/metrics"
@@ -28,6 +29,11 @@ import (
 const cniLivezDialTimeout = 2 * time.Second
 
 func main() {
+	if filepath.Base(os.Args[0]) == acl_sample.CommandName {
+		acl_sample.CmdMain()
+		return
+	}
+
 	defer klog.Flush()
 	config := daemon.ParseFlags()
 	klog.Info(versions.String())

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -16,6 +16,7 @@ RUN ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-monitor && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-webhook && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-leader-checker && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-ic-controller && \
+    ln -s /kube-ovn/kube-ovn-daemon /kube-ovn/kube-ovn-acl-sample && \
     ln -s /kube-ovn/kube-ovn-controller /kube-ovn/kube-ovn-pinger && \
     setcap CAP_NET_BIND_SERVICE+eip /kube-ovn/kube-ovn-cmd && \
     setcap CAP_NET_RAW,CAP_NET_BIND_SERVICE+eip /kube-ovn/kube-ovn-controller && \

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -43,6 +43,8 @@ showHelp(){
   echo "  perf [image] performance test default image is docker.io/kubeovn/test:v1.13.0"
   echo "  icnbctl [ovn-nbctl options ...]    invoke ovn-ic-nbctl"
   echo "  icsbctl [ovn-sbctl options ...]    invoke ovn-ic-sbctl"
+  echo "  acl-sample decode {cookie-or-metadata}    decode a NetworkPolicy ACL sample through OVN NBDB"
+  echo "  acl-sample listen --node {nodeName}       listen for decoded NetworkPolicy ACL samples on a node"
 }
 
 # usage: ipv4_to_hex 192.168.0.1
@@ -843,6 +845,113 @@ getOvnCentralPod(){
     fi
     REGISTRY=$(dirname $image)
     KUBE_OVN_VERSION=$(basename $image | awk -F ':' '{print $2}')
+}
+
+aclSampleDecode(){
+  if [ "$#" -ne 1 ]; then
+    echo "kubectl ko acl-sample decode {cookie-or-metadata}" >&2
+    return 1
+  fi
+
+  OVN_NB_POD=$(getLeaderPod "ovn-nb-leader" "nb")
+  kubectl exec "$OVN_NB_POD" -n "$KUBE_OVN_NS" -c ovn-central -- \
+    /kube-ovn/kube-ovn-acl-sample decode \
+    --ovn-nb-addr=unix:/var/run/ovn/ovnnb_db.sock "$1"
+}
+
+aclSampleListen(){
+  local nodeName=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --node)
+        if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+          echo "--node requires a node name" >&2
+          return 1
+        fi
+        nodeName="$2"
+        shift 2
+        ;;
+      --node=*)
+        nodeName=${1#--node=}
+        shift
+        ;;
+      *)
+        echo "unknown acl-sample listen argument: $1" >&2
+        return 1
+        ;;
+    esac
+  done
+  if [ -z "$nodeName" ]; then
+    echo "kubectl ko acl-sample listen --node {nodeName}" >&2
+    return 1
+  fi
+
+  local daemonArgs enabled groupID
+  daemonArgs=$(kubectl get daemonset kube-ovn-cni -n "$KUBE_OVN_NS" \
+    -o 'jsonpath={range .spec.template.spec.containers[?(@.name=="cni-server")].args}{.}{"\n"}{end}')
+  enabled=false
+  groupID=""
+  while IFS= read -r arg; do
+    case "$arg" in
+      --enable-acl-sampling=*) enabled=${arg#*=} ;;
+      --acl-sampling-local-group-id=*) groupID=${arg#*=} ;;
+    esac
+  done <<< "$daemonArgs"
+  if [ "$enabled" != "true" ]; then
+    echo "ACL sampling is not enabled on the kube-ovn-cni DaemonSet" >&2
+    return 1
+  fi
+  case "$groupID" in
+    ''|*[!0-9]*)
+      echo "cannot determine a valid ACL sampling local group ID from the kube-ovn-cni DaemonSet" >&2
+      return 1
+      ;;
+  esac
+
+  local cniPods cniPod
+  cniPods=$(kubectl get pods -n "$KUBE_OVN_NS" -l app=kube-ovn-cni \
+    --field-selector "spec.nodeName=$nodeName" \
+    -o 'jsonpath={range .items[?(@.status.phase=="Running")]}{.metadata.name}{"\n"}{end}')
+  cniPod=${cniPods%%$'\n'*}
+  if [ -z "$cniPod" ]; then
+    echo "cannot find a running kube-ovn-cni Pod on node $nodeName" >&2
+    return 1
+  fi
+
+  OVN_NB_POD=$(getLeaderPod "ovn-nb-leader" "nb")
+  kubectl exec -i "$cniPod" -n "$KUBE_OVN_NS" -c cni-server -- \
+    /kube-ovn/kube-ovn-acl-sample listen --group-id="$groupID" |
+    while IFS= read -r cookie; do
+      if [ -z "$cookie" ]; then
+        continue
+      fi
+      local decoded
+      if decoded=$(kubectl exec "$OVN_NB_POD" -n "$KUBE_OVN_NS" -c ovn-central -- \
+        /kube-ovn/kube-ovn-acl-sample decode \
+        --ovn-nb-addr=unix:/var/run/ovn/ovnnb_db.sock "$cookie"); then
+        printf '%s\n%s\n' '---' "$decoded"
+      else
+        echo "failed to decode ACL sample cookie $cookie; continuing" >&2
+      fi
+    done
+}
+
+aclSample(){
+  if [ "$#" -lt 1 ]; then
+    echo "kubectl ko acl-sample {decode|listen} ..." >&2
+    return 1
+  fi
+
+  local action="$1"
+  shift
+  case "$action" in
+    decode) aclSampleDecode "$@" ;;
+    listen) aclSampleListen "$@" ;;
+    *)
+      echo "unknown acl-sample action: $action" >&2
+      return 1
+      ;;
+  esac
 }
 
 getOVNICNBPod(){
@@ -1712,6 +1821,9 @@ case $subcommand in
   perf)
     getOvnCentralPod
     perf "$@"
+    ;;
+  acl-sample)
+    aclSample "$@"
     ;;
   *)
     showHelp

--- a/dist/images/kubectl-ko-acl-sample_test.sh
+++ b/dist/images/kubectl-ko-acl-sample_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+FAKE_BIN="$TEST_DIR/bin"
+FAKE_LOG="$TEST_DIR/kubectl.log"
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${FAKE_LOG:?}"
+
+if [[ " $* " == *" get daemonset kube-ovn-cni "* ]]; then
+  printf '%s\n' \
+    "--enable-acl-sampling=${FAKE_ACL_ENABLED:-true}" \
+    "--acl-sampling-local-group-id=5000"
+  exit 0
+fi
+
+if [[ " $* " == *" get pods "*"--field-selector spec.nodeName=node-a"* ]]; then
+  printf 'kube-ovn-cni-node-a\n'
+  exit 0
+fi
+
+if [[ " $* " == *" get pod "*"ovn-nb-leader=true"* ]]; then
+  printf 'ovn-central-0 1/1 Running 0 1m\n'
+  exit 0
+fi
+
+if [[ " $* " == *" exec -i kube-ovn-cni-node-a "*" /kube-ovn/kube-ovn-acl-sample listen "* ]]; then
+  printf '%s\n' '0x640abcde000000c8' '0x670abcde000000c9'
+  exit 0
+fi
+
+if [[ " $* " == *" /kube-ovn/kube-ovn-acl-sample decode "* ]]; then
+  cookie=${!#}
+  printf 'schemaVersion: v1\nsample:\n  cookie: %s\n' "$cookie"
+  exit 0
+fi
+
+echo "unexpected kubectl invocation: $*" >&2
+exit 1
+FAKE
+chmod +x "$FAKE_BIN/kubectl"
+
+assert_contains() {
+  local output=$1
+  local expected=$2
+  if [[ "$output" != *"$expected"* ]]; then
+    printf 'expected output to contain %q, got:\n%s\n' "$expected" "$output" >&2
+    exit 1
+  fi
+}
+
+decode_output=$(PATH="$FAKE_BIN:$PATH" FAKE_LOG="$FAKE_LOG" \
+  bash "$SCRIPT_DIR/kubectl-ko" acl-sample decode 0x640abcde000000c8)
+assert_contains "$decode_output" 'schemaVersion: v1'
+assert_contains "$decode_output" 'cookie: 0x640abcde000000c8'
+
+listen_output=$(PATH="$FAKE_BIN:$PATH" FAKE_LOG="$FAKE_LOG" \
+  bash "$SCRIPT_DIR/kubectl-ko" acl-sample listen --node node-a)
+assert_contains "$listen_output" 'cookie: 0x640abcde000000c8'
+assert_contains "$listen_output" 'cookie: 0x670abcde000000c9'
+if [[ $(grep -c '^---$' <<< "$listen_output") -ne 2 ]]; then
+  printf 'expected two YAML document separators, got:\n%s\n' "$listen_output" >&2
+  exit 1
+fi
+
+if PATH="$FAKE_BIN:$PATH" FAKE_LOG="$FAKE_LOG" FAKE_ACL_ENABLED=false \
+  bash "$SCRIPT_DIR/kubectl-ko" acl-sample listen --node node-a \
+  >"$TEST_DIR/disabled.out" 2>"$TEST_DIR/disabled.err"; then
+  echo 'expected disabled ACL sampling listen to fail' >&2
+  exit 1
+fi
+assert_contains "$(<"$TEST_DIR/disabled.err")" 'ACL sampling is not enabled'
+
+assert_contains "$(<"$FAKE_LOG")" '--group-id=5000'
+assert_contains "$(<"$FAKE_LOG")" '--ovn-nb-addr=unix:/var/run/ovn/ovnnb_db.sock'
+
+echo 'kubectl-ko ACL sample tests passed'

--- a/pkg/aclsampling/event.go
+++ b/pkg/aclsampling/event.go
@@ -153,3 +153,16 @@ func (r SampleReference) Validate() error {
 	}
 	return nil
 }
+
+// Cookie returns the 64-bit OVS user cookie represented by a reference from a
+// local psample event. Metadata-only references cannot be converted back to a
+// cookie because they do not contain an observation domain.
+func (r SampleReference) Cookie() (uint64, error) {
+	if err := r.Validate(); err != nil {
+		return 0, err
+	}
+	if r.ObservationDomain == nil {
+		return 0, errors.New("ACL sample observation domain is required to format a cookie")
+	}
+	return uint64(*r.ObservationDomain)<<32 | uint64(r.Metadata), nil
+}

--- a/pkg/aclsampling/event_test.go
+++ b/pkg/aclsampling/event_test.go
@@ -75,6 +75,20 @@ func TestParseSampleReferenceRejectsInvalidInput(t *testing.T) {
 	}
 }
 
+func TestSampleReferenceCookie(t *testing.T) {
+	reference, err := ParseSampleReference("0x640abcde000000c8")
+	require.NoError(t, err)
+
+	cookie, err := reference.Cookie()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0x640abcde000000c8), cookie)
+
+	metadataOnly, err := ParseSampleReference("200")
+	require.NoError(t, err)
+	_, err = metadataOnly.Cookie()
+	require.ErrorContains(t, err, "observation domain")
+}
+
 func uint32Pointer(value uint32) *uint32 {
 	return &value
 }


### PR DESCRIPTION
Related to #7146.

## Summary

- add a `kube-ovn-acl-sample` image command for decoding cookies or metadata through OVN NBDB and for streaming local psample cookies
- expose `kubectl ko acl-sample decode <cookie-or-metadata>` through the OVN northbound leader local socket
- expose `kubectl ko acl-sample listen --node <node>` by discovering the enabled DaemonSet local group, listening in the selected CNI Pod, and decoding each cookie in OVN central
- preserve TLS compatibility by keeping NBDB resolution out of the node-local listener
- dispatch through the capability-bearing daemon binary so the listener retains its existing node-side privileges without broadening the shared command binary capabilities
- emit one YAML document per decoded live sample and continue after individual decode failures

## Stack

1. #7149 - configuration
2. #7150 - stable metadata allocator
3. #7148 - OVN sampling object reconciler
4. #7151 - NetworkPolicy ACL attachment
5. #7152 - sampling-only retry and enforcement isolation
6. #7153 - ownership-aware disable and cleanup
7. #7154 - controller availability metrics
8. #7155 - node-local psample delivery
9. #7156 - cookie and metadata event decoder
10. #7157 - Linux psample listener
11. **this PR - ACL sample debug commands**

Base: `feature/acl-sampling-psample-listener`

## Validation

All Go and shell validation commands ran in transient systemd scopes with `MemoryMax=2G` and `MemorySwapMax=0`. Go commands also used `GOMAXPROCS=2`, `GOMEMLIMIT=1700MiB`, and `GOFLAGS=-p=1`.

- `go test ./cmd ./cmd/acl_sample ./cmd/daemon ./pkg/aclsampling -count=1`
- `go test ./pkg/ovs -count=1`
- `go vet ./cmd ./cmd/acl_sample ./cmd/daemon ./pkg/aclsampling ./pkg/ovs`
- `bash -n dist/images/kubectl-ko dist/images/kubectl-ko-acl-sample_test.sh`
- `bash dist/images/kubectl-ko-acl-sample_test.sh`
- `git diff --cached --check`

Local golangci-lint and full-repository builds were intentionally not run because of their high memory usage; GitHub CI remains the lint and image-build gate.

Next: #7159 - v2 chart configuration
