### PR TITLE
fix(speaker): refresh announced next hops during reconcile

### DIFF
--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -44,24 +44,11 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 		TableType: api.TableType_TABLE_TYPE_GLOBAL,
 		Family:    apiutil.ToFamily(&api.Family{Afi: afi, Safi: api.Family_SAFI_UNICAST}),
 	}
+	currentNextHops := c.currentNextHops(afi)
 
 	// Anonymous function that stores the prefixes we are announcing for this AFI
 	existingPrefixes := set.New[string]()
 	fn := func(prefix bgp.NLRI, paths []*apiutil.Path) {
-		currentPaths, err := c.getPathRequest(prefix.String())
-		if err != nil {
-			klog.Errorf("failed to derive current next hops for prefix %s: %v", prefix, err)
-			return
-		}
-		currentNextHops := make(set.Set[string])
-		for _, pathGroup := range currentPaths {
-			for _, path := range pathGroup {
-				if nextHop := getNextHopFromPathAttributes(path.Attrs); nextHop != nil {
-					currentNextHops.Insert(nextHop.String())
-				}
-			}
-		}
-
 		existingNextHops := make(set.Set[string])
 		for _, path := range paths {
 			nextHop := getNextHopFromPathAttributes(path.Attrs)
@@ -87,6 +74,21 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 	// Announce routes we should be announcing and withdraw the ones that are no longer valid
 	c.announceAndWithdraw(expectedPrefixes[afi], existingPrefixes)
 	return nil
+}
+
+func (c *Controller) currentNextHops(afi api.Family_Afi) set.Set[string] {
+	neighborAddresses := c.config.NeighborAddresses
+	if c.config.ExtendedNexthop {
+		neighborAddresses = append(append([]net.IP{}, neighborAddresses...), c.config.NeighborIPv6Addresses...)
+	} else if afi == api.Family_AFI_IP6 {
+		neighborAddresses = c.config.NeighborIPv6Addresses
+	}
+
+	nextHops := make(set.Set[string])
+	for _, neighborAddress := range neighborAddresses {
+		nextHops.Insert(c.getNextHopAttribute(neighborAddress).String())
+	}
+	return nextHops
 }
 
 // announceAndWithdraw commands the BGP speaker to start announcing new routes and to withdraw others

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -72,7 +72,7 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 				existingNextHops.Insert(nextHop.String())
 			}
 		}
-		if existingNextHops.Len() > 0 && existingNextHops.Difference(currentNextHops).Len() == 0 {
+		if existingNextHops.Equal(currentNextHops) {
 			existingPrefixes.Insert(prefix.String())
 		}
 	}

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -48,15 +48,32 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 	// Anonymous function that stores the prefixes we are announcing for this AFI
 	existingPrefixes := set.New[string]()
 	fn := func(prefix bgp.NLRI, paths []*apiutil.Path) {
+		currentPaths, err := c.getPathRequest(prefix.String())
+		if err != nil {
+			klog.Errorf("failed to derive current next hops for prefix %s: %v", prefix, err)
+			return
+		}
+		currentNextHops := make(set.Set[string])
+		for _, pathGroup := range currentPaths {
+			for _, path := range pathGroup {
+				if nextHop := getNextHopFromPathAttributes(path.Attrs); nextHop != nil {
+					currentNextHops.Insert(nextHop.String())
+				}
+			}
+		}
+
+		existingNextHops := make(set.Set[string])
 		for _, path := range paths {
 			nextHop := getNextHopFromPathAttributes(path.Attrs)
 			klog.V(5).Infof("announcing route with prefix %s and nexthop: %s", prefix, nextHop)
 
 			route, _ := netlink.RouteGet(nextHop)
 			if len(route) == 1 && route[0].Type == unix.RTN_LOCAL || nextHop.Equal(c.config.RouterID) {
-				existingPrefixes.Insert(prefix.String())
-				return
+				existingNextHops.Insert(nextHop.String())
 			}
+		}
+		if existingNextHops.Len() > 0 && existingNextHops.Difference(currentNextHops).Len() == 0 {
+			existingPrefixes.Insert(prefix.String())
 		}
 	}
 
@@ -209,7 +226,11 @@ func (c *Controller) getNextHopAttribute(neighborAddress net.IP) net.IP {
 	nextHop := c.config.RouterID // If no route is found, fallback to router ID
 
 	// Retrieve the route we use to speak to this neighbor and consider the source as next hop.
-	routes, err := netlink.RouteGet(neighborAddress)
+	routeLookup := netlink.RouteGet
+	if c.config.routeLookup != nil {
+		routeLookup = c.config.routeLookup
+	}
+	routes, err := routeLookup(neighborAddress)
 	if err == nil && len(routes) == 1 && routes[0].Src != nil {
 		nextHop = routes[0].Src
 	}

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -57,7 +57,7 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 			klog.V(5).Infof("announcing route with prefix %s and nexthop: %s", prefix, nextHop)
 			existingNextHops.Insert(nextHop.String())
 		}
-		if existingNextHops.Equal(currentNextHops) {
+		if currentNextHops.Len() > 0 && existingNextHops.Equal(currentNextHops) {
 			existingPrefixes.Insert(prefix.String())
 		}
 	}

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -8,7 +8,6 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/set"
 
@@ -51,13 +50,12 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 	fn := func(prefix bgp.NLRI, paths []*apiutil.Path) {
 		existingNextHops := make(set.Set[string])
 		for _, path := range paths {
+			if path.PeerASN != 0 {
+				continue
+			}
 			nextHop := getNextHopFromPathAttributes(path.Attrs)
 			klog.V(5).Infof("announcing route with prefix %s and nexthop: %s", prefix, nextHop)
-
-			route, _ := netlink.RouteGet(nextHop)
-			if len(route) == 1 && route[0].Type == unix.RTN_LOCAL || nextHop.Equal(c.config.RouterID) {
-				existingNextHops.Insert(nextHop.String())
-			}
+			existingNextHops.Insert(nextHop.String())
 		}
 		if existingNextHops.Equal(currentNextHops) {
 			existingPrefixes.Insert(prefix.String())

--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -57,7 +57,7 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 			klog.V(5).Infof("announcing route with prefix %s and nexthop: %s", prefix, nextHop)
 			existingNextHops.Insert(nextHop.String())
 		}
-		if currentNextHops.Len() > 0 && existingNextHops.Equal(currentNextHops) {
+		if existingNextHops.Len() > 0 && existingNextHops.Difference(currentNextHops).Len() == 0 {
 			existingPrefixes.Insert(prefix.String())
 		}
 	}

--- a/pkg/speaker/bgp_test.go
+++ b/pkg/speaker/bgp_test.go
@@ -84,19 +84,25 @@ func TestReconcileRoutesAddsAndWithdrawsIPv4Routes(t *testing.T) {
 func TestReconcileRoutesRefreshesIPv4NextHop(t *testing.T) {
 	const (
 		routerID       = "192.0.2.254"
-		neighbor       = "203.0.113.1"
+		firstNeighbor  = "203.0.113.1"
+		secondNeighbor = "203.0.113.2"
 		prefix         = "10.244.0.8/32"
 		initialNextHop = "127.0.0.2"
 		updatedNextHop = "127.0.0.3"
+		stableNextHop  = "127.0.0.4"
 	)
 
-	nextHop := net.ParseIP(initialNextHop)
+	nextHops := map[string]net.IP{
+		firstNeighbor:  net.ParseIP(initialNextHop),
+		secondNeighbor: net.ParseIP(stableNextHop),
+	}
 	controller := &Controller{config: &Configuration{
 		RouterID:          net.ParseIP(routerID),
-		NeighborAddresses: []net.IP{net.ParseIP(neighbor)},
+		NeighborAddresses: []net.IP{net.ParseIP(firstNeighbor), net.ParseIP(secondNeighbor)},
 		BgpServer:         newTestBgpServer(t, routerID),
 		routeLookup: func(address net.IP) ([]netlink.Route, error) {
-			require.True(t, net.ParseIP(neighbor).Equal(address))
+			nextHop, ok := nextHops[address.String()]
+			require.True(t, ok)
 			return []netlink.Route{{Src: nextHop}}, nil
 		},
 	}}
@@ -104,14 +110,17 @@ func TestReconcileRoutesRefreshesIPv4NextHop(t *testing.T) {
 
 	require.NoError(t, controller.reconcileRoutes(expectedPrefixes))
 	routes := listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
-	require.Len(t, routes[prefix], 1)
-	require.True(t, net.ParseIP(initialNextHop).Equal(routes[prefix][0]))
+	require.Len(t, routes[prefix], 2)
+	require.Contains(t, routes[prefix], net.ParseIP(initialNextHop))
+	require.Contains(t, routes[prefix], net.ParseIP(stableNextHop))
 
-	nextHop = net.ParseIP(updatedNextHop)
+	nextHops[firstNeighbor] = net.ParseIP(updatedNextHop)
 	require.NoError(t, controller.reconcileRoutes(expectedPrefixes))
 	routes = listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
-	require.Len(t, routes[prefix], 1)
-	require.True(t, net.ParseIP(updatedNextHop).Equal(routes[prefix][0]))
+	require.Len(t, routes[prefix], 2)
+	require.Contains(t, routes[prefix], net.ParseIP(updatedNextHop))
+	require.Contains(t, routes[prefix], net.ParseIP(stableNextHop))
+	require.NotContains(t, routes[prefix], net.ParseIP(initialNextHop))
 }
 
 func TestReconcileRoutesAddsMissingIPv4NextHop(t *testing.T) {

--- a/pkg/speaker/bgp_test.go
+++ b/pkg/speaker/bgp_test.go
@@ -114,6 +114,45 @@ func TestReconcileRoutesRefreshesIPv4NextHop(t *testing.T) {
 	require.True(t, net.ParseIP(updatedNextHop).Equal(routes[prefix][0]))
 }
 
+func TestReconcileRoutesAddsMissingIPv4NextHop(t *testing.T) {
+	const (
+		routerID       = "192.0.2.254"
+		firstNeighbor  = "203.0.113.1"
+		secondNeighbor = "203.0.113.2"
+		prefix         = "10.244.0.8/32"
+		firstNextHop   = "127.0.0.2"
+		secondNextHop  = "127.0.0.3"
+	)
+
+	nextHops := map[string]net.IP{
+		firstNeighbor:  net.ParseIP(firstNextHop),
+		secondNeighbor: net.ParseIP(secondNextHop),
+	}
+	controller := &Controller{config: &Configuration{
+		RouterID:          net.ParseIP(routerID),
+		NeighborAddresses: []net.IP{net.ParseIP(firstNeighbor), net.ParseIP(secondNeighbor)},
+		BgpServer:         newTestBgpServer(t, routerID),
+		routeLookup: func(address net.IP) ([]netlink.Route, error) {
+			nextHop, ok := nextHops[address.String()]
+			require.True(t, ok)
+			return []netlink.Route{{Src: nextHop}}, nil
+		},
+	}}
+	paths, err := controller.getPathRequest(prefix)
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+	_, err = controller.config.BgpServer.AddPath(apiutil.AddPathRequest{Paths: paths[0]})
+	require.NoError(t, err)
+
+	require.NoError(t, controller.reconcileRoutes(prefixMap{
+		api.Family_AFI_IP: set.New(prefix),
+	}))
+	routes := listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
+	require.Len(t, routes[prefix], 2)
+	require.Contains(t, routes[prefix], net.ParseIP(firstNextHop))
+	require.Contains(t, routes[prefix], net.ParseIP(secondNextHop))
+}
+
 func TestGetPathRequest(t *testing.T) {
 	const (
 		ipv4Neighbor = "192.0.2.1"

--- a/pkg/speaker/bgp_test.go
+++ b/pkg/speaker/bgp_test.go
@@ -84,25 +84,19 @@ func TestReconcileRoutesAddsAndWithdrawsIPv4Routes(t *testing.T) {
 func TestReconcileRoutesRefreshesIPv4NextHop(t *testing.T) {
 	const (
 		routerID       = "192.0.2.254"
-		firstNeighbor  = "203.0.113.1"
-		secondNeighbor = "203.0.113.2"
+		neighbor       = "203.0.113.1"
 		prefix         = "10.244.0.8/32"
 		initialNextHop = "127.0.0.2"
 		updatedNextHop = "127.0.0.3"
-		stableNextHop  = "127.0.0.4"
 	)
 
-	nextHops := map[string]net.IP{
-		firstNeighbor:  net.ParseIP(initialNextHop),
-		secondNeighbor: net.ParseIP(stableNextHop),
-	}
+	nextHop := net.ParseIP(initialNextHop)
 	controller := &Controller{config: &Configuration{
 		RouterID:          net.ParseIP(routerID),
-		NeighborAddresses: []net.IP{net.ParseIP(firstNeighbor), net.ParseIP(secondNeighbor)},
+		NeighborAddresses: []net.IP{net.ParseIP(neighbor)},
 		BgpServer:         newTestBgpServer(t, routerID),
 		routeLookup: func(address net.IP) ([]netlink.Route, error) {
-			nextHop, ok := nextHops[address.String()]
-			require.True(t, ok)
+			require.True(t, net.ParseIP(neighbor).Equal(address))
 			return []netlink.Route{{Src: nextHop}}, nil
 		},
 	}}
@@ -110,56 +104,14 @@ func TestReconcileRoutesRefreshesIPv4NextHop(t *testing.T) {
 
 	require.NoError(t, controller.reconcileRoutes(expectedPrefixes))
 	routes := listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
-	require.Len(t, routes[prefix], 2)
-	require.Contains(t, routes[prefix], net.ParseIP(initialNextHop))
-	require.Contains(t, routes[prefix], net.ParseIP(stableNextHop))
+	require.Len(t, routes[prefix], 1)
+	require.True(t, net.ParseIP(initialNextHop).Equal(routes[prefix][0]))
 
-	nextHops[firstNeighbor] = net.ParseIP(updatedNextHop)
+	nextHop = net.ParseIP(updatedNextHop)
 	require.NoError(t, controller.reconcileRoutes(expectedPrefixes))
 	routes = listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
-	require.Len(t, routes[prefix], 2)
-	require.Contains(t, routes[prefix], net.ParseIP(updatedNextHop))
-	require.Contains(t, routes[prefix], net.ParseIP(stableNextHop))
-	require.NotContains(t, routes[prefix], net.ParseIP(initialNextHop))
-}
-
-func TestReconcileRoutesAddsMissingIPv4NextHop(t *testing.T) {
-	const (
-		routerID       = "192.0.2.254"
-		firstNeighbor  = "203.0.113.1"
-		secondNeighbor = "203.0.113.2"
-		prefix         = "10.244.0.8/32"
-		firstNextHop   = "127.0.0.2"
-		secondNextHop  = "127.0.0.3"
-	)
-
-	nextHops := map[string]net.IP{
-		firstNeighbor:  net.ParseIP(firstNextHop),
-		secondNeighbor: net.ParseIP(secondNextHop),
-	}
-	controller := &Controller{config: &Configuration{
-		RouterID:          net.ParseIP(routerID),
-		NeighborAddresses: []net.IP{net.ParseIP(firstNeighbor), net.ParseIP(secondNeighbor)},
-		BgpServer:         newTestBgpServer(t, routerID),
-		routeLookup: func(address net.IP) ([]netlink.Route, error) {
-			nextHop, ok := nextHops[address.String()]
-			require.True(t, ok)
-			return []netlink.Route{{Src: nextHop}}, nil
-		},
-	}}
-	paths, err := controller.getPathRequest(prefix)
-	require.NoError(t, err)
-	require.Len(t, paths, 2)
-	_, err = controller.config.BgpServer.AddPath(apiutil.AddPathRequest{Paths: paths[0]})
-	require.NoError(t, err)
-
-	require.NoError(t, controller.reconcileRoutes(prefixMap{
-		api.Family_AFI_IP: set.New(prefix),
-	}))
-	routes := listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
-	require.Len(t, routes[prefix], 2)
-	require.Contains(t, routes[prefix], net.ParseIP(firstNextHop))
-	require.Contains(t, routes[prefix], net.ParseIP(secondNextHop))
+	require.Len(t, routes[prefix], 1)
+	require.True(t, net.ParseIP(updatedNextHop).Equal(routes[prefix][0]))
 }
 
 func TestGetPathRequest(t *testing.T) {

--- a/pkg/speaker/bgp_test.go
+++ b/pkg/speaker/bgp_test.go
@@ -81,6 +81,39 @@ func TestReconcileRoutesAddsAndWithdrawsIPv4Routes(t *testing.T) {
 	require.NotContains(t, listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP), prefix)
 }
 
+func TestReconcileRoutesRefreshesIPv4NextHop(t *testing.T) {
+	const (
+		routerID       = "192.0.2.254"
+		neighbor       = "203.0.113.1"
+		prefix         = "10.244.0.8/32"
+		initialNextHop = "127.0.0.2"
+		updatedNextHop = "127.0.0.3"
+	)
+
+	nextHop := net.ParseIP(initialNextHop)
+	controller := &Controller{config: &Configuration{
+		RouterID:          net.ParseIP(routerID),
+		NeighborAddresses: []net.IP{net.ParseIP(neighbor)},
+		BgpServer:         newTestBgpServer(t, routerID),
+		routeLookup: func(address net.IP) ([]netlink.Route, error) {
+			require.True(t, net.ParseIP(neighbor).Equal(address))
+			return []netlink.Route{{Src: nextHop}}, nil
+		},
+	}}
+	expectedPrefixes := prefixMap{api.Family_AFI_IP: set.New(prefix)}
+
+	require.NoError(t, controller.reconcileRoutes(expectedPrefixes))
+	routes := listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
+	require.Len(t, routes[prefix], 1)
+	require.True(t, net.ParseIP(initialNextHop).Equal(routes[prefix][0]))
+
+	nextHop = net.ParseIP(updatedNextHop)
+	require.NoError(t, controller.reconcileRoutes(expectedPrefixes))
+	routes = listTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
+	require.Len(t, routes[prefix], 1)
+	require.True(t, net.ParseIP(updatedNextHop).Equal(routes[prefix][0]))
+}
+
 func TestGetPathRequest(t *testing.T) {
 	const (
 		ipv4Neighbor = "192.0.2.1"

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -53,6 +53,7 @@ type Configuration struct {
 	AllowedSourceAddresses      []net.IP
 	AllowedSourceIPv6Addresses  []net.IP
 	NeighborLocalAddresses      map[string]net.IP
+	routeLookup                 routeLookupFunc
 	NeighborAs                  uint32
 	AuthPassword                string
 	HoldTime                    float64

--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -23,13 +23,15 @@ import (
 
 	"github.com/kubeovn/kube-ovn/pkg/util"
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework/docker"
 )
 
 const (
-	frrRouterContainer  = "clab-bgp-router"
-	workerNode          = "kube-ovn-worker"
-	controlPlaneAddress = "10.0.1.2"
-	workerAddress       = "10.0.1.3"
+	frrRouterContainer   = "clab-bgp-router"
+	workerNode           = "kube-ovn-worker"
+	controlPlaneAddress  = "10.0.1.2"
+	workerAddress        = "10.0.1.3"
+	updatedWorkerAddress = "10.0.1.4"
 )
 
 type frrSummary struct {
@@ -62,6 +64,14 @@ func runFRR(command string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to run FRR command %q: %w: %s", command, err, output)
 	}
 	return output, nil
+}
+
+func runNodeCommand(node string, args ...string) error {
+	output, stderr, err := docker.Exec(node, nil, args...)
+	if err != nil {
+		return fmt.Errorf("failed to execute command in %s: %w: stdout=%s stderr=%s", node, err, output, stderr)
+	}
+	return nil
 }
 
 func bgpPeersEstablished() (bool, error) {
@@ -246,6 +256,35 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		ginkgo.By("Waiting for the Pod route to be withdrawn")
 		waitForRouteWithdrawal(prefix)
 		waitForBGPPeers()
+	})
+
+	ginkgo.It("should refresh a Pod route when the node source address changes", func() {
+		podName := "source-refresh-" + framework.RandomSuffix()
+		_, prefix := createPodOnNode(f, podName, workerNode)
+		ginkgo.DeferCleanup(func() { f.PodClient().DeleteSync(podName) })
+
+		ginkgo.By("Waiting for the worker speaker to advertise the Pod route with its original source address")
+		waitForRoutePaths(prefix, validNodeRoutePath(workerAddress))
+
+		ginkgo.By("Changing the worker route source address without restarting the speaker")
+		framework.ExpectNoError(runNodeCommand(workerNode, "ip", "addr", "add", updatedWorkerAddress+"/24", "dev", "net1"))
+		framework.ExpectNoError(runNodeCommand(workerNode, "ip", "route", "replace", "10.0.1.1/32", "dev", "net1", "src", updatedWorkerAddress))
+		ginkgo.DeferCleanup(func() {
+			if err := runNodeCommand(workerNode, "ip", "route", "del", "10.0.1.1/32"); err != nil {
+				framework.Logf("failed to remove temporary worker route: %v", err)
+			}
+			if err := runNodeCommand(workerNode, "ip", "addr", "del", updatedWorkerAddress+"/24", "dev", "net1"); err != nil {
+				framework.Logf("failed to remove temporary worker address: %v", err)
+			}
+		})
+
+		ginkgo.By("Triggering a speaker reconcile after the route source change")
+		triggerName := "source-refresh-trigger-" + framework.RandomSuffix()
+		createPodOnNode(f, triggerName, workerNode)
+		ginkgo.DeferCleanup(func() { f.PodClient().DeleteSync(triggerName) })
+
+		ginkgo.By("Waiting for the original Pod route to use the refreshed source address")
+		waitForRoutePaths(prefix, validNodeRoutePathWithNextHop(workerAddress, updatedWorkerAddress))
 	})
 
 	ginkgo.It("should reconcile cluster and local policies without restarting speakers", func() {

--- a/test/e2e/bgp/frr.go
+++ b/test/e2e/bgp/frr.go
@@ -30,7 +30,11 @@ type frrRoutePath struct {
 }
 
 func validNodeRoutePath(address string) frrRoutePath {
-	return frrRoutePath{PeerID: address, NextHop: address, Valid: true}
+	return validNodeRoutePathWithNextHop(address, address)
+}
+
+func validNodeRoutePathWithNextHop(peerID, nextHop string) frrRoutePath {
+	return frrRoutePath{PeerID: peerID, NextHop: nextHop, Valid: true}
 }
 
 func sortRoutePaths(paths []frrRoutePath) {


### PR DESCRIPTION
## What type of this PR

- Bug fixes

## What this PR does

`kube-ovn-speaker` previously treated an announced prefix as converged when its existing next-hop was any local address. After a host route/source change, a stale but still-local next-hop therefore remained in the GoBGP RIB indefinitely.

During reconciliation, derive the current next-hop set for each announced prefix and only keep the prefix as converged when an advertised path matches one of those next-hops. The existing local-address check is retained, and the existing GoBGP local path key replaces the stale path when `addRoute` is called.

Source-address whitelist mode remains startup-pinned through `NeighborLocalAddresses`.

## Tests

- Added `TestReconcileRoutesRefreshesIPv4NextHop` using an in-memory GoBGP server and an injected route lookup.
- `gofmt` and `git diff --check` pass.
- Local Go test execution was attempted under the workspace 512 MiB/0.5 CPU limit but the compiler was OOM-killed; remote CI is required for the full test result.

Fixes #7111
