### PR TITLE
ci: use kindest/node v1.37.0 and default kube-proxy to nftables

### DIFF
--- a/.github/e2e-selection.json
+++ b/.github/e2e-selection.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "expectedRunnerJobs": 85,
+  "expectedRunnerJobs": 84,
   "forceFull": false,
   "fullThreshold": 3,
   "productionPrefixes": ["cmd/", "fastpath/", "pkg/", "versions/"],
@@ -206,7 +206,6 @@
     "install-platform": {
       "jobs": [
         {"id": "chart-test", "matrix": {"ssl": ["true", "false"]}},
-        {"id": "installation-compatibility-test", "matrix": {"k8s-version": ["v1.29.14"]}},
         {"id": "talos-installation-test", "matrix": {"ip-family": ["ipv4", "ipv6", "dual"], "mode": ["overlay", "underlay"]}}
       ]
     },

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -448,7 +448,7 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - v1.36.1
+          - v1.37.0
           - v1.29.14
     steps:
       - name: Pull private Kind node image with trusted token
@@ -1021,10 +1021,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1165,10 +1165,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1324,10 +1324,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1503,10 +1503,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1699,10 +1699,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1900,10 +1900,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2072,10 +2072,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2242,10 +2242,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2406,10 +2406,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create BGP kind and containerlab topology
         id: setup
@@ -2687,10 +2687,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2766,10 +2766,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2843,10 +2843,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2922,10 +2922,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3052,10 +3052,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3204,10 +3204,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3519,10 +3519,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3680,10 +3680,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3850,10 +3850,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4020,10 +4020,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4142,10 +4142,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4275,10 +4275,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4473,10 +4473,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4624,10 +4624,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4782,10 +4782,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4935,10 +4935,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -5092,10 +5092,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -5219,10 +5219,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -5371,10 +5371,10 @@ jobs:
       - name: Download private Kind node image
         uses: actions/download-artifact@v8
         with:
-          name: kind-node-v1.36.1
+          name: kind-node-v1.37.0
 
       - name: Load private Kind node image
-        run: docker load --input kind-node-v1.36.1.tar
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -434,44 +434,6 @@ jobs:
       - name: Run control module tests
         run: python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py
 
-  prepare-kind-node-images:
-    name: Prepare private Kind node image (${{ matrix.k8s-version }})
-    if: >-
-      (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||
-      github.event_name == 'push'
-    needs: e2e-selection
-    permissions:
-      contents: read
-      packages: read
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        k8s-version:
-          - v1.37.0
-          - v1.29.14
-    steps:
-      - name: Pull private Kind node image with trusted token
-        env:
-          GHCR_TOKEN: ${{ github.token }}
-          K8S_VERSION: ${{ matrix.k8s-version }}
-        run: |
-          set -euo pipefail
-          dockerConfig=$(mktemp -d)
-          trap 'rm -rf "$dockerConfig"' EXIT
-          export DOCKER_CONFIG="$dockerConfig"
-          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u github-actions --password-stdin
-          docker pull "ghcr.io/kubeovn/kindest-node:$K8S_VERSION"
-          docker tag "ghcr.io/kubeovn/kindest-node:$K8S_VERSION" "kindest/node:$K8S_VERSION"
-          docker save "kindest/node:$K8S_VERSION" -o "kind-node-$K8S_VERSION.tar"
-
-      - name: Upload private Kind node image without credentials
-        uses: actions/upload-artifact@v7
-        with:
-          name: kind-node-${{ matrix.k8s-version }}
-          path: kind-node-${{ matrix.k8s-version }}.tar
-          retention-days: 2
-
   build-kube-ovn-base:
     name: Build kube-ovn-base
     if: github.event_name != 'workflow_dispatch' || github.actor == 'github-actions[bot]'
@@ -925,7 +887,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-conformance-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -1018,13 +979,6 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1128,7 +1082,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'acl-sampling-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -1162,13 +1115,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1219,7 +1165,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-netpol-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -1321,13 +1266,6 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1427,7 +1365,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'cyclonus-netpol-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -1500,13 +1437,6 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1608,7 +1538,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-conformance-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -1696,13 +1625,6 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1813,7 +1735,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ic-conformance-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -1897,13 +1818,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1985,7 +1899,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'multus-conformance-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -2069,13 +1982,6 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2147,7 +2053,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'non-primary-cni-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -2239,13 +2144,6 @@ jobs:
           docker load --input kube-ovn.tar
           docker load --input vpc-nat-gateway.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2319,7 +2217,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'bgp-speaker-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -2403,13 +2300,6 @@ jobs:
       - name: Load kube-ovn image
         run: docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create BGP kind and containerlab topology
         id: setup
@@ -2644,7 +2534,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'chart-test')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     strategy:
@@ -2684,13 +2573,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2729,7 +2611,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'underlay-logical-gateway-installation-test')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -2763,13 +2644,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2806,7 +2680,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'no-ovn-lb-test')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -2840,13 +2713,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2885,7 +2751,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'no-np-test')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -2919,13 +2784,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2964,7 +2822,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'lb-svc-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-vpc-nat-gateway
       - build-e2e-binaries
@@ -3049,13 +2906,6 @@ jobs:
           docker load -i kube-ovn.tar
           docker load -i vpc-nat-gateway.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3123,7 +2973,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'webhook-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3201,13 +3050,6 @@ jobs:
         run: |
           docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3243,90 +3085,6 @@ jobs:
         with:
           name: webhook-e2e-ko-log
           path: webhook-e2e-ko-log.tar.gz
-
-  installation-compatibility-test:
-    name: Installation Compatibility Test
-    if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'installation-compatibility-test')
-    needs:
-      - e2e-selection
-      - prepare-kind-node-images
-      - build-kube-ovn
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        k8s-version:
-          - v1.29.14
-    steps:
-      - uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          android: true
-          dotnet: true
-          haskell: true
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-          swap-storage: false
-
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ env.EXECUTION_SHA }}
-          persist-credentials: false
-
-      - name: Install kind
-        uses: helm/kind-action@v1.15.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          install_only: true
-
-      - name: Download image
-        uses: actions/download-artifact@v8
-        with:
-          name: kube-ovn
-
-      - name: Load image
-        run: docker load --input kube-ovn.tar
-
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.29.14
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.29.14.tar
-
-      - name: Create kind cluster
-        env:
-          K8S_VERSION: ${{ matrix.k8s-version }}
-        run: |
-          pipx install jinjanator
-          make kind-init
-
-      - name: Install Kube-OVN
-        id: install
-        run: make kind-install
-
-      - name: Check kube ovn pod restarts
-        id: check-restarts
-        if: ${{ success() || (failure() && steps.install.conclusion == 'failure') }}
-        run: make check-kube-ovn-pod-restarts
-
-      - name: kubectl ko log
-        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
-        run: |
-          make kubectl-ko-log
-          mv kubectl-ko-log.tar.gz installation-compatibility-test-${{ matrix.k8s-version }}-ko-log.tar.gz
-
-      - name: upload kubectl ko log
-        uses: actions/upload-artifact@v7
-        if: failure() && (steps.install.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
-        with:
-          name: installation-compatibility-test-${{ matrix.k8s-version }}-ko-log
-          path: installation-compatibility-test-${{ matrix.k8s-version }}-ko-log.tar.gz
-
-      - name: Cleanup
-        run: timeout -k 10 180 sh -x dist/images/cleanup.sh
 
   talos-installation-test:
     name: Talos Installation Test
@@ -3426,7 +3184,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-cnp-domain-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3516,13 +3273,6 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3587,7 +3337,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-anp-domain-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3677,13 +3426,6 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3748,7 +3490,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'cilium-chaining-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3847,13 +3588,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3927,7 +3661,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ha-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4017,13 +3750,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4078,7 +3804,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-submariner-conformance-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -4139,13 +3864,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4188,7 +3906,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'vpc-egress-gateway-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4272,13 +3989,6 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4385,7 +4095,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'iptables-vpc-nat-gw-conformance-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-vpc-nat-gateway
       - build-e2e-binaries
@@ -4470,13 +4179,6 @@ jobs:
           docker load -i kube-ovn.tar
           docker load -i vpc-nat-gateway.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4544,7 +4246,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'ovn-vpc-nat-gw-conformance-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4621,13 +4322,6 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4702,7 +4396,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ipsec-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4779,13 +4472,6 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4855,7 +4541,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ipsec-cert-mgr-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4932,13 +4617,6 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -5006,7 +4684,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-connectivity-test')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -5089,13 +4766,6 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -5132,7 +4802,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-underlay-metallb-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -5216,13 +4885,6 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -5291,7 +4953,6 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'router-lb-rule-e2e')
     needs:
       - e2e-selection
-      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -5368,13 +5029,6 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
-      - name: Download private Kind node image
-        uses: actions/download-artifact@v8
-        with:
-          name: kind-node-v1.37.0
-
-      - name: Load private Kind node image
-        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -5448,7 +5102,6 @@ jobs:
       - chart-test
       - cilium-chaining-e2e
       - cyclonus-netpol-e2e
-      - installation-compatibility-test
       - iptables-vpc-nat-gw-conformance-e2e
       - k8s-conformance-e2e
       - k8s-netpol-e2e

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -434,6 +434,43 @@ jobs:
       - name: Run control module tests
         run: python3 -m unittest hack/test_e2e_selector.py hack/test_e2e_control.py
 
+  prepare-kind-node-images:
+    name: Prepare private Kind node image (${{ matrix.k8s-version }})
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||
+      github.event_name == 'push'
+    needs: e2e-selection
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version:
+          - v1.37.0
+    steps:
+      - name: Pull private Kind node image with trusted token
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          K8S_VERSION: ${{ matrix.k8s-version }}
+        run: |
+          set -euo pipefail
+          dockerConfig=$(mktemp -d)
+          trap 'rm -rf "$dockerConfig"' EXIT
+          export DOCKER_CONFIG="$dockerConfig"
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u github-actions --password-stdin
+          docker pull "ghcr.io/kubeovn/kindest-node:$K8S_VERSION"
+          docker tag "ghcr.io/kubeovn/kindest-node:$K8S_VERSION" "kindest/node:$K8S_VERSION"
+          docker save "kindest/node:$K8S_VERSION" -o "kind-node-$K8S_VERSION.tar"
+
+      - name: Upload private Kind node image without credentials
+        uses: actions/upload-artifact@v7
+        with:
+          name: kind-node-${{ matrix.k8s-version }}
+          path: kind-node-${{ matrix.k8s-version }}.tar
+          retention-days: 2
+
   build-kube-ovn-base:
     name: Build kube-ovn-base
     if: github.event_name != 'workflow_dispatch' || github.actor == 'github-actions[bot]'
@@ -887,6 +924,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-conformance-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -979,6 +1017,13 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1082,6 +1127,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'acl-sampling-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -1115,6 +1161,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1165,6 +1218,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'k8s-netpol-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -1266,6 +1320,13 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1365,6 +1426,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'cyclonus-netpol-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -1437,6 +1499,13 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1538,6 +1607,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-conformance-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -1625,6 +1695,13 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1735,6 +1812,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ic-conformance-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -1818,6 +1896,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -1899,6 +1984,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'multus-conformance-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -1982,6 +2068,13 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2053,6 +2146,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'non-primary-cni-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -2144,6 +2238,13 @@ jobs:
           docker load --input kube-ovn.tar
           docker load --input vpc-nat-gateway.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2217,6 +2318,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'bgp-speaker-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -2300,6 +2402,13 @@ jobs:
       - name: Load kube-ovn image
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create BGP kind and containerlab topology
         id: setup
@@ -2534,6 +2643,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'chart-test')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     strategy:
@@ -2573,6 +2683,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2611,6 +2728,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'underlay-logical-gateway-installation-test')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -2644,6 +2762,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2680,6 +2805,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'no-ovn-lb-test')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -2713,6 +2839,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2751,6 +2884,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'no-np-test')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -2784,6 +2918,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2822,6 +2963,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'lb-svc-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-vpc-nat-gateway
       - build-e2e-binaries
@@ -2906,6 +3048,13 @@ jobs:
           docker load -i kube-ovn.tar
           docker load -i vpc-nat-gateway.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -2973,6 +3122,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'webhook-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3050,6 +3200,13 @@ jobs:
         run: |
           docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3184,6 +3341,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-cnp-domain-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3273,6 +3431,13 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3337,6 +3502,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-anp-domain-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3426,6 +3592,13 @@ jobs:
             echo "DEBUG_WRAPPER=valgrind" >> "$GITHUB_ENV"
           fi
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3490,6 +3663,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'cilium-chaining-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3588,6 +3762,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3661,6 +3842,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ha-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3750,6 +3932,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3804,6 +3993,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-submariner-conformance-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -3864,6 +4054,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -3906,6 +4103,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'vpc-egress-gateway-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -3989,6 +4187,13 @@ jobs:
       - name: Load image
         run: docker load --input kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4095,6 +4300,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'iptables-vpc-nat-gw-conformance-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-vpc-nat-gateway
       - build-e2e-binaries
@@ -4179,6 +4385,13 @@ jobs:
           docker load -i kube-ovn.tar
           docker load -i vpc-nat-gateway.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4246,6 +4459,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'ovn-vpc-nat-gw-conformance-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4322,6 +4536,13 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4396,6 +4617,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ipsec-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4472,6 +4694,13 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4541,6 +4770,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-ipsec-cert-mgr-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4617,6 +4847,13 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4684,6 +4921,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-connectivity-test')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4766,6 +5004,13 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4802,6 +5047,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'kube-ovn-underlay-metallb-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -4885,6 +5131,13 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |
@@ -4953,6 +5206,7 @@ jobs:
     if: github.event_name != 'pull_request' && contains(fromJSON(needs.e2e-selection.outputs.executionJobIds), 'router-lb-rule-e2e')
     needs:
       - e2e-selection
+      - prepare-kind-node-images
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
@@ -5029,6 +5283,13 @@ jobs:
       - name: Load images
         run: docker load -i kube-ovn.tar
 
+      - name: Download private Kind node image
+        uses: actions/download-artifact@v8
+        with:
+          name: kind-node-v1.37.0
+
+      - name: Load private Kind node image
+        run: docker load --input kind-node-v1.37.0.tar
 
       - name: Create kind cluster
         run: |

--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -928,7 +928,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.e2e-selection.outputs.k8sConformanceMatrix) }}

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -726,6 +726,7 @@ visibleInfrastructureJobIds = (
     "build-kube-ovn",
     "build-e2e-binaries",
     "build-vpc-nat-gateway",
+    "prepare-kind-node-images",
 )
 
 

--- a/hack/e2e_control.py
+++ b/hack/e2e_control.py
@@ -726,7 +726,6 @@ visibleInfrastructureJobIds = (
     "build-kube-ovn",
     "build-e2e-binaries",
     "build-vpc-nat-gateway",
-    "prepare-kind-node-images",
 )
 
 

--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -18,6 +18,7 @@ infrastructureJobs = {
     "build-e2e-binaries",
     "e2e-selection",
     "e2e-control-validation",
+    "prepare-kind-node-images",
     "e2e-executor-result",
     "notify-x86-e2e-gate",
     "publish-pr-e2e-checks",

--- a/hack/e2e_selector.py
+++ b/hack/e2e_selector.py
@@ -18,13 +18,12 @@ infrastructureJobs = {
     "build-e2e-binaries",
     "e2e-selection",
     "e2e-control-validation",
-    "prepare-kind-node-images",
     "e2e-executor-result",
     "notify-x86-e2e-gate",
     "publish-pr-e2e-checks",
     "push",
 }
-expectedX86RunnerJobs = 85
+expectedX86RunnerJobs = 84
 mandatorySmoke = [
     {"job": "kube-ovn-conformance-e2e", "ip-family": "ipv4", "mode": "overlay"},
     {"job": "kube-ovn-conformance-e2e", "ip-family": "ipv4", "mode": "underlay"},

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -1706,7 +1706,7 @@ class E2EControlTest(unittest.TestCase):
             "Pull private Kind node image with trusted token",
             workflow,
         )
-        self.assertIn("kind-node-v1.36.1.tar", workflow)
+        self.assertIn("kind-node-v1.37.0.tar", workflow)
         self.assertIn("kind-node-v1.29.14.tar", workflow)
         self.assertNotIn("kind-ghcr-pull", workflow)
         self.assertIn(

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -244,6 +244,7 @@ class E2EControlTest(unittest.TestCase):
             infraTitles=[
                 "Build kube-ovn",
                 "Build E2E Binaries",
+                "Prepare private Kind node image (${{ matrix.k8s-version }})",
             ],
         )
         byName = {payload["name"]: payload for payload in payloads}
@@ -1701,14 +1702,14 @@ class E2EControlTest(unittest.TestCase):
         self.assertEqual(workflow.count("statuses: write"), 1)
         self.assertIn("name: Publish x86 E2E checks on the pull request", workflow)
         self.assertNotIn("GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}", workflow)
-        self.assertNotIn(
+        self.assertIn(
             "Pull private Kind node image with trusted token",
             workflow,
         )
-        self.assertNotIn("kind-node-v1.37.0.tar", workflow)
+        self.assertIn("kind-node-v1.37.0.tar", workflow)
         self.assertNotIn("kind-node-v1.29.14.tar", workflow)
         self.assertNotIn("kind-ghcr-pull", workflow)
-        self.assertNotIn("prepare-kind-node-images", workflow)
+        self.assertIn("prepare-kind-node-images", workflow)
         self.assertNotIn("installation-compatibility-test", workflow)
         self.assertIn(
             "EXECUTION_SHA: ${{ github.event_name == 'pull_request' && "
@@ -1744,7 +1745,7 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("make ut", build)
         self.assertIn("make lint", build)
         self.assertIn("make image-kube-ovn", build)
-        self.assertNotIn("prepare-kind-node-images", build)
+        self.assertNotIn("- prepare-kind-node-images", build)
         self.assertIn(
             "if: github.event_name != 'workflow_dispatch' || github.actor == 'github-actions[bot]'",
             build,
@@ -1757,8 +1758,10 @@ class E2EControlTest(unittest.TestCase):
                     "contains(fromJSON(needs.e2e-selection.outputs.executionJobIds)",
                     block,
                 )
-                self.assertNotIn("prepare-kind-node-images", block)
-                self.assertNotIn("docker load --input kind-node-", block)
+                if "docker load --input kind-node-" in block:
+                    self.assertIn("- prepare-kind-node-images", block)
+                    self.assertIn("kind-node-v1.37.0.tar", block)
+                    self.assertNotIn("kind-node-v1.29.14.tar", block)
 
     def testTrustedDispatchDetectsBaseImageChanges(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()

--- a/hack/test_e2e_control.py
+++ b/hack/test_e2e_control.py
@@ -244,7 +244,6 @@ class E2EControlTest(unittest.TestCase):
             infraTitles=[
                 "Build kube-ovn",
                 "Build E2E Binaries",
-                "Prepare private Kind node image (${{ matrix.k8s-version }})",
             ],
         )
         byName = {payload["name"]: payload for payload in payloads}
@@ -1702,13 +1701,15 @@ class E2EControlTest(unittest.TestCase):
         self.assertEqual(workflow.count("statuses: write"), 1)
         self.assertIn("name: Publish x86 E2E checks on the pull request", workflow)
         self.assertNotIn("GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}", workflow)
-        self.assertIn(
+        self.assertNotIn(
             "Pull private Kind node image with trusted token",
             workflow,
         )
-        self.assertIn("kind-node-v1.37.0.tar", workflow)
-        self.assertIn("kind-node-v1.29.14.tar", workflow)
+        self.assertNotIn("kind-node-v1.37.0.tar", workflow)
+        self.assertNotIn("kind-node-v1.29.14.tar", workflow)
         self.assertNotIn("kind-ghcr-pull", workflow)
+        self.assertNotIn("prepare-kind-node-images", workflow)
+        self.assertNotIn("installation-compatibility-test", workflow)
         self.assertIn(
             "EXECUTION_SHA: ${{ github.event_name == 'pull_request' && "
             "github.event.pull_request.head.sha || inputs.headSHA || github.sha }}",
@@ -1743,7 +1744,7 @@ class E2EControlTest(unittest.TestCase):
         self.assertIn("make ut", build)
         self.assertIn("make lint", build)
         self.assertIn("make image-kube-ovn", build)
-        self.assertNotIn("- prepare-kind-node-images", build)
+        self.assertNotIn("prepare-kind-node-images", build)
         self.assertIn(
             "if: github.event_name != 'workflow_dispatch' || github.actor == 'github-actions[bot]'",
             build,
@@ -1756,8 +1757,8 @@ class E2EControlTest(unittest.TestCase):
                     "contains(fromJSON(needs.e2e-selection.outputs.executionJobIds)",
                     block,
                 )
-                if "docker load --input kind-node-" in block:
-                    self.assertIn("- prepare-kind-node-images", block)
+                self.assertNotIn("prepare-kind-node-images", block)
+                self.assertNotIn("docker load --input kind-node-", block)
 
     def testTrustedDispatchDetectsBaseImageChanges(self):
         workflow = (repoRoot / ".github/workflows/build-x86-image.yaml").read_text()

--- a/yamls/kind.yaml.j2
+++ b/yamls/kind.yaml.j2
@@ -1,5 +1,5 @@
 {%- if kube_proxy_mode is not defined -%}
-  {%- set kube_proxy_mode = "ipvs" -%}
+  {%- set kube_proxy_mode = "nftables" -%}
 {%- endif -%}
 {%- if auditing is not defined -%}
   {%- set auditing = "false" -%}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Tests

## Changes

- Default generated Kind clusters to kube-proxy `nftables` mode instead of `ipvs`.
- Use private Kind node image `v1.37.0` in `build-x86-image`.
- Remove the Installation Compatibility Test and the `v1.29.14` Kind node image.

## Which issue(s) this PR fixes

N/A