### PR TITLE
fix: release QoS finalizer only after the referencing EIP/NatGw is truly gone

### DIFF
--- a/pkg/controller/qos_policy.go
+++ b/pkg/controller/qos_policy.go
@@ -23,7 +23,16 @@ import (
 )
 
 func (c *Controller) enqueueAddQoSPolicy(obj any) {
-	key := cache.MetaObjectToName(obj.(*kubeovnv1.QoSPolicy)).String()
+	qos := obj.(*kubeovnv1.QoSPolicy)
+	key := cache.MetaObjectToName(qos).String()
+	// A policy already marked for deletion must go through the update reconcile so its finalizer
+	// can be released; handleAddQoSPolicy does not process terminating policies. This also covers
+	// controller restart, where the informer re-lists objects already in their final state.
+	if !qos.DeletionTimestamp.IsZero() {
+		klog.V(3).Infof("enqueue update to clean qos %s", key)
+		c.updateQoSPolicyQueue.Add(key)
+		return
+	}
 	klog.V(3).Infof("enqueue add qos policy %s", key)
 	c.addQoSPolicyQueue.Add(key)
 }
@@ -104,6 +113,13 @@ func (c *Controller) handleAddQoSPolicy(key string) error {
 	c.vpcNatGwKeyMutex.LockKey(key)
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle add QoS policy %s", key)
+
+	// Add the finalizer as soon as the policy exists so that deletion always goes through
+	// the reference check, even for policies whose spec is never updated after creation.
+	if err = c.handleAddQoSPolicyFinalizer(key); err != nil {
+		klog.Errorf("failed to handle add finalizer for qos %s, %v", key, err)
+		return err
+	}
 
 	sortedNewRules := cachedQoS.Spec.BandwidthLimitRules
 	sort.Slice(sortedNewRules, func(i, j int) bool {
@@ -511,7 +527,7 @@ func (c *Controller) handleAddQoSPolicyFinalizer(key string) error {
 		klog.Error(err)
 		return err
 	}
-	if !cachedQoSPolicy.DeletionTimestamp.IsZero() || len(cachedQoSPolicy.GetFinalizers()) != 0 {
+	if !cachedQoSPolicy.DeletionTimestamp.IsZero() || controllerutil.ContainsFinalizer(cachedQoSPolicy, util.KubeOVNControllerFinalizer) {
 		return nil
 	}
 	newQoSPolicy := cachedQoSPolicy.DeepCopy()

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -140,10 +140,19 @@ func (c *Controller) enqueueAddOrUpdateVpcNatGwByName(gwName, reason string) {
 	c.addOrUpdateVpcNatGatewayQueue.Add(gwName)
 }
 
-func (c *Controller) enqueueUpdateVpcNatGw(_, newObj any) {
-	key := cache.MetaObjectToName(newObj.(*kubeovnv1.VpcNatGateway)).String()
+func (c *Controller) enqueueUpdateVpcNatGw(oldObj, newObj any) {
+	oldGw := oldObj.(*kubeovnv1.VpcNatGateway)
+	newGw := newObj.(*kubeovnv1.VpcNatGateway)
+	key := cache.MetaObjectToName(newGw).String()
 	klog.V(3).Infof("enqueue update vpc-nat-gw %s", key)
 	c.addOrUpdateVpcNatGatewayQueue.Add(key)
+
+	// QoS reconcile decides "in use" via the QoSLabel selector, so key the re-enqueue on the
+	// label's previous value: when it is cleared or switched, re-enqueue the previous QoS so it
+	// can drop its finalizer. UpdateFunc fires after the informer cache reflects the label change.
+	if oldQoS := oldGw.Labels[util.QoSLabel]; oldQoS != "" && oldQoS != newGw.Labels[util.QoSLabel] {
+		c.updateQoSPolicyQueue.Add(oldQoS)
+	}
 }
 
 func (c *Controller) enqueueDeleteVpcNatGw(obj any) {
@@ -172,10 +181,10 @@ func (c *Controller) enqueueDeleteVpcNatGw(obj any) {
 	klog.V(3).Infof("enqueue del vpc-nat-gw %s", key)
 	c.delVpcNatGatewayQueue.Add(key)
 
-	// Trigger QoS Policy reconcile after NatGw is deleted
-	// This allows the QoS Policy to remove its finalizer if no other NatGws are using it
-	if gw.Status.QoSPolicy != "" {
-		c.updateQoSPolicyQueue.Add(gw.Status.QoSPolicy)
+	// Trigger QoS Policy reconcile after NatGw is deleted so it can drop its finalizer if no
+	// other NatGw references it. Key on the QoSLabel, matching the QoS in-use check.
+	if qos := gw.Labels[util.QoSLabel]; qos != "" {
+		c.updateQoSPolicyQueue.Add(qos)
 	}
 }
 

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -38,6 +38,13 @@ func (c *Controller) enqueueUpdateIptablesEip(oldObj, newObj any) {
 		klog.Infof("enqueue update iptables eip %s", key)
 		c.updateIptablesEipQueue.Add(key)
 	}
+
+	// QoS reconcile decides "in use" via the QoSLabel selector, so key the re-enqueue on the
+	// label's previous value: when it is cleared or switched, re-enqueue the previous QoS so it
+	// can drop its finalizer. UpdateFunc fires after the informer cache reflects the label change.
+	if oldQoS := oldEip.Labels[util.QoSLabel]; oldQoS != "" && oldQoS != newEip.Labels[util.QoSLabel] {
+		c.updateQoSPolicyQueue.Add(oldQoS)
+	}
 }
 
 func (c *Controller) enqueueDelIptablesEip(obj any) {
@@ -60,6 +67,12 @@ func (c *Controller) enqueueDelIptablesEip(obj any) {
 	key := cache.MetaObjectToName(eip).String()
 	klog.Infof("enqueue del iptables eip %s", key)
 	c.delIptablesEipQueue.Add(eip)
+
+	// Re-trigger QoS reconcile so it can drop its finalizer once unused. DeleteFunc runs after
+	// the informer cache dropped this EIP. Key on the QoSLabel, matching the QoS in-use check.
+	if qos := eip.Labels[util.QoSLabel]; qos != "" {
+		c.updateQoSPolicyQueue.Add(qos)
+	}
 }
 
 // natEipNamespace returns the namespace where the NAT gateway pod for the given EIP resides.
@@ -239,9 +252,7 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 				return err
 			}
 		}
-		// Save qosPolicy before deleting, we need to trigger QoS Policy reconcile after EIP is deleted
-		qosPolicyName := cachedEip.Status.QoSPolicy
-		if qosPolicyName != "" {
+		if cachedEip.Status.QoSPolicy != "" {
 			if err = c.delEipQoS(cachedEip, cachedEip.Status.IP); err != nil {
 				klog.Errorf("failed to del qos '%s' in pod, %v", key, err)
 				return err
@@ -250,16 +261,11 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 		// Release IP from IPAM before removing finalizer
 		c.ipam.ReleaseAddressByPod(key, cachedEip.Spec.ExternalSubnet)
 
-		// Now remove finalizer, which will trigger subnet status update
+		// Now remove finalizer, which will trigger subnet status update.
+		// QoS reconcile is re-triggered from the EIP DeleteFunc after the cache drops this EIP.
 		if err = c.handleDelIptablesEipFinalizer(key); err != nil {
 			klog.Errorf("failed to handle del finalizer for eip %s, %v", key, err)
 			return err
-		}
-
-		// Trigger QoS Policy reconcile after EIP is deleted
-		// This allows the QoS Policy to remove its finalizer if no other EIPs are using it
-		if qosPolicyName != "" {
-			c.updateQoSPolicyQueue.Add(qosPolicyName)
 		}
 
 		return nil

--- a/test/e2e/iptables-eip-qos/e2e_test.go
+++ b/test/e2e/iptables-eip-qos/e2e_test.go
@@ -689,6 +689,96 @@ func eipQoSCases(f *framework.Framework,
 	// Cleanup is now handled by DeferCleanup
 }
 
+// createQoSMarkedForDeletionWhileBound creates a QoS policy of the given binding type, waits for
+// its KubeOVN controller finalizer, runs bind to attach it to a resource, then deletes it while
+// still bound and asserts it stays in Terminating. It returns the policy name so the caller can
+// exercise the release trigger (deleting or unbinding the referencing resource).
+func createQoSMarkedForDeletionWhileBound(
+	f *framework.Framework,
+	shared bool,
+	bindingType apiv1.QoSPolicyBindingType,
+	rules apiv1.QoSPolicyBandwidthLimitRules,
+	bind func(qosName string),
+) (qosName string) {
+	ginkgo.GinkgoHelper()
+
+	qosPolicyClient := f.QoSPolicyClient()
+
+	qosName = "qos-life-policy-" + framework.RandomSuffix()
+	ginkgo.By("Creating qos policy " + qosName)
+	qos := framework.MakeQoSPolicy(qosName, shared, bindingType, rules)
+	_ = qosPolicyClient.CreateSync(qos)
+	ginkgo.DeferCleanup(func() {
+		ginkgo.By("Cleaning up qos policy " + qosName)
+		qosPolicyClient.DeleteSync(qosName)
+	})
+
+	// A newly created policy must carry the KubeOVN controller finalizer, otherwise deletion
+	// would not be blocked while still referenced and there would be nothing to regress on.
+	ginkgo.By("Verifying qos policy " + qosName + " has the controller finalizer")
+	gomega.Eventually(func(g gomega.Gomega) {
+		p, err := qosPolicyClient.QoSPolicyInterface.Get(context.TODO(), qosName, metav1.GetOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(p.Finalizers).To(gomega.ContainElement(util.KubeOVNControllerFinalizer))
+	}, 10*time.Second, 1*time.Second).Should(gomega.Succeed())
+
+	bind(qosName)
+
+	ginkgo.By("Marking qos policy " + qosName + " for deletion while still bound")
+	qosPolicyClient.Delete(qosName)
+
+	// Wait for the policy to enter Terminating, then assert it stays there while still
+	// referenced. The initial Eventually avoids a flake if the apiserver update lags.
+	stillTerminating := func(g gomega.Gomega) {
+		p, err := qosPolicyClient.QoSPolicyInterface.Get(context.TODO(), qosName, metav1.GetOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(p.DeletionTimestamp.IsZero()).To(gomega.BeFalse())
+	}
+	ginkgo.By("Waiting for qos policy " + qosName + " to enter Terminating")
+	gomega.Eventually(stillTerminating, 10*time.Second, 1*time.Second).Should(gomega.Succeed())
+	ginkgo.By("Verifying qos policy " + qosName + " stays in Terminating while still referenced")
+	gomega.Consistently(stillTerminating, 5*time.Second, 1*time.Second).Should(gomega.Succeed())
+
+	return qosName
+}
+
+// setupEIPBoundQoSMarkedForDeletion binds a fresh EIP (no FIP, so it can be deleted freely) to a
+// new EIP-type QoS policy marked for deletion. It returns the EIP and QoS names.
+func setupEIPBoundQoSMarkedForDeletion(f *framework.Framework, vpcQosParams *qosParams) (eipName, qosName string) {
+	ginkgo.GinkgoHelper()
+
+	eipClient := f.IptablesEIPClient()
+
+	eipName = "qos-life-eip-" + framework.RandomSuffix()
+	ginkgo.By("Creating dedicated eip " + eipName)
+	eip := framework.MakeIptablesEIP(eipName, "", "", "", vpcQosParams.qosNatGwName, vpcQosParams.attachDefName, "")
+	_ = eipClient.CreateSync(eip)
+	waitForIptablesEIPReady(eipClient, eipName, 60*time.Second)
+	ginkgo.DeferCleanup(func() {
+		ginkgo.By("Cleaning up eip " + eipName)
+		eipClient.DeleteSync(eipName)
+	})
+
+	qosName = createQoSMarkedForDeletionWhileBound(f, false, apiv1.QoSBindingTypeEIP, getEIPQoSRule(eipLimit), func(qos string) {
+		ginkgo.By("Binding eip " + eipName + " to qos policy " + qos)
+		_ = eipClient.PatchQoSPolicySync(eipName, qos)
+	})
+	return eipName, qosName
+}
+
+// setupNatGwBoundQoSMarkedForDeletion binds the given NAT gateway to a new NatGw-type QoS policy
+// marked for deletion. It returns the QoS name.
+func setupNatGwBoundQoSMarkedForDeletion(f *framework.Framework, natgwName string) (qosName string) {
+	ginkgo.GinkgoHelper()
+
+	natgwClient := f.VpcNatGatewayClient()
+	// A NatGw-bound QoS policy must be shared (see validateQosPolicy).
+	return createQoSMarkedForDeletionWhileBound(f, true, apiv1.QoSBindingTypeNatGw, getNicDefaultQoSPolicy(defaultNicLimit), func(qos string) {
+		ginkgo.By("Binding natgw " + natgwName + " to qos policy " + qos)
+		_ = natgwClient.PatchQoSPolicySync(natgwName, qos)
+	})
+}
+
 // multiEIPQoSIsolationCases tests that QoS policies on multiple EIPs on the SAME NAT Gateway
 // don't interfere with each other. This also tests decimal bandwidth values.
 //
@@ -1468,6 +1558,57 @@ var _ = framework.OrderedDescribe("[group:qos-policy]", func() {
 			attachDefName:  networkAttachDefName,
 			subnetProvider: externalSubnetProvider,
 		}
+	})
+
+	framework.ConformanceIt("eip qos policy finalizer is released after the bound eip is deleted", func() {
+		// Regression: deleting an EIP without first unbinding its QoS policy must still let
+		// the QoS policy (already marked for deletion) drop its finalizer.
+		setupQosTestResources(f, dockerExtNetNetwork, vpcQosParams, net1NicName)
+
+		eipClient := f.IptablesEIPClient()
+		qosPolicyClient := f.QoSPolicyClient()
+		eipName, qosName := setupEIPBoundQoSMarkedForDeletion(f, vpcQosParams)
+
+		ginkgo.By("Deleting eip " + eipName + " without unbinding qos policy " + qosName)
+		eipClient.DeleteSync(eipName)
+
+		ginkgo.By("Expecting qos policy " + qosName + " to be cleaned up after the eip is deleted")
+		gomega.Expect(qosPolicyClient.WaitToDisappear(qosName, 2*time.Second, 2*time.Minute)).To(gomega.Succeed(),
+			"qos policy should drop its finalizer once the bound eip is deleted")
+	})
+
+	framework.ConformanceIt("eip qos policy finalizer is released after the qos policy is unbound", func() {
+		// Regression: unbinding the QoS policy from an EIP must re-trigger the QoS reconcile
+		// so a policy already marked for deletion can drop its finalizer.
+		setupQosTestResources(f, dockerExtNetNetwork, vpcQosParams, net1NicName)
+
+		eipClient := f.IptablesEIPClient()
+		qosPolicyClient := f.QoSPolicyClient()
+		eipName, qosName := setupEIPBoundQoSMarkedForDeletion(f, vpcQosParams)
+
+		ginkgo.By("Unbinding qos policy " + qosName + " from eip " + eipName)
+		_ = eipClient.PatchQoSPolicySync(eipName, "")
+
+		ginkgo.By("Expecting qos policy " + qosName + " to be cleaned up after being unbound")
+		gomega.Expect(qosPolicyClient.WaitToDisappear(qosName, 2*time.Second, 2*time.Minute)).To(gomega.Succeed(),
+			"qos policy should drop its finalizer once it is unbound from the eip")
+	})
+
+	framework.ConformanceIt("natgw qos policy finalizer is released after the qos policy is unbound", func() {
+		// Regression: unbinding a NatGw-level QoS must re-trigger the QoS reconcile (keyed on the
+		// QoSLabel) so a policy already marked for deletion can drop its finalizer.
+		setupQosTestResources(f, dockerExtNetNetwork, vpcQosParams, net1NicName)
+
+		natgwClient := f.VpcNatGatewayClient()
+		qosPolicyClient := f.QoSPolicyClient()
+		qosName := setupNatGwBoundQoSMarkedForDeletion(f, vpcQosParams.qosNatGwName)
+
+		ginkgo.By("Unbinding qos policy " + qosName + " from natgw " + vpcQosParams.qosNatGwName)
+		_ = natgwClient.PatchQoSPolicySync(vpcQosParams.qosNatGwName, "")
+
+		ginkgo.By("Expecting qos policy " + qosName + " to be cleaned up after being unbound")
+		gomega.Expect(qosPolicyClient.WaitToDisappear(qosName, 2*time.Second, 2*time.Minute)).To(gomega.Succeed(),
+			"qos policy should drop its finalizer once it is unbound from the natgw")
 	})
 
 	framework.ConformanceIt("default nic qos", func() {


### PR DESCRIPTION
Trigger the dependent QoS policy cleanup only once the referencing resource is actually released, keyed off events that guarantee the informer cache is already consistent:

- Delete event (DeleteFunc): the EIP/NatGw has been dropped from the informer indexer, so re-enqueue its QoS policy for reconcile.
- Status change (UpdateFunc): status.qosPolicy moving away from a non-empty value means the QoS was unbound or switched, so re-enqueue the previous QoS policy.

The former immediate enqueue right after removing the EIP finalizer raced with the cache update: the QoS reconcile still observed the EIP as in use and skipped removing the finalizer, leaving the QoS stuck in Terminating. Add e2e coverage for both the delete and unbind paths.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
