### PR TITLE
fix(ipam): stop random allocation of excludeIps after IPPool reconcile

### DIFF
--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -1510,7 +1510,6 @@ func TestIPAMNamedPoolStaticAddressRemainsAllocatableAfterSubnetUpdate(t *testin
 	}
 }
 
-
 func TestIPAMRandomAddressSkipsReleasedExcludeIPsAfterIPPoolReconcile(t *testing.T) {
 	ipam := NewIPAM()
 	subnetName := "subnet"

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -1516,20 +1516,24 @@ func TestIPAMRandomAddressSkipsReleasedExcludeIPsAfterIPPoolReconcile(t *testing
 	subnetName := "subnet"
 	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "10.10.0.0/24", "10.10.0.1", []string{
 		"10.10.0.1",
-		"10.10.0.10..10.10.0.12",
+		"10.10.0.2..10.10.0.5",
 	}))
 	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "pool", []string{"10.10.0.200..10.10.0.210"}))
 
-	v4IP, _, _, err := ipam.GetStaticAddress("static-pod", "static-pod", "10.10.0.10", nil, subnetName, true)
+	v4IP, _, _, err := ipam.GetStaticAddress("static-pod", "static-pod", "10.10.0.2", nil, subnetName, true)
 	require.NoError(t, err)
-	require.Equal(t, "10.10.0.10", v4IP)
+	require.Equal(t, "10.10.0.2", v4IP)
 	ipam.ReleaseAddressByNic("static-pod", "static-pod", subnetName)
 
 	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "pool", []string{"10.10.0.200..10.10.0.210"}))
 
+	excludedIP, err := NewIP("10.10.0.2")
+	require.NoError(t, err)
+	require.False(t, ipam.Subnets[subnetName].IPPools[""].V4Free.Contains(excludedIP))
+
 	v4IP, _, _, err = ipam.GetRandomAddress("random-pod", "random-pod", nil, subnetName, "", nil, true)
 	require.NoError(t, err)
-	require.Equal(t, "10.10.0.2", v4IP)
+	require.Equal(t, "10.10.0.6", v4IP)
 }
 
 func TestIPAMRandomAddressDoesNotRecycleReservedIPs(t *testing.T) {

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -1557,12 +1557,13 @@ func TestIPAMRandomAddressDoesNotRecycleReservedIPs(t *testing.T) {
 
 func TestIPAMDualRandomAddressHandlesV4OnV6Exhaustion(t *testing.T) {
 	tests := []struct {
-		name        string
-		existingV4  string
-		wantV4Using string
+		name             string
+		existingV4       string
+		wantV4Using      string
+		wantV4UsingRange string
 	}{
 		{name: "RollsBackNewV4", wantV4Using: "0"},
-		{name: "PreservesExistingV4", existingV4: "10.0.0.2", wantV4Using: "1"},
+		{name: "PreservesExistingV4", existingV4: "10.0.0.2", wantV4Using: "1", wantV4UsingRange: "10.0.0.2"},
 	}
 
 	for _, tt := range tests {
@@ -1581,8 +1582,9 @@ func TestIPAMDualRandomAddressHandlesV4OnV6Exhaustion(t *testing.T) {
 			_, _, _, err := ipam.GetRandomAddress("pod", "pod", nil, "dual", "", nil, true)
 			require.ErrorIs(t, err, ErrNoAvailable)
 
-			_, v4Using, _, v6Using, _, _, _, _ := ipam.IPPoolStatistics("dual", "")
+			_, v4Using, _, v6Using, _, v4UsingRange, _, _ := ipam.IPPoolStatistics("dual", "")
 			require.Equal(t, tt.wantV4Using, v4Using.String())
+			require.Equal(t, tt.wantV4UsingRange, v4UsingRange)
 			require.Equal(t, "0", v6Using.String())
 		})
 	}

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -1554,3 +1554,36 @@ func TestIPAMRandomAddressDoesNotRecycleReservedIPs(t *testing.T) {
 	_, _, _, err = ipam.GetRandomAddress("random-pod", "random-pod", nil, subnetName, "", nil, true)
 	require.ErrorIs(t, err, ErrNoAvailable)
 }
+
+func TestIPAMDualRandomAddressHandlesV4OnV6Exhaustion(t *testing.T) {
+	tests := []struct {
+		name        string
+		existingV4  string
+		wantV4Using string
+	}{
+		{name: "RollsBackNewV4", wantV4Using: "0"},
+		{name: "PreservesExistingV4", existingV4: "10.0.0.2", wantV4Using: "1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipam := NewIPAM()
+			if tt.existingV4 != "" {
+				require.NoError(t, ipam.AddOrUpdateSubnet("dual", "10.0.0.0/30", "10.0.0.1", []string{"10.0.0.1"}))
+				v4IP, _, _, err := ipam.GetStaticAddress("pod", "pod", tt.existingV4, nil, "dual", true)
+				require.NoError(t, err)
+				require.Equal(t, tt.existingV4, v4IP)
+			}
+			require.NoError(t, ipam.AddOrUpdateSubnet(
+				"dual", "10.0.0.0/30,fd00::/126", "10.0.0.1,fd00::1", []string{"10.0.0.1", "fd00::1..fd00::2"},
+			))
+
+			_, _, _, err := ipam.GetRandomAddress("pod", "pod", nil, "dual", "", nil, true)
+			require.ErrorIs(t, err, ErrNoAvailable)
+
+			_, v4Using, _, v6Using, _, _, _, _ := ipam.IPPoolStatistics("dual", "")
+			require.Equal(t, tt.wantV4Using, v4Using.String())
+			require.Equal(t, "0", v6Using.String())
+		})
+	}
+}

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -1509,3 +1509,44 @@ func TestIPAMNamedPoolStaticAddressRemainsAllocatableAfterSubnetUpdate(t *testin
 		})
 	}
 }
+
+
+func TestIPAMRandomAddressSkipsReleasedExcludeIPsAfterIPPoolReconcile(t *testing.T) {
+	ipam := NewIPAM()
+	subnetName := "underlay-186"
+	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "172.24.186.0/23", "172.24.187.254", []string{
+		"172.24.186.1..172.24.186.21",
+		"172.24.187.229..172.24.187.255",
+	}))
+	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "lb186-ips", []string{"172.24.187.180..172.24.187.199"}))
+
+	v4IP, _, _, err := ipam.GetStaticAddress("sit-mng", "sit-mng", "172.24.186.4", nil, subnetName, true)
+	require.NoError(t, err)
+	require.Equal(t, "172.24.186.4", v4IP)
+	ipam.ReleaseAddressByNic("sit-mng", "sit-mng", subnetName)
+
+	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "lb186-ips", []string{"172.24.187.180..172.24.187.199"}))
+
+	v4IP, _, _, err = ipam.GetRandomAddress("uat-pod", "uat-pod", nil, subnetName, "", nil, true)
+	require.NoError(t, err)
+	require.Equal(t, "172.24.186.22", v4IP)
+}
+
+func TestIPAMRandomAddressDoesNotRecycleReservedIPs(t *testing.T) {
+	ipam := NewIPAM()
+	subnetName := "underlay-186"
+	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "172.24.186.0/24", "172.24.186.1", []string{
+		"172.24.186.1..172.24.186.21",
+	}))
+
+	subnet := ipam.Subnets[subnetName]
+	pool := subnet.IPPools[""]
+	reservedIP, err := NewIP("172.24.186.4")
+	require.NoError(t, err)
+	require.True(t, pool.V4Released.Add(reservedIP))
+	pool.V4Free = NewEmptyIPRangeList()
+	subnet.V4Free = NewEmptyIPRangeList()
+
+	_, _, _, err = ipam.GetRandomAddress("uat-pod", "uat-pod", nil, subnetName, "", nil, true)
+	require.ErrorIs(t, err, ErrNoAvailable)
+}

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -1513,40 +1513,41 @@ func TestIPAMNamedPoolStaticAddressRemainsAllocatableAfterSubnetUpdate(t *testin
 
 func TestIPAMRandomAddressSkipsReleasedExcludeIPsAfterIPPoolReconcile(t *testing.T) {
 	ipam := NewIPAM()
-	subnetName := "underlay-186"
-	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "172.24.186.0/23", "172.24.187.254", []string{
-		"172.24.186.1..172.24.186.21",
-		"172.24.187.229..172.24.187.255",
+	subnetName := "subnet"
+	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "10.10.0.0/24", "10.10.0.1", []string{
+		"10.10.0.1",
+		"10.10.0.10..10.10.0.12",
 	}))
-	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "lb186-ips", []string{"172.24.187.180..172.24.187.199"}))
+	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "pool", []string{"10.10.0.200..10.10.0.210"}))
 
-	v4IP, _, _, err := ipam.GetStaticAddress("sit-mng", "sit-mng", "172.24.186.4", nil, subnetName, true)
+	v4IP, _, _, err := ipam.GetStaticAddress("static-pod", "static-pod", "10.10.0.10", nil, subnetName, true)
 	require.NoError(t, err)
-	require.Equal(t, "172.24.186.4", v4IP)
-	ipam.ReleaseAddressByNic("sit-mng", "sit-mng", subnetName)
+	require.Equal(t, "10.10.0.10", v4IP)
+	ipam.ReleaseAddressByNic("static-pod", "static-pod", subnetName)
 
-	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "lb186-ips", []string{"172.24.187.180..172.24.187.199"}))
+	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "pool", []string{"10.10.0.200..10.10.0.210"}))
 
-	v4IP, _, _, err = ipam.GetRandomAddress("uat-pod", "uat-pod", nil, subnetName, "", nil, true)
+	v4IP, _, _, err = ipam.GetRandomAddress("random-pod", "random-pod", nil, subnetName, "", nil, true)
 	require.NoError(t, err)
-	require.Equal(t, "172.24.186.22", v4IP)
+	require.Equal(t, "10.10.0.2", v4IP)
 }
 
 func TestIPAMRandomAddressDoesNotRecycleReservedIPs(t *testing.T) {
 	ipam := NewIPAM()
-	subnetName := "underlay-186"
-	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "172.24.186.0/24", "172.24.186.1", []string{
-		"172.24.186.1..172.24.186.21",
+	subnetName := "subnet"
+	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "10.10.0.0/30", "10.10.0.1", []string{
+		"10.10.0.1",
+		"10.10.0.2",
 	}))
 
 	subnet := ipam.Subnets[subnetName]
 	pool := subnet.IPPools[""]
-	reservedIP, err := NewIP("172.24.186.4")
+	reservedIP, err := NewIP("10.10.0.2")
 	require.NoError(t, err)
 	require.True(t, pool.V4Released.Add(reservedIP))
 	pool.V4Free = NewEmptyIPRangeList()
 	subnet.V4Free = NewEmptyIPRangeList()
 
-	_, _, _, err = ipam.GetRandomAddress("uat-pod", "uat-pod", nil, subnetName, "", nil, true)
+	_, _, _, err = ipam.GetRandomAddress("random-pod", "random-pod", nil, subnetName, "", nil, true)
 	require.ErrorIs(t, err, ErrNoAvailable)
 }

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -328,10 +328,6 @@ func (s *Subnet) getV4RandomAddress(ippoolName, podName, nicName string, mac *st
 
 	pool.V4Free = pool.V4Free.Separate(pool.V4Reserved)
 	if pool.V4Free.Len() == 0 {
-		if pool.V4Released.Len() == 0 {
-			klog.Errorf("no free v4 ip in ip pool %s", ippoolName)
-			return nil, nil, "", ErrNoAvailable
-		}
 		pool.V4Free = pool.V4Released.Separate(pool.V4Reserved)
 		pool.V4Released = NewEmptyIPRangeList()
 		if pool.V4Free.Len() == 0 {
@@ -397,10 +393,6 @@ func (s *Subnet) getV6RandomAddress(ippoolName, podName, nicName string, mac *st
 
 	pool.V6Free = pool.V6Free.Separate(pool.V6Reserved)
 	if pool.V6Free.Len() == 0 {
-		if pool.V6Released.Len() == 0 {
-			klog.Errorf("no free v6 ip in ip pool %s", ippoolName)
-			return nil, nil, "", ErrNoAvailable
-		}
 		pool.V6Free = pool.V6Released.Separate(pool.V6Reserved)
 		pool.V6Released = NewEmptyIPRangeList()
 		if pool.V6Free.Len() == 0 {

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -326,13 +326,18 @@ func (s *Subnet) getV4RandomAddress(ippoolName, podName, nicName string, mac *st
 		return nil, nil, "", ErrNoAvailable
 	}
 
+	pool.V4Free = pool.V4Free.Separate(pool.V4Reserved)
 	if pool.V4Free.Len() == 0 {
 		if pool.V4Released.Len() == 0 {
 			klog.Errorf("no free v4 ip in ip pool %s", ippoolName)
 			return nil, nil, "", ErrNoAvailable
 		}
-		pool.V4Free = pool.V4Released
+		pool.V4Free = pool.V4Released.Separate(pool.V4Reserved)
 		pool.V4Released = NewEmptyIPRangeList()
+		if pool.V4Free.Len() == 0 {
+			klog.Errorf("no free v4 ip in ip pool %s", ippoolName)
+			return nil, nil, "", ErrNoAvailable
+		}
 	}
 
 	skipped := make([]IP, 0, len(skippedAddrs))
@@ -390,13 +395,18 @@ func (s *Subnet) getV6RandomAddress(ippoolName, podName, nicName string, mac *st
 		return nil, nil, "", ErrNoAvailable
 	}
 
+	pool.V6Free = pool.V6Free.Separate(pool.V6Reserved)
 	if pool.V6Free.Len() == 0 {
 		if pool.V6Released.Len() == 0 {
 			klog.Errorf("no free v6 ip in ip pool %s", ippoolName)
 			return nil, nil, "", ErrNoAvailable
 		}
-		pool.V6Free = pool.V6Released
+		pool.V6Free = pool.V6Released.Separate(pool.V6Reserved)
 		pool.V6Released = NewEmptyIPRangeList()
+		if pool.V6Free.Len() == 0 {
+			klog.Errorf("no free v6 ip in ip pool %s", ippoolName)
+			return nil, nil, "", ErrNoAvailable
+		}
 	}
 
 	skipped := make([]IP, 0, len(skippedAddrs))
@@ -831,23 +841,23 @@ func (s *Subnet) AddOrUpdateIPPool(name string, ips []string) error {
 	if p := s.IPPools[name]; p != nil {
 		defaultPool.V4IPs = defaultPool.V4IPs.Merge(p.V4IPs).Separate(pool.V4IPs)
 		defaultPool.V6IPs = defaultPool.V6IPs.Merge(p.V6IPs).Separate(pool.V6IPs)
-		defaultPool.V4Free = defaultPool.V4Available.Merge(p.V4Available).Separate(pool.V4Free)
-		defaultPool.V6Free = defaultPool.V6Available.Merge(p.V6Available).Separate(pool.V6Free)
 		defaultPool.V4Using = defaultPool.V4Using.Merge(p.V4Using).Separate(pool.V4Using)
 		defaultPool.V6Using = defaultPool.V6Using.Merge(p.V6Using).Separate(pool.V6Using)
 		defaultPool.V4Reserved = defaultPool.V4Reserved.Merge(p.V4Reserved).Separate(pool.V4Reserved)
 		defaultPool.V6Reserved = defaultPool.V6Reserved.Merge(p.V6Reserved).Separate(pool.V6Reserved)
+		defaultPool.V4Free = defaultPool.V4Available.Merge(p.V4Available).Separate(pool.V4Free).Separate(s.V4Reserved)
+		defaultPool.V6Free = defaultPool.V6Available.Merge(p.V6Available).Separate(pool.V6Free).Separate(s.V6Reserved)
 		defaultPool.V4Available = defaultPool.V4Free.Clone()
 		defaultPool.V6Available = defaultPool.V6Free.Clone()
 	} else {
 		defaultPool.V4IPs = defaultPool.V4IPs.Separate(pool.V4IPs)
 		defaultPool.V6IPs = defaultPool.V6IPs.Separate(pool.V6IPs)
-		defaultPool.V4Free = defaultPool.V4Available.Separate(pool.V4Free)
-		defaultPool.V6Free = defaultPool.V6Available.Separate(pool.V6Free)
 		defaultPool.V4Using = defaultPool.V4Using.Separate(pool.V4Using)
 		defaultPool.V6Using = defaultPool.V6Using.Separate(pool.V6Using)
 		defaultPool.V4Reserved = defaultPool.V4Reserved.Separate(pool.V4Reserved)
 		defaultPool.V6Reserved = defaultPool.V6Reserved.Separate(pool.V6Reserved)
+		defaultPool.V4Free = defaultPool.V4Available.Separate(pool.V4Free).Separate(s.V4Reserved)
+		defaultPool.V6Free = defaultPool.V6Available.Separate(pool.V6Free).Separate(s.V6Reserved)
 		defaultPool.V4Available = defaultPool.V4Free.Clone()
 		defaultPool.V6Available = defaultPool.V6Free.Clone()
 	}


### PR DESCRIPTION
## Summary
- Keep `excludeIps` out of the default pool free list when an IPPool is created or reconciled. Rebuilding `V4Free`/`V6Free` from `Available` previously reintroduced released reserved addresses.
- Strip reserved addresses before random allocation, including the `Released` recycle path, so ordinary pods cannot receive excluded IPs.
- Add regressions for the customer-style sequence (static use of an excluded IP, release, IPPool reconcile, default-pool random allocation) and for recycling reserved addresses from `Released`.
- Verify that V6 exhaustion rolls back a newly allocated V4 address while preserving an existing V4 lease.

Static allocation from `excludeIps` remains allowed.

## Test Plan
- `go test -count=1 ./pkg/ipam`
- `go vet ./pkg/ipam`