### PR TITLE
ci: skip the x86 E2E gate when the PR is already merged

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -24,13 +24,6 @@ defaults:
       shutil.rmtree(shadowDir); sys.exit(result.returncode)" {0}
 
 on:
-  pull_request:
-    branches:
-    - master
-    - release-*
-    paths-ignore:
-    - 'docs/**'
-    - '**.md'
   push:
     branches:
     - master

--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -159,19 +159,23 @@ jobs:
                 -f state=open \
                 -f "head=$headOwner:$RUN_HEAD_BRANCH" \
                 > associated-pull-requests.json
-              jq \
-                --arg repository "$GITHUB_REPOSITORY" \
-                --arg headSHA "$RUN_WORKFLOW_SHA" \
-                --arg headRepository "$RUN_HEAD_REPOSITORY" \
-                '[.[] | select(
-                  .state == "open" and
-                  .head.sha == $headSHA and
-                  .head.repo.full_name == $headRepository and
-                  .base.repo.full_name == $repository
-                )] |
-                if length == 1 then .
-                else error("workflow HEAD must resolve to exactly one open pull request")
-                end' associated-pull-requests.json > run-pull-requests.json
+              python3 - "$GITHUB_REPOSITORY" "$RUN_WORKFLOW_SHA" "$RUN_HEAD_REPOSITORY" <<'PY' \
+                > run-pull-requests.json
+          import json
+          import sys
+          from pathlib import Path
+          import e2e_control as e2eControl
+
+          pulls = json.loads(Path("associated-pull-requests.json").read_text())
+          matched = e2eControl.associatedOpenPullRequests(
+              pulls, sys.argv[1], sys.argv[2], sys.argv[3]
+          )
+          if len(matched) > 1:
+              raise SystemExit(
+                  "workflow HEAD must resolve to exactly one open pull request"
+              )
+          print(json.dumps(matched))
+          PY
             fi
             prNumber=$(jq -r '.[0].number // empty' run-pull-requests.json)
             expectedHead=$(jq -r '.[0].head.sha // empty' run-pull-requests.json)
@@ -188,8 +192,9 @@ jobs:
             approved=false
             trustedExecution=false
             if [ -z "$prNumber" ] || [ -z "$expectedHead" ] || [ -z "$trustedRef" ]; then
-              echo 'The completed pull_request run is not associated with one open pull request.' >&2
-              exit 1
+              echo 'The completed pull_request run is not associated with one open pull request.'
+              echo 'skip=true' >> "$GITHUB_OUTPUT"
+              exit 0
             fi
           fi
           if ! [[ "$trustedRef" =~ ^[0-9a-f]{40}$ ]]; then

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -980,6 +980,27 @@ def inProgressAutomaticExecutorRunIds(runs, prNumber, headSHA):
     return matched
 
 
+def associatedOpenPullRequests(pulls, repository, headSHA, headRepository):
+    if not re.fullmatch(headPattern, headSHA or ""):
+        raise ValueError("invalid pull request HEAD for gate association")
+    matched = []
+    for pull in pulls or []:
+        if not isinstance(pull, dict):
+            continue
+        head = pull.get("head") if isinstance(pull.get("head"), dict) else {}
+        base = pull.get("base") if isinstance(pull.get("base"), dict) else {}
+        headRepo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+        baseRepo = base.get("repo") if isinstance(base.get("repo"), dict) else {}
+        if (
+            pull.get("state") == "open"
+            and head.get("sha") == headSHA
+            and headRepo.get("full_name") == headRepository
+            and baseRepo.get("full_name") == repository
+        ):
+            matched.append(pull)
+    return matched
+
+
 def parseArgs():
     parser = argparse.ArgumentParser(description="Control comment-gated x86 E2E workflows")
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1037,6 +1037,66 @@ class E2EControlTest(unittest.TestCase):
             [11, 12],
         )
 
+    def testAssociatedOpenPullRequestsSkipMergedHeads(self):
+        head = "a" * 40
+        other = "b" * 40
+        openPR = {
+            "number": 7280,
+            "state": "open",
+            "head": {
+                "sha": head,
+                "repo": {"full_name": "zhangzujian/kube-ovn"},
+            },
+            "base": {"repo": {"full_name": "kubeovn/kube-ovn"}},
+        }
+        closedPR = {
+            **openPR,
+            "number": 7279,
+            "state": "closed",
+        }
+        otherHead = {
+            **openPR,
+            "number": 7281,
+            "head": {
+                "sha": other,
+                "repo": {"full_name": "zhangzujian/kube-ovn"},
+            },
+        }
+
+        self.assertEqual(
+            e2eControl.associatedOpenPullRequests(
+                [closedPR, otherHead],
+                "kubeovn/kube-ovn",
+                head,
+                "zhangzujian/kube-ovn",
+            ),
+            [],
+        )
+        self.assertEqual(
+            [
+                pull["number"]
+                for pull in e2eControl.associatedOpenPullRequests(
+                    [closedPR, openPR, otherHead],
+                    "kubeovn/kube-ovn",
+                    head,
+                    "zhangzujian/kube-ovn",
+                )
+            ],
+            [7280],
+        )
+        self.assertEqual(
+            [
+                pull["number"]
+                for pull in e2eControl.associatedOpenPullRequests(
+                    [openPR, {**openPR, "number": 7282}],
+                    "kubeovn/kube-ovn",
+                    head,
+                    "zhangzujian/kube-ovn",
+                )
+            ],
+            [7280, 7282],
+        )
+
     def testDispatchCliWritesDecisionJson(self):
         with tempfile.TemporaryDirectory() as directory:
             directory = Path(directory)
@@ -1233,9 +1293,21 @@ class E2EControlTest(unittest.TestCase):
             workflow,
         )
         self.assertIn('-f "head=$headOwner:$RUN_HEAD_BRANCH"', workflow)
-        self.assertIn("workflow HEAD must resolve to exactly one open pull request", workflow)
-        self.assertIn('.head.repo.full_name == $headRepository', workflow)
-        self.assertIn('.base.repo.full_name == $repository', workflow)
+        gate = e2eSelector.workflowJobBlocks(workflow)["gate"]
+        resolve = gate.split("Download the executed SelectionPlan")[0]
+        self.assertIn("associatedOpenPullRequests", resolve)
+        self.assertIn("workflow HEAD must resolve to exactly one open pull request", resolve)
+        self.assertIn(
+            "The completed pull_request run is not associated with one open pull request.",
+            resolve,
+        )
+        missing = resolve.index(
+            "The completed pull_request run is not associated with one open pull request."
+        )
+        self.assertIn(
+            'echo \'skip=true\' >> "$GITHUB_OUTPUT"',
+            resolve[missing:missing + 400],
+        )
         self.assertIn("automatic: ${{ steps.context.outputs.automatic }}", workflow)
         self.assertIn("controlledLabels: ${{ steps.context.outputs.controlledLabels }}", workflow)
         self.assertIn("A trusted comment approval supersedes this automatic executor.", workflow)

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1487,7 +1487,7 @@ class E2EControlTest(unittest.TestCase):
             workflow,
         )
 
-    def testPullRequestKeepsBaselineBuildWithoutKindImageGate(self):
+    def testTrustedExecutorKeepsBaselineBuildWithoutKindImageGate(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
         blocks = e2eSelector.workflowJobBlocks(workflow)
         catalog = e2eSelector.loadCatalog(repoRoot / ".github/e2e-selection.json")
@@ -1517,7 +1517,15 @@ class E2EControlTest(unittest.TestCase):
                 if "docker load --input kind-node-" in block:
                     self.assertIn("- prepare-kind-node-images", block)
 
-    def testPullRequestsExecuteAutomaticCoverageAndPushStaysFull(self):
+    def testTrustedDispatchIsTheOnlyPullRequestExecutionEntry(self):
+        workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
+        triggers = workflow.split("\non:\n", 1)[1].split("\nconcurrency:", 1)[0]
+
+        self.assertNotIn("pull_request:", triggers)
+        self.assertIn("push:", triggers)
+        self.assertIn("workflow_dispatch:", triggers)
+
+    def testTrustedDispatchExecutesAutomaticCoverageAndPushStaysFull(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
         blocks = e2eSelector.workflowJobBlocks(workflow)
         catalog = e2eSelector.loadCatalog(repoRoot / ".github/e2e-selection.json")


### PR DESCRIPTION
The unprivileged `pull_request` Build x86 Image for #7280 completed after the PR was merged:

https://github.com/kubeovn/kube-ovn/actions/runs/32360797816/job/96399743984

`workflow_run.pull_requests` was empty, the fallback listed `state=open` PRs for `zhangzujian:fix/e2e-pr-check-run-input`, and jq failed with:

```
workflow HEAD must resolve to exactly one open pull request
```

Zero matching open PRs means the source PR is already gone; skip the gate. Still fail when more than one open PR matches the same HEAD.

Signed-off-by: Zujian Zhang <zhangzujian.7@gmail.com>