### PR TITLE
fix(controller): recycle NP/ANP/BANP OVN objects when features are disabled

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -1001,7 +1001,8 @@ func (c *Controller) gcDisabledDNSNameResolvers() error {
 	}
 
 	resolvers, err := c.config.KubeOvnClient.KubeovnV1().DNSNameResolvers().List(
-		context.TODO(), metav1.ListOptions{LabelSelector: adminNetworkPolicyKey})
+		context.TODO(), metav1.ListOptions{LabelSelector: adminNetworkPolicyKey},
+	)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -1013,7 +1014,8 @@ func (c *Controller) gcDisabledDNSNameResolvers() error {
 	for i := range resolvers.Items {
 		resolver := &resolvers.Items[i]
 		if err := c.config.KubeOvnClient.KubeovnV1().DNSNameResolvers().Delete(
-			context.TODO(), resolver.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+			context.TODO(), resolver.Name, metav1.DeleteOptions{},
+		); err != nil && !k8serrors.IsNotFound(err) {
 			klog.Errorf("delete disabled admin network policy DNSNameResolver %s: %v", resolver.Name, err)
 			return err
 		}

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -1003,6 +1003,9 @@ func (c *Controller) gcDisabledDNSNameResolvers() error {
 	resolvers, err := c.config.KubeOvnClient.KubeovnV1().DNSNameResolvers().List(
 		context.TODO(), metav1.ListOptions{LabelSelector: adminNetworkPolicyKey})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		klog.Errorf("list disabled admin network policy DNSNameResolvers: %v", err)
 		return err
 	}

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -40,6 +40,7 @@ func (c *Controller) gc() error {
 		// The lsp gc is processed periodically by markAndCleanLSP, will not gc lsp when init
 		c.gcLoadBalancer,
 		c.gcNetworkPolicy,
+		c.gcAdminNetworkPolicy,
 		c.gcSecurityGroup,
 		c.gcAddressSet,
 		c.gcRoutePolicy,
@@ -939,7 +940,79 @@ func (c *Controller) gcNetworkPolicy() error {
 		return err
 	}
 
+	if !c.config.EnableNP {
+		if err := c.gcDisabledNetworkPolicyResources(delPgNames.List()); err != nil {
+			return err
+		}
+	}
+
 	klog.Infof("finish to gc network policy")
+	return nil
+}
+
+func (c *Controller) gcDisabledNetworkPolicyResources(pgNames []string) error {
+	meterPGs := strset.New(pgNames...)
+	addressSets, err := c.OVNNbClient.ListAddressSets(map[string]string{networkPolicyKey: ""})
+	if err != nil {
+		klog.Errorf("failed to list network policy address sets: %v", err)
+		return err
+	}
+	for _, as := range addressSets {
+		parts := strings.Split(as.ExternalIDs[networkPolicyKey], "/")
+		if len(parts) != 3 {
+			continue
+		}
+		meterPGs.Add(npPortGroupName(parts[0], parts[1]))
+	}
+	for _, pgName := range meterPGs.List() {
+		for _, meterName := range networkPolicyMeterNames(pgName) {
+			if err := c.OVNNbClient.DeleteMeter(meterName); err != nil {
+				klog.Errorf("failed to gc network policy meter %s: %v", meterName, err)
+				return err
+			}
+		}
+	}
+	if err := c.OVNNbClient.DeleteAddressSets(map[string]string{networkPolicyKey: ""}); err != nil {
+		klog.Errorf("failed to gc network policy address sets: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) gcAdminNetworkPolicy() error {
+	if c.config.EnableANP {
+		return nil
+	}
+
+	klog.Infof("start to gc admin network policy")
+	for _, key := range []string{adminNetworkPolicyKey, baselineAdminNetworkPolicyKey, clusterNetworkPolicyKey} {
+		if err := c.gcPortGroupsAndAddressSetsByExternalID(key); err != nil {
+			return err
+		}
+	}
+	klog.Infof("finish to gc admin network policy")
+	return nil
+}
+
+func (c *Controller) gcPortGroupsAndAddressSetsByExternalID(externalIDKey string) error {
+	pgs, err := c.OVNNbClient.ListPortGroups(map[string]string{externalIDKey: ""})
+	if err != nil {
+		klog.Errorf("list port groups with external id %s: %v", externalIDKey, err)
+		return err
+	}
+	pgNames := make([]string, 0, len(pgs))
+	for _, pg := range pgs {
+		klog.Infof("gc port group %s with external id %s=%s", pg.Name, externalIDKey, pg.ExternalIDs[externalIDKey])
+		pgNames = append(pgNames, pg.Name)
+	}
+	if err := c.OVNNbClient.DeletePortGroup(pgNames...); err != nil {
+		klog.Errorf("failed to gc port groups %v: %v", pgNames, err)
+		return err
+	}
+	if err := c.OVNNbClient.DeleteAddressSets(map[string]string{externalIDKey: ""}); err != nil {
+		klog.Errorf("failed to gc address sets with external id %s: %v", externalIDKey, err)
+		return err
+	}
 	return nil
 }
 

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -41,6 +41,7 @@ func (c *Controller) gc() error {
 		c.gcLoadBalancer,
 		c.gcNetworkPolicy,
 		c.gcAdminNetworkPolicy,
+		c.gcDisabledDNSNameResolvers,
 		c.gcSecurityGroup,
 		c.gcAddressSet,
 		c.gcRoutePolicy,
@@ -991,6 +992,29 @@ func (c *Controller) gcAdminNetworkPolicy() error {
 		}
 	}
 	klog.Infof("finish to gc admin network policy")
+	return nil
+}
+
+func (c *Controller) gcDisabledDNSNameResolvers() error {
+	if c.config.EnableANP && c.config.EnableDNSNameResolver {
+		return nil
+	}
+
+	resolvers, err := c.config.KubeOvnClient.KubeovnV1().DNSNameResolvers().List(
+		context.TODO(), metav1.ListOptions{LabelSelector: adminNetworkPolicyKey})
+	if err != nil {
+		klog.Errorf("list disabled admin network policy DNSNameResolvers: %v", err)
+		return err
+	}
+
+	for i := range resolvers.Items {
+		resolver := &resolvers.Items[i]
+		if err := c.config.KubeOvnClient.KubeovnV1().DNSNameResolvers().Delete(
+			context.TODO(), resolver.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+			klog.Errorf("delete disabled admin network policy DNSNameResolver %s: %v", resolver.Name, err)
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -175,4 +176,83 @@ func TestGetVMLsps(t *testing.T) {
 			ovs.PodNameToPortName("vm-nad", "ns3", nadProvider),
 		}, lsps)
 	})
+}
+
+func TestGcNetworkPolicyDeletesLeftoversWhenDisabled(t *testing.T) {
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Nodes: []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}},
+	})
+	require.NoError(t, err)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	ctrl.config.EnableNP = false
+
+	npPG := ovnnb.PortGroup{
+		Name: "allow.default",
+		ExternalIDs: map[string]string{
+			networkPolicyKey: "default/allow",
+		},
+	}
+	nodePG := ovnnb.PortGroup{
+		Name: "node.node1",
+		ExternalIDs: map[string]string{
+			networkPolicyKey: "node/node1",
+		},
+	}
+
+	mockOvnClient.EXPECT().ListPortGroups(map[string]string{networkPolicyKey: ""}).Return([]ovnnb.PortGroup{npPG, nodePG}, nil)
+	mockOvnClient.EXPECT().DeletePortGroup(npPG.Name).Return(nil)
+	mockOvnClient.EXPECT().ListAddressSets(map[string]string{networkPolicyKey: ""}).Return([]ovnnb.AddressSet{{
+		Name: "default.allow.ipv4.ingress",
+		ExternalIDs: map[string]string{
+			networkPolicyKey: "default/allow/ingress",
+		},
+	}}, nil)
+	mockOvnClient.EXPECT().DeleteMeter("allow.default_to-lport_meter").Return(nil)
+	mockOvnClient.EXPECT().DeleteMeter("allow.default_from-lport_meter").Return(nil)
+	mockOvnClient.EXPECT().DeleteAddressSets(map[string]string{networkPolicyKey: ""}).Return(nil)
+
+	require.NoError(t, ctrl.gcNetworkPolicy())
+}
+
+func TestGcAdminNetworkPolicySkipsWhenEnabled(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	ctrl.config.EnableANP = true
+
+	require.NoError(t, ctrl.gcAdminNetworkPolicy())
+}
+
+func TestGcAdminNetworkPolicyDeletesLeftoversWhenDisabled(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	ctrl.config.EnableANP = false
+
+	anpPG := ovnnb.PortGroup{
+		Name: "anp.foo",
+		ExternalIDs: map[string]string{
+			adminNetworkPolicyKey: "anp.foo",
+		},
+	}
+	banpPG := ovnnb.PortGroup{
+		Name: "banp.bar",
+		ExternalIDs: map[string]string{
+			baselineAdminNetworkPolicyKey: "banp.bar",
+		},
+	}
+
+	mockOvnClient.EXPECT().ListPortGroups(map[string]string{adminNetworkPolicyKey: ""}).Return([]ovnnb.PortGroup{anpPG}, nil)
+	mockOvnClient.EXPECT().DeletePortGroup(anpPG.Name).Return(nil)
+	mockOvnClient.EXPECT().DeleteAddressSets(map[string]string{adminNetworkPolicyKey: ""}).Return(nil)
+
+	mockOvnClient.EXPECT().ListPortGroups(map[string]string{baselineAdminNetworkPolicyKey: ""}).Return([]ovnnb.PortGroup{banpPG}, nil)
+	mockOvnClient.EXPECT().DeletePortGroup(banpPG.Name).Return(nil)
+	mockOvnClient.EXPECT().DeleteAddressSets(map[string]string{baselineAdminNetworkPolicyKey: ""}).Return(nil)
+
+	mockOvnClient.EXPECT().ListPortGroups(map[string]string{clusterNetworkPolicyKey: ""}).Return(nil, nil)
+	mockOvnClient.EXPECT().DeletePortGroup().Return(nil)
+	mockOvnClient.EXPECT().DeleteAddressSets(map[string]string{clusterNetworkPolicyKey: ""}).Return(nil)
+
+	require.NoError(t, ctrl.gcAdminNetworkPolicy())
 }

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -13,9 +14,11 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/keymutex"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -255,4 +258,70 @@ func TestGcAdminNetworkPolicyDeletesLeftoversWhenDisabled(t *testing.T) {
 	mockOvnClient.EXPECT().DeleteAddressSets(map[string]string{clusterNetworkPolicyKey: ""}).Return(nil)
 
 	require.NoError(t, ctrl.gcAdminNetworkPolicy())
+}
+
+func TestGcDisabledDNSNameResolvers(t *testing.T) {
+	tests := []struct {
+		name                  string
+		enableANP             bool
+		enableDNSNameResolver bool
+		shouldDelete          bool
+	}{
+		{name: "all features enabled", enableANP: true, enableDNSNameResolver: true},
+		{name: "anp disabled", enableDNSNameResolver: true, shouldDelete: true},
+		{name: "dns resolver disabled", enableANP: true, shouldDelete: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeController := newFakeController(t)
+			ctrl := fakeController.fakeController
+			ctrl.config.EnableANP = tt.enableANP
+			ctrl.config.EnableDNSNameResolver = tt.enableDNSNameResolver
+
+			resolver := &kubeovnv1.DNSNameResolver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "anp-example-resolver",
+					Labels: map[string]string{adminNetworkPolicyKey: "example"},
+				},
+			}
+			unmanaged := &kubeovnv1.DNSNameResolver{ObjectMeta: metav1.ObjectMeta{Name: "unmanaged-resolver"}}
+			client := ctrl.config.KubeOvnClient.KubeovnV1().DNSNameResolvers()
+			_, err := client.Create(context.Background(), resolver, metav1.CreateOptions{})
+			require.NoError(t, err)
+			_, err = client.Create(context.Background(), unmanaged, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			require.NoError(t, ctrl.gcDisabledDNSNameResolvers())
+			_, err = client.Get(context.Background(), resolver.Name, metav1.GetOptions{})
+			if tt.shouldDelete {
+				require.True(t, k8serrors.IsNotFound(err))
+			} else {
+				require.NoError(t, err)
+			}
+			_, err = client.Get(context.Background(), unmanaged.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestHandleDeleteNpReturnsMeterError(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	ctrl.npKeyMutex = keymutex.NewHashed(1)
+	meterErr := errors.New("meter delete failed")
+
+	mockOvnClient.EXPECT().DeleteMeter("allow.default_to-lport_meter").Return(meterErr)
+	mockOvnClient.EXPECT().DeleteMeter("allow.default_from-lport_meter").Return(nil)
+	mockOvnClient.EXPECT().DeletePortGroup("allow.default").Return(nil)
+	mockOvnClient.EXPECT().DeleteAddressSets(map[string]string{
+		networkPolicyKey: "default/allow/ingress",
+	}).Return(nil)
+	mockOvnClient.EXPECT().DeleteAddressSets(map[string]string{
+		networkPolicyKey: "default/allow/egress",
+	}).Return(nil)
+
+	err := ctrl.handleDeleteNp("default/allow")
+	require.ErrorIs(t, err, meterErr)
 }

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -525,16 +525,11 @@ func (c *Controller) handleDeleteNp(key string) error {
 		npName = "np" + name
 	}
 
-	pgName := strings.ReplaceAll(fmt.Sprintf("%s.%s", npName, namespace), "-", ".")
-	ingressMeterName := fmt.Sprintf("%s_to-lport_meter", pgName)
-	egressMeterName := fmt.Sprintf("%s_from-lport_meter", pgName)
-
-	if err := c.OVNNbClient.DeleteMeter(ingressMeterName); err != nil {
-		klog.Errorf("delete ingress meter %s for np %s: %v", ingressMeterName, key, err)
-	}
-
-	if err := c.OVNNbClient.DeleteMeter(egressMeterName); err != nil {
-		klog.Errorf("delete egress meter %s for np %s: %v", egressMeterName, key, err)
+	pgName := npPortGroupName(namespace, npName)
+	for _, meterName := range networkPolicyMeterNames(pgName) {
+		if err := c.OVNNbClient.DeleteMeter(meterName); err != nil {
+			klog.Errorf("delete meter %s for np %s: %v", meterName, key, err)
+		}
 	}
 
 	if err = c.OVNNbClient.DeletePortGroup(pgName); err != nil {
@@ -868,4 +863,15 @@ func parseACLLogRate(annotations map[string]string) int {
 		return 0
 	}
 	return rate
+}
+
+func npPortGroupName(namespace, npName string) string {
+	return strings.ReplaceAll(fmt.Sprintf("%s.%s", npName, namespace), "-", ".")
+}
+
+func networkPolicyMeterNames(pgName string) []string {
+	return []string{
+		fmt.Sprintf("%s_to-lport_meter", pgName),
+		fmt.Sprintf("%s_from-lport_meter", pgName),
+	}
 }

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -526,31 +526,42 @@ func (c *Controller) handleDeleteNp(key string) error {
 	}
 
 	pgName := npPortGroupName(namespace, npName)
+	var firstErr error
 	for _, meterName := range networkPolicyMeterNames(pgName) {
 		if err := c.OVNNbClient.DeleteMeter(meterName); err != nil {
 			klog.Errorf("delete meter %s for np %s: %v", meterName, key, err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 
-	if err = c.OVNNbClient.DeletePortGroup(pgName); err != nil {
+	if err := c.OVNNbClient.DeletePortGroup(pgName); err != nil {
 		klog.Errorf("delete np %s port group: %v", key, err)
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
 
 	if err := c.OVNNbClient.DeleteAddressSets(map[string]string{
 		networkPolicyKey: fmt.Sprintf("%s/%s/%s", namespace, npName, "ingress"),
 	}); err != nil {
 		klog.Errorf("delete np %s ingress address set: %v", key, err)
-		return err
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
 
 	if err := c.OVNNbClient.DeleteAddressSets(map[string]string{
 		networkPolicyKey: fmt.Sprintf("%s/%s/%s", namespace, npName, "egress"),
 	}); err != nil {
 		klog.Errorf("delete np %s egress address set: %v", key, err)
-		return err
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
 
-	return nil
+	return firstErr
 }
 
 func parsePolicyFor(np *netv1.NetworkPolicy) set.Set[string] {

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -132,7 +132,7 @@ func (c *Controller) handleUpdateNp(key string) error {
 	// TODO: ovn acl doesn't support address_set name with '-', now we replace '-' by '.'.
 	// This may cause conflict if two np with name test-np and test.np. Maybe hash is a better solution,
 	// but we do not want to lost the readability now.
-	pgName := strings.ReplaceAll(fmt.Sprintf("%s.%s", npName, np.Namespace), "-", ".")
+	pgName := npPortGroupName(np.Namespace, npName)
 	ingressAllowAsNamePrefix := strings.ReplaceAll(fmt.Sprintf("%s.%s.ingress.allow", npName, np.Namespace), "-", ".")
 	ingressExceptAsNamePrefix := strings.ReplaceAll(fmt.Sprintf("%s.%s.ingress.except", npName, np.Namespace), "-", ".")
 	egressAllowAsNamePrefix := strings.ReplaceAll(fmt.Sprintf("%s.%s.egress.allow", npName, np.Namespace), "-", ".")


### PR DESCRIPTION
### Description

When `--enable-np` or `--enable-anp` is turned off, kube-ovn-controller stops the corresponding workers but does not recycle OVN objects created while the feature was enabled.

This change adds disable-path GC:

- `--enable-np=false`: keep existing Port Group GC, and also delete leftover NetworkPolicy Address Sets and QoS meters. Node / distributed-subnet Port Groups are still preserved.
- `--enable-anp=false`: delete leftover ANP, BANP, and CNP Port Groups and Address Sets. CNP is included because it is gated by the same flag.

References #7266 (partial: this PR only handles NP/ANP-family OVN objects; other disable-path cleanup remains tracked separately.)

### How did you test it?

- Unit tests in `pkg/controller/gc_test.go` cover NP leftovers with a kept node Port Group, ANP skip when enabled, ANP/BANP/CNP cleanup when disabled, DNSNameResolver cleanup gates, and NP deletion error retry.
- `gofmt` applied. Local `go test ./pkg/controller` for these cases compiles the full controller package and exceeds this environment's 512MiB memory cap; CI will run the tests.

### Checklist

- [x] I have run `make lint` locally (skipped: `golangci-lint` is not run in this environment; CI will lint)
- [x] I have added tests
- [x] I have updated the documentation if needed (N/A)