### PR TITLE
fix(ci): ignore unrelated E2E workflow completions

### DIFF
--- a/.github/workflows/x86-e2e-gate.yaml
+++ b/.github/workflows/x86-e2e-gate.yaml
@@ -116,8 +116,9 @@ jobs:
             exit 1
           fi
           if [ "$RUN_EVENT" != workflow_dispatch ] && [ "$RUN_EVENT" != pull_request ]; then
-            echo "Unsupported x86 E2E source event: $RUN_EVENT" >&2
-            exit 1
+            echo "Unsupported x86 E2E source event: $RUN_EVENT; skipping."
+            echo 'skip=true' >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" > context-run-state.json
           currentAttempt=$(jq -r '.run_attempt' context-run-state.json)

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1548,6 +1548,10 @@ class E2EControlTest(unittest.TestCase):
             resolve,
         )
         self.assertIn("Unsupported x86 E2E source event", resolve)
+        unsupported = resolve.index("Unsupported x86 E2E source event")
+        unsupportedBranch = resolve[unsupported:unsupported + 300]
+        self.assertIn('echo \'skip=true\' >> "$GITHUB_OUTPUT"', unsupportedBranch)
+        self.assertIn("exit 0", unsupportedBranch)
 
     def testWorkflowDispatchInputsUseGitHubRESTStringFields(self):
         for workflowName in ["x86-e2e-dispatcher.yaml", "x86-e2e-gate.yaml"]:


### PR DESCRIPTION
Follow-up to #7307. `Build x86 Image` also runs for default-branch pushes, so evaluating every `workflow_run` completion must ignore unsupported source events without making those unrelated runs fail.

Keep the gate job runnable for trusted `workflow_dispatch` executor completions, but mark other source events as `skip=true` and exit successfully before any gate mutation. Regression coverage verifies the explicit no-op path.

Validation:
- `python3 -m unittest hack/test_e2e_control.py hack/test_e2e_selector.py` (102 tests)
- `actionlint .github/workflows/x86-e2e-gate.yaml`
- YAML parse
- `git diff --check`

Signed-off-by: Zujian Zhang <zhangzujian.7@gmail.com>