### PR TITLE
test: add BGP speaker unit and end-to-end coverage

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1815,8 +1815,13 @@ jobs:
           E2E_NETWORK_MODE: overlay
         run: make kube-ovn-bgp-speaker-e2e
 
+      - name: Check kube ovn pod restarts
+        id: check-restarts
+        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')) }}
+        run: make check-kube-ovn-pod-restarts
+
       - name: Collect BGP diagnostics
-        if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           mkdir -p bgp-speaker-e2e-diagnostics
           docker exec clab-bgp-router vtysh -c "show bgp ipv4 unicast summary json" > bgp-speaker-e2e-diagnostics/frr-summary.json || true
@@ -1830,25 +1835,24 @@ jobs:
 
       - name: Upload BGP diagnostics
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
           name: bgp-speaker-e2e-diagnostics
           path: bgp-speaker-e2e-diagnostics.tar.gz
 
-      - name: Check kube ovn pod restarts
-        id: check-restarts
-        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')) }}
-        run: make check-kube-ovn-pod-restarts
-
       - name: kubectl ko log
-        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
+        if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz bgp-speaker-e2e-ko-log.tar.gz
+          if make kubectl-ko-log && test -f kubectl-ko-log.tar.gz; then
+            mv kubectl-ko-log.tar.gz bgp-speaker-e2e-ko-log.tar.gz
+          else
+            echo "kubectl ko log was unavailable because the BGP test cluster did not become usable." > bgp-speaker-e2e-ko-log-unavailable.txt
+            tar zcf bgp-speaker-e2e-ko-log.tar.gz bgp-speaker-e2e-ko-log-unavailable.txt
+          fi
 
       - name: Upload kubectl ko log
         uses: actions/upload-artifact@v7
-        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
+        if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
           name: bgp-speaker-e2e-ko-log
           path: bgp-speaker-e2e-ko-log.tar.gz

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1719,6 +1719,144 @@ jobs:
           name: non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log
           path: non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
+  bgp-speaker-e2e:
+    name: BGP Speaker E2E
+    needs:
+      - build-kube-ovn
+      - build-e2e-binaries
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
+      - uses: actions/checkout@v7
+
+      - name: Create the default branch directory
+        if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
+        run: mkdir -p test/e2e/source
+
+      - name: Check out the default branch
+        if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          path: test/e2e/source
+
+      - name: Export E2E directory
+        run: |
+          if [ '${{ github.base_ref || github.ref_name }}' = '${{ github.event.repository.default_branch }}' ]; then
+            echo "E2E_DIR=." >> "$GITHUB_ENV"
+          else
+            echo "E2E_DIR=test/e2e/source" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/setup-go@v7
+        id: setup-go
+        with:
+          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          check-latest: true
+          cache: false
+
+      - name: Export Go full version
+        run: echo "GO_VERSION=${{ steps.setup-go.outputs.go-version }}" >> "$GITHUB_ENV"
+
+      - name: Go cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-e2e-go-${{ env.GO_VERSION }}-x86-${{ github.ref_name }}-${{ hashFiles(format('{0}/**/go.sum', env.E2E_DIR)) }}
+          restore-keys: |
+            ${{ runner.os }}-e2e-go-${{ env.GO_VERSION }}-x86-${{ github.ref_name }}-
+            ${{ runner.os }}-e2e-go-${{ env.GO_VERSION }}-x86-${{ github.base_ref }}-
+
+      - name: Install kind
+        uses: helm/kind-action@v1.14.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          install_only: true
+
+      - name: Download kube-ovn image
+        uses: actions/download-artifact@v8
+        with:
+          name: kube-ovn
+
+      - name: Load kube-ovn image
+        run: docker load -i kube-ovn.tar
+
+      - name: Create BGP kind and containerlab topology
+        id: setup
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pipx install jinjanator
+          make kind-ghcr-pull kind-init-bgp
+
+      - name: Install Kube-OVN and BGP speakers
+        id: install
+        run: make kind-install-bgp
+
+      - name: Run BGP speaker E2E
+        id: e2e
+        working-directory: ${{ env.E2E_DIR }}
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
+          E2E_IP_FAMILY: ipv4
+          E2E_NETWORK_MODE: overlay
+        run: make kube-ovn-bgp-speaker-e2e
+
+      - name: Collect BGP diagnostics
+        if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        run: |
+          mkdir -p bgp-speaker-e2e-diagnostics
+          docker exec clab-bgp-router vtysh -c "show bgp ipv4 unicast summary json" > bgp-speaker-e2e-diagnostics/frr-summary.json || true
+          docker exec clab-bgp-router vtysh -c "show bgp ipv4 unicast json" > bgp-speaker-e2e-diagnostics/frr-routes.json || true
+          kubectl -n kube-system get ds kube-ovn-speaker -o yaml > bgp-speaker-e2e-diagnostics/speaker-daemonset.yaml || true
+          kubectl -n kube-system get pods -l app=kube-ovn-speaker -o wide > bgp-speaker-e2e-diagnostics/speaker-pods.txt || true
+          kubectl -n kube-system logs -l app=kube-ovn-speaker --all-containers --prefix > bgp-speaker-e2e-diagnostics/speaker.log || true
+          kubectl get events -A -o yaml > bgp-speaker-e2e-diagnostics/events.yaml || true
+          docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log bgp-speaker-e2e-diagnostics/ || true
+          tar zcf bgp-speaker-e2e-diagnostics.tar.gz bgp-speaker-e2e-diagnostics
+
+      - name: Upload BGP diagnostics
+        uses: actions/upload-artifact@v7
+        if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        with:
+          name: bgp-speaker-e2e-diagnostics
+          path: bgp-speaker-e2e-diagnostics.tar.gz
+
+      - name: Check kube ovn pod restarts
+        id: check-restarts
+        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')) }}
+        run: make check-kube-ovn-pod-restarts
+
+      - name: kubectl ko log
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
+        run: |
+          make kubectl-ko-log
+          mv kubectl-ko-log.tar.gz bgp-speaker-e2e-ko-log.tar.gz
+
+      - name: Upload kubectl ko log
+        uses: actions/upload-artifact@v7
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
+        with:
+          name: bgp-speaker-e2e-ko-log
+          path: bgp-speaker-e2e-ko-log.tar.gz
+
+      - name: Clean BGP topology
+        if: always()
+        run: make kind-clean-bgp
+
   kube-ovn-hosted-ovn-central-e2e:
     name: Kube-OVN Hosted OVN Central E2E (${{ matrix.ip-family }}, ${{ matrix.tenant-control-plane }} control-plane)
     needs:
@@ -4418,6 +4556,7 @@ jobs:
       - kube-ovn-underlay-metallb-e2e
       - multus-conformance-e2e
       - non-primary-cni-e2e
+      - bgp-speaker-e2e
       - kube-ovn-hosted-ovn-central-e2e
       - vpc-egress-gateway-e2e
       - ovn-vpc-nat-gw-conformance-e2e

--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -92,6 +92,7 @@ e2e-build:
 	$(GINKGO_E2E_BUILD) ./test/e2e/ovn-ic
 	$(GINKGO_E2E_BUILD) ./test/e2e/multus
 	$(GINKGO_E2E_BUILD) ./test/e2e/non-primary-cni
+	$(GINKGO_E2E_BUILD) ./test/e2e/bgp
 	$(GINKGO_E2E_BUILD) ./test/e2e/lb-svc
 	$(GINKGO_E2E_BUILD) ./test/e2e/vip
 	$(GINKGO_E2E_BUILD) ./test/e2e/vpc-egress-gateway
@@ -188,6 +189,16 @@ kube-ovn-non-primary-cni-e2e:
 	KUBE_OVN_PRIMARY_CNI=$(shell echo $${KUBE_OVN_PRIMARY_CNI:-false}) \
 	$(GINKGO_E2E_RUN_PARALLEL) --timeout=15m \
 		--focus="group:non-primary-cni" ./test/e2e/non-primary-cni/non-primary-cni.test -- $(TEST_BIN_ARGS)
+
+.PHONY: kube-ovn-bgp-speaker-e2e
+kube-ovn-bgp-speaker-e2e:
+	$(call kind_load_image,kube-ovn,$(AGNHOST_IMAGE),1)
+	$(GINKGO_E2E_BUILD) ./test/e2e/bgp
+	E2E_BRANCH=$(E2E_BRANCH) \
+	E2E_IP_FAMILY=ipv4 \
+	E2E_NETWORK_MODE=overlay \
+	$(GINKGO_E2E_RUN) --timeout=15m \
+		--focus="group:bgp-speaker" ./test/e2e/bgp/bgp.test -- $(TEST_BIN_ARGS)
 
 .PHONY: kube-ovn-lb-svc-conformance-e2e
 kube-ovn-lb-svc-conformance-e2e:

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -701,6 +701,8 @@ kind-install-bgp: kind-install
 		-e 's/--neighbor-as=.*/--neighbor-as=65001/' \
 		-e 's/--cluster-as=.*/--cluster-as=65002/' yamls/speaker.yaml | \
 		kubectl apply -f -
+	kubectl -n kube-system patch ds kube-ovn-speaker --type=json \
+		-p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--announce-cluster-ip=true"}]'
 	kubectl -n kube-system rollout status ds kube-ovn-speaker --timeout 60s
 	docker exec clab-bgp-router vtysh -c "show ip route bgp"
 
@@ -713,6 +715,8 @@ kind-install-bgp-ha: kind-install
 		-e 's/--neighbor-as=.*/--neighbor-as=65001/' \
 		-e 's/--cluster-as=.*/--cluster-as=65002/' yamls/speaker.yaml | \
 		kubectl apply -f -
+	kubectl -n kube-system patch ds kube-ovn-speaker --type=json \
+		-p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--announce-cluster-ip=true"}]'
 	kubectl -n kube-system rollout status ds kube-ovn-speaker --timeout 60s
 	docker exec clab-bgp-router-1 vtysh -c "show ip route bgp"
 	docker exec clab-bgp-router-2 vtysh -c "show ip route bgp"

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -715,8 +715,6 @@ kind-install-bgp-ha: kind-install
 		-e 's/--neighbor-as=.*/--neighbor-as=65001/' \
 		-e 's/--cluster-as=.*/--cluster-as=65002/' yamls/speaker.yaml | \
 		kubectl apply -f -
-	kubectl -n kube-system patch ds kube-ovn-speaker --type=json \
-		-p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--announce-cluster-ip=true"}]'
 	kubectl -n kube-system rollout status ds kube-ovn-speaker --timeout 60s
 	docker exec clab-bgp-router-1 vtysh -c "show ip route bgp"
 	docker exec clab-bgp-router-2 vtysh -c "show ip route bgp"

--- a/pkg/speaker/bgp_test.go
+++ b/pkg/speaker/bgp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
 	"k8s.io/utils/set"
 )
 
@@ -33,7 +34,7 @@ func newTestBgpServer(t *testing.T, routerID string) *gobgp.BgpServer {
 	return server
 }
 
-func listTestPrefixes(t *testing.T, server *gobgp.BgpServer, afi api.Family_Afi) map[string][]net.IP {
+func listTestPrefixNextHops(t *testing.T, server *gobgp.BgpServer, afi api.Family_Afi) map[string][]net.IP {
 	t.Helper()
 
 	prefixes := map[string][]net.IP{}
@@ -69,7 +70,7 @@ func TestReconcileRoutesAddsAndWithdrawsIPv4Routes(t *testing.T) {
 	require.NoError(t, controller.reconcileRoutes(prefixMap{
 		api.Family_AFI_IP: set.New(prefix),
 	}))
-	routes := listTestPrefixes(t, controller.config.BgpServer, api.Family_AFI_IP)
+	routes := listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
 	require.Contains(t, routes, prefix)
 	require.Len(t, routes[prefix], 1)
 	require.True(t, net.ParseIP(routerID).Equal(routes[prefix][0]))
@@ -77,7 +78,7 @@ func TestReconcileRoutesAddsAndWithdrawsIPv4Routes(t *testing.T) {
 	require.NoError(t, controller.reconcileRoutes(prefixMap{
 		api.Family_AFI_IP: set.New[string](),
 	}))
-	require.NotContains(t, listTestPrefixes(t, controller.config.BgpServer, api.Family_AFI_IP), prefix)
+	require.NotContains(t, listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP), prefix)
 }
 
 func TestGetPathRequest(t *testing.T) {
@@ -204,12 +205,30 @@ func TestGetNextHopFromPathAttributes(t *testing.T) {
 	}
 }
 
-func TestGetNextHopAttributeUsesCachedLocalAddress(t *testing.T) {
-	const neighbor = "192.0.2.1"
-	localAddress := net.ParseIP("192.0.2.10")
-	controller := &Controller{config: &Configuration{
-		NeighborLocalAddresses: map[string]net.IP{neighbor: localAddress},
-	}}
+func TestGetNextHopAttributeReusesInitializedNeighborLocalAddresses(t *testing.T) {
+	ipv4Neighbor := net.ParseIP("192.0.2.1")
+	ipv4StartupAddress := net.ParseIP("192.0.2.10")
+	ipv6Neighbor := net.ParseIP("2001:db8::1")
+	ipv6StartupAddress := net.ParseIP("2001:db8::10")
+	routeSources := map[string]net.IP{
+		ipv4Neighbor.String(): ipv4StartupAddress,
+		ipv6Neighbor.String(): ipv6StartupAddress,
+	}
+	config := &Configuration{
+		NeighborAddresses:          []net.IP{ipv4Neighbor},
+		NeighborIPv6Addresses:      []net.IP{ipv6Neighbor},
+		AllowedSourceAddresses:     []net.IP{ipv4StartupAddress},
+		AllowedSourceIPv6Addresses: []net.IP{ipv6StartupAddress},
+	}
+	require.NoError(t, config.initNeighborLocalAddressesWithRouteLookup(func(address net.IP) ([]netlink.Route, error) {
+		source, ok := routeSources[address.String()]
+		require.True(t, ok)
+		return []netlink.Route{{Src: source}}, nil
+	}))
 
-	require.True(t, localAddress.Equal(controller.getNextHopAttribute(net.ParseIP(neighbor))))
+	routeSources[ipv4Neighbor.String()] = net.ParseIP("192.0.2.20")
+	routeSources[ipv6Neighbor.String()] = net.ParseIP("2001:db8::20")
+	controller := &Controller{config: config}
+	require.True(t, ipv4StartupAddress.Equal(controller.getNextHopAttribute(ipv4Neighbor)))
+	require.True(t, ipv6StartupAddress.Equal(controller.getNextHopAttribute(ipv6Neighbor)))
 }

--- a/pkg/speaker/bgp_test.go
+++ b/pkg/speaker/bgp_test.go
@@ -1,0 +1,215 @@
+package speaker
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	gobgp "github.com/osrg/gobgp/v4/pkg/server"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/set"
+)
+
+func newTestBgpServer(t *testing.T, routerID string) *gobgp.BgpServer {
+	t.Helper()
+
+	server := gobgp.NewBgpServer()
+	go server.Serve()
+	require.NoError(t, server.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65000,
+			RouterId:   routerID,
+			ListenPort: -1,
+		},
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, server.StopBgp(context.Background(), &api.StopBgpRequest{}))
+		server.Stop()
+	})
+	return server
+}
+
+func listTestPrefixes(t *testing.T, server *gobgp.BgpServer, afi api.Family_Afi) map[string][]net.IP {
+	t.Helper()
+
+	prefixes := map[string][]net.IP{}
+	err := server.ListPath(apiutil.ListPathRequest{
+		TableType: api.TableType_TABLE_TYPE_GLOBAL,
+		Family: apiutil.ToFamily(&api.Family{
+			Afi:  afi,
+			Safi: api.Family_SAFI_UNICAST,
+		}),
+	}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
+		for _, path := range paths {
+			prefixes[prefix.String()] = append(prefixes[prefix.String()], getNextHopFromPathAttributes(path.Attrs))
+		}
+	})
+	require.NoError(t, err)
+	return prefixes
+}
+
+func TestReconcileRoutesAddsAndWithdrawsIPv4Routes(t *testing.T) {
+	const (
+		routerID = "192.0.2.10"
+		neighbor = "192.0.2.1"
+		prefix   = "10.244.0.8/32"
+	)
+
+	controller := &Controller{config: &Configuration{
+		RouterID:               net.ParseIP(routerID),
+		NeighborAddresses:      []net.IP{net.ParseIP(neighbor)},
+		NeighborLocalAddresses: map[string]net.IP{neighbor: net.ParseIP(routerID)},
+		BgpServer:              newTestBgpServer(t, routerID),
+	}}
+
+	require.NoError(t, controller.reconcileRoutes(prefixMap{
+		api.Family_AFI_IP: set.New(prefix),
+	}))
+	routes := listTestPrefixes(t, controller.config.BgpServer, api.Family_AFI_IP)
+	require.Contains(t, routes, prefix)
+	require.Len(t, routes[prefix], 1)
+	require.True(t, net.ParseIP(routerID).Equal(routes[prefix][0]))
+
+	require.NoError(t, controller.reconcileRoutes(prefixMap{
+		api.Family_AFI_IP: set.New[string](),
+	}))
+	require.NotContains(t, listTestPrefixes(t, controller.config.BgpServer, api.Family_AFI_IP), prefix)
+}
+
+func TestGetPathRequest(t *testing.T) {
+	const (
+		ipv4Neighbor = "192.0.2.1"
+		ipv4NextHop  = "192.0.2.10"
+		ipv6Neighbor = "2001:db8::1"
+		ipv6NextHop  = "2001:db8::10"
+	)
+
+	tests := []struct {
+		name             string
+		route            string
+		extendedNexthop  bool
+		expectedPrefix   string
+		expectedFamily   bgp.Family
+		expectedNextHops []string
+		expectError      string
+	}{
+		{
+			name:             "IPv4 route uses IPv4 neighbors",
+			route:            "10.244.0.8",
+			expectedPrefix:   "10.244.0.8/32",
+			expectedFamily:   bgp.RF_IPv4_UC,
+			expectedNextHops: []string{ipv4NextHop},
+		},
+		{
+			name:             "IPv6 route uses IPv6 neighbors",
+			route:            "fd00::8/128",
+			expectedPrefix:   "fd00::8/128",
+			expectedFamily:   bgp.RF_IPv6_UC,
+			expectedNextHops: []string{ipv6NextHop},
+		},
+		{
+			name:             "extended nexthop uses every neighbor",
+			route:            "10.244.0.0/24",
+			extendedNexthop:  true,
+			expectedPrefix:   "10.244.0.0/24",
+			expectedFamily:   bgp.RF_IPv4_UC,
+			expectedNextHops: []string{ipv4NextHop, ipv6NextHop},
+		},
+		{
+			name:        "invalid route is rejected",
+			route:       "not-an-ip",
+			expectError: "failed to parse route",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := &Controller{config: &Configuration{
+				NeighborAddresses:     []net.IP{net.ParseIP(ipv4Neighbor)},
+				NeighborIPv6Addresses: []net.IP{net.ParseIP(ipv6Neighbor)},
+				NeighborLocalAddresses: map[string]net.IP{
+					ipv4Neighbor: net.ParseIP(ipv4NextHop),
+					ipv6Neighbor: net.ParseIP(ipv6NextHop),
+				},
+				ExtendedNexthop: tt.extendedNexthop,
+			}}
+
+			paths, err := controller.getPathRequest(tt.route)
+			if tt.expectError != "" {
+				require.ErrorContains(t, err, tt.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, paths, len(tt.expectedNextHops))
+			for i, pathGroup := range paths {
+				require.Len(t, pathGroup, 1)
+				path := pathGroup[0]
+				require.Equal(t, tt.expectedFamily, path.Family)
+				require.Equal(t, tt.expectedPrefix, path.Nlri.String())
+				require.True(t, net.ParseIP(tt.expectedNextHops[i]).Equal(getNextHopFromPathAttributes(path.Attrs)))
+			}
+		})
+	}
+}
+
+func TestGetNextHopFromPathAttributes(t *testing.T) {
+	ipv4 := net.ParseIP("192.0.2.10")
+	ipv6 := net.ParseIP("2001:db8::10")
+	nextHopAttr, err := bgp.NewPathAttributeNextHop(netip.MustParseAddr(ipv4.String()))
+	require.NoError(t, err)
+	ipv6Prefix, err := bgp.NewIPAddrPrefix(netip.MustParsePrefix("fd00::8/128"))
+	require.NoError(t, err)
+	mpReachAttr, err := bgp.NewPathAttributeMpReachNLRI(
+		bgp.RF_IPv6_UC,
+		[]bgp.PathNLRI{{NLRI: ipv6Prefix}},
+		netip.MustParseAddr(ipv6.String()),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		attrs    []bgp.PathAttributeInterface
+		expected net.IP
+	}{
+		{
+			name:     "NEXT_HOP",
+			attrs:    []bgp.PathAttributeInterface{nextHopAttr},
+			expected: ipv4,
+		},
+		{
+			name:     "MP_REACH_NLRI",
+			attrs:    []bgp.PathAttributeInterface{mpReachAttr},
+			expected: ipv6,
+		},
+		{
+			name:  "missing next hop",
+			attrs: []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getNextHopFromPathAttributes(tt.attrs)
+			if tt.expected == nil {
+				require.Nil(t, actual)
+				return
+			}
+			require.True(t, tt.expected.Equal(actual))
+		})
+	}
+}
+
+func TestGetNextHopAttributeUsesCachedLocalAddress(t *testing.T) {
+	const neighbor = "192.0.2.1"
+	localAddress := net.ParseIP("192.0.2.10")
+	controller := &Controller{config: &Configuration{
+		NeighborLocalAddresses: map[string]net.IP{neighbor: localAddress},
+	}}
+
+	require.True(t, localAddress.Equal(controller.getNextHopAttribute(net.ParseIP(neighbor))))
+}

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -335,11 +335,11 @@ func (config *Configuration) initKubeClient() error {
 }
 
 func (config *Configuration) checkGracefulRestartOptions() error {
-	if config.GracefulRestartTime > time.Second*4095 || config.GracefulRestartTime <= 0 {
-		return errors.New("GracefulRestartTime should be less than 4095 seconds or more than 0")
+	if config.GracefulRestartTime > 4095*time.Second || config.GracefulRestartTime < time.Second {
+		return errors.New("GracefulRestartTime should be between 1 and 4095 seconds")
 	}
-	if config.GracefulRestartDeferralTime > time.Hour*18 || config.GracefulRestartDeferralTime <= 0 {
-		return errors.New("GracefulRestartDeferralTime should be less than 18 hours or more than 0")
+	if config.GracefulRestartDeferralTime > 18*time.Hour || config.GracefulRestartDeferralTime < time.Second {
+		return errors.New("GracefulRestartDeferralTime should be between 1 second and 18 hours")
 	}
 
 	return nil
@@ -554,13 +554,19 @@ func (config *Configuration) watchPeerState() {
 	}
 }
 
+type routeLookupFunc func(net.IP) ([]netlink.Route, error)
+
 func (config *Configuration) initNeighborLocalAddresses() error {
+	return config.initNeighborLocalAddressesWithRouteLookup(netlink.RouteGet)
+}
+
+func (config *Configuration) initNeighborLocalAddressesWithRouteLookup(routeLookup routeLookupFunc) error {
 	config.NeighborLocalAddresses = make(map[string]net.IP, len(config.NeighborAddresses)+len(config.NeighborIPv6Addresses))
 
 	for _, neighbor := range config.NeighborAddresses {
 		if len(config.AllowedSourceAddresses) != 0 {
 			klog.Infof("Resolving BGP local address for neighbor %s with allowed IPv4 source addresses %v", neighbor, config.AllowedSourceAddresses)
-			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor, config.AllowedSourceAddresses)
+			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor, config.AllowedSourceAddresses, routeLookup)
 			if err != nil {
 				return err
 			}
@@ -571,7 +577,7 @@ func (config *Configuration) initNeighborLocalAddresses() error {
 	for _, neighbor := range config.NeighborIPv6Addresses {
 		if len(config.AllowedSourceIPv6Addresses) != 0 {
 			klog.Infof("Resolving BGP local address for neighbor %s with allowed IPv6 source addresses %v", neighbor, config.AllowedSourceIPv6Addresses)
-			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor, config.AllowedSourceIPv6Addresses)
+			localAddr, err := config.resolveWhitelistedNeighborLocalAddress(neighbor, config.AllowedSourceIPv6Addresses, routeLookup)
 			if err != nil {
 				return err
 			}
@@ -598,8 +604,8 @@ func (config *Configuration) getNeighborLocalAddress(neighborAddress net.IP) net
 	return nil
 }
 
-func (config *Configuration) resolveWhitelistedNeighborLocalAddress(neighborAddress net.IP, allowedLocalAddresses []net.IP) (net.IP, error) {
-	routes, err := netlink.RouteGet(neighborAddress)
+func (config *Configuration) resolveWhitelistedNeighborLocalAddress(neighborAddress net.IP, allowedLocalAddresses []net.IP, routeLookup routeLookupFunc) (net.IP, error) {
+	routes, err := routeLookup(neighborAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine local address for BGP neighbor %s from route lookup: %w", neighborAddress, err)
 	}

--- a/pkg/speaker/config_additional_test.go
+++ b/pkg/speaker/config_additional_test.go
@@ -1,0 +1,82 @@
+package speaker
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckGracefulRestartOptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		restartTime  time.Duration
+		deferralTime time.Duration
+		expectError  string
+	}{
+		{
+			name:         "valid boundary values",
+			restartTime:  4095 * time.Second,
+			deferralTime: 18 * time.Hour,
+		},
+		{
+			name:         "zero restart time",
+			restartTime:  0,
+			deferralTime: time.Minute,
+			expectError:  "GracefulRestartTime",
+		},
+		{
+			name:         "restart time above maximum",
+			restartTime:  4095*time.Second + time.Nanosecond,
+			deferralTime: time.Minute,
+			expectError:  "GracefulRestartTime",
+		},
+		{
+			name:         "zero deferral time",
+			restartTime:  time.Minute,
+			deferralTime: 0,
+			expectError:  "GracefulRestartDeferralTime",
+		},
+		{
+			name:         "deferral time above maximum",
+			restartTime:  time.Minute,
+			deferralTime: 18*time.Hour + time.Nanosecond,
+			expectError:  "GracefulRestartDeferralTime",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Configuration{
+				GracefulRestartTime:         tt.restartTime,
+				GracefulRestartDeferralTime: tt.deferralTime,
+			}
+			err := config.checkGracefulRestartOptions()
+			if tt.expectError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.expectError)
+		})
+	}
+}
+
+func TestGetNeighborLocalAddress(t *testing.T) {
+	const neighbor = "192.0.2.1"
+	localAddress := net.ParseIP("192.0.2.10")
+
+	config := &Configuration{
+		NeighborLocalAddresses: map[string]net.IP{neighbor: localAddress},
+	}
+	require.True(t, localAddress.Equal(config.getNeighborLocalAddress(net.ParseIP(neighbor))))
+
+	config = &Configuration{
+		AllowedSourceAddresses: []net.IP{localAddress},
+		NeighborLocalAddresses: map[string]net.IP{},
+	}
+	require.PanicsWithValue(t,
+		"invariant violated: failed to determine local address for BGP neighbor 192.0.2.1: no allowed source address matched the whitelist",
+		func() { config.getNeighborLocalAddress(net.ParseIP(neighbor)) },
+	)
+}

--- a/pkg/speaker/config_additional_test.go
+++ b/pkg/speaker/config_additional_test.go
@@ -16,9 +16,20 @@ func TestCheckGracefulRestartOptions(t *testing.T) {
 		expectError  string
 	}{
 		{
-			name:         "valid boundary values",
+			name:         "valid lower boundary values",
+			restartTime:  time.Second,
+			deferralTime: time.Second,
+		},
+		{
+			name:         "valid upper boundary values",
 			restartTime:  4095 * time.Second,
 			deferralTime: 18 * time.Hour,
+		},
+		{
+			name:         "restart time below one second",
+			restartTime:  time.Second - time.Nanosecond,
+			deferralTime: time.Minute,
+			expectError:  "GracefulRestartTime",
 		},
 		{
 			name:         "zero restart time",
@@ -31,6 +42,12 @@ func TestCheckGracefulRestartOptions(t *testing.T) {
 			restartTime:  4095*time.Second + time.Nanosecond,
 			deferralTime: time.Minute,
 			expectError:  "GracefulRestartTime",
+		},
+		{
+			name:         "deferral time below one second",
+			restartTime:  time.Minute,
+			deferralTime: time.Second - time.Nanosecond,
+			expectError:  "GracefulRestartDeferralTime",
 		},
 		{
 			name:         "zero deferral time",

--- a/pkg/speaker/eip.go
+++ b/pkg/speaker/eip.go
@@ -46,6 +46,10 @@ func (c *Controller) syncEIPRoutes() error {
 
 // announceEIPs announce all the prefixes related to EIPs attached to a GW
 func (c *Controller) announceEIPs(eips []*v1.IptablesEIP) error {
+	return c.reconcileRoutes(collectEIPExpectedPrefixes(eips))
+}
+
+func collectEIPExpectedPrefixes(eips []*v1.IptablesEIP) prefixMap {
 	expectedPrefixes := make(prefixMap)
 	for _, eip := range eips {
 		// Only announce EIPs marked as "ready" and with the BGP annotation set to true
@@ -62,5 +66,5 @@ func (c *Controller) announceEIPs(eips []*v1.IptablesEIP) error {
 		}
 	}
 
-	return c.reconcileRoutes(expectedPrefixes)
+	return expectedPrefixes
 }

--- a/pkg/speaker/eip.go
+++ b/pkg/speaker/eip.go
@@ -46,10 +46,6 @@ func (c *Controller) syncEIPRoutes() error {
 
 // announceEIPs announce all the prefixes related to EIPs attached to a GW
 func (c *Controller) announceEIPs(eips []*v1.IptablesEIP) error {
-	return c.reconcileRoutes(collectEIPExpectedPrefixes(eips))
-}
-
-func collectEIPExpectedPrefixes(eips []*v1.IptablesEIP) prefixMap {
 	expectedPrefixes := make(prefixMap)
 	for _, eip := range eips {
 		// Only announce EIPs marked as "ready" and with the BGP annotation set to true
@@ -66,5 +62,5 @@ func collectEIPExpectedPrefixes(eips []*v1.IptablesEIP) prefixMap {
 		}
 	}
 
-	return expectedPrefixes
+	return c.reconcileRoutes(expectedPrefixes)
 }

--- a/pkg/speaker/eip_test.go
+++ b/pkg/speaker/eip_test.go
@@ -1,0 +1,52 @@
+package speaker
+
+import (
+	"testing"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestCollectEIPExpectedPrefixes(t *testing.T) {
+	eips := []*kubeovnv1.IptablesEIP{
+		{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.BgpAnnotation: "true"}},
+			Spec:       kubeovnv1.IptablesEIPSpec{V4ip: "192.0.2.10", V6ip: "2001:db8::10"},
+			Status:     kubeovnv1.IptablesEIPStatus{Ready: true},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.BgpAnnotation: "true"}},
+			Spec:       kubeovnv1.IptablesEIPSpec{V4ip: "192.0.2.11"},
+			Status:     kubeovnv1.IptablesEIPStatus{Ready: false},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.BgpAnnotation: "false"}},
+			Spec:       kubeovnv1.IptablesEIPSpec{V4ip: "192.0.2.12"},
+			Status:     kubeovnv1.IptablesEIPStatus{Ready: true},
+		},
+		{
+			Spec:   kubeovnv1.IptablesEIPSpec{V4ip: "192.0.2.13"},
+			Status: kubeovnv1.IptablesEIPStatus{Ready: true},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.BgpAnnotation: "true"}},
+			Spec:       kubeovnv1.IptablesEIPSpec{V4ip: "192.0.2.10"},
+			Status:     kubeovnv1.IptablesEIPStatus{Ready: true},
+		},
+	}
+
+	prefixes := collectEIPExpectedPrefixes(eips)
+	require.ElementsMatch(t, []string{"192.0.2.10/32"}, prefixes[api.Family_AFI_IP].UnsortedList())
+	require.ElementsMatch(t, []string{"2001:db8::10/128"}, prefixes[api.Family_AFI_IP6].UnsortedList())
+}
+
+func TestSyncEIPRoutesRequiresGatewayName(t *testing.T) {
+	t.Setenv(util.EnvGatewayName, "")
+
+	err := (&Controller{}).syncEIPRoutes()
+	require.ErrorContains(t, err, "failed to retrieve the name of the gateway")
+}

--- a/pkg/speaker/eip_test.go
+++ b/pkg/speaker/eip_test.go
@@ -1,6 +1,7 @@
 package speaker
 
 import (
+	"net"
 	"testing"
 
 	"github.com/osrg/gobgp/v4/api"
@@ -11,7 +12,25 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-func TestCollectEIPExpectedPrefixes(t *testing.T) {
+func TestAnnounceEIPsFiltersAndDeduplicatesPrefixes(t *testing.T) {
+	const (
+		routerID     = "192.0.2.10"
+		ipv4Neighbor = "192.0.2.1"
+		ipv6NextHop  = "2001:db8::10"
+		ipv6Neighbor = "2001:db8::1"
+	)
+
+	controller := &Controller{config: &Configuration{
+		RouterID:              net.ParseIP(routerID),
+		NeighborAddresses:     []net.IP{net.ParseIP(ipv4Neighbor)},
+		NeighborIPv6Addresses: []net.IP{net.ParseIP(ipv6Neighbor)},
+		NeighborLocalAddresses: map[string]net.IP{
+			ipv4Neighbor: net.ParseIP(routerID),
+			ipv6Neighbor: net.ParseIP(ipv6NextHop),
+		},
+		BgpServer: newTestBgpServer(t, routerID),
+	}}
+
 	eips := []*kubeovnv1.IptablesEIP{
 		{
 			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{util.BgpAnnotation: "true"}},
@@ -39,9 +58,19 @@ func TestCollectEIPExpectedPrefixes(t *testing.T) {
 		},
 	}
 
-	prefixes := collectEIPExpectedPrefixes(eips)
-	require.ElementsMatch(t, []string{"192.0.2.10/32"}, prefixes[api.Family_AFI_IP].UnsortedList())
-	require.ElementsMatch(t, []string{"2001:db8::10/128"}, prefixes[api.Family_AFI_IP6].UnsortedList())
+	require.NoError(t, controller.announceEIPs(eips))
+	ipv4Prefixes := listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
+	require.Len(t, ipv4Prefixes, 1)
+	require.Len(t, ipv4Prefixes["192.0.2.10/32"], 1)
+	require.True(t, net.ParseIP(routerID).Equal(ipv4Prefixes["192.0.2.10/32"][0]))
+
+	ipv6Prefixes := listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP6)
+	require.Len(t, ipv6Prefixes, 1)
+	require.Len(t, ipv6Prefixes["2001:db8::10/128"], 1)
+	require.True(t, net.ParseIP(ipv6NextHop).Equal(ipv6Prefixes["2001:db8::10/128"][0]))
+
+	require.NoError(t, controller.announceEIPs(nil))
+	require.Empty(t, listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP))
 }
 
 func TestSyncEIPRoutesRequiresGatewayName(t *testing.T) {

--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -1,0 +1,310 @@
+package bgp
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/netip"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e"
+	k8sframework "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/config"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+const (
+	frrRouterContainer  = "clab-bgp-router"
+	workerNode          = "kube-ovn-worker"
+	controlPlaneNextHop = "10.0.1.2"
+	workerNextHop       = "10.0.1.3"
+)
+
+type frrSummary struct {
+	Peers map[string]struct {
+		State string `json:"state"`
+	} `json:"peers"`
+}
+
+type frrRoute struct {
+	Paths []struct {
+		Valid    bool `json:"valid"`
+		Nexthops []struct {
+			IP string `json:"ip"`
+		} `json:"nexthops"`
+	} `json:"paths"`
+}
+
+type speakerPodState struct {
+	UID          string
+	RestartCount int32
+}
+
+func init() {
+	klog.SetOutput(ginkgo.GinkgoWriter)
+	config.CopyFlags(config.Flags, flag.CommandLine)
+	k8sframework.RegisterCommonFlags(flag.CommandLine)
+	k8sframework.RegisterClusterFlags(flag.CommandLine)
+}
+
+func TestE2E(t *testing.T) {
+	k8sframework.AfterReadingAllFlags(&k8sframework.TestContext)
+	e2e.RunE2ETests(t)
+}
+
+func runFRR(command string) ([]byte, error) {
+	cmd := exec.Command("docker", "exec", frrRouterContainer, "vtysh", "-c", command)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run FRR command %q: %w: %s", command, err, output)
+	}
+	return output, nil
+}
+
+func waitForBGPPeers() {
+	ginkgo.GinkgoHelper()
+	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		output, err := runFRR("show bgp ipv4 unicast summary json")
+		if err != nil {
+			framework.Logf("Failed to read FRR BGP summary: %v", err)
+			return false, nil
+		}
+		var summary frrSummary
+		if err = json.Unmarshal(output, &summary); err != nil {
+			framework.Logf("Failed to parse FRR BGP summary: %v; output=%s", err, output)
+			return false, nil
+		}
+		if len(summary.Peers) != 2 {
+			framework.Logf("Expected two FRR BGP peers, got %d; output=%s", len(summary.Peers), output)
+			return false, nil
+		}
+		for address, peer := range summary.Peers {
+			if peer.State != "Established" {
+				framework.Logf("FRR BGP peer %s is in state %s", address, peer.State)
+				return false, nil
+			}
+		}
+		return true, nil
+	}, "both BGP speaker peers to become Established")
+}
+
+func routeNextHops(prefix string) ([]string, error) {
+	output, err := runFRR("show bgp ipv4 unicast " + prefix + " json")
+	if err != nil {
+		return nil, err
+	}
+	var route frrRoute
+	if err = json.Unmarshal(output, &route); err != nil {
+		return nil, fmt.Errorf("failed to parse FRR route output for %s: %w: %s", prefix, err, output)
+	}
+
+	nextHops := make([]string, 0, len(route.Paths))
+	for _, path := range route.Paths {
+		if !path.Valid {
+			continue
+		}
+		for _, nextHop := range path.Nexthops {
+			if nextHop.IP != "" && !slices.Contains(nextHops, nextHop.IP) {
+				nextHops = append(nextHops, nextHop.IP)
+			}
+		}
+	}
+	slices.Sort(nextHops)
+	return nextHops, nil
+}
+
+func waitForRouteNextHops(prefix string, expected ...string) {
+	ginkgo.GinkgoHelper()
+	slices.Sort(expected)
+	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		nextHops, err := routeNextHops(prefix)
+		if err != nil {
+			return false, nil
+		}
+		return slices.Equal(nextHops, expected), nil
+	}, fmt.Sprintf("route %s to have next hops %v", prefix, expected))
+}
+
+func waitForRouteWithdrawal(prefix string) {
+	ginkgo.GinkgoHelper()
+	waitForRouteNextHops(prefix)
+}
+
+func ipv4Prefix(address string) string {
+	ginkgo.GinkgoHelper()
+	address = strings.TrimSpace(strings.Split(address, ",")[0])
+	if strings.Contains(address, "/") {
+		prefix, err := netip.ParsePrefix(address)
+		framework.ExpectNoError(err)
+		return prefix.Masked().String()
+	}
+	addr, err := netip.ParseAddr(address)
+	framework.ExpectNoError(err)
+	return netip.PrefixFrom(addr, addr.BitLen()).String()
+}
+
+func createPodOnNode(f *framework.Framework, name, nodeName string) (*corev1.Pod, string) {
+	ginkgo.GinkgoHelper()
+	pod := framework.MakePod(f.Namespace.Name, name, nil, nil, framework.AgnhostImage, nil, nil)
+	pod.Spec.NodeName = nodeName
+	pod = f.PodClient().CreateSync(pod)
+	pod = f.PodClient().GetPod(name)
+	return pod, ipv4Prefix(pod.Annotations[util.IPAddressAnnotation])
+}
+
+func setDefaultSubnetBGPPolicy(f *framework.Framework, policy string) string {
+	ginkgo.GinkgoHelper()
+	client := f.KubeOVNClientSet.KubeovnV1().Subnets()
+	subnet, err := client.Get(context.TODO(), util.DefaultSubnet, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	oldPolicy := subnet.Annotations[util.BgpAnnotation]
+	framework.WaitUntil(time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+		subnet, err = client.Get(ctx, util.DefaultSubnet, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		modified := subnet.DeepCopy()
+		if modified.Annotations == nil {
+			modified.Annotations = map[string]string{}
+		}
+		modified.Annotations[util.BgpAnnotation] = policy
+		_, err = client.Update(ctx, modified, metav1.UpdateOptions{})
+		return err == nil, nil
+	}, fmt.Sprintf("default subnet BGP policy to become %s", policy))
+	return oldPolicy
+}
+
+func defaultSubnetIPv4CIDR(f *framework.Framework) string {
+	ginkgo.GinkgoHelper()
+	subnet, err := f.KubeOVNClientSet.KubeovnV1().Subnets().Get(context.TODO(), util.DefaultSubnet, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	return ipv4Prefix(subnet.Spec.CIDRBlock)
+}
+
+func getSpeakerPodStates(f *framework.Framework) map[string]speakerPodState {
+	ginkgo.GinkgoHelper()
+	pods, err := f.ClientSet.CoreV1().Pods(framework.KubeOvnNamespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=kube-ovn-speaker",
+	})
+	framework.ExpectNoError(err)
+	gomega.Expect(pods.Items).To(gomega.HaveLen(2))
+
+	states := make(map[string]speakerPodState, len(pods.Items))
+	for _, pod := range pods.Items {
+		gomega.Expect(pod.Status.ContainerStatuses).To(gomega.HaveLen(1))
+		gomega.Expect(pod.Status.ContainerStatuses[0].Ready).To(gomega.BeTrue())
+		states[pod.Spec.NodeName] = speakerPodState{
+			UID:          string(pod.UID),
+			RestartCount: pod.Status.ContainerStatuses[0].RestartCount,
+		}
+	}
+	return states
+}
+
+func expectSpeakerPodsUnchanged(f *framework.Framework, expected map[string]speakerPodState) {
+	ginkgo.GinkgoHelper()
+	gomega.Expect(getSpeakerPodStates(f)).To(gomega.Equal(expected))
+}
+
+var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
+	f := framework.NewDefaultFramework("bgp-speaker")
+
+	ginkgo.BeforeEach(func() {
+		f.SkipVersionPriorTo(1, 13, "BGP local and cluster announce policies require v1.13+")
+		if !f.IsIPv4() {
+			ginkgo.Skip("the current BGP containerlab topology supports IPv4 only")
+		}
+		_ = getSpeakerPodStates(f)
+		waitForBGPPeers()
+	})
+
+	ginkgo.It("should advertise and withdraw a local Pod route", func() {
+		podName := "local-route-" + framework.RandomSuffix()
+		_, prefix := createPodOnNode(f, podName, workerNode)
+
+		ginkgo.By("Waiting for the worker speaker to advertise the Pod route")
+		waitForRouteNextHops(prefix, workerNextHop)
+
+		ginkgo.By("Deleting the Pod")
+		f.PodClient().DeleteSync(podName)
+
+		ginkgo.By("Waiting for the Pod route to be withdrawn")
+		waitForRouteWithdrawal(prefix)
+		waitForBGPPeers()
+	})
+
+	ginkgo.It("should reconcile cluster and local policies without restarting speakers", func() {
+		podName := "policy-route-" + framework.RandomSuffix()
+		_, podPrefix := createPodOnNode(f, podName, workerNode)
+		ginkgo.DeferCleanup(func() { f.PodClient().DeleteSync(podName) })
+		subnetPrefix := defaultSubnetIPv4CIDR(f)
+		initialSpeakers := getSpeakerPodStates(f)
+
+		ginkgo.By("Switching the default subnet to cluster policy")
+		oldPolicy := setDefaultSubnetBGPPolicy(f, "cluster")
+		ginkgo.DeferCleanup(func() { setDefaultSubnetBGPPolicy(f, oldPolicy) })
+		waitForRouteNextHops(podPrefix, controlPlaneNextHop, workerNextHop)
+		waitForRouteNextHops(subnetPrefix, controlPlaneNextHop, workerNextHop)
+
+		ginkgo.By("Switching the default subnet back to local policy")
+		setDefaultSubnetBGPPolicy(f, "local")
+		waitForRouteNextHops(podPrefix, workerNextHop)
+		waitForRouteWithdrawal(subnetPrefix)
+		expectSpeakerPodsUnchanged(f, initialSpeakers)
+	})
+
+	ginkgo.It("should advertise and withdraw an annotated ClusterIP Service", func() {
+		podName := "service-backend-" + framework.RandomSuffix()
+		serviceName := "bgp-service-" + framework.RandomSuffix()
+		labels := map[string]string{"app": serviceName}
+		pod := framework.MakePod(f.Namespace.Name, podName, labels, nil, framework.AgnhostImage, nil, nil)
+		pod.Spec.NodeName = workerNode
+		f.PodClient().CreateSync(pod)
+		ginkgo.DeferCleanup(func() { f.PodClient().DeleteSync(podName) })
+
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        serviceName,
+				Namespace:   f.Namespace.Name,
+				Annotations: map[string]string{util.BgpAnnotation: "true"},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: labels,
+				Ports: []corev1.ServicePort{{
+					Name: "http",
+					Port: 80,
+				}},
+			},
+		}
+		service, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(func() { f.ServiceClient().DeleteSync(serviceName) })
+		servicePrefix := ipv4Prefix(service.Spec.ClusterIP)
+
+		ginkgo.By("Waiting for both speakers to advertise the ClusterIP")
+		waitForRouteNextHops(servicePrefix, controlPlaneNextHop, workerNextHop)
+
+		ginkgo.By("Removing the BGP annotation while keeping the Service")
+		service = service.DeepCopy()
+		delete(service.Annotations, util.BgpAnnotation)
+		service, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+		framework.ExpectNoError(err)
+		waitForRouteWithdrawal(servicePrefix)
+
+		current, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		gomega.Expect(current.Spec.ClusterIP).To(gomega.Equal(service.Spec.ClusterIP))
+	})
+})

--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -28,8 +28,8 @@ import (
 const (
 	frrRouterContainer  = "clab-bgp-router"
 	workerNode          = "kube-ovn-worker"
-	controlPlaneNextHop = "10.0.1.2"
-	workerNextHop       = "10.0.1.3"
+	controlPlaneAddress = "10.0.1.2"
+	workerAddress       = "10.0.1.3"
 )
 
 type frrSummary struct {
@@ -40,11 +40,31 @@ type frrSummary struct {
 
 type frrRoute struct {
 	Paths []struct {
-		Valid    bool `json:"valid"`
+		PeerID   string `json:"peerId"`
+		Valid    bool   `json:"valid"`
 		Nexthops []struct {
 			IP string `json:"ip"`
 		} `json:"nexthops"`
 	} `json:"paths"`
+}
+
+type frrRoutePath struct {
+	PeerID  string
+	NextHop string
+	Valid   bool
+}
+
+func validNodeRoutePath(address string) frrRoutePath {
+	return frrRoutePath{PeerID: address, NextHop: address, Valid: true}
+}
+
+func sortRoutePaths(paths []frrRoutePath) {
+	slices.SortFunc(paths, func(a, b frrRoutePath) int {
+		if result := strings.Compare(a.PeerID, b.PeerID); result != 0 {
+			return result
+		}
+		return strings.Compare(a.NextHop, b.NextHop)
+	})
 }
 
 type speakerPodState struct {
@@ -73,34 +93,41 @@ func runFRR(command string) ([]byte, error) {
 	return output, nil
 }
 
+func bgpPeersEstablished() (bool, error) {
+	output, err := runFRR("show bgp ipv4 unicast summary json")
+	if err != nil {
+		return false, err
+	}
+	var summary frrSummary
+	if err = json.Unmarshal(output, &summary); err != nil {
+		return false, fmt.Errorf("failed to parse FRR BGP summary: %w: %s", err, output)
+	}
+	if len(summary.Peers) != 2 {
+		framework.Logf("Expected two FRR BGP peers, got %d; output=%s", len(summary.Peers), output)
+		return false, nil
+	}
+	for address, peer := range summary.Peers {
+		if peer.State != "Established" {
+			framework.Logf("FRR BGP peer %s is in state %s", address, peer.State)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 func waitForBGPPeers() {
 	ginkgo.GinkgoHelper()
 	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
-		output, err := runFRR("show bgp ipv4 unicast summary json")
+		established, err := bgpPeersEstablished()
 		if err != nil {
-			framework.Logf("Failed to read FRR BGP summary: %v", err)
+			framework.Logf("Failed to read FRR BGP peers: %v", err)
 			return false, nil
 		}
-		var summary frrSummary
-		if err = json.Unmarshal(output, &summary); err != nil {
-			framework.Logf("Failed to parse FRR BGP summary: %v; output=%s", err, output)
-			return false, nil
-		}
-		if len(summary.Peers) != 2 {
-			framework.Logf("Expected two FRR BGP peers, got %d; output=%s", len(summary.Peers), output)
-			return false, nil
-		}
-		for address, peer := range summary.Peers {
-			if peer.State != "Established" {
-				framework.Logf("FRR BGP peer %s is in state %s", address, peer.State)
-				return false, nil
-			}
-		}
-		return true, nil
+		return established, nil
 	}, "both BGP speaker peers to become Established")
 }
 
-func routeNextHops(prefix string) ([]string, error) {
+func readFRRRoute(prefix string) (*frrRoute, error) {
 	output, err := runFRR("show bgp ipv4 unicast " + prefix + " json")
 	if err != nil {
 		return nil, err
@@ -109,37 +136,62 @@ func routeNextHops(prefix string) ([]string, error) {
 	if err = json.Unmarshal(output, &route); err != nil {
 		return nil, fmt.Errorf("failed to parse FRR route output for %s: %w: %s", prefix, err, output)
 	}
+	return &route, nil
+}
 
-	nextHops := make([]string, 0, len(route.Paths))
+func routePaths(prefix string) ([]frrRoutePath, error) {
+	route, err := readFRRRoute(prefix)
+	if err != nil {
+		return nil, err
+	}
+	return routePathsFromRoute(route), nil
+}
+
+func routePathsFromRoute(route *frrRoute) []frrRoutePath {
+	paths := make([]frrRoutePath, 0, len(route.Paths))
 	for _, path := range route.Paths {
-		if !path.Valid {
-			continue
-		}
 		for _, nextHop := range path.Nexthops {
-			if nextHop.IP != "" && !slices.Contains(nextHops, nextHop.IP) {
-				nextHops = append(nextHops, nextHop.IP)
+			if nextHop.IP != "" {
+				paths = append(paths, frrRoutePath{PeerID: path.PeerID, NextHop: nextHop.IP, Valid: path.Valid})
 			}
 		}
 	}
-	slices.Sort(nextHops)
-	return nextHops, nil
+	sortRoutePaths(paths)
+	return paths
 }
 
-func waitForRouteNextHops(prefix string, expected ...string) {
+func waitForRoutePaths(prefix string, expected ...frrRoutePath) {
 	ginkgo.GinkgoHelper()
-	slices.Sort(expected)
+	sortRoutePaths(expected)
 	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
-		nextHops, err := routeNextHops(prefix)
+		paths, err := routePaths(prefix)
 		if err != nil {
+			framework.Logf("Failed to read FRR route %s: %v", prefix, err)
 			return false, nil
 		}
-		return slices.Equal(nextHops, expected), nil
-	}, fmt.Sprintf("route %s to have next hops %v", prefix, expected))
+		return slices.Equal(paths, expected), nil
+	}, fmt.Sprintf("route %s to have paths %v", prefix, expected))
 }
 
 func waitForRouteWithdrawal(prefix string) {
 	ginkgo.GinkgoHelper()
-	waitForRouteNextHops(prefix)
+	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		established, err := bgpPeersEstablished()
+		if err != nil {
+			framework.Logf("Failed to read FRR BGP peers while waiting for route %s withdrawal: %v", prefix, err)
+			return false, nil
+		}
+		if !established {
+			return false, nil
+		}
+
+		route, err := readFRRRoute(prefix)
+		if err != nil {
+			framework.Logf("Failed to read FRR route %s while waiting for withdrawal: %v", prefix, err)
+			return false, nil
+		}
+		return len(route.Paths) == 0, nil
+	}, fmt.Sprintf("route %s to be absent while both BGP peers remain Established", prefix))
 }
 
 func ipv4Prefix(address string) string {
@@ -165,23 +217,15 @@ func createPodOnNode(f *framework.Framework, name, nodeName string) (*corev1.Pod
 
 func setDefaultSubnetBGPPolicy(f *framework.Framework, policy string) string {
 	ginkgo.GinkgoHelper()
-	client := f.KubeOVNClientSet.KubeovnV1().Subnets()
-	subnet, err := client.Get(context.TODO(), util.DefaultSubnet, metav1.GetOptions{})
-	framework.ExpectNoError(err)
-	oldPolicy := subnet.Annotations[util.BgpAnnotation]
-	framework.WaitUntil(time.Second, time.Minute, func(ctx context.Context) (bool, error) {
-		subnet, err = client.Get(ctx, util.DefaultSubnet, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-		modified := subnet.DeepCopy()
-		if modified.Annotations == nil {
-			modified.Annotations = map[string]string{}
-		}
-		modified.Annotations[util.BgpAnnotation] = policy
-		_, err = client.Update(ctx, modified, metav1.UpdateOptions{})
-		return err == nil, nil
-	}, fmt.Sprintf("default subnet BGP policy to become %s", policy))
+	client := f.SubnetClient()
+	original := client.Get(util.DefaultSubnet)
+	oldPolicy := original.Annotations[util.BgpAnnotation]
+	modified := original.DeepCopy()
+	if modified.Annotations == nil {
+		modified.Annotations = map[string]string{}
+	}
+	modified.Annotations[util.BgpAnnotation] = policy
+	client.Patch(original, modified, time.Minute)
 	return oldPolicy
 }
 
@@ -192,7 +236,7 @@ func defaultSubnetIPv4CIDR(f *framework.Framework) string {
 	return ipv4Prefix(subnet.Spec.CIDRBlock)
 }
 
-func getSpeakerPodStates(f *framework.Framework) map[string]speakerPodState {
+func requireReadySpeakerPodStates(f *framework.Framework) map[string]speakerPodState {
 	ginkgo.GinkgoHelper()
 	pods, err := f.ClientSet.CoreV1().Pods(framework.KubeOvnNamespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app=kube-ovn-speaker",
@@ -214,7 +258,7 @@ func getSpeakerPodStates(f *framework.Framework) map[string]speakerPodState {
 
 func expectSpeakerPodsUnchanged(f *framework.Framework, expected map[string]speakerPodState) {
 	ginkgo.GinkgoHelper()
-	gomega.Expect(getSpeakerPodStates(f)).To(gomega.Equal(expected))
+	gomega.Expect(requireReadySpeakerPodStates(f)).To(gomega.Equal(expected))
 }
 
 var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
@@ -225,7 +269,7 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		if !f.IsIPv4() {
 			ginkgo.Skip("the current BGP containerlab topology supports IPv4 only")
 		}
-		_ = getSpeakerPodStates(f)
+		requireReadySpeakerPodStates(f)
 		waitForBGPPeers()
 	})
 
@@ -234,7 +278,7 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		_, prefix := createPodOnNode(f, podName, workerNode)
 
 		ginkgo.By("Waiting for the worker speaker to advertise the Pod route")
-		waitForRouteNextHops(prefix, workerNextHop)
+		waitForRoutePaths(prefix, validNodeRoutePath(workerAddress))
 
 		ginkgo.By("Deleting the Pod")
 		f.PodClient().DeleteSync(podName)
@@ -249,17 +293,23 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		_, podPrefix := createPodOnNode(f, podName, workerNode)
 		ginkgo.DeferCleanup(func() { f.PodClient().DeleteSync(podName) })
 		subnetPrefix := defaultSubnetIPv4CIDR(f)
-		initialSpeakers := getSpeakerPodStates(f)
+		initialSpeakers := requireReadySpeakerPodStates(f)
 
 		ginkgo.By("Switching the default subnet to cluster policy")
 		oldPolicy := setDefaultSubnetBGPPolicy(f, "cluster")
 		ginkgo.DeferCleanup(func() { setDefaultSubnetBGPPolicy(f, oldPolicy) })
-		waitForRouteNextHops(podPrefix, controlPlaneNextHop, workerNextHop)
-		waitForRouteNextHops(subnetPrefix, controlPlaneNextHop, workerNextHop)
+		waitForRoutePaths(podPrefix,
+			validNodeRoutePath(controlPlaneAddress),
+			validNodeRoutePath(workerAddress),
+		)
+		waitForRoutePaths(subnetPrefix,
+			validNodeRoutePath(controlPlaneAddress),
+			validNodeRoutePath(workerAddress),
+		)
 
 		ginkgo.By("Switching the default subnet back to local policy")
 		setDefaultSubnetBGPPolicy(f, "local")
-		waitForRouteNextHops(podPrefix, workerNextHop)
+		waitForRoutePaths(podPrefix, validNodeRoutePath(workerAddress))
 		waitForRouteWithdrawal(subnetPrefix)
 		expectSpeakerPodsUnchanged(f, initialSpeakers)
 	})
@@ -293,7 +343,10 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		servicePrefix := ipv4Prefix(service.Spec.ClusterIP)
 
 		ginkgo.By("Waiting for both speakers to advertise the ClusterIP")
-		waitForRouteNextHops(servicePrefix, controlPlaneNextHop, workerNextHop)
+		waitForRoutePaths(servicePrefix,
+			validNodeRoutePath(controlPlaneAddress),
+			validNodeRoutePath(workerAddress),
+		)
 
 		ginkgo.By("Removing the BGP annotation while keeping the Service")
 		original := serviceClient.Get(serviceName)

--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -160,7 +160,6 @@ func createPodOnNode(f *framework.Framework, name, nodeName string) (*corev1.Pod
 	pod := framework.MakePod(f.Namespace.Name, name, nil, nil, framework.AgnhostImage, nil, nil)
 	pod.Spec.NodeName = nodeName
 	pod = f.PodClient().CreateSync(pod)
-	pod = f.PodClient().GetPod(name)
 	return pod, ipv4Prefix(pod.Annotations[util.IPAddressAnnotation])
 }
 

--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -287,23 +287,22 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 				}},
 			},
 		}
-		service, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), service, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-		ginkgo.DeferCleanup(func() { f.ServiceClient().DeleteSync(serviceName) })
+		serviceClient := f.ServiceClient()
+		service = serviceClient.Create(service)
+		ginkgo.DeferCleanup(func() { serviceClient.DeleteSync(serviceName) })
 		servicePrefix := ipv4Prefix(service.Spec.ClusterIP)
 
 		ginkgo.By("Waiting for both speakers to advertise the ClusterIP")
 		waitForRouteNextHops(servicePrefix, controlPlaneNextHop, workerNextHop)
 
 		ginkgo.By("Removing the BGP annotation while keeping the Service")
-		service = service.DeepCopy()
-		delete(service.Annotations, util.BgpAnnotation)
-		service, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		original := serviceClient.Get(serviceName)
+		modified := original.DeepCopy()
+		delete(modified.Annotations, util.BgpAnnotation)
+		service = serviceClient.Patch(original, modified)
 		waitForRouteWithdrawal(servicePrefix)
 
-		current, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		current := serviceClient.Get(serviceName)
 		gomega.Expect(current.Spec.ClusterIP).To(gomega.Equal(service.Spec.ClusterIP))
 	})
 })

--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -38,35 +38,6 @@ type frrSummary struct {
 	} `json:"peers"`
 }
 
-type frrRoute struct {
-	Paths []struct {
-		PeerID   string `json:"peerId"`
-		Valid    bool   `json:"valid"`
-		Nexthops []struct {
-			IP string `json:"ip"`
-		} `json:"nexthops"`
-	} `json:"paths"`
-}
-
-type frrRoutePath struct {
-	PeerID  string
-	NextHop string
-	Valid   bool
-}
-
-func validNodeRoutePath(address string) frrRoutePath {
-	return frrRoutePath{PeerID: address, NextHop: address, Valid: true}
-}
-
-func sortRoutePaths(paths []frrRoutePath) {
-	slices.SortFunc(paths, func(a, b frrRoutePath) int {
-		if result := strings.Compare(a.PeerID, b.PeerID); result != 0 {
-			return result
-		}
-		return strings.Compare(a.NextHop, b.NextHop)
-	})
-}
-
 type speakerPodState struct {
 	UID          string
 	RestartCount int32
@@ -128,15 +99,7 @@ func waitForBGPPeers() {
 }
 
 func readFRRRoute(prefix string) (*frrRoute, error) {
-	output, err := runFRR("show bgp ipv4 unicast " + prefix + " json")
-	if err != nil {
-		return nil, err
-	}
-	var route frrRoute
-	if err = json.Unmarshal(output, &route); err != nil {
-		return nil, fmt.Errorf("failed to parse FRR route output for %s: %w: %s", prefix, err, output)
-	}
-	return &route, nil
+	return readFRRRouteWithRunner(prefix, runFRR)
 }
 
 func routePaths(prefix string) ([]frrRoutePath, error) {
@@ -147,29 +110,26 @@ func routePaths(prefix string) ([]frrRoutePath, error) {
 	return routePathsFromRoute(route), nil
 }
 
-func routePathsFromRoute(route *frrRoute) []frrRoutePath {
-	paths := make([]frrRoutePath, 0, len(route.Paths))
-	for _, path := range route.Paths {
-		for _, nextHop := range path.Nexthops {
-			if nextHop.IP != "" {
-				paths = append(paths, frrRoutePath{PeerID: path.PeerID, NextHop: nextHop.IP, Valid: path.Valid})
-			}
-		}
-	}
-	sortRoutePaths(paths)
-	return paths
-}
-
 func waitForRoutePaths(prefix string, expected ...frrRoutePath) {
 	ginkgo.GinkgoHelper()
 	sortRoutePaths(expected)
+	var lastObserved []frrRoutePath
+	haveObservation := false
 	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
 		paths, err := routePaths(prefix)
 		if err != nil {
 			framework.Logf("Failed to read FRR route %s: %v", prefix, err)
 			return false, nil
 		}
-		return slices.Equal(paths, expected), nil
+		if slices.Equal(paths, expected) {
+			return true, nil
+		}
+		if !haveObservation || !slices.Equal(paths, lastObserved) {
+			framework.Logf("FRR route %s has paths %v, waiting for %v", prefix, paths, expected)
+			lastObserved = slices.Clone(paths)
+			haveObservation = true
+		}
+		return false, nil
 	}, fmt.Sprintf("route %s to have paths %v", prefix, expected))
 }
 

--- a/test/e2e/bgp/frr.go
+++ b/test/e2e/bgp/frr.go
@@ -1,0 +1,68 @@
+package bgp
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type frrPath struct {
+	PeerID   string `json:"peerId"`
+	Valid    bool   `json:"valid"`
+	Nexthops []struct {
+		IP string `json:"ip"`
+	} `json:"nexthops"`
+}
+
+type frrRoute struct {
+	Paths []frrPath `json:"paths"`
+}
+
+type frrRIB struct {
+	Routes map[string][]frrPath `json:"routes"`
+}
+
+type frrRoutePath struct {
+	PeerID  string
+	NextHop string
+	Valid   bool
+}
+
+func validNodeRoutePath(address string) frrRoutePath {
+	return frrRoutePath{PeerID: address, NextHop: address, Valid: true}
+}
+
+func sortRoutePaths(paths []frrRoutePath) {
+	slices.SortFunc(paths, func(a, b frrRoutePath) int {
+		if result := strings.Compare(a.PeerID, b.PeerID); result != 0 {
+			return result
+		}
+		return strings.Compare(a.NextHop, b.NextHop)
+	})
+}
+
+func readFRRRouteWithRunner(prefix string, runner func(string) ([]byte, error)) (*frrRoute, error) {
+	output, err := runner("show bgp ipv4 unicast json")
+	if err != nil {
+		return nil, err
+	}
+	var rib frrRIB
+	if err = json.Unmarshal(output, &rib); err != nil {
+		return nil, fmt.Errorf("failed to parse FRR RIB output for %s: %w: %s", prefix, err, output)
+	}
+	return &frrRoute{Paths: rib.Routes[prefix]}, nil
+}
+
+func routePathsFromRoute(route *frrRoute) []frrRoutePath {
+	paths := make([]frrRoutePath, 0, len(route.Paths))
+	for _, path := range route.Paths {
+		for _, nextHop := range path.Nexthops {
+			if nextHop.IP != "" {
+				paths = append(paths, frrRoutePath{PeerID: path.PeerID, NextHop: nextHop.IP, Valid: path.Valid})
+			}
+		}
+	}
+	sortRoutePaths(paths)
+	return paths
+}

--- a/test/e2e/bgp/frr_test.go
+++ b/test/e2e/bgp/frr_test.go
@@ -33,3 +33,23 @@ func TestRoutePathsFromRoutePreservesPeerAndValidity(t *testing.T) {
 func TestRoutePathsFromRouteHandlesAbsentRoute(t *testing.T) {
 	require.Empty(t, routePathsFromRoute(&frrRoute{}))
 }
+
+func TestReadFRRRouteWithRunnerUsesFullRIBPeerMetadata(t *testing.T) {
+	const prefix = "10.16.0.8/32"
+	var command string
+	route, err := readFRRRouteWithRunner(prefix, func(cmd string) ([]byte, error) {
+		command = cmd
+		return []byte(`{
+			"routes": {
+				"10.16.0.8/32": [{
+					"peerId": "10.0.1.3",
+					"valid": true,
+					"nexthops": [{"ip": "10.0.1.3"}]
+				}]
+			}
+		}`), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "show bgp ipv4 unicast json", command)
+	require.Equal(t, []frrRoutePath{{PeerID: "10.0.1.3", NextHop: "10.0.1.3", Valid: true}}, routePathsFromRoute(route))
+}

--- a/test/e2e/bgp/frr_test.go
+++ b/test/e2e/bgp/frr_test.go
@@ -1,0 +1,35 @@
+package bgp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoutePathsFromRoutePreservesPeerAndValidity(t *testing.T) {
+	var route frrRoute
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"paths": [
+			{
+				"peerId": "10.0.1.3",
+				"valid": false,
+				"nexthops": [{"ip": "10.0.1.3"}]
+			},
+			{
+				"peerId": "10.0.1.2",
+				"valid": true,
+				"nexthops": [{"ip": "10.0.1.2"}]
+			}
+		]
+	}`), &route))
+
+	require.Equal(t, []frrRoutePath{
+		{PeerID: "10.0.1.2", NextHop: "10.0.1.2", Valid: true},
+		{PeerID: "10.0.1.3", NextHop: "10.0.1.3", Valid: false},
+	}, routePathsFromRoute(&route))
+}
+
+func TestRoutePathsFromRouteHandlesAbsentRoute(t *testing.T) {
+	require.Empty(t, routePathsFromRoute(&frrRoute{}))
+}


### PR DESCRIPTION
## What this PR does

Adds focused unit and end-to-end coverage for the classic `kube-ovn-speaker` BGP implementation.

### Unit tests

- exercise IPv4 route add/withdraw reconciliation against an in-memory GoBGP server
- verify IPv4, IPv6, and extended-nexthop path construction
- cover NEXT_HOP and MP_REACH_NLRI extraction
- cover EIP readiness/annotation filtering and deduplication through the production reconciliation path
- cover whole-second graceful-restart boundaries and reject sub-second values that would be truncated to zero by GoBGP
- cover reuse of the startup-selected cached neighbor source address

### End-to-end tests

Adds a serial IPv4 Ginkgo suite using the existing Kind + containerlab + FRR topology. It verifies:

- both speaker sessions become Established
- a local-policy Pod `/32` is learned from its hosting node with the exact expected nexthop and is withdrawn after Pod deletion
- switching `ovn-default` between `cluster` and `local` reconciles exact Pod/CIDR peer+nexthop paths without restarting speakers
- an annotated ClusterIP is advertised by both speakers and withdrawn when the annotation is removed
- FRR paths are read from the full IPv4 unicast RIB because FRR 9.1.3 omits `peerId` from prefix-specific JSON output

Withdrawal checks require the route path to be absent while both BGP sessions remain Established, so session loss or an invalid/stale retained path cannot produce a false pass.

The suite is wired into `e2e-build`, a dedicated Make target, and the x86 workflow. Failure artifacts include FRR summary/RIB output, speaker DaemonSet/Pod state and logs, events, audit logs, and `kubectl ko log`; setup failures upload an explicit unavailable marker when the cluster never becomes usable.

## Local verification

All local compile, test, and static-check commands ran with `MemoryMax=512M`:

- `go test ./pkg/speaker -count=1 -cover` (39.9%)
- `go test -race ./pkg/speaker -count=1`
- `go vet ./pkg/speaker`
- `go test test/e2e/bgp/frr.go test/e2e/bgp/frr_test.go -count=1`
- workflow YAML parse and BGP job wiring assertions
- `git diff --check`

The privileged Kind/containerlab E2E and repository `golangci-lint` are delegated to GitHub Actions.
