### PR TITLE
test(e2e): wait for live OVN DB cluster recovery

### DIFF
--- a/test/e2e/ha/ha_test.go
+++ b/test/e2e/ha/ha_test.go
@@ -69,17 +69,35 @@ func cmdClusterStatus(db string) string {
 	return fmt.Sprintf("ovn-appctl -t /var/run/ovn/ovn%s_db.ctl cluster/status %s", db, dbNames[db])
 }
 
+func clusterStatusHasAllServers(output string, expected int) bool {
+	status := ""
+	serverCount := 0
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.Fields(line)
+		switch {
+		case strings.HasPrefix(line, "Status:"):
+			status = strings.TrimSpace(strings.TrimPrefix(line, "Status:"))
+		case slices.Contains(fields, "at"):
+			serverCount++
+		}
+	}
+	return status == "cluster member" && serverCount == expected
+}
+
 func waitForDbRecovery(f *framework.Framework, pods []corev1.Pod) {
 	ginkgo.GinkgoHelper()
 
+	expected := len(pods)
 	for pod := range slices.Values(pods) {
 		for _, db := range [...]string{"nb", "sb"} {
-			dbFile := dbFilePath(db)
-			ginkgo.By("Waiting for db file " + dbFile + " on node " + pod.Spec.NodeName + " to be healthy")
+			ginkgo.By("Waiting for ovn" + db + " db cluster on node " + pod.Spec.NodeName + " to show all servers")
 			framework.WaitUntil(time.Second, 60*time.Second, func(_ context.Context) (bool, error) {
-				_, _, err := framework.ExecShellInPod(context.Background(), f, pod.Namespace, pod.Name, "ovsdb-tool check-cluster "+dbFile)
-				return err == nil, nil
-			}, fmt.Sprintf("db file %s on node %s to be healthy", dbFile, pod.Spec.NodeName))
+				stdout, _, err := framework.ExecShellInPod(context.Background(), f, pod.Namespace, pod.Name, cmdClusterStatus(db))
+				if err != nil {
+					return false, nil
+				}
+				return clusterStatusHasAllServers(stdout, expected), nil
+			}, fmt.Sprintf("ovn%s db cluster on node %s to show %d servers", db, pod.Spec.NodeName, expected))
 		}
 	}
 }

--- a/test/e2e/ha/ha_test_unit_test.go
+++ b/test/e2e/ha/ha_test_unit_test.go
@@ -1,0 +1,35 @@
+package ha
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClusterStatusHasAllServers(t *testing.T) {
+	const status = `
+Status: cluster member
+Servers:
+    3e81 (3e81 at tcp:[172.18.0.2]:6643) (self)
+    68d9 (68d9 at tcp:[172.18.0.4]:6643) last msg 10 ms ago
+    007f (007f at tcp:[172.18.0.3]:6643) last msg 10 ms ago
+`
+
+	tests := []struct {
+		name     string
+		output   string
+		expected int
+		want     bool
+	}{
+		{name: "all members and healthy status", output: status, expected: 3, want: true},
+		{name: "missing member", output: status, expected: 4, want: false},
+		{name: "not a cluster member", output: strings.ReplaceAll(status, "Status: cluster member", "Status: joining"), expected: 3, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clusterStatusHasAllServers(tt.output, tt.expected); got != tt.want {
+				t.Fatalf("clusterStatusHasAllServers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The HA database corruption test waits for `ovsdb-tool check-cluster` on each recovered database file. This checks the on-disk Raft log while `ovsdb-server` is still asynchronously truncating and replaying entries. In run [100693105472](https://github.com/kubeovn/kube-ovn/actions/runs/33766383890/job/100693105472), the final SB recovery remained in this transitional state for the 60-second timeout even though the live cluster was reconnecting and electing a leader.

## Fix

- Wait for each live NB/SB database to report `Status: cluster member` and all expected servers through `cluster/status`.
- Keep the existing server ID, node placement, and final cluster membership assertions.
- Add unit coverage for healthy, incomplete, and joining cluster status output.

This uses the runtime cluster state as the recovery condition and avoids treating a temporary disk-log check failure as a failed recovery.

## Validation

- `go test ./test/e2e/ha -run TestClusterStatusHasAllServers -count=1`
- `go test ./test/e2e/ha -run '^$' -count=1`\n- `go test ./pkg/ovn_leader_checker -count=1`\n- `bash -n dist/images/start-db.sh`\n- `git diff --check`\n\nFull Kind E2E requires the GitHub Actions environment.