### PR TITLE
ci: stream trusted x86 E2E job status onto PR checks

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -5381,18 +5381,17 @@ jobs:
 
   publish-pr-e2e-checks:
     name: Publish x86 E2E checks on the pull request
-    if: always() && github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     permissions:
       actions: read
       checks: write
       contents: read
     needs:
       - e2e-selection
-      - e2e-executor-result
     runs-on: ubuntu-24.04
+    timeout-minutes: 360
     env:
       GH_TOKEN: ${{ github.token }}
-      PYTHONPATH: hack
       PYTHONDONTWRITEBYTECODE: "1"
       HEAD_SHA: ${{ inputs.headSHA }}
       PR_NUMBER: ${{ inputs.prNumber }}
@@ -5403,26 +5402,27 @@ jobs:
           ref: ${{ inputs.baseSHA }}
           persist-credentials: false
 
-      - name: Mirror selected executor jobs onto the pull request HEAD
+      - name: Stream selected executor jobs onto the pull request HEAD
         env:
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          gh api --paginate --slurp \
-            "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?per_page=100" \
-            | jq '[.[].jobs[]]' > executor-jobs.json
-          python3 - "$PR_NUMBER" "$HEAD_SHA" "$SELECTED_JOB_IDS" <<'PY'
+          python3 - "$PR_NUMBER" "$HEAD_SHA" "$SELECTED_JOB_IDS" "$GITHUB_REPOSITORY" "$RUN_ID" <<'PY'
           import json
-          import os
           import subprocess
           import sys
+          import time
           from pathlib import Path
+
+          sys.path.insert(0, "hack")
           import e2e_control as e2eControl
           import e2e_selector as e2eSelector
 
           prNumber = int(sys.argv[1])
           headSHA = sys.argv[2]
           selectedJobIds = json.loads(sys.argv[3])
+          repository = sys.argv[4]
+          runId = sys.argv[5]
           workflow = Path(".github/workflows/build-x86-image.yaml").read_text()
           blocks = e2eSelector.workflowJobBlocks(workflow)
           selectedTitles = [
@@ -5430,30 +5430,102 @@ jobs:
               for jobId in selectedJobIds
               if jobId in blocks
           ]
-          jobs = json.loads(Path("executor-jobs.json").read_text())
-          checks = [
-              e2eControl.prCheckRunFromExecutorJob(job, headSHA, prNumber)
-              for job in e2eControl.selectedExecutorJobs(jobs, selectedTitles)
-          ]
-          Path("pr-e2e-checks.json").write_text(json.dumps(checks) + "\n")
-          print(f"Publishing {len(checks)} pull request E2E checks.")
+
+          def gh_json(*args):
+              return json.loads(
+                  subprocess.check_output(["gh", "api", *args], text=True)
+              )
+
+          def load_jobs():
+              pages = json.loads(
+                  subprocess.check_output(
+                      [
+                          "gh",
+                          "api",
+                          "--paginate",
+                          "--slurp",
+                          f"repos/{repository}/actions/runs/{runId}/jobs?per_page=100",
+                      ],
+                      text=True,
+                  )
+              )
+              jobs = []
+              for page in pages:
+                  jobs.extend(page.get("jobs") or [])
+              return jobs
+
+          published = {}
+          for _ in range(720):
+              jobs = load_jobs()
+              selected = e2eControl.selectedExecutorJobs(jobs, selectedTitles)
+              for job in selected:
+                  payload = e2eControl.prCheckRunFromExecutorJob(
+                      job, headSHA, prNumber
+                  )
+                  fingerprint = (
+                      payload["status"],
+                      payload.get("conclusion"),
+                      payload.get("details_url"),
+                  )
+                  externalId = payload["external_id"]
+                  if published.get(externalId) == fingerprint:
+                      continue
+                  existing = gh_json(
+                      "-H",
+                      "Accept: application/vnd.github+json",
+                      f"repos/{repository}/commits/{headSHA}/check-runs?per_page=100",
+                  )
+                  checkId = next(
+                      (
+                          check.get("id")
+                          for check in existing.get("check_runs") or []
+                          if check.get("external_id") == externalId
+                      ),
+                      None,
+                  )
+                  if checkId is None:
+                      subprocess.check_call(
+                          [
+                              "gh",
+                              "api",
+                              "--method",
+                              "POST",
+                              f"repos/{repository}/check-runs",
+                              "--input",
+                              "-",
+                          ],
+                          input=json.dumps(payload),
+                          text=True,
+                      )
+                  else:
+                      update = dict(payload)
+                      update.pop("name", None)
+                      update.pop("head_sha", None)
+                      subprocess.check_call(
+                          [
+                              "gh",
+                              "api",
+                              "--method",
+                              "PATCH",
+                              f"repos/{repository}/check-runs/{checkId}",
+                              "--input",
+                              "-",
+                          ],
+                          input=json.dumps(update),
+                          text=True,
+                      )
+                  published[externalId] = fingerprint
+                  print(
+                      f"{payload['status']} {payload.get('conclusion') or '-'} {payload['name']}",
+                      flush=True,
+                  )
+              if e2eControl.selectedExecutorJobsAreTerminal(jobs, selectedTitles):
+                  print(f"Mirrored {len(published)} pull request E2E checks.", flush=True)
+                  break
+              time.sleep(20)
+          else:
+              raise SystemExit("timed out while mirroring pull request E2E checks")
           PY
-          jq -c '.[]' pr-e2e-checks.json | while read -r payload; do
-            name=$(jq -r '.name' <<< "$payload")
-            externalId=$(jq -r '.external_id' <<< "$payload")
-            existing=$(gh api \
-              -H 'Accept: application/vnd.github+json' \
-              "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100" \
-              | jq -r --arg externalId "$externalId" \
-                '[.check_runs[] | select(.external_id == $externalId)][0].id // empty')
-            if [ -n "$existing" ]; then
-              jq 'del(.name, .head_sha)' <<< "$payload" | \
-                gh api --method PATCH "repos/$GITHUB_REPOSITORY/check-runs/$existing" --input -
-            else
-              gh api --method POST "repos/$GITHUB_REPOSITORY/check-runs" --input - <<< "$payload"
-            fi
-            echo "Published $name"
-          done
 
   push:
     name: Push Images

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -731,6 +731,26 @@ def selectedExecutorJobs(jobs, selectedTitles):
     return matched
 
 
+def selectedExecutorJobsAreTerminal(jobs, selectedTitles):
+    if not selectedTitles:
+        return True
+    matched = selectedExecutorJobs(jobs, selectedTitles)
+    seenTitles = set()
+    for job in matched:
+        name = job.get("name") or ""
+        for title in selectedTitles:
+            prefix = title.split("${{", 1)[0].rstrip()
+            if name == title or (prefix and name.startswith(prefix)):
+                seenTitles.add(title)
+                break
+    if seenTitles != set(selectedTitles):
+        return False
+    return all(
+        job.get("status") == "completed" or bool(job.get("conclusion"))
+        for job in matched
+    )
+
+
 def prCheckRunFromExecutorJob(job, headSHA, prNumber):
     if not re.fullmatch(headPattern, headSHA or ""):
         raise ValueError("invalid pull request HEAD for E2E check")

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -160,6 +160,27 @@ class E2EControlTest(unittest.TestCase):
         self.assertEqual(completed["details_url"], jobs[0]["html_url"])
         self.assertEqual(pending["status"], "in_progress")
         self.assertNotIn("conclusion", pending)
+        self.assertFalse(
+            e2eControl.selectedExecutorJobsAreTerminal(
+                jobs,
+                [
+                    "Kubernetes Conformance E2E",
+                    "Kube-OVN Hosted OVN Central E2E (${{ matrix.ip-family }}, ${{ matrix.tenant-control-plane }} control-plane)",
+                ],
+            )
+        )
+        self.assertTrue(
+            e2eControl.selectedExecutorJobsAreTerminal(
+                [jobs[0]],
+                ["Kubernetes Conformance E2E"],
+            )
+        )
+        self.assertFalse(
+            e2eControl.selectedExecutorJobsAreTerminal(
+                [],
+                ["Kubernetes Conformance E2E"],
+            )
+        )
 
     def testApprovedGateReservationIgnoresGitHubRewrittenDetailsURL(self):
         headSHA = "94fd288b1db022d10863ac3254d2b40fe1dad01a"
@@ -1279,10 +1300,14 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("if: always() && github.event_name != 'pull_request'", resultBlock)
         self.assertIn("permissions: {}", resultBlock)
         publish = blocks["publish-pr-e2e-checks"]
-        self.assertIn("if: always() && github.event_name == 'workflow_dispatch'", publish)
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", publish)
         self.assertIn("checks: write", publish)
         self.assertIn("prCheckRunFromExecutorJob", publish)
+        self.assertIn("selectedExecutorJobsAreTerminal", publish)
+        self.assertIn("time.sleep(20)", publish)
         self.assertIn("HEAD_SHA: ${{ inputs.headSHA }}", publish)
+        self.assertIn("- e2e-selection\n", publish)
+        self.assertNotIn("- e2e-executor-result", publish)
         self.assertIn(
             'requiredJobIds = ["e2e-selection", "e2e-control-validation"] + selectedJobIds',
             resultBlock,


### PR DESCRIPTION
## What this PR does / why we need it

#7273 mirrored trusted executor jobs onto the PR HEAD only after the
whole run finished. This reporter now starts with selection and polls
the live executor jobs every 20s, upserting Check Runs so in-progress
jobs appear in PR checks as they start and complete.

The executor still runs on the trusted disposable ref. The PR only gets
Check Run mirrors bound to `inputs.headSHA`.

## Which issue(s) this PR fixes

Towards #7230.