### PR TITLE
Add support for multiple external subnets per vpc nat gw

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -33,6 +33,9 @@
 #
 # ============================================================================
 
+#file for eip to external interface mapping
+EIP_INTERFACE_MAP="/run/kube-ovn/eip-interface-map"
+
 # Read interfaces from persistent file
 if [ -f /etc/kube-ovn/nat-gateway.env ]; then
     # shellcheck disable=SC1091
@@ -40,7 +43,10 @@ if [ -f /etc/kube-ovn/nat-gateway.env ]; then
 fi
 # Default interfaces
 VPC_INTERFACE=${VPC_INTERFACE:-"eth0"}
-EXTERNAL_INTERFACE=${EXTERNAL_INTERFACE:-"net1"}
+# Comma-separated external interfaces. The first one is kept as the
+# backward-compatible EXTERNAL_INTERFACE alias.
+EXTERNAL_INTERFACES=${EXTERNAL_INTERFACES:-${EXTERNAL_INTERFACE:-"net1"}}
+EXTERNAL_INTERFACE=$(echo "$EXTERNAL_INTERFACES" | cut -d',' -f1)
 # Debug mode: set to "true" to enable verbose QoS debugging output
 # In production, leave this as "false" to reduce log volume
 QOS_DEBUG=${QOS_DEBUG:-"false"}
@@ -58,7 +64,8 @@ function show_help() {
     echo ""
     echo "Environment Variables:"
     echo "  VPC_INTERFACE       - Interface connecting to VPC (default: eth0)"
-    echo "  EXTERNAL_INTERFACE  - Interface connecting to external network (default: net1)"
+    echo "  EXTERNAL_INTERFACES - Comma-separated external interfaces (default: net1)"
+    echo "  EXTERNAL_INTERFACE  - Backward-compatible alias for the first external interface"
     echo "  QOS_DEBUG           - Enable verbose QoS debugging output (default: false)"
     echo ""
     echo "Usage: $0 [COMMAND] [ARGS...]"
@@ -86,8 +93,9 @@ function show_help() {
     echo "  get-iptables-version     - Show iptables version"
     echo ""
     echo "Examples:"
-    echo "  # Use custom interfaces"
-    echo "  $0 init net1, net2"
+    echo "  # Use one internal/VPC interface and one or more external interfaces"
+    echo "  $0 init net1,net2"
+    echo "  $0 init net1,net2,net3"
     echo ""
     echo "  # Use default interfaces (eth0,net1)"
     echo "  $0 init"
@@ -114,42 +122,71 @@ function check_inited() {
     fi
 }
 
+function init_eip_interface_map() {
+    mkdir -p "$(dirname "$EIP_INTERFACE_MAP")"
+
+    # Start with an empty mapping file
+    : > "$EIP_INTERFACE_MAP"
+
+    echo "Initialized EIP interface mapping: $EIP_INTERFACE_MAP"
+}
+
 function init() {
     interfaces=$1
     echo "init $interfaces"
     if [ -n "$interfaces" ]; then
-        # First, remove all spaces around commas
+        # First interface is the VPC/tenant interface.
+        # All remaining interfaces are external interfaces.
         interfaces=$(echo "$interfaces" | sed 's/[[:space:]]*,[[:space:]]*/,/g')
         IFS=',' read -r -a interface_array <<< "$interfaces"
-        if [ ${#interface_array[@]} -ne 2 ]; then
-            >&2 echo "Error: Expected two interfaces separated by a comma (e.g., net1,net2)"
+
+        if [ ${#interface_array[@]} -lt 2 ]; then
+            >&2 echo "Error: Expected at least two interfaces: VPC interface followed by one or more external interfaces (e.g., net1,net2,net3)"
             exit 1
         fi
 
-        # Trim any remaining leading and trailing whitespace
         VPC_INTERFACE=$(echo "${interface_array[0]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        EXTERNAL_INTERFACE=$(echo "${interface_array[1]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        EXTERNAL_INTERFACES=""
+        for ((i=1; i<${#interface_array[@]}; i++)); do
+            ext=$(echo "${interface_array[$i]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            if [ -z "$ext" ]; then
+                >&2 echo "Error: External interface names cannot be empty"
+                exit 1
+            fi
+            if [ -z "$EXTERNAL_INTERFACES" ]; then
+                EXTERNAL_INTERFACES="$ext"
+            else
+                EXTERNAL_INTERFACES="$EXTERNAL_INTERFACES,$ext"
+            fi
+        done
+        EXTERNAL_INTERFACE=$(echo "$EXTERNAL_INTERFACES" | cut -d',' -f1)
 
-        # Validate interface names are not empty after trimming
-        if [ -z "$VPC_INTERFACE" ] || [ -z "$EXTERNAL_INTERFACE" ]; then
+        if [ -z "$VPC_INTERFACE" ] || [ -z "$EXTERNAL_INTERFACES" ]; then
             >&2 echo "Error: Interface names cannot be empty"
             exit 1
         fi
     fi
+
     echo "using VPC interface: $VPC_INTERFACE"
-    echo "using External interface: $EXTERNAL_INTERFACE"
-    # check if interfaces exist
+    echo "using External interfaces: $EXTERNAL_INTERFACES"
+
     if ! ip link show "$VPC_INTERFACE" >/dev/null 2>&1; then
         >&2 echo "Error: VPC interface '$VPC_INTERFACE' not found"
         exit 1
     fi
-    if ! ip link show "$EXTERNAL_INTERFACE" >/dev/null 2>&1; then
-        >&2 echo "Error: External interface '$EXTERNAL_INTERFACE' not found"
-        exit 1
-    fi
-    # Store interfaces persistently
+
+    IFS=',' read -r -a external_interface_array <<< "$EXTERNAL_INTERFACES"
+    for ext in "${external_interface_array[@]}"; do
+        if ! ip link show "$ext" >/dev/null 2>&1; then
+            >&2 echo "Error: External interface '$ext' not found"
+            exit 1
+        fi
+    done
+
+    # Store interfaces persistently.
     mkdir -p /etc/kube-ovn
     echo "VPC_INTERFACE=$VPC_INTERFACE" > /etc/kube-ovn/nat-gateway.env
+    echo "EXTERNAL_INTERFACES=$EXTERNAL_INTERFACES" >> /etc/kube-ovn/nat-gateway.env
     echo "EXTERNAL_INTERFACE=$EXTERNAL_INTERFACE" >> /etc/kube-ovn/nat-gateway.env
 
     # run once is enough
@@ -180,11 +217,8 @@ function init() {
     $iptables_cmd -t mangle -A VPC_MARK -i "$VPC_INTERFACE" -j MARK --set-xmark 0x1/0x1
 
     # Load IFB kernel module for ingress QoS traffic shaping
-    # IFB (Intermediate Functional Block) is required for ingress rate limiting using HTB
-    # Load it early in init to detect any issues before QoS rules are applied
     echo "Loading IFB kernel module for ingress QoS support..."
     if ! modprobe ifb 2>/dev/null; then
-        # Check if IFB module is already loaded
         if lsmod | grep -q "^ifb "; then
             echo "IFB kernel module already loaded"
         else
@@ -196,17 +230,21 @@ function init() {
         echo "IFB kernel module loaded successfully"
     fi
 
-    # Send gratuitous ARP for all the IPs on the external network interface at initialization
-    # This is especially useful to update the MAC of the nexthop we announce to the BGP speaker
-    # Only send ARP if there are IP addresses on the external interface (skip in no-IPAM mode)
-    external_ips=$(ip -4 addr show dev $EXTERNAL_INTERFACE | awk '/inet /{print $2}' | cut -d/ -f1)
-    if [ -n "$external_ips" ]; then
-        echo "Sending gratuitous ARP for external IPs on $EXTERNAL_INTERFACE"
-        echo "$external_ips" | xargs -n1 arping -I $EXTERNAL_INTERFACE -c 3 -U
-        echo "Gratuitous ARP completed"
-    else
-        echo "INFO: No IP addresses on $EXTERNAL_INTERFACE, skipping gratuitous ARP (no-IPAM mode or waiting for EIP allocation)"
-    fi
+    # Send gratuitous ARP on every external interface.
+    IFS=',' read -r -a external_interface_array <<< "$EXTERNAL_INTERFACES"
+    for ext in "${external_interface_array[@]}"; do
+        external_ips=$(ip -4 addr show dev "$ext" | awk '/inet /{print $2}' | cut -d/ -f1)
+        if [ -n "$external_ips" ]; then
+            echo "Sending gratuitous ARP for external IPs on $ext"
+            echo "$external_ips" | xargs -n1 arping -I "$ext" -c 3 -U
+            echo "Gratuitous ARP completed on $ext"
+        else
+            echo "INFO: No IP addresses on $ext, skipping gratuitous ARP (no-IPAM mode or waiting for EIP allocation)"
+        fi
+    done
+
+    #create a file foe storing EIP to external interface mapping
+    init_eip_interface_map
 }
 
 
@@ -239,53 +277,100 @@ function del_vpc_internal_route() {
     done
 }
 
-function del_vpc_external_route() {
-    # make sure inited
-    check_inited
-    # never do this, if deleted, will cause error
+get_external_interface_for_eip() {
+    local eip="$1"
 
-    # for rule in $@
-    # do
-    #     arr=(${rule//,/ })
-    #     cidr=${arr[0]}
-    #     exec_cmd "ip route del $cidr dev $EXTERNAL_INTERFACE"
-    #     sleep 1
-    #     exec_cmd "ip route del default dev $EXTERNAL_INTERFACE"
-    # done
+    if [[ ! -f "$EIP_INTERFACE_MAP" ]]; then
+        echo "Error: EIP interface mapping file does not exist: $EIP_INTERFACE_MAP" >&2
+        return 1
+    fi
+
+    local interface
+    interface=$(awk -v eip="$eip" '$1 == eip {print $2; exit}' "$EIP_INTERFACE_MAP")
+
+    if [[ -n "$interface" ]]; then
+        echo "$interface"
+        return 0
+    fi
+
+    echo "Error: No external interface mapping found for EIP '$eip'" >&2
+    return 1
+}
+
+# Resolve an EIP to its external interface.
+#
+# An interface can be supplied explicitly as the second comma-separated field:
+#   eip-add 10.20.30.40/24
+#
+# The script uses the connected route
+# from EIP to determine the correct interface.
+
+function get_external_interface_for_ip() {
+    local ip=$1
+    local route_output
+    local external_interface
+
+    route_output=$(ip route get "$ip" 2>&1)
+    local route_status=$?
+
+    if [ $route_status -ne 0 ]; then
+        >&2 echo "Error: Could not determine route for EIP '$ip'"
+        return 1
+    fi
+
+    external_interface=$(echo "$route_output" | awk '
+        {
+            for (i = 1; i < NF; i++) {
+                if ($i == "dev") {
+                    print $(i + 1)
+                    exit
+                }
+            }
+        }
+    ')
+
+    if [ -z "$external_interface" ]; then
+        >&2 echo "Error: Could not determine external interface for EIP '$ip'"
+        >&2 echo "Route output: $route_output"
+        return 1
+    fi
+
+    echo "$external_interface"
+    return 0
 }
 
 function add_eip() {
     # make sure inited
     check_inited
-    for rule in $@
+    for rule in "$@"
     do
-        eip=${rule}
+        arr=(${rule//,/ })
+        eip=${arr[0]}
         eip_without_prefix=(${eip//\// })
-        exec_cmd "ip addr replace $eip dev $EXTERNAL_INTERFACE"
-        exec_cmd "arping -I $EXTERNAL_INTERFACE -c 3 -U $eip_without_prefix"
 
-        # Add hairpin SNAT rule for this EIP
-        # This rule SNATs traffic originating from the VPC and targeting an EIP back to the same EIP
-        # when it is DNAT'd and routed back to the VPC. This avoids asymmetric routing issues.
+        ext=$(get_external_interface_for_ip "$eip_without_prefix") || exit 1
+
+        if [[ ! -f "$EIP_INTERFACE_MAP" ]]; then
+            echo "Error: EIP interface mapping file does not exist. Run init first." >&2
+            return 1
+        fi
+
+        # Remove existing mapping
+        sed -i "\|^${eip_without_prefix}[[:space:]]|d" "$EIP_INTERFACE_MAP" 2>/dev/null || true
+
+        # Store EIP -> interface
+        echo "$eip_without_prefix $ext" >> "$EIP_INTERFACE_MAP"
+
+        echo "Adding EIP $eip on external interface $ext"
+
+        exec_cmd "ip addr replace $eip dev $ext"
+
+        # Add hairpin SNAT rule for this EIP.
         local hairpin_rule="-m mark --mark 0x1/0x1 -o $VPC_INTERFACE -m conntrack --ctstate DNAT --ctorigdst $eip_without_prefix -j SNAT --to-source $eip_without_prefix"
-        # Check if the rule already exists to maintain idempotency
         if ! $iptables_cmd -t nat -C HAIRPIN_SNAT $hairpin_rule --random-fully >/dev/null 2>&1; then
             exec_cmd "$iptables_cmd -t nat -A HAIRPIN_SNAT $hairpin_rule --random-fully"
         fi
     done
-
-    # Use "onlink" to skip the kernel's "gateway must be directly reachable" check.
-    # This allows EIPs from a different external subnet to share the NAT gateway's
-    # default route, as long as the gateway is L2-reachable (same VLAN/broadcast domain).
-    # When the gateway IS on the same subnet, "onlink" has no behavioral difference
-    # from the non-onlink form — the forwarding path and ARP resolution are identical.
-    if [ -n "$GATEWAY_V4" ]; then
-        exec_cmd "ip route replace default via $GATEWAY_V4 dev $EXTERNAL_INTERFACE onlink"
-    fi
-
-    if [ -n "$GATEWAY_V6" ]; then
-        exec_cmd "ip -6 route replace default via $GATEWAY_V6 dev $EXTERNAL_INTERFACE onlink"
-    fi
 }
 
 function del_eip() {
@@ -296,17 +381,25 @@ function del_eip() {
         arr=(${rule//,/ })
         eip=${arr[0]}
         eip_without_prefix=(${eip//\// })
-        ipCidr=`ip addr show "$EXTERNAL_INTERFACE" | grep -w "$eip" | awk '{print $2 }'`
+
+        ext=$(get_external_interface_for_eip "$eip_without_prefix") || continue
+        ipCidr=$(ip addr show "$ext" | grep -w "$eip" | awk '{print $2 }')
         if [ -n "$ipCidr" ]; then
-            exec_cmd "ip addr del $ipCidr dev $EXTERNAL_INTERFACE"
+            exec_cmd "ip addr del $ipCidr dev $ext"
         fi
 
-        # Remove hairpin SNAT rule for this EIP
+        # Remove hairpin SNAT rule for this EIP.
         local hairpin_rule="-m mark --mark 0x1/0x1 -o $VPC_INTERFACE -m conntrack --ctstate DNAT --ctorigdst $eip_without_prefix -j SNAT --to-source $eip_without_prefix"
-        # Check if the rule exists before attempting to delete it
         if $iptables_cmd -t nat -C HAIRPIN_SNAT $hairpin_rule --random-fully >/dev/null 2>&1; then
             exec_cmd "$iptables_cmd -t nat -D HAIRPIN_SNAT $hairpin_rule --random-fully"
         fi
+
+        if [[ ! -f "$EIP_INTERFACE_MAP" ]]; then
+            echo "Warning: EIP interface mapping file does not exist: $EIP_INTERFACE_MAP" >&2
+            return 0
+        fi
+
+        sed -i "\|^${eip_without_prefix}[[:space:]]|d" "$EIP_INTERFACE_MAP"
     done
 }
 
@@ -405,6 +498,7 @@ function add_snat() {
         eip=(${arr[0]//\// })
         internalCIDR=${arr[1]}
         randomFullyOption=${arr[2]}
+	ext=$(get_external_interface_for_eip "$eip") || exit 1
         # check if exact (eip, internalCIDR) pair already exists (idempotent)
         ruleMatch=$(echo "$all_shared_snat_rules" | grep -w -- "-s $internalCIDR" | grep -E -- "--to-source $eip(\$| )")
         if [ -n "$ruleMatch" ]; then
@@ -428,17 +522,24 @@ function add_snat() {
             }
             END { print n + 1 }
         ')
-        exec_cmd "$iptables_cmd -t nat -I SHARED_SNAT $pos -o $EXTERNAL_INTERFACE -s $internalCIDR -j SNAT --to-source $eip $randomFullyOption"
+        exec_cmd "$iptables_cmd -t nat -I SHARED_SNAT $pos -o $ext -s $internalCIDR -j SNAT --to-source $eip $randomFullyOption"
         # Keep the local snapshot in sync so subsequent iterations in this
         # invocation compute position correctly.
         all_shared_snat_rules="$all_shared_snat_rules
--A SHARED_SNAT -o $EXTERNAL_INTERFACE -s $internalCIDR -j SNAT --to-source $eip $randomFullyOption"
+-A SHARED_SNAT -o $ext -s $internalCIDR -j SNAT --to-source $eip $randomFullyOption"
     done
 }
 function del_snat() {
     # NOTE: Current SNAT CRD/controller path sends one rule per invocation.
     # The for-loop is currently of limited practical value.
     # TODO: Consider removing the for-loop and avoid cache optimizations driven only by loop batching.
+    #
+    # Ordering: iptables evaluates rules in a chain top-down (first-match wins).
+    # When multiple SHARED_SNAT rules have overlapping CIDRs (e.g., 10.0.0.0/16 and
+    # 10.0.1.0/24), the more specific rule must come first to honor longest-prefix
+    # match. We therefore insert each new rule at the position right after all
+    # existing rules whose prefix length is equal to or greater (more specific)
+    # than the new rule's prefix, yielding a descending-prefix order in the chain.
     # make sure inited
     check_inited
     local all_shared_snat_rules
@@ -1165,7 +1266,7 @@ function delete_ifb_filter_and_class() {
 
 # EIP-level ingress QoS using IFB + HTB (TCP-friendly, queues instead of drops)
 # Caller: controller via execNatGwRules(gwPod, natGwEipIngressQoSAdd, rules)
-# Flow: external --> $EXTERNAL_INTERFACE --> ingress redirect --> IFB --> HTB class --> internal
+# Flow: external --> selected external interface --> ingress redirect --> IFB --> HTB class --> internal
 #
 # Parameter count: 4 fields (comma-separated)
 # Format: "ip,priority,rate,burst"
@@ -1191,8 +1292,9 @@ function eip_ingress_qos_add() {
         local priority=${arr[1]} # 2
         local rate=${arr[2]}     # Mbit/s
         local burst=${arr[3]}    # MB
-        local dev="$EXTERNAL_INTERFACE"
         local matchDirection="dst"
+        local dev
+        dev=$(get_external_interface_for_ip "$v4ip") || exit 1
 
         qos_debug "Processing ingress QoS rule - v4ip=$v4ip, priority=$priority, rate=$rate, burst=$burst, dev=$dev"
 
@@ -1275,7 +1377,7 @@ function eip_ingress_qos_add() {
 #
 # Example: "172.21.0.23,2,25,25"
 #
-# Flow: internal --> $EXTERNAL_INTERFACE --> HTB class --> external
+# Flow: internal --> selected external interface --> HTB class --> external
 function eip_egress_qos_add() {
     qos_debug "eip_egress_qos_add called with args: $@"
     for rule in $@
@@ -1285,7 +1387,8 @@ function eip_egress_qos_add() {
         local priority=${arr[1]} # 2
         local rate=${arr[2]}     # Mbit/s
         local burst=${arr[3]}    # MB
-        local dev="$EXTERNAL_INTERFACE"
+        local dev
+        dev=$(get_external_interface_for_ip "$v4ip") || exit 1
 
         qos_debug "Processing egress QoS rule - v4ip=$v4ip, priority=$priority, rate=$rate, burst=$burst, dev=$dev"
 
@@ -1679,7 +1782,8 @@ function eip_ingress_qos_del() {
         arr=(${rule//,/ })
         local v4ip=${arr[0]}  # 172.21.0.23
         local matchDirection="dst"
-        local dev="$EXTERNAL_INTERFACE"
+        local dev
+        dev=$(get_external_interface_for_ip "$v4ip") || continue
         local ifb_dev
         ifb_dev=$(get_ifb_device "$dev")
 
@@ -1722,7 +1826,8 @@ function eip_egress_qos_del() {
     do
         arr=(${rule//,/ })
         local v4ip=${arr[0]}  # 172.21.0.23
-        local dev="$EXTERNAL_INTERFACE"
+        local dev
+        dev=$(get_external_interface_for_ip "$v4ip") || continue
 
         # Ensure HTB root qdisc exists before trying to delete
         if ! tc qdisc show dev "$dev" | grep -q "htb 1:"; then

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -515,18 +515,30 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 		var interfaces []string
 		if c.config.EnableNonPrimaryCNI {
 			// extract external nad interface name
-			externalNadNs, externalNadName, nadErr := c.getExternalSubnetNad(gw)
+			externalNads, nadErr := c.getExternalSubnetNads(gw)
 			if nadErr != nil {
 				klog.Errorf("failed to get external subnet NAD for gateway %s: %v", gw.Name, nadErr)
 				return nadErr
 			}
 			networkStatusAnnotations := pod.Annotations[nadv1.NetworkStatusAnnot]
-			externalNadFullName := fmt.Sprintf("%s/%s", externalNadNs, externalNadName)
-			externalNadIfName, err := util.GetNadInterfaceFromNetworkStatusAnnotation(networkStatusAnnotations, externalNadFullName)
-			if err != nil {
-				klog.Errorf("failed to extract external nad interface name from runtime Pod annotation network-status, %v", err)
-				return err
+
+			externalNadIfNames := make([]string, 0, len(externalNads))
+			for _, externalNad := range externalNads {
+				externalNadFullName := fmt.Sprintf("%s/%s", externalNad.Namespace, externalNad.Name)
+
+				externalNadIfName, err := util.GetNadInterfaceFromNetworkStatusAnnotation(
+					networkStatusAnnotations,
+					externalNadFullName,
+				)
+				if err != nil {
+					klog.Errorf("failed to extract external nad interface name from runtime Pod annotation network-status for %s, %v",
+						externalNadFullName, err)
+					return err
+				}
+
+				externalNadIfNames = append(externalNadIfNames, externalNadIfName)
 			}
+
 			// extract vpc nad interface name
 			providers, err := c.getPodProviders(pod)
 			if err != nil {
@@ -553,10 +565,19 @@ func (c *Controller) handleInitVpcNatGw(key string) error {
 				return err
 			}
 
-			klog.Infof("nat gw pod %s/%s internal nad interface %s, external nad interface %s", pod.Namespace, pod.Name, vpcNadIfName, externalNadIfName)
-			interfaces = []string{
-				strings.Join([]string{vpcNadIfName, externalNadIfName}, ","),
-			}
+			klog.Infof("nat gw pod %s/%s internal nad interface %s, external nad interfaces %s", pod.Namespace, pod.Name, vpcNadIfName, externalNadIfNames)
+			interfaces := make([]string, 0, len(externalNadIfNames)+1)
+			interfaces = append(interfaces, vpcNadIfName)
+			interfaces = append(interfaces, externalNadIfNames...)
+
+			interfacesArg := strings.Join(interfaces, ",")
+
+			klog.Infof(
+				"nat gw pod %s/%s interfaces %s",
+				pod.Namespace,
+				pod.Name,
+				interfacesArg,
+			)
 		}
 		if err = c.execNatGwRules(pod, natGwInit, interfaces); err != nil {
 			// Check if this is a transient initialization error (e.g., first attempt before iptables chains are created)
@@ -1160,7 +1181,7 @@ func (c *Controller) generateNatGwRoutes(
 }
 
 func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1.StatefulSet, natGwPodContainerRestartCount int32) (*v1.StatefulSet, error) {
-	externalNadNamespace, externalNadName, err := c.getExternalSubnetNad(gw)
+	externalNads, err := c.getExternalSubnetNads(gw)
 	if err != nil {
 		klog.Errorf("failed to get gw external subnet nad: %v", err)
 		return nil, err
@@ -1182,7 +1203,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 
 	// Generate StatefulSet Pod template annotations.
 	// User-defined annotations (gw.Spec.Annotations) are used as base, system annotations are set on top.
-	templateAnnotations, err := util.GenNatGwPodAnnotations(gw.Spec.Annotations, gw, externalNadNamespace, externalNadName, eth0SubnetProvider, additionalNetworks, c.config.EnableNonPrimaryCNI)
+	templateAnnotations, err := util.GenNatGwPodAnnotations(gw.Spec.Annotations, gw, externalNads, eth0SubnetProvider, additionalNetworks, c.config.EnableNonPrimaryCNI)
 	if err != nil {
 		klog.Errorf("vpc nat gateway annotation generation failed: %s", err.Error())
 		return nil, err
@@ -1211,8 +1232,10 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 		return nil, err
 	}
 
+	// Get only the first external subnet for default routes, as the NAT gateway can only have one default route
+	firstExtSubnet := util.GetNatGwExternalNetwork(gw.Spec.ExternalSubnets)[0]
 	// Get the external subnet for default routes
-	net1Subnet, err := c.subnetsLister.Get(util.GetNatGwExternalNetwork(gw.Spec.ExternalSubnets))
+	net1Subnet, err := c.subnetsLister.Get(firstExtSubnet)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -1337,7 +1360,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 // It reuses most of the logic from genNatGwStatefulSet but creates a Deployment instead.
 func (c *Controller) genNatGwDeployment(gw *kubeovnv1.VpcNatGateway) (*v1.Deployment, error) {
 	// Reuse all the annotation and routing logic from StatefulSet generation
-	externalNadNamespace, externalNadName, err := c.getExternalSubnetNad(gw)
+	externalNads, err := c.getExternalSubnetNads(gw)
 	if err != nil {
 		klog.Errorf("failed to get gw external subnet nad: %v", err)
 		return nil, err
@@ -1354,7 +1377,7 @@ func (c *Controller) genNatGwDeployment(gw *kubeovnv1.VpcNatGateway) (*v1.Deploy
 		additionalNetworks = gw.Annotations[nadv1.NetworkAttachmentAnnot]
 	}
 
-	templateAnnotations, err := util.GenNatGwPodAnnotations(gw.Spec.Annotations, gw, externalNadNamespace, externalNadName, eth0SubnetProvider, additionalNetworks, c.config.EnableNonPrimaryCNI)
+	templateAnnotations, err := util.GenNatGwPodAnnotations(gw.Spec.Annotations, gw, externalNads, eth0SubnetProvider, additionalNetworks, c.config.EnableNonPrimaryCNI)
 	if err != nil {
 		klog.Errorf("vpc nat gateway annotation generation failed: %s", err.Error())
 		return nil, err
@@ -1385,8 +1408,11 @@ func (c *Controller) genNatGwDeployment(gw *kubeovnv1.VpcNatGateway) (*v1.Deploy
 		return nil, err
 	}
 
+	// Get only the first external subnet for default routes, as the NAT gateway can only have one default route
+	firstExtSubnet := util.GetNatGwExternalNetwork(gw.Spec.ExternalSubnets)[0]
+
 	// Get the external subnet for default routes
-	net1Subnet, err := c.subnetsLister.Get(util.GetNatGwExternalNetwork(gw.Spec.ExternalSubnets))
+	net1Subnet, err := c.subnetsLister.Get(firstExtSubnet)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -1533,30 +1559,45 @@ func (c *Controller) genNatGwDeployment(gw *kubeovnv1.VpcNatGateway) (*v1.Deploy
 	return deploy, nil
 }
 
-// getExternalSubnetNad returns the namespace and name of the NetworkAttachmentDefinition associated with
-// an external network attached to a NAT gateway
-func (c *Controller) getExternalSubnetNad(gw *kubeovnv1.VpcNatGateway) (string, string, error) {
+// getExternalSubnetNads returns the namespace and name of the NetworkAttachmentDefinition(s)
+// associated with external networks attached to a NAT gateway
+func (c *Controller) getExternalSubnetNads(gw *kubeovnv1.VpcNatGateway) ([]util.ExternalSubnetNad, error) {
 	externalNadNamespace := c.config.PodNamespace
-	// GetNatGwExternalNetwork returns the subnet name from ExternalSubnets, or "ovn-vpc-external-network" if empty
-	externalSubnetName := util.GetNatGwExternalNetwork(gw.Spec.ExternalSubnets)
 
-	externalSubnet, err := c.subnetsLister.Get(externalSubnetName)
-	if err != nil {
-		err = fmt.Errorf("failed to get external subnet %s for NAT gateway %s: %w", externalSubnetName, gw.Name, err)
-		klog.Error(err)
-		return "", "", err
+	externalSubnetNames := util.GetNatGwExternalNetwork(gw.Spec.ExternalSubnets)
+
+	externalNads := make([]util.ExternalSubnetNad, 0, len(externalSubnetNames))
+
+	for _, externalSubnetName := range externalSubnetNames {
+		externalSubnet, err := c.subnetsLister.Get(externalSubnetName)
+		if err != nil {
+			err = fmt.Errorf("failed to get external subnet %s for NAT gateway %s: %w",
+				externalSubnetName, gw.Name, err)
+			klog.Error(err)
+			return nil, err
+		}
+
+		// Try to parse NAD info from subnet's provider
+		if name, namespace, ok := util.GetNadBySubnetProvider(externalSubnet.Spec.Provider); ok {
+			externalNads = append(externalNads, util.ExternalSubnetNad{
+				Namespace: namespace,
+				Name:      name,
+			})
+			continue
+		}
+
+		// Provider cannot be parsed to NAD info (e.g., provider is "ovn" or empty)
+		// Fall back to default NAD name which is the same as subnet name for external subnets
+		klog.Warningf("subnet %s provider %q cannot be parsed to NAD info, using default NAD %s/%s",
+			externalSubnetName, externalSubnet.Spec.Provider, externalNadNamespace, externalSubnetName)
+
+		externalNads = append(externalNads, util.ExternalSubnetNad{
+			Namespace: externalNadNamespace,
+			Name:      externalSubnetName,
+		})
 	}
 
-	// Try to parse NAD info from subnet's provider
-	if name, namespace, ok := util.GetNadBySubnetProvider(externalSubnet.Spec.Provider); ok {
-		return namespace, name, nil
-	}
-
-	// Provider cannot be parsed to NAD info (e.g., provider is "ovn" or empty)
-	// Fall back to default NAD name which is the same as subnet name for external subnets
-	klog.Warningf("subnet %s provider %q cannot be parsed to NAD info, using default NAD %s/%s",
-		externalSubnetName, externalSubnet.Spec.Provider, externalNadNamespace, externalSubnetName)
-	return externalNadNamespace, externalSubnetName, nil
+	return externalNads, nil
 }
 
 func (c *Controller) cleanUpVpcNatGw() error {

--- a/pkg/controller/vpc_nat_gateway_test.go
+++ b/pkg/controller/vpc_nat_gateway_test.go
@@ -367,7 +367,7 @@ func TestGetExternalSubnetNad(t *testing.T) {
 			controller := fakeController.fakeController
 			controller.config.PodNamespace = tt.podNamespace
 
-			namespace, name, err := controller.getExternalSubnetNad(tt.gw)
+			nads, err := controller.getExternalSubnetNads(tt.gw)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -375,8 +375,9 @@ func TestGetExternalSubnetNad(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedNamespace, namespace, "namespace mismatch")
-			assert.Equal(t, tt.expectedName, name, "name mismatch")
+			// since the testcase uses single external subnet, we expect only one NAD to be returned
+			assert.Equal(t, tt.expectedNamespace, nads[0].Namespace, "namespace mismatch")
+			assert.Equal(t, tt.expectedName, nads[0].Name, "name mismatch")
 		})
 	}
 }

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -14,6 +14,11 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
 
+type ExternalSubnetNad struct {
+	Namespace string
+	Name      string
+}
+
 // VpcNatGwNameDefaultPrefix is the default prefix appended to the name of the NAT gateways
 const VpcNatGwNameDefaultPrefix = "vpc-nat-gw"
 
@@ -68,11 +73,11 @@ func ValidateNatGwStatefulSetNameLength(prefix, gwName string) error {
 }
 
 // GetNatGwExternalNetwork returns the external network attached to a NAT gateway
-func GetNatGwExternalNetwork(externalNets []string) string {
+func GetNatGwExternalNetwork(externalNets []string) []string {
 	if len(externalNets) == 0 {
-		return vpcExternalNet
+		return []string{vpcExternalNet}
 	}
-	return externalNets[0]
+	return externalNets
 }
 
 // GenNatGwLabels returns the labels to set on a NAT gateway
@@ -104,13 +109,21 @@ func GenNatGwSelectors(selectors []string) map[string]string {
 // running as a non-primary CNI; in that mode eth0 must stay on the cluster's primary CNI pod
 // network (e.g. Calico) so the gateway pod can reach the Kubernetes control plane, so the
 // v1.multus-cni.io/default-network override is skipped.
-func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.VpcNatGateway, externalNadNamespace, externalNadName, provider, additionalNetworks string, enableNonPrimaryCNI bool) (map[string]string, error) {
+func GenNatGwPodAnnotations(userAnnotations map[string]string, gw *kubeovnv1.VpcNatGateway, externalNads []ExternalSubnetNad, provider, additionalNetworks string, enableNonPrimaryCNI bool) (map[string]string, error) {
 	p := provider
 	if p == "" {
 		p = OvnProvider
 	}
 
-	attachedNetworks := fmt.Sprintf("%s/%s", externalNadNamespace, externalNadName)
+	var networkNames []string
+	for _, externalNad := range externalNads {
+		if externalNad.Namespace == "" || externalNad.Name == "" {
+			return nil, fmt.Errorf("invalid external NAD info: namespace=%q, name=%q", externalNad.Namespace, externalNad.Name)
+		}
+		networkNames = append(networkNames, fmt.Sprintf("%s/%s", externalNad.Namespace, externalNad.Name))
+	}
+
+	attachedNetworks := strings.Join(networkNames, ",")
 	if additionalNetworks != "" {
 		attachedNetworks = additionalNetworks + ", " + attachedNetworks
 	}

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -161,29 +162,29 @@ func TestGetNatGwExternalNetwork(t *testing.T) {
 	tests := []struct {
 		name         string
 		externalNets []string
-		expected     string
+		expected     []string
 	}{
 		{
 			name:         "External network specified",
 			externalNets: []string{"custom-external-network"},
-			expected:     "custom-external-network",
+			expected:     []string{"custom-external-network"},
 		},
 		{
 			name:         "External network not specified",
 			externalNets: []string{},
-			expected:     vpcExternalNet,
+			expected:     []string{vpcExternalNet},
 		},
 		{
 			name:         "Multiple external networks specified",
 			externalNets: []string{"custom-external-network1", "custom-external-network2"},
-			expected:     "custom-external-network1",
+			expected:     []string{"custom-external-network1", "custom-external-network2"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := GetNatGwExternalNetwork(tc.externalNets)
-			if result != tc.expected {
+			if !slices.Equal(result, tc.expected) {
 				t.Errorf("got %v, but want %v", result, tc.expected)
 			}
 		})
@@ -280,15 +281,14 @@ func TestGenNatGwSelectors(t *testing.T) {
 
 func TestGenNatGwPodAnnotations(t *testing.T) {
 	tests := []struct {
-		name                 string
-		gw                   v1.VpcNatGateway
-		externalNadNamespace string
-		externalNadName      string
-		provider             string
-		additionalNetworks   string
-		enableNonPrimaryCNI  bool
-		expected             map[string]string
-		expectError          bool
+		name                string
+		gw                  v1.VpcNatGateway
+		externalSubnetNad   []ExternalSubnetNad
+		provider            string
+		additionalNetworks  string
+		enableNonPrimaryCNI bool
+		expected            map[string]string
+		expectError         bool
 	}{
 		{
 			name: "Empty provider defaults to ovn",
@@ -301,10 +301,15 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "10.20.30.40",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             "",
-			additionalNetworks:   "",
+
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:           "",
+			additionalNetworks: "",
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
 				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
@@ -324,10 +329,14 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "10.20.30.40",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             OvnProvider,
-			additionalNetworks:   "",
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:           OvnProvider,
+			additionalNetworks: "",
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
 				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
@@ -347,10 +356,14 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "10.20.30.40",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             "subnet.namespace.ovn",
-			additionalNetworks:   "",
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:           "subnet.namespace.ovn",
+			additionalNetworks: "",
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
 				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
@@ -371,10 +384,14 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "10.20.30.40",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             "subnet.namespace.ovn",
-			additionalNetworks:   "default/extra-net1, default/extra-net2",
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:           "subnet.namespace.ovn",
+			additionalNetworks: "default/extra-net1, default/extra-net2",
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
 				nadv1.NetworkAttachmentAnnot: "default/extra-net1, default/extra-net2, kube-system/external-subnet",
@@ -395,11 +412,15 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "10.20.30.40",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             "subnet.namespace.ovn",
-			additionalNetworks:   "",
-			enableNonPrimaryCNI:  true,
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:            "subnet.namespace.ovn",
+			additionalNetworks:  "",
+			enableNonPrimaryCNI: true,
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
 				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
@@ -419,11 +440,15 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "10.20.30.40",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             "subnet.namespace.ovn",
-			additionalNetworks:   "default/tenant-nad",
-			enableNonPrimaryCNI:  true,
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:            "subnet.namespace.ovn",
+			additionalNetworks:  "default/tenant-nad",
+			enableNonPrimaryCNI: true,
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
 				nadv1.NetworkAttachmentAnnot: "default/tenant-nad, kube-system/external-subnet",
@@ -443,10 +468,14 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             OvnProvider,
-			additionalNetworks:   "",
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:           OvnProvider,
+			additionalNetworks: "",
 			expected: map[string]string{
 				VpcNatGatewayAnnotation:      "test-gateway",
 				nadv1.NetworkAttachmentAnnot: "kube-system/external-subnet",
@@ -466,12 +495,16 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "10.20.30.40",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             "invalid-provider",
-			additionalNetworks:   "",
-			expected:             nil,
-			expectError:          true,
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:           "invalid-provider",
+			additionalNetworks: "",
+			expected:           nil,
+			expectError:        true,
 		},
 		{
 			name: "Invalid provider syntax under non-primary CNI still returns error",
@@ -484,19 +517,55 @@ func TestGenNatGwPodAnnotations(t *testing.T) {
 					LanIP:  "10.20.30.40",
 				},
 			},
-			externalNadName:      "external-subnet",
-			externalNadNamespace: metav1.NamespaceSystem,
-			provider:             "invalid-provider",
-			additionalNetworks:   "",
-			enableNonPrimaryCNI:  true,
-			expected:             nil,
-			expectError:          true,
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+			},
+			provider:            "invalid-provider",
+			additionalNetworks:  "",
+			enableNonPrimaryCNI: true,
+			expected:            nil,
+			expectError:         true,
+		},
+		{
+			name: "Non-primary CNI with multiple external networks",
+			gw: v1.VpcNatGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway",
+				},
+				Spec: v1.VpcNatGatewaySpec{
+					Subnet: "internal-subnet",
+					LanIP:  "10.20.30.40",
+				},
+			},
+			externalSubnetNad: []ExternalSubnetNad{
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet",
+				},
+				{
+					Namespace: metav1.NamespaceSystem,
+					Name:      "external-subnet1",
+				},
+			},
+			provider:            "subnet.namespace.ovn",
+			additionalNetworks:  "default/tenant-nad",
+			enableNonPrimaryCNI: true,
+			expected: map[string]string{
+				VpcNatGatewayAnnotation:      "test-gateway",
+				nadv1.NetworkAttachmentAnnot: "default/tenant-nad, kube-system/external-subnet,kube-system/external-subnet1",
+				fmt.Sprintf(LogicalSwitchAnnotationTemplate, "subnet.namespace.ovn"): "internal-subnet",
+				fmt.Sprintf(IPAddressAnnotationTemplate, "subnet.namespace.ovn"):     "10.20.30.40",
+			},
+			expectError: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := GenNatGwPodAnnotations(nil, &tc.gw, tc.externalNadNamespace, tc.externalNadName, tc.provider, tc.additionalNetworks, tc.enableNonPrimaryCNI)
+			result, err := GenNatGwPodAnnotations(nil, &tc.gw, tc.externalSubnetNad, tc.provider, tc.additionalNetworks, tc.enableNonPrimaryCNI)
 			if (err != nil) != tc.expectError {
 				t.Errorf("expected error: %v, but got: %v", tc.expectError, err)
 			}


### PR DESCRIPTION
# Pull Request

- [ yes] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Enhancement to support multiple external subnets per vpc nat gw config

Code changes in this PR:

- VPC NAT Gateway controller logic should be modified to handle multiple external subnets and create network annotations for each of them.(This will make sure to create multiple external interfaces in the vpc nat gw pod)
- Retain the default gw via the first external interface.
- Modify the nat-gateway.sh script to handle multiple external interfaces instead of single EXTERNAL_INTERFACE
 (get the external interface for each EIP using ip route get of EIP)

Tests:
```
kubectl get subnets
NAME              PROVIDER                           VPC           VLAN       PROTOCOL   CIDR             PRIVATE   NAT     DEFAULT   GATEWAYTYPE   V4USED   V4AVAILABLE   V6USED   V6AVAILABLE   EXCLUDEIPS                                                                                    U2OINTERCONNECTIONIP
join              ovn                                ovn-cluster              IPv4       100.64.0.0/16    false     false   false                   2        65531         0        0             ["100.64.0.1"]                                                                                
ovn-default       ovn                                ovn-cluster              IPv4       10.54.0.0/16     false     true    true      distributed   0        65533         0        0             ["10.54.0.1"]                                                                                 
subnetexternal    vswitchexternal.kube-system.ovn    commonvpc     vlan2017   IPv4       10.115.48.0/21   false     true    false                   6        2034          0        0             ["10.115.48.10","10.115.48.16","10.115.48.17","10.115.48.18","10.115.48.5","10.115.55.254"]   
subnetexternal1   vswitchexternal1.kube-system.ovn   commonvpc     vlan2015   IPv4       10.115.32.0/21   false     true    false                   2        2041          0        0             ["10.115.32.1","10.115.32.5","10.115.39.254"]                                                 
subnetinternal    vswitchinternal.default.ovn        commonvpc                IPv4       172.20.10.0/24   false     true    false                   2        251           0        0             ["172.20.10.1"]                                                                               
hp-65:~/vpcnatgw # kubectl get provider-network
NAME   DEFAULTINTERFACE   READY
pn1    bond0              true
hp-65:~/vpcnatgw # kubectl get vlan
NAME       ID     PROVIDER   CONFLICT
vlan2015   2015   pn1        
vlan2017   2017   pn1        

```
```
kubectl get vpc-nat-gw -o yaml
apiVersion: v1
items:
- apiVersion: kubeovn.io/v1
  kind: VpcNatGateway
  metadata:
    annotations:
      k8s.v1.cni.cncf.io/networks: default/vswitchinternal
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"kubeovn.io/v1","kind":"VpcNatGateway","metadata":{"annotations":{"k8s.v1.cni.cncf.io/networks":"default/vswitchinternal"},"name":"gw1"},"spec":{"externalSubnets":["subnetexternal","subnetexternal1"],"lanIp":"172.20.10.1","subnet":"subnetinternal","vpc":"commonvpc"}}
    creationTimestamp: "2026-08-13T20:11:49Z"
    generation: 1
    labels:
      ovn.kubernetes.io/qos: ""
      ovn.kubernetes.io/subnet: subnetinternal
      ovn.kubernetes.io/vpc: commonvpc
    name: gw1
    resourceVersion: "98735500"
    uid: 905977c4-b40c-443f-bef1-e2a48394651b
  spec:
    externalSubnets:
    - subnetexternal
    - subnetexternal1
    lanIp: 172.20.10.1
    subnet: subnetinternal
    vpc: commonvpc
  status:
    affinity: {}
    externalSubnets:
    - subnetexternal
    - subnetexternal1
    qosPolicy: ""
kind: List
metadata:
  resourceVersion: ""

kubectl get eip
NAME      IP              MAC                 NAT         NATGWDP   READY
my-eip    10.115.55.200   fe:46:a2:80:bb:5f   dnat,snat   gw1       true
my-eip1   10.115.35.147   42:b9:6e:cb:5c:21   dnat,snat   gw1       true
hp-65:~/vpcnatgw # kubectl get snat
NAME       EIP       V4IP            V6IP   INTERNALCIDR     NATGWDP   READY
my-snat    my-eip    10.115.55.200          172.20.10.0/24   gw1       true
my-snat1   my-eip1   10.115.35.147          172.20.10.0/24   gw1       true
hp-65:~/vpcnatgw # kubectl get dnat
NAME     EIP       PROTOCOL   V4IP            V6IP   INTERNALIP    EXTERNALPORT   INTERNALPORT   NATGWDP   READY
dnat01   my-eip    tcp        10.115.55.200          172.20.10.2   8888           80             gw1       true
dnat02   my-eip1   tcp        10.115.35.147          172.20.10.3   8888           80             gw1       true
```
```
kubectl describe pod vpc-nat-gw-gw1-0 -n kube-system
Name:             vpc-nat-gw-gw1-0
Namespace:        kube-system
Priority:         0
Service Account:  default
Node:             hp-46/10.115.14.70
Start Time:       Tue, 11 Aug 2026 23:59:45 +0000
Labels:           app=vpc-nat-gw-gw1
                  apps.kubernetes.io/pod-index=0
                  controller-revision-hash=vpc-nat-gw-gw1-698549bcc5
                  ovn.kubernetes.io/vpc-nat-gw=true
                  statefulset.kubernetes.io/pod-name=vpc-nat-gw-gw1-0
Annotations:      cni.projectcalico.org/containerID: 81cb117495d57476d5d0f6e01c879a7896c2d70e016f3344280e14758363b351
                  cni.projectcalico.org/podIP: 10.52.1.127/32
                  cni.projectcalico.org/podIPs: 10.52.1.127/32
                  k8s.v1.cni.cncf.io/network-status:
                    [{
                        "name": "k8s-pod-network",
                        "interface": "eth0",
                        "ips": [
                            "10.52.1.127"
                        ],
                        "mac": "2e:33:95:6f:0d:37",
                        "default": true,
                        "dns": {}
                    },{
                        "name": "default/vswitchinternal",
                        "interface": "net1",
                        "ips": [
                            "172.20.10.1"
                        ],
                        "mac": "5e:50:0f:c9:f0:13",
                        "dns": {}
                    },{
                        "name": "kube-system/vswitchexternal",
                        "interface": "net2",
                        "ips": [
                            "10.115.48.3"
                        ],
                        "mac": "9a:f5:cd:0e:8e:58",
                        "dns": {},
                        "gateway": [
                            "10.115.55.254"
                        ]
                    },{
                        "name": "kube-system/vswitchexternal1",
                        "interface": "net3",
                        "ips": [
                            "10.115.32.3"
                        ],
                        "mac": "f2:ec:8a:0b:33:99",
                        "dns": {}
                    }]
                  k8s.v1.cni.cncf.io/networks: default/vswitchinternal, kube-system/vswitchexternal,kube-system/vswitchexternal1
                  ovn.kubernetes.io/vpc_nat_gw: gw1
                  vswitchexternal.kube-system.ovn.kubernetes.io/allocated: true
                  vswitchexternal.kube-system.ovn.kubernetes.io/cidr: 10.115.48.0/21
                  vswitchexternal.kube-system.ovn.kubernetes.io/gateway: 10.115.55.254
                  vswitchexternal.kube-system.ovn.kubernetes.io/ip_address: 10.115.48.3
                  vswitchexternal.kube-system.ovn.kubernetes.io/logical_switch: subnetexternal
                  vswitchexternal.kube-system.ovn.kubernetes.io/mac_address: 9a:f5:cd:0e:8e:58
                  vswitchexternal.kube-system.ovn.kubernetes.io/pod_nic_type: veth-pair
                  vswitchexternal.kube-system.ovn.kubernetes.io/provider_network: pn1
                  vswitchexternal.kube-system.ovn.kubernetes.io/routed: true
                  vswitchexternal.kube-system.ovn.kubernetes.io/routes: [{"dst":"0.0.0.0/0","gw":"10.115.55.254"}]
                  vswitchexternal.kube-system.ovn.kubernetes.io/vlan_id: 2017
                  vswitchexternal1.kube-system.ovn.kubernetes.io/allocated: true
                  vswitchexternal1.kube-system.ovn.kubernetes.io/cidr: 10.115.32.0/21
                  vswitchexternal1.kube-system.ovn.kubernetes.io/gateway: 10.115.39.254
                  vswitchexternal1.kube-system.ovn.kubernetes.io/ip_address: 10.115.32.3
                  vswitchexternal1.kube-system.ovn.kubernetes.io/logical_switch: subnetexternal1
                  vswitchexternal1.kube-system.ovn.kubernetes.io/mac_address: f2:ec:8a:0b:33:99
                  vswitchexternal1.kube-system.ovn.kubernetes.io/pod_nic_type: veth-pair
                  vswitchexternal1.kube-system.ovn.kubernetes.io/provider_network: pn1
                  vswitchexternal1.kube-system.ovn.kubernetes.io/routed: true
                  vswitchexternal1.kube-system.ovn.kubernetes.io/vlan_id: 2015
                  vswitchinternal.default.ovn.kubernetes.io/allocated: true
                  vswitchinternal.default.ovn.kubernetes.io/cidr: 172.20.10.0/24
                  vswitchinternal.default.ovn.kubernetes.io/gateway: 172.20.10.1
                  vswitchinternal.default.ovn.kubernetes.io/ip_address: 172.20.10.1
                  vswitchinternal.default.ovn.kubernetes.io/logical_router: commonvpc
                  vswitchinternal.default.ovn.kubernetes.io/logical_switch: subnetinternal
                  vswitchinternal.default.ovn.kubernetes.io/mac_address: 5e:50:0f:c9:f0:13
                  vswitchinternal.default.ovn.kubernetes.io/pod_nic_type: veth-pair
                  vswitchinternal.default.ovn.kubernetes.io/routed: true
                  vswitchinternal.default.ovn.kubernetes.io/routes: [{"dst":"10.55.0.0/16","gw":"172.20.10.1"}]
Status:           Running
IP:               10.52.1.127
IPs:
  IP:           10.52.1.127
Controlled By:  StatefulSet/vpc-nat-gw-gw1
Containers:
  vpc-nat-gw:
    Container ID:  containerd://0cf461d3d6c1239ce8b4bc563b228227e2238433bc4cf7387099ff69e7ef9ff7
    Image:         renukaraaj17/vpc-nat-gateway:v1.16.1
    Image ID:      sha256:9f64a1e5bd0af1f03d20ae98c7c25d95b6b5828ca47ace91ef18dd4c52850286
    Port:          <none>
    Host Port:     <none>
    Command:
      sleep
      infinity
    State:          Running
      Started:      Wed, 12 Aug 2026 00:00:04 +0000
    Ready:          True
    Restart Count:  0
    Environment:
      GATEWAY_V4:  10.115.55.254
      GATEWAY_V6:  
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-st5nd (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True 
  Initialized                 True 
  Ready                       True 
  ContainersReady             True 
  PodScheduled                True 
Volumes:
  kube-api-access-st5nd:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    Optional:                false
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason          Age   From               Message
  ----    ------          ----  ----               -------
  Normal  Scheduled       29s   default-scheduler  Successfully assigned kube-system/vpc-nat-gw-gw1-0 to hp-46
  Normal  AddedInterface  28s   multus             Add eth0 [10.52.1.127/32] from k8s-pod-network
  Normal  AddedInterface  22s   multus             Add net1 [172.20.10.1/24] from default/vswitchinternal
  Normal  AddedInterface  17s   multus             Add net2 [10.115.48.3/21] from kube-system/vswitchexternal
  Normal  AddedInterface  11s   multus             Add net3 [10.115.32.3/21] from kube-system/vswitchexternal1
  Normal  Pulled          10s   kubelet            spec.containers{vpc-nat-gw}: Container image "renukaraaj17/vpc-nat-gateway:v1.16.1" already present on machine and can be accessed by the pod
  Normal  Created         10s   kubelet            spec.containers{vpc-nat-gw}: Container created
  Normal  Started         10s   kubelet            spec.containers{vpc-nat-gw}: Container started
```

```
kubectl describe statefulset -n kube-system vpc-nat-gw
Name:               vpc-nat-gw-gw1
Namespace:          kube-system
CreationTimestamp:  Tue, 11 Aug 2026 23:59:45 +0000
Selector:           app=vpc-nat-gw-gw1,ovn.kubernetes.io/vpc-nat-gw=true
Labels:             app=vpc-nat-gw-gw1
                    ovn.kubernetes.io/vpc-nat-gw=true
Annotations:        <none>
Replicas:           1 desired | 1 total
Update Strategy:    RollingUpdate
Pods Status:        1 Running / 0 Waiting / 0 Succeeded / 0 Failed
Pod Template:
  Labels:       app=vpc-nat-gw-gw1
                ovn.kubernetes.io/vpc-nat-gw=true
  Annotations:  k8s.v1.cni.cncf.io/networks: default/vswitchinternal, kube-system/vswitchexternal,kube-system/vswitchexternal1
                ovn.kubernetes.io/vpc_nat_gw: gw1
                vswitchexternal.kube-system.ovn.kubernetes.io/routes: [{"dst":"0.0.0.0/0","gw":"10.115.55.254"}]
                vswitchinternal.default.ovn.kubernetes.io/ip_address: 172.20.10.1
                vswitchinternal.default.ovn.kubernetes.io/logical_switch: subnetinternal
                vswitchinternal.default.ovn.kubernetes.io/routes: [{"dst":"10.55.0.0/16","gw":"172.20.10.1"}]
  Containers:
   vpc-nat-gw:
    Image:      renukaraaj17/vpc-nat-gateway:v1.16.1
    Port:       <none>
    Host Port:  <none>
    Command:
      sleep
      infinity
    Environment:
      GATEWAY_V4:  10.115.55.254
      GATEWAY_V6:  
    Mounts:        <none>
  Volumes:         <none>
  Node-Selectors:  <none>
  Tolerations:     <none>
Volume Claims:     <none>
Events:
  Type    Reason            Age   From                    Message
  ----    ------            ----  ----                    -------
  Normal  SuccessfulCreate  102s  statefulset-controller  Create Pod vpc-nat-gw-gw1-0 in StatefulSet vpc-nat-gw-gw1 successful
```

```
root@vpc-nat-gw-gw1-0:/kube-ovn# iptables-legacy-save -t nat
# Generated by iptables-save v1.8.10 on Thu Aug 13 19:27:38 2026
*nat
:PREROUTING ACCEPT [252:34379]
:INPUT ACCEPT [11:3430]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [1:60]
:DNAT_FILTER - [0:0]
:EXCLUSIVE_DNAT - [0:0]
:EXCLUSIVE_SNAT - [0:0]
:HAIRPIN_SNAT - [0:0]
:SHARED_DNAT - [0:0]
:SHARED_SNAT - [0:0]
:SNAT_FILTER - [0:0]
-A PREROUTING -j DNAT_FILTER
-A POSTROUTING -j SNAT_FILTER
-A DNAT_FILTER -j EXCLUSIVE_DNAT
-A DNAT_FILTER -j SHARED_DNAT
-A HAIRPIN_SNAT -o eth0 -m mark --mark 0x1/0x1 -m conntrack --ctstate DNAT --ctorigdst 10.115.35.147 -j SNAT --to-source 10.115.35.147 --random-fully
-A HAIRPIN_SNAT -o eth0 -m mark --mark 0x1/0x1 -m conntrack --ctstate DNAT --ctorigdst 10.115.55.200 -j SNAT --to-source 10.115.55.200 --random-fully
-A SHARED_DNAT -d 10.115.35.147/32 -p tcp -m tcp --dport 8888 -j DNAT --to-destination 172.20.10.3:80
-A SHARED_DNAT -d 10.115.55.200/32 -p tcp -m tcp --dport 8888 -j DNAT --to-destination 172.20.10.2:80
-A SHARED_SNAT -s 172.20.10.0/24 -o net3 -j SNAT --to-source 10.115.35.147 --random-fully
-A SHARED_SNAT -s 172.20.10.0/24 -o net2 -j SNAT --to-source 10.115.55.200 --random-fully
-A SNAT_FILTER -j EXCLUSIVE_SNAT
-A SNAT_FILTER -j SHARED_SNAT
-A SNAT_FILTER -j HAIRPIN_SNAT
COMMIT
# Completed on Thu Aug 13 19:27:38 2026
root@vpc-nat-gw-gw1-0:/kube-ovn# ip route show
default via 10.115.39.254 dev net3 
10.55.0.0/16 via 172.20.10.1 dev net1 
10.115.32.0/21 dev net3 proto kernel scope link src 10.115.32.16 
10.115.48.0/21 dev net2 proto kernel scope link src 10.115.48.14 
169.254.1.1 dev eth0 scope link 
172.20.10.0/24 dev net1 proto kernel scope link src 172.20.10.1 
root@vpc-nat-gw-gw1-0:/kube-ovn# ip neighbor show
172.20.10.3 dev net1 lladdr b2:6a:a2:e3:0a:88 STALE 
172.20.10.2 dev net1 lladdr 1a:48:ee:4b:94:88 STALE 
10.115.55.254 dev net2 lladdr 00:09:0f:09:00:10 STALE 
10.115.39.254 dev net3 lladdr 00:09:0f:09:00:10 STALE 
root@vpc-nat-gw-gw1-0:/kube-ovn# ip route del default
root@vpc-nat-gw-gw1-0:/kube-ovn# ip route add default via 10.115.55.2544 dev net2
Error: any valid address is expected rather than "10.115.55.2544".
root@vpc-nat-gw-gw1-0:/kube-ovn# ip route add default via 10.115.55.254 dev net2
root@vpc-nat-gw-gw1-0:/kube-ovn# ip route show
default via 10.115.55.254 dev net2 
10.55.0.0/16 via 172.20.10.1 dev net1 
10.115.32.0/21 dev net3 proto kernel scope link src 10.115.32.16 
10.115.48.0/21 dev net2 proto kernel scope link src 10.115.48.14 
169.254.1.1 dev eth0 scope link 
172.20.10.0/24 dev net1 proto kernel scope link src 172.20.10.1 
```
```
curl -k http://10.115.55.200:8888
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
renuka@renuka-ThinkPad-P14s-Gen-4:~/gc-vpc-ui/docs$ curl -k http://10.115.35.147:8888
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
```
## Which issue(s) this PR fixes

Fixes #(issue-number)
https://github.com/kubeovn/kube-ovn/issues/7134