### PR TITLE
[release-1.15] feat: make controller leader election timings configurable

### DIFF
--- a/charts/kube-ovn-v2/README.md
+++ b/charts/kube-ovn-v2/README.md
@@ -729,6 +729,46 @@ false
 			<td>Labels to be added to all top-level kube-ovn-controller objects (resources under templates/controller)</td>
 		</tr>
 		<tr>
+			<td>controller.leaderElection</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "leaseDuration": "",
+  "renewDeadline": "",
+  "retryPeriod": ""
+}
+</pre>
+</td>
+			<td>Leader election timing configuration.</td>
+		</tr>
+		<tr>
+			<td>controller.leaderElection.leaseDuration</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Duration non-leader candidates wait after observing a renewal before attempting to acquire leadership. Empty uses the controller default of 30s.</td>
+		</tr>
+		<tr>
+			<td>controller.leaderElection.renewDeadline</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Duration the acting leader retries refreshing leadership before giving up. Empty uses the controller default of 20s.</td>
+		</tr>
+		<tr>
+			<td>controller.leaderElection.retryPeriod</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Duration leader election clients wait between attempts. Empty uses the controller default of 6s.</td>
+		</tr>
+		<tr>
 			<td>controller.metrics</td>
 			<td>object</td>
 			<td><pre lang="">

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -84,6 +84,15 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - /kube-ovn/start-controller.sh
+          {{- if .Values.controller.leaderElection.leaseDuration }}
+          - --leader-elect-lease-duration={{ .Values.controller.leaderElection.leaseDuration }}
+          {{- end }}
+          {{- if .Values.controller.leaderElection.renewDeadline }}
+          - --leader-elect-renew-deadline={{ .Values.controller.leaderElection.renewDeadline }}
+          {{- end }}
+          {{- if .Values.controller.leaderElection.retryPeriod }}
+          - --leader-elect-retry-period={{ .Values.controller.leaderElection.retryPeriod }}
+          {{- end }}
           - --default-ls={{ .Values.networking.pods.subnetName }}
           - --default-cidr=
           {{- if eq .Values.networking.stack "Dual" -}}

--- a/charts/kube-ovn-v2/tests/controller_leader_election_test.yaml
+++ b/charts/kube-ovn-v2/tests/controller_leader_election_test.yaml
@@ -1,0 +1,45 @@
+suite: Kube-OVN controller leader election (v2)
+templates:
+  - controller/controller-deployment.yaml
+tests:
+  - it: relies on controller defaults when leader election timings are empty
+    set:
+      masterNodes:
+        - "10.0.0.1"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-lease-duration=30s
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-lease-duration=
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-renew-deadline=20s
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-renew-deadline=
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-retry-period=6s
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-retry-period=
+
+  - it: renders custom leader election timings
+    set:
+      masterNodes:
+        - "10.0.0.1"
+      controller.leaderElection.leaseDuration: 1m
+      controller.leaderElection.renewDeadline: 40s
+      controller.leaderElection.retryPeriod: 10s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-lease-duration=1m
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-renew-deadline=40s
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-retry-period=10s

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -714,6 +714,18 @@ monitor:
 # @section -- Kube-OVN controller configuration
 # @default -- "{}"
 controller:
+  # -- Leader election timing configuration.
+  # @section -- Kube-OVN controller configuration
+  leaderElection:
+    # -- Duration non-leader candidates wait after observing a renewal before attempting to acquire leadership. Empty uses the controller default of 30s.
+    # @section -- Kube-OVN controller configuration
+    leaseDuration: ""
+    # -- Duration the acting leader retries refreshing leadership before giving up. Empty uses the controller default of 20s.
+    # @section -- Kube-OVN controller configuration
+    renewDeadline: ""
+    # -- Duration leader election clients wait between attempts. Empty uses the controller default of 6s.
+    # @section -- Kube-OVN controller configuration
+    retryPeriod: ""
   # -- Annotations to be added to all top-level kube-ovn-controller objects (resources under templates/controller)
   # @section -- Kube-OVN controller configuration
   annotations: {}

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -76,6 +76,15 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - /kube-ovn/start-controller.sh
+          {{- if (index .Values "kube-ovn-controller" "leaderElection" "leaseDuration") }}
+          - --leader-elect-lease-duration={{ index .Values "kube-ovn-controller" "leaderElection" "leaseDuration" }}
+          {{- end }}
+          {{- if (index .Values "kube-ovn-controller" "leaderElection" "renewDeadline") }}
+          - --leader-elect-renew-deadline={{ index .Values "kube-ovn-controller" "leaderElection" "renewDeadline" }}
+          {{- end }}
+          {{- if (index .Values "kube-ovn-controller" "leaderElection" "retryPeriod") }}
+          - --leader-elect-retry-period={{ index .Values "kube-ovn-controller" "leaderElection" "retryPeriod" }}
+          {{- end }}
           - --default-ls={{ .Values.networking.DEFAULT_SUBNET }}
           - --default-cidr=
           {{- if eq .Values.networking.NET_STACK "dual_stack" -}}

--- a/charts/kube-ovn/tests/controller_leader_election_test.yaml
+++ b/charts/kube-ovn/tests/controller_leader_election_test.yaml
@@ -1,0 +1,43 @@
+suite: Kube-OVN controller leader election
+templates:
+  - controller-deploy.yaml
+tests:
+  - it: relies on controller defaults when leader election timings are empty
+    set:
+      MASTER_NODES: "10.0.0.1"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-lease-duration=30s
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-lease-duration=
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-renew-deadline=20s
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-renew-deadline=
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-retry-period=6s
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-retry-period=
+
+  - it: renders custom leader election timings
+    set:
+      MASTER_NODES: "10.0.0.1"
+      kube-ovn-controller.leaderElection.leaseDuration: 1m
+      kube-ovn-controller.leaderElection.renewDeadline: 40s
+      kube-ovn-controller.leaderElection.retryPeriod: 10s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-lease-duration=1m
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-renew-deadline=40s
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-retry-period=10s

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -251,6 +251,13 @@ ovs-ovn:
     memory: "1000Mi"
     ephemeral-storage: 1Gi
 kube-ovn-controller:
+  leaderElection:
+    # Duration non-leader candidates wait after observing a renewal before attempting to acquire leadership. Empty uses the controller default of 30s.
+    leaseDuration: ""
+    # Duration the acting leader retries refreshing leadership before giving up. Empty uses the controller default of 20s.
+    renewDeadline: ""
+    # Duration leader election clients wait between attempts. Empty uses the controller default of 6s.
+    retryPeriod: ""
   requests:
     cpu: "200m"
     memory: "200Mi"

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -146,16 +146,16 @@ func CmdMain() {
 			EventRecorder: recorder,
 		},
 		config.KubeRestConfig,
-		20*time.Second)
+		config.LeaderElection.RenewDeadline)
 	if err != nil {
 		klog.Fatalf("error creating lock: %v", err)
 	}
 
 	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 		Lock:          rl,
-		LeaseDuration: 30 * time.Second,
-		RenewDeadline: 20 * time.Second,
-		RetryPeriod:   6 * time.Second,
+		LeaseDuration: config.LeaderElection.LeaseDuration,
+		RenewDeadline: config.LeaderElection.RenewDeadline,
+		RetryPeriod:   config.LeaderElection.RetryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				controller.Run(ctx, config)

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -62,6 +62,9 @@ OVSDB_CON_TIMEOUT=${OVSDB_CON_TIMEOUT:-3}
 OVSDB_INACTIVITY_TIMEOUT=${OVSDB_INACTIVITY_TIMEOUT:-10}
 ENABLE_LIVE_MIGRATION_OPTIMIZE=${ENABLE_LIVE_MIGRATION_OPTIMIZE:-true}
 ENABLE_OVN_LB_PREFER_LOCAL=${ENABLE_OVN_LB_PREFER_LOCAL:-false}
+LEADER_ELECT_LEASE_DURATION=${LEADER_ELECT_LEASE_DURATION:-30s}
+LEADER_ELECT_RENEW_DEADLINE=${LEADER_ELECT_RENEW_DEADLINE:-20s}
+LEADER_ELECT_RETRY_PERIOD=${LEADER_ELECT_RETRY_PERIOD:-6s}
 
 function ovn_central_tls_env {
   cat <<EOF
@@ -5509,6 +5512,9 @@ spec:
           imagePullPolicy: $IMAGE_PULL_POLICY
           args:
           - /kube-ovn/start-controller.sh
+          - --leader-elect-lease-duration=$LEADER_ELECT_LEASE_DURATION
+          - --leader-elect-renew-deadline=$LEADER_ELECT_RENEW_DEADLINE
+          - --leader-elect-retry-period=$LEADER_ELECT_RETRY_PERIOD
           - --default-cidr=$POD_CIDR
           - --default-gateway=$POD_GATEWAY
           - --default-gateway-check=$CHECK_GATEWAY

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/klog/v2"
 	"kubevirt.io/client-go/kubecli"
 	anpclientset "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned"
@@ -22,7 +23,53 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-// Configuration is the controller conf
+const (
+	defaultLeaderLeaseDuration = 30 * time.Second
+	defaultLeaderRenewDeadline = 20 * time.Second
+	defaultLeaderRetryPeriod   = 6 * time.Second
+)
+
+// LeaderElectionConfiguration contains the timing configuration for controller leader election.
+type LeaderElectionConfiguration struct {
+	LeaseDuration time.Duration
+	RenewDeadline time.Duration
+	RetryPeriod   time.Duration
+}
+
+func defaultLeaderElectionConfiguration() LeaderElectionConfiguration {
+	return LeaderElectionConfiguration{
+		LeaseDuration: defaultLeaderLeaseDuration,
+		RenewDeadline: defaultLeaderRenewDeadline,
+		RetryPeriod:   defaultLeaderRetryPeriod,
+	}
+}
+
+func (config *LeaderElectionConfiguration) addFlags(flagSet *pflag.FlagSet) {
+	flagSet.DurationVar(&config.LeaseDuration, "leader-elect-lease-duration", config.LeaseDuration, "The duration that non-leader candidates will wait after observing a leadership renewal before attempting to acquire leadership")
+	flagSet.DurationVar(&config.RenewDeadline, "leader-elect-renew-deadline", config.RenewDeadline, "The duration that the acting leader will retry refreshing leadership before giving up")
+	flagSet.DurationVar(&config.RetryPeriod, "leader-elect-retry-period", config.RetryPeriod, "The duration leader election clients should wait between attempts")
+}
+
+func (config LeaderElectionConfiguration) validate() error {
+	if config.LeaseDuration <= 0 {
+		return errors.New("--leader-elect-lease-duration must be greater than zero")
+	}
+	if config.RenewDeadline <= 0 {
+		return errors.New("--leader-elect-renew-deadline must be greater than zero")
+	}
+	if config.RetryPeriod <= 0 {
+		return errors.New("--leader-elect-retry-period must be greater than zero")
+	}
+	if config.LeaseDuration <= config.RenewDeadline {
+		return errors.New("--leader-elect-lease-duration must be greater than --leader-elect-renew-deadline")
+	}
+	if config.RenewDeadline <= time.Duration(leaderelection.JitterFactor*float64(config.RetryPeriod)) {
+		return fmt.Errorf("--leader-elect-renew-deadline must be greater than --leader-elect-retry-period multiplied by %.1f", leaderelection.JitterFactor)
+	}
+	return nil
+}
+
+// Configuration is the controller config
 type Configuration struct {
 	OvnNbAddr              string
 	OvnSbAddr              string
@@ -67,9 +114,10 @@ type Configuration struct {
 	ClusterUDPSessionLoadBalancer  string
 	ClusterSctpSessionLoadBalancer string
 
-	PodName      string
-	PodNamespace string
-	PodNicType   string
+	PodName        string
+	PodNamespace   string
+	PodNicType     string
+	LeaderElection LeaderElectionConfiguration
 
 	WorkerNum       int
 	PprofPort       int32
@@ -139,6 +187,9 @@ type Configuration struct {
 // ParseFlags parses cmd args then init kubeclient and conf
 // TODO: validate configuration
 func ParseFlags() (*Configuration, error) {
+	leaderElectionConfig := defaultLeaderElectionConfiguration()
+	leaderElectionConfig.addFlags(pflag.CommandLine)
+
 	var (
 		argOvnNbAddr              = pflag.String("ovn-nb-addr", "", "ovn-nb address")
 		argOvnSbAddr              = pflag.String("ovn-sb-addr", "", "ovn-sb address")
@@ -291,6 +342,7 @@ func ParseFlags() (*Configuration, error) {
 		PodName:                        os.Getenv(util.EnvPodName),
 		PodNamespace:                   os.Getenv(util.EnvPodNamespace),
 		PodNicType:                     *argPodNicType,
+		LeaderElection:                 leaderElectionConfig,
 		EnableLb:                       *argEnableLb,
 		EnableNP:                       *argEnableNP,
 		EnableEipSnat:                  *argEnableEipSnat,
@@ -323,6 +375,9 @@ func ParseFlags() (*Configuration, error) {
 		EnableNonPrimaryCNI:            *argNonPrimaryCNI,
 		NetworkPolicyEnforcement:       *argNPEnforcement,
 		SkipConntrackDstCidrs:          *argSkipConntrackDstCidrs,
+	}
+	if err := config.LeaderElection.validate(); err != nil {
+		return nil, err
 	}
 	if config.OvsDbInactivityTimeout > 0 && config.OvsDbConnectTimeout >= config.OvsDbInactivityTimeout {
 		return nil, errors.New("OVS DB inactivity timeout value should be greater than reconnect timeout value")

--- a/pkg/controller/config_test.go
+++ b/pkg/controller/config_test.go
@@ -1,0 +1,108 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaderElectionConfigurationFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected LeaderElectionConfiguration
+	}{
+		{
+			name: "defaults",
+			expected: LeaderElectionConfiguration{
+				LeaseDuration: 30 * time.Second,
+				RenewDeadline: 20 * time.Second,
+				RetryPeriod:   6 * time.Second,
+			},
+		},
+		{
+			name: "custom durations",
+			args: []string{
+				"--leader-elect-lease-duration=1m",
+				"--leader-elect-renew-deadline=40s",
+				"--leader-elect-retry-period=10s",
+			},
+			expected: LeaderElectionConfiguration{
+				LeaseDuration: time.Minute,
+				RenewDeadline: 40 * time.Second,
+				RetryPeriod:   10 * time.Second,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := defaultLeaderElectionConfiguration()
+			flagSet := pflag.NewFlagSet(tt.name, pflag.ContinueOnError)
+			config.addFlags(flagSet)
+
+			require.NoError(t, flagSet.Parse(tt.args))
+			require.Equal(t, tt.expected, config)
+			require.NoError(t, config.validate())
+		})
+	}
+}
+
+func TestLeaderElectionConfigurationValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      LeaderElectionConfiguration
+		errorString string
+	}{
+		{
+			name: "lease duration must be positive",
+			config: LeaderElectionConfiguration{
+				RenewDeadline: time.Second,
+				RetryPeriod:   time.Millisecond,
+			},
+			errorString: "--leader-elect-lease-duration must be greater than zero",
+		},
+		{
+			name: "renew deadline must be positive",
+			config: LeaderElectionConfiguration{
+				LeaseDuration: time.Second,
+				RetryPeriod:   time.Millisecond,
+			},
+			errorString: "--leader-elect-renew-deadline must be greater than zero",
+		},
+		{
+			name: "retry period must be positive",
+			config: LeaderElectionConfiguration{
+				LeaseDuration: time.Second,
+				RenewDeadline: time.Millisecond,
+			},
+			errorString: "--leader-elect-retry-period must be greater than zero",
+		},
+		{
+			name: "lease duration must exceed renew deadline",
+			config: LeaderElectionConfiguration{
+				LeaseDuration: 20 * time.Second,
+				RenewDeadline: 20 * time.Second,
+				RetryPeriod:   time.Second,
+			},
+			errorString: "--leader-elect-lease-duration must be greater than --leader-elect-renew-deadline",
+		},
+		{
+			name: "renew deadline must allow retry jitter",
+			config: LeaderElectionConfiguration{
+				LeaseDuration: 30 * time.Second,
+				RenewDeadline: 12 * time.Second,
+				RetryPeriod:   10 * time.Second,
+			},
+			errorString: "--leader-elect-renew-deadline must be greater than --leader-elect-retry-period multiplied by 1.2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.EqualError(t, tt.config.validate(), tt.errorString)
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed Kube-OVN Code Style.

## What type of this PR

- Features
- Tests

## What this PR does

Backport merged PR #7177 (commit 27ab34cde98698f5f51ed559c00309394f0d7983) to release-1.15.

Expose kube-ovn-controller leader election lease duration, renew deadline, and retry period through controller flags, classic/v2 Helm charts, and install.sh. Preserve 30s/20s/6s defaults and reject invalid timing relationships before Kubernetes client initialization.

## Testing

- Go controller tests; classic Helm 20/20; v2 Helm 18/18
- Helm lint for classic and v2 charts
- bash -n dist/images/install.sh
- git diff --check

## Which issue(s) this PR fixes

N/A