### PR TITLE
fix: reconcile terminating OVN EIP/FIP/DNAT/SNAT from the add handler on restart

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -369,6 +369,21 @@ func enqueueUpdateIfTerminating(queue workqueue.TypedRateLimitingInterface[strin
 	return false
 }
 
+// enqueueUpdateIfTerminatingWithFinalizer behaves like enqueueUpdateIfTerminating but skips objects
+// whose finalizer has already been removed (their cleanup is done and they only await API server
+// deletion), mirroring the OVN enqueueUpdate* deletion branch to avoid a double delete. It returns
+// true when the object is terminating, so the add handler stops regardless of whether it enqueued.
+func enqueueUpdateIfTerminatingWithFinalizer(queue workqueue.TypedRateLimitingInterface[string], key, kind string, deletionTimestamp *metav1.Time, finalizers []string) bool {
+	if deletionTimestamp.IsZero() {
+		return false
+	}
+	if len(finalizers) != 0 {
+		klog.V(3).Infof("enqueue update to clean %s %s", kind, key)
+		queue.Add(key)
+	}
+	return true
+}
+
 // Run creates and runs a new ovn controller
 func Run(ctx context.Context, config *Configuration) {
 	klog.V(4).Info("Creating event broadcaster")

--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -21,7 +21,12 @@ import (
 )
 
 func (c *Controller) enqueueAddOvnDnatRule(obj any) {
-	key := cache.MetaObjectToName(obj.(*kubeovnv1.OvnDnatRule)).String()
+	dnat := obj.(*kubeovnv1.OvnDnatRule)
+	key := cache.MetaObjectToName(dnat).String()
+	// A terminating object reconciles via the update queue for cleanup (handleAdd skips it; resync=0).
+	if enqueueUpdateIfTerminatingWithFinalizer(c.updateOvnDnatRuleQueue, key, "ovn dnat", dnat.DeletionTimestamp, dnat.GetFinalizers()) {
+		return
+	}
 	klog.Infof("enqueue add ovn dnat %s", key)
 	c.addOvnDnatRuleQueue.Add(key)
 }
@@ -29,14 +34,7 @@ func (c *Controller) enqueueAddOvnDnatRule(obj any) {
 func (c *Controller) enqueueUpdateOvnDnatRule(oldObj, newObj any) {
 	newDnat := newObj.(*kubeovnv1.OvnDnatRule)
 	key := cache.MetaObjectToName(newDnat).String()
-	if !newDnat.DeletionTimestamp.IsZero() {
-		if len(newDnat.GetFinalizers()) == 0 {
-			// avoid delete twice
-			return
-		}
-		// DNAT with finalizer should be handled in updateOvnDnatRuleQueue
-		klog.Infof("enqueue update (deleting) ovn dnat %s", key)
-		c.updateOvnDnatRuleQueue.Add(key)
+	if enqueueUpdateIfTerminatingWithFinalizer(c.updateOvnDnatRuleQueue, key, "ovn dnat", newDnat.DeletionTimestamp, newDnat.GetFinalizers()) {
 		return
 	}
 	oldDnat := oldObj.(*kubeovnv1.OvnDnatRule)

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -23,22 +23,19 @@ import (
 func (c *Controller) enqueueAddOvnEip(obj any) {
 	eip := obj.(*kubeovnv1.OvnEip)
 	key := cache.MetaObjectToName(eip).String()
+	c.requeueRouterLBRulesForEip(eip.Name, false)
+	// A terminating object reconciles via the update queue for cleanup (handleAdd skips it; resync=0).
+	if enqueueUpdateIfTerminatingWithFinalizer(c.updateOvnEipQueue, key, "ovn eip", eip.DeletionTimestamp, eip.GetFinalizers()) {
+		return
+	}
 	klog.Infof("enqueue add ovn eip %s", key)
 	c.addOvnEipQueue.Add(key)
-	c.requeueRouterLBRulesForEip(eip.Name, false)
 }
 
 func (c *Controller) enqueueUpdateOvnEip(oldObj, newObj any) {
 	newEip := newObj.(*kubeovnv1.OvnEip)
 	key := cache.MetaObjectToName(newEip).String()
-	if !newEip.DeletionTimestamp.IsZero() {
-		if len(newEip.GetFinalizers()) == 0 {
-			// avoid delete eip twice
-			return
-		}
-		// EIP with finalizer should be handled in updateOvnEipQueue
-		klog.Infof("enqueue update (deleting) ovn eip %s", key)
-		c.updateOvnEipQueue.Add(key)
+	if enqueueUpdateIfTerminatingWithFinalizer(c.updateOvnEipQueue, key, "ovn eip", newEip.DeletionTimestamp, newEip.GetFinalizers()) {
 		return
 	}
 	oldEip := oldObj.(*kubeovnv1.OvnEip)

--- a/pkg/controller/ovn_eip_test.go
+++ b/pkg/controller/ovn_eip_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -96,4 +97,127 @@ func Test_getOvnEipNat(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, nat)
 	})
+}
+
+// assertEnqueueAddRoutingWithFinalizer checks the OVN add-path routing: a live object goes to the
+// add queue, a terminating object with a finalizer goes to the update queue (deletion cleanup), and
+// a terminating object whose finalizer is already gone is skipped (cleanup done, awaiting deletion).
+func assertEnqueueAddRoutingWithFinalizer(
+	t *testing.T,
+	addQueue, updateQueue workqueue.TypedRateLimitingInterface[string],
+	enqueue func(any),
+	live, terminatingWithFinalizer, terminatingNoFinalizer any,
+) {
+	t.Helper()
+	enqueue(live)
+	require.Equal(t, 1, addQueue.Len(), "live object should go to the add queue")
+	require.Equal(t, 0, updateQueue.Len(), "live object must not go to the update queue")
+
+	enqueue(terminatingWithFinalizer)
+	require.Equal(t, 1, addQueue.Len(), "terminating object must not go to the add queue")
+	require.Equal(t, 1, updateQueue.Len(), "terminating object with finalizer should go to the update queue")
+
+	enqueue(terminatingNoFinalizer)
+	require.Equal(t, 1, addQueue.Len(), "terminating object without finalizer must not go to the add queue")
+	require.Equal(t, 1, updateQueue.Len(), "terminating object without finalizer must not be re-enqueued")
+}
+
+func TestEnqueueAddOvnEip(t *testing.T) {
+	t.Parallel()
+	c := &Controller{
+		config:            &Configuration{},
+		addOvnEipQueue:    newTypedRateLimitingQueue[string]("AddOvnEip", nil),
+		updateOvnEipQueue: newTypedRateLimitingQueue[string]("UpdateOvnEip", nil),
+	}
+	t.Cleanup(c.addOvnEipQueue.ShutDown)
+	t.Cleanup(c.updateOvnEipQueue.ShutDown)
+	now := metav1.Now()
+	fin := []string{util.KubeOVNControllerFinalizer}
+	assertEnqueueAddRoutingWithFinalizer(t, c.addOvnEipQueue, c.updateOvnEipQueue, c.enqueueAddOvnEip,
+		&kubeovnv1.OvnEip{ObjectMeta: metav1.ObjectMeta{Name: "live-eip"}},
+		&kubeovnv1.OvnEip{ObjectMeta: metav1.ObjectMeta{Name: "terminating-eip", DeletionTimestamp: &now, Finalizers: fin}},
+		&kubeovnv1.OvnEip{ObjectMeta: metav1.ObjectMeta{Name: "terminating-eip-no-finalizer", DeletionTimestamp: &now}},
+	)
+}
+
+func TestEnqueueAddOvnFip(t *testing.T) {
+	t.Parallel()
+	c := &Controller{
+		addOvnFipQueue:    newTypedRateLimitingQueue[string]("AddOvnFip", nil),
+		updateOvnFipQueue: newTypedRateLimitingQueue[string]("UpdateOvnFip", nil),
+	}
+	t.Cleanup(c.addOvnFipQueue.ShutDown)
+	t.Cleanup(c.updateOvnFipQueue.ShutDown)
+	now := metav1.Now()
+	fin := []string{util.KubeOVNControllerFinalizer}
+	assertEnqueueAddRoutingWithFinalizer(t, c.addOvnFipQueue, c.updateOvnFipQueue, c.enqueueAddOvnFip,
+		&kubeovnv1.OvnFip{ObjectMeta: metav1.ObjectMeta{Name: "live-fip"}},
+		&kubeovnv1.OvnFip{ObjectMeta: metav1.ObjectMeta{Name: "terminating-fip", DeletionTimestamp: &now, Finalizers: fin}},
+		&kubeovnv1.OvnFip{ObjectMeta: metav1.ObjectMeta{Name: "terminating-fip-no-finalizer", DeletionTimestamp: &now}},
+	)
+}
+
+func TestEnqueueAddOvnDnatRule(t *testing.T) {
+	t.Parallel()
+	c := &Controller{
+		addOvnDnatRuleQueue:    newTypedRateLimitingQueue[string]("AddOvnDnat", nil),
+		updateOvnDnatRuleQueue: newTypedRateLimitingQueue[string]("UpdateOvnDnat", nil),
+	}
+	t.Cleanup(c.addOvnDnatRuleQueue.ShutDown)
+	t.Cleanup(c.updateOvnDnatRuleQueue.ShutDown)
+	now := metav1.Now()
+	fin := []string{util.KubeOVNControllerFinalizer}
+	assertEnqueueAddRoutingWithFinalizer(t, c.addOvnDnatRuleQueue, c.updateOvnDnatRuleQueue, c.enqueueAddOvnDnatRule,
+		&kubeovnv1.OvnDnatRule{ObjectMeta: metav1.ObjectMeta{Name: "live-dnat"}},
+		&kubeovnv1.OvnDnatRule{ObjectMeta: metav1.ObjectMeta{Name: "terminating-dnat", DeletionTimestamp: &now, Finalizers: fin}},
+		&kubeovnv1.OvnDnatRule{ObjectMeta: metav1.ObjectMeta{Name: "terminating-dnat-no-finalizer", DeletionTimestamp: &now}},
+	)
+}
+
+func TestEnqueueAddOvnSnatRule(t *testing.T) {
+	t.Parallel()
+	c := &Controller{
+		addOvnSnatRuleQueue:    newTypedRateLimitingQueue[string]("AddOvnSnat", nil),
+		updateOvnSnatRuleQueue: newTypedRateLimitingQueue[string]("UpdateOvnSnat", nil),
+	}
+	t.Cleanup(c.addOvnSnatRuleQueue.ShutDown)
+	t.Cleanup(c.updateOvnSnatRuleQueue.ShutDown)
+	now := metav1.Now()
+	fin := []string{util.KubeOVNControllerFinalizer}
+	assertEnqueueAddRoutingWithFinalizer(t, c.addOvnSnatRuleQueue, c.updateOvnSnatRuleQueue, c.enqueueAddOvnSnatRule,
+		&kubeovnv1.OvnSnatRule{ObjectMeta: metav1.ObjectMeta{Name: "live-snat"}},
+		&kubeovnv1.OvnSnatRule{ObjectMeta: metav1.ObjectMeta{Name: "terminating-snat", DeletionTimestamp: &now, Finalizers: fin}},
+		&kubeovnv1.OvnSnatRule{ObjectMeta: metav1.ObjectMeta{Name: "terminating-snat-no-finalizer", DeletionTimestamp: &now}},
+	)
+}
+
+// TestEnqueueAddOvnEipRequeuesRouterLBRules verifies that enqueueAddOvnEip re-queues an EIP's
+// RouterLBRules even when the EIP is terminating (the side effect must run before the terminating
+// route returns, so LB rules react to the EIP going away).
+func TestEnqueueAddOvnEipRequeuesRouterLBRules(t *testing.T) {
+	t.Parallel()
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		RouterLBRules: []*kubeovnv1.RouterLBRule{{
+			ObjectMeta: metav1.ObjectMeta{Name: "rlr1"},
+			Spec:       kubeovnv1.RouterLBRuleSpec{OvnEip: "eip1"},
+		}},
+	})
+	require.NoError(t, err)
+	c := fc.fakeController
+	c.config.EnableLb = true
+	c.addRouterLBRuleQueue = newTypedRateLimitingQueue[string]("AddRouterLBRule", nil)
+	c.addOvnEipQueue = newTypedRateLimitingQueue[string]("AddOvnEip", nil)
+	c.updateOvnEipQueue = newTypedRateLimitingQueue[string]("UpdateOvnEip", nil)
+	t.Cleanup(c.addRouterLBRuleQueue.ShutDown)
+	t.Cleanup(c.addOvnEipQueue.ShutDown)
+	t.Cleanup(c.updateOvnEipQueue.ShutDown)
+
+	now := metav1.Now()
+	c.enqueueAddOvnEip(&kubeovnv1.OvnEip{
+		ObjectMeta: metav1.ObjectMeta{Name: "eip1", DeletionTimestamp: &now, Finalizers: []string{util.KubeOVNControllerFinalizer}},
+	})
+
+	require.Equal(t, 1, c.updateOvnEipQueue.Len(), "terminating eip with finalizer goes to the update queue")
+	require.Equal(t, 0, c.addOvnEipQueue.Len(), "terminating eip must not go to the add queue")
+	require.Equal(t, 1, c.addRouterLBRuleQueue.Len(), "router lb rules must be re-queued even for a terminating eip")
 }

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -22,7 +22,12 @@ import (
 )
 
 func (c *Controller) enqueueAddOvnFip(obj any) {
-	key := cache.MetaObjectToName(obj.(*kubeovnv1.OvnFip)).String()
+	fip := obj.(*kubeovnv1.OvnFip)
+	key := cache.MetaObjectToName(fip).String()
+	// A terminating object reconciles via the update queue for cleanup (handleAdd skips it; resync=0).
+	if enqueueUpdateIfTerminatingWithFinalizer(c.updateOvnFipQueue, key, "ovn fip", fip.DeletionTimestamp, fip.GetFinalizers()) {
+		return
+	}
 	klog.Infof("enqueue add ovn fip %s", key)
 	c.addOvnFipQueue.Add(key)
 }
@@ -30,14 +35,7 @@ func (c *Controller) enqueueAddOvnFip(obj any) {
 func (c *Controller) enqueueUpdateOvnFip(oldObj, newObj any) {
 	newFip := newObj.(*kubeovnv1.OvnFip)
 	key := cache.MetaObjectToName(newFip).String()
-	if !newFip.DeletionTimestamp.IsZero() {
-		if len(newFip.GetFinalizers()) == 0 {
-			// avoid delete twice
-			return
-		}
-		// FIP with finalizer should be handled in updateOvnFipQueue
-		klog.Infof("enqueue update (deleting) ovn fip %s", key)
-		c.updateOvnFipQueue.Add(key)
+	if enqueueUpdateIfTerminatingWithFinalizer(c.updateOvnFipQueue, key, "ovn fip", newFip.DeletionTimestamp, newFip.GetFinalizers()) {
 		return
 	}
 	oldFip := oldObj.(*kubeovnv1.OvnFip)

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -20,7 +20,12 @@ import (
 )
 
 func (c *Controller) enqueueAddOvnSnatRule(obj any) {
-	key := cache.MetaObjectToName(obj.(*kubeovnv1.OvnSnatRule)).String()
+	snat := obj.(*kubeovnv1.OvnSnatRule)
+	key := cache.MetaObjectToName(snat).String()
+	// A terminating object reconciles via the update queue for cleanup (handleAdd skips it; resync=0).
+	if enqueueUpdateIfTerminatingWithFinalizer(c.updateOvnSnatRuleQueue, key, "ovn snat", snat.DeletionTimestamp, snat.GetFinalizers()) {
+		return
+	}
 	klog.Infof("enqueue add ovn snat %s", key)
 	c.addOvnSnatRuleQueue.Add(key)
 }
@@ -28,14 +33,7 @@ func (c *Controller) enqueueAddOvnSnatRule(obj any) {
 func (c *Controller) enqueueUpdateOvnSnatRule(oldObj, newObj any) {
 	newSnat := newObj.(*kubeovnv1.OvnSnatRule)
 	key := cache.MetaObjectToName(newSnat).String()
-	if !newSnat.DeletionTimestamp.IsZero() {
-		if len(newSnat.GetFinalizers()) == 0 {
-			// avoid delete twice
-			return
-		}
-		// SNAT with finalizer should be handled in updateOvnSnatRuleQueue
-		klog.Infof("enqueue update (deleting) ovn snat %s", key)
-		c.updateOvnSnatRuleQueue.Add(key)
+	if enqueueUpdateIfTerminatingWithFinalizer(c.updateOvnSnatRuleQueue, key, "ovn snat", newSnat.DeletionTimestamp, newSnat.GetFinalizers()) {
 		return
 	}
 	oldSnat := oldObj.(*kubeovnv1.OvnSnatRule)


### PR DESCRIPTION


OVN EIP/FIP/DNAT/SNAT deletion cleanup only runs in handleUpdateOvn*. On restart the informer re-lists existing objects and fires only AddFunc; with resync=0 a terminating object lands in the add queue, hits the already-ok short-circuit and never removes its finalizer. Route terminating objects to the update queue via a new enqueueUpdateIfTerminatingWithFinalizer helper that mirrors the OVN update handlers: terminating objects without a finalizer are skipped (cleanup done, awaiting apiserver deletion) to avoid a double delete. enqueueAddOvnEip keeps its requeueRouterLBRulesForEip side effect regardless.

test: verify OVN enqueue-add routing for terminating objects

Cover live->add, terminating+finalizer->update, terminating-without-finalizer->skip for OvnEip/OvnFip/OvnDnatRule/OvnSnatRule via a shared assertEnqueueAddRoutingWithFinalizer.

refactor: reuse terminating-route helper in OVN update handlers

The four enqueueUpdateOvn* deletion branches duplicated the terminating->update-queue logic now provided by enqueueUpdateIfTerminatingWithFinalizer. Reuse the helper to remove the duplication; the enqueue log unifies to V(3) "enqueue update to clean".

test: cover router LB rule requeue for a terminating OVN eip

enqueueAddOvnEip must still requeue an EIP's RouterLBRules when the EIP is terminating; the side effect runs before the terminating route returns.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
