### PR TITLE
controller: deduplicate vpc egress gateway delete errors

### DIFF
--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -1255,8 +1255,7 @@ func (c *Controller) handleDelVpcEgressGateway(key string) error {
 	klog.Infof("handle deleting vpc-egress-gateway %s", key)
 	if err = c.cleanOVNForVpcEgressGateway(key, cachedGateway.Spec.VPC); err != nil {
 		klog.Error(err)
-		c.recordVpcEgressGatewayEvent(cachedGateway, corev1.EventTypeWarning, "DeleteFailed", err.Error())
-		return err
+		return c.recordVpcEgressGatewayError(cachedGateway, "DeleteFailed", err)
 	}
 
 	gw := cachedGateway.DeepCopy()
@@ -1265,8 +1264,7 @@ func (c *Controller) handleDelVpcEgressGateway(key string) error {
 			Update(context.Background(), gw, metav1.UpdateOptions{}); err != nil {
 			err = fmt.Errorf("failed to remove finalizer from vpc-egress-gateway %s: %w", key, err)
 			klog.Error(err)
-			c.recordVpcEgressGatewayEvent(gw, corev1.EventTypeWarning, "DeleteFailed", err.Error())
-			return err
+			return c.recordVpcEgressGatewayError(gw, "DeleteFailed", err)
 		}
 		c.recordVpcEgressGatewayEvent(gw, corev1.EventTypeNormal, "DeleteSuccess", fmt.Sprintf("VpcEgressGateway %s/%s deleted successfully", gw.Namespace, gw.Name))
 	}


### PR DESCRIPTION
## Summary

- reuse the existing VpcEgressGateway error-event helper in both deletion failure paths;
- preserve warning event formatting, error identity, logging, and retry behavior;
- apply the same cleanup to the release-1.16 backport in #7181.

## Test Plan

- go test ./pkg/controller -count=1
- gofmt -d pkg/controller/vpc_egress_gateway.go
- git diff --check origin/master...HEAD

Full repository lint was attempted with a 2 GiB memory limit. It completed CRD verification but remained memory-bound without diagnostics, so it was stopped; GitHub Actions will run the complete lint suite.