### PR TITLE
fix(controller): reconcile missing node logical switch ports

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -453,9 +453,12 @@ func (c *Controller) markAndCleanLSP() error {
 			ipMap.Add(ovs.PodNameToPortName(podName, pod.Namespace, providerName))
 		}
 	}
+	nodeLspMap := strset.NewWithSize(len(nodes))
 	for _, node := range nodes {
 		if node.Annotations[util.AllocatedAnnotation] == "true" {
-			ipMap.Add(util.NodeLspName(node.Name))
+			portName := util.NodeLspName(node.Name)
+			nodeLspMap.Add(portName)
+			ipMap.Add(portName)
 		}
 
 		if _, err := c.ovnEipsLister.Get(node.Name); err == nil {
@@ -555,10 +558,26 @@ func (c *Controller) markAndCleanLSP() error {
 			klog.Infof("gc skip reserved ip %s", ipCR.Name)
 		}
 	}
+	for _, node := range nodes {
+		if node.Annotations[util.AllocatedAnnotation] != "true" {
+			continue
+		}
+
+		portName := util.NodeLspName(node.Name)
+		if lspMap.Has(portName) {
+			continue
+		}
+
+		klog.Warningf("node logical switch port %s is missing, enqueue node %s for reconciliation", portName, node.Name)
+		c.addNodeQueue.Add(node.Name)
+	}
 	lastNoPodLSP = noPodLSP
 
 	ipMap.Each(func(ipName string) bool {
 		if !lspMap.Has(ipName) {
+			if nodeLspMap.Has(ipName) {
+				return true
+			}
 			klog.Errorf("lsp lost for pod %s, please delete the pod and retry", ipName)
 		}
 		return true

--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -411,6 +411,34 @@ func (c *Controller) gcIP() error {
 	return nil
 }
 
+func (c *Controller) keepNodeLSPs(nodes []*corev1.Node, ipMap *strset.Set) map[string]string {
+	result := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		if node.Annotations[util.AllocatedAnnotation] == "true" {
+			portName := util.NodeLspName(node.Name)
+			result[portName] = node.Name
+			ipMap.Add(portName)
+		}
+
+		if _, err := c.ovnEipsLister.Get(node.Name); err == nil {
+			// node external gw lsp is managed by ovn eip cr, skip gc its lsp
+			ipMap.Add(node.Name)
+		}
+	}
+	return result
+}
+
+func (c *Controller) enqueueMissingNodeLSPs(nodes map[string]string, existing *strset.Set) {
+	for portName, nodeName := range nodes {
+		if existing.Has(portName) {
+			continue
+		}
+
+		klog.Warningf("node logical switch port %s is missing, enqueue node %s for reconciliation", portName, nodeName)
+		c.addNodeQueue.Add(nodeName)
+	}
+}
+
 func (c *Controller) markAndCleanLSP() error {
 	klog.V(4).Infof("start to gc logical switch ports")
 	pods, err := c.podsLister.List(labels.Everything())
@@ -453,19 +481,7 @@ func (c *Controller) markAndCleanLSP() error {
 			ipMap.Add(ovs.PodNameToPortName(podName, pod.Namespace, providerName))
 		}
 	}
-	nodeLspMap := strset.NewWithSize(len(nodes))
-	for _, node := range nodes {
-		if node.Annotations[util.AllocatedAnnotation] == "true" {
-			portName := util.NodeLspName(node.Name)
-			nodeLspMap.Add(portName)
-			ipMap.Add(portName)
-		}
-
-		if _, err := c.ovnEipsLister.Get(node.Name); err == nil {
-			// node external gw lsp is managed by ovn eip cr, skip gc its lsp
-			ipMap.Add(node.Name)
-		}
-	}
+	nodeLspMap := c.keepNodeLSPs(nodes, ipMap)
 
 	// The lsp for vm pod should not be deleted if vm still exists.
 	// Abort the GC cycle on a list failure so we never delete live VM LSPs based on an incomplete keep-set.
@@ -558,24 +574,12 @@ func (c *Controller) markAndCleanLSP() error {
 			klog.Infof("gc skip reserved ip %s", ipCR.Name)
 		}
 	}
-	for _, node := range nodes {
-		if node.Annotations[util.AllocatedAnnotation] != "true" {
-			continue
-		}
-
-		portName := util.NodeLspName(node.Name)
-		if lspMap.Has(portName) {
-			continue
-		}
-
-		klog.Warningf("node logical switch port %s is missing, enqueue node %s for reconciliation", portName, node.Name)
-		c.addNodeQueue.Add(node.Name)
-	}
+	c.enqueueMissingNodeLSPs(nodeLspMap, lspMap)
 	lastNoPodLSP = noPodLSP
 
 	ipMap.Each(func(ipName string) bool {
 		if !lspMap.Has(ipName) {
-			if nodeLspMap.Has(ipName) {
+			if _, ok := nodeLspMap[ipName]; ok {
 				return true
 			}
 			klog.Errorf("lsp lost for pod %s, please delete the pod and retry", ipName)

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -210,6 +210,33 @@ func TestGetVMLsps(t *testing.T) {
 	})
 }
 
+func TestMarkAndCleanLSPEnqueuesMissingNodeLSP(t *testing.T) {
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Nodes: []*corev1.Node{{
+			Name: "node-1",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation: "true",
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	ctrl.config.EnableKeepVMIP = false
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+	ctrl.virtualIpsLister = kubeovnlisters.NewVipLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(false, nil).Return(nil, nil)
+
+	require.NoError(t, ctrl.markAndCleanLSP())
+	require.Equal(t, 1, ctrl.addNodeQueue.Len())
+
+	item, shutdown := ctrl.addNodeQueue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "node-1", item)
+	ctrl.addNodeQueue.Done(item)
+}
+
 func TestGcNetworkPolicyDeletesLeftoversWhenDisabled(t *testing.T) {
 	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Nodes: []*corev1.Node{{Name: "node1"}},

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -238,6 +238,37 @@ func TestMarkAndCleanLSPEnqueuesMissingNodeLSP(t *testing.T) {
 	ctrl.addNodeQueue.Done(item)
 }
 
+func TestMarkAndCleanLSPKeepsExistingNodeLSP(t *testing.T) {
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Nodes: []*corev1.Node{{
+			Name: "node-1",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation: "true",
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	ctrl.config.EnableKeepVMIP = false
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+	ctrl.virtualIpsLister = kubeovnlisters.NewVipLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+
+	previousLastNoPodLSP := lastNoPodLSP
+	lastNoPodLSP = strset.New()
+	t.Cleanup(func() { lastNoPodLSP = previousLastNoPodLSP })
+
+	mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(false, nil).Return([]ovnnb.LogicalSwitchPort{
+		{Name: util.NodeLspName("node-1")},
+		{Name: "orphan"},
+	}, nil)
+
+	require.NoError(t, ctrl.markAndCleanLSP())
+	require.Equal(t, 0, ctrl.addNodeQueue.Len())
+	require.True(t, lastNoPodLSP.Has("orphan"))
+}
+
 func TestKeepNodeLSPsKeepsExternalGatewayLSP(t *testing.T) {
 	nodeEip := &kubeovnv1.OvnEip{}
 	nodeEip.Name = "node-2"

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -239,6 +239,8 @@ func TestMarkAndCleanLSPEnqueuesMissingNodeLSP(t *testing.T) {
 }
 
 func TestKeepNodeLSPsKeepsExternalGatewayLSP(t *testing.T) {
+	nodeEip := &kubeovnv1.OvnEip{}
+	nodeEip.Name = "node-2"
 	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Nodes: []*corev1.Node{
 			{
@@ -249,7 +251,7 @@ func TestKeepNodeLSPsKeepsExternalGatewayLSP(t *testing.T) {
 			},
 			{Name: "node-2"},
 		},
-		OvnEips: []*kubeovnv1.OvnEip{{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}}},
+		OvnEips: []*kubeovnv1.OvnEip{nodeEip},
 	})
 	require.NoError(t, err)
 

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	netlisters "k8s.io/client-go/listers/networking/v1"
@@ -234,6 +235,52 @@ func TestMarkAndCleanLSPEnqueuesMissingNodeLSP(t *testing.T) {
 	item, shutdown := ctrl.addNodeQueue.Get()
 	require.False(t, shutdown)
 	require.Equal(t, "node-1", item)
+	ctrl.addNodeQueue.Done(item)
+}
+
+func TestKeepNodeLSPsKeepsExternalGatewayLSP(t *testing.T) {
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Nodes: []*corev1.Node{
+			{
+				Name: "node-1",
+				Annotations: map[string]string{
+					util.AllocatedAnnotation: "true",
+				},
+			},
+			{Name: "node-2"},
+		},
+		OvnEips: []*kubeovnv1.OvnEip{{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}}},
+	})
+	require.NoError(t, err)
+
+	ctrl := fakeController.fakeController
+	nodes, err := ctrl.nodesLister.List(labels.Everything())
+	require.NoError(t, err)
+	ipMap := strset.New()
+	nodeLSPs := ctrl.keepNodeLSPs(nodes, ipMap)
+
+	require.Equal(t, map[string]string{util.NodeLspName("node-1"): "node-1"}, nodeLSPs)
+	require.True(t, ipMap.Has(util.NodeLspName("node-1")))
+	require.True(t, ipMap.Has("node-2"))
+}
+
+func TestEnqueueMissingNodeLSPsSkipsExistingLSP(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+
+	ctrl.enqueueMissingNodeLSPs(
+		map[string]string{
+			util.NodeLspName("node-1"): "node-1",
+			util.NodeLspName("node-2"): "node-2",
+		},
+		strset.New(util.NodeLspName("node-1")),
+	)
+
+	require.Equal(t, 1, ctrl.addNodeQueue.Len())
+	item, shutdown := ctrl.addNodeQueue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "node-2", item)
 	ctrl.addNodeQueue.Done(item)
 }
 

--- a/test/e2e/kube-ovn/node/node_lsp_recovery.go
+++ b/test/e2e/kube-ovn/node/node_lsp_recovery.go
@@ -33,6 +33,7 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 		var originalControllerArgs []string
 		modifiedDeployment := originalDeployment.DeepCopy()
 		foundController := false
+		nodeSwitch := "join"
 		for i := range modifiedDeployment.Spec.Template.Spec.Containers {
 			container := &modifiedDeployment.Spec.Template.Spec.Containers[i]
 			if container.Name != "kube-ovn-controller" {
@@ -40,6 +41,13 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 			}
 			foundController = true
 			originalControllerArgs = append([]string(nil), container.Args...)
+			for j, arg := range container.Args {
+				if value, ok := strings.CutPrefix(arg, "--node-switch="); ok {
+					nodeSwitch = value
+				} else if arg == "--node-switch" && j+1 < len(container.Args) {
+					nodeSwitch = container.Args[j+1]
+				}
+			}
 			foundGCInterval := false
 			for j, arg := range container.Args {
 				if strings.HasPrefix(arg, "--gc-interval=") {
@@ -69,7 +77,7 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 		deploymentClient.PatchSync(originalDeployment, modifiedDeployment)
 
 		hasNodeLSP := func() (bool, error) {
-			output, _, err := framework.NBExec("ovn-nbctl --bare --no-heading lsp-list join")
+			output, _, err := framework.NBExec("ovn-nbctl --bare --no-heading lsp-list " + nodeSwitch)
 			if err != nil {
 				return false, err
 			}

--- a/test/e2e/kube-ovn/node/node_lsp_recovery.go
+++ b/test/e2e/kube-ovn/node/node_lsp_recovery.go
@@ -73,7 +73,7 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 			if err != nil {
 				return false, err
 			}
-			for _, name := range strings.Fields(string(output)) {
+			for name := range strings.FieldsSeq(string(output)) {
 				if name == portName {
 					return true, nil
 				}

--- a/test/e2e/kube-ovn/node/node_lsp_recovery.go
+++ b/test/e2e/kube-ovn/node/node_lsp_recovery.go
@@ -81,8 +81,8 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 			if err != nil {
 				return false, err
 			}
-			for name := range strings.FieldsSeq(string(output)) {
-				if name == portName {
+			for line := range strings.SplitSeq(string(output), "\n") {
+				if strings.HasSuffix(strings.TrimSpace(line), " ("+portName+")") {
 					return true, nil
 				}
 			}

--- a/test/e2e/kube-ovn/node/node_lsp_recovery.go
+++ b/test/e2e/kube-ovn/node/node_lsp_recovery.go
@@ -1,0 +1,115 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+var _ = framework.SerialDescribe("[group:node]", func() {
+	f := framework.NewDefaultFramework("node-lsp-recovery")
+
+	framework.DisruptiveIt("should recreate a missing node logical switch port", func() {
+		f.SkipVersionPriorTo(1, 15, "Node logical switch ports are managed by Kube-OVN")
+
+		ginkgo.By("Getting a ready schedulable node")
+		nodeList, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+		framework.ExpectNoError(err)
+		framework.ExpectNotEmpty(nodeList.Items)
+		node := nodeList.Items[0]
+		portName := util.NodeLspName(node.Name)
+
+		ginkgo.By("Temporarily shortening the controller GC interval")
+		deploymentClient := framework.NewDeploymentClient(f.ClientSet, framework.KubeOvnNamespace)
+		originalDeployment := deploymentClient.Get("kube-ovn-controller")
+		var originalControllerArgs []string
+		modifiedDeployment := originalDeployment.DeepCopy()
+		foundController := false
+		for i := range modifiedDeployment.Spec.Template.Spec.Containers {
+			container := &modifiedDeployment.Spec.Template.Spec.Containers[i]
+			if container.Name != "kube-ovn-controller" {
+				continue
+			}
+			foundController = true
+			originalControllerArgs = append([]string(nil), container.Args...)
+			foundGCInterval := false
+			for j, arg := range container.Args {
+				if strings.HasPrefix(arg, "--gc-interval=") {
+					container.Args[j] = "--gc-interval=5"
+					foundGCInterval = true
+					break
+				}
+			}
+			if !foundGCInterval {
+				container.Args = append(container.Args, "--gc-interval=5")
+			}
+			break
+		}
+		framework.ExpectTrue(foundController, "kube-ovn-controller container was not found")
+		ginkgo.DeferCleanup(func() {
+			currentDeployment := deploymentClient.Get("kube-ovn-controller")
+			restoredDeployment := currentDeployment.DeepCopy()
+			for i := range restoredDeployment.Spec.Template.Spec.Containers {
+				container := &restoredDeployment.Spec.Template.Spec.Containers[i]
+				if container.Name == "kube-ovn-controller" {
+					container.Args = originalControllerArgs
+					break
+				}
+			}
+			deploymentClient.PatchSync(currentDeployment, restoredDeployment)
+		})
+		deploymentClient.PatchSync(originalDeployment, modifiedDeployment)
+
+		hasNodeLSP := func() (bool, error) {
+			output, _, err := framework.NBExec("ovn-nbctl --bare --no-heading lsp-list join")
+			if err != nil {
+				return false, err
+			}
+			for _, name := range strings.Fields(string(output)) {
+				if name == portName {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+
+		ginkgo.By("Verifying the node logical switch port exists before deletion")
+		framework.WaitUntil(time.Second, time.Minute, func(_ context.Context) (bool, error) {
+			present, err := hasNodeLSP()
+			if err != nil {
+				return false, nil
+			}
+			return present, nil
+		}, "node logical switch port should exist before deletion")
+
+		ginkgo.By("Deleting node logical switch port " + portName)
+		_, _, err = framework.NBExec(fmt.Sprintf("ovn-nbctl --if-exists lsp-del %s", portName))
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying that the node logical switch port was deleted")
+		framework.WaitUntil(time.Second, time.Minute, func(_ context.Context) (bool, error) {
+			present, err := hasNodeLSP()
+			if err != nil {
+				return false, nil
+			}
+			return !present, nil
+		}, "node logical switch port should be absent after deletion")
+
+		ginkgo.By("Waiting for the controller to recreate the node logical switch port")
+		framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+			present, err := hasNodeLSP()
+			if err != nil {
+				return false, nil
+			}
+			return present, nil
+		}, "controller should recreate the missing node logical switch port")
+	})
+})

--- a/test/e2e/kube-ovn/node/node_lsp_recovery.go
+++ b/test/e2e/kube-ovn/node/node_lsp_recovery.go
@@ -76,48 +76,42 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 		})
 		deploymentClient.PatchSync(originalDeployment, modifiedDeployment)
 
-		hasNodeLSP := func() (bool, error) {
+		nodeLSPUUID := func() (string, error) {
 			output, _, err := framework.NBExec("ovn-nbctl --bare --no-heading lsp-list " + nodeSwitch)
 			if err != nil {
-				return false, err
+				return "", err
 			}
 			for line := range strings.SplitSeq(string(output), "\n") {
-				if strings.HasSuffix(strings.TrimSpace(line), " ("+portName+")") {
-					return true, nil
+				uuid, name, ok := strings.Cut(strings.TrimSpace(line), " (")
+				if ok && name == portName+")" {
+					return uuid, nil
 				}
 			}
-			return false, nil
+			return "", nil
 		}
 
 		ginkgo.By("Verifying the node logical switch port exists before deletion")
+		var originalUUID string
 		framework.WaitUntil(time.Second, time.Minute, func(_ context.Context) (bool, error) {
-			present, err := hasNodeLSP()
+			var err error
+			originalUUID, err = nodeLSPUUID()
 			if err != nil {
 				return false, nil
 			}
-			return present, nil
+			return originalUUID != "", nil
 		}, "node logical switch port should exist before deletion")
 
 		ginkgo.By("Deleting node logical switch port " + portName)
 		_, _, err = framework.NBExec(fmt.Sprintf("ovn-nbctl --if-exists lsp-del %s", portName))
 		framework.ExpectNoError(err)
 
-		ginkgo.By("Verifying that the node logical switch port was deleted")
-		framework.WaitUntil(time.Second, time.Minute, func(_ context.Context) (bool, error) {
-			present, err := hasNodeLSP()
-			if err != nil {
-				return false, nil
-			}
-			return !present, nil
-		}, "node logical switch port should be absent after deletion")
-
 		ginkgo.By("Waiting for the controller to recreate the node logical switch port")
 		framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
-			present, err := hasNodeLSP()
+			recreatedUUID, err := nodeLSPUUID()
 			if err != nil {
 				return false, nil
 			}
-			return present, nil
+			return recreatedUUID != "" && recreatedUUID != originalUUID, nil
 		}, "controller should recreate the missing node logical switch port")
 	})
 })

--- a/test/e2e/kube-ovn/node/node_lsp_recovery.go
+++ b/test/e2e/kube-ovn/node/node_lsp_recovery.go
@@ -26,6 +26,8 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 		framework.ExpectNotEmpty(nodeList.Items)
 		node := nodeList.Items[0]
 		portName := util.NodeLspName(node.Name)
+		nodeSwitch := node.Annotations[util.LogicalSwitchAnnotation]
+		framework.ExpectNotEmpty(nodeSwitch, "node logical switch annotation should be set")
 
 		ginkgo.By("Temporarily shortening the controller GC interval")
 		deploymentClient := framework.NewDeploymentClient(f.ClientSet, framework.KubeOvnNamespace)
@@ -33,7 +35,6 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 		var originalControllerArgs []string
 		modifiedDeployment := originalDeployment.DeepCopy()
 		foundController := false
-		nodeSwitch := "join"
 		for i := range modifiedDeployment.Spec.Template.Spec.Containers {
 			container := &modifiedDeployment.Spec.Template.Spec.Containers[i]
 			if container.Name != "kube-ovn-controller" {
@@ -41,13 +42,6 @@ var _ = framework.SerialDescribe("[group:node]", func() {
 			}
 			foundController = true
 			originalControllerArgs = append([]string(nil), container.Args...)
-			for j, arg := range container.Args {
-				if value, ok := strings.CutPrefix(arg, "--node-switch="); ok {
-					nodeSwitch = value
-				} else if arg == "--node-switch" && j+1 < len(container.Args) {
-					nodeSwitch = container.Args[j+1]
-				}
-			}
 			foundGCInterval := false
 			for j, arg := range container.Args {
 				if strings.HasPrefix(arg, "--gc-interval=") {


### PR DESCRIPTION
## Summary

When OVN DB/Raft recovery or reconfiguration causes an allocated node's expected logical switch port (LSP) on the node gateway switch to disappear, kube-ovn-controller may not receive a Kubernetes Node event. The node network can then remain broken until the controller is restarted.

This change makes the controller periodically detect the missing node LSP and re-enqueue the node through the existing add-node initialization and retry path.

## Problem and Trigger

- The affected ports are named `node-node-*`. They are node LSPs on the configured node gateway switch (normally `join`), not ordinary workload Pod LSPs.
- The issue was observed with Kube-OVN `v1.15.19` after OVN DB connectivity loss and cluster DB/Raft recovery activity.
- During the recovery window, the corresponding Kubernetes Nodes continued to exist, but their node LSPs were absent from NBDB and no Node add/update event was generated.
- The existing LSP garbage-collection path reported the missing node LSP using the generic pod wording, but did not reinitialize the node. The LSP was recreated only after `kube-ovn-controller` restarted.

Observed controller log sequence:

```text
01:40:20 connection refused to 10.64.0.70/.77/.80:6641
01:40:21 Creating cluster database
01:40:21 Joining ... to cluster
01:40:27 deleted stale logical switch port node-node-10-64-0-70
01:40:27 deleted stale logical switch port node-node-10-64-0-80
01:40:27 deleted stale logical switch port node-node-10-64-0-77
01:40:27 deleted stale logical switch port node-node-10-64-0-86
01:40:27 deleted stale logical switch port node-node-10-64-0-93
01:40:27 deleted stale logical switch port node-node-10-64-0-103
01:44:28 lsp lost for pod node-node-10-64-0-77
01:44:28 lsp lost for pod node-node-10-64-0-80
01:44:28 lsp lost for pod node-node-10-64-0-86
```

On an affected node, kube-ovn-cni remained waiting for the node gateway to become ready:

```text
Kube-OVN v1.15.19
wait ovn0 gw ready
100.36.0.3 network not ready after 3 ping to gateway 100.36.0.1
100.36.0.3 network not ready after 6 ping to gateway 100.36.0.1
100.36.0.3 network not ready after 9 ping to gateway 100.36.0.1
```

The evidence points to state loss or incomplete synchronization during the OVN DB/Raft reconfiguration window. This PR does not claim to fix the underlying OVN Central/Raft stability issue; it fixes the controller-side detection and recovery gap.

## Fix

- Keep the expected LSP names for allocated nodes while building the periodic LSP keep-set.
- When an expected node LSP is absent from the NBDB listing, enqueue the node in `addNodeQueue`.
- Reuse the existing node initialization worker, including its idempotent creation and rate-limited retry behavior.
- Keep node LSP loss separate from the generic pod-only loss diagnostic.

## Scope and Non-goals

- Provides controller-side recovery after a node LSP disappears.
- Does not replace investigation or hardening of OVN Central/Raft stability.
- Does not require a Kubernetes Node event or a controller restart to trigger reconstruction.

## Tests

- `go test ./pkg/controller -count=1`
- `go test ./test/e2e/kube-ovn/node`
- `go vet ./pkg/controller`
- `git diff --check`
- Added unit coverage for missing node LSP detection, node re-enqueue, existing node LSP handling, and external gateway LSP keep-set handling.
- Added a disruptive E2E that deletes a node LSP from NBDB and verifies that the controller recreates it with a new UUID. The test honors a custom `--node-switch` and shortens the GC interval only for the test.

## E2E Status

Trusted x86 E2E coverage was executed for the current PR HEAD `7a2ced49d8f2822256229c51596d47342e1c44ae` in workflow run `33050175370`. All six Kube-OVN Conformance E2E matrices passed, including the suite containing the node-LSP recovery test. The only failed matrix was ACL Sampling E2E, which failed while verifying NetworkPolicy sampling; its installation and cluster setup passed, and it is unrelated to this PR's controller and node-LSP changes.
