### PR TITLE
fix: close orphaned NAT leaks in ovn fip/snat/dnat/eip controllers

### DIFF
--- a/pkg/controller/ovn_dnat.go
+++ b/pkg/controller/ovn_dnat.go
@@ -205,6 +205,10 @@ func (c *Controller) handleAddOvnDnatRule(key string) error {
 			return err
 		}
 	}
+	if err = c.patchOvnDnatStatus(key, vpcName, v4Eip, v6Eip, internalV4Ip, internalV6Ip, false); err != nil {
+		klog.Errorf("failed to record nat status for dnat %s, %v", key, err)
+		return err
+	}
 	if err := c.handleAddOvnDnatFinalizer(cachedDnat); err != nil {
 		klog.Errorf("failed to add finalizer for ovn dnat %s, %v", cachedDnat.Name, err)
 		return err
@@ -556,7 +560,7 @@ func (c *Controller) patchOvnDnatStatus(key, vpcName, v4Eip, v6Eip, internalV4Ip
 		dnat.Status.InternalPort = dnat.Spec.InternalPort
 		changed = true
 	}
-	if ready && dnat.Spec.ExternalPort != "" && dnat.Status.ExternalPort != dnat.Spec.ExternalPort {
+	if dnat.Spec.ExternalPort != "" && dnat.Status.ExternalPort != dnat.Spec.ExternalPort {
 		dnat.Status.ExternalPort = dnat.Spec.ExternalPort
 		changed = true
 	}

--- a/pkg/controller/ovn_dnat_test.go
+++ b/pkg/controller/ovn_dnat_test.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8stesting "k8s.io/client-go/testing"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestHandleAddOvnDnatRule_RecordsNatStatusBeforeReady(t *testing.T) {
+	t.Parallel()
+
+	eip := &kubeovnv1.OvnEip{
+		Name: "test-eip",
+		Spec: kubeovnv1.OvnEipSpec{ExternalSubnet: "pubnet"},
+	}
+	eip.Status.V4Ip = "10.0.0.10"
+	dnat := &kubeovnv1.OvnDnatRule{
+		Name: "test-dnat",
+		Spec: kubeovnv1.OvnDnatRuleSpec{
+			OvnEip:       eip.Name,
+			Vpc:          "test-vpc",
+			V4Ip:         "10.0.1.5",
+			Protocol:     "tcp",
+			ExternalPort: "2222",
+			InternalPort: "22",
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		OvnEips:      []*kubeovnv1.OvnEip{eip},
+		OvnDnatRules: []*kubeovnv1.OvnDnatRule{dnat},
+	})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+
+	fc.mockOvnClient.EXPECT().CreateLoadBalancer(dnat.Name, dnat.Spec.Protocol).Return(nil)
+	fc.mockOvnClient.EXPECT().LoadBalancerAddVip(dnat.Name, eip.Status.V4Ip+":"+dnat.Spec.ExternalPort, dnat.Spec.V4Ip+":"+dnat.Spec.InternalPort).Return(nil)
+	fc.mockOvnClient.EXPECT().LogicalRouterUpdateLoadBalancers(dnat.Spec.Vpc, ovsdb.MutateOperationInsert, dnat.Name).Return(nil)
+
+	kubeovnClient, ok := ctrl.config.KubeOvnClient.(*kubeovnfake.Clientset)
+	require.True(t, ok)
+	kubeovnClient.PrependReactor("patch", "ovn-dnat-rules", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if ok && patchAction.GetPatchType() == types.JSONPatchType &&
+			strings.Contains(string(patchAction.GetPatch()), "/metadata/annotations") {
+			return true, nil, errors.New("injected failure after nat status recorded")
+		}
+		return false, nil, nil
+	})
+
+	err = ctrl.handleAddOvnDnatRule(dnat.Name)
+	require.Error(t, err)
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnDnatRules().Get(t.Context(), dnat.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+	require.Equal(t, dnat.Spec.Vpc, got.Status.Vpc)
+	require.Equal(t, eip.Status.V4Ip, got.Status.V4Eip)
+	require.Equal(t, dnat.Spec.ExternalPort, got.Status.ExternalPort)
+	require.False(t, got.Status.Ready)
+}
+
+func TestHandleUpdateOvnDnatRule_DeleteRemovesLBAndFinalizer(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	dnat := &kubeovnv1.OvnDnatRule{
+		Name:              "test-dnat",
+		Finalizers:        []string{util.KubeOVNControllerFinalizer},
+		DeletionTimestamp: &now,
+		Spec:              kubeovnv1.OvnDnatRuleSpec{OvnEip: "test-eip", Vpc: "test-vpc"},
+	}
+	dnat.Status = kubeovnv1.OvnDnatRuleStatus{
+		Vpc:          "test-vpc",
+		V4Eip:        "10.0.0.10",
+		ExternalPort: "2222",
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{OvnDnatRules: []*kubeovnv1.OvnDnatRule{dnat}})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+	ctrl.resetOvnEipQueue = newTypedRateLimitingQueue[string]("ResetOvnEip", nil)
+	t.Cleanup(ctrl.resetOvnEipQueue.ShutDown)
+	ctrl.updateOvnEipQueue = newTypedRateLimitingQueue[string]("UpdateOvnEip", nil)
+	t.Cleanup(ctrl.updateOvnEipQueue.ShutDown)
+
+	fc.mockOvnClient.EXPECT().
+		LoadBalancerDeleteVip(dnat.Name, dnat.Status.V4Eip+":"+dnat.Status.ExternalPort, true).
+		Return(nil)
+	fc.mockOvnClient.EXPECT().
+		LogicalRouterUpdateLoadBalancers(dnat.Status.Vpc, ovsdb.MutateOperationDelete, dnat.Name).
+		Return(nil)
+
+	require.NoError(t, ctrl.handleUpdateOvnDnatRule(dnat.Name))
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnDnatRules().Get(t.Context(), dnat.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+}

--- a/pkg/controller/ovn_eip.go
+++ b/pkg/controller/ovn_eip.go
@@ -273,6 +273,17 @@ func (c *Controller) handleDelOvnEip(eip *kubeovnv1.OvnEip) error {
 	// EIPs with finalizers are handled in handleUpdateOvnEip
 	klog.Infof("handle del ovn eip %s (without finalizer)", eip.Name)
 
+	nat, err := c.getOvnEipNat(eip.Spec.V4Ip, eip.Spec.V6Ip)
+	if err != nil {
+		klog.Errorf("failed to get ovn eip %s nat rules, %v", eip.Name, err)
+		return err
+	}
+	if nat != "" {
+		err := fmt.Errorf("ovn eip %s is still being used by NAT rules: %s, waiting for them to be deleted", eip.Name, nat)
+		klog.Error(err)
+		return err
+	}
+
 	// Clean up resources if they still exist
 	if eip.Spec.Type == util.OvnEipTypeLSP {
 		if err := c.OVNNbClient.DeleteLogicalSwitchPort(eip.Name); err != nil {

--- a/pkg/controller/ovn_eip_test.go
+++ b/pkg/controller/ovn_eip_test.go
@@ -215,3 +215,40 @@ func TestEnqueueAddOvnEipRequeuesRouterLBRules(t *testing.T) {
 	require.Equal(t, 0, c.addOvnEipQueue.Len(), "terminating eip must not go to the add queue")
 	require.Equal(t, 1, c.addRouterLBRuleQueue.Len(), "router lb rules must be re-queued even for a terminating eip")
 }
+
+func TestHandleDelOvnEip_BlocksWhileNatStillUsesIt(t *testing.T) {
+	t.Parallel()
+
+	eip := &kubeovnv1.OvnEip{
+		Name: "test-eip",
+		Spec: kubeovnv1.OvnEipSpec{ExternalSubnet: "pubnet", V4Ip: "10.0.0.10"},
+	}
+	fip := &kubeovnv1.OvnFip{
+		Name:   "test-fip",
+		Labels: map[string]string{util.EipV4IpLabel: eip.Spec.V4Ip},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		OvnEips:     []*kubeovnv1.OvnEip{eip},
+		OvnFipRules: []*kubeovnv1.OvnFip{fip},
+	})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+
+	require.Error(t, ctrl.handleDelOvnEip(eip))
+}
+
+func TestHandleDelOvnEip_ReleasesWhenNoNatRemains(t *testing.T) {
+	t.Parallel()
+
+	eip := &kubeovnv1.OvnEip{
+		Name: "test-eip",
+		Spec: kubeovnv1.OvnEipSpec{ExternalSubnet: "pubnet", V4Ip: "10.0.0.10"},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{OvnEips: []*kubeovnv1.OvnEip{eip}})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+
+	require.NoError(t, ctrl.handleDelOvnEip(eip))
+}

--- a/pkg/controller/ovn_fip.go
+++ b/pkg/controller/ovn_fip.go
@@ -232,6 +232,11 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		}
 	}
 
+	if err = c.patchOvnFipStatus(key, vpcName, v4Eip, v6Eip, v4IP, v6IP, false); err != nil {
+		klog.Errorf("failed to record nat status for fip %s, %v", key, err)
+		return err
+	}
+
 	if err = c.handleAddOvnFipFinalizer(cachedFip); err != nil {
 		klog.Errorf("failed to add finalizer for ovn fip, %v", err)
 		return err
@@ -246,7 +251,7 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		klog.Errorf("failed to update label for fip %s, %v", key, err)
 		return err
 	}
-	if err = c.patchOvnFipStatus(key, vpcName, v4Eip, v4IP, true); err != nil {
+	if err = c.patchOvnFipStatus(key, vpcName, v4Eip, v6Eip, v4IP, v6IP, true); err != nil {
 		klog.Errorf("failed to patch status for fip %s, %v", key, err)
 		return err
 	}
@@ -255,6 +260,18 @@ func (c *Controller) handleAddOvnFip(key string) error {
 		return err
 	}
 	return nil
+}
+
+func (c *Controller) deleteNatIgnoreNotFound(lrName, natType, externalIP, logicalIP string) error {
+	exists, err := c.OVNNbClient.NatExists(lrName, natType, externalIP, logicalIP)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	return c.OVNNbClient.DeleteNat(lrName, natType, externalIP, logicalIP)
 }
 
 func (c *Controller) handleUpdateOvnFip(key string) error {
@@ -281,13 +298,13 @@ func (c *Controller) handleUpdateOvnFip(key string) error {
 
 		// ovn delete fip nat
 		if cachedFip.Status.V4Eip != "" && cachedFip.Status.V4Ip != "" {
-			if err = c.OVNNbClient.DeleteNat(cachedFip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, cachedFip.Status.V4Eip, cachedFip.Status.V4Ip); err != nil {
+			if err = c.deleteNatIgnoreNotFound(cachedFip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, cachedFip.Status.V4Eip, cachedFip.Status.V4Ip); err != nil {
 				klog.Errorf("failed to delete v4 fip %s, %v", key, err)
 				return err
 			}
 		}
 		if cachedFip.Status.V6Eip != "" && cachedFip.Status.V6Ip != "" {
-			if err = c.OVNNbClient.DeleteNat(cachedFip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, cachedFip.Status.V6Eip, cachedFip.Status.V6Ip); err != nil {
+			if err = c.deleteNatIgnoreNotFound(cachedFip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, cachedFip.Status.V6Eip, cachedFip.Status.V6Ip); err != nil {
 				klog.Errorf("failed to delete v6 fip %s, %v", key, err)
 				return err
 			}
@@ -427,13 +444,13 @@ func (c *Controller) handleDelOvnFip(key string) error {
 	}
 	// ovn delete fip nat
 	if cachedFip.Status.V4Eip != "" && cachedFip.Status.V4Ip != "" {
-		if err = c.OVNNbClient.DeleteNat(cachedFip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, cachedFip.Status.V4Eip, cachedFip.Status.V4Ip); err != nil {
+		if err = c.deleteNatIgnoreNotFound(cachedFip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, cachedFip.Status.V4Eip, cachedFip.Status.V4Ip); err != nil {
 			klog.Errorf("failed to delete v4 fip %s, %v", key, err)
 			return err
 		}
 	}
 	if cachedFip.Status.V6Eip != "" && cachedFip.Status.V6Ip != "" {
-		if err = c.OVNNbClient.DeleteNat(cachedFip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, cachedFip.Status.V6Eip, cachedFip.Status.V6Ip); err != nil {
+		if err = c.deleteNatIgnoreNotFound(cachedFip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, cachedFip.Status.V6Eip, cachedFip.Status.V6Ip); err != nil {
 			klog.Errorf("failed to delete v6 fip %s, %v", key, err)
 			return err
 		}
@@ -486,7 +503,7 @@ func (c *Controller) patchOvnFipAnnotations(key, eipName string) error {
 	return nil
 }
 
-func (c *Controller) patchOvnFipStatus(key, vpcName, v4Eip, podIP string, ready bool) error {
+func (c *Controller) patchOvnFipStatus(key, vpcName, v4Eip, v6Eip, v4IP, v6IP string, ready bool) error {
 	oriFip, err := c.ovnFipsLister.Get(key)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -532,8 +549,16 @@ func (c *Controller) patchOvnFipStatus(key, vpcName, v4Eip, podIP string, ready 
 		fip.Status.V4Eip = v4Eip
 		changed = true
 	}
-	if podIP != "" && fip.Status.V4Ip != podIP {
-		fip.Status.V4Ip = podIP
+	if v6Eip != "" && fip.Status.V6Eip != v6Eip {
+		fip.Status.V6Eip = v6Eip
+		changed = true
+	}
+	if v4IP != "" && fip.Status.V4Ip != v4IP {
+		fip.Status.V4Ip = v4IP
+		changed = true
+	}
+	if v6IP != "" && fip.Status.V6Ip != v6IP {
+		fip.Status.V6Ip = v6IP
 		changed = true
 	}
 	if changed {

--- a/pkg/controller/ovn_fip_test.go
+++ b/pkg/controller/ovn_fip_test.go
@@ -1,0 +1,179 @@
+package controller
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8stesting "k8s.io/client-go/testing"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestHandleAddOvnFip_RecordsNatStatusBeforeReady(t *testing.T) {
+	t.Parallel()
+
+	eip := &kubeovnv1.OvnEip{
+		Name: "test-eip",
+		Spec: kubeovnv1.OvnEipSpec{ExternalSubnet: "pubnet"},
+	}
+	eip.Status.V4Ip = "10.0.0.10"
+	fip := &kubeovnv1.OvnFip{
+		Name: "test-fip",
+		Spec: kubeovnv1.OvnFipSpec{
+			OvnEip: eip.Name,
+			Vpc:    "test-vpc",
+			V4Ip:   "10.0.1.5",
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		OvnEips:     []*kubeovnv1.OvnEip{eip},
+		OvnFipRules: []*kubeovnv1.OvnFip{fip},
+	})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+
+	fc.mockOvnClient.EXPECT().
+		AddNat(fip.Spec.Vpc, ovnnb.NATTypeDNATAndSNAT, eip.Status.V4Ip, fip.Spec.V4Ip, gomock.Any(), fip.Spec.IPName, gomock.Any()).
+		Return(nil)
+
+	kubeovnClient, ok := ctrl.config.KubeOvnClient.(*kubeovnfake.Clientset)
+	require.True(t, ok)
+	kubeovnClient.PrependReactor("patch", "ovn-fips", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if ok && patchAction.GetPatchType() == types.JSONPatchType &&
+			strings.Contains(string(patchAction.GetPatch()), "/metadata/annotations") {
+			return true, nil, errors.New("injected failure after nat status recorded")
+		}
+		return false, nil, nil
+	})
+
+	err = ctrl.handleAddOvnFip(fip.Name)
+	require.Error(t, err)
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnFips().Get(t.Context(), fip.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+	require.Equal(t, fip.Spec.Vpc, got.Status.Vpc)
+	require.Equal(t, eip.Status.V4Ip, got.Status.V4Eip)
+	require.Equal(t, fip.Spec.V4Ip, got.Status.V4Ip)
+	require.False(t, got.Status.Ready)
+}
+
+func TestHandleAddOvnFip_RecordsV6NatStatus(t *testing.T) {
+	t.Parallel()
+
+	eip := &kubeovnv1.OvnEip{
+		Name: "test-eip",
+		Spec: kubeovnv1.OvnEipSpec{ExternalSubnet: "pubnet"},
+	}
+	eip.Status.V6Ip = "2001:db8::10"
+	fip := &kubeovnv1.OvnFip{
+		Name: "test-fip",
+		Spec: kubeovnv1.OvnFipSpec{
+			OvnEip: eip.Name,
+			Vpc:    "test-vpc",
+			V6Ip:   "2001:db8::5",
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		OvnEips:     []*kubeovnv1.OvnEip{eip},
+		OvnFipRules: []*kubeovnv1.OvnFip{fip},
+	})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+
+	fc.mockOvnClient.EXPECT().
+		AddNat(fip.Spec.Vpc, ovnnb.NATTypeDNATAndSNAT, eip.Status.V6Ip, fip.Spec.V6Ip, gomock.Any(), fip.Spec.IPName, gomock.Any()).
+		Return(nil)
+
+	require.NoError(t, ctrl.handleAddOvnFip(fip.Name))
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnFips().Get(t.Context(), fip.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, eip.Status.V6Ip, got.Status.V6Eip)
+	require.Equal(t, fip.Spec.V6Ip, got.Status.V6Ip)
+}
+
+func TestHandleUpdateOvnFip_DeleteRemovesNatAndFinalizer(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	fip := &kubeovnv1.OvnFip{
+		Name:              "test-fip",
+		Finalizers:        []string{util.KubeOVNControllerFinalizer},
+		DeletionTimestamp: &now,
+		Spec:              kubeovnv1.OvnFipSpec{OvnEip: "test-eip", Vpc: "test-vpc", V4Ip: "10.0.1.5"},
+	}
+	fip.Status = kubeovnv1.OvnFipStatus{
+		Vpc:   "test-vpc",
+		V4Eip: "10.0.0.10",
+		V4Ip:  "10.0.1.5",
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{OvnFipRules: []*kubeovnv1.OvnFip{fip}})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+	ctrl.resetOvnEipQueue = newTypedRateLimitingQueue[string]("ResetOvnEip", nil)
+	t.Cleanup(ctrl.resetOvnEipQueue.ShutDown)
+	ctrl.updateOvnEipQueue = newTypedRateLimitingQueue[string]("UpdateOvnEip", nil)
+	t.Cleanup(ctrl.updateOvnEipQueue.ShutDown)
+
+	fc.mockOvnClient.EXPECT().
+		NatExists(fip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, fip.Status.V4Eip, fip.Status.V4Ip).
+		Return(true, nil)
+	fc.mockOvnClient.EXPECT().
+		DeleteNat(fip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, fip.Status.V4Eip, fip.Status.V4Ip).
+		Return(nil)
+
+	require.NoError(t, ctrl.handleUpdateOvnFip(fip.Name))
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnFips().Get(t.Context(), fip.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+}
+
+func TestHandleUpdateOvnFip_DeleteToleratesMissingNat(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	fip := &kubeovnv1.OvnFip{
+		Name:              "test-fip",
+		Finalizers:        []string{util.KubeOVNControllerFinalizer},
+		DeletionTimestamp: &now,
+		Spec:              kubeovnv1.OvnFipSpec{OvnEip: "test-eip", Vpc: "test-vpc", V4Ip: "10.0.1.5"},
+	}
+	fip.Status = kubeovnv1.OvnFipStatus{
+		Vpc:   "test-vpc",
+		V4Eip: "10.0.0.10",
+		V4Ip:  "10.0.1.5",
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{OvnFipRules: []*kubeovnv1.OvnFip{fip}})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+	ctrl.resetOvnEipQueue = newTypedRateLimitingQueue[string]("ResetOvnEip", nil)
+	t.Cleanup(ctrl.resetOvnEipQueue.ShutDown)
+	ctrl.updateOvnEipQueue = newTypedRateLimitingQueue[string]("UpdateOvnEip", nil)
+	t.Cleanup(ctrl.updateOvnEipQueue.ShutDown)
+
+	fc.mockOvnClient.EXPECT().
+		NatExists(fip.Status.Vpc, ovnnb.NATTypeDNATAndSNAT, fip.Status.V4Eip, fip.Status.V4Ip).
+		Return(false, nil)
+
+	require.NoError(t, ctrl.handleUpdateOvnFip(fip.Name))
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnFips().Get(t.Context(), fip.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+}

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -164,6 +164,10 @@ func (c *Controller) handleAddOvnSnatRule(key string) error {
 			return err
 		}
 	}
+	if err = c.patchOvnSnatStatus(key, vpcName, v4Eip, v6Eip, v4IpCidr, v6IpCidr, false); err != nil {
+		klog.Errorf("failed to record nat status for snat %s, %v", key, err)
+		return err
+	}
 	if err := c.handleAddOvnSnatFinalizer(cachedSnat); err != nil {
 		klog.Errorf("failed to add finalizer for ovn snat %s, %v", cachedSnat.Name, err)
 		return err
@@ -211,13 +215,13 @@ func (c *Controller) handleUpdateOvnSnatRule(key string) error {
 
 		// ovn delete snat
 		if cachedSnat.Status.V4Eip != "" && cachedSnat.Status.V4IpCidr != "" {
-			if err = c.OVNNbClient.DeleteNat(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT, cachedSnat.Status.V4Eip, cachedSnat.Status.V4IpCidr); err != nil {
+			if err = c.deleteNatIgnoreNotFound(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT, cachedSnat.Status.V4Eip, cachedSnat.Status.V4IpCidr); err != nil {
 				klog.Errorf("failed to delete v4 snat %s, %v", key, err)
 				return err
 			}
 		}
 		if cachedSnat.Status.V6Eip != "" && cachedSnat.Status.V6IpCidr != "" {
-			if err = c.OVNNbClient.DeleteNat(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT, cachedSnat.Status.V6Eip, cachedSnat.Status.V6IpCidr); err != nil {
+			if err = c.deleteNatIgnoreNotFound(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT, cachedSnat.Status.V6Eip, cachedSnat.Status.V6IpCidr); err != nil {
 				klog.Errorf("failed to delete v6 snat %s, %v", key, err)
 				return err
 			}
@@ -346,14 +350,14 @@ func (c *Controller) handleDelOvnSnatRule(key string) error {
 	}
 	// ovn delete snat
 	if cachedSnat.Status.Vpc != "" && cachedSnat.Status.V4Eip != "" && cachedSnat.Status.V4IpCidr != "" {
-		if err = c.OVNNbClient.DeleteNat(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT,
-			cachedSnat.Status.V4Eip, cachedSnat.Status.V4IpCidr); err != nil {
+		if err = c.deleteNatIgnoreNotFound(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT,
+		cachedSnat.Status.V4Eip, cachedSnat.Status.V4IpCidr); err != nil {
 			klog.Errorf("failed to delete v4 snat %s, %v", key, err)
 			return err
 		}
 	}
 	if cachedSnat.Status.Vpc != "" && cachedSnat.Status.V6Eip != "" && cachedSnat.Status.V6IpCidr != "" {
-		if err = c.OVNNbClient.DeleteNat(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT, cachedSnat.Status.V6Eip, cachedSnat.Status.V6IpCidr); err != nil {
+		if err = c.deleteNatIgnoreNotFound(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT, cachedSnat.Status.V6Eip, cachedSnat.Status.V6IpCidr); err != nil {
 			klog.Errorf("failed to delete v6 snat, %v", err)
 			return err
 		}

--- a/pkg/controller/ovn_snat.go
+++ b/pkg/controller/ovn_snat.go
@@ -351,7 +351,7 @@ func (c *Controller) handleDelOvnSnatRule(key string) error {
 	// ovn delete snat
 	if cachedSnat.Status.Vpc != "" && cachedSnat.Status.V4Eip != "" && cachedSnat.Status.V4IpCidr != "" {
 		if err = c.deleteNatIgnoreNotFound(cachedSnat.Status.Vpc, ovnnb.NATTypeSNAT,
-		cachedSnat.Status.V4Eip, cachedSnat.Status.V4IpCidr); err != nil {
+			cachedSnat.Status.V4Eip, cachedSnat.Status.V4IpCidr); err != nil {
 			klog.Errorf("failed to delete v4 snat %s, %v", key, err)
 			return err
 		}

--- a/pkg/controller/ovn_snat_test.go
+++ b/pkg/controller/ovn_snat_test.go
@@ -1,0 +1,142 @@
+package controller
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8stesting "k8s.io/client-go/testing"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestHandleAddOvnSnatRule_RecordsNatStatusBeforeReady(t *testing.T) {
+	t.Parallel()
+
+	eip := &kubeovnv1.OvnEip{
+		Name: "test-eip",
+		Spec: kubeovnv1.OvnEipSpec{ExternalSubnet: "pubnet"},
+	}
+	eip.Status.V4Ip = "10.0.0.10"
+	snat := &kubeovnv1.OvnSnatRule{
+		Name: "test-snat",
+		Spec: kubeovnv1.OvnSnatRuleSpec{
+			OvnEip:   eip.Name,
+			Vpc:      "test-vpc",
+			V4IpCidr: "10.0.1.0/24",
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		OvnEips:      []*kubeovnv1.OvnEip{eip},
+		OvnSnatRules: []*kubeovnv1.OvnSnatRule{snat},
+	})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+
+	fc.mockOvnClient.EXPECT().
+		AddNat(snat.Spec.Vpc, ovnnb.NATTypeSNAT, eip.Status.V4Ip, snat.Spec.V4IpCidr, "", "", nil).
+		Return(nil)
+
+	kubeovnClient, ok := ctrl.config.KubeOvnClient.(*kubeovnfake.Clientset)
+	require.True(t, ok)
+	kubeovnClient.PrependReactor("patch", "ovn-snat-rules", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if ok && patchAction.GetPatchType() == types.JSONPatchType &&
+			strings.Contains(string(patchAction.GetPatch()), "/metadata/annotations") {
+			return true, nil, errors.New("injected failure after nat status recorded")
+		}
+		return false, nil, nil
+	})
+
+	err = ctrl.handleAddOvnSnatRule(snat.Name)
+	require.Error(t, err)
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnSnatRules().Get(t.Context(), snat.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+	require.Equal(t, snat.Spec.Vpc, got.Status.Vpc)
+	require.Equal(t, eip.Status.V4Ip, got.Status.V4Eip)
+	require.Equal(t, snat.Spec.V4IpCidr, got.Status.V4IpCidr)
+	require.False(t, got.Status.Ready)
+}
+
+func TestHandleUpdateOvnSnatRule_DeleteRemovesNatAndFinalizer(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	snat := &kubeovnv1.OvnSnatRule{
+		Name:              "test-snat",
+		Finalizers:        []string{util.KubeOVNControllerFinalizer},
+		DeletionTimestamp: &now,
+		Spec:              kubeovnv1.OvnSnatRuleSpec{OvnEip: "test-eip", Vpc: "test-vpc", V4IpCidr: "10.0.1.0/24"},
+	}
+	snat.Status = kubeovnv1.OvnSnatRuleStatus{
+		Vpc:      "test-vpc",
+		V4Eip:    "10.0.0.10",
+		V4IpCidr: "10.0.1.0/24",
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{OvnSnatRules: []*kubeovnv1.OvnSnatRule{snat}})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+	ctrl.resetOvnEipQueue = newTypedRateLimitingQueue[string]("ResetOvnEip", nil)
+	t.Cleanup(ctrl.resetOvnEipQueue.ShutDown)
+	ctrl.updateOvnEipQueue = newTypedRateLimitingQueue[string]("UpdateOvnEip", nil)
+	t.Cleanup(ctrl.updateOvnEipQueue.ShutDown)
+
+	fc.mockOvnClient.EXPECT().
+		NatExists(snat.Status.Vpc, ovnnb.NATTypeSNAT, snat.Status.V4Eip, snat.Status.V4IpCidr).
+		Return(true, nil)
+	fc.mockOvnClient.EXPECT().
+		DeleteNat(snat.Status.Vpc, ovnnb.NATTypeSNAT, snat.Status.V4Eip, snat.Status.V4IpCidr).
+		Return(nil)
+
+	require.NoError(t, ctrl.handleUpdateOvnSnatRule(snat.Name))
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnSnatRules().Get(t.Context(), snat.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+}
+
+func TestHandleUpdateOvnSnatRule_DeleteToleratesMissingNat(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	snat := &kubeovnv1.OvnSnatRule{
+		Name:              "test-snat",
+		Finalizers:        []string{util.KubeOVNControllerFinalizer},
+		DeletionTimestamp: &now,
+		Spec:              kubeovnv1.OvnSnatRuleSpec{OvnEip: "test-eip", Vpc: "test-vpc", V4IpCidr: "10.0.1.0/24"},
+	}
+	snat.Status = kubeovnv1.OvnSnatRuleStatus{
+		Vpc:      "test-vpc",
+		V4Eip:    "10.0.0.10",
+		V4IpCidr: "10.0.1.0/24",
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{OvnSnatRules: []*kubeovnv1.OvnSnatRule{snat}})
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+	ctrl.resetOvnEipQueue = newTypedRateLimitingQueue[string]("ResetOvnEip", nil)
+	t.Cleanup(ctrl.resetOvnEipQueue.ShutDown)
+	ctrl.updateOvnEipQueue = newTypedRateLimitingQueue[string]("UpdateOvnEip", nil)
+	t.Cleanup(ctrl.updateOvnEipQueue.ShutDown)
+
+	fc.mockOvnClient.EXPECT().
+		NatExists(snat.Status.Vpc, ovnnb.NATTypeSNAT, snat.Status.V4Eip, snat.Status.V4IpCidr).
+		Return(false, nil)
+
+	require.NoError(t, ctrl.handleUpdateOvnSnatRule(snat.Name))
+
+	got, err := ctrl.config.KubeOvnClient.KubeovnV1().OvnSnatRules().Get(t.Context(), snat.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, got.Finalizers, util.KubeOVNControllerFinalizer)
+}


### PR DESCRIPTION
# Pull Request

- Bug fixes
- Tests

Fixes orphaned NAT/load-balancer leaks in the OVN FIP/SNAT/DNAT/EIP controllers:

- `ovn_fip.go`, `ovn_snat.go`: `Status` (which the delete path uses to decide whether OVN cleanup is needed) was only patched as the last step of the add flow, after the NAT rule already existed in OVN. Deleting the resource before that patch landed left the NAT rule orphaned
forever. `Status` is now recorded right after the NAT rule is created. Delete paths also became idempotent (`deleteNatIgnoreNotFound`) so a NAT rule missing in OVN no longer blocks finalizer removal.
- `ovn_fip.go`: `patchOvnFipStatus` never persisted `V6Eip`/`V6Ip`, so the v6 NAT rule of any IPv6/dual-stack FIP was never deleted. Fixed.
- `ovn_dnat.go`: `ExternalPort` was only recorded once `ready=true`; the delete path needs it earlier, mirroring the fip/snat fix.
- `ovn_eip.go`: `handleDelOvnEip` released the EIP's IP in IPAM unconditionally, without checking whether a FIP/DNAT/SNAT was still using it — unlike the primary `handleUpdateOvnEip` delete path, which already guards on `getOvnEipNat`. This allowed a still-referenced IP to be
released and reissued elsewhere. Added the same guard.

Added unit tests for all four controllers covering the fixed behavior.
