### PR TITLE
fix(ci): save trusted E2E Go cache

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -893,7 +893,11 @@ jobs:
           swap-storage: false
 
       - name: Go cache
-        if: steps.lookup-go-cache.outputs.cache-hit != 'true' && github.event_name == 'push'
+        # Trusted dispatches use an executor-specific ref, so this cache remains isolated from PRs and branches.
+        if: >-
+          steps.lookup-go-cache.outputs.cache-hit != 'true' &&
+          (github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]'))
         uses: actions/cache@v6
         with:
           path: |


### PR DESCRIPTION
## What changed

Allow the `Build E2E Binaries` job to save its Go cache when it is running from a trusted `workflow_dispatch` started by `github-actions[bot]`.

## Why

Trusted E2E dispatches previously restored the cache in lookup-only mode, but the subsequent `Go cache` step only allowed `push` events. As a result, `make e2e-build` ran without producing a cache for the other E2E jobs in the same run.

The cache key continues to use the executor-specific ref, so dispatch-built caches remain isolated from PR and branch caches. No untrusted pull-request event is allowed to write a cache.

## Validation

- `git diff --check`
- `actionlint -ignore 'label "larger-runner" is unknown' .github/workflows/build-x86-image.yaml`
