### PR TITLE
test(e2e): use kubelet secret update timeout

### DIFF
--- a/test/e2e/security/kube_ovn_tls_rotation_test.go
+++ b/test/e2e/security/kube_ovn_tls_rotation_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 
 	"github.com/onsi/ginkgo/v2"
@@ -103,11 +104,12 @@ var _ = framework.Describe("[group:security] kube-ovn TLS rotation", func() {
 
 		ginkgo.By("Waiting for kube-ovn-tls files to be projected")
 		expectedFileHashes := kubeOVNTLSFileHashes(updatedData)
-		waitDeploymentTLSFilesProjected(cs, deploy, expectedFileHashes, "kube-ovn-controller")
-		waitDeploymentTLSFilesProjected(cs, monitorDeploy, expectedFileHashes, "kube-ovn-monitor")
-		waitDaemonSetTLSFilesProjected(daemonSetClient, pingerDS, expectedFileHashes, "kube-ovn-pinger")
-		waitDeploymentTLSFilesProjected(cs, centralDeploy, expectedFileHashes, "ovn-central")
-		waitPodListTLSFilesProjected(&corev1.PodList{Items: ovsPods}, expectedFileHashes, "ovs-ovn")
+		projectionTimeout := e2epod.GetPodSecretUpdateTimeout(context.Background(), cs)
+		waitDeploymentTLSFilesProjected(cs, deploy, expectedFileHashes, projectionTimeout, "kube-ovn-controller")
+		waitDeploymentTLSFilesProjected(cs, monitorDeploy, expectedFileHashes, projectionTimeout, "kube-ovn-monitor")
+		waitDaemonSetTLSFilesProjected(daemonSetClient, pingerDS, expectedFileHashes, projectionTimeout, "kube-ovn-pinger")
+		waitDeploymentTLSFilesProjected(cs, centralDeploy, expectedFileHashes, projectionTimeout, "ovn-central")
+		waitPodListTLSFilesProjected(&corev1.PodList{Items: ovsPods}, expectedFileHashes, projectionTimeout, "ovs-ovn")
 
 		ginkgo.By("Waiting for ovn-central to reload TLS")
 		waitOVNCentralTLSReloaded(cs, centralDeploy, centralTLSHashes)
@@ -358,25 +360,25 @@ func deploymentTLSHashes(cs kubernetes.Interface, deploy *appsv1.Deployment) map
 	return hashes
 }
 
-func waitDeploymentTLSFilesProjected(cs kubernetes.Interface, deploy *appsv1.Deployment, expectedHashes map[string]string, name string) {
+func waitDeploymentTLSFilesProjected(cs kubernetes.Interface, deploy *appsv1.Deployment, expectedHashes map[string]string, timeout time.Duration, name string) {
 	ginkgo.GinkgoHelper()
 
-	waitPodListTLSFilesProjected(deploymentPods(cs, deploy), expectedHashes, name)
+	waitPodListTLSFilesProjected(deploymentPods(cs, deploy), expectedHashes, timeout, name)
 }
 
-func waitDaemonSetTLSFilesProjected(client *framework.DaemonSetClient, ds *appsv1.DaemonSet, expectedHashes map[string]string, name string) {
+func waitDaemonSetTLSFilesProjected(client *framework.DaemonSetClient, ds *appsv1.DaemonSet, expectedHashes map[string]string, timeout time.Duration, name string) {
 	ginkgo.GinkgoHelper()
 
 	pods, err := client.GetPods(ds)
 	framework.ExpectNoError(err)
-	waitPodListTLSFilesProjected(pods, expectedHashes, name)
+	waitPodListTLSFilesProjected(pods, expectedHashes, timeout, name)
 }
 
-func waitPodListTLSFilesProjected(pods *corev1.PodList, expectedHashes map[string]string, name string) {
+func waitPodListTLSFilesProjected(pods *corev1.PodList, expectedHashes map[string]string, timeout time.Duration, name string) {
 	ginkgo.GinkgoHelper()
 
 	framework.ExpectNotEmpty(pods.Items, "no %s pod found", name)
-	framework.WaitUntil(5*time.Second, 90*time.Second, func(_ context.Context) (bool, error) {
+	framework.WaitUntil(5*time.Second, timeout, func(_ context.Context) (bool, error) {
 		for _, pod := range pods.Items {
 			hashes, err := podTLSFileHashes(pod)
 			if err != nil {

--- a/test/e2e/security/kube_ovn_tls_rotation_test.go
+++ b/test/e2e/security/kube_ovn_tls_rotation_test.go
@@ -95,21 +95,22 @@ var _ = framework.Describe("[group:security] kube-ovn TLS rotation", func() {
 		initialOVNControllerPIDs := ovnControllerPIDs(ovsPods)
 
 		ginkgo.By("Installing updated kube-ovn-tls secret")
+		projectionTimeout := e2epod.GetPodSecretUpdateTimeout(context.Background(), cs)
 		updatedData, err := generateUpdatedKubeOVNTLSSecretData()
 		framework.ExpectNoError(err)
 		updatedHash := kubeOVNTLSDataHash(updatedData)
 		framework.ExpectNotEqual(updatedHash, originalHash)
 		framework.ExpectNotEqual(kubeOVNTLSCertSerial(updatedData), originalSerial)
 		updateKubeOVNTLSSecretData(cs, updatedData)
+		projectionDeadline := time.Now().Add(projectionTimeout)
 
 		ginkgo.By("Waiting for kube-ovn-tls files to be projected")
 		expectedFileHashes := kubeOVNTLSFileHashes(updatedData)
-		projectionTimeout := e2epod.GetPodSecretUpdateTimeout(context.Background(), cs)
-		waitDeploymentTLSFilesProjected(cs, deploy, expectedFileHashes, projectionTimeout, "kube-ovn-controller")
-		waitDeploymentTLSFilesProjected(cs, monitorDeploy, expectedFileHashes, projectionTimeout, "kube-ovn-monitor")
-		waitDaemonSetTLSFilesProjected(daemonSetClient, pingerDS, expectedFileHashes, projectionTimeout, "kube-ovn-pinger")
-		waitDeploymentTLSFilesProjected(cs, centralDeploy, expectedFileHashes, projectionTimeout, "ovn-central")
-		waitPodListTLSFilesProjected(&corev1.PodList{Items: ovsPods}, expectedFileHashes, projectionTimeout, "ovs-ovn")
+		waitDeploymentTLSFilesProjected(cs, deploy, expectedFileHashes, projectionDeadline, "kube-ovn-controller")
+		waitDeploymentTLSFilesProjected(cs, monitorDeploy, expectedFileHashes, projectionDeadline, "kube-ovn-monitor")
+		waitDaemonSetTLSFilesProjected(daemonSetClient, pingerDS, expectedFileHashes, projectionDeadline, "kube-ovn-pinger")
+		waitDeploymentTLSFilesProjected(cs, centralDeploy, expectedFileHashes, projectionDeadline, "ovn-central")
+		waitPodListTLSFilesProjected(&corev1.PodList{Items: ovsPods}, expectedFileHashes, projectionDeadline, "ovs-ovn")
 
 		ginkgo.By("Waiting for ovn-central to reload TLS")
 		waitOVNCentralTLSReloaded(cs, centralDeploy, centralTLSHashes)
@@ -360,25 +361,25 @@ func deploymentTLSHashes(cs kubernetes.Interface, deploy *appsv1.Deployment) map
 	return hashes
 }
 
-func waitDeploymentTLSFilesProjected(cs kubernetes.Interface, deploy *appsv1.Deployment, expectedHashes map[string]string, timeout time.Duration, name string) {
+func waitDeploymentTLSFilesProjected(cs kubernetes.Interface, deploy *appsv1.Deployment, expectedHashes map[string]string, deadline time.Time, name string) {
 	ginkgo.GinkgoHelper()
 
-	waitPodListTLSFilesProjected(deploymentPods(cs, deploy), expectedHashes, timeout, name)
+	waitPodListTLSFilesProjected(deploymentPods(cs, deploy), expectedHashes, deadline, name)
 }
 
-func waitDaemonSetTLSFilesProjected(client *framework.DaemonSetClient, ds *appsv1.DaemonSet, expectedHashes map[string]string, timeout time.Duration, name string) {
+func waitDaemonSetTLSFilesProjected(client *framework.DaemonSetClient, ds *appsv1.DaemonSet, expectedHashes map[string]string, deadline time.Time, name string) {
 	ginkgo.GinkgoHelper()
 
 	pods, err := client.GetPods(ds)
 	framework.ExpectNoError(err)
-	waitPodListTLSFilesProjected(pods, expectedHashes, timeout, name)
+	waitPodListTLSFilesProjected(pods, expectedHashes, deadline, name)
 }
 
-func waitPodListTLSFilesProjected(pods *corev1.PodList, expectedHashes map[string]string, timeout time.Duration, name string) {
+func waitPodListTLSFilesProjected(pods *corev1.PodList, expectedHashes map[string]string, deadline time.Time, name string) {
 	ginkgo.GinkgoHelper()
 
 	framework.ExpectNotEmpty(pods.Items, "no %s pod found", name)
-	framework.WaitUntil(5*time.Second, timeout, func(_ context.Context) (bool, error) {
+	framework.WaitUntil(5*time.Second, time.Until(deadline), func(_ context.Context) (bool, error) {
 		for _, pod := range pods.Items {
 			hashes, err := podTLSFileHashes(pod)
 			if err != nil {

--- a/test/e2e/security/kube_ovn_tls_rotation_test.go
+++ b/test/e2e/security/kube_ovn_tls_rotation_test.go
@@ -15,8 +15,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 
@@ -94,6 +96,14 @@ var _ = framework.Describe("[group:security] kube-ovn TLS rotation", func() {
 		seedOVSTLSHashes(ovsPods)
 		initialOVNControllerPIDs := ovnControllerPIDs(ovsPods)
 
+		projectionPods := deploymentPods(cs, deploy)
+		projectionPods.Items = append(projectionPods.Items, deploymentPods(cs, monitorDeploy).Items...)
+		pingerPods, err := daemonSetClient.GetPods(pingerDS)
+		framework.ExpectNoError(err)
+		projectionPods.Items = append(projectionPods.Items, pingerPods.Items...)
+		projectionPods.Items = append(projectionPods.Items, deploymentPods(cs, centralDeploy).Items...)
+		projectionPods.Items = append(projectionPods.Items, ovsPods...)
+
 		ginkgo.By("Installing updated kube-ovn-tls secret")
 		projectionTimeout := e2epod.GetPodSecretUpdateTimeout(context.Background(), cs)
 		updatedData, err := generateUpdatedKubeOVNTLSSecretData()
@@ -106,11 +116,7 @@ var _ = framework.Describe("[group:security] kube-ovn TLS rotation", func() {
 
 		ginkgo.By("Waiting for kube-ovn-tls files to be projected")
 		expectedFileHashes := kubeOVNTLSFileHashes(updatedData)
-		waitDeploymentTLSFilesProjected(cs, deploy, expectedFileHashes, projectionDeadline, "kube-ovn-controller")
-		waitDeploymentTLSFilesProjected(cs, monitorDeploy, expectedFileHashes, projectionDeadline, "kube-ovn-monitor")
-		waitDaemonSetTLSFilesProjected(daemonSetClient, pingerDS, expectedFileHashes, projectionDeadline, "kube-ovn-pinger")
-		waitDeploymentTLSFilesProjected(cs, centralDeploy, expectedFileHashes, projectionDeadline, "ovn-central")
-		waitPodListTLSFilesProjected(&corev1.PodList{Items: ovsPods}, expectedFileHashes, projectionDeadline, "ovs-ovn")
+		waitPodListTLSFilesProjected(projectionPods, expectedFileHashes, projectionDeadline, "kube-ovn components")
 
 		ginkgo.By("Waiting for ovn-central to reload TLS")
 		waitOVNCentralTLSReloaded(cs, centralDeploy, centralTLSHashes)
@@ -361,27 +367,13 @@ func deploymentTLSHashes(cs kubernetes.Interface, deploy *appsv1.Deployment) map
 	return hashes
 }
 
-func waitDeploymentTLSFilesProjected(cs kubernetes.Interface, deploy *appsv1.Deployment, expectedHashes map[string]string, deadline time.Time, name string) {
-	ginkgo.GinkgoHelper()
-
-	waitPodListTLSFilesProjected(deploymentPods(cs, deploy), expectedHashes, deadline, name)
-}
-
-func waitDaemonSetTLSFilesProjected(client *framework.DaemonSetClient, ds *appsv1.DaemonSet, expectedHashes map[string]string, deadline time.Time, name string) {
-	ginkgo.GinkgoHelper()
-
-	pods, err := client.GetPods(ds)
-	framework.ExpectNoError(err)
-	waitPodListTLSFilesProjected(pods, expectedHashes, deadline, name)
-}
-
 func waitPodListTLSFilesProjected(pods *corev1.PodList, expectedHashes map[string]string, deadline time.Time, name string) {
 	ginkgo.GinkgoHelper()
 
 	framework.ExpectNotEmpty(pods.Items, "no %s pod found", name)
-	framework.WaitUntil(5*time.Second, time.Until(deadline), func(_ context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, time.Until(deadline), true, func(_ context.Context) (bool, error) {
 		for _, pod := range pods.Items {
-			hashes, err := podTLSFileHashes(pod)
+			hashes, err := podTLSFileHashes(pod, deadline)
 			if err != nil {
 				return false, nil
 			}
@@ -390,21 +382,36 @@ func waitPodListTLSFilesProjected(pods *corev1.PodList, expectedHashes map[strin
 			}
 		}
 		return true, nil
-	}, fmt.Sprintf("%s projected kube-ovn-tls files", name))
+	})
+	if errors.Is(err, context.DeadlineExceeded) {
+		framework.Failf("timed out while waiting for %s projected kube-ovn-tls files", name)
+	}
+	framework.ExpectNoError(err)
 }
 
-func podTLSFileHashes(pod corev1.Pod) (map[string]string, error) {
+func podTLSFileHashes(pod corev1.Pod, deadline time.Time) (map[string]string, error) {
 	ginkgo.GinkgoHelper()
 
-	output, err := e2epodoutput.RunHostCmd(
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return nil, context.DeadlineExceeded
+	}
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	output, err := e2ekubectl.NewKubectlCommand(
 		pod.Namespace,
+		"exec",
 		pod.Name,
+		"--",
+		"/bin/sh",
+		"-x",
+		"-c",
 		`set -eu
 for file in cacert cert key; do
   test -s "/var/run/tls/${file}"
   printf "%s %s\n" "${file}" "$(sha256sum "/var/run/tls/${file}" | awk '{print $1}')"
 done`,
-	)
+	).WithTimeout(timer.C).Exec()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Root cause

The TLS rotation E2E test used a fixed 90-second deadline for Secret volume projection. Kubernetes E2E uses 240 seconds plus the node Secret TTL because projection can take a full kubelet sync period, cache TTL, and propagation slack. In the failing HA job, one controller pod still had the old files at 90 seconds while the other pods had already updated.

## Change

- Use Kubernetes GetPodSecretUpdateTimeout for TLS Secret projection waits.
- Establish one deadline after the Secret update so all workloads share the same propagation budget.
- Snapshot all target Pods before the update and check them in one immediate poll.
- Bound each kubectl exec by the remaining deadline.
- Keep validating automatic projection; no pod annotation or forced refresh masks the behavior.

## Validation

- go test ./test/e2e/security -run TestNonExistent
- golangci-lint run -v ./test/e2e/security

Failing job: https://github.com/kubeovn/kube-ovn/actions/runs/31360634022/job/93372366318