### PR TITLE
fix(daemon): cap provider VLAN internal port names

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -602,7 +602,7 @@ func (c *Controller) cleanProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v
 		return err
 	}
 
-	if err := c.ovsCleanProviderNetwork(pn.Name, providerNetworkNic(pn, node.Name)); err != nil {
+	if err := c.ovsCleanProviderNetwork(pn.Name, providerNetworkNic(pn, node.Name), pn.Spec.VlanInterfaces); err != nil {
 		return err
 	}
 
@@ -610,7 +610,7 @@ func (c *Controller) cleanProviderNetwork(pn *kubeovnv1.ProviderNetwork, node *v
 }
 
 func (c *Controller) handleDeleteProviderNetwork(pn *kubeovnv1.ProviderNetwork) error {
-	if err := c.ovsCleanProviderNetwork(pn.Name, providerNetworkNic(pn, c.config.NodeName)); err != nil {
+	if err := c.ovsCleanProviderNetwork(pn.Name, providerNetworkNic(pn, c.config.NodeName), pn.Spec.VlanInterfaces); err != nil {
 		klog.Error(err)
 		return err
 	}

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -98,6 +98,10 @@ func InitMirror(config *Configuration) error {
 }
 
 func (c *Controller) ovsInitProviderNetwork(provider, nic string, trunks []string, exchangeLinkName, macLearningFallback bool, vlanInterfaceMap map[string]int) (int, error) { // create and configure external bridge
+	if err := validateProviderVlanInterfaceMap(vlanInterfaceMap); err != nil {
+		return 0, err
+	}
+
 	brName := util.ExternalBridgeName(provider)
 	if exchangeLinkName {
 		exchanged, err := c.changeProviderNicName(nic, brName)
@@ -145,7 +149,7 @@ func (c *Controller) ovsInitProviderNetwork(provider, nic string, trunks []strin
 	return mtu, nil
 }
 
-func (c *Controller) ovsCleanProviderNetwork(provider, nic string) error {
+func (c *Controller) ovsCleanProviderNetwork(provider, nic string, vlanInterfaces []string) error {
 	mappings, err := getOvnMappings("ovn-bridge-mappings")
 	if err != nil {
 		klog.Error(err)
@@ -212,10 +216,10 @@ func (c *Controller) ovsCleanProviderNetwork(provider, nic string) error {
 				if output != "" {
 					continue
 				}
-				// Check if this is a VLAN internal port (e.g., br-eth0-vlan10)
-				if matched, vlanID := util.IsVlanInternalPort(port); matched {
+				// Check if this is a VLAN internal port.
+				if matched, vlanID := util.IsVlanInternalPortForBridge(port, brName); matched {
 					klog.Infof("removing VLAN internal port %s (VLAN %d) from bridge %s", port, vlanID, brName)
-					if err = c.removeProviderVlanInterface(port, brName, vlanID); err != nil {
+					if err = c.removeProviderVlanInterface(port, provider, brName, nic, vlanInterfaces, vlanID); err != nil {
 						klog.Errorf("failed to remove VLAN internal port %s from external bridge %s: %v", port, brName, err)
 						return err
 					}

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -232,12 +232,19 @@ func (c *Controller) cleanProviderBridgePorts(ctx providerVlanRestoreContext) er
 	if err != nil {
 		return fmt.Errorf("failed to list ports of OVS bridge %s: %w: %q", ctx.bridge, err, output)
 	}
-	for port := range strings.SplitSeq(output, "\n") {
+	for _, port := range providerBridgePorts(output) {
 		if err := c.cleanProviderBridgePort(port, ctx); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func providerBridgePorts(output string) []string {
+	if output == "" {
+		return nil
+	}
+	return slices.Collect(strings.SplitSeq(output, "\n"))
 }
 
 func (c *Controller) cleanProviderBridgePort(port string, ctx providerVlanRestoreContext) error {

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -207,6 +207,7 @@ func (c *Controller) ovsCleanProviderNetwork(provider, nic string, vlanInterface
 
 		// remove host nic from the external bridge
 		if output != "" {
+			ctx := providerVlanRestoreContext{provider: provider, bridge: brName, nic: nic, vlanInterfaces: vlanInterfaces}
 			for port := range strings.SplitSeq(output, "\n") {
 				// patch port created by ovn-controller has an external ID ovn-localnet-port=localnet.<SUBNET>
 				if output, err = ovs.Exec("--data=bare", "--no-heading", "--columns=_uuid", "find", "port", "name="+port, `external-ids:ovn-localnet-port!=""`); err != nil {
@@ -217,9 +218,13 @@ func (c *Controller) ovsCleanProviderNetwork(provider, nic string, vlanInterface
 					continue
 				}
 				// Check if this is a VLAN internal port.
-				if matched, vlanID := util.IsVlanInternalPortForBridge(port, brName); matched {
+				owned, err := ovs.ValidatePortVendor(port)
+				if err != nil {
+					return fmt.Errorf("failed to check vendor of port %s: %w", port, err)
+				}
+				if matched, vlanID := util.IsVlanInternalPortForBridge(port, brName); matched && owned {
 					klog.Infof("removing VLAN internal port %s (VLAN %d) from bridge %s", port, vlanID, brName)
-					if err = c.removeProviderVlanInterface(port, provider, brName, nic, vlanInterfaces, vlanID); err != nil {
+					if err = c.removeProviderVlanInterface(port, ctx, vlanID); err != nil {
 						klog.Errorf("failed to remove VLAN internal port %s from external bridge %s: %v", port, brName, err)
 						return err
 					}

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -199,44 +199,9 @@ func (c *Controller) ovsCleanProviderNetwork(provider, nic string, vlanInterface
 	}
 
 	if !isUserspaceDP {
-		// get host nic
-		if output, err = ovs.Exec("list-ports", brName); err != nil {
-			klog.Errorf("failed to list ports of OVS bridge %s, %v: %q", brName, err, output)
+		ctx := providerVlanRestoreContext{provider: provider, bridge: brName, nic: nic, vlanInterfaces: vlanInterfaces}
+		if err := c.cleanProviderBridgePorts(ctx); err != nil {
 			return err
-		}
-
-		// remove host nic from the external bridge
-		if output != "" {
-			ctx := providerVlanRestoreContext{provider: provider, bridge: brName, nic: nic, vlanInterfaces: vlanInterfaces}
-			for port := range strings.SplitSeq(output, "\n") {
-				// patch port created by ovn-controller has an external ID ovn-localnet-port=localnet.<SUBNET>
-				if output, err = ovs.Exec("--data=bare", "--no-heading", "--columns=_uuid", "find", "port", "name="+port, `external-ids:ovn-localnet-port!=""`); err != nil {
-					klog.Errorf("failed to find ovs port %s, %v: %q", port, err, output)
-					return err
-				}
-				if output != "" {
-					continue
-				}
-				// Check if this is a VLAN internal port.
-				owned, err := ovs.ValidatePortVendor(port)
-				if err != nil {
-					return fmt.Errorf("failed to check vendor of port %s: %w", port, err)
-				}
-				if matched, vlanID := util.IsVlanInternalPortForBridge(port, brName); matched && owned {
-					klog.Infof("removing VLAN internal port %s (VLAN %d) from bridge %s", port, vlanID, brName)
-					if err = c.removeProviderVlanInterface(port, ctx, vlanID); err != nil {
-						klog.Errorf("failed to remove VLAN internal port %s from external bridge %s: %v", port, brName, err)
-						return err
-					}
-				} else {
-					klog.Infof("removing ovs port %s from bridge %s", port, brName)
-					if err = c.removeProviderNic(port, brName); err != nil {
-						klog.Errorf("failed to remove port %s from external bridge %s: %v", port, brName, err)
-						return err
-					}
-				}
-				klog.Infof("ovs port %s has been removed from bridge %s", port, brName)
-			}
 		}
 
 		// remove OVS bridge
@@ -260,4 +225,48 @@ func (c *Controller) ovsCleanProviderNetwork(provider, nic string, vlanInterface
 		return err
 	}
 	return removeOvnMapping("ovn-bridge-mappings", provider)
+}
+
+func (c *Controller) cleanProviderBridgePorts(ctx providerVlanRestoreContext) error {
+	output, err := ovs.Exec("list-ports", ctx.bridge)
+	if err != nil {
+		return fmt.Errorf("failed to list ports of OVS bridge %s: %w: %q", ctx.bridge, err, output)
+	}
+	for port := range strings.SplitSeq(output, "\n") {
+		if err := c.cleanProviderBridgePort(port, ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) cleanProviderBridgePort(port string, ctx providerVlanRestoreContext) error {
+	output, err := ovs.Exec("--data=bare", "--no-heading", "--columns=_uuid", "find", "port", "name="+port, `external-ids:ovn-localnet-port!=""`)
+	if err != nil {
+		return fmt.Errorf("failed to find OVS port %s: %w: %q", port, err, output)
+	}
+	if output != "" {
+		return nil
+	}
+	owned, err := ovs.ValidatePortVendor(port)
+	if err != nil {
+		return fmt.Errorf("failed to check vendor of port %s: %w", port, err)
+	}
+	switch providerBridgePortCleanupAction(port, ctx.bridge, owned) {
+	case providerBridgePortReject:
+		return fmt.Errorf("refusing to remove OVS bridge %s: VLAN-shaped port %s has different vendor", ctx.bridge, port)
+	case providerBridgePortRemoveVlan:
+		_, vlanID := util.IsVlanInternalPortForBridge(port, ctx.bridge)
+		klog.Infof("removing VLAN internal port %s (VLAN %d) from bridge %s", port, vlanID, ctx.bridge)
+		if err := c.removeProviderVlanInterface(port, ctx, vlanID); err != nil {
+			return fmt.Errorf("failed to remove VLAN internal port %s from external bridge %s: %w", port, ctx.bridge, err)
+		}
+	case providerBridgePortRemoveNic:
+		klog.Infof("removing ovs port %s from bridge %s", port, ctx.bridge)
+		if err := c.removeProviderNic(port, ctx.bridge); err != nil {
+			return fmt.Errorf("failed to remove port %s from external bridge %s: %w", port, ctx.bridge, err)
+		}
+	}
+	klog.Infof("ovs port %s has been removed from bridge %s", port, ctx.bridge)
+	return nil
 }

--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -15,6 +15,41 @@ import (
 
 const gatewayCheckMaxRetry = 200
 
+type providerVlanPortKind uint8
+
+const (
+	providerVlanPortUnrelated providerVlanPortKind = iota
+	providerVlanPortCurrent
+	providerVlanPortLegacy
+	providerVlanPortStale
+)
+
+func classifyProviderVlanPort(portName, bridge string, vlanID int) providerVlanPortKind {
+	currentName := util.VlanInternalPortName(bridge, vlanID)
+	if portName == currentName {
+		return providerVlanPortCurrent
+	}
+	legacyName := fmt.Sprintf("%s-vlan%d", bridge, vlanID)
+	if legacyName != currentName && portName == legacyName {
+		return providerVlanPortLegacy
+	}
+	return providerVlanPortUnrelated
+}
+
+func classifyProviderVlanPortForBridge(portName, bridge string, vlanInterfaceMap map[string]int) (providerVlanPortKind, int, string) {
+	matched, vlanID := util.IsVlanInternalPortForBridge(portName, bridge)
+	if !matched {
+		return providerVlanPortUnrelated, 0, ""
+	}
+
+	for vlanInterface, desiredVlanID := range vlanInterfaceMap {
+		if desiredVlanID == vlanID {
+			return classifyProviderVlanPort(portName, bridge, vlanID), vlanID, vlanInterface
+		}
+	}
+	return providerVlanPortStale, vlanID, ""
+}
+
 func pingGateway(gw, src string, verbose bool, maxRetry int, done chan struct{}) (count int, err error) {
 	pinger, err := goping.NewPinger(gw)
 	if err != nil {
@@ -276,23 +311,31 @@ func (c *Controller) configExternalBridge(provider, bridge, nic string, exchange
 		return fmt.Errorf("failed to list ports of OVS bridge %s, %w: %q", bridge, err, output)
 	}
 	if output != "" {
+		providerNic := nic
+		if exchangeLinkName {
+			providerNic = bridge
+		}
+		vlanInterfaces := make([]string, 0, len(vlanInterfaceMap))
+		for vlanInterface := range vlanInterfaceMap {
+			vlanInterfaces = append(vlanInterfaces, vlanInterface)
+		}
+
 		for port := range strings.SplitSeq(output, "\n") {
 			// Skip the main NIC or VLAN subinterfaces belonging to it
 			if port == nic {
 				klog.Infof("Skipping main NIC port %s on bridge %s", port, bridge)
 				continue
 			}
-			// Check if this port is a VLAN internal port we created (e.g., br-eth0-vlan10)
-			isVlanInternalPort := false
-			for vlanIf, vlanID := range vlanInterfaceMap {
-				expectedInternalPort := fmt.Sprintf("%s-vlan%d", bridge, vlanID)
-				if port == expectedInternalPort {
-					klog.Infof("Preserving VLAN internal port %s for VLAN interface %s on bridge %s", port, vlanIf, bridge)
-					isVlanInternalPort = true
-					break
-				}
+			vlanPortKind, vlanID, vlanInterface := classifyProviderVlanPortForBridge(port, bridge, vlanInterfaceMap)
+			if vlanPortKind == providerVlanPortCurrent {
+				klog.Infof("Preserving VLAN internal port %s for VLAN interface %s on bridge %s", port, vlanInterface, bridge)
+				continue
 			}
-			if isVlanInternalPort {
+			if vlanPortKind == providerVlanPortLegacy || vlanPortKind == providerVlanPortStale {
+				klog.Infof("Removing obsolete VLAN internal port %s from bridge %s", port, bridge)
+				if err = c.removeProviderVlanInterface(port, provider, bridge, providerNic, vlanInterfaces, vlanID); err != nil {
+					return fmt.Errorf("failed to remove obsolete VLAN internal port %s from OVS bridge %s: %w", port, bridge, err)
+				}
 				continue
 			}
 

--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -15,7 +15,10 @@ import (
 
 const gatewayCheckMaxRetry = 200
 
-type providerVlanPortKind uint8
+type (
+	providerVlanPortKind     uint8
+	providerBridgePortAction uint8
+)
 
 const (
 	providerVlanPortUnrelated providerVlanPortKind = iota
@@ -24,6 +27,22 @@ const (
 	providerVlanPortStale
 	providerVlanPortForeign
 )
+
+const (
+	providerBridgePortReject providerBridgePortAction = iota
+	providerBridgePortRemoveVlan
+	providerBridgePortRemoveNic
+)
+
+func providerBridgePortCleanupAction(portName, bridge string, owned bool) providerBridgePortAction {
+	if matched, _ := util.IsVlanInternalPortForBridge(portName, bridge); matched {
+		if owned {
+			return providerBridgePortRemoveVlan
+		}
+		return providerBridgePortReject
+	}
+	return providerBridgePortRemoveNic
+}
 
 func classifyProviderVlanPort(portName, bridge string, vlanID int) providerVlanPortKind {
 	currentName := util.VlanInternalPortName(bridge, vlanID)

--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -22,6 +22,7 @@ const (
 	providerVlanPortCurrent
 	providerVlanPortLegacy
 	providerVlanPortStale
+	providerVlanPortForeign
 )
 
 func classifyProviderVlanPort(portName, bridge string, vlanID int) providerVlanPortKind {
@@ -36,10 +37,13 @@ func classifyProviderVlanPort(portName, bridge string, vlanID int) providerVlanP
 	return providerVlanPortUnrelated
 }
 
-func classifyProviderVlanPortForBridge(portName, bridge string, vlanInterfaceMap map[string]int) (providerVlanPortKind, int, string) {
+func classifyProviderVlanPortForBridge(portName, bridge string, vlanInterfaceMap map[string]int, owned bool) (providerVlanPortKind, int, string) {
 	matched, vlanID := util.IsVlanInternalPortForBridge(portName, bridge)
 	if !matched {
 		return providerVlanPortUnrelated, 0, ""
+	}
+	if !owned {
+		return providerVlanPortForeign, vlanID, ""
 	}
 
 	for vlanInterface, desiredVlanID := range vlanInterfaceMap {
@@ -326,25 +330,25 @@ func (c *Controller) configExternalBridge(provider, bridge, nic string, exchange
 				klog.Infof("Skipping main NIC port %s on bridge %s", port, bridge)
 				continue
 			}
-			vlanPortKind, vlanID, vlanInterface := classifyProviderVlanPortForBridge(port, bridge, vlanInterfaceMap)
+			owned, err := ovs.ValidatePortVendor(port)
+			if err != nil {
+				return fmt.Errorf("failed to check vendor of port %s: %w", port, err)
+			}
+			vlanPortKind, vlanID, vlanInterface := classifyProviderVlanPortForBridge(port, bridge, vlanInterfaceMap, owned)
 			if vlanPortKind == providerVlanPortCurrent {
 				klog.Infof("Preserving VLAN internal port %s for VLAN interface %s on bridge %s", port, vlanInterface, bridge)
 				continue
 			}
 			if vlanPortKind == providerVlanPortLegacy || vlanPortKind == providerVlanPortStale {
 				klog.Infof("Removing obsolete VLAN internal port %s from bridge %s", port, bridge)
-				if err = c.removeProviderVlanInterface(port, provider, bridge, providerNic, vlanInterfaces, vlanID); err != nil {
+				ctx := providerVlanRestoreContext{provider: provider, bridge: bridge, nic: providerNic, vlanInterfaces: vlanInterfaces}
+				if err = c.removeProviderVlanInterface(port, ctx, vlanID); err != nil {
 					return fmt.Errorf("failed to remove obsolete VLAN internal port %s from OVS bridge %s: %w", port, bridge, err)
 				}
 				continue
 			}
 
-			ok, err := ovs.ValidatePortVendor(port)
-			if err != nil {
-				return fmt.Errorf("failed to check vendor of port %s: %w", port, err)
-			}
-
-			if ok {
+			if owned {
 				klog.Infof("Removing unmanaged port %s from bridge %s", port, bridge)
 				if err = c.removeProviderNic(port, bridge); err != nil {
 					return fmt.Errorf("failed to remove port %s from OVS bridge %s: %w", port, bridge, err)

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -2380,19 +2380,21 @@ func (c *Controller) transferVlanAddrsToInternalPort(srcName, dstName string) er
 	if err != nil {
 		return fmt.Errorf("failed to get routes on source %s: %w", srcName, err)
 	}
+	return transferProviderVlanRoutes(dst, routes, netlink.RouteReplace)
+}
 
-	for _, route := range routes {
+func transferProviderVlanRoutes(dst netlink.Link, routes []netlink.Route, routeReplace func(*netlink.Route) error) error {
+	for _, current := range routes {
+		route := current
 		if route.Gw == nil && route.Dst != nil && route.Dst.IP.IsLinkLocalUnicast() {
 			continue
 		}
 		route.LinkIndex = dst.Attrs().Index
-		if err = netlink.RouteReplace(&route); err != nil {
-			klog.Warningf("failed to add/replace route %s to destination %s: %v", route.String(), dstName, err)
-		} else {
-			klog.Infof("route %q has been added/replaced to link %s", route.String(), dstName)
+		if err := routeReplace(&route); err != nil {
+			return fmt.Errorf("failed to add/replace route %s on destination %s: %w", route.String(), dst.Attrs().Name, err)
 		}
+		klog.Infof("route %q has been added/replaced to link %s", route.String(), dst.Attrs().Name)
 	}
-
 	return nil
 }
 

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -2205,16 +2205,20 @@ func (c *Controller) cleanupAutoCreatedVlanInterfaces(providerName, nic string, 
 
 func (c *Controller) configProviderVlanInterfaces(vlanInterfaceMap map[string]int, brName string) error {
 	for vlanIfName, vlanID := range vlanInterfaceMap {
+		internalPortName := util.VlanInternalPortName(brName, vlanID)
+		recordedVlanInterface, err := ovs.Get("Port", internalPortName, "external_ids", providerVlanInterfaceExternalID, true)
+		if err != nil {
+			return fmt.Errorf("failed to get source VLAN interface for OVS port %s: %w", internalPortName, err)
+		}
+		if err := validateProviderVlanPortSource(internalPortName, recordedVlanInterface, vlanIfName); err != nil {
+			return err
+		}
+	}
+
+	for vlanIfName, vlanID := range vlanInterfaceMap {
 		klog.V(3).Infof("configuring VLAN interface %s (VLAN %d) on bridge %s", vlanIfName, vlanID, brName)
 
-		internalPortName := fmt.Sprintf("%s-vlan%d", brName, vlanID)
-
-		args := []string{
-			ovs.MayExist, "add-port", brName, internalPortName,
-			"--", "set", "interface", internalPortName, "type=internal",
-			"--", "set", "port", internalPortName, fmt.Sprintf("tag=%d", vlanID),
-			"external_ids:vendor=" + util.CniTypeName,
-		}
+		internalPortName, args := providerVlanPortArgs(brName, vlanIfName, vlanID)
 
 		if _, err := ovs.Exec(args...); err != nil {
 			klog.Errorf("failed to create OVS internal port %s: %v", internalPortName, err)
@@ -2235,6 +2239,42 @@ func (c *Controller) configProviderVlanInterfaces(vlanInterfaceMap map[string]in
 	}
 
 	return nil
+}
+
+func validateProviderVlanPortSource(portName, recordedVlanInterface, requestedVlanInterface string) error {
+	if !hasRecordedProviderVlanInterface(recordedVlanInterface) || recordedVlanInterface == requestedVlanInterface {
+		return nil
+	}
+	return fmt.Errorf("OVS port %s records source VLAN interface %s, refusing to replace it with %s", portName, recordedVlanInterface, requestedVlanInterface)
+}
+
+func hasRecordedProviderVlanInterface(value string) bool {
+	return value != "" && value != "[]"
+}
+
+func validateProviderVlanInterfaceMap(vlanInterfaceMap map[string]int) error {
+	interfacesByVlanID := make(map[int]string, len(vlanInterfaceMap))
+	for vlanIfName, vlanID := range vlanInterfaceMap {
+		if existing, ok := interfacesByVlanID[vlanID]; ok && existing != vlanIfName {
+			return fmt.Errorf("vlan interfaces %s and %s use the same VLAN ID %d", existing, vlanIfName, vlanID)
+		}
+		interfacesByVlanID[vlanID] = vlanIfName
+	}
+	return nil
+}
+
+const providerVlanInterfaceExternalID = "provider-vlan-interface"
+
+func providerVlanPortArgs(brName, vlanIfName string, vlanID int) (string, []string) {
+	internalPortName := util.VlanInternalPortName(brName, vlanID)
+	args := []string{
+		ovs.MayExist, "add-port", brName, internalPortName,
+		"--", "set", "interface", internalPortName, "type=internal",
+		"--", "set", "port", internalPortName, fmt.Sprintf("tag=%d", vlanID),
+		"external_ids:vendor=" + util.CniTypeName,
+		"external_ids:" + providerVlanInterfaceExternalID + "=" + vlanIfName,
+	}
+	return internalPortName, args
 }
 
 func (c *Controller) transferVlanAddrsToInternalPort(srcName, dstName string) error {
@@ -2297,19 +2337,168 @@ func (c *Controller) transferVlanAddrsToInternalPort(srcName, dstName string) er
 	return nil
 }
 
-func (c *Controller) removeProviderVlanInterface(internalPortName, brName string, vlanID int) error {
-	klog.Infof("Cleaning up VLAN internal port %s (VLAN %d) from bridge %s", internalPortName, vlanID, brName)
-
-	parts := strings.Split(internalPortName, "-vlan")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid VLAN internal port name format: %s", internalPortName)
+func selectProviderVlanSourceInterface(recordedVlanInterface string, vlanInterfaces []string, vlanID int, interfaceExists func(string) bool) (string, error) {
+	if hasRecordedProviderVlanInterface(recordedVlanInterface) {
+		return recordedVlanInterface, nil
 	}
-	baseInterfaceName := strings.TrimPrefix(parts[0], "br-")
+
+	candidates := make([]string, 0, 1)
+	seen := make(map[string]struct{}, len(vlanInterfaces))
+	for _, candidate := range vlanInterfaces {
+		if _, ok := seen[candidate]; ok || !interfaceExists(candidate) {
+			continue
+		}
+		seen[candidate] = struct{}{}
+
+		candidateVlanID, err := util.ExtractVlanIDFromInterface(candidate)
+		if err != nil {
+			return "", fmt.Errorf("failed to extract VLAN ID from interface %s: %w", candidate, err)
+		}
+		if candidateVlanID == vlanID {
+			candidates = append(candidates, candidate)
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		return "", nil
+	case 1:
+		return candidates[0], nil
+	default:
+		return "", fmt.Errorf("multiple interfaces match VLAN %d: %s", vlanID, strings.Join(candidates, ", "))
+	}
+}
+
+func providerVlanRestoreNames(provider, brName, nic, vlanInterface string, vlanID int) (string, string, error) {
+	vlanName := fmt.Sprintf("%s.%d", nic, vlanID)
+	if vlanInterface != "" {
+		candidateVlanID, err := util.ExtractVlanIDFromInterface(vlanInterface)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to extract VLAN ID from interface %s: %w", vlanInterface, err)
+		}
+		if candidateVlanID != vlanID {
+			return "", "", fmt.Errorf("vlan interface %s has VLAN ID %d, expected %d", vlanInterface, candidateVlanID, vlanID)
+		}
+		vlanName = vlanInterface
+	}
+
+	parentName, _, _ := strings.Cut(vlanName, ".")
+	if parentName == nic && brName != util.ExternalBridgeName(provider) {
+		parentName = util.ExternalBridgeName(provider)
+	}
+	return vlanName, parentName, nil
+}
+
+func ensureProviderVlanInterface(parentName, vlanName string, vlanID int) (netlink.Link, error) {
+	vlanLink, vlanErr := netlink.LinkByName(vlanName)
+	if vlanErr != nil {
+		if _, ok := vlanErr.(netlink.LinkNotFoundError); !ok {
+			return nil, fmt.Errorf("failed to get kernel VLAN interface %s: %w", vlanName, vlanErr)
+		}
+	}
+
+	parentLink, err := netlink.LinkByName(parentName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parent interface %s for kernel VLAN %s: %w", parentName, vlanName, err)
+	}
+	if vlanErr == nil {
+		if err := prepareProviderVlanLink(vlanLink, parentLink, vlanID); err != nil {
+			return nil, err
+		}
+		klog.Infof("Kernel VLAN interface %s already exists, using existing interface", vlanName)
+		return vlanLink, nil
+	}
+
+	vlan := &netlink.Vlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        vlanName,
+			ParentIndex: parentLink.Attrs().Index,
+		},
+		VlanId: vlanID,
+	}
+	if err := netlink.LinkAdd(vlan); err != nil {
+		return nil, fmt.Errorf("failed to create kernel VLAN interface %s: %w", vlanName, err)
+	}
+	klog.Infof("Created kernel VLAN interface %s", vlanName)
+
+	vlanLink, err = netlink.LinkByName(vlanName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kernel VLAN interface %s: %w", vlanName, err)
+	}
+	if err := prepareProviderVlanLink(vlanLink, parentLink, vlanID); err != nil {
+		return nil, err
+	}
+	return vlanLink, nil
+}
+
+func prepareProviderVlanLink(vlanLink, parentLink netlink.Link, vlanID int) error {
+	if err := validateProviderVlanLink(vlanLink, parentLink, vlanID); err != nil {
+		return err
+	}
+	if err := netlink.LinkSetUp(vlanLink); err != nil {
+		return fmt.Errorf("failed to set kernel VLAN interface %s up: %w", vlanLink.Attrs().Name, err)
+	}
+	return nil
+}
+
+func validateProviderVlanLink(vlanLink, parentLink netlink.Link, vlanID int) error {
+	vlan, ok := vlanLink.(*netlink.Vlan)
+	if !ok {
+		return fmt.Errorf("restore target %s is a %s link, expected VLAN", vlanLink.Attrs().Name, vlanLink.Type())
+	}
+	if vlan.VlanId != vlanID {
+		return fmt.Errorf("restore target %s has VLAN ID %d, expected %d", vlan.Attrs().Name, vlan.VlanId, vlanID)
+	}
+	if vlan.ParentIndex != parentLink.Attrs().Index {
+		return fmt.Errorf("restore target %s has parent index %d, expected %d for %s", vlan.Attrs().Name, vlan.ParentIndex, parentLink.Attrs().Index, parentLink.Attrs().Name)
+	}
+	return nil
+}
+
+func restoreProviderVlanNetworkState(vlanLink netlink.Link, addrs []netlink.Addr, routes []netlink.Route, addrReplace func(netlink.Link, *netlink.Addr) error, routeReplace func(*netlink.Route) error) error {
+	for _, current := range addrs {
+		if current.IP.IsLinkLocalUnicast() {
+			continue
+		}
+
+		addr := current
+		addr.Label = ""
+		if err := addrReplace(vlanLink, &addr); err != nil {
+			return fmt.Errorf("failed to restore address %s to kernel VLAN %s: %w", addr.String(), vlanLink.Attrs().Name, err)
+		}
+		klog.Infof("Restored address %s to kernel VLAN interface %s", addr.String(), vlanLink.Attrs().Name)
+	}
+
+	for _, scope := range routeScopeOrders {
+		for _, current := range routes {
+			if current.Gw == nil && current.Dst != nil && current.Dst.IP.IsLinkLocalUnicast() {
+				continue
+			}
+			if current.Scope != scope {
+				continue
+			}
+
+			route := current
+			route.LinkIndex = vlanLink.Attrs().Index
+			if err := routeReplace(&route); err != nil {
+				return fmt.Errorf("failed to restore route %s to kernel VLAN %s: %w", route.String(), vlanLink.Attrs().Name, err)
+			}
+			klog.Infof("Restored route %s to kernel VLAN interface %s", route.String(), vlanLink.Attrs().Name)
+		}
+	}
+	return nil
+}
+
+func (c *Controller) removeProviderVlanInterface(internalPortName, provider, brName, nic string, vlanInterfaces []string, vlanID int) error {
+	klog.Infof("Cleaning up VLAN internal port %s (VLAN %d) from bridge %s", internalPortName, vlanID, brName)
 
 	internalPort, err := netlink.LinkByName(internalPortName)
 	if err != nil {
 		if _, ok := err.(netlink.LinkNotFoundError); ok {
-			klog.Warningf("VLAN internal port %s not found, may already be cleaned up", internalPortName)
+			klog.Warningf("VLAN internal port %s not found, removing any stale OVS row", internalPortName)
+			if _, err = ovs.Exec(ovs.IfExists, "del-port", brName, internalPortName); err != nil {
+				return fmt.Errorf("failed to remove stale VLAN internal port %s from OVS bridge %s: %w", internalPortName, brName, err)
+			}
 			return nil
 		}
 		return fmt.Errorf("failed to get VLAN internal port %s: %w", internalPortName, err)
@@ -2325,82 +2514,32 @@ func (c *Controller) removeProviderVlanInterface(internalPortName, brName string
 		return fmt.Errorf("failed to get routes on VLAN internal port %s: %w", internalPortName, err)
 	}
 
+	if len(addrs) > 0 || len(routes) > 0 {
+		recordedVlanInterface, err := ovs.Get("Port", internalPortName, "external_ids", providerVlanInterfaceExternalID, true)
+		if err != nil {
+			return fmt.Errorf("failed to get source VLAN interface for OVS port %s: %w", internalPortName, err)
+		}
+		vlanInterface, err := selectProviderVlanSourceInterface(recordedVlanInterface, vlanInterfaces, vlanID, util.CheckInterfaceExists)
+		if err != nil {
+			return fmt.Errorf("failed to select source interface for VLAN internal port %s: %w", internalPortName, err)
+		}
+		kernelVlanName, baseInterfaceName, err := providerVlanRestoreNames(provider, brName, nic, vlanInterface, vlanID)
+		if err != nil {
+			return fmt.Errorf("failed to determine restore target for VLAN internal port %s: %w", internalPortName, err)
+		}
+		vlanLink, err := ensureProviderVlanInterface(baseInterfaceName, kernelVlanName, vlanID)
+		if err != nil {
+			return err
+		}
+		if err := restoreProviderVlanNetworkState(vlanLink, addrs, routes, netlink.AddrReplace, netlink.RouteReplace); err != nil {
+			return err
+		}
+	}
+
 	if _, err = ovs.Exec(ovs.IfExists, "del-port", brName, internalPortName); err != nil {
 		return fmt.Errorf("failed to remove VLAN internal port %s from OVS bridge %s: %w", internalPortName, brName, err)
 	}
 	klog.Infof("VLAN internal port %s has been removed from bridge %s", internalPortName, brName)
-
-	if len(addrs) > 0 || len(routes) > 0 {
-		kernelVlanName := fmt.Sprintf("%s.%d", baseInterfaceName, vlanID)
-
-		baseLink, err := netlink.LinkByName(baseInterfaceName)
-		if err != nil {
-			klog.Warningf("Base interface %s not found, cannot recreate kernel VLAN %s", baseInterfaceName, kernelVlanName)
-			return nil
-		}
-
-		if _, err := netlink.LinkByName(kernelVlanName); err == nil {
-			klog.Infof("Kernel VLAN interface %s already exists, using existing interface", kernelVlanName)
-		} else {
-			vlan := &netlink.Vlan{
-				LinkAttrs: netlink.LinkAttrs{
-					Name:        kernelVlanName,
-					ParentIndex: baseLink.Attrs().Index,
-				},
-				VlanId: vlanID,
-			}
-
-			if err := netlink.LinkAdd(vlan); err != nil {
-				return fmt.Errorf("failed to create kernel VLAN interface %s: %w", kernelVlanName, err)
-			}
-			klog.Infof("Created kernel VLAN interface %s", kernelVlanName)
-		}
-
-		vlanLink, err := netlink.LinkByName(kernelVlanName)
-		if err != nil {
-			return fmt.Errorf("failed to get kernel VLAN interface %s: %w", kernelVlanName, err)
-		}
-
-		for _, addr := range addrs {
-			if addr.IP.IsLinkLocalUnicast() {
-				continue
-			}
-
-			addr.Label = ""
-			if err := netlink.AddrReplace(vlanLink, &addr); err != nil {
-				klog.Errorf("failed to restore address %s to kernel VLAN %s: %v", addr.String(), kernelVlanName, err)
-			} else {
-				klog.Infof("Restored address %s to kernel VLAN interface %s", addr.String(), kernelVlanName)
-			}
-		}
-
-		if err := netlink.LinkSetUp(vlanLink); err != nil {
-			klog.Errorf("failed to set kernel VLAN interface %s up: %v", kernelVlanName, err)
-		}
-
-		scopeOrders := [...]netlink.Scope{
-			netlink.SCOPE_HOST,
-			netlink.SCOPE_LINK,
-			netlink.SCOPE_SITE,
-			netlink.SCOPE_UNIVERSE,
-		}
-
-		for _, scope := range scopeOrders {
-			for _, route := range routes {
-				if route.Gw == nil && route.Dst != nil && route.Dst.IP.IsLinkLocalUnicast() {
-					continue
-				}
-				if route.Scope == scope {
-					route.LinkIndex = vlanLink.Attrs().Index
-					if err := netlink.RouteReplace(&route); err != nil {
-						klog.Errorf("failed to restore route %s to kernel VLAN %s: %v", route.String(), kernelVlanName, err)
-					} else {
-						klog.Infof("Restored route %s to kernel VLAN interface %s", route.String(), kernelVlanName)
-					}
-				}
-			}
-		}
-	}
 
 	return nil
 }

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -2206,11 +2206,28 @@ func (c *Controller) cleanupAutoCreatedVlanInterfaces(providerName, nic string, 
 func (c *Controller) configProviderVlanInterfaces(vlanInterfaceMap map[string]int, brName string) error {
 	for vlanIfName, vlanID := range vlanInterfaceMap {
 		internalPortName := util.VlanInternalPortName(brName, vlanID)
-		recordedVlanInterface, err := ovs.Get("Port", internalPortName, "external_ids", providerVlanInterfaceExternalID, true)
+		portExists, err := ovs.PortExists(internalPortName)
 		if err != nil {
-			return fmt.Errorf("failed to get source VLAN interface for OVS port %s: %w", internalPortName, err)
+			return fmt.Errorf("failed to check OVS port %s: %w", internalPortName, err)
 		}
-		if err := validateProviderVlanPortSource(internalPortName, recordedVlanInterface, vlanIfName); err != nil {
+		state := providerVlanPortSourceState{exists: portExists}
+		if portExists {
+			state.owned, err = ovs.ValidatePortVendor(internalPortName)
+			if err != nil {
+				return fmt.Errorf("failed to check vendor of OVS port %s: %w", internalPortName, err)
+			}
+			state.recorded, err = ovs.Get("Port", internalPortName, "external_ids", providerVlanInterfaceExternalID, true)
+			if err != nil {
+				return fmt.Errorf("failed to get source VLAN interface for OVS port %s: %w", internalPortName, err)
+			}
+			if state.owned && !hasRecordedProviderVlanInterface(state.recorded) {
+				state.candidates, state.requestedHasState, err = providerVlanSourceCandidates(vlanID, vlanIfName)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if err := validateProviderVlanPortSource(internalPortName, vlanIfName, state); err != nil {
 			return err
 		}
 	}
@@ -2241,11 +2258,69 @@ func (c *Controller) configProviderVlanInterfaces(vlanInterfaceMap map[string]in
 	return nil
 }
 
-func validateProviderVlanPortSource(portName, recordedVlanInterface, requestedVlanInterface string) error {
-	if !hasRecordedProviderVlanInterface(recordedVlanInterface) || recordedVlanInterface == requestedVlanInterface {
+func providerVlanSourceCandidates(vlanID int, requested string) ([]string, bool, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to list kernel VLAN interfaces for VLAN %d: %w", vlanID, err)
+	}
+	candidates := make([]string, 0, 1)
+	requestedHasState := false
+	for _, link := range links {
+		if vlan, ok := link.(*netlink.Vlan); ok && vlan.VlanId == vlanID {
+			candidates = append(candidates, vlan.Attrs().Name)
+			if vlan.Attrs().Name == requested {
+				requestedHasState, err = providerVlanLinkHasNetworkState(vlan)
+				if err != nil {
+					return nil, false, err
+				}
+			}
+		}
+	}
+	return candidates, requestedHasState, nil
+}
+
+func providerVlanLinkHasNetworkState(link netlink.Link) (bool, error) {
+	addrs, err := util.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return false, fmt.Errorf("failed to list addresses on candidate source VLAN interface %s: %w", link.Attrs().Name, err)
+	}
+	if slices.ContainsFunc(addrs, func(addr netlink.Addr) bool { return !addr.IP.IsLinkLocalUnicast() }) {
+		return true, nil
+	}
+	routes, err := netlink.RouteList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return false, fmt.Errorf("failed to list routes on candidate source VLAN interface %s: %w", link.Attrs().Name, err)
+	}
+	return slices.ContainsFunc(routes, func(route netlink.Route) bool {
+		return route.Gw != nil || route.Dst == nil || !route.Dst.IP.IsLinkLocalUnicast()
+	}), nil
+}
+
+type providerVlanPortSourceState struct {
+	exists            bool
+	owned             bool
+	recorded          string
+	candidates        []string
+	requestedHasState bool
+}
+
+func validateProviderVlanPortSource(portName, requestedVlanInterface string, state providerVlanPortSourceState) error {
+	if !state.exists {
 		return nil
 	}
-	return fmt.Errorf("OVS port %s records source VLAN interface %s, refusing to replace it with %s", portName, recordedVlanInterface, requestedVlanInterface)
+	if !state.owned {
+		return fmt.Errorf("OVS port %s already exists but is not owned by %s", portName, util.CniTypeName)
+	}
+	if hasRecordedProviderVlanInterface(state.recorded) {
+		if state.recorded == requestedVlanInterface {
+			return nil
+		}
+		return fmt.Errorf("OVS port %s records source VLAN interface %s, refusing to replace it with %s", portName, state.recorded, requestedVlanInterface)
+	}
+	if len(state.candidates) == 1 && state.candidates[0] == requestedVlanInterface && !state.requestedHasState {
+		return nil
+	}
+	return fmt.Errorf("existing OVS port %s has no recorded source VLAN interface; local VLAN candidates are %v, refusing to adopt %s", portName, state.candidates, requestedVlanInterface)
 }
 
 func hasRecordedProviderVlanInterface(value string) bool {
@@ -2293,24 +2368,8 @@ func (c *Controller) transferVlanAddrsToInternalPort(srcName, dstName string) er
 	if err != nil {
 		return fmt.Errorf("failed to get addresses on source %s: %w", srcName, err)
 	}
-
-	for _, addr := range addrs {
-		if addr.IP.IsLinkLocalUnicast() {
-			continue
-		}
-
-		if err = netlink.AddrDel(src, &addr); err != nil {
-			klog.Warningf("failed to delete address %q on source %s: %v", addr.String(), srcName, err)
-		} else {
-			klog.Infof("address %q has been removed from link %s", addr.String(), srcName)
-		}
-
-		addr.Label = ""
-		addr.PreferedLft, addr.ValidLft = 0, 0
-		if err = netlink.AddrReplace(dst, &addr); err != nil {
-			return fmt.Errorf("failed to replace address %q on destination %s: %w", addr.String(), dstName, err)
-		}
-		klog.Infof("address %q has been added/replaced to link %s", addr.String(), dstName)
+	if err := transferProviderVlanAddresses(src, dst, addrs, netlink.AddrReplace, netlink.AddrDel); err != nil {
+		return err
 	}
 
 	if err = netlink.LinkSetUp(dst); err != nil {
@@ -2334,6 +2393,28 @@ func (c *Controller) transferVlanAddrsToInternalPort(srcName, dstName string) er
 		}
 	}
 
+	return nil
+}
+
+func transferProviderVlanAddresses(src, dst netlink.Link, addrs []netlink.Addr, addrReplace, addrDelete func(netlink.Link, *netlink.Addr) error) error {
+	for _, current := range addrs {
+		addr := current
+		if addr.IP.IsLinkLocalUnicast() {
+			continue
+		}
+
+		addr.Label = ""
+		addr.PreferedLft, addr.ValidLft = 0, 0
+		if err := addrReplace(dst, &addr); err != nil {
+			return fmt.Errorf("failed to replace address %q on destination %s: %w", addr.String(), dst.Attrs().Name, err)
+		}
+		klog.Infof("address %q has been added/replaced to link %s", addr.String(), dst.Attrs().Name)
+
+		if err := addrDelete(src, &current); err != nil {
+			return fmt.Errorf("failed to delete address %q on source %s after copying it to %s: %w", current.String(), src.Attrs().Name, dst.Attrs().Name, err)
+		}
+		klog.Infof("address %q has been removed from link %s", current.String(), src.Attrs().Name)
+	}
 	return nil
 }
 
@@ -2369,8 +2450,15 @@ func selectProviderVlanSourceInterface(recordedVlanInterface string, vlanInterfa
 	}
 }
 
-func providerVlanRestoreNames(provider, brName, nic, vlanInterface string, vlanID int) (string, string, error) {
-	vlanName := fmt.Sprintf("%s.%d", nic, vlanID)
+type providerVlanRestoreContext struct {
+	provider       string
+	bridge         string
+	nic            string
+	vlanInterfaces []string
+}
+
+func providerVlanRestoreNames(ctx providerVlanRestoreContext, vlanInterface string, vlanID int) (string, string, error) {
+	vlanName := fmt.Sprintf("%s.%d", ctx.nic, vlanID)
 	if vlanInterface != "" {
 		candidateVlanID, err := util.ExtractVlanIDFromInterface(vlanInterface)
 		if err != nil {
@@ -2383,8 +2471,8 @@ func providerVlanRestoreNames(provider, brName, nic, vlanInterface string, vlanI
 	}
 
 	parentName, _, _ := strings.Cut(vlanName, ".")
-	if parentName == nic && brName != util.ExternalBridgeName(provider) {
-		parentName = util.ExternalBridgeName(provider)
+	if parentName == ctx.nic && ctx.bridge != util.ExternalBridgeName(ctx.provider) {
+		parentName = util.ExternalBridgeName(ctx.provider)
 	}
 	return vlanName, parentName, nil
 }
@@ -2489,15 +2577,15 @@ func restoreProviderVlanNetworkState(vlanLink netlink.Link, addrs []netlink.Addr
 	return nil
 }
 
-func (c *Controller) removeProviderVlanInterface(internalPortName, provider, brName, nic string, vlanInterfaces []string, vlanID int) error {
-	klog.Infof("Cleaning up VLAN internal port %s (VLAN %d) from bridge %s", internalPortName, vlanID, brName)
+func (c *Controller) removeProviderVlanInterface(internalPortName string, ctx providerVlanRestoreContext, vlanID int) error {
+	klog.Infof("Cleaning up VLAN internal port %s (VLAN %d) from bridge %s", internalPortName, vlanID, ctx.bridge)
 
 	internalPort, err := netlink.LinkByName(internalPortName)
 	if err != nil {
 		if _, ok := err.(netlink.LinkNotFoundError); ok {
 			klog.Warningf("VLAN internal port %s not found, removing any stale OVS row", internalPortName)
-			if _, err = ovs.Exec(ovs.IfExists, "del-port", brName, internalPortName); err != nil {
-				return fmt.Errorf("failed to remove stale VLAN internal port %s from OVS bridge %s: %w", internalPortName, brName, err)
+			if _, err = ovs.Exec(ovs.IfExists, "del-port", ctx.bridge, internalPortName); err != nil {
+				return fmt.Errorf("failed to remove stale VLAN internal port %s from OVS bridge %s: %w", internalPortName, ctx.bridge, err)
 			}
 			return nil
 		}
@@ -2519,11 +2607,11 @@ func (c *Controller) removeProviderVlanInterface(internalPortName, provider, brN
 		if err != nil {
 			return fmt.Errorf("failed to get source VLAN interface for OVS port %s: %w", internalPortName, err)
 		}
-		vlanInterface, err := selectProviderVlanSourceInterface(recordedVlanInterface, vlanInterfaces, vlanID, util.CheckInterfaceExists)
+		vlanInterface, err := selectProviderVlanSourceInterface(recordedVlanInterface, ctx.vlanInterfaces, vlanID, util.CheckInterfaceExists)
 		if err != nil {
 			return fmt.Errorf("failed to select source interface for VLAN internal port %s: %w", internalPortName, err)
 		}
-		kernelVlanName, baseInterfaceName, err := providerVlanRestoreNames(provider, brName, nic, vlanInterface, vlanID)
+		kernelVlanName, baseInterfaceName, err := providerVlanRestoreNames(ctx, vlanInterface, vlanID)
 		if err != nil {
 			return fmt.Errorf("failed to determine restore target for VLAN internal port %s: %w", internalPortName, err)
 		}
@@ -2536,10 +2624,10 @@ func (c *Controller) removeProviderVlanInterface(internalPortName, provider, brN
 		}
 	}
 
-	if _, err = ovs.Exec(ovs.IfExists, "del-port", brName, internalPortName); err != nil {
-		return fmt.Errorf("failed to remove VLAN internal port %s from OVS bridge %s: %w", internalPortName, brName, err)
+	if _, err = ovs.Exec(ovs.IfExists, "del-port", ctx.bridge, internalPortName); err != nil {
+		return fmt.Errorf("failed to remove VLAN internal port %s from OVS bridge %s: %w", internalPortName, ctx.bridge, err)
 	}
-	klog.Infof("VLAN internal port %s has been removed from bridge %s", internalPortName, brName)
+	klog.Infof("VLAN internal port %s has been removed from bridge %s", internalPortName, ctx.bridge)
 
 	return nil
 }

--- a/pkg/daemon/ovs_linux_test.go
+++ b/pkg/daemon/ovs_linux_test.go
@@ -219,6 +219,20 @@ func TestTransferProviderVlanAddressesPreservesSourceUntilDestinationReady(t *te
 	require.ErrorIs(t, err, deleteErr)
 }
 
+func TestTransferProviderVlanRoutesReturnsDestinationFailure(t *testing.T) {
+	t.Parallel()
+
+	dst := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "kv20-l2bvmi7mc4", Index: 21}}
+	_, network, err := net.ParseCIDR("198.51.100.0/24")
+	require.NoError(t, err)
+	replaceErr := errors.New("replace route")
+
+	err = transferProviderVlanRoutes(dst, []netlink.Route{{Dst: network, Scope: netlink.SCOPE_UNIVERSE}}, func(*netlink.Route) error {
+		return replaceErr
+	})
+	require.ErrorIs(t, err, replaceErr)
+}
+
 func TestSelectProviderVlanSourceInterface(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/daemon/ovs_linux_test.go
+++ b/pkg/daemon/ovs_linux_test.go
@@ -76,7 +76,8 @@ func TestProviderVlanRestoreNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			vlanName, parentName, err := providerVlanRestoreNames(tt.provider, tt.bridge, tt.nic, tt.vlanInterface, tt.vlanID)
+			ctx := providerVlanRestoreContext{provider: tt.provider, bridge: tt.bridge, nic: tt.nic}
+			vlanName, parentName, err := providerVlanRestoreNames(ctx, tt.vlanInterface, tt.vlanID)
 			if tt.wantError {
 				require.Error(t, err)
 				return
@@ -112,10 +113,23 @@ func TestValidateProviderVlanInterfaceMap(t *testing.T) {
 func TestValidateProviderVlanPortSource(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "", "bond0.20"))
-	require.NoError(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "[]", "bond0.20"))
-	require.NoError(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "bond0.20", "bond0.20"))
-	require.Error(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "bond0.20", "eth0.20"))
+	require.NoError(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "bond0.20", providerVlanPortSourceState{}))
+	require.Error(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "bond0.20", providerVlanPortSourceState{exists: true}))
+	require.NoError(t, validateProviderVlanPortSource("br-e-vlan20", "bond0.20", providerVlanPortSourceState{
+		exists: true, owned: true, recorded: "[]", candidates: []string{"bond0.20"},
+	}))
+	require.Error(t, validateProviderVlanPortSource("br-e-vlan20", "eth0.20", providerVlanPortSourceState{
+		exists: true, owned: true, candidates: []string{"eth0.20"}, requestedHasState: true,
+	}))
+	require.Error(t, validateProviderVlanPortSource("br-e-vlan20", "eth0.20", providerVlanPortSourceState{
+		exists: true, owned: true, candidates: []string{"bond0.20", "eth0.20"},
+	}))
+	require.NoError(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "bond0.20", providerVlanPortSourceState{
+		exists: true, owned: true, recorded: "bond0.20",
+	}))
+	require.Error(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "eth0.20", providerVlanPortSourceState{
+		exists: true, owned: true, recorded: "bond0.20",
+	}))
 }
 
 func TestValidateProviderVlanLink(t *testing.T) {
@@ -163,6 +177,46 @@ func TestRestoreProviderVlanNetworkStateReturnsError(t *testing.T) {
 		func(*netlink.Route) error { return routeErr },
 	)
 	require.ErrorIs(t, err, routeErr)
+}
+
+func TestTransferProviderVlanAddressesPreservesSourceUntilDestinationReady(t *testing.T) {
+	t.Parallel()
+
+	src := &netlink.Vlan{LinkAttrs: netlink.LinkAttrs{Name: "bond0.20", Index: 20}, VlanId: 20}
+	dst := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "kv20-l2bvmi7mc4", Index: 21}}
+	addr := netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("192.0.2.10"), Mask: net.CIDRMask(24, 32)}}
+	replaceErr := errors.New("replace address")
+	deleted := false
+
+	err := transferProviderVlanAddresses(src, dst, []netlink.Addr{addr},
+		func(netlink.Link, *netlink.Addr) error { return replaceErr },
+		func(netlink.Link, *netlink.Addr) error {
+			deleted = true
+			return nil
+		},
+	)
+	require.ErrorIs(t, err, replaceErr)
+	require.False(t, deleted, "source address must remain when destination setup fails")
+
+	steps := make([]string, 0, 2)
+	require.NoError(t, transferProviderVlanAddresses(src, dst, []netlink.Addr{addr},
+		func(netlink.Link, *netlink.Addr) error {
+			steps = append(steps, "replace-destination")
+			return nil
+		},
+		func(netlink.Link, *netlink.Addr) error {
+			steps = append(steps, "delete-source")
+			return nil
+		},
+	))
+	require.Equal(t, []string{"replace-destination", "delete-source"}, steps)
+
+	deleteErr := errors.New("delete source address")
+	err = transferProviderVlanAddresses(src, dst, []netlink.Addr{addr},
+		func(netlink.Link, *netlink.Addr) error { return nil },
+		func(netlink.Link, *netlink.Addr) error { return deleteErr },
+	)
+	require.ErrorIs(t, err, deleteErr)
 }
 
 func TestSelectProviderVlanSourceInterface(t *testing.T) {

--- a/pkg/daemon/ovs_linux_test.go
+++ b/pkg/daemon/ovs_linux_test.go
@@ -1,10 +1,222 @@
 package daemon
 
 import (
+	"errors"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func TestProviderVlanRestoreNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		provider       string
+		bridge         string
+		nic            string
+		vlanInterface  string
+		vlanID         int
+		wantVlanName   string
+		wantParentName string
+		wantError      bool
+	}{
+		{
+			name:           "default bridge",
+			provider:       "underlay",
+			bridge:         "br-underlay",
+			nic:            "enp16s0f0",
+			vlanID:         500,
+			wantVlanName:   "enp16s0f0.500",
+			wantParentName: "enp16s0f0",
+		},
+		{
+			name:           "explicit VLAN interface",
+			provider:       "underlay",
+			bridge:         "br-underlay",
+			nic:            "eth0",
+			vlanInterface:  "bond0.20",
+			vlanID:         20,
+			wantVlanName:   "bond0.20",
+			wantParentName: "bond0",
+		},
+		{
+			name:          "invalid explicit VLAN interface",
+			provider:      "underlay",
+			bridge:        "br-underlay",
+			nic:           "eth0",
+			vlanInterface: "bond0.invalid",
+			vlanID:        20,
+			wantError:     true,
+		},
+		{
+			name:          "mismatched explicit VLAN interface",
+			provider:      "underlay",
+			bridge:        "br-underlay",
+			nic:           "eth0",
+			vlanInterface: "bond0.21",
+			vlanID:        20,
+			wantError:     true,
+		},
+		{
+			name:           "exchanged link name",
+			provider:       "underlay",
+			bridge:         "enp16s0f0",
+			nic:            "enp16s0f0",
+			vlanID:         500,
+			wantVlanName:   "enp16s0f0.500",
+			wantParentName: "br-underlay",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			vlanName, parentName, err := providerVlanRestoreNames(tt.provider, tt.bridge, tt.nic, tt.vlanInterface, tt.vlanID)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantVlanName, vlanName)
+			require.Equal(t, tt.wantParentName, parentName)
+		})
+	}
+}
+
+func TestProviderVlanPortArgsRecordsSourceInterface(t *testing.T) {
+	t.Parallel()
+
+	portName, args := providerVlanPortArgs("br-underlay", "bond0.20", 20)
+	require.Equal(t, util.VlanInternalPortName("br-underlay", 20), portName)
+	require.Contains(t, args, "external_ids:provider-vlan-interface=bond0.20")
+}
+
+func TestValidateProviderVlanInterfaceMap(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateProviderVlanInterfaceMap(map[string]int{
+		"eth0.20":  20,
+		"bond0.30": 30,
+	}))
+	require.Error(t, validateProviderVlanInterfaceMap(map[string]int{
+		"eth0.20":  20,
+		"bond0.20": 20,
+	}))
+}
+
+func TestValidateProviderVlanPortSource(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "", "bond0.20"))
+	require.NoError(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "[]", "bond0.20"))
+	require.NoError(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "bond0.20", "bond0.20"))
+	require.Error(t, validateProviderVlanPortSource("kv20-l2bvmi7mc4", "bond0.20", "eth0.20"))
+}
+
+func TestValidateProviderVlanLink(t *testing.T) {
+	t.Parallel()
+
+	parent := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "bond0", Index: 10}}
+	valid := &netlink.Vlan{
+		LinkAttrs: netlink.LinkAttrs{Name: "bond0.20", ParentIndex: 10},
+		VlanId:    20,
+	}
+	require.NoError(t, validateProviderVlanLink(valid, parent, 20))
+	require.Error(t, validateProviderVlanLink(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "bond0.20"}}, parent, 20))
+
+	wrongVlanID := *valid
+	wrongVlanID.VlanId = 21
+	require.Error(t, validateProviderVlanLink(&wrongVlanID, parent, 20))
+
+	wrongParent := *valid
+	wrongParent.ParentIndex = 11
+	require.Error(t, validateProviderVlanLink(&wrongParent, parent, 20))
+}
+
+func TestRestoreProviderVlanNetworkStateReturnsError(t *testing.T) {
+	t.Parallel()
+
+	vlanLink := &netlink.Vlan{LinkAttrs: netlink.LinkAttrs{Name: "bond0.20", Index: 20}, VlanId: 20}
+	addr := netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("192.0.2.10"), Mask: net.CIDRMask(24, 32)}}
+	_, dst, err := net.ParseCIDR("198.51.100.0/24")
+	require.NoError(t, err)
+	route := netlink.Route{Dst: dst, Scope: netlink.SCOPE_UNIVERSE}
+
+	addrErr := errors.New("replace address")
+	err = restoreProviderVlanNetworkState(vlanLink, []netlink.Addr{addr}, []netlink.Route{route},
+		func(netlink.Link, *netlink.Addr) error { return addrErr },
+		func(*netlink.Route) error {
+			t.Fatal("route replacement must not run after address failure")
+			return nil
+		},
+	)
+	require.ErrorIs(t, err, addrErr)
+
+	routeErr := errors.New("replace route")
+	err = restoreProviderVlanNetworkState(vlanLink, []netlink.Addr{addr}, []netlink.Route{route},
+		func(netlink.Link, *netlink.Addr) error { return nil },
+		func(*netlink.Route) error { return routeErr },
+	)
+	require.ErrorIs(t, err, routeErr)
+}
+
+func TestSelectProviderVlanSourceInterface(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		recorded      string
+		candidates    []string
+		existing      map[string]bool
+		wantInterface string
+		wantError     bool
+	}{
+		{
+			name:          "recorded interface survives spec update",
+			recorded:      "bond0.20",
+			candidates:    []string{"eth0.20"},
+			existing:      map[string]bool{"eth0.20": true},
+			wantInterface: "bond0.20",
+		},
+		{
+			name:          "unique local explicit interface",
+			candidates:    []string{"eth0.20", "bond0.20"},
+			existing:      map[string]bool{"bond0.20": true},
+			wantInterface: "bond0.20",
+		},
+		{
+			name:       "ambiguous local explicit interfaces",
+			candidates: []string{"eth0.20", "bond0.20"},
+			existing:   map[string]bool{"eth0.20": true, "bond0.20": true},
+			wantError:  true,
+		},
+		{
+			name:       "no local explicit interface",
+			candidates: []string{"eth0.20", "bond0.20"},
+			existing:   map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := selectProviderVlanSourceInterface(tt.recorded, tt.candidates, 20, func(name string) bool {
+				return tt.existing[name]
+			})
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantInterface, got)
+		})
+	}
+}
 
 func TestWaitNetworkReady_IPGatewayMismatch(t *testing.T) {
 	tests := []struct {

--- a/pkg/daemon/ovs_test.go
+++ b/pkg/daemon/ovs_test.go
@@ -40,3 +40,12 @@ func TestClassifyProviderVlanPortForBridge(t *testing.T) {
 	require.Equal(t, 20, vlanID)
 	require.Empty(t, vlanInterface)
 }
+
+func TestProviderBridgePortCleanupAction(t *testing.T) {
+	t.Parallel()
+
+	const bridge = "br-underlay"
+	require.Equal(t, providerBridgePortReject, providerBridgePortCleanupAction("br-underlay-vlan20", bridge, false))
+	require.Equal(t, providerBridgePortRemoveVlan, providerBridgePortCleanupAction("br-underlay-vlan20", bridge, true))
+	require.Equal(t, providerBridgePortRemoveNic, providerBridgePortCleanupAction("eth0", bridge, false))
+}

--- a/pkg/daemon/ovs_test.go
+++ b/pkg/daemon/ovs_test.go
@@ -49,3 +49,10 @@ func TestProviderBridgePortCleanupAction(t *testing.T) {
 	require.Equal(t, providerBridgePortRemoveVlan, providerBridgePortCleanupAction("br-underlay-vlan20", bridge, true))
 	require.Equal(t, providerBridgePortRemoveNic, providerBridgePortCleanupAction("eth0", bridge, false))
 }
+
+func TestProviderBridgePorts(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, providerBridgePorts(""))
+	require.Equal(t, []string{"eth0", "br-underlay-vlan20"}, providerBridgePorts("eth0\nbr-underlay-vlan20"))
+}

--- a/pkg/daemon/ovs_test.go
+++ b/pkg/daemon/ovs_test.go
@@ -25,13 +25,18 @@ func TestClassifyProviderVlanPortForBridge(t *testing.T) {
 
 	vlanInterfaces := map[string]int{"bond0.20": 20}
 
-	kind, vlanID, vlanInterface := classifyProviderVlanPortForBridge(util.VlanInternalPortName("br-underlay", 20), "br-underlay", vlanInterfaces)
+	kind, vlanID, vlanInterface := classifyProviderVlanPortForBridge(util.VlanInternalPortName("br-underlay", 20), "br-underlay", vlanInterfaces, true)
 	require.Equal(t, providerVlanPortCurrent, kind)
 	require.Equal(t, 20, vlanID)
 	require.Equal(t, "bond0.20", vlanInterface)
 
-	kind, vlanID, vlanInterface = classifyProviderVlanPortForBridge(util.VlanInternalPortName("br-underlay", 30), "br-underlay", vlanInterfaces)
+	kind, vlanID, vlanInterface = classifyProviderVlanPortForBridge(util.VlanInternalPortName("br-underlay", 30), "br-underlay", vlanInterfaces, true)
 	require.Equal(t, providerVlanPortStale, kind)
 	require.Equal(t, 30, vlanID)
+	require.Empty(t, vlanInterface)
+
+	kind, vlanID, vlanInterface = classifyProviderVlanPortForBridge("br-underlay-vlan20", "br-underlay", vlanInterfaces, false)
+	require.Equal(t, providerVlanPortForeign, kind)
+	require.Equal(t, 20, vlanID)
 	require.Empty(t, vlanInterface)
 }

--- a/pkg/daemon/ovs_test.go
+++ b/pkg/daemon/ovs_test.go
@@ -1,0 +1,37 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestClassifyProviderVlanPort(t *testing.T) {
+	t.Parallel()
+
+	bridge := "br-underlay"
+	const vlanID = 500
+
+	require.Equal(t, providerVlanPortCurrent, classifyProviderVlanPort("kv500-l2bvmi7mc", bridge, vlanID))
+	require.Equal(t, providerVlanPortLegacy, classifyProviderVlanPort("br-underlay-vlan500", bridge, vlanID))
+	require.Equal(t, providerVlanPortCurrent, classifyProviderVlanPort("br-e-vlan10", "br-e", 10))
+	require.Equal(t, providerVlanPortUnrelated, classifyProviderVlanPort("enp16s0f0", bridge, vlanID))
+}
+
+func TestClassifyProviderVlanPortForBridge(t *testing.T) {
+	t.Parallel()
+
+	vlanInterfaces := map[string]int{"bond0.20": 20}
+
+	kind, vlanID, vlanInterface := classifyProviderVlanPortForBridge(util.VlanInternalPortName("br-underlay", 20), "br-underlay", vlanInterfaces)
+	require.Equal(t, providerVlanPortCurrent, kind)
+	require.Equal(t, 20, vlanID)
+	require.Equal(t, "bond0.20", vlanInterface)
+
+	kind, vlanID, vlanInterface = classifyProviderVlanPortForBridge(util.VlanInternalPortName("br-underlay", 30), "br-underlay", vlanInterfaces)
+	require.Equal(t, providerVlanPortStale, kind)
+	require.Equal(t, 30, vlanID)
+	require.Empty(t, vlanInterface)
+}

--- a/pkg/util/vlan_interfaces.go
+++ b/pkg/util/vlan_interfaces.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"crypto/sha256"
+	"encoding/base32"
 	"fmt"
 	"strconv"
 	"strings"
@@ -8,6 +10,24 @@ import (
 	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 )
+
+const linuxInterfaceNameMaxLength = 15
+
+var vlanInternalPortHashEncoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
+
+// VlanInternalPortName returns a deterministic OVS internal interface name that
+// fits Linux's IFNAMSIZ limit while preserving existing compatible names.
+func VlanInternalPortName(bridgeName string, vlanID int) string {
+	name := fmt.Sprintf("%s-vlan%d", bridgeName, vlanID)
+	if len(name) <= linuxInterfaceNameMaxLength {
+		return name
+	}
+
+	prefix := fmt.Sprintf("kv%d-", vlanID)
+	digest := sha256.Sum256([]byte(bridgeName))
+	hash := vlanInternalPortHashEncoding.EncodeToString(digest[:])
+	return prefix + hash[:linuxInterfaceNameMaxLength-len(prefix)]
+}
 
 func DetectVlanInterfaces(parentInterface string) []int {
 	vlanIDs := make([]int, 0)
@@ -82,23 +102,61 @@ func FindKubeOVNAutoCreatedInterfaces(providerName string) ([]string, error) {
 }
 
 func IsVlanInternalPort(portName string) (bool, int) {
-	if !strings.Contains(portName, "-vlan") {
+	if matched, vlanID := isCompactVlanInternalPort(portName); matched {
+		return true, vlanID
+	}
+
+	separatorIndex := strings.LastIndex(portName, "-vlan")
+	if separatorIndex == -1 || !strings.HasPrefix(portName[:separatorIndex], "br-") {
+		return false, 0
+	}
+	return parseVlanID(portName[separatorIndex+len("-vlan"):])
+}
+
+// IsVlanInternalPortForBridge reports whether portName is a compact or legacy
+// VLAN internal port created for bridgeName.
+func IsVlanInternalPortForBridge(portName, bridgeName string) (bool, int) {
+	if matched, vlanID := isCompactVlanInternalPort(portName); matched {
+		if portName == VlanInternalPortName(bridgeName, vlanID) {
+			return true, vlanID
+		}
 		return false, 0
 	}
 
-	parts := strings.Split(portName, "-vlan")
-	if len(parts) != 2 {
+	vlanIDText, found := strings.CutPrefix(portName, bridgeName+"-vlan")
+	if !found {
 		return false, 0
 	}
+	return parseVlanID(vlanIDText)
+}
 
-	if !strings.HasPrefix(parts[0], "br-") {
+func isCompactVlanInternalPort(portName string) (bool, int) {
+	if len(portName) == linuxInterfaceNameMaxLength && strings.HasPrefix(portName, "kv") {
+		vlanIDText, hash, found := strings.Cut(portName[2:], "-")
+		if !found || !isLowerBase32(hash) {
+			return false, 0
+		}
+		return parseVlanID(vlanIDText)
+	}
+	return false, 0
+}
+
+func parseVlanID(value string) (bool, int) {
+	vlanID, err := strconv.Atoi(value)
+	if err != nil || vlanID < 0 || vlanID > 4095 {
 		return false, 0
 	}
-
-	vlanID, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return false, 0
-	}
-
 	return true, vlanID
+}
+
+func isLowerBase32(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if (char < 'a' || char > 'z') && (char < '2' || char > '7') {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/util/vlan_interfaces_test.go
+++ b/pkg/util/vlan_interfaces_test.go
@@ -181,3 +181,133 @@ func TestExtractVlanIDFromInterface(t *testing.T) {
 		})
 	}
 }
+
+func TestVlanInternalPortName(t *testing.T) {
+	tests := []struct {
+		name       string
+		bridgeName string
+		vlanID     int
+		want       string
+	}{
+		{
+			name:       "preserves compatible name",
+			bridgeName: "br-eth0",
+			vlanID:     10,
+			want:       "br-eth0-vlan10",
+		},
+		{
+			name:       "shortens name exceeding Linux limit",
+			bridgeName: "br-underlay",
+			vlanID:     500,
+			want:       "kv500-l2bvmi7mc",
+		},
+		{
+			name:       "fits maximum VLAN ID",
+			bridgeName: "br-underlay",
+			vlanID:     4094,
+			want:       "kv4094-l2bvmi7m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := VlanInternalPortName(tt.bridgeName, tt.vlanID)
+			if got != tt.want {
+				t.Fatalf("VlanInternalPortName() = %q, want %q", got, tt.want)
+			}
+			if len(got) > linuxInterfaceNameMaxLength {
+				t.Fatalf("VlanInternalPortName() length = %d, want at most %d", len(got), linuxInterfaceNameMaxLength)
+			}
+		})
+	}
+}
+
+func TestIsVlanInternalPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		portName string
+		matched  bool
+		vlanID   int
+	}{
+		{
+			name:     "legacy name",
+			portName: "br-eth0-vlan10",
+			matched:  true,
+			vlanID:   10,
+		},
+		{
+			name:     "short name",
+			portName: "kv500-l2bvmi7mc",
+			matched:  true,
+			vlanID:   500,
+		},
+		{
+			name:     "invalid short name hash",
+			portName: "kv500-notbase3!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, vlanID := IsVlanInternalPort(tt.portName)
+			if matched != tt.matched || vlanID != tt.vlanID {
+				t.Fatalf("IsVlanInternalPort() = (%t, %d), want (%t, %d)", matched, vlanID, tt.matched, tt.vlanID)
+			}
+		})
+	}
+}
+
+func TestIsVlanInternalPortForBridge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		portName string
+		bridge   string
+		matched  bool
+		vlanID   int
+	}{
+		{
+			name:     "exchange link name legacy port",
+			portName: "enp16s0f0-vlan500",
+			bridge:   "enp16s0f0",
+			matched:  true,
+			vlanID:   500,
+		},
+		{
+			name:     "compact port",
+			portName: "kv500-l2bvmi7mc",
+			bridge:   "br-underlay",
+			matched:  true,
+			vlanID:   500,
+		},
+		{
+			name:     "compact priority-tag VLAN",
+			portName: VlanInternalPortName("br-underlay", 0),
+			bridge:   "br-underlay",
+			matched:  true,
+		},
+		{
+			name:     "compact maximum API VLAN",
+			portName: VlanInternalPortName("br-underlay", 4095),
+			bridge:   "br-underlay",
+			matched:  true,
+			vlanID:   4095,
+		},
+		{
+			name:     "different bridge legacy port",
+			portName: "enp16s0f0-vlan500",
+			bridge:   "enp17s0f0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matched, vlanID := IsVlanInternalPortForBridge(tt.portName, tt.bridge)
+			if matched != tt.matched || vlanID != tt.vlanID {
+				t.Fatalf("IsVlanInternalPortForBridge() = (%t, %d), want (%t, %d)", matched, vlanID, tt.matched, tt.vlanID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- preserve existing provider VLAN internal port names when they fit Linux IFNAMSIZ
- use `kv<vlanID>-<lower-base32(SHA256(bridgeName))>` when the legacy name exceeds 15 bytes
- remove stale overlong legacy OVS rows without treating them as host NICs during reconciliation
- recognize compact and exact bridge-scoped legacy names during cleanup, including `exchangeLinkName`
- record the actual source VLAN interface on each OVS port and restore addresses and routes to that source during cleanup
- reject source changes and ambiguous legacy adoption when an existing port cannot be safely attributed
- migrate addresses destination-first and propagate route failures so reconciliation remains retryable
- reject foreign VLAN-shaped OVS ports during bridge teardown instead of deleting or adopting them
- validate restore-target VLAN type, ID, parent, and link-up state before deleting an internal port
- restore all addresses and routes to the validated target before deleting the internal port

The compact format keeps the VLAN ID readable, identifies Kube-OVN VLAN ports with the `kv` prefix, groups ports from the same provider by hash suffix, and retains at least 40 bits of bridge identity for valid VLAN IDs.

## Root cause

Provider VLAN internal ports used `br-<provider>-vlan<id>` as kernel interface names. Long provider names exceeded Linux IFNAMSIZ, leaving an OVS Interface row whose internal netdevice could not be created.

Upgrade reconciliation must distinguish Kube-OVN-owned ports from foreign ports, safely adopt pre-metadata ports, and preserve network state across partial netlink failures. Cleanup also cannot infer the source interface from current cluster-wide `spec.vlanInterfaces`: different nodes can select different interfaces, and the spec can change after setup. The fix persists the selected source in OVS, validates legacy adoption and restore targets, migrates state in retry-safe order, and prevents bridge deletion when a foreign VLAN-shaped port is present.

## Upgrade scenarios covered

- existing short legacy port remains unchanged and gains source metadata only after safe ownership/source validation
- existing long legacy OVS-only row is removed without moving bridge state to a nonexistent host NIC
- daemon restart after partial address or route migration retries without losing source state
- `spec.vlanInterfaces` changes cannot overwrite a previously recorded source
- ambiguous legacy sources and foreign same-name ports fail closed
- cleanup restores state to recorded source, including `exchangeLinkName` mappings
- route restore or migration failures keep ProviderNetwork reconciliation retryable

## Tests

- `go test ./pkg/util ./pkg/daemon -count=1`
- `go test -race ./pkg/daemon -run 'Test(ProviderVlanRestoreNames|ValidateProviderVlanPortSource|TransferProviderVlanAddressesPreservesSourceUntilDestinationReady|TransferProviderVlanRoutesReturnsDestinationFailure|ProviderBridgePortCleanupAction|ClassifyProviderVlanPortForBridge|RestoreProviderVlanNetworkStateReturnsError|SelectProviderVlanSourceInterface)$' -count=1`
- `go vet ./pkg/util/... ./pkg/daemon/...`
- `golangci-lint run ./pkg/util/... ./pkg/daemon/...`
- `golangci-lint run --enable-only modernize ./pkg/util/... ./pkg/daemon/...`

Full-repository `make lint` reached the enforced 2 GiB local memory limit; scoped packages pass all configured linters, and GitHub Actions runs full checks.

Fixes #7196
