### PR TITLE
fix(e2e): run KubeVirt tests serially

### DIFF
--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -291,7 +291,7 @@ kube-ovn-kubevirt-e2e:
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
 	KUBEVIRT_CONTAINERDISK_IMAGE=$(KUBEVIRT_CONTAINERDISK_IMAGE) \
-	$(GINKGO_E2E_RUN_PARALLEL) --focus=CNI:Kube-OVN ./test/e2e/kubevirt/kubevirt.test -- $(TEST_BIN_ARGS)
+	$(GINKGO_E2E_RUN) --focus=CNI:Kube-OVN ./test/e2e/kubevirt/kubevirt.test -- $(TEST_BIN_ARGS)
 
 .PHONY: kube-ovn-webhook-e2e
 kube-ovn-webhook-e2e:


### PR DESCRIPTION
## Summary

- run the KubeVirt E2E suite serially instead of inheriting the global `nproc * 2` process count
- avoid starting all software-emulated VMs at once on GitHub-hosted runners
- keep the existing VM readiness timeouts unchanged

## Root cause

The KubeVirt KIND installation enables `useEmulation: true`, but the E2E target used the global parallel Ginkgo runner. On a 4-vCPU GitHub-hosted runner, all seven specs started software-emulated QEMU VMs concurrently. In [job 94308035025](https://github.com/kubeovn/kube-ovn/actions/runs/31653986452/job/94308035025), six VMs became ready while one launcher Pod was Running and network-ready but its VMI remained `Scheduled` / `GuestNotRunning` for the full 120-second timeout. Kube-OVN configured that Pod network successfully before the timeout.

Running this small suite serially removes the QEMU startup contention instead of masking a stuck domain with a longer timeout.

## Test plan

- [x] Verify the KubeVirt recipe does not use `GINKGO_E2E_RUN_PARALLEL`
- [x] Verify `CI=true make -n kube-ovn-kubevirt-e2e` emits no `--procs` option
- [x] Build `./test/e2e/kubevirt` under a 2 GiB memory limit
- [x] Run `git diff --check`
- [x] Pass the KubeVirt E2E matrix in GitHub Actions ([ipv6, underlay job 94328958420](https://github.com/kubeovn/kube-ovn/actions/runs/31661507066/job/94328958420): 7/7 passed serially)

Signed-off-by: zhangzujian <zhangzujian.7@gmail.com>