### PR TITLE
ci: publish queued x86 E2E placeholders on PR checks

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -5430,6 +5430,7 @@ jobs:
               for jobId in selectedJobIds
               if jobId in blocks
           ]
+          infraTitles = e2eControl.visibleInfrastructureTitles(blocks)
 
           def gh_json(*args):
               return json.loads(
@@ -5457,11 +5458,14 @@ jobs:
           published = {}
           for _ in range(720):
               jobs = load_jobs()
-              selected = e2eControl.selectedExecutorJobs(jobs, selectedTitles)
-              for job in selected:
-                  payload = e2eControl.prCheckRunFromExecutorJob(
-                      job, headSHA, prNumber
-                  )
+              for payload in e2eControl.prCheckRunsToPublish(
+                  jobs,
+                  selectedTitles,
+                  headSHA,
+                  prNumber,
+                  detailsURL=f"https://github.com/{repository}/actions/runs/{runId}",
+                  infraTitles=infraTitles,
+              ):
                   fingerprint = (
                       payload["status"],
                       payload.get("conclusion"),

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -714,20 +714,58 @@ def workflowJobTitle(block):
     return ""
 
 
+visibleInfrastructureJobIds = (
+    "build-kube-ovn",
+    "build-e2e-binaries",
+    "build-vpc-nat-gateway",
+    "prepare-kind-node-images",
+)
+
+
+def visibleInfrastructureTitles(blocks):
+    titles = []
+    for jobId in visibleInfrastructureJobIds:
+        block = blocks.get(jobId)
+        if not block:
+            continue
+        title = workflowJobTitle(block)
+        if title:
+            titles.append(title)
+    return titles
+
+
+def jobTitlePrefix(title):
+    return title.split("${{", 1)[0].rstrip()
+
+
+def jobMatchesTitle(name, title):
+    prefix = jobTitlePrefix(title)
+    return bool(name) and (name == title or (bool(prefix) and name.startswith(prefix)))
+
+
+def placeholderCheckName(title):
+    if "${{" not in title:
+        return title
+    prefix = jobTitlePrefix(title)
+    if prefix.endswith("("):
+        prefix = prefix[:-1].rstrip()
+    return prefix or title
+
+
 def selectedExecutorJobs(jobs, selectedTitles):
     matched = []
     seen = set()
     for job in jobs:
         name = job.get("name") or ""
         for title in selectedTitles:
-            prefix = title.split("${{", 1)[0].rstrip()
-            if name == title or (prefix and name.startswith(prefix)):
-                jobId = job.get("id")
-                if jobId in seen:
-                    break
-                seen.add(jobId)
-                matched.append(job)
+            if not jobMatchesTitle(name, title):
+                continue
+            jobId = job.get("id")
+            if jobId in seen:
                 break
+            seen.add(jobId)
+            matched.append(job)
+            break
     return matched
 
 
@@ -739,8 +777,7 @@ def selectedExecutorJobsAreTerminal(jobs, selectedTitles):
     for job in matched:
         name = job.get("name") or ""
         for title in selectedTitles:
-            prefix = title.split("${{", 1)[0].rstrip()
-            if name == title or (prefix and name.startswith(prefix)):
+            if jobMatchesTitle(name, title):
                 seenTitles.add(title)
                 break
     if seenTitles != set(selectedTitles):
@@ -751,6 +788,10 @@ def selectedExecutorJobsAreTerminal(jobs, selectedTitles):
     )
 
 
+def prCheckRunExternalId(name, headSHA, prNumber):
+    return f"x86-e2e-pr-{int(prNumber)}-{headSHA}-{name}"[:255]
+
+
 def prCheckRunFromExecutorJob(job, headSHA, prNumber):
     if not re.fullmatch(headPattern, headSHA or ""):
         raise ValueError("invalid pull request HEAD for E2E check")
@@ -758,12 +799,19 @@ def prCheckRunFromExecutorJob(job, headSHA, prNumber):
     if not name:
         raise ValueError("executor job is missing a name")
     conclusion = job.get("conclusion")
-    completed = job.get("status") == "completed" or bool(conclusion)
+    status = job.get("status") or ""
+    completed = status == "completed" or bool(conclusion)
+    if completed:
+        checkStatus = "completed"
+    elif status == "queued":
+        checkStatus = "queued"
+    else:
+        checkStatus = "in_progress"
     payload = {
         "name": name,
         "head_sha": headSHA,
-        "status": "completed" if completed else "in_progress",
-        "external_id": f"x86-e2e-pr-{int(prNumber)}-{headSHA}-{name}"[:255],
+        "status": checkStatus,
+        "external_id": prCheckRunExternalId(name, headSHA, prNumber),
         "details_url": job.get("html_url") or "",
         "output": {
             "title": name,
@@ -775,6 +823,93 @@ def prCheckRunFromExecutorJob(job, headSHA, prNumber):
     if completed:
         payload["conclusion"] = conclusion or "cancelled"
     return payload
+
+
+def placeholderCheckRun(name, headSHA, prNumber, *, queued, detailsURL, summary):
+    if not re.fullmatch(headPattern, headSHA or ""):
+        raise ValueError("invalid pull request HEAD for E2E check")
+    if not name:
+        raise ValueError("executor job is missing a name")
+    payload = {
+        "name": name,
+        "head_sha": headSHA,
+        "status": "queued" if queued else "completed",
+        "external_id": prCheckRunExternalId(name, headSHA, prNumber),
+        "details_url": detailsURL or "",
+        "output": {
+            "title": name,
+            "summary": summary,
+        },
+    }
+    if not queued:
+        payload["conclusion"] = "skipped"
+    return payload
+
+
+def prCheckRunsToPublish(
+    jobs,
+    selectedTitles,
+    headSHA,
+    prNumber,
+    detailsURL="",
+    infraTitles=None,
+):
+    payloads = []
+    seenNames = set()
+
+    def add(payload):
+        name = payload["name"]
+        if name in seenNames:
+            return
+        seenNames.add(name)
+        payloads.append(payload)
+
+    for job in selectedExecutorJobs(jobs, infraTitles or []):
+        add(prCheckRunFromExecutorJob(job, headSHA, prNumber))
+    selected = selectedExecutorJobs(jobs, selectedTitles)
+    for job in selected:
+        add(prCheckRunFromExecutorJob(job, headSHA, prNumber))
+    matchedByTitle = {title: [] for title in selectedTitles}
+    for job in selected:
+        name = job.get("name") or ""
+        for title in selectedTitles:
+            if jobMatchesTitle(name, title):
+                matchedByTitle[title].append(job)
+                break
+    for title in selectedTitles:
+        placeholderName = placeholderCheckName(title)
+        matched = matchedByTitle.get(title) or []
+        if any((job.get("name") or "") == placeholderName for job in matched):
+            continue
+        if matched:
+            add(
+                placeholderCheckRun(
+                    placeholderName,
+                    headSHA,
+                    prNumber,
+                    queued=False,
+                    detailsURL=matched[0].get("html_url") or detailsURL,
+                    summary=(
+                        f"Trusted x86 E2E matrix `{placeholderName}` is running "
+                        f"for pull request HEAD `{headSHA}`."
+                    ),
+                )
+            )
+            continue
+        add(
+            placeholderCheckRun(
+                placeholderName,
+                headSHA,
+                prNumber,
+                queued=True,
+                detailsURL=detailsURL,
+                summary=(
+                    f"Trusted x86 E2E job `{placeholderName}` is waiting to start "
+                    f"for pull request HEAD `{headSHA}`."
+                ),
+            )
+        )
+    return payloads
 
 
 def latestExecutorRun(

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -182,6 +182,113 @@ class E2EControlTest(unittest.TestCase):
             )
         )
 
+    def testUnstartedSelectedJobsArePublishedAsQueuedPlaceholders(self):
+        jobs = [
+            {
+                "id": 10,
+                "name": "Build kube-ovn",
+                "status": "in_progress",
+                "conclusion": None,
+                "html_url": "https://github.com/kubeovn/kube-ovn/actions/runs/1/job/10",
+            }
+        ]
+        selectedTitles = [
+            "Kubernetes Conformance E2E (${{ matrix.ip-family }}, ${{ matrix.mode }})",
+            "Kube-OVN Conformance E2E (${{ matrix.ip-family }}, ${{ matrix.mode }})",
+            "Cilium Chaining E2E",
+        ]
+        payloads = e2eControl.prCheckRunsToPublish(
+            jobs,
+            selectedTitles,
+            "a" * 40,
+            7275,
+            detailsURL="https://github.com/kubeovn/kube-ovn/actions/runs/1",
+            infraTitles=[
+                "Build kube-ovn",
+                "Build E2E Binaries",
+                "Prepare private Kind node image (${{ matrix.k8s-version }})",
+            ],
+        )
+        byName = {payload["name"]: payload for payload in payloads}
+        self.assertEqual(
+            [payload["name"] for payload in payloads],
+            [
+                "Build kube-ovn",
+                "Kubernetes Conformance E2E",
+                "Kube-OVN Conformance E2E",
+                "Cilium Chaining E2E",
+            ],
+        )
+        self.assertEqual(byName["Build kube-ovn"]["status"], "in_progress")
+        self.assertEqual(byName["Build kube-ovn"]["head_sha"], "a" * 40)
+        self.assertEqual(
+            byName["Build kube-ovn"]["details_url"],
+            jobs[0]["html_url"],
+        )
+        self.assertEqual(byName["Kubernetes Conformance E2E"]["status"], "queued")
+        self.assertNotIn("conclusion", byName["Kubernetes Conformance E2E"])
+        self.assertEqual(
+            byName["Kubernetes Conformance E2E"]["details_url"],
+            "https://github.com/kubeovn/kube-ovn/actions/runs/1",
+        )
+        self.assertEqual(byName["Cilium Chaining E2E"]["status"], "queued")
+        self.assertTrue(
+            byName["Kubernetes Conformance E2E"]["external_id"].startswith(
+                "x86-e2e-pr-7275-"
+            )
+        )
+
+    def testMatrixPlaceholdersCompleteAfterRealJobsStart(self):
+        jobs = [
+            {
+                "id": 2,
+                "name": "Build kube-ovn",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "https://github.com/kubeovn/kube-ovn/actions/runs/1/job/12",
+            },
+            {
+                "id": 4,
+                "name": "Kubernetes Conformance E2E (ipv4, overlay)",
+                "status": "in_progress",
+                "conclusion": None,
+                "html_url": "https://github.com/kubeovn/kube-ovn/actions/runs/1/job/14",
+            },
+            {
+                "id": 5,
+                "name": "Cilium Chaining E2E",
+                "status": "queued",
+                "conclusion": None,
+                "html_url": "https://github.com/kubeovn/kube-ovn/actions/runs/1/job/15",
+            },
+        ]
+        payloads = e2eControl.prCheckRunsToPublish(
+            jobs,
+            [
+                "Kubernetes Conformance E2E (${{ matrix.ip-family }}, ${{ matrix.mode }})",
+                "Cilium Chaining E2E",
+            ],
+            "a" * 40,
+            7275,
+            detailsURL="https://github.com/kubeovn/kube-ovn/actions/runs/1",
+            infraTitles=["Build kube-ovn"],
+        )
+        byName = {payload["name"]: payload for payload in payloads}
+        self.assertEqual(byName["Build kube-ovn"]["status"], "completed")
+        self.assertEqual(byName["Build kube-ovn"]["conclusion"], "success")
+        self.assertEqual(
+            byName["Kubernetes Conformance E2E (ipv4, overlay)"]["status"],
+            "in_progress",
+        )
+        self.assertEqual(byName["Kubernetes Conformance E2E"]["status"], "completed")
+        self.assertEqual(byName["Kubernetes Conformance E2E"]["conclusion"], "skipped")
+        self.assertEqual(byName["Cilium Chaining E2E"]["status"], "queued")
+        self.assertNotIn("conclusion", byName["Cilium Chaining E2E"])
+        self.assertEqual(
+            [payload["name"] for payload in payloads].count("Cilium Chaining E2E"),
+            1,
+        )
+
     def testApprovedGateReservationIgnoresGitHubRewrittenDetailsURL(self):
         headSHA = "94fd288b1db022d10863ac3254d2b40fe1dad01a"
         check = {
@@ -1302,7 +1409,8 @@ class E2EControlTest(unittest.TestCase):
         publish = blocks["publish-pr-e2e-checks"]
         self.assertIn("if: github.event_name == 'workflow_dispatch'", publish)
         self.assertIn("checks: write", publish)
-        self.assertIn("prCheckRunFromExecutorJob", publish)
+        self.assertIn("prCheckRunsToPublish", publish)
+        self.assertIn("visibleInfrastructureTitles", publish)
         self.assertIn("selectedExecutorJobsAreTerminal", publish)
         self.assertIn("time.sleep(20)", publish)
         self.assertIn("HEAD_SHA: ${{ inputs.headSHA }}", publish)


### PR DESCRIPTION
The trusted executor reporter only mirrored GitHub Actions jobs that already existed in the current run. Selected E2E jobs `needs: build-kube-ovn`, so during image build `selectedExecutorJobs()` is empty and pull request HEAD checks stay blank. That is what happened on #7275: the `pull_request` reporter is skipped, and the trusted `workflow_dispatch` reporter had nothing to upsert yet.

This change publishes queued placeholders for every selected job as soon as the reporter starts, also mirrors the running infrastructure jobs (`Build kube-ovn`, `Build E2E Binaries`, Kind image prep, vpc-nat-gateway), and skips the generic matrix placeholders once the real `(ipv4, overlay)` cells exist.

Fixes the live PR-check gap for #7230. After merge, a new trusted executor (automatic or `/test e2e ...`) should show in-progress `Build kube-ovn` and queued conformance checks on the PR HEAD before E2E jobs are queued.

Signed-off-by: Zujian Zhang <zhangzujian.7@gmail.com>