### PR TITLE
feat: attach sampling to NetworkPolicy ACLs

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -2499,6 +2499,35 @@ func (m *MockACLSampling) EXPECT() *MockACLSamplingMockRecorder {
 	return m.recorder
 }
 
+// ApplyNetworkPolicyACLSampling mocks base method.
+func (m *MockACLSampling) ApplyNetworkPolicyACLSampling(config aclsampling.ControllerConfig, request *ovs.NetworkPolicySamplingRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyNetworkPolicyACLSampling", config, request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyNetworkPolicyACLSampling indicates an expected call of ApplyNetworkPolicyACLSampling.
+func (mr *MockACLSamplingMockRecorder) ApplyNetworkPolicyACLSampling(config, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyNetworkPolicyACLSampling", reflect.TypeOf((*MockACLSampling)(nil).ApplyNetworkPolicyACLSampling), config, request)
+}
+
+// PrepareNetworkPolicyACLSampling mocks base method.
+func (m *MockACLSampling) PrepareNetworkPolicyACLSampling(pgName, namespace, name, uid string) (*ovs.NetworkPolicySamplingRequest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareNetworkPolicyACLSampling", pgName, namespace, name, uid)
+	ret0, _ := ret[0].(*ovs.NetworkPolicySamplingRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrepareNetworkPolicyACLSampling indicates an expected call of PrepareNetworkPolicyACLSampling.
+func (mr *MockACLSamplingMockRecorder) PrepareNetworkPolicyACLSampling(pgName, namespace, name, uid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareNetworkPolicyACLSampling", reflect.TypeOf((*MockACLSampling)(nil).PrepareNetworkPolicyACLSampling), pgName, namespace, name, uid)
+}
+
 // ReconcileACLSampling mocks base method.
 func (m *MockACLSampling) ReconcileACLSampling(config aclsampling.ControllerConfig) error {
 	m.ctrl.T.Helper()
@@ -3470,6 +3499,20 @@ func (mr *MockNbClientMockRecorder) AddressSetUpdateAddress(asName any, addresse
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{asName}, addresses...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressSetUpdateAddress", reflect.TypeOf((*MockNbClient)(nil).AddressSetUpdateAddress), varargs...)
+}
+
+// ApplyNetworkPolicyACLSampling mocks base method.
+func (m *MockNbClient) ApplyNetworkPolicyACLSampling(config aclsampling.ControllerConfig, request *ovs.NetworkPolicySamplingRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyNetworkPolicyACLSampling", config, request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyNetworkPolicyACLSampling indicates an expected call of ApplyNetworkPolicyACLSampling.
+func (mr *MockNbClientMockRecorder) ApplyNetworkPolicyACLSampling(config, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyNetworkPolicyACLSampling", reflect.TypeOf((*MockNbClient)(nil).ApplyNetworkPolicyACLSampling), config, request)
 }
 
 // BatchAddLogicalRouterPolicy mocks base method.
@@ -5471,6 +5514,21 @@ func (m *MockNbClient) ReconcileGatewayChassises(lrpName string, chassises []str
 	ret := m.ctrl.Call(m, "ReconcileGatewayChassises", lrpName, chassises)
 	ret0, _ := ret[0].(error)
 	return ret0
+}
+
+// PrepareNetworkPolicyACLSampling mocks base method.
+func (m *MockNbClient) PrepareNetworkPolicyACLSampling(pgName, namespace, name, uid string) (*ovs.NetworkPolicySamplingRequest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareNetworkPolicyACLSampling", pgName, namespace, name, uid)
+	ret0, _ := ret[0].(*ovs.NetworkPolicySamplingRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrepareNetworkPolicyACLSampling indicates an expected call of PrepareNetworkPolicyACLSampling.
+func (mr *MockNbClientMockRecorder) PrepareNetworkPolicyACLSampling(pgName, namespace, name, uid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareNetworkPolicyACLSampling", reflect.TypeOf((*MockNbClient)(nil).PrepareNetworkPolicyACLSampling), pgName, namespace, name, uid)
 }
 
 // ReconcileACLSampling mocks base method.

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -201,6 +201,8 @@ type ACL interface {
 
 type ACLSampling interface {
 	ReconcileACLSampling(config aclsampling.ControllerConfig) error
+	PrepareNetworkPolicyACLSampling(pgName, namespace, name, uid string) (*NetworkPolicySamplingRequest, error)
+	ApplyNetworkPolicyACLSampling(config aclsampling.ControllerConfig, request *NetworkPolicySamplingRequest) error
 }
 
 type AddressSet interface {

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -81,7 +81,7 @@ func (c *OVNNbClient) UpdateDefaultBlockACLOps(npName, pgName, direction string,
 	}
 
 	options := func(acl *ovnnb.ACL) {
-		setACLName(acl, npName)
+		setNetworkPolicyACLName(acl, npName)
 		if loggingEnabled {
 			acl.Log = true
 			acl.Severity = ptr.To(ovnnb.ACLSeverityWarning)

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -204,7 +204,7 @@ func (c *OVNNbClient) UpdateIngressACLOps(pgName, asIngressName, asExceptName, p
 	matches := newNetworkPolicyACLMatch(pgName, asIngressName, asExceptName, protocol, ovnnb.ACLDirectionToLport, npp, namedPortMap)
 	for _, m := range matches {
 		options := func(acl *ovnnb.ACL) {
-			setACLName(acl, aclName)
+			setNetworkPolicyACLName(acl, aclName)
 			if logEnable && slices.Contains(logACLActions, ovnnb.ACLActionAllow) {
 				acl.Log = true
 				if logEnable && logRate > 0 {
@@ -249,7 +249,7 @@ func (c *OVNNbClient) UpdateEgressACLOps(pgName, asEgressName, asExceptName, pro
 	matches := newNetworkPolicyACLMatch(pgName, asEgressName, asExceptName, protocol, ovnnb.ACLDirectionFromLport, npp, namedPortMap)
 	for _, m := range matches {
 		allowACL, err := c.newACLWithoutCheck(pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, ovnnb.ACLActionAllowRelated, util.NetpolACLTier, func(acl *ovnnb.ACL) {
-			setACLName(acl, aclName)
+			setNetworkPolicyACLName(acl, aclName)
 			if acl.Options == nil {
 				acl.Options = make(map[string]string)
 			}
@@ -1391,7 +1391,7 @@ func (c *OVNNbClient) UpdateIngressIPBlockACLOps(pgName, protocol, aclName strin
 	acls := make([]*ovnnb.ACL, 0, len(matches))
 	for _, m := range matches {
 		options := func(acl *ovnnb.ACL) {
-			setACLName(acl, aclName)
+			setNetworkPolicyACLName(acl, aclName)
 			if logEnable && slices.Contains(logACLActions, ovnnb.ACLActionAllow) {
 				acl.Log = true
 				if logRate > 0 {
@@ -1421,7 +1421,7 @@ func (c *OVNNbClient) UpdateEgressIPBlockACLOps(pgName, protocol, aclName string
 	acls := make([]*ovnnb.ACL, 0, len(matches))
 	for _, m := range matches {
 		allowACL, err := c.newACLWithoutCheck(pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, m, ovnnb.ACLActionAllowRelated, util.NetpolACLTier, func(acl *ovnnb.ACL) {
-			setACLName(acl, aclName)
+			setNetworkPolicyACLName(acl, aclName)
 			if acl.Options == nil {
 				acl.Options = make(map[string]string)
 			}

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -160,6 +160,9 @@ func (suite *OvnClientTestSuite) testUpdateDefaultBlockACLOps() {
 		require.Len(t, ops, 2)
 
 		expect(ops[0].Row, "drop", ovnnb.ACLDirectionToLport, fmt.Sprintf("outport == @%s && ip", pgName), util.IngressDefaultDrop)
+		externalIDs, ok := ops[0].Row["external_ids"].(ovsdb.OvsMap)
+		require.True(t, ok)
+		require.Equal(t, netpol, externalIDs.GoMap[networkPolicyACLNameExternalID])
 	})
 
 	t.Run("default block egress", func(t *testing.T) {

--- a/pkg/ovs/ovn-nb-network-policy-sampling.go
+++ b/pkg/ovs/ovn-nb-network-policy-sampling.go
@@ -124,7 +124,11 @@ func (c *OVNNbClient) ApplyNetworkPolicyACLSampling(config aclsampling.Controlle
 	}
 	eligible := make([]eligibleNetworkPolicyACL, 0, len(acls))
 	for _, acl := range acls {
-		if candidate, ok := classifyNetworkPolicySamplingACL(acl); ok {
+		candidate, ok, err := classifyNetworkPolicySamplingACL(acl)
+		if err != nil {
+			return fmt.Errorf("classify NetworkPolicy ACL %s for sampling: %w", acl.UUID, err)
+		}
+		if ok {
 			eligible = append(eligible, candidate)
 		}
 	}
@@ -271,19 +275,31 @@ func (c *OVNNbClient) networkPolicySampleCollectors() (map[string]*ovnnb.SampleC
 	return result, nil
 }
 
-func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, bool) {
+func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, bool, error) {
 	if acl.Tier != util.NetpolACLTier {
-		return eligibleNetworkPolicyACL{}, false
+		return eligibleNetworkPolicyACL{}, false, nil
 	}
 	direction, ok := networkPolicyDirection(acl.Direction)
 	if !ok {
-		return eligibleNetworkPolicyACL{}, false
+		return eligibleNetworkPolicyACL{}, false, nil
 	}
-	allowPriority := mustPriority(util.IngressAllowPriority)
-	defaultDropPriority := mustPriority(util.IngressDefaultDrop)
+	allowPriority, err := strconv.Atoi(util.IngressAllowPriority)
+	if err != nil {
+		return eligibleNetworkPolicyACL{}, false, fmt.Errorf("parse ingress allow priority: %w", err)
+	}
+	defaultDropPriority, err := strconv.Atoi(util.IngressDefaultDrop)
+	if err != nil {
+		return eligibleNetworkPolicyACL{}, false, fmt.Errorf("parse ingress default-drop priority: %w", err)
+	}
 	if direction == aclsampling.DirectionEgress {
-		allowPriority = mustPriority(util.EgressAllowPriority)
-		defaultDropPriority = mustPriority(util.EgressDefaultDrop)
+		allowPriority, err = strconv.Atoi(util.EgressAllowPriority)
+		if err != nil {
+			return eligibleNetworkPolicyACL{}, false, fmt.Errorf("parse egress allow priority: %w", err)
+		}
+		defaultDropPriority, err = strconv.Atoi(util.EgressDefaultDrop)
+		if err != nil {
+			return eligibleNetworkPolicyACL{}, false, fmt.Errorf("parse egress default-drop priority: %w", err)
+		}
 	}
 
 	if acl.Action == ovnnb.ACLActionDrop && acl.Priority == defaultDropPriority {
@@ -293,10 +309,10 @@ func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, 
 			role:      aclsampling.RoleDefaultDeny,
 			protocol:  defaultDenyProtocol,
 			verdict:   aclsampling.RoleDefaultDeny,
-		}, true
+		}, true, nil
 	}
 	if acl.Action != ovnnb.ACLActionAllowRelated || acl.Priority != allowPriority {
-		return eligibleNetworkPolicyACL{}, false
+		return eligibleNetworkPolicyACL{}, false, nil
 	}
 
 	aclName := acl.ExternalIDs[networkPolicyACLNameExternalID]
@@ -305,17 +321,17 @@ func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, 
 	}
 	parts := strings.Split(aclName, "/")
 	if len(parts) != 5 && (len(parts) != 6 || parts[5] != "ipBlock") {
-		return eligibleNetworkPolicyACL{}, false
+		return eligibleNetworkPolicyACL{}, false, nil
 	}
 	if parts[0] != "np" || (parts[2] != "ingress" && parts[2] != "egress") || parts[3] == "" {
-		return eligibleNetworkPolicyACL{}, false
+		return eligibleNetworkPolicyACL{}, false, nil
 	}
 	if (parts[2] == "ingress") != (direction == aclsampling.DirectionIngress) {
-		return eligibleNetworkPolicyACL{}, false
+		return eligibleNetworkPolicyACL{}, false, nil
 	}
 	ruleIndex, err := strconv.Atoi(parts[4])
 	if err != nil || ruleIndex < 0 {
-		return eligibleNetworkPolicyACL{}, false
+		return eligibleNetworkPolicyACL{}, false, nil
 	}
 	return eligibleNetworkPolicyACL{
 		acl:       acl,
@@ -324,7 +340,7 @@ func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, 
 		role:      aclsampling.RoleRuleAllow,
 		protocol:  parts[3],
 		verdict:   "allow",
-	}, true
+	}, true, nil
 }
 
 func setNetworkPolicyACLName(acl *ovnnb.ACL, name string) {
@@ -341,11 +357,6 @@ func networkPolicyDirection(direction string) (string, bool) {
 	default:
 		return "", false
 	}
-}
-
-func mustPriority(value string) int {
-	priority, _ := strconv.Atoi(value)
-	return priority
 }
 
 func storedNetworkPolicySampleMappings(acls []ovnnb.ACL) ([]aclsampling.OccupiedMetadata, error) {

--- a/pkg/ovs/ovn-nb-network-policy-sampling.go
+++ b/pkg/ovs/ovn-nb-network-policy-sampling.go
@@ -1,0 +1,528 @@
+package ovs
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/ovn-kubernetes/libovsdb/model"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+const (
+	sampleSchemaVersionExternalID  = "kube-ovn.io/sample-schema-version"
+	sampleFeatureExternalID        = "kube-ovn.io/sample-feature"
+	sampleRoleExternalID           = "kube-ovn.io/sample-role"
+	policyAPIVersionExternalID     = "kube-ovn.io/policy-api-version"
+	policyKindExternalID           = "kube-ovn.io/policy-kind"
+	policyNamespaceExternalID      = "kube-ovn.io/policy-namespace"
+	policyNameExternalID           = "kube-ovn.io/policy-name"
+	policyUIDExternalID            = "kube-ovn.io/policy-uid"
+	policyDirectionExternalID      = "kube-ovn.io/policy-direction"
+	policyRuleIndexExternalID      = "kube-ovn.io/policy-rule-index"
+	policyVerdictExternalID        = "kube-ovn.io/policy-verdict"
+	ovnActionExternalID            = "kube-ovn.io/ovn-action"
+	aclMatchHashExternalID         = "kube-ovn.io/acl-match-hash"
+	sampleKeyHashExternalID        = "kube-ovn.io/sample-key-hash"
+	sampleMetadataExternalID       = "kube-ovn.io/sample-metadata"
+	networkPolicyACLNameExternalID = "kube-ovn.io/network-policy-acl-name"
+
+	networkPolicySampleFeature = "network-policy"
+	networkPolicyAPIVersion    = "networking.k8s.io/v1"
+	networkPolicyKind          = "NetworkPolicy"
+	defaultDenyProtocol        = "IP"
+)
+
+var networkPolicySamplingExternalIDs = []string{
+	sampleSchemaVersionExternalID,
+	sampleFeatureExternalID,
+	sampleRoleExternalID,
+	policyAPIVersionExternalID,
+	policyKindExternalID,
+	policyNamespaceExternalID,
+	policyNameExternalID,
+	policyUIDExternalID,
+	policyDirectionExternalID,
+	policyRuleIndexExternalID,
+	policyVerdictExternalID,
+	ovnActionExternalID,
+	aclMatchHashExternalID,
+	sampleKeyHashExternalID,
+	sampleMetadataExternalID,
+}
+
+// NetworkPolicySamplingRequest carries the metadata snapshot that must be
+// taken before enforcement replaces a NetworkPolicy's ACLs. Callers treat the
+// value as opaque and apply it only after all enforcement transactions succeed.
+type NetworkPolicySamplingRequest struct {
+	portGroup       string
+	policyNamespace string
+	policyName      string
+	policyUID       string
+	previous        []aclsampling.OccupiedMetadata
+}
+
+type eligibleNetworkPolicyACL struct {
+	acl       ovnnb.ACL
+	direction string
+	ruleIndex *int
+	role      string
+	protocol  string
+	verdict   string
+}
+
+// PrepareNetworkPolicyACLSampling snapshots the stable metadata mappings from
+// ACLs that an enforcement transaction is about to replace.
+func (c *OVNNbClient) PrepareNetworkPolicyACLSampling(pgName, namespace, name, uid string) (*NetworkPolicySamplingRequest, error) {
+	request := &NetworkPolicySamplingRequest{
+		portGroup:       pgName,
+		policyNamespace: namespace,
+		policyName:      name,
+		policyUID:       uid,
+	}
+	if pgName == "" || namespace == "" || name == "" || uid == "" {
+		return request, errors.New("network policy sampling request fields must not be empty")
+	}
+
+	acls, err := c.ListAcls("", map[string]string{aclParentKey: pgName})
+	if err != nil {
+		return request, fmt.Errorf("snapshot NetworkPolicy ACL sampling metadata: %w", err)
+	}
+	request.previous, err = storedNetworkPolicySampleMappings(acls)
+	if err != nil {
+		return request, fmt.Errorf("snapshot NetworkPolicy ACL sampling metadata: %w", err)
+	}
+	return request, nil
+}
+
+// ApplyNetworkPolicyACLSampling attaches best-effort sampling to the eligible
+// ACLs in a transaction separate from NetworkPolicy enforcement.
+func (c *OVNNbClient) ApplyNetworkPolicyACLSampling(config aclsampling.ControllerConfig, request *NetworkPolicySamplingRequest) error {
+	if request == nil {
+		return errors.New("network policy sampling request must not be nil")
+	}
+	if !config.Enabled {
+		return nil
+	}
+	if err := c.ReconcileACLSampling(config); err != nil {
+		return err
+	}
+
+	acls, err := c.ListAcls("", map[string]string{aclParentKey: request.portGroup})
+	if err != nil {
+		return fmt.Errorf("list NetworkPolicy ACLs for sampling: %w", err)
+	}
+	eligible := make([]eligibleNetworkPolicyACL, 0, len(acls))
+	for _, acl := range acls {
+		if candidate, ok := classifyNetworkPolicySamplingACL(acl); ok {
+			eligible = append(eligible, candidate)
+		}
+	}
+	if len(eligible) == 0 {
+		return nil
+	}
+
+	samples, err := c.listSamples()
+	if err != nil {
+		return err
+	}
+	allACLs, err := c.ListAcls("", nil)
+	if err != nil {
+		return fmt.Errorf("list ACL sample metadata reservations: %w", err)
+	}
+	occupied, err := currentSampleMetadata(samples, allACLs, request.previous)
+	if err != nil {
+		return err
+	}
+	allocator, err := aclsampling.NewAllocator(occupied)
+	if err != nil {
+		return fmt.Errorf("initialize ACL sample metadata allocator: %w", err)
+	}
+
+	collectors, err := c.networkPolicySampleCollectors()
+	if err != nil {
+		return err
+	}
+	samplesByMetadata := make(map[uint32]*ovnnb.Sample, len(samples)+len(eligible))
+	for i := range samples {
+		sample := &samples[i]
+		metadata, err := networkPolicySampleMetadata(sample.Metadata)
+		if err != nil {
+			return fmt.Errorf("sample %s: %w", sample.UUID, err)
+		}
+		samplesByMetadata[metadata] = sample
+	}
+	operations, err := c.networkPolicySamplingOps(config, request, eligible, allocator, collectors, samplesByMetadata)
+	if err != nil {
+		return err
+	}
+	if len(operations) == 0 {
+		return nil
+	}
+	if err := c.Transact("network-policy-acl-sampling-attach", operations); err != nil {
+		return fmt.Errorf("attach NetworkPolicy ACL sampling: %w", err)
+	}
+	return nil
+}
+
+func (c *OVNNbClient) networkPolicySamplingOps(config aclsampling.ControllerConfig, request *NetworkPolicySamplingRequest, eligible []eligibleNetworkPolicyACL, allocator *aclsampling.Allocator, collectors map[string]*ovnnb.SampleCollector, samplesByMetadata map[uint32]*ovnnb.Sample) ([]ovsdb.Operation, error) {
+	operations := make([]ovsdb.Operation, 0, len(eligible)*2)
+	for i := range eligible {
+		candidate := &eligible[i]
+		owned := candidate.acl.ExternalIDs[sampleFeatureExternalID] == networkPolicySampleFeature
+		enabled := config.AllowProbabilityPercent != 0
+		collector := collectors[aclSamplingRoleAllow]
+		if candidate.role == aclsampling.RoleDefaultDeny {
+			enabled = config.DefaultDenyProbabilityPercent != 0
+			collector = collectors[aclSamplingRoleDefaultDeny]
+		}
+		if !enabled {
+			if !owned {
+				continue
+			}
+			ops, err := c.clearNetworkPolicySamplingOps(&candidate.acl)
+			if err != nil {
+				return nil, err
+			}
+			operations = append(operations, ops...)
+			continue
+		}
+		if feature := candidate.acl.ExternalIDs[sampleFeatureExternalID]; feature != "" && !owned {
+			return nil, fmt.Errorf("ACL %s has sampling metadata owned by feature %s", candidate.acl.UUID, feature)
+		}
+		if !owned && (candidate.acl.SampleNew != nil || candidate.acl.SampleEst != nil) {
+			return nil, fmt.Errorf("ACL %s has unowned sample references", candidate.acl.UUID)
+		}
+
+		allocation, err := allocator.Allocate(aclsampling.SampleKey{
+			SchemaVersion: aclsampling.SchemaVersionV1,
+			PolicyUID:     request.policyUID,
+			Direction:     candidate.direction,
+			RuleIndex:     candidate.ruleIndex,
+			Role:          candidate.role,
+			Protocol:      candidate.protocol,
+			ACLMatchHash:  aclsampling.HashACLMatch(candidate.acl.Match),
+			OVNAction:     candidate.acl.Action,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("allocate sample metadata for ACL %s: %w", candidate.acl.UUID, err)
+		}
+
+		sampleUUID, sampleOps, err := c.ensureNetworkPolicySample(allocation.Metadata, collector, samplesByMetadata)
+		if err != nil {
+			return nil, err
+		}
+		operations = append(operations, sampleOps...)
+		aclOps, err := c.setNetworkPolicySamplingOps(&candidate.acl, request, *candidate, allocation, sampleUUID)
+		if err != nil {
+			return nil, err
+		}
+		operations = append(operations, aclOps...)
+	}
+	return operations, nil
+}
+
+func (c *OVNNbClient) listSamples() ([]ovnnb.Sample, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	samples := make([]ovnnb.Sample, 0)
+	if err := c.WhereCache(func(*ovnnb.Sample) bool { return true }).List(ctx, &samples); err != nil {
+		return nil, fmt.Errorf("list OVN samples: %w", err)
+	}
+	return samples, nil
+}
+
+func (c *OVNNbClient) networkPolicySampleCollectors() (map[string]*ovnnb.SampleCollector, error) {
+	collectors, err := c.listSampleCollectors()
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]*ovnnb.SampleCollector, 2)
+	for i := range collectors {
+		collector := &collectors[i]
+		if !isOwnedACLSamplingObject(collector.ExternalIDs) {
+			continue
+		}
+		role := collector.ExternalIDs[aclSamplingRoleExternalID]
+		if role != aclSamplingRoleAllow && role != aclSamplingRoleDefaultDeny {
+			continue
+		}
+		if result[role] != nil {
+			return nil, fmt.Errorf("multiple owned sample collectors have role %s", role)
+		}
+		result[role] = collector
+	}
+	for _, role := range []string{aclSamplingRoleAllow, aclSamplingRoleDefaultDeny} {
+		if result[role] == nil {
+			return nil, fmt.Errorf("owned %s sample collector is not available", role)
+		}
+	}
+	return result, nil
+}
+
+func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, bool) {
+	if acl.Tier != util.NetpolACLTier {
+		return eligibleNetworkPolicyACL{}, false
+	}
+	direction, ok := networkPolicyDirection(acl.Direction)
+	if !ok {
+		return eligibleNetworkPolicyACL{}, false
+	}
+	allowPriority := mustPriority(util.IngressAllowPriority)
+	defaultDropPriority := mustPriority(util.IngressDefaultDrop)
+	if direction == aclsampling.DirectionEgress {
+		allowPriority = mustPriority(util.EgressAllowPriority)
+		defaultDropPriority = mustPriority(util.EgressDefaultDrop)
+	}
+
+	if acl.Action == ovnnb.ACLActionDrop && acl.Priority == defaultDropPriority {
+		return eligibleNetworkPolicyACL{
+			acl:       acl,
+			direction: direction,
+			role:      aclsampling.RoleDefaultDeny,
+			protocol:  defaultDenyProtocol,
+			verdict:   aclsampling.RoleDefaultDeny,
+		}, true
+	}
+	if acl.Action != ovnnb.ACLActionAllowRelated || acl.Priority != allowPriority {
+		return eligibleNetworkPolicyACL{}, false
+	}
+
+	aclName := acl.ExternalIDs[networkPolicyACLNameExternalID]
+	if aclName == "" && acl.Name != nil {
+		aclName = *acl.Name
+	}
+	parts := strings.Split(aclName, "/")
+	if len(parts) != 5 && (len(parts) != 6 || parts[5] != "ipBlock") {
+		return eligibleNetworkPolicyACL{}, false
+	}
+	if parts[0] != "np" || (parts[2] != "ingress" && parts[2] != "egress") || parts[3] == "" {
+		return eligibleNetworkPolicyACL{}, false
+	}
+	if (parts[2] == "ingress") != (direction == aclsampling.DirectionIngress) {
+		return eligibleNetworkPolicyACL{}, false
+	}
+	ruleIndex, err := strconv.Atoi(parts[4])
+	if err != nil || ruleIndex < 0 {
+		return eligibleNetworkPolicyACL{}, false
+	}
+	return eligibleNetworkPolicyACL{
+		acl:       acl,
+		direction: direction,
+		ruleIndex: &ruleIndex,
+		role:      aclsampling.RoleRuleAllow,
+		protocol:  parts[3],
+		verdict:   "allow",
+	}, true
+}
+
+func setNetworkPolicyACLName(acl *ovnnb.ACL, name string) {
+	setACLName(acl, name)
+	acl.ExternalIDs[networkPolicyACLNameExternalID] = name
+}
+
+func networkPolicyDirection(direction string) (string, bool) {
+	switch direction {
+	case ovnnb.ACLDirectionToLport:
+		return aclsampling.DirectionIngress, true
+	case ovnnb.ACLDirectionFromLport:
+		return aclsampling.DirectionEgress, true
+	default:
+		return "", false
+	}
+}
+
+func mustPriority(value string) int {
+	priority, _ := strconv.Atoi(value)
+	return priority
+}
+
+func storedNetworkPolicySampleMappings(acls []ovnnb.ACL) ([]aclsampling.OccupiedMetadata, error) {
+	mappings := make([]aclsampling.OccupiedMetadata, 0)
+	for _, acl := range acls {
+		if acl.ExternalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
+			continue
+		}
+		mapping, err := storedNetworkPolicySampleMapping(acl.ExternalIDs)
+		if err != nil {
+			return nil, fmt.Errorf("ACL %s: %w", acl.UUID, err)
+		}
+		mappings = append(mappings, mapping)
+	}
+	return mappings, nil
+}
+
+func storedNetworkPolicySampleMapping(externalIDs map[string]string) (aclsampling.OccupiedMetadata, error) {
+	metadataValue := externalIDs[sampleMetadataExternalID]
+	keyHash := externalIDs[sampleKeyHashExternalID]
+	metadata, err := strconv.ParseUint(metadataValue, 10, 32)
+	if err != nil || metadata == 0 {
+		return aclsampling.OccupiedMetadata{}, fmt.Errorf("invalid sample metadata %q", metadataValue)
+	}
+	decoded, err := hex.DecodeString(keyHash)
+	if err != nil || len(decoded) != 32 || strings.ToLower(keyHash) != keyHash {
+		return aclsampling.OccupiedMetadata{}, fmt.Errorf("invalid sample key hash %q", keyHash)
+	}
+	return aclsampling.OccupiedMetadata{Metadata: uint32(metadata), KeyHash: keyHash}, nil
+}
+
+func networkPolicySampleMetadata(value int) (uint32, error) {
+	metadata, err := strconv.ParseUint(strconv.Itoa(value), 10, 32)
+	if err != nil || metadata == 0 {
+		return 0, fmt.Errorf("invalid sample metadata %d", value)
+	}
+	return uint32(metadata), nil
+}
+
+func currentSampleMetadata(samples []ovnnb.Sample, acls []ovnnb.ACL, previous []aclsampling.OccupiedMetadata) ([]aclsampling.OccupiedMetadata, error) {
+	metadataIndex := make(map[uint32]int, len(samples))
+	sampleMetadata := make(map[string]uint32, len(samples))
+	occupied := make([]aclsampling.OccupiedMetadata, 0, len(samples)+len(previous))
+	for _, sample := range samples {
+		metadata, err := networkPolicySampleMetadata(sample.Metadata)
+		if err != nil {
+			return nil, fmt.Errorf("sample %s: %w", sample.UUID, err)
+		}
+		metadataIndex[metadata] = len(occupied)
+		sampleMetadata[sample.UUID] = metadata
+		occupied = append(occupied, aclsampling.OccupiedMetadata{Metadata: metadata})
+	}
+
+	for _, acl := range acls {
+		if acl.ExternalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
+			continue
+		}
+		mapping, err := storedNetworkPolicySampleMapping(acl.ExternalIDs)
+		if err != nil {
+			return nil, fmt.Errorf("read ACL %s sample metadata: %w", acl.UUID, err)
+		}
+		for _, sampleUUID := range compactSampleReferences(acl) {
+			metadata, ok := sampleMetadata[sampleUUID]
+			if !ok {
+				return nil, fmt.Errorf("ACL %s references unknown sample %s", acl.UUID, sampleUUID)
+			}
+			if metadata != mapping.Metadata {
+				return nil, fmt.Errorf("ACL %s sample reference metadata %d does not match external ID %d", acl.UUID, metadata, mapping.Metadata)
+			}
+			index := metadataIndex[metadata]
+			if occupied[index].KeyHash != "" && occupied[index].KeyHash != mapping.KeyHash {
+				return nil, fmt.Errorf("sample metadata %d has conflicting key hashes", metadata)
+			}
+			occupied[index].KeyHash = mapping.KeyHash
+		}
+	}
+
+	for _, mapping := range previous {
+		if index, ok := metadataIndex[mapping.Metadata]; ok {
+			if occupied[index].KeyHash == mapping.KeyHash {
+				continue
+			}
+			// The previous metadata has been claimed since the snapshot. Keep
+			// the current reservation and let the allocator probe a new value.
+			continue
+		}
+		metadataIndex[mapping.Metadata] = len(occupied)
+		occupied = append(occupied, mapping)
+	}
+	return occupied, nil
+}
+
+func compactSampleReferences(acl ovnnb.ACL) []string {
+	references := make([]string, 0, 2)
+	if acl.SampleNew != nil {
+		references = append(references, *acl.SampleNew)
+	}
+	if acl.SampleEst != nil && (acl.SampleNew == nil || *acl.SampleEst != *acl.SampleNew) {
+		references = append(references, *acl.SampleEst)
+	}
+	return references
+}
+
+func (c *OVNNbClient) ensureNetworkPolicySample(metadata uint32, collector *ovnnb.SampleCollector, samplesByMetadata map[uint32]*ovnnb.Sample) (string, []ovsdb.Operation, error) {
+	if sample := samplesByMetadata[metadata]; sample != nil {
+		if !slices.Equal(sample.Collectors, []string{collector.UUID}) {
+			return "", nil, fmt.Errorf("sample metadata %d is associated with unexpected collectors", metadata)
+		}
+		return sample.UUID, nil, nil
+	}
+
+	sample := &ovnnb.Sample{
+		UUID:       ovsclient.NamedUUID(),
+		Collectors: []string{collector.UUID},
+		Metadata:   int(metadata),
+	}
+	ops, err := c.Create(model.Model(sample))
+	if err != nil {
+		return "", nil, fmt.Errorf("build create operation for sample metadata %d: %w", metadata, err)
+	}
+	samplesByMetadata[metadata] = sample
+	return sample.UUID, ops, nil
+}
+
+func (c *OVNNbClient) setNetworkPolicySamplingOps(acl *ovnnb.ACL, request *NetworkPolicySamplingRequest, candidate eligibleNetworkPolicyACL, allocation aclsampling.Allocation, sampleUUID string) ([]ovsdb.Operation, error) {
+	externalIDs := maps.Clone(acl.ExternalIDs)
+	if externalIDs == nil {
+		externalIDs = make(map[string]string, len(networkPolicySamplingExternalIDs))
+	}
+	externalIDs[sampleSchemaVersionExternalID] = aclsampling.SchemaVersionV1
+	externalIDs[sampleFeatureExternalID] = networkPolicySampleFeature
+	externalIDs[sampleRoleExternalID] = candidate.role
+	externalIDs[policyAPIVersionExternalID] = networkPolicyAPIVersion
+	externalIDs[policyKindExternalID] = networkPolicyKind
+	externalIDs[policyNamespaceExternalID] = request.policyNamespace
+	externalIDs[policyNameExternalID] = request.policyName
+	externalIDs[policyUIDExternalID] = request.policyUID
+	externalIDs[policyDirectionExternalID] = candidate.direction
+	externalIDs[policyVerdictExternalID] = candidate.verdict
+	externalIDs[ovnActionExternalID] = candidate.acl.Action
+	externalIDs[aclMatchHashExternalID] = aclsampling.HashACLMatch(candidate.acl.Match)
+	externalIDs[sampleKeyHashExternalID] = allocation.KeyHash
+	externalIDs[sampleMetadataExternalID] = strconv.FormatUint(uint64(allocation.Metadata), 10)
+	if candidate.ruleIndex == nil {
+		delete(externalIDs, policyRuleIndexExternalID)
+	} else {
+		externalIDs[policyRuleIndexExternalID] = strconv.Itoa(*candidate.ruleIndex)
+	}
+
+	acl.ExternalIDs = externalIDs
+	acl.SampleNew = &sampleUUID
+	if candidate.role == aclsampling.RoleRuleAllow {
+		acl.SampleEst = &sampleUUID
+	} else {
+		acl.SampleEst = nil
+	}
+	ops, err := c.Where(acl).Update(acl, &acl.ExternalIDs, &acl.SampleNew, &acl.SampleEst)
+	if err != nil {
+		return nil, fmt.Errorf("build sample attachment operation for ACL %s: %w", acl.UUID, err)
+	}
+	return ops, nil
+}
+
+func (c *OVNNbClient) clearNetworkPolicySamplingOps(acl *ovnnb.ACL) ([]ovsdb.Operation, error) {
+	if acl.SampleNew == nil && acl.SampleEst == nil && acl.ExternalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
+		return nil, nil
+	}
+	externalIDs := maps.Clone(acl.ExternalIDs)
+	for _, key := range networkPolicySamplingExternalIDs {
+		delete(externalIDs, key)
+	}
+	acl.ExternalIDs = externalIDs
+	acl.SampleNew = nil
+	acl.SampleEst = nil
+	ops, err := c.Where(acl).Update(acl, &acl.ExternalIDs, &acl.SampleNew, &acl.SampleEst)
+	if err != nil {
+		return nil, fmt.Errorf("build sample cleanup operation for ACL %s: %w", acl.UUID, err)
+	}
+	return ops, nil
+}

--- a/pkg/ovs/ovn-nb-network-policy-sampling.go
+++ b/pkg/ovs/ovn-nb-network-policy-sampling.go
@@ -41,7 +41,12 @@ const (
 	networkPolicyAPIVersion    = "networking.k8s.io/v1"
 	networkPolicyKind          = "NetworkPolicy"
 	defaultDenyProtocol        = "IP"
+
+	networkPolicyVerdictAllow       networkPolicyVerdict = "allow"
+	networkPolicyVerdictDefaultDeny networkPolicyVerdict = "default-deny"
 )
+
+type networkPolicyVerdict string
 
 var networkPolicySamplingExternalIDs = []string{
 	sampleSchemaVersionExternalID,
@@ -74,11 +79,11 @@ type NetworkPolicySamplingRequest struct {
 
 type eligibleNetworkPolicyACL struct {
 	acl       ovnnb.ACL
-	direction string
+	direction aclsampling.PolicyDirection
 	ruleIndex *int
-	role      string
+	role      aclsampling.ACLRole
 	protocol  string
-	verdict   string
+	verdict   networkPolicyVerdict
 }
 
 // PrepareNetworkPolicyACLSampling snapshots the stable metadata mappings from
@@ -166,74 +171,69 @@ func (c *OVNNbClient) ApplyNetworkPolicyACLSampling(config aclsampling.Controlle
 		}
 		samplesByMetadata[metadata] = sample
 	}
-	operations, err := c.networkPolicySamplingOps(config, request, eligible, allocator, collectors, samplesByMetadata)
-	if err != nil {
-		return err
-	}
-	if len(operations) == 0 {
-		return nil
-	}
-	if err := c.Transact("network-policy-acl-sampling-attach", operations); err != nil {
-		return fmt.Errorf("attach NetworkPolicy ACL sampling: %w", err)
-	}
-	return nil
-}
-
-func (c *OVNNbClient) networkPolicySamplingOps(config aclsampling.ControllerConfig, request *NetworkPolicySamplingRequest, eligible []eligibleNetworkPolicyACL, allocator *aclsampling.Allocator, collectors map[string]*ovnnb.SampleCollector, samplesByMetadata map[uint32]*ovnnb.Sample) ([]ovsdb.Operation, error) {
-	operations := make([]ovsdb.Operation, 0, len(eligible)*2)
+	applyErrors := make([]error, 0)
 	for i := range eligible {
 		candidate := &eligible[i]
-		owned := candidate.acl.ExternalIDs[sampleFeatureExternalID] == networkPolicySampleFeature
-		enabled := config.AllowProbabilityPercent != 0
-		collector := collectors[aclSamplingRoleAllow]
-		if candidate.role == aclsampling.RoleDefaultDeny {
-			enabled = config.DefaultDenyProbabilityPercent != 0
-			collector = collectors[aclSamplingRoleDefaultDeny]
-		}
-		if !enabled {
-			if !owned {
-				continue
-			}
-			ops, err := c.clearNetworkPolicySamplingOps(&candidate.acl)
-			if err != nil {
-				return nil, err
-			}
-			operations = append(operations, ops...)
+		operations, err := c.networkPolicySamplingOps(config, request, candidate, allocator, collectors, samplesByMetadata)
+		if err != nil {
+			applyErrors = append(applyErrors, fmt.Errorf("ACL %s: %w", candidate.acl.UUID, err))
 			continue
 		}
-		if feature := candidate.acl.ExternalIDs[sampleFeatureExternalID]; feature != "" && !owned {
-			return nil, fmt.Errorf("ACL %s has sampling metadata owned by feature %s", candidate.acl.UUID, feature)
+		if len(operations) == 0 {
+			continue
 		}
-		if !owned && (candidate.acl.SampleNew != nil || candidate.acl.SampleEst != nil) {
-			return nil, fmt.Errorf("ACL %s has unowned sample references", candidate.acl.UUID)
+		if err := c.Transact("network-policy-acl-sampling-attach", operations); err != nil {
+			applyErrors = append(applyErrors, fmt.Errorf("attach sampling to ACL %s: %w", candidate.acl.UUID, err))
 		}
-
-		allocation, err := allocator.Allocate(aclsampling.SampleKey{
-			SchemaVersion: aclsampling.SchemaVersionV1,
-			PolicyUID:     request.policyUID,
-			Direction:     candidate.direction,
-			RuleIndex:     candidate.ruleIndex,
-			Role:          candidate.role,
-			Protocol:      candidate.protocol,
-			ACLMatchHash:  aclsampling.HashACLMatch(candidate.acl.Match),
-			OVNAction:     candidate.acl.Action,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("allocate sample metadata for ACL %s: %w", candidate.acl.UUID, err)
-		}
-
-		sampleUUID, sampleOps, err := c.ensureNetworkPolicySample(allocation.Metadata, collector, samplesByMetadata)
-		if err != nil {
-			return nil, err
-		}
-		operations = append(operations, sampleOps...)
-		aclOps, err := c.setNetworkPolicySamplingOps(&candidate.acl, request, *candidate, allocation, sampleUUID)
-		if err != nil {
-			return nil, err
-		}
-		operations = append(operations, aclOps...)
 	}
-	return operations, nil
+	return errors.Join(applyErrors...)
+}
+
+func (c *OVNNbClient) networkPolicySamplingOps(config aclsampling.ControllerConfig, request *NetworkPolicySamplingRequest, candidate *eligibleNetworkPolicyACL, allocator *aclsampling.Allocator, collectors map[string]*ovnnb.SampleCollector, samplesByMetadata map[uint32]*ovnnb.Sample) ([]ovsdb.Operation, error) {
+	owned := isOwnedNetworkPolicySamplingACL(candidate.acl.ExternalIDs)
+	enabled := config.AllowProbabilityPercent != 0
+	collector := collectors[aclSamplingRoleAllow]
+	if candidate.role == aclsampling.RoleDefaultDeny {
+		enabled = config.DefaultDenyProbabilityPercent != 0
+		collector = collectors[aclSamplingRoleDefaultDeny]
+	}
+	if !enabled {
+		if !owned {
+			return nil, nil
+		}
+		ops, err := c.clearNetworkPolicySamplingOps(&candidate.acl)
+		return ops, err
+	}
+	if feature := candidate.acl.ExternalIDs[sampleFeatureExternalID]; feature != "" && !owned {
+		return nil, fmt.Errorf("sampling metadata is owned by feature %s", feature)
+	}
+	if !owned && (candidate.acl.SampleNew != nil || candidate.acl.SampleEst != nil) {
+		return nil, errors.New("has unowned sample references")
+	}
+
+	allocation, err := allocator.Allocate(aclsampling.SampleKey{
+		SchemaVersion: aclsampling.SchemaVersionV1,
+		PolicyUID:     request.policyUID,
+		Direction:     candidate.direction,
+		RuleIndex:     candidate.ruleIndex,
+		Role:          candidate.role,
+		Protocol:      candidate.protocol,
+		ACLMatchHash:  aclsampling.HashACLMatch(candidate.acl.Match),
+		OVNAction:     aclsampling.OVNAction(candidate.acl.Action),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("allocate sample metadata: %w", err)
+	}
+
+	sampleUUID, sampleOps, err := c.ensureNetworkPolicySample(allocation.Metadata, collector, samplesByMetadata)
+	if err != nil {
+		return nil, err
+	}
+	aclOps, err := c.setNetworkPolicySamplingOps(&candidate.acl, request, *candidate, allocation, sampleUUID)
+	if err != nil {
+		return nil, err
+	}
+	return append(sampleOps, aclOps...), nil
 }
 
 func (c *OVNNbClient) listSamples() ([]ovnnb.Sample, error) {
@@ -276,6 +276,10 @@ func (c *OVNNbClient) networkPolicySampleCollectors() (map[string]*ovnnb.SampleC
 }
 
 func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, bool, error) {
+	aclName := acl.ExternalIDs[networkPolicyACLNameExternalID]
+	if acl.ExternalIDs[ExternalIDVendor] != util.CniTypeName || aclName == "" {
+		return eligibleNetworkPolicyACL{}, false, nil
+	}
 	if acl.Tier != util.NetpolACLTier {
 		return eligibleNetworkPolicyACL{}, false, nil
 	}
@@ -308,17 +312,13 @@ func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, 
 			direction: direction,
 			role:      aclsampling.RoleDefaultDeny,
 			protocol:  defaultDenyProtocol,
-			verdict:   aclsampling.RoleDefaultDeny,
+			verdict:   networkPolicyVerdictDefaultDeny,
 		}, true, nil
 	}
 	if acl.Action != ovnnb.ACLActionAllowRelated || acl.Priority != allowPriority {
 		return eligibleNetworkPolicyACL{}, false, nil
 	}
 
-	aclName := acl.ExternalIDs[networkPolicyACLNameExternalID]
-	if aclName == "" && acl.Name != nil {
-		aclName = *acl.Name
-	}
 	parts := strings.Split(aclName, "/")
 	if len(parts) != 5 && (len(parts) != 6 || parts[5] != "ipBlock") {
 		return eligibleNetworkPolicyACL{}, false, nil
@@ -339,7 +339,7 @@ func classifyNetworkPolicySamplingACL(acl ovnnb.ACL) (eligibleNetworkPolicyACL, 
 		ruleIndex: &ruleIndex,
 		role:      aclsampling.RoleRuleAllow,
 		protocol:  parts[3],
-		verdict:   "allow",
+		verdict:   networkPolicyVerdictAllow,
 	}, true, nil
 }
 
@@ -348,7 +348,7 @@ func setNetworkPolicyACLName(acl *ovnnb.ACL, name string) {
 	acl.ExternalIDs[networkPolicyACLNameExternalID] = name
 }
 
-func networkPolicyDirection(direction string) (string, bool) {
+func networkPolicyDirection(direction string) (aclsampling.PolicyDirection, bool) {
 	switch direction {
 	case ovnnb.ACLDirectionToLport:
 		return aclsampling.DirectionIngress, true
@@ -362,7 +362,7 @@ func networkPolicyDirection(direction string) (string, bool) {
 func storedNetworkPolicySampleMappings(acls []ovnnb.ACL) ([]aclsampling.OccupiedMetadata, error) {
 	mappings := make([]aclsampling.OccupiedMetadata, 0)
 	for _, acl := range acls {
-		if acl.ExternalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
+		if !isOwnedNetworkPolicySamplingACL(acl.ExternalIDs) {
 			continue
 		}
 		mapping, err := storedNetworkPolicySampleMapping(acl.ExternalIDs)
@@ -411,7 +411,7 @@ func currentSampleMetadata(samples []ovnnb.Sample, acls []ovnnb.ACL, previous []
 	}
 
 	for _, acl := range acls {
-		if acl.ExternalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
+		if !isOwnedNetworkPolicySamplingACL(acl.ExternalIDs) {
 			continue
 		}
 		mapping, err := storedNetworkPolicySampleMapping(acl.ExternalIDs)
@@ -477,7 +477,6 @@ func (c *OVNNbClient) ensureNetworkPolicySample(metadata uint32, collector *ovnn
 	if err != nil {
 		return "", nil, fmt.Errorf("build create operation for sample metadata %d: %w", metadata, err)
 	}
-	samplesByMetadata[metadata] = sample
 	return sample.UUID, ops, nil
 }
 
@@ -488,14 +487,14 @@ func (c *OVNNbClient) setNetworkPolicySamplingOps(acl *ovnnb.ACL, request *Netwo
 	}
 	externalIDs[sampleSchemaVersionExternalID] = aclsampling.SchemaVersionV1
 	externalIDs[sampleFeatureExternalID] = networkPolicySampleFeature
-	externalIDs[sampleRoleExternalID] = candidate.role
+	externalIDs[sampleRoleExternalID] = string(candidate.role)
 	externalIDs[policyAPIVersionExternalID] = networkPolicyAPIVersion
 	externalIDs[policyKindExternalID] = networkPolicyKind
 	externalIDs[policyNamespaceExternalID] = request.policyNamespace
 	externalIDs[policyNameExternalID] = request.policyName
 	externalIDs[policyUIDExternalID] = request.policyUID
-	externalIDs[policyDirectionExternalID] = candidate.direction
-	externalIDs[policyVerdictExternalID] = candidate.verdict
+	externalIDs[policyDirectionExternalID] = string(candidate.direction)
+	externalIDs[policyVerdictExternalID] = string(candidate.verdict)
 	externalIDs[ovnActionExternalID] = candidate.acl.Action
 	externalIDs[aclMatchHashExternalID] = aclsampling.HashACLMatch(candidate.acl.Match)
 	externalIDs[sampleKeyHashExternalID] = allocation.KeyHash
@@ -521,7 +520,7 @@ func (c *OVNNbClient) setNetworkPolicySamplingOps(acl *ovnnb.ACL, request *Netwo
 }
 
 func (c *OVNNbClient) clearNetworkPolicySamplingOps(acl *ovnnb.ACL) ([]ovsdb.Operation, error) {
-	if acl.SampleNew == nil && acl.SampleEst == nil && acl.ExternalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
+	if acl.SampleNew == nil && acl.SampleEst == nil && !isOwnedNetworkPolicySamplingACL(acl.ExternalIDs) {
 		return nil, nil
 	}
 	externalIDs := maps.Clone(acl.ExternalIDs)
@@ -536,4 +535,10 @@ func (c *OVNNbClient) clearNetworkPolicySamplingOps(acl *ovnnb.ACL) ([]ovsdb.Ope
 		return nil, fmt.Errorf("build sample cleanup operation for ACL %s: %w", acl.UUID, err)
 	}
 	return ops, nil
+}
+
+func isOwnedNetworkPolicySamplingACL(externalIDs map[string]string) bool {
+	return externalIDs[ExternalIDVendor] == util.CniTypeName &&
+		externalIDs[sampleFeatureExternalID] == networkPolicySampleFeature &&
+		externalIDs[sampleSchemaVersionExternalID] == aclsampling.SchemaVersionV1
 }

--- a/pkg/ovs/ovn-nb-network-policy-sampling.go
+++ b/pkg/ovs/ovn-nb-network-policy-sampling.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ovn-kubernetes/libovsdb/model"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
@@ -174,7 +175,7 @@ func (c *OVNNbClient) ApplyNetworkPolicyACLSampling(config aclsampling.Controlle
 	applyErrors := make([]error, 0)
 	for i := range eligible {
 		candidate := &eligible[i]
-		operations, err := c.networkPolicySamplingOps(config, request, candidate, allocator, collectors, samplesByMetadata)
+		operations, createdMetadata, err := c.networkPolicySamplingOps(config, request, candidate, allocator, collectors, samplesByMetadata)
 		if err != nil {
 			applyErrors = append(applyErrors, fmt.Errorf("ACL %s: %w", candidate.acl.UUID, err))
 			continue
@@ -184,12 +185,21 @@ func (c *OVNNbClient) ApplyNetworkPolicyACLSampling(config aclsampling.Controlle
 		}
 		if err := c.Transact("network-policy-acl-sampling-attach", operations); err != nil {
 			applyErrors = append(applyErrors, fmt.Errorf("attach sampling to ACL %s: %w", candidate.acl.UUID, err))
+			continue
+		}
+		if createdMetadata != 0 {
+			sample, err := c.waitForNetworkPolicySample(createdMetadata)
+			if err != nil {
+				applyErrors = append(applyErrors, fmt.Errorf("ACL %s: %w", candidate.acl.UUID, err))
+				continue
+			}
+			samplesByMetadata[createdMetadata] = sample
 		}
 	}
 	return errors.Join(applyErrors...)
 }
 
-func (c *OVNNbClient) networkPolicySamplingOps(config aclsampling.ControllerConfig, request *NetworkPolicySamplingRequest, candidate *eligibleNetworkPolicyACL, allocator *aclsampling.Allocator, collectors map[string]*ovnnb.SampleCollector, samplesByMetadata map[uint32]*ovnnb.Sample) ([]ovsdb.Operation, error) {
+func (c *OVNNbClient) networkPolicySamplingOps(config aclsampling.ControllerConfig, request *NetworkPolicySamplingRequest, candidate *eligibleNetworkPolicyACL, allocator *aclsampling.Allocator, collectors map[string]*ovnnb.SampleCollector, samplesByMetadata map[uint32]*ovnnb.Sample) ([]ovsdb.Operation, uint32, error) {
 	owned := isOwnedNetworkPolicySamplingACL(candidate.acl.ExternalIDs)
 	enabled := config.AllowProbabilityPercent != 0
 	collector := collectors[aclSamplingRoleAllow]
@@ -199,16 +209,16 @@ func (c *OVNNbClient) networkPolicySamplingOps(config aclsampling.ControllerConf
 	}
 	if !enabled {
 		if !owned {
-			return nil, nil
+			return nil, 0, nil
 		}
 		ops, err := c.clearNetworkPolicySamplingOps(&candidate.acl)
-		return ops, err
+		return ops, 0, err
 	}
 	if feature := candidate.acl.ExternalIDs[sampleFeatureExternalID]; feature != "" && !owned {
-		return nil, fmt.Errorf("sampling metadata is owned by feature %s", feature)
+		return nil, 0, fmt.Errorf("sampling metadata is owned by feature %s", feature)
 	}
 	if !owned && (candidate.acl.SampleNew != nil || candidate.acl.SampleEst != nil) {
-		return nil, errors.New("has unowned sample references")
+		return nil, 0, errors.New("has unowned sample references")
 	}
 
 	allocation, err := allocator.Allocate(aclsampling.SampleKey{
@@ -222,18 +232,51 @@ func (c *OVNNbClient) networkPolicySamplingOps(config aclsampling.ControllerConf
 		OVNAction:     aclsampling.OVNAction(candidate.acl.Action),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("allocate sample metadata: %w", err)
+		return nil, 0, fmt.Errorf("allocate sample metadata: %w", err)
 	}
 
 	sampleUUID, sampleOps, err := c.ensureNetworkPolicySample(allocation.Metadata, collector, samplesByMetadata)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	aclOps, err := c.setNetworkPolicySamplingOps(&candidate.acl, request, *candidate, allocation, sampleUUID)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return append(sampleOps, aclOps...), nil
+	createdMetadata := uint32(0)
+	if len(sampleOps) != 0 {
+		createdMetadata = allocation.Metadata
+	}
+	return append(sampleOps, aclOps...), createdMetadata, nil
+}
+
+func (c *OVNNbClient) waitForNetworkPolicySample(metadata uint32) (*ovnnb.Sample, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		samples, err := c.listSamples()
+		if err != nil {
+			return nil, err
+		}
+		for i := range samples {
+			sampleMetadata, err := networkPolicySampleMetadata(samples[i].Metadata)
+			if err != nil {
+				return nil, fmt.Errorf("sample %s: %w", samples[i].UUID, err)
+			}
+			if sampleMetadata == metadata {
+				return &samples[i], nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("wait for sample metadata %d: %w", metadata, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func (c *OVNNbClient) listSamples() ([]ovnnb.Sample, error) {

--- a/pkg/ovs/ovn-nb-network-policy-sampling_test.go
+++ b/pkg/ovs/ovn-nb-network-policy-sampling_test.go
@@ -150,6 +150,30 @@ func TestNetworkPolicyACLSamplingReusesSnapshotMetadata(t *testing.T) {
 	}, 3*time.Second, 20*time.Millisecond)
 }
 
+func TestNetworkPolicyACLSamplingReusesSampleCreatedInSameRun(t *testing.T) {
+	client := newACLSamplingTestClient(t, "network-policy-created-sample-reuse")
+	const pgName = "duplicate-rule.default"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+
+	const aclName = "np/duplicate-rule.default/ingress/IPv4/0"
+	first := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, aclName)
+	second := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, aclName)
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, first, second))
+	waitForACLCount(t, client, pgName, 2)
+
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "duplicate-rule", "bbbbbbbb-cccc-dddd-eeee-ffffffffffff")
+	require.NoError(t, err)
+	require.NoError(t, client.ApplyNetworkPolicyACLSampling(validACLSamplingConfig(), request))
+	require.Eventually(t, func() bool {
+		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		if listErr != nil || len(acls) != 2 || acls[0].SampleNew == nil || acls[1].SampleNew == nil {
+			return false
+		}
+		return *acls[0].SampleNew == *acls[1].SampleNew
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestNetworkPolicyACLSamplingPreservesUnownedReferences(t *testing.T) {
 	client := newACLSamplingTestClient(t, "network-policy-unowned-reference")
 	const pgName = "external-sample.default"

--- a/pkg/ovs/ovn-nb-network-policy-sampling_test.go
+++ b/pkg/ovs/ovn-nb-network-policy-sampling_test.go
@@ -184,10 +184,12 @@ func TestNetworkPolicyACLSamplingPreservesUnownedReferences(t *testing.T) {
 
 func TestClassifyNetworkPolicySamplingACLUsesUntruncatedName(t *testing.T) {
 	fullName := "np/" + strings.Repeat("long-policy-name.", 5) + "default/ingress/IPv4/12/ipBlock"
+	priority, err := strconv.Atoi(util.IngressAllowPriority)
+	require.NoError(t, err)
 	acl := ovnnb.ACL{
 		Action:    ovnnb.ACLActionAllowRelated,
 		Direction: ovnnb.ACLDirectionToLport,
-		Priority:  mustPriority(util.IngressAllowPriority),
+		Priority:  priority,
 		Tier:      util.NetpolACLTier,
 		ExternalIDs: map[string]string{
 			networkPolicyACLNameExternalID: fullName,
@@ -196,7 +198,8 @@ func TestClassifyNetworkPolicySamplingACLUsesUntruncatedName(t *testing.T) {
 	setACLName(&acl, fullName)
 	require.LessOrEqual(t, len(*acl.Name), 63)
 
-	candidate, ok := classifyNetworkPolicySamplingACL(acl)
+	candidate, ok, err := classifyNetworkPolicySamplingACL(acl)
+	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, 12, *candidate.ruleIndex)
 	require.Equal(t, "IPv4", candidate.protocol)

--- a/pkg/ovs/ovn-nb-network-policy-sampling_test.go
+++ b/pkg/ovs/ovn-nb-network-policy-sampling_test.go
@@ -1,0 +1,293 @@
+package ovs
+
+import (
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestApplyNetworkPolicyACLSamplingSelectsEligibleACLs(t *testing.T) {
+	client := newACLSamplingTestClient(t, "network-policy-attachment")
+	const pgName = "sample-policy.default"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+
+	eligibleAllow := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/sample-policy.default/ingress/IPv4/0")
+	eligibleIPBlock := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, ovnnb.ACLActionAllowRelated, "np/sample-policy.default/egress/IPv6/1/ipBlock")
+	eligibleDefaultDeny := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, ovnnb.ACLActionDrop, "default/sample-policy")
+	syntheticAll := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/sample-policy.default/ingress/IPv4/all")
+	dhcpException := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "default/sample-policy")
+	gateway := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowStateless, "np/sample-policy.default/ingress/IPv6/0")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, eligibleAllow, eligibleIPBlock, eligibleDefaultDeny, syntheticAll, dhcpException, gateway))
+	waitForACLCount(t, client, pgName, 6)
+
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "sample-policy", "11111111-2222-3333-4444-555555555555")
+	require.NoError(t, err)
+	config := validACLSamplingConfig()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.NoError(collect, client.ApplyNetworkPolicyACLSampling(config, request))
+	}, 3*time.Second, 20*time.Millisecond)
+
+	var actual []ovnnb.ACL
+	require.Eventually(t, func() bool {
+		var listErr error
+		actual, listErr = client.ListAcls("", map[string]string{aclParentKey: pgName})
+		if listErr != nil {
+			return false
+		}
+		return countSampledACLs(actual) == 3
+	}, 3*time.Second, 20*time.Millisecond)
+
+	allow := aclByName(t, actual, "np/sample-policy.default/ingress/IPv4/0")
+	require.NotNil(t, allow.SampleNew)
+	require.NotNil(t, allow.SampleEst)
+	require.Equal(t, *allow.SampleNew, *allow.SampleEst)
+	require.Equal(t, "0", allow.ExternalIDs[policyRuleIndexExternalID])
+	require.Equal(t, "allow", allow.ExternalIDs[policyVerdictExternalID])
+	require.Equal(t, aclsampling.RoleRuleAllow, allow.ExternalIDs[sampleRoleExternalID])
+	require.Equal(t, aclsampling.DirectionIngress, allow.ExternalIDs[policyDirectionExternalID])
+	require.Equal(t, "sample-policy", allow.ExternalIDs[policyNameExternalID])
+	require.Len(t, allow.ExternalIDs[aclMatchHashExternalID], 64)
+
+	deny := aclByNameAndAction(t, actual, "default/sample-policy", ovnnb.ACLActionDrop)
+	require.NotNil(t, deny.SampleNew)
+	require.Nil(t, deny.SampleEst)
+	require.NotContains(t, deny.ExternalIDs, policyRuleIndexExternalID)
+	require.Equal(t, aclsampling.RoleDefaultDeny, deny.ExternalIDs[policyVerdictExternalID])
+
+	for _, name := range []string{
+		"np/sample-policy.default/ingress/IPv4/all",
+		"np/sample-policy.default/ingress/IPv6/0",
+	} {
+		acl := aclByName(t, actual, name)
+		require.Nil(t, acl.SampleNew)
+		require.Nil(t, acl.SampleEst)
+		require.NotContains(t, acl.ExternalIDs, sampleFeatureExternalID)
+	}
+	for _, acl := range actual {
+		if acl.Name != nil && *acl.Name == "default/sample-policy" && acl.Action == ovnnb.ACLActionAllowRelated {
+			require.Nil(t, acl.SampleNew)
+			require.NotContains(t, acl.ExternalIDs, sampleFeatureExternalID)
+		}
+	}
+
+	config.AllowProbabilityPercent = 0
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.NoError(collect, client.ApplyNetworkPolicyACLSampling(config, request))
+	}, 3*time.Second, 20*time.Millisecond)
+	require.Eventually(t, func() bool {
+		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		if listErr != nil {
+			return false
+		}
+		allow = aclByName(t, acls, "np/sample-policy.default/ingress/IPv4/0")
+		deny = aclByNameAndAction(t, acls, "default/sample-policy", ovnnb.ACLActionDrop)
+		return allow.SampleNew == nil && allow.SampleEst == nil &&
+			allow.ExternalIDs[sampleFeatureExternalID] == "" && deny.SampleNew != nil
+	}, 3*time.Second, 20*time.Millisecond)
+}
+
+func TestNetworkPolicyACLSamplingReusesSnapshotMetadata(t *testing.T) {
+	client := newACLSamplingTestClient(t, "network-policy-prior-metadata")
+	const pgName = "collision-policy.default"
+	const policyUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+
+	oldACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/collision-policy.default/ingress/IPv4/0")
+	allocation, err := aclsampling.NewAllocator(nil)
+	require.NoError(t, err)
+	expected, err := allocation.Allocate(aclsampling.SampleKey{
+		SchemaVersion: aclsampling.SchemaVersionV1,
+		PolicyUID:     policyUID,
+		Direction:     aclsampling.DirectionIngress,
+		RuleIndex:     new(0),
+		Role:          aclsampling.RoleRuleAllow,
+		Protocol:      "IPv4",
+		ACLMatchHash:  aclsampling.HashACLMatch(oldACL.Match),
+		OVNAction:     aclsampling.ActionAllowRelated,
+	})
+	require.NoError(t, err)
+	oldACL.ExternalIDs[sampleFeatureExternalID] = networkPolicySampleFeature
+	oldACL.ExternalIDs[sampleKeyHashExternalID] = expected.KeyHash
+	oldACL.ExternalIDs[sampleMetadataExternalID] = "42"
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, oldACL))
+	waitForACLCount(t, client, pgName, 1)
+
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "collision-policy", policyUID)
+	require.NoError(t, err)
+	require.NoError(t, client.DeleteAcls(pgName, portGroupKey, "", nil))
+	waitForACLCount(t, client, pgName, 0)
+	replacement := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/collision-policy.default/ingress/IPv4/0")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, replacement))
+	waitForACLCount(t, client, pgName, 1)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.NoError(collect, client.ApplyNetworkPolicyACLSampling(validACLSamplingConfig(), request))
+	}, 3*time.Second, 20*time.Millisecond)
+	require.Eventually(t, func() bool {
+		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		return listErr == nil && len(acls) == 1 && acls[0].ExternalIDs[sampleMetadataExternalID] == "42"
+	}, 3*time.Second, 20*time.Millisecond)
+}
+
+func TestNetworkPolicyACLSamplingPreservesUnownedReferences(t *testing.T) {
+	client := newACLSamplingTestClient(t, "network-policy-unowned-reference")
+	const pgName = "external-sample.default"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+
+	acl := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/external-sample.default/ingress/IPv4/0")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, acl))
+	waitForACLCount(t, client, pgName, 1)
+	actual, err := client.ListAcls("", map[string]string{aclParentKey: pgName})
+	require.NoError(t, err)
+	acl = &actual[0]
+	externalSample := &ovnnb.Sample{UUID: ovsclient.NamedUUID(), Metadata: 99}
+	createOps, err := client.Create(externalSample)
+	require.NoError(t, err)
+	acl.SampleNew = &externalSample.UUID
+	updateOps, err := client.Where(acl).Update(acl, &acl.SampleNew)
+	require.NoError(t, err)
+	require.NoError(t, client.Transact("seed-unowned-acl-sample-reference", append(createOps, updateOps...)))
+	require.Eventually(t, func() bool {
+		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		return listErr == nil && len(acls) == 1 && acls[0].SampleNew != nil
+	}, time.Second, 10*time.Millisecond)
+
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "external-sample", "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb")
+	require.NoError(t, err)
+	config := validACLSamplingConfig()
+	require.NoError(t, client.ReconcileACLSampling(config))
+	waitForACLSamplingObjects(t, client)
+	err = client.ApplyNetworkPolicyACLSampling(config, request)
+	require.ErrorContains(t, err, "has unowned sample references")
+
+	config.AllowProbabilityPercent = 0
+	require.NoError(t, client.ApplyNetworkPolicyACLSampling(config, request))
+	actual, err = client.ListAcls("", map[string]string{aclParentKey: pgName})
+	require.NoError(t, err)
+	require.Len(t, actual, 1)
+	require.NotNil(t, actual[0].SampleNew)
+	require.NotContains(t, actual[0].ExternalIDs, sampleFeatureExternalID)
+}
+
+func TestClassifyNetworkPolicySamplingACLUsesUntruncatedName(t *testing.T) {
+	fullName := "np/" + strings.Repeat("long-policy-name.", 5) + "default/ingress/IPv4/12/ipBlock"
+	acl := ovnnb.ACL{
+		Action:    ovnnb.ACLActionAllowRelated,
+		Direction: ovnnb.ACLDirectionToLport,
+		Priority:  mustPriority(util.IngressAllowPriority),
+		Tier:      util.NetpolACLTier,
+		ExternalIDs: map[string]string{
+			networkPolicyACLNameExternalID: fullName,
+		},
+	}
+	setACLName(&acl, fullName)
+	require.LessOrEqual(t, len(*acl.Name), 63)
+
+	candidate, ok := classifyNetworkPolicySamplingACL(acl)
+	require.True(t, ok)
+	require.Equal(t, 12, *candidate.ruleIndex)
+	require.Equal(t, "IPv4", candidate.protocol)
+}
+
+func TestNetworkPolicySampleMetadata(t *testing.T) {
+	type testCase struct {
+		name     string
+		value    int
+		expected uint32
+		wantErr  bool
+	}
+	tests := []testCase{
+		{name: "negative", value: -1, wantErr: true},
+		{name: "zero", value: 0, wantErr: true},
+		{name: "positive", value: 1, expected: 1},
+	}
+	if strconv.IntSize == 64 {
+		maxUint32 := uint64(math.MaxUint32)
+		tests = append(tests,
+			testCase{name: "maximum", value: int(maxUint32), expected: math.MaxUint32},
+			testCase{name: "overflow", value: int(maxUint32 + 1), wantErr: true},
+		)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := networkPolicySampleMetadata(test.value)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func newNetworkPolicySamplingTestACL(t *testing.T, client *OVNNbClient, pgName, direction, priority, action, name string) *ovnnb.ACL {
+	t.Helper()
+	acl, err := client.newACLWithoutCheck(pgName, direction, priority, "ip && test == "+strconv.Quote(name), action, util.NetpolACLTier, func(acl *ovnnb.ACL) {
+		setACLName(acl, name)
+	})
+	require.NoError(t, err)
+	return acl
+}
+
+func waitForPortGroup(t *testing.T, client *OVNNbClient, pgName string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		pg, err := client.GetPortGroup(pgName, true)
+		return err == nil && pg != nil
+	}, time.Second, 10*time.Millisecond)
+}
+
+func waitForACLCount(t *testing.T, client *OVNNbClient, pgName string, count int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		acls, err := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		return err == nil && len(acls) == count
+	}, time.Second, 10*time.Millisecond)
+}
+
+func countSampledACLs(acls []ovnnb.ACL) int {
+	count := 0
+	for _, acl := range acls {
+		if acl.ExternalIDs[sampleFeatureExternalID] == networkPolicySampleFeature {
+			count++
+		}
+	}
+	return count
+}
+
+func aclByName(t *testing.T, acls []ovnnb.ACL, name string) ovnnb.ACL {
+	t.Helper()
+	for _, acl := range acls {
+		if acl.Name != nil && *acl.Name == name {
+			return acl
+		}
+	}
+	t.Fatalf("ACL %q not found", name)
+	return ovnnb.ACL{}
+}
+
+func aclByNameAndAction(t *testing.T, acls []ovnnb.ACL, name, action string) ovnnb.ACL {
+	t.Helper()
+	for _, acl := range acls {
+		if acl.Name != nil && *acl.Name == name && acl.Action == action {
+			return acl
+		}
+	}
+	t.Fatalf("ACL %q with action %q not found", name, action)
+	return ovnnb.ACL{}
+}

--- a/pkg/ovs/ovn-nb-network-policy-sampling_test.go
+++ b/pkg/ovs/ovn-nb-network-policy-sampling_test.go
@@ -25,11 +25,14 @@ func TestApplyNetworkPolicyACLSamplingSelectsEligibleACLs(t *testing.T) {
 	eligibleAllow := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/sample-policy.default/ingress/IPv4/0")
 	eligibleIPBlock := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionFromLport, util.EgressAllowPriority, ovnnb.ACLActionAllowRelated, "np/sample-policy.default/egress/IPv6/1/ipBlock")
 	eligibleDefaultDeny := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressDefaultDrop, ovnnb.ACLActionDrop, "default/sample-policy")
+	unmarkedAllow := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/sample-policy.default/ingress/IPv4/2")
+	delete(unmarkedAllow.ExternalIDs, networkPolicyACLNameExternalID)
+	unmarkedAllow.ExternalIDs[ExternalIDVendor] = "external-observer"
 	syntheticAll := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/sample-policy.default/ingress/IPv4/all")
 	dhcpException := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "default/sample-policy")
 	gateway := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowStateless, "np/sample-policy.default/ingress/IPv6/0")
-	require.NoError(t, client.CreateAcls(pgName, portGroupKey, eligibleAllow, eligibleIPBlock, eligibleDefaultDeny, syntheticAll, dhcpException, gateway))
-	waitForACLCount(t, client, pgName, 6)
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, eligibleAllow, eligibleIPBlock, eligibleDefaultDeny, unmarkedAllow, syntheticAll, dhcpException, gateway))
+	waitForACLCount(t, client, pgName, 7)
 
 	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "sample-policy", "11111111-2222-3333-4444-555555555555")
 	require.NoError(t, err)
@@ -54,8 +57,8 @@ func TestApplyNetworkPolicyACLSamplingSelectsEligibleACLs(t *testing.T) {
 	require.Equal(t, *allow.SampleNew, *allow.SampleEst)
 	require.Equal(t, "0", allow.ExternalIDs[policyRuleIndexExternalID])
 	require.Equal(t, "allow", allow.ExternalIDs[policyVerdictExternalID])
-	require.Equal(t, aclsampling.RoleRuleAllow, allow.ExternalIDs[sampleRoleExternalID])
-	require.Equal(t, aclsampling.DirectionIngress, allow.ExternalIDs[policyDirectionExternalID])
+	require.Equal(t, string(aclsampling.RoleRuleAllow), allow.ExternalIDs[sampleRoleExternalID])
+	require.Equal(t, string(aclsampling.DirectionIngress), allow.ExternalIDs[policyDirectionExternalID])
 	require.Equal(t, "sample-policy", allow.ExternalIDs[policyNameExternalID])
 	require.Len(t, allow.ExternalIDs[aclMatchHashExternalID], 64)
 
@@ -63,7 +66,12 @@ func TestApplyNetworkPolicyACLSamplingSelectsEligibleACLs(t *testing.T) {
 	require.NotNil(t, deny.SampleNew)
 	require.Nil(t, deny.SampleEst)
 	require.NotContains(t, deny.ExternalIDs, policyRuleIndexExternalID)
-	require.Equal(t, aclsampling.RoleDefaultDeny, deny.ExternalIDs[policyVerdictExternalID])
+	require.Equal(t, string(aclsampling.RoleDefaultDeny), deny.ExternalIDs[policyVerdictExternalID])
+
+	unmarked := aclByName(t, actual, "np/sample-policy.default/ingress/IPv4/2")
+	require.Nil(t, unmarked.SampleNew)
+	require.Nil(t, unmarked.SampleEst)
+	require.NotContains(t, unmarked.ExternalIDs, sampleFeatureExternalID)
 
 	for _, name := range []string{
 		"np/sample-policy.default/ingress/IPv4/all",
@@ -119,6 +127,7 @@ func TestNetworkPolicyACLSamplingReusesSnapshotMetadata(t *testing.T) {
 	})
 	require.NoError(t, err)
 	oldACL.ExternalIDs[sampleFeatureExternalID] = networkPolicySampleFeature
+	oldACL.ExternalIDs[sampleSchemaVersionExternalID] = aclsampling.SchemaVersionV1
 	oldACL.ExternalIDs[sampleKeyHashExternalID] = expected.KeyHash
 	oldACL.ExternalIDs[sampleMetadataExternalID] = "42"
 	require.NoError(t, client.CreateAcls(pgName, portGroupKey, oldACL))
@@ -148,11 +157,13 @@ func TestNetworkPolicyACLSamplingPreservesUnownedReferences(t *testing.T) {
 	waitForPortGroup(t, client, pgName)
 
 	acl := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/external-sample.default/ingress/IPv4/0")
-	require.NoError(t, client.CreateAcls(pgName, portGroupKey, acl))
-	waitForACLCount(t, client, pgName, 1)
+	independent := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/external-sample.default/ingress/IPv4/1")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, acl, independent))
+	waitForACLCount(t, client, pgName, 2)
 	actual, err := client.ListAcls("", map[string]string{aclParentKey: pgName})
 	require.NoError(t, err)
-	acl = &actual[0]
+	actualACL := aclByName(t, actual, "np/external-sample.default/ingress/IPv4/0")
+	acl = &actualACL
 	externalSample := &ovnnb.Sample{UUID: ovsclient.NamedUUID(), Metadata: 99}
 	createOps, err := client.Create(externalSample)
 	require.NoError(t, err)
@@ -162,7 +173,7 @@ func TestNetworkPolicyACLSamplingPreservesUnownedReferences(t *testing.T) {
 	require.NoError(t, client.Transact("seed-unowned-acl-sample-reference", append(createOps, updateOps...)))
 	require.Eventually(t, func() bool {
 		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
-		return listErr == nil && len(acls) == 1 && acls[0].SampleNew != nil
+		return listErr == nil && len(acls) == 2 && aclByName(t, acls, "np/external-sample.default/ingress/IPv4/0").SampleNew != nil
 	}, time.Second, 10*time.Millisecond)
 
 	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "external-sample", "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb")
@@ -172,14 +183,23 @@ func TestNetworkPolicyACLSamplingPreservesUnownedReferences(t *testing.T) {
 	waitForACLSamplingObjects(t, client)
 	err = client.ApplyNetworkPolicyACLSampling(config, request)
 	require.ErrorContains(t, err, "has unowned sample references")
+	require.Eventually(t, func() bool {
+		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		if listErr != nil {
+			return false
+		}
+		attached := aclByName(t, acls, "np/external-sample.default/ingress/IPv4/1")
+		return attached.SampleNew != nil && attached.SampleEst != nil
+	}, time.Second, 10*time.Millisecond)
 
 	config.AllowProbabilityPercent = 0
 	require.NoError(t, client.ApplyNetworkPolicyACLSampling(config, request))
 	actual, err = client.ListAcls("", map[string]string{aclParentKey: pgName})
 	require.NoError(t, err)
-	require.Len(t, actual, 1)
-	require.NotNil(t, actual[0].SampleNew)
-	require.NotContains(t, actual[0].ExternalIDs, sampleFeatureExternalID)
+	require.Len(t, actual, 2)
+	preserved := aclByName(t, actual, "np/external-sample.default/ingress/IPv4/0")
+	require.NotNil(t, preserved.SampleNew)
+	require.NotContains(t, preserved.ExternalIDs, sampleFeatureExternalID)
 }
 
 func TestClassifyNetworkPolicySamplingACLUsesUntruncatedName(t *testing.T) {
@@ -193,6 +213,7 @@ func TestClassifyNetworkPolicySamplingACLUsesUntruncatedName(t *testing.T) {
 		Tier:      util.NetpolACLTier,
 		ExternalIDs: map[string]string{
 			networkPolicyACLNameExternalID: fullName,
+			ExternalIDVendor:               util.CniTypeName,
 		},
 	}
 	setACLName(&acl, fullName)
@@ -241,7 +262,7 @@ func TestNetworkPolicySampleMetadata(t *testing.T) {
 func newNetworkPolicySamplingTestACL(t *testing.T, client *OVNNbClient, pgName, direction, priority, action, name string) *ovnnb.ACL {
 	t.Helper()
 	acl, err := client.newACLWithoutCheck(pgName, direction, priority, "ip && test == "+strconv.Quote(name), action, util.NetpolACLTier, func(acl *ovnnb.ACL) {
-		setACLName(acl, name)
+		setNetworkPolicyACLName(acl, name)
 	})
 	require.NoError(t, err)
 	return acl


### PR DESCRIPTION
Related to #7146.

## Summary

- mark eligible NetworkPolicy ACLs while preserving names beyond the OVN 63-character display limit
- snapshot prior sample key-to-metadata mappings before enforcement replaces ACLs
- allocate or reuse globally unique Sample metadata and attach allow/default-deny sampling in a separate transaction
- write complete schema-v1 ACL external IDs without storing full matches
- preserve unowned sample references and clear owned attachments when verdict probability is zero

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. **#7163 — NetworkPolicy ACL attachment**
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-ovn-objects`

## Validation

- `GOMAXPROCS=2 go test ./pkg/ovs -count=1`
- targeted NetworkPolicy attachment race tests
- `GOMAXPROCS=2 go vet ./pkg/ovs ./pkg/controller`
- diff-scoped `golangci-lint` with one worker: 0 issues
- `git diff --check`