### PR TITLE
test(e2e): wait for TLS restoration before HA tests

### DIFF
--- a/test/e2e/security/kube_ovn_tls_rotation_test.go
+++ b/test/e2e/security/kube_ovn_tls_rotation_test.go
@@ -68,10 +68,6 @@ var _ = framework.Describe("[group:security] kube-ovn TLS rotation", func() {
 		originalData := copySecretData(originalSecret.Data)
 		originalHash := kubeOVNTLSDataHash(originalData)
 		originalSerial := kubeOVNTLSCertSerial(originalData)
-		ginkgo.DeferCleanup(func() {
-			ginkgo.By("Restoring kube-ovn-tls secret")
-			restoreSecretData(cs, originalData)
-		})
 
 		ginkgo.By("Recording kube-ovn-controller restart counts")
 		restartCounts := deploymentContainerRestartCounts(cs, deploy, kubeOVNControllerContainer)
@@ -104,14 +100,48 @@ var _ = framework.Describe("[group:security] kube-ovn TLS rotation", func() {
 		projectionPods.Items = append(projectionPods.Items, deploymentPods(cs, centralDeploy).Items...)
 		projectionPods.Items = append(projectionPods.Items, ovsPods...)
 
-		ginkgo.By("Installing updated kube-ovn-tls secret")
 		projectionTimeout := e2epod.GetPodSecretUpdateTimeout(context.Background(), cs)
+		secretUpdated := false
+		ginkgo.DeferCleanup(func() {
+			if !secretUpdated {
+				return
+			}
+
+			var projectionDeadline time.Time
+			restoreKubeOVNTLSState(
+				func() {
+					ginkgo.By("Restoring kube-ovn-tls secret")
+					updateKubeOVNTLSSecretData(cs, originalData)
+					projectionDeadline = time.Now().Add(projectionTimeout)
+				},
+				func() {
+					ginkgo.By("Waiting for restored kube-ovn-tls files to be projected")
+					waitPodListTLSFilesProjected(projectionPods, kubeOVNTLSFileHashes(originalData), projectionDeadline, "kube-ovn components")
+				},
+				func() {
+					ginkgo.By("Waiting for ovn-central to reload the restored TLS files")
+					waitDeploymentTLSHashFiles(cs, centralDeploy, ovnCentralTLSHashFile, "ovn-central")
+				},
+				func() {
+					ginkgo.By("Waiting for ovn-controller to reload the restored TLS files")
+					waitPodListTLSHashFiles(&corev1.PodList{Items: ovsPods}, ovsOVNTLSHashFile, "ovs-ovn")
+				},
+				func() {
+					ginkgo.By("Ensuring restored TLS files can connect to OVN databases")
+					assertDeploymentOVNDBSSLConnectivity(cs, deploy)
+					assertPodListOVNDBSSLConnectivity(&corev1.PodList{Items: ovsPods}, "ovs-ovn")
+				},
+			)
+		})
+
+		ginkgo.By("Installing updated kube-ovn-tls secret")
 		updatedData, err := generateUpdatedKubeOVNTLSSecretData()
 		framework.ExpectNoError(err)
 		updatedHash := kubeOVNTLSDataHash(updatedData)
 		framework.ExpectNotEqual(updatedHash, originalHash)
 		framework.ExpectNotEqual(kubeOVNTLSCertSerial(updatedData), originalSerial)
 		updateKubeOVNTLSSecretData(cs, updatedData)
+		secretUpdated = true
 		projectionDeadline := time.Now().Add(projectionTimeout)
 
 		ginkgo.By("Waiting for kube-ovn-tls files to be projected")
@@ -172,10 +202,12 @@ func copySecretData(data map[string][]byte) map[string][]byte {
 	return copied
 }
 
-func restoreSecretData(cs kubernetes.Interface, data map[string][]byte) {
-	ginkgo.GinkgoHelper()
-
-	updateKubeOVNTLSSecretData(cs, data)
+func restoreKubeOVNTLSState(restoreSecret, waitForProjection, waitForOVNCentral, waitForOVS, verifyConnectivity func()) {
+	restoreSecret()
+	waitForProjection()
+	waitForOVNCentral()
+	waitForOVS()
+	verifyConnectivity()
 }
 
 func updateKubeOVNTLSSecretData(cs kubernetes.Interface, data map[string][]byte) *corev1.Secret {

--- a/test/e2e/security/kube_ovn_tls_rotation_test_test.go
+++ b/test/e2e/security/kube_ovn_tls_rotation_test_test.go
@@ -1,0 +1,24 @@
+package security
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestRestoreKubeOVNTLSStateWaitsForStability(t *testing.T) {
+	t.Parallel()
+
+	var steps []string
+	restoreKubeOVNTLSState(
+		func() { steps = append(steps, "restore") },
+		func() { steps = append(steps, "projection") },
+		func() { steps = append(steps, "ovn-central") },
+		func() { steps = append(steps, "ovs-ovn") },
+		func() { steps = append(steps, "connectivity") },
+	)
+
+	want := []string{"restore", "projection", "ovn-central", "ovs-ovn", "connectivity"}
+	if !slices.Equal(steps, want) {
+		t.Fatalf("unexpected TLS restoration steps: got %v, want %v", steps, want)
+	}
+}


### PR DESCRIPTION
## Root cause

The TLS rotation E2E restored the original kube-ovn-tls Secret in DeferCleanup but returned immediately after the API update. Secret projection and TLS reload continued asynchronously while the HA suite started.

In run 31372797094, both failing SSL/bind-local HA jobs entered destructive database recovery during that rollback window. OVN logs show repeated unknown CA errors. Recovered NB servers then changed SID (8d7a to baba and 9a42 to 9a4f), while peers retained the old SID, leaving four RAFT members and repeated misrouted messages.

## Change

- Wait for the original Secret data to be projected to every Kube-OVN component during cleanup.
- Wait for ovn-central and ovs-ovn TLS reload hash files to match restored mounted files.
- Verify restored credentials can connect to OVN databases before cleanup returns.
- Skip restoration waits when the test fails before updating the Secret.
- Add a regression test for the synchronous restoration sequence.

## Validation

- go test ./test/e2e/security -run TestRestoreKubeOVNTLSStateWaitsForStability -count=1 -v
- golangci-lint run -v --concurrency 1 ./test/e2e/security (0 issues)
- git diff --check

Failing run: https://github.com/kubeovn/kube-ovn/actions/runs/31372797094
Failing jobs:
- https://github.com/kubeovn/kube-ovn/actions/runs/31372797094/job/93410208674
- https://github.com/kubeovn/kube-ovn/actions/runs/31372797094/job/93410208741