### PR TITLE
feat: add gzip to container image for logrotate compression

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -244,7 +244,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt install ca-certificates netbase ethtool iproute2 ncat libunbound8 \
         kmod iptables python3-netifaces python3-sortedcontainers tcpdump ipvsadm ipset curl \
         uuid-runtime openssl inetutils-ping arping ndisc6 conntrack traceroute iputils-tracepath \
-        logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
+        gzip logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
         libcharon-extauth-plugins libstrongswan-extra-plugins libstrongswan-standard-plugins \
         -y --no-install-recommends --auto-remove && \
     apt remove -y --allow-remove-essential --auto-remove login && \

--- a/dist/images/Dockerfile.base-dpdk
+++ b/dist/images/Dockerfile.base-dpdk
@@ -117,7 +117,7 @@ ARG PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt update && apt upgrade -y && apt install ca-certificates python3 libunwind8 netbase \
         ethtool iproute2 ncat libunbound8 libatomic1 kmod iptables python3-netifaces python3-sortedcontainers \
         tcpdump ipvsadm ipset curl uuid-runtime openssl inetutils-ping arping ndisc6 conntrack iputils-tracepath \
-        logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
+        gzip logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
         libcharon-extauth-plugins libstrongswan-extra-plugins libstrongswan-standard-plugins \
         python3-pip build-essential libssl-dev libibverbs-dev libnuma-dev libpcap-dev -y --no-install-recommends && \
         rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
# Pull Request

- [X] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

This is a simple feature addition and partly a bug fix -- I updated the Docker images to include gzip, so that logrotate works correctly with compression settings. Currently, logrotate in the container fails when gzip compression is enabled because gzip is not available.