### PR TITLE
fix(ci): use PR Go version in trusted E2E jobs

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -859,7 +859,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -964,7 +964,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -1174,7 +1174,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -1551,7 +1551,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -1760,7 +1760,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -1932,7 +1932,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -2097,7 +2097,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -2266,7 +2266,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -2905,7 +2905,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -3063,7 +3063,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -3373,7 +3373,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -3534,7 +3534,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -3710,7 +3710,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -3880,7 +3880,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -4135,7 +4135,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -4326,7 +4326,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -4484,7 +4484,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -4642,7 +4642,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -4795,7 +4795,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -4952,7 +4952,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -5079,7 +5079,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 
@@ -5231,7 +5231,7 @@ jobs:
       - uses: actions/setup-go@v7
         id: setup-go
         with:
-          go-version-file: ${{ env.E2E_DIR }}/go.mod
+          go-version-file: go.mod
           check-latest: true
           cache: false
 


### PR DESCRIPTION
The trusted x86 E2E executor is dispatched from the default branch workflow, while PR jobs check out the PR revision separately. On Go 1.27 upgrade PRs, `${{ env.E2E_DIR }}/go.mod` points at the default-branch E2E checkout (Go 1.26.6), but controller-gen analyzes the PR root module (Go 1.27.0).

Read the trusted executor's Go version from the root `go.mod` for every E2E job. This keeps the analyzer enabled and lets the default-branch E2E source run with a newer compatible Go toolchain.