### PR TITLE
fix: require localConnectIP for VPC peering

### DIFF
--- a/pkg/controller/vpc.go
+++ b/pkg/controller/vpc.go
@@ -314,6 +314,11 @@ func (c *Controller) handleAddOrUpdateVpc(key string) error {
 
 	var newPeers []string
 	for _, peering := range vpc.Spec.VpcPeerings {
+		if peering.LocalConnectIP == "" {
+			err := fmt.Errorf("localConnectIP is required for vpc peering with %s, e.g. 169.254.0.1/30", peering.RemoteVpc)
+			klog.Error(err)
+			return err
+		}
 		if err = util.CheckCidrs(peering.LocalConnectIP); err != nil {
 			klog.Errorf("invalid cidr %s", peering.LocalConnectIP)
 			return err

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -606,6 +606,9 @@ func ValidateVpc(vpc *kubeovnv1.Vpc) error {
 	}
 
 	for _, item := range vpc.Spec.VpcPeerings {
+		if item.LocalConnectIP == "" {
+			return fmt.Errorf("localConnectIP is required for vpc peering with %s, e.g. 169.254.0.1/30", item.RemoteVpc)
+		}
 		if err := CheckCidrs(item.LocalConnectIP); err != nil {
 			klog.Error(err)
 			return fmt.Errorf("invalid cidr %s", item.LocalConnectIP)


### PR DESCRIPTION
## Description

When `localConnectIP` is empty (the default due to `omitempty` in the CRD), both the admission validator and the VPC controller call `util.CheckCidrs` on an empty string, which returns `CIDRInvalid`. This blocks the entire VPC reconciliation and prevents the VPC from being created.

Since `CreatePeerRouterPort` also cannot function without a valid IP (it uses `localRouterPortIP` directly in OVN `Networks`), `localConnectIP` must be required for VPC peering.

## Changes

- **`pkg/util/validator.go`**: Add empty-string check before `CheckCidrs` in `ValidateVpc`, with a clear error message including an example format
- **`pkg/controller/vpc.go`**: Same check in the VPC reconciliation loop (covers the case where the admission webhook is disabled)

## Related Issue

Fixes #7343

## Test Plan

- Create a VPC with a `vpcPeerings` entry where `localConnectIP` is empty → should get a clear admission error
- Create a VPC with a valid `localConnectIP` (e.g. `169.254.0.1/30`) → should succeed as before