### PR TITLE
fix(speaker): refresh announced next hops during reconcile

### DIFF
--- a/pkg/speaker/bgp.go
+++ b/pkg/speaker/bgp.go
@@ -8,7 +8,6 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/set"
 
@@ -44,19 +43,22 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 		TableType: api.TableType_TABLE_TYPE_GLOBAL,
 		Family:    apiutil.ToFamily(&api.Family{Afi: afi, Safi: api.Family_SAFI_UNICAST}),
 	}
+	currentNextHops := c.currentNextHops(afi)
 
 	// Anonymous function that stores the prefixes we are announcing for this AFI
 	existingPrefixes := set.New[string]()
 	fn := func(prefix bgp.NLRI, paths []*apiutil.Path) {
+		existingNextHops := make(set.Set[string])
 		for _, path := range paths {
+			if path.PeerASN != 0 {
+				continue
+			}
 			nextHop := getNextHopFromPathAttributes(path.Attrs)
 			klog.V(5).Infof("announcing route with prefix %s and nexthop: %s", prefix, nextHop)
-
-			route, _ := netlink.RouteGet(nextHop)
-			if len(route) == 1 && route[0].Type == unix.RTN_LOCAL || nextHop.Equal(c.config.RouterID) {
-				existingPrefixes.Insert(prefix.String())
-				return
-			}
+			existingNextHops.Insert(nextHop.String())
+		}
+		if existingNextHops.Equal(currentNextHops) {
+			existingPrefixes.Insert(prefix.String())
 		}
 	}
 
@@ -70,6 +72,21 @@ func (c *Controller) reconcileIPFamily(afi api.Family_Afi, expectedPrefixes pref
 	// Announce routes we should be announcing and withdraw the ones that are no longer valid
 	c.announceAndWithdraw(expectedPrefixes[afi], existingPrefixes)
 	return nil
+}
+
+func (c *Controller) currentNextHops(afi api.Family_Afi) set.Set[string] {
+	neighborAddresses := c.config.NeighborAddresses
+	if c.config.ExtendedNexthop {
+		neighborAddresses = append(append([]net.IP{}, neighborAddresses...), c.config.NeighborIPv6Addresses...)
+	} else if afi == api.Family_AFI_IP6 {
+		neighborAddresses = c.config.NeighborIPv6Addresses
+	}
+
+	nextHops := make(set.Set[string])
+	for _, neighborAddress := range neighborAddresses {
+		nextHops.Insert(c.getNextHopAttribute(neighborAddress).String())
+	}
+	return nextHops
 }
 
 // announceAndWithdraw commands the BGP speaker to start announcing new routes and to withdraw others
@@ -202,8 +219,12 @@ func (c *Controller) getPathRequest(route string) ([][]*apiutil.Path, error) {
 func (c *Controller) getNextHopAttribute(neighborAddress net.IP) net.IP {
 	nextHop := c.config.RouterID // If no route is found, fallback to router ID
 
-	// Retrieve the route we use to speak to this neighbor and consider the source as next hop
-	routes, err := netlink.RouteGet(neighborAddress)
+	// Retrieve the route we use to speak to this neighbor and consider the source as next hop.
+	routeLookup := netlink.RouteGet
+	if c.config.routeLookup != nil {
+		routeLookup = c.config.routeLookup
+	}
+	routes, err := routeLookup(neighborAddress)
 	if err == nil && len(routes) == 1 && routes[0].Src != nil {
 		nextHop = routes[0].Src
 	}

--- a/pkg/speaker/bgp_test.go
+++ b/pkg/speaker/bgp_test.go
@@ -1,0 +1,79 @@
+package speaker
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	gobgp "github.com/osrg/gobgp/v4/pkg/server"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"k8s.io/utils/set"
+)
+
+func newSpeakerTestBgpServer(t *testing.T, routerID string) *gobgp.BgpServer {
+	t.Helper()
+
+	server := gobgp.NewBgpServer()
+	go server.Serve()
+	require.NoError(t, server.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{Asn: 65000, RouterId: routerID, ListenPort: -1},
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, server.StopBgp(context.Background(), &api.StopBgpRequest{}))
+		server.Stop()
+	})
+	return server
+}
+
+func speakerTestPrefixNextHops(t *testing.T, server *gobgp.BgpServer, afi api.Family_Afi) map[string][]net.IP {
+	t.Helper()
+
+	prefixes := map[string][]net.IP{}
+	err := server.ListPath(apiutil.ListPathRequest{
+		TableType: api.TableType_TABLE_TYPE_GLOBAL,
+		Family:    apiutil.ToFamily(&api.Family{Afi: afi, Safi: api.Family_SAFI_UNICAST}),
+	}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
+		for _, path := range paths {
+			prefixes[prefix.String()] = append(prefixes[prefix.String()], getNextHopFromPathAttributes(path.Attrs))
+		}
+	})
+	require.NoError(t, err)
+	return prefixes
+}
+
+func TestReconcileRoutesRefreshesIPv4NextHop(t *testing.T) {
+	const (
+		routerID       = "192.0.2.254"
+		neighbor       = "203.0.113.1"
+		prefix         = "10.244.0.8/32"
+		initialNextHop = "127.0.0.2"
+		updatedNextHop = "127.0.0.3"
+	)
+
+	nextHop := net.ParseIP(initialNextHop)
+	controller := &Controller{config: &Configuration{
+		RouterID:          net.ParseIP(routerID),
+		NeighborAddresses: []net.IP{net.ParseIP(neighbor)},
+		BgpServer:         newSpeakerTestBgpServer(t, routerID),
+		routeLookup: func(address net.IP) ([]netlink.Route, error) {
+			require.True(t, net.ParseIP(neighbor).Equal(address))
+			return []netlink.Route{{Src: nextHop}}, nil
+		},
+	}}
+	expectedPrefixes := prefixMap{api.Family_AFI_IP: set.New(prefix)}
+
+	require.NoError(t, controller.reconcileRoutes(expectedPrefixes))
+	routes := speakerTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
+	require.Len(t, routes[prefix], 1)
+	require.True(t, net.ParseIP(initialNextHop).Equal(routes[prefix][0]))
+
+	nextHop = net.ParseIP(updatedNextHop)
+	require.NoError(t, controller.reconcileRoutes(expectedPrefixes))
+	routes = speakerTestPrefixNextHops(t, controller.config.BgpServer, api.Family_AFI_IP)
+	require.Len(t, routes[prefix], 1)
+	require.True(t, net.ParseIP(updatedNextHop).Equal(routes[prefix][0]))
+}

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 	"github.com/spf13/pflag"
+	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -46,6 +47,7 @@ type Configuration struct {
 	NodeIPs                     map[string]net.IP
 	NeighborAddresses           []net.IP
 	NeighborIPv6Addresses       []net.IP
+	routeLookup                 routeLookupFunc
 	NeighborAs                  uint32
 	AuthPassword                string
 	HoldTime                    float64
@@ -68,6 +70,8 @@ type Configuration struct {
 	PprofPort int32
 	LogPerm   string
 }
+
+type routeLookupFunc func(net.IP) ([]netlink.Route, error)
 
 func ParseFlags() (*Configuration, error) {
 	var (


### PR DESCRIPTION
Backport of #7296 to `release-1.16`.

When the source address selected for a BGP neighbor changes, reconciliation now compares the current next-hop set with all local GoBGP paths and re-announces stale routes. External paths are ignored, and route lookup is resolved once per AFI reconciliation.

The maintenance branch predates the BGP speaker unit and E2E suite introduced by #7241, so this backport keeps the change scoped to the existing 1.16 speaker implementation and adds an equivalent focused regression test with injectable route lookup.

Tests:
- `go test ./pkg/speaker -count=1`
- `git diff --check`
