### PR TITLE
feat: retry NetworkPolicy ACL sampling independently

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -268,14 +268,14 @@ type Controller struct {
 	deploymentsLister appsv1.DeploymentLister
 	deploymentsSynced cache.InformerSynced
 
-	npsLister          netv1.NetworkPolicyLister
-	npsSynced          cache.InformerSynced
-	npIndexer          cache.Indexer
-	updateNpQueue      workqueue.TypedRateLimitingInterface[string]
-	deleteNpQueue      workqueue.TypedRateLimitingInterface[string]
-	npSamplingQueue    workqueue.TypedRateLimitingInterface[string]
-	npSamplingRequests *xsync.Map[string, *ovs.NetworkPolicySamplingRequest]
-	npKeyMutex         keymutex.KeyMutex
+	npsLister        netv1.NetworkPolicyLister
+	npsSynced        cache.InformerSynced
+	npIndexer        cache.Indexer
+	updateNpQueue    workqueue.TypedRateLimitingInterface[string]
+	deleteNpQueue    workqueue.TypedRateLimitingInterface[string]
+	npSamplingQueue  workqueue.TypedRateLimitingInterface[string]
+	npSamplingStates *xsync.Map[string, *networkPolicySamplingState]
+	npKeyMutex       keymutex.KeyMutex
 
 	sgsLister          kubeovnlister.SecurityGroupLister
 	sgSynced           cache.InformerSynced
@@ -765,7 +765,7 @@ func Run(ctx context.Context, config *Configuration) {
 		controller.deleteNpQueue = newTypedRateLimitingQueue[string]("DeleteNetworkPolicy", nil)
 		if config.ACLSampling.Enabled {
 			controller.npSamplingQueue = newTypedRateLimitingQueue[string]("SampleNetworkPolicyACL", nil)
-			controller.npSamplingRequests = xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest]()
+			controller.npSamplingStates = xsync.NewMap[string, *networkPolicySamplingState]()
 		}
 		controller.npKeyMutex = keymutex.NewHashed(numKeyLocks)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -272,7 +272,7 @@ type Controller struct {
 	npsSynced        cache.InformerSynced
 	npIndexer        cache.Indexer
 	updateNpQueue    workqueue.TypedRateLimitingInterface[string]
-	deleteNpQueue    workqueue.TypedRateLimitingInterface[string]
+	deleteNpQueue    workqueue.TypedRateLimitingInterface[networkPolicyDeleteRequest]
 	npSamplingQueue  workqueue.TypedRateLimitingInterface[string]
 	npSamplingStates *xsync.Map[string, *networkPolicySamplingState]
 	npKeyMutex       keymutex.KeyMutex
@@ -762,7 +762,7 @@ func Run(ctx context.Context, config *Configuration) {
 		controller.npsSynced = npInformer.Informer().HasSynced
 		controller.npIndexer = npInformer.Informer().GetIndexer()
 		controller.updateNpQueue = newTypedRateLimitingQueue[string]("UpdateNetworkPolicy", nil)
-		controller.deleteNpQueue = newTypedRateLimitingQueue[string]("DeleteNetworkPolicy", nil)
+		controller.deleteNpQueue = newTypedRateLimitingQueue[networkPolicyDeleteRequest]("DeleteNetworkPolicy", nil)
 		if config.ACLSampling.Enabled {
 			controller.npSamplingQueue = newTypedRateLimitingQueue[string]("SampleNetworkPolicyACL", nil)
 			controller.npSamplingStates = xsync.NewMap[string, *networkPolicySamplingState]()
@@ -1738,6 +1738,8 @@ func getWorkItemKey(obj any) string {
 		return v.key
 	case *SwitchLBRuleInfo:
 		return v.Name
+	case networkPolicyDeleteRequest:
+		return v.key
 	default:
 		key, err := cache.MetaNamespaceKeyFunc(obj)
 		if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -268,12 +268,14 @@ type Controller struct {
 	deploymentsLister appsv1.DeploymentLister
 	deploymentsSynced cache.InformerSynced
 
-	npsLister     netv1.NetworkPolicyLister
-	npsSynced     cache.InformerSynced
-	npIndexer     cache.Indexer
-	updateNpQueue workqueue.TypedRateLimitingInterface[string]
-	deleteNpQueue workqueue.TypedRateLimitingInterface[string]
-	npKeyMutex    keymutex.KeyMutex
+	npsLister          netv1.NetworkPolicyLister
+	npsSynced          cache.InformerSynced
+	npIndexer          cache.Indexer
+	updateNpQueue      workqueue.TypedRateLimitingInterface[string]
+	deleteNpQueue      workqueue.TypedRateLimitingInterface[string]
+	npSamplingQueue    workqueue.TypedRateLimitingInterface[string]
+	npSamplingRequests *xsync.Map[string, *ovs.NetworkPolicySamplingRequest]
+	npKeyMutex         keymutex.KeyMutex
 
 	sgsLister          kubeovnlister.SecurityGroupLister
 	sgSynced           cache.InformerSynced
@@ -761,6 +763,10 @@ func Run(ctx context.Context, config *Configuration) {
 		controller.npIndexer = npInformer.Informer().GetIndexer()
 		controller.updateNpQueue = newTypedRateLimitingQueue[string]("UpdateNetworkPolicy", nil)
 		controller.deleteNpQueue = newTypedRateLimitingQueue[string]("DeleteNetworkPolicy", nil)
+		if config.ACLSampling.Enabled {
+			controller.npSamplingQueue = newTypedRateLimitingQueue[string]("SampleNetworkPolicyACL", nil)
+			controller.npSamplingRequests = xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest]()
+		}
 		controller.npKeyMutex = keymutex.NewHashed(numKeyLocks)
 	}
 
@@ -1384,6 +1390,9 @@ func (c *Controller) shutdown() {
 	if c.config.EnableNP {
 		c.updateNpQueue.ShutDown()
 		c.deleteNpQueue.ShutDown()
+		if c.npSamplingQueue != nil {
+			c.npSamplingQueue.ShutDown()
+		}
 	}
 	if c.config.EnableANP {
 		c.addAnpQueue.ShutDown()
@@ -1518,6 +1527,9 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		if c.config.EnableNP {
 			go wait.Until(runWorker("update network policy", c.updateNpQueue, c.handleUpdateNp), time.Second, ctx.Done())
 			go wait.Until(runWorker("delete network policy", c.deleteNpQueue, c.handleDeleteNp), time.Second, ctx.Done())
+			if c.npSamplingQueue != nil {
+				go wait.Until(runWorker("sample network policy ACL", c.npSamplingQueue, c.handleNetworkPolicyACLSampling), time.Second, ctx.Done())
+			}
 		}
 
 		go wait.Until(runWorker("delete vlan", c.delVlanQueue, c.handleDelVlan), time.Second, ctx.Done())

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"unicode"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
@@ -16,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/set"
 
@@ -874,13 +874,10 @@ func (c *Controller) gcNetworkPolicy() error {
 		}
 
 		for _, np := range nps {
-			npName := np.Name
-			nameArray := []rune(np.Name)
-			if !unicode.IsLetter(nameArray[0]) {
-				npName = "np" + np.Name
-			}
-
-			npNames.Add(fmt.Sprintf("%s/%s", np.Namespace, npName))
+			npNames.Add(cache.MetaObjectToName(np).String())
+			// Keep port groups written by older controllers, which stored the
+			// normalized OVN resource name instead of the Kubernetes object name.
+			npNames.Add(fmt.Sprintf("%s/%s", np.Namespace, networkPolicyResourceName(np.Name)))
 		}
 	}
 
@@ -926,9 +923,13 @@ func (c *Controller) gcNetworkPolicy() error {
 		}
 		if !npNames.Has(pg.ExternalIDs[networkPolicyKey]) {
 			klog.Infof("gc port group '%s' network policy '%s'", pg.Name, pg.ExternalIDs[networkPolicyKey])
-			delPgNames.Add(pg.Name)
 			if c.config.EnableNP {
-				c.deleteNpQueue.Add(networkPolicyDeleteRequest{key: pg.ExternalIDs[networkPolicyKey]})
+				c.deleteNpQueue.Add(networkPolicyDeleteRequest{
+					key:           pg.ExternalIDs[networkPolicyKey],
+					portGroupName: pg.Name,
+				})
+			} else {
+				delPgNames.Add(pg.Name)
 			}
 		}
 	}

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -928,7 +928,7 @@ func (c *Controller) gcNetworkPolicy() error {
 			klog.Infof("gc port group '%s' network policy '%s'", pg.Name, pg.ExternalIDs[networkPolicyKey])
 			delPgNames.Add(pg.Name)
 			if c.config.EnableNP {
-				c.deleteNpQueue.Add(pg.ExternalIDs[networkPolicyKey])
+				c.deleteNpQueue.Add(networkPolicyDeleteRequest{key: pg.ExternalIDs[networkPolicyKey]})
 			}
 		}
 	}

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -15,10 +15,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/keymutex"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	netlisters "k8s.io/client-go/listers/networking/v1"
+	"k8s.io/client-go/tools/cache"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnlisters "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -80,6 +84,33 @@ func TestGcSecurityGroupSkipsVpcEgressGatewayPortGroup(t *testing.T) {
 	mockOvnClient.EXPECT().DeletePortGroup(gomock.Any()).Times(0)
 
 	require.NoError(t, ctrl.gcSecurityGroup())
+}
+
+func TestGcNetworkPolicyQueuesNormalizedPortGroupDeletion(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	ctrl.config.EnableNP = true
+	ctrl.deleteNpQueue = newTypedRateLimitingQueue[networkPolicyDeleteRequest]("TestDeleteNetworkPolicy", nil)
+	ctrl.npsLister = netlisters.NewNetworkPolicyLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	ctrl.nodesLister = corelisters.NewNodeLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	ctrl.subnetsLister = kubeovnlisters.NewSubnetLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	t.Cleanup(ctrl.deleteNpQueue.ShutDown)
+
+	fakeController.mockOvnClient.EXPECT().ListPortGroups(map[string]string{networkPolicyKey: ""}).Return([]ovnnb.PortGroup{{
+		Name:        "np1test.default",
+		ExternalIDs: map[string]string{networkPolicyKey: "default/np1test"},
+	}}, nil)
+	// Enabled NetworkPolicy cleanup runs through the serialized delete worker;
+	// GC must not delete a port group after a replacement policy appears.
+	fakeController.mockOvnClient.EXPECT().DeletePortGroup().Return(nil)
+
+	require.NoError(t, ctrl.gcNetworkPolicy())
+	require.Equal(t, 1, ctrl.deleteNpQueue.Len())
+	request, shutdown := ctrl.deleteNpQueue.Get()
+	require.False(t, shutdown)
+	ctrl.deleteNpQueue.Done(request)
+	require.Equal(t, "default/np1test", request.key)
+	require.Equal(t, "np1test.default", request.portGroupName)
 }
 
 func vmTemplate(networks []kubevirtv1.Network, annotations map[string]string) *kubevirtv1.VirtualMachineInstanceTemplateSpec {

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -15,6 +15,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -56,7 +57,7 @@ func (c *Controller) enqueueDeleteNp(obj any) {
 
 	key := cache.MetaObjectToName(np).String()
 	klog.V(3).Infof("enqueue delete network policy %s", key)
-	c.deleteNpQueue.Add(key)
+	c.deleteNpQueue.Add(networkPolicyDeleteRequest{key: key, policyUID: np.UID})
 }
 
 func (c *Controller) enqueueUpdateNp(oldObj, newObj any) {
@@ -512,8 +513,14 @@ func (c *Controller) handleUpdateNp(key string) error {
 
 type networkPolicySamplingState struct {
 	// Access is serialized with the policy's npKeyMutex lock.
-	request *ovs.NetworkPolicySamplingRequest
-	ready   bool
+	request   *ovs.NetworkPolicySamplingRequest
+	policyUID types.UID
+	ready     bool
+}
+
+type networkPolicyDeleteRequest struct {
+	key       string
+	policyUID types.UID
 }
 
 func (c *Controller) prepareNetworkPolicyACLSampling(key, pgName string, np *netv1.NetworkPolicy) *networkPolicySamplingState {
@@ -521,8 +528,11 @@ func (c *Controller) prepareNetworkPolicyACLSampling(key, pgName string, np *net
 		return nil
 	}
 	if state, ok := c.npSamplingStates.Load(key); ok {
-		state.ready = false
-		return state
+		if state.policyUID == np.UID {
+			state.ready = false
+			return state
+		}
+		c.npSamplingStates.Delete(key)
 	}
 
 	request, err := c.OVNNbClient.PrepareNetworkPolicyACLSampling(pgName, np.Namespace, np.Name, string(np.UID))
@@ -531,7 +541,7 @@ func (c *Controller) prepareNetworkPolicyACLSampling(key, pgName string, np *net
 		klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
 		return nil
 	}
-	state := &networkPolicySamplingState{request: request}
+	state := &networkPolicySamplingState{request: request, policyUID: np.UID}
 	c.npSamplingStates.Store(key, state)
 	return state
 }
@@ -552,6 +562,18 @@ func (c *Controller) setNetworkPolicyACLLog(pgName, key string, logEnable, isIng
 		return false
 	}
 	return true
+}
+
+func (c *Controller) deleteNetworkPolicySamplingState(key string, policyUID types.UID) {
+	if c.npSamplingStates == nil {
+		return
+	}
+	c.npSamplingStates.Compute(key, func(state *networkPolicySamplingState, loaded bool) (*networkPolicySamplingState, xsync.ComputeOp) {
+		if loaded && (policyUID == "" || state.policyUID == policyUID) {
+			return nil, xsync.DeleteOp
+		}
+		return state, xsync.CancelOp
+	})
 }
 
 func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
@@ -578,7 +600,8 @@ func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
 	return nil
 }
 
-func (c *Controller) handleDeleteNp(key string) error {
+func (c *Controller) handleDeleteNp(request networkPolicyDeleteRequest) error {
+	key := request.key
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
@@ -588,9 +611,13 @@ func (c *Controller) handleDeleteNp(key string) error {
 	c.npKeyMutex.LockKey(key)
 	defer func() { _ = c.npKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle delete network policy %s", key)
-	if c.npSamplingStates != nil {
-		c.npSamplingStates.Delete(key)
+	if _, err := c.npsLister.NetworkPolicies(namespace).Get(name); err == nil {
+		klog.V(3).Infof("ignore stale delete for network policy %s", key)
+		return nil
+	} else if !k8serrors.IsNotFound(err) {
+		return err
 	}
+	c.deleteNetworkPolicySamplingState(key, request.policyUID)
 
 	npName := name
 	nameArray := []rune(name)

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -523,6 +523,13 @@ func (c *Controller) handleUpdateNp(key string) error {
 }
 
 func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
+	c.npKeyMutex.LockKey(key)
+	defer func() {
+		if err := c.npKeyMutex.UnlockKey(key); err != nil {
+			klog.Errorf("failed to unlock network policy %s after ACL sampling: %v", key, err)
+		}
+	}()
+
 	request, ok := c.npSamplingRequests.Load(key)
 	if !ok {
 		return nil

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/scylladb/go-set/strset"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -169,6 +170,15 @@ func (c *Controller) handleUpdateNp(key string) error {
 	if err = c.OVNNbClient.PortGroupSetPorts(pgName, ports); err != nil {
 		klog.Errorf("failed to set ports of port group %s to %v: %v", pgName, ports, err)
 		return err
+	}
+
+	var samplingRequest *ovs.NetworkPolicySamplingRequest
+	if c.config.ACLSampling.Enabled {
+		samplingRequest, err = c.OVNNbClient.PrepareNetworkPolicyACLSampling(pgName, np.Namespace, np.Name, string(np.UID))
+		if err != nil {
+			// Sampling is best-effort and must never block NetworkPolicy enforcement.
+			klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
+		}
 	}
 
 	ingressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil)
@@ -505,6 +515,27 @@ func (c *Controller) handleUpdateNp(key string) error {
 			return err
 		}
 	}
+	if samplingRequest != nil {
+		c.npSamplingRequests.Store(key, samplingRequest)
+		c.npSamplingQueue.Add(key)
+	}
+	return nil
+}
+
+func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
+	request, ok := c.npSamplingRequests.Load(key)
+	if !ok {
+		return nil
+	}
+	if err := c.OVNNbClient.ApplyNetworkPolicyACLSampling(c.config.ACLSampling, request); err != nil {
+		return err
+	}
+	c.npSamplingRequests.Compute(key, func(current *ovs.NetworkPolicySamplingRequest, loaded bool) (*ovs.NetworkPolicySamplingRequest, xsync.ComputeOp) {
+		if loaded && current == request {
+			return nil, xsync.DeleteOp
+		}
+		return current, xsync.CancelOp
+	})
 	return nil
 }
 

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/scylladb/go-set/strset"
@@ -31,6 +32,31 @@ const (
 	NetworkPolicyEnforcementStandard = "standard"
 	NetworkPolicyEnforcementLax      = "lax"
 )
+
+func networkPolicyResourceName(name string) string {
+	first, _ := utf8.DecodeRuneInString(name)
+	if !unicode.IsLetter(first) {
+		return "np" + name
+	}
+	return name
+}
+
+func networkPolicyPortGroupName(namespace, name string) string {
+	return strings.ReplaceAll(fmt.Sprintf("%s.%s", networkPolicyResourceName(name), namespace), "-", ".")
+}
+
+func (c *Controller) networkPolicyPortGroupInUse(namespace, portGroupName string) (bool, error) {
+	policies, err := c.npsLister.NetworkPolicies(namespace).List(labels.Everything())
+	if err != nil {
+		return false, err
+	}
+	for _, policy := range policies {
+		if networkPolicyPortGroupName(policy.Namespace, policy.Name) == portGroupName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 func (c *Controller) enqueueAddNp(obj any) {
 	key := cache.MetaObjectToName(obj.(*netv1.NetworkPolicy)).String()
@@ -57,7 +83,11 @@ func (c *Controller) enqueueDeleteNp(obj any) {
 
 	key := cache.MetaObjectToName(np).String()
 	klog.V(3).Infof("enqueue delete network policy %s", key)
-	c.deleteNpQueue.Add(networkPolicyDeleteRequest{key: key, policyUID: np.UID})
+	c.deleteNpQueue.Add(networkPolicyDeleteRequest{
+		key:           key,
+		policyUID:     np.UID,
+		portGroupName: networkPolicyPortGroupName(np.Namespace, np.Name),
+	})
 }
 
 func (c *Controller) enqueueUpdateNp(oldObj, newObj any) {
@@ -94,8 +124,9 @@ func (c *Controller) handleUpdateNp(key string) error {
 		return nil
 	}
 
-	c.npKeyMutex.LockKey(key)
-	defer func() { _ = c.npKeyMutex.UnlockKey(key) }()
+	lockKey := networkPolicyPortGroupName(namespace, name)
+	c.npKeyMutex.LockKey(lockKey)
+	defer func() { _ = c.npKeyMutex.UnlockKey(lockKey) }()
 	klog.Infof("handle add/update network policy %s", key)
 
 	np, err := c.npsLister.NetworkPolicies(namespace).Get(name)
@@ -125,22 +156,18 @@ func (c *Controller) handleUpdateNp(key string) error {
 
 	providers := parsePolicyFor(np)
 
-	npName := np.Name
-	nameArray := []rune(np.Name)
-	if !unicode.IsLetter(nameArray[0]) {
-		npName = "np" + np.Name
-	}
+	npName := networkPolicyResourceName(np.Name)
 
 	// TODO: ovn acl doesn't support address_set name with '-', now we replace '-' by '.'.
 	// This may cause conflict if two np with name test-np and test.np. Maybe hash is a better solution,
 	// but we do not want to lost the readability now.
-	pgName := npPortGroupName(np.Namespace, npName)
+	pgName := networkPolicyPortGroupName(np.Namespace, np.Name)
 	ingressAllowAsNamePrefix := strings.ReplaceAll(fmt.Sprintf("%s.%s.ingress.allow", npName, np.Namespace), "-", ".")
 	ingressExceptAsNamePrefix := strings.ReplaceAll(fmt.Sprintf("%s.%s.ingress.except", npName, np.Namespace), "-", ".")
 	egressAllowAsNamePrefix := strings.ReplaceAll(fmt.Sprintf("%s.%s.egress.allow", npName, np.Namespace), "-", ".")
 	egressExceptAsNamePrefix := strings.ReplaceAll(fmt.Sprintf("%s.%s.egress.except", npName, np.Namespace), "-", ".")
 
-	if err = c.OVNNbClient.CreatePortGroup(pgName, map[string]string{networkPolicyKey: np.Namespace + "/" + npName}); err != nil {
+	if err = c.OVNNbClient.CreatePortGroup(pgName, map[string]string{networkPolicyKey: key}); err != nil {
 		klog.Errorf("create port group for np %s: %v", key, err)
 		return err
 	}
@@ -513,14 +540,16 @@ func (c *Controller) handleUpdateNp(key string) error {
 
 type networkPolicySamplingState struct {
 	// Access is serialized with the policy's npKeyMutex lock.
-	request   *ovs.NetworkPolicySamplingRequest
-	policyUID types.UID
-	ready     bool
+	request       *ovs.NetworkPolicySamplingRequest
+	policyUID     types.UID
+	portGroupName string
+	ready         bool
 }
 
 type networkPolicyDeleteRequest struct {
-	key       string
-	policyUID types.UID
+	key           string
+	policyUID     types.UID
+	portGroupName string
 }
 
 func (c *Controller) prepareNetworkPolicyACLSampling(key, pgName string, np *netv1.NetworkPolicy) *networkPolicySamplingState {
@@ -541,7 +570,7 @@ func (c *Controller) prepareNetworkPolicyACLSampling(key, pgName string, np *net
 		klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
 		return nil
 	}
-	state := &networkPolicySamplingState{request: request, policyUID: np.UID}
+	state := &networkPolicySamplingState{request: request, policyUID: np.UID, portGroupName: pgName}
 	c.npSamplingStates.Store(key, state)
 	return state
 }
@@ -564,12 +593,21 @@ func (c *Controller) setNetworkPolicyACLLog(pgName, key string, logEnable, isIng
 	return true
 }
 
-func (c *Controller) deleteNetworkPolicySamplingState(key string, policyUID types.UID) {
+func (c *Controller) deleteNetworkPolicySamplingState(key, portGroupName string, policyUID types.UID) {
 	if c.npSamplingStates == nil {
 		return
 	}
+	if policyUID == "" {
+		c.npSamplingStates.Range(func(candidateKey string, state *networkPolicySamplingState) bool {
+			if state.portGroupName == portGroupName {
+				c.npSamplingStates.Delete(candidateKey)
+			}
+			return true
+		})
+		return
+	}
 	c.npSamplingStates.Compute(key, func(state *networkPolicySamplingState, loaded bool) (*networkPolicySamplingState, xsync.ComputeOp) {
-		if loaded && (policyUID == "" || state.policyUID == policyUID) {
+		if loaded && state.policyUID == policyUID {
 			return nil, xsync.DeleteOp
 		}
 		return state, xsync.CancelOp
@@ -577,9 +615,15 @@ func (c *Controller) deleteNetworkPolicySamplingState(key string, policyUID type
 }
 
 func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
-	c.npKeyMutex.LockKey(key)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+	lockKey := networkPolicyPortGroupName(namespace, name)
+	c.npKeyMutex.LockKey(lockKey)
 	defer func() {
-		if err := c.npKeyMutex.UnlockKey(key); err != nil {
+		if err := c.npKeyMutex.UnlockKey(lockKey); err != nil {
 			klog.Errorf("failed to unlock network policy %s after ACL sampling: %v", key, err)
 		}
 	}()
@@ -608,24 +652,25 @@ func (c *Controller) handleDeleteNp(request networkPolicyDeleteRequest) error {
 		return nil
 	}
 
-	c.npKeyMutex.LockKey(key)
-	defer func() { _ = c.npKeyMutex.UnlockKey(key) }()
+	lockKey := request.portGroupName
+	if lockKey == "" {
+		lockKey = networkPolicyPortGroupName(namespace, name)
+	}
+	c.npKeyMutex.LockKey(lockKey)
+	defer func() { _ = c.npKeyMutex.UnlockKey(lockKey) }()
 	klog.Infof("handle delete network policy %s", key)
-	if _, err := c.npsLister.NetworkPolicies(namespace).Get(name); err == nil {
-		klog.V(3).Infof("ignore stale delete for network policy %s", key)
-		return nil
-	} else if !k8serrors.IsNotFound(err) {
+	inUse, err := c.networkPolicyPortGroupInUse(namespace, lockKey)
+	if err != nil {
 		return err
 	}
-	c.deleteNetworkPolicySamplingState(key, request.policyUID)
-
-	npName := name
-	nameArray := []rune(name)
-	if !unicode.IsLetter(nameArray[0]) {
-		npName = "np" + name
+	if inUse {
+		klog.V(3).Infof("ignore stale delete for network policy %s", key)
+		return nil
 	}
+	c.deleteNetworkPolicySamplingState(key, lockKey, request.policyUID)
 
-	pgName := npPortGroupName(namespace, npName)
+	npName := networkPolicyResourceName(name)
+	pgName := lockKey
 	var firstErr error
 	for _, meterName := range networkPolicyMeterNames(pgName) {
 		if err := c.OVNNbClient.DeleteMeter(meterName); err != nil {

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -172,14 +172,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 		return err
 	}
 
-	var samplingRequest *ovs.NetworkPolicySamplingRequest
-	if c.config.ACLSampling.Enabled {
-		samplingRequest, err = c.OVNNbClient.PrepareNetworkPolicyACLSampling(pgName, np.Namespace, np.Name, string(np.UID))
-		if err != nil {
-			// Sampling is best-effort and must never block NetworkPolicy enforcement.
-			klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
-		}
-	}
+	samplingState := c.prepareNetworkPolicyACLSampling(key, pgName, np)
 
 	ingressACLOps, err := c.OVNNbClient.DeleteAclsOps(pgName, portGroupKey, "to-lport", nil)
 	if err != nil {
@@ -300,9 +293,8 @@ func (c *Controller) handleUpdateNp(key string) error {
 			return fmt.Errorf("add ingress acls to %s: %w", pgName, err)
 		}
 
-		if err := c.OVNNbClient.SetNetPolACLLog(pgName, logEnable, true); err != nil {
-			// just log and do not return err here
-			klog.Errorf("failed to set ingress acl log for np %s, %v", key, err)
+		if !c.setNetworkPolicyACLLog(pgName, key, logEnable, true) {
+			samplingState = nil
 		}
 
 		ass, err := c.OVNNbClient.ListAddressSets(map[string]string{
@@ -463,9 +455,8 @@ func (c *Controller) handleUpdateNp(key string) error {
 			return fmt.Errorf("add egress acls to %s: %w", pgName, err)
 		}
 
-		if err := c.OVNNbClient.SetNetPolACLLog(pgName, logEnable, false); err != nil {
-			// just log and do not return err here
-			klog.Errorf("failed to set egress acl log for np %s, %v", key, err)
+		if !c.setNetworkPolicyACLLog(pgName, key, logEnable, false) {
+			samplingState = nil
 		}
 
 		ass, err := c.OVNNbClient.ListAddressSets(map[string]string{
@@ -515,11 +506,52 @@ func (c *Controller) handleUpdateNp(key string) error {
 			return err
 		}
 	}
-	if samplingRequest != nil {
-		c.npSamplingRequests.Store(key, samplingRequest)
-		c.npSamplingQueue.Add(key)
-	}
+	c.queueNetworkPolicyACLSampling(key, samplingState)
 	return nil
+}
+
+type networkPolicySamplingState struct {
+	// Access is serialized with the policy's npKeyMutex lock.
+	request *ovs.NetworkPolicySamplingRequest
+	ready   bool
+}
+
+func (c *Controller) prepareNetworkPolicyACLSampling(key, pgName string, np *netv1.NetworkPolicy) *networkPolicySamplingState {
+	if !c.config.ACLSampling.Enabled {
+		return nil
+	}
+	if state, ok := c.npSamplingStates.Load(key); ok {
+		state.ready = false
+		return state
+	}
+
+	request, err := c.OVNNbClient.PrepareNetworkPolicyACLSampling(pgName, np.Namespace, np.Name, string(np.UID))
+	if err != nil {
+		// Sampling is best-effort and must never block NetworkPolicy enforcement.
+		klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
+		return nil
+	}
+	state := &networkPolicySamplingState{request: request}
+	c.npSamplingStates.Store(key, state)
+	return state
+}
+
+func (c *Controller) queueNetworkPolicyACLSampling(key string, state *networkPolicySamplingState) {
+	if state == nil {
+		return
+	}
+	state.ready = true
+	c.npSamplingQueue.Add(key)
+}
+
+func (c *Controller) setNetworkPolicyACLLog(pgName, key string, logEnable, isIngress bool) bool {
+	if err := c.OVNNbClient.SetNetPolACLLog(pgName, logEnable, isIngress); err != nil {
+		// Logging is best-effort for enforcement, but sampling waits for the
+		// complete enforcement path to succeed.
+		klog.Errorf("failed to set network policy %s ACL log: %v", key, err)
+		return false
+	}
+	return true
 }
 
 func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
@@ -530,15 +562,15 @@ func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
 		}
 	}()
 
-	request, ok := c.npSamplingRequests.Load(key)
-	if !ok {
+	state, ok := c.npSamplingStates.Load(key)
+	if !ok || !state.ready {
 		return nil
 	}
-	if err := c.OVNNbClient.ApplyNetworkPolicyACLSampling(c.config.ACLSampling, request); err != nil {
+	if err := c.OVNNbClient.ApplyNetworkPolicyACLSampling(c.config.ACLSampling, state.request); err != nil {
 		return err
 	}
-	c.npSamplingRequests.Compute(key, func(current *ovs.NetworkPolicySamplingRequest, loaded bool) (*ovs.NetworkPolicySamplingRequest, xsync.ComputeOp) {
-		if loaded && current == request {
+	c.npSamplingStates.Compute(key, func(current *networkPolicySamplingState, loaded bool) (*networkPolicySamplingState, xsync.ComputeOp) {
+		if loaded && current == state {
 			return nil, xsync.DeleteOp
 		}
 		return current, xsync.CancelOp
@@ -556,6 +588,9 @@ func (c *Controller) handleDeleteNp(key string) error {
 	c.npKeyMutex.LockKey(key)
 	defer func() { _ = c.npKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle delete network policy %s", key)
+	if c.npSamplingStates != nil {
+		c.npSamplingStates.Delete(key)
+	}
 
 	npName := name
 	nameArray := []rune(name)

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/keymutex"
 
 	mockovs "github.com/kubeovn/kube-ovn/mocks/pkg/ovs"
@@ -15,55 +18,112 @@ import (
 )
 
 func TestHandleNetworkPolicyACLSamplingRetriesOnlySampling(t *testing.T) {
-	mockController := gomock.NewController(t)
-	nbClient := mockovs.NewMockNbClient(mockController)
-	config := aclsampling.ControllerConfig{Enabled: true}
-	controller := &Controller{
-		config:             &Configuration{ACLSampling: config},
-		OVNNbClient:        nbClient,
-		npSamplingRequests: xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest](),
-		npKeyMutex:         keymutex.NewHashed(1),
-	}
+	controller, nbClient, config := newNetworkPolicySamplingTestController(t)
 	request := new(ovs.NetworkPolicySamplingRequest)
-	controller.npSamplingRequests.Store("default/test", request)
+	controller.npSamplingStates.Store("default/test", &networkPolicySamplingState{request: request, ready: true})
 
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(errors.New("injected sampling failure"))
 	require.ErrorContains(t, controller.handleNetworkPolicyACLSampling("default/test"), "injected sampling failure")
-	actual, ok := controller.npSamplingRequests.Load("default/test")
+	actual, ok := controller.npSamplingStates.Load("default/test")
 	require.True(t, ok)
-	require.Same(t, request, actual)
+	require.Same(t, request, actual.request)
 
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(nil)
 	require.NoError(t, controller.handleNetworkPolicyACLSampling("default/test"))
-	_, ok = controller.npSamplingRequests.Load("default/test")
+	_, ok = controller.npSamplingStates.Load("default/test")
 	require.False(t, ok)
 }
 
 func TestHandleNetworkPolicyACLSamplingUsesRequestStoredByConcurrentEnforcement(t *testing.T) {
-	mockController := gomock.NewController(t)
-	nbClient := mockovs.NewMockNbClient(mockController)
-	config := aclsampling.ControllerConfig{Enabled: true}
-	controller := &Controller{
-		config:             &Configuration{ACLSampling: config},
-		OVNNbClient:        nbClient,
-		npSamplingRequests: xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest](),
-		npKeyMutex:         keymutex.NewHashed(1),
-	}
+	controller, nbClient, config := newNetworkPolicySamplingTestController(t)
 	const key = "default/test"
 	oldRequest := new(ovs.NetworkPolicySamplingRequest)
 	newRequest := new(ovs.NetworkPolicySamplingRequest)
-	controller.npSamplingRequests.Store(key, oldRequest)
+	controller.npSamplingStates.Store(key, &networkPolicySamplingState{request: oldRequest, ready: true})
 
 	controller.npKeyMutex.LockKey(key)
 	done := make(chan error, 1)
 	go func() {
 		done <- controller.handleNetworkPolicyACLSampling(key)
 	}()
-	controller.npSamplingRequests.Store(key, newRequest)
+	controller.npSamplingStates.Store(key, &networkPolicySamplingState{request: newRequest, ready: true})
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, newRequest).Return(nil)
 	require.NoError(t, controller.npKeyMutex.UnlockKey(key))
 
 	require.NoError(t, <-done)
-	_, ok := controller.npSamplingRequests.Load(key)
+	_, ok := controller.npSamplingStates.Load(key)
 	require.False(t, ok)
+}
+
+func TestPrepareNetworkPolicyACLSamplingRejectsIncompleteSnapshot(t *testing.T) {
+	controller, nbClient, _ := newNetworkPolicySamplingTestController(t)
+	request := new(ovs.NetworkPolicySamplingRequest)
+	nbClient.EXPECT().PrepareNetworkPolicyACLSampling("pg", "default", "test", "uid").
+		Return(request, errors.New("injected snapshot failure"))
+
+	require.Nil(t, controller.prepareNetworkPolicyACLSampling("default/test", "pg", networkPolicySamplingTestPolicy()))
+	_, ok := controller.npSamplingStates.Load("default/test")
+	require.False(t, ok)
+}
+
+func TestPrepareNetworkPolicyACLSamplingRetainsSnapshotAcrossEnforcementRetries(t *testing.T) {
+	controller, _, _ := newNetworkPolicySamplingTestController(t)
+	const key = "default/test"
+	state := &networkPolicySamplingState{request: new(ovs.NetworkPolicySamplingRequest), ready: true}
+	controller.npSamplingStates.Store(key, state)
+
+	actual := controller.prepareNetworkPolicyACLSampling(key, "pg", networkPolicySamplingTestPolicy())
+	require.Same(t, state, actual)
+	require.False(t, actual.ready)
+}
+
+func TestHandleNetworkPolicyACLSamplingWaitsForSuccessfulEnforcement(t *testing.T) {
+	controller, nbClient, config := newNetworkPolicySamplingTestController(t)
+	const key = "default/test"
+	request := new(ovs.NetworkPolicySamplingRequest)
+	state := &networkPolicySamplingState{request: request}
+	controller.npSamplingStates.Store(key, state)
+
+	require.NoError(t, controller.handleNetworkPolicyACLSampling(key))
+	actual, ok := controller.npSamplingStates.Load(key)
+	require.True(t, ok)
+	require.Same(t, state, actual)
+
+	controller.queueNetworkPolicyACLSampling(key, state)
+	require.True(t, state.ready)
+	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(nil)
+	require.NoError(t, controller.handleNetworkPolicyACLSampling(key))
+	_, ok = controller.npSamplingStates.Load(key)
+	require.False(t, ok)
+}
+
+func TestSetNetworkPolicyACLLogReportsSamplingReadiness(t *testing.T) {
+	controller, nbClient, _ := newNetworkPolicySamplingTestController(t)
+	nbClient.EXPECT().SetNetPolACLLog("pg", true, true).Return(nil)
+	require.True(t, controller.setNetworkPolicyACLLog("pg", "default/test", true, true))
+	nbClient.EXPECT().SetNetPolACLLog("pg", true, false).Return(errors.New("injected logging failure"))
+	require.False(t, controller.setNetworkPolicyACLLog("pg", "default/test", true, false))
+}
+
+func newNetworkPolicySamplingTestController(t *testing.T) (*Controller, *mockovs.MockNbClient, aclsampling.ControllerConfig) {
+	t.Helper()
+	config := aclsampling.ControllerConfig{Enabled: true}
+	nbClient := mockovs.NewMockNbClient(gomock.NewController(t))
+	controller := &Controller{
+		config:           &Configuration{ACLSampling: config},
+		OVNNbClient:      nbClient,
+		npSamplingQueue:  newTypedRateLimitingQueue[string]("TestNetworkPolicyACLSampling", nil),
+		npSamplingStates: xsync.NewMap[string, *networkPolicySamplingState](),
+		npKeyMutex:       keymutex.NewHashed(1),
+	}
+	t.Cleanup(controller.npSamplingQueue.ShutDown)
+	return controller, nbClient, config
+}
+
+func networkPolicySamplingTestPolicy() *netv1.NetworkPolicy {
+	return &netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "test",
+		UID:       types.UID("uid"),
+	}}
 }

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -10,6 +10,8 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	netlisters "k8s.io/client-go/listers/networking/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/keymutex"
 
 	mockovs "github.com/kubeovn/kube-ovn/mocks/pkg/ovs"
@@ -41,14 +43,15 @@ func TestHandleNetworkPolicyACLSamplingUsesRequestStoredByConcurrentEnforcement(
 	newRequest := new(ovs.NetworkPolicySamplingRequest)
 	controller.npSamplingStates.Store(key, &networkPolicySamplingState{request: oldRequest, ready: true})
 
-	controller.npKeyMutex.LockKey(key)
+	lockKey := networkPolicyPortGroupName("default", "test")
+	controller.npKeyMutex.LockKey(lockKey)
 	done := make(chan error, 1)
 	go func() {
 		done <- controller.handleNetworkPolicyACLSampling(key)
 	}()
 	controller.npSamplingStates.Store(key, &networkPolicySamplingState{request: newRequest, ready: true})
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, newRequest).Return(nil)
-	require.NoError(t, controller.npKeyMutex.UnlockKey(key))
+	require.NoError(t, controller.npKeyMutex.UnlockKey(lockKey))
 
 	require.NoError(t, <-done)
 	_, ok := controller.npSamplingStates.Load(key)
@@ -97,14 +100,39 @@ func TestDeleteNetworkPolicySamplingStateMatchesPolicyUID(t *testing.T) {
 	state := &networkPolicySamplingState{request: new(ovs.NetworkPolicySamplingRequest), policyUID: types.UID("new-uid")}
 	controller.npSamplingStates.Store(key, state)
 
-	controller.deleteNetworkPolicySamplingState(key, types.UID("old-uid"))
+	controller.deleteNetworkPolicySamplingState(key, "pg", types.UID("old-uid"))
 	actual, ok := controller.npSamplingStates.Load(key)
 	require.True(t, ok)
 	require.Same(t, state, actual)
 
-	controller.deleteNetworkPolicySamplingState(key, types.UID("new-uid"))
+	controller.deleteNetworkPolicySamplingState(key, "pg", types.UID("new-uid"))
 	_, ok = controller.npSamplingStates.Load(key)
 	require.False(t, ok)
+}
+
+func TestDeleteNetworkPolicySamplingStateMatchesLegacyPortGroupName(t *testing.T) {
+	controller, _, _ := newNetworkPolicySamplingTestController(t)
+	const key = "default/1test"
+	state := &networkPolicySamplingState{
+		request:       new(ovs.NetworkPolicySamplingRequest),
+		policyUID:     types.UID("uid"),
+		portGroupName: "np1test.default",
+	}
+	controller.npSamplingStates.Store(key, state)
+
+	controller.deleteNetworkPolicySamplingState("default/np1test", "np1test.default", "")
+	_, ok := controller.npSamplingStates.Load(key)
+	require.False(t, ok)
+}
+
+func TestNetworkPolicyPortGroupInUseMatchesNormalizedName(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, indexer.Add(&netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "1test"}}))
+	controller := &Controller{npsLister: netlisters.NewNetworkPolicyLister(indexer)}
+
+	inUse, err := controller.networkPolicyPortGroupInUse("default", "np1test.default")
+	require.NoError(t, err)
+	require.True(t, inUse)
 }
 
 func TestHandleNetworkPolicyACLSamplingWaitsForSuccessfulEnforcement(t *testing.T) {

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"k8s.io/utils/keymutex"
 
 	mockovs "github.com/kubeovn/kube-ovn/mocks/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
@@ -21,6 +22,7 @@ func TestHandleNetworkPolicyACLSamplingRetriesOnlySampling(t *testing.T) {
 		config:             &Configuration{ACLSampling: config},
 		OVNNbClient:        nbClient,
 		npSamplingRequests: xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest](),
+		npKeyMutex:         keymutex.NewHashed(1),
 	}
 	request := new(ovs.NetworkPolicySamplingRequest)
 	controller.npSamplingRequests.Store("default/test", request)
@@ -34,5 +36,34 @@ func TestHandleNetworkPolicyACLSamplingRetriesOnlySampling(t *testing.T) {
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(nil)
 	require.NoError(t, controller.handleNetworkPolicyACLSampling("default/test"))
 	_, ok = controller.npSamplingRequests.Load("default/test")
+	require.False(t, ok)
+}
+
+func TestHandleNetworkPolicyACLSamplingUsesRequestStoredByConcurrentEnforcement(t *testing.T) {
+	mockController := gomock.NewController(t)
+	nbClient := mockovs.NewMockNbClient(mockController)
+	config := aclsampling.ControllerConfig{Enabled: true}
+	controller := &Controller{
+		config:             &Configuration{ACLSampling: config},
+		OVNNbClient:        nbClient,
+		npSamplingRequests: xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest](),
+		npKeyMutex:         keymutex.NewHashed(1),
+	}
+	const key = "default/test"
+	oldRequest := new(ovs.NetworkPolicySamplingRequest)
+	newRequest := new(ovs.NetworkPolicySamplingRequest)
+	controller.npSamplingRequests.Store(key, oldRequest)
+
+	controller.npKeyMutex.LockKey(key)
+	done := make(chan error, 1)
+	go func() {
+		done <- controller.handleNetworkPolicyACLSampling(key)
+	}()
+	controller.npSamplingRequests.Store(key, newRequest)
+	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, newRequest).Return(nil)
+	require.NoError(t, controller.npKeyMutex.UnlockKey(key))
+
+	require.NoError(t, <-done)
+	_, ok := controller.npSamplingRequests.Load(key)
 	require.False(t, ok)
 }

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -69,12 +69,42 @@ func TestPrepareNetworkPolicyACLSamplingRejectsIncompleteSnapshot(t *testing.T) 
 func TestPrepareNetworkPolicyACLSamplingRetainsSnapshotAcrossEnforcementRetries(t *testing.T) {
 	controller, _, _ := newNetworkPolicySamplingTestController(t)
 	const key = "default/test"
-	state := &networkPolicySamplingState{request: new(ovs.NetworkPolicySamplingRequest), ready: true}
+	state := &networkPolicySamplingState{request: new(ovs.NetworkPolicySamplingRequest), policyUID: types.UID("uid"), ready: true}
 	controller.npSamplingStates.Store(key, state)
 
 	actual := controller.prepareNetworkPolicyACLSampling(key, "pg", networkPolicySamplingTestPolicy())
 	require.Same(t, state, actual)
 	require.False(t, actual.ready)
+}
+
+func TestPrepareNetworkPolicyACLSamplingReplacesSnapshotForNewPolicyUID(t *testing.T) {
+	controller, nbClient, _ := newNetworkPolicySamplingTestController(t)
+	const key = "default/test"
+	oldState := &networkPolicySamplingState{request: new(ovs.NetworkPolicySamplingRequest), policyUID: types.UID("old-uid"), ready: true}
+	controller.npSamplingStates.Store(key, oldState)
+	newRequest := new(ovs.NetworkPolicySamplingRequest)
+	nbClient.EXPECT().PrepareNetworkPolicyACLSampling("pg", "default", "test", "uid").Return(newRequest, nil)
+
+	actual := controller.prepareNetworkPolicyACLSampling(key, "pg", networkPolicySamplingTestPolicy())
+	require.NotSame(t, oldState, actual)
+	require.Same(t, newRequest, actual.request)
+	require.Equal(t, types.UID("uid"), actual.policyUID)
+}
+
+func TestDeleteNetworkPolicySamplingStateMatchesPolicyUID(t *testing.T) {
+	controller, _, _ := newNetworkPolicySamplingTestController(t)
+	const key = "default/test"
+	state := &networkPolicySamplingState{request: new(ovs.NetworkPolicySamplingRequest), policyUID: types.UID("new-uid")}
+	controller.npSamplingStates.Store(key, state)
+
+	controller.deleteNetworkPolicySamplingState(key, types.UID("old-uid"))
+	actual, ok := controller.npSamplingStates.Load(key)
+	require.True(t, ok)
+	require.Same(t, state, actual)
+
+	controller.deleteNetworkPolicySamplingState(key, types.UID("new-uid"))
+	_, ok = controller.npSamplingStates.Load(key)
+	require.False(t, ok)
 }
 
 func TestHandleNetworkPolicyACLSamplingWaitsForSuccessfulEnforcement(t *testing.T) {

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	mockovs "github.com/kubeovn/kube-ovn/mocks/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+)
+
+func TestHandleNetworkPolicyACLSamplingRetriesOnlySampling(t *testing.T) {
+	mockController := gomock.NewController(t)
+	nbClient := mockovs.NewMockNbClient(mockController)
+	config := aclsampling.ControllerConfig{Enabled: true}
+	controller := &Controller{
+		config:             &Configuration{ACLSampling: config},
+		OVNNbClient:        nbClient,
+		npSamplingRequests: xsync.NewMap[string, *ovs.NetworkPolicySamplingRequest](),
+	}
+	request := new(ovs.NetworkPolicySamplingRequest)
+	controller.npSamplingRequests.Store("default/test", request)
+
+	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(errors.New("injected sampling failure"))
+	require.ErrorContains(t, controller.handleNetworkPolicyACLSampling("default/test"), "injected sampling failure")
+	actual, ok := controller.npSamplingRequests.Load("default/test")
+	require.True(t, ok)
+	require.Same(t, request, actual)
+
+	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(nil)
+	require.NoError(t, controller.handleNetworkPolicyACLSampling("default/test"))
+	_, ok = controller.npSamplingRequests.Load("default/test")
+	require.False(t, ok)
+}


### PR DESCRIPTION
Related to #7146.

## Summary

- capture prior sampling metadata before ingress enforcement replaces ACLs
- enqueue sampling only after ingress, egress, logging, and helper enforcement succeeds
- retry sampling through a dedicated rate-limited queue without failing or re-running enforcement
- serialize same-policy sampling with enforcement and always reload the latest request
- retain failed requests and remove only the exact request that completed successfully

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. **#7164 — sampling-only retry and enforcement isolation**
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-network-policy-attachment`

## Validation

- `GOMAXPROCS=2 go test ./pkg/controller -count=1`
- `go test -race ./pkg/controller -run TestHandleNetworkPolicyACLSampling -count=1`
- `GOMAXPROCS=2 go vet ./pkg/ovs ./pkg/controller`
- diff-scoped `golangci-lint` with one worker: 0 issues
- `git diff --check`