### PR TITLE
fix(controller): tolerate TLS rotation database outage

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -348,6 +348,17 @@ type Controller struct {
 	distributedSubnetNeedSync atomic.Bool
 }
 
+const (
+	// Secret projected volumes can take up to two minutes to converge on all
+	// nodes. Keep the database health check alive for that TLS rotation window.
+	dbStatusInterval    = 15 * time.Second
+	dbStatusMaxFailures = 11
+)
+
+func dbStatusFailureExceeded(failures int) bool {
+	return failures >= dbStatusMaxFailures
+}
+
 func newTypedRateLimitingQueue[T comparable](name string, rateLimiter workqueue.TypedRateLimiter[T]) workqueue.TypedRateLimitingInterface[T] {
 	if rateLimiter == nil {
 		rateLimiter = workqueue.DefaultTypedControllerRateLimiter[T]()
@@ -1224,8 +1235,6 @@ func (c *Controller) Run(ctx context.Context) {
 }
 
 func (c *Controller) dbStatus() {
-	const maxFailures = 5
-
 	done := make(chan error, 2)
 	go func() {
 		done <- c.OVNNbClient.Echo(context.Background())
@@ -1243,17 +1252,17 @@ func (c *Controller) dbStatus() {
 			resultsReceived++
 			if err != nil {
 				c.dbFailureCount++
-				klog.Errorf("OVN database echo failed (%d/%d): %v", c.dbFailureCount, maxFailures, err)
-				if c.dbFailureCount >= maxFailures {
-					util.LogFatalAndExit(err, "OVN database connection failed after %d attempts", maxFailures)
+				klog.Errorf("OVN database echo failed (%d/%d): %v", c.dbFailureCount, dbStatusMaxFailures, err)
+				if dbStatusFailureExceeded(c.dbFailureCount) {
+					util.LogFatalAndExit(err, "OVN database connection failed after %d attempts", dbStatusMaxFailures)
 				}
 				return
 			}
 		case <-timeout:
 			c.dbFailureCount++
-			klog.Errorf("OVN database echo timeout (%d/%d) after %ds", c.dbFailureCount, maxFailures, c.config.OvnTimeout)
-			if c.dbFailureCount >= maxFailures {
-				util.LogFatalAndExit(nil, "OVN database connection timeout after %d attempts", maxFailures)
+			klog.Errorf("OVN database echo timeout (%d/%d) after %ds", c.dbFailureCount, dbStatusMaxFailures, c.config.OvnTimeout)
+			if dbStatusFailureExceeded(c.dbFailureCount) {
+				util.LogFatalAndExit(nil, "OVN database connection timeout after %d attempts", dbStatusMaxFailures)
 			}
 			return
 		}
@@ -1632,7 +1641,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 
 	go wait.Until(runWorker("delete vm", c.deleteVMQueue, c.handleDeleteVM), time.Second, ctx.Done())
 
-	go wait.Until(c.dbStatus, 15*time.Second, ctx.Done())
+	go wait.Until(c.dbStatus, dbStatusInterval, ctx.Done())
 }
 
 func (c *Controller) allSubnetReady(subnets ...string) (bool, error) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
@@ -51,6 +52,18 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	os.Exit(m.Run())
+}
+
+func TestDBStatusFailureWindowAllowsTLSRotation(t *testing.T) {
+	if got := (dbStatusMaxFailures - 1) * dbStatusInterval; got < 2*time.Minute {
+		t.Fatalf("database health check failure window = %v, want at least 2m", got)
+	}
+	if dbStatusFailureExceeded(dbStatusMaxFailures - 1) {
+		t.Fatalf("database health check must not exit before %d failures during TLS rotation", dbStatusMaxFailures)
+	}
+	if !dbStatusFailureExceeded(dbStatusMaxFailures) {
+		t.Fatalf("database health check must exit after %d failures", dbStatusMaxFailures)
+	}
 }
 
 type fakeControllerInformers struct {


### PR DESCRIPTION
## Summary

- keep the controller database health check alive through the Kubernetes projected Secret and OVN TLS reload window
- preserve fatal exit for sustained database outages after the extended failure budget
- add a regression test covering the TLS rotation failure boundary

## Root cause

During TLS Secret rotation, OVN central reloaded before the controller Pod received the projected files. The controller health check ran every 15 seconds and exited after five consecutive echo failures (about 75 seconds), before Secret projection completed.

The failure budget is extended to eleven checks. Since the first check runs immediately, the eleventh failure occurs after 10 intervals (150 seconds), covering the documented two-minute projection window while still failing closed on a sustained outage.