### PR TITLE
test(ci): accept trusted dispatch cache condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,8 @@ yamls/gen
 /frr/
 
 .claude/*
+
+# Python cache files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1806,7 +1806,13 @@ class E2EControlTest(unittest.TestCase):
             "matrix: ${{ fromJSON(needs.e2e-selection.outputs.kubeOvnConformanceMatrix) }}",
             blocks["kube-ovn-conformance-e2e"],
         )
-        self.assertIn("if: steps.lookup-go-cache.outputs.cache-hit != 'true' && github.event_name == 'push'", workflow)
+        normalizedWorkflow = " ".join(workflow.split())
+        self.assertIn(
+            "if: >- steps.lookup-go-cache.outputs.cache-hit != 'true' && "
+            "(github.event_name == 'push' || "
+            "(github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]'))",
+            normalizedWorkflow,
+        )
         self.assertIn("--force-full-reason \"$FORCE_FULL_REASON\"", workflow)
         self.assertIn("--request-full", workflow)
         self.assertNotIn("args+=(--label e2e:full)", workflow)


### PR DESCRIPTION
## Summary
- update the x86 E2E control test to match the trusted dispatch Go cache condition
- make the assertion insensitive to YAML line wrapping while preserving the required push and trusted bot dispatch branches

## Root Cause
Commit e5d74366f changed the Go cache step from a push-only single-line condition to a folded expression that also allows trusted github-actions[bot] workflow dispatches. The control test still required the removed single-line text, so the validation job failed before any E2E test ran.

## Validation
- python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py: 105 tests passed
- git diff --check

## CI Note
The trusted workflow intentionally checks out the approved base revision for e2e-control-validation. Therefore, the x86 validation run for this PR can still report the old assertion until this test update is merged; this PR does not change that security boundary.

Original failures:
- https://github.com/kubeovn/kube-ovn/actions/runs/33713086549/job/100516530109
- https://github.com/kubeovn/kube-ovn/actions/runs/33715264595/job/100523006037