### PR TITLE
daemon: consolidate pod QoS reconciliation

### DIFF
--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1722,15 +1722,16 @@ func TestHandleDeletePodRetriesOrphanedVMPortIPLookupFailure(t *testing.T) {
 	mockKubevirt.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(mockVMIs).Times(2)
 	mockVMIs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(&kubevirtv1.VirtualMachineInstance{}, nil).Times(2)
 	mockKubevirt.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(mockVMs).Times(4)
-	vm := &kubevirtv1.VirtualMachine{Spec: kubevirtv1.VirtualMachineSpec{Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.LogicalSwitchAnnotation: subnet.Name}},
+	vmTemplate := &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 		Spec: kubevirtv1.VirtualMachineInstanceSpec{Networks: []kubevirtv1.Network{{
 			Name: "net1",
 			Multus: &kubevirtv1.MultusNetwork{
 				NetworkName: "default/net1",
 			},
 		}}},
-	}}}
+	}
+	vmTemplate.ObjectMeta.Annotations = map[string]string{util.LogicalSwitchAnnotation: subnet.Name}
+	vm := &kubevirtv1.VirtualMachine{Spec: kubevirtv1.VirtualMachineSpec{Template: vmTemplate}}
 	mockVMs.EXPECT().Get(gomock.Any(), "test-vm", gomock.Any()).Return(vm, nil).Times(4)
 	fc.fakeController.config.KubevirtClient = mockKubevirt
 

--- a/pkg/daemon/controller_linux.go
+++ b/pkg/daemon/controller_linux.go
@@ -39,11 +39,25 @@ const (
 	kernelModuleIP6Tables = "ip6_tables"
 )
 
-var (
-	setInterfaceBandwidth = ovs.SetInterfaceBandwidth
-	configInterfaceMirror = ovs.ConfigInterfaceMirror
-	setNetemQos           = ovs.SetNetemQos
-)
+type podQoSOperations interface {
+	setInterfaceBandwidth(podName, podNamespace, iface, ingress, egress, ingressBurst, egressBurst string) error
+	configInterfaceMirror(enableMirror bool, mirrorControl, iface string) error
+	setNetemQoS(podName, podNamespace, iface, latency, limit, loss, jitter string) error
+}
+
+type ovsPodQoSOperations struct{}
+
+func (ovsPodQoSOperations) setInterfaceBandwidth(podName, podNamespace, iface, ingress, egress, ingressBurst, egressBurst string) error {
+	return ovs.SetInterfaceBandwidth(podName, podNamespace, iface, ingress, egress, ingressBurst, egressBurst)
+}
+
+func (ovsPodQoSOperations) configInterfaceMirror(enableMirror bool, mirrorControl, iface string) error {
+	return ovs.ConfigInterfaceMirror(enableMirror, mirrorControl, iface)
+}
+
+func (ovsPodQoSOperations) setNetemQoS(podName, podNamespace, iface, latency, limit, loss, jitter string) error {
+	return ovs.SetNetemQos(podName, podNamespace, iface, latency, limit, loss, jitter)
+}
 
 // ControllerRuntime represents runtime specific controller members
 type ControllerRuntime struct {
@@ -60,6 +74,7 @@ type ControllerRuntime struct {
 	flowCache      map[string]map[string][]string // key: bridgeName -> flowKey -> flow rules
 	flowCacheMutex sync.RWMutex
 	flowChan       chan struct{} // channel to trigger immediate flow sync
+	podQoSOps      podQoSOperations
 }
 
 type LbServiceRules struct {
@@ -98,6 +113,9 @@ func isLegacyIptablesMode() (bool, error) {
 }
 
 func (c *Controller) initRuntime() error {
+	if c.podQoSOps == nil {
+		c.podQoSOps = ovsPodQoSOperations{}
+	}
 	ok, err := isLegacyIptablesMode()
 	if err != nil {
 		klog.Errorf("failed to check iptables mode: %v", err)
@@ -858,6 +876,42 @@ func (c *Controller) getPolicyRouting(subnet *kubeovnv1.Subnet) ([]netlink.Rule,
 	return rules, routes, nil
 }
 
+func (c *Controller) applyPodQoS(pod *v1.Pod, podName, provider string) (string, error) {
+	ifaceID := ovs.PodNameToPortName(podName, pod.Namespace, provider)
+	annotations := pod.Annotations
+	annotation := func(template string) string {
+		return annotations[fmt.Sprintf(template, provider)]
+	}
+	ops := c.podQoSOps
+	if ops == nil {
+		ops = ovsPodQoSOperations{}
+	}
+	recordFailure := func(stage string, err error) {
+		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=%s provider=%s interface=%s node=%s: %v", stage, provider, ifaceID, c.config.NodeName, err)
+	}
+
+	if err := ops.setInterfaceBandwidth(podName, pod.Namespace, ifaceID,
+		annotation(util.EgressRateAnnotationTemplate), annotation(util.IngressRateAnnotationTemplate),
+		annotation(util.EgressBurstAnnotationTemplate), annotation(util.IngressBurstAnnotationTemplate)); err != nil {
+		klog.Error(err)
+		recordFailure("bandwidth", err)
+		return ifaceID, err
+	}
+	if err := ops.configInterfaceMirror(c.config.EnableMirror, annotation(util.MirrorControlAnnotationTemplate), ifaceID); err != nil {
+		klog.Error(err)
+		recordFailure("mirror", err)
+		return ifaceID, err
+	}
+	if err := ops.setNetemQoS(podName, pod.Namespace, ifaceID,
+		annotation(util.NetemQosLatencyAnnotationTemplate), annotation(util.NetemQosLimitAnnotationTemplate),
+		annotation(util.NetemQosLossAnnotationTemplate), annotation(util.NetemQosJitterAnnotationTemplate)); err != nil {
+		klog.Error(err)
+		recordFailure("netem", err)
+		return ifaceID, err
+	}
+	return ifaceID, nil
+}
+
 func (c *Controller) handleUpdatePod(key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -886,30 +940,8 @@ func (c *Controller) handleUpdatePod(key string) error {
 		podName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, util.OvnProvider)]
 	}
 
-	// set default nic bandwidth
-	//  ovsIngress and ovsEgress are derived from the pod's egress and ingress rate annotations respectively, their roles are reversed from the OVS interface perspective.
-	ifaceID := ovs.PodNameToPortName(podName, pod.Namespace, util.OvnProvider)
-	ovsIngress := pod.Annotations[util.EgressRateAnnotation]
-	ovsEgress := pod.Annotations[util.IngressRateAnnotation]
-	ovsIngressBurst := pod.Annotations[util.EgressBurstAnnotation]
-	ovsEgressBurst := pod.Annotations[util.IngressBurstAnnotation]
-	err = setInterfaceBandwidth(podName, pod.Namespace, ifaceID, ovsIngress, ovsEgress, ovsIngressBurst, ovsEgressBurst)
+	ifaceID, err := c.applyPodQoS(pod, podName, util.OvnProvider)
 	if err != nil {
-		klog.Error(err)
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=bandwidth provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
-		return err
-	}
-	err = configInterfaceMirror(c.config.EnableMirror, pod.Annotations[util.MirrorControlAnnotation], ifaceID)
-	if err != nil {
-		klog.Error(err)
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
-		return err
-	}
-	// set linux-netem qos
-	err = setNetemQos(podName, pod.Namespace, ifaceID, pod.Annotations[util.NetemQosLatencyAnnotation], pod.Annotations[util.NetemQosLimitAnnotation], pod.Annotations[util.NetemQosLossAnnotation], pod.Annotations[util.NetemQosJitterAnnotation])
-	if err != nil {
-		klog.Error(err)
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", util.OvnProvider, ifaceID, c.config.NodeName, err)
 		return err
 	}
 	processed := []string{fmt.Sprintf("provider=%s interface=%s", util.OvnProvider, ifaceID)}
@@ -930,27 +962,8 @@ func (c *Controller) handleUpdatePod(key string) error {
 			multiNetPodName = pod.Annotations[fmt.Sprintf(util.VMAnnotationTemplate, provider)]
 		}
 		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)] == "true" {
-			ifaceID = ovs.PodNameToPortName(multiNetPodName, pod.Namespace, provider)
-			err = setInterfaceBandwidth(multiNetPodName, pod.Namespace, ifaceID,
-				pod.Annotations[fmt.Sprintf(util.EgressRateAnnotationTemplate, provider)],
-				pod.Annotations[fmt.Sprintf(util.IngressRateAnnotationTemplate, provider)],
-				pod.Annotations[fmt.Sprintf(util.EgressBurstAnnotationTemplate, provider)],
-				pod.Annotations[fmt.Sprintf(util.IngressBurstAnnotationTemplate, provider)])
+			ifaceID, err = c.applyPodQoS(pod, multiNetPodName, provider)
 			if err != nil {
-				klog.Error(err)
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=bandwidth provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
-				return err
-			}
-			err = configInterfaceMirror(c.config.EnableMirror, pod.Annotations[fmt.Sprintf(util.MirrorControlAnnotationTemplate, provider)], ifaceID)
-			if err != nil {
-				klog.Error(err)
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=mirror provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
-				return err
-			}
-			err = setNetemQos(multiNetPodName, pod.Namespace, ifaceID, pod.Annotations[fmt.Sprintf(util.NetemQosLatencyAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLimitAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosLossAnnotationTemplate, provider)], pod.Annotations[fmt.Sprintf(util.NetemQosJitterAnnotationTemplate, provider)])
-			if err != nil {
-				klog.Error(err)
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "PodQoSUpdateFailed", "Failed to update pod QoS: stage=netem provider=%s interface=%s node=%s: %v", provider, ifaceID, c.config.NodeName, err)
 				return err
 			}
 			processed = append(processed, fmt.Sprintf("provider=%s interface=%s", provider, ifaceID))

--- a/pkg/daemon/controller_linux_test.go
+++ b/pkg/daemon/controller_linux_test.go
@@ -73,13 +73,13 @@ func TestHandleUpdatePodValidationFailureEmitsOnlyValidationEvent(t *testing.T) 
 
 func TestHandleUpdatePodBandwidthFailureEmitsQoSFailureEvent(t *testing.T) {
 	failErr := errors.New("default bandwidth failure")
-	stubPodQoSFunctions(t, "bandwidth", "pod.default", failErr)
-	pod := &v1.Pod{
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name:        "pod",
 		Namespace:   metav1.NamespaceDefault,
 		Annotations: map[string]string{},
-	}
+	}}
 	controller, recorder := newPodQoSTestController(t, pod)
+	stubPodQoSOperations(controller, "bandwidth", "pod.default", failErr)
 
 	require.ErrorIs(t, controller.handleUpdatePod("default/pod"), failErr)
 	requirePodEvent(t, recorder,
@@ -88,39 +88,37 @@ func TestHandleUpdatePodBandwidthFailureEmitsQoSFailureEvent(t *testing.T) {
 	requireNoPodEvent(t, recorder)
 }
 
-func stubPodQoSFunctions(t *testing.T, failStage, failInterface string, failErr error) map[string][]string {
-	t.Helper()
+type fakePodQoSOperations struct {
+	calls         map[string][]string
+	failStage     string
+	failInterface string
+	failErr       error
+}
 
-	originalBandwidth := setInterfaceBandwidth
-	originalMirror := configInterfaceMirror
-	originalNetem := setNetemQos
-	t.Cleanup(func() {
-		setInterfaceBandwidth = originalBandwidth
-		configInterfaceMirror = originalMirror
-		setNetemQos = originalNetem
-	})
+func (o *fakePodQoSOperations) result(stage, iface string) error {
+	o.calls[stage] = append(o.calls[stage], iface)
+	if o.failStage == stage && o.failInterface == iface {
+		return o.failErr
+	}
+	return nil
+}
 
+func (o *fakePodQoSOperations) setInterfaceBandwidth(_, _, iface, _, _, _, _ string) error {
+	return o.result("bandwidth", iface)
+}
+
+func (o *fakePodQoSOperations) configInterfaceMirror(_ bool, _, iface string) error {
+	return o.result("mirror", iface)
+}
+
+func (o *fakePodQoSOperations) setNetemQoS(_, _, iface, _, _, _, _ string) error {
+	return o.result("netem", iface)
+}
+
+func stubPodQoSOperations(controller *Controller, failStage, failInterface string, failErr error) map[string][]string {
 	calls := map[string][]string{}
-	setInterfaceBandwidth = func(_, _, iface, _, _, _, _ string) error {
-		calls["bandwidth"] = append(calls["bandwidth"], iface)
-		if failStage == "bandwidth" && iface == failInterface {
-			return failErr
-		}
-		return nil
-	}
-	configInterfaceMirror = func(_ bool, _, iface string) error {
-		calls["mirror"] = append(calls["mirror"], iface)
-		if failStage == "mirror" && iface == failInterface {
-			return failErr
-		}
-		return nil
-	}
-	setNetemQos = func(_, _, iface, _, _, _, _ string) error {
-		calls["netem"] = append(calls["netem"], iface)
-		if failStage == "netem" && iface == failInterface {
-			return failErr
-		}
-		return nil
+	controller.podQoSOps = &fakePodQoSOperations{
+		calls: calls, failStage: failStage, failInterface: failInterface, failErr: failErr,
 	}
 	return calls
 }
@@ -144,8 +142,8 @@ func TestHandleUpdatePodQoSCallFailuresEmitOneEvent(t *testing.T) {
 
 	for _, stage := range []string{"bandwidth", "mirror", "netem"} {
 		t.Run(stage, func(t *testing.T) {
-			calls := stubPodQoSFunctions(t, stage, multusInterface, failErr)
 			controller, recorder := newPodQoSTestController(t, newPodQoSTestPod("default/net1"))
+			calls := stubPodQoSOperations(controller, stage, multusInterface, failErr)
 
 			require.ErrorIs(t, controller.handleUpdatePod("default/pod"), failErr)
 			require.Contains(t, calls[stage], multusInterface)
@@ -159,8 +157,8 @@ func TestHandleUpdatePodQoSCallFailuresEmitOneEvent(t *testing.T) {
 }
 
 func TestHandleUpdatePodSuccessEmitsOneEventWithProcessedInterfaces(t *testing.T) {
-	calls := stubPodQoSFunctions(t, "", "", nil)
 	controller, recorder := newPodQoSTestController(t, newPodQoSTestPod("default/net1"))
+	calls := stubPodQoSOperations(controller, "", "", nil)
 
 	require.NoError(t, controller.handleUpdatePod("default/pod"))
 	require.Equal(t, []string{"pod.default", "pod.default.net1.default.ovn"}, calls["netem"])
@@ -175,8 +173,8 @@ func TestHandleUpdatePodKeepsMultusPodNamesIndependent(t *testing.T) {
 	pod := newPodQoSTestPod("default/net1,default/net2")
 	pod.Annotations["net1.default.ovn.kubernetes.io/virtualmachine"] = "vm-one"
 	pod.Annotations["net2.default.ovn.kubernetes.io/allocated"] = "true"
-	calls := stubPodQoSFunctions(t, "", "", nil)
 	controller, recorder := newPodQoSTestController(t, pod)
+	calls := stubPodQoSOperations(controller, "", "", nil)
 
 	require.NoError(t, controller.handleUpdatePod("default/pod"))
 	expectedInterfaces := []string{
@@ -195,9 +193,9 @@ func TestHandleUpdatePodKeepsMultusPodNamesIndependent(t *testing.T) {
 }
 
 func TestHandleUpdatePodNetworkAttachmentParseFailureEmitsOneEvent(t *testing.T) {
-	stubPodQoSFunctions(t, "", "", nil)
 	pod := newPodQoSTestPod("[")
 	controller, recorder := newPodQoSTestController(t, pod)
+	stubPodQoSOperations(controller, "", "", nil)
 
 	err := controller.handleUpdatePod("default/pod")
 	require.Error(t, err)
@@ -208,8 +206,8 @@ func TestHandleUpdatePodNetworkAttachmentParseFailureEmitsOneEvent(t *testing.T)
 }
 
 func TestHandleUpdatePodWithoutMultusEmitsDefaultInterfaceSuccess(t *testing.T) {
-	stubPodQoSFunctions(t, "", "", nil)
 	controller, recorder := newPodQoSTestController(t, newPodQoSTestPod(""))
+	stubPodQoSOperations(controller, "", "", nil)
 
 	require.NoError(t, controller.handleUpdatePod("default/pod"))
 	requirePodEvent(t, recorder,

--- a/pkg/daemon/controller_linux_test.go
+++ b/pkg/daemon/controller_linux_test.go
@@ -73,11 +73,11 @@ func TestHandleUpdatePodValidationFailureEmitsOnlyValidationEvent(t *testing.T) 
 
 func TestHandleUpdatePodBandwidthFailureEmitsQoSFailureEvent(t *testing.T) {
 	failErr := errors.New("default bandwidth failure")
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+	pod := &v1.Pod{
 		Name:        "pod",
 		Namespace:   metav1.NamespaceDefault,
 		Annotations: map[string]string{},
-	}}
+	}
 	controller, recorder := newPodQoSTestController(t, pod)
 	stubPodQoSOperations(controller, "bandwidth", "pod.default", failErr)
 


### PR DESCRIPTION
## What this PR does

Splits the Pod QoS reconciliation cleanup from #7182 into an independently reviewable change:

- consolidate default and Multus bandwidth, mirror, and netem reconciliation
- preserve provider-specific annotations and VM-derived interface IDs
- replace package-global mutable test hooks with controller-scoped QoS operations
- keep failure Events and processed-interface success Events unchanged

## Tests

- `go test ./pkg/daemon -count=1`
- `CGO_ENABLED=1 go test -race ./pkg/daemon -run "TestHandleUpdatePod|TestEnqueueUpdatePodOnlyQueuesRelevantAnnotationChanges" -count=1`
- `golangci-lint run ./pkg/daemon/...`
- `git diff --check`

Split from #7182.