### PR TITLE
deps: update libovsdb to latest upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -294,7 +294,7 @@ replace (
 	github.com/mdlayher/arp => github.com/kubeovn/arp v0.0.0-20260528080449-dad82eb4dedd
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
-	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20260822084948-e3463a03300a
+	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20260822122319-7d52ac1264ec
 	k8s.io/api => k8s.io/api v0.36.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.36.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.36.4

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.43.0
 	github.com/osrg/gobgp/v4 v4.9.0
-	github.com/ovn-kubernetes/libovsdb v0.8.1
+	github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260710115425-adb4e0375fb5
 	github.com/parnurzeal/gorequest v0.3.0
 	github.com/prometheus-community/pro-bing v0.9.1
 	github.com/prometheus/client_golang v1.24.1
@@ -147,7 +147,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.30.2 // indirect
+	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
@@ -294,7 +294,6 @@ replace (
 	github.com/mdlayher/arp => github.com/kubeovn/arp v0.0.0-20260528080449-dad82eb4dedd
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
-	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20251212071713-cb1c2bc5d43e
 	k8s.io/api => k8s.io/api v0.36.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.36.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.36.4
@@ -315,7 +314,6 @@ replace (
 	k8s.io/endpointslice => k8s.io/endpointslice v0.36.4
 	k8s.io/externaljwt => k8s.io/externaljwt v0.36.4
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.36.4
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.36.4
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.36.4
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.36.4

--- a/go.mod
+++ b/go.mod
@@ -294,7 +294,7 @@ replace (
 	github.com/mdlayher/arp => github.com/kubeovn/arp v0.0.0-20260528080449-dad82eb4dedd
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
-	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20260822122319-7d52ac1264ec
+	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20260902074400-457a5d8cc172
 	k8s.io/api => k8s.io/api v0.36.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.36.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.36.4

--- a/go.mod
+++ b/go.mod
@@ -294,7 +294,7 @@ replace (
 	github.com/mdlayher/arp => github.com/kubeovn/arp v0.0.0-20260528080449-dad82eb4dedd
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
-	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20260817053248-db2b82416679
+	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20260822084948-e3463a03300a
 	k8s.io/api => k8s.io/api v0.36.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.36.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.36.4
@@ -315,6 +315,7 @@ replace (
 	k8s.io/endpointslice => k8s.io/endpointslice v0.36.4
 	k8s.io/externaljwt => k8s.io/externaljwt v0.36.4
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.36.4
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.36.4
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.36.4
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.36.4

--- a/go.mod
+++ b/go.mod
@@ -294,6 +294,7 @@ replace (
 	github.com/mdlayher/arp => github.com/kubeovn/arp v0.0.0-20260528080449-dad82eb4dedd
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
+	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20260817053248-db2b82416679
 	k8s.io/api => k8s.io/api v0.36.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.36.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.36.4

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92 h1:6x4
 github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92/go.mod h1:/SGJYGjOEAz+rw8JvkkbpcAyjQF1v4XPgpn1HqRg1fs=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2 h1:9r0zbCgxavpZ3DhNhiKA7wWWC6fpIAP2wTYKGyPrOD8=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2/go.mod h1:OB5Eqq9BM+N+L0nhSxTe8NuMLryhxxGQW21rSaImHjo=
-github.com/kubeovn/libovsdb v0.0.0-20260822122319-7d52ac1264ec h1:IFNe5ONoOLikvvk/NeT6lDlFSzjkWCRoNRvW8k+TqJg=
-github.com/kubeovn/libovsdb v0.0.0-20260822122319-7d52ac1264ec/go.mod h1:X8p5JMPYK5iKCyZ/RxFxvjl1sHfN7H9mo5UbtS5uImo=
+github.com/kubeovn/libovsdb v0.0.0-20260902074400-457a5d8cc172 h1:e8XTmu6psCshewB2CJau1bzLAJQ3czL3nNI4UFUEfyE=
+github.com/kubeovn/libovsdb v0.0.0-20260902074400-457a5d8cc172/go.mod h1:X8p5JMPYK5iKCyZ/RxFxvjl1sHfN7H9mo5UbtS5uImo=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475 h1:KZba2Kj9TXCUdUSqOR3eiy4VvkkIyhDVImYmYs6GQWU=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475/go.mod h1:LAd0qoeAAm/QyZcpxN2BnpndM2/dhZt+/kokPvcxKcE=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyPlUHk/ofpgvBcNcawJLtf4PYHORLjAA=
@@ -528,8 +528,6 @@ github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/osrg/gobgp/v4 v4.9.0 h1:pKOw914kwQ4I/lWNVTfEDosEN3FuqPGytMEInXxpTyQ=
 github.com/osrg/gobgp/v4 v4.9.0/go.mod h1:bJbFm7T2nRANggShfl3I9h0UpPCzu4uAY5J/6dTdRvs=
-github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260710115425-adb4e0375fb5 h1:YYN1tnlbI1WHmslGDQd+HZw2F6dnWieRGCGcHhdG/Vs=
-github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260710115425-adb4e0375fb5/go.mod h1:FE+0C838CfGFOuoCbsR3tcEAIY4Xxicu+Nhv19LA900=
 github.com/parnurzeal/gorequest v0.3.0 h1:SoFyqCDC9COr1xuS6VA8fC8RU7XyrJZN2ona1kEX7FI=
 github.com/parnurzeal/gorequest v0.3.0/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,8 @@ github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92 h1:6x4
 github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92/go.mod h1:/SGJYGjOEAz+rw8JvkkbpcAyjQF1v4XPgpn1HqRg1fs=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2 h1:9r0zbCgxavpZ3DhNhiKA7wWWC6fpIAP2wTYKGyPrOD8=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2/go.mod h1:OB5Eqq9BM+N+L0nhSxTe8NuMLryhxxGQW21rSaImHjo=
+github.com/kubeovn/libovsdb v0.0.0-20260817053248-db2b82416679 h1:6dKJagYbrT6W6/4EDJ7h3lwDtSijkyZjPnj2kFc2TVA=
+github.com/kubeovn/libovsdb v0.0.0-20260817053248-db2b82416679/go.mod h1:KmVSQM4r8CZND3GDXsBeJXGi9vlKTwkmQcsXdqhd3c4=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475 h1:KZba2Kj9TXCUdUSqOR3eiy4VvkkIyhDVImYmYs6GQWU=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475/go.mod h1:LAd0qoeAAm/QyZcpxN2BnpndM2/dhZt+/kokPvcxKcE=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyPlUHk/ofpgvBcNcawJLtf4PYHORLjAA=

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92 h1:6x4
 github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92/go.mod h1:/SGJYGjOEAz+rw8JvkkbpcAyjQF1v4XPgpn1HqRg1fs=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2 h1:9r0zbCgxavpZ3DhNhiKA7wWWC6fpIAP2wTYKGyPrOD8=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2/go.mod h1:OB5Eqq9BM+N+L0nhSxTe8NuMLryhxxGQW21rSaImHjo=
-github.com/kubeovn/libovsdb v0.0.0-20260822084948-e3463a03300a h1:GZ5KOPJO3Q4tiMPmRrJC5I8LdEGh+fYB2kLsTi2izjg=
-github.com/kubeovn/libovsdb v0.0.0-20260822084948-e3463a03300a/go.mod h1:KmVSQM4r8CZND3GDXsBeJXGi9vlKTwkmQcsXdqhd3c4=
+github.com/kubeovn/libovsdb v0.0.0-20260822122319-7d52ac1264ec h1:IFNe5ONoOLikvvk/NeT6lDlFSzjkWCRoNRvW8k+TqJg=
+github.com/kubeovn/libovsdb v0.0.0-20260822122319-7d52ac1264ec/go.mod h1:X8p5JMPYK5iKCyZ/RxFxvjl1sHfN7H9mo5UbtS5uImo=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475 h1:KZba2Kj9TXCUdUSqOR3eiy4VvkkIyhDVImYmYs6GQWU=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475/go.mod h1:LAd0qoeAAm/QyZcpxN2BnpndM2/dhZt+/kokPvcxKcE=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyPlUHk/ofpgvBcNcawJLtf4PYHORLjAA=

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92 h1:6x4
 github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92/go.mod h1:/SGJYGjOEAz+rw8JvkkbpcAyjQF1v4XPgpn1HqRg1fs=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2 h1:9r0zbCgxavpZ3DhNhiKA7wWWC6fpIAP2wTYKGyPrOD8=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2/go.mod h1:OB5Eqq9BM+N+L0nhSxTe8NuMLryhxxGQW21rSaImHjo=
-github.com/kubeovn/libovsdb v0.0.0-20260817053248-db2b82416679 h1:6dKJagYbrT6W6/4EDJ7h3lwDtSijkyZjPnj2kFc2TVA=
-github.com/kubeovn/libovsdb v0.0.0-20260817053248-db2b82416679/go.mod h1:KmVSQM4r8CZND3GDXsBeJXGi9vlKTwkmQcsXdqhd3c4=
+github.com/kubeovn/libovsdb v0.0.0-20260822084948-e3463a03300a h1:GZ5KOPJO3Q4tiMPmRrJC5I8LdEGh+fYB2kLsTi2izjg=
+github.com/kubeovn/libovsdb v0.0.0-20260822084948-e3463a03300a/go.mod h1:KmVSQM4r8CZND3GDXsBeJXGi9vlKTwkmQcsXdqhd3c4=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475 h1:KZba2Kj9TXCUdUSqOR3eiy4VvkkIyhDVImYmYs6GQWU=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475/go.mod h1:LAd0qoeAAm/QyZcpxN2BnpndM2/dhZt+/kokPvcxKcE=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyPlUHk/ofpgvBcNcawJLtf4PYHORLjAA=

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.30.2 h1:JiFIMtSSHb2/XBUbWM4i/MpeQm9ZK2xqPNk8vgvu5JQ=
-github.com/go-playground/validator/v10 v10.30.2/go.mod h1:mAf2pIOVXjTEBrwUMGKkCWKKPs9NheYGabeB04txQSc=
+github.com/go-playground/validator/v10 v10.30.3 h1:4MU6YkEwx7GbcPJOZxrtbu+QfF3pJLJuaYTeAH0DYy8=
+github.com/go-playground/validator/v10 v10.30.3/go.mod h1:4Axh7oCNGcoGkqLoE4YWt6n20mcEIsPRlB7vPk3lpyc=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
@@ -381,8 +381,6 @@ github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92 h1:6x4
 github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20260127125406-1297b522ba92/go.mod h1:/SGJYGjOEAz+rw8JvkkbpcAyjQF1v4XPgpn1HqRg1fs=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2 h1:9r0zbCgxavpZ3DhNhiKA7wWWC6fpIAP2wTYKGyPrOD8=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20260427030114-71d35a2bb8b2/go.mod h1:OB5Eqq9BM+N+L0nhSxTe8NuMLryhxxGQW21rSaImHjo=
-github.com/kubeovn/libovsdb v0.0.0-20251212071713-cb1c2bc5d43e h1:/DjPaByhzfDJcJ8A9jqoi16q/O1N5nGOHy9VmNZVnVM=
-github.com/kubeovn/libovsdb v0.0.0-20251212071713-cb1c2bc5d43e/go.mod h1:uqOuVsuGSJPoHDOS5O9VkJz/TIPm6Az/YZesHZ3qwDw=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475 h1:KZba2Kj9TXCUdUSqOR3eiy4VvkkIyhDVImYmYs6GQWU=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475/go.mod h1:LAd0qoeAAm/QyZcpxN2BnpndM2/dhZt+/kokPvcxKcE=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyPlUHk/ofpgvBcNcawJLtf4PYHORLjAA=
@@ -528,6 +526,8 @@ github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/osrg/gobgp/v4 v4.9.0 h1:pKOw914kwQ4I/lWNVTfEDosEN3FuqPGytMEInXxpTyQ=
 github.com/osrg/gobgp/v4 v4.9.0/go.mod h1:bJbFm7T2nRANggShfl3I9h0UpPCzu4uAY5J/6dTdRvs=
+github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260710115425-adb4e0375fb5 h1:YYN1tnlbI1WHmslGDQd+HZw2F6dnWieRGCGcHhdG/Vs=
+github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260710115425-adb4e0375fb5/go.mod h1:FE+0C838CfGFOuoCbsR3tcEAIY4Xxicu+Nhv19LA900=
 github.com/parnurzeal/gorequest v0.3.0 h1:SoFyqCDC9COr1xuS6VA8fC8RU7XyrJZN2ona1kEX7FI=
 github.com/parnurzeal/gorequest v0.3.0/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -44,7 +44,6 @@ const (
 	MaxFailCount                   = 3
 	maxDuplicateLeaderObservations = 3
 	northdDialTimeout              = 3 * time.Second
-	serverDatabaseName             = "_Server"
 )
 
 var failCount int
@@ -232,7 +231,7 @@ func isDBLeader(address, database string) (bool, error) {
 		return false, fmt.Errorf("unsupported database %s", database)
 	}
 
-	result, err := ovs.Query(dbAddr, serverDatabaseName, 1, ovsdb.Operation{
+	result, err := ovs.Query(dbAddr, serverdb.DatabaseName, 1, ovsdb.Operation{
 		Op:    ovsdb.OperationSelect,
 		Table: serverdb.DatabaseTable,
 		Where: []ovsdb.Condition{{

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -44,6 +44,7 @@ const (
 	MaxFailCount                   = 3
 	maxDuplicateLeaderObservations = 3
 	northdDialTimeout              = 3 * time.Second
+	serverDatabaseName             = "_Server"
 )
 
 var failCount int
@@ -231,7 +232,7 @@ func isDBLeader(address, database string) (bool, error) {
 		return false, fmt.Errorf("unsupported database %s", database)
 	}
 
-	result, err := ovs.Query(dbAddr, serverdb.DatabaseName, 1, ovsdb.Operation{
+	result, err := ovs.Query(dbAddr, serverDatabaseName, 1, ovsdb.Operation{
 		Op:    ovsdb.OperationSelect,
 		Table: serverdb.DatabaseTable,
 		Where: []ovsdb.Condition{{

--- a/pkg/ovs/ovn-nb-logical_router_policy.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy.go
@@ -488,7 +488,9 @@ func (c *OVNNbClient) listLogicalRouterPoliciesByFilter(lrName string, filter fu
 	}
 
 	policyList := make([]*ovnnb.LogicalRouterPolicy, 0, len(lr.Policies))
-	if err = c.WhereCache(predicate).List(context.Background(), &policyList); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	if err := c.WhereCache(predicate).List(ctx, &policyList); err != nil {
 		klog.Error(err)
 		return nil, err
 	}

--- a/pkg/ovs/ovn-nb-logical_router_route.go
+++ b/pkg/ovs/ovn-nb-logical_router_route.go
@@ -476,7 +476,9 @@ func (c *OVNNbClient) listLogicalRouterStaticRoutesByFilter(lrName string, filte
 	}
 
 	routeList := make([]*ovnnb.LogicalRouterStaticRoute, 0, len(lr.StaticRoutes))
-	if err = c.WhereCache(predicate).List(context.Background(), &routeList); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	if err := c.WhereCache(predicate).List(ctx, &routeList); err != nil {
 		klog.Error(err)
 		return nil, err
 	}

--- a/pkg/ovs/ovn-nb-nat.go
+++ b/pkg/ovs/ovn-nb-nat.go
@@ -546,7 +546,9 @@ func (c *OVNNbClient) listLogicalRouterNatByFilter(lrName string, filter func(ro
 	}
 
 	natList := make([]*ovnnb.NAT, 0, len(lr.Nat))
-	if err = c.WhereCache(predicate).List(context.Background(), &natList); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	if err := c.WhereCache(predicate).List(ctx, &natList); err != nil {
 		klog.Error(err)
 		return nil, err
 	}


### PR DESCRIPTION
## What type of PR is this?

/kind dependency
/kind cleanup

## What this PR does / why we need it

Update `github.com/ovn-kubernetes/libovsdb` from the old Kube-OVN fork baseline at `cb1c2bc5d43e` to the latest upstream `main` commit, `adb4e0375fb531a6fbbb3a669b55cc046c994b2f`.

Kube-OVN still requires bounded failover when an established OVSDB endpoint loses its network path or power. Therefore this PR keeps a focused `replace` to `kubeovn/libovsdb@db2b82416679` rather than replaying the old fork wholesale. In kubeovn/libovsdb#5, the current fork `main` first merges upstream `main`, then appends this single tested failover patch commit:

- set Linux `TCP_USER_TIMEOUT` on plain TCP and the underlying socket of TLS connections;
- rotate the endpoint that actually disconnected while preserving runtime `UpdateEndpoints` ordering;
- budget reconnect time per endpoint so one blackholed address cannot starve later healthy endpoints;
- clear connected state immediately on disconnect and reject non-positive reconnect timeouts;
- exercise TCP and TLS active-endpoint blackholes, inactivity probes, and a blackholed standby endpoint in an isolated network namespace.

The focused libovsdb change is tracked in:

- kubeovn/libovsdb#5 — fork synchronization and downstream pin
- ovn-kubernetes/libovsdb#492 — upstream proposal

## Fork review outcome

The other fork-only changes are intentionally not replayed:

- current upstream provides broader cache-consistency handling for `Get`, `List`, and conditional `Where*().List()` reads;
- the fork-only `WherePredict` API is unused by Kube-OVN;
- the previous TCP callback could overwrite the actual socket-option error and did not affect TLS;
- the previous per-endpoint reconnect implementation ignored caller cancellation and mishandled zero timeouts;
- modelgen enum and database-name differences remain separate from this runtime dependency update.

Compatibility adjustments in Kube-OVN:

- define the stable `_Server` database name locally instead of relying on the fork-only `serverdb.DatabaseName`;
- bound three previously unbounded conditional cache reads with the configured OVN client timeout, because current upstream waits for cache consistency at `List()` time.

## Which issue(s) this PR fixes

None.

## Special notes for your reviewer

The latest published libovsdb release remains `v0.8.1`; the required module stays at the latest upstream pseudo-version `v0.8.2-0.20260710115425-adb4e0375fb5`, with the focused failover commit supplied by the temporary fork replacement. The replacement can be removed after the upstream change is merged and released.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Tests

Kube-OVN:

- `go test ./pkg/ovn_leader_checker -count=1`
- `go test ./pkg/ovs -run '^TestOvnClientTestSuite$' -count=1`
- compile checks for `pkg/ovn_leader_checker`, `pkg/ovsdb/...`, `pkg/pinger`, `pkg/ovnmonitor`, and `pkg/apis/kubeovn/v1`
- `go vet ./pkg/ovn_leader_checker ./pkg/ovsdb/... ./pkg/ovs`
- `go mod verify`
- `git diff --check`

libovsdb:

- `go test -race ./client -count=1`
- isolated network namespace blackhole tests with `LIBOVSDB_TEST_NETWORK_BLACKHOLE=1`
- TCP and TLS active blackhole, inactivity, and blackholed standby scenarios
- `go vet ./client`
- `go mod verify`
- Darwin client cross-compilation
- final focused Standards/Spec review: no findings

Local `golangci-lint` execution is prohibited by the workspace resource policy; GitHub CI is the lint authority for this PR.
