### PR TITLE
fix: preserve VEG policies without dangling address sets

### DIFF
--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -849,6 +849,26 @@ func setVpcEgressGatewayBandwidthAnnotations(annotations map[string]string, band
 	return nil
 }
 
+func vpcEgressGatewayPolicyMatches(af int, pgName, asName string, includePortGroup bool) set.Set[string] {
+	matches := set.New[string](fmt.Sprintf("ip%d.src == $%s", af, asName))
+	if includePortGroup {
+		matches.Insert(fmt.Sprintf("ip%d.src == $%s_ip%d", af, pgName, af))
+	}
+	return matches
+}
+
+func vpcEgressGatewayLocalPolicyMatches(af int, localPgName, pgName, asName string, includePortGroup bool) set.Set[string] {
+	matches := set.New[string](fmt.Sprintf(
+		"ip%d.src == $%s_ip%d && ip%d.src == $%s", af, localPgName, af, af, asName,
+	))
+	if includePortGroup {
+		matches.Insert(fmt.Sprintf(
+			"ip%d.src == $%s_ip%d && ip%d.src == $%s_ip%d", af, localPgName, af, af, pgName, af,
+		))
+	}
+	return matches
+}
+
 func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressGateway, af int, lrName, lrpName, bfdIP string, nodeNexthops map[string]set.Set[string], sources set.Set[string]) error {
 	nextHops := flattenVpcEgressGatewayNexthops(nodeNexthops)
 
@@ -905,6 +925,7 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 	}
 	key := cache.MetaObjectToName(gw).String()
 	pgName := vegPortGroupName(key)
+	includePortGroup := len(gw.Spec.Selectors) > 0
 	if err = c.OVNNbClient.CreatePortGroup(pgName, externalIDs); err != nil {
 		err = fmt.Errorf("failed to create port group %s: %w", pgName, err)
 		klog.Error(err)
@@ -963,8 +984,9 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 				return err
 			}
 			localPgName := strings.ReplaceAll(portName, "-", ".")
-			rules[fmt.Sprintf("ip%d.src == $%s_ip%d && ip%d.src == $%s_ip%d", af, localPgName, af, af, pgName, af)] = nodeNextHops
-			rules[fmt.Sprintf("ip%d.src == $%s_ip%d && ip%d.src == $%s", af, localPgName, af, af, asName)] = nodeNextHops
+			for _, match := range vpcEgressGatewayLocalPolicyMatches(af, localPgName, pgName, asName, includePortGroup).UnsortedList() {
+				rules[match] = nodeNextHops
+			}
 		}
 		policies, err := c.OVNNbClient.ListLogicalRouterPolicies(lrName, util.EgressGatewayLocalPolicyPriority, externalIDs, false)
 		if err != nil {
@@ -1013,10 +1035,7 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 	}
 	matches := set.New[string]()
 	if nextHops.Len() != 0 {
-		matches.Insert(
-			fmt.Sprintf("ip%d.src == $%s_ip%d", af, pgName, af),
-			fmt.Sprintf("ip%d.src == $%s", af, asName),
-		)
+		matches = vpcEgressGatewayPolicyMatches(af, pgName, asName, includePortGroup)
 	}
 	for _, policy := range policies {
 		if matches.Has(policy.Match) {
@@ -1050,10 +1069,7 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 			klog.Error(err)
 			return err
 		}
-		matches = set.New(
-			fmt.Sprintf("ip%d.src == $%s_ip%d", af, pgName, af),
-			fmt.Sprintf("ip%d.src == $%s", af, asName),
-		)
+		matches = vpcEgressGatewayPolicyMatches(af, pgName, asName, includePortGroup)
 		for _, policy := range policies {
 			if matches.Has(policy.Match) {
 				matches.Delete(policy.Match)

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -925,14 +925,24 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 	}
 	key := cache.MetaObjectToName(gw).String()
 	pgName := vegPortGroupName(key)
-	includePortGroup := len(gw.Spec.Selectors) > 0
-	if err = c.OVNNbClient.CreatePortGroup(pgName, externalIDs); err != nil {
-		err = fmt.Errorf("failed to create port group %s: %w", pgName, err)
-		klog.Error(err)
-		return err
-	}
-	if err = c.OVNNbClient.PortGroupSetPorts(pgName, ports.UnsortedList()); err != nil {
-		err = fmt.Errorf("failed to set ports of port group %s: %w", pgName, err)
+	// Keep both policy forms for compatibility with existing policy observers. For
+	// subnet-only gateways, the port-group address-set name is backed by an empty
+	// standalone address set below because no Port Group selector exists.
+	includePortGroup := true
+	hasSelectors := len(gw.Spec.Selectors) > 0
+	if hasSelectors {
+		if err = c.OVNNbClient.CreatePortGroup(pgName, externalIDs); err != nil {
+			err = fmt.Errorf("failed to create port group %s: %w", pgName, err)
+			klog.Error(err)
+			return err
+		}
+		if err = c.OVNNbClient.PortGroupSetPorts(pgName, ports.UnsortedList()); err != nil {
+			err = fmt.Errorf("failed to set ports of port group %s: %w", pgName, err)
+			klog.Error(err)
+			return err
+		}
+	} else if err = c.OVNNbClient.DeletePortGroup(pgName); err != nil {
+		err = fmt.Errorf("failed to delete stale port group %s: %w", pgName, err)
 		klog.Error(err)
 		return err
 	}
@@ -946,6 +956,23 @@ func (c *Controller) reconcileVpcEgressGatewayOVNRoutes(gw *kubeovnv1.VpcEgressG
 	}
 	if err = c.OVNNbClient.AddressSetUpdateAddress(asName, sources.SortedList()...); err != nil {
 		err = fmt.Errorf("failed to update address set %s: %w", asName, err)
+		klog.Error(err)
+		return err
+	}
+	compatAsName := vegPortGroupAddressSetName(key, af)
+	if !hasSelectors {
+		if err = c.OVNNbClient.CreateAddressSet(compatAsName, externalIDs); err != nil {
+			err = fmt.Errorf("failed to create compatibility address set %s: %w", compatAsName, err)
+			klog.Error(err)
+			return err
+		}
+		if err = c.OVNNbClient.AddressSetUpdateAddress(compatAsName); err != nil {
+			err = fmt.Errorf("failed to clear compatibility address set %s: %w", compatAsName, err)
+			klog.Error(err)
+			return err
+		}
+	} else if err = c.OVNNbClient.DeleteAddressSet(compatAsName); err != nil {
+		err = fmt.Errorf("failed to delete stale compatibility address set %s: %w", compatAsName, err)
 		klog.Error(err)
 		return err
 	}
@@ -1443,6 +1470,10 @@ func (c *Controller) cleanOVNForVpcEgressGateway(key, lrName string) error {
 			klog.Error(err)
 			return err
 		}
+		if err = c.OVNNbClient.DeleteAddressSet(vegPortGroupAddressSetName(key, af)); err != nil {
+			klog.Error(err)
+			return err
+		}
 	}
 
 	return nil
@@ -1451,6 +1482,10 @@ func (c *Controller) cleanOVNForVpcEgressGateway(key, lrName string) error {
 func vegPortGroupName(key string) string {
 	hash := util.Sha256Hash([]byte(key))
 	return "VEG." + hash[:12]
+}
+
+func vegPortGroupAddressSetName(key string, af int) string {
+	return fmt.Sprintf("%s_ip%d", vegPortGroupName(key), af)
 }
 
 func vegAddressSetName(key string, af int) string {

--- a/pkg/controller/vpc_egress_gateway_routes_test.go
+++ b/pkg/controller/vpc_egress_gateway_routes_test.go
@@ -1,0 +1,136 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/set"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestVpcEgressGatewayPolicyMatches(t *testing.T) {
+	tests := []struct {
+		name             string
+		includePortGroup bool
+		want             []string
+	}{
+		{
+			name:             "subnet-only gateway omits port-group address set",
+			includePortGroup: false,
+			want:             []string{"ip4.src == $VEG.example.ipv4"},
+		},
+		{
+			name:             "selector gateway includes both address sets",
+			includePortGroup: true,
+			want: []string{
+				"ip4.src == $VEG.example.ipv4",
+				"ip4.src == $VEG.example_ip4",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vpcEgressGatewayPolicyMatches(4, "VEG.example", "VEG.example.ipv4", tt.includePortGroup)
+			require.Equal(t, tt.want, got.SortedList())
+		})
+	}
+}
+
+func TestVpcEgressGatewayLocalPolicyMatches(t *testing.T) {
+	got := vpcEgressGatewayLocalPolicyMatches(6, "node.example", "VEG.example", "VEG.example.ipv6", false)
+	require.Equal(t, []string{
+		"ip6.src == $node.example_ip6 && ip6.src == $VEG.example.ipv6",
+	}, got.SortedList())
+
+	got = vpcEgressGatewayLocalPolicyMatches(6, "node.example", "VEG.example", "VEG.example.ipv6", true)
+	require.Equal(t, []string{
+		"ip6.src == $node.example_ip6 && ip6.src == $VEG.example.ipv6",
+		"ip6.src == $node.example_ip6 && ip6.src == $VEG.example_ip6",
+	}, got.SortedList())
+}
+
+func TestReconcileVpcEgressGatewayOVNRoutesOmitsPortGroupMatchWithoutSelectors(t *testing.T) {
+	fakeController := newFakeController(t)
+	controller := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	gw := &kubeovnv1.VpcEgressGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "veg", Namespace: "default"},
+		Spec: kubeovnv1.VpcEgressGatewaySpec{
+			BFD: kubeovnv1.VpcEgressGatewayBFDConfig{Enabled: true},
+		},
+	}
+	externalIDs := map[string]string{
+		ovs.ExternalIDVendor:           util.CniTypeName,
+		ovs.ExternalIDVpcEgressGateway: "default/veg",
+		"af":                           "4",
+	}
+	pgName := vegPortGroupName("default/veg")
+	asName := vegAddressSetName("default/veg", 4)
+	asMatch := "ip4.src == $" + asName
+
+	mockOvnClient.EXPECT().CreatePortGroup(pgName, externalIDs).Return(nil)
+	mockOvnClient.EXPECT().PortGroupSetPorts(pgName, gomock.Any()).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(asName, externalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(asName, "10.0.0.0/24").Return(nil)
+	mockOvnClient.EXPECT().FindBFD(externalIDs).Return(nil, nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicies("tenant", util.EgressGatewayLocalPolicyPriority, externalIDs).Return(nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies("tenant", util.EgressGatewayPolicyPriority, externalIDs, false).Return(nil, nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+		"tenant", util.EgressGatewayPolicyPriority, asMatch, ovnnb.LogicalRouterPolicyActionReroute,
+		[]string{"192.0.2.2"}, gomock.Any(), externalIDs,
+	).Return(nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies("tenant", util.EgressGatewayDropPolicyPriority, externalIDs, false).Return(nil, nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+		"tenant", util.EgressGatewayDropPolicyPriority, asMatch, ovnnb.LogicalRouterPolicyActionDrop,
+		nil, nil, externalIDs,
+	).Return(nil)
+
+	err := controller.reconcileVpcEgressGatewayOVNRoutes(
+		gw, 4, "tenant", "tenant-public", "",
+		map[string]set.Set[string]{"node-a": set.New("192.0.2.2")}, set.New("10.0.0.0/24"),
+	)
+	require.NoError(t, err)
+}
+
+func TestReconcileVpcEgressGatewayOVNRoutesCleansStalePolicyWithoutNextHops(t *testing.T) {
+	fakeController := newFakeController(t)
+	controller := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	gw := &kubeovnv1.VpcEgressGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "veg", Namespace: "default"},
+	}
+	externalIDs := map[string]string{
+		ovs.ExternalIDVendor:           util.CniTypeName,
+		ovs.ExternalIDVpcEgressGateway: "default/veg",
+		"af":                           "4",
+	}
+	pgName := vegPortGroupName("default/veg")
+	asName := vegAddressSetName("default/veg", 4)
+	stalePolicy := &ovnnb.LogicalRouterPolicy{
+		UUID:  "stale-policy",
+		Match: "ip4.src == $" + pgName + "_ip4",
+	}
+
+	mockOvnClient.EXPECT().CreatePortGroup(pgName, externalIDs).Return(nil)
+	mockOvnClient.EXPECT().PortGroupSetPorts(pgName, gomock.Any()).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(asName, externalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(asName, "10.0.0.0/24").Return(nil)
+	mockOvnClient.EXPECT().FindBFD(externalIDs).Return(nil, nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicies("tenant", util.EgressGatewayLocalPolicyPriority, externalIDs).Return(nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies("tenant", util.EgressGatewayPolicyPriority, externalIDs, false).
+		Return([]*ovnnb.LogicalRouterPolicy{stalePolicy}, nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID("tenant", stalePolicy.UUID).Return(nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicies("tenant", util.EgressGatewayDropPolicyPriority, externalIDs).Return(nil)
+
+	err := controller.reconcileVpcEgressGatewayOVNRoutes(
+		gw, 4, "tenant", "tenant-public", "", nil, set.New("10.0.0.0/24"),
+	)
+	require.NoError(t, err)
+}

--- a/pkg/controller/vpc_egress_gateway_routes_test.go
+++ b/pkg/controller/vpc_egress_gateway_routes_test.go
@@ -56,7 +56,7 @@ func TestVpcEgressGatewayLocalPolicyMatches(t *testing.T) {
 	}, got.SortedList())
 }
 
-func TestReconcileVpcEgressGatewayOVNRoutesOmitsPortGroupMatchWithoutSelectors(t *testing.T) {
+func TestReconcileVpcEgressGatewayOVNRoutesKeepsCompatibilityMatchWithoutSelectors(t *testing.T) {
 	fakeController := newFakeController(t)
 	controller := fakeController.fakeController
 	mockOvnClient := fakeController.mockOvnClient
@@ -73,12 +73,15 @@ func TestReconcileVpcEgressGatewayOVNRoutesOmitsPortGroupMatchWithoutSelectors(t
 	}
 	pgName := vegPortGroupName("default/veg")
 	asName := vegAddressSetName("default/veg", 4)
+	compatAsName := vegPortGroupAddressSetName("default/veg", 4)
 	asMatch := "ip4.src == $" + asName
+	compatMatch := "ip4.src == $" + compatAsName
 
-	mockOvnClient.EXPECT().CreatePortGroup(pgName, externalIDs).Return(nil)
-	mockOvnClient.EXPECT().PortGroupSetPorts(pgName, gomock.Any()).Return(nil)
+	mockOvnClient.EXPECT().DeletePortGroup(pgName).Return(nil)
 	mockOvnClient.EXPECT().CreateAddressSet(asName, externalIDs).Return(nil)
 	mockOvnClient.EXPECT().AddressSetUpdateAddress(asName, "10.0.0.0/24").Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(compatAsName, externalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(compatAsName).Return(nil)
 	mockOvnClient.EXPECT().FindBFD(externalIDs).Return(nil, nil)
 	mockOvnClient.EXPECT().DeleteLogicalRouterPolicies("tenant", util.EgressGatewayLocalPolicyPriority, externalIDs).Return(nil)
 	mockOvnClient.EXPECT().ListLogicalRouterPolicies("tenant", util.EgressGatewayPolicyPriority, externalIDs, false).Return(nil, nil)
@@ -86,9 +89,17 @@ func TestReconcileVpcEgressGatewayOVNRoutesOmitsPortGroupMatchWithoutSelectors(t
 		"tenant", util.EgressGatewayPolicyPriority, asMatch, ovnnb.LogicalRouterPolicyActionReroute,
 		[]string{"192.0.2.2"}, gomock.Any(), externalIDs,
 	).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+		"tenant", util.EgressGatewayPolicyPriority, compatMatch, ovnnb.LogicalRouterPolicyActionReroute,
+		[]string{"192.0.2.2"}, gomock.Any(), externalIDs,
+	).Return(nil)
 	mockOvnClient.EXPECT().ListLogicalRouterPolicies("tenant", util.EgressGatewayDropPolicyPriority, externalIDs, false).Return(nil, nil)
 	mockOvnClient.EXPECT().AddLogicalRouterPolicy(
 		"tenant", util.EgressGatewayDropPolicyPriority, asMatch, ovnnb.LogicalRouterPolicyActionDrop,
+		nil, nil, externalIDs,
+	).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+		"tenant", util.EgressGatewayDropPolicyPriority, compatMatch, ovnnb.LogicalRouterPolicyActionDrop,
 		nil, nil, externalIDs,
 	).Return(nil)
 
@@ -113,15 +124,17 @@ func TestReconcileVpcEgressGatewayOVNRoutesCleansStalePolicyWithoutNextHops(t *t
 	}
 	pgName := vegPortGroupName("default/veg")
 	asName := vegAddressSetName("default/veg", 4)
+	compatAsName := vegPortGroupAddressSetName("default/veg", 4)
 	stalePolicy := &ovnnb.LogicalRouterPolicy{
 		UUID:  "stale-policy",
 		Match: "ip4.src == $" + pgName + "_ip4",
 	}
 
-	mockOvnClient.EXPECT().CreatePortGroup(pgName, externalIDs).Return(nil)
-	mockOvnClient.EXPECT().PortGroupSetPorts(pgName, gomock.Any()).Return(nil)
+	mockOvnClient.EXPECT().DeletePortGroup(pgName).Return(nil)
 	mockOvnClient.EXPECT().CreateAddressSet(asName, externalIDs).Return(nil)
 	mockOvnClient.EXPECT().AddressSetUpdateAddress(asName, "10.0.0.0/24").Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(compatAsName, externalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(compatAsName).Return(nil)
 	mockOvnClient.EXPECT().FindBFD(externalIDs).Return(nil, nil)
 	mockOvnClient.EXPECT().DeleteLogicalRouterPolicies("tenant", util.EgressGatewayLocalPolicyPriority, externalIDs).Return(nil)
 	mockOvnClient.EXPECT().ListLogicalRouterPolicies("tenant", util.EgressGatewayPolicyPriority, externalIDs, false).

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -190,7 +190,7 @@ func newVpcEgressGatewayDeleteController(t *testing.T, gw *kubeovnv1.VpcEgressGa
 	mockOvnClient.EXPECT().FindBFD(gomock.Any()).Return(nil, nil)
 	mockOvnClient.EXPECT().DeleteLogicalRouterPolicies(util.DefaultVpc, -1, gomock.Any()).Return(nil)
 	mockOvnClient.EXPECT().DeletePortGroup(gomock.Any()).Return(nil)
-	mockOvnClient.EXPECT().DeleteAddressSet(gomock.Any()).Return(nil).Times(2)
+	mockOvnClient.EXPECT().DeleteAddressSet(gomock.Any()).Return(nil).Times(4)
 	recorder := record.NewFakeRecorder(2)
 
 	c := &Controller{
@@ -460,6 +460,7 @@ func newVegOVNRouteFixture(t *testing.T) *vegOVNRouteFixture {
 func (f *vegOVNRouteFixture) expectResources() {
 	f.fc.mockOvnClient.EXPECT().CreatePortGroup(f.pgName, f.externalIDs).Return(nil)
 	f.fc.mockOvnClient.EXPECT().PortGroupSetPorts(f.pgName, gomock.Any()).Return(nil)
+	f.fc.mockOvnClient.EXPECT().DeleteAddressSet(vegPortGroupAddressSetName("default/veg", 4)).Return(nil)
 	f.fc.mockOvnClient.EXPECT().CreateAddressSet(f.asName, f.externalIDs).Return(nil)
 	f.fc.mockOvnClient.EXPECT().AddressSetUpdateAddress(f.asName).Return(nil)
 }

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -413,6 +413,9 @@ func newVegOVNRouteFixture(t *testing.T) *vegOVNRouteFixture {
 			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "veg"},
 			Spec: kubeovnv1.VpcEgressGatewaySpec{
 				TrafficPolicy: kubeovnv1.TrafficPolicyLocal,
+				Selectors: []kubeovnv1.VpcEgressGatewaySelector{{
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"test": "selected"}},
+				}},
 				BFD: kubeovnv1.VpcEgressGatewayBFDConfig{
 					Enabled:    true,
 					MinTX:      100,

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -50,8 +50,7 @@ import (
 )
 
 var (
-	uuidRegexp    = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
-	ipTokenRegexp = regexp.MustCompile(`[0-9A-Fa-f:.]+`)
+	uuidRegexp = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
 )
 
 func init() {
@@ -925,9 +924,8 @@ func waitPortGroupExists(pgName string) {
 	}, "Port_Group "+pgName+" to exist")
 }
 
-func waitVpcEgressGatewayPolicyNexthops(vegKey string, priority, af int, expected []string) {
+func waitVpcEgressGatewayPolicyNexthops(vegKey string, priority, af int, expected []string, expectedPolicyCount int) {
 	ginkgo.GinkgoHelper()
-	want := set.New(expected...)
 
 	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
 		cmd := fmt.Sprintf(
@@ -942,22 +940,9 @@ func waitVpcEgressGatewayPolicyNexthops(vegKey string, priority, af int, expecte
 			return false, nil
 		}
 
-		lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")
-		if len(lines) != 2 || lines[0] == "" {
-			framework.Logf("gateway %s has %d matching policies, expected 2", vegKey, len(lines))
+		if err := validateVpcEgressGatewayPolicyNexthops(string(stdout), expected, expectedPolicyCount); err != nil {
+			framework.Logf("gateway %s policy nexthops are not ready: %v", vegKey, err)
 			return false, nil
-		}
-		for _, line := range lines {
-			got := set.New[string]()
-			for _, token := range ipTokenRegexp.FindAllString(line, -1) {
-				if net.ParseIP(token) != nil {
-					got.Insert(token)
-				}
-			}
-			if !want.Equal(got) {
-				framework.Logf("gateway %s policy nexthops are %v, expected %v", vegKey, got.UnsortedList(), expected)
-				return false, nil
-			}
 		}
 		return true, nil
 	}, fmt.Sprintf("gateway %s priority %d IPv%d policy nexthops", vegKey, priority, af))
@@ -2045,11 +2030,12 @@ func validateVegTestWorkload(f *framework.Framework, veg *apiv1.VpcEgressGateway
 	expectedIPv4, expectedIPv6 := util.SplitIpsByProtocol(expectedNexthops)
 	if veg.Spec.PodAntiAffinity == apiv1.PodAntiAffinityPreferred {
 		vegKey := veg.Namespace + "/" + veg.Name
+		expectedPolicyCount := vpcEgressGatewayPolicyCount(veg)
 		if len(expectedIPv4) != 0 {
-			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayPolicyPriority, 4, expectedIPv4)
+			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayPolicyPriority, 4, expectedIPv4, expectedPolicyCount)
 		}
 		if len(expectedIPv6) != 0 {
-			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayPolicyPriority, 6, expectedIPv6)
+			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayPolicyPriority, 6, expectedIPv6, expectedPolicyCount)
 		}
 	}
 	if veg.Spec.BFD.Enabled && !f.VersionPriorTo(1, 15) {
@@ -2114,11 +2100,12 @@ func validateVegTestAccess(f *framework.Framework, veg *apiv1.VpcEgressGateway, 
 		veg = vegClient.PatchSync(original, modified)
 
 		vegKey := namespaceName + "/" + veg.Name
+		expectedPolicyCount := vpcEgressGatewayPolicyCount(veg)
 		if len(expectedIPv4) != 0 {
-			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayLocalPolicyPriority, 4, expectedIPv4)
+			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayLocalPolicyPriority, 4, expectedIPv4, expectedPolicyCount)
 		}
 		if len(expectedIPv6) != 0 {
-			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayLocalPolicyPriority, 6, expectedIPv6)
+			waitVpcEgressGatewayPolicyNexthops(vegKey, util.EgressGatewayLocalPolicyPriority, 6, expectedIPv6, expectedPolicyCount)
 		}
 		checkAccess(veg.Status.Workload.Nodes[0])
 	}

--- a/test/e2e/vpc-egress-gateway/e2e_test.go
+++ b/test/e2e/vpc-egress-gateway/e2e_test.go
@@ -49,9 +49,7 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework/kind"
 )
 
-var (
-	uuidRegexp = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
-)
+var uuidRegexp = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
 
 func init() {
 	klog.SetOutput(ginkgo.GinkgoWriter)

--- a/test/e2e/vpc-egress-gateway/policy_nexthops.go
+++ b/test/e2e/vpc-egress-gateway/policy_nexthops.go
@@ -1,0 +1,42 @@
+package multus
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+
+	"k8s.io/utils/set"
+
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+var ipTokenRegexp = regexp.MustCompile(`[0-9A-Fa-f:.]+`)
+
+func vpcEgressGatewayPolicyCount(veg *apiv1.VpcEgressGateway) int {
+	if len(veg.Spec.Selectors) == 0 {
+		return 1
+	}
+	return 2
+}
+
+func validateVpcEgressGatewayPolicyNexthops(output string, expected []string, expectedPolicyCount int) error {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != expectedPolicyCount || lines[0] == "" {
+		return fmt.Errorf("got %d matching policies, expected %d", len(lines), expectedPolicyCount)
+	}
+
+	want := set.New(expected...)
+	for _, line := range lines {
+		got := set.New[string]()
+		for _, token := range ipTokenRegexp.FindAllString(line, -1) {
+			if net.ParseIP(token) != nil {
+				got.Insert(token)
+			}
+		}
+		if !want.Equal(got) {
+			return fmt.Errorf("got policy nexthops %v, expected %v", got.UnsortedList(), expected)
+		}
+	}
+	return nil
+}

--- a/test/e2e/vpc-egress-gateway/policy_nexthops.go
+++ b/test/e2e/vpc-egress-gateway/policy_nexthops.go
@@ -13,10 +13,7 @@ import (
 
 var ipTokenRegexp = regexp.MustCompile(`[0-9A-Fa-f:.]+`)
 
-func vpcEgressGatewayPolicyCount(veg *apiv1.VpcEgressGateway) int {
-	if len(veg.Spec.Selectors) == 0 {
-		return 1
-	}
+func vpcEgressGatewayPolicyCount(_ *apiv1.VpcEgressGateway) int {
 	return 2
 }
 

--- a/test/e2e/vpc-egress-gateway/policy_nexthops_test.go
+++ b/test/e2e/vpc-egress-gateway/policy_nexthops_test.go
@@ -13,7 +13,7 @@ func TestVpcEgressGatewayPolicyCount(t *testing.T) {
 		selectors []apiv1.VpcEgressGatewaySelector
 		want      int
 	}{
-		{name: "subnet-only gateway", want: 1},
+		{name: "subnet-only gateway", want: 2},
 		{name: "selector gateway", selectors: []apiv1.VpcEgressGatewaySelector{{}}, want: 2},
 	}
 

--- a/test/e2e/vpc-egress-gateway/policy_nexthops_test.go
+++ b/test/e2e/vpc-egress-gateway/policy_nexthops_test.go
@@ -1,0 +1,78 @@
+package multus
+
+import (
+	"strings"
+	"testing"
+
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+func TestVpcEgressGatewayPolicyCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors []apiv1.VpcEgressGatewaySelector
+		want      int
+	}{
+		{name: "subnet-only gateway", want: 1},
+		{name: "selector gateway", selectors: []apiv1.VpcEgressGatewaySelector{{}}, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			veg := &apiv1.VpcEgressGateway{Spec: apiv1.VpcEgressGatewaySpec{Selectors: tt.selectors}}
+			if got := vpcEgressGatewayPolicyCount(veg); got != tt.want {
+				t.Fatalf("expected %d policies, got %d", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestValidateVpcEgressGatewayPolicyNexthops(t *testing.T) {
+	const nexthops = "10.241.187.2 10.241.187.3"
+	tests := []struct {
+		name                string
+		output              string
+		expected            []string
+		expectedPolicyCount int
+		wantErr             string
+	}{
+		{
+			name:                "subnet-only policy",
+			output:              nexthops + "\n",
+			expected:            []string{"10.241.187.2", "10.241.187.3"},
+			expectedPolicyCount: 1,
+		},
+		{
+			name:                "address set and port group policies",
+			output:              nexthops + "\n" + nexthops + "\n",
+			expected:            []string{"10.241.187.2", "10.241.187.3"},
+			expectedPolicyCount: 2,
+		},
+		{
+			name:                "unexpected policy count",
+			output:              nexthops + "\n",
+			expected:            []string{"10.241.187.2", "10.241.187.3"},
+			expectedPolicyCount: 2,
+			wantErr:             "got 1 matching policies, expected 2",
+		},
+		{
+			name:                "unexpected nexthops",
+			output:              "10.241.187.2\n",
+			expected:            []string{"10.241.187.2", "10.241.187.3"},
+			expectedPolicyCount: 1,
+			wantErr:             "got policy nexthops",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVpcEgressGatewayPolicyNexthops(tt.output, tt.expected, tt.expectedPolicyCount)
+			if tt.wantErr == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

For a VpcEgressGateway without selectors, keep the existing two-policy contract without leaving an unresolvable port-group address-set reference. Subnet-only gateways now remove the unused Port Group and create an empty standalone compatibility address set named `VEG.<hash>_ip4` or `VEG.<hash>_ip6`. The existing policy therefore remains parseable and matches no traffic, while subnet traffic continues to use the populated `VEG.<hash>.ipv4` or `VEG.<hash>.ipv6` address set.

Gateways with selectors continue to use the Port Group auto-generated address sets. Reconciliation removes the standalone compatibility address set before using the Port Group, so the name has exactly one owner. Gateway deletion cleans up both address-set forms.

Regression tests cover subnet-only and selector resource ownership, regular reroute and BFD drop policies, IPv6 local-policy matches, stale-policy cleanup, deletion cleanup, and the two-policy E2E assertion.

## Which issue(s) this PR fixes

Fixes #7247

## Testing

- `gofmt` completed successfully.
- `git diff --check` completed successfully.
- `go test policy_nexthops.go policy_nexthops_test.go -count=1` passed under the required 512 MiB / 0.5 CPU systemd scope.
- The targeted `pkg/controller` test was attempted with `-p 1` and compiler concurrency `-c=1`, but the Go compiler still exceeded the required 512 MiB cgroup limit before tests could run. It was not retried without the limit; GitHub Actions provides the compiled controller test result.
