### PR TITLE
feat: configure ACL sampling in v2 chart

### DIFF
--- a/charts/kube-ovn-v2/README.md
+++ b/charts/kube-ovn-v2/README.md
@@ -232,6 +232,107 @@ This README is generated using [helm-docs](https://github.com/norwoodj/helm-docs
 
 ## Values
 
+<h3>ACL sampling configuration</h3>
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td>aclSampling</td>
+			<td>object</td>
+			<td><pre lang="">
+"{}"
+</pre>
+</td>
+			<td>Experimental OVN ACL sampling for NetworkPolicy events.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.allowProbabilityPercent</td>
+			<td>int</td>
+			<td><pre lang="json">
+1
+</pre>
+</td>
+			<td>Sampling probability percentage for allowed decisions.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.appIDEstablished</td>
+			<td>int</td>
+			<td><pre lang="json">
+103
+</pre>
+</td>
+			<td>OVN sampling application ID for established ACL sessions.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.appIDNew</td>
+			<td>int</td>
+			<td><pre lang="json">
+102
+</pre>
+</td>
+			<td>OVN sampling application ID for new ACL sessions.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.collectorIDAllow</td>
+			<td>int</td>
+			<td><pre lang="json">
+1
+</pre>
+</td>
+			<td>OVN sample collector ID for allowed decisions.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.collectorIDDefaultDeny</td>
+			<td>int</td>
+			<td><pre lang="json">
+2
+</pre>
+</td>
+			<td>OVN sample collector ID for default-deny decisions.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.defaultDenyProbabilityPercent</td>
+			<td>int</td>
+			<td><pre lang="json">
+100
+</pre>
+</td>
+			<td>Sampling probability percentage for default-deny decisions.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.enabled</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Enable controller-side ACL sampling and node-local psample delivery.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.localGroupID</td>
+			<td>int</td>
+			<td><pre lang="json">
+142
+</pre>
+</td>
+			<td>Linux psample multicast group ID used for local delivery.</td>
+		</tr>
+		<tr>
+			<td>aclSampling.setID</td>
+			<td>int</td>
+			<td><pre lang="json">
+142
+</pre>
+</td>
+			<td>OVN sample collector set ID shared by controller and agents.</td>
+		</tr>
+	</tbody>
+</table>
 <h3>CNI agent configuration</h3>
 <table>
 	<thead>

--- a/charts/kube-ovn-v2/README.md
+++ b/charts/kube-ovn-v2/README.md
@@ -252,12 +252,12 @@ This README is generated using [helm-docs](https://github.com/norwoodj/helm-docs
 		</tr>
 		<tr>
 			<td>aclSampling.allowProbabilityPercent</td>
-			<td>int</td>
+			<td>float</td>
 			<td><pre lang="json">
 1
 </pre>
 </td>
-			<td>Sampling probability percentage for allowed decisions.</td>
+			<td>Sampling probability percentage for allowed decisions. Fractional percentages are supported.</td>
 		</tr>
 		<tr>
 			<td>aclSampling.appIDEstablished</td>
@@ -297,12 +297,12 @@ This README is generated using [helm-docs](https://github.com/norwoodj/helm-docs
 		</tr>
 		<tr>
 			<td>aclSampling.defaultDenyProbabilityPercent</td>
-			<td>int</td>
+			<td>float</td>
 			<td><pre lang="json">
 100
 </pre>
 </td>
-			<td>Sampling probability percentage for default-deny decisions.</td>
+			<td>Sampling probability percentage for default-deny decisions. Fractional percentages are supported.</td>
 		</tr>
 		<tr>
 			<td>aclSampling.enabled</td>

--- a/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/agent/agent-daemonset.yaml
@@ -152,6 +152,11 @@ spec:
           - --enable-ovn-ipsec={{- .Values.features.enableOvnIpsec }}
           - --host-tunnel-src={{- .Values.features.enableHostTunnelSrc | default false }}
           - --non-primary-cni-mode={{- .Values.cni.nonPrimaryCNI }}
+          {{- if .Values.aclSampling.enabled }}
+          - --enable-acl-sampling=true
+          - --acl-sampling-set-id={{- .Values.aclSampling.setID }}
+          - --acl-sampling-local-group-id={{- .Values.aclSampling.localGroupID }}
+          {{- end }}
         securityContext:
           runAsGroup: 0
           runAsUser: 0

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -144,6 +144,16 @@ spec:
           - --pod-nic-type={{- .Values.networking.podNicType }}
           - --enable-lb={{- .Values.features.enableLoadbalancer }}
           - --enable-np={{- .Values.features.enableNetworkPolicies }}
+          {{- if .Values.aclSampling.enabled }}
+          - --enable-acl-sampling=true
+          - --acl-sampling-set-id={{- .Values.aclSampling.setID }}
+          - --acl-sampling-app-id-new={{- .Values.aclSampling.appIDNew }}
+          - --acl-sampling-app-id-established={{- .Values.aclSampling.appIDEstablished }}
+          - --acl-sampling-collector-id-allow={{- .Values.aclSampling.collectorIDAllow }}
+          - --acl-sampling-collector-id-default-deny={{- .Values.aclSampling.collectorIDDefaultDeny }}
+          - --acl-sampling-allow-probability-percent={{- .Values.aclSampling.allowProbabilityPercent }}
+          - --acl-sampling-default-deny-probability-percent={{- .Values.aclSampling.defaultDenyProbabilityPercent }}
+          {{- end }}
           - --enable-eip-snat={{- .Values.networking.enableEipSnat }}
           {{- if .Values.networking.externalGatewayConfigNs }}
           - --external-gateway-config-ns={{- .Values.networking.externalGatewayConfigNs }}

--- a/charts/kube-ovn-v2/tests/acl_sampling_test.yaml
+++ b/charts/kube-ovn-v2/tests/acl_sampling_test.yaml
@@ -1,0 +1,94 @@
+suite: ACL sampling configuration (v2)
+templates:
+  - controller/controller-deployment.yaml
+  - agent/agent-daemonset.yaml
+tests:
+  - it: keeps ACL sampling disabled by default
+    template: controller/controller-deployment.yaml
+    set:
+      masterNodes:
+        - "10.0.0.1"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-acl-sampling=false
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-allow-probability-percent=1
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-default-deny-probability-percent=100
+
+  - it: omits agent ACL sampling flags by default
+    template: agent/agent-daemonset.yaml
+    set:
+      masterNodes:
+        - "10.0.0.1"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-acl-sampling=false
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-set-id=142
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-local-group-id=142
+
+  - it: renders controller ACL sampling overrides
+    template: controller/controller-deployment.yaml
+    set:
+      masterNodes:
+        - "10.0.0.1"
+      aclSampling.enabled: true
+      aclSampling.setID: 240
+      aclSampling.appIDNew: 104
+      aclSampling.appIDEstablished: 105
+      aclSampling.collectorIDAllow: 3
+      aclSampling.collectorIDDefaultDeny: 4
+      aclSampling.allowProbabilityPercent: 0.5
+      aclSampling.defaultDenyProbabilityPercent: 75
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-acl-sampling=true
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-set-id=240
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-app-id-new=104
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-app-id-established=105
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-collector-id-allow=3
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-collector-id-default-deny=4
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-allow-probability-percent=0.5
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-default-deny-probability-percent=75
+
+  - it: renders agent local ACL sampling overrides
+    template: agent/agent-daemonset.yaml
+    set:
+      masterNodes:
+        - "10.0.0.1"
+      aclSampling.enabled: true
+      aclSampling.setID: 240
+      aclSampling.localGroupID: 241
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-acl-sampling=true
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-set-id=240
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --acl-sampling-local-group-id=241

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -462,6 +462,38 @@ networkPolicies:
   # @section -- Network Policies
   enforcement: "standard"
 
+# -- Experimental OVN ACL sampling for NetworkPolicy events.
+# @section -- ACL sampling configuration
+# @default -- "{}"
+aclSampling:
+  # -- Enable controller-side ACL sampling and node-local psample delivery.
+  # @section -- ACL sampling configuration
+  enabled: false
+  # -- OVN sample collector set ID shared by controller and agents.
+  # @section -- ACL sampling configuration
+  setID: 142
+  # -- Linux psample multicast group ID used for local delivery.
+  # @section -- ACL sampling configuration
+  localGroupID: 142
+  # -- OVN sampling application ID for new ACL sessions.
+  # @section -- ACL sampling configuration
+  appIDNew: 102
+  # -- OVN sampling application ID for established ACL sessions.
+  # @section -- ACL sampling configuration
+  appIDEstablished: 103
+  # -- OVN sample collector ID for allowed decisions.
+  # @section -- ACL sampling configuration
+  collectorIDAllow: 1
+  # -- OVN sample collector ID for default-deny decisions.
+  # @section -- ACL sampling configuration
+  collectorIDDefaultDeny: 2
+  # -- Sampling probability percentage for allowed decisions.
+  # @section -- ACL sampling configuration
+  allowProbabilityPercent: 1
+  # -- Sampling probability percentage for default-deny decisions.
+  # @section -- ACL sampling configuration
+  defaultDenyProbabilityPercent: 100
+
 # -- API NetworkAttachmentDefinition to give some pods (CoreDNS, NAT GW) in custom VPCs access to the K8S API.
 # This requires Multus to be installed.
 # @section -- API Network Attachment Definition configuration

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -487,12 +487,12 @@ aclSampling:
   # -- OVN sample collector ID for default-deny decisions.
   # @section -- ACL sampling configuration
   collectorIDDefaultDeny: 2
-  # -- Sampling probability percentage for allowed decisions.
+  # -- Sampling probability percentage for allowed decisions. Fractional percentages are supported.
   # @section -- ACL sampling configuration
-  allowProbabilityPercent: 1
-  # -- Sampling probability percentage for default-deny decisions.
+  allowProbabilityPercent: 1.0
+  # -- Sampling probability percentage for default-deny decisions. Fractional percentages are supported.
   # @section -- ACL sampling configuration
-  defaultDenyProbabilityPercent: 100
+  defaultDenyProbabilityPercent: 100.0
 
 # -- API NetworkAttachmentDefinition to give some pods (CoreDNS, NAT GW) in custom VPCs access to the K8S API.
 # This requires Multus to be installed.


### PR DESCRIPTION
Related to #7146.

## Summary

- expose experimental ACL sampling settings through the recommended v2 Helm chart
- pass controller-side application, collector, set, and probability settings to `kube-ovn-controller`
- pass shared set ID and local psample group ID to the v2 CNI agent DaemonSet
- omit all new arguments while disabled so the chart remains installable with an older image
- keep the feature disabled by default with defaults matching the classic chart
- document probability values as fractional percentages and add focused Helm unit coverage for defaults and overrides

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. **#7171 — v2 chart configuration**
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-cli`

## Validation

- `helm unittest charts/kube-ovn-v2 -f tests/acl_sampling_test.yaml` (4 tests passed)
- `helm lint charts/kube-ovn-v2 --set masterNodes[0]=10.0.0.1`
- v2 `helm template` with ACL sampling enabled and default float values
- `helm-docs v1.14.2` output verification for probability field types
- `git diff --check`
