### PR TITLE
fix(controller): tolerate TLS rotation database outage

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -333,6 +333,17 @@ type Controller struct {
 	distributedSubnetNeedSync atomic.Bool
 }
 
+const (
+	// Secret projected volumes can take up to two minutes to converge on all
+	// nodes. Keep the database health check alive for that TLS rotation window.
+	dbStatusInterval    = 15 * time.Second
+	dbStatusMaxFailures = 11
+)
+
+func dbStatusFailureExceeded(failures int) bool {
+	return failures >= dbStatusMaxFailures
+}
+
 func newTypedRateLimitingQueue[T comparable](name string, rateLimiter workqueue.TypedRateLimiter[T]) workqueue.TypedRateLimitingInterface[T] {
 	if rateLimiter == nil {
 		rateLimiter = workqueue.DefaultTypedControllerRateLimiter[T]()
@@ -1122,8 +1133,6 @@ func (c *Controller) Run(ctx context.Context) {
 }
 
 func (c *Controller) dbStatus() {
-	const maxFailures = 5
-
 	done := make(chan error, 2)
 	go func() {
 		done <- c.OVNNbClient.Echo(context.Background())
@@ -1141,17 +1150,17 @@ func (c *Controller) dbStatus() {
 			resultsReceived++
 			if err != nil {
 				c.dbFailureCount++
-				klog.Errorf("OVN database echo failed (%d/%d): %v", c.dbFailureCount, maxFailures, err)
-				if c.dbFailureCount >= maxFailures {
-					util.LogFatalAndExit(err, "OVN database connection failed after %d attempts", maxFailures)
+				klog.Errorf("OVN database echo failed (%d/%d): %v", c.dbFailureCount, dbStatusMaxFailures, err)
+				if dbStatusFailureExceeded(c.dbFailureCount) {
+					util.LogFatalAndExit(err, "OVN database connection failed after %d attempts", dbStatusMaxFailures)
 				}
 				return
 			}
 		case <-timeout:
 			c.dbFailureCount++
-			klog.Errorf("OVN database echo timeout (%d/%d) after %ds", c.dbFailureCount, maxFailures, c.config.OvnTimeout)
-			if c.dbFailureCount >= maxFailures {
-				util.LogFatalAndExit(nil, "OVN database connection timeout after %d attempts", maxFailures)
+			klog.Errorf("OVN database echo timeout (%d/%d) after %ds", c.dbFailureCount, dbStatusMaxFailures, c.config.OvnTimeout)
+			if dbStatusFailureExceeded(c.dbFailureCount) {
+				util.LogFatalAndExit(nil, "OVN database connection timeout after %d attempts", dbStatusMaxFailures)
 			}
 			return
 		}
@@ -1522,7 +1531,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 
 	go wait.Until(runWorker("delete vm", c.deleteVMQueue, c.handleDeleteVM), time.Second, ctx.Done())
 
-	go wait.Until(c.dbStatus, 15*time.Second, ctx.Done())
+	go wait.Until(c.dbStatus, dbStatusInterval, ctx.Done())
 }
 
 func (c *Controller) allSubnetReady(subnets ...string) (bool, error) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
@@ -51,6 +52,18 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	os.Exit(m.Run())
+}
+
+func TestDBStatusFailureWindowAllowsTLSRotation(t *testing.T) {
+	if got := (dbStatusMaxFailures - 1) * dbStatusInterval; got < 2*time.Minute {
+		t.Fatalf("database health check failure window = %v, want at least 2m", got)
+	}
+	if dbStatusFailureExceeded(dbStatusMaxFailures - 1) {
+		t.Fatalf("database health check must not exit before %d failures during TLS rotation", dbStatusMaxFailures)
+	}
+	if !dbStatusFailureExceeded(dbStatusMaxFailures) {
+		t.Fatalf("database health check must exit after %d failures", dbStatusMaxFailures)
+	}
 }
 
 type fakeControllerInformers struct {


### PR DESCRIPTION
## Summary

Backport the TLS rotation database health-check fix to release-1.16.

During TLS Secret rotation, OVN central can reload before projected Secret files reach kube-ovn-controller. The old five-failure budget could restart the controller during this expected transition. The backport uses eleven checks at a 15-second interval; because the first check runs immediately, the fatal threshold is reached after 150 seconds. Sustained database outages still terminate the controller.

Includes the policy regression test.