### PR TITLE
fix(ci): let the x86 E2E reducer post PR comments

### DIFF
--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -839,7 +839,7 @@ jobs:
       contents: write
       actions: write
       checks: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     concurrency:
       group: x86-e2e-reduce-${{ inputs.prNumber }}-${{ inputs.approvalGeneration }}

--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -47,8 +47,8 @@ permissions:
   contents: read
   actions: read
   checks: write
-  issues: read
-  pull-requests: read
+  issues: write
+  pull-requests: write
 
 jobs:
   gate:
@@ -832,7 +832,7 @@ jobs:
       checks: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
       PYTHONPATH: hack

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -940,7 +940,7 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("checks: write", workflow)
         self.assertIn("actions: write", workflow)
         self.assertIn("issues: write", workflow)
-        self.assertIn("pull-requests: read", workflow)
+        self.assertIn("pull-requests: write", workflow)
         self.assertIn("RUN_PATH: ${{ github.event.workflow_run.path }}", workflow)
         self.assertIn("RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}", workflow)
         self.assertIn("RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}", workflow)


### PR DESCRIPTION
Follow-up to #7268. The reducer job still 403s when commenting that the isolated executor was not visible.