### PR TITLE
fix(ci): include ACL sampling in x86 E2E result

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -5431,6 +5431,7 @@ jobs:
     needs:
       - e2e-selection
       - e2e-control-validation
+      - acl-sampling-e2e
       - bgp-speaker-e2e
       - chart-test
       - cilium-chaining-e2e


### PR DESCRIPTION
The trusted x86 E2E executor result job did not include the newly added `acl-sampling-e2e` job in its `needs` list.

As a result, the control validation result reported `acl-sampling-e2e: missing`, marked the executor failed, and skipped all selected E2E jobs. Include the job in the result aggregation so the PR status reflects the actual executor jobs.

Validation:
- `python3 -m unittest hack/test_e2e_control.py hack/test_e2e_selector.py` (103 tests)
- `git diff --check`