### PR TITLE
test(controller): fix Go 1.27 modernize diagnostics

### DIFF
--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -219,12 +219,14 @@ func TestGcNetworkPolicyDeletesLeftoversWhenDisabled(t *testing.T) {
 	mockOvnClient := fakeController.mockOvnClient
 	ctrl.config.EnableNP = false
 
-	npPG := ovnnb.PortGroup{}
-	npPG.Name = "allow.default"
-	npPG.ExternalIDs = map[string]string{networkPolicyKey: "default/allow"}
-	nodePG := ovnnb.PortGroup{}
-	nodePG.Name = "node.node1"
-	nodePG.ExternalIDs = map[string]string{networkPolicyKey: "node/node1"}
+	npPG := ovnnb.PortGroup{
+		Name:        "allow.default",
+		ExternalIDs: map[string]string{networkPolicyKey: "default/allow"},
+	}
+	nodePG := ovnnb.PortGroup{
+		Name:        "node.node1",
+		ExternalIDs: map[string]string{networkPolicyKey: "node/node1"},
+	}
 
 	mockOvnClient.EXPECT().ListPortGroups(map[string]string{networkPolicyKey: ""}).Return([]ovnnb.PortGroup{npPG, nodePG}, nil)
 	mockOvnClient.EXPECT().DeletePortGroup(npPG.Name).Return(nil)
@@ -255,12 +257,14 @@ func TestGcAdminNetworkPolicyDeletesLeftoversWhenDisabled(t *testing.T) {
 	mockOvnClient := fakeController.mockOvnClient
 	ctrl.config.EnableANP = false
 
-	anpPG := ovnnb.PortGroup{}
-	anpPG.Name = "anp.foo"
-	anpPG.ExternalIDs = map[string]string{adminNetworkPolicyKey: "anp.foo"}
-	banpPG := ovnnb.PortGroup{}
-	banpPG.Name = "banp.bar"
-	banpPG.ExternalIDs = map[string]string{baselineAdminNetworkPolicyKey: "banp.bar"}
+	anpPG := ovnnb.PortGroup{
+		Name:        "anp.foo",
+		ExternalIDs: map[string]string{adminNetworkPolicyKey: "anp.foo"},
+	}
+	banpPG := ovnnb.PortGroup{
+		Name:        "banp.bar",
+		ExternalIDs: map[string]string{baselineAdminNetworkPolicyKey: "banp.bar"},
+	}
 
 	mockOvnClient.EXPECT().ListPortGroups(map[string]string{adminNetworkPolicyKey: ""}).Return([]ovnnb.PortGroup{anpPG}, nil)
 	mockOvnClient.EXPECT().DeletePortGroup(anpPG.Name).Return(nil)


### PR DESCRIPTION
Fix the Go 1.27 modernize diagnostics in pkg/controller/gc_test.go.

The four PortGroup fixtures now initialize Name and ExternalIDs directly in struct literals instead of assigning fields after an empty literal.

Validation:
- go test ./pkg/controller -run 'TestGc(NetworkPolicyDeletesLeftoversWhenDisabled|AdminNetworkPolicyDeletesLeftoversWhenDisabled)' -count=1\n- modernize -test ./pkg/controller\n- gofmt and git diff --check