### PR TITLE
fix(ci): use Image Factory installer for Talos 1.14

### DIFF
--- a/makefiles/talos.mk
+++ b/makefiles/talos.mk
@@ -8,7 +8,10 @@ TALOS_IMAGE_DIR ?= /var/lib/talos
 # customization:
 #   extraKernelArgs:
 #     - talos.network.interface.ignore=enp0s5f1
-TALOS_IMAGE_URL = https://factory.talos.dev/image/9ecea35ddd146528c1d742aab47e680a1f1137a93fc7bab55edc1afee125a658/$(TALOS_VERSION)/metal-$(TALOS_ARCH).iso
+TALOS_IMAGE_SCHEMATIC ?= 9ecea35ddd146528c1d742aab47e680a1f1137a93fc7bab55edc1afee125a658
+TALOS_IMAGE_URL = https://factory.talos.dev/image/$(TALOS_IMAGE_SCHEMATIC)/$(TALOS_VERSION)/metal-$(TALOS_ARCH).iso
+TALOS_INSTALLER_IMAGE = factory.talos.dev/metal-installer/$(TALOS_IMAGE_SCHEMATIC):$(TALOS_VERSION)
+TALOS_INSTALL_DISK ?= /dev/vda
 TALOS_IMAGE_ISO = $(TALOS_VERSION)-metal-$(TALOS_ARCH).iso
 TALOS_IMAGE_PATH = $(TALOS_IMAGE_DIR)/$(TALOS_IMAGE_ISO)
 
@@ -70,7 +73,7 @@ talos-registry-mirror:
 .PHONY: talos-prepare-images
 talos-prepare-images: talos-registry-mirror
 	@echo ">>> Preparing Talos images..."
-	@for image in ghcr.io/siderolabs/installer:$(TALOS_VERSION) $$(talosctl image default | grep -v flannel); do \
+	@for image in $(TALOS_INSTALLER_IMAGE) $$(talosctl image default | grep -v flannel); do \
 		if echo "$$image" | grep -qE '/(kube-(apiserver|controller-manager|scheduler|proxy)|kubelet):'; then \
 			image=$$(echo $$image | sed -e 's/:v\([[:digit:]]\+\.\)\{2\}[[:digit:]]\+$$/:v$(TALOS_K8S_VERSION)/'); \
 		fi; \
@@ -166,10 +169,17 @@ talos-apply-config-%:
 	ip_family=$* jinjanate talos/cluster-config.yaml.j2 -o talos/cluster-config.yaml
 	talosctl gen config --force -o talos \
 		--kubernetes-version "$(TALOS_K8S_VERSION)" \
+		--install-disk "$(TALOS_INSTALL_DISK)" \
+		--install-image "$(TALOS_INSTALLER_IMAGE)" \
+		--with-cluster-discovery=false \
+		--additional-sans talos-control-plane \
+		--additional-sans $(TALOS_CONTROL_PLANE_IPV4) \
+		--additional-sans $(TALOS_CONTROL_PLANE_IPV6) \
 		--registry-mirror docker.io=$(TALOS_REGISTRY_MIRROR_URL) \
 		--registry-mirror gcr.io=$(TALOS_REGISTRY_MIRROR_URL) \
 		--registry-mirror ghcr.io=$(TALOS_REGISTRY_MIRROR_URL) \
 		--registry-mirror registry.k8s.io=$(TALOS_REGISTRY_MIRROR_URL) \
+		--registry-mirror factory.talos.dev=$(TALOS_REGISTRY_MIRROR_URL) \
 		--config-patch "@talos/cluster-config.yaml" "$(TALOS_CLUSTER_NAME)" "$(TALOS_ENDPOINT)"
 	mv talos/talosconfig ~/.talos/config
 	@echo ">>> Applying Talos node $* configuration..."

--- a/talos/cluster-config.yaml.j2
+++ b/talos/cluster-config.yaml.j2
@@ -1,39 +1,36 @@
 {%- if ip_family is not defined -%}
   {%- set ip_family = "ipv4" -%}
 {%- endif -%}
-cluster:
-  discovery:
-    enabled: false
-  allowSchedulingOnControlPlanes: true
-  apiServer:
-    certSANs:
-      - talos-control-plane
-      - 172.99.99.10
-      - 2001:db8:99:99::10
-  controllerManager:
-    extraArgs:
-      {%- if ip_family is equalto "ipv4" %}
-      node-cidr-mask-size: 24
-      {%- elif ip_family is equalto "ipv6" %}
-      node-cidr-mask-size: 120
-      {%- else %}
-      node-cidr-mask-size-ipv4: 24
-      node-cidr-mask-size-ipv6: 120
-      {%- endif %}
-  network:
-    cni:
-      name: none
-    podSubnets:
-      {%- if ip_family is equalto "ipv4" or ip_family is equalto "dual" %}
-      - 10.16.0.0/16
-      {%- endif %}
-      {%- if ip_family is equalto "ipv6" or ip_family is equalto "dual" %}
-      - fd00:10:16::/112
-      {%- endif %}
-    serviceSubnets:
-      {%- if ip_family is equalto "ipv4" or ip_family is equalto "dual" %}
-      - 10.96.0.0/12
-      {%- endif %}
-      {%- if ip_family is equalto "ipv6" or ip_family is equalto "dual" %}
-      - fd00:10:96::/108
-      {%- endif %}
+apiVersion: v1alpha1
+kind: KubeNetworkConfig
+dnsDomain: cluster.local
+podSubnets:
+  {%- if ip_family is equalto "ipv4" or ip_family is equalto "dual" %}
+  - 10.16.0.0/16
+  {%- endif %}
+  {%- if ip_family is equalto "ipv6" or ip_family is equalto "dual" %}
+  - fd00:10:16::/112
+  {%- endif %}
+serviceSubnets:
+  {%- if ip_family is equalto "ipv4" or ip_family is equalto "dual" %}
+  - 10.96.0.0/12
+  {%- endif %}
+  {%- if ip_family is equalto "ipv6" or ip_family is equalto "dual" %}
+  - fd00:10:96::/108
+  {%- endif %}
+{%- if ip_family is equalto "ipv4" %}
+nodeCIDRMaskSizeIPv4: 24
+{%- elif ip_family is equalto "ipv6" %}
+nodeCIDRMaskSizeIPv6: 120
+{%- else %}
+nodeCIDRMaskSizeIPv4: 24
+nodeCIDRMaskSizeIPv6: 120
+{%- endif %}
+---
+apiVersion: v1alpha1
+kind: KubeFlannelCNIConfig
+$patch: delete
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+taints: null

--- a/talos/machine-config.yaml.j2
+++ b/talos/machine-config.yaml.j2
@@ -12,27 +12,29 @@
   {%- set ip_family = "ipv4" -%}
 {%- endif -%}
 machine:
-  install:
-    disk: /dev/vda
-    wipe: true
   kernel:
     modules:
       # the following kernel modules configuration may be unnecessary
       - name: openvswitch
       - name: geneve
       - name: vxlan
-  kubelet:
-    nodeIP:
-      validSubnets:
-        # subnets MUST match the libvirt network CIDRs
-        {%- if ip_family is equalto "ipv4" or ip_family is equalto "dual" %}
-        - 172.99.99.0/24
-        {%- endif %}
-        {%- if ip_family is equalto "ipv6" or ip_family is equalto "dual" %}
-        - 2001:db8:99:99::/120
-        {%- endif %}
-    extraArgs:
-      provider-id: talos://libvirt/{{ cluster }}/{{ node }}
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+nodeIP:
+  validSubnets:
+    # subnets MUST match the libvirt network CIDRs
+    {%- if ip_family is equalto "ipv4" or ip_family is equalto "dual" %}
+    - 172.99.99.0/24
+    {%- endif %}
+    {%- if ip_family is equalto "ipv6" or ip_family is equalto "dual" %}
+    - 2001:db8:99:99::/120
+    {%- endif %}
+---
+apiVersion: v1alpha1
+kind: KubeletConfig
+extraArgs:
+  provider-id: talos://libvirt/{{ cluster }}/{{ node }}
 ---
 apiVersion: v1alpha1
 kind: TimeSyncConfig


### PR DESCRIPTION
## What

Talos installation tests fail on master after #7382 because they still pull `ghcr.io/siderolabs/installer:v1.14.0`.

## Why

Talos 1.14 no longer publishes `ghcr.io/siderolabs/installer`. The default installer is now `factory.talos.dev/metal-installer/<schematic>:<version>`. `talosctl gen config` also emits `UnattendedInstallConfig`, which is incompatible with the `.machine.install` patch used by the libvirt test.

Evidence from https://github.com/kubeovn/kube-ovn/actions/runs/34099528285/job/101683884793:

```
>>> Pulling ghcr.io/siderolabs/installer:v1.14.0...
Error response from daemon: manifest unknown
make: *** [makefiles/talos.mk:73: talos-prepare-images] Error 1
```

All six Talos Installation Test matrix jobs fail at `Create Talos cluster`.

## How

- Pre-pull `factory.talos.dev/metal-installer` with the same Image Factory schematic as the ISO.
- Mirror `factory.talos.dev` into the local Talos registry mirror.
- Generate config with `--install-disk /dev/vda` and `--install-image` so 1.14 uses `UnattendedInstallConfig` instead of `.machine.install`.

## Verification

- Confirmed `ghcr.io/siderolabs/installer:v1.14.0` is 404 and `v1.13.8` still exists.
- Confirmed `factory.talos.dev/metal-installer/<schematic>:v1.14.0` returns 200 for both the ISO schematic and the vanilla schematic.