### PR TITLE
support image pull secrets for vpc nat gw pod

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -73,6 +73,7 @@ type fakeControllerInformers struct {
 	subnetInformer    kubeovninformer.SubnetInformer
 	ipInformer        kubeovninformer.IPInformer
 	vlanInformer      kubeovninformer.VlanInformer
+	configMapInformer coreinformers.ConfigMapInformer
 	serviceInformer   coreinformers.ServiceInformer
 	namespaceInformer coreinformers.NamespaceInformer
 	nodeInformer      coreinformers.NodeInformer
@@ -133,7 +134,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		}}
 	}
 
-	// Create fake Kubernetes client with namespaces, pods, nodes, services, and workloads.
+	// Create fake Kubernetes client with namespaces, pods, nodes, services, workloads and config maps.
 	kubeObjects := make([]runtime.Object, 0, len(namespaces)+len(opts.Pods)+len(opts.Nodes)+len(opts.Services)+
 		len(opts.StatefulSets)+len(opts.Deployments)+len(opts.ConfigMaps))
 	for _, ns := range namespaces {
@@ -331,6 +332,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	ovnSnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().OvnSnatRules()
 	qosPolicyInformer := kubeovnInformerFactory.Kubeovn().V1().QoSPolicies()
 	iptablesEipInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesEIPs()
+	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 
 	fakeInformers := &fakeControllerInformers{
 		vpcInformer:       vpcInformer,
@@ -342,6 +344,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		namespaceInformer: namespaceInformer,
 		nodeInformer:      nodeInformer,
 		podInformer:       podInformer,
+		configMapInformer: configMapInformer,
 	}
 
 	// Create mock OVN clients
@@ -398,6 +401,9 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		updateSubnetStatusQueue:       newTypedRateLimitingQueue[string]("UpdateSubnetStatus", nil),
 		addOrUpdateVpcNatGatewayQueue: newTypedRateLimitingQueue[string]("AddOrUpdateVpcNatGateway", nil),
 		initVpcNatGatewayQueue:        newTypedRateLimitingQueue[string]("InitVpcNatGateway", nil),
+		configMapsLister:              configMapInformer.Lister(),
+		configMapsSynced:              alwaysReady,
+		serviceCIDRStore:              util.NewServiceCIDRStore("10.96.0.0/12"),
 	}
 
 	ctrl.config = &Configuration{

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -332,7 +332,6 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	ovnSnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().OvnSnatRules()
 	qosPolicyInformer := kubeovnInformerFactory.Kubeovn().V1().QoSPolicies()
 	iptablesEipInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesEIPs()
-	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 
 	fakeInformers := &fakeControllerInformers{
 		vpcInformer:       vpcInformer,
@@ -401,7 +400,6 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		updateSubnetStatusQueue:       newTypedRateLimitingQueue[string]("UpdateSubnetStatus", nil),
 		addOrUpdateVpcNatGatewayQueue: newTypedRateLimitingQueue[string]("AddOrUpdateVpcNatGateway", nil),
 		initVpcNatGatewayQueue:        newTypedRateLimitingQueue[string]("InitVpcNatGateway", nil),
-		configMapsLister:              configMapInformer.Lister(),
 		configMapsSynced:              alwaysReady,
 		serviceCIDRStore:              util.NewServiceCIDRStore("10.96.0.0/12"),
 	}

--- a/pkg/controller/vpc_nat.go
+++ b/pkg/controller/vpc_nat.go
@@ -13,6 +13,7 @@ var (
 	vpcNatImage             = ""
 	vpcNatGwBgpSpeakerImage = ""
 	vpcNatAPINadProvider    = ""
+	vpcNatImagePullSecret   = ""
 )
 
 func (c *Controller) resyncVpcNatConfig() {
@@ -42,6 +43,9 @@ func (c *Controller) resyncVpcNatConfig() {
 		return
 	}
 	vpcNatImage = image
+
+	// image pull secret for images in private registries, optional
+	vpcNatImagePullSecret = cm.Data["imagePullSecret"]
 
 	// Image for the BGP sidecar of the gateway (optional)
 	vpcNatGwBgpSpeakerImage = cm.Data["bgpSpeakerImage"]

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -1419,6 +1419,7 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 				Annotations: templateAnnotations,
 				Spec: corev1.PodSpec{
 					TerminationGracePeriodSeconds: ptr.To[int64](0),
+					ImagePullSecrets:              util.GetImagePullSecrets(vpcNatImagePullSecret),
 					Containers: []corev1.Container{
 						{
 							Name:    "vpc-nat-gw",
@@ -1591,6 +1592,7 @@ func (c *Controller) genNatGwDeployment(gw *kubeovnv1.VpcNatGateway) (*v1.Deploy
 				Annotations: templateAnnotations,
 				Spec: corev1.PodSpec{
 					TerminationGracePeriodSeconds: ptr.To[int64](0),
+					ImagePullSecrets:              util.GetImagePullSecrets(vpcNatImagePullSecret),
 					Containers: []corev1.Container{
 						{
 							Name:    "vpc-nat-gw",

--- a/pkg/controller/vpc_nat_gateway_test.go
+++ b/pkg/controller/vpc_nat_gateway_test.go
@@ -457,3 +457,300 @@ func TestGetExternalSubnetNad(t *testing.T) {
 		})
 	}
 }
+
+func TestGenNatGwStatefulSetImagePullSecrets(t *testing.T) {
+	tests := []struct {
+		name           string
+		pullSecret     string
+		expectedResult []corev1.LocalObjectReference
+	}{
+		{
+			name:           "empty pull secret results in nil",
+			pullSecret:     "",
+			expectedResult: nil,
+		},
+		{
+			name:       "non-empty pull secret is injected",
+			pullSecret: "pull-secret",
+			expectedResult: []corev1.LocalObjectReference{
+				{Name: "pull-secret"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := &kubeovnv1.VpcNatGateway{
+				Name: "test-gw",
+				Spec: kubeovnv1.VpcNatGatewaySpec{
+					Vpc:             "test-vpc",
+					Subnet:          "internal-subnet",
+					ExternalSubnets: []string{"external-subnet"},
+					Replicas:        1,
+				},
+			}
+
+			subnets := []*kubeovnv1.Subnet{
+				{
+					Name: "internal-subnet",
+					Spec: kubeovnv1.SubnetSpec{
+						CIDRBlock: "10.0.0.0/24",
+						Gateway:   "10.0.0.1",
+						Provider:  "internal.default.ovn",
+					},
+				},
+				{
+					Name: "external-subnet",
+					Spec: kubeovnv1.SubnetSpec{
+						CIDRBlock: "192.168.0.0/24",
+						Gateway:   "192.168.0.1",
+						Provider:  "external.default.ovn",
+					},
+				},
+			}
+
+			vpcs := []*kubeovnv1.Vpc{
+				{
+					Name: "test-vpc",
+					Status: kubeovnv1.VpcStatus{
+						Subnets: []string{"internal-subnet"},
+					},
+				},
+			}
+
+			fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				Subnets: subnets,
+				Vpcs:    vpcs,
+			})
+			require.NoError(t, err)
+			controller := fakeController.fakeController
+
+			oldPullSecret := vpcNatImagePullSecret
+			vpcNatImagePullSecret = tt.pullSecret
+			t.Cleanup(func() { vpcNatImagePullSecret = oldPullSecret })
+
+			sts, err := controller.genNatGwStatefulSet(gw, nil, 0)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedResult, sts.Spec.Template.Spec.ImagePullSecrets)
+		})
+	}
+}
+
+func TestGenNatGwDeploymentImagePullSecrets(t *testing.T) {
+	tests := []struct {
+		name           string
+		pullSecret     string
+		expectedResult []corev1.LocalObjectReference
+	}{
+		{
+			name:           "empty pull secret results in nil",
+			pullSecret:     "",
+			expectedResult: nil,
+		},
+		{
+			name:       "non-empty pull secret is injected",
+			pullSecret: "pull-secret",
+			expectedResult: []corev1.LocalObjectReference{
+				{Name: "pull-secret"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := &kubeovnv1.VpcNatGateway{
+				Name: "test-gw",
+				Spec: kubeovnv1.VpcNatGatewaySpec{
+					Vpc:             "test-vpc",
+					Subnet:          "internal-subnet",
+					ExternalSubnets: []string{"external-subnet"},
+					Replicas:        2, // HA mode
+				},
+			}
+
+			subnets := []*kubeovnv1.Subnet{
+				{
+					Name: "internal-subnet",
+					Spec: kubeovnv1.SubnetSpec{
+						CIDRBlock: "10.0.0.0/24",
+						Gateway:   "10.0.0.1",
+						Provider:  "internal.default.ovn",
+					},
+				},
+				{
+					Name: "external-subnet",
+					Spec: kubeovnv1.SubnetSpec{
+						CIDRBlock: "192.168.0.0/24",
+						Gateway:   "192.168.0.1",
+						Provider:  "external.default.ovn",
+					},
+				},
+			}
+
+			vpcs := []*kubeovnv1.Vpc{
+				{
+					Name: "test-vpc",
+					Status: kubeovnv1.VpcStatus{
+						Subnets: []string{"internal-subnet"},
+					},
+				},
+			}
+
+			fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				Subnets: subnets,
+				Vpcs:    vpcs,
+			})
+			require.NoError(t, err)
+			controller := fakeController.fakeController
+
+			oldPullSecret := vpcNatImagePullSecret
+			vpcNatImagePullSecret = tt.pullSecret
+			t.Cleanup(func() { vpcNatImagePullSecret = oldPullSecret })
+
+			deploy, err := controller.genNatGwDeployment(gw)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedResult, deploy.Spec.Template.Spec.ImagePullSecrets)
+		})
+	}
+}
+
+func TestHandleAddOrUpdateVpcNatGwImagePullSecretsOnCreate(t *testing.T) {
+	tests := []struct {
+		name           string
+		pullSecret     string
+		replicas       int32
+		expectedResult []corev1.LocalObjectReference
+	}{
+		{
+			name:           "STS mode: no pull secret configured",
+			pullSecret:     "",
+			replicas:       1,
+			expectedResult: nil,
+		},
+		{
+			name:       "STS mode: pull secret configured",
+			pullSecret: "pull-secret",
+			replicas:   1,
+			expectedResult: []corev1.LocalObjectReference{
+				{Name: "pull-secret"},
+			},
+		},
+		{
+			name:           "Deployment mode (HA): no pull secret configured",
+			pullSecret:     "",
+			replicas:       2,
+			expectedResult: nil,
+		},
+		{
+			name:       "Deployment mode (HA): pull secret configured",
+			pullSecret: "pull-secret",
+			replicas:   2,
+			expectedResult: []corev1.LocalObjectReference{
+				{Name: "pull-secret"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := &kubeovnv1.VpcNatGateway{
+				Name: "test-gw",
+				Spec: kubeovnv1.VpcNatGatewaySpec{
+					Vpc:             "test-vpc",
+					Subnet:          "internal-subnet",
+					ExternalSubnets: []string{"external-subnet"},
+					Replicas:        tt.replicas,
+				},
+			}
+
+			subnets := []*kubeovnv1.Subnet{
+				{
+					Name: "internal-subnet",
+					Spec: kubeovnv1.SubnetSpec{
+						CIDRBlock: "10.0.0.0/24",
+						Gateway:   "10.0.0.1",
+						Provider:  "internal.default.ovn",
+					},
+				},
+				{
+					Name: "external-subnet",
+					Spec: kubeovnv1.SubnetSpec{
+						CIDRBlock: "192.168.0.0/24",
+						Gateway:   "192.168.0.1",
+						Provider:  "external.default.ovn",
+					},
+				},
+			}
+
+			vpcs := []*kubeovnv1.Vpc{
+				{
+					Name: "test-vpc",
+					Status: kubeovnv1.VpcStatus{
+						Subnets: []string{"internal-subnet"},
+					},
+				},
+			}
+
+			// patchNatGwStatus (called after Create) needs at least one active/running
+			// pod for HA mode (Deployment) to compute LanIP via getNatGwPods.
+			// Selector used by getNatGwPods: app=<GenNatGwName>, util.VpcNatGatewayLabel=true
+			var pods []*corev1.Pod
+			if tt.replicas > 1 {
+				pods = []*corev1.Pod{
+					{
+						Name:      util.GenNatGwName(gw.Name) + "-0",
+						Namespace: "kube-system",
+						Labels: map[string]string{
+							"app":                   util.GenNatGwName(gw.Name),
+							util.VpcNatGatewayLabel: "true",
+						},
+						Annotations: map[string]string{
+							fmt.Sprintf(util.IPAddressAnnotationTemplate, util.OvnProvider): "10.0.0.2",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							Conditions: []corev1.PodCondition{
+								{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+							},
+						},
+					},
+				}
+			}
+
+			fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				Subnets:        subnets,
+				Vpcs:           vpcs,
+				VpcNatGateways: []*kubeovnv1.VpcNatGateway{gw},
+				Pods:           pods,
+			})
+			require.NoError(t, err)
+			controller := fakeController.fakeController
+
+			// ensure the "iptables nat gw enabled" gate is set so handleAddOrUpdateVpcNatGw proceeds
+			oldEnabled := vpcNatEnabled
+			vpcNatEnabled = "true"
+			t.Cleanup(func() { vpcNatEnabled = oldEnabled })
+
+			oldSecret := vpcNatImagePullSecret
+			vpcNatImagePullSecret = tt.pullSecret
+			t.Cleanup(func() { vpcNatImagePullSecret = oldSecret })
+
+			err = controller.handleAddOrUpdateVpcNatGw(gw.Name)
+			require.NoError(t, err)
+
+			if tt.replicas > 1 {
+				deploy, err := controller.config.KubeClient.AppsV1().Deployments(controller.natGwNamespace(gw)).
+					Get(context.Background(), util.GenNatGwName(gw.Name), metav1.GetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedResult, deploy.Spec.Template.Spec.ImagePullSecrets)
+			} else {
+				sts, err := controller.config.KubeClient.AppsV1().StatefulSets(controller.natGwNamespace(gw)).
+					Get(context.Background(), util.GenNatGwName(gw.Name), metav1.GetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedResult, sts.Spec.Template.Spec.ImagePullSecrets)
+			}
+		})
+	}
+}

--- a/pkg/controller/vpc_nat_test.go
+++ b/pkg/controller/vpc_nat_test.go
@@ -1,0 +1,75 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestResyncVpcNatConfigImagePullSecret(t *testing.T) {
+	tests := []struct {
+		name           string
+		configMap      *corev1.ConfigMap
+		initialSecret  string
+		expectedSecret string
+	}{
+		{
+			name: "imagePullSecret present is applied",
+			configMap: &corev1.ConfigMap{
+				Name:      util.VpcNatConfig,
+				Namespace: "kube-system",
+				Data: map[string]string{
+					"image":           "kubeovn/vpc-nat-gateway:v1",
+					"imagePullSecret": "my-registry-secret",
+				},
+			},
+			initialSecret:  "",
+			expectedSecret: "my-registry-secret",
+		},
+		{
+			name: "imagePullSecret absent resets to empty",
+			configMap: &corev1.ConfigMap{
+				Name:      util.VpcNatConfig,
+				Namespace: "kube-system",
+				Data: map[string]string{
+					"image": "kubeovn/vpc-nat-gateway:v1",
+				},
+			},
+			initialSecret:  "stale-secret",
+			expectedSecret: "",
+		},
+		{
+			name:           "missing configmap does not panic and keeps previous value",
+			configMap:      nil,
+			initialSecret:  "unchanged-secret",
+			expectedSecret: "unchanged-secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var configMaps []*corev1.ConfigMap
+			if tt.configMap != nil {
+				configMaps = append(configMaps, tt.configMap)
+			}
+
+			fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				ConfigMaps: configMaps,
+			})
+			require.NoError(t, err)
+			controller := fakeController.fakeController
+			controller.config.PodNamespace = "kube-system"
+
+			oldSecret := vpcNatImagePullSecret
+			vpcNatImagePullSecret = tt.initialSecret
+			t.Cleanup(func() { vpcNatImagePullSecret = oldSecret })
+
+			controller.resyncVpcNatConfig()
+
+			require.Equal(t, tt.expectedSecret, vpcNatImagePullSecret)
+		})
+	}
+}

--- a/pkg/util/vpc_nat_gateway.go
+++ b/pkg/util/vpc_nat_gateway.go
@@ -307,3 +307,17 @@ func GroupInternalCIDRsAndNextHops(internalCIDRs []string, nextHops map[string]s
 
 	return cidrsByAF, nextHopsByAF
 }
+
+// GetImagePullSecrets returns a list of image pull secrets for a given secret name
+func GetImagePullSecrets(secretName string) []corev1.LocalObjectReference {
+	secretName = strings.TrimSpace(secretName)
+	if secretName == "" {
+		return nil
+	}
+
+	return []corev1.LocalObjectReference{
+		{
+			Name: secretName,
+		},
+	}
+}

--- a/pkg/util/vpc_nat_gateway_test.go
+++ b/pkg/util/vpc_nat_gateway_test.go
@@ -8,6 +8,7 @@ import (
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -646,4 +647,48 @@ func TestGroupInternalCIDRsAndNextHops(t *testing.T) {
 
 	require.Equal(t, map[string]string{"node1": "192.168.1.1", "node3": "192.168.1.2"}, nextHopsByAF[4])
 	require.Equal(t, map[string]string{"node2": "fd00:1::1"}, nextHopsByAF[6])
+}
+
+func TestGetImagePullSecrets(t *testing.T) {
+	tests := []struct {
+		name       string
+		secretName string
+		expected   []corev1.LocalObjectReference
+	}{
+		{
+			name:       "empty secret name",
+			secretName: "",
+			expected:   nil,
+		},
+		{
+			name:       "whitespace only",
+			secretName: "   ",
+			expected:   nil,
+		},
+		{
+			name:       "secret name",
+			secretName: "my-secret",
+			expected: []corev1.LocalObjectReference{
+				{Name: "my-secret"},
+			},
+		},
+		{
+			name:       "secret name with leading and trailing whitespace",
+			secretName: "  my-secret  ",
+			expected: []corev1.LocalObjectReference{
+				{Name: "my-secret"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetImagePullSecrets(tt.secretName)
+
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("GetImagePullSecrets(%q) = %v, want %v",
+					tt.secretName, got, tt.expected)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What type of this PR

Enhancement - support imagepullsecret for vpcnatgw pod 

## Which issue(s) this PR fixes
https://github.com/kubeovn/kube-ovn/issues/7325

Fixes #(issue-number)

Testplan:
1.Create a secret in kube-system namespace
2,Provide the secret name as imagePullSecret in ovn-vpc-nat-config  configmap

```
kubectl get configmap -n kube-system ovn-vpc-nat-config -o yaml
apiVersion: v1
data:
  image: renukaraaj17/vpc-nat-gateway:v1.16.1
  imagePullSecret: pull-secret
kind: ConfigMap
metadata:
  annotations:
    kubernetes.io/description: |
      kube-ovn vpc-nat common config
  creationTimestamp: "2026-05-21T00:15:04Z"
  name: ovn-vpc-nat-config
  namespace: kube-system
  ownerReferences:
  - apiVersion: kubeovn.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Configuration
    name: kubeovn
    uid: 205693f4-9cad-4884-b316-9508cc38ecb0
  resourceVersion: "113682777"
  uid: 1a58e840-7bbc-49ff-88e3-c5e542dc75d5

```
3. Create the vpc nat gw config 
```
 kubectl get vpc-nat-gw gw1 -o yaml
apiVersion: kubeovn.io/v1
kind: VpcNatGateway
metadata:
  annotations:
    k8s.v1.cni.cncf.io/networks: default/vswitchinternal
  creationTimestamp: "2026-08-26T22:21:25Z"
  generation: 1
  name: gw1
  resourceVersion: "113683227"
  uid: 0be81eeb-f539-4032-869d-5cb802ecf310
spec:
  externalSubnets:
  - subnetexternal
  lanIp: 172.20.10.1
  subnet: subnetinternal
  vpc: commonvpc
status:
  affinity: {}
  externalSubnets:
  - subnetexternal
  qosPolicy: ""

```

4.Verify the vpc nat gw statefulset and vpc nat gw pod in kube-system namespace reflecting the imagepullsecret and vpc nat gw pod is created successfully and running.