### PR TITLE
fix: add DNS resolution fallback in CheckProtocol() and export resolved env vars in start-db.sh

### DIFF
--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -255,6 +255,7 @@ function set_nb_version_compatibility() {
 
 if [[ -n "${NODE_IPS:-}" ]]; then
     normalize_raft_addrs
+    export POD_IP NODE_IPS DB_CLUSTER_ADDR
 fi
 
 function archive_recovery_file {

--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -566,10 +566,17 @@ func doOvnLeaderCheck(cfg *Configuration, podName, podNamespace string) {
 		util.LogFatalAndExit(nil, "preValidChkCfg: invalid cfg")
 	}
 
-	// Determine the expected AddressType based on pod IP protocol
+	// Determine the expected AddressType based on pod IP protocol.
+	// In HCP mode POD_IP is a headless-Service hostname (e.g.
+	// ovn-central-0.ovn-central.kube-system.svc) rather than a literal IP,
+	// so it must be resolved to determine the address family.
 	podIP := os.Getenv(util.EnvPodIP)
+	protocol, err := util.ResolveProtocol(podIP)
+	if err != nil {
+		klog.Warningf("failed to resolve POD_IP %q to an address family, defaulting to %s: %v", podIP, kubeovnv1.ProtocolIPv4, err)
+	}
 	var expectedAddrType discoveryv1.AddressType
-	if util.CheckProtocol(podIP) == kubeovnv1.ProtocolIPv6 {
+	if err == nil && protocol == kubeovnv1.ProtocolIPv6 {
 		expectedAddrType = discoveryv1.AddressTypeIPv6
 	} else {
 		expectedAddrType = discoveryv1.AddressTypeIPv4

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -226,6 +227,63 @@ func CheckProtocol(address string) string {
 	err := fmt.Errorf("invalid address %q", address)
 	klog.Error(err)
 	return ""
+}
+
+// resolveProtocol classifies the given address into kubeovnv1.ProtocolIPv4 or
+// kubeovnv1.ProtocolIPv6. The address may be a literal IP address or a
+// hostname, in which case lookup is used to resolve it. lookup is injectable
+// so tests can provide deterministic results.
+//
+// When a hostname resolves to addresses of both address families, IPv4 is
+// preferred: the choice must be deterministic because resolver ordering is
+// not, and callers (e.g. the OVN leader checker) only distinguish IPv4 from
+// IPv6.
+func resolveProtocol(ctx context.Context, lookup func(ctx context.Context, host string) ([]net.IP, error), address string) (string, error) {
+	address = strings.Split(address, "/")[0]
+	if ip := net.ParseIP(address); ip != nil {
+		if ip.To4() != nil {
+			return kubeovnv1.ProtocolIPv4, nil
+		}
+		return kubeovnv1.ProtocolIPv6, nil
+	}
+
+	addrs, err := lookup(ctx, address)
+	if err != nil || len(addrs) == 0 {
+		return "", fmt.Errorf("failed to resolve address %q: %w", address, err)
+	}
+	var v4, v6 bool
+	for _, addr := range addrs {
+		if addr.To4() != nil {
+			v4 = true
+		} else if addr.To16() != nil {
+			v6 = true
+		}
+	}
+	switch {
+	case v4:
+		return kubeovnv1.ProtocolIPv4, nil
+	case v6:
+		return kubeovnv1.ProtocolIPv6, nil
+	default:
+		return "", fmt.Errorf("failed to resolve address %q to a valid IP", address)
+	}
+}
+
+// ResolveProtocol returns the address family of the given IP address or
+// hostname. Unlike CheckProtocol, which only accepts literal IP addresses,
+// hostnames are resolved via DNS.
+func ResolveProtocol(address string) (string, error) {
+	return resolveProtocol(context.Background(), func(ctx context.Context, host string) ([]net.IP, error) {
+		addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		ips := make([]net.IP, 0, len(addrs))
+		for _, addr := range addrs {
+			ips = append(ips, addr.IP)
+		}
+		return ips, nil
+	}, address)
 }
 
 func AddressCountBigInt(network *net.IPNet) internal.BigInt {

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"context"
+	"errors"
 	"math/big"
 	"net"
 	"os"
@@ -482,6 +484,84 @@ func TestCheckProtocol(t *testing.T) {
 				t.Errorf("%v expected %v, but %v got",
 					c.address, c.want, ans)
 			}
+		})
+	}
+}
+
+func TestResolveProtocol(t *testing.T) {
+	errLookupFailed := errors.New("lookup failed")
+	tests := []struct {
+		name    string
+		address string
+		addrs   []net.IP
+		lookErr error
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "literalIPv4",
+			address: "192.168.0.23",
+			want:    kubeovnv1.ProtocolIPv4,
+		},
+		{
+			name:    "literalIPv6",
+			address: "ffff:ffff:ffff:ffff:ffff:0:ffff:fffe",
+			want:    kubeovnv1.ProtocolIPv6,
+		},
+		{
+			name:    "hostnameResolvesIPv4",
+			address: "ovn-central-0.ovn-central.kube-system.svc",
+			addrs:   []net.IP{net.ParseIP("192.168.0.23")},
+			want:    kubeovnv1.ProtocolIPv4,
+		},
+		{
+			name:    "hostnameResolvesIPv6",
+			address: "ovn-central-0.ovn-central.kube-system.svc",
+			addrs:   []net.IP{net.ParseIP("ffff::fffe")},
+			want:    kubeovnv1.ProtocolIPv6,
+		},
+		{
+			name:    "hostnameResolvesBothFamiliesPrefersIPv4",
+			address: "ovn-central-0.ovn-central.kube-system.svc",
+			addrs:   []net.IP{net.ParseIP("ffff::fffe"), net.ParseIP("192.168.0.23")},
+			want:    kubeovnv1.ProtocolIPv4,
+		},
+		{
+			name:    "hostnameResolvesBothFamiliesIPv4FirstAlsoPrefersIPv4",
+			address: "ovn-central-0.ovn-central.kube-system.svc",
+			addrs:   []net.IP{net.ParseIP("192.168.0.23"), net.ParseIP("ffff::fffe")},
+			want:    kubeovnv1.ProtocolIPv4,
+		},
+		{
+			name:    "lookupFails",
+			address: "missing.svc.cluster.local",
+			lookErr: errLookupFailed,
+			wantErr: true,
+		},
+		{
+			name:    "lookupReturnsNoAddresses",
+			address: "empty.svc.cluster.local",
+			addrs:   []net.IP{},
+			wantErr: true,
+		},
+		{
+			name:    "emptyAddress",
+			address: "",
+			wantErr: true,
+		},
+	}
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			lookup := func(_ context.Context, _ string) ([]net.IP, error) {
+				return c.addrs, c.lookErr
+			}
+			got, err := resolveProtocol(context.Background(), lookup, c.address)
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Description

In HCP mode, ovn-central intentionally supplies a headless-Service hostname as `POD_IP` (e.g. `ovn-central-0.ovn-central.kube-system.svc`), while the leader checker needs the address family to pick the EndpointSlice address type (#7341).

Per review feedback, this PR keeps the generic `CheckProtocol` validator **literal-only** and introduces an explicit, testable resolver used only by the HCP leader-checker path:

- `util.resolveProtocol` (injectable lookup) + `util.ResolveProtocol` (wrapper over `net.DefaultResolver`) in `pkg/util/net.go`
- Dual-stack behavior is defined explicitly: when a hostname resolves to both A and AAAA records, **IPv4 is preferred** — deterministic, since resolver ordering is not and callers only distinguish IPv4/IPv6
- The leader checker falls back to IPv4 with a warning when resolution fails, preserving its previous defaulting behavior
- `CheckProtocol` is unchanged: no ambient DNS lookups from IP/CIDR validation paths
- `start-db.sh`: export the shell-resolved `POD_IP`/`NODE_IPS`/`DB_CLUSTER_ADDR` after `normalize_raft_addrs`

## Changes

- `pkg/util/net.go`: add `resolveProtocol` (injectable lookup) + `ResolveProtocol`; `CheckProtocol` untouched
- `pkg/ovn_leader_checker/ovn.go`: classify `POD_IP` via `ResolveProtocol`, warn + default to IPv4 on failure
- `pkg/util/net_test.go`: `TestResolveProtocol` with fake lookup covering literal v4/v6, hostname→v4/v6, hostname→both families (asserts IPv4 determinism), lookup failure, empty result, empty input
- `dist/images/start-db.sh`: export resolved env values

## Review notes

- The container capabilities change initially bundled here was split into a separate PR (to be linked).

## Test Plan

- `go test ./pkg/util/ -run "TestCheckProtocol|TestResolveProtocol" -v` — all pass, including the previously failing invalid-input cases (`not-an-ip`, `1.2.3`)
- `go test ./pkg/ovn_leader_checker/` — all pass

Fixes #7341