### PR TITLE
[release-1.15] deps: update libovsdb to latest upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/osrg/gobgp/v4 v4.7.0
-	github.com/ovn-kubernetes/libovsdb v0.8.1
+	github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260710115425-adb4e0375fb5
 	github.com/parnurzeal/gorequest v0.3.0
 	github.com/prometheus-community/pro-bing v0.8.0
 	github.com/prometheus/client_golang v1.23.2
@@ -98,7 +98,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.11 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gaissmai/bart v0.26.1 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
@@ -118,7 +118,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.28.0 // indirect
+	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/godbus/dbus/v5 v5.2.0 // indirect
@@ -228,7 +228,7 @@ replace (
 	github.com/mdlayher/arp => github.com/kubeovn/arp v0.0.0-20240218024213-d9612a263f68
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
-	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20251212071713-cb1c2bc5d43e
+	github.com/ovn-kubernetes/libovsdb => github.com/kubeovn/libovsdb v0.0.0-20260902074400-457a5d8cc172
 	k8s.io/api => k8s.io/api v0.34.11
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.11
 	k8s.io/apimachinery => k8s.io/apimachinery v0.34.11

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gabriel-vasile/mimetype v1.4.11 h1:AQvxbp830wPhHTqc1u7nzoLT+ZFxGY7emj5DR5DYFik=
-github.com/gabriel-vasile/mimetype v1.4.11/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
+github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gaissmai/bart v0.26.1 h1:+w4rnLGNlA2GDVn382Tfe3jOsK5vOr5n4KmigJ9lbTo=
 github.com/gaissmai/bart v0.26.1/go.mod h1:GREWQfTLRWz/c5FTOsIw+KkscuFkIV5t8Rp7Nd1Td5c=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
@@ -193,8 +193,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.28.0 h1:Q7ibns33JjyW48gHkuFT91qX48KG0ktULL6FgHdG688=
-github.com/go-playground/validator/v10 v10.28.0/go.mod h1:GoI6I1SjPBh9p7ykNE/yj3fFYbyDOpwMn5KXd+m2hUU=
+github.com/go-playground/validator/v10 v10.30.3 h1:4MU6YkEwx7GbcPJOZxrtbu+QfF3pJLJuaYTeAH0DYy8=
+github.com/go-playground/validator/v10 v10.30.3/go.mod h1:4Axh7oCNGcoGkqLoE4YWt6n20mcEIsPRlB7vPk3lpyc=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
@@ -328,8 +328,8 @@ github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20250410045132-f48faac0d315 h1:PYw
 github.com/kubeovn/gonetworkmanager/v3 v3.0.0-20250410045132-f48faac0d315/go.mod h1:/SGJYGjOEAz+rw8JvkkbpcAyjQF1v4XPgpn1HqRg1fs=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20251128080558-ab7d8b8b5a66 h1:FlIRHOhiL78OOMcvM8rfEACgdBKiDpw0E3FSn272wJA=
 github.com/kubeovn/kubevirt-client-go v0.0.0-20251128080558-ab7d8b8b5a66/go.mod h1:98SIBmkgyZgcqIA+Rx3p2JLIk0Njjs5ZjyWu71epN7g=
-github.com/kubeovn/libovsdb v0.0.0-20251212071713-cb1c2bc5d43e h1:/DjPaByhzfDJcJ8A9jqoi16q/O1N5nGOHy9VmNZVnVM=
-github.com/kubeovn/libovsdb v0.0.0-20251212071713-cb1c2bc5d43e/go.mod h1:uqOuVsuGSJPoHDOS5O9VkJz/TIPm6Az/YZesHZ3qwDw=
+github.com/kubeovn/libovsdb v0.0.0-20260902074400-457a5d8cc172 h1:e8XTmu6psCshewB2CJau1bzLAJQ3czL3nNI4UFUEfyE=
+github.com/kubeovn/libovsdb v0.0.0-20260902074400-457a5d8cc172/go.mod h1:X8p5JMPYK5iKCyZ/RxFxvjl1sHfN7H9mo5UbtS5uImo=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475 h1:KZba2Kj9TXCUdUSqOR3eiy4VvkkIyhDVImYmYs6GQWU=
 github.com/kubeovn/ovsdb v0.0.0-20240410091831-5dd26006c475/go.mod h1:LAd0qoeAAm/QyZcpxN2BnpndM2/dhZt+/kokPvcxKcE=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyPlUHk/ofpgvBcNcawJLtf4PYHORLjAA=

--- a/pkg/ovs/ovn-nb-logical_router_policy.go
+++ b/pkg/ovs/ovn-nb-logical_router_policy.go
@@ -482,7 +482,9 @@ func (c *OVNNbClient) listLogicalRouterPoliciesByFilter(lrName string, filter fu
 	}
 
 	policyList := make([]*ovnnb.LogicalRouterPolicy, 0, len(lr.Policies))
-	if err = c.WhereCache(predicate).List(context.Background(), &policyList); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	if err := c.WhereCache(predicate).List(ctx, &policyList); err != nil {
 		klog.Error(err)
 		return nil, err
 	}


### PR DESCRIPTION
## What type of PR is this?

/kind dependency
/kind cleanup

## What this PR does / why we need it

Backport #7242 to `release-1.15`.

This updates `github.com/ovn-kubernetes/libovsdb` to the upstream pseudo-version `v0.8.2-0.20260710115425-adb4e0375fb5` and replaces it with `github.com/kubeovn/libovsdb@457a5d8cc172`. The fork commit is rebased onto `ovn-kubernetes/libovsdb@6acd868996b9` and retains the bounded OVSDB endpoint failover and reconnect behavior required by Kube-OVN.

## Release branch adaptation

- Apply the configured OVN client timeout to the logical router policy conditional cache read.
- Keep the release branch UUID-based static-route and NAT lookups because `GetLogicalRouterStaticRouteByUUID` and `GetNATByUUID` already use `c.Timeout`.
- Update the validator and MIME type transitive dependencies required by the new libovsdb module graph without changing the Kubernetes dependency baseline.
- Leave `pkg/ovn_leader_checker/ovn.go` unchanged because this branch already uses `serverdb.DatabaseName`.

## Which issue(s) this PR fixes

None.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Verification

- `go test ./pkg/ovs/...`
- `go test ./pkg/ovn_leader_checker ./pkg/ovsdb/...`
- `go mod tidy -diff`
- `git diff --check`

Source PR: #7242
Source merge commit: `6d5a9ef352af8ea007d8b5c5df188a5e4731abe2`