### PR TITLE
controller: record node reconciliation failures

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -182,6 +182,13 @@ func (c *Controller) recordNodeReconcileFailure(node *v1.Node, reason string, er
 	}
 }
 
+type nodeJoinNetwork struct {
+	subnet   *kubeovnv1.Subnet
+	portName string
+	ip       string
+	mac      string
+}
+
 func (c *Controller) handleAddNode(key string) (err error) {
 	c.nodeKeyMutex.LockKey(key)
 	defer func() { _ = c.nodeKeyMutex.UnlockKey(key) }()
@@ -203,153 +210,24 @@ func (c *Controller) handleAddNode(key string) (err error) {
 		klog.Errorf("failed to list subnets: %v", err)
 		return err
 	}
-
-	nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(*node)
-	for _, subnet := range subnets {
-		if subnet.Spec.Vpc != c.config.ClusterRouter {
-			continue
-		}
-
-		v4, v6 := util.SplitStringIP(subnet.Spec.CIDRBlock)
-		if subnet.Spec.Vlan == "" && (util.CIDRContainIP(v4, nodeIPv4) || util.CIDRContainIP(v6, nodeIPv6)) {
-			msg := fmt.Sprintf("internal IP address of node %s is in CIDR of subnet %s, this may result in network issues", node.Name, subnet.Name)
-			klog.Warning(msg)
-			c.recorder.Eventf(&v1.Node{Name: node.Name, UID: types.UID(node.Name)}, v1.EventTypeWarning, "NodeAddressConflictWithSubnet", "%s", msg)
-			break
-		}
-	}
+	c.recordNodeAddressConflict(node, subnets)
 
 	if err = c.handleNodeAnnotationsForProviderNetworks(node); err != nil {
 		klog.Errorf("failed to handle annotations of node %s for provider networks: %v", node.Name, err)
 		return err
 	}
 
-	subnet, err := c.subnetsLister.Get(c.config.NodeSwitch)
-	if err != nil {
-		klog.Errorf("failed to get node subnet: %v", err)
+	var joinNetwork *nodeJoinNetwork
+	if joinNetwork, err = c.ensureNodeJoinNetwork(node); err != nil {
 		return err
 	}
-
-	var v4IP, v6IP, mac string
-
-	portName := util.NodeLspName(key)
-	if node.Annotations[util.AllocatedAnnotation] == "true" && node.Annotations[util.IPAddressAnnotation] != "" && node.Annotations[util.MacAddressAnnotation] != "" {
-		macStr := node.Annotations[util.MacAddressAnnotation]
-		v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(portName, portName, node.Annotations[util.IPAddressAnnotation],
-			&macStr, node.Annotations[util.LogicalSwitchAnnotation], true)
-		if err != nil {
-			klog.Errorf("failed to alloc static ip addrs for node %v: %v", node.Name, err)
-			return err
-		}
-	} else {
-		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, portName, nil, c.config.NodeSwitch, "", nil, true)
-		if err != nil {
-			klog.Errorf("failed to alloc random ip addrs for node %v: %v", node.Name, err)
-			return err
-		}
-
-		// Clean up potentially existing logical switch ports to avoid leftover issues from previous failed configurations
-		if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
-			klog.Errorf("failed to delete stale logical switch port %s: %v", portName, err)
-			return err
-		}
-		klog.Infof("deleted stale logical switch port %s", portName)
-	}
-
-	ipStr := util.GetStringIP(v4IP, v6IP)
-	if err := c.OVNNbClient.CreateBareLogicalSwitchPort(c.config.NodeSwitch, portName, ipStr, mac); err != nil {
-		klog.Errorf("failed to create logical switch port %s: %v", portName, err)
+	if err = c.addNodeJoinPolicyRoutes(node, joinNetwork); err != nil {
 		return err
 	}
-
-	for ip := range strings.SplitSeq(ipStr, ",") {
-		if ip == "" {
-			continue
-		}
-
-		nodeIP, af := nodeIPv4, 4
-		protocol := util.CheckProtocol(ip)
-		if protocol == kubeovnv1.ProtocolIPv6 {
-			nodeIP, af = nodeIPv6, 6
-		}
-		if nodeIP != "" {
-			var (
-				match       = fmt.Sprintf("ip%d.dst == %s", af, nodeIP)
-				action      = kubeovnv1.PolicyRouteActionReroute
-				externalIDs = map[string]string{
-					"vendor":         util.CniTypeName,
-					"node":           node.Name,
-					"address-family": strconv.Itoa(af),
-				}
-			)
-			klog.Infof("add policy route for router: %s, match %s, action %s, nexthop %s, externalID %v", c.config.ClusterRouter, match, action, ip, externalIDs)
-			if err = c.addPolicyRouteToVpc(
-				c.config.ClusterRouter,
-				&kubeovnv1.PolicyRoute{
-					Priority:  util.NodeRouterPolicyPriority,
-					Match:     match,
-					Action:    action,
-					NextHopIP: ip,
-				},
-				externalIDs,
-			); err != nil {
-				klog.Errorf("failed to add logical router policy for node %s: %v", node.Name, err)
-				return err
-			}
-
-			dnsIPs := make([]string, 0, len(c.config.NodeLocalDNSIPs))
-			for _, ip := range c.config.NodeLocalDNSIPs {
-				if util.CheckProtocol(ip) == protocol {
-					dnsIPs = append(dnsIPs, ip)
-				}
-			}
-
-			if err = c.addPolicyRouteForLocalDNSCacheOnNode(dnsIPs, portName, ip, node.Name, af); err != nil {
-				klog.Errorf("failed to add policy route for node %s: %v", node.Name, err)
-				return err
-			}
-		}
-	}
-
-	patch := util.KVPatch{
-		util.IPAddressAnnotation:     ipStr,
-		util.MacAddressAnnotation:    mac,
-		util.CidrAnnotation:          subnet.Spec.CIDRBlock,
-		util.GatewayAnnotation:       subnet.Spec.Gateway,
-		util.LogicalSwitchAnnotation: c.config.NodeSwitch,
-		util.AllocatedAnnotation:     "true",
-		util.PortNameAnnotation:      portName,
-	}
-	if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
-		klog.Errorf("failed to update annotations of node %s: %v", node.Name, err)
+	if err = c.patchNodeJoinNetwork(node, joinNetwork); err != nil {
 		return err
 	}
-
-	if err := c.createOrUpdateIPCR("", "", ipStr, mac, c.config.NodeSwitch, "", node.Name, ""); err != nil {
-		klog.Errorf("failed to create or update IPs %s: %v", portName, err)
-		return err
-	}
-
-	for _, subnet := range subnets {
-		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
-			continue
-		}
-		if err = c.createPortGroupForDistributedSubnet(node, subnet); err != nil {
-			klog.Errorf("failed to create port group for node %s and subnet %s: %v", node.Name, subnet.Name, err)
-			return err
-		}
-	}
-	c.distributedSubnetNeedSync.Store(true)
-
-	// ovn acl doesn't support address_set name with '-', so replace '-' by '.'
-	pgName := strings.ReplaceAll(portName, "-", ".")
-	if err = c.OVNNbClient.CreatePortGroup(pgName, map[string]string{"node": node.Name, networkPolicyKey: "node" + "/" + key}); err != nil {
-		klog.Errorf("create port group %s for node %s: %v", pgName, key, err)
-		return err
-	}
-
-	if err := c.addPolicyRouteForCentralizedSubnetOnNode(node, ipStr); err != nil {
-		klog.Errorf("failed to add policy route for node %s, %v", key, err)
+	if err = c.ensureNodePortGroups(node, subnets, joinNetwork); err != nil {
 		return err
 	}
 
@@ -360,6 +238,140 @@ func (c *Controller) handleAddNode(key string) (err error) {
 
 	if err := c.retryDelDupChassis(util.ChassisRetryMaxTimes, util.ChassisControllerRetryInterval, c.cleanDuplicatedChassis, node); err != nil {
 		klog.Errorf("failed to clean duplicated chassis for node %s: %v", node.Name, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) recordNodeAddressConflict(node *v1.Node, subnets []*kubeovnv1.Subnet) {
+	nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(*node)
+	for _, subnet := range subnets {
+		if subnet.Spec.Vpc != c.config.ClusterRouter {
+			continue
+		}
+		v4, v6 := util.SplitStringIP(subnet.Spec.CIDRBlock)
+		if subnet.Spec.Vlan != "" || (!util.CIDRContainIP(v4, nodeIPv4) && !util.CIDRContainIP(v6, nodeIPv6)) {
+			continue
+		}
+		msg := fmt.Sprintf("internal IP address of node %s is in CIDR of subnet %s, this may result in network issues", node.Name, subnet.Name)
+		klog.Warning(msg)
+		c.recorder.Eventf(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: node.Name, UID: types.UID(node.Name)}}, v1.EventTypeWarning, "NodeAddressConflictWithSubnet", "%s", msg)
+		return
+	}
+}
+
+func (c *Controller) ensureNodeJoinNetwork(node *v1.Node) (*nodeJoinNetwork, error) {
+	subnet, err := c.subnetsLister.Get(c.config.NodeSwitch)
+	if err != nil {
+		klog.Errorf("failed to get node subnet: %v", err)
+		return nil, err
+	}
+
+	portName := util.NodeLspName(node.Name)
+	var v4IP, v6IP, mac string
+	if node.Annotations[util.AllocatedAnnotation] == "true" && node.Annotations[util.IPAddressAnnotation] != "" && node.Annotations[util.MacAddressAnnotation] != "" {
+		macStr := node.Annotations[util.MacAddressAnnotation]
+		v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(portName, portName, node.Annotations[util.IPAddressAnnotation], &macStr, node.Annotations[util.LogicalSwitchAnnotation], true)
+	} else {
+		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, portName, nil, c.config.NodeSwitch, "", nil, true)
+		if err == nil {
+			err = c.OVNNbClient.DeleteLogicalSwitchPort(portName)
+			if err == nil {
+				klog.Infof("deleted stale logical switch port %s", portName)
+			}
+		}
+	}
+	if err != nil {
+		klog.Errorf("failed to allocate join network address for node %s: %v", node.Name, err)
+		return nil, err
+	}
+
+	ipStr := util.GetStringIP(v4IP, v6IP)
+	if err = c.OVNNbClient.CreateBareLogicalSwitchPort(c.config.NodeSwitch, portName, ipStr, mac); err != nil {
+		klog.Errorf("failed to create logical switch port %s: %v", portName, err)
+		return nil, err
+	}
+	return &nodeJoinNetwork{subnet: subnet, portName: portName, ip: ipStr, mac: mac}, nil
+}
+
+func (c *Controller) addNodeJoinPolicyRoutes(node *v1.Node, joinNetwork *nodeJoinNetwork) error {
+	nodeIPv4, nodeIPv6 := util.GetNodeInternalIP(*node)
+	for ip := range strings.SplitSeq(joinNetwork.ip, ",") {
+		if ip == "" {
+			continue
+		}
+		nodeIP, af := nodeIPv4, 4
+		protocol := util.CheckProtocol(ip)
+		if protocol == kubeovnv1.ProtocolIPv6 {
+			nodeIP, af = nodeIPv6, 6
+		}
+		if nodeIP == "" {
+			continue
+		}
+
+		match := fmt.Sprintf("ip%d.dst == %s", af, nodeIP)
+		externalIDs := map[string]string{"vendor": util.CniTypeName, "node": node.Name, "address-family": strconv.Itoa(af)}
+		policy := &kubeovnv1.PolicyRoute{Priority: util.NodeRouterPolicyPriority, Match: match, Action: kubeovnv1.PolicyRouteActionReroute, NextHopIP: ip}
+		klog.Infof("add policy route for router: %s, match %s, action %s, nexthop %s, externalID %v", c.config.ClusterRouter, match, policy.Action, ip, externalIDs)
+		if err := c.addPolicyRouteToVpc(c.config.ClusterRouter, policy, externalIDs); err != nil {
+			klog.Errorf("failed to add logical router policy for node %s: %v", node.Name, err)
+			return err
+		}
+
+		dnsIPs := make([]string, 0, len(c.config.NodeLocalDNSIPs))
+		for _, dnsIP := range c.config.NodeLocalDNSIPs {
+			if util.CheckProtocol(dnsIP) == protocol {
+				dnsIPs = append(dnsIPs, dnsIP)
+			}
+		}
+		if err := c.addPolicyRouteForLocalDNSCacheOnNode(dnsIPs, joinNetwork.portName, ip, node.Name, af); err != nil {
+			klog.Errorf("failed to add policy route for node %s: %v", node.Name, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) patchNodeJoinNetwork(node *v1.Node, joinNetwork *nodeJoinNetwork) error {
+	patch := util.KVPatch{
+		util.IPAddressAnnotation:     joinNetwork.ip,
+		util.MacAddressAnnotation:    joinNetwork.mac,
+		util.CidrAnnotation:          joinNetwork.subnet.Spec.CIDRBlock,
+		util.GatewayAnnotation:       joinNetwork.subnet.Spec.Gateway,
+		util.LogicalSwitchAnnotation: c.config.NodeSwitch,
+		util.AllocatedAnnotation:     "true",
+		util.PortNameAnnotation:      joinNetwork.portName,
+	}
+	if err := util.PatchAnnotations(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
+		klog.Errorf("failed to update annotations of node %s: %v", node.Name, err)
+		return err
+	}
+	if err := c.createOrUpdateIPCR("", "", joinNetwork.ip, joinNetwork.mac, c.config.NodeSwitch, "", node.Name, ""); err != nil {
+		klog.Errorf("failed to create or update IPs %s: %v", joinNetwork.portName, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) ensureNodePortGroups(node *v1.Node, subnets []*kubeovnv1.Subnet, joinNetwork *nodeJoinNetwork) error {
+	for _, subnet := range subnets {
+		if (subnet.Spec.Vlan != "" && !subnet.Spec.LogicalGateway) || subnet.Spec.Vpc != c.config.ClusterRouter || subnet.Name == c.config.NodeSwitch || subnet.Spec.GatewayType != kubeovnv1.GWDistributedType {
+			continue
+		}
+		if err := c.createPortGroupForDistributedSubnet(node, subnet); err != nil {
+			klog.Errorf("failed to create port group for node %s and subnet %s: %v", node.Name, subnet.Name, err)
+			return err
+		}
+	}
+	c.distributedSubnetNeedSync.Store(true)
+
+	pgName := strings.ReplaceAll(joinNetwork.portName, "-", ".")
+	if err := c.OVNNbClient.CreatePortGroup(pgName, map[string]string{"node": node.Name, networkPolicyKey: "node" + "/" + node.Name}); err != nil {
+		klog.Errorf("create port group %s for node %s: %v", pgName, node.Name, err)
+		return err
+	}
+	if err := c.addPolicyRouteForCentralizedSubnetOnNode(node, joinNetwork.ip); err != nil {
+		klog.Errorf("failed to add policy route for node %s, %v", node.Name, err)
 		return err
 	}
 	return nil

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -176,6 +176,12 @@ func nodeUnderlayAddressSetName(node string, af int) string {
 	return fmt.Sprintf("node_%s_underlay_v%d", strings.ReplaceAll(node, "-", "_"), af)
 }
 
+func (c *Controller) recordNodeReconcileFailure(node *v1.Node, reason string, err error) {
+	if err != nil {
+		c.recorder.Eventf(node, v1.EventTypeWarning, reason, "%s", err.Error())
+	}
+}
+
 func (c *Controller) handleAddNode(key string) (err error) {
 	c.nodeKeyMutex.LockKey(key)
 	defer func() { _ = c.nodeKeyMutex.UnlockKey(key) }()
@@ -189,11 +195,7 @@ func (c *Controller) handleAddNode(key string) (err error) {
 		return err
 	}
 	node := cachedNode.DeepCopy()
-	defer func() {
-		if err != nil {
-			c.recorder.Eventf(node, v1.EventTypeWarning, "AddNodeFailed", "%s", err.Error())
-		}
-	}()
+	defer func() { c.recordNodeReconcileFailure(node, "AddNodeFailed", err) }()
 	klog.Infof("handle add node %s", node.Name)
 
 	subnets, err := c.subnetsLister.List(labels.Everything())
@@ -465,11 +467,7 @@ func (c *Controller) handleDeleteNode(key string) (err error) {
 	if !ok {
 		return nil
 	}
-	defer func() {
-		if err != nil {
-			c.recorder.Eventf(node, v1.EventTypeWarning, "DeleteNodeFailed", "%s", err.Error())
-		}
-	}()
+	defer func() { c.recordNodeReconcileFailure(node, "DeleteNodeFailed", err) }()
 	n, _ := c.nodesLister.Get(key)
 	if n != nil && n.UID != node.UID {
 		klog.Warningf("Node %s is adding, skip the node delete handler, but it may leave some gc resources behind", key)
@@ -606,11 +604,7 @@ func (c *Controller) handleUpdateNode(key string) (err error) {
 		klog.Errorf("failed to get node %s: %v", key, err)
 		return err
 	}
-	defer func() {
-		if err != nil {
-			c.recorder.Eventf(node, v1.EventTypeWarning, "UpdateNodeFailed", "%s", err.Error())
-		}
-	}()
+	defer func() { c.recordNodeReconcileFailure(node, "UpdateNodeFailed", err) }()
 
 	if err = c.handleNodeAnnotationsForProviderNetworks(node); err != nil {
 		klog.Errorf("failed to handle annotations of node %s for provider networks: %v", node.Name, err)

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -176,7 +176,7 @@ func nodeUnderlayAddressSetName(node string, af int) string {
 	return fmt.Sprintf("node_%s_underlay_v%d", strings.ReplaceAll(node, "-", "_"), af)
 }
 
-func (c *Controller) handleAddNode(key string) error {
+func (c *Controller) handleAddNode(key string) (err error) {
 	c.nodeKeyMutex.LockKey(key)
 	defer func() { _ = c.nodeKeyMutex.UnlockKey(key) }()
 
@@ -189,6 +189,11 @@ func (c *Controller) handleAddNode(key string) error {
 		return err
 	}
 	node := cachedNode.DeepCopy()
+	defer func() {
+		if err != nil {
+			c.recorder.Eventf(node, v1.EventTypeWarning, "AddNodeFailed", "%s", err.Error())
+		}
+	}()
 	klog.Infof("handle add node %s", node.Name)
 
 	subnets, err := c.subnetsLister.List(labels.Everything())
@@ -460,6 +465,11 @@ func (c *Controller) handleDeleteNode(key string) (err error) {
 	if !ok {
 		return nil
 	}
+	defer func() {
+		if err != nil {
+			c.recorder.Eventf(node, v1.EventTypeWarning, "DeleteNodeFailed", "%s", err.Error())
+		}
+	}()
 	n, _ := c.nodesLister.Get(key)
 	if n != nil && n.UID != node.UID {
 		klog.Warningf("Node %s is adding, skip the node delete handler, but it may leave some gc resources behind", key)
@@ -583,7 +593,7 @@ func (c *Controller) updateProviderNetworkForNodeDeletion(pn *kubeovnv1.Provider
 	return nil
 }
 
-func (c *Controller) handleUpdateNode(key string) error {
+func (c *Controller) handleUpdateNode(key string) (err error) {
 	c.nodeKeyMutex.LockKey(key)
 	defer func() { _ = c.nodeKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle update node %s", key)
@@ -596,6 +606,11 @@ func (c *Controller) handleUpdateNode(key string) error {
 		klog.Errorf("failed to get node %s: %v", key, err)
 		return err
 	}
+	defer func() {
+		if err != nil {
+			c.recorder.Eventf(node, v1.EventTypeWarning, "UpdateNodeFailed", "%s", err.Error())
+		}
+	}()
 
 	if err = c.handleNodeAnnotationsForProviderNetworks(node); err != nil {
 		klog.Errorf("failed to handle annotations of node %s for provider networks: %v", node.Name, err)

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -16,7 +16,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -255,7 +254,7 @@ func (c *Controller) recordNodeAddressConflict(node *v1.Node, subnets []*kubeovn
 		}
 		msg := fmt.Sprintf("internal IP address of node %s is in CIDR of subnet %s, this may result in network issues", node.Name, subnet.Name)
 		klog.Warning(msg)
-		c.recorder.Eventf(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: node.Name, UID: types.UID(node.Name)}}, v1.EventTypeWarning, "NodeAddressConflictWithSubnet", "%s", msg)
+		c.recorder.Eventf(node, v1.EventTypeWarning, "NodeAddressConflictWithSubnet", "%s", msg)
 		return
 	}
 }

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -198,15 +198,30 @@ func TestHandleAddNodeRecordsFailureEvent(t *testing.T) {
 	t.Parallel()
 
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	joinSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "join"},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.0.0.1/32",
+			Gateway:   "10.0.0.1",
+		},
+	}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
-		Nodes: []*corev1.Node{node},
+		Nodes:   []*corev1.Node{node},
+		Subnets: []*kubeovnv1.Subnet{joinSubnet},
 	})
 	require.NoError(t, err)
 	fc.fakeController.nodeKeyMutex = keymutex.NewHashed(0)
+	require.NoError(t, fc.fakeController.ipam.AddOrUpdateSubnet(
+		joinSubnet.Name,
+		joinSubnet.Spec.CIDRBlock,
+		joinSubnet.Spec.Gateway,
+		[]string{joinSubnet.Spec.Gateway},
+	))
 
 	err = fc.fakeController.handleAddNode(node.Name)
 
 	require.Error(t, err)
+	require.ErrorContains(t, err, "NoAvailableAddress")
 	require.Equal(t, "Warning AddNodeFailed "+err.Error(), requireRecorderEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
 }
 

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -12,6 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/keymutex"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	ovs "github.com/kubeovn/kube-ovn/pkg/ovs"
@@ -190,6 +192,64 @@ func TestKubeOvnAnnotationsChanged(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleAddNodeRecordsFailureEvent(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Nodes: []*corev1.Node{node},
+	})
+	require.NoError(t, err)
+	fc.fakeController.nodeKeyMutex = keymutex.NewHashed(0)
+
+	err = fc.fakeController.handleAddNode(node.Name)
+
+	require.Error(t, err)
+	require.Equal(t, "Warning AddNodeFailed "+err.Error(), requireRecorderEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+}
+
+func TestHandleUpdateNodeRecordsFailureEvent(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-1",
+		Annotations: map[string]string{
+			util.ChassisAnnotation: "chassis-1",
+		},
+	}}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Nodes: []*corev1.Node{node},
+	})
+	require.NoError(t, err)
+	fc.fakeController.nodeKeyMutex = keymutex.NewHashed(0)
+	failure := errors.New("get chassis failed")
+	fc.mockOvnSbClient.EXPECT().GetChassis("chassis-1", true).Return(nil, failure)
+
+	err = fc.fakeController.handleUpdateNode(node.Name)
+
+	require.ErrorIs(t, err, failure)
+	require.Equal(t, "Warning UpdateNodeFailed "+failure.Error(), requireRecorderEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+}
+
+func TestHandleDeleteNodeRecordsFailureEvent(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	fc := newFakeController(t)
+	fc.fakeController.nodeKeyMutex = keymutex.NewHashed(0)
+	fc.fakeController.deletingNodeObjMap = xsync.NewMap[string, *corev1.Node]()
+	fc.fakeController.deletingNodeObjMap.Store(node.Name, node)
+	failure := errors.New("delete logical switch port failed")
+	fc.mockOvnClient.EXPECT().DeleteLogicalSwitchPort(util.NodeLspName(node.Name)).Return(failure)
+
+	err := fc.fakeController.handleDeleteNode(node.Name)
+
+	require.ErrorIs(t, err, failure)
+	require.Equal(t, "Warning DeleteNodeFailed "+failure.Error(), requireRecorderEvent(t, fc.fakeController.recorder.(*record.FakeRecorder)))
+	_, retained := fc.fakeController.deletingNodeObjMap.Load(node.Name)
+	require.True(t, retained, "deleting node must remain queued for retry")
 }
 
 func newBFDPortVpc(name string, selector map[string]string) *kubeovnv1.Vpc {

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -197,9 +197,9 @@ func TestKubeOvnAnnotationsChanged(t *testing.T) {
 func TestHandleAddNodeRecordsFailureEvent(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	node := &corev1.Node{Name: "node-1"}
 	joinSubnet := &kubeovnv1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{Name: "join"},
+		Name: "join",
 		Spec: kubeovnv1.SubnetSpec{
 			CIDRBlock: "10.0.0.1/32",
 			Gateway:   "10.0.0.1",
@@ -228,12 +228,12 @@ func TestHandleAddNodeRecordsFailureEvent(t *testing.T) {
 func TestHandleUpdateNodeRecordsFailureEvent(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+	node := &corev1.Node{
 		Name: "node-1",
 		Annotations: map[string]string{
 			util.ChassisAnnotation: "chassis-1",
 		},
-	}}
+	}
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Nodes: []*corev1.Node{node},
 	})
@@ -251,7 +251,7 @@ func TestHandleUpdateNodeRecordsFailureEvent(t *testing.T) {
 func TestHandleDeleteNodeRecordsFailureEvent(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	node := &corev1.Node{Name: "node-1", UID: "node-uid"}
 	fc := newFakeController(t)
 	fc.fakeController.nodeKeyMutex = keymutex.NewHashed(0)
 	fc.fakeController.deletingNodeObjMap = xsync.NewMap[string, *corev1.Node]()

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -79,7 +79,9 @@ type Controller struct {
 	serviceCIDRSynced          cache.InformerSynced
 	serviceCIDRInformerFactory informers.SharedInformerFactory
 
-	recorder record.EventRecorder
+	recorder          record.EventRecorder
+	nodeFailuresMutex sync.Mutex
+	nodeFailures      map[nodeFailureKey]string
 
 	protocol string
 
@@ -999,7 +1001,9 @@ func (c *Controller) handleUpdateNode(key string) error {
 	}
 
 	klog.Infof("updating node networks for node %s", key)
-	return c.config.UpdateNodeNetworks(node)
+	return c.reconcileNodeNetworkStage(node, "updateNodeNetworks", func() error {
+		return c.config.UpdateNodeNetworks(node)
+	})
 }
 
 // Run starts controller
@@ -1020,6 +1024,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	go wait.Until(rotateLog, 1*time.Hour, stopCh)
 
 	if err := c.setIPSet(); err != nil {
+		c.recordLocalNodeFailureSync("setIPSet", err)
 		util.LogFatalAndExit(err, "failed to set ipsets")
 	}
 

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -81,7 +81,7 @@ type Controller struct {
 
 	recorder          record.EventRecorder
 	nodeFailuresMutex sync.Mutex
-	nodeFailures      map[nodeFailureKey]string
+	nodeFailures      map[nodeFailureKey]struct{}
 
 	protocol string
 

--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -18,24 +18,27 @@ import (
 )
 
 func (c *Controller) runGateway() {
-	if err := c.setIPSet(); err != nil {
-		klog.Errorf("failed to set gw ipsets")
-	}
-	if err := c.setPolicyRouting(); err != nil {
-		klog.Errorf("failed to set gw policy routing")
-	}
-	if err := c.setIptables(); err != nil {
-		klog.Errorf("failed to set gw iptables")
+	node, err := c.nodesLister.Get(c.config.NodeName)
+	if err != nil {
+		klog.Errorf("failed to get node %s for gateway reconciliation: %v", c.config.NodeName, err)
+		return
 	}
 
-	if err := c.setGatewayBandwidth(); err != nil {
-		klog.Errorf("failed to set gw bandwidth, %v", err)
+	stages := []struct {
+		name      string
+		reconcile func() error
+	}{
+		{name: "setIPSet", reconcile: c.setIPSet},
+		{name: "setPolicyRouting", reconcile: c.setPolicyRouting},
+		{name: "setIptables", reconcile: c.setIptables},
+		{name: "setGatewayBandwidth", reconcile: c.setGatewayBandwidth},
+		{name: "setICGateway", reconcile: c.setICGateway},
+		{name: "setExGateway", reconcile: c.setExGateway},
 	}
-	if err := c.setICGateway(); err != nil {
-		klog.Errorf("failed to set ic gateway, %v", err)
-	}
-	if err := c.setExGateway(); err != nil {
-		klog.Errorf("failed to set ex gateway, %v", err)
+	for _, stage := range stages {
+		if err := c.reconcileNodeNetworkStage(node, stage.name, stage.reconcile); err != nil {
+			klog.Errorf("gateway reconciliation stage %s failed: %v", stage.name, err)
+		}
 	}
 	c.gcIPSet()
 }

--- a/pkg/daemon/gateway_linux.go
+++ b/pkg/daemon/gateway_linux.go
@@ -134,7 +134,9 @@ func (c *Controller) setIPSet() error {
 			SetID:   OtherNodeSet,
 			Type:    ipsets.IPSetTypeHashNet,
 		}, otherNode)
-		c.reconcileNatOutGoingPolicyIPset(allSubnets, protocol)
+		if err := c.reconcileNatOutGoingPolicyIPset(allSubnets, protocol); err != nil {
+			return err
+		}
 		c.ipsets[protocol].ApplyUpdates()
 	}
 	return nil
@@ -176,11 +178,11 @@ func (c *Controller) addNatOutGoingPolicyRuleIPset(rule kubeovnv1.NatOutgoingPol
 	}
 }
 
-func (c *Controller) removeNatOutGoingPolicyRuleIPset(protocol string, natPolicyRuleIDs *strset.Set) {
+func (c *Controller) removeNatOutGoingPolicyRuleIPset(protocol string, natPolicyRuleIDs *strset.Set) error {
 	sets, err := c.k8sipsets.ListSets()
 	if err != nil {
 		klog.Errorf("failed to list ipsets: %v", err)
-		return
+		return err
 	}
 	for _, set := range sets {
 		if isNatOutGoingPolicyRuleIPSet(set) {
@@ -190,9 +192,10 @@ func (c *Controller) removeNatOutGoingPolicyRuleIPset(protocol string, natPolicy
 			}
 		}
 	}
+	return nil
 }
 
-func (c *Controller) reconcileNatOutGoingPolicyIPset(allSubnets []*kubeovnv1.Subnet, protocol string) {
+func (c *Controller) reconcileNatOutGoingPolicyIPset(allSubnets []*kubeovnv1.Subnet, protocol string) error {
 	subnets := c.getSubnetsNatOutGoingPolicy(allSubnets, protocol)
 	subnetCidrs := make([]string, 0, len(subnets))
 	natPolicyRuleIDs := strset.New()
@@ -221,7 +224,7 @@ func (c *Controller) reconcileNatOutGoingPolicyIPset(allSubnets []*kubeovnv1.Sub
 		Type:    ipsets.IPSetTypeHashNet,
 	}, subnetCidrs)
 
-	c.removeNatOutGoingPolicyRuleIPset(protocol, natPolicyRuleIDs)
+	return c.removeNatOutGoingPolicyRuleIPset(protocol, natPolicyRuleIDs)
 }
 
 func (c *Controller) setPolicyRouting() error {
@@ -789,7 +792,8 @@ func (c *Controller) setIptables() error {
 		if existingIPSets.Has(ipset) {
 			iptablesRules[0].Rule = strings.Fields(fmt.Sprintf(`-i %s -m set --match-set %s src -m set --match-set %s dst,dst -j MARK --set-xmark 0x4000/0x4000`, util.NodeNic, matchset, ipset))
 			rejectRule := strings.Fields(fmt.Sprintf(`-p tcp -m mark ! --mark 0x4000/0x4000 -m set --match-set %s dst -m conntrack --ctstate NEW -j REJECT`, svcMatchset))
-			iptablesRules = append(iptablesRules,
+			iptablesRules = append(
+				iptablesRules,
 				util.IPTableRule{Table: "filter", Chain: "INPUT", Rule: rejectRule},
 				util.IPTableRule{Table: "filter", Chain: "OUTPUT", Rule: rejectRule},
 			)
@@ -833,7 +837,8 @@ func (c *Controller) setIptables() error {
 				rule := fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL -m set --match-set %s dst -j MARK --set-xmark 0x80000/0x80000", p, ipset)
 				rule2 := fmt.Sprintf("-p %s -m set --match-set %s src -m set --match-set %s dst -j MARK --set-xmark 0x4000/0x4000", p, nodeMatchSet, ipset)
 				obsoleteRules = append(obsoleteRules, util.IPTableRule{Table: NAT, Chain: Prerouting, Rule: strings.Fields(rule)})
-				iptablesRules = append(iptablesRules,
+				iptablesRules = append(
+					iptablesRules,
 					util.IPTableRule{Table: NAT, Chain: OvnPrerouting, Rule: strings.Fields(rule)},
 					util.IPTableRule{Table: NAT, Chain: OvnPrerouting, Rule: strings.Fields(rule2)},
 				)
@@ -846,7 +851,8 @@ func (c *Controller) setIptables() error {
 		for _, name := range slices.Sorted(maps.Keys(subnetCidrs)) {
 			subnetCidr := subnetCidrs[name]
 			subnetNames.Insert(name)
-			iptablesRules = append(iptablesRules,
+			iptablesRules = append(
+				iptablesRules,
 				util.IPTableRule{Table: "filter", Chain: "FORWARD", Rule: strings.Fields(fmt.Sprintf(`-m comment --comment %s,%s -s %s`, util.OvnSubnetGatewayIptables, name, subnetCidr))},
 				util.IPTableRule{Table: "filter", Chain: "FORWARD", Rule: strings.Fields(fmt.Sprintf(`-m comment --comment %s,%s -d %s`, util.OvnSubnetGatewayIptables, name, subnetCidr))},
 			)
@@ -1061,7 +1067,8 @@ func getKubeOVNBaseIptablesRulesForCleanup(protocol string) []util.IPTableRule {
 	nodePortRules := make([]util.IPTableRule, 0, 4)
 	for _, p := range [...]string{"tcp", "udp"} {
 		nodePortIPSet := fmt.Sprintf("KUBE-%sNODE-PORT-LOCAL-%s", nodePortPrefix, strings.ToUpper(p))
-		nodePortRules = append(nodePortRules,
+		nodePortRules = append(
+			nodePortRules,
 			util.IPTableRule{Table: NAT, Chain: Prerouting, Rule: strings.Fields(fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL -m set --match-set %s dst -j MARK --set-xmark 0x80000/0x80000", p, nodePortIPSet))},
 			util.IPTableRule{Table: NAT, Chain: Prerouting, Rule: strings.Fields(fmt.Sprintf("-p %s -m set --match-set %s src -m set --match-set %s dst -j MARK --set-xmark 0x4000/0x4000", p, nodeMatchset, nodePortIPSet))},
 		)

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -83,11 +83,17 @@ func InitNodeGateway(config *Configuration) (err error) {
 		}
 		if annotationErr != nil {
 			klog.Errorf("validate node %s address annotation failed, %v", nodeName, annotationErr)
+			for existingKey := range annotationFailures {
+				if existingKey.nodeName == node.Name && existingKey.nodeUID != node.UID {
+					delete(annotationFailures, existingKey)
+				}
+			}
 			failureKey := nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: addNodeFailedReason, stage: "validateOvn0Annotations", message: annotationErr.Error()}
 			if _, seen := annotationFailures[failureKey]; !seen {
 				if eventErr := recordNodeFailureEventSync(config.KubeClient, node, config.NodeName, addNodeFailedReason, "validateOvn0Annotations", annotationErr); eventErr != nil {
 					klog.Errorf("failed to record node %s annotation validation event: %v", config.NodeName, eventErr)
 				} else {
+					trimNodeFailureSignatures(annotationFailures, failureKey)
 					annotationFailures[failureKey] = struct{}{}
 				}
 			}

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
@@ -50,12 +51,22 @@ func InitOVSBridges() (map[string]string, error) {
 	return mappings, nil
 }
 
+var configureNodeGateway = configureNodeNic
+
 // InitNodeGateway init ovn0
-func InitNodeGateway(config *Configuration) error {
+func InitNodeGateway(config *Configuration) (err error) {
 	var portName, ip, joinCIDR, macAddr, gw, ipAddr string
+	var node *corev1.Node
+	defer func() {
+		if err != nil {
+			if eventErr := recordNodeFailureEventSync(config.KubeClient, node, config.NodeName, addNodeFailedReason, "initializeOvn0", err); eventErr != nil {
+				klog.Errorf("failed to record node %s initialization event: %v", config.NodeName, eventErr)
+			}
+		}
+	}()
 	for {
 		nodeName := config.NodeName
-		node, err := config.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		node, err = config.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 		if err != nil {
 			klog.Errorf("failed to get node %s info %v", nodeName, err)
 			return err
@@ -65,8 +76,8 @@ func InitNodeGateway(config *Configuration) error {
 			time.Sleep(3 * time.Second)
 			continue
 		}
-		if err := util.ValidatePodNetwork(node.Annotations); err != nil {
-			klog.Errorf("validate node %s address annotation failed, %v", nodeName, err)
+		if validateErr := util.ValidatePodNetwork(node.Annotations); validateErr != nil {
+			klog.Errorf("validate node %s address annotation failed, %v", nodeName, validateErr)
 			time.Sleep(3 * time.Second)
 			continue
 		}
@@ -79,7 +90,7 @@ func InitNodeGateway(config *Configuration) error {
 	}
 	mac, err := net.ParseMAC(macAddr)
 	if err != nil {
-		return fmt.Errorf("failed to parse mac %s %w", mac, err)
+		return fmt.Errorf("failed to parse mac %s: %w", macAddr, err)
 	}
 
 	ipAddr, err = util.GetIPAddrWithMask(ip, joinCIDR)
@@ -87,7 +98,7 @@ func InitNodeGateway(config *Configuration) error {
 		klog.Errorf("failed to get ip %s with mask %s, %v", ip, joinCIDR, err)
 		return err
 	}
-	return configureNodeNic(config.KubeClient, config.NodeName, portName, ipAddr, gw, joinCIDR, mac, config.MTU, config.EnableNonPrimaryCNI)
+	return configureNodeGateway(config.KubeClient, config.NodeName, portName, ipAddr, gw, joinCIDR, mac, config.MTU, config.EnableNonPrimaryCNI)
 }
 
 func InitMirror(config *Configuration) error {

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -60,8 +60,7 @@ var (
 func InitNodeGateway(config *Configuration) (err error) {
 	var portName, ip, joinCIDR, macAddr, gw, ipAddr string
 	var node *corev1.Node
-	var lastAnnotationFailure nodeFailureKey
-	var lastAnnotationFailureMessage string
+	annotationFailures := make(map[nodeFailureKey]struct{})
 	defer func() {
 		if err != nil {
 			if eventErr := recordNodeFailureEventSync(config.KubeClient, node, config.NodeName, addNodeFailedReason, "initializeOvn0", err); eventErr != nil {
@@ -84,13 +83,12 @@ func InitNodeGateway(config *Configuration) (err error) {
 		}
 		if annotationErr != nil {
 			klog.Errorf("validate node %s address annotation failed, %v", nodeName, annotationErr)
-			failureKey := nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: addNodeFailedReason, stage: "validateOvn0Annotations"}
-			if failureKey != lastAnnotationFailure || annotationErr.Error() != lastAnnotationFailureMessage {
+			failureKey := nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: addNodeFailedReason, stage: "validateOvn0Annotations", message: annotationErr.Error()}
+			if _, seen := annotationFailures[failureKey]; !seen {
 				if eventErr := recordNodeFailureEventSync(config.KubeClient, node, config.NodeName, addNodeFailedReason, "validateOvn0Annotations", annotationErr); eventErr != nil {
 					klog.Errorf("failed to record node %s annotation validation event: %v", config.NodeName, eventErr)
 				} else {
-					lastAnnotationFailure = failureKey
-					lastAnnotationFailureMessage = annotationErr.Error()
+					annotationFailures[failureKey] = struct{}{}
 				}
 			}
 			time.Sleep(nodeGatewayInitRetryInterval)

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -60,7 +60,8 @@ var (
 func InitNodeGateway(config *Configuration) (err error) {
 	var portName, ip, joinCIDR, macAddr, gw, ipAddr string
 	var node *corev1.Node
-	var lastAnnotationFailure string
+	var lastAnnotationFailure nodeFailureKey
+	var lastAnnotationFailureMessage string
 	defer func() {
 		if err != nil {
 			if eventErr := recordNodeFailureEventSync(config.KubeClient, node, config.NodeName, addNodeFailedReason, "initializeOvn0", err); eventErr != nil {
@@ -83,11 +84,14 @@ func InitNodeGateway(config *Configuration) (err error) {
 		}
 		if annotationErr != nil {
 			klog.Errorf("validate node %s address annotation failed, %v", nodeName, annotationErr)
-			if annotationErr.Error() != lastAnnotationFailure {
+			failureKey := nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: addNodeFailedReason, stage: "validateOvn0Annotations"}
+			if failureKey != lastAnnotationFailure || annotationErr.Error() != lastAnnotationFailureMessage {
 				if eventErr := recordNodeFailureEventSync(config.KubeClient, node, config.NodeName, addNodeFailedReason, "validateOvn0Annotations", annotationErr); eventErr != nil {
 					klog.Errorf("failed to record node %s annotation validation event: %v", config.NodeName, eventErr)
+				} else {
+					lastAnnotationFailure = failureKey
+					lastAnnotationFailureMessage = annotationErr.Error()
 				}
-				lastAnnotationFailure = annotationErr.Error()
 			}
 			time.Sleep(nodeGatewayInitRetryInterval)
 			continue

--- a/pkg/daemon/init.go
+++ b/pkg/daemon/init.go
@@ -51,12 +51,16 @@ func InitOVSBridges() (map[string]string, error) {
 	return mappings, nil
 }
 
-var configureNodeGateway = configureNodeNic
+var (
+	configureNodeGateway         = configureNodeNic
+	nodeGatewayInitRetryInterval = 3 * time.Second
+)
 
 // InitNodeGateway init ovn0
 func InitNodeGateway(config *Configuration) (err error) {
 	var portName, ip, joinCIDR, macAddr, gw, ipAddr string
 	var node *corev1.Node
+	var lastAnnotationFailure string
 	defer func() {
 		if err != nil {
 			if eventErr := recordNodeFailureEventSync(config.KubeClient, node, config.NodeName, addNodeFailedReason, "initializeOvn0", err); eventErr != nil {
@@ -71,14 +75,21 @@ func InitNodeGateway(config *Configuration) (err error) {
 			klog.Errorf("failed to get node %s info %v", nodeName, err)
 			return err
 		}
+		var annotationErr error
 		if node.Annotations[util.IPAddressAnnotation] == "" {
-			klog.Warningf("no %s address for node %s, please check kube-ovn-controller logs", util.NodeNic, nodeName)
-			time.Sleep(3 * time.Second)
-			continue
+			annotationErr = fmt.Errorf("no %s address for node %s, please check kube-ovn-controller logs", util.NodeNic, nodeName)
+		} else {
+			annotationErr = util.ValidatePodNetwork(node.Annotations)
 		}
-		if validateErr := util.ValidatePodNetwork(node.Annotations); validateErr != nil {
-			klog.Errorf("validate node %s address annotation failed, %v", nodeName, validateErr)
-			time.Sleep(3 * time.Second)
+		if annotationErr != nil {
+			klog.Errorf("validate node %s address annotation failed, %v", nodeName, annotationErr)
+			if annotationErr.Error() != lastAnnotationFailure {
+				if eventErr := recordNodeFailureEventSync(config.KubeClient, node, config.NodeName, addNodeFailedReason, "validateOvn0Annotations", annotationErr); eventErr != nil {
+					klog.Errorf("failed to record node %s annotation validation event: %v", config.NodeName, eventErr)
+				}
+				lastAnnotationFailure = annotationErr.Error()
+			}
+			time.Sleep(nodeGatewayInitRetryInterval)
 			continue
 		}
 		macAddr = node.Annotations[util.MacAddressAnnotation]

--- a/pkg/daemon/node_events.go
+++ b/pkg/daemon/node_events.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	eventutil "k8s.io/client-go/tools/record/util"
+	"k8s.io/klog/v2"
+)
+
+const (
+	addNodeFailedReason    = "AddNodeFailed"
+	updateNodeFailedReason = "UpdateNodeFailed"
+)
+
+type nodeFailureKey struct {
+	nodeName string
+	nodeUID  types.UID
+	reason   string
+	stage    string
+}
+
+const nodeEventWriteTimeout = 3 * time.Second
+
+func recordNodeFailureEvent(recorder record.EventRecorder, node *corev1.Node, reason, stage string, err error) {
+	if recorder == nil || node == nil || err == nil {
+		return
+	}
+	recorder.Eventf(node, corev1.EventTypeWarning, reason, "stage=%s error=%v", stage, err)
+}
+
+func (c *Controller) recordNodeFailure(node *corev1.Node, reason, stage string, err error) {
+	if node == nil || err == nil {
+		return
+	}
+
+	key := nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: reason, stage: stage}
+	message := err.Error()
+	c.nodeFailuresMutex.Lock()
+	if c.nodeFailures == nil {
+		c.nodeFailures = make(map[nodeFailureKey]string)
+	}
+	for existingKey := range c.nodeFailures {
+		if existingKey.nodeName == node.Name && existingKey.nodeUID != node.UID {
+			delete(c.nodeFailures, existingKey)
+		}
+	}
+	if c.nodeFailures[key] == message {
+		c.nodeFailuresMutex.Unlock()
+		return
+	}
+	c.nodeFailures[key] = message
+	c.nodeFailuresMutex.Unlock()
+
+	recordNodeFailureEvent(c.recorder, node, reason, stage, err)
+}
+
+func (c *Controller) clearNodeFailure(node *corev1.Node, reason, stage string) {
+	c.nodeFailuresMutex.Lock()
+	delete(c.nodeFailures, nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: reason, stage: stage})
+	c.nodeFailuresMutex.Unlock()
+}
+
+func (c *Controller) reconcileNodeNetworkStage(node *corev1.Node, stage string, reconcile func() error) error {
+	err := reconcile()
+	if err != nil {
+		c.recordNodeFailure(node, updateNodeFailedReason, stage, err)
+		return err
+	}
+	c.clearNodeFailure(node, updateNodeFailedReason, stage)
+	return nil
+}
+
+func recordNodeFailureEventSync(client kubernetes.Interface, node *corev1.Node, component, reason, stage string, failure error) error {
+	if client == nil || node == nil || failure == nil {
+		return errors.New("node event requires client, node, and failure")
+	}
+
+	now := metav1.Now()
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      eventutil.GenerateEventName(node.Name, now.UnixNano()),
+			Namespace: metav1.NamespaceDefault,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:            "Node",
+			APIVersion:      corev1.SchemeGroupVersion.String(),
+			Name:            node.Name,
+			UID:             node.UID,
+			ResourceVersion: node.ResourceVersion,
+		},
+		Reason:              reason,
+		Message:             fmt.Sprintf("stage=%s error=%v", stage, failure),
+		Source:              corev1.EventSource{Component: component},
+		FirstTimestamp:      now,
+		LastTimestamp:       now,
+		Count:               1,
+		Type:                corev1.EventTypeWarning,
+		ReportingController: component,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), nodeEventWriteTimeout)
+	defer cancel()
+	_, err := client.CoreV1().Events(metav1.NamespaceDefault).Create(ctx, event, metav1.CreateOptions{})
+	return err
+}
+
+func (c *Controller) recordLocalNodeFailureSync(stage string, failure error) {
+	node, err := c.nodesLister.Get(c.config.NodeName)
+	if err != nil {
+		klog.Errorf("failed to get node %s while recording stage %s failure: %v", c.config.NodeName, stage, err)
+		return
+	}
+	if err := recordNodeFailureEventSync(c.config.KubeClient, node, c.config.NodeName, updateNodeFailedReason, stage, failure); err != nil {
+		klog.Errorf("failed to record node %s stage %s failure: %v", c.config.NodeName, stage, err)
+	}
+}

--- a/pkg/daemon/node_events.go
+++ b/pkg/daemon/node_events.go
@@ -64,13 +64,16 @@ func (c *Controller) recordNodeFailure(node *corev1.Node, reason, stage string, 
 
 func (c *Controller) clearNodeFailure(node *corev1.Node, reason, stage string) {
 	c.nodeFailuresMutex.Lock()
-	delete(c.nodeFailures, nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: reason, stage: stage})
+	for existingKey := range c.nodeFailures {
+		if existingKey.nodeName == node.Name && (existingKey.nodeUID != node.UID || existingKey.reason == reason && existingKey.stage == stage) {
+			delete(c.nodeFailures, existingKey)
+		}
+	}
 	c.nodeFailuresMutex.Unlock()
 }
 
 func (c *Controller) reconcileNodeNetworkStage(node *corev1.Node, stage string, reconcile func() error) error {
-	err := reconcile()
-	if err != nil {
+	if err := reconcile(); err != nil {
 		c.recordNodeFailure(node, updateNodeFailedReason, stage, err)
 		return err
 	}
@@ -114,8 +117,14 @@ func recordNodeFailureEventSync(client kubernetes.Interface, node *corev1.Node, 
 func (c *Controller) recordLocalNodeFailureSync(stage string, failure error) {
 	node, err := c.nodesLister.Get(c.config.NodeName)
 	if err != nil {
-		klog.Errorf("failed to get node %s while recording stage %s failure: %v", c.config.NodeName, stage, err)
-		return
+		klog.Warningf("failed to get node %s from cache while recording stage %s failure: %v", c.config.NodeName, stage, err)
+		ctx, cancel := context.WithTimeout(context.Background(), nodeEventWriteTimeout)
+		defer cancel()
+		node, err = c.config.KubeClient.CoreV1().Nodes().Get(ctx, c.config.NodeName, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("failed to get node %s while recording stage %s failure: %v", c.config.NodeName, stage, err)
+			return
+		}
 	}
 	if err := recordNodeFailureEventSync(c.config.KubeClient, node, c.config.NodeName, updateNodeFailedReason, stage, failure); err != nil {
 		klog.Errorf("failed to record node %s stage %s failure: %v", c.config.NodeName, stage, err)

--- a/pkg/daemon/node_events.go
+++ b/pkg/daemon/node_events.go
@@ -25,6 +25,7 @@ type nodeFailureKey struct {
 	nodeUID  types.UID
 	reason   string
 	stage    string
+	message  string
 }
 
 const nodeEventWriteTimeout = 3 * time.Second
@@ -41,22 +42,22 @@ func (c *Controller) recordNodeFailure(node *corev1.Node, reason, stage string, 
 		return
 	}
 
-	key := nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: reason, stage: stage}
 	message := err.Error()
+	key := nodeFailureKey{nodeName: node.Name, nodeUID: node.UID, reason: reason, stage: stage, message: message}
 	c.nodeFailuresMutex.Lock()
 	if c.nodeFailures == nil {
-		c.nodeFailures = make(map[nodeFailureKey]string)
+		c.nodeFailures = make(map[nodeFailureKey]struct{})
 	}
 	for existingKey := range c.nodeFailures {
 		if existingKey.nodeName == node.Name && existingKey.nodeUID != node.UID {
 			delete(c.nodeFailures, existingKey)
 		}
 	}
-	if c.nodeFailures[key] == message {
+	if _, exists := c.nodeFailures[key]; exists {
 		c.nodeFailuresMutex.Unlock()
 		return
 	}
-	c.nodeFailures[key] = message
+	c.nodeFailures[key] = struct{}{}
 	c.nodeFailuresMutex.Unlock()
 
 	recordNodeFailureEvent(c.recorder, node, reason, stage, err)

--- a/pkg/daemon/node_events.go
+++ b/pkg/daemon/node_events.go
@@ -106,10 +106,8 @@ func recordNodeFailureEventSync(client kubernetes.Interface, node *corev1.Node, 
 
 	now := metav1.Now()
 	event := &corev1.Event{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      eventutil.GenerateEventName(node.Name, now.UnixNano()),
-			Namespace: metav1.NamespaceDefault,
-		},
+		Name:      eventutil.GenerateEventName(node.Name, now.UnixNano()),
+		Namespace: metav1.NamespaceDefault,
 		InvolvedObject: corev1.ObjectReference{
 			Kind:            "Node",
 			APIVersion:      corev1.SchemeGroupVersion.String(),

--- a/pkg/daemon/node_events.go
+++ b/pkg/daemon/node_events.go
@@ -30,6 +30,22 @@ type nodeFailureKey struct {
 
 const nodeEventWriteTimeout = 3 * time.Second
 
+// Keep changing failure messages from growing the in-memory deduplication set without bound.
+const maxNodeFailureSignatures = 16
+
+func trimNodeFailureSignatures(failures map[nodeFailureKey]struct{}, key nodeFailureKey) {
+	count := 0
+	for existingKey := range failures {
+		if existingKey.nodeName == key.nodeName && existingKey.nodeUID == key.nodeUID && existingKey.reason == key.reason && existingKey.stage == key.stage {
+			count++
+			if count >= maxNodeFailureSignatures {
+				delete(failures, existingKey)
+				return
+			}
+		}
+	}
+}
+
 func recordNodeFailureEvent(recorder record.EventRecorder, node *corev1.Node, reason, stage string, err error) {
 	if recorder == nil || node == nil || err == nil {
 		return
@@ -57,6 +73,7 @@ func (c *Controller) recordNodeFailure(node *corev1.Node, reason, stage string, 
 		c.nodeFailuresMutex.Unlock()
 		return
 	}
+	trimNodeFailureSignatures(c.nodeFailures, key)
 	c.nodeFailures[key] = struct{}{}
 	c.nodeFailuresMutex.Unlock()
 

--- a/pkg/daemon/node_events_test.go
+++ b/pkg/daemon/node_events_test.go
@@ -6,14 +6,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	listerv1 "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	k8sipset "k8s.io/kubernetes/pkg/proxy/ipvs/ipset"
 
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
@@ -52,6 +56,18 @@ func newNodeEventTestController(t *testing.T, node *corev1.Node) (*Controller, *
 		nodesLister: listerv1.NewNodeLister(indexer),
 		recorder:    recorder,
 	}, recorder
+}
+
+type sequenceIPSet struct {
+	k8sipset.Interface
+	errors []error
+	call   int
+}
+
+func (s *sequenceIPSet) ListSets() ([]string, error) {
+	err := s.errors[s.call]
+	s.call++
+	return nil, err
 }
 
 func TestHandleUpdateNodeRecordsFailureEvent(t *testing.T) {
@@ -98,6 +114,47 @@ func TestReconcileNodeNetworkStageDeduplicatesFailuresUntilSuccess(t *testing.T)
 	requireNodeEvent(t, recorder, "Warning", "UpdateNodeFailed", "stage=setIptables", failure.Error())
 }
 
+func TestGatewayIPSetListFailureIsRecordedUntilSuccess(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	controller, recorder := newNodeEventTestController(t, node)
+	failure := errors.New("failed to list ipsets")
+	controller.k8sipsets = &sequenceIPSet{errors: []error{failure, failure, nil, failure}}
+	reconcile := func() error {
+		return controller.removeNatOutGoingPolicyRuleIPset(string(corev1.IPv4Protocol), strset.New())
+	}
+
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setIPSet", reconcile), failure)
+	requireNodeEvent(t, recorder, "UpdateNodeFailed", "stage=setIPSet", failure.Error())
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setIPSet", reconcile), failure)
+	requireNoNodeEvent(t, recorder)
+	require.NoError(t, controller.reconcileNodeNetworkStage(node, "setIPSet", reconcile))
+	requireNoNodeEvent(t, recorder)
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setIPSet", reconcile), failure)
+	requireNodeEvent(t, recorder, "UpdateNodeFailed", "stage=setIPSet", failure.Error())
+}
+
+func TestRecordLocalNodeFailureSyncFallsBackToAPI(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	client := fake.NewSimpleClientset(node)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	controller := &Controller{
+		config:      &Configuration{KubeClient: client, NodeName: node.Name},
+		nodesLister: listerv1.NewNodeLister(indexer),
+	}
+
+	controller.recordLocalNodeFailureSync("checkOvn0Link", errors.New("ovn0 is down"))
+
+	events, err := client.CoreV1().Events(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+	require.Equal(t, node.UID, events.Items[0].InvolvedObject.UID)
+	require.Contains(t, events.Items[0].Message, "stage=checkOvn0Link")
+}
+
 func TestInitNodeGatewayRecordsFailureEvent(t *testing.T) {
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
 		Name: "node-1",
@@ -130,4 +187,74 @@ func TestInitNodeGatewayRecordsFailureEvent(t *testing.T) {
 	require.Equal(t, addNodeFailedReason, events.Items[0].Reason)
 	require.Contains(t, events.Items[0].Message, "stage=initializeOvn0")
 	require.Contains(t, events.Items[0].Message, failure.Error())
+}
+
+func TestInitNodeGatewayDeduplicatesInvalidAnnotations(t *testing.T) {
+	invalidNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-1",
+		UID:  "node-uid",
+		Annotations: map[string]string{
+			util.IPAddressAnnotation:  "invalid",
+			util.CidrAnnotation:       "10.0.0.0/24",
+			util.MacAddressAnnotation: "00:00:00:00:00:01",
+			util.PortNameAnnotation:   "node-node-1",
+			util.GatewayAnnotation:    "10.0.0.1",
+		},
+	}}
+	validNode := invalidNode.DeepCopy()
+	validNode.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	missingAddressNode := invalidNode.DeepCopy()
+	delete(missingAddressNode.Annotations, util.IPAddressAnnotation)
+	client := fake.NewSimpleClientset(validNode)
+	getCalls := 0
+	client.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		switch getCalls {
+		case 1, 2:
+			return true, invalidNode.DeepCopy(), nil
+		case 4, 5:
+			return true, missingAddressNode.DeepCopy(), nil
+		default:
+			return true, validNode.DeepCopy(), nil
+		}
+	})
+
+	originalConfigureNodeGateway := configureNodeGateway
+	originalRetryInterval := nodeGatewayInitRetryInterval
+	configureNodeGateway = func(kubernetes.Interface, string, string, string, string, string, net.HardwareAddr, int, bool) error {
+		return nil
+	}
+	nodeGatewayInitRetryInterval = 0
+	t.Cleanup(func() {
+		configureNodeGateway = originalConfigureNodeGateway
+		nodeGatewayInitRetryInterval = originalRetryInterval
+	})
+	config := &Configuration{KubeClient: client, NodeName: validNode.Name}
+
+	require.NoError(t, InitNodeGateway(config))
+	require.NoError(t, InitNodeGateway(config))
+
+	events, err := client.CoreV1().Events(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 2)
+	for _, event := range events.Items {
+		require.Equal(t, addNodeFailedReason, event.Reason)
+		require.Contains(t, event.Message, "stage=validateOvn0Annotations")
+	}
+	require.Contains(t, events.Items[0].Message+events.Items[1].Message, "no ovn0 address")
+}
+
+func TestUpdateNodeNetworkUnavailableConditionReturnsPatchFailure(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	client := fake.NewSimpleClientset(node)
+	failure := errors.New("failed to patch node condition")
+	client.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, failure
+	})
+
+	err := updateNodeNetworkUnavailableCondition(client, node.Name, "10.0.0.1", nil)
+
+	require.ErrorIs(t, err, failure)
 }

--- a/pkg/daemon/node_events_test.go
+++ b/pkg/daemon/node_events_test.go
@@ -1,0 +1,133 @@
+package daemon
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func requireNodeEvent(t *testing.T, recorder *record.FakeRecorder, parts ...string) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		for _, part := range parts {
+			require.Contains(t, event, part)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected node event")
+	}
+}
+
+func requireNoNodeEvent(t *testing.T, recorder *record.FakeRecorder) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected node event: %s", event)
+	default:
+	}
+}
+
+func newNodeEventTestController(t *testing.T, node *corev1.Node) (*Controller, *record.FakeRecorder) {
+	t.Helper()
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	require.NoError(t, indexer.Add(node))
+	recorder := record.NewFakeRecorder(10)
+	return &Controller{
+		config:      &Configuration{NodeName: node.Name},
+		nodesLister: listerv1.NewNodeLister(indexer),
+		recorder:    recorder,
+	}, recorder
+}
+
+func TestHandleUpdateNodeRecordsFailureEvent(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-1",
+		Annotations: map[string]string{
+			util.NodeNetworksAnnotation: "invalid json",
+		},
+	}}
+	controller, recorder := newNodeEventTestController(t, node)
+
+	err := controller.handleUpdateNode(node.Name)
+
+	require.Error(t, err)
+	requireNodeEvent(t, recorder, "Warning", "UpdateNodeFailed", "stage=updateNodeNetworks", err.Error())
+}
+
+func TestReconcileNodeNetworkStageDeduplicatesFailuresUntilSuccess(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "old-uid"}}
+	controller, recorder := newNodeEventTestController(t, node)
+	failure := errors.New("iptables failed")
+
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setIptables", func() error { return failure }), failure)
+	requireNodeEvent(t, recorder, "Warning", "UpdateNodeFailed", "stage=setIptables", failure.Error())
+
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setIptables", func() error { return failure }), failure)
+	requireNoNodeEvent(t, recorder)
+
+	replacementNode := node.DeepCopy()
+	replacementNode.UID = "new-uid"
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(replacementNode, "setIptables", func() error { return failure }), failure)
+	requireNodeEvent(t, recorder, "Warning", "UpdateNodeFailed", "stage=setIptables", failure.Error())
+	require.Len(t, controller.nodeFailures, 1)
+
+	require.NoError(t, controller.reconcileNodeNetworkStage(replacementNode, "setIptables", func() error { return nil }))
+	requireNoNodeEvent(t, recorder)
+	require.Empty(t, controller.nodeFailures)
+
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(replacementNode, "setIptables", func() error { return failure }), failure)
+	requireNodeEvent(t, recorder, "Warning", "UpdateNodeFailed", "stage=setIptables", failure.Error())
+}
+
+func TestInitNodeGatewayRecordsFailureEvent(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-1",
+		Annotations: map[string]string{
+			util.IPAddressAnnotation:  "10.0.0.2",
+			util.CidrAnnotation:       "10.0.0.0/24",
+			util.MacAddressAnnotation: "00:00:00:00:00:01",
+			util.PortNameAnnotation:   "node-node-1",
+			util.GatewayAnnotation:    "10.0.0.1",
+		},
+	}}
+	failure := errors.New("configure ovn0 failed")
+	originalConfigureNodeGateway := configureNodeGateway
+	configureNodeGateway = func(kubernetes.Interface, string, string, string, string, string, net.HardwareAddr, int, bool) error {
+		return failure
+	}
+	t.Cleanup(func() { configureNodeGateway = originalConfigureNodeGateway })
+
+	client := fake.NewSimpleClientset(node)
+	err := InitNodeGateway(&Configuration{
+		KubeClient: client,
+		NodeName:   node.Name,
+	})
+
+	require.ErrorIs(t, err, failure)
+	events, listErr := client.CoreV1().Events(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	require.Len(t, events.Items, 1)
+	require.Equal(t, corev1.EventTypeWarning, events.Items[0].Type)
+	require.Equal(t, addNodeFailedReason, events.Items[0].Reason)
+	require.Contains(t, events.Items[0].Message, "stage=initializeOvn0")
+	require.Contains(t, events.Items[0].Message, failure.Error())
+}

--- a/pkg/daemon/node_events_test.go
+++ b/pkg/daemon/node_events_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -133,6 +134,20 @@ func TestReconcileNodeNetworkStageDeduplicatesEachFailureMessage(t *testing.T) {
 	require.NoError(t, controller.reconcileNodeNetworkStage(node, "setGateway", func() error { return nil }))
 	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setGateway", func() error { return failureA }), failureA)
 	requireNodeEvent(t, recorder, failureA.Error())
+}
+
+func TestReconcileNodeNetworkStageBoundsFailureSignatures(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	controller, recorder := newNodeEventTestController(t, node)
+	for i := range maxNodeFailureSignatures + 4 {
+		failure := fmt.Errorf("failure-%d", i)
+		require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setGateway", func() error { return failure }), failure)
+		requireNodeEvent(t, recorder, failure.Error())
+	}
+
+	require.Len(t, controller.nodeFailures, maxNodeFailureSignatures)
 }
 
 func TestGatewayIPSetListFailureIsRecordedUntilSuccess(t *testing.T) {

--- a/pkg/daemon/node_events_test.go
+++ b/pkg/daemon/node_events_test.go
@@ -338,6 +338,11 @@ func TestInitNodeGatewayRecordsRouteFailureWhenGatewayIsReady(t *testing.T) {
 	require.Len(t, events.Items, 1)
 	require.Equal(t, addNodeFailedReason, events.Items[0].Reason)
 	require.Contains(t, events.Items[0].Message, routeFailure.Error())
+	updatedNode, getErr := client.CoreV1().Nodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+	require.NoError(t, getErr)
+	require.Len(t, updatedNode.Status.Conditions, 1)
+	require.Equal(t, corev1.ConditionFalse, updatedNode.Status.Conditions[0].Status)
+	require.Equal(t, "JoinSubnetGatewayReachable", updatedNode.Status.Conditions[0].Reason)
 }
 
 func TestUpdateNodeNetworkUnavailableConditionReturnsPatchFailure(t *testing.T) {

--- a/pkg/daemon/node_events_test.go
+++ b/pkg/daemon/node_events_test.go
@@ -402,7 +402,7 @@ func TestInitNodeGatewayRecordsRouteFailureWhenGatewayIsReady(t *testing.T) {
 	originalReplaceNodeRoute := replaceNodeRoute
 	originalCheckNodeGatewayReady := checkNodeGatewayReady
 	configureNodeGateway = func(client kubernetes.Interface, nodeName, _, ip, gateway, _ string, _ net.HardwareAddr, _ int, enableNonPrimaryCNI bool) error {
-		link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: util.NodeNic, Index: 1}}
+		link := &netlink.Dummy{Name: util.NodeNic, Index: 1}
 		return finishNodeGatewaySetup(client, nodeName, ip, gateway, link, []netlink.Route{{}}, enableNonPrimaryCNI)
 	}
 	replaceNodeRoute = func(*netlink.Route) error { return routeFailure }

--- a/pkg/daemon/node_events_test.go
+++ b/pkg/daemon/node_events_test.go
@@ -115,6 +115,26 @@ func TestReconcileNodeNetworkStageDeduplicatesFailuresUntilSuccess(t *testing.T)
 	requireNodeEvent(t, recorder, "Warning", "UpdateNodeFailed", "stage=setIptables", failure.Error())
 }
 
+func TestReconcileNodeNetworkStageDeduplicatesEachFailureMessage(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	controller, recorder := newNodeEventTestController(t, node)
+	failureA := errors.New("iptables failed")
+	failureB := errors.New("ipset failed")
+
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setGateway", func() error { return failureA }), failureA)
+	requireNodeEvent(t, recorder, failureA.Error())
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setGateway", func() error { return failureB }), failureB)
+	requireNodeEvent(t, recorder, failureB.Error())
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setGateway", func() error { return failureA }), failureA)
+	requireNoNodeEvent(t, recorder)
+
+	require.NoError(t, controller.reconcileNodeNetworkStage(node, "setGateway", func() error { return nil }))
+	require.ErrorIs(t, controller.reconcileNodeNetworkStage(node, "setGateway", func() error { return failureA }), failureA)
+	requireNodeEvent(t, recorder, failureA.Error())
+}
+
 func TestGatewayIPSetListFailureIsRecordedUntilSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -247,6 +267,54 @@ func TestInitNodeGatewayDeduplicatesInvalidAnnotations(t *testing.T) {
 		require.Contains(t, event.Message, "stage=validateOvn0Annotations")
 	}
 	require.Contains(t, events.Items[0].Message+events.Items[1].Message+events.Items[2].Message, "no ovn0 address")
+}
+
+func TestInitNodeGatewayDeduplicatesEachAnnotationFailureMessage(t *testing.T) {
+	invalidAddressNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-1",
+		UID:  "node-uid",
+		Annotations: map[string]string{
+			util.IPAddressAnnotation:  "invalid",
+			util.CidrAnnotation:       "10.0.0.0/24",
+			util.MacAddressAnnotation: "00:00:00:00:00:01",
+			util.PortNameAnnotation:   "node-node-1",
+			util.GatewayAnnotation:    "10.0.0.1",
+		},
+	}}
+	missingAddressNode := invalidAddressNode.DeepCopy()
+	delete(missingAddressNode.Annotations, util.IPAddressAnnotation)
+	validNode := invalidAddressNode.DeepCopy()
+	validNode.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	client := fake.NewSimpleClientset(validNode)
+	getCalls := 0
+	client.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		switch getCalls {
+		case 1, 3:
+			return true, invalidAddressNode.DeepCopy(), nil
+		case 2:
+			return true, missingAddressNode.DeepCopy(), nil
+		default:
+			return true, validNode.DeepCopy(), nil
+		}
+	})
+
+	originalConfigureNodeGateway := configureNodeGateway
+	originalRetryInterval := nodeGatewayInitRetryInterval
+	configureNodeGateway = func(kubernetes.Interface, string, string, string, string, string, net.HardwareAddr, int, bool) error {
+		return nil
+	}
+	nodeGatewayInitRetryInterval = 0
+	t.Cleanup(func() {
+		configureNodeGateway = originalConfigureNodeGateway
+		nodeGatewayInitRetryInterval = originalRetryInterval
+	})
+
+	require.NoError(t, InitNodeGateway(&Configuration{KubeClient: client, NodeName: validNode.Name}))
+
+	events, err := client.CoreV1().Events(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 2)
 }
 
 func TestInitNodeGatewayRetriesFailedAnnotationEventWrite(t *testing.T) {

--- a/pkg/daemon/node_events_test.go
+++ b/pkg/daemon/node_events_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -201,9 +202,11 @@ func TestInitNodeGatewayDeduplicatesInvalidAnnotations(t *testing.T) {
 			util.GatewayAnnotation:    "10.0.0.1",
 		},
 	}}
-	validNode := invalidNode.DeepCopy()
+	replacementNode := invalidNode.DeepCopy()
+	replacementNode.UID = "replacement-uid"
+	validNode := replacementNode.DeepCopy()
 	validNode.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
-	missingAddressNode := invalidNode.DeepCopy()
+	missingAddressNode := replacementNode.DeepCopy()
 	delete(missingAddressNode.Annotations, util.IPAddressAnnotation)
 	client := fake.NewSimpleClientset(validNode)
 	getCalls := 0
@@ -212,7 +215,9 @@ func TestInitNodeGatewayDeduplicatesInvalidAnnotations(t *testing.T) {
 		switch getCalls {
 		case 1, 2:
 			return true, invalidNode.DeepCopy(), nil
-		case 4, 5:
+		case 3, 4:
+			return true, replacementNode.DeepCopy(), nil
+		case 6, 7:
 			return true, missingAddressNode.DeepCopy(), nil
 		default:
 			return true, validNode.DeepCopy(), nil
@@ -236,12 +241,103 @@ func TestInitNodeGatewayDeduplicatesInvalidAnnotations(t *testing.T) {
 
 	events, err := client.CoreV1().Events(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, events.Items, 2)
+	require.Len(t, events.Items, 3)
 	for _, event := range events.Items {
 		require.Equal(t, addNodeFailedReason, event.Reason)
 		require.Contains(t, event.Message, "stage=validateOvn0Annotations")
 	}
-	require.Contains(t, events.Items[0].Message+events.Items[1].Message, "no ovn0 address")
+	require.Contains(t, events.Items[0].Message+events.Items[1].Message+events.Items[2].Message, "no ovn0 address")
+}
+
+func TestInitNodeGatewayRetriesFailedAnnotationEventWrite(t *testing.T) {
+	invalidNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-1",
+		UID:  "node-uid",
+		Annotations: map[string]string{
+			util.IPAddressAnnotation:  "invalid",
+			util.CidrAnnotation:       "10.0.0.0/24",
+			util.MacAddressAnnotation: "00:00:00:00:00:01",
+			util.PortNameAnnotation:   "node-node-1",
+			util.GatewayAnnotation:    "10.0.0.1",
+		},
+	}}
+	validNode := invalidNode.DeepCopy()
+	validNode.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
+	client := fake.NewSimpleClientset(validNode)
+	getCalls := 0
+	client.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls <= 2 {
+			return true, invalidNode.DeepCopy(), nil
+		}
+		return true, validNode.DeepCopy(), nil
+	})
+	eventCreateCalls := 0
+	eventWriteFailure := errors.New("event API unavailable")
+	client.PrependReactor("create", "events", func(k8stesting.Action) (bool, runtime.Object, error) {
+		eventCreateCalls++
+		if eventCreateCalls == 1 {
+			return true, nil, eventWriteFailure
+		}
+		return false, nil, nil
+	})
+
+	originalConfigureNodeGateway := configureNodeGateway
+	originalRetryInterval := nodeGatewayInitRetryInterval
+	configureNodeGateway = func(kubernetes.Interface, string, string, string, string, string, net.HardwareAddr, int, bool) error {
+		return nil
+	}
+	nodeGatewayInitRetryInterval = 0
+	t.Cleanup(func() {
+		configureNodeGateway = originalConfigureNodeGateway
+		nodeGatewayInitRetryInterval = originalRetryInterval
+	})
+
+	require.NoError(t, InitNodeGateway(&Configuration{KubeClient: client, NodeName: validNode.Name}))
+	require.Equal(t, 2, eventCreateCalls)
+	events, err := client.CoreV1().Events(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+	require.Contains(t, events.Items[0].Message, "stage=validateOvn0Annotations")
+}
+
+func TestInitNodeGatewayRecordsRouteFailureWhenGatewayIsReady(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-1",
+		UID:  "node-uid",
+		Annotations: map[string]string{
+			util.IPAddressAnnotation:  "10.0.0.2",
+			util.CidrAnnotation:       "10.0.0.0/24",
+			util.MacAddressAnnotation: "00:00:00:00:00:01",
+			util.PortNameAnnotation:   "node-node-1",
+			util.GatewayAnnotation:    "10.0.0.1",
+		},
+	}}
+	client := fake.NewSimpleClientset(node)
+	routeFailure := errors.New("route replace failed")
+	originalConfigureNodeGateway := configureNodeGateway
+	originalReplaceNodeRoute := replaceNodeRoute
+	originalCheckNodeGatewayReady := checkNodeGatewayReady
+	configureNodeGateway = func(client kubernetes.Interface, nodeName, _, ip, gateway, _ string, _ net.HardwareAddr, _ int, enableNonPrimaryCNI bool) error {
+		link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: util.NodeNic, Index: 1}}
+		return finishNodeGatewaySetup(client, nodeName, ip, gateway, link, []netlink.Route{{}}, enableNonPrimaryCNI)
+	}
+	replaceNodeRoute = func(*netlink.Route) error { return routeFailure }
+	checkNodeGatewayReady = func(string, string, string, bool, bool, int, chan struct{}) error { return nil }
+	t.Cleanup(func() {
+		configureNodeGateway = originalConfigureNodeGateway
+		replaceNodeRoute = originalReplaceNodeRoute
+		checkNodeGatewayReady = originalCheckNodeGatewayReady
+	})
+
+	err := InitNodeGateway(&Configuration{KubeClient: client, NodeName: node.Name})
+
+	require.ErrorIs(t, err, routeFailure)
+	events, listErr := client.CoreV1().Events(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	require.Len(t, events.Items, 1)
+	require.Equal(t, addNodeFailedReason, events.Items[0].Reason)
+	require.Contains(t, events.Items[0].Message, routeFailure.Error())
 }
 
 func TestUpdateNodeNetworkUnavailableConditionReturnsPatchFailure(t *testing.T) {

--- a/pkg/daemon/node_events_test.go
+++ b/pkg/daemon/node_events_test.go
@@ -75,12 +75,12 @@ func (s *sequenceIPSet) ListSets() ([]string, error) {
 func TestHandleUpdateNodeRecordsFailureEvent(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+	node := &corev1.Node{
 		Name: "node-1",
 		Annotations: map[string]string{
 			util.NodeNetworksAnnotation: "invalid json",
 		},
-	}}
+	}
 	controller, recorder := newNodeEventTestController(t, node)
 
 	err := controller.handleUpdateNode(node.Name)
@@ -92,7 +92,7 @@ func TestHandleUpdateNodeRecordsFailureEvent(t *testing.T) {
 func TestReconcileNodeNetworkStageDeduplicatesFailuresUntilSuccess(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "old-uid"}}
+	node := &corev1.Node{Name: "node-1", UID: "old-uid"}
 	controller, recorder := newNodeEventTestController(t, node)
 	failure := errors.New("iptables failed")
 
@@ -119,7 +119,7 @@ func TestReconcileNodeNetworkStageDeduplicatesFailuresUntilSuccess(t *testing.T)
 func TestReconcileNodeNetworkStageDeduplicatesEachFailureMessage(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	node := &corev1.Node{Name: "node-1", UID: "node-uid"}
 	controller, recorder := newNodeEventTestController(t, node)
 	failureA := errors.New("iptables failed")
 	failureB := errors.New("ipset failed")
@@ -139,7 +139,7 @@ func TestReconcileNodeNetworkStageDeduplicatesEachFailureMessage(t *testing.T) {
 func TestReconcileNodeNetworkStageBoundsFailureSignatures(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	node := &corev1.Node{Name: "node-1", UID: "node-uid"}
 	controller, recorder := newNodeEventTestController(t, node)
 	for i := range maxNodeFailureSignatures + 4 {
 		failure := fmt.Errorf("failure-%d", i)
@@ -153,7 +153,7 @@ func TestReconcileNodeNetworkStageBoundsFailureSignatures(t *testing.T) {
 func TestGatewayIPSetListFailureIsRecordedUntilSuccess(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	node := &corev1.Node{Name: "node-1", UID: "node-uid"}
 	controller, recorder := newNodeEventTestController(t, node)
 	failure := errors.New("failed to list ipsets")
 	controller.k8sipsets = &sequenceIPSet{errors: []error{failure, failure, nil, failure}}
@@ -174,7 +174,7 @@ func TestGatewayIPSetListFailureIsRecordedUntilSuccess(t *testing.T) {
 func TestRecordLocalNodeFailureSyncFallsBackToAPI(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "node-uid"}}
+	node := &corev1.Node{Name: "node-1", UID: "node-uid"}
 	client := fake.NewSimpleClientset(node)
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	controller := &Controller{
@@ -192,7 +192,7 @@ func TestRecordLocalNodeFailureSyncFallsBackToAPI(t *testing.T) {
 }
 
 func TestInitNodeGatewayRecordsFailureEvent(t *testing.T) {
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+	node := &corev1.Node{
 		Name: "node-1",
 		Annotations: map[string]string{
 			util.IPAddressAnnotation:  "10.0.0.2",
@@ -201,7 +201,7 @@ func TestInitNodeGatewayRecordsFailureEvent(t *testing.T) {
 			util.PortNameAnnotation:   "node-node-1",
 			util.GatewayAnnotation:    "10.0.0.1",
 		},
-	}}
+	}
 	failure := errors.New("configure ovn0 failed")
 	originalConfigureNodeGateway := configureNodeGateway
 	configureNodeGateway = func(kubernetes.Interface, string, string, string, string, string, net.HardwareAddr, int, bool) error {
@@ -226,7 +226,7 @@ func TestInitNodeGatewayRecordsFailureEvent(t *testing.T) {
 }
 
 func TestInitNodeGatewayDeduplicatesInvalidAnnotations(t *testing.T) {
-	invalidNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+	invalidNode := &corev1.Node{
 		Name: "node-1",
 		UID:  "node-uid",
 		Annotations: map[string]string{
@@ -236,7 +236,7 @@ func TestInitNodeGatewayDeduplicatesInvalidAnnotations(t *testing.T) {
 			util.PortNameAnnotation:   "node-node-1",
 			util.GatewayAnnotation:    "10.0.0.1",
 		},
-	}}
+	}
 	replacementNode := invalidNode.DeepCopy()
 	replacementNode.UID = "replacement-uid"
 	validNode := replacementNode.DeepCopy()
@@ -285,7 +285,7 @@ func TestInitNodeGatewayDeduplicatesInvalidAnnotations(t *testing.T) {
 }
 
 func TestInitNodeGatewayDeduplicatesEachAnnotationFailureMessage(t *testing.T) {
-	invalidAddressNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+	invalidAddressNode := &corev1.Node{
 		Name: "node-1",
 		UID:  "node-uid",
 		Annotations: map[string]string{
@@ -295,7 +295,7 @@ func TestInitNodeGatewayDeduplicatesEachAnnotationFailureMessage(t *testing.T) {
 			util.PortNameAnnotation:   "node-node-1",
 			util.GatewayAnnotation:    "10.0.0.1",
 		},
-	}}
+	}
 	missingAddressNode := invalidAddressNode.DeepCopy()
 	delete(missingAddressNode.Annotations, util.IPAddressAnnotation)
 	validNode := invalidAddressNode.DeepCopy()
@@ -333,7 +333,7 @@ func TestInitNodeGatewayDeduplicatesEachAnnotationFailureMessage(t *testing.T) {
 }
 
 func TestInitNodeGatewayRetriesFailedAnnotationEventWrite(t *testing.T) {
-	invalidNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+	invalidNode := &corev1.Node{
 		Name: "node-1",
 		UID:  "node-uid",
 		Annotations: map[string]string{
@@ -343,7 +343,7 @@ func TestInitNodeGatewayRetriesFailedAnnotationEventWrite(t *testing.T) {
 			util.PortNameAnnotation:   "node-node-1",
 			util.GatewayAnnotation:    "10.0.0.1",
 		},
-	}}
+	}
 	validNode := invalidNode.DeepCopy()
 	validNode.Annotations[util.IPAddressAnnotation] = "10.0.0.2"
 	client := fake.NewSimpleClientset(validNode)
@@ -385,7 +385,7 @@ func TestInitNodeGatewayRetriesFailedAnnotationEventWrite(t *testing.T) {
 }
 
 func TestInitNodeGatewayRecordsRouteFailureWhenGatewayIsReady(t *testing.T) {
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+	node := &corev1.Node{
 		Name: "node-1",
 		UID:  "node-uid",
 		Annotations: map[string]string{
@@ -395,7 +395,7 @@ func TestInitNodeGatewayRecordsRouteFailureWhenGatewayIsReady(t *testing.T) {
 			util.PortNameAnnotation:   "node-node-1",
 			util.GatewayAnnotation:    "10.0.0.1",
 		},
-	}}
+	}
 	client := fake.NewSimpleClientset(node)
 	routeFailure := errors.New("route replace failed")
 	originalConfigureNodeGateway := configureNodeGateway
@@ -431,7 +431,7 @@ func TestInitNodeGatewayRecordsRouteFailureWhenGatewayIsReady(t *testing.T) {
 func TestUpdateNodeNetworkUnavailableConditionReturnsPatchFailure(t *testing.T) {
 	t.Parallel()
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	node := &corev1.Node{Name: "node-1"}
 	client := fake.NewSimpleClientset(node)
 	failure := errors.New("failed to patch node condition")
 	client.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -820,22 +820,28 @@ func configureNodeNic(cs kubernetes.Interface, nodeName, portName, ip, gw, joinC
 
 	// Only set NetworkUnavailable condition when running as primary CNI
 	if !enableNonPrimaryCNI {
-		status := corev1.ConditionFalse
-		reason := "JoinSubnetGatewayReachable"
-		message := fmt.Sprintf("ping check to gateway ip %s succeeded", gw)
-		if err != nil {
-			status = corev1.ConditionTrue
-			reason = "JoinSubnetGatewayUnreachable"
-			message = fmt.Sprintf("ping check to gateway ip %s failed", gw)
-		}
-		if setErr := util.SetNodeNetworkUnavailableCondition(cs, nodeName, status, reason, message); setErr != nil {
-			klog.Errorf("failed to set node network unavailable condition: %v", setErr)
-		}
+		err = updateNodeNetworkUnavailableCondition(cs, nodeName, gw, err)
 	} else {
 		klog.Infof("running in non-primary CNI mode, skipping NetworkUnavailable condition update")
 	}
 
 	return err
+}
+
+func updateNodeNetworkUnavailableCondition(cs kubernetes.Interface, nodeName, gateway string, gatewayErr error) error {
+	status := corev1.ConditionFalse
+	reason := "JoinSubnetGatewayReachable"
+	message := fmt.Sprintf("ping check to gateway ip %s succeeded", gateway)
+	if gatewayErr != nil {
+		status = corev1.ConditionTrue
+		reason = "JoinSubnetGatewayUnreachable"
+		message = fmt.Sprintf("ping check to gateway ip %s failed", gateway)
+	}
+	if err := util.SetNodeNetworkUnavailableCondition(cs, nodeName, status, reason, message); err != nil {
+		klog.Errorf("failed to set node network unavailable condition: %v", err)
+		return errors.Join(gatewayErr, err)
+	}
+	return gatewayErr
 }
 
 // If OVS restart, the ovn0 port will down and prevent host to pod network,

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -848,11 +848,16 @@ func (c *Controller) loopOvn0Check() {
 
 	link, err := netlink.LinkByName(util.NodeNic)
 	if err != nil {
+		c.recordLocalNodeFailureSync("checkOvn0Link", err)
 		util.LogFatalAndExit(err, "failed to get node nic %s", util.NodeNic)
+		return
 	}
 
 	if link.Attrs().OperState == netlink.OperDown {
+		err = fmt.Errorf("node nic %s is down", util.NodeNic)
+		c.recordLocalNodeFailureSync("checkOvn0Link", err)
 		util.LogFatalAndExit(err, "node nic %s is down", util.NodeNic)
+		return
 	}
 
 	node, err := c.nodesLister.Get(c.config.NodeName)
@@ -881,14 +886,24 @@ func (c *Controller) loopOvn0Check() {
 		}
 	}
 	if !alreadySet {
-		if err := util.SetNodeNetworkUnavailableCondition(c.config.KubeClient, c.config.NodeName, status, reason, message); err != nil {
-			klog.Errorf("failed to set node network unavailable condition: %v", err)
+		if setErr := util.SetNodeNetworkUnavailableCondition(c.config.KubeClient, c.config.NodeName, status, reason, message); setErr != nil {
+			klog.Errorf("failed to set node network unavailable condition: %v", setErr)
+			c.recordNodeFailure(node, updateNodeFailedReason, "updateNetworkUnavailableCondition", setErr)
+		} else {
+			c.clearNodeFailure(node, updateNodeFailedReason, "updateNetworkUnavailableCondition")
 		}
+	} else {
+		c.clearNodeFailure(node, updateNodeFailedReason, "updateNetworkUnavailableCondition")
 	}
 
 	if err != nil {
+		if eventErr := recordNodeFailureEventSync(c.config.KubeClient, node, c.config.NodeName, updateNodeFailedReason, "checkOvn0Gateway", err); eventErr != nil {
+			klog.Errorf("failed to record node %s ovn0 gateway check failure: %v", c.config.NodeName, eventErr)
+		}
 		util.LogFatalAndExit(err, "failed to ping %s gateway %s", util.NodeNic, gw)
+		return
 	}
+	c.clearNodeFailure(node, updateNodeFailedReason, "checkOvn0Gateway")
 }
 
 // This method checks the status of the tunnel interface,

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -40,7 +40,11 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-var pciAddrRegexp = regexp.MustCompile(`\b([0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}.\d{1}\S*)`)
+var (
+	pciAddrRegexp         = regexp.MustCompile(`\b([0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}.\d{1}\S*)`)
+	replaceNodeRoute      = netlink.RouteReplace
+	checkNodeGatewayReady = waitNetworkReady
+)
 
 func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, netns, containerID, ifName, _ string, _ int, ip, _, ingress, egress, ingressBurst, egressBurst, shortSharedDir, socketName, socketConsumption string) error {
 	sharedDir := filepath.Join("/var", shortSharedDir)
@@ -804,28 +808,37 @@ func configureNodeNic(cs kubernetes.Interface, nodeName, portName, ip, gw, joinC
 		klog.Infof("routes to be added on nic %s: %v", util.NodeNic, toAdd)
 	}
 
-	for _, r := range toAdd {
-		r.LinkIndex = hostLink.Attrs().Index
-		klog.Infof("adding route %q on %s", r.String(), hostLink.Attrs().Name)
-		if err = netlink.RouteReplace(&r); err != nil && !errors.Is(err, syscall.EEXIST) {
-			klog.Errorf("failed to replace route %v: %v", r, err)
+	return finishNodeGatewaySetup(cs, nodeName, ip, gw, hostLink, toAdd, enableNonPrimaryCNI)
+}
+
+func finishNodeGatewaySetup(cs kubernetes.Interface, nodeName, ip, gateway string, hostLink netlink.Link, routes []netlink.Route, enableNonPrimaryCNI bool) error {
+	routeErr := addNodeNicRoutes(hostLink, routes)
+
+	klog.Infof("wait %s gw ready", util.NodeNic)
+	gatewayErr := checkNodeGatewayReady(util.NodeNic, ip, gateway, false, true, gatewayCheckMaxRetry, nil)
+	if gatewayErr != nil {
+		klog.Errorf("failed to init %s check: %v", util.NodeNic, gatewayErr)
+	}
+	err := errors.Join(routeErr, gatewayErr)
+	if !enableNonPrimaryCNI {
+		return updateNodeNetworkUnavailableCondition(cs, nodeName, gateway, err)
+	}
+	klog.Infof("running in non-primary CNI mode, skipping NetworkUnavailable condition update")
+	return err
+}
+
+func addNodeNicRoutes(hostLink netlink.Link, routes []netlink.Route) error {
+	var result error
+	for _, route := range routes {
+		route.LinkIndex = hostLink.Attrs().Index
+		klog.Infof("adding route %q on %s", route.String(), hostLink.Attrs().Name)
+		if err := replaceNodeRoute(&route); err != nil && !errors.Is(err, syscall.EEXIST) {
+			wrappedErr := fmt.Errorf("failed to replace route %v: %w", route, err)
+			klog.Error(wrappedErr)
+			result = errors.Join(result, wrappedErr)
 		}
 	}
-
-	// ping ovn0 gw to activate the flow
-	klog.Infof("wait %s gw ready", util.NodeNic)
-	if err = waitNetworkReady(util.NodeNic, ip, gw, false, true, gatewayCheckMaxRetry, nil); err != nil {
-		klog.Errorf("failed to init %s check: %v", util.NodeNic, err)
-	}
-
-	// Only set NetworkUnavailable condition when running as primary CNI
-	if !enableNonPrimaryCNI {
-		err = updateNodeNetworkUnavailableCondition(cs, nodeName, gw, err)
-	} else {
-		klog.Infof("running in non-primary CNI mode, skipping NetworkUnavailable condition update")
-	}
-
-	return err
+	return result
 }
 
 func updateNodeNetworkUnavailableCondition(cs kubernetes.Interface, nodeName, gateway string, gatewayErr error) error {

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -819,12 +819,12 @@ func finishNodeGatewaySetup(cs kubernetes.Interface, nodeName, ip, gateway strin
 	if gatewayErr != nil {
 		klog.Errorf("failed to init %s check: %v", util.NodeNic, gatewayErr)
 	}
-	err := errors.Join(routeErr, gatewayErr)
 	if !enableNonPrimaryCNI {
-		return updateNodeNetworkUnavailableCondition(cs, nodeName, gateway, err)
+		conditionErr := updateNodeNetworkUnavailableCondition(cs, nodeName, gateway, gatewayErr)
+		return errors.Join(routeErr, conditionErr)
 	}
 	klog.Infof("running in non-primary CNI mode, skipping NetworkUnavailable condition update")
-	return err
+	return errors.Join(routeErr, gatewayErr)
 }
 
 func addNodeNicRoutes(hostLink netlink.Link, routes []netlink.Route) error {


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- [x] Features
- [x] Tests

## What this PR does

Record Warning Events when Node reconciliation or daemon-side Node networking fails:

- `AddNodeFailed` for join-network allocation, annotation validation, and `ovn0` setup failures
- `UpdateNodeFailed` for Node network updates, gateway reconciliation stages, and periodic `ovn0` checks
- `DeleteNodeFailed` for Node network cleanup failures

Controller Events use the cached Node object, including the preserved deletion object. Daemon Events are deduplicated by Node UID, stage, and error until the stage succeeds; a recreated Node or a failure after recovery emits a new Event. Fatal daemon paths synchronously create the Event before exit and fall back to an API GET when the informer cache misses.

## Validation

- `go test ./pkg/controller ./pkg/daemon ./cmd/daemon -count=1`
- `go test -race ./pkg/controller -run "TestHandle(Add|Update|Delete)NodeRecordsFailureEvent" -count=1`
- `go test -race ./pkg/daemon -run "Test(HandleUpdateNodeRecordsFailureEvent|ReconcileNodeNetworkStageDeduplicatesFailuresUntilSuccess|GatewayIPSetListFailureIsRecordedUntilSuccess|RecordLocalNodeFailureSyncFallsBackToAPI|InitNodeGateway|UpdateNodeNetworkUnavailableConditionReturnsPatchFailure)" -count=1`
- `go vet ./pkg/controller ./pkg/daemon`
- `golangci-lint run --new-from-rev=origin/master ./pkg/controller/... ./pkg/daemon/...` (0 issues)
- `git diff --check`
- Standards review: 0 findings
- Spec review: 0 findings

## Which issue(s) this PR fixes

None.