### PR TITLE
fix(ci): recognize approved gates after GitHub rewrites details_url

### DIFF
--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -986,19 +986,30 @@ jobs:
             echo "The cumulative x86 E2E request is already recorded: $duplicate"
             exit 0
           fi
-          externalId="x86-e2e-pr-$PR_NUMBER-$HEAD_SHA"
-          expectedURL="https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER?request=$REQUEST_KEY&approval=$APPROVAL_GENERATION"
           approvalReady=false
           for _ in $(seq 1 24); do
-            ready=$(gh api \
+            gh api \
               -H 'Accept: application/vnd.github+json' \
               "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?check_name=x86-e2e%20%2F%20required-gate&per_page=100" \
-              | jq -r --arg externalId "$externalId" --arg expectedURL "$expectedURL" \
-                'any(.check_runs[]; .name == "x86-e2e / required-gate" and
-                  .external_id == $externalId and .status == "completed" and
-                  .conclusion == "action_required" and .details_url == $expectedURL)')
-            if [ "$ready" = true ]; then
-              approvalReady=true
+              > approved-gate-checks.json
+            approvalReady=$(python3 - "$PR_NUMBER" "$HEAD_SHA" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+          import e2e_control as e2eControl
+
+          checks = json.loads(Path("approved-gate-checks.json").read_text()).get("check_runs") or []
+          print(
+              "true"
+              if any(
+                  e2eControl.isApprovedGateReservation(check, sys.argv[1], sys.argv[2])
+                  for check in checks
+              )
+              else "false"
+          )
+          PY
+            )
+            if [ "$approvalReady" = true ]; then
               break
             fi
             sleep 5
@@ -1015,13 +1026,27 @@ jobs:
             echo 'The cumulative request became stale during gate reconciliation.'
             exit 0
           fi
-          ready=$(gh api \
+          gh api \
             -H 'Accept: application/vnd.github+json' \
             "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?check_name=x86-e2e%20%2F%20required-gate&per_page=100" \
-            | jq -r --arg externalId "$externalId" --arg expectedURL "$expectedURL" \
-              'any(.check_runs[]; .name == "x86-e2e / required-gate" and
-                .external_id == $externalId and .status == "completed" and
-                .conclusion == "action_required" and .details_url == $expectedURL)')
+            > approved-gate-checks.json
+          ready=$(python3 - "$PR_NUMBER" "$HEAD_SHA" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+          import e2e_control as e2eControl
+
+          checks = json.loads(Path("approved-gate-checks.json").read_text()).get("check_runs") or []
+          print(
+              "true"
+              if any(
+                  e2eControl.isApprovedGateReservation(check, sys.argv[1], sys.argv[2])
+                  for check in checks
+              )
+              else "false"
+          )
+          PY
+          )
           if [ "$ready" != true ]; then
             exit 0
           fi

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -684,6 +684,24 @@ def isolatedExecutorRefAction(payload, expectedSHA):
     return "reuse"
 
 
+def isApprovedGateReservation(check, prNumber, headSHA):
+    if not isinstance(check, dict):
+        return False
+    if not re.fullmatch(headPattern, headSHA or ""):
+        raise ValueError("invalid approved gate HEAD")
+    summary = ""
+    output = check.get("output")
+    if isinstance(output, dict):
+        summary = output.get("summary") or ""
+    return (
+        check.get("name") == "x86-e2e / required-gate"
+        and check.get("external_id") == f"x86-e2e-pr-{int(prNumber)}-{headSHA}"
+        and check.get("status") == "completed"
+        and check.get("conclusion") == "action_required"
+        and "waiting for its trusted executor" in summary
+    )
+
+
 def isTrustedExecutorRef(refName, baseRef, request):
     return refName == baseRef or refName == executorHeadBranch(request)
 

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -119,6 +119,34 @@ class E2EControlTest(unittest.TestCase):
             controlledLabels=controlledLabels,
         )
 
+    def testApprovedGateReservationIgnoresGitHubRewrittenDetailsURL(self):
+        headSHA = "94fd288b1db022d10863ac3254d2b40fe1dad01a"
+        check = {
+            "name": "x86-e2e / required-gate",
+            "external_id": f"x86-e2e-pr-7260-{headSHA}",
+            "status": "completed",
+            "conclusion": "action_required",
+            "details_url": "https://github.com/kubeovn/kube-ovn/runs/96297378780",
+            "output": {
+                "title": "x86 E2E gate",
+                "summary": "The latest authorized x86 E2E approval is waiting for its trusted executor.",
+            },
+        }
+
+        self.assertTrue(e2eControl.isApprovedGateReservation(check, 7260, headSHA))
+        self.assertFalse(
+            e2eControl.isApprovedGateReservation(
+                {
+                    **check,
+                    "output": {
+                        "summary": "The pull request target branch advanced; authorize x86 E2E again for the new base revision."
+                    },
+                },
+                7260,
+                headSHA,
+            )
+        )
+
     def testUnboundCommandBindsToLiveHead(self):
         decision = self.dispatchDecision(body="/test e2e core", bindHead=False)
 
@@ -925,6 +953,8 @@ class E2EControlTest(unittest.TestCase):
         self.assertNotIn("group: x86-e2e-dispatch-", workflow)
         self.assertIn("contents: write", workflow)
         self.assertIn("print(e2eControl.executorHeadBranch(request))", workflow)
+        self.assertIn("isApprovedGateReservation", workflow)
+        self.assertNotIn(".details_url == $expectedURL", workflow)
         self.assertGreaterEqual(workflow.count("isolatedExecutorRefAction"), 2)
         self.assertNotIn("--jq '.object.sha'", workflow)
         self.assertIn('git/refs/heads/$executorRef', workflow)


### PR DESCRIPTION
## What this PR does / why we need it

`/test e2e core` on #7260 recorded a durable approval, then the reducer
timed out waiting for:

```text
details_url == https://github.com/kubeovn/kube-ovn/pull/7260?request=...&approval=...
```

The live check run is:

```text
details_url: https://github.com/kubeovn/kube-ovn/runs/96297378780
conclusion: action_required
summary: The latest authorized x86 E2E approval is waiting for its trusted executor.
```

GitHub Actions rewrites `details_url` to the check's `/runs/<id>` URL, so
the reducer never dispatched the isolated executor. Match the reservation
by `external_id`, `action_required`, and the waiting-executor summary.

## Which issue(s) this PR fixes

Follow-up to #7267 / #7268 / #7270. Seen on
https://github.com/kubeovn/kube-ovn/actions/runs/32326793300