### PR TITLE
controller: record subnet and IPPool lifecycle events

### DIFF
--- a/pkg/controller/ippool.go
+++ b/pkg/controller/ippool.go
@@ -74,14 +74,14 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 			return nil
 		}
 		klog.Error(err)
-		return err
+		return c.recordIPPoolKeyError(key, "GetIPPoolFailed", err)
 	}
 	klog.Infof("handle add/update ippool %s", cachedIPPool.Name)
 
 	ippool := cachedIPPool.DeepCopy()
 	if err = c.handleAddIPPoolFinalizer(ippool); err != nil {
 		klog.Errorf("failed to add finalizer for ippool %s: %v", ippool.Name, err)
-		return err
+		return c.recordIPPoolError(ippool, "UpdateFinalizerFailed", err)
 	}
 	if !ippool.DeletionTimestamp.IsZero() {
 		klog.Infof("ippool %s is being deleted, skip add/update handling", ippool.Name)
@@ -107,7 +107,7 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 
 	if err = c.patchIPPoolStatusCondition(ippool, "UpdateIPAMSucceeded", ""); err != nil {
 		klog.Error(err)
-		return err
+		return c.recordIPPoolError(ippool, "UpdateStatusFailed", err)
 	}
 
 	for _, ns := range ippool.Spec.Namespaces {
@@ -117,13 +117,20 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 	return nil
 }
 
-func (c *Controller) handleDeleteIPPool(ippool *kubeovnv1.IPPool) error {
+func (c *Controller) handleDeleteIPPool(ippool *kubeovnv1.IPPool) (err error) {
 	c.ippoolKeyMutex.LockKey(ippool.Name)
 	defer func() { _ = c.ippoolKeyMutex.UnlockKey(ippool.Name) }()
+	defer func() {
+		if err != nil {
+			_ = c.recordIPPoolError(ippool, "DeleteFailed", fmt.Errorf("failed to delete ippool %s: %w", ippool.Name, err))
+		}
+	}()
+	hadFinalizer := controllerutil.ContainsFinalizer(ippool, util.DeprecatedFinalizerName) ||
+		controllerutil.ContainsFinalizer(ippool, util.KubeOVNControllerFinalizer)
 
 	klog.Infof("handle delete ippool %s", ippool.Name)
 	c.ipam.RemoveIPPool(ippool.Spec.Subnet, ippool.Name)
-	if err := c.OVNNbClient.DeleteAddressSet(util.IPPoolAddressSetName(ippool.Name)); err != nil {
+	if err = c.OVNNbClient.DeleteAddressSet(util.IPPoolAddressSetName(ippool.Name)); err != nil {
 		klog.Errorf("failed to delete address set for ippool %s: %v", ippool.Name, err)
 		return err
 	}
@@ -140,9 +147,13 @@ func (c *Controller) handleDeleteIPPool(ippool *kubeovnv1.IPPool) error {
 		}
 	}
 
-	if err := c.handleDelIPPoolFinalizer(ippool); err != nil {
+	if err = c.handleDelIPPoolFinalizer(ippool); err != nil {
 		klog.Errorf("failed to remove finalizer for ippool %s: %v", ippool.Name, err)
 		return err
+	}
+
+	if hadFinalizer {
+		c.recordIPPoolEvent(ippool, corev1.EventTypeNormal, "DeleteSuccess", fmt.Sprintf("IPPool %s deleted successfully", ippool.Name))
 	}
 
 	return nil
@@ -158,7 +169,7 @@ func (c *Controller) handleUpdateIPPoolStatus(key string) error {
 			return nil
 		}
 		klog.Error(err)
-		return err
+		return c.recordIPPoolKeyError(key, "GetIPPoolFailed", err)
 	}
 
 	ippool := cachedIPPool.DeepCopy()
@@ -167,18 +178,21 @@ func (c *Controller) handleUpdateIPPoolStatus(key string) error {
 		return nil
 	}
 
-	return c.patchIPPoolStatus(ippool)
+	if err := c.patchIPPoolStatus(ippool); err != nil {
+		return c.recordIPPoolError(ippool, "UpdateStatusFailed", err)
+	}
+	return nil
 }
 
 func (c *Controller) patchIPPoolStatusCondition(ippool *kubeovnv1.IPPool, reason, errMsg string) error {
 	if errMsg != "" {
 		ippool.Status.SetError(reason, errMsg)
 		ippool.Status.NotReady(reason, errMsg)
-		c.recorder.Eventf(ippool, corev1.EventTypeWarning, reason, "%s", errMsg)
+		c.recordIPPoolEvent(ippool, corev1.EventTypeWarning, reason, errMsg)
 	} else {
 		ippool.Status.Ready(reason, "")
 		// to observe ippool status change to normal
-		c.recorder.Eventf(ippool, corev1.EventTypeNormal, reason, "")
+		c.recordIPPoolEvent(ippool, corev1.EventTypeNormal, reason, fmt.Sprintf("IPPool %s reconciled successfully", ippool.Name))
 	}
 
 	return c.patchIPPoolStatus(ippool)

--- a/pkg/controller/ippool.go
+++ b/pkg/controller/ippool.go
@@ -82,7 +82,7 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 	ippool := cachedIPPool.DeepCopy()
 	if err = c.handleAddIPPoolFinalizer(ippool); err != nil {
 		klog.Errorf("failed to add finalizer for ippool %s: %v", ippool.Name, err)
-		return c.recordIPPoolError(ippool, "UpdateFinalizerFailed", err)
+		return c.recordResourceError(ippool, "UpdateFinalizerFailed", err)
 	}
 	if !ippool.DeletionTimestamp.IsZero() {
 		klog.Infof("ippool %s is being deleted, skip add/update handling", ippool.Name)
@@ -93,7 +93,7 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 		klog.Errorf("failed to reconcile address set for ippool %s: %v", ippool.Name, err)
 		if patchErr := c.patchIPPoolStatusCondition(ippool, "ReconcileAddressSetFailed", err.Error()); patchErr != nil {
 			klog.Error(patchErr)
-			return errors.Join(err, c.recordIPPoolError(ippool, "UpdateStatusFailed", patchErr))
+			return errors.Join(err, c.recordResourceError(ippool, "UpdateStatusFailed", patchErr))
 		}
 		return err
 	}
@@ -101,7 +101,7 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 		klog.Errorf("failed to add/update ippool %s with IPs %v in subnet %s: %v", ippool.Name, ippool.Spec.IPs, ippool.Spec.Subnet, err)
 		if patchErr := c.patchIPPoolStatusCondition(ippool, "UpdateIPAMFailed", err.Error()); patchErr != nil {
 			klog.Error(patchErr)
-			return errors.Join(err, c.recordIPPoolError(ippool, "UpdateStatusFailed", patchErr))
+			return errors.Join(err, c.recordResourceError(ippool, "UpdateStatusFailed", patchErr))
 		}
 		return err
 	}
@@ -110,7 +110,7 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 
 	if err = c.patchIPPoolStatusCondition(ippool, "UpdateIPAMSucceeded", ""); err != nil {
 		klog.Error(err)
-		return c.recordIPPoolError(ippool, "UpdateStatusFailed", err)
+		return c.recordResourceError(ippool, "UpdateStatusFailed", err)
 	}
 
 	for _, ns := range ippool.Spec.Namespaces {
@@ -125,7 +125,7 @@ func (c *Controller) handleDeleteIPPool(ippool *kubeovnv1.IPPool) (err error) {
 	defer func() { _ = c.ippoolKeyMutex.UnlockKey(ippool.Name) }()
 	defer func() {
 		if err != nil {
-			_ = c.recordIPPoolError(ippool, "DeleteFailed", fmt.Errorf("failed to delete ippool %s: %w", ippool.Name, err))
+			_ = c.recordResourceError(ippool, "DeleteFailed", fmt.Errorf("failed to delete ippool %s: %w", ippool.Name, err))
 		}
 	}()
 	hadFinalizer := controllerutil.ContainsFinalizer(ippool, util.DeprecatedFinalizerName) ||
@@ -156,7 +156,7 @@ func (c *Controller) handleDeleteIPPool(ippool *kubeovnv1.IPPool) (err error) {
 	}
 
 	if hadFinalizer {
-		c.recordIPPoolEvent(ippool, corev1.EventTypeNormal, "DeleteSuccess", fmt.Sprintf("IPPool %s deleted successfully", ippool.Name))
+		c.recordResourceEvent(ippool, corev1.EventTypeNormal, "DeleteSuccess", fmt.Sprintf("IPPool %s deleted successfully", ippool.Name))
 	}
 
 	return nil
@@ -182,7 +182,7 @@ func (c *Controller) handleUpdateIPPoolStatus(key string) error {
 	}
 
 	if err := c.patchIPPoolStatus(ippool); err != nil {
-		return c.recordIPPoolError(ippool, "UpdateStatusFailed", err)
+		return c.recordResourceError(ippool, "UpdateStatusFailed", err)
 	}
 	return nil
 }
@@ -191,7 +191,7 @@ func (c *Controller) patchIPPoolStatusCondition(ippool *kubeovnv1.IPPool, reason
 	if errMsg != "" {
 		ippool.Status.SetError(reason, errMsg)
 		ippool.Status.NotReady(reason, errMsg)
-		c.recordIPPoolEvent(ippool, corev1.EventTypeWarning, reason, errMsg)
+		c.recordResourceEvent(ippool, corev1.EventTypeWarning, reason, errMsg)
 		return c.patchIPPoolStatus(ippool)
 	}
 
@@ -200,7 +200,7 @@ func (c *Controller) patchIPPoolStatusCondition(ippool *kubeovnv1.IPPool, reason
 		return err
 	}
 	// to observe ippool status change to normal
-	c.recordIPPoolEvent(ippool, corev1.EventTypeNormal, reason, fmt.Sprintf("IPPool %s reconciled successfully", ippool.Name))
+	c.recordResourceEvent(ippool, corev1.EventTypeNormal, reason, fmt.Sprintf("IPPool %s reconciled successfully", ippool.Name))
 	return nil
 }
 

--- a/pkg/controller/ippool.go
+++ b/pkg/controller/ippool.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -92,6 +93,7 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 		klog.Errorf("failed to reconcile address set for ippool %s: %v", ippool.Name, err)
 		if patchErr := c.patchIPPoolStatusCondition(ippool, "ReconcileAddressSetFailed", err.Error()); patchErr != nil {
 			klog.Error(patchErr)
+			return errors.Join(err, c.recordIPPoolError(ippool, "UpdateStatusFailed", patchErr))
 		}
 		return err
 	}
@@ -99,6 +101,7 @@ func (c *Controller) handleAddOrUpdateIPPool(key string) error {
 		klog.Errorf("failed to add/update ippool %s with IPs %v in subnet %s: %v", ippool.Name, ippool.Spec.IPs, ippool.Spec.Subnet, err)
 		if patchErr := c.patchIPPoolStatusCondition(ippool, "UpdateIPAMFailed", err.Error()); patchErr != nil {
 			klog.Error(patchErr)
+			return errors.Join(err, c.recordIPPoolError(ippool, "UpdateStatusFailed", patchErr))
 		}
 		return err
 	}
@@ -189,13 +192,16 @@ func (c *Controller) patchIPPoolStatusCondition(ippool *kubeovnv1.IPPool, reason
 		ippool.Status.SetError(reason, errMsg)
 		ippool.Status.NotReady(reason, errMsg)
 		c.recordIPPoolEvent(ippool, corev1.EventTypeWarning, reason, errMsg)
-	} else {
-		ippool.Status.Ready(reason, "")
-		// to observe ippool status change to normal
-		c.recordIPPoolEvent(ippool, corev1.EventTypeNormal, reason, fmt.Sprintf("IPPool %s reconciled successfully", ippool.Name))
+		return c.patchIPPoolStatus(ippool)
 	}
 
-	return c.patchIPPoolStatus(ippool)
+	ippool.Status.Ready(reason, "")
+	if err := c.patchIPPoolStatus(ippool); err != nil {
+		return err
+	}
+	// to observe ippool status change to normal
+	c.recordIPPoolEvent(ippool, corev1.EventTypeNormal, reason, fmt.Sprintf("IPPool %s reconciled successfully", ippool.Name))
+	return nil
 }
 
 func (c *Controller) patchIPPoolStatus(ippool *kubeovnv1.IPPool) error {

--- a/pkg/controller/resource_events.go
+++ b/pkg/controller/resource_events.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+func (c *Controller) recordSubnetEvent(subnet *kubeovnv1.Subnet, eventType, reason, message string) {
+	if c.recorder == nil || subnet == nil {
+		return
+	}
+	c.recorder.Eventf(subnet, eventType, reason, "%s", message)
+}
+
+func (c *Controller) recordSubnetError(subnet *kubeovnv1.Subnet, reason string, err error) error {
+	if err != nil {
+		c.recordSubnetEvent(subnet, corev1.EventTypeWarning, reason, err.Error())
+	}
+	return err
+}
+
+func (c *Controller) recordSubnetKeyError(name, reason string, err error) error {
+	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	return c.recordSubnetError(subnet, reason, err)
+}
+
+func (c *Controller) recordIPPoolEvent(ippool *kubeovnv1.IPPool, eventType, reason, message string) {
+	if c.recorder == nil || ippool == nil {
+		return
+	}
+	c.recorder.Eventf(ippool, eventType, reason, "%s", message)
+}
+
+func (c *Controller) recordIPPoolError(ippool *kubeovnv1.IPPool, reason string, err error) error {
+	if err != nil {
+		c.recordIPPoolEvent(ippool, corev1.EventTypeWarning, reason, err.Error())
+	}
+	return err
+}
+
+func (c *Controller) recordIPPoolKeyError(name, reason string, err error) error {
+	ippool := &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	return c.recordIPPoolError(ippool, reason, err)
+}

--- a/pkg/controller/resource_events.go
+++ b/pkg/controller/resource_events.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -29,11 +28,11 @@ func (c *Controller) recordResourceError(object runtime.Object, reason string, e
 }
 
 func (c *Controller) recordSubnetKeyError(name, reason string, err error) error {
-	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	subnet := &kubeovnv1.Subnet{Name: name}
 	return c.recordResourceError(subnet, reason, err)
 }
 
 func (c *Controller) recordIPPoolKeyError(name, reason string, err error) error {
-	ippool := &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	ippool := &kubeovnv1.IPPool{Name: name}
 	return c.recordResourceError(ippool, reason, err)
 }

--- a/pkg/controller/resource_events.go
+++ b/pkg/controller/resource_events.go
@@ -1,46 +1,39 @@
 package controller
 
 import (
+	"reflect"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
 
-func (c *Controller) recordSubnetEvent(subnet *kubeovnv1.Subnet, eventType, reason, message string) {
-	if c.recorder == nil || subnet == nil {
+func (c *Controller) recordResourceEvent(object runtime.Object, eventType, reason, message string) {
+	if c.recorder == nil || object == nil {
 		return
 	}
-	c.recorder.Eventf(subnet, eventType, reason, "%s", message)
+	value := reflect.ValueOf(object)
+	if value.Kind() == reflect.Pointer && value.IsNil() {
+		return
+	}
+	c.recorder.Eventf(object, eventType, reason, "%s", message)
 }
 
-func (c *Controller) recordSubnetError(subnet *kubeovnv1.Subnet, reason string, err error) error {
+func (c *Controller) recordResourceError(object runtime.Object, reason string, err error) error {
 	if err != nil {
-		c.recordSubnetEvent(subnet, corev1.EventTypeWarning, reason, err.Error())
+		c.recordResourceEvent(object, corev1.EventTypeWarning, reason, err.Error())
 	}
 	return err
 }
 
 func (c *Controller) recordSubnetKeyError(name, reason string, err error) error {
 	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	return c.recordSubnetError(subnet, reason, err)
-}
-
-func (c *Controller) recordIPPoolEvent(ippool *kubeovnv1.IPPool, eventType, reason, message string) {
-	if c.recorder == nil || ippool == nil {
-		return
-	}
-	c.recorder.Eventf(ippool, eventType, reason, "%s", message)
-}
-
-func (c *Controller) recordIPPoolError(ippool *kubeovnv1.IPPool, reason string, err error) error {
-	if err != nil {
-		c.recordIPPoolEvent(ippool, corev1.EventTypeWarning, reason, err.Error())
-	}
-	return err
+	return c.recordResourceError(subnet, reason, err)
 }
 
 func (c *Controller) recordIPPoolKeyError(name, reason string, err error) error {
 	ippool := &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	return c.recordIPPoolError(ippool, reason, err)
+	return c.recordResourceError(ippool, reason, err)
 }

--- a/pkg/controller/resource_events_test.go
+++ b/pkg/controller/resource_events_test.go
@@ -31,7 +31,7 @@ func (r *objectCapturingRecorder) Eventf(object runtime.Object, eventType, reaso
 func TestRecordResourceError(t *testing.T) {
 	recorder := record.NewFakeRecorder(1)
 	c := &Controller{recorder: recorder}
-	object := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}
+	object := &kubeovnv1.Subnet{Name: "subnet-a"}
 	sourceErr := errors.New("boom")
 
 	err := c.recordResourceError(object, "ReconcileSubnetFailed", sourceErr)
@@ -58,8 +58,8 @@ func TestResourceEventHelpersAllowMissingRecorderAndObject(t *testing.T) {
 
 func TestHandleAddOrUpdateSubnetRecordsFormatFailure(t *testing.T) {
 	subnet := &kubeovnv1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{Name: "invalid-subnet"},
-		Spec:       kubeovnv1.SubnetSpec{CIDRBlock: "invalid"},
+		Name: "invalid-subnet",
+		Spec: kubeovnv1.SubnetSpec{CIDRBlock: "invalid"},
 	}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Subnets: []*kubeovnv1.Subnet{subnet}})
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestHandleAddOrUpdateSubnetRecordsFormatFailure(t *testing.T) {
 
 func TestHandleAddOrUpdateSubnetRecordsStatusCalculationFailure(t *testing.T) {
 	subnet := &kubeovnv1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"},
+		Name: "subnet-a",
 		Spec: kubeovnv1.SubnetSpec{
 			Vpc:       util.DefaultVpc,
 			CIDRBlock: "10.16.0.0/24",
@@ -94,11 +94,9 @@ func TestHandleAddOrUpdateSubnetRecordsStatusCalculationFailure(t *testing.T) {
 
 func TestHandleAddOrUpdateIPPoolRecordsStatusPatchFailure(t *testing.T) {
 	ippool := &kubeovnv1.IPPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "pool-a",
-			Finalizers: []string{util.KubeOVNControllerFinalizer},
-		},
-		Spec: kubeovnv1.IPPoolSpec{Subnet: "subnet-a"},
+		Name:       "pool-a",
+		Finalizers: []string{util.KubeOVNControllerFinalizer},
+		Spec:       kubeovnv1.IPPoolSpec{Subnet: "subnet-a"},
 	}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{IPPools: []*kubeovnv1.IPPool{ippool}})
 	require.NoError(t, err)
@@ -125,7 +123,7 @@ func TestHandleAddOrUpdateIPPoolRecordsStatusPatchFailure(t *testing.T) {
 
 func TestHandleAddOrUpdateSubnetDoesNotRecordSuccessWhenStatusPatchFails(t *testing.T) {
 	subnet := &kubeovnv1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"},
+		Name: "subnet-a",
 		Spec: kubeovnv1.SubnetSpec{
 			Vpc:       util.DefaultVpc,
 			CIDRBlock: "10.16.0.0/24",
@@ -157,7 +155,7 @@ func TestHandleAddOrUpdateSubnetDoesNotRecordSuccessWhenStatusPatchFails(t *test
 
 func TestHandleAddOrUpdateSubnetRecordsFinalizerPatchFailure(t *testing.T) {
 	subnet := &kubeovnv1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"},
+		Name: "subnet-a",
 		Spec: kubeovnv1.SubnetSpec{
 			Vpc:      util.DefaultVpc,
 			Provider: "external.provider",
@@ -165,12 +163,12 @@ func TestHandleAddOrUpdateSubnetRecordsFinalizerPatchFailure(t *testing.T) {
 		},
 	}
 	vlan := &kubeovnv1.Vlan{
-		ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"},
-		Spec:       kubeovnv1.VlanSpec{Provider: "provider-a"},
+		Name: "vlan-a",
+		Spec: kubeovnv1.VlanSpec{Provider: "provider-a"},
 	}
 	providerNetwork := &kubeovnv1.ProviderNetwork{
-		ObjectMeta: metav1.ObjectMeta{Name: "provider-a"},
-		Status:     kubeovnv1.ProviderNetworkStatus{Vlans: []string{"vlan-a"}},
+		Name:   "provider-a",
+		Status: kubeovnv1.ProviderNetworkStatus{Vlans: []string{"vlan-a"}},
 	}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Subnets:          []*kubeovnv1.Subnet{subnet},
@@ -201,10 +199,8 @@ func TestHandleAddOrUpdateSubnetRecordsFinalizerPatchFailure(t *testing.T) {
 
 func TestHandleAddOrUpdateIPPoolDoesNotRecordSuccessWhenStatusPatchFails(t *testing.T) {
 	ippool := &kubeovnv1.IPPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "pool-a",
-			Finalizers: []string{util.KubeOVNControllerFinalizer},
-		},
+		Name:       "pool-a",
+		Finalizers: []string{util.KubeOVNControllerFinalizer},
 		Spec: kubeovnv1.IPPoolSpec{
 			Subnet: "subnet-a",
 			IPs:    []string{"10.16.0.10"},
@@ -239,8 +235,8 @@ func TestHandleAddOrUpdateIPPoolDoesNotRecordSuccessWhenStatusPatchFails(t *test
 func TestRecordResourceSuccessEvents(t *testing.T) {
 	recorder := record.NewFakeRecorder(2)
 	c := &Controller{recorder: recorder}
-	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}
-	ippool := &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "pool-a"}}
+	subnet := &kubeovnv1.Subnet{Name: "subnet-a"}
+	ippool := &kubeovnv1.IPPool{Name: "pool-a"}
 
 	c.recordResourceEvent(subnet, corev1.EventTypeNormal, "ReconcileSuccess", "Subnet subnet-a reconciled successfully")
 	c.recordResourceEvent(ippool, corev1.EventTypeNormal, "DeleteSuccess", "IPPool pool-a deleted successfully")
@@ -269,11 +265,9 @@ func TestHandleDeleteIPPoolRecordsOutcome(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ippool := &kubeovnv1.IPPool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "pool-a",
-					Finalizers: []string{util.KubeOVNControllerFinalizer},
-				},
-				Spec: kubeovnv1.IPPoolSpec{Subnet: "subnet-a"},
+				Name:       "pool-a",
+				Finalizers: []string{util.KubeOVNControllerFinalizer},
+				Spec:       kubeovnv1.IPPoolSpec{Subnet: "subnet-a"},
 			}
 			fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{IPPools: []*kubeovnv1.IPPool{ippool}})
 			require.NoError(t, err)

--- a/pkg/controller/resource_events_test.go
+++ b/pkg/controller/resource_events_test.go
@@ -18,37 +18,42 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-func TestRecordSubnetError(t *testing.T) {
+type objectCapturingRecorder struct {
+	record.EventRecorder
+	objects []runtime.Object
+}
+
+func (r *objectCapturingRecorder) Eventf(object runtime.Object, eventType, reason, messageFmt string, args ...any) {
+	r.objects = append(r.objects, object)
+	r.EventRecorder.Eventf(object, eventType, reason, messageFmt, args...)
+}
+
+func TestRecordResourceError(t *testing.T) {
 	recorder := record.NewFakeRecorder(1)
 	c := &Controller{recorder: recorder}
-	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}
+	object := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}
 	sourceErr := errors.New("boom")
 
-	err := c.recordSubnetError(subnet, "ReconcileSubnetFailed", sourceErr)
+	err := c.recordResourceError(object, "ReconcileSubnetFailed", sourceErr)
 
 	require.ErrorIs(t, err, sourceErr)
 	require.Equal(t, "Warning ReconcileSubnetFailed boom", requireRecorderEvent(t, recorder))
 }
 
-func TestRecordIPPoolError(t *testing.T) {
+func TestResourceEventHelpersAllowMissingRecorderAndObject(t *testing.T) {
 	recorder := record.NewFakeRecorder(1)
 	c := &Controller{recorder: recorder}
-	ippool := &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "pool-a"}}
-	sourceErr := errors.New("boom")
-
-	err := c.recordIPPoolError(ippool, "UpdateIPAMFailed", sourceErr)
-
-	require.ErrorIs(t, err, sourceErr)
-	require.Equal(t, "Warning UpdateIPAMFailed boom", requireRecorderEvent(t, recorder))
-}
-
-func TestResourceEventHelpersAllowMissingRecorderAndObject(t *testing.T) {
-	c := &Controller{}
+	var subnet *kubeovnv1.Subnet
 
 	require.NotPanics(t, func() {
-		c.recordSubnetEvent(nil, corev1.EventTypeNormal, "ReconcileSuccess", "done")
-		c.recordIPPoolEvent(nil, corev1.EventTypeNormal, "ReconcileSuccess", "done")
+		c.recordResourceEvent(nil, corev1.EventTypeNormal, "ReconcileSuccess", "done")
+		c.recordResourceEvent(subnet, corev1.EventTypeNormal, "ReconcileSuccess", "done")
 	})
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event %q", event)
+	default:
+	}
 }
 
 func TestHandleAddOrUpdateSubnetRecordsFormatFailure(t *testing.T) {
@@ -150,6 +155,50 @@ func TestHandleAddOrUpdateSubnetDoesNotRecordSuccessWhenStatusPatchFails(t *test
 	}
 }
 
+func TestHandleAddOrUpdateSubnetRecordsFinalizerPatchFailure(t *testing.T) {
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:      util.DefaultVpc,
+			Provider: "external.provider",
+			Vlan:     "vlan-a",
+		},
+	}
+	vlan := &kubeovnv1.Vlan{
+		ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"},
+		Spec:       kubeovnv1.VlanSpec{Provider: "provider-a"},
+	}
+	providerNetwork := &kubeovnv1.ProviderNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: "provider-a"},
+		Status:     kubeovnv1.ProviderNetworkStatus{Vlans: []string{"vlan-a"}},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets:          []*kubeovnv1.Subnet{subnet},
+		Vlans:            []*kubeovnv1.Vlan{vlan},
+		ProviderNetworks: []*kubeovnv1.ProviderNetwork{providerNetwork},
+	})
+	require.NoError(t, err)
+	controller := fc.fakeController
+	finalizerErr := errors.New("finalizer patch failed")
+	controller.config.KubeOvnClient.(*kubeovnfake.Clientset).PrependReactor("patch", "subnets", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "status" {
+			return false, nil, nil
+		}
+		return true, nil, finalizerErr
+	})
+	fakeRecorder := controller.recorder.(*record.FakeRecorder)
+	recorder := &objectCapturingRecorder{EventRecorder: fakeRecorder}
+	controller.recorder = recorder
+
+	err = controller.handleAddOrUpdateSubnet(subnet.Name)
+
+	require.ErrorIs(t, err, finalizerErr)
+	require.Equal(t, "Normal ValidateLogicalSwitchSuccess Subnet subnet-a status updated successfully", requireRecorderEvent(t, fakeRecorder))
+	require.Equal(t, "Warning UpdateFinalizerFailed finalizer patch failed", requireRecorderEvent(t, fakeRecorder))
+	require.Len(t, recorder.objects, 2)
+	require.Equal(t, "subnet-a", recorder.objects[1].(metav1.Object).GetName())
+}
+
 func TestHandleAddOrUpdateIPPoolDoesNotRecordSuccessWhenStatusPatchFails(t *testing.T) {
 	ippool := &kubeovnv1.IPPool{
 		ObjectMeta: metav1.ObjectMeta{
@@ -193,8 +242,8 @@ func TestRecordResourceSuccessEvents(t *testing.T) {
 	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}
 	ippool := &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "pool-a"}}
 
-	c.recordSubnetEvent(subnet, corev1.EventTypeNormal, "ReconcileSuccess", "Subnet subnet-a reconciled successfully")
-	c.recordIPPoolEvent(ippool, corev1.EventTypeNormal, "DeleteSuccess", "IPPool pool-a deleted successfully")
+	c.recordResourceEvent(subnet, corev1.EventTypeNormal, "ReconcileSuccess", "Subnet subnet-a reconciled successfully")
+	c.recordResourceEvent(ippool, corev1.EventTypeNormal, "DeleteSuccess", "IPPool pool-a deleted successfully")
 
 	require.Equal(t, "Normal ReconcileSuccess Subnet subnet-a reconciled successfully", requireRecorderEvent(t, recorder))
 	require.Equal(t, "Normal DeleteSuccess IPPool pool-a deleted successfully", requireRecorderEvent(t, recorder))

--- a/pkg/controller/resource_events_test.go
+++ b/pkg/controller/resource_events_test.go
@@ -7,10 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/keymutex"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -59,6 +63,128 @@ func TestHandleAddOrUpdateSubnetRecordsFormatFailure(t *testing.T) {
 
 	require.Error(t, err)
 	require.Equal(t, "Warning FormatSubnetFailed failed to format subnet invalid-subnet, subnet invalid-subnet cidr invalid is invalid", requireRecorderEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+}
+
+func TestHandleAddOrUpdateSubnetRecordsStatusCalculationFailure(t *testing.T) {
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       util.DefaultVpc,
+			CIDRBlock: "10.16.0.0/24",
+			Gateway:   "10.16.0.1",
+		},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	controller := fc.fakeController
+	controller.ipIndexer = cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	recorder := controller.recorder.(*record.FakeRecorder)
+
+	err = controller.handleAddOrUpdateSubnet(subnet.Name)
+
+	require.ErrorContains(t, err, "Index with name bySubnet does not exist")
+	require.Equal(t, "Normal ValidateLogicalSwitchSuccess Subnet subnet-a status updated successfully", requireRecorderEvent(t, recorder))
+	require.Equal(t, "Warning CalculateStatusFailed Index with name bySubnet does not exist", requireRecorderEvent(t, recorder))
+}
+
+func TestHandleAddOrUpdateIPPoolRecordsStatusPatchFailure(t *testing.T) {
+	ippool := &kubeovnv1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "pool-a",
+			Finalizers: []string{util.KubeOVNControllerFinalizer},
+		},
+		Spec: kubeovnv1.IPPoolSpec{Subnet: "subnet-a"},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{IPPools: []*kubeovnv1.IPPool{ippool}})
+	require.NoError(t, err)
+	controller := fc.fakeController
+	controller.ippoolKeyMutex = keymutex.NewHashed(0)
+	reconcileErr := errors.New("delete address set failed")
+	statusErr := errors.New("status patch failed")
+	fc.mockOvnClient.EXPECT().DeleteAddressSet("pool.a").Return(reconcileErr)
+	controller.config.KubeOvnClient.(*kubeovnfake.Clientset).PrependReactor("patch", "ippools", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		return true, nil, statusErr
+	})
+	recorder := controller.recorder.(*record.FakeRecorder)
+
+	err = controller.handleAddOrUpdateIPPool(ippool.Name)
+
+	require.ErrorIs(t, err, reconcileErr)
+	require.ErrorIs(t, err, statusErr)
+	require.Equal(t, "Warning ReconcileAddressSetFailed failed to delete address set pool.a: delete address set failed", requireRecorderEvent(t, recorder))
+	require.Equal(t, "Warning UpdateStatusFailed status patch failed", requireRecorderEvent(t, recorder))
+}
+
+func TestHandleAddOrUpdateSubnetDoesNotRecordSuccessWhenStatusPatchFails(t *testing.T) {
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       util.DefaultVpc,
+			CIDRBlock: "10.16.0.0/24",
+			Gateway:   "10.16.0.1",
+		},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+	controller := fc.fakeController
+	statusErr := errors.New("status patch failed")
+	controller.config.KubeOvnClient.(*kubeovnfake.Clientset).PrependReactor("patch", "subnets", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		return true, nil, statusErr
+	})
+	recorder := controller.recorder.(*record.FakeRecorder)
+
+	err = controller.handleAddOrUpdateSubnet(subnet.Name)
+
+	require.ErrorIs(t, err, statusErr)
+	require.Equal(t, "Warning UpdateStatusFailed status patch failed", requireRecorderEvent(t, recorder))
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event %q", event)
+	default:
+	}
+}
+
+func TestHandleAddOrUpdateIPPoolDoesNotRecordSuccessWhenStatusPatchFails(t *testing.T) {
+	ippool := &kubeovnv1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "pool-a",
+			Finalizers: []string{util.KubeOVNControllerFinalizer},
+		},
+		Spec: kubeovnv1.IPPoolSpec{
+			Subnet: "subnet-a",
+			IPs:    []string{"10.16.0.10"},
+		},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{IPPools: []*kubeovnv1.IPPool{ippool}})
+	require.NoError(t, err)
+	controller := fc.fakeController
+	controller.ippoolKeyMutex = keymutex.NewHashed(0)
+	require.NoError(t, controller.ipam.AddOrUpdateSubnet("subnet-a", "10.16.0.0/24", "10.16.0.1", nil))
+	fc.mockOvnClient.EXPECT().DeleteAddressSet("pool.a").Return(nil)
+	statusErr := errors.New("status patch failed")
+	controller.config.KubeOvnClient.(*kubeovnfake.Clientset).PrependReactor("patch", "ippools", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		return true, nil, statusErr
+	})
+	recorder := controller.recorder.(*record.FakeRecorder)
+
+	err = controller.handleAddOrUpdateIPPool(ippool.Name)
+
+	require.ErrorIs(t, err, statusErr)
+	require.Equal(t, "Warning UpdateStatusFailed status patch failed", requireRecorderEvent(t, recorder))
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event %q", event)
+	default:
+	}
 }
 
 func TestRecordResourceSuccessEvents(t *testing.T) {

--- a/pkg/controller/resource_events_test.go
+++ b/pkg/controller/resource_events_test.go
@@ -1,0 +1,118 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/keymutex"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestRecordSubnetError(t *testing.T) {
+	recorder := record.NewFakeRecorder(1)
+	c := &Controller{recorder: recorder}
+	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}
+	sourceErr := errors.New("boom")
+
+	err := c.recordSubnetError(subnet, "ReconcileSubnetFailed", sourceErr)
+
+	require.ErrorIs(t, err, sourceErr)
+	require.Equal(t, "Warning ReconcileSubnetFailed boom", requireRecorderEvent(t, recorder))
+}
+
+func TestRecordIPPoolError(t *testing.T) {
+	recorder := record.NewFakeRecorder(1)
+	c := &Controller{recorder: recorder}
+	ippool := &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "pool-a"}}
+	sourceErr := errors.New("boom")
+
+	err := c.recordIPPoolError(ippool, "UpdateIPAMFailed", sourceErr)
+
+	require.ErrorIs(t, err, sourceErr)
+	require.Equal(t, "Warning UpdateIPAMFailed boom", requireRecorderEvent(t, recorder))
+}
+
+func TestResourceEventHelpersAllowMissingRecorderAndObject(t *testing.T) {
+	c := &Controller{}
+
+	require.NotPanics(t, func() {
+		c.recordSubnetEvent(nil, corev1.EventTypeNormal, "ReconcileSuccess", "done")
+		c.recordIPPoolEvent(nil, corev1.EventTypeNormal, "ReconcileSuccess", "done")
+	})
+}
+
+func TestHandleAddOrUpdateSubnetRecordsFormatFailure(t *testing.T) {
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-subnet"},
+		Spec:       kubeovnv1.SubnetSpec{CIDRBlock: "invalid"},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Subnets: []*kubeovnv1.Subnet{subnet}})
+	require.NoError(t, err)
+
+	err = fc.fakeController.handleAddOrUpdateSubnet(subnet.Name)
+
+	require.Error(t, err)
+	require.Equal(t, "Warning FormatSubnetFailed failed to format subnet invalid-subnet, subnet invalid-subnet cidr invalid is invalid", requireRecorderEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+}
+
+func TestRecordResourceSuccessEvents(t *testing.T) {
+	recorder := record.NewFakeRecorder(2)
+	c := &Controller{recorder: recorder}
+	subnet := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: "subnet-a"}}
+	ippool := &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "pool-a"}}
+
+	c.recordSubnetEvent(subnet, corev1.EventTypeNormal, "ReconcileSuccess", "Subnet subnet-a reconciled successfully")
+	c.recordIPPoolEvent(ippool, corev1.EventTypeNormal, "DeleteSuccess", "IPPool pool-a deleted successfully")
+
+	require.Equal(t, "Normal ReconcileSuccess Subnet subnet-a reconciled successfully", requireRecorderEvent(t, recorder))
+	require.Equal(t, "Normal DeleteSuccess IPPool pool-a deleted successfully", requireRecorderEvent(t, recorder))
+}
+
+func TestHandleDeleteIPPoolRecordsOutcome(t *testing.T) {
+	tests := []struct {
+		name          string
+		deleteErr     error
+		expectedEvent string
+	}{
+		{
+			name:          "failure",
+			deleteErr:     errors.New("delete address set failed"),
+			expectedEvent: "Warning DeleteFailed failed to delete ippool pool-a: delete address set failed",
+		},
+		{
+			name:          "success",
+			expectedEvent: "Normal DeleteSuccess IPPool pool-a deleted successfully",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ippool := &kubeovnv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pool-a",
+					Finalizers: []string{util.KubeOVNControllerFinalizer},
+				},
+				Spec: kubeovnv1.IPPoolSpec{Subnet: "subnet-a"},
+			}
+			fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{IPPools: []*kubeovnv1.IPPool{ippool}})
+			require.NoError(t, err)
+			controller := fc.fakeController
+			controller.ippoolKeyMutex = keymutex.NewHashed(0)
+			fc.mockOvnClient.EXPECT().DeleteAddressSet("pool.a").Return(tt.deleteErr)
+
+			err = controller.handleDeleteIPPool(ippool)
+			if tt.deleteErr != nil {
+				require.ErrorIs(t, err, tt.deleteErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expectedEvent, requireRecorderEvent(t, controller.recorder.(*record.FakeRecorder)))
+		})
+	}
+}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -765,7 +765,7 @@ func (c *Controller) finishOvnSubnetReconcile(subnet *kubeovnv1.Subnet, vpc *kub
 		return c.recordResourceError(subnet, "UpdateNatOutgoingPolicyStatusFailed", err)
 	}
 
-	if err = c.reconcileSubnetBaseACLs(subnet, vpc.Status.Router); err != nil {
+	if err := c.reconcileSubnetBaseACLs(subnet, vpc.Status.Router); err != nil {
 		return err
 	}
 
@@ -817,7 +817,7 @@ func (c *Controller) reconcileSubnetBaseACLs(subnet *kubeovnv1.Subnet, router st
 			klog.Error(lrpErr)
 			if patchErr := c.patchSubnetStatus(subnet, "SetRoutedLogicalSwitchFailed", lrpErr.Error()); patchErr != nil {
 				klog.Error(patchErr)
-				return errors.Join(lrpErr, patchErr)
+				return errors.Join(lrpErr, c.recordResourceError(subnet, "UpdateStatusFailed", patchErr))
 			}
 			return lrpErr
 		}
@@ -825,31 +825,40 @@ func (c *Controller) reconcileSubnetBaseACLs(subnet *kubeovnv1.Subnet, router st
 			klog.Error(routedErr)
 			if patchErr := c.patchSubnetStatus(subnet, "SetRoutedLogicalSwitchFailed", routedErr.Error()); patchErr != nil {
 				klog.Error(patchErr)
-				return errors.Join(routedErr, patchErr)
+				return errors.Join(routedErr, c.recordResourceError(subnet, "UpdateStatusFailed", patchErr))
 			}
 			return routedErr
 		}
-		return c.patchSubnetStatus(subnet, "SetRoutedLogicalSwitchSuccess", "")
+		if err := c.patchSubnetStatus(subnet, "SetRoutedLogicalSwitchSuccess", ""); err != nil {
+			return c.recordResourceError(subnet, "UpdateStatusFailed", err)
+		}
+		return nil
 	case subnet.Spec.Private:
 		if privErr := c.OVNNbClient.SetLogicalSwitchPrivate(subnet.Name, subnet.Spec.CIDRBlock, c.config.NodeSwitchCIDR, subnet.Spec.AllowSubnets); privErr != nil {
 			klog.Error(privErr)
 			if patchErr := c.patchSubnetStatus(subnet, "SetPrivateLogicalSwitchFailed", privErr.Error()); patchErr != nil {
 				klog.Error(patchErr)
-				return errors.Join(privErr, patchErr)
+				return errors.Join(privErr, c.recordResourceError(subnet, "UpdateStatusFailed", patchErr))
 			}
 			return privErr
 		}
-		return c.patchSubnetStatus(subnet, "SetPrivateLogicalSwitchSuccess", "")
+		if err := c.patchSubnetStatus(subnet, "SetPrivateLogicalSwitchSuccess", ""); err != nil {
+			return c.recordResourceError(subnet, "UpdateStatusFailed", err)
+		}
+		return nil
 	default:
 		if aclErr := c.OVNNbClient.DeleteAcls(subnet.Name, logicalSwitchKey, "", nil); aclErr != nil {
 			klog.Error(aclErr)
 			if patchErr := c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclFailed", aclErr.Error()); patchErr != nil {
 				klog.Error(patchErr)
-				return errors.Join(aclErr, patchErr)
+				return errors.Join(aclErr, c.recordResourceError(subnet, "UpdateStatusFailed", patchErr))
 			}
 			return aclErr
 		}
-		return c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", "")
+		if err := c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", ""); err != nil {
+			return c.recordResourceError(subnet, "UpdateStatusFailed", err)
+		}
+		return nil
 	}
 }
 
@@ -1404,7 +1413,7 @@ func (c *Controller) reconcileDistributedSubnetRouteInDefaultVpc(subnet *kubeovn
 		subnet.Status.ActivateGateway = ""
 		if err := c.patchSubnetStatus(subnet, "ChangeToDistributedGw", ""); err != nil {
 			klog.Error(err)
-			return err
+			return c.recordResourceError(subnet, "UpdateStatusFailed", err)
 		}
 	}
 
@@ -1573,7 +1582,7 @@ func (c *Controller) reconcileDefaultCentralizedSubnetRouteInDefaultVpc(subnet *
 	subnet.Status.ActivateGateway = newActivateNode
 	if err := c.patchSubnetStatus(subnet, "ReconcileCentralizedGatewaySuccess", ""); err != nil {
 		klog.Error(err)
-		return err
+		return c.recordResourceError(subnet, "UpdateStatusFailed", err)
 	}
 
 	klog.Infof("delete old distributed policy route for subnet %s", subnet.Name)
@@ -1730,7 +1739,7 @@ func (c *Controller) reconcileOvnDefaultVpcRoute(subnet *kubeovnv1.Subnet) error
 				subnet.Status.NotReady("NoReadyGateway", "")
 				if err := c.patchSubnetStatus(subnet, "NoReadyGateway", ""); err != nil {
 					klog.Error(err)
-					return err
+					return c.recordResourceError(subnet, "UpdateStatusFailed", err)
 				}
 				err := fmt.Errorf("subnet %s Spec.GatewayNode or Spec.GatewayNodeSelectors must be specified for centralized gateway type", subnet.Name)
 				klog.Error(err)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -98,12 +98,12 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 		}
 
 		if oldSubnet.Spec.GatewayType != newSubnet.Spec.GatewayType {
-			c.recordSubnetEvent(newSubnet, v1.EventTypeNormal, "SubnetGatewayTypeChanged",
+			c.recordResourceEvent(newSubnet, v1.EventTypeNormal, "SubnetGatewayTypeChanged",
 				fmt.Sprintf("subnet gateway type changes from %q to %q", oldSubnet.Spec.GatewayType, newSubnet.Spec.GatewayType))
 		}
 
 		if oldSubnet.Spec.GatewayNode != newSubnet.Spec.GatewayNode {
-			c.recordSubnetEvent(newSubnet, v1.EventTypeNormal, "SubnetGatewayNodeChanged",
+			c.recordResourceEvent(newSubnet, v1.EventTypeNormal, "SubnetGatewayNodeChanged",
 				fmt.Sprintf("gateway node changes from %q to %q", oldSubnet.Spec.GatewayNode, newSubnet.Spec.GatewayNode))
 		}
 
@@ -546,7 +546,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	if err != nil {
 		err := fmt.Errorf("failed to format subnet %s, %w", key, err)
 		klog.Error(err)
-		return c.recordSubnetError(cachedSubnet, "FormatSubnetFailed", err)
+		return c.recordResourceError(cachedSubnet, "FormatSubnetFailed", err)
 	}
 
 	err = c.validateSubnetVlan(subnet)
@@ -561,7 +561,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		klog.Error(err)
 		if patchErr := c.patchSubnetStatus(subnet, "ValidateSubnetVlanFailed", err.Error()); patchErr != nil {
 			klog.Error(patchErr)
-			return c.recordSubnetError(subnet, "UpdateStatusFailed", patchErr)
+			return c.recordResourceError(subnet, "UpdateStatusFailed", patchErr)
 		}
 		return err
 	}
@@ -570,26 +570,26 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		klog.Errorf("failed to validate subnet %s, %v", subnet.Name, err)
 		if patchErr := c.patchSubnetStatus(subnet, "ValidateLogicalSwitchFailed", err.Error()); patchErr != nil {
 			klog.Error(patchErr)
-			return c.recordSubnetError(subnet, "UpdateStatusFailed", patchErr)
+			return c.recordResourceError(subnet, "UpdateStatusFailed", patchErr)
 		}
 		return err
 	}
 	if err = c.patchSubnetStatus(subnet, "ValidateLogicalSwitchSuccess", ""); err != nil {
 		klog.Error(err)
-		return c.recordSubnetError(subnet, "UpdateStatusFailed", err)
+		return c.recordResourceError(subnet, "UpdateStatusFailed", err)
 	}
 
 	if subnet.Spec.CIDRBlock != "" {
 		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
 			klog.Error(err)
-			return c.recordSubnetError(subnet, "UpdateIPAMFailed", err)
+			return c.recordResourceError(subnet, "UpdateIPAMFailed", err)
 		}
 
 		// availableIPStr valued from ipam, so leave update subnet.status after ipam process
 		updatedSubnet, err := c.calcSubnetStatusIP(subnet)
 		if err != nil {
 			klog.Errorf("calculate subnet %s used ip failed, %v", cachedSubnet.Name, err)
-			return c.recordSubnetError(subnet, "CalculateStatusFailed", err)
+			return c.recordResourceError(subnet, "CalculateStatusFailed", err)
 		}
 		subnet = updatedSubnet
 	} else {
@@ -599,43 +599,56 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		// is no subnet IP status to calculate.
 		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, "", "", nil); err != nil {
 			klog.Error(err)
-			return c.recordSubnetError(subnet, "UpdateIPAMFailed", err)
+			return c.recordResourceError(subnet, "UpdateIPAMFailed", err)
 		}
 		klog.Infof("registered mac-only subnet %s in IPAM (no cidrBlock, BYO-DHCP / external DHCP)", subnet.Name)
 	}
 
-	subnet, deleted, err := c.handleSubnetFinalizer(subnet)
+	updatedSubnet, deleted, err := c.handleSubnetFinalizer(subnet)
 	if err != nil {
 		klog.Errorf("handle subnet finalizer failed %v", err)
-		return c.recordSubnetError(subnet, "UpdateFinalizerFailed", err)
+		return c.recordResourceError(subnet, "UpdateFinalizerFailed", err)
 	}
+	subnet = updatedSubnet
 	if deleted {
 		return nil
 	}
 
 	if !isOvnSubnet(subnet) {
-		// subnet provider is not ovn, and vpc is empty, should not reconcile
-		if err = c.patchSubnetStatus(subnet, "SetNonOvnSubnetSuccess", ""); err != nil {
-			klog.Error(err)
-			return c.recordSubnetError(subnet, "UpdateStatusFailed", err)
-		}
-
-		subnet.Status.EnsureStandardConditions()
-		klog.Infof("non ovn subnet %s is ready", subnet.Name)
-		c.recordSubnetEvent(subnet, v1.EventTypeNormal, "ReconcileSuccess", fmt.Sprintf("Subnet %s reconciled successfully", subnet.Name))
-		return nil
+		return c.finishNonOvnSubnetReconcile(subnet)
 	}
 
+	vpc, err := c.prepareOvnSubnet(subnet)
+	if err != nil {
+		return err
+	}
+	return c.finishOvnSubnetReconcile(subnet, vpc)
+}
+
+func (c *Controller) finishNonOvnSubnetReconcile(subnet *kubeovnv1.Subnet) error {
+	// subnet provider is not ovn, and vpc is empty, should not reconcile
+	if err := c.patchSubnetStatus(subnet, "SetNonOvnSubnetSuccess", ""); err != nil {
+		klog.Error(err)
+		return c.recordResourceError(subnet, "UpdateStatusFailed", err)
+	}
+
+	subnet.Status.EnsureStandardConditions()
+	klog.Infof("non ovn subnet %s is ready", subnet.Name)
+	c.recordResourceEvent(subnet, v1.EventTypeNormal, "ReconcileSuccess", fmt.Sprintf("Subnet %s reconciled successfully", subnet.Name))
+	return nil
+}
+
+func (c *Controller) prepareOvnSubnet(subnet *kubeovnv1.Subnet) (*kubeovnv1.Vpc, error) {
 	// This validate should be processed after isOvnSubnet, since maybe there's no vpc for subnet not managed by kube-ovn
 	vpc, err := c.validateVpcBySubnet(subnet)
 	if err != nil {
 		klog.Errorf("failed to get subnet's vpc '%s', %v", subnet.Spec.Vpc, err)
-		return c.recordSubnetError(subnet, "ValidateVpcFailed", err)
+		return nil, c.recordResourceError(subnet, "ValidateVpcFailed", err)
 	}
 	_, isMcastQuerierChanged, err := c.reconcileSubnetSpecialIPs(subnet)
 	if err != nil {
 		klog.Errorf("failed to reconcile subnet %s Custom IPs %v", subnet.Name, err)
-		return c.recordSubnetError(subnet, "ReconcileSpecialIPsFailed", err)
+		return nil, c.recordResourceError(subnet, "ReconcileSpecialIPsFailed", err)
 	}
 
 	needRouter := subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway ||
@@ -654,7 +667,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 
 	if err := c.clearOldU2OResource(subnet); err != nil {
 		klog.Errorf("clear subnet %s old u2o resource failed: %v", subnet.Name, err)
-		return c.recordSubnetError(subnet, "ClearU2OResourcesFailed", err)
+		return nil, c.recordResourceError(subnet, "ClearU2OResourcesFailed", err)
 	}
 
 	// Lock VPC to prevent CIDR conflict between concurrent subnet creations in the same VPC
@@ -673,7 +686,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 		return nil
 	}(); err != nil {
-		return c.recordSubnetError(subnet, "CreateLogicalSwitchFailed", err)
+		return nil, c.recordResourceError(subnet, "CreateLogicalSwitchFailed", err)
 	}
 
 	// Record the gateway MAC in ipam if router port exists
@@ -691,46 +704,55 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	if isMcastQuerierChanged {
 		if err := c.handleMcastQuerierChange(subnet); err != nil {
 			klog.Errorf("failed to handle mcast querier IP change for subnet %s: %v", subnet.Name, err)
-			return c.recordSubnetError(subnet, "UpdateMcastQuerierFailed", err)
+			return nil, c.recordResourceError(subnet, "UpdateMcastQuerierFailed", err)
 		}
 	}
 
 	subnet.Status.EnsureStandardConditions()
-
 	if err := c.updateSubnetDHCPOption(subnet, needRouter); err != nil {
 		klog.Errorf("failed to update subnet %s dhcpOptions: %v", subnet.Name, err)
-		return c.recordSubnetError(subnet, "UpdateDHCPOptionsFailed", err)
+		return nil, c.recordResourceError(subnet, "UpdateDHCPOptionsFailed", err)
 	}
-
-	if c.config.EnableLb && subnet.Name != c.config.NodeSwitch {
-		lbs := []string{
-			vpc.Status.TCPLoadBalancer,
-			vpc.Status.TCPSessionLoadBalancer,
-			vpc.Status.UDPLoadBalancer,
-			vpc.Status.UDPSessionLoadBalancer,
-			vpc.Status.SctpLoadBalancer,
-			vpc.Status.SctpSessionLoadBalancer,
-		}
-		if subnet.Spec.EnableLb != nil && *subnet.Spec.EnableLb {
-			if lbErr := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(subnet.Name, ovsdb.MutateOperationInsert, lbs...); lbErr != nil {
-				klog.Error(lbErr)
-				if patchErr := c.patchSubnetStatus(subnet, "AddLbToLogicalSwitchFailed", lbErr.Error()); patchErr != nil {
-					klog.Error(patchErr)
-					return c.recordSubnetError(subnet, "UpdateStatusFailed", errors.Join(lbErr, patchErr))
-				}
-				return lbErr
-			}
-		} else {
-			if err := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(subnet.Name, ovsdb.MutateOperationDelete, lbs...); err != nil {
-				klog.Errorf("remove load-balancer from subnet %s failed: %v", subnet.Name, err)
-				return c.recordSubnetError(subnet, "RemoveLbFromLogicalSwitchFailed", err)
-			}
-		}
+	if err := c.updateSubnetLoadBalancers(subnet, vpc); err != nil {
+		return nil, err
 	}
+	return vpc, nil
+}
 
+func (c *Controller) updateSubnetLoadBalancers(subnet *kubeovnv1.Subnet, vpc *kubeovnv1.Vpc) error {
+	if !c.config.EnableLb || subnet.Name == c.config.NodeSwitch {
+		return nil
+	}
+	lbs := []string{
+		vpc.Status.TCPLoadBalancer,
+		vpc.Status.TCPSessionLoadBalancer,
+		vpc.Status.UDPLoadBalancer,
+		vpc.Status.UDPSessionLoadBalancer,
+		vpc.Status.SctpLoadBalancer,
+		vpc.Status.SctpSessionLoadBalancer,
+	}
+	if subnet.Spec.EnableLb != nil && *subnet.Spec.EnableLb {
+		if lbErr := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(subnet.Name, ovsdb.MutateOperationInsert, lbs...); lbErr != nil {
+			klog.Error(lbErr)
+			if patchErr := c.patchSubnetStatus(subnet, "AddLbToLogicalSwitchFailed", lbErr.Error()); patchErr != nil {
+				klog.Error(patchErr)
+				return c.recordResourceError(subnet, "UpdateStatusFailed", errors.Join(lbErr, patchErr))
+			}
+			return lbErr
+		}
+		return nil
+	}
+	if err := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(subnet.Name, ovsdb.MutateOperationDelete, lbs...); err != nil {
+		klog.Errorf("remove load-balancer from subnet %s failed: %v", subnet.Name, err)
+		return c.recordResourceError(subnet, "RemoveLbFromLogicalSwitchFailed", err)
+	}
+	return nil
+}
+
+func (c *Controller) finishOvnSubnetReconcile(subnet *kubeovnv1.Subnet, vpc *kubeovnv1.Vpc) error {
 	if err := c.reconcileSubnet(subnet); err != nil {
 		klog.Errorf("reconcile subnet for %s failed, %v", subnet.Name, err)
-		return c.recordSubnetError(subnet, "ReconcileSubnetFailed", err)
+		return c.recordResourceError(subnet, "ReconcileSubnetFailed", err)
 	}
 
 	subnet.Status.U2OInterconnectionVPC = ""
@@ -738,9 +760,9 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		subnet.Status.U2OInterconnectionVPC = vpc.Status.Router
 	}
 
-	if err = c.updateNatOutgoingPolicyRulesStatus(subnet); err != nil {
+	if err := c.updateNatOutgoingPolicyRulesStatus(subnet); err != nil {
 		klog.Errorf("failed to update NAT outgoing policy status for subnet %s: %v", subnet.Name, err)
-		return c.recordSubnetError(subnet, "UpdateNatOutgoingPolicyStatusFailed", err)
+		return c.recordResourceError(subnet, "UpdateNatOutgoingPolicyStatusFailed", err)
 	}
 
 	if err = c.reconcileSubnetBaseACLs(subnet, vpc.Status.Router); err != nil {
@@ -758,7 +780,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		klog.Error(aclErr)
 		if patchErr := c.patchSubnetStatus(subnet, "SetLogicalSwitchAclsFailed", aclErr.Error()); patchErr != nil {
 			klog.Error(patchErr)
-			return c.recordSubnetError(subnet, "UpdateStatusFailed", errors.Join(aclErr, patchErr))
+			return c.recordResourceError(subnet, "UpdateStatusFailed", errors.Join(aclErr, patchErr))
 		}
 		return aclErr
 	}
@@ -768,7 +790,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	ippools, err := c.ippoolLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list ippools: %v", err)
-		return c.recordSubnetError(subnet, "ListIPPoolsFailed", err)
+		return c.recordResourceError(subnet, "ListIPPoolsFailed", err)
 	}
 
 	for _, p := range ippools {
@@ -777,8 +799,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 	}
 
-	c.recordSubnetEvent(subnet, v1.EventTypeNormal, "ReconcileSuccess", fmt.Sprintf("Subnet %s reconciled successfully", subnet.Name))
-
+	c.recordResourceEvent(subnet, v1.EventTypeNormal, "ReconcileSuccess", fmt.Sprintf("Subnet %s reconciled successfully", subnet.Name))
 	return nil
 }
 
@@ -888,7 +909,7 @@ func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) (err error) {
 	defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
 	defer func() {
 		if err != nil {
-			_ = c.recordSubnetError(subnet, "DeleteFailed", fmt.Errorf("failed to delete subnet %s: %w", subnet.Name, err))
+			_ = c.recordResourceError(subnet, "DeleteFailed", fmt.Errorf("failed to delete subnet %s: %w", subnet.Name, err))
 		}
 	}()
 
@@ -971,7 +992,7 @@ func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) (err error) {
 		}
 	}
 
-	c.recordSubnetEvent(subnet, v1.EventTypeNormal, "DeleteSuccess", fmt.Sprintf("Subnet %s deleted successfully", subnet.Name))
+	c.recordResourceEvent(subnet, v1.EventTypeNormal, "DeleteSuccess", fmt.Sprintf("Subnet %s deleted successfully", subnet.Name))
 
 	return nil
 }

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -98,13 +98,13 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 		}
 
 		if oldSubnet.Spec.GatewayType != newSubnet.Spec.GatewayType {
-			c.recorder.Eventf(newSubnet, v1.EventTypeNormal, "SubnetGatewayTypeChanged",
-				"subnet gateway type changes from %q to %q", oldSubnet.Spec.GatewayType, newSubnet.Spec.GatewayType)
+			c.recordSubnetEvent(newSubnet, v1.EventTypeNormal, "SubnetGatewayTypeChanged",
+				fmt.Sprintf("subnet gateway type changes from %q to %q", oldSubnet.Spec.GatewayType, newSubnet.Spec.GatewayType))
 		}
 
 		if oldSubnet.Spec.GatewayNode != newSubnet.Spec.GatewayNode {
-			c.recorder.Eventf(newSubnet, v1.EventTypeNormal, "SubnetGatewayNodeChanged",
-				"gateway node changes from %q to %q", oldSubnet.Spec.GatewayNode, newSubnet.Spec.GatewayNode)
+			c.recordSubnetEvent(newSubnet, v1.EventTypeNormal, "SubnetGatewayNodeChanged",
+				fmt.Sprintf("gateway node changes from %q to %q", oldSubnet.Spec.GatewayNode, newSubnet.Spec.GatewayNode))
 		}
 
 		c.addOrUpdateSubnetQueue.Add(key)
@@ -539,14 +539,14 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 			return nil
 		}
 		klog.Error(err)
-		return err
+		return c.recordSubnetKeyError(key, "GetSubnetFailed", err)
 	}
 	klog.V(3).Infof("handle add or update subnet %s", cachedSubnet.Name)
 	subnet, err := c.formatSubnet(cachedSubnet)
 	if err != nil {
 		err := fmt.Errorf("failed to format subnet %s, %w", key, err)
 		klog.Error(err)
-		return err
+		return c.recordSubnetError(cachedSubnet, "FormatSubnetFailed", err)
 	}
 
 	err = c.validateSubnetVlan(subnet)
@@ -561,7 +561,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		klog.Error(err)
 		if patchErr := c.patchSubnetStatus(subnet, "ValidateSubnetVlanFailed", err.Error()); patchErr != nil {
 			klog.Error(patchErr)
-			return patchErr
+			return c.recordSubnetError(subnet, "UpdateStatusFailed", patchErr)
 		}
 		return err
 	}
@@ -570,26 +570,26 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		klog.Errorf("failed to validate subnet %s, %v", subnet.Name, err)
 		if patchErr := c.patchSubnetStatus(subnet, "ValidateLogicalSwitchFailed", err.Error()); patchErr != nil {
 			klog.Error(patchErr)
-			return patchErr
+			return c.recordSubnetError(subnet, "UpdateStatusFailed", patchErr)
 		}
 		return err
 	}
 	if err = c.patchSubnetStatus(subnet, "ValidateLogicalSwitchSuccess", ""); err != nil {
 		klog.Error(err)
-		return err
+		return c.recordSubnetError(subnet, "UpdateStatusFailed", err)
 	}
 
 	if subnet.Spec.CIDRBlock != "" {
 		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
 			klog.Error(err)
-			return err
+			return c.recordSubnetError(subnet, "UpdateIPAMFailed", err)
 		}
 
 		// availableIPStr valued from ipam, so leave update subnet.status after ipam process
 		subnet, err = c.calcSubnetStatusIP(subnet)
 		if err != nil {
 			klog.Errorf("calculate subnet %s used ip failed, %v", cachedSubnet.Name, err)
-			return err
+			return c.recordSubnetError(subnet, "CalculateStatusFailed", err)
 		}
 	} else {
 		// Mac-only subnet (underlay without CIDR, BYO-DHCP / external DHCP). Register a
@@ -598,7 +598,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		// is no subnet IP status to calculate.
 		if err := c.ipam.AddOrUpdateSubnet(subnet.Name, "", "", nil); err != nil {
 			klog.Error(err)
-			return err
+			return c.recordSubnetError(subnet, "UpdateIPAMFailed", err)
 		}
 		klog.Infof("registered mac-only subnet %s in IPAM (no cidrBlock, BYO-DHCP / external DHCP)", subnet.Name)
 	}
@@ -606,7 +606,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	subnet, deleted, err := c.handleSubnetFinalizer(subnet)
 	if err != nil {
 		klog.Errorf("handle subnet finalizer failed %v", err)
-		return err
+		return c.recordSubnetError(subnet, "UpdateFinalizerFailed", err)
 	}
 	if deleted {
 		return nil
@@ -616,11 +616,12 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		// subnet provider is not ovn, and vpc is empty, should not reconcile
 		if err = c.patchSubnetStatus(subnet, "SetNonOvnSubnetSuccess", ""); err != nil {
 			klog.Error(err)
-			return err
+			return c.recordSubnetError(subnet, "UpdateStatusFailed", err)
 		}
 
 		subnet.Status.EnsureStandardConditions()
 		klog.Infof("non ovn subnet %s is ready", subnet.Name)
+		c.recordSubnetEvent(subnet, v1.EventTypeNormal, "ReconcileSuccess", fmt.Sprintf("Subnet %s reconciled successfully", subnet.Name))
 		return nil
 	}
 
@@ -628,12 +629,12 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	vpc, err := c.validateVpcBySubnet(subnet)
 	if err != nil {
 		klog.Errorf("failed to get subnet's vpc '%s', %v", subnet.Spec.Vpc, err)
-		return err
+		return c.recordSubnetError(subnet, "ValidateVpcFailed", err)
 	}
 	_, isMcastQuerierChanged, err := c.reconcileSubnetSpecialIPs(subnet)
 	if err != nil {
 		klog.Errorf("failed to reconcile subnet %s Custom IPs %v", subnet.Name, err)
-		return err
+		return c.recordSubnetError(subnet, "ReconcileSpecialIPsFailed", err)
 	}
 
 	needRouter := subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway ||
@@ -652,7 +653,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 
 	if err := c.clearOldU2OResource(subnet); err != nil {
 		klog.Errorf("clear subnet %s old u2o resource failed: %v", subnet.Name, err)
-		return err
+		return c.recordSubnetError(subnet, "ClearU2OResourcesFailed", err)
 	}
 
 	// Lock VPC to prevent CIDR conflict between concurrent subnet creations in the same VPC
@@ -671,7 +672,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 		return nil
 	}(); err != nil {
-		return err
+		return c.recordSubnetError(subnet, "CreateLogicalSwitchFailed", err)
 	}
 
 	// Record the gateway MAC in ipam if router port exists
@@ -689,7 +690,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	if isMcastQuerierChanged {
 		if err := c.handleMcastQuerierChange(subnet); err != nil {
 			klog.Errorf("failed to handle mcast querier IP change for subnet %s: %v", subnet.Name, err)
-			return err
+			return c.recordSubnetError(subnet, "UpdateMcastQuerierFailed", err)
 		}
 	}
 
@@ -697,7 +698,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 
 	if err := c.updateSubnetDHCPOption(subnet, needRouter); err != nil {
 		klog.Errorf("failed to update subnet %s dhcpOptions: %v", subnet.Name, err)
-		return err
+		return c.recordSubnetError(subnet, "UpdateDHCPOptionsFailed", err)
 	}
 
 	if c.config.EnableLb && subnet.Name != c.config.NodeSwitch {
@@ -714,21 +715,21 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 				klog.Error(lbErr)
 				if patchErr := c.patchSubnetStatus(subnet, "AddLbToLogicalSwitchFailed", lbErr.Error()); patchErr != nil {
 					klog.Error(patchErr)
-					return errors.Join(lbErr, patchErr)
+					return c.recordSubnetError(subnet, "UpdateStatusFailed", errors.Join(lbErr, patchErr))
 				}
 				return lbErr
 			}
 		} else {
 			if err := c.OVNNbClient.LogicalSwitchUpdateLoadBalancers(subnet.Name, ovsdb.MutateOperationDelete, lbs...); err != nil {
 				klog.Errorf("remove load-balancer from subnet %s failed: %v", subnet.Name, err)
-				return err
+				return c.recordSubnetError(subnet, "RemoveLbFromLogicalSwitchFailed", err)
 			}
 		}
 	}
 
 	if err := c.reconcileSubnet(subnet); err != nil {
 		klog.Errorf("reconcile subnet for %s failed, %v", subnet.Name, err)
-		return err
+		return c.recordSubnetError(subnet, "ReconcileSubnetFailed", err)
 	}
 
 	subnet.Status.U2OInterconnectionVPC = ""
@@ -738,7 +739,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 
 	if err = c.updateNatOutgoingPolicyRulesStatus(subnet); err != nil {
 		klog.Errorf("failed to update NAT outgoing policy status for subnet %s: %v", subnet.Name, err)
-		return err
+		return c.recordSubnetError(subnet, "UpdateNatOutgoingPolicyStatusFailed", err)
 	}
 
 	if err = c.reconcileSubnetBaseACLs(subnet, vpc.Status.Router); err != nil {
@@ -756,7 +757,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		klog.Error(aclErr)
 		if patchErr := c.patchSubnetStatus(subnet, "SetLogicalSwitchAclsFailed", aclErr.Error()); patchErr != nil {
 			klog.Error(patchErr)
-			return errors.Join(aclErr, patchErr)
+			return c.recordSubnetError(subnet, "UpdateStatusFailed", errors.Join(aclErr, patchErr))
 		}
 		return aclErr
 	}
@@ -766,7 +767,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	ippools, err := c.ippoolLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list ippools: %v", err)
-		return err
+		return c.recordSubnetError(subnet, "ListIPPoolsFailed", err)
 	}
 
 	for _, p := range ippools {
@@ -774,6 +775,8 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 			c.addOrUpdateIPPoolQueue.Add(p.Name)
 		}
 	}
+
+	c.recordSubnetEvent(subnet, v1.EventTypeNormal, "ReconcileSuccess", fmt.Sprintf("Subnet %s reconciled successfully", subnet.Name))
 
 	return nil
 }
@@ -879,9 +882,14 @@ func (c *Controller) handleDeleteLogicalSwitch(key string) (err error) {
 	return c.delLocalnet(key)
 }
 
-func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) error {
+func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) (err error) {
 	c.subnetKeyMutex.LockKey(subnet.Name)
 	defer func() { _ = c.subnetKeyMutex.UnlockKey(subnet.Name) }()
+	defer func() {
+		if err != nil {
+			_ = c.recordSubnetError(subnet, "DeleteFailed", fmt.Errorf("failed to delete subnet %s: %w", subnet.Name, err))
+		}
+	}()
 
 	c.updateVpcStatusQueue.Add(subnet.Spec.Vpc)
 	klog.Infof("delete u2o interconnection policy route for subnet %s", subnet.Name)
@@ -924,7 +932,7 @@ func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) error {
 		return err
 	}
 
-	err := c.handleDeleteLogicalSwitch(subnet.Name)
+	err = c.handleDeleteLogicalSwitch(subnet.Name)
 	if err != nil {
 		klog.Errorf("failed to delete logical switch %s %v", subnet.Name, err)
 		return err
@@ -961,6 +969,8 @@ func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) error {
 			return err
 		}
 	}
+
+	c.recordSubnetEvent(subnet, v1.EventTypeNormal, "DeleteSuccess", fmt.Sprintf("Subnet %s deleted successfully", subnet.Name))
 
 	return nil
 }

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -586,11 +586,12 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 
 		// availableIPStr valued from ipam, so leave update subnet.status after ipam process
-		subnet, err = c.calcSubnetStatusIP(subnet)
+		updatedSubnet, err := c.calcSubnetStatusIP(subnet)
 		if err != nil {
 			klog.Errorf("calculate subnet %s used ip failed, %v", cachedSubnet.Name, err)
 			return c.recordSubnetError(subnet, "CalculateStatusFailed", err)
 		}
+		subnet = updatedSubnet
 	} else {
 		// Mac-only subnet (underlay without CIDR, BYO-DHCP / external DHCP). Register a
 		// lightweight IPAM entry so MAC allocations are tracked and the GC does not

--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -56,10 +56,10 @@ func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr 
 			subnet.Status.Validated(reason, "")
 		}
 		subnet.Status.NotReady(reason, errStr)
-		c.recorder.Eventf(subnet, v1.EventTypeWarning, reason, "%s", errStr)
+		c.recordSubnetEvent(subnet, v1.EventTypeWarning, reason, errStr)
 	} else {
 		subnet.Status.Validated(reason, "")
-		c.recorder.Eventf(subnet, v1.EventTypeNormal, reason, "%s", errStr)
+		c.recordSubnetEvent(subnet, v1.EventTypeNormal, reason, fmt.Sprintf("Subnet %s status updated successfully", subnet.Name))
 		if reason == "SetPrivateLogicalSwitchSuccess" ||
 			reason == "ResetLogicalSwitchAclSuccess" ||
 			reason == "ReconcileCentralizedGatewaySuccess" ||
@@ -85,19 +85,19 @@ func (c *Controller) handleUpdateSubnetStatus(key string) error {
 	defer func() { _ = c.subnetKeyMutex.UnlockKey(key) }()
 
 	cachedSubnet, err := c.subnetsLister.Get(key)
-	subnet := cachedSubnet.DeepCopy()
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 		klog.Error(err)
-		return err
+		return c.recordSubnetKeyError(key, "GetSubnetFailed", err)
 	}
+	subnet := cachedSubnet.DeepCopy()
 
 	ippools, err := c.ippoolLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list ippool: %v", err)
-		return err
+		return c.recordSubnetError(subnet, "ListIPPoolsFailed", err)
 	}
 	for _, p := range ippools {
 		if p.Spec.Subnet == subnet.Name {
@@ -108,12 +108,12 @@ func (c *Controller) handleUpdateSubnetStatus(key string) error {
 	if subnet.Spec.CIDRBlock != "" {
 		if _, err = c.calcSubnetStatusIP(subnet); err != nil {
 			klog.Error(err)
-			return err
+			return c.recordSubnetError(subnet, "CalculateStatusFailed", err)
 		}
 
 		if err := c.checkSubnetUsingIPs(subnet); err != nil {
 			klog.Errorf("inconsistency detected in status of subnet %s : %v", subnet.Name, err)
-			return err
+			return c.recordSubnetError(subnet, "CheckStatusConsistencyFailed", err)
 		}
 	}
 	return nil

--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -56,7 +56,7 @@ func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr 
 			subnet.Status.Validated(reason, "")
 		}
 		subnet.Status.NotReady(reason, errStr)
-		c.recordSubnetEvent(subnet, v1.EventTypeWarning, reason, errStr)
+		c.recordResourceEvent(subnet, v1.EventTypeWarning, reason, errStr)
 	} else {
 		subnet.Status.Validated(reason, "")
 		if reason == "SetPrivateLogicalSwitchSuccess" ||
@@ -77,7 +77,7 @@ func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr 
 		return err
 	}
 	if errStr == "" {
-		c.recordSubnetEvent(subnet, v1.EventTypeNormal, reason, fmt.Sprintf("Subnet %s status updated successfully", subnet.Name))
+		c.recordResourceEvent(subnet, v1.EventTypeNormal, reason, fmt.Sprintf("Subnet %s status updated successfully", subnet.Name))
 	}
 	return nil
 }
@@ -99,7 +99,7 @@ func (c *Controller) handleUpdateSubnetStatus(key string) error {
 	ippools, err := c.ippoolLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list ippool: %v", err)
-		return c.recordSubnetError(subnet, "ListIPPoolsFailed", err)
+		return c.recordResourceError(subnet, "ListIPPoolsFailed", err)
 	}
 	for _, p := range ippools {
 		if p.Spec.Subnet == subnet.Name {
@@ -110,12 +110,12 @@ func (c *Controller) handleUpdateSubnetStatus(key string) error {
 	if subnet.Spec.CIDRBlock != "" {
 		if _, err = c.calcSubnetStatusIP(subnet); err != nil {
 			klog.Error(err)
-			return c.recordSubnetError(subnet, "CalculateStatusFailed", err)
+			return c.recordResourceError(subnet, "CalculateStatusFailed", err)
 		}
 
 		if err := c.checkSubnetUsingIPs(subnet); err != nil {
 			klog.Errorf("inconsistency detected in status of subnet %s : %v", subnet.Name, err)
-			return c.recordSubnetError(subnet, "CheckStatusConsistencyFailed", err)
+			return c.recordResourceError(subnet, "CheckStatusConsistencyFailed", err)
 		}
 	}
 	return nil

--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -59,7 +59,6 @@ func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr 
 		c.recordSubnetEvent(subnet, v1.EventTypeWarning, reason, errStr)
 	} else {
 		subnet.Status.Validated(reason, "")
-		c.recordSubnetEvent(subnet, v1.EventTypeNormal, reason, fmt.Sprintf("Subnet %s status updated successfully", subnet.Name))
 		if reason == "SetPrivateLogicalSwitchSuccess" ||
 			reason == "ResetLogicalSwitchAclSuccess" ||
 			reason == "ReconcileCentralizedGatewaySuccess" ||
@@ -76,6 +75,9 @@ func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr 
 	if _, err := c.config.KubeOvnClient.KubeovnV1().Subnets().Patch(context.Background(), subnet.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status"); err != nil {
 		klog.Errorf("failed to patch status for subnet %s, %v", subnet.Name, err)
 		return err
+	}
+	if errStr == "" {
+		c.recordSubnetEvent(subnet, v1.EventTypeNormal, reason, fmt.Sprintf("Subnet %s status updated successfully", subnet.Name))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- record Kubernetes warning events for Subnet and IPPool reconciliation, status, finalizer, and deletion failures
- record meaningful reconciliation and deletion success events only after the corresponding status update succeeds
- keep event recording nil-safe and attach cache lookup failures to synthetic resource references
- preserve the original Subnet as the event target when status calculation or finalizer updates fail
- fix the Subnet status worker nil dereference when a cache lookup fails
- split Subnet reconciliation into focused stages and share resource event helpers

## Tests

- `go test ./pkg/controller -count=1`
- `go test -race ./pkg/controller -run 'TestHandleAddOrUpdate(Subnet|IPPool).*|TestRecordResource.*|TestResourceEventHelpers.*' -count=1`
- `golangci-lint run -v -j 1 ./pkg/controller/...`
- `GOMEMLIMIT=1500MiB GOMAXPROCS=1 go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./pkg/controller`

All commands ran under a 2 GiB systemd memory scope.
