### PR TITLE
feat: configure ACL sampling in install script

### DIFF
--- a/dist/images/install-acl-sampling_test.sh
+++ b/dist/images/install-acl-sampling_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+INSTALL_SCRIPT="$SCRIPT_DIR/install.sh"
+
+assert_equal() {
+  local expected=$1
+  local actual=$2
+  if [ "$actual" != "$expected" ]; then
+    printf 'expected %q, got %q\n' "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_script_contains() {
+  local expected=$1
+  if ! grep -Fq -- "$expected" "$INSTALL_SCRIPT"; then
+    printf 'install.sh does not contain %q\n' "$expected" >&2
+    exit 1
+  fi
+}
+
+load_acl_sampling_config() {
+  eval "$(sed -n \
+    '/^ENABLE_ACL_SAMPLING=/,/^ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT=/p' \
+    "$INSTALL_SCRIPT")"
+}
+
+unset ENABLE_ACL_SAMPLING ACL_SAMPLING_SET_ID ACL_SAMPLING_LOCAL_GROUP_ID
+unset ACL_SAMPLING_APP_ID_NEW ACL_SAMPLING_APP_ID_ESTABLISHED
+unset ACL_SAMPLING_COLLECTOR_ID_ALLOW ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY
+unset ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT
+load_acl_sampling_config
+
+assert_equal false "$ENABLE_ACL_SAMPLING"
+assert_equal 142 "$ACL_SAMPLING_SET_ID"
+assert_equal 142 "$ACL_SAMPLING_LOCAL_GROUP_ID"
+assert_equal 102 "$ACL_SAMPLING_APP_ID_NEW"
+assert_equal 103 "$ACL_SAMPLING_APP_ID_ESTABLISHED"
+assert_equal 1 "$ACL_SAMPLING_COLLECTOR_ID_ALLOW"
+assert_equal 2 "$ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY"
+assert_equal 1 "$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT"
+assert_equal 100 "$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT"
+
+ENABLE_ACL_SAMPLING=true
+ACL_SAMPLING_SET_ID=240
+ACL_SAMPLING_LOCAL_GROUP_ID=241
+ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT=100
+ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT=25
+load_acl_sampling_config
+
+assert_equal true "$ENABLE_ACL_SAMPLING"
+assert_equal 240 "$ACL_SAMPLING_SET_ID"
+assert_equal 241 "$ACL_SAMPLING_LOCAL_GROUP_ID"
+assert_equal 100 "$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT"
+assert_equal 25 "$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT"
+
+for argument in \
+  '--enable-acl-sampling=$ENABLE_ACL_SAMPLING' \
+  '--acl-sampling-set-id=$ACL_SAMPLING_SET_ID' \
+  '--acl-sampling-local-group-id=$ACL_SAMPLING_LOCAL_GROUP_ID' \
+  '--acl-sampling-app-id-new=$ACL_SAMPLING_APP_ID_NEW' \
+  '--acl-sampling-app-id-established=$ACL_SAMPLING_APP_ID_ESTABLISHED' \
+  '--acl-sampling-collector-id-allow=$ACL_SAMPLING_COLLECTOR_ID_ALLOW' \
+  '--acl-sampling-collector-id-default-deny=$ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY' \
+  '--acl-sampling-allow-probability-percent=$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT' \
+  '--acl-sampling-default-deny-probability-percent=$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT'
+do
+  assert_script_contains "$argument"
+done
+
+echo 'install.sh ACL sampling tests passed'

--- a/dist/images/install-acl-sampling_test.sh
+++ b/dist/images/install-acl-sampling_test.sh
@@ -57,15 +57,15 @@ assert_equal 100 "$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT"
 assert_equal 25 "$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT"
 
 for argument in \
-  '--enable-acl-sampling=$ENABLE_ACL_SAMPLING' \
-  '--acl-sampling-set-id=$ACL_SAMPLING_SET_ID' \
-  '--acl-sampling-local-group-id=$ACL_SAMPLING_LOCAL_GROUP_ID' \
-  '--acl-sampling-app-id-new=$ACL_SAMPLING_APP_ID_NEW' \
-  '--acl-sampling-app-id-established=$ACL_SAMPLING_APP_ID_ESTABLISHED' \
-  '--acl-sampling-collector-id-allow=$ACL_SAMPLING_COLLECTOR_ID_ALLOW' \
-  '--acl-sampling-collector-id-default-deny=$ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY' \
-  '--acl-sampling-allow-probability-percent=$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT' \
-  '--acl-sampling-default-deny-probability-percent=$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT'
+  "--enable-acl-sampling=\$ENABLE_ACL_SAMPLING" \
+  "--acl-sampling-set-id=\$ACL_SAMPLING_SET_ID" \
+  "--acl-sampling-local-group-id=\$ACL_SAMPLING_LOCAL_GROUP_ID" \
+  "--acl-sampling-app-id-new=\$ACL_SAMPLING_APP_ID_NEW" \
+  "--acl-sampling-app-id-established=\$ACL_SAMPLING_APP_ID_ESTABLISHED" \
+  "--acl-sampling-collector-id-allow=\$ACL_SAMPLING_COLLECTOR_ID_ALLOW" \
+  "--acl-sampling-collector-id-default-deny=\$ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY" \
+  "--acl-sampling-allow-probability-percent=\$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT" \
+  "--acl-sampling-default-deny-probability-percent=\$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT"
 do
   assert_script_contains "$argument"
 done

--- a/dist/images/install-acl-sampling_test.sh
+++ b/dist/images/install-acl-sampling_test.sh
@@ -13,18 +13,62 @@ assert_equal() {
   fi
 }
 
-assert_script_contains() {
-  local expected=$1
-  if ! grep -Fq -- "$expected" "$INSTALL_SCRIPT"; then
-    printf 'install.sh does not contain %q\n' "$expected" >&2
-    exit 1
-  fi
-}
-
 load_acl_sampling_config() {
   eval "$(sed -n \
     '/^ENABLE_ACL_SAMPLING=/,/^ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT=/p' \
     "$INSTALL_SCRIPT")"
+}
+
+extract_container() {
+  local workload=$1
+  local container=$2
+  awk -v workload="$workload" -v container="$container" '
+    function indentation(line, spaces) {
+      spaces = line
+      sub(/[^ ].*$/, "", spaces)
+      return length(spaces)
+    }
+
+    /^---$/ {
+      in_workload = 0
+      capturing = 0
+    }
+    $0 == "  name: " workload {
+      in_workload = 1
+    }
+    in_workload && $0 ~ "^ *- name: " container "$" {
+      capturing = 1
+      container_indent = indentation($0)
+      print
+      next
+    }
+    capturing {
+      if ($0 != "" && indentation($0) <= container_indent) {
+        exit
+      }
+      print
+    }
+  ' "$INSTALL_SCRIPT"
+}
+
+render_acl_sampling_args() {
+  local workload=$1
+  local container=$2
+  local argument flag variable
+
+  while IFS= read -r argument; do
+    argument=${argument#*'- '}
+    flag=${argument%%=*}
+    variable=${argument#*=\$}
+    if [[ $variable != ACL_SAMPLING_* && $variable != ENABLE_ACL_SAMPLING ]]; then
+      printf 'unexpected ACL sampling argument %q\n' "$argument" >&2
+      exit 1
+    fi
+    printf '%s=%s\n' "$flag" "${!variable}"
+  done < <(
+    extract_container "$workload" "$container" |
+      grep -E -- '^[[:space:]]*- --.*acl-sampling.*=\$[A-Z_]+$'
+  )
 }
 
 unset ENABLE_ACL_SAMPLING ACL_SAMPLING_SET_ID ACL_SAMPLING_LOCAL_GROUP_ID
@@ -46,28 +90,45 @@ assert_equal 100 "$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT"
 ENABLE_ACL_SAMPLING=true
 ACL_SAMPLING_SET_ID=240
 ACL_SAMPLING_LOCAL_GROUP_ID=241
-ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT=100
-ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT=25
+ACL_SAMPLING_APP_ID_NEW=104
+ACL_SAMPLING_APP_ID_ESTABLISHED=105
+ACL_SAMPLING_COLLECTOR_ID_ALLOW=3
+ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY=4
+ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT=0.5
+ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT=75
 load_acl_sampling_config
 
 assert_equal true "$ENABLE_ACL_SAMPLING"
 assert_equal 240 "$ACL_SAMPLING_SET_ID"
 assert_equal 241 "$ACL_SAMPLING_LOCAL_GROUP_ID"
-assert_equal 100 "$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT"
-assert_equal 25 "$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT"
+assert_equal 104 "$ACL_SAMPLING_APP_ID_NEW"
+assert_equal 105 "$ACL_SAMPLING_APP_ID_ESTABLISHED"
+assert_equal 3 "$ACL_SAMPLING_COLLECTOR_ID_ALLOW"
+assert_equal 4 "$ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY"
+assert_equal 0.5 "$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT"
+assert_equal 75 "$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT"
 
-for argument in \
-  "--enable-acl-sampling=\$ENABLE_ACL_SAMPLING" \
-  "--acl-sampling-set-id=\$ACL_SAMPLING_SET_ID" \
-  "--acl-sampling-local-group-id=\$ACL_SAMPLING_LOCAL_GROUP_ID" \
-  "--acl-sampling-app-id-new=\$ACL_SAMPLING_APP_ID_NEW" \
-  "--acl-sampling-app-id-established=\$ACL_SAMPLING_APP_ID_ESTABLISHED" \
-  "--acl-sampling-collector-id-allow=\$ACL_SAMPLING_COLLECTOR_ID_ALLOW" \
-  "--acl-sampling-collector-id-default-deny=\$ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY" \
-  "--acl-sampling-allow-probability-percent=\$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT" \
-  "--acl-sampling-default-deny-probability-percent=\$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT"
-do
-  assert_script_contains "$argument"
-done
+expected_controller_args=$(cat <<'EOF'
+--enable-acl-sampling=true
+--acl-sampling-set-id=240
+--acl-sampling-app-id-new=104
+--acl-sampling-app-id-established=105
+--acl-sampling-collector-id-allow=3
+--acl-sampling-collector-id-default-deny=4
+--acl-sampling-allow-probability-percent=0.5
+--acl-sampling-default-deny-probability-percent=75
+EOF
+)
+actual_controller_args=$(render_acl_sampling_args kube-ovn-controller kube-ovn-controller)
+assert_equal "$expected_controller_args" "$actual_controller_args"
+
+expected_cni_args=$(cat <<'EOF'
+--enable-acl-sampling=true
+--acl-sampling-set-id=240
+--acl-sampling-local-group-id=241
+EOF
+)
+actual_cni_args=$(render_acl_sampling_args kube-ovn-cni cni-server)
+assert_equal "$expected_cni_args" "$actual_cni_args"
 
 echo 'install.sh ACL sampling tests passed'

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -22,6 +22,15 @@ HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_LB=${ENABLE_LB:-true}
 ENABLE_NP=${ENABLE_NP:-true}
 NP_ENFORCEMENT=${NP_ENFORCEMENT:-standard}
+ENABLE_ACL_SAMPLING=${ENABLE_ACL_SAMPLING:-false}
+ACL_SAMPLING_SET_ID=${ACL_SAMPLING_SET_ID:-142}
+ACL_SAMPLING_LOCAL_GROUP_ID=${ACL_SAMPLING_LOCAL_GROUP_ID:-142}
+ACL_SAMPLING_APP_ID_NEW=${ACL_SAMPLING_APP_ID_NEW:-102}
+ACL_SAMPLING_APP_ID_ESTABLISHED=${ACL_SAMPLING_APP_ID_ESTABLISHED:-103}
+ACL_SAMPLING_COLLECTOR_ID_ALLOW=${ACL_SAMPLING_COLLECTOR_ID_ALLOW:-1}
+ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY=${ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY:-2}
+ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT=${ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT:-1}
+ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT=${ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT:-100}
 ENABLE_EIP_SNAT=${ENABLE_EIP_SNAT:-true}
 LS_DNAT_MOD_DL_DST=${LS_DNAT_MOD_DL_DST:-true}
 LS_CT_SKIP_DST_LPORT_IPS=${LS_CT_SKIP_DST_LPORT_IPS:-true}
@@ -241,6 +250,7 @@ echo "Default Subnet CIDR:  $POD_CIDR"
 echo "Join Subnet CIDR:     $JOIN_CIDR"
 echo "Enable SVC LB:        $ENABLE_LB"
 echo "Enable Networkpolicy: $ENABLE_NP"
+echo "Enable ACL Sampling:  $ENABLE_ACL_SAMPLING"
 echo "Enable EIP and SNAT:  $ENABLE_EIP_SNAT"
 echo "Enable Mirror:        $ENABLE_MIRROR"
 echo "-------------------------------"
@@ -8878,6 +8888,14 @@ spec:
           - --enable-lb=$ENABLE_LB
           - --enable-np=$ENABLE_NP
           - --np-enforcement=$NP_ENFORCEMENT
+          - --enable-acl-sampling=$ENABLE_ACL_SAMPLING
+          - --acl-sampling-set-id=$ACL_SAMPLING_SET_ID
+          - --acl-sampling-app-id-new=$ACL_SAMPLING_APP_ID_NEW
+          - --acl-sampling-app-id-established=$ACL_SAMPLING_APP_ID_ESTABLISHED
+          - --acl-sampling-collector-id-allow=$ACL_SAMPLING_COLLECTOR_ID_ALLOW
+          - --acl-sampling-collector-id-default-deny=$ACL_SAMPLING_COLLECTOR_ID_DEFAULT_DENY
+          - --acl-sampling-allow-probability-percent=$ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT
+          - --acl-sampling-default-deny-probability-percent=$ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT
           - --enable-eip-snat=$ENABLE_EIP_SNAT
           - --enable-external-vpc=$ENABLE_EXTERNAL_VPC
           - --logtostderr=false
@@ -9104,6 +9122,9 @@ spec:
           - --cert-manager-issuer-name=$CERT_MANAGER_ISSUER_NAME
           - --set-vxlan-tx-off=$SET_VXLAN_TX_OFF
           - --host-tunnel-src=$HOST_TUNNEL_SRC
+          - --enable-acl-sampling=$ENABLE_ACL_SAMPLING
+          - --acl-sampling-set-id=$ACL_SAMPLING_SET_ID
+          - --acl-sampling-local-group-id=$ACL_SAMPLING_LOCAL_GROUP_ID
         securityContext:
           runAsUser: 0
           privileged: false

--- a/docs/acl-sampling.md
+++ b/docs/acl-sampling.md
@@ -66,6 +66,19 @@ Use `./charts/kube-ovn` instead to configure the classic chart. Keep the
 controller and CNI agent values identical across split or independently
 managed deployments.
 
+For the manifest-based installer, use the equivalent environment variables:
+
+```bash
+ENABLE_ACL_SAMPLING=true \
+ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT=1 \
+ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT=100 \
+bash dist/images/install.sh
+```
+
+The remaining variable names are the upper snake-case forms of the Helm
+fields, prefixed with `ACL_SAMPLING_`, for example
+`ACL_SAMPLING_LOCAL_GROUP_ID` and `ACL_SAMPLING_APP_ID_ESTABLISHED`.
+
 The configuration fields have the following semantics:
 
 | Field | Constraint | Purpose |


### PR DESCRIPTION
Related to #7146.

## Summary

- expose ACL sampling through the manifest-based `dist/images/install.sh` path used by Kind and CI jobs
- keep installer defaults aligned with both Helm charts and keep the feature disabled by default
- pass controller-side application, collector, set, and probability settings to `kube-ovn-controller`
- pass enabled flag, shared set ID, and local psample group ID to every CNI agent
- document equivalent installer environment variables
- add a shell regression test for defaults, overrides, and template argument wiring

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. **#7173 — manifest installer configuration**
15. #7174 — end-to-end coverage

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-docs`

## Validation

- `bash -n dist/images/install.sh dist/images/install-acl-sampling_test.sh`
- `bash dist/images/install-acl-sampling_test.sh`
- `shellcheck dist/images/install-acl-sampling_test.sh`
- `git diff --check`
