### PR TITLE
feat: deliver ACL samples locally on nodes

### DIFF
--- a/pkg/daemon/acl_sampling.go
+++ b/pkg/daemon/acl_sampling.go
@@ -1,0 +1,17 @@
+package daemon
+
+import "k8s.io/klog/v2"
+
+func (c *Controller) reconcileACLSamplingCollectorSet() {
+	if err := c.vswitchClient.ReconcileACLSamplingCollectorSet(c.config.ACLSampling); err != nil {
+		metricACLSamplingNodeAvailable.WithLabelValues(c.config.NodeName).Set(0)
+		metricACLSamplingNodeFailures.WithLabelValues(c.config.NodeName).Inc()
+		klog.Warningf("ACL sampling is unavailable on node %s: %v", c.config.NodeName, err)
+		return
+	}
+	if c.config.ACLSampling.Enabled {
+		metricACLSamplingNodeAvailable.WithLabelValues(c.config.NodeName).Set(1)
+	} else {
+		metricACLSamplingNodeAvailable.WithLabelValues(c.config.NodeName).Set(0)
+	}
+}

--- a/pkg/daemon/acl_sampling_test.go
+++ b/pkg/daemon/acl_sampling_test.go
@@ -1,0 +1,56 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+)
+
+type fakeACLSamplingVswitch struct {
+	ovs.Vswitch
+	err     error
+	configs []aclsampling.NodeConfig
+}
+
+func (f *fakeACLSamplingVswitch) ReconcileACLSamplingCollectorSet(config aclsampling.NodeConfig) error {
+	f.configs = append(f.configs, config)
+	return f.err
+}
+
+func TestReconcileACLSamplingCollectorSetRecordsAvailability(t *testing.T) {
+	nodeName := "acl-sampling-node-success"
+	config := aclsampling.NodeConfig{Enabled: true, SetID: 142, LocalGroupID: 142}
+	client := &fakeACLSamplingVswitch{}
+	controller := &Controller{
+		config:        &Configuration{NodeName: nodeName, ACLSampling: config},
+		vswitchClient: client,
+	}
+
+	controller.reconcileACLSamplingCollectorSet()
+	require.Equal(t, []aclsampling.NodeConfig{config}, client.configs)
+	require.Equal(t, float64(1), testutil.ToFloat64(metricACLSamplingNodeAvailable.WithLabelValues(nodeName)))
+
+	controller.config.ACLSampling.Enabled = false
+	controller.reconcileACLSamplingCollectorSet()
+	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingNodeAvailable.WithLabelValues(nodeName)))
+}
+
+func TestReconcileACLSamplingCollectorSetRecordsFailure(t *testing.T) {
+	nodeName := "acl-sampling-node-failure"
+	config := aclsampling.NodeConfig{Enabled: true, SetID: 142, LocalGroupID: 142}
+	client := &fakeACLSamplingVswitch{err: errors.New("injected psample capability failure")}
+	controller := &Controller{
+		config:        &Configuration{NodeName: nodeName, ACLSampling: config},
+		vswitchClient: client,
+	}
+	failuresBefore := testutil.ToFloat64(metricACLSamplingNodeFailures.WithLabelValues(nodeName))
+
+	controller.reconcileACLSamplingCollectorSet()
+	require.Equal(t, failuresBefore+1, testutil.ToFloat64(metricACLSamplingNodeFailures.WithLabelValues(nodeName)))
+	require.Equal(t, float64(0), testutil.ToFloat64(metricACLSamplingNodeAvailable.WithLabelValues(nodeName)))
+}

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -1015,6 +1015,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	defer c.vswitchClient.Close()
 
 	go wait.Until(c.gcInterfaces, time.Minute, stopCh)
+	go wait.Until(c.reconcileACLSamplingCollectorSet, time.Minute, stopCh)
 	go wait.Until(recompute, 10*time.Minute, stopCh)
 	go wait.Until(rotateLog, 1*time.Hour, stopCh)
 

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -138,6 +138,22 @@ var (
 	}, []string{
 		"hostname",
 	})
+
+	metricACLSamplingNodeAvailable = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "acl_sampling_node_available",
+			Help: "Whether local ACL sampling delivery is available on the node.",
+		},
+		[]string{"node_name"},
+	)
+
+	metricACLSamplingNodeFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "acl_sampling_node_failures_total",
+			Help: "Total number of local ACL sampling reconciliation failures.",
+		},
+		[]string{"node_name"},
+	)
 )
 
 func InitMetrics() {
@@ -147,6 +163,8 @@ func InitMetrics() {
 	metrics.Registry.MustRegister(cniWaitAddressResult)
 	metrics.Registry.MustRegister(cniWaitRouteResult)
 	metrics.Registry.MustRegister(cniConnectivityResult)
+	metrics.Registry.MustRegister(metricACLSamplingNodeAvailable)
+	metrics.Registry.MustRegister(metricACLSamplingNodeFailures)
 }
 
 func registerOvnSubnetGatewayMetrics() {

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -21,6 +21,7 @@ type Vswitch interface {
 	ListBridge(needVendorFilter bool, filter func(sw *vswitch.Bridge) bool) ([]vswitch.Bridge, error)
 	ListPort(filter func(sp *vswitch.Port) bool) ([]vswitch.Port, error)
 	ListInterface(filter func(si *vswitch.Interface) bool) ([]vswitch.Interface, error)
+	ReconcileACLSamplingCollectorSet(config aclsampling.NodeConfig) error
 }
 
 type NBGlobal interface {

--- a/pkg/ovs/ovs-vswitch-acl-sampling.go
+++ b/pkg/ovs/ovs-vswitch-acl-sampling.go
@@ -1,0 +1,317 @@
+package ovs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/ovn-kubernetes/libovsdb/mapper"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/vswitch"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+var (
+	ErrACLSamplingNodeUnsupported = errors.New("local ACL sampling is unsupported")
+	ErrACLSamplingNodeConflict    = errors.New("local ACL sampling collector set conflicts with an unowned object")
+)
+
+const aclSamplingIntegrationBridge = "br-int"
+
+type aclSamplingCollectorSetOwnership struct {
+	UUID        string            `ovsdb:"_uuid"`
+	ExternalIDs map[string]string `ovsdb:"external_ids"`
+}
+
+// ReconcileACLSamplingCollectorSet idempotently configures local psample
+// delivery for the integration bridge. Capability checks and all OVSDB
+// changes stay best-effort and never affect the node networking setup.
+func (c *VswitchClient) ReconcileACLSamplingCollectorSet(config aclsampling.NodeConfig) error {
+	if !config.Enabled {
+		return c.cleanupACLSamplingCollectorSets()
+	}
+	if err := config.Validate(); err != nil {
+		return fmt.Errorf("invalid node ACL sampling configuration: %w", err)
+	}
+	if err := validateNodeACLSamplingSchema(c.Schema()); err != nil {
+		return err
+	}
+
+	bridge, collectorSets, err := c.readNodeACLSamplingState()
+	if err != nil {
+		return err
+	}
+
+	desiredExternalIDs := map[string]string{
+		ExternalIDVendor:             util.CniTypeName,
+		aclSamplingFeatureExternalID: aclSamplingFeature,
+	}
+	var desired *vswitch.FlowSampleCollectorSet
+	operations := make([]ovsdb.Operation, 0, len(collectorSets)+1)
+	for i := range collectorSets {
+		collectorSet := &collectorSets[i]
+		isDesiredKey := collectorSet.Bridge == bridge.UUID && collectorSet.ID == int(config.SetID)
+		if isDesiredKey && !isOwnedACLSamplingObject(collectorSet.ExternalIDs) {
+			return fmt.Errorf("%w: collector set ID %d on bridge %s", ErrACLSamplingNodeConflict, config.SetID, bridge.Name)
+		}
+		if !isOwnedACLSamplingObject(collectorSet.ExternalIDs) {
+			continue
+		}
+		if isDesiredKey {
+			desired = collectorSet
+			continue
+		}
+		operations = append(operations, deleteVswitchRowOperation(vswitch.FlowSampleCollectorSetTable, collectorSet.UUID))
+	}
+
+	localGroupID := int(config.LocalGroupID)
+	if desired == nil {
+		desired = &vswitch.FlowSampleCollectorSet{
+			Bridge:       bridge.UUID,
+			ExternalIDs:  desiredExternalIDs,
+			ID:           int(config.SetID),
+			LocalGroupID: &localGroupID,
+		}
+		row, err := newVswitchRow(c.Schema(), vswitch.FlowSampleCollectorSetTable, desired)
+		if err != nil {
+			return fmt.Errorf("build local ACL sampling collector set: %w", err)
+		}
+		operations = append(operations, ovsdb.Operation{
+			Op:    ovsdb.OperationInsert,
+			Table: vswitch.FlowSampleCollectorSetTable,
+			Row:   row,
+		})
+	} else if desired.IPFIX != nil || desired.LocalGroupID == nil || *desired.LocalGroupID != localGroupID ||
+		!maps.Equal(desired.ExternalIDs, desiredExternalIDs) {
+		desired.IPFIX = nil
+		desired.LocalGroupID = &localGroupID
+		desired.ExternalIDs = desiredExternalIDs
+		row, err := newVswitchRow(c.Schema(), vswitch.FlowSampleCollectorSetTable, desired,
+			&desired.IPFIX, &desired.LocalGroupID, &desired.ExternalIDs)
+		if err != nil {
+			return fmt.Errorf("build local ACL sampling collector set update: %w", err)
+		}
+		operations = append(operations, ovsdb.Operation{
+			Op:    ovsdb.OperationUpdate,
+			Table: vswitch.FlowSampleCollectorSetTable,
+			Where: uuidWhere(desired.UUID),
+			Row:   row,
+		})
+	}
+
+	if err := c.Transact("acl-sampling-node-reconcile", operations); err != nil {
+		return fmt.Errorf("reconcile local ACL sampling collector set: %w", err)
+	}
+	return nil
+}
+
+func validateNodeACLSamplingSchema(schema ovsdb.DatabaseSchema) error {
+	required := map[string][]string{
+		vswitch.BridgeTable:                 {"name", "datapath_type"},
+		vswitch.DatapathTable:               {"capabilities"},
+		vswitch.OpenvSwitchTable:            {"datapaths"},
+		vswitch.FlowSampleCollectorSetTable: {"bridge", "external_ids", "id", "ipfix", "local_group_id"},
+	}
+	for tableName, columns := range required {
+		table, ok := schema.Tables[tableName]
+		if !ok {
+			return fmt.Errorf("%w: table %s is missing", ErrACLSamplingNodeUnsupported, tableName)
+		}
+		for _, column := range columns {
+			if _, ok := table.Columns[column]; !ok {
+				return fmt.Errorf("%w: column %s.%s is missing", ErrACLSamplingNodeUnsupported, tableName, column)
+			}
+		}
+	}
+	return nil
+}
+
+func validateNodeACLSamplingCleanupSchema(schema ovsdb.DatabaseSchema) error {
+	table, ok := schema.Tables[vswitch.FlowSampleCollectorSetTable]
+	if !ok {
+		return fmt.Errorf("%w: table %s is missing", ErrACLSamplingNodeUnsupported, vswitch.FlowSampleCollectorSetTable)
+	}
+	if _, ok := table.Columns["external_ids"]; !ok {
+		return fmt.Errorf("%w: column %s.external_ids is missing", ErrACLSamplingNodeUnsupported, vswitch.FlowSampleCollectorSetTable)
+	}
+	return nil
+}
+
+func (c *VswitchClient) readNodeACLSamplingState() (*vswitch.Bridge, []vswitch.FlowSampleCollectorSet, error) {
+	operations := []ovsdb.Operation{
+		{
+			Op:      ovsdb.OperationSelect,
+			Table:   vswitch.BridgeTable,
+			Where:   []ovsdb.Condition{{Column: "name", Function: ovsdb.ConditionEqual, Value: aclSamplingIntegrationBridge}},
+			Columns: []string{"_uuid", "name", "datapath_type"},
+		},
+		{
+			Op:      ovsdb.OperationSelect,
+			Table:   vswitch.OpenvSwitchTable,
+			Where:   []ovsdb.Condition{},
+			Columns: []string{"_uuid", "datapaths"},
+		},
+		{
+			Op:      ovsdb.OperationSelect,
+			Table:   vswitch.DatapathTable,
+			Where:   []ovsdb.Condition{},
+			Columns: []string{"_uuid", "capabilities"},
+		},
+		{
+			Op:      ovsdb.OperationSelect,
+			Table:   vswitch.FlowSampleCollectorSetTable,
+			Where:   []ovsdb.Condition{},
+			Columns: []string{"_uuid", "bridge", "external_ids", "id", "ipfix", "local_group_id"},
+		},
+	}
+	results, err := c.transactVswitchOperations(operations)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read local ACL sampling state: %w", err)
+	}
+
+	bridges, err := decodeVswitchRows[vswitch.Bridge](c.Schema(), vswitch.BridgeTable, results[0].Rows)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(bridges) != 1 {
+		return nil, nil, fmt.Errorf("%w: expected one %s bridge, found %d", ErrACLSamplingNodeUnsupported, aclSamplingIntegrationBridge, len(bridges))
+	}
+	bridge := &bridges[0]
+	datapathType := bridge.DatapathType
+	if datapathType == "" {
+		datapathType = "system"
+	}
+	if datapathType != "system" {
+		return nil, nil, fmt.Errorf("%w: bridge %s uses datapath type %s", ErrACLSamplingNodeUnsupported, bridge.Name, datapathType)
+	}
+
+	openVSwitchRows, err := decodeVswitchRows[vswitch.OpenvSwitch](c.Schema(), vswitch.OpenvSwitchTable, results[1].Rows)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(openVSwitchRows) != 1 {
+		return nil, nil, fmt.Errorf("%w: expected one Open_vSwitch row, found %d", ErrACLSamplingNodeUnsupported, len(openVSwitchRows))
+	}
+	datapathUUID := openVSwitchRows[0].Datapaths[datapathType]
+	if datapathUUID == "" {
+		return nil, nil, fmt.Errorf("%w: datapath type %s is not active", ErrACLSamplingNodeUnsupported, datapathType)
+	}
+
+	datapaths, err := decodeVswitchRows[vswitch.Datapath](c.Schema(), vswitch.DatapathTable, results[2].Rows)
+	if err != nil {
+		return nil, nil, err
+	}
+	foundDatapath := false
+	for i := range datapaths {
+		if datapaths[i].UUID != datapathUUID {
+			continue
+		}
+		foundDatapath = true
+		if !strings.EqualFold(datapaths[i].Capabilities["psample"], "true") {
+			return nil, nil, fmt.Errorf("%w: datapath type %s does not report psample=true", ErrACLSamplingNodeUnsupported, datapathType)
+		}
+		break
+	}
+	if !foundDatapath {
+		return nil, nil, fmt.Errorf("%w: active datapath %s was not found", ErrACLSamplingNodeUnsupported, datapathUUID)
+	}
+
+	collectorSets, err := decodeVswitchRows[vswitch.FlowSampleCollectorSet](c.Schema(), vswitch.FlowSampleCollectorSetTable, results[3].Rows)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bridge, collectorSets, nil
+}
+
+func (c *VswitchClient) cleanupACLSamplingCollectorSets() error {
+	if err := validateNodeACLSamplingCleanupSchema(c.Schema()); err != nil {
+		if errors.Is(err, ErrACLSamplingNodeUnsupported) {
+			return nil
+		}
+		return err
+	}
+	operations := []ovsdb.Operation{{
+		Op:      ovsdb.OperationSelect,
+		Table:   vswitch.FlowSampleCollectorSetTable,
+		Where:   []ovsdb.Condition{},
+		Columns: []string{"_uuid", "external_ids"},
+	}}
+	results, err := c.transactVswitchOperations(operations)
+	if err != nil {
+		return fmt.Errorf("list local ACL sampling collector sets for cleanup: %w", err)
+	}
+	collectorSets, err := decodeVswitchRows[aclSamplingCollectorSetOwnership](c.Schema(), vswitch.FlowSampleCollectorSetTable, results[0].Rows)
+	if err != nil {
+		return err
+	}
+	deleteOperations := make([]ovsdb.Operation, 0, len(collectorSets))
+	for i := range collectorSets {
+		if isOwnedACLSamplingObject(collectorSets[i].ExternalIDs) {
+			deleteOperations = append(deleteOperations,
+				deleteVswitchRowOperation(vswitch.FlowSampleCollectorSetTable, collectorSets[i].UUID))
+		}
+	}
+	if err := c.Transact("acl-sampling-node-cleanup", deleteOperations); err != nil {
+		return fmt.Errorf("clean up local ACL sampling collector sets: %w", err)
+	}
+	return nil
+}
+
+func (c *VswitchClient) transactVswitchOperations(operations []ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	results, err := c.Client.Transact(ctx, operations...)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := ovsdb.CheckOperationResults(results, operations); err != nil {
+		return nil, err
+	}
+	if len(results) != len(operations) {
+		return nil, fmt.Errorf("expected %d OVSDB operation results, got %d", len(operations), len(results))
+	}
+	return results, nil
+}
+
+func decodeVswitchRows[T any](schema ovsdb.DatabaseSchema, tableName string, rows []ovsdb.Row) ([]T, error) {
+	table := schema.Table(tableName)
+	if table == nil {
+		return nil, fmt.Errorf("OVSDB table %s is missing", tableName)
+	}
+	ovsMapper := mapper.NewMapper(schema)
+	result := make([]T, len(rows))
+	for i := range rows {
+		info, err := mapper.NewInfo(tableName, table, &result[i])
+		if err != nil {
+			return nil, fmt.Errorf("build OVSDB mapper for table %s: %w", tableName, err)
+		}
+		if err := ovsMapper.GetRowDataWithUUID(&rows[i], info); err != nil {
+			return nil, fmt.Errorf("decode OVSDB row from table %s: %w", tableName, err)
+		}
+	}
+	return result, nil
+}
+
+func newVswitchRow(schema ovsdb.DatabaseSchema, tableName string, value any, fields ...any) (ovsdb.Row, error) {
+	table := schema.Table(tableName)
+	if table == nil {
+		return nil, fmt.Errorf("OVSDB table %s is missing", tableName)
+	}
+	info, err := mapper.NewInfo(tableName, table, value)
+	if err != nil {
+		return nil, err
+	}
+	return mapper.NewMapper(schema).NewRow(info, fields...)
+}
+
+func uuidWhere(uuid string) []ovsdb.Condition {
+	return []ovsdb.Condition{{Column: "_uuid", Function: ovsdb.ConditionEqual, Value: ovsdb.UUID{GoUUID: uuid}}}
+}
+
+func deleteVswitchRowOperation(tableName, uuid string) ovsdb.Operation {
+	return ovsdb.Operation{Op: ovsdb.OperationDelete, Table: tableName, Where: uuidWhere(uuid)}
+}

--- a/pkg/ovs/ovs-vswitch-acl-sampling_test.go
+++ b/pkg/ovs/ovs-vswitch-acl-sampling_test.go
@@ -1,0 +1,218 @@
+package ovs
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ovn-kubernetes/libovsdb/model"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/vswitch"
+)
+
+func TestReconcileACLSamplingCollectorSetLifecycle(t *testing.T) {
+	client := newACLSamplingVswitchTestClient(t, "", map[string]string{"psample": "true"})
+	config := aclsampling.NodeConfig{Enabled: true, SetID: 142, LocalGroupID: 142}
+
+	require.NoError(t, client.ReconcileACLSamplingCollectorSet(config))
+	collectorSets := listACLSamplingCollectorSets(t, client)
+	require.Len(t, collectorSets, 1)
+	require.Equal(t, 142, collectorSets[0].ID)
+	require.Equal(t, 142, *collectorSets[0].LocalGroupID)
+	require.Nil(t, collectorSets[0].IPFIX)
+	require.True(t, isOwnedACLSamplingObject(collectorSets[0].ExternalIDs))
+
+	require.NoError(t, client.ReconcileACLSamplingCollectorSet(config))
+	require.Len(t, listACLSamplingCollectorSets(t, client), 1)
+	collectorSets = listACLSamplingCollectorSets(t, client)
+	attachIPFIXToACLSamplingCollectorSet(t, client, &collectorSets[0])
+	require.NoError(t, client.ReconcileACLSamplingCollectorSet(config))
+	collectorSets = listACLSamplingCollectorSets(t, client)
+	require.Nil(t, collectorSets[0].IPFIX)
+
+	config.LocalGroupID = 143
+	require.NoError(t, client.ReconcileACLSamplingCollectorSet(config))
+	collectorSets = listACLSamplingCollectorSets(t, client)
+	require.Len(t, collectorSets, 1)
+	require.Equal(t, 143, *collectorSets[0].LocalGroupID)
+
+	config.SetID = 144
+	require.NoError(t, client.ReconcileACLSamplingCollectorSet(config))
+	collectorSets = listACLSamplingCollectorSets(t, client)
+	require.Len(t, collectorSets, 1)
+	require.Equal(t, 144, collectorSets[0].ID)
+
+	config.Enabled = false
+	require.NoError(t, client.ReconcileACLSamplingCollectorSet(config))
+	require.Empty(t, listACLSamplingCollectorSets(t, client))
+}
+
+func TestReconcileACLSamplingCollectorSetPreservesUnownedConflict(t *testing.T) {
+	client := newACLSamplingVswitchTestClient(t, "system", map[string]string{"psample": "true"})
+	bridge := getACLSamplingIntegrationBridge(t, client)
+	localGroupID := 777
+	seedACLSamplingCollectorSet(t, client, &vswitch.FlowSampleCollectorSet{
+		Bridge:       bridge.UUID,
+		ExternalIDs:  map[string]string{ExternalIDVendor: "another-application"},
+		ID:           142,
+		LocalGroupID: &localGroupID,
+	})
+
+	config := aclsampling.NodeConfig{Enabled: true, SetID: 142, LocalGroupID: 142}
+	err := client.ReconcileACLSamplingCollectorSet(config)
+	require.ErrorIs(t, err, ErrACLSamplingNodeConflict)
+	collectorSets := listACLSamplingCollectorSets(t, client)
+	require.Len(t, collectorSets, 1)
+	require.Equal(t, 777, *collectorSets[0].LocalGroupID)
+	require.Equal(t, "another-application", collectorSets[0].ExternalIDs[ExternalIDVendor])
+
+	config.Enabled = false
+	require.NoError(t, client.ReconcileACLSamplingCollectorSet(config))
+	require.Len(t, listACLSamplingCollectorSets(t, client), 1)
+}
+
+func TestReconcileACLSamplingCollectorSetRejectsUnsupportedNode(t *testing.T) {
+	tests := []struct {
+		name         string
+		datapathType string
+		capabilities map[string]string
+	}{
+		{
+			name:         "userspace datapath",
+			datapathType: "netdev",
+			capabilities: map[string]string{"psample": "true"},
+		},
+		{
+			name:         "missing psample capability",
+			datapathType: "system",
+			capabilities: map[string]string{},
+		},
+		{
+			name:         "disabled psample capability",
+			datapathType: "system",
+			capabilities: map[string]string{"psample": "false"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newACLSamplingVswitchTestClient(t, test.datapathType, test.capabilities)
+			err := client.ReconcileACLSamplingCollectorSet(aclsampling.NodeConfig{
+				Enabled: true, SetID: 142, LocalGroupID: 142,
+			})
+			require.ErrorIs(t, err, ErrACLSamplingNodeUnsupported)
+			require.Empty(t, listACLSamplingCollectorSets(t, client))
+		})
+	}
+}
+
+func TestReconcileACLSamplingCollectorSetHandlesLegacySchema(t *testing.T) {
+	schema := vswitch.Schema()
+	delete(schema.Tables[vswitch.FlowSampleCollectorSetTable].Columns, "local_group_id")
+	require.ErrorIs(t, validateNodeACLSamplingSchema(schema), ErrACLSamplingNodeUnsupported)
+
+	delete(schema.Tables, vswitch.FlowSampleCollectorSetTable)
+	dbModel, err := model.NewClientDBModel(vswitch.DatabaseName, map[string]model.Model{
+		vswitch.BridgeTable:      &vswitch.Bridge{},
+		vswitch.InterfaceTable:   &vswitch.Interface{},
+		vswitch.OpenvSwitchTable: &vswitch.OpenvSwitch{},
+		vswitch.PortTable:        &vswitch.Port{},
+	})
+	require.NoError(t, err)
+	_, socket := newOVSDBServer(t, fmt.Sprintf("acl-sampling-legacy-%d", time.Now().UnixNano()), dbModel, schema)
+	client, err := NewVswitchClient("unix:"+socket, 1, 1)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	require.NoError(t, client.ReconcileACLSamplingCollectorSet(aclsampling.NodeConfig{}))
+}
+
+func newACLSamplingVswitchTestClient(t *testing.T, datapathType string, capabilities map[string]string) *VswitchClient {
+	t.Helper()
+	dbModel, err := vswitch.FullDatabaseModel()
+	require.NoError(t, err)
+	_, socket := newOVSDBServer(t, fmt.Sprintf("acl-sampling-vswitch-%d", time.Now().UnixNano()), dbModel, vswitch.Schema())
+	client, err := NewVswitchClient("unix:"+socket, 1, 1)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	activeDatapathType := datapathType
+	if activeDatapathType == "" {
+		activeDatapathType = "system"
+	}
+	datapath := &vswitch.Datapath{Capabilities: capabilities}
+	bridge := &vswitch.Bridge{Name: aclSamplingIntegrationBridge, DatapathType: datapathType}
+	openVSwitch := &vswitch.OpenvSwitch{
+		Bridges:   []string{"acl-sampling-bridge"},
+		Datapaths: map[string]string{activeDatapathType: "acl-sampling-datapath"},
+	}
+	datapathRow, err := newVswitchRow(client.Schema(), vswitch.DatapathTable, datapath)
+	require.NoError(t, err)
+	bridgeRow, err := newVswitchRow(client.Schema(), vswitch.BridgeTable, bridge)
+	require.NoError(t, err)
+	openVSwitchRow, err := newVswitchRow(client.Schema(), vswitch.OpenvSwitchTable, openVSwitch)
+	require.NoError(t, err)
+	require.NoError(t, client.Transact("seed-acl-sampling-vswitch", []ovsdb.Operation{
+		{Op: ovsdb.OperationInsert, Table: vswitch.DatapathTable, Row: datapathRow, UUIDName: "acl-sampling-datapath"},
+		{Op: ovsdb.OperationInsert, Table: vswitch.BridgeTable, Row: bridgeRow, UUIDName: "acl-sampling-bridge"},
+		{Op: ovsdb.OperationInsert, Table: vswitch.OpenvSwitchTable, Row: openVSwitchRow},
+	}))
+	return client
+}
+
+func getACLSamplingIntegrationBridge(t *testing.T, client *VswitchClient) vswitch.Bridge {
+	t.Helper()
+	operations := []ovsdb.Operation{{
+		Op:      ovsdb.OperationSelect,
+		Table:   vswitch.BridgeTable,
+		Where:   []ovsdb.Condition{{Column: "name", Function: ovsdb.ConditionEqual, Value: aclSamplingIntegrationBridge}},
+		Columns: []string{"_uuid", "name", "datapath_type"},
+	}}
+	results, err := client.transactVswitchOperations(operations)
+	require.NoError(t, err)
+	bridges, err := decodeVswitchRows[vswitch.Bridge](client.Schema(), vswitch.BridgeTable, results[0].Rows)
+	require.NoError(t, err)
+	require.Len(t, bridges, 1)
+	return bridges[0]
+}
+
+func seedACLSamplingCollectorSet(t *testing.T, client *VswitchClient, collectorSet *vswitch.FlowSampleCollectorSet) {
+	t.Helper()
+	row, err := newVswitchRow(client.Schema(), vswitch.FlowSampleCollectorSetTable, collectorSet)
+	require.NoError(t, err)
+	require.NoError(t, client.Transact("seed-acl-sampling-collector-set", []ovsdb.Operation{{
+		Op: ovsdb.OperationInsert, Table: vswitch.FlowSampleCollectorSetTable, Row: row,
+	}}))
+}
+
+func attachIPFIXToACLSamplingCollectorSet(t *testing.T, client *VswitchClient, collectorSet *vswitch.FlowSampleCollectorSet) {
+	t.Helper()
+	ipfix := &vswitch.IPFIX{Targets: []string{"127.0.0.1:4739"}}
+	ipfixRow, err := newVswitchRow(client.Schema(), vswitch.IPFIXTable, ipfix)
+	require.NoError(t, err)
+	ipfixUUID := "acl-sampling-ipfix"
+	collectorSet.IPFIX = &ipfixUUID
+	collectorSetRow, err := newVswitchRow(client.Schema(), vswitch.FlowSampleCollectorSetTable, collectorSet, &collectorSet.IPFIX)
+	require.NoError(t, err)
+	require.NoError(t, client.Transact("attach-ipfix-to-acl-sampling-collector-set", []ovsdb.Operation{
+		{Op: ovsdb.OperationInsert, Table: vswitch.IPFIXTable, Row: ipfixRow, UUIDName: ipfixUUID},
+		{Op: ovsdb.OperationUpdate, Table: vswitch.FlowSampleCollectorSetTable, Where: uuidWhere(collectorSet.UUID), Row: collectorSetRow},
+	}))
+}
+
+func listACLSamplingCollectorSets(t *testing.T, client *VswitchClient) []vswitch.FlowSampleCollectorSet {
+	t.Helper()
+	operations := []ovsdb.Operation{{
+		Op:      ovsdb.OperationSelect,
+		Table:   vswitch.FlowSampleCollectorSetTable,
+		Where:   []ovsdb.Condition{},
+		Columns: []string{"_uuid", "bridge", "external_ids", "id", "ipfix", "local_group_id"},
+	}}
+	results, err := client.transactVswitchOperations(operations)
+	require.NoError(t, err)
+	collectorSets, err := decodeVswitchRows[vswitch.FlowSampleCollectorSet](client.Schema(), vswitch.FlowSampleCollectorSetTable, results[0].Rows)
+	require.NoError(t, err)
+	return collectorSets
+}


### PR DESCRIPTION
Related to #7146.

## Summary

- reconcile an owned `Flow_Sample_Collector_Set` for `br-int` and remove only owned rows when disabled
- reject unowned collector-set ID collisions without adopting or modifying external rows
- require `local_group_id`, Linux `system` datapath, and runtime `psample=true` capability
- resolve capability through `Open_vSwitch.datapaths` and referenced `Datapath.capabilities`
- use raw transactions so the regular Vswitch client remains compatible with older schemas
- clear IPFIX so the initial path remains local-delivery-only
- retry independently every minute and expose node availability/failure metrics

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. **#7167 — node-local psample delivery**
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-metrics`

## Validation

- `go test -p 1 ./pkg/ovs ./pkg/daemon -count=1`
- targeted ACL sampling race tests for `pkg/ovs` and `pkg/daemon`
- `go vet ./pkg/ovs ./pkg/daemon`
- diff-scoped `golangci-lint` with one worker: 0 issues
- `git diff --check`