### PR TITLE
ci: simplify x86 E2E approval commands

### DIFF
--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -512,15 +512,10 @@ def renderSummary(plan, changedPaths):
         lines.append(f"- Full-suite reason: {safeSummaryText(plan['fullReason'])}")
     if plan["approvalRequired"]:
         commandGroups = safeSummaryText(",".join(plan["recommendedGroups"]))
-        binding = ""
-        if plan.get("requestNonce"):
-            binding = (
-                f" --head {plan['headSHA']} --nonce {plan['requestNonce']}"
-            )
         lines.extend(
             [
-                f"- Waiting for: `/test e2e{binding}`",
-                f"- Alternative: `/test e2e {commandGroups}{binding}`",
+                "- Waiting for: `/test e2e`",
+                f"- Alternative: `/test e2e {commandGroups}`",
             ]
         )
     if plan["reasons"]:

--- a/hack/test_e2e_selector.py
+++ b/hack/test_e2e_selector.py
@@ -521,15 +521,8 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertIn("Automatic coverage: mandatory smoke &#40;3 runner jobs&#41;", summary)
         self.assertIn("Recommended deferred groups: policy", summary)
         self.assertIn("Approval required: `yes`", summary)
-        nonce = e2eSelector.requestNonce(
-            7231,
-            "a" * 40,
-            "b" * 40,
-            plan["catalogRevision"],
-        )
-        binding = f"--head {'a' * 40} --nonce {nonce}"
-        self.assertIn(f"Waiting for: `/test e2e {binding}`", summary)
-        self.assertIn(f"Alternative: `/test e2e policy {binding}`", summary)
+        self.assertIn("Waiting for: `/test e2e`", summary)
+        self.assertIn("Alternative: `/test e2e policy`", summary)
 
     def testCatalogFailureEmitsFullFallbackPlan(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- show `/test e2e` as the primary command for recommended x86 E2E groups
- show `/test e2e <group>` for an explicit group request
- keep server-side live HEAD binding and the optional `--head/--nonce` form unchanged

## Validation
- `python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py`
- `git diff --check`