### PR TITLE
feat: listen for local ACL samples

### DIFF
--- a/pkg/aclsampling/event.go
+++ b/pkg/aclsampling/event.go
@@ -122,6 +122,10 @@ func ParseSampleReference(value string) (SampleReference, error) {
 	if err != nil {
 		return SampleReference{}, fmt.Errorf("invalid ACL sample cookie or metadata %q: %w", value, err)
 	}
+	return sampleReferenceFromUint64(raw)
+}
+
+func sampleReferenceFromUint64(raw uint64) (SampleReference, error) {
 	if raw == 0 {
 		return SampleReference{}, errors.New("ACL sample metadata must be greater than zero")
 	}

--- a/pkg/aclsampling/psample.go
+++ b/pkg/aclsampling/psample.go
@@ -1,0 +1,18 @@
+package aclsampling
+
+// PacketSample is an ACL sample received from the Linux psample generic
+// netlink family. Data contains the captured packet bytes and may be shorter
+// than OriginalSize.
+type PacketSample struct {
+	GroupID           uint32
+	Sequence          uint32
+	SampleRate        uint32
+	OriginalSize      uint32
+	IngressIfIndex    uint32
+	EgressIfIndex     uint32
+	Timestamp         uint64
+	Protocol          uint16
+	RateIsProbability bool
+	Reference         SampleReference
+	Data              []byte
+}

--- a/pkg/aclsampling/psample_linux.go
+++ b/pkg/aclsampling/psample_linux.go
@@ -48,8 +48,8 @@ var errNotACLPSample = errors.New("psample message is not an ACL sample")
 
 // ListenPSamples subscribes to the Linux psample packets multicast group and
 // invokes handle for each ACL sample emitted to groupID. Context cancellation
-// stops the blocking receive and returns nil.
-func ListenPSamples(ctx context.Context, groupID uint32, handle func(PacketSample) error) error {
+// stops the blocking receive.
+func ListenPSamples(ctx context.Context, groupID uint32, handle func(PacketSample) error) (retErr error) {
 	if ctx == nil {
 		return errors.New("psample context must not be nil")
 	}
@@ -74,17 +74,26 @@ func ListenPSamples(ctx context.Context, groupID uint32, handle func(PacketSampl
 		return fmt.Errorf("open psample generic netlink socket: %w", err)
 	}
 	if err := unix.SetsockoptInt(socket.GetFd(), unix.SOL_NETLINK, unix.NETLINK_ADD_MEMBERSHIP, int(multicastGroupID)); err != nil {
-		_ = socket.Close()
-		return fmt.Errorf("subscribe to psample packets multicast group: %w", err)
+		subscribeErr := fmt.Errorf("subscribe to psample packets multicast group: %w", err)
+		if closeErr := socket.Close(); closeErr != nil {
+			return errors.Join(subscribeErr, fmt.Errorf("close psample generic netlink socket: %w", closeErr))
+		}
+		return subscribeErr
 	}
 
 	var closeOnce sync.Once
+	var closeErr error
 	closeSocket := func() {
-		closeOnce.Do(func() { _ = socket.Close() })
+		closeOnce.Do(func() { closeErr = socket.Close() })
 	}
 	done := make(chan struct{})
 	defer close(done)
-	defer closeSocket()
+	defer func() {
+		closeSocket()
+		if closeErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("close psample generic netlink socket: %w", closeErr))
+		}
+	}()
 	go func() {
 		select {
 		case <-ctx.Done():

--- a/pkg/aclsampling/psample_linux.go
+++ b/pkg/aclsampling/psample_linux.go
@@ -46,10 +46,40 @@ const (
 
 var errNotACLPSample = errors.New("psample message is not an ACL sample")
 
+type psampleNetlinkSocket interface {
+	GetFd() int
+	Receive() ([]syscall.NetlinkMessage, *unix.SockaddrNetlink, error)
+	Close() error
+}
+
+type psampleNetlinkAPI interface {
+	family(string) (*netlink.GenlFamily, error)
+	subscribe(int) (psampleNetlinkSocket, error)
+	addMembership(int, uint32) error
+}
+
+type linuxPSampleNetlink struct{}
+
+func (linuxPSampleNetlink) family(name string) (*netlink.GenlFamily, error) {
+	return netlink.GenlFamilyGet(name)
+}
+
+func (linuxPSampleNetlink) subscribe(protocol int) (psampleNetlinkSocket, error) {
+	return nl.Subscribe(protocol)
+}
+
+func (linuxPSampleNetlink) addMembership(fd int, groupID uint32) error {
+	return unix.SetsockoptInt(fd, unix.SOL_NETLINK, unix.NETLINK_ADD_MEMBERSHIP, int(groupID))
+}
+
 // ListenPSamples subscribes to the Linux psample packets multicast group and
 // invokes handle for each ACL sample emitted to groupID. Context cancellation
 // stops the blocking receive.
-func ListenPSamples(ctx context.Context, groupID uint32, handle func(PacketSample) error) (retErr error) {
+func ListenPSamples(ctx context.Context, groupID uint32, handle func(PacketSample) error) error {
+	return listenPSamples(ctx, groupID, handle, linuxPSampleNetlink{})
+}
+
+func listenPSamples(ctx context.Context, groupID uint32, handle func(PacketSample) error, netlinkAPI psampleNetlinkAPI) (retErr error) {
 	if ctx == nil {
 		return errors.New("psample context must not be nil")
 	}
@@ -57,7 +87,7 @@ func ListenPSamples(ctx context.Context, groupID uint32, handle func(PacketSampl
 		return errors.New("psample handler must not be nil")
 	}
 
-	family, err := netlink.GenlFamilyGet(psampleFamilyName)
+	family, err := netlinkAPI.family(psampleFamilyName)
 	if err != nil {
 		return fmt.Errorf("get psample generic netlink family: %w", err)
 	}
@@ -69,11 +99,11 @@ func ListenPSamples(ctx context.Context, groupID uint32, handle func(PacketSampl
 		return err
 	}
 
-	socket, err := nl.Subscribe(unix.NETLINK_GENERIC)
+	socket, err := netlinkAPI.subscribe(unix.NETLINK_GENERIC)
 	if err != nil {
 		return fmt.Errorf("open psample generic netlink socket: %w", err)
 	}
-	if err := unix.SetsockoptInt(socket.GetFd(), unix.SOL_NETLINK, unix.NETLINK_ADD_MEMBERSHIP, int(multicastGroupID)); err != nil {
+	if err := netlinkAPI.addMembership(socket.GetFd(), multicastGroupID); err != nil {
 		subscribeErr := fmt.Errorf("subscribe to psample packets multicast group: %w", err)
 		if closeErr := socket.Close(); closeErr != nil {
 			return errors.Join(subscribeErr, fmt.Errorf("close psample generic netlink socket: %w", closeErr))
@@ -146,6 +176,8 @@ func packetSampleFromNetlinkMessage(message syscall.NetlinkMessage, familyID uin
 	switch message.Header.Type {
 	case unix.NLMSG_NOOP, unix.NLMSG_DONE:
 		return nil, false, nil
+	case unix.NLMSG_OVERRUN:
+		return nil, false, errors.New("psample netlink receive overrun: samples were lost")
 	case unix.NLMSG_ERROR:
 		if err := netlinkMessageError(message.Data); err != nil {
 			return nil, false, fmt.Errorf("psample generic netlink error: %w", err)
@@ -178,7 +210,11 @@ func parsePSampleMessage(message []byte) (*PacketSample, error) {
 	if message[1] != psampleVersion {
 		return nil, fmt.Errorf("unsupported psample message version %d", message[1])
 	}
-	attrs, err := nl.ParseRouteAttr(message[psampleGenericHeaderSize:])
+	attrData := message[psampleGenericHeaderSize:]
+	if err := validatePSampleAttributeStream(attrData); err != nil {
+		return nil, fmt.Errorf("validate psample attributes: %w", err)
+	}
+	attrs, err := nl.ParseRouteAttr(attrData)
 	if err != nil {
 		return nil, fmt.Errorf("parse psample attributes: %w", err)
 	}
@@ -187,37 +223,16 @@ func parsePSampleMessage(message []byte) (*PacketSample, error) {
 	seen := make(map[uint16]struct{}, len(attrs))
 	for _, attr := range attrs {
 		attrType := attr.Attr.Type & psampleNetlinkTypeMask
-		if _, ok := seen[attrType]; ok && isUniquePSampleAttribute(attrType) {
+		known, attrErr := parsePSampleAttribute(sample, attrType, attr.Value)
+		if !known {
+			continue
+		}
+		if _, ok := seen[attrType]; ok {
 			return nil, fmt.Errorf("psample attribute %d is duplicated", attrType)
 		}
 		seen[attrType] = struct{}{}
-
-		switch attrType {
-		case psampleAttrIngressIfIndex:
-			sample.IngressIfIndex, err = psampleIfIndex(attr.Value)
-		case psampleAttrEgressIfIndex:
-			sample.EgressIfIndex, err = psampleIfIndex(attr.Value)
-		case psampleAttrOriginalSize:
-			sample.OriginalSize, err = psampleUint32(attr.Value)
-		case psampleAttrSampleGroup:
-			sample.GroupID, err = psampleUint32(attr.Value)
-		case psampleAttrGroupSequence:
-			sample.Sequence, err = psampleUint32(attr.Value)
-		case psampleAttrSampleRate:
-			sample.SampleRate, err = psampleUint32(attr.Value)
-		case psampleAttrData:
-			sample.Data = append([]byte(nil), attr.Value...)
-		case psampleAttrTimestamp:
-			sample.Timestamp, err = psampleUint64(attr.Value)
-		case psampleAttrProtocol:
-			sample.Protocol, err = psampleUint16(attr.Value)
-		case psampleAttrUserCookie:
-			err = parsePSampleCookie(sample, attr.Value)
-		case psampleAttrSampleProbability:
-			sample.RateIsProbability = true
-		}
-		if err != nil {
-			return nil, fmt.Errorf("parse psample attribute %d: %w", attrType, err)
+		if attrErr != nil {
+			return nil, fmt.Errorf("parse psample attribute %d: %w", attrType, attrErr)
 		}
 	}
 	if _, ok := seen[psampleAttrSampleGroup]; !ok {
@@ -227,6 +242,59 @@ func parsePSampleMessage(message []byte) (*PacketSample, error) {
 		return nil, errNotACLPSample
 	}
 	return sample, nil
+}
+
+func validatePSampleAttributeStream(data []byte) error {
+	for len(data) != 0 {
+		if len(data) < unix.SizeofRtAttr {
+			return fmt.Errorf("%d trailing bytes do not form an attribute header", len(data))
+		}
+		length := int(nl.NativeEndian().Uint16(data[:2]))
+		if length < unix.SizeofRtAttr {
+			return fmt.Errorf("attribute length %d is shorter than its header", length)
+		}
+		alignedLength := (length + unix.SizeofRtAttr - 1) &^ (unix.SizeofRtAttr - 1)
+		if alignedLength > len(data) {
+			return fmt.Errorf("aligned attribute length %d exceeds %d remaining bytes", alignedLength, len(data))
+		}
+		data = data[alignedLength:]
+	}
+	return nil
+}
+
+func parsePSampleAttribute(sample *PacketSample, attrType uint16, value []byte) (bool, error) {
+	var err error
+	switch attrType {
+	case psampleAttrIngressIfIndex:
+		sample.IngressIfIndex, err = psampleIfIndex(value)
+	case psampleAttrEgressIfIndex:
+		sample.EgressIfIndex, err = psampleIfIndex(value)
+	case psampleAttrOriginalSize:
+		sample.OriginalSize, err = psampleUint32(value)
+	case psampleAttrSampleGroup:
+		sample.GroupID, err = psampleUint32(value)
+	case psampleAttrGroupSequence:
+		sample.Sequence, err = psampleUint32(value)
+	case psampleAttrSampleRate:
+		sample.SampleRate, err = psampleUint32(value)
+	case psampleAttrData:
+		sample.Data = append([]byte(nil), value...)
+	case psampleAttrTimestamp:
+		sample.Timestamp, err = psampleUint64(value)
+	case psampleAttrProtocol:
+		sample.Protocol, err = psampleUint16(value)
+	case psampleAttrUserCookie:
+		err = parsePSampleCookie(sample, value)
+	case psampleAttrSampleProbability:
+		if len(value) != 0 {
+			err = fmt.Errorf("expected flag with no value, got %d bytes", len(value))
+		} else {
+			sample.RateIsProbability = true
+		}
+	default:
+		return false, nil
+	}
+	return true, err
 }
 
 func parsePSampleCookie(sample *PacketSample, value []byte) error {
@@ -239,18 +307,6 @@ func parsePSampleCookie(sample *PacketSample, value []byte) error {
 	}
 	sample.Reference = reference
 	return nil
-}
-
-func isUniquePSampleAttribute(attrType uint16) bool {
-	switch attrType {
-	case psampleAttrIngressIfIndex, psampleAttrEgressIfIndex, psampleAttrOriginalSize,
-		psampleAttrSampleGroup, psampleAttrGroupSequence, psampleAttrSampleRate,
-		psampleAttrData, psampleAttrTimestamp, psampleAttrProtocol,
-		psampleAttrUserCookie, psampleAttrSampleProbability:
-		return true
-	default:
-		return false
-	}
 }
 
 func psampleIfIndex(value []byte) (uint32, error) {

--- a/pkg/aclsampling/psample_linux.go
+++ b/pkg/aclsampling/psample_linux.go
@@ -1,0 +1,292 @@
+//go:build linux
+
+package aclsampling
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	psampleFamilyName        = "psample"
+	psamplePacketsGroupName  = "packets"
+	psampleVersion           = 1
+	psampleCommandSample     = 0
+	psampleGenericHeaderSize = 4
+	psampleNetlinkTypeMask   = 0x3fff
+)
+
+const (
+	psampleAttrIngressIfIndex = iota
+	psampleAttrEgressIfIndex
+	psampleAttrOriginalSize
+	psampleAttrSampleGroup
+	psampleAttrGroupSequence
+	psampleAttrSampleRate
+	psampleAttrData
+	psampleAttrGroupRefcount
+	psampleAttrTunnel
+	psampleAttrPad
+	psampleAttrOutputTC
+	psampleAttrOutputTCOccupancy
+	psampleAttrLatency
+	psampleAttrTimestamp
+	psampleAttrProtocol
+	psampleAttrUserCookie
+	psampleAttrSampleProbability
+)
+
+var errNotACLPSample = errors.New("psample message is not an ACL sample")
+
+// ListenPSamples subscribes to the Linux psample packets multicast group and
+// invokes handle for each ACL sample emitted to groupID. Context cancellation
+// stops the blocking receive and returns nil.
+func ListenPSamples(ctx context.Context, groupID uint32, handle func(PacketSample) error) error {
+	if ctx == nil {
+		return errors.New("psample context must not be nil")
+	}
+	if handle == nil {
+		return errors.New("psample handler must not be nil")
+	}
+
+	family, err := netlink.GenlFamilyGet(psampleFamilyName)
+	if err != nil {
+		return fmt.Errorf("get psample generic netlink family: %w", err)
+	}
+	if family.Version != psampleVersion {
+		return fmt.Errorf("unsupported psample generic netlink version %d", family.Version)
+	}
+	multicastGroupID, err := psamplePacketsMulticastGroup(family)
+	if err != nil {
+		return err
+	}
+
+	socket, err := nl.Subscribe(unix.NETLINK_GENERIC)
+	if err != nil {
+		return fmt.Errorf("open psample generic netlink socket: %w", err)
+	}
+	if err := unix.SetsockoptInt(socket.GetFd(), unix.SOL_NETLINK, unix.NETLINK_ADD_MEMBERSHIP, int(multicastGroupID)); err != nil {
+		_ = socket.Close()
+		return fmt.Errorf("subscribe to psample packets multicast group: %w", err)
+	}
+
+	var closeOnce sync.Once
+	closeSocket := func() {
+		closeOnce.Do(func() { _ = socket.Close() })
+	}
+	done := make(chan struct{})
+	defer close(done)
+	defer closeSocket()
+	go func() {
+		select {
+		case <-ctx.Done():
+			closeSocket()
+		case <-done:
+		}
+	}()
+
+	for {
+		messages, sender, err := socket.Receive()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("receive psample generic netlink message: %w", err)
+		}
+		if sender == nil || sender.Pid != 0 {
+			continue
+		}
+		for _, message := range messages {
+			sample, ok, err := packetSampleFromNetlinkMessage(message, family.ID, groupID)
+			if err != nil {
+				return err
+			}
+			if ok {
+				if err := handle(*sample); err != nil {
+					return fmt.Errorf("handle ACL psample event: %w", err)
+				}
+			}
+		}
+	}
+}
+
+func psamplePacketsMulticastGroup(family *netlink.GenlFamily) (uint32, error) {
+	if family == nil {
+		return 0, errors.New("psample generic netlink family is nil")
+	}
+	for _, group := range family.Groups {
+		if group.Name == psamplePacketsGroupName {
+			if group.ID == 0 {
+				break
+			}
+			return group.ID, nil
+		}
+	}
+	return 0, errors.New("psample packets multicast group is unavailable")
+}
+
+func packetSampleFromNetlinkMessage(message syscall.NetlinkMessage, familyID uint16, groupID uint32) (*PacketSample, bool, error) {
+	switch message.Header.Type {
+	case unix.NLMSG_NOOP, unix.NLMSG_DONE:
+		return nil, false, nil
+	case unix.NLMSG_ERROR:
+		if err := netlinkMessageError(message.Data); err != nil {
+			return nil, false, fmt.Errorf("psample generic netlink error: %w", err)
+		}
+		return nil, false, nil
+	}
+	if message.Header.Type != familyID {
+		return nil, false, nil
+	}
+	sample, err := parsePSampleMessage(message.Data)
+	if errors.Is(err, errNotACLPSample) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("parse psample generic netlink message: %w", err)
+	}
+	if sample.GroupID != groupID {
+		return nil, false, nil
+	}
+	return sample, true, nil
+}
+
+func parsePSampleMessage(message []byte) (*PacketSample, error) {
+	if len(message) < psampleGenericHeaderSize {
+		return nil, errors.New("psample generic netlink header is truncated")
+	}
+	if message[0] != psampleCommandSample {
+		return nil, errNotACLPSample
+	}
+	if message[1] != psampleVersion {
+		return nil, fmt.Errorf("unsupported psample message version %d", message[1])
+	}
+	attrs, err := nl.ParseRouteAttr(message[psampleGenericHeaderSize:])
+	if err != nil {
+		return nil, fmt.Errorf("parse psample attributes: %w", err)
+	}
+
+	sample := &PacketSample{}
+	seen := make(map[uint16]struct{}, len(attrs))
+	for _, attr := range attrs {
+		attrType := attr.Attr.Type & psampleNetlinkTypeMask
+		if _, ok := seen[attrType]; ok && isUniquePSampleAttribute(attrType) {
+			return nil, fmt.Errorf("psample attribute %d is duplicated", attrType)
+		}
+		seen[attrType] = struct{}{}
+
+		switch attrType {
+		case psampleAttrIngressIfIndex:
+			sample.IngressIfIndex, err = psampleIfIndex(attr.Value)
+		case psampleAttrEgressIfIndex:
+			sample.EgressIfIndex, err = psampleIfIndex(attr.Value)
+		case psampleAttrOriginalSize:
+			sample.OriginalSize, err = psampleUint32(attr.Value)
+		case psampleAttrSampleGroup:
+			sample.GroupID, err = psampleUint32(attr.Value)
+		case psampleAttrGroupSequence:
+			sample.Sequence, err = psampleUint32(attr.Value)
+		case psampleAttrSampleRate:
+			sample.SampleRate, err = psampleUint32(attr.Value)
+		case psampleAttrData:
+			sample.Data = append([]byte(nil), attr.Value...)
+		case psampleAttrTimestamp:
+			sample.Timestamp, err = psampleUint64(attr.Value)
+		case psampleAttrProtocol:
+			sample.Protocol, err = psampleUint16(attr.Value)
+		case psampleAttrUserCookie:
+			err = parsePSampleCookie(sample, attr.Value)
+		case psampleAttrSampleProbability:
+			sample.RateIsProbability = true
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse psample attribute %d: %w", attrType, err)
+		}
+	}
+	if _, ok := seen[psampleAttrSampleGroup]; !ok {
+		return nil, errors.New("psample group ID is missing")
+	}
+	if _, ok := seen[psampleAttrUserCookie]; !ok {
+		return nil, errNotACLPSample
+	}
+	return sample, nil
+}
+
+func parsePSampleCookie(sample *PacketSample, value []byte) error {
+	if len(value) != 8 {
+		return errNotACLPSample
+	}
+	reference, err := sampleReferenceFromUint64(binary.BigEndian.Uint64(value))
+	if err != nil || reference.ApplicationID == nil {
+		return errNotACLPSample
+	}
+	sample.Reference = reference
+	return nil
+}
+
+func isUniquePSampleAttribute(attrType uint16) bool {
+	switch attrType {
+	case psampleAttrIngressIfIndex, psampleAttrEgressIfIndex, psampleAttrOriginalSize,
+		psampleAttrSampleGroup, psampleAttrGroupSequence, psampleAttrSampleRate,
+		psampleAttrData, psampleAttrTimestamp, psampleAttrProtocol,
+		psampleAttrUserCookie, psampleAttrSampleProbability:
+		return true
+	default:
+		return false
+	}
+}
+
+func psampleIfIndex(value []byte) (uint32, error) {
+	switch len(value) {
+	case 2:
+		return uint32(nl.NativeEndian().Uint16(value)), nil
+	case 4:
+		return nl.NativeEndian().Uint32(value), nil
+	default:
+		return 0, fmt.Errorf("expected a 2-byte or 4-byte interface index, got %d bytes", len(value))
+	}
+}
+
+func psampleUint16(value []byte) (uint16, error) {
+	if len(value) != 2 {
+		return 0, fmt.Errorf("expected 2 bytes, got %d", len(value))
+	}
+	return nl.NativeEndian().Uint16(value), nil
+}
+
+func psampleUint32(value []byte) (uint32, error) {
+	if len(value) != 4 {
+		return 0, fmt.Errorf("expected 4 bytes, got %d", len(value))
+	}
+	return nl.NativeEndian().Uint32(value), nil
+}
+
+func psampleUint64(value []byte) (uint64, error) {
+	if len(value) != 8 {
+		return 0, fmt.Errorf("expected 8 bytes, got %d", len(value))
+	}
+	return nl.NativeEndian().Uint64(value), nil
+}
+
+func netlinkMessageError(data []byte) error {
+	if len(data) < 4 {
+		return errors.New("netlink error payload is truncated")
+	}
+	// #nosec G115 -- NLMSG_ERROR stores a signed errno in two's-complement form.
+	code := int32(nl.NativeEndian().Uint32(data[:4]))
+	if code == 0 {
+		return nil
+	}
+	if code > 0 {
+		return fmt.Errorf("invalid positive netlink error code %d", code)
+	}
+	return syscall.Errno(-code)
+}

--- a/pkg/aclsampling/psample_linux_test.go
+++ b/pkg/aclsampling/psample_linux_test.go
@@ -6,8 +6,11 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
@@ -78,7 +81,10 @@ func TestParsePSampleMessageRejectsInvalidInput(t *testing.T) {
 		{name: "non OVN cookie", message: psampleMessageForTest(group, psampleAttributeForTest(psampleAttrUserCookie, []byte{0, 0, 0, 100, 0, 0, 0, 200})), notACLSample: true},
 		{name: "duplicate group", message: psampleMessageForTest(group, group, cookie)},
 		{name: "invalid group length", message: psampleMessageForTest(psampleAttributeForTest(psampleAttrSampleGroup, []byte{1}), cookie)},
-		{name: "malformed attribute", message: append([]byte{0, 1, 0, 0}, []byte{3, 0, 1, 0}...)},
+		{name: "malformed attribute", message: append([]byte{0, 1, 0, 0}, rawPSampleAttributeForTest(3, 1, nil)...)},
+		{name: "missing attribute padding", message: append([]byte{0, 1, 0, 0}, rawPSampleAttributeForTest(5, psampleAttrData, []byte{1})...)},
+		{name: "trailing attribute bytes", message: append(psampleMessageForTest(group, cookie), 0)},
+		{name: "probability flag with value", message: psampleMessageForTest(group, cookie, psampleAttributeForTest(psampleAttrSampleProbability, []byte{1}))},
 	}
 
 	for _, test := range tests {
@@ -129,6 +135,12 @@ func TestPacketSampleFromNetlinkMessageFiltersFamilyAndGroup(t *testing.T) {
 	}, familyID, 142)
 	require.ErrorIs(t, err, unix.EPERM)
 	require.False(t, ok)
+
+	_, ok, err = packetSampleFromNetlinkMessage(syscall.NetlinkMessage{
+		Header: syscall.NlMsghdr{Type: unix.NLMSG_OVERRUN},
+	}, familyID, 142)
+	require.ErrorContains(t, err, "samples were lost")
+	require.False(t, ok)
 }
 
 func TestPSamplePacketsMulticastGroup(t *testing.T) {
@@ -152,6 +164,116 @@ func TestListenPSamplesValidatesArguments(t *testing.T) {
 	require.Error(t, ListenPSamples(context.Background(), 0, nil))
 }
 
+func TestListenPSamplesReturnsSetupErrors(t *testing.T) {
+	t.Run("family discovery", func(t *testing.T) {
+		familyErr := errors.New("family failed")
+		netlinkAPI := newFakePSampleNetlink(nil)
+		netlinkAPI.familyErr = familyErr
+		err := listenPSamples(context.Background(), 142, func(PacketSample) error { return nil }, netlinkAPI)
+		require.ErrorIs(t, err, familyErr)
+	})
+
+	t.Run("socket subscribe", func(t *testing.T) {
+		subscribeErr := errors.New("subscribe failed")
+		netlinkAPI := newFakePSampleNetlink(nil)
+		netlinkAPI.subscribeErr = subscribeErr
+		err := listenPSamples(context.Background(), 142, func(PacketSample) error { return nil }, netlinkAPI)
+		require.ErrorIs(t, err, subscribeErr)
+	})
+}
+
+func TestListenPSamplesJoinsMembershipAndCloseErrors(t *testing.T) {
+	membershipErr := errors.New("membership failed")
+	closeErr := errors.New("close failed")
+	var closeCount atomic.Int32
+	socket := &fakePSampleSocket{closeFunc: func() error {
+		closeCount.Add(1)
+		return closeErr
+	}}
+	netlinkAPI := newFakePSampleNetlink(socket)
+	netlinkAPI.membershipErr = membershipErr
+
+	err := listenPSamples(context.Background(), 142, func(PacketSample) error { return nil }, netlinkAPI)
+	require.ErrorIs(t, err, membershipErr)
+	require.ErrorIs(t, err, closeErr)
+	require.Equal(t, int32(1), closeCount.Load())
+	require.Equal(t, uint32(42), netlinkAPI.membershipGroup)
+}
+
+func TestListenPSamplesJoinsReceiveAndCloseErrors(t *testing.T) {
+	closeErr := errors.New("close failed")
+	var closeCount atomic.Int32
+	socket := &fakePSampleSocket{
+		receiveFunc: func() ([]syscall.NetlinkMessage, *unix.SockaddrNetlink, error) {
+			return nil, nil, unix.EPERM
+		},
+		closeFunc: func() error {
+			closeCount.Add(1)
+			return closeErr
+		},
+	}
+
+	err := listenPSamples(context.Background(), 142, func(PacketSample) error { return nil }, newFakePSampleNetlink(socket))
+	require.ErrorIs(t, err, unix.EPERM)
+	require.ErrorIs(t, err, closeErr)
+	require.Equal(t, int32(1), closeCount.Load())
+}
+
+func TestListenPSamplesJoinsHandlerAndCloseErrors(t *testing.T) {
+	handleErr := errors.New("handler failed")
+	closeErr := errors.New("close failed")
+	var closeCount atomic.Int32
+	socket := &fakePSampleSocket{
+		receiveFunc: func() ([]syscall.NetlinkMessage, *unix.SockaddrNetlink, error) {
+			return []syscall.NetlinkMessage{validPSampleNetlinkMessageForTest(30, 142)}, &unix.SockaddrNetlink{}, nil
+		},
+		closeFunc: func() error {
+			closeCount.Add(1)
+			return closeErr
+		},
+	}
+
+	err := listenPSamples(context.Background(), 142, func(PacketSample) error { return handleErr }, newFakePSampleNetlink(socket))
+	require.ErrorIs(t, err, handleErr)
+	require.ErrorIs(t, err, closeErr)
+	require.Equal(t, int32(1), closeCount.Load())
+}
+
+func TestListenPSamplesCancellationClosesSocketOnce(t *testing.T) {
+	closeErr := errors.New("close failed")
+	receiveStarted := make(chan struct{})
+	socketClosed := make(chan struct{})
+	var receiveOnce sync.Once
+	var closeCount atomic.Int32
+	socket := &fakePSampleSocket{
+		receiveFunc: func() ([]syscall.NetlinkMessage, *unix.SockaddrNetlink, error) {
+			receiveOnce.Do(func() { close(receiveStarted) })
+			<-socketClosed
+			return nil, nil, unix.EBADF
+		},
+		closeFunc: func() error {
+			closeCount.Add(1)
+			close(socketClosed)
+			return closeErr
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- listenPSamples(ctx, 142, func(PacketSample) error { return nil }, newFakePSampleNetlink(socket))
+	}()
+	<-receiveStarted
+	cancel()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, closeErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("ListenPSamples did not stop after context cancellation")
+	}
+	require.Equal(t, int32(1), closeCount.Load())
+}
+
 func psampleMessageForTest(attrs ...[]byte) []byte {
 	message := []byte{psampleCommandSample, psampleVersion, 0, 0}
 	for _, attr := range attrs {
@@ -165,6 +287,14 @@ func psampleAttributeForTest(attrType uint16, value []byte) []byte {
 	alignedLength := (length + 3) &^ 3
 	attr := make([]byte, alignedLength)
 	nl.NativeEndian().PutUint16(attr[0:2], uint16(length))
+	nl.NativeEndian().PutUint16(attr[2:4], attrType)
+	copy(attr[unix.SizeofRtAttr:], value)
+	return attr
+}
+
+func rawPSampleAttributeForTest(length, attrType uint16, value []byte) []byte {
+	attr := make([]byte, unix.SizeofRtAttr+len(value))
+	nl.NativeEndian().PutUint16(attr[0:2], length)
 	nl.NativeEndian().PutUint16(attr[2:4], attrType)
 	copy(attr[unix.SizeofRtAttr:], value)
 	return attr
@@ -186,4 +316,66 @@ func nativeUint64ForTest(value uint64) []byte {
 	data := make([]byte, 8)
 	nl.NativeEndian().PutUint64(data, value)
 	return data
+}
+
+type fakePSampleSocket struct {
+	receiveFunc func() ([]syscall.NetlinkMessage, *unix.SockaddrNetlink, error)
+	closeFunc   func() error
+}
+
+func (*fakePSampleSocket) GetFd() int { return 10 }
+
+func (s *fakePSampleSocket) Receive() ([]syscall.NetlinkMessage, *unix.SockaddrNetlink, error) {
+	return s.receiveFunc()
+}
+
+func (s *fakePSampleSocket) Close() error {
+	return s.closeFunc()
+}
+
+type fakePSampleNetlink struct {
+	socket          psampleNetlinkSocket
+	familyErr       error
+	subscribeErr    error
+	membershipErr   error
+	membershipGroup uint32
+}
+
+func newFakePSampleNetlink(socket psampleNetlinkSocket) *fakePSampleNetlink {
+	return &fakePSampleNetlink{socket: socket}
+}
+
+func (f *fakePSampleNetlink) family(string) (*netlink.GenlFamily, error) {
+	if f.familyErr != nil {
+		return nil, f.familyErr
+	}
+	return &netlink.GenlFamily{
+		ID:      30,
+		Version: psampleVersion,
+		Groups:  []netlink.GenlMulticastGroup{{ID: 42, Name: psamplePacketsGroupName}},
+	}, nil
+}
+
+func (f *fakePSampleNetlink) subscribe(int) (psampleNetlinkSocket, error) {
+	if f.subscribeErr != nil {
+		return nil, f.subscribeErr
+	}
+	return f.socket, nil
+}
+
+func (f *fakePSampleNetlink) addMembership(_ int, groupID uint32) error {
+	f.membershipGroup = groupID
+	return f.membershipErr
+}
+
+func validPSampleNetlinkMessageForTest(familyID uint16, groupID uint32) syscall.NetlinkMessage {
+	cookie := make([]byte, 8)
+	binary.BigEndian.PutUint64(cookie, uint64(0x66000001)<<32|1)
+	return syscall.NetlinkMessage{
+		Header: syscall.NlMsghdr{Type: familyID},
+		Data: psampleMessageForTest(
+			psampleAttributeForTest(psampleAttrSampleGroup, nativeUint32ForTest(groupID)),
+			psampleAttributeForTest(psampleAttrUserCookie, cookie),
+		),
+	}
 }

--- a/pkg/aclsampling/psample_linux_test.go
+++ b/pkg/aclsampling/psample_linux_test.go
@@ -1,0 +1,189 @@
+//go:build linux
+
+package aclsampling
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+func TestParsePSampleMessage(t *testing.T) {
+	const (
+		applicationID = uint32(102)
+		datapathKey   = uint32(0x0abcde)
+		metadata      = uint32(0x12345678)
+	)
+	observationDomain := applicationID<<24 | datapathKey
+	cookie := make([]byte, 8)
+	binary.BigEndian.PutUint64(cookie, uint64(observationDomain)<<32|uint64(metadata))
+
+	message := psampleMessageForTest(
+		psampleAttributeForTest(psampleAttrIngressIfIndex, nativeUint16ForTest(12)),
+		psampleAttributeForTest(psampleAttrEgressIfIndex, nativeUint32ForTest(34)),
+		psampleAttributeForTest(psampleAttrOriginalSize, nativeUint32ForTest(128)),
+		psampleAttributeForTest(psampleAttrSampleGroup, nativeUint32ForTest(142)),
+		psampleAttributeForTest(psampleAttrGroupSequence, nativeUint32ForTest(7)),
+		psampleAttributeForTest(psampleAttrSampleRate, nativeUint32ForTest(0xffffffff)),
+		psampleAttributeForTest(psampleAttrData, []byte{1, 2, 3, 4}),
+		psampleAttributeForTest(psampleAttrTimestamp, nativeUint64ForTest(123456789)),
+		psampleAttributeForTest(psampleAttrProtocol, nativeUint16ForTest(0x0800)),
+		psampleAttributeForTest(psampleAttrUserCookie, cookie),
+		psampleAttributeForTest(psampleAttrSampleProbability, nil),
+		psampleAttributeForTest(100, []byte{9}),
+	)
+
+	sample, err := parsePSampleMessage(message)
+	require.NoError(t, err)
+	require.Equal(t, uint32(142), sample.GroupID)
+	require.Equal(t, uint32(7), sample.Sequence)
+	require.Equal(t, uint32(0xffffffff), sample.SampleRate)
+	require.Equal(t, uint32(128), sample.OriginalSize)
+	require.Equal(t, uint32(12), sample.IngressIfIndex)
+	require.Equal(t, uint32(34), sample.EgressIfIndex)
+	require.Equal(t, uint64(123456789), sample.Timestamp)
+	require.Equal(t, uint16(0x0800), sample.Protocol)
+	require.True(t, sample.RateIsProbability)
+	require.Equal(t, []byte{1, 2, 3, 4}, sample.Data)
+	require.Equal(t, observationDomain, *sample.Reference.ObservationDomain)
+	require.Equal(t, applicationID, *sample.Reference.ApplicationID)
+	require.Equal(t, datapathKey, *sample.Reference.DatapathKey)
+	require.Equal(t, metadata, sample.Reference.Metadata)
+}
+
+func TestParsePSampleMessageRejectsInvalidInput(t *testing.T) {
+	validCookie := make([]byte, 8)
+	binary.BigEndian.PutUint64(validCookie, uint64(0x66000001)<<32|1)
+	group := psampleAttributeForTest(psampleAttrSampleGroup, nativeUint32ForTest(142))
+	cookie := psampleAttributeForTest(psampleAttrUserCookie, validCookie)
+
+	tests := []struct {
+		name         string
+		message      []byte
+		notACLSample bool
+	}{
+		{name: "truncated header", message: []byte{0, 1}},
+		{name: "other command", message: append([]byte{1, 1, 0, 0}, group...), notACLSample: true},
+		{name: "other version", message: append(append([]byte{0, 2, 0, 0}, group...), cookie...)},
+		{name: "missing group", message: psampleMessageForTest(cookie)},
+		{name: "missing cookie", message: psampleMessageForTest(group), notACLSample: true},
+		{name: "short cookie", message: psampleMessageForTest(group, psampleAttributeForTest(psampleAttrUserCookie, []byte{1, 2, 3, 4})), notACLSample: true},
+		{name: "non OVN cookie", message: psampleMessageForTest(group, psampleAttributeForTest(psampleAttrUserCookie, []byte{0, 0, 0, 100, 0, 0, 0, 200})), notACLSample: true},
+		{name: "duplicate group", message: psampleMessageForTest(group, group, cookie)},
+		{name: "invalid group length", message: psampleMessageForTest(psampleAttributeForTest(psampleAttrSampleGroup, []byte{1}), cookie)},
+		{name: "malformed attribute", message: append([]byte{0, 1, 0, 0}, []byte{3, 0, 1, 0}...)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parsePSampleMessage(test.message)
+			require.Error(t, err)
+			require.Equal(t, test.notACLSample, errors.Is(err, errNotACLPSample))
+		})
+	}
+}
+
+func TestPacketSampleFromNetlinkMessageFiltersFamilyAndGroup(t *testing.T) {
+	const familyID = uint16(30)
+	cookie := make([]byte, 8)
+	binary.BigEndian.PutUint64(cookie, uint64(0x66000001)<<32|1)
+	payload := psampleMessageForTest(
+		psampleAttributeForTest(psampleAttrSampleGroup, nativeUint32ForTest(142)),
+		psampleAttributeForTest(psampleAttrUserCookie, cookie),
+	)
+
+	sample, ok, err := packetSampleFromNetlinkMessage(syscall.NetlinkMessage{
+		Header: syscall.NlMsghdr{Type: familyID},
+		Data:   payload,
+	}, familyID, 142)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(142), sample.GroupID)
+
+	_, ok, err = packetSampleFromNetlinkMessage(syscall.NetlinkMessage{
+		Header: syscall.NlMsghdr{Type: familyID},
+		Data:   payload,
+	}, familyID, 143)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, ok, err = packetSampleFromNetlinkMessage(syscall.NetlinkMessage{
+		Header: syscall.NlMsghdr{Type: familyID + 1},
+		Data:   payload,
+	}, familyID, 142)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	errorCode := -int32(unix.EPERM)
+	errorPayload := nativeUint32ForTest(uint32(errorCode))
+	_, ok, err = packetSampleFromNetlinkMessage(syscall.NetlinkMessage{
+		Header: syscall.NlMsghdr{Type: unix.NLMSG_ERROR},
+		Data:   errorPayload,
+	}, familyID, 142)
+	require.ErrorIs(t, err, unix.EPERM)
+	require.False(t, ok)
+}
+
+func TestPSamplePacketsMulticastGroup(t *testing.T) {
+	family := &netlink.GenlFamily{Groups: []netlink.GenlMulticastGroup{
+		{ID: 10, Name: "config"},
+		{ID: 42, Name: psamplePacketsGroupName},
+	}}
+	groupID, err := psamplePacketsMulticastGroup(family)
+	require.NoError(t, err)
+	require.Equal(t, uint32(42), groupID)
+
+	_, err = psamplePacketsMulticastGroup(&netlink.GenlFamily{})
+	require.Error(t, err)
+	_, err = psamplePacketsMulticastGroup(nil)
+	require.Error(t, err)
+}
+
+func TestListenPSamplesValidatesArguments(t *testing.T) {
+	//nolint:staticcheck // Explicitly verify nil context validation.
+	require.Error(t, ListenPSamples(nil, 0, func(PacketSample) error { return nil }))
+	require.Error(t, ListenPSamples(context.Background(), 0, nil))
+}
+
+func psampleMessageForTest(attrs ...[]byte) []byte {
+	message := []byte{psampleCommandSample, psampleVersion, 0, 0}
+	for _, attr := range attrs {
+		message = append(message, attr...)
+	}
+	return message
+}
+
+func psampleAttributeForTest(attrType uint16, value []byte) []byte {
+	length := unix.SizeofRtAttr + len(value)
+	alignedLength := (length + 3) &^ 3
+	attr := make([]byte, alignedLength)
+	nl.NativeEndian().PutUint16(attr[0:2], uint16(length))
+	nl.NativeEndian().PutUint16(attr[2:4], attrType)
+	copy(attr[unix.SizeofRtAttr:], value)
+	return attr
+}
+
+func nativeUint16ForTest(value uint16) []byte {
+	data := make([]byte, 2)
+	nl.NativeEndian().PutUint16(data, value)
+	return data
+}
+
+func nativeUint32ForTest(value uint32) []byte {
+	data := make([]byte, 4)
+	nl.NativeEndian().PutUint32(data, value)
+	return data
+}
+
+func nativeUint64ForTest(value uint64) []byte {
+	data := make([]byte, 8)
+	nl.NativeEndian().PutUint64(data, value)
+	return data
+}

--- a/pkg/aclsampling/psample_unsupported.go
+++ b/pkg/aclsampling/psample_unsupported.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package aclsampling
+
+import (
+	"context"
+	"errors"
+)
+
+// ListenPSamples is unavailable outside Linux because psample is a Linux
+// generic netlink family.
+func ListenPSamples(context.Context, uint32, func(PacketSample) error) error {
+	return errors.New("Linux psample is unsupported on this operating system")
+}


### PR DESCRIPTION
Related to #7146.

## Summary

- discover the Linux `psample` generic-netlink family and its `packets` multicast group at runtime
- subscribe with `NETLINK_ADD_MEMBERSHIP`, including multicast group IDs above the legacy 32-bit bind mask
- accept only kernel messages and filter events by the configured local psample group
- parse packet bytes, interface indexes, size, sequence, protocol, timestamp, and probability metadata
- decode the 8-byte big-endian OVS cookie into the OVN observation domain, application byte, datapath key, and ACL metadata
- stop blocking receives on context cancellation, propagate socket cleanup errors, and provide an explicit unsupported implementation outside Linux

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. **#7169 — Linux psample listener**
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-event-decode`

## Validation

- `go test ./pkg/aclsampling ./pkg/ovs -count=1`
- `go test -race ./pkg/aclsampling -count=1`
- `go vet ./pkg/aclsampling ./pkg/ovs`
- `git diff --check`
