### PR TITLE
[release-1.15] feat: add gzip to container image for logrotate compression

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -244,7 +244,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt install ca-certificates netbase ethtool iproute2 ncat libunbound8 \
         kmod iptables python3-netifaces python3-sortedcontainers tcpdump ipvsadm ipset curl \
         uuid-runtime openssl inetutils-ping arping ndisc6 conntrack traceroute iputils-tracepath \
-        logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
+        gzip logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
         libcharon-extauth-plugins libstrongswan-extra-plugins libstrongswan-standard-plugins \
         -y --no-install-recommends --auto-remove && \
     apt remove -y --allow-remove-essential --auto-remove login && \

--- a/dist/images/Dockerfile.base-dpdk
+++ b/dist/images/Dockerfile.base-dpdk
@@ -117,7 +117,7 @@ ARG PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt update && apt upgrade -y && apt install ca-certificates python3 libunwind8 netbase \
         ethtool iproute2 ncat libunbound8 libatomic1 kmod iptables python3-netifaces python3-sortedcontainers \
         tcpdump ipvsadm ipset curl uuid-runtime openssl inetutils-ping arping ndisc6 conntrack iputils-tracepath \
-        logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
+        gzip logrotate dnsutils net-tools strongswan strongswan-pki libcharon-extra-plugins \
         libcharon-extauth-plugins libstrongswan-extra-plugins libstrongswan-standard-plugins \
         python3-pip build-essential libssl-dev libibverbs-dev libnuma-dev libpcap-dev -y --no-install-recommends && \
         rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed Kube-OVN Code Style.

## What type of this PR

- Bug fixes

## What this PR does

Backport merged PR #7217 to `release-1.15`.

Explicitly install `gzip` in both the standard and DPDK runtime base images so the existing logrotate configurations can honor their `compress` directive.

## Testing

- Backport stable patch ID matches source PR head commit `615893ac27f1572cdcd85ff38d53eeae73a3b853`
- Verified that only `dist/images/Dockerfile.base` and `dist/images/Dockerfile.base-dpdk` change
- Verified that both runtime package lists contain one explicit `gzip logrotate` declaration
- Verified that all existing `dist/images/logrotate/*` configurations enable `compress`
- `git diff --check origin/release-1.15...HEAD`

Full-repository `make lint CI=true` was run under the required 2 GiB local memory limit, but the Go lint stage could not complete within that limit. This backport changes only runtime package lists, and GitHub Actions will run the branch checks.

## Which issue(s) this PR fixes

N/A

Backport of #7217.
