### PR TITLE
fix(ci): resolve the live E2E target revision

### DIFF
--- a/.github/workflows/x86-e2e-dispatcher.yaml
+++ b/.github/workflows/x86-e2e-dispatcher.yaml
@@ -241,11 +241,14 @@ jobs:
             exit 0
           fi
           headSHA=$(jq -r '.head.sha' automatic-pull-request.json)
-          baseSHA=$(jq -r '.base.sha' automatic-pull-request.json)
           baseRef=$(jq -r '.base.ref' automatic-pull-request.json)
           if ! [[ "$baseRef" == master || "$baseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
             exit 0
           fi
+          baseSHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$baseRef" --jq '.object.sha')
+          jq --arg baseSHA "$baseSHA" '.base.sha = $baseSHA' automatic-pull-request.json \
+            > live-automatic-pull-request.json
+          mv live-automatic-pull-request.json automatic-pull-request.json
           gh api "repos/$GITHUB_REPOSITORY/contents/.github/e2e-selection.json?ref=$baseRef" \
             --jq '.content' | base64 --decode > automatic-catalog.json
           gh api --paginate --slurp \
@@ -416,6 +419,13 @@ jobs:
         run: |
           set -euo pipefail
           : > approved-pulls.txt
+          liveBaseSHA=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$GITHUB_REF_NAME" \
+            --jq '.object.sha')
+          if [ "$liveBaseSHA" != "$GITHUB_SHA" ]; then
+            echo 'approvedPullRequests=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           catalogRevision=$(python3 - <<'PY'
           import json
           from pathlib import Path
@@ -437,6 +447,9 @@ jobs:
               | jq -r 'any(.check_runs[]; .name == "x86-e2e / required-gate")')
             [ "$hasGate" = true ] || continue
             gh api "repos/$GITHUB_REPOSITORY/pulls/$prNumber" > refresh-pull-request.json
+            jq --arg baseSHA "$liveBaseSHA" '.base.sha = $baseSHA' refresh-pull-request.json \
+              > live-refresh-pull-request.json
+            mv live-refresh-pull-request.json refresh-pull-request.json
             gh api --paginate --slurp \
               "repos/$GITHUB_REPOSITORY/issues/$prNumber/comments?per_page=100" \
               > refresh-comments.json
@@ -542,6 +555,10 @@ jobs:
             echo 'Pull request base branch is outside the supported trusted set.' >&2
             exit 1
           fi
+          baseSHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$baseRef" --jq '.object.sha')
+          jq --arg baseSHA "$baseSHA" '.base.sha = $baseSHA' pull-request.json \
+            > live-pull-request.json
+          mv live-pull-request.json pull-request.json
           gh api "repos/$GITHUB_REPOSITORY/contents/.github/e2e-selection.json?ref=$baseRef" \
             --jq '.content' | base64 --decode > trusted-catalog.json
           gh api --paginate --slurp \
@@ -601,14 +618,23 @@ jobs:
           action=$(jq -r '.action' dispatch-decision.json)
           headSHA=$(jq -r '.headSHA' dispatch-decision.json)
           baseSHA=$(jq -r '.baseSHA' dispatch-decision.json)
+          baseRef=$(jq -r '.baseRef' dispatch-decision.json)
           gh api "repos/$GITHUB_REPOSITORY/pulls/$prNumber" > confirmed-pull-request.json
           confirmedHead=$(jq -r '.head.sha' confirmed-pull-request.json)
-          confirmedBase=$(jq -r '.base.sha' confirmed-pull-request.json)
-          if [ "$confirmedHead" != "$headSHA" ] || [ "$confirmedBase" != "$baseSHA" ]; then
+          confirmedBaseRef=$(jq -r '.base.ref' confirmed-pull-request.json)
+          confirmedBase=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$confirmedBaseRef" \
+            --jq '.object.sha')
+          if [ "$confirmedHead" != "$headSHA" ] || \
+             [ "$confirmedBaseRef" != "$baseRef" ] || \
+             [ "$confirmedBase" != "$baseSHA" ]; then
             gh api "repos/$GITHUB_REPOSITORY/issues/$prNumber/comments" \
               -f body='x86 E2E request became stale before dispatch; comment again for the current HEAD and target revision.'
             exit 1
           fi
+          jq --arg baseSHA "$confirmedBase" '.base.sha = $baseSHA' confirmed-pull-request.json \
+            > live-confirmed-pull-request.json
+          mv live-confirmed-pull-request.json confirmed-pull-request.json
           if [ "$action" = dispatch ]; then
             python3 - <<'PY' > request-marker.txt
           import json
@@ -890,14 +916,21 @@ jobs:
             exit 1
           fi
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > final-rerun-pull-request.json
+          finalBaseRef=$(jq -r '.base.ref' final-rerun-pull-request.json)
+          finalBaseSHA=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$finalBaseRef" \
+            --jq '.object.sha')
           if [ "$(jq -r '.state' final-rerun-pull-request.json)" != open ] || \
              [ "$(jq -r '.head.sha' final-rerun-pull-request.json)" != "$HEAD_SHA" ] || \
-             [ "$(jq -r '.base.sha' final-rerun-pull-request.json)" != "$BASE_SHA" ]; then
+             [ "$finalBaseRef" != "$BASE_REF" ] || [ "$finalBaseSHA" != "$BASE_SHA" ]; then
             gh api --method POST "repos/$GITHUB_REPOSITORY/actions/runs/$runId/cancel" >/dev/null 2>&1 || true
             gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
               -f body='The pull request changed before the failed-job rerun; no stale rerun was started.'
             exit 0
           fi
+          jq --arg baseSHA "$finalBaseSHA" '.base.sha = $baseSHA' final-rerun-pull-request.json \
+            > live-final-rerun-pull-request.json
+          mv live-final-rerun-pull-request.json final-rerun-pull-request.json
           gh api --paginate --slurp \
             "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
             > final-rerun-comments.json
@@ -1025,6 +1058,10 @@ jobs:
             echo 'hasApprovals=false' >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          baseSHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$baseRef" --jq '.object.sha')
+          jq --arg baseSHA "$baseSHA" '.base.sha = $baseSHA' pull-request.json \
+            > live-pull-request.json
+          mv live-pull-request.json pull-request.json
           gh api "repos/$GITHUB_REPOSITORY/contents/.github/e2e-selection.json?ref=$baseRef" \
             --jq '.content' | base64 --decode > trusted-catalog.json
           gh api --paginate --slurp \
@@ -1091,8 +1128,13 @@ jobs:
         run: |
           set -euo pipefail
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > confirmed-pull-request.json
+          confirmedBaseRef=$(jq -r '.base.ref' confirmed-pull-request.json)
+          confirmedBaseSHA=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$confirmedBaseRef" \
+            --jq '.object.sha')
           if [ "$(jq -r '.head.sha' confirmed-pull-request.json)" != "$HEAD_SHA" ] || \
-             [ "$(jq -r '.base.sha' confirmed-pull-request.json)" != "$BASE_SHA" ]; then
+             [ "$confirmedBaseRef" != "$BASE_REF" ] || \
+             [ "$confirmedBaseSHA" != "$BASE_SHA" ]; then
             echo 'The cumulative request became stale before dispatch.'
             exit 0
           fi
@@ -1175,9 +1217,13 @@ jobs:
             exit 1
           fi
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > final-pull-request.json
+          finalBaseRef=$(jq -r '.base.ref' final-pull-request.json)
+          finalBaseSHA=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$finalBaseRef" \
+            --jq '.object.sha')
           if [ "$(jq -r '.state' final-pull-request.json)" != open ] || \
              [ "$(jq -r '.head.sha' final-pull-request.json)" != "$HEAD_SHA" ] || \
-             [ "$(jq -r '.base.sha' final-pull-request.json)" != "$BASE_SHA" ]; then
+             [ "$finalBaseRef" != "$BASE_REF" ] || [ "$finalBaseSHA" != "$BASE_SHA" ]; then
             echo 'The cumulative request became stale during gate reconciliation.'
             exit 0
           fi

--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -207,9 +207,15 @@ jobs:
           fi
           gh api "repos/$GITHUB_REPOSITORY/pulls/$prNumber" > pull-request.json
           currentHead=$(jq -r '.head.sha' pull-request.json)
-          currentBaseSHA=$(jq -r '.base.sha' pull-request.json)
           baseRef=$(jq -r '.base.ref' pull-request.json)
           state=$(jq -r '.state' pull-request.json)
+          if ! [[ "$baseRef" == master || "$baseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
+            echo 'Pull request base branch is outside the supported trusted set.' >&2
+            exit 1
+          fi
+          currentBaseSHA=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$baseRef" \
+            --jq '.object.sha')
           if ! [[ "$currentBaseSHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo 'Current pull request base revision is invalid.' >&2
             exit 1
@@ -220,10 +226,6 @@ jobs:
             trustedExecution=false
           fi
           trustedRef="$currentBaseSHA"
-          if ! [[ "$baseRef" == master || "$baseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
-            echo 'Pull request base branch is outside the supported trusted set.' >&2
-            exit 1
-          fi
           if [ "$RUN_EVENT" = workflow_dispatch ] && {
             [ "$RUN_ACTOR" != 'github-actions[bot]' ] || [ "$RUN_HEAD_BRANCH" != "$expectedExecutorRef" ];
           }; then
@@ -706,14 +708,23 @@ jobs:
             echo 'mutate=false' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          liveBaseSHA=$(jq -r '.base.sha' pull-request.json)
+          baseRef=$(jq -r '.base.ref' pull-request.json)
+          if ! [[ "$baseRef" == master || "$baseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
+            echo 'mutate=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          liveBaseSHA=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$baseRef" \
+            --jq '.object.sha')
           if [ "$BASE_REFRESH" = true ]; then
             export BASE_SHA="$liveBaseSHA"
           elif [ "$liveBaseSHA" != "$BASE_SHA" ]; then
             echo 'mutate=false' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          baseRef=$(jq -r '.base.ref' pull-request.json)
+          jq --arg baseSHA "$liveBaseSHA" '.base.sha = $baseSHA' pull-request.json \
+            > live-pull-request.json
+          mv live-pull-request.json pull-request.json
           gh api "repos/$GITHUB_REPOSITORY/contents/.github/e2e-selection.json?ref=$baseRef" \
             --jq '.content' | base64 --decode > trusted-catalog.json
           gh api --paginate --slurp \
@@ -811,7 +822,7 @@ jobs:
           fi
           summary='The latest authorized x86 E2E approval is waiting for its trusted executor.'
           if [ "$BASE_REFRESH" = true ]; then
-            summary='The pull request target branch advanced; authorize x86 E2E again for the new base revision.'
+            summary='The pull request target branch advanced; trusted x86 E2E coverage is required for the new base revision.'
           fi
           {
             echo 'mutate=true'
@@ -820,7 +831,7 @@ jobs:
             echo "summary=$summary"
             echo "approvalGeneration=$(jq -r '.approvalGeneration' cumulative-request.json)"
             echo "baseRef=$baseRef"
-            echo "baseSHA=$(jq -r '.base.sha' pull-request.json)"
+            echo "baseSHA=$liveBaseSHA"
             echo "catalogRevision=$(jq -r '.catalogRevision' cumulative-request.json)"
             echo "requestKey=$(jq -r '.requestKey' cumulative-request.json)"
             echo "requestedGroups=$(jq -c '.requestedGroups' cumulative-request.json)"
@@ -895,13 +906,23 @@ jobs:
              [ "$(jq -r '.head.sha' final-pull-request.json)" != "$HEAD_SHA" ]; then
             exit 0
           fi
-          currentBaseSHA=$(jq -r '.base.sha' final-pull-request.json)
-          if [ "$currentBaseSHA" != "$BASE_SHA" ]; then
+          currentBaseRef=$(jq -r '.base.ref' final-pull-request.json)
+          if ! [[ "$currentBaseRef" == master || "$currentBaseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
+            exit 0
+          fi
+          currentBaseSHA=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$currentBaseRef" \
+            --jq '.object.sha')
+          jq --arg baseSHA "$currentBaseSHA" '.base.sha = $baseSHA' final-pull-request.json \
+            > live-final-pull-request.json
+          mv live-final-pull-request.json final-pull-request.json
+          if [ "$currentBaseRef" != "$BASE_REF" ] || [ "$currentBaseSHA" != "$BASE_SHA" ]; then
             RUN_ACTION=base_refresh
             STATUS=completed
             CONCLUSION=action_required
-            SUMMARY='The pull request target branch advanced; authorize x86 E2E again for the new base revision.'
+            SUMMARY='The pull request target branch advanced; trusted x86 E2E coverage is required for the new base revision.'
             RUN_URL="https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER"
+            BASE_REF="$currentBaseRef"
             export BASE_SHA="$currentBaseSHA"
             export TRUSTED_REF="$currentBaseSHA"
           fi
@@ -1503,15 +1524,21 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > write-pull-request.json
           writeState=$(jq -r '.state' write-pull-request.json)
           writeHead=$(jq -r '.head.sha' write-pull-request.json)
-          writeBase=$(jq -r '.base.sha' write-pull-request.json)
+          writeBaseRef=$(jq -r '.base.ref' write-pull-request.json)
+          if ! [[ "$writeBaseRef" == master || "$writeBaseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
+            exit 0
+          fi
+          writeBase=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$writeBaseRef" \
+            --jq '.object.sha')
           if [ "$writeState" != open ] || [ "$writeHead" != "$HEAD_SHA" ]; then
             exit 0
           fi
-          if [ "$writeBase" != "$BASE_SHA" ]; then
+          if [ "$writeBaseRef" != "$BASE_REF" ] || [ "$writeBase" != "$BASE_SHA" ]; then
             RUN_ACTION=base_refresh
             STATUS=completed
             CONCLUSION=action_required
-            SUMMARY='The pull request target branch advanced; authorize x86 E2E again for the new base revision.'
+            SUMMARY='The pull request target branch advanced; trusted x86 E2E coverage is required for the new base revision.'
             RUN_URL="https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER"
           fi
           jq -n \

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -309,7 +309,7 @@ class E2EControlTest(unittest.TestCase):
                 {
                     **check,
                     "output": {
-                        "summary": "The pull request target branch advanced; authorize x86 E2E again for the new base revision."
+                        "summary": "The pull request target branch advanced; trusted x86 E2E coverage is required for the new base revision."
                     },
                 },
                 7260,
@@ -1329,7 +1329,10 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("isApprovedGateReservation", workflow)
         self.assertNotIn(".details_url == $expectedURL", workflow)
         self.assertGreaterEqual(workflow.count("isolatedExecutorRefAction"), 2)
-        self.assertNotIn("--jq '.object.sha'", workflow)
+        self.assertNotIn(
+            'git/ref/heads/$executorRef" \\\n            --jq',
+            workflow,
+        )
         self.assertIn('git/refs/heads/$executorRef', workflow)
         self.assertIn('-f ref="$executorRef"', workflow)
         self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
@@ -1407,6 +1410,21 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("mode=approved groups=$REQUESTED_GROUP_NAMES labels=-", reduce)
         self.assertNotIn('inputs[controlledLabels]=$CONTROLLED_LABELS', reduce)
 
+    def testTrustedWorkflowsResolveTheLiveTargetBranchRevision(self):
+        dispatcher = (repoRoot / ".github/workflows/x86-e2e-dispatcher.yaml").read_text()
+        gate = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()
+
+        self.assertGreaterEqual(
+            dispatcher.count('git/ref/heads/'),
+            7,
+        )
+        self.assertGreaterEqual(
+            gate.count('git/ref/heads/'),
+            3,
+        )
+        self.assertNotIn("=$(jq -r '.base.sha'", dispatcher)
+        self.assertNotIn("=$(jq -r '.base.sha'", gate)
+
     def testGateWorkflowCanOnlyReadRunsAndWriteChecks(self):
         workflow = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()
 
@@ -1483,17 +1501,21 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("A newer authorized attempt supersedes this workflow_run event", workflow)
         self.assertIn("The latest completed executor decision artifact is not available yet", workflow)
         self.assertIn("Durable approval coverage changed before the serialized gate mutation", workflow)
-        self.assertIn("liveBaseSHA=$(jq -r '.base.sha' pull-request.json)", workflow)
+        self.assertIn('git/ref/heads/$baseRef', workflow)
         self.assertIn('if [ "$BASE_REFRESH" = true ]; then', workflow)
         self.assertIn('if [ "$BASE_REFRESH" != true ] && [ -n "$duplicate" ]; then', workflow)
         self.assertIn('export BASE_SHA="$liveBaseSHA"', workflow)
         self.assertIn('metadata["executorHeadBranch"] = e2eControl.executorHeadBranch(metadata)', workflow)
         self.assertIn('[ "$RUN_HEAD_BRANCH" != "$expectedExecutorRef" ]', workflow)
         self.assertIn("authorizedAttempt = e2eControl.isAuthorizedRunAttempt", workflow)
-        self.assertIn("currentBaseSHA=$(jq -r '.base.sha' final-pull-request.json)", workflow)
+        self.assertIn('git/ref/heads/$currentBaseRef', workflow)
         self.assertIn("RUN_ACTION=base_refresh", workflow)
         self.assertIn("write-pull-request.json", workflow)
-        self.assertIn("if [ \"$writeBase\" != \"$BASE_SHA\" ]; then", workflow)
+        self.assertIn(
+            'if [ "$writeBaseRef" != "$BASE_REF" ] || '
+            '[ "$writeBase" != "$BASE_SHA" ]; then',
+            workflow,
+        )
         self.assertLess(
             workflow.index("write-pull-request.json"),
             workflow.index('gh api --method PATCH "repos/$GITHUB_REPOSITORY/check-runs/$checkId"'),


### PR DESCRIPTION
## What this PR does

Resolve trusted x86 E2E requests against the current target branch Git ref instead of the stale `pull.base.sha` snapshot returned by the Pull Request API. This lets a durable `/test e2e` approval dispatch a fresh executor after the target branch advances.

The dispatcher and gate now use the same live base revision for request keys, isolated executor refs, stale checks, and final gate mutations. Base-update summaries no longer tell users to repeat an already durable approval.

## Why this is needed

After #7304 merged, PR #7296 still resolved `master` to `2e933d689` through `pull.base.sha` while the live branch was `c69814b8a`. The reducer therefore matched the prior failed executor request and exited with `The cumulative x86 E2E request is already recorded`, leaving the required gate failed.

## Validation

- `python3 -m unittest hack/test_e2e_control.py hack/test_e2e_selector.py`
- `actionlint .github/workflows/x86-e2e-dispatcher.yaml .github/workflows/x86-e2e-gate.yaml`
- YAML parsing for both workflows
- `git diff --check`

Signed-off-by: Zujian Zhang <zhangzujian.7@gmail.com>