### PR TITLE
feat: add routed subnet mode with /32 addressing and gateway hairpin

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -2807,6 +2807,14 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              routed:
+                description: |-
+                  Routed configures pods with /32 (IPv4) or /128 (IPv6) addresses and
+                  on-link routes to the gateway. Same-subnet traffic is forced through the
+                  OVN logical router instead of direct L2. Requires an OVN logical router
+                  port (overlay, or underlay with logicalGateway / u2oInterconnection).
+                  Existing pods must be recreated after enabling or disabling this field.
+                type: boolean
               u2oFeatures:
                 description: Feature configurations for underlay to overlay interconnection.
                 properties:

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -2826,6 +2826,14 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              routed:
+                description: |-
+                  Routed configures pods with /32 (IPv4) or /128 (IPv6) addresses and
+                  on-link routes to the gateway. Same-subnet traffic is forced through the
+                  OVN logical router instead of direct L2. Requires an OVN logical router
+                  port (overlay, or underlay with logicalGateway / u2oInterconnection).
+                  Existing pods must be recreated after enabling or disabling this field.
+                type: boolean
               u2oFeatures:
                 description: Feature configurations for underlay to overlay interconnection.
                 properties:

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3219,6 +3219,14 @@ spec:
               routeTable:
                 description: Route table associated with the subnet.
                 type: string
+              routed:
+                description: |-
+                  Routed configures pods with /32 (IPv4) or /128 (IPv6) addresses and
+                  on-link routes to the gateway. Same-subnet traffic is forced through the
+                  OVN logical router instead of direct L2. Requires an OVN logical router
+                  port (overlay, or underlay with logicalGateway / u2oInterconnection).
+                  Existing pods must be recreated after enabling or disabling this field.
+                type: boolean
               u2oFeatures:
                 description: Feature configurations for underlay to overlay interconnection.
                 properties:

--- a/docs/routed-subnet.md
+++ b/docs/routed-subnet.md
@@ -15,7 +15,8 @@ ip route add default via 10.0.0.1
 Same-subnet east-west traffic is hairpinned through the OVN logical router. OVN ACLs use an allow-list / default-deny policy:
 
 - Allow ARP/ND only for the gateway
-- Allow IP frames whose Ethernet source or destination is the logical router port MAC (both ACL directions), so pod→router and router→pod hairpin traffic is permitted while direct L2 pod→pod is denied
+- Allow IP frames to the logical router port MAC (`eth.dst`) on both ACL directions (pod→router)
+- Allow IP frames from the logical router port MAC (`eth.src`) on `to-lport`, and on `from-lport` only when `inport` is the router LSP (so pods cannot spoof the LRP MAC; port security is off by default)
 - Drop all other IP/ARP/ND (both directions)
 
 When `private: true`, ingress via the router is further limited to hairpin (own CIDR), node join CIDR, and `allowSubnets`.

--- a/docs/routed-subnet.md
+++ b/docs/routed-subnet.md
@@ -1,0 +1,27 @@
+# Routed subnet mode
+
+Set `spec.routed: true` on a Subnet so pods get host routes (`/32` IPv4 or `/128` IPv6) and send all traffic through the subnet gateway instead of sharing an L2 broadcast domain.
+
+## Behavior
+
+With CIDR `10.0.0.0/16` and gateway `10.0.0.1`, each pod is configured like:
+
+```text
+ip addr add 10.0.0.5/32 dev eth0
+ip route add 10.0.0.1/32 dev eth0
+ip route add default via 10.0.0.1
+```
+
+Same-subnet east-west traffic is hairpinned through the OVN logical router. OVN ACLs allow ARP/ND only for the gateway and IP frames only to/from the logical router port MAC.
+
+## Requirements
+
+- OVN provider subnet
+- Overlay, or underlay with `logicalGateway` / `u2oInterconnection` (a logical router port is required)
+- Not compatible with `enableDHCP`, `enableIPv6RA`, `enableMulticastSnoop`, or mac-only / BYO-DHCP subnets
+
+## Notes
+
+- IPAM still allocates from `spec.cidrBlock`; only the pod interface mask and routes change.
+- Enabling or disabling `routed` does not reconfigure existing pods; recreate pods to apply the new addressing.
+- Distinct from the pod annotation `ovn.kubernetes.io/routed`, which means OVN routes are ready for the pod.

--- a/docs/routed-subnet.md
+++ b/docs/routed-subnet.md
@@ -12,13 +12,26 @@ ip route add 10.0.0.1/32 dev eth0
 ip route add default via 10.0.0.1
 ```
 
-Same-subnet east-west traffic is hairpinned through the OVN logical router. OVN ACLs allow ARP/ND only for the gateway and IP frames only to/from the logical router port MAC.
+Same-subnet east-west traffic is hairpinned through the OVN logical router. OVN ACLs use an allow-list / default-deny policy:
+
+- Allow ARP/ND only for the gateway
+- Allow IP frames only to/from the logical router port MAC
+- Drop all other IP/ARP/ND (both directions)
+
+When `private: true`, ingress via the router is further limited to hairpin (own CIDR), node join CIDR, and `allowSubnets`.
+
+## Pod route annotations
+
+Provider route annotations (e.g. `ovn.kubernetes.io/routes`) are supported on non-DPDK interfaces when every annotated route uses the **subnet gateway** as next hop (or the U2O interconnection IP when that applies). CNI ADD fails if a route cannot be parsed or installed.
+
+Other next hops are rejected: with `/32`/`/128` addressing and gateway-only ACLs, the pod can only ARP the subnet gateway.
 
 ## Requirements
 
 - OVN provider subnet
 - Overlay, or underlay with `logicalGateway` / `u2oInterconnection` (a logical router port is required)
-- Not compatible with `enableDHCP`, `enableIPv6RA`, `enableMulticastSnoop`, or mac-only / BYO-DHCP subnets
+- Not compatible with `enableDHCP`, `enableIPv6RA`, `enableMulticastSnoop`, mac-only / BYO-DHCP, custom `spec.acls`, or DPDK/vhost-user NICs
+- DPDK/vhost-user also rejects pods that carry route annotations (they cannot be applied on that path)
 
 ## Notes
 

--- a/docs/routed-subnet.md
+++ b/docs/routed-subnet.md
@@ -15,7 +15,7 @@ ip route add default via 10.0.0.1
 Same-subnet east-west traffic is hairpinned through the OVN logical router. OVN ACLs use an allow-list / default-deny policy:
 
 - Allow ARP/ND only for the gateway
-- Allow IP frames only to/from the logical router port MAC
+- Allow IP frames whose Ethernet source or destination is the logical router port MAC (both ACL directions), so pod→router and router→pod hairpin traffic is permitted while direct L2 pod→pod is denied
 - Drop all other IP/ARP/ND (both directions)
 
 When `private: true`, ingress via the router is further limited to hairpin (own CIDR), node join CIDR, and `allowSubnets`.

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -2312,6 +2312,20 @@ func (mr *MockACLMockRecorder) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSw
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPrivate", reflect.TypeOf((*MockACL)(nil).SetLogicalSwitchPrivate), lsName, cidrBlock, nodeSwitchCIDR, allowSubnets)
 }
 
+// SetLogicalSwitchRouted mocks base method.
+func (m *MockACL) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLogicalSwitchRouted", lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLogicalSwitchRouted indicates an expected call of SetLogicalSwitchRouted.
+func (mr *MockACLMockRecorder) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchRouted", reflect.TypeOf((*MockACL)(nil).SetLogicalSwitchRouted), lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+}
+
 // SetNetPolACLLog mocks base method.
 func (m *MockACL) SetNetPolACLLog(pgName string, logEnable, isIngress bool) error {
 	m.ctrl.T.Helper()
@@ -5759,6 +5773,20 @@ func (m *MockNbClient) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR
 func (mr *MockNbClientMockRecorder) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR, allowSubnets any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchPrivate", reflect.TypeOf((*MockNbClient)(nil).SetLogicalSwitchPrivate), lsName, cidrBlock, nodeSwitchCIDR, allowSubnets)
+}
+
+// SetLogicalSwitchRouted mocks base method.
+func (m *MockNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLogicalSwitchRouted", lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLogicalSwitchRouted indicates an expected call of SetLogicalSwitchRouted.
+func (mr *MockNbClientMockRecorder) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchRouted", reflect.TypeOf((*MockNbClient)(nil).SetLogicalSwitchRouted), lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
 }
 
 // SetLsCtSkipDstLportIPs mocks base method.

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -2313,17 +2313,17 @@ func (mr *MockACLMockRecorder) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSw
 }
 
 // SetLogicalSwitchRouted mocks base method.
-func (m *MockACL) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
+func (m *MockACL) SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetLogicalSwitchRouted", lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+	ret := m.ctrl.Call(m, "SetLogicalSwitchRouted", lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetLogicalSwitchRouted indicates an expected call of SetLogicalSwitchRouted.
-func (mr *MockACLMockRecorder) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private any) *gomock.Call {
+func (mr *MockACLMockRecorder) SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchRouted", reflect.TypeOf((*MockACL)(nil).SetLogicalSwitchRouted), lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchRouted", reflect.TypeOf((*MockACL)(nil).SetLogicalSwitchRouted), lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
 }
 
 // SetNetPolACLLog mocks base method.
@@ -5776,17 +5776,17 @@ func (mr *MockNbClientMockRecorder) SetLogicalSwitchPrivate(lsName, cidrBlock, n
 }
 
 // SetLogicalSwitchRouted mocks base method.
-func (m *MockNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
+func (m *MockNbClient) SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetLogicalSwitchRouted", lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+	ret := m.ctrl.Call(m, "SetLogicalSwitchRouted", lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetLogicalSwitchRouted indicates an expected call of SetLogicalSwitchRouted.
-func (mr *MockNbClientMockRecorder) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private any) *gomock.Call {
+func (mr *MockNbClientMockRecorder) SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchRouted", reflect.TypeOf((*MockNbClient)(nil).SetLogicalSwitchRouted), lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogicalSwitchRouted", reflect.TypeOf((*MockNbClient)(nil).SetLogicalSwitchRouted), lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
 }
 
 // SetLsCtSkipDstLportIPs mocks base method.

--- a/pkg/apis/kubeovn/v1/subnet.go
+++ b/pkg/apis/kubeovn/v1/subnet.go
@@ -101,6 +101,12 @@ type SubnetSpec struct {
 
 	// Whether the subnet is private.
 	Private bool `json:"private"`
+	// Routed configures pods with /32 (IPv4) or /128 (IPv6) addresses and
+	// on-link routes to the gateway. Same-subnet traffic is forced through the
+	// OVN logical router instead of direct L2. Requires an OVN logical router
+	// port (overlay, or underlay with logicalGateway / u2oInterconnection).
+	// Existing pods must be recreated after enabling or disabling this field.
+	Routed bool `json:"routed,omitempty"`
 	// Allowed subnets for east-west traffic.
 	AllowSubnets []string `json:"allowSubnets,omitempty"`
 

--- a/pkg/client/applyconfiguration/kubeovn/v1/subnetspec.go
+++ b/pkg/client/applyconfiguration/kubeovn/v1/subnetspec.go
@@ -59,6 +59,8 @@ type SubnetSpecApplyConfiguration struct {
 	Mtu *uint32 `json:"mtu,omitempty"`
 	// Whether the subnet is private.
 	Private *bool `json:"private,omitempty"`
+	// Routed configures pods with /32 (or /128) addresses and on-link gateway routes.
+	Routed *bool `json:"routed,omitempty"`
 	// Allowed subnets for east-west traffic.
 	AllowSubnets []string `json:"allowSubnets,omitempty"`
 	// VLAN ID or provider network name.
@@ -257,6 +259,14 @@ func (b *SubnetSpecApplyConfiguration) WithMtu(value uint32) *SubnetSpecApplyCon
 // If called multiple times, the Private field is set to the value of the last call.
 func (b *SubnetSpecApplyConfiguration) WithPrivate(value bool) *SubnetSpecApplyConfiguration {
 	b.Private = &value
+	return b
+}
+
+// WithRouted sets the Routed field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Routed field is set to the value of the last call.
+func (b *SubnetSpecApplyConfiguration) WithRouted(value bool) *SubnetSpecApplyConfiguration {
+	b.Routed = &value
 	return b
 }
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -705,6 +705,11 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		}
 		patch[fmt.Sprintf(util.CidrAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.CIDRBlock
 		patch[fmt.Sprintf(util.GatewayAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.Gateway
+		if subnet.Spec.Routed {
+			patch[fmt.Sprintf(util.RoutedSubnetAnnotationTemplate, podNet.ProviderName)] = "true"
+		} else {
+			patch[fmt.Sprintf(util.RoutedSubnetAnnotationTemplate, podNet.ProviderName)] = nil
+		}
 		if isOvnSubnet(podNet.Subnet) {
 			patch[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podNet.ProviderName)] = subnet.Name
 			if pod.Annotations[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] == "" {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -796,7 +796,7 @@ func (c *Controller) reconcileSubnetBaseACLs(subnet *kubeovnv1.Subnet, router st
 			}
 			return lrpErr
 		}
-		if routedErr := c.OVNNbClient.SetLogicalSwitchRouted(subnet.Name, subnet.Spec.CIDRBlock, gateway, lrp.MAC, c.config.NodeSwitchCIDR, subnet.Spec.AllowSubnets, subnet.Spec.Private); routedErr != nil {
+		if routedErr := c.OVNNbClient.SetLogicalSwitchRouted(subnet.Name, router, subnet.Spec.CIDRBlock, gateway, lrp.MAC, c.config.NodeSwitchCIDR, subnet.Spec.AllowSubnets, subnet.Spec.Private); routedErr != nil {
 			klog.Error(routedErr)
 			if patchErr := c.patchSubnetStatus(subnet, "SetRoutedLogicalSwitchFailed", routedErr.Error()); patchErr != nil {
 				klog.Error(patchErr)

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -741,38 +741,12 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		return err
 	}
 
-	if subnet.Spec.Private {
-		if privErr := c.OVNNbClient.SetLogicalSwitchPrivate(subnet.Name, subnet.Spec.CIDRBlock, c.config.NodeSwitchCIDR, subnet.Spec.AllowSubnets); privErr != nil {
-			klog.Error(privErr)
-			if patchErr := c.patchSubnetStatus(subnet, "SetPrivateLogicalSwitchFailed", privErr.Error()); patchErr != nil {
-				klog.Error(patchErr)
-				return errors.Join(privErr, patchErr)
-			}
-			return privErr
-		}
-
-		if err = c.patchSubnetStatus(subnet, "SetPrivateLogicalSwitchSuccess", ""); err != nil {
-			klog.Error(err)
-			return err
-		}
-	} else {
-		// clear acl when direction is ""
-		if aclErr := c.OVNNbClient.DeleteAcls(subnet.Name, logicalSwitchKey, "", nil); aclErr != nil {
-			klog.Error(aclErr)
-			if patchErr := c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclFailed", aclErr.Error()); patchErr != nil {
-				klog.Error(patchErr)
-				return errors.Join(aclErr, patchErr)
-			}
-			return aclErr
-		}
-
-		if err = c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", ""); err != nil {
-			klog.Error(err)
-			return err
-		}
+	if err = c.reconcileSubnetBaseACLs(subnet, vpc.Status.Router); err != nil {
+		return err
 	}
 
-	if aclErr := c.OVNNbClient.UpdateLogicalSwitchACL(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Acls, subnet.Spec.AllowEWTraffic); aclErr != nil {
+	allowEWTraffic := subnet.Spec.AllowEWTraffic && !subnet.Spec.Routed
+	if aclErr := c.OVNNbClient.UpdateLogicalSwitchACL(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Acls, allowEWTraffic); aclErr != nil {
 		klog.Error(aclErr)
 		if patchErr := c.patchSubnetStatus(subnet, "SetLogicalSwitchAclsFailed", aclErr.Error()); patchErr != nil {
 			klog.Error(patchErr)
@@ -796,6 +770,56 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	}
 
 	return nil
+}
+
+// reconcileSubnetBaseACLs applies routed, private, or cleared base ACLs on the subnet LS.
+func (c *Controller) reconcileSubnetBaseACLs(subnet *kubeovnv1.Subnet, router string) error {
+	switch {
+	case subnet.Spec.Routed:
+		gateway := subnet.Spec.Gateway
+		if subnet.Status.U2OInterconnectionIP != "" && subnet.Spec.U2OInterconnection {
+			gateway = subnet.Status.U2OInterconnectionIP
+		}
+		routerPortName := ovs.LogicalRouterPortName(router, subnet.Name)
+		lrp, lrpErr := c.OVNNbClient.GetLogicalRouterPort(routerPortName, false)
+		if lrpErr != nil {
+			klog.Error(lrpErr)
+			if patchErr := c.patchSubnetStatus(subnet, "SetRoutedLogicalSwitchFailed", lrpErr.Error()); patchErr != nil {
+				klog.Error(patchErr)
+				return errors.Join(lrpErr, patchErr)
+			}
+			return lrpErr
+		}
+		if routedErr := c.OVNNbClient.SetLogicalSwitchRouted(subnet.Name, subnet.Spec.CIDRBlock, gateway, lrp.MAC, c.config.NodeSwitchCIDR, subnet.Spec.AllowSubnets, subnet.Spec.Private); routedErr != nil {
+			klog.Error(routedErr)
+			if patchErr := c.patchSubnetStatus(subnet, "SetRoutedLogicalSwitchFailed", routedErr.Error()); patchErr != nil {
+				klog.Error(patchErr)
+				return errors.Join(routedErr, patchErr)
+			}
+			return routedErr
+		}
+		return c.patchSubnetStatus(subnet, "SetRoutedLogicalSwitchSuccess", "")
+	case subnet.Spec.Private:
+		if privErr := c.OVNNbClient.SetLogicalSwitchPrivate(subnet.Name, subnet.Spec.CIDRBlock, c.config.NodeSwitchCIDR, subnet.Spec.AllowSubnets); privErr != nil {
+			klog.Error(privErr)
+			if patchErr := c.patchSubnetStatus(subnet, "SetPrivateLogicalSwitchFailed", privErr.Error()); patchErr != nil {
+				klog.Error(patchErr)
+				return errors.Join(privErr, patchErr)
+			}
+			return privErr
+		}
+		return c.patchSubnetStatus(subnet, "SetPrivateLogicalSwitchSuccess", "")
+	default:
+		if aclErr := c.OVNNbClient.DeleteAcls(subnet.Name, logicalSwitchKey, "", nil); aclErr != nil {
+			klog.Error(aclErr)
+			if patchErr := c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclFailed", aclErr.Error()); patchErr != nil {
+				klog.Error(patchErr)
+				return errors.Join(aclErr, patchErr)
+			}
+			return aclErr
+		}
+		return c.patchSubnetStatus(subnet, "ResetLogicalSwitchAclSuccess", "")
+	}
 }
 
 func (c *Controller) handleDeleteLogicalSwitch(key string) (err error) {

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -746,7 +746,13 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	}
 
 	allowEWTraffic := subnet.Spec.AllowEWTraffic && !subnet.Spec.Routed
-	if aclErr := c.OVNNbClient.UpdateLogicalSwitchACL(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.Acls, allowEWTraffic); aclErr != nil {
+	subnetAcls := subnet.Spec.Acls
+	if subnet.Spec.Routed {
+		// Routed mode installs an allow-list / default-deny policy that must
+		// not be overridden by Spec.Acls (also rejected in ValidateSubnet).
+		subnetAcls = nil
+	}
+	if aclErr := c.OVNNbClient.UpdateLogicalSwitchACL(subnet.Name, subnet.Spec.CIDRBlock, subnetAcls, allowEWTraffic); aclErr != nil {
 		klog.Error(aclErr)
 		if patchErr := c.patchSubnetStatus(subnet, "SetLogicalSwitchAclsFailed", aclErr.Error()); patchErr != nil {
 			klog.Error(patchErr)

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -199,7 +199,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	var gatewayCheckMode int
 	var macAddr, ip, ipAddr, cidr, gw, subnet, ingress, egress, ingressBurst, egressBurst, providerNetwork, ifName, nicType, podNicName, vmName, latency, limit, loss, jitter, u2oInterconnectionIP, oldPodName string
 	var routes []request.Route
-	var isDefaultRoute, noIPAM, macOnly bool
+	var isDefaultRoute, noIPAM, macOnly, routedSubnet bool
 	var pod *v1.Pod
 	var err error
 
@@ -259,7 +259,8 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		jitter = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.NetemQosJitterAnnotationTemplate, appendIfName)
 		providerNetwork = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.ProviderNetworkTemplate, appendIfName)
 		vmName = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.VMAnnotationTemplate, appendIfName)
-		ipAddr, noIPAM, err = util.GetIPAddrWithMaskForCNI(ip, cidr)
+		routedSubnet = util.GetAnnotationWithIfNameOverride(pod.Annotations, podRequest.Provider, podRequest.IfName, util.RoutedSubnetAnnotationTemplate, appendIfName) == "true"
+		ipAddr, noIPAM, err = util.GetIPAddrWithMaskForCNIHostMask(ip, cidr, routedSubnet)
 		if err != nil {
 			errMsg := fmt.Errorf("failed to get ip address with mask, %w", err)
 			klog.Error(errMsg)
@@ -488,7 +489,7 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			err = csh.configureDpdkNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, ingressBurst, egressBurst, getShortSharedDir(pod.UID, podRequest.VhostUserSocketVolumeName), podRequest.VhostUserSocketName, podRequest.VhostUserSocketConsumption)
 			routes = nil
 		default:
-			routes, err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, vmMigration, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, ingressBurst, egressBurst, podRequest.DeviceID, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet, appendIfName)
+			routes, err = csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, podRequest.VfDriver, ifName, macAddr, mtu, ipAddr, gw, isDefaultRoute, vmMigration, routes, podRequest.DNS.Nameservers, podRequest.DNS.Search, ingress, egress, ingressBurst, egressBurst, podRequest.DeviceID, latency, limit, loss, jitter, gatewayCheckMode, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet, appendIfName, routedSubnet)
 		}
 		if err != nil {
 			errMsg := fmt.Errorf("configure nic %s for pod %s/%s failed: %w", ifName, podRequest.PodName, podRequest.PodNamespace, err)
@@ -545,6 +546,16 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 
 	v4IP, v6IP := util.SplitStringIP(ip)
 	v4CIDR, v6CIDR := util.SplitStringIP(cidr)
+	if routedSubnet && ipAddr != "" {
+		// Report host masks (/32|/128) so the CNI result matches the container interface.
+		v4Addr, v6Addr := util.SplitStringIP(ipAddr)
+		if v4Addr != "" {
+			v4CIDR = v4Addr
+		}
+		if v6Addr != "" {
+			v6CIDR = v6Addr
+		}
+	}
 	v4GW, v6GW := util.SplitStringIP(gw)
 
 	var ips []request.IPConfig

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -486,6 +486,24 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 
 		switch nicType {
 		case util.DpdkType:
+			if routedSubnet {
+				errMsg := fmt.Errorf("routed subnet mode is not supported with DPDK/vhost-user NICs for pod %s/%s", podRequest.PodNamespace, podRequest.PodName)
+				klog.Error(errMsg)
+				recordFailure("configure-nic", errMsg)
+				if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
+					klog.Errorf("failed to write response, %v", err)
+				}
+				return
+			}
+			if len(routes) > 0 {
+				errMsg := fmt.Errorf("route annotations are not supported with DPDK/vhost-user NICs for pod %s/%s", podRequest.PodNamespace, podRequest.PodName)
+				klog.Error(errMsg)
+				recordFailure("configure-nic", errMsg)
+				if err := resp.WriteHeaderAndEntity(http.StatusBadRequest, request.CniResponse{Err: errMsg.Error()}); err != nil {
+					klog.Errorf("failed to write response, %v", err)
+				}
+				return
+			}
 			err = csh.configureDpdkNic(podRequest.PodName, podRequest.PodNamespace, podRequest.Provider, podRequest.NetNs, podRequest.ContainerID, ifName, macAddr, mtu, ipAddr, gw, ingress, egress, ingressBurst, egressBurst, getShortSharedDir(pod.UID, podRequest.VhostUserSocketVolumeName), podRequest.VhostUserSocketName, podRequest.VhostUserSocketConsumption)
 			routes = nil
 		default:

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -525,21 +525,20 @@ func (csh cniServerHandler) configureContainerNic(podName, podNamespace, nicName
 		// Routed mode: host-route the gateway on-link before installing the default route
 		// (there is no connected subnet route when the address is /32 or /128).
 		if routedSubnet {
-			for _, gw := range util.SplitTrimmed(containerGw, ",") {
-				gwIP := net.ParseIP(gw)
-				if gwIP == nil {
-					return fmt.Errorf("invalid gateway %s for routed subnet", gw)
-				}
-				bits := 32
-				if gwIP.To4() == nil {
-					bits = 128
-				}
+			if err = util.ValidateRoutedAnnotationRoutes(routes, containerGw); err != nil {
+				return err
+			}
+			onLinkRoutes, routeErr := util.GatewayOnLinkRoutes(containerGw, containerLink.Attrs().Index)
+			if routeErr != nil {
+				return routeErr
+			}
+			for _, route := range onLinkRoutes {
 				if err = netlink.RouteReplace(&netlink.Route{
 					LinkIndex: containerLink.Attrs().Index,
 					Scope:     netlink.SCOPE_LINK,
-					Dst:       &net.IPNet{IP: gwIP, Mask: net.CIDRMask(bits, bits)},
+					Dst:       route.Dst,
 				}); err != nil {
-					return fmt.Errorf("failed to configure on-link route to gateway %s: %w", gw, err)
+					return fmt.Errorf("failed to configure on-link route to gateway %s: %w", route.Gateway, err)
 				}
 			}
 		}
@@ -561,16 +560,14 @@ func (csh cniServerHandler) configureContainerNic(podName, podNamespace, nicName
 			var dst *net.IPNet
 			if r.Destination != "" {
 				if _, dst, err = net.ParseCIDR(r.Destination); err != nil {
-					klog.Errorf("invalid route destination %s: %v", r.Destination, err)
-					continue
+					return fmt.Errorf("invalid route destination %s: %w", r.Destination, err)
 				}
 			}
 
 			var gw net.IP
 			if r.Gateway != "" {
 				if gw = net.ParseIP(r.Gateway); gw == nil {
-					klog.Errorf("invalid route gateway %s", r.Gateway)
-					continue
+					return fmt.Errorf("invalid route gateway %s", r.Gateway)
 				}
 			}
 
@@ -580,7 +577,7 @@ func (csh cniServerHandler) configureContainerNic(podName, podNamespace, nicName
 				LinkIndex: containerLink.Attrs().Index,
 			}
 			if err = netlink.RouteReplace(route); err != nil {
-				klog.Errorf("failed to add route %+v: %v", r, err)
+				return fmt.Errorf("failed to add route %+v: %w", r, err)
 			}
 		}
 

--- a/pkg/daemon/ovs_linux.go
+++ b/pkg/daemon/ovs_linux.go
@@ -71,7 +71,7 @@ func (csh cniServerHandler) configureDpdkNic(podName, podNamespace, provider, ne
 	return ovs.SetInterfaceBandwidth(podName, podNamespace, ifaceID, egress, ingress, egressBurst, ingressBurst)
 }
 
-func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, _, _ []string, ingress, egress, ingressBurst, egressBurst, deviceID, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet string, appendIfName bool) ([]request.Route, error) {
+func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns, containerID, vfDriver, ifName, mac string, mtu int, ip, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, _, _ []string, ingress, egress, ingressBurst, egressBurst, deviceID, latency, limit, loss, jitter string, gwCheckMode int, u2oInterconnectionIP, oldPodName, encapIP, localnetSubnet string, appendIfName, routedSubnet bool) ([]request.Route, error) {
 	var err error
 	var hostNicName, containerNicName, pfPci string
 	var vfID int
@@ -285,7 +285,7 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, provider, netns,
 		return nil, err
 	}
 	defer podNS.Close()
-	finalRoutes, err := csh.configureContainerNic(podName, podNamespace, containerNicName, ifName, ip, gateway, isDefaultRoute, vmMigration, routes, macAddr, podNS, mtu, gwCheckMode, u2oInterconnectionIP)
+	finalRoutes, err := csh.configureContainerNic(podName, podNamespace, containerNicName, ifName, ip, gateway, isDefaultRoute, vmMigration, routes, macAddr, podNS, mtu, gwCheckMode, u2oInterconnectionIP, routedSubnet)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -477,7 +477,7 @@ func configureHostNic(nicName string) error {
 	return nil
 }
 
-func (csh cniServerHandler) configureContainerNic(podName, podNamespace, nicName, ifName, ipAddr, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, macAddr net.HardwareAddr, netns ns.NetNS, mtu, gwCheckMode int, u2oInterconnectionIP string) ([]request.Route, error) {
+func (csh cniServerHandler) configureContainerNic(podName, podNamespace, nicName, ifName, ipAddr, gateway string, isDefaultRoute, vmMigration bool, routes []request.Route, macAddr net.HardwareAddr, netns ns.NetNS, mtu, gwCheckMode int, u2oInterconnectionIP string, routedSubnet bool) ([]request.Route, error) {
 	containerLink, err := netlink.LinkByName(nicName)
 	if err != nil {
 		return nil, fmt.Errorf("can not find container nic %s: %w", nicName, err)
@@ -517,13 +517,35 @@ func (csh cniServerHandler) configureContainerNic(podName, podNamespace, nicName
 			return nil
 		}
 
+		containerGw := gateway
+		if u2oInterconnectionIP != "" {
+			containerGw = u2oInterconnectionIP
+		}
+
+		// Routed mode: host-route the gateway on-link before installing the default route
+		// (there is no connected subnet route when the address is /32 or /128).
+		if routedSubnet {
+			for _, gw := range util.SplitTrimmed(containerGw, ",") {
+				gwIP := net.ParseIP(gw)
+				if gwIP == nil {
+					return fmt.Errorf("invalid gateway %s for routed subnet", gw)
+				}
+				bits := 32
+				if gwIP.To4() == nil {
+					bits = 128
+				}
+				if err = netlink.RouteReplace(&netlink.Route{
+					LinkIndex: containerLink.Attrs().Index,
+					Scope:     netlink.SCOPE_LINK,
+					Dst:       &net.IPNet{IP: gwIP, Mask: net.CIDRMask(bits, bits)},
+				}); err != nil {
+					return fmt.Errorf("failed to configure on-link route to gateway %s: %w", gw, err)
+				}
+			}
+		}
+
 		if isDefaultRoute {
 			// Only eth0 requires the default route and gateway
-			containerGw := gateway
-			if u2oInterconnectionIP != "" {
-				containerGw = u2oInterconnectionIP
-			}
-
 			for _, gw := range util.SplitTrimmed(containerGw, ",") {
 				if err = netlink.RouteReplace(&netlink.Route{
 					LinkIndex: containerLink.Attrs().Index,

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -189,7 +189,7 @@ type ACL interface {
 	UpdateLogicalSwitchACL(lsName, cidrBlock string, subnetAcls []kubeovnv1.ACL, allowEWTraffic bool) error
 	SetNetPolACLLog(pgName string, logEnable, isIngress bool) error
 	SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR string, allowSubnets []string) error
-	SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error
+	SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error
 	SGLostACL(sg *kubeovnv1.SecurityGroup) (bool, error)
 	DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string) error
 	DeleteAclsOps(parentName, parentType, direction string, externalIDs map[string]string) ([]ovsdb.Operation, error)

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -189,6 +189,7 @@ type ACL interface {
 	UpdateLogicalSwitchACL(lsName, cidrBlock string, subnetAcls []kubeovnv1.ACL, allowEWTraffic bool) error
 	SetNetPolACLLog(pgName string, logEnable, isIngress bool) error
 	SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR string, allowSubnets []string) error
+	SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error
 	SGLostACL(sg *kubeovnv1.SecurityGroup) (bool, error)
 	DeleteAcls(parentName, parentType, direction string, externalIDs map[string]string) error
 	DeleteAclsOps(parentName, parentType, direction string, externalIDs map[string]string) ([]ovsdb.Operation, error)

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -883,20 +883,28 @@ func (c *OVNNbClient) buildRoutedGatewayDiscoveryACLs(lsName, gateway string, op
 func (c *OVNNbClient) buildRoutedIPAllowACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool, options func(*ovnnb.ACL)) ([]*ovnnb.ACL, error) {
 	acls := make([]*ovnnb.ACL, 0)
 
-	egressToGW := NewAndACLMatch(NewACLMatch("ip", "", "", ""), NewACLMatch("eth.dst", "==", gatewayMAC, ""))
-	egressACL, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, egressToGW.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
-	if err != nil {
-		return nil, fmt.Errorf("new routed egress-to-gateway acl for logical switch %s: %w", lsName, err)
+	// from-lport is evaluated on inport and to-lport on outport. Pod->router
+	// frames still have eth.src=<pod> and eth.dst=<LRP>, so both ACL directions
+	// must allow eth.dst==LRP (to the router) and eth.src==LRP (from the router).
+	// Direct L2 pod->pod has neither and hits default-deny.
+	for _, direction := range []string{ovnnb.ACLDirectionFromLport, ovnnb.ACLDirectionToLport} {
+		for _, ethField := range []string{"eth.src", "eth.dst"} {
+			// Private mode replaces the blanket to-lport eth.src allow with
+			// CIDR-constrained ingress rules below.
+			if private && direction == ovnnb.ACLDirectionToLport && ethField == "eth.src" {
+				continue
+			}
+			match := NewAndACLMatch(NewACLMatch("ip", "", "", ""), NewACLMatch(ethField, "==", gatewayMAC, ""))
+			acl, err := c.newACL(lsName, direction, util.RoutedAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+			if err != nil {
+				return nil, fmt.Errorf("new routed %s %s acl for logical switch %s: %w", direction, ethField, lsName, err)
+			}
+			acls = append(acls, acl)
+		}
 	}
-	acls = append(acls, egressACL)
 
 	if !private {
-		ingressFromGW := NewAndACLMatch(NewACLMatch("ip", "", "", ""), NewACLMatch("eth.src", "==", gatewayMAC, ""))
-		ingressACL, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, ingressFromGW.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
-		if err != nil {
-			return nil, fmt.Errorf("new routed ingress-from-gateway acl for logical switch %s: %w", lsName, err)
-		}
-		return append(acls, ingressACL), nil
+		return acls, nil
 	}
 
 	privateIngress, err := c.buildRoutedPrivateIngressACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR, allowSubnets, options)

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -790,6 +790,197 @@ func (c *OVNNbClient) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR 
 	return nil
 }
 
+// SetLogicalSwitchRouted installs ACLs so pods may only ARP/ND the gateway and
+// send IP frames to the logical router port MAC. Same-subnet traffic is hairpinned
+// through the OVN logical router. When private is true, also isolate from other
+// subnets (like SetLogicalSwitchPrivate) without allowing direct same-subnet L2.
+func (c *OVNNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
+	if lsName == "" {
+		return errors.New("logical switch name is required")
+	}
+	if gatewayMAC == "" {
+		return fmt.Errorf("gateway MAC is required for routed subnet %s", lsName)
+	}
+
+	if err := c.DeleteAcls(lsName, LogicalSwitchKey, "", nil); err != nil {
+		klog.Error(err)
+		return fmt.Errorf("clear logical switch %s acls: %w", lsName, err)
+	}
+
+	acls := make([]*ovnnb.ACL, 0)
+	options := func(acl *ovnnb.ACL) {
+		setACLName(acl, lsName)
+	}
+
+	gateways := util.SplitTrimmed(gateway, ",")
+	for _, gw := range gateways {
+		protocol := util.CheckProtocol(gw)
+		switch protocol {
+		case kubeovnv1.ProtocolIPv4:
+			arpAllow := NewAndACLMatch(
+				NewACLMatch("arp", "", "", ""),
+				NewACLMatch("arp.tpa", "==", gw, ""),
+			)
+			acl, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, arpAllow.String(), ovnnb.ACLActionAllow, util.NetpolACLTier, options)
+			if err != nil {
+				return fmt.Errorf("new routed ARP allow acl for logical switch %s: %w", lsName, err)
+			}
+			acls = append(acls, acl)
+
+			arpIngress := NewAndACLMatch(
+				NewACLMatch("arp", "", "", ""),
+				NewACLMatch("arp.spa", "==", gw, ""),
+			)
+			acl, err = c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, arpIngress.String(), ovnnb.ACLActionAllow, util.NetpolACLTier, options)
+			if err != nil {
+				return fmt.Errorf("new routed ARP ingress acl for logical switch %s: %w", lsName, err)
+			}
+			acls = append(acls, acl)
+		case kubeovnv1.ProtocolIPv6:
+			ndAllow := NewAndACLMatch(
+				NewACLMatch("nd_ns", "", "", ""),
+				NewACLMatch("nd.target", "==", gw, ""),
+			)
+			acl, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, ndAllow.String(), ovnnb.ACLActionAllow, util.NetpolACLTier, options)
+			if err != nil {
+				return fmt.Errorf("new routed ND allow acl for logical switch %s: %w", lsName, err)
+			}
+			acls = append(acls, acl)
+
+			ndIngress := NewAndACLMatch(
+				NewACLMatch("nd_na", "", "", ""),
+				NewACLMatch("ip6.src", "==", gw, ""),
+			)
+			acl, err = c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, ndIngress.String(), ovnnb.ACLActionAllow, util.NetpolACLTier, options)
+			if err != nil {
+				return fmt.Errorf("new routed ND ingress acl for logical switch %s: %w", lsName, err)
+			}
+			acls = append(acls, acl)
+		}
+	}
+
+	egressToGW := NewAndACLMatch(
+		NewACLMatch("ip", "", "", ""),
+		NewACLMatch("eth.dst", "==", gatewayMAC, ""),
+	)
+	egressACL, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, egressToGW.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+	if err != nil {
+		return fmt.Errorf("new routed egress-to-gateway acl for logical switch %s: %w", lsName, err)
+	}
+	acls = append(acls, egressACL)
+
+	ingressFromGW := NewAndACLMatch(
+		NewACLMatch("ip", "", "", ""),
+		NewACLMatch("eth.src", "==", gatewayMAC, ""),
+	)
+	ingressACL, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, ingressFromGW.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+	if err != nil {
+		return fmt.Errorf("new routed ingress-from-gateway acl for logical switch %s: %w", lsName, err)
+	}
+	acls = append(acls, ingressACL)
+
+	for cidr := range strings.SplitSeq(cidrBlock, ",") {
+		if cidr == "" {
+			continue
+		}
+		protocol := util.CheckProtocol(cidr)
+		ipSuffix := "ip4"
+		if protocol == kubeovnv1.ProtocolIPv6 {
+			ipSuffix = "ip6"
+		}
+
+		sameSubnetDrop := NewAndACLMatch(
+			NewACLMatch(ipSuffix+".src", "==", cidr, ""),
+			NewACLMatch(ipSuffix+".dst", "==", cidr, ""),
+		)
+		dropACL, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedDropPriority, sameSubnetDrop.String(), ovnnb.ACLActionDrop, util.NetpolACLTier, options)
+		if err != nil {
+			return fmt.Errorf("new routed same-subnet drop acl for logical switch %s: %w", lsName, err)
+		}
+		acls = append(acls, dropACL)
+
+		var peerDiscoveryDrop ACLMatch
+		if protocol == kubeovnv1.ProtocolIPv4 {
+			peerDiscoveryDrop = NewAndACLMatch(
+				NewACLMatch("arp", "", "", ""),
+				NewACLMatch("arp.tpa", "==", cidr, ""),
+			)
+		} else {
+			peerDiscoveryDrop = NewAndACLMatch(
+				NewACLMatch("nd_ns", "", "", ""),
+				NewACLMatch("nd.target", "==", cidr, ""),
+			)
+		}
+		dropACL, err = c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedDropPriority, peerDiscoveryDrop.String(), ovnnb.ACLActionDrop, util.NetpolACLTier, options)
+		if err != nil {
+			return fmt.Errorf("new routed peer discovery drop acl for logical switch %s: %w", lsName, err)
+		}
+		acls = append(acls, dropACL)
+
+		if private {
+			nodeSubnetACLFunc := func(protocol, ipSuffix string) error {
+				for nodeCidr := range strings.SplitSeq(nodeSwitchCIDR, ",") {
+					if protocol != util.CheckProtocol(nodeCidr) {
+						continue
+					}
+					match := NewACLMatch(ipSuffix+".src", "==", nodeCidr, "")
+					acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+					if err != nil {
+						return fmt.Errorf("new node subnet ingress acl for logical switch %s: %w", lsName, err)
+					}
+					acls = append(acls, acl)
+				}
+				return nil
+			}
+			if err := nodeSubnetACLFunc(protocol, ipSuffix); err != nil {
+				return err
+			}
+
+			for _, allowSubnet := range allowSubnets {
+				subnet := strings.TrimSpace(allowSubnet)
+				if subnet == "" || util.CheckProtocol(subnet) != protocol {
+					continue
+				}
+				match := NewOrACLMatch(
+					NewAndACLMatch(
+						NewACLMatch(ipSuffix+".src", "==", cidr, ""),
+						NewACLMatch(ipSuffix+".dst", "==", subnet, ""),
+					),
+					NewAndACLMatch(
+						NewACLMatch(ipSuffix+".src", "==", subnet, ""),
+						NewACLMatch(ipSuffix+".dst", "==", cidr, ""),
+					),
+				)
+				acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.SubnetAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+				if err != nil {
+					return fmt.Errorf("new allow subnet ingress acl for logical switch %s: %w", lsName, err)
+				}
+				acls = append(acls, acl)
+			}
+		}
+	}
+
+	if private {
+		allIPMatch := NewACLMatch("ip", "", "", "")
+		dropOptions := func(acl *ovnnb.ACL) {
+			setACLName(acl, lsName)
+			acl.Log = true
+			acl.Severity = ptr.To(ovnnb.ACLSeverityWarning)
+		}
+		defaultDropACL, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.DefaultDropPriority, allIPMatch.String(), ovnnb.ACLActionDrop, util.NetpolACLTier, dropOptions)
+		if err != nil {
+			return fmt.Errorf("new default drop ingress acl for logical switch %s: %w", lsName, err)
+		}
+		acls = append(acls, defaultDropACL)
+	}
+
+	if err := c.CreateAcls(lsName, LogicalSwitchKey, acls...); err != nil {
+		klog.Error(err)
+		return fmt.Errorf("add routed acls to logical switch %s: %w", lsName, err)
+	}
+	return nil
+}
+
 func (c *OVNNbClient) SetNetPolACLLog(pgName string, logEnable, isIngress bool) error {
 	direction := ovnnb.ACLDirectionToLport
 	portDirection := "outport"

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -795,9 +795,17 @@ func (c *OVNNbClient) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR 
 // router port MAC. Same-subnet traffic is hairpinned through the OVN logical
 // router. When private is true, ingress via the router is further limited to
 // the subnet CIDR (hairpin), node join CIDR, and allowSubnets.
-func (c *OVNNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
+//
+// router is the logical router name used to derive the router LSP on the
+// switch; from-lport allows that use eth.src == LRP MAC are constrained to
+// that inport so pods cannot spoof the router MAC (port security is off by
+// default).
+func (c *OVNNbClient) SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
 	if lsName == "" {
 		return errors.New("logical switch name is required")
+	}
+	if router == "" {
+		return fmt.Errorf("router is required for routed subnet %s", lsName)
 	}
 	if gatewayMAC == "" {
 		return fmt.Errorf("gateway MAC is required for routed subnet %s", lsName)
@@ -808,7 +816,7 @@ func (c *OVNNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gateway
 		return fmt.Errorf("clear logical switch %s acls: %w", lsName, err)
 	}
 
-	acls, err := c.buildRoutedLogicalSwitchACLs(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+	acls, err := c.buildRoutedLogicalSwitchACLs(lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
 	if err != nil {
 		return err
 	}
@@ -819,7 +827,7 @@ func (c *OVNNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gateway
 	return nil
 }
 
-func (c *OVNNbClient) buildRoutedLogicalSwitchACLs(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) ([]*ovnnb.ACL, error) {
+func (c *OVNNbClient) buildRoutedLogicalSwitchACLs(lsName, router, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) ([]*ovnnb.ACL, error) {
 	options := func(acl *ovnnb.ACL) { setACLName(acl, lsName) }
 	acls := make([]*ovnnb.ACL, 0)
 
@@ -829,7 +837,7 @@ func (c *OVNNbClient) buildRoutedLogicalSwitchACLs(lsName, cidrBlock, gateway, g
 	}
 	acls = append(acls, discoveryACLs...)
 
-	ipACLs, err := c.buildRoutedIPAllowACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR, allowSubnets, private, options)
+	ipACLs, err := c.buildRoutedIPAllowACLs(lsName, router, cidrBlock, gatewayMAC, nodeSwitchCIDR, allowSubnets, private, options)
 	if err != nil {
 		return nil, err
 	}
@@ -880,31 +888,44 @@ func (c *OVNNbClient) buildRoutedGatewayDiscoveryACLs(lsName, gateway string, op
 	return acls, nil
 }
 
-func (c *OVNNbClient) buildRoutedIPAllowACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool, options func(*ovnnb.ACL)) ([]*ovnnb.ACL, error) {
+func (c *OVNNbClient) buildRoutedIPAllowACLs(lsName, router, cidrBlock, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool, options func(*ovnnb.ACL)) ([]*ovnnb.ACL, error) {
 	acls := make([]*ovnnb.ACL, 0)
+	routerLSP := LogicalSwitchPortName(router, lsName)
 
-	// from-lport is evaluated on inport and to-lport on outport. Pod->router
-	// frames still have eth.src=<pod> and eth.dst=<LRP>, so both ACL directions
-	// must allow eth.dst==LRP (to the router) and eth.src==LRP (from the router).
-	// Direct L2 pod->pod has neither and hits default-deny.
+	// Pod -> router: eth.dst == LRP on both ACL directions. from-lport is
+	// evaluated on the pod inport; to-lport is evaluated when delivering to
+	// the router LSP. Direct L2 pod->pod has eth.dst != LRP and is denied.
+	toRouter := NewAndACLMatch(NewACLMatch("ip", "", "", ""), NewACLMatch("eth.dst", "==", gatewayMAC, ""))
 	for _, direction := range []string{ovnnb.ACLDirectionFromLport, ovnnb.ACLDirectionToLport} {
-		for _, ethField := range []string{"eth.src", "eth.dst"} {
-			// Private mode replaces the blanket to-lport eth.src allow with
-			// CIDR-constrained ingress rules below.
-			if private && direction == ovnnb.ACLDirectionToLport && ethField == "eth.src" {
-				continue
-			}
-			match := NewAndACLMatch(NewACLMatch("ip", "", "", ""), NewACLMatch(ethField, "==", gatewayMAC, ""))
-			acl, err := c.newACL(lsName, direction, util.RoutedAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
-			if err != nil {
-				return nil, fmt.Errorf("new routed %s %s acl for logical switch %s: %w", direction, ethField, lsName, err)
-			}
-			acls = append(acls, acl)
+		acl, err := c.newACL(lsName, direction, util.RoutedAllowPriority, toRouter.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+		if err != nil {
+			return nil, fmt.Errorf("new routed to-router %s acl for logical switch %s: %w", direction, lsName, err)
 		}
+		acls = append(acls, acl)
 	}
 
+	// Router -> switch: allow eth.src == LRP only when the packet actually
+	// enters from the router LSP. A bare from-lport eth.src==LRP allow would
+	// let pods spoof the router MAC (port security is disabled by default).
+	fromRouter := NewAndACLMatch(
+		NewACLMatch("ip", "", "", ""),
+		NewACLMatch("inport", "==", fmt.Sprintf(`"%s"`, routerLSP), ""),
+		NewACLMatch("eth.src", "==", gatewayMAC, ""),
+	)
+	fromRouterACL, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, fromRouter.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+	if err != nil {
+		return nil, fmt.Errorf("new routed from-router acl for logical switch %s: %w", lsName, err)
+	}
+	acls = append(acls, fromRouterACL)
+
 	if !private {
-		return acls, nil
+		// Router -> pods: delivery to pod ports has eth.src == LRP.
+		fromGW := NewAndACLMatch(NewACLMatch("ip", "", "", ""), NewACLMatch("eth.src", "==", gatewayMAC, ""))
+		ingressACL, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, fromGW.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+		if err != nil {
+			return nil, fmt.Errorf("new routed ingress-from-gateway acl for logical switch %s: %w", lsName, err)
+		}
+		return append(acls, ingressACL), nil
 	}
 
 	privateIngress, err := c.buildRoutedPrivateIngressACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR, allowSubnets, options)

--- a/pkg/ovs/ovn-nb-acl.go
+++ b/pkg/ovs/ovn-nb-acl.go
@@ -790,10 +790,11 @@ func (c *OVNNbClient) SetLogicalSwitchPrivate(lsName, cidrBlock, nodeSwitchCIDR 
 	return nil
 }
 
-// SetLogicalSwitchRouted installs ACLs so pods may only ARP/ND the gateway and
-// send IP frames to the logical router port MAC. Same-subnet traffic is hairpinned
-// through the OVN logical router. When private is true, also isolate from other
-// subnets (like SetLogicalSwitchPrivate) without allowing direct same-subnet L2.
+// SetLogicalSwitchRouted installs an allow-list / default-deny ACL policy so
+// pods may only ARP/ND the gateway and send/receive IP frames via the logical
+// router port MAC. Same-subnet traffic is hairpinned through the OVN logical
+// router. When private is true, ingress via the router is further limited to
+// the subnet CIDR (hairpin), node join CIDR, and allowSubnets.
 func (c *OVNNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) error {
 	if lsName == "" {
 		return errors.New("logical switch name is required")
@@ -807,78 +808,106 @@ func (c *OVNNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gateway
 		return fmt.Errorf("clear logical switch %s acls: %w", lsName, err)
 	}
 
-	acls := make([]*ovnnb.ACL, 0)
-	options := func(acl *ovnnb.ACL) {
-		setACLName(acl, lsName)
+	acls, err := c.buildRoutedLogicalSwitchACLs(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR, allowSubnets, private)
+	if err != nil {
+		return err
 	}
+	if err := c.CreateAcls(lsName, LogicalSwitchKey, acls...); err != nil {
+		klog.Error(err)
+		return fmt.Errorf("add routed acls to logical switch %s: %w", lsName, err)
+	}
+	return nil
+}
 
-	gateways := util.SplitTrimmed(gateway, ",")
-	for _, gw := range gateways {
-		protocol := util.CheckProtocol(gw)
-		switch protocol {
+func (c *OVNNbClient) buildRoutedLogicalSwitchACLs(lsName, cidrBlock, gateway, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool) ([]*ovnnb.ACL, error) {
+	options := func(acl *ovnnb.ACL) { setACLName(acl, lsName) }
+	acls := make([]*ovnnb.ACL, 0)
+
+	discoveryACLs, err := c.buildRoutedGatewayDiscoveryACLs(lsName, gateway, options)
+	if err != nil {
+		return nil, err
+	}
+	acls = append(acls, discoveryACLs...)
+
+	ipACLs, err := c.buildRoutedIPAllowACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR, allowSubnets, private, options)
+	if err != nil {
+		return nil, err
+	}
+	acls = append(acls, ipACLs...)
+
+	denyACLs, err := c.buildRoutedDefaultDenyACLs(lsName, options)
+	if err != nil {
+		return nil, err
+	}
+	acls = append(acls, denyACLs...)
+	return acls, nil
+}
+
+func (c *OVNNbClient) buildRoutedGatewayDiscoveryACLs(lsName, gateway string, options func(*ovnnb.ACL)) ([]*ovnnb.ACL, error) {
+	acls := make([]*ovnnb.ACL, 0)
+	for _, gw := range util.SplitTrimmed(gateway, ",") {
+		switch util.CheckProtocol(gw) {
 		case kubeovnv1.ProtocolIPv4:
-			arpAllow := NewAndACLMatch(
-				NewACLMatch("arp", "", "", ""),
-				NewACLMatch("arp.tpa", "==", gw, ""),
-			)
+			arpAllow := NewAndACLMatch(NewACLMatch("arp", "", "", ""), NewACLMatch("arp.tpa", "==", gw, ""))
 			acl, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, arpAllow.String(), ovnnb.ACLActionAllow, util.NetpolACLTier, options)
 			if err != nil {
-				return fmt.Errorf("new routed ARP allow acl for logical switch %s: %w", lsName, err)
+				return nil, fmt.Errorf("new routed ARP allow acl for logical switch %s: %w", lsName, err)
 			}
 			acls = append(acls, acl)
 
-			arpIngress := NewAndACLMatch(
-				NewACLMatch("arp", "", "", ""),
-				NewACLMatch("arp.spa", "==", gw, ""),
-			)
+			arpIngress := NewAndACLMatch(NewACLMatch("arp", "", "", ""), NewACLMatch("arp.spa", "==", gw, ""))
 			acl, err = c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, arpIngress.String(), ovnnb.ACLActionAllow, util.NetpolACLTier, options)
 			if err != nil {
-				return fmt.Errorf("new routed ARP ingress acl for logical switch %s: %w", lsName, err)
+				return nil, fmt.Errorf("new routed ARP ingress acl for logical switch %s: %w", lsName, err)
 			}
 			acls = append(acls, acl)
 		case kubeovnv1.ProtocolIPv6:
-			ndAllow := NewAndACLMatch(
-				NewACLMatch("nd_ns", "", "", ""),
-				NewACLMatch("nd.target", "==", gw, ""),
-			)
+			ndAllow := NewAndACLMatch(NewACLMatch("nd_ns", "", "", ""), NewACLMatch("nd.target", "==", gw, ""))
 			acl, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, ndAllow.String(), ovnnb.ACLActionAllow, util.NetpolACLTier, options)
 			if err != nil {
-				return fmt.Errorf("new routed ND allow acl for logical switch %s: %w", lsName, err)
+				return nil, fmt.Errorf("new routed ND allow acl for logical switch %s: %w", lsName, err)
 			}
 			acls = append(acls, acl)
 
-			ndIngress := NewAndACLMatch(
-				NewACLMatch("nd_na", "", "", ""),
-				NewACLMatch("ip6.src", "==", gw, ""),
-			)
+			ndIngress := NewAndACLMatch(NewACLMatch("nd_na", "", "", ""), NewACLMatch("ip6.src", "==", gw, ""))
 			acl, err = c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, ndIngress.String(), ovnnb.ACLActionAllow, util.NetpolACLTier, options)
 			if err != nil {
-				return fmt.Errorf("new routed ND ingress acl for logical switch %s: %w", lsName, err)
+				return nil, fmt.Errorf("new routed ND ingress acl for logical switch %s: %w", lsName, err)
 			}
 			acls = append(acls, acl)
 		}
 	}
+	return acls, nil
+}
 
-	egressToGW := NewAndACLMatch(
-		NewACLMatch("ip", "", "", ""),
-		NewACLMatch("eth.dst", "==", gatewayMAC, ""),
-	)
+func (c *OVNNbClient) buildRoutedIPAllowACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, private bool, options func(*ovnnb.ACL)) ([]*ovnnb.ACL, error) {
+	acls := make([]*ovnnb.ACL, 0)
+
+	egressToGW := NewAndACLMatch(NewACLMatch("ip", "", "", ""), NewACLMatch("eth.dst", "==", gatewayMAC, ""))
 	egressACL, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, egressToGW.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
 	if err != nil {
-		return fmt.Errorf("new routed egress-to-gateway acl for logical switch %s: %w", lsName, err)
+		return nil, fmt.Errorf("new routed egress-to-gateway acl for logical switch %s: %w", lsName, err)
 	}
 	acls = append(acls, egressACL)
 
-	ingressFromGW := NewAndACLMatch(
-		NewACLMatch("ip", "", "", ""),
-		NewACLMatch("eth.src", "==", gatewayMAC, ""),
-	)
-	ingressACL, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, ingressFromGW.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
-	if err != nil {
-		return fmt.Errorf("new routed ingress-from-gateway acl for logical switch %s: %w", lsName, err)
+	if !private {
+		ingressFromGW := NewAndACLMatch(NewACLMatch("ip", "", "", ""), NewACLMatch("eth.src", "==", gatewayMAC, ""))
+		ingressACL, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, ingressFromGW.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+		if err != nil {
+			return nil, fmt.Errorf("new routed ingress-from-gateway acl for logical switch %s: %w", lsName, err)
+		}
+		return append(acls, ingressACL), nil
 	}
-	acls = append(acls, ingressACL)
 
+	privateIngress, err := c.buildRoutedPrivateIngressACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR, allowSubnets, options)
+	if err != nil {
+		return nil, err
+	}
+	return append(acls, privateIngress...), nil
+}
+
+func (c *OVNNbClient) buildRoutedPrivateIngressACLs(lsName, cidrBlock, gatewayMAC, nodeSwitchCIDR string, allowSubnets []string, options func(*ovnnb.ACL)) ([]*ovnnb.ACL, error) {
+	acls := make([]*ovnnb.ACL, 0)
 	for cidr := range strings.SplitSeq(cidrBlock, ",") {
 		if cidr == "" {
 			continue
@@ -889,96 +918,72 @@ func (c *OVNNbClient) SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gateway
 			ipSuffix = "ip6"
 		}
 
-		sameSubnetDrop := NewAndACLMatch(
+		// Hairpin: same-subnet traffic returning via the LRP.
+		hairpin := NewAndACLMatch(
+			NewACLMatch("ip", "", "", ""),
+			NewACLMatch("eth.src", "==", gatewayMAC, ""),
 			NewACLMatch(ipSuffix+".src", "==", cidr, ""),
-			NewACLMatch(ipSuffix+".dst", "==", cidr, ""),
 		)
-		dropACL, err := c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedDropPriority, sameSubnetDrop.String(), ovnnb.ACLActionDrop, util.NetpolACLTier, options)
+		acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, hairpin.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
 		if err != nil {
-			return fmt.Errorf("new routed same-subnet drop acl for logical switch %s: %w", lsName, err)
+			return nil, fmt.Errorf("new routed private hairpin acl for logical switch %s: %w", lsName, err)
 		}
-		acls = append(acls, dropACL)
+		acls = append(acls, acl)
 
-		var peerDiscoveryDrop ACLMatch
-		if protocol == kubeovnv1.ProtocolIPv4 {
-			peerDiscoveryDrop = NewAndACLMatch(
-				NewACLMatch("arp", "", "", ""),
-				NewACLMatch("arp.tpa", "==", cidr, ""),
+		for nodeCidr := range strings.SplitSeq(nodeSwitchCIDR, ",") {
+			if protocol != util.CheckProtocol(nodeCidr) {
+				continue
+			}
+			match := NewAndACLMatch(
+				NewACLMatch("ip", "", "", ""),
+				NewACLMatch("eth.src", "==", gatewayMAC, ""),
+				NewACLMatch(ipSuffix+".src", "==", nodeCidr, ""),
 			)
-		} else {
-			peerDiscoveryDrop = NewAndACLMatch(
-				NewACLMatch("nd_ns", "", "", ""),
-				NewACLMatch("nd.target", "==", cidr, ""),
+			acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+			if err != nil {
+				return nil, fmt.Errorf("new routed private node acl for logical switch %s: %w", lsName, err)
+			}
+			acls = append(acls, acl)
+		}
+
+		for _, allowSubnet := range allowSubnets {
+			subnet := strings.TrimSpace(allowSubnet)
+			if subnet == "" || util.CheckProtocol(subnet) != protocol {
+				continue
+			}
+			match := NewAndACLMatch(
+				NewACLMatch("ip", "", "", ""),
+				NewACLMatch("eth.src", "==", gatewayMAC, ""),
+				NewACLMatch(ipSuffix+".src", "==", subnet, ""),
 			)
-		}
-		dropACL, err = c.newACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedDropPriority, peerDiscoveryDrop.String(), ovnnb.ACLActionDrop, util.NetpolACLTier, options)
-		if err != nil {
-			return fmt.Errorf("new routed peer discovery drop acl for logical switch %s: %w", lsName, err)
-		}
-		acls = append(acls, dropACL)
-
-		if private {
-			nodeSubnetACLFunc := func(protocol, ipSuffix string) error {
-				for nodeCidr := range strings.SplitSeq(nodeSwitchCIDR, ",") {
-					if protocol != util.CheckProtocol(nodeCidr) {
-						continue
-					}
-					match := NewACLMatch(ipSuffix+".src", "==", nodeCidr, "")
-					acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.NodeAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
-					if err != nil {
-						return fmt.Errorf("new node subnet ingress acl for logical switch %s: %w", lsName, err)
-					}
-					acls = append(acls, acl)
-				}
-				return nil
+			acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
+			if err != nil {
+				return nil, fmt.Errorf("new routed private allow-subnet acl for logical switch %s: %w", lsName, err)
 			}
-			if err := nodeSubnetACLFunc(protocol, ipSuffix); err != nil {
-				return err
-			}
-
-			for _, allowSubnet := range allowSubnets {
-				subnet := strings.TrimSpace(allowSubnet)
-				if subnet == "" || util.CheckProtocol(subnet) != protocol {
-					continue
-				}
-				match := NewOrACLMatch(
-					NewAndACLMatch(
-						NewACLMatch(ipSuffix+".src", "==", cidr, ""),
-						NewACLMatch(ipSuffix+".dst", "==", subnet, ""),
-					),
-					NewAndACLMatch(
-						NewACLMatch(ipSuffix+".src", "==", subnet, ""),
-						NewACLMatch(ipSuffix+".dst", "==", cidr, ""),
-					),
-				)
-				acl, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.SubnetAllowPriority, match.String(), ovnnb.ACLActionAllowRelated, util.NetpolACLTier, options)
-				if err != nil {
-					return fmt.Errorf("new allow subnet ingress acl for logical switch %s: %w", lsName, err)
-				}
-				acls = append(acls, acl)
-			}
+			acls = append(acls, acl)
 		}
 	}
+	return acls, nil
+}
 
-	if private {
-		allIPMatch := NewACLMatch("ip", "", "", "")
-		dropOptions := func(acl *ovnnb.ACL) {
-			setACLName(acl, lsName)
-			acl.Log = true
-			acl.Severity = ptr.To(ovnnb.ACLSeverityWarning)
-		}
-		defaultDropACL, err := c.newACL(lsName, ovnnb.ACLDirectionToLport, util.DefaultDropPriority, allIPMatch.String(), ovnnb.ACLActionDrop, util.NetpolACLTier, dropOptions)
-		if err != nil {
-			return fmt.Errorf("new default drop ingress acl for logical switch %s: %w", lsName, err)
-		}
-		acls = append(acls, defaultDropACL)
+func (c *OVNNbClient) buildRoutedDefaultDenyACLs(lsName string, options func(*ovnnb.ACL)) ([]*ovnnb.ACL, error) {
+	dropOptions := func(acl *ovnnb.ACL) {
+		options(acl)
+		acl.Log = true
+		acl.Severity = ptr.To(ovnnb.ACLSeverityWarning)
 	}
 
-	if err := c.CreateAcls(lsName, LogicalSwitchKey, acls...); err != nil {
-		klog.Error(err)
-		return fmt.Errorf("add routed acls to logical switch %s: %w", lsName, err)
+	acls := make([]*ovnnb.ACL, 0, 8)
+	for _, direction := range []string{ovnnb.ACLDirectionFromLport, ovnnb.ACLDirectionToLport} {
+		for _, match := range []string{"ip", "arp", "nd_ns", "nd_na"} {
+			acl, err := c.newACL(lsName, direction, util.RoutedDefaultDropPriority, match, ovnnb.ACLActionDrop, util.NetpolACLTier, dropOptions)
+			if err != nil {
+				return nil, fmt.Errorf("new routed default-deny %s acl (%s) for logical switch %s: %w", match, direction, lsName, err)
+			}
+			acls = append(acls, acl)
+		}
 	}
-	return nil
+	return acls, nil
 }
 
 func (c *OVNNbClient) SetNetPolACLLog(pgName string, logEnable, isIngress bool) error {

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -1523,22 +1523,18 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
 		require.NoError(t, err)
-		// ARP allow/ingress + IP egress/ingress + 8 default-deny (ip/arp/nd_ns/nd_na × 2 dirs)
-		require.Len(t, ls.ACLs, 12)
-
-		match := fmt.Sprintf("ip && eth.dst == %s", gatewayMAC)
-		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, match, util.NetpolACLTier, false)
-		require.NoError(t, err)
-		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
-
-		ingressMatch := fmt.Sprintf("ip && eth.src == %s", gatewayMAC)
-		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, ingressMatch, util.NetpolACLTier, false)
-		require.NoError(t, err)
-		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+		// ARP allow/ingress + IP via-LRP (eth.src/dst × 2 dirs) + 8 default-deny
+		require.Len(t, ls.ACLs, 14)
 
 		for _, direction := range []string{ovnnb.ACLDirectionFromLport, ovnnb.ACLDirectionToLport} {
+			for _, ethField := range []string{"eth.src", "eth.dst"} {
+				match := fmt.Sprintf("ip && %s == %s", ethField, gatewayMAC)
+				acl, err := nbClient.GetACL(lsName, direction, util.RoutedAllowPriority, match, util.NetpolACLTier, false)
+				require.NoError(t, err)
+				require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+			}
 			for _, denyMatch := range []string{"ip", "arp", "nd_ns", "nd_na"} {
-				acl, err = nbClient.GetACL(lsName, direction, util.RoutedDefaultDropPriority, denyMatch, util.NetpolACLTier, false)
+				acl, err := nbClient.GetACL(lsName, direction, util.RoutedDefaultDropPriority, denyMatch, util.NetpolACLTier, false)
 				require.NoError(t, err)
 				require.Equal(t, ovnnb.ACLActionDrop, acl.Action)
 			}
@@ -1557,8 +1553,8 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
 		require.NoError(t, err)
-		// v4 ARP×2 + v6 ND×2 + IP egress/ingress + 8 default-deny = 14
-		require.Len(t, ls.ACLs, 14)
+		// v4 ARP×2 + v6 ND×2 + IP via-LRP×4 + 8 default-deny = 16
+		require.Len(t, ls.ACLs, 16)
 
 		ndMatch := "nd_ns && nd.target == fd00::1"
 		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, ndMatch, util.NetpolACLTier, false)
@@ -1577,13 +1573,22 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 		err = nbClient.SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeCIDR, allowSubnets, true)
 		require.NoError(t, err)
 
-		// Blanket eth.src == mac allow must not exist.
+		// Blanket eth.src == mac allow must not exist on to-lport.
 		blanket := fmt.Sprintf("ip && eth.src == %s", gatewayMAC)
 		_, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, blanket, util.NetpolACLTier, false)
 		require.Error(t, err)
 
+		// Traffic to the router must still be allowed on both directions.
+		toRouter := fmt.Sprintf("ip && eth.dst == %s", gatewayMAC)
+		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, toRouter, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, toRouter, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+
 		hairpin := fmt.Sprintf("ip && eth.src == %s && ip4.src == %s", gatewayMAC, cidrBlock)
-		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, hairpin, util.NetpolACLTier, false)
+		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, hairpin, util.NetpolACLTier, false)
 		require.NoError(t, err)
 		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
 

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -1510,35 +1510,72 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 	gateway := "10.244.0.1"
 	gatewayMAC := "00:00:00:11:22:33"
 	nodeCIDR := "100.64.0.0/16"
+	router := "ovn-cluster"
 
 	t.Run("routed overlay ipv4 allow-list and default-deny", func(t *testing.T) {
 		t.Parallel()
 
 		lsName := "test_set_routed_ls"
+		routerLSP := LogicalSwitchPortName(router, lsName)
 		err := nbClient.CreateBareLogicalSwitch(lsName)
 		require.NoError(t, err)
 
-		err = nbClient.SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeCIDR, nil, false)
+		err = nbClient.SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeCIDR, nil, false)
 		require.NoError(t, err)
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
 		require.NoError(t, err)
-		// ARP allow/ingress + IP via-LRP (eth.src/dst × 2 dirs) + 8 default-deny
+		// ARP allow/ingress + to-router×2 + from-router inport + to-lport eth.src + 8 default-deny
 		require.Len(t, ls.ACLs, 14)
 
+		toRouter := fmt.Sprintf("ip && eth.dst == %s", gatewayMAC)
 		for _, direction := range []string{ovnnb.ACLDirectionFromLport, ovnnb.ACLDirectionToLport} {
-			for _, ethField := range []string{"eth.src", "eth.dst"} {
-				match := fmt.Sprintf("ip && %s == %s", ethField, gatewayMAC)
-				acl, err := nbClient.GetACL(lsName, direction, util.RoutedAllowPriority, match, util.NetpolACLTier, false)
-				require.NoError(t, err)
-				require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
-			}
+			acl, err := nbClient.GetACL(lsName, direction, util.RoutedAllowPriority, toRouter, util.NetpolACLTier, false)
+			require.NoError(t, err)
+			require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+		}
+
+		fromRouter := fmt.Sprintf(`ip && inport == "%s" && eth.src == %s`, routerLSP, gatewayMAC)
+		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, fromRouter, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+
+		fromGW := fmt.Sprintf("ip && eth.src == %s", gatewayMAC)
+		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, fromGW, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+
+		for _, direction := range []string{ovnnb.ACLDirectionFromLport, ovnnb.ACLDirectionToLport} {
 			for _, denyMatch := range []string{"ip", "arp", "nd_ns", "nd_na"} {
 				acl, err := nbClient.GetACL(lsName, direction, util.RoutedDefaultDropPriority, denyMatch, util.NetpolACLTier, false)
 				require.NoError(t, err)
 				require.Equal(t, ovnnb.ACLActionDrop, acl.Action)
 			}
 		}
+	})
+
+	t.Run("pod-forged eth.src LRP MAC is not allowed on from-lport", func(t *testing.T) {
+		t.Parallel()
+
+		lsName := "test_set_routed_antispoof"
+		routerLSP := LogicalSwitchPortName(router, lsName)
+		err := nbClient.CreateBareLogicalSwitch(lsName)
+		require.NoError(t, err)
+
+		err = nbClient.SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeCIDR, nil, false)
+		require.NoError(t, err)
+
+		// Bare from-lport eth.src == LRP would let a pod spoof the router MAC
+		// (port security is disabled by default). Only the inport-constrained
+		// allow may exist.
+		spoofMatch := fmt.Sprintf("ip && eth.src == %s", gatewayMAC)
+		_, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, spoofMatch, util.NetpolACLTier, false)
+		require.Error(t, err)
+
+		fromRouter := fmt.Sprintf(`ip && inport == "%s" && eth.src == %s`, routerLSP, gatewayMAC)
+		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, fromRouter, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
 	})
 
 	t.Run("routed dual-stack", func(t *testing.T) {
@@ -1548,12 +1585,12 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 		err := nbClient.CreateBareLogicalSwitch(lsName)
 		require.NoError(t, err)
 
-		err = nbClient.SetLogicalSwitchRouted(lsName, "10.244.0.0/16,fd00::/64", "10.244.0.1,fd00::1", gatewayMAC, "100.64.0.0/16,fd00:100:64::/112", nil, false)
+		err = nbClient.SetLogicalSwitchRouted(lsName, router, "10.244.0.0/16,fd00::/64", "10.244.0.1,fd00::1", gatewayMAC, "100.64.0.0/16,fd00:100:64::/112", nil, false)
 		require.NoError(t, err)
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
 		require.NoError(t, err)
-		// v4 ARP×2 + v6 ND×2 + IP via-LRP×4 + 8 default-deny = 16
+		// v4 ARP×2 + v6 ND×2 + to-router×2 + from-router + to-lport eth.src + 8 default-deny = 16
 		require.Len(t, ls.ACLs, 16)
 
 		ndMatch := "nd_ns && nd.target == fd00::1"
@@ -1566,11 +1603,12 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 		t.Parallel()
 
 		lsName := "test_set_routed_private"
+		routerLSP := LogicalSwitchPortName(router, lsName)
 		err := nbClient.CreateBareLogicalSwitch(lsName)
 		require.NoError(t, err)
 
 		allowSubnets := []string{"10.250.0.0/16"}
-		err = nbClient.SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeCIDR, allowSubnets, true)
+		err = nbClient.SetLogicalSwitchRouted(lsName, router, cidrBlock, gateway, gatewayMAC, nodeCIDR, allowSubnets, true)
 		require.NoError(t, err)
 
 		// Blanket eth.src == mac allow must not exist on to-lport.
@@ -1584,6 +1622,11 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 		require.NoError(t, err)
 		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
 		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, toRouter, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+
+		fromRouter := fmt.Sprintf(`ip && inport == "%s" && eth.src == %s`, routerLSP, gatewayMAC)
+		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, fromRouter, util.NetpolACLTier, false)
 		require.NoError(t, err)
 		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
 
@@ -1605,13 +1648,19 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 
 	t.Run("missing gateway mac", func(t *testing.T) {
 		t.Parallel()
-		err := nbClient.SetLogicalSwitchRouted("test_routed_no_mac", cidrBlock, gateway, "", "", nil, false)
+		err := nbClient.SetLogicalSwitchRouted("test_routed_no_mac", router, cidrBlock, gateway, "", "", nil, false)
 		require.ErrorContains(t, err, "gateway MAC is required")
+	})
+
+	t.Run("missing router", func(t *testing.T) {
+		t.Parallel()
+		err := nbClient.SetLogicalSwitchRouted("test_routed_no_router", "", cidrBlock, gateway, gatewayMAC, "", nil, false)
+		require.ErrorContains(t, err, "router is required")
 	})
 
 	t.Run("empty ls name", func(t *testing.T) {
 		t.Parallel()
-		err := nbClient.SetLogicalSwitchRouted("", cidrBlock, gateway, gatewayMAC, "", nil, false)
+		err := nbClient.SetLogicalSwitchRouted("", router, cidrBlock, gateway, gatewayMAC, "", nil, false)
 		require.ErrorContains(t, err, "logical switch name is required")
 	})
 }

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -1501,6 +1501,49 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchPrivate() {
 	})
 }
 
+func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
+	t := suite.T()
+	t.Parallel()
+
+	nbClient := suite.ovnNBClient
+	cidrBlock := "10.244.0.0/16"
+	gateway := "10.244.0.1"
+	gatewayMAC := "00:00:00:11:22:33"
+
+	t.Run("routed overlay ipv4", func(t *testing.T) {
+		t.Parallel()
+
+		lsName := "test_set_routed_ls"
+		err := nbClient.CreateBareLogicalSwitch(lsName)
+		require.NoError(t, err)
+
+		err = nbClient.SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, "100.64.0.0/16", nil, false)
+		require.NoError(t, err)
+
+		ls, err := nbClient.GetLogicalSwitch(lsName, false)
+		require.NoError(t, err)
+		// ARP allow + ARP ingress + IP egress + IP ingress + same-subnet drop + peer ARP drop
+		require.Len(t, ls.ACLs, 6)
+
+		match := fmt.Sprintf("ip && eth.dst == %s", gatewayMAC)
+		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, match, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+	})
+
+	t.Run("missing gateway mac", func(t *testing.T) {
+		t.Parallel()
+		err := nbClient.SetLogicalSwitchRouted("test_routed_no_mac", cidrBlock, gateway, "", "", nil, false)
+		require.ErrorContains(t, err, "gateway MAC is required")
+	})
+
+	t.Run("empty ls name", func(t *testing.T) {
+		t.Parallel()
+		err := nbClient.SetLogicalSwitchRouted("", cidrBlock, gateway, gatewayMAC, "", nil, false)
+		require.ErrorContains(t, err, "logical switch name is required")
+	})
+}
+
 func (suite *OvnClientTestSuite) testNewSgRuleACL() {
 	t := suite.T()
 	t.Parallel()

--- a/pkg/ovs/ovn-nb-acl_test.go
+++ b/pkg/ovs/ovn-nb-acl_test.go
@@ -1509,24 +1509,91 @@ func (suite *OvnClientTestSuite) testSetLogicalSwitchRouted() {
 	cidrBlock := "10.244.0.0/16"
 	gateway := "10.244.0.1"
 	gatewayMAC := "00:00:00:11:22:33"
+	nodeCIDR := "100.64.0.0/16"
 
-	t.Run("routed overlay ipv4", func(t *testing.T) {
+	t.Run("routed overlay ipv4 allow-list and default-deny", func(t *testing.T) {
 		t.Parallel()
 
 		lsName := "test_set_routed_ls"
 		err := nbClient.CreateBareLogicalSwitch(lsName)
 		require.NoError(t, err)
 
-		err = nbClient.SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, "100.64.0.0/16", nil, false)
+		err = nbClient.SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeCIDR, nil, false)
 		require.NoError(t, err)
 
 		ls, err := nbClient.GetLogicalSwitch(lsName, false)
 		require.NoError(t, err)
-		// ARP allow + ARP ingress + IP egress + IP ingress + same-subnet drop + peer ARP drop
-		require.Len(t, ls.ACLs, 6)
+		// ARP allow/ingress + IP egress/ingress + 8 default-deny (ip/arp/nd_ns/nd_na × 2 dirs)
+		require.Len(t, ls.ACLs, 12)
 
 		match := fmt.Sprintf("ip && eth.dst == %s", gatewayMAC)
 		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, match, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+
+		ingressMatch := fmt.Sprintf("ip && eth.src == %s", gatewayMAC)
+		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, ingressMatch, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+
+		for _, direction := range []string{ovnnb.ACLDirectionFromLport, ovnnb.ACLDirectionToLport} {
+			for _, denyMatch := range []string{"ip", "arp", "nd_ns", "nd_na"} {
+				acl, err = nbClient.GetACL(lsName, direction, util.RoutedDefaultDropPriority, denyMatch, util.NetpolACLTier, false)
+				require.NoError(t, err)
+				require.Equal(t, ovnnb.ACLActionDrop, acl.Action)
+			}
+		}
+	})
+
+	t.Run("routed dual-stack", func(t *testing.T) {
+		t.Parallel()
+
+		lsName := "test_set_routed_dual"
+		err := nbClient.CreateBareLogicalSwitch(lsName)
+		require.NoError(t, err)
+
+		err = nbClient.SetLogicalSwitchRouted(lsName, "10.244.0.0/16,fd00::/64", "10.244.0.1,fd00::1", gatewayMAC, "100.64.0.0/16,fd00:100:64::/112", nil, false)
+		require.NoError(t, err)
+
+		ls, err := nbClient.GetLogicalSwitch(lsName, false)
+		require.NoError(t, err)
+		// v4 ARP×2 + v6 ND×2 + IP egress/ingress + 8 default-deny = 14
+		require.Len(t, ls.ACLs, 14)
+
+		ndMatch := "nd_ns && nd.target == fd00::1"
+		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionFromLport, util.RoutedAllowPriority, ndMatch, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllow, acl.Action)
+	})
+
+	t.Run("private routed constrains router ingress", func(t *testing.T) {
+		t.Parallel()
+
+		lsName := "test_set_routed_private"
+		err := nbClient.CreateBareLogicalSwitch(lsName)
+		require.NoError(t, err)
+
+		allowSubnets := []string{"10.250.0.0/16"}
+		err = nbClient.SetLogicalSwitchRouted(lsName, cidrBlock, gateway, gatewayMAC, nodeCIDR, allowSubnets, true)
+		require.NoError(t, err)
+
+		// Blanket eth.src == mac allow must not exist.
+		blanket := fmt.Sprintf("ip && eth.src == %s", gatewayMAC)
+		_, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, blanket, util.NetpolACLTier, false)
+		require.Error(t, err)
+
+		hairpin := fmt.Sprintf("ip && eth.src == %s && ip4.src == %s", gatewayMAC, cidrBlock)
+		acl, err := nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, hairpin, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+
+		allowMatch := fmt.Sprintf("ip && eth.src == %s && ip4.src == %s", gatewayMAC, allowSubnets[0])
+		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, allowMatch, util.NetpolACLTier, false)
+		require.NoError(t, err)
+		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
+
+		nodeMatch := fmt.Sprintf("ip && eth.src == %s && ip4.src == %s", gatewayMAC, nodeCIDR)
+		acl, err = nbClient.GetACL(lsName, ovnnb.ACLDirectionToLport, util.RoutedAllowPriority, nodeMatch, util.NetpolACLTier, false)
 		require.NoError(t, err)
 		require.Equal(t, ovnnb.ACLActionAllowRelated, acl.Action)
 	})

--- a/pkg/ovs/ovn-nb-suite_test.go
+++ b/pkg/ovs/ovn-nb-suite_test.go
@@ -767,6 +767,10 @@ func (suite *OvnClientTestSuite) Test_SetLogicalSwitchPrivate() {
 	suite.testSetLogicalSwitchPrivate()
 }
 
+func (suite *OvnClientTestSuite) Test_SetLogicalSwitchRouted() {
+	suite.testSetLogicalSwitchRouted()
+}
+
 func (suite *OvnClientTestSuite) Test_newSgRuleACL() {
 	suite.testNewSgRuleACL()
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -193,9 +193,12 @@ const (
 
 	AllowEWTrafficPriority = "1900"
 
-	// Routed subnet ACL priorities (gateway-only L2).
-	RoutedAllowPriority = "1002"
-	RoutedDropPriority  = "1001"
+	// Routed subnet ACL priorities (gateway-only L2). Kept above typical
+	// user ACL priorities (often ~1000) and SubnetAllowPriority so the
+	// allow-list / default-deny policy cannot be bypassed by Spec.Acls;
+	// Spec.Acls are rejected entirely when routed is enabled.
+	RoutedAllowPriority       = "2100"
+	RoutedDefaultDropPriority = "2000"
 
 	SubnetAllowPriority = "1001"
 	DefaultDropPriority = "1000"

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -70,9 +70,13 @@ const (
 	PortSecurityAnnotation          = "ovn.kubernetes.io/port_security"
 	NorthGatewayAnnotation          = "ovn.kubernetes.io/north_gateway"
 
-	AllocatedAnnotationSuffix       = ".kubernetes.io/allocated"
-	AllocatedAnnotationTemplate     = "%s.kubernetes.io/allocated"
-	RoutedAnnotationTemplate        = "%s.kubernetes.io/routed"
+	AllocatedAnnotationSuffix   = ".kubernetes.io/allocated"
+	AllocatedAnnotationTemplate = "%s.kubernetes.io/allocated"
+	RoutedAnnotationTemplate    = "%s.kubernetes.io/routed"
+	// RoutedSubnetAnnotationTemplate marks that the pod's subnet uses routed
+	// mode (/32 or /128 addresses with on-link gateway routes). Distinct from
+	// RoutedAnnotationTemplate, which means OVN routes are ready for the pod.
+	RoutedSubnetAnnotationTemplate  = "%s.kubernetes.io/routed_subnet"
 	RoutesAnnotationTemplate        = "%s.kubernetes.io/routes"
 	MacAddressAnnotationTemplate    = "%s.kubernetes.io/mac_address"
 	IPAddressAnnotationTemplate     = "%s.kubernetes.io/ip_address"
@@ -188,6 +192,10 @@ const (
 	EgressDefaultDrop   = "2000"
 
 	AllowEWTrafficPriority = "1900"
+
+	// Routed subnet ACL priorities (gateway-only L2).
+	RoutedAllowPriority = "1002"
+	RoutedDropPriority  = "1001"
 
 	SubnetAllowPriority = "1001"
 	DefaultDropPriority = "1000"

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -347,12 +347,67 @@ func GetStringIP(v4IP, v6IP string) string {
 	return strings.Join(ipList, ",")
 }
 
+func GetIPAddrWithMask(ip, cidr string) (string, error) {
+	return getIPAddrWithMask(ip, cidr, false)
+}
+
+// GetIPAddrWithHostMask returns ip with /32 (IPv4) or /128 (IPv6) masks for routed subnet mode.
+func GetIPAddrWithHostMask(ip, cidr string) (string, error) {
+	return getIPAddrWithMask(ip, cidr, true)
+}
+
+func getIPAddrWithMask(ip, cidr string, hostMask bool) (string, error) {
+	var ipAddr string
+	ips := strings.Split(ip, ",")
+	if CheckProtocol(cidr) == kubeovnv1.ProtocolDual {
+		cidrBlocks := strings.Split(cidr, ",")
+		if len(cidrBlocks) == 2 {
+			if len(ips) == 2 {
+				v4Mask, v6Mask := strings.Split(cidrBlocks[0], "/")[1], strings.Split(cidrBlocks[1], "/")[1]
+				if hostMask {
+					v4Mask, v6Mask = "32", "128"
+				}
+				v4IP := fmt.Sprintf("%s/%s", ips[0], v4Mask)
+				v6IP := fmt.Sprintf("%s/%s", ips[1], v6Mask)
+				ipAddr = v4IP + "," + v6IP
+			} else {
+				err := fmt.Errorf("ip %s should be dualstack", ip)
+				klog.Error(err)
+				return "", err
+			}
+		}
+	} else {
+		if len(ips) == 1 {
+			mask := strings.Split(cidr, "/")[1]
+			if hostMask {
+				if CheckProtocol(ip) == kubeovnv1.ProtocolIPv6 {
+					mask = "128"
+				} else {
+					mask = "32"
+				}
+			}
+			ipAddr = fmt.Sprintf("%s/%s", ip, mask)
+		} else {
+			err := fmt.Errorf("ip %s should be singlestack", ip)
+			klog.Error(err)
+			return ipAddr, err
+		}
+	}
+	return ipAddr, nil
+}
+
 // GetIPAddrWithMaskForCNI returns IP address with mask for CNI plugin.
 // When ip is empty, it indicates no-IPAM mode (e.g., NAT gateway macvlan without default EIP).
 // When cidr is dual-stack, the CNI path uses the actual allocated IP families
 // and selects the matching mask instead of requiring the pod IP itself to be dual-stack.
+// When hostMask is true (routed subnet mode), pods get /32 or /128 addresses.
 // Returns (ipAddr, noIPAM, error) where noIPAM is true when IP allocation is skipped.
 func GetIPAddrWithMaskForCNI(ip, cidr string) (string, bool, error) {
+	return GetIPAddrWithMaskForCNIHostMask(ip, cidr, false)
+}
+
+// GetIPAddrWithMaskForCNIHostMask is like GetIPAddrWithMaskForCNI but can force host (/32|/128) masks.
+func GetIPAddrWithMaskForCNIHostMask(ip, cidr string, hostMask bool) (string, bool, error) {
 	if ip == "" {
 		// Network attachment definition using no-IPAM plugin (e.g., NAT gateway net1 macvlan with no default EIP)
 		// IP is not allocated by Kube-OVN, but cidr still comes from subnet configuration
@@ -380,40 +435,19 @@ func GetIPAddrWithMaskForCNI(ip, cidr string) (string, bool, error) {
 			if !ok || mask == "" {
 				return "", false, fmt.Errorf("invalid cidr %s", cidrBlock)
 			}
+			if hostMask {
+				if CheckProtocol(ip) == kubeovnv1.ProtocolIPv6 {
+					mask = "128"
+				} else {
+					mask = "32"
+				}
+			}
 			ipAddrs = append(ipAddrs, fmt.Sprintf("%s/%s", ip, mask))
 		}
 		return strings.Join(ipAddrs, ","), false, nil
 	}
-	ipAddr, err := GetIPAddrWithMask(ip, cidr)
+	ipAddr, err := getIPAddrWithMask(ip, cidr, hostMask)
 	return ipAddr, false, err
-}
-
-func GetIPAddrWithMask(ip, cidr string) (string, error) {
-	var ipAddr string
-	ips := strings.Split(ip, ",")
-	if CheckProtocol(cidr) == kubeovnv1.ProtocolDual {
-		cidrBlocks := strings.Split(cidr, ",")
-		if len(cidrBlocks) == 2 {
-			if len(ips) == 2 {
-				v4IP := fmt.Sprintf("%s/%s", ips[0], strings.Split(cidrBlocks[0], "/")[1])
-				v6IP := fmt.Sprintf("%s/%s", ips[1], strings.Split(cidrBlocks[1], "/")[1])
-				ipAddr = v4IP + "," + v6IP
-			} else {
-				err := fmt.Errorf("ip %s should be dualstack", ip)
-				klog.Error(err)
-				return "", err
-			}
-		}
-	} else {
-		if len(ips) == 1 {
-			ipAddr = fmt.Sprintf("%s/%s", ip, strings.Split(cidr, "/")[1])
-		} else {
-			err := fmt.Errorf("ip %s should be singlestack", ip)
-			klog.Error(err)
-			return ipAddr, err
-		}
-	}
-	return ipAddr, nil
 }
 
 func GetIPWithoutMask(ipStr string) string {

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -1000,6 +1000,54 @@ func TestGetStringIP(t *testing.T) {
 	}
 }
 
+func TestGetIPAddrWithHostMask(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		cidr string
+		want string
+	}{
+		{
+			name: "IPv4 host mask",
+			ip:   "192.168.1.1",
+			cidr: "192.168.1.0/24",
+			want: "192.168.1.1/32",
+		},
+		{
+			name: "IPv6 host mask",
+			ip:   "2001:db8::1",
+			cidr: "2001:db8::/32",
+			want: "2001:db8::1/128",
+		},
+		{
+			name: "Dual stack host masks",
+			ip:   "192.168.1.1,2001:db8::1",
+			cidr: "192.168.1.0/24,2001:db8::/32",
+			want: "192.168.1.1/32,2001:db8::1/128",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetIPAddrWithHostMask(tt.ip, tt.cidr)
+			if err != nil || got != tt.want {
+				t.Errorf("got %v (err=%v), but want %v", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetIPAddrWithMaskForCNIHostMask(t *testing.T) {
+	got, noIP, err := GetIPAddrWithMaskForCNIHostMask("10.0.0.5", "10.0.0.0/16", true)
+	if err != nil || noIP || got != "10.0.0.5/32" {
+		t.Fatalf("got %q noIP=%v err=%v, want 10.0.0.5/32", got, noIP, err)
+	}
+	got, noIP, err = GetIPAddrWithMaskForCNIHostMask("10.0.0.5,fd00::5", "10.0.0.0/16,fd00::/64", true)
+	if err != nil || noIP || got != "10.0.0.5/32,fd00::5/128" {
+		t.Fatalf("got %q noIP=%v err=%v", got, noIP, err)
+	}
+}
+
 func TestGetIPAddrWithMask(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/util/routed_routes.go
+++ b/pkg/util/routed_routes.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+
+	"github.com/kubeovn/kube-ovn/pkg/request"
+)
+
+// GatewayOnLinkRoute describes a SCOPE_LINK host route to a gateway IP
+// for routed subnet mode (/32 or /128 on-link).
+type GatewayOnLinkRoute struct {
+	Gateway net.IP
+	Dst     *net.IPNet
+}
+
+// GatewayOnLinkRoutes builds on-link host routes for each gateway address.
+// linkIndex is accepted for callers that install via netlink; the returned
+// destinations are independent of the index.
+func GatewayOnLinkRoutes(gateway string, _ int) ([]GatewayOnLinkRoute, error) {
+	routes := make([]GatewayOnLinkRoute, 0)
+	for _, gw := range SplitTrimmed(gateway, ",") {
+		gwIP := net.ParseIP(gw)
+		if gwIP == nil {
+			return nil, fmt.Errorf("invalid gateway %s for routed subnet", gw)
+		}
+		bits := 32
+		if gwIP.To4() == nil {
+			bits = 128
+		}
+		routes = append(routes, GatewayOnLinkRoute{
+			Gateway: gwIP,
+			Dst:     &net.IPNet{IP: gwIP, Mask: net.CIDRMask(bits, bits)},
+		})
+	}
+	return routes, nil
+}
+
+// ValidateRoutedAnnotationRoutes ensures pod route annotations are compatible
+// with routed (/32|/128) mode. Next hops must be the subnet gateway because
+// OVN ACLs only allow ARP/ND for that gateway and IP frames to the LRP MAC.
+func ValidateRoutedAnnotationRoutes(routes []request.Route, subnetGateway string) error {
+	if len(routes) == 0 {
+		return nil
+	}
+	allowed := SplitTrimmed(subnetGateway, ",")
+	if len(allowed) == 0 {
+		return errors.New("routed subnet route annotations require a subnet gateway")
+	}
+	for _, r := range routes {
+		if r.Destination != "" {
+			if _, _, err := net.ParseCIDR(r.Destination); err != nil {
+				return fmt.Errorf("invalid route destination %s: %w", r.Destination, err)
+			}
+		}
+		if r.Gateway == "" {
+			return fmt.Errorf("routed subnet route annotations must set gateway to the subnet gateway %q (got destination %q with empty gateway)", subnetGateway, r.Destination)
+		}
+		if net.ParseIP(r.Gateway) == nil {
+			return fmt.Errorf("invalid route gateway %s", r.Gateway)
+		}
+		if !slices.Contains(allowed, r.Gateway) {
+			return fmt.Errorf("routed subnet route annotation gateway %s must be the subnet gateway %s", r.Gateway, subnetGateway)
+		}
+	}
+	return nil
+}

--- a/pkg/util/routed_routes_test.go
+++ b/pkg/util/routed_routes_test.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"net"
+	"testing"
+
+	"github.com/kubeovn/kube-ovn/pkg/request"
+)
+
+func TestGatewayOnLinkRoutes(t *testing.T) {
+	routes, err := GatewayOnLinkRoutes("10.0.0.1", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("got %d routes, want 1", len(routes))
+	}
+	if routes[0].Dst.String() != "10.0.0.1/32" {
+		t.Fatalf("got dst %s, want 10.0.0.1/32", routes[0].Dst)
+	}
+
+	routes, err = GatewayOnLinkRoutes("fd00::1", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].Dst.String() != "fd00::1/128" {
+		t.Fatalf("got dst %s, want fd00::1/128", routes[0].Dst)
+	}
+
+	routes, err = GatewayOnLinkRoutes("10.0.0.1,fd00::1", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("got %d routes, want 2", len(routes))
+	}
+	if !routes[0].Gateway.Equal(net.ParseIP("10.0.0.1")) || !routes[1].Gateway.Equal(net.ParseIP("fd00::1")) {
+		t.Fatalf("unexpected gateways: %#v", routes)
+	}
+
+	if _, err := GatewayOnLinkRoutes("not-an-ip", 1); err == nil {
+		t.Fatal("expected error for invalid gateway")
+	}
+}
+
+func TestValidateRoutedAnnotationRoutes(t *testing.T) {
+	if err := ValidateRoutedAnnotationRoutes(nil, "10.0.0.1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ok := []request.Route{{Destination: "192.168.1.0/24", Gateway: "10.0.0.1"}}
+	if err := ValidateRoutedAnnotationRoutes(ok, "10.0.0.1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateRoutedAnnotationRoutes(ok, "10.0.0.1,fd00::1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ValidateRoutedAnnotationRoutes([]request.Route{{Destination: "192.168.1.0/24", Gateway: "10.0.0.2"}}, "10.0.0.1"); err == nil {
+		t.Fatal("expected error for non-subnet gateway")
+	}
+	if err := ValidateRoutedAnnotationRoutes([]request.Route{{Destination: "192.168.1.0/24"}}, "10.0.0.1"); err == nil {
+		t.Fatal("expected error for empty gateway")
+	}
+	if err := ValidateRoutedAnnotationRoutes([]request.Route{{Destination: "bad", Gateway: "10.0.0.1"}}, "10.0.0.1"); err == nil {
+		t.Fatal("expected error for invalid destination")
+	}
+}

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -236,6 +236,9 @@ func validateRoutedSubnet(subnet kubeovnv1.Subnet, isUnderlayWithoutCIDR bool) e
 	if subnet.Spec.EnableIPv6RA {
 		return fmt.Errorf("routed mode conflicts with enableIPv6RA on subnet %s", subnet.Name)
 	}
+	if len(subnet.Spec.Acls) != 0 {
+		return fmt.Errorf("routed mode does not support custom spec.acls on subnet %s (they could bypass gateway-only isolation)", subnet.Name)
+	}
 	return nil
 }
 

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -158,6 +158,10 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		return errors.New("logicalGateway and u2oInterconnection can't be opened at the same time")
 	}
 
+	if err := validateRoutedSubnet(subnet, isUnderlayWithoutCIDR); err != nil {
+		return err
+	}
+
 	if subnet.Spec.U2OFeatures.OverlayOnlyRouting {
 		if !subnet.Spec.U2OInterconnection {
 			return errors.New("u2oFeatures.overlayOnlyRouting can only be enabled when u2OInterconnection is true")
@@ -200,6 +204,38 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		}
 	}
 
+	return nil
+}
+
+// validateRoutedSubnet checks constraints for routed (/32|/128 + gateway hairpin) mode.
+func validateRoutedSubnet(subnet kubeovnv1.Subnet, isUnderlayWithoutCIDR bool) error {
+	if !subnet.Spec.Routed {
+		return nil
+	}
+
+	if isUnderlayWithoutCIDR || subnet.Spec.Protocol == kubeovnv1.ProtocolMac {
+		return fmt.Errorf("routed mode is not supported for mac-only / BYO-DHCP subnet %s", subnet.Name)
+	}
+	if subnet.Spec.CIDRBlock == "" {
+		return fmt.Errorf("routed mode requires cidrBlock on subnet %s", subnet.Name)
+	}
+	if !IsOvnProvider(subnet.Spec.Provider) {
+		return fmt.Errorf("routed mode requires an OVN provider on subnet %s", subnet.Name)
+	}
+	// Routed mode needs an OVN logical router port to hairpin same-subnet traffic.
+	hasRouter := subnet.Spec.Vlan == "" || subnet.Spec.LogicalGateway || subnet.Spec.U2OInterconnection
+	if !hasRouter {
+		return fmt.Errorf("routed mode requires overlay or underlay with logicalGateway/u2oInterconnection on subnet %s", subnet.Name)
+	}
+	if subnet.Spec.EnableMulticastSnoop {
+		return fmt.Errorf("routed mode conflicts with enableMulticastSnoop on subnet %s", subnet.Name)
+	}
+	if subnet.Spec.EnableDHCP {
+		return fmt.Errorf("routed mode conflicts with enableDHCP on subnet %s", subnet.Name)
+	}
+	if subnet.Spec.EnableIPv6RA {
+		return fmt.Errorf("routed mode conflicts with enableIPv6RA on subnet %s", subnet.Name)
+	}
 	return nil
 }
 

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -389,6 +389,32 @@ func TestValidateSubnet(t *testing.T) {
 			err: "routed mode conflicts with enableDHCP on subnet ut-routed-dhcp-err",
 		},
 		{
+			name: "RoutedWithCustomAclsErr",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-routed-acls-err",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolIPv4,
+					CIDRBlock:   "10.16.0.0/16",
+					Gateway:     "10.16.0.1",
+					ExcludeIps:  []string{"10.16.0.1"},
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Routed:      true,
+					Acls: []kubeovnv1.ACL{{
+						Direction: "to-lport",
+						Priority:  3000,
+						Match:     "ip4",
+						Action:    "allow",
+					}},
+				},
+			},
+			err: "routed mode does not support custom spec.acls on subnet ut-routed-acls-err (they could bypass gateway-only isolation)",
+		},
+		{
 			name: "ValidateNatOutgoingPolicyRulesErr",
 			subnet: kubeovnv1.Subnet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -328,6 +328,67 @@ func TestValidateSubnet(t *testing.T) {
 			},
 		},
 		{
+			name: "RoutedOverlayCorrect",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-routed-overlay",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolIPv4,
+					CIDRBlock:   "10.16.0.0/16",
+					Gateway:     "10.16.0.1",
+					ExcludeIps:  []string{"10.16.0.1"},
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Routed:      true,
+				},
+			},
+		},
+		{
+			name: "RoutedUnderlayWithoutRouterErr",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-routed-underlay-err",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolIPv4,
+					CIDRBlock:   "10.16.0.0/16",
+					Gateway:     "10.16.0.1",
+					ExcludeIps:  []string{"10.16.0.1"},
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Vlan:        "vlan1",
+					Routed:      true,
+				},
+			},
+			err: "routed mode requires overlay or underlay with logicalGateway/u2oInterconnection on subnet ut-routed-underlay-err",
+		},
+		{
+			name: "RoutedWithDHCPErr",
+			subnet: kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-routed-dhcp-err",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         DefaultVpc,
+					Protocol:    kubeovnv1.ProtocolIPv4,
+					CIDRBlock:   "10.16.0.0/16",
+					Gateway:     "10.16.0.1",
+					ExcludeIps:  []string{"10.16.0.1"},
+					Provider:    OvnProvider,
+					GatewayType: kubeovnv1.GWDistributedType,
+					Routed:      true,
+					EnableDHCP:  true,
+				},
+			},
+			err: "routed mode conflicts with enableDHCP on subnet ut-routed-dhcp-err",
+		},
+		{
 			name: "ValidateNatOutgoingPolicyRulesErr",
 			subnet: kubeovnv1.Subnet{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

Adds a new Subnet option `spec.routed` that switches the subnet from a shared L2 broadcast domain to a routed (/32|/128) model.

When enabled (CIDR can still be something like `10.0.0.0/16`):
- Each pod gets a host address (`/32` IPv4 or `/128` IPv6), not the subnet prefix.
- The pod netns is configured with an on-link route to the gateway, then a default route via that gateway:
  ```
  ip addr add 10.0.0.5/32 dev eth0
  ip route add 10.0.0.1/32 dev eth0
  ip route add default via 10.0.0.1
  ```
- Same-subnet east-west traffic is forced through the OVN logical router (gateway hairpin), not direct L2 between pods.
- OVN ACLs allow ARP/ND only for the gateway and IP frames only to/from the logical router port MAC, so pods cannot talk peer-to-peer on the logical switch.

This improves scalability by removing the host-visible broadcast domain and making the gateway the only L2 neighbor for pods.

## Scope / constraints

- Supported on overlay subnets, and underlay only when an OVN router port exists (`logicalGateway` or `u2oInterconnection`).
- Rejected for pure underlay with a physical gateway, non-OVN providers, mac-only/BYO-DHCP, DHCP, IPv6 RA, and multicast snoop.
- IPAM is unchanged: addresses are still allocated from `spec.cidrBlock`.
- Existing pods must be recreated after enabling or disabling `routed` (CNI configures addressing at ADD time).
- Distinct from the existing pod annotation `ovn.kubernetes.io/routed` (that only means “OVN routes are ready”).

## How to try

```yaml
apiVersion: kubeovn.io/v1
kind: Subnet
metadata:
  name: routed-subnet
spec:
  cidrBlock: 10.0.0.0/16
  gateway: 10.0.0.1
  protocol: IPv4
  provider: ovn
  routed: true
```

Then create pods on that subnet and verify:
1. Pod iface address is `/32` (or `/128`).
2. On-link route to the gateway and default via gateway exist.
3. Pod-to-pod on the same subnet still works, but via the gateway (not direct L2).

## Test plan

- [ ] Unit: validation matrix for `spec.routed`
- [ ] Unit: host-mask helpers (`/32`/`/128`, dual-stack)
- [ ] Unit: OVN ACL builder for routed mode
- [ ] Manual: create overlay subnet with `routed: true`, schedule two pods, confirm `/32` + gateway routes and same-subnet connectivity via gateway
- [ ] Manual: confirm underlay without logical gateway/U2O is rejected
- [ ] Manual: recreate pods after toggling `routed` and confirm addressing updates