### PR TITLE
fix(ci): run trusted E2E tests from PR head

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -98,6 +98,8 @@ concurrency:
 
 env:
   EXECUTION_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.headSHA || github.sha }}
+  # The trusted selector validates inputs.headSHA against the live pull request before dispatch.
+  E2E_SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.headSHA || github.event.repository.default_branch }}
   # renovate: datasource=github-releases depName=kind packageName=kubernetes-sigs/kind
   KIND_VERSION: v0.32.0
   # renovate: datasource=github-releases depName=golangci-lint packageName=golangci/golangci-lint
@@ -843,7 +845,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -943,7 +945,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -1153,7 +1155,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -1360,7 +1362,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -1535,7 +1537,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -1744,7 +1746,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -1916,7 +1918,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -2076,7 +2078,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -2250,7 +2252,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -2889,7 +2891,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -3047,7 +3049,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -3357,7 +3359,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -3518,7 +3520,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -3685,7 +3687,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -3864,7 +3866,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -4001,7 +4003,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -4119,7 +4121,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -4310,7 +4312,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -4468,7 +4470,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -4626,7 +4628,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -4779,7 +4781,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -4936,7 +4938,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -5063,7 +5065,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source
@@ -5215,7 +5217,7 @@ jobs:
         if: (github.base_ref || github.ref_name) != github.event.repository.default_branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.E2E_SOURCE_REF }}
           persist-credentials: false
           fetch-depth: 1
           path: test/e2e/source

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1676,6 +1676,12 @@ class E2EControlTest(unittest.TestCase):
             "github.event.pull_request.head.sha || inputs.headSHA || github.sha }}",
             workflow,
         )
+        self.assertIn(
+            "E2E_SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && "
+            "inputs.headSHA || github.event.repository.default_branch }}",
+            workflow,
+        )
+        self.assertEqual(workflow.count("ref: ${{ env.E2E_SOURCE_REF }}"), 24)
         self.assertNotIn("ref: ${{ inputs.headSHA || github.sha }}", workflow)
         self.assertNotIn("github.event.pull_request.head.sha || inputs.headSHA", workflow.replace(
             "EXECUTION_SHA: ${{ github.event_name == 'pull_request' && "


### PR DESCRIPTION
The trusted workflow_dispatch executor validates the PR head SHA, but all E2E source checkouts still used the default branch. This makes PR test fixes invisible to trusted E2E runs.

Use the validated inputs.headSHA for E2E_SOURCE_REF during workflow_dispatch, while preserving default-branch source selection for push and maintenance-branch runs. Add a contract assertion covering all 24 E2E source checkouts.

Validation: 65 hack.test_e2e_control tests, targeted executor contract test, actionlint with the repository's existing larger-runner label ignored, and git diff --check.