### PR TITLE
test: add ACL sampling end-to-end coverage

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -472,6 +472,9 @@ jobs:
           kube-ovn-controller:
           - go.mod
           - go.sum
+          - .github/workflows/build-x86-image.yaml
+          - dist/images/install.sh
+          - hack/acl-sampling-e2e.sh
           EOF
 
           sh hack/go-list.sh pkg/controller | while read f; do
@@ -681,6 +684,79 @@ jobs:
               exit 1
             fi;
           done
+
+  acl-sampling-e2e:
+    name: ACL Sampling E2E
+    if: |
+      always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') &&
+      (needs.netpol-path-filter.outputs.test-netpol == 1 || contains(github.event.pull_request.labels.*.name, 'network policy'))
+    needs:
+      - build-kube-ovn
+      - netpol-path-filter
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
+      - uses: actions/checkout@v7
+
+      - name: Install kind
+        uses: helm/kind-action@v1.14.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          install_only: true
+
+      - name: Download image
+        uses: actions/download-artifact@v8
+        with:
+          name: kube-ovn
+
+      - name: Load image
+        run: docker load --input kube-ovn.tar
+
+      - name: Create kind cluster
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pipx install jinjanator
+          make kind-ghcr-pull kind-init-ipv4
+
+      - name: Install Kube-OVN with deterministic ACL sampling
+        id: install
+        env:
+          ENABLE_ACL_SAMPLING: "true"
+          ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT: "100"
+          ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT: "100"
+        run: make kind-install-ipv4
+
+      - name: Verify sampled NetworkPolicy decisions
+        id: e2e
+        run: bash hack/acl-sampling-e2e.sh
+
+      - name: Collect diagnostics
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        run: |
+          kubectl get events -A -o yaml > acl-sampling-e2e-events.yaml
+          kubectl get pods -A -o wide > acl-sampling-e2e-pods.txt
+          make kubectl-ko-log
+
+      - name: Upload diagnostics
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        uses: actions/upload-artifact@v7
+        with:
+          name: acl-sampling-e2e-diagnostics
+          path: |
+            acl-sampling-e2e-events.yaml
+            acl-sampling-e2e-pods.txt
+            kubectl-ko-log/
 
   k8s-netpol-e2e:
     name: Kubernetes Network Policy E2E

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="acl-sampling-e2e-${RANDOM}"
+SAMPLE_OUTPUT=$(mktemp)
+LISTENER_LOG=$(mktemp)
+LISTENER_PID=""
+POLICY_NAME=acl-sampling
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if [ -n "$LISTENER_PID" ]; then
+    kill "$LISTENER_PID" 2>/dev/null || true
+    wait "$LISTENER_PID" 2>/dev/null || true
+  fi
+  if [ "$status" -ne 0 ]; then
+    echo 'ACL sample listener standard output:' >&2
+    sed -n '1,240p' "$SAMPLE_OUTPUT" >&2
+    echo 'ACL sample listener standard error:' >&2
+    sed -n '1,240p' "$LISTENER_LOG" >&2
+  fi
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  rm -f "$SAMPLE_OUTPUT" "$LISTENER_LOG"
+  exit "$status"
+}
+trap cleanup EXIT
+
+wait_for() {
+  local description=$1
+  local timeout_seconds=$2
+  shift 2
+  local deadline=$((SECONDS + timeout_seconds))
+  until "$@"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "timed out waiting for $description" >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+sampling_references_ready() {
+  local rows
+  rows=$(kubectl ko nbctl --format=csv --data=bare --no-heading \
+    --columns=action,sample_new,sample_est find ACL \
+    "external_ids:kube-ovn.io/policy-uid=$POLICY_UID")
+  grep -Eq 'allow-related.*[[:xdigit:]]{8}-.*[[:xdigit:]]{8}-' <<< "$rows" &&
+    grep -Eq 'drop.*[[:xdigit:]]{8}-' <<< "$rows"
+}
+
+has_sample_document() {
+  local verdict=$1
+  local application=$2
+  local extra=$3
+  awk -v verdict="verdict: $verdict" -v application="app: $application" \
+    -v uid="uid: $POLICY_UID" -v extra="$extra" '
+      BEGIN { RS = "---" }
+      index($0, verdict) && index($0, application) && index($0, uid) && index($0, extra) { found = 1 }
+      END { exit !found }
+    ' "$SAMPLE_OUTPUT"
+}
+
+expected_samples_ready() {
+  has_sample_document allow acl-new 'ruleIndex: 0' &&
+    has_sample_document allow acl-est 'ruleIndex: 0' &&
+    has_sample_document default-deny acl-new 'attribution: non-exclusive'
+}
+
+disable_acl_sampling() {
+  local resource=$1
+  local name=$2
+  local container_name=$3
+  local container_index argument_index
+  container_index=$(kubectl get "$resource" -n kube-system "$name" -o json |
+    jq --arg name "$container_name" '.spec.template.spec.containers | map(.name) | index($name)')
+  if [ "$container_index" = "null" ]; then
+    echo "cannot locate container $container_name in $resource/$name" >&2
+    return 1
+  fi
+  argument_index=$(kubectl get "$resource" -n kube-system "$name" -o json |
+    jq --argjson index "$container_index" \
+      '.spec.template.spec.containers[$index].args | index("--enable-acl-sampling=true")')
+  if [ "$argument_index" = "null" ]; then
+    echo "cannot locate the enabled ACL sampling argument in $resource/$name" >&2
+    return 1
+  fi
+
+  kubectl patch "$resource" -n kube-system "$name" --type=json -p="[{
+    \"op\": \"replace\",
+    \"path\": \"/spec/template/spec/containers/$container_index/args/$argument_index\",
+    \"value\": \"--enable-acl-sampling=false\"
+  }]"
+}
+
+sampling_cleanup_complete() {
+  local sampled_acls applications collectors node_sets
+  sampled_acls=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
+    find ACL 'external_ids:kube-ovn.io/sample-feature=network-policy')
+  applications=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
+    find Sampling_App 'external_ids:kube-ovn.io/feature=acl-sampling')
+  collectors=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
+    find Sample_Collector 'external_ids:kube-ovn.io/feature=acl-sampling')
+  node_sets=$(kubectl ko vsctl "$NODE_NAME" --data=bare --no-heading --columns=_uuid \
+    find Flow_Sample_Collector_Set 'external_ids:kube-ovn.io/feature=acl-sampling')
+  [ -z "$sampled_acls" ] && [ -z "$applications" ] &&
+    [ -z "$collectors" ] && [ -z "$node_sets" ]
+}
+
+NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+if [ -z "$NODE_NAME" ]; then
+  echo 'no Kubernetes node is available for ACL sampling E2E' >&2
+  exit 1
+fi
+
+kubectl create namespace "$NAMESPACE"
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: $NAMESPACE
+  name: target
+  labels:
+    app: target
+spec:
+  nodeName: $NODE_NAME
+  containers:
+    - name: agnhost
+      image: ghcr.io/kubeovn/agnhost:2.47
+      args: ["netexec", "--http-port=8080"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: $NAMESPACE
+  name: allowed
+  labels:
+    access: allowed
+spec:
+  nodeName: $NODE_NAME
+  containers:
+    - name: agnhost
+      image: ghcr.io/kubeovn/agnhost:2.47
+      args: ["pause"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: $NAMESPACE
+  name: denied
+  labels:
+    access: denied
+spec:
+  nodeName: $NODE_NAME
+  containers:
+    - name: agnhost
+      image: ghcr.io/kubeovn/agnhost:2.47
+      args: ["pause"]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: $NAMESPACE
+  name: $POLICY_NAME
+spec:
+  podSelector:
+    matchLabels:
+      app: target
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              access: allowed
+      ports:
+        - protocol: TCP
+          port: 8080
+EOF
+
+kubectl wait -n "$NAMESPACE" --for=condition=Ready pod/target pod/allowed pod/denied --timeout=2m
+POLICY_UID=$(kubectl get networkpolicy -n "$NAMESPACE" "$POLICY_NAME" -o jsonpath='{.metadata.uid}')
+TARGET_IP=$(kubectl get pod -n "$NAMESPACE" target -o jsonpath='{.status.podIP}')
+if [[ "$TARGET_IP" == *:* ]]; then
+  TARGET_ENDPOINT="[$TARGET_IP]:8080"
+else
+  TARGET_ENDPOINT="$TARGET_IP:8080"
+fi
+
+wait_for 'NetworkPolicy ACL sampling references' 90 sampling_references_ready
+
+timeout 90s kubectl ko acl-sample listen --node "$NODE_NAME" >"$SAMPLE_OUTPUT" 2>"$LISTENER_LOG" &
+LISTENER_PID=$!
+sleep 3
+if ! kill -0 "$LISTENER_PID" 2>/dev/null; then
+  echo 'ACL sample listener exited before traffic generation' >&2
+  exit 1
+fi
+
+for _ in $(seq 1 10); do
+  kubectl exec -n "$NAMESPACE" allowed -- \
+    /agnhost connect --timeout=3s "$TARGET_ENDPOINT"
+done
+
+for _ in $(seq 1 3); do
+  if kubectl exec -n "$NAMESPACE" denied -- \
+    /agnhost connect --timeout=2s "$TARGET_ENDPOINT"; then
+    echo 'default-denied client unexpectedly reached the target Pod' >&2
+    exit 1
+  fi
+done
+
+wait_for 'decoded acl-new, acl-est, and default-deny samples' 45 expected_samples_ready
+
+kill "$LISTENER_PID" 2>/dev/null || true
+wait "$LISTENER_PID" 2>/dev/null || true
+LISTENER_PID=""
+
+disable_acl_sampling deployment kube-ovn-controller kube-ovn-controller
+disable_acl_sampling daemonset kube-ovn-cni cni-server
+kubectl rollout status deployment/kube-ovn-controller -n kube-system --timeout=2m
+kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout=2m
+wait_for 'owned controller and node ACL sampling state cleanup' 90 sampling_cleanup_complete
+
+echo 'ACL sampling E2E passed'


### PR DESCRIPTION
Related to #7146.

## Summary

- add a dedicated IPv4 Kind job for deterministic ACL sampling coverage without changing the existing NetworkPolicy matrix
- install Kube-OVN with 100% allow and default-deny sampling probabilities
- verify allow `acl-new`, allow `acl-est`, and non-exclusive default-deny events through `kubectl ko acl-sample listen`
- disable controller and node sampling, then verify sampled ACL references and owned OVN/OVS sampling objects are cleaned up
- upload cluster events, pod state, and listener logs when the job fails

## Stack

1. #7149 - configuration
2. #7150 - stable metadata allocator
3. #7148 - OVN sampling object reconciler
4. #7151 - NetworkPolicy ACL attachment
5. #7152 - sampling-only retry and enforcement isolation
6. #7153 - ownership-aware disable and cleanup
7. #7154 - controller availability metrics
8. #7155 - node-local psample delivery
9. #7156 - cookie and metadata event decoder
10. #7157 - Linux psample listener
11. #7158 - ACL sample debug commands
12. #7159 - v2 chart configuration
13. #7160 - operations and compatibility documentation
14. #7161 - manifest installer configuration
15. **this PR - end-to-end coverage**

Base: `feature/acl-sampling-install-script`

## Validation

Every local validation command ran in a transient systemd scope with `MemoryMax=2G` and `MemorySwapMax=0`.

- `bash -n hack/acl-sampling-e2e.sh`
- `shellcheck hack/acl-sampling-e2e.sh`
- parsed `.github/workflows/build-x86-image.yaml` as YAML
- `git diff --check`

The Kind scenario was not run locally because this workspace prohibits high-memory local workloads. The new dedicated GitHub Actions job is the execution evidence for the cluster-level scenario.
