### PR TITLE
ipam: align dual-stack family preservation

### DIFF
--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -345,178 +345,95 @@ func TestGetStaticAddressWithFamily(t *testing.T) {
 	require.True(t, subnet.V6Using.Contains(ip))
 }
 
-// TestGetStaticAddressDualStackPreserveCounters verifies that dual-stack
-// GetStaticAddress keeps the unchanged family's address in every IPAM view
-// when it replaces the other family's static address, not just in lookup maps.
-// It asserts the preserved address stays in V{N}Using and out of
-// V{N}Available/Released at both the subnet and pool levels. The exhaustion
-// kill-shot subtests prove that the preserved address is never re-issued to another pod.
 func TestGetStaticAddressDualStackPreserveCounters(t *testing.T) {
 	t.Run("ReplaceV4PreserveV6", func(t *testing.T) {
-		ipam := NewIPAM()
-		subnetName := "dualPreserveSubnet"
-		subnet, err := NewSubnet(subnetName, "10.0.0.0/30,2001:db8::/125", nil)
-		require.NoError(t, err)
-		ipam.Subnets[subnetName] = subnet
-		pool := subnet.IPPools[""]
-		require.NotNil(t, pool)
-
-		v4, v6, macStr, err := ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::1", nil, subnetName, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.1", v4)
-		require.Equal(t, "2001:db8::1", v6)
-		require.NotEmpty(t, macStr)
-
-		v4, v6, macStr, err = ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.2,2001:db8::1", nil, subnetName, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.2", v4)
-		require.Equal(t, "2001:db8::1", v6)
-		require.NotEmpty(t, macStr)
-
-		newV4IP, err := NewIP("10.0.0.2")
-		require.NoError(t, err)
-		oldV4IP, err := NewIP("10.0.0.1")
-		require.NoError(t, err)
-		v6IP, err := NewIP("2001:db8::1")
-		require.NoError(t, err)
-
-		require.True(t, subnet.V4NicToIP["pod1.default"].Equal(newV4IP))
-		require.Equal(t, "pod1.default", subnet.V4IPToPod["10.0.0.2"])
-
-		_, exists := subnet.V4IPToPod["10.0.0.1"]
-		require.False(t, exists)
-		require.False(t, subnet.V4Using.Contains(oldV4IP))
-		require.True(t, subnet.V4Available.Contains(oldV4IP))
-
-		require.True(t, subnet.V6NicToIP["pod1.default"].Equal(v6IP))
-		require.Equal(t, "pod1.default", subnet.V6IPToPod["2001:db8::1"])
-
-		require.True(t, subnet.V6Using.Contains(v6IP), "subnet.V6Using must contain preserved v6")
-		require.False(t, subnet.V6Available.Contains(v6IP), "subnet.V6Available must not contain preserved v6")
-
-		require.True(t, pool.V6Using.Contains(v6IP), "pool.V6Using must contain preserved v6")
-		require.False(t, pool.V6Available.Contains(v6IP), "pool.V6Available must not contain preserved v6")
-		require.False(t, pool.V6Released.Contains(v6IP), "pool.V6Released must not contain preserved v6")
+		testIPAMStaticAddressPreservesOtherFamily(t, kubeovnv1.ProtocolIPv4)
 	})
-
 	t.Run("ReplaceV6PreserveV4", func(t *testing.T) {
-		ipam := NewIPAM()
-		subnetName := "dualPreserveSubnet"
-		subnet, err := NewSubnet(subnetName, "10.0.0.0/30,2001:db8::/125", nil)
-		require.NoError(t, err)
-		ipam.Subnets[subnetName] = subnet
-		pool := subnet.IPPools[""]
-		require.NotNil(t, pool)
-
-		v4, v6, macStr, err := ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::1", nil, subnetName, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.1", v4)
-		require.Equal(t, "2001:db8::1", v6)
-		require.NotEmpty(t, macStr)
-
-		v4, v6, macStr, err = ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::2", nil, subnetName, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.1", v4)
-		require.Equal(t, "2001:db8::2", v6)
-		require.NotEmpty(t, macStr)
-
-		v4IP, err := NewIP("10.0.0.1")
-		require.NoError(t, err)
-		newV6IP, err := NewIP("2001:db8::2")
-		require.NoError(t, err)
-		oldV6IP, err := NewIP("2001:db8::1")
-		require.NoError(t, err)
-
-		require.True(t, subnet.V4NicToIP["pod1.default"].Equal(v4IP))
-		require.Equal(t, "pod1.default", subnet.V4IPToPod["10.0.0.1"])
-
-		require.True(t, subnet.V6NicToIP["pod1.default"].Equal(newV6IP))
-		require.Equal(t, "pod1.default", subnet.V6IPToPod["2001:db8::2"])
-
-		_, exists := subnet.V6IPToPod["2001:db8::1"]
-		require.False(t, exists)
-		require.False(t, subnet.V6Using.Contains(oldV6IP))
-		require.True(t, subnet.V6Available.Contains(oldV6IP))
-
-		require.True(t, subnet.V4Using.Contains(v4IP), "subnet.V4Using must contain preserved v4")
-		require.False(t, subnet.V4Available.Contains(v4IP), "subnet.V4Available must not contain preserved v4")
-
-		require.True(t, pool.V4Using.Contains(v4IP), "pool.V4Using must contain preserved v4")
-		require.False(t, pool.V4Available.Contains(v4IP), "pool.V4Available must not contain preserved v4")
-		require.False(t, pool.V4Released.Contains(v4IP), "pool.V4Released must not contain preserved v4")
+		testIPAMStaticAddressPreservesOtherFamily(t, kubeovnv1.ProtocolIPv6)
 	})
-
 	t.Run("ReplaceV4PreserveV6RandomExhaustion", func(t *testing.T) {
-		ipam := NewIPAM()
-		subnetName := "dualPreserveSubnetExhaustV6"
-		subnet, err := NewSubnet(subnetName, "10.0.0.0/29,2001:db8::/125", nil)
-		require.NoError(t, err)
-		ipam.Subnets[subnetName] = subnet
-
-		v4, v6, macStr, err := ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::1", nil, subnetName, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.1", v4)
-		require.Equal(t, "2001:db8::1", v6)
-		require.NotEmpty(t, macStr)
-
-		v4, v6, macStr, err = ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.2,2001:db8::1", nil, subnetName, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.2", v4)
-		require.Equal(t, "2001:db8::1", v6)
-		require.NotEmpty(t, macStr)
-
-		// The /125 IPv6 range exposes six usable addresses (::1 through ::6). pod1
-		// already owns ::1, so pods 2-6 consume the other five; pod7 must therefore
-		// fail with ErrNoAvailable rather than recycle ::1 from Released. Changing
-		// the CIDR requires re-deriving both the loop bound and the exhaustion pod count.
-		preservedV6 := "2001:db8::1"
-		for i := 2; i <= 6; i++ {
-			pod := fmt.Sprintf("pod%d.default", i)
-			_, v6, _, err := ipam.GetRandomAddressWithFamily(pod, pod, nil, subnetName, "", kubeovnv1.ProtocolIPv6, nil, true)
-			require.NoError(t, err, "pod %s should get a v6 address before exhaustion", pod)
-			require.NotEqual(t, preservedV6, v6, "pod %s received the preserved v6 address", pod)
-		}
-
-		pod7 := "pod7.default"
-		_, v6, _, err = ipam.GetRandomAddressWithFamily(pod7, pod7, nil, subnetName, "", kubeovnv1.ProtocolIPv6, nil, true)
-		require.ErrorIs(t, err, ErrNoAvailable, "pool exhausted: v6 allocation must fail, not recycle the preserved address (got %s)", v6)
+		testIPAMPreservedAddressIsNotReissued(t, kubeovnv1.ProtocolIPv6)
 	})
-
 	t.Run("ReplaceV6PreserveV4RandomExhaustion", func(t *testing.T) {
-		ipam := NewIPAM()
-		subnetName := "dualPreserveSubnetExhaustV4"
-		subnet, err := NewSubnet(subnetName, "10.0.0.0/29,2001:db8::/125", nil)
-		require.NoError(t, err)
-		ipam.Subnets[subnetName] = subnet
-
-		v4, v6, macStr, err := ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::1", nil, subnetName, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.1", v4)
-		require.Equal(t, "2001:db8::1", v6)
-		require.NotEmpty(t, macStr)
-
-		v4, v6, macStr, err = ipam.GetStaticAddress("pod1.default", "pod1.default", "10.0.0.1,2001:db8::2", nil, subnetName, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.1", v4)
-		require.Equal(t, "2001:db8::2", v6)
-		require.NotEmpty(t, macStr)
-
-		// The /29 IPv4 range exposes six usable addresses (.1 through .6). pod1
-		// already owns .1, so pods 2-6 consume the other five; pod7 must therefore
-		// fail with ErrNoAvailable rather than recycle .1 from Released. Changing
-		// the CIDR requires re-deriving both the loop bound and the exhaustion pod count.
-		preservedV4 := "10.0.0.1"
-		for i := 2; i <= 6; i++ {
-			pod := fmt.Sprintf("pod%d.default", i)
-			v4, _, _, err := ipam.GetRandomAddressWithFamily(pod, pod, nil, subnetName, "", kubeovnv1.ProtocolIPv4, nil, true)
-			require.NoError(t, err, "pod %s should get a v4 address before exhaustion", pod)
-			require.NotEqual(t, preservedV4, v4, "pod %s received the preserved v4 address", pod)
-		}
-
-		pod7 := "pod7.default"
-		v4, _, _, err = ipam.GetRandomAddressWithFamily(pod7, pod7, nil, subnetName, "", kubeovnv1.ProtocolIPv4, nil, true)
-		require.ErrorIs(t, err, ErrNoAvailable, "pool exhausted: v4 allocation must fail, not recycle the preserved address (got %s)", v4)
+		testIPAMPreservedAddressIsNotReissued(t, kubeovnv1.ProtocolIPv4)
 	})
+}
+
+func testIPAMStaticAddressPreservesOtherFamily(t *testing.T, replacedFamily string) {
+	ipam := NewIPAM()
+	subnetName := "dualPreserveSubnet"
+	subnet, err := NewSubnet(subnetName, "10.0.0.0/30,2001:db8::/125", nil)
+	require.NoError(t, err)
+	ipam.Subnets[subnetName] = subnet
+	podName := "pod1.default"
+	oldV4, oldV6 := "10.0.0.1", "2001:db8::1"
+	newV4, newV6 := oldV4, "2001:db8::2"
+	if replacedFamily == kubeovnv1.ProtocolIPv4 {
+		newV4, newV6 = "10.0.0.2", oldV6
+	}
+
+	_, _, oldMAC, err := ipam.GetStaticAddress(podName, podName, oldV4+","+oldV6, nil, subnetName, true)
+	require.NoError(t, err)
+	v4, v6, newMAC, err := ipam.GetStaticAddress(podName, podName, newV4+","+newV6, nil, subnetName, true)
+	require.NoError(t, err)
+	require.Equal(t, newV4, v4)
+	require.Equal(t, newV6, v6)
+	require.Equal(t, oldMAC, newMAC)
+
+	preserved, err := NewIP(oldV4)
+	require.NoError(t, err)
+	replaced, err := NewIP(oldV6)
+	require.NoError(t, err)
+	preservedFamily := kubeovnv1.ProtocolIPv4
+	if replacedFamily == kubeovnv1.ProtocolIPv4 {
+		preserved, err = NewIP(oldV6)
+		require.NoError(t, err)
+		replaced, err = NewIP(oldV4)
+		require.NoError(t, err)
+		preservedFamily = kubeovnv1.ProtocolIPv6
+	}
+	assertPreservedAddressViews(t, subnet, podName, podName, preserved, preservedFamily)
+	if replacedFamily == kubeovnv1.ProtocolIPv4 {
+		require.Empty(t, subnet.V4IPToPod[replaced.String()])
+		require.False(t, subnet.V4Using.Contains(replaced))
+		require.True(t, subnet.V4Available.Contains(replaced))
+	} else {
+		require.Empty(t, subnet.V6IPToPod[replaced.String()])
+		require.False(t, subnet.V6Using.Contains(replaced))
+		require.True(t, subnet.V6Available.Contains(replaced))
+	}
+}
+
+func testIPAMPreservedAddressIsNotReissued(t *testing.T, preservedFamily string) {
+	ipam := NewIPAM()
+	subnetName := "dualPreserveSubnetExhaustion"
+	subnet, err := NewSubnet(subnetName, "10.0.0.0/29,2001:db8::/125", nil)
+	require.NoError(t, err)
+	ipam.Subnets[subnetName] = subnet
+	podName := "pod1.default"
+	initial := "10.0.0.1,2001:db8::1"
+	replacement := "10.0.0.2,2001:db8::1"
+	family := kubeovnv1.ProtocolIPv6
+	preserved := "2001:db8::1"
+	if preservedFamily == kubeovnv1.ProtocolIPv4 {
+		replacement = "10.0.0.1,2001:db8::2"
+		family = kubeovnv1.ProtocolIPv4
+		preserved = "10.0.0.1"
+	}
+	_, _, _, err = ipam.GetStaticAddress(podName, podName, initial, nil, subnetName, true)
+	require.NoError(t, err)
+	_, _, _, err = ipam.GetStaticAddress(podName, podName, replacement, nil, subnetName, true)
+	require.NoError(t, err)
+
+	for i := 2; i <= 6; i++ {
+		pod := fmt.Sprintf("pod%d.default", i)
+		v4, v6, _, err := ipam.GetRandomAddressWithFamily(pod, pod, nil, subnetName, "", family, nil, true)
+		require.NoError(t, err, "pod %s should get an address before exhaustion", pod)
+		require.NotEqual(t, preserved, v4+v6, "pod %s received the preserved address", pod)
+	}
+	v4, v6, _, err := ipam.GetRandomAddressWithFamily("pod7.default", "pod7.default", nil, subnetName, "", family, nil, true)
+	require.ErrorIs(t, err, ErrNoAvailable, "pool exhausted: allocation must not recycle %s (got %s%s)", preserved, v4, v6)
 }
 
 func TestCheckAndAppendIpsForDual(t *testing.T) {

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -436,134 +436,15 @@ func (s *Subnet) getV6RandomAddress(ippoolName, podName, nicName string, mac *st
 }
 
 func (s *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *string, force, checkConflict bool) (IP, string, error) {
-	var v4, v6 bool
-	isAllocated := false
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
 
-	if ip.To4() != nil {
-		v4 = s.V4CIDR != nil
-	} else {
-		v6 = s.V6CIDR != nil
+	family, err := s.staticAddressFamilyForIP(ip, checkConflict)
+	if err != nil {
+		return nil, "", err
 	}
-
-	if v4 && !s.V4CIDR.Contains(net.IP(ip)) {
-		klog.Errorf("ip %s is out of range", ip)
-		return nil, "", ErrOutOfRange
-	}
-	if v6 && !s.V6CIDR.Contains(net.IP(ip)) {
-		klog.Errorf("ip %s is out of range", ip)
-		return nil, "", ErrOutOfRange
-	}
-
-	var pool *IPPool
-	for _, p := range s.IPPools {
-		if v4 && p.V4IPs.Contains(ip) {
-			pool = p
-			break
-		}
-		if v6 && p.V6IPs.Contains(ip) {
-			pool = p
-			break
-		}
-	}
-
-	if pool == nil {
-		klog.Errorf("ip %s is out of range", ip)
-		return nil, "", ErrOutOfRange
-	}
-	gateway := s.V4Gw
-	if v6 {
-		gateway = s.V6Gw
-	}
-	if checkConflict && net.IP(ip).Equal(net.ParseIP(gateway)) {
-		klog.Errorf("ip %s conflicts with subnet gateway", ip)
-		return nil, "", ErrConflict
-	}
-
-	// Release existing address for this nicName if it exists and is different from requested IP
-	// For dual-stack scenarios, preserve the other protocol's address
-	if v4 && s.V4NicToIP[nicName] != nil && !s.V4NicToIP[nicName].Equal(ip) {
-		// Preserve IPv6 address if it exists
-		var preservedV6IP IP
-		var preservedMac string
-		if s.V6NicToIP[nicName] != nil {
-			preservedV6IP = s.V6NicToIP[nicName]
-			preservedMac = s.NicToMac[nicName]
-		}
-
-		s.releaseAddr(podName, nicName)
-
-		// Restore IPv6 address if it was preserved
-		if preservedV6IP != nil {
-			s.V6NicToIP[nicName] = preservedV6IP
-			s.V6IPToPod[preservedV6IP.String()] = podName
-			if preservedMac != "" {
-				s.NicToMac[nicName] = preservedMac
-				s.MacToPod[preservedMac] = podName
-			}
-			// Restore preserved address to counter views so it is not re-allocated.
-			s.V6Using.Add(preservedV6IP)
-			s.V6Available.Remove(preservedV6IP)
-			for _, p := range s.IPPools {
-				if p.V6IPs.Contains(preservedV6IP) {
-					p.V6Using.Add(preservedV6IP)
-					p.V6Available.Remove(preservedV6IP)
-					p.V6Released.Remove(preservedV6IP)
-					break
-				}
-			}
-		}
-	} else if v6 && s.V6NicToIP[nicName] != nil && !s.V6NicToIP[nicName].Equal(ip) {
-		// Preserve IPv4 address if it exists
-		var preservedV4IP IP
-		var preservedMac string
-		if s.V4NicToIP[nicName] != nil {
-			preservedV4IP = s.V4NicToIP[nicName]
-			preservedMac = s.NicToMac[nicName]
-		}
-
-		s.releaseAddr(podName, nicName)
-
-		// Restore IPv4 address if it was preserved
-		if preservedV4IP != nil {
-			s.V4NicToIP[nicName] = preservedV4IP
-			s.V4IPToPod[preservedV4IP.String()] = podName
-			if preservedMac != "" {
-				s.NicToMac[nicName] = preservedMac
-				s.MacToPod[preservedMac] = podName
-			}
-			// Restore preserved address to counter views so it is not re-allocated.
-			s.V4Using.Add(preservedV4IP)
-			s.V4Available.Remove(preservedV4IP)
-			for _, p := range s.IPPools {
-				if p.V4IPs.Contains(preservedV4IP) {
-					p.V4Using.Add(preservedV4IP)
-					p.V4Available.Remove(preservedV4IP)
-					p.V4Released.Remove(preservedV4IP)
-					break
-				}
-			}
-		}
-	}
-
-	defer func() {
-		s.pushPodNic(podName, nicName)
-		if isAllocated {
-			if v4 {
-				s.V4Available.Remove(ip)
-				s.V4Using.Add(ip)
-				pool.V4Available.Remove(ip)
-				pool.V4Using.Add(ip)
-			}
-			if v6 {
-				s.V6Available.Remove(ip)
-				s.V6Using.Add(ip)
-				pool.V6Available.Remove(ip)
-				pool.V6Using.Add(ip)
-			}
-		}
-	}()
+	releaseCurrentStaticAddress(family, podName, nicName, ip)
+	defer s.pushPodNic(podName, nicName)
 
 	var macStr string
 	if mac == nil {
@@ -580,82 +461,125 @@ func (s *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *string, f
 		macStr = *mac
 	}
 
+	allocated, err := allocateStaticAddress(family, podName, nicName, ip, force, checkConflict)
+	if err != nil {
+		return nil, "", err
+	}
+	if allocated {
+		markStaticAddressAllocated(family, ip)
+	}
+	return ip, macStr, nil
+}
+
+func (s *Subnet) staticAddressFamilyForIP(ip IP, checkConflict bool) (staticAddressFamily, error) {
+	v4 := ip.To4() != nil
+	cidr := s.V6CIDR
+	gateway := s.V6Gw
 	if v4 {
-		if existPod, ok := s.V4IPToPod[ip.String()]; ok {
-			pods := strings.Split(existPod, ",")
-			if !slices.Contains(pods, podName) {
-				if !checkConflict {
-					s.V4NicToIP[nicName] = ip
-					s.V4IPToPod[ip.String()] = fmt.Sprintf("%s,%s", s.V4IPToPod[ip.String()], podName)
-					return ip, macStr, nil
-				}
-				klog.Errorf("ip %s has been allocated to %v", ip.String(), pods)
-				return nil, "", ErrConflict
-			}
-			if !force {
-				return ip, macStr, nil
-			}
-		}
+		cidr = s.V4CIDR
+		gateway = s.V4Gw
+	}
+	if cidr == nil || !cidr.Contains(net.IP(ip)) {
+		klog.Errorf("ip %s is out of range", ip)
+		return staticAddressFamily{}, ErrOutOfRange
+	}
 
-		if pool.V4Reserved.Contains(ip) {
-			s.V4NicToIP[nicName] = ip
-			s.V4IPToPod[ip.String()] = podName
-			// ip allocated from excludeIPs should be recorded in usingIPs since when the ip is removed from excludeIPs, there's no way to update usingIPs
-			isAllocated = true
-			return ip, macStr, nil
+	for _, pool := range s.IPPools {
+		inPool := pool.V6IPs.Contains(ip)
+		if v4 {
+			inPool = pool.V4IPs.Contains(ip)
 		}
+		if !inPool {
+			continue
+		}
+		if checkConflict && net.IP(ip).Equal(net.ParseIP(gateway)) {
+			klog.Errorf("ip %s conflicts with subnet gateway", ip)
+			return staticAddressFamily{}, ErrConflict
+		}
+		if v4 {
+			return s.v4StaticAddressFamily(pool), nil
+		}
+		return s.v6StaticAddressFamily(pool), nil
+	}
 
-		if pool.V4Free.Remove(ip) {
-			s.V4Free.Remove(ip)
-			s.V4NicToIP[nicName] = ip
-			s.V4IPToPod[ip.String()] = podName
-			isAllocated = true
-			return ip, macStr, nil
-		} else if pool.V4Released.Remove(ip) {
-			s.V4NicToIP[nicName] = ip
-			s.V4IPToPod[ip.String()] = podName
-			isAllocated = true
-			return ip, macStr, nil
-		}
-	} else if v6 {
-		if existPod, ok := s.V6IPToPod[ip.String()]; ok {
-			pods := strings.Split(existPod, ",")
-			if !slices.Contains(pods, podName) {
-				if !checkConflict {
-					s.V6NicToIP[nicName] = ip
-					s.V6IPToPod[ip.String()] = fmt.Sprintf("%s,%s", s.V6IPToPod[ip.String()], podName)
-					return ip, macStr, nil
-				}
-				klog.Errorf("ip %s has been allocated to %v", ip.String(), pods)
-				return nil, "", ErrConflict
+	klog.Errorf("ip %s is out of range", ip)
+	return staticAddressFamily{}, ErrOutOfRange
+}
+
+type staticAddressFamily struct {
+	nicToIP         map[string]IP
+	ipToPod         map[string]string
+	subnetFree      *IPRangeList
+	subnetAvailable *IPRangeList
+	subnetUsing     *IPRangeList
+	poolFree        *IPRangeList
+	poolAvailable   *IPRangeList
+	poolReserved    *IPRangeList
+	poolReleased    *IPRangeList
+	poolUsing       *IPRangeList
+	release         func(string, string)
+}
+
+func (s *Subnet) v4StaticAddressFamily(pool *IPPool) staticAddressFamily {
+	return staticAddressFamily{
+		nicToIP: s.V4NicToIP, ipToPod: s.V4IPToPod,
+		subnetFree: s.V4Free, subnetAvailable: s.V4Available, subnetUsing: s.V4Using,
+		poolFree: pool.V4Free, poolAvailable: pool.V4Available, poolReserved: pool.V4Reserved,
+		poolReleased: pool.V4Released, poolUsing: pool.V4Using, release: s.releaseV4Addr,
+	}
+}
+
+func (s *Subnet) v6StaticAddressFamily(pool *IPPool) staticAddressFamily {
+	return staticAddressFamily{
+		nicToIP: s.V6NicToIP, ipToPod: s.V6IPToPod,
+		subnetFree: s.V6Free, subnetAvailable: s.V6Available, subnetUsing: s.V6Using,
+		poolFree: pool.V6Free, poolAvailable: pool.V6Available, poolReserved: pool.V6Reserved,
+		poolReleased: pool.V6Released, poolUsing: pool.V6Using, release: s.releaseV6Addr,
+	}
+}
+
+func releaseCurrentStaticAddress(family staticAddressFamily, podName, nicName string, ip IP) {
+	if current := family.nicToIP[nicName]; current != nil && !current.Equal(ip) {
+		family.release(podName, nicName)
+	}
+}
+
+func allocateStaticAddress(family staticAddressFamily, podName, nicName string, ip IP, force, checkConflict bool) (bool, error) {
+	if existPod, ok := family.ipToPod[ip.String()]; ok {
+		pods := strings.Split(existPod, ",")
+		if !slices.Contains(pods, podName) {
+			if !checkConflict {
+				family.nicToIP[nicName] = ip
+				family.ipToPod[ip.String()] = fmt.Sprintf("%s,%s", existPod, podName)
+				return false, nil
 			}
-			if !force {
-				return ip, macStr, nil
-			}
+			klog.Errorf("ip %s has been allocated to %v", ip, pods)
+			return false, ErrConflict
 		}
-
-		if pool.V6Reserved.Contains(ip) {
-			s.V6NicToIP[nicName] = ip
-			s.V6IPToPod[ip.String()] = podName
-			isAllocated = true
-			return ip, macStr, nil
-		}
-
-		if pool.V6Free.Remove(ip) {
-			s.V6Free.Remove(ip)
-			s.V6NicToIP[nicName] = ip
-			s.V6IPToPod[ip.String()] = podName
-			isAllocated = true
-			return ip, macStr, nil
-		} else if pool.V6Released.Remove(ip) {
-			s.V6NicToIP[nicName] = ip
-			s.V6IPToPod[ip.String()] = podName
-			isAllocated = true
-			return ip, macStr, nil
+		if !force {
+			return false, nil
 		}
 	}
-	klog.Errorf("no available ip")
-	return nil, "", ErrNoAvailable
+
+	switch {
+	case family.poolReserved.Contains(ip):
+	case family.poolFree.Remove(ip):
+		family.subnetFree.Remove(ip)
+	case family.poolReleased.Remove(ip):
+	default:
+		klog.Errorf("no available ip")
+		return false, ErrNoAvailable
+	}
+	family.nicToIP[nicName] = ip
+	family.ipToPod[ip.String()] = podName
+	return true, nil
+}
+
+func markStaticAddressAllocated(family staticAddressFamily, ip IP) {
+	family.subnetAvailable.Remove(ip)
+	family.subnetUsing.Add(ip)
+	family.poolAvailable.Remove(ip)
+	family.poolUsing.Add(ip)
 }
 
 // releaseV4Addr drops a pod's IPv4 lease from this subnet without touching

--- a/pkg/ipam/subnet_test.go
+++ b/pkg/ipam/subnet_test.go
@@ -561,6 +561,61 @@ func TestGetRandomDualStackAddress(t *testing.T) {
 	require.NotEqual(t, mac1, mac2)
 }
 
+func TestGetDualRandomAddressSkipsOnlyRequestedFamilies(t *testing.T) {
+	tests := []struct {
+		name           string
+		skipV4, skipV6 bool
+	}{
+		{name: "IPv4", skipV4: true},
+		{name: "IPv6", skipV6: true},
+		{name: "Both", skipV4: true, skipV6: true},
+	}
+
+	for _, poolName := range []string{"", "named"} {
+		poolLabel := "DefaultPool"
+		if poolName != "" {
+			poolLabel = "NamedPool"
+		}
+		for _, tt := range tests {
+			t.Run(poolLabel+"/Skip"+tt.name, func(t *testing.T) {
+				subnet, err := NewSubnet("dualSubnet", "10.0.0.0/28,2001:db8::/124", nil)
+				require.NoError(t, err)
+				if poolName != "" {
+					err = subnet.AddOrUpdateIPPool(poolName, []string{"10.0.0.2..10.0.0.10", "2001:db8::2..2001:db8::a"})
+					require.NoError(t, err)
+				}
+
+				podName := "pod.default"
+				nicName := "pod.default"
+				oldV4, oldV6, oldMAC, err := subnet.GetRandomAddress(poolName, podName, nicName, nil, nil, true)
+				require.NoError(t, err)
+
+				skippedAddrs := make([]string, 0, 2)
+				if tt.skipV4 {
+					skippedAddrs = append(skippedAddrs, oldV4.String())
+				}
+				if tt.skipV6 {
+					skippedAddrs = append(skippedAddrs, oldV6.String())
+				}
+				newV4, newV6, newMAC, err := subnet.GetRandomAddress(poolName, podName, nicName, nil, skippedAddrs, true)
+				require.NoError(t, err)
+
+				if tt.skipV4 {
+					require.NotEqual(t, oldV4, newV4)
+				} else {
+					require.Equal(t, oldV4, newV4)
+				}
+				if tt.skipV6 {
+					require.NotEqual(t, oldV6, newV6)
+				} else {
+					require.Equal(t, oldV6, newV6)
+				}
+				require.Equal(t, oldMAC, newMAC)
+			})
+		}
+	}
+}
+
 func TestReleaseAddrForV4Subnet(t *testing.T) {
 	excludeIps := []string{
 		"10.0.0.2", "10.0.0.4", "10.0.0.100",
@@ -1177,272 +1232,183 @@ func TestPopPodNic(t *testing.T) {
 }
 
 func TestGetStaticAddressReleaseExisting(t *testing.T) {
-	// Test IPv4 scenario
-	t.Run("IPv4_ReleaseExistingAddress", func(t *testing.T) {
-		subnet, err := NewSubnet("v4Subnet", "10.0.0.0/24", nil)
-		require.NoError(t, err)
-		require.NotNil(t, subnet)
-
-		podName := "pod1.default"
-		nicName := "nic1"
-
-		// First allocation
-		firstIP, err := NewIP("10.0.0.5")
-		require.NoError(t, err)
-		ip1, mac1, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.5", ip1.String())
-		require.NotEmpty(t, mac1)
-
-		// Verify first allocation
-		require.Equal(t, firstIP, subnet.V4NicToIP[nicName])
-		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.5"])
-		require.True(t, subnet.V4Using.Contains(firstIP))
-		require.False(t, subnet.V4Available.Contains(firstIP))
-
-		// Second allocation with different IP for same nicName
-		secondIP, err := NewIP("10.0.0.10")
-		require.NoError(t, err)
-		ip2, mac2, err := subnet.GetStaticAddress(podName, nicName, secondIP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.10", ip2.String())
-		require.NotEmpty(t, mac2)
-
-		// Verify second allocation and first address is released
-		require.Equal(t, secondIP, subnet.V4NicToIP[nicName])
-		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.10"])
-		require.True(t, subnet.V4Using.Contains(secondIP))
-		require.False(t, subnet.V4Available.Contains(secondIP))
-
-		// Verify first address is released
-		_, exists := subnet.V4IPToPod["10.0.0.5"]
-		require.False(t, exists)
-		require.False(t, subnet.V4Using.Contains(firstIP))
-	})
-
+	t.Run("IPv4_ReleaseExistingAddress", testStaticAddressReleasesExistingIPv4)
 	t.Run("IPv4_KeepExistingAddressOnGatewayIPConflict", func(t *testing.T) {
-		subnet, err := NewSubnet("v4Subnet", "10.0.0.0/24", nil)
-		require.NoError(t, err)
-		subnet.V4Gw = "10.0.0.2"
+		testStaticAddressKeepsExistingOnGatewayConflict(t, "10.0.0.0/24", "10.0.0.5", "10.0.0.2", apiv1.ProtocolIPv4)
+	})
+	t.Run("IPv6_KeepExistingAddressOnGatewayIPConflict", func(t *testing.T) {
+		testStaticAddressKeepsExistingOnGatewayConflict(t, "2001:db8::/64", "2001:db8::5", "2001:db8::2", apiv1.ProtocolIPv6)
+	})
+	t.Run("IPv6_ReleaseExistingAddress", testStaticAddressReleasesExistingIPv6)
+	t.Run("SameIP_NoRelease", testStaticAddressKeepsSameAddress)
+	t.Run("DualStack_SameProtocolReplacement", testStaticAddressReplacesV4AndPreservesV6)
+	t.Run("DualStack_CrossProtocolPreserve", testStaticAddressReplacesV6AndPreservesV4)
+}
 
-		podName := "pod1.default"
-		nicName := "nic1"
-		firstIP, err := NewIP("10.0.0.5")
-		require.NoError(t, err)
-		gatewayIP, err := NewIP("10.0.0.2")
-		require.NoError(t, err)
+func testStaticAddressReleasesExistingIPv4(t *testing.T) {
+	subnet, err := NewSubnet("v4Subnet", "10.0.0.0/24", nil)
+	require.NoError(t, err)
+	podName, nicName := "pod1.default", "nic1"
+	firstIP, err := NewIP("10.0.0.5")
+	require.NoError(t, err)
+	_, firstMAC, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstMAC)
 
-		_, mac, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
-		require.NoError(t, err)
+	secondIP, err := NewIP("10.0.0.10")
+	require.NoError(t, err)
+	got, secondMAC, err := subnet.GetStaticAddress(podName, nicName, secondIP, nil, false, true)
+	require.NoError(t, err)
+	require.Equal(t, secondIP, got)
+	require.NotEmpty(t, secondMAC)
+	require.Equal(t, secondIP, subnet.V4NicToIP[nicName])
+	require.Equal(t, podName, subnet.V4IPToPod[secondIP.String()])
+	require.True(t, subnet.V4Using.Contains(secondIP))
+	require.False(t, subnet.V4Available.Contains(secondIP))
+	require.Empty(t, subnet.V4IPToPod[firstIP.String()])
+	require.False(t, subnet.V4Using.Contains(firstIP))
+}
 
-		_, _, err = subnet.GetStaticAddress(podName, nicName, gatewayIP, nil, false, true)
-		require.ErrorIs(t, err, ErrConflict)
+func testStaticAddressReleasesExistingIPv6(t *testing.T) {
+	subnet, err := NewSubnet("v6Subnet", "2001:db8::/64", nil)
+	require.NoError(t, err)
+	podName, nicName := "pod1.default", "nic1"
+	firstIP, err := NewIP("2001:db8::5")
+	require.NoError(t, err)
+	_, firstMAC, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstMAC)
+
+	secondIP, err := NewIP("2001:db8::10")
+	require.NoError(t, err)
+	got, secondMAC, err := subnet.GetStaticAddress(podName, nicName, secondIP, nil, false, true)
+	require.NoError(t, err)
+	require.Equal(t, secondIP, got)
+	require.NotEmpty(t, secondMAC)
+	require.Equal(t, secondIP, subnet.V6NicToIP[nicName])
+	require.Equal(t, podName, subnet.V6IPToPod[secondIP.String()])
+	require.True(t, subnet.V6Using.Contains(secondIP))
+	require.False(t, subnet.V6Available.Contains(secondIP))
+	require.Empty(t, subnet.V6IPToPod[firstIP.String()])
+	require.False(t, subnet.V6Using.Contains(firstIP))
+}
+
+func testStaticAddressKeepsExistingOnGatewayConflict(t *testing.T, cidr, first, gateway, family string) {
+	subnet, err := NewSubnet("subnet", cidr, nil)
+	require.NoError(t, err)
+	if family == apiv1.ProtocolIPv4 {
+		subnet.V4Gw = gateway
+	} else {
+		subnet.V6Gw = gateway
+	}
+	podName, nicName := "pod1.default", "nic1"
+	firstIP, err := NewIP(first)
+	require.NoError(t, err)
+	gatewayIP, err := NewIP(gateway)
+	require.NoError(t, err)
+	_, mac, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
+	require.NoError(t, err)
+	_, _, err = subnet.GetStaticAddress(podName, nicName, gatewayIP, nil, false, true)
+	require.ErrorIs(t, err, ErrConflict)
+
+	if family == apiv1.ProtocolIPv4 {
 		require.Equal(t, firstIP, subnet.V4NicToIP[nicName])
-		require.Equal(t, podName, subnet.V4IPToPod[firstIP.String()])
+		require.Equal(t, podName, subnet.V4IPToPod[first])
 		require.True(t, subnet.V4Using.Contains(firstIP))
 		require.False(t, subnet.V4Available.Contains(firstIP))
-		require.Empty(t, subnet.V4IPToPod[gatewayIP.String()])
-		require.False(t, subnet.V4Using.Contains(gatewayIP))
-		require.Equal(t, mac, subnet.NicToMac[nicName])
-	})
-
-	t.Run("IPv6_KeepExistingAddressOnGatewayIPConflict", func(t *testing.T) {
-		subnet, err := NewSubnet("v6Subnet", "2001:db8::/64", nil)
-		require.NoError(t, err)
-		subnet.V6Gw = "2001:db8::2"
-
-		podName := "pod1.default"
-		nicName := "nic1"
-		firstIP, err := NewIP("2001:db8::5")
-		require.NoError(t, err)
-		gatewayIP, err := NewIP("2001:db8::2")
-		require.NoError(t, err)
-
-		_, mac, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
-		require.NoError(t, err)
-
-		_, _, err = subnet.GetStaticAddress(podName, nicName, gatewayIP, nil, false, true)
-		require.ErrorIs(t, err, ErrConflict)
+		require.Empty(t, subnet.V4IPToPod[gateway])
+	} else {
 		require.Equal(t, firstIP, subnet.V6NicToIP[nicName])
-		require.Equal(t, podName, subnet.V6IPToPod[firstIP.String()])
+		require.Equal(t, podName, subnet.V6IPToPod[first])
 		require.True(t, subnet.V6Using.Contains(firstIP))
 		require.False(t, subnet.V6Available.Contains(firstIP))
-		require.Empty(t, subnet.V6IPToPod[gatewayIP.String()])
-		require.False(t, subnet.V6Using.Contains(gatewayIP))
-		require.Equal(t, mac, subnet.NicToMac[nicName])
-	})
+		require.Empty(t, subnet.V6IPToPod[gateway])
+	}
+	require.Equal(t, mac, subnet.NicToMac[nicName])
+}
 
-	// Test IPv6 scenario
-	t.Run("IPv6_ReleaseExistingAddress", func(t *testing.T) {
-		subnet, err := NewSubnet("v6Subnet", "2001:db8::/64", nil)
-		require.NoError(t, err)
-		require.NotNil(t, subnet)
+func testStaticAddressKeepsSameAddress(t *testing.T) {
+	subnet, err := NewSubnet("v4Subnet", "10.0.0.0/24", nil)
+	require.NoError(t, err)
+	podName, nicName := "pod1.default", "nic1"
+	targetIP, err := NewIP("10.0.0.5")
+	require.NoError(t, err)
+	_, firstMAC, err := subnet.GetStaticAddress(podName, nicName, targetIP, nil, false, true)
+	require.NoError(t, err)
+	got, secondMAC, err := subnet.GetStaticAddress(podName, nicName, targetIP, nil, false, true)
+	require.NoError(t, err)
+	require.Equal(t, targetIP, got)
+	require.Equal(t, firstMAC, secondMAC)
+	require.Equal(t, targetIP, subnet.V4NicToIP[nicName])
+	require.Equal(t, podName, subnet.V4IPToPod[targetIP.String()])
+	require.True(t, subnet.V4Using.Contains(targetIP))
+}
 
-		podName := "pod1.default"
-		nicName := "nic1"
+func testStaticAddressReplacesV4AndPreservesV6(t *testing.T) {
+	subnet, err := NewSubnet("dualSubnet", "10.0.0.0/24,2001:db8::/64", nil)
+	require.NoError(t, err)
+	podName, nicName := "pod1.default", "nic1"
+	firstV4, err := NewIP("10.0.0.5")
+	require.NoError(t, err)
+	firstV6, err := NewIP("2001:db8::5")
+	require.NoError(t, err)
+	secondV4, err := NewIP("10.0.0.10")
+	require.NoError(t, err)
+	_, _, err = subnet.GetStaticAddress(podName, nicName, firstV4, nil, false, true)
+	require.NoError(t, err)
+	_, _, err = subnet.GetStaticAddress(podName, nicName, firstV6, nil, false, true)
+	require.NoError(t, err)
+	got, _, err := subnet.GetStaticAddress(podName, nicName, secondV4, nil, false, true)
+	require.NoError(t, err)
+	require.Equal(t, secondV4, got)
+	require.Empty(t, subnet.V4IPToPod[firstV4.String()])
+	require.Equal(t, secondV4, subnet.V4NicToIP[nicName])
+	assertPreservedAddressViews(t, subnet, nicName, podName, firstV6, apiv1.ProtocolIPv6)
+}
 
-		// First allocation
-		firstIP, err := NewIP("2001:db8::5")
-		require.NoError(t, err)
-		ip1, mac1, err := subnet.GetStaticAddress(podName, nicName, firstIP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "2001:db8::5", ip1.String())
-		require.NotEmpty(t, mac1)
+func testStaticAddressReplacesV6AndPreservesV4(t *testing.T) {
+	subnet, err := NewSubnet("dualSubnet", "10.0.0.0/30,2001:db8::/125", nil)
+	require.NoError(t, err)
+	podName, nicName := "pod1.default", "nic1"
+	firstV4, err := NewIP("10.0.0.1")
+	require.NoError(t, err)
+	firstV6, err := NewIP("2001:db8::1")
+	require.NoError(t, err)
+	secondV6, err := NewIP("2001:db8::2")
+	require.NoError(t, err)
+	_, _, err = subnet.GetStaticAddress(podName, nicName, firstV4, nil, false, true)
+	require.NoError(t, err)
+	_, _, err = subnet.GetStaticAddress(podName, nicName, firstV6, nil, false, true)
+	require.NoError(t, err)
+	got, _, err := subnet.GetStaticAddress(podName, nicName, secondV6, nil, false, true)
+	require.NoError(t, err)
+	require.Equal(t, secondV6, got)
+	require.Empty(t, subnet.V6IPToPod[firstV6.String()])
+	require.Equal(t, secondV6, subnet.V6NicToIP[nicName])
+	assertPreservedAddressViews(t, subnet, nicName, podName, firstV4, apiv1.ProtocolIPv4)
+}
 
-		// Verify first allocation
-		require.Equal(t, firstIP, subnet.V6NicToIP[nicName])
-		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::5"])
-		require.True(t, subnet.V6Using.Contains(firstIP))
-		require.False(t, subnet.V6Available.Contains(firstIP))
-
-		// Second allocation with different IP for same nicName
-		secondIP, err := NewIP("2001:db8::10")
-		require.NoError(t, err)
-		ip2, mac2, err := subnet.GetStaticAddress(podName, nicName, secondIP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "2001:db8::10", ip2.String())
-		require.NotEmpty(t, mac2)
-
-		// Verify second allocation and first address is released
-		require.Equal(t, secondIP, subnet.V6NicToIP[nicName])
-		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::10"])
-		require.True(t, subnet.V6Using.Contains(secondIP))
-		require.False(t, subnet.V6Available.Contains(secondIP))
-
-		// Verify first address is released
-		_, exists := subnet.V6IPToPod["2001:db8::5"]
-		require.False(t, exists)
-		require.False(t, subnet.V6Using.Contains(firstIP))
-	})
-
-	// Test same IP allocation should not release
-	t.Run("SameIP_NoRelease", func(t *testing.T) {
-		subnet, err := NewSubnet("v4Subnet", "10.0.0.0/24", nil)
-		require.NoError(t, err)
-		require.NotNil(t, subnet)
-
-		podName := "pod1.default"
-		nicName := "nic1"
-
-		// First allocation
-		targetIP, err := NewIP("10.0.0.5")
-		require.NoError(t, err)
-		ip1, mac1, err := subnet.GetStaticAddress(podName, nicName, targetIP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.5", ip1.String())
-		require.NotEmpty(t, mac1)
-
-		// Second allocation with same IP for same nicName
-		ip2, mac2, err := subnet.GetStaticAddress(podName, nicName, targetIP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.5", ip2.String())
-		require.Equal(t, mac1, mac2) // MAC should remain same
-
-		// Verify address is still allocated
-		require.Equal(t, targetIP, subnet.V4NicToIP[nicName])
-		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.5"])
-		require.True(t, subnet.V4Using.Contains(targetIP))
-	})
-
-	// Test dual stack scenario - same protocol replacement
-	t.Run("DualStack_SameProtocolReplacement", func(t *testing.T) {
-		subnet, err := NewSubnet("dualSubnet", "10.0.0.0/24,2001:db8::/64", nil)
-		require.NoError(t, err)
-		require.NotNil(t, subnet)
-
-		podName := "pod1.default"
-		nicName := "nic1"
-
-		// First allocation - IPv4
-		firstV4IP, err := NewIP("10.0.0.5")
-		require.NoError(t, err)
-		ip1, _, err := subnet.GetStaticAddress(podName, nicName, firstV4IP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.5", ip1.String())
-
-		// Second allocation - IPv6 for same nicName (should coexist in dual stack)
-		firstV6IP, err := NewIP("2001:db8::5")
-		require.NoError(t, err)
-		ip2, _, err := subnet.GetStaticAddress(podName, nicName, firstV6IP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "2001:db8::5", ip2.String())
-
-		// Verify both IPv4 and IPv6 coexist in dual stack
-		require.Equal(t, firstV4IP, subnet.V4NicToIP[nicName], "IPv4 should coexist with IPv6")
-		require.Equal(t, firstV6IP, subnet.V6NicToIP[nicName])
-		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.5"])
-		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::5"])
-
-		// Third allocation - Different IPv4 for same nicName (should replace IPv4 only)
-		secondV4IP, err := NewIP("10.0.0.10")
-		require.NoError(t, err)
-		ip3, _, err := subnet.GetStaticAddress(podName, nicName, secondV4IP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.10", ip3.String())
-
-		// Verify IPv4 is replaced but IPv6 remains
-		require.Equal(t, secondV4IP, subnet.V4NicToIP[nicName], "New IPv4 should replace old one")
-		require.Equal(t, firstV6IP, subnet.V6NicToIP[nicName], "IPv6 should remain unchanged")
-		_, v4exists := subnet.V4IPToPod["10.0.0.5"]
-		require.False(t, v4exists, "Original IPv4 should be released")
-		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.10"])
-		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::5"])
-
-		pool := subnet.IPPools[""]
-		require.NotNil(t, pool)
-		require.True(t, subnet.V6Using.Contains(firstV6IP))
-		require.False(t, subnet.V6Available.Contains(firstV6IP))
-		require.True(t, pool.V6Using.Contains(firstV6IP))
-		require.False(t, pool.V6Available.Contains(firstV6IP))
-		require.False(t, pool.V6Released.Contains(firstV6IP))
-	})
-
-	t.Run("DualStack_CrossProtocolPreserve", func(t *testing.T) {
-		subnet, err := NewSubnet("dualSubnet", "10.0.0.0/30,2001:db8::/125", nil)
-		require.NoError(t, err)
-		require.NotNil(t, subnet)
-
-		podName := "pod1.default"
-		nicName := "nic1"
-
-		firstV4IP, err := NewIP("10.0.0.1")
-		require.NoError(t, err)
-		ip1, _, err := subnet.GetStaticAddress(podName, nicName, firstV4IP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "10.0.0.1", ip1.String())
-
-		firstV6IP, err := NewIP("2001:db8::1")
-		require.NoError(t, err)
-		ip2, _, err := subnet.GetStaticAddress(podName, nicName, firstV6IP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "2001:db8::1", ip2.String())
-
-		require.Equal(t, firstV4IP, subnet.V4NicToIP[nicName])
-		require.Equal(t, firstV6IP, subnet.V6NicToIP[nicName])
-		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.1"])
-		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::1"])
-
-		secondV6IP, err := NewIP("2001:db8::2")
-		require.NoError(t, err)
-		ip3, _, err := subnet.GetStaticAddress(podName, nicName, secondV6IP, nil, false, true)
-		require.NoError(t, err)
-		require.Equal(t, "2001:db8::2", ip3.String())
-
-		require.Equal(t, firstV4IP, subnet.V4NicToIP[nicName])
-		require.Equal(t, secondV6IP, subnet.V6NicToIP[nicName])
-		_, v6exists := subnet.V6IPToPod["2001:db8::1"]
-		require.False(t, v6exists)
-		require.Equal(t, podName, subnet.V4IPToPod["10.0.0.1"])
-		require.Equal(t, podName, subnet.V6IPToPod["2001:db8::2"])
-
-		pool := subnet.IPPools[""]
-		require.NotNil(t, pool)
-		require.True(t, subnet.V4Using.Contains(firstV4IP))
-		require.False(t, subnet.V4Available.Contains(firstV4IP))
-		require.True(t, pool.V4Using.Contains(firstV4IP))
-		require.False(t, pool.V4Available.Contains(firstV4IP))
-		require.False(t, pool.V4Released.Contains(firstV4IP))
-	})
+func assertPreservedAddressViews(t *testing.T, subnet *Subnet, nicName, podName string, ip IP, family string) {
+	t.Helper()
+	pool := subnet.IPPools[""]
+	require.NotNil(t, pool)
+	if family == apiv1.ProtocolIPv4 {
+		require.Equal(t, ip, subnet.V4NicToIP[nicName])
+		require.Equal(t, podName, subnet.V4IPToPod[ip.String()])
+		require.True(t, subnet.V4Using.Contains(ip))
+		require.False(t, subnet.V4Available.Contains(ip))
+		require.True(t, pool.V4Using.Contains(ip))
+		require.False(t, pool.V4Available.Contains(ip))
+		require.False(t, pool.V4Released.Contains(ip))
+		return
+	}
+	require.Equal(t, ip, subnet.V6NicToIP[nicName])
+	require.Equal(t, podName, subnet.V6IPToPod[ip.String()])
+	require.True(t, subnet.V6Using.Contains(ip))
+	require.False(t, subnet.V6Available.Contains(ip))
+	require.True(t, pool.V6Using.Contains(ip))
+	require.False(t, pool.V6Available.Contains(ip))
+	require.False(t, pool.V6Released.Contains(ip))
 }
 
 func TestGetStaticMac(t *testing.T) {


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

Follow up on #7187 and align static and random dual-stack allocation with the same family-specific release semantics.

`GetStaticAddress` now releases only the address family being replaced. The other family and MAC stay in their existing lookup and counter views, so the implementation no longer releases the whole NIC and manually rebuilds preserved state. A family view centralizes the IPv4/IPv6 maps and counters used by static allocation, while focused helpers keep each changed function below the repository 100-line limit.

Random skipped-address regression coverage now verifies both the default pool and a named IPPool for:

- skipped IPv4: replace IPv4 and preserve IPv6/MAC;
- skipped IPv6: replace IPv6 and preserve IPv4/MAC;
- both families skipped: replace both addresses and preserve MAC.

Existing static replacement tests are split into focused cases without changing controller flow or validation behavior.

Validation:

- `go test ./pkg/ipam -count=1`
- `go test -race ./pkg/ipam -count=1`
- `go vet ./pkg/ipam`
- `golangci-lint run ./pkg/ipam/...`

## Which issue(s) this PR fixes

Related: #7187
