### PR TITLE
[release-1.16] fix: keep OVN-IC routes and gateways consistent

### DIFF
--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -785,6 +785,68 @@ func (m *MockGatewayChassis) EXPECT() *MockGatewayChassisMockRecorder {
 	return m.recorder
 }
 
+// CreateGatewayChassises mocks base method.
+func (m *MockGatewayChassis) CreateGatewayChassises(lrpName string, chassises ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []any{lrpName}
+	for _, a := range chassises {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateGatewayChassises", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateGatewayChassises indicates an expected call of CreateGatewayChassises.
+func (mr *MockGatewayChassisMockRecorder) CreateGatewayChassises(lrpName any, chassises ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{lrpName}, chassises...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGatewayChassises", reflect.TypeOf((*MockGatewayChassis)(nil).CreateGatewayChassises), varargs...)
+}
+
+// DeleteGatewayChassises mocks base method.
+func (m *MockGatewayChassis) DeleteGatewayChassises(lrpName string, chassises []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteGatewayChassises", lrpName, chassises)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteGatewayChassises indicates an expected call of DeleteGatewayChassises.
+func (mr *MockGatewayChassisMockRecorder) DeleteGatewayChassises(lrpName, chassises any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGatewayChassises", reflect.TypeOf((*MockGatewayChassis)(nil).DeleteGatewayChassises), lrpName, chassises)
+}
+
+// GetGatewayChassis mocks base method.
+func (m *MockGatewayChassis) GetGatewayChassis(name string, ignoreNotFound bool) (*ovnnb.GatewayChassis, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGatewayChassis", name, ignoreNotFound)
+	ret0, _ := ret[0].(*ovnnb.GatewayChassis)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGatewayChassis indicates an expected call of GetGatewayChassis.
+func (mr *MockGatewayChassisMockRecorder) GetGatewayChassis(name, ignoreNotFound any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGatewayChassis", reflect.TypeOf((*MockGatewayChassis)(nil).GetGatewayChassis), name, ignoreNotFound)
+}
+
+// ReconcileGatewayChassises mocks base method.
+func (m *MockGatewayChassis) ReconcileGatewayChassises(lrpName string, chassises []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileGatewayChassises", lrpName, chassises)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileGatewayChassises indicates an expected call of ReconcileGatewayChassises.
+func (mr *MockGatewayChassisMockRecorder) ReconcileGatewayChassises(lrpName, chassises any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileGatewayChassises", reflect.TypeOf((*MockGatewayChassis)(nil).ReconcileGatewayChassises), lrpName, chassises)
+}
+
 // UpdateGatewayChassis mocks base method.
 func (m *MockGatewayChassis) UpdateGatewayChassis(gwChassis *ovnnb.GatewayChassis, fields ...any) error {
 	m.ctrl.T.Helper()
@@ -2983,6 +3045,20 @@ func (mr *MockNATMockRecorder) DeleteNats(lrName, natType, logicalIP any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNats", reflect.TypeOf((*MockNAT)(nil).DeleteNats), lrName, natType, logicalIP)
 }
 
+// EnsureSnat mocks base method.
+func (m *MockNAT) EnsureSnat(lrName, externalIP, logicalIP string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureSnat", lrName, externalIP, logicalIP)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureSnat indicates an expected call of EnsureSnat.
+func (mr *MockNATMockRecorder) EnsureSnat(lrName, externalIP, logicalIP any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSnat", reflect.TypeOf((*MockNAT)(nil).EnsureSnat), lrName, externalIP, logicalIP)
+}
+
 // GetNATByUUID mocks base method.
 func (m *MockNAT) GetNATByUUID(uuid string) (*ovnnb.NAT, error) {
 	m.ctrl.T.Helper()
@@ -3040,20 +3116,6 @@ func (m *MockNAT) UpdateDnatAndSnat(lrName, externalIP, logicalIP, lspName, exte
 func (mr *MockNATMockRecorder) UpdateDnatAndSnat(lrName, externalIP, logicalIP, lspName, externalMac, gatewayType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDnatAndSnat", reflect.TypeOf((*MockNAT)(nil).UpdateDnatAndSnat), lrName, externalIP, logicalIP, lspName, externalMac, gatewayType)
-}
-
-// EnsureSnat mocks base method.
-func (m *MockNAT) EnsureSnat(lrName, externalIP, logicalIP string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureSnat", lrName, externalIP, logicalIP)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnsureSnat indicates an expected call of EnsureSnat.
-func (mr *MockNATMockRecorder) EnsureSnat(lrName, externalIP, logicalIP any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSnat", reflect.TypeOf((*MockNAT)(nil).EnsureSnat), lrName, externalIP, logicalIP)
 }
 
 // MockDHCPOptions is a mock of DHCPOptions interface.
@@ -3576,6 +3638,25 @@ func (mr *MockNbClientMockRecorder) CreateGatewayACL(lsName, pgName any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGatewayACL", reflect.TypeOf((*MockNbClient)(nil).CreateGatewayACL), lsName, pgName)
 }
 
+// CreateGatewayChassises mocks base method.
+func (m *MockNbClient) CreateGatewayChassises(lrpName string, chassises ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []any{lrpName}
+	for _, a := range chassises {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateGatewayChassises", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateGatewayChassises indicates an expected call of CreateGatewayChassises.
+func (mr *MockNbClientMockRecorder) CreateGatewayChassises(lrpName any, chassises ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{lrpName}, chassises...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGatewayChassises", reflect.TypeOf((*MockNbClient)(nil).CreateGatewayChassises), varargs...)
+}
+
 // CreateGatewayLogicalSwitch mocks base method.
 func (m *MockNbClient) CreateGatewayLogicalSwitch(lsName, lrName, provider, ip, mac string, vlanID int, chassises ...string) error {
 	m.ctrl.T.Helper()
@@ -3983,6 +4064,20 @@ func (mr *MockNbClientMockRecorder) DeleteDHCPOptionsForPort(portName any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDHCPOptionsForPort", reflect.TypeOf((*MockNbClient)(nil).DeleteDHCPOptionsForPort), portName)
 }
 
+// DeleteGatewayChassises mocks base method.
+func (m *MockNbClient) DeleteGatewayChassises(lrpName string, chassises []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteGatewayChassises", lrpName, chassises)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteGatewayChassises indicates an expected call of DeleteGatewayChassises.
+func (mr *MockNbClientMockRecorder) DeleteGatewayChassises(lrpName, chassises any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGatewayChassises", reflect.TypeOf((*MockNbClient)(nil).DeleteGatewayChassises), lrpName, chassises)
+}
+
 // DeleteHAChassisGroup mocks base method.
 func (m *MockNbClient) DeleteHAChassisGroup(name string) error {
 	m.ctrl.T.Helper()
@@ -4351,6 +4446,20 @@ func (mr *MockNbClientMockRecorder) EnablePortLayer2forward(lspName any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnablePortLayer2forward", reflect.TypeOf((*MockNbClient)(nil).EnablePortLayer2forward), lspName)
 }
 
+// EnsureSnat mocks base method.
+func (m *MockNbClient) EnsureSnat(lrName, externalIP, logicalIP string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureSnat", lrName, externalIP, logicalIP)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureSnat indicates an expected call of EnsureSnat.
+func (mr *MockNbClientMockRecorder) EnsureSnat(lrName, externalIP, logicalIP any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSnat", reflect.TypeOf((*MockNbClient)(nil).EnsureSnat), lrName, externalIP, logicalIP)
+}
+
 // FindBFD mocks base method.
 func (m *MockNbClient) FindBFD(externalIDs map[string]string) ([]ovnnb.BFD, error) {
 	m.ctrl.T.Helper()
@@ -4378,6 +4487,21 @@ func (m *MockNbClient) GetEntityInfo(entity any) error {
 func (mr *MockNbClientMockRecorder) GetEntityInfo(entity any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityInfo", reflect.TypeOf((*MockNbClient)(nil).GetEntityInfo), entity)
+}
+
+// GetGatewayChassis mocks base method.
+func (m *MockNbClient) GetGatewayChassis(name string, ignoreNotFound bool) (*ovnnb.GatewayChassis, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGatewayChassis", name, ignoreNotFound)
+	ret0, _ := ret[0].(*ovnnb.GatewayChassis)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGatewayChassis indicates an expected call of GetGatewayChassis.
+func (mr *MockNbClientMockRecorder) GetGatewayChassis(name, ignoreNotFound any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGatewayChassis", reflect.TypeOf((*MockNbClient)(nil).GetGatewayChassis), name, ignoreNotFound)
 }
 
 // GetHAChassisGroup mocks base method.
@@ -5288,6 +5412,20 @@ func (mr *MockNbClientMockRecorder) PortGroupSetPorts(pgName, ports any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortGroupSetPorts", reflect.TypeOf((*MockNbClient)(nil).PortGroupSetPorts), pgName, ports)
 }
 
+// ReconcileGatewayChassises mocks base method.
+func (m *MockNbClient) ReconcileGatewayChassises(lrpName string, chassises []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileGatewayChassises", lrpName, chassises)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileGatewayChassises indicates an expected call of ReconcileGatewayChassises.
+func (mr *MockNbClientMockRecorder) ReconcileGatewayChassises(lrpName, chassises any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileGatewayChassises", reflect.TypeOf((*MockNbClient)(nil).ReconcileGatewayChassises), lrpName, chassises)
+}
+
 // ReconcilePortDHCPOptions mocks base method.
 func (m *MockNbClient) ReconcilePortDHCPOptions(lsName, portName string, subnetDHCP *ovs.DHCPOptionsUUIDs, cidrBlock, gateway, v4Options, v6Options string, mtu int) (*ovs.DHCPOptionsUUIDs, bool, error) {
 	m.ctrl.T.Helper()
@@ -6067,20 +6205,6 @@ func (m *MockNbClient) UpdateSgACL(sg *v1.SecurityGroup, direction string) error
 func (mr *MockNbClientMockRecorder) UpdateSgACL(sg, direction any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSgACL", reflect.TypeOf((*MockNbClient)(nil).UpdateSgACL), sg, direction)
-}
-
-// EnsureSnat mocks base method.
-func (m *MockNbClient) EnsureSnat(lrName, externalIP, logicalIP string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureSnat", lrName, externalIP, logicalIP)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnsureSnat indicates an expected call of EnsureSnat.
-func (mr *MockNbClientMockRecorder) EnsureSnat(lrName, externalIP, logicalIP any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSnat", reflect.TypeOf((*MockNbClient)(nil).EnsureSnat), lrName, externalIP, logicalIP)
 }
 
 // MockSbClient is a mock of SbClient interface.

--- a/pkg/ovn_ic_controller/controller.go
+++ b/pkg/ovn_ic_controller/controller.go
@@ -3,6 +3,7 @@ package ovn_ic_controller
 import (
 	"time"
 
+	"github.com/scylladb/go-set/strset"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -43,6 +44,8 @@ type Controller struct {
 	ovnLegacyClient *ovs.LegacyClient
 	OVNNbClient     ovs.NbClient
 	OVNSbClient     ovs.SbClient
+
+	icConflictCIDRs *strset.Set
 }
 
 func NewController(config *Configuration) *Controller {
@@ -86,6 +89,7 @@ func NewController(config *Configuration) *Controller {
 		recorder:               recorder,
 
 		ovnLegacyClient: ovs.NewLegacyClient(config.OvnTimeout),
+		icConflictCIDRs: strset.New(),
 	}
 
 	var err error
@@ -116,7 +120,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	c.informerFactory.Start(stopCh)
 	c.kubeovnInformerFactory.Start(stopCh)
 
-	if !cache.WaitForCacheSync(stopCh, c.subnetSynced, c.nodesSynced) {
+	if !cache.WaitForCacheSync(stopCh, c.subnetSynced, c.nodesSynced, c.configMapsSynced, c.vpcSynced) {
 		util.LogFatalAndExit(nil, "failed to wait for caches to sync")
 		return
 	}

--- a/pkg/ovn_ic_controller/ovn_ic_controller.go
+++ b/pkg/ovn_ic_controller/ovn_ic_controller.go
@@ -1,9 +1,7 @@
 package ovn_ic_controller
 
 import (
-	"context"
 	"fmt"
-	"maps"
 	"os"
 	"os/exec"
 	"slices"
@@ -13,7 +11,6 @@ import (
 
 	"github.com/scylladb/go-set/strset"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
@@ -27,12 +24,6 @@ var (
 	lastIcCm  map[string]string
 	lastTSs   []string
 	curTSs    []string
-)
-
-const (
-	icNoAction = iota
-	icFirstEstablish
-	icConfigChange
 )
 
 func (c *Controller) disableOVNIC(azName string) error {
@@ -63,6 +54,11 @@ func (c *Controller) setAutoRoute(autoRoute bool) error {
 		if subnet.Spec.DisableInterConnection || subnet.Name == c.config.NodeSwitch {
 			blackList = append(blackList, subnet.Spec.CIDRBlock)
 		}
+	}
+	if autoRoute {
+		blackList = append(blackList, c.conflictCIDRList()...)
+	} else if c.icConflictCIDRs != nil {
+		c.icConflictCIDRs.Clear()
 	}
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
@@ -126,21 +122,20 @@ func (c *Controller) DeleteICResources(azName string) error {
 }
 
 func (c *Controller) getICState(cmData, lastcmData map[string]string) int {
-	if icEnabled != "true" && len(lastcmData) == 0 && cmData["enable-ic"] == "true" {
-		return icFirstEstablish
+	state := classifyICConfig(icEnabled, lastcmData, cmData)
+	if state != icNoAction {
+		return state
 	}
 
-	if icEnabled == "true" && lastcmData != nil && maps.Equal(cmData, lastcmData) {
-		var err error
-		c.ovnLegacyClient.OvnICNbAddress = genHostAddress(cmData["ic-db-host"], cmData["ic-nb-port"])
-		curTSs, err = c.ovnLegacyClient.GetTs()
-		if err != nil {
-			klog.Errorf("failed to get Transit_Switch, %v", err)
-			return icNoAction
-		}
-		if slices.Equal(lastTSs, curTSs) {
-			return icNoAction
-		}
+	c.ovnLegacyClient.OvnICNbAddress = genHostAddress(cmData["ic-db-host"], cmData["ic-nb-port"])
+	var err error
+	curTSs, err = c.ovnLegacyClient.GetTs()
+	if err != nil {
+		klog.Errorf("failed to get Transit_Switch, %v", err)
+		return icNoAction
+	}
+	if slices.Equal(lastTSs, curTSs) {
+		return icNoAction
 	}
 	return icConfigChange
 }
@@ -152,58 +147,66 @@ func (c *Controller) resyncInterConnection() {
 		return
 	}
 
-	if k8serrors.IsNotFound(err) || cm.Data["enable-ic"] == "false" {
-		if icEnabled == "false" {
-			return
-		}
-		klog.Info("start to remove ovn-ic")
-		var azName, icDBHost, icSBPort, icNBPort string
-		if cm != nil {
-			azName = cm.Data["az-name"]
-			icDBHost = cm.Data["ic-db-host"]
-			icSBPort = cm.Data["ic-sb-port"]
-			icNBPort = cm.Data["ic-nb-port"]
-		} else if lastIcCm != nil {
-			azName = lastIcCm["az-name"]
-			icDBHost = lastIcCm["ic-db-host"]
-			icSBPort = lastIcCm["ic-sb-port"]
-			icNBPort = lastIcCm["ic-nb-port"]
-		}
-
-		if icDBHost != "" {
-			c.ovnLegacyClient.OvnICSbAddress = genHostAddress(icDBHost, icSBPort)
-			c.ovnLegacyClient.OvnICNbAddress = genHostAddress(icDBHost, icNBPort)
-		}
-
-		err := c.disableOVNIC(azName)
-		if err != nil {
-			klog.Errorf("Disable az %s OVN IC failed: %v", azName, err)
-			return
-		}
-		if err = c.setAutoRoute(false); err != nil {
-			klog.Errorf("failed to disable auto route: %v", err)
-			return
-		}
-
-		icEnabled = "false"
-		lastIcCm = nil
-
-		klog.Info("finish removing ovn-ic")
+	if k8serrors.IsNotFound(err) {
+		c.disableInterConnection(nil)
 		return
 	}
+	if cm.Data["enable-ic"] == "false" {
+		c.disableInterConnection(cm.Data)
+		return
+	}
+	c.reconcileInterConnection(cm.Data)
+}
 
-	if err = c.setAutoRoute(cm.Data["auto-route"] == "true"); err != nil {
+func (c *Controller) disableInterConnection(config map[string]string) {
+	if icEnabled == "false" {
+		return
+	}
+	klog.Info("start to remove ovn-ic")
+	if config == nil {
+		config = lastIcCm
+	}
+	if config != nil && config["ic-db-host"] != "" {
+		c.ovnLegacyClient.OvnICSbAddress = genHostAddress(config["ic-db-host"], config["ic-sb-port"])
+		c.ovnLegacyClient.OvnICNbAddress = genHostAddress(config["ic-db-host"], config["ic-nb-port"])
+	}
+	if err := c.setAutoRoute(false); err != nil {
+		klog.Errorf("failed to disable auto route: %v", err)
+		return
+	}
+	azName := ""
+	if config != nil {
+		azName = config["az-name"]
+	}
+	if err := c.disableOVNIC(azName); err != nil {
+		klog.Errorf("Disable az %s OVN IC failed: %v", azName, err)
+		return
+	}
+	icEnabled = "false"
+	lastIcCm = nil
+	klog.Info("finish removing ovn-ic")
+}
+
+func (c *Controller) reconcileInterConnection(config map[string]string) {
+	autoRoute := config["auto-route"] == "true"
+	if autoRoute {
+		if err := c.refreshConflictCIDRs(); err != nil {
+			klog.Errorf("failed to refresh conflicting learned routes: %v", err)
+			return
+		}
+	}
+	if err := c.setAutoRoute(autoRoute); err != nil {
 		klog.Errorf("failed to set auto route: %v", err)
 		return
 	}
 
-	switch c.getICState(cm.Data, lastIcCm) {
+	switch c.getICState(config, lastIcCm) {
 	case icNoAction:
 		return
 	case icFirstEstablish:
-		c.ovnLegacyClient.OvnICNbAddress = genHostAddress(cm.Data["ic-db-host"], cm.Data["ic-nb-port"])
+		c.ovnLegacyClient.OvnICNbAddress = genHostAddress(config["ic-db-host"], config["ic-nb-port"])
 		klog.Info("start to establish ovn-ic")
-		if err := c.establishInterConnection(cm.Data); err != nil {
+		if err := c.establishInterConnection(config); err != nil {
 			klog.Errorf("failed to establish ovn-ic, %v", err)
 			return
 		}
@@ -213,26 +216,38 @@ func (c *Controller) resyncInterConnection() {
 			return
 		}
 		icEnabled = "true"
-		lastIcCm = cm.Data
+		lastIcCm = cloneICConfig(config)
 		lastTSs = curTSs
 		klog.Info("finish establishing ovn-ic")
 		return
+	case icGatewayChange:
+		c.ovnLegacyClient.OvnICSbAddress = genHostAddress(config["ic-db-host"], config["ic-sb-port"])
+		c.ovnLegacyClient.OvnICNbAddress = genHostAddress(config["ic-db-host"], config["ic-nb-port"])
+		klog.Info("start to reconcile ovn-ic gateways")
+		if err := c.establishInterConnection(config); err != nil {
+			klog.Errorf("failed to reconcile ovn-ic gateways: %v", err)
+			return
+		}
+		icEnabled = "true"
+		lastIcCm = cloneICConfig(config)
+		klog.Info("finish reconciling ovn-ic gateways")
+		return
 	case icConfigChange:
-		c.ovnLegacyClient.OvnICSbAddress = genHostAddress(lastIcCm["ic-db-host"], cm.Data["ic-sb-port"])
-		c.ovnLegacyClient.OvnICNbAddress = genHostAddress(lastIcCm["ic-db-host"], cm.Data["ic-nb-port"])
+		c.ovnLegacyClient.OvnICSbAddress = genHostAddress(lastIcCm["ic-db-host"], config["ic-sb-port"])
+		c.ovnLegacyClient.OvnICNbAddress = genHostAddress(lastIcCm["ic-db-host"], config["ic-nb-port"])
 		err := c.disableOVNIC(lastIcCm["az-name"])
 		if err != nil {
 			klog.Errorf("Disable az %s OVN IC failed: %v", lastIcCm["az-name"], err)
 			return
 		}
 		klog.Info("start to reestablish ovn-ic")
-		if err := c.establishInterConnection(cm.Data); err != nil {
+		if err := c.establishInterConnection(config); err != nil {
 			klog.Errorf("failed to reestablish ovn-ic, %v", err)
 			return
 		}
 
 		icEnabled = "true"
-		lastIcCm = cm.Data
+		lastIcCm = cloneICConfig(config)
 		lastTSs = curTSs
 		klog.Info("finish reestablishing ovn-ic")
 		return
@@ -288,43 +303,32 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 
 	sort.Strings(tsNames)
 
-	gwNodes := strings.Split(strings.Trim(config["gw-nodes"], ","), ",")
-	chassises := make([]string, len(gwNodes))
+	gwNodes := parseGwNodes(config["gw-nodes"])
+	if err := c.syncICGatewayNodeLabels(gwNodes); err != nil {
+		return err
+	}
 
 	for i, tsName := range tsNames {
-		gwNodesOrdered := generateNewOrderGwNodes(gwNodes, i)
-		for j, gw := range gwNodesOrdered {
-			gw = strings.TrimSpace(gw)
-			chassis, err := c.OVNSbClient.GetChassisByHost(gw)
-			if err != nil {
-				klog.Errorf("failed to get gw %q chassis: %v", gw, err)
-				return err
-			}
-			if chassis.Name == "" {
-				return fmt.Errorf("no chassis for gw %q", gw)
-			}
-			chassises[j] = chassis.Name
-
-			node, err := c.nodesLister.Get(gw)
-			if err != nil {
-				klog.Errorf("failed to get gw node %q: %v", gw, err)
-				return err
-			}
-			patch := util.KVPatch{util.ICGatewayLabel: "true"}
-			if err = util.PatchLabels(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
-				klog.Errorf("failed to patch ic gw node %s: %v", node.Name, err)
-				return err
-			}
-		}
-
 		tsPort := fmt.Sprintf("%s-%s", tsName, config["az-name"])
+		lrpName := fmt.Sprintf("%s-%s", config["az-name"], tsName)
 		exist, err := c.OVNNbClient.LogicalSwitchPortExists(tsPort)
 		if err != nil {
 			klog.Errorf("failed to check logical switch port %q: %v", tsPort, err)
 			return err
 		}
 		if exist {
-			klog.Infof("ts port %s already exists", tsPort)
+			klog.Infof("ts port %s already exists, reconciling gateway chassis", tsPort)
+			chassises, err := c.gatewayChassisNames(gwNodes, i)
+			if err != nil {
+				return err
+			}
+			if err := c.OVNNbClient.ReconcileGatewayChassises(lrpName, chassises); err != nil {
+				klog.Errorf("failed to reconcile gateway chassis for ic lrp %q: %v", lrpName, err)
+				return err
+			}
+			continue
+		}
+		if len(gwNodes) == 0 {
 			continue
 		}
 
@@ -334,7 +338,10 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 			return err
 		}
 
-		lrpName := fmt.Sprintf("%s-%s", config["az-name"], tsName)
+		chassises, err := c.gatewayChassisNames(gwNodes, i)
+		if err != nil {
+			return err
+		}
 		if err := c.OVNNbClient.CreateLogicalPatchPort(tsName, c.config.ClusterRouter, tsPort, lrpName, lrpAddr, util.GenerateMac(), chassises...); err != nil {
 			klog.Errorf("failed to create ovn-ic lrp %q: %v", lrpName, err)
 			return err
@@ -342,6 +349,34 @@ func (c *Controller) establishInterConnection(config map[string]string) error {
 	}
 
 	return nil
+}
+
+func (c *Controller) gatewayChassisNames(gwNodes []string, order int) ([]string, error) {
+	ordered := generateNewOrderGwNodes(gwNodes, order)
+	chassises := make([]string, len(ordered))
+	for i, gw := range ordered {
+		chassis, err := c.OVNSbClient.GetChassisByHost(gw)
+		if err != nil {
+			klog.Errorf("failed to get gw %q chassis: %v", gw, err)
+			return nil, err
+		}
+		if chassis.Name == "" {
+			return nil, fmt.Errorf("no chassis for gw %q", gw)
+		}
+		chassises[i] = chassis.Name
+
+		node, err := c.nodesLister.Get(gw)
+		if err != nil {
+			klog.Errorf("failed to get gw node %q: %v", gw, err)
+			return nil, err
+		}
+		patch := util.KVPatch{util.ICGatewayLabel: "true"}
+		if err = util.PatchLabels(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
+			klog.Errorf("failed to patch ic gw node %s: %v", node.Name, err)
+			return nil, err
+		}
+	}
+	return chassises, nil
 }
 
 func (c *Controller) acquireLrpAddress(ts string) (string, error) {
@@ -419,62 +454,13 @@ func (c *Controller) delLearnedRoute() error {
 		return err
 	}
 	for _, lr := range lrList {
-		routeList, err := c.OVNNbClient.ListLogicalRouterStaticRoutes(lr.Name, nil, nil, "", map[string]string{"ic-learned-route": ""})
-		if err != nil {
-			klog.Errorf("failed to list learned static routes on logical router %s: %v", lr.Name, err)
+		if err = c.OVNNbClient.DeleteLogicalRouterStaticRouteByExternalIDs(lr.Name, map[string]string{"ic-learned-route": ""}); err != nil {
+			klog.Errorf("failed to delete learned static routes on logical router %s: %v", lr.Name, err)
 			return err
-		}
-		for _, r := range routeList {
-			var policy ovnnb.LogicalRouterStaticRoutePolicy
-			if r.Policy != nil {
-				policy = *r.Policy
-			}
-
-			if err = c.deleteStaticRouteFromVpc(
-				lr.Name,
-				r.RouteTable,
-				r.IPPrefix,
-				r.Nexthop,
-				reversePolicy(policy),
-			); err != nil {
-				klog.Errorf("failed to delete learned static route %#v on logical router %s: %v", r, lr.Name, err)
-				return err
-			}
 		}
 	}
 
 	klog.V(5).Infof("finish removing learned routes")
-	return nil
-}
-
-func (c *Controller) deleteStaticRouteFromVpc(name, table, cidr, nextHop string, policy kubeovnv1.RoutePolicy) error {
-	var (
-		vpc, cachedVpc *kubeovnv1.Vpc
-		policyStr      string
-		err            error
-	)
-
-	policyStr = convertPolicy(policy)
-	if err = c.OVNNbClient.DeleteLogicalRouterStaticRoute(name, &table, &policyStr, cidr, nextHop); err != nil {
-		klog.Errorf("del vpc %s static route failed, %v", name, err)
-		return err
-	}
-
-	cachedVpc, err = c.vpcsLister.Get(name)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		klog.Error(err)
-		return err
-	}
-	vpc = cachedVpc.DeepCopy()
-	// make sure custom policies not be deleted
-	_, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Update(context.Background(), vpc, metav1.UpdateOptions{})
-	if err != nil {
-		klog.Error(err)
-		return err
-	}
 	return nil
 }
 
@@ -657,6 +643,9 @@ func (c *Controller) listRemoteLogicalSwitchPortAddress() (*strset.Set, error) {
 }
 
 func generateNewOrderGwNodes(arr []string, order int) []string {
+	if len(arr) == 0 {
+		return nil
+	}
 	if order >= len(arr) {
 		order %= len(arr)
 	}
@@ -664,16 +653,113 @@ func generateNewOrderGwNodes(arr []string, order int) []string {
 	return append(arr[order:], arr[:order]...)
 }
 
-func convertPolicy(origin kubeovnv1.RoutePolicy) string {
-	if origin == kubeovnv1.PolicyDst {
-		return ovnnb.LogicalRouterStaticRoutePolicyDstIP
+func (c *Controller) conflictCIDRList() []string {
+	if c == nil || c.icConflictCIDRs == nil {
+		return nil
 	}
-	return ovnnb.LogicalRouterStaticRoutePolicySrcIP
+	list := c.icConflictCIDRs.List()
+	sort.Strings(list)
+	return list
 }
 
-func reversePolicy(origin ovnnb.LogicalRouterStaticRoutePolicy) kubeovnv1.RoutePolicy {
-	if origin == ovnnb.LogicalRouterStaticRoutePolicyDstIP {
-		return kubeovnv1.PolicyDst
+func (c *Controller) refreshConflictCIDRs() error {
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets, %v", err)
+		return err
 	}
-	return kubeovnv1.PolicySrc
+	localCIDRs := subnetCIDRs(subnets)
+	persisted, err := c.persistedConflictCIDRs(localCIDRs)
+	if err != nil {
+		return err
+	}
+
+	lrList, err := c.OVNNbClient.ListLogicalRouter(false, nil)
+	if err != nil {
+		klog.Errorf("failed to list logical routers: %v", err)
+		return err
+	}
+
+	learnedPrefixes := make([]string, 0)
+	type learnedRoute struct {
+		lrName string
+		uuid   string
+		prefix string
+	}
+	var learned []learnedRoute
+	for _, lr := range lrList {
+		routeList, err := c.OVNNbClient.ListLogicalRouterStaticRoutes(lr.Name, nil, nil, "", map[string]string{"ic-learned-route": ""})
+		if err != nil {
+			klog.Errorf("failed to list learned static routes on logical router %s: %v", lr.Name, err)
+			return err
+		}
+		for _, route := range routeList {
+			learnedPrefixes = append(learnedPrefixes, route.IPPrefix)
+			learned = append(learned, learnedRoute{lrName: lr.Name, uuid: route.UUID, prefix: route.IPPrefix})
+		}
+	}
+
+	sticky := append(c.conflictCIDRList(), persisted...)
+	conflicts := mergeConflictCIDRs(localCIDRs, learnedPrefixes, sticky)
+	if c.icConflictCIDRs == nil {
+		c.icConflictCIDRs = strset.New()
+	}
+	c.icConflictCIDRs.Clear()
+	if len(conflicts) > 0 {
+		c.icConflictCIDRs.Add(conflicts...)
+		klog.Infof("detected ovn-ic cidr conflicts %v, adding them to ic-route-blacklist", conflicts)
+	}
+
+	conflictSet := strset.New(conflicts...)
+	for _, route := range learned {
+		if !conflictSet.Has(route.prefix) {
+			matched := false
+			for _, cidr := range conflicts {
+				if util.CIDROverlap(cidr, route.prefix) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		if err = c.OVNNbClient.DeleteLogicalRouterStaticRouteByUUID(route.lrName, route.uuid); err != nil {
+			klog.Errorf("failed to delete conflicting learned route %s on logical router %s: %v", route.prefix, route.lrName, err)
+			return err
+		}
+		klog.Infof("deleted conflicting learned route %s on logical router %s", route.prefix, route.lrName)
+	}
+	return nil
+}
+
+func (c *Controller) persistedConflictCIDRs(localCIDRs []string) ([]string, error) {
+	nbGlobal, err := c.OVNNbClient.GetNbGlobal()
+	if err != nil {
+		klog.Errorf("failed to get NB_Global while restoring IC conflicts: %v", err)
+		return nil, err
+	}
+
+	return filterPersistedConflictCIDRs(localCIDRs, nbGlobal.Options["ic-route-blacklist"]), nil
+}
+
+func (c *Controller) syncICGatewayNodeLabels(gwNodes []string) error {
+	desired := strset.New(gwNodes...)
+	selector := labels.Set{util.ICGatewayLabel: "true"}.AsSelector()
+	nodes, err := c.nodesLister.List(selector)
+	if err != nil {
+		klog.Errorf("failed to list ic gateway nodes, %v", err)
+		return err
+	}
+	for _, node := range nodes {
+		if desired.Has(node.Name) {
+			continue
+		}
+		patch := util.KVPatch{util.ICGatewayLabel: "false"}
+		if err = util.PatchLabels(c.config.KubeClient.CoreV1().Nodes(), node.Name, patch); err != nil {
+			klog.Errorf("failed to patch ic gw node %s: %v", node.Name, err)
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/ovn_ic_controller/ovn_ic_logic.go
+++ b/pkg/ovn_ic_controller/ovn_ic_logic.go
@@ -1,0 +1,119 @@
+package ovn_ic_controller
+
+import (
+	"maps"
+	"sort"
+	"strings"
+
+	"github.com/scylladb/go-set/strset"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+const (
+	icNoAction = iota
+	icFirstEstablish
+	icConfigChange
+	icGatewayChange
+)
+
+func cloneICConfig(data map[string]string) map[string]string {
+	if data == nil {
+		return nil
+	}
+	return maps.Clone(data)
+}
+
+func configWithoutGwNodes(data map[string]string) map[string]string {
+	out := cloneICConfig(data)
+	if out == nil {
+		return nil
+	}
+	delete(out, "gw-nodes")
+	return out
+}
+
+func classifyICConfig(enabled string, last, cur map[string]string) int {
+	if enabled != "true" && len(last) == 0 && cur["enable-ic"] == "true" {
+		return icFirstEstablish
+	}
+	if enabled == "true" && last != nil {
+		if maps.Equal(last, cur) {
+			return icNoAction
+		}
+		if maps.Equal(configWithoutGwNodes(last), configWithoutGwNodes(cur)) {
+			return icGatewayChange
+		}
+	}
+	return icConfigChange
+}
+
+func mergeConflictCIDRs(localCIDRs, learnedPrefixes, sticky []string) []string {
+	out := strset.New()
+	for _, cidr := range sticky {
+		for _, local := range localCIDRs {
+			if util.CIDROverlap(local, cidr) {
+				out.Add(cidr)
+				break
+			}
+		}
+	}
+	for _, local := range localCIDRs {
+		for _, learned := range learnedPrefixes {
+			if util.CIDROverlap(local, learned) {
+				out.Add(local)
+				out.Add(learned)
+				break
+			}
+		}
+	}
+	list := out.List()
+	sort.Strings(list)
+	return list
+}
+
+func parseGwNodes(gwNodes string) []string {
+	parts := strings.Split(gwNodes, ",")
+	nodes := make([]string, 0, len(parts))
+	for _, node := range parts {
+		node = strings.TrimSpace(node)
+		if node != "" {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
+func subnetCIDRs(subnets []*kubeovnv1.Subnet) []string {
+	cidrs := make([]string, 0, len(subnets))
+	for _, subnet := range subnets {
+		if subnet != nil && subnet.Spec.CIDRBlock != "" {
+			v4, v6 := util.SplitStringIP(subnet.Spec.CIDRBlock)
+			if v4 != "" {
+				cidrs = append(cidrs, v4)
+			}
+			if v6 != "" {
+				cidrs = append(cidrs, v6)
+			}
+		}
+	}
+	return cidrs
+}
+
+func filterPersistedConflictCIDRs(localCIDRs []string, blacklist string) []string {
+	var persisted []string
+	for entry := range strings.SplitSeq(blacklist, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		for _, local := range localCIDRs {
+			if util.CIDROverlap(local, entry) {
+				persisted = append(persisted, entry)
+				break
+			}
+		}
+	}
+	return persisted
+}

--- a/pkg/ovn_ic_controller/ovn_ic_logic_test.go
+++ b/pkg/ovn_ic_controller/ovn_ic_logic_test.go
@@ -1,0 +1,115 @@
+package ovn_ic_controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+func TestClassifyICConfig(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]string{
+		"enable-ic":  "true",
+		"az-name":    "region1",
+		"ic-db-host": "192.168.0.1",
+		"ic-nb-port": "6645",
+		"ic-sb-port": "6646",
+		"auto-route": "true",
+		"gw-nodes":   "192.168.137.158,192.168.142.47,192.168.143.70",
+	}
+
+	t.Run("first establish", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, icFirstEstablish, classifyICConfig("unknown", nil, base))
+	})
+
+	t.Run("no action when unchanged", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, icNoAction, classifyICConfig("true", cloneICConfig(base), cloneICConfig(base)))
+	})
+
+	t.Run("gateway-only change", func(t *testing.T) {
+		t.Parallel()
+		cur := cloneICConfig(base)
+		cur["gw-nodes"] = "192.168.142.47"
+		require.Equal(t, icGatewayChange, classifyICConfig("true", cloneICConfig(base), cur))
+	})
+
+	t.Run("az change is full reestablish", func(t *testing.T) {
+		t.Parallel()
+		cur := cloneICConfig(base)
+		cur["az-name"] = "region2"
+		require.Equal(t, icConfigChange, classifyICConfig("true", cloneICConfig(base), cur))
+	})
+}
+
+func TestCloneICConfigIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	orig := map[string]string{"gw-nodes": "a,b"}
+	cloned := cloneICConfig(orig)
+	orig["gw-nodes"] = "b"
+	require.Equal(t, "a,b", cloned["gw-nodes"])
+}
+
+func TestMergeConflictCIDRs(t *testing.T) {
+	t.Parallel()
+
+	local := []string{"10.16.0.0/16", "10.254.201.0/24"}
+	learned := []string{"10.3.0.0/16", "10.254.201.0/24"}
+	got := mergeConflictCIDRs(local, learned, nil)
+	require.Equal(t, []string{"10.254.201.0/24"}, got)
+
+	t.Run("blacklists both sides of a broad overlap", func(t *testing.T) {
+		t.Parallel()
+		got := mergeConflictCIDRs([]string{"10.0.1.0/24"}, []string{"10.0.0.0/16"}, nil)
+		require.Equal(t, []string{"10.0.0.0/16", "10.0.1.0/24"}, got)
+	})
+
+	t.Run("keeps persisted overlap after learned route is deleted", func(t *testing.T) {
+		t.Parallel()
+		got := mergeConflictCIDRs([]string{"10.0.1.0/24"}, nil, []string{"10.0.0.0/16"})
+		require.Equal(t, []string{"10.0.0.0/16"}, got)
+	})
+
+	t.Run("sticky keeps conflict after learned route is gone", func(t *testing.T) {
+		t.Parallel()
+		got := mergeConflictCIDRs(local, []string{"10.3.0.0/16"}, []string{"10.254.201.0/24"})
+		require.Equal(t, []string{"10.254.201.0/24"}, got)
+	})
+
+	t.Run("drop sticky after local subnet is deleted", func(t *testing.T) {
+		t.Parallel()
+		got := mergeConflictCIDRs([]string{"10.16.0.0/16"}, nil, []string{"10.254.201.0/24"})
+		require.Empty(t, got)
+	})
+
+	t.Run("unique remote cidr is not a conflict", func(t *testing.T) {
+		t.Parallel()
+		got := mergeConflictCIDRs([]string{"10.16.0.0/16"}, []string{"10.3.0.0/16"}, nil)
+		require.Empty(t, got)
+	})
+}
+
+func TestSubnetCIDRsSplitsFamilies(t *testing.T) {
+	t.Parallel()
+
+	subnets := []*kubeovnv1.Subnet{{Spec: kubeovnv1.SubnetSpec{CIDRBlock: "10.0.0.0/24,fd00::/64"}}}
+	require.Equal(t, []string{"10.0.0.0/24", "fd00::/64"}, subnetCIDRs(subnets))
+}
+
+func TestFilterPersistedConflictCIDRs(t *testing.T) {
+	t.Parallel()
+
+	local := []string{"10.0.1.0/24", "fd00::/64"}
+	require.Equal(t, []string{"10.0.0.0/16", "fd00::/64"}, filterPersistedConflictCIDRs(local, "10.0.0.0/16,10.10.0.0/16,fd00::/64"))
+}
+
+func TestGenerateNewOrderGwNodesEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, generateNewOrderGwNodes(nil, 0))
+}

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -70,6 +70,10 @@ type HAChassisGroup interface {
 }
 
 type GatewayChassis interface {
+	CreateGatewayChassises(lrpName string, chassises ...string) error
+	DeleteGatewayChassises(lrpName string, chassises []string) error
+	GetGatewayChassis(name string, ignoreNotFound bool) (*ovnnb.GatewayChassis, error)
+	ReconcileGatewayChassises(lrpName string, chassises []string) error
 	UpdateGatewayChassis(gwChassis *ovnnb.GatewayChassis, fields ...any) error
 }
 

--- a/pkg/ovs/ovn-nb-gateway_chassis.go
+++ b/pkg/ovs/ovn-nb-gateway_chassis.go
@@ -66,7 +66,10 @@ func (c *OVNNbClient) DeleteGatewayChassises(lrpName string, chassises []string)
 		uuid, delOps, err := c.DeleteGatewayChassisOp(gwChassisName)
 		if err != nil {
 			klog.Error(err)
-			return nil
+			return err
+		}
+		if uuid == "" {
+			continue
 		}
 
 		mutateOps, err := c.Where(lrp).Mutate(lrp, model.Mutation{
@@ -76,11 +79,14 @@ func (c *OVNNbClient) DeleteGatewayChassises(lrpName string, chassises []string)
 		})
 		if err != nil {
 			klog.Error(err)
-			return nil
+			return err
 		}
 
 		ops = append(ops, mutateOps...)
 		ops = append(ops, delOps...)
+	}
+	if len(ops) == 0 {
+		return nil
 	}
 
 	if err := c.Transact("gateway-chassises-delete", ops); err != nil {
@@ -234,4 +240,52 @@ func (c *OVNNbClient) DeleteGatewayChassisOp(chassisName string) (uuid string, o
 	}
 
 	return gwChassis.UUID, ops, nil
+}
+
+// ReconcileGatewayChassises make gateway chassis of a logical router port match the desired list and priority.
+func (c *OVNNbClient) ReconcileGatewayChassises(lrpName string, chassises []string) error {
+	existing, err := c.ListGatewayChassisByLogicalRouterPort(lrpName, true)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	desired := make(map[string]int, len(chassises))
+	for i, chassisName := range chassises {
+		if chassisName != "" {
+			desired[chassisName] = 100 - i
+		}
+	}
+
+	var stale []string
+	for _, gw := range existing {
+		if _, ok := desired[gw.ChassisName]; !ok {
+			stale = append(stale, gw.ChassisName)
+		}
+	}
+	if err := c.DeleteGatewayChassises(lrpName, stale); err != nil {
+		klog.Error(err)
+		return err
+	}
+	if err := c.CreateGatewayChassises(lrpName, chassises...); err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	for chassisName, priority := range desired {
+		gwChassis, err := c.GetGatewayChassis(lrpName+"-"+chassisName, false)
+		if err != nil {
+			klog.Error(err)
+			return err
+		}
+		if gwChassis.Priority == priority {
+			continue
+		}
+		gwChassis.Priority = priority
+		if err := c.UpdateGatewayChassis(gwChassis, &gwChassis.Priority); err != nil {
+			klog.Error(err)
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/ovs/ovn-nb-gateway_chassis_test.go
+++ b/pkg/ovs/ovn-nb-gateway_chassis_test.go
@@ -207,3 +207,41 @@ func (suite *OvnClientTestSuite) testNewGatewayChassis() {
 		require.Equal(t, newLrpName, gwChassis.ExternalIDs["lrp"])
 	})
 }
+
+func (suite *OvnClientTestSuite) testReconcileGatewayChassises() {
+	t := suite.T()
+	t.Parallel()
+
+	nbClient := suite.ovnNBClient
+	lrName := "test-reconcile-gateway-chassises-lr"
+	lrpName := "test-reconcile-gateway-chassises-lrp"
+	oldPrimary := "reconcile-gw-old"
+	newPrimary := "reconcile-gw-new"
+	standby := "reconcile-gw-standby"
+
+	err := nbClient.CreateLogicalRouter(lrName)
+	require.NoError(t, err)
+	err = nbClient.CreateLogicalRouterPort(lrName, lrpName, "00:11:22:37:af:62", []string{"fd00::c0a8:1001/120"})
+	require.NoError(t, err)
+	err = nbClient.CreateGatewayChassises(lrpName, oldPrimary, newPrimary, standby)
+	require.NoError(t, err)
+
+	err = nbClient.ReconcileGatewayChassises(lrpName, []string{newPrimary})
+	require.NoError(t, err)
+
+	exists, err := nbClient.GatewayChassisExist(lrpName + "-" + oldPrimary)
+	require.NoError(t, err)
+	require.False(t, exists)
+	exists, err = nbClient.GatewayChassisExist(lrpName + "-" + standby)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	gwChassis, err := nbClient.GetGatewayChassis(lrpName+"-"+newPrimary, false)
+	require.NoError(t, err)
+	require.Equal(t, 100, gwChassis.Priority)
+
+	lrp, err := nbClient.GetLogicalRouterPort(lrpName, false)
+	require.NoError(t, err)
+	require.Len(t, lrp.GatewayChassis, 1)
+	require.Contains(t, lrp.GatewayChassis, gwChassis.UUID)
+}

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -501,6 +501,10 @@ func (suite *OvnClientTestSuite) Test_NewGatewayChassis() {
 	suite.testNewGatewayChassis()
 }
 
+func (suite *OvnClientTestSuite) Test_ReconcileGatewayChassises() {
+	suite.testReconcileGatewayChassises()
+}
+
 /* ha_chassis_group unit test */
 func (suite *OvnClientTestSuite) Test_CreateHAChassisGroup() {
 	suite.testCreateHAChassisGroup()


### PR DESCRIPTION
## Summary
Backport #7265 to the 1.16 maintenance branch.

This keeps OVN-IC learned routes and transit-switch Gateway_Chassis consistent, disables `ic-route-learn` before stopping OVN-IC, and removes leftover learned routes by external ID. The older maintenance-branch Gateway_Chassis helper was adapted in place to avoid duplicate implementations.

Related: #7264
Source: #7265

## Verification
- `go generate ./mocks` completed successfully.
- `gofmt` and `git diff --check` pass.
- Local Go tests were attempted under the repository 512 MiB limit but were terminated by the memory limit during compilation; please rely on CI for full build/test verification.