### PR TITLE
test: add ACL sampling end-to-end coverage

### DIFF
--- a/.github/e2e-selection.json
+++ b/.github/e2e-selection.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "expectedRunnerJobs": 84,
+  "expectedRunnerJobs": 85,
   "forceFull": false,
   "fullThreshold": 3,
   "productionPrefixes": ["cmd/", "fastpath/", "pkg/", "versions/"],
@@ -78,6 +78,12 @@
       "groups": ["policy"],
       "owner": "networking-e2e",
       "reason": "network policy reconciliation"
+    },
+    {
+      "patterns": ["pkg/aclsampling/**", "cmd/acl_sample/**", "hack/acl-sampling-e2e.sh", "dist/images/install.sh", "dist/images/kubectl-ko"],
+      "groups": ["policy"],
+      "owner": "networking-e2e",
+      "reason": "ACL sampling controller, node delivery, debug commands, and end-to-end coverage"
     },
     {
       "patterns": ["test/e2e/bgp/**", "pkg/speaker/**", "cmd/speaker/**"],
@@ -170,6 +176,7 @@
       "jobs": [
         {"id": "k8s-netpol-e2e", "matrix": {"ip-family": ["ipv4", "ipv6", "dual"], "np-enforcement": ["standard", "lax"]}},
         {"id": "cyclonus-netpol-e2e", "matrix": {"ip-family": ["ipv4", "ipv6", "dual"], "np-enforcement": ["standard", "lax"]}},
+        {"id": "acl-sampling-e2e"},
         {"id": "no-np-test"},
         {"id": "kube-ovn-cnp-domain-e2e", "matrix": {"ip-family": ["ipv4"], "mode": ["overlay"]}},
         {"id": "kube-ovn-anp-domain-e2e", "matrix": {"ip-family": ["ipv4"], "mode": ["overlay"]}}

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1111,6 +1111,87 @@ jobs:
             fi;
           done
 
+  acl-sampling-e2e:
+    name: ACL Sampling E2E
+    if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'acl-sampling-e2e')
+    needs:
+      - e2e-selection
+      - prepare-kind-node-images
+      - build-kube-ovn
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.EXECUTION_SHA }}
+          persist-credentials: false
+
+      - name: Install kind
+        uses: helm/kind-action@v1.14.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          install_only: true
+
+      - name: Download image
+        uses: actions/download-artifact@v8
+        with:
+          name: kube-ovn
+
+      - name: Load image
+        run: docker load --input kube-ovn.tar
+
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
+      - name: Create kind cluster
+        run: |
+          pipx install jinjanator
+          make kind-init-ipv4
+
+      - name: Install Kube-OVN with deterministic ACL sampling
+        id: install
+        env:
+          ENABLE_ACL_SAMPLING: "true"
+          ACL_SAMPLING_ALLOW_PROBABILITY_PERCENT: "100"
+          ACL_SAMPLING_DEFAULT_DENY_PROBABILITY_PERCENT: "100"
+        run: make kind-install-ipv4
+
+      - name: Verify sampled NetworkPolicy decisions
+        id: e2e
+        run: bash hack/acl-sampling-e2e.sh
+
+      - name: Collect diagnostics
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        run: |
+          kubectl get events -A -o yaml > acl-sampling-e2e-events.yaml
+          kubectl get pods -A -o wide > acl-sampling-e2e-pods.txt
+          make kubectl-ko-log
+
+      - name: Upload diagnostics
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        uses: actions/upload-artifact@v7
+        with:
+          name: acl-sampling-e2e-diagnostics
+          path: |
+            acl-sampling-e2e-events.yaml
+            acl-sampling-e2e-pods.txt
+            kubectl-ko-log/
+
   k8s-netpol-e2e:
     name: Kubernetes Network Policy E2E
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-netpol-e2e')

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1175,15 +1175,23 @@ jobs:
         id: e2e
         run: bash hack/acl-sampling-e2e.sh
 
-      - name: Collect diagnostics
-        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
-        run: |
-          kubectl get events -A -o yaml > acl-sampling-e2e-events.yaml
-          kubectl get pods -A -o wide > acl-sampling-e2e-pods.txt
-          make kubectl-ko-log
+      - name: Collect events
+        if: always() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        continue-on-error: true
+        run: kubectl get events -A -o yaml > acl-sampling-e2e-events.yaml
+
+      - name: Collect pod status
+        if: always() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        continue-on-error: true
+        run: kubectl get pods -A -o wide > acl-sampling-e2e-pods.txt
+
+      - name: Collect kubectl ko log
+        if: always() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        continue-on-error: true
+        run: make kubectl-ko-log
 
       - name: Upload diagnostics
-        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        if: always() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
         uses: actions/upload-artifact@v7
         with:
           name: acl-sampling-e2e-diagnostics

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1119,7 +1119,7 @@ jobs:
       - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: jlumbroso/free-disk-space@v1.3.1
         with:
@@ -1190,6 +1190,8 @@ jobs:
           path: |
             acl-sampling-e2e-events.yaml
             acl-sampling-e2e-pods.txt
+            acl-sampling-e2e-listener.out
+            acl-sampling-e2e-listener.err
             kubectl-ko-log/
 
   k8s-netpol-e2e:

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -36,7 +36,9 @@ cleanup() {
     wait "$LISTENER_PID" 2>/dev/null || true
   fi
   if [ "$DATAPATH_CAPABILITY_OVERRIDDEN" = true ] && [ -n "$NODE_NAME" ] && [ -n "$DATAPATH_UUID" ]; then
-    kubectl ko vsctl "$NODE_NAME" set Datapath "$DATAPATH_UUID" capabilities:psample=true >/dev/null 2>&1 || true
+    if ! kubectl ko vsctl "$NODE_NAME" set Datapath "$DATAPATH_UUID" capabilities:psample=true >/dev/null; then
+      echo "failed to restore psample capability on node $NODE_NAME" >&2
+    fi
   fi
   if [ -n "$CONFLICT_COLLECTOR_UUID" ]; then
     if ! restore_controller_collector_ownership >/dev/null 2>&1; then

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="acl-sampling-e2e-${RANDOM}"
+SAMPLE_OUTPUT=$(mktemp)
+LISTENER_LOG=$(mktemp)
+LISTENER_PID=""
+POLICY_NAME=acl-sampling
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if [ -n "$LISTENER_PID" ]; then
+    kill "$LISTENER_PID" 2>/dev/null || true
+    wait "$LISTENER_PID" 2>/dev/null || true
+  fi
+  if [ "$status" -ne 0 ]; then
+    echo 'ACL sample listener standard output:' >&2
+    sed -n '1,240p' "$SAMPLE_OUTPUT" >&2
+    echo 'ACL sample listener standard error:' >&2
+    sed -n '1,240p' "$LISTENER_LOG" >&2
+  fi
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  rm -f "$SAMPLE_OUTPUT" "$LISTENER_LOG"
+  exit "$status"
+}
+trap cleanup EXIT
+
+wait_for() {
+  local description=$1
+  local timeout_seconds=$2
+  shift 2
+  local deadline=$((SECONDS + timeout_seconds))
+  until "$@"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "timed out waiting for $description" >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+sampling_references_ready() {
+  local rows
+  rows=$(kubectl ko nbctl --format=csv --data=bare --no-heading \
+    --columns=action,sample_new,sample_est find ACL \
+    "external_ids:kube-ovn.io/policy-uid=$POLICY_UID")
+  grep -Eq 'allow-related.*[[:xdigit:]]{8}-.*[[:xdigit:]]{8}-' <<< "$rows" &&
+    grep -Eq 'drop.*[[:xdigit:]]{8}-' <<< "$rows"
+}
+
+has_sample_document() {
+  local verdict=$1
+  local application=$2
+  local extra=$3
+  awk -v verdict="verdict: $verdict" -v application="app: $application" \
+    -v uid="uid: $POLICY_UID" -v extra="$extra" '
+      BEGIN { RS = "---" }
+      index($0, verdict) && index($0, application) && index($0, uid) && index($0, extra) { found = 1 }
+      END { exit !found }
+    ' "$SAMPLE_OUTPUT"
+}
+
+expected_samples_ready() {
+  has_sample_document allow acl-new 'ruleIndex: 0' &&
+    has_sample_document allow acl-est 'ruleIndex: 0' &&
+    has_sample_document default-deny acl-new 'attribution: non-exclusive'
+}
+
+disable_acl_sampling() {
+  local resource=$1
+  local name=$2
+  local container_name=$3
+  local container_index argument_index
+  container_index=$(kubectl get "$resource" -n kube-system "$name" -o json |
+    jq --arg name "$container_name" '.spec.template.spec.containers | map(.name) | index($name)')
+  if [ "$container_index" = "null" ]; then
+    echo "cannot locate container $container_name in $resource/$name" >&2
+    return 1
+  fi
+  argument_index=$(kubectl get "$resource" -n kube-system "$name" -o json |
+    jq --argjson index "$container_index" \
+      '.spec.template.spec.containers[$index].args | index("--enable-acl-sampling=true")')
+  if [ "$argument_index" = "null" ]; then
+    echo "cannot locate the enabled ACL sampling argument in $resource/$name" >&2
+    return 1
+  fi
+
+  kubectl patch "$resource" -n kube-system "$name" --type=json -p="[{
+    \"op\": \"replace\",
+    \"path\": \"/spec/template/spec/containers/$container_index/args/$argument_index\",
+    \"value\": \"--enable-acl-sampling=false\"
+  }]"
+}
+
+sampling_cleanup_complete() {
+  local sampled_acls applications collectors node_sets
+  sampled_acls=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
+    find ACL 'external_ids:kube-ovn.io/sample-feature=network-policy')
+  applications=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
+    find Sampling_App 'external_ids:kube-ovn.io/feature=acl-sampling')
+  collectors=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
+    find Sample_Collector 'external_ids:kube-ovn.io/feature=acl-sampling')
+  node_sets=$(kubectl ko vsctl "$NODE_NAME" --data=bare --no-heading --columns=_uuid \
+    find Flow_Sample_Collector_Set 'external_ids:kube-ovn.io/feature=acl-sampling')
+  [ -z "$sampled_acls" ] && [ -z "$applications" ] &&
+    [ -z "$collectors" ] && [ -z "$node_sets" ]
+}
+
+NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+if [ -z "$NODE_NAME" ]; then
+  echo 'no Kubernetes node is available for ACL sampling E2E' >&2
+  exit 1
+fi
+
+kubectl create namespace "$NAMESPACE"
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: $NAMESPACE
+  name: target
+  labels:
+    app: target
+spec:
+  nodeName: $NODE_NAME
+  containers:
+    - name: agnhost
+      image: ghcr.io/kubeovn/agnhost:2.47
+      args: ["netexec", "--http-port=8080"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: $NAMESPACE
+  name: allowed
+  labels:
+    access: allowed
+spec:
+  nodeName: $NODE_NAME
+  containers:
+    - name: agnhost
+      image: ghcr.io/kubeovn/agnhost:2.47
+      args: ["pause"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: $NAMESPACE
+  name: denied
+  labels:
+    access: denied
+spec:
+  nodeName: $NODE_NAME
+  containers:
+    - name: agnhost
+      image: ghcr.io/kubeovn/agnhost:2.47
+      args: ["pause"]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: $NAMESPACE
+  name: $POLICY_NAME
+spec:
+  podSelector:
+    matchLabels:
+      app: target
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              access: allowed
+      ports:
+        - protocol: TCP
+          port: 8080
+EOF
+
+kubectl wait -n "$NAMESPACE" --for=condition=Ready pod/target pod/allowed pod/denied --timeout=2m
+POLICY_UID=$(kubectl get networkpolicy -n "$NAMESPACE" "$POLICY_NAME" -o jsonpath='{.metadata.uid}')
+TARGET_IP=$(kubectl get pod -n "$NAMESPACE" target -o jsonpath='{.status.podIP}')
+if [[ "$TARGET_IP" == *:* ]]; then
+  TARGET_ENDPOINT="[$TARGET_IP]:8080"
+else
+  TARGET_ENDPOINT="$TARGET_IP:8080"
+fi
+
+wait_for 'NetworkPolicy ACL sampling references' 90 sampling_references_ready
+
+timeout 90s kubectl ko acl-sample listen --node "$NODE_NAME" >"$SAMPLE_OUTPUT" 2>"$LISTENER_LOG" &
+LISTENER_PID=$!
+sleep 3
+if ! kill -0 "$LISTENER_PID" 2>/dev/null; then
+  echo 'ACL sample listener exited before traffic generation' >&2
+  exit 1
+fi
+
+for _ in $(seq 1 10); do
+  kubectl exec -n "$NAMESPACE" allowed -- \
+    /agnhost connect --timeout=3s "$TARGET_ENDPOINT"
+done
+
+for _ in $(seq 1 3); do
+  if kubectl exec -n "$NAMESPACE" denied -- \
+    /agnhost connect --timeout=2s "$TARGET_ENDPOINT"; then
+    echo 'default-denied client unexpectedly reached the target Pod' >&2
+    exit 1
+  fi
+done
+
+wait_for 'decoded acl-new, acl-est, and default-deny samples' 45 expected_samples_ready
+
+kill "$LISTENER_PID" 2>/dev/null || true
+wait "$LISTENER_PID" 2>/dev/null || true
+LISTENER_PID=""
+
+disable_acl_sampling deployment kube-ovn-controller kube-ovn-controller
+disable_acl_sampling daemonset kube-ovn-cni cni-server
+kubectl rollout status deployment/kube-ovn-controller -n kube-system --timeout=2m
+kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout=2m
+wait_for 'owned controller and node ACL sampling state cleanup' 90 sampling_cleanup_complete
+
+echo 'ACL sampling E2E passed'

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -151,7 +151,8 @@ controller_sampling_failure_observed() {
   kubectl logs -n kube-system -l app=kube-ovn-controller -c kube-ovn-controller \
     --since=5m --tail=1000 2>/dev/null |
     awk -v key="$NAMESPACE/sampling-failure" '
-      index($0, "error syncing sample network policy ACL \"" key "\"") &&
+      index($0, "error syncing sample network policy ACL") &&
+        index($0, key) &&
         index($0, "sample collector ID 1 is owned by another application") { found = 1 }
       END { exit !found }
     '

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -308,12 +308,13 @@ kill "$LISTENER_PID" 2>/dev/null || true
 wait "$LISTENER_PID" 2>/dev/null || true
 LISTENER_PID=""
 
-CONFLICT_COLLECTOR_UUID=$(kubectl ko nbctl create Sample_Collector \
-  id=1 set_id=142 probability=65535 name=acl-sampling-e2e-conflict)
+CONFLICT_COLLECTOR_UUID=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
+  find Sample_Collector id=1 'external_ids:kube-ovn.io/feature=acl-sampling')
 if [ -z "$CONFLICT_COLLECTOR_UUID" ]; then
-  echo 'failed to create the unowned controller sampling conflict' >&2
+  echo 'cannot locate the owned controller sampling collector to inject a conflict' >&2
   exit 1
 fi
+kubectl ko nbctl clear Sample_Collector "$CONFLICT_COLLECTOR_UUID" external_ids
 kubectl rollout restart deployment/kube-ovn-controller -n kube-system
 kubectl rollout status deployment/kube-ovn-controller -n kube-system --timeout=2m
 

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -14,6 +14,18 @@ NODE_NAME=""
 : >"$SAMPLE_OUTPUT"
 : >"$LISTENER_LOG"
 
+restore_controller_collector_ownership() {
+  if [ -z "$CONFLICT_COLLECTOR_UUID" ]; then
+    return
+  fi
+  kubectl ko nbctl set Sample_Collector "$CONFLICT_COLLECTOR_UUID" \
+    external_ids:vendor=kube-ovn \
+    'external_ids:kube-ovn.io/feature=acl-sampling' \
+    'external_ids:kube-ovn.io/acl-sampling-kind=collector' \
+    'external_ids:kube-ovn.io/acl-sampling-role=allow'
+  CONFLICT_COLLECTOR_UUID=""
+}
+
 cleanup() {
   local status=$?
   trap - EXIT
@@ -25,7 +37,7 @@ cleanup() {
     kubectl ko vsctl "$NODE_NAME" set Datapath "$DATAPATH_UUID" capabilities:psample=true >/dev/null 2>&1 || true
   fi
   if [ -n "$CONFLICT_COLLECTOR_UUID" ]; then
-    kubectl ko nbctl destroy Sample_Collector "$CONFLICT_COLLECTOR_UUID" >/dev/null 2>&1 || true
+    restore_controller_collector_ownership >/dev/null 2>&1 || true
   fi
   if [ "$status" -ne 0 ]; then
     echo 'ACL sample listener standard output:' >&2
@@ -370,8 +382,7 @@ wait_for 'sampling references to remain absent after the injected failure' 30 \
   policy_sampling_references_absent "$FAILURE_PORT_GROUP"
 verify_policy_connectivity "$FAILURE_TARGET_ENDPOINT"
 
-kubectl ko nbctl destroy Sample_Collector "$CONFLICT_COLLECTOR_UUID"
-CONFLICT_COLLECTOR_UUID=""
+restore_controller_collector_ownership
 wait_for 'sampling-only retry after controller failure' 90 sampling_references_ready "$FAILURE_POLICY_UID"
 
 NODE_COLLECTOR_UUID=$(node_collector_set_uuids | sed -n '1p')

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -18,11 +18,13 @@ restore_controller_collector_ownership() {
   if [ -z "$CONFLICT_COLLECTOR_UUID" ]; then
     return
   fi
-  kubectl ko nbctl set Sample_Collector "$CONFLICT_COLLECTOR_UUID" \
+  if ! kubectl ko nbctl set Sample_Collector "$CONFLICT_COLLECTOR_UUID" \
     external_ids:vendor=kube-ovn \
     'external_ids:kube-ovn.io/feature=acl-sampling' \
     'external_ids:kube-ovn.io/acl-sampling-kind=collector' \
-    'external_ids:kube-ovn.io/acl-sampling-role=allow'
+    'external_ids:kube-ovn.io/acl-sampling-role=allow'; then
+    return 1
+  fi
   CONFLICT_COLLECTOR_UUID=""
 }
 
@@ -37,7 +39,9 @@ cleanup() {
     kubectl ko vsctl "$NODE_NAME" set Datapath "$DATAPATH_UUID" capabilities:psample=true >/dev/null 2>&1 || true
   fi
   if [ -n "$CONFLICT_COLLECTOR_UUID" ]; then
-    restore_controller_collector_ownership >/dev/null 2>&1 || true
+    if ! restore_controller_collector_ownership >/dev/null 2>&1; then
+      echo 'failed to restore ACL sampling collector ownership' >&2
+    fi
   fi
   if [ "$status" -ne 0 ]; then
     echo 'ACL sample listener standard output:' >&2

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NAMESPACE="acl-sampling-e2e-${RANDOM}"
-SAMPLE_OUTPUT=$(mktemp)
-LISTENER_LOG=$(mktemp)
+NAMESPACE="acl-sampling-e2e-${GITHUB_RUN_ID:-$RANDOM}-${RANDOM}"
+NAMESPACE_CREATED=false
+SAMPLE_OUTPUT=acl-sampling-e2e-listener.out
+LISTENER_LOG=acl-sampling-e2e-listener.err
 LISTENER_PID=""
 POLICY_NAME=acl-sampling
+CONFLICT_COLLECTOR_UUID=""
+DATAPATH_UUID=""
+DATAPATH_CAPABILITY_OVERRIDDEN=false
+NODE_NAME=""
+: >"$SAMPLE_OUTPUT"
+: >"$LISTENER_LOG"
 
 cleanup() {
   local status=$?
@@ -14,14 +21,23 @@ cleanup() {
     kill "$LISTENER_PID" 2>/dev/null || true
     wait "$LISTENER_PID" 2>/dev/null || true
   fi
+  if [ "$DATAPATH_CAPABILITY_OVERRIDDEN" = true ] && [ -n "$NODE_NAME" ] && [ -n "$DATAPATH_UUID" ]; then
+    kubectl ko vsctl "$NODE_NAME" set Datapath "$DATAPATH_UUID" capabilities:psample=true >/dev/null 2>&1 || true
+  fi
+  if [ -n "$CONFLICT_COLLECTOR_UUID" ]; then
+    kubectl ko nbctl destroy Sample_Collector "$CONFLICT_COLLECTOR_UUID" >/dev/null 2>&1 || true
+  fi
   if [ "$status" -ne 0 ]; then
     echo 'ACL sample listener standard output:' >&2
     sed -n '1,240p' "$SAMPLE_OUTPUT" >&2
     echo 'ACL sample listener standard error:' >&2
     sed -n '1,240p' "$LISTENER_LOG" >&2
+  else
+    rm -f "$SAMPLE_OUTPUT" "$LISTENER_LOG"
   fi
-  kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
-  rm -f "$SAMPLE_OUTPUT" "$LISTENER_LOG"
+  if [ "$NAMESPACE_CREATED" = true ]; then
+    kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  fi
   exit "$status"
 }
 trap cleanup EXIT
@@ -41,12 +57,17 @@ wait_for() {
 }
 
 sampling_references_ready() {
+  local policy_uid=$1
   local rows
   rows=$(kubectl ko nbctl --format=csv --data=bare --no-heading \
     --columns=action,sample_new,sample_est find ACL \
-    "external_ids:kube-ovn.io/policy-uid=$POLICY_UID")
-  grep -Eq 'allow-related.*[[:xdigit:]]{8}-.*[[:xdigit:]]{8}-' <<< "$rows" &&
-    grep -Eq 'drop.*[[:xdigit:]]{8}-' <<< "$rows"
+    "external_ids:kube-ovn.io/policy-uid=$policy_uid")
+  awk -F, '
+    $1 == "allow-related" && $2 ~ /^[[:xdigit:]]{8}-/ && $3 ~ /^[[:xdigit:]]{8}-/ { allow = 1 }
+    $1 == "drop" && $2 ~ /^[[:xdigit:]]{8}-/ && ($3 == "" || $3 == "[]") { default_deny = 1 }
+    $1 == "drop" && $3 != "" && $3 != "[]" { invalid_default_deny = 1 }
+    END { exit !(allow && default_deny && !invalid_default_deny) }
+  ' <<< "$rows"
 }
 
 has_sample_document() {
@@ -65,6 +86,95 @@ expected_samples_ready() {
   has_sample_document allow acl-new 'ruleIndex: 0' &&
     has_sample_document allow acl-est 'ruleIndex: 0' &&
     has_sample_document default-deny acl-new 'attribution: non-exclusive'
+}
+
+wait_for_expected_samples() {
+  local deadline=$((SECONDS + 60))
+  while ! expected_samples_ready; do
+    if ! kill -0 "$LISTENER_PID" 2>/dev/null; then
+      echo 'ACL sample listener exited before all expected samples arrived' >&2
+      return 1
+    fi
+    for _ in $(seq 1 3); do
+      kubectl exec -n "$NAMESPACE" allowed -- \
+        /agnhost connect --timeout=3s "$TARGET_ENDPOINT"
+    done
+    if kubectl exec -n "$NAMESPACE" denied -- \
+      /agnhost connect --timeout=2s "$TARGET_ENDPOINT"; then
+      echo 'default-denied client unexpectedly reached the target Pod' >&2
+      return 1
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo 'timed out waiting for decoded acl-new, acl-est, and default-deny samples' >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+policy_enforcement_acls_ready() {
+  local policy_parent=$1
+  local actions
+  actions=$(kubectl ko nbctl --data=bare --no-heading --columns=action find ACL \
+    "external_ids:parent=$policy_parent")
+  grep -Fxq allow-related <<< "$actions" && grep -Fxq drop <<< "$actions"
+}
+
+policy_sampling_references_absent() {
+  local policy_parent=$1
+  local references
+  references=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid find ACL \
+    "external_ids:parent=$policy_parent" 'sample_new!=[]')
+  [ -z "$references" ] || return 1
+  references=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid find ACL \
+    "external_ids:parent=$policy_parent" 'sample_est!=[]')
+  [ -z "$references" ]
+}
+
+controller_sampling_failure_observed() {
+  kubectl logs -n kube-system -l app=kube-ovn-controller -c kube-ovn-controller \
+    --since=5m --tail=1000 2>/dev/null |
+    awk -v key="$NAMESPACE/sampling-failure" '
+      index($0, "error syncing sample network policy ACL \"" key "\"") &&
+        index($0, "sample collector ID 1 is owned by another application") { found = 1 }
+      END { exit !found }
+    '
+}
+
+verify_policy_connectivity() {
+  local endpoint=$1
+  for _ in $(seq 1 3); do
+    kubectl exec -n "$NAMESPACE" allowed -- /agnhost connect --timeout=3s "$endpoint"
+  done
+  for _ in $(seq 1 3); do
+    if kubectl exec -n "$NAMESPACE" denied -- /agnhost connect --timeout=2s "$endpoint"; then
+      echo "default-denied client unexpectedly reached $endpoint" >&2
+      return 1
+    fi
+  done
+}
+
+node_collector_set_uuids() {
+  kubectl ko vsctl "$NODE_NAME" --data=bare --no-heading --columns=_uuid \
+    find Flow_Sample_Collector_Set 'external_ids:kube-ovn.io/feature=acl-sampling'
+}
+
+node_collector_set_ready() {
+  local uuids
+  uuids=$(node_collector_set_uuids)
+  [ -n "$uuids" ]
+}
+
+node_collector_set_absent() {
+  local uuids
+  uuids=$(node_collector_set_uuids)
+  [ -z "$uuids" ]
+}
+
+node_capability_failure_observed() {
+  kubectl logs -n kube-system -l app=kube-ovn-cni -c cni-server \
+    --since=5m --tail=1000 2>/dev/null |
+    grep -F 'does not report psample=true' >/dev/null
 }
 
 disable_acl_sampling() {
@@ -114,6 +224,7 @@ if [ -z "$NODE_NAME" ]; then
 fi
 
 kubectl create namespace "$NAMESPACE"
+NAMESPACE_CREATED=true
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
@@ -187,34 +298,107 @@ else
   TARGET_ENDPOINT="$TARGET_IP:8080"
 fi
 
-wait_for 'NetworkPolicy ACL sampling references' 90 sampling_references_ready
+wait_for 'NetworkPolicy ACL sampling references' 90 sampling_references_ready "$POLICY_UID"
 
-timeout 90s kubectl ko acl-sample listen --node "$NODE_NAME" >"$SAMPLE_OUTPUT" 2>"$LISTENER_LOG" &
+kubectl ko acl-sample listen --node "$NODE_NAME" >"$SAMPLE_OUTPUT" 2>"$LISTENER_LOG" &
 LISTENER_PID=$!
-sleep 3
-if ! kill -0 "$LISTENER_PID" 2>/dev/null; then
-  echo 'ACL sample listener exited before traffic generation' >&2
-  exit 1
-fi
-
-for _ in $(seq 1 10); do
-  kubectl exec -n "$NAMESPACE" allowed -- \
-    /agnhost connect --timeout=3s "$TARGET_ENDPOINT"
-done
-
-for _ in $(seq 1 3); do
-  if kubectl exec -n "$NAMESPACE" denied -- \
-    /agnhost connect --timeout=2s "$TARGET_ENDPOINT"; then
-    echo 'default-denied client unexpectedly reached the target Pod' >&2
-    exit 1
-  fi
-done
-
-wait_for 'decoded acl-new, acl-est, and default-deny samples' 45 expected_samples_ready
+wait_for_expected_samples
 
 kill "$LISTENER_PID" 2>/dev/null || true
 wait "$LISTENER_PID" 2>/dev/null || true
 LISTENER_PID=""
+
+CONFLICT_COLLECTOR_UUID=$(kubectl ko nbctl create Sample_Collector \
+  id=1 set_id=142 probability=65535 name=acl-sampling-e2e-conflict)
+if [ -z "$CONFLICT_COLLECTOR_UUID" ]; then
+  echo 'failed to create the unowned controller sampling conflict' >&2
+  exit 1
+fi
+kubectl rollout restart deployment/kube-ovn-controller -n kube-system
+kubectl rollout status deployment/kube-ovn-controller -n kube-system --timeout=2m
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: $NAMESPACE
+  name: failure-target
+  labels:
+    app: failure-target
+spec:
+  nodeName: $NODE_NAME
+  containers:
+    - name: agnhost
+      image: ghcr.io/kubeovn/agnhost:2.47
+      args: ["netexec", "--http-port=8080"]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: $NAMESPACE
+  name: sampling-failure
+spec:
+  podSelector:
+    matchLabels:
+      app: failure-target
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              access: allowed
+      ports:
+        - protocol: TCP
+          port: 8080
+EOF
+
+kubectl wait -n "$NAMESPACE" --for=condition=Ready pod/failure-target --timeout=2m
+FAILURE_POLICY_UID=$(kubectl get networkpolicy -n "$NAMESPACE" sampling-failure -o jsonpath='{.metadata.uid}')
+FAILURE_PORT_GROUP="sampling.failure.${NAMESPACE//-/.}"
+FAILURE_TARGET_IP=$(kubectl get pod -n "$NAMESPACE" failure-target -o jsonpath='{.status.podIP}')
+if [[ "$FAILURE_TARGET_IP" == *:* ]]; then
+  FAILURE_TARGET_ENDPOINT="[$FAILURE_TARGET_IP]:8080"
+else
+  FAILURE_TARGET_ENDPOINT="$FAILURE_TARGET_IP:8080"
+fi
+
+wait_for 'failure-injection NetworkPolicy enforcement ACLs' 90 policy_enforcement_acls_ready "$FAILURE_PORT_GROUP"
+wait_for 'controller ACL sampling conflict warning' 90 controller_sampling_failure_observed
+wait_for 'sampling references to remain absent after the injected failure' 30 \
+  policy_sampling_references_absent "$FAILURE_PORT_GROUP"
+verify_policy_connectivity "$FAILURE_TARGET_ENDPOINT"
+
+kubectl ko nbctl destroy Sample_Collector "$CONFLICT_COLLECTOR_UUID"
+CONFLICT_COLLECTOR_UUID=""
+wait_for 'sampling-only retry after controller failure' 90 sampling_references_ready "$FAILURE_POLICY_UID"
+
+NODE_COLLECTOR_UUID=$(node_collector_set_uuids | sed -n '1p')
+if [ -z "$NODE_COLLECTOR_UUID" ]; then
+  echo 'cannot locate the owned node ACL sampling collector set' >&2
+  exit 1
+fi
+DATAPATH_UUID=$(kubectl ko vsctl "$NODE_NAME" --data=bare --no-heading --columns=_uuid \
+  find Datapath capabilities:psample=true | sed -n '1p')
+if [ -z "$DATAPATH_UUID" ]; then
+  echo 'cannot locate the active psample-capable OVS datapath' >&2
+  exit 1
+fi
+
+kubectl ko vsctl "$NODE_NAME" set Datapath "$DATAPATH_UUID" capabilities:psample=false
+DATAPATH_CAPABILITY_OVERRIDDEN=true
+kubectl ko vsctl "$NODE_NAME" destroy Flow_Sample_Collector_Set "$NODE_COLLECTOR_UUID"
+kubectl rollout restart daemonset/kube-ovn-cni -n kube-system
+kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout=2m
+wait_for 'unsupported node capability warning' 90 node_capability_failure_observed
+wait_for 'collector set to remain absent on the unsupported node' 30 node_collector_set_absent
+verify_policy_connectivity "$TARGET_ENDPOINT"
+
+kubectl ko vsctl "$NODE_NAME" set Datapath "$DATAPATH_UUID" capabilities:psample=true
+DATAPATH_CAPABILITY_OVERRIDDEN=false
+kubectl rollout restart daemonset/kube-ovn-cni -n kube-system
+kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout=2m
+wait_for 'node ACL sampling recovery' 90 node_collector_set_ready
 
 disable_acl_sampling deployment kube-ovn-controller kube-ovn-controller
 disable_acl_sampling daemonset kube-ovn-cni cni-server

--- a/hack/acl-sampling-e2e.sh
+++ b/hack/acl-sampling-e2e.sh
@@ -74,6 +74,28 @@ wait_for() {
   done
 }
 
+endpoint_for_ip() {
+  local ip=$1
+  if [[ "$ip" == *:* ]]; then
+    printf '[%s]:8080\n' "$ip"
+  else
+    printf '%s:8080\n' "$ip"
+  fi
+}
+
+start_sample_listener() {
+  : >"$SAMPLE_OUTPUT"
+  : >"$LISTENER_LOG"
+  kubectl ko acl-sample listen --node "$NODE_NAME" >"$SAMPLE_OUTPUT" 2>"$LISTENER_LOG" &
+  LISTENER_PID=$!
+}
+
+stop_sample_listener() {
+  kill "$LISTENER_PID" 2>/dev/null || true
+  wait "$LISTENER_PID" 2>/dev/null || true
+  LISTENER_PID=""
+}
+
 sampling_references_ready() {
   local policy_uid=$1
   local rows
@@ -142,11 +164,25 @@ policy_sampling_references_absent() {
   local policy_parent=$1
   local references
   references=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid find ACL \
-    "external_ids:parent=$policy_parent" 'sample_new!=[]')
+    "external_ids:parent=$policy_parent" 'sample_new!=[]') || return 1
   [ -z "$references" ] || return 1
   references=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid find ACL \
-    "external_ids:parent=$policy_parent" 'sample_est!=[]')
+    "external_ids:parent=$policy_parent" 'sample_est!=[]') || return 1
   [ -z "$references" ]
+}
+
+policy_sampling_disabled() {
+  local policy_parent=$1
+  local rows
+  rows=$(kubectl ko nbctl --format=csv --data=bare --no-heading \
+    --columns=action,sample_new,sample_est find ACL \
+    "external_ids:parent=$policy_parent") || return 1
+  awk -F, '
+    $1 == "allow-related" { allow = 1 }
+    $1 == "drop" { default_deny = 1 }
+    ($2 != "" && $2 != "[]") || ($3 != "" && $3 != "[]") { sampled = 1 }
+    END { exit !(allow && default_deny && !sampled) }
+  ' <<< "$rows"
 }
 
 controller_sampling_failure_observed() {
@@ -180,13 +216,13 @@ node_collector_set_uuids() {
 
 node_collector_set_ready() {
   local uuids
-  uuids=$(node_collector_set_uuids)
+  uuids=$(node_collector_set_uuids) || return 1
   [ -n "$uuids" ]
 }
 
 node_collector_set_absent() {
   local uuids
-  uuids=$(node_collector_set_uuids)
+  uuids=$(node_collector_set_uuids) || return 1
   [ -z "$uuids" ]
 }
 
@@ -223,17 +259,25 @@ disable_acl_sampling() {
 }
 
 sampling_cleanup_complete() {
-  local sampled_acls applications collectors node_sets
+  local sampled_acls applications collectors node_sets nodes node
+  policy_sampling_disabled "$POLICY_PARENT" || return 1
+  policy_sampling_disabled "$FAILURE_PORT_GROUP" || return 1
   sampled_acls=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
-    find ACL 'external_ids:kube-ovn.io/sample-feature=network-policy')
+    find ACL 'external_ids:kube-ovn.io/sample-feature=network-policy') || return 1
   applications=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
-    find Sampling_App 'external_ids:kube-ovn.io/feature=acl-sampling')
+    find Sampling_App 'external_ids:kube-ovn.io/feature=acl-sampling') || return 1
   collectors=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
-    find Sample_Collector 'external_ids:kube-ovn.io/feature=acl-sampling')
-  node_sets=$(kubectl ko vsctl "$NODE_NAME" --data=bare --no-heading --columns=_uuid \
-    find Flow_Sample_Collector_Set 'external_ids:kube-ovn.io/feature=acl-sampling')
+    find Sample_Collector 'external_ids:kube-ovn.io/feature=acl-sampling') || return 1
+  nodes=$(kubectl get nodes -o name) || return 1
+  [ -n "$nodes" ] || return 1
+  while IFS= read -r node; do
+    node=${node#node/}
+    node_sets=$(kubectl ko vsctl "$node" --data=bare --no-heading --columns=_uuid \
+      find Flow_Sample_Collector_Set 'external_ids:kube-ovn.io/feature=acl-sampling') || return 1
+    [ -z "$node_sets" ] || return 1
+  done <<< "$nodes"
   [ -z "$sampled_acls" ] && [ -z "$applications" ] &&
-    [ -z "$collectors" ] && [ -z "$node_sets" ]
+    [ -z "$collectors" ]
 }
 
 NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
@@ -310,22 +354,15 @@ EOF
 
 kubectl wait -n "$NAMESPACE" --for=condition=Ready pod/target pod/allowed pod/denied --timeout=2m
 POLICY_UID=$(kubectl get networkpolicy -n "$NAMESPACE" "$POLICY_NAME" -o jsonpath='{.metadata.uid}')
+POLICY_PARENT="${POLICY_NAME//-/.}.${NAMESPACE//-/.}"
 TARGET_IP=$(kubectl get pod -n "$NAMESPACE" target -o jsonpath='{.status.podIP}')
-if [[ "$TARGET_IP" == *:* ]]; then
-  TARGET_ENDPOINT="[$TARGET_IP]:8080"
-else
-  TARGET_ENDPOINT="$TARGET_IP:8080"
-fi
+TARGET_ENDPOINT=$(endpoint_for_ip "$TARGET_IP")
 
 wait_for 'NetworkPolicy ACL sampling references' 90 sampling_references_ready "$POLICY_UID"
 
-kubectl ko acl-sample listen --node "$NODE_NAME" >"$SAMPLE_OUTPUT" 2>"$LISTENER_LOG" &
-LISTENER_PID=$!
+start_sample_listener
 wait_for_expected_samples
-
-kill "$LISTENER_PID" 2>/dev/null || true
-wait "$LISTENER_PID" 2>/dev/null || true
-LISTENER_PID=""
+stop_sample_listener
 
 CONFLICT_COLLECTOR_UUID=$(kubectl ko nbctl --data=bare --no-heading --columns=_uuid \
   find Sample_Collector id=1 'external_ids:kube-ovn.io/feature=acl-sampling')
@@ -377,11 +414,7 @@ kubectl wait -n "$NAMESPACE" --for=condition=Ready pod/failure-target --timeout=
 FAILURE_POLICY_UID=$(kubectl get networkpolicy -n "$NAMESPACE" sampling-failure -o jsonpath='{.metadata.uid}')
 FAILURE_PORT_GROUP="sampling.failure.${NAMESPACE//-/.}"
 FAILURE_TARGET_IP=$(kubectl get pod -n "$NAMESPACE" failure-target -o jsonpath='{.status.podIP}')
-if [[ "$FAILURE_TARGET_IP" == *:* ]]; then
-  FAILURE_TARGET_ENDPOINT="[$FAILURE_TARGET_IP]:8080"
-else
-  FAILURE_TARGET_ENDPOINT="$FAILURE_TARGET_IP:8080"
-fi
+FAILURE_TARGET_ENDPOINT=$(endpoint_for_ip "$FAILURE_TARGET_IP")
 
 wait_for 'failure-injection NetworkPolicy enforcement ACLs' 90 policy_enforcement_acls_ready "$FAILURE_PORT_GROUP"
 wait_for 'controller ACL sampling conflict warning' 90 controller_sampling_failure_observed
@@ -418,11 +451,16 @@ DATAPATH_CAPABILITY_OVERRIDDEN=false
 kubectl rollout restart daemonset/kube-ovn-cni -n kube-system
 kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout=2m
 wait_for 'node ACL sampling recovery' 90 node_collector_set_ready
+start_sample_listener
+wait_for_expected_samples
+stop_sample_listener
 
 disable_acl_sampling deployment kube-ovn-controller kube-ovn-controller
 disable_acl_sampling daemonset kube-ovn-cni cni-server
 kubectl rollout status deployment/kube-ovn-controller -n kube-system --timeout=2m
 kubectl rollout status daemonset/kube-ovn-cni -n kube-system --timeout=2m
 wait_for 'owned controller and node ACL sampling state cleanup' 90 sampling_cleanup_complete
+verify_policy_connectivity "$TARGET_ENDPOINT"
+verify_policy_connectivity "$FAILURE_TARGET_ENDPOINT"
 
 echo 'ACL sampling E2E passed'

--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -24,7 +24,7 @@ infrastructureJobs = {
     "publish-pr-e2e-checks",
     "push",
 }
-expectedX86RunnerJobs = 84
+expectedX86RunnerJobs = 85
 mandatorySmoke = [
     {"job": "kube-ovn-conformance-e2e", "ip-family": "ipv4", "mode": "overlay"},
     {"job": "kube-ovn-conformance-e2e", "ip-family": "ipv4", "mode": "underlay"},

--- a/hack/test_e2e_selector.py
+++ b/hack/test_e2e_selector.py
@@ -30,6 +30,9 @@ class E2ESelectorTest(unittest.TestCase):
             baseSHA="b" * 40,
         )
 
+    def expectedRunnerJobs(self):
+        return self.catalog["expectedRunnerJobs"]
+
     def testCatalogCoversCurrentX86TestJobs(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
         e2eSelector.validateWorkflow(self.catalog, workflow)
@@ -139,7 +142,7 @@ class E2ESelectorTest(unittest.TestCase):
         executionPlan = e2eSelector.executionPlan(self.catalog, plan, "pull_request")
 
         self.assertTrue(executionPlan["full"])
-        self.assertEqual(len(executionPlan["matrix"]), 84)
+        self.assertEqual(len(executionPlan["matrix"]), self.expectedRunnerJobs())
 
     def testTrustedDispatchExecutesRecommendedAndRequestedCoverage(self):
         plan = self.select(
@@ -153,13 +156,13 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertEqual(executionPlan["recommendedGroups"], [])
         self.assertFalse(executionPlan["approvalRequired"])
         self.assertEqual(executionPlan["executionMode"], "approved")
-        self.assertEqual(len(executionPlan["matrix"]), 21)
+        self.assertEqual(len(executionPlan["matrix"]), 22)
         summary = e2eSelector.renderSummary(
             executionPlan,
             ["test/e2e/cnp-domain/e2e_test.go"],
         )
         self.assertIn("Approval required: `no`", summary)
-        self.assertIn("Authorized coverage: approved selection &#40;21 runner jobs&#41;", summary)
+        self.assertIn("Authorized coverage: approved selection &#40;22 runner jobs&#41;", summary)
         self.assertIn("Authorized coverage is executing for this HEAD", summary)
         self.assertNotIn("deferred groups wait", summary)
         self.assertNotIn("Waiting for:", summary)
@@ -170,7 +173,7 @@ class E2ESelectorTest(unittest.TestCase):
         executionPlan = e2eSelector.executionPlan(self.catalog, plan, "push")
 
         self.assertTrue(executionPlan["full"])
-        self.assertEqual(len(executionPlan["matrix"]), 84)
+        self.assertEqual(len(executionPlan["matrix"]), self.expectedRunnerJobs())
 
     def testExplicitForceFullReasonOverridesAVisibleSafeFileList(self):
         plan = e2eSelector.select(
@@ -183,7 +186,7 @@ class E2ESelectorTest(unittest.TestCase):
         )
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 84)
+        self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
         self.assertIn("file list is incomplete", plan["fullReason"])
 
     def testPathsLabelsAndRequestsAreUnioned(self):
@@ -202,7 +205,7 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertEqual(plan["recommendedGroups"], ["multi-cni", "policy"])
         self.assertEqual(plan["requestedGroups"], ["nat-egress"])
         self.assertTrue(plan["approvalRequired"])
-        self.assertEqual(len(plan["matrix"]), 3 + 6 + 5 + 15)
+        self.assertEqual(len(plan["matrix"]), 3 + 6 + 5 + 16)
         self.assertTrue(any(reason["source"] == "path" for reason in plan["reasons"]))
         self.assertTrue(any(reason["source"] == "label" for reason in plan["reasons"]))
         self.assertTrue(any(reason["source"] == "request" for reason in plan["reasons"]))
@@ -217,14 +220,14 @@ class E2ESelectorTest(unittest.TestCase):
         )
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 84)
+        self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
         self.assertIn("matched 3 test groups", plan["fullReason"])
 
     def testUnknownProductionPathPromotesToFull(self):
         plan = self.select(["pkg/new-component/new_feature.go"])
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 84)
+        self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
         self.assertIn("unclassified production path", plan["fullReason"])
 
     def testCommonPathPromotesToFull(self):
@@ -247,7 +250,7 @@ class E2ESelectorTest(unittest.TestCase):
             with self.subTest(path=path):
                 plan = self.select([path])
                 self.assertTrue(plan["full"])
-                self.assertEqual(len(plan["matrix"]), 84)
+                self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
                 self.assertIn("shared path", plan["fullReason"])
 
     def testInstallationBuildAndCodegenPathsPromoteToFull(self):
@@ -262,7 +265,7 @@ class E2ESelectorTest(unittest.TestCase):
             with self.subTest(path=path):
                 plan = self.select([path])
                 self.assertTrue(plan["full"])
-                self.assertEqual(len(plan["matrix"]), 84)
+                self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
                 self.assertIn("shared path", plan["fullReason"])
 
     def testSharedE2ESourcesSelectEveryExecutingGroup(self):
@@ -325,7 +328,7 @@ class E2ESelectorTest(unittest.TestCase):
             with self.subTest(script=script):
                 plan = self.select([script])
                 self.assertTrue(plan["full"])
-                self.assertEqual(len(plan["matrix"]), 84)
+                self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
 
     def testSharedE2EMakeScriptsPromoteToFull(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
@@ -352,13 +355,13 @@ class E2ESelectorTest(unittest.TestCase):
             with self.subTest(script=script):
                 plan = self.select([script])
                 self.assertTrue(plan["full"])
-                self.assertEqual(len(plan["matrix"]), 84)
+                self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
 
     def testForceFullLabelPromotesToFull(self):
         plan = self.select(["docs/design.md"], labels=["e2e:full"])
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 84)
+        self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
         self.assertEqual(plan["fullReason"], "label e2e:full requested the full suite")
 
     def testRequestedFullIsNotReportedAsAutomaticCoverage(self):
@@ -375,7 +378,7 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertTrue(plan["requestedFull"])
         self.assertEqual(plan["automaticGroups"], [])
         self.assertEqual(plan["selectedGroups"], sorted(self.catalog["groups"]))
-        self.assertEqual(len(plan["matrix"]), 84)
+        self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
         self.assertEqual(plan["fullReason"], "authorized request selected the full suite")
         executionPlan = e2eSelector.executionPlan(
             self.catalog,
@@ -386,9 +389,15 @@ class E2ESelectorTest(unittest.TestCase):
             executionPlan,
             ["test/e2e/cnp-domain/e2e_test.go"],
         )
-        self.assertIn("Authorized coverage: full suite &#40;84 runner jobs&#41;", summary)
+        self.assertIn(
+            f"Authorized coverage: full suite &#40;{self.expectedRunnerJobs()} runner jobs&#41;",
+            summary,
+        )
         self.assertNotIn("Automatic coverage: mandatory smoke", summary)
-        self.assertIn("Runner jobs in this run: 84", summary)
+        self.assertIn(
+            f"Runner jobs in this run: {self.expectedRunnerJobs()}",
+            summary,
+        )
 
     def testInvalidRequestedGroupFails(self):
         with self.assertRaisesRegex(ValueError, "unknown requested group"):
@@ -449,7 +458,7 @@ class E2ESelectorTest(unittest.TestCase):
                     )
                     result = json.loads(plan.read_text())
                     self.assertTrue(result["full"])
-                    self.assertEqual(len(result["matrix"]), 84)
+                    self.assertEqual(len(result["matrix"]), self.expectedRunnerJobs())
                     self.assertIn("selection error", result["fullReason"])
 
     def testPlanIsJsonSerializableAndBoundToHead(self):
@@ -572,7 +581,7 @@ class E2ESelectorTest(unittest.TestCase):
                     result = json.loads(plan.read_text())
                     self.assertTrue(result["full"])
                     self.assertEqual(result["headSHA"], "0123456789abcdef")
-                    self.assertEqual(len(result["matrix"]), 84)
+                    self.assertEqual(len(result["matrix"]), self.expectedRunnerJobs())
                     self.assertIn("catalog error", result["fullReason"])
                     self.assertIn("Full suite: `yes`", summary.read_text())
 
@@ -596,11 +605,14 @@ class E2ESelectorTest(unittest.TestCase):
             inlineWorkflow,
             "catalog",
         )
-        self.assertEqual(len(plan["matrix"]), 84)
+        self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
         executionPlan = e2eSelector.executionPlan(None, plan, "pull_request")
         self.assertEqual(executionPlan, {**plan, "executionMode": "automatic"})
         summary = e2eSelector.renderSummary(executionPlan, [])
-        self.assertIn("Automatic coverage: full suite &#40;84 runner jobs&#41;", summary)
+        self.assertIn(
+            f"Automatic coverage: full suite &#40;{self.expectedRunnerJobs()} runner jobs&#41;",
+            summary,
+        )
         self.assertIn("Groups executing in this run: full suite", summary)
         self.assertNotIn("Groups executing in this run: smoke only", summary)
 
@@ -645,7 +657,7 @@ class E2ESelectorTest(unittest.TestCase):
                     )
                     result = json.loads(plan.read_text())
                     self.assertTrue(result["full"])
-                    self.assertEqual(len(result["matrix"]), 84)
+                    self.assertEqual(len(result["matrix"]), self.expectedRunnerJobs())
                     self.assertIn("selection error", result["fullReason"])
 
     def testSelectorFilesHaveCodeOwners(self):
@@ -674,6 +686,7 @@ class E2ESelectorTest(unittest.TestCase):
             ("test/e2e/connectivity/e2e_test.go", "core"),
             ("test/e2e/cnp-domain/e2e_test.go", "policy"),
             ("pkg/controller/network_policy.go", "policy"),
+            ("pkg/aclsampling/config.go", "policy"),
             ("test/e2e/bgp/e2e_test.go", "bgp-routing"),
             ("test/e2e/multus/e2e_test.go", "multi-cni"),
             ("test/e2e/lb-svc/e2e_test.go", "service-lb-underlay"),
@@ -721,7 +734,7 @@ class E2ESelectorTest(unittest.TestCase):
         plan = self.select(["test/e2e/framework/pod.go"])
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 84)
+        self.assertEqual(len(plan["matrix"]), self.expectedRunnerJobs())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Related to #7146.

## Summary

- add a dedicated IPv4 Kind job for deterministic ACL sampling coverage without changing the existing NetworkPolicy matrix
- install Kube-OVN with 100% allow and default-deny sampling probabilities
- verify allow `acl-new`, allow `acl-est`, and non-exclusive default-deny events; assert default-deny has no `sample_est`
- inject an unowned controller collector conflict, verify enforcement allow/deny traffic remains correct, then verify sampling-only retry recovery
- override the active OVS datapath to `psample=false`, verify the unsupported-node path leaves enforcement working, then restore node delivery
- disable controller and node sampling and verify sampled ACL references plus owned OVN/OVS objects are cleaned up
- retain and upload listener output with cluster diagnostics when the job fails

## Stack

1. #7149 — configuration
2. #7150 — stable metadata allocator
3. #7148 — OVN sampling object reconciler
4. #7163 — NetworkPolicy ACL attachment
5. #7164 — sampling-only retry and enforcement isolation
6. #7165 — ownership-aware disable and cleanup
7. #7166 — controller availability metrics
8. #7167 — node-local psample delivery
9. #7168 — cookie and metadata event decoder
10. #7169 — Linux psample listener
11. #7170 — ACL sample debug commands
12. #7171 — v2 chart configuration
13. #7172 — operations and compatibility documentation
14. #7173 — manifest installer configuration
15. **#7174 — end-to-end coverage**

Merge in listed order. Each PR targets preceding stack branch.

Base: `feature/acl-sampling-install-script`

## Validation

- `bash -n hack/acl-sampling-e2e.sh`
- `shellcheck hack/acl-sampling-e2e.sh`
- parsed `.github/workflows/build-x86-image.yaml` as YAML
- `git diff --check`

Local Kind execution is intentionally omitted because this workspace prohibits high-memory local workloads. The dedicated GitHub Actions `ACL Sampling E2E` job provides cluster-level evidence.
