### PR TITLE
fix(vpc-nat-gw): isolate and serialize NAT gateway QoS state

### DIFF
--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -33,10 +33,16 @@
 #
 # ============================================================================
 
+# Where the interface configuration is persisted. It lives in the container's
+# writable layer, so a restarted vpc-nat-gw container starts without it and the
+# init command has to write it again. NAT_GW_ENV_FILE only exists so that tests
+# can keep the absolute system path untouched.
+NAT_GW_ENV_FILE=${NAT_GW_ENV_FILE:-/etc/kube-ovn/nat-gateway.env}
+
 # Read interfaces from persistent file
-if [ -f /etc/kube-ovn/nat-gateway.env ]; then
+if [ -f "$NAT_GW_ENV_FILE" ]; then
     # shellcheck disable=SC1091
-    source /etc/kube-ovn/nat-gateway.env
+    source "$NAT_GW_ENV_FILE"
 fi
 # Default interfaces
 VPC_INTERFACE=${VPC_INTERFACE:-"eth0"}
@@ -148,9 +154,9 @@ function init() {
         exit 1
     fi
     # Store interfaces persistently
-    mkdir -p /etc/kube-ovn
-    echo "VPC_INTERFACE=$VPC_INTERFACE" > /etc/kube-ovn/nat-gateway.env
-    echo "EXTERNAL_INTERFACE=$EXTERNAL_INTERFACE" >> /etc/kube-ovn/nat-gateway.env
+    mkdir -p "$(dirname "$NAT_GW_ENV_FILE")"
+    echo "VPC_INTERFACE=$VPC_INTERFACE" > "$NAT_GW_ENV_FILE"
+    echo "EXTERNAL_INTERFACE=$EXTERNAL_INTERFACE" >> "$NAT_GW_ENV_FILE"
 
     # run once is enough
     $iptables_save_cmd | grep DNAT_FILTER && exit 0
@@ -207,6 +213,11 @@ function init() {
     else
         echo "INFO: No IP addresses on $EXTERNAL_INTERFACE, skipping gratuitous ARP (no-IPAM mode or waiting for EIP allocation)"
     fi
+
+    # The controller records this Pod as initialized only after this command succeeds, so the
+    # chains have to exist by then. The chain creation above does not go through exec_cmd, so
+    # without this check a failed iptables call would still end the script with exit code 0.
+    check_inited
 }
 
 
@@ -897,7 +908,8 @@ function burst_mb_to_bytes() {
 # Log debug message only if QOS_DEBUG is enabled
 # Args: message
 function qos_debug() {
-    [ "$QOS_DEBUG" = "true" ] && echo "DEBUG: $*" >&2
+    [ "$QOS_DEBUG" = "true" ] || return 0
+    echo "DEBUG: $*" >&2
 }
 
 # Dump all tc QoS rules on a device for debugging
@@ -973,37 +985,14 @@ function verify_tc_filter_exists() {
     fi
 }
 
-# Verify a tc filter does NOT exist for a specific IP (after deletion)
-# Args: dev, ip (e.g., "192.168.1.1"), match_direction (src/dst)
-# Returns: 0 if NOT found (good), 1 if still exists (bad)
-# Only outputs debug info when QOS_DEBUG=true
-function verify_tc_filter_deleted() {
-    local dev=$1
-    local ip=$2
-    local match_direction=$3
-
-    local ip_escaped
-    ip_escaped=$(escape_for_regex "$ip/32")
-
-    local filter_output
-    filter_output=$(tc -p filter show dev "$dev" parent 1: 2>/dev/null)
-
-    if echo "$filter_output" | grep -qiE "match ip $match_direction $ip_escaped"; then
-        echo "ERROR: Filter for $ip ($match_direction) still exists on $dev after deletion!" >&2
-        return 1
-    else
-        qos_debug "Verified filter for $ip ($match_direction) was deleted from $dev"
-        return 0
-    fi
-}
-
 # ============================================================================
 # End of QoS Debugging and Verification Functions
 # ============================================================================
 
 # Generate a unique classid from IP address for HTB class
 # Uses all 4 octets with weighted sum to minimize collision probability
-# Range: 0x1-0x7ffe (1-32766) - uses hex format for tc compatibility
+# Range: 0x1-0x7ffe (1-32766). The shared default class 1:9999 is
+# hexadecimal 0x9999, so it is outside this range.
 # Note: Same IP will always produce same classid (deterministic)
 # Collision probability is low for typical deployments (<100 EIPs)
 #
@@ -1023,7 +1012,7 @@ function ip_to_classid() {
     # Weighted hash using prime multipliers for better distribution
     # Formula ensures different IPs get different classids in most cases
     local hash=$(( (octets[0] * 251 + octets[1] * 241 + octets[2] * 239 + octets[3] * 233) % 32766 ))
-    # classid range: 0x1-0x7fff (add 1 to avoid 0)
+    # classid range: 0x1-0x7ffe (add 1 to avoid 0)
     printf "0x%x" $((hash + 1))
 }
 
@@ -1042,22 +1031,25 @@ function find_available_classid() {
     # Strip 0x prefix for grep matching
     local classid_no_prefix=${classid_hex#0x}
 
-    # Check if this classid is already in use
     local filter_output
-    filter_output=$(tc -p filter show dev "$dev" parent 1: 2>/dev/null | grep -E "flowid 1:$classid_no_prefix\b" || true)
+    filter_output=$(tc -p filter show dev "$dev" parent 1: 2>/dev/null)
+    local class_pattern="flowid 1:$classid_no_prefix([^0-9a-fA-F]|$)"
 
-    if [ -n "$filter_output" ]; then
-        # Classid is in use, check if it's for the same IP
+    if echo "$filter_output" | grep -qE "$class_pattern"; then
         local target_ip_escaped
         target_ip_escaped=$(escape_for_regex "$target_ip/32")
-        if echo "$filter_output" | grep -qiE "match ip $match_direction $target_ip_escaped"; then
-            # Same IP, safe to reuse classid (this is an update scenario)
+        if echo "$filter_output" | awk -v class_pattern="$class_pattern" -v match_pattern="match ip $match_direction $target_ip_escaped([^0-9./]|$)" '
+            /flowid/ { owns_class = $0 ~ class_pattern }
+            tolower($0) ~ tolower(match_pattern) && owns_class { found = 1 }
+            END { exit !found }
+        '; then
             printf "0x%x" $classid
             return
         fi
 
-        # Collision with different IP - find alternative classid
-        # Try offsets in a different range to avoid further collision
+        # Collision with different IP - find alternative classid.
+        # Ten deterministic probes bound the script latency; widen this to a
+        # preloaded full-range scan only if real gateways exhaust the chain.
         local attempts=0
         while [ $attempts -lt 10 ]; do
             classid=$((classid + 3571))  # Use prime offset for better distribution
@@ -1067,7 +1059,6 @@ function find_available_classid() {
             if [ $classid -lt 1 ]; then
                 classid=1
             fi
-
             local new_classid_hex
             new_classid_hex=$(printf "0x%x" $classid)
             local existing
@@ -1080,43 +1071,71 @@ function find_available_classid() {
             attempts=$((attempts + 1))
         done
 
-        # If all attempts failed, use the original classid anyway (very rare)
-        # The old filter will be replaced
-        echo "WARNING: find_available_classid failed to find available classid after 10 attempts for IP '$target_ip' on dev '$dev'. Using classid 0x$(printf '%x' $classid) which may cause collision." >&2
+        echo "ERROR: no available EIP QoS classid for IP '$target_ip' on dev '$dev'" >&2
+        return 1
     fi
 
     printf "0x%x" $classid
 }
 
 # Delete existing HTB u32 filter and class
-# Args: dev, ip_escaped (regex-escaped IP/32, e.g., "192\.168\.1\.1/32"), match_direction (src/dst)
+# Args: dev, ip_escaped, match_direction, class_range (eip/natgw), priority (optional)
 function delete_htb_filter_and_class() {
     local dev=$1
     local ip_escaped=$2
     local match_direction=$3
+    local class_range=$4
+    local priority=${5:-}
 
-    qos_debug "delete_htb_filter_and_class called: dev=$dev, ip_escaped=$ip_escaped, match_direction=$match_direction"
+    qos_debug "delete_htb_filter_and_class called: dev=$dev, ip_escaped=$ip_escaped, match_direction=$match_direction, class_range=$class_range"
 
     local filter_output
     # -p: use human-readable IP format (192.168.1.1 instead of hex c0a80101)
-    filter_output=$(tc -p filter show dev "$dev" parent 1: 2>/dev/null)
+    if ! filter_output=$(tc -p filter show dev "$dev" parent 1:); then
+        echo "ERROR: failed to list QoS filters on $dev" >&2
+        return 1
+    fi
 
     qos_debug "filter_output length: ${#filter_output}"
 
     # Use -i for case-insensitive match (tc output may use "IP" or "ip" depending on version)
     if echo "$filter_output" | grep -qiE "match ip $match_direction $ip_escaped"; then
         qos_debug "Found matching filter for $ip_escaped on $dev"
-        # Extract filter info: grep -iB2 gets 2 lines before the match line
-        # tc output format is stable: flowid line is typically 1-2 lines before match line
-        # Then we use a second grep to precisely extract the flowid line from context
-        # This two-step approach is simple and reliable across tc versions
-        local filter_info
-        filter_info=$(echo "$filter_output" | grep -iB2 "match ip $match_direction $ip_escaped" | head -3)
-        qos_debug "filter_info: $filter_info"
-        # Only extract from the line containing 'flowid' (the actual filter line, not hash table declaration)
+        # Keep the flowid immediately preceding the matching IP line. A fixed number
+        # of preceding lines is unsafe when multiple filters share the same priority.
+        local match_pattern="match ip $match_direction $ip_escaped([^0-9./]|$)"
+        local class_pattern
+        case "$class_range" in
+            eip) class_pattern='flowid 1:[0-7][0-9a-fA-F]*([^0-9a-fA-F]|$)' ;;
+            natgw) class_pattern='flowid 1:[89a-fA-F][0-9a-fA-F]*([^0-9a-fA-F]|$)' ;;
+            *) echo "ERROR: unknown QoS class range '$class_range'" >&2; return 1 ;;
+        esac
         local flowid_line
-        flowid_line=$(echo "$filter_info" | grep "flowid" | head -1)
+        flowid_line=$(echo "$filter_output" | awk -v pattern="$match_pattern" -v class_pattern="$class_pattern" -v priority="$priority" '
+            /flowid/ {
+                priority_pattern = "pref " priority "([^0-9]|$)"
+                flowid = ($0 ~ class_pattern && (priority == "" || $0 ~ priority_pattern)) ? $0 : ""
+            }
+            tolower($0) ~ tolower(pattern) && flowid != "" { print flowid; exit }
+        ')
         qos_debug "flowid_line: $flowid_line"
+        # tc rewrites some requested priorities before storing them (a configured
+        # priority 0 is stored as 49152), so a filter written before this
+        # constraint may carry no pref matching the rule. Such a filter is only
+        # accepted when it is the sole candidate for this identity, so a filter
+        # belonging to a different rule is never picked up by accident.
+        if [ -z "$flowid_line" ] && [ -n "$priority" ]; then
+            local candidates
+            candidates=$(echo "$filter_output" | awk -v pattern="$match_pattern" -v class_pattern="$class_pattern" '
+                /flowid/ { flowid = ($0 ~ class_pattern) ? $0 : "" }
+                tolower($0) ~ tolower(pattern) && flowid != "" { print flowid }
+            ')
+            if [ "$(printf '%s\n' "$candidates" | grep -c .)" -eq 1 ]; then
+                flowid_line=$candidates
+                qos_debug "Single filter matches this identity without a matching pref: $flowid_line"
+            fi
+        fi
+        [ -n "$flowid_line" ] || return 0
         local old_handle old_prio old_classid
         old_handle=$(echo "$flowid_line" | grep -oE 'fh [0-9a-f:]+' | awk '{print $2}')
         old_prio=$(echo "$flowid_line" | grep -oE 'pref [0-9]+' | awk '{print $2}')
@@ -1124,106 +1143,77 @@ function delete_htb_filter_and_class() {
         # Add 0x prefix so tc class del interprets it as hex (tc accepts 0x prefix)
         old_classid=$(echo "$flowid_line" | grep -oE 'flowid 1:[0-9a-fA-F]+' | sed 's/flowid 1:/0x/')
         qos_debug "Extracted - old_handle=$old_handle, old_prio=$old_prio, old_classid=$old_classid"
-        if [ -n "$old_handle" ] && [ -n "$old_prio" ]; then
-            qos_debug "Deleting filter: tc filter del dev $dev parent 1: prio $old_prio handle $old_handle u32"
-            tc filter del dev "$dev" parent 1: prio $old_prio handle $old_handle u32 2>/dev/null || true
-        else
-            qos_debug "Missing old_handle or old_prio, cannot delete filter"
+        if [ -z "$old_handle" ] || [ -z "$old_prio" ] || [ -z "$old_classid" ]; then
+            echo "ERROR: failed to parse QoS filter identity for $ip_escaped on $dev" >&2
+            return 1
         fi
-        if [ -n "$old_classid" ]; then
-            qos_debug "Deleting class: tc class del dev $dev classid 1:$old_classid"
-            tc class del dev "$dev" classid 1:$old_classid 2>/dev/null || true
-        else
-            qos_debug "Missing old_classid, cannot delete class"
+        qos_debug "Deleting filter: tc filter del dev $dev parent 1: prio $old_prio handle $old_handle u32"
+        if ! tc filter del dev "$dev" parent 1: prio "$old_prio" handle "$old_handle" u32; then
+            echo "ERROR: failed to delete QoS filter for $ip_escaped on $dev" >&2
+            return 1
+        fi
+        qos_debug "Deleting class: tc class del dev $dev classid 1:$old_classid"
+        if ! tc class del dev "$dev" classid 1:"$old_classid" 2>/dev/null; then
+            echo "WARNING: failed to delete orphan QoS class 1:$old_classid on $dev" >&2
         fi
 
-        # Verify deletion was successful
-        # Extract IP from escaped pattern for verification
-        local ip_for_verify
-        ip_for_verify=$(echo "$ip_escaped" | sed 's/\\//g' | sed 's|/32||')
-        if ! verify_tc_filter_deleted "$dev" "$ip_for_verify" "$match_direction"; then
-            echo "WARNING: Filter deletion verification failed for $ip_for_verify on $dev" >&2
-        fi
     else
         qos_debug "No matching filter found for pattern 'match ip $match_direction $ip_escaped' on $dev"
     fi
 }
 
-# Delete existing HTB matchall filter and class (egress with HTB qdisc)
+# Delete existing HTB matchall filter and class by its fixed target classid.
 # Args:
 #   dev: network device name
-#   target_classid: (optional) specific classid to delete, handles orphaned classes
-#
-# Why target_classid is needed:
-#   When QoS policy is updated, the old class may become orphaned if:
-#   1. Filter was deleted but class deletion failed (e.g., classid parsing failed)
-#   2. Filter doesn't exist (deleted by another operation) so grep finds nothing
-#   Without target_classid, orphaned classes cause "RTNETLINK answers: File exists"
-#   error when adding new class with the same classid.
+#   target_classid: classid of the matchall rule to delete
 #
 # Note: tc requires filter to be deleted BEFORE its associated class can be deleted.
-#   This function first deletes the filter (if found), then deletes the class.
+#   This function first deletes the exact filter (if found), then the class.
 function delete_htb_matchall_filter_and_class() {
     local dev=$1
-    local target_classid=${2:-}  # Optional: specific classid to delete (handles orphaned classes)
+    local target_classid=${2:-}
+    if [ -z "$target_classid" ]; then
+        qos_debug "delete_htb_matchall_filter_and_class called without a target classid on $dev; skipping"
+        return
+    fi
 
     local filter_output
-    filter_output=$(tc filter show dev "$dev" parent 1: 2>/dev/null)
+    if ! filter_output=$(tc filter show dev "$dev" parent 1:); then
+        echo "ERROR: failed to list matchall filters on $dev" >&2
+        return 1
+    fi
 
-    if echo "$filter_output" | grep -qw "matchall"; then
-        # Directly grep the matchall filter line that contains 'flowid'
-        # This avoids the issue of grep -B2 picking up unrelated u32 filter lines
-        local flowid_line
-        flowid_line=$(echo "$filter_output" | grep "matchall.*flowid" | head -1)
-        local old_handle old_prio old_classid
+    local target_no_prefix=${target_classid#0x}
+    local flowid_line
+    # Multiple matchall filters can coexist on the same parent, so only the
+    # filter whose flowid is exactly the requested classid may be removed.
+    flowid_line=$(echo "$filter_output" | grep -iE "flowid 1:${target_no_prefix}([^0-9a-fA-F]|$)" | head -1)
+    qos_debug "delete_htb_matchall_filter_and_class: target=$target_classid, flowid_line=$flowid_line"
+    if [ -n "$flowid_line" ]; then
+        local old_handle old_prio
         # matchall filter uses "handle 0xNNNN" format, not "fh" like u32 filters
         old_handle=$(echo "$flowid_line" | grep -oE 'handle 0x[0-9a-fA-F]+' | sed 's/handle //')
         old_prio=$(echo "$flowid_line" | grep -oE 'pref [0-9]+' | awk '{print $2}')
-        # tc filter show outputs classid WITHOUT 0x prefix (e.g., "flowid 1:ff00")
-        # Add 0x prefix so tc class del interprets it as hex (tc accepts 0x prefix)
-        old_classid=$(echo "$flowid_line" | grep -oE 'flowid 1:[0-9a-fA-F]+' | sed 's/flowid 1:/0x/')
-        if [ -n "$old_handle" ] && [ -n "$old_prio" ]; then
-            tc filter del dev "$dev" parent 1: prio "$old_prio" handle "$old_handle" matchall 2>/dev/null || true
+        if [ -z "$old_handle" ] || [ -z "$old_prio" ]; then
+            echo "ERROR: failed to parse matchall filter identity for class $target_classid on $dev" >&2
+            return 1
         fi
-        if [ -n "$old_classid" ]; then
-            tc class del dev "$dev" classid 1:$old_classid 2>/dev/null || true
-        fi
-    fi
-
-    # Also delete the target classid if provided (handles orphaned classes)
-    # This ensures cleanup even if no filter exists pointing to this class
-    if [ -n "$target_classid" ]; then
-        tc class del dev "$dev" classid 1:$target_classid 2>/dev/null || true
-    fi
-}
-
-# Delete HTB filter and class by classid (fallback when IP grep doesn't match)
-# Args: dev, classid_hex (e.g., "0x4586")
-function delete_htb_filter_by_classid() {
-    local dev=$1
-    local classid_hex=$2
-
-    # tc filter show outputs classid WITHOUT 0x prefix (e.g., "flowid 1:4586")
-    # Strip 0x prefix for grep matching
-    local classid_no_prefix=${classid_hex#0x}
-    local filter_by_classid
-    filter_by_classid=$(tc filter show dev "$dev" parent 1: 2>/dev/null | grep -E "flowid 1:$classid_no_prefix\b" || true)
-    if [ -n "$filter_by_classid" ]; then
-        local old_prio old_handle
-        old_prio=$(echo "$filter_by_classid" | grep -oE 'pref [0-9]+' | head -1 | awk '{print $2}')
-        # u32 filters use "fh xxx:yyy" format, matchall filters use "handle 0xNNN" format
-        old_handle=$(echo "$filter_by_classid" | grep -oE 'fh [0-9a-f:]+' | head -1 | awk '{print $2}')
-        # Fallback: if fh format not found, try matchall handle format
-        [ -z "$old_handle" ] && old_handle=$(echo "$filter_by_classid" | grep -oE 'handle 0x[0-9a-fA-F]+' | head -1 | sed 's/handle //')
-        if [ -n "$old_prio" ] && [ -n "$old_handle" ]; then
-            # Try both u32 and matchall since we don't know the filter type
-            tc filter del dev "$dev" parent 1: prio "$old_prio" handle "$old_handle" u32 2>/dev/null || true
-            tc filter del dev "$dev" parent 1: prio "$old_prio" handle "$old_handle" matchall 2>/dev/null || true
+        qos_debug "Deleting matchall filter: tc filter del dev $dev parent 1: prio $old_prio handle $old_handle matchall"
+        if ! tc filter del dev "$dev" parent 1: prio "$old_prio" handle "$old_handle" matchall; then
+            echo "ERROR: failed to delete matchall filter for class $target_classid on $dev" >&2
+            return 1
         fi
     fi
 
-    # Delete class regardless of filter existence
-    tc class del dev "$dev" classid 1:$classid_hex 2>/dev/null || true
+    local class_output
+    if ! class_output=$(tc class show dev "$dev" classid 1:"$target_classid"); then
+        echo "ERROR: failed to list matchall class $target_classid on $dev" >&2
+        return 1
+    fi
+    if [ -n "$class_output" ] && ! tc class del dev "$dev" classid 1:"$target_classid"; then
+        echo "ERROR: failed to delete matchall class $target_classid on $dev" >&2
+        return 1
+    fi
 }
 
 # Get or create the IFB device name for a given interface
@@ -1264,14 +1254,8 @@ function setup_ifb_device() {
     # Setup ingress qdisc on the physical interface to redirect traffic to IFB
     tc qdisc add dev "$dev" ingress 2>/dev/null || true
 
-    # Setup HTB qdisc on IFB device for traffic shaping
-    # Use default class 9999 for unclassified traffic (no rate limit)
-    tc qdisc add dev "$ifb_dev" root handle 1: htb default 9999 2>/dev/null || true
-
-    # Create default class 9999 for unclassified traffic (very high rate = no limit)
-    # Without this class, unclassified traffic would be DROPPED because the default class doesn't exist
-    # Use 10000mbit as "unlimited" rate (effectively no limit for normal network speeds)
-    tc class add dev "$ifb_dev" parent 1: classid 1:9999 htb rate 10000mbit ceil 10000mbit 2>/dev/null || true
+    # The HTB root and the default class 1:9999 on the IFB device are owned by
+    # ensure_qos_root, which every caller runs right after this function.
 
     # Add redirect action from physical interface ingress to IFB
     # Check if redirect filter already exists
@@ -1289,6 +1273,18 @@ function setup_ifb_device() {
     echo "$ifb_dev"
 }
 
+# Reconcile the HTB root qdisc and the default class 1:9999 on a device. Both
+# are shared by every QoS rule on that device, so this only ever creates or
+# refreshes them and never touches a per-rule class.
+# Args: dev
+function ensure_qos_root() {
+    local dev=$1
+    if ! tc qdisc show dev "$dev" | grep -q "htb 1:"; then
+        exec_cmd "tc qdisc replace dev $dev root handle 1: htb default 9999"
+    fi
+    exec_cmd "tc class replace dev $dev parent 1: classid 1:9999 htb rate 10000mbit ceil 10000mbit"
+}
+
 # Delete IFB filter and class for a specific IP
 # Args: ifb_dev, ip_escaped (regex-escaped IP/32), match_direction (src/dst)
 function delete_ifb_filter_and_class() {
@@ -1296,8 +1292,8 @@ function delete_ifb_filter_and_class() {
     local ip_escaped=$2
     local match_direction=$3
 
-    # Reuse the HTB deletion logic since IFB uses HTB
-    delete_htb_filter_and_class "$ifb_dev" "$ip_escaped" "$match_direction"
+    # Reuse the HTB deletion logic since IFB uses HTB.
+    delete_htb_filter_and_class "$ifb_dev" "$ip_escaped" "$match_direction" eip
 }
 
 # EIP-level ingress QoS using IFB + HTB (TCP-friendly, queues instead of drops)
@@ -1333,26 +1329,22 @@ function eip_ingress_qos_add() {
 
         qos_debug "Processing ingress QoS rule - v4ip=$v4ip, priority=$priority, rate=$rate, burst=$burst, dev=$dev"
 
-        # Setup IFB device and get its name
         local ifb_dev
         ifb_dev=$(setup_ifb_device "$dev")
+        ensure_qos_root "$ifb_dev"
         qos_debug "IFB device = $ifb_dev"
 
-        # Delete any existing filter/class for this IP on IFB
+        # Replace cannot update an existing u32 filter on all supported tc versions.
         local v4ip_escaped
         v4ip_escaped=$(escape_for_regex "$v4ip/32")
-        qos_debug "Calling delete_ifb_filter_and_class for ingress"
-        delete_ifb_filter_and_class "$ifb_dev" "$v4ip_escaped" "$matchDirection"
+        delete_ifb_filter_and_class "$ifb_dev" "$v4ip_escaped" "$matchDirection" || return 1
 
         # Generate classid for this IP (reuse the same function as egress)
         local initial_classid
         initial_classid=$(ip_to_classid "$v4ip")
         local classid
-        classid=$(find_available_classid "$ifb_dev" "$initial_classid" "$v4ip" "$matchDirection")
+        classid=$(find_available_classid "$ifb_dev" "$initial_classid" "$v4ip" "$matchDirection") || return 1
         qos_debug "classid for $v4ip = $classid (initial was $initial_classid)"
-
-        # Delete any orphaned class with this classid
-        tc class del dev "$ifb_dev" classid 1:$classid 2>/dev/null || true
 
         # Convert burst from MB to bytes (handles decimal values like 1.5)
         local burst_bytes
@@ -1365,8 +1357,8 @@ function eip_ingress_qos_add() {
         # Create HTB class with rate limiting on IFB device
         # rate: guaranteed bandwidth, ceil: maximum bandwidth (same for hard limit)
         # burst/cburst: use bytes to avoid tc parsing issues with decimal MB values
-        qos_debug "Creating class: tc class add dev $ifb_dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
-        exec_cmd "tc class add dev $ifb_dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
+        qos_debug "Creating class: tc class replace dev $ifb_dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
+        exec_cmd "tc class replace dev $ifb_dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
 
         # Add fq_codel as leaf qdisc for better handling of bursty traffic
         # fq_codel provides:
@@ -1381,8 +1373,8 @@ function eip_ingress_qos_add() {
         exec_cmd "tc qdisc replace dev $ifb_dev parent 1:$classid fq_codel"
 
         # Create filter to classify traffic matching dst IP (ingress to this EIP) to this class
-        qos_debug "Creating filter: tc filter add dev $ifb_dev parent 1: protocol ip prio $priority handle $classid u32 match ip $matchDirection $v4ip/32 flowid 1:$classid"
-        exec_cmd "tc filter add dev $ifb_dev parent 1: protocol ip prio $priority handle $classid u32 match ip $matchDirection $v4ip/32 flowid 1:$classid"
+        qos_debug "Creating filter: tc filter replace dev $ifb_dev parent 1: protocol ip prio $priority handle $classid u32 match ip $matchDirection $v4ip/32 flowid 1:$classid"
+        exec_cmd "tc filter replace dev $ifb_dev parent 1: protocol ip prio $priority handle $classid u32 match ip $matchDirection $v4ip/32 flowid 1:$classid"
 
         # Verify the rules were created correctly
         qos_debug "Verifying ingress QoS rules for $v4ip..."
@@ -1426,31 +1418,20 @@ function eip_egress_qos_add() {
 
         qos_debug "Processing egress QoS rule - v4ip=$v4ip, priority=$priority, rate=$rate, burst=$burst, dev=$dev"
 
-        # Create root HTB qdisc if not exists (default class 9999 for unclassified traffic)
-        tc qdisc add dev $dev root handle 1: htb default 9999 2>/dev/null || true
+        ensure_qos_root "$dev"
 
-        # Create default class 9999 for unclassified traffic (very high rate = no limit)
-        # Without this class, unclassified traffic would be DROPPED because the default class doesn't exist
-        # Use 10000mbit as "unlimited" rate (effectively no limit for normal network speeds)
-        tc class add dev "$dev" parent 1: classid 1:9999 htb rate 10000mbit ceil 10000mbit 2>/dev/null || true
-
-        # Delete any existing filter/class for this IP first (use IP/32 for CIDR match)
+        # Replace cannot update an existing u32 filter on all supported tc versions.
         local v4ip_escaped
         v4ip_escaped=$(escape_for_regex "$v4ip/32")
-        qos_debug "Calling delete_htb_filter_and_class for egress"
-        delete_htb_filter_and_class "$dev" "$v4ip_escaped" "src"
+        delete_htb_filter_and_class "$dev" "$v4ip_escaped" "src" eip || return 1
 
         # ip_to_classid returns classid WITH 0x prefix (e.g., "0x4586")
         # find_available_classid also returns WITH 0x prefix
         local initial_classid
         initial_classid=$(ip_to_classid "$v4ip")
         local classid
-        classid=$(find_available_classid "$dev" "$initial_classid" "$v4ip" "src")
+        classid=$(find_available_classid "$dev" "$initial_classid" "$v4ip" "src") || return 1
         qos_debug "classid for $v4ip = $classid (initial was $initial_classid)"
-
-        # Delete any orphaned class with this classid (safe because find_available_classid
-        # already verified it's either unused or belongs to this IP)
-        tc class del dev $dev classid 1:$classid 2>/dev/null || true
 
         # Convert burst from MB to bytes (handles decimal values like 1.5)
         local burst_bytes
@@ -1463,8 +1444,8 @@ function eip_egress_qos_add() {
         # Create HTB class with rate limiting
         # rate: guaranteed bandwidth, ceil: maximum bandwidth (same for hard limit)
         # burst/cburst: use bytes to avoid tc parsing issues with decimal MB values
-        qos_debug "Creating class: tc class add dev $dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
-        exec_cmd "tc class add dev $dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
+        qos_debug "Creating class: tc class replace dev $dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
+        exec_cmd "tc class replace dev $dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
 
         # Add fq_codel as leaf qdisc for better handling of bursty traffic
         # This provides fair queuing and active queue management for egress traffic
@@ -1473,7 +1454,7 @@ function eip_egress_qos_add() {
 
         # Create filter to classify traffic matching src IP to this class
         # tc u32 match requires CIDR format, so append /32 for single IP
-        exec_cmd "tc filter add dev $dev parent 1: protocol ip prio $priority handle $classid u32 match ip src $v4ip/32 flowid 1:$classid"
+        exec_cmd "tc filter replace dev $dev parent 1: protocol ip prio $priority handle $classid u32 match ip src $v4ip/32 flowid 1:$classid"
 
         # Verify the rules were created correctly
         qos_debug "Verifying egress QoS rules for $v4ip..."
@@ -1517,20 +1498,24 @@ function cidr_to_classid() {
     IFS='.' read -r -a octets <<< "$ip"
     # Use weighted sum with different primes than ip_to_classid
     local hash=$(( (octets[0] * 11 + octets[1] * 13 + octets[2] * 17 + octets[3] * 19) % 32511 ))
-    # Range: 0x8000-0xfeff (32768-65279, avoids collision with matchall range)
+    # Range: 0x8000-0xfeff, excluding shared default class 0x9999.
     local classid=$((hash + 32768))
+    if [ "$classid" -eq $((0x9999)) ]; then
+        classid=$((0xfeff))
+    fi
     printf "0x%x" $classid
 }
 
 # Find an available classid for NatGw-level QoS, handling collision with different CIDR
-# Args: dev, initial_classid (hex format), target_cidr, match_direction (src/dst)
-# Returns: available classid in hex format (may be same as initial if no collision or collision with same CIDR)
+# Args: dev, initial_classid, target_cidr, match_direction, priority
+# Returns: available classid in hex format (may be the initial class for the same rule)
 # Note: This function handles the 0x8000-0xfeff range (NatGw QoS)
 function find_available_classid_for_cidr() {
     local dev=$1
     local classid_hex=$2
     local target_cidr=$3
     local match_direction=$4
+    local priority=$5
 
     # Convert hex to decimal for arithmetic
     local classid=$((classid_hex))
@@ -1538,22 +1523,28 @@ function find_available_classid_for_cidr() {
     # Strip 0x prefix for grep matching
     local classid_no_prefix=${classid_hex#0x}
 
-    # Check if this classid is already in use
     local filter_output
-    filter_output=$(tc -p filter show dev "$dev" parent 1: 2>/dev/null | grep -E "flowid 1:$classid_no_prefix\b" || true)
+    filter_output=$(tc -p filter show dev "$dev" parent 1: 2>/dev/null)
+    local class_pattern="flowid 1:$classid_no_prefix([^0-9a-fA-F]|$)"
 
-    if [ -n "$filter_output" ]; then
-        # Classid is in use, check if it's for the same CIDR
+    if echo "$filter_output" | grep -qE "$class_pattern"; then
         local target_cidr_escaped
         target_cidr_escaped=$(escape_for_regex "$target_cidr")
-        if echo "$filter_output" | grep -qiE "match ip $match_direction $target_cidr_escaped"; then
-            # Same CIDR, safe to reuse classid (this is an update scenario)
+        if echo "$filter_output" | awk -v class_pattern="$class_pattern" -v match_pattern="match ip $match_direction $target_cidr_escaped([^0-9./]|$)" -v priority="$priority" '
+            /flowid/ {
+                same_rule = $0 ~ class_pattern && $0 ~ ("pref " priority "([^0-9]|$)")
+            }
+            tolower($0) ~ tolower(match_pattern) && same_rule { found = 1 }
+            END { exit !found }
+        '; then
             printf "0x%x" $classid
             return
         fi
 
-        # Collision with different CIDR - find alternative classid
-        # Range: 0x8000-0xfeff (32768-65279, avoids matchall range 0xff00-0xfffe)
+        # Collision with different CIDR - find alternative classid.
+        # Range: 0x8000-0xfeff (32768-65279, avoids matchall range 0xff00-0xfffe).
+        # Ten deterministic probes bound the script latency; widen this to a
+        # preloaded full-range scan only if real gateways exhaust the chain.
         local attempts=0
         while [ $attempts -lt 10 ]; do
             classid=$((classid + 3571))  # Use prime offset for better distribution
@@ -1562,6 +1553,9 @@ function find_available_classid_for_cidr() {
             fi
             if [ $classid -lt 32768 ]; then
                 classid=32768
+            fi
+            if [ "$classid" -eq $((0x9999)) ]; then
+                classid=$((classid + 1))
             fi
 
             local new_classid_hex
@@ -1576,9 +1570,8 @@ function find_available_classid_for_cidr() {
             attempts=$((attempts + 1))
         done
 
-        # If all attempts failed, use the original classid anyway (very rare)
-        # The old filter will be replaced
-        echo "WARNING: find_available_classid_for_cidr failed to find available classid after 10 attempts for CIDR '$target_cidr' on dev '$dev'. Using classid 0x$(printf '%x' $classid) which may cause collision." >&2
+        echo "ERROR: no available NAT gateway QoS classid for CIDR '$target_cidr' on dev '$dev'" >&2
+        return 1
     fi
 
     printf "0x%x" $classid
@@ -1622,35 +1615,28 @@ function qos_add() {
             # Ingress: use IFB + HTB for TCP-friendly traffic shaping
             local ifb_dev
             ifb_dev=$(setup_ifb_device "$dev")
+            ensure_qos_root "$ifb_dev"
 
             # cidr_to_classid returns classid WITH 0x prefix (e.g., "0x8000")
             local initial_classid=$(cidr_to_classid "$cidr" "$priority")
             local classid
 
-            # Delete existing rule for this IP/matchall before adding new one
             if [ "$classifierType" == "u32" ]; then
                 local cidr_escaped
                 cidr_escaped=$(escape_for_regex "$cidr")
-                delete_htb_filter_and_class "$ifb_dev" "$cidr_escaped" "$matchDirection"
-
-                # Check for collision and find available classid
-                classid=$(find_available_classid_for_cidr "$ifb_dev" "$initial_classid" "$cidr" "$matchDirection")
+                delete_htb_filter_and_class "$ifb_dev" "$cidr_escaped" "$matchDirection" natgw "$priority" || return 1
+                classid=$(find_available_classid_for_cidr "$ifb_dev" "$initial_classid" "$cidr" "$matchDirection" "$priority") || return 1
             elif [ "$classifierType" == "matchall" ]; then
-                # Pass initial_classid to ensure orphaned classes are cleaned up
-                delete_htb_matchall_filter_and_class "$ifb_dev" "$initial_classid"
-                # matchall uses fixed classid, no collision detection needed
                 classid=$initial_classid
+                delete_htb_matchall_filter_and_class "$ifb_dev" "$classid" || return 1
             fi
-
-            # Delete any orphaned class with this classid
-            tc class del dev "$ifb_dev" classid 1:$classid 2>/dev/null || true
 
             # Convert burst from MB to bytes (handles decimal values like 1.5)
             local burst_bytes
             burst_bytes=$(burst_mb_to_bytes "$burst")
 
             # Create HTB class on IFB
-            exec_cmd "tc class add dev $ifb_dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
+            exec_cmd "tc class replace dev $ifb_dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
 
             # Add fq_codel as leaf qdisc for better handling of bursty traffic
             # Use 'replace' instead of 'add' to make this idempotent
@@ -1658,47 +1644,35 @@ function qos_add() {
 
             # Create filter on IFB
             if [ "$classifierType" == "u32" ]; then
-                exec_cmd "tc filter add dev $ifb_dev parent 1: protocol ip prio $priority handle $classid u32 match $matchType $matchDirection $cidr flowid 1:$classid"
+                exec_cmd "tc filter replace dev $ifb_dev parent 1: protocol ip prio $priority handle $classid u32 match $matchType $matchDirection $cidr flowid 1:$classid"
             elif [ "$classifierType" == "matchall" ]; then
-                exec_cmd "tc filter add dev $ifb_dev parent 1: protocol ip prio $priority handle $classid matchall flowid 1:$classid"
+                exec_cmd "tc filter replace dev $ifb_dev parent 1: protocol ip prio $priority handle $classid matchall flowid 1:$classid"
             fi
 
         elif [ "$qdiscType" == "egress" ]; then
             # Egress: use HTB class (queue packets instead of dropping)
-            tc qdisc add dev $dev root handle 1: htb default 9999 2>/dev/null || true
-
-            # Create default class 9999 for unclassified traffic (very high rate = no limit)
-            # Without this class, unclassified traffic would be DROPPED because the default class doesn't exist
-            tc class add dev "$dev" parent 1: classid 1:9999 htb rate 10000mbit ceil 10000mbit 2>/dev/null || true
+            ensure_qos_root "$dev"
 
             # cidr_to_classid returns classid WITH 0x prefix (e.g., "0x8000")
             local initial_classid=$(cidr_to_classid "$cidr" "$priority")
             local classid
 
-            # Delete existing rule for this IP/matchall before adding new one
             if [ "$classifierType" == "u32" ]; then
                 local cidr_escaped
                 cidr_escaped=$(escape_for_regex "$cidr")
-                delete_htb_filter_and_class "$dev" "$cidr_escaped" "$matchDirection"
-
-                # Check for collision and find available classid
-                classid=$(find_available_classid_for_cidr "$dev" "$initial_classid" "$cidr" "$matchDirection")
+                delete_htb_filter_and_class "$dev" "$cidr_escaped" "$matchDirection" natgw "$priority" || return 1
+                classid=$(find_available_classid_for_cidr "$dev" "$initial_classid" "$cidr" "$matchDirection" "$priority") || return 1
             elif [ "$classifierType" == "matchall" ]; then
-                # Pass initial_classid to ensure orphaned classes are cleaned up
-                delete_htb_matchall_filter_and_class "$dev" "$initial_classid"
-                # matchall uses fixed classid, no collision detection needed
                 classid=$initial_classid
+                delete_htb_matchall_filter_and_class "$dev" "$classid" || return 1
             fi
-
-            # Delete any orphaned class with this classid (must be after filter deletion)
-            tc class del dev "$dev" classid 1:$classid 2>/dev/null || true
 
             # Convert burst from MB to bytes (handles decimal values like 1.5)
             local burst_bytes
             burst_bytes=$(burst_mb_to_bytes "$burst")
 
             # Create HTB class
-            exec_cmd "tc class add dev $dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
+            exec_cmd "tc class replace dev $dev parent 1: classid 1:$classid htb rate ${rate}mbit ceil ${rate}mbit burst ${burst_bytes} cburst ${burst_bytes}"
 
             # Add fq_codel as leaf qdisc for better handling of bursty traffic
             # Use 'replace' instead of 'add' to make this idempotent
@@ -1706,9 +1680,9 @@ function qos_add() {
 
             # Create filter
             if [ "$classifierType" == "u32" ]; then
-                exec_cmd "tc filter add dev $dev parent 1: protocol ip prio $priority handle $classid u32 match $matchType $matchDirection $cidr flowid 1:$classid"
+                exec_cmd "tc filter replace dev $dev parent 1: protocol ip prio $priority handle $classid u32 match $matchType $matchDirection $cidr flowid 1:$classid"
             elif [ "$classifierType" == "matchall" ]; then
-                exec_cmd "tc filter add dev $dev parent 1: protocol ip prio $priority handle $classid matchall flowid 1:$classid"
+                exec_cmd "tc filter replace dev $dev parent 1: protocol ip prio $priority handle $classid matchall flowid 1:$classid"
             fi
         fi
     done
@@ -1759,41 +1733,26 @@ function qos_del() {
                 continue
             fi
 
-            # cidr_to_classid returns classid WITH 0x prefix (e.g., "0x8000")
-            local classid=$(cidr_to_classid "$cidr" "$priority")
-
-            # For u32 filter, find and delete by IP match
             if [ "$classifierType" == "u32" ]; then
                 local cidr_escaped
                 cidr_escaped=$(escape_for_regex "$cidr")
-                delete_htb_filter_and_class "$ifb_dev" "$cidr_escaped" "$matchDirection"
+                delete_htb_filter_and_class "$ifb_dev" "$cidr_escaped" "$matchDirection" natgw "$priority" || return 1
             elif [ "$classifierType" == "matchall" ]; then
-                delete_htb_matchall_filter_and_class "$ifb_dev" "$classid"
+                delete_htb_matchall_filter_and_class "$ifb_dev" "$(cidr_to_classid "$cidr" "$priority")" || return 1
             fi
-
-            # Also try to delete filter by classid (handles case where grep pattern didn't match)
-            delete_htb_filter_by_classid "$ifb_dev" "$classid"
-
         elif [ "$qdiscType" == "egress" ]; then
             # Ensure HTB root qdisc exists
             if ! tc qdisc show dev "$dev" | grep -q "htb 1:"; then
                 continue
             fi
 
-            # cidr_to_classid returns classid WITH 0x prefix (e.g., "0x8000")
-            local classid=$(cidr_to_classid "$cidr" "$priority")
-
-            # For u32 filter, find and delete by IP match (handles collision case)
             if [ "$classifierType" == "u32" ]; then
                 local cidr_escaped
                 cidr_escaped=$(escape_for_regex "$cidr")
-                delete_htb_filter_and_class "$dev" "$cidr_escaped" "$matchDirection"
+                delete_htb_filter_and_class "$dev" "$cidr_escaped" "$matchDirection" natgw "$priority" || return 1
             elif [ "$classifierType" == "matchall" ]; then
-                delete_htb_matchall_filter_and_class "$dev" "$classid"
+                delete_htb_matchall_filter_and_class "$dev" "$(cidr_to_classid "$cidr" "$priority")" || return 1
             fi
-
-            # Also try to delete filter by classid (handles case where grep pattern didn't match)
-            delete_htb_filter_by_classid "$dev" "$classid"
         fi
     done
 }
@@ -1828,17 +1787,10 @@ function eip_ingress_qos_del() {
             continue
         fi
 
-        # ip_to_classid returns classid WITH 0x prefix (e.g., "0x4586")
-        local classid
-        classid=$(ip_to_classid "$v4ip")
-
         # Use helper function to delete HTB filter and class by IP match on IFB
         local v4ip_escaped
         v4ip_escaped=$(escape_for_regex "$v4ip/32")
-        delete_ifb_filter_and_class "$ifb_dev" "$v4ip_escaped" "$matchDirection"
-
-        # Also try to delete filter by classid (handles case where grep pattern didn't match)
-        delete_htb_filter_by_classid "$ifb_dev" "$classid"
+        delete_ifb_filter_and_class "$ifb_dev" "$v4ip_escaped" "$matchDirection" || return 1
     done
 }
 
@@ -1866,17 +1818,10 @@ function eip_egress_qos_del() {
             continue
         fi
 
-        # ip_to_classid returns classid WITH 0x prefix (e.g., "0x4586")
-        local classid
-        classid=$(ip_to_classid "$v4ip")
-
         # Use helper function to delete HTB filter and class by IP match
         local v4ip_escaped
         v4ip_escaped=$(escape_for_regex "$v4ip/32")
-        delete_htb_filter_and_class "$dev" "$v4ip_escaped" "src"
-
-        # Also try to delete filter by classid (handles case where grep pattern didn't match)
-        delete_htb_filter_by_classid "$dev" "$classid"
+        delete_htb_filter_and_class "$dev" "$v4ip_escaped" "src" eip || return 1
     done
 }
 
@@ -1943,6 +1888,10 @@ case $opt in
     get-iptables-version)
         echo "get-iptables-version $*"
         get_iptables_version "$@"
+        ;;
+    check-inited)
+        # Exit status is the answer: 0 when this Pod holds the chains the data plane needs.
+        check_inited
         ;;
     help|--help|-h)
         show_help

--- a/dist/images/vpcnatgateway/nat_gateway_qos_test.sh
+++ b/dist/images/vpcnatgateway/nat_gateway_qos_test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script="$(cd "$(dirname "$0")" && pwd)/nat-gateway.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Load definitions without executing the command dispatcher at the end.
+eval "$(sed '/^opt=\$1$/,$d' "$script")"
+
+# This address hashes to decimal 9999 (hex 0x270f). It must remain available:
+# tc's textual class 1:9999 is hexadecimal 0x9999, outside the EIP range.
+[[ "$(ip_to_classid 0.1.34.7)" == "0x270f" ]]
+# This CIDR hashes to the shared default 0x9999 and must be remapped within
+# the NAT gateway range instead of replacing the default class.
+[[ "$(cidr_to_classid 0.0.115.242/32 1)" == "0xfeff" ]]
+
+tc_log="$tmp_dir/tc.log"
+scenario=overlap
+tc() {
+    if [[ "$1 $2 $3 $4 $5" == "-p filter show dev net1" ]]; then
+        [[ "$scenario" == filter-show-failure ]] && return 1
+        case "$scenario" in
+            delete-failure)
+                printf 'filter parent 1: protocol ip pref 2 u32 fh 270::800 flowid 1:270f\n'
+                printf '  match IP src 192.0.2.1/32\n'
+                ;;
+            collision)
+                printf 'filter parent 1: protocol ip pref 1 u32 fh 100::800 flowid 1:100\n'
+                printf '  match IP src 198.51.100.1/32\n'
+                printf 'filter parent 1: protocol ip pref 2 u32 fh 800::800 flowid 1:8000\n'
+                printf '  match IP src 198.51.100.0/24\n'
+                ;;
+            priority)
+                printf 'filter parent 1: protocol ip pref 1 u32 fh 800::800 flowid 1:8000\n'
+                printf '  match IP src 192.0.2.0/24\n'
+                ;;
+            overlap)
+                printf 'filter parent 1: protocol ip pref 1 u32 fh 800::800 flowid 1:8000\n'
+                printf '  match IP src 192.0.2.1/32\n'
+                printf 'filter parent 1: protocol ip pref 3 u32 fh 801::800 flowid 1:8001\n'
+                printf '  match IP src 192.0.2.1/32\n'
+                printf 'filter parent 1: protocol ip pref 2 u32 fh 270::800 flowid 1:270f\n'
+                printf '  match IP src 192.0.2.1/32\n'
+                ;;
+            default)
+                printf 'filter parent 1: protocol ip pref 1 u32 fh 999::800 flowid 1:9999\n'
+                printf '  match IP src 192.0.2.1/32\n'
+                ;;
+            legacy-priority)
+                # A rule configured with priority 0 is stored by tc as pref 49152.
+                printf 'filter parent 1: protocol ip pref 49152 u32 fh 800::800 flowid 1:8000\n'
+                printf '  match IP src 192.0.2.1/32\n'
+                ;;
+            ambiguous-priority)
+                # Same identity, two rules, neither at the requested priority.
+                printf 'filter parent 1: protocol ip pref 49152 u32 fh 800::800 flowid 1:8000\n'
+                printf '  match IP src 192.0.2.1/32\n'
+                printf 'filter parent 1: protocol ip pref 49153 u32 fh 801::800 flowid 1:8001\n'
+                printf '  match IP src 192.0.2.1/32\n'
+                ;;
+            deleted)
+                # The filter is already gone, so there is no candidate at all.
+                ;;
+        esac
+        return
+    fi
+    if [[ "$1 $2 $3 $4" == "filter show dev net1" ]]; then
+        [[ "$scenario" == matchall-show-failure ]] && return 1
+        if [[ "$scenario" == matchall-filter-failure ]]; then
+            printf 'filter protocol ip pref 3 matchall handle 0xff03 flowid 1:ff03\n'
+        fi
+        return
+    fi
+    if [[ "$1 $2 $3" == "class show dev" ]]; then
+        [[ "$scenario" == class-show-failure ]] && return 1
+        if [[ "$scenario" == collision ]]; then
+            printf 'class htb 1:100 parent 1:\n'
+        elif [[ "$scenario" == matchall-class-failure ]]; then
+            printf 'class htb 1:ff03 parent 1:\n'
+        fi
+        return
+    fi
+    printf '%s\n' "$*" >>"$tc_log"
+    if [[ "$scenario" == *-failure && "$1 $2" == "filter del" ||
+        "$scenario" == matchall-class-failure && "$1 $2" == "class del" ]]; then
+        return 1
+    fi
+}
+
+delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src eip
+grep -q '^filter del dev net1 parent 1: prio 2 handle 270::800 u32$' "$tc_log"
+grep -q '^class del dev net1 classid 1:0x270f$' "$tc_log"
+! grep -q 'handle 800::800' "$tc_log"
+
+: >"$tc_log"
+delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src natgw 1
+grep -q '^filter del dev net1 parent 1: prio 1 handle 800::800 u32$' "$tc_log"
+grep -q '^class del dev net1 classid 1:0x8000$' "$tc_log"
+! grep -q 'handle 270::800' "$tc_log"
+! grep -q 'handle 801::800' "$tc_log"
+
+: >"$tc_log"
+scenario=default
+delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src eip
+[[ ! -s "$tc_log" ]]
+
+# A natgw rule whose configured priority 0 was rewritten by tc must still be
+# removable, and only when a single filter matches it.
+: >"$tc_log"
+scenario=legacy-priority
+delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src natgw 0
+grep -q '^filter del dev net1 parent 1: prio 49152 handle 800::800 u32$' "$tc_log"
+grep -q '^class del dev net1 classid 1:0x8000$' "$tc_log"
+
+: >"$tc_log"
+scenario=ambiguous-priority
+delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src natgw 0
+[[ ! -s "$tc_log" ]]
+
+# Re-deleting a rule whose filter is already gone stays a no-op instead of
+# falling back to a filter it cannot identify.
+: >"$tc_log"
+scenario=deleted
+delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src natgw 1
+delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src eip
+[[ ! -s "$tc_log" ]]
+
+scenario=priority
+[[ "$(find_available_classid_for_cidr net1 0x8000 192.0.2.0/24 src 1)" == "0x8000" ]]
+classid=$(find_available_classid_for_cidr net1 0x8000 192.0.2.0/24 src 2)
+[[ "$classid" != "0x8000" ]]
+
+scenario=collision
+[[ "$(find_available_classid net1 0x100 198.51.100.1 src)" == "0x100" ]]
+! classid=$(find_available_classid net1 0x100 192.0.2.1 src 2>"$tmp_dir/eip-error")
+[[ -z "$classid" ]]
+grep -q 'no available EIP QoS classid' "$tmp_dir/eip-error"
+! classid=$(find_available_classid_for_cidr net1 0x8000 192.0.2.0/24 src 1 2>"$tmp_dir/natgw-error")
+[[ -z "$classid" ]]
+grep -q 'no available NAT gateway QoS classid' "$tmp_dir/natgw-error"
+
+: >"$tc_log"
+scenario=delete-failure
+! delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src eip 2>"$tmp_dir/delete-error"
+grep -q 'failed to delete QoS filter' "$tmp_dir/delete-error"
+! grep -q '^class del ' "$tc_log"
+
+: >"$tc_log"
+scenario=matchall-filter-failure
+! delete_htb_matchall_filter_and_class net1 0xff03 2>"$tmp_dir/matchall-filter-error"
+grep -q 'failed to delete matchall filter' "$tmp_dir/matchall-filter-error"
+! grep -q '^class del ' "$tc_log"
+
+: >"$tc_log"
+scenario=matchall-class-failure
+! delete_htb_matchall_filter_and_class net1 0xff03 2>"$tmp_dir/matchall-class-error"
+grep -q 'failed to delete matchall class' "$tmp_dir/matchall-class-error"
+
+scenario=filter-show-failure
+! delete_htb_filter_and_class net1 '192\.0\.2\.1/32' src eip 2>"$tmp_dir/filter-show-error"
+grep -q 'failed to list QoS filters' "$tmp_dir/filter-show-error"
+
+scenario=matchall-show-failure
+! delete_htb_matchall_filter_and_class net1 0xff03 2>"$tmp_dir/matchall-show-error"
+grep -q 'failed to list matchall filters' "$tmp_dir/matchall-show-error"
+
+scenario=class-show-failure
+! delete_htb_matchall_filter_and_class net1 0xff03 2>"$tmp_dir/class-show-error"
+grep -q 'failed to list matchall class' "$tmp_dir/class-show-error"
+
+# A restarted vpc-nat-gw container loses its writable layer: the iptables chains
+# (in the pod netns) survive, but the persisted interfaces do not. Re-running init
+# must rewrite them before it exits early on the existing chains.
+export NAT_GW_ENV_FILE="$tmp_dir/nat-gateway.env"
+ip() { return 0; }
+iptables_cmd=true
+iptables_save_cmd=iptables_save_stub
+iptables_save_stub() { printf 'DNAT_FILTER\n'; }
+( init "net1,net1" )
+grep -q '^VPC_INTERFACE=net1$' "$NAT_GW_ENV_FILE"
+grep -q '^EXTERNAL_INTERFACE=net1$' "$NAT_GW_ENV_FILE"
+
+echo 'PASS: QoS class ranges isolate EIP and shared state'

--- a/makefiles/ut.mk
+++ b/makefiles/ut.mk
@@ -4,6 +4,7 @@
 ut:
 	$(GINKGO) --show-node-events --poll-progress-after=60s $(GINKGO_OUTPUT_OPT) -v test/unittest
 	go test -coverprofile=profile.cov $$(go list ./pkg/... | grep -vw '^github.com/kubeovn/kube-ovn/pkg/client')
+	bash dist/images/vpcnatgateway/nat_gateway_qos_test.sh
 
 .PHONY: ovs-sandbox
 ovs-sandbox: clean-ovs-sandbox

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -110,7 +110,11 @@ type Controller struct {
 	updateVpcSnatQueue            workqueue.TypedRateLimitingInterface[string]
 	updateVpcSubnetQueue          workqueue.TypedRateLimitingInterface[string]
 	vpcNatGwKeyMutex              keymutex.KeyMutex
-	vpcNatGwExecKeyMutex          keymutex.KeyMutex
+	// qosNatGwKeyMutex is the only QoS data-plane lock. It is keyed by NAT gateway,
+	// never by EIP or QoS policy, because every QoS rule on one gateway shares its
+	// HTB root, IFB device and ingress redirect state.
+	qosNatGwKeyMutex     keymutex.KeyMutex
+	vpcNatGwExecKeyMutex keymutex.KeyMutex
 
 	vpcEgressGatewayLister           kubeovnlister.VpcEgressGatewayLister
 	vpcEgressGatewaySynced           cache.InformerSynced
@@ -533,6 +537,7 @@ func Run(ctx context.Context, config *Configuration) {
 		updateVpcSnatQueue:               newTypedRateLimitingQueue("UpdateVpcSnat", custCrdRateLimiter),
 		updateVpcSubnetQueue:             newTypedRateLimitingQueue("UpdateVpcSubnet", custCrdRateLimiter),
 		vpcNatGwKeyMutex:                 keymutex.NewHashed(numKeyLocks),
+		qosNatGwKeyMutex:                 keymutex.NewHashed(numKeyLocks),
 		vpcNatGwExecKeyMutex:             keymutex.NewHashed(numKeyLocks),
 		vpcEgressGatewayLister:           vpcEgressGatewayInformer.Lister(),
 		vpcEgressGatewaySynced:           vpcEgressGatewayInformer.Informer().HasSynced,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -386,6 +386,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		deploymentsLister:             deploymentInformer.Lister(),
 		configMapsLister:              configMapInformer.Lister(),
 		vpcNatGwKeyMutex:              keymutex.NewHashed(0),
+		qosNatGwKeyMutex:              keymutex.NewHashed(1),
 		OVNNbClient:                   mockOvnClient,
 		OVNSbClient:                   mockOvnSbClient,
 		ipam:                          ovnipam.NewIPAM(),
@@ -398,6 +399,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		updateSubnetStatusQueue:       newTypedRateLimitingQueue[string]("UpdateSubnetStatus", nil),
 		addOrUpdateVpcNatGatewayQueue: newTypedRateLimitingQueue[string]("AddOrUpdateVpcNatGateway", nil),
 		initVpcNatGatewayQueue:        newTypedRateLimitingQueue[string]("InitVpcNatGateway", nil),
+		updateIptablesEipQueue:        newTypedRateLimitingQueue[string]("UpdateIptablesEip", nil),
 	}
 
 	ctrl.config = &Configuration{

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -308,6 +308,7 @@ func (c *Controller) enqueueDeletePod(obj any) {
 func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 	oldPod := oldObj.(*v1.Pod)
 	newPod := newObj.(*v1.Pod)
+	c.enqueueVpcNatGatewayRestart(oldPod, newPod)
 	// Only kube-ovn network annotations can change the backend NIC resolution without an
 	// EndpointSlice update (the k8s endpointslice controller already emits EndpointSlice
 	// updates for readiness, deletion, PodIP and label changes). Re-checking every status
@@ -560,12 +561,6 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 			return nil
 		}
 	}
-
-	// A restarted vpc-nat-gw container loses the state the gateway script keeps in its writable
-	// layer, so the Pod has to be recreated for its init flow to run again. Workload status only
-	// carries replica counts and cannot report a restart, and this is not an allocation event
-	// either, so it needs its own trigger.
-	c.enqueueVpcNatGatewayRestart(pod)
 
 	// Reconcile per-port DHCP options for pods that carry DHCP annotations.
 	// This handles annotation add/change on already-running pods without requiring a pod restart.
@@ -1942,28 +1937,56 @@ func (c *Controller) enqueueVpcNatGatewayInit(pod *v1.Pod) {
 	}
 }
 
-// enqueueVpcNatGatewayRestart asks the gateway to recreate a Pod whose vpc-nat-gw container has
-// been restarted. Other Pods, and Pods that were not restarted, are ignored.
-func (c *Controller) enqueueVpcNatGatewayRestart(pod *v1.Pod) {
-	isVpcNatGw, vpcGwName := c.checkIsPodVpcNatGw(pod)
-	if !isVpcNatGw || !needRestartNatGatewayPod(pod) {
+// enqueueVpcNatGatewayRestart re-runs gateway initialization when the gateway
+// container starts after a restart, and keeps retrying while a gateway Pod is still
+// missing the mark its init command writes on completion. Initialization is
+// idempotent, and a restarted container is only observable through its ContainerID:
+// a container restart cannot be triggered from a Pod exec, because PID 1 of the
+// container's own namespace ignores the signals such an exec could send.
+func (c *Controller) enqueueVpcNatGatewayRestart(oldPod, newPod *v1.Pod) {
+	// The Pod-only checks run first: this runs on every Pod update in the cluster.
+	if !natGwContainerRestarted(oldPod, newPod) && !natGwPodPendingInit(newPod) {
 		return
 	}
-	klog.Infof("restarting vpc nat gateway %s", vpcGwName)
-	c.addOrUpdateVpcNatGatewayQueue.Add(vpcGwName)
+	isVpcNatGw, vpcGwName := c.checkIsPodVpcNatGw(newPod)
+	if !isVpcNatGw {
+		return
+	}
+	klog.Infof("reinitializing vpc nat gateway %s", vpcGwName)
+	c.initVpcNatGatewayQueue.Add(vpcGwName)
 }
 
-// needRestartNatGatewayPod reports whether the vpc-nat-gw container has been restarted.
-func needRestartNatGatewayPod(pod *v1.Pod) bool {
-	for _, psc := range pod.Status.ContainerStatuses {
-		if psc.Name != "vpc-nat-gw" {
-			continue
-		}
-		if psc.RestartCount > 0 {
-			return true
+// natGwPodPendingInit reports whether a gateway Pod still needs the init command. The label is
+// checked first so that the Pod updates of every other workload in the cluster stop before
+// touching the annotation map. The completion mark is bound to the container instance: a Pod
+// that was recreated under the same name, or whose container restarted in place, carries the
+// mark of an instance that is gone and has to be initialized again.
+func natGwPodPendingInit(pod *v1.Pod) bool {
+	if pod.Labels[util.VpcNatGatewayLabel] != "true" {
+		return false
+	}
+	if pod.Annotations[util.VpcNatGatewayInitAnnotation] != "true" {
+		return true
+	}
+	instanceToken := natGwPodInstanceToken(pod)
+	return instanceToken != "" && pod.Annotations[util.VpcNatGatewayInitInstanceAnnotation] != instanceToken
+}
+
+// natGwContainerRestarted reports whether a new vpc-nat-gw container instance
+// is running. ContainerID comes from the current CRI instance; unlike restart
+// count, it is not reconstructed from previous kubelet status.
+func natGwContainerRestarted(oldPod, newPod *v1.Pod) bool {
+	oldID, newID := natGwContainerID(oldPod), natGwContainerID(newPod)
+	return newID != "" && newID != oldID
+}
+
+func natGwContainerID(pod *v1.Pod) string {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == "vpc-nat-gw" && status.State.Running != nil {
+			return status.ContainerID
 		}
 	}
-	return false
+	return ""
 }
 
 func (c *Controller) podNeedSync(pod *v1.Pod) (bool, error) {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -61,19 +61,99 @@ func TestEnqueueVpcNatGwFromPod(t *testing.T) {
 	controller.enqueueVpcNatGatewayInit(pod)
 	require.Equal(t, 1, controller.initVpcNatGatewayQueue.Len())
 
-	// A restart is not an allocation event, so it carries its own trigger.
-	controller.enqueueVpcNatGatewayRestart(pod)
-	require.Zero(t, controller.addOrUpdateVpcNatGatewayQueue.Len())
-	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{Name: "vpc-nat-gw", RestartCount: 1}}
-	controller.enqueueVpcNatGatewayRestart(pod)
-	require.Equal(t, 1, controller.addOrUpdateVpcNatGatewayQueue.Len())
+	// A restart reuses the idempotent init path.
+	item, shutdown := controller.initVpcNatGatewayQueue.Get()
+	require.False(t, shutdown)
+	controller.initVpcNatGatewayQueue.Done(item)
+
+	// No running container instance is not a restart, and neither is a resync.
+	oldPod := pod.DeepCopy()
+	controller.enqueueVpcNatGatewayRestart(oldPod, pod)
+	require.Zero(t, controller.initVpcNatGatewayQueue.Len())
+
+	// The first running container instance wakes initialization.
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "vpc-nat-gw", ContainerID: "containerd://first", RestartCount: 1,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}}
+	controller.enqueueVpcNatGatewayRestart(oldPod, pod)
+	require.Equal(t, 1, controller.initVpcNatGatewayQueue.Len())
+
+	// Resyncing the same instance does nothing. A new ContainerID wakes recovery
+	// even if restart count is unchanged.
+	controller.enqueueVpcNatGatewayRestart(pod, pod.DeepCopy())
+	require.Equal(t, 1, controller.initVpcNatGatewayQueue.Len())
+	item, shutdown = controller.initVpcNatGatewayQueue.Get()
+	require.False(t, shutdown)
+	controller.initVpcNatGatewayQueue.Done(item)
+	controller.initVpcNatGatewayQueue.Forget(item)
+
+	restartedPod := pod.DeepCopy()
+	restartedPod.Status.ContainerStatuses[0].ContainerID = "containerd://second"
+	controller.enqueueVpcNatGatewayRestart(pod, restartedPod)
+	require.Equal(t, 1, controller.initVpcNatGatewayQueue.Len())
 
 	// A regular Pod triggers nothing.
-	regularPod := &corev1.Pod{Name: "regular", Namespace: metav1.NamespaceSystem}
+	regularPod := &corev1.Pod{
+		Name:      "regular",
+		Namespace: metav1.NamespaceSystem,
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "vpc-nat-gw", ContainerID: "containerd://regular",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
 	controller.enqueueVpcNatGatewayInit(regularPod)
-	controller.enqueueVpcNatGatewayRestart(regularPod)
+	controller.enqueueVpcNatGatewayRestart(&corev1.Pod{Name: "regular", Namespace: metav1.NamespaceSystem}, regularPod)
 	require.Equal(t, 1, controller.initVpcNatGatewayQueue.Len())
-	require.Equal(t, 1, controller.addOrUpdateVpcNatGatewayQueue.Len())
+	require.Zero(t, controller.addOrUpdateVpcNatGatewayQueue.Len())
+
+	// A gateway Pod that never completed initialization is woken by any of its own updates,
+	// even when its container instance is unchanged: a replacement Pod can be observed
+	// before its init command has run.
+	uninitialized := &corev1.Pod{
+		Name:      util.GenNatGwName("pending-init-gw") + "-0",
+		Namespace: metav1.NamespaceSystem,
+		Labels:    map[string]string{util.VpcNatGatewayLabel: "true"},
+		Annotations: map[string]string{
+			util.VpcNatGatewayAnnotation: "pending-init-gw",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "vpc-nat-gw", ContainerID: "containerd://running",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+	// Drain the key left by the previous case so the assertion cannot be satisfied by dedup.
+	item, shutdown = controller.initVpcNatGatewayQueue.Get()
+	require.False(t, shutdown)
+	controller.initVpcNatGatewayQueue.Done(item)
+	controller.initVpcNatGatewayQueue.Forget(item)
+
+	controller.enqueueVpcNatGatewayRestart(uninitialized.DeepCopy(), uninitialized)
+	require.Equal(t, 1, controller.initVpcNatGatewayQueue.Len(), "uninitialized gateway pod must retry init")
+	item, shutdown = controller.initVpcNatGatewayQueue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, "pending-init-gw", item)
+	controller.initVpcNatGatewayQueue.Done(item)
+
+	// Once the init command marked the Pod, further updates of the same instance do nothing.
+	initialized := uninitialized.DeepCopy()
+	initialized.Annotations[util.VpcNatGatewayInitAnnotation] = "true"
+	initialized.Annotations[util.VpcNatGatewayInitInstanceAnnotation] = natGwPodInstanceToken(initialized)
+	require.NotEmpty(t, initialized.Annotations[util.VpcNatGatewayInitInstanceAnnotation])
+	controller.enqueueVpcNatGatewayRestart(initialized.DeepCopy(), initialized)
+	require.Zero(t, controller.initVpcNatGatewayQueue.Len())
+
+	// The mark belongs to the instance that completed init, so a replacement Pod under the same
+	// name (new UID) or a restarted container (new ContainerID) must initialize again.
+	replaced := initialized.DeepCopy()
+	replaced.UID = "replacement-uid"
+	controller.enqueueVpcNatGatewayRestart(initialized.DeepCopy(), replaced)
+	require.Equal(t, 1, controller.initVpcNatGatewayQueue.Len())
 }
 
 func TestCheckIsPodVpcNatGw(t *testing.T) {

--- a/pkg/controller/qos_policy.go
+++ b/pkg/controller/qos_policy.go
@@ -2,11 +2,14 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,16 +38,14 @@ func (c *Controller) enqueueAddQoSPolicy(obj any) {
 	c.addQoSPolicyQueue.Add(key)
 }
 
-// enqueueQoSPolicyRelease re-enqueues a QoS policy whose QoSLabel a referencing resource (EIP or
-// NatGw) no longer carries, so a policy marked for deletion can drop its finalizer once unused.
-// The QoS reconcile decides "in use" via the QoSLabel selector, so the re-enqueue must key on the
-// label's old value. It is triggered from the delete handler (old labels only, newLabels nil) and
-// from the update handler when the label is cleared or switched; both fire only after the informer
-// cache already reflects the change, which avoids the stale-cache race that left policies stuck in
-// Terminating.
-func (c *Controller) enqueueQoSPolicyRelease(oldLabels, newLabels map[string]string) {
-	if oldQoS := oldLabels[util.QoSLabel]; oldQoS != "" && oldQoS != newLabels[util.QoSLabel] {
-		c.updateQoSPolicyQueue.Add(oldQoS)
+// enqueueQoSPolicyRelease re-enqueues policies no longer present in either the
+// desired Spec reference or the applied Status credential. The event handler runs
+// after the informer store update, so cleanup has converged before finalizer release.
+func (c *Controller) enqueueQoSPolicyRelease(oldSpec, oldStatus, newSpec, newStatus string) {
+	for _, qos := range []string{oldSpec, oldStatus} {
+		if qos != "" && qos != newSpec && qos != newStatus {
+			c.updateQoSPolicyQueue.Add(qos)
+		}
 	}
 }
 
@@ -69,9 +70,13 @@ func compareQoSPolicyBandwidthLimitRules(oldObj, newObj kubeovnv1.QoSPolicyBandw
 	return reflect.DeepEqual(sortedOld, sortedNew)
 }
 
-func (c *Controller) enqueueUpdateQoSPolicy(_, newObj any) {
+func (c *Controller) enqueueUpdateQoSPolicy(oldObj, newObj any) {
+	oldQos := oldObj.(*kubeovnv1.QoSPolicy)
 	newQos := newObj.(*kubeovnv1.QoSPolicy)
 	key := cache.MetaObjectToName(newQos).String()
+	if oldQos.Status.BindingType == "" && qosPolicyStatusMatchesSpec(newQos) {
+		c.enqueueQoSPolicyReferences(newQos)
+	}
 	if !newQos.DeletionTimestamp.IsZero() {
 		klog.V(3).Infof("enqueue update to clean qos %s", key)
 		c.updateQoSPolicyQueue.Add(key)
@@ -86,6 +91,53 @@ func (c *Controller) enqueueUpdateQoSPolicy(_, newObj any) {
 		klog.V(3).Infof("enqueue update qos %s", key)
 		c.updateQoSPolicyQueue.Add(key)
 		return
+	}
+}
+
+func qosPolicyStatusMatchesSpec(qos *kubeovnv1.QoSPolicy) bool {
+	return qos.Status.Shared == qos.Spec.Shared && qos.Status.BindingType == qos.Spec.BindingType &&
+		compareQoSPolicyBandwidthLimitRules(qos.Status.BandwidthLimitRules, qos.Spec.BandwidthLimitRules)
+}
+
+func iptablesEIPsUsingQoS(eips []*kubeovnv1.IptablesEIP, qos string) []*kubeovnv1.IptablesEIP {
+	result := make([]*kubeovnv1.IptablesEIP, 0, len(eips))
+	for _, eip := range eips {
+		if eip.Spec.QoSPolicy == qos || eip.Status.QoSPolicy == qos {
+			result = append(result, eip)
+		}
+	}
+	return result
+}
+
+// enqueueQoSPolicyReferences notifies the resources referencing a policy once it
+// first becomes usable. Each referrer reconciles the policy from its own queue, so
+// a referrer that cannot apply the policy cannot hold up an unrelated one.
+func (c *Controller) enqueueQoSPolicyReferences(qos *kubeovnv1.QoSPolicy) {
+	switch qos.Status.BindingType {
+	case kubeovnv1.QoSBindingTypeEIP:
+		eips, err := c.iptablesEipsLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to list eips referencing QoS policy %s: %v", qos.Name, err)
+			return
+		}
+		for _, eip := range eips {
+			if eip.Spec.QoSPolicy == qos.Name {
+				klog.V(3).Infof("enqueue eip %s for ready QoS policy %s", eip.Name, qos.Name)
+				c.updateIptablesEipQueue.Add(eip.Name)
+			}
+		}
+	case kubeovnv1.QoSBindingTypeNatGw:
+		items, err := c.vpcNatGatewayLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to list nat gateways referencing QoS policy %s: %v", qos.Name, err)
+			return
+		}
+		for _, gateway := range items {
+			if gateway.Spec.QoSPolicy == qos.Name {
+				klog.V(3).Infof("enqueue vpc nat gateway %s for ready QoS policy %s", gateway.Name, qos.Name)
+				c.addOrUpdateVpcNatGatewayQueue.Add(gateway.Name)
+			}
+		}
 	}
 }
 
@@ -132,7 +184,7 @@ func (c *Controller) handleAddQoSPolicy(key string) error {
 		return err
 	}
 
-	sortedNewRules := cachedQoS.Spec.BandwidthLimitRules
+	sortedNewRules := slices.Clone(cachedQoS.Spec.BandwidthLimitRules)
 	sort.Slice(sortedNewRules, func(i, j int) bool {
 		return sortedNewRules[i].Name < sortedNewRules[j].Name
 	})
@@ -245,14 +297,18 @@ func diffQoSPolicyBandwidthLimitRules(oldList, newList kubeovnv1.QoSPolicyBandwi
 
 	// Loop through new rules and compare with old rules
 	for _, s := range newList {
-		if old, ok := oldMap[s.Name]; !ok {
-			// add the rule
+		old, ok := oldMap[s.Name]
+		switch {
+		case !ok:
 			added = append(added, s)
-		} else if !reflect.DeepEqual(old, s) {
-			// updated the rule
+		case reflect.DeepEqual(old, s):
+		case old.Direction == s.Direction && old.Interface == s.Interface && old.Priority == s.Priority &&
+			old.MatchType == s.MatchType && old.MatchValue == s.MatchValue:
 			updated = append(updated, s)
+		default:
+			deleted = append(deleted, old)
+			added = append(added, s)
 		}
-		// keep the rule not changed
 		delete(oldMap, s.Name)
 	}
 
@@ -264,55 +320,42 @@ func diffQoSPolicyBandwidthLimitRules(oldList, newList kubeovnv1.QoSPolicyBandwi
 	return added, deleted, updated
 }
 
-func (c *Controller) reconcileEIPBandwidthLimitRules(
+func (c *Controller) reconcileEIPBandwidthLimitRulesLocked(
 	eip *kubeovnv1.IptablesEIP,
 	added kubeovnv1.QoSPolicyBandwidthLimitRules,
 	deleted kubeovnv1.QoSPolicyBandwidthLimitRules,
 	updated kubeovnv1.QoSPolicyBandwidthLimitRules,
 ) error {
-	var err error
-	// in this case, we must delete rules first, then add or update rules
+	if eip.Spec.NatGwDp == "" || eip.Status.IP == "" {
+		return nil
+	}
+	// Rules whose identity changed are deleted first, then the new rules are
+	// added, so that the gateway never carries stale tc classes from the old rule.
 	if len(deleted) > 0 {
-		if err = c.delEIPBandwidthLimitRules(eip, eip.Status.IP, deleted); err != nil {
-			klog.Errorf("failed to delete eip %s bandwidth limit rules, %v", eip.Name, err)
-			return err
+		if err := c.delEIPBandwidthLimitRulesLocked(eip, eip.Status.IP, deleted); err != nil {
+			return fmt.Errorf("failed to delete eip %s bandwidth limit rules: %w", eip.Name, err)
 		}
 	}
 	if len(added) > 0 {
-		if err = c.addOrUpdateEIPBandwidthLimitRules(eip, eip.Status.IP, added); err != nil {
-			klog.Errorf("failed to add eip %s bandwidth limit rules, %v", eip.Name, err)
-			return err
+		if err := c.addOrUpdateEIPBandwidthLimitRulesLocked(eip, eip.Status.IP, added); err != nil {
+			return fmt.Errorf("failed to add eip %s bandwidth limit rules: %w", eip.Name, err)
 		}
 	}
 	if len(updated) > 0 {
-		if err = c.addOrUpdateEIPBandwidthLimitRules(eip, eip.Status.IP, updated); err != nil {
-			klog.Errorf("failed to update eip %s bandwidth limit rules, %v", eip.Name, err)
-			return err
+		if err := c.addOrUpdateEIPBandwidthLimitRulesLocked(eip, eip.Status.IP, updated); err != nil {
+			return fmt.Errorf("failed to update eip %s bandwidth limit rules: %w", eip.Name, err)
 		}
 	}
-
 	return nil
 }
 
 func validateIPMatchValue(matchValue string) bool {
 	parts := strings.Split(matchValue, " ")
-	if len(parts) != 2 {
-		klog.Errorf("invalid ip MatchValue %s", matchValue)
+	if len(parts) != 2 || parts[0] != "src" && parts[0] != "dst" {
 		return false
 	}
-
-	direction := parts[0]
-	if direction != "src" && direction != "dst" {
-		klog.Errorf("invalid direction %s, must be src or dst", direction)
-		return false
-	}
-
-	cidr := parts[1]
-	if _, _, err := net.ParseCIDR(cidr); err != nil {
-		klog.Errorf("invalid cidr %s", cidr)
-		return false
-	}
-	return true
+	prefix, err := netip.ParsePrefix(parts[1])
+	return err == nil && prefix.Addr().Is4() && prefix == prefix.Masked()
 }
 
 // numericRatePattern validates that rate/burst values are numeric (integer or decimal)
@@ -329,10 +372,17 @@ var interfaceNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,15}$`)
 
 func validateRateValue(value, fieldName string) error {
 	if value == "" {
-		return nil // empty is allowed (omitempty in CRD)
+		return fmt.Errorf("%s must not be empty", fieldName)
 	}
 	if !numericRatePattern.MatchString(value) {
 		return fmt.Errorf("invalid %s value %q: must be a positive number (e.g., 100 or 0.5)", fieldName, value)
+	}
+	n, err := strconv.ParseFloat(value, 64)
+	if err != nil || n <= 0 {
+		return fmt.Errorf("invalid %s value %q: must be greater than zero", fieldName, value)
+	}
+	if fieldName == "rateMax" && n < 0.000008 {
+		return fmt.Errorf("invalid rateMax value %q: tc cannot represent less than 0.000008 Mbps", value)
 	}
 	return nil
 }
@@ -352,51 +402,103 @@ func validateInterfaceName(iface string) error {
 // validateDirection validates QoS rule direction to prevent command injection
 // Only "ingress" and "egress" are valid values
 func validateDirection(direction kubeovnv1.QoSPolicyRuleDirection) error {
-	if direction == "" {
-		return nil // empty is allowed (omitempty in CRD)
-	}
 	if direction != kubeovnv1.QoSDirectionIngress && direction != kubeovnv1.QoSDirectionEgress {
 		return fmt.Errorf("invalid direction %q: must be 'ingress' or 'egress'", direction)
 	}
 	return nil
 }
 
+func qosRuleInterface(rule kubeovnv1.QoSPolicyBandwidthLimitRule) string {
+	if rule.Interface != "" {
+		return rule.Interface
+	}
+	if rule.Direction == kubeovnv1.QoSDirectionIngress {
+		return "eth0"
+	}
+	return "net1"
+}
+
 func (c *Controller) validateQosPolicy(qosPolicy *kubeovnv1.QoSPolicy) error {
-	var err error
-	if qosPolicy.Spec.BandwidthLimitRules != nil {
-		for _, rule := range qosPolicy.Spec.BandwidthLimitRules {
-			// Validate RateMax and BurstMax are numeric only (prevents command injection)
-			if err = validateRateValue(rule.RateMax, "rateMax"); err != nil {
-				klog.Error(err)
-				return err
+	if qosPolicy.Spec.BindingType != kubeovnv1.QoSBindingTypeEIP &&
+		qosPolicy.Spec.BindingType != kubeovnv1.QoSBindingTypeNatGw {
+		return fmt.Errorf("invalid binding type %q: must be EIP or NATGW", qosPolicy.Spec.BindingType)
+	}
+	names := make(map[string]struct{}, len(qosPolicy.Spec.BandwidthLimitRules))
+	directions := make(map[kubeovnv1.QoSPolicyRuleDirection]struct{}, 2)
+	identities := make(map[struct {
+		direction  kubeovnv1.QoSPolicyRuleDirection
+		iface      string
+		priority   int
+		matchType  kubeovnv1.QoSPolicyRuleMatchType
+		matchValue string
+	}]struct{}, len(qosPolicy.Spec.BandwidthLimitRules))
+	for _, rule := range qosPolicy.Spec.BandwidthLimitRules {
+		if _, ok := names[rule.Name]; ok {
+			return fmt.Errorf("duplicate bandwidth rule name %q", rule.Name)
+		}
+		names[rule.Name] = struct{}{}
+		if rule.Priority < 0 || rule.Priority > 65535 {
+			return fmt.Errorf("invalid priority %d: must be between 0 and 65535", rule.Priority)
+		}
+		if qosPolicy.Spec.BindingType == kubeovnv1.QoSBindingTypeNatGw &&
+			rule.MatchType == kubeovnv1.QoSMatchTypeIP && rule.Priority == 0 {
+			return errors.New("priority must be greater than zero for NATGW ip match rules")
+		}
+		if err := validateRateValue(rule.RateMax, "rateMax"); err != nil {
+			return err
+		}
+		if err := validateRateValue(rule.BurstMax, "burstMax"); err != nil {
+			return err
+		}
+		if err := validateInterfaceName(rule.Interface); err != nil {
+			return err
+		}
+		if err := validateDirection(rule.Direction); err != nil {
+			return err
+		}
+		switch rule.MatchType {
+		case "":
+			if rule.MatchValue != "" {
+				return errors.New("matchValue must be empty when matchType is empty")
 			}
-			if err = validateRateValue(rule.BurstMax, "burstMax"); err != nil {
-				klog.Error(err)
-				return err
+		case kubeovnv1.QoSMatchTypeIP:
+			if !validateIPMatchValue(rule.MatchValue) {
+				return fmt.Errorf("invalid ip MatchValue %s", rule.MatchValue)
 			}
-			// Validate Interface name (prevents command injection)
-			if err = validateInterfaceName(rule.Interface); err != nil {
-				klog.Error(err)
-				return err
+		default:
+			return fmt.Errorf("invalid match type %q", rule.MatchType)
+		}
+
+		if qosPolicy.Spec.BindingType == kubeovnv1.QoSBindingTypeNatGw {
+			matchValue := rule.MatchValue
+			priority := rule.Priority
+			if rule.MatchType == "" {
+				matchValue = ""
+				priority %= 255
 			}
-			// Validate Direction (prevents command injection)
-			if err = validateDirection(rule.Direction); err != nil {
-				klog.Error(err)
-				return err
+			identity := struct {
+				direction  kubeovnv1.QoSPolicyRuleDirection
+				iface      string
+				priority   int
+				matchType  kubeovnv1.QoSPolicyRuleMatchType
+				matchValue string
+			}{rule.Direction, qosRuleInterface(rule), priority, rule.MatchType, matchValue}
+			if _, ok := identities[identity]; ok {
+				return fmt.Errorf("bandwidth rule %q duplicates an existing rule identity", rule.Name)
 			}
-			if rule.MatchType == "ip" {
-				if !validateIPMatchValue(rule.MatchValue) {
-					err = fmt.Errorf("invalid ip MatchValue %s", rule.MatchValue)
-					klog.Error(err)
-					return err
-				}
+			identities[identity] = struct{}{}
+		} else {
+			if rule.Interface != "" || rule.MatchType != "" || rule.MatchValue != "" {
+				return fmt.Errorf("bandwidth rule %q: interface and match fields are not supported for EIP binding", rule.Name)
 			}
+			if _, ok := directions[rule.Direction]; ok {
+				return fmt.Errorf("bandwidth rule %q duplicates direction %q", rule.Name, rule.Direction)
+			}
+			directions[rule.Direction] = struct{}{}
 		}
 	}
 	if !qosPolicy.Spec.Shared && qosPolicy.Spec.BindingType == kubeovnv1.QoSBindingTypeNatGw {
-		err = fmt.Errorf("qos policy %s is not shared, but binding to nat gateway", qosPolicy.Name)
-		klog.Error(err)
-		return err
+		return fmt.Errorf("qos policy %s is not shared, but binding to nat gateway", qosPolicy.Name)
 	}
 	return nil
 }
@@ -417,30 +519,23 @@ func (c *Controller) handleUpdateQoSPolicy(key string) error {
 
 	// should delete
 	if !cachedQos.DeletionTimestamp.IsZero() {
-		// Check if the QoS policy is still being used before allowing deletion
-		var inUse bool
-		if cachedQos.Spec.BindingType == kubeovnv1.QoSBindingTypeEIP {
-			eips, err := c.iptablesEipsLister.List(
-				labels.SelectorFromSet(labels.Set{util.QoSLabel: key}),
-			)
-			// when eip is not found, we should delete finalizer
-			if err != nil && !k8serrors.IsNotFound(err) {
-				klog.Errorf("failed to get eip list, %v", err)
-				return err
-			}
-			inUse = len(eips) != 0
+		// Check both supported reference types. BindingType changes are rejected by
+		// reconciliation but not by API validation, so deletion cannot trust Spec alone.
+		eips, err := c.iptablesEipsLister.List(labels.Everything())
+		if err != nil {
+			return fmt.Errorf("failed to list eips: %w", err)
 		}
-
-		if cachedQos.Spec.BindingType == kubeovnv1.QoSBindingTypeNatGw {
-			gws, err := c.vpcNatGatewayLister.List(
-				labels.SelectorFromSet(labels.Set{util.QoSLabel: key}),
-			)
-			// when nat gw is not found, we should delete finalizer
-			if err != nil && !k8serrors.IsNotFound(err) {
-				klog.Errorf("failed to get gw list, %v", err)
-				return err
+		inUse := slices.ContainsFunc(eips, func(eip *kubeovnv1.IptablesEIP) bool {
+			return eip.Spec.QoSPolicy == key || eip.Status.QoSPolicy == key
+		})
+		if !inUse {
+			gateways, err := c.vpcNatGatewayLister.List(labels.Everything())
+			if err != nil {
+				return fmt.Errorf("failed to list nat gateways: %w", err)
 			}
-			inUse = len(gws) != 0
+			inUse = slices.ContainsFunc(gateways, func(gateway *kubeovnv1.VpcNatGateway) bool {
+				return gateway.Spec.QoSPolicy == key || gateway.Status.QoSPolicy == key
+			})
 		}
 
 		if inUse {
@@ -489,40 +584,35 @@ func (c *Controller) handleUpdateQoSPolicy(key string) error {
 			return err
 		}
 
-		if cachedQos.Status.BindingType == kubeovnv1.QoSBindingTypeEIP {
-			// filter to eip
-			eips, err := c.iptablesEipsLister.List(
-				labels.SelectorFromSet(labels.Set{util.QoSLabel: key}),
-			)
-			if err != nil {
-				klog.Errorf("failed to get eip list, %v", err)
-				return err
-			}
-			switch {
-			case len(eips) == 0:
-				// not thing to do
-			case len(eips) == 1:
-				eip := eips[0]
-				if err = c.reconcileEIPBandwidthLimitRules(eip, added, deleted, updated); err != nil {
-					klog.Errorf("failed to reconcile eip %s bandwidth limit rules, %v", eip.Name, err)
-					return err
-				}
-			default:
-				err := fmt.Errorf("not support qos %s change rule, related eip more than one", key)
-				klog.Error(err)
-				return err
-			}
-		}
-
-		sortedNewRules := cachedQos.Spec.BandwidthLimitRules
+		sortedNewRules := slices.Clone(cachedQos.Spec.BandwidthLimitRules)
 		sort.Slice(sortedNewRules, func(i, j int) bool {
 			return sortedNewRules[i].Name < sortedNewRules[j].Name
 		})
 
-		// .Status.Shared and .Status.BindingType are not supported to change
+		if cachedQos.Status.BindingType == kubeovnv1.QoSBindingTypeEIP {
+			eips, err := c.iptablesEipsLister.List(labels.Everything())
+			if err != nil {
+				return fmt.Errorf("failed to list eips for QoS policy %s: %w", key, err)
+			}
+			eips = iptablesEIPsUsingQoS(eips, key)
+			switch len(eips) {
+			case 0:
+			case 1:
+				eip := eips[0]
+				return c.withNatGwQoSLock(eip.Spec.NatGwDp, func() error {
+					if err := c.reconcileEIPBandwidthLimitRulesLocked(eip, added, deleted, updated); err != nil {
+						return err
+					}
+					return c.patchQoSStatus(key, cachedQos.Status.Shared, cachedQos.Status.BindingType, sortedNewRules)
+				})
+			default:
+				return fmt.Errorf("not support qos %s change rule, related eip more than one", key)
+			}
+		}
+
+		// .Status.Shared and .Status.BindingType are not supported to change.
 		if err = c.patchQoSStatus(key, cachedQos.Status.Shared, cachedQos.Status.BindingType, sortedNewRules); err != nil {
-			klog.Errorf("failed to patch status for qos %s, %v", key, err)
-			return err
+			return fmt.Errorf("failed to patch status for qos %s: %w", key, err)
 		}
 	}
 	return nil

--- a/pkg/controller/qos_policy_test.go
+++ b/pkg/controller/qos_policy_test.go
@@ -36,10 +36,11 @@ func TestValidateRateValue(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "valid zero value",
+			name:      "zero value is rejected",
 			value:     "0",
 			fieldName: "rateMax",
-			wantErr:   false,
+			wantErr:   true,
+			errMsg:    "must be greater than zero",
 		},
 		{
 			name:      "valid decimal value",
@@ -60,6 +61,19 @@ func TestValidateRateValue(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "minimum representable rate",
+			value:     "0.000008",
+			fieldName: "rateMax",
+			wantErr:   false,
+		},
+		{
+			name:      "rate below one byte per second is rejected",
+			value:     "0.000007",
+			fieldName: "rateMax",
+			wantErr:   true,
+			errMsg:    "tc cannot represent less than 0.000008 Mbps",
+		},
+		{
 			name:      "valid very small decimal value 0.001",
 			value:     "0.001",
 			fieldName: "rateMax",
@@ -78,10 +92,11 @@ func TestValidateRateValue(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "empty value allowed",
+			name:      "empty value is rejected",
 			value:     "",
 			fieldName: "rateMax",
-			wantErr:   false,
+			wantErr:   true,
+			errMsg:    "must not be empty",
 		},
 		{
 			name:      "invalid - contains unit suffix",
@@ -191,6 +206,16 @@ func TestValidateIPMatchValue(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "host bits in prefix are rejected",
+			matchValue: "src 192.168.1.1/24",
+			want:       false,
+		},
+		{
+			name:       "IPv6 is rejected",
+			matchValue: "src 2001:db8::/64",
+			want:       false,
+		},
+		{
 			name:       "valid dst with IPv4 CIDR /32",
 			matchValue: "dst 10.0.0.1/32",
 			want:       true,
@@ -203,16 +228,6 @@ func TestValidateIPMatchValue(t *testing.T) {
 		{
 			name:       "valid dst with IPv4 subnet",
 			matchValue: "dst 10.0.0.0/8",
-			want:       true,
-		},
-		{
-			name:       "valid src with IPv6 CIDR",
-			matchValue: "src 2001:db8::1/128",
-			want:       true,
-		},
-		{
-			name:       "valid dst with IPv6 subnet",
-			matchValue: "dst 2001:db8::/32",
 			want:       true,
 		},
 		{
@@ -362,11 +377,13 @@ func TestDiffQoSPolicyBandwidthLimitRules(t *testing.T) {
 			newList: kubeovnv1.QoSPolicyBandwidthLimitRules{
 				{Name: "rule1", RateMax: "100", BurstMax: "10", Direction: "ingress"},
 			},
-			wantAdded:   kubeovnv1.QoSPolicyBandwidthLimitRules{},
-			wantDeleted: kubeovnv1.QoSPolicyBandwidthLimitRules{},
-			wantUpdated: kubeovnv1.QoSPolicyBandwidthLimitRules{
+			wantAdded: kubeovnv1.QoSPolicyBandwidthLimitRules{
 				{Name: "rule1", RateMax: "100", BurstMax: "10", Direction: "ingress"},
 			},
+			wantDeleted: kubeovnv1.QoSPolicyBandwidthLimitRules{
+				{Name: "rule1", RateMax: "100", BurstMax: "10", Direction: "egress"},
+			},
+			wantUpdated: kubeovnv1.QoSPolicyBandwidthLimitRules{},
 		},
 		{
 			name: "complex scenario - add, delete, update",
@@ -398,11 +415,13 @@ func TestDiffQoSPolicyBandwidthLimitRules(t *testing.T) {
 			newList: kubeovnv1.QoSPolicyBandwidthLimitRules{
 				{Name: "rule1", RateMax: "100", MatchType: "ip", MatchValue: "dst 10.0.0.0/8"},
 			},
-			wantAdded:   kubeovnv1.QoSPolicyBandwidthLimitRules{},
-			wantDeleted: kubeovnv1.QoSPolicyBandwidthLimitRules{},
-			wantUpdated: kubeovnv1.QoSPolicyBandwidthLimitRules{
+			wantAdded: kubeovnv1.QoSPolicyBandwidthLimitRules{
 				{Name: "rule1", RateMax: "100", MatchType: "ip", MatchValue: "dst 10.0.0.0/8"},
 			},
+			wantDeleted: kubeovnv1.QoSPolicyBandwidthLimitRules{
+				{Name: "rule1", RateMax: "100", MatchType: "ip", MatchValue: "src 192.168.1.0/24"},
+			},
+			wantUpdated: kubeovnv1.QoSPolicyBandwidthLimitRules{},
 		},
 		{
 			name: "update rule with Interface change",
@@ -412,11 +431,13 @@ func TestDiffQoSPolicyBandwidthLimitRules(t *testing.T) {
 			newList: kubeovnv1.QoSPolicyBandwidthLimitRules{
 				{Name: "rule1", RateMax: "100", Interface: "net1"},
 			},
-			wantAdded:   kubeovnv1.QoSPolicyBandwidthLimitRules{},
-			wantDeleted: kubeovnv1.QoSPolicyBandwidthLimitRules{},
-			wantUpdated: kubeovnv1.QoSPolicyBandwidthLimitRules{
+			wantAdded: kubeovnv1.QoSPolicyBandwidthLimitRules{
 				{Name: "rule1", RateMax: "100", Interface: "net1"},
 			},
+			wantDeleted: kubeovnv1.QoSPolicyBandwidthLimitRules{
+				{Name: "rule1", RateMax: "100", Interface: "eth0"},
+			},
+			wantUpdated: kubeovnv1.QoSPolicyBandwidthLimitRules{},
 		},
 		{
 			name: "update rule with Priority change",
@@ -426,11 +447,13 @@ func TestDiffQoSPolicyBandwidthLimitRules(t *testing.T) {
 			newList: kubeovnv1.QoSPolicyBandwidthLimitRules{
 				{Name: "rule1", RateMax: "100", Priority: 2},
 			},
-			wantAdded:   kubeovnv1.QoSPolicyBandwidthLimitRules{},
-			wantDeleted: kubeovnv1.QoSPolicyBandwidthLimitRules{},
-			wantUpdated: kubeovnv1.QoSPolicyBandwidthLimitRules{
+			wantAdded: kubeovnv1.QoSPolicyBandwidthLimitRules{
 				{Name: "rule1", RateMax: "100", Priority: 2},
 			},
+			wantDeleted: kubeovnv1.QoSPolicyBandwidthLimitRules{
+				{Name: "rule1", RateMax: "100", Priority: 1},
+			},
+			wantUpdated: kubeovnv1.QoSPolicyBandwidthLimitRules{},
 		},
 		{
 			name:    "multiple adds",
@@ -593,9 +616,10 @@ func TestValidateDirection(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "empty direction allowed",
+			name:      "empty direction is rejected",
 			direction: "",
-			wantErr:   false,
+			wantErr:   true,
+			errMsg:    "must be 'ingress' or 'egress'",
 		},
 		{
 			name:      "invalid - arbitrary string",
@@ -747,6 +771,171 @@ func TestValidateQosPolicy(t *testing.T) {
 			},
 		},
 		{
+			name:      "unknown binding type is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{BindingType: "unknown"}},
+			errMsg:    "invalid binding type",
+		},
+		{
+			name: "duplicate rule name is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeNatGw,
+				Shared:      true,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{
+					{Name: "duplicate", RateMax: "1", BurstMax: "1", Direction: kubeovnv1.QoSDirectionIngress},
+					{Name: "duplicate", RateMax: "2", BurstMax: "2", Direction: kubeovnv1.QoSDirectionEgress},
+				},
+			}},
+			errMsg: "duplicate bandwidth rule name",
+		},
+		{
+			name: "eip duplicate direction is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeEIP,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{
+					{Name: "first", RateMax: "1", BurstMax: "1", Direction: kubeovnv1.QoSDirectionIngress},
+					{Name: "second", RateMax: "2", BurstMax: "2", Direction: kubeovnv1.QoSDirectionIngress},
+				},
+			}},
+			errMsg: "duplicates direction",
+		},
+		{
+			name: "natgw normalized duplicate identity is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeNatGw,
+				Shared:      true,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{
+					{Name: "default-interface", RateMax: "1", BurstMax: "1", Direction: kubeovnv1.QoSDirectionEgress},
+					{Name: "explicit-interface", Interface: "net1", RateMax: "2", BurstMax: "2", Direction: kubeovnv1.QoSDirectionEgress},
+				},
+			}},
+			errMsg: "duplicates an existing rule identity",
+		},
+		{
+			name: "natgw matchall value does not distinguish identity",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeNatGw,
+				Shared:      true,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{
+					{Name: "first", RateMax: "1", BurstMax: "1", Direction: kubeovnv1.QoSDirectionEgress, MatchValue: "ignored-1"},
+					{Name: "second", RateMax: "2", BurstMax: "2", Direction: kubeovnv1.QoSDirectionEgress, MatchValue: "ignored-2"},
+				},
+			}},
+			errMsg: "matchValue must be empty",
+		},
+		{
+			name: "natgw same direction with different priority is valid",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeNatGw,
+				Shared:      true,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{
+					{Name: "first", RateMax: "1", BurstMax: "1", Priority: 1, Direction: kubeovnv1.QoSDirectionEgress},
+					{Name: "second", RateMax: "2", BurstMax: "2", Priority: 2, Direction: kubeovnv1.QoSDirectionEgress},
+				},
+			}},
+		},
+		{
+			name: "natgw matchall priority wraps to the same identity",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeNatGw,
+				Shared:      true,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{
+					{Name: "first", RateMax: "1", BurstMax: "1", Priority: 1, Direction: kubeovnv1.QoSDirectionEgress},
+					{Name: "second", RateMax: "2", BurstMax: "2", Priority: 256, Direction: kubeovnv1.QoSDirectionEgress},
+				},
+			}},
+			errMsg: "duplicates an existing rule identity",
+		},
+		{
+			name: "zero priority is rejected for natgw ip match",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeNatGw,
+				Shared:      true,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{
+					Name: "rule", RateMax: "1", BurstMax: "1", Direction: kubeovnv1.QoSDirectionEgress,
+					MatchType: kubeovnv1.QoSMatchTypeIP, MatchValue: "src 192.0.2.0/24",
+				}},
+			}},
+			errMsg: "priority must be greater than zero",
+		},
+		{
+			name: "priority above tc limit is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeEIP,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{
+					Name: "rule", RateMax: "1", BurstMax: "1", Priority: 65536, Direction: kubeovnv1.QoSDirectionIngress,
+				}},
+			}},
+			errMsg: "must be between 0 and 65535",
+		},
+		{
+			name: "negative priority is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{
+				Spec: kubeovnv1.QoSPolicySpec{
+					BindingType: kubeovnv1.QoSBindingTypeEIP,
+					BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{
+						Name: "rule", RateMax: "1", BurstMax: "1", Priority: -1, Direction: kubeovnv1.QoSDirectionIngress,
+					}},
+				},
+			},
+			errMsg: "must be between 0 and 65535",
+		},
+		{
+			name: "empty direction is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType:         kubeovnv1.QoSBindingTypeEIP,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{Name: "rule", RateMax: "1", BurstMax: "1"}},
+			}},
+			errMsg: "invalid direction",
+		},
+		{
+			name: "empty rate is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType:         kubeovnv1.QoSBindingTypeEIP,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{Name: "rule", BurstMax: "1", Direction: kubeovnv1.QoSDirectionIngress}},
+			}},
+			errMsg: "rateMax must not be empty",
+		},
+		{
+			name: "empty burst is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType:         kubeovnv1.QoSBindingTypeEIP,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{Name: "rule", RateMax: "1", Direction: kubeovnv1.QoSDirectionIngress}},
+			}},
+			errMsg: "burstMax must not be empty",
+		},
+		{
+			name: "match value without match type is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeNatGw,
+				Shared:      true,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{
+					Name: "rule", RateMax: "1", BurstMax: "1", Direction: kubeovnv1.QoSDirectionIngress, MatchValue: "src 192.0.2.0/24",
+				}},
+			}},
+			errMsg: "matchValue must be empty",
+		},
+		{
+			name: "eip match fields are rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeEIP,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{
+					Name: "rule", Interface: "net1", RateMax: "1", BurstMax: "1", Direction: kubeovnv1.QoSDirectionIngress,
+				}},
+			}},
+			errMsg: "not supported for EIP binding",
+		},
+		{
+			name: "unknown match type is rejected",
+			qosPolicy: &kubeovnv1.QoSPolicy{Spec: kubeovnv1.QoSPolicySpec{
+				BindingType: kubeovnv1.QoSBindingTypeNatGw,
+				Shared:      true,
+				BandwidthLimitRules: kubeovnv1.QoSPolicyBandwidthLimitRules{{
+					Name: "rule", RateMax: "1", BurstMax: "1", Direction: kubeovnv1.QoSDirectionIngress, MatchType: "unknown",
+				}},
+			}},
+			errMsg: "invalid match type",
+		},
+		{
 			name: "invalid rate is rejected",
 			qosPolicy: &kubeovnv1.QoSPolicy{
 				Name: "qos-invalid-rate",
@@ -772,6 +961,7 @@ func TestValidateQosPolicy(t *testing.T) {
 						Name:       "net1-extip-egress",
 						RateMax:    "25",
 						BurstMax:   "25",
+						Priority:   1,
 						Direction:  kubeovnv1.QoSDirectionEgress,
 						MatchType:  kubeovnv1.QoSMatchTypeIP,
 						MatchValue: "dst 172.20.0.24",
@@ -820,6 +1010,134 @@ func eipQoSRules(rate string) kubeovnv1.QoSPolicyBandwidthLimitRules {
 	}
 }
 
+func TestEnqueueQoSPolicyReferences(t *testing.T) {
+	eipPolicy := &kubeovnv1.QoSPolicy{
+		Name:   "eip-qos",
+		Spec:   kubeovnv1.QoSPolicySpec{BindingType: kubeovnv1.QoSBindingTypeEIP},
+		Status: kubeovnv1.QoSPolicyStatus{BindingType: kubeovnv1.QoSBindingTypeEIP},
+	}
+	gwPolicy := &kubeovnv1.QoSPolicy{
+		Name:   "gw-qos",
+		Spec:   kubeovnv1.QoSPolicySpec{BindingType: kubeovnv1.QoSBindingTypeNatGw},
+		Status: kubeovnv1.QoSPolicyStatus{BindingType: kubeovnv1.QoSBindingTypeNatGw},
+	}
+	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		QoSPolicies: []*kubeovnv1.QoSPolicy{eipPolicy, gwPolicy},
+		IptablesEips: []*kubeovnv1.IptablesEIP{
+			{Name: "bound-eip", Spec: kubeovnv1.IptablesEIPSpec{NatGwDp: "eip-gw", QoSPolicy: eipPolicy.Name}},
+			{Name: "other-eip"},
+		},
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{
+			{Name: "bound-gw", Spec: kubeovnv1.VpcNatGatewaySpec{QoSPolicy: gwPolicy.Name}},
+			{Name: "other-gw"},
+		},
+	})
+	require.NoError(t, err)
+	ctrl := fakeCtrl.fakeController
+	ctrl.updateQoSPolicyQueue = newTypedRateLimitingQueue[string]("UpdateQoSPolicy", nil)
+
+	oldEIPPolicy := eipPolicy.DeepCopy()
+	oldEIPPolicy.Status = kubeovnv1.QoSPolicyStatus{}
+	partialEIPPolicy := eipPolicy.DeepCopy()
+	partialEIPPolicy.Status.BindingType = ""
+	ctrl.enqueueUpdateQoSPolicy(oldEIPPolicy, partialEIPPolicy)
+	require.Zero(t, ctrl.updateIptablesEipQueue.Len())
+
+	ctrl.enqueueUpdateQoSPolicy(partialEIPPolicy, eipPolicy)
+	// The referencing EIP is woken, not its gateway: one EIP that cannot apply the
+	// policy must not hold up the gateway initialization of the others.
+	require.Equal(t, 1, ctrl.updateIptablesEipQueue.Len())
+	require.Zero(t, ctrl.addOrUpdateVpcNatGatewayQueue.Len())
+
+	oldGWPolicy := gwPolicy.DeepCopy()
+	oldGWPolicy.Status = kubeovnv1.QoSPolicyStatus{}
+	ctrl.enqueueUpdateQoSPolicy(oldGWPolicy, gwPolicy)
+	require.Equal(t, 1, ctrl.addOrUpdateVpcNatGatewayQueue.Len())
+
+	for ctrl.updateIptablesEipQueue.Len() != 0 {
+		item, _ := ctrl.updateIptablesEipQueue.Get()
+		ctrl.updateIptablesEipQueue.Done(item)
+		ctrl.updateIptablesEipQueue.Forget(item)
+	}
+	ctrl.enqueueUpdateQoSPolicy(eipPolicy, eipPolicy.DeepCopy())
+	require.Zero(t, ctrl.updateIptablesEipQueue.Len())
+	require.Zero(t, ctrl.initVpcNatGatewayQueue.Len())
+}
+
+func TestEnqueueQoSPolicyReleaseWaitsForAppliedStatus(t *testing.T) {
+	ctrl := &Controller{updateQoSPolicyQueue: newTypedRateLimitingQueue[string]("UpdateQoSPolicy", nil)}
+	t.Cleanup(ctrl.updateQoSPolicyQueue.ShutDown)
+
+	ctrl.enqueueQoSPolicyRelease("old-qos", "old-qos", "", "old-qos")
+	require.Zero(t, ctrl.updateQoSPolicyQueue.Len())
+
+	ctrl.enqueueQoSPolicyRelease("", "old-qos", "", "")
+	require.Equal(t, 1, ctrl.updateQoSPolicyQueue.Len())
+}
+
+func TestDeletingQoSPolicyKeepsFinalizerWhileReferenced(t *testing.T) {
+	tests := []struct {
+		name        string
+		bindingType kubeovnv1.QoSPolicyBindingType
+		eip         *kubeovnv1.IptablesEIP
+	}{
+		{name: "desired spec reference", bindingType: kubeovnv1.QoSBindingTypeEIP, eip: &kubeovnv1.IptablesEIP{
+			Name: "pending-eip", Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: "terminating-qos"},
+		}},
+		{name: "applied status credential", bindingType: kubeovnv1.QoSBindingTypeEIP, eip: &kubeovnv1.IptablesEIP{
+			Name: "cleaning-eip", Status: kubeovnv1.IptablesEIPStatus{QoSPolicy: "terminating-qos"},
+		}},
+		{name: "binding type drift", bindingType: kubeovnv1.QoSBindingTypeNatGw, eip: &kubeovnv1.IptablesEIP{
+			Name: "old-eip", Status: kubeovnv1.IptablesEIPStatus{QoSPolicy: "terminating-qos"},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := metav1.Now()
+			qos := &kubeovnv1.QoSPolicy{
+				Name:              "terminating-qos",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{util.KubeOVNControllerFinalizer},
+				Spec:              kubeovnv1.QoSPolicySpec{BindingType: tt.bindingType},
+			}
+			fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				QoSPolicies: []*kubeovnv1.QoSPolicy{qos}, IptablesEips: []*kubeovnv1.IptablesEIP{tt.eip},
+			})
+			require.NoError(t, err)
+
+			require.NoError(t, fakeCtrl.fakeController.handleUpdateQoSPolicy(qos.Name))
+			got, err := fakeCtrl.fakeController.config.KubeOvnClient.KubeovnV1().QoSPolicies().Get(
+				context.Background(), qos.Name, metav1.GetOptions{},
+			)
+			require.NoError(t, err)
+			require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+		})
+	}
+}
+
+func TestDeletingNatGwQoSPolicyKeepsFinalizerForAppliedStatus(t *testing.T) {
+	now := metav1.Now()
+	qos := &kubeovnv1.QoSPolicy{
+		Name: "terminating-qos", DeletionTimestamp: &now,
+		Finalizers: []string{util.KubeOVNControllerFinalizer},
+		Spec:       kubeovnv1.QoSPolicySpec{BindingType: kubeovnv1.QoSBindingTypeNatGw},
+	}
+	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		QoSPolicies: []*kubeovnv1.QoSPolicy{qos},
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{{
+			Name: "cleaning-gateway", Status: kubeovnv1.VpcNatGatewayStatus{QoSPolicy: qos.Name},
+		}},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, fakeCtrl.fakeController.handleUpdateQoSPolicy(qos.Name))
+	got, err := fakeCtrl.fakeController.config.KubeOvnClient.KubeovnV1().QoSPolicies().Get(
+		context.Background(), qos.Name, metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+}
+
 func TestHandleUpdateQoSPolicy(t *testing.T) {
 	// A shared QoS policy (which a NAT gateway bound policy always is, see validateQosPolicy)
 	// does not support changing its bandwidth limit rules: the limits of a NAT gateway can only
@@ -851,11 +1169,14 @@ func TestHandleUpdateQoSPolicy(t *testing.T) {
 	for _, name := range []string{"eip-1", "eip-2"} {
 		eips = append(eips, &kubeovnv1.IptablesEIP{
 			Name:   name,
-			Labels: map[string]string{util.QoSLabel: multiEIPQoS.Name},
 			Spec:   kubeovnv1.IptablesEIPSpec{QoSPolicy: multiEIPQoS.Name},
 			Status: kubeovnv1.IptablesEIPStatus{IP: "172.20.0.10"},
 		})
 	}
+	// The second EIP has released its desired reference but still owns applied
+	// data-plane state, so the unshared policy remains claimed until cleanup.
+	eips[1].Spec.QoSPolicy = ""
+	eips[1].Status.QoSPolicy = multiEIPQoS.Name
 
 	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		QoSPolicies:  []*kubeovnv1.QoSPolicy{sharedNatGwQoS, unboundEIPQoS, multiEIPQoS, unchangedQoS, sharedChangedQoS},

--- a/pkg/controller/service_cidr.go
+++ b/pkg/controller/service_cidr.go
@@ -115,9 +115,9 @@ func (c *Controller) onServiceCIDRDelete(obj any) {
 // against the freshly merged set.
 //
 // VpcNatGateways are deliberately skipped: handleAddOrUpdateVpcNatGw only diffs
-// Spec, and handleInitVpcNatGw bails on VpcNatGatewayInitAnnotation. Existing
-// NAT GWs need pod recreation to pick up new routes; new ones already render
-// against the current store.
+// Spec, and the gateway init script re-runs as a no-op once its chains exist.
+// Existing NAT GWs need pod recreation to pick up new routes; new ones already
+// render against the current store.
 func (c *Controller) reconcileForServiceCIDRChange() {
 	subnets, err := c.subnetsLister.List(labels.Everything())
 	if err != nil {

--- a/pkg/controller/vpc_nat_gateway.go
+++ b/pkg/controller/vpc_nat_gateway.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,7 +38,6 @@ import (
 var (
 	vpcNatEnabled   = "unknown"
 	VpcNatCmVersion = ""
-	natGwCreatedAT  = ""
 )
 
 const (
@@ -155,9 +155,8 @@ func (c *Controller) enqueueUpdateVpcNatGw(oldObj, newObj any) {
 	klog.V(3).Infof("enqueue update vpc-nat-gw %s", key)
 	c.addOrUpdateVpcNatGatewayQueue.Add(key)
 
-	// When the QoSLabel is cleared or switched, re-enqueue the previous QoS policy so it can drop
-	// its finalizer once unused (the in-use check is keyed on the label).
-	c.enqueueQoSPolicyRelease(oldGw.Labels, newGw.Labels)
+	c.enqueueQoSPolicyRelease(oldGw.Spec.QoSPolicy, oldGw.Status.QoSPolicy,
+		newGw.Spec.QoSPolicy, newGw.Status.QoSPolicy)
 }
 
 func (c *Controller) enqueueDeleteVpcNatGw(obj any) {
@@ -187,9 +186,8 @@ func (c *Controller) enqueueDeleteVpcNatGw(obj any) {
 	klog.V(3).Infof("enqueue del vpc-nat-gw %s", key)
 	c.delVpcNatGatewayQueue.Add(key)
 
-	// Trigger QoS Policy reconcile after NatGw is deleted so it can drop its finalizer if no
-	// other NatGw references it. Key on the QoSLabel, matching the QoS in-use check.
-	c.enqueueQoSPolicyRelease(gw.Labels, nil)
+	// Trigger QoS reconciliation after the informer cache drops this gateway.
+	c.enqueueQoSPolicyRelease(gw.Spec.QoSPolicy, gw.Status.QoSPolicy, "", "")
 }
 
 // handleDelVpcNatGw handles NAT gateways when they've been deleted
@@ -318,29 +316,28 @@ func natGwWorkloadLabelsChanged(current, desired map[string]string) bool {
 // handleAddOrUpdateVpcNatGw is called when a VPC NAT gateway is added or updated.
 // If a VPC NAT gateway is deleted, the deletionTimestamp will be updated and this function will also be called.
 func (c *Controller) handleAddOrUpdateVpcNatGw(key string) (retErr error) {
+	c.vpcNatGwKeyMutex.LockKey(key)
 	gw, err := c.vpcNatGatewayLister.Get(key)
 	if err != nil {
+		_ = c.vpcNatGwKeyMutex.UnlockKey(key)
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
-		klog.Error(err)
-		_ = c.recordResourceError(&kubeovnv1.VpcNatGateway{Name: key},
-			"GetVpcNatGatewayFailed", err)
+		_ = c.recordResourceError(&kubeovnv1.VpcNatGateway{Name: key}, "GetVpcNatGatewayFailed", err)
 		return err
 	}
-
-	statusUpdateFailed := false
 	if !gw.DeletionTimestamp.IsZero() {
+		_ = c.vpcNatGwKeyMutex.UnlockKey(key)
 		return c.handleDelVpcNatGw(key)
 	}
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
+
+	statusUpdateFailed := false
 	defer func() {
 		if retErr != nil && !statusUpdateFailed {
 			_ = c.recordResourceError(gw, "ReconcileFailed", retErr)
 		}
 	}()
-
-	c.vpcNatGwKeyMutex.LockKey(key)
-	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
 
 	if err := c.handleAddVpcNatGwFinalizer(gw); err != nil {
 		klog.Errorf("failed to add vpc nat gateway finalizer for %s: %v", key, err)
@@ -372,16 +369,6 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) (retErr error) {
 		klog.Error(err)
 		return err
 	}
-	var natGwPodContainerRestartCount int32
-	for _, pod := range pods {
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.Name == "vpc-nat-gw" {
-				natGwPodContainerRestartCount = max(natGwPodContainerRestartCount, containerStatus.RestartCount)
-			}
-		}
-	}
-	needRestartRecovery := natGwPodContainerRestartCount > 0
-
 	// Choose between Deployment (HA mode) or StatefulSet (legacy mode)
 	if util.IsNatGwHAMode(gw) {
 		// HA mode: use Deployment
@@ -471,7 +458,7 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) (retErr error) {
 		}
 		gwChanged := isVpcNatGwChanged(gw)
 
-		newSts, err := c.genNatGwStatefulSet(gw, oldSts, natGwPodContainerRestartCount)
+		newSts, err := c.genNatGwStatefulSet(gw)
 		if err != nil {
 			klog.Error(err)
 			return err
@@ -515,7 +502,7 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) (retErr error) {
 		labelsChanged := natGwWorkloadLabelsChanged(oldSts.Labels, newSts.Labels)
 		// WARNING: This will update STS template directly, which triggers NAT GW Pod recreation.
 		// TODO: support hot update of runtime Pod annotations directly via patch
-		if gwChanged || templateChanged || labelsChanged || needRestartRecovery {
+		if gwChanged || templateChanged || labelsChanged {
 			// Update the stored workload in place so that owner references and metadata set
 			// by third parties survive; only the spec is owned by this controller.
 			updatedSts := oldSts.DeepCopy()
@@ -544,17 +531,21 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) (retErr error) {
 
 	// Handle QoS update (independent of StatefulSet/Deployment changes)
 	if gw.Spec.QoSPolicy != gw.Status.QoSPolicy {
-		if gw.Status.QoSPolicy != "" {
-			if err = c.execNatGwQoS(gw, gw.Status.QoSPolicy, QoSDel); err != nil {
-				klog.Errorf("failed to del qos for nat gw %s, %v", key, err)
-				return err
+		if err = c.withNatGwQoSLock(gw.Name, func() error {
+			if gw.Status.QoSPolicy != "" {
+				if err = c.execNatGwQoSLocked(gw, gw.Status.QoSPolicy, QoSDel); err != nil {
+					return fmt.Errorf("failed to del qos for nat gw %s: %w", gw.Name, err)
+				}
 			}
-		}
-		if gw.Spec.QoSPolicy != "" {
-			if err = c.execNatGwQoS(gw, gw.Spec.QoSPolicy, QoSAdd); err != nil {
-				klog.Errorf("failed to add qos for nat gw %s, %v", key, err)
-				return err
+			if gw.Spec.QoSPolicy != "" {
+				if err = c.execNatGwQoSLocked(gw, gw.Spec.QoSPolicy, QoSAdd); err != nil {
+					return fmt.Errorf("failed to add qos for nat gw %s: %w", gw.Name, err)
+				}
 			}
+			return nil
+		}); err != nil {
+			klog.Error(err)
+			return err
 		}
 		if err := c.updateCrdNatGwLabels(key, gw.Spec.QoSPolicy); err != nil {
 			err := fmt.Errorf("failed to update nat gw %s: %w", gw.Name, err)
@@ -593,27 +584,33 @@ func (c *Controller) handleAddOrUpdateVpcNatGw(key string) (retErr error) {
 //
 // The order matters: stage 1 closes the window in which a Pod recreation could pick a
 // different address, and it must not be held up by stage 2, which legitimately fails on its
-// first attempts. Both stages are idempotent, stage 1 through the preconditions of its JSON
-// patch and stage 2 through the init annotation it sets on each Pod.
+// first attempts. Both stages are idempotent: stage 1 through the preconditions of its JSON
+// patch and stage 2 through the script operations. The init annotation only records completion.
 //
 // This is a separate work queue rather than a step of handleAddOrUpdateVpcNatGw because the
 // exec takes seconds and its unit of work is a Pod instance rather than the gateway
 // generation, so it needs its own back-off, and a flapping exec must not block the gateway
 // reconcile. The two never interleave for one gateway because both take vpcNatGwKeyMutex.
 func (c *Controller) handleInitVpcNatGw(key string) (retErr error) {
+	c.vpcNatGwKeyMutex.LockKey(key)
+	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
+	klog.Infof("handle init vpc nat gateway %s", key)
+
+	// The queue item may have waited behind a gateway update. Read from the
+	// informer after taking the shared lock so initialization cannot restore the
+	// object captured before it waited.
 	gw, err := c.vpcNatGatewayLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
-		klog.Error(err)
-		_ = c.recordResourceError(&kubeovnv1.VpcNatGateway{Name: key},
-			"GetVpcNatGatewayFailed", err)
+		_ = c.recordResourceError(&kubeovnv1.VpcNatGateway{Name: key}, "GetVpcNatGatewayFailed", err)
 		return err
 	}
 	statusUpdateFailed := false
+	initWaitingForPod := false
 	defer func() {
-		if retErr != nil && !statusUpdateFailed {
+		if retErr != nil && !statusUpdateFailed && !initWaitingForPod {
 			_ = c.recordResourceError(gw, "InitializeFailed", retErr)
 		}
 	}()
@@ -621,10 +618,6 @@ func (c *Controller) handleInitVpcNatGw(key string) (retErr error) {
 	if vpcNatEnabled != "true" {
 		return errors.New("iptables nat gw not enable")
 	}
-
-	c.vpcNatGwKeyMutex.LockKey(key)
-	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(key) }()
-	klog.Infof("handle init vpc nat gateway %s", key)
 
 	// Stage 1: reconcile the status, which pins the allocated address. patchNatGwStatus is
 	// reused as a whole rather than reduced to the pinning: persistNatGwLanIP is guarded by a
@@ -647,22 +640,45 @@ func (c *Controller) handleInitVpcNatGw(key string) (retErr error) {
 	// Stage 2: configure the Pods themselves.
 	// subnet for vpc-nat-gw has been checked when create vpc-nat-gw
 
-	pods, err := c.getNatGwPods(key, c.natGwNamespace(gw), true)
+	// Read the Pods live: after a replacement the informer cache can still return the previous
+	// instance together with the completion annotation it carries, which would make this handler
+	// skip a Pod that is in fact not initialized yet.
+	pods, err := c.listNatGwPods(gw)
 	if err != nil {
 		err := fmt.Errorf("failed to get nat gw %s pods: %w", gw.Name, err)
 		klog.Error(err)
 		return err
 	}
 
-	for _, pod := range pods {
-		if _, hasInit := pod.Annotations[util.VpcNatGatewayInitAnnotation]; hasInit {
+	// A terminating Pod cannot be initialized and its replacement may not be visible yet.
+	// Reporting success here would leave that replacement uninitialized until an unrelated
+	// event re-runs this handler, which is what leaves a recreated gateway without any
+	// data-plane state.
+	initTargets := natGwInitTargets(pods)
+	if natGwInitPending(gw, initTargets) {
+		// The replacement Pod is not available yet. This is a retry, not a gateway failure,
+		// so it is not recorded as a resource error.
+		initWaitingForPod = true
+		return fmt.Errorf("nat gateway %s has no live pod to initialize, will retry", key)
+	}
+	if len(initTargets) == 0 {
+		// The gateway is being deleted: there is nothing left to initialize.
+		return nil
+	}
+
+	// The init script is re-run on every reconcile: it exits early once its
+	// iptables chains exist, but it first rewrites the interface configuration it
+	// persists, which a restarted vpc-nat-gw container loses with its writable layer.
+	// A pod that is not running yet is not skipped: the failing exec is what
+	// requeues this handler, since a Pending->Running transition raises no init
+	// event of its own.
+	for _, pod := range initTargets {
+		if !natGwPodPendingInit(pod) {
+			// Already initialized on this instance. Upstream skipped these Pods, and the
+			// completion mark now carries the instance identity, so a restart or replacement
+			// still re-runs the command.
 			continue
 		}
-		last, _ := time.Parse("2006-01-02T15:04:05", natGwCreatedAT)
-		if pod.CreationTimestamp.Unix() > last.Unix() {
-			natGwCreatedAT = pod.CreationTimestamp.Format("2006-01-02T15:04:05")
-		}
-		klog.V(3).Infof("nat gw pod '%s/%s' inited at %s", pod.Namespace, pod.Name, natGwCreatedAT)
 		// During initialization, when KubeOVN is running on non primary cni mode, we need to ensure the NAT gateway interfaces
 		// are properly configured. We extract the interfaces from the runtime Pod annotations (network-status).
 		var interfaces []string
@@ -718,12 +734,8 @@ func (c *Controller) handleInitVpcNatGw(key string) (retErr error) {
 			return fmt.Errorf("failed to init vpc nat gateway, %w", err)
 		}
 	}
-
-	if gw.Spec.QoSPolicy != "" {
-		if err = c.execNatGwQoS(gw, gw.Spec.QoSPolicy, QoSAdd); err != nil {
-			klog.Errorf("failed to add qos for nat gw %s, %v", key, err)
-			return err
-		}
+	if err = c.restoreVpcNatGwQoS(gw); err != nil {
+		return err
 	}
 	// if update qos success, will update nat gw status
 	if gw.Spec.QoSPolicy != gw.Status.QoSPolicy {
@@ -741,25 +753,95 @@ func (c *Controller) handleInitVpcNatGw(key string) (retErr error) {
 		return err
 	}
 
-	c.updateVpcFloatingIPQueue.Add(key)
-	c.updateVpcDnatQueue.Add(key)
-	c.updateVpcSnatQueue.Add(key)
-	c.updateVpcSubnetQueue.Add(key)
-	c.updateVpcEipQueue.Add(key)
-
-	for _, pod := range pods {
-		if _, hasInit := pod.Annotations[util.VpcNatGatewayInitAnnotation]; hasInit {
+	for _, pod := range initTargets {
+		instanceToken := natGwPodInstanceToken(pod)
+		hasInit := pod.Annotations[util.VpcNatGatewayInitAnnotation] == "true"
+		// The exec runs against the container by name, so the init command can succeed while the
+		// cached Pod still reports its previous status. Record completion in that case too, and
+		// let the next attempt attach the instance token once the status is observed.
+		if hasInit && (instanceToken == "" ||
+			pod.Annotations[util.VpcNatGatewayInitInstanceAnnotation] == instanceToken) {
 			continue
 		}
-
 		patch := util.KVPatch{util.VpcNatGatewayInitAnnotation: "true"}
+		if instanceToken != "" {
+			patch[util.VpcNatGatewayInitInstanceAnnotation] = instanceToken
+		}
 		if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(pod.Namespace), pod.Name, patch); err != nil {
 			err := fmt.Errorf("failed to patch pod %s/%s: %w", pod.Namespace, pod.Name, err)
 			klog.Error(err)
 			return err
 		}
 	}
+
+	// A previous attempt on a replaced Pod may have left these queues in back-off, which delays
+	// the data-plane restore far beyond the Pod becoming ready. Forget the failure counts so the
+	// redo runs as soon as this initialization succeeded.
+	c.updateVpcFloatingIPQueue.Forget(key)
+	c.updateVpcDnatQueue.Forget(key)
+	c.updateVpcSnatQueue.Forget(key)
+	c.updateVpcSubnetQueue.Forget(key)
+	c.updateVpcEipQueue.Forget(key)
+
+	c.updateVpcFloatingIPQueue.Add(key)
+	c.updateVpcDnatQueue.Add(key)
+	c.updateVpcSnatQueue.Add(key)
+	c.updateVpcSubnetQueue.Add(key)
+	c.updateVpcEipQueue.Add(key)
 	return nil
+}
+
+// natGwInitTargets returns the gateway Pods the init command can be run on. A Pod that is
+// terminating is excluded: its replacement takes over the same address, and the gateway is
+// not initialized until that replacement has been configured.
+func natGwInitTargets(pods []*corev1.Pod) []*corev1.Pod {
+	targets := make([]*corev1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		targets = append(targets, pod)
+	}
+	return targets
+}
+
+// natGwInitPending reports whether the init handler has to come back later because the
+// gateway still exists but has no Pod to run the init command on. The terminating Pod is
+// gone before its replacement is visible, so this gap is expected.
+func natGwInitPending(gw *kubeovnv1.VpcNatGateway, targets []*corev1.Pod) bool {
+	return len(targets) == 0 && gw.DeletionTimestamp.IsZero()
+}
+
+// natGwPodInstanceToken identifies the running vpc-nat-gw container instance of one Pod. A
+// recreated Pod has a new UID and a restarted container a new ContainerID, and both lose the
+// state the init command writes, so the token covers both. An empty token means the container
+// is not running and the Pod cannot be initialized right now.
+func natGwPodInstanceToken(pod *corev1.Pod) string {
+	if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+		return ""
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == "vpc-nat-gw" && status.State.Running != nil && status.ContainerID != "" {
+			return fmt.Sprintf("%x", sha256.Sum256([]byte(string(pod.UID)+"="+status.ContainerID)))
+		}
+	}
+	return ""
+}
+
+// restoreVpcNatGwQoS re-applies the gateway policy on a (re)created gateway pod.
+// EIP policies are not part of this restore: they own a per-EIP redo credential
+// (handleUpdateVpcEip) and reconcile from their own queue, so one EIP that cannot
+// be applied cannot hold up the initialization of its gateway.
+func (c *Controller) restoreVpcNatGwQoS(gw *kubeovnv1.VpcNatGateway) error {
+	if gw.Spec.QoSPolicy == "" {
+		return nil
+	}
+	return c.withNatGwQoSLock(gw.Name, func() error {
+		if err := c.execNatGwQoSLocked(gw, gw.Spec.QoSPolicy, QoSAdd); err != nil {
+			return fmt.Errorf("failed to restore QoS for nat gateway %s: %w", gw.Name, err)
+		}
+		return nil
+	})
 }
 
 func (c *Controller) handleUpdateVpcFloatingIP(natGwKey string) error {
@@ -771,10 +853,8 @@ func (c *Controller) handleUpdateVpcFloatingIP(natGwKey string) error {
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
 	klog.Infof("handle update vpc fip %s", natGwKey)
 
-	// refresh exist fips
-	if err := c.initCreateAt(natGwKey); err != nil {
-		err = fmt.Errorf("failed to init nat gw pod '%s' create at, %w", natGwKey, err)
-		klog.Error(err)
+	redoToken, err := c.natGwRedoToken(natGwKey)
+	if err != nil {
 		return err
 	}
 
@@ -786,9 +866,9 @@ func (c *Controller) handleUpdateVpcFloatingIP(natGwKey string) error {
 	}
 
 	for _, fip := range fips {
-		if fip.Status.Redo != natGwCreatedAT {
+		if fip.Status.Redo != redoToken {
 			klog.V(3).Infof("redo fip %s", fip.Name)
-			if err = c.redoFip(fip.Name, natGwCreatedAT, false); err != nil {
+			if err = c.redoFip(fip.Name, redoToken, false); err != nil {
 				klog.Errorf("failed to update eip '%s' to re-apply, %v", fip.Spec.EIP, err)
 				return err
 			}
@@ -806,25 +886,21 @@ func (c *Controller) handleUpdateVpcEip(natGwKey string) error {
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
 	klog.Infof("handle update vpc eip %s", natGwKey)
 
-	// refresh exist fips
-	if err := c.initCreateAt(natGwKey); err != nil {
-		err = fmt.Errorf("failed to init nat gw pod '%s' create at, %w", natGwKey, err)
-		klog.Error(err)
+	redoToken, err := c.natGwRedoToken(natGwKey)
+	if err != nil {
 		return err
 	}
 	eips, err := c.iptablesEipsLister.List(labels.Everything())
 	if err != nil {
-		err = fmt.Errorf("failed to get eip list, %w", err)
-		klog.Error(err)
-		return err
+		return fmt.Errorf("failed to get eip list: %w", err)
 	}
 	for _, eip := range eips {
-		if eip.Spec.NatGwDp == natGwKey && eip.Status.Redo != natGwCreatedAT {
-			klog.V(3).Infof("redo eip %s", eip.Name)
-			if err = c.patchEipStatus(eip.Name, "", natGwCreatedAT, "", false); err != nil {
-				klog.Errorf("failed to update eip '%s' to re-apply, %v", eip.Name, err)
-				return err
-			}
+		if eip.Spec.NatGwDp != natGwKey || !eip.DeletionTimestamp.IsZero() || eip.Status.Redo == redoToken {
+			continue
+		}
+		klog.V(3).Infof("redo eip %s", eip.Name)
+		if err = c.patchEipStatus(eip.Name, "", redoToken, "", false); err != nil {
+			return fmt.Errorf("failed to update eip %s for re-apply: %w", eip.Name, err)
 		}
 	}
 	return nil
@@ -839,10 +915,8 @@ func (c *Controller) handleUpdateVpcSnat(natGwKey string) error {
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
 	klog.Infof("handle update vpc snat %s", natGwKey)
 
-	// refresh exist snats
-	if err := c.initCreateAt(natGwKey); err != nil {
-		err = fmt.Errorf("failed to init nat gw pod '%s' create at, %w", natGwKey, err)
-		klog.Error(err)
+	redoToken, err := c.natGwRedoToken(natGwKey)
+	if err != nil {
 		return err
 	}
 	snats, err := c.iptablesSnatRulesLister.List(labels.SelectorFromSet(labels.Set{util.VpcNatGatewayNameLabel: natGwKey}))
@@ -852,9 +926,9 @@ func (c *Controller) handleUpdateVpcSnat(natGwKey string) error {
 		return err
 	}
 	for _, snat := range snats {
-		if snat.Status.Redo != natGwCreatedAT {
+		if snat.Status.Redo != redoToken {
 			klog.V(3).Infof("redo snat %s", snat.Name)
-			if err = c.redoSnat(snat.Name, natGwCreatedAT, false); err != nil {
+			if err = c.redoSnat(snat.Name, redoToken, false); err != nil {
 				err = fmt.Errorf("failed to update eip '%s' to re-apply, %w", snat.Spec.EIP, err)
 				klog.Error(err)
 				return err
@@ -873,10 +947,8 @@ func (c *Controller) handleUpdateVpcDnat(natGwKey string) error {
 	defer func() { _ = c.vpcNatGwKeyMutex.UnlockKey(natGwKey) }()
 	klog.Infof("handle update vpc dnat %s", natGwKey)
 
-	// refresh exist dnats
-	if err := c.initCreateAt(natGwKey); err != nil {
-		err = fmt.Errorf("failed to init nat gw pod '%s' create at, %w", natGwKey, err)
-		klog.Error(err)
+	redoToken, err := c.natGwRedoToken(natGwKey)
+	if err != nil {
 		return err
 	}
 
@@ -887,9 +959,9 @@ func (c *Controller) handleUpdateVpcDnat(natGwKey string) error {
 		return err
 	}
 	for _, dnat := range dnats {
-		if dnat.Status.Redo != natGwCreatedAT {
+		if dnat.Status.Redo != redoToken {
 			klog.V(3).Infof("redo dnat %s", dnat.Name)
-			if err = c.redoDnat(dnat.Name, natGwCreatedAT, false); err != nil {
+			if err = c.redoDnat(dnat.Name, redoToken, false); err != nil {
 				err := fmt.Errorf("failed to update dnat '%s' to redo, %w", dnat.Name, err)
 				klog.Error(err)
 				return err
@@ -1099,6 +1171,18 @@ func (c *Controller) handleUpdateNatGwSubnetRoute(natGwKey string) error {
 	return nil
 }
 
+// natGwPodInited asks the gateway whether this Pod holds the chains the data plane needs. The
+// script command's exit status is the answer, so no stderr text is interpreted here.
+func (c *Controller) natGwPodInited(pod *corev1.Pod) (bool, error) {
+	args := []string{"bash", "/kube-ovn/nat-gateway.sh", "check-inited"}
+	_, errOutput, err := util.ExecuteCommandInContainer(c.config.KubeClient, c.config.KubeRestConfig,
+		pod.Namespace, pod.Name, "vpc-nat-gw", args...)
+	if err != nil {
+		return false, fmt.Errorf("pod %s/%s is not initialized: %w: %s", pod.Namespace, pod.Name, err, errOutput)
+	}
+	return true, nil
+}
+
 func (c *Controller) execNatGwRules(pod *corev1.Pod, operation string, rules []string) error {
 	lockKey := fmt.Sprintf("nat-gw-exec:%s/%s", pod.Namespace, pod.Name)
 
@@ -1114,6 +1198,17 @@ func (c *Controller) execNatGwRules(pod *corev1.Pod, operation string, rules []s
 		if len(errOutput) > 0 {
 			klog.Errorf("NAT gateway command failed - stderr: %v", errOutput)
 		}
+		// The data plane just proved that this Pod is not initialized. Let that failure drive
+		// convergence instead of relying on a Pod event to re-run the init command.
+		// Ask the gateway itself whether it is initialized, through a command whose exit status
+		// is the answer: a failing data-plane command only proves that something is wrong, and
+		// its stderr is not an interface.
+		if inited, checkErr := c.natGwPodInited(pod); checkErr != nil || !inited {
+			if isGw, gwName := c.checkIsPodVpcNatGw(pod); isGw {
+				klog.Infof("nat gateway %s needs initialization (%v), requeuing it", gwName, checkErr)
+				c.initVpcNatGatewayQueue.Add(gwName)
+			}
+		}
 		if len(stdOutput) > 0 {
 			klog.Infof("NAT gateway command failed - stdout: %v", stdOutput)
 		}
@@ -1126,28 +1221,9 @@ func (c *Controller) execNatGwRules(pod *corev1.Pod, operation string, rules []s
 	}
 
 	if len(errOutput) > 0 {
-		// tc commands may output warnings to stderr (e.g., "Warning: sch_htb: quantum of class is big")
-		// Filter out lines that are only warnings, but preserve actual errors
-		lines := strings.Split(errOutput, "\n")
-		var errorLines []string
-		for _, line := range lines {
-			trimmedLine := strings.TrimSpace(line)
-			if trimmedLine == "" {
-				continue
-			}
-			// Skip lines that are just warnings
-			if strings.HasPrefix(trimmedLine, "Warning:") {
-				klog.Warningf("NAT gateway command warning: %v", trimmedLine)
-				continue
-			}
-			errorLines = append(errorLines, trimmedLine)
-		}
-		// If there are actual error lines (not just warnings), return error
-		if len(errorLines) > 0 {
-			errMsg := strings.Join(errorLines, "; ")
-			klog.Errorf("failed to ExecuteCommandInContainer errOutput: %v", errMsg)
-			return errors.New(errMsg)
-		}
+		// The command exited successfully, so its stderr is diagnostic only: the gateway script
+		// is responsible for reporting failures through its exit status.
+		klog.Warningf("nat gateway %s command wrote to stderr: %v", operation, errOutput)
 	}
 	return nil
 }
@@ -1314,7 +1390,7 @@ func (c *Controller) generateNatGwRoutes(
 	return annotations, nil
 }
 
-func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1.StatefulSet, natGwPodContainerRestartCount int32) (*v1.StatefulSet, error) {
+func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway) (*v1.StatefulSet, error) {
 	externalNadNamespace, externalNadName, err := c.getExternalSubnetNad(gw)
 	if err != nil {
 		klog.Errorf("failed to get gw external subnet nad: %v", err)
@@ -1343,12 +1419,6 @@ func (c *Controller) genNatGwStatefulSet(gw *kubeovnv1.VpcNatGateway, oldSts *v1
 		return nil, err
 	}
 
-	// Restart logic to fix #5072
-	if oldSts != nil && len(oldSts.Spec.Template.Annotations) != 0 {
-		if _, ok := oldSts.Spec.Template.Annotations[util.VpcNatGatewayContainerRestartAnnotation]; !ok && natGwPodContainerRestartCount > 0 {
-			templateAnnotations[util.VpcNatGatewayContainerRestartAnnotation] = ""
-		}
-	}
 	klog.V(3).Infof("%s templateAnnotations:%v", gw.Name, templateAnnotations)
 
 	// Add an interface that can reach the API server, we need access to it to probe Kube-OVN resources
@@ -1751,30 +1821,45 @@ func (c *Controller) getNatGwPods(name, namespace string, allPods bool) ([]*core
 	return activePods, nil
 }
 
-func (c *Controller) initCreateAt(key string) (err error) {
-	if natGwCreatedAT != "" {
-		return nil
-	}
+// natGwRedoToken identifies the running gateway container instances without
+// relying on clocks. Pod UID changes on recreation and ContainerID changes on
+// an in-place container restart.
+//
+// A Pod whose container is not running yet carries no instance to identify and is
+// skipped: it cannot be configured either, and the Pod update that starts its
+// container adds the instance to the token, which triggers the redo again.
+func (c *Controller) natGwRedoToken(key string) (string, error) {
 	gw, err := c.vpcNatGatewayLister.Get(key)
 	if err != nil {
-		klog.Error(err)
-		return err
+		return "", err
 	}
-	pods, err := c.getNatGwPods(key, c.natGwNamespace(gw), false)
+	pods, err := c.listNatGwPods(gw)
 	if err != nil {
-		klog.Error(err)
-		return err
+		return "", err
 	}
-
-	natGwCreatedAT = pods[0].CreationTimestamp.Format("2006-01-02T15:04:05")
+	instances := make([]string, 0, len(pods))
 	for _, pod := range pods {
-		last, _ := time.Parse("2006-01-02T15:04:05", natGwCreatedAT)
-		if pod.CreationTimestamp.Unix() > last.Unix() {
-			natGwCreatedAT = pod.CreationTimestamp.Format("2006-01-02T15:04:05")
+		if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+			continue
 		}
+		var containerID string
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name == "vpc-nat-gw" && status.State.Running != nil {
+				containerID = status.ContainerID
+				break
+			}
+		}
+		if containerID == "" {
+			klog.V(3).Infof("nat gateway pod %s/%s container is not running, skipping it", pod.Namespace, pod.Name)
+			continue
+		}
+		instances = append(instances, string(pod.UID)+"="+containerID)
 	}
-
-	return nil
+	if len(instances) == 0 {
+		return "", fmt.Errorf("nat gateway %s has no running pod", key)
+	}
+	slices.Sort(instances)
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(instances, ",")))), nil
 }
 
 func (c *Controller) updateCrdNatGwLabels(key, qos string) error {
@@ -2072,21 +2157,23 @@ func (c *Controller) patchNatGwStatus(oriGw *kubeovnv1.VpcNatGateway, pods []*co
 	return nil
 }
 
-func (c *Controller) execNatGwQoS(gw *kubeovnv1.VpcNatGateway, qos, operation string) error {
+func (c *Controller) execNatGwQoSLocked(gw *kubeovnv1.VpcNatGateway, qos, operation string) error {
 	qosPolicy, err := c.qosPoliciesLister.Get(qos)
 	if err != nil {
-		klog.Errorf("get qos policy %s failed: %v", qos, err)
-		return err
+		return fmt.Errorf("failed to get qos policy %s: %w", qos, err)
 	}
+	if operation == QoSAdd && !qosPolicyStatusMatchesSpec(qosPolicy) {
+		return fmt.Errorf("qos policy %s is not ready", qos)
+	}
+	return c.execNatGwQoSPolicyLocked(gw, qosPolicy, operation)
+}
+
+func (c *Controller) execNatGwQoSPolicyLocked(gw *kubeovnv1.VpcNatGateway, qosPolicy *kubeovnv1.QoSPolicy, operation string) error {
 	if !qosPolicy.Status.Shared {
-		err := fmt.Errorf("not support unshared qos policy %s to related to gw", qos)
-		klog.Error(err)
-		return err
+		return fmt.Errorf("not support unshared qos policy %s to related to gw", qosPolicy.Name)
 	}
 	if qosPolicy.Status.BindingType != kubeovnv1.QoSBindingTypeNatGw {
-		err := fmt.Errorf("not support qos policy %s binding type %s to related to gw", qos, qosPolicy.Status.BindingType)
-		klog.Error(err)
-		return err
+		return fmt.Errorf("not support qos policy %s binding type %s to related to gw", qosPolicy.Name, qosPolicy.Status.BindingType)
 	}
 	return c.execNatGwBandwidthLimitRules(gw, qosPolicy.Status.BandwidthLimitRules, operation)
 }
@@ -2131,14 +2218,7 @@ func (c *Controller) execNatGwQoSInPod(
 		klog.Error(err)
 		return err
 	}
-	iface := r.Interface
-	if iface == "" {
-		if r.Direction == kubeovnv1.QoSDirectionEgress {
-			iface = "net1"
-		} else {
-			iface = "eth0"
-		}
-	}
+	iface := qosRuleInterface(*r)
 	rule := fmt.Sprintf("%s,%s,%d,%s,%s,%s,%s,%s,%s",
 		r.Direction, iface, r.Priority,
 		classifierType, r.MatchType, matchDirection,
@@ -2187,9 +2267,6 @@ func (c *Controller) initVpcNatGw() error {
 
 		for _, pod := range pods {
 			if isNatGateway, natGateway := c.checkIsPodVpcNatGw(pod); isNatGateway {
-				if _, hasInit := pod.Annotations[util.VpcNatGatewayInitAnnotation]; hasInit {
-					continue
-				}
 				c.initVpcNatGatewayQueue.Add(natGateway)
 			}
 		}

--- a/pkg/controller/vpc_nat_gateway_qos_test.go
+++ b/pkg/controller/vpc_nat_gateway_qos_test.go
@@ -1,0 +1,115 @@
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+func TestNatGwRedoTokenUsesContainerInstancesPerGateway(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	started := metav1.NewTime(created.Add(time.Minute))
+	gateway := func(name string) *kubeovnv1.VpcNatGateway {
+		return &kubeovnv1.VpcNatGateway{Name: name}
+	}
+	pod := func(gateway, containerID string) *corev1.Pod {
+		return &corev1.Pod{
+			Name: gateway + "-0", Namespace: metav1.NamespaceSystem, UID: types.UID(gateway + "-uid"),
+			Labels:            map[string]string{"app": "vpc-nat-gw-" + gateway, "ovn.kubernetes.io/vpc-nat-gw": "true"},
+			CreationTimestamp: created,
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "vpc-nat-gw", ContainerID: containerID,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: started}},
+				}},
+			},
+		}
+	}
+	fakeCtrl, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		VpcNatGateways: []*kubeovnv1.VpcNatGateway{gateway("gw1"), gateway("gw2")},
+		Pods:           []*corev1.Pod{pod("gw1", "containerd://one"), pod("gw2", "containerd://two")},
+	})
+	require.NoError(t, err)
+
+	token1, err := fakeCtrl.fakeController.natGwRedoToken("gw1")
+	require.NoError(t, err)
+	token2, err := fakeCtrl.fakeController.natGwRedoToken("gw2")
+	require.NoError(t, err)
+	require.Len(t, token1, sha256.Size*2)
+	require.Len(t, token2, sha256.Size*2)
+	require.NotEqual(t, token1, token2)
+
+	restarted := pod("gw1", "containerd://restarted")
+	_, err = fakeCtrl.fakeController.config.KubeClient.CoreV1().Pods(metav1.NamespaceSystem).Update(
+		context.Background(), restarted, metav1.UpdateOptions{},
+	)
+	require.NoError(t, err)
+	restartedToken, err := fakeCtrl.fakeController.natGwRedoToken("gw1")
+	require.NoError(t, err)
+	require.Len(t, restartedToken, sha256.Size*2)
+	require.NotEqual(t, token1, restartedToken)
+
+	// A replica whose container is not running carries no instance to identify and
+	// must not stop the other replicas from being restored.
+	waiting := pod("gw1", "")
+	waiting.Name = "gw1-1"
+	waiting.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "vpc-nat-gw",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+			Reason: "CrashLoopBackOff",
+		}},
+	}}
+	_, err = fakeCtrl.fakeController.config.KubeClient.CoreV1().Pods(metav1.NamespaceSystem).Create(
+		context.Background(), waiting, metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+	withoutWaitingReplica, err := fakeCtrl.fakeController.natGwRedoToken("gw1")
+	require.NoError(t, err)
+	require.Equal(t, restartedToken, withoutWaitingReplica)
+
+	// Starting that container adds its instance to the token, which asks for a redo.
+	waiting.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "vpc-nat-gw", ContainerID: "containerd://second-replica",
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: started}},
+	}}
+	_, err = fakeCtrl.fakeController.config.KubeClient.CoreV1().Pods(metav1.NamespaceSystem).Update(
+		context.Background(), waiting, metav1.UpdateOptions{},
+	)
+	require.NoError(t, err)
+	withWaitingReplica, err := fakeCtrl.fakeController.natGwRedoToken("gw1")
+	require.NoError(t, err)
+	require.NotEqual(t, withoutWaitingReplica, withWaitingReplica)
+}
+
+func TestNatGwInitTargets(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	live := &corev1.Pod{Name: "gw-0"}
+	terminating := &corev1.Pod{Name: "gw-old", DeletionTimestamp: &now}
+
+	// A terminating Pod cannot be initialized, so its replacement has to be waited for
+	// instead of reporting a successful initialization of the gateway.
+	require.Equal(t, []*corev1.Pod{live}, natGwInitTargets([]*corev1.Pod{terminating, live}))
+	require.Empty(t, natGwInitTargets([]*corev1.Pod{terminating}))
+	require.Empty(t, natGwInitTargets(nil))
+
+	// Only a gateway that still exists waits for its replacement Pod: a gateway already
+	// marked for deletion has nothing left to initialize, and a gateway with a Pod has a
+	// target to run the init command on.
+	gateway := &kubeovnv1.VpcNatGateway{Name: "gw"}
+	require.True(t, natGwInitPending(gateway, nil))
+	require.False(t, natGwInitPending(gateway, []*corev1.Pod{live}))
+	terminatingGateway := gateway.DeepCopy()
+	terminatingGateway.DeletionTimestamp = &now
+	require.False(t, natGwInitPending(terminatingGateway, nil))
+}

--- a/pkg/controller/vpc_nat_gw_eip.go
+++ b/pkg/controller/vpc_nat_gw_eip.go
@@ -30,6 +30,13 @@ func (c *Controller) enqueueAddIptablesEip(obj any) {
 	if enqueueUpdateIfTerminating(c.updateIptablesEipQueue, key, "iptables eip", eip.DeletionTimestamp) {
 		return
 	}
+	// On controller restart, informer relist delivers existing objects through AddFunc.
+	// An allocated EIP with a pending QoS credential must resume the update path;
+	// handleAddIptablesEip intentionally returns early for allocated EIPs.
+	if eip.Status.Ready && eip.Status.IP != "" && eip.Spec.QoSPolicy != eip.Status.QoSPolicy {
+		c.updateIptablesEipQueue.Add(key)
+		return
+	}
 	klog.Infof("enqueue add iptables eip %s", key)
 	c.addIptablesEipQueue.Add(key)
 }
@@ -47,9 +54,8 @@ func (c *Controller) enqueueUpdateIptablesEip(oldObj, newObj any) {
 		c.updateIptablesEipQueue.Add(key)
 	}
 
-	// When the QoSLabel is cleared or switched, re-enqueue the previous QoS policy so it can drop
-	// its finalizer once unused (the in-use check is keyed on the label).
-	c.enqueueQoSPolicyRelease(oldEip.Labels, newEip.Labels)
+	c.enqueueQoSPolicyRelease(oldEip.Spec.QoSPolicy, oldEip.Status.QoSPolicy,
+		newEip.Spec.QoSPolicy, newEip.Status.QoSPolicy)
 }
 
 func (c *Controller) enqueueDelIptablesEip(obj any) {
@@ -74,9 +80,8 @@ func (c *Controller) enqueueDelIptablesEip(obj any) {
 	klog.Infof("enqueue del iptables eip %s", key)
 	c.delIptablesEipQueue.Add(eip)
 
-	// Re-trigger QoS reconcile so it can drop its finalizer once unused. DeleteFunc runs after
-	// the informer cache dropped this EIP; key on the QoSLabel, matching the QoS in-use check.
-	c.enqueueQoSPolicyRelease(eip.Labels, nil)
+	// DeleteFunc runs after the informer cache dropped this EIP.
+	c.enqueueQoSPolicyRelease(eip.Spec.QoSPolicy, eip.Status.QoSPolicy, "", "")
 }
 
 // natEipNamespace returns the namespace where the NAT gateway pod for the given EIP resides.
@@ -296,17 +301,21 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 
 	// update qos
 	if cachedEip.Status.QoSPolicy != cachedEip.Spec.QoSPolicy {
-		if cachedEip.Status.QoSPolicy != "" {
-			if err = c.delEipQoS(cachedEip, cachedEip.Status.IP); err != nil {
-				klog.Errorf("failed to del qos '%s' in pod, %v", key, err)
-				return err
+		if err = c.withNatGwQoSLock(cachedEip.Spec.NatGwDp, func() error {
+			if cachedEip.Status.QoSPolicy != "" {
+				if err = c.delEipQoSLocked(cachedEip, cachedEip.Status.IP); err != nil {
+					return fmt.Errorf("failed to del qos %s in pod: %w", cachedEip.Status.QoSPolicy, err)
+				}
 			}
-		}
-		if cachedEip.Spec.QoSPolicy != "" {
-			if err = c.addEipQoS(cachedEip, cachedEip.Status.IP); err != nil {
-				klog.Errorf("failed to add qos '%s' in pod, %v", key, err)
-				return err
+			if cachedEip.Spec.QoSPolicy != "" {
+				if err = c.addEipQoSLocked(cachedEip, cachedEip.Status.IP); err != nil {
+					return fmt.Errorf("failed to add qos %s in pod: %w", cachedEip.Spec.QoSPolicy, err)
+				}
 			}
+			return nil
+		}); err != nil {
+			klog.Errorf("failed to update qos for eip %s, %v", key, err)
+			return err
 		}
 
 		if err = c.patchEipLabel(key); err != nil {
@@ -325,31 +334,6 @@ func (c *Controller) handleUpdateIptablesEip(key string) error {
 		cachedEip.Status.Redo != "" &&
 		cachedEip.Status.IP != "" &&
 		cachedEip.DeletionTimestamp.IsZero() {
-		gwPods, err := c.getNatGwPods(cachedEip.Spec.NatGwDp, c.natEipNamespace(cachedEip), false)
-		if err != nil {
-			klog.Error(err)
-			return err
-		}
-		// compare gw pod started time with eip redo time. if redo time before gw pod started. redo again
-		eipRedo, _ := time.ParseInLocation("2006-01-02T15:04:05", cachedEip.Status.Redo, time.Local)
-		allReady := true
-		for _, gwPod := range gwPods {
-			if len(gwPod.Status.ContainerStatuses) == 0 || gwPod.Status.ContainerStatuses[0].State.Running == nil {
-				allReady = false
-				break
-			}
-
-			if !gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: eipRedo}) {
-				allReady = false
-				break
-			}
-		}
-
-		if cachedEip.Status.Ready && cachedEip.Status.IP != "" && allReady {
-			// already ok
-			klog.V(3).Infof("eip %s already ok", key)
-			return nil
-		}
 		addrV4, err := util.GetIPAddrWithMask(cachedEip.Status.IP, v4Cidr)
 		if err != nil {
 			err = fmt.Errorf("failed to get eip %s with mask by cidr %s: %w", cachedEip.Status.IP, v4Cidr, err)
@@ -479,7 +463,18 @@ func (c *Controller) deleteEipInPod(dp, v4Cidr, ns string) error {
 	return nil
 }
 
-func (c *Controller) addOrUpdateEIPBandwidthLimitRules(eip *kubeovnv1.IptablesEIP, v4ip string, rules kubeovnv1.QoSPolicyBandwidthLimitRules) error {
+// withNatGwQoSLock serializes every QoS mutation that touches the shared HTB
+// root, IFB device, ingress redirect or default class of one NAT gateway. tc
+// has no atomic check-and-create across the several netlink commands a rule
+// needs, so this gateway-scoped lock is what keeps two EIP/QoS policies from
+// interfering.
+func (c *Controller) withNatGwQoSLock(gateway string, fn func() error) error {
+	c.qosNatGwKeyMutex.LockKey(gateway)
+	defer func() { _ = c.qosNatGwKeyMutex.UnlockKey(gateway) }()
+	return fn()
+}
+
+func (c *Controller) addOrUpdateEIPBandwidthLimitRulesLocked(eip *kubeovnv1.IptablesEIP, v4ip string, rules kubeovnv1.QoSPolicyBandwidthLimitRules) error {
 	var err error
 	for _, rule := range rules {
 		if err = c.addEipQoSInPod(eip.Spec.NatGwDp, v4ip, c.natEipNamespace(eip), rule.Direction, rule.Priority, rule.RateMax, rule.BurstMax); err != nil {
@@ -492,35 +487,37 @@ func (c *Controller) addOrUpdateEIPBandwidthLimitRules(eip *kubeovnv1.IptablesEI
 
 // add tc rule for eip in nat gw pod
 func (c *Controller) addEipQoS(eip *kubeovnv1.IptablesEIP, v4ip string) error {
+	return c.withNatGwQoSLock(eip.Spec.NatGwDp, func() error {
+		return c.addEipQoSLocked(eip, v4ip)
+	})
+}
+
+func (c *Controller) addEipQoSLocked(eip *kubeovnv1.IptablesEIP, v4ip string) error {
 	var err error
 	qosPolicy, err := c.qosPoliciesLister.Get(eip.Spec.QoSPolicy)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		klog.Errorf("failed to get qos policy %s, %v", eip.Spec.QoSPolicy, err)
-		return err
+		return fmt.Errorf("failed to get qos policy %s: %w", eip.Spec.QoSPolicy, err)
+	}
+	if !qosPolicyStatusMatchesSpec(qosPolicy) {
+		return fmt.Errorf("qos policy %s is not ready", qosPolicy.Name)
+	}
+	if qosPolicy.Status.BindingType != kubeovnv1.QoSBindingTypeEIP {
+		return fmt.Errorf("qos policy %s binding type %s does not support eip", qosPolicy.Name, qosPolicy.Status.BindingType)
 	}
 	if !qosPolicy.Status.Shared {
-		eips, err := c.iptablesEipsLister.List(
-			labels.SelectorFromSet(labels.Set{util.QoSLabel: qosPolicy.Name}),
-		)
+		eips, err := c.iptablesEipsLister.List(labels.Everything())
 		if err != nil {
-			klog.Errorf("failed to get eip list, %v", err)
-			return err
+			return fmt.Errorf("failed to list eips: %w", err)
 		}
-		if len(eips) != 0 {
-			if eips[0].Name != eip.Name {
-				err := fmt.Errorf("not support unshared qos policy %s to related to multiple eip", eip.Spec.QoSPolicy)
-				klog.Error(err)
-				return err
-			}
+		eips = iptablesEIPsUsingQoS(eips, qosPolicy.Name)
+		if len(eips) > 1 || len(eips) == 1 && eips[0].Name != eip.Name {
+			return fmt.Errorf("not support unshared qos policy %s related to multiple eips", eip.Spec.QoSPolicy)
 		}
 	}
-	return c.addOrUpdateEIPBandwidthLimitRules(eip, v4ip, qosPolicy.Status.BandwidthLimitRules)
+	return c.addOrUpdateEIPBandwidthLimitRulesLocked(eip, v4ip, qosPolicy.Status.BandwidthLimitRules)
 }
 
-func (c *Controller) delEIPBandwidthLimitRules(eip *kubeovnv1.IptablesEIP, v4ip string, rules kubeovnv1.QoSPolicyBandwidthLimitRules) error {
+func (c *Controller) delEIPBandwidthLimitRulesLocked(eip *kubeovnv1.IptablesEIP, v4ip string, rules kubeovnv1.QoSPolicyBandwidthLimitRules) error {
 	var err error
 	for _, rule := range rules {
 		if err = c.delEipQoSInPod(eip.Spec.NatGwDp, v4ip, c.natEipNamespace(eip), rule.Direction); err != nil {
@@ -533,34 +530,24 @@ func (c *Controller) delEIPBandwidthLimitRules(eip *kubeovnv1.IptablesEIP, v4ip 
 
 // del tc rule for eip in nat gw pod
 func (c *Controller) delEipQoS(eip *kubeovnv1.IptablesEIP, v4ip string) error {
+	return c.withNatGwQoSLock(eip.Spec.NatGwDp, func() error {
+		return c.delEipQoSLocked(eip, v4ip)
+	})
+}
+
+func (c *Controller) delEipQoSLocked(eip *kubeovnv1.IptablesEIP, v4ip string) error {
 	qosPolicy, err := c.qosPoliciesLister.Get(eip.Status.QoSPolicy)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get qos policy %s: %w", eip.Status.QoSPolicy, err)
 		}
-		klog.Errorf("failed to get qos policy %s, %v", eip.Status.QoSPolicy, err)
-		return err
+		return c.delEIPBandwidthLimitRulesLocked(eip, v4ip, kubeovnv1.QoSPolicyBandwidthLimitRules{
+			{Direction: kubeovnv1.QoSDirectionIngress},
+			{Direction: kubeovnv1.QoSDirectionEgress},
+		})
 	}
 
-	if err = c.delEIPBandwidthLimitRules(eip, v4ip, qosPolicy.Status.BandwidthLimitRules); err != nil {
-		return err
-	}
-
-	// Reapply QoS for the other EIPs on this gateway. Removing one EIP's tc
-	// filter can remove the shared HTB state, so its peers must be restored.
-	eips, err := c.iptablesEipsLister.List(labels.Everything())
-	if err != nil {
-		return err
-	}
-	for _, peer := range eips {
-		if peer.Name == eip.Name || peer.Spec.NatGwDp != eip.Spec.NatGwDp || peer.Spec.QoSPolicy == "" || peer.Status.IP == "" {
-			continue
-		}
-		if err = c.addEipQoS(peer, peer.Status.IP); err != nil {
-			return err
-		}
-	}
-	return nil
+	return c.delEIPBandwidthLimitRulesLocked(eip, v4ip, qosPolicy.Status.BandwidthLimitRules)
 }
 
 func (c *Controller) addEipQoSInPod(

--- a/pkg/controller/vpc_nat_gw_eip_test.go
+++ b/pkg/controller/vpc_nat_gw_eip_test.go
@@ -101,4 +101,17 @@ func TestEnqueueAddIptablesEip(t *testing.T) {
 		&kubeovnv1.IptablesEIP{Name: "live-eip"},
 		&kubeovnv1.IptablesEIP{Name: "terminating-eip", DeletionTimestamp: &now},
 	)
+
+	// Informer relist uses AddFunc after a controller restart. Resume a QoS update
+	// that had not yet published its applied credential instead of taking the add
+	// handler's allocated-EIP fast path.
+	c.enqueueAddIptablesEip(&kubeovnv1.IptablesEIP{
+		Name: "pending-qos-eip",
+		Spec: kubeovnv1.IptablesEIPSpec{QoSPolicy: "new-qos"},
+		Status: kubeovnv1.IptablesEIPStatus{
+			Ready: true, IP: "192.0.2.10", QoSPolicy: "old-qos",
+		},
+	})
+	require.Equal(t, 1, c.addIptablesEipQueue.Len(), "allocated EIP must not re-enter add")
+	require.Equal(t, 2, c.updateIptablesEipQueue.Len(), "pending QoS credential must resume update")
 }

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -490,27 +490,6 @@ func (c *Controller) handleUpdateIptablesFip(key string) error {
 		cachedFip.Status.V4ip != "" &&
 		cachedFip.DeletionTimestamp.IsZero() {
 		klog.V(3).Infof("reapply fip '%s' in pod", key)
-		gwPods, err := c.getNatGwPods(cachedFip.Status.NatGwDp, c.natGwNamespaceByName(cachedFip.Status.NatGwDp), false)
-		if err != nil {
-			klog.Error(err)
-			return err
-		}
-		// If all Pods started before the redo timestamp, they have not restarted since
-		// the redo was marked — iptables rules are still intact, skip re-creation.
-		fipRedo, _ := time.ParseInLocation("2006-01-02T15:04:05", cachedFip.Status.Redo, time.Local)
-		allPodsStartedBeforeRedo := true
-		for _, gwPod := range gwPods {
-			if len(gwPod.Status.ContainerStatuses) == 0 || gwPod.Status.ContainerStatuses[0].State.Running == nil {
-				return fmt.Errorf("fip %s: gateway pod %s/%s container not running, will retry redo", key, gwPod.Namespace, gwPod.Name)
-			}
-			if !gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: fipRedo}) {
-				allPodsStartedBeforeRedo = false
-			}
-		}
-		if allPodsStartedBeforeRedo {
-			klog.V(3).Infof("fip %s: all pods started before redo mark, rules intact, skip", key)
-			return nil
-		}
 		if err = c.createFipInPod(cachedFip.Status.NatGwDp, cachedFip.Status.V4ip, cachedFip.Status.InternalIP); err != nil {
 			klog.Errorf("failed to create fip, %v", err)
 			return err
@@ -819,28 +798,6 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		cachedDnat.Status.V4ip != "" &&
 		cachedDnat.DeletionTimestamp.IsZero() {
 		klog.V(3).Infof("reapply dnat in pod for %s", key)
-		gwPods, err := c.getNatGwPods(cachedDnat.Status.NatGwDp, c.natGwNamespaceByName(cachedDnat.Status.NatGwDp), false)
-		if err != nil {
-			klog.Error(err)
-			return err
-		}
-		// If all Pods started before the redo timestamp, they have not restarted since
-		// the redo was marked — iptables rules are still intact, skip re-creation.
-		dnatRedo, _ := time.ParseInLocation("2006-01-02T15:04:05", cachedDnat.Status.Redo, time.Local)
-		allPodsStartedBeforeRedo := true
-		for _, gwPod := range gwPods {
-			if len(gwPod.Status.ContainerStatuses) == 0 || gwPod.Status.ContainerStatuses[0].State.Running == nil {
-				return fmt.Errorf("dnat %s: gateway pod %s/%s container not running, will retry redo", key, gwPod.Namespace, gwPod.Name)
-			}
-			if !gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: dnatRedo}) {
-				allPodsStartedBeforeRedo = false
-			}
-		}
-		if allPodsStartedBeforeRedo {
-			klog.V(3).Infof("dnat %s: all pods started before redo mark, rules intact, skip", key)
-			return nil
-		}
-
 		switch cachedDnat.Spec.Type {
 		case kubeovnv1.DnatRuleTypeShare:
 			// Share type: rebuild nft rule with all backends.
@@ -1126,27 +1083,6 @@ func (c *Controller) handleUpdateIptablesSnatRule(key string) error {
 		cachedSnat.Status.Redo != "" &&
 		cachedSnat.Status.V4ip != "" &&
 		cachedSnat.DeletionTimestamp.IsZero() {
-		gwPods, err := c.getNatGwPods(cachedSnat.Status.NatGwDp, c.natGwNamespaceByName(cachedSnat.Status.NatGwDp), false)
-		if err != nil {
-			klog.Error(err)
-			return err
-		}
-		// If all Pods started before the redo timestamp, they have not restarted since
-		// the redo was marked — iptables rules are still intact, skip re-creation.
-		snatRedo, _ := time.ParseInLocation("2006-01-02T15:04:05", cachedSnat.Status.Redo, time.Local)
-		allPodsStartedBeforeRedo := true
-		for _, gwPod := range gwPods {
-			if len(gwPod.Status.ContainerStatuses) == 0 || gwPod.Status.ContainerStatuses[0].State.Running == nil {
-				return fmt.Errorf("snat %s: gateway pod %s/%s container not running, will retry redo", key, gwPod.Namespace, gwPod.Name)
-			}
-			if !gwPod.Status.ContainerStatuses[0].State.Running.StartedAt.Before(&metav1.Time{Time: snatRedo}) {
-				allPodsStartedBeforeRedo = false
-			}
-		}
-		if allPodsStartedBeforeRedo {
-			klog.V(3).Infof("snat %s: all pods started before redo mark, rules intact, skip", key)
-			return nil
-		}
 		if err = c.createSnatInPod(cachedSnat.Status.NatGwDp, cachedSnat.Status.V4ip, cachedSnat.Status.InternalCIDR); err != nil {
 			klog.Errorf("failed to create new snat, %v", err)
 			return err

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -36,8 +36,12 @@ const (
 	VMAnnotation                 = "ovn.kubernetes.io/virtualmachine"
 	ActivationStrategyAnnotation = "ovn.kubernetes.io/activation_strategy"
 
-	VpcNatGatewayAnnotation                 = "ovn.kubernetes.io/vpc_nat_gw"
-	VpcNatGatewayInitAnnotation             = "ovn.kubernetes.io/vpc_nat_gw_init"
+	VpcNatGatewayAnnotation     = "ovn.kubernetes.io/vpc_nat_gw"
+	VpcNatGatewayInitAnnotation = "ovn.kubernetes.io/vpc_nat_gw_init"
+	// VpcNatGatewayInitInstanceAnnotation records the container instance the init command
+	// completed on, so a replacement instance initializes again.
+	VpcNatGatewayInitInstanceAnnotation = "ovn.kubernetes.io/vpc_nat_gw_init_instance"
+	// Deprecated: container restarts are detected from Pod status.
 	VpcNatGatewayContainerRestartAnnotation = "ovn.kubernetes.io/vpc_nat_gw_container_restarted"
 	VpcNatGatewayActivatedAnnotation        = "ovn.kubernetes.io/vpc_nat_gw_activated"
 	VpcEipsAnnotation                       = "ovn.kubernetes.io/vpc_eips"

--- a/test/e2e/iptables-eip-qos/e2e_test.go
+++ b/test/e2e/iptables-eip-qos/e2e_test.go
@@ -571,19 +571,21 @@ func restartNatGwPods(f *framework.Framework, natgwName string) {
 		framework.ExpectNoError(podClient.Delete(pod.Name), "failed to delete natgw pod "+pod.Name)
 	}
 
-	// The old pods must be gone before waiting for readiness, otherwise the readiness check could
-	// observe the pod which is still terminating and return before the gateway is rebuilt.
-	ginkgo.By("Wait for the old natgw pods of " + natgwName + " to disappear")
+	// The old pods must be gone and their replacements must have completed initialization.
+	// Checking only for an initialized Pod with the gateway labels could still observe the
+	// terminating Pod, and returning then would let the caller assert against a gateway whose
+	// data plane has not been rebuilt.
+	ginkgo.By("Wait for the recreated natgw " + natgwName + " pod to be initialized")
 	gomega.Eventually(func(g gomega.Gomega) {
 		pods, err := f.ClientSet.CoreV1().Pods(framework.KubeOvnNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
 		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(pods.Items).NotTo(gomega.BeEmpty(), "no natgw pod exists after recreation")
 		for _, pod := range pods.Items {
 			g.Expect(oldUIDs).NotTo(gomega.HaveKey(pod.UID), "natgw pod %s is still terminating", pod.Name)
+			g.Expect(pod.Annotations[util.VpcNatGatewayInitAnnotation]).To(gomega.Equal("true"),
+				"natgw pod %s has not been initialized yet", pod.Name)
 		}
 	}, 2*time.Minute, 2*time.Second).Should(gomega.Succeed())
-
-	ginkgo.By("Wait for natgw " + natgwName + " pod to be ready after recreation")
-	f.VpcNatGatewayClient().WaitGwPodReady(natgwName, "", 2*time.Minute, f.ClientSet)
 }
 
 // tcRateMatcher builds a matcher for the rate of a tc class as printed by tc, which uses either
@@ -621,6 +623,23 @@ func expectTcClassOnNatGwDev(f *framework.Framework, natgwName, dev string, rate
 		"expected the tc class limited to %gMbps on %s of natgw %s to exist: %v", rateMbps, dev, natgwName, expectExists)
 }
 
+func expectTcFilterMatchCountOnNatGwDev(
+	f *framework.Framework,
+	natgwName, dev, ip, direction string,
+	count int,
+) {
+	ginkgo.GinkgoHelper()
+
+	cmd := fmt.Sprintf("tc -p filter show dev %s parent 1: | grep -ci 'match IP %s %s/32' || true", dev, direction, ip)
+	gomega.Eventually(func(g gomega.Gomega) {
+		podName := getNatGwPodName(f, natgwName, "")
+		stdOutput, errOutput, err := framework.ExecShellInPod(context.Background(), f, framework.KubeOvnNamespace, podName, cmd)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), errOutput)
+		g.Expect(strings.TrimSpace(stdOutput)).To(gomega.Equal(strconv.Itoa(count)))
+	}, 60*time.Second, 3*time.Second).Should(gomega.Succeed(),
+		"expected %d tc filter match(es) for %s %s/32 on %s of natgw %s", count, direction, ip, dev, natgwName)
+}
+
 // expectTcRateOnNatGw asserts that the HTB classes on the NAT gateway carry the expected rates in
 // both directions (egress on net1, ingress on ifb-net1).
 func expectTcRateOnNatGw(f *framework.Framework, natgwName string, ratesMbps ...float64) {
@@ -631,6 +650,27 @@ func expectTcRateOnNatGw(f *framework.Framework, natgwName string, ratesMbps ...
 			expectTcClassOnNatGwDev(f, natgwName, dev, rate, true)
 		}
 	}
+}
+
+// expectSharedQoSInfrastructure asserts that the state shared by every EIP QoS
+// rule on the external interface survives: the HTB root, the default class
+// 1:9999 that carries unclassified traffic, and the ingress redirect to the IFB
+// device.
+func expectSharedQoSInfrastructure(f *framework.Framework, natgwName string) {
+	ginkgo.GinkgoHelper()
+
+	podName := getNatGwPodName(f, natgwName, "")
+	for _, dev := range []string{"net1", "ifb-net1"} {
+		stdOutput, errOutput, err := framework.ExecShellInPod(context.Background(), f, framework.KubeOvnNamespace, podName,
+			fmt.Sprintf("tc qdisc show dev %s; tc class show dev %s classid 1:9999", dev, dev))
+		framework.ExpectNoError(err, errOutput)
+		gomega.Expect(stdOutput).To(gomega.And(gomega.ContainSubstring("htb 1:"), gomega.ContainSubstring("class htb 1:9999")),
+			"shared QoS infrastructure is missing on %s", dev)
+	}
+	stdOutput, errOutput, err := framework.ExecShellInPod(context.Background(), f, framework.KubeOvnNamespace, podName,
+		"tc filter show dev net1 parent ffff:")
+	framework.ExpectNoError(err, errOutput)
+	gomega.Expect(stdOutput).To(gomega.ContainSubstring("mirred"), "shared ingress redirect is missing on net1")
 }
 
 // natGwQoSCasesLegacy validates QoS on versions whose nat-gateway image still uses tc police
@@ -1599,6 +1639,57 @@ var _ = framework.OrderedDescribe("[group:qos-policy]", func() {
 		ginkgo.By("Expecting qos policy " + qosName + " to be cleaned up after being unbound")
 		gomega.Expect(qosPolicyClient.WaitToDisappear(qosName, 2*time.Second, 2*time.Minute)).To(gomega.Succeed(),
 			"qos policy should drop its finalizer once it is unbound from the natgw")
+	})
+
+	framework.ConformanceIt("qos add and qos del are idempotent", func() {
+		f.SkipVersionPriorTo(1, 17, "idempotent QoS script commands require the v1.17 NAT gateway script")
+		setupQosNatGwEnvironment(f, dockerExtNetNetwork, vpcQosParams, net1NicName, "")
+
+		podName := getNatGwPodName(f, vpcQosParams.qosNatGwName, "")
+
+		// An EIP without a QoS policy provides a real external IP for the tc
+		// filters while keeping the controller out of this test's data path.
+		eipName := "qos-idempotent-eip-" + framework.RandomSuffix()
+		eipClient := f.IptablesEIPClient()
+		eip := framework.MakeIptablesEIP(eipName, "", "", "", vpcQosParams.qosNatGwName, vpcQosParams.attachDefName, "")
+		_ = eipClient.CreateSync(eip)
+		eip = waitForIptablesEIPReady(eipClient, eipName, 60*time.Second)
+		ginkgo.DeferCleanup(func() { eipClient.DeleteSync(eipName) })
+
+		execQoSCmd := func(args ...string) {
+			ginkgo.GinkgoHelper()
+			_, errOutput, err := framework.ExecCommandInContainer(f, framework.KubeOvnNamespace, podName, "vpc-nat-gw",
+				append([]string{"bash", "/kube-ovn/nat-gateway.sh"}, args...)...)
+			framework.ExpectNoError(err, errOutput)
+		}
+
+		// Add egress and ingress rules twice each: the second run must not create
+		// duplicate classes/filters or fail because the first one already exists.
+		for range 2 {
+			execQoSCmd("eip-egress-qos-add", eip.Status.IP+",1,2.5,0.3")
+			expectTcClassOnNatGwDev(f, vpcQosParams.qosNatGwName, "net1", 2.5, true)
+			expectTcFilterMatchCountOnNatGwDev(f, vpcQosParams.qosNatGwName, "net1", eip.Status.IP, "src", 1)
+		}
+		for range 2 {
+			execQoSCmd("eip-ingress-qos-add", eip.Status.IP+",1,2.5,0.3")
+			expectTcClassOnNatGwDev(f, vpcQosParams.qosNatGwName, "ifb-net1", 2.5, true)
+			expectTcFilterMatchCountOnNatGwDev(f, vpcQosParams.qosNatGwName, "ifb-net1", eip.Status.IP, "dst", 1)
+		}
+
+		// Delete egress and ingress rules twice each: the second run is a no-op
+		// and must leave shared infrastructure intact.
+		for range 2 {
+			execQoSCmd("eip-egress-qos-del", eip.Status.IP)
+			expectTcClassOnNatGwDev(f, vpcQosParams.qosNatGwName, "net1", 2.5, false)
+			expectTcFilterMatchCountOnNatGwDev(f, vpcQosParams.qosNatGwName, "net1", eip.Status.IP, "src", 0)
+		}
+		for range 2 {
+			execQoSCmd("eip-ingress-qos-del", eip.Status.IP)
+			expectTcClassOnNatGwDev(f, vpcQosParams.qosNatGwName, "ifb-net1", 2.5, false)
+			expectTcFilterMatchCountOnNatGwDev(f, vpcQosParams.qosNatGwName, "ifb-net1", eip.Status.IP, "dst", 0)
+		}
+
+		expectSharedQoSInfrastructure(f, vpcQosParams.qosNatGwName)
 	})
 
 	framework.ConformanceIt("natgw qos", func() {


### PR DESCRIPTION
## Purpose

Make VPC NAT gateway QoS converge safely across concurrent EIP/gateway updates, reference cleanup, Pod recreation, and in-place container restarts.

The governing rule is: notifications only enqueue work; each controller reconciles from the latest Spec, applied Status credentials, and live container state. Data-plane cleanup must finish before labels, Status, and finalizers advance.

## What changed

### Isolate and serialize QoS data-plane state

- Serialize QoS mutations per NAT gateway. Rules on different gateways remain independent.
- Separate shared HTB root, default class `1:9999`, IFB device, and ingress redirect from per-rule classes and filters.
- Keep EIP classes, NAT gateway IP-match classes, NAT gateway matchall classes, and the shared default class in distinct ranges.
- Make rule creation idempotent with `tc class/filter replace`.
- Delete u32 and matchall filters by their complete data-plane identity.
- Treat a missing rule as an idempotent success, but propagate `tc` read and deletion failures so reconciliation retries before Status or finalizers advance.

### Converge references and finalizers in order

- Treat `Spec.QoSPolicy` as the desired reference and `Status.QoSPolicy` as the applied credential.
- Notify a referenced QoS policy only after the old policy has left both Spec and Status.
- Check both EIP and NAT gateway Spec/Status claims before removing a QoS policy finalizer, including BindingType drift.
- Count both desired and applied EIP claims when enforcing unshared-policy ownership.
- Publish a QoS policy as usable before notifying referencing gateways; referencing workers retry while the policy is absent or not ready.

The cleanup order is:

1. remove old data-plane state;
2. update the QoS label/reference credential;
3. update resource Status;
4. notify the old QoS policy through its queue;
5. remove the QoS policy finalizer after no desired or applied claims remain.

### Recover after Pod and container replacement

- Detect a running `vpc-nat-gw` container instance change from `ContainerID`, rather than assuming restart counts or workload replica Status identify an in-place restart.
- Build a clock-independent recovery token from the sorted live `Pod UID + ContainerID` set.
- Re-run idempotent gateway initialization and restore gateway QoS plus EIP/FIP/DNAT/SNAT state through existing queues.
- Preserve the exported legacy restart annotation constant for source compatibility, but stop using template mutation to force Pod recreation.

### Validate only representable QoS rules

- Require supported binding types, directions, positive rates/bursts, canonical IPv4 matches, unique names, and unique normalized rule identities.
- Reject priorities outside tc's `0..65535` range.
- Reject automatic priority `0` only for NAT gateway IP-match rules, where tc rewrites the priority and makes later identity-based cleanup unreliable.
- Reject rates below `0.000008 Mbps`, the one-byte-per-second minimum representable by tc's `mbit` parser.
- Preserve priority `0` for EIP and matchall paths that can reconcile it safely.

## Kubernetes event model

The implementation uses existing informer and workqueue behavior:

- Pod, StatefulSet, Deployment, VpcNatGateway, IptablesEIP, and QoSPolicy add/update/delete handlers are registered.
- Pod `ContainerID` changes arrive through Pod Status updates and enqueue gateway initialization.
- StatefulSet/Deployment Status is not relied on to identify in-place container restarts.
- Existing rate-limited queues retry failed data-plane, label, Status, and finalizer operations.
- No new goroutines, workers, CRD fields, or external dependencies are added.

NAT gateways use StatefulSets or Deployments; no DaemonSet-specific path is required.

## Compatibility and cost

- No CRD schema or external script command interface changes.
- No exported Go API removals.
- Existing `Status.Redo` remains a string and naturally converges to the new instance token.
- Normal reconciliation adds no global lock; the new lock is scoped by NAT gateway.
- Live API reads are limited to restart/restore paths where informer ordering cannot prove current Pod/EIP state.

## Tests

Added or extended coverage for:

- QoS rule diff identity changes;
- QoS policy readiness and reference notifications;
- Spec/Status claim ordering and finalizer retention;
- unshared EIP policy ownership during cleanup;
- Pod ContainerID restart detection and recovery tokens;
- tc class-range isolation, idempotent add/delete, collision handling, and read/delete failures;
- shared HTB root, default class, and IFB redirect preservation in E2E coverage.

Locally verified:

```text
go test ./pkg/controller -count=1
make lint
bash -n dist/images/vpcnatgateway/nat-gateway.sh
dist/images/vpcnatgateway/nat_gateway_qos_test.sh
test/e2e/iptables-vpc-nat-gw/nat_gateway_cleanup_test.sh
```

The full cluster E2E suite was not rerun in the final local verification environment.

# Pull Request

- [x] Followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
