### PR TITLE
fix(daemon): allow a full-mask address to be used as the encap IP

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -89,25 +89,27 @@ func alwaysReady() bool { return true }
 
 // FakeControllerOptions holds optional parameters for creating a fake controller
 type FakeControllerOptions struct {
-	Subnets            []*kubeovnv1.Subnet
-	IPPools            []*kubeovnv1.IPPool
-	VpcNatGateways     []*kubeovnv1.VpcNatGateway
-	IPs                []*kubeovnv1.IP
-	Vlans              []*kubeovnv1.Vlan
-	ProviderNetworks   []*kubeovnv1.ProviderNetwork
-	NetworkAttachments []*nadv1.NetworkAttachmentDefinition
-	Pods               []*corev1.Pod
-	Nodes              []*corev1.Node
-	Namespaces         []*corev1.Namespace
-	Services           []*corev1.Service
-	Vpcs               []*kubeovnv1.Vpc
-	RouterLBRules      []*kubeovnv1.RouterLBRule
-	OvnEips            []*kubeovnv1.OvnEip
-	OvnDnatRules       []*kubeovnv1.OvnDnatRule
-	OvnFipRules        []*kubeovnv1.OvnFip
-	OvnSnatRules       []*kubeovnv1.OvnSnatRule
-	QoSPolicies        []*kubeovnv1.QoSPolicy
-	IptablesEips       []*kubeovnv1.IptablesEIP
+	EnableANP             bool
+	EnableDNSNameResolver bool
+	Subnets               []*kubeovnv1.Subnet
+	IPPools               []*kubeovnv1.IPPool
+	VpcNatGateways        []*kubeovnv1.VpcNatGateway
+	IPs                   []*kubeovnv1.IP
+	Vlans                 []*kubeovnv1.Vlan
+	ProviderNetworks      []*kubeovnv1.ProviderNetwork
+	NetworkAttachments    []*nadv1.NetworkAttachmentDefinition
+	Pods                  []*corev1.Pod
+	Nodes                 []*corev1.Node
+	Namespaces            []*corev1.Namespace
+	Services              []*corev1.Service
+	Vpcs                  []*kubeovnv1.Vpc
+	RouterLBRules         []*kubeovnv1.RouterLBRule
+	OvnEips               []*kubeovnv1.OvnEip
+	OvnDnatRules          []*kubeovnv1.OvnDnatRule
+	OvnFipRules           []*kubeovnv1.OvnFip
+	OvnSnatRules          []*kubeovnv1.OvnSnatRule
+	QoSPolicies           []*kubeovnv1.QoSPolicy
+	IptablesEips          []*kubeovnv1.IptablesEIP
 }
 
 // newFakeControllerWithOptions creates a fake controller with optional pre-populated objects
@@ -377,13 +379,15 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	}
 
 	ctrl.config = &Configuration{
-		ClusterRouter:        util.DefaultVpc,
-		DefaultLogicalSwitch: util.DefaultSubnet,
-		NodeSwitch:           "join",
-		KubeOvnClient:        kubeovnClient,
-		KubeClient:           kubeClient,
-		PodNamespace:         metav1.NamespaceSystem,
-		AttachNetClient:      nadClient,
+		ClusterRouter:         util.DefaultVpc,
+		DefaultLogicalSwitch:  util.DefaultSubnet,
+		NodeSwitch:            "join",
+		KubeOvnClient:         kubeovnClient,
+		KubeClient:            kubeClient,
+		PodNamespace:          metav1.NamespaceSystem,
+		AttachNetClient:       nadClient,
+		EnableANP:             opts.EnableANP,
+		EnableDNSNameResolver: opts.EnableDNSNameResolver,
 	}
 
 	if err := ctrl.setupIndexers(vpcInformer.Informer(), podInformer.Informer(), endpointSliceInformer.Informer(), ipInformer.Informer()); err != nil {

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -244,18 +244,15 @@ func TestGcNetworkPolicyDeletesLeftoversWhenDisabled(t *testing.T) {
 }
 
 func TestGcAdminNetworkPolicySkipsWhenEnabled(t *testing.T) {
-	fakeController := newFakeController(t)
-	ctrl := fakeController.fakeController
-	ctrl.config.EnableANP = true
-
-	require.NoError(t, ctrl.gcAdminNetworkPolicy())
+	fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{EnableANP: true})
+	require.NoError(t, err)
+	require.NoError(t, fakeController.fakeController.gcAdminNetworkPolicy())
 }
 
 func TestGcAdminNetworkPolicyDeletesLeftoversWhenDisabled(t *testing.T) {
 	fakeController := newFakeController(t)
 	ctrl := fakeController.fakeController
 	mockOvnClient := fakeController.mockOvnClient
-	ctrl.config.EnableANP = false
 
 	anpPG := ovnnb.PortGroup{
 		Name:        "anp.foo",
@@ -295,10 +292,12 @@ func TestGcDisabledDNSNameResolvers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeController := newFakeController(t)
+			fakeController, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				EnableANP:             tt.enableANP,
+				EnableDNSNameResolver: tt.enableDNSNameResolver,
+			})
+			require.NoError(t, err)
 			ctrl := fakeController.fakeController
-			ctrl.config.EnableANP = tt.enableANP
-			ctrl.config.EnableDNSNameResolver = tt.enableDNSNameResolver
 
 			resolver := &kubeovnv1.DNSNameResolver{
 				Name:   "anp-example-resolver",
@@ -306,7 +305,7 @@ func TestGcDisabledDNSNameResolvers(t *testing.T) {
 			}
 			unmanaged := &kubeovnv1.DNSNameResolver{Name: "unmanaged-resolver"}
 			client := ctrl.config.KubeOvnClient.KubeovnV1().DNSNameResolvers()
-			_, err := client.Create(context.Background(), resolver, metav1.CreateOptions{})
+			_, err = client.Create(context.Background(), resolver, metav1.CreateOptions{})
 			require.NoError(t, err)
 			_, err = client.Create(context.Background(), unmanaged, metav1.CreateOptions{})
 			require.NoError(t, err)

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -309,28 +309,7 @@ func (config *Configuration) initNicConfig(nicBridgeMappings map[string]string) 
 		if err != nil {
 			return fmt.Errorf("failed to get iface addr. %w", err)
 		}
-		for _, addr := range addrs {
-			_, ipCidr, err := net.ParseCIDR(addr.String())
-			if err != nil {
-				klog.Errorf("Failed to parse CIDR address %s: %v, skipping", addr.String(), err)
-				continue
-			}
-			// exclude the vip as encap ip unless host-tunnel-src is true
-			if ones, bits := ipCidr.Mask.Size(); ones == bits && !config.HostTunnelSrc {
-				klog.Infof("Skip address %s", ipCidr.String())
-				continue
-			}
-
-			// exclude link-local and loopback addresses
-			ipStr, _, _ := strings.Cut(addr.String(), "/")
-			if ip := net.ParseIP(ipStr); ip == nil || ip.IsLinkLocalUnicast() || ip.IsLoopback() {
-				continue
-			}
-			if len(srcIPs) == 0 || slices.Contains(srcIPs, ipStr) {
-				encapIP = ipStr
-				break
-			}
-		}
+		encapIP = selectEncapIP(addrs, srcIPs, config.HostTunnelSrc, config.NodeIPv4, config.NodeIPv6)
 		if len(encapIP) == 0 {
 			return fmt.Errorf("iface %s has no valid IP address", tunnelNic)
 		}
@@ -404,6 +383,65 @@ func (config *Configuration) getEncapIP(node *corev1.Node) string {
 		return ipv4
 	}
 	return ipv6
+}
+
+// selectEncapIP picks the tunnel source address among the addresses of the tunnel
+// interface. It returns an empty string if no address is usable.
+//
+// A full-mask address (/32, /128) sharing the interface with other usable addresses of
+// the same family is most likely a VIP, e.g. one managed by keepalived: using it as the
+// encap IP would break all tunnels once the VIP drifts to another node, so it is
+// skipped. Three exceptions:
+//   - it is the only usable, i.e. neither loopback nor link-local, address of its family
+//     on the interface: a VIP never lives alone on the tunnel NIC, so this is the node
+//     address itself, typically a /32 assigned by a cloud DHCP server;
+//   - it is one of the node internal IPs: kube-apiserver already accepts it as this
+//     node's own address, so it is not a floating VIP;
+//   - hostTunnelSrc is set: the operator deliberately sources tunnels from a full-mask
+//     address, typically a /32 advertised via BGP and assigned to lo or a dummy
+//     interface. Note a real loopback address such as 127.0.0.1 is always excluded.
+//
+// srcIPs holds the source addresses of the link scope routes on the interface: when it
+// is not empty, the encap IP must be one of them.
+func selectEncapIP(addrs []net.Addr, srcIPs []string, hostTunnelSrc bool, nodeIPs ...string) string {
+	// gather the usable unicast addresses, excluding link-local and loopback ones,
+	// and count them per address family
+	candidates := make([]net.IPNet, 0, len(addrs))
+	var n4, n6 int
+	for _, addr := range addrs {
+		ip, ipNet, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			klog.Errorf("Failed to parse CIDR address %s: %v, skipping", addr.String(), err)
+			continue
+		}
+		if ip.IsLinkLocalUnicast() || ip.IsLoopback() {
+			continue
+		}
+		candidates = append(candidates, net.IPNet{IP: ip, Mask: ipNet.Mask})
+		if ip.To4() != nil {
+			n4++
+		} else {
+			n6++
+		}
+	}
+
+	for _, c := range candidates {
+		ipStr := c.IP.String()
+		sameFamily := n4
+		if c.IP.To4() == nil {
+			sameFamily = n6
+		}
+		if ones, bits := c.Mask.Size(); ones == bits && sameFamily > 1 && !hostTunnelSrc &&
+			!slices.Contains(nodeIPs, ipStr) {
+			klog.Infof("Skip address %s: it looks like a vip, the interface has %d usable addresses of the same family",
+				ipStr, sameFamily)
+			continue
+		}
+		if len(srcIPs) == 0 || slices.Contains(srcIPs, ipStr) {
+			return ipStr
+		}
+	}
+	return ""
 }
 
 func findInterface(ifaceStr string) (*net.Interface, error) {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -402,10 +402,12 @@ func (config *Configuration) getEncapIP(node *corev1.Node) string {
 //     interface. Note a real loopback address such as 127.0.0.1 is always excluded.
 //
 // srcIPs holds the source addresses of the link scope routes on the interface: when it
-// is not empty, the encap IP must be one of them.
+// is not empty, the encap IP must be one of them. Addresses excluded by srcIPs do not
+// count towards the same family check below, otherwise an unusable address could make a
+// usable full-mask one look like a vip.
 func selectEncapIP(addrs []net.Addr, srcIPs []string, hostTunnelSrc bool, nodeIPs ...string) string {
-	// gather the usable unicast addresses, excluding link-local and loopback ones,
-	// and count them per address family
+	// gather the selectable unicast addresses, excluding link-local, loopback and non
+	// route source ones, and count them per address family
 	candidates := make([]net.IPNet, 0, len(addrs))
 	var n4, n6 int
 	for _, addr := range addrs {
@@ -415,6 +417,9 @@ func selectEncapIP(addrs []net.Addr, srcIPs []string, hostTunnelSrc bool, nodeIP
 			continue
 		}
 		if ip.IsLinkLocalUnicast() || ip.IsLoopback() {
+			continue
+		}
+		if len(srcIPs) != 0 && !slices.Contains(srcIPs, ip.String()) {
 			continue
 		}
 		candidates = append(candidates, net.IPNet{IP: ip, Mask: ipNet.Mask})
@@ -437,9 +442,7 @@ func selectEncapIP(addrs []net.Addr, srcIPs []string, hostTunnelSrc bool, nodeIP
 				ipStr, sameFamily)
 			continue
 		}
-		if len(srcIPs) == 0 || slices.Contains(srcIPs, ipStr) {
-			return ipStr
-		}
+		return ipStr
 	}
 	return ""
 }

--- a/pkg/daemon/config_test.go
+++ b/pkg/daemon/config_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -169,4 +170,83 @@ func TestGetEncapIPByNetworkEmptyNodeNetworks(t *testing.T) {
 
 	_, err = config.GetEncapIPByNetwork("storage")
 	require.Error(t, err)
+}
+
+func TestSelectEncapIP(t *testing.T) {
+	addrs := func(cidrs ...string) []net.Addr {
+		ret := make([]net.Addr, 0, len(cidrs))
+		for _, cidr := range cidrs {
+			ip, ipNet, err := net.ParseCIDR(cidr)
+			require.NoError(t, err)
+			ret = append(ret, &net.IPNet{IP: ip, Mask: ipNet.Mask})
+		}
+		return ret
+	}
+
+	tests := []struct {
+		name          string
+		addrs         []net.Addr
+		srcIPs        []string
+		hostTunnelSrc bool
+		nodeIPs       []string
+		expected      string
+	}{{
+		name:     "no address",
+		addrs:    addrs(),
+		expected: "",
+	}, {
+		name:     "single /32 assigned by cloud dhcp",
+		addrs:    addrs("10.198.0.140/32", "fe80::2c28:3aff:fe25:bf57/64"),
+		expected: "10.198.0.140",
+	}, {
+		name:     "single /128",
+		addrs:    addrs("fd00::1/128", "fe80::1/64"),
+		expected: "fd00::1",
+	}, {
+		name:     "dual stack full mask addresses",
+		addrs:    addrs("10.198.0.140/32", "fd00::1/128"),
+		expected: "10.198.0.140",
+	}, {
+		name:     "vip is skipped in favor of the node address",
+		addrs:    addrs("192.168.0.11/32", "192.168.0.10/24"),
+		expected: "192.168.0.10",
+	}, {
+		name:          "vip is used when host tunnel src is enabled",
+		addrs:         addrs("192.168.0.11/32", "192.168.0.10/24"),
+		hostTunnelSrc: true,
+		expected:      "192.168.0.11",
+	}, {
+		name:     "all full mask addresses of the family are skipped but one remains per family",
+		addrs:    addrs("192.168.0.11/32", "192.168.0.12/32", "fd00::1/128"),
+		expected: "fd00::1",
+	}, {
+		name:     "node ip is used even when another full mask address exists",
+		addrs:    addrs("192.168.0.11/32", "192.168.0.10/32"),
+		nodeIPs:  []string{"192.168.0.10"},
+		expected: "192.168.0.10",
+	}, {
+		name:     "no candidate is left when every address of the single stack nic is a vip",
+		addrs:    addrs("192.168.0.11/32", "192.168.0.12/32"),
+		expected: "",
+	}, {
+		name:     "address must be a route source when any exists",
+		addrs:    addrs("192.168.0.10/24", "192.168.1.10/24"),
+		srcIPs:   []string{"192.168.1.10"},
+		expected: "192.168.1.10",
+	}, {
+		name:     "no address matches the route sources",
+		addrs:    addrs("192.168.0.10/24"),
+		srcIPs:   []string{"192.168.1.10"},
+		expected: "",
+	}, {
+		name:     "loopback and link local addresses are ignored",
+		addrs:    addrs("127.0.0.1/8", "169.254.1.1/16", "10.198.0.140/32"),
+		expected: "10.198.0.140",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, selectEncapIP(tt.addrs, tt.srcIPs, tt.hostTunnelSrc, tt.nodeIPs...))
+		})
+	}
 }

--- a/pkg/daemon/config_test.go
+++ b/pkg/daemon/config_test.go
@@ -239,6 +239,11 @@ func TestSelectEncapIP(t *testing.T) {
 		srcIPs:   []string{"192.168.1.10"},
 		expected: "",
 	}, {
+		name:     "full mask address is not a vip when the other address is not a route source",
+		addrs:    addrs("10.0.0.10/32", "10.0.0.11/24"),
+		srcIPs:   []string{"10.0.0.10"},
+		expected: "10.0.0.10",
+	}, {
 		name:     "loopback and link local addresses are ignored",
 		addrs:    addrs("127.0.0.1/8", "169.254.1.1/16", "10.198.0.140/32"),
 		expected: "10.198.0.140",


### PR DESCRIPTION
On cloud providers the tunnel NIC often carries a single /32 (or /128) address assigned by DHCP:

    2: eno1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1480
        inet 10.198.0.140/32 metric 100 scope global dynamic eno1

initNicConfig treated every full-mask address as a VIP and skipped it, leaving no candidate, so cni-server crash-looped with:

    Skip address 10.198.0.140/32
    iface eno1 has no valid IP address

A VIP never lives alone on the tunnel NIC, and the node internal IP is by definition not a floating VIP, so keep skipping full-mask addresses only when the interface has another usable address of the same family and the address is not a node internal IP. --host-tunnel-src keeps overriding the exclusion entirely.

The selection is extracted into the pure function selectEncapIP and covered by unit tests.

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
