### PR TITLE
ci: stop duplicate automatic x86 E2E executors

### DIFF
--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -198,7 +198,18 @@ jobs:
     if: >-
       always() &&
       github.event_name == 'pull_request_target' &&
-      github.event.action != 'closed'
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize' ||
+        (
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+          startsWith(github.event.label.name, 'e2e:')
+        )
+      )
+    concurrency:
+      group: x86-e2e-automatic-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+      cancel-in-progress: true
     permissions:
       actions: write
       contents: write
@@ -260,7 +271,28 @@ jobs:
             '.controlledLabels | if length == 0 then "-" else join(",") end' \
             automatic-context.json)
           approvalGeneration=1
-          requestKey="automatic-$DISPATCH_GENERATION"
+          requestKey="automatic-$PR_NUMBER-$headSHA"
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/build-x86-image.yaml/runs?event=workflow_dispatch&per_page=100" \
+            | jq '{workflow_runs: [.[].workflow_runs[]]}' > automatic-executor-runs.json
+          python3 - "$PR_NUMBER" "$headSHA" <<'PY' > stale-automatic-runs.txt
+          import json
+          import sys
+          from pathlib import Path
+          import e2e_control as e2eControl
+
+          runs = json.loads(Path("automatic-executor-runs.json").read_text())["workflow_runs"]
+          for runId in e2eControl.inProgressAutomaticExecutorRunIds(
+              runs, int(sys.argv[1]), sys.argv[2]
+          ):
+              print(runId)
+          PY
+          while IFS= read -r runId; do
+            [ -n "$runId" ] || continue
+            if ! gh api --method POST "repos/$GITHUB_REPOSITORY/actions/runs/$runId/cancel"; then
+              echo "Automatic executor run $runId finished before cancellation." >&2
+            fi
+          done < stale-automatic-runs.txt
           executorRef=$(python3 - "$PR_NUMBER" "$approvalGeneration" "$DISPATCH_GENERATION" <<'PY'
           import sys
           import e2e_control as e2eControl

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -817,6 +817,34 @@ def latestExecutorRun(
     return matchingRuns[0][1]
 
 
+def inProgressAutomaticExecutorRunIds(runs, prNumber, headSHA):
+    if not re.fullmatch(headPattern, headSHA or ""):
+        raise ValueError("invalid pull request HEAD for automatic executor cancellation")
+    prNumber = int(prNumber)
+    matched = []
+    for run in runs:
+        if run.get("status") not in {"queued", "in_progress"}:
+            continue
+        if run.get("actor", {}).get("login") != "github-actions[bot]":
+            continue
+        path = run.get("path")
+        if path not in (None, "", ".github/workflows/build-x86-image.yaml"):
+            continue
+        try:
+            metadata = parseExecutorRunName(run.get("display_title") or "")
+        except ValueError:
+            continue
+        if (
+            metadata["prNumber"] == prNumber
+            and metadata["headSHA"] == headSHA
+            and metadata["automatic"]
+        ):
+            runId = run.get("id")
+            if runId is not None:
+                matched.append(runId)
+    return matched
+
+
 def parseArgs():
     parser = argparse.ArgumentParser(description="Control comment-gated x86 E2E workflows")
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -869,6 +869,67 @@ class E2EControlTest(unittest.TestCase):
 
         self.assertEqual(latest["id"], 8)
 
+    def testInProgressAutomaticExecutorsForTheSameHeadAreCancelled(self):
+        head = "a" * 40
+        otherHead = "b" * 40
+        runs = [
+            {
+                "id": 11,
+                "path": ".github/workflows/build-x86-image.yaml",
+                "actor": {"login": "github-actions[bot]"},
+                "status": "in_progress",
+                "display_title": (
+                    "x86-e2e pr=7278 head=" + head
+                    + " approval=1 generation=1001 mode=automatic groups=- labels=- full=0"
+                ),
+            },
+            {
+                "id": 12,
+                "path": ".github/workflows/build-x86-image.yaml",
+                "actor": {"login": "github-actions[bot]"},
+                "status": "queued",
+                "display_title": (
+                    "x86-e2e pr=7278 head=" + head
+                    + " approval=1 generation=1002 mode=automatic groups=- labels=- full=0"
+                ),
+            },
+            {
+                "id": 13,
+                "path": ".github/workflows/build-x86-image.yaml",
+                "actor": {"login": "github-actions[bot]"},
+                "status": "in_progress",
+                "display_title": (
+                    "x86-e2e pr=7278 head=" + head
+                    + " approval=1 generation=1003 mode=approved groups=core labels=- full=0"
+                ),
+            },
+            {
+                "id": 14,
+                "path": ".github/workflows/build-x86-image.yaml",
+                "actor": {"login": "github-actions[bot]"},
+                "status": "in_progress",
+                "display_title": (
+                    "x86-e2e pr=7278 head=" + otherHead
+                    + " approval=1 generation=1004 mode=automatic groups=- labels=- full=0"
+                ),
+            },
+            {
+                "id": 15,
+                "path": ".github/workflows/build-x86-image.yaml",
+                "actor": {"login": "github-actions[bot]"},
+                "status": "completed",
+                "display_title": (
+                    "x86-e2e pr=7278 head=" + head
+                    + " approval=1 generation=1005 mode=automatic groups=- labels=- full=0"
+                ),
+            },
+        ]
+
+        self.assertEqual(
+            e2eControl.inProgressAutomaticExecutorRunIds(runs, 7278, head),
+            [11, 12],
+        )
+
     def testDispatchCliWritesDecisionJson(self):
         with tempfile.TemporaryDirectory() as directory:
             directory = Path(directory)
@@ -1023,6 +1084,28 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn('git/refs/heads/$executorRef', workflow)
         self.assertIn('-f ref="$executorRef"', workflow)
         self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
+
+    def testAutomaticCoverageIgnoresUncontrolledLabelEvents(self):
+        workflow = (repoRoot / ".github/workflows/x86-e2e-dispatcher.yaml").read_text()
+        automatic = e2eSelector.workflowJobBlocks(workflow)["automatic"]
+
+        self.assertIn("github.event.action == 'opened'", automatic)
+        self.assertIn("github.event.action == 'reopened'", automatic)
+        self.assertIn("github.event.action == 'synchronize'", automatic)
+        self.assertIn("github.event.action == 'labeled'", automatic)
+        self.assertIn("github.event.action == 'unlabeled'", automatic)
+        self.assertIn("startsWith(github.event.label.name, 'e2e:')", automatic)
+        self.assertNotIn("github.event.action != 'closed'", automatic)
+        self.assertIn(
+            "group: x86-e2e-automatic-${{ github.event.pull_request.number }}-"
+            "${{ github.event.pull_request.head.sha }}",
+            automatic,
+        )
+        self.assertIn("cancel-in-progress: true", automatic)
+        self.assertIn("inProgressAutomaticExecutorRunIds", automatic)
+        self.assertIn("actions/runs/$runId/cancel", automatic)
+        self.assertIn('requestKey="automatic-$PR_NUMBER-$headSHA"', automatic)
+        self.assertNotIn('requestKey="automatic-$DISPATCH_GENERATION"', automatic)
 
     def testGateWorkflowCanOnlyReadRunsAndWriteChecks(self):
         workflow = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()


### PR DESCRIPTION
Opening a PR currently starts one automatic executor, then dosubot `size:*` / `ci` / `github_actions` labels start more. Each dispatcher run uses `generation=${{ github.run_id }}` and `requestKey=automatic-$DISPATCH_GENERATION`, so GitHub concurrency does not collapse them. `Cancel obsolete` only drops stale HEADs.

On #7278 that produced four identical smoke executors for `6c45ded99` within a few seconds.

This change:
- starts automatic coverage only on `opened` / `reopened` / `synchronize`, or `labeled`/`unlabeled` of `e2e:*`
- uses dispatcher job concurrency `x86-e2e-automatic-<pr>-<headSHA>` with `cancel-in-progress`
- sets executor `requestKey=automatic-<pr>-<headSHA>` so the existing Build x86 Image concurrency cancels the previous automatic run
- cancels any still in-progress automatic executor for that PR HEAD before dispatching a replacement

Approved `/test e2e` executors are left alone.

Signed-off-by: Zujian Zhang <zhangzujian.7@gmail.com>