### PR TITLE
ci: enable selective x86 E2E execution

### DIFF
--- a/.github/e2e-selection.json
+++ b/.github/e2e-selection.json
@@ -25,7 +25,6 @@
     "charts/**",
     "hack/ci-check-crash.sh",
     "hack/gen-crd.sh",
-    "hack/go-list.sh",
     "hack/update-codegen.sh",
     "hack/mockgen.sh",
     "hack/modelgen.sh",

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1,6 +1,6 @@
 name: Build x86 Image
 
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('x86-e2e pr={0} head={1} approval={2} generation={3} groups={4} full={5}', inputs.prNumber, inputs.headSHA, inputs.approvalGeneration, inputs.dispatchGeneration, inputs.requestedGroupNames, inputs.full && '1' || '0') || '' }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('x86-e2e pr={0} head={1} approval={2} generation={3} mode={4} groups={5} labels={6} full={7}', inputs.prNumber, inputs.headSHA, inputs.approvalGeneration, inputs.dispatchGeneration, inputs.automatic && 'automatic' || 'approved', inputs.requestedGroupNames, inputs.controlledLabelNames, inputs.full && '1' || '0') || '' }}
 
 permissions:
   contents: read
@@ -56,6 +56,11 @@ on:
         description: Durable authorized comment generation
         required: true
         type: number
+      automatic:
+        description: Execute automatic smoke or fail-closed full coverage
+        required: true
+        default: false
+        type: boolean
       dispatchGeneration:
         description: Unique trusted reducer run generation
         required: true
@@ -67,6 +72,16 @@ on:
         type: string
       requestedGroupNames:
         description: Canonical comma-separated groups, or a single dash
+        required: true
+        default: '-'
+        type: string
+      controlledLabels:
+        description: JSON array of trusted persistent E2E labels
+        required: true
+        default: '[]'
+        type: string
+      controlledLabelNames:
+        description: Canonical comma-separated controlled labels, or a single dash
         required: true
         default: '-'
         type: string
@@ -114,6 +129,7 @@ jobs:
       k8sConformanceMatrix: ${{ steps.outputs.outputs.k8sConformanceMatrix || steps.fallbackMatrices.outputs.k8sConformanceMatrix }}
       kubeOvnConformanceMatrix: ${{ steps.outputs.outputs.kubeOvnConformanceMatrix || steps.fallbackMatrices.outputs.kubeOvnConformanceMatrix }}
       headSHA: ${{ steps.context.outputs.headSHA }}
+      baseSHA: ${{ steps.context.outputs.baseSHA }}
       prNumber: ${{ steps.context.outputs.prNumber }}
     steps:
       - uses: actions/checkout@v7
@@ -136,6 +152,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_HEAD_SHA: ${{ inputs.headSHA }}
           INPUT_BASE_SHA: ${{ inputs.baseSHA }}
+          INPUT_AUTOMATIC: ${{ inputs.automatic }}
+          INPUT_CONTROLLED_LABELS: ${{ inputs.controlledLabels }}
+          INPUT_CONTROLLED_LABEL_NAMES: ${{ inputs.controlledLabelNames }}
           INPUT_PR_NUMBER: ${{ inputs.prNumber }}
           INPUT_REQUESTED_GROUPS: ${{ inputs.requestedGroups }}
           INPUT_REQUESTED_GROUP_NAMES: ${{ inputs.requestedGroupNames }}
@@ -152,6 +171,7 @@ jobs:
           forceFullReason=''
           requestedGroups='[]'
           headSHA="$GITHUB_SHA"
+          baseSHA="$GITHUB_SHA"
           prNumber=0
           checkedOutSHA=$(git rev-parse HEAD)
           if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$checkedOutSHA" != "$INPUT_BASE_SHA" ]; then
@@ -185,11 +205,13 @@ jobs:
           Path("selector-event.json").write_text(json.dumps(event))
           PY
             headSHA="$PR_HEAD_SHA"
+            baseSHA="$PR_BASE_SHA"
             prNumber="$PR_NUMBER"
           elif [ "$EVENT_NAME" = workflow_dispatch ]; then
             gh api "repos/$GITHUB_REPOSITORY/pulls/$INPUT_PR_NUMBER" > pull-request.json
             python3 - "$INPUT_HEAD_SHA" "$INPUT_BASE_SHA" "$GITHUB_REF_NAME" "$GITHUB_SHA" <<'PY'
           import json
+          import os
           import re
           import sys
           from pathlib import Path
@@ -207,7 +229,14 @@ jobs:
               raise SystemExit("executor must run from the pull request base branch")
           if sys.argv[4] != sys.argv[2]:
               raise SystemExit("executor workflow revision does not match the approved base")
-          pullRequest["labels"] = []
+          controlledLabels = json.loads(os.environ["INPUT_CONTROLLED_LABELS"])
+          if not isinstance(controlledLabels, list) or any(
+              not isinstance(label, str) for label in controlledLabels
+          ):
+              raise SystemExit("controlledLabels must be a JSON array of strings")
+          if os.environ["INPUT_AUTOMATIC"] != "true":
+              controlledLabels = []
+          pullRequest["labels"] = [{"name": label} for label in controlledLabels]
           Path("selector-event.json").write_text(json.dumps({"pull_request": pullRequest}))
           PY
             gh api --paginate --slurp \
@@ -237,7 +266,7 @@ jobs:
             if [ -s force-full-reason.txt ]; then
               forceFullReason=$(cat force-full-reason.txt)
             fi
-            python3 - "$INPUT_REQUESTED_GROUPS" "$INPUT_REQUESTED_GROUP_NAMES" "$INPUT_CATALOG_REVISION" <<'PY'
+            python3 - "$INPUT_REQUESTED_GROUPS" "$INPUT_REQUESTED_GROUP_NAMES" "$INPUT_CATALOG_REVISION" "$INPUT_CONTROLLED_LABELS" "$INPUT_CONTROLLED_LABEL_NAMES" "$INPUT_AUTOMATIC" "$INPUT_FULL" <<'PY'
           import hashlib
           import json
           import sys
@@ -259,8 +288,25 @@ jobs:
           canonical = ",".join(canonicalGroups) or "-"
           if canonical != sys.argv[2]:
               raise SystemExit("requested group names do not match requestedGroups")
+          labels = json.loads(sys.argv[4])
+          knownLabels = {"e2e:full"} | {f"e2e:{group}" for group in catalog["groups"]}
+          if (
+              not isinstance(labels, list)
+              or any(not isinstance(label, str) for label in labels)
+              or set(labels) - knownLabels
+          ):
+              raise SystemExit("controlledLabels contains an unknown label")
+          canonicalLabels = ",".join(sorted(set(labels))) or "-"
+          if canonicalLabels != sys.argv[5]:
+              raise SystemExit("controlled label names do not match controlledLabels")
+          automatic = sys.argv[6] == "true"
+          if automatic and (canonicalGroups or sys.argv[7] == "true"):
+              raise SystemExit("automatic execution cannot contain an approved request")
+          if not automatic and labels:
+              raise SystemExit("approved execution cannot carry automatic controlled labels")
           PY
             headSHA="$INPUT_HEAD_SHA"
+            baseSHA="$INPUT_BASE_SHA"
             prNumber="$INPUT_PR_NUMBER"
             requestedGroups="$INPUT_REQUESTED_GROUPS"
             requestFull="$INPUT_FULL"
@@ -268,6 +314,7 @@ jobs:
             forceFullReason='push events always run the full x86 E2E suite'
           fi
           echo "headSHA=$headSHA" >> "$GITHUB_OUTPUT"
+          echo "baseSHA=$baseSHA" >> "$GITHUB_OUTPUT"
           echo "prNumber=$prNumber" >> "$GITHUB_OUTPUT"
           echo "requestFull=$requestFull" >> "$GITHUB_OUTPUT"
           echo "forceFullReason=$forceFullReason" >> "$GITHUB_OUTPUT"
@@ -285,6 +332,8 @@ jobs:
             --event-file selector-event.json
             --request-groups-json "$REQUESTED_GROUPS"
             --head-sha "$HEAD_SHA"
+            --base-sha "${{ steps.context.outputs.baseSHA }}"
+            --pr-number "${{ steps.context.outputs.prNumber }}"
             --force-full-reason "$FORCE_FULL_REASON"
             --plan-file e2e-selection-plan.json
             --summary-file e2e-selection-summary.md
@@ -297,7 +346,7 @@ jobs:
       - name: Export executor job IDs
         id: outputs
         env:
-          EVENT_NAME: ${{ github.event_name }}
+          EVENT_NAME: ${{ inputs.automatic && 'pull_request' || github.event_name }}
         run: |
           python3 - <<'PY'
           import json
@@ -364,6 +413,44 @@ jobs:
 
       - name: Run control module tests
         run: python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py
+
+  prepare-kind-node-images:
+    name: Prepare private Kind node image (${{ matrix.k8s-version }})
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||
+      github.event_name == 'push'
+    needs: e2e-selection
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version:
+          - v1.36.1
+          - v1.29.14
+    steps:
+      - name: Pull private Kind node image with trusted token
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          K8S_VERSION: ${{ matrix.k8s-version }}
+        run: |
+          set -euo pipefail
+          dockerConfig=$(mktemp -d)
+          trap 'rm -rf "$dockerConfig"' EXIT
+          export DOCKER_CONFIG="$dockerConfig"
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u github-actions --password-stdin
+          docker pull "ghcr.io/kubeovn/kindest-node:$K8S_VERSION"
+          docker tag "ghcr.io/kubeovn/kindest-node:$K8S_VERSION" "kindest/node:$K8S_VERSION"
+          docker save "kindest/node:$K8S_VERSION" -o "kind-node-$K8S_VERSION.tar"
+
+      - name: Upload private Kind node image without credentials
+        uses: actions/upload-artifact@v7
+        with:
+          name: kind-node-${{ matrix.k8s-version }}
+          path: kind-node-${{ matrix.k8s-version }}.tar
+          retention-days: 2
 
   build-kube-ovn-base:
     name: Build kube-ovn-base
@@ -497,6 +584,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn-base
       - build-kube-ovn-dpdk-base
     steps:
@@ -897,12 +985,18 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          make kind-init-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         id: install
@@ -1102,12 +1196,18 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          make kind-init-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         id: install
@@ -1274,12 +1374,18 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          make kind-init-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         env:
@@ -1463,12 +1569,18 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          make kind-init-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         id: install
@@ -1657,9 +1769,15 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Create kind clusters
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
+      - name: Create kind cluster
         run: |
           pipx install jinjanator
           make kind-init-ovn-ic-${{ matrix.ip-family }}
@@ -1822,12 +1940,18 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          make kind-init-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         id: install
@@ -1985,12 +2109,18 @@ jobs:
           docker load --input kube-ovn.tar
           docker load --input vpc-nat-gateway.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          make kind-init-${{ matrix.ip-family }}
 
       - name: Load vpc-nat-gateway image into kind cluster
         run: make kind-load-image-vpc-nat-gateway
@@ -2135,13 +2265,19 @@ jobs:
       - name: Load kube-ovn image
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create BGP kind and containerlab topology
         id: setup
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-bgp
+          make kind-init-bgp
 
       - name: Install Kube-OVN and BGP speakers
         id: install
@@ -2407,12 +2543,18 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN
         id: install
@@ -2479,12 +2621,18 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-dual
+          make kind-init-dual
 
       - name: Install Kube-OVN
         id: install
@@ -2549,12 +2697,18 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN without LoadBalancer
         id: install
@@ -2621,12 +2775,18 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN
         id: install
@@ -2744,12 +2904,18 @@ jobs:
           docker load -i kube-ovn.tar
           docker load -i vpc-nat-gateway.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Multus and Kube-OVN
         id: install
@@ -2889,12 +3055,18 @@ jobs:
         run: |
           docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN with webhook
         id: install
@@ -2969,13 +3141,20 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.29.14
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.29.14.tar
+
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
           K8S_VERSION: ${{ matrix.k8s-version }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN
         id: install
@@ -3189,12 +3368,18 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          make kind-init-${{ matrix.ip-family }}
 
       - name: Clone DNSNameResolver repository
         run: |
@@ -3343,12 +3528,18 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          make kind-init-${{ matrix.ip-family }}
 
       - name: Clone DNSNameResolver repository
         run: |
@@ -3506,12 +3697,18 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-cilium-chaining-${{ matrix.ip-family }}
+          make kind-init-cilium-chaining-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN with Cilium chaining
         id: install
@@ -3669,12 +3866,18 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-ha-${{ matrix.ip-family }}
+          make kind-init-ha-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         id: install
@@ -3784,12 +3987,18 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init-ovn-submariner
+          make kind-init-ovn-submariner
 
       - name: Install Kube-OVN and Submariner
         id: install
@@ -3910,12 +4119,18 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          n_worker=2 make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          n_worker=2 make kind-init-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         id: install
@@ -4101,12 +4316,18 @@ jobs:
           docker load -i kube-ovn.tar
           docker load -i vpc-nat-gateway.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN with VPC NAT gateway enabled
         id: install
@@ -4245,12 +4466,18 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN
         id: install
@@ -4396,12 +4623,18 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN
         id: install
@@ -4542,12 +4775,18 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN
         id: install
@@ -4692,12 +4931,18 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN
         id: install
@@ -4812,12 +5057,18 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          n_worker=2 make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
+          n_worker=2 make kind-init-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN
         id: install
@@ -4957,12 +5208,18 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.36.1
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.36.1.tar
+
       - name: Create kind cluster
-        env:
-          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
-          make kind-ghcr-pull kind-init
+          make kind-init
 
       - name: Install Kube-OVN
         id: install
@@ -5021,7 +5278,7 @@ jobs:
 
   e2e-executor-result:
     name: x86 E2E Selected Result
-    if: always()
+    if: always() && github.event_name != 'pull_request'
     permissions: {}
     needs:
       - e2e-selection

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -89,6 +89,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  EXECUTION_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
   # renovate: datasource=github-releases depName=kind packageName=kubernetes-sigs/kind
   KIND_VERSION: v0.32.0
   # renovate: datasource=github-releases depName=golangci-lint packageName=golangci/golangci-lint
@@ -309,7 +310,8 @@ jobs:
 
           try:
               catalog = e2eSelector.loadCatalog(".github/e2e-selection.json")
-          except Exception:
+          except Exception as error:
+              print(f"failed to reload the E2E catalog: {error}", file=sys.stderr)
               catalog = None
           plan = json.loads(Path("e2e-selection-plan.json").read_text())
           executionPlan = e2eSelector.executionPlan(catalog, plan, os.environ["EVENT_NAME"])
@@ -337,9 +339,6 @@ jobs:
           PY
           cat e2e-selection-summary.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Validate the E2E control modules
-        run: python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py
-
       - name: Upload the selection plan
         if: always()
         uses: actions/upload-artifact@v7
@@ -351,6 +350,21 @@ jobs:
             e2e-selection-summary.md
           retention-days: 30
 
+  e2e-control-validation:
+    name: Validate x86 E2E control modules
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'github-actions[bot]'
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSHA || github.sha }}
+          persist-credentials: false
+
+      - name: Run control module tests
+        run: python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py
+
   build-kube-ovn-base:
     name: Build kube-ovn-base
     if: github.event_name != 'workflow_dispatch' || github.actor == 'github-actions[bot]'
@@ -360,7 +374,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
           fetch-depth: 0
 
@@ -431,7 +445,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
           fetch-depth: 0
 
@@ -498,7 +512,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
       - uses: docker/setup-buildx-action@v4
       - uses: actions/setup-go@v7
@@ -689,7 +703,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Build
@@ -712,7 +726,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -811,7 +825,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1014,7 +1028,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1214,7 +1228,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1382,7 +1396,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1584,7 +1598,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1749,7 +1763,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1902,7 +1916,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -2062,7 +2076,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -2232,7 +2246,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Remove DNS search domain
@@ -2376,7 +2390,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Install kind
@@ -2448,7 +2462,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Install kind
@@ -2518,7 +2532,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Install kind
@@ -2590,7 +2604,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Install kind
@@ -2664,7 +2678,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -2815,7 +2829,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -2938,7 +2952,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Install kind
@@ -3019,7 +3033,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Install talosctl
@@ -3110,7 +3124,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3264,7 +3278,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3421,7 +3435,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
       - uses: azure/setup-helm@v5.0.1
         with:
@@ -3596,7 +3610,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3726,7 +3740,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3837,7 +3851,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4021,7 +4035,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4172,7 +4186,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4323,7 +4337,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4469,7 +4483,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4619,7 +4633,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4739,7 +4753,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4884,7 +4898,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -5011,6 +5025,7 @@ jobs:
     permissions: {}
     needs:
       - e2e-selection
+      - e2e-control-validation
       - bgp-speaker-e2e
       - chart-test
       - cilium-chaining-e2e
@@ -5054,14 +5069,15 @@ jobs:
 
           needs = json.loads(os.environ["NEEDS_JSON"])
           selectedJobIds = json.loads(os.environ["SELECTED_JOB_IDS"])
+          requiredJobIds = ["e2e-selection", "e2e-control-validation"] + selectedJobIds
           incomplete = {
               jobId: needs.get(jobId, {}).get("result", "missing")
-              for jobId in selectedJobIds
+              for jobId in requiredJobIds
               if needs.get(jobId, {}).get("result") != "success"
           }
           if incomplete:
-              raise SystemExit(f"selected x86 E2E Jobs did not succeed: {incomplete}")
-          print(f"Verified {len(selectedJobIds)} selected x86 E2E Jobs.")
+              raise SystemExit(f"required x86 E2E Jobs did not succeed: {incomplete}")
+          print(f"Verified {len(requiredJobIds)} required x86 E2E Jobs.")
           PY
 
   push:
@@ -5083,7 +5099,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+          ref: ${{ env.EXECUTION_SHA }}
           persist-credentials: false
 
       - name: Download kube-ovn image

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -104,7 +104,6 @@ jobs:
   e2e-selection:
     name: x86 E2E Selection
     if: github.event_name != 'workflow_dispatch' || github.actor == 'github-actions[bot]'
-    continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.token || '' }}
@@ -148,7 +147,7 @@ jobs:
           set -euo pipefail
           printf '{}' > selector-event.json
           : > changed-paths.txt
-          forceFull=false
+          requestFull=false
           forceFullReason=''
           requestedGroups='[]'
           headSHA="$GITHUB_SHA"
@@ -263,21 +262,21 @@ jobs:
             headSHA="$INPUT_HEAD_SHA"
             prNumber="$INPUT_PR_NUMBER"
             requestedGroups="$INPUT_REQUESTED_GROUPS"
-            forceFull="$INPUT_FULL"
+            requestFull="$INPUT_FULL"
           else
-            forceFull=true
+            forceFullReason='push events always run the full x86 E2E suite'
           fi
           echo "headSHA=$headSHA" >> "$GITHUB_OUTPUT"
           echo "prNumber=$prNumber" >> "$GITHUB_OUTPUT"
-          echo "forceFull=$forceFull" >> "$GITHUB_OUTPUT"
+          echo "requestFull=$requestFull" >> "$GITHUB_OUTPUT"
           echo "forceFullReason=$forceFullReason" >> "$GITHUB_OUTPUT"
           echo "requestedGroups=$requestedGroups" >> "$GITHUB_OUTPUT"
 
       - name: Compute the selection plan
         env:
-          FORCE_FULL: ${{ steps.context.outputs.forceFull }}
           FORCE_FULL_REASON: ${{ steps.context.outputs.forceFullReason }}
           HEAD_SHA: ${{ steps.context.outputs.headSHA }}
+          REQUESTED_FULL: ${{ steps.context.outputs.requestFull }}
           REQUESTED_GROUPS: ${{ steps.context.outputs.requestedGroups }}
         run: |
           args=(
@@ -289,11 +288,10 @@ jobs:
             --plan-file e2e-selection-plan.json
             --summary-file e2e-selection-summary.md
           )
-          if [ "$FORCE_FULL" = true ]; then
-            args+=(--label e2e:full)
+          if [ "$REQUESTED_FULL" = true ]; then
+            args+=(--request-full)
           fi
           python3 hack/e2e_selector.py "${args[@]}"
-          cat e2e-selection-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Export executor job IDs
         id: outputs
@@ -309,12 +307,18 @@ jobs:
           sys.path.insert(0, "hack")
           import e2e_selector as e2eSelector
 
+          try:
+              catalog = e2eSelector.loadCatalog(".github/e2e-selection.json")
+          except Exception:
+              catalog = None
           plan = json.loads(Path("e2e-selection-plan.json").read_text())
-          if os.environ["EVENT_NAME"] == "workflow_dispatch":
-              executionPlan = plan
-          else:
-              workflow = Path(".github/workflows/build-x86-image.yaml").read_text()
-              executionPlan = {"matrix": e2eSelector.expandWorkflow(workflow)}
+          executionPlan = e2eSelector.executionPlan(catalog, plan, os.environ["EVENT_NAME"])
+          e2eSelector.writePlan(
+              executionPlan,
+              e2eSelector.readPaths("changed-paths.txt"),
+              "e2e-selection-plan.json",
+              "e2e-selection-summary.md",
+          )
           jobIds = sorted({entry["job"] for entry in executionPlan["matrix"]})
           matrices = {
               "k8sConformanceMatrix": e2eSelector.jobMatrix(
@@ -331,6 +335,7 @@ jobs:
               for name, matrix in matrices.items():
                   stream.write(name + "=" + json.dumps(matrix, separators=(",", ":")) + "\n")
           PY
+          cat e2e-selection-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validate the E2E control modules
         run: python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py
@@ -355,9 +360,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
-          fetch-depth: 2
+          fetch-depth: 0
 
       - id: check
         run: |
@@ -372,7 +377,7 @@ jobs:
           dist/images/go-deps/download-go-deps.sh
           dist/images/go-deps/rebuild-go-deps.sh
           EOF
-          if git diff --name-only HEAD^ HEAD | grep -Ff "$tmp_dir/on_changes.txt"; then
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -Ff "$tmp_dir/on_changes.txt"; then
             echo build-base=1 >> "$GITHUB_OUTPUT"
           fi
           rm -frv "$tmp_dir"
@@ -426,9 +431,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
-          fetch-depth: 2
+          fetch-depth: 0
 
       - id: check
         run: |
@@ -440,7 +445,7 @@ jobs:
           dist/images/Dockerfile.base-dpdk
           dist/images/patches/
           EOF
-          if git diff --name-only HEAD^ HEAD | grep -Ff "$tmp_dir/on_changes.txt"; then
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -Ff "$tmp_dir/on_changes.txt"; then
             echo build-dpdk-base=1 >> "$GITHUB_OUTPUT"
           fi
           rm -frv "$tmp_dir"
@@ -493,7 +498,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
       - uses: docker/setup-buildx-action@v4
       - uses: actions/setup-go@v7
@@ -684,7 +689,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Build
@@ -707,7 +712,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -781,50 +786,9 @@ jobs:
         if: steps.lookup-go-cache.outputs.cache-hit != 'true'
         working-directory: ${{ env.E2E_DIR }}
 
-  netpol-path-filter:
-    name: Network Policy Path Filter
-    needs: e2e-selection
-    if: >-
-      github.event_name != 'pull_request' &&
-      (github.event_name != 'workflow_dispatch' || github.actor == 'github-actions[bot]')
-    runs-on: ubuntu-24.04
-    outputs:
-      test-netpol: ${{ steps.filter.outputs.kube-ovn-controller }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.headSHA || github.sha }}
-          persist-credentials: false
-      - uses: actions/setup-go@v7
-        id: setup-go
-        with:
-          go-version-file: go.mod
-          check-latest: true
-          cache: false
-
-      - name: Generate path filter
-        run: |
-          filter=".github/path-filters.yaml"
-          cat > $filter <<EOF
-          kube-ovn-controller:
-          - go.mod
-          - go.sum
-          EOF
-
-          sh hack/go-list.sh pkg/controller | while read f; do
-            echo "- $f" | tee -a $filter
-          done
-
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          base: ${{ github.base_ref || github.ref_name }}
-          filters: .github/path-filters.yaml
-          list-files: csv
-
   k8s-conformance-e2e:
     name: Kubernetes Conformance E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-conformance-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-conformance-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -847,7 +811,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -921,7 +885,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -1020,18 +984,11 @@ jobs:
 
   k8s-netpol-e2e:
     name: Kubernetes Network Policy E2E
-    if: |
-      (github.event_name == 'workflow_dispatch' &&
-       contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-netpol-e2e')) ||
-      (github.event_name != 'workflow_dispatch' && (
-        always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') &&
-        (needs.netpol-path-filter.outputs.test-netpol == 1 || contains(github.event.pull_request.labels.*.name, 'network policy'))
-      ))
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-netpol-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
       - build-e2e-binaries
-      - netpol-path-filter
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -1057,7 +1014,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1133,7 +1090,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -1228,17 +1185,10 @@ jobs:
 
   cyclonus-netpol-e2e:
     name: Cyclonus Network Policy E2E
-    if: |
-      (github.event_name == 'workflow_dispatch' &&
-       contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'cyclonus-netpol-e2e')) ||
-      (github.event_name != 'workflow_dispatch' && (
-        always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') &&
-        (needs.netpol-path-filter.outputs.test-netpol == 1 || contains(github.event.pull_request.labels.*.name, 'network policy'))
-      ))
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'cyclonus-netpol-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
-      - netpol-path-filter
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -1264,7 +1214,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1312,7 +1262,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -1409,7 +1359,7 @@ jobs:
 
   kube-ovn-conformance-e2e:
     name: Kube-OVN Conformance E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-conformance-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-conformance-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -1432,7 +1382,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1501,7 +1451,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -1607,7 +1557,7 @@ jobs:
 
   kube-ovn-ic-conformance-e2e:
     name: Kube-OVN IC Conformance E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ic-conformance-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ic-conformance-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -1634,7 +1584,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1695,7 +1645,7 @@ jobs:
 
       - name: Create kind clusters
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-init-ovn-ic-${{ matrix.ip-family }}
@@ -1772,7 +1722,7 @@ jobs:
 
   multus-conformance-e2e:
     name: Multus Conformance E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'multus-conformance-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'multus-conformance-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -1799,7 +1749,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -1860,7 +1810,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -1927,7 +1877,7 @@ jobs:
 
   non-primary-cni-e2e:
     name: Non-Primary CNI E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'non-primary-cni-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'non-primary-cni-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -1952,7 +1902,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -2023,7 +1973,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -2092,7 +2042,7 @@ jobs:
 
   bgp-speaker-e2e:
     name: BGP Speaker E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'bgp-speaker-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'bgp-speaker-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2112,7 +2062,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -2174,7 +2124,7 @@ jobs:
       - name: Create BGP kind and containerlab topology
         id: setup
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-bgp
@@ -2240,7 +2190,7 @@ jobs:
 
   kube-ovn-hosted-ovn-central-e2e:
     name: Kube-OVN Hosted OVN Central E2E (${{ matrix.ip-family }}, ${{ matrix.tenant-control-plane }} control-plane)
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-hosted-ovn-central-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-hosted-ovn-central-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2282,7 +2232,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Remove DNS search domain
@@ -2401,7 +2351,7 @@ jobs:
 
   chart-test:
     name: Chart Installation/Uninstallation Test
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'chart-test')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'chart-test')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2426,7 +2376,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Install kind
@@ -2445,7 +2395,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -2479,7 +2429,7 @@ jobs:
 
   underlay-logical-gateway-installation-test:
     name: Underlay Logical Gateway Installation Test
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'underlay-logical-gateway-installation-test')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'underlay-logical-gateway-installation-test')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2498,7 +2448,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Install kind
@@ -2517,7 +2467,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-dual
@@ -2549,7 +2499,7 @@ jobs:
 
   no-ovn-lb-test:
     name: Disable OVN LB Test
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'no-ovn-lb-test')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'no-ovn-lb-test')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2568,7 +2518,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Install kind
@@ -2587,7 +2537,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -2621,7 +2571,7 @@ jobs:
 
   no-np-test:
     name: Disable Network Policy Test
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'no-np-test')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'no-np-test')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2640,7 +2590,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Install kind
@@ -2659,7 +2609,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -2693,7 +2643,7 @@ jobs:
 
   lb-svc-e2e:
     name: LB Service E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'lb-svc-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'lb-svc-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2714,7 +2664,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -2782,7 +2732,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -2845,7 +2795,7 @@ jobs:
 
   webhook-e2e:
     name: Webhook E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'webhook-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'webhook-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2865,7 +2815,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -2927,7 +2877,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -2964,7 +2914,7 @@ jobs:
 
   installation-compatibility-test:
     name: Installation Compatibility Test
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'installation-compatibility-test')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'installation-compatibility-test')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -2988,7 +2938,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Install kind
@@ -3007,7 +2957,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
           K8S_VERSION: ${{ matrix.k8s-version }}
         run: |
           pipx install jinjanator
@@ -3040,7 +2990,7 @@ jobs:
 
   talos-installation-test:
     name: Talos Installation Test
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'talos-installation-test')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'talos-installation-test')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -3069,7 +3019,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Install talosctl
@@ -3133,7 +3083,7 @@ jobs:
 
   kube-ovn-cnp-domain-e2e:
     name: Kube-OVN CNP Domain E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-cnp-domain-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-cnp-domain-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -3160,7 +3110,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3227,7 +3177,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -3287,7 +3237,7 @@ jobs:
 
   kube-ovn-anp-domain-e2e:
     name: Kube-OVN ANP Domain E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-anp-domain-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-anp-domain-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -3314,7 +3264,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3381,7 +3331,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -3441,7 +3391,7 @@ jobs:
 
   cilium-chaining-e2e:
     name: Cilium Chaining E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'cilium-chaining-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'cilium-chaining-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -3471,7 +3421,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
       - uses: azure/setup-helm@v5.0.1
         with:
@@ -3544,7 +3494,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-cilium-chaining-${{ matrix.ip-family }}
@@ -3613,7 +3563,7 @@ jobs:
 
   kube-ovn-ha-e2e:
     name: Kube-OVN HA E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ha-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ha-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -3646,7 +3596,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3707,7 +3657,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-ha-${{ matrix.ip-family }}
@@ -3757,7 +3707,7 @@ jobs:
 
   kube-ovn-submariner-conformance-e2e:
     name: Kube-OVN Submariner Conformance E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-submariner-conformance-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-submariner-conformance-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -3776,7 +3726,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3822,7 +3772,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init-ovn-submariner
@@ -3860,7 +3810,7 @@ jobs:
 
   vpc-egress-gateway-e2e:
     name: VPC Egress Gateway E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'vpc-egress-gateway-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'vpc-egress-gateway-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -3887,7 +3837,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -3948,7 +3898,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           n_worker=2 make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -4050,7 +4000,7 @@ jobs:
 
   iptables-vpc-nat-gw-conformance-e2e:
     name: Iptables VPC NAT Gateway E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'iptables-vpc-nat-gw-conformance-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'iptables-vpc-nat-gw-conformance-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -4071,7 +4021,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4139,7 +4089,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -4202,7 +4152,7 @@ jobs:
 
   ovn-vpc-nat-gw-conformance-e2e:
     name: OVN VPC NAT Gateway E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'ovn-vpc-nat-gw-conformance-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'ovn-vpc-nat-gw-conformance-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -4222,7 +4172,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4283,7 +4233,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -4353,7 +4303,7 @@ jobs:
 
   kube-ovn-ipsec-e2e:
     name: OVN IPSEC E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ipsec-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ipsec-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -4373,7 +4323,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4434,7 +4384,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -4499,7 +4449,7 @@ jobs:
 
   kube-ovn-ipsec-cert-mgr-e2e:
     name: OVN IPSEC E2E CERT MANAGER
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ipsec-cert-mgr-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ipsec-cert-mgr-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -4519,7 +4469,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4580,7 +4530,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -4643,7 +4593,7 @@ jobs:
 
   kube-ovn-connectivity-test:
     name: Kube-OVN Connectivity E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-connectivity-test')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-connectivity-test')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -4669,7 +4619,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4730,7 +4680,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -4762,7 +4712,7 @@ jobs:
 
   kube-ovn-underlay-metallb-e2e:
     name: OVN METALLB E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-underlay-metallb-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-underlay-metallb-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -4789,7 +4739,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4850,7 +4800,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           n_worker=2 make kind-ghcr-pull kind-init-${{ matrix.ip-family }}
@@ -4914,7 +4864,7 @@ jobs:
 
   router-lb-rule-e2e:
     name: Router LB Rule E2E
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'router-lb-rule-e2e')
+    if: contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'router-lb-rule-e2e')
     needs:
       - e2e-selection
       - build-kube-ovn
@@ -4934,7 +4884,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Create the default branch directory
@@ -4995,7 +4945,7 @@ jobs:
 
       - name: Create kind cluster
         env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}
         run: |
           pipx install jinjanator
           make kind-ghcr-pull kind-init
@@ -5056,8 +5006,8 @@ jobs:
           path: router-lb-rule-e2e-ko-log.tar.gz
 
   e2e-executor-result:
-    name: x86 E2E Executor Result
-    if: github.event_name == 'workflow_dispatch' && always()
+    name: x86 E2E Selected Result
+    if: always()
     permissions: {}
     needs:
       - e2e-selection
@@ -5117,35 +5067,8 @@ jobs:
   push:
     name: Push Images
     needs:
-      - e2e-selection
-      - k8s-conformance-e2e
-      - k8s-netpol-e2e
-      - cyclonus-netpol-e2e
-      - kube-ovn-conformance-e2e
-      - kube-ovn-ic-conformance-e2e
-      - kube-ovn-ipsec-e2e
-      - kube-ovn-ipsec-cert-mgr-e2e
-      - kube-ovn-underlay-metallb-e2e
-      - multus-conformance-e2e
-      - non-primary-cni-e2e
-      - bgp-speaker-e2e
-      - kube-ovn-hosted-ovn-central-e2e
-      - vpc-egress-gateway-e2e
-      - ovn-vpc-nat-gw-conformance-e2e
-      - iptables-vpc-nat-gw-conformance-e2e
-      - webhook-e2e
-      - lb-svc-e2e
-      - underlay-logical-gateway-installation-test
-      - chart-test
-      - installation-compatibility-test
-      - talos-installation-test
-      - no-ovn-lb-test
-      - no-np-test
-      - cilium-chaining-e2e
-      - kube-ovn-ha-e2e
-      - kube-ovn-submariner-conformance-e2e
-      - router-lb-rule-e2e
-    if: github.event_name != 'workflow_dispatch' && always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+      - e2e-executor-result
+    if: github.event_name == 'push' && needs.e2e-executor-result.result == 'success'
     runs-on: ubuntu-24.04
     steps:
       - uses: jlumbroso/free-disk-space@v1.3.1
@@ -5160,7 +5083,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.headSHA || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
           persist-credentials: false
 
       - name: Download kube-ovn image

--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [synchronize, closed]
+    types: [opened, reopened, synchronize, labeled, unlabeled, closed]
   push:
     branches:
       - master
@@ -32,6 +32,111 @@ permissions:
   issues: write
 
 jobs:
+  record-controlled-label:
+    name: Record trusted x86 E2E controlled labels
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      startsWith(github.event.label.name, 'e2e:')
+    runs-on: ubuntu-24.04
+    env:
+      ACTION: ${{ github.event.action }}
+      GH_TOKEN: ${{ github.token }}
+      LABEL_NAME: ${{ github.event.label.name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PYTHONPATH: hack
+      PYTHONDONTWRITEBYTECODE: "1"
+      SENDER: ${{ github.actor }}
+    steps:
+      - name: Check out trusted control logic
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Validate and record the controlled label transition
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > label-pull-request.json
+          baseRef=$(jq -r '.base.ref' label-pull-request.json)
+          if ! [[ "$baseRef" == master || "$baseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
+            exit 0
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/contents/.github/e2e-selection.json?ref=$baseRef" \
+            --jq '.content' | base64 --decode > label-catalog.json
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            > label-comments.json
+          permission=$(gh api \
+            "repos/$GITHUB_REPOSITORY/collaborators/$SENDER/permission" \
+            --jq '.permission' 2>/dev/null || printf 'none')
+          known=$(python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          catalog = json.loads(Path("label-catalog.json").read_text())
+          known = {"e2e:full"} | {f"e2e:{group}" for group in catalog["groups"]}
+          print("true" if os.environ["LABEL_NAME"] in known else "false")
+          PY
+          )
+          authorized=false
+          if [[ "$permission" == admin || "$permission" == maintain || "$permission" == write ]] && \
+             [ "$known" = true ]; then
+            authorized=true
+          fi
+          if [ "$authorized" != true ]; then
+            encodedLabel=$(jq -rn --arg value "$LABEL_NAME" '$value | @uri')
+            if [ "$ACTION" = labeled ]; then
+              gh api --method DELETE \
+                "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/$encodedLabel" \
+                >/dev/null 2>&1 || true
+            else
+              restore=$(python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import e2e_control as e2eControl
+
+          catalog = json.loads(Path("label-catalog.json").read_text())
+          pages = json.loads(Path("label-comments.json").read_text())
+          labels = e2eControl.trustedControlledLabels(
+              catalog,
+              pages,
+              [os.environ["LABEL_NAME"]],
+          )
+          print("true" if os.environ["LABEL_NAME"] in labels else "false")
+          PY
+              )
+              if [ "$restore" = true ]; then
+                gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+                  -f "labels[]=$LABEL_NAME" >/dev/null
+              fi
+            fi
+            gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              -f body="Rejected controlled label \`$LABEL_NAME\`: repository write permission and a catalog-defined label are required."
+            exit 0
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > confirmed-label-pull-request.json
+          present=$(jq -r --arg label "$LABEL_NAME" \
+            'any(.labels[]; .name == $label)' confirmed-label-pull-request.json)
+          expectedPresent=false
+          [ "$ACTION" != labeled ] || expectedPresent=true
+          if [ "$present" != "$expectedPresent" ]; then
+            echo 'Controlled label state changed before provenance could be recorded.'
+            exit 0
+          fi
+          marker=$(python3 - "$LABEL_NAME" "$expectedPresent" <<'PY'
+          import sys
+          import e2e_control as e2eControl
+
+          print(e2eControl.renderControlledLabelMarker(sys.argv[1], sys.argv[2] == "true"))
+          PY
+          )
+          body=$(printf "Recorded trusted x86 E2E label transition by \`%s\`: \`%s\` is now \`%s\`.\n\n%s" \
+            "$SENDER" "$LABEL_NAME" "$expectedPresent" "$marker")
+          gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" -f body="$body"
+
   cancel-stale:
     name: Cancel obsolete x86 E2E executors
     if: github.event_name == 'pull_request_target'
@@ -84,6 +189,139 @@ jobs:
               echo "Executor run $runId finished before cancellation." >&2
             fi
           done < stale-runs.txt
+
+  automatic:
+    name: Start trusted automatic x86 E2E coverage
+    needs:
+      - record-controlled-label
+      - cancel-stale
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      github.event.action != 'closed'
+    permissions:
+      actions: write
+      contents: write
+      issues: read
+      pull-requests: read
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PYTHONPATH: hack
+      PYTHONDONTWRITEBYTECODE: "1"
+    steps:
+      - name: Check out trusted automatic dispatcher logic
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Dispatch automatic smoke or fail-closed full coverage
+        env:
+          DISPATCH_GENERATION: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > automatic-pull-request.json
+          if [ "$(jq -r '.state' automatic-pull-request.json)" != open ]; then
+            exit 0
+          fi
+          headSHA=$(jq -r '.head.sha' automatic-pull-request.json)
+          baseSHA=$(jq -r '.base.sha' automatic-pull-request.json)
+          baseRef=$(jq -r '.base.ref' automatic-pull-request.json)
+          if ! [[ "$baseRef" == master || "$baseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
+            exit 0
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/contents/.github/e2e-selection.json?ref=$baseRef" \
+            --jq '.content' | base64 --decode > automatic-catalog.json
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            > automatic-comments.json
+          python3 - <<'PY' > automatic-context.json
+          import json
+          from pathlib import Path
+          import e2e_control as e2eControl
+          import e2e_selector as e2eSelector
+
+          pullRequest = json.loads(Path("automatic-pull-request.json").read_text())
+          catalog = json.loads(Path("automatic-catalog.json").read_text())
+          e2eSelector.validateCatalog(catalog)
+          pages = json.loads(Path("automatic-comments.json").read_text())
+          liveLabels = [label["name"] for label in pullRequest.get("labels", [])]
+          labels = e2eControl.trustedControlledLabels(catalog, pages, liveLabels)
+          print(json.dumps({
+              "catalogRevision": e2eSelector.catalogRevision(catalog),
+              "controlledLabels": labels,
+          }))
+          PY
+          catalogRevision=$(jq -r '.catalogRevision' automatic-context.json)
+          controlledLabels=$(jq -c '.controlledLabels' automatic-context.json)
+          controlledLabelNames=$(jq -r \
+            '.controlledLabels | if length == 0 then "-" else join(",") end' \
+            automatic-context.json)
+          approvalGeneration=1
+          requestKey="automatic-$DISPATCH_GENERATION"
+          executorRef=$(python3 - "$PR_NUMBER" "$approvalGeneration" "$DISPATCH_GENERATION" <<'PY'
+          import sys
+          import e2e_control as e2eControl
+
+          print(e2eControl.executorHeadBranch({
+              "prNumber": int(sys.argv[1]),
+              "approvalGeneration": int(sys.argv[2]),
+              "dispatchGeneration": int(sys.argv[3]),
+          }))
+          PY
+          )
+          refPath="refs/heads/$executorRef"
+          existingSHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$executorRef" \
+            --jq '.object.sha' 2>/dev/null || true)
+          if [ -n "$existingSHA" ] && [ "$existingSHA" != "$baseSHA" ]; then
+            echo 'The isolated automatic executor ref points at an unexpected revision.' >&2
+            exit 1
+          fi
+          createdRef=false
+          if [ -z "$existingSHA" ]; then
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="$refPath" -f sha="$baseSHA"
+            createdRef=true
+          fi
+          if ! gh api --method POST \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/build-x86-image.yaml/dispatches" \
+            -f ref="$executorRef" \
+            -F "inputs[prNumber]=$PR_NUMBER" \
+            -f "inputs[headSHA]=$headSHA" \
+            -f "inputs[baseSHA]=$baseSHA" \
+            -F "inputs[approvalGeneration]=$approvalGeneration" \
+            -F 'inputs[automatic]=true' \
+            -F "inputs[dispatchGeneration]=$DISPATCH_GENERATION" \
+            -f 'inputs[requestedGroups]=[]' \
+            -f 'inputs[requestedGroupNames]=-' \
+            -f "inputs[controlledLabels]=$controlledLabels" \
+            -f "inputs[controlledLabelNames]=$controlledLabelNames" \
+            -F 'inputs[full]=false' \
+            -f "inputs[requestKey]=$requestKey" \
+            -f "inputs[catalogRevision]=$catalogRevision"; then
+            [ "$createdRef" = false ] || gh api --method DELETE \
+              "repos/$GITHUB_REPOSITORY/git/refs/heads/$executorRef"
+            exit 1
+          fi
+          expectedTitle="x86-e2e pr=$PR_NUMBER head=$headSHA approval=$approvalGeneration generation=$DISPATCH_GENERATION mode=automatic groups=- labels=$controlledLabelNames full=0"
+          runVisible=false
+          for _ in $(seq 1 24); do
+            runVisible=$(gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/build-x86-image.yaml/runs?event=workflow_dispatch&branch=$executorRef&per_page=100" \
+              | jq -r --arg branch "$executorRef" --arg sha "$baseSHA" --arg title "$expectedTitle" \
+                'any(.[].workflow_runs[]; .path == ".github/workflows/build-x86-image.yaml" and
+                  .actor.login == "github-actions[bot]" and .head_branch == $branch and
+                  .head_sha == $sha and .display_title == $title)')
+            [ "$runVisible" = true ] && break
+            sleep 5
+          done
+          if [ "$runVisible" != true ]; then
+            echo 'The isolated automatic executor run was not visible; its temporary ref was retained.' >&2
+            exit 1
+          fi
+          gh api --method DELETE "repos/$GITHUB_REPOSITORY/git/refs/heads/$executorRef"
 
   invalidate-base:
     name: Invalidate x86 E2E gates after a base update
@@ -162,6 +400,7 @@ jobs:
       - name: Validate command, permission, and current HEAD
         id: decision
         env:
+          COMMENT_ID: ${{ github.event.comment.id }}
           COMMENTER: ${{ github.event.comment.user.login }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
@@ -170,6 +409,9 @@ jobs:
             "repos/$GITHUB_REPOSITORY/collaborators/$COMMENTER/permission" \
             --jq '.permission' 2>/dev/null || printf 'none')
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > pull-request.json
+          if ! gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID" > live-comment.json; then
+            printf 'null\n' > live-comment.json
+          fi
           baseRef=$(jq -r '.base.ref' pull-request.json)
           if ! [[ "$baseRef" == master || "$baseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
             echo 'Pull request base branch is outside the supported trusted set.' >&2
@@ -177,6 +419,20 @@ jobs:
           fi
           gh api "repos/$GITHUB_REPOSITORY/contents/.github/e2e-selection.json?ref=$baseRef" \
             --jq '.content' | base64 --decode > trusted-catalog.json
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            > controlled-label-comments.json
+          python3 - <<'PY' > controlled-labels.json
+          import json
+          from pathlib import Path
+          import e2e_control as e2eControl
+
+          pullRequest = json.loads(Path("pull-request.json").read_text())
+          catalog = json.loads(Path("trusted-catalog.json").read_text())
+          pages = json.loads(Path("controlled-label-comments.json").read_text())
+          liveLabels = [label["name"] for label in pullRequest.get("labels", [])]
+          print(json.dumps(e2eControl.trustedControlledLabels(catalog, pages, liveLabels)))
+          PY
           confirmedHead=$(gh api \
             "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
             --jq '.head.sha')
@@ -186,6 +442,8 @@ jobs:
             --permission "$permission" \
             --pull-request-file pull-request.json \
             --confirmed-head-sha "$confirmedHead" \
+            --live-comment-file live-comment.json \
+            --controlled-labels-file controlled-labels.json \
             --decision-file dispatch-decision.json
           python3 - <<'PY'
           import json
@@ -783,9 +1041,12 @@ jobs:
             -f "inputs[headSHA]=$HEAD_SHA" \
             -f "inputs[baseSHA]=$BASE_SHA" \
             -F "inputs[approvalGeneration]=$APPROVAL_GENERATION" \
+            -F 'inputs[automatic]=false' \
             -F "inputs[dispatchGeneration]=$DISPATCH_GENERATION" \
             -f "inputs[requestedGroups]=$REQUESTED_GROUPS" \
             -f "inputs[requestedGroupNames]=$REQUESTED_GROUP_NAMES" \
+            -f 'inputs[controlledLabels]=[]' \
+            -f 'inputs[controlledLabelNames]=-' \
             -F "inputs[full]=$FULL" \
             -f "inputs[requestKey]=$REQUEST_KEY" \
             -f "inputs[catalogRevision]=$CATALOG_REVISION"; then
@@ -795,7 +1056,7 @@ jobs:
               -f body='The trusted x86 E2E executor could not be started; retry the authorized command.'
             exit 1
           fi
-          expectedTitle="x86-e2e pr=$PR_NUMBER head=$HEAD_SHA approval=$APPROVAL_GENERATION generation=$DISPATCH_GENERATION groups=$REQUESTED_GROUP_NAMES full=$([ "$FULL" = true ] && echo 1 || echo 0)"
+          expectedTitle="x86-e2e pr=$PR_NUMBER head=$HEAD_SHA approval=$APPROVAL_GENERATION generation=$DISPATCH_GENERATION mode=approved groups=$REQUESTED_GROUP_NAMES labels=- full=$([ "$FULL" = true ] && echo 1 || echo 0)"
           runVisible=false
           for _ in $(seq 1 24); do
             runVisible=$(gh api --paginate --slurp \

--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -288,17 +288,17 @@ jobs:
           if ! gh api --method POST \
             "repos/$GITHUB_REPOSITORY/actions/workflows/build-x86-image.yaml/dispatches" \
             -f ref="$executorRef" \
-            -F "inputs[prNumber]=$PR_NUMBER" \
+            -f "inputs[prNumber]=$PR_NUMBER" \
             -f "inputs[headSHA]=$headSHA" \
             -f "inputs[baseSHA]=$baseSHA" \
-            -F "inputs[approvalGeneration]=$approvalGeneration" \
-            -F 'inputs[automatic]=true' \
-            -F "inputs[dispatchGeneration]=$DISPATCH_GENERATION" \
+            -f "inputs[approvalGeneration]=$approvalGeneration" \
+            -f 'inputs[automatic]=true' \
+            -f "inputs[dispatchGeneration]=$DISPATCH_GENERATION" \
             -f 'inputs[requestedGroups]=[]' \
             -f 'inputs[requestedGroupNames]=-' \
             -f "inputs[controlledLabels]=$controlledLabels" \
             -f "inputs[controlledLabelNames]=$controlledLabelNames" \
-            -F 'inputs[full]=false' \
+            -f 'inputs[full]=false' \
             -f "inputs[requestKey]=$requestKey" \
             -f "inputs[catalogRevision]=$catalogRevision"; then
             [ "$createdRef" = false ] || gh api --method DELETE \
@@ -364,15 +364,15 @@ jobs:
             gh api --method POST \
               "repos/$GITHUB_REPOSITORY/actions/workflows/x86-e2e-gate.yaml/dispatches" \
               -f ref="$GITHUB_REF_NAME" \
-              -F "inputs[prNumber]=$prNumber" \
+              -f "inputs[prNumber]=$prNumber" \
               -f "inputs[headSHA]=$headSHA" \
               -f "inputs[baseSHA]=$GITHUB_SHA" \
-              -F 'inputs[approvalGeneration]=1' \
+              -f 'inputs[approvalGeneration]=1' \
               -f "inputs[catalogRevision]=$catalogRevision" \
               -f 'inputs[requestedGroups]=[]' \
-              -F 'inputs[full]=false' \
-              -F 'inputs[recordIntent]=false' \
-              -F 'inputs[baseRefresh]=true'
+              -f 'inputs[full]=false' \
+              -f 'inputs[recordIntent]=false' \
+              -f 'inputs[baseRefresh]=true'
           done < open-pulls.tsv
 
   dispatch:
@@ -553,15 +553,15 @@ jobs:
               gh api --method POST \
                 "repos/$GITHUB_REPOSITORY/actions/workflows/x86-e2e-gate.yaml/dispatches" \
                 -f ref="$defaultBranch" \
-                -F "inputs[prNumber]=$prNumber" \
+                -f "inputs[prNumber]=$prNumber" \
                 -f "inputs[headSHA]=$headSHA" \
                 -f "inputs[baseSHA]=$baseSHA" \
-                -F "inputs[approvalGeneration]=$approvalGeneration" \
+                -f "inputs[approvalGeneration]=$approvalGeneration" \
                 -f "inputs[catalogRevision]=$catalogRevision" \
                 -f "inputs[requestedGroups]=$requestedGroups" \
-                -F "inputs[full]=$full" \
-                -F "inputs[recordIntent]=$recordIntent" \
-                -F 'inputs[baseRefresh]=false'
+                -f "inputs[full]=$full" \
+                -f "inputs[recordIntent]=$recordIntent" \
+                -f 'inputs[baseRefresh]=false'
             }
             if ! dispatchGate false; then
               gh api "repos/$GITHUB_REPOSITORY/issues/$prNumber/comments" \
@@ -1037,17 +1037,17 @@ jobs:
           if ! gh api --method POST \
             "repos/$GITHUB_REPOSITORY/actions/workflows/build-x86-image.yaml/dispatches" \
             -f ref="$executorRef" \
-            -F "inputs[prNumber]=$PR_NUMBER" \
+            -f "inputs[prNumber]=$PR_NUMBER" \
             -f "inputs[headSHA]=$HEAD_SHA" \
             -f "inputs[baseSHA]=$BASE_SHA" \
-            -F "inputs[approvalGeneration]=$APPROVAL_GENERATION" \
-            -F 'inputs[automatic]=false' \
-            -F "inputs[dispatchGeneration]=$DISPATCH_GENERATION" \
+            -f "inputs[approvalGeneration]=$APPROVAL_GENERATION" \
+            -f 'inputs[automatic]=false' \
+            -f "inputs[dispatchGeneration]=$DISPATCH_GENERATION" \
             -f "inputs[requestedGroups]=$REQUESTED_GROUPS" \
             -f "inputs[requestedGroupNames]=$REQUESTED_GROUP_NAMES" \
             -f 'inputs[controlledLabels]=[]' \
             -f 'inputs[controlledLabelNames]=-' \
-            -F "inputs[full]=$FULL" \
+            -f "inputs[full]=$FULL" \
             -f "inputs[requestKey]=$REQUEST_KEY" \
             -f "inputs[catalogRevision]=$CATALOG_REVISION"; then
             [ "$createdRef" = false ] || gh api --method DELETE \

--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -79,6 +79,8 @@ jobs:
       runURL: ${{ github.event.workflow_run.html_url }}
       runEvent: ${{ github.event.workflow_run.event }}
       trustedRef: ${{ steps.context.outputs.trustedRef }}
+      automatic: ${{ steps.context.outputs.automatic }}
+      controlledLabels: ${{ steps.context.outputs.controlledLabels }}
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
@@ -131,11 +133,13 @@ jobs:
             approvalGeneration=$(jq -r '.approvalGeneration' executor-metadata.json)
             dispatchGeneration=$(jq -r '.dispatchGeneration' executor-metadata.json)
             requestedGroups=$(jq -c '.requestedGroups' executor-metadata.json)
+            controlledLabels=$(jq -c '.controlledLabels' executor-metadata.json)
+            automatic=$(jq -r '.automatic' executor-metadata.json)
             requestKey=''
             expectedCatalogRevision=''
             trustedRef="$RUN_WORKFLOW_SHA"
             full=$(jq -r '.full' executor-metadata.json)
-            approved=true
+            approved=$([ "$automatic" = true ] && echo false || echo true)
             trustedExecution=true
           else
             printf '%s' "$RUN_PULL_REQUESTS" > run-pull-requests.json
@@ -146,6 +150,8 @@ jobs:
             approvalGeneration=0
             dispatchGeneration=0
             requestedGroups='[]'
+            controlledLabels='[]'
+            automatic=false
             requestKey=''
             expectedCatalogRevision=''
             full=false
@@ -205,6 +211,8 @@ jobs:
               "head": {"sha": sys.argv[2]},
               "base": {"sha": sys.argv[3], "ref": sys.argv[4]},
           }
+          livePullRequest = json.loads(Path("pull-request.json").read_text())
+          pullRequest["labels"] = livePullRequest.get("labels", [])
           pages = json.loads(Path("current-comments.json").read_text())
           request = e2eControl.approvedRequest(pullRequest, catalog, pages)
           if request is None:
@@ -213,11 +221,17 @@ jobs:
                   "requestKey": "",
                   "catalogRevision": e2eSelector.catalogRevision(catalog),
               }
+          request["controlledLabels"] = e2eControl.trustedControlledLabels(
+              catalog,
+              pages,
+              [label.get("name", "") for label in pullRequest["labels"]],
+          )
           print(json.dumps(request))
           PY
           latestApprovalGeneration=$(jq -r '.approvalGeneration' current-request.json)
           latestRequestKey=$(jq -r '.requestKey // ""' current-request.json)
           currentCatalogRevision=$(jq -r '.catalogRevision' current-request.json)
+          currentControlledLabels=$(jq -c '.controlledLabels // []' current-request.json)
           if [ "$RUN_EVENT" = workflow_dispatch ] && [ "$RUN_ATTEMPT" != "$currentAttempt" ]; then
             newerAttemptAuthorized=false
             if [ "$currentTriggeringActor" = 'github-actions[bot]' ]; then
@@ -273,7 +287,19 @@ jobs:
           PY
             )
             expectedCatalogRevision="$currentCatalogRevision"
-            if [ "$requestKey" != "$latestRequestKey" ]; then
+            if [ "$automatic" = true ]; then
+              requestKey=''
+              if [ "$latestApprovalGeneration" != 0 ]; then
+                echo 'A trusted comment approval supersedes this automatic executor.'
+                echo 'skip=true' >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              if [ "$controlledLabels" != "$currentControlledLabels" ]; then
+                echo 'Controlled label provenance changed; the automatic executor is stale.'
+                echo 'skip=true' >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            elif [ "$requestKey" != "$latestRequestKey" ]; then
               echo 'A different durable approval supersedes this executor.'
               echo 'skip=true' >> "$GITHUB_OUTPUT"
               exit 0
@@ -301,6 +327,11 @@ jobs:
             exit 0
           fi
           if [ "$RUN_EVENT" = workflow_dispatch ] || [ "$RUN_EVENT" = pull_request ]; then
+            # A stale approved run must not suppress a fresh automatic probe
+            # after controlled-label provenance changed.
+            if [ "$automatic" = true ] && [ "$latestApprovalGeneration" = 0 ]; then
+              latestRun=''
+            else
             gh api --paginate --slurp \
               "repos/$GITHUB_REPOSITORY/actions/workflows/build-x86-image.yaml/runs?event=workflow_dispatch&per_page=100" \
               > executor-run-pages.json
@@ -329,6 +360,7 @@ jobs:
               echo 'skip=true' >> "$GITHUB_OUTPUT"
               exit 0
             fi
+            fi
           fi
           {
             echo 'skip=false'
@@ -347,6 +379,8 @@ jobs:
             echo "trustedExecution=$trustedExecution"
             echo "full=$full"
             echo "requestedGroups=$requestedGroups"
+            echo "automatic=$automatic"
+            echo "controlledLabels=$controlledLabels"
             echo "requestKey=$requestKey"
           } >> "$GITHUB_OUTPUT"
 
@@ -413,6 +447,7 @@ jobs:
           HEAD_SHA: ${{ steps.context.outputs.expectedHead }}
           REQUESTED_GROUPS: ${{ steps.context.outputs.requestedGroups }}
           FULL: ${{ steps.context.outputs.full }}
+          CONTROLLED_LABELS: ${{ steps.context.outputs.controlledLabels }}
           EXECUTION_EVENT: ${{ steps.context.outputs.approved == 'true' && 'workflow_dispatch' || 'pull_request' }}
         run: |
           set -euo pipefail
@@ -422,7 +457,8 @@ jobs:
           from pathlib import Path
 
           pullRequest = json.loads(Path("pull-request.json").read_text())
-          pullRequest["labels"] = []
+          controlledLabels = json.loads(__import__("os").environ["CONTROLLED_LABELS"])
+          pullRequest["labels"] = [{"name": label} for label in controlledLabels]
           Path("selector-event.json").write_text(json.dumps({"pull_request": pullRequest}))
           PY
           gh api --paginate --slurp \
@@ -458,6 +494,8 @@ jobs:
             --event-file selector-event.json
             --request-groups-json "$REQUESTED_GROUPS"
             --head-sha "$HEAD_SHA"
+            --base-sha "${{ steps.context.outputs.expectedBase }}"
+            --pr-number "$PR_NUMBER"
             --force-full-reason "$forceFullReason"
             --plan-file e2e-selection-plan.json
           )

--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -461,7 +461,7 @@ jobs:
             --plan-file e2e-selection-plan.json
           )
           if [ "$FULL" = true ]; then
-            args+=(--label e2e:full)
+            args+=(--request-full)
           fi
           python3 hack/e2e_selector.py "${args[@]}"
 

--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -1541,15 +1541,15 @@ jobs:
             if ! gh api --method POST \
               "repos/$GITHUB_REPOSITORY/actions/workflows/x86-e2e-gate.yaml/dispatches" \
               -f ref="$defaultBranch" \
-              -F "inputs[prNumber]=$PR_NUMBER" \
+              -f "inputs[prNumber]=$PR_NUMBER" \
               -f "inputs[headSHA]=$HEAD_SHA" \
               -f "inputs[baseSHA]=$BASE_SHA" \
-              -F "inputs[approvalGeneration]=$SOURCE_APPROVAL_GENERATION" \
+              -f "inputs[approvalGeneration]=$SOURCE_APPROVAL_GENERATION" \
               -f "inputs[catalogRevision]=$CATALOG_REVISION" \
               -f "inputs[requestedGroups]=$SOURCE_REQUESTED_GROUPS" \
-              -F "inputs[full]=$SOURCE_FULL" \
-              -F 'inputs[recordIntent]=true' \
-              -F 'inputs[baseRefresh]=false'; then
+              -f "inputs[full]=$SOURCE_FULL" \
+              -f 'inputs[recordIntent]=true' \
+              -f 'inputs[baseRefresh]=false'; then
               gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
                 -f body='The x86 E2E intent is durable and the gate remains blocked, but reconciliation must be retried.'
               exit 1
@@ -1577,9 +1577,9 @@ jobs:
             if ! gh api --method POST \
               "repos/$GITHUB_REPOSITORY/actions/workflows/x86-e2e-dispatcher.yaml/dispatches" \
               -f ref="$defaultBranch" \
-              -F "inputs[prNumber]=$PR_NUMBER" \
+              -f "inputs[prNumber]=$PR_NUMBER" \
               -f "inputs[headSHA]=$HEAD_SHA" \
-              -F "inputs[approvalGeneration]=$APPROVAL_GENERATION"; then
+              -f "inputs[approvalGeneration]=$APPROVAL_GENERATION"; then
               gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
                 -f body='The approval was recorded, but its trusted x86 E2E reducer could not be started; retry the authorized command.'
               exit 1

--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -413,6 +413,7 @@ jobs:
           HEAD_SHA: ${{ steps.context.outputs.expectedHead }}
           REQUESTED_GROUPS: ${{ steps.context.outputs.requestedGroups }}
           FULL: ${{ steps.context.outputs.full }}
+          EXECUTION_EVENT: ${{ steps.context.outputs.approved == 'true' && 'workflow_dispatch' || 'pull_request' }}
         run: |
           set -euo pipefail
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > pull-request.json
@@ -464,6 +465,19 @@ jobs:
             args+=(--request-full)
           fi
           python3 hack/e2e_selector.py "${args[@]}"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import e2e_selector as e2eSelector
+
+          catalog = e2eSelector.loadCatalog(".github/e2e-selection.json")
+          plan = json.loads(Path("e2e-selection-plan.json").read_text())
+          plan = e2eSelector.executionPlan(catalog, plan, os.environ["EXECUTION_EVENT"])
+          Path("e2e-selection-plan.json").write_text(
+              json.dumps(plan, indent=2) + "\n"
+          )
+          PY
 
       - name: Evaluate the fixed gate
         if: steps.context.outputs.skip != 'true' && steps.context.outputs.runAction == 'completed'

--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -101,6 +101,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           RUN_EVENT: ${{ github.event.workflow_run.event }}
           RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_NAME: ${{ github.event.workflow_run.display_title }}
           RUN_PATH: ${{ github.event.workflow_run.path }}
@@ -143,6 +144,35 @@ jobs:
             trustedExecution=true
           else
             printf '%s' "$RUN_PULL_REQUESTS" > run-pull-requests.json
+            if [ "$(jq 'length' run-pull-requests.json)" -eq 0 ]; then
+              if ! [[ "$RUN_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+                echo 'The pull request workflow HEAD is invalid.' >&2
+                exit 1
+              fi
+              headOwner=${RUN_HEAD_REPOSITORY%%/*}
+              if [ -z "$headOwner" ] || [ "$headOwner" = "$RUN_HEAD_REPOSITORY" ]; then
+                echo 'The pull request workflow head repository is invalid.' >&2
+                exit 1
+              fi
+              gh api --method GET \
+                "repos/$GITHUB_REPOSITORY/pulls" \
+                -f state=open \
+                -f "head=$headOwner:$RUN_HEAD_BRANCH" \
+                > associated-pull-requests.json
+              jq \
+                --arg repository "$GITHUB_REPOSITORY" \
+                --arg headSHA "$RUN_WORKFLOW_SHA" \
+                --arg headRepository "$RUN_HEAD_REPOSITORY" \
+                '[.[] | select(
+                  .state == "open" and
+                  .head.sha == $headSHA and
+                  .head.repo.full_name == $headRepository and
+                  .base.repo.full_name == $repository
+                )] |
+                if length == 1 then .
+                else error("workflow HEAD must resolve to exactly one open pull request")
+                end' associated-pull-requests.json > run-pull-requests.json
+            fi
             prNumber=$(jq -r '.[0].number // empty' run-pull-requests.json)
             expectedHead=$(jq -r '.[0].head.sha // empty' run-pull-requests.json)
             trustedRef=$(jq -r '.[0].base.sha // empty' run-pull-requests.json)
@@ -158,7 +188,7 @@ jobs:
             approved=false
             trustedExecution=false
             if [ -z "$prNumber" ] || [ -z "$expectedHead" ] || [ -z "$trustedRef" ]; then
-              echo 'The completed pull_request run is not associated with a pull request.' >&2
+              echo 'The completed pull_request run is not associated with one open pull request.' >&2
               exit 1
             fi
           fi

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -10,29 +10,62 @@ import e2e_selector as e2eSelector
 
 
 groupPattern = r"[a-z0-9]+(?:-[a-z0-9]+)*"
+headPattern = r"[0-9a-f]{40}"
+noncePattern = r"[0-9a-f]{16}"
 
 
 def canonicalRequestedGroups(requestedGroups, full):
     return [] if full else sorted(set(requestedGroups))
 
 
+def requestNonce(prNumber, headSHA, baseSHA, catalogRevision):
+    return e2eSelector.requestNonce(prNumber, headSHA, baseSHA, catalogRevision)
+
+
 def parseCommand(body):
     body = body.strip()
-    if not body.startswith("/test e2e") and body != "/retest e2e-failed":
+    if not body.startswith("/test e2e") and not body.startswith("/retest e2e-failed"):
         return None
-    if body == "/test e2e":
-        return {"action": "dispatch", "requestedGroups": [], "full": False}
-    if body == "/test e2e-all":
-        return {"action": "dispatch", "requestedGroups": [], "full": True}
-    if body == "/retest e2e-failed":
-        return {"action": "rerun-failed", "requestedGroups": [], "full": False}
-    match = re.fullmatch(rf"/test e2e ({groupPattern}(?:,{groupPattern})*)", body)
+    binding = rf" --head ({headPattern}) --nonce ({noncePattern})"
+    match = re.fullmatch(rf"/test e2e{binding}", body)
+    if match:
+        return {
+            "action": "dispatch",
+            "requestedGroups": [],
+            "full": False,
+            "headSHA": match.group(1),
+            "nonce": match.group(2),
+        }
+    match = re.fullmatch(rf"/test e2e-all{binding}", body)
+    if match:
+        return {
+            "action": "dispatch",
+            "requestedGroups": [],
+            "full": True,
+            "headSHA": match.group(1),
+            "nonce": match.group(2),
+        }
+    match = re.fullmatch(rf"/retest e2e-failed{binding}", body)
+    if match:
+        return {
+            "action": "rerun-failed",
+            "requestedGroups": [],
+            "full": False,
+            "headSHA": match.group(1),
+            "nonce": match.group(2),
+        }
+    match = re.fullmatch(
+        rf"/test e2e ({groupPattern}(?:,{groupPattern})*){binding}",
+        body,
+    )
     if not match:
         raise ValueError("invalid E2E command")
     return {
         "action": "dispatch",
         "requestedGroups": sorted(set(match.group(1).split(","))),
         "full": False,
+        "headSHA": match.group(2),
+        "nonce": match.group(3),
     }
 
 
@@ -53,6 +86,8 @@ def decideDispatch(
     confirmedHeadSHA,
     knownGroups,
     catalogRevision,
+    liveComment=None,
+    controlledLabels=(),
 ):
     body = event.get("comment", {}).get("body", "")
     try:
@@ -64,6 +99,34 @@ def decideDispatch(
         )
     if command is None:
         return None
+    controlledLabels = set(controlledLabels)
+    knownControlledLabels = {"e2e:full"} | {f"e2e:{group}" for group in knownGroups}
+    invalidControlledLabels = sorted(controlledLabels - knownControlledLabels)
+    if invalidControlledLabels:
+        return rejectedDecision(command, "controlled label provenance is invalid")
+    controlledGroups = {
+        label.removeprefix("e2e:")
+        for label in controlledLabels
+        if label != "e2e:full"
+    }
+    command = {
+        **command,
+        "requestedGroups": canonicalRequestedGroups(
+            set(command["requestedGroups"]) | controlledGroups,
+            command["full"] or "e2e:full" in controlledLabels,
+        ),
+        "full": command["full"] or "e2e:full" in controlledLabels,
+    }
+    eventComment = event.get("comment", {})
+    eventUser = eventComment.get("user", {})
+    liveUser = liveComment.get("user", {}) if isinstance(liveComment, dict) else {}
+    if (
+        liveComment is None
+        or liveComment.get("id") != eventComment.get("id")
+        or liveComment.get("body") != eventComment.get("body")
+        or liveUser.get("login") != eventUser.get("login")
+    ):
+        return rejectedDecision(command, "comment changed or was deleted before dispatch")
     unknownGroups = sorted(set(command["requestedGroups"]) - set(knownGroups))
     if unknownGroups:
         return rejectedDecision(
@@ -88,6 +151,11 @@ def decideDispatch(
     if not re.fullmatch(r"[0-9a-f]{40}", baseSHA or ""):
         return rejectedDecision(command, "pull request base revision is invalid")
     prNumber = pullRequest.get("number")
+    if command["headSHA"] != headSHA:
+        return rejectedDecision(command, "comment is bound to another pull request HEAD")
+    expectedNonce = requestNonce(prNumber, headSHA, baseSHA, catalogRevision)
+    if command["nonce"] != expectedNonce:
+        return rejectedDecision(command, "comment binding nonce is stale or invalid")
     approvalGeneration = event.get("comment", {}).get("id")
     if not isinstance(approvalGeneration, int) or approvalGeneration <= 0:
         return rejectedDecision(command, "comment identifier is invalid")
@@ -115,10 +183,13 @@ def decideDispatch(
         "approvalGeneration": approvalGeneration,
         "catalogRevision": catalogRevision,
         "requestKey": requestKey,
+        "controlledLabels": sorted(controlledLabels),
     }
 
 
 def executorRequestKey(request):
+    if request.get("automatic", False):
+        return ""
     payload = {
         "prNumber": request["prNumber"],
         "headSHA": request["headSHA"],
@@ -156,11 +227,24 @@ def mergeApprovedRequests(decision, priorRequests):
     merged["requestedGroups"] = canonicalRequestedGroups(groups, full)
     merged["full"] = full
     merged["approvalGeneration"] = approvalGeneration
+    merged["controlledLabels"] = sorted(
+        set(decision.get("controlledLabels", []))
+        | {
+            label
+            for request in priorRequests
+            for label in request.get("controlledLabels", [])
+        }
+    )
     merged["requestKey"] = executorRequestKey(merged)
     return merged
 
 
 def approvedRequest(pullRequest, catalog, commentPages):
+    currentControlledLabels = trustedControlledLabels(
+        catalog,
+        commentPages,
+        [label.get("name", "") for label in pullRequest.get("labels", [])],
+    )
     seed = {
         "prNumber": pullRequest["number"],
         "headSHA": pullRequest["head"]["sha"],
@@ -170,6 +254,7 @@ def approvedRequest(pullRequest, catalog, commentPages):
         "catalogRevision": e2eSelector.catalogRevision(catalog),
         "requestedGroups": [],
         "full": False,
+        "controlledLabels": currentControlledLabels,
     }
     approvals = []
     for page in commentPages:
@@ -186,6 +271,7 @@ def approvedRequest(pullRequest, catalog, commentPages):
                 and marker["headSHA"] == seed["headSHA"]
                 and marker["baseSHA"] == seed["baseSHA"]
                 and marker["catalogRevision"] == seed["catalogRevision"]
+                and marker.get("controlledLabels", []) == currentControlledLabels
             ):
                 approvals.append(marker)
     if not approvals:
@@ -204,6 +290,9 @@ def renderRequestMarker(request):
         ),
         "full": request["full"],
     }
+    controlledLabels = sorted(set(request.get("controlledLabels", [])))
+    if controlledLabels:
+        payload["controlledLabels"] = controlledLabels
     return "<!-- x86-e2e-request " + json.dumps(
         payload, sort_keys=True, separators=(",", ":")
     ) + " -->"
@@ -220,6 +309,9 @@ def renderApprovalIntent(request):
         ),
         "full": request["full"],
     }
+    controlledLabels = sorted(set(request.get("controlledLabels", [])))
+    if controlledLabels:
+        payload["controlledLabels"] = controlledLabels
     return "<!-- x86-e2e-intent " + json.dumps(
         payload, sort_keys=True, separators=(",", ":")
     ) + " -->"
@@ -236,6 +328,11 @@ def approvalIntents(pullRequest, catalog, commentPages):
     headSHA = pullRequest["head"]["sha"]
     baseSHA = pullRequest["base"]["sha"]
     catalogRevision = e2eSelector.catalogRevision(catalog)
+    currentControlledLabels = trustedControlledLabels(
+        catalog,
+        commentPages,
+        [label.get("name", "") for label in pullRequest.get("labels", [])],
+    )
     intents = []
     for page in commentPages:
         for comment in page:
@@ -251,9 +348,63 @@ def approvalIntents(pullRequest, catalog, commentPages):
                 and intent["headSHA"] == headSHA
                 and intent["baseSHA"] == baseSHA
                 and intent["catalogRevision"] == catalogRevision
+                and intent.get("controlledLabels", []) == currentControlledLabels
             ):
                 intents.append(intent)
     return intents
+
+
+def renderControlledLabelMarker(label, present):
+    payload = {"label": label, "present": bool(present)}
+    return "<!-- x86-e2e-label " + json.dumps(
+        payload, sort_keys=True, separators=(",", ":")
+    ) + " -->"
+
+
+def parseControlledLabelMarker(body):
+    match = re.search(r"<!-- x86-e2e-label (\{[^\n]*\}) -->", body)
+    if not match:
+        return None
+    marker = json.loads(match.group(1))
+    label = marker.get("label")
+    if not isinstance(label, str) or not re.fullmatch(
+        rf"e2e:(?:full|{groupPattern})", label
+    ):
+        raise ValueError("invalid controlled label marker")
+    if not isinstance(marker.get("present"), bool):
+        raise ValueError("invalid controlled label state")
+    return {"label": label, "present": marker["present"]}
+
+
+def trustedControlledLabels(catalog, commentPages, liveLabels):
+    knownLabels = {"e2e:full"} | {f"e2e:{group}" for group in catalog["groups"]}
+    live = set(liveLabels)
+    latest = {}
+    for page in commentPages:
+        for comment in page:
+            user = comment.get("user", {})
+            commentId = comment.get("id")
+            if (
+                user.get("login") != "github-actions[bot]"
+                or user.get("type") != "Bot"
+                or not isinstance(commentId, int)
+                or commentId <= 0
+            ):
+                continue
+            try:
+                marker = parseControlledLabelMarker(comment.get("body", ""))
+            except (ValueError, json.JSONDecodeError):
+                continue
+            if marker is None or marker["label"] not in knownLabels:
+                continue
+            prior = latest.get(marker["label"])
+            if prior is None or commentId > prior[0]:
+                latest[marker["label"]] = (commentId, marker["present"])
+    return sorted(
+        label
+        for label, (_, present) in latest.items()
+        if present and label in live
+    )
 
 
 def renderRerunMarker(runId, runAttempt, headSHA, baseSHA):
@@ -328,6 +479,7 @@ def validateRequestMarker(request):
     catalogRevision = request.get("catalogRevision")
     groups = request.get("requestedGroups")
     full = request.get("full")
+    controlledLabels = request.get("controlledLabels", [])
     if not re.fullmatch(r"[0-9a-f]{40}", headSHA or ""):
         raise ValueError("invalid request marker HEAD")
     if not re.fullmatch(r"[0-9a-f]{40}", baseSHA or ""):
@@ -343,7 +495,13 @@ def validateRequestMarker(request):
         raise ValueError("invalid request marker groups")
     if not isinstance(full, bool):
         raise ValueError("invalid request marker full value")
-    return {
+    if not isinstance(controlledLabels, list) or any(
+        not isinstance(label, str)
+        or not re.fullmatch(rf"e2e:(?:full|{groupPattern})", label)
+        for label in controlledLabels
+    ):
+        raise ValueError("invalid request marker controlled labels")
+    parsed = {
         "headSHA": headSHA,
         "baseSHA": baseSHA,
         "approvalGeneration": approvalGeneration,
@@ -351,6 +509,9 @@ def validateRequestMarker(request):
         "requestedGroups": canonicalRequestedGroups(groups, full),
         "full": full,
     }
+    if "controlledLabels" in request:
+        parsed["controlledLabels"] = sorted(set(controlledLabels))
+    return parsed
 
 
 def parseRequestMarker(body):
@@ -436,19 +597,28 @@ def parseExecutorRunName(name):
     match = re.fullmatch(
         rf"x86-e2e pr=([1-9][0-9]*) head=([0-9a-f]{{40}}) "
         rf"approval=([1-9][0-9]*) generation=([1-9][0-9]*) "
-        rf"groups=({groupPattern}(?:,{groupPattern})*|-) full=([01])",
+        rf"(?:mode=(automatic|approved) )?"
+        rf"groups=({groupPattern}(?:,{groupPattern})*|-) "
+        rf"(?:labels=(e2e:(?:full|{groupPattern})(?:,e2e:(?:full|{groupPattern}))*|-) )?"
+        rf"full=([01])",
         name,
     )
     if not match:
         raise ValueError("invalid x86 E2E executor run name")
-    groups = [] if match.group(5) == "-" else sorted(set(match.group(5).split(",")))
+    groups = [] if match.group(6) == "-" else sorted(set(match.group(6).split(",")))
+    labelsValue = match.group(7) or "-"
+    controlledLabels = (
+        [] if labelsValue == "-" else sorted(set(labelsValue.split(",")))
+    )
     return {
         "prNumber": int(match.group(1)),
         "headSHA": match.group(2),
         "approvalGeneration": int(match.group(3)),
         "dispatchGeneration": int(match.group(4)),
+        "automatic": match.group(5) == "automatic",
         "requestedGroups": groups,
-        "full": match.group(6) == "1",
+        "controlledLabels": controlledLabels,
+        "full": match.group(8) == "1",
     }
 
 
@@ -471,6 +641,7 @@ def latestExecutorRun(
         r"release-[A-Za-z0-9._-]+", baseRef or ""
     ):
         return None
+    matchingRuns = []
     for run in runs:
         if (
             run.get("path") != ".github/workflows/build-x86-image.yaml"
@@ -487,8 +658,15 @@ def latestExecutorRun(
             and metadata["prNumber"] == prNumber
             and metadata["headSHA"] == headSHA
         ):
+            matchingRuns.append((metadata, run))
+    if not matchingRuns:
+        return None
+    # An automatic run is a coverage probe and must never supersede a durable
+    # approved request that is already in flight for the same HEAD.
+    for metadata, run in matchingRuns:
+        if not metadata["automatic"]:
             return run
-    return None
+    return matchingRuns[0][1]
 
 
 def parseArgs():
@@ -500,6 +678,12 @@ def parseArgs():
     dispatch.add_argument("--permission", required=True)
     dispatch.add_argument("--pull-request-file", dest="pullRequestFile", required=True)
     dispatch.add_argument("--confirmed-head-sha", dest="confirmedHeadSHA", required=True)
+    dispatch.add_argument("--live-comment-file", dest="liveCommentFile", required=True)
+    dispatch.add_argument(
+        "--controlled-labels-file",
+        dest="controlledLabelsFile",
+        required=True,
+    )
     dispatch.add_argument("--decision-file", dest="decisionFile", required=True)
     return parser.parse_args()
 
@@ -510,6 +694,14 @@ def main():
         event = json.loads(Path(args.eventFile).read_text(encoding="utf-8"))
         catalog = json.loads(Path(args.catalog).read_text(encoding="utf-8"))
         pullRequest = json.loads(Path(args.pullRequestFile).read_text(encoding="utf-8"))
+        liveComment = json.loads(Path(args.liveCommentFile).read_text(encoding="utf-8"))
+        controlledLabels = json.loads(
+            Path(args.controlledLabelsFile).read_text(encoding="utf-8")
+        )
+        if not isinstance(controlledLabels, list) or any(
+            not isinstance(label, str) for label in controlledLabels
+        ):
+            raise SystemExit("controlled labels must be a JSON array of strings")
         decision = decideDispatch(
             event,
             args.permission,
@@ -517,6 +709,8 @@ def main():
             args.confirmedHeadSHA,
             set(catalog["groups"]),
             e2eSelector.catalogRevision(catalog),
+            liveComment,
+            controlledLabels,
         )
         Path(args.decisionFile).write_text(
             json.dumps(decision, indent=2) + "\n",

--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -18,6 +18,7 @@ infrastructureJobs = {
     "build-e2e-binaries",
     "e2e-selection",
     "e2e-control-validation",
+    "prepare-kind-node-images",
     "e2e-executor-result",
     "push",
 }
@@ -309,6 +310,18 @@ def catalogRevision(catalog):
     return hashlib.sha256(payload).hexdigest()
 
 
+def requestNonce(prNumber, headSHA, baseSHA, catalogRevisionValue):
+    payload = {
+        "prNumber": int(prNumber),
+        "headSHA": headSHA,
+        "baseSHA": baseSHA,
+        "catalogRevision": catalogRevisionValue,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:16]
+
+
 def deduplicateMatrix(entries):
     result = []
     seen = {}
@@ -330,6 +343,8 @@ def select(
     headSHA,
     forcedFullReason="",
     requestedFull=False,
+    prNumber=0,
+    baseSHA="",
 ):
     paths = sorted(set(paths))
     labels = sorted(set(labels))
@@ -372,6 +387,15 @@ def select(
     smoke = [{**entry, "selection": "smoke"} for entry in catalog["smoke"]]
     selected = [{**entry, "selection": "group"} for entry in expandGroups(catalog, effectiveGroups)]
     matrix = deduplicateMatrix(smoke + selected)
+    revision = catalogRevision(catalog)
+    nonce = ""
+    if (
+        isinstance(prNumber, int)
+        and prNumber > 0
+        and re.fullmatch(r"[0-9a-f]{40}", headSHA or "")
+        and re.fullmatch(r"[0-9a-f]{40}", baseSHA or "")
+    ):
+        nonce = requestNonce(prNumber, headSHA, baseSHA, revision)
     return {
         "schemaVersion": 1,
         "headSHA": headSHA,
@@ -385,7 +409,10 @@ def select(
         "full": full,
         "approvalRequired": bool(recommendedGroups),
         "fullReason": reason,
-        "catalogRevision": catalogRevision(catalog),
+        "catalogRevision": revision,
+        "prNumber": prNumber,
+        "baseSHA": baseSHA,
+        "requestNonce": nonce,
     }
 
 
@@ -484,10 +511,15 @@ def renderSummary(plan, changedPaths):
         lines.append(f"- Full-suite reason: {safeSummaryText(plan['fullReason'])}")
     if plan["approvalRequired"]:
         commandGroups = safeSummaryText(",".join(plan["recommendedGroups"]))
+        binding = ""
+        if plan.get("requestNonce"):
+            binding = (
+                f" --head {plan['headSHA']} --nonce {plan['requestNonce']}"
+            )
         lines.extend(
             [
-                "- Waiting for: `/test e2e`",
-                f"- Alternative: `/test e2e {commandGroups}`",
+                f"- Waiting for: `/test e2e{binding}`",
+                f"- Alternative: `/test e2e {commandGroups}{binding}`",
             ]
         )
     if plan["reasons"]:
@@ -525,6 +557,9 @@ def fallbackPlan(headSHA, error, workflow, source):
         "approvalRequired": False,
         "fullReason": reason,
         "catalogRevision": "",
+        "prNumber": 0,
+        "baseSHA": "",
+        "requestNonce": "",
     }
 
 
@@ -593,6 +628,8 @@ def parseArgs():
     parser.add_argument("--request-group", dest="requestGroup", action="append", default=[])
     parser.add_argument("--request-groups-json", dest="requestGroupsJSON", default="[]")
     parser.add_argument("--head-sha", dest="headSHA", required=True)
+    parser.add_argument("--base-sha", dest="baseSHA", default="")
+    parser.add_argument("--pr-number", dest="prNumber", type=int, default=0)
     parser.add_argument("--force-full-reason", dest="forceFullReason", default="")
     parser.add_argument("--request-full", dest="requestedFull", action="store_true")
     parser.add_argument("--plan-file", dest="planFile", required=True)
@@ -631,6 +668,8 @@ def main():
                 args.headSHA,
                 args.forceFullReason,
                 requestedFull=args.requestedFull,
+                prNumber=args.prNumber,
+                baseSHA=args.baseSHA,
             )
         except Exception as error:
             workflow = Path(args.workflow).read_text(encoding="utf-8")

--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -16,7 +16,6 @@ infrastructureJobs = {
     "build-kube-ovn",
     "build-vpc-nat-gateway",
     "build-e2e-binaries",
-    "netpol-path-filter",
     "e2e-selection",
     "e2e-executor-result",
     "push",
@@ -322,7 +321,15 @@ def deduplicateMatrix(entries):
     return result
 
 
-def select(catalog, paths, labels, requestedGroups, headSHA, forcedFullReason=""):
+def select(
+    catalog,
+    paths,
+    labels,
+    requestedGroups,
+    headSHA,
+    forcedFullReason="",
+    requestedFull=False,
+):
     paths = sorted(set(paths))
     labels = sorted(set(labels))
     requestedGroups = sorted(set(requestedGroups))
@@ -347,16 +354,19 @@ def select(catalog, paths, labels, requestedGroups, headSHA, forcedFullReason=""
         {"source": "request", "groups": [group], "reason": f"requested group {group}"}
         for group in requestedGroups
     )
-    reason = forcedFullReason or fullReason(
+    automaticFullReason = forcedFullReason or fullReason(
         catalog,
         paths,
         labels,
         pathGroups,
         classifiedPaths,
     )
-    full = bool(reason)
+    full = bool(automaticFullReason) or requestedFull
+    reason = automaticFullReason or (
+        "authorized request selected the full suite" if requestedFull else ""
+    )
     recommendedGroups = sorted(pathGroups | labelGroups) if not full else []
-    automaticGroups = sorted(knownGroups) if full else []
+    automaticGroups = sorted(knownGroups) if automaticFullReason else []
     effectiveGroups = sorted(knownGroups if full else selectedGroups)
     smoke = [{**entry, "selection": "smoke"} for entry in catalog["smoke"]]
     selected = [{**entry, "selection": "group"} for entry in expandGroups(catalog, effectiveGroups)]
@@ -367,6 +377,7 @@ def select(catalog, paths, labels, requestedGroups, headSHA, forcedFullReason=""
         "automaticGroups": automaticGroups,
         "recommendedGroups": recommendedGroups,
         "requestedGroups": requestedGroups,
+        "requestedFull": requestedFull and not bool(automaticFullReason),
         "selectedGroups": effectiveGroups,
         "matrix": matrix,
         "reasons": reasons,
@@ -377,19 +388,58 @@ def select(catalog, paths, labels, requestedGroups, headSHA, forcedFullReason=""
     }
 
 
+def executionPlan(catalog, plan, eventName):
+    if eventName not in {"pull_request", "push", "workflow_dispatch"}:
+        raise ValueError(f"unsupported x86 E2E workflow event: {eventName}")
+    if plan["full"]:
+        return plan
+    if eventName == "workflow_dispatch":
+        return {
+            **plan,
+            "recommendedGroups": [],
+            "approvalRequired": False,
+        }
+    if catalog is None:
+        raise ValueError("a valid catalog is required for a partial execution plan")
+    if eventName == "push":
+        reason = plan.get("fullReason") or "push requires the full suite"
+        return {
+            **plan,
+            "automaticGroups": sorted(catalog["groups"]),
+            "recommendedGroups": [],
+            "requestedFull": False,
+            "selectedGroups": sorted(catalog["groups"]),
+            "matrix": [
+                {**entry, "selection": "group"}
+                for entry in expandAll(catalog)
+            ],
+            "full": True,
+            "approvalRequired": False,
+            "fullReason": reason,
+        }
+    return {
+        **plan,
+        "selectedGroups": [],
+        "matrix": [{**entry, "selection": "smoke"} for entry in catalog["smoke"]],
+    }
+
+
 def renderSummary(plan, changedPaths):
-    groups = safeSummaryText(", ".join(plan["selectedGroups"]) or "smoke only")
+    groups = ", ".join(plan["selectedGroups"])
+    if not groups:
+        groups = "full suite" if plan["full"] else "smoke only"
+    groups = safeSummaryText(groups)
     recommended = safeSummaryText(", ".join(plan["recommendedGroups"]) or "none")
     requested = safeSummaryText(", ".join(plan["requestedGroups"]) or "none")
     automatic = (
         f"full suite ({len(plan['matrix'])} runner jobs)"
-        if plan["full"]
+        if plan["full"] and not plan.get("requestedFull", False)
         else f"mandatory smoke ({len(mandatorySmoke)} runner jobs)"
     )
     lines = [
-        "## x86 E2E selection shadow report",
+        "## x86 E2E selection report",
         "",
-        "> Shadow mode only: the current x86 E2E jobs still run unchanged.",
+        "> Automatic smoke or fail-closed full coverage starts immediately; deferred groups wait for an authorized comment.",
         "",
         f"- HEAD: `{plan['headSHA']}`",
         f"- Full suite: `{'yes' if plan['full'] else 'no'}`",
@@ -397,8 +447,8 @@ def renderSummary(plan, changedPaths):
         f"- Recommended deferred groups: {recommended}",
         f"- Requested groups: {requested}",
         f"- Approval required: `{'yes' if plan['approvalRequired'] else 'no'}`",
-        f"- Selected groups: {groups}",
-        f"- Proposed runner jobs: {len(plan['matrix'])}",
+        f"- Groups executing in this run: {groups}",
+        f"- Runner jobs in this run: {len(plan['matrix'])}",
         f"- Changed paths: {len(changedPaths)}",
     ]
     if plan["fullReason"]:
@@ -438,6 +488,7 @@ def fallbackPlan(headSHA, error, workflow, source):
         "automaticGroups": [],
         "recommendedGroups": [],
         "requestedGroups": [],
+        "requestedFull": False,
         "selectedGroups": [],
         "matrix": matrix,
         "reasons": [{"source": source, "groups": [], "reason": reason}],
@@ -514,6 +565,7 @@ def parseArgs():
     parser.add_argument("--request-groups-json", dest="requestGroupsJSON", default="[]")
     parser.add_argument("--head-sha", dest="headSHA", required=True)
     parser.add_argument("--force-full-reason", dest="forceFullReason", default="")
+    parser.add_argument("--request-full", dest="requestedFull", action="store_true")
     parser.add_argument("--plan-file", dest="planFile", required=True)
     parser.add_argument("--summary-file", dest="summaryFile")
     return parser.parse_args()
@@ -549,6 +601,7 @@ def main():
                 args.requestGroup + requestedGroups,
                 args.headSHA,
                 args.forceFullReason,
+                requestedFull=args.requestedFull,
             )
         except Exception as error:
             workflow = Path(args.workflow).read_text(encoding="utf-8")

--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -17,6 +17,7 @@ infrastructureJobs = {
     "build-vpc-nat-gateway",
     "build-e2e-binaries",
     "e2e-selection",
+    "e2e-control-validation",
     "e2e-executor-result",
     "push",
 }
@@ -389,15 +390,22 @@ def select(
 
 
 def executionPlan(catalog, plan, eventName):
-    if eventName not in {"pull_request", "push", "workflow_dispatch"}:
+    executionModes = {
+        "pull_request": "automatic",
+        "push": "push",
+        "workflow_dispatch": "approved",
+    }
+    if eventName not in executionModes:
         raise ValueError(f"unsupported x86 E2E workflow event: {eventName}")
+    executionMode = executionModes[eventName]
     if plan["full"]:
-        return plan
+        return {**plan, "executionMode": executionMode}
     if eventName == "workflow_dispatch":
         return {
             **plan,
             "recommendedGroups": [],
             "approvalRequired": False,
+            "executionMode": executionMode,
         }
     if catalog is None:
         raise ValueError("a valid catalog is required for a partial execution plan")
@@ -416,11 +424,13 @@ def executionPlan(catalog, plan, eventName):
             "full": True,
             "approvalRequired": False,
             "fullReason": reason,
+            "executionMode": executionMode,
         }
     return {
         **plan,
         "selectedGroups": [],
         "matrix": [{**entry, "selection": "smoke"} for entry in catalog["smoke"]],
+        "executionMode": executionMode,
     }
 
 
@@ -431,19 +441,38 @@ def renderSummary(plan, changedPaths):
     groups = safeSummaryText(groups)
     recommended = safeSummaryText(", ".join(plan["recommendedGroups"]) or "none")
     requested = safeSummaryText(", ".join(plan["requestedGroups"]) or "none")
-    automatic = (
-        f"full suite ({len(plan['matrix'])} runner jobs)"
-        if plan["full"] and not plan.get("requestedFull", False)
-        else f"mandatory smoke ({len(mandatorySmoke)} runner jobs)"
-    )
+    executionMode = plan.get("executionMode", "automatic")
+    if executionMode == "approved":
+        banner = "Authorized coverage is executing for this HEAD."
+        coverageLabel = "Authorized coverage"
+        coverage = (
+            f"full suite ({len(plan['matrix'])} runner jobs)"
+            if plan["full"]
+            else f"approved selection ({len(plan['matrix'])} runner jobs)"
+        )
+    elif executionMode == "push":
+        banner = "Push events execute the complete x86 E2E catalog."
+        coverageLabel = "Push coverage"
+        coverage = f"full suite ({len(plan['matrix'])} runner jobs)"
+    else:
+        banner = (
+            "Automatic smoke or fail-closed full coverage starts immediately; "
+            "deferred groups wait for an authorized comment."
+        )
+        coverageLabel = "Automatic coverage"
+        coverage = (
+            f"full suite ({len(plan['matrix'])} runner jobs)"
+            if plan["full"] and not plan.get("requestedFull", False)
+            else f"mandatory smoke ({len(mandatorySmoke)} runner jobs)"
+        )
     lines = [
         "## x86 E2E selection report",
         "",
-        "> Automatic smoke or fail-closed full coverage starts immediately; deferred groups wait for an authorized comment.",
+        f"> {banner}",
         "",
         f"- HEAD: `{plan['headSHA']}`",
         f"- Full suite: `{'yes' if plan['full'] else 'no'}`",
-        f"- Automatic coverage: {safeSummaryText(automatic)}",
+        f"- {coverageLabel}: {safeSummaryText(coverage)}",
         f"- Recommended deferred groups: {recommended}",
         f"- Requested groups: {requested}",
         f"- Approval required: `{'yes' if plan['approvalRequired'] else 'no'}`",

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -17,11 +17,21 @@ import e2e_selector as e2eSelector
 
 class E2EControlTest(unittest.TestCase):
     def testParsesSupportedCommentCommands(self):
+        headSHA = "a" * 40
+        nonce = "b" * 16
         cases = {
-            "/test e2e": ("dispatch", [], False),
-            "/test e2e policy,multi-cni": ("dispatch", ["multi-cni", "policy"], False),
-            "/test e2e-all": ("dispatch", [], True),
-            "/retest e2e-failed": ("rerun-failed", [], False),
+            f"/test e2e --head {headSHA} --nonce {nonce}": ("dispatch", [], False),
+            f"/test e2e policy,multi-cni --head {headSHA} --nonce {nonce}": (
+                "dispatch",
+                ["multi-cni", "policy"],
+                False,
+            ),
+            f"/test e2e-all --head {headSHA} --nonce {nonce}": ("dispatch", [], True),
+            f"/retest e2e-failed --head {headSHA} --nonce {nonce}": (
+                "rerun-failed",
+                [],
+                False,
+            ),
         }
 
         for body, expected in cases.items():
@@ -31,9 +41,12 @@ class E2EControlTest(unittest.TestCase):
                     (command["action"], command["requestedGroups"], command["full"]),
                     expected,
                 )
+                self.assertEqual(command["headSHA"], headSHA)
+                self.assertEqual(command["nonce"], nonce)
 
     def testRejectsMalformedOrInjectedCommands(self):
         for body in [
+            "/test e2e",
             "/test e2e policy bogus",
             "/test e2e policy;echo-owned",
             "/test e2e policy\n/test e2e-all",
@@ -49,13 +62,23 @@ class E2EControlTest(unittest.TestCase):
 
     def dispatchDecision(
         self,
-        body="/test e2e policy",
+        body=None,
         permission="write",
         observedHeadSHA="a" * 40,
         confirmedHeadSHA="a" * 40,
         state="open",
         baseRef="master",
+        controlledLabels=(),
     ):
+        catalog = json.loads((repoRoot / ".github/e2e-selection.json").read_text())
+        catalogRevision = e2eSelector.catalogRevision(catalog)
+        baseSHA = "b" * 40
+        if body is None:
+            nonce = e2eControl.requestNonce(7231, observedHeadSHA, baseSHA, catalogRevision)
+            body = f"/test e2e policy --head {observedHeadSHA} --nonce {nonce}"
+        elif " --head " not in body:
+            nonce = e2eControl.requestNonce(7231, observedHeadSHA, baseSHA, catalogRevision)
+            body = f"{body} --head {observedHeadSHA} --nonce {nonce}"
         event = {
             "action": "created",
             "comment": {"id": 1001, "body": body, "user": {"login": "maintainer"}},
@@ -66,16 +89,17 @@ class E2EControlTest(unittest.TestCase):
             "number": 7231,
             "state": state,
             "head": {"sha": observedHeadSHA},
-            "base": {"ref": baseRef, "sha": "b" * 40},
+            "base": {"ref": baseRef, "sha": baseSHA},
         }
-        catalog = json.loads((repoRoot / ".github/e2e-selection.json").read_text())
         return e2eControl.decideDispatch(
             event,
             permission,
             pullRequest,
             confirmedHeadSHA,
             set(catalog["groups"]),
-            e2eSelector.catalogRevision(catalog),
+            catalogRevision,
+            liveComment=event["comment"],
+            controlledLabels=controlledLabels,
         )
 
     def testAuthorizedCommandIsBoundToCurrentHead(self):
@@ -107,6 +131,57 @@ class E2EControlTest(unittest.TestCase):
         self.assertFalse(decision["accepted"])
         self.assertEqual(decision["reason"], "pull request HEAD changed; comment again")
 
+    def testCommentBindingCannotBeReplayedForAnotherHead(self):
+        catalog = json.loads((repoRoot / ".github/e2e-selection.json").read_text())
+        nonce = e2eControl.requestNonce(
+            7231,
+            "a" * 40,
+            "b" * 40,
+            e2eSelector.catalogRevision(catalog),
+        )
+        decision = self.dispatchDecision(
+            body=f"/test e2e --head {'a' * 40} --nonce {nonce}",
+            observedHeadSHA="c" * 40,
+            confirmedHeadSHA="c" * 40,
+        )
+
+        self.assertFalse(decision["accepted"])
+        self.assertEqual(decision["reason"], "comment is bound to another pull request HEAD")
+
+    def testEditedOrDeletedCommentEventCannotBeReplayed(self):
+        catalog = json.loads((repoRoot / ".github/e2e-selection.json").read_text())
+        catalogRevision = e2eSelector.catalogRevision(catalog)
+        nonce = e2eControl.requestNonce(7231, "a" * 40, "b" * 40, catalogRevision)
+        event = {
+            "action": "created",
+            "comment": {
+                "id": 1001,
+                "body": f"/test e2e --head {'a' * 40} --nonce {nonce}",
+                "user": {"login": "maintainer"},
+            },
+            "issue": {"number": 7231, "pull_request": {}},
+            "repository": {"full_name": "kubeovn/kube-ovn"},
+        }
+        pullRequest = {
+            "number": 7231,
+            "state": "open",
+            "head": {"sha": "a" * 40},
+            "base": {"ref": "master", "sha": "b" * 40},
+        }
+
+        decision = e2eControl.decideDispatch(
+            event,
+            "write",
+            pullRequest,
+            "a" * 40,
+            set(catalog["groups"]),
+            catalogRevision,
+            liveComment={**event["comment"], "body": "edited"},
+        )
+
+        self.assertFalse(decision["accepted"])
+        self.assertEqual(decision["reason"], "comment changed or was deleted before dispatch")
+
     def testClosedPullRequestIsRejected(self):
         decision = self.dispatchDecision(state="closed")
 
@@ -124,6 +199,20 @@ class E2EControlTest(unittest.TestCase):
 
         self.assertFalse(decision["accepted"])
         self.assertEqual(decision["reason"], "unknown requested E2E group: not-a-group")
+
+    def testTrustedControlledLabelsCanOnlyAddApprovedCoverage(self):
+        grouped = self.dispatchDecision(
+            body="/test e2e",
+            controlledLabels=["e2e:multi-cni", "e2e:policy"],
+        )
+        full = self.dispatchDecision(
+            body="/test e2e policy",
+            controlledLabels=["e2e:full"],
+        )
+
+        self.assertEqual(grouped["requestedGroups"], ["multi-cni", "policy"])
+        self.assertTrue(full["full"])
+        self.assertEqual(full["requestedGroups"], [])
 
     def testUnrelatedCommentProducesNoDecision(self):
         self.assertIsNone(self.dispatchDecision(body="looks good"))
@@ -283,6 +372,79 @@ class E2EControlTest(unittest.TestCase):
 
         self.assertEqual(intents, [intent])
 
+    def testControlledLabelsRequireLatestTrustedBotMarkerAndLivePresence(self):
+        catalog = e2eSelector.loadCatalog(repoRoot / ".github/e2e-selection.json")
+        policyPresent = e2eControl.renderControlledLabelMarker("e2e:policy", True)
+        policyRemoved = e2eControl.renderControlledLabelMarker("e2e:policy", False)
+        fullPresent = e2eControl.renderControlledLabelMarker("e2e:full", True)
+        pages = [[
+            {
+                "id": 10,
+                "user": {"login": "github-actions[bot]", "type": "Bot"},
+                "body": policyPresent,
+            },
+            {
+                "id": 11,
+                "user": {"login": "attacker", "type": "User"},
+                "body": fullPresent,
+            },
+            {
+                "id": 12,
+                "user": {"login": "github-actions[bot]", "type": "Bot"},
+                "body": policyRemoved,
+            },
+            {
+                "id": 13,
+                "user": {"login": "github-actions[bot]", "type": "Bot"},
+                "body": fullPresent,
+            },
+        ]]
+
+        labels = e2eControl.trustedControlledLabels(
+            catalog,
+            pages,
+            ["e2e:policy", "e2e:full", "e2e:unknown"],
+        )
+
+        self.assertEqual(labels, ["e2e:full"])
+        self.assertEqual(
+            e2eControl.parseControlledLabelMarker(fullPresent),
+            {"label": "e2e:full", "present": True},
+        )
+
+    def testApprovalMarkerIsInvalidatedWhenTrustedLabelsChange(self):
+        catalog = e2eSelector.loadCatalog(repoRoot / ".github/e2e-selection.json")
+        pullRequest = {
+            "number": 7231,
+            "head": {"sha": "a" * 40},
+            "base": {"ref": "master", "sha": "b" * 40},
+            "labels": [{"name": "e2e:policy"}],
+        }
+        catalogRevision = e2eSelector.catalogRevision(catalog)
+        pages = [[
+            {
+                "id": 10,
+                "user": {"login": "github-actions[bot]", "type": "Bot"},
+                "body": e2eControl.renderControlledLabelMarker("e2e:policy", True),
+            },
+            {
+                "id": 11,
+                "user": {"login": "github-actions[bot]", "type": "Bot"},
+                "body": e2eControl.renderRequestMarker(
+                    {
+                        "headSHA": "a" * 40,
+                        "baseSHA": "b" * 40,
+                        "approvalGeneration": 1001,
+                        "catalogRevision": catalogRevision,
+                        "requestedGroups": ["policy"],
+                        "full": False,
+                    }
+                ),
+            },
+        ]]
+
+        self.assertIsNone(e2eControl.approvedRequest(pullRequest, catalog, pages))
+
     def testRerunAuthorizationMarkerBindsExactAttempt(self):
         marker = e2eControl.renderRerunMarker(42, 2, "a" * 40, "b" * 40)
         pages = [[
@@ -377,7 +539,7 @@ class E2EControlTest(unittest.TestCase):
         metadata = e2eControl.parseExecutorRunName(
             "x86-e2e pr=7231 head="
             + "a" * 40
-            + " approval=1001 generation=2001 groups=multi-cni,policy full=0"
+            + " approval=1001 generation=2001 mode=approved groups=multi-cni,policy labels=- full=0"
         )
 
         self.assertEqual(metadata["prNumber"], 7231)
@@ -385,7 +547,22 @@ class E2EControlTest(unittest.TestCase):
         self.assertEqual(metadata["approvalGeneration"], 1001)
         self.assertEqual(metadata["dispatchGeneration"], 2001)
         self.assertEqual(metadata["requestedGroups"], ["multi-cni", "policy"])
+        self.assertEqual(metadata["controlledLabels"], [])
+        self.assertFalse(metadata["automatic"])
         self.assertFalse(metadata["full"])
+
+    def testParsesTrustedAutomaticExecutorRunName(self):
+        metadata = e2eControl.parseExecutorRunName(
+            "x86-e2e pr=7231 head="
+            + "a" * 40
+            + " approval=1 generation=2001 mode=automatic groups=- labels=e2e:policy full=0"
+        )
+        metadata["baseSHA"] = "b" * 40
+        metadata["catalogRevision"] = "c" * 64
+
+        self.assertTrue(metadata["automatic"])
+        self.assertEqual(metadata["controlledLabels"], ["e2e:policy"])
+        self.assertEqual(e2eControl.executorRequestKey(metadata), "")
 
     def testFullRequestIdentityIgnoresRequestedGroups(self):
         request = {
@@ -426,7 +603,7 @@ class E2EControlTest(unittest.TestCase):
             e2eControl.parseExecutorRunName(
                 "x86-e2e pr=7231 head="
                 + "a" * 40
-                + " approval=0 generation=2001 groups=multi-cni,policy full=0"
+                + " approval=0 generation=2001 mode=approved groups=multi-cni,policy labels=- full=0"
             )
 
     def testLatestExecutorRunRejectsUntrustedCandidates(self):
@@ -447,7 +624,7 @@ class E2EControlTest(unittest.TestCase):
         title = (
             "x86-e2e pr=7231 head="
             + "a" * 40
-            + " approval=1001 generation=2001 groups=policy full=0"
+            + " approval=1001 generation=2001 mode=approved groups=policy labels=- full=0"
         )
         trusted = {
             "id": 3,
@@ -478,7 +655,7 @@ class E2EControlTest(unittest.TestCase):
             "display_title": (
                 "x86-e2e pr=7231 head="
                 + "a" * 40
-                + " approval=1001 generation=2001 groups=policy full=0"
+                + " approval=1001 generation=2001 mode=approved groups=policy labels=- full=0"
             ),
         }
 
@@ -503,17 +680,67 @@ class E2EControlTest(unittest.TestCase):
             )
         )
 
+    def testLatestExecutorRunPrefersApprovedCoverageOverAutomaticProbe(self):
+        head = "a" * 40
+        base = "d" * 40
+        automatic = {
+            "id": 9,
+            "path": ".github/workflows/build-x86-image.yaml",
+            "actor": {"login": "github-actions[bot]"},
+            "head_branch": "x86-e2e/pr-7231-a-1-d-2002",
+            "head_sha": base,
+            "display_title": (
+                "x86-e2e pr=7231 head=" + head
+                + " approval=1 generation=2002 mode=automatic groups=- labels=- full=0"
+            ),
+        }
+        approved = {
+            **automatic,
+            "id": 8,
+            "head_branch": "x86-e2e/pr-7231-a-1-d-2001",
+            "display_title": (
+                "x86-e2e pr=7231 head=" + head
+                + " approval=1 generation=2001 mode=approved groups=policy labels=- full=0"
+            ),
+        }
+
+        latest = e2eControl.latestExecutorRun(
+            [automatic, approved], 7231, head, "master", None, base
+        )
+
+        self.assertEqual(latest["id"], 8)
+
     def testDispatchCliWritesDecisionJson(self):
         with tempfile.TemporaryDirectory() as directory:
             directory = Path(directory)
             event = directory / "event.json"
             pullRequest = directory / "pr.json"
+            liveComment = directory / "comment.json"
+            controlledLabels = directory / "controlled-labels.json"
             decision = directory / "decision.json"
             event.write_text(
                 json.dumps(
                     {
                         "action": "created",
-                        "comment": {"id": 1001, "body": "/test e2e policy", "user": {"login": "maintainer"}},
+                        "comment": {
+                            "id": 1001,
+                            "body": (
+                                "/test e2e policy --head "
+                                + "a" * 40
+                                + " --nonce "
+                                + e2eControl.requestNonce(
+                                    7231,
+                                    "a" * 40,
+                                    "b" * 40,
+                                    e2eSelector.catalogRevision(
+                                        e2eSelector.loadCatalog(
+                                            repoRoot / ".github/e2e-selection.json"
+                                        )
+                                    ),
+                                )
+                            ),
+                            "user": {"login": "maintainer"},
+                        },
                         "issue": {"number": 7231, "pull_request": {"url": "https://api.example/pr/7231"}},
                         "repository": {"full_name": "kubeovn/kube-ovn"},
                     }
@@ -529,6 +756,8 @@ class E2EControlTest(unittest.TestCase):
                     }
                 )
             )
+            liveComment.write_text(json.dumps(json.loads(event.read_text())["comment"]))
+            controlledLabels.write_text("[]")
 
             subprocess.run(
                 [
@@ -543,6 +772,10 @@ class E2EControlTest(unittest.TestCase):
                     str(pullRequest),
                     "--confirmed-head-sha",
                     "a" * 40,
+                    "--live-comment-file",
+                    str(liveComment),
+                    "--controlled-labels-file",
+                    str(controlledLabels),
                     "--decision-file",
                     str(decision),
                 ],
@@ -556,7 +789,10 @@ class E2EControlTest(unittest.TestCase):
         workflow = (repoRoot / ".github/workflows/x86-e2e-dispatcher.yaml").read_text()
 
         self.assertIn("issue_comment:\n    types: [created]", workflow)
-        self.assertIn("pull_request_target:\n    types: [synchronize, closed]", workflow)
+        self.assertIn(
+            "pull_request_target:\n    types: [opened, reopened, synchronize, labeled, unlabeled, closed]",
+            workflow,
+        )
         self.assertIn("push:\n    branches:", workflow)
         self.assertIn("name: Invalidate x86 E2E gates after a base update", workflow)
         self.assertIn("inputs[baseRefresh]=true", workflow)
@@ -567,8 +803,15 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("pull-requests: read", workflow)
         self.assertIn("issues: write", workflow)
         self.assertIn("--catalog trusted-catalog.json", workflow)
+        self.assertIn("--live-comment-file live-comment.json", workflow)
+        self.assertIn("issues/comments/$COMMENT_ID", workflow)
         self.assertIn("e2e-selection.json?ref=$baseRef", workflow)
         self.assertIn("Cancel obsolete x86 E2E executors", workflow)
+        self.assertIn("Record trusted x86 E2E controlled labels", workflow)
+        self.assertIn("collaborators/$SENDER/permission", workflow)
+        self.assertIn("renderControlledLabelMarker", workflow)
+        self.assertIn("trustedControlledLabels", workflow)
+        self.assertIn("labels/$encodedLabel", workflow)
         self.assertIn("live-pull-request.json", workflow)
         self.assertNotIn("Recorded x86 E2E approval", workflow)
         self.assertNotIn("Queued x86 E2E approval intent", workflow)
@@ -631,6 +874,11 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}", workflow)
         self.assertIn("RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}", workflow)
         self.assertIn("RUN_TRIGGERING_ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}", workflow)
+        self.assertIn("automatic: ${{ steps.context.outputs.automatic }}", workflow)
+        self.assertIn("controlledLabels: ${{ steps.context.outputs.controlledLabels }}", workflow)
+        self.assertIn("A trusted comment approval supersedes this automatic executor.", workflow)
+        self.assertIn("Controlled label provenance changed; the automatic executor is stale.", workflow)
+        self.assertIn("CONTROLLED_LABELS: ${{ steps.context.outputs.controlledLabels }}", workflow)
         self.assertIn("currentTriggeringActor=$(jq -r", workflow)
         self.assertIn("[ \"$RUN_TRIGGERING_ACTOR\" = 'github-actions[bot]' ]", workflow)
         self.assertGreaterEqual(workflow.count("isAuthorizedRunAttempt"), 6)
@@ -736,6 +984,10 @@ class E2EControlTest(unittest.TestCase):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
 
         self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("automatic:", workflow)
+        self.assertIn("controlledLabels:", workflow)
+        self.assertIn("inputs.automatic && 'automatic'", workflow)
+        self.assertIn("EVENT_NAME: ${{ inputs.automatic && 'pull_request' || github.event_name }}", workflow)
         self.assertIn(
             "GH_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.token || '' }}",
             workflow,
@@ -759,9 +1011,12 @@ class E2EControlTest(unittest.TestCase):
         self.assertNotIn("checks: write", workflow)
         self.assertNotIn("GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}", workflow)
         self.assertIn(
-            "GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}",
+            "Pull private Kind node image with trusted token",
             workflow,
         )
+        self.assertIn("kind-node-v1.36.1.tar", workflow)
+        self.assertIn("kind-node-v1.29.14.tar", workflow)
+        self.assertNotIn("kind-ghcr-pull", workflow)
         self.assertIn(
             "EXECUTION_SHA: ${{ github.event_name == 'pull_request' && "
             "github.event.pull_request.head.sha || inputs.headSHA || github.sha }}",
@@ -821,7 +1076,7 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("permissions:\n      contents: read", validationBlock)
         self.assertIn("python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py", validationBlock)
         resultBlock = blocks["e2e-executor-result"]
-        self.assertIn("if: always()", resultBlock)
+        self.assertIn("if: always() && github.event_name != 'pull_request'", resultBlock)
         self.assertIn("permissions: {}", resultBlock)
         self.assertIn(
             'requiredJobIds = ["e2e-selection", "e2e-control-validation"] + selectedJobIds',

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+import re
 import subprocess
 import sys
 import tempfile
@@ -614,7 +615,7 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("print(e2eControl.executorHeadBranch(request))", workflow)
         self.assertIn('git/refs/heads/$executorRef', workflow)
         self.assertIn('-f ref="$executorRef"', workflow)
-        self.assertNotIn("inputs.headSHA || github.sha", workflow)
+        self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
 
     def testGateWorkflowCanOnlyReadRunsAndWriteChecks(self):
         workflow = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()
@@ -718,13 +719,15 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("attempt <= currentAttempt", workflow)
         self.assertIn("executed-selection-plan.json", workflow)
         self.assertIn("expectedCount >= 3000", workflow)
+        self.assertIn("args+=(--request-full)", workflow)
+        self.assertNotIn("args+=(--label e2e:full)", workflow)
         self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
         self.assertIn("ref: ${{ steps.context.outputs.trustedRef }}", workflow)
         self.assertNotIn("ref: ${{ steps.context.outputs.baseRef }}", workflow)
-        self.assertNotIn("inputs.headSHA || github.sha", workflow)
+        self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
         self.assertNotIn("contents: write", workflow)
 
-    def testExecutorDispatchKeepsPullRequestAndPushCoverageUnchanged(self):
+    def testPullRequestsExecuteAutomaticCoverageAndPushStaysFull(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
         blocks = e2eSelector.workflowJobBlocks(workflow)
         catalog = e2eSelector.loadCatalog(repoRoot / ".github/e2e-selection.json")
@@ -744,8 +747,8 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("executor workflow revision does not match the approved base", workflow)
         self.assertIn("trusted selector checkout does not match the approved base revision", workflow)
         self.assertIn("ref: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSHA", workflow)
-        self.assertGreaterEqual(workflow.count("github.actor == 'github-actions[bot]'"), 6)
-        self.assertGreaterEqual(workflow.count("needs: e2e-selection"), 3)
+        self.assertGreaterEqual(workflow.count("github.actor == 'github-actions[bot]'"), 5)
+        self.assertGreaterEqual(workflow.count("needs: e2e-selection"), 2)
         self.assertNotIn('entry["selection"] != "smoke"', workflow)
         self.assertIn("contents: read", workflow)
         self.assertIn("packages: read", workflow)
@@ -757,8 +760,8 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("allowed=('TAG','GO_VERSION','E2E_DIR','VERSION','DEBUG_WRAPPER')", workflow)
         self.assertNotIn("actions: write", workflow)
         self.assertNotIn("checks: write", workflow)
-        self.assertIn("GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}", workflow)
-        self.assertNotIn(
+        self.assertNotIn("GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}", workflow)
+        self.assertIn(
             "GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}",
             workflow,
         )
@@ -777,21 +780,59 @@ class E2EControlTest(unittest.TestCase):
             workflow,
         )
         self.assertIn("--force-full-reason \"$FORCE_FULL_REASON\"", workflow)
+        self.assertIn("--request-full", workflow)
+        self.assertNotIn("args+=(--label e2e:full)", workflow)
         self.assertIn("expectedCount >= 3000", workflow)
-        self.assertIn("e2eSelector.expandWorkflow(workflow)", workflow)
+        self.assertIn(
+            'e2eSelector.executionPlan(catalog, plan, os.environ["EVENT_NAME"])',
+            workflow,
+        )
+        self.assertIn("except Exception:\n              catalog = None", workflow)
+        self.assertIn(
+            '"${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"',
+            workflow,
+        )
+        self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
+        self.assertGreaterEqual(
+            workflow.count(
+                "github.event.pull_request.head.sha || inputs.headSHA || github.sha"
+            ),
+            31,
+        )
+        self.assertIn(
+            '"e2e-selection-plan.json",\n              "e2e-selection-summary.md",',
+            workflow,
+        )
+        self.assertNotIn("continue-on-error:", blocks["e2e-selection"])
+        self.assertNotIn("e2eSelector.expandWorkflow(workflow)", workflow)
         resultBlock = blocks["e2e-executor-result"]
+        self.assertIn("if: always()", resultBlock)
         self.assertIn("permissions: {}", resultBlock)
         self.assertIn("selected x86 E2E Jobs did not succeed", resultBlock)
+        self.assertNotIn("netpol-path-filter", blocks)
+        resultNeeds = set(re.findall(r"(?m)^      - ([a-z0-9-]+)$", resultBlock))
+        self.assertEqual(resultNeeds, testJobs | {"e2e-selection"})
+        pushNeeds = set(re.findall(r"(?m)^      - ([a-z0-9-]+)$", blocks["push"]))
+        self.assertEqual(pushNeeds, {"e2e-executor-result"})
         for jobId in testJobs:
             with self.subTest(jobId=jobId):
                 self.assertIn(f"      - {jobId}\n", resultBlock)
                 block = blocks[jobId]
                 self.assertRegex(block, r"(?m)^    needs:(?:\n      - .+)+\n")
                 self.assertIn("e2e-selection", block)
-                self.assertIn("github.event_name != 'workflow_dispatch'", block)
-                self.assertIn("inputs.headSHA || github.sha", block)
+                self.assertIn(
+                    f"contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), '{jobId}')",
+                    block,
+                )
+                self.assertNotIn("github.event_name != 'workflow_dispatch'", block)
+                self.assertIn(
+                    "github.event.pull_request.head.sha || inputs.headSHA || github.sha",
+                    block,
+                )
                 self.assertIn("persist-credentials: false", block)
-        self.assertIn("github.event_name != 'workflow_dispatch'", blocks["push"])
+        self.assertIn("github.event_name == 'push'", blocks["push"])
+        self.assertIn("needs.e2e-executor-result.result == 'success'", blocks["push"])
+        self.assertNotIn("github.event_name != 'workflow_dispatch'", blocks["push"])
 
     def testKindPullUsesAnonymousGhcrWhenTokenIsAbsent(self):
         makefile = (repoRoot / "makefiles/kind.mk").read_text()

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -874,6 +874,14 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}", workflow)
         self.assertIn("RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}", workflow)
         self.assertIn("RUN_TRIGGERING_ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}", workflow)
+        self.assertIn(
+            "RUN_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}",
+            workflow,
+        )
+        self.assertIn('-f "head=$headOwner:$RUN_HEAD_BRANCH"', workflow)
+        self.assertIn("workflow HEAD must resolve to exactly one open pull request", workflow)
+        self.assertIn('.head.repo.full_name == $headRepository', workflow)
+        self.assertIn('.base.repo.full_name == $repository', workflow)
         self.assertIn("automatic: ${{ steps.context.outputs.automatic }}", workflow)
         self.assertIn("controlledLabels: ${{ steps.context.outputs.controlledLabels }}", workflow)
         self.assertIn("A trusted comment approval supersedes this automatic executor.", workflow)

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -721,21 +721,19 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("expectedCount >= 3000", workflow)
         self.assertIn("args+=(--request-full)", workflow)
         self.assertNotIn("args+=(--label e2e:full)", workflow)
+        self.assertIn(
+            'e2eSelector.executionPlan(catalog, plan, os.environ["EXECUTION_EVENT"])',
+            workflow,
+        )
+        self.assertIn("EXECUTION_EVENT: ${{ steps.context.outputs.approved == 'true'", workflow)
         self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
         self.assertIn("ref: ${{ steps.context.outputs.trustedRef }}", workflow)
         self.assertNotIn("ref: ${{ steps.context.outputs.baseRef }}", workflow)
         self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
         self.assertNotIn("contents: write", workflow)
 
-    def testPullRequestsExecuteAutomaticCoverageAndPushStaysFull(self):
+    def testExecutorWorkflowUsesUnprivilegedExactHeadContext(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
-        blocks = e2eSelector.workflowJobBlocks(workflow)
-        catalog = e2eSelector.loadCatalog(repoRoot / ".github/e2e-selection.json")
-        testJobs = {
-            job["id"]
-            for group in catalog["groups"].values()
-            for job in group["jobs"]
-        }
 
         self.assertIn("workflow_dispatch:", workflow)
         self.assertIn(
@@ -748,7 +746,6 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("trusted selector checkout does not match the approved base revision", workflow)
         self.assertIn("ref: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSHA", workflow)
         self.assertGreaterEqual(workflow.count("github.actor == 'github-actions[bot]'"), 5)
-        self.assertGreaterEqual(workflow.count("needs: e2e-selection"), 2)
         self.assertNotIn('entry["selection"] != "smoke"', workflow)
         self.assertIn("contents: read", workflow)
         self.assertIn("packages: read", workflow)
@@ -765,6 +762,34 @@ class E2EControlTest(unittest.TestCase):
             "GHCR_TOKEN: ${{ github.event_name == 'push' && secrets.GITHUB_TOKEN || '' }}",
             workflow,
         )
+        self.assertIn(
+            "EXECUTION_SHA: ${{ github.event_name == 'pull_request' && "
+            "github.event.pull_request.head.sha || inputs.headSHA || github.sha }}",
+            workflow,
+        )
+        self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
+        self.assertNotIn("github.event.pull_request.head.sha || inputs.headSHA", workflow.replace(
+            "EXECUTION_SHA: ${{ github.event_name == 'pull_request' && "
+            "github.event.pull_request.head.sha || inputs.headSHA || github.sha }}",
+            "",
+        ))
+        self.assertGreaterEqual(workflow.count("ref: ${{ env.EXECUTION_SHA }}"), 31)
+        self.assertIn(
+            '"${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"',
+            workflow,
+        )
+
+    def testPullRequestsExecuteAutomaticCoverageAndPushStaysFull(self):
+        workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
+        blocks = e2eSelector.workflowJobBlocks(workflow)
+        catalog = e2eSelector.loadCatalog(repoRoot / ".github/e2e-selection.json")
+        testJobs = {
+            job["id"]
+            for group in catalog["groups"].values()
+            for job in group["jobs"]
+        }
+
+        self.assertGreaterEqual(workflow.count("needs: e2e-selection"), 2)
         self.assertIn("Initialize fail-closed conformance matrices", workflow)
         self.assertIn("steps.fallbackMatrices.outputs.k8sConformanceMatrix", workflow)
         self.assertIn(
@@ -775,10 +800,7 @@ class E2EControlTest(unittest.TestCase):
             "matrix: ${{ fromJSON(needs.e2e-selection.outputs.kubeOvnConformanceMatrix) }}",
             blocks["kube-ovn-conformance-e2e"],
         )
-        self.assertIn(
-            "if: github.event_name == 'push'\n        uses: actions/cache@v6",
-            workflow,
-        )
+        self.assertIn("if: github.event_name == 'push'\n        uses: actions/cache@v6", workflow)
         self.assertIn("--force-full-reason \"$FORCE_FULL_REASON\"", workflow)
         self.assertIn("--request-full", workflow)
         self.assertNotIn("args+=(--label e2e:full)", workflow)
@@ -787,31 +809,31 @@ class E2EControlTest(unittest.TestCase):
             'e2eSelector.executionPlan(catalog, plan, os.environ["EVENT_NAME"])',
             workflow,
         )
-        self.assertIn("except Exception:\n              catalog = None", workflow)
-        self.assertIn(
-            '"${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"',
-            workflow,
-        )
-        self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
-        self.assertGreaterEqual(
-            workflow.count(
-                "github.event.pull_request.head.sha || inputs.headSHA || github.sha"
-            ),
-            31,
-        )
+        self.assertIn("except Exception as error:", workflow)
+        self.assertIn("failed to reload the E2E catalog", workflow)
         self.assertIn(
             '"e2e-selection-plan.json",\n              "e2e-selection-summary.md",',
             workflow,
         )
         self.assertNotIn("continue-on-error:", blocks["e2e-selection"])
         self.assertNotIn("e2eSelector.expandWorkflow(workflow)", workflow)
+        validationBlock = blocks["e2e-control-validation"]
+        self.assertIn("permissions:\n      contents: read", validationBlock)
+        self.assertIn("python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py", validationBlock)
         resultBlock = blocks["e2e-executor-result"]
         self.assertIn("if: always()", resultBlock)
         self.assertIn("permissions: {}", resultBlock)
-        self.assertIn("selected x86 E2E Jobs did not succeed", resultBlock)
+        self.assertIn(
+            'requiredJobIds = ["e2e-selection", "e2e-control-validation"] + selectedJobIds',
+            resultBlock,
+        )
+        self.assertIn("required x86 E2E Jobs did not succeed", resultBlock)
         self.assertNotIn("netpol-path-filter", blocks)
         resultNeeds = set(re.findall(r"(?m)^      - ([a-z0-9-]+)$", resultBlock))
-        self.assertEqual(resultNeeds, testJobs | {"e2e-selection"})
+        self.assertEqual(
+            resultNeeds,
+            testJobs | {"e2e-selection", "e2e-control-validation"},
+        )
         pushNeeds = set(re.findall(r"(?m)^      - ([a-z0-9-]+)$", blocks["push"]))
         self.assertEqual(pushNeeds, {"e2e-executor-result"})
         for jobId in testJobs:
@@ -820,15 +842,13 @@ class E2EControlTest(unittest.TestCase):
                 block = blocks[jobId]
                 self.assertRegex(block, r"(?m)^    needs:(?:\n      - .+)+\n")
                 self.assertIn("e2e-selection", block)
+                self.assertNotIn("e2e-control-validation", block)
                 self.assertIn(
                     f"contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), '{jobId}')",
                     block,
                 )
                 self.assertNotIn("github.event_name != 'workflow_dispatch'", block)
-                self.assertIn(
-                    "github.event.pull_request.head.sha || inputs.headSHA || github.sha",
-                    block,
-                )
+                self.assertIn("ref: ${{ env.EXECUTION_SHA }}", block)
                 self.assertIn("persist-credentials: false", block)
         self.assertIn("github.event_name == 'push'", blocks["push"])
         self.assertIn("needs.e2e-executor-result.result == 'success'", blocks["push"])

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -950,6 +950,19 @@ class E2EControlTest(unittest.TestCase):
         )
         self.assertGreaterEqual(workflow.count("approvalIntents"), 2)
 
+    def testWorkflowDispatchInputsUseGitHubRESTStringFields(self):
+        for workflowName in ["x86-e2e-dispatcher.yaml", "x86-e2e-gate.yaml"]:
+            with self.subTest(workflow=workflowName):
+                workflow = (repoRoot / ".github/workflows" / workflowName).read_text()
+                typedInputs = re.findall(r"-F\s+['\"]inputs\[", workflow)
+
+                self.assertEqual(
+                    typedInputs,
+                    [],
+                    "workflow_dispatch REST inputs must use -f so GitHub can "
+                    "validate and coerce them using the target workflow schema",
+                )
+
     def testGateWorkflowRecoversTrustedTerminalDecisions(self):
         workflow = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()
 

--- a/hack/test_e2e_selector.py
+++ b/hack/test_e2e_selector.py
@@ -25,7 +25,9 @@ class E2ESelectorTest(unittest.TestCase):
             paths,
             labels,
             requestedGroups,
-            "0123456789abcdef",
+            "a" * 40,
+            prNumber=7231,
+            baseSHA="b" * 40,
         )
 
     def testCatalogCoversCurrentX86TestJobs(self):
@@ -453,7 +455,7 @@ class E2ESelectorTest(unittest.TestCase):
     def testPlanIsJsonSerializableAndBoundToHead(self):
         plan = self.select(["test/e2e/ipsec/e2e_test.go"])
 
-        self.assertEqual(plan["headSHA"], "0123456789abcdef")
+        self.assertEqual(plan["headSHA"], "a" * 40)
         self.assertEqual(plan["schemaVersion"], 1)
         self.assertIn("catalogRevision", plan)
         json.dumps(plan)
@@ -519,8 +521,15 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertIn("Automatic coverage: mandatory smoke &#40;3 runner jobs&#41;", summary)
         self.assertIn("Recommended deferred groups: policy", summary)
         self.assertIn("Approval required: `yes`", summary)
-        self.assertIn("Waiting for: `/test e2e`", summary)
-        self.assertIn("Alternative: `/test e2e policy`", summary)
+        nonce = e2eSelector.requestNonce(
+            7231,
+            "a" * 40,
+            "b" * 40,
+            plan["catalogRevision"],
+        )
+        binding = f"--head {'a' * 40} --nonce {nonce}"
+        self.assertIn(f"Waiting for: `/test e2e {binding}`", summary)
+        self.assertIn(f"Alternative: `/test e2e policy {binding}`", summary)
 
     def testCatalogFailureEmitsFullFallbackPlan(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/hack/test_e2e_selector.py
+++ b/hack/test_e2e_selector.py
@@ -150,12 +150,16 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertEqual(executionPlan["selectedGroups"], ["bgp-routing", "policy"])
         self.assertEqual(executionPlan["recommendedGroups"], [])
         self.assertFalse(executionPlan["approvalRequired"])
+        self.assertEqual(executionPlan["executionMode"], "approved")
         self.assertEqual(len(executionPlan["matrix"]), 19)
         summary = e2eSelector.renderSummary(
             executionPlan,
             ["test/e2e/cnp-domain/e2e_test.go"],
         )
         self.assertIn("Approval required: `no`", summary)
+        self.assertIn("Authorized coverage: approved selection &#40;19 runner jobs&#41;", summary)
+        self.assertIn("Authorized coverage is executing for this HEAD", summary)
+        self.assertNotIn("deferred groups wait", summary)
         self.assertNotIn("Waiting for:", summary)
 
     def testPushExecutesTheCompleteSuite(self):
@@ -371,8 +375,17 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertEqual(plan["selectedGroups"], sorted(self.catalog["groups"]))
         self.assertEqual(len(plan["matrix"]), 82)
         self.assertEqual(plan["fullReason"], "authorized request selected the full suite")
-        summary = e2eSelector.renderSummary(plan, ["test/e2e/cnp-domain/e2e_test.go"])
-        self.assertIn("Automatic coverage: mandatory smoke &#40;3 runner jobs&#41;", summary)
+        executionPlan = e2eSelector.executionPlan(
+            self.catalog,
+            plan,
+            "workflow_dispatch",
+        )
+        summary = e2eSelector.renderSummary(
+            executionPlan,
+            ["test/e2e/cnp-domain/e2e_test.go"],
+        )
+        self.assertIn("Authorized coverage: full suite &#40;82 runner jobs&#41;", summary)
+        self.assertNotIn("Automatic coverage: mandatory smoke", summary)
         self.assertIn("Runner jobs in this run: 82", summary)
 
     def testInvalidRequestedGroupFails(self):
@@ -583,7 +596,7 @@ class E2ESelectorTest(unittest.TestCase):
         )
         self.assertEqual(len(plan["matrix"]), 82)
         executionPlan = e2eSelector.executionPlan(None, plan, "pull_request")
-        self.assertEqual(executionPlan, plan)
+        self.assertEqual(executionPlan, {**plan, "executionMode": "automatic"})
         summary = e2eSelector.renderSummary(executionPlan, [])
         self.assertIn("Automatic coverage: full suite &#40;82 runner jobs&#41;", summary)
         self.assertIn("Groups executing in this run: full suite", summary)

--- a/hack/test_e2e_selector.py
+++ b/hack/test_e2e_selector.py
@@ -117,6 +117,55 @@ class E2ESelectorTest(unittest.TestCase):
             6,
         )
 
+    def testPullRequestExecutesOnlyAutomaticSmokeWhileGroupsWait(self):
+        plan = self.select(["test/e2e/cnp-domain/e2e_test.go"])
+
+        executionPlan = e2eSelector.executionPlan(self.catalog, plan, "pull_request")
+
+        self.assertEqual(executionPlan["selectedGroups"], [])
+        self.assertEqual(len(executionPlan["matrix"]), 3)
+        self.assertEqual(
+            {entry["selection"] for entry in executionPlan["matrix"]},
+            {"smoke"},
+        )
+        self.assertEqual(plan["recommendedGroups"], ["policy"])
+        self.assertTrue(plan["approvalRequired"])
+
+    def testPullRequestExecutesAutomaticFullCoverageWhenRequired(self):
+        plan = self.select(["pkg/controller/pod.go"])
+
+        executionPlan = e2eSelector.executionPlan(self.catalog, plan, "pull_request")
+
+        self.assertTrue(executionPlan["full"])
+        self.assertEqual(len(executionPlan["matrix"]), 82)
+
+    def testTrustedDispatchExecutesRecommendedAndRequestedCoverage(self):
+        plan = self.select(
+            ["test/e2e/cnp-domain/e2e_test.go"],
+            requestedGroups=["bgp-routing"],
+        )
+
+        executionPlan = e2eSelector.executionPlan(self.catalog, plan, "workflow_dispatch")
+
+        self.assertEqual(executionPlan["selectedGroups"], ["bgp-routing", "policy"])
+        self.assertEqual(executionPlan["recommendedGroups"], [])
+        self.assertFalse(executionPlan["approvalRequired"])
+        self.assertEqual(len(executionPlan["matrix"]), 19)
+        summary = e2eSelector.renderSummary(
+            executionPlan,
+            ["test/e2e/cnp-domain/e2e_test.go"],
+        )
+        self.assertIn("Approval required: `no`", summary)
+        self.assertNotIn("Waiting for:", summary)
+
+    def testPushExecutesTheCompleteSuite(self):
+        plan = self.select(["docs/design.md"])
+
+        executionPlan = e2eSelector.executionPlan(self.catalog, plan, "push")
+
+        self.assertTrue(executionPlan["full"])
+        self.assertEqual(len(executionPlan["matrix"]), 82)
+
     def testExplicitForceFullReasonOverridesAVisibleSafeFileList(self):
         plan = e2eSelector.select(
             self.catalog,
@@ -266,8 +315,6 @@ class E2ESelectorTest(unittest.TestCase):
             for script in re.findall(r"(?:\./)?(hack/[a-z0-9_./-]+\.sh)", blocks.get(jobId, ""))
             if (repoRoot / script).is_file()
         }
-        self.assertIn("hack/go-list.sh", scripts)
-
         for script in scripts:
             with self.subTest(script=script):
                 plan = self.select([script])
@@ -307,6 +354,26 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertTrue(plan["full"])
         self.assertEqual(len(plan["matrix"]), 82)
         self.assertEqual(plan["fullReason"], "label e2e:full requested the full suite")
+
+    def testRequestedFullIsNotReportedAsAutomaticCoverage(self):
+        plan = e2eSelector.select(
+            self.catalog,
+            ["test/e2e/cnp-domain/e2e_test.go"],
+            [],
+            [],
+            "0123456789abcdef",
+            requestedFull=True,
+        )
+
+        self.assertTrue(plan["full"])
+        self.assertTrue(plan["requestedFull"])
+        self.assertEqual(plan["automaticGroups"], [])
+        self.assertEqual(plan["selectedGroups"], sorted(self.catalog["groups"]))
+        self.assertEqual(len(plan["matrix"]), 82)
+        self.assertEqual(plan["fullReason"], "authorized request selected the full suite")
+        summary = e2eSelector.renderSummary(plan, ["test/e2e/cnp-domain/e2e_test.go"])
+        self.assertIn("Automatic coverage: mandatory smoke &#40;3 runner jobs&#41;", summary)
+        self.assertIn("Runner jobs in this run: 82", summary)
 
     def testInvalidRequestedGroupFails(self):
         with self.assertRaisesRegex(ValueError, "unknown requested group"):
@@ -434,6 +501,8 @@ class E2ESelectorTest(unittest.TestCase):
         plan = self.select(["test/e2e/cnp-domain/e2e_test.go"])
 
         summary = e2eSelector.renderSummary(plan, ["test/e2e/cnp-domain/e2e_test.go"])
+        self.assertIn("## x86 E2E selection report", summary)
+        self.assertNotIn("Shadow mode", summary)
         self.assertIn("Automatic coverage: mandatory smoke &#40;3 runner jobs&#41;", summary)
         self.assertIn("Recommended deferred groups: policy", summary)
         self.assertIn("Approval required: `yes`", summary)
@@ -513,6 +582,12 @@ class E2ESelectorTest(unittest.TestCase):
             "catalog",
         )
         self.assertEqual(len(plan["matrix"]), 82)
+        executionPlan = e2eSelector.executionPlan(None, plan, "pull_request")
+        self.assertEqual(executionPlan, plan)
+        summary = e2eSelector.renderSummary(executionPlan, [])
+        self.assertIn("Automatic coverage: full suite &#40;82 runner jobs&#41;", summary)
+        self.assertIn("Groups executing in this run: full suite", summary)
+        self.assertNotIn("Groups executing in this run: smoke only", summary)
 
     def testInvalidEventPayloadFallsBackToFullThroughCLI(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

Continue #7230 after #7231 by implementing the non-blocking selective-execution mechanics:

- run the fixed three-runner smoke matrix for safely classified pull requests;
- preserve fail-closed automatic full coverage for shared, unknown, or unsafe changes;
- keep path-recommended groups deferred until an authorized comment dispatches them;
- execute the complete catalog on every push;
- make the uploaded `SelectionPlan`, job outputs, and step summary describe the exact matrix executed by that run;
- use one selected-job aggregator for pull requests, trusted comment executors, and the push publication gate.

The legacy NetworkPolicy path filter is removed so the selector catalog is the single policy implementation. Authorized `/test e2e-all` requests are represented as requested full coverage rather than as an automatic `e2e:full` label.

## Safety properties

- selector and catalog fallback remains executable even when the catalog cannot be loaded a second time, and a full fallback report cannot be mislabeled as smoke;
- every build and test checkout is bound to the exact pull request HEAD rather than the synthetic merge SHA;
- selector and contract failures are blocking; there is no selector `continue-on-error` fail-open path;
- every catalog test job is controlled only by `executionJobIds`;
- the aggregator treats selected jobs as successful only when every selected job concludes `success`;
- image publication depends on the full selected-job aggregator, so skipped, missing, failed, or cancelled full-suite jobs cannot publish images;
- private Kind node images are pulled only by a trusted job and handed to unprivileged E2E jobs through short-lived artifacts; PR-controlled Make targets never receive GHCR credentials;
- ordinary `pull_request` runs remain untrusted by the fixed gate; trusted automatic and approved comment executors use isolated base refs and exact PR HEAD checkouts;
- controlled `e2e:*` labels require repository write permission and trusted bot provenance; label-state changes invalidate stale approvals;

## Validation

- `python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py` — 82 passed
- Python AST parsing — passed
- workflow/catalog JSON and YAML parsing — passed
- actionlint on the changed workflows — passed (repository-existing ShellCheck findings and the custom `larger-runner` label excluded)
- `git diff --check` — passed
- online checks for `1116558e0`: dispatcher, x86, arm64, CodeQL, and DCO passed; the x86 control-module job exercised the new dispatch-input regression contract

`make lint` was not run locally because the workspace policy prohibits local `golangci-lint`; this change does not modify Go code or CRDs. The repository CI runs the normal lint target.

## Comment-dispatch follow-up

The `/test e2e core,multi-cni` trial did not launch an executor: dispatcher run `32127702311` failed while reserving the trusted gate because `gh api -F` sent typed JSON values in the workflow-dispatch `inputs` map. Commit `1116558e0` changes all cross-workflow inputs to REST string fields (`-f`) and adds a regression contract. The full SHA/nonce-bound dispatcher → gate → executor path still requires post-merge validation because `issue_comment` loads trusted workflow code from the default branch.

## Promotion status

This PR is currently **Ready for review**, but it must not be merged yet. Promotion remains blocked on the Issue #7230 rollout criteria, including at least two weeks and 20 non-documentation shadow PRs, plus online fork/authorization/stale-HEAD/duplicate/injection evidence. The SHA/nonce binding, trusted label provenance, base-update reconciliation, and trusted automatic-executor/gate mechanics are now implemented; online rollout evidence is still required before the fixed gate can become required.