### PR TITLE
fix(ci): rebuild base images for trusted PR dispatch

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -486,8 +486,12 @@ jobs:
           fetch-depth: 0
 
       - id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSHA || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.headSHA || github.event.pull_request.head.sha }}
         run: |
-          if [ ${{ github.event_name }} != 'pull_request' ]; then
+          if [ "$EVENT_NAME" != 'pull_request' ] && [ "$EVENT_NAME" != 'workflow_dispatch' ]; then
             exit
           fi
           tmp_dir=`mktemp -d`
@@ -498,7 +502,7 @@ jobs:
           dist/images/go-deps/download-go-deps.sh
           dist/images/go-deps/rebuild-go-deps.sh
           EOF
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -Ff "$tmp_dir/on_changes.txt"; then
+          if git diff --name-only "$BASE_SHA...$HEAD_SHA" | grep -Ff "$tmp_dir/on_changes.txt"; then
             echo build-base=1 >> "$GITHUB_OUTPUT"
           fi
           rm -frv "$tmp_dir"
@@ -557,8 +561,12 @@ jobs:
           fetch-depth: 0
 
       - id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSHA || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.headSHA || github.event.pull_request.head.sha }}
         run: |
-          if [ ${{ github.event_name }} != 'pull_request' ]; then
+          if [ "$EVENT_NAME" != 'pull_request' ] && [ "$EVENT_NAME" != 'workflow_dispatch' ]; then
             exit
           fi
           tmp_dir=`mktemp -d`
@@ -566,7 +574,7 @@ jobs:
           dist/images/Dockerfile.base-dpdk
           dist/images/patches/
           EOF
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -Ff "$tmp_dir/on_changes.txt"; then
+          if git diff --name-only "$BASE_SHA...$HEAD_SHA" | grep -Ff "$tmp_dir/on_changes.txt"; then
             echo build-dpdk-base=1 >> "$GITHUB_OUTPUT"
           fi
           rm -frv "$tmp_dir"

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1727,10 +1727,7 @@ class E2EControlTest(unittest.TestCase):
             "",
         ))
         self.assertGreaterEqual(workflow.count("ref: ${{ env.EXECUTION_SHA }}"), 31)
-        self.assertIn(
-            '"${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"',
-            workflow,
-        )
+        self.assertIn('git diff --name-only "$BASE_SHA...$HEAD_SHA"', workflow)
 
     def testTrustedExecutorKeepsBaselineBuildWithoutKindImageGate(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
@@ -1761,6 +1758,24 @@ class E2EControlTest(unittest.TestCase):
                 )
                 if "docker load --input kind-node-" in block:
                     self.assertIn("- prepare-kind-node-images", block)
+
+    def testTrustedDispatchDetectsBaseImageChanges(self):
+        workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()
+        blocks = e2eSelector.workflowJobBlocks(workflow)
+
+        for jobId, outputName, path in [
+            ("build-kube-ovn-base", "build-base", "dist/images/Dockerfile.base"),
+            ("build-kube-ovn-dpdk-base", "build-dpdk-base", "dist/images/Dockerfile.base-dpdk"),
+        ]:
+            with self.subTest(jobId=jobId):
+                block = blocks[jobId]
+                self.assertIn("EVENT_NAME: ${{ github.event_name }}", block)
+                self.assertIn("BASE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSHA || github.event.pull_request.base.sha }}", block)
+                self.assertIn("HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.headSHA || github.event.pull_request.head.sha }}", block)
+                self.assertIn("if [ \"$EVENT_NAME\" != 'pull_request' ] && [ \"$EVENT_NAME\" != 'workflow_dispatch' ]; then", block)
+                self.assertIn('git diff --name-only "$BASE_SHA...$HEAD_SHA"', block)
+                self.assertIn(path, block)
+                self.assertIn(f"echo {outputName}=1", block)
 
     def testTrustedDispatchIsTheOnlyPullRequestExecutionEntry(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()


### PR DESCRIPTION
## Summary

Trusted `workflow_dispatch` x86 E2E executors currently skip `Build kube-ovn-base` and `Build kube-ovn-dpdk-base` change detection because the check step exits for every non-`pull_request` event. This caused run [33704219389](https://github.com/kubeovn/kube-ovn/actions/runs/33704219389), triggered for PR #6683, to skip base image rebuild steps even though the PR changed both base Dockerfiles and a base patch.

This change:

- Reuses the trusted `inputs.baseSHA` and `inputs.headSHA` for `workflow_dispatch` base change detection.
- Keeps push events out of the PR-only check.
- Adds a workflow contract test covering both base jobs.

## Validation

- `python3 -m unittest hack/test_e2e_control.py` (67 tests passed)
- `git diff --check`

Related: https://github.com/kubeovn/kube-ovn/actions/runs/33704219389/job/100489784105
