### PR TITLE
controller: propagate VIP release errors

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -294,7 +294,7 @@ func (c *Controller) gcVip() error {
 			_, err := c.podsLister.Pods(namespace).Get(podName)
 			if err != nil {
 				if k8serrors.IsNotFound(err) {
-					if err = c.releaseVip(vip.Name); err != nil {
+					if _, err = c.releaseVip(vip.Name); err != nil {
 						klog.Errorf("failed to clean label from vip %s, %v", vip.Name, err)
 						return err
 					}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -1459,14 +1459,13 @@ func (c *Controller) handleDeletePod(key string) (err error) {
 			}
 		}
 		if pod.Annotations[util.VipAnnotation] != "" {
-			vip, vipErr := c.virtualIpsLister.Get(pod.Annotations[util.VipAnnotation])
-			vipWillChange := vipErr == nil && vip.Labels[util.IPReservedLabel] != ""
 			stage = "releaseVIP"
-			if err = c.releaseVip(pod.Annotations[util.VipAnnotation]); err != nil {
+			var vipReleased bool
+			if vipReleased, err = c.releaseVip(pod.Annotations[util.VipAnnotation]); err != nil {
 				klog.Errorf("failed to clean label from vip %s, %v", pod.Annotations[util.VipAnnotation], err)
 				return err
 			}
-			if vipWillChange {
+			if vipReleased {
 				changed = true
 				released = append(released, "vip="+pod.Annotations[util.VipAnnotation])
 			}

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1691,6 +1691,53 @@ func TestHandleDeletePodRecordsFailure(t *testing.T) {
 	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=deleteLogicalSwitchPort", "delete lsp failed")
 }
 
+func TestHandleDeletePodReportsVIPListerFailure(t *testing.T) {
+	pod, subnet := podEventFixture()
+	pod.Annotations[util.VipAnnotation] = "test-vip"
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	failure := errors.New("get vip failed")
+	fc.fakeController.virtualIpsLister = &errorVipLister{err: failure}
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, map[string]string{"pod": "default/test-pod"}).Return(nil, nil)
+	storeDeletingPod(fc.fakeController, pod)
+
+	err = fc.fakeController.handleDeletePod("default/test-pod")
+
+	require.ErrorIs(t, err, failure)
+	assertPodEvent(t, fc.fakeController, "Warning PodNetworkReleaseFailed", "stage=releaseVIP", failure.Error())
+	_, retained := fc.fakeController.deletingPodObjMap.Load("default/test-pod")
+	assert.True(t, retained, "deleting pod must remain queued for retry")
+}
+
+func TestReleaseVipReportsLabelChange(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        map[string]string
+		expectChanged bool
+	}{
+		{name: "reserved label", labels: map[string]string{util.IPReservedLabel: "test-pod.default"}, expectChanged: true},
+		{name: "no reserved label", labels: map[string]string{}, expectChanged: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc, err := newFakeControllerWithOptions(t, nil)
+			require.NoError(t, err)
+			vip := &kubeovnv1.Vip{Name: "test-vip", Labels: tt.labels}
+			_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().Vips().Create(context.Background(), vip, metav1.CreateOptions{})
+			require.NoError(t, err)
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			require.NoError(t, indexer.Add(vip))
+			fc.fakeController.virtualIpsLister = kubeovnlister.NewVipLister(indexer)
+
+			changed, err := fc.fakeController.releaseVip(vip.Name)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectChanged, changed)
+		})
+	}
+}
+
 func TestHandleDeletePodRetriesOrphanedVMPortIPLookupFailure(t *testing.T) {
 	pod, subnet := podEventFixture()
 	now := metav1.Now()
@@ -2253,6 +2300,18 @@ type errorOnceIPLister struct {
 	ip    *kubeovnv1.IP
 	err   error
 	calls int
+}
+
+type errorVipLister struct {
+	err error
+}
+
+func (l *errorVipLister) List(labels.Selector) ([]*kubeovnv1.Vip, error) {
+	return nil, l.err
+}
+
+func (l *errorVipLister) Get(string) (*kubeovnv1.Vip, error) {
+	return nil, l.err
 }
 
 func (l *errorOnceIPLister) List(labels.Selector) ([]*kubeovnv1.IP, error) {

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -477,44 +477,38 @@ func (c *Controller) podReuseVip(vipName, portName string, keepVIP bool) error {
 	return nil
 }
 
-func (c *Controller) releaseVip(key string) error {
+func (c *Controller) releaseVip(key string) (bool, error) {
 	// clean vip label when pod delete
 	oriVip, err := c.virtualIpsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			return false, nil
 		}
 		klog.Error(err)
-		return err
+		return false, err
 	}
 	vip := oriVip.DeepCopy()
-	var needUpdateLabel bool
-	var op string
 	if vip.Labels[util.IPReservedLabel] == "" {
-		return nil
+		return false, nil
 	}
-	op = "replace"
 	vip.Labels[util.IPReservedLabel] = ""
-	needUpdateLabel = true
-	if needUpdateLabel {
-		klog.V(3).Infof("clean reserved label from vip %s", key)
-		patchPayloadTemplate := `[{ "op": "%s", "path": "/metadata/labels", "value": %s }]`
-		raw, _ := json.Marshal(vip.Labels)
-		patchPayload := fmt.Sprintf(patchPayloadTemplate, op, raw)
-		if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(context.Background(), vip.Name,
-			types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}); err != nil {
-			klog.Errorf("failed to patch label for vip '%s', %v", vip.Name, err)
-			return err
-		}
-		mac := &vip.Status.Mac
-		if vip.Status.Mac == "" {
-			mac = nil
-		}
-		if _, _, _, err = c.ipam.GetStaticAddress(key, vip.Name, vip.Status.V4ip, mac, vip.Spec.Subnet, false); err != nil {
-			klog.Errorf("failed to recover IPAM from vip CR %s: %v", vip.Name, err)
-		}
+	klog.V(3).Infof("clean reserved label from vip %s", key)
+	patchPayloadTemplate := `[{ "op": "replace", "path": "/metadata/labels", "value": %s }]`
+	raw, _ := json.Marshal(vip.Labels)
+	patchPayload := fmt.Sprintf(patchPayloadTemplate, raw)
+	if _, err := c.config.KubeOvnClient.KubeovnV1().Vips().Patch(context.Background(), vip.Name,
+		types.JSONPatchType, []byte(patchPayload), metav1.PatchOptions{}); err != nil {
+		klog.Errorf("failed to patch label for vip '%s', %v", vip.Name, err)
+		return false, err
 	}
-	return nil
+	mac := &vip.Status.Mac
+	if vip.Status.Mac == "" {
+		mac = nil
+	}
+	if _, _, _, err = c.ipam.GetStaticAddress(key, vip.Name, vip.Status.V4ip, mac, vip.Spec.Subnet, false); err != nil {
+		klog.Errorf("failed to recover IPAM from vip CR %s: %v", vip.Name, err)
+	}
+	return true, nil
 }
 
 func (c *Controller) handleAddOrUpdateVipFinalizer(key string) error {


### PR DESCRIPTION
## What this PR does

Splits the VIP release follow-up from #7182 into an independently reviewable change:

- propagate VIP lister and patch errors during pod network release
- return whether the VIP reserved label actually changed
- emit the existing PodNetworkReleaseFailed Event on VIP release failure
- retain the deleting Pod object so reconciliation can retry
- update the VIP GC caller for the new return value

## Tests

- `go test ./pkg/controller -count=1`
- `golangci-lint run ./pkg/controller/...`
- `git diff --check`

Split from #7182.