### PR TITLE
feat: clean up owned ACL sampling state

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1424,8 +1424,28 @@ func (c *Controller) shutdown() {
 	}
 }
 
+func (c *Controller) runDisabledACLSamplingCleanup(ctx context.Context) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		err := c.OVNNbClient.ReconcileACLSampling(c.config.ACLSampling)
+		if err == nil {
+			return
+		}
+		klog.Warningf("failed to clean up disabled ACL sampling state: %v", err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
 func (c *Controller) startWorkers(ctx context.Context) {
 	klog.Info("Starting workers")
+	if !c.config.ACLSampling.Enabled {
+		go c.runDisabledACLSamplingCleanup(ctx)
+	}
 
 	go wait.Until(runWorker("add/update vpc", c.addOrUpdateVpcQueue, c.handleAddOrUpdateVpc), time.Second, ctx.Done())
 	go wait.Until(runWorker("delete vpc", c.delVpcQueue, c.handleDelVpc), time.Second, ctx.Done())

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -1,8 +1,10 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/require"
@@ -161,6 +163,28 @@ func TestSetNetworkPolicyACLLogReportsSamplingReadiness(t *testing.T) {
 	require.True(t, controller.setNetworkPolicyACLLog("pg", "default/test", true, true))
 	nbClient.EXPECT().SetNetPolACLLog("pg", true, false).Return(errors.New("injected logging failure"))
 	require.False(t, controller.setNetworkPolicyACLLog("pg", "default/test", true, false))
+}
+
+func TestRunDisabledACLSamplingCleanupRetries(t *testing.T) {
+	controller, nbClient, config := newNetworkPolicySamplingTestController(t)
+	config.Enabled = false
+	controller.config.ACLSampling = config
+	nbClient.EXPECT().ReconcileACLSampling(config).Return(errors.New("injected cleanup failure"))
+	nbClient.EXPECT().ReconcileACLSampling(config).Return(nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		controller.runDisabledACLSamplingCleanup(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for disabled ACL sampling cleanup retry")
+	}
 }
 
 func newNetworkPolicySamplingTestController(t *testing.T) (*Controller, *mockovs.MockNbClient, aclsampling.ControllerConfig) {

--- a/pkg/ovs/ovn-nb-acl-sampling.go
+++ b/pkg/ovs/ovn-nb-acl-sampling.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"time"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
@@ -47,7 +48,7 @@ type desiredSampleCollector struct {
 // never adopted.
 func (c *OVNNbClient) ReconcileACLSampling(config aclsampling.ControllerConfig) error {
 	if !config.Enabled {
-		return nil
+		return c.cleanupACLSampling()
 	}
 	if err := config.Validate(); err != nil {
 		return fmt.Errorf("invalid ACL sampling configuration: %w", err)
@@ -316,4 +317,163 @@ func ownedACLSamplingExternalIDs(kind, role string) map[string]string {
 func isOwnedACLSamplingObject(externalIDs map[string]string) bool {
 	return externalIDs[ExternalIDVendor] == util.CniTypeName &&
 		externalIDs[aclSamplingFeatureExternalID] == aclSamplingFeature
+}
+
+func (c *OVNNbClient) cleanupACLSampling() error {
+	if err := validateACLSamplingSchema(c.Schema()); err != nil {
+		if errors.Is(err, ErrACLSamplingUnsupported) {
+			return nil
+		}
+		return err
+	}
+	if err := c.ensureACLSamplingMonitor(); err != nil {
+		return err
+	}
+
+	acls, err := c.ListAcls("", map[string]string{sampleFeatureExternalID: networkPolicySampleFeature})
+	if err != nil {
+		return fmt.Errorf("list owned ACL sampling references: %w", err)
+	}
+	clearOps := make([]ovsdb.Operation, 0, len(acls))
+	for i := range acls {
+		ops, err := c.clearNetworkPolicySamplingOps(&acls[i])
+		if err != nil {
+			return err
+		}
+		clearOps = append(clearOps, ops...)
+	}
+	if len(clearOps) != 0 {
+		if err := c.Transact("acl-sampling-cleanup-references", clearOps); err != nil {
+			return fmt.Errorf("clear owned ACL sampling references: %w", err)
+		}
+	}
+
+	collectors, err := c.listSampleCollectors()
+	if err != nil {
+		return err
+	}
+	ownedCollectors := make(map[string]struct{}, len(collectors))
+	for i := range collectors {
+		if isOwnedACLSamplingObject(collectors[i].ExternalIDs) {
+			ownedCollectors[collectors[i].UUID] = struct{}{}
+		}
+	}
+	retainedCollectors, err := c.waitForACLSamplingSampleGC(ownedCollectors)
+	if err != nil {
+		return err
+	}
+	if err := c.deleteUnreferencedACLSamplingCollectors(collectors, retainedCollectors); err != nil {
+		return err
+	}
+	return c.deleteOwnedACLSamplingApps()
+}
+
+func (c *OVNNbClient) waitForACLSamplingSampleGC(ownedCollectors map[string]struct{}) (map[string]struct{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		retained, pending, err := c.aclSamplingCollectorReferences(ownedCollectors)
+		if err != nil {
+			return nil, err
+		}
+		if !pending {
+			return retained, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("wait for owned ACL samples to be garbage collected: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (c *OVNNbClient) aclSamplingCollectorReferences(ownedCollectors map[string]struct{}) (map[string]struct{}, bool, error) {
+	acls, err := c.ListAcls("", nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("list ACL references during sampling cleanup: %w", err)
+	}
+	referencedSamples := make(map[string]struct{})
+	for _, acl := range acls {
+		if acl.ExternalIDs[sampleFeatureExternalID] == networkPolicySampleFeature {
+			return nil, true, nil
+		}
+		for _, sampleUUID := range compactSampleReferences(acl) {
+			referencedSamples[sampleUUID] = struct{}{}
+		}
+	}
+
+	samples, err := c.listSamples()
+	if err != nil {
+		return nil, false, err
+	}
+	retained := make(map[string]struct{})
+	pending := false
+	for _, sample := range samples {
+		_, referenced := referencedSamples[sample.UUID]
+		for _, collectorUUID := range sample.Collectors {
+			if _, owned := ownedCollectors[collectorUUID]; !owned {
+				continue
+			}
+			if referenced {
+				retained[collectorUUID] = struct{}{}
+			} else {
+				pending = true
+			}
+		}
+	}
+	return retained, pending, nil
+}
+
+func (c *OVNNbClient) deleteUnreferencedACLSamplingCollectors(collectors []ovnnb.SampleCollector, retained map[string]struct{}) error {
+	operations := make([]ovsdb.Operation, 0, len(collectors))
+	for i := range collectors {
+		collector := &collectors[i]
+		if !isOwnedACLSamplingObject(collector.ExternalIDs) {
+			continue
+		}
+		if _, ok := retained[collector.UUID]; ok {
+			continue
+		}
+		ops, err := c.Where(collector).Delete()
+		if err != nil {
+			return fmt.Errorf("build delete operation for owned sample collector %s: %w", collector.UUID, err)
+		}
+		operations = append(operations, ops...)
+	}
+	if len(operations) == 0 {
+		return nil
+	}
+	if err := c.Transact("acl-sampling-cleanup-collectors", operations); err != nil {
+		return fmt.Errorf("delete unreferenced owned sample collectors: %w", err)
+	}
+	return nil
+}
+
+func (c *OVNNbClient) deleteOwnedACLSamplingApps() error {
+	apps, err := c.listSamplingApps()
+	if err != nil {
+		return err
+	}
+	operations := make([]ovsdb.Operation, 0, len(apps))
+	for i := range apps {
+		app := &apps[i]
+		if !isOwnedACLSamplingObject(app.ExternalIDs) {
+			continue
+		}
+		ops, err := c.Where(app).Delete()
+		if err != nil {
+			return fmt.Errorf("build delete operation for owned sampling application %s: %w", app.UUID, err)
+		}
+		operations = append(operations, ops...)
+	}
+	if len(operations) == 0 {
+		return nil
+	}
+	if err := c.Transact("acl-sampling-cleanup-applications", operations); err != nil {
+		return fmt.Errorf("delete owned sampling applications: %w", err)
+	}
+	return nil
 }

--- a/pkg/ovs/ovn-nb-acl-sampling.go
+++ b/pkg/ovs/ovn-nb-acl-sampling.go
@@ -336,6 +336,9 @@ func (c *OVNNbClient) cleanupACLSampling() error {
 	}
 	clearOps := make([]ovsdb.Operation, 0, len(acls))
 	for i := range acls {
+		if !isOwnedNetworkPolicySamplingACL(acls[i].ExternalIDs) {
+			continue
+		}
 		ops, err := c.clearNetworkPolicySamplingOps(&acls[i])
 		if err != nil {
 			return err
@@ -397,7 +400,7 @@ func (c *OVNNbClient) aclSamplingCollectorReferences(ownedCollectors map[string]
 	}
 	referencedSamples := make(map[string]struct{})
 	for _, acl := range acls {
-		if acl.ExternalIDs[sampleFeatureExternalID] == networkPolicySampleFeature {
+		if isOwnedNetworkPolicySamplingACL(acl.ExternalIDs) {
 			return nil, true, nil
 		}
 		for _, sampleUUID := range compactSampleReferences(acl) {

--- a/pkg/ovs/ovn-nb-acl-sampling_test.go
+++ b/pkg/ovs/ovn-nb-acl-sampling_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
 	ovsclient "github.com/kubeovn/kube-ovn/pkg/ovsdb/client"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func newACLSamplingTestClient(t *testing.T, schemaName string) *OVNNbClient {
@@ -201,6 +202,121 @@ func TestValidateACLSamplingSchema(t *testing.T) {
 	err := validateACLSamplingSchema(schema)
 	require.ErrorIs(t, err, ErrACLSamplingUnsupported)
 	require.ErrorContains(t, err, "table Sample is missing")
+}
+
+func TestReconcileACLSamplingDisabledCleansOwnedState(t *testing.T) {
+	client := newACLSamplingTestClient(t, "cleanup-owned-state")
+	config := validACLSamplingConfig()
+	externalIDs := map[string]string{"owner": "external-observer"}
+	externalApp := &ovnnb.SamplingApp{
+		UUID:        ovsclient.NamedUUID(),
+		ExternalIDs: externalIDs,
+		ID:          int(config.AppIDNew),
+		Type:        ovnnb.SamplingAppTypeACLNew,
+	}
+	externalCollector := &ovnnb.SampleCollector{
+		UUID:        ovsclient.NamedUUID(),
+		ExternalIDs: externalIDs,
+		ID:          200,
+		Name:        "external-collector",
+		Probability: 100,
+		SetID:       200,
+	}
+	operations, err := client.Create(externalApp)
+	require.NoError(t, err)
+	collectorOps, err := client.Create(externalCollector)
+	require.NoError(t, err)
+	operations = append(operations, collectorOps...)
+	require.NoError(t, client.Transact("seed-unowned-sampling-objects", operations))
+
+	require.NoError(t, client.ReconcileACLSampling(config))
+	require.Eventually(t, func() bool {
+		apps, appErr := client.listSamplingApps()
+		collectors, collectorErr := client.listSampleCollectors()
+		return appErr == nil && collectorErr == nil && len(apps) == 2 && len(collectors) == 3
+	}, time.Second, 10*time.Millisecond)
+
+	const pgName = "cleanup-policy.default"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+	acl := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/cleanup-policy.default/ingress/IPv4/0")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, acl))
+	waitForACLCount(t, client, pgName, 1)
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "cleanup-policy", "11111111-aaaa-bbbb-cccc-222222222222")
+	require.NoError(t, err)
+	require.NoError(t, client.ApplyNetworkPolicyACLSampling(config, request))
+	require.Eventually(t, func() bool {
+		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		return listErr == nil && len(acls) == 1 && acls[0].SampleNew != nil && acls[0].SampleEst != nil
+	}, time.Second, 10*time.Millisecond)
+
+	config.Enabled = false
+	require.NoError(t, client.ReconcileACLSampling(config))
+	require.Eventually(t, func() bool {
+		acls, aclErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		apps, appErr := client.listSamplingApps()
+		collectors, collectorErr := client.listSampleCollectors()
+		samples, sampleErr := client.listSamples()
+		return aclErr == nil && appErr == nil && collectorErr == nil && sampleErr == nil &&
+			len(acls) == 1 && acls[0].SampleNew == nil && acls[0].SampleEst == nil &&
+			acls[0].ExternalIDs[sampleFeatureExternalID] == "" &&
+			len(apps) == 1 && maps.Equal(apps[0].ExternalIDs, externalIDs) &&
+			len(collectors) == 1 && maps.Equal(collectors[0].ExternalIDs, externalIDs) && len(samples) == 0
+	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestReconcileACLSamplingDisabledRetainsReferencedOwnedCollector(t *testing.T) {
+	client := newACLSamplingTestClient(t, "cleanup-retained-collector")
+	config := validACLSamplingConfig()
+	require.NoError(t, client.ReconcileACLSampling(config))
+	waitForACLSamplingObjects(t, client)
+
+	const pgName = "retained-policy.default"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+	eligible := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/retained-policy.default/ingress/IPv4/0")
+	external := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, ovnnb.ACLActionAllowRelated, "external-reference")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, eligible, external))
+	waitForACLCount(t, client, pgName, 2)
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "retained-policy", "33333333-aaaa-bbbb-cccc-444444444444")
+	require.NoError(t, err)
+	require.NoError(t, client.ApplyNetworkPolicyACLSampling(config, request))
+
+	var sampled ovnnb.ACL
+	require.Eventually(t, func() bool {
+		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		if listErr != nil {
+			return false
+		}
+		sampled = aclByName(t, acls, "np/retained-policy.default/ingress/IPv4/0")
+		return sampled.SampleNew != nil
+	}, time.Second, 10*time.Millisecond)
+	acls, err := client.ListAcls("", map[string]string{aclParentKey: pgName})
+	require.NoError(t, err)
+	externalACL := aclByName(t, acls, "external-reference")
+	externalACL.SampleNew = sampled.SampleNew
+	updateOps, err := client.Where(&externalACL).Update(&externalACL, &externalACL.SampleNew)
+	require.NoError(t, err)
+	require.NoError(t, client.Transact("seed-external-sample-reference", updateOps))
+	require.Eventually(t, func() bool {
+		current, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		return listErr == nil && aclByName(t, current, "external-reference").SampleNew != nil
+	}, time.Second, 10*time.Millisecond)
+
+	config.Enabled = false
+	require.NoError(t, client.ReconcileACLSampling(config))
+	require.Eventually(t, func() bool {
+		collectors, collectorErr := client.listSampleCollectors()
+		apps, appErr := client.listSamplingApps()
+		current, aclErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		if collectorErr != nil || appErr != nil || aclErr != nil {
+			return false
+		}
+		externalACL = aclByName(t, current, "external-reference")
+		return len(collectors) == 1 && collectors[0].ExternalIDs[aclSamplingRoleExternalID] == aclSamplingRoleAllow &&
+			len(apps) == 0 && externalACL.SampleNew != nil &&
+			aclByName(t, current, "np/retained-policy.default/ingress/IPv4/0").SampleNew == nil
+	}, 3*time.Second, 10*time.Millisecond)
 }
 
 func waitForACLSamplingObjects(t *testing.T, client *OVNNbClient) ([]ovnnb.SamplingApp, []ovnnb.SampleCollector) {

--- a/pkg/ovs/ovn-nb-acl-sampling_test.go
+++ b/pkg/ovs/ovn-nb-acl-sampling_test.go
@@ -237,18 +237,7 @@ func TestReconcileACLSamplingDisabledCleansOwnedState(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	const pgName = "cleanup-policy.default"
-	require.NoError(t, client.CreatePortGroup(pgName, nil))
-	waitForPortGroup(t, client, pgName)
-	acl := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/cleanup-policy.default/ingress/IPv4/0")
-	require.NoError(t, client.CreateAcls(pgName, portGroupKey, acl))
-	waitForACLCount(t, client, pgName, 1)
-	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "cleanup-policy", "11111111-aaaa-bbbb-cccc-222222222222")
-	require.NoError(t, err)
-	require.NoError(t, client.ApplyNetworkPolicyACLSampling(config, request))
-	require.Eventually(t, func() bool {
-		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
-		return listErr == nil && len(acls) == 1 && acls[0].SampleNew != nil && acls[0].SampleEst != nil
-	}, time.Second, 10*time.Millisecond)
+	seedSampledNetworkPolicyACL(t, client, config, pgName, "cleanup-policy", "11111111-aaaa-bbbb-cccc-222222222222")
 
 	config.Enabled = false
 	require.NoError(t, client.ReconcileACLSampling(config))
@@ -272,25 +261,12 @@ func TestReconcileACLSamplingDisabledRetainsReferencedOwnedCollector(t *testing.
 	waitForACLSamplingObjects(t, client)
 
 	const pgName = "retained-policy.default"
-	require.NoError(t, client.CreatePortGroup(pgName, nil))
-	waitForPortGroup(t, client, pgName)
-	eligible := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/retained-policy.default/ingress/IPv4/0")
+	sampled := seedSampledNetworkPolicyACL(t, client, config, pgName, "retained-policy", "33333333-aaaa-bbbb-cccc-444444444444")
 	external := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, ovnnb.ACLActionAllowRelated, "external-reference")
-	require.NoError(t, client.CreateAcls(pgName, portGroupKey, eligible, external))
+	external.ExternalIDs[ExternalIDVendor] = "external-observer"
+	external.ExternalIDs[sampleFeatureExternalID] = networkPolicySampleFeature
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, external))
 	waitForACLCount(t, client, pgName, 2)
-	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "retained-policy", "33333333-aaaa-bbbb-cccc-444444444444")
-	require.NoError(t, err)
-	require.NoError(t, client.ApplyNetworkPolicyACLSampling(config, request))
-
-	var sampled ovnnb.ACL
-	require.Eventually(t, func() bool {
-		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
-		if listErr != nil {
-			return false
-		}
-		sampled = aclByName(t, acls, "np/retained-policy.default/ingress/IPv4/0")
-		return sampled.SampleNew != nil
-	}, time.Second, 10*time.Millisecond)
 	acls, err := client.ListAcls("", map[string]string{aclParentKey: pgName})
 	require.NoError(t, err)
 	externalACL := aclByName(t, acls, "external-reference")
@@ -315,8 +291,34 @@ func TestReconcileACLSamplingDisabledRetainsReferencedOwnedCollector(t *testing.
 		externalACL = aclByName(t, current, "external-reference")
 		return len(collectors) == 1 && collectors[0].ExternalIDs[aclSamplingRoleExternalID] == aclSamplingRoleAllow &&
 			len(apps) == 0 && externalACL.SampleNew != nil &&
+			externalACL.ExternalIDs[ExternalIDVendor] == "external-observer" &&
+			externalACL.ExternalIDs[sampleFeatureExternalID] == networkPolicySampleFeature &&
 			aclByName(t, current, "np/retained-policy.default/ingress/IPv4/0").SampleNew == nil
 	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func seedSampledNetworkPolicyACL(t *testing.T, client *OVNNbClient, config aclsampling.ControllerConfig, pgName, policyName, policyUID string) ovnnb.ACL {
+	t.Helper()
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+	aclName := fmt.Sprintf("np/%s.default/ingress/IPv4/0", policyName)
+	acl := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, aclName)
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, acl))
+	waitForACLCount(t, client, pgName, 1)
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", policyName, policyUID)
+	require.NoError(t, err)
+	require.NoError(t, client.ApplyNetworkPolicyACLSampling(config, request))
+
+	var sampled ovnnb.ACL
+	require.Eventually(t, func() bool {
+		acls, listErr := client.ListAcls("", map[string]string{aclParentKey: pgName})
+		if listErr != nil || len(acls) != 1 {
+			return false
+		}
+		sampled = acls[0]
+		return sampled.SampleNew != nil && sampled.SampleEst != nil
+	}, time.Second, 10*time.Millisecond)
+	return sampled
 }
 
 func waitForACLSamplingObjects(t *testing.T, client *OVNNbClient) ([]ovnnb.SamplingApp, []ovnnb.SampleCollector) {


### PR DESCRIPTION
Related to #7146.

## Summary

- clear only ACLs marked as Kube-OVN NetworkPolicy sampling ACLs when disabled
- wait for non-root Sample rows to be garbage collected after references are removed
- delete only owned collectors no longer referenced by retained Samples
- preserve unowned applications, collectors, and ACL sample references
- delete owned applications last while preserving reused external applications
- treat unsupported sampling schema as a no-op while disabled

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. **#7165 — ownership-aware disable and cleanup**
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-network-policy`

## Validation

- `GOMAXPROCS=2 go test ./pkg/ovs -count=1`
- `go test -race ./pkg/ovs -run TestReconcileACLSamplingDisabled -count=1`
- `GOMAXPROCS=2 go vet ./pkg/ovs ./pkg/controller`
- diff-scoped `golangci-lint` with one worker: 0 issues
- `git diff --check`