### PR TITLE
fix(vpc-nat-gw): track nat references by UID

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1232,6 +1232,12 @@ func (c *Controller) Run(ctx context.Context) {
 	if err := c.syncFinalizers(); err != nil {
 		util.LogFatalAndExit(err, "failed to initialize crd finalizers")
 	}
+	if err := c.syncNatUIDLabels(); err != nil {
+		// References that could not be migrated keep their previous labels and are migrated on
+		// the next start, but the controller must stay up: a single object that a webhook or an
+		// inconsistent spec rejects would otherwise restart the controller in a loop.
+		klog.Errorf("failed to migrate NAT UID labels: %v", err)
+	}
 
 	if err := c.InitIPAM(); err != nil {
 		util.LogFatalAndExit(err, "failed to initialize ipam")

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -111,6 +111,9 @@ type FakeControllerOptions struct {
 	OvnSnatRules          []*kubeovnv1.OvnSnatRule
 	QoSPolicies           []*kubeovnv1.QoSPolicy
 	IptablesEips          []*kubeovnv1.IptablesEIP
+	IptablesFips          []*kubeovnv1.IptablesFIPRule
+	IptablesDnatRules     []*kubeovnv1.IptablesDnatRule
+	IptablesSnatRules     []*kubeovnv1.IptablesSnatRule
 	StatefulSets          []*appsv1.StatefulSet
 	Deployments           []*appsv1.Deployment
 	ConfigMaps            []*corev1.ConfigMap
@@ -284,6 +287,21 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 			return nil, err
 		}
 	}
+	for _, fip := range opts.IptablesFips {
+		if _, err := kubeovnClient.KubeovnV1().IptablesFIPRules().Create(context.Background(), fip, metav1.CreateOptions{}); err != nil {
+			return nil, err
+		}
+	}
+	for _, dnat := range opts.IptablesDnatRules {
+		if _, err := kubeovnClient.KubeovnV1().IptablesDnatRules().Create(context.Background(), dnat, metav1.CreateOptions{}); err != nil {
+			return nil, err
+		}
+	}
+	for _, snat := range opts.IptablesSnatRules {
+		if _, err := kubeovnClient.KubeovnV1().IptablesSnatRules().Create(context.Background(), snat, metav1.CreateOptions{}); err != nil {
+			return nil, err
+		}
+	}
 
 	// Create informer factories
 	kubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, 0,
@@ -331,6 +349,9 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	ovnSnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().OvnSnatRules()
 	qosPolicyInformer := kubeovnInformerFactory.Kubeovn().V1().QoSPolicies()
 	iptablesEipInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesEIPs()
+	iptablesFipInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesFIPRules()
+	iptablesDnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesDnatRules()
+	iptablesSnatRuleInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesSnatRules()
 
 	fakeInformers := &fakeControllerInformers{
 		vpcInformer:       vpcInformer,
@@ -382,6 +403,9 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		qosPoliciesLister:             qosPolicyInformer.Lister(),
 		qosPolicySynced:               alwaysReady,
 		iptablesEipsLister:            iptablesEipInformer.Lister(),
+		iptablesFipsLister:            iptablesFipInformer.Lister(),
+		iptablesDnatRulesLister:       iptablesDnatRuleInformer.Lister(),
+		iptablesSnatRulesLister:       iptablesSnatRuleInformer.Lister(),
 		statefulSetsLister:            statefulSetInformer.Lister(),
 		deploymentsLister:             deploymentInformer.Lister(),
 		configMapsLister:              configMapInformer.Lister(),

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -27,6 +27,168 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
+// syncNatUIDLabels migrates legacy name/address references to UID labels. A reference is
+// identified by the UID of the object it points at, so objects created before the UID
+// labels existed have to be labeled before the referenced object can be deleted again.
+//
+// The migration is best effort: an object that cannot be updated keeps its previous labels
+// and is migrated on the next start instead of holding up the whole controller. Every
+// failure is reported so it stays visible.
+func (c *Controller) syncNatUIDLabels() error {
+	ctx := context.Background()
+	qos, err := c.config.KubeOvnClient.KubeovnV1().QoSPolicies().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	qosUID := make(map[string]string, len(qos.Items))
+	for i := range qos.Items {
+		qosUID[qos.Items[i].Name] = string(qos.Items[i].UID)
+	}
+
+	var errs []error
+	eips, err := c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range eips.Items {
+		eip := eips.Items[i].DeepCopy()
+		uid := qosUID[eip.Spec.QoSPolicy]
+		hasBinding := eip.Labels[util.QoSLabel] == eip.Spec.QoSPolicy || eip.Status.QoSPolicy == eip.Spec.QoSPolicy
+		if !eip.DeletionTimestamp.IsZero() && !hasBinding {
+			continue
+		}
+		if uid == "" && eip.Spec.QoSPolicy == "" && eip.Labels[util.QoSLabel] == "" && eip.Labels[util.QoSPolicyUIDLabel] == "" {
+			continue
+		}
+		if eip.Labels == nil {
+			eip.Labels = map[string]string{}
+		}
+		if uid == "" && eip.Spec.QoSPolicy != "" {
+			continue
+		}
+		if uid == "" {
+			delete(eip.Labels, util.QoSLabel)
+			delete(eip.Labels, util.QoSPolicyUIDLabel)
+		} else {
+			if eip.Labels[util.QoSLabel] == eip.Spec.QoSPolicy && eip.Labels[util.QoSPolicyUIDLabel] == uid {
+				continue
+			}
+			eip.Labels[util.QoSLabel] = eip.Spec.QoSPolicy
+			eip.Labels[util.QoSPolicyUIDLabel] = uid
+		}
+
+		if _, err = c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Update(ctx, eip, metav1.UpdateOptions{}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to migrate qos claim of iptables eip %s: %w", eip.Name, err))
+		}
+	}
+
+	gws, err := c.config.KubeOvnClient.KubeovnV1().VpcNatGateways().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range gws.Items {
+		gw := gws.Items[i].DeepCopy()
+		uid := qosUID[gw.Spec.QoSPolicy]
+		hasBinding := gw.Labels[util.QoSLabel] == gw.Spec.QoSPolicy || gw.Status.QoSPolicy == gw.Spec.QoSPolicy
+		if !gw.DeletionTimestamp.IsZero() && !hasBinding {
+			continue
+		}
+		if uid == "" && gw.Spec.QoSPolicy == "" && gw.Labels[util.QoSLabel] == "" && gw.Labels[util.QoSPolicyUIDLabel] == "" {
+			continue
+		}
+		if gw.Labels == nil {
+			gw.Labels = map[string]string{}
+		}
+		if uid == "" && gw.Spec.QoSPolicy != "" {
+			continue
+		}
+		if uid == "" {
+			delete(gw.Labels, util.QoSLabel)
+			delete(gw.Labels, util.QoSPolicyUIDLabel)
+		} else {
+			if gw.Labels[util.QoSLabel] == gw.Spec.QoSPolicy && gw.Labels[util.QoSPolicyUIDLabel] == uid {
+				continue
+			}
+			gw.Labels[util.QoSLabel] = gw.Spec.QoSPolicy
+			gw.Labels[util.QoSPolicyUIDLabel] = uid
+		}
+
+		if _, err = c.config.KubeOvnClient.KubeovnV1().VpcNatGateways().Update(ctx, gw, metav1.UpdateOptions{}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to migrate qos claim of vpc nat gateway %s: %w", gw.Name, err))
+		}
+	}
+	return errors.Join(append(errs, c.syncNatRuleUIDLabels(ctx, eips.Items))...)
+}
+
+func (c *Controller) syncNatRuleUIDLabels(ctx context.Context, eips []kubeovnv1.IptablesEIP) error {
+	eipUID := make(map[string]string, len(eips))
+	for i := range eips {
+		eipUID[eips[i].Name] = string(eips[i].UID)
+	}
+	fips, err := c.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range fips.Items {
+		if err = c.syncNatRuleUID(ctx, &fips.Items[i], eipUID); err != nil {
+			return err
+		}
+	}
+	dnats, err := c.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range dnats.Items {
+		if err = c.syncNatRuleUID(ctx, &dnats.Items[i], eipUID); err != nil {
+			return err
+		}
+	}
+	snats, err := c.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range snats.Items {
+		if err = c.syncNatRuleUID(ctx, &snats.Items[i], eipUID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) syncNatRuleUID(ctx context.Context, rule client.Object, eips map[string]string) error {
+	// The concrete rule types expose Spec.EIP; use the existing label when no migration target exists.
+	var eipName string
+	switch obj := rule.(type) {
+	case *kubeovnv1.IptablesFIPRule:
+		eipName = obj.Spec.EIP
+	case *kubeovnv1.IptablesDnatRule:
+		eipName = obj.Spec.EIP
+	case *kubeovnv1.IptablesSnatRule:
+		eipName = obj.Spec.EIP
+	}
+	uid := eips[eipName]
+	if uid == "" || (!rule.GetDeletionTimestamp().IsZero() && rule.GetLabels()[util.EipV4IpLabel] == "") || rule.GetLabels()[util.EipUIDLabel] == uid {
+		return nil
+	}
+	updated := rule.DeepCopyObject().(client.Object)
+	labelsCopy := maps.Clone(rule.GetLabels())
+	if labelsCopy == nil {
+		labelsCopy = map[string]string{}
+	}
+	labelsCopy[util.EipUIDLabel] = uid
+	updated.SetLabels(labelsCopy)
+	var err error
+	switch obj := updated.(type) {
+	case *kubeovnv1.IptablesFIPRule:
+		_, err = c.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Update(ctx, obj, metav1.UpdateOptions{})
+	case *kubeovnv1.IptablesDnatRule:
+		_, err = c.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().Update(ctx, obj, metav1.UpdateOptions{})
+	case *kubeovnv1.IptablesSnatRule:
+		_, err = c.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().Update(ctx, obj, metav1.UpdateOptions{})
+	}
+	return err
+}
+
 func (c *Controller) InitOVN() error {
 	var err error
 

--- a/pkg/controller/qos_policy.go
+++ b/pkg/controller/qos_policy.go
@@ -99,10 +99,24 @@ func qosPolicyStatusMatchesSpec(qos *kubeovnv1.QoSPolicy) bool {
 		compareQoSPolicyBandwidthLimitRules(qos.Status.BandwidthLimitRules, qos.Spec.BandwidthLimitRules)
 }
 
-func iptablesEIPsUsingQoS(eips []*kubeovnv1.IptablesEIP, qos string) []*kubeovnv1.IptablesEIP {
+// qosReferencedByEip reports whether the EIP still claims the policy generation. Spec and
+// Status hold names, so they cannot tell two policies of the same name apart: a leftover
+// reference of an earlier policy would otherwise both hide and prolong the claim of the
+// current one. The claim is therefore keyed on the UID the EIP was labeled with, which its
+// controller only clears after the data plane of that policy generation is gone.
+func qosReferencedByEip(eip *kubeovnv1.IptablesEIP, qos *kubeovnv1.QoSPolicy) bool {
+	return qos.UID != "" && eip.Labels[util.QoSPolicyUIDLabel] == string(qos.UID)
+}
+
+// qosReferencedByNatGw is the NAT gateway counterpart of qosReferencedByEip.
+func qosReferencedByNatGw(gw *kubeovnv1.VpcNatGateway, qos *kubeovnv1.QoSPolicy) bool {
+	return qos.UID != "" && gw.Labels[util.QoSPolicyUIDLabel] == string(qos.UID)
+}
+
+func iptablesEIPsUsingQoS(eips []*kubeovnv1.IptablesEIP, qos *kubeovnv1.QoSPolicy) []*kubeovnv1.IptablesEIP {
 	result := make([]*kubeovnv1.IptablesEIP, 0, len(eips))
 	for _, eip := range eips {
-		if eip.Spec.QoSPolicy == qos || eip.Status.QoSPolicy == qos {
+		if qosReferencedByEip(eip, qos) {
 			result = append(result, eip)
 		}
 	}
@@ -520,13 +534,14 @@ func (c *Controller) handleUpdateQoSPolicy(key string) error {
 	// should delete
 	if !cachedQos.DeletionTimestamp.IsZero() {
 		// Check both supported reference types. BindingType changes are rejected by
-		// reconciliation but not by API validation, so deletion cannot trust Spec alone.
+		// reconciliation but not by API validation, so a referrer labeled with this
+		// policy generation is looked up among EIPs and among NAT gateways.
 		eips, err := c.iptablesEipsLister.List(labels.Everything())
 		if err != nil {
 			return fmt.Errorf("failed to list eips: %w", err)
 		}
 		inUse := slices.ContainsFunc(eips, func(eip *kubeovnv1.IptablesEIP) bool {
-			return eip.Spec.QoSPolicy == key || eip.Status.QoSPolicy == key
+			return qosReferencedByEip(eip, cachedQos)
 		})
 		if !inUse {
 			gateways, err := c.vpcNatGatewayLister.List(labels.Everything())
@@ -534,7 +549,7 @@ func (c *Controller) handleUpdateQoSPolicy(key string) error {
 				return fmt.Errorf("failed to list nat gateways: %w", err)
 			}
 			inUse = slices.ContainsFunc(gateways, func(gateway *kubeovnv1.VpcNatGateway) bool {
-				return gateway.Spec.QoSPolicy == key || gateway.Status.QoSPolicy == key
+				return qosReferencedByNatGw(gateway, cachedQos)
 			})
 		}
 
@@ -594,7 +609,7 @@ func (c *Controller) handleUpdateQoSPolicy(key string) error {
 			if err != nil {
 				return fmt.Errorf("failed to list eips for QoS policy %s: %w", key, err)
 			}
-			eips = iptablesEIPsUsingQoS(eips, key)
+			eips = iptablesEIPsUsingQoS(eips, cachedQos)
 			switch len(eips) {
 			case 0:
 			case 1:

--- a/pkg/controller/qos_policy_test.go
+++ b/pkg/controller/qos_policy_test.go
@@ -8,10 +8,77 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func TestQoSPolicyDeleteHonorsUIDClaim(t *testing.T) {
+	makePolicy := func() *kubeovnv1.QoSPolicy {
+		now := metav1.Now()
+		return &kubeovnv1.QoSPolicy{
+			Name:              "qos-delete",
+			UID:               "qos-delete-uid",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{util.KubeOVNControllerFinalizer},
+			Spec:              kubeovnv1.QoSPolicySpec{BindingType: kubeovnv1.QoSBindingTypeEIP},
+		}
+	}
+
+	t.Run("referencing EIP blocks finalizer removal", func(t *testing.T) {
+		qos := makePolicy()
+		eip := &kubeovnv1.IptablesEIP{
+			Name: "eip", UID: "eip-uid", Labels: map[string]string{util.QoSPolicyUIDLabel: string(qos.UID)},
+			Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: qos.Name},
+		}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{QoSPolicies: []*kubeovnv1.QoSPolicy{qos}, IptablesEips: []*kubeovnv1.IptablesEIP{eip}})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.handleUpdateQoSPolicy(qos.Name))
+		got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().QoSPolicies().Get(context.Background(), qos.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+	})
+
+	t.Run("without claim removes finalizer", func(t *testing.T) {
+		qos := makePolicy()
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{QoSPolicies: []*kubeovnv1.QoSPolicy{qos}})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.handleUpdateQoSPolicy(qos.Name))
+		got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().QoSPolicies().Get(context.Background(), qos.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+	})
+}
+
+func TestEnqueueQoSPolicyRelease(t *testing.T) {
+	t.Parallel()
+	q := newTypedRateLimitingQueue[string]("UpdateQoSPolicy", nil)
+	t.Cleanup(q.ShutDown)
+	c := &Controller{updateQoSPolicyQueue: q}
+
+	c.enqueueQoSPolicyRelease("old", "", "new", "")
+	require.Equal(t, 1, q.Len())
+	got, shutdown := q.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "old", got)
+	q.Done(got)
+
+	c.enqueueQoSPolicyRelease("old", "", "old", "")
+	require.Equal(t, 0, q.Len())
+
+	// A reference that is still applied keeps the policy enqueued until the referring
+	// resource has cleaned up its data plane, even though the desired reference is gone.
+	c.enqueueQoSPolicyRelease("", "applied", "", "")
+	require.Equal(t, 1, q.Len())
+	got, shutdown = q.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "applied", got)
+	q.Done(got)
+
+	c.enqueueQoSPolicyRelease("unchanged", "unchanged", "unchanged", "unchanged")
+	require.Equal(t, 0, q.Len())
+}
 
 func TestValidateRateValue(t *testing.T) {
 	t.Parallel()
@@ -989,7 +1056,7 @@ func makeQoSPolicyForUpdate(name string, shared bool, bindingType kubeovnv1.QoSP
 	statusRules, specRules kubeovnv1.QoSPolicyBandwidthLimitRules,
 ) *kubeovnv1.QoSPolicy {
 	return &kubeovnv1.QoSPolicy{
-		Name: name,
+		Name: name, UID: types.UID(name + "-uid"),
 		Spec: kubeovnv1.QoSPolicySpec{
 			Shared:              shared,
 			BindingType:         bindingType,
@@ -1075,20 +1142,39 @@ func TestEnqueueQoSPolicyReleaseWaitsForAppliedStatus(t *testing.T) {
 	require.Equal(t, 1, ctrl.updateQoSPolicyQueue.Len())
 }
 
-func TestDeletingQoSPolicyKeepsFinalizerWhileReferenced(t *testing.T) {
+func TestDeletingQoSPolicyKeepsFinalizerWhileClaimed(t *testing.T) {
+	// Spec and Status only carry names, so only the UID the referrer was labeled with
+	// tells the generation of the policy it claims. A leftover reference of an earlier
+	// policy that used the same name must neither block nor delay the claim of this one.
+	const qosUID = "terminating-qos-uid"
 	tests := []struct {
-		name        string
-		bindingType kubeovnv1.QoSPolicyBindingType
-		eip         *kubeovnv1.IptablesEIP
+		name           string
+		bindingType    kubeovnv1.QoSPolicyBindingType
+		eip            *kubeovnv1.IptablesEIP
+		keepsFinalizer bool
 	}{
 		{name: "desired spec reference", bindingType: kubeovnv1.QoSBindingTypeEIP, eip: &kubeovnv1.IptablesEIP{
-			Name: "pending-eip", Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: "terminating-qos"},
-		}},
+			Name: "pending-eip", Labels: map[string]string{util.QoSPolicyUIDLabel: qosUID},
+			Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: "terminating-qos"},
+		}, keepsFinalizer: true},
 		{name: "applied status credential", bindingType: kubeovnv1.QoSBindingTypeEIP, eip: &kubeovnv1.IptablesEIP{
-			Name: "cleaning-eip", Status: kubeovnv1.IptablesEIPStatus{QoSPolicy: "terminating-qos"},
-		}},
+			Name: "cleaning-eip", Labels: map[string]string{util.QoSPolicyUIDLabel: qosUID},
+			Status: kubeovnv1.IptablesEIPStatus{QoSPolicy: "terminating-qos"},
+		}, keepsFinalizer: true},
 		{name: "binding type drift", bindingType: kubeovnv1.QoSBindingTypeNatGw, eip: &kubeovnv1.IptablesEIP{
-			Name: "old-eip", Status: kubeovnv1.IptablesEIPStatus{QoSPolicy: "terminating-qos"},
+			Name: "old-eip", Labels: map[string]string{util.QoSPolicyUIDLabel: qosUID},
+			Status: kubeovnv1.IptablesEIPStatus{QoSPolicy: "terminating-qos"},
+		}, keepsFinalizer: true},
+		{
+			name: "reference of an earlier policy with the same name", bindingType: kubeovnv1.QoSBindingTypeEIP,
+			eip: &kubeovnv1.IptablesEIP{
+				Name: "stale-eip", Labels: map[string]string{util.QoSPolicyUIDLabel: "replaced-qos-uid"},
+				Spec:   kubeovnv1.IptablesEIPSpec{QoSPolicy: "terminating-qos"},
+				Status: kubeovnv1.IptablesEIPStatus{QoSPolicy: "terminating-qos"},
+			},
+		},
+		{name: "reference without a claim", bindingType: kubeovnv1.QoSBindingTypeEIP, eip: &kubeovnv1.IptablesEIP{
+			Name: "unclaimed-eip", Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: "terminating-qos"},
 		}},
 	}
 	for _, tt := range tests {
@@ -1096,6 +1182,7 @@ func TestDeletingQoSPolicyKeepsFinalizerWhileReferenced(t *testing.T) {
 			now := metav1.Now()
 			qos := &kubeovnv1.QoSPolicy{
 				Name:              "terminating-qos",
+				UID:               qosUID,
 				DeletionTimestamp: &now,
 				Finalizers:        []string{util.KubeOVNControllerFinalizer},
 				Spec:              kubeovnv1.QoSPolicySpec{BindingType: tt.bindingType},
@@ -1110,32 +1197,54 @@ func TestDeletingQoSPolicyKeepsFinalizerWhileReferenced(t *testing.T) {
 				context.Background(), qos.Name, metav1.GetOptions{},
 			)
 			require.NoError(t, err)
-			require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+			if tt.keepsFinalizer {
+				require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+			} else {
+				require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+			}
 		})
 	}
 }
 
-func TestDeletingNatGwQoSPolicyKeepsFinalizerForAppliedStatus(t *testing.T) {
-	now := metav1.Now()
-	qos := &kubeovnv1.QoSPolicy{
-		Name: "terminating-qos", DeletionTimestamp: &now,
-		Finalizers: []string{util.KubeOVNControllerFinalizer},
-		Spec:       kubeovnv1.QoSPolicySpec{BindingType: kubeovnv1.QoSBindingTypeNatGw},
+func TestDeletingNatGwQoSPolicyKeepsFinalizerWhileClaimed(t *testing.T) {
+	const qosUID = "terminating-qos-uid"
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		keepsFinalizer bool
+	}{
+		{name: "applied status credential", labels: map[string]string{util.QoSPolicyUIDLabel: qosUID}, keepsFinalizer: true},
+		{name: "claim of an earlier policy with the same name", labels: map[string]string{util.QoSPolicyUIDLabel: "replaced-qos-uid"}},
 	}
-	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
-		QoSPolicies: []*kubeovnv1.QoSPolicy{qos},
-		VpcNatGateways: []*kubeovnv1.VpcNatGateway{{
-			Name: "cleaning-gateway", Status: kubeovnv1.VpcNatGatewayStatus{QoSPolicy: qos.Name},
-		}},
-	})
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := metav1.Now()
+			qos := &kubeovnv1.QoSPolicy{
+				Name: "terminating-qos", UID: qosUID, DeletionTimestamp: &now,
+				Finalizers: []string{util.KubeOVNControllerFinalizer},
+				Spec:       kubeovnv1.QoSPolicySpec{BindingType: kubeovnv1.QoSBindingTypeNatGw},
+			}
+			fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				QoSPolicies: []*kubeovnv1.QoSPolicy{qos},
+				VpcNatGateways: []*kubeovnv1.VpcNatGateway{{
+					Name: "cleaning-gateway", Labels: tt.labels,
+					Status: kubeovnv1.VpcNatGatewayStatus{QoSPolicy: qos.Name},
+				}},
+			})
+			require.NoError(t, err)
 
-	require.NoError(t, fakeCtrl.fakeController.handleUpdateQoSPolicy(qos.Name))
-	got, err := fakeCtrl.fakeController.config.KubeOvnClient.KubeovnV1().QoSPolicies().Get(
-		context.Background(), qos.Name, metav1.GetOptions{},
-	)
-	require.NoError(t, err)
-	require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+			require.NoError(t, fakeCtrl.fakeController.handleUpdateQoSPolicy(qos.Name))
+			got, err := fakeCtrl.fakeController.config.KubeOvnClient.KubeovnV1().QoSPolicies().Get(
+				context.Background(), qos.Name, metav1.GetOptions{},
+			)
+			require.NoError(t, err)
+			if tt.keepsFinalizer {
+				require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+			} else {
+				require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+			}
+		})
+	}
 }
 
 func TestHandleUpdateQoSPolicy(t *testing.T) {
@@ -1168,7 +1277,11 @@ func TestHandleUpdateQoSPolicy(t *testing.T) {
 	eips := make([]*kubeovnv1.IptablesEIP, 0, 2)
 	for _, name := range []string{"eip-1", "eip-2"} {
 		eips = append(eips, &kubeovnv1.IptablesEIP{
-			Name:   name,
+			Name: name,
+			Labels: map[string]string{
+				util.QoSLabel:          multiEIPQoS.Name,
+				util.QoSPolicyUIDLabel: string(multiEIPQoS.UID),
+			},
 			Spec:   kubeovnv1.IptablesEIPSpec{QoSPolicy: multiEIPQoS.Name},
 			Status: kubeovnv1.IptablesEIPStatus{IP: "172.20.0.10"},
 		})

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -131,6 +131,10 @@ func (c *Controller) enqueueAddVpcNatGw(obj any) {
 	gw := obj.(*kubeovnv1.VpcNatGateway)
 	c.enqueueNftableLbServicesForNatGw(gw.Name)
 	key := cache.MetaObjectToName(gw).String()
+	if !gw.DeletionTimestamp.IsZero() {
+		c.delVpcNatGatewayQueue.Add(key)
+		return
+	}
 	klog.V(3).Infof("enqueue add vpc-nat-gw %s", key)
 	c.addOrUpdateVpcNatGatewayQueue.Add(key)
 }
@@ -152,6 +156,10 @@ func (c *Controller) enqueueUpdateVpcNatGw(oldObj, newObj any) {
 		c.enqueueNftableLbServicesForNatGw(newGw.Name)
 	}
 	key := cache.MetaObjectToName(newGw).String()
+	if !newGw.DeletionTimestamp.IsZero() {
+		c.delVpcNatGatewayQueue.Add(key)
+		return
+	}
 	klog.V(3).Infof("enqueue update vpc-nat-gw %s", key)
 	c.addOrUpdateVpcNatGatewayQueue.Add(key)
 
@@ -537,6 +545,13 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) (retErr error) {
 					return fmt.Errorf("failed to del qos for nat gw %s: %w", gw.Name, err)
 				}
 			}
+			// Rewrite the claim only after the rules of the previous generation are gone and
+			// before the rules of the new one can exist: the new policy has to see this gateway
+			// as a user from the moment its rules can be applied, while the previous policy
+			// stays claimed until its rules are deleted.
+			if err := c.updateCrdNatGwLabels(key, gw.Spec.QoSPolicy); err != nil {
+				return fmt.Errorf("failed to update nat gw %s labels: %w", gw.Name, err)
+			}
 			if gw.Spec.QoSPolicy != "" {
 				if err = c.execNatGwQoSLocked(gw, gw.Spec.QoSPolicy, QoSAdd); err != nil {
 					return fmt.Errorf("failed to add qos for nat gw %s: %w", gw.Name, err)
@@ -544,11 +559,6 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) (retErr error) {
 			}
 			return nil
 		}); err != nil {
-			klog.Error(err)
-			return err
-		}
-		if err := c.updateCrdNatGwLabels(key, gw.Spec.QoSPolicy); err != nil {
-			err := fmt.Errorf("failed to update nat gw %s: %w", gw.Name, err)
 			klog.Error(err)
 			return err
 		}
@@ -615,6 +625,9 @@ func (c *Controller) handleInitVpcNatGw(key string) (retErr error) {
 		}
 	}()
 
+	if !gw.DeletionTimestamp.IsZero() {
+		return nil
+	}
 	if vpcNatEnabled != "true" {
 		return errors.New("iptables nat gw not enable")
 	}
@@ -734,7 +747,7 @@ func (c *Controller) handleInitVpcNatGw(key string) (retErr error) {
 			return fmt.Errorf("failed to init vpc nat gateway, %w", err)
 		}
 	}
-	if err = c.restoreVpcNatGwQoS(gw); err != nil {
+	if err = c.claimAndRestoreVpcNatGwQoS(gw); err != nil {
 		return err
 	}
 	// if update qos success, will update nat gw status
@@ -745,12 +758,6 @@ func (c *Controller) handleInitVpcNatGw(key string) (retErr error) {
 			_ = c.recordResourceError(gw, "UpdateStatusFailed", err)
 			return err
 		}
-	}
-
-	if err := c.updateCrdNatGwLabels(gw.Name, gw.Spec.QoSPolicy); err != nil {
-		err := fmt.Errorf("failed to update nat gw %s: %w", gw.Name, err)
-		klog.Error(err)
-		return err
 	}
 
 	for _, pod := range initTargets {
@@ -826,6 +833,16 @@ func natGwPodInstanceToken(pod *corev1.Pod) string {
 		}
 	}
 	return ""
+}
+
+// claimAndRestoreVpcNatGwQoS publishes the qos claim of the gateway and then re-applies its
+// policy on a (re)created gateway pod, so the policy cannot be released between the two: the
+// claim is written first and the rules follow.
+func (c *Controller) claimAndRestoreVpcNatGwQoS(gw *kubeovnv1.VpcNatGateway) error {
+	if err := c.updateCrdNatGwLabels(gw.Name, gw.Spec.QoSPolicy); err != nil {
+		return fmt.Errorf("failed to update nat gw %s: %w", gw.Name, err)
+	}
+	return c.restoreVpcNatGwQoS(gw)
 }
 
 // restoreVpcNatGwQoS re-applies the gateway policy on a (re)created gateway pod.
@@ -1862,6 +1879,10 @@ func (c *Controller) natGwRedoToken(key string) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(instances, ",")))), nil
 }
 
+// updateCrdNatGwLabels records the subnet, vpc and qos references of the gateway, including the
+// UID claim of the policy generation it uses (ovn.kubernetes.io/qos_uid). A caller that applies
+// the rules of a policy must write the claim before those rules can reach the data plane, and a
+// caller that drops the reference must do so only after the rules are gone.
 func (c *Controller) updateCrdNatGwLabels(key, qos string) error {
 	oriGw, err := c.vpcNatGatewayLister.Get(key)
 	if err != nil {
@@ -1869,6 +1890,21 @@ func (c *Controller) updateCrdNatGwLabels(key, qos string) error {
 		klog.Error(errMsg)
 		return errMsg
 	}
+	qosUID := ""
+	if qos != "" {
+		policy, err := c.qosPoliciesLister.Get(qos)
+		switch {
+		case err != nil && oriGw.DeletionTimestamp.IsZero():
+			return fmt.Errorf("failed to get qos policy %s: %w", qos, err)
+		case err != nil:
+			qosUID = oriGw.Labels[util.QoSPolicyUIDLabel]
+		case !policy.DeletionTimestamp.IsZero() && oriGw.DeletionTimestamp.IsZero() && oriGw.Labels[util.QoSLabel] != qos:
+			return fmt.Errorf("qos policy %s is terminating", qos)
+		default:
+			qosUID = string(policy.UID)
+		}
+	}
+
 	var needUpdateLabel bool
 	var op string
 
@@ -1882,6 +1918,7 @@ func (c *Controller) updateCrdNatGwLabels(key, qos string) error {
 		labels[util.SubnetNameLabel] = oriGw.Spec.Subnet
 		labels[util.VpcNameLabel] = oriGw.Spec.Vpc
 		labels[util.QoSLabel] = qos
+		labels[util.QoSPolicyUIDLabel] = qosUID
 		needUpdateLabel = true
 	} else {
 		if oriGw.Labels[util.SubnetNameLabel] != oriGw.Spec.Subnet {
@@ -1894,9 +1931,10 @@ func (c *Controller) updateCrdNatGwLabels(key, qos string) error {
 			labels[util.VpcNameLabel] = oriGw.Spec.Vpc
 			needUpdateLabel = true
 		}
-		if oriGw.Labels[util.QoSLabel] != qos {
+		if oriGw.Labels[util.QoSLabel] != qos || oriGw.Labels[util.QoSPolicyUIDLabel] != qosUID {
 			op = "replace"
 			labels[util.QoSLabel] = qos
+			labels[util.QoSPolicyUIDLabel] = qosUID
 			needUpdateLabel = true
 		}
 	}

--- a/pkg/controller/vpc_nat_gateway_qos_test.go
+++ b/pkg/controller/vpc_nat_gateway_qos_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func TestNatGwRedoTokenUsesContainerInstancesPerGateway(t *testing.T) {
@@ -112,4 +113,127 @@ func TestNatGwInitTargets(t *testing.T) {
 	terminatingGateway := gateway.DeepCopy()
 	terminatingGateway.DeletionTimestamp = &now
 	require.False(t, natGwInitPending(terminatingGateway, nil))
+}
+
+// TestUpdateCrdNatGwLabelsQoSClaim pins the claim the gateway label carries: the UID of the
+// policy generation it references. A terminating policy must not be taken by a new binding,
+// while a gateway that already references it keeps the claim it had, so that the referenced
+// policy generation is still recognized while the gateway cleans up.
+// TestNatGwQoSClaimIsWrittenBeforeRestore pins that a gateway re-asserts the claim of the policy
+// generation whose rules it re-applies when its pod is (re)initialized.
+func TestNatGwQoSClaimIsWrittenBeforeRestore(t *testing.T) {
+	rules := kubeovnv1.QoSPolicyBandwidthLimitRules{{Direction: kubeovnv1.QoSDirectionEgress, Interface: "net1"}}
+	qos := &kubeovnv1.QoSPolicy{
+		Name: "qos", UID: "qos-uid",
+		Spec: kubeovnv1.QoSPolicySpec{
+			Shared: true, BindingType: kubeovnv1.QoSBindingTypeNatGw, BandwidthLimitRules: rules,
+		},
+		Status: kubeovnv1.QoSPolicyStatus{
+			Shared: true, BindingType: kubeovnv1.QoSBindingTypeNatGw, BandwidthLimitRules: rules,
+		},
+	}
+	gw := &kubeovnv1.VpcNatGateway{
+		Name: "gw",
+		Labels: map[string]string{
+			util.SubnetNameLabel: "test-subnet", util.VpcNameLabel: "test-vpc",
+		},
+		Spec: kubeovnv1.VpcNatGatewaySpec{Vpc: "test-vpc", Subnet: "test-subnet", QoSPolicy: "qos"},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		QoSPolicies: []*kubeovnv1.QoSPolicy{qos}, VpcNatGateways: []*kubeovnv1.VpcNatGateway{gw},
+	})
+	require.NoError(t, err)
+
+	// The gateway has no pod, so the rules cannot be re-applied and the call fails.
+	require.Error(t, fc.fakeController.claimAndRestoreVpcNatGwQoS(gw))
+	got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().VpcNatGateways().Get(
+		context.Background(), "gw", metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "qos-uid", got.Labels[util.QoSPolicyUIDLabel])
+}
+
+func TestUpdateCrdNatGwLabelsQoSClaim(t *testing.T) {
+	now := metav1.Now()
+	policy := func(name, uid string, terminating bool) *kubeovnv1.QoSPolicy {
+		qos := &kubeovnv1.QoSPolicy{Name: name, UID: types.UID(uid)}
+		if terminating {
+			qos.DeletionTimestamp = &now
+		}
+		return qos
+	}
+	gateway := func(labels map[string]string, terminating bool) *kubeovnv1.VpcNatGateway {
+		gw := &kubeovnv1.VpcNatGateway{
+			Name: "gw", Labels: labels,
+			Spec: kubeovnv1.VpcNatGatewaySpec{Vpc: "test-vpc", Subnet: "test-subnet"},
+		}
+		if terminating {
+			gw.DeletionTimestamp = &now
+		}
+		return gw
+	}
+	bound := func() map[string]string {
+		return map[string]string{
+			util.SubnetNameLabel: "test-subnet", util.VpcNameLabel: "test-vpc",
+			util.QoSLabel: "qos", util.QoSPolicyUIDLabel: "qos-uid",
+		}
+	}
+
+	tests := []struct {
+		name      string
+		qos       string
+		policies  []*kubeovnv1.QoSPolicy
+		gateway   *kubeovnv1.VpcNatGateway
+		wantErr   string
+		wantClaim string
+	}{
+		{
+			name: "healthy policy claims its generation", qos: "qos",
+			policies:  []*kubeovnv1.QoSPolicy{policy("qos", "qos-uid", false)},
+			gateway:   gateway(map[string]string{util.SubnetNameLabel: "test-subnet", util.VpcNameLabel: "test-vpc"}, false),
+			wantClaim: "qos-uid",
+		},
+		{
+			name: "terminating policy is rejected for a new binding", qos: "qos",
+			policies: []*kubeovnv1.QoSPolicy{policy("qos", "qos-uid", true)},
+			gateway:  gateway(nil, false), wantErr: "is terminating",
+		},
+		{
+			name: "terminating policy keeps the claim of a bound gateway", qos: "qos",
+			policies: []*kubeovnv1.QoSPolicy{policy("qos", "qos-uid", true)},
+			gateway:  gateway(bound(), false), wantClaim: "qos-uid",
+		},
+		{
+			name: "missing policy keeps the claim of a terminating gateway", qos: "qos",
+			gateway: gateway(bound(), true), wantClaim: "qos-uid",
+		},
+		{
+			name: "missing policy is reported for a live gateway", qos: "qos",
+			gateway: gateway(bound(), false), wantErr: "failed to get qos policy",
+		},
+		{
+			name: "unbinding drops the claim", qos: "",
+			gateway: gateway(bound(), false), wantClaim: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				QoSPolicies: tt.policies, VpcNatGateways: []*kubeovnv1.VpcNatGateway{tt.gateway},
+			})
+			require.NoError(t, err)
+
+			err = fc.fakeController.updateCrdNatGwLabels("gw", tt.qos)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().VpcNatGateways().Get(
+				context.Background(), "gw", metav1.GetOptions{},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantClaim, got.Labels[util.QoSPolicyUIDLabel])
+		})
+	}
 }

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -110,6 +110,10 @@ func (c *Controller) handleAddIptablesEip(key string) error {
 		return errors.New("iptables nat gw not enable")
 	}
 
+	if !cachedEip.DeletionTimestamp.IsZero() {
+		return c.handleUpdateIptablesEip(key)
+	}
+
 	c.vpcNatGwKeyMutex.LockKey(key)
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle add iptables eip %s", key)
@@ -218,28 +222,23 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle update iptables eip %s", key)
 
-	subnetName := util.GetExternalNetwork(cachedEip.Spec.ExternalSubnet)
-	subnet, err := c.subnetsLister.Get(subnetName)
-	if err != nil {
-		klog.Errorf("failed to get subnet %s: %v", subnetName, err)
-		return err
-	}
-
-	v4Cidr, _ := util.SplitStringIP(subnet.Spec.CIDRBlock)
-	if v4Cidr == "" {
-		err = fmt.Errorf("subnet %s does not support ipv4", subnet.Name)
-		klog.Error(err)
-		return err
-	}
-
 	if !cachedEip.DeletionTimestamp.IsZero() {
+		// Deletion must not depend on the external Subnet still being present. A forced or
+		// independently completed Subnet deletion must not strand the EIP finalizer.
+		subnetName := util.GetExternalNetwork(cachedEip.Spec.ExternalSubnet)
+		subnet, subnetErr := c.subnetsLister.Get(subnetName)
+		v4Cidr := ""
+		if subnetErr == nil {
+			v4Cidr, _ = util.SplitStringIP(subnet.Spec.CIDRBlock)
+		}
+
 		klog.Infof("clean eip %q in pod", key)
 
 		// Check if EIP is still being used by any NAT rules (FIP/DNAT/SNAT)
 		// Only remove finalizer when no NAT rules are using it
 		// Note: We query NAT rules directly instead of relying on cachedEip.Status.Nat
 		// to avoid cache staleness issues
-		nat, err := c.getIptablesEipNat(cachedEip.Spec.V4ip)
+		nat, err := c.getIptablesEipNat(cachedEip)
 		if err != nil {
 			klog.Errorf("failed to get eip %s nat rules, %v", key, err)
 			return err
@@ -249,7 +248,7 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 			return nil
 		}
 
-		if vpcNatEnabled == "true" {
+		if vpcNatEnabled == "true" && v4Cidr != "" && cachedEip.Status.IP != "" {
 			v4ipCidr, err := util.GetIPAddrWithMask(cachedEip.Status.IP, v4Cidr)
 			if err != nil {
 				err = fmt.Errorf("failed to get eip %s with mask by cidr %s: %w", cachedEip.Status.IP, v4Cidr, err)
@@ -267,8 +266,13 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 				return err
 			}
 		}
-		// Release IP from IPAM before removing finalizer
-		c.ipam.ReleaseAddressByPod(key, cachedEip.Spec.ExternalSubnet)
+		// Release IP from IPAM before removing finalizer. If the subnet is gone, the API object
+		// cannot be repaired; releasing the EIP is safer than retaining a permanent finalizer.
+		if subnetErr == nil {
+			c.ipam.ReleaseAddressByPod(key, cachedEip.Spec.ExternalSubnet)
+		} else if !k8serrors.IsNotFound(subnetErr) {
+			return subnetErr
+		}
 
 		// Now remove finalizer, which will trigger subnet status update.
 		// QoS reconcile is re-triggered from the EIP DeleteFunc after the cache drops this EIP.
@@ -278,6 +282,19 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 		}
 
 		return nil
+	}
+
+	subnetName := util.GetExternalNetwork(cachedEip.Spec.ExternalSubnet)
+	subnet, err := c.subnetsLister.Get(subnetName)
+	if err != nil {
+		klog.Errorf("failed to get subnet %s: %v", subnetName, err)
+		return err
+	}
+	v4Cidr, _ := util.SplitStringIP(subnet.Spec.CIDRBlock)
+	if v4Cidr == "" {
+		err = fmt.Errorf("subnet %s does not support ipv4", subnet.Name)
+		klog.Error(err)
+		return err
 	}
 	klog.Infof("handle update eip %s", key)
 	// v6 ip address can not use upper case
@@ -307,6 +324,13 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 					return fmt.Errorf("failed to del qos %s in pod: %w", cachedEip.Status.QoSPolicy, err)
 				}
 			}
+			// Rewrite the claim only after the rules of the previous generation are gone and
+			// before the rules of the new one can exist: the new policy has to see this eip as
+			// a user from the moment its rules can be applied, while the previous policy stays
+			// claimed until its rules are deleted.
+			if err = c.patchEipLabel(key); err != nil {
+				return fmt.Errorf("failed to label qos in eip %s: %w", key, err)
+			}
 			if cachedEip.Spec.QoSPolicy != "" {
 				if err = c.addEipQoSLocked(cachedEip, cachedEip.Status.IP); err != nil {
 					return fmt.Errorf("failed to add qos %s in pod: %w", cachedEip.Spec.QoSPolicy, err)
@@ -315,11 +339,6 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 			return nil
 		}); err != nil {
 			klog.Errorf("failed to update qos for eip %s, %v", key, err)
-			return err
-		}
-
-		if err = c.patchEipLabel(key); err != nil {
-			klog.Errorf("failed to label qos in eip, %v", err)
 			return err
 		}
 
@@ -346,6 +365,12 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 		}
 
 		if cachedEip.Spec.QoSPolicy != "" {
+			// Re-applying the rules also re-asserts the claim, so a policy that is marked for
+			// deletion cannot be released while this eip still carries its rules.
+			if err = c.patchEipLabel(key); err != nil {
+				klog.Errorf("failed to label qos in eip %s, %v", key, err)
+				return err
+			}
 			if err = c.addEipQoS(cachedEip, cachedEip.Status.IP); err != nil {
 				klog.Errorf("failed to add qos '%s' in pod, %v", key, err)
 				return err
@@ -509,7 +534,7 @@ func (c *Controller) addEipQoSLocked(eip *kubeovnv1.IptablesEIP, v4ip string) er
 		if err != nil {
 			return fmt.Errorf("failed to list eips: %w", err)
 		}
-		eips = iptablesEIPsUsingQoS(eips, qosPolicy.Name)
+		eips = iptablesEIPsUsingQoS(eips, qosPolicy)
 		if len(eips) > 1 || len(eips) == 1 && eips[0].Name != eip.Name {
 			return fmt.Errorf("not support unshared qos policy %s related to multiple eips", eip.Spec.QoSPolicy)
 		}
@@ -701,7 +726,22 @@ func (c *Controller) GetGwBySubnet(name string) (string, string, error) {
 	return v4, v6, nil
 }
 
+func (c *Controller) qosPolicyUID(name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+	qosPolicy, err := c.qosPoliciesLister.Get(name)
+	if err != nil {
+		return "", err
+	}
+	return string(qosPolicy.UID), nil
+}
+
 func (c *Controller) createOrUpdateEipCR(key, v4ip, v6ip, mac, natGwDp, qos, externalNet, gwNamespace string) error {
+	qosUID, err := c.qosPolicyUID(qos)
+	if err != nil {
+		return fmt.Errorf("failed to get qos policy %s: %w", qos, err)
+	}
 	needCreate := false
 	cachedEip, err := c.iptablesEipsLister.Get(key)
 	if err != nil {
@@ -714,7 +754,8 @@ func (c *Controller) createOrUpdateEipCR(key, v4ip, v6ip, mac, natGwDp, qos, ext
 	}
 	if needCreate {
 		klog.V(3).Infof("create eip cr %s", key)
-		// Create CR with finalizer, labels and status all at once
+		// Create CR with finalizer, labels, the qos claim and status all at once, so the eip
+		// cannot be referenced before the policy generation it uses is recorded.
 		_, err := c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Create(context.Background(), &kubeovnv1.IptablesEIP{
 			Name:       key,
 			Finalizers: []string{util.KubeOVNControllerFinalizer},
@@ -722,6 +763,8 @@ func (c *Controller) createOrUpdateEipCR(key, v4ip, v6ip, mac, natGwDp, qos, ext
 				util.SubnetNameLabel:        externalNet,
 				util.EipV4IpLabel:           v4ip,
 				util.VpcNatGatewayNameLabel: natGwDp,
+				util.QoSLabel:               qos,
+				util.QoSPolicyUIDLabel:      qosUID,
 			},
 			Spec: kubeovnv1.IptablesEIPSpec{
 				V4ip:       v4ip,
@@ -754,9 +797,10 @@ func (c *Controller) createOrUpdateEipCR(key, v4ip, v6ip, mac, natGwDp, qos, ext
 		eip.Labels[util.SubnetNameLabel] = externalNet
 		eip.Labels[util.VpcNatGatewayNameLabel] = natGwDp
 		eip.Labels[util.EipV4IpLabel] = v4ip
-		if eip.Spec.QoSPolicy != "" {
-			eip.Labels[util.QoSLabel] = eip.Spec.QoSPolicy
-		}
+		// The qos claim is published together with the spec and status of the eip, so no rule can
+		// depend on this eip before the policy generation it uses is recorded.
+		eip.Labels[util.QoSLabel] = qos
+		eip.Labels[util.QoSPolicyUIDLabel] = qosUID
 
 		if v4ip != "" {
 			klog.V(3).Infof("update eip cr %s", key)
@@ -927,9 +971,9 @@ func (c *Controller) patchEipQoSStatus(key, qos string) error {
 	return nil
 }
 
-func (c *Controller) getIptablesEipNat(eipV4IP string) (string, error) {
+func (c *Controller) getIptablesEipNat(eip *kubeovnv1.IptablesEIP) (string, error) {
 	nats := make([]string, 0, 3)
-	selector := labels.SelectorFromSet(labels.Set{util.EipV4IpLabel: eipV4IP})
+	selector := labels.SelectorFromSet(labels.Set{util.EipUIDLabel: string(eip.UID)})
 	dnats, err := c.iptablesDnatRulesLister.List(selector)
 	if err != nil {
 		klog.Errorf("failed to get dnats, %v", err)
@@ -984,7 +1028,7 @@ func (c *Controller) patchEipStatus(key, v4ip, redo, qos string, ready bool) err
 		changed = true
 	}
 
-	nat, err := c.getIptablesEipNat(oriEip.Spec.V4ip)
+	nat, err := c.getIptablesEipNat(oriEip)
 	if err != nil {
 		err = fmt.Errorf("failed to get eip nat: %w", err)
 		klog.Error(err)
@@ -1020,6 +1064,9 @@ func (c *Controller) patchEipStatus(key, v4ip, redo, qos string, ready bool) err
 	return nil
 }
 
+// patchEipLabel records the subnet, gateway, address and qos references of the eip, including the
+// UID claim of the policy generation it uses (ovn.kubernetes.io/qos_uid). A caller that applies
+// the rules of a policy must write the claim before those rules can reach the data plane.
 func (c *Controller) patchEipLabel(eipName string) error {
 	oriEip, err := c.iptablesEipsLister.Get(eipName)
 	if err != nil {
@@ -1030,6 +1077,10 @@ func (c *Controller) patchEipLabel(eipName string) error {
 		return err
 	}
 	externalNetwork := util.GetExternalNetwork(oriEip.Spec.ExternalSubnet)
+	qosUID, err := c.qosPolicyUID(oriEip.Spec.QoSPolicy)
+	if err != nil && oriEip.Spec.QoSPolicy != "" {
+		return fmt.Errorf("failed to get qos policy %s: %w", oriEip.Spec.QoSPolicy, err)
+	}
 
 	eip := oriEip.DeepCopy()
 	var needUpdateLabel bool
@@ -1041,14 +1092,16 @@ func (c *Controller) patchEipLabel(eipName string) error {
 			util.SubnetNameLabel:        externalNetwork,
 			util.VpcNatGatewayNameLabel: eip.Spec.NatGwDp,
 			util.QoSLabel:               eip.Spec.QoSPolicy,
+			util.QoSPolicyUIDLabel:      qosUID,
 			util.EipV4IpLabel:           eip.Spec.V4ip,
 		}
-	} else if eip.Labels[util.VpcNatGatewayNameLabel] != eip.Spec.NatGwDp || eip.Labels[util.QoSLabel] != eip.Spec.QoSPolicy {
+	} else if eip.Labels[util.VpcNatGatewayNameLabel] != eip.Spec.NatGwDp || eip.Labels[util.QoSLabel] != eip.Spec.QoSPolicy || eip.Labels[util.QoSPolicyUIDLabel] != qosUID {
 		op = "replace"
 		needUpdateLabel = true
 		eip.Labels[util.SubnetNameLabel] = externalNetwork
 		eip.Labels[util.VpcNatGatewayNameLabel] = eip.Spec.NatGwDp
 		eip.Labels[util.QoSLabel] = eip.Spec.QoSPolicy
+		eip.Labels[util.QoSPolicyUIDLabel] = qosUID
 		eip.Labels[util.EipV4IpLabel] = eip.Spec.V4ip
 	}
 	if needUpdateLabel {

--- a/pkg/controller/vpc_nat_gw_eip_test.go
+++ b/pkg/controller/vpc_nat_gw_eip_test.go
@@ -1,12 +1,20 @@
 package controller
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8stesting "k8s.io/client-go/testing"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 // fakeGw returns a minimal VpcNatGateway CRD object for use in tests.
@@ -15,6 +23,363 @@ func fakeGw(name string) *kubeovnv1.VpcNatGateway {
 		Name: name,
 		Spec: kubeovnv1.VpcNatGatewaySpec{},
 	}
+}
+
+func TestSyncNatUIDLabels(t *testing.T) {
+	t.Parallel()
+	qos := &kubeovnv1.QoSPolicy{Name: "qos", UID: "qos-uid"}
+	eip := &kubeovnv1.IptablesEIP{
+		Name: "eip", UID: "eip-uid",
+		Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: "qos"},
+	}
+	fip := &kubeovnv1.IptablesFIPRule{
+		Name: "fip",
+		Spec: kubeovnv1.IptablesFIPRuleSpec{EIP: "eip"},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		QoSPolicies:  []*kubeovnv1.QoSPolicy{qos},
+		IptablesEips: []*kubeovnv1.IptablesEIP{eip},
+	})
+	require.NoError(t, err)
+	_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Create(context.Background(), fip, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.syncNatUIDLabels())
+
+	gotEip, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Get(context.Background(), "eip", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "qos-uid", gotEip.Labels[util.QoSPolicyUIDLabel])
+	gotFip, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Get(context.Background(), "fip", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "eip-uid", gotFip.Labels[util.EipUIDLabel])
+}
+
+func TestFipRebindPreservesEipClaim(t *testing.T) {
+	oldEnabled := vpcNatEnabled
+	vpcNatEnabled = "true"
+	t.Cleanup(func() { vpcNatEnabled = oldEnabled })
+
+	newFip := func(statusGateway string) *kubeovnv1.IptablesFIPRule {
+		return &kubeovnv1.IptablesFIPRule{
+			Name: "fip", Labels: map[string]string{util.EipUIDLabel: "old-uid"},
+			Spec:   kubeovnv1.IptablesFIPRuleSpec{EIP: "new-eip", InternalIP: "10.0.0.1"},
+			Status: kubeovnv1.IptablesFIPRuleStatus{V4ip: "1.1.1.1", NatGwDp: statusGateway, InternalIP: "10.0.0.1", Ready: true},
+		}
+	}
+	setup := func(t *testing.T, fip *kubeovnv1.IptablesFIPRule) *Controller {
+		t.Helper()
+		eip := &kubeovnv1.IptablesEIP{
+			Name: "new-eip", UID: "new-uid",
+			Spec:   kubeovnv1.IptablesEIPSpec{V4ip: "2.2.2.2", NatGwDp: "gw"},
+			Status: kubeovnv1.IptablesEIPStatus{IP: "2.2.2.2"},
+		}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("gw")},
+			IptablesEips:   []*kubeovnv1.IptablesEIP{eip},
+			IptablesFips:   []*kubeovnv1.IptablesFIPRule{fip},
+		})
+		require.NoError(t, err)
+		return fc.fakeController
+	}
+	getClaim := func(t *testing.T, c *Controller) string {
+		t.Helper()
+		fip, err := c.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Get(context.Background(), "fip", metav1.GetOptions{})
+		require.NoError(t, err)
+		return fip.Labels[util.EipUIDLabel]
+	}
+
+	t.Run("old claim remains when old rule cleanup fails", func(t *testing.T) {
+		c := setup(t, newFip("gw"))
+		require.Error(t, c.handleUpdateIptablesFip("fip"))
+		require.Equal(t, "old-uid", getClaim(t, c))
+	})
+	t.Run("new claim is written before new rule creation", func(t *testing.T) {
+		c := setup(t, newFip("retired-gw"))
+		require.Error(t, c.handleUpdateIptablesFip("fip"))
+		require.Equal(t, "new-uid", getClaim(t, c))
+	})
+}
+
+func TestSyncNatUIDLabelsKeepsTerminatingBindings(t *testing.T) {
+	now := metav1.Now()
+	qos := &kubeovnv1.QoSPolicy{Name: "qos", UID: "qos-uid", DeletionTimestamp: &now}
+	eip := &kubeovnv1.IptablesEIP{
+		Name: "eip", UID: "eip-uid", DeletionTimestamp: &now,
+		Labels: map[string]string{util.QoSLabel: "qos"},
+		Spec:   kubeovnv1.IptablesEIPSpec{QoSPolicy: "qos"},
+	}
+	fip := &kubeovnv1.IptablesFIPRule{
+		Name: "fip", Labels: map[string]string{util.EipV4IpLabel: "10.0.0.2"},
+		Spec: kubeovnv1.IptablesFIPRuleSpec{EIP: "eip"},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		QoSPolicies:  []*kubeovnv1.QoSPolicy{qos},
+		IptablesEips: []*kubeovnv1.IptablesEIP{eip},
+	})
+	require.NoError(t, err)
+	_, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Create(context.Background(), fip, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.syncNatUIDLabels())
+
+	gotEip, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Get(context.Background(), "eip", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "qos-uid", gotEip.Labels[util.QoSPolicyUIDLabel])
+	gotFip, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Get(context.Background(), "fip", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "eip-uid", gotFip.Labels[util.EipUIDLabel])
+}
+
+func TestSyncNatUIDLabelsCorrectsStaleAndClearsDroppedQoS(t *testing.T) {
+	qos := &kubeovnv1.QoSPolicy{Name: "qos", UID: "current-uid"}
+	stale := &kubeovnv1.IptablesEIP{
+		Name: "stale", Labels: map[string]string{util.QoSLabel: "qos", util.QoSPolicyUIDLabel: "old-uid"},
+		Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: "qos"},
+	}
+	cleared := &kubeovnv1.IptablesEIP{
+		Name: "cleared", Labels: map[string]string{util.QoSLabel: "qos", util.QoSPolicyUIDLabel: "old-uid"},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{QoSPolicies: []*kubeovnv1.QoSPolicy{qos}, IptablesEips: []*kubeovnv1.IptablesEIP{stale, cleared}})
+	require.NoError(t, err)
+	require.NoError(t, fc.fakeController.syncNatUIDLabels())
+
+	got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Get(context.Background(), "stale", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "current-uid", got.Labels[util.QoSPolicyUIDLabel])
+	got, err = fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Get(context.Background(), "cleared", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, got.Labels, util.QoSPolicyUIDLabel)
+	require.NotContains(t, got.Labels, util.QoSLabel)
+}
+
+func TestQoSPolicyUID(t *testing.T) {
+	t.Parallel()
+	qos := &kubeovnv1.QoSPolicy{Name: "qos", UID: "qos-uid"}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{QoSPolicies: []*kubeovnv1.QoSPolicy{qos}})
+	require.NoError(t, err)
+
+	uid, err := fc.fakeController.qosPolicyUID(qos.Name)
+	require.NoError(t, err)
+	require.Equal(t, string(qos.UID), uid)
+
+	uid, err = fc.fakeController.qosPolicyUID("")
+	require.NoError(t, err)
+	require.Empty(t, uid)
+
+	_, err = fc.fakeController.qosPolicyUID("missing")
+	require.Error(t, err)
+}
+
+func TestIptablesEipDeleteHonorsUIDClaim(t *testing.T) {
+	oldEnabled := vpcNatEnabled
+	vpcNatEnabled = "false"
+	t.Cleanup(func() { vpcNatEnabled = oldEnabled })
+	newEip := func() *kubeovnv1.IptablesEIP {
+		now := metav1.Now()
+		return &kubeovnv1.IptablesEIP{
+			Name: "eip-delete", UID: "eip-delete-uid", DeletionTimestamp: &now,
+			Finalizers: []string{util.KubeOVNControllerFinalizer},
+		}
+	}
+
+	t.Run("matching claim blocks finalizer removal", func(t *testing.T) {
+		eip := newEip()
+		fip := &kubeovnv1.IptablesFIPRule{
+			Name: "fip", Labels: map[string]string{util.EipUIDLabel: string(eip.UID)},
+		}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			IptablesEips: []*kubeovnv1.IptablesEIP{eip}, IptablesFips: []*kubeovnv1.IptablesFIPRule{fip},
+		})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.handleUpdateIptablesEip(eip.Name))
+		got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Get(context.Background(), eip.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+	})
+
+	t.Run("different UID does not block finalizer removal", func(t *testing.T) {
+		eip := newEip()
+		fip := &kubeovnv1.IptablesFIPRule{
+			Name: "fip", Labels: map[string]string{util.EipUIDLabel: "other-uid", util.EipV4IpLabel: "same-address"},
+		}
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			IptablesEips: []*kubeovnv1.IptablesEIP{eip}, IptablesFips: []*kubeovnv1.IptablesFIPRule{fip},
+		})
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.handleUpdateIptablesEip(eip.Name))
+		got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Get(context.Background(), eip.Name, metav1.GetOptions{})
+		if err == nil {
+			require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+		} else {
+			require.True(t, k8serrors.IsNotFound(err))
+		}
+	})
+}
+
+func TestGetIptablesEipNatUsesUID(t *testing.T) {
+	eip := &kubeovnv1.IptablesEIP{Name: "eip", UID: "eip-uid"}
+	makeLabels := func(uid string) map[string]string {
+		return map[string]string{util.EipUIDLabel: uid}
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		IptablesEips: []*kubeovnv1.IptablesEIP{eip},
+		IptablesFips: []*kubeovnv1.IptablesFIPRule{
+			{Name: "same", Labels: makeLabels("eip-uid")},
+			{Name: "other", Labels: makeLabels("other-uid")},
+		},
+		IptablesDnatRules: []*kubeovnv1.IptablesDnatRule{
+			{Name: "dnat", Labels: makeLabels("eip-uid")},
+		},
+	})
+	require.NoError(t, err)
+	got, err := fc.fakeController.getIptablesEipNat(eip)
+	require.NoError(t, err)
+	require.Equal(t, util.DnatUsingEip+","+util.FipUsingEip, got)
+}
+
+// TestEipQoSClaimIsWrittenBeforeApply pins the ordering of the claim and the data plane: the
+// generation an eip is switching to must be claimed before its rules can be created, and the
+// generation it is leaving must stay claimed until its rules are gone.
+func TestEipQoSClaimIsWrittenBeforeApply(t *testing.T) {
+	oldEnabled := vpcNatEnabled
+	vpcNatEnabled = "true"
+	t.Cleanup(func() { vpcNatEnabled = oldEnabled })
+
+	// A rule is required so that both applying and deleting reach the pod and fail without one.
+	rules := kubeovnv1.QoSPolicyBandwidthLimitRules{{Direction: kubeovnv1.QoSDirectionIngress}}
+	policy := func(name, uid string) *kubeovnv1.QoSPolicy {
+		return &kubeovnv1.QoSPolicy{
+			Name: name, UID: types.UID(uid),
+			Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeEIP, BandwidthLimitRules: rules,
+			},
+			Status: kubeovnv1.QoSPolicyStatus{
+				BindingType: kubeovnv1.QoSBindingTypeEIP, BandwidthLimitRules: rules,
+			},
+		}
+	}
+	eip := func(appliedQoS string) *kubeovnv1.IptablesEIP {
+		return &kubeovnv1.IptablesEIP{
+			Name: "eip", UID: "eip-uid",
+			Labels: map[string]string{
+				util.QoSLabel:          "old-qos",
+				util.QoSPolicyUIDLabel: "old-qos-uid",
+			},
+			Spec: kubeovnv1.IptablesEIPSpec{
+				V4ip: "2.2.2.2", NatGwDp: "gw", QoSPolicy: "new-qos", ExternalSubnet: "ext-net",
+			},
+			Status: kubeovnv1.IptablesEIPStatus{IP: "2.2.2.2", QoSPolicy: appliedQoS, Ready: true},
+		}
+	}
+	setup := func(t *testing.T, cachedEip *kubeovnv1.IptablesEIP) *Controller {
+		t.Helper()
+		fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+			Subnets: []*kubeovnv1.Subnet{{
+				Name: "ext-net",
+				Spec: kubeovnv1.SubnetSpec{CIDRBlock: "2.2.2.0/24"},
+			}},
+			VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("gw")},
+			QoSPolicies:    []*kubeovnv1.QoSPolicy{policy("new-qos", "new-qos-uid"), policy("old-qos", "old-qos-uid")},
+			IptablesEips:   []*kubeovnv1.IptablesEIP{cachedEip},
+		})
+		require.NoError(t, err)
+		return fc.fakeController
+	}
+	claim := func(t *testing.T, c *Controller) string {
+		t.Helper()
+		got, err := c.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Get(context.Background(), "eip", metav1.GetOptions{})
+		require.NoError(t, err)
+		return got.Labels[util.QoSPolicyUIDLabel]
+	}
+
+	t.Run("new generation is claimed before its rules are applied", func(t *testing.T) {
+		c := setup(t, eip(""))
+		require.Error(t, c.handleUpdateIptablesEip("eip"))
+		require.Equal(t, "new-qos-uid", claim(t, c))
+	})
+
+	t.Run("previous generation keeps its claim while its rules still exist", func(t *testing.T) {
+		c := setup(t, eip("old-qos"))
+		require.Error(t, c.handleUpdateIptablesEip("eip"))
+		require.Equal(t, "old-qos-uid", claim(t, c))
+	})
+}
+
+// TestCreateOrUpdateEipCRPublishesQoSClaim pins the claim of the eip creation flow: the policy
+// generation is recorded in the same update that publishes the spec and status of the eip, so no
+// rule can use the eip before the policy generation it depends on is claimed.
+func TestCreateOrUpdateEipCRPublishesQoSClaim(t *testing.T) {
+	qos := &kubeovnv1.QoSPolicy{Name: "qos", UID: "qos-uid"}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		QoSPolicies: []*kubeovnv1.QoSPolicy{qos},
+		IptablesEips: []*kubeovnv1.IptablesEIP{{
+			Name: "eip", UID: "eip-uid",
+			Spec: kubeovnv1.IptablesEIPSpec{NatGwDp: "gw", ExternalSubnet: "ext-net"},
+		}},
+		Subnets: []*kubeovnv1.Subnet{{
+			Name: "ext-net",
+			Spec: kubeovnv1.SubnetSpec{CIDRBlock: "2.2.2.0/24"},
+		}},
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("gw")},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, fc.fakeController.createOrUpdateEipCR("eip", "2.2.2.2", "", "", "gw", "qos", "ext-net", ""))
+
+	got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesEIPs().Get(
+		context.Background(), "eip", metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "qos-uid", got.Labels[util.QoSPolicyUIDLabel])
+	require.Equal(t, "qos", got.Labels[util.QoSLabel])
+	require.Equal(t, "2.2.2.2", got.Status.IP)
+	require.True(t, got.Status.Ready)
+	require.Equal(t, "qos", got.Status.QoSPolicy)
+}
+
+// TestSyncNatUIDLabelsIsIdempotentAndBestEffort pins the migration contract: objects whose
+// claim is already correct are left untouched, and an object that cannot be migrated is
+// reported without stopping the migration of the others.
+func TestSyncNatUIDLabelsIsIdempotentAndBestEffort(t *testing.T) {
+	qos := &kubeovnv1.QoSPolicy{Name: "qos", UID: "qos-uid"}
+	upToDate := &kubeovnv1.IptablesEIP{
+		Name: "up-to-date", UID: "eip-1",
+		Labels: map[string]string{util.QoSLabel: "qos", util.QoSPolicyUIDLabel: "qos-uid"},
+		Spec:   kubeovnv1.IptablesEIPSpec{QoSPolicy: "qos"},
+	}
+	toBeMigrated := &kubeovnv1.IptablesEIP{
+		Name: "to-migrate", UID: "eip-2",
+		Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: "qos"},
+	}
+	gateway := &kubeovnv1.VpcNatGateway{
+		Name: "gw",
+		Spec: kubeovnv1.VpcNatGatewaySpec{QoSPolicy: "qos"},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		QoSPolicies:    []*kubeovnv1.QoSPolicy{qos},
+		IptablesEips:   []*kubeovnv1.IptablesEIP{upToDate, toBeMigrated},
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{gateway},
+	})
+	require.NoError(t, err)
+
+	client := fc.fakeController.config.KubeOvnClient.(*kubeovnfake.Clientset)
+	client.PrependReactor("update", "vpc-nat-gateways", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("admission webhook rejected the update")
+	})
+
+	err = fc.fakeController.syncNatUIDLabels()
+	require.ErrorContains(t, err, "gw")
+
+	got, err := client.KubeovnV1().IptablesEIPs().Get(context.Background(), "to-migrate", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "qos-uid", got.Labels[util.QoSPolicyUIDLabel])
+
+	// The eip that already carried the claim must not be written again.
+	updates := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "update" && action.GetResource().Resource == "iptables-eips" {
+			updates++
+		}
+	}
+	require.Equal(t, 1, updates)
 }
 
 func TestNatGwDeleted(t *testing.T) {

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -234,6 +234,10 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 		return errors.New("iptables nat gw not enable")
 	}
 
+	if !fip.DeletionTimestamp.IsZero() {
+		return c.handleUpdateIptablesFip(key)
+	}
+
 	c.vpcNatGwKeyMutex.LockKey(key)
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle add iptables fip %s", key)
@@ -254,7 +258,7 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 		return err
 	}
 
-	if err = c.fipTryUseEip(key, eip.Spec.V4ip); err != nil {
+	if err = c.fipTryUseEip(key, eip); err != nil {
 		err = fmt.Errorf("failed to create fip %s, %w", key, err)
 		klog.Error(err)
 		return err
@@ -270,17 +274,19 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 		return err
 	}
 
+	// Claim the eip generation before the rule can reach the data plane, so an eip marked for
+	// deletion already sees this fip as a user of this generation.
+	if err = c.patchFipLabel(key, eip); err != nil {
+		klog.Errorf("failed to update label for fip %s before creating rule, %v", key, err)
+		return err
+	}
+
 	if err = c.createFipInPod(eip.Spec.NatGwDp, eip.Status.IP, fip.Spec.InternalIP); err != nil {
 		klog.Errorf("failed to create fip, %v", err)
 		return err
 	}
 	if err = c.patchFipStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 		klog.Errorf("failed to patch status for fip %s, %v", key, err)
-		return err
-	}
-	// label too long cause error
-	if err = c.patchFipLabel(key, eip); err != nil {
-		klog.Errorf("failed to update label for fip %s, %v", key, err)
 		return err
 	}
 	if err = c.patchEipStatus(fip.Spec.EIP, "", "", "", true); err != nil {
@@ -295,9 +301,9 @@ func (c *Controller) handleAddIptablesFip(key string) error {
 	return nil
 }
 
-func (c *Controller) fipTryUseEip(fipName, eipV4IP string) error {
-	// check if has another fip using this eip already
-	selector := labels.SelectorFromSet(labels.Set{util.EipV4IpLabel: eipV4IP})
+func (c *Controller) fipTryUseEip(fipName string, eip *kubeovnv1.IptablesEIP) error {
+	// check if another FIP already uses this EIP generation
+	selector := labels.SelectorFromSet(labels.Set{util.EipUIDLabel: string(eip.UID)})
 	usingFips, err := c.iptablesFipsLister.List(selector)
 	if err != nil {
 		klog.Errorf("failed to get fips, %v", err)
@@ -305,7 +311,7 @@ func (c *Controller) fipTryUseEip(fipName, eipV4IP string) error {
 	}
 	for _, uf := range usingFips {
 		if uf.Name != fipName {
-			err = fmt.Errorf("%s is used by the other fip %s", eipV4IP, uf.Name)
+			err = fmt.Errorf("%s is used by the other fip %s", eip.Spec.V4ip, uf.Name)
 			klog.Error(err)
 			return err
 		}
@@ -400,7 +406,7 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 		return err
 	}
 
-	if err = c.fipTryUseEip(key, eip.Spec.V4ip); err != nil {
+	if err = c.fipTryUseEip(key, eip); err != nil {
 		err = fmt.Errorf("failed to update fip %s, %w", key, err)
 		klog.Error(err)
 		return err
@@ -454,16 +460,16 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 		if err = c.finalDeleteFipInPod(key, cachedFip); err != nil {
 			return err
 		}
+		if err = c.patchFipLabel(key, eip); err != nil {
+			klog.Errorf("failed to update label for fip %s before creating rule, %v", key, err)
+			return err
+		}
 		if err = c.createFipInPod(eip.Spec.NatGwDp, newV4ip, newInternalIP); err != nil {
 			klog.Errorf("failed to create fip %s, %v", key, err)
 			return err
 		}
 		if err = c.patchFipStatus(key, newV4ip, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 			klog.Errorf("failed to patch status for fip %s, %v", key, err)
-			return err
-		}
-		if err = c.patchFipLabel(key, eip); err != nil {
-			klog.Errorf("failed to update label for fip %s, %v", key, err)
 			return err
 		}
 		if err = c.patchEipStatus(cachedFip.Spec.EIP, "", "", "", true); err != nil {
@@ -539,6 +545,10 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		return errors.New("iptables nat gw not enable")
 	}
 
+	if !dnat.DeletionTimestamp.IsZero() {
+		return c.handleUpdateIptablesDnatRule(key)
+	}
+
 	c.vpcNatGwKeyMutex.LockKey(key)
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle add iptables dnat rule %s", key)
@@ -570,6 +580,13 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		return err
 	}
 
+	// Claim the eip generation before the rule can reach the data plane, so an eip marked for
+	// deletion already sees this dnat as a user of this generation.
+	if err = c.patchDnatLabel(key, eip); err != nil {
+		klog.Errorf("failed to patch label for dnat %s before creating rule, %v", key, err)
+		return err
+	}
+
 	switch dnat.Spec.Type {
 	case kubeovnv1.DnatRuleTypeShare:
 		// Share type: use nft map-based DNAT
@@ -595,11 +612,6 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 	}
 	if err = c.patchDnatStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 		klog.Errorf("failed to patch status for dnat %s, %v", key, err)
-		return err
-	}
-	// label too long cause error
-	if err = c.patchDnatLabel(key, eip); err != nil {
-		klog.Errorf("failed to patch label for dnat %s, %v", key, err)
 		return err
 	}
 	if err = c.patchEipStatus(dnat.Spec.EIP, "", "", "", true); err != nil {
@@ -743,6 +755,10 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		if err = c.finalDeleteDnatInPod(key, cachedDnat); err != nil {
 			return err
 		}
+		if err = c.patchDnatLabel(key, eip); err != nil {
+			klog.Errorf("failed to patch label for dnat %s before creating rule, %v", key, err)
+			return err
+		}
 
 		switch cachedDnat.Spec.Type {
 		case kubeovnv1.DnatRuleTypeShare:
@@ -768,10 +784,6 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		}
 		if err = c.patchDnatStatus(key, newV4ip, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 			klog.Errorf("failed to patch status for dnat %s, %v", key, err)
-			return err
-		}
-		if err = c.patchDnatLabel(key, eip); err != nil {
-			klog.Errorf("failed to patch label for dnat %s, %v", key, err)
 			return err
 		}
 		if err = c.patchEipStatus(cachedDnat.Spec.EIP, "", "", "", true); err != nil {
@@ -869,6 +881,10 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 		return errors.New("iptables nat gw not enable")
 	}
 
+	if !snat.DeletionTimestamp.IsZero() {
+		return c.handleUpdateIptablesSnatRule(key)
+	}
+
 	c.vpcNatGwKeyMutex.LockKey(key)
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 	klog.Infof("handle add iptables snat rule %s", key)
@@ -902,16 +918,18 @@ func (c *Controller) handleAddIptablesSnatRule(key string) error {
 		klog.Errorf("failed to handle add finalizer for snat, %v", err)
 		return err
 	}
+	// Claim the eip generation before the rule can reach the data plane, so an eip marked for
+	// deletion already sees this snat as a user of this generation.
+	if err = c.patchSnatLabel(key, eip); err != nil {
+		klog.Errorf("failed to patch label for snat %s before creating rule, %v", key, err)
+		return err
+	}
 	if err = c.createSnatInPod(eip.Spec.NatGwDp, eip.Status.IP, v4Cidr); err != nil {
 		klog.Errorf("failed to create snat, %v", err)
 		return err
 	}
 	if err = c.patchSnatStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 		klog.Errorf("failed to update status for snat %s, %v", key, err)
-		return err
-	}
-	if err = c.patchSnatLabel(key, eip); err != nil {
-		klog.Errorf("failed to patch label for snat %s, %v", key, err)
 		return err
 	}
 	if err = c.patchEipStatus(snat.Spec.EIP, "", "", "", true); err != nil {
@@ -1048,16 +1066,16 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 		if err = c.finalDeleteSnatInPod(key, cachedSnat); err != nil {
 			return err
 		}
+		if err = c.patchSnatLabel(key, eip); err != nil {
+			klog.Errorf("failed to patch label for snat %s before creating rule, %v", key, err)
+			return err
+		}
 		if err = c.createSnatInPod(eip.Spec.NatGwDp, newV4ip, newV4Cidr); err != nil {
 			klog.Errorf("failed to create snat %s, %v", key, err)
 			return err
 		}
 		if err = c.patchSnatStatus(key, newV4ip, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 			klog.Errorf("failed to patch status for snat %s, %v", key, err)
-			return err
-		}
-		if err = c.patchSnatLabel(key, eip); err != nil {
-			klog.Errorf("failed to patch label for snat %s, %v", key, err)
 			return err
 		}
 		if err = c.patchEipStatus(cachedSnat.Spec.EIP, "", "", "", true); err != nil {
@@ -1250,6 +1268,9 @@ func (c *Controller) handleDelIptablesDnatFinalizer(key string) error {
 	return nil
 }
 
+// patchFipLabel records the gateway and eip references of the fip, including the UID of the eip
+// generation it uses (ovn.kubernetes.io/eip_uid). The claim is written before the rule is created
+// in the pod, and rewritten only after the rule of the previous eip generation is gone.
 func (c *Controller) patchFipLabel(key string, eip *kubeovnv1.IptablesEIP) error {
 	oriFip, err := c.iptablesFipsLister.Get(key)
 	if err != nil {
@@ -1267,13 +1288,16 @@ func (c *Controller) patchFipLabel(key string, eip *kubeovnv1.IptablesEIP) error
 		fip.Labels = map[string]string{
 			util.VpcNatGatewayNameLabel: eip.Spec.NatGwDp,
 			util.EipV4IpLabel:           eip.Spec.V4ip,
+			util.EipUIDLabel:            string(eip.UID),
 		}
 		needUpdateLabel = true
-	} else if fip.Labels[util.SubnetNameLabel] != eip.Spec.NatGwDp ||
-		fip.Labels[util.EipV4IpLabel] != eip.Spec.V4ip {
+	} else if fip.Labels[util.VpcNatGatewayNameLabel] != eip.Spec.NatGwDp ||
+		fip.Labels[util.EipV4IpLabel] != eip.Spec.V4ip ||
+		fip.Labels[util.EipUIDLabel] != string(eip.UID) {
 		op = "replace"
 		fip.Labels[util.VpcNatGatewayNameLabel] = eip.Spec.NatGwDp
 		fip.Labels[util.EipV4IpLabel] = eip.Spec.V4ip
+		fip.Labels[util.EipUIDLabel] = string(eip.UID)
 		needUpdateLabel = true
 	}
 	if needUpdateLabel {
@@ -1455,6 +1479,9 @@ func (c *Controller) redoFip(key, redo string, eipReady bool) error {
 	return err
 }
 
+// patchDnatLabel records the gateway, port and eip references of the dnat, including the UID of
+// the eip generation it uses (ovn.kubernetes.io/eip_uid). The claim is written before the rule is
+// created in the pod, and rewritten only after the rule of the previous eip generation is gone.
 func (c *Controller) patchDnatLabel(key string, eip *kubeovnv1.IptablesEIP) error {
 	oriDnat, err := c.iptablesDnatRulesLister.Get(key)
 	if err != nil {
@@ -1473,15 +1500,18 @@ func (c *Controller) patchDnatLabel(key string, eip *kubeovnv1.IptablesEIP) erro
 			util.VpcNatGatewayNameLabel: eip.Spec.NatGwDp,
 			util.VpcDnatEPortLabel:      dnat.Spec.ExternalPort,
 			util.EipV4IpLabel:           eip.Spec.V4ip,
+			util.EipUIDLabel:            string(eip.UID),
 		}
 		needUpdateLabel = true
 	} else if dnat.Labels[util.VpcNatGatewayNameLabel] != eip.Spec.NatGwDp ||
 		dnat.Labels[util.VpcDnatEPortLabel] != dnat.Spec.ExternalPort ||
-		dnat.Labels[util.EipV4IpLabel] != eip.Spec.V4ip {
+		dnat.Labels[util.EipV4IpLabel] != eip.Spec.V4ip ||
+		dnat.Labels[util.EipUIDLabel] != string(eip.UID) {
 		op = "replace"
 		dnat.Labels[util.VpcNatGatewayNameLabel] = eip.Spec.NatGwDp
 		dnat.Labels[util.VpcDnatEPortLabel] = dnat.Spec.ExternalPort
 		dnat.Labels[util.EipV4IpLabel] = eip.Spec.V4ip
+		dnat.Labels[util.EipUIDLabel] = string(eip.UID)
 		needUpdateLabel = true
 	}
 	if needUpdateLabel {
@@ -1597,6 +1627,9 @@ func (c *Controller) redoDnat(key, redo string, eipReady bool) error {
 	return nil
 }
 
+// patchSnatLabel records the gateway and eip references of the snat, including the UID of the eip
+// generation it uses (ovn.kubernetes.io/eip_uid). The claim is written before the rule is created
+// in the pod, and rewritten only after the rule of the previous eip generation is gone.
 func (c *Controller) patchSnatLabel(key string, eip *kubeovnv1.IptablesEIP) error {
 	oriSnat, err := c.iptablesSnatRulesLister.Get(key)
 	if err != nil {
@@ -1614,13 +1647,16 @@ func (c *Controller) patchSnatLabel(key string, eip *kubeovnv1.IptablesEIP) erro
 		snat.Labels = map[string]string{
 			util.VpcNatGatewayNameLabel: eip.Spec.NatGwDp,
 			util.EipV4IpLabel:           eip.Spec.V4ip,
+			util.EipUIDLabel:            string(eip.UID),
 		}
 		needUpdateLabel = true
-	} else if snat.Labels[util.SubnetNameLabel] != eip.Spec.NatGwDp ||
-		snat.Labels[util.EipV4IpLabel] != eip.Spec.V4ip {
+	} else if snat.Labels[util.VpcNatGatewayNameLabel] != eip.Spec.NatGwDp ||
+		snat.Labels[util.EipV4IpLabel] != eip.Spec.V4ip ||
+		snat.Labels[util.EipUIDLabel] != string(eip.UID) {
 		op = "replace"
 		snat.Labels[util.VpcNatGatewayNameLabel] = eip.Spec.NatGwDp
 		snat.Labels[util.EipV4IpLabel] = eip.Spec.V4ip
+		snat.Labels[util.EipUIDLabel] = string(eip.UID)
 		needUpdateLabel = true
 	}
 	if needUpdateLabel {

--- a/pkg/controller/vpc_nat_gw_nat_test.go
+++ b/pkg/controller/vpc_nat_gw_nat_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -14,6 +15,86 @@ import (
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+// TestNatRuleCreationClaimsEipBeforeRule pins that every NAT rule records the eip generation it
+// depends on before the rule can exist in the gateway pod. An eip marked for deletion finds its
+// users through that label, so a rule that is already in the pod must be able to claim the eip.
+func TestNatRuleCreationClaimsEipBeforeRule(t *testing.T) {
+	oldEnabled := vpcNatEnabled
+	vpcNatEnabled = "true"
+	t.Cleanup(func() { vpcNatEnabled = oldEnabled })
+
+	eip := func() *kubeovnv1.IptablesEIP {
+		return &kubeovnv1.IptablesEIP{
+			Name: "eip", UID: "eip-uid",
+			Spec:   kubeovnv1.IptablesEIPSpec{V4ip: "2.2.2.2", NatGwDp: "gw"},
+			Status: kubeovnv1.IptablesEIPStatus{IP: "2.2.2.2", Ready: true},
+		}
+	}
+	// The gateway exists but has no pod, so creating the rule fails while the claim is written.
+	options := func() *FakeControllerOptions {
+		return &FakeControllerOptions{
+			VpcNatGateways: []*kubeovnv1.VpcNatGateway{fakeGw("gw")},
+			IptablesEips:   []*kubeovnv1.IptablesEIP{eip()},
+		}
+	}
+
+	t.Run("fip", func(t *testing.T) {
+		fip := &kubeovnv1.IptablesFIPRule{
+			Name: "fip",
+			Spec: kubeovnv1.IptablesFIPRuleSpec{EIP: "eip", InternalIP: "10.0.0.5"},
+		}
+		opts := options()
+		opts.IptablesFips = []*kubeovnv1.IptablesFIPRule{fip}
+		fc, err := newFakeControllerWithOptions(t, opts)
+		require.NoError(t, err)
+
+		require.Error(t, fc.fakeController.handleAddIptablesFip("fip"))
+		got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesFIPRules().Get(
+			context.Background(), "fip", metav1.GetOptions{},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "eip-uid", got.Labels[util.EipUIDLabel])
+	})
+
+	t.Run("dnat", func(t *testing.T) {
+		dnat := &kubeovnv1.IptablesDnatRule{
+			Name: "dnat",
+			Spec: kubeovnv1.IptablesDnatRuleSpec{
+				EIP: "eip", Protocol: "tcp", ExternalPort: "80", InternalIP: "10.0.0.5", InternalPort: "8080",
+			},
+		}
+		opts := options()
+		opts.IptablesDnatRules = []*kubeovnv1.IptablesDnatRule{dnat}
+		fc, err := newFakeControllerWithOptions(t, opts)
+		require.NoError(t, err)
+
+		require.Error(t, fc.fakeController.handleAddIptablesDnatRule("dnat"))
+		got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesDnatRules().Get(
+			context.Background(), "dnat", metav1.GetOptions{},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "eip-uid", got.Labels[util.EipUIDLabel])
+	})
+
+	t.Run("snat", func(t *testing.T) {
+		snat := &kubeovnv1.IptablesSnatRule{
+			Name: "snat",
+			Spec: kubeovnv1.IptablesSnatRuleSpec{EIP: "eip", InternalCIDR: "10.0.0.0/24"},
+		}
+		opts := options()
+		opts.IptablesSnatRules = []*kubeovnv1.IptablesSnatRule{snat}
+		fc, err := newFakeControllerWithOptions(t, opts)
+		require.NoError(t, err)
+
+		require.Error(t, fc.fakeController.handleAddIptablesSnatRule("snat"))
+		got, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().IptablesSnatRules().Get(
+			context.Background(), "snat", metav1.GetOptions{},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "eip-uid", got.Labels[util.EipUIDLabel])
+	})
+}
 
 func TestValidateDnat(t *testing.T) {
 	c := &Controller{}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -57,6 +57,7 @@ const (
 	VpcNatAnnotation                        = "ovn.kubernetes.io/vpc_nat"
 	OvnEipTypeLabel                         = "ovn.kubernetes.io/ovn_eip_type"
 	EipV4IpLabel                            = "ovn.kubernetes.io/eip_v4_ip"
+	EipUIDLabel                             = "ovn.kubernetes.io/eip_uid"
 	EipV6IpLabel                            = "ovn.kubernetes.io/eip_v6_ip"
 
 	RouterLBRuleVipsAnnotation = "ovn.kubernetes.io/router_lb_vip"
@@ -143,6 +144,7 @@ const (
 	VpcLbLabel                         = "ovn.kubernetes.io/vpc_lb"
 	VpcDNSNameLabel                    = "ovn.kubernetes.io/vpc-dns"
 	QoSLabel                           = "ovn.kubernetes.io/qos"
+	QoSPolicyUIDLabel                  = "ovn.kubernetes.io/qos_uid"
 	NodeNameLabel                      = "ovn.kubernetes.io/node-name"
 	NetworkPolicyLogAnnotation         = "ovn.kubernetes.io/enable_log"
 	NetworkPolicyEnforcementAnnotation = "ovn.kubernetes.io/network_policy_enforcement"

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -46,9 +46,10 @@ func (v *ValidatingHook) VpcNatGwCreateOrUpdateHook(ctx context.Context, req adm
 	// 1. Changing the namespace would create a new StatefulSet in the new namespace while
 	// leaving the old one orphaned; there is no migration path for the running workload.
 	// 2. HA to non-HA (or vice-versa) is not supported without a deletion.
+	var gwOld *ovnv1.VpcNatGateway
 	if len(req.OldObject.Raw) > 0 {
-		gwOld := ovnv1.VpcNatGateway{}
-		if err := v.decoder.DecodeRaw(req.OldObject, &gwOld); err != nil {
+		gwOld = &ovnv1.VpcNatGateway{}
+		if err := v.decoder.DecodeRaw(req.OldObject, gwOld); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
 		if gwOld.Spec.Namespace != gw.Spec.Namespace {
@@ -75,7 +76,7 @@ func (v *ValidatingHook) VpcNatGwCreateOrUpdateHook(ctx context.Context, req adm
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
 
-		if err := validateVpcNatGatewayLanIPUpdate(&gwOld, &gw); err != nil {
+		if err := validateVpcNatGatewayLanIPUpdate(gwOld, &gw); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
 	}
@@ -90,6 +91,19 @@ func (v *ValidatingHook) VpcNatGwCreateOrUpdateHook(ctx context.Context, req adm
 
 	if err := v.ValidateVpcNatGW(ctx, &gw); err != nil {
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
+	}
+
+	// A policy that is terminating may only be referenced by objects that already reference it:
+	// their controller still has to refresh labels and status, and to clean up the data plane,
+	// while the policy terminates. Only a reference this request introduces is rejected.
+	var oldQoSPolicy string
+	if gwOld != nil {
+		oldQoSPolicy = gwOld.Spec.QoSPolicy
+	}
+	if gwOld == nil || oldQoSPolicy != gw.Spec.QoSPolicy {
+		if err := validateQoSPolicyRef(ctx, v.cache, gw.Spec.QoSPolicy); err != nil {
+			return ctrlwebhook.Errored(http.StatusBadRequest, err)
+		}
 	}
 
 	return ctrlwebhook.Allowed("bypass")
@@ -144,6 +158,11 @@ func (v *ValidatingHook) iptablesEIPCreateHook(ctx context.Context, req admissio
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
+	// A new eip introduces both of its references, so both have to be live.
+	if err := v.validateNewEipReferences(ctx, &eip, nil); err != nil {
+		return ctrlwebhook.Errored(http.StatusBadRequest, err)
+	}
+
 	return ctrlwebhook.Allowed("bypass")
 }
 
@@ -191,6 +210,10 @@ func (v *ValidatingHook) iptablesEIPUpdateHook(ctx context.Context, req admissio
 		if err := v.ValidateIptablesEIP(ctx, &eipNew); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
+
+		if err := v.validateNewEipReferences(ctx, &eipNew, &eipOld); err != nil {
+			return ctrlwebhook.Errored(http.StatusBadRequest, err)
+		}
 	}
 	return ctrlwebhook.Allowed("bypass")
 }
@@ -215,15 +238,12 @@ func (v *ValidatingHook) iptablesEIPDeleteHook(ctx context.Context, req admissio
 		snatList := ovnv1.IptablesSnatRuleList{}
 		dnatList := ovnv1.IptablesDnatRuleList{}
 
-		for natType := range strings.SplitSeq(eip.Status.Nat, ",") {
-			switch natType {
-			case util.FipUsingEip:
-				err = v.cache.List(ctx, &fipList, cli.MatchingLabels{util.EipV4IpLabel: eip.Status.IP})
-			case util.SnatUsingEip:
-				err = v.cache.List(ctx, &snatList, cli.MatchingLabels{util.EipV4IpLabel: eip.Status.IP})
-			case util.DnatUsingEip:
-				err = v.cache.List(ctx, &dnatList, cli.MatchingLabels{util.EipV4IpLabel: eip.Status.IP})
-			}
+		selector := cli.MatchingLabels{util.EipUIDLabel: string(eip.UID)}
+		if err = v.cache.List(ctx, &fipList, selector); err == nil {
+			err = v.cache.List(ctx, &snatList, selector)
+		}
+		if err == nil {
+			err = v.cache.List(ctx, &dnatList, selector)
 		}
 
 		if err != nil {
@@ -233,7 +253,17 @@ func (v *ValidatingHook) iptablesEIPDeleteHook(ctx context.Context, req admissio
 		}
 
 		if len(fipList.Items) != 0 || len(snatList.Items) != 0 || len(dnatList.Items) != 0 {
-			err = fmt.Errorf("eip \"%s\" is still in use, you need to delete the %s of eip first", eip.Name, eip.Status.Nat)
+			var inUse []string
+			if len(fipList.Items) != 0 {
+				inUse = append(inUse, util.FipUsingEip)
+			}
+			if len(snatList.Items) != 0 {
+				inUse = append(inUse, util.SnatUsingEip)
+			}
+			if len(dnatList.Items) != 0 {
+				inUse = append(inUse, util.DnatUsingEip)
+			}
+			err = fmt.Errorf("eip \"%s\" is still in use, you need to delete the %s of eip first", eip.Name, strings.Join(inUse, ","))
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
 	}
@@ -256,6 +286,9 @@ func (v *ValidatingHook) iptablesDnatCreateHook(ctx context.Context, req admissi
 	}
 
 	if err := v.ValidateIptablesDnat(ctx, &dnat); err != nil {
+		return ctrlwebhook.Errored(http.StatusBadRequest, err)
+	}
+	if err := v.validateNewRuleEipReferences(ctx, dnat.Spec.EIP, true); err != nil {
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
@@ -303,6 +336,9 @@ func (v *ValidatingHook) iptablesDnatUpdateHook(ctx context.Context, req admissi
 		if err := v.ValidateIptablesDnat(ctx, &dnatNew); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
+		if err := v.validateNewRuleEipReferences(ctx, dnatNew.Spec.EIP, dnatOld.Spec.EIP != dnatNew.Spec.EIP); err != nil {
+			return ctrlwebhook.Errored(http.StatusBadRequest, err)
+		}
 	}
 
 	return ctrlwebhook.Allowed("bypass")
@@ -323,6 +359,9 @@ func (v *ValidatingHook) iptablesSnatCreateHook(ctx context.Context, req admissi
 	}
 
 	if err := v.ValidateIptablesSnat(ctx, &snat); err != nil {
+		return ctrlwebhook.Errored(http.StatusBadRequest, err)
+	}
+	if err := v.validateNewRuleEipReferences(ctx, snat.Spec.EIP, true); err != nil {
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
@@ -350,6 +389,9 @@ func (v *ValidatingHook) iptablesSnatUpdateHook(ctx context.Context, req admissi
 		if err := v.ValidateIptablesSnat(ctx, &snatNew); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
+		if err := v.validateNewRuleEipReferences(ctx, snatNew.Spec.EIP, snatOld.Spec.EIP != snatNew.Spec.EIP); err != nil {
+			return ctrlwebhook.Errored(http.StatusBadRequest, err)
+		}
 	}
 
 	return ctrlwebhook.Allowed("bypass")
@@ -370,6 +412,9 @@ func (v *ValidatingHook) iptablesFipCreateHook(ctx context.Context, req admissio
 	}
 
 	if err := v.ValidateIptablesFip(ctx, &fip); err != nil {
+		return ctrlwebhook.Errored(http.StatusBadRequest, err)
+	}
+	if err := v.validateNewRuleEipReferences(ctx, fip.Spec.EIP, true); err != nil {
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
@@ -395,6 +440,9 @@ func (v *ValidatingHook) iptablesFipUpdateHook(ctx context.Context, req admissio
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
 		if err := v.ValidateIptablesFip(ctx, &fipNew); err != nil {
+			return ctrlwebhook.Errored(http.StatusBadRequest, err)
+		}
+		if err := v.validateNewRuleEipReferences(ctx, fipNew.Spec.EIP, fipOld.Spec.EIP != fipNew.Spec.EIP); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
 	}
@@ -468,14 +516,6 @@ func (v *ValidatingHook) ValidateVpcNatGW(ctx context.Context, gw *ovnv1.VpcNatG
 		}
 	}
 
-	if gw.Spec.QoSPolicy != "" {
-		qos := &ovnv1.QoSPolicy{}
-		key = cli.ObjectKey{Name: gw.Spec.QoSPolicy}
-		if err := v.cache.Get(ctx, key, qos); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -509,6 +549,80 @@ func (v *ValidatingHook) ValidateVpcNatGatewayConfig(ctx context.Context) error 
 	}
 
 	return nil
+}
+
+func validateEipRef(ctx context.Context, reader cli.Reader, name string) error {
+	eip := &ovnv1.IptablesEIP{}
+	if err := reader.Get(ctx, cli.ObjectKey{Name: name}, eip); err != nil {
+		return err
+	}
+	if !eip.DeletionTimestamp.IsZero() {
+		return fmt.Errorf("eip %s is terminating", name)
+	}
+	return nil
+}
+
+func validateNatGwRef(ctx context.Context, reader cli.Reader, name string) error {
+	gw := &ovnv1.VpcNatGateway{}
+	if err := reader.Get(ctx, cli.ObjectKey{Name: name}, gw); err != nil {
+		return err
+	}
+	if !gw.DeletionTimestamp.IsZero() {
+		return fmt.Errorf("vpc nat gateway %s is terminating", name)
+	}
+	return nil
+}
+
+func validateQoSPolicyRef(ctx context.Context, reader cli.Reader, name string) error {
+	if name == "" {
+		return nil
+	}
+	qos := &ovnv1.QoSPolicy{}
+	if err := reader.Get(ctx, cli.ObjectKey{Name: name}, qos); err != nil {
+		return err
+	}
+	if !qos.DeletionTimestamp.IsZero() {
+		return fmt.Errorf("qos policy %s is terminating", name)
+	}
+	return nil
+}
+
+// validateNewEipReferences validates the references a create or update introduces. Both
+// references belong to the spec of the eip, and a reference the object already carried is not
+// re-validated: its controller still has to refresh labels and status, and to clean up the data
+// plane, while the referenced object terminates. oldEip is nil when the eip is created.
+func (v *ValidatingHook) validateNewEipReferences(ctx context.Context, eip, oldEip *ovnv1.IptablesEIP) error {
+	if oldEip == nil || oldEip.Spec.NatGwDp != eip.Spec.NatGwDp {
+		if err := validateNatGwRef(ctx, v.cache, eip.Spec.NatGwDp); err != nil {
+			return err
+		}
+	}
+	if oldEip == nil || oldEip.Spec.QoSPolicy != eip.Spec.QoSPolicy {
+		if err := validateQoSPolicyRef(ctx, v.cache, eip.Spec.QoSPolicy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateNewRuleEipReferences is the DNAT/SNAT/FIP counterpart of validateNewEipReferences.
+// Those rules point at an eip by name and inherit its gateway, so both the eip and its gateway
+// are references of the rule. eipChanged is false when the rule keeps pointing at its eip.
+func (v *ValidatingHook) validateNewRuleEipReferences(ctx context.Context, eipName string, eipChanged bool) error {
+	if !eipChanged {
+		return nil
+	}
+	if err := validateEipRef(ctx, v.cache, eipName); err != nil {
+		return err
+	}
+	eip := &ovnv1.IptablesEIP{}
+	if err := v.cache.Get(ctx, cli.ObjectKey{Name: eipName}, eip); err != nil {
+		return err
+	}
+	if eip.Spec.NatGwDp == "" {
+		return nil
+	}
+	return validateNatGwRef(ctx, v.cache, eip.Spec.NatGwDp)
 }
 
 func (v *ValidatingHook) ValidateIptablesEIP(ctx context.Context, eip *ovnv1.IptablesEIP) error {
@@ -565,7 +679,6 @@ func (v *ValidatingHook) ValidateIptablesDnat(ctx context.Context, dnat *ovnv1.I
 	if err := v.cache.Get(ctx, key, eip); err != nil {
 		return err
 	}
-
 	if dnat.Spec.ExternalPort == "" {
 		return errors.New("parameter \"externalPort\" cannot be empty")
 	}
@@ -660,7 +773,7 @@ func (v *ValidatingHook) ValidateIptablesDnat(ctx context.Context, dnat *ovnv1.I
 	// which shadows any port-specific DNAT rules (SHARED_DNAT) for the same EIP.
 	if eip.Status.IP != "" {
 		fipList := &ovnv1.IptablesFIPRuleList{}
-		if err := v.cache.List(ctx, fipList, cli.MatchingLabels{util.EipV4IpLabel: eip.Status.IP}); err != nil {
+		if err := v.cache.List(ctx, fipList, cli.MatchingLabels{util.EipUIDLabel: string(eip.UID)}); err != nil {
 			return fmt.Errorf("failed to list iptables FIP rules: %w", err)
 		}
 		if len(fipList.Items) != 0 {
@@ -742,7 +855,6 @@ func (v *ValidatingHook) ValidateIptablesSnat(ctx context.Context, snat *ovnv1.I
 	if err := v.cache.Get(ctx, key, eip); err != nil {
 		return err
 	}
-
 	if err := util.CheckCidrs(snat.Spec.InternalCIDR); err != nil {
 		return fmt.Errorf("invalid cidr %s", snat.Spec.InternalCIDR)
 	}
@@ -760,7 +872,6 @@ func (v *ValidatingHook) ValidateIptablesFip(ctx context.Context, fip *ovnv1.Ipt
 	if err := v.cache.Get(ctx, key, eip); err != nil {
 		return err
 	}
-
 	if net.ParseIP(fip.Spec.InternalIP) == nil {
 		err := fmt.Errorf("internalIP %s is not a valid", fip.Spec.InternalIP)
 		return err
@@ -770,7 +881,7 @@ func (v *ValidatingHook) ValidateIptablesFip(ctx context.Context, fip *ovnv1.Ipt
 	// which shadows any port-specific DNAT rules (SHARED_DNAT) for the same EIP.
 	if eip.Status.IP != "" {
 		dnatList := &ovnv1.IptablesDnatRuleList{}
-		if err := v.cache.List(ctx, dnatList, cli.MatchingLabels{util.EipV4IpLabel: eip.Status.IP}); err != nil {
+		if err := v.cache.List(ctx, dnatList, cli.MatchingLabels{util.EipUIDLabel: string(eip.UID)}); err != nil {
 			return fmt.Errorf("failed to list iptables DNAT rules: %w", err)
 		}
 		if len(dnatList.Items) != 0 {

--- a/pkg/webhook/vpc_nat_gateway_ref_test.go
+++ b/pkg/webhook/vpc_nat_gateway_ref_test.go
@@ -1,0 +1,188 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	ovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+// natReferenceCache holds the objects the NAT gateway and EIP hooks validate against: the two
+// config maps, a vpc and a subnet, one healthy and one terminating gateway, and one healthy and
+// one terminating qos policy.
+func natReferenceCache() *mockCache {
+	now := metav1.Now()
+	objects := map[string]runtime.Object{
+		"kube-system/ovn-vpc-nat-config": &corev1.ConfigMap{
+			Name: util.VpcNatConfig, Namespace: metav1.NamespaceSystem,
+			Data: map[string]string{"image": "test-image"},
+		},
+		"kube-system/ovn-vpc-nat-gw-config": &corev1.ConfigMap{
+			Name: util.VpcNatGatewayConfig, Namespace: metav1.NamespaceSystem,
+			Data: map[string]string{"enable-vpc-nat-gw": "true"},
+		},
+		"/test-vpc": &ovnv1.Vpc{Name: "test-vpc"},
+		"/test-subnet": &ovnv1.Subnet{
+			Name: "test-subnet",
+			Spec: ovnv1.SubnetSpec{CIDRBlock: "10.0.0.0/24"},
+		},
+		"/healthy-gw": &ovnv1.VpcNatGateway{
+			Name: "healthy-gw",
+			Spec: ovnv1.VpcNatGatewaySpec{Vpc: "test-vpc", Subnet: "test-subnet"},
+		},
+		"/terminating-gw": &ovnv1.VpcNatGateway{
+			Name: "terminating-gw", DeletionTimestamp: &now,
+			Spec: ovnv1.VpcNatGatewaySpec{Vpc: "test-vpc", Subnet: "test-subnet"},
+		},
+		"/healthy-qos": &ovnv1.QoSPolicy{Name: "healthy-qos"},
+		"/terminating-qos": &ovnv1.QoSPolicy{
+			Name: "terminating-qos", DeletionTimestamp: &now,
+		},
+	}
+	return &mockCache{objects: objects}
+}
+
+func newNatReferenceHook(t *testing.T) *ValidatingHook {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, ovnv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return &ValidatingHook{decoder: admission.NewDecoder(scheme), cache: natReferenceCache()}
+}
+
+func updateRequest(t *testing.T, oldObj, newObj any) admission.Request {
+	t.Helper()
+	oldRaw, err := json.Marshal(oldObj)
+	require.NoError(t, err)
+	newRaw, err := json.Marshal(newObj)
+	require.NoError(t, err)
+	return admission.Request{
+		Operation: admissionv1.Update,
+		Object:    runtime.RawExtension{Raw: newRaw},
+		OldObject: runtime.RawExtension{Raw: oldRaw},
+	}
+}
+
+func createRequest(t *testing.T, obj any) admission.Request {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return admission.Request{Operation: admissionv1.Create, Object: runtime.RawExtension{Raw: raw}}
+}
+
+// TestNatGwQoSReferenceValidatedOnlyWhenIntroduced pins the reference contract of the NAT
+// gateway hook: a terminating policy must not be referenced by a *new* binding, while a gateway
+// that already references it keeps being updatable, so that its controller can still refresh
+// labels and status and clean up the data plane while the policy terminates.
+func TestNatGwQoSReferenceValidatedOnlyWhenIntroduced(t *testing.T) {
+	hook := newNatReferenceHook(t)
+	gateway := func(qos string, tolerations []corev1.Toleration) *ovnv1.VpcNatGateway {
+		return &ovnv1.VpcNatGateway{
+			Name: "test-gw",
+			Spec: ovnv1.VpcNatGatewaySpec{
+				Vpc: "test-vpc", Subnet: "test-subnet", Replicas: 1,
+				QoSPolicy: qos, Tolerations: tolerations,
+			},
+		}
+	}
+
+	t.Run("create with a terminating policy is rejected", func(t *testing.T) {
+		resp := hook.VpcNatGwCreateOrUpdateHook(context.Background(), createRequest(t, gateway("terminating-qos", nil)))
+		require.False(t, resp.Allowed)
+		require.Contains(t, resp.Result.Message, "is terminating")
+	})
+
+	t.Run("create with a healthy policy is allowed", func(t *testing.T) {
+		resp := hook.VpcNatGwCreateOrUpdateHook(context.Background(), createRequest(t, gateway("healthy-qos", nil)))
+		require.True(t, resp.Allowed, "expected allowed, got: %+v", resp.Result)
+	})
+
+	t.Run("label only update keeps working while the policy terminates", func(t *testing.T) {
+		oldGw := gateway("terminating-qos", nil)
+		newGw := gateway("terminating-qos", nil)
+		newGw.Labels = map[string]string{util.QoSPolicyUIDLabel: "terminating-qos-uid"}
+		resp := hook.VpcNatGwCreateOrUpdateHook(context.Background(), updateRequest(t, oldGw, newGw))
+		require.True(t, resp.Allowed, "expected allowed, got: %+v", resp.Result)
+	})
+
+	t.Run("unrelated spec change keeps working while the policy terminates", func(t *testing.T) {
+		oldGw := gateway("terminating-qos", nil)
+		newGw := gateway("terminating-qos", []corev1.Toleration{{
+			Key: "dedicated", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule,
+		}})
+		resp := hook.VpcNatGwCreateOrUpdateHook(context.Background(), updateRequest(t, oldGw, newGw))
+		require.True(t, resp.Allowed, "expected allowed, got: %+v", resp.Result)
+	})
+
+	t.Run("switching to a terminating policy is rejected", func(t *testing.T) {
+		resp := hook.VpcNatGwCreateOrUpdateHook(context.Background(),
+			updateRequest(t, gateway("healthy-qos", nil), gateway("terminating-qos", nil)))
+		require.False(t, resp.Allowed)
+		require.Contains(t, resp.Result.Message, "is terminating")
+	})
+
+	t.Run("clearing the reference is allowed", func(t *testing.T) {
+		resp := hook.VpcNatGwCreateOrUpdateHook(context.Background(),
+			updateRequest(t, gateway("terminating-qos", nil), gateway("", nil)))
+		require.True(t, resp.Allowed, "expected allowed, got: %+v", resp.Result)
+	})
+}
+
+// TestIptablesEipReferenceValidatedOnlyWhenIntroduced is the eip counterpart: its gateway and
+// policy references are validated when the request introduces them, not when the eip's specs
+// change for another reason.
+func TestIptablesEipReferenceValidatedOnlyWhenIntroduced(t *testing.T) {
+	hook := newNatReferenceHook(t)
+	eip := func(natGwDp, qos string) *ovnv1.IptablesEIP {
+		return &ovnv1.IptablesEIP{
+			Name: "test-eip",
+			Spec: ovnv1.IptablesEIPSpec{
+				NatGwDp: natGwDp, QoSPolicy: qos, ExternalSubnet: "test-subnet", V4ip: "10.0.0.5",
+			},
+		}
+	}
+
+	t.Run("create with a terminating gateway is rejected", func(t *testing.T) {
+		resp := hook.iptablesEIPCreateHook(context.Background(), createRequest(t, eip("terminating-gw", "")))
+		require.False(t, resp.Allowed)
+		require.Contains(t, resp.Result.Message, "is terminating")
+	})
+
+	t.Run("create with a terminating policy is rejected", func(t *testing.T) {
+		resp := hook.iptablesEIPCreateHook(context.Background(), createRequest(t, eip("healthy-gw", "terminating-qos")))
+		require.False(t, resp.Allowed)
+		require.Contains(t, resp.Result.Message, "is terminating")
+	})
+
+	t.Run("unrelated spec change keeps working while the gateway terminates", func(t *testing.T) {
+		oldEip := eip("terminating-gw", "")
+		newEip := eip("terminating-gw", "")
+		newEip.Spec.MacAddress = "00:00:00:00:00:01"
+		resp := hook.iptablesEIPUpdateHook(context.Background(), updateRequest(t, oldEip, newEip))
+		require.True(t, resp.Allowed, "expected allowed, got: %+v", resp.Result)
+	})
+
+	t.Run("unrelated spec change keeps working while the policy terminates", func(t *testing.T) {
+		oldEip := eip("healthy-gw", "terminating-qos")
+		newEip := eip("healthy-gw", "terminating-qos")
+		newEip.Spec.MacAddress = "00:00:00:00:00:01"
+		resp := hook.iptablesEIPUpdateHook(context.Background(), updateRequest(t, oldEip, newEip))
+		require.True(t, resp.Allowed, "expected allowed, got: %+v", resp.Result)
+	})
+
+	t.Run("switching to a terminating policy is rejected", func(t *testing.T) {
+		resp := hook.iptablesEIPUpdateHook(context.Background(),
+			updateRequest(t, eip("healthy-gw", ""), eip("healthy-gw", "terminating-qos")))
+		require.False(t, resp.Allowed)
+		require.Contains(t, resp.Result.Message, "is terminating")
+	})
+}

--- a/pkg/webhook/vpc_nat_gateway_test.go
+++ b/pkg/webhook/vpc_nat_gateway_test.go
@@ -44,6 +44,8 @@ func (m *mockCache) Get(_ context.Context, key client.ObjectKey, obj client.Obje
 		*t = *o.(*ovnv1.QoSPolicy)
 	case *ovnv1.IptablesEIP:
 		*t = *o.(*ovnv1.IptablesEIP)
+	case *ovnv1.VpcNatGateway:
+		*t = *o.(*ovnv1.VpcNatGateway)
 	default:
 		return fmt.Errorf("unsupported type in mock cache: %T", obj)
 	}

--- a/test/e2e/iptables-eip-qos/e2e_test.go
+++ b/test/e2e/iptables-eip-qos/e2e_test.go
@@ -1064,6 +1064,13 @@ func eipQoSCases(f *framework.Framework,
 // its KubeOVN controller finalizer, runs bind to attach it to a resource, then deletes it while
 // still bound and asserts it stays in Terminating. It returns the policy name so the caller can
 // exercise the release trigger (deleting or unbinding the referencing resource).
+//
+// A policy is protected by the resources that claim its generation, which the referencing
+// controller records in the `ovn.kubernetes.io/qos_uid` label of the referencing resource after
+// the reference is applied. bind must therefore wait for that claim before the policy is
+// deleted, otherwise the policy is deleted before any resource claims it. The resource is then
+// left referencing a policy that no longer exists, which is a different scenario than the one
+// these cases cover.
 func createQoSMarkedForDeletionWhileBound(
 	f *framework.Framework,
 	shared bool,
@@ -1133,6 +1140,7 @@ func setupEIPBoundQoSMarkedForDeletion(f *framework.Framework, vpcQosParams *qos
 	qosName = createQoSMarkedForDeletionWhileBound(f, false, apiv1.QoSBindingTypeEIP, getEIPQoSRule(eipLimit), func(qos string) {
 		ginkgo.By("Binding eip " + eipName + " to qos policy " + qos)
 		_ = eipClient.PatchQoSPolicySync(eipName, qos)
+		waitForQoSClaim(f, eipName, func() map[string]string { return eipClient.Get(eipName).Labels }, qos)
 	})
 	return eipName, qosName
 }
@@ -1147,7 +1155,21 @@ func setupNatGwBoundQoSMarkedForDeletion(f *framework.Framework, natgwName strin
 	return createQoSMarkedForDeletionWhileBound(f, true, apiv1.QoSBindingTypeNatGw, getNicDefaultQoSPolicy(defaultNicLimit), func(qos string) {
 		ginkgo.By("Binding natgw " + natgwName + " to qos policy " + qos)
 		_ = natgwClient.PatchQoSPolicySync(natgwName, qos)
+		waitForQoSClaim(f, natgwName, func() map[string]string { return natgwClient.Get(natgwName).Labels }, qos)
 	})
+}
+
+// waitForQoSClaim waits until the resource carries the claim of the given policy generation, so
+// that the policy is protected before a test marks it for deletion.
+func waitForQoSClaim(f *framework.Framework, resource string, labels func() map[string]string, qosName string) {
+	ginkgo.GinkgoHelper()
+
+	policy, err := f.QoSPolicyClient().QoSPolicyInterface.Get(context.TODO(), qosName, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(labels()).To(gomega.HaveKeyWithValue(util.QoSPolicyUIDLabel, string(policy.UID)))
+	}, 2*time.Minute, 2*time.Second).Should(gomega.Succeed(),
+		"resource %s must claim qos policy generation %s before the policy is deleted", resource, policy.UID)
 }
 
 // parseBandwidthFromIperfOutput extracts bandwidth values from iperf CSV output


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

## 目标（中文）

VPC NAT 网关的资源引用原先按**名字 / 地址**匹配（`spec.qosPolicy`、`spec.eip`、`status.nat`、EIP 的 IP 标签等）。同名对象被删除后重建时无法区分代际：新代的引用会被误判为在引用旧代，旧代残留也可能被同名的新引用一直挡住。

本 PR 把引用改为按**被引用对象的 UID** 判定：

- 引用方记录它所使用的那一代对象 UID：EIP / VpcNatGateway 上的 `ovn.kubernetes.io/qos_uid`（QoS 策略），FIP / DNAT / SNAT 上的 `ovn.kubernetes.io/eip_uid`（EIP）；
- 被引用方（QoS 策略 / EIP）删除时只判定"是否仍有对象 claim 我这一代的 UID"，没有即可摘除 finalizer；
- 顺序不变量：**先写 claim 再让规则进入数据面**；**只在旧代规则清理完成之后才改写 claim**（claim 消失 ⇒ 该代数据面已清理）；
- 启动迁移 `syncNatUIDLabels` 把历史对象（只带名字/地址引用）回填成 UID claim，幂等且 best effort：单个对象写入失败只上报，不重启控制器；
- webhook 的引用存活校验（被引用对象处于 terminating）只作用于**本次请求新增的引用**（create，或引用字段发生变化）；已存在的引用不会阻塞引用方刷新 label/status 与清理数据面。

### 顺序不变量覆盖的路径

add / update / redo / pod (re)init 四条 apply 路径都在规则进入数据面前写 claim；NAT 规则（FIP / DNAT / SNAT）创建同样先写 `eip_uid` 再落规则。

### 行为变化与兼容性

- `qos_uid` / `eip_uid` 为纯新增 label，CRD / API 与 `install.sh` 未变，升级路径兼容。
- 语义变化 1：策略被删除后，如果引用方尚未 claim 该代 UID（"绑定后立刻删策略"的窗口），策略会被释放，引用方随后会因策略不存在而显式报错（不会留下数据面残留）。`test/e2e/iptables-eip-qos` 的生命周期用例已按该契约改为"等到 claim 之后再删策略"。
- 语义变化 2：已存在的引用在对方 terminating 时仍可更新（新增引用仍会被拒绝）。
- 未纳入本 PR（仅记录）：`handleAdd*` 的 terminating 早退、EIP 删除与外部 Subnet 解耦、`patchFip/SnatLabel` 键名修正等生命周期/校验强化，以及迁移失败对象在稳态的自愈。

### 测试

- UT：UID 删除门禁（EIP / QoS）、EIP claim-before-apply（新旧两个方向）、创建流程中 claim 与 spec/status 同一次写入、NatGw claim 的六种分支、网关 pod (re)init 先 claim 后恢复规则、NAT 规则创建先写 `eip_uid`、迁移幂等与单点失败不中断、webhook 只拦新增引用。
- 本机 kind e2e（控制器镜像由本分支构建）：
  - `make iptables-eip-conformance-e2e`：18 Passed / 0 Failed
  - `make iptables-eip-qos-conformance-e2e`：6 Passed / 0 Failed（含三个 QoS 生命周期用例）
- `make lint`：0 issues（含 verify-crd）。

## Goal (English)

The NAT gateway resources used to identify their references by **name / address** (`spec.qosPolicy`, `spec.eip`, `status.nat`, the EIP IP label, ...). Once an object was deleted and recreated under the same name, the two generations could not be told apart: a reference of the new generation was mistaken for a reference of the old one, and a leftover reference of an earlier generation could block the current one forever.

This PR identifies references by the **UID of the referenced object**:

- A referencing object records the generation it uses: `ovn.kubernetes.io/qos_uid` on EIP / VpcNatGateway (QoS policy), and `ovn.kubernetes.io/eip_uid` on FIP / DNAT / SNAT (EIP).
- A referenced object (QoS policy / EIP) is released as soon as no object claims its UID generation.
- Ordering invariants: the claim is written **before** the rules of its generation can reach the data plane, and it is rewritten **only after** the rules of the previous generation are gone (claim dropped means that generation's data plane is clean).
- The startup migration `syncNatUIDLabels` backfills the labels of objects that only carry name/address references. It is idempotent and best effort: an object that cannot be updated is reported instead of restarting the controller.
- The webhook only rejects references a request **introduces** (create, or a changed reference field) to a terminating NatGw / QoS policy; an existing reference never blocks the referrer from refreshing its labels/status or from cleaning up its data plane.

### Behaviour changes and compatibility

- `qos_uid` / `eip_uid` are new labels; CRD/API and `install.sh` are unchanged, so the upgrade path is compatible.
- Behaviour 1: if a policy is deleted before its referrer claimed that generation (the "bind then immediately delete" window), the policy is released and the referrer later fails explicitly because the policy is gone (no data plane residue). The `test/e2e/iptables-eip-qos` lifecycle cases were adapted to wait for the claim before deleting the policy.
- Behaviour 2: an existing reference stays updatable while the referenced object terminates (new references are still rejected).
- Out of scope here (recorded only): the terminating shortcuts in `handleAdd*`, decoupling EIP deletion from the external Subnet, the `patchFip/SnatLabel` key fix and other lifecycle/validation hardening, plus steady state self healing of a claim whose migration failed.

### Tests

- Unit tests: UID based delete gates (EIP / QoS), claim-before-apply on the eip in both directions, the claim published together with the eip spec/status in the creation flow, all NatGw label branches, claim before restoring the rules on gateway pod (re)init, NAT rules claiming the eip before the rule is created, migration idempotency and per object failure reporting, and the webhook rejecting only introduced references.
- Local kind e2e (controller image built from this branch):
  - `make iptables-eip-conformance-e2e`: 18 passed / 0 failed
  - `make iptables-eip-qos-conformance-e2e`: 6 passed / 0 failed (including the three QoS lifecycle cases)
- `make lint`: 0 issues (includes verify-crd).

## Which issue(s) this PR fixes

No linked issue / 无关联 issue。
