### PR TITLE
fix(controller): preserve subnet IP status during reconciliation

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -515,7 +516,15 @@ func (c *Controller) updateSubnetDHCPOption(subnet *kubeovnv1.Subnet, needRouter
 	if subnet.Status.DHCPv4OptionsUUID != dhcpOptionsUUIDs.DHCPv4OptionsUUID || subnet.Status.DHCPv6OptionsUUID != dhcpOptionsUUIDs.DHCPv6OptionsUUID {
 		subnet.Status.DHCPv4OptionsUUID = dhcpOptionsUUIDs.DHCPv4OptionsUUID
 		subnet.Status.DHCPv6OptionsUUID = dhcpOptionsUUIDs.DHCPv6OptionsUUID
-		bytes, err := subnet.Status.Bytes()
+		patch := struct {
+			Status struct {
+				DHCPv4OptionsUUID string `json:"dhcpV4OptionsUUID"`
+				DHCPv6OptionsUUID string `json:"dhcpV6OptionsUUID"`
+			} `json:"status"`
+		}{}
+		patch.Status.DHCPv4OptionsUUID = subnet.Status.DHCPv4OptionsUUID
+		patch.Status.DHCPv6OptionsUUID = subnet.Status.DHCPv6OptionsUUID
+		bytes, err := json.Marshal(patch)
 		if err != nil {
 			klog.Error(err)
 			return err

--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -47,6 +47,36 @@ func (c *Controller) updateNatOutgoingPolicyRulesStatus(subnet *kubeovnv1.Subnet
 	return nil
 }
 
+type subnetStatusPatch struct {
+	Status struct {
+		Conditions             []kubeovnv1.Condition                   `json:"conditions,omitempty"`
+		ActivateGateway        string                                  `json:"activateGateway"`
+		DHCPv4OptionsUUID      string                                  `json:"dhcpV4OptionsUUID"`
+		DHCPv6OptionsUUID      string                                  `json:"dhcpV6OptionsUUID"`
+		U2OInterconnectionIP   string                                  `json:"u2oInterconnectionIP"`
+		U2OInterconnectionMAC  string                                  `json:"u2oInterconnectionMAC"`
+		U2OInterconnectionVPC  string                                  `json:"u2oInterconnectionVPC"`
+		NatOutgoingPolicyRules []kubeovnv1.NatOutgoingPolicyRuleStatus `json:"natOutgoingPolicyRules"`
+		McastQuerierIP         string                                  `json:"mcastQuerierIP"`
+		McastQuerierMAC        string                                  `json:"mcastQuerierMAC"`
+	} `json:"status"`
+}
+
+func buildSubnetStatusPatch(status *kubeovnv1.SubnetStatus) ([]byte, error) {
+	patch := subnetStatusPatch{}
+	patch.Status.Conditions = status.Conditions
+	patch.Status.ActivateGateway = status.ActivateGateway
+	patch.Status.DHCPv4OptionsUUID = status.DHCPv4OptionsUUID
+	patch.Status.DHCPv6OptionsUUID = status.DHCPv6OptionsUUID
+	patch.Status.U2OInterconnectionIP = status.U2OInterconnectionIP
+	patch.Status.U2OInterconnectionMAC = status.U2OInterconnectionMAC
+	patch.Status.U2OInterconnectionVPC = status.U2OInterconnectionVPC
+	patch.Status.NatOutgoingPolicyRules = status.NatOutgoingPolicyRules
+	patch.Status.McastQuerierIP = status.McastQuerierIP
+	patch.Status.McastQuerierMAC = status.McastQuerierMAC
+	return json.Marshal(patch)
+}
+
 func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr string) error {
 	if errStr != "" {
 		subnet.Status.SetError(reason, errStr)
@@ -68,7 +98,9 @@ func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason, errStr 
 		}
 	}
 
-	bytes, err := subnet.Status.Bytes()
+	// IP statistics are owned by calcSubnetStatusIP. Omitting them from this
+	// patch prevents a stale informer object from overwriting newer values.
+	bytes, err := buildSubnetStatusPatch(&subnet.Status)
 	if err != nil {
 		klog.Error(err)
 		return err

--- a/pkg/controller/subnet_status.go
+++ b/pkg/controller/subnet_status.go
@@ -51,8 +51,6 @@ type subnetStatusPatch struct {
 	Status struct {
 		Conditions             []kubeovnv1.Condition                   `json:"conditions,omitempty"`
 		ActivateGateway        string                                  `json:"activateGateway"`
-		DHCPv4OptionsUUID      string                                  `json:"dhcpV4OptionsUUID"`
-		DHCPv6OptionsUUID      string                                  `json:"dhcpV6OptionsUUID"`
 		U2OInterconnectionIP   string                                  `json:"u2oInterconnectionIP"`
 		U2OInterconnectionMAC  string                                  `json:"u2oInterconnectionMAC"`
 		U2OInterconnectionVPC  string                                  `json:"u2oInterconnectionVPC"`
@@ -66,8 +64,6 @@ func buildSubnetStatusPatch(status *kubeovnv1.SubnetStatus) ([]byte, error) {
 	patch := subnetStatusPatch{}
 	patch.Status.Conditions = status.Conditions
 	patch.Status.ActivateGateway = status.ActivateGateway
-	patch.Status.DHCPv4OptionsUUID = status.DHCPv4OptionsUUID
-	patch.Status.DHCPv6OptionsUUID = status.DHCPv6OptionsUUID
 	patch.Status.U2OInterconnectionIP = status.U2OInterconnectionIP
 	patch.Status.U2OInterconnectionMAC = status.U2OInterconnectionMAC
 	patch.Status.U2OInterconnectionVPC = status.U2OInterconnectionVPC

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -21,6 +21,55 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
+func TestPatchSubnetStatusPreservesIPStatistics(t *testing.T) {
+	t.Parallel()
+
+	const subnetName = "centralized-dual"
+	liveSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Status: kubeovnv1.SubnetStatus{
+			V4AvailableIPs:     internal.NewBigInt(253),
+			V4AvailableIPRange: "10.0.0.2-10.0.0.254",
+			V4UsingIPs:         internal.NewBigInt(1),
+			V4UsingIPRange:     "10.0.0.1",
+			V6AvailableIPs:     internal.NewBigInt(4294967293),
+			V6AvailableIPRange: "fd00::2-fd00::ffff:fffe",
+			V6UsingIPs:         internal.NewBigInt(1),
+			V6UsingIPRange:     "fd00::1",
+		},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{liveSubnet},
+	})
+	require.NoError(t, err)
+
+	staleSubnet := liveSubnet.DeepCopy()
+	staleSubnet.Status.V4AvailableIPs = internal.BigInt{}
+	staleSubnet.Status.V4AvailableIPRange = ""
+	staleSubnet.Status.V4UsingIPs = internal.BigInt{}
+	staleSubnet.Status.V4UsingIPRange = ""
+	staleSubnet.Status.V6AvailableIPs = internal.BigInt{}
+	staleSubnet.Status.V6AvailableIPRange = ""
+	staleSubnet.Status.V6UsingIPs = internal.BigInt{}
+	staleSubnet.Status.V6UsingIPRange = ""
+	staleSubnet.Status.ActivateGateway = "node-1"
+
+	require.NoError(t, fc.fakeController.patchSubnetStatus(staleSubnet, "ReconcileCentralizedGatewaySuccess", ""))
+	updated, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().Subnets().Get(
+		context.Background(), subnetName, metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, internal.NewBigInt(253), updated.Status.V4AvailableIPs)
+	require.Equal(t, "10.0.0.2-10.0.0.254", updated.Status.V4AvailableIPRange)
+	require.Equal(t, internal.NewBigInt(1), updated.Status.V4UsingIPs)
+	require.Equal(t, "10.0.0.1", updated.Status.V4UsingIPRange)
+	require.Equal(t, internal.NewBigInt(4294967293), updated.Status.V6AvailableIPs)
+	require.Equal(t, "fd00::2-fd00::ffff:fffe", updated.Status.V6AvailableIPRange)
+	require.Equal(t, internal.NewBigInt(1), updated.Status.V6UsingIPs)
+	require.Equal(t, "fd00::1", updated.Status.V6UsingIPRange)
+	require.Equal(t, "node-1", updated.Status.ActivateGateway)
+}
+
 func Test_readyToRemoveFinalizer(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -70,6 +70,37 @@ func TestPatchSubnetStatusPreservesIPStatistics(t *testing.T) {
 	require.Equal(t, "node-1", updated.Status.ActivateGateway)
 }
 
+func TestPatchSubnetStatusPreservesDHCPOptions(t *testing.T) {
+	t.Parallel()
+
+	const subnetName = "centralized-dual"
+	liveSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Status: kubeovnv1.SubnetStatus{
+			DHCPv4OptionsUUID: "new-v4",
+			DHCPv6OptionsUUID: "new-v6",
+		},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{liveSubnet},
+	})
+	require.NoError(t, err)
+
+	staleSubnet := liveSubnet.DeepCopy()
+	staleSubnet.Status.DHCPv4OptionsUUID = "old-v4"
+	staleSubnet.Status.DHCPv6OptionsUUID = "old-v6"
+	staleSubnet.Status.ActivateGateway = "node-1"
+
+	require.NoError(t, fc.fakeController.patchSubnetStatus(staleSubnet, "ReconcileCentralizedGatewaySuccess", ""))
+	updated, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().Subnets().Get(
+		context.Background(), subnetName, metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "new-v4", updated.Status.DHCPv4OptionsUUID)
+	require.Equal(t, "new-v6", updated.Status.DHCPv6OptionsUUID)
+	require.Equal(t, "node-1", updated.Status.ActivateGateway)
+}
+
 func Test_readyToRemoveFinalizer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Subnet route reconciliation can operate on a stale informer object after `calcSubnetStatusIP` has written newer IP statistics. `patchSubnetStatus` previously sent the entire stale status, overwriting the available and used IP counts and ranges. Pods then failed allocation with `NoAvailableAddress`.

This change:

- limits general subnet status patches to fields owned by route and subnet reconciliation;
- limits DHCP option updates to DHCP status fields;
- keeps IP statistics exclusively owned by `calcSubnetStatusIP`;
- adds regression tests covering all eight IPv4 and IPv6 count/range fields
  and preserving newer DHCP option UUIDs during stale general status patches.

## Which issue(s) this PR fixes

None.

## Special notes for your reviewer

The failure was reproduced in the dual-stack underlay conformance case `create centralized subnet without enableEcmp`. The original failing job reported `NoAvailableAddress`; with this fix, the same case passed in 28.850 seconds and the suite completed with 104 passed, 0 failed.

Local validation passed for the controller package, targeted race tests, `go vet`,
and the package's 18 configured golangci-lint analyzers.

## Does this PR introduce a user-facing change?

```release-note
Fix stale subnet reconciliation overwriting current IP availability statistics.
```

## Additional documentation

None.
