### PR TITLE
ci: separate approved groups from label provenance

### DIFF
--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -1088,10 +1088,8 @@ jobs:
           REQUEST_KEY: ${{ steps.request.outputs.requestKey }}
           REQUESTED_GROUP_NAMES: ${{ steps.request.outputs.requestedGroupNames }}
           REQUESTED_GROUPS: ${{ steps.request.outputs.requestedGroups }}
-          CONTROLLED_LABELS: ${{ steps.request.outputs.controlledLabels }}
         run: |
           set -euo pipefail
-          controlledLabelNames=$(jq -r '.controlledLabels | if length == 0 then "-" else join(",") end' cumulative-request.json)
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > confirmed-pull-request.json
           if [ "$(jq -r '.head.sha' confirmed-pull-request.json)" != "$HEAD_SHA" ] || \
              [ "$(jq -r '.base.sha' confirmed-pull-request.json)" != "$BASE_SHA" ]; then
@@ -1254,8 +1252,8 @@ jobs:
             -f "inputs[dispatchGeneration]=$DISPATCH_GENERATION" \
             -f "inputs[requestedGroups]=$REQUESTED_GROUPS" \
             -f "inputs[requestedGroupNames]=$REQUESTED_GROUP_NAMES" \
-            -f "inputs[controlledLabels]=$CONTROLLED_LABELS" \
-            -f "inputs[controlledLabelNames]=$controlledLabelNames" \
+            -f 'inputs[controlledLabels]=[]' \
+            -f 'inputs[controlledLabelNames]=-' \
             -f "inputs[full]=$FULL" \
             -f "inputs[requestKey]=$REQUEST_KEY" \
             -f "inputs[catalogRevision]=$CATALOG_REVISION"; then
@@ -1265,7 +1263,7 @@ jobs:
               -f body='The trusted x86 E2E executor could not be started; retry the authorized command.'
             exit 1
           fi
-          expectedTitle="x86-e2e pr=$PR_NUMBER head=$HEAD_SHA approval=$APPROVAL_GENERATION generation=$DISPATCH_GENERATION mode=approved groups=$REQUESTED_GROUP_NAMES labels=$controlledLabelNames full=$([ "$FULL" = true ] && echo 1 || echo 0)"
+          expectedTitle="x86-e2e pr=$PR_NUMBER head=$HEAD_SHA approval=$APPROVAL_GENERATION generation=$DISPATCH_GENERATION mode=approved groups=$REQUESTED_GROUP_NAMES labels=- full=$([ "$FULL" = true ] && echo 1 || echo 0)"
           runVisible=false
           for _ in $(seq 1 24); do
             runVisible=$(gh api --paginate --slurp \

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1295,7 +1295,8 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("inputs[baseSHA]=$BASE_SHA", workflow)
         self.assertIn("inputs[approvalGeneration]=$APPROVAL_GENERATION", workflow)
         self.assertIn("inputs[dispatchGeneration]=$DISPATCH_GENERATION", workflow)
-        self.assertIn('inputs[controlledLabels]=$CONTROLLED_LABELS', workflow)
+        self.assertIn('inputs[controlledLabels]=$controlledLabels', workflow)
+        self.assertIn("-f 'inputs[controlledLabels]=[]'", workflow)
         self.assertIn("controlledLabels=", workflow)
         self.assertIn("retry the authorized command", workflow)
         self.assertIn("REQUEST_KEY: ${{ steps.request.outputs.requestKey }}", workflow)
@@ -1396,6 +1397,15 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("matrix:", reduce)
         self.assertIn("needs.invalidate-base.outputs.approvedPullRequests", reduce)
         self.assertIn("PR_NUMBER: ${{ matrix.prNumber }}", reduce)
+
+    def testApprovedExecutorDoesNotCarryAutomaticControlledLabels(self):
+        workflow = (repoRoot / ".github/workflows/x86-e2e-dispatcher.yaml").read_text()
+        reduce = e2eSelector.workflowJobBlocks(workflow)["reduce"]
+
+        self.assertIn("-f 'inputs[controlledLabels]=[]'", reduce)
+        self.assertIn("-f 'inputs[controlledLabelNames]=-'", reduce)
+        self.assertIn("mode=approved groups=$REQUESTED_GROUP_NAMES labels=-", reduce)
+        self.assertNotIn('inputs[controlledLabels]=$CONTROLLED_LABELS', reduce)
 
     def testGateWorkflowCanOnlyReadRunsAndWriteChecks(self):
         workflow = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()


### PR DESCRIPTION
## What this PR does

Keeps trusted controlled labels in durable approval markers and gate reconciliation, but clears them from `mode=approved` executor inputs and run titles. Approved execution already receives the immutable `requestedGroups`/`full` selection, while controlled labels are reserved for automatic selection.

This fixes the fail-closed selection error observed after #7303 successfully restored the durable executor path:

```text
approved execution cannot carry automatic controlled labels
```

## Verification

- `python3 -m unittest hack/test_e2e_control.py hack/test_e2e_selector.py` (100 tests)
- `actionlint -ignore 'label "larger-runner" is unknown' .github/workflows/x86-e2e-dispatcher.yaml .github/workflows/build-x86-image.yaml .github/workflows/x86-e2e-gate.yaml`\n- `git diff --check`\n\nFollow-up to #7302 and #7303.\n\nEvidence: https://github.com/kubeovn/kube-ovn/actions/runs/32475835749/job/96751868610.