### PR TITLE
ci: publish trusted x86 E2E jobs as pull request checks

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -5379,6 +5379,82 @@ jobs:
           print(f"Verified {len(requiredJobIds)} required x86 E2E Jobs.")
           PY
 
+  publish-pr-e2e-checks:
+    name: Publish x86 E2E checks on the pull request
+    if: always() && github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+    needs:
+      - e2e-selection
+      - e2e-executor-result
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PYTHONPATH: hack
+      PYTHONDONTWRITEBYTECODE: "1"
+      HEAD_SHA: ${{ inputs.headSHA }}
+      PR_NUMBER: ${{ inputs.prNumber }}
+      SELECTED_JOB_IDS: ${{ needs.e2e-selection.outputs.executionJobIds }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.baseSHA }}
+          persist-credentials: false
+
+      - name: Mirror selected executor jobs onto the pull request HEAD
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?per_page=100" \
+            | jq '[.[].jobs[]]' > executor-jobs.json
+          python3 - "$PR_NUMBER" "$HEAD_SHA" "$SELECTED_JOB_IDS" <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+          import e2e_control as e2eControl
+          import e2e_selector as e2eSelector
+
+          prNumber = int(sys.argv[1])
+          headSHA = sys.argv[2]
+          selectedJobIds = json.loads(sys.argv[3])
+          workflow = Path(".github/workflows/build-x86-image.yaml").read_text()
+          blocks = e2eSelector.workflowJobBlocks(workflow)
+          selectedTitles = [
+              e2eControl.workflowJobTitle(blocks[jobId])
+              for jobId in selectedJobIds
+              if jobId in blocks
+          ]
+          jobs = json.loads(Path("executor-jobs.json").read_text())
+          checks = [
+              e2eControl.prCheckRunFromExecutorJob(job, headSHA, prNumber)
+              for job in e2eControl.selectedExecutorJobs(jobs, selectedTitles)
+          ]
+          Path("pr-e2e-checks.json").write_text(json.dumps(checks) + "\n")
+          print(f"Publishing {len(checks)} pull request E2E checks.")
+          PY
+          jq -c '.[]' pr-e2e-checks.json | while read -r payload; do
+            name=$(jq -r '.name' <<< "$payload")
+            externalId=$(jq -r '.external_id' <<< "$payload")
+            existing=$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100" \
+              | jq -r --arg externalId "$externalId" \
+                '[.check_runs[] | select(.external_id == $externalId)][0].id // empty')
+            if [ -n "$existing" ]; then
+              jq 'del(.name, .head_sha)' <<< "$payload" | \
+                gh api --method PATCH "repos/$GITHUB_REPOSITORY/check-runs/$existing" --input -
+            else
+              gh api --method POST "repos/$GITHUB_REPOSITORY/check-runs" --input - <<< "$payload"
+            fi
+            echo "Published $name"
+          done
+
   push:
     name: Push Images
     needs:

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -706,6 +706,57 @@ def isTrustedExecutorRef(refName, baseRef, request):
     return refName == baseRef or refName == executorHeadBranch(request)
 
 
+def workflowJobTitle(block):
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("name:"):
+            return stripped.split(":", 1)[1].strip()
+    return ""
+
+
+def selectedExecutorJobs(jobs, selectedTitles):
+    matched = []
+    seen = set()
+    for job in jobs:
+        name = job.get("name") or ""
+        for title in selectedTitles:
+            prefix = title.split("${{", 1)[0].rstrip()
+            if name == title or (prefix and name.startswith(prefix)):
+                jobId = job.get("id")
+                if jobId in seen:
+                    break
+                seen.add(jobId)
+                matched.append(job)
+                break
+    return matched
+
+
+def prCheckRunFromExecutorJob(job, headSHA, prNumber):
+    if not re.fullmatch(headPattern, headSHA or ""):
+        raise ValueError("invalid pull request HEAD for E2E check")
+    name = job.get("name") or ""
+    if not name:
+        raise ValueError("executor job is missing a name")
+    conclusion = job.get("conclusion")
+    completed = job.get("status") == "completed" or bool(conclusion)
+    payload = {
+        "name": name,
+        "head_sha": headSHA,
+        "status": "completed" if completed else "in_progress",
+        "external_id": f"x86-e2e-pr-{int(prNumber)}-{headSHA}-{name}"[:255],
+        "details_url": job.get("html_url") or "",
+        "output": {
+            "title": name,
+            "summary": (
+                f"Trusted x86 E2E result for pull request HEAD `{headSHA}`."
+            ),
+        },
+    }
+    if completed:
+        payload["conclusion"] = conclusion or "cancelled"
+    return payload
+
+
 def latestExecutorRun(
     runs,
     prNumber,

--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -20,6 +20,7 @@ infrastructureJobs = {
     "e2e-control-validation",
     "prepare-kind-node-images",
     "e2e-executor-result",
+    "publish-pr-e2e-checks",
     "push",
 }
 expectedX86RunnerJobs = 82

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -119,6 +119,48 @@ class E2EControlTest(unittest.TestCase):
             controlledLabels=controlledLabels,
         )
 
+    def testExecutorJobsArePublishedAsPullRequestChecks(self):
+        jobs = [
+            {
+                "id": 1,
+                "name": "Kubernetes Conformance E2E (ipv4, overlay)",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "https://github.com/kubeovn/kube-ovn/actions/runs/1/job/11",
+            },
+            {
+                "id": 2,
+                "name": "Build kube-ovn",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "https://github.com/kubeovn/kube-ovn/actions/runs/1/job/12",
+            },
+            {
+                "id": 3,
+                "name": "Kube-OVN Hosted OVN Central E2E (ipv4, 1 control-plane)",
+                "status": "in_progress",
+                "conclusion": None,
+                "html_url": "https://github.com/kubeovn/kube-ovn/actions/runs/1/job/13",
+            },
+        ]
+        selected = e2eControl.selectedExecutorJobs(
+            jobs,
+            [
+                "Kubernetes Conformance E2E",
+                "Kube-OVN Hosted OVN Central E2E (${{ matrix.ip-family }}, ${{ matrix.tenant-control-plane }} control-plane)",
+            ],
+        )
+        self.assertEqual([job["id"] for job in selected], [1, 3])
+        headSHA = "a" * 40
+        completed = e2eControl.prCheckRunFromExecutorJob(jobs[0], headSHA, 7260)
+        pending = e2eControl.prCheckRunFromExecutorJob(jobs[2], headSHA, 7260)
+        self.assertEqual(completed["head_sha"], headSHA)
+        self.assertEqual(completed["status"], "completed")
+        self.assertEqual(completed["conclusion"], "success")
+        self.assertEqual(completed["details_url"], jobs[0]["html_url"])
+        self.assertEqual(pending["status"], "in_progress")
+        self.assertNotIn("conclusion", pending)
+
     def testApprovedGateReservationIgnoresGitHubRewrittenDetailsURL(self):
         headSHA = "94fd288b1db022d10863ac3254d2b40fe1dad01a"
         check = {
@@ -1135,7 +1177,8 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("os.environ['GITHUB_ENV']=shadowDir+'/env'", workflow)
         self.assertIn("allowed=('TAG','GO_VERSION','E2E_DIR','VERSION','DEBUG_WRAPPER')", workflow)
         self.assertNotIn("actions: write", workflow)
-        self.assertNotIn("checks: write", workflow)
+        self.assertEqual(workflow.count("checks: write"), 1)
+        self.assertIn("name: Publish x86 E2E checks on the pull request", workflow)
         self.assertNotIn("GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}", workflow)
         self.assertIn(
             "Pull private Kind node image with trusted token",
@@ -1235,6 +1278,11 @@ class E2EControlTest(unittest.TestCase):
         resultBlock = blocks["e2e-executor-result"]
         self.assertIn("if: always() && github.event_name != 'pull_request'", resultBlock)
         self.assertIn("permissions: {}", resultBlock)
+        publish = blocks["publish-pr-e2e-checks"]
+        self.assertIn("if: always() && github.event_name == 'workflow_dispatch'", publish)
+        self.assertIn("checks: write", publish)
+        self.assertIn("prCheckRunFromExecutorJob", publish)
+        self.assertIn("HEAD_SHA: ${{ inputs.headSHA }}", publish)
         self.assertIn(
             'requiredJobIds = ["e2e-selection", "e2e-control-validation"] + selectedJobIds',
             resultBlock,


### PR DESCRIPTION
## What this PR does / why we need it

Issue #7230 wants comment/label triggered x86 E2E to show up on the pull
request. The executor still has to run as trusted `workflow_dispatch` on
a disposable base-SHA ref; otherwise the workflow file would come from
untrusted PR HEAD.

This keeps that security boundary, then mirrors each selected executor
job onto the PR HEAD with the Checks API. After `/test e2e core` (or
automatic smoke) finishes, Kubernetes/Kube-OVN conformance and the other
selected jobs appear in the PR checks list, with `details_url` pointing
at the trusted job.

## Which issue(s) this PR fixes

Towards #7230.