### PR TITLE
fix(ci): validate executors against the live base

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -204,6 +204,17 @@ jobs:
             prNumber="$PR_NUMBER"
           elif [ "$EVENT_NAME" = workflow_dispatch ]; then
             gh api "repos/$GITHUB_REPOSITORY/pulls/$INPUT_PR_NUMBER" > pull-request.json
+            baseRef=$(jq -r '.base.ref' pull-request.json)
+            if ! [[ "$baseRef" == master || "$baseRef" =~ ^release-[A-Za-z0-9._-]+$ ]]; then
+              echo 'pull request base branch is outside the supported trusted set' >&2
+              exit 1
+            fi
+            baseSHA=$(gh api \
+              "repos/$GITHUB_REPOSITORY/git/ref/heads/$baseRef" \
+              --jq '.object.sha')
+            jq --arg baseSHA "$baseSHA" '.base.sha = $baseSHA' pull-request.json \
+              > live-pull-request.json
+            mv live-pull-request.json pull-request.json
             python3 - "$INPUT_HEAD_SHA" "$INPUT_BASE_SHA" "$GITHUB_REF_NAME" "$GITHUB_SHA" \
               "$INPUT_PR_NUMBER" "$INPUT_APPROVAL_GENERATION" "$INPUT_DISPATCH_GENERATION" <<'PY'
           import json

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1601,6 +1601,8 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("executor catalog revision does not match dispatcher", workflow)
         self.assertIn("executor workflow revision does not match the approved base", workflow)
         self.assertIn("isTrustedExecutorRef", workflow)
+        self.assertIn('git/ref/heads/$baseRef', workflow)
+        self.assertIn("'.base.sha = $baseSHA' pull-request.json", workflow)
         self.assertNotIn(
             'if pullRequest["base"]["ref"] != sys.argv[3]:',
             workflow,


### PR DESCRIPTION
## What this PR does

Resolve the current target branch SHA from its Git ref before the trusted x86 E2E executor validates `pull.base.sha`. The executor keeps all existing exact SHA and isolated-ref checks, but no longer rejects a valid dispatch because the Pull Request API returns a stale base snapshot.

## Why this is needed

After #7305, the durable approval for PR #7296 correctly created executor run 32477945418 at live master `f500a1cbb`. Its Selection job still compared that revision with stale `pull.base.sha=2e933d689` and failed with `pull request base revision changed; dispatch again`.

## Validation

- `python3 -m unittest hack/test_e2e_control.py hack/test_e2e_selector.py`
- `actionlint` for the executor, dispatcher, and gate workflows (only the existing custom `larger-runner` label warning)
- `git diff --check`

Signed-off-by: Zujian Zhang <zhangzujian.7@gmail.com>