### PR TITLE
fix(ipam): stop random allocation of excludeIps after IPPool reconcile

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -1036,7 +1036,7 @@ jobs:
       - build-kube-ovn
       - build-e2e-binaries
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -990,3 +990,83 @@ func TestGetSubnetV4Mask(t *testing.T) {
 	require.Equal(t, err, ErrNoAvailable)
 	require.Empty(t, mask)
 }
+
+func TestIPAMRandomAddressSkipsReleasedExcludeIPsAfterIPPoolReconcile(t *testing.T) {
+	ipam := NewIPAM()
+	subnetName := "subnet"
+	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "10.10.0.0/24", "10.10.0.1", []string{
+		"10.10.0.1",
+		"10.10.0.2..10.10.0.5",
+	}))
+	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "pool", []string{"10.10.0.200..10.10.0.210"}))
+
+	v4IP, _, _, err := ipam.GetStaticAddress("static-pod", "static-pod", "10.10.0.2", nil, subnetName, true)
+	require.NoError(t, err)
+	require.Equal(t, "10.10.0.2", v4IP)
+	ipam.ReleaseAddressByNic("static-pod", "static-pod", subnetName)
+
+	require.NoError(t, ipam.AddOrUpdateIPPool(subnetName, "pool", []string{"10.10.0.200..10.10.0.210"}))
+
+	excludedIP, err := NewIP("10.10.0.2")
+	require.NoError(t, err)
+	require.False(t, ipam.Subnets[subnetName].IPPools[""].V4Free.Contains(excludedIP))
+
+	v4IP, _, _, err = ipam.GetRandomAddress("random-pod", "random-pod", nil, subnetName, "", nil, true)
+	require.NoError(t, err)
+	require.Equal(t, "10.10.0.6", v4IP)
+}
+
+func TestIPAMRandomAddressDoesNotRecycleReservedIPs(t *testing.T) {
+	ipam := NewIPAM()
+	subnetName := "subnet"
+	require.NoError(t, ipam.AddOrUpdateSubnet(subnetName, "10.10.0.0/30", "10.10.0.1", []string{
+		"10.10.0.1",
+		"10.10.0.2",
+	}))
+
+	subnet := ipam.Subnets[subnetName]
+	pool := subnet.IPPools[""]
+	reservedIP, err := NewIP("10.10.0.2")
+	require.NoError(t, err)
+	require.True(t, pool.V4Released.Add(reservedIP))
+	pool.V4Free = NewEmptyIPRangeList()
+	subnet.V4Free = NewEmptyIPRangeList()
+
+	_, _, _, err = ipam.GetRandomAddress("random-pod", "random-pod", nil, subnetName, "", nil, true)
+	require.ErrorIs(t, err, ErrNoAvailable)
+}
+
+func TestIPAMDualRandomAddressHandlesV4OnV6Exhaustion(t *testing.T) {
+	tests := []struct {
+		name             string
+		existingV4       string
+		wantV4Using      string
+		wantV4UsingRange string
+	}{
+		{name: "RollsBackNewV4", wantV4Using: "0"},
+		{name: "PreservesExistingV4", existingV4: "10.0.0.2", wantV4Using: "1", wantV4UsingRange: "10.0.0.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipam := NewIPAM()
+			if tt.existingV4 != "" {
+				require.NoError(t, ipam.AddOrUpdateSubnet("dual", "10.0.0.0/30", "10.0.0.1", []string{"10.0.0.1"}))
+				v4IP, _, _, err := ipam.GetStaticAddress("pod", "pod", tt.existingV4, nil, "dual", true)
+				require.NoError(t, err)
+				require.Equal(t, tt.existingV4, v4IP)
+			}
+			require.NoError(t, ipam.AddOrUpdateSubnet(
+				"dual", "10.0.0.0/30,fd00::/126", "10.0.0.1,fd00::1", []string{"10.0.0.1", "fd00::1..fd00::2"},
+			))
+
+			_, _, _, err := ipam.GetRandomAddress("pod", "pod", nil, "dual", "", nil, true)
+			require.ErrorIs(t, err, ErrNoAvailable)
+
+			_, v4Using, _, v6Using, _, v4UsingRange, _, _ := ipam.IPPoolStatistics("dual", "")
+			require.Equal(t, tt.wantV4Using, v4Using.String())
+			require.Equal(t, tt.wantV4UsingRange, v4UsingRange)
+			require.Equal(t, "0", v6Using.String())
+		})
+	}
+}

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -205,6 +205,8 @@ func (s *Subnet) GetRandomAddress(poolName, podName, nicName string, mac *string
 }
 
 func (s *Subnet) getDualRandomAddress(poolName, podName, nicName string, mac *string, skippedAddrs []string, checkConflict bool) (IP, IP, string, error) {
+	existingV4 := s.V4NicToIP[nicName]
+
 	v4IP, _, _, err := s.getV4RandomAddress(poolName, podName, nicName, mac, skippedAddrs, checkConflict)
 	if err != nil {
 		klog.Error(err)
@@ -212,6 +214,10 @@ func (s *Subnet) getDualRandomAddress(poolName, podName, nicName string, mac *st
 	}
 	_, v6IP, macStr, err := s.getV6RandomAddress(poolName, podName, nicName, mac, skippedAddrs, checkConflict)
 	if err != nil {
+		if existingV4 == nil || !existingV4.Equal(v4IP) {
+			s.releaseV4Addr(podName, nicName)
+			s.popPodNic(podName, nicName)
+		}
 		klog.Error(err)
 		return nil, nil, "", err
 	}
@@ -241,13 +247,14 @@ func (s *Subnet) getV4RandomAddress(ippoolName, podName, nicName string, mac *st
 		return nil, nil, "", ErrNoAvailable
 	}
 
+	pool.V4Free = pool.V4Free.Separate(pool.V4Reserved)
 	if pool.V4Free.Len() == 0 {
-		if pool.V4Released.Len() == 0 {
+		pool.V4Free = pool.V4Released.Separate(pool.V4Reserved)
+		pool.V4Released = NewEmptyIPRangeList()
+		if pool.V4Free.Len() == 0 {
 			klog.Errorf("no free v4 ip in ip pool %s", ippoolName)
 			return nil, nil, "", ErrNoAvailable
 		}
-		pool.V4Free = pool.V4Released
-		pool.V4Released = NewEmptyIPRangeList()
 	}
 
 	skipped := make([]IP, 0, len(skippedAddrs))
@@ -298,13 +305,14 @@ func (s *Subnet) getV6RandomAddress(ippoolName, podName, nicName string, mac *st
 		return nil, nil, "", ErrNoAvailable
 	}
 
+	pool.V6Free = pool.V6Free.Separate(pool.V6Reserved)
 	if pool.V6Free.Len() == 0 {
-		if pool.V6Released.Len() == 0 {
+		pool.V6Free = pool.V6Released.Separate(pool.V6Reserved)
+		pool.V6Released = NewEmptyIPRangeList()
+		if pool.V6Free.Len() == 0 {
 			klog.Errorf("no free v6 ip in ip pool %s", ippoolName)
 			return nil, nil, "", ErrNoAvailable
 		}
-		pool.V6Free = pool.V6Released
-		pool.V6Released = NewEmptyIPRangeList()
 	}
 
 	skipped := make([]IP, 0, len(skippedAddrs))
@@ -539,50 +547,59 @@ func (s *Subnet) GetStaticAddress(podName, nicName string, ip IP, mac *string, f
 	return nil, "", ErrNoAvailable
 }
 
+func (s *Subnet) releaseV4Addr(podName, nicName string) {
+	ip, ok := s.V4NicToIP[nicName]
+	if !ok {
+		return
+	}
+	oldPods := strings.Split(s.V4IPToPod[ip.String()], ",")
+	if len(oldPods) > 1 {
+		newPods := util.RemoveString(oldPods, podName)
+		s.V4IPToPod[ip.String()] = strings.Join(newPods, ",")
+		return
+	}
+	delete(s.V4NicToIP, nicName)
+	delete(s.V4IPToPod, ip.String())
+	var mac string
+	if m, hasMac := s.NicToMac[nicName]; hasMac {
+		mac = m
+		if _, hasV6 := s.V6NicToIP[nicName]; !hasV6 {
+			delete(s.NicToMac, nicName)
+			delete(s.MacToPod, mac)
+		}
+	}
+	var changed bool
+	if !s.V4CIDR.Contains(net.IP(ip)) {
+		klog.Infof("release v4 %s mac %s from subnet %s for %s, ignore ip", ip, mac, s.Name, podName)
+		changed = true
+	}
+	if s.V4Reserved.Contains(ip) {
+		klog.Infof("release v4 %s mac %s from subnet %s for %s, ip is in reserved list", ip, mac, s.Name, podName)
+		changed = true
+	}
+	s.V4Using.Remove(ip)
+	if !changed {
+		s.V4Available.Add(ip)
+	}
+	for _, pool := range s.IPPools {
+		if pool.V4Using.Remove(ip) {
+			if !changed {
+				pool.V4Available.Add(ip)
+				if pool.V4Released.Add(ip) {
+					klog.Infof("release v4 %s mac %s from subnet %s for %s, add ip to released list", ip, mac, s.Name, podName)
+				}
+			}
+			break
+		}
+	}
+}
+
 func (s *Subnet) releaseAddr(podName, nicName string) {
+	s.releaseV4Addr(podName, nicName)
+
 	var ip IP
 	var mac string
 	var ok, changed bool
-	if ip, ok = s.V4NicToIP[nicName]; ok {
-		oldPods := strings.Split(s.V4IPToPod[ip.String()], ",")
-		if len(oldPods) > 1 {
-			newPods := util.RemoveString(oldPods, podName)
-			s.V4IPToPod[ip.String()] = strings.Join(newPods, ",")
-		} else {
-			delete(s.V4NicToIP, nicName)
-			delete(s.V4IPToPod, ip.String())
-			if mac, ok = s.NicToMac[nicName]; ok {
-				delete(s.NicToMac, nicName)
-				delete(s.MacToPod, mac)
-			}
-
-			// When CIDR changed, do not relocate ip to CIDR list
-			if !s.V4CIDR.Contains(net.IP(ip)) {
-				// Continue to release IPv6 address
-				klog.Infof("release v4 %s mac %s from subnet %s for %s, ignore ip", ip, mac, s.Name, podName)
-				changed = true
-			}
-
-			if s.V4Reserved.Contains(ip) {
-				klog.Infof("release v4 %s mac %s from subnet %s for %s, ip is in reserved list", ip, mac, s.Name, podName)
-				changed = true
-			}
-
-			s.V4Available.Add(ip)
-			s.V4Using.Remove(ip)
-			for _, pool := range s.IPPools {
-				if pool.V4Using.Remove(ip) {
-					pool.V4Available.Add(ip)
-					if !changed {
-						if pool.V4Released.Add(ip) {
-							klog.Infof("release v4 %s mac %s from subnet %s for %s, add ip to released list", ip, mac, s.Name, podName)
-						}
-					}
-					break
-				}
-			}
-		}
-	}
 	if ip, ok = s.V6NicToIP[nicName]; ok {
 		oldPods := strings.Split(s.V6IPToPod[ip.String()], ",")
 		if len(oldPods) > 1 {
@@ -754,23 +771,23 @@ func (s *Subnet) AddOrUpdateIPPool(name string, ips []string) error {
 	if p := s.IPPools[name]; p != nil {
 		defaultPool.V4IPs = defaultPool.V4IPs.Merge(p.V4IPs).Separate(pool.V4IPs)
 		defaultPool.V6IPs = defaultPool.V6IPs.Merge(p.V6IPs).Separate(pool.V6IPs)
-		defaultPool.V4Free = defaultPool.V4Available.Merge(p.V4Available).Separate(pool.V4Free)
-		defaultPool.V6Free = defaultPool.V6Available.Merge(p.V6Available).Separate(pool.V6Free)
 		defaultPool.V4Using = defaultPool.V4Using.Merge(p.V4Using).Separate(pool.V4Using)
 		defaultPool.V6Using = defaultPool.V6Using.Merge(p.V6Using).Separate(pool.V6Using)
 		defaultPool.V4Reserved = defaultPool.V4Reserved.Merge(p.V4Reserved).Separate(pool.V4Reserved)
 		defaultPool.V6Reserved = defaultPool.V6Reserved.Merge(p.V6Reserved).Separate(pool.V6Reserved)
+		defaultPool.V4Free = defaultPool.V4Available.Merge(p.V4Available).Separate(pool.V4Free).Separate(s.V4Reserved)
+		defaultPool.V6Free = defaultPool.V6Available.Merge(p.V6Available).Separate(pool.V6Free).Separate(s.V6Reserved)
 		defaultPool.V4Available = defaultPool.V4Free.Clone()
 		defaultPool.V6Available = defaultPool.V6Free.Clone()
 	} else {
 		defaultPool.V4IPs = defaultPool.V4IPs.Separate(pool.V4IPs)
 		defaultPool.V6IPs = defaultPool.V6IPs.Separate(pool.V6IPs)
-		defaultPool.V4Free = defaultPool.V4Available.Separate(pool.V4Free)
-		defaultPool.V6Free = defaultPool.V6Available.Separate(pool.V6Free)
 		defaultPool.V4Using = defaultPool.V4Using.Separate(pool.V4Using)
 		defaultPool.V6Using = defaultPool.V6Using.Separate(pool.V6Using)
 		defaultPool.V4Reserved = defaultPool.V4Reserved.Separate(pool.V4Reserved)
 		defaultPool.V6Reserved = defaultPool.V6Reserved.Separate(pool.V6Reserved)
+		defaultPool.V4Free = defaultPool.V4Available.Separate(pool.V4Free).Separate(s.V4Reserved)
+		defaultPool.V6Free = defaultPool.V6Available.Separate(pool.V6Free).Separate(s.V6Reserved)
 		defaultPool.V4Available = defaultPool.V4Free.Clone()
 		defaultPool.V6Available = defaultPool.V6Free.Clone()
 	}


### PR DESCRIPTION
## Summary
- Backport of #7275 / #7276 to `release-1.14`.
- Keep `excludeIps` out of the default pool free list when an IPPool is reconciled.
- Strip reserved addresses before random allocation, including the `Released` recycle path.
- Roll back a newly allocated V4 address when V6 allocation fails, while preserving an existing V4 lease.
- Add table-driven public API regressions for both partial-allocation cases.

Static allocation from `excludeIps` remains allowed.

Fixes the `release-1.14` gap for ACP-55320.

## Test Plan
- `go test -count=1 ./pkg/ipam`
- `go vet ./pkg/ipam`