### PR TITLE
fix: reconcile terminating iptables EIP/FIP/DNAT/SNAT from the add handler on restart

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -355,6 +355,20 @@ func newTypedRateLimitingQueue[T comparable](name string, rateLimiter workqueue.
 	return workqueue.NewTypedRateLimitingQueueWithConfig(rateLimiter, workqueue.TypedRateLimitingQueueConfig[T]{Name: name})
 }
 
+// enqueueUpdateIfTerminating routes an object that is already marked for deletion to the update
+// queue so the deletion cleanup runs. On controller restart the informer re-lists existing objects
+// and fires only AddFunc, so a terminating object would otherwise land in the add queue, hit the
+// already-ok short-circuit (or worse, recreate rules for a deleted resource) and never remove its
+// finalizer. The update handlers run the deletion path for these resources.
+func enqueueUpdateIfTerminating(queue workqueue.TypedRateLimitingInterface[string], key, kind string, deletionTimestamp *metav1.Time) bool {
+	if !deletionTimestamp.IsZero() {
+		klog.V(3).Infof("enqueue update to clean %s %s", kind, key)
+		queue.Add(key)
+		return true
+	}
+	return false
+}
+
 // Run creates and runs a new ovn controller
 func Run(ctx context.Context, config *Configuration) {
 	klog.V(4).Info("Creating event broadcaster")

--- a/pkg/controller/qos_policy.go
+++ b/pkg/controller/qos_policy.go
@@ -28,13 +28,24 @@ func (c *Controller) enqueueAddQoSPolicy(obj any) {
 	// A policy already marked for deletion must go through the update reconcile so its finalizer
 	// can be released; handleAddQoSPolicy does not process terminating policies. This also covers
 	// controller restart, where the informer re-lists objects already in their final state.
-	if !qos.DeletionTimestamp.IsZero() {
-		klog.V(3).Infof("enqueue update to clean qos %s", key)
-		c.updateQoSPolicyQueue.Add(key)
+	if enqueueUpdateIfTerminating(c.updateQoSPolicyQueue, key, "qos", qos.DeletionTimestamp) {
 		return
 	}
 	klog.V(3).Infof("enqueue add qos policy %s", key)
 	c.addQoSPolicyQueue.Add(key)
+}
+
+// enqueueQoSPolicyRelease re-enqueues a QoS policy whose QoSLabel a referencing resource (EIP or
+// NatGw) no longer carries, so a policy marked for deletion can drop its finalizer once unused.
+// The QoS reconcile decides "in use" via the QoSLabel selector, so the re-enqueue must key on the
+// label's old value. It is triggered from the delete handler (old labels only, newLabels nil) and
+// from the update handler when the label is cleared or switched; both fire only after the informer
+// cache already reflects the change, which avoids the stale-cache race that left policies stuck in
+// Terminating.
+func (c *Controller) enqueueQoSPolicyRelease(oldLabels, newLabels map[string]string) {
+	if oldQoS := oldLabels[util.QoSLabel]; oldQoS != "" && oldQoS != newLabels[util.QoSLabel] {
+		c.updateQoSPolicyQueue.Add(oldQoS)
+	}
 }
 
 func compareQoSPolicyBandwidthLimitRules(oldObj, newObj kubeovnv1.QoSPolicyBandwidthLimitRules) bool {

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -147,12 +147,9 @@ func (c *Controller) enqueueUpdateVpcNatGw(oldObj, newObj any) {
 	klog.V(3).Infof("enqueue update vpc-nat-gw %s", key)
 	c.addOrUpdateVpcNatGatewayQueue.Add(key)
 
-	// QoS reconcile decides "in use" via the QoSLabel selector, so key the re-enqueue on the
-	// label's previous value: when it is cleared or switched, re-enqueue the previous QoS so it
-	// can drop its finalizer. UpdateFunc fires after the informer cache reflects the label change.
-	if oldQoS := oldGw.Labels[util.QoSLabel]; oldQoS != "" && oldQoS != newGw.Labels[util.QoSLabel] {
-		c.updateQoSPolicyQueue.Add(oldQoS)
-	}
+	// When the QoSLabel is cleared or switched, re-enqueue the previous QoS policy so it can drop
+	// its finalizer once unused (the in-use check is keyed on the label).
+	c.enqueueQoSPolicyRelease(oldGw.Labels, newGw.Labels)
 }
 
 func (c *Controller) enqueueDeleteVpcNatGw(obj any) {
@@ -183,9 +180,7 @@ func (c *Controller) enqueueDeleteVpcNatGw(obj any) {
 
 	// Trigger QoS Policy reconcile after NatGw is deleted so it can drop its finalizer if no
 	// other NatGw references it. Key on the QoSLabel, matching the QoS in-use check.
-	if qos := gw.Labels[util.QoSLabel]; qos != "" {
-		c.updateQoSPolicyQueue.Add(qos)
-	}
+	c.enqueueQoSPolicyRelease(gw.Labels, nil)
 }
 
 // handleDelVpcNatGw handles NAT gateways when they've been deleted

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -23,7 +23,12 @@ import (
 )
 
 func (c *Controller) enqueueAddIptablesEip(obj any) {
-	key := cache.MetaObjectToName(obj.(*kubeovnv1.IptablesEIP)).String()
+	eip := obj.(*kubeovnv1.IptablesEIP)
+	key := cache.MetaObjectToName(eip).String()
+	// A terminating object reconciles via the update queue for cleanup (handleAdd skips it; resync=0).
+	if enqueueUpdateIfTerminating(c.updateIptablesEipQueue, key, "iptables eip", eip.DeletionTimestamp) {
+		return
+	}
 	klog.Infof("enqueue add iptables eip %s", key)
 	c.addIptablesEipQueue.Add(key)
 }
@@ -39,12 +44,9 @@ func (c *Controller) enqueueUpdateIptablesEip(oldObj, newObj any) {
 		c.updateIptablesEipQueue.Add(key)
 	}
 
-	// QoS reconcile decides "in use" via the QoSLabel selector, so key the re-enqueue on the
-	// label's previous value: when it is cleared or switched, re-enqueue the previous QoS so it
-	// can drop its finalizer. UpdateFunc fires after the informer cache reflects the label change.
-	if oldQoS := oldEip.Labels[util.QoSLabel]; oldQoS != "" && oldQoS != newEip.Labels[util.QoSLabel] {
-		c.updateQoSPolicyQueue.Add(oldQoS)
-	}
+	// When the QoSLabel is cleared or switched, re-enqueue the previous QoS policy so it can drop
+	// its finalizer once unused (the in-use check is keyed on the label).
+	c.enqueueQoSPolicyRelease(oldEip.Labels, newEip.Labels)
 }
 
 func (c *Controller) enqueueDelIptablesEip(obj any) {
@@ -69,10 +71,8 @@ func (c *Controller) enqueueDelIptablesEip(obj any) {
 	c.delIptablesEipQueue.Add(eip)
 
 	// Re-trigger QoS reconcile so it can drop its finalizer once unused. DeleteFunc runs after
-	// the informer cache dropped this EIP. Key on the QoSLabel, matching the QoS in-use check.
-	if qos := eip.Labels[util.QoSLabel]; qos != "" {
-		c.updateQoSPolicyQueue.Add(qos)
-	}
+	// the informer cache dropped this EIP; key on the QoSLabel, matching the QoS in-use check.
+	c.enqueueQoSPolicyRelease(eip.Labels, nil)
 }
 
 // natEipNamespace returns the namespace where the NAT gateway pod for the given EIP resides.

--- a/pkg/controller/vpc_nat_gw_eip_test.go
+++ b/pkg/controller/vpc_nat_gw_eip_test.go
@@ -83,3 +83,40 @@ func TestDelEipQoSInPod_NatGwExistsPodMissing(t *testing.T) {
 	err = fc.fakeController.delEipQoSInPod("test-gw", "10.0.0.1", "kube-system", kubeovnv1.QoSDirectionEgress)
 	require.Error(t, err, "should return error to retry when pod is temporarily absent")
 }
+
+// TestEnqueueAddIptablesEip verifies that on the add path a terminating EIP is routed to the
+// update queue (which runs deletion cleanup) instead of the add queue. This is what lets a
+// stuck-terminating EIP be finalized after a controller restart, where the informer re-lists
+// existing objects and fires only AddFunc.
+func TestEnqueueAddIptablesEip(t *testing.T) {
+	t.Parallel()
+
+	newController := func(t *testing.T) *Controller {
+		c := &Controller{
+			addIptablesEipQueue:    newTypedRateLimitingQueue[string]("AddIptablesEip", nil),
+			updateIptablesEipQueue: newTypedRateLimitingQueue[string]("UpdateIptablesEip", nil),
+		}
+		t.Cleanup(c.addIptablesEipQueue.ShutDown)
+		t.Cleanup(c.updateIptablesEipQueue.ShutDown)
+		return c
+	}
+
+	t.Run("live eip goes to the add queue", func(t *testing.T) {
+		c := newController(t)
+		c.enqueueAddIptablesEip(&kubeovnv1.IptablesEIP{
+			ObjectMeta: metav1.ObjectMeta{Name: "live-eip"},
+		})
+		require.Equal(t, 1, c.addIptablesEipQueue.Len())
+		require.Equal(t, 0, c.updateIptablesEipQueue.Len())
+	})
+
+	t.Run("terminating eip goes to the update queue for cleanup", func(t *testing.T) {
+		c := newController(t)
+		now := metav1.Now()
+		c.enqueueAddIptablesEip(&kubeovnv1.IptablesEIP{
+			ObjectMeta: metav1.ObjectMeta{Name: "terminating-eip", DeletionTimestamp: &now},
+		})
+		require.Equal(t, 0, c.addIptablesEipQueue.Len())
+		require.Equal(t, 1, c.updateIptablesEipQueue.Len())
+	})
+}

--- a/pkg/controller/vpc_nat_gw_eip_test.go
+++ b/pkg/controller/vpc_nat_gw_eip_test.go
@@ -90,33 +90,15 @@ func TestDelEipQoSInPod_NatGwExistsPodMissing(t *testing.T) {
 // existing objects and fires only AddFunc.
 func TestEnqueueAddIptablesEip(t *testing.T) {
 	t.Parallel()
-
-	newController := func(t *testing.T) *Controller {
-		c := &Controller{
-			addIptablesEipQueue:    newTypedRateLimitingQueue[string]("AddIptablesEip", nil),
-			updateIptablesEipQueue: newTypedRateLimitingQueue[string]("UpdateIptablesEip", nil),
-		}
-		t.Cleanup(c.addIptablesEipQueue.ShutDown)
-		t.Cleanup(c.updateIptablesEipQueue.ShutDown)
-		return c
+	c := &Controller{
+		addIptablesEipQueue:    newTypedRateLimitingQueue[string]("AddIptablesEip", nil),
+		updateIptablesEipQueue: newTypedRateLimitingQueue[string]("UpdateIptablesEip", nil),
 	}
-
-	t.Run("live eip goes to the add queue", func(t *testing.T) {
-		c := newController(t)
-		c.enqueueAddIptablesEip(&kubeovnv1.IptablesEIP{
-			ObjectMeta: metav1.ObjectMeta{Name: "live-eip"},
-		})
-		require.Equal(t, 1, c.addIptablesEipQueue.Len())
-		require.Equal(t, 0, c.updateIptablesEipQueue.Len())
-	})
-
-	t.Run("terminating eip goes to the update queue for cleanup", func(t *testing.T) {
-		c := newController(t)
-		now := metav1.Now()
-		c.enqueueAddIptablesEip(&kubeovnv1.IptablesEIP{
-			ObjectMeta: metav1.ObjectMeta{Name: "terminating-eip", DeletionTimestamp: &now},
-		})
-		require.Equal(t, 0, c.addIptablesEipQueue.Len())
-		require.Equal(t, 1, c.updateIptablesEipQueue.Len())
-	})
+	t.Cleanup(c.addIptablesEipQueue.ShutDown)
+	t.Cleanup(c.updateIptablesEipQueue.ShutDown)
+	now := metav1.Now()
+	assertEnqueueAddRouting(t, c.addIptablesEipQueue, c.updateIptablesEipQueue, c.enqueueAddIptablesEip,
+		&kubeovnv1.IptablesEIP{ObjectMeta: metav1.ObjectMeta{Name: "live-eip"}},
+		&kubeovnv1.IptablesEIP{ObjectMeta: metav1.ObjectMeta{Name: "terminating-eip", DeletionTimestamp: &now}},
+	)
 }

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -22,7 +22,12 @@ import (
 )
 
 func (c *Controller) enqueueAddIptablesFip(obj any) {
-	key := cache.MetaObjectToName(obj.(*kubeovnv1.IptablesFIPRule)).String()
+	fip := obj.(*kubeovnv1.IptablesFIPRule)
+	key := cache.MetaObjectToName(fip).String()
+	// A terminating object reconciles via the update queue for cleanup (handleAdd skips it; resync=0).
+	if enqueueUpdateIfTerminating(c.updateIptablesFipQueue, key, "fip", fip.DeletionTimestamp) {
+		return
+	}
 	klog.V(3).Infof("enqueue add iptables fip %s", key)
 	c.addIptablesFipQueue.Add(key)
 }
@@ -73,7 +78,12 @@ func (c *Controller) enqueueDelIptablesFip(obj any) {
 }
 
 func (c *Controller) enqueueAddIptablesDnatRule(obj any) {
-	key := cache.MetaObjectToName(obj.(*kubeovnv1.IptablesDnatRule)).String()
+	dnat := obj.(*kubeovnv1.IptablesDnatRule)
+	key := cache.MetaObjectToName(dnat).String()
+	// A terminating object reconciles via the update queue for cleanup (handleAdd skips it; resync=0).
+	if enqueueUpdateIfTerminating(c.updateIptablesDnatRuleQueue, key, "dnat", dnat.DeletionTimestamp) {
+		return
+	}
 	klog.V(3).Infof("enqueue add iptables dnat %s", key)
 	c.addIptablesDnatRuleQueue.Add(key)
 }
@@ -129,7 +139,12 @@ func (c *Controller) enqueueDelIptablesDnatRule(obj any) {
 }
 
 func (c *Controller) enqueueAddIptablesSnatRule(obj any) {
-	key := cache.MetaObjectToName(obj.(*kubeovnv1.IptablesSnatRule)).String()
+	snat := obj.(*kubeovnv1.IptablesSnatRule)
+	key := cache.MetaObjectToName(snat).String()
+	// A terminating object reconciles via the update queue for cleanup (handleAdd skips it; resync=0).
+	if enqueueUpdateIfTerminating(c.updateIptablesSnatRuleQueue, key, "snat", snat.DeletionTimestamp) {
+		return
+	}
 	klog.V(3).Infof("enqueue add iptables snat %s", key)
 	c.addIptablesSnatRuleQueue.Add(key)
 }

--- a/pkg/controller/vpc_nat_gw_nat_test.go
+++ b/pkg/controller/vpc_nat_gw_nat_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
@@ -691,4 +692,67 @@ func TestIsDnatDuplicated(t *testing.T) {
 			}
 		})
 	}
+}
+
+// assertEnqueueAddRouting checks that the add handler routes a live object to the add queue and a
+// terminating object to the update queue (the deletion-cleanup path relied on after a restart).
+func assertEnqueueAddRouting(
+	t *testing.T,
+	addQueue, updateQueue workqueue.TypedRateLimitingInterface[string],
+	enqueue func(any),
+	live, terminating any,
+) {
+	t.Helper()
+	enqueue(live)
+	require.Equal(t, 1, addQueue.Len(), "live object should go to the add queue")
+	require.Equal(t, 0, updateQueue.Len(), "live object must not go to the update queue")
+
+	enqueue(terminating)
+	require.Equal(t, 1, addQueue.Len(), "terminating object must not go to the add queue")
+	require.Equal(t, 1, updateQueue.Len(), "terminating object should go to the update queue for cleanup")
+}
+
+func TestEnqueueAddIptablesFip(t *testing.T) {
+	t.Parallel()
+	c := &Controller{
+		addIptablesFipQueue:    newTypedRateLimitingQueue[string]("AddIptablesFip", nil),
+		updateIptablesFipQueue: newTypedRateLimitingQueue[string]("UpdateIptablesFip", nil),
+	}
+	t.Cleanup(c.addIptablesFipQueue.ShutDown)
+	t.Cleanup(c.updateIptablesFipQueue.ShutDown)
+	now := metav1.Now()
+	assertEnqueueAddRouting(t, c.addIptablesFipQueue, c.updateIptablesFipQueue, c.enqueueAddIptablesFip,
+		&kubeovnv1.IptablesFIPRule{ObjectMeta: metav1.ObjectMeta{Name: "live-fip"}},
+		&kubeovnv1.IptablesFIPRule{ObjectMeta: metav1.ObjectMeta{Name: "terminating-fip", DeletionTimestamp: &now}},
+	)
+}
+
+func TestEnqueueAddIptablesDnatRule(t *testing.T) {
+	t.Parallel()
+	c := &Controller{
+		addIptablesDnatRuleQueue:    newTypedRateLimitingQueue[string]("AddIptablesDnat", nil),
+		updateIptablesDnatRuleQueue: newTypedRateLimitingQueue[string]("UpdateIptablesDnat", nil),
+	}
+	t.Cleanup(c.addIptablesDnatRuleQueue.ShutDown)
+	t.Cleanup(c.updateIptablesDnatRuleQueue.ShutDown)
+	now := metav1.Now()
+	assertEnqueueAddRouting(t, c.addIptablesDnatRuleQueue, c.updateIptablesDnatRuleQueue, c.enqueueAddIptablesDnatRule,
+		&kubeovnv1.IptablesDnatRule{ObjectMeta: metav1.ObjectMeta{Name: "live-dnat"}},
+		&kubeovnv1.IptablesDnatRule{ObjectMeta: metav1.ObjectMeta{Name: "terminating-dnat", DeletionTimestamp: &now}},
+	)
+}
+
+func TestEnqueueAddIptablesSnatRule(t *testing.T) {
+	t.Parallel()
+	c := &Controller{
+		addIptablesSnatRuleQueue:    newTypedRateLimitingQueue[string]("AddIptablesSnat", nil),
+		updateIptablesSnatRuleQueue: newTypedRateLimitingQueue[string]("UpdateIptablesSnat", nil),
+	}
+	t.Cleanup(c.addIptablesSnatRuleQueue.ShutDown)
+	t.Cleanup(c.updateIptablesSnatRuleQueue.ShutDown)
+	now := metav1.Now()
+	assertEnqueueAddRouting(t, c.addIptablesSnatRuleQueue, c.updateIptablesSnatRuleQueue, c.enqueueAddIptablesSnatRule,
+		&kubeovnv1.IptablesSnatRule{ObjectMeta: metav1.ObjectMeta{Name: "live-snat"}},
+		&kubeovnv1.IptablesSnatRule{ObjectMeta: metav1.ObjectMeta{Name: "terminating-snat", DeletionTimestamp: &now}},
+	)
 }


### PR DESCRIPTION


Deletion cleanup for these resources only runs in the update reconcile. After a controller restart the informer re-lists existing objects and fires only AddFunc; with resync=0 a terminating object would land in the add queue, hit the already-ok short-circuit (or worse, recreate iptables rules for a deleted resource) and never remove its finalizer. Route terminating objects to the update queue, matching the existing enqueueUpdate* handlers.

test: verify terminating IptablesEIP is routed to the update queue on add

Covers the restart path: the informer re-lists existing objects and fires only AddFunc, so a terminating EIP must be routed to the update queue (cleanup) rather than the add queue.

refactor: extract shared helpers for terminating-route and QoS release enqueue

Collapse the five duplicated terminating->update-queue blocks and the four duplicated QoS-label release blocks into two helpers with identical behavior:

- enqueueUpdateIfTerminating(queue, key, kind, deletionTimestamp): routes a terminating object to its update queue (add handlers for EIP/FIP/DNAT/SNAT/QoS).
- enqueueQoSPolicyRelease(oldLabels, newLabels): re-enqueues the previously referenced QoS policy on EIP/NatGw label change (update) or deletion (nil newLabels), keyed on QoSLabel to match the in-use check.

No behavior change (nil DeletionTimestamp and nil newLabels are handled the same as before); EIP's terminating log drops from Infof to V(3) for consistency.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
