### PR TITLE
[release-1.16] controller, daemon: record pod network lifecycle events

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -176,6 +176,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		}),
 	)
 	serviceInformer := kubeInformerFactory.Core().V1().Services()
+	endpointSliceInformer := kubeInformerFactory.Discovery().V1().EndpointSlices()
 	namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
 	nodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	podInformer := kubeInformerFactory.Core().V1().Pods()
@@ -223,6 +224,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	// Create controller with all informers
 	ctrl := &Controller{
 		servicesLister:          serviceInformer.Lister(),
+		endpointSlicesLister:    endpointSliceInformer.Lister(),
 		namespacesLister:        namespaceInformer.Lister(),
 		nodesLister:             nodeInformer.Lister(),
 		podsLister:              podInformer.Lister(),
@@ -242,6 +244,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		OVNSbClient:             mockOvnSbClient,
 		ipam:                    ovnipam.NewIPAM(),
 		recorder:                record.NewFakeRecorder(100),
+		podKeyMutex:             keymutex.NewHashed(0),
 		subnetKeyMutex:          keymutex.NewHashed(0),
 		nsKeyMutex:              keymutex.NewHashed(0),
 		addOrUpdateSubnetQueue:  newTypedRateLimitingQueue[string]("AddOrUpdateSubnet", nil),

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -531,12 +531,13 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	}
 
 	// check and do hotnoplug nic
-	var hotplugDetails string
-	if pod, hotplugDetails, err = c.syncKubeOvnNet(pod, podNets); err != nil {
+	updatedPod, hotplugDetails, err := c.syncKubeOvnNet(pod, podNets)
+	if err != nil {
 		klog.Errorf("failed to sync pod nets %v", err)
 		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=syncKubeOvnNet error=%v", err)
 		return err
 	}
+	pod = updatedPod
 	if pod == nil {
 		// pod has been deleted
 		return nil
@@ -654,9 +655,10 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	podName := c.getNameByPod(pod)
 	// todo: isVmPod, getPodType, getNameByPod has duplicated logic
 
+	eventPod := pod
 	var err error
 	recordFailure := func(stage string, err error) {
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkAllocationFailed", "stage=%s error=%v", stage, err)
+		c.recorder.Eventf(eventPod, v1.EventTypeWarning, "PodNetworkAllocationFailed", "stage=%s error=%v", stage, err)
 	}
 	var vmKey string
 	if isVMPod && c.config.EnableKeepVMIP {
@@ -829,11 +831,11 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		return nil, err
 	}
 
-	oldPod := pod
-	if pod, err = c.config.KubeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
+	updatedPod, err := c.config.KubeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			key := strings.Join([]string{namespace, name}, "/")
-			c.deletingPodObjMap.Store(key, oldPod)
+			c.deletingPodObjMap.Store(key, pod)
 			c.deletePodQueue.AddRateLimited(key)
 			return nil, nil
 		}
@@ -841,6 +843,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		recordFailure("getPatchedPod", err)
 		return nil, err
 	}
+	pod = updatedPod
 
 	// Clean stale attachment IPs/LSPs from previous NAD references when a new
 	// VM pod starts. This handles the stop→patch NAD→start workflow where the

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -16,6 +16,7 @@ import (
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	"github.com/scylladb/go-set/strset"
+	multustypes "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -342,6 +343,7 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 	podNets, err := c.getPodKubeovnNets(newPod)
 	if err != nil {
 		klog.Errorf("failed to get newPod nets %v", err)
+		c.recorder.Eventf(newPod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=getPodKubeovnNets error=%v", err)
 		return
 	}
 
@@ -524,12 +526,15 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to get pod nets %v", err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=getPodKubeovnNets error=%v", err)
 		return err
 	}
 
 	// check and do hotnoplug nic
-	if pod, err = c.syncKubeOvnNet(pod, podNets); err != nil {
+	var hotplugDetails string
+	if pod, hotplugDetails, err = c.syncKubeOvnNet(pod, podNets); err != nil {
 		klog.Errorf("failed to sync pod nets %v", err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=syncKubeOvnNet error=%v", err)
 		return err
 	}
 	if pod == nil {
@@ -560,11 +565,31 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	// Reconcile per-port DHCP options for pods that carry DHCP annotations.
 	// This handles annotation add/change on already-running pods without requiring a pod restart.
 	if err = c.reconcilePodDHCPOptions(pod, podNets); err != nil {
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=reconcilePodDHCPOptions error=%v", err)
 		return err
 	}
 
 	// check if route subnet is need.
-	return c.reconcileRouteSubnets(pod, needRouteSubnets(pod, podNets))
+	needRoutePodNets := needRouteSubnets(pod, podNets)
+	if err = c.reconcileRouteSubnets(pod, needRoutePodNets); err != nil {
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=reconcileRouteSubnets error=%v", err)
+		return err
+	}
+
+	if len(needAllocatePodNets) != 0 {
+		details := c.podNetworkEventDetails(pod, needAllocatePodNets)
+		if hotplugDetails != "" {
+			details += "; " + hotplugDetails
+		}
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkAllocated", "%s", details)
+	} else if hotplugDetails != "" || len(needRoutePodNets) != 0 {
+		details := []string{hotplugDetails}
+		if routeDetails := c.podNetworkEventDetails(pod, needRoutePodNets); routeDetails != "" {
+			details = append(details, routeDetails)
+		}
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkUpdated", "%s", strings.TrimPrefix(strings.Join(details, "; "), "; "))
+	}
+	return nil
 }
 
 // subnetDHCPOptionsUUIDs returns the subnet-level DHCP option UUIDs from the subnet status.
@@ -624,13 +649,15 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	name := pod.Name
 	klog.Infof("sync pod %s/%s allocated", namespace, name)
 
-	vipsMap := c.getVirtualIPs(pod, needAllocatePodNets)
 	isVMPod, vmName := isVMPod(pod)
 	podType := getPodType(pod)
 	podName := c.getNameByPod(pod)
 	// todo: isVmPod, getPodType, getNameByPod has duplicated logic
 
 	var err error
+	recordFailure := func(stage string, err error) {
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkAllocationFailed", "stage=%s error=%v", stage, err)
+	}
 	var vmKey string
 	if isVMPod && c.config.EnableKeepVMIP {
 		vmKey = fmt.Sprintf("%s/%s", namespace, vmName)
@@ -641,10 +668,11 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		// the subnet may changed when alloc static ip from the latter subnet after ns supports multi subnets
 		v4IP, v6IP, mac, subnet, err := c.acquireAddress(pod, podNet)
 		if err != nil {
-			c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", err.Error())
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", "stage=acquireAddress error=%v", err)
 			klog.Error(err)
 			return nil, err
 		}
+		podNet.Subnet = subnet
 		ipStr := util.GetStringIP(v4IP, v6IP)
 		patch[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] = ipStr
 		if mac == "" {
@@ -669,7 +697,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		}
 		if err := util.ValidateNetworkBroadcast(podNet.Subnet.Spec.CIDRBlock, ipStr); err != nil {
 			klog.Errorf("validate pod %s/%s failed: %v", namespace, name, err)
-			c.recorder.Eventf(pod, v1.EventTypeWarning, "ValidatePodNetworkFailed", err.Error())
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "ValidatePodNetworkFailed", "stage=validateNetworkBroadcast error=%v", err)
 			return nil, err
 		}
 
@@ -682,7 +710,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 				vlan, err := c.vlansLister.Get(subnet.Spec.Vlan)
 				if err != nil {
 					klog.Error(err)
-					c.recorder.Eventf(pod, v1.EventTypeWarning, "GetVlanInfoFailed", err.Error())
+					c.recorder.Eventf(pod, v1.EventTypeWarning, "GetVlanInfoFailed", "stage=getVlanInfo error=%v", err)
 					return nil, err
 				}
 				patch[fmt.Sprintf(util.VlanIDAnnotationTemplate, podNet.ProviderName)] = strconv.Itoa(vlan.Spec.ID)
@@ -694,7 +722,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 				portSecurity = true
 			}
 
-			vips := vipsMap[fmt.Sprintf("%s.%s", podNet.Subnet.Name, podNet.ProviderName)]
+			vips := c.getVirtualIPs(pod, []*kubeovnNet{podNet})[fmt.Sprintf("%s.%s", podNet.Subnet.Name, podNet.ProviderName)]
 			for ip := range strings.SplitSeq(vips, ",") {
 				if ip != "" && net.ParseIP(ip) == nil {
 					klog.Errorf("invalid vip address '%s' for pod %s", ip, name)
@@ -712,6 +740,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			var gateway string
 			if dhcpV4 != "" || dhcpV6 != "" {
 				if mtu, err = c.getSubnetMTU(subnet); err != nil {
+					recordFailure("getSubnetMTU", err)
 					return nil, err
 				}
 				gateway = subnet.Spec.Gateway
@@ -726,6 +755,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			)
 			if err != nil {
 				klog.Errorf("failed to reconcile DHCP options for port %s: %v", portName, err)
+				recordFailure("reconcilePortDHCPOptions", err)
 				return nil, err
 			}
 
@@ -737,6 +767,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 				existingLsp, err := c.OVNNbClient.GetLogicalSwitchPort(portName, true)
 				if err != nil {
 					klog.Errorf("failed to get logical switch port %s: %v", portName, err)
+					recordFailure("getLogicalSwitchPort", err)
 					return nil, err
 				}
 				if existingLsp != nil {
@@ -747,14 +778,14 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			securityGroupAnnotation := pod.Annotations[fmt.Sprintf(util.SecurityGroupAnnotationTemplate, podNet.ProviderName)]
 			if err := c.OVNNbClient.CreateLogicalSwitchPort(subnet.Name, portName, ipStr, mac, podName, pod.Namespace,
 				portSecurity, securityGroupAnnotation, vips, enableDHCP, dhcpOptions, subnet.Spec.Vpc); err != nil {
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "CreateOVNPortFailed", err.Error())
+				c.recorder.Eventf(pod, v1.EventTypeWarning, "CreateOVNPortFailed", "stage=createLogicalSwitchPort error=%v", err)
 				klog.Errorf("%v", err)
 				return nil, err
 			}
 
 			if pod.Annotations[fmt.Sprintf(util.Layer2ForwardAnnotationTemplate, podNet.ProviderName)] == "true" {
 				if err := c.OVNNbClient.EnablePortLayer2forward(portName); err != nil {
-					c.recorder.Eventf(pod, v1.EventTypeWarning, "SetOVNPortL2ForwardFailed", err.Error())
+					c.recorder.Eventf(pod, v1.EventTypeWarning, "SetOVNPortL2ForwardFailed", "stage=setLogicalSwitchPortLayer2Forward error=%v", err)
 					klog.Errorf("%v", err)
 					return nil, err
 				}
@@ -780,6 +811,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		if err := c.createOrUpdateIPCR(ipCRName, podName, ipStr, mac, subnet.Name, pod.Namespace, pod.Spec.NodeName, podType); err != nil {
 			err = fmt.Errorf("failed to create ips CR %s.%s: %w", podName, pod.Namespace, err)
 			klog.Error(err)
+			recordFailure("createOrUpdateIPCR", err)
 			return nil, err
 		}
 	}
@@ -793,6 +825,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			return nil, nil
 		}
 		klog.Errorf("failed to patch pod %s/%s: %v", namespace, name, err)
+		recordFailure("patchPodAnnotations", err)
 		return nil, err
 	}
 
@@ -805,6 +838,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			return nil, nil
 		}
 		klog.Errorf("failed to get pod %s/%s: %v", namespace, name, err)
+		recordFailure("getPatchedPod", err)
 		return nil, err
 	}
 
@@ -1105,9 +1139,27 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 	now := time.Now()
 	klog.Infof("handle delete pod %s", key)
 	podName := c.getNameByPod(pod)
+	changed := false
+	stage := "prepare"
+	released := []string{}
+	var podNets []*kubeovnNet
+	var keepIPCR, isOwnerRefToDel, isOwnerRefDeleted bool
+	var ipcrToDelete []string
+	var vmOrphanedPorts map[string]bool
 	c.podKeyMutex.LockKey(key)
 	defer func() {
 		_ = c.podKeyMutex.UnlockKey(key)
+		if err != nil {
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkReleaseFailed", "stage=%s error=%v", stage, err)
+		} else if changed {
+			details := strings.Join(released, "; ")
+			if !keepIPCR {
+				if networkDetails := c.podNetworkEventDetails(pod, podNets); networkDetails != "" {
+					details += "; " + networkDetails
+				}
+			}
+			c.recorder.Eventf(pod, v1.EventTypeNormal, "PodNetworkReleased", "%s", strings.TrimPrefix(details, "; "))
+		}
 		if err == nil {
 			c.deletingPodObjMap.Delete(key)
 		}
@@ -1135,9 +1187,6 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, podName)
 
-	var keepIPCR, isOwnerRefToDel, isOwnerRefDeleted bool
-	var ipcrToDelete []string
-	var vmOrphanedPorts map[string]bool
 	isStsPod, stsName, stsUID := isStatefulSetPod(pod)
 	if isStsPod {
 		if !pod.DeletionTimestamp.IsZero() {
@@ -1149,6 +1198,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 		}
 		if keepIPCR {
+			stage = "checkStatefulSetOwner"
 			isOwnerRefDeleted, ipcrToDelete, err = appendCheckPodNetToDel(c, pod, stsName, util.KindStatefulSet)
 			if err != nil {
 				klog.Error(err)
@@ -1160,16 +1210,19 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 		}
 	}
+	stage = "listLogicalSwitchPorts"
 	ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": podKey})
 	if err != nil {
 		klog.Errorf("failed to list lsps of pod %s: %v", podKey, err)
 		return err
 	}
+	stage = "releaseNetworkResources"
 
 	var hasAliveVMSibling bool
 	isVMPod, vmName := isVMPod(pod)
 	if isVMPod && c.config.EnableKeepVMIP {
 		for _, port := range ports {
+			stage = "cleanLogicalSwitchPortMigrateOptions"
 			if err := c.OVNNbClient.CleanLogicalSwitchPortMigrateOptions(port.Name); err != nil {
 				err = fmt.Errorf("failed to clean migrate options for vm lsp %s, %w", port.Name, err)
 				klog.Error(err)
@@ -1188,6 +1241,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 				// running the VM. If another live sibling exists (e.g. a
 				// live-migration destination while the completed source is being
 				// GC'd), its memberships must not be wiped out.
+				stage = "listVMPodSiblings"
 				siblings, listErr := c.podsLister.Pods(pod.Namespace).List(labels.Everything())
 				if listErr != nil {
 					klog.Errorf("failed to list pods in namespace %s: %v", pod.Namespace, listErr)
@@ -1197,6 +1251,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 		}
 		if keepIPCR {
+			stage = "checkVMOwner"
 			isOwnerRefDeleted, ipcrToDelete, err = appendCheckPodNetToDel(c, pod, vmName, util.KindVirtualMachineInstance)
 			if err != nil {
 				klog.Error(err)
@@ -1216,37 +1271,53 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 		}
 	}
 
-	podNets, err := c.getPodKubeovnNets(pod)
+	stage = "getPodKubeovnNets"
+	podNets, err = c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to get kube-ovn nets of pod %s: %v", podKey, err)
+		return err
 	}
 	if keepIPCR {
 		for _, port := range ports {
 			switch {
 			case vmOrphanedPorts[port.Name]:
 				// Orphaned attachment LSP from NAD hotplug: delete and release its IP.
+				stage = "getIPCR"
+				ipCR, getErr := c.ipsLister.Get(port.Name)
+				if getErr != nil && !k8serrors.IsNotFound(getErr) {
+					klog.Errorf("failed to get ip %s: %v", port.Name, getErr)
+					return getErr
+				}
 				klog.Infof("delete orphaned vm attachment lsp %s", port.Name)
+				stage = "deleteLogicalSwitchPort"
 				if err := c.OVNNbClient.DeleteLogicalSwitchPort(port.Name); err != nil {
 					klog.Errorf("failed to delete orphaned lsp %s: %v", port.Name, err)
 					return err
 				}
-				ipCR, err := c.ipsLister.Get(port.Name)
-				if err != nil {
-					if !k8serrors.IsNotFound(err) {
-						klog.Errorf("failed to get ip %s: %v", port.Name, err)
-					}
+				changed = true
+				released = append(released, "logicalSwitchPort="+port.Name)
+				if k8serrors.IsNotFound(getErr) {
 					continue
 				}
 				if ipCR.Labels[util.IPReservedLabel] != "true" {
 					klog.Infof("delete orphaned vm attachment ip CR %s", ipCR.Name)
+					stage = "deleteIPCR"
 					if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipCR.Name, metav1.DeleteOptions{}); err != nil {
 						if !k8serrors.IsNotFound(err) {
 							klog.Errorf("failed to delete ip %s: %v", ipCR.Name, err)
 							return err
 						}
+					} else {
+						changed = true
+						released = append(released, fmt.Sprintf("ipCR=%s subnet=%s", ipCR.Name, ipCR.Spec.Subnet))
 					}
 					if subnetName := ipCR.Spec.Subnet; subnetName != "" {
+						addressCount := len(c.ipam.GetPodAddress(podKey))
 						c.ipam.ReleaseAddressByNic(podKey, port.Name, subnetName)
+						if len(c.ipam.GetPodAddress(podKey)) < addressCount {
+							changed = true
+							released = append(released, fmt.Sprintf("ipam=%s subnet=%s", port.Name, subnetName))
+						}
 						c.updateSubnetStatusQueue.Add(subnetName)
 					}
 				}
@@ -1254,6 +1325,7 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 				klog.Infof("skip removing lsp %s from port groups: another alive virt-launcher pod exists for vm %s/%s", port.Name, pod.Namespace, vmName)
 			default:
 				klog.Infof("remove lsp %s from all port groups", port.Name)
+				stage = "removeLogicalSwitchPortFromPortGroups"
 				if err = c.OVNNbClient.RemovePortFromPortGroups(port.Name); err != nil {
 					klog.Errorf("failed to remove lsp %s from all port groups: %v", port.Name, err)
 					return err
@@ -1312,10 +1384,13 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 		for _, port := range ports {
 			// when lsp is deleted, the port of pod is deleted from any port-group automatically.
 			klog.Infof("delete logical switch port %s", port.Name)
+			stage = "deleteLogicalSwitchPort"
 			if err := c.OVNNbClient.DeleteLogicalSwitchPort(port.Name); err != nil {
 				klog.Errorf("failed to delete lsp %s, %v", port.Name, err)
 				return err
 			}
+			changed = true
+			released = append(released, "logicalSwitchPort="+port.Name)
 		}
 		klog.Infof("try release all ip address for deleting pod %s", podKey)
 		for _, podNet := range podNets {
@@ -1336,23 +1411,39 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 			if ipCR.Labels[util.IPReservedLabel] != "true" {
 				klog.Infof("delete ip CR %s", ipCR.Name)
+				stage = "deleteIPCR"
 				if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipCR.Name, metav1.DeleteOptions{}); err != nil {
 					if !k8serrors.IsNotFound(err) {
 						klog.Errorf("failed to delete ip %s, %v", ipCR.Name, err)
 						return err
 					}
+				} else {
+					changed = true
+					released = append(released, fmt.Sprintf("ipCR=%s subnet=%s", ipCR.Name, podNet.Subnet.Name))
 				}
 				// release ipam address after delete ip CR
+				addressCount := len(c.ipam.GetPodAddress(podKey))
 				c.ipam.ReleaseAddressByNic(podKey, portName, podNet.Subnet.Name)
+				if len(c.ipam.GetPodAddress(podKey)) < addressCount {
+					changed = true
+					released = append(released, fmt.Sprintf("ipam=%s subnet=%s", portName, podNet.Subnet.Name))
+				}
 				// Trigger subnet status update after IPAM release
 				// This is needed when IP CR is deleted without finalizer (race condition)
 				c.updateSubnetStatusQueue.Add(podNet.Subnet.Name)
 			}
 		}
 		if pod.Annotations[util.VipAnnotation] != "" {
+			vip, vipErr := c.virtualIpsLister.Get(pod.Annotations[util.VipAnnotation])
+			vipWillChange := vipErr == nil && vip.Labels[util.IPReservedLabel] != ""
+			stage = "releaseVIP"
 			if err = c.releaseVip(pod.Annotations[util.VipAnnotation]); err != nil {
 				klog.Errorf("failed to clean label from vip %s, %v", pod.Annotations[util.VipAnnotation], err)
 				return err
+			}
+			if vipWillChange {
+				changed = true
+				released = append(released, "vip="+pod.Annotations[util.VipAnnotation])
 			}
 		}
 	}
@@ -1406,10 +1497,12 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 	podNets, err := c.getPodKubeovnNets(pod)
 	if err != nil {
 		klog.Errorf("failed to pod nets %v", err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodSecurityUpdateFailed", "stage=getPodKubeovnNets error=%v", err)
 		return err
 	}
 
 	vipsMap := c.getVirtualIPs(pod, podNets)
+	updatedPodNets := make([]*kubeovnNet, 0, len(podNets))
 
 	// associated with security group
 	for _, podNet := range podNets {
@@ -1429,6 +1522,7 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 		portName := ovs.PodNameToPortName(podName, namespace, podNet.ProviderName)
 		if err = c.OVNNbClient.SetLogicalSwitchPortSecurity(portSecurity, portName, mac, ipStr, vips); err != nil {
 			klog.Errorf("failed to set security for logical switch port %s: %v", portName, err)
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodSecurityUpdateFailed", "stage=setLogicalSwitchPortSecurity error=%v", err)
 			return err
 		}
 
@@ -1445,8 +1539,13 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 		}
 		if err = c.reconcilePortSg(portName, securityGroups); err != nil {
 			klog.Errorf("reconcilePortSg failed. %v", err)
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodSecurityUpdateFailed", "stage=reconcilePortSg error=%v", err)
 			return err
 		}
+		updatedPodNets = append(updatedPodNets, podNet)
+	}
+	if len(updatedPodNets) != 0 {
+		c.recorder.Eventf(pod, v1.EventTypeNormal, "PodSecurityUpdated", "%s", c.podNetworkEventDetails(pod, updatedPodNets))
 	}
 	return nil
 }
@@ -1455,7 +1554,27 @@ func (c *Controller) handleUpdatePodSecurity(key string) error {
 // there is no mac or ip address request here in the object generated from here
 // interface name in providerName is used for annotation for ip address
 
-func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, error) {
+func stalePortNetworkDetails(pod *v1.Pod, podName string, port ovnnb.LogicalSwitchPort) (string, string, error) {
+	portPrefix := ovs.PodNameToPortName(podName, pod.Namespace, util.OvnProvider)
+	providerName := util.OvnProvider
+	if port.Name != portPrefix {
+		var ok bool
+		providerName, ok = strings.CutPrefix(port.Name, portPrefix+".")
+		if !ok || providerName == "" {
+			return "", "", fmt.Errorf("logical switch port %q does not match pod prefix %q", port.Name, portPrefix)
+		}
+	}
+	details := fmt.Sprintf("provider=%s subnet=%s ip=%s mac=%s logicalSwitchPort=%s",
+		providerName,
+		port.ExternalIDs["ls"],
+		pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerName)],
+		pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, providerName)],
+		port.Name,
+	)
+	return providerName, details, nil
+}
+
+func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, string, error) {
 	podName := c.getNameByPod(pod)
 	key := cache.NewObjectName(pod.Namespace, podName).String()
 	targetPortNameList := strset.NewWithSize(len(podNets))
@@ -1463,33 +1582,46 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	annotationsNeedToDel := []string{}
 	annotationsNeedToAdd := make(map[string]string)
 	subnetUsedByPort := make(map[string]string)
+	changedPodNets := []*kubeovnNet{}
+	hotplugDetails := []string{}
 
 	for _, podNet := range podNets {
 		portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
 		targetPortNameList.Add(portName)
-		if podNet.IPRequest != "" {
+		changed := false
+		if podNet.IPRequest != "" && pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] != podNet.IPRequest {
 			klog.Infof("pod %s/%s use custom IP %s for provider %s", pod.Namespace, pod.Name, podNet.IPRequest, podNet.ProviderName)
 			annotationsNeedToAdd[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)] = podNet.IPRequest
+			changed = true
 		}
 
-		if podNet.MacRequest != "" {
+		if podNet.MacRequest != "" && pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)] != podNet.MacRequest {
 			klog.Infof("pod %s/%s use custom MAC %s for provider %s", pod.Namespace, pod.Name, podNet.MacRequest, podNet.ProviderName)
 			annotationsNeedToAdd[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)] = podNet.MacRequest
+			changed = true
+		}
+		if changed {
+			changedPodNets = append(changedPodNets, podNet)
 		}
 	}
 
 	ports, err := c.OVNNbClient.ListNormalLogicalSwitchPorts(true, map[string]string{"pod": key})
 	if err != nil {
 		klog.Errorf("failed to list lsps of pod '%s', %v", pod.Name, err)
-		return nil, err
+		return nil, "", err
 	}
 
 	for _, port := range ports {
 		if !targetPortNameList.Has(port.Name) {
 			portsNeedToDel = append(portsNeedToDel, port.Name)
 			subnetUsedByPort[port.Name] = port.ExternalIDs["ls"]
-			portNameSlice := strings.Split(port.Name, ".")
-			providerName := strings.Join(portNameSlice[2:], ".")
+			providerName, details, parseErr := stalePortNetworkDetails(pod, podName, port)
+			if parseErr != nil {
+				klog.Warning(parseErr)
+				hotplugDetails = append(hotplugDetails, fmt.Sprintf("provider=unknown subnet=%s ip= mac= logicalSwitchPort=%s", port.ExternalIDs["ls"], port.Name))
+				continue
+			}
+			hotplugDetails = append(hotplugDetails, details)
 			if providerName == util.OvnProvider {
 				continue
 			}
@@ -1498,7 +1630,7 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	if len(portsNeedToDel) == 0 && len(annotationsNeedToAdd) == 0 {
-		return pod, nil
+		return pod, "", nil
 	}
 
 	for _, portNeedDel := range portsNeedToDel {
@@ -1506,12 +1638,12 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 		c.ipam.ReleaseAddressByNic(key, portNeedDel, subnetUsedByPort[portNeedDel])
 		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portNeedDel); err != nil {
 			klog.Errorf("failed to delete lsp %s, %v", portNeedDel, err)
-			return nil, err
+			return nil, "", err
 		}
 		if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), portNeedDel, metav1.DeleteOptions{}); err != nil {
 			if !k8serrors.IsNotFound(err) {
 				klog.Errorf("failed to delete ip %s, %v", portNeedDel, err)
-				return nil, err
+				return nil, "", err
 			}
 		}
 	}
@@ -1530,26 +1662,45 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	if len(patch) == 0 {
-		return pod, nil
+		return pod, strings.Join(hotplugDetails, "; "), nil
 	}
 
 	if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(pod.Namespace), pod.Name, patch); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, nil
+			return nil, "", nil
 		}
 		klog.Errorf("failed to clean annotations for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		return nil, err
+		return nil, "", err
 	}
 
 	if pod, err = c.config.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, nil
+			return nil, "", nil
 		}
 		klog.Errorf("failed to get pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		return nil, err
+		return nil, "", err
 	}
 
-	return pod, nil
+	if details := c.podNetworkEventDetails(pod, changedPodNets); details != "" {
+		hotplugDetails = append(hotplugDetails, details)
+	}
+	return pod, strings.Join(hotplugDetails, "; "), nil
+}
+
+func (c *Controller) podNetworkEventDetails(pod *v1.Pod, podNets []*kubeovnNet) string {
+	podName := c.getNameByPod(pod)
+	details := make([]string, 0, len(podNets))
+	for _, podNet := range podNets {
+		details = append(details, fmt.Sprintf(
+			"provider=%s subnet=%s ip=%s mac=%s logicalSwitchPort=%s",
+			podNet.ProviderName,
+			podNet.Subnet.Name,
+			pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podNet.ProviderName)],
+			pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, podNet.ProviderName)],
+			ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName),
+		))
+	}
+	return strings.Join(details, "; ")
 }
 
 func isStatefulSetPod(pod *v1.Pod) (bool, string, types.UID) {
@@ -2127,7 +2278,11 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 			}
 			result = append(result, ret)
 		} else {
+			if !isKubeOVNIPAMNetwork(netCfg) {
+				continue
+			}
 			providerName = fmt.Sprintf("%s.%s", attach.Name, attach.Namespace)
+			foundSubnet := false
 			for _, subnet := range subnets {
 				if subnet.Spec.Provider == providerName {
 					result = append(result, &kubeovnNet{
@@ -2140,12 +2295,33 @@ func (c *Controller) getPodAttachmentNet(pod *v1.Pod) ([]*kubeovnNet, error) {
 						NadNamespace:  attach.Namespace,
 						InterfaceName: attach.InterfaceRequest,
 					})
+					foundSubnet = true
 					break
 				}
+			}
+			if !foundSubnet {
+				err = fmt.Errorf("provider %s is not bound to any subnet", providerName)
+				if ignoreSubnetNotExist {
+					klog.Errorf("deleting pod %s/%s IPAM network %s %v, gc will clean its ip cr", pod.Namespace, pod.Name, providerName, err)
+					continue
+				}
+				return nil, err
 			}
 		}
 	}
 	return result, nil
+}
+
+func isKubeOVNIPAMNetwork(netCfg *multustypes.DelegateNetConf) bool {
+	if netCfg.Conf.IPAM.Type == util.CniTypeName {
+		return true
+	}
+	for _, plugin := range netCfg.ConfList.Plugins {
+		if plugin.IPAM.Type == util.CniTypeName {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Controller) validatePodIP(podName, subnetName, ipv4, ipv6 string) (bool, bool, error) {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -2,22 +2,35 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/internal"
 	"github.com/kubeovn/kube-ovn/pkg/ipam"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -1201,4 +1214,1021 @@ func TestGetPodAttachmentNetIPAMOnlyNADGone(t *testing.T) {
 	require.Len(t, nets, 1)
 	assert.Equal(t, "net1.default", nets[0].ProviderName)
 	assert.Equal(t, "ipam-net1", nets[0].Subnet.Name)
+}
+
+func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
+
+	err := controller.handleAddOrUpdatePod("default/test-pod")
+	require.Error(t, err)
+
+	assertPodEvent(t, controller, "Warning PodNetworkUpdateFailed", "stage=getPodKubeovnNets", "provider net1.default is not bound to any subnet")
+}
+
+func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-pod",
+			Namespace:       metav1.NamespaceDefault,
+			ResourceVersion: "1",
+			Annotations:     map[string]string{},
+		},
+	}
+	newPod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
+	require.NoError(t, err)
+	newPod = newPod.DeepCopy()
+	newPod.ResourceVersion = "2"
+
+	controller.enqueueUpdatePod(oldPod, newPod)
+
+	assertPodEvent(t, controller, "Warning PodNetworkUpdateFailed", "stage=getPodKubeovnNets", "provider net1.default is not bound to any subnet")
+}
+
+func TestHandleUpdatePodSecurityRecordsIPAMSubnetMissingEvent(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
+
+	err := controller.handleUpdatePodSecurity("default/test-pod")
+	require.Error(t, err)
+
+	assertPodEvent(t, controller, "Warning PodSecurityUpdateFailed", "stage=getPodKubeovnNets", "provider net1.default is not bound to any subnet")
+}
+
+func TestPodNetworkEventDetailsIncludesMultipleNetworks(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			util.IPAddressAnnotation:  "10.0.0.2",
+			util.MacAddressAnnotation: "00:00:00:00:00:01",
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, "net1.default.ovn"):  "10.1.0.2",
+			fmt.Sprintf(util.MacAddressAnnotationTemplate, "net1.default.ovn"): "00:00:00:00:00:02",
+		},
+	}}
+	controller := newFakeController(t).fakeController
+	nets := []*kubeovnNet{
+		{ProviderName: util.OvnProvider, Subnet: &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}},
+		{ProviderName: "net1.default.ovn", Subnet: &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}}},
+	}
+
+	details := controller.podNetworkEventDetails(pod, nets)
+
+	for _, part := range []string{
+		"provider=ovn", "subnet=subnet-a", "ip=10.0.0.2", "mac=00:00:00:00:00:01", "logicalSwitchPort=test-pod.default",
+		"provider=net1.default.ovn", "subnet=subnet-b", "ip=10.1.0.2", "mac=00:00:00:00:00:02", "logicalSwitchPort=test-pod.default.net1.default.ovn",
+		"; ",
+	} {
+		assert.Contains(t, details, part)
+	}
+}
+
+func TestSyncKubeOvnNetReportsAnnotationChange(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: metav1.NamespaceDefault, Annotations: map[string]string{}}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+
+	updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, []*kubeovnNet{{
+		ProviderName: util.OvnProvider,
+		IPRequest:    "10.0.0.2",
+		Subnet:       &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}},
+	}})
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, details)
+	assert.Equal(t, "10.0.0.2", updatedPod.Annotations[util.IPAddressAnnotation])
+}
+
+func TestSyncKubeOvnNetReportsNoChange(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:        "test-pod",
+		Namespace:   metav1.NamespaceDefault,
+		Annotations: map[string]string{util.IPAddressAnnotation: "10.0.0.2"},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+
+	_, details, err := fc.fakeController.syncKubeOvnNet(pod, []*kubeovnNet{{
+		ProviderName: util.OvnProvider,
+		IPRequest:    "10.0.0.2",
+	}})
+
+	require.NoError(t, err)
+	assert.Empty(t, details)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestSyncKubeOvnNetParsesStalePortProviders(t *testing.T) {
+	const (
+		provider = "net1.default.ovn"
+		keepKey  = "example.com/keep"
+	)
+
+	t.Run("default OVN port", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{util.AllocatedAnnotation: "true", keepKey: "true"},
+		}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+		require.NoError(t, err)
+		portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "true", updatedPod.Annotations[util.AllocatedAnnotation])
+		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
+		assert.Contains(t, details, "provider="+util.OvnProvider)
+		assert.Contains(t, details, "logicalSwitchPort="+portName)
+	})
+
+	t.Run("attachment provider containing dots", func(t *testing.T) {
+		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
+		}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+		require.NoError(t, err)
+		portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+		require.NoError(t, err)
+		assert.NotContains(t, updatedPod.Annotations, providerKey)
+		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
+		assert.Contains(t, details, "provider="+provider)
+		assert.Contains(t, details, "logicalSwitchPort="+portName)
+	})
+
+	t.Run("VM name containing dots", func(t *testing.T) {
+		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "virt-launcher-test", Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: kubevirtv1.SchemeGroupVersion.String(), Kind: util.KindVirtualMachineInstance, Name: "test.vm",
+			}},
+		}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+		require.NoError(t, err)
+		fc.fakeController.config.EnableKeepVMIP = true
+		portName := ovs.PodNameToPortName("test.vm", pod.Namespace, provider)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+		require.NoError(t, err)
+		assert.NotContains(t, updatedPod.Annotations, providerKey)
+		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
+		assert.Contains(t, details, "provider="+provider)
+		assert.Contains(t, details, "logicalSwitchPort="+portName)
+	})
+
+	t.Run("unmatched pod prefix", func(t *testing.T) {
+		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
+		}}
+		_, subnet := podEventFixture()
+		portName := "legacy-port-name"
+		ipCR := &kubeovnv1.IP{ObjectMeta: metav1.ObjectMeta{Name: portName}, Spec: kubeovnv1.IPSpec{Subnet: subnet.Name}}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}, IPs: []*kubeovnv1.IP{ipCR},
+		})
+		require.NoError(t, err)
+		fc.fakeController.config.EnableNonPrimaryCNI = true
+		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+		_, _, _, err = fc.fakeController.ipam.GetStaticAddress("default/test-pod", portName, "10.0.0.2", nil, subnet.Name, false)
+		require.NoError(t, err)
+		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{
+			Name: portName,
+			ExternalIDs: map[string]string{
+				"pod": "default/test-pod",
+				"ls":  subnet.Name,
+			},
+		}}, nil)
+		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+		err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+		require.NoError(t, err)
+		updatedPod, err := fc.fakeController.config.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "true", updatedPod.Annotations[providerKey])
+		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
+		assert.True(t, k8serrors.IsNotFound(err))
+		assert.Empty(t, fc.fakeController.ipam.GetPodAddress("default/test-pod"))
+		event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider=unknown", "subnet="+subnet.Name, "logicalSwitchPort="+portName)
+		assert.NotContains(t, event, "provider="+provider)
+		assert.NotContains(t, event, "provider= ")
+		assertNoPodEvent(t, fc.fakeController)
+	})
+}
+
+func TestHandleUpdatePodSecurityRecordsSuccess(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[util.MacAddressAnnotation] = "00:00:00:00:00:01"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortSecurity(false, portName, "00:00:00:00:00:01", "10.0.0.2", "").Return(nil)
+	fc.mockOvnClient.EXPECT().GetLogicalSwitchPort(portName, false).Return(&ovnnb.LogicalSwitchPort{Name: portName, ExternalIDs: map[string]string{}}, nil)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortExternalIDs(portName, map[string]string{"security_groups": ""}).Return(nil)
+
+	err = fc.fakeController.handleUpdatePodSecurity("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController, "Normal PodSecurityUpdated", "provider=ovn", "subnet=subnet-a", "ip=10.0.0.2", "mac=00:00:00:00:00:01", "logicalSwitchPort=test-pod.default")
+}
+
+func TestHandleUpdatePodSecurityRecordsFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortSecurity(false, portName, "", "", "").Return(errors.New("set security failed"))
+
+	err = fc.fakeController.handleUpdatePodSecurity("default/test-pod")
+
+	require.EqualError(t, err, "set security failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodSecurityUpdateFailed", "stage=setLogicalSwitchPortSecurity", "set security failed")
+}
+
+func TestHandleUpdatePodSecuritySkipsNonOVNNetworkWithoutSuccess(t *testing.T) {
+	controller := newIPAMNetworkController(t)
+
+	err := controller.handleUpdatePodSecurity("default/test-pod")
+
+	require.NoError(t, err)
+	assertNoPodEvent(t, controller)
+}
+
+func TestHandleUpdatePodSecurityReportsOnlyProcessedOVNNetworks(t *testing.T) {
+	const ipamProvider = "net1.default"
+	pod, ovnSubnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[util.MacAddressAnnotation] = "00:00:00:00:00:01"
+	pod.Annotations[nadv1.NetworkAttachmentAnnot] = `[{"name":"net1"}]`
+	pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, ipamProvider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, ipamProvider)] = "10.1.0.2"
+	ipamSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "ipam-subnet"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Protocol: kubeovnv1.ProtocolIPv4, Provider: ipamProvider,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{ovnSubnet, ipamSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: ipamNADConfig(util.CniTypeName)},
+		}},
+	})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortSecurity(false, portName, "00:00:00:00:00:01", "10.0.0.2", "").Return(nil)
+	fc.mockOvnClient.EXPECT().GetLogicalSwitchPort(portName, false).Return(&ovnnb.LogicalSwitchPort{Name: portName, ExternalIDs: map[string]string{}}, nil)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortExternalIDs(portName, map[string]string{"security_groups": ""}).Return(nil)
+
+	err = fc.fakeController.handleUpdatePodSecurity("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodSecurityUpdated", "provider=ovn", "logicalSwitchPort=test-pod.default")
+	assert.NotContains(t, event, "provider="+ipamProvider)
+	assert.NotContains(t, event, "logicalSwitchPort=test-pod.default.net1.default")
+}
+
+func TestHandleDeletePodRecordsReleasedPort(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-pod"}).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController, "Normal PodNetworkReleased", "provider=ovn", "subnet=subnet-a", "logicalSwitchPort=test-pod.default")
+}
+
+func TestHandleDeletePodRecordsFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-pod"}).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(errors.New("delete lsp failed"))
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.EqualError(t, err, "delete lsp failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=deleteLogicalSwitchPort", "delete lsp failed")
+}
+
+func TestHandleDeletePodRetriesOrphanedVMPortIPLookupFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+	pod.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: kubevirtv1.SchemeGroupVersion.String(),
+		Kind:       util.KindVirtualMachineInstance,
+		Name:       "test-vm",
+	}}
+	portName := ovs.PodNameToPortName("test-vm", pod.Namespace, "old.default.ovn")
+	ipCR := &kubeovnv1.IP{ObjectMeta: metav1.ObjectMeta{Name: portName}, Spec: kubeovnv1.IPSpec{
+		PodName: "test-vm", Namespace: pod.Namespace, Subnet: subnet.Name,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}, IPs: []*kubeovnv1.IP{ipCR},
+	})
+	require.NoError(t, err)
+	fc.fakeController.config.EnableKeepVMIP = true
+	ipLister := &errorOnceIPLister{ip: ipCR, err: errors.New("get ip failed")}
+	fc.fakeController.ipsLister = ipLister
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	_, _, _, err = fc.fakeController.ipam.GetStaticAddress("default/test-vm", portName, "10.0.0.2", nil, subnet.Name, false)
+	require.NoError(t, err)
+
+	mockCtrl := gomock.NewController(t)
+	mockVMIs := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
+	mockVMs := kubecli.NewMockVirtualMachineInterface(mockCtrl)
+	mockKubevirt := kubecli.NewMockKubevirtClient(mockCtrl)
+	mockKubevirt.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(mockVMIs).Times(2)
+	mockVMIs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(&kubevirtv1.VirtualMachineInstance{}, nil).Times(2)
+	mockKubevirt.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(mockVMs).Times(4)
+	vm := &kubevirtv1.VirtualMachine{Spec: kubevirtv1.VirtualMachineSpec{Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.LogicalSwitchAnnotation: subnet.Name}},
+		Spec: kubevirtv1.VirtualMachineInstanceSpec{Networks: []kubevirtv1.Network{{
+			Name: "net1",
+			NetworkSource: kubevirtv1.NetworkSource{Multus: &kubevirtv1.MultusNetwork{
+				NetworkName: "default/net1",
+			}},
+		}}},
+	}}}
+	mockVMs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(vm, nil).Times(4)
+	fc.fakeController.config.KubevirtClient = mockKubevirt
+
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-vm"}).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil).Times(2)
+	fc.mockOvnClient.EXPECT().CleanLogicalSwitchPortMigrateOptions(portName).Return(nil).Times(2)
+	deleteCalls := 0
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).DoAndReturn(func(string) error {
+		deleteCalls++
+		return nil
+	}).AnyTimes()
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.EqualError(t, err, "get ip failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=getIPCR", "get ip failed")
+	assertNoPodEvent(t, fc.fakeController)
+	assert.Zero(t, deleteCalls)
+	_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, fc.fakeController.ipam.GetPodAddress("default/test-vm"))
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleteCalls)
+	_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
+	assert.True(t, k8serrors.IsNotFound(err))
+	assert.Empty(t, fc.fakeController.ipam.GetPodAddress("default/test-vm"))
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkReleased", "logicalSwitchPort="+portName, "ipCR="+portName, "ipam="+portName)
+	assert.NotContains(t, event, "provider=ovn")
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleDeletePodReportsStatefulSetOwnerCheckStage(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Name = "test-sts-0"
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+	pod.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+		Kind:       util.KindStatefulSet,
+		Name:       "test-sts",
+		UID:        "sts-uid",
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.fakeController.config.KubeClient.(*k8sfake.Clientset).PrependReactor("get", "statefulsets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("get statefulset failed")
+	})
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.EqualError(t, err, "get statefulset failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=checkStatefulSetOwner", "get statefulset failed")
+}
+
+func TestHandleDeletePodWithoutResourcesDoesNotRecordSuccess(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-pod"}).Return(nil, nil)
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleDeletePodWithReplacementDoesNotRecordSuccess(t *testing.T) {
+	deletedPod, subnet := podEventFixture()
+	livePod := deletedPod.DeepCopy()
+	livePod.UID = "replacement-uid"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{livePod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	storeDeletingPod(fc.fakeController, deletedPod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleAddOrUpdatePodRecordsAllocationSuccess(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.MacAddressAnnotation] = "00:00:00:00:00:01"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(subnet.Name, portName, gomock.Any(), subnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(subnet.Name, portName, gomock.Any(), gomock.Any(), pod.Name, pod.Namespace, false, "", "", false, gomock.Any(), util.DefaultVpc).Return(nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController, "Normal PodNetworkAllocated", "provider=ovn", "subnet=subnet-a", "ip=10.0.0.", "mac=00:00:00:00:00:01", "logicalSwitchPort=test-pod.default")
+}
+
+func TestHandleAddOrUpdatePodReportsOnlyAllocatedNetworks(t *testing.T) {
+	const provider = "net1.default.ovn"
+	pod, defaultSubnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[nadv1.NetworkAttachmentAnnot] = `[{"name":"net1"}]`
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] = "subnet-b"
+	attachmentSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Gateway: "10.1.0.1", Protocol: kubeovnv1.ProtocolIPv4, Provider: provider, Vpc: util.DefaultVpc,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{defaultSubnet, attachmentSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion":"0.3.1","name":"net1","type":"kube-ovn","provider":"net1.default.ovn"}`},
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(attachmentSubnet.Name, attachmentSubnet.Spec.CIDRBlock, attachmentSubnet.Spec.Gateway, nil))
+	defaultPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	attachmentPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: defaultPort}}, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(attachmentSubnet.Name, attachmentPort, gomock.Any(), attachmentSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(defaultSubnet.Name, defaultPort, gomock.Any(), defaultSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(attachmentSubnet.Name, attachmentPort, gomock.Any(), gomock.Any(), pod.Name, pod.Namespace, false, "", "", false, gomock.Any(), util.DefaultVpc).Return(nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkAllocated", "provider="+provider, "subnet=subnet-b", "logicalSwitchPort="+attachmentPort)
+	assert.NotContains(t, event, "provider=ovn")
+}
+
+func TestHandleAddOrUpdatePodCombinesAllocatedAndRemovedNetworks(t *testing.T) {
+	const (
+		allocatedProvider = "net1.default.ovn"
+		removedProvider   = "old.default.ovn"
+	)
+	pod, defaultSubnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[nadv1.NetworkAttachmentAnnot] = `[{"name":"net1"}]`
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, allocatedProvider)] = "subnet-b"
+	pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, removedProvider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, removedProvider)] = "subnet-old"
+	attachmentSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Gateway: "10.1.0.1", Protocol: kubeovnv1.ProtocolIPv4, Provider: allocatedProvider, Vpc: util.DefaultVpc,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{defaultSubnet, attachmentSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion":"0.3.1","name":"net1","type":"kube-ovn","provider":"net1.default.ovn"}`},
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(attachmentSubnet.Name, attachmentSubnet.Spec.CIDRBlock, attachmentSubnet.Spec.Gateway, nil))
+	defaultPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	allocatedPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, allocatedProvider)
+	removedPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, removedProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{
+		{Name: defaultPort},
+		{Name: removedPort, ExternalIDs: map[string]string{"ls": "subnet-old"}},
+	}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(removedPort).Return(nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(attachmentSubnet.Name, allocatedPort, gomock.Any(), attachmentSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(defaultSubnet.Name, defaultPort, gomock.Any(), defaultSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(attachmentSubnet.Name, allocatedPort, gomock.Any(), gomock.Any(), pod.Name, pod.Namespace, false, "", "", false, gomock.Any(), util.DefaultVpc).Return(nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController,
+		"Normal PodNetworkAllocated",
+		"provider="+allocatedProvider,
+		"logicalSwitchPort="+allocatedPort,
+		"provider="+removedProvider,
+		"logicalSwitchPort="+removedPort,
+	)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestHandleAddOrUpdatePodReportsOnlyRoutedNetworks(t *testing.T) {
+	const provider = "net1.default.ovn"
+	pod, defaultSubnet := podEventFixture()
+	pod.Spec.NodeName = "node-a"
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[nadv1.NetworkAttachmentAnnot] = `[{"name":"net1"}]`
+	pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] = "subnet-b"
+	pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, provider)] = "10.1.0.2"
+	attachmentSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Gateway: "10.1.0.1", Protocol: kubeovnv1.ProtocolIPv4, Provider: provider, Vpc: "other-vpc",
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Nodes:   []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: pod.Spec.NodeName}}},
+		Subnets: []*kubeovnv1.Subnet{defaultSubnet, attachmentSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion":"0.3.1","name":"net1","type":"kube-ovn","provider":"net1.default.ovn"}`},
+		}},
+	})
+	require.NoError(t, err)
+	defaultPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	attachmentPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: defaultPort}, {Name: attachmentPort}}, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(defaultSubnet.Name, defaultPort, gomock.Any(), defaultSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(attachmentSubnet.Name, attachmentPort, gomock.Any(), attachmentSubnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+	fc.mockOvnClient.EXPECT().ListPortGroups(gomock.Any()).Return(nil, nil).Times(2)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider="+provider, "subnet=subnet-b", "logicalSwitchPort="+attachmentPort)
+	assert.NotContains(t, event, "provider=ovn")
+}
+
+func TestHandleAddOrUpdatePodRecordsAllocationDHCPFailureOnce(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(subnet.Name, portName, gomock.Any(), subnet.Spec.CIDRBlock, "", "", "", 0).Return(nil, false, errors.New("allocate dhcp failed"))
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.EqualError(t, err, "allocate dhcp failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkAllocationFailed", "stage=reconcilePortDHCPOptions", "allocate dhcp failed")
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestReconcileAllocateSubnetsSpecificFailureEventsIncludeStage(t *testing.T) {
+	t.Run("acquire address", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.Error(t, err)
+		assertPodEvent(t, fc.fakeController, "Warning AcquireAddressFailed", "stage=acquireAddress", err.Error())
+	})
+
+	t.Run("validate network broadcast", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		pod.Annotations[util.VipAnnotation] = "broadcast-vip"
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+		vip := &kubeovnv1.Vip{
+			ObjectMeta: metav1.ObjectMeta{Name: "broadcast-vip", Labels: map[string]string{}},
+			Spec:       kubeovnv1.VipSpec{Subnet: subnet.Name},
+			Status:     kubeovnv1.VipStatus{V4ip: "10.0.0.0", Mac: "00:00:00:00:00:01"},
+		}
+		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Create(context.Background(), vip, metav1.CreateOptions{})
+		require.NoError(t, err)
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		require.NoError(t, indexer.Add(vip))
+		fc.fakeController.virtualIpsLister = kubeovnlister.NewVipLister(indexer)
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.Error(t, err)
+		assertPodEvent(t, fc.fakeController, "Warning ValidatePodNetworkFailed", "stage=validateNetworkBroadcast", err.Error())
+	})
+
+	t.Run("get vlan info", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		subnet.Spec.Vlan = "missing-vlan"
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.Error(t, err)
+		assertPodEvent(t, fc.fakeController, "Warning GetVlanInfoFailed", "stage=getVlanInfo", err.Error())
+	})
+
+	t.Run("create logical switch port", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+		fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+		fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("create port failed"))
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.EqualError(t, err, "create port failed")
+		assertPodEvent(t, fc.fakeController, "Warning CreateOVNPortFailed", "stage=createLogicalSwitchPort", err.Error())
+	})
+
+	t.Run("set logical switch port layer2 forward", func(t *testing.T) {
+		pod, subnet := podEventFixture()
+		pod.Annotations[fmt.Sprintf(util.Layer2ForwardAnnotationTemplate, util.OvnProvider)] = "true"
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+		fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+		fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		fc.mockOvnClient.EXPECT().EnablePortLayer2forward(gomock.Any()).Return(errors.New("enable layer2 forward failed"))
+
+		_, err = fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{Type: providerTypeOriginal, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true}})
+
+		require.EqualError(t, err, "enable layer2 forward failed")
+		assertPodEvent(t, fc.fakeController, "Warning SetOVNPortL2ForwardFailed", "stage=setLogicalSwitchPortLayer2Forward", err.Error())
+	})
+}
+
+func TestHandleAddOrUpdatePodReportsActualAllocatedSubnet(t *testing.T) {
+	pod, subnetA := podEventFixture()
+	pod.Annotations = map[string]string{
+		util.IPAddressAnnotation:                                      "10.1.0.2",
+		util.MacAddressAnnotation:                                     "00:00:00:00:00:01",
+		fmt.Sprintf(util.PortVipAnnotationTemplate, util.OvnProvider): "10.1.0.100",
+	}
+	subnetB := subnetA.DeepCopy()
+	subnetB.Name = "subnet-b"
+	subnetB.Spec.CIDRBlock = "10.1.0.0/24"
+	subnetB.Spec.Gateway = "10.1.0.1"
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			util.LogicalSwitchAnnotation: "subnet-a,subnet-b",
+		},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:       []*corev1.Pod{pod},
+		Subnets:    []*kubeovnv1.Subnet{subnetA, subnetB},
+		Namespaces: []*corev1.Namespace{namespace},
+	})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnetA.Name, subnetA.Spec.CIDRBlock, subnetA.Spec.Gateway, nil))
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnetB.Name, subnetB.Spec.CIDRBlock, subnetB.Spec.Gateway, nil))
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil).Times(2)
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort("subnet-b", gomock.Any(), "10.1.0.2", "00:00:00:00:00:01", pod.Name, pod.Namespace, false, "", "10.1.0.100", false, gomock.Any(), util.DefaultVpc).Return(nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkAllocated", "provider=ovn", "subnet=subnet-b", "ip=10.1.0.2")
+	assert.NotContains(t, event, "subnet=subnet-a")
+}
+
+func TestHandleAddOrUpdatePodRecordsHotplugUpdate(t *testing.T) {
+	const provider = "net1.default.ovn"
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			nadv1.NetworkAttachmentAnnot:                                `[{"name":"net1","ips":["10.1.0.2"]}]`,
+			fmt.Sprintf(util.AllocatedAnnotationTemplate, provider):     "true",
+			fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider): "subnet-b",
+			fmt.Sprintf(util.MacAddressAnnotationTemplate, provider):    "00:00:00:00:00:02",
+			fmt.Sprintf(util.RoutedAnnotationTemplate, provider):        "true",
+		},
+	}}
+	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-b"}, Spec: kubeovnv1.SubnetSpec{
+		CIDRBlock: "10.1.0.0/24", Gateway: "10.1.0.1", Protocol: kubeovnv1.ProtocolIPv4, Provider: provider, Vpc: util.DefaultVpc,
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods:    []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{subnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion":"0.3.1","name":"net1","type":"kube-ovn","provider":"net1.default.ovn"}`},
+		}},
+	})
+	require.NoError(t, err)
+	fc.fakeController.config.EnableNonPrimaryCNI = true
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(subnet.Name, portName, gomock.Any(), subnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider=net1.default.ovn", "subnet=subnet-b", "ip=10.1.0.2", "mac=00:00:00:00:00:02", "logicalSwitchPort=test-pod.default.net1.default.ovn")
+}
+
+func TestHandleAddOrUpdatePodReportsRemovedHotplugNetwork(t *testing.T) {
+	const removedProvider = "old.default.ovn"
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	pod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, removedProvider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, removedProvider)] = "true"
+	pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, removedProvider)] = "subnet-old"
+	pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, removedProvider)] = "10.2.0.2"
+	pod.Annotations[fmt.Sprintf(util.MacAddressAnnotationTemplate, removedProvider)] = "00:00:00:00:00:03"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	defaultPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	removedPort := ovs.PodNameToPortName(pod.Name, pod.Namespace, removedProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{
+		{Name: defaultPort},
+		{Name: removedPort, ExternalIDs: map[string]string{"ls": "subnet-old"}},
+	}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(removedPort).Return(nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(subnet.Name, defaultPort, gomock.Any(), subnet.Spec.CIDRBlock, "", "", "", 0).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider="+removedProvider, "subnet=subnet-old", "logicalSwitchPort="+removedPort)
+	assert.NotContains(t, event, "provider=ovn")
+}
+
+func TestHandleAddOrUpdatePodRecordsDHCPUpdateFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false, errors.New("update dhcp failed"))
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.EqualError(t, err, "update dhcp failed")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkUpdateFailed", "stage=reconcilePodDHCPOptions", "update dhcp failed")
+}
+
+func TestHandleAddOrUpdatePodRecordsRouteFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Spec.NodeName = "missing-node"
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-node")
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkUpdateFailed", "stage=reconcileRouteSubnets", "missing-node")
+}
+
+func TestHandleAddOrUpdatePodWithoutWorkDoesNotRecordSuccess(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.AllocatedAnnotation] = "true"
+	pod.Annotations[util.RoutedAnnotation] = "true"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, nil)
+	fc.mockOvnClient.EXPECT().ReconcilePortDHCPOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ovs.DHCPOptionsUUIDs{}, false, nil)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.NoError(t, err)
+	assertNoPodEvent(t, fc.fakeController)
+}
+
+func podEventFixture() (*corev1.Pod, *kubeovnv1.Subnet) {
+	return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: metav1.NamespaceDefault, UID: "pod-uid", Annotations: map[string]string{
+				util.LogicalSwitchAnnotation: "subnet-a",
+			}},
+		}, &kubeovnv1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"},
+			Spec: kubeovnv1.SubnetSpec{
+				CIDRBlock: "10.0.0.0/24",
+				Gateway:   "10.0.0.1",
+				Protocol:  kubeovnv1.ProtocolIPv4,
+				Provider:  util.OvnProvider,
+				Vpc:       util.DefaultVpc,
+				Default:   true,
+			},
+			Status: kubeovnv1.SubnetStatus{V4AvailableIPs: internal.NewBigInt(253)},
+		}
+}
+
+func storeDeletingPod(controller *Controller, pod *corev1.Pod) {
+	controller.deletingPodObjMap = xsync.NewMap[string, *corev1.Pod]()
+	controller.deletingPodObjMap.Store("default/test-pod", pod)
+}
+
+type errorOnceIPLister struct {
+	ip    *kubeovnv1.IP
+	err   error
+	calls int
+}
+
+func (l *errorOnceIPLister) List(labels.Selector) ([]*kubeovnv1.IP, error) {
+	return []*kubeovnv1.IP{l.ip}, nil
+}
+
+func (l *errorOnceIPLister) Get(string) (*kubeovnv1.IP, error) {
+	l.calls++
+	if l.calls == 1 {
+		return nil, l.err
+	}
+	return l.ip, nil
+}
+
+func newIPAMNetworkController(t *testing.T) *Controller {
+	t.Helper()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			nadv1.NetworkAttachmentAnnot: `[{"name":"net1"}]`,
+		},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods: []*corev1.Pod{pod},
+		Subnets: []*kubeovnv1.Subnet{{ObjectMeta: metav1.ObjectMeta{Name: "ipam-subnet"}, Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.1.0.0/24", Provider: "net1.default", Protocol: kubeovnv1.ProtocolIPv4,
+		}}},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: metav1.NamespaceDefault},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: ipamNADConfig(util.CniTypeName)},
+		}},
+	})
+	require.NoError(t, err)
+	fc.fakeController.config.EnableNonPrimaryCNI = true
+	return fc.fakeController
+}
+
+func TestGetPodAttachmentNetIgnoresNonKubeOVNIPAMWithoutSubnet(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig("host-local"))
+	pod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
+	require.NoError(t, err)
+
+	nets, err := controller.getPodAttachmentNet(pod)
+	require.NoError(t, err)
+	assert.Empty(t, nets)
+}
+
+func TestGetPodAttachmentNetIPAMConflistWithoutSubnet(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr bool
+	}{
+		{
+			name:    "Kube-OVN IPAM returns an error",
+			config:  `{"cniVersion":"0.3.1","name":"net1","plugins":[{"type":"macvlan","ipam":{"type":"kube-ovn"}}]}`,
+			wantErr: true,
+		},
+		{
+			name:   "non-Kube-OVN IPAM is ignored",
+			config: `{"cniVersion":"0.3.1","name":"net1","plugins":[{"type":"macvlan","ipam":{"type":"host-local"}}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := newIPAMSubnetMissingController(t, tt.config)
+			pod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
+			require.NoError(t, err)
+
+			nets, err := controller.getPodAttachmentNet(pod)
+			if tt.wantErr {
+				require.EqualError(t, err, "provider net1.default is not bound to any subnet")
+				return
+			}
+			require.NoError(t, err)
+			assert.Empty(t, nets)
+		})
+	}
+}
+
+func TestGetPodAttachmentNetIgnoresMissingKubeOVNIPAMSubnetForDeletingPod(t *testing.T) {
+	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
+	pod, err := controller.podsLister.Pods(metav1.NamespaceDefault).Get("test-pod")
+	require.NoError(t, err)
+	pod = pod.DeepCopy()
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+
+	nets, err := controller.getPodAttachmentNet(pod)
+	require.NoError(t, err)
+	assert.Empty(t, nets)
+}
+
+func newIPAMSubnetMissingController(t *testing.T, config string) *Controller {
+	t.Helper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: `[{"name": "net1"}]`,
+			},
+		},
+	}
+
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods: []*corev1.Pod{pod},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "net1",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: nadv1.NetworkAttachmentDefinitionSpec{
+					Config: config,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	controller := fakeController.fakeController
+	controller.config.EnableNonPrimaryCNI = true
+	return controller
+}
+
+func ipamNADConfig(ipamType string) string {
+	return fmt.Sprintf(`{"cniVersion":"0.3.1","name":"net1","type":"macvlan","ipam":{"type":%q}}`, ipamType)
+}
+
+func assertPodEvent(t *testing.T, controller *Controller, parts ...string) string {
+	t.Helper()
+
+	recorder := controller.recorder.(*record.FakeRecorder)
+	select {
+	case event := <-recorder.Events:
+		for _, part := range parts {
+			assert.Contains(t, event, part)
+		}
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("expected pod event")
+		return ""
+	}
+}
+
+func assertNoPodEvent(t *testing.T, controller *Controller) {
+	t.Helper()
+
+	recorder := controller.recorder.(*record.FakeRecorder)
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected pod event: %s", event)
+	default:
+	}
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -1225,6 +1226,20 @@ func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 	assertPodEvent(t, controller, "Warning PodNetworkUpdateFailed", "stage=getPodKubeovnNets", "provider net1.default is not bound to any subnet")
 }
 
+func TestHandleAddOrUpdatePodSyncFailureRecordsOriginalPod(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	injectedErr := errors.New("list ports failed")
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, injectedErr)
+	events := useRealPodEventRecorder(t, fc.fakeController)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.ErrorIs(t, err, injectedErr)
+	assertRecordedPodEvent(t, events, pod, "PodNetworkUpdateFailed", "stage=syncKubeOvnNet")
+}
+
 func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
 	oldPod := &corev1.Pod{
@@ -1899,6 +1914,26 @@ func TestReconcileAllocateSubnetsSpecificFailureEventsIncludeStage(t *testing.T)
 	})
 }
 
+func TestReconcileAllocateSubnetsRefetchFailureRecordsOriginalPod(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	injectedErr := errors.New("get patched pod failed")
+	fc.fakeController.config.KubeClient.(*k8sfake.Clientset).PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	events := useRealPodEventRecorder(t, fc.fakeController)
+
+	updatedPod, err := fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{
+		Type: providerTypeIPAM, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true,
+	}})
+
+	require.Nil(t, updatedPod)
+	require.ErrorIs(t, err, injectedErr)
+	assertRecordedPodEvent(t, events, pod, "PodNetworkAllocationFailed", "stage=getPatchedPod")
+}
+
 func TestHandleAddOrUpdatePodReportsActualAllocatedSubnet(t *testing.T) {
 	pod, subnetA := podEventFixture()
 	pod.Annotations = map[string]string{
@@ -2230,5 +2265,40 @@ func assertNoPodEvent(t *testing.T, controller *Controller) {
 	case event := <-recorder.Events:
 		t.Fatalf("unexpected pod event: %s", event)
 	default:
+	}
+}
+
+func useRealPodEventRecorder(t *testing.T, controller *Controller) <-chan *corev1.Event {
+	t.Helper()
+
+	events := make(chan *corev1.Event, 1)
+	broadcaster := record.NewBroadcaster()
+	watcher := broadcaster.StartEventWatcher(func(event *corev1.Event) {
+		events <- event
+	})
+	t.Cleanup(func() {
+		watcher.Stop()
+		broadcaster.Shutdown()
+	})
+	controller.recorder = broadcaster.NewRecorder(kubescheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+	return events
+}
+
+func assertRecordedPodEvent(t *testing.T, events <-chan *corev1.Event, pod *corev1.Pod, reason string, messageParts ...string) {
+	t.Helper()
+
+	select {
+	case event := <-events:
+		assert.Equal(t, corev1.EventTypeWarning, event.Type)
+		assert.Equal(t, reason, event.Reason)
+		assert.Equal(t, "Pod", event.InvolvedObject.Kind)
+		assert.Equal(t, pod.Namespace, event.InvolvedObject.Namespace)
+		assert.Equal(t, pod.Name, event.InvolvedObject.Name)
+		assert.Equal(t, pod.UID, event.InvolvedObject.UID)
+		for _, part := range messageParts {
+			assert.Contains(t, event.Message, part)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected pod event")
 	}
 }

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -39,6 +39,12 @@ const (
 	kernelModuleIP6Tables = "ip6_tables"
 )
 
+var (
+	setInterfaceBandwidth = ovs.SetInterfaceBandwidth
+	configInterfaceMirror = ovs.ConfigInterfaceMirror
+	setNetemQos           = ovs.SetNetemQos
+)
+
 // ControllerRuntime represents runtime specific controller members
 type ControllerRuntime struct {
 	iptables         map[string]*iptables.IPTables
@@ -885,58 +891,69 @@ func (c *Controller) handleUpdatePod(key string) error {
 	ifaceID := ovs.PodNameToPortName(podName, pod.Namespace, util.OvnProvider)
 	ovsIngress := pod.Annotations[util.EgressRateAnnotation]
 	ovsEgress := pod.Annotations[util.IngressRateAnnotation]
-	err = ovs.SetInterfaceBandwidth(podName, pod.Namespace, ifaceID, ovsIngress, ovsEgress)
+	err = setInterfaceBandwidth(podName, pod.Namespace, ifaceID, ovsIngress, ovsEgress)
 	if err != nil {
 		klog.Error(err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=bandwidth provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
 		return err
 	}
-	err = ovs.ConfigInterfaceMirror(c.config.EnableMirror, pod.Annotations[util.MirrorControlAnnotation], ifaceID)
+	err = configInterfaceMirror(c.config.EnableMirror, pod.Annotations[util.MirrorControlAnnotation], ifaceID)
 	if err != nil {
 		klog.Error(err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
 		return err
 	}
 	// set linux-netem qos
-	err = ovs.SetNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[util.NetemQosLatencyAnnotation], pod.Annotations[util.NetemQosLimitAnnotation], pod.Annotations[util.NetemQosLossAnnotation], pod.Annotations[util.NetemQosJitterAnnotation])
+	err = setNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[util.NetemQosLatencyAnnotation], pod.Annotations[util.NetemQosLimitAnnotation], pod.Annotations[util.NetemQosLossAnnotation], pod.Annotations[util.NetemQosJitterAnnotation])
 	if err != nil {
 		klog.Error(err)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
 		return err
 	}
+	processed := []string{fmt.Sprintf("provider=%s interface=%s", util.OvnProvider, ifaceID)}
 
 	// set multus-nic bandwidth
 	attachNets, err := nadutils.ParsePodNetworkAnnotation(pod)
 	if err != nil {
-		if _, ok := err.(*nadv1.NoK8sNetworkError); ok {
-			return nil
+		if _, ok := err.(*nadv1.NoK8sNetworkError); !ok {
+			klog.Error(err)
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=parseNetworkAttachment provider=unknown interface=unknown node=%s: %v", c.config.NodeName, err)
+			return err
 		}
-		klog.Error(err)
-		return err
 	}
 	for _, multiNet := range attachNets {
 		provider := fmt.Sprintf("%s.%s.%s", multiNet.Name, multiNet.Namespace, util.OvnProvider)
+		multiNetPodName := pod.Name
 		if pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)] != "" {
-			podName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)]
+			multiNetPodName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)]
 		}
 		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] == "true" {
-			ifaceID = ovs.PodNameToPortName(podName, pod.Namespace, provider)
-
-			err = ovs.SetInterfaceBandwidth(podName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)])
+			ifaceID = ovs.PodNameToPortName(multiNetPodName, pod.Namespace, provider)
+			err = setInterfaceBandwidth(multiNetPodName, pod.Namespace, ifaceID,
+				pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)],
+				pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)])
 			if err != nil {
 				klog.Error(err)
+				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=bandwidth provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
-			err = ovs.ConfigInterfaceMirror(c.config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, provider)], ifaceID)
+			err = configInterfaceMirror(c.config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, provider)], ifaceID)
 			if err != nil {
 				klog.Error(err)
+				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
-			err = ovs.SetNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)])
+			err = setNetemQos(multiNetPodName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)])
 			if err != nil {
 				klog.Error(err)
+				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
+			processed = append(processed, fmt.Sprintf("provider=%s interface=%s", provider, ifaceID))
 		}
 	}
 
+	c.recorder.Eventf(pod, v1.EventTypeNormal, "PodQoSUpdated", "Updated pod QoS: node=%s %s", c.config.NodeName, strings.Join(processed, ", "))
 	return nil
 }
 

--- a/pkg/daemon/controller_linux_test.go
+++ b/pkg/daemon/controller_linux_test.go
@@ -1,9 +1,12 @@
 package daemon
 
 import (
+	"errors"
 	"net"
 	"testing"
+	"time"
 
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -11,10 +14,269 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func newPodQoSTestController(t *testing.T, pod *v1.Pod) (*Controller, *record.FakeRecorder) {
+	t.Helper()
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	require.NoError(t, indexer.Add(pod))
+	recorder := record.NewFakeRecorder(10)
+	return &Controller{
+		config:     &Configuration{NodeName: "node-a"},
+		podsLister: listerv1.NewPodLister(indexer),
+		recorder:   recorder,
+	}, recorder
+}
+
+func requirePodEvent(t *testing.T, recorder *record.FakeRecorder, parts ...string) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		for _, part := range parts {
+			require.Contains(t, event, part)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected pod event")
+	}
+}
+
+func requireNoPodEvent(t *testing.T, recorder *record.FakeRecorder) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected pod event: %s", event)
+	default:
+	}
+}
+
+func TestHandleUpdatePodValidationFailureEmitsOnlyValidationEvent(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "pod",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			util.IPAddressAnnotation: "invalid",
+		},
+	}}
+	controller, recorder := newPodQoSTestController(t, pod)
+
+	require.Error(t, controller.handleUpdatePod("default/pod"))
+	requirePodEvent(t, recorder, "Warning", "ValidatePodNetworkFailed", "invalid")
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodBandwidthFailureEmitsQoSFailureEvent(t *testing.T) {
+	failErr := errors.New("default bandwidth failure")
+	stubPodQoSFunctions(t, "bandwidth", "pod.default", failErr)
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:        "pod",
+		Namespace:   metav1.NamespaceDefault,
+		Annotations: map[string]string{},
+	}}
+	controller, recorder := newPodQoSTestController(t, pod)
+
+	require.ErrorIs(t, controller.handleUpdatePod("default/pod"), failErr)
+	requirePodEvent(t, recorder,
+		"Warning", "PodQoSUpdateFailed", "stage=bandwidth", "provider=ovn",
+		"interface=pod.default", "node=node-a", failErr.Error())
+	requireNoPodEvent(t, recorder)
+}
+
+func stubPodQoSFunctions(t *testing.T, failStage, failInterface string, failErr error) map[string][]string {
+	t.Helper()
+
+	originalBandwidth := setInterfaceBandwidth
+	originalMirror := configInterfaceMirror
+	originalNetem := setNetemQos
+	t.Cleanup(func() {
+		setInterfaceBandwidth = originalBandwidth
+		configInterfaceMirror = originalMirror
+		setNetemQos = originalNetem
+	})
+
+	calls := map[string][]string{}
+	setInterfaceBandwidth = func(_, _, iface, _, _ string) error {
+		calls["bandwidth"] = append(calls["bandwidth"], iface)
+		if failStage == "bandwidth" && iface == failInterface {
+			return failErr
+		}
+		return nil
+	}
+	configInterfaceMirror = func(_ bool, _, iface string) error {
+		calls["mirror"] = append(calls["mirror"], iface)
+		if failStage == "mirror" && iface == failInterface {
+			return failErr
+		}
+		return nil
+	}
+	setNetemQos = func(_, _, iface, _, _, _, _ string) error {
+		calls["netem"] = append(calls["netem"], iface)
+		if failStage == "netem" && iface == failInterface {
+			return failErr
+		}
+		return nil
+	}
+	return calls
+}
+
+func newPodQoSTestPod(networkAnnotation string) *v1.Pod {
+	annotations := map[string]string{}
+	if networkAnnotation != "" {
+		annotations[nadv1.NetworkAttachmentAnnot] = networkAnnotation
+		annotations["net1.default.ovn.kubernetes.io/allocated"] = "true"
+	}
+	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:        "pod",
+		Namespace:   metav1.NamespaceDefault,
+		Annotations: annotations,
+	}}
+}
+
+func TestHandleUpdatePodQoSCallFailuresEmitOneEvent(t *testing.T) {
+	const multusInterface = "pod.default.net1.default.ovn"
+	failErr := errors.New("injected QoS failure")
+
+	for _, stage := range []string{"bandwidth", "mirror", "netem"} {
+		t.Run(stage, func(t *testing.T) {
+			calls := stubPodQoSFunctions(t, stage, multusInterface, failErr)
+			controller, recorder := newPodQoSTestController(t, newPodQoSTestPod("default/net1"))
+
+			require.ErrorIs(t, controller.handleUpdatePod("default/pod"), failErr)
+			require.Contains(t, calls[stage], multusInterface)
+			requirePodEvent(t, recorder,
+				"Warning", "PodQoSUpdateFailed", "stage="+stage,
+				"provider=net1.default.ovn", "interface="+multusInterface,
+				"node=node-a", failErr.Error())
+			requireNoPodEvent(t, recorder)
+		})
+	}
+}
+
+func TestHandleUpdatePodSuccessEmitsOneEventWithProcessedInterfaces(t *testing.T) {
+	calls := stubPodQoSFunctions(t, "", "", nil)
+	controller, recorder := newPodQoSTestController(t, newPodQoSTestPod("default/net1"))
+
+	require.NoError(t, controller.handleUpdatePod("default/pod"))
+	require.Equal(t, []string{"pod.default", "pod.default.net1.default.ovn"}, calls["netem"])
+	requirePodEvent(t, recorder,
+		"Normal", "PodQoSUpdated", "node=node-a",
+		"provider=ovn interface=pod.default",
+		"provider=net1.default.ovn interface=pod.default.net1.default.ovn")
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodKeepsMultusPodNamesIndependent(t *testing.T) {
+	pod := newPodQoSTestPod("default/net1,default/net2")
+	pod.Annotations["net1.default.ovn.kubernetes.io/virtualmachine"] = "vm-one"
+	pod.Annotations["net2.default.ovn.kubernetes.io/allocated"] = "true"
+	calls := stubPodQoSFunctions(t, "", "", nil)
+	controller, recorder := newPodQoSTestController(t, pod)
+
+	require.NoError(t, controller.handleUpdatePod("default/pod"))
+	expectedInterfaces := []string{
+		"pod.default",
+		"vm-one.default.net1.default.ovn",
+		"pod.default.net2.default.ovn",
+	}
+	for _, stage := range []string{"bandwidth", "mirror", "netem"} {
+		require.Equal(t, expectedInterfaces, calls[stage])
+	}
+	requirePodEvent(t, recorder,
+		"Normal", "PodQoSUpdated",
+		"provider=net1.default.ovn interface=vm-one.default.net1.default.ovn",
+		"provider=net2.default.ovn interface=pod.default.net2.default.ovn")
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodNetworkAttachmentParseFailureEmitsOneEvent(t *testing.T) {
+	stubPodQoSFunctions(t, "", "", nil)
+	pod := newPodQoSTestPod("[")
+	controller, recorder := newPodQoSTestController(t, pod)
+
+	err := controller.handleUpdatePod("default/pod")
+	require.Error(t, err)
+	requirePodEvent(t, recorder,
+		"Warning", "PodQoSUpdateFailed", "stage=parseNetworkAttachment",
+		"provider=unknown", "interface=unknown", "node=node-a", err.Error())
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodWithoutMultusEmitsDefaultInterfaceSuccess(t *testing.T) {
+	stubPodQoSFunctions(t, "", "", nil)
+	controller, recorder := newPodQoSTestController(t, newPodQoSTestPod(""))
+
+	require.NoError(t, controller.handleUpdatePod("default/pod"))
+	requirePodEvent(t, recorder,
+		"Normal", "PodQoSUpdated", "node=node-a", "provider=ovn interface=pod.default")
+	requireNoPodEvent(t, recorder)
+}
+
+func TestHandleUpdatePodNotFoundEmitsNoEvent(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	recorder := record.NewFakeRecorder(1)
+	controller := &Controller{
+		config:     &Configuration{NodeName: "node-a"},
+		podsLister: listerv1.NewPodLister(indexer),
+		recorder:   recorder,
+	}
+
+	require.NoError(t, controller.handleUpdatePod("default/missing"))
+	requireNoPodEvent(t, recorder)
+}
+
+func TestEnqueueUpdatePodOnlyQueuesRelevantAnnotationChanges(t *testing.T) {
+	basePod := newPodQoSTestPod("default/net1")
+	basePod.Annotations[util.IngressRateAnnotation] = "10"
+	basePod.Annotations[util.MirrorControlAnnotation] = "true"
+	basePod.Annotations[util.NetemQosLatencyAnnotation] = "5"
+	basePod.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	basePod.Annotations["net1.default.ovn.kubernetes.io/ingress_rate"] = "20"
+
+	tests := []struct {
+		name       string
+		annotation string
+		value      string
+		wantQueue  bool
+	}{
+		{name: "unchanged", wantQueue: false},
+		{name: "unrelated annotation", annotation: "example.com/unrelated", value: "changed", wantQueue: false},
+		{name: "default bandwidth", annotation: util.IngressRateAnnotation, value: "11", wantQueue: true},
+		{name: "default mirror", annotation: util.MirrorControlAnnotation, value: "false", wantQueue: true},
+		{name: "default netem", annotation: util.NetemQosLatencyAnnotation, value: "6", wantQueue: true},
+		{name: "default IP", annotation: util.IPAddressAnnotation, value: "10.0.0.3", wantQueue: true},
+		{name: "multus bandwidth", annotation: "net1.default.ovn.kubernetes.io/ingress_rate", value: "21", wantQueue: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldPod := basePod.DeepCopy()
+			newPod := basePod.DeepCopy()
+			if tt.annotation != "" {
+				newPod.Annotations[tt.annotation] = tt.value
+			}
+			recorder := record.NewFakeRecorder(1)
+			controller := &Controller{
+				updatePodQueue: newTypedRateLimitingQueue[string]("test-update-pod", nil),
+				recorder:       recorder,
+			}
+			t.Cleanup(controller.updatePodQueue.ShutDown)
+
+			controller.enqueueUpdatePod(oldPod, newPod)
+			if tt.wantQueue {
+				require.Equal(t, 1, controller.updatePodQueue.Len())
+			} else {
+				require.Zero(t, controller.updatePodQueue.Len())
+			}
+			requireNoPodEvent(t, recorder)
+		})
+	}
+}
 
 func newPodForPolicyRouting(name, namespace, subnetName, podIP string, podIPs []v1.PodIP) *v1.Pod {
 	return &v1.Pod{

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -46,6 +46,61 @@ func createCniServerHandler(config *Configuration, controller *Controller) *cniS
 	return csh
 }
 
+func podForCNIEvent(pod *v1.Pod, podRequest *request.CniRequest) *v1.Pod {
+	if pod != nil {
+		return pod
+	}
+	return &v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: podRequest.PodNamespace,
+			Name:      podRequest.PodName,
+		},
+	}
+}
+
+func cniEventInterfaceNames(containerID, ifName string) []string {
+	ifNames := []string{ifName}
+	if ifName == "" {
+		ifNames = append(ifNames, "eth0")
+	}
+
+	var names []string
+	for _, name := range ifNames {
+		if name == "eth0" {
+			if len(containerID) >= 12 {
+				names = append(names, containerID[:12]+"_h", containerID[:12]+"_c")
+			}
+			continue
+		}
+		if strings.HasPrefix(name, "pod") && len(name) == 14 {
+			name = name[3 : len(name)-4]
+		}
+		prefixLen := 12 - len(name)
+		if prefixLen < 0 || len(containerID) < prefixLen {
+			continue
+		}
+		prefix := containerID[:prefixLen] + "_" + name
+		names = append(names, prefix+"_h", prefix+"_c")
+	}
+	return names
+}
+
+func (csh cniServerHandler) recordCNIPodEvent(pod *v1.Pod, podRequest *request.CniRequest, eventType, reason, message string) {
+	ifName := podRequest.IfName
+	if ifName == "" {
+		ifName = "eth0"
+	}
+	details := []string{podRequest.ContainerID, podRequest.NetNs, podRequest.DeviceID}
+	details = append(details, cniEventInterfaceNames(podRequest.ContainerID, podRequest.IfName)...)
+	for _, detail := range details {
+		if detail != "" {
+			message = strings.ReplaceAll(message, detail, "<redacted>")
+		}
+	}
+	csh.Controller.recorder.Eventf(pod, eventType, reason, "%s provider=%s interface=%s node=%s", message, podRequest.Provider, ifName, csh.Config.NodeName)
+}
+
 func (csh cniServerHandler) providerExists(provider, ifName string) (*kubeovnv1.Subnet, bool) {
 	if provider == "" || provider == util.OvnProvider {
 		return nil, true
@@ -77,11 +132,16 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		}
 		return
 	}
+	eventPod := podForCNIEvent(nil, &podRequest)
+	recordFailure := func(stage string, err error) {
+		csh.recordCNIPodEvent(eventPod, &podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed", fmt.Sprintf("stage=%s error=%v", stage, err))
+	}
 	klog.V(5).Infof("request body is %v", podRequest)
 	podSubnet, exist := csh.providerExists(podRequest.Provider, podRequest.IfName)
 	if !exist {
 		errMsg := fmt.Errorf("provider %s is not bound to any subnet", podRequest.Provider)
 		klog.Error(errMsg)
+		recordFailure("provider", errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -91,6 +151,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	klog.Infof("add port request: %v", podRequest)
 	if err := csh.validatePodRequest(&podRequest); err != nil {
 		klog.Error(err)
+		recordFailure("validate-request", err)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -111,11 +172,13 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if pod, err = csh.Controller.podsLister.Pods(podRequest.PodNamespace).Get(podRequest.PodName); err != nil {
 			errMsg := fmt.Errorf("get pod %s/%s failed %w", podRequest.PodNamespace, podRequest.PodName, err)
 			klog.Error(errMsg)
+			recordFailure("get-pod", errMsg)
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
 			return
 		}
+		eventPod = pod
 
 		// in case of multiple nics from same subnet
 		_, ok := pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, providerWithIfName)]
@@ -155,6 +218,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if err != nil {
 			errMsg := fmt.Errorf("failed to get ip address with mask, %w", err)
 			klog.Error(errMsg)
+			recordFailure("parse-address", errMsg)
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -166,6 +230,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			if err = json.Unmarshal([]byte(s), &routes); err != nil {
 				errMsg := fmt.Errorf("invalid routes for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 				klog.Error(errMsg)
+				recordFailure("parse-routes", errMsg)
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)
 				}
@@ -188,6 +253,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			nicType = util.DpdkType
 			if err = createShortSharedDir(pod, podRequest.VhostUserSocketVolumeName, podRequest.VhostUserSocketConsumption, csh.Config.KubeletDir); err != nil {
 				klog.Error(err.Error())
+				recordFailure("prepare-dpdk", err)
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)
 				}
@@ -223,6 +289,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	if util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.IPAddressAnnotationTemplate, appendIfName) == "" {
 		err := fmt.Errorf("no address allocated to pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
 		klog.Error(err)
+		recordFailure("wait-address", err)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -234,6 +301,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	}
 	if !noIPAM {
 		if err := csh.UpdateIPCR(podRequest, subnet, ip, appendIfName); err != nil {
+			recordFailure("update-ip-cr", err)
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -244,6 +312,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	if isDefaultRoute && pod.Annotations[fmt.Sprintf(util.RoutedAnnotationTemplate, podRequest.Provider)] != "true" && util.IsOvnProvider(podRequest.Provider) {
 		err := fmt.Errorf("route is not ready for pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
 		klog.Error(err)
+		recordFailure("wait-route", err)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -257,6 +326,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if err != nil {
 			errMsg := fmt.Errorf("failed to get subnet %s: %w", subnet, err)
 			klog.Error(errMsg)
+			recordFailure("get-subnet", errMsg)
 			if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response: %v", err)
 			}
@@ -266,6 +336,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if podSubnet.Status.U2OInterconnectionIP == "" && podSubnet.Spec.U2OInterconnection {
 			errMsg := fmt.Errorf("failed to generate u2o ip on subnet %s", podSubnet.Name)
 			klog.Error(errMsg)
+			recordFailure("u2o-address", errMsg)
 			return
 		}
 
@@ -305,6 +376,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 				if err != nil {
 					errMsg := fmt.Errorf("failed to get node %s: %w", csh.Config.NodeName, err)
 					klog.Error(errMsg)
+					recordFailure("get-node", errMsg)
 					if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 						klog.Errorf("failed to write response: %v", err)
 					}
@@ -315,6 +387,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 					if mtu, err = strconv.Atoi(mtuStr); err != nil || mtu <= 0 {
 						errMsg := fmt.Errorf("failed to parse provider network MTU %s: %w", mtuStr, err)
 						klog.Error(errMsg)
+						recordFailure("mtu", errMsg)
 						if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 							klog.Errorf("failed to write response: %v", err)
 						}
@@ -336,6 +409,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			if err != nil {
 				errMsg := fmt.Errorf("failed to get encap IP for node network %s: %w", podSubnet.Spec.NodeNetwork, err)
 				klog.Error(errMsg)
+				recordFailure("encap-ip", errMsg)
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)
 				}
@@ -353,6 +427,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		if err != nil {
 			errMsg := fmt.Errorf("configure nic %s for pod %s/%s failed: %w", ifName, podRequest.PodName, podRequest.PodNamespace, err)
 			klog.Error(errMsg)
+			recordFailure("configure-nic", errMsg)
 			if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -362,12 +437,14 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		ifaceID := ovs.PodNameToPortName(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider)
 		if err = ovs.ConfigInterfaceMirror(csh.Config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, podRequest.Provider)], ifaceID); err != nil {
 			klog.Errorf("failed mirror to mirror0, %v", err)
+			recordFailure("mirror", err)
 			return
 		}
 
 		if err = csh.Controller.addEgressConfig(podSubnet, ip); err != nil {
 			errMsg := fmt.Errorf("failed to add egress configuration: %w", err)
 			klog.Error(errMsg)
+			recordFailure("egress", errMsg)
 			if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 				klog.Errorf("failed to write response, %v", err)
 			}
@@ -391,6 +468,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			if err = csh.removeDefaultRoute(podRequest.NetNs, hasDefaultRoute[kubeovnv1.ProtocolIPv4], hasDefaultRoute[kubeovnv1.ProtocolIPv6]); err != nil {
 				errMsg := fmt.Errorf("failed to remove existing default route for interface %s of pod %s/%s: %w", podRequest.IfName, podRequest.PodNamespace, podRequest.PodName, err)
 				klog.Error(errMsg)
+				recordFailure("remove-default-route", errMsg)
 				if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 					klog.Errorf("failed to write response: %v", err)
 				}
@@ -426,6 +504,11 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		Routes:     routes,
 		Mtu:        mtu,
 	}
+	eventMAC := macAddr
+	if eventMAC == "" {
+		eventMAC = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.MacAddressAnnotationTemplate, appendIfName)
+	}
+	csh.recordCNIPodEvent(eventPod, &podRequest, v1.EventTypeNormal, "PodNetworkConfigured", fmt.Sprintf("subnet=%s ip=%s mac=%s", subnet, ip, eventMAC))
 	if err := resp.WriteHeaderAndEntity(http.StatusOK, response); err != nil {
 		klog.Errorf("failed to write response, %v", err)
 	}
@@ -486,16 +569,24 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 		}
 		return
 	}
+	eventPod := podForCNIEvent(nil, &podRequest)
+	recordFailure := func(stage string, err error) {
+		csh.recordCNIPodEvent(eventPod, &podRequest, v1.EventTypeWarning, "PodNetworkRemoveFailed", fmt.Sprintf("stage=%s error=%v", stage, err))
+	}
 
 	// Try to get the Pod, but if it fails due to not being found, log a warning and continue.
 	pod, err := csh.Controller.podsLister.Pods(podRequest.PodNamespace).Get(podRequest.PodName)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		errMsg := fmt.Errorf("failed to retrieve Pod %s/%s: %w", podRequest.PodNamespace, podRequest.PodName, err)
 		klog.Error(errMsg)
+		recordFailure("get-pod", errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
 		return
+	}
+	if pod != nil {
+		eventPod = pod
 	}
 
 	providerWithIfName := fmt.Sprintf("%s.%s", podRequest.Provider, podRequest.IfName)
@@ -508,6 +599,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 	klog.Infof("del port request: %v", podRequest)
 	if err := csh.validatePodRequest(&podRequest); err != nil {
 		klog.Error(err)
+		recordFailure("validate-request", err)
 		if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: err.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
@@ -530,6 +622,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 				if err = csh.Controller.removeEgressConfig(subnet, ip); err != nil {
 					errMsg := fmt.Errorf("failed to remove egress configuration: %w", err)
 					klog.Error(errMsg)
+					recordFailure("remove-egress", errMsg)
 					if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 						klog.Errorf("failed to write response, %v", err)
 					}
@@ -544,6 +637,7 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 				nicType = util.DpdkType
 				if err = removeShortSharedDir(pod, podRequest.VhostUserSocketVolumeName, podRequest.VhostUserSocketConsumption); err != nil {
 					klog.Error(err.Error())
+					recordFailure("remove-dpdk-dir", err)
 					if err = resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
 						klog.Errorf("failed to write response: %v", err)
 					}
@@ -581,10 +675,12 @@ func (csh cniServerHandler) handleDel(req *restful.Request, resp *restful.Respon
 	if err != nil {
 		errMsg := fmt.Errorf("del nic failed %w", err)
 		klog.Error(errMsg)
+		recordFailure("delete-nic", errMsg)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
 		return
 	}
+	csh.recordCNIPodEvent(eventPod, &podRequest, v1.EventTypeNormal, "PodNetworkRemoved", "removed pod network")
 	resp.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/daemon/handler_test.go
+++ b/pkg/daemon/handler_test.go
@@ -1,0 +1,302 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/request"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+type recordedCNIEvent struct {
+	object    runtime.Object
+	eventType string
+	reason    string
+	message   string
+}
+
+type cniEventRecorder struct {
+	events []recordedCNIEvent
+}
+
+func (r *cniEventRecorder) Event(object runtime.Object, eventType, reason, message string) {
+	r.events = append(r.events, recordedCNIEvent{object: object, eventType: eventType, reason: reason, message: message})
+}
+
+func (r *cniEventRecorder) Eventf(object runtime.Object, eventType, reason, messageFmt string, args ...any) {
+	r.Event(object, eventType, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (r *cniEventRecorder) AnnotatedEventf(object runtime.Object, _ map[string]string, eventType, reason, messageFmt string, args ...any) {
+	r.Eventf(object, eventType, reason, messageFmt, args...)
+}
+
+func TestPodForCNIEvent(t *testing.T) {
+	t.Run("real pod", func(t *testing.T) {
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns", UID: types.UID("uid")}}
+		require.Same(t, pod, podForCNIEvent(pod, &request.CniRequest{}))
+		require.Equal(t, types.UID("uid"), podForCNIEvent(pod, &request.CniRequest{}).UID)
+	})
+
+	t.Run("synthetic pod", func(t *testing.T) {
+		pod := podForCNIEvent(nil, &request.CniRequest{PodName: "pod", PodNamespace: "ns"})
+		require.Equal(t, "v1", pod.APIVersion)
+		require.Equal(t, "Pod", pod.Kind)
+		require.Equal(t, "ns", pod.Namespace)
+		require.Equal(t, "pod", pod.Name)
+	})
+}
+
+func TestRecordCNIPodEvent(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+	podRequest := &request.CniRequest{PodName: "pod", PodNamespace: "ns", Provider: "provider"}
+	handler.recordCNIPodEvent(podForCNIEvent(nil, podRequest), podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed", "stage=get-pod error=boom")
+
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeWarning, event.eventType)
+	require.Equal(t, "PodNetworkConfigureFailed", event.reason)
+	require.Contains(t, event.message, "stage=get-pod")
+	require.Contains(t, event.message, "error=boom")
+	require.Contains(t, event.message, "provider=provider")
+	require.Contains(t, event.message, "interface=eth0")
+	require.Contains(t, event.message, "node=node-a")
+}
+
+func TestRecordCNIPodEventRedactsRuntimeDetails(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+	podRequest := &request.CniRequest{
+		PodName: "pod", PodNamespace: "ns", Provider: "provider",
+		ContainerID: "1234567890abcdef", NetNs: "/runtime/netns/pod", DeviceID: "0000:65:00.1",
+	}
+	handler.recordCNIPodEvent(
+		podForCNIEvent(nil, podRequest), podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed",
+		`stage=configure-nic error=failed on device 0000:65:00.1 and 1234567890ab_h in /runtime/netns/pod for 1234567890abcdef: boom`,
+	)
+
+	event := requireSingleCNIEvent(t, recorder)
+	require.Contains(t, event.message, "stage=configure-nic")
+	require.Contains(t, event.message, "boom")
+	require.NotContains(t, event.message, "1234567890ab_h")
+	require.NotContains(t, event.message, "1234567890ab")
+	require.NotContains(t, event.message, podRequest.ContainerID)
+	require.NotContains(t, event.message, podRequest.NetNs)
+	require.NotContains(t, event.message, podRequest.DeviceID)
+}
+
+func TestRecordCNIPodEventHandlesUnsafeDerivedNameInputs(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+	podRequest := &request.CniRequest{
+		PodName: "pod", PodNamespace: "ns", Provider: "provider",
+		ContainerID: "short", IfName: "interface-name-longer-than-twelve",
+	}
+	require.NotPanics(t, func() {
+		handler.recordCNIPodEvent(
+			podForCNIEvent(nil, podRequest), podRequest, v1.EventTypeWarning, "PodNetworkConfigureFailed", "stage=configure-nic error=boom",
+		)
+	})
+	require.Contains(t, requireSingleCNIEvent(t, recorder).message, "error=boom")
+}
+
+func TestHandleAddSuccessEvent(t *testing.T) {
+	const (
+		provider = "macvlan.default"
+		subnet   = "underlay"
+		ip       = "10.0.0.2"
+		mac      = "00:00:00:00:00:02"
+	)
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "pod", Namespace: "ns", UID: types.UID("real-uid"),
+		Annotations: map[string]string{
+			fmt.Sprintf(util.IPAddressAnnotationTemplate, provider):     ip,
+			fmt.Sprintf(util.CidrAnnotationTemplate, provider):          "10.0.0.0/24",
+			fmt.Sprintf(util.MacAddressAnnotationTemplate, provider):    mac,
+			fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider): subnet,
+		},
+	}}
+	podSubnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: subnet}, Spec: kubeovnv1.SubnetSpec{Provider: provider}}
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, pod, podSubnet, recorder)
+	ipCRName := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
+	handler.KubeOvnClient = kubeovnfake.NewSimpleClientset(&kubeovnv1.IP{
+		ObjectMeta: metav1.ObjectMeta{Name: ipCRName},
+		Spec:       kubeovnv1.IPSpec{NodeName: "node-a"},
+	})
+
+	response := serveCNIRequest(t, handler, "/api/v1/add", request.CniRequest{
+		CniType: util.CniTypeName, PodName: pod.Name, PodNamespace: pod.Namespace,
+		Provider: provider, IfName: "net1",
+	})
+	require.Equal(t, http.StatusOK, response.Code)
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeNormal, event.eventType)
+	require.Equal(t, "PodNetworkConfigured", event.reason)
+	require.Same(t, pod, event.object)
+	for _, part := range []string{"subnet=" + subnet, "ip=" + ip, "mac=" + mac, "provider=" + provider, "interface=net1", "node=node-a"} {
+		require.Contains(t, event.message, part)
+	}
+}
+
+func TestHandleAddFailureEvent(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+
+	response := serveCNIRequest(t, handler, "/api/v1/add", request.CniRequest{
+		PodName: "missing", PodNamespace: "ns", Provider: util.OvnProvider,
+	})
+	require.Equal(t, http.StatusInternalServerError, response.Code)
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeWarning, event.eventType)
+	require.Equal(t, "PodNetworkConfigureFailed", event.reason)
+	require.Contains(t, event.message, "stage=get-pod")
+	require.Contains(t, event.message, `pod "missing" not found`)
+	pod, ok := event.object.(*v1.Pod)
+	require.True(t, ok)
+	require.Equal(t, "missing", pod.Name)
+	require.Equal(t, "ns", pod.Namespace)
+}
+
+func TestHandleDelSuccessEventPreservesPodReference(t *testing.T) {
+	useFakeOVSVsctl(t, true)
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "virt-launcher", Namespace: "ns", UID: types.UID("real-uid"),
+		Annotations: map[string]string{
+			fmt.Sprintf(util.VMAnnotationTemplate, util.OvnProvider): "vm-name",
+		},
+	}}
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, pod, nil, recorder)
+
+	response := serveCNIRequest(t, handler, "/api/v1/del", request.CniRequest{
+		CniType: util.CniTypeName, PodName: pod.Name, PodNamespace: pod.Namespace,
+		ContainerID: "1234567890abcdef", NetNs: "/missing/netns", Provider: util.OvnProvider,
+	})
+	require.Equal(t, http.StatusNoContent, response.Code)
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeNormal, event.eventType)
+	require.Equal(t, "PodNetworkRemoved", event.reason)
+	require.Same(t, pod, event.object)
+	require.Equal(t, "virt-launcher", event.object.(*v1.Pod).Name)
+	require.NotContains(t, event.message, "vm-name")
+	for _, part := range []string{"provider=ovn", "interface=eth0", "node=node-a"} {
+		require.Contains(t, event.message, part)
+	}
+}
+
+func TestHandleDelFailureEvent(t *testing.T) {
+	useFakeOVSVsctl(t, false)
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+
+	response := serveCNIRequest(t, handler, "/api/v1/del", request.CniRequest{
+		PodName: "deleted", PodNamespace: "ns", ContainerID: "1234567890abcdef",
+		NetNs: "/missing/netns", Provider: util.OvnProvider, IfName: "net1",
+	})
+	require.Equal(t, http.StatusInternalServerError, response.Code)
+	event := requireSingleCNIEvent(t, recorder)
+	require.Equal(t, v1.EventTypeWarning, event.eventType)
+	require.Equal(t, "PodNetworkRemoveFailed", event.reason)
+	require.Contains(t, event.message, "stage=delete-nic")
+	require.Contains(t, event.message, "exit status 1")
+	require.NotContains(t, event.message, "12345678_net1_h")
+	require.NotContains(t, event.message, "12345678")
+	pod := event.object.(*v1.Pod)
+	require.Equal(t, "deleted", pod.Name)
+	require.Equal(t, "ns", pod.Namespace)
+}
+
+func TestHandleDelNoNetNSHasNoEvent(t *testing.T) {
+	recorder := &cniEventRecorder{}
+	handler := cniEventTestHandler(t, nil, nil, recorder)
+
+	response := serveCNIRequest(t, handler, "/api/v1/del", request.CniRequest{
+		PodName: "deleted", PodNamespace: "ns", Provider: util.OvnProvider,
+	})
+	require.Equal(t, http.StatusNoContent, response.Code)
+	require.Empty(t, recorder.events)
+}
+
+func TestHandleAddAndDelInvalidRequestHaveNoEvent(t *testing.T) {
+	for _, path := range []string{"/api/v1/add", "/api/v1/del"} {
+		t.Run(path, func(t *testing.T) {
+			recorder := &cniEventRecorder{}
+			handler := cniEventTestHandler(t, nil, nil, recorder)
+			request := httptest.NewRequest(http.MethodPost, path, nil)
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+
+			createHandler(handler).ServeHTTP(response, request)
+
+			require.Equal(t, http.StatusBadRequest, response.Code)
+			require.Empty(t, recorder.events)
+		})
+	}
+}
+
+func cniEventTestHandler(t *testing.T, pod *v1.Pod, subnet *kubeovnv1.Subnet, recorder *cniEventRecorder) *cniServerHandler {
+	t.Helper()
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if pod != nil {
+		require.NoError(t, podIndexer.Add(pod))
+	}
+	subnetIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if subnet != nil {
+		require.NoError(t, subnetIndexer.Add(subnet))
+	}
+	config := &Configuration{NodeName: "node-a"}
+	controller := &Controller{
+		config:        config,
+		podsLister:    listerv1.NewPodLister(podIndexer),
+		subnetsLister: kubeovnlister.NewSubnetLister(subnetIndexer),
+		recorder:      recorder,
+	}
+	return createCniServerHandler(config, controller)
+}
+
+func serveCNIRequest(t *testing.T, handler *cniServerHandler, path string, podRequest request.CniRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(podRequest)
+	require.NoError(t, err)
+	request := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	createHandler(handler).ServeHTTP(response, request)
+	return response
+}
+
+func requireSingleCNIEvent(t *testing.T, recorder *cniEventRecorder) recordedCNIEvent {
+	t.Helper()
+	require.Len(t, recorder.events, 1)
+	return recorder.events[0]
+}
+
+func useFakeOVSVsctl(t *testing.T, succeed bool) {
+	t.Helper()
+	target := "/bin/false"
+	if succeed {
+		target = "/bin/true"
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.Symlink(target, filepath.Join(dir, "ovs-vsctl")))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}


### PR DESCRIPTION
Backport of #6989 to `release-1.16`.

Record auditable Pod events for controller network allocation, update, security, and release operations; daemon QoS updates; and CNI ADD/DEL outcomes. Preserve no-op behavior and redact runtime identifiers from CNI-derived event messages.

Branch-specific adaptations:

- keep the release-1.16 bandwidth API, which does not include the master-only burst arguments
- keep Multus Pod names isolated while recording QoS events
- omit the unrelated master-only `gatewayForCNIIPFamily` helper
- initialize the EndpointSlice lister in the shared fake controller because the release-1.16 Pod update path uses it

## Verification

- `go test ./pkg/controller ./pkg/daemon -count=1`
- `CGO_ENABLED=1 go test -race ./pkg/daemon -run 'TestHandleUpdatePod|TestEnqueueUpdatePodOnlyQueuesRelevantAnnotationChanges|TestPodForCNIEvent|TestRecordCNIPodEvent|TestHandle(Add|Del).*Event|TestHandleDelNoNetNSHasNoEvent' -count=1`
- `git diff --check`
