### PR TITLE
fix(controller): stop overwriting VPC status on bootstrap

### DIFF
--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -290,7 +291,18 @@ func (c *Controller) initLB(name, protocol string, sessionAffinity bool) error {
 	return nil
 }
 
-// InitLoadBalancer init the default tcp and udp cluster loadbalancer
+// InitLoadBalancer creates the default TCP/UDP/SCTP cluster load balancers in
+// OVN for every existing VPC and records their names in each VPC's status so
+// the subnet worker can attach them to its logical switch on its first
+// reconcile.
+//
+// The status write uses a targeted merge patch that contains only the six
+// LB-name fields. An earlier version serialized the whole VpcStatus via
+// vpc.Status.Bytes() and raced InitDefaultVpc: if the VPC lister cache still
+// held the pre-UpdateStatus copy (Standby=false) the whole-status merge patch
+// would silently overwrite the Standby/Default/Router/DefaultLogicalSwitch
+// fields that InitDefaultVpc had just written, deadlocking the subnet worker.
+// A field-scoped patch avoids that class of overwrite entirely.
 func (c *Controller) initLoadBalancer() error {
 	vpcs, err := c.vpcsLister.List(labels.Everything())
 	if err != nil {
@@ -299,8 +311,7 @@ func (c *Controller) initLoadBalancer() error {
 	}
 
 	for _, cachedVpc := range vpcs {
-		vpc := cachedVpc.DeepCopy()
-		vpcLb := c.GenVpcLoadBalancer(vpc.Name)
+		vpcLb := c.GenVpcLoadBalancer(cachedVpc.Name)
 		if err = c.initLB(vpcLb.TCPLoadBalancer, string(v1.ProtocolTCP), false); err != nil {
 			klog.Error(err)
 			return err
@@ -326,23 +337,42 @@ func (c *Controller) initLoadBalancer() error {
 			return err
 		}
 
-		vpc.Status.TCPLoadBalancer = vpcLb.TCPLoadBalancer
-		vpc.Status.TCPSessionLoadBalancer = vpcLb.TCPSessLoadBalancer
-		vpc.Status.UDPLoadBalancer = vpcLb.UDPLoadBalancer
-		vpc.Status.UDPSessionLoadBalancer = vpcLb.UDPSessLoadBalancer
-		vpc.Status.SctpLoadBalancer = vpcLb.SctpLoadBalancer
-		vpc.Status.SctpSessionLoadBalancer = vpcLb.SctpSessLoadBalancer
-		bytes, err := vpc.Status.Bytes()
+		body, err := buildVpcLBStatusPatch(vpcLb)
 		if err != nil {
 			klog.Error(err)
 			return err
 		}
-		if _, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), vpc.Name, types.MergePatchType, bytes, metav1.PatchOptions{}, "status"); err != nil {
+		if _, err = c.config.KubeOvnClient.KubeovnV1().Vpcs().Patch(context.Background(), cachedVpc.Name, types.MergePatchType, body, metav1.PatchOptions{}, "status"); err != nil {
 			klog.Error(err)
 			return err
 		}
 	}
 	return nil
+}
+
+// buildVpcLBStatusPatch builds a merge-patch body that updates only the six
+// LB-name fields of VpcStatus. It deliberately excludes every other field so
+// the merge patch cannot overwrite state owned by InitDefaultVpc (Standby,
+// Default, Router, DefaultLogicalSwitch) when the caller reads from a stale
+// lister cache.
+func buildVpcLBStatusPatch(vpcLb *VpcLoadBalancer) ([]byte, error) {
+	patch := struct {
+		Status struct {
+			TCPLoadBalancer         string `json:"tcpLoadBalancer"`
+			TCPSessionLoadBalancer  string `json:"tcpSessionLoadBalancer"`
+			UDPLoadBalancer         string `json:"udpLoadBalancer"`
+			UDPSessionLoadBalancer  string `json:"udpSessionLoadBalancer"`
+			SctpLoadBalancer        string `json:"sctpLoadBalancer"`
+			SctpSessionLoadBalancer string `json:"sctpSessionLoadBalancer"`
+		} `json:"status"`
+	}{}
+	patch.Status.TCPLoadBalancer = vpcLb.TCPLoadBalancer
+	patch.Status.TCPSessionLoadBalancer = vpcLb.TCPSessLoadBalancer
+	patch.Status.UDPLoadBalancer = vpcLb.UDPLoadBalancer
+	patch.Status.UDPSessionLoadBalancer = vpcLb.UDPSessLoadBalancer
+	patch.Status.SctpLoadBalancer = vpcLb.SctpLoadBalancer
+	patch.Status.SctpSessionLoadBalancer = vpcLb.SctpSessLoadBalancer
+	return json.Marshal(patch)
 }
 
 func (c *Controller) InitIPAM() error {

--- a/pkg/controller/init_load_balancer_test.go
+++ b/pkg/controller/init_load_balancer_test.go
@@ -1,0 +1,80 @@
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildVpcLBStatusPatch_PreservesInitDefaultVpcFields is the regression
+// guard for the bootstrap race: initLoadBalancer's status patch must only set
+// the six LB-name fields and preserve fields owned by InitDefaultVpc.
+func TestBuildVpcLBStatusPatch_PreservesInitDefaultVpcFields(t *testing.T) {
+	t.Parallel()
+
+	vpcLb := &VpcLoadBalancer{
+		TCPLoadBalancer:      "cluster-tcp-loadbalancer",
+		TCPSessLoadBalancer:  "cluster-tcp-session-loadbalancer",
+		UDPLoadBalancer:      "cluster-udp-loadbalancer",
+		UDPSessLoadBalancer:  "cluster-udp-session-loadbalancer",
+		SctpLoadBalancer:     "cluster-sctp-loadbalancer",
+		SctpSessLoadBalancer: "cluster-sctp-session-loadbalancer",
+	}
+
+	body, err := buildVpcLBStatusPatch(vpcLb)
+	require.NoError(t, err)
+
+	var raw struct {
+		Status map[string]json.RawMessage `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.ElementsMatch(t,
+		[]string{
+			"tcpLoadBalancer", "tcpSessionLoadBalancer",
+			"udpLoadBalancer", "udpSessionLoadBalancer",
+			"sctpLoadBalancer", "sctpSessionLoadBalancer",
+		},
+		keysOf(raw.Status),
+	)
+
+	target, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{"name": "ovn-cluster"},
+		"status": map[string]any{
+			"standby":              true,
+			"default":              true,
+			"router":               "ovn-cluster",
+			"defaultLogicalSwitch": "ovn-default",
+		},
+	})
+	require.NoError(t, err)
+
+	merged, err := jsonpatch.MergePatch(target, body)
+	require.NoError(t, err)
+
+	var got struct {
+		Status map[string]any `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(merged, &got))
+
+	require.Equal(t, true, got.Status["standby"], "Standby must survive the LB patch")
+	require.Equal(t, true, got.Status["default"], "Default must survive the LB patch")
+	require.Equal(t, "ovn-cluster", got.Status["router"], "Router must survive the LB patch")
+	require.Equal(t, "ovn-default", got.Status["defaultLogicalSwitch"], "DefaultLogicalSwitch must survive the LB patch")
+
+	require.Equal(t, vpcLb.TCPLoadBalancer, got.Status["tcpLoadBalancer"])
+	require.Equal(t, vpcLb.TCPSessLoadBalancer, got.Status["tcpSessionLoadBalancer"])
+	require.Equal(t, vpcLb.UDPLoadBalancer, got.Status["udpLoadBalancer"])
+	require.Equal(t, vpcLb.UDPSessLoadBalancer, got.Status["udpSessionLoadBalancer"])
+	require.Equal(t, vpcLb.SctpLoadBalancer, got.Status["sctpLoadBalancer"])
+	require.Equal(t, vpcLb.SctpSessLoadBalancer, got.Status["sctpSessionLoadBalancer"])
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}


### PR DESCRIPTION
Backport of #6650 to release-1.15.

## Root cause

`release-1.15` contains the same unsafe `initLoadBalancer` behavior: it serializes the whole cached `VpcStatus` and sends it as a merge patch. A stale informer object can therefore overwrite `Standby`, `Default`, `Router`, and `DefaultLogicalSwitch` values written by `InitDefaultVpc`. Although the exact retry path differs from release-1.16, the bootstrap status corruption is the same.

## Fix

- Patch only the six load-balancer status fields.
- Add a focused regression test that applies the patch to the post-`InitDefaultVpc` state and verifies those fields are preserved.
- Keep the branch-specific removal of the old `init_test.go`; the regression test lives in `init_load_balancer_test.go`.

## Validation

- `git diff --check` passed.
- Standards review: no findings.
- Spec review: no findings.
- The focused controller test could not complete locally under the workspace-mandated 512 MiB memory limit; the Go compiler was OOM-killed. CI is expected to run the test with repository resources.

Upstream commit: 6435556fa6f977934dcb271fcb73524e5e885d52