### PR TITLE
Backport #7322 to release-1.14

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -418,6 +418,34 @@ func (c *Controller) gcIP() error {
 	return nil
 }
 
+func (c *Controller) keepNodeLSPs(nodes []*corev1.Node, ipMap *strset.Set) map[string]string {
+	result := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		if node.Annotations[util.AllocatedAnnotation] == "true" {
+			portName := util.NodeLspName(node.Name)
+			result[portName] = node.Name
+			ipMap.Add(portName)
+		}
+
+		if _, err := c.ovnEipsLister.Get(node.Name); err == nil {
+			// node external gw lsp is managed by ovn eip cr, skip gc its lsp
+			ipMap.Add(node.Name)
+		}
+	}
+	return result
+}
+
+func (c *Controller) enqueueMissingNodeLSPs(nodes map[string]string, existing *strset.Set) {
+	for portName, nodeName := range nodes {
+		if existing.Has(portName) {
+			continue
+		}
+
+		klog.Warningf("node logical switch port %s is missing, enqueue node %s for reconciliation", portName, nodeName)
+		c.addNodeQueue.Add(nodeName)
+	}
+}
+
 func (c *Controller) markAndCleanLSP() error {
 	klog.V(4).Infof("start to gc logical switch ports")
 	pods, err := c.podsLister.List(labels.Everything())
@@ -456,16 +484,7 @@ func (c *Controller) markAndCleanLSP() error {
 			ipMap.Add(ovs.PodNameToPortName(podName, pod.Namespace, providerName))
 		}
 	}
-	for _, node := range nodes {
-		if node.Annotations[util.AllocatedAnnotation] == "true" {
-			ipMap.Add(util.NodeLspName(node.Name))
-		}
-
-		if _, err := c.ovnEipsLister.Get(node.Name); err == nil {
-			// node external gw lsp is managed by ovn eip cr, skip gc its lsp
-			ipMap.Add(node.Name)
-		}
-	}
+	nodeLspMap := c.keepNodeLSPs(nodes, ipMap)
 
 	// The lsp for vm pod should not be deleted if vm still exists
 	ipMap.Add(c.getVMLsps()...)
@@ -552,10 +571,14 @@ func (c *Controller) markAndCleanLSP() error {
 			klog.Infof("gc skip reserved ip %s", ipCR.Name)
 		}
 	}
+	c.enqueueMissingNodeLSPs(nodeLspMap, lspMap)
 	lastNoPodLSP = noPodLSP
 
 	ipMap.Each(func(ipName string) bool {
 		if !lspMap.Has(ipName) {
+			if _, ok := nodeLspMap[ipName]; ok {
+				return true
+			}
 			klog.Errorf("lsp lost for pod %s, please delete the pod and retry", ipName)
 		}
 		return true

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func newLogicalRouterPort(lrName, lrpName, mac string, networks []string) *ovnnb.LogicalRouterPort {
@@ -65,4 +66,21 @@ func TestGcSecurityGroupSkipsVpcEgressGatewayPortGroup(t *testing.T) {
 	mockOvnClient.EXPECT().DeletePortGroup(gomock.Any()).Times(0)
 
 	require.NoError(t, ctrl.gcSecurityGroup())
+}
+
+func TestEnqueueMissingNodeLSPs(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+
+	ctrl.enqueueMissingNodeLSPs(
+		map[string]string{util.NodeLspName("node-1"): "node-1"},
+		strset.New(),
+	)
+
+	require.Equal(t, 1, ctrl.addNodeQueue.Len())
+	item, shutdown := ctrl.addNodeQueue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "node-1", item)
+	ctrl.addNodeQueue.Done(item)
 }


### PR DESCRIPTION
Backport the controller fix from #7322.

- Includes pkg/controller/gc.go and controller unit tests.

- Does not include the master E2E case.