### PR TITLE
feat: decode NetworkPolicy ACL samples

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -136,6 +136,20 @@ func (mr *MockVswitchMockRecorder) ListPort(filter any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPort", reflect.TypeOf((*MockVswitch)(nil).ListPort), filter)
 }
 
+// ReconcileACLSamplingCollectorSet mocks base method.
+func (m *MockVswitch) ReconcileACLSamplingCollectorSet(config aclsampling.NodeConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileACLSamplingCollectorSet", config)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileACLSamplingCollectorSet indicates an expected call of ReconcileACLSamplingCollectorSet.
+func (mr *MockVswitchMockRecorder) ReconcileACLSamplingCollectorSet(config any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileACLSamplingCollectorSet", reflect.TypeOf((*MockVswitch)(nil).ReconcileACLSamplingCollectorSet), config)
+}
+
 // Transact mocks base method.
 func (m *MockVswitch) Transact(method string, operations []ovsdb.Operation) error {
 	m.ctrl.T.Helper()
@@ -2540,6 +2554,21 @@ func (m *MockACLSampling) ReconcileACLSampling(config aclsampling.ControllerConf
 func (mr *MockACLSamplingMockRecorder) ReconcileACLSampling(config any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileACLSampling", reflect.TypeOf((*MockACLSampling)(nil).ReconcileACLSampling), config)
+}
+
+// ResolveNetworkPolicyACLSample mocks base method.
+func (m *MockACLSampling) ResolveNetworkPolicyACLSample(reference aclsampling.SampleReference) (*aclsampling.Event, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveNetworkPolicyACLSample", reference)
+	ret0, _ := ret[0].(*aclsampling.Event)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveNetworkPolicyACLSample indicates an expected call of ResolveNetworkPolicyACLSample.
+func (mr *MockACLSamplingMockRecorder) ResolveNetworkPolicyACLSample(reference any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNetworkPolicyACLSample", reflect.TypeOf((*MockACLSampling)(nil).ResolveNetworkPolicyACLSample), reference)
 }
 
 // MockAddressSet is a mock of AddressSet interface.
@@ -5612,6 +5641,21 @@ func (m *MockNbClient) ResetLogicalSwitchPortMigrateOptions(lspName, srcNodeName
 func (mr *MockNbClientMockRecorder) ResetLogicalSwitchPortMigrateOptions(lspName, srcNodeName, targetNodeName, migratedFail any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetLogicalSwitchPortMigrateOptions", reflect.TypeOf((*MockNbClient)(nil).ResetLogicalSwitchPortMigrateOptions), lspName, srcNodeName, targetNodeName, migratedFail)
+}
+
+// ResolveNetworkPolicyACLSample mocks base method.
+func (m *MockNbClient) ResolveNetworkPolicyACLSample(reference aclsampling.SampleReference) (*aclsampling.Event, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveNetworkPolicyACLSample", reference)
+	ret0, _ := ret[0].(*aclsampling.Event)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveNetworkPolicyACLSample indicates an expected call of ResolveNetworkPolicyACLSample.
+func (mr *MockNbClientMockRecorder) ResolveNetworkPolicyACLSample(reference any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNetworkPolicyACLSample", reflect.TypeOf((*MockNbClient)(nil).ResolveNetworkPolicyACLSample), reference)
 }
 
 // SGLostACL mocks base method.

--- a/pkg/aclsampling/event.go
+++ b/pkg/aclsampling/event.go
@@ -9,55 +9,75 @@ import (
 )
 
 const (
-	ApplicationACLNew = "acl-new"
-	ApplicationACLEst = "acl-est"
+	ApplicationACLNew Application = "acl-new"
+	ApplicationACLEst Application = "acl-est"
 
-	VerdictAllow       = "allow"
-	VerdictDefaultDeny = "default-deny"
+	VerdictAllow       Verdict = "allow"
+	VerdictDefaultDeny Verdict = "default-deny"
 
-	ReasonNetworkPolicyDefaultDeny = "network-policy-default-deny"
-	AttributionNonExclusive        = "non-exclusive"
+	ReasonNetworkPolicyDefaultDeny Reason      = "network-policy-default-deny"
+	AttributionNonExclusive        Attribution = "non-exclusive"
 )
 
-// SampleReference identifies the OVN observation attached to a local psample
-// event. ApplicationID is nil when the input contains metadata only.
-type SampleReference struct {
+// Application identifies the OVN sampling application that produced an
+// observation.
+type Application string
+
+// Verdict identifies the NetworkPolicy decision represented by an event.
+type Verdict string
+
+// Reason identifies why a sampled decision was produced.
+type Reason string
+
+// Attribution describes whether a policy reference uniquely caused a
+// sampled decision.
+type Attribution string
+
+// OVNACLDirection identifies where an OVN ACL is evaluated.
+type OVNACLDirection string
+
+// SampleObservation contains the values encoded in ACL sample metadata or a
+// local-sampling cookie.
+type SampleObservation struct {
 	ObservationDomain *uint32 `json:"observationDomain,omitempty" yaml:"observationDomain,omitempty"`
 	ApplicationID     *uint32 `json:"applicationID,omitempty" yaml:"applicationID,omitempty"`
 	DatapathKey       *uint32 `json:"datapathKey,omitempty" yaml:"datapathKey,omitempty"`
 	Metadata          uint32  `json:"metadata" yaml:"metadata"`
+}
+
+// SampleReference identifies the OVN observation attached to a local psample
+// event. ApplicationID is nil when the input contains metadata only.
+type SampleReference struct {
+	SampleObservation `yaml:",inline"`
 }
 
 // PolicyReference identifies the Kubernetes NetworkPolicy data stored on an
 // eligible ACL.
 type PolicyReference struct {
-	APIVersion string `json:"apiVersion" yaml:"apiVersion"`
-	Kind       string `json:"kind" yaml:"kind"`
-	Namespace  string `json:"namespace" yaml:"namespace"`
-	Name       string `json:"name" yaml:"name"`
-	UID        string `json:"uid" yaml:"uid"`
-	Direction  string `json:"direction" yaml:"direction"`
-	RuleIndex  *int   `json:"ruleIndex,omitempty" yaml:"ruleIndex,omitempty"`
+	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string          `json:"kind" yaml:"kind"`
+	Namespace  string          `json:"namespace" yaml:"namespace"`
+	Name       string          `json:"name" yaml:"name"`
+	UID        string          `json:"uid" yaml:"uid"`
+	Direction  PolicyDirection `json:"direction" yaml:"direction"`
+	RuleIndex  *int            `json:"ruleIndex,omitempty" yaml:"ruleIndex,omitempty"`
 }
 
 // OVNACLReference describes the OVN ACL that owns a sample reference.
 type OVNACLReference struct {
-	UUID      string `json:"aclUUID" yaml:"aclUUID"`
-	Name      string `json:"aclName,omitempty" yaml:"aclName,omitempty"`
-	Action    string `json:"action" yaml:"action"`
-	Priority  int    `json:"priority" yaml:"priority"`
-	Tier      int    `json:"tier" yaml:"tier"`
-	Direction string `json:"direction" yaml:"direction"`
-	MatchHash string `json:"matchHash" yaml:"matchHash"`
+	UUID      string          `json:"aclUUID" yaml:"aclUUID"`
+	Name      string          `json:"aclName,omitempty" yaml:"aclName,omitempty"`
+	Action    OVNAction       `json:"action" yaml:"action"`
+	Priority  int             `json:"priority" yaml:"priority"`
+	Tier      int             `json:"tier" yaml:"tier"`
+	Direction OVNACLDirection `json:"direction" yaml:"direction"`
+	MatchHash string          `json:"matchHash" yaml:"matchHash"`
 }
 
 // SampleDetails describes how OVN encoded a resolved sample.
 type SampleDetails struct {
-	App               string  `json:"app,omitempty" yaml:"app,omitempty"`
-	ObservationDomain *uint32 `json:"observationDomain,omitempty" yaml:"observationDomain,omitempty"`
-	ApplicationID     *uint32 `json:"applicationID,omitempty" yaml:"applicationID,omitempty"`
-	DatapathKey       *uint32 `json:"datapathKey,omitempty" yaml:"datapathKey,omitempty"`
-	Metadata          uint32  `json:"metadata" yaml:"metadata"`
+	App               Application `json:"app,omitempty" yaml:"app,omitempty"`
+	SampleObservation `yaml:",inline"`
 }
 
 // Event is the stable debug representation of a sampled NetworkPolicy ACL
@@ -66,9 +86,9 @@ type SampleDetails struct {
 type Event struct {
 	SchemaVersion string           `json:"schemaVersion" yaml:"schemaVersion"`
 	Feature       string           `json:"feature" yaml:"feature"`
-	Verdict       string           `json:"verdict" yaml:"verdict"`
-	Reason        string           `json:"reason,omitempty" yaml:"reason,omitempty"`
-	Attribution   string           `json:"attribution,omitempty" yaml:"attribution,omitempty"`
+	Verdict       Verdict          `json:"verdict" yaml:"verdict"`
+	Reason        Reason           `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Attribution   Attribution      `json:"attribution,omitempty" yaml:"attribution,omitempty"`
 	Policy        *PolicyReference `json:"policy,omitempty" yaml:"policy,omitempty"`
 	PolicyOwner   *PolicyReference `json:"policyOwner,omitempty" yaml:"policyOwner,omitempty"`
 	OVN           OVNACLReference  `json:"ovn" yaml:"ovn"`
@@ -106,7 +126,7 @@ func ParseSampleReference(value string) (SampleReference, error) {
 		return SampleReference{}, errors.New("ACL sample metadata must be greater than zero")
 	}
 	if raw <= math.MaxUint32 {
-		return SampleReference{Metadata: uint32(raw)}, nil
+		return SampleReference{SampleObservation: SampleObservation{Metadata: uint32(raw)}}, nil
 	}
 
 	observationDomain := uint32(raw >> 32)
@@ -120,10 +140,12 @@ func ParseSampleReference(value string) (SampleReference, error) {
 		return SampleReference{}, errors.New("ACL sample cookie metadata must be greater than zero")
 	}
 	return SampleReference{
-		ObservationDomain: &observationDomain,
-		ApplicationID:     &applicationID,
-		DatapathKey:       &datapathKey,
-		Metadata:          metadata,
+		SampleObservation: SampleObservation{
+			ObservationDomain: &observationDomain,
+			ApplicationID:     &applicationID,
+			DatapathKey:       &datapathKey,
+			Metadata:          metadata,
+		},
 	}, nil
 }
 

--- a/pkg/aclsampling/event.go
+++ b/pkg/aclsampling/event.go
@@ -1,0 +1,151 @@
+package aclsampling
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const (
+	ApplicationACLNew = "acl-new"
+	ApplicationACLEst = "acl-est"
+
+	VerdictAllow       = "allow"
+	VerdictDefaultDeny = "default-deny"
+
+	ReasonNetworkPolicyDefaultDeny = "network-policy-default-deny"
+	AttributionNonExclusive        = "non-exclusive"
+)
+
+// SampleReference identifies the OVN observation attached to a local psample
+// event. ApplicationID is nil when the input contains metadata only.
+type SampleReference struct {
+	ObservationDomain *uint32 `json:"observationDomain,omitempty" yaml:"observationDomain,omitempty"`
+	ApplicationID     *uint32 `json:"applicationID,omitempty" yaml:"applicationID,omitempty"`
+	DatapathKey       *uint32 `json:"datapathKey,omitempty" yaml:"datapathKey,omitempty"`
+	Metadata          uint32  `json:"metadata" yaml:"metadata"`
+}
+
+// PolicyReference identifies the Kubernetes NetworkPolicy data stored on an
+// eligible ACL.
+type PolicyReference struct {
+	APIVersion string `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string `json:"kind" yaml:"kind"`
+	Namespace  string `json:"namespace" yaml:"namespace"`
+	Name       string `json:"name" yaml:"name"`
+	UID        string `json:"uid" yaml:"uid"`
+	Direction  string `json:"direction" yaml:"direction"`
+	RuleIndex  *int   `json:"ruleIndex,omitempty" yaml:"ruleIndex,omitempty"`
+}
+
+// OVNACLReference describes the OVN ACL that owns a sample reference.
+type OVNACLReference struct {
+	UUID      string `json:"aclUUID" yaml:"aclUUID"`
+	Name      string `json:"aclName,omitempty" yaml:"aclName,omitempty"`
+	Action    string `json:"action" yaml:"action"`
+	Priority  int    `json:"priority" yaml:"priority"`
+	Tier      int    `json:"tier" yaml:"tier"`
+	Direction string `json:"direction" yaml:"direction"`
+	MatchHash string `json:"matchHash" yaml:"matchHash"`
+}
+
+// SampleDetails describes how OVN encoded a resolved sample.
+type SampleDetails struct {
+	App               string  `json:"app,omitempty" yaml:"app,omitempty"`
+	ObservationDomain *uint32 `json:"observationDomain,omitempty" yaml:"observationDomain,omitempty"`
+	ApplicationID     *uint32 `json:"applicationID,omitempty" yaml:"applicationID,omitempty"`
+	DatapathKey       *uint32 `json:"datapathKey,omitempty" yaml:"datapathKey,omitempty"`
+	Metadata          uint32  `json:"metadata" yaml:"metadata"`
+}
+
+// Event is the stable debug representation of a sampled NetworkPolicy ACL
+// decision. Allow events populate Policy; default-deny events populate
+// PolicyOwner to avoid claiming exclusive policy attribution.
+type Event struct {
+	SchemaVersion string           `json:"schemaVersion" yaml:"schemaVersion"`
+	Feature       string           `json:"feature" yaml:"feature"`
+	Verdict       string           `json:"verdict" yaml:"verdict"`
+	Reason        string           `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Attribution   string           `json:"attribution,omitempty" yaml:"attribution,omitempty"`
+	Policy        *PolicyReference `json:"policy,omitempty" yaml:"policy,omitempty"`
+	PolicyOwner   *PolicyReference `json:"policyOwner,omitempty" yaml:"policyOwner,omitempty"`
+	OVN           OVNACLReference  `json:"ovn" yaml:"ovn"`
+	Sample        SampleDetails    `json:"sample" yaml:"sample"`
+}
+
+// ParseSampleReference accepts a decimal or 0x-prefixed hexadecimal metadata
+// value or local-sampling cookie. A cookie stores the observation domain in
+// the high 32 bits and the ACL metadata in the low 32 bits. OVN puts the
+// application ID in the domain's high byte and the datapath key in its low 24
+// bits.
+func ParseSampleReference(value string) (SampleReference, error) {
+	if value == "" {
+		return SampleReference{}, errors.New("ACL sample cookie or metadata must not be empty")
+	}
+	if strings.TrimSpace(value) != value || strings.HasPrefix(value, "+") || strings.HasPrefix(value, "-") {
+		return SampleReference{}, fmt.Errorf("invalid ACL sample cookie or metadata %q", value)
+	}
+
+	base := 10
+	digits := value
+	if strings.HasPrefix(value, "0x") || strings.HasPrefix(value, "0X") {
+		base = 16
+		digits = value[2:]
+	}
+	if digits == "" {
+		return SampleReference{}, fmt.Errorf("invalid ACL sample cookie or metadata %q", value)
+	}
+
+	raw, err := strconv.ParseUint(digits, base, 64)
+	if err != nil {
+		return SampleReference{}, fmt.Errorf("invalid ACL sample cookie or metadata %q: %w", value, err)
+	}
+	if raw == 0 {
+		return SampleReference{}, errors.New("ACL sample metadata must be greater than zero")
+	}
+	if raw <= math.MaxUint32 {
+		return SampleReference{Metadata: uint32(raw)}, nil
+	}
+
+	observationDomain := uint32(raw >> 32)
+	applicationID := observationDomain >> 24
+	datapathKey := observationDomain & 0x00ffffff
+	metadata := uint32(raw) // #nosec G115 -- OVN encodes metadata in the cookie's low 32 bits.
+	if applicationID == 0 || applicationID > maxOVNObjectID {
+		return SampleReference{}, fmt.Errorf("ACL sample application ID %d must be in the range 1-255", applicationID)
+	}
+	if metadata == 0 {
+		return SampleReference{}, errors.New("ACL sample cookie metadata must be greater than zero")
+	}
+	return SampleReference{
+		ObservationDomain: &observationDomain,
+		ApplicationID:     &applicationID,
+		DatapathKey:       &datapathKey,
+		Metadata:          metadata,
+	}, nil
+}
+
+// Validate checks whether a programmatically constructed sample reference can
+// be resolved through the OVN northbound sampling schema.
+func (r SampleReference) Validate() error {
+	if r.Metadata == 0 {
+		return errors.New("ACL sample metadata must be greater than zero")
+	}
+	if r.ApplicationID != nil && (*r.ApplicationID == 0 || *r.ApplicationID > maxOVNObjectID) {
+		return fmt.Errorf("ACL sample application ID %d must be in the range 1-255", *r.ApplicationID)
+	}
+	if (r.ObservationDomain == nil) != (r.ApplicationID == nil) || (r.DatapathKey == nil) != (r.ApplicationID == nil) {
+		return errors.New("ACL sample observation domain, application ID, and datapath key must be provided together")
+	}
+	if r.ObservationDomain != nil {
+		if *r.ApplicationID != *r.ObservationDomain>>24 {
+			return errors.New("ACL sample application ID does not match the observation domain")
+		}
+		if *r.DatapathKey != *r.ObservationDomain&0x00ffffff {
+			return errors.New("ACL sample datapath key does not match the observation domain")
+		}
+	}
+	return nil
+}

--- a/pkg/aclsampling/event_test.go
+++ b/pkg/aclsampling/event_test.go
@@ -1,0 +1,76 @@
+package aclsampling
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSampleReference(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		observationDomain *uint32
+		applicationID     *uint32
+		datapathKey       *uint32
+		metadata          uint32
+	}{
+		{name: "decimal metadata", input: "200", metadata: 200},
+		{name: "hex metadata", input: "0xc8", metadata: 200},
+		{name: "maximum metadata", input: "4294967295", metadata: 4294967295},
+		{
+			name:              "decimal cookie",
+			input:             strconv.FormatUint(uint64(0x640abcde)<<32|200, 10),
+			observationDomain: new(uint32(0x640abcde)),
+			applicationID:     new(uint32(100)),
+			datapathKey:       new(uint32(0x0abcde)),
+			metadata:          200,
+		},
+		{
+			name:              "hex cookie",
+			input:             "0x640abcde000000c8",
+			observationDomain: new(uint32(0x640abcde)),
+			applicationID:     new(uint32(100)),
+			datapathKey:       new(uint32(0x0abcde)),
+			metadata:          200,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reference, err := ParseSampleReference(test.input)
+			require.NoError(t, err)
+			require.Equal(t, test.observationDomain, reference.ObservationDomain)
+			require.Equal(t, test.applicationID, reference.ApplicationID)
+			require.Equal(t, test.datapathKey, reference.DatapathKey)
+			require.Equal(t, test.metadata, reference.Metadata)
+			require.NoError(t, reference.Validate())
+		})
+	}
+}
+
+func TestParseSampleReferenceRejectsInvalidInput(t *testing.T) {
+	tests := []string{
+		"",
+		"0",
+		"0x",
+		"-1",
+		"+1",
+		" 1",
+		"1 ",
+		"0xgg",
+		"18446744073709551616",
+		"0x64000000c8",
+		"0x0000010000000001",
+		"0x6400000000000000",
+	}
+
+	for _, input := range tests {
+		t.Run(fmt.Sprintf("input_%q", input), func(t *testing.T) {
+			_, err := ParseSampleReference(input)
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/aclsampling/event_test.go
+++ b/pkg/aclsampling/event_test.go
@@ -1,12 +1,34 @@
 package aclsampling
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestSampleDetailsJSONFlattensObservation(t *testing.T) {
+	details := SampleDetails{
+		App: ApplicationACLNew,
+		SampleObservation: SampleObservation{
+			ObservationDomain: new(uint32(0x640abcde)),
+			ApplicationID:     new(uint32(100)),
+			DatapathKey:       new(uint32(0x0abcde)),
+			Metadata:          200,
+		},
+	}
+	data, err := json.Marshal(details)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"app":"acl-new",
+		"observationDomain":1678425310,
+		"applicationID":100,
+		"datapathKey":703710,
+		"metadata":200
+	}`, string(data))
+}
 
 func TestParseSampleReference(t *testing.T) {
 	tests := []struct {

--- a/pkg/aclsampling/metadata.go
+++ b/pkg/aclsampling/metadata.go
@@ -107,12 +107,10 @@ func (a *Allocator) Allocate(key SampleKey) (Allocation, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	canonical, err := key.canonical()
+	sum, err := key.hash()
 	if err != nil {
 		return Allocation{}, err
 	}
-
-	sum := sha256.Sum256([]byte(canonical))
 	keyHash := hex.EncodeToString(sum[:])
 	if metadata, ok := a.keyHashToMetadata[keyHash]; ok {
 		return Allocation{Metadata: metadata, KeyHash: keyHash}, nil
@@ -131,6 +129,15 @@ func (a *Allocator) Allocate(key SampleKey) (Allocation, error) {
 			return Allocation{}, errors.New("no non-zero ACL sample metadata is available")
 		}
 	}
+}
+
+// KeyHash returns the lowercase SHA-256 digest of the canonical sample key.
+func (key SampleKey) KeyHash() (string, error) {
+	sum, err := key.hash()
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // HashACLMatch returns the lowercase SHA-256 digest stored instead of the full
@@ -160,6 +167,14 @@ func (key SampleKey) canonical() (string, error) {
 		"ovn-action="+string(key.OVNAction),
 	)
 	return strings.Join(fields, "\n") + "\n", nil
+}
+
+func (key SampleKey) hash() ([sha256.Size]byte, error) {
+	canonical, err := key.canonical()
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256([]byte(canonical)), nil
 }
 
 func (key SampleKey) validate() error {

--- a/pkg/aclsampling/metadata_test.go
+++ b/pkg/aclsampling/metadata_test.go
@@ -30,8 +30,15 @@ func TestSampleKeyCanonicalHash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	keyHash, err := validAllowSampleKey().KeyHash()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	const wantKeyHash = "cbef9de432159cede19e36ee3748e823a814fa28805569c45977be4ace46181d"
+	if keyHash != wantKeyHash {
+		t.Fatalf("KeyHash() = %q, want %q", keyHash, wantKeyHash)
+	}
 	if allocation.KeyHash != wantKeyHash {
 		t.Fatalf("key hash = %q, want %q", allocation.KeyHash, wantKeyHash)
 	}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -204,6 +204,7 @@ type ACLSampling interface {
 	ReconcileACLSampling(config aclsampling.ControllerConfig) error
 	PrepareNetworkPolicyACLSampling(pgName, namespace, name, uid string) (*NetworkPolicySamplingRequest, error)
 	ApplyNetworkPolicyACLSampling(config aclsampling.ControllerConfig, request *NetworkPolicySamplingRequest) error
+	ResolveNetworkPolicyACLSample(reference aclsampling.SampleReference) (*aclsampling.Event, error)
 }
 
 type AddressSet interface {

--- a/pkg/ovs/ovn-nb-acl-sample-event.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -14,6 +16,14 @@ var (
 	ErrACLSampleNotFound  = errors.New("ACL sample event was not found")
 	ErrACLSampleAmbiguous = errors.New("ACL sample event is ambiguous")
 )
+
+func networkPolicyResourceName(name string) string {
+	first, _ := utf8.DecodeRuneInString(name)
+	if !unicode.IsLetter(first) {
+		return "np" + name
+	}
+	return name
+}
 
 // ResolveNetworkPolicyACLSample resolves a local psample cookie or metadata
 // value to the single Kube-OVN NetworkPolicy ACL that owns the sample. The
@@ -259,7 +269,7 @@ func validateNetworkPolicyACLIdentity(candidate eligibleNetworkPolicyACL) error 
 	}
 	switch candidate.role {
 	case aclsampling.RoleRuleAllow:
-		if !strings.HasPrefix(aclName, "np/"+policyName+"."+policyNamespace+"/") {
+		if !strings.HasPrefix(aclName, "np/"+networkPolicyResourceName(policyName)+"."+policyNamespace+"/") {
 			return errors.New("rule-allow ACL name does not match the NetworkPolicy identity")
 		}
 	case aclsampling.RoleDefaultDeny:

--- a/pkg/ovs/ovn-nb-acl-sample-event.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event.go
@@ -1,0 +1,221 @@
+package ovs
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+var (
+	ErrACLSampleNotFound  = errors.New("ACL sample event was not found")
+	ErrACLSampleAmbiguous = errors.New("ACL sample event is ambiguous")
+)
+
+// ResolveNetworkPolicyACLSample resolves a local psample cookie or metadata
+// value to the single Kube-OVN NetworkPolicy ACL that owns the sample. The
+// caller does not need to understand OVN strong references or external IDs.
+func (c *OVNNbClient) ResolveNetworkPolicyACLSample(reference aclsampling.SampleReference) (*aclsampling.Event, error) {
+	if err := reference.Validate(); err != nil {
+		return nil, err
+	}
+	if err := c.ensureACLSamplingMonitor(); err != nil {
+		return nil, err
+	}
+
+	application, err := c.resolveACLSampleApplication(reference.ApplicationID)
+	if err != nil {
+		return nil, err
+	}
+	sample, err := c.resolveSampleMetadata(reference.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	acls, err := c.ListAcls("", map[string]string{sampleFeatureExternalID: networkPolicySampleFeature})
+	if err != nil {
+		return nil, fmt.Errorf("list NetworkPolicy ACL sample owners: %w", err)
+	}
+	matches := make([]ovnnb.ACL, 0, 1)
+	for i := range acls {
+		if aclReferencesSample(acls[i], sample.UUID, application) {
+			matches = append(matches, acls[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("%w: no Kube-OVN NetworkPolicy ACL references metadata %d", ErrACLSampleNotFound, reference.Metadata)
+	}
+	if len(matches) != 1 {
+		return nil, fmt.Errorf("%w: metadata %d is referenced by %d Kube-OVN NetworkPolicy ACLs", ErrACLSampleAmbiguous, reference.Metadata, len(matches))
+	}
+
+	event, err := networkPolicyACLSampleEvent(matches[0], reference, application)
+	if err != nil {
+		return nil, fmt.Errorf("decode NetworkPolicy ACL %s: %w", matches[0].UUID, err)
+	}
+	return event, nil
+}
+
+func (c *OVNNbClient) resolveACLSampleApplication(applicationID *uint32) (string, error) {
+	if applicationID == nil {
+		return "", nil
+	}
+	apps, err := c.listSamplingApps()
+	if err != nil {
+		return "", err
+	}
+	matches := make([]ovnnb.SamplingApp, 0, 1)
+	for i := range apps {
+		if apps[i].ID == int(*applicationID) {
+			matches = append(matches, apps[i])
+		}
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("%w: sampling application ID %d does not exist", ErrACLSampleNotFound, *applicationID)
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("%w: sampling application ID %d has %d rows", ErrACLSampleAmbiguous, *applicationID, len(matches))
+	}
+	switch matches[0].Type {
+	case ovnnb.SamplingAppTypeACLNew:
+		return aclsampling.ApplicationACLNew, nil
+	case ovnnb.SamplingAppTypeACLEst:
+		return aclsampling.ApplicationACLEst, nil
+	default:
+		return "", fmt.Errorf("%w: sampling application ID %d has unsupported type %s", ErrACLSampleNotFound, *applicationID, matches[0].Type)
+	}
+}
+
+func (c *OVNNbClient) resolveSampleMetadata(metadata uint32) (*ovnnb.Sample, error) {
+	samples, err := c.listSamples()
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]ovnnb.Sample, 0, 1)
+	for i := range samples {
+		if samples[i].Metadata == int(metadata) {
+			matches = append(matches, samples[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("%w: sample metadata %d does not exist", ErrACLSampleNotFound, metadata)
+	}
+	if len(matches) != 1 {
+		return nil, fmt.Errorf("%w: sample metadata %d has %d rows", ErrACLSampleAmbiguous, metadata, len(matches))
+	}
+	return &matches[0], nil
+}
+
+func aclReferencesSample(acl ovnnb.ACL, sampleUUID, application string) bool {
+	switch application {
+	case aclsampling.ApplicationACLNew:
+		return acl.SampleNew != nil && *acl.SampleNew == sampleUUID
+	case aclsampling.ApplicationACLEst:
+		return acl.SampleEst != nil && *acl.SampleEst == sampleUUID
+	default:
+		return (acl.SampleNew != nil && *acl.SampleNew == sampleUUID) ||
+			(acl.SampleEst != nil && *acl.SampleEst == sampleUUID)
+	}
+}
+
+func networkPolicyACLSampleEvent(acl ovnnb.ACL, reference aclsampling.SampleReference, application string) (*aclsampling.Event, error) {
+	externalIDs := acl.ExternalIDs
+	if externalIDs[sampleSchemaVersionExternalID] != aclsampling.SchemaVersionV1 {
+		return nil, fmt.Errorf("unsupported sample schema version %q", externalIDs[sampleSchemaVersionExternalID])
+	}
+	if externalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
+		return nil, fmt.Errorf("unsupported sample feature %q", externalIDs[sampleFeatureExternalID])
+	}
+	if externalIDs[policyAPIVersionExternalID] != networkPolicyAPIVersion || externalIDs[policyKindExternalID] != networkPolicyKind {
+		return nil, fmt.Errorf("unsupported policy identity %s %s", externalIDs[policyAPIVersionExternalID], externalIDs[policyKindExternalID])
+	}
+	if acl.Tier != util.NetpolACLTier {
+		return nil, fmt.Errorf("ACL tier %d is not the NetworkPolicy tier", acl.Tier)
+	}
+
+	for _, key := range []string{policyNamespaceExternalID, policyNameExternalID, policyUIDExternalID, policyDirectionExternalID} {
+		if externalIDs[key] == "" {
+			return nil, fmt.Errorf("required external ID %s is missing", key)
+		}
+	}
+	direction, ok := networkPolicyDirection(acl.Direction)
+	if !ok || externalIDs[policyDirectionExternalID] != direction {
+		return nil, fmt.Errorf("policy direction %q does not match ACL direction %q", externalIDs[policyDirectionExternalID], acl.Direction)
+	}
+	if externalIDs[ovnActionExternalID] != acl.Action {
+		return nil, fmt.Errorf("OVN action external ID %q does not match ACL action %q", externalIDs[ovnActionExternalID], acl.Action)
+	}
+	matchHash := aclsampling.HashACLMatch(acl.Match)
+	if externalIDs[aclMatchHashExternalID] != matchHash {
+		return nil, errors.New("ACL match hash does not match the current ACL match")
+	}
+	mapping, err := storedNetworkPolicySampleMapping(externalIDs)
+	if err != nil {
+		return nil, err
+	}
+	if mapping.Metadata != reference.Metadata {
+		return nil, fmt.Errorf("sample metadata external ID %d does not match observed metadata %d", mapping.Metadata, reference.Metadata)
+	}
+
+	policy := &aclsampling.PolicyReference{
+		APIVersion: networkPolicyAPIVersion,
+		Kind:       networkPolicyKind,
+		Namespace:  externalIDs[policyNamespaceExternalID],
+		Name:       externalIDs[policyNameExternalID],
+		UID:        externalIDs[policyUIDExternalID],
+		Direction:  direction,
+	}
+	event := &aclsampling.Event{
+		SchemaVersion: aclsampling.SchemaVersionV1,
+		Feature:       networkPolicySampleFeature,
+		OVN: aclsampling.OVNACLReference{
+			UUID:      acl.UUID,
+			Action:    acl.Action,
+			Priority:  acl.Priority,
+			Tier:      acl.Tier,
+			Direction: acl.Direction,
+			MatchHash: matchHash,
+		},
+		Sample: aclsampling.SampleDetails{
+			App:               application,
+			ObservationDomain: reference.ObservationDomain,
+			ApplicationID:     reference.ApplicationID,
+			DatapathKey:       reference.DatapathKey,
+			Metadata:          reference.Metadata,
+		},
+	}
+	if acl.Name != nil {
+		event.OVN.Name = *acl.Name
+	}
+
+	switch externalIDs[sampleRoleExternalID] {
+	case aclsampling.RoleRuleAllow:
+		if externalIDs[policyVerdictExternalID] != aclsampling.VerdictAllow || acl.Action != ovnnb.ACLActionAllowRelated {
+			return nil, errors.New("rule-allow sample metadata does not describe an allow-related ACL")
+		}
+		ruleIndex, err := strconv.Atoi(externalIDs[policyRuleIndexExternalID])
+		if err != nil || ruleIndex < 0 {
+			return nil, fmt.Errorf("invalid NetworkPolicy rule index %q", externalIDs[policyRuleIndexExternalID])
+		}
+		policy.RuleIndex = &ruleIndex
+		event.Verdict = aclsampling.VerdictAllow
+		event.Policy = policy
+	case aclsampling.RoleDefaultDeny:
+		if externalIDs[policyVerdictExternalID] != aclsampling.VerdictDefaultDeny || acl.Action != ovnnb.ACLActionDrop {
+			return nil, errors.New("default-deny sample metadata does not describe a drop ACL")
+		}
+		if _, exists := externalIDs[policyRuleIndexExternalID]; exists {
+			return nil, errors.New("default-deny sample metadata must not include a rule index")
+		}
+		event.Verdict = aclsampling.VerdictDefaultDeny
+		event.Reason = aclsampling.ReasonNetworkPolicyDefaultDeny
+		event.Attribution = aclsampling.AttributionNonExclusive
+		event.PolicyOwner = policy
+	default:
+		return nil, fmt.Errorf("unsupported NetworkPolicy ACL sample role %q", externalIDs[sampleRoleExternalID])
+	}
+	return event, nil
+}

--- a/pkg/ovs/ovn-nb-acl-sample-event.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
-	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 var (
@@ -39,11 +39,24 @@ func (c *OVNNbClient) ResolveNetworkPolicyACLSample(reference aclsampling.Sample
 	if err != nil {
 		return nil, fmt.Errorf("list NetworkPolicy ACL sample owners: %w", err)
 	}
-	matches := make([]ovnnb.ACL, 0, 1)
+	matches := make([]*aclsampling.Event, 0, 1)
 	for i := range acls {
-		if aclReferencesSample(acls[i], sample.UUID, application) {
-			matches = append(matches, acls[i])
+		acl := acls[i]
+		if !isOwnedNetworkPolicySamplingACL(acl.ExternalIDs) {
+			continue
 		}
+		candidate, eligible, err := classifyNetworkPolicySamplingACL(acl)
+		if err != nil {
+			return nil, fmt.Errorf("classify NetworkPolicy ACL %s: %w", acl.UUID, err)
+		}
+		if !eligible || !aclReferencesSample(acl, sample.UUID, application) {
+			continue
+		}
+		event, err := networkPolicyACLSampleEvent(candidate, sample.UUID, reference, application)
+		if err != nil {
+			return nil, fmt.Errorf("decode NetworkPolicy ACL %s: %w", acl.UUID, err)
+		}
+		matches = append(matches, event)
 	}
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("%w: no Kube-OVN NetworkPolicy ACL references metadata %d", ErrACLSampleNotFound, reference.Metadata)
@@ -52,14 +65,10 @@ func (c *OVNNbClient) ResolveNetworkPolicyACLSample(reference aclsampling.Sample
 		return nil, fmt.Errorf("%w: metadata %d is referenced by %d Kube-OVN NetworkPolicy ACLs", ErrACLSampleAmbiguous, reference.Metadata, len(matches))
 	}
 
-	event, err := networkPolicyACLSampleEvent(matches[0], reference, application)
-	if err != nil {
-		return nil, fmt.Errorf("decode NetworkPolicy ACL %s: %w", matches[0].UUID, err)
-	}
-	return event, nil
+	return matches[0], nil
 }
 
-func (c *OVNNbClient) resolveACLSampleApplication(applicationID *uint32) (string, error) {
+func (c *OVNNbClient) resolveACLSampleApplication(applicationID *uint32) (aclsampling.Application, error) {
 	if applicationID == nil {
 		return "", nil
 	}
@@ -109,7 +118,7 @@ func (c *OVNNbClient) resolveSampleMetadata(metadata uint32) (*ovnnb.Sample, err
 	return &matches[0], nil
 }
 
-func aclReferencesSample(acl ovnnb.ACL, sampleUUID, application string) bool {
+func aclReferencesSample(acl ovnnb.ACL, sampleUUID string, application aclsampling.Application) bool {
 	switch application {
 	case aclsampling.ApplicationACLNew:
 		return acl.SampleNew != nil && *acl.SampleNew == sampleUUID
@@ -121,44 +130,12 @@ func aclReferencesSample(acl ovnnb.ACL, sampleUUID, application string) bool {
 	}
 }
 
-func networkPolicyACLSampleEvent(acl ovnnb.ACL, reference aclsampling.SampleReference, application string) (*aclsampling.Event, error) {
-	externalIDs := acl.ExternalIDs
-	if externalIDs[sampleSchemaVersionExternalID] != aclsampling.SchemaVersionV1 {
-		return nil, fmt.Errorf("unsupported sample schema version %q", externalIDs[sampleSchemaVersionExternalID])
-	}
-	if externalIDs[sampleFeatureExternalID] != networkPolicySampleFeature {
-		return nil, fmt.Errorf("unsupported sample feature %q", externalIDs[sampleFeatureExternalID])
-	}
-	if externalIDs[policyAPIVersionExternalID] != networkPolicyAPIVersion || externalIDs[policyKindExternalID] != networkPolicyKind {
-		return nil, fmt.Errorf("unsupported policy identity %s %s", externalIDs[policyAPIVersionExternalID], externalIDs[policyKindExternalID])
-	}
-	if acl.Tier != util.NetpolACLTier {
-		return nil, fmt.Errorf("ACL tier %d is not the NetworkPolicy tier", acl.Tier)
-	}
-
-	for _, key := range []string{policyNamespaceExternalID, policyNameExternalID, policyUIDExternalID, policyDirectionExternalID} {
-		if externalIDs[key] == "" {
-			return nil, fmt.Errorf("required external ID %s is missing", key)
-		}
-	}
-	direction, ok := networkPolicyDirection(acl.Direction)
-	if !ok || externalIDs[policyDirectionExternalID] != direction {
-		return nil, fmt.Errorf("policy direction %q does not match ACL direction %q", externalIDs[policyDirectionExternalID], acl.Direction)
-	}
-	if externalIDs[ovnActionExternalID] != acl.Action {
-		return nil, fmt.Errorf("OVN action external ID %q does not match ACL action %q", externalIDs[ovnActionExternalID], acl.Action)
-	}
-	matchHash := aclsampling.HashACLMatch(acl.Match)
-	if externalIDs[aclMatchHashExternalID] != matchHash {
-		return nil, errors.New("ACL match hash does not match the current ACL match")
-	}
-	mapping, err := storedNetworkPolicySampleMapping(externalIDs)
-	if err != nil {
+func networkPolicyACLSampleEvent(candidate eligibleNetworkPolicyACL, sampleUUID string, reference aclsampling.SampleReference, application aclsampling.Application) (*aclsampling.Event, error) {
+	acl := candidate.acl
+	if err := validateNetworkPolicyACLSample(candidate, sampleUUID, reference, application); err != nil {
 		return nil, err
 	}
-	if mapping.Metadata != reference.Metadata {
-		return nil, fmt.Errorf("sample metadata external ID %d does not match observed metadata %d", mapping.Metadata, reference.Metadata)
-	}
+	externalIDs := acl.ExternalIDs
 
 	policy := &aclsampling.PolicyReference{
 		APIVersion: networkPolicyAPIVersion,
@@ -166,50 +143,35 @@ func networkPolicyACLSampleEvent(acl ovnnb.ACL, reference aclsampling.SampleRefe
 		Namespace:  externalIDs[policyNamespaceExternalID],
 		Name:       externalIDs[policyNameExternalID],
 		UID:        externalIDs[policyUIDExternalID],
-		Direction:  direction,
+		Direction:  candidate.direction,
 	}
+	matchHash := aclsampling.HashACLMatch(acl.Match)
 	event := &aclsampling.Event{
 		SchemaVersion: aclsampling.SchemaVersionV1,
 		Feature:       networkPolicySampleFeature,
 		OVN: aclsampling.OVNACLReference{
 			UUID:      acl.UUID,
-			Action:    acl.Action,
+			Action:    aclsampling.OVNAction(acl.Action),
 			Priority:  acl.Priority,
 			Tier:      acl.Tier,
-			Direction: acl.Direction,
+			Direction: aclsampling.OVNACLDirection(acl.Direction),
 			MatchHash: matchHash,
 		},
 		Sample: aclsampling.SampleDetails{
 			App:               application,
-			ObservationDomain: reference.ObservationDomain,
-			ApplicationID:     reference.ApplicationID,
-			DatapathKey:       reference.DatapathKey,
-			Metadata:          reference.Metadata,
+			SampleObservation: reference.SampleObservation,
 		},
 	}
 	if acl.Name != nil {
 		event.OVN.Name = *acl.Name
 	}
 
-	switch externalIDs[sampleRoleExternalID] {
+	switch candidate.role {
 	case aclsampling.RoleRuleAllow:
-		if externalIDs[policyVerdictExternalID] != aclsampling.VerdictAllow || acl.Action != ovnnb.ACLActionAllowRelated {
-			return nil, errors.New("rule-allow sample metadata does not describe an allow-related ACL")
-		}
-		ruleIndex, err := strconv.Atoi(externalIDs[policyRuleIndexExternalID])
-		if err != nil || ruleIndex < 0 {
-			return nil, fmt.Errorf("invalid NetworkPolicy rule index %q", externalIDs[policyRuleIndexExternalID])
-		}
-		policy.RuleIndex = &ruleIndex
+		policy.RuleIndex = candidate.ruleIndex
 		event.Verdict = aclsampling.VerdictAllow
 		event.Policy = policy
 	case aclsampling.RoleDefaultDeny:
-		if externalIDs[policyVerdictExternalID] != aclsampling.VerdictDefaultDeny || acl.Action != ovnnb.ACLActionDrop {
-			return nil, errors.New("default-deny sample metadata does not describe a drop ACL")
-		}
-		if _, exists := externalIDs[policyRuleIndexExternalID]; exists {
-			return nil, errors.New("default-deny sample metadata must not include a rule index")
-		}
 		event.Verdict = aclsampling.VerdictDefaultDeny
 		event.Reason = aclsampling.ReasonNetworkPolicyDefaultDeny
 		event.Attribution = aclsampling.AttributionNonExclusive
@@ -218,4 +180,113 @@ func networkPolicyACLSampleEvent(acl ovnnb.ACL, reference aclsampling.SampleRefe
 		return nil, fmt.Errorf("unsupported NetworkPolicy ACL sample role %q", externalIDs[sampleRoleExternalID])
 	}
 	return event, nil
+}
+
+func validateNetworkPolicyACLSample(candidate eligibleNetworkPolicyACL, sampleUUID string, reference aclsampling.SampleReference, application aclsampling.Application) error {
+	acl := candidate.acl
+	externalIDs := acl.ExternalIDs
+	if !isOwnedNetworkPolicySamplingACL(externalIDs) {
+		return errors.New("ACL is not owned by Kube-OVN NetworkPolicy sampling")
+	}
+	if externalIDs[policyAPIVersionExternalID] != networkPolicyAPIVersion || externalIDs[policyKindExternalID] != networkPolicyKind {
+		return fmt.Errorf("unsupported policy identity %s %s", externalIDs[policyAPIVersionExternalID], externalIDs[policyKindExternalID])
+	}
+	for _, key := range []string{policyNamespaceExternalID, policyNameExternalID, policyUIDExternalID, policyDirectionExternalID} {
+		if externalIDs[key] == "" {
+			return fmt.Errorf("required external ID %s is missing", key)
+		}
+	}
+	if externalIDs[policyDirectionExternalID] != string(candidate.direction) {
+		return fmt.Errorf("policy direction %q does not match ACL direction %q", externalIDs[policyDirectionExternalID], acl.Direction)
+	}
+	if externalIDs[sampleRoleExternalID] != string(candidate.role) || externalIDs[policyVerdictExternalID] != string(candidate.verdict) {
+		return errors.New("ACL sample role or verdict does not match the canonical NetworkPolicy ACL")
+	}
+	switch candidate.role {
+	case aclsampling.RoleRuleAllow:
+		ruleIndex, err := strconv.Atoi(externalIDs[policyRuleIndexExternalID])
+		if err != nil || candidate.ruleIndex == nil || ruleIndex != *candidate.ruleIndex {
+			return fmt.Errorf("NetworkPolicy rule index %q does not match the canonical ACL", externalIDs[policyRuleIndexExternalID])
+		}
+	case aclsampling.RoleDefaultDeny:
+		if _, exists := externalIDs[policyRuleIndexExternalID]; exists {
+			return errors.New("default-deny sample metadata must not include a rule index")
+		}
+	}
+	if externalIDs[ovnActionExternalID] != acl.Action {
+		return fmt.Errorf("OVN action external ID %q does not match ACL action %q", externalIDs[ovnActionExternalID], acl.Action)
+	}
+	matchHash := aclsampling.HashACLMatch(acl.Match)
+	if externalIDs[aclMatchHashExternalID] != matchHash {
+		return errors.New("ACL match hash does not match the current ACL match")
+	}
+	mapping, err := storedNetworkPolicySampleMapping(externalIDs)
+	if err != nil {
+		return err
+	}
+	if mapping.Metadata != reference.Metadata {
+		return fmt.Errorf("sample metadata external ID %d does not match observed metadata %d", mapping.Metadata, reference.Metadata)
+	}
+	expectedKeyHash, err := (aclsampling.SampleKey{
+		SchemaVersion: aclsampling.SchemaVersionV1,
+		PolicyUID:     externalIDs[policyUIDExternalID],
+		Direction:     candidate.direction,
+		RuleIndex:     candidate.ruleIndex,
+		Role:          candidate.role,
+		Protocol:      candidate.protocol,
+		ACLMatchHash:  matchHash,
+		OVNAction:     aclsampling.OVNAction(acl.Action),
+	}).KeyHash()
+	if err != nil {
+		return fmt.Errorf("build canonical sample key: %w", err)
+	}
+	if mapping.KeyHash != expectedKeyHash {
+		return errors.New("sample key hash does not match the canonical NetworkPolicy ACL")
+	}
+	if err := validateNetworkPolicyACLIdentity(candidate); err != nil {
+		return err
+	}
+	return validateNetworkPolicyACLSampleReferences(candidate, sampleUUID, application)
+}
+
+func validateNetworkPolicyACLIdentity(candidate eligibleNetworkPolicyACL) error {
+	externalIDs := candidate.acl.ExternalIDs
+	aclName := externalIDs[networkPolicyACLNameExternalID]
+	policyNamespace := externalIDs[policyNamespaceExternalID]
+	policyName := externalIDs[policyNameExternalID]
+	if candidate.acl.Name == nil || *candidate.acl.Name != aclName {
+		return errors.New("OVN ACL name does not match the canonical NetworkPolicy ACL name")
+	}
+	switch candidate.role {
+	case aclsampling.RoleRuleAllow:
+		if !strings.HasPrefix(aclName, "np/"+policyName+"."+policyNamespace+"/") {
+			return errors.New("rule-allow ACL name does not match the NetworkPolicy identity")
+		}
+	case aclsampling.RoleDefaultDeny:
+		if aclName != policyNamespace+"/"+policyName {
+			return errors.New("default-deny ACL name does not match the NetworkPolicy identity")
+		}
+	default:
+		return fmt.Errorf("unsupported NetworkPolicy ACL sample role %q", candidate.role)
+	}
+	return nil
+}
+
+func validateNetworkPolicyACLSampleReferences(candidate eligibleNetworkPolicyACL, sampleUUID string, application aclsampling.Application) error {
+	acl := candidate.acl
+	sampleNewMatches := acl.SampleNew != nil && *acl.SampleNew == sampleUUID
+	sampleEstMatches := acl.SampleEst != nil && *acl.SampleEst == sampleUUID
+	switch candidate.role {
+	case aclsampling.RoleRuleAllow:
+		if !sampleNewMatches || !sampleEstMatches {
+			return errors.New("rule-allow ACL must reference the same Sample from sample_new and sample_est")
+		}
+	case aclsampling.RoleDefaultDeny:
+		if !sampleNewMatches || acl.SampleEst != nil || application == aclsampling.ApplicationACLEst {
+			return errors.New("default-deny ACL must reference its Sample only from sample_new")
+		}
+	default:
+		return fmt.Errorf("unsupported NetworkPolicy ACL sample role %q", candidate.role)
+	}
+	return nil
 }

--- a/pkg/ovs/ovn-nb-acl-sample-event.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event.go
@@ -254,7 +254,7 @@ func validateNetworkPolicyACLIdentity(candidate eligibleNetworkPolicyACL) error 
 	aclName := externalIDs[networkPolicyACLNameExternalID]
 	policyNamespace := externalIDs[policyNamespaceExternalID]
 	policyName := externalIDs[policyNameExternalID]
-	if candidate.acl.Name == nil || *candidate.acl.Name != aclName {
+	if candidate.acl.Name == nil || *candidate.acl.Name != limitedACLName(aclName) {
 		return errors.New("OVN ACL name does not match the canonical NetworkPolicy ACL name")
 	}
 	switch candidate.role {

--- a/pkg/ovs/ovn-nb-acl-sample-event_test.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event_test.go
@@ -1,0 +1,127 @@
+package ovs
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/aclsampling"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestResolveNetworkPolicyACLSample(t *testing.T) {
+	client := newACLSamplingTestClient(t, "event-resolver")
+	const pgName = "decoded-policy.default"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+
+	allowACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/decoded-policy.default/ingress/IPv4/3")
+	denyACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionFromLport, util.EgressDefaultDrop, ovnnb.ACLActionDrop, "default/decoded-policy")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, allowACL, denyACL))
+	waitForACLCount(t, client, pgName, 2)
+
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "decoded-policy", "11111111-2222-3333-4444-555555555555")
+	require.NoError(t, err)
+	config := validACLSamplingConfig()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.NoError(collect, client.ApplyNetworkPolicyACLSampling(config, request))
+	}, 3*time.Second, 20*time.Millisecond)
+
+	var sampled []ovnnb.ACL
+	require.Eventually(t, func() bool {
+		sampled, err = client.ListAcls("", map[string]string{sampleFeatureExternalID: networkPolicySampleFeature})
+		return err == nil && len(sampled) == 2
+	}, 3*time.Second, 20*time.Millisecond)
+
+	allow := aclByName(t, sampled, "np/decoded-policy.default/ingress/IPv4/3")
+	allowMetadata := parseSampleMetadataForTest(t, allow)
+	const datapathKey = uint32(0x0abcde)
+	newCookie := aclSampleCookieForTest(config.AppIDNew, datapathKey, allowMetadata)
+	reference, err := aclsampling.ParseSampleReference(newCookie)
+	require.NoError(t, err)
+	event, err := client.ResolveNetworkPolicyACLSample(reference)
+	require.NoError(t, err)
+	require.Equal(t, aclsampling.VerdictAllow, event.Verdict)
+	require.NotNil(t, event.Policy)
+	require.Nil(t, event.PolicyOwner)
+	require.Equal(t, 3, *event.Policy.RuleIndex)
+	require.Equal(t, aclsampling.ApplicationACLNew, event.Sample.App)
+	require.Equal(t, config.AppIDNew, *event.Sample.ApplicationID)
+	require.Equal(t, datapathKey, *event.Sample.DatapathKey)
+	require.Equal(t, config.AppIDNew<<24|datapathKey, *event.Sample.ObservationDomain)
+	require.Equal(t, allowMetadata, event.Sample.Metadata)
+	require.Equal(t, allow.UUID, event.OVN.UUID)
+
+	establishedCookie := aclSampleCookieForTest(config.AppIDEstablished, datapathKey, allowMetadata)
+	reference, err = aclsampling.ParseSampleReference(establishedCookie)
+	require.NoError(t, err)
+	event, err = client.ResolveNetworkPolicyACLSample(reference)
+	require.NoError(t, err)
+	require.Equal(t, aclsampling.ApplicationACLEst, event.Sample.App)
+	require.Equal(t, aclsampling.VerdictAllow, event.Verdict)
+
+	metadataOnly, err := aclsampling.ParseSampleReference(strconv.FormatUint(uint64(allowMetadata), 10))
+	require.NoError(t, err)
+	event, err = client.ResolveNetworkPolicyACLSample(metadataOnly)
+	require.NoError(t, err)
+	require.Empty(t, event.Sample.App)
+	require.Nil(t, event.Sample.ObservationDomain)
+	require.Nil(t, event.Sample.ApplicationID)
+	require.Nil(t, event.Sample.DatapathKey)
+
+	deny := aclByNameAndAction(t, sampled, "default/decoded-policy", ovnnb.ACLActionDrop)
+	denyMetadata := parseSampleMetadataForTest(t, deny)
+	denyCookie := aclSampleCookieForTest(config.AppIDNew, datapathKey, denyMetadata)
+	reference, err = aclsampling.ParseSampleReference(denyCookie)
+	require.NoError(t, err)
+	event, err = client.ResolveNetworkPolicyACLSample(reference)
+	require.NoError(t, err)
+	require.Equal(t, aclsampling.VerdictDefaultDeny, event.Verdict)
+	require.Nil(t, event.Policy)
+	require.NotNil(t, event.PolicyOwner)
+	require.Nil(t, event.PolicyOwner.RuleIndex)
+	require.Equal(t, aclsampling.ReasonNetworkPolicyDefaultDeny, event.Reason)
+	require.Equal(t, aclsampling.AttributionNonExclusive, event.Attribution)
+
+	establishedCookie = aclSampleCookieForTest(config.AppIDEstablished, datapathKey, denyMetadata)
+	reference, err = aclsampling.ParseSampleReference(establishedCookie)
+	require.NoError(t, err)
+	_, err = client.ResolveNetworkPolicyACLSample(reference)
+	require.ErrorIs(t, err, ErrACLSampleNotFound)
+}
+
+func TestResolveNetworkPolicyACLSampleRejectsUnknownValues(t *testing.T) {
+	client := newACLSamplingTestClient(t, "event-resolver-not-found")
+	require.NoError(t, client.ReconcileACLSampling(validACLSamplingConfig()))
+	waitForACLSamplingObjects(t, client)
+
+	_, err := client.ResolveNetworkPolicyACLSample(aclsampling.SampleReference{Metadata: 999})
+	require.ErrorIs(t, err, ErrACLSampleNotFound)
+
+	reference, parseErr := aclsampling.ParseSampleReference(aclSampleCookieForTest(200, 1, 999))
+	require.NoError(t, parseErr)
+	_, err = client.ResolveNetworkPolicyACLSample(reference)
+	require.ErrorIs(t, err, ErrACLSampleNotFound)
+
+	_, err = client.ResolveNetworkPolicyACLSample(aclsampling.SampleReference{})
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrACLSampleNotFound))
+}
+
+func parseSampleMetadataForTest(t *testing.T, acl ovnnb.ACL) uint32 {
+	t.Helper()
+	metadata, err := strconv.ParseUint(acl.ExternalIDs[sampleMetadataExternalID], 10, 32)
+	require.NoError(t, err)
+	return uint32(metadata)
+}
+
+func aclSampleCookieForTest(applicationID, datapathKey, metadata uint32) string {
+	observationDomain := applicationID<<24 | datapathKey
+	return fmt.Sprintf("0x%08x%08x", observationDomain, metadata)
+}

--- a/pkg/ovs/ovn-nb-acl-sample-event_test.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event_test.go
@@ -3,6 +3,7 @@ package ovs
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"testing"
 	"time"
@@ -16,30 +17,7 @@ import (
 )
 
 func TestResolveNetworkPolicyACLSample(t *testing.T) {
-	client := newACLSamplingTestClient(t, "event-resolver")
-	const pgName = "decoded-policy.default"
-	require.NoError(t, client.CreatePortGroup(pgName, nil))
-	waitForPortGroup(t, client, pgName)
-
-	allowACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, "np/decoded-policy.default/ingress/IPv4/3")
-	denyACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionFromLport, util.EgressDefaultDrop, ovnnb.ACLActionDrop, "default/decoded-policy")
-	require.NoError(t, client.CreateAcls(pgName, portGroupKey, allowACL, denyACL))
-	waitForACLCount(t, client, pgName, 2)
-
-	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "decoded-policy", "11111111-2222-3333-4444-555555555555")
-	require.NoError(t, err)
-	config := validACLSamplingConfig()
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		require.NoError(collect, client.ApplyNetworkPolicyACLSampling(config, request))
-	}, 3*time.Second, 20*time.Millisecond)
-
-	var sampled []ovnnb.ACL
-	require.Eventually(t, func() bool {
-		sampled, err = client.ListAcls("", map[string]string{sampleFeatureExternalID: networkPolicySampleFeature})
-		return err == nil && len(sampled) == 2
-	}, 3*time.Second, 20*time.Millisecond)
-
-	allow := aclByName(t, sampled, "np/decoded-policy.default/ingress/IPv4/3")
+	client, config, allow, deny := newNetworkPolicySampleResolverFixture(t, "event-resolver")
 	allowMetadata := parseSampleMetadataForTest(t, allow)
 	const datapathKey = uint32(0x0abcde)
 	newCookie := aclSampleCookieForTest(config.AppIDNew, datapathKey, allowMetadata)
@@ -75,7 +53,6 @@ func TestResolveNetworkPolicyACLSample(t *testing.T) {
 	require.Nil(t, event.Sample.ApplicationID)
 	require.Nil(t, event.Sample.DatapathKey)
 
-	deny := aclByNameAndAction(t, sampled, "default/decoded-policy", ovnnb.ACLActionDrop)
 	denyMetadata := parseSampleMetadataForTest(t, deny)
 	denyCookie := aclSampleCookieForTest(config.AppIDNew, datapathKey, denyMetadata)
 	reference, err = aclsampling.ParseSampleReference(denyCookie)
@@ -96,12 +73,87 @@ func TestResolveNetworkPolicyACLSample(t *testing.T) {
 	require.ErrorIs(t, err, ErrACLSampleNotFound)
 }
 
+func TestResolveNetworkPolicyACLSampleRejectsInconsistentOwner(t *testing.T) {
+	t.Run("unowned ACL", func(t *testing.T) {
+		client, config, allow, _ := newNetworkPolicySampleResolverFixture(t, "event-resolver-unowned")
+		metadata := parseSampleMetadataForTest(t, allow)
+		allow.ExternalIDs = maps.Clone(allow.ExternalIDs)
+		delete(allow.ExternalIDs, ExternalIDVendor)
+		require.NoError(t, client.UpdateACL(&allow, &allow.ExternalIDs))
+
+		reference, err := aclsampling.ParseSampleReference(aclSampleCookieForTest(config.AppIDNew, 1, metadata))
+		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := client.ResolveNetworkPolicyACLSample(reference)
+			require.ErrorIs(collect, err, ErrACLSampleNotFound)
+		}, 3*time.Second, 20*time.Millisecond)
+	})
+
+	t.Run("tampered policy UID", func(t *testing.T) {
+		client, config, allow, _ := newNetworkPolicySampleResolverFixture(t, "event-resolver-uid")
+		metadata := parseSampleMetadataForTest(t, allow)
+		allow.ExternalIDs = maps.Clone(allow.ExternalIDs)
+		allow.ExternalIDs[policyUIDExternalID] = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+		require.NoError(t, client.UpdateACL(&allow, &allow.ExternalIDs))
+
+		reference, err := aclsampling.ParseSampleReference(aclSampleCookieForTest(config.AppIDNew, 1, metadata))
+		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := client.ResolveNetworkPolicyACLSample(reference)
+			require.ErrorContains(collect, err, "sample key hash does not match")
+		}, 3*time.Second, 20*time.Millisecond)
+	})
+
+	t.Run("tampered policy name", func(t *testing.T) {
+		client, config, allow, _ := newNetworkPolicySampleResolverFixture(t, "event-resolver-name")
+		metadata := parseSampleMetadataForTest(t, allow)
+		allow.ExternalIDs = maps.Clone(allow.ExternalIDs)
+		allow.ExternalIDs[policyNameExternalID] = "another-policy"
+		require.NoError(t, client.UpdateACL(&allow, &allow.ExternalIDs))
+
+		reference, err := aclsampling.ParseSampleReference(aclSampleCookieForTest(config.AppIDNew, 1, metadata))
+		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := client.ResolveNetworkPolicyACLSample(reference)
+			require.ErrorContains(collect, err, "ACL name does not match")
+		}, 3*time.Second, 20*time.Millisecond)
+	})
+
+	t.Run("allow references different samples", func(t *testing.T) {
+		client, config, allow, _ := newNetworkPolicySampleResolverFixture(t, "event-resolver-allow-refs")
+		metadata := parseSampleMetadataForTest(t, allow)
+		allow.SampleEst = nil
+		require.NoError(t, client.UpdateACL(&allow, &allow.SampleEst))
+
+		reference, err := aclsampling.ParseSampleReference(aclSampleCookieForTest(config.AppIDNew, 1, metadata))
+		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := client.ResolveNetworkPolicyACLSample(reference)
+			require.ErrorContains(collect, err, "same Sample")
+		}, 3*time.Second, 20*time.Millisecond)
+	})
+
+	t.Run("default deny references established sample", func(t *testing.T) {
+		client, config, _, deny := newNetworkPolicySampleResolverFixture(t, "event-resolver-deny-est")
+		metadata := parseSampleMetadataForTest(t, deny)
+		deny.SampleEst = deny.SampleNew
+		require.NoError(t, client.UpdateACL(&deny, &deny.SampleEst))
+
+		reference, err := aclsampling.ParseSampleReference(aclSampleCookieForTest(config.AppIDEstablished, 1, metadata))
+		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := client.ResolveNetworkPolicyACLSample(reference)
+			require.ErrorContains(collect, err, "only from sample_new")
+		}, 3*time.Second, 20*time.Millisecond)
+	})
+}
+
 func TestResolveNetworkPolicyACLSampleRejectsUnknownValues(t *testing.T) {
 	client := newACLSamplingTestClient(t, "event-resolver-not-found")
 	require.NoError(t, client.ReconcileACLSampling(validACLSamplingConfig()))
 	waitForACLSamplingObjects(t, client)
 
-	_, err := client.ResolveNetworkPolicyACLSample(aclsampling.SampleReference{Metadata: 999})
+	_, err := client.ResolveNetworkPolicyACLSample(aclsampling.SampleReference{SampleObservation: aclsampling.SampleObservation{Metadata: 999}})
 	require.ErrorIs(t, err, ErrACLSampleNotFound)
 
 	reference, parseErr := aclsampling.ParseSampleReference(aclSampleCookieForTest(200, 1, 999))
@@ -112,6 +164,34 @@ func TestResolveNetworkPolicyACLSampleRejectsUnknownValues(t *testing.T) {
 	_, err = client.ResolveNetworkPolicyACLSample(aclsampling.SampleReference{})
 	require.Error(t, err)
 	require.False(t, errors.Is(err, ErrACLSampleNotFound))
+}
+
+func newNetworkPolicySampleResolverFixture(t *testing.T, testName string) (*OVNNbClient, aclsampling.ControllerConfig, ovnnb.ACL, ovnnb.ACL) {
+	t.Helper()
+	client := newACLSamplingTestClient(t, testName)
+	pgName := testName + ".default"
+	require.NoError(t, client.CreatePortGroup(pgName, nil))
+	waitForPortGroup(t, client, pgName)
+
+	allowName := "np/decoded-policy.default/ingress/IPv4/3"
+	allowACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionToLport, util.IngressAllowPriority, ovnnb.ACLActionAllowRelated, allowName)
+	denyACL := newNetworkPolicySamplingTestACL(t, client, pgName, ovnnb.ACLDirectionFromLport, util.EgressDefaultDrop, ovnnb.ACLActionDrop, "default/decoded-policy")
+	require.NoError(t, client.CreateAcls(pgName, portGroupKey, allowACL, denyACL))
+	waitForACLCount(t, client, pgName, 2)
+
+	request, err := client.PrepareNetworkPolicyACLSampling(pgName, "default", "decoded-policy", "11111111-2222-3333-4444-555555555555")
+	require.NoError(t, err)
+	config := validACLSamplingConfig()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.NoError(collect, client.ApplyNetworkPolicyACLSampling(config, request))
+	}, 3*time.Second, 20*time.Millisecond)
+
+	var sampled []ovnnb.ACL
+	require.Eventually(t, func() bool {
+		sampled, err = client.ListAcls("", map[string]string{sampleFeatureExternalID: networkPolicySampleFeature})
+		return err == nil && len(sampled) == 2
+	}, 3*time.Second, 20*time.Millisecond)
+	return client, config, aclByName(t, sampled, allowName), aclByNameAndAction(t, sampled, "default/decoded-policy", ovnnb.ACLActionDrop)
 }
 
 func parseSampleMetadataForTest(t *testing.T, acl ovnnb.ACL) uint32 {

--- a/pkg/ovs/ovn-nb-acl-sample-event_test.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -164,6 +165,31 @@ func TestResolveNetworkPolicyACLSampleRejectsUnknownValues(t *testing.T) {
 	_, err = client.ResolveNetworkPolicyACLSample(aclsampling.SampleReference{})
 	require.Error(t, err)
 	require.False(t, errors.Is(err, ErrACLSampleNotFound))
+}
+
+func TestValidateNetworkPolicyACLIdentityAcceptsTruncatedOVNName(t *testing.T) {
+	policyName := strings.Repeat("long-policy-name-", 5) + "tail"
+	aclName := "np/" + policyName + ".default/ingress/IPv4/3"
+	priority, err := strconv.Atoi(util.IngressAllowPriority)
+	require.NoError(t, err)
+	acl := ovnnb.ACL{
+		Action:    ovnnb.ACLActionAllowRelated,
+		Direction: ovnnb.ACLDirectionToLport,
+		Priority:  priority,
+		Tier:      util.NetpolACLTier,
+		ExternalIDs: map[string]string{
+			ExternalIDVendor:               util.CniTypeName,
+			networkPolicyACLNameExternalID: aclName,
+			policyNamespaceExternalID:      "default",
+			policyNameExternalID:           policyName,
+		},
+	}
+	setACLName(&acl, aclName)
+	candidate, eligible, err := classifyNetworkPolicySamplingACL(acl)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	require.NoError(t, validateNetworkPolicyACLIdentity(candidate))
+	require.Equal(t, limitedACLName(aclName), *acl.Name)
 }
 
 func newNetworkPolicySampleResolverFixture(t *testing.T, testName string) (*OVNNbClient, aclsampling.ControllerConfig, ovnnb.ACL, ovnnb.ACL) {

--- a/pkg/ovs/ovn-nb-acl-sample-event_test.go
+++ b/pkg/ovs/ovn-nb-acl-sample-event_test.go
@@ -192,6 +192,30 @@ func TestValidateNetworkPolicyACLIdentityAcceptsTruncatedOVNName(t *testing.T) {
 	require.Equal(t, limitedACLName(aclName), *acl.Name)
 }
 
+func TestValidateNetworkPolicyACLIdentityAcceptsNumericPolicyName(t *testing.T) {
+	const policyName = "123-policy"
+	aclName := "np/" + policyName + ".default/ingress/IPv4/3"
+	priority, err := strconv.Atoi(util.IngressAllowPriority)
+	require.NoError(t, err)
+	acl := ovnnb.ACL{
+		Action:    ovnnb.ACLActionAllowRelated,
+		Direction: ovnnb.ACLDirectionToLport,
+		Priority:  priority,
+		Tier:      util.NetpolACLTier,
+		ExternalIDs: map[string]string{
+			ExternalIDVendor:               util.CniTypeName,
+			networkPolicyACLNameExternalID: aclName,
+			policyNamespaceExternalID:      "default",
+			policyNameExternalID:           policyName,
+		},
+	}
+	setACLName(&acl, aclName)
+	candidate, eligible, err := classifyNetworkPolicySamplingACL(acl)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	require.NoError(t, validateNetworkPolicyACLIdentity(candidate))
+}
+
 func newNetworkPolicySampleResolverFixture(t *testing.T, testName string) (*OVNNbClient, aclsampling.ControllerConfig, ovnnb.ACL, ovnnb.ACL) {
 	t.Helper()
 	client := newACLSamplingTestClient(t, testName)

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -46,11 +46,16 @@ func NewACLError(errType ACLErrorType, msg string) *ACLError {
 }
 
 func setACLName(acl *ovnnb.ACL, name string) {
+	name = limitedACLName(name)
+	acl.Name = new(name)
+}
+
+func limitedACLName(name string) string {
 	if len(name) > 63 {
 		// ACL name length limit is 63
-		name = name[:60] + "..."
+		return name[:60] + "..."
 	}
-	acl.Name = new(name)
+	return name
 }
 
 // UpdateDefaultBlockACLOps returns operations to update/create the default block ACL


### PR DESCRIPTION
Related to #7146.

## Summary

- parse decimal or hexadecimal ACL metadata and 64-bit local-sampling cookies
- decode observation domain into application byte and 24-bit datapath key
- resolve sampling application, Sample row, and owning NetworkPolicy ACL through one interface
- emit stable allow and default-deny event models with non-exclusive deny attribution
- reject unknown applications, missing metadata, ambiguous owners, and inconsistent ACL metadata

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. **#7168 — cookie and metadata event decoder**
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-node-delivery`

## Validation

- `go test ./pkg/aclsampling ./pkg/ovs -count=1`
- parser/resolver race tests
- `go vet ./pkg/aclsampling ./pkg/ovs`
- diff-scoped `golangci-lint` with one worker: 0 issues
- `git diff --check`