### PR TITLE
Backport #7322 to release-1.15

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -419,6 +419,34 @@ func (c *Controller) gcIP() error {
 	return nil
 }
 
+func (c *Controller) keepNodeLSPs(nodes []*corev1.Node, ipMap *strset.Set) map[string]string {
+	result := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		if node.Annotations[util.AllocatedAnnotation] == "true" {
+			portName := util.NodeLspName(node.Name)
+			result[portName] = node.Name
+			ipMap.Add(portName)
+		}
+
+		if _, err := c.ovnEipsLister.Get(node.Name); err == nil {
+			// node external gw lsp is managed by ovn eip cr, skip gc its lsp
+			ipMap.Add(node.Name)
+		}
+	}
+	return result
+}
+
+func (c *Controller) enqueueMissingNodeLSPs(nodes map[string]string, existing *strset.Set) {
+	for portName, nodeName := range nodes {
+		if existing.Has(portName) {
+			continue
+		}
+
+		klog.Warningf("node logical switch port %s is missing, enqueue node %s for reconciliation", portName, nodeName)
+		c.addNodeQueue.Add(nodeName)
+	}
+}
+
 func (c *Controller) markAndCleanLSP() error {
 	klog.V(4).Infof("start to gc logical switch ports")
 	pods, err := c.podsLister.List(labels.Everything())
@@ -461,16 +489,7 @@ func (c *Controller) markAndCleanLSP() error {
 			ipMap.Add(ovs.PodNameToPortName(podName, pod.Namespace, providerName))
 		}
 	}
-	for _, node := range nodes {
-		if node.Annotations[util.AllocatedAnnotation] == "true" {
-			ipMap.Add(util.NodeLspName(node.Name))
-		}
-
-		if _, err := c.ovnEipsLister.Get(node.Name); err == nil {
-			// node external gw lsp is managed by ovn eip cr, skip gc its lsp
-			ipMap.Add(node.Name)
-		}
-	}
+	nodeLspMap := c.keepNodeLSPs(nodes, ipMap)
 
 	// The lsp for vm pod should not be deleted if vm still exists
 	ipMap.Add(c.getVMLsps()...)
@@ -557,10 +576,14 @@ func (c *Controller) markAndCleanLSP() error {
 			klog.Infof("gc skip reserved ip %s", ipCR.Name)
 		}
 	}
+	c.enqueueMissingNodeLSPs(nodeLspMap, lspMap)
 	lastNoPodLSP = noPodLSP
 
 	ipMap.Each(func(ipName string) bool {
 		if !lspMap.Has(ipName) {
+			if _, ok := nodeLspMap[ipName]; ok {
+				return true
+			}
 			klog.Errorf("lsp lost for pod %s, please delete the pod and retry", ipName)
 		}
 		return true

--- a/pkg/controller/gc_test.go
+++ b/pkg/controller/gc_test.go
@@ -6,7 +6,11 @@ import (
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
+	kubeovnlisters "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -68,4 +72,81 @@ func TestGcSecurityGroupSkipsVpcEgressGatewayPortGroup(t *testing.T) {
 	mockOvnClient.EXPECT().DeletePortGroup(gomock.Any()).Times(0)
 
 	require.NoError(t, ctrl.gcSecurityGroup())
+}
+
+func TestMarkAndCleanLSPEnqueuesMissingNodeLSP(t *testing.T) {
+	fakeController, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	require.NoError(t, fakeController.fakeInformers.nodeInformer.Informer().GetStore().Add(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation: "true",
+			},
+		},
+	}))
+
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	ctrl.config.EnableKeepVMIP = false
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+	ctrl.virtualIpsLister = kubeovnlisters.NewVipLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	ctrl.ovnEipsLister = kubeovnlisters.NewOvnEipLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(false, nil).Return(nil, nil)
+
+	require.NoError(t, ctrl.markAndCleanLSP())
+	require.Equal(t, 1, ctrl.addNodeQueue.Len())
+}
+
+func TestMarkAndCleanLSPKeepsExistingNodeLSP(t *testing.T) {
+	fakeController, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	require.NoError(t, fakeController.fakeInformers.nodeInformer.Informer().GetStore().Add(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation: "true",
+			},
+		},
+	}))
+
+	ctrl := fakeController.fakeController
+	mockOvnClient := fakeController.mockOvnClient
+	ctrl.config.EnableKeepVMIP = false
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+	ctrl.virtualIpsLister = kubeovnlisters.NewVipLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	ctrl.ovnEipsLister = kubeovnlisters.NewOvnEipLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+
+	previousLastNoPodLSP := lastNoPodLSP
+	lastNoPodLSP = strset.New()
+	t.Cleanup(func() { lastNoPodLSP = previousLastNoPodLSP })
+
+	mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(false, nil).Return([]ovnnb.LogicalSwitchPort{
+		{Name: util.NodeLspName("node-1")},
+		{Name: "orphan"},
+	}, nil)
+
+	require.NoError(t, ctrl.markAndCleanLSP())
+	require.Equal(t, 0, ctrl.addNodeQueue.Len())
+	require.True(t, lastNoPodLSP.Has("orphan"))
+}
+
+func TestEnqueueMissingNodeLSPsSkipsExistingLSP(t *testing.T) {
+	fakeController := newFakeController(t)
+	ctrl := fakeController.fakeController
+	ctrl.addNodeQueue = newTypedRateLimitingQueue[string]("AddNode", nil)
+
+	ctrl.enqueueMissingNodeLSPs(
+		map[string]string{
+			util.NodeLspName("node-1"): "node-1",
+			util.NodeLspName("node-2"): "node-2",
+		},
+		strset.New(util.NodeLspName("node-1")),
+	)
+
+	require.Equal(t, 1, ctrl.addNodeQueue.Len())
+	item, shutdown := ctrl.addNodeQueue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "node-2", item)
+	ctrl.addNodeQueue.Done(item)
 }


### PR DESCRIPTION
Backport the controller fix from #7322.

- Includes pkg/controller/gc.go and controller unit tests.

- Does not include the master E2E case.