### PR TITLE
ipam: restore counter views when preserving the other family's static…

### DIFF
--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -1,6 +1,7 @@
 package ipam
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -342,6 +343,180 @@ func TestGetStaticAddressWithFamily(t *testing.T) {
 	ip, err = NewIP("2001:db8::1")
 	require.NoError(t, err)
 	require.True(t, subnet.V6Using.Contains(ip))
+}
+
+// TestGetStaticAddressDualStackPreserveCounters verifies that dual-stack
+// GetStaticAddress keeps the unchanged family's address in every IPAM view
+// when it replaces the other family's static address, not just in lookup maps.
+// It asserts the preserved address stays in V{N}Using and out of
+// V{N}Available/Released at both the subnet and pool levels. The exhaustion
+// kill-shot subtests prove that the preserved address is never re-issued to another pod.
+func TestGetStaticAddressDualStackPreserveCounters(t *testing.T) {
+	t.Run("ReplaceV4PreserveV6", func(t *testing.T) {
+		ipam := NewIPAM()
+		subnetName := "dualPreserveSubnet"
+		subnet, err := NewSubnet(subnetName, "10.0.0.0/30,2001:db8::/125", nil)
+		require.NoError(t, err)
+		ipam.Subnets[subnetName] = subnet
+		pool := subnet.IPPools[""]
+		require.NotNil(t, pool)
+
+		v4, v6, macStr, err := ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::1", nil, subnetName, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", v4)
+		require.Equal(t, "2001:db8::1", v6)
+		require.NotEmpty(t, macStr)
+
+		v4, v6, macStr, err = ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.2,2001:db8::1", nil, subnetName, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.2", v4)
+		require.Equal(t, "2001:db8::1", v6)
+		require.NotEmpty(t, macStr)
+
+		newV4IP, err := NewIP("10.0.0.2")
+		require.NoError(t, err)
+		oldV4IP, err := NewIP("10.0.0.1")
+		require.NoError(t, err)
+		v6IP, err := NewIP("2001:db8::1")
+		require.NoError(t, err)
+
+		require.True(t, subnet.V4NicToIP["pod1.default"].Equal(newV4IP))
+		require.Equal(t, "pod1.default", subnet.V4IPToPod["10.0.0.2"])
+
+		_, exists := subnet.V4IPToPod["10.0.0.1"]
+		require.False(t, exists)
+		require.False(t, subnet.V4Using.Contains(oldV4IP))
+		require.True(t, subnet.V4Available.Contains(oldV4IP))
+
+		require.True(t, subnet.V6NicToIP["pod1.default"].Equal(v6IP))
+		require.Equal(t, "pod1.default", subnet.V6IPToPod["2001:db8::1"])
+
+		require.True(t, subnet.V6Using.Contains(v6IP), "subnet.V6Using must contain preserved v6")
+		require.False(t, subnet.V6Available.Contains(v6IP), "subnet.V6Available must not contain preserved v6")
+
+		require.True(t, pool.V6Using.Contains(v6IP), "pool.V6Using must contain preserved v6")
+		require.False(t, pool.V6Available.Contains(v6IP), "pool.V6Available must not contain preserved v6")
+		require.False(t, pool.V6Released.Contains(v6IP), "pool.V6Released must not contain preserved v6")
+	})
+
+	t.Run("ReplaceV6PreserveV4", func(t *testing.T) {
+		ipam := NewIPAM()
+		subnetName := "dualPreserveSubnet"
+		subnet, err := NewSubnet(subnetName, "10.0.0.0/30,2001:db8::/125", nil)
+		require.NoError(t, err)
+		ipam.Subnets[subnetName] = subnet
+		pool := subnet.IPPools[""]
+		require.NotNil(t, pool)
+
+		v4, v6, macStr, err := ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::1", nil, subnetName, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", v4)
+		require.Equal(t, "2001:db8::1", v6)
+		require.NotEmpty(t, macStr)
+
+		v4, v6, macStr, err = ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::2", nil, subnetName, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", v4)
+		require.Equal(t, "2001:db8::2", v6)
+		require.NotEmpty(t, macStr)
+
+		v4IP, err := NewIP("10.0.0.1")
+		require.NoError(t, err)
+		newV6IP, err := NewIP("2001:db8::2")
+		require.NoError(t, err)
+		oldV6IP, err := NewIP("2001:db8::1")
+		require.NoError(t, err)
+
+		require.True(t, subnet.V4NicToIP["pod1.default"].Equal(v4IP))
+		require.Equal(t, "pod1.default", subnet.V4IPToPod["10.0.0.1"])
+
+		require.True(t, subnet.V6NicToIP["pod1.default"].Equal(newV6IP))
+		require.Equal(t, "pod1.default", subnet.V6IPToPod["2001:db8::2"])
+
+		_, exists := subnet.V6IPToPod["2001:db8::1"]
+		require.False(t, exists)
+		require.False(t, subnet.V6Using.Contains(oldV6IP))
+		require.True(t, subnet.V6Available.Contains(oldV6IP))
+
+		require.True(t, subnet.V4Using.Contains(v4IP), "subnet.V4Using must contain preserved v4")
+		require.False(t, subnet.V4Available.Contains(v4IP), "subnet.V4Available must not contain preserved v4")
+
+		require.True(t, pool.V4Using.Contains(v4IP), "pool.V4Using must contain preserved v4")
+		require.False(t, pool.V4Available.Contains(v4IP), "pool.V4Available must not contain preserved v4")
+		require.False(t, pool.V4Released.Contains(v4IP), "pool.V4Released must not contain preserved v4")
+	})
+
+	t.Run("ReplaceV4PreserveV6RandomExhaustion", func(t *testing.T) {
+		ipam := NewIPAM()
+		subnetName := "dualPreserveSubnetExhaustV6"
+		subnet, err := NewSubnet(subnetName, "10.0.0.0/29,2001:db8::/125", nil)
+		require.NoError(t, err)
+		ipam.Subnets[subnetName] = subnet
+
+		v4, v6, macStr, err := ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::1", nil, subnetName, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", v4)
+		require.Equal(t, "2001:db8::1", v6)
+		require.NotEmpty(t, macStr)
+
+		v4, v6, macStr, err = ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.2,2001:db8::1", nil, subnetName, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.2", v4)
+		require.Equal(t, "2001:db8::1", v6)
+		require.NotEmpty(t, macStr)
+
+		// The /125 IPv6 range exposes six usable addresses (::1 through ::6). pod1
+		// already owns ::1, so pods 2-6 consume the other five; pod7 must therefore
+		// fail with ErrNoAvailable rather than recycle ::1 from Released. Changing
+		// the CIDR requires re-deriving both the loop bound and the exhaustion pod count.
+		preservedV6 := "2001:db8::1"
+		for i := 2; i <= 6; i++ {
+			pod := fmt.Sprintf("pod%d.default", i)
+			_, v6, _, err := ipam.GetRandomAddressWithFamily(pod, pod, nil, subnetName, "", kubeovnv1.ProtocolIPv6, nil, true)
+			require.NoError(t, err, "pod %s should get a v6 address before exhaustion", pod)
+			require.NotEqual(t, preservedV6, v6, "pod %s received the preserved v6 address", pod)
+		}
+
+		pod7 := "pod7.default"
+		_, v6, _, err = ipam.GetRandomAddressWithFamily(pod7, pod7, nil, subnetName, "", kubeovnv1.ProtocolIPv6, nil, true)
+		require.ErrorIs(t, err, ErrNoAvailable, "pool exhausted: v6 allocation must fail, not recycle the preserved address (got %s)", v6)
+	})
+
+	t.Run("ReplaceV6PreserveV4RandomExhaustion", func(t *testing.T) {
+		ipam := NewIPAM()
+		subnetName := "dualPreserveSubnetExhaustV4"
+		subnet, err := NewSubnet(subnetName, "10.0.0.0/29,2001:db8::/125", nil)
+		require.NoError(t, err)
+		ipam.Subnets[subnetName] = subnet
+
+		v4, v6, macStr, err := ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::1", nil, subnetName, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", v4)
+		require.Equal(t, "2001:db8::1", v6)
+		require.NotEmpty(t, macStr)
+
+		v4, v6, macStr, err = ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::2", nil, subnetName, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", v4)
+		require.Equal(t, "2001:db8::2", v6)
+		require.NotEmpty(t, macStr)
+
+		// The /29 IPv4 range exposes six usable addresses (.1 through .6). pod1
+		// already owns .1, so pods 2-6 consume the other five; pod7 must therefore
+		// fail with ErrNoAvailable rather than recycle .1 from Released. Changing
+		// the CIDR requires re-deriving both the loop bound and the exhaustion pod count.
+		preservedV4 := "10.0.0.1"
+		for i := 2; i <= 6; i++ {
+			pod := fmt.Sprintf("pod%d.default", i)
+			v4, _, _, err := ipam.GetRandomAddressWithFamily(pod, pod, nil, subnetName, "", kubeovnv1.ProtocolIPv4, nil, true)
+			require.NoError(t, err, "pod %s should get a v4 address before exhaustion", pod)
+			require.NotEqual(t, preservedV4, v4, "pod %s received the preserved v4 address", pod)
+		}
+
+		pod7 := "pod7.default"
+		v4, _, _, err = ipam.GetRandomAddressWithFamily(pod7, pod7, nil, subnetName, "", kubeovnv1.ProtocolIPv4, nil, true)
+		require.ErrorIs(t, err, ErrNoAvailable, "pool exhausted: v4 allocation must fail, not recycle the preserved address (got %s)", v4)
+	})
 }
 
 func TestCheckAndAppendIpsForDual(t *testing.T) {

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -315,7 +315,9 @@ func (s *Subnet) getV4RandomAddress(ippoolName, podName, nicName string, mac *st
 		if !slices.Contains(skippedAddrs, s.V4NicToIP[nicName].String()) {
 			return s.V4NicToIP[nicName], nil, s.NicToMac[nicName], nil
 		}
-		s.releaseAddr(podName, nicName)
+		// only the skipped IPv4 half may be released; the IPv6 half (if any) on
+		// the same nic must stay untouched, as in the mac-conflict path below.
+		s.releaseV4Addr(podName, nicName)
 	}
 
 	pool := s.IPPools[ippoolName]
@@ -377,7 +379,9 @@ func (s *Subnet) getV6RandomAddress(ippoolName, podName, nicName string, mac *st
 		if !slices.Contains(skippedAddrs, s.V6NicToIP[nicName].String()) {
 			return nil, s.V6NicToIP[nicName], s.NicToMac[nicName], nil
 		}
-		s.releaseAddr(podName, nicName)
+		// only the skipped IPv6 half may be released; the IPv4 half (if any) on
+		// the same nic must stay untouched, as in the mac-conflict path below.
+		s.releaseV6Addr(podName, nicName)
 	}
 
 	pool := s.IPPools[ippoolName]
@@ -498,6 +502,17 @@ func (s *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *string, f
 				s.NicToMac[nicName] = preservedMac
 				s.MacToPod[preservedMac] = podName
 			}
+			// Restore preserved address to counter views so it is not re-allocated.
+			s.V6Using.Add(preservedV6IP)
+			s.V6Available.Remove(preservedV6IP)
+			for _, p := range s.IPPools {
+				if p.V6IPs.Contains(preservedV6IP) {
+					p.V6Using.Add(preservedV6IP)
+					p.V6Available.Remove(preservedV6IP)
+					p.V6Released.Remove(preservedV6IP)
+					break
+				}
+			}
 		}
 	} else if v6 && s.V6NicToIP[nicName] != nil && !s.V6NicToIP[nicName].Equal(ip) {
 		// Preserve IPv4 address if it exists
@@ -517,6 +532,17 @@ func (s *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *string, f
 			if preservedMac != "" {
 				s.NicToMac[nicName] = preservedMac
 				s.MacToPod[preservedMac] = podName
+			}
+			// Restore preserved address to counter views so it is not re-allocated.
+			s.V4Using.Add(preservedV4IP)
+			s.V4Available.Remove(preservedV4IP)
+			for _, p := range s.IPPools {
+				if p.V4IPs.Contains(preservedV4IP) {
+					p.V4Using.Add(preservedV4IP)
+					p.V4Available.Remove(preservedV4IP)
+					p.V4Released.Remove(preservedV4IP)
+					break
+				}
 			}
 		}
 	}

--- a/pkg/ipam/subnet_test.go
+++ b/pkg/ipam/subnet_test.go
@@ -1387,6 +1387,61 @@ func TestGetStaticAddressReleaseExisting(t *testing.T) {
 		require.False(t, v4exists, "Original IPv4 should be released")
 		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.10"])
 		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::5"])
+
+		pool := subnet.IPPools[""]
+		require.NotNil(t, pool)
+		require.True(t, subnet.V6Using.Contains(firstV6IP))
+		require.False(t, subnet.V6Available.Contains(firstV6IP))
+		require.True(t, pool.V6Using.Contains(firstV6IP))
+		require.False(t, pool.V6Available.Contains(firstV6IP))
+		require.False(t, pool.V6Released.Contains(firstV6IP))
+	})
+
+	t.Run("DualStack_CrossProtocolPreserve", func(t *testing.T) {
+		subnet, err := NewSubnet("dualSubnet", "10.0.0.0/30,2001:db8::/125", nil)
+		require.NoError(t, err)
+		require.NotNil(t, subnet)
+
+		podName := "pod1.default"
+		nicName := "nic1"
+
+		firstV4IP, err := NewIP("10.0.0.1")
+		require.NoError(t, err)
+		ip1, _, err := subnet.GetStaticAddress(podName, nicName, firstV4IP, nil, false, true)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", ip1.String())
+
+		firstV6IP, err := NewIP("2001:db8::1")
+		require.NoError(t, err)
+		ip2, _, err := subnet.GetStaticAddress(podName, nicName, firstV6IP, nil, false, true)
+		require.NoError(t, err)
+		require.Equal(t, "2001:db8::1", ip2.String())
+
+		require.Equal(t, firstV4IP, subnet.V4NicToIP[nicName])
+		require.Equal(t, firstV6IP, subnet.V6NicToIP[nicName])
+		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.1"])
+		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::1"])
+
+		secondV6IP, err := NewIP("2001:db8::2")
+		require.NoError(t, err)
+		ip3, _, err := subnet.GetStaticAddress(podName, nicName, secondV6IP, nil, false, true)
+		require.NoError(t, err)
+		require.Equal(t, "2001:db8::2", ip3.String())
+
+		require.Equal(t, firstV4IP, subnet.V4NicToIP[nicName])
+		require.Equal(t, secondV6IP, subnet.V6NicToIP[nicName])
+		_, v6exists := subnet.V6IPToPod["2001:db8::1"]
+		require.False(t, v6exists)
+		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.1"])
+		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::2"])
+
+		pool := subnet.IPPools[""]
+		require.NotNil(t, pool)
+		require.True(t, subnet.V4Using.Contains(firstV4IP))
+		require.False(t, subnet.V4Available.Contains(firstV4IP))
+		require.True(t, pool.V4Using.Contains(firstV4IP))
+		require.False(t, pool.V4Available.Contains(firstV4IP))
+		require.False(t, pool.V4Released.Contains(firstV4IP))
 	})
 }
 


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

ipam: keep counter views consistent when preserving the other family's static address.

In a dual-stack subnet, `GetStaticAddress` replacing one family's static address
preserves the other. The preserve path calls `releaseAddr` and restores only the
lookup maps, not the counter sets, leaving the preserved address in
`Available`/`Released` and out of `Using`. When the pool exhausts and recycles
from `Released`, a later random allocation can hand the still-configured address
to another pod, producing a duplicate address and drifting `usingIPs`/`availableIPs`.

Restore the counter views along with the maps: re-add the address to `Using`
and remove it from `Available`/`Released` at subnet and pool level, mirroring
`releaseV4Addr`/`releaseV6Addr`. The operations are idempotent set operations,
so the out-of-CIDR/reserved and multi-owner paths are unaffected.

Unit test: `TestGetStaticAddressDualStackPreserveCounters` covers both
directions, asserting view consistency at subnet and pool level and proving via
pool exhaustion that the preserved address is never re-issued (pre-fix the final
allocation received the preserved address instead of `ErrNoAvailable`).

## Which issue(s) this PR fixes

-