### PR TITLE
ci: refresh durable E2E approvals on base updates

### DIFF
--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -397,6 +397,8 @@ jobs:
   invalidate-base:
     name: Invalidate x86 E2E gates after a base update
     if: github.event_name == 'push'
+    outputs:
+      approvedPullRequests: ${{ steps.invalidate.outputs.approvedPullRequests }}
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
@@ -410,8 +412,10 @@ jobs:
           persist-credentials: false
 
       - name: Block fixed gates bound to the previous base revision
+        id: invalidate
         run: |
           set -euo pipefail
+          : > approved-pulls.txt
           catalogRevision=$(python3 - <<'PY'
           import json
           from pathlib import Path
@@ -449,6 +453,7 @@ jobs:
           print(json.dumps(request or {}))
           PY
             if [ "$(jq -r 'length' refresh-request.json)" -gt 0 ]; then
+              printf '%s\n' "$prNumber" >> approved-pulls.txt
               refreshHeadSHA=$(jq -r '.headSHA' refresh-request.json)
               refreshBaseSHA=$(jq -r '.baseSHA' refresh-request.json)
               refreshApprovalGeneration=$(jq -r '.approvalGeneration' refresh-request.json)
@@ -485,6 +490,10 @@ jobs:
                 -f 'inputs[baseRefresh]=true'
             fi
           done < open-pulls.tsv
+          approvedPullRequests=$(jq -Rsc \
+            'split("\n") | map(select(length > 0) | tonumber) | unique' \
+            approved-pulls.txt)
+          echo "approvedPullRequests=$approvedPullRequests" >> "$GITHUB_OUTPUT"
 
   dispatch:
     name: Validate and record x86 E2E commands
@@ -948,6 +957,7 @@ jobs:
     needs:
       - dispatch
       - automatic
+      - invalidate-base
     if: >-
       always() &&
       (
@@ -964,6 +974,11 @@ jobs:
           github.event_name == 'pull_request_target' &&
           needs.automatic.result == 'success' &&
           needs.automatic.outputs.durableApproval == 'true'
+        ) ||
+        (
+          github.event_name == 'push' &&
+          needs.invalidate-base.result == 'success' &&
+          needs.invalidate-base.outputs.approvedPullRequests != '[]'
         )
       )
     permissions:
@@ -973,12 +988,16 @@ jobs:
       pull-requests: write
       issues: write
     concurrency:
-      group: x86-e2e-reduce-${{ inputs.prNumber || github.event.issue.number || github.event.pull_request.number }}-${{ inputs.approvalGeneration || github.run_id }}
+      group: x86-e2e-reduce-${{ matrix.prNumber }}-${{ inputs.approvalGeneration || github.run_id }}
       cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        prNumber: ${{ fromJSON(github.event_name == 'push' && needs.invalidate-base.outputs.approvedPullRequests || format('[{0}]', inputs.prNumber || github.event.issue.number || github.event.pull_request.number)) }}
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
-      PR_NUMBER: ${{ inputs.prNumber || github.event.issue.number || github.event.pull_request.number }}
+      PR_NUMBER: ${{ matrix.prNumber }}
       PYTHONPATH: hack
       PYTHONDONTWRITEBYTECODE: "1"
     steps:

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1281,11 +1281,14 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("github.actor == 'github-actions[bot]'", workflow)
         self.assertIn("name: Reduce recorded x86 E2E approvals", workflow)
         self.assertIn(
-            "group: x86-e2e-reduce-${{ inputs.prNumber || github.event.issue.number || "
-            "github.event.pull_request.number }}-${{ inputs.approvalGeneration || github.run_id }}",
+            "group: x86-e2e-reduce-${{ matrix.prNumber }}-"
+            "${{ inputs.approvalGeneration || github.run_id }}",
             workflow,
         )
-        self.assertIn("needs:\n      - dispatch\n      - automatic", workflow)
+        self.assertIn(
+            "needs:\n      - dispatch\n      - automatic\n      - invalidate-base",
+            workflow,
+        )
         self.assertIn("no approval was recorded", workflow)
         self.assertIn("actions/workflows/x86-e2e-gate.yaml/dispatches", workflow)
         self.assertIn("github.event_name == 'workflow_dispatch'", workflow)
@@ -1358,7 +1361,10 @@ class E2EControlTest(unittest.TestCase):
         workflow = (repoRoot / ".github/workflows/x86-e2e-dispatcher.yaml").read_text()
         reduce = e2eSelector.workflowJobBlocks(workflow)["reduce"]
 
-        self.assertIn("needs:\n      - dispatch\n      - automatic", reduce)
+        self.assertIn(
+            "needs:\n      - dispatch\n      - automatic\n      - invalidate-base",
+            reduce,
+        )
         self.assertIn("github.event_name == 'issue_comment'", reduce)
         self.assertIn("needs.dispatch.outputs.accepted == 'true'", reduce)
         self.assertIn("needs.dispatch.outputs.action == 'dispatch'", reduce)
@@ -1372,6 +1378,24 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("durableApproval: ${{ steps.coverage.outputs.durableApproval }}", automatic)
         self.assertIn("id: coverage", automatic)
         self.assertIn("echo 'durableApproval=true' >> \"$GITHUB_OUTPUT\"", automatic)
+
+    def testBaseRefreshDurableApprovalsReachReducerMatrix(self):
+        workflow = (repoRoot / ".github/workflows/x86-e2e-dispatcher.yaml").read_text()
+        blocks = e2eSelector.workflowJobBlocks(workflow)
+        invalidate = blocks["invalidate-base"]
+        reduce = blocks["reduce"]
+
+        self.assertIn("approvedPullRequests: ${{ steps.invalidate.outputs.approvedPullRequests }}", invalidate)
+        self.assertIn("id: invalidate", invalidate)
+        self.assertIn("approved-pulls.txt", invalidate)
+        self.assertIn("approvedPullRequests=$approvedPullRequests", invalidate)
+        self.assertIn("- invalidate-base", reduce)
+        self.assertIn("github.event_name == 'push'", reduce)
+        self.assertIn("needs.invalidate-base.result == 'success'", reduce)
+        self.assertIn("needs.invalidate-base.outputs.approvedPullRequests != '[]'", reduce)
+        self.assertIn("matrix:", reduce)
+        self.assertIn("needs.invalidate-base.outputs.approvedPullRequests", reduce)
+        self.assertIn("PR_NUMBER: ${{ matrix.prNumber }}", reduce)
 
     def testGateWorkflowCanOnlyReadRunsAndWriteChecks(self):
         workflow = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()


### PR DESCRIPTION
## What this PR does

Completes the durable approval liveness fix from #7302 for target branch updates. The trusted base invalidator records every open pull request that still has a durable approval, and the existing reducer runs as a per-PR matrix in the original trusted `push` workflow.

This keeps executor dispatch at the top-level workflow boundary and avoids the nested `workflow_dispatch` chain that left #7296 permanently waiting. Pull requests without a durable approval continue to receive only the existing gate invalidation.

## Verification

- `python3 -m unittest hack/test_e2e_control.py hack/test_e2e_selector.py` (99 tests)
- `actionlint .github/workflows/x86-e2e-dispatcher.yaml .github/workflows/x86-e2e-gate.yaml`
- `git diff --check`

Follow-up to #7302.

Fixes the base-refresh path observed at https://github.com/kubeovn/kube-ovn/pull/7296/checks?check_run_id=96736406530.