### PR TITLE
controller, daemon: address pod event review findings

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -291,7 +291,7 @@ func (c *Controller) gcVip() error {
 			_, err := c.podsLister.Pods(namespace).Get(podName)
 			if err != nil {
 				if k8serrors.IsNotFound(err) {
-					if err = c.releaseVip(vip.Name); err != nil {
+					if _, err = c.releaseVip(vip.Name); err != nil {
 						klog.Errorf("failed to clean label from vip %s, %v", vip.Name, err)
 						return err
 					}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1456,14 +1456,13 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 		}
 		if pod.Annotations[util.VipAnnotation] != "" {
-			vip, vipErr := c.virtualIpsLister.Get(pod.Annotations[util.VipAnnotation])
-			vipWillChange := vipErr == nil && vip.Labels[util.IPReservedLabel] != ""
 			stage = "releaseVIP"
-			if err = c.releaseVip(pod.Annotations[util.VipAnnotation]); err != nil {
+			var vipReleased bool
+			if vipReleased, err = c.releaseVip(pod.Annotations[util.VipAnnotation]); err != nil {
 				klog.Errorf("failed to clean label from vip %s, %v", pod.Annotations[util.VipAnnotation], err)
 				return err
 			}
-			if vipWillChange {
+			if vipReleased {
 				changed = true
 				released = append(released, "vip="+pod.Annotations[util.VipAnnotation])
 			}
@@ -1596,16 +1595,41 @@ func stalePortNetworkDetails(pod *v1.Pod, podName string, port ovnnb.LogicalSwit
 	return providerName, details, nil
 }
 
+type stalePodNetworkState struct {
+	ports               []string
+	annotationProviders []string
+	subnetsByPort       map[string]string
+	details             []string
+}
+
+func collectStalePodNetworkState(pod *v1.Pod, podName string, targetPorts *strset.Set, ports []ovnnb.LogicalSwitchPort) stalePodNetworkState {
+	state := stalePodNetworkState{subnetsByPort: make(map[string]string)}
+	for _, port := range ports {
+		if targetPorts.Has(port.Name) {
+			continue
+		}
+		state.ports = append(state.ports, port.Name)
+		state.subnetsByPort[port.Name] = port.ExternalIDs["ls"]
+		providerName, details, err := stalePortNetworkDetails(pod, podName, port)
+		if err != nil {
+			klog.Warning(err)
+			state.details = append(state.details, fmt.Sprintf("provider=unknown subnet=%s ip= mac= logicalSwitchPort=%s", port.ExternalIDs["ls"], port.Name))
+			continue
+		}
+		state.details = append(state.details, details)
+		if providerName != util.OvnProvider {
+			state.annotationProviders = append(state.annotationProviders, providerName)
+		}
+	}
+	return state
+}
+
 func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod, string, error) {
 	podName := c.getNameByPod(pod)
 	key := cache.NewObjectName(pod.Namespace, podName).String()
 	targetPortNameList := strset.NewWithSize(len(podNets))
-	portsNeedToDel := []string{}
-	annotationsNeedToDel := []string{}
 	annotationsNeedToAdd := make(map[string]string)
-	subnetUsedByPort := make(map[string]string)
 	changedPodNets := []*kubeovnNet{}
-	hotplugDetails := []string{}
 
 	for _, podNet := range podNets {
 		portName := ovs.PodNameToPortName(podName, pod.Namespace, podNet.ProviderName)
@@ -1633,31 +1657,14 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 		return nil, "", err
 	}
 
-	for _, port := range ports {
-		if !targetPortNameList.Has(port.Name) {
-			portsNeedToDel = append(portsNeedToDel, port.Name)
-			subnetUsedByPort[port.Name] = port.ExternalIDs["ls"]
-			providerName, details, parseErr := stalePortNetworkDetails(pod, podName, port)
-			if parseErr != nil {
-				klog.Warning(parseErr)
-				hotplugDetails = append(hotplugDetails, fmt.Sprintf("provider=unknown subnet=%s ip= mac= logicalSwitchPort=%s", port.ExternalIDs["ls"], port.Name))
-				continue
-			}
-			hotplugDetails = append(hotplugDetails, details)
-			if providerName == util.OvnProvider {
-				continue
-			}
-			annotationsNeedToDel = append(annotationsNeedToDel, providerName)
-		}
-	}
-
-	if len(portsNeedToDel) == 0 && len(annotationsNeedToAdd) == 0 {
+	staleState := collectStalePodNetworkState(pod, podName, targetPortNameList, ports)
+	if len(staleState.ports) == 0 && len(annotationsNeedToAdd) == 0 {
 		return pod, "", nil
 	}
 
-	for _, portNeedDel := range portsNeedToDel {
+	for _, portNeedDel := range staleState.ports {
 		klog.Infof("release port %s for pod %s", portNeedDel, podName)
-		c.ipam.ReleaseAddressByNic(key, portNeedDel, subnetUsedByPort[portNeedDel])
+		c.ipam.ReleaseAddressByNic(key, portNeedDel, staleState.subnetsByPort[portNeedDel])
 		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portNeedDel); err != nil {
 			klog.Errorf("failed to delete lsp %s, %v", portNeedDel, err)
 			return nil, "", err
@@ -1671,7 +1678,7 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	patch := util.KVPatch{}
-	for _, providerName := range annotationsNeedToDel {
+	for _, providerName := range staleState.annotationProviders {
 		for key := range pod.Annotations {
 			if strings.HasPrefix(key, providerName) {
 				patch[key] = nil
@@ -1684,7 +1691,7 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	if len(patch) == 0 {
-		return pod, strings.Join(hotplugDetails, "; "), nil
+		return pod, strings.Join(staleState.details, "; "), nil
 	}
 
 	if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(pod.Namespace), pod.Name, patch); err != nil {
@@ -1704,9 +1711,9 @@ func (c *Controller) syncKubeOvnNet(pod *v1.Pod, podNets []*kubeovnNet) (*v1.Pod
 	}
 
 	if details := c.podNetworkEventDetails(pod, changedPodNets); details != "" {
-		hotplugDetails = append(hotplugDetails, details)
+		staleState.details = append(staleState.details, details)
 	}
-	return pod, strings.Join(hotplugDetails, "; "), nil
+	return pod, strings.Join(staleState.details, "; "), nil
 }
 
 func (c *Controller) podNetworkEventDetails(pod *v1.Pod, podNets []*kubeovnNet) string {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1531,119 +1531,117 @@ func TestSyncKubeOvnNetReportsNoChange(t *testing.T) {
 	assertNoPodEvent(t, fc.fakeController)
 }
 
-func TestSyncKubeOvnNetParsesStalePortProviders(t *testing.T) {
-	const (
-		provider = "net1.default.ovn"
-		keepKey  = "example.com/keep"
-	)
+const (
+	stalePortTestProvider = "net1.default.ovn"
+	stalePortTestKeepKey  = "example.com/keep"
+)
 
-	t.Run("default OVN port", func(t *testing.T) {
-		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-			Name: "test-pod", Namespace: metav1.NamespaceDefault,
-			Annotations: map[string]string{util.AllocatedAnnotation: "true", keepKey: "true"},
-		}}
-		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
-		require.NoError(t, err)
-		portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
-		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
-		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+func TestSyncKubeOvnNetKeepsDefaultOVNAnnotations(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-pod", Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{util.AllocatedAnnotation: "true", stalePortTestKeepKey: "true"},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
 
-		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+	updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
 
-		require.NoError(t, err)
-		assert.Equal(t, "true", updatedPod.Annotations[util.AllocatedAnnotation])
-		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
-		assert.Contains(t, details, "provider="+util.OvnProvider)
-		assert.Contains(t, details, "logicalSwitchPort="+portName)
+	require.NoError(t, err)
+	assert.Equal(t, "true", updatedPod.Annotations[util.AllocatedAnnotation])
+	assert.Equal(t, "true", updatedPod.Annotations[stalePortTestKeepKey])
+	assert.Contains(t, details, "provider="+util.OvnProvider)
+	assert.Contains(t, details, "logicalSwitchPort="+portName)
+}
+
+func TestSyncKubeOvnNetParsesAttachmentProviderWithDots(t *testing.T) {
+	providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, stalePortTestProvider)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-pod", Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{providerKey: "true", stalePortTestKeepKey: "true"},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+	require.NoError(t, err)
+	portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, stalePortTestProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+	updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+	require.NoError(t, err)
+	assert.NotContains(t, updatedPod.Annotations, providerKey)
+	assert.Equal(t, "true", updatedPod.Annotations[stalePortTestKeepKey])
+	assert.Contains(t, details, "provider="+stalePortTestProvider)
+	assert.Contains(t, details, "logicalSwitchPort="+portName)
+}
+
+func TestSyncKubeOvnNetHandlesVMNameWithDots(t *testing.T) {
+	providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, stalePortTestProvider)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "virt-launcher-test", Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{providerKey: "true", stalePortTestKeepKey: "true"},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: kubevirtv1.SchemeGroupVersion.String(), Kind: util.KindVirtualMachineInstance, Name: "test.vm",
+		}},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+	require.NoError(t, err)
+	fc.fakeController.config.EnableKeepVMIP = true
+	portName := ovs.PodNameToPortName("test.vm", pod.Namespace, stalePortTestProvider)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+
+	updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
+
+	require.NoError(t, err)
+	assert.NotContains(t, updatedPod.Annotations, providerKey)
+	assert.Equal(t, "true", updatedPod.Annotations[stalePortTestKeepKey])
+	assert.Contains(t, details, "provider="+stalePortTestProvider)
+	assert.Contains(t, details, "logicalSwitchPort="+portName)
+}
+
+func TestSyncKubeOvnNetReportsUnmatchedPodPrefix(t *testing.T) {
+	providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, stalePortTestProvider)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-pod", Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{providerKey: "true", stalePortTestKeepKey: "true"},
+	}}
+	_, subnet := podEventFixture()
+	portName := "legacy-port-name"
+	ipCR := &kubeovnv1.IP{ObjectMeta: metav1.ObjectMeta{Name: portName}, Spec: kubeovnv1.IPSpec{Subnet: subnet.Name}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}, IPs: []*kubeovnv1.IP{ipCR},
 	})
+	require.NoError(t, err)
+	fc.fakeController.config.EnableNonPrimaryCNI = true
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	_, _, _, err = fc.fakeController.ipam.GetStaticAddress("default/test-pod", portName, "10.0.0.2", nil, subnet.Name, false)
+	require.NoError(t, err)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{
+		Name: portName,
+		ExternalIDs: map[string]string{
+			"pod": "default/test-pod",
+			"ls":  subnet.Name,
+		},
+	}}, nil)
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
 
-	t.Run("attachment provider containing dots", func(t *testing.T) {
-		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
-		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-			Name: "test-pod", Namespace: metav1.NamespaceDefault,
-			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
-		}}
-		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
-		require.NoError(t, err)
-		portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, provider)
-		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
-		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
 
-		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
-
-		require.NoError(t, err)
-		assert.NotContains(t, updatedPod.Annotations, providerKey)
-		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
-		assert.Contains(t, details, "provider="+provider)
-		assert.Contains(t, details, "logicalSwitchPort="+portName)
-	})
-
-	t.Run("VM name containing dots", func(t *testing.T) {
-		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
-		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-			Name: "virt-launcher-test", Namespace: metav1.NamespaceDefault,
-			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: kubevirtv1.SchemeGroupVersion.String(), Kind: util.KindVirtualMachineInstance, Name: "test.vm",
-			}},
-		}}
-		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
-		require.NoError(t, err)
-		fc.fakeController.config.EnableKeepVMIP = true
-		portName := ovs.PodNameToPortName("test.vm", pod.Namespace, provider)
-		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
-		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
-
-		updatedPod, details, err := fc.fakeController.syncKubeOvnNet(pod, nil)
-
-		require.NoError(t, err)
-		assert.NotContains(t, updatedPod.Annotations, providerKey)
-		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
-		assert.Contains(t, details, "provider="+provider)
-		assert.Contains(t, details, "logicalSwitchPort="+portName)
-	})
-
-	t.Run("unmatched pod prefix", func(t *testing.T) {
-		providerKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
-		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-			Name: "test-pod", Namespace: metav1.NamespaceDefault,
-			Annotations: map[string]string{providerKey: "true", keepKey: "true"},
-		}}
-		_, subnet := podEventFixture()
-		portName := "legacy-port-name"
-		ipCR := &kubeovnv1.IP{ObjectMeta: metav1.ObjectMeta{Name: portName}, Spec: kubeovnv1.IPSpec{Subnet: subnet.Name}}
-		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
-			Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}, IPs: []*kubeovnv1.IP{ipCR},
-		})
-		require.NoError(t, err)
-		fc.fakeController.config.EnableNonPrimaryCNI = true
-		require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
-		_, _, _, err = fc.fakeController.ipam.GetStaticAddress("default/test-pod", portName, "10.0.0.2", nil, subnet.Name, false)
-		require.NoError(t, err)
-		fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return([]ovnnb.LogicalSwitchPort{{
-			Name: portName,
-			ExternalIDs: map[string]string{
-				"pod": "default/test-pod",
-				"ls":  subnet.Name,
-			},
-		}}, nil)
-		fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(portName).Return(nil)
-
-		err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
-
-		require.NoError(t, err)
-		updatedPod, err := fc.fakeController.config.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
-		require.NoError(t, err)
-		assert.Equal(t, "true", updatedPod.Annotations[providerKey])
-		assert.Equal(t, "true", updatedPod.Annotations[keepKey])
-		_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
-		assert.True(t, k8serrors.IsNotFound(err))
-		assert.Empty(t, fc.fakeController.ipam.GetPodAddress("default/test-pod"))
-		event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider=unknown", "subnet="+subnet.Name, "logicalSwitchPort="+portName)
-		assert.NotContains(t, event, "provider="+provider)
-		assert.NotContains(t, event, "provider= ")
-		assertNoPodEvent(t, fc.fakeController)
-	})
+	require.NoError(t, err)
+	updatedPod, err := fc.fakeController.config.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", updatedPod.Annotations[providerKey])
+	assert.Equal(t, "true", updatedPod.Annotations[stalePortTestKeepKey])
+	_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IPs().Get(context.Background(), portName, metav1.GetOptions{})
+	assert.True(t, k8serrors.IsNotFound(err))
+	assert.Empty(t, fc.fakeController.ipam.GetPodAddress("default/test-pod"))
+	event := assertPodEvent(t, fc.fakeController, "Normal PodNetworkUpdated", "provider=unknown", "subnet="+subnet.Name, "logicalSwitchPort="+portName)
+	assert.NotContains(t, event, "provider="+stalePortTestProvider)
+	assert.NotContains(t, event, "provider= ")
+	assertNoPodEvent(t, fc.fakeController)
 }
 
 func TestHandleUpdatePodSecurityRecordsSuccess(t *testing.T) {
@@ -1749,6 +1747,24 @@ func TestHandleDeletePodRecordsFailure(t *testing.T) {
 
 	require.EqualError(t, err, "delete lsp failed")
 	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=deleteLogicalSwitchPort", "delete lsp failed")
+}
+
+func TestHandleDeletePodReportsVIPListerFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.VipAnnotation] = "test-vip"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	failure := errors.New("get vip failed")
+	fc.fakeController.virtualIpsLister = &errorVipLister{err: failure}
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-pod"}).Return(nil, nil)
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.ErrorIs(t, err, failure)
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=releaseVIP", failure.Error())
+	_, retained := fc.fakeController.deletingPodObjMap.Load("default/test-pod")
+	assert.True(t, retained, "deleting pod must remain queued for retry")
 }
 
 func TestHandleDeletePodRetriesOrphanedVMPortIPLookupFailure(t *testing.T) {
@@ -2286,6 +2302,18 @@ type errorOnceIPLister struct {
 	ip    *kubeovnv1.IP
 	err   error
 	calls int
+}
+
+type errorVipLister struct {
+	err error
+}
+
+func (l *errorVipLister) List(labels.Selector) ([]*kubeovnv1.Vip, error) {
+	return nil, l.err
+}
+
+func (l *errorVipLister) Get(string) (*kubeovnv1.Vip, error) {
+	return nil, l.err
 }
 
 func (l *errorOnceIPLister) List(labels.Selector) ([]*kubeovnv1.IP, error) {

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -479,44 +479,38 @@ func (c *Controller) podReuseVip(vipName, portName string, keepVIP bool) error {
 	return nil
 }
 
-func (c *Controller) releaseVip(key string) error {
+func (c *Controller) releaseVip(key string) (bool, error) {
 	// clean vip label when pod delete
 	oriVip, err := c.virtualIpsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			return false, nil
 		}
 		klog.Error(err)
-		return err
+		return false, err
 	}
 	vip := oriVip.DeepCopy()
-	var needUpdateLabel bool
-	var op string
 	if vip.Labels[util.IPReservedLabel] == "" {
-		return nil
+		return false, nil
 	}
-	op = "replace"
 	vip.Labels[util.IPReservedLabel] = ""
-	needUpdateLabel = true
-	if needUpdateLabel {
-		klog.V(3).Infof("clean reserved label from vip %s", key)
-		patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`
-		raw, _ := json.Marshal(vip.Labels)
-		patchPayload := fmt.Sprintf(patchPayloadTemplate, op, raw)
-		if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(context.Background(), vip.Name,
-			types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}); err != nil {
-			klog.Errorf("failed to patch label for vip '%s', %v", vip.Name, err)
-			return err
-		}
-		mac := &vip.Status.Mac
-		if vip.Status.Mac == "" {
-			mac = nil
-		}
-		if _, _, _, err = c.ipam.GetStaticAddress(key, vip.Name, vip.Status.V4ip, mac, vip.Spec.Subnet, false); err != nil {
-			klog.Errorf("failed to recover IPAM from vip CR %s: %v", vip.Name, err)
-		}
+	klog.V(3).Infof("clean reserved label from vip %s", key)
+	patchPayloadTemplate := `[{ "op": "replace", "path": "/metadata/labels", "value": %s }]`
+	raw, _ := json.Marshal(vip.Labels)
+	patchPayload := fmt.Sprintf(patchPayloadTemplate, raw)
+	if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(context.Background(), vip.Name,
+		types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}); err != nil {
+		klog.Errorf("failed to patch label for vip '%s', %v", vip.Name, err)
+		return false, err
 	}
-	return nil
+	mac := &vip.Status.Mac
+	if vip.Status.Mac == "" {
+		mac = nil
+	}
+	if _, _, _, err = c.ipam.GetStaticAddress(key, vip.Name, vip.Status.V4ip, mac, vip.Spec.Subnet, false); err != nil {
+		klog.Errorf("failed to recover IPAM from vip CR %s: %v", vip.Name, err)
+	}
+	return true, nil
 }
 
 func (c *Controller) handleAddOrUpdateVipFinalizer(key string) error {

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -39,11 +39,25 @@ const (
 	kernelModuleIP6Tables = "ip6_tables"
 )
 
-var (
-	setInterfaceBandwidth = ovs.SetInterfaceBandwidth
-	configInterfaceMirror = ovs.ConfigInterfaceMirror
-	setNetemQos           = ovs.SetNetemQos
-)
+type podQoSOperations interface {
+	setInterfaceBandwidth(podName, podNamespace, iface, ingress, egress, ingressBurst, egressBurst string) error
+	configInterfaceMirror(enableMirror bool, mirrorControl, iface string) error
+	setNetemQoS(podName, podNamespace, iface, latency, limit, loss, jitter string) error
+}
+
+type ovsPodQoSOperations struct{}
+
+func (ovsPodQoSOperations) setInterfaceBandwidth(podName, podNamespace, iface, ingress, egress, ingressBurst, egressBurst string) error {
+	return ovs.SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress, ingressBurst, egressBurst)
+}
+
+func (ovsPodQoSOperations) configInterfaceMirror(enableMirror bool, mirrorControl, iface string) error {
+	return ovs.ConfigInterfaceMirror(enableMirror, mirrorControl, iface)
+}
+
+func (ovsPodQoSOperations) setNetemQoS(podName, podNamespace, iface, latency, limit, loss, jitter string) error {
+	return ovs.SetNetemQos(podName, podNamespace, iface, latency, limit, loss, jitter)
+}
 
 // ControllerRuntime represents runtime specific controller members
 type ControllerRuntime struct {
@@ -60,6 +74,7 @@ type ControllerRuntime struct {
 	flowCache      map[string]map[string][]string // key: bridgeName -> flowKey -> flow rules
 	flowCacheMutex sync.RWMutex
 	flowChan       chan struct{} // channel to trigger immediate flow sync
+	podQoSOps      podQoSOperations
 }
 
 type LbServiceRules struct {
@@ -98,6 +113,9 @@ func isLegacyIptablesMode() (bool, error) {
 }
 
 func (c *Controller) initRuntime() error {
+	if c.podQoSOps == nil {
+		c.podQoSOps = ovsPodQoSOperations{}
+	}
 	ok, err := isLegacyIptablesMode()
 	if err != nil {
 		klog.Errorf("failed to check iptables mode: %v", err)
@@ -858,6 +876,42 @@ func (c *Controller) getPolicyRouting(subnet *kubeovnv1.Subnet) ([]netlink.Rule,
 	return rules, routes, nil
 }
 
+func (c *Controller) applyPodQoS(pod *v1.Pod, podName, provider string) (string, error) {
+	ifaceID := ovs.PodNameToPortName(podName, pod.Namespace, provider)
+	annotations := pod.Annotations
+	annotation := func(template string) string {
+		return annotations[fmt.Sprintf(template, provider)]
+	}
+	ops := c.podQoSOps
+	if ops == nil {
+		ops = ovsPodQoSOperations{}
+	}
+	recordFailure := func(stage string, err error) {
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=%s provider=%s interface=%s node=%s: %v", stage, provider, ifaceID, c.config.NodeName, err)
+	}
+
+	if err := ops.setInterfaceBandwidth(podName, pod.Namespace, ifaceID,
+		annotation(util.EgressRateAnnotationTemplate), annotation(util.IngressRateAnnotationTemplate),
+		annotation(util.EgressBurstAnnotationTemplate), annotation(util.IngressBurstAnnotationTemplate)); err != nil {
+		klog.Error(err)
+		recordFailure("bandwidth", err)
+		return ifaceID, err
+	}
+	if err := ops.configInterfaceMirror(c.config.EnableMirror, annotation(util.MirrorControlAnnotationTemplate), ifaceID); err != nil {
+		klog.Error(err)
+		recordFailure("mirror", err)
+		return ifaceID, err
+	}
+	if err := ops.setNetemQoS(podName, pod.Namespace, ifaceID,
+		annotation(util.NetemQosLatencyAnnotationTemplate), annotation(util.NetemQosLimitAnnotationTemplate),
+		annotation(util.NetemQosLossAnnotationTemplate), annotation(util.NetemQosJitterAnnotationTemplate)); err != nil {
+		klog.Error(err)
+		recordFailure("netem", err)
+		return ifaceID, err
+	}
+	return ifaceID, nil
+}
+
 func (c *Controller) handleUpdatePod(key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -886,30 +940,8 @@ func (c *Controller) handleUpdatePod(key string) error {
 		podName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, util.OvnProvider)]
 	}
 
-	// set default nic bandwidth
-	//  ovsIngress and ovsEgress are derived from the pod's egress and ingress rate annotations respectively, their roles are reversed from the OVS interface perspective.
-	ifaceID := ovs.PodNameToPortName(podName, pod.Namespace, util.OvnProvider)
-	ovsIngress := pod.Annotations[util.EgressRateAnnotation]
-	ovsEgress := pod.Annotations[util.IngressRateAnnotation]
-	ovsIngressBurst := pod.Annotations[util.EgressBurstAnnotation]
-	ovsEgressBurst := pod.Annotations[util.IngressBurstAnnotation]
-	err = setInterfaceBandwidth(podName, pod.Namespace, ifaceID, ovsIngress, ovsEgress, ovsIngressBurst, ovsEgressBurst)
+	ifaceID, err := c.applyPodQoS(pod, podName, util.OvnProvider)
 	if err != nil {
-		klog.Error(err)
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=bandwidth provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
-		return err
-	}
-	err = configInterfaceMirror(c.config.EnableMirror, pod.Annotations[util.MirrorControlAnnotation], ifaceID)
-	if err != nil {
-		klog.Error(err)
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
-		return err
-	}
-	// set linux-netem qos
-	err = setNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[util.NetemQosLatencyAnnotation], pod.Annotations[util.NetemQosLimitAnnotation], pod.Annotations[util.NetemQosLossAnnotation], pod.Annotations[util.NetemQosJitterAnnotation])
-	if err != nil {
-		klog.Error(err)
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
 		return err
 	}
 	processed := []string{fmt.Sprintf("provider=%s interface=%s", util.OvnProvider, ifaceID)}
@@ -930,27 +962,8 @@ func (c *Controller) handleUpdatePod(key string) error {
 			multiNetPodName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)]
 		}
 		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] == "true" {
-			ifaceID = ovs.PodNameToPortName(multiNetPodName, pod.Namespace, provider)
-			err = setInterfaceBandwidth(multiNetPodName, pod.Namespace, ifaceID,
-				pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)],
-				pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)],
-				pod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, provider)],
-				pod.Annotations[fmt.Sprintf(util.IngressBurstAnnotationTemplate, provider)])
+			ifaceID, err = c.applyPodQoS(pod, multiNetPodName, provider)
 			if err != nil {
-				klog.Error(err)
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=bandwidth provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
-				return err
-			}
-			err = configInterfaceMirror(c.config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, provider)], ifaceID)
-			if err != nil {
-				klog.Error(err)
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
-				return err
-			}
-			err = setNetemQos(multiNetPodName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)])
-			if err != nil {
-				klog.Error(err)
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
 			processed = append(processed, fmt.Sprintf("provider=%s interface=%s", provider, ifaceID))

--- a/pkg/daemon/controller_linux_test.go
+++ b/pkg/daemon/controller_linux_test.go
@@ -73,13 +73,13 @@ func TestHandleUpdatePodValidationFailureEmitsOnlyValidationEvent(t *testing.T) 
 
 func TestHandleUpdatePodBandwidthFailureEmitsQoSFailureEvent(t *testing.T) {
 	failErr := errors.New("default bandwidth failure")
-	stubPodQoSFunctions(t, "bandwidth", "pod.default", failErr)
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name:        "pod",
 		Namespace:   metav1.NamespaceDefault,
 		Annotations: map[string]string{},
 	}}
 	controller, recorder := newPodQoSTestController(t, pod)
+	stubPodQoSOperations(controller, "bandwidth", "pod.default", failErr)
 
 	require.ErrorIs(t, controller.handleUpdatePod("default/pod"), failErr)
 	requirePodEvent(t, recorder,
@@ -88,39 +88,37 @@ func TestHandleUpdatePodBandwidthFailureEmitsQoSFailureEvent(t *testing.T) {
 	requireNoPodEvent(t, recorder)
 }
 
-func stubPodQoSFunctions(t *testing.T, failStage, failInterface string, failErr error) map[string][]string {
-	t.Helper()
+type fakePodQoSOperations struct {
+	calls         map[string][]string
+	failStage     string
+	failInterface string
+	failErr       error
+}
 
-	originalBandwidth := setInterfaceBandwidth
-	originalMirror := configInterfaceMirror
-	originalNetem := setNetemQos
-	t.Cleanup(func() {
-		setInterfaceBandwidth = originalBandwidth
-		configInterfaceMirror = originalMirror
-		setNetemQos = originalNetem
-	})
+func (o *fakePodQoSOperations) result(stage, iface string) error {
+	o.calls[stage] = append(o.calls[stage], iface)
+	if o.failStage == stage && o.failInterface == iface {
+		return o.failErr
+	}
+	return nil
+}
 
+func (o *fakePodQoSOperations) setInterfaceBandwidth(_, _, iface, _, _, _, _ string) error {
+	return o.result("bandwidth", iface)
+}
+
+func (o *fakePodQoSOperations) configInterfaceMirror(_ bool, _, iface string) error {
+	return o.result("mirror", iface)
+}
+
+func (o *fakePodQoSOperations) setNetemQoS(_, _, iface, _, _, _, _ string) error {
+	return o.result("netem", iface)
+}
+
+func stubPodQoSOperations(controller *Controller, failStage, failInterface string, failErr error) map[string][]string {
 	calls := map[string][]string{}
-	setInterfaceBandwidth = func(_, _, iface, _, _, _, _ string) error {
-		calls["bandwidth"] = append(calls["bandwidth"], iface)
-		if failStage == "bandwidth" && iface == failInterface {
-			return failErr
-		}
-		return nil
-	}
-	configInterfaceMirror = func(_ bool, _, iface string) error {
-		calls["mirror"] = append(calls["mirror"], iface)
-		if failStage == "mirror" && iface == failInterface {
-			return failErr
-		}
-		return nil
-	}
-	setNetemQos = func(_, _, iface, _, _, _, _ string) error {
-		calls["netem"] = append(calls["netem"], iface)
-		if failStage == "netem" && iface == failInterface {
-			return failErr
-		}
-		return nil
+	controller.podQoSOps = &fakePodQoSOperations{
+		calls: calls, failStage: failStage, failInterface: failInterface, failErr: failErr,
 	}
 	return calls
 }
@@ -144,8 +142,8 @@ func TestHandleUpdatePodQoSCallFailuresEmitOneEvent(t *testing.T) {
 
 	for _, stage := range []string{"bandwidth", "mirror", "netem"} {
 		t.Run(stage, func(t *testing.T) {
-			calls := stubPodQoSFunctions(t, stage, multusInterface, failErr)
 			controller, recorder := newPodQoSTestController(t, newPodQoSTestPod("default/net1"))
+			calls := stubPodQoSOperations(controller, stage, multusInterface, failErr)
 
 			require.ErrorIs(t, controller.handleUpdatePod("default/pod"), failErr)
 			require.Contains(t, calls[stage], multusInterface)
@@ -159,8 +157,8 @@ func TestHandleUpdatePodQoSCallFailuresEmitOneEvent(t *testing.T) {
 }
 
 func TestHandleUpdatePodSuccessEmitsOneEventWithProcessedInterfaces(t *testing.T) {
-	calls := stubPodQoSFunctions(t, "", "", nil)
 	controller, recorder := newPodQoSTestController(t, newPodQoSTestPod("default/net1"))
+	calls := stubPodQoSOperations(controller, "", "", nil)
 
 	require.NoError(t, controller.handleUpdatePod("default/pod"))
 	require.Equal(t, []string{"pod.default", "pod.default.net1.default.ovn"}, calls["netem"])
@@ -175,8 +173,8 @@ func TestHandleUpdatePodKeepsMultusPodNamesIndependent(t *testing.T) {
 	pod := newPodQoSTestPod("default/net1,default/net2")
 	pod.Annotations["net1.default.ovn.kubernetes.io/virtualmachine"] = "vm-one"
 	pod.Annotations["net2.default.ovn.kubernetes.io/allocated"] = "true"
-	calls := stubPodQoSFunctions(t, "", "", nil)
 	controller, recorder := newPodQoSTestController(t, pod)
+	calls := stubPodQoSOperations(controller, "", "", nil)
 
 	require.NoError(t, controller.handleUpdatePod("default/pod"))
 	expectedInterfaces := []string{
@@ -195,9 +193,9 @@ func TestHandleUpdatePodKeepsMultusPodNamesIndependent(t *testing.T) {
 }
 
 func TestHandleUpdatePodNetworkAttachmentParseFailureEmitsOneEvent(t *testing.T) {
-	stubPodQoSFunctions(t, "", "", nil)
 	pod := newPodQoSTestPod("[")
 	controller, recorder := newPodQoSTestController(t, pod)
+	stubPodQoSOperations(controller, "", "", nil)
 
 	err := controller.handleUpdatePod("default/pod")
 	require.Error(t, err)
@@ -208,8 +206,8 @@ func TestHandleUpdatePodNetworkAttachmentParseFailureEmitsOneEvent(t *testing.T)
 }
 
 func TestHandleUpdatePodWithoutMultusEmitsDefaultInterfaceSuccess(t *testing.T) {
-	stubPodQoSFunctions(t, "", "", nil)
 	controller, recorder := newPodQoSTestController(t, newPodQoSTestPod(""))
+	stubPodQoSOperations(controller, "", "", nil)
 
 	require.NoError(t, controller.handleUpdatePod("default/pod"))
 	requirePodEvent(t, recorder,


### PR DESCRIPTION
## What this PR does

Addresses follow-up review findings from #6989 and its release-1.16 backport #7180:

- propagate VIP lister and patch errors during pod network release, and report whether VIP state changed
- extract stale pod network state collection to keep reconciliation focused
- consolidate default and Multus pod QoS reconciliation
- scope QoS test dependencies to each controller instead of package-global mutable hooks
- split the oversized stale-port provider test into focused cases
- cover VIP lister failures, release failure Events, and retry retention

## Tests

- `go test ./pkg/controller ./pkg/daemon -count=1`
- `CGO_ENABLED=1 go test -race ./pkg/daemon -run "TestHandleUpdatePod|TestEnqueueUpdatePodOnlyQueuesRelevantAnnotationChanges" -count=1`
- `golangci-lint run ./pkg/controller/... ./pkg/daemon/...`
- `git diff --check`