### PR TITLE
[release-1.16] feat(veg): add ippool option to vpc egress gateway

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -3439,6 +3439,12 @@ spec:
                   optional EVPN configuration name
                   it references a cluster-scoped EvpnConf resource
                 type: string
+              externalIPPool:
+                description: |-
+                  optional name of an IPPool resource used to allocate the external IP for the workload
+                  the referenced IPPool's subnet must match the external subnet
+                  mutually exclusive with externalIPs
+                type: string
               externalIPs:
                 description: External IP addresses for the egress gateway
                 items:
@@ -3451,6 +3457,12 @@ spec:
                 description: |-
                   optional image used by the workload
                   if not specified, the default image passed in by kube-ovn-controller will be used
+                type: string
+              internalIPPool:
+                description: |-
+                  optional name of an IPPool resource used to allocate the internal IP for the workload
+                  the referenced IPPool's subnet must match the internal subnet
+                  mutually exclusive with internalIPs
                 type: string
               internalIPs:
                 description: |-
@@ -4247,6 +4259,15 @@ spec:
             required:
             - externalSubnet
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .internalIPPool
+              message: internalIPs and internalIPPool are mutually exclusive
+              rule: '!(has(self.internalIPs) && size(self.internalIPs) != 0 && has(self.internalIPPool)
+                && size(self.internalIPPool) > 0)'
+            - fieldPath: .externalIPPool
+              message: externalIPs and externalIPPool are mutually exclusive
+              rule: '!(has(self.externalIPs) && size(self.externalIPs) != 0 && has(self.externalIPPool)
+                && size(self.externalIPPool) > 0)'
           status:
             properties:
               conditions:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -3462,6 +3462,12 @@ spec:
                   optional EVPN configuration name
                   it references a cluster-scoped EvpnConf resource
                 type: string
+              externalIPPool:
+                description: |-
+                  optional name of an IPPool resource used to allocate the external IP for the workload
+                  the referenced IPPool's subnet must match the external subnet
+                  mutually exclusive with externalIPs
+                type: string
               externalIPs:
                 description: External IP addresses for the egress gateway
                 items:
@@ -3474,6 +3480,12 @@ spec:
                 description: |-
                   optional image used by the workload
                   if not specified, the default image passed in by kube-ovn-controller will be used
+                type: string
+              internalIPPool:
+                description: |-
+                  optional name of an IPPool resource used to allocate the internal IP for the workload
+                  the referenced IPPool's subnet must match the internal subnet
+                  mutually exclusive with internalIPs
                 type: string
               internalIPs:
                 description: |-
@@ -4270,6 +4282,15 @@ spec:
             required:
             - externalSubnet
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .internalIPPool
+              message: internalIPs and internalIPPool are mutually exclusive
+              rule: '!(has(self.internalIPs) && size(self.internalIPs) != 0 && has(self.internalIPPool)
+                && size(self.internalIPPool) > 0)'
+            - fieldPath: .externalIPPool
+              message: externalIPs and externalIPPool are mutually exclusive
+              rule: '!(has(self.externalIPs) && size(self.externalIPs) != 0 && has(self.externalIPPool)
+                && size(self.externalIPPool) > 0)'
           status:
             properties:
               conditions:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3850,6 +3850,12 @@ spec:
                   optional EVPN configuration name
                   it references a cluster-scoped EvpnConf resource
                 type: string
+              externalIPPool:
+                description: |-
+                  optional name of an IPPool resource used to allocate the external IP for the workload
+                  the referenced IPPool's subnet must match the external subnet
+                  mutually exclusive with externalIPs
+                type: string
               externalIPs:
                 description: External IP addresses for the egress gateway
                 items:
@@ -3862,6 +3868,12 @@ spec:
                 description: |-
                   optional image used by the workload
                   if not specified, the default image passed in by kube-ovn-controller will be used
+                type: string
+              internalIPPool:
+                description: |-
+                  optional name of an IPPool resource used to allocate the internal IP for the workload
+                  the referenced IPPool's subnet must match the internal subnet
+                  mutually exclusive with internalIPs
                 type: string
               internalIPs:
                 description: |-
@@ -4658,6 +4670,15 @@ spec:
             required:
             - externalSubnet
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .internalIPPool
+              message: internalIPs and internalIPPool are mutually exclusive
+              rule: '!(has(self.internalIPs) && size(self.internalIPs) != 0 && has(self.internalIPPool)
+                && size(self.internalIPPool) > 0)'
+            - fieldPath: .externalIPPool
+              message: externalIPs and externalIPPool are mutually exclusive
+              rule: '!(has(self.externalIPs) && size(self.externalIPs) != 0 && has(self.externalIPPool)
+                && size(self.externalIPPool) > 0)'
           status:
             properties:
               conditions:

--- a/pkg/apis/kubeovn/v1/vpc-egress-gateway.go
+++ b/pkg/apis/kubeovn/v1/vpc-egress-gateway.go
@@ -254,6 +254,8 @@ func (b *BandwidthLimit) Mbps() (int64, int64, error) {
 	return ingress, egress, nil
 }
 
+// +kubebuilder:validation:XValidation:rule="!(has(self.internalIPs) && size(self.internalIPs) != 0 && has(self.internalIPPool) && size(self.internalIPPool) > 0)",message="internalIPs and internalIPPool are mutually exclusive",fieldPath=".internalIPPool"
+// +kubebuilder:validation:XValidation:rule="!(has(self.externalIPs) && size(self.externalIPs) != 0 && has(self.externalIPPool) && size(self.externalIPPool) > 0)",message="externalIPs and externalIPPool are mutually exclusive",fieldPath=".externalIPPool"
 type VpcEgressGatewaySpec struct {
 	// optional VPC name
 	// if not specified, the default VPC will be used
@@ -285,6 +287,14 @@ type VpcEgressGatewaySpec struct {
 	InternalIPs []string `json:"internalIPs,omitempty"`
 	// External IP addresses for the egress gateway
 	ExternalIPs []string `json:"externalIPs,omitempty"`
+	// optional name of an IPPool resource used to allocate the internal IP for the workload
+	// the referenced IPPool's subnet must match the internal subnet
+	// mutually exclusive with internalIPs
+	InternalIPPool string `json:"internalIPPool,omitempty"`
+	// optional name of an IPPool resource used to allocate the external IP for the workload
+	// the referenced IPPool's subnet must match the external subnet
+	// mutually exclusive with externalIPs
+	ExternalIPPool string `json:"externalIPPool,omitempty"`
 	// namespace/pod selectors
 	Selectors []VpcEgressGatewaySelector `json:"selectors,omitempty"`
 	// optional traffic policy used to control the traffic routing

--- a/pkg/controller/vpc_egress_gateway.go
+++ b/pkg/controller/vpc_egress_gateway.go
@@ -474,6 +474,16 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 		klog.Error(err)
 		return "", nil, nil, nil, err
 	}
+	if len(gw.Spec.InternalIPs) != 0 && gw.Spec.InternalIPPool != "" {
+		err := errors.New("internalIPs and internalIPPool are mutually exclusive")
+		klog.Error(err)
+		return "", nil, nil, nil, err
+	}
+	if len(gw.Spec.ExternalIPs) != 0 && gw.Spec.ExternalIPPool != "" {
+		err := errors.New("externalIPs and externalIPPool are mutually exclusive")
+		klog.Error(err)
+		return "", nil, nil, nil, err
+	}
 
 	internalSubnet := gw.Spec.InternalSubnet
 	if internalSubnet == "" {
@@ -597,10 +607,36 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 	if len(gw.Spec.InternalIPs) != 0 {
 		// set internal IPs
 		annotations[util.IPPoolAnnotation] = strings.Join(gw.Spec.InternalIPs, ";")
+	} else if gw.Spec.InternalIPPool != "" {
+		// allocate the internal IP from the referenced IPPool
+		pool, err := c.ippoolLister.Get(gw.Spec.InternalIPPool)
+		if err != nil {
+			klog.Error(err)
+			return attachmentNetworkName, nil, nil, nil, err
+		}
+		if pool.Spec.Subnet != intSubnet.Name {
+			err = fmt.Errorf("subnet %q of internal IPPool %q does not match internal subnet %q", pool.Spec.Subnet, gw.Spec.InternalIPPool, intSubnet.Name)
+			klog.Error(err)
+			return attachmentNetworkName, nil, nil, nil, err
+		}
+		annotations[util.IPPoolAnnotation] = gw.Spec.InternalIPPool
 	}
 	if len(gw.Spec.ExternalIPs) != 0 {
 		// set external IPs
 		annotations[fmt.Sprintf(util.IPPoolAnnotationTemplate, extSubnet.Spec.Provider)] = strings.Join(gw.Spec.ExternalIPs, ";")
+	} else if gw.Spec.ExternalIPPool != "" {
+		// allocate the external IP from the referenced IPPool
+		pool, err := c.ippoolLister.Get(gw.Spec.ExternalIPPool)
+		if err != nil {
+			klog.Error(err)
+			return attachmentNetworkName, nil, nil, nil, err
+		}
+		if pool.Spec.Subnet != extSubnet.Name {
+			err = fmt.Errorf("subnet %q of external IPPool %q does not match external subnet %q", pool.Spec.Subnet, gw.Spec.ExternalIPPool, extSubnet.Name)
+			klog.Error(err)
+			return attachmentNetworkName, nil, nil, nil, err
+		}
+		annotations[fmt.Sprintf(util.IPPoolAnnotationTemplate, extSubnet.Spec.Provider)] = gw.Spec.ExternalIPPool
 	}
 	if err := setVpcEgressGatewayBandwidthAnnotations(annotations, gw.Spec.Bandwidth); err != nil {
 		return attachmentNetworkName, nil, nil, nil, err
@@ -819,20 +855,24 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 	// replicas and the hash annotation should be excluded from hash calculation
 	deploy.Spec.Replicas = new(gw.Spec.Replicas)
 	deploy.Annotations = map[string]string{util.GenerateHashAnnotation: hash}
-	if currentDeploy, err := c.deploymentsLister.Deployments(gw.Namespace).Get(deploy.Name); err != nil {
-		if !k8serrors.IsNotFound(err) {
+	var currentDeploy *appsv1.Deployment
+	if c.deploymentsLister != nil {
+		if currentDeploy, err = c.deploymentsLister.Deployments(gw.Namespace).Get(deploy.Name); err != nil && !k8serrors.IsNotFound(err) {
 			err = fmt.Errorf("failed to get deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
 			klog.Error(err)
 			return attachmentNetworkName, nil, nil, nil, err
 		}
+	}
+	switch {
+	case currentDeploy == nil:
 		if deploy, err = c.config.KubeClient.AppsV1().Deployments(gw.Namespace).
 			Create(context.Background(), deploy, metav1.CreateOptions{}); err != nil {
 			err = fmt.Errorf("failed to create deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
 			klog.Error(err)
 			return attachmentNetworkName, nil, nil, nil, err
 		}
-	} else if !reflect.DeepEqual(currentDeploy.Spec.Replicas, deploy.Spec.Replicas) ||
-		currentDeploy.Annotations[util.GenerateHashAnnotation] != hash {
+	case !reflect.DeepEqual(currentDeploy.Spec.Replicas, deploy.Spec.Replicas) ||
+		currentDeploy.Annotations[util.GenerateHashAnnotation] != hash:
 		// update the deployment if replicas or hash annotation is changed
 		if deploy, err = c.config.KubeClient.AppsV1().Deployments(gw.Namespace).
 			Update(context.Background(), deploy, metav1.UpdateOptions{}); err != nil {
@@ -840,7 +880,7 @@ func (c *Controller) reconcileVpcEgressGatewayWorkload(gw *kubeovnv1.VpcEgressGa
 			klog.Error(err)
 			return attachmentNetworkName, nil, nil, nil, err
 		}
-	} else {
+	default:
 		// no need to create or update the deployment
 		deploy = currentDeploy
 	}

--- a/pkg/controller/vpc_egress_gateway_test.go
+++ b/pkg/controller/vpc_egress_gateway_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -584,4 +585,140 @@ func TestCollectVpcEgressGatewayWorkloadStatusRetainsNetworkedNotReadyPod(t *tes
 	require.Equal(t, map[string]string{"node-1": "10.16.1.10", "node-2": "10.16.1.11"}, ipv4)
 	require.Empty(t, ipv6)
 	require.Len(t, messages, 1)
+}
+
+func newVpcEgressGatewayWorkloadTestController(t *testing.T, ippools []*kubeovnv1.IPPool) (*Controller, *kubeovnv1.Subnet, *kubeovnv1.Subnet) {
+	t.Helper()
+	intSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "int-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.16.0.0/16",
+			Gateway:   "10.16.0.1",
+		},
+	}
+	extSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ext-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "172.20.0.0/16",
+			Gateway:   "172.20.0.1",
+			Provider:  "eth1.default",
+		},
+	}
+	nad := &nadv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "eth1", Namespace: "default"},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets:            []*kubeovnv1.Subnet{intSubnet, extSubnet},
+		NetworkAttachments: []*nadv1.NetworkAttachmentDefinition{nad},
+	})
+	require.NoError(t, err)
+	ippoolIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, ippool := range ippools {
+		require.NoError(t, ippoolIndexer.Add(ippool))
+	}
+	fc.fakeController.ippoolLister = kubeovnlister.NewIPPoolLister(ippoolIndexer)
+	return fc.fakeController, intSubnet, extSubnet
+}
+
+func newVpcEgressGatewayForWorkloadTest(intSubnet, extSubnet *kubeovnv1.Subnet) *kubeovnv1.VpcEgressGateway {
+	return &kubeovnv1.VpcEgressGateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "veg"},
+		Spec: kubeovnv1.VpcEgressGatewaySpec{
+			Image:          "test-image",
+			InternalSubnet: intSubnet.Name,
+			ExternalSubnet: extSubnet.Name,
+		},
+	}
+}
+
+func TestReconcileVpcEgressGatewayWorkloadIPPoolAnnotations(t *testing.T) {
+	ippools := []*kubeovnv1.IPPool{
+		{ObjectMeta: metav1.ObjectMeta{Name: "int-pool"}, Spec: kubeovnv1.IPPoolSpec{Subnet: "int-subnet"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ext-pool"}, Spec: kubeovnv1.IPPoolSpec{Subnet: "ext-subnet"}},
+	}
+	c, intSubnet, extSubnet := newVpcEgressGatewayWorkloadTestController(t, ippools)
+
+	gw := newVpcEgressGatewayForWorkloadTest(intSubnet, extSubnet)
+	gw.Spec.InternalIPPool = "int-pool"
+	gw.Spec.ExternalIPPool = "ext-pool"
+
+	_, _, _, deploy, err := c.reconcileVpcEgressGatewayWorkload(gw, &kubeovnv1.Vpc{}, "", "", "")
+	require.NoError(t, err)
+	require.Equal(t, "int-pool", deploy.Spec.Template.Annotations[util.IPPoolAnnotation])
+	require.Equal(t, "ext-pool", deploy.Spec.Template.Annotations[fmt.Sprintf(util.IPPoolAnnotationTemplate, extSubnet.Spec.Provider)])
+}
+
+func TestReconcileVpcEgressGatewayWorkloadIPPoolSubnetMismatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		pool    *kubeovnv1.IPPool
+		setSpec func(spec *kubeovnv1.VpcEgressGatewaySpec, poolName string)
+		wantErr string
+	}{
+		{
+			name: "internal pool subnet mismatch",
+			pool: &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "int-pool"}, Spec: kubeovnv1.IPPoolSpec{Subnet: "other-subnet"}},
+			setSpec: func(spec *kubeovnv1.VpcEgressGatewaySpec, poolName string) {
+				spec.InternalIPPool = poolName
+			},
+			wantErr: "does not match internal subnet",
+		},
+		{
+			name: "external pool subnet mismatch",
+			pool: &kubeovnv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "ext-pool"}, Spec: kubeovnv1.IPPoolSpec{Subnet: "other-subnet"}},
+			setSpec: func(spec *kubeovnv1.VpcEgressGatewaySpec, poolName string) {
+				spec.ExternalIPPool = poolName
+			},
+			wantErr: "does not match external subnet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, intSubnet, extSubnet := newVpcEgressGatewayWorkloadTestController(t, []*kubeovnv1.IPPool{tt.pool})
+
+			gw := newVpcEgressGatewayForWorkloadTest(intSubnet, extSubnet)
+			tt.setSpec(&gw.Spec, tt.pool.Name)
+
+			_, _, _, _, err := c.reconcileVpcEgressGatewayWorkload(gw, &kubeovnv1.Vpc{}, "", "", "")
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestReconcileVpcEgressGatewayWorkloadMutuallyExclusiveIPFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		setSpec func(spec *kubeovnv1.VpcEgressGatewaySpec)
+		wantErr string
+	}{
+		{
+			name: "internal IPs and pool set",
+			setSpec: func(spec *kubeovnv1.VpcEgressGatewaySpec) {
+				spec.InternalIPs = []string{"10.16.0.10"}
+				spec.InternalIPPool = "int-pool"
+			},
+			wantErr: "internalIPs and internalIPPool are mutually exclusive",
+		},
+		{
+			name: "external IPs and pool set",
+			setSpec: func(spec *kubeovnv1.VpcEgressGatewaySpec) {
+				spec.ExternalIPs = []string{"172.20.0.10"}
+				spec.ExternalIPPool = "ext-pool"
+			},
+			wantErr: "externalIPs and externalIPPool are mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{config: &Configuration{}}
+			gw := &kubeovnv1.VpcEgressGateway{Spec: kubeovnv1.VpcEgressGatewaySpec{Image: "test-image"}}
+			tt.setSpec(&gw.Spec)
+
+			_, _, _, _, err := c.reconcileVpcEgressGatewayWorkload(gw, &kubeovnv1.Vpc{}, "", "", "")
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
 }


### PR DESCRIPTION
Backport of #7250.

Original merge commit: 86ee7932d3b23230cde8bf86bea86bf110ce7f92

This backport adds `internalIPPool` and `externalIPPool` support, validation, controller handling, and regression tests. The release-1.16 branch does not contain the master applyconfiguration generation package, so the master-only generated `vpcegressgatewayspec.go` file is intentionally not copied.

The existing IPPool informer handlers still do not enqueue VPC Egress Gateways that reference a changed or deleted pool; that follow-up is outside this merged commit.