### PR TITLE
test(bgp): avoid duplicate IPv6 source cleanup

### DIFF
--- a/test/e2e/bgp/e2e_test.go
+++ b/test/e2e/bgp/e2e_test.go
@@ -365,13 +365,18 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		}
 
 		ginkgo.By("Changing the worker route source address without restarting the speaker")
+		sourceAddressAdded := make(map[string]bool, len(bgpFamilies(f)))
 		for _, family := range bgpFamilies(f) {
 			ginkgo.DeferCleanup(func() {
+				if !sourceAddressAdded[family.name] {
+					return
+				}
 				if err := removeWorkerSourceAddress(family); err != nil {
 					framework.Logf("failed to remove temporary %s worker source address: %v", family.name, err)
 				}
 			})
 			framework.ExpectNoError(addWorkerSourceAddress(family))
+			sourceAddressAdded[family.name] = true
 			framework.ExpectNoError(updateWorkerRoute(family))
 		}
 
@@ -388,6 +393,7 @@ var _ = framework.SerialDescribe("[group:bgp-speaker] BGP speaker", func() {
 		ginkgo.By("Restoring the worker route source address and reconciling the original route")
 		for _, family := range bgpFamilies(f) {
 			framework.ExpectNoError(removeWorkerSourceAddress(family))
+			sourceAddressAdded[family.name] = false
 		}
 		restoreTriggerName := "source-refresh-restore-trigger-" + framework.RandomSuffix()
 		createPodOnNode(f, restoreTriggerName, workerNode)


### PR DESCRIPTION
The IPv6 BGP speaker E2E explicitly restores the temporary worker source address before the test finishes, but its deferred cleanup remained armed and attempted to delete the address a second time.

Track whether each family still owns the temporary address and skip deferred cleanup after explicit restoration. Deferred cleanup remains active when setup or reconciliation fails.

Validation:
- go test ./test/e2e/bgp -run 'Test(PeersForFamilyFiltersFRRAddressFamilies|WorkerSourceAddressCommandsUseNoDADAndRestoreOriginalRoute|RoutePathsFromRoute)' -count=1\n- git diff --check\n\nObserved failure: GitHub Actions job 99094034367 exited with code 2 after `ip -6 addr del fd00:10:1::4/64` reported `address not found` during duplicate cleanup.