### PR TITLE
test(e2e): skip QoS finalizer cases before v1.17

### DIFF
--- a/test/e2e/iptables-eip-qos/e2e_test.go
+++ b/test/e2e/iptables-eip-qos/e2e_test.go
@@ -1531,6 +1531,8 @@ var _ = framework.OrderedDescribe("[group:qos-policy]", func() {
 	})
 
 	framework.ConformanceIt("eip qos policy finalizer is released after the bound eip is deleted", func() {
+		f.SkipVersionPriorTo(1, 17, "QoS policy finalizer release requires the v1.17 controller implementation")
+
 		// Regression: deleting an EIP without first unbinding its QoS policy must still let
 		// the QoS policy (already marked for deletion) drop its finalizer.
 		setupQosNatGwEnvironment(f, dockerExtNetNetwork, vpcQosParams, net1NicName, "")
@@ -1548,6 +1550,8 @@ var _ = framework.OrderedDescribe("[group:qos-policy]", func() {
 	})
 
 	framework.ConformanceIt("eip qos policy finalizer is released after the qos policy is unbound", func() {
+		f.SkipVersionPriorTo(1, 17, "QoS policy finalizer release requires the v1.17 controller implementation")
+
 		// Regression: unbinding the QoS policy from an EIP must re-trigger the QoS reconcile
 		// so a policy already marked for deletion can drop its finalizer.
 		setupQosNatGwEnvironment(f, dockerExtNetNetwork, vpcQosParams, net1NicName, "")
@@ -1565,6 +1569,8 @@ var _ = framework.OrderedDescribe("[group:qos-policy]", func() {
 	})
 
 	framework.ConformanceIt("natgw qos policy finalizer is released after the qos policy is unbound", func() {
+		f.SkipVersionPriorTo(1, 17, "QoS policy finalizer release requires the v1.17 controller implementation")
+
 		// Regression: unbinding a NatGw-level QoS must re-trigger the QoS reconcile (keyed on the
 		// QoSLabel) so a policy already marked for deletion can drop its finalizer.
 		setupQosNatGwEnvironment(f, dockerExtNetNetwork, vpcQosParams, net1NicName, "")


### PR DESCRIPTION
## Summary

- Skip the three QoS finalizer lifecycle regression cases when the installed Kube-OVN version is older than v1.17.
- Keep the legacy QoS and iptables behavior cases enabled for release-1.16.

## Why

The release-1.16 controller does not add the QoS finalizer during the create reconcile. The finalizer lifecycle implementation from #7176 is not present on release-1.16, while the default-branch E2E source is used by the release workflow. This caused `Iptables VPC NAT Gateway E2E` run 33371645069 to fail identically in attempts 1, 2, and 3 at `e2e_test.go:1540`, before exercising the intended release path.

## Validation

- `gofmt`
- `git diff --check`
- `go test -c -o /tmp/iptables-eip-qos.test ./test/e2e/iptables-eip-qos`
- `go test ./test/e2e/iptables-eip-qos` reaches Ginkgo but requires a Kubernetes cluster locally

Signed-off-by: Zujian Zhang <zhangzujian.7@gmail.com>