### PR TITLE
fix: use per-family match for dual-stack EIP/SNAT policies

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -113,6 +113,7 @@ type FakeControllerOptions struct {
 	IptablesEips          []*kubeovnv1.IptablesEIP
 	StatefulSets          []*appsv1.StatefulSet
 	Deployments           []*appsv1.Deployment
+	ConfigMaps            []*corev1.ConfigMap
 }
 
 // newFakeControllerWithOptions creates a fake controller with optional pre-populated objects
@@ -134,7 +135,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 
 	// Create fake Kubernetes client with namespaces, pods, nodes, services, and workloads.
 	kubeObjects := make([]runtime.Object, 0, len(namespaces)+len(opts.Pods)+len(opts.Nodes)+len(opts.Services)+
-		len(opts.StatefulSets)+len(opts.Deployments))
+		len(opts.StatefulSets)+len(opts.Deployments)+len(opts.ConfigMaps))
 	for _, ns := range namespaces {
 		kubeObjects = append(kubeObjects, ns)
 	}
@@ -152,6 +153,9 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	}
 	for _, deploy := range opts.Deployments {
 		kubeObjects = append(kubeObjects, deploy)
+	}
+	for _, cm := range opts.ConfigMaps {
+		kubeObjects = append(kubeObjects, cm)
 	}
 	kubeClient := fake.NewSimpleClientset(kubeObjects...)
 
@@ -293,6 +297,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
 	nodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	podInformer := kubeInformerFactory.Core().V1().Pods()
+	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	endpointSliceInformer := kubeInformerFactory.Discovery().V1().EndpointSlices()
 	statefulSetInformer := kubeInformerFactory.Apps().V1().StatefulSets()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
@@ -379,6 +384,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		iptablesEipsLister:            iptablesEipInformer.Lister(),
 		statefulSetsLister:            statefulSetInformer.Lister(),
 		deploymentsLister:             deploymentInformer.Lister(),
+		configMapsLister:              configMapInformer.Lister(),
 		vpcNatGwKeyMutex:              keymutex.NewHashed(0),
 		OVNNbClient:                   mockOvnClient,
 		OVNSbClient:                   mockOvnSbClient,

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -893,6 +893,17 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	return pod, nil
 }
 
+func policyRouteSrcMatches(podIP, nextHop string) []string {
+	var matches []string
+	for podAddr := range strings.SplitSeq(podIP, ",") {
+		if util.CheckProtocol(podAddr) != util.CheckProtocol(nextHop) {
+			continue
+		}
+		matches = append(matches, fmt.Sprintf("%s.src == %s", getIPSuffix(util.CheckProtocol(podAddr)), podAddr))
+	}
+	return matches
+}
+
 // do the same thing as update pod
 func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kubeovnNet) error {
 	// the lb-svc pod has dependencies on Running state, check it when pod state get updated
@@ -1015,21 +1026,32 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 					nextHop = strings.Split(nextHop, "/")[0]
 				}
 
-				if err := c.addPolicyRouteToVpc(
-					subnet.Spec.Vpc,
-					&kubeovnv1.PolicyRoute{
-						Priority:  util.NorthGatewayRoutePolicyPriority,
-						Match:     "ip4.src == " + podIP,
-						Action:    kubeovnv1.PolicyRouteActionReroute,
-						NextHopIP: nextHop,
-					},
-					map[string]string{
-						"vendor": util.CniTypeName,
-						"subnet": subnet.Name,
-					},
-				); err != nil {
-					klog.Errorf("failed to add policy route, %v", err)
-					return err
+				legacyMatch := "ip4.src == " + podIP
+				matches := policyRouteSrcMatches(podIP, nextHop)
+				if !slices.Contains(matches, legacyMatch) {
+					if err := c.deletePolicyRouteFromVpc(subnet.Spec.Vpc, util.NorthGatewayRoutePolicyPriority, legacyMatch); err != nil {
+						klog.Errorf("failed to delete stale policy route, %v", err)
+						return err
+					}
+				}
+
+				for _, match := range matches {
+					if err := c.addPolicyRouteToVpc(
+						subnet.Spec.Vpc,
+						&kubeovnv1.PolicyRoute{
+							Priority:  util.NorthGatewayRoutePolicyPriority,
+							Match:     match,
+							Action:    kubeovnv1.PolicyRouteActionReroute,
+							NextHopIP: nextHop,
+						},
+						map[string]string{
+							"vendor": util.CniTypeName,
+							"subnet": subnet.Name,
+						},
+					); err != nil {
+						klog.Errorf("failed to add policy route, %v", err)
+						return err
+					}
 				}
 
 				// remove lsp from port group to make EIP/SNAT work

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -893,13 +893,31 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	return pod, nil
 }
 
-func policyRouteSrcMatches(podIP, nextHop string) []string {
-	var matches []string
+type policyRouteMatch struct {
+	match     string
+	nextHopIP string
+}
+
+func policyRouteSrcMatches(podIP, nextHop string) []policyRouteMatch {
+	var matches []policyRouteMatch
+	nextHopV4, nextHopV6 := util.SplitStringIP(nextHop)
+	nextHopV4, _, _ = strings.Cut(nextHopV4, "/")
+	nextHopV6, _, _ = strings.Cut(nextHopV6, "/")
 	for podAddr := range strings.SplitSeq(podIP, ",") {
-		if util.CheckProtocol(podAddr) != util.CheckProtocol(nextHop) {
+		var hop string
+		switch util.CheckProtocol(podAddr) {
+		case kubeovnv1.ProtocolIPv4:
+			hop = nextHopV4
+		case kubeovnv1.ProtocolIPv6:
+			hop = nextHopV6
+		}
+		if hop == "" {
 			continue
 		}
-		matches = append(matches, fmt.Sprintf("%s.src == %s", getIPSuffix(util.CheckProtocol(podAddr)), podAddr))
+		matches = append(matches, policyRouteMatch{
+			match:     fmt.Sprintf("%s.src == %s", getIPSuffix(util.CheckProtocol(podAddr)), podAddr),
+			nextHopIP: hop,
+		})
 	}
 	return matches
 }
@@ -1022,13 +1040,9 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 						return errors.New("no available gateway address")
 					}
 				}
-				if strings.Contains(nextHop, "/") {
-					nextHop = strings.Split(nextHop, "/")[0]
-				}
-
 				legacyMatch := "ip4.src == " + podIP
 				matches := policyRouteSrcMatches(podIP, nextHop)
-				if !slices.Contains(matches, legacyMatch) {
+				if !slices.ContainsFunc(matches, func(m policyRouteMatch) bool { return m.match == legacyMatch }) {
 					if err := c.deletePolicyRouteFromVpc(subnet.Spec.Vpc, util.NorthGatewayRoutePolicyPriority, legacyMatch); err != nil {
 						klog.Errorf("failed to delete stale policy route, %v", err)
 						return err
@@ -1040,9 +1054,9 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 						subnet.Spec.Vpc,
 						&kubeovnv1.PolicyRoute{
 							Priority:  util.NorthGatewayRoutePolicyPriority,
-							Match:     match,
+							Match:     match.match,
 							Action:    kubeovnv1.PolicyRouteActionReroute,
-							NextHopIP: nextHop,
+							NextHopIP: match.nextHopIP,
 						},
 						map[string]string{
 							"vendor": util.CniTypeName,
@@ -1095,22 +1109,14 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 				}
 
 				if pod.Annotations[util.NorthGatewayAnnotation] != "" && pod.Annotations[util.IPAddressAnnotation] != "" {
-					for podAddr := range strings.SplitSeq(pod.Annotations[util.IPAddressAnnotation], ",") {
-						if util.CheckProtocol(podAddr) != util.CheckProtocol(pod.Annotations[util.NorthGatewayAnnotation]) {
-							continue
-						}
-						ipSuffix := "ip4"
-						if util.CheckProtocol(podAddr) == kubeovnv1.ProtocolIPv6 {
-							ipSuffix = "ip6"
-						}
-
+					for _, match := range policyRouteSrcMatches(pod.Annotations[util.IPAddressAnnotation], pod.Annotations[util.NorthGatewayAnnotation]) {
 						if err := c.addPolicyRouteToVpc(
 							subnet.Spec.Vpc,
 							&kubeovnv1.PolicyRoute{
 								Priority:  util.NorthGatewayRoutePolicyPriority,
-								Match:     fmt.Sprintf("%s.src == %s", ipSuffix, podAddr),
+								Match:     match.match,
 								Action:    kubeovnv1.PolicyRouteActionReroute,
-								NextHopIP: pod.Annotations[util.NorthGatewayAnnotation],
+								NextHopIP: match.nextHopIP,
 							},
 							map[string]string{
 								"vendor": util.CniTypeName,

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -2155,6 +2156,173 @@ func TestHandleAddOrUpdatePodWithoutWorkDoesNotRecordSuccess(t *testing.T) {
 
 	require.NoError(t, err)
 	assertNoPodEvent(t, fc.fakeController)
+}
+
+func TestReconcileRouteSubnetsEIPUsesPerFamilyPolicyMatch(t *testing.T) {
+	const (
+		nodeName   = "node1"
+		podIPv4    = "10.40.0.13"
+		podIPv6    = "2001:db8:1:801:1::d"
+		dualPodIP  = podIPv4 + "," + podIPv6
+		v4OnlyIP   = "10.42.0.6"
+		nextHop    = "203.0.113.62"
+		eipV4      = "203.0.113.26"
+		macAddress = "00:00:00:00:00:01"
+	)
+
+	tests := []struct {
+		name          string
+		podIP         string
+		nextHop       string
+		wantMatch     string
+		wantLegacyDel string
+	}{
+		{
+			name:          "dual-stack pod with IPv4 external gateway",
+			podIP:         dualPodIP,
+			nextHop:       nextHop + "/26",
+			wantMatch:     "ip4.src == " + podIPv4,
+			wantLegacyDel: "ip4.src == " + dualPodIP,
+		},
+		{
+			name:      "IPv4-only pod keeps a single ip4.src match",
+			podIP:     v4OnlyIP,
+			nextHop:   nextHop,
+			wantMatch: "ip4.src == " + v4OnlyIP,
+		},
+		{
+			name:          "dual-stack pod with IPv6 external gateway",
+			podIP:         dualPodIP,
+			nextHop:       "2001:db8:2::1",
+			wantMatch:     "ip6.src == " + podIPv6,
+			wantLegacyDel: "ip4.src == " + dualPodIP,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				Name:      "repro-dualstack",
+				Namespace: metav1.NamespaceDefault,
+				UID:       "pod-uid",
+				Spec:      corev1.PodSpec{NodeName: nodeName},
+				Annotations: map[string]string{
+					util.AllocatedAnnotation:     "true",
+					util.IPAddressAnnotation:     tc.podIP,
+					util.MacAddressAnnotation:    macAddress,
+					util.EipAnnotation:           eipV4,
+					util.LogicalSwitchAnnotation: "ovn-default",
+				},
+			}
+			subnet := &kubeovnv1.Subnet{
+				Name: "ovn-default",
+				Spec: kubeovnv1.SubnetSpec{
+					CIDRBlock: "10.40.0.0/16,2001:db8:1:801:1::/80",
+					Gateway:   "10.40.0.1,2001:db8:1:801:1::1",
+					Protocol:  kubeovnv1.ProtocolDual,
+					Provider:  util.OvnProvider,
+					Vpc:       util.DefaultVpc,
+					Default:   true,
+				},
+			}
+			node := &corev1.Node{
+				Name: nodeName,
+				Annotations: map[string]string{
+					util.PortNameAnnotation: nodeName,
+				},
+			}
+			gwCM := &corev1.ConfigMap{
+				Name:      util.ExternalGatewayConfig,
+				Namespace: metav1.NamespaceSystem,
+				Data: map[string]string{
+					"external-gw-addr": tc.nextHop,
+				},
+			}
+			fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				Pods:       []*corev1.Pod{pod},
+				Nodes:      []*corev1.Node{node},
+				Subnets:    []*kubeovnv1.Subnet{subnet},
+				ConfigMaps: []*corev1.ConfigMap{gwCM},
+			})
+			require.NoError(t, err)
+			fc.fakeController.config.EnableEipSnat = true
+			fc.fakeController.config.ExternalGatewayConfigNS = metav1.NamespaceSystem
+
+			portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+			fc.mockOvnClient.EXPECT().ListPortGroups(gomock.Any()).Return(nil, nil).AnyTimes()
+			fc.mockOvnClient.EXPECT().RemovePortFromPortGroups(portName).Return(nil)
+			fc.mockOvnClient.EXPECT().PortGroupAddPorts(gomock.Any(), portName).Return(nil)
+			fc.mockOvnClient.EXPECT().PortGroupRemovePorts(gomock.Any(), portName).Return(nil)
+			fc.mockOvnClient.EXPECT().UpdateDnatAndSnat(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			fc.mockOvnClient.EXPECT().DeleteNats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			if tc.wantLegacyDel != "" {
+				fc.mockOvnClient.EXPECT().DeleteLogicalRouterPolicy(util.DefaultVpc, util.NorthGatewayRoutePolicyPriority, tc.wantLegacyDel).Return(nil)
+			}
+			strippedHop, _, _ := strings.Cut(tc.nextHop, "/")
+			fc.mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+				util.DefaultVpc,
+				util.NorthGatewayRoutePolicyPriority,
+				tc.wantMatch,
+				string(kubeovnv1.PolicyRouteActionReroute),
+				[]string{strippedHop},
+				([]string)(nil),
+				map[string]string{"vendor": util.CniTypeName, "subnet": subnet.Name},
+			).Return(nil)
+
+			err = fc.fakeController.reconcileRouteSubnets(pod, []*kubeovnNet{{
+				ProviderName: util.OvnProvider,
+				Subnet:       subnet,
+				IsDefault:    true,
+			}})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPolicyRouteSrcMatches(t *testing.T) {
+	tests := []struct {
+		name    string
+		podIP   string
+		nextHop string
+		want    []string
+	}{
+		{
+			name:    "dual-stack pod with IPv4 next hop",
+			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
+			nextHop: "203.0.113.62",
+			want:    []string{"ip4.src == 10.40.0.13"},
+		},
+		{
+			name:    "dual-stack pod with IPv6 next hop",
+			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
+			nextHop: "2001:db8:2::1",
+			want:    []string{"ip6.src == 2001:db8:1:801:1::d"},
+		},
+		{
+			name:    "IPv4-only pod",
+			podIP:   "10.42.0.6",
+			nextHop: "203.0.113.62",
+			want:    []string{"ip4.src == 10.42.0.6"},
+		},
+		{
+			name:    "IPv6-only pod",
+			podIP:   "2001:db8:1:801:1::d",
+			nextHop: "2001:db8:2::1",
+			want:    []string{"ip6.src == 2001:db8:1:801:1::d"},
+		},
+		{
+			name:    "family mismatch yields no match",
+			podIP:   "2001:db8:1:801:1::d",
+			nextHop: "203.0.113.62",
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, policyRouteSrcMatches(tc.podIP, tc.nextHop))
+		})
+	}
 }
 
 func podEventFixture() (*corev1.Pod, *kubeovnv1.Subnet) {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -2174,28 +2173,54 @@ func TestReconcileRouteSubnetsEIPUsesPerFamilyPolicyMatch(t *testing.T) {
 		name          string
 		podIP         string
 		nextHop       string
-		wantMatch     string
+		snat          bool
+		wantPolicies  []policyRouteMatch
 		wantLegacyDel string
 	}{
 		{
-			name:          "dual-stack pod with IPv4 external gateway",
-			podIP:         dualPodIP,
-			nextHop:       nextHop + "/26",
-			wantMatch:     "ip4.src == " + podIPv4,
+			name:    "dual-stack pod with IPv4 external gateway",
+			podIP:   dualPodIP,
+			nextHop: nextHop + "/26",
+			wantPolicies: []policyRouteMatch{
+				{match: "ip4.src == " + podIPv4, nextHopIP: nextHop},
+			},
 			wantLegacyDel: "ip4.src == " + dualPodIP,
 		},
 		{
-			name:      "IPv4-only pod keeps a single ip4.src match",
-			podIP:     v4OnlyIP,
-			nextHop:   nextHop,
-			wantMatch: "ip4.src == " + v4OnlyIP,
+			name:    "IPv4-only pod keeps a single ip4.src match",
+			podIP:   v4OnlyIP,
+			nextHop: nextHop,
+			wantPolicies: []policyRouteMatch{
+				{match: "ip4.src == " + v4OnlyIP, nextHopIP: nextHop},
+			},
 		},
 		{
-			name:          "dual-stack pod with IPv6 external gateway",
-			podIP:         dualPodIP,
-			nextHop:       "2001:db8:2::1",
-			wantMatch:     "ip6.src == " + podIPv6,
+			name:    "dual-stack pod with IPv6 external gateway",
+			podIP:   dualPodIP,
+			nextHop: "2001:db8:2::1",
+			wantPolicies: []policyRouteMatch{
+				{match: "ip6.src == " + podIPv6, nextHopIP: "2001:db8:2::1"},
+			},
 			wantLegacyDel: "ip4.src == " + dualPodIP,
+		},
+		{
+			name:    "dual-stack pod with dual-stack external gateway",
+			podIP:   dualPodIP,
+			nextHop: nextHop + "/26,2001:db8:2::1/64",
+			wantPolicies: []policyRouteMatch{
+				{match: "ip4.src == " + podIPv4, nextHopIP: nextHop},
+				{match: "ip6.src == " + podIPv6, nextHopIP: "2001:db8:2::1"},
+			},
+			wantLegacyDel: "ip4.src == " + dualPodIP,
+		},
+		{
+			name:    "IPv4-only SNAT pod keeps a single ip4.src match",
+			podIP:   v4OnlyIP,
+			nextHop: nextHop,
+			snat:    true,
+			wantPolicies: []policyRouteMatch{
+				{match: "ip4.src == " + v4OnlyIP, nextHopIP: nextHop},
+			},
 		},
 	}
 
@@ -2210,7 +2235,6 @@ func TestReconcileRouteSubnetsEIPUsesPerFamilyPolicyMatch(t *testing.T) {
 					util.AllocatedAnnotation:     "true",
 					util.IPAddressAnnotation:     tc.podIP,
 					util.MacAddressAnnotation:    macAddress,
-					util.EipAnnotation:           eipV4,
 					util.LogicalSwitchAnnotation: "ovn-default",
 				},
 			}
@@ -2253,21 +2277,28 @@ func TestReconcileRouteSubnetsEIPUsesPerFamilyPolicyMatch(t *testing.T) {
 			fc.mockOvnClient.EXPECT().RemovePortFromPortGroups(portName).Return(nil)
 			fc.mockOvnClient.EXPECT().PortGroupAddPorts(gomock.Any(), portName).Return(nil)
 			fc.mockOvnClient.EXPECT().PortGroupRemovePorts(gomock.Any(), portName).Return(nil)
+			if tc.snat {
+				pod.Annotations[util.SnatAnnotation] = eipV4
+			} else {
+				pod.Annotations[util.EipAnnotation] = eipV4
+			}
 			fc.mockOvnClient.EXPECT().UpdateDnatAndSnat(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			fc.mockOvnClient.EXPECT().EnsureSnat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			fc.mockOvnClient.EXPECT().DeleteNats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			if tc.wantLegacyDel != "" {
 				fc.mockOvnClient.EXPECT().DeleteLogicalRouterPolicy(util.DefaultVpc, util.NorthGatewayRoutePolicyPriority, tc.wantLegacyDel).Return(nil)
 			}
-			strippedHop, _, _ := strings.Cut(tc.nextHop, "/")
-			fc.mockOvnClient.EXPECT().AddLogicalRouterPolicy(
-				util.DefaultVpc,
-				util.NorthGatewayRoutePolicyPriority,
-				tc.wantMatch,
-				string(kubeovnv1.PolicyRouteActionReroute),
-				[]string{strippedHop},
-				([]string)(nil),
-				map[string]string{"vendor": util.CniTypeName, "subnet": subnet.Name},
-			).Return(nil)
+			for _, policy := range tc.wantPolicies {
+				fc.mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+					util.DefaultVpc,
+					util.NorthGatewayRoutePolicyPriority,
+					policy.match,
+					string(kubeovnv1.PolicyRouteActionReroute),
+					[]string{policy.nextHopIP},
+					([]string)(nil),
+					map[string]string{"vendor": util.CniTypeName, "subnet": subnet.Name},
+				).Return(nil)
+			}
 
 			err = fc.fakeController.reconcileRouteSubnets(pod, []*kubeovnNet{{
 				ProviderName: util.OvnProvider,
@@ -2284,37 +2315,54 @@ func TestPolicyRouteSrcMatches(t *testing.T) {
 		name    string
 		podIP   string
 		nextHop string
-		want    []string
+		want    []policyRouteMatch
 	}{
 		{
 			name:    "dual-stack pod with IPv4 next hop",
 			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
 			nextHop: "203.0.113.62",
-			want:    []string{"ip4.src == 10.40.0.13"},
+			want:    []policyRouteMatch{{match: "ip4.src == 10.40.0.13", nextHopIP: "203.0.113.62"}},
 		},
 		{
 			name:    "dual-stack pod with IPv6 next hop",
 			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
 			nextHop: "2001:db8:2::1",
-			want:    []string{"ip6.src == 2001:db8:1:801:1::d"},
+			want:    []policyRouteMatch{{match: "ip6.src == 2001:db8:1:801:1::d", nextHopIP: "2001:db8:2::1"}},
 		},
 		{
 			name:    "IPv4-only pod",
 			podIP:   "10.42.0.6",
 			nextHop: "203.0.113.62",
-			want:    []string{"ip4.src == 10.42.0.6"},
+			want:    []policyRouteMatch{{match: "ip4.src == 10.42.0.6", nextHopIP: "203.0.113.62"}},
 		},
 		{
 			name:    "IPv6-only pod",
 			podIP:   "2001:db8:1:801:1::d",
 			nextHop: "2001:db8:2::1",
-			want:    []string{"ip6.src == 2001:db8:1:801:1::d"},
+			want:    []policyRouteMatch{{match: "ip6.src == 2001:db8:1:801:1::d", nextHopIP: "2001:db8:2::1"}},
 		},
 		{
 			name:    "family mismatch yields no match",
 			podIP:   "2001:db8:1:801:1::d",
 			nextHop: "203.0.113.62",
-			want:    nil,
+		},
+		{
+			name:    "dual-stack pod with dual-stack next hop",
+			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
+			nextHop: "203.0.113.62,2001:db8:2::1",
+			want: []policyRouteMatch{
+				{match: "ip4.src == 10.40.0.13", nextHopIP: "203.0.113.62"},
+				{match: "ip6.src == 2001:db8:1:801:1::d", nextHopIP: "2001:db8:2::1"},
+			},
+		},
+		{
+			name:    "dual-stack CIDR next hop strips prefixes per family",
+			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
+			nextHop: "203.0.113.62/26,2001:db8:2::1/64",
+			want: []policyRouteMatch{
+				{match: "ip4.src == 10.40.0.13", nextHopIP: "203.0.113.62"},
+				{match: "ip6.src == 2001:db8:1:801:1::d", nextHopIP: "2001:db8:2::1"},
+			},
 		},
 	}
 


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

Dual-stack pods annotated with `ovn.kubernetes.io/eip` or `ovn.kubernetes.io/snat` were programmed with a single `ip4.src` match that concatenated both addresses, e.g. `ip4.src == 10.40.0.13,2001:db8:1:801:1::d`. OVN accepts that policy, but it never matches. Because this path also removes the LSP from the subnet port group to disable `natOutgoing`, the pod is left with no external connectivity.

This change loops over pod addresses, keeps only the family that matches the external gateway next hop, and programs `ip4.src` / `ip6.src` accordingly. The historical concatenated match is deleted on reconcile so already-broken dual-stack pods recover after upgrade.

## Which issue(s) this PR fixes

Fixes #7400