### PR TITLE
fix(ci): allow the x86 E2E gate to post PR comments

### DIFF
--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -47,8 +47,8 @@ permissions:
   contents: read
   actions: read
   checks: write
-  issues: read
-  pull-requests: read
+  issues: write
+  pull-requests: write
 
 jobs:
   gate:
@@ -832,7 +832,7 @@ jobs:
       checks: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
       PYTHONPATH: hack

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -940,7 +940,7 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("checks: write", workflow)
         self.assertIn("actions: write", workflow)
         self.assertIn("issues: write", workflow)
-        self.assertIn("pull-requests: read", workflow)
+        self.assertIn("pull-requests: write", workflow)
         self.assertIn("RUN_PATH: ${{ github.event.workflow_run.path }}", workflow)
         self.assertIn("RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}", workflow)
         self.assertIn("RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}", workflow)


### PR DESCRIPTION
## What this PR does / why we need it

#7267 let `/test e2e core` be accepted, but the trusted gate still failed
while recording the durable approval intent:

```text
The trusted x86 E2E reservation did not become durable; no approval was recorded.
```

The serialize job posted the intent with the issues comments API and got
`Resource not accessible by integration (HTTP 403)` because it only had
`pull-requests: read`. Grant `pull-requests: write` so the reservation
comment can land and the executor can start.

## Which issue(s) this PR fixes

Follow-up to #7267 / #7244. Seen on
https://github.com/kubeovn/kube-ovn/actions/runs/32326328281