### PR TITLE
test(ipam): wait for excluded pool reconciliation

### DIFF
--- a/test/e2e/kube-ovn/ipam/ipam.go
+++ b/test/e2e/kube-ovn/ipam/ipam.go
@@ -969,6 +969,9 @@ var _ = framework.Describe("[group:ipam]", func() {
 		modifiedSubnet.Spec.ExcludeIps = append(slices.Clone(subnet.Spec.ExcludeIps), poolIPs...)
 		subnet = subnetClient.PatchSync(subnet, modifiedSubnet)
 
+		ginkgo.By("Waiting for the IPPool to become exhausted")
+		_ = waitForIPPoolCounts(f, ippoolClient, ippoolName, 0, 0)
+
 		ginkgo.By("Creating pod " + podName + " from the exhausted IPPool")
 		annotations := map[string]string{util.IPPoolAnnotation: ippoolName}
 		pod := framework.MakePod(namespaceName, podName, nil, annotations, "", nil, nil)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Tests

## What this PR does

Wait for the named IPPool to report zero available addresses after updating the Subnet exclusion list and before creating the Pod.

`PatchSync` only observes the Subnet API update and its existing Ready condition. IPAM reconciliation is asynchronous, so the Pod could still receive an address that had just been excluded. This synchronization removes that E2E race.

## Verification

- The original failing dual-stack overlay E2E passed with this change: https://github.com/kubeovn/kube-ovn/actions/runs/31548729622/job/93968604423

## Which issue(s) this PR fixes

None
