### PR TITLE
controller: record VLAN resource events

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -232,7 +232,7 @@ type Controller struct {
 	vlansLister     kubeovnlister.VlanLister
 	vlanSynced      cache.InformerSynced
 	addVlanQueue    workqueue.TypedRateLimitingInterface[string]
-	delVlanQueue    workqueue.TypedRateLimitingInterface[string]
+	delVlanQueue    workqueue.TypedRateLimitingInterface[*kubeovnv1.Vlan]
 	updateVlanQueue workqueue.TypedRateLimitingInterface[string]
 	vlanKeyMutex    keymutex.KeyMutex
 
@@ -585,7 +585,7 @@ func Run(ctx context.Context, config *Configuration) {
 		vlansLister:     vlanInformer.Lister(),
 		vlanSynced:      vlanInformer.Informer().HasSynced,
 		addVlanQueue:    newTypedRateLimitingQueue[string]("AddVlan", nil),
-		delVlanQueue:    newTypedRateLimitingQueue[string]("DeleteVlan", nil),
+		delVlanQueue:    newTypedRateLimitingQueue[*kubeovnv1.Vlan]("DeleteVlan", nil),
 		updateVlanQueue: newTypedRateLimitingQueue[string]("UpdateVlan", nil),
 		vlanKeyMutex:    keymutex.NewHashed(numKeyLocks),
 

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -87,7 +87,7 @@ func (c *Controller) enqueueDelVlan(obj any) {
 
 	key := cache.MetaObjectToName(vlan).String()
 	klog.V(3).Infof("enqueue delete vlan %s", key)
-	c.delVlanQueue.Add(key)
+	c.delVlanQueue.Add(vlan)
 }
 
 func (c *Controller) handleAddVlan(key string) error {
@@ -283,11 +283,11 @@ func (c *Controller) handleUpdateVlan(key string) error {
 	return nil
 }
 
-func (c *Controller) handleDelVlan(key string) error {
+func (c *Controller) handleDelVlan(vlan *kubeovnv1.Vlan) error {
+	key := cache.MetaObjectToName(vlan).String()
 	c.vlanKeyMutex.LockKey(key)
 	defer func() { _ = c.vlanKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle delete vlan %s", key)
-	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: key}}
 
 	subnet, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -15,6 +16,25 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func (c *Controller) recordVlanEvent(vlan *kubeovnv1.Vlan, eventType, reason, message string) {
+	if c.recorder == nil || vlan == nil {
+		return
+	}
+	c.recorder.Eventf(vlan, eventType, reason, "%s", message)
+}
+
+func (c *Controller) recordVlanError(vlan *kubeovnv1.Vlan, reason string, err error) error {
+	if err != nil {
+		c.recordVlanEvent(vlan, corev1.EventTypeWarning, reason, err.Error())
+	}
+	return err
+}
+
+func (c *Controller) recordVlanKeyError(name, reason string, err error) error {
+	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	return c.recordVlanError(vlan, reason, err)
+}
 
 func (c *Controller) enqueueAddVlan(obj any) {
 	key := cache.MetaObjectToName(obj.(*kubeovnv1.Vlan)).String()
@@ -37,6 +57,7 @@ func (c *Controller) enqueueUpdateVlan(oldObj, newObj any) {
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets when vlan %s provider changed: %v", newVlan.Name, err)
+		c.recordVlanEvent(newVlan, corev1.EventTypeWarning, "ListSubnetsFailed", err.Error())
 		return
 	}
 
@@ -80,22 +101,24 @@ func (c *Controller) handleAddVlan(key string) error {
 			return nil
 		}
 		klog.Error(err)
-		return err
+		return c.recordVlanKeyError(key, "GetVlanFailed", err)
 	}
 
 	vlan := cachedVlan.DeepCopy()
 	if vlan.Spec.Provider == "" {
 		vlan.Spec.Provider = c.config.DefaultProviderName
-		if vlan, err = c.config.KubeOvnClient.KubeovnV1().Vlans().Update(context.Background(), vlan, metav1.UpdateOptions{}); err != nil {
-			klog.Errorf("failed to update vlan %s, %v", vlan.Name, err)
-			return err
+		updatedVlan, updateErr := c.config.KubeOvnClient.KubeovnV1().Vlans().Update(context.Background(), vlan, metav1.UpdateOptions{})
+		if updateErr != nil {
+			klog.Errorf("failed to update vlan %s, %v", vlan.Name, updateErr)
+			return c.recordVlanError(vlan, "UpdateSpecFailed", updateErr)
 		}
+		vlan = updatedVlan
 	}
 
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets: %v", err)
-		return err
+		return c.recordVlanError(vlan, "ListSubnetsFailed", err)
 	}
 
 	var needUpdate bool
@@ -107,17 +130,18 @@ func (c *Controller) handleAddVlan(key string) error {
 	}
 
 	if needUpdate {
-		vlan, err = c.config.KubeOvnClient.KubeovnV1().Vlans().UpdateStatus(context.Background(), vlan, metav1.UpdateOptions{})
-		if err != nil {
-			klog.Errorf("failed to update status of vlan %s: %v", vlan.Name, err)
-			return err
+		updatedVlan, updateErr := c.config.KubeOvnClient.KubeovnV1().Vlans().UpdateStatus(context.Background(), vlan, metav1.UpdateOptions{})
+		if updateErr != nil {
+			klog.Errorf("failed to update status of vlan %s: %v", vlan.Name, updateErr)
+			return c.recordVlanError(vlan, "UpdateStatusFailed", updateErr)
 		}
+		vlan = updatedVlan
 	}
 
 	pn, err := c.providerNetworksLister.Get(vlan.Spec.Provider)
 	if err != nil {
 		klog.Errorf("failed to get provider network %s: %v", vlan.Spec.Provider, err)
-		return err
+		return c.recordVlanError(vlan, "GetProviderNetworkFailed", err)
 	}
 
 	if err = c.checkVlanConflict(vlan); err != nil {
@@ -137,7 +161,7 @@ func (c *Controller) handleAddVlan(key string) error {
 		_, err = c.config.KubeOvnClient.KubeovnV1().ProviderNetworks().UpdateStatus(context.Background(), newPn, metav1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("failed to update status of provider network %s: %v", pn.Name, err)
-			return err
+			return c.recordVlanError(vlan, "UpdateProviderNetworkStatusFailed", err)
 		}
 	}
 
@@ -148,6 +172,8 @@ func (c *Controller) handleAddVlan(key string) error {
 			c.addOrUpdateSubnetQueue.Add(subnet.Name)
 		}
 	}
+
+	c.recordVlanEvent(vlan, corev1.EventTypeNormal, "ReconcileSuccess", fmt.Sprintf("Vlan %s reconciled successfully", vlan.Name))
 
 	return nil
 }
@@ -161,7 +187,7 @@ func (c *Controller) checkVlanConflict(vlan *kubeovnv1.Vlan) error {
 	vlans, err := c.vlansLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list vlans: %v", err)
-		return err
+		return c.recordVlanError(vlan, "ListVlansFailed", err)
 	}
 	// check if new vlan conflict with old vlan
 	var conflict bool
@@ -176,11 +202,15 @@ func (c *Controller) checkVlanConflict(vlan *kubeovnv1.Vlan) error {
 	}
 	if vlan.Status.Conflict != conflict {
 		vlan.Status.Conflict = conflict
-		vlan, err = c.config.KubeOvnClient.KubeovnV1().Vlans().UpdateStatus(context.Background(), vlan, metav1.UpdateOptions{})
-		if err != nil {
-			klog.Errorf("failed to update conflict status of vlan %s: %v", vlan.Name, err)
-			return err
+		updatedVlan, updateErr := c.config.KubeOvnClient.KubeovnV1().Vlans().UpdateStatus(context.Background(), vlan, metav1.UpdateOptions{})
+		if updateErr != nil {
+			klog.Errorf("failed to update conflict status of vlan %s: %v", vlan.Name, updateErr)
+			return c.recordVlanError(vlan, "UpdateStatusFailed", updateErr)
 		}
+		vlan = updatedVlan
+	}
+	if conflictErr != nil {
+		return c.recordVlanError(vlan, "VlanConflict", conflictErr)
 	}
 	return conflictErr
 }
@@ -196,16 +226,18 @@ func (c *Controller) handleUpdateVlan(key string) error {
 			return nil
 		}
 		klog.Error(err)
-		return err
+		return c.recordVlanKeyError(key, "GetVlanFailed", err)
 	}
 
 	if vlan.Spec.Provider == "" {
 		newVlan := vlan.DeepCopy()
 		newVlan.Spec.Provider = c.config.DefaultProviderName
-		if vlan, err = c.config.KubeOvnClient.KubeovnV1().Vlans().Update(context.Background(), newVlan, metav1.UpdateOptions{}); err != nil {
-			klog.Errorf("failed to update vlan %s: %v", vlan.Name, err)
-			return err
+		updatedVlan, updateErr := c.config.KubeOvnClient.KubeovnV1().Vlans().Update(context.Background(), newVlan, metav1.UpdateOptions{})
+		if updateErr != nil {
+			klog.Errorf("failed to update vlan %s: %v", vlan.Name, updateErr)
+			return c.recordVlanError(vlan, "UpdateSpecFailed", updateErr)
 		}
+		vlan = updatedVlan
 	}
 	newVlan := vlan.DeepCopy()
 	if err = c.checkVlanConflict(newVlan); err != nil {
@@ -220,31 +252,33 @@ func (c *Controller) handleUpdateVlan(key string) error {
 	pn, err := c.providerNetworksLister.Get(vlan.Spec.Provider)
 	if err != nil {
 		klog.Errorf("failed to get provider network %s: %v", vlan.Spec.Provider, err)
-		return err
+		return c.recordVlanError(vlan, "GetProviderNetworkFailed", err)
 	}
 	if !slices.Contains(pn.Status.Vlans, vlan.Name) {
 		newPn := pn.DeepCopy()
 		newPn.Status.Vlans = append(newPn.Status.Vlans, vlan.Name)
 		if _, err = c.config.KubeOvnClient.KubeovnV1().ProviderNetworks().UpdateStatus(context.Background(), newPn, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("failed to update status of provider network %s: %v", pn.Name, err)
-			return err
+			return c.recordVlanError(vlan, "UpdateProviderNetworkStatusFailed", err)
 		}
 	}
 
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets: %v", err)
-		return err
+		return c.recordVlanError(vlan, "ListSubnetsFailed", err)
 	}
 
 	for _, subnet := range subnets {
 		if subnet.Spec.Vlan == vlan.Name {
 			if err = c.setLocalnetTag(subnet.Name, vlan.Spec.ID); err != nil {
 				klog.Error(err)
-				return err
+				return c.recordVlanError(vlan, "SetLocalnetTagFailed", err)
 			}
 		}
 	}
+
+	c.recordVlanEvent(vlan, corev1.EventTypeNormal, "ReconcileSuccess", fmt.Sprintf("Vlan %s reconciled successfully", vlan.Name))
 
 	return nil
 }
@@ -253,11 +287,12 @@ func (c *Controller) handleDelVlan(key string) error {
 	c.vlanKeyMutex.LockKey(key)
 	defer func() { _ = c.vlanKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle delete vlan %s", key)
+	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: key}}
 
 	subnet, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list subnets: %v", err)
-		return err
+		return c.recordVlanError(vlan, "ListSubnetsFailed", err)
 	}
 
 	for _, s := range subnet {
@@ -269,15 +304,17 @@ func (c *Controller) handleDelVlan(key string) error {
 	providerNetworks, err := c.providerNetworksLister.List(labels.Everything())
 	if err != nil && !k8serrors.IsNotFound(err) {
 		klog.Errorf("failed to list provider networks: %v", err)
-		return err
+		return c.recordVlanError(vlan, "ListProviderNetworksFailed", err)
 	}
 
 	for _, pn := range providerNetworks {
 		if err = c.updateProviderNetworkStatusForVlanDeletion(pn, key); err != nil {
 			klog.Error(err)
-			return err
+			return c.recordVlanError(vlan, "UpdateProviderNetworkStatusFailed", err)
 		}
 	}
+
+	c.recordVlanEvent(vlan, corev1.EventTypeNormal, "DeleteSuccess", fmt.Sprintf("Vlan %s deleted successfully", key))
 
 	return nil
 }

--- a/pkg/controller/vlan.go
+++ b/pkg/controller/vlan.go
@@ -32,7 +32,7 @@ func (c *Controller) recordVlanError(vlan *kubeovnv1.Vlan, reason string, err er
 }
 
 func (c *Controller) recordVlanKeyError(name, reason string, err error) error {
-	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	vlan := &kubeovnv1.Vlan{Name: name}
 	return c.recordVlanError(vlan, reason, err)
 }
 

--- a/pkg/controller/vlan_test.go
+++ b/pkg/controller/vlan_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,6 +18,29 @@ import (
 	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 )
+
+type recordedVlanEvent struct {
+	object    runtime.Object
+	eventType string
+	reason    string
+	message   string
+}
+
+type vlanEventRecorder struct {
+	events []recordedVlanEvent
+}
+
+func (r *vlanEventRecorder) Event(object runtime.Object, eventType, reason, message string) {
+	r.events = append(r.events, recordedVlanEvent{object: object, eventType: eventType, reason: reason, message: message})
+}
+
+func (r *vlanEventRecorder) Eventf(object runtime.Object, eventType, reason, messageFmt string, args ...any) {
+	r.Event(object, eventType, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (r *vlanEventRecorder) AnnotatedEventf(object runtime.Object, _ map[string]string, eventType, reason, messageFmt string, args ...any) {
+	r.Eventf(object, eventType, reason, messageFmt, args...)
+}
 
 func requireVlanEvent(t *testing.T, recorder *record.FakeRecorder, parts ...string) string {
 	t.Helper()
@@ -84,11 +108,13 @@ func TestHandleAddVlanRecordsMissingProviderNetwork(t *testing.T) {
 }
 
 func TestHandleAddVlanRecordsUpdateFailure(t *testing.T) {
-	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"}}
+	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: "vlan-a", UID: "vlan-uid"}}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Vlans: []*kubeovnv1.Vlan{vlan}})
 	require.NoError(t, err)
 	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
 	fc.fakeController.config.DefaultProviderName = "provider-a"
+	recorder := &vlanEventRecorder{}
+	fc.fakeController.recorder = recorder
 	sourceErr := errors.New("update failed")
 	kubeovnClient := fc.fakeController.config.KubeOvnClient.(*kubeovnfake.Clientset)
 	kubeovnClient.PrependReactor("update", "vlans", func(k8stesting.Action) (bool, runtime.Object, error) {
@@ -98,7 +124,14 @@ func TestHandleAddVlanRecordsUpdateFailure(t *testing.T) {
 	err = fc.fakeController.handleAddVlan(vlan.Name)
 
 	require.ErrorIs(t, err, sourceErr)
-	require.Equal(t, "Warning UpdateSpecFailed update failed", requireVlanEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+	require.Len(t, recorder.events, 1)
+	event := recorder.events[0]
+	require.Equal(t, corev1.EventTypeWarning, event.eventType)
+	require.Equal(t, "UpdateSpecFailed", event.reason)
+	require.Equal(t, sourceErr.Error(), event.message)
+	target := event.object.(*kubeovnv1.Vlan)
+	require.Equal(t, vlan.Name, target.Name)
+	require.Equal(t, vlan.UID, target.UID)
 }
 
 func TestHandleAddVlanRecordsConflict(t *testing.T) {
@@ -163,6 +196,7 @@ func TestHandleDelVlanRecordsSuccess(t *testing.T) {
 		vlanName = "vlan-a"
 		pnName   = "provider-a"
 	)
+	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: vlanName, UID: "vlan-uid"}}
 	pn := &kubeovnv1.ProviderNetwork{
 		ObjectMeta: metav1.ObjectMeta{Name: pnName},
 		Status:     kubeovnv1.ProviderNetworkStatus{Vlans: []string{vlanName}},
@@ -172,9 +206,16 @@ func TestHandleDelVlanRecordsSuccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
+	recorder := &vlanEventRecorder{}
+	fc.fakeController.recorder = recorder
 
-	err = fc.fakeController.handleDelVlan(vlanName)
+	err = fc.fakeController.handleDelVlan(vlan)
 
 	require.NoError(t, err)
-	require.Equal(t, "Normal DeleteSuccess Vlan vlan-a deleted successfully", requireVlanEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+	require.Len(t, recorder.events, 1)
+	event := recorder.events[0]
+	require.Equal(t, corev1.EventTypeNormal, event.eventType)
+	require.Equal(t, "DeleteSuccess", event.reason)
+	require.Equal(t, "Vlan vlan-a deleted successfully", event.message)
+	require.Equal(t, vlan.UID, event.object.(*kubeovnv1.Vlan).UID)
 }

--- a/pkg/controller/vlan_test.go
+++ b/pkg/controller/vlan_test.go
@@ -8,14 +8,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/keymutex"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	kubeovnlisters "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 )
 
@@ -28,6 +31,20 @@ type recordedVlanEvent struct {
 
 type vlanEventRecorder struct {
 	events []recordedVlanEvent
+}
+
+type transientErrorSubnetLister struct {
+	kubeovnlisters.SubnetLister
+	err error
+}
+
+func (l *transientErrorSubnetLister) List(selector labels.Selector) ([]*kubeovnv1.Subnet, error) {
+	if l.err != nil {
+		err := l.err
+		l.err = nil
+		return nil, err
+	}
+	return l.SubnetLister.List(selector)
 }
 
 func (r *vlanEventRecorder) Event(object runtime.Object, eventType, reason, message string) {
@@ -59,7 +76,7 @@ func requireVlanEvent(t *testing.T, recorder *record.FakeRecorder, parts ...stri
 func TestRecordVlanError(t *testing.T) {
 	recorder := record.NewFakeRecorder(1)
 	controller := &Controller{recorder: recorder}
-	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"}}
+	vlan := &kubeovnv1.Vlan{Name: "vlan-a"}
 	sourceErr := errors.New("reconcile failed")
 
 	err := controller.recordVlanError(vlan, "ReconcileFailed", sourceErr)
@@ -74,10 +91,10 @@ func TestHandleAddVlanRecordsSuccess(t *testing.T) {
 		pnName   = "provider-a"
 	)
 	vlan := &kubeovnv1.Vlan{
-		ObjectMeta: metav1.ObjectMeta{Name: vlanName},
-		Spec:       kubeovnv1.VlanSpec{Provider: pnName},
+		Name: vlanName,
+		Spec: kubeovnv1.VlanSpec{Provider: pnName},
 	}
-	pn := &kubeovnv1.ProviderNetwork{ObjectMeta: metav1.ObjectMeta{Name: pnName}}
+	pn := &kubeovnv1.ProviderNetwork{Name: pnName}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Vlans:            []*kubeovnv1.Vlan{vlan},
 		ProviderNetworks: []*kubeovnv1.ProviderNetwork{pn},
@@ -93,8 +110,8 @@ func TestHandleAddVlanRecordsSuccess(t *testing.T) {
 
 func TestHandleAddVlanRecordsMissingProviderNetwork(t *testing.T) {
 	vlan := &kubeovnv1.Vlan{
-		ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"},
-		Spec:       kubeovnv1.VlanSpec{Provider: "missing-provider"},
+		Name: "vlan-a",
+		Spec: kubeovnv1.VlanSpec{Provider: "missing-provider"},
 	}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Vlans: []*kubeovnv1.Vlan{vlan}})
 	require.NoError(t, err)
@@ -108,7 +125,7 @@ func TestHandleAddVlanRecordsMissingProviderNetwork(t *testing.T) {
 }
 
 func TestHandleAddVlanRecordsUpdateFailure(t *testing.T) {
-	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: "vlan-a", UID: "vlan-uid"}}
+	vlan := &kubeovnv1.Vlan{Name: "vlan-a", UID: "vlan-uid"}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Vlans: []*kubeovnv1.Vlan{vlan}})
 	require.NoError(t, err)
 	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
@@ -137,10 +154,10 @@ func TestHandleAddVlanRecordsUpdateFailure(t *testing.T) {
 func TestHandleAddVlanRecordsConflict(t *testing.T) {
 	const pnName = "provider-a"
 	vlans := []*kubeovnv1.Vlan{
-		{ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"}, Spec: kubeovnv1.VlanSpec{ID: 100, Provider: pnName}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "vlan-b"}, Spec: kubeovnv1.VlanSpec{ID: 100, Provider: pnName}},
+		{Name: "vlan-a", Spec: kubeovnv1.VlanSpec{ID: 100, Provider: pnName}},
+		{Name: "vlan-b", Spec: kubeovnv1.VlanSpec{ID: 100, Provider: pnName}},
 	}
-	pn := &kubeovnv1.ProviderNetwork{ObjectMeta: metav1.ObjectMeta{Name: pnName}}
+	pn := &kubeovnv1.ProviderNetwork{Name: pnName}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Vlans:            vlans,
 		ProviderNetworks: []*kubeovnv1.ProviderNetwork{pn},
@@ -162,16 +179,16 @@ func TestHandleUpdateVlanRecordsLocalnetFailure(t *testing.T) {
 		subnetName = "subnet-a"
 	)
 	vlan := &kubeovnv1.Vlan{
-		ObjectMeta: metav1.ObjectMeta{Name: vlanName},
-		Spec:       kubeovnv1.VlanSpec{ID: 100, Provider: pnName},
+		Name: vlanName,
+		Spec: kubeovnv1.VlanSpec{ID: 100, Provider: pnName},
 	}
 	pn := &kubeovnv1.ProviderNetwork{
-		ObjectMeta: metav1.ObjectMeta{Name: pnName},
-		Status:     kubeovnv1.ProviderNetworkStatus{Vlans: []string{vlanName}},
+		Name:   pnName,
+		Status: kubeovnv1.ProviderNetworkStatus{Vlans: []string{vlanName}},
 	}
 	subnet := &kubeovnv1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
-		Spec:       kubeovnv1.SubnetSpec{Vlan: vlanName},
+		Name: subnetName,
+		Spec: kubeovnv1.SubnetSpec{Vlan: vlanName},
 	}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Vlans:            []*kubeovnv1.Vlan{vlan},
@@ -196,10 +213,10 @@ func TestHandleDelVlanRecordsSuccess(t *testing.T) {
 		vlanName = "vlan-a"
 		pnName   = "provider-a"
 	)
-	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: vlanName, UID: "vlan-uid"}}
+	vlan := &kubeovnv1.Vlan{Name: vlanName, UID: "vlan-uid"}
 	pn := &kubeovnv1.ProviderNetwork{
-		ObjectMeta: metav1.ObjectMeta{Name: pnName},
-		Status:     kubeovnv1.ProviderNetworkStatus{Vlans: []string{vlanName}},
+		Name:   pnName,
+		Status: kubeovnv1.ProviderNetworkStatus{Vlans: []string{vlanName}},
 	}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		ProviderNetworks: []*kubeovnv1.ProviderNetwork{pn},
@@ -218,4 +235,112 @@ func TestHandleDelVlanRecordsSuccess(t *testing.T) {
 	require.Equal(t, "DeleteSuccess", event.reason)
 	require.Equal(t, "Vlan vlan-a deleted successfully", event.message)
 	require.Equal(t, vlan.UID, event.object.(*kubeovnv1.Vlan).UID)
+}
+
+type deleteVlanRetryTestCase struct {
+	name           string
+	tombstone      bool
+	failureStage   deleteVlanRetryFailureStage
+	expectedReason string
+}
+
+type deleteVlanRetryFailureStage int
+
+const (
+	deleteVlanProviderNetworkUpdateFailure deleteVlanRetryFailureStage = iota
+	deleteVlanSubnetListFailure
+)
+
+func runDeleteVlanQueueRetryTest(t *testing.T, tc deleteVlanRetryTestCase) {
+	t.Helper()
+	const (
+		vlanName     = "vlan-a"
+		deletedUID   = "deleted-vlan-uid"
+		recreatedUID = "recreated-vlan-uid"
+		pnName       = "provider-a"
+	)
+	deletedVlan := &kubeovnv1.Vlan{Name: vlanName, UID: deletedUID}
+	recreatedVlan := &kubeovnv1.Vlan{Name: vlanName, UID: recreatedUID}
+	options := &FakeControllerOptions{
+		Vlans: []*kubeovnv1.Vlan{recreatedVlan},
+		ProviderNetworks: []*kubeovnv1.ProviderNetwork{{
+			Name:   pnName,
+			Status: kubeovnv1.ProviderNetworkStatus{Vlans: []string{vlanName}},
+		}},
+	}
+	fc, err := newFakeControllerWithOptions(t, options)
+	require.NoError(t, err)
+	controller := fc.fakeController
+	controller.vlanKeyMutex = keymutex.NewHashed(0)
+	controller.delVlanQueue = newTypedRateLimitingQueue(
+		"DeleteVlan",
+		workqueue.NewTypedItemExponentialFailureRateLimiter[*kubeovnv1.Vlan](0, 0),
+	)
+	t.Cleanup(controller.delVlanQueue.ShutDown)
+	recorder := &vlanEventRecorder{}
+	controller.recorder = recorder
+
+	sourceErr := errors.New(tc.expectedReason)
+	updateAttempts := 0
+	expectedUpdateAttempts := 0
+	switch tc.failureStage {
+	case deleteVlanProviderNetworkUpdateFailure:
+		expectedUpdateAttempts = 2
+		kubeovnClient := controller.config.KubeOvnClient.(*kubeovnfake.Clientset)
+		kubeovnClient.PrependReactor("update", "provider-networks", func(k8stesting.Action) (bool, runtime.Object, error) {
+			updateAttempts++
+			if updateAttempts == 1 {
+				return true, nil, sourceErr
+			}
+			return false, nil, nil
+		})
+	case deleteVlanSubnetListFailure:
+		controller.subnetsLister = &transientErrorSubnetLister{
+			SubnetLister: controller.subnetsLister,
+			err:          sourceErr,
+		}
+	default:
+		t.Fatalf("unknown VLAN deletion failure stage %d", tc.failureStage)
+	}
+
+	deleteEvent := any(deletedVlan)
+	if tc.tombstone {
+		deleteEvent = cache.DeletedFinalStateUnknown{Key: vlanName, Obj: deletedVlan}
+	}
+	controller.enqueueDelVlan(deleteEvent)
+	require.Equal(t, 1, controller.delVlanQueue.Len())
+
+	require.True(t, processNextWorkItem("delete vlan", controller.delVlanQueue, controller.handleDelVlan, getWorkItemKey))
+	require.Equal(t, 1, controller.delVlanQueue.NumRequeues(deletedVlan))
+	require.Len(t, recorder.events, 1)
+	warning := recorder.events[0]
+	require.Equal(t, corev1.EventTypeWarning, warning.eventType)
+	require.Equal(t, tc.expectedReason, warning.reason)
+	require.Equal(t, sourceErr.Error(), warning.message)
+	require.Equal(t, deletedVlan.UID, warning.object.(*kubeovnv1.Vlan).UID)
+
+	require.True(t, processNextWorkItem("delete vlan", controller.delVlanQueue, controller.handleDelVlan, getWorkItemKey))
+	require.Zero(t, controller.delVlanQueue.NumRequeues(deletedVlan))
+	require.Equal(t, expectedUpdateAttempts, updateAttempts)
+	require.Len(t, recorder.events, 2)
+	success := recorder.events[1]
+	require.Equal(t, corev1.EventTypeNormal, success.eventType)
+	require.Equal(t, "DeleteSuccess", success.reason)
+	require.Equal(t, "Vlan vlan-a deleted successfully", success.message)
+	target := success.object.(*kubeovnv1.Vlan)
+	require.Equal(t, vlanName, target.Name)
+	require.Equal(t, deletedVlan.UID, target.UID)
+	require.NotEqual(t, recreatedVlan.UID, target.UID)
+}
+
+func TestDeleteVlanQueuePreservesEventIdentityAcrossRetry(t *testing.T) {
+	for _, tc := range []deleteVlanRetryTestCase{
+		{name: "direct object after provider network update failure", failureStage: deleteVlanProviderNetworkUpdateFailure, expectedReason: "UpdateProviderNetworkStatusFailed"},
+		{name: "tombstone after provider network update failure", tombstone: true, failureStage: deleteVlanProviderNetworkUpdateFailure, expectedReason: "UpdateProviderNetworkStatusFailed"},
+		{name: "tombstone after subnet list failure", tombstone: true, failureStage: deleteVlanSubnetListFailure, expectedReason: "ListSubnetsFailed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runDeleteVlanQueueRetryTest(t, tc)
+		})
+	}
 }

--- a/pkg/controller/vlan_test.go
+++ b/pkg/controller/vlan_test.go
@@ -1,0 +1,180 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/keymutex"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+)
+
+func requireVlanEvent(t *testing.T, recorder *record.FakeRecorder, parts ...string) string {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		for _, part := range parts {
+			require.Contains(t, event, part)
+		}
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for VLAN event")
+		return ""
+	}
+}
+
+func TestRecordVlanError(t *testing.T) {
+	recorder := record.NewFakeRecorder(1)
+	controller := &Controller{recorder: recorder}
+	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"}}
+	sourceErr := errors.New("reconcile failed")
+
+	err := controller.recordVlanError(vlan, "ReconcileFailed", sourceErr)
+
+	require.ErrorIs(t, err, sourceErr)
+	require.Equal(t, "Warning ReconcileFailed reconcile failed", requireVlanEvent(t, recorder))
+}
+
+func TestHandleAddVlanRecordsSuccess(t *testing.T) {
+	const (
+		vlanName = "vlan-a"
+		pnName   = "provider-a"
+	)
+	vlan := &kubeovnv1.Vlan{
+		ObjectMeta: metav1.ObjectMeta{Name: vlanName},
+		Spec:       kubeovnv1.VlanSpec{Provider: pnName},
+	}
+	pn := &kubeovnv1.ProviderNetwork{ObjectMeta: metav1.ObjectMeta{Name: pnName}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Vlans:            []*kubeovnv1.Vlan{vlan},
+		ProviderNetworks: []*kubeovnv1.ProviderNetwork{pn},
+	})
+	require.NoError(t, err)
+	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
+
+	err = fc.fakeController.handleAddVlan(vlanName)
+
+	require.NoError(t, err)
+	require.Equal(t, "Normal ReconcileSuccess Vlan vlan-a reconciled successfully", requireVlanEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+}
+
+func TestHandleAddVlanRecordsMissingProviderNetwork(t *testing.T) {
+	vlan := &kubeovnv1.Vlan{
+		ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"},
+		Spec:       kubeovnv1.VlanSpec{Provider: "missing-provider"},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Vlans: []*kubeovnv1.Vlan{vlan}})
+	require.NoError(t, err)
+	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
+
+	err = fc.fakeController.handleAddVlan(vlan.Name)
+
+	require.Error(t, err)
+	requireVlanEvent(t, fc.fakeController.recorder.(*record.FakeRecorder),
+		"Warning GetProviderNetworkFailed", `providernetwork.kubeovn.io "missing-provider" not found`)
+}
+
+func TestHandleAddVlanRecordsUpdateFailure(t *testing.T) {
+	vlan := &kubeovnv1.Vlan{ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Vlans: []*kubeovnv1.Vlan{vlan}})
+	require.NoError(t, err)
+	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
+	fc.fakeController.config.DefaultProviderName = "provider-a"
+	sourceErr := errors.New("update failed")
+	kubeovnClient := fc.fakeController.config.KubeOvnClient.(*kubeovnfake.Clientset)
+	kubeovnClient.PrependReactor("update", "vlans", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, sourceErr
+	})
+
+	err = fc.fakeController.handleAddVlan(vlan.Name)
+
+	require.ErrorIs(t, err, sourceErr)
+	require.Equal(t, "Warning UpdateSpecFailed update failed", requireVlanEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+}
+
+func TestHandleAddVlanRecordsConflict(t *testing.T) {
+	const pnName = "provider-a"
+	vlans := []*kubeovnv1.Vlan{
+		{ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"}, Spec: kubeovnv1.VlanSpec{ID: 100, Provider: pnName}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "vlan-b"}, Spec: kubeovnv1.VlanSpec{ID: 100, Provider: pnName}},
+	}
+	pn := &kubeovnv1.ProviderNetwork{ObjectMeta: metav1.ObjectMeta{Name: pnName}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Vlans:            vlans,
+		ProviderNetworks: []*kubeovnv1.ProviderNetwork{pn},
+	})
+	require.NoError(t, err)
+	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
+
+	err = fc.fakeController.handleAddVlan("vlan-b")
+
+	require.Error(t, err)
+	requireVlanEvent(t, fc.fakeController.recorder.(*record.FakeRecorder),
+		"Warning VlanConflict", "provider provider-a new vlan vlan-b conflict with old vlan vlan-a")
+}
+
+func TestHandleUpdateVlanRecordsLocalnetFailure(t *testing.T) {
+	const (
+		vlanName   = "vlan-a"
+		pnName     = "provider-a"
+		subnetName = "subnet-a"
+	)
+	vlan := &kubeovnv1.Vlan{
+		ObjectMeta: metav1.ObjectMeta{Name: vlanName},
+		Spec:       kubeovnv1.VlanSpec{ID: 100, Provider: pnName},
+	}
+	pn := &kubeovnv1.ProviderNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: pnName},
+		Status:     kubeovnv1.ProviderNetworkStatus{Vlans: []string{vlanName}},
+	}
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Spec:       kubeovnv1.SubnetSpec{Vlan: vlanName},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Vlans:            []*kubeovnv1.Vlan{vlan},
+		ProviderNetworks: []*kubeovnv1.ProviderNetwork{pn},
+		Subnets:          []*kubeovnv1.Subnet{subnet},
+	})
+	require.NoError(t, err)
+	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
+	fc.mockOvnClient.EXPECT().
+		SetLogicalSwitchPortVlanTag(ovs.GetLocalnetName(subnetName), 100).
+		Return(errors.New("set tag failed"))
+
+	err = fc.fakeController.handleUpdateVlan(vlanName)
+
+	require.Error(t, err)
+	requireVlanEvent(t, fc.fakeController.recorder.(*record.FakeRecorder),
+		corev1.EventTypeWarning+" SetLocalnetTagFailed", "set tag failed")
+}
+
+func TestHandleDelVlanRecordsSuccess(t *testing.T) {
+	const (
+		vlanName = "vlan-a"
+		pnName   = "provider-a"
+	)
+	pn := &kubeovnv1.ProviderNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: pnName},
+		Status:     kubeovnv1.ProviderNetworkStatus{Vlans: []string{vlanName}},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		ProviderNetworks: []*kubeovnv1.ProviderNetwork{pn},
+	})
+	require.NoError(t, err)
+	fc.fakeController.vlanKeyMutex = keymutex.NewHashed(0)
+
+	err = fc.fakeController.handleDelVlan(vlanName)
+
+	require.NoError(t, err)
+	require.Equal(t, "Normal DeleteSuccess Vlan vlan-a deleted successfully", requireVlanEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Features
- Tests

## What this PR does

- Records Normal events when VLAN reconciliation or deletion succeeds.
- Records stage-specific Warning events for VLAN reconciliation and cleanup failures, including provider-network lookup, conflict detection, status updates, and localnet tag programming.
- Preserves the original VLAN event target when API updates fail without returning an object.
- Preserves the deleted VLAN incarnation, including its UID, through direct informer events, tombstones, rate-limited retries, and same-name recreation.
- Adds unit coverage for success, conflict, missing provider network, API update failure, localnet failure, and deletion cleanup retries.

## Which issue(s) this PR fixes

None.

## Validation

- `go test ./pkg/controller -count=1`
- `go test -race ./pkg/controller -run '^Test(HandleAddVlanRecordsUpdateFailure|HandleDelVlanRecordsSuccess|DeleteVlanQueuePreservesEventIdentityAcrossRetry)$' -count=1`
- `go vet ./pkg/controller`
- `GOMAXPROCS=1 golangci-lint run --new-from-rev=origin/master ./pkg/controller/...`
- `git diff --check`
