### PR TITLE
fix: delete vip mapping from VPC load balancers on SwitchLBRule deletion

### DIFF
--- a/pkg/controller/switch_lb_rule.go
+++ b/pkg/controller/switch_lb_rule.go
@@ -378,6 +378,21 @@ func (c *Controller) handleDelSwitchLBRule(info *SwitchLBRuleInfo) error {
 		}
 	}
 
+	// The LBHC-driven cleanup above only removes health-check-related state; the
+	// actual vip->backends mapping on the VPC load balancers is otherwise only
+	// removed asynchronously once the backing service delete event reaches
+	// handleDeleteService. Delete it here too so the load balancer mapping is
+	// gone as soon as the SLR is deleted, rather than depending on that separate
+	// event to arrive and be processed.
+	for lbName := range vpcLBNames {
+		for _, vip := range info.Vips {
+			if err = c.OVNNbClient.LoadBalancerDeleteVip(lbName, vip, true); err != nil && !k8serrors.IsNotFound(err) {
+				klog.Errorf("failed to delete vip %s from load balancer %s, err: %v", vip, lbName, err)
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/controller/switch_lb_rule.go
+++ b/pkg/controller/switch_lb_rule.go
@@ -381,9 +381,11 @@ func (c *Controller) handleDelSwitchLBRule(info *SwitchLBRuleInfo) error {
 	// The LBHC-driven cleanup above only removes health-check-related state; the
 	// actual vip->backends mapping on the VPC load balancers is otherwise only
 	// removed asynchronously once the backing service delete event reaches
-	// handleDeleteService. Delete it here too so the load balancer mapping is
-	// gone as soon as the SLR is deleted, rather than depending on that separate
-	// event to arrive and be processed.
+	// handleDeleteService. When the VPC is known (vpcLBNames != nil), delete the
+	// mapping here too so it is gone as soon as the SLR is deleted, rather than
+	// depending on that separate event to arrive and be processed. If the VPC is
+	// unknown, vpcLBNames is nil and this loop is a no-op, falling back to the
+	// asynchronous handleDeleteService cleanup.
 	for lbName := range vpcLBNames {
 		for _, vip := range info.Vips {
 			if err = c.OVNNbClient.LoadBalancerDeleteVip(lbName, vip, true); err != nil && !k8serrors.IsNotFound(err) {

--- a/pkg/controller/switch_lb_rule_test.go
+++ b/pkg/controller/switch_lb_rule_test.go
@@ -244,6 +244,8 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		fc.mockOvnClient.EXPECT().DeleteLoadBalancerHealthChecks(gomock.Any()).Return(nil)
 		// Second call: after LBHC deletion, no more LBHCs for this subnet
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
+		// The VIP mapping itself is deleted directly from the SLR's VPC load balancer
+		fc.mockOvnClient.EXPECT().LoadBalancerDeleteVip(tcpLBName, vip1, true).Return(nil)
 
 		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
@@ -275,6 +277,7 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		fc.mockOvnClient.EXPECT().LoadBalancerDeleteIPPortMapping(tcpLBName, vip1).Return(nil)
 		fc.mockOvnClient.EXPECT().DeleteLoadBalancerHealthChecks(gomock.Any()).Return(nil)
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
+		fc.mockOvnClient.EXPECT().LoadBalancerDeleteVip(tcpLBName, vip1, true).Return(nil)
 
 		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
@@ -311,6 +314,9 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 				ExternalIDs: map[string]string{util.SwitchLBRuleSubnet: subnetName},
 			}}, nil,
 		)
+		// The SLR's own VPC LB is still checked/cleaned directly, independent of
+		// which VPC's LBHC was found above.
+		fc.mockOvnClient.EXPECT().LoadBalancerDeleteVip(tcpLBName, vip1, true).Return(nil)
 
 		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
@@ -328,6 +334,7 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
 		// Fallback: no LBHC for subnet after deletion check
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
+		fc.mockOvnClient.EXPECT().LoadBalancerDeleteVip(tcpLBName, vip1, true).Return(nil)
 
 		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)
@@ -400,6 +407,8 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 				ExternalIDs: map[string]string{util.SwitchLBRuleSubnet: subnetName},
 			}}, nil,
 		)
+		// info.VPC still resolves the SLR's own VPC LB, which is checked/cleaned directly.
+		fc.mockOvnClient.EXPECT().LoadBalancerDeleteVip(tcpLBName, vip1, true).Return(nil)
 
 		info := &SwitchLBRuleInfo{
 			Name:      slrName,
@@ -432,6 +441,8 @@ func Test_handleDelSwitchLBRule(t *testing.T) {
 		fc.mockOvnClient.EXPECT().DeleteLoadBalancerHealthChecks(gomock.Any()).Return(nil)
 		// After deletion, no more LBHCs for this subnet
 		fc.mockOvnClient.EXPECT().ListLoadBalancerHealthChecks(gomock.Any()).Return([]ovnnb.LoadBalancerHealthCheck{}, nil)
+		fc.mockOvnClient.EXPECT().LoadBalancerDeleteVip(tcpLBName, vip1, true).Return(nil)
+		fc.mockOvnClient.EXPECT().LoadBalancerDeleteVip(tcpLBName, vip2, true).Return(nil)
 
 		info := &SwitchLBRuleInfo{Name: slrName, Namespace: namespace, Vips: []string{vip1, vip2}}
 		err := fc.fakeController.handleDelSwitchLBRule(info)


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:

- Bug fixes

## Which issue(s) this PR fixes

Fixes #(issue-number)

## Details

When a `SwitchLBRule` (SLR) is deleted, `handleDelSwitchLBRule` cleans up the
associated `LoadBalancerHealthCheck`, IP-port mappings, and the Kubernetes-side
VIP custom resource, but it never removed the actual `vip -> backends` entry
from the SLR's VPC OVN load balancers (TCP/UDP/SCTP and their session-affinity
variants). That entry was previously only removed indirectly and
asynchronously, once the SLR's underlying headless Service object was deleted
and picked up by the separate `handleDeleteService` path in
`pkg/controller/service.go`.

This adds a direct, synchronous `LoadBalancerDeleteVip` call for each of the
SLR's own VPC load balancers and each of the SLR's vips, scoped by the
already-computed `vpcLBNames` set so it cannot touch another VPC's load
balancer. The call is idempotent (`LoadBalancerDeleteVip` is a no-op if the
vip isn't present on that particular load balancer), so it is additive and
does not change behavior when the vip has already been cleaned up via the
existing service-delete path.

Note: `make lint` mirrors this repo's CI-pinned golangci-lint (v2.13.1); the
x86 E2E gate workflow is currently red on `master` for unrelated reasons
(`Update x86 E2E gate`), independent of this change.

CI on this repo requires a maintainer to add `ok-to-test` — happy to address
anything it surfaces.

Fixes #6392