### PR TITLE
ci: keep durable E2E approvals live

### DIFF
--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -215,6 +215,8 @@ jobs:
       contents: write
       issues: read
       pull-requests: read
+    outputs:
+      durableApproval: ${{ steps.coverage.outputs.durableApproval }}
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
@@ -229,6 +231,7 @@ jobs:
           persist-credentials: false
 
       - name: Dispatch automatic smoke or fail-closed full coverage
+        id: coverage
         env:
           DISPATCH_GENERATION: ${{ github.run_id }}
         run: |
@@ -287,6 +290,7 @@ jobs:
               -f "inputs[full]=$full" \
               -f 'inputs[recordIntent]=false' \
               -f 'inputs[baseRefresh]=false'
+            echo 'durableApproval=true' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           catalogRevision=$(jq -r '.catalogRevision' automatic-context.json)
@@ -941,11 +945,27 @@ jobs:
 
   reduce:
     name: Reduce recorded x86 E2E approvals
-    needs: dispatch
+    needs:
+      - dispatch
+      - automatic
     if: >-
       always() &&
-      github.event_name == 'workflow_dispatch' &&
-      github.actor == 'github-actions[bot]'
+      (
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.actor == 'github-actions[bot]'
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          needs.dispatch.outputs.accepted == 'true' &&
+          needs.dispatch.outputs.action == 'dispatch'
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          needs.automatic.result == 'success' &&
+          needs.automatic.outputs.durableApproval == 'true'
+        )
+      )
     permissions:
       contents: write
       actions: write
@@ -953,12 +973,12 @@ jobs:
       pull-requests: write
       issues: write
     concurrency:
-      group: x86-e2e-reduce-${{ inputs.prNumber }}-${{ inputs.approvalGeneration }}
+      group: x86-e2e-reduce-${{ inputs.prNumber || github.event.issue.number || github.event.pull_request.number }}-${{ inputs.approvalGeneration || github.run_id }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
-      PR_NUMBER: ${{ inputs.prNumber }}
+      PR_NUMBER: ${{ inputs.prNumber || github.event.issue.number || github.event.pull_request.number }}
       PYTHONPATH: hack
       PYTHONDONTWRITEBYTECODE: "1"
     steps:

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1280,8 +1280,12 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("reservation did not become durable", workflow)
         self.assertIn("github.actor == 'github-actions[bot]'", workflow)
         self.assertIn("name: Reduce recorded x86 E2E approvals", workflow)
-        self.assertIn("group: x86-e2e-reduce-${{ inputs.prNumber }}-${{ inputs.approvalGeneration }}", workflow)
-        self.assertIn("needs: dispatch", workflow)
+        self.assertIn(
+            "group: x86-e2e-reduce-${{ inputs.prNumber || github.event.issue.number || "
+            "github.event.pull_request.number }}-${{ inputs.approvalGeneration || github.run_id }}",
+            workflow,
+        )
+        self.assertIn("needs:\n      - dispatch\n      - automatic", workflow)
         self.assertIn("no approval was recorded", workflow)
         self.assertIn("actions/workflows/x86-e2e-gate.yaml/dispatches", workflow)
         self.assertIn("github.event_name == 'workflow_dispatch'", workflow)
@@ -1349,6 +1353,25 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("actions/runs/$runId/cancel", automatic)
         self.assertIn('requestKey="automatic-$PR_NUMBER-$headSHA"', automatic)
         self.assertNotIn('requestKey="automatic-$DISPATCH_GENERATION"', automatic)
+
+    def testDurableApprovalsReachReducerWithoutNestedWorkflowDispatch(self):
+        workflow = (repoRoot / ".github/workflows/x86-e2e-dispatcher.yaml").read_text()
+        reduce = e2eSelector.workflowJobBlocks(workflow)["reduce"]
+
+        self.assertIn("needs:\n      - dispatch\n      - automatic", reduce)
+        self.assertIn("github.event_name == 'issue_comment'", reduce)
+        self.assertIn("needs.dispatch.outputs.accepted == 'true'", reduce)
+        self.assertIn("needs.dispatch.outputs.action == 'dispatch'", reduce)
+        self.assertIn("github.event_name == 'pull_request_target'", reduce)
+        self.assertIn("needs.automatic.result == 'success'", reduce)
+        self.assertIn("needs.automatic.outputs.durableApproval == 'true'", reduce)
+        self.assertIn("github.event.issue.number", reduce)
+        self.assertIn("github.event.pull_request.number", reduce)
+
+        automatic = e2eSelector.workflowJobBlocks(workflow)["automatic"]
+        self.assertIn("durableApproval: ${{ steps.coverage.outputs.durableApproval }}", automatic)
+        self.assertIn("id: coverage", automatic)
+        self.assertIn("echo 'durableApproval=true' >> \"$GITHUB_OUTPUT\"", automatic)
 
     def testGateWorkflowCanOnlyReadRunsAndWriteChecks(self):
         workflow = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()


### PR DESCRIPTION
## What this PR does

Runs the existing trusted approval reducer in the original `issue_comment` or `pull_request_target` workflow after the gate reservation is created. This avoids relying on a nested `workflow_dispatch` chain that can leave the required gate permanently waiting without an executor run.

The automatic path exposes a `durableApproval` output so ordinary smoke-only pull requests do not run the reducer. Event-specific PR numbers and concurrency keys keep the reducer isolated per request.

## Verification

- `python3 -m unittest hack/test_e2e_control.py hack/test_e2e_selector.py` (98 tests)
- `actionlint .github/workflows/x86-e2e-dispatcher.yaml .github/workflows/x86-e2e-gate.yaml`
- `git diff --check`

Fixes the liveness failure observed at https://github.com/kubeovn/kube-ovn/pull/7296/checks?check_run_id=96736406530.