### PR TITLE
fix(ci): reconcile completed E2E executors

### DIFF
--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -57,10 +57,7 @@ permissions:
 jobs:
   gate:
     name: Evaluate x86-e2e / required-gate
-    if: >-
-      github.event_name == 'workflow_run' &&
-      (github.event.workflow_run.event == 'pull_request' ||
-       github.event.workflow_run.event == 'workflow_dispatch')
+    if: github.event_name == 'workflow_run'
     outputs:
       mutate: ${{ steps.mutation.outputs.mutate }}
       status: ${{ steps.mutation.outputs.status }}
@@ -116,6 +113,10 @@ jobs:
           set -euo pipefail
           if [ "$RUN_PATH" != '.github/workflows/build-x86-image.yaml' ]; then
             echo 'workflow_run did not originate from the trusted executor path.' >&2
+            exit 1
+          fi
+          if [ "$RUN_EVENT" != workflow_dispatch ] && [ "$RUN_EVENT" != pull_request ]; then
+            echo "Unsupported x86 E2E source event: $RUN_EVENT" >&2
             exit 1
           fi
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" > context-run-state.json

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1523,6 +1523,7 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("RUN_REQUEST_KEY: ${{ needs.gate.outputs.mutate == 'true'", workflow)
         self.assertIn("inputs.baseRefresh && 'base_refresh'", workflow)
         self.assertIn("Queued x86 E2E approval intent", workflow)
+
         self.assertIn("Recorded x86 E2E approval", workflow)
         self.assertLess(
             workflow.index('gh api --method PATCH "repos/$GITHUB_REPOSITORY/check-runs/$checkId"'),
@@ -1533,6 +1534,20 @@ class E2EControlTest(unittest.TestCase):
             workflow.index("Recorded x86 E2E approval"),
         )
         self.assertGreaterEqual(workflow.count("approvalIntents"), 2)
+
+    def testGateWorkflowValidatesCompletedSourceEventsInsideTheJob(self):
+        workflow = (repoRoot / ".github/workflows/x86-e2e-gate.yaml").read_text()
+        gate = e2eSelector.workflowJobBlocks(workflow)["gate"]
+        gateHeader = gate.split("outputs:", 1)[0]
+        resolve = gate.split("Download the executed SelectionPlan", 1)[0]
+
+        self.assertIn("if: github.event_name == 'workflow_run'", gateHeader)
+        self.assertNotIn("github.event.workflow_run.event", gateHeader)
+        self.assertIn(
+            'if [ "$RUN_EVENT" != workflow_dispatch ] && [ "$RUN_EVENT" != pull_request ]; then',
+            resolve,
+        )
+        self.assertIn("Unsupported x86 E2E source event", resolve)
 
     def testWorkflowDispatchInputsUseGitHubRESTStringFields(self):
         for workflowName in ["x86-e2e-dispatcher.yaml", "x86-e2e-gate.yaml"]:


### PR DESCRIPTION
The completed trusted executor for #7296 succeeded, but its `workflow_run` gate run skipped every job before evaluating the result. The gate job-level condition was filtering on the nested source event, so a valid completion could be silently ignored and leave the old required check unchanged.

Run the gate job for every configured `workflow_run` trigger, then validate the source event explicitly inside the trusted context step. Unsupported source events now fail closed with a diagnostic instead of silently skipping.

Regression coverage locks both parts of that contract.

Validation:
- `python3 -m unittest hack/test_e2e_control.py hack/test_e2e_selector.py` (102 tests)
- `actionlint .github/workflows/x86-e2e-gate.yaml`
- YAML parse
- `git diff --check`

Signed-off-by: Zujian Zhang <zhangzujian.7@gmail.com>