### PR TITLE
fix(controller): tolerate TLS rotation database outage

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -322,6 +322,17 @@ type Controller struct {
 	distributedSubnetNeedSync atomic.Bool
 }
 
+const (
+	// Secret projected volumes can take up to two minutes to converge on all
+	// nodes. Keep the database health check alive for that TLS rotation window.
+	dbStatusInterval    = 15 * time.Second
+	dbStatusMaxFailures = 11
+)
+
+func dbStatusFailureExceeded(failures int) bool {
+	return failures >= dbStatusMaxFailures
+}
+
 func newTypedRateLimitingQueue[T comparable](name string, rateLimiter workqueue.TypedRateLimiter[T]) workqueue.TypedRateLimitingInterface[T] {
 	if rateLimiter == nil {
 		rateLimiter = workqueue.DefaultTypedControllerRateLimiter[T]()
@@ -1095,8 +1106,6 @@ func (c *Controller) Run(ctx context.Context) {
 }
 
 func (c *Controller) dbStatus() {
-	const maxFailures = 5
-
 	done := make(chan error, 2)
 	go func() {
 		done <- c.OVNNbClient.Echo(context.Background())
@@ -1114,17 +1123,17 @@ func (c *Controller) dbStatus() {
 			resultsReceived++
 			if err != nil {
 				c.dbFailureCount++
-				klog.Errorf("OVN database echo failed (%d/%d): %v", c.dbFailureCount, maxFailures, err)
-				if c.dbFailureCount >= maxFailures {
-					util.LogFatalAndExit(err, "OVN database connection failed after %d attempts", maxFailures)
+				klog.Errorf("OVN database echo failed (%d/%d): %v", c.dbFailureCount, dbStatusMaxFailures, err)
+				if dbStatusFailureExceeded(c.dbFailureCount) {
+					util.LogFatalAndExit(err, "OVN database connection failed after %d attempts", dbStatusMaxFailures)
 				}
 				return
 			}
 		case <-timeout:
 			c.dbFailureCount++
-			klog.Errorf("OVN database echo timeout (%d/%d) after %ds", c.dbFailureCount, maxFailures, c.config.OvnTimeout)
-			if c.dbFailureCount >= maxFailures {
-				util.LogFatalAndExit(nil, "OVN database connection timeout after %d attempts", maxFailures)
+			klog.Errorf("OVN database echo timeout (%d/%d) after %ds", c.dbFailureCount, dbStatusMaxFailures, c.config.OvnTimeout)
+			if dbStatusFailureExceeded(c.dbFailureCount) {
+				util.LogFatalAndExit(nil, "OVN database connection timeout after %d attempts", dbStatusMaxFailures)
 			}
 			return
 		}
@@ -1495,7 +1504,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 
 	go wait.Until(runWorker("delete vm", c.deleteVMQueue, c.handleDeleteVM), time.Second, ctx.Done())
 
-	go wait.Until(c.dbStatus, 15*time.Second, ctx.Done())
+	go wait.Until(c.dbStatus, dbStatusInterval, ctx.Done())
 }
 
 func (c *Controller) allSubnetReady(subnets ...string) (bool, error) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -16,6 +16,7 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
@@ -39,6 +40,18 @@ import (
 	ovnipam "github.com/kubeovn/kube-ovn/pkg/ipam"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func TestDBStatusFailureWindowAllowsTLSRotation(t *testing.T) {
+	if got := (dbStatusMaxFailures - 1) * dbStatusInterval; got < 2*time.Minute {
+		t.Fatalf("database health check failure window = %v, want at least 2m", got)
+	}
+	if dbStatusFailureExceeded(dbStatusMaxFailures - 1) {
+		t.Fatalf("database health check must not exit before %d failures during TLS rotation", dbStatusMaxFailures)
+	}
+	if !dbStatusFailureExceeded(dbStatusMaxFailures) {
+		t.Fatalf("database health check must exit after %d failures", dbStatusMaxFailures)
+	}
+}
 
 type fakeControllerInformers struct {
 	vpcInformer       kubeovninformer.VpcInformer


### PR DESCRIPTION
## Summary

Backport the TLS rotation database health-check fix to release-1.15.

During TLS Secret rotation, OVN central can reload before projected Secret files reach kube-ovn-controller. The old five-failure budget could restart the controller during this expected transition. The backport uses eleven checks at a 15-second interval; because the first check runs immediately, the fatal threshold is reached after 150 seconds. Sustained database outages still terminate the controller.

Includes the policy regression test. The master-only WatchList TestMain was intentionally not backported.