### PR TITLE
feat(controller): add failure events for IP resources

### DIFF
--- a/pkg/controller/ip.go
+++ b/pkg/controller/ip.go
@@ -25,6 +25,17 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
+const (
+	reasonAddIPFailed    = "AddIPFailed"
+	reasonUpdateIPFailed = "UpdateIPFailed"
+)
+
+func (c *Controller) recordIPError(ip *kubeovnv1.IP, reason string, err error) {
+	if c.recorder != nil {
+		c.recorder.Eventf(ip, corev1.EventTypeWarning, reason, "%s", err.Error())
+	}
+}
+
 func (c *Controller) enqueueAddIP(obj any) {
 	ipObj := obj.(*kubeovnv1.IP)
 	if strings.HasPrefix(ipObj.Name, util.U2OInterconnName[0:20]) ||
@@ -54,23 +65,33 @@ func (c *Controller) enqueueUpdateIP(oldObj, newObj any) {
 		return
 	}
 	if oldIP.Spec.Namespace != "" && newIP.Spec.Namespace != oldIP.Spec.Namespace {
-		klog.Errorf("ip %s namespace can not change", newIP.Name)
+		err := fmt.Errorf("ip %s namespace can not change", newIP.Name)
+		klog.Error(err)
+		c.recordIPError(newIP, reasonUpdateIPFailed, err)
 		return
 	}
 	if oldIP.Spec.PodName != "" && newIP.Spec.PodName != oldIP.Spec.PodName {
-		klog.Errorf("ip %s podName can not change", newIP.Name)
+		err := fmt.Errorf("ip %s podName can not change", newIP.Name)
+		klog.Error(err)
+		c.recordIPError(newIP, reasonUpdateIPFailed, err)
 		return
 	}
 	if oldIP.Spec.PodType != "" && newIP.Spec.PodType != oldIP.Spec.PodType {
-		klog.Errorf("ip %s podType can not change", newIP.Name)
+		err := fmt.Errorf("ip %s podType can not change", newIP.Name)
+		klog.Error(err)
+		c.recordIPError(newIP, reasonUpdateIPFailed, err)
 		return
 	}
 	if oldIP.Spec.MacAddress != "" && newIP.Spec.MacAddress != oldIP.Spec.MacAddress {
-		klog.Errorf("ip %s macAddress can not change", newIP.Name)
+		err := fmt.Errorf("ip %s macAddress can not change", newIP.Name)
+		klog.Error(err)
+		c.recordIPError(newIP, reasonUpdateIPFailed, err)
 		return
 	}
 	if oldIP.Spec.V4IPAddress != "" && newIP.Spec.V4IPAddress != oldIP.Spec.V4IPAddress {
-		klog.Errorf("ip %s v4IPAddress can not change", newIP.Name)
+		err := fmt.Errorf("ip %s v4IPAddress can not change", newIP.Name)
+		klog.Error(err)
+		c.recordIPError(newIP, reasonUpdateIPFailed, err)
 		return
 	}
 	if oldIP.Spec.V6IPAddress != "" {
@@ -78,10 +99,13 @@ func (c *Controller) enqueueUpdateIP(oldObj, newObj any) {
 		if util.ContainsUppercase(newIP.Spec.V6IPAddress) {
 			err := fmt.Errorf("ip %s v6 ip address %s can not contain upper case", newIP.Name, newIP.Spec.V6IPAddress)
 			klog.Error(err)
+			c.recordIPError(newIP, reasonUpdateIPFailed, err)
 			return
 		}
 		if newIP.Spec.V6IPAddress != oldIP.Spec.V6IPAddress {
-			klog.Errorf("ip %s v6IPAddress can not change", newIP.Name)
+			err := fmt.Errorf("ip %s v6IPAddress can not change", newIP.Name)
+			klog.Error(err)
+			c.recordIPError(newIP, reasonUpdateIPFailed, err)
 			return
 		}
 	}
@@ -127,7 +151,7 @@ func (c *Controller) enqueueDelIP(obj any) {
 	c.delIPQueue.Add(ipObj)
 }
 
-func (c *Controller) handleAddReservedIP(key string) error {
+func (c *Controller) handleAddReservedIP(key string) (err error) {
 	ip, err := c.ipsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -136,6 +160,11 @@ func (c *Controller) handleAddReservedIP(key string) error {
 		klog.Error(err)
 		return err
 	}
+	defer func() {
+		if err != nil {
+			c.recordIPError(ip, reasonAddIPFailed, err)
+		}
+	}()
 	if !ip.DeletionTimestamp.IsZero() {
 		klog.Infof("handle add process stop for deleting ip %s", ip.Name)
 		return nil
@@ -229,7 +258,7 @@ func (c *Controller) handleAddReservedIP(key string) error {
 	return nil
 }
 
-func (c *Controller) handleUpdateIP(key string) error {
+func (c *Controller) handleUpdateIP(key string) (err error) {
 	cachedIP, err := c.ipsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -238,6 +267,11 @@ func (c *Controller) handleUpdateIP(key string) error {
 		klog.Error(err)
 		return err
 	}
+	defer func() {
+		if err != nil {
+			c.recordIPError(cachedIP, reasonUpdateIPFailed, err)
+		}
+	}()
 	if !cachedIP.DeletionTimestamp.IsZero() {
 		klog.Infof("handle deleting ip %s", cachedIP.Name)
 		subnet, err := c.subnetsLister.Get(cachedIP.Spec.Subnet)

--- a/pkg/controller/ip_test.go
+++ b/pkg/controller/ip_test.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -47,4 +49,90 @@ func Test_handleUpdateIP_deletedSubnet(t *testing.T) {
 
 	// Verify the subnet status update was enqueued
 	require.Equal(t, 1, ctrl.updateSubnetStatusQueue.Len())
+}
+
+func TestHandleAddReservedIPRecordsFailureEvent(t *testing.T) {
+	t.Parallel()
+
+	ip := &kubeovnv1.IP{ObjectMeta: metav1.ObjectMeta{Name: "test-ip"}}
+	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		IPs: []*kubeovnv1.IP{ip},
+	})
+	require.NoError(t, err)
+
+	err = fakeCtrl.fakeController.handleAddReservedIP(ip.Name)
+
+	require.EqualError(t, err, "subnet parameter cannot be empty")
+	require.Equal(t, "Warning AddIPFailed subnet parameter cannot be empty", requireRecorderEvent(t, fakeCtrl.fakeController.recorder.(*record.FakeRecorder)))
+}
+
+func TestHandleUpdateIPRecordsFailureEvent(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	ip := &kubeovnv1.IP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-ip",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{util.KubeOVNControllerFinalizer},
+		},
+		Spec: kubeovnv1.IPSpec{Subnet: "test-subnet"},
+	}
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: ip.Spec.Subnet},
+		Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+	}
+	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		IPs:     []*kubeovnv1.IP{ip},
+		Subnets: []*kubeovnv1.Subnet{subnet},
+	})
+	require.NoError(t, err)
+	injectedErr := errors.New("get logical switch port failed")
+	fakeCtrl.mockOvnClient.EXPECT().GetLogicalSwitchPort(ip.Name, true).Return(nil, injectedErr)
+
+	err = fakeCtrl.fakeController.handleUpdateIP(ip.Name)
+
+	require.ErrorIs(t, err, injectedErr)
+	require.Equal(t, "Warning UpdateIPFailed "+injectedErr.Error(), requireRecorderEvent(t, fakeCtrl.fakeController.recorder.(*record.FakeRecorder)))
+}
+
+func TestEnqueueUpdateIPRecordsImmutableFieldChangeEvent(t *testing.T) {
+	original := &kubeovnv1.IP{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ip"},
+		Spec: kubeovnv1.IPSpec{
+			Subnet:      "subnet-a",
+			Namespace:   "default",
+			PodName:     "pod-a",
+			PodType:     util.KindStatefulSet,
+			MacAddress:  "00:00:00:AA:BB:CC",
+			V4IPAddress: "10.0.0.2",
+			V6IPAddress: "fd00::2",
+		},
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*kubeovnv1.IP)
+		message string
+	}{
+		{name: "namespace", mutate: func(ip *kubeovnv1.IP) { ip.Spec.Namespace = "other" }, message: "ip test-ip namespace can not change"},
+		{name: "pod name", mutate: func(ip *kubeovnv1.IP) { ip.Spec.PodName = "pod-b" }, message: "ip test-ip podName can not change"},
+		{name: "pod type", mutate: func(ip *kubeovnv1.IP) { ip.Spec.PodType = util.KindVirtualMachine }, message: "ip test-ip podType can not change"},
+		{name: "MAC address", mutate: func(ip *kubeovnv1.IP) { ip.Spec.MacAddress = "00:00:00:DD:EE:FF" }, message: "ip test-ip macAddress can not change"},
+		{name: "IPv4 address", mutate: func(ip *kubeovnv1.IP) { ip.Spec.V4IPAddress = "10.0.0.3" }, message: "ip test-ip v4IPAddress can not change"},
+		{name: "uppercase IPv6 address", mutate: func(ip *kubeovnv1.IP) { ip.Spec.V6IPAddress = "FD00::2" }, message: "ip test-ip v6 ip address FD00::2 can not contain upper case"},
+		{name: "IPv6 address", mutate: func(ip *kubeovnv1.IP) { ip.Spec.V6IPAddress = "fd00::3" }, message: "ip test-ip v6IPAddress can not change"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updated := original.DeepCopy()
+			tt.mutate(updated)
+			recorder := record.NewFakeRecorder(1)
+			controller := &Controller{recorder: recorder}
+
+			controller.enqueueUpdateIP(original, updated)
+
+			require.Equal(t, "Warning UpdateIPFailed "+tt.message, requireRecorderEvent(t, recorder))
+		})
+	}
 }


### PR DESCRIPTION
## What type of this PR

- Features

## What this PR does

Adds warning events to IP resources so users can diagnose reconciliation failures with `kubectl describe ip`.

- Emits `AddIPFailed` when reserved IP reconciliation fails after the IP object is loaded.
- Emits `UpdateIPFailed` when deletion cleanup fails or an immutable IP field change is rejected.
- Keeps successful, no-op, internal U2O, and multicast querier reconciliation silent.

## Verification

- `go test ./pkg/controller -count=1`
- `golangci-lint run -v --fix ./pkg/controller` (18 linters, 0 issues)
- `git diff --check`

Full `make lint` completed CRD verification, then exceeded the local 2 GiB memory limit during whole-repository lint. GitHub Actions will run the full lint suite.