### PR TITLE
feat(chart): make monitor replicas configurable

### DIFF
--- a/.github/workflows/helm-testing.yaml
+++ b/.github/workflows/helm-testing.yaml
@@ -3,6 +3,7 @@ name: Lint and Test Charts
 on:
   pull_request:
     paths:
+      - 'charts/kube-ovn/**'
       - 'charts/kube-ovn-v2/**'
       - '.github/workflows/helm-testing.yaml'
 
@@ -37,6 +38,8 @@ jobs:
       - name: Run chart-testing (lint)
         run: |
           ct lint --target-branch ${{ github.event.repository.default_branch }} --config charts/kube-ovn-v2/ct.yaml
+          # Lint the legacy chart separately; it is intentionally not installed in the shared Kind cluster.
+          ct lint --target-branch ${{ github.event.repository.default_branch }} --config charts/kube-ovn/ct.yaml
 
       - name: Install kind
         uses: helm/kind-action@v1.14.0

--- a/charts/kube-ovn-v2/README.md
+++ b/charts/kube-ovn-v2/README.md
@@ -1551,6 +1551,15 @@ false
 			<td>Labels to be added to kube-ovn-monitor pods.</td>
 		</tr>
 		<tr>
+			<td>monitor.replicas</td>
+			<td>int</td>
+			<td><pre lang="json">
+1
+</pre>
+</td>
+			<td>Number of kube-ovn-monitor replicas.</td>
+		</tr>
+		<tr>
 			<td>monitor.resources</td>
 			<td>object</td>
 			<td><pre lang="json">

--- a/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/monitor/monitor-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.monitor.replicas }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/charts/kube-ovn-v2/tests/monitor_deployment_test.yaml
+++ b/charts/kube-ovn-v2/tests/monitor_deployment_test.yaml
@@ -1,0 +1,17 @@
+suite: Kube-OVN monitor deployment (v2)
+templates:
+  - monitor/monitor-deployment.yaml
+tests:
+  - it: uses one replica by default
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: supports a custom replica count
+    set:
+      monitor.replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -794,6 +794,10 @@ pinger:
 # @section -- OVN monitoring daemon configuration
 # @default -- "{}"
 monitor:
+  # -- Number of kube-ovn-monitor replicas.
+  # @section -- OVN monitoring daemon configuration
+  replicas: 1
+
   # -- Override image settings for kube-ovn-monitor. Empty fields fall back to the global kube-ovn image.
   # @section -- OVN monitoring daemon configuration
   image:

--- a/charts/kube-ovn/ct.yaml
+++ b/charts/kube-ovn/ct.yaml
@@ -1,0 +1,6 @@
+charts: charts/kube-ovn
+validate-maintainers: false
+check-version-increment: false
+namespace: kube-system
+release-label: app.kubernetes.io/instance
+skip-clean-up: true

--- a/charts/kube-ovn/templates/monitor-deploy.yaml
+++ b/charts/kube-ovn/templates/monitor-deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/description: |
       Metrics for OVN components: northd, nb and sb.
 spec:
-  replicas: 1
+  replicas: {{ index .Values "kube-ovn-monitor" "replicas" }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/charts/kube-ovn/tests/monitor_deployment_test.yaml
+++ b/charts/kube-ovn/tests/monitor_deployment_test.yaml
@@ -1,0 +1,17 @@
+suite: Kube-OVN monitor deployment
+templates:
+  - monitor-deploy.yaml
+tests:
+  - it: uses one replica by default
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: supports a custom replica count
+    set:
+      kube-ovn-monitor.replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -291,6 +291,7 @@ kube-ovn-pinger:
     memory: "400Mi"
     ephemeral-storage: 1Gi
 kube-ovn-monitor:
+  replicas: 1
   requests:
     cpu: "200m"
     memory: "200Mi"


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Features
- Docs
- Tests

## What this PR changes

Both Helm charts hardcoded `kube-ovn-monitor` to one replica. This caused Helm upgrades to overwrite manual scaling and prevented HA OVN deployments from collecting the local Raft role from every central node.

This PR:

- adds `kube-ovn-monitor.replicas` to the classic chart and `monitor.replicas` to the v2 chart, both defaulting to 1;
- renders the configured value in both monitor Deployments;
- documents the v2 value;
- adds Helm unit tests for the default and custom replica counts.

## Validation

- `helm unittest charts/kube-ovn` (28 passed)
- `helm unittest charts/kube-ovn-v2` (28 passed)
- `helm lint charts/kube-ovn`
- `helm lint charts/kube-ovn-v2`
- full renders with each replica value set to 3

## Which issue(s) this PR fixes

Fixes #7105