### PR TITLE
test(bgp): run speaker E2E across IP families

### DIFF
--- a/.github/e2e-selection.json
+++ b/.github/e2e-selection.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "expectedRunnerJobs": 82,
+  "expectedRunnerJobs": 84,
   "forceFull": false,
   "fullThreshold": 3,
   "productionPrefixes": ["cmd/", "fastpath/", "pkg/", "versions/"],
@@ -177,7 +177,7 @@
     },
     "bgp-routing": {
       "jobs": [
-        {"id": "bgp-speaker-e2e"}
+        {"id": "bgp-speaker-e2e", "matrix": {"ip-family": ["ipv4", "ipv6", "dual"]}}
       ]
     },
     "multi-cni": {

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -2210,7 +2210,7 @@ jobs:
           path: non-primary-cni-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
   bgp-speaker-e2e:
-    name: BGP Speaker E2E
+    name: BGP Speaker E2E (${{ matrix.ip-family }})
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'bgp-speaker-e2e')
     needs:
       - e2e-selection
@@ -2219,6 +2219,13 @@ jobs:
       - build-e2e-binaries
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        ip-family:
+          - ipv4
+          - ipv6
+          - dual
     steps:
       - uses: jlumbroso/free-disk-space@v1.3.1
         with:
@@ -2303,18 +2310,18 @@ jobs:
         id: setup
         run: |
           pipx install jinjanator
-          make kind-init-bgp
+          make kind-init-bgp-${{ matrix.ip-family }}
 
       - name: Install Kube-OVN and BGP speakers
         id: install
-        run: make kind-install-bgp
+        run: make kind-install-bgp-${{ matrix.ip-family }}
 
       - name: Run BGP speaker E2E
         id: e2e
         working-directory: ${{ env.E2E_DIR }}
         env:
           E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
-          E2E_IP_FAMILY: ipv4
+          E2E_IP_FAMILY: ${{ matrix.ip-family }}
           E2E_NETWORK_MODE: overlay
         run: make kube-ovn-bgp-speaker-e2e
 
@@ -2327,8 +2334,10 @@ jobs:
         if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           mkdir -p bgp-speaker-e2e-diagnostics
-          docker exec clab-bgp-router vtysh -c "show bgp ipv4 unicast summary json" > bgp-speaker-e2e-diagnostics/frr-summary.json || true
-          docker exec clab-bgp-router vtysh -c "show bgp ipv4 unicast json" > bgp-speaker-e2e-diagnostics/frr-routes.json || true
+          for afi in ipv4 ipv6; do
+            docker exec clab-bgp-router vtysh -c "show bgp $afi unicast summary json" > "bgp-speaker-e2e-diagnostics/frr-summary-$afi.json" || true
+            docker exec clab-bgp-router vtysh -c "show bgp $afi unicast json" > "bgp-speaker-e2e-diagnostics/frr-routes-$afi.json" || true
+          done
           kubectl -n kube-system get ds kube-ovn-speaker -o yaml > bgp-speaker-e2e-diagnostics/speaker-daemonset.yaml || true
           kubectl -n kube-system get pods -l app=kube-ovn-speaker -o wide > bgp-speaker-e2e-diagnostics/speaker-pods.txt || true
           kubectl -n kube-system logs -l app=kube-ovn-speaker --all-containers --prefix > bgp-speaker-e2e-diagnostics/speaker.log || true
@@ -2340,25 +2349,25 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: bgp-speaker-e2e-diagnostics
+          name: bgp-speaker-e2e-diagnostics-${{ matrix.ip-family }}
           path: bgp-speaker-e2e-diagnostics.tar.gz
 
       - name: kubectl ko log
         if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         run: |
           if make kubectl-ko-log && test -f kubectl-ko-log.tar.gz; then
-            mv kubectl-ko-log.tar.gz bgp-speaker-e2e-ko-log.tar.gz
+            mv kubectl-ko-log.tar.gz bgp-speaker-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
           else
             echo "kubectl ko log was unavailable because the BGP test cluster did not become usable." > bgp-speaker-e2e-ko-log-unavailable.txt
-            tar zcf bgp-speaker-e2e-ko-log.tar.gz bgp-speaker-e2e-ko-log-unavailable.txt
+            tar zcf bgp-speaker-e2e-${{ matrix.ip-family }}-ko-log.tar.gz bgp-speaker-e2e-ko-log-unavailable.txt
           fi
 
       - name: Upload kubectl ko log
         uses: actions/upload-artifact@v7
         if: failure() && (steps.setup.conclusion == 'failure' || steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
         with:
-          name: bgp-speaker-e2e-ko-log
-          path: bgp-speaker-e2e-ko-log.tar.gz
+          name: bgp-speaker-e2e-ko-log-${{ matrix.ip-family }}
+          path: bgp-speaker-e2e-${{ matrix.ip-family }}-ko-log.tar.gz
 
       - name: Clean BGP topology
         if: always()

--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -24,7 +24,7 @@ infrastructureJobs = {
     "publish-pr-e2e-checks",
     "push",
 }
-expectedX86RunnerJobs = 82
+expectedX86RunnerJobs = 84
 mandatorySmoke = [
     {"job": "kube-ovn-conformance-e2e", "ip-family": "ipv4", "mode": "overlay"},
     {"job": "kube-ovn-conformance-e2e", "ip-family": "ipv4", "mode": "underlay"},

--- a/hack/test_e2e_selector.py
+++ b/hack/test_e2e_selector.py
@@ -139,7 +139,7 @@ class E2ESelectorTest(unittest.TestCase):
         executionPlan = e2eSelector.executionPlan(self.catalog, plan, "pull_request")
 
         self.assertTrue(executionPlan["full"])
-        self.assertEqual(len(executionPlan["matrix"]), 82)
+        self.assertEqual(len(executionPlan["matrix"]), 84)
 
     def testTrustedDispatchExecutesRecommendedAndRequestedCoverage(self):
         plan = self.select(
@@ -153,13 +153,13 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertEqual(executionPlan["recommendedGroups"], [])
         self.assertFalse(executionPlan["approvalRequired"])
         self.assertEqual(executionPlan["executionMode"], "approved")
-        self.assertEqual(len(executionPlan["matrix"]), 19)
+        self.assertEqual(len(executionPlan["matrix"]), 21)
         summary = e2eSelector.renderSummary(
             executionPlan,
             ["test/e2e/cnp-domain/e2e_test.go"],
         )
         self.assertIn("Approval required: `no`", summary)
-        self.assertIn("Authorized coverage: approved selection &#40;19 runner jobs&#41;", summary)
+        self.assertIn("Authorized coverage: approved selection &#40;21 runner jobs&#41;", summary)
         self.assertIn("Authorized coverage is executing for this HEAD", summary)
         self.assertNotIn("deferred groups wait", summary)
         self.assertNotIn("Waiting for:", summary)
@@ -170,7 +170,7 @@ class E2ESelectorTest(unittest.TestCase):
         executionPlan = e2eSelector.executionPlan(self.catalog, plan, "push")
 
         self.assertTrue(executionPlan["full"])
-        self.assertEqual(len(executionPlan["matrix"]), 82)
+        self.assertEqual(len(executionPlan["matrix"]), 84)
 
     def testExplicitForceFullReasonOverridesAVisibleSafeFileList(self):
         plan = e2eSelector.select(
@@ -183,7 +183,7 @@ class E2ESelectorTest(unittest.TestCase):
         )
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 82)
+        self.assertEqual(len(plan["matrix"]), 84)
         self.assertIn("file list is incomplete", plan["fullReason"])
 
     def testPathsLabelsAndRequestsAreUnioned(self):
@@ -217,14 +217,14 @@ class E2ESelectorTest(unittest.TestCase):
         )
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 82)
+        self.assertEqual(len(plan["matrix"]), 84)
         self.assertIn("matched 3 test groups", plan["fullReason"])
 
     def testUnknownProductionPathPromotesToFull(self):
         plan = self.select(["pkg/new-component/new_feature.go"])
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 82)
+        self.assertEqual(len(plan["matrix"]), 84)
         self.assertIn("unclassified production path", plan["fullReason"])
 
     def testCommonPathPromotesToFull(self):
@@ -247,7 +247,7 @@ class E2ESelectorTest(unittest.TestCase):
             with self.subTest(path=path):
                 plan = self.select([path])
                 self.assertTrue(plan["full"])
-                self.assertEqual(len(plan["matrix"]), 82)
+                self.assertEqual(len(plan["matrix"]), 84)
                 self.assertIn("shared path", plan["fullReason"])
 
     def testInstallationBuildAndCodegenPathsPromoteToFull(self):
@@ -262,7 +262,7 @@ class E2ESelectorTest(unittest.TestCase):
             with self.subTest(path=path):
                 plan = self.select([path])
                 self.assertTrue(plan["full"])
-                self.assertEqual(len(plan["matrix"]), 82)
+                self.assertEqual(len(plan["matrix"]), 84)
                 self.assertIn("shared path", plan["fullReason"])
 
     def testSharedE2ESourcesSelectEveryExecutingGroup(self):
@@ -325,7 +325,7 @@ class E2ESelectorTest(unittest.TestCase):
             with self.subTest(script=script):
                 plan = self.select([script])
                 self.assertTrue(plan["full"])
-                self.assertEqual(len(plan["matrix"]), 82)
+                self.assertEqual(len(plan["matrix"]), 84)
 
     def testSharedE2EMakeScriptsPromoteToFull(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
@@ -352,13 +352,13 @@ class E2ESelectorTest(unittest.TestCase):
             with self.subTest(script=script):
                 plan = self.select([script])
                 self.assertTrue(plan["full"])
-                self.assertEqual(len(plan["matrix"]), 82)
+                self.assertEqual(len(plan["matrix"]), 84)
 
     def testForceFullLabelPromotesToFull(self):
         plan = self.select(["docs/design.md"], labels=["e2e:full"])
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 82)
+        self.assertEqual(len(plan["matrix"]), 84)
         self.assertEqual(plan["fullReason"], "label e2e:full requested the full suite")
 
     def testRequestedFullIsNotReportedAsAutomaticCoverage(self):
@@ -375,7 +375,7 @@ class E2ESelectorTest(unittest.TestCase):
         self.assertTrue(plan["requestedFull"])
         self.assertEqual(plan["automaticGroups"], [])
         self.assertEqual(plan["selectedGroups"], sorted(self.catalog["groups"]))
-        self.assertEqual(len(plan["matrix"]), 82)
+        self.assertEqual(len(plan["matrix"]), 84)
         self.assertEqual(plan["fullReason"], "authorized request selected the full suite")
         executionPlan = e2eSelector.executionPlan(
             self.catalog,
@@ -386,9 +386,9 @@ class E2ESelectorTest(unittest.TestCase):
             executionPlan,
             ["test/e2e/cnp-domain/e2e_test.go"],
         )
-        self.assertIn("Authorized coverage: full suite &#40;82 runner jobs&#41;", summary)
+        self.assertIn("Authorized coverage: full suite &#40;84 runner jobs&#41;", summary)
         self.assertNotIn("Automatic coverage: mandatory smoke", summary)
-        self.assertIn("Runner jobs in this run: 82", summary)
+        self.assertIn("Runner jobs in this run: 84", summary)
 
     def testInvalidRequestedGroupFails(self):
         with self.assertRaisesRegex(ValueError, "unknown requested group"):
@@ -449,7 +449,7 @@ class E2ESelectorTest(unittest.TestCase):
                     )
                     result = json.loads(plan.read_text())
                     self.assertTrue(result["full"])
-                    self.assertEqual(len(result["matrix"]), 82)
+                    self.assertEqual(len(result["matrix"]), 84)
                     self.assertIn("selection error", result["fullReason"])
 
     def testPlanIsJsonSerializableAndBoundToHead(self):
@@ -572,7 +572,7 @@ class E2ESelectorTest(unittest.TestCase):
                     result = json.loads(plan.read_text())
                     self.assertTrue(result["full"])
                     self.assertEqual(result["headSHA"], "0123456789abcdef")
-                    self.assertEqual(len(result["matrix"]), 82)
+                    self.assertEqual(len(result["matrix"]), 84)
                     self.assertIn("catalog error", result["fullReason"])
                     self.assertIn("Full suite: `yes`", summary.read_text())
 
@@ -596,11 +596,11 @@ class E2ESelectorTest(unittest.TestCase):
             inlineWorkflow,
             "catalog",
         )
-        self.assertEqual(len(plan["matrix"]), 82)
+        self.assertEqual(len(plan["matrix"]), 84)
         executionPlan = e2eSelector.executionPlan(None, plan, "pull_request")
         self.assertEqual(executionPlan, {**plan, "executionMode": "automatic"})
         summary = e2eSelector.renderSummary(executionPlan, [])
-        self.assertIn("Automatic coverage: full suite &#40;82 runner jobs&#41;", summary)
+        self.assertIn("Automatic coverage: full suite &#40;84 runner jobs&#41;", summary)
         self.assertIn("Groups executing in this run: full suite", summary)
         self.assertNotIn("Groups executing in this run: smoke only", summary)
 
@@ -645,7 +645,7 @@ class E2ESelectorTest(unittest.TestCase):
                     )
                     result = json.loads(plan.read_text())
                     self.assertTrue(result["full"])
-                    self.assertEqual(len(result["matrix"]), 82)
+                    self.assertEqual(len(result["matrix"]), 84)
                     self.assertIn("selection error", result["fullReason"])
 
     def testSelectorFilesHaveCodeOwners(self):
@@ -721,7 +721,7 @@ class E2ESelectorTest(unittest.TestCase):
         plan = self.select(["test/e2e/framework/pod.go"])
 
         self.assertTrue(plan["full"])
-        self.assertEqual(len(plan["matrix"]), 82)
+        self.assertEqual(len(plan["matrix"]), 84)
 
 
 if __name__ == "__main__":

--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -195,7 +195,7 @@ kube-ovn-bgp-speaker-e2e:
 	$(call kind_load_image,kube-ovn,$(AGNHOST_IMAGE),1)
 	$(GINKGO_E2E_BUILD) ./test/e2e/bgp
 	E2E_BRANCH=$(E2E_BRANCH) \
-	E2E_IP_FAMILY=ipv4 \
+	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=overlay \
 	$(GINKGO_E2E_RUN) --timeout=15m \
 		--focus="group:bgp-speaker" ./test/e2e/bgp/bgp.test -- $(TEST_BIN_ARGS)

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -212,8 +212,12 @@ kind-init-single-%:
 	@single=true $(MAKE) kind-init-$*
 
 .PHONY: kind-init-bgp
-kind-init-bgp: kind-clean-bgp kind-init
-	kube_ovn_version=$(VERSION) frr_image=$(FRR_IMAGE) jinjanate yamls/clab-bgp.yaml.j2 -o yamls/clab-bgp.yaml
+kind-init-bgp: kind-init-bgp-ipv4
+
+.PHONY: kind-init-bgp-%
+kind-init-bgp-%: kind-clean-bgp
+	@$(MAKE) kind-init-$*
+	kube_ovn_version=$(VERSION) frr_image=$(FRR_IMAGE) ip_family=$* jinjanate yamls/clab-bgp.yaml.j2 -o yamls/clab-bgp.yaml
 	docker run --rm --privileged \
 		--name kube-ovn-bgp \
 		--network host \
@@ -693,18 +697,37 @@ kind-install-cilium-delegate-%:
 	kubectl -n kube-system rollout status ds cilium --timeout 120s
 
 .PHONY: kind-install-bgp
-kind-install-bgp: kind-install
+kind-install-bgp: kind-install-bgp-ipv4
+
+.PHONY: kind-install-bgp-%
+kind-install-bgp-%: kind-install-%
 	kubectl label node --all ovn.kubernetes.io/bgp=true
 	kubectl annotate subnet ovn-default ovn.kubernetes.io/bgp=local
+	@case "$*" in \
+		ipv6) neighbor_sed='s/--neighbor-address=.*/--neighbor-ipv6-address=fd00:10:1::1/' ;; \
+		*) neighbor_sed='s/--neighbor-address=.*/--neighbor-address=10.0.1.1/' ;; \
+	esac; \
 	sed -e 's#image: .*#image: $(REGISTRY)/kube-ovn:$(VERSION)#' \
-		-e 's/--neighbor-address=.*/--neighbor-address=10.0.1.1/' \
+		-e "$$neighbor_sed" \
 		-e 's/--neighbor-as=.*/--neighbor-as=65001/' \
 		-e 's/--cluster-as=.*/--cluster-as=65002/' yamls/speaker.yaml | \
 		kubectl apply -f -
+	@if [ "$*" = dual ]; then \
+		kubectl -n kube-system patch ds kube-ovn-speaker --type=json \
+			-p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--neighbor-ipv6-address=fd00:10:1::1"}]'; \
+	fi
+	@if [ "$*" = ipv6 ]; then \
+		kubectl -n kube-system patch ds kube-ovn-speaker --type=json \
+			-p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--router-id=10.0.1.2"}]'; \
+	fi
 	kubectl -n kube-system patch ds kube-ovn-speaker --type=json \
 		-p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--announce-cluster-ip=true"}]'
 	kubectl -n kube-system rollout status ds kube-ovn-speaker --timeout 60s
-	docker exec clab-bgp-router vtysh -c "show ip route bgp"
+	@if [ "$*" = ipv6 ]; then \
+		docker exec clab-bgp-router vtysh -c "show ipv6 route bgp"; \
+	else \
+		docker exec clab-bgp-router vtysh -c "show ip route bgp"; \
+	fi
 
 .PHONY: kind-install-bgp-ha
 kind-install-bgp-ha: kind-install

--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -116,7 +116,6 @@ func bgpPeersEstablished(family bgpFamily) (bool, error) {
 func waitForBGPPeers(f *framework.Framework) {
 	ginkgo.GinkgoHelper()
 	for _, family := range bgpFamilies(f) {
-		family := family
 		framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
 			established, err := bgpPeersEstablished(family)
 			if err != nil {
@@ -187,7 +186,7 @@ func waitForRouteWithdrawal(family bgpFamily, prefix string) {
 func prefixForFamily(addresses string, family bgpFamily) string {
 	ginkgo.GinkgoHelper()
 	wantIPv6 := family.name == "ipv6"
-	for _, address := range strings.Split(addresses, ",") {
+	for address := range strings.SplitSeq(addresses, ",") {
 		address = strings.TrimSpace(address)
 		if address == "" {
 			continue
@@ -339,7 +338,6 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 
 		ginkgo.By("Changing the worker route source address without restarting the speaker")
 		for _, family := range bgpFamilies(f) {
-			family := family
 			framework.ExpectNoError(addWorkerSourceAddress(family))
 			framework.ExpectNoError(updateWorkerRoute(family))
 			ginkgo.DeferCleanup(func() {

--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -27,12 +27,29 @@ import (
 )
 
 const (
-	frrRouterContainer   = "clab-bgp-router"
-	workerNode           = "kube-ovn-worker"
-	controlPlaneAddress  = "10.0.1.2"
-	workerAddress        = "10.0.1.3"
-	updatedWorkerAddress = "10.0.1.4"
+	frrRouterContainer = "clab-bgp-router"
+	workerNode         = "kube-ovn-worker"
 )
+
+type bgpFamily struct {
+	name, controlPlaneAddress, workerAddress, updatedWorkerAddress string
+}
+
+var (
+	ipv4Family = bgpFamily{"ipv4", "10.0.1.2", "10.0.1.3", "10.0.1.4"}
+	ipv6Family = bgpFamily{"ipv6", "fd00:10:1::2", "fd00:10:1::3", "fd00:10:1::4"}
+)
+
+func bgpFamilies(f *framework.Framework) []bgpFamily {
+	families := make([]bgpFamily, 0, 2)
+	if f.HasIPv4() {
+		families = append(families, ipv4Family)
+	}
+	if f.HasIPv6() {
+		families = append(families, ipv6Family)
+	}
+	return families
+}
 
 type frrSummary struct {
 	Peers map[string]struct {
@@ -74,8 +91,8 @@ func runNodeCommand(node string, args ...string) error {
 	return nil
 }
 
-func bgpPeersEstablished() (bool, error) {
-	output, err := runFRR("show bgp ipv4 unicast summary json")
+func bgpPeersEstablished(family bgpFamily) (bool, error) {
+	output, err := runFRR("show bgp " + family.name + " unicast summary json")
 	if err != nil {
 		return false, err
 	}
@@ -84,7 +101,7 @@ func bgpPeersEstablished() (bool, error) {
 		return false, fmt.Errorf("failed to parse FRR BGP summary: %w: %s", err, output)
 	}
 	if len(summary.Peers) != 2 {
-		framework.Logf("Expected two FRR BGP peers, got %d; output=%s", len(summary.Peers), output)
+		framework.Logf("Expected two %s FRR BGP peers, got %d; output=%s", family.name, len(summary.Peers), output)
 		return false, nil
 	}
 	for address, peer := range summary.Peers {
@@ -96,39 +113,42 @@ func bgpPeersEstablished() (bool, error) {
 	return true, nil
 }
 
-func waitForBGPPeers() {
+func waitForBGPPeers(f *framework.Framework) {
 	ginkgo.GinkgoHelper()
-	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
-		established, err := bgpPeersEstablished()
-		if err != nil {
-			framework.Logf("Failed to read FRR BGP peers: %v", err)
-			return false, nil
-		}
-		return established, nil
-	}, "both BGP speaker peers to become Established")
+	for _, family := range bgpFamilies(f) {
+		family := family
+		framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+			established, err := bgpPeersEstablished(family)
+			if err != nil {
+				framework.Logf("Failed to read %s FRR BGP peers: %v", family.name, err)
+				return false, nil
+			}
+			return established, nil
+		}, "both "+family.name+" BGP speaker peers to become Established")
+	}
 }
 
-func readFRRRoute(prefix string) (*frrRoute, error) {
-	return readFRRRouteWithRunner(prefix, runFRR)
+func readFRRRoute(prefix string, family bgpFamily) (*frrRoute, error) {
+	return readFRRRouteWithFamilyWithRunner(prefix, family.name, runFRR)
 }
 
-func routePaths(prefix string) ([]frrRoutePath, error) {
-	route, err := readFRRRoute(prefix)
+func routePaths(prefix string, family bgpFamily) ([]frrRoutePath, error) {
+	route, err := readFRRRoute(prefix, family)
 	if err != nil {
 		return nil, err
 	}
 	return routePathsFromRoute(route), nil
 }
 
-func waitForRoutePaths(prefix string, expected ...frrRoutePath) {
+func waitForRoutePaths(family bgpFamily, prefix string, expected ...frrRoutePath) {
 	ginkgo.GinkgoHelper()
 	sortRoutePaths(expected)
 	var lastObserved []frrRoutePath
 	haveObservation := false
 	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
-		paths, err := routePaths(prefix)
+		paths, err := routePaths(prefix, family)
 		if err != nil {
-			framework.Logf("Failed to read FRR route %s: %v", prefix, err)
+			framework.Logf("Failed to read %s FRR route %s: %v", family.name, prefix, err)
 			return false, nil
 		}
 		if slices.Equal(paths, expected) {
@@ -143,46 +163,90 @@ func waitForRoutePaths(prefix string, expected ...frrRoutePath) {
 	}, fmt.Sprintf("route %s to have paths %v", prefix, expected))
 }
 
-func waitForRouteWithdrawal(prefix string) {
+func waitForRouteWithdrawal(family bgpFamily, prefix string) {
 	ginkgo.GinkgoHelper()
 	framework.WaitUntil(2*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
-		established, err := bgpPeersEstablished()
+		established, err := bgpPeersEstablished(family)
 		if err != nil {
-			framework.Logf("Failed to read FRR BGP peers while waiting for route %s withdrawal: %v", prefix, err)
+			framework.Logf("Failed to read %s FRR BGP peers while waiting for route %s withdrawal: %v", family.name, prefix, err)
 			return false, nil
 		}
 		if !established {
 			return false, nil
 		}
 
-		route, err := readFRRRoute(prefix)
+		route, err := readFRRRoute(prefix, family)
 		if err != nil {
-			framework.Logf("Failed to read FRR route %s while waiting for withdrawal: %v", prefix, err)
+			framework.Logf("Failed to read %s FRR route %s while waiting for withdrawal: %v", family.name, prefix, err)
 			return false, nil
 		}
 		return len(route.Paths) == 0, nil
 	}, fmt.Sprintf("route %s to be absent while both BGP peers remain Established", prefix))
 }
 
-func ipv4Prefix(address string) string {
+func prefixForFamily(addresses string, family bgpFamily) string {
 	ginkgo.GinkgoHelper()
-	address = strings.TrimSpace(strings.Split(address, ",")[0])
-	if strings.Contains(address, "/") {
-		prefix, err := netip.ParsePrefix(address)
+	wantIPv6 := family.name == "ipv6"
+	for _, address := range strings.Split(addresses, ",") {
+		address = strings.TrimSpace(address)
+		if address == "" {
+			continue
+		}
+		if strings.Contains(address, "/") {
+			prefix, err := netip.ParsePrefix(address)
+			framework.ExpectNoError(err)
+			if prefix.Addr().Is6() == wantIPv6 {
+				return prefix.Masked().String()
+			}
+			continue
+		}
+		addr, err := netip.ParseAddr(address)
 		framework.ExpectNoError(err)
-		return prefix.Masked().String()
+		if addr.Is6() == wantIPv6 {
+			return netip.PrefixFrom(addr, addr.BitLen()).String()
+		}
 	}
-	addr, err := netip.ParseAddr(address)
-	framework.ExpectNoError(err)
-	return netip.PrefixFrom(addr, addr.BitLen()).String()
+	framework.ExpectNoError(fmt.Errorf("no %s address found in %q", family.name, addresses))
+	return ""
 }
 
-func createPodOnNode(f *framework.Framework, name, nodeName string) (*corev1.Pod, string) {
+func createPodOnNode(f *framework.Framework, name, nodeName string) (*corev1.Pod, map[string]string) {
 	ginkgo.GinkgoHelper()
 	pod := framework.MakePod(f.Namespace.Name, name, nil, nil, framework.AgnhostImage, nil, nil)
 	pod.Spec.NodeName = nodeName
 	pod = f.PodClient().CreateSync(pod)
-	return pod, ipv4Prefix(pod.Annotations[util.IPAddressAnnotation])
+	prefixes := make(map[string]string, 2)
+	for _, family := range bgpFamilies(f) {
+		prefixes[family.name] = prefixForFamily(pod.Annotations[util.IPAddressAnnotation], family)
+	}
+	return pod, prefixes
+}
+
+func updateWorkerRoute(family bgpFamily) error {
+	if family.name == "ipv6" {
+		return runNodeCommand(workerNode, "ip", "-6", "route", "replace", "fd00:10:1::1/128", "dev", "net1", "src", family.updatedWorkerAddress)
+	}
+	return runNodeCommand(workerNode, "ip", "route", "replace", "10.0.1.1/32", "dev", "net1", "src", family.updatedWorkerAddress)
+}
+
+func addWorkerSourceAddress(family bgpFamily) error {
+	if family.name == "ipv6" {
+		return runNodeCommand(workerNode, "ip", "-6", "addr", "add", family.updatedWorkerAddress+"/64", "dev", "net1")
+	}
+	return runNodeCommand(workerNode, "ip", "addr", "add", family.updatedWorkerAddress+"/24", "dev", "net1")
+}
+
+func removeWorkerSourceAddress(family bgpFamily) error {
+	if family.name == "ipv6" {
+		if err := runNodeCommand(workerNode, "ip", "-6", "route", "del", "fd00:10:1::1/128"); err != nil {
+			return err
+		}
+		return runNodeCommand(workerNode, "ip", "-6", "addr", "del", family.updatedWorkerAddress+"/64", "dev", "net1")
+	}
+	if err := runNodeCommand(workerNode, "ip", "route", "del", "10.0.1.1/32"); err != nil {
+		return err
+	}
+	return runNodeCommand(workerNode, "ip", "addr", "del", family.updatedWorkerAddress+"/24", "dev", "net1")
 }
 
 func setDefaultSubnetBGPPolicy(f *framework.Framework, policy string) string {
@@ -199,11 +263,15 @@ func setDefaultSubnetBGPPolicy(f *framework.Framework, policy string) string {
 	return oldPolicy
 }
 
-func defaultSubnetIPv4CIDR(f *framework.Framework) string {
+func defaultSubnetCIDRs(f *framework.Framework) map[string]string {
 	ginkgo.GinkgoHelper()
 	subnet, err := f.KubeOVNClientSet.KubeovnV1().Subnets().Get(context.TODO(), util.DefaultSubnet, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	return ipv4Prefix(subnet.Spec.CIDRBlock)
+	cidrs := make(map[string]string, 2)
+	for _, family := range bgpFamilies(f) {
+		cidrs[family.name] = prefixForFamily(subnet.Spec.CIDRBlock, family)
+	}
+	return cidrs
 }
 
 func requireReadySpeakerPodStates(f *framework.Framework) map[string]speakerPodState {
@@ -236,47 +304,50 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 
 	ginkgo.BeforeEach(func() {
 		f.SkipVersionPriorTo(1, 13, "BGP local and cluster announce policies require v1.13+")
-		if !f.IsIPv4() {
-			ginkgo.Skip("the current BGP containerlab topology supports IPv4 only")
-		}
 		requireReadySpeakerPodStates(f)
-		waitForBGPPeers()
+		waitForBGPPeers(f)
 	})
 
 	ginkgo.It("should advertise and withdraw a local Pod route", func() {
 		podName := "local-route-" + framework.RandomSuffix()
-		_, prefix := createPodOnNode(f, podName, workerNode)
+		_, prefixes := createPodOnNode(f, podName, workerNode)
 
 		ginkgo.By("Waiting for the worker speaker to advertise the Pod route")
-		waitForRoutePaths(prefix, validNodeRoutePath(workerAddress))
+		for _, family := range bgpFamilies(f) {
+			waitForRoutePaths(family, prefixes[family.name], validNodeRoutePath(family.workerAddress))
+		}
 
 		ginkgo.By("Deleting the Pod")
 		f.PodClient().DeleteSync(podName)
 
 		ginkgo.By("Waiting for the Pod route to be withdrawn")
-		waitForRouteWithdrawal(prefix)
-		waitForBGPPeers()
+		for _, family := range bgpFamilies(f) {
+			waitForRouteWithdrawal(family, prefixes[family.name])
+		}
+		waitForBGPPeers(f)
 	})
 
 	ginkgo.It("should refresh a Pod route when the node source address changes", func() {
 		podName := "source-refresh-" + framework.RandomSuffix()
-		_, prefix := createPodOnNode(f, podName, workerNode)
+		_, prefixes := createPodOnNode(f, podName, workerNode)
 		ginkgo.DeferCleanup(func() { f.PodClient().DeleteSync(podName) })
 
 		ginkgo.By("Waiting for the worker speaker to advertise the Pod route with its original source address")
-		waitForRoutePaths(prefix, validNodeRoutePath(workerAddress))
+		for _, family := range bgpFamilies(f) {
+			waitForRoutePaths(family, prefixes[family.name], validNodeRoutePath(family.workerAddress))
+		}
 
 		ginkgo.By("Changing the worker route source address without restarting the speaker")
-		framework.ExpectNoError(runNodeCommand(workerNode, "ip", "addr", "add", updatedWorkerAddress+"/24", "dev", "net1"))
-		framework.ExpectNoError(runNodeCommand(workerNode, "ip", "route", "replace", "10.0.1.1/32", "dev", "net1", "src", updatedWorkerAddress))
-		ginkgo.DeferCleanup(func() {
-			if err := runNodeCommand(workerNode, "ip", "route", "del", "10.0.1.1/32"); err != nil {
-				framework.Logf("failed to remove temporary worker route: %v", err)
-			}
-			if err := runNodeCommand(workerNode, "ip", "addr", "del", updatedWorkerAddress+"/24", "dev", "net1"); err != nil {
-				framework.Logf("failed to remove temporary worker address: %v", err)
-			}
-		})
+		for _, family := range bgpFamilies(f) {
+			family := family
+			framework.ExpectNoError(addWorkerSourceAddress(family))
+			framework.ExpectNoError(updateWorkerRoute(family))
+			ginkgo.DeferCleanup(func() {
+				if err := removeWorkerSourceAddress(family); err != nil {
+					framework.Logf("failed to remove temporary %s worker source address: %v", family.name, err)
+				}
+			})
+		}
 
 		ginkgo.By("Triggering a speaker reconcile after the route source change")
 		triggerName := "source-refresh-trigger-" + framework.RandomSuffix()
@@ -284,32 +355,38 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		ginkgo.DeferCleanup(func() { f.PodClient().DeleteSync(triggerName) })
 
 		ginkgo.By("Waiting for the original Pod route to use the refreshed source address")
-		waitForRoutePaths(prefix, validNodeRoutePathWithNextHop(workerAddress, updatedWorkerAddress))
+		for _, family := range bgpFamilies(f) {
+			waitForRoutePaths(family, prefixes[family.name], validNodeRoutePathWithNextHop(family.workerAddress, family.updatedWorkerAddress))
+		}
 	})
 
 	ginkgo.It("should reconcile cluster and local policies without restarting speakers", func() {
 		podName := "policy-route-" + framework.RandomSuffix()
-		_, podPrefix := createPodOnNode(f, podName, workerNode)
+		_, podPrefixes := createPodOnNode(f, podName, workerNode)
 		ginkgo.DeferCleanup(func() { f.PodClient().DeleteSync(podName) })
-		subnetPrefix := defaultSubnetIPv4CIDR(f)
+		subnetPrefixes := defaultSubnetCIDRs(f)
 		initialSpeakers := requireReadySpeakerPodStates(f)
 
 		ginkgo.By("Switching the default subnet to cluster policy")
 		oldPolicy := setDefaultSubnetBGPPolicy(f, "cluster")
 		ginkgo.DeferCleanup(func() { setDefaultSubnetBGPPolicy(f, oldPolicy) })
-		waitForRoutePaths(podPrefix,
-			validNodeRoutePath(controlPlaneAddress),
-			validNodeRoutePath(workerAddress),
-		)
-		waitForRoutePaths(subnetPrefix,
-			validNodeRoutePath(controlPlaneAddress),
-			validNodeRoutePath(workerAddress),
-		)
+		for _, family := range bgpFamilies(f) {
+			waitForRoutePaths(family, podPrefixes[family.name],
+				validNodeRoutePath(family.controlPlaneAddress),
+				validNodeRoutePath(family.workerAddress),
+			)
+			waitForRoutePaths(family, subnetPrefixes[family.name],
+				validNodeRoutePath(family.controlPlaneAddress),
+				validNodeRoutePath(family.workerAddress),
+			)
+		}
 
 		ginkgo.By("Switching the default subnet back to local policy")
 		setDefaultSubnetBGPPolicy(f, "local")
-		waitForRoutePaths(podPrefix, validNodeRoutePath(workerAddress))
-		waitForRouteWithdrawal(subnetPrefix)
+		for _, family := range bgpFamilies(f) {
+			waitForRoutePaths(family, podPrefixes[family.name], validNodeRoutePath(family.workerAddress))
+			waitForRouteWithdrawal(family, subnetPrefixes[family.name])
+		}
 		expectSpeakerPodsUnchanged(f, initialSpeakers)
 	})
 
@@ -339,20 +416,27 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		serviceClient := f.ServiceClient()
 		service = serviceClient.Create(service)
 		ginkgo.DeferCleanup(func() { serviceClient.DeleteSync(serviceName) })
-		servicePrefix := ipv4Prefix(service.Spec.ClusterIP)
+		servicePrefixes := make(map[string]string, 2)
+		for _, family := range bgpFamilies(f) {
+			servicePrefixes[family.name] = prefixForFamily(strings.Join(util.ServiceClusterIPs(*service), ","), family)
+		}
 
 		ginkgo.By("Waiting for both speakers to advertise the ClusterIP")
-		waitForRoutePaths(servicePrefix,
-			validNodeRoutePath(controlPlaneAddress),
-			validNodeRoutePath(workerAddress),
-		)
+		for _, family := range bgpFamilies(f) {
+			waitForRoutePaths(family, servicePrefixes[family.name],
+				validNodeRoutePath(family.controlPlaneAddress),
+				validNodeRoutePath(family.workerAddress),
+			)
+		}
 
 		ginkgo.By("Removing the BGP annotation while keeping the Service")
 		original := serviceClient.Get(serviceName)
 		modified := original.DeepCopy()
 		delete(modified.Annotations, util.BgpAnnotation)
 		service = serviceClient.Patch(original, modified)
-		waitForRouteWithdrawal(servicePrefix)
+		for _, family := range bgpFamilies(f) {
+			waitForRouteWithdrawal(family, servicePrefixes[family.name])
+		}
 
 		current := serviceClient.Get(serviceName)
 		gomega.Expect(current.Spec.ClusterIP).To(gomega.Equal(service.Spec.ClusterIP))

--- a/test/e2e/bgp/frr.go
+++ b/test/e2e/bgp/frr.go
@@ -47,7 +47,11 @@ func sortRoutePaths(paths []frrRoutePath) {
 }
 
 func readFRRRouteWithRunner(prefix string, runner func(string) ([]byte, error)) (*frrRoute, error) {
-	output, err := runner("show bgp ipv4 unicast json")
+	return readFRRRouteWithFamilyWithRunner(prefix, prefixFamily(prefix), runner)
+}
+
+func readFRRRouteWithFamilyWithRunner(prefix, family string, runner func(string) ([]byte, error)) (*frrRoute, error) {
+	output, err := runner("show bgp " + family + " unicast json")
 	if err != nil {
 		return nil, err
 	}
@@ -56,6 +60,13 @@ func readFRRRouteWithRunner(prefix string, runner func(string) ([]byte, error)) 
 		return nil, fmt.Errorf("failed to parse FRR RIB output for %s: %w: %s", prefix, err, output)
 	}
 	return &frrRoute{Paths: rib.Routes[prefix]}, nil
+}
+
+func prefixFamily(prefix string) string {
+	if strings.Contains(prefix, ":") {
+		return "ipv6"
+	}
+	return "ipv4"
 }
 
 func routePathsFromRoute(route *frrRoute) []frrRoutePath {

--- a/test/e2e/bgp/frr_test.go
+++ b/test/e2e/bgp/frr_test.go
@@ -53,3 +53,15 @@ func TestReadFRRRouteWithRunnerUsesFullRIBPeerMetadata(t *testing.T) {
 	require.Equal(t, "show bgp ipv4 unicast json", command)
 	require.Equal(t, []frrRoutePath{{PeerID: "10.0.1.3", NextHop: "10.0.1.3", Valid: true}}, routePathsFromRoute(route))
 }
+
+func TestReadFRRRouteWithRunnerSelectsIPv6RIB(t *testing.T) {
+	const prefix = "fd00:10:16::8/128"
+	var command string
+	route, err := readFRRRouteWithRunner(prefix, func(cmd string) ([]byte, error) {
+		command = cmd
+		return []byte(`{"routes":{"fd00:10:16::8/128":[{"peerId":"fd00:10:1::3","valid":true,"nexthops":[{"ip":"fd00:10:1::3"}]}]}}`), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "show bgp ipv6 unicast json", command)
+	require.Equal(t, []frrRoutePath{{PeerID: "fd00:10:1::3", NextHop: "fd00:10:1::3", Valid: true}}, routePathsFromRoute(route))
+}

--- a/yamls/clab-bgp.yaml.j2
+++ b/yamls/clab-bgp.yaml.j2
@@ -1,3 +1,6 @@
+{%- if ip_family is not defined -%}
+  {%- set ip_family = "ipv4" -%}
+{%- endif -%}
 name: bgp
 topology:
   kinds:
@@ -17,8 +20,15 @@ topology:
       - ip link set net1 master br0
       - ip link set net2 master br0
       - ip link set br0 up
+{%- if ip_family != "ipv6" %}
       - ip address add 10.0.1.1/24 dev br0
       - ip address add 10.0.2.1/24 dev net3
+{%- endif %}
+{%- if ip_family != "ipv4" %}
+      - ip address add fd00:10:1::1/64 dev br0
+      - ip address add fd00:10:2::1/64 dev net3
+{%- endif %}
+{%- if ip_family != "ipv6" %}
       - ip link add vrf-vpn type vrf table 1016
       - ip link set vrf-vpn up
       - ip link add br-vrf-vpn type bridge
@@ -28,6 +38,7 @@ topology:
       - ip link set vxlan1016 master br-vrf-vpn
       - ip link set vxlan1016 up
       - ip link set net3 master vrf-vpn
+{%- endif %}
       - touch /etc/frr/vtysh.conf
       - sed -i -e 's/bgpd=no/bgpd=yes/g' /etc/frr/daemons
       - /usr/lib/frr/frrinit.sh start
@@ -39,27 +50,58 @@ topology:
          -c ' no bgp ebgp-requires-policy'
          -c ' neighbor SERVERS peer-group'
          -c ' neighbor SERVERS remote-as external'
+{%- if ip_family != "ipv6" %}
          -c ' neighbor 10.0.1.2 peer-group SERVERS'
          -c ' neighbor 10.0.1.3 peer-group SERVERS'
+{%- endif %}
+{%- if ip_family != "ipv4" %}
+         -c ' neighbor fd00:10:1::2 peer-group SERVERS'
+         -c ' neighbor fd00:10:1::3 peer-group SERVERS'
+{%- endif %}
+{%- if ip_family != "ipv6" %}
          -c ' address-family ipv4 unicast'
          -c '   redistribute connected'
          -c '  exit-address-family'
+{%- endif %}
+{%- if ip_family != "ipv4" %}
+         -c ' address-family ipv6 unicast'
+         -c '   redistribute connected'
+         -c '  exit-address-family'
+{%- endif %}
          -c '!'
     kube-ovn-control-plane:
       kind: ext-container
       exec:
+{%- if ip_family != "ipv6" %}
       - ip address add 10.0.1.2/24 dev net1
       - ip route add 10.0.0.0/16 via 10.0.1.1
+{%- endif %}
+{%- if ip_family != "ipv4" %}
+      - ip address add fd00:10:1::2/64 dev net1
+      - ip -6 route add fd00:10:0::/48 via fd00:10:1::1
+{%- endif %}
     kube-ovn-worker:
       kind: ext-container
       exec:
+{%- if ip_family != "ipv6" %}
       - ip address add 10.0.1.3/24 dev net1
       - ip route add 10.0.0.0/16 via 10.0.1.1
+{%- endif %}
+{%- if ip_family != "ipv4" %}
+      - ip address add fd00:10:1::3/64 dev net1
+      - ip -6 route add fd00:10:0::/48 via fd00:10:1::1
+{%- endif %}
     ext:
       kind: linux
       exec:
+{%- if ip_family != "ipv6" %}
       - ip address add 10.0.2.2/24 dev net1
       - ip route replace default via 10.0.2.1
+{%- endif %}
+{%- if ip_family != "ipv4" %}
+      - ip address add fd00:10:2::2/64 dev net1
+      - ip -6 route replace default via fd00:10:2::1
+{%- endif %}
 
   links:
   - type: veth


### PR DESCRIPTION
## Summary

- extend the BGP containerlab topology and speaker setup to IPv4, IPv6, and dual-stack
- run BGP speaker E2E as a three-entry x86 CI matrix and collect per-family diagnostics
- validate both AFIs in dual-stack tests, including Pod, subnet, Service, policy, withdrawal, and next-hop refresh paths

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest hack/test_e2e_selector.py`
- rendered `clab-bgp.yaml` for `ipv4`, `ipv6`, and `dual` with `jinjanate`; YAML structure validated
- `git diff --check`
- `actionlint .github/workflows/build-x86-image.yaml` (only the repository-existing custom `larger-runner` label warning)
- `go test ./test/e2e/bgp` started under the required 512 MiB / 0.5 CPU limit but did not finish during the local verification window while linking the Kubernetes E2E binary