### PR TITLE
controller: preserve pod references for failure events

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -530,12 +530,13 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	}
 
 	// check and do hotnoplug nic
-	var hotplugDetails string
-	if pod, hotplugDetails, err = c.syncKubeOvnNet(pod, podNets); err != nil {
+	updatedPod, hotplugDetails, err := c.syncKubeOvnNet(pod, podNets)
+	if err != nil {
 		klog.Errorf("failed to sync pod nets %v", err)
 		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkUpdateFailed", "stage=syncKubeOvnNet error=%v", err)
 		return err
 	}
+	pod = updatedPod
 	if pod == nil {
 		// pod has been deleted
 		return nil
@@ -675,9 +676,10 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	podName := c.getNameByPod(pod)
 	// todo: isVmPod, getPodType, getNameByPod has duplicated logic
 
+	eventPod := pod
 	var err error
 	recordFailure := func(stage string, err error) {
-		c.recorder.Eventf(pod, v1.EventTypeWarning, "PodNetworkAllocationFailed", "stage=%s error=%v", stage, err)
+		c.recorder.Eventf(eventPod, v1.EventTypeWarning, "PodNetworkAllocationFailed", "stage=%s error=%v", stage, err)
 	}
 	var vmKey string
 	if isVMPod && c.config.EnableKeepVMIP {
@@ -851,11 +853,11 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		return nil, err
 	}
 
-	oldPod := pod
-	if pod, err = c.config.KubeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
+	updatedPod, err := c.config.KubeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			key := strings.Join([]string{namespace, name}, "/")
-			c.deletingPodObjMap.Store(key, oldPod)
+			c.deletingPodObjMap.Store(key, pod)
 			c.deletePodQueue.AddRateLimited(key)
 			return nil, nil
 		}
@@ -863,6 +865,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		recordFailure("getPatchedPod", err)
 		return nil, err
 	}
+	pod = updatedPod
 
 	// Clean stale attachment IPs/LSPs from previous NAD references when a new
 	// VM pod starts. This handles the stop→patch NAD→start workflow where the

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -1437,6 +1438,20 @@ func TestHandleAddOrUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 	assertPodEvent(t, controller, "Warning PodNetworkUpdateFailed", "stage=getPodKubeovnNets", "provider net1.default is not bound to any subnet")
 }
 
+func TestHandleAddOrUpdatePodSyncFailureRecordsOriginalPod(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	injectedErr := errors.New("list ports failed")
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(true, gomock.Any()).Return(nil, injectedErr)
+	events := useRealPodEventRecorder(t, fc.fakeController)
+
+	err = fc.fakeController.handleAddOrUpdatePod("default/test-pod")
+
+	require.ErrorIs(t, err, injectedErr)
+	assertRecordedPodEvent(t, events, pod, "PodNetworkUpdateFailed", "stage=syncKubeOvnNet")
+}
+
 func TestEnqueueUpdatePodRecordsIPAMSubnetMissingEvent(t *testing.T) {
 	controller := newIPAMSubnetMissingController(t, ipamNADConfig(util.CniTypeName))
 	oldPod := &corev1.Pod{
@@ -2111,6 +2126,26 @@ func TestReconcileAllocateSubnetsSpecificFailureEventsIncludeStage(t *testing.T)
 	})
 }
 
+func TestReconcileAllocateSubnetsRefetchFailureRecordsOriginalPod(t *testing.T) {
+	pod, subnet := podEventFixture()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}, Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, nil))
+	injectedErr := errors.New("get patched pod failed")
+	fc.fakeController.config.KubeClient.(*k8sfake.Clientset).PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	events := useRealPodEventRecorder(t, fc.fakeController)
+
+	updatedPod, err := fc.fakeController.reconcileAllocateSubnets(pod, []*kubeovnNet{{
+		Type: providerTypeIPAM, ProviderName: util.OvnProvider, Subnet: subnet, IsDefault: true,
+	}})
+
+	require.Nil(t, updatedPod)
+	require.ErrorIs(t, err, injectedErr)
+	assertRecordedPodEvent(t, events, pod, "PodNetworkAllocationFailed", "stage=getPatchedPod")
+}
+
 func TestHandleAddOrUpdatePodReportsActualAllocatedSubnet(t *testing.T) {
 	pod, subnetA := podEventFixture()
 	pod.Annotations = map[string]string{
@@ -2442,5 +2477,40 @@ func assertNoPodEvent(t *testing.T, controller *Controller) {
 	case event := <-recorder.Events:
 		t.Fatalf("unexpected pod event: %s", event)
 	default:
+	}
+}
+
+func useRealPodEventRecorder(t *testing.T, controller *Controller) <-chan *corev1.Event {
+	t.Helper()
+
+	events := make(chan *corev1.Event, 1)
+	broadcaster := record.NewBroadcaster()
+	watcher := broadcaster.StartEventWatcher(func(event *corev1.Event) {
+		events <- event
+	})
+	t.Cleanup(func() {
+		watcher.Stop()
+		broadcaster.Shutdown()
+	})
+	controller.recorder = broadcaster.NewRecorder(kubescheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+	return events
+}
+
+func assertRecordedPodEvent(t *testing.T, events <-chan *corev1.Event, pod *corev1.Pod, reason string, messageParts ...string) {
+	t.Helper()
+
+	select {
+	case event := <-events:
+		assert.Equal(t, corev1.EventTypeWarning, event.Type)
+		assert.Equal(t, reason, event.Reason)
+		assert.Equal(t, "Pod", event.InvolvedObject.Kind)
+		assert.Equal(t, pod.Namespace, event.InvolvedObject.Namespace)
+		assert.Equal(t, pod.Name, event.InvolvedObject.Name)
+		assert.Equal(t, pod.UID, event.InvolvedObject.UID)
+		for _, part := range messageParts {
+			assert.Contains(t, event.Message, part)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected pod event")
 	}
 }


### PR DESCRIPTION
## Summary

- preserve the original Pod until `syncKubeOvnNet` succeeds, so failure events never receive a typed nil Pod
- preserve the original Pod while refetching patched annotations, so allocation failures keep the correct object reference
- exercise both paths with the real client-go event recorder instead of the permissive fake recorder

## Testing

- `go test ./pkg/controller -count=1`
- `golangci-lint run --concurrency 1 ./pkg/controller`