### PR TITLE
fix(chart): grant volume-init DAC capabilities in HCP mode

### DIFF
--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -85,6 +85,8 @@ spec:
               {{- if .Values.central.hcp.enabled }}
               add:
                 - CHOWN
+                - DAC_OVERRIDE
+                - DAC_READ_SEARCH
               {{- end }}
               drop:
                 - ALL

--- a/charts/kube-ovn-v2/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn-v2/tests/central_hcp_test.yaml
@@ -316,18 +316,42 @@ tests:
             name: OVN_SB_ADDR
             value: tcp:ovn-sb.example.com:6642
 
-  - it: points ovs upgrade hook at the HCP OVN NB address
-    template: hooks/upgrade-ovs-ovn.yaml
-    documentSelector:
-      path: kind
-      value: Job
+  - it: grants volume-init the capabilities needed to chown HCP volumes
+    template: central/central-deployment.yaml
     set:
       central.hcp.enabled: true
+      central.hcp.namespace: hcp
       central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
       central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
     asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: volume-init
       - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: OVN_NB_ADDR
-            value: tcp:ovn-nb.example.com:6641
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: CHOWN
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: DAC_OVERRIDE
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: DAC_READ_SEARCH
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: does not add capabilities to hostpath-init outside HCP mode
+    template: central/central-deployment.yaml
+    set:
+      central.hcp.enabled: false
+      masterNodes:
+        - 10.0.0.1
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: hostpath-init
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop
+          content: ALL

--- a/charts/kube-ovn/templates/central-deploy.yaml
+++ b/charts/kube-ovn/templates/central-deploy.yaml
@@ -111,6 +111,8 @@ spec:
               {{- if index .Values "ovn-central" "hcp" "enabled" }}
               add:
                 - CHOWN
+                - DAC_OVERRIDE
+                - DAC_READ_SEARCH
               {{- end }}
               drop:
                 - ALL

--- a/charts/kube-ovn/tests/central_hcp_test.yaml
+++ b/charts/kube-ovn/tests/central_hcp_test.yaml
@@ -268,3 +268,27 @@ tests:
           content:
             name: OVN_SB_ADDR
             value: tcp:ovn-sb.example.com:6642
+
+  - it: grants volume-init the capabilities needed to chown HCP volumes
+    template: central-deploy.yaml
+    set:
+      ovn-central.hcp.enabled: true
+      ovn-central.hcp.namespace: hcp
+      ovn-central.hcp.nbAddress: tcp:ovn-nb.example.com:6641
+      ovn-central.hcp.sbAddress: tcp:ovn-sb.example.com:6642
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: volume-init
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: CHOWN
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: DAC_OVERRIDE
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: DAC_READ_SEARCH
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop
+          content: ALL


### PR DESCRIPTION
## Description

In HCP mode, the `volume-init` initContainer runs as root with only `CAP_CHOWN` and executes:

```
chown -R nobody: /var/run/ovn /etc/ovn /var/log/ovn
```

On ext4 volumes the root directory contains `lost+found`, whose entries are owned by `root` with restrictive modes. `chown -R` must traverse that directory to complete the recursion; without `CAP_DAC_OVERRIDE`/`CAP_DAC_READ_SEARCH` the traversal fails with `EACCES`, so `volume-init` crashloops and ovn-central never starts.

This was observed on an HCP deployment where ovn-central state is PVC-backed (ext4): the init container never completed until the two capabilities were granted.

## Changes

- `charts/kube-ovn/templates/central-deploy.yaml`: add `DAC_OVERRIDE` and `DAC_READ_SEARCH` to the `volume-init` capabilities when HCP is enabled
- `charts/kube-ovn-v2/templates/central/central-deployment.yaml`: same fix
- Both charts: helm-unittest cases asserting the `volume-init` capabilities in HCP mode, and that `hostpath-init` outside HCP mode adds no capabilities

## Review notes

- This was originally bundled in #7342 and split out per review feedback: it is unrelated to the `CheckProtocol` fix and needs to cover both supported charts.
- Also removes one stale v2 test asserting the ovs-ovn upgrade hook receives `OVN_NB_ADDR`, which fails on master since #7358 removed the hook's compatibility upgrade logic. Without this the helm-unittest CI job fails on this branch for an unrelated reason.

## Test Plan

- `helm unittest -f 'tests/*.yaml' charts/kube-ovn charts/kube-ovn-v2` — 66/66 pass