### PR TITLE
feat: enhance tcpdump for kubevirt / fix: add default container to tcpdump / feat: enhance namespace selection for tcpdump

### DIFF
--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -171,15 +171,15 @@ kubevirt-tcpdump(){
 
   if [ "$hostNetwork" = "true" ]; then
     set -x
-    kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- tcpdump -nn "$@"
+    kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- tcpdump -nn "$@"
   else
-    nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$vmName"."$namespace" | tr -d '\r')
+    nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$vmName"."$namespace" | tr -d '\r')
     if [ -z "$nicName" ]; then
       echo "nic doesn't exist on node $nodeName"
       exit 1
     fi
     podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-    podNetNs=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
+    podNetNs=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
     ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
     if [ -z "$ovnCni" ]; then
       echo "kube-ovn-cni not exist on node $nodeName"
@@ -187,9 +187,9 @@ kubevirt-tcpdump(){
     fi
     set -x
     if [ "$podNicType" = "internal-port" ]; then
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
     else
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i k6t-eth0 "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- nsenter --net="$podNetNs" tcpdump -nn -i k6t-eth0 "$@"
     fi
   fi
 }
@@ -218,15 +218,15 @@ tcpdump(){
 
   if [ "$hostNetwork" = "true" ]; then
     set -x
-    kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- tcpdump -nn "$@"
+    kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- tcpdump -nn "$@"
   else
-    nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$podName"."$namespace" | tr -d '\r')
+    nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$podName"."$namespace" | tr -d '\r')
     if [ -z "$nicName" ]; then
       echo "nic doesn't exist on node $nodeName"
       exit 1
     fi
     podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-    podNetNs=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
+    podNetNs=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
     ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
     if [ -z "$ovnCni" ]; then
       echo "kube-ovn-cni not exist on node $nodeName"
@@ -234,9 +234,9 @@ tcpdump(){
     fi
     set -x
     if [ "$podNicType" = "internal-port" ]; then
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
     else
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i eth0 "$@"
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- nsenter --net="$podNetNs" tcpdump -nn -i eth0 "$@"
     fi
   fi
 }

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -152,7 +152,8 @@ kubevirt-tcpdump(){
   namespace=$(echo "$namespacedPod" | cut -d "/" -f1)
   vmName=$(echo "$namespacedPod" | cut -d "/" -f2)
   if [ "$vmName" = "$namespacedPod" ]; then
-    namespace="default"
+    namespace=$(kubectl config view --minify -o jsonpath='{..namespace}')
+    namespace=${namespace:-default}
   fi
 
   podName=$(kubectl get pod -l vm.kubevirt.io/name="$vmName" -o jsonpath='{.items[*].metadata.name}')
@@ -199,7 +200,8 @@ tcpdump(){
   namespace=$(echo "$namespacedPod" | cut -d "/" -f1)
   podName=$(echo "$namespacedPod" | cut -d "/" -f2)
   if [ "$podName" = "$namespacedPod" ]; then
-    namespace="default"
+    namespace=$(kubectl config view --minify -o jsonpath='{..namespace}')
+    namespace=${namespace:-default}
   fi
 
   nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -31,7 +31,6 @@ showHelp(){
   echo "  dpctl {nodeName} [ovs-dpctl options ...]   invoke ovs-dpctl on the specified node"
   echo "  appctl {nodeName} [ovs-appctl options ...]   invoke ovs-appctl on the specified node"
   echo "  tcpdump {namespace/podname} [tcpdump options ...]     capture pod traffic"
-  echo "  kubevirt-tcpdump {namespace/vmname} [tcpdump options ...]     capture vm traffic"
   echo "  {trace|ovn-trace} ...    trace ovn microflow of specific packet"
   echo "    {trace|ovn-trace} {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]    trace ICMP/TCP/UDP"
   echo "    {trace|ovn-trace} {namespace/podname} {target ip address} [target mac address] arp {request|reply}                     trace ARP request/reply"
@@ -147,66 +146,29 @@ ipIsInCidr(){
   return 1
 }
 
-kubevirt-tcpdump(){
-  namespacedPod="$1"; shift
-  namespace=$(echo "$namespacedPod" | cut -d "/" -f1)
-  vmName=$(echo "$namespacedPod" | cut -d "/" -f2)
-  if [ "$vmName" = "$namespacedPod" ]; then
-    namespace=$(kubectl config view --minify -o jsonpath='{..namespace}')
-    namespace=${namespace:-default}
-  fi
-
-  podName=$(kubectl get pod -l vm.kubevirt.io/name="$vmName" -o jsonpath='{.items[*].metadata.name}')
-  nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
-  hostNetwork=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.hostNetwork})
-  if [ -z "$nodeName" ]; then
-    echo "Pod $namespacedPod not exists on any node"
-    exit 1
-  fi
-
-  ovsPod=$(kubectl get pod -n $KUBE_OVN_NS -l app=ovs -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
-  if [ -z "$ovsPod" ]; then
-    echo "ovs-ovn not exist on node $nodeName"
-    exit 1
-  fi
-
-  if [ "$hostNetwork" = "true" ]; then
-    set -x
-    kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- tcpdump -nn "$@"
-  else
-    nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$vmName"."$namespace" | tr -d '\r')
-    if [ -z "$nicName" ]; then
-      echo "nic doesn't exist on node $nodeName"
-      exit 1
-    fi
-    podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-    podNetNs=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
-    ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
-    if [ -z "$ovnCni" ]; then
-      echo "kube-ovn-cni not exist on node $nodeName"
-      exit 1
-    fi
-    set -x
-    if [ "$podNicType" = "internal-port" ]; then
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
-    else
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- nsenter --net="$podNetNs" tcpdump -nn -i k6t-eth0 "$@"
-    fi
-  fi
-}
-
 tcpdump(){
   namespacedPod="$1"; shift
   namespace=$(echo "$namespacedPod" | cut -d "/" -f1)
+
   podName=$(echo "$namespacedPod" | cut -d "/" -f2)
   if [ "$podName" = "$namespacedPod" ]; then
     namespace=$(kubectl config view --minify -o jsonpath='{..namespace}')
     namespace=${namespace:-default}
   fi
 
-  nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
-  hostNetwork=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.hostNetwork})
+  isVm=$([[ "$(kubectl get vmi "$podName" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachine")].kind}' 2>/dev/null)" == "VirtualMachine" ]] && echo true || echo false)
+  if [ "$isVm" = "true" ]; then
+    vmName=$(echo "$podName")
+    podName=$(kubectl get pod -l vm.kubevirt.io/name="$vmName" -o jsonpath='{.items[*].metadata.name}')
+  fi
 
+  isVmi=$([[ "$(kubectl get pod "$podName" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachineInstance")].kind}' 2>/dev/null)" == "VirtualMachineInstance" ]] && echo true || echo false)
+  if [ "$isVmi" = "true" ]; then
+    vmName=$(kubectl get pod "$podName" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachineInstance")].name}')
+    isVm=true
+  fi
+  
+  nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
   if [ -z "$nodeName" ]; then
     echo "Pod $namespacedPod not exists on any node"
     exit 1
@@ -218,28 +180,29 @@ tcpdump(){
     exit 1
   fi
 
+  hostNetwork=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.hostNetwork})
   if [ "$hostNetwork" = "true" ]; then
     set -x
     kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- tcpdump -nn "$@"
   else
-    nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$podName"."$namespace" | tr -d '\r')
+    if [ "$isVm" = "true" ]; then
+      nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$vmName"."$namespace" | tr -d '\r')
+    else
+      nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$podName"."$namespace" | tr -d '\r')
+    fi
+
     if [ -z "$nicName" ]; then
       echo "nic doesn't exist on node $nodeName"
       exit 1
     fi
-    podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
-    podNetNs=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -c openvswitch -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
+
     ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
     if [ -z "$ovnCni" ]; then
       echo "kube-ovn-cni not exist on node $nodeName"
       exit 1
     fi
     set -x
-    if [ "$podNicType" = "internal-port" ]; then
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
-    else
-      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- nsenter --net="$podNetNs" tcpdump -nn -i eth0 "$@"
-    fi
+    kubectl exec "$ovnCni" -n $KUBE_OVN_NS -c cni-server -- tcpdump -nn -i "$nicName" "$@"
   fi
 }
 
@@ -1845,9 +1808,6 @@ case $subcommand in
   nb|sb)
     getOvnCentralPod
     dbtool "$subcommand" "$@"
-    ;;
-  kubevirt-tcpdump)
-    kubevirt-tcpdump "$@"
     ;;
   tcpdump)
     tcpdump "$@"

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -31,6 +31,7 @@ showHelp(){
   echo "  dpctl {nodeName} [ovs-dpctl options ...]   invoke ovs-dpctl on the specified node"
   echo "  appctl {nodeName} [ovs-appctl options ...]   invoke ovs-appctl on the specified node"
   echo "  tcpdump {namespace/podname} [tcpdump options ...]     capture pod traffic"
+  echo "  kubevirt-tcpdump {namespace/vmname} [tcpdump options ...]     capture vm traffic"
   echo "  {trace|ovn-trace} ...    trace ovn microflow of specific packet"
   echo "    {trace|ovn-trace} {namespace/podname} {target ip address} [target mac address] {icmp|tcp|udp} [target tcp/udp port]    trace ICMP/TCP/UDP"
   echo "    {trace|ovn-trace} {namespace/podname} {target ip address} [target mac address] arp {request|reply}                     trace ARP request/reply"
@@ -144,6 +145,53 @@ ipIsInCidr(){
   fi
 
   return 1
+}
+
+kubevirt-tcpdump(){
+  namespacedPod="$1"; shift
+  namespace=$(echo "$namespacedPod" | cut -d "/" -f1)
+  vmName=$(echo "$namespacedPod" | cut -d "/" -f2)
+  if [ "$vmName" = "$namespacedPod" ]; then
+    namespace="default"
+  fi
+
+  podName=$(kubectl get pod -l vm.kubevirt.io/name="$vmName" -o jsonpath='{.items[*].metadata.name}')
+  nodeName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.nodeName})
+  hostNetwork=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.spec.hostNetwork})
+  if [ -z "$nodeName" ]; then
+    echo "Pod $namespacedPod not exists on any node"
+    exit 1
+  fi
+
+  ovsPod=$(kubectl get pod -n $KUBE_OVN_NS -l app=ovs -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
+  if [ -z "$ovsPod" ]; then
+    echo "ovs-ovn not exist on node $nodeName"
+    exit 1
+  fi
+
+  if [ "$hostNetwork" = "true" ]; then
+    set -x
+    kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- tcpdump -nn "$@"
+  else
+    nicName=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading --columns=name find interface external-ids:iface-id="$vmName"."$namespace" | tr -d '\r')
+    if [ -z "$nicName" ]; then
+      echo "nic doesn't exist on node $nodeName"
+      exit 1
+    fi
+    podNicType=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath={.metadata.annotations.ovn\\.kubernetes\\.io/pod_nic_type})
+    podNetNs=$(kubectl exec "$ovsPod" -n $KUBE_OVN_NS -- ovs-vsctl --data=bare --no-heading get interface "$nicName" external-ids:pod_netns | tr -d '\r' | sed -e 's/^"//' -e 's/"$//')
+    ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -l app=kube-ovn-cni -o 'jsonpath={.items[?(@.spec.nodeName=="'$nodeName'")].metadata.name}')
+    if [ -z "$ovnCni" ]; then
+      echo "kube-ovn-cni not exist on node $nodeName"
+      exit 1
+    fi
+    set -x
+    if [ "$podNicType" = "internal-port" ]; then
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i "$nicName" "$@"
+    else
+      kubectl exec "$ovnCni" -n $KUBE_OVN_NS -- nsenter --net="$podNetNs" tcpdump -nn -i k6t-eth0 "$@"
+    fi
+  fi
 }
 
 tcpdump(){
@@ -1795,6 +1843,9 @@ case $subcommand in
   nb|sb)
     getOvnCentralPod
     dbtool "$subcommand" "$@"
+    ;;
+  kubevirt-tcpdump)
+    kubevirt-tcpdump "$@"
     ;;
   tcpdump)
     tcpdump "$@"

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -156,15 +156,29 @@ tcpdump(){
     namespace=${namespace:-default}
   fi
 
-  isVm=$([[ "$(kubectl get vmi "$podName" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachine")].kind}' 2>/dev/null)" == "VirtualMachine" ]] && echo true || echo false)
+  isVm=$([[ "$(kubectl get vmi "$podName" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachine")].kind}' 2>/dev/null)" == "VirtualMachine" ]] && echo true || echo false)
   if [ "$isVm" = "true" ]; then
     vmName=$(echo "$podName")
-    podName=$(kubectl get pod -l vm.kubevirt.io/name="$vmName" -o jsonpath='{.items[*].metadata.name}')
+
+    migrationState=$(kubectl get vmi "$vmName" -n "$namespace" -o jsonpath='{.status.migrationState}' 2>/dev/null)
+    migrationStateCompleted=$(kubectl get vmi "$vmName" -n "$namespace" -o jsonpath='{.status.migrationState.completed}' 2>/dev/null)
+    if [[ -n "$migrationState" && -z "$migrationStateCompleted" ]]; then # migration in progress
+      podName=$(kubectl get vmi "$vmName" -n "$namespace" -o jsonpath='{.status.migrationState.sourcePod}')
+      echo "WARNING: Migration in progress"
+      echo "$podName"
+    elif [[ -n "$migrationState" && -n "$migrationStateCompleted" ]]; then # migration done
+      podName=$(kubectl get vmi "$vmName" -n "$namespace" -o jsonpath='{.status.migrationState.targetPod}')
+      echo "$podName"
+    else
+      nodeName=$(kubectl get vmi "$vmName" -n "$namespace" -o jsonpath='{.status.nodeName}')
+      podName=$(kubectl get pod -n "$namespace" -l vm.kubevirt.io/name="$vmName" -o jsonpath="{range .items[?(@.spec.nodeName=='$nodeName')]}{.metadata.name}{'\n'}{end}")
+      echo "$podName"
+    fi
   fi
 
-  isVmi=$([[ "$(kubectl get pod "$podName" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachineInstance")].kind}' 2>/dev/null)" == "VirtualMachineInstance" ]] && echo true || echo false)
+  isVmi=$([[ "$(kubectl get pod "$podName" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachineInstance")].kind}' 2>/dev/null)" == "VirtualMachineInstance" ]] && echo true || echo false)
   if [ "$isVmi" = "true" ]; then
-    vmName=$(kubectl get pod "$podName" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachineInstance")].name}')
+    vmName=$(kubectl get pod "$podName" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[?(@.kind == "VirtualMachineInstance")].name}')
     isVm=true
   fi
   


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR
- Features
- Fix
- Docs

## Changes
- For troubleshooting and analysis, you can run kubectl ko tcpdump namespace/vm. This creates a packet capture session for the virtual machine, providing functionality equivalent to tcpdump. this cases are covered (pod / vm / virt-launcher)
- The default container has been added to kubectl exec. This prevents messages such as: ```Defaulted container "cni-server" out of: cni-server, hostpath-init (init), install-cni (init)``` from being displayed during execution.
- Namespace handling has been enhanced. If no namespace is provided as an input parameter, the tool first attempts to use the namespace of the current Kubernetes context. If the current context does not define a namespace, the tool automatically falls back to the default namespace.
## Which issue(s) this PR fixes
