### PR TITLE
fix(ci): accept isolated executor refs in x86 E2E selection

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -156,6 +156,8 @@ jobs:
           INPUT_CONTROLLED_LABELS: ${{ inputs.controlledLabels }}
           INPUT_CONTROLLED_LABEL_NAMES: ${{ inputs.controlledLabelNames }}
           INPUT_PR_NUMBER: ${{ inputs.prNumber }}
+          INPUT_APPROVAL_GENERATION: ${{ inputs.approvalGeneration }}
+          INPUT_DISPATCH_GENERATION: ${{ inputs.dispatchGeneration }}
           INPUT_REQUESTED_GROUPS: ${{ inputs.requestedGroups }}
           INPUT_REQUESTED_GROUP_NAMES: ${{ inputs.requestedGroupNames }}
           INPUT_CATALOG_REVISION: ${{ inputs.catalogRevision }}
@@ -209,12 +211,16 @@ jobs:
             prNumber="$PR_NUMBER"
           elif [ "$EVENT_NAME" = workflow_dispatch ]; then
             gh api "repos/$GITHUB_REPOSITORY/pulls/$INPUT_PR_NUMBER" > pull-request.json
-            python3 - "$INPUT_HEAD_SHA" "$INPUT_BASE_SHA" "$GITHUB_REF_NAME" "$GITHUB_SHA" <<'PY'
+            python3 - "$INPUT_HEAD_SHA" "$INPUT_BASE_SHA" "$GITHUB_REF_NAME" "$GITHUB_SHA" \
+              "$INPUT_PR_NUMBER" "$INPUT_APPROVAL_GENERATION" "$INPUT_DISPATCH_GENERATION" <<'PY'
           import json
           import os
           import re
           import sys
           from pathlib import Path
+
+          sys.path.insert(0, "hack")
+          import e2e_control as e2eControl
 
           pullRequest = json.loads(Path("pull-request.json").read_text())
           if pullRequest.get("state") != "open":
@@ -225,7 +231,15 @@ jobs:
               raise SystemExit("pull request HEAD changed; dispatch again")
           if pullRequest["base"]["sha"] != sys.argv[2]:
               raise SystemExit("pull request base revision changed; dispatch again")
-          if pullRequest["base"]["ref"] != sys.argv[3]:
+          if not e2eControl.isTrustedExecutorRef(
+              sys.argv[3],
+              pullRequest["base"]["ref"],
+              {
+                  "prNumber": int(sys.argv[5]),
+                  "approvalGeneration": int(sys.argv[6]),
+                  "dispatchGeneration": int(sys.argv[7]),
+              },
+          ):
               raise SystemExit("executor must run from the pull request base branch")
           if sys.argv[4] != sys.argv[2]:
               raise SystemExit("executor workflow revision does not match the approved base")

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -662,6 +662,10 @@ def isolatedExecutorRefAction(payload, expectedSHA):
     return "reuse"
 
 
+def isTrustedExecutorRef(refName, baseRef, request):
+    return refName == baseRef or refName == executorHeadBranch(request)
+
+
 def latestExecutorRun(
     runs,
     prNumber,

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -620,6 +620,25 @@ class E2EControlTest(unittest.TestCase):
             "reject",
         )
 
+    def testTrustedExecutorRefAcceptsIsolatedBranchName(self):
+        request = {
+            "prNumber": 7251,
+            "approvalGeneration": 1,
+            "dispatchGeneration": 32235889723,
+        }
+        isolated = "x86-e2e/pr-7251-a-1-d-32235889723"
+
+        self.assertTrue(e2eControl.isTrustedExecutorRef("master", "master", request))
+        self.assertTrue(e2eControl.isTrustedExecutorRef(isolated, "master", request))
+        self.assertFalse(e2eControl.isTrustedExecutorRef("ci-e2e-demand-gate", "master", request))
+        self.assertFalse(
+            e2eControl.isTrustedExecutorRef(
+                "x86-e2e/pr-7251-a-1-d-1",
+                "master",
+                request,
+            )
+        )
+
     def testRejectsMalformedExecutorRunName(self):
         with self.assertRaisesRegex(ValueError, "invalid x86 E2E executor run name"):
             e2eControl.parseExecutorRunName(
@@ -1040,6 +1059,11 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("unknown requested E2E group", workflow)
         self.assertIn("executor catalog revision does not match dispatcher", workflow)
         self.assertIn("executor workflow revision does not match the approved base", workflow)
+        self.assertIn("isTrustedExecutorRef", workflow)
+        self.assertNotIn(
+            'if pullRequest["base"]["ref"] != sys.argv[3]:',
+            workflow,
+        )
         self.assertIn("trusted selector checkout does not match the approved base revision", workflow)
         self.assertIn("ref: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSHA", workflow)
         self.assertGreaterEqual(workflow.count("github.actor == 'github-actions[bot]'"), 5)


### PR DESCRIPTION
## What this PR does / why we need it

#7253 unblocked creating the disposable automatic executor ref. The
executor then failed immediately in `x86 E2E Selection`:

```text
executor must run from the pull request base branch
```

Selection compared `GITHUB_REF_NAME` to `pull_request.base.ref`. Isolated
executor refs are named `x86-e2e/pr-<n>-a-<approval>-d-<generation>` and
only *point at* the base SHA, so that check can never succeed for the
intended dispatch path.

This keeps the SHA == base check, and accepts either the real base branch
or the exact isolated executor ref for that approval/dispatch generation.

Evidence from the first post-hotfix executor:

- dispatcher https://github.com/kubeovn/kube-ovn/actions/runs/32235889723/job/96015881669 created `x86-e2e/pr-7251-a-1-d-32235889723` at `f8b3c711f`
- executor https://github.com/kubeovn/kube-ovn/actions/runs/32235988010/job/96015961745 failed the base-branch name check

Until this lands on `master`, `workflow_dispatch` still loads the old
selector from the isolated ref, so this PR's own automatic executor will
keep failing that check.

## Which issue(s) this PR fixes

Follow-up to #7253 / #7244. Related to #7230.

## Special notes for reviewers

`hack/test_e2e_control.py` now covers the exact isolated ref from PR #7251
generation `32235889723`.