### PR TITLE
fix(ci): treat missing isolated executor refs as create

### DIFF
--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -273,14 +273,25 @@ jobs:
           PY
           )
           refPath="refs/heads/$executorRef"
-          existingSHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$executorRef" \
-            --jq '.object.sha' 2>/dev/null || true)
-          if [ -n "$existingSHA" ] && [ "$existingSHA" != "$baseSHA" ]; then
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$executorRef" \
+            > automatic-executor-ref.json || true
+          refAction=$(python3 - "$baseSHA" <<'PY'
+          import sys
+          from pathlib import Path
+          import e2e_control as e2eControl
+
+          print(e2eControl.isolatedExecutorRefAction(
+              Path("automatic-executor-ref.json").read_text(),
+              sys.argv[1],
+          ))
+          PY
+          )
+          if [ "$refAction" = reject ]; then
             echo 'The isolated automatic executor ref points at an unexpected revision.' >&2
             exit 1
           fi
           createdRef=false
-          if [ -z "$existingSHA" ]; then
+          if [ "$refAction" = create ]; then
             gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
               -f ref="$refPath" -f sha="$baseSHA"
             createdRef=true
@@ -1022,14 +1033,25 @@ jobs:
           PY
           )
           refPath="refs/heads/$executorRef"
-          existingSHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$executorRef" \
-            --jq '.object.sha' 2>/dev/null || true)
-          if [ -n "$existingSHA" ] && [ "$existingSHA" != "$BASE_SHA" ]; then
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$executorRef" \
+            > approved-executor-ref.json || true
+          refAction=$(python3 - "$BASE_SHA" <<'PY'
+          import sys
+          from pathlib import Path
+          import e2e_control as e2eControl
+
+          print(e2eControl.isolatedExecutorRefAction(
+              Path("approved-executor-ref.json").read_text(),
+              sys.argv[1],
+          ))
+          PY
+          )
+          if [ "$refAction" = reject ]; then
             echo 'The isolated executor ref points at an unexpected revision.' >&2
             exit 1
           fi
           createdRef=false
-          if [ -z "$existingSHA" ]; then
+          if [ "$refAction" = create ]; then
             gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
               -f ref="$refPath" -f sha="$BASE_SHA"
             createdRef=true

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -629,6 +629,39 @@ def executorHeadBranch(request):
     )
 
 
+def isolatedExecutorRefSHA(payload):
+    if payload is None:
+        return ""
+    if isinstance(payload, (bytes, bytearray)):
+        payload = payload.decode()
+    if isinstance(payload, str):
+        text = payload.strip()
+        if not text:
+            return ""
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            return ""
+    if not isinstance(payload, dict):
+        return ""
+    obj = payload.get("object")
+    sha = obj.get("sha") if isinstance(obj, dict) else None
+    if isinstance(sha, str) and re.fullmatch(headPattern, sha):
+        return sha
+    return ""
+
+
+def isolatedExecutorRefAction(payload, expectedSHA):
+    if not re.fullmatch(headPattern, expectedSHA or ""):
+        raise ValueError("invalid expected isolated executor revision")
+    sha = isolatedExecutorRefSHA(payload)
+    if not sha:
+        return "create"
+    if sha != expectedSHA:
+        return "reject"
+    return "reuse"
+
+
 def latestExecutorRun(
     runs,
     prNumber,

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -598,6 +598,28 @@ class E2EControlTest(unittest.TestCase):
 
         self.assertNotEqual(first, second)
 
+    def testIsolatedExecutorRefActionTreatsMissingGitHubRefAsCreate(self):
+        expected = "e" * 40
+        missingRef = json.dumps(
+            {
+                "message": "Not Found",
+                "documentation_url": "https://docs.github.com/rest/git/refs#get-a-reference",
+                "status": "404",
+            }
+        )
+
+        self.assertEqual(e2eControl.isolatedExecutorRefAction("", expected), "create")
+        self.assertEqual(e2eControl.isolatedExecutorRefAction(missingRef, expected), "create")
+        self.assertEqual(e2eControl.isolatedExecutorRefAction("null", expected), "create")
+        self.assertEqual(
+            e2eControl.isolatedExecutorRefAction({"object": {"sha": expected}}, expected),
+            "reuse",
+        )
+        self.assertEqual(
+            e2eControl.isolatedExecutorRefAction({"object": {"sha": "f" * 40}}, expected),
+            "reject",
+        )
+
     def testRejectsMalformedExecutorRunName(self):
         with self.assertRaisesRegex(ValueError, "invalid x86 E2E executor run name"):
             e2eControl.parseExecutorRunName(
@@ -856,6 +878,8 @@ class E2EControlTest(unittest.TestCase):
         self.assertNotIn("group: x86-e2e-dispatch-", workflow)
         self.assertIn("contents: write", workflow)
         self.assertIn("print(e2eControl.executorHeadBranch(request))", workflow)
+        self.assertGreaterEqual(workflow.count("isolatedExecutorRefAction"), 2)
+        self.assertNotIn("--jq '.object.sha'", workflow)
         self.assertIn('git/refs/heads/$executorRef', workflow)
         self.assertIn('-f ref="$executorRef"', workflow)
         self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)


### PR DESCRIPTION
## What this PR does / why we need it

After #7244, the first automatic x86 E2E dispatch on an open PR fails in
`Start trusted automatic x86 E2E coverage` with:

```text
The isolated automatic executor ref points at an unexpected revision.
```

The dispatcher treats a missing isolated ref as an existing SHA. `gh api`
writes the GitHub 404 JSON body to stdout and exits 1; `existingSHA=$(... || true)`
captures that body, so `-n "$existingSHA"` is true and the job fail-closes
before creating the disposable executor ref.

This is not specific to #7251. The same automatic job also failed on
[run 32233126920](https://github.com/kubeovn/kube-ovn/actions/runs/32233126920)
after #7244 merged.

The helper now accepts only a 40-hex `object.sha`. A 404 body, empty payload,
or `null` means **create**; a matching SHA means **reuse**; any other SHA
still **reject**.

Because `pull_request_target` runs the dispatcher YAML from `master`, this
PR's own automatic job will still use the broken logic until this change is
merged. After merge, a new `pull_request_target` event is required on
affected PRs; re-running the old jobs will keep the old workflow file.

## Which issue(s) this PR fixes

Fixes the post-#7244 automatic dispatcher outage seen on
https://github.com/kubeovn/kube-ovn/actions/runs/32233221924/job/96007447187

Related to #7230.

## Special notes for reviewers

Local reproduction of the old assignment against a 404-body `gh` mock:

```text
RED: treated missing ref as unexpected revision
existingSHA={"message":"Not Found",...}
```

The new helper returns `create` for that payload. `hack/test_e2e_control.py`
covers missing/404/`null`/reuse/reject, and the dispatcher contract requires
both automatic and approved paths to call `isolatedExecutorRefAction`.