### PR TITLE
feat: report ACL sampling availability

### DIFF
--- a/pkg/controller/acl_sampling.go
+++ b/pkg/controller/acl_sampling.go
@@ -1,12 +1,19 @@
 package controller
 
-import "k8s.io/klog/v2"
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/klog/v2"
+)
 
 const (
 	aclSamplingOperationReconcile = "reconcile"
 	aclSamplingOperationPrepare   = "prepare"
 	aclSamplingOperationAttach    = "attach"
 )
+
+var aclSamplingPrepareWarningLimiter = rate.NewLimiter(rate.Every(time.Minute), 1)
 
 func (c *Controller) reconcileACLSampling() {
 	if err := c.OVNNbClient.ReconcileACLSampling(c.config.ACLSampling); err != nil {
@@ -28,4 +35,10 @@ func recordACLSamplingFailure(operation string) {
 
 func recordACLSamplingSuccess() {
 	metricACLSamplingControllerAvailable.Set(1)
+}
+
+func warnACLSamplingPrepareFailure(key string, err error) {
+	if aclSamplingPrepareWarningLimiter.Allow() {
+		klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
+	}
 }

--- a/pkg/controller/acl_sampling.go
+++ b/pkg/controller/acl_sampling.go
@@ -15,17 +15,18 @@ const (
 
 var aclSamplingPrepareWarningLimiter = rate.NewLimiter(rate.Every(time.Minute), 1)
 
-func (c *Controller) reconcileACLSampling() {
+func (c *Controller) reconcileACLSampling() bool {
 	if err := c.OVNNbClient.ReconcileACLSampling(c.config.ACLSampling); err != nil {
 		recordACLSamplingFailure(aclSamplingOperationReconcile)
 		klog.Warningf("ACL sampling is unavailable: %v", err)
-		return
+		return false
 	}
 	if c.config.ACLSampling.Enabled {
 		metricACLSamplingControllerAvailable.Set(1)
 	} else {
 		metricACLSamplingControllerAvailable.Set(0)
 	}
+	return true
 }
 
 func recordACLSamplingFailure(operation string) {
@@ -40,5 +41,7 @@ func recordACLSamplingSuccess() {
 func warnACLSamplingPrepareFailure(key string, err error) {
 	if aclSamplingPrepareWarningLimiter.Allow() {
 		klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
+		return
 	}
+	klog.V(4).Infof("suppressed rate-limited ACL sampling prepare warning for network policy %s: %v", key, err)
 }

--- a/pkg/controller/acl_sampling.go
+++ b/pkg/controller/acl_sampling.go
@@ -1,0 +1,31 @@
+package controller
+
+import "k8s.io/klog/v2"
+
+const (
+	aclSamplingOperationReconcile = "reconcile"
+	aclSamplingOperationPrepare   = "prepare"
+	aclSamplingOperationAttach    = "attach"
+)
+
+func (c *Controller) reconcileACLSampling() {
+	if err := c.OVNNbClient.ReconcileACLSampling(c.config.ACLSampling); err != nil {
+		recordACLSamplingFailure(aclSamplingOperationReconcile)
+		klog.Warningf("ACL sampling is unavailable: %v", err)
+		return
+	}
+	if c.config.ACLSampling.Enabled {
+		metricACLSamplingControllerAvailable.Set(1)
+	} else {
+		metricACLSamplingControllerAvailable.Set(0)
+	}
+}
+
+func recordACLSamplingFailure(operation string) {
+	metricACLSamplingControllerAvailable.Set(0)
+	metricACLSamplingControllerFailures.WithLabelValues(operation).Inc()
+}
+
+func recordACLSamplingSuccess() {
+	metricACLSamplingControllerAvailable.Set(1)
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -714,6 +714,7 @@ func Run(ctx context.Context, config *Configuration) {
 	); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn sb client")
 	}
+	controller.reconcileACLSampling()
 	if config.EnableLb {
 		controller.routerLBRuleLister = routerLBRuleInformer.Lister()
 		controller.routerLBRuleSynced = routerLBRuleInformer.Informer().HasSynced

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -714,7 +714,11 @@ func Run(ctx context.Context, config *Configuration) {
 	); err != nil {
 		util.LogFatalAndExit(err, "failed to create ovn sb client")
 	}
-	controller.reconcileACLSampling()
+	if config.ACLSampling.Enabled {
+		controller.reconcileACLSampling()
+	} else {
+		go controller.runDisabledACLSamplingCleanup(ctx)
+	}
 	if config.EnableLb {
 		controller.routerLBRuleLister = routerLBRuleInformer.Lister()
 		controller.routerLBRuleSynced = routerLBRuleInformer.Informer().HasSynced
@@ -1429,11 +1433,9 @@ func (c *Controller) runDisabledACLSamplingCleanup(ctx context.Context) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
-		err := c.OVNNbClient.ReconcileACLSampling(c.config.ACLSampling)
-		if err == nil {
+		if c.reconcileACLSampling() {
 			return
 		}
-		klog.Warningf("failed to clean up disabled ACL sampling state: %v", err)
 		select {
 		case <-ctx.Done():
 			return
@@ -1444,9 +1446,6 @@ func (c *Controller) runDisabledACLSamplingCleanup(ctx context.Context) {
 
 func (c *Controller) startWorkers(ctx context.Context) {
 	klog.Info("Starting workers")
-	if !c.config.ACLSampling.Enabled {
-		go c.runDisabledACLSamplingCleanup(ctx)
-	}
 
 	go wait.Until(runWorker("add/update vpc", c.addOrUpdateVpcQueue, c.handleAddOrUpdateVpc), time.Second, ctx.Done())
 	go wait.Until(runWorker("delete vpc", c.delVpcQueue, c.handleDelVpc), time.Second, ctx.Done())

--- a/pkg/controller/net_metrics.go
+++ b/pkg/controller/net_metrics.go
@@ -71,6 +71,20 @@ var (
 			"pod_name",
 		},
 	)
+
+	metricACLSamplingControllerAvailable = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "acl_sampling_controller_available",
+			Help: "Whether the controller ACL sampling path is enabled and its latest operation succeeded.",
+		})
+
+	metricACLSamplingControllerFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "acl_sampling_controller_failures_total",
+			Help: "The number of best-effort controller ACL sampling failures by operation.",
+		},
+		[]string{"operation"},
+		)
 )
 
 func registerMetrics() {
@@ -79,4 +93,6 @@ func registerMetrics() {
 	metrics.Registry.MustRegister(metricCentralSubnetInfo)
 	metrics.Registry.MustRegister(metricSubnetIPAMInfo)
 	metrics.Registry.MustRegister(metricSubnetIPAssignedInfo)
+	metrics.Registry.MustRegister(metricACLSamplingControllerAvailable)
+	metrics.Registry.MustRegister(metricACLSamplingControllerFailures)
 }

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -567,6 +567,7 @@ func (c *Controller) prepareNetworkPolicyACLSampling(key, pgName string, np *net
 	request, err := c.OVNNbClient.PrepareNetworkPolicyACLSampling(pgName, np.Namespace, np.Name, string(np.UID))
 	if err != nil {
 		// Sampling is best-effort and must never block NetworkPolicy enforcement.
+		recordACLSamplingFailure(aclSamplingOperationPrepare)
 		klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
 		return nil
 	}
@@ -633,8 +634,10 @@ func (c *Controller) handleNetworkPolicyACLSampling(key string) error {
 		return nil
 	}
 	if err := c.OVNNbClient.ApplyNetworkPolicyACLSampling(c.config.ACLSampling, state.request); err != nil {
+		recordACLSamplingFailure(aclSamplingOperationAttach)
 		return err
 	}
+	recordACLSamplingSuccess()
 	c.npSamplingStates.Compute(key, func(current *networkPolicySamplingState, loaded bool) (*networkPolicySamplingState, xsync.ComputeOp) {
 		if loaded && current == state {
 			return nil, xsync.DeleteOp

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -568,7 +568,7 @@ func (c *Controller) prepareNetworkPolicyACLSampling(key, pgName string, np *net
 	if err != nil {
 		// Sampling is best-effort and must never block NetworkPolicy enforcement.
 		recordACLSamplingFailure(aclSamplingOperationPrepare)
-		klog.Warningf("failed to prepare ACL sampling for network policy %s: %v", key, err)
+		warnACLSamplingPrepareFailure(key, err)
 		return nil
 	}
 	state := &networkPolicySamplingState{request: request, policyUID: np.UID, portGroupName: pgName}

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -25,15 +26,19 @@ func TestHandleNetworkPolicyACLSamplingRetriesOnlySampling(t *testing.T) {
 	controller, nbClient, config := newNetworkPolicySamplingTestController(t)
 	request := new(ovs.NetworkPolicySamplingRequest)
 	controller.npSamplingStates.Store("default/test", &networkPolicySamplingState{request: request, ready: true})
+	failuresBefore := testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationAttach))
 
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(errors.New("injected sampling failure"))
 	require.ErrorContains(t, controller.handleNetworkPolicyACLSampling("default/test"), "injected sampling failure")
+	require.Equal(t, failuresBefore+1, testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationAttach)))
+	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 	actual, ok := controller.npSamplingStates.Load("default/test")
 	require.True(t, ok)
 	require.Same(t, request, actual.request)
 
 	nbClient.EXPECT().ApplyNetworkPolicyACLSampling(config, request).Return(nil)
 	require.NoError(t, controller.handleNetworkPolicyACLSampling("default/test"))
+	require.Equal(t, float64(1), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 	_, ok = controller.npSamplingStates.Load("default/test")
 	require.False(t, ok)
 }
@@ -208,4 +213,30 @@ func networkPolicySamplingTestPolicy() *netv1.NetworkPolicy {
 		Name:      "test",
 		UID:       types.UID("uid"),
 	}}
+}
+
+func TestReconcileACLSamplingRecordsAvailability(t *testing.T) {
+	mockController := gomock.NewController(t)
+	nbClient := mockovs.NewMockNbClient(mockController)
+	config := aclsampling.ControllerConfig{Enabled: true}
+	controller := &Controller{
+		config:      &Configuration{ACLSampling: config},
+		OVNNbClient: nbClient,
+	}
+
+	failuresBefore := testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationReconcile))
+	nbClient.EXPECT().ReconcileACLSampling(config).Return(errors.New("injected schema conflict"))
+	controller.reconcileACLSampling()
+	require.Equal(t, failuresBefore+1, testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationReconcile)))
+	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingControllerAvailable))
+
+	nbClient.EXPECT().ReconcileACLSampling(config).Return(nil)
+	controller.reconcileACLSampling()
+	require.Equal(t, float64(1), testutil.ToFloat64(metricACLSamplingControllerAvailable))
+
+	config.Enabled = false
+	controller.config.ACLSampling = config
+	nbClient.EXPECT().ReconcileACLSampling(config).Return(nil)
+	controller.reconcileACLSampling()
+	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 }

--- a/pkg/controller/network_policy_sampling_test.go
+++ b/pkg/controller/network_policy_sampling_test.go
@@ -174,6 +174,7 @@ func TestRunDisabledACLSamplingCleanupRetries(t *testing.T) {
 	controller, nbClient, config := newNetworkPolicySamplingTestController(t)
 	config.Enabled = false
 	controller.config.ACLSampling = config
+	failuresBefore := testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationReconcile))
 	nbClient.EXPECT().ReconcileACLSampling(config).Return(errors.New("injected cleanup failure"))
 	nbClient.EXPECT().ReconcileACLSampling(config).Return(nil)
 
@@ -190,6 +191,7 @@ func TestRunDisabledACLSamplingCleanupRetries(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for disabled ACL sampling cleanup retry")
 	}
+	require.Equal(t, failuresBefore+1, testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationReconcile)))
 }
 
 func newNetworkPolicySamplingTestController(t *testing.T) (*Controller, *mockovs.MockNbClient, aclsampling.ControllerConfig) {
@@ -226,17 +228,17 @@ func TestReconcileACLSamplingRecordsAvailability(t *testing.T) {
 
 	failuresBefore := testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationReconcile))
 	nbClient.EXPECT().ReconcileACLSampling(config).Return(errors.New("injected schema conflict"))
-	controller.reconcileACLSampling()
+	require.False(t, controller.reconcileACLSampling())
 	require.Equal(t, failuresBefore+1, testutil.ToFloat64(metricACLSamplingControllerFailures.WithLabelValues(aclSamplingOperationReconcile)))
 	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 
 	nbClient.EXPECT().ReconcileACLSampling(config).Return(nil)
-	controller.reconcileACLSampling()
+	require.True(t, controller.reconcileACLSampling())
 	require.Equal(t, float64(1), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 
 	config.Enabled = false
 	controller.config.ACLSampling = config
 	nbClient.EXPECT().ReconcileACLSampling(config).Return(nil)
-	controller.reconcileACLSampling()
+	require.True(t, controller.reconcileACLSampling())
 	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingControllerAvailable))
 }


### PR DESCRIPTION
Related to #7146.

## Summary

- reconcile or clean up ACL sampling objects at controller startup without failing controller startup
- expose `acl_sampling_controller_available` for latest path availability
- count `reconcile`, `prepare`, and `attach` failures with `acl_sampling_controller_failures_total`
- rate-limit repeated prepare warnings while retaining every failure metric
- restore availability after successful reconciliation or attachment retry

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. **#7166 — controller availability metrics**
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-cleanup`

## Validation

- `GOMAXPROCS=2 go test ./pkg/controller -count=1`
- targeted controller ACL sampling race tests
- `GOMAXPROCS=2 go vet ./pkg/ovs ./pkg/controller`
- diff-scoped `golangci-lint` with one worker: 0 issues
- `git diff --check`